### PR TITLE
docs(dashboard): FSM phase 문자열의 실제 소유 모듈로 정정 (#27528 재작업)

### DIFF
--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -27,7 +27,7 @@ const POLL_INTERVAL_MS = 5_000
 const RECENT_LIMIT = 50
 
 // The gates the backend emits. Every Attribution constructor call in masc
-// passes gate:"keeper_fsm" (keeper_state_machine.ml:544/547 and the
+// passes gate:"keeper_fsm" (lib/keeper_registry/keeper_state_machine.ml and the
 // policy_failed sites), so this is the whole set. A gate outside this list
 // still gets a card from the live data (see gatesToRender), which is what
 // makes listing a gate ahead of its first emission unnecessary: the six

--- a/dashboard/src/components/common/coverage-gap-block.ts
+++ b/dashboard/src/components/common/coverage-gap-block.ts
@@ -15,7 +15,7 @@ export type CoverageErrorHint = {
 }
 
 // Substring vocabulary mirrors backend SSOT in
-// `lib/keeper_disk_pressure.ml` (`is_disk_exhaustion_text`) so the
+// `lib/core/system_error_class.ml` (`disk_needles`) so the
 // dashboard reaches the same classification the runtime already acts on.
 // Add new patterns here only when (a) backend has a matching typed
 // detector, and (b) there is a canonical RFC describing the operator
@@ -48,7 +48,7 @@ export function classifyCoverageError(error: string | null | undefined): Coverag
     }
   }
   // RFC-0122: keeper disk pressure circuit breaker — mirrors backend
-  // detector at `lib/keeper_disk_pressure.ml:55` which trips spawn slot
+  // detector in `lib/core/system_error_class.ml` which trips spawn slot
   // admission on these substrings.
   if (DISK_EXHAUSTION_NEEDLES.some(needle => lower.includes(needle))) {
     return {

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -407,7 +407,7 @@ function blockingNextStep(snapshot: KeeperCompositeSnapshot): string {
 function staleCause(snapshot: KeeperCompositeSnapshot, ageText: string): string {
   const receiptReason = snapshot.execution?.operator_disposition_reason
   // `snapshot.phase` wire format is lowercase (phase_to_string in
-  // keeper_state_machine.ml:21-35); the prior PascalCase compare was dead.
+  // lib/keeper_registry/keeper_state_machine_phase.ml); the prior PascalCase compare was dead.
   const base = snapshot.phase === 'running'
     ? 'KSM=running이지만 live turn 없음'
     : `live turn 없음 · KSM=${snapshot.phase}`

--- a/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
@@ -208,7 +208,7 @@ describe('deriveOperationalInsight', () => {
     expect(insight.tone).toBe('warn')
   })
 
-  // Backend wire format (keeper_state_machine.ml:21-35) emits the 13 raw KSM
+  // Backend wire format (lib/keeper_registry/keeper_state_machine_phase.ml) emits the 13 raw KSM
   // phases lowercase. A 7-phase composite projection with a 'Stable' carrier
   // is specced (KeeperCompositeLifecycle.tla:143) but not currently emitted,
   // so the dashboard surfaces `collapsed_from` directly whenever the backend

--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -56,7 +56,7 @@ function invariantDetail(
   }
 }
 
-// Backend (lib/keeper/keeper_state_machine.ml:21-35) emits phase strings
+// Backend (lib/keeper_registry/keeper_state_machine_phase.ml) emits phase strings
 // via `phase_to_string` in lowercase + snake_case: 'running', 'failing',
 // 'handing_off' etc. The composite observer (keeper_composite_observer.ml:628)
 // passes the same wire format through `snapshot.phase`. Compare against

--- a/dashboard/src/components/fsm-hub-lane-analysis.test.ts
+++ b/dashboard/src/components/fsm-hub-lane-analysis.test.ts
@@ -6,7 +6,7 @@ import { isObservedStall } from './fsm-hub-lane-analysis'
 // ================================================================
 
 // Wire format is lowercase + snake_case (phase_to_string in
-// keeper_state_machine.ml:21-35). Prior fixtures asserted PascalCase
+// lib/keeper_registry/keeper_state_machine_phase.ml). Prior fixtures asserted PascalCase
 // that never reached the function in production — mock↔mock loophole.
 describe('isObservedStall', () => {
   // --- phase lane ---

--- a/dashboard/src/components/fsm-hub-lane-analysis.ts
+++ b/dashboard/src/components/fsm-hub-lane-analysis.ts
@@ -17,7 +17,7 @@ export function isObservedStall(
   observedForSec: number,
 ): boolean {
   if (key === 'phase') {
-    // Wire format from `phase_to_string` (lib/keeper/keeper_state_machine.ml:21-35)
+    // Wire format from `phase_to_string` (lib/keeper_registry/keeper_state_machine_phase.ml)
     // is lowercase + snake_case. Prior PascalCase compares never matched —
     // KSM stalled detection silently disabled for every non-terminal phase.
     if (value === 'failing') return observedForSec >= 90
@@ -53,7 +53,7 @@ function laneMeaning(
   const base: { tone: InsightTone; meaning: string } = (() => {
     switch (key) {
     case 'phase':
-      // Wire format from `phase_to_string` (lib/keeper/keeper_state_machine.ml:21-35)
+      // Wire format from `phase_to_string` (lib/keeper_registry/keeper_state_machine_phase.ml)
       // is lowercase + snake_case. PascalCase cases ('Stable' was the
       // 7-phase composite projection per KeeperCompositeLifecycle.tla:143,
       // never emitted by the backend; remove rather than carry the dead

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -224,7 +224,7 @@ function PhaseSparkline({
 
 /** Human-readable descriptions for sub-FSM states.
  *  Keys match the wire format from `keeper_composite_observer.ml` exactly:
- *    KSM phase via `phase_to_string` (lib/keeper/keeper_state_machine.ml:21-35) — lowercase + snake_case.
+ *    KSM phase via `phase_to_string` (lib/keeper_registry/keeper_state_machine_phase.ml) — lowercase + snake_case.
  *    KTC/KDP/KCL/KMC via the per-axis to_string fns (lib/keeper/keeper_composite_observer.ml:141-201) — lowercase.
  *  Shown as native title tooltips on hover. */
 const STATE_DESCRIPTIONS: Record<string, string> = {

--- a/dashboard/src/components/fsm-hub-timeline-panels.test.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.test.ts
@@ -8,7 +8,7 @@ import {
 
 // ── swimlaneSegmentColor ──────────────────────────────────────
 
-// Wire format: backend (keeper_state_machine.ml:21-35 + keeper_composite_observer.ml:141-201)
+// Wire format: backend (lib/keeper_registry/keeper_state_machine_phase.ml + keeper_composite_observer.ml:141-201)
 // emits all lane values lowercase + snake_case. Prior fixtures asserted
 // PascalCase ('Failing', 'Overflowed', 'Stable', 'HandingOff') that the
 // backend never emits — mock↔mock loophole that hid the dead branches.

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -52,7 +52,7 @@ const SWIMLANE_LANES: Array<{
 ]
 
 // Wire format is lowercase + snake_case for every lane:
-//   - KSM phase: `phase_to_string` in lib/keeper/keeper_state_machine.ml:21-35
+//   - KSM phase: `phase_to_string` in lib/keeper_registry/keeper_state_machine_phase.ml
 //     emits 'running' | 'failing' | 'handing_off' etc.
 //   - KTC/KDP/KCL/KMC: keeper_composite_observer.ml:141-201 lowercase.
 // Prior PascalCase entries ('Failing', 'Overflowed', 'Stable', 'HandingOff')

--- a/dashboard/src/components/keeper-fsm-specs.test.ts
+++ b/dashboard/src/components/keeper-fsm-specs.test.ts
@@ -9,7 +9,7 @@ import {
 } from './keeper-fsm-specs'
 
 // State alphabets the dashboard renders. These must stay in lockstep with
-// the OCaml runtime: KSM ← keeper_state_machine.ml `type phase` (13 ctors),
+// the OCaml runtime: KSM ← lib/keeper_registry/keeper_state_machine_phase.ml `type phase` (13 ctors),
 // KTC ← keeper_registry.ml `type turn_phase` (7 ctors), KDP/KCL/KMC ← the
 // matching keeper_registry.ml sub-FSM types. If you change one of these
 // arrays you almost certainly need a matching change on the OCaml side and

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -118,7 +118,7 @@ export function getPhaseStyle(phase: KeeperPhase | string | null | undefined): P
   // `as KeeperPhase` assertion. `toKeeperPhase` accepts both PascalCase
   // (canonical `Keeper.phase`) and lowercase backend tokens (the same
   // shape `phase_to_string` emits in
-  // `lib/keeper/keeper_state_machine.ml:21-34`) and returns `null` on
+  // `lib/keeper_registry/keeper_state_machine_phase.ml`) and returns `null` on
   // unknown input. This matches `software-development.md` §"Parse,
   // don't validate": arbitrary strings should be narrowed through a
   // total parser, not coerced through an unchecked cast that silently

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -453,7 +453,7 @@ describe('classifyCoverageError', () => {
   })
 
   it('detects disk-pressure substrings shared with backend SSOT', () => {
-    // Mirrors lib/keeper_disk_pressure.ml `is_disk_exhaustion_text` vocabulary
+    // Mirrors lib/core/system_error_class.ml `disk_needles` vocabulary
     expect(classifyCoverageError('disk full')?.reason).toBe('disk_exhaustion')
     expect(classifyCoverageError('ENOSPC on append')?.reason).toBe('disk_exhaustion')
     expect(classifyCoverageError('Disk quota exceeded')?.reason).toBe('disk_exhaustion')

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -184,7 +184,7 @@ function normalizeKeeperSandboxProfile(raw: unknown): Keeper['sandbox_profile'] 
   }
 }
 
-/** Maps lowercase backend phase strings (`keeper_state_machine.ml:phase_to_string`)
+/** Maps lowercase backend phase strings (`phase_to_string` in lib/keeper_registry/keeper_state_machine_phase.ml)
  *  to PascalCase `KeeperPhase` values. The two unions must stay 1:1 — this is
  *  enforced at compile time by `_BACKEND_PHASE_COVERAGE_CHECK` below.
  *

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -402,7 +402,7 @@ function refineOfflineStatus(keeper: Keeper | null | undefined): KeeperPhaseToke
   // Only `'offline'` is filtered — that is the `'Offline'.toLowerCase()`
   // case we are refining away. The prior version also filtered
   // `'inactive'`, but `KeeperPhase` does not contain that variant
-  // (audit: `keeper_state_machine.ml:21-34` `phase_to_string` emits
+  // (audit: `lib/keeper_registry/keeper_state_machine_phase.ml` `phase_to_string` emits
   // only the 13 PascalCase phases, none of which lowercase to
   // `'inactive'`), so the guard was dead defensive.
   if (keeper.last_heartbeat && isHeartbeatAlive(keeper.last_heartbeat)) {


### PR DESCRIPTION
#27528 이 닫힌 지적은 타당했다 — **죽은 경로를 존재하는 경로로 바꾸는 것만으로 SSOT 주장이 참이 되지 않는다.** 지적된 두 건을 실제로 검증했고 둘 다 맞았다. 이 PR 은 그 좁은 절반만 다시 한다.

## 1. `phase_to_string` 의 소유자는 aggregator 가 아니다

14개 주석이 phase wire format 의 근거로 `keeper_state_machine.ml` 을 든다. 그 모듈은 `phase_to_string` 을 **호출만** 한다.

```
lib/keeper_registry/keeper_state_machine_phase.ml:31   let phase_to_string = function   ← 정의
lib/keeper_registry/keeper_state_machine.ml:504        (phase_to_string new_phase)      ← 호출
```

`type phase` 도 같은 파일에 있다. 13곳이 이제 정의 위치를 가리킨다.

14번째(`attribution-panel.ts`)는 `gate:"keeper_fsm"` 호출부에 대한 것이고 그건 실제로 `keeper_state_machine.ml` 에 있다 — 경로만 정정하고 `544/547` 줄 쌍은 뗐다. **`544` 는 맞지만 `547` 은 실제 `549`** 였다.

## 2. 존재하지 않는 detector

disk-pressure 미러가 `keeper_disk_pressure.ml` 의 `is_disk_exhaustion_text` 를 따른다고 적혀 있다. **그 함수는 lib 전체에 없다.** 실제 detector 는 `lib/core/system_error_class.ml` 의 `disk_needles` 이고 6개 needle 이 대시보드 목록과 일치한다.

`tool-quality-panel.test.ts` 에도 같은 주장이 있었다 — **이전 스윕이 `.test.ts` 를 제외해서 살아남았다.** 이번엔 테스트 포함 전수로 잡았다.

## 이번에는 하지 않은 것

문서 링크 수선은 **전혀 포함하지 않았다.** #27535 가 닫힌 이유(“죽은 문서를 열리는 링크로 수선하면 죽은 컨텍스트가 재활성화된다”)를 받아들여, `RFC-0259` 같은 superseded 문서를 다시 잇는 변경은 제외했다. 이 PR 은 코드 주석의 소유자 표기만 고친다.

줄 번호 인용은 전부 제거했다 — 여기서 확인 가능한 3건 중 2건이 틀렸다.

## 검증

- `npx tsc --noEmit`: EXIT=0
- `npx vitest run`: 636 파일 / 8797 테스트 통과
- `rg 'is_disk_exhaustion_text' dashboard/src lib/` → 0
- `rg 'keeper_state_machine\.ml' dashboard/src` → 1건(정확한 gate 호출부 참조)
