### PR TITLE
refactor: hard-cut retired compatibility surfaces

### DIFF
--- a/bin/keeper_feature_proof_report.ml
+++ b/bin/keeper_feature_proof_report.ml
@@ -5,18 +5,14 @@ let usage =
 
 Options:
   --base-path PATH        Runtime workspace root (default: MASC_BASE_PATH)
-  --n N                  Accepted for compatibility; ignored
   --window-hours HOURS   Optional scheduled-autonomy evidence window
-  --threshold PCT        Accepted for compatibility; ignored
   --strict               Exit 2 when any feature is warn/fail
   -h, --help             Print this help
 |}
 
 type config = {
   base_path : string option;
-  n : int;
   window_hours : float option;
-  threshold : float;
   strict : bool;
 }
 
@@ -33,16 +29,9 @@ let env_base_path () =
 let initial_config () =
   {
     base_path = env_base_path ();
-    n = 5000;
     window_hours = None;
-    threshold = 80.0;
     strict = false;
   }
-
-let parse_int_arg name value =
-  match int_of_string_opt value with
-  | Some n when n > 0 -> n
-  | _ -> error (Printf.sprintf "invalid %s: %S" name value)
 
 let parse_float_arg name value =
   match float_of_string_opt value with
@@ -60,9 +49,6 @@ let rec parse_args argv index cfg =
     | "--base-path" when index + 1 < Array.length argv ->
         parse_args argv (index + 2)
           { cfg with base_path = Some argv.(index + 1) }
-    | "--n" when index + 1 < Array.length argv ->
-        parse_args argv (index + 2)
-          { cfg with n = parse_int_arg "--n" argv.(index + 1) }
     | "--window-hours" when index + 1 < Array.length argv ->
         parse_args argv (index + 2)
           {
@@ -70,9 +56,6 @@ let rec parse_args argv index cfg =
             window_hours =
               Some (parse_float_arg "--window-hours" argv.(index + 1));
           }
-    | "--threshold" when index + 1 < Array.length argv ->
-        parse_args argv (index + 2)
-          { cfg with threshold = parse_float_arg "--threshold" argv.(index + 1) }
     | arg -> error (Printf.sprintf "unknown or incomplete argument: %S" arg)
 
 let resolve_base_path cfg =

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -481,7 +481,7 @@ let acquire_pid_lock port =
   match Server_startup_takeover.acquire_pid_lock port with
   | Server_startup_takeover.Acquired -> ()
   | Server_startup_takeover.Already_running { pid } ->
-      Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
+      Log.startup_console ~level:Log.Error ~module_name:"Server"
         (Printf.sprintf
            "[FATAL] Another MASC server (PID %d) is already running on port %d. Kill it first: kill %d"
            pid port pid);
@@ -492,13 +492,13 @@ let acquire_base_path_lock ~run_dir base_path =
   | Server_startup_takeover.Base_path_acquired lease -> lease
   | Server_startup_takeover.Base_path_already_owned { pid } ->
       let owner = Option.fold ~none:"unknown" ~some:string_of_int pid in
-      Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
+      Log.startup_console ~level:Log.Error ~module_name:"Server"
         (Printf.sprintf
            "[FATAL] Another MASC runtime (PID %s) already owns base path %s"
            owner base_path);
       exit 1
   | Server_startup_takeover.Base_path_rejected rejection ->
-      Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
+      Log.startup_console ~level:Log.Error ~module_name:"Server"
         (Printf.sprintf
            "[FATAL] BasePath ownership boundary rejected %s: %s"
            base_path
@@ -587,24 +587,9 @@ let run_cmd host port cli_base_path =
   Unix.putenv "MASC_BASE_PATH" canonical_base_path;
   Workspace_utils_backend_setup.cache_resolved_base_path canonical_base_path;
   Unix.putenv "MASC_BASE_PATH_RESOLUTION_SOURCE" resolution_source;
-  (* Persist logs inside .masc/logs/ — colocated with state, not a sibling.
-     Previous code wrote to base_path/logs/ which diverged from .masc/ when
-     base_path differed from the repo checkout directory. *)
+  (* Persist logs inside .masc/logs/, colocated with runtime state. *)
   let log_dir = Filename.concat masc_dir "logs" in
   Fs_compat.mkdir_p log_dir;
-  (* Migration: move .jsonl files from old base_path/logs/ if they exist *)
-  let old_log_dir = Filename.concat canonical_base_path "logs" in
-  (if Sys.file_exists old_log_dir && Sys.is_directory old_log_dir then
-     let files = try Sys.readdir old_log_dir with Sys_error _ -> [||] in
-     Array.iter (fun fname ->
-       if Filename.check_suffix fname ".jsonl" then begin
-         let src = Filename.concat old_log_dir fname in
-         let dst = Filename.concat log_dir fname in
-         if not (Sys.file_exists dst) then
-           (try Sys.rename src dst;
-                Log.Server.info "log migration: moved %s -> .masc/logs/" fname
-            with Sys_error _ -> ())
-          end) files);
   Log.Ring.init_file_sink log_dir;
   Log.Ring.cleanup_old_files log_dir;
   Eio_main.run @@ fun env ->

--- a/bin/masc_tui_types.ml
+++ b/bin/masc_tui_types.ml
@@ -206,9 +206,6 @@ type surface =
   | Approvals
   | Planning
 
-(** Backward-compatible alias. *)
-type view_mode = surface
-
 (** Dashboard state *)
 type state = {
   mutable agents: agent list;
@@ -217,7 +214,7 @@ type state = {
   mutable keepers: keeper list;
   mutable connection_status: connection_status;
   mutable last_refresh: float;
-  mutable view: view_mode;
+  mutable view: surface;
   mutable keeper_cursor: int;
   mutable log_entries: log_entry list;
   mutable log_scroll: int;

--- a/ci/logging-consistency-allowlist.txt
+++ b/ci/logging-consistency-allowlist.txt
@@ -28,9 +28,8 @@ lib/fs_compat/
 # (b) FATAL exception handlers for Out_of_memory / Stack_overflow that must not
 # allocate through the logging stack, or (c) the `login` / `init` CLI
 # subcommands whose stderr/stdout is user-facing CLI output, not server logs.
-# The legacy_stderr "[FATAL] Another MASC server ... already running" lines are
-# the RFC-0079 raw-passthrough bridge (embedded [FATAL] prefix; migrating would
-# double-prefix the operator-visible message).
+# Ownership failures use Log.startup_console because runtime filtering must not
+# suppress diagnostics that explain why initialization stopped.
 bin/main_eio.ml
 
 # --- Standalone CLI tools (not the server runtime) ---
@@ -43,20 +42,6 @@ bin/masc_cost.ml
 bin/masc_compaction_audit.ml
 bin/keeper_feature_proof_report.ml
 bin/env_knob_catalog.ml
-
-# --- RFC-0079 legacy raw-stderr bridge (embedded [LEVEL] prefix) ---
-# Log.legacy_stderr / Log.legacy_traceln deliberately emit a raw, unprefixed
-# stderr line AND mirror it into the ring with a Legacy_stderr / Legacy_traceln
-# source tag (read back by dashboard/src/api/schemas/logs.ts). Every call site
-# embeds its own [FATAL] / [WARN] / [DEBUG] marker in the message body, so
-# migrating to Log.<Module>.<lvl> would (a) double-prefix the message and
-# (b) drop the Legacy_* source classification. They stay as the documented
-# bridge. (lib/server/server_startup_takeover.ml is allowlisted whole because
-# its only non-canonical logging is these legacy_stderr lines.)
-lib/server/server_startup_takeover.ml
-lib/backend/backend.ml
-lib/workspace/workspace_query.ml
-lib/mcp_server_eio_resource.ml
 
 # --- Dynamic component (runtime variable) ---
 # Log.warn ~ctx:context / Log.info ~ctx:context use a runtime-computed component

--- a/dashboard/src/api/dashboard-mission.ts
+++ b/dashboard/src/api/dashboard-mission.ts
@@ -12,10 +12,6 @@ export function fetchDashboardBriefing(): Promise<DashboardMissionResponse> {
   return get('/api/v1/dashboard/briefing')
 }
 
-export function fetchDashboardMission(): Promise<DashboardMissionResponse> {
-  return fetchDashboardBriefing()
-}
-
 export function fetchDashboardMissionBriefing(
   force = false,
   opts?: { signal?: AbortSignal },

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -28,7 +28,6 @@ import {
   parseMemoryOsFactCategory,
   fetchKeeperTurnTranscript,
   fetchDashboardMemory,
-  fetchDashboardMission,
   fetchDashboardMissionBriefing,
   fetchDashboardRuntimeProbe,
   fetchCostLatency,
@@ -256,32 +255,6 @@ describe('dashboard briefing fetchers', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     await fetchDashboardBriefing()
-
-    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/briefing')
-  })
-
-  it('keeps the mission snapshot fetcher as a compatibility alias', async () => {
-    const rawResponse = {
-      summary: { workspace_health: 'ok' },
-      incidents: [],
-      recommended_actions: [],
-      command_focus: {},
-      operator_targets: { keepers: [], pending_confirms: [], available_actions: [] },
-      attention_queue: [],
-      sessions: [],
-      agent_briefs: [],
-      keeper_briefs: [],
-      internal_signals: [],
-    }
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify(rawResponse), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
-    vi.stubGlobal('fetch', fetchMock)
-
-    await fetchDashboardMission()
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/briefing')
   })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -148,7 +148,7 @@ export {
   setGateMode,
 } from './dashboard-gate'
 export { pruneSchedules } from './dashboard-schedule'
-export { fetchDashboardBriefing, fetchDashboardMission } from './dashboard-mission'
+export { fetchDashboardBriefing } from './dashboard-mission'
 
 export type {
   DashboardRuntimeProviderSnapshot,

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -106,8 +106,7 @@ const LEVEL_COLORS: Record<string, string> = {
 
 const SOURCE_LABELS: Record<string, string> = {
   structured: 'structured',
-  legacy_stderr: 'stderr',
-  legacy_traceln: 'trace line',
+  startup_console: 'startup console',
   client_tool_host: 'client tool-host',
   sse: 'sse',
 }
@@ -441,10 +440,8 @@ function sourceTone(source: string): string {
   switch (source) {
     case 'client_tool_host':
       return 'text-[var(--color-accent-fg)] bg-[var(--accent-10)] border-[var(--accent-22)]'
-    case 'legacy_stderr':
+    case 'startup_console':
       return 'text-[var(--bad-light)] bg-[var(--err-soft)] border-[var(--err-border)]'
-    case 'legacy_traceln':
-      return 'text-[var(--warn-fg)] bg-[var(--warn-soft)] border-[var(--warn-border)]'
     default:
       return 'text-[var(--color-fg-muted)] bg-[var(--color-bg-surface)] border-[var(--color-border-default)]'
   }

--- a/dashboard/src/journal-entry.test.ts
+++ b/dashboard/src/journal-entry.test.ts
@@ -41,8 +41,7 @@ describe('journal severity helpers', () => {
 describe('normalizeJournalSource', () => {
   it('maps each recognized source string to its first-class variant', () => {
     expect(normalizeJournalSource('structured')).toBe('structured')
-    expect(normalizeJournalSource('legacy_stderr')).toBe('legacy_stderr')
-    expect(normalizeJournalSource('legacy_traceln')).toBe('legacy_traceln')
+    expect(normalizeJournalSource('startup_console')).toBe('startup_console')
     expect(normalizeJournalSource('sse')).toBe('sse')
   })
 

--- a/dashboard/src/journal-entry.ts
+++ b/dashboard/src/journal-entry.ts
@@ -30,10 +30,8 @@ export function normalizeJournalSource(value: string | null | undefined): Journa
   switch ((value ?? '').trim().toLowerCase()) {
     case 'structured':
       return 'structured'
-    case 'legacy_stderr':
-      return 'legacy_stderr'
-    case 'legacy_traceln':
-      return 'legacy_traceln'
+    case 'startup_console':
+      return 'startup_console'
     case 'sse':
       return 'sse'
     default:

--- a/dashboard/src/mission-actions.test.ts
+++ b/dashboard/src/mission-actions.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const apiMocks = vi.hoisted(() => ({
-  fetchDashboardMission: vi.fn(),
+  fetchDashboardBriefing: vi.fn(),
   fetchDashboardMissionBriefing: vi.fn(),
   fetchDashboardMissionSession: vi.fn(),
 }))
@@ -62,7 +62,7 @@ afterEach(() => {
 
 describe('refreshMissionSnapshot', () => {
   it('requests the mission endpoint without extra query flags', async () => {
-    apiMocks.fetchDashboardMission.mockResolvedValue(missionPayload)
+    apiMocks.fetchDashboardBriefing.mockResolvedValue(missionPayload)
 
     const missionActions = await import('./mission-actions')
     const missionStore = await import('./mission-store')
@@ -77,13 +77,13 @@ describe('refreshMissionSnapshot', () => {
           agent_briefs?: unknown[]
         }
       | null
-    expect(apiMocks.fetchDashboardMission).toHaveBeenCalledWith()
+    expect(apiMocks.fetchDashboardBriefing).toHaveBeenCalledWith()
     expect(mission?.summary?.workspace_health).toBe('ok')
     expect(mission?.agent_briefs).toHaveLength(1)
   })
 
   it('keeps the existing mission data when the cached mission is still initializing', async () => {
-    apiMocks.fetchDashboardMission
+    apiMocks.fetchDashboardBriefing
       .mockResolvedValueOnce(missionPayload)
       .mockResolvedValueOnce(initializingMissionPayload)
 

--- a/dashboard/src/mission-actions.ts
+++ b/dashboard/src/mission-actions.ts
@@ -46,8 +46,8 @@ export async function refreshMissionSnapshot(
   missionError.value = null
   inflightMissionSnapshotRefresh = (async () => {
     try {
-      const { fetchDashboardMission } = await import('./api/dashboard-mission')
-      const raw = await fetchDashboardMission()
+      const { fetchDashboardBriefing } = await import('./api/dashboard-mission')
+      const raw = await fetchDashboardBriefing()
       const normalized = normalizeMission(raw)
       if (isMissionInitializingPayload(normalized) && missionSnapshot.value) {
         lastMissionSnapshotRefreshAt = Date.now()

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -546,16 +546,6 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.pending_confirms[0]!.confirm_token).toBe('tok-e1')
   })
 
-  it('falls back to pending_confirms when no envelope', () => {
-    const result = normalizeOperatorSnapshot({
-      pending_confirms: [
-        { confirm_token: 'tok-raw', actor: 'system' },
-      ],
-    })
-    expect(result.pending_confirms).toHaveLength(1)
-    expect(result.pending_confirms[0]!.confirm_token).toBe('tok-raw')
-  })
-
   it('extracts top-level needs_attention, attention_reason and next_human_action from keeper payload', () => {
     const result = normalizeOperatorSnapshot({
       keepers: [

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -467,21 +467,27 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.recent_messages[0]!.id).toBe('msg-1')
   })
 
-  it('extracts pending_confirms with confirm_token', () => {
+  it('derives pending_confirms from envelope items', () => {
     const result = normalizeOperatorSnapshot({
-      pending_confirms: [
-        { confirm_token: 'tok-1', actor: 'agent-1', action_type: 'pause' },
-      ],
+      pending_confirm_envelope: {
+        items: [
+          { confirm_token: 'tok-1', actor: 'agent-1', action_type: 'pause' },
+        ],
+        summary: { visible_count: 1, total_count: 1 },
+      },
     })
     expect(result.pending_confirms).toHaveLength(1)
     expect(result.pending_confirms[0]!.confirm_token).toBe('tok-1')
   })
 
-  it('filters pending_confirms without token', () => {
+  it('filters envelope items without token', () => {
     const result = normalizeOperatorSnapshot({
-      pending_confirms: [
-        { actor: 'agent-1' }, // no token
-      ],
+      pending_confirm_envelope: {
+        items: [
+          { actor: 'agent-1' }, // no token
+        ],
+        summary: { visible_count: 1, total_count: 1 },
+      },
     })
     expect(result.pending_confirms).toEqual([])
   })

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -196,15 +196,9 @@ export function normalizeOperatorSnapshot(raw: unknown): OperatorSnapshot {
     recent_messages: extractArray(root.recent_messages, ['messages'])
       .map(normalizeMessage)
       .filter((item): item is Message => item !== null),
-    pending_confirms: pendingConfirmEnvelope?.items
-      ?? extractArray(root.pending_confirms, ['items', 'confirms'])
-        .map(normalizePendingConfirmation)
-        .filter((item): item is PendingConfirmation => item !== null),
+    pending_confirms: pendingConfirmEnvelope?.items ?? [],
     pending_confirm_envelope: pendingConfirmEnvelope ?? undefined,
-    pending_confirm_summary:
-      pendingConfirmEnvelope?.summary
-      ?? normalizePendingConfirmSummary(root.pending_confirm_summary)
-      ?? undefined,
+    pending_confirm_summary: pendingConfirmEnvelope?.summary,
     available_actions: extractArray(root.available_actions, ['actions'])
       .map(normalizeOperatorActionDescriptor)
       .filter((item): item is OperatorActionDescriptor => item !== null),

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -1,9 +1,7 @@
 import { isRecord, asString, asNumber, asBoolean, asStringArray, extractArray } from './components/common/normalize'
 import {
   normalizeOperatorActionDescriptor,
-  normalizePendingConfirmation,
   normalizePendingConfirmEnvelope,
-  normalizePendingConfirmSummary,
 } from './pending-confirm'
 import {
   normalizeKeeperContextMetricsUnavailable,
@@ -26,7 +24,6 @@ import type {
   OperatorRecommendedAction,
   OperatorSnapshot,
   OperatorNamespaceSnapshot,
-  PendingConfirmation,
 } from './types'
 import { SYSTEM_ACTOR_NAME } from './types/core'
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -98,7 +98,7 @@ export type JournalSeverity = 'debug' | 'info' | 'warn' | 'error' | 'unknown'
 // (mirroring JournalSeverity) so that `normalizeJournalSource` can fail
 // loud on unrecognized wire data instead of silently coercing it to
 // `'sse'`. Source of truth: see `normalizeJournalSource` in journal-entry.ts.
-export type JournalSource = 'structured' | 'legacy_stderr' | 'legacy_traceln' | 'sse' | 'unknown'
+export type JournalSource = 'structured' | 'startup_console' | 'sse' | 'unknown'
 
 // --- Attribution envelope ---
 // Structured verdict metadata for gate decisions. Emitted alongside existing

--- a/dashboard_bonsai/src/logs_types.ml
+++ b/dashboard_bonsai/src/logs_types.ml
@@ -12,11 +12,7 @@ type entry =
   { seq : int
   ; ts : string                  (* ISO8601 UTC, e.g. "2026-04-19T14:32:15Z" *)
   ; level : string               (* canonical level — always set *)
-  ; raw_level : string           (* original pre-normalisation string *)
-  ; normalized_level : string    (* "DEBUG" | "INFO" | "WARN" | "ERROR" *)
-  ; source : string              (* "structured" | "legacy_stderr"
-                                    | "legacy_traceln" | "client_tool_host" *)
-  ; legacy_classified : bool
+  ; source : string              (* "structured" | "startup_console" | "client_tool_host" *)
   ; module_ : string             (* JSON field "module" — reserved keyword *)
   ; message : string
   ; details : string option      (* raw JSON string — parsed lazily by callers *)
@@ -67,10 +63,7 @@ let entry_of_yojson (json : Yojson.Safe.t) : entry =
   { seq = int_field json "seq"
   ; ts = string_field json "ts"
   ; level
-  ; raw_level = string_field ~default:level json "raw_level"
-  ; normalized_level = string_field ~default:level json "normalized_level"
   ; source = string_field ~default:"structured" json "source"
-  ; legacy_classified = bool_field json "legacy_classified"
   ; module_ = string_field json "module"
   ; message = string_field json "message"
   ; details
@@ -121,33 +114,24 @@ let fixture : response =
       [ { seq = 3
         ; ts = "2026-04-19T17:12:03Z"
         ; level = "ERROR"
-        ; raw_level = "ERROR"
-        ; normalized_level = "ERROR"
-        ; source = "structured"
-        ; legacy_classified = false
-        ; module_ = "Keeper"
+                    ; source = "structured"
+              ; module_ = "Keeper"
         ; message = "heartbeat check failed: timeout after 30s"
         ; details = Some {|{"request_id":"req-9aa1","session_id":"sess-0012"}|}
         }
       ; { seq = 2
         ; ts = "2026-04-19T17:12:02Z"
         ; level = "WARN"
-        ; raw_level = "WARN"
-        ; normalized_level = "WARN"
-        ; source = "structured"
-        ; legacy_classified = false
-        ; module_ = "Keeper"
+                    ; source = "structured"
+              ; module_ = "Keeper"
         ; message = "retry scheduled in 5s"
         ; details = None
         }
       ; { seq = 1
         ; ts = "2026-04-19T17:12:00Z"
         ; level = "INFO"
-        ; raw_level = "INFO"
-        ; normalized_level = "INFO"
-        ; source = "structured"
-        ; legacy_classified = false
-        ; module_ = "Server"
+                    ; source = "structured"
+              ; module_ = "Server"
         ; message = "masc server started on :8935"
         ; details = None
         }

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -82,9 +82,9 @@ module FileSystem = struct
     | Eio.Cancel.Cancelled _ as e ->
       Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
     | exn ->
-      Log.legacy_traceln ~level:Log.Debug ~module_name:"Backend"
+      Log.Backend.emit Log.Debug
         (Printf.sprintf
-           "[DEBUG] backend mutex %s observer failed for op=%s: %s"
+           "backend mutex %s observer failed for op=%s: %s"
            kind op (Printexc.to_string exn))
 
   (** Wrap a write critical section with acquire/held observers.
@@ -124,8 +124,8 @@ module FileSystem = struct
     (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 path
      with Eio.Cancel.Cancelled _ as e -> raise e
         | e ->
-            Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
-              (Printf.sprintf "[WARN] mkdirs base failed: %s"
+            Log.Backend.emit Log.Warn
+              (Printf.sprintf "mkdirs base failed: %s"
                  (Printexc.to_string e)));
     {
       config;
@@ -256,8 +256,8 @@ module FileSystem = struct
          with Eio.Cancel.Cancelled _ as exn -> raise exn
           | exn ->
               if log_errors then
-                Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
-                  (Printf.sprintf "[WARN] mkdirs failed: %s"
+                Log.Backend.emit Log.Warn
+                  (Printf.sprintf "mkdirs failed: %s"
                      (Printexc.to_string exn))
               else
                 raise exn)
@@ -707,8 +707,8 @@ module FileSystem = struct
            (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
             with Eio.Cancel.Cancelled _ as e -> raise e
                | e ->
-                   Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
-                     (Printf.sprintf "[WARN] mkdirs failed: %s"
+                   Log.Backend.emit Log.Warn
+                     (Printf.sprintf "mkdirs failed: %s"
                         (Printexc.to_string e)))
        | None -> ());
 
@@ -775,8 +775,8 @@ module FileSystem = struct
            (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
             with Eio.Cancel.Cancelled _ as e -> raise e
                | e ->
-                   Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
-                     (Printf.sprintf "[WARN] mkdirs failed: %s"
+                   Log.Backend.emit Log.Warn
+                     (Printf.sprintf "mkdirs failed: %s"
                         (Printexc.to_string e)))
        | None -> ());
 

--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -198,10 +198,13 @@ let json ?actor ~config ~sw ~clock ~proc_mgr
       ]
   in
   let operator_targets_json =
+    let pending_confirm_envelope =
+      member_assoc "pending_confirm_envelope" projection.snapshot_json
+    in
     `Assoc
       [
         ("keepers", `List projection.keeper_briefs);
-        ("pending_confirms", member_assoc "pending_confirms" projection.snapshot_json);
+        ("pending_confirms", member_assoc "items" pending_confirm_envelope);
         ("available_actions", member_assoc "available_actions" projection.snapshot_json);
       ]
   in

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -113,13 +113,9 @@ let get_store () =
 (** Reset the store reference.  For testing only. *)
 let reset_store_for_testing () = store_ref := None
 
-(** Set the process-local verdict store to an explicit isolated directory.
-    Offline eval tooling uses this after verdict-store isolation checks; tests
-    use [set_store_for_testing] as a compatibility alias. *)
+(** Set the process-local verdict store to an explicit isolated directory. *)
 let set_store ~base_dir =
   store_ref := Some (Dated_jsonl.create ~base_dir ())
-
-let set_store_for_testing = set_store
 
 (** Resolve where an offline eval tool's [--record-verdicts] verdicts are
     written. Such a tool drives a real judge and persists verdicts; if those

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -68,11 +68,9 @@ val reset_store_for_testing : unit -> unit
 (** Reset the store reference.  For testing only. *)
 
 (** Set the process-local verdict store to an explicit isolated directory.
-    Used by offline eval tooling after verdict-store isolation checks and by
-    tests through [set_store_for_testing]. *)
-
-val set_store_for_testing : base_dir:string -> unit
-(** Compatibility alias for [set_store] used by tests. *)
+    Used by offline eval tooling and tests after verdict-store isolation
+    checks. *)
+val set_store : base_dir:string -> unit
 
 val absolute_workspace_base_path : ?cwd:string -> string -> string
 (** Normalize a workspace base path into the absolute path expected by offline

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -203,22 +203,6 @@ let find_duplicate fields =
   loop [] fields
 ;;
 
-(** [persona] lost its target when the Persona subsystem was hard-cut
-    (masc#27048) -- no persona lookup remains to resolve it against. Every
-    live keeper meta JSON predating that cut still carries it (masc#27393:
-    exact-schema rejection took autoboot to 0/7 in production). Pre-release
-    policy tolerates legacy-version data rather than shipping migration
-    code (CLAUDE.md, "레거시 필드... 마이그레이션을 위한 코드나 구현을
-    하지 말라는 이야기임") -- the TOML loader made the same call for
-    [keeper.persona_name] in #27048's own round 4. Tolerated here on read,
-    never round-tripped: {!object_of_field_values} only ever emits
-    {!all_fields}, so a persona-bearing meta that gets rewritten drops the
-    field on its own, with no migration step needed. *)
-let legacy_ignored_meta_field_names = [ "persona" ]
-
-let known_meta_field_names =
-  current_field_names @ legacy_ignored_meta_field_names
-
 let validate_current_object (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
@@ -228,8 +212,8 @@ let validate_current_object (json : Yojson.Safe.t) =
          (invalid_currentf "duplicate field %s" key)
      | None ->
        let present = List.map fst fields in
-       let outside_current =
-         List.filter (fun key -> not (List.mem key known_meta_field_names)) present
+        let outside_current =
+         List.filter (fun key -> not (List.mem key current_field_names)) present
        in
        let missing =
          List.filter (fun key -> not (List.mem key present)) current_field_names

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -22,29 +22,23 @@ let keeper_toml_field_names =
   ; "always_allow"
   ]
 
-(** [keeper.persona_name] lost its target when the Persona subsystem was
-    hard-cut -- no persona lookup remains to resolve it against. Pre-release
-    policy tolerates legacy-version data instead of shipping migration code
-    (CLAUDE.md, "레거시 필드... 마이그레이션을 위한 코드나 구현을 하지
-    말라는 이야기임"): every keeper TOML that predates this cut still
-    carries the key, so rejecting it as unknown would fail every one of
-    them at load. Tolerated and discarded -- accepted here, never parsed
-    into [keeper_profile_defaults]. *)
-let legacy_ignored_keeper_toml_keys = [ "persona_name" ]
+let canonical_keeper_toml_key_names = keeper_toml_field_names
 
-let known_keeper_toml_key_names =
-  keeper_toml_field_names @ legacy_ignored_keeper_toml_keys
-
-let unknown_keeper_toml_keys doc =
+(** One current-key detector shared by profile loading and config audit. *)
+let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
   let known =
-    List.map (fun key -> "keeper." ^ key) known_keeper_toml_key_names
+    List.map (fun key -> "keeper." ^ key) canonical_keeper_toml_key_names
+  in
+  let oas_env_prefix_len = String.length oas_env_key_prefix in
+  let starts_with_oas_env key =
+    String.length key > oas_env_prefix_len
+    && String.starts_with key ~prefix:oas_env_key_prefix
   in
   doc
   |> List.map fst
   |> List.filter (fun key ->
-       not (List.mem key known)
-       && not (String.starts_with key ~prefix:oas_env_key_prefix))
-  |> List.sort_uniq String.compare
+       not (List.mem key known) && not (starts_with_oas_env key))
+  |> dedupe_keep_order
 
 let toml_value_kind = function
   | Keeper_toml_loader.Toml_string _ -> "string"
@@ -128,7 +122,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   let has key = List.mem_assoc (k key) doc in
   let oas_env = extract_oas_env_from_doc doc in
   let result =
-    match unknown_keeper_toml_keys doc with
+    match detect_unknown_keeper_toml_keys doc with
     | [] -> Ok ()
     | fields ->
         Error
@@ -228,33 +222,11 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     being declared known first. *)
 let parsed_field_key_names = keeper_toml_field_names
 
-(** Canonical TOML key names accepted by the strict parser and config audit:
-    fields parsed into the record, plus [legacy_ignored_keeper_toml_keys]
-    (accepted so old-version data still loads, never parsed into anything). *)
-let canonical_keeper_toml_key_names = known_keeper_toml_key_names
-
 let () =
   assert (
     List.for_all
       (fun key -> List.mem key canonical_keeper_toml_key_names)
       parsed_field_key_names)
-
-(** Pure detector used by the strict parser and invalid-config audit. *)
-let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
-  let known =
-    canonical_keeper_toml_key_names |> List.map (fun k -> "keeper." ^ k)
-  in
-  let oas_env_prefix = oas_env_key_prefix in
-  let oas_env_prefix_len = String.length oas_env_prefix in
-  let starts_with_oas_env k =
-    String.length k > oas_env_prefix_len
-    && String.starts_with k ~prefix:oas_env_prefix
-  in
-  doc
-  |> List.map fst
-  |> List.filter (fun key ->
-       not (List.mem key known) && not (starts_with_oas_env key))
-  |> dedupe_keep_order
 
 let merge_string_list ~base overlay =
   match overlay with [] -> base | xs -> xs

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -919,8 +919,8 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
          list, because there taking the parent and taking the child are not two
          independent moves. A child whose parent is absent -- owned, terminal,
          or already served by a Task -- is its own invitation and stays at the
-         top level. Depth stops at one: [parent_goal_id] is a single link and
-         nesting further would trade the fact for a shape. *)
+         top level. Goal_store permits arbitrary parent depth, so the projection
+         follows the whole chain rather than dropping descendants. *)
       let unowned_block =
         match unowned_executing_goals_without_tasks ~config with
         | [] -> None
@@ -944,15 +944,29 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
             | None -> true
             | Some p -> not (List.exists (String.equal p) present)
           in
+          let rendered_ids = ref [] in
+          let rec render_subtree ~depth ((goal_id, _, _) as goal) =
+            if List.exists (String.equal goal_id) !rendered_ids
+            then []
+            else (
+              rendered_ids := goal_id :: !rendered_ids;
+              let indent = String.make (depth * 2) ' ' in
+              line ~indent goal
+              :: List.concat_map
+                   (render_subtree ~depth:(depth + 1))
+                   (children_of goal_id))
+          in
+          let rendered_roots =
+            goals
+            |> List.filter stands_alone
+            |> List.concat_map (render_subtree ~depth:0)
+          in
           let rendered =
-            List.concat_map
-              (fun ((goal_id, _, _) as goal) ->
-                 if not (stands_alone goal)
-                 then []
-                 else
-                   line ~indent:"" goal
-                   :: List.map (line ~indent:"  ") (children_of goal_id))
-              goals
+            rendered_roots
+            @ (goals
+               |> List.filter (fun (goal_id, _, _) ->
+                    not (List.exists (String.equal goal_id) !rendered_ids))
+               |> List.concat_map (render_subtree ~depth:0))
           in
           Some
             (Printf.sprintf

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -9,8 +9,7 @@ type level =
 
 type source =
   | Structured
-  | Legacy_stderr
-  | Legacy_traceln
+  | Startup_console
   | Client_tool_host
 
 type event_class = Routine
@@ -95,19 +94,13 @@ let protect ~default f =
 
 let source_to_string = function
   | Structured -> "structured"
-  | Legacy_stderr -> "legacy_stderr"
-  | Legacy_traceln -> "legacy_traceln"
+  | Startup_console -> "startup_console"
   | Client_tool_host -> "client_tool_host"
 
 let event_class_to_string : event_class -> string = function
   | Routine -> "routine"
 
 let has_prefix ~prefix value = String.starts_with ~prefix value
-
-(* RFC-0079: [infer_legacy_level] (a string-prefix classifier on the
-   message body) was deleted along with the [?level] option on
-   [legacy_stderr] / [legacy_traceln]. All callers now pass typed [~level]
-   explicitly; see [Log.legacy_stderr] / [Log.legacy_traceln] below. *)
 
 (** Check if level should be logged *)
 let should_log level =
@@ -451,8 +444,7 @@ module Ring = struct
      drift between encoder and decoder is visible to the reviewer. *)
   let source_of_string = function
     | "structured" -> Structured
-    | "legacy_stderr" -> Legacy_stderr
-    | "legacy_traceln" -> Legacy_traceln
+    | "startup_console" -> Startup_console
     | "client_tool_host" -> Client_tool_host
     | s -> raise (Entry_decode_error (Printf.sprintf "unknown source: %S" s))
 
@@ -566,13 +558,7 @@ module Ring = struct
       Fs_compat.fold_jsonl_lines
         ~init:()
         ~f:(fun () ~line_no json ->
-          (* RFC-0079: file-fold is the one boundary that tolerates legacy
-             rows written before the typed encoder. Older JSONL files (with
-             [raw_level] / [normalized_level] / [legacy_classified]) fail
-             [entry_of_json] because their schema is gone; the cleanup_old
-             rotation deletes them within [keep_days], so the WARN here is
-             load-bearing only during that window. Anywhere else, a decode
-             error propagates as [Entry_decode_error]. *)
+          (* File reads keep processing after a malformed row so one corrupt entry does not hide later current-schema entries. *)
           match entry_of_json json with
           | exception Entry_decode_error msg ->
               Printf.eprintf

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -86,8 +86,7 @@ val error : ?ctx:string -> ?category:category -> ('a, unit, string, unit) format
 (** Mirror source kinds carried on every [Ring.entry]. *)
 type source =
   | Structured
-  | Legacy_stderr
-  | Legacy_traceln
+  | Startup_console
   | Client_tool_host
 
 val source_to_string : source -> string
@@ -95,14 +94,10 @@ val source_to_string : source -> string
     in [dashboard/src/api/schemas/logs.ts] reads this back via
     [source_of_string]. *)
 
-val legacy_stderr : level:level -> ?module_name:string -> string -> unit
-(** Mirror a stderr line into the dashboard log ring.  [~level] is
-    required as of RFC-0079; the prior [?level] option backed a
-    string-prefix classifier ([infer_legacy_level]) that has been removed. *)
-
-val legacy_traceln : level:level -> ?module_name:string -> string -> unit
-(** Mirror an [Eio.traceln]-style line into the dashboard log ring.
-    [~level] required (see [legacy_stderr]). *)
+val startup_console : level:level -> ?module_name:string -> string -> unit
+(** Write an initialization diagnostic without applying runtime log filtering,
+    and mirror it into the dashboard ring. Use only before server logging is
+    fully initialized or while acquiring the single-runtime ownership lease. *)
 
 (** In-memory ring buffer exposed for dashboard log viewer routes. *)
 module Ring : sig

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -12,11 +12,6 @@
     - Mcp_server_eio_protocol: JSON-RPC handlers, subscriptions, transport
 *)
 
-(** {1 Re-exported Types} *)
-
-type server_state = Mcp_server.server_state
-type jsonrpc_request = Mcp_transport_protocol.jsonrpc_request
-
 type tool_profile = Mcp_server_eio_types.tool_profile =
   | Full
   | Managed_agent

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -15,14 +15,6 @@
 *)
 
 
-(** {1 Types} *)
-
-(** Server state - same as Mcp_server.server_state for compatibility *)
-type server_state = Mcp_server.server_state
-
-(** JSON-RPC request (re-exported for convenience) *)
-type jsonrpc_request = Mcp_server.jsonrpc_request
-
 (** Tool exposure profile for streamable HTTP endpoints. *)
 type tool_profile =
   | Full
@@ -32,7 +24,7 @@ type tool_profile =
 (** {1 JSON-RPC Helpers (re-exported)} *)
 
 val is_jsonrpc_response : Yojson.Safe.t -> bool
-val get_id : jsonrpc_request -> Yojson.Safe.t
+val get_id : Mcp_transport_protocol.jsonrpc_request -> Yojson.Safe.t
 val is_valid_request_id : Yojson.Safe.t -> bool
 val validate_initialize_params : Yojson.Safe.t option -> (unit, string) result
 
@@ -65,7 +57,7 @@ val get_clock : unit -> (float Eio.Time.clock_ty Eio.Resource.t, string) result
 (** {1 State Management} *)
 
 module For_testing : sig
-  val create_state : base_path:string -> unit -> server_state
+  val create_state : base_path:string -> unit -> Mcp_server.server_state
   (** Create non-runtime state and explicitly disable workspace authentication.
       This constructor is isolated from the production bootstrap surface. *)
 end
@@ -91,7 +83,7 @@ val create_state_eio :
   mono_clock:Eio.Time.Mono.ty Eio.Resource.t ->
   net:[> `Generic | `Unix] Eio.Net.ty Eio.Resource.t ->
   base_path:string ->
-  server_state
+  Mcp_server.server_state
 
 (** {1 Request Handling - Eio Native} *)
 
@@ -115,7 +107,7 @@ val handle_request :
   ?otel_transport_context:Otel_dispatch_hook.transport_context ->
   ?auth_token:string ->
   ?internal_keeper_runtime:bool ->
-  server_state ->
+  Mcp_server.server_state ->
   string ->
   Yojson.Safe.t
 
@@ -131,7 +123,7 @@ val execute_tool_eio :
   ?invocation_ref:Tool_invocation_ref.t ->
   ?auth_token:string ->
   ?internal_keeper_runtime:bool ->
-  server_state ->
+  Mcp_server.server_state ->
   name:string ->
   arguments:Yojson.Safe.t ->
   Tool_result.result
@@ -150,4 +142,8 @@ val clear_resource_subscriptions_for_session : string -> unit
     @param sw Eio.Switch for structured concurrency
     @param env Eio environment (for stdin/stdout)
     @param state Server state *)
-val run_stdio : sw:Eio.Switch.t -> env:Eio_unix.Stdenv.base -> server_state -> unit
+val run_stdio :
+  sw:Eio.Switch.t ->
+  env:Eio_unix.Stdenv.base ->
+  Mcp_server.server_state ->
+  unit

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -63,11 +63,9 @@ let handle_read_resource_eio state id params =
                     incr count
                 | Ok _ -> ()
                 | Error detail ->
-                  Log.legacy_traceln
-                    ~level:Log.Warn
-                    ~module_name:"MCP"
+                  Log.Mcp.emit Log.Warn
                     (Printf.sprintf
-                       "[WARN] Failed to decode message resource %s: %s"
+                       "Failed to decode message resource %s: %s"
                        path
                        detail)
               end
@@ -85,9 +83,9 @@ let handle_read_resource_eio state id params =
               | json -> Some json
               | exception Yojson.Json_error msg ->
                 let preview = String_util.utf8_safe ~max_bytes:53 ~suffix:"..." line |> String_util.to_string in
-                Log.legacy_traceln ~level:Log.Warn ~module_name:"MCP"
+                Log.Mcp.emit Log.Warn
                   (Printf.sprintf
-                     "[WARN] Failed to parse event JSON: %s (line: %s)" msg
+                     "Failed to parse event JSON: %s (line: %s)" msg
                      preview);
                 None
             ) lines

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -690,9 +690,7 @@ in
          @ (let confirm_scope =
               timed "pending_confirms" (fun () -> pending_confirm_scope ?actor config)
             in
-            [ ( "pending_confirms"
-              , `List (List.map pending_confirm_to_yojson confirm_scope.visible_entries) )
-            ; ( "pending_confirm_envelope"
+            [ ( "pending_confirm_envelope"
               , `Assoc
                   [ ( "items"
                     , `List
@@ -700,8 +698,6 @@ in
                     )
                   ; "summary", pending_confirm_summary_json_of_scope confirm_scope
                   ] )
-            ; ( "pending_confirm_summary"
-              , pending_confirm_summary_json_of_scope confirm_scope )
             ])
          @ [ "available_actions", available_actions_json
            ; ( "recent_actions"

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -301,10 +301,6 @@ let pending_confirm_scope_of_entries ?actor entries =
 let pending_confirm_scope ?actor config =
   pending_confirm_scope_of_entries ?actor (read_pending_confirms config)
 
-let pending_confirms_json ?actor config =
-  let scope = pending_confirm_scope ?actor config in
-  `List (List.map pending_confirm_to_yojson scope.visible_entries)
-
 let available_actions : available_action list =
   [
     make_available_action ~action_type:"broadcast" ~tool_name:"masc_broadcast"
@@ -370,11 +366,3 @@ let pending_confirm_summary_json_of_scope scope =
 
 let pending_confirm_summary_json ?actor config =
   pending_confirm_summary_json_of_scope (pending_confirm_scope ?actor config)
-
-let pending_confirm_envelope_json ?actor config =
-  let scope = pending_confirm_scope ?actor config in
-  `Assoc
-    [
-      ("items", `List (List.map pending_confirm_to_yojson scope.visible_entries));
-      ("summary", pending_confirm_summary_json_of_scope scope);
-    ]

--- a/lib/operator/operator_pending_confirm.mli
+++ b/lib/operator/operator_pending_confirm.mli
@@ -63,10 +63,8 @@ val remove_pending_confirms_by_typed_target :
 val normalize_pending_confirm_actor_filter : string option -> string option
 val pending_confirm_scope_of_entries : ?actor:string -> pending_confirm list -> pending_confirm_scope
 val pending_confirm_scope : ?actor:string -> Workspace.config -> pending_confirm_scope
-val pending_confirms_json : ?actor:string -> Workspace.config -> Yojson.Safe.t
 val available_actions : available_action list
 val available_action_to_yojson : available_action -> Yojson.Safe.t
 val available_actions_json : Yojson.Safe.t
 val pending_confirm_summary_json_of_scope : pending_confirm_scope -> Yojson.Safe.t
 val pending_confirm_summary_json : ?actor:string -> Workspace.config -> Yojson.Safe.t
-val pending_confirm_envelope_json : ?actor:string -> Workspace.config -> Yojson.Safe.t

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -429,7 +429,7 @@ let write_takeover_breadcrumb ~lock_path ~port ~target_pid ~signal_name =
       ~finally:(fun () -> close_out_noerr oc)
       (fun () -> output_string oc (Yojson.Safe.to_string payload))
   | exception Sys_error reason ->
-    Log.legacy_stderr
+    Log.startup_console
       ~level:Log.Warn
       ~module_name:"Server"
       (Printf.sprintf "[WARN] takeover breadcrumb write failed at %s: %s" path reason)
@@ -528,7 +528,7 @@ let acquire_pid_lock
             | Some command -> not (looks_like_server_command command)
             | None -> true
           then (
-            Log.legacy_stderr
+            Log.startup_console
               ~level:Log.Error
               ~module_name:"Server"
               (Printf.sprintf
@@ -537,7 +537,7 @@ let acquire_pid_lock
                  pid);
             Already_running { pid })
           else (
-            Log.legacy_stderr
+            Log.startup_console
               ~level:Log.Warn
               ~module_name:"Server"
               (Printf.sprintf
@@ -554,7 +554,7 @@ let acquire_pid_lock
             if
               not (wait_for_pid_exit ~poll_interval_sec ~timeout_sec:term_timeout_sec pid)
             then (
-              Log.legacy_stderr
+              Log.startup_console
                 ~level:Log.Warn
                 ~module_name:"Server"
                 (Printf.sprintf "[WARN] PID %d did not exit; sending SIGKILL" pid);
@@ -566,7 +566,7 @@ let acquire_pid_lock
               Safe_ops.protect ~default:() (fun () -> Unix.kill pid Sys.sigkill);
               if not (wait_for_pid_exit ~poll_interval_sec ~timeout_sec:kill_wait_sec pid)
               then
-                Log.legacy_stderr
+                Log.startup_console
                   ~level:Log.Warn
                   ~module_name:"Server"
                   (Printf.sprintf
@@ -574,7 +574,7 @@ let acquire_pid_lock
                      pid));
             Acquired)
         else (
-          Log.legacy_stderr
+          Log.startup_console
             ~level:Log.Warn
             ~module_name:"Server"
             (Printf.sprintf
@@ -582,7 +582,7 @@ let acquire_pid_lock
                pid);
           Acquired)
       | _ ->
-        Log.legacy_stderr
+        Log.startup_console
           ~level:Log.Warn
           ~module_name:"Server"
           "[WARN] Invalid PID file contents, overwriting";

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -357,8 +357,8 @@ let collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label =
                  | Ok _ | Error _ -> loop remaining acc rest)
             | exception (Eio.Cancel.Cancelled _ as e) -> raise e
             | exception e ->
-                Log.legacy_traceln ~level:Log.Warn ~module_name:"Workspace"
-                  (Printf.sprintf "[WARN] Failed to read %s %s: %s" warn_label
+                Log.Workspace.emit Log.Warn
+                  (Printf.sprintf "Failed to read %s %s: %s" warn_label
                      name (Printexc.to_string e));
                 loop remaining acc rest
     in
@@ -396,9 +396,9 @@ let get_all_messages_raw config ~since_seq =
                  | Ok _ | Error _ -> loop acc rest)
             | exception (Eio.Cancel.Cancelled _ as e) -> raise e
             | exception e ->
-                Log.legacy_traceln ~level:Log.Warn ~module_name:"Workspace"
+                Log.Workspace.emit Log.Warn
                   (Printf.sprintf
-                     "[WARN] Failed to read workspace message %s: %s"
+                     "Failed to read workspace message %s: %s"
                      name (Printexc.to_string e));
                 loop acc rest
       in

--- a/scripts/ci/check-logging-consistency.sh
+++ b/scripts/ci/check-logging-consistency.sh
@@ -7,9 +7,10 @@
 #   lib/masc_log/log.ml exposes one canonical logging surface:
 #     Log.<Module>.{info,warn,error,debug}   (normal logs)
 #     Log.<Module>.routine                   (routine/housekeeping)
+#     Log.startup_console                    (pre-runtime ownership diagnostics)
 #   Everything else (raw Printf.eprintf / prerr_*, the top-level
 #   Log.{info,warn,error,debug} ~ctx form, the `Logs.*` library, the
-#   Log.legacy_stderr/legacy_traceln RFC-0079 bridge, and bare Log.emit /
+#   bare Log.emit /
 #   Log.emit_event) is a non-canonical way to write the same output. A mix of
 #   ~6 styles makes severity, component naming, and dashboard routing
 #   inconsistent. This gate scans lib/ and bin/ for the non-canonical styles,
@@ -116,8 +117,6 @@ scan_rows() {
       [ "toplevel", qr/\bLog\.(?!(?:[A-Z][A-Za-z0-9_]*)\.)(info|warn|error|debug)(?:\s+|\s*\n\s*)(?:~ctx|")/ ],
       # the Logs.* library (distinct from masc Log)
       [ "logs_lib", qr/\bLogs\.(info|warn|err|debug|app)\b/ ],
-      # RFC-0079 legacy raw-stderr bridge
-      [ "legacy",   qr/\bLog\.legacy_(stderr|traceln)\b/ ],
       # bare top-level Log.emit / Log.emit_event (emit_routine is the routine API,
       # intentionally not flagged)
       [ "emit",     qr/\bLog\.(emit|emit_event)(?!_routine)\b/ ],

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -77,7 +77,7 @@ let test_record_verdict_writes () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let req = make_req () in
   let result = make_result () in
   Cal.record_verdict ~task_id:"task-1" ~req ~result ();
@@ -93,7 +93,7 @@ let test_record_verdict_reject () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let req = make_req () in
   let result =
     make_result ~verdict:(AR.Reject "vague notes") ~gate:AR.Structured_tool ()
@@ -110,7 +110,7 @@ let test_record_verdict_hash_matches () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let req = make_req () in
   let result = make_result () in
   Cal.record_verdict ~task_id:"task-3" ~req ~result ();
@@ -130,7 +130,7 @@ let test_record_human_label () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   Cal.record_human_label
     ~notes_hash:"abc123" ~human_verdict:Cal.Reject_label
     ~labeler:"vincent" ~reason:"work was incomplete";
@@ -151,7 +151,7 @@ let test_find_divergences_false_positive () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let req = make_req ~title:"FP task" ~notes:"looks ok but not" () in
   let result = make_result ~verdict:AR.Approve ~gate:AR.Structured_tool () in
   Cal.record_verdict ~task_id:"t1" ~req ~result ();
@@ -172,7 +172,7 @@ let test_find_divergences_false_negative () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let req = make_req ~title:"FN task" ~notes:"actually good work" () in
   let result =
     make_result ~verdict:(AR.Reject "unclear") ~gate:AR.Structured_tool ()
@@ -193,7 +193,7 @@ let test_find_divergences_agreement () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let req = make_req ~title:"OK task" ~notes:"done correctly" () in
   let result = make_result ~verdict:AR.Approve () in
   Cal.record_verdict ~task_id:"t3" ~req ~result ();
@@ -209,7 +209,7 @@ let test_find_divergences_no_labels () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let req = make_req () in
   let result = make_result () in
   Cal.record_verdict ~task_id:"t4" ~req ~result ();
@@ -225,7 +225,7 @@ let test_select_examples_max () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   (* Create 3 false positives *)
   for i = 1 to 3 do
     let title = Printf.sprintf "task-%d" i in
@@ -246,7 +246,7 @@ let test_select_examples_empty () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let examples = Cal.select_examples ~max_examples:5 in
   check int "empty when no data" 0 (List.length examples);
   Cal.reset_store_for_testing ()
@@ -275,7 +275,7 @@ let test_calibration_stats () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   (* 2 approvals, 1 rejection *)
   let req1 = make_req ~title:"t1" ~notes:"n1" () in
   Cal.record_verdict ~task_id:"id1" ~req:req1
@@ -310,7 +310,7 @@ let test_calibration_stats_cross_model_mix () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   Fun.protect ~finally:Cal.reset_store_for_testing @@ fun () ->
   (* Four verdicts:
      - same runtime (generator = evaluator)     → NOT cross-model
@@ -385,7 +385,7 @@ let test_on_harness_verdict_callback () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let received = ref None in
   let req = make_req () in
   let result = make_result () in
@@ -402,7 +402,7 @@ let test_on_harness_verdict_with_collector () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let collector = Agent_sdk.Eval.create_collector
     ~agent_name:"test-agent" ~run_id:"run-1" in
   let req = make_req () in
@@ -419,7 +419,7 @@ let test_on_harness_verdict_exception_safe () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
-  Cal.set_store_for_testing ~base_dir:dir;
+  Cal.set_store ~base_dir:dir;
   let req = make_req () in
   let result = make_result () in
   Cal.record_verdict ~task_id:"exc-1" ~req ~result

--- a/test/test_keeper_goal_phase_projection.ml
+++ b/test/test_keeper_goal_phase_projection.ml
@@ -381,6 +381,23 @@ let test_a_child_renders_under_its_parent () =
     (contains_in world "taking one is a move you can make (3)")
 ;;
 
+let test_all_descendants_render_at_their_full_depth () =
+  with_workspace @@ fun config ->
+  Goal_store.write_state config
+    { version = 1
+    ; updated_at = Masc_domain.now_iso ()
+    ; goals =
+        [ goal_in Goal_phase.Executing "goal-root" "root"
+        ; goal_child_of "goal-root" Goal_phase.Executing "goal-child" "child"
+        ; goal_child_of "goal-child" Goal_phase.Executing "goal-grandchild" "grandchild"
+        ]
+    };
+  let world = rendered_world_state config in
+  check bool "the complete parent chain is visible" true
+    (contains_in world
+       "- goal-root — root\n  - goal-child — child\n    - goal-grandchild — grandchild")
+;;
+
 (* A child whose parent is not in this list -- owned, terminal, or already served
    by a Task -- is its own invitation, so it must not be hidden by the nesting. *)
 let test_a_child_whose_parent_is_absent_stands_alone () =
@@ -433,6 +450,8 @@ let () =
             test_unowned_goals_reach_the_rendered_turn
         ; test_case "a child renders under its parent" `Quick
             test_a_child_renders_under_its_parent
+        ; test_case "all descendants render at their full depth" `Quick
+            test_all_descendants_render_at_their_full_depth
         ; test_case "a child whose parent is absent stands alone" `Quick
             test_a_child_whose_parent_is_absent_stands_alone
         ] )

--- a/test/test_keeper_meta_current_schema.ml
+++ b/test/test_keeper_meta_current_schema.ml
@@ -154,29 +154,10 @@ let test_retired_compaction_failure_authority_requires_reset () =
      |> replace_field "compaction_consecutive_failures" (`Int 3))
 ;;
 
-(* masc#27393: the Persona hard-cut (masc#27048) dropped [persona] from the
-   current schema, and this decoder's exact-fields check made every real,
-   durable keeper meta JSON unloadable overnight -- every live keeper still
-   carried the field. Tolerated on read, never round-tripped: the writer
-   only ever emits {!Keeper_meta_json.current_field_names}, so a
-   persona-bearing meta drops the field on its own next write, with no
-   migration step. *)
-let test_legacy_persona_field_loads () =
-  expect_current
-    "meta with a legacy persona field"
+let test_retired_persona_field_is_outside_current_schema () =
+  expect_rejected
+    "meta with retired persona field"
     (current_json () |> replace_field "persona" (`String "sangsu"))
-;;
-
-let test_legacy_persona_field_does_not_round_trip () =
-  let json = current_json () |> replace_field "persona" (`String "sangsu") in
-  match Keeper_meta_json_parse.meta_of_json json with
-  | Error detail -> Alcotest.failf "legacy persona field rejected: %s" detail
-  | Ok meta ->
-    let written_keys =
-      Keeper_meta_json.meta_to_json meta |> fields_exn |> List.map fst
-    in
-    check bool "next write drops the legacy persona field" false
-      (List.mem "persona" written_keys)
 ;;
 
 let () =
@@ -201,10 +182,8 @@ let () =
             test_retired_compaction_failure_authority_requires_reset
         ; test_case "writer rejects non-finite values" `Quick
             test_current_writer_rejects_non_finite_values
-        ; test_case "legacy persona field loads (masc#27393)" `Quick
-            test_legacy_persona_field_loads
-        ; test_case "legacy persona field does not round-trip" `Quick
-            test_legacy_persona_field_does_not_round_trip
+        ; test_case "retired persona field is outside current schema" `Quick
+            test_retired_persona_field_is_outside_current_schema
         ] )
     ]
 ;;

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1161,14 +1161,7 @@ let test_keeper_toml_inline_instructions_needs_no_agent_md () =
     check (option string) "inline TOML instructions are used directly"
       (Some "legacy inline instructions") defaults.instructions
 
-let test_keeper_toml_tolerates_legacy_persona_name () =
-  (* keeper.persona_name lost its target when the Persona subsystem was
-     hard-cut, but it is still present in every live keeper TOML this
-     operator has (analyst, code-reviewer, rondo, sangsu, taskmaster). The
-     pre-release policy is to tolerate legacy-version data rather than ship
-     migration code, so this key must not fail the load -- and it must not
-     be silently parsed into anything either, since no persona lookup
-     exists to resolve it against. *)
+let test_keeper_toml_rejects_retired_persona_name () =
   with_profile_base @@ fun ~base_path ~config_dir:_ ~keepers_dir ->
   let keeper_path = Filename.concat keepers_dir "veteran.toml" in
   write_file keeper_path
@@ -1178,10 +1171,12 @@ let test_keeper_toml_tolerates_legacy_persona_name () =
       ~base_path
       "veteran"
   with
-  | Error error -> fail (KTP.keeper_toml_load_error_to_string error)
-  | Ok defaults ->
-    check (option string) "instructions load despite the tolerated legacy key"
-      (Some "veteran inline instructions") defaults.instructions
+  | Ok _ -> fail "retired keeper.persona_name unexpectedly loaded"
+  | Error error ->
+    check bool "error names the retired key" true
+      (Astring.String.is_infix
+         ~affix:"keeper.persona_name"
+         (KTP.keeper_toml_load_error_to_string error))
 
 let test_keeper_config_directory_probe_is_typed () =
   let path = Filename.temp_file "keeper-config-not-dir" ".toml" in
@@ -1691,8 +1686,8 @@ let () =
             test_keeper_agent_read_failure_is_typed_profile_error;
           test_case "inline TOML instructions need no AGENT.md" `Quick
             test_keeper_toml_inline_instructions_needs_no_agent_md;
-          test_case "tolerates legacy persona_name" `Quick
-            test_keeper_toml_tolerates_legacy_persona_name;
+          test_case "rejects retired persona_name" `Quick
+            test_keeper_toml_rejects_retired_persona_name;
           test_case "config directory probe is typed" `Quick
             test_keeper_config_directory_probe_is_typed;
         ] );

--- a/test/test_log_ring_encoder.ml
+++ b/test/test_log_ring_encoder.ml
@@ -36,7 +36,7 @@ let test_round_trip_all_sources () =
        let decoded = Log.Ring.entry_of_json (Log.Ring.entry_to_json original) in
        Alcotest.(check bool)
          (Log.source_to_string source) true (decoded.source = source))
-    [ Log.Structured; Log.Legacy_stderr; Log.Legacy_traceln; Log.Client_tool_host ]
+    [ Log.Structured; Log.Startup_console; Log.Client_tool_host ]
 
 let test_round_trip_optional_fields () =
   let with_optional =

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -52,22 +52,6 @@ let latest_seq () =
   | (entry : Log.Ring.entry) :: _ -> entry.seq
   | [] -> -1
 
-let test_legacy_traceln_records_metadata () =
-  let module_name = "TestLogLegacy" in
-  let message =
-    Printf.sprintf "[WARN] legacy warning %f" (Unix.gettimeofday ())
-  in
-  Log.legacy_traceln ~level:Log.Warn ~module_name message;
-  match find_entry ~module_name ~message with
-  | None -> Alcotest.fail "legacy traceln entry not found"
-  | Some (entry : Log.Ring.entry) ->
-      Alcotest.(check string)
-        "source" "legacy_traceln"
-        (Log.source_to_string entry.source);
-      Alcotest.(check string)
-        "level" "WARN"
-        (Log.level_to_string entry.level)
-
 let test_recent_since_seq_returns_only_new_entries () =
   let module_name = "TestLogDelta" in
   let baseline = latest_seq () in
@@ -203,8 +187,6 @@ let () =
   Alcotest.run "Masc_log" [
     ( "ring",
       [
-        Alcotest.test_case "legacy traceln records metadata" `Quick
-          test_legacy_traceln_records_metadata;
         Alcotest.test_case "recent since_seq returns only new entries" `Quick
           test_recent_since_seq_returns_only_new_entries;
         Alcotest.test_case "recent before_seq returns only older entries" `Quick

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -331,22 +331,11 @@ let resource_mime_type_exn response =
   | Some (`String value) -> value
   | _ -> Alcotest.fail "resource mime type missing"
 
-(* ===== Unit Tests for Type Re-exports ===== *)
-
 let test_create_state () =
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
   Alcotest.(check string) "base_path preserved"
     base_path (Mcp_server.workspace_config state).base_path;
-  cleanup_dir base_path
-
-let test_type_compatibility () =
-  (* Verify Mcp_server_eio.server_state is same type as Mcp_server.server_state *)
-  let base_path = temp_dir () in
-  let state : Mcp_eio.server_state = Mcp_eio.For_testing.create_state ~base_path () in
-  let state2 : Mcp.server_state = state in  (* Type unification at compile time *)
-  (* Verify the unified type preserves field access *)
-  Alcotest.(check string) "base_path via unified type" base_path (Mcp_server.workspace_config state2).base_path;
   cleanup_dir base_path
 
 let test_eio_context_delegation () =
@@ -2997,7 +2986,6 @@ let test_handle_request_resources_subscribe_roundtrip () =
 
 let state_tests = [
   "create_state", `Quick, test_create_state;
-  "type compatibility", `Quick, test_type_compatibility;
   "eio context delegation", `Quick, test_eio_context_delegation;
   "eio context scoped restore", `Quick, test_eio_context_with_test_env_restores;
 ]

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -22,7 +22,7 @@ type fixture = {
   auth_token : string;
   clock : float Eio.Time.clock_ty Eio.Resource.t;
   sw : Eio.Switch.t;
-  state : Mcp_eio.server_state;
+  state : Mcp_server.server_state;
   worktree_dir : string;
   mutable task_id : string option;
   mutable board_post_id : string option;

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -114,7 +114,8 @@ let test_task_inject_executes_after_confirmation () =
       in
       let snapshot = Operator_control.snapshot_json ~actor:"operator" ctx in
       let pending_confirms =
-        snapshot |> Yojson.Safe.Util.member "pending_confirms"
+        snapshot |> Yojson.Safe.Util.member "pending_confirm_envelope"
+        |> Yojson.Safe.Util.member "items"
         |> Yojson.Safe.Util.to_list
       in
       Alcotest.(check int) "pending confirm count" 1 (List.length pending_confirms);
@@ -143,7 +144,8 @@ let test_task_inject_executes_after_confirmation () =
         (Yojson.Safe.Util.member "result" confirm_json <> `Null);
       let snapshot = Operator_control.snapshot_json ~actor:"operator" ctx in
       let pending_confirms =
-        snapshot |> Yojson.Safe.Util.member "pending_confirms"
+        snapshot |> Yojson.Safe.Util.member "pending_confirm_envelope"
+        |> Yojson.Safe.Util.member "items"
         |> Yojson.Safe.Util.to_list
       in
       Alcotest.(check int) "pending confirm removed" 0

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -321,8 +321,7 @@ let test_confirm_consumes_pending_token_before_delegated_action_fails () =
        | Ok () -> ()
        | Error err -> Alcotest.failf "failed to persist pending confirm fixture: %s" err);
       let initial_pending_confirms =
-        Operator_control.pending_confirms_json ~actor:"operator" config
-        |> Yojson.Safe.Util.to_list
+        (Operator_control.pending_confirm_scope ~actor:"operator" config).visible_entries
       in
       Alcotest.(check int)
         "pending confirm fixture persisted" 1
@@ -336,8 +335,7 @@ let test_confirm_consumes_pending_token_before_delegated_action_fails () =
       | Error err ->
           Alcotest.(check bool) "non-empty error" true (String.length err > 0));
       let pending_confirms =
-        Operator_control.pending_confirms_json ~actor:"operator" config
-        |> Yojson.Safe.Util.to_list
+        (Operator_control.pending_confirm_scope ~actor:"operator" config).visible_entries
       in
       Alcotest.(check int) "pending confirm consumed" 0 (List.length pending_confirms))
 

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -758,8 +758,8 @@ let test_snapshot_has_expected_sections () =
         (Yojson.Safe.Util.member "keepers" json <> `Null);
       Alcotest.(check bool) "recent_messages present" true
         (Yojson.Safe.Util.member "recent_messages" json <> `Null);
-      Alcotest.(check bool) "pending_confirms present" true
-        (Yojson.Safe.Util.member "pending_confirms" json <> `Null);
+      Alcotest.(check bool) "pending-confirm envelope present" true
+        (Yojson.Safe.Util.member "pending_confirm_envelope" json <> `Null);
       Alcotest.(check bool) "trace_id present" true
         (json |> Yojson.Safe.Util.member "trace_id" |> Yojson.Safe.Util.to_string
        <> "");
@@ -815,7 +815,9 @@ let test_snapshot_pending_confirm_summary_tracks_actor_scope () =
       request_namespace_pause "operator-a";
       request_namespace_pause "operator-b";
       let snapshot = Operator_control.snapshot_json ~actor:"operator-a" ctx in
-      let summary = Yojson.Safe.Util.(snapshot |> member "pending_confirm_summary") in
+      let summary =
+        Yojson.Safe.Util.(snapshot |> member "pending_confirm_envelope" |> member "summary")
+      in
       Alcotest.(check string) "actor filter" "operator-a"
         Yojson.Safe.Util.(summary |> member "actor_filter" |> to_string);
       Alcotest.(check bool) "filter active" true


### PR DESCRIPTION
## Summary
- hard-cut retired keeper persona fields and obsolete CLI/API aliases
- render the complete unowned-goal hierarchy instead of dropping deeper descendants
- make pending-confirm envelope the single operator snapshot wire contract
- remove legacy log sources and route runtime logs through typed module loggers
- retain only explicit startup diagnostics required before runtime logging is initialized

## Scope
- no migration or compatibility shim
- no new scheduler, approval, or feature gate
- pre-existing untracked docs/reports/TLA artifacts are excluded

## Verification
- local tests were not run; GitHub CI is the build authority for this incremental cleanup PR