### PR TITLE
fix(dashboard): 커넥터 경로를 서버 값에서 읽고 사망 필드까지 숙청 (#27571 재작업)

### DIFF
--- a/dashboard/src/components/connector-paths-strip.test.ts
+++ b/dashboard/src/components/connector-paths-strip.test.ts
@@ -24,35 +24,35 @@ describe('deriveMascPaths', () => {
   it('falls back to repo-relative paths when no connector has names_path', () => {
     const paths = deriveMascPaths([])
     expect(paths.connectorsDir).toBeNull()
-    expect(paths.logsDir).toBeNull()
     expect(paths.keepersDir).toBe('config/keepers/')
     expect(paths.sidecarsDir).toBe('sidecars/')
   })
 
-  it('derives connectors + logs dir from standard names_path pattern', () => {
+  // What the server sends: Channel_gate_discord_names writes
+  // .gate/runtime/<id>/names.json. The old regex demanded
+  // <root>/connectors/<id>/names.json and so never matched.
+  it('takes the directory of the file the server reports', () => {
     const c = mkConnector({
-      names_path: '/Users/alice/.masc/connectors/discord/names.json',
+      names_path: '/Users/alice/.gate/runtime/discord/names.json',
     } as never)
     const paths = deriveMascPaths([c])
-    expect(paths.connectorsDir).toBe('/Users/alice/.masc/connectors/')
-    expect(paths.logsDir).toBe('/Users/alice/.masc/logs/')
+    expect(paths.connectorsDir).toBe('/Users/alice/.gate/runtime/discord/')
   })
 
-  it('falls back when names_path is non-standard', () => {
-    const c = mkConnector({ names_path: '/somewhere/else/names.json' } as never)
+  it('falls back when names_path has no directory', () => {
+    const c = mkConnector({ names_path: 'names.json' } as never)
     const paths = deriveMascPaths([c])
     expect(paths.connectorsDir).toBeNull()
-    expect(paths.logsDir).toBeNull()
   })
 
   it('ignores empty / whitespace names_path and falls through to next connector', () => {
     const c1 = mkConnector({ connector_id: 'discord', names_path: '' } as never)
     const c2 = mkConnector({
       connector_id: 'slack',
-      names_path: '/srv/project/.masc/connectors/slack/names.json',
+      names_path: '/srv/project/.gate/runtime/slack/names.json',
     } as never)
     const paths = deriveMascPaths([c1, c2])
-    expect(paths.connectorsDir).toBe('/srv/project/.masc/connectors/')
+    expect(paths.connectorsDir).toBe('/srv/project/.gate/runtime/slack/')
   })
 })
 
@@ -93,7 +93,7 @@ describe('ConnectorPathsStrip', () => {
 
   it('surfaces Connectors + Logs rows once a connector reports a names_path', async () => {
     const c = mkConnector({
-      names_path: '/Users/alice/.masc/connectors/discord/names.json',
+      names_path: '/Users/alice/.gate/runtime/discord/names.json',
     } as never)
     render(html`<${ConnectorPathsStrip} connectors=${[c]} />`, container)
     const toggle = container.querySelector<HTMLButtonElement>('[data-panel="connector-paths-strip"] button')!
@@ -104,7 +104,7 @@ describe('ConnectorPathsStrip', () => {
     }
     const rows = container.querySelectorAll('[data-paths-row]')
     const labels = Array.from(rows).map(r => r.getAttribute('data-paths-row'))
-    expect(labels).toEqual(['커넥터', '로그', '키퍼', '사이드카'])
+    expect(labels).toEqual(['커넥터', '키퍼', '사이드카'])
   })
 
   it('header shows runtime hint when no connector has names_path', () => {

--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -5,15 +5,13 @@
 // "where is the sidecar log?" and today the only answer is a code tour
 // or Slack. This strip surfaces four MASC-managed paths directly:
 //
-//   - Connectors dir : {mascRoot}/connectors/ — sidecar names.json /
-//                      status.json; derived from an observed connector's
-//                      `names_path` if available
-//   - Logs dir       : {mascRoot}/logs/       — sidecar log directory
-//   - Keepers dir    : config/keepers/         — keeper TOML (repo-relative)
-//   - Sidecars dir   : sidecars/               — sidecar run.sh scripts
-//                                                (repo-relative)
+//   - Connectors dir : the directory of an observed connector's
+//                      `names_path`, as the server reports it
+//   - Keepers dir    : config/keepers/  — keeper TOML (repo-relative)
+//   - Sidecars dir   : sidecars/        — sidecar run.sh scripts
+//                                         (repo-relative)
 //
-// The top two are derived from runtime; the bottom two are repo-relative
+// The first is derived from runtime; the other two are repo-relative
 // conventions and always shown. Collapsed by default so the main overview
 // strip stays dense.
 
@@ -31,7 +29,6 @@ export function _testResetPathsStrip() {
 
 export interface MascPaths {
   connectorsDir: string | null
-  logsDir: string | null
   keepersDir: string
   sidecarsDir: string
 }
@@ -45,7 +42,6 @@ export interface MascPaths {
 export function deriveMascPaths(connectors: GateConnectorInfo[]): MascPaths {
   const fallback: MascPaths = {
     connectorsDir: null,
-    logsDir: null,
     keepersDir: 'config/keepers/',
     sidecarsDir: 'sidecars/',
   }
@@ -53,12 +49,14 @@ export function deriveMascPaths(connectors: GateConnectorInfo[]): MascPaths {
     c => typeof c.names_path === 'string' && c.names_path.length > 0,
   )
   if (!withPath) return fallback
-  const match = withPath.names_path.match(/^(.*)\/connectors\/[^/]+\/names\.json$/)
-  if (!match) return fallback
-  const mascRoot = match[1] ?? ''
+  // The server sends the file it actually writes; take its directory rather
+  // than re-deriving a layout from the string. A regex for
+  // `<root>/connectors/<id>/names.json` never matched after the runtime moved
+  // to .gate/runtime/ in #7467, so both rows below stayed hidden.
+  const dir = withPath.names_path.replace(/\/[^/]*$/, '')
+  if (dir === '' || dir === withPath.names_path) return fallback
   return {
-    connectorsDir: `${mascRoot}/connectors/`,
-    logsDir: `${mascRoot}/logs/`,
+    connectorsDir: `${dir}/`,
     keepersDir: 'config/keepers/',
     sidecarsDir: 'sidecars/',
   }
@@ -105,9 +103,6 @@ export function ConnectorPathsStrip({ connectors }: { connectors: GateConnectorI
             <div id="connector-paths-body" class="space-y-1.5 border-t border-[var(--color-border-default)] px-3 py-2">
               ${paths.connectorsDir
                 ? html`<${PathRow} label="커넥터" value=${paths.connectorsDir} hint="sidecar names.json / status.json 위치" />`
-                : null}
-              ${paths.logsDir
-                ? html`<${PathRow} label="로그" value=${paths.logsDir} hint="sidecar 로그 디렉토리" />`
                 : null}
               <${PathRow} label="키퍼" value=${paths.keepersDir} hint="keeper TOML 설정 파일" />
               <${PathRow} label="사이드카" value=${paths.sidecarsDir} hint="sidecar 스크립트 (run.sh) 위치" />


### PR DESCRIPTION
#27571 은 "수정 자체는 맞지만 partial cleanup" 으로 닫혔다. 지적된 둘을 같은 PR 에서 마저 정리했다.

## 본 결함 — 4개월간 커넥터 경로 미표시

`ConnectorPathsStrip` 이 `names_path` 를 정규식으로 역추론한다.

```
서버:    .gate/runtime/discord/names.json
정규식:  <root>/connectors/<id>/names.json
```

`#7467`(2026-04-16)이 런타임을 옮겼고, 이 strip 은 **그 다음 날** `#8013` 에서 옛 레이아웃 기준으로 들어왔다 — **처음부터 맞은 적이 없다.**

실패가 조용하다: 매치 실패 → fallback → `(런타임 미관찰 · sidecar 경로만 표시)` 만 뜨고 커넥터 행은 안 그려진다.

이제 **서버가 보고한 파일의 디렉터리를 그대로** 쓴다. 어떤 레이아웃이 와도 파일명만 떼면 되므로 정규식보다 강건하다.

## 지적 1 — `logsDir` 사망 필드 숙청

응답에 로그 디렉터리를 알려주는 필드가 없어 `logsDir` 은 **모든 경로에서 `null`** 이 된다. `null` 을 남기면 렌더 분기도 죽은 채로 남는다. 다음을 전부 제거했다.

- `MascPaths.logsDir` 타입 슬롯
- 두 초기화 지점
- 이 필드로 가드되던 로그 행 렌더 분기
- `expect(paths.logsDir).toBeNull()` 단언 3곳

`rg 'logsDir' dashboard/src` → **0**.

## 지적 2 — 헤더 주석 모순

`connector-paths-strip.ts:8-11` 이 `{mascRoot}/connectors/` · `{mascRoot}/logs/` 레이아웃을 계속 서술하고 있었다. 코드가 더는 그렇게 하지 않으므로 실제 동작으로 갱신했다.

## 테스트가 결함을 고정하고 있었다

옛 레이아웃을 4곳에서 단언했고, 그중 하나는 제목이 **"derives connectors + logs dir from standard names_path pattern"** — 서버가 보낼 수 없는 입력을 "standard" 라고 부른다.

옛 정규식을 되살리면 실패하는 것을 확인했다.

## 검증

- `npx tsc --noEmit`: EXIT=0
- `npx vitest run`: 636 파일 / 8797 테스트 통과
