### PR TITLE
refactor(gate): sidecar 레이아웃 단일화 + 마이그레이션 호환 경로 숙청 (#27541 재작업)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1700,7 +1700,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_assertion_kind_mirror @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_keeper_catchup_digest @test/runtest-test_workspace_root_state_parity"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_assertion_kind_mirror @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_sidecar_runtime_layout @test/runtest-test_keeper_catchup_digest @test/runtest-test_workspace_root_state_parity"
 
       # Four more suites landed on main without a runtest target (persona name
       # via #26962, tool-result demotion via #27013, verification authority

--- a/lib/gate/channel_gate_discord_names.ml
+++ b/lib/gate/channel_gate_discord_names.ml
@@ -15,7 +15,11 @@ type name_map = {
   updated_at : string;
 }
 
-let default_names_path = ".gate/runtime/discord/names.json"
+let default_names_path =
+  Filename.concat
+    (Channel_gate_sidecar_state.runtime_dir ~connector_id:"discord")
+    "names.json"
+;;
 
 let configured_write_path env_name ~default =
   match Sys.getenv_opt env_name |> Env_config_core.trim_opt with

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -13,9 +13,9 @@ let display_name = "Discord"
 let channel = "discord"
 
 
-let default_status_path = ".gate/runtime/discord/status.json"
-let default_binding_store_path = ".gate/runtime/discord/bindings.json"
-let default_binding_audit_path = ".gate/runtime/discord/binding_audit.jsonl"
+let default_status_path = Channel_gate_sidecar_state.default_status_path ~connector_id
+let default_binding_store_path = Channel_gate_sidecar_state.default_binding_store_path ~connector_id
+let default_binding_audit_path = Channel_gate_sidecar_state.default_binding_audit_path ~connector_id
 
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_DISCORD_STATUS_STALE_SEC"

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -10,9 +10,9 @@ let connector_id = "imessage"
 let display_name = "iMessage"
 let channel = "imessage"
 
-let default_status_path = ".gate/runtime/imessage/status.json"
-let default_binding_store_path = ".gate/runtime/imessage/bindings.json"
-let default_binding_audit_path = ".gate/runtime/imessage/binding_audit.jsonl"
+let default_status_path = Channel_gate_sidecar_state.default_status_path ~connector_id
+let default_binding_store_path = Channel_gate_sidecar_state.default_binding_store_path ~connector_id
+let default_binding_audit_path = Channel_gate_sidecar_state.default_binding_audit_path ~connector_id
 
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_IMESSAGE_STATUS_STALE_SEC"

--- a/lib/gate/channel_gate_sidecar_state.ml
+++ b/lib/gate/channel_gate_sidecar_state.ml
@@ -3,13 +3,29 @@
 module U = Yojson.Safe.Util
 module Store = Channel_gate_binding_store
 
+(* Every sidecar connector keeps its files under
+   [.gate/runtime/<connector_id>/]. Derived from the id so relocating the tree,
+   or adding a channel, does not re-spell the layout. *)
+let runtime_dir ~connector_id =
+  Filename.concat (Filename.concat ".gate" "runtime") connector_id
+;;
+
+let default_status_path ~connector_id =
+  Filename.concat (runtime_dir ~connector_id) "status.json"
+;;
+
+let default_binding_store_path ~connector_id =
+  Filename.concat (runtime_dir ~connector_id) "bindings.json"
+;;
+
+let default_binding_audit_path ~connector_id =
+  Filename.concat (runtime_dir ~connector_id) "binding_audit.jsonl"
+;;
+
 module type Config = sig
   val connector_id : string
   val display_name : string
   val channel : string
-  val default_status_path : string
-  val default_binding_store_path : string
-  val default_binding_audit_path : string
   val status_path_env_names : string list
   val binding_store_path_env_names : string list
   val binding_audit_path_env_names : string list
@@ -17,6 +33,10 @@ module type Config = sig
 end
 
 module Make (Config : Config) = struct
+  let default_status_path = default_status_path ~connector_id:Config.connector_id
+  let default_binding_store_path = default_binding_store_path ~connector_id:Config.connector_id
+  let default_binding_audit_path = default_binding_audit_path ~connector_id:Config.connector_id
+
   type binding = Store.binding = {
     channel_id : string;
     keeper_name : string;
@@ -44,17 +64,17 @@ module Make (Config : Config) = struct
 
   let status_path () =
     configured_write_path Config.status_path_env_names
-      ~default:Config.default_status_path
+      ~default:default_status_path
 
   let binding_store_path () =
     configured_write_path Config.binding_store_path_env_names
-      ~default:Config.default_binding_store_path
+      ~default:default_binding_store_path
 
   let binding_store_read_path = binding_store_path
 
   let binding_audit_path () =
     configured_write_path Config.binding_audit_path_env_names
-      ~default:Config.default_binding_audit_path
+      ~default:default_binding_audit_path
 
   let binding_audit_read_path = binding_audit_path
 

--- a/lib/gate/channel_gate_sidecar_state.mli
+++ b/lib/gate/channel_gate_sidecar_state.mli
@@ -4,13 +4,19 @@
     [.gate/runtime/<connector>/]. This functor wires those sidecars into the
     same dashboard bind/unbind and connector status API as Discord/iMessage. *)
 
+(** [.gate/runtime/<connector_id>] and the three files a sidecar connector
+    keeps there. Derived from the id so relocating the tree, or adding a
+    channel, does not re-spell the layout. *)
+val runtime_dir : connector_id:string -> string
+
+val default_status_path : connector_id:string -> string
+val default_binding_store_path : connector_id:string -> string
+val default_binding_audit_path : connector_id:string -> string
+
 module type Config = sig
   val connector_id : string
   val display_name : string
   val channel : string
-  val default_status_path : string
-  val default_binding_store_path : string
-  val default_binding_audit_path : string
   val status_path_env_names : string list
   val binding_store_path_env_names : string list
   val binding_audit_path_env_names : string list

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -20,9 +20,9 @@ let connector_id = "slack"
 let display_name = "Slack"
 let channel = "slack"
 
-let default_status_path = ".gate/runtime/slack/status.json"
-let default_binding_store_path = ".gate/runtime/slack/bindings.json"
-let default_binding_audit_path = ".gate/runtime/slack/binding_audit.jsonl"
+let default_status_path = Channel_gate_sidecar_state.default_status_path ~connector_id
+let default_binding_store_path = Channel_gate_sidecar_state.default_binding_store_path ~connector_id
+let default_binding_audit_path = Channel_gate_sidecar_state.default_binding_audit_path ~connector_id
 
 (* Slack has no Discord-style guilds; the bot token authorizes per-workspace.
    Path resolvers read an env override, else fall back to the default. *)

--- a/lib/gate/channel_gate_telegram_state.ml
+++ b/lib/gate/channel_gate_telegram_state.ml
@@ -4,9 +4,6 @@ include
       let connector_id = "telegram"
       let display_name = "Telegram"
       let channel = "telegram"
-      let default_status_path = ".gate/runtime/telegram/status.json"
-      let default_binding_store_path = ".gate/runtime/telegram/bindings.json"
-      let default_binding_audit_path = ".gate/runtime/telegram/binding_audit.jsonl"
       let status_path_env_names =
         [ "TELEGRAM_STATUS_PATH"; "MASC_TELEGRAM_STATUS_PATH" ]
       let binding_store_path_env_names =

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -242,13 +242,13 @@ let desired_record_of_json = function
 let sidecar_desired_path ~base_path id =
   Filename.concat
     base_path
-    (Printf.sprintf ".gate/runtime/%s/sidecar_lifecycle_desired.json" id)
+    (Filename.concat (Channel_gate_sidecar_state.runtime_dir ~connector_id:id) "sidecar_lifecycle_desired.json")
 ;;
 
 let sidecar_attempt_path ~base_path id =
   Filename.concat
     base_path
-    (Printf.sprintf ".gate/runtime/%s/sidecar_lifecycle_attempt.json" id)
+    (Filename.concat (Channel_gate_sidecar_state.runtime_dir ~connector_id:id) "sidecar_lifecycle_attempt.json")
 ;;
 
 (* Silent [Sys_error _ | Yojson.Json_error _ -> None] previously collapsed
@@ -536,17 +536,16 @@ let sidecar_status_retention_json ~base_path ~id ~status_path =
     [ "scope", `String "runtime_sidecar_status"
     ; "status_path", `String status_path
     ; "default_status_path"
-      , `String (Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/status.json" id))
-    ; "legacy_status_path", `String (Filename.concat base_path (legacy_status_rel id))
+      , `String (Filename.concat base_path (Channel_gate_sidecar_state.default_status_path ~connector_id:id))
     ; "lifecycle_desired_path", `String (sidecar_desired_path ~base_path id)
     ; "lifecycle_attempt_path", `String (sidecar_attempt_path ~base_path id)
     ; "binding_store_path"
-      , `String (Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/bindings.json" id))
+      , `String (Filename.concat base_path (Channel_gate_sidecar_state.default_binding_store_path ~connector_id:id))
     ; "binding_audit_store_path"
       , `String
           (Filename.concat
              base_path
-             (Printf.sprintf ".gate/runtime/%s/binding_audit.jsonl" id))
+             (Channel_gate_sidecar_state.default_binding_audit_path ~connector_id:id))
     ]
 ;;
 

--- a/lib/server/server_routes_http_routes_sidecar.mli
+++ b/lib/server/server_routes_http_routes_sidecar.mli
@@ -72,9 +72,6 @@ val missing_sidecar_dir_message :
 (** {1 Date / status path helpers} *)
 
 val today_yyyymmdd : unit -> string
-(** Local-timezone [yyyymmdd] used in log file names. *)
-
-val legacy_status_rel : string -> string
 (** Legacy relative path of the per-sidecar status JSON. *)
 
 (** {1 Sidecar status config (env / TOML lookup)} *)

--- a/lib/server/server_routes_http_sidecar_paths.ml
+++ b/lib/server/server_routes_http_sidecar_paths.ml
@@ -118,8 +118,6 @@ let today_yyyymmdd () =
   Printf.sprintf "%04d%02d%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
 ;;
 
-let legacy_status_rel id =
-  Filename.concat Common.masc_dirname (Printf.sprintf "connectors/%s/status.json" id)
 ;;
 
 type sidecar_status_config =
@@ -228,7 +226,9 @@ let first_existing_or_first = function
 ;;
 
 let runtime_toml_path ~base_path id =
-  Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/config.toml" id)
+  Filename.concat
+    base_path
+    (Filename.concat (Channel_gate_sidecar_state.runtime_dir ~connector_id:id) "config.toml")
 ;;
 
 let status_file_candidates ?sidecar_root ?project_root ?sidecar_dir ~base_path id =
@@ -256,16 +256,21 @@ let status_file_candidates ?sidecar_root ?project_root ?sidecar_dir ~base_path i
     |> List.concat
   in
   let default_paths =
-    resolve_relative_path ~roots (Printf.sprintf ".gate/runtime/%s/status.json" id)
+    resolve_relative_path
+      ~roots
+      (Channel_gate_sidecar_state.default_status_path ~connector_id:id)
   in
-  let legacy_paths = resolve_relative_path ~roots (legacy_status_rel id) in
-  Json_util.dedupe_keep_order (env_paths @ dotenv_paths @ toml_paths @ default_paths @ legacy_paths)
+  Json_util.dedupe_keep_order (env_paths @ dotenv_paths @ toml_paths @ default_paths)
 ;;
 
 let status_file ?sidecar_root ?project_root ?sidecar_dir ~base_path id =
   status_file_candidates ?sidecar_root ?project_root ?sidecar_dir ~base_path id
   |> first_existing_or_first
-  |> Option.value ~default:(Filename.concat base_path (legacy_status_rel id))
+  |> Option.value
+       ~default:
+         (Filename.concat
+            base_path
+            (Channel_gate_sidecar_state.default_status_path ~connector_id:id))
 ;;
 
 let log_file_candidates ?sidecar_root ?project_root ~base_path id =

--- a/lib/server/server_routes_http_sidecar_paths.mli
+++ b/lib/server/server_routes_http_sidecar_paths.mli
@@ -29,8 +29,6 @@ val missing_sidecar_dir_message :
   ?project_root:string -> base_path:string -> string -> string
 
 val today_yyyymmdd : unit -> string
-val legacy_status_rel : string -> string
-
 type sidecar_status_config =
   { env_names : string list
   ; toml_keys : string list

--- a/lib/server/server_routes_sidecar_config_schema.ml
+++ b/lib/server/server_routes_sidecar_config_schema.ml
@@ -206,7 +206,9 @@ let coerce_value (typ : declared_type) (raw : string) : (toml_value, string) res
 (* ─── Config path / body parsing ──────────────────────────────────────── *)
 
 let config_toml_path ~base_path id =
-  Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/config.toml" id)
+  Filename.concat
+    base_path
+    (Filename.concat (Channel_gate_sidecar_state.runtime_dir ~connector_id:id) "config.toml")
 ;;
 
 (** Parse a JSON body of the form [{"<KEY>": "<VALUE>", ...}] into a

--- a/test/dune
+++ b/test/dune
@@ -1690,6 +1690,8 @@
 
 (include stanzas/test_discord_gateway_state.inc)
 
+(include stanzas/test_sidecar_runtime_layout.inc)
+
 (include stanzas/test_slack_gateway_state.inc)
 
 (include stanzas/test_discord_gateway_client.inc)

--- a/test/stanzas/test_sidecar_runtime_layout.inc
+++ b/test/stanzas/test_sidecar_runtime_layout.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_sidecar_runtime_layout)
+ (modules test_sidecar_runtime_layout)
+ (libraries alcotest masc masc.gate masc.server masc_test_deps))

--- a/test/test_sidecar_runtime_layout.ml
+++ b/test/test_sidecar_runtime_layout.ml
@@ -1,0 +1,71 @@
+(** Sidecar connectors keep their files under [.gate/runtime/<connector_id>/].
+
+    The layout was spelled at nineteen sites, and the status resolver also
+    carried a second one: [.masc/connectors/<id>/status.json] was appended to
+    the candidate list and returned as the default when no file existed, so a
+    fresh install was pointed at a path nothing writes. These pin the single
+    layout and the absence of the second. *)
+
+open Alcotest
+
+module S = Channel_gate_sidecar_state
+module P = Server_routes_http_sidecar_paths
+
+let layout () =
+  check string "runtime dir" ".gate/runtime/slack" (S.runtime_dir ~connector_id:"slack");
+  check
+    string
+    "status"
+    ".gate/runtime/discord/status.json"
+    (S.default_status_path ~connector_id:"discord");
+  check
+    string
+    "bindings"
+    ".gate/runtime/imessage/bindings.json"
+    (S.default_binding_store_path ~connector_id:"imessage");
+  check
+    string
+    "audit"
+    ".gate/runtime/telegram/binding_audit.jsonl"
+    (S.default_binding_audit_path ~connector_id:"telegram")
+;;
+
+(* A caller holding only the directory must compose the same path a connector
+   reads. *)
+let files_sit_under_the_dir () =
+  let id = "slack" in
+  let dir = S.runtime_dir ~connector_id:id in
+  List.iter
+    (fun path -> check string ("under " ^ dir) dir (Filename.dirname path))
+    [ S.default_status_path ~connector_id:id
+    ; S.default_binding_store_path ~connector_id:id
+    ; S.default_binding_audit_path ~connector_id:id
+    ]
+;;
+
+let contains haystack needle =
+  let n = String.length needle and h = String.length haystack in
+  let rec go i = i + n <= h && (String.sub haystack i n = needle || go (i + 1)) in
+  n = 0 || go 0
+;;
+
+(* The candidate list is what the status route serves; a compatibility path in
+   it reaches operators as a real answer. *)
+let no_second_layout () =
+  let candidates = P.status_file_candidates ~base_path:"/tmp/masc-layout-probe" "discord" in
+  List.iter
+    (fun path ->
+       check bool ("no connectors/ layout in " ^ path) false (contains path "connectors/"))
+    candidates
+;;
+
+let () =
+  run
+    "sidecar_runtime_layout"
+    [ ( "layout"
+      , [ test_case "paths keep their spelling" `Quick layout
+        ; test_case "files sit under the reported dir" `Quick files_sit_under_the_dir
+        ; test_case "status candidates carry one layout" `Quick no_second_layout
+        ] )
+    ]
+;;


### PR DESCRIPTION
#27541 이 닫힌 지적은 **결정적인 부분에서 옳았다** — 소유자를 세우는 작업은 "무엇을 옮겼나"가 아니라 **"같은 파일에 무엇이 안 옮겨진 채 남았나"** 로 판정해야 한다. 현재 main 에서 다시 만들었다.

## P0 — 마이그레이션 호환 경로 숙청

`status_file_candidates` 가 두 번째 레이아웃을 갖고 있었다.

```ocaml
let legacy_status_rel id =
  Filename.concat Common.masc_dirname (Printf.sprintf "connectors/%s/status.json" id)
```

이게 후보 목록 끝에 붙고, `status_file` 은 **파일이 하나도 없으면 이 경로를 기본값으로 반환**한다. 신규 설치가 아무도 쓰지 않는 경로를 답으로 받는다.

라우트는 이를 `legacy_status_path` 라는 wire 필드로 공개까지 한다 — `dashboard/src`, `test/`, `scripts/` 어디에도 소비자가 없고 디스크에 `.masc/connectors` 도 없다.

둘 다 제거했고 기본값은 현재 레이아웃이 됐다.

## 반경 완성 (19곳)

`Channel_gate_sidecar_state` 가 `.gate/runtime/<connector_id>/` 와 그 아래 세 파일을 소유한다. 파생 대상:

- 채널 4곳 + `channel_gate_discord_names`(리뷰가 지목한 누락분)
- 서버 라우트/스키마: `config.toml`(두 모듈에 **바이트 단위로 동일**했다), lifecycle 파일 2개, status/bindings/audit

functor 는 `Config` 로 받는 대신 인스턴스에서 파생하므로 **새 채널은 id 만 주면 된다.**

`rg '"\.gate/runtime/|\.gate/runtime/%s' lib/` → **0** (남은 3건은 주석).

## 회귀 방지

`test_sidecar_runtime_layout` 이 세 가지를 고정한다.

1. 경로 문자열
2. 세 파일이 소유자가 보고하는 디렉터리 **안에** 있음
3. `status_file_candidates` 에 `connectors/` 경로가 **없음**

레거시 후보를 되살리면 3번이 실패하는 것을 확인했다. CI 에 배선.

## 검증

- `dune build @check`: EXIT=0
- `test_gate_connector_observability`, `test_channel_gate_content_length_knob`, `test_discord_gateway_state`, `test_slack_gateway_state`: 전부 통과
- `audit-ci-test-targets.sh`: baseline 유지
