### PR TITLE
fix(tools): make the judge and the producer read the same description

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,15 @@ jobs:
       - name: Check odoc references
         run: python3 scripts/audit-odoc-refs.py
 
+      # A tool description is a prompt -- it is what the model reads when
+      # choosing a tool. Some tools carry one in keeper_tool_descriptor.ml (what
+      # production hands a Keeper) and another in lib/tool_surface/ (the shard
+      # catalog), and nine already disagree. #27542 edited the shard copy, added
+      # a test that read the shard copy, and passed while changing nothing a
+      # Keeper sees. This is that review, mechanised.
+      - name: Check tool description drift
+        run: python3 scripts/audit-tool-description-drift.py
+
       # Both directions of the hand-maintained CI test allowlist. A target
       # whose suite was deleted makes dune hard-fail after a full build
       # (#24352, and again today when config/prompts/behavior emptied), and a

--- a/scripts/audit-tool-description-drift.py
+++ b/scripts/audit-tool-description-drift.py
@@ -4,13 +4,22 @@
 A tool description is a prompt: it is what the model reads when deciding
 whether to call the tool. Two of them exist for some tools:
 
-    lib/keeper/keeper_tool_descriptor.ml   what production hands the model,
-                                           through model_visible_schemas ()
-    lib/tool_surface/*.ml                  the shard catalog
+    lib/keeper/keeper_tool_descriptor.ml   what a Keeper reads, through
+                                           model_visible_schemas ()
+    lib/tool_surface/*.ml                  what the verification authority
+                                           reads, through
+                                           Verification_authority_tools.schemas
 
-Only the first reaches a Keeper. PR #27542 edited the second, added a test that
-read the second, and passed while proving nothing about what any Keeper sees --
-the reviewer closed it for exactly that. This audit is that review, mechanised.
+Both reach a model, and the contract says they must say the same thing.
+verification_authority_tools.mli:
+
+    These are the keeper schemas verbatim: a judge and a producer read the
+    same description of the same tool.
+
+Nine pairs do not. PR #27542 edited only the shard copy, added a test that read
+only the shard copy, and passed while the Keeper-facing description was
+unchanged -- the reviewer closed it for exactly that. This audit is that review,
+mechanised, and it also covers the judge side the review did not name.
 
 At the time of writing, 11 tools carry a description in both places and 9 of
 them already differ. That is the baseline: the number may not grow. Lowering it
@@ -93,7 +102,7 @@ def main() -> int:
     )
 
     if drifted:
-        print("\nthe model reads the keeper_tool_descriptor.ml text; the other is unread:\n")
+        print("\na Keeper reads the first, the verification authority reads the second,\nand verification_authority_tools.mli says they are the same text:\n")
         for name in drifted:
             print(f"  {name}")
             print(f"    production: {production[name][:110]}")
@@ -106,9 +115,11 @@ def main() -> int:
         print(
             f"\n[tool-description-drift] {len(drifted)} exceeds the baseline of "
             f"{DRIFT_BASELINE}.\n"
-            "A description is what the model reads when choosing a tool. Edit the "
-            "one in\nkeeper_tool_descriptor.ml -- that is the copy production "
-            "hands a Keeper -- or\nmake both say the same thing."
+            "A description is what a model reads when choosing a tool, and both "
+            "of these\nreach one: the Keeper reads keeper_tool_descriptor.ml, "
+            "the verification\nauthority reads the shard. Make them say the "
+            "same thing -- that is what\nverification_authority_tools.mli "
+            "already claims they do."
         )
         return 1
 

--- a/scripts/audit-tool-description-drift.py
+++ b/scripts/audit-tool-description-drift.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Fail when a tool's description exists in two places and they disagree.
+
+A tool description is a prompt: it is what the model reads when deciding
+whether to call the tool. Two of them exist for some tools:
+
+    lib/keeper/keeper_tool_descriptor.ml   what production hands the model,
+                                           through model_visible_schemas ()
+    lib/tool_surface/*.ml                  the shard catalog
+
+Only the first reaches a Keeper. PR #27542 edited the second, added a test that
+read the second, and passed while proving nothing about what any Keeper sees --
+the reviewer closed it for exactly that. This audit is that review, mechanised.
+
+At the time of writing, 11 tools carry a description in both places and 9 of
+them already differ. That is the baseline: the number may not grow. Lowering it
+is the work; this only stops it rising.
+
+Extraction is deliberately narrow -- name-literal descriptors with a literal
+description. Descriptors built by a helper (the Board family, the Library
+family) resolve their text through the canonical registry and are not a second
+copy, so they are outside the comparison and outside the baseline.
+
+Usage:
+    scripts/audit-tool-description-drift.py           # report, exit 1 above baseline
+    scripts/audit-tool-description-drift.py --list    # report, always exit 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Tools whose two descriptions already disagree. This is a ceiling, not a
+# target: a new divergence fails, and fixing one should lower the number.
+DRIFT_BASELINE = 9
+
+PRODUCTION = REPO_ROOT / "lib" / "keeper" / "keeper_tool_descriptor.ml"
+SHARD_GLOB = "lib/tool_surface/*.ml"
+
+PRODUCTION_RE = re.compile(
+    r'~name:"([a-z_0-9]+)"\s*\n?\s*~description:\s*\n?\s*"((?:[^"\\]|\\.)*)"',
+    re.S,
+)
+SHARD_RE = re.compile(
+    r'\{\s*name = "([a-z_0-9]+)"\s*;\s*description =\s*\n?\s*"((?:[^"\\]|\\.)*)"',
+    re.S,
+)
+
+
+def normalise(text: str) -> str:
+    """OCaml line continuations and wrapping are not content."""
+    return re.sub(r"\s+", " ", re.sub(r"\\\s*\n\s*", "", text)).strip()
+
+
+def descriptions(path: Path, pattern: re.Pattern[str]) -> dict[str, str]:
+    try:
+        source = path.read_text(errors="ignore")
+    except OSError:
+        return {}
+    return {m.group(1): normalise(m.group(2)) for m in pattern.finditer(source)}
+
+
+def collect() -> tuple[dict[str, str], dict[str, str]]:
+    production = descriptions(PRODUCTION, PRODUCTION_RE)
+    shard: dict[str, str] = {}
+    for path in sorted(REPO_ROOT.glob(SHARD_GLOB)):
+        shard.update(descriptions(path, SHARD_RE))
+    return production, shard
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Report and exit 0, for inspecting the current state.",
+    )
+    args = parser.parse_args()
+
+    production, shard = collect()
+    shared = sorted(set(production) & set(shard))
+    drifted = [name for name in shared if production[name] != shard[name]]
+
+    print(
+        f"[tool-description-drift] {len(shared)} tool(s) described in both "
+        f"keeper_tool_descriptor.ml and lib/tool_surface/, "
+        f"{len(drifted)} disagreeing"
+    )
+
+    if drifted:
+        print("\nthe model reads the keeper_tool_descriptor.ml text; the other is unread:\n")
+        for name in drifted:
+            print(f"  {name}")
+            print(f"    production: {production[name][:110]}")
+            print(f"    shard     : {shard[name][:110]}")
+
+    if args.list:
+        return 0
+
+    if len(drifted) > DRIFT_BASELINE:
+        print(
+            f"\n[tool-description-drift] {len(drifted)} exceeds the baseline of "
+            f"{DRIFT_BASELINE}.\n"
+            "A description is what the model reads when choosing a tool. Edit the "
+            "one in\nkeeper_tool_descriptor.ml -- that is the copy production "
+            "hands a Keeper -- or\nmake both say the same thing."
+        )
+        return 1
+
+    if len(drifted) < DRIFT_BASELINE:
+        print(
+            f"\n[tool-description-drift] OK - {len(drifted)} drifted, "
+            f"{DRIFT_BASELINE} baseline - lower DRIFT_BASELINE to hold the "
+            f"{DRIFT_BASELINE - len(drifted)} you fixed"
+        )
+        return 0
+
+    print(f"\n[tool-description-drift] OK - {len(drifted)} drifted, at baseline")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Grew out of **#27542**, which you closed. The rejection was right, and following
it produced a bigger finding than the PR it killed.

## The invariant that was broken

`verification_authority_tools.mli:81` states it outright:

> These are the keeper schemas **verbatim**: a judge and a producer read the
> **same description of the same tool**.

**Nine pairs did not.** For example `keeper_context_status`:

```
Keeper reads : Return persisted checkpoint, recent-message, memory, and sandbox state …
judge reads  : Check your own persisted checkpoint and session state. Returns: name …
```

A description is a prompt. The judge evaluating a producer's evidence was
reading a different account of the tool the producer used.

## How #27542 led here

That PR edited `keeper_surface_post`'s description in `lib/tool_surface/`, added
a test that read `Tool_shard_types.surface_tools`, and passed — while the text a
Keeper reads, in `keeper_tool_descriptor.ml`, was untouched. Your close said so.

Chasing it turned up the second copy, then the second reader, then the contract
that says there should be no difference between them. **Neither the compiler nor
any test could see it**: both sides were internally consistent.

I also had this wrong once more along the way — the first version of this PR
claimed the shard copy was unread. It is not; it is the verification authority's
surface. Corrected in `e618106778`, and that correction is what turned a
tidiness argument into a contract violation.

## Change

**The nine are synced** to the Keeper-facing text — the copy production hands a
Keeper via `model_visible_schemas ()`. No test pinned the shard wording, so
nothing was rewritten to accommodate this.

**`scripts/audit-tool-description-drift.py`**, wired into `ci.yml`, baseline
**0**: any divergence now fails, naming both texts and citing the contract.

Kept as a constant rather than a hard zero — if a deliberate per-audience
difference is ever argued for, it belongs there with its reason rather than
passing silently.

## Deliberately narrow

Only name-literal descriptors with a literal description. The Board and Library
families build theirs through a helper that resolves from the canonical
registry — one source, not a second copy — so they are outside the comparison.
That is why the count is 11 and not larger.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
audit-tool-description-drift.py     11 shared, 0 disagreeing, at baseline

  a new divergence introduced by hand  → exit 1
  reverted                             → exit 0

test_verification_authority_tools    8 tests run   Successful
test_keeper_tool_schema_bytes        2 tests run   Successful
test_tool_registry_consistency       8 tests run   Successful
test_tool_contract_truth             9 tests run   Successful
test_enum_mirror_sync                3 tests run   Successful
```

## What this is not

It does not re-land #27542. The `keeper_surface_post` audience clause is not
here; if it is wanted, it belongs in `keeper_tool_descriptor.ml`, and this audit
now makes the shard follow automatically.

RFC-WAIVED: two copies of one description made identical, per a contract that
already said they were, plus the check that keeps them that way.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>