### PR TITLE
chore(ci): 아무도 읽지 않는 CI 환경변수 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1647,7 +1647,6 @@ jobs:
           ALCOTEST_QUICK_TESTS: "1"
           CI_TEST_HEARTBEAT_SEC: 15
           MASC_LOCAL_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
-          MASC_KEEPER_MSG_TIMEOUT_MAX_SEC: "10"
           MASC_E2E_TESTS: "true"
           DUNE_JOBS: 1
         run: |


### PR DESCRIPTION
`ci.yml` 이 operator 테스트 잡에 이 변수를 넘긴다.

```yaml
MASC_KEEPER_MSG_TIMEOUT_MAX_SEC: "10"
```

`#5114`(2026-04-04, "remove dead reward/policy model and unused config")가 접근자를 삭제했다.

```ocaml
let keeper_msg_timeout_max_sec () : int =
  int_of_env_default "MASC_KEEPER_MSG_TIMEOUT_MAX_SEC" ~default:300 ~min_v:5
```

`lib/`, `bin/`, `scripts/`, `test/`, `dashboard/src` 어디에도 이 이름을 읽는 곳이 없고 `MASC_KEEPER_MSG_*` 로 개명된 knob 도 없다. 넘긴 `"10"` 은 아무 데도 도달하지 않는다.

## 같은 자리의 다른 변수는 살아있다

- `MASC_E2E_TESTS` — `test/` 에서 6곳이 읽는다
- `MASC_LOCAL_RUNTIMES_JSON` — 1곳

## 이 라운드에서 확인했으나 결함이 아니었던 것

같은 방법을 설정 계층 전반에 돌렸고 대부분 건강했다.

| 검사 | 결과 |
|---|---|
| TOML 설정 키 26개 (`config/runtime.toml`, `presets/classic/keepers/*.toml`) | 전부 코드가 파싱 |
| `env_config_snapshot` 카탈로그 138개 | 코드가 안 읽는 항목 0 |
| `feature_flag_registry` 15개 | 전부 살아있음 |
| `HARNESS_*` 스크립트 변수 13개 | 4건이 write-only 로 보였으나 전부 `${VAR:-default}` / `"$VAR"` 형태로 소비됨 |

## 검증

- `ci.yml` YAML 파싱 OK
- `rg 'MASC_KEEPER_MSG_TIMEOUT_MAX_SEC' .github/` → 0
