### PR TITLE
chore: 철회된 RFC 를 근거로 든 주석 정리

### DIFF
--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -193,9 +193,8 @@
 .wka-switch::after { content: ""; position: absolute; top: 3px; left: 3px; width: 10px; height: 10px; border-radius: 50%; background: var(--text-dim); transition: transform 120ms ease, background 120ms ease; }
 .wka-switch.on { border-color: var(--volt-dim); background: var(--volt-wash); }
 .wka-switch.on::after { transform: translateX(15px); background: var(--volt-strong); }
-/* RFC-0319: the switch is an interactive <button role="switch"> — reset the
-   default button chrome so it renders identically to the former display span,
-   and expose keyboard focus + a disabled affordance. */
+/* The switch is an interactive <button role="switch"> — reset the default
+   button chrome, and expose keyboard focus + a disabled affordance. */
 button.wka-switch { padding: 0; margin: 0; cursor: pointer; -webkit-appearance: none; appearance: none; }
 button.wka-switch:disabled { cursor: not-allowed; opacity: 0.5; }
 button.wka-switch:focus-visible { outline: 2px solid var(--volt-strong); outline-offset: 2px; }

--- a/lib/dune
+++ b/lib/dune
@@ -204,8 +204,6 @@
   ;; RFC-0058 Phase 1 — Declarative runtime TOML config. Separate sub-library
   ;; to avoid type name collisions (transport, provider, binding, tier, strategy)
   ;; with identically-named types in the main library.
-  ;; RFC-0163 Phase D1 — Runtime_name leaf extraction (lib/runtime_id/).
-  ;; Pure canonical-name validation, stdlib-only.
   uri
   tls
   tls-eio

--- a/lib/workspace/workspace_task_verification.mli
+++ b/lib/workspace/workspace_task_verification.mli
@@ -1,11 +1,6 @@
 (** Verification-evidence helpers for task lifecycle.
 
-    Substring-classifier predicates were retired in Phase E (RFC-0109
-    closeout). The legacy [text_has_verification_artifact_ref] /
-    [evidence_ref_has_verification_artifact_ref] /
-    [notes_have_verification_artifact_ref] /
-    [verification_evidence_error_message] are gone. Completion judgment lives
-    at the LLM Task-review boundary. *)
+    Completion judgment lives at the LLM Task-review boundary. *)
 
 val flatten_lock_result : (('a, 'b) result, 'b) result -> ('a, 'b) result
 


### PR DESCRIPTION
#27535 가 닫힌 이유("죽은 문서를 열리는 링크로 수선하면 죽은 컨텍스트가 재활성화된다")를 축으로 삼아, **철회된 RFC 를 근거로 드는 코드**를 전수했다.

## 판정: 29건 중 3건만 결함

코드가 인용하는 RFC 중 문서가 비활성 상태를 선언한 것이 29개다. **26개는 위양성**이다 — 제목이 `"Withdraw ..."` 로 시작하는 **철회 결정 RFC** 이고, `status: Withdrawn` 은 철회 *대상*을 가리킨다.

```
RFC-0295  "Withdraw derived fleet runtime bands"
RFC-0265  "Withdraw MASC modality capability rerouting"
RFC-0273  "Withdraw policy-bearing Keeper configuration tiers"
RFC-0323  "Withdraw mandatory cross-verifier completion"
```

이들을 코드가 인용하는 건 정당하다(가장 많이 인용된 것이 26곳).

## 실제 결함 3건

**`lib/dune`** — `RFC-0163 Phase D1 — Runtime_name leaf extraction (lib/runtime_id/)`. 그 디렉터리는 없고 `Runtime_name` 모듈도 트리에 없다. 게다가 이 주석은 **자기 라이브러리 항목 없이 `uri` 와 `tls` 사이에 떠 있다** — 추출이 철회되며 대상만 사라지고 설명이 남았다.

**`workspace_task_verification.mli`** — 사라진 술어 4개를 이름으로 나열하며 "are gone" 이라고 적는다. 각 이름은 저장소에서 **정확히 한 번, 바로 그 문장에서만** 등장한다. completion judgment 의 현재 위치를 말하는 줄은 남겼다.

**`approvals-v2.css`** — `RFC-0319` 을 스위치가 실제 `<button role="switch">` 가 된 근거로 든다. 버튼은 실재하므로(4곳) 규칙과 동작 설명은 유지하고 철회된 참조만 제거했다.

## 함께 확인한 것 (결함 아님)

- 폐기 선언 문서 96개 중, **살아있는 문서가 링크하는 경우는 3건**이고 전부 RFC 계보 인용(`Builds on`, `Meta-RFC`)이라 정상이다.

## 검증

- `dune build @check`: EXIT=0
- dashboard `npx tsc --noEmit`: EXIT=0
