### PR TITLE
fix(link-preview): IPv4를 품은 v6 주소를 IPv4 규칙으로 판정한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -924,6 +924,16 @@ jobs:
             @test/runtest-test_tool_task_coverage \
             @test/runtest-test_tool_workspace_coverage
 
+      - name: Run link preview address filter suite
+        # The filter decides whether a dashboard-supplied URL may leave the
+        # process, so a false negative is a fetch to an internal address.
+        # @check compiles these cases but does not run them, and the suite had
+        # no address cases at all until ::ffff:169.254.169.254 was found to
+        # pass the V6 branch.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_dashboard_link_preview
+
       - name: Run completion-authority lookup surface suite
         # The judge's lookup tools reach the filesystem and Git inside a
         # producer's root. @check compiles the containment cases but does not

--- a/lib/server/server_dashboard_http_link_preview.ml
+++ b/lib/server/server_dashboard_http_link_preview.ml
@@ -74,7 +74,27 @@ let is_http_scheme = function
 let is_loopback_or_unspecified_host host =
   Server_auth.is_loopback_host host || Server_auth.is_unspecified_host host
 
-let ipaddr_is_private_or_reserved = function
+(* An IPv4 address carried inside a V6 one is invisible to the V6 range checks
+   below, because those match on the rendered text and every carrier form
+   renders starting with "::".  [::ffff:169.254.169.254] renders as
+   "::ffff:169.254.169.254", matches no prefix in that list, and so reached the
+   fetcher even though the V4 rules reject 169.254.0.0/16.  Hand both the
+   mapped form and the deprecated compatible form (RFC 4291 §2.5.5.1) back to
+   the V4 rules rather than restating those ranges here. *)
+let embedded_v4 addr =
+  match Ipaddr.v4_of_v6 addr with
+  | Some _ as mapped -> mapped
+  | None ->
+    let octets = Ipaddr.V6.to_octets addr in
+    let rec leading_zeros i = i >= 12 || (Char.code octets.[i] = 0 && leading_zeros (i + 1)) in
+    if leading_zeros 0
+    then (
+      match Ipaddr.V4.of_octets (String.sub octets 12 4) with
+      | Ok v4 -> Some v4
+      | Error _ -> None)
+    else None
+
+let rec ipaddr_is_private_or_reserved = function
   | Ipaddr.V4 addr ->
       let octets = Ipaddr.V4.to_octets addr in
       let byte idx = Char.code octets.[idx] in
@@ -92,17 +112,20 @@ let ipaddr_is_private_or_reserved = function
       || (b0 = 203 && b1 = 0)
       || b0 >= 224
   | Ipaddr.V6 addr ->
-      let text = Ipaddr.V6.to_string addr |> String.lowercase_ascii in
-      Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0
-      || Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
-      || String.starts_with ~prefix:"fc" text
-      || String.starts_with ~prefix:"fd" text
-      || String.starts_with ~prefix:"fe8" text
-      || String.starts_with ~prefix:"fe9" text
-      || String.starts_with ~prefix:"fea" text
-      || String.starts_with ~prefix:"feb" text
-      || String.starts_with ~prefix:"ff" text
-      || String.starts_with ~prefix:"2001:db8" text
+    (match embedded_v4 addr with
+     | Some v4 -> ipaddr_is_private_or_reserved (Ipaddr.V4 v4)
+     | None ->
+       let text = Ipaddr.V6.to_string addr |> String.lowercase_ascii in
+       Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0
+       || Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
+       || String.starts_with ~prefix:"fc" text
+       || String.starts_with ~prefix:"fd" text
+       || String.starts_with ~prefix:"fe8" text
+       || String.starts_with ~prefix:"fe9" text
+       || String.starts_with ~prefix:"fea" text
+       || String.starts_with ~prefix:"feb" text
+       || String.starts_with ~prefix:"ff" text
+       || String.starts_with ~prefix:"2001:db8" text)
 
 let eio_ipaddr_is_private_or_reserved ip =
   let rendered = Fmt.str "%a" Eio.Net.Ipaddr.pp ip in

--- a/lib/server/server_dashboard_http_link_preview.mli
+++ b/lib/server/server_dashboard_http_link_preview.mli
@@ -39,6 +39,18 @@ type preview_extract = {
 
 (** {1 URL helpers} *)
 
+val ipaddr_is_private_or_reserved : Ipaddr.t -> bool
+(** [true] when the address must not be fetched: loopback,
+    RFC 1918, link-local, carrier-grade NAT, multicast, and
+    the documentation ranges.  The fetch path applies this to
+    every address the host resolves to, so a [false] here is
+    what lets a request leave the process.
+
+    A V6 address that carries an IPv4 one — the mapped
+    [::ffff:a.b.c.d] form or the deprecated compatible
+    [::a.b.c.d] form — is judged by the IPv4 rules, since the
+    V6 ranges cannot see the address inside it. *)
+
 val normalize_request_url : string -> (string, string) result
 (** Trims, parses, and normalizes a request URL.  Returns
     [Error reason] when the input is empty, missing a host,

--- a/test/dune
+++ b/test/dune
@@ -623,7 +623,8 @@
   test_workspace_handoff_boundary
   test_exec_command_gate_log_sink)
  (libraries
-  masc_test_deps masc_schedule multimodal bigstringaf masc.keeper_checkpoint_ref))
+  masc_test_deps masc_schedule multimodal bigstringaf masc.keeper_checkpoint_ref
+  ipaddr))
 
 ; Repository catalog tests depend only on the focused repo_manager library.
 (test

--- a/test/test_dashboard_link_preview.ml
+++ b/test/test_dashboard_link_preview.ml
@@ -50,6 +50,39 @@ let test_normalize_request_url_rejects_non_http () =
   | Ok value ->
       failf "expected non-http URL to be rejected, got %s" value
 
+let check_addr expected raw =
+  match Ipaddr.of_string raw with
+  | Error _ -> failf "test input %S did not parse as an IP address" raw
+  | Ok ip ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s blocked" raw)
+        expected
+        (Server_dashboard_http_link_preview.ipaddr_is_private_or_reserved ip)
+
+(* The V6 arm matched on the rendered address, and every IPv4-carrying form
+   renders starting with "::", so none of its prefixes could see the address
+   inside. ::ffff:169.254.169.254 reached the fetcher even though the V4 arm
+   rejects 169.254.0.0/16. *)
+let test_v4_inside_v6_is_blocked () =
+  List.iter (check_addr true)
+    [
+      "::ffff:127.0.0.1";
+      "::ffff:169.254.169.254";
+      "::ffff:10.0.0.1";
+      "::ffff:192.168.1.1";
+      "::ffff:172.16.0.1";
+      "::ffff:100.64.0.1";
+      "::127.0.0.1";
+    ]
+
+let test_native_v6_ranges_stay_blocked () =
+  List.iter (check_addr true)
+    [ "::1"; "::"; "fe80::1"; "febf::1"; "fc00::1"; "fd00::1"; "ff02::1"; "2001:db8::1" ]
+
+let test_public_addresses_stay_allowed () =
+  List.iter (check_addr false)
+    [ "8.8.8.8"; "1.1.1.1"; "2001:4860:4860::8888"; "::ffff:8.8.8.8" ]
+
 let () =
   Alcotest.run "dashboard_link_preview"
     [
@@ -60,5 +93,11 @@ let () =
           test_case "image url detection" `Quick test_image_url_detection;
           test_case "normalize rejects non-http" `Quick
             test_normalize_request_url_rejects_non_http;
+          test_case "IPv4 inside IPv6 is blocked" `Quick
+            test_v4_inside_v6_is_blocked;
+          test_case "native v6 ranges stay blocked" `Quick
+            test_native_v6_ranges_stay_blocked;
+          test_case "public addresses stay allowed" `Quick
+            test_public_addresses_stay_allowed;
         ] );
     ]


### PR DESCRIPTION
## 문제

링크 프리뷰의 주소 필터(`server_dashboard_http_link_preview.ml`)는 대시보드가 준 URL 을 실제로 가져가도 되는지 판정한다. 두 분기가 있었다.

- **V4 분기** — 옥텟을 **수치로** 비교. loopback, RFC 1918, link-local, CGNAT, multicast, documentation 대역을 덮는다.
- **V6 분기** — 렌더된 문자열의 **접두사**를 비교.

IPv4 를 품은 v6 주소는 어떤 형태든 `"::"` 로 시작하게 렌더된다. 그래서 그 접두사 목록 중 **아무것도 매치되지 않는다.**

실측(`Ipaddr` 로 직접 확인):

```
::ffff:127.0.0.1        render="::ffff:127.0.0.1"        blocked=false
::ffff:169.254.169.254  render="::ffff:169.254.169.254"  blocked=false
::ffff:10.0.0.1         render="::ffff:10.0.0.1"         blocked=false
::127.0.0.1             render="::7f00:1"                blocked=false
```

`169.254.169.254` 는 클라우드 메타데이터 주소이고, **V4 분기는 이것을 정확히 거부한다**(`b0 = 169 && b1 = 254`). 같은 주소가 mapped 형태로 오면 통과했다.

## 변경

mapped 형태와 폐기된 compatible 형태(RFC 4291 §2.5.5.1) 모두 **V4 규칙으로 돌려보낸다.** V6 분기에 대역을 다시 적지 않는다.

```ocaml
| Ipaddr.V6 addr ->
  (match embedded_v4 addr with
   | Some v4 -> ipaddr_is_private_or_reserved (Ipaddr.V4 v4)
   | None -> ...기존 V6 검사...)
```

**`Ipaddr.is_private` 로 통째 교체하지 않았다.** 실측 결과 라이브러리는 `fc00::1` 과 `2001:db8::1` 에 `false` 를 준다. 위임하면 필터가 **넓어진다**.

```
fc00::1        lib_is_private=false   (masc 는 차단)
2001:db8::1    lib_is_private=false   (masc 는 차단)
```

## 검증

기존 스위트에는 **주소 케이스가 하나도 없었다**(3케이스: html 추출, 이미지 URL, 비-http 거부).

수정 전 트리에서 먼저 확인:

```
> [FAIL]  preview  3  IPv4 inside IPv6 is blocked.
ASSERT ::ffff:127.0.0.1 blocked          RC=1
  [OK]   preview  4  native v6 ranges stay blocked.
  [OK]   preview  5  public addresses stay allowed.
```

4·5 가 그대로 통과한 것은 이 수정이 네이티브 V6 판정과 공인 주소 판정을 바꾸지 않는다는 뜻이다.

수정 후 6/6 통과.

## CI 배선도 함께 고쳤다

이 스위트는 `test/dune` 에 선언돼 있지만 **`ci.yml` 의 runtest 목록에 없었다.** masc CI 는 이름 지정 타깃 106개만 돌리므로 이 테스트는 여태 **컴파일만 되고 실행된 적이 없다**. 회귀 테스트가 안 돌면 의미가 없으므로 전용 스텝을 추가했다.

`test/dune` 병합 블록 libraries 에 `ipaddr` 한 줄을 더했다(이미 전이 의존이라 가산적).

## 도달성은 확정하지 못했다

분류 함수의 결함은 실측으로 확정했지만, **`Eio.Net.getaddrinfo_stream` 이 어떤 조건에서 IPv4-mapped 주소를 돌려주는지는 확인하지 않았다.** 따라서 이 PR 을 "작동하는 익스플로잇을 막았다" 로 읽지 말 것. 필터의 두 분기가 같은 주소에 다른 답을 주던 것을 일치시킨 것이다.

`validate_resolved_host` 는 DNS 해석 결과 각각에 이 함수를 적용하고(`:130-137`), 그 앞에 호스트 문자열 수준의 loopback 사전 검사가 따로 있다(`:117`).

## 보안 경로 리뷰 요청

`CLAUDE.md` 의 "보안/인증 관련 → 인간 리뷰 필수" 에 해당한다. 판정 함수를 `.mli` 에 문서와 함께 노출했으므로 그 계약 문구도 함께 봐 주기 바란다.
