### PR TITLE
test(dashboard): listener_mode 픽스처를 서버 어휘로 정정

### DIFF
--- a/dashboard/src/api/schemas/transport-health.test.ts
+++ b/dashboard/src/api/schemas/transport-health.test.ts
@@ -207,7 +207,7 @@ describe('parseTransportHealthData', () => {
         supports_delete: true,
       },
       http2: {
-        listener_mode: 'prior_knowledge',
+        listener_mode: 'h2_only',
         multiplex_ready: true,
         prior_knowledge_path: '/mcp',
       },

--- a/dashboard/src/api/transport-health.test.ts
+++ b/dashboard/src/api/transport-health.test.ts
@@ -185,7 +185,7 @@ describe('decodeTransportHealthData', () => {
         supports_delete: true,
       },
       http2: {
-        listener_mode: 'h2c',
+        listener_mode: 'h2_only',
         multiplex_ready: true,
         prior_knowledge_path: '/mcp',
       },

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -113,7 +113,7 @@ function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
       supports_delete: true,
     },
     http2: {
-      listener_mode: 'h2',
+      listener_mode: 'h2_only',
       multiplex_ready: true,
       prior_knowledge_path: '/mcp',
     },
@@ -746,7 +746,7 @@ function makeData(overrides?: Partial<TransportHealthData>): TransportHealthData
       supports_delete: true,
     },
     http2: {
-      listener_mode: 'h2',
+      listener_mode: 'h2_only',
       multiplex_ready: true,
       prior_knowledge_path: '/mcp',
     },


### PR DESCRIPTION
`transport-health` 픽스처 4곳이 `http2.listener_mode` 에 서버가 내지 않는 값을 넣는다.

```
픽스처:  'prior_knowledge'  'h2c'  'h2'
서버:    "auto" | "h1_only" | "h2_only" | (미인식 설정의 원문)
```

이 필드는 **설정된 HTTP 모드**를 나른다. `Transport_metrics` 가 `Env_config.Transport.use_h2 ()` 를 `h2_mode_to_string` 으로 변환해 넣는다.

`'prior_knowledge'` 는 같은 객체 바로 옆에 있는 실재 필드 `prior_knowledge_path` 에서 이름을 빌려온 것으로 보인다.

## 왜 값이 중요한가

```ocaml
"multiplex_ready", `Bool (not (String.equal listener_mode "h1_only"))
```

대시보드가 이 값을 HTTP 카드의 ok/warn 으로 바꾼다(`transport-health.ts:283`). 어휘 밖 값을 넣은 픽스처는 **서버가 만들 수 없는 경우**를 검사한다.

## 확인했으나 결함이 아니었던 것

처음엔 `"h1_only"` 비교가 잘못이라고 판단했다. `server_bootstrap_http.ml` 이 `let mode = "h1"` / `"h2"` / `"auto"` 를 설정하므로 `h1_only` 와 절대 같지 않아 `multiplex_ready` 가 항상 `true` 라고 봤다.

**틀렸다.** 두 필드는 이름이 비슷할 뿐 다른 어휘다.

| 필드 | 출처 | 값 |
|---|---|---|
| `http2.listener_mode` | `h2_mode_to_string` (설정) | `auto` / `h1_only` / `h2_only` |
| `listener.mode` | `http_listener_mode_runtime` Atomic (런타임) | `h1` / `h2` / `auto` / `unknown` |

`server_bootstrap_http.ml` 이 설정하는 것은 후자다. 비교는 정확하고, 이 PR 은 서버 코드를 건드리지 않는다.

## 검증

- `npx tsc --noEmit`: EXIT=0
- `npx vitest run`: 636 파일 / 8797 테스트 통과
