### PR TITLE
fix(fs_compat): HOME 가드를 구분자 경계로 비교한다

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -105,11 +105,15 @@ let test_exec_home_guard ~op path =
           then String.sub trimmed 0 (len - 1)
           else trimmed
         in
-        let home_len = String.length home_norm in
+        (* Match on the separator boundary, not the bare prefix.  A bare
+           [starts_with ~prefix:home_norm] also fires for a sibling whose name
+           merely extends HOME's: with HOME=/home/runner it blocks
+           /home/runner-cache, which is not under HOME.  The first disjunct
+           keeps HOME itself blocked, which the bare prefix also covered. *)
         if
-          home_len > 0
-          && String.length path >= home_len
-          && String.starts_with path ~prefix:home_norm
+          String.length home_norm > 0
+          && (String.equal path home_norm
+              || String.starts_with path ~prefix:(home_norm ^ "/"))
         then
           raise
             (Test_isolation_breach

--- a/test/test_fs_compat_home_guard.ml
+++ b/test/test_fs_compat_home_guard.ml
@@ -69,6 +69,43 @@ let test_tmp_write_allowed () =
   (try Sys.remove path with Sys_error _ -> ());
   (try Unix.rmdir dir with Unix.Unix_error _ -> ())
 
+(* A sibling whose name merely extends HOME's is not under HOME.  The guard
+   matched on the bare prefix, so with HOME=/home/runner it also blocked
+   /home/runner-cache and failed the test with a message telling the author to
+   fix a test setup that was already correct.  HOME is repointed at a temp
+   directory here so the probe stays inside the temp tree. *)
+let test_home_sibling_allowed () =
+  disable_escape_hatch ();
+  let real_home = home () in
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-9921-sibling-%d" (Unix.getpid ()))
+  in
+  let fake_home = Filename.concat base "home" in
+  let sibling = fake_home ^ "-cache" in
+  let path = Filename.concat sibling "probe.txt" in
+  FC.mkdir_p fake_home;
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.putenv "HOME" real_home;
+      (try Sys.remove path with Sys_error _ -> ());
+      (try Unix.rmdir sibling with Unix.Unix_error _ -> ());
+      (try Unix.rmdir fake_home with Unix.Unix_error _ -> ());
+      try Unix.rmdir base with Unix.Unix_error _ -> ())
+    (fun () ->
+      Unix.putenv "HOME" fake_home;
+      try
+        FC.mkdir_p sibling;
+        FC.append_file path "ok\n";
+        Alcotest.(check bool) "sibling write succeeded" true (Sys.file_exists path)
+      with FC.Test_isolation_breach msg ->
+        Alcotest.failf
+          "guard fired for %S, which is a sibling of HOME=%S and not under it: %s"
+          path
+          fake_home
+          msg)
+
 let test_escape_hatch_allows_home () =
   Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" "1";
   let path = guard_path "_9921_guard_probe_bypass.jsonl" in
@@ -101,6 +138,8 @@ let () =
         test_mkdir_under_home_raises;
       Alcotest.test_case "tmp write allowed" `Quick
         test_tmp_write_allowed;
+      Alcotest.test_case "HOME sibling allowed" `Quick
+        test_home_sibling_allowed;
       Alcotest.test_case "escape hatch allows HOME" `Quick
         test_escape_hatch_allows_home;
     ];


### PR DESCRIPTION
## 문제

`test_exec_home_guard` (`lib/fs_compat/fs_compat.ml:78-`) 가 경로를 **문자열 접두사**로만 비교한다.

```ocaml
String.starts_with path ~prefix:home_norm
```

이름이 HOME 을 연장하는 형제 디렉터리는 이 접두사를 공유하지만 HOME 하위가 아니다. `HOME=/home/runner` 일 때 `/home/runner-cache` 도 걸린다. 이 가드는 `Test_isolation_breach` 를 던지면서 **"fix the test setup"** 이라고 안내하는데, 정작 그 setup 은 올바르다.

## 방향은 fail-closed 였다

과다 차단이지 과소 차단이 아니다. **빠져나간 쓰기는 없다.** 비용은 오해를 부르는 메시지와 함께 나는 헛된 실패다.

## 변경

구분자 경계로 비교하고, HOME 자기 자신은 기존처럼 막히도록 등호 분기를 명시했다.

```ocaml
String.equal path home_norm
|| String.starts_with path ~prefix:(home_norm ^ "/")
```

저장소가 이미 쓰는 형태다.

- `server_routes_http_routes_workspace.ml:292-299` (`path_within`) — 동일한 등호 + 경계 조합
- `server_dashboard_http_keeper_api.ml:270-278` — `Filename.dir_sep` 를 붙인 뒤 비교
- `config/playground_paths.ml:93,151` — `base_with_slash`

## 검증

기존 스위트(`test/test_fs_compat_home_guard.ml`, CI `ci.yml:960` 에 배선됨)에는 이 경우가 없었다. HOME **하위** 차단 3건과 임시디렉터리 허용 1건뿐이고, 넷 다 HOME 의 접두사를 공유하지 않는다.

형제 경로 케이스를 추가하고 **수정 전 트리에서 실패하는지 먼저 확인**했다.

수정 전 (`git checkout origin/main -- lib/fs_compat/fs_compat.ml`):

```
> [FAIL]        guard          4   HOME sibling allowed.
ASSERT guard fired for ".../masc-9921-sibling-84369/home-cache/probe.txt",
which is a sibling of HOME=".../masc-9921-sibling-84369/home" and not under it
RC=1
```

나머지 5건은 그대로 통과했다 — 이 수정이 기존에 덮인 동작을 바꾸지 않는다는 뜻이다.

수정 후:

```
[OK] append under HOME raises / save under HOME raises / mkdir under HOME raises
[OK] tmp write allowed / HOME sibling allowed / escape hatch allows HOME
Test Successful in 0.001s. 6 tests run.   RC=0
```

테스트는 HOME 을 임시 디렉터리로 옮겨 프로브가 temp 트리 안에 머물게 하고, `Fun.protect` 로 원래 HOME 을 복원한다.
