### PR TITLE
docs(runtime): OAS 교차 저장소 인용을 심볼 앵커로 고정

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -143,7 +143,8 @@ let find_declared_lane (lanes : Runtime_lane.t list) (id : string) =
    requests a wire response format, leaving a variant with match arms and no
    construction site — dead weight that reads as an available option. The tool
    channel it could not express is refused by OAS at dispatch through
-   candidate_rejection_disposition (oas/lib/llm_provider/exact_output.mli:126-132),
+   candidate_rejection_disposition
+   (oas/lib/llm_provider/exact_output.mli::candidate_rejection_disposition),
    which is pre-dispatch and therefore failover-eligible: ordering rather than
    exclusion, which is what the spec asks for. *)
 type reference_domain =


### PR DESCRIPTION
## 문제

`lib/runtime/runtime.ml` 의 `reference_domain` 주석이 OAS 쪽 타입을 줄 번호로 인용한다.

```
candidate_rejection_disposition (oas/lib/llm_provider/exact_output.mli:126-132)
```

그 타입은 현재 **185행**이다. 인용된 126-132 에는 `requested_assurance` 변형과 `actual_assurance` 가 있어, 읽는 사람을 무관한 선언으로 보낸다.

```
$ sed -n '126,132p' oas/lib/llm_provider/exact_output.mli
  | Provider_schema (** Explicit opt-in to a provider-native schema request. *)
  type actual_assurance =
$ rg -n 'candidate_rejection_disposition' oas/lib/llm_provider/exact_output.mli
185:type candidate_rejection_disposition =
```

## 변경

주장 자체는 여전히 참이다 — 타입은 존재하고 pre-dispatch 거부 경로를 담당한다. **포인터만 썩었으므로 앵커만 바꾼다.**

저장소가 이미 선호하고 이미 쓰는 `path::symbol` 형식으로 교체:

- `scripts/lint/exhaustive-guard.allowlist:13` — *"Prefer path::symbol: line anchors die whenever a file is split."*
- 기존 사용례: `lib/turn_fsm/turn_fsm.ml::classify_transition`, `lib/keeper/keeper_event_bridge.ml::native_event_to_json`

## 범위에 대한 정직한 진술

`lib/` 전체의 `file:line` 주석 인용을 훑은 결과 **7건**뿐이었고, 그중 실제 결함은 이 1건이다.

- 1건은 **제 스캐너의 오탐**이었다 — `oas/` 접두를 정규식이 벗겨내 "파일 없음"으로 잘못 표시했다. 파일은 OAS 에 있다. 드리프트는 그 오탐을 확인하다가 별도로 드러났다.
- 1건(`lib/sse_event/sse_event.ml:95`, 삭제된 `runtime_event_bridge.ml` 인용)은 **미병합 브랜치 `039e683cbe` 가 이미 고치고 있어** 손대지 않았다. 중복하면 충돌한다.

즉 이 축은 거의 비어 있다. 이 PR 을 일반화된 문제의 발견으로 읽지 말 것.

## 검증

`dune build --root . @lib/runtime/check` → RC=0. 주석 변경이라 동작 변화는 없다.
