### PR TITLE
docs: dune·spec 인용이 가리키는 실제 위치로 정정

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -92,7 +92,7 @@
   ;; Owns Shell IR command/path policy and typed path-check errors.
   masc.exec_policy
   ;; RFC-0056 Phase 1N — Keeper_state_* deterministic FSM cluster extracted to
-  ;; lib/keeper_state/. Parent still references bare Keeper_state_* modules.
+  ;; lib/keeper_registry/. Parent still references bare Keeper_state_* modules.
   masc.keeper_registry
   masc.keeper_checkpoint_ref
   ;; Keeper-owned pure/type leaves extracted from lib/keeper/.
@@ -164,12 +164,12 @@
   ;; PR #21019; the library is now diagnostic-only.
   masc.tool_call_quality_benchmark
   ;; RFC-0056 Phase 1I — Keeper_event_queue (first lib/keeper/ leaf)
-  ;; extracted to lib/keeper_event_queue/. 91+87 LoC, deps: stdlib +
+  ;; extracted to lib/keeper_runtime/. deps: stdlib +
   ;; Unix only. Pure data structure (urgency variants + FIFO + dedup)
   ;; backed by specs/keeper-state-machine/KeeperEventQueue.tla.
   ;; Referenced by keeper_supervisor + keeper_registry godfiles.
   ;; RFC-0056 Phase 1J — Keeper_invariant (second lib/keeper/ leaf)
-  ;; extracted to lib/keeper_invariant/. 119+77 LoC, stdlib-only
+  ;; extracted to lib/keeper_contract/. stdlib-only
   ;; (List/Printf/Set/String/StringSet/Result). Fan-in: 1 lib + 1 test.
   ;; RFC-0056 Phase 1K — Compaction_trigger (third lib/keeper/ leaf)
   ;; extracted to lib/compaction_trigger/. 94+45 LoC, deps: stdlib +

--- a/test/test_keeper_phase_drift_contract.ml
+++ b/test/test_keeper_phase_drift_contract.ml
@@ -7,7 +7,7 @@
 
    Also checks that oas Runtime.phase yojson variants are recognized
    by the masc bridge layer (cross-repo drift detection).
-   Reference: specs/AgentLifecycle.tla, specs/AgentCancellation.tla
+   Reference: specs/keeper-state-machine/KeeperStateMachine.tla
 *)
 
 module KSM = Keeper_state_machine


### PR DESCRIPTION
#27573 에서 `lib/dune` 주석이 존재하지 않는 추출 대상을 가리키는 걸 발견했다. **그 형태를 전수했다.**

## dune 주석의 추출 대상 (28개 중 4개 부재)

`lib/dune` 은 각 sub-library 가 **어디로 추출됐는지**를 기록한다. 셋이 틀렸다.

| 모듈 | 주석이 말하는 곳 | 실제 |
|---|---|---|
| `Keeper_event_queue` | `lib/keeper_event_queue/` | `lib/keeper_runtime/` |
| `Keeper_invariant` | `lib/keeper_invariant/` | `lib/keeper_contract/` |
| `Keeper_state_*` | `lib/keeper_state/` | `lib/keeper_registry/` |

셋 다 **실제로 존재하는 클러스터**인데 도착지만 다르다. 네 번째 부재(`lib/runtime_id/`)는 아예 일어나지 않은 추출이라 #27573 에서 제거 중이다.

## spec 인용 (22개 중 2개 부재)

`test_keeper_phase_drift_contract` 이 round-trip 의 근거로 두 spec 을 든다.

```
Reference: specs/AgentLifecycle.tla, specs/AgentCancellation.tla
```

**둘 다 트리에 없고 git 이력에도 없다** — 추가하거나 삭제한 커밋이 하나도 없다. 이 테스트가 대응하는 spec 은 `specs/keeper-state-machine/KeeperStateMachine.tla` 이고, 다른 4개 호출 지점이 이미 그 경로로 인용한다.

## 위양성으로 걸러낸 것

나머지 부재는 TLC 스크래치 출력(`Foo_TTrace_1.tla`, `TraceData.tla`, `specs/states/`)과 `specs/` 문자열이 들어간 opentelemetry.io URL 이다.

dune 주석이 언급한 라이브러리 6개(`masc.*`)는 전부 실재한다.

## 검증

- `dune build @check`: EXIT=0
- `test_keeper_phase_drift_contract`: 8 케이스 통과
- 재검사 결과 dune 경로 부재 1건(`runtime_id`, #27573 대상), spec 부재 0
