### PR TITLE
chore: 철회된 RFC 3건이 남긴 개념 전면 숙청 (#27565 재작업)

### DIFF
--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -189,16 +189,6 @@
 .wka-auto-top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .wka-auto-lbl { display: flex; flex-direction: column; gap: 2px; color: var(--text-dim); font-size: var(--fs-11); }
 .wka-auto-lbl b { color: var(--text-bright); font-size: var(--fs-13); }
-.wka-switch { position: relative; width: 34px; height: 18px; flex: none; border-radius: var(--radius-pill); border: 1px solid var(--border-soft); background: var(--bg-sunken); }
-.wka-switch::after { content: ""; position: absolute; top: 3px; left: 3px; width: 10px; height: 10px; border-radius: 50%; background: var(--text-dim); transition: transform 120ms ease, background 120ms ease; }
-.wka-switch.on { border-color: var(--volt-dim); background: var(--volt-wash); }
-.wka-switch.on::after { transform: translateX(15px); background: var(--volt-strong); }
-/* RFC-0319: the switch is an interactive <button role="switch"> — reset the
-   default button chrome so it renders identically to the former display span,
-   and expose keyboard focus + a disabled affordance. */
-button.wka-switch { padding: 0; margin: 0; cursor: pointer; -webkit-appearance: none; appearance: none; }
-button.wka-switch:disabled { cursor: not-allowed; opacity: 0.5; }
-button.wka-switch:focus-visible { outline: 2px solid var(--volt-strong); outline-offset: 2px; }
 .wka-auto-stat { color: var(--text-primary); font-size: var(--fs-12); }
 .wka-auto-note { color: var(--text-dim); font-size: var(--fs-11); line-height: 1.45; }
 .wka-auto-note b { color: var(--text-bright); }

--- a/lib/dune
+++ b/lib/dune
@@ -204,8 +204,6 @@
   ;; RFC-0058 Phase 1 — Declarative runtime TOML config. Separate sub-library
   ;; to avoid type name collisions (transport, provider, binding, tier, strategy)
   ;; with identically-named types in the main library.
-  ;; RFC-0163 Phase D1 — Runtime_name leaf extraction (lib/runtime_id/).
-  ;; Pure canonical-name validation, stdlib-only.
   uri
   tls
   tls-eio

--- a/lib/workspace/workspace_task_verification.ml
+++ b/lib/workspace/workspace_task_verification.ml
@@ -1,8 +1,4 @@
-(** Verification-evidence helpers for task lifecycle,
-    extracted from task_state.ml.
-
-    Legacy substring classifiers that rejected empty or analysis-only
-    submissions at the transition layer are retired.
+(** Verification-evidence helpers for task lifecycle.
 
     Evidence refs are collected from the producer's typed handoff refs.
     Narrative summaries are represented explicitly as [note:] evidence so the

--- a/lib/workspace/workspace_task_verification.mli
+++ b/lib/workspace/workspace_task_verification.mli
@@ -1,11 +1,6 @@
 (** Verification-evidence helpers for task lifecycle.
 
-    Substring-classifier predicates were retired in Phase E (RFC-0109
-    closeout). The legacy [text_has_verification_artifact_ref] /
-    [evidence_ref_has_verification_artifact_ref] /
-    [notes_have_verification_artifact_ref] /
-    [verification_evidence_error_message] are gone. Completion judgment lives
-    at the LLM Task-review boundary. *)
+    Completion judgment lives at the LLM Task-review boundary. *)
 
 val flatten_lock_result : (('a, 'b) result, 'b) result -> ('a, 'b) result
 

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -135,8 +135,6 @@
   (re_export masc.tool_schemas_specs)
   (re_export masc.tool_catalog_surfaces)
   (re_export masc.config_dir_resolver)
-  ;; RFC-0163 Phase D1 — Runtime_name leaf extracted to lib/runtime_id/.
-  ;; Re-export so test code using bare `Runtime_name.X` resolves.
   ;; RFC-0086 PR-2H — Tool_args + Tool_result shared types extracted to
   ;; lib/tool_types/. Re-export so test code using bare
   ;; `Tool_args.X` / `Tool_result.X` resolves.

--- a/test/test_workspace_task_verification_phase_e.ml
+++ b/test/test_workspace_task_verification_phase_e.ml
@@ -1,6 +1,4 @@
-(* RFC-0109 Phase E regression guard.
-
-   The transition layer does not decide whether evidence is sufficient. It
+(* The transition layer does not decide whether evidence is sufficient. It
    preserves explicitly typed producer refs and represents completion prose as
    [note:] evidence; contract requirements are projected separately. *)
 


### PR DESCRIPTION
#27565 가 "hard cut 이 아니다"로 닫힌 지적은 맞았다. 그 목록대로 **코드 전 범위**를 다시 잡았다.

## RFC-0163 — 일어나지 않은 추출

`Runtime_name` 을 `lib/runtime_id/` 로 뽑았다고 설명하는 주석이 둘 있었다. **디렉터리도 모듈도 없다.**

- `lib/dune:207` — 자기 라이브러리 항목 없이 `uri` 와 `tls` 사이에 떠 있었다
- `test/deps/dune:138` — *"Re-export so test code using bare `Runtime_name.X` resolves"* 라고 적으면서 **대응하는 `(re_export ...)` 줄이 없다**

저장소에서 `Runtime_name` 의 유일한 등장이 이 문장들이었다.

## RFC-0109 — 부고가 두 벌

`.mli` 는 은퇴한 술어 4개를 이름으로 나열했다. 각 이름은 저장소에서 **정확히 한 번, 그 문장에서만** 등장한다. `.ml` 은 같은 내용을 다르게 적었다("legacy substring classifiers ... are retired").

`test_workspace_task_verification_phase_e` 는 **현재 동작을 지키는 유효한 가드**라 유지하고 헤더의 RFC 번호만 뗐다.

## RFC-0319 — `.wka-switch`

7건 전부 CSS 규칙 정의이고 `.ts` 소비자는 0이다(현재 UI 는 `ap-viewseg`). 규칙을 참조와 함께 제거했다.

같은 계열은 살아있어 구분해 남겼다: `wka-h`(29), `wka-auto`(6), `wka-card`(3).

## 건드리지 않은 것

RFC 문서 자체와 `RFC-0112`/`RFC-0115`/`RFC-0122`/`RFC-0145` 의 원장(ledger) 기록은 그대로 뒀다. 그 줄들은 **어떤 번호가 할당됐는지를 기록**하는 것이고, README 의 monotonic-ledger 정책이 요구하는 바다.

## 검증

- `rg` over `lib/ bin/ test/ dashboard/src scripts/`: `RFC-0109`, `RFC-0163`, `RFC-0319`, `Runtime_name`, `wka-switch` **전부 0**
- `dune build @check`: EXIT=0
- Phase E 가드 테스트: 통과
- dashboard: `tsc --noEmit` EXIT=0, 636 파일 / 8797 테스트 통과
