### PR TITLE
fix(surface): project repeat guidance from one owner

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1631,10 +1631,7 @@ let internal_descriptors : t list =
       ~keeper_model_projection:Internal_name
       ~id:"keeper.surface.post"
       ~name:"keeper_surface_post"
-      ~description:
-        "Post a message to one conversation endpoint: 'dashboard' (appears \
-         in the operator's chat transcript) or 'discord' (sends to the bound \
-         channel). Posting to an unbound surface is an error."
+      ~description:Tool_shard_types.keeper_surface_post_description
       ~input_schema:surface_post_schema
       ~policy:(write_in_process_policy ())
       ~handler:Tool_surface_post

--- a/lib/tool_surface/tool_shard_types.mli
+++ b/lib/tool_surface/tool_shard_types.mli
@@ -44,9 +44,11 @@ val voice_tools : Masc_domain.tool_schema list
 
 val library_tools : Masc_domain.tool_schema list
 
+val keeper_surface_post_description : string
+(** Canonical description projected into Keeper model and help surfaces. *)
+
 val surface_tools : Masc_domain.tool_schema list
-(** keeper_surface_read lane reading (RFC-0223 P3). *)
-(** Library tool schemas. *)
+(** Surface read/post schemas projected into help and dispatch registries. *)
 
 val taskboard_tools : Masc_domain.tool_schema list
 (** Taskboard tool schemas. *)

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -1,6 +1,15 @@
 (** Tool_shard_types_schemas_surface — keeper_surface_* tool schemas
     (RFC-0223 P3). *)
 
+let keeper_surface_post_description =
+  "Post a message to one conversation endpoint: 'dashboard' (appears \
+   in the operator's chat transcript) or 'discord' (sends to the bound \
+   channel). Posting to an unbound surface is an error. Both endpoints \
+   are read by a person, so an unchanged status reposted every cycle \
+   crowds their view and says nothing the previous one did not; when \
+   there is nothing new, the turn ends without a post."
+;;
+
 let surface_tools : Masc_domain.tool_schema list =
   [ { name = "keeper_surface_read"
     ; description =
@@ -50,10 +59,7 @@ let surface_tools : Masc_domain.tool_schema list =
           ]
     }
   ; { name = "keeper_surface_post"
-    ; description =
-        "Post a message to one conversation endpoint: 'dashboard' (appears \
-         in the operator's chat transcript) or 'discord' (sends to the bound \
-         channel). Posting to an unbound surface is an error."
+    ; description = keeper_surface_post_description
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -3473,6 +3473,47 @@ let terminal_surface_post tools =
   | None -> fail "keeper_surface_post missing from Keeper tool bundle"
 ;;
 
+let test_surface_post_bundle_names_reader_and_repeat_cost () =
+  with_exec_fixture
+    "surface_post_model_description"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let bundle =
+         Masc.Keeper_tools_oas_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       in
+       let description =
+         (terminal_surface_post bundle.tools).Agent_sdk.Tool.schema.description
+       in
+       let help_description =
+         match
+           List.find_opt
+             (fun (schema : Masc_domain.tool_schema) ->
+                String.equal schema.name "keeper_surface_post")
+             Tool_shard_types.surface_tools
+         with
+         | Some schema -> schema.description
+         | None -> fail "keeper_surface_post missing from help schema projection"
+       in
+       check string
+         "help and OAS projections use the same description"
+         help_description
+         description;
+       List.iter
+         (fun phrase ->
+            check bool
+              (Printf.sprintf "projected description contains %S" phrase)
+              true
+              (contains_substring description phrase))
+         [ "read by a person"
+         ; "unchanged status reposted every cycle"
+         ; "the turn ends without a post"
+         ])
+;;
+
 let test_invalid_surface_post_input_stays_correction_capable () =
   with_exec_fixture
     ~bind_eio_context:true
@@ -4115,5 +4156,7 @@ let () =
         test_catalog_metadata_does_not_infer_oas_descriptors;
       test_case "model-visible aliases do not infer OAS descriptors" `Quick
         test_model_visible_tools_do_not_infer_oas_descriptors;
+      test_case "surface post description reaches the OAS bundle" `Quick
+        test_surface_post_bundle_names_reader_and_repeat_cost;
     ]);
   ]


### PR DESCRIPTION
## Summary
- own `keeper_surface_post` description once in the surface schema leaf
- project the same description into both help/introspection and the actual Keeper OAS bundle
- tell the Keeper that unchanged human-facing status reposts add no new fact

## Verification
- typed projection test compares the help schema with the OAS-bundled `Agent_sdk.Tool` description
- focused phrases are asserted on the actual OAS tool
- `ocamlformat --check` and `git diff --check`

Local focused Dune build was refused by `scripts/dune-local.sh` because two long-running bare Dune processes are active. CI is the build authority.