### PR TITLE
fix(dashboard): names_path 문자열 추론 제거 — 두 컴포넌트 (#27577 재작업)

### DIFF
--- a/dashboard/src/components/connector-paths-strip.test.ts
+++ b/dashboard/src/components/connector-paths-strip.test.ts
@@ -24,35 +24,35 @@ describe('deriveMascPaths', () => {
   it('falls back to repo-relative paths when no connector has names_path', () => {
     const paths = deriveMascPaths([])
     expect(paths.connectorsDir).toBeNull()
-    expect(paths.logsDir).toBeNull()
     expect(paths.keepersDir).toBe('config/keepers/')
     expect(paths.sidecarsDir).toBe('sidecars/')
   })
 
-  it('derives connectors + logs dir from standard names_path pattern', () => {
+  // What the server sends: Channel_gate_discord_names writes
+  // .gate/runtime/<id>/names.json. The old regex demanded
+  // <root>/connectors/<id>/names.json and so never matched.
+  it('takes the directory of the file the server reports', () => {
     const c = mkConnector({
-      names_path: '/Users/alice/.masc/connectors/discord/names.json',
+      names_path: '/Users/alice/.gate/runtime/discord/names.json',
     } as never)
     const paths = deriveMascPaths([c])
-    expect(paths.connectorsDir).toBe('/Users/alice/.masc/connectors/')
-    expect(paths.logsDir).toBe('/Users/alice/.masc/logs/')
+    expect(paths.connectorsDir).toBe('/Users/alice/.gate/runtime/discord/')
   })
 
-  it('falls back when names_path is non-standard', () => {
-    const c = mkConnector({ names_path: '/somewhere/else/names.json' } as never)
+  it('falls back when names_path has no directory', () => {
+    const c = mkConnector({ names_path: 'names.json' } as never)
     const paths = deriveMascPaths([c])
     expect(paths.connectorsDir).toBeNull()
-    expect(paths.logsDir).toBeNull()
   })
 
   it('ignores empty / whitespace names_path and falls through to next connector', () => {
     const c1 = mkConnector({ connector_id: 'discord', names_path: '' } as never)
     const c2 = mkConnector({
       connector_id: 'slack',
-      names_path: '/srv/project/.masc/connectors/slack/names.json',
+      names_path: '/srv/project/.gate/runtime/slack/names.json',
     } as never)
     const paths = deriveMascPaths([c1, c2])
-    expect(paths.connectorsDir).toBe('/srv/project/.masc/connectors/')
+    expect(paths.connectorsDir).toBe('/srv/project/.gate/runtime/slack/')
   })
 })
 
@@ -93,7 +93,7 @@ describe('ConnectorPathsStrip', () => {
 
   it('surfaces Connectors + Logs rows once a connector reports a names_path', async () => {
     const c = mkConnector({
-      names_path: '/Users/alice/.masc/connectors/discord/names.json',
+      names_path: '/Users/alice/.gate/runtime/discord/names.json',
     } as never)
     render(html`<${ConnectorPathsStrip} connectors=${[c]} />`, container)
     const toggle = container.querySelector<HTMLButtonElement>('[data-panel="connector-paths-strip"] button')!
@@ -104,7 +104,7 @@ describe('ConnectorPathsStrip', () => {
     }
     const rows = container.querySelectorAll('[data-paths-row]')
     const labels = Array.from(rows).map(r => r.getAttribute('data-paths-row'))
-    expect(labels).toEqual(['커넥터', '로그', '키퍼', '사이드카'])
+    expect(labels).toEqual(['커넥터', '키퍼', '사이드카'])
   })
 
   it('header shows runtime hint when no connector has names_path', () => {

--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -5,15 +5,13 @@
 // "where is the sidecar log?" and today the only answer is a code tour
 // or Slack. This strip surfaces four MASC-managed paths directly:
 //
-//   - Connectors dir : {mascRoot}/connectors/ — sidecar names.json /
-//                      status.json; derived from an observed connector's
-//                      `names_path` if available
-//   - Logs dir       : {mascRoot}/logs/       — sidecar log directory
-//   - Keepers dir    : config/keepers/         — keeper TOML (repo-relative)
-//   - Sidecars dir   : sidecars/               — sidecar run.sh scripts
-//                                                (repo-relative)
+//   - Connectors dir : the directory of an observed connector's
+//                      `names_path`, as the server reports it
+//   - Keepers dir    : config/keepers/  — keeper TOML (repo-relative)
+//   - Sidecars dir   : sidecars/        — sidecar run.sh scripts
+//                                         (repo-relative)
 //
-// The top two are derived from runtime; the bottom two are repo-relative
+// The first is derived from runtime; the other two are repo-relative
 // conventions and always shown. Collapsed by default so the main overview
 // strip stays dense.
 
@@ -31,7 +29,6 @@ export function _testResetPathsStrip() {
 
 export interface MascPaths {
   connectorsDir: string | null
-  logsDir: string | null
   keepersDir: string
   sidecarsDir: string
 }
@@ -45,7 +42,6 @@ export interface MascPaths {
 export function deriveMascPaths(connectors: GateConnectorInfo[]): MascPaths {
   const fallback: MascPaths = {
     connectorsDir: null,
-    logsDir: null,
     keepersDir: 'config/keepers/',
     sidecarsDir: 'sidecars/',
   }
@@ -53,12 +49,14 @@ export function deriveMascPaths(connectors: GateConnectorInfo[]): MascPaths {
     c => typeof c.names_path === 'string' && c.names_path.length > 0,
   )
   if (!withPath) return fallback
-  const match = withPath.names_path.match(/^(.*)\/connectors\/[^/]+\/names\.json$/)
-  if (!match) return fallback
-  const mascRoot = match[1] ?? ''
+  // The server sends the file it actually writes; take its directory rather
+  // than re-deriving a layout from the string. A regex for
+  // `<root>/connectors/<id>/names.json` never matched after the runtime moved
+  // to .gate/runtime/ in #7467, so both rows below stayed hidden.
+  const dir = withPath.names_path.replace(/\/[^/]*$/, '')
+  if (dir === '' || dir === withPath.names_path) return fallback
   return {
-    connectorsDir: `${mascRoot}/connectors/`,
-    logsDir: `${mascRoot}/logs/`,
+    connectorsDir: `${dir}/`,
     keepersDir: 'config/keepers/',
     sidecarsDir: 'sidecars/',
   }
@@ -105,9 +103,6 @@ export function ConnectorPathsStrip({ connectors }: { connectors: GateConnectorI
             <div id="connector-paths-body" class="space-y-1.5 border-t border-[var(--color-border-default)] px-3 py-2">
               ${paths.connectorsDir
                 ? html`<${PathRow} label="커넥터" value=${paths.connectorsDir} hint="sidecar names.json / status.json 위치" />`
-                : null}
-              ${paths.logsDir
-                ? html`<${PathRow} label="로그" value=${paths.logsDir} hint="sidecar 로그 디렉토리" />`
                 : null}
               <${PathRow} label="키퍼" value=${paths.keepersDir} hint="keeper TOML 설정 파일" />
               <${PathRow} label="사이드카" value=${paths.sidecarsDir} hint="sidecar 스크립트 (run.sh) 위치" />

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -634,13 +634,6 @@ function ConnectorLivePanel({
     gateHealthLabel = 'unhealthy'
   }
 
-  const sidecarLogPath = connector?.names_path
-    ? connector.names_path.replace(
-        /\/\.masc\/connectors\/[^/]+\/names\.json$/,
-        `/.masc/logs/${connectorId}-sidecar-YYYYMMDD.log`,
-      )
-    : ''
-
   // observedWorkspaces / bindingsByKeeper / knownNames / knownGroups form a
   // derivation chain over stable props (gate, connector, configuredBindings,
   // keepers). The panel re-renders on unrelated UI state (keeperQuery filter
@@ -810,9 +803,6 @@ function ConnectorLivePanel({
             ? html`<${SidecarLogToggle} connectorId=${connectorId} />`
             : null}
           <${ConnectorConfigToggle} connectorId=${connectorId} />
-          ${sidecarLogPath && !isInProcessConnector(connectorId)
-            ? html`<span class="cursor-help text-3xs text-[var(--color-fg-disabled)]" title=${sidecarLogPath} aria-hidden="true">↗</span>`
-            : null}
           <button
             type="button"
             class="cursor-pointer rounded-[var(--r-1)] border border-[var(--color-border-default)] px-1.5 text-2xs text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)]"
@@ -1280,9 +1270,6 @@ function ConnectorLivePanel({
             <div class="cn-runtime-paths mt-4 flex flex-wrap gap-3 text-3xs text-[var(--color-fg-disabled)]">
               ${connector.status_path
                 ? html`<span title=${connector.status_path}>runtime ${truncateMiddle(connector.status_path, 50)}</span>`
-                : null}
-              ${sidecarLogPath
-                ? html`<span title=${sidecarLogPath}>logs ${truncateMiddle(sidecarLogPath, 50)}</span>`
                 : null}
             </div>
           `


### PR DESCRIPTION
#27577 은 "지적된 둘은 정리됐으나 네 번째 항목이 남았다"로 닫혔다. 그 항목이 **같은 결함의 두 번째 사례**였다. 두 컴포넌트를 함께 처리한다.

## 공통 원인

둘 다 `names_path` **문자열에서 레이아웃을 재유도**한다. `#7467`(2026-04-16)이 런타임을 `.gate/runtime/` 으로 옮긴 뒤 어느 쪽 패턴도 실제 응답과 맞지 않는다.

## 1. `ConnectorPathsStrip` — 조용한 폴백

정규식 미스 → fallback → `(런타임 미관찰 · sidecar 경로만 표시)` 만 뜨고 커넥터 행이 안 그려진다.

이제 **서버가 보고한 파일의 디렉터리**를 쓴다.

`logsDir` 은 응답에 대응 필드가 없어 **모든 경로에서 `null`** 이었다. 타입 슬롯·초기화 2곳·이 필드로 가드되던 렌더 분기·`toBeNull()` 단언 3곳을 전부 제거했다.

## 2. `ConnectorStatus` — 더 나쁜 실패 모드

```ts
connector.names_path.replace(
  /\/\.masc\/connectors\/[^/]+\/names\.json$/,
  `/.masc/logs/${connectorId}-sidecar-YYYYMMDD.log`,
)
```

**`String.replace` 는 패턴이 안 맞으면 입력을 그대로 돌려준다.** 폴백이 아니라 *틀린 값*이 나온다 — `logs …` 행과 ↗ 어포던스가 **`names.json` 경로 자체를 로그 경로라고 표시해 왔다.**

바로 옆 줄에서 `connector.status_path` 는 서버 값을 그대로 쓴다. 커넥터 페이로드에는 로그 경로가 없다(`log_path` 는 존재하지만 `/sidecar/log` **응답**에 있고 커넥터 객체에는 없다). 추론과 두 렌더 지점을 제거했다.

## 범위 밖으로 둔 것

#27543 이 지적한 `scripts/audit-keeper-fleet-readiness.py` 등 Python 쪽 raw layout 소유는 확인했다(`metrics`, `execution-receipts`, `trajectories`, `runtime-manifests`). OCaml variant 를 Python 이 공유할 수단이 없어 **#27583(cross-language SSOT)** 의 주제이며 이 PR 에서 다루지 않는다.

## 검증

- `npx tsc --noEmit`: EXIT=0
- `npx vitest run`: 636 파일 / 8797 테스트 통과
- `rg 'logsDir|sidecarLogPath' dashboard/src` → 0
