### PR TITLE
refactor(workspace): close task-store path consumers

### DIFF
--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -308,9 +308,9 @@ type workspace_state_mount_kind =
   | Workspace_state_dir
 
 let docker_workspace_state_mounts =
-  [ Workspace_state_dir, "tasks"
+  [ Workspace_state_dir, Workspace_utils.tasks_dirname
   ; Workspace_state_file, "tasks.json"
-  ; Workspace_state_file, "backlog.json"
+  ; Workspace_state_file, Workspace_utils.backlog_filename
   ; Workspace_state_file, "board_posts.jsonl"
   ; Workspace_state_file, "board_comments.jsonl"
   ; Workspace_state_file, "board_votes.jsonl"

--- a/lib/server/masc_grpc_service.ml
+++ b/lib/server/masc_grpc_service.ml
@@ -365,7 +365,7 @@ let handle_heartbeat
                 then Array.length (Sys.readdir agents_dir)
                 else 0
               in
-              let tasks_dir = Filename.concat masc_dir "tasks" in
+              let tasks_dir = Filename.concat masc_dir Workspace_utils.tasks_dirname in
               let pending_count =
                 if Sys.file_exists tasks_dir
                 then

--- a/lib/workspace/workspace_bootstrap.ml
+++ b/lib/workspace/workspace_bootstrap.ml
@@ -26,9 +26,9 @@ let ensure_workspace_bootstrap config =
   let root_agents_dir = Filename.concat root_dir "agents" in
   let root_keepers_dir = Filename.concat root_dir Common.keepers_runtime_dirname in
   let root_traces_dir = Filename.concat root_dir "traces" in
-  let root_tasks_dir = Filename.concat root_dir "tasks" in
+  let root_tasks_dir = Filename.concat root_dir Workspace_utils.tasks_dirname in
   let root_messages_dir = Filename.concat root_dir "messages" in
-  let root_backlog_path = Filename.concat root_tasks_dir "backlog.json" in
+  let root_backlog_path = Filename.concat root_tasks_dir Workspace_utils.backlog_filename in
   List.iter mkdir_p
     [
       root_agents_dir;

--- a/lib/workspace/workspace_init.ml
+++ b/lib/workspace/workspace_init.ml
@@ -16,9 +16,9 @@ let init config ~agent_name =
   let root_agents_dir = Filename.concat root_dir "agents" in
   let root_keepers_dir = Filename.concat root_dir Common.keepers_runtime_dirname in
   let root_traces_dir = Filename.concat root_dir "traces" in
-  let root_tasks_dir = Filename.concat root_dir "tasks" in
+  let root_tasks_dir = Filename.concat root_dir Workspace_utils.tasks_dirname in
   let root_messages_dir = Filename.concat root_dir "messages" in
-  let root_backlog_path = Filename.concat root_tasks_dir "backlog.json" in
+  let root_backlog_path = Filename.concat root_tasks_dir Workspace_utils.backlog_filename in
   List.iter
     mkdir_p
     [ root_agents_dir

--- a/test/test_workspace_bootstrap.ml
+++ b/test/test_workspace_bootstrap.ml
@@ -23,8 +23,8 @@ module Types = Masc_domain
        on the same tmpdir leaves the seed files unchanged
        (mtime-stable) and produces no extra directories.
     3. {b ensure_workspace_bootstrap creates expected dirs} — after
-       a single call, [.masc/agents/], [.masc/tasks/],
-       [.masc/messages/] exist plus the root mirrors. *)
+    a single call, the agent, task, and message stores exist plus the root
+    mirrors. *)
 
 module B = Workspace_bootstrap
 (* [Workspace] is the wrapper module re-exported by [masc]; it
@@ -112,7 +112,7 @@ let test_ensure_workspace_bootstrap_creates_scoped_dirs () =
           let p = Filename.concat masc sub in
           assert (Sys.file_exists p);
           assert (Sys.is_directory p))
-        [ "agents"; "tasks"; "messages" ])
+        [ "agents"; Workspace_utils.tasks_dirname; "messages" ])
 
 let test_ensure_workspace_bootstrap_creates_root_dirs () =
   (* The root layout (under [.masc/] sibling) — agents / keepers /
@@ -128,7 +128,12 @@ let test_ensure_workspace_bootstrap_creates_root_dirs () =
           let p = Filename.concat root_dir sub in
           assert (Sys.file_exists p);
           assert (Sys.is_directory p))
-        [ "agents"; "keepers"; "traces"; "tasks"; "messages" ])
+        [ "agents"
+        ; "keepers"
+        ; "traces"
+        ; Workspace_utils.tasks_dirname
+        ; "messages"
+        ])
 
 let test_ensure_workspace_bootstrap_seeds_state_json () =
   (* The scoped state JSON file should be created. *)
@@ -140,6 +145,10 @@ let test_ensure_workspace_bootstrap_seeds_state_json () =
       let backlog_path =
         Workspace_utils.backlog_path config
       in
+      assert (Filename.basename backlog_path = Workspace_utils.backlog_filename);
+      assert (
+        Filename.basename (Filename.dirname backlog_path)
+        = Workspace_utils.tasks_dirname);
       assert (Sys.file_exists backlog_path))
 
 (* ── (3) idempotency ──────────────────────────────────────── *)


### PR DESCRIPTION
## Summary
- route bootstrap and init task-store paths through `Workspace_utils`
- route the gRPC task reader through the same directory owner
- route Keeper sandbox task/backlog mounts through the same owner

## Verification
- `git diff --check`
- `ocamlformat --check` on all four changed OCaml files
- exact-literal audit: no raw `"tasks"` or `"backlog.json"` remains in these four consumers

## Context
Follow-up to #27518: that merge introduced the owner constants but left these production readers/writers on raw path literals.