### PR TITLE
refactor: has_prefix 래퍼 5개를 String.starts_with 로 정리

### DIFF
--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -258,11 +258,6 @@ let redacted_http_url_opt ?on_drop url =
   | _ -> drop Invalid_url
 ;;
 
-let has_prefix ~prefix value =
-  let prefix_len = String.length prefix in
-  String.length value >= prefix_len && String.sub value 0 prefix_len = prefix
-;;
-
 let opt_string_field key = function
   | None -> []
   | Some value -> [ (key, `String value) ]
@@ -497,7 +492,7 @@ let parse_text_to_blocks text : chat_block list =
       let acc = push_text_fragment acc before in
       let acc =
         match cap with
-        | Some lang when has_prefix ~prefix:"mermaid" lang ->
+        | Some lang when String.starts_with ~prefix:"mermaid" lang ->
           Mermaid { source; caption = None } :: acc
         | _ -> Code { cap; html = escape_html source; source = Some source } :: acc
       in

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -102,7 +102,6 @@ let source_to_string = function
 let event_class_to_string : event_class -> string = function
   | Routine -> "routine"
 
-let has_prefix ~prefix value = String.starts_with ~prefix value
 
 (* RFC-0079: [infer_legacy_level] (a string-prefix classifier on the
    message body) was deleted along with the [?level] option on
@@ -616,7 +615,7 @@ module Ring = struct
           (Time_compat.now () -. (float_of_int keep_days *. 86400.0))
       in
       Array.iter (fun fname ->
-        if has_prefix ~prefix:"system_log_" fname
+        if String.starts_with ~prefix:"system_log_" fname
            && Filename.check_suffix fname ".jsonl" then begin
           (* Extract date from system_log_YYYY-MM-DD.jsonl *)
           let date_part = String.sub fname 11 10 in

--- a/lib/server/masc_grpc_server.ml
+++ b/lib/server/masc_grpc_server.ml
@@ -181,7 +181,6 @@ module Reflection_bridge = struct
   ;;
 
   let masc_symbols = [ Masc_grpc_service.service_name ]
-  let has_prefix ~prefix value = String.starts_with ~prefix value
 
   let decode_varint (bytes : string) (pos : int ref) : int =
     let result = ref 0 in
@@ -318,24 +317,24 @@ module Reflection_bridge = struct
   ;;
 
   let handles_health_symbol symbol =
-    List.mem symbol health_symbols || has_prefix ~prefix:"grpc.health.v1." symbol
+    List.mem symbol health_symbols || String.starts_with ~prefix:"grpc.health.v1." symbol
   ;;
 
   let handles_health_filename filename = List.mem filename health_proto_filenames
 
   let handles_masc_symbol symbol =
-    List.mem symbol masc_symbols || has_prefix ~prefix:"masc.workspace.v1." symbol
+    List.mem symbol masc_symbols || String.starts_with ~prefix:"masc.workspace.v1." symbol
   ;;
 
   let handles_masc_filename filename = List.mem filename masc_proto_filenames
 
   let handles_reflection_v1_symbol symbol =
-    List.mem symbol reflection_symbols || has_prefix ~prefix:"grpc.reflection.v1." symbol
+    List.mem symbol reflection_symbols || String.starts_with ~prefix:"grpc.reflection.v1." symbol
   ;;
 
   let handles_reflection_v1alpha_symbol symbol =
     List.mem symbol reflection_v1alpha_symbols
-    || has_prefix ~prefix:"grpc.reflection.v1alpha." symbol
+    || String.starts_with ~prefix:"grpc.reflection.v1alpha." symbol
   ;;
 
   let handles_reflection_v1_filename filename =

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -303,17 +303,13 @@ let keeper_chat_request_prefixes =
     "/api/v1/keepers/chat/requests/";
   ]
 
-let has_prefix ~prefix value =
-  let prefix_len = String.length prefix in
-  String.length value >= prefix_len
-  && String.equal (String.sub value 0 prefix_len) prefix
 
 let keeper_chat_request_suffix request =
   let path = Http.Request.path request in
   let rec loop = function
     | [] -> None
     | prefix :: rest ->
-        if has_prefix ~prefix path then
+        if String.starts_with ~prefix path then
           Some
             (String.sub path (String.length prefix)
                (String.length path - String.length prefix))

--- a/lib/voice/voice_session_manager.ml
+++ b/lib/voice/voice_session_manager.ml
@@ -80,12 +80,8 @@ let realtime_supported = function
 
 let realtime_bridge_env = "MASC_VOICE_REALTIME_WS_URL"
 
-let has_prefix ~prefix s =
-  let prefix_len = String.length prefix in
-  String.length s >= prefix_len && String.sub s 0 prefix_len = prefix
-
 let valid_realtime_bridge_endpoint endpoint =
-  has_prefix ~prefix:"ws://" endpoint || has_prefix ~prefix:"wss://" endpoint
+  String.starts_with ~prefix:"ws://" endpoint || String.starts_with ~prefix:"wss://" endpoint
 
 let realtime_bridge_endpoint ?(getenv = Sys.getenv_opt) () =
   match getenv realtime_bridge_env with


### PR DESCRIPTION
## 문제

다섯 파일이 각각 자기 `has_prefix ~prefix` 를 들고 있었다.

| 파일 | 형태 |
|---|---|
| `lib/masc_log/log.ml:105` | `String.starts_with` 얇은 별칭 |
| `lib/server/masc_grpc_server.ml:184` | `String.starts_with` 얇은 별칭 |
| `lib/keeper/keeper_chat_blocks.ml:261` | `String.sub` 로 재구현 |
| `lib/voice/voice_session_manager.ml:83` | `String.sub` 로 재구현 |
| `lib/server/server_routes_http_keeper_stream.ml:306` | `String.sub` 로 재구현 |

재구현 셋은 전부 이 형태다.

```ocaml
String.length value >= prefix_len && String.sub value 0 prefix_len = prefix
```

`String.starts_with` 와 **같은 술어**다. 빈 prefix 도, value 보다 긴 prefix 도 같은 답을 낸다. 다만 호출마다 부분문자열을 할당한다는 점만 다르다.

## 변경

정의 5개를 지우고 호출 9곳을 `String.starts_with` 로 바꿨다.

**판정이 달라지는 곳은 없다.** 다섯 구현이 동작상 동일했으므로 이 PR 은 결함 수정이 아니라 중복 제거다.

대시보드 composite `.mli` 들이 선언하는 `has_prefix` 는 별개의 공개 표면이라 건드리지 않았다.

## 검증

`dune build --root . @check` → RC=0, 경고 없음.

동작 변화가 없으므로 새 테스트는 추가하지 않았다. 다섯 구현의 동치성은 위 표의 코드 비교가 근거다.

## 배경

"같은 술어가 여러 곳에 구현돼 답이 갈리는가" 를 훑다 나왔다. `has_prefix` 는 **갈리지 않았다** — 이 PR 은 그 확인의 결과물이다. 같은 훑기에서 실제로 갈린 것은 #27576 (루프백 판정 5구현, IPv4 범위 3종) 이고 그쪽은 보안적 판단이 필요해 이슈로 남겼다.
