### PR TITLE
docs(workspace): 백엔드 키 접두사 문서를 실제 동작에 맞춘다

### DIFF
--- a/lib/workspace/workspace_utils_paths_backend.ml
+++ b/lib/workspace/workspace_utils_paths_backend.ml
@@ -137,16 +137,20 @@ let backend_cleanup_pubsub config ~days ~max_messages =
 (* ============================================ *)
 
 (** Generate a short hash prefix for project isolation.
-    Uses first 8 chars of MD5 hash of base_path.
-    This ensures different test directories get different keys. *)
+    Returns the first 8 hex chars of the MD5 digest of [base_path], so two
+    configs rooted at different paths get different key namespaces. The
+    truncation keeps 32 bits, which makes distinct prefixes overwhelmingly
+    likely rather than guaranteed; nothing here detects a collision. *)
 let project_prefix config =
   let hash = Digest.string config.base_path |> Digest.to_hex in
   String.sub hash 0 8
 
 (** Convert absolute path to backend key.
-    For distributed backends: includes project hash prefix for isolation.
+    [Memory] shares one process-wide store across configs, so its keys carry
+    the {!project_prefix} to keep separate roots apart.
     Example: /tmp/test-abc/.masc/state.json -> "a1b2c3d4:state.json"
-    For filesystem: returns relative path without prefix. *)
+    [FileSystem] is already scoped by its own root, so it returns the relative
+    path without a prefix. *)
 let key_of_path_from_root config ~root path =
   let prefix = root ^ "/" in
   if String.starts_with path ~prefix then

--- a/lib/workspace/workspace_utils_paths_backend.mli
+++ b/lib/workspace/workspace_utils_paths_backend.mli
@@ -43,8 +43,9 @@ val backlog_filename : string
 
 val root_state_path : config -> string
 
-(** Project-scoped key prefix for backend keys (e.g.
-    ["proj:default"]). Used by broadcast/pubsub channel naming. *)
+(** Project-scoped key prefix for backend keys: 8 hex chars of the MD5 digest
+    of the config's [base_path] (e.g. ["a1b2c3d4"]). Used by broadcast/pubsub
+    channel naming and by [Memory]-backend keys. *)
 val project_prefix : config -> string
 
 (** {1 Backend dispatch} *)


### PR DESCRIPTION
## 문제

`project_prefix` 주변 세 진술이 코드와 어긋난다.

### 1. 존재하지 않는 백엔드 계층을 설명한다

`key_of_path_from_root` 주석이 접두사를 **"For distributed backends"** 로 귀속시킨다. 분산 백엔드는 없다.

```ocaml
match config.backend with
| Memory _ -> Some (project_prefix config ^ ":" ^ key)
| FileSystem _ -> Some key
```

접두사가 붙는 쪽은 `Memory` — in-process 이므로 distributed 의 반대다. 실제 이유는 `Memory` 가 하나의 프로세스 저장소를 config 들이 공유하는 반면 `FileSystem` 은 자기 root 로 이미 격리돼 있다는 것이다.

이 문서를 읽는 사람(사람이든 에이전트든)은 masc 에 분산 백엔드가 있다고 믿게 된다.

### 2. 보증할 수 없는 것을 보증한다

```
This ensures different test directories get different keys.
```

`String.sub (Digest.to_hex (Digest.string base_path)) 0 8` 는 **32비트**다. 서로 다른 접두사가 나올 확률이 매우 높을 뿐 확실하지 않고, 충돌을 검사하는 호출자도 없다.

### 3. `.mli` 예시가 불가능한 값이다

```
(** Project-scoped key prefix for backend keys (e.g. ["proj:default"]). *)
```

이 함수는 MD5 다이제스트의 hex 8자를 반환한다. `"proj:default"` 는 나올 수 없다. 또 broadcast/pubsub 호출자만 적고 같은 모듈의 `Memory` 키 호출자는 빠져 있다.

## 변경

세 진술을 실제 동작 서술로 교체했다. 보증 대신 32비트 절단이라는 사실과 충돌 미검출을 적었고, `.mli` 예시를 `["a1b2c3d4"]` 로 고치고 두 호출자를 모두 적었다.

**주석과 인터페이스 문서만 바뀐다. 동작 변화 없음.**

## 검증

`dune build --root . @lib/workspace/check` → RC=0.

## 범위에 대한 정직한 진술

이 PR 은 **동작 결함을 고치지 않는다.** 실제 충돌 확률은 무시할 수준이다 — 프로세스 내 서로 다른 `base_path` 수는 작고, n=100 이면 충돌 확률은 대략 1e-6 이다. 고치는 것은 "분산 백엔드가 있다" 는 죽은 개념과 근거 없는 보증 문구, 그리고 불가능한 예시다.
