### PR TITLE
chore: 철회 RFC 가 남긴 죽은 개념 숙청 (#27559 재작업)

### DIFF
--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -189,16 +189,6 @@
 .wka-auto-top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .wka-auto-lbl { display: flex; flex-direction: column; gap: 2px; color: var(--text-dim); font-size: var(--fs-11); }
 .wka-auto-lbl b { color: var(--text-bright); font-size: var(--fs-13); }
-.wka-switch { position: relative; width: 34px; height: 18px; flex: none; border-radius: var(--radius-pill); border: 1px solid var(--border-soft); background: var(--bg-sunken); }
-.wka-switch::after { content: ""; position: absolute; top: 3px; left: 3px; width: 10px; height: 10px; border-radius: 50%; background: var(--text-dim); transition: transform 120ms ease, background 120ms ease; }
-.wka-switch.on { border-color: var(--volt-dim); background: var(--volt-wash); }
-.wka-switch.on::after { transform: translateX(15px); background: var(--volt-strong); }
-/* RFC-0319: the switch is an interactive <button role="switch"> — reset the
-   default button chrome so it renders identically to the former display span,
-   and expose keyboard focus + a disabled affordance. */
-button.wka-switch { padding: 0; margin: 0; cursor: pointer; -webkit-appearance: none; appearance: none; }
-button.wka-switch:disabled { cursor: not-allowed; opacity: 0.5; }
-button.wka-switch:focus-visible { outline: 2px solid var(--volt-strong); outline-offset: 2px; }
 .wka-auto-stat { color: var(--text-primary); font-size: var(--fs-12); }
 .wka-auto-note { color: var(--text-dim); font-size: var(--fs-11); line-height: 1.45; }
 .wka-auto-note b { color: var(--text-bright); }

--- a/lib/dune
+++ b/lib/dune
@@ -204,8 +204,6 @@
   ;; RFC-0058 Phase 1 — Declarative runtime TOML config. Separate sub-library
   ;; to avoid type name collisions (transport, provider, binding, tier, strategy)
   ;; with identically-named types in the main library.
-  ;; RFC-0163 Phase D1 — Runtime_name leaf extraction (lib/runtime_id/).
-  ;; Pure canonical-name validation, stdlib-only.
   uri
   tls
   tls-eio

--- a/lib/workspace/workspace_task_verification.mli
+++ b/lib/workspace/workspace_task_verification.mli
@@ -1,11 +1,6 @@
 (** Verification-evidence helpers for task lifecycle.
 
-    Substring-classifier predicates were retired in Phase E (RFC-0109
-    closeout). The legacy [text_has_verification_artifact_ref] /
-    [evidence_ref_has_verification_artifact_ref] /
-    [notes_have_verification_artifact_ref] /
-    [verification_evidence_error_message] are gone. Completion judgment lives
-    at the LLM Task-review boundary. *)
+    Completion judgment lives at the LLM Task-review boundary. *)
 
 val flatten_lock_result : (('a, 'b) result, 'b) result -> ('a, 'b) result
 


### PR DESCRIPTION
#27559 는 닫힌 판단이 옳았다. **내 근거가 틀렸다.**

`.wka-switch` 가 4곳에 나온다는 것을 "버튼이 실재한다"로 읽었는데, 세어보니 **7건 전부 `approvals-v2.css` 의 규칙 정의**였고 `.ts` 소비자는 **0**이다. 현재 UI 는 `ap-viewseg` 를 쓴다.

```
$ rg -c 'wka-switch' dashboard/src --glob '*.ts'
0
```

규칙 자체가 죽은 코드였으므로 `RFC-0319` 주석만이 아니라 **규칙 10줄을 함께 제거**한다.

## 같은 계열은 살아있다 — 구분해서 남겼다

| 클래스 | TS 소비 |
|---|---|
| `wka-h` | 29 |
| `wka-auto` | 6 |
| `wka-card` | 3 |
| `wka-switch` | **0** |

## 함께 확정한 OCaml 2건

**`lib/dune`** — `RFC-0163 Phase D1 — Runtime_name leaf extraction (lib/runtime_id/)`. 디렉터리도 모듈도 없고, 주석이 **자기 라이브러리 항목 없이 `uri` 와 `tls` 사이에 떠 있다.**

**`workspace_task_verification.mli`** — 사라진 술어 4개를 이름으로 나열하며 "are gone". 각 이름은 저장소에서 **정확히 한 번, 그 문장에서만** 등장한다.

## 검증

- `dune build @check`: EXIT=0
- dashboard `npx tsc --noEmit`: EXIT=0
- `rg 'wka-switch' dashboard/src` → 0
