### PR TITLE
fix(dashboard): 커넥터 경로를 서버가 보낸 값에서 읽는다 (4개월간 미표시)

### DIFF
--- a/dashboard/src/components/connector-paths-strip.test.ts
+++ b/dashboard/src/components/connector-paths-strip.test.ts
@@ -29,30 +29,31 @@ describe('deriveMascPaths', () => {
     expect(paths.sidecarsDir).toBe('sidecars/')
   })
 
-  it('derives connectors + logs dir from standard names_path pattern', () => {
+  // What the server sends: Channel_gate_discord_names writes
+  // .gate/runtime/<id>/names.json. The old regex demanded
+  // <root>/connectors/<id>/names.json and so never matched.
+  it('takes the directory of the file the server reports', () => {
     const c = mkConnector({
-      names_path: '/Users/alice/.masc/connectors/discord/names.json',
+      names_path: '/Users/alice/.gate/runtime/discord/names.json',
     } as never)
     const paths = deriveMascPaths([c])
-    expect(paths.connectorsDir).toBe('/Users/alice/.masc/connectors/')
-    expect(paths.logsDir).toBe('/Users/alice/.masc/logs/')
+    expect(paths.connectorsDir).toBe('/Users/alice/.gate/runtime/discord/')
   })
 
-  it('falls back when names_path is non-standard', () => {
-    const c = mkConnector({ names_path: '/somewhere/else/names.json' } as never)
+  it('falls back when names_path has no directory', () => {
+    const c = mkConnector({ names_path: 'names.json' } as never)
     const paths = deriveMascPaths([c])
     expect(paths.connectorsDir).toBeNull()
-    expect(paths.logsDir).toBeNull()
   })
 
   it('ignores empty / whitespace names_path and falls through to next connector', () => {
     const c1 = mkConnector({ connector_id: 'discord', names_path: '' } as never)
     const c2 = mkConnector({
       connector_id: 'slack',
-      names_path: '/srv/project/.masc/connectors/slack/names.json',
+      names_path: '/srv/project/.gate/runtime/slack/names.json',
     } as never)
     const paths = deriveMascPaths([c1, c2])
-    expect(paths.connectorsDir).toBe('/srv/project/.masc/connectors/')
+    expect(paths.connectorsDir).toBe('/srv/project/.gate/runtime/slack/')
   })
 })
 
@@ -93,7 +94,7 @@ describe('ConnectorPathsStrip', () => {
 
   it('surfaces Connectors + Logs rows once a connector reports a names_path', async () => {
     const c = mkConnector({
-      names_path: '/Users/alice/.masc/connectors/discord/names.json',
+      names_path: '/Users/alice/.gate/runtime/discord/names.json',
     } as never)
     render(html`<${ConnectorPathsStrip} connectors=${[c]} />`, container)
     const toggle = container.querySelector<HTMLButtonElement>('[data-panel="connector-paths-strip"] button')!
@@ -104,7 +105,7 @@ describe('ConnectorPathsStrip', () => {
     }
     const rows = container.querySelectorAll('[data-paths-row]')
     const labels = Array.from(rows).map(r => r.getAttribute('data-paths-row'))
-    expect(labels).toEqual(['커넥터', '로그', '키퍼', '사이드카'])
+    expect(labels).toEqual(['커넥터', '키퍼', '사이드카'])
   })
 
   it('header shows runtime hint when no connector has names_path', () => {

--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -53,12 +53,15 @@ export function deriveMascPaths(connectors: GateConnectorInfo[]): MascPaths {
     c => typeof c.names_path === 'string' && c.names_path.length > 0,
   )
   if (!withPath) return fallback
-  const match = withPath.names_path.match(/^(.*)\/connectors\/[^/]+\/names\.json$/)
-  if (!match) return fallback
-  const mascRoot = match[1] ?? ''
+  // The server sends the file it actually writes; take its directory rather
+  // than re-deriving a layout from the string. A regex for
+  // `<root>/connectors/<id>/names.json` never matched after the runtime moved
+  // to .gate/runtime/ in #7467, so both rows below stayed hidden.
+  const dir = withPath.names_path.replace(/\/[^/]*$/, '')
+  if (dir === '' || dir === withPath.names_path) return fallback
   return {
-    connectorsDir: `${mascRoot}/connectors/`,
-    logsDir: `${mascRoot}/logs/`,
+    connectorsDir: `${dir}/`,
+    logsDir: null,
     keepersDir: 'config/keepers/',
     sidecarsDir: 'sidecars/',
   }


### PR DESCRIPTION
#27562 리뷰가 지목한 P0 를 검증했다. **지적이 맞고, 내 PR 과 무관한 기존 결함이다.**

`ConnectorPathsStrip` 은 커넥터 경로를 정규식으로 역추론한다.

```ts
const match = withPath.names_path.match(/^(.*)\/connectors\/[^/]+\/names\.json$/)
if (!match) return fallback
```

**서버는 그 형태를 보낸 적이 없다.** `#7467`(2026-04-16)이 Discord 런타임을 `.gate/runtime/` 으로 옮겼고, 이 strip 은 **그 다음 날** `#8013` 에서 옛 레이아웃 기준으로 들어왔다.

```
서버:      .gate/runtime/discord/names.json
정규식:    <root>/connectors/<id>/names.json
```

## 실패가 조용하다

매치 실패 시 fallback 을 반환하고, 화면은 이렇게 렌더된다.

```
경로  sidecars/  (런타임 미관찰 · sidecar 경로만 표시)
```

커넥터·로그 행은 아예 그려지지 않는다. **약 4개월간 돌고 있는 시스템에서 이 문구만 나왔다.**

## 수정

문자열에서 레이아웃을 다시 유도하는 대신, **서버가 보고한 파일의 디렉터리를 그대로 쓴다.** `logsDir` 은 정규식과 함께 제거했다 — 응답에 로그 디렉터리를 알려주는 필드가 없고, 이 컴포넌트 밖에서 그 필드를 읽는 코드도 없다.

## 테스트가 결함을 고정하고 있었다

스위트가 옛 레이아웃을 4곳에서 단언했고, 그중 하나는 제목이 **"derives connectors + logs dir from standard names_path pattern"** 이다 — 서버가 보낼 수 없는 입력을 "standard" 라고 부른다.

서버가 실제로 보내는 형태로 바꿨고, **옛 정규식을 되살리면 실패하는 것을 확인**했다.

## 검증

- `npx tsc --noEmit`: EXIT=0
- `npx vitest run`: 636 파일 / 8797 테스트 통과
