### PR TITLE
fix(dashboard): in-process 커넥터에 없는 사이드카 status 파일을 안내하지 않는다

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -905,7 +905,9 @@ function ConnectorLivePanel({
                 <${BoldLabel}>Next: </${BoldLabel}>
                 ${connectorError
                   ? html`refresh the dashboard or check <${Tk}>/api/v1/gate/connectors<//> on ${connector?.gate_base_url || 'the Gate server'}.`
-                  : html`run the ${connectorName} status command and inspect <${Tk}>${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}<//>.`}
+                  : isInProcessConnector(connectorId)
+                    ? html`${connectorName} runs inside the server — check the server log, not a status file.`
+                    : html`run the ${connectorName} status command and inspect <${Tk}>${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}<//>.`}
               </div>
             </${SurfaceCard}>
           `
@@ -1014,7 +1016,9 @@ function ConnectorLivePanel({
                   </div>
                 </div>
                 <div class="text-2xs text-[var(--color-status-warn)]/80">
-                  사이드카 status 파일이 <${Tk}>${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}<//> 에서 관찰되지 않았습니다.
+                  ${isInProcessConnector(connectorId)
+                    ? html`${connectorName} 는 서버 프로세스 안에서 동작합니다 — status 파일이 아니라 서버 로그를 확인하세요.`
+                    : html`사이드카 status 파일이 <${Tk}>${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}<//> 에서 관찰되지 않았습니다.`}
                 </div>
                 <div class="mt-2 grid grid-cols-1 gap-1.5">
                   <${CopyableCode}


### PR DESCRIPTION
#27591 이 제기한 "Discord `status_path` 는 writer 가 없다"를 검증했다. **사실이고, 운영자 안내가 존재하지 않는 파일을 가리킨다.**

## 디스크가 확정한다

```
$ ls ~/.gate/runtime/discord/
binding_audit.jsonl  bindings.json  names.json
sidecar_lifecycle_attempt.json  sidecar_lifecycle_desired.json
```

`status.json` 이 없다. slack·imessage·telegram 디렉터리에도 없다. `Channel_gate_discord_state` 는 `status_path` 를 **계산해서 JSON 에 넣을 뿐 읽지도 쓰지도 않는다.**

## 잘못된 안내 2곳

```ts
run the ${connectorName} status command and inspect
  ${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}

사이드카 status 파일이 ... 에서 관찰되지 않았습니다.
```

Discord 와 Slack 은 `IN_PROCESS_CONNECTOR_IDS` — **서버 프로세스 안에서 동작하므로 사이드카도 status 파일도 없다.** 운영자가 이 안내를 따르면 없는 파일을 찾게 된다.

두 메시지가 `isInProcessConnector` 로 분기해, in-process 커넥터에는 **서버 로그**를 가리킨다. 실제로 사이드카를 돌리는 커넥터의 문구는 그대로다.

## 범위

#27591 은 타입화된 경로 계약 전반을 다룬다. 이 PR 은 **운영자 대면 절반만** 고친다 — 서버가 in-process 커넥터에 `status_path` 를 계속 내보내는 것 자체는 그 이슈의 주제다.

## 검증

- `npx tsc --noEmit`: EXIT=0
- `npx vitest run`: 636 파일 / 8797 테스트 통과
