### PR TITLE
fix(fs_compat): HOME 가드를 구분자 경계로 비교한다 (#27570 대체, HOME=/ 회귀 포함)

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -105,11 +105,26 @@ let test_exec_home_guard ~op path =
           then String.sub trimmed 0 (len - 1)
           else trimmed
         in
+        (* Compare on the separator boundary.  A bare [starts_with
+           ~prefix:home_norm] also fires for a sibling whose name extends
+           HOME's: with HOME=/home/runner it blocked /home/runner-cache, which
+           is not under HOME.
+
+           [home_norm] can already end in a separator -- the normalization above
+           only strips one when the value is longer than one character, so
+           HOME=/ stays "/".  Appending unconditionally would look for a "//"
+           prefix there and block nothing, so append only when it is missing.
+           The equality arm keeps HOME itself blocked, as the bare prefix did. *)
         let home_len = String.length home_norm in
+        let home_prefix =
+          if home_len > 0 && Char.equal home_norm.[home_len - 1] '/'
+          then home_norm
+          else home_norm ^ "/"
+        in
         if
           home_len > 0
-          && String.length path >= home_len
-          && String.starts_with path ~prefix:home_norm
+          && (String.equal path home_norm
+              || String.starts_with path ~prefix:home_prefix)
         then
           raise
             (Test_isolation_breach

--- a/test/test_fs_compat_home_guard.ml
+++ b/test/test_fs_compat_home_guard.ml
@@ -69,6 +69,69 @@ let test_tmp_write_allowed () =
   (try Sys.remove path with Sys_error _ -> ());
   (try Unix.rmdir dir with Unix.Unix_error _ -> ())
 
+(* A sibling whose name merely extends HOME's is not under HOME.  Matching on
+   the bare prefix also fired for it: with HOME=/home/runner the guard blocked
+   /home/runner-cache and told the author to fix a test setup that was already
+   correct.  HOME is repointed at a temp directory so the probe stays inside the
+   temp tree. *)
+let test_home_sibling_allowed () =
+  disable_escape_hatch ();
+  let real_home = home () in
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-9921-sibling-%d" (Unix.getpid ()))
+  in
+  let fake_home = Filename.concat base "home" in
+  let sibling = fake_home ^ "-cache" in
+  let path = Filename.concat sibling "probe.txt" in
+  FC.mkdir_p fake_home;
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.putenv "HOME" real_home;
+      (try Sys.remove path with Sys_error _ -> ());
+      (try Unix.rmdir sibling with Unix.Unix_error _ -> ());
+      (try Unix.rmdir fake_home with Unix.Unix_error _ -> ());
+      try Unix.rmdir base with Unix.Unix_error _ -> ())
+    (fun () ->
+      Unix.putenv "HOME" fake_home;
+      try
+        FC.mkdir_p sibling;
+        FC.append_file path "ok\n";
+        Alcotest.(check bool) "sibling write succeeded" true (Sys.file_exists path)
+      with FC.Test_isolation_breach msg ->
+        Alcotest.failf
+          "guard fired for %S, which is a sibling of HOME=%S and not under it: %s"
+          path
+          fake_home
+          msg)
+
+(* [HOME=/] is the case a separator boundary can silently open.  The
+   normalization only strips a trailing slash when the value is longer than one
+   character, so HOME stays "/" and every absolute path is under it.  A guard
+   that appends a separator before comparing would look for a "//" prefix and
+   block nothing.  Containers running as root with no home set do use HOME=/. *)
+let test_home_root_blocks_everything () =
+  disable_escape_hatch ();
+  let real_home = home () in
+  let path =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-9921-root-%d.txt" (Unix.getpid ()))
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.putenv "HOME" real_home;
+      try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+      Unix.putenv "HOME" "/";
+      try
+        FC.append_file path "must not be written\n";
+        Alcotest.failf
+          "expected Test_isolation_breach with HOME=/, but wrote %S"
+          path
+      with FC.Test_isolation_breach _ -> ())
+
 let test_escape_hatch_allows_home () =
   Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" "1";
   let path = guard_path "_9921_guard_probe_bypass.jsonl" in
@@ -101,6 +164,10 @@ let () =
         test_mkdir_under_home_raises;
       Alcotest.test_case "tmp write allowed" `Quick
         test_tmp_write_allowed;
+      Alcotest.test_case "HOME sibling allowed" `Quick
+        test_home_sibling_allowed;
+      Alcotest.test_case "HOME=/ blocks everything" `Quick
+        test_home_root_blocks_everything;
       Alcotest.test_case "escape hatch allows HOME" `Quick
         test_escape_hatch_allows_home;
     ];


### PR DESCRIPTION
## 문제

`test_exec_home_guard` (`lib/fs_compat/fs_compat.ml:78-`) 가 경로를 문자열 접두사로만 비교한다.

```ocaml
String.starts_with path ~prefix:home_norm
```

이름이 HOME 을 연장하는 형제 디렉터리는 이 접두사를 공유하지만 HOME 하위가 아니다. `HOME=/home/runner` 일 때 `/home/runner-cache` 도 걸리고, 가드는 `Test_isolation_breach` 를 던지며 "fix the test setup" 이라 안내한다. 그 setup 은 이미 올바르다.

과다 차단이므로 빠져나간 쓰기는 없다. 비용은 오해를 부르는 헛된 실패다.

## 이 PR 은 #27570 을 대체한다 — 그 PR 은 가드를 열었다

#27570 에서 나는 이렇게 고쳤다.

```ocaml
String.equal path home_norm || String.starts_with path ~prefix:(home_norm ^ "/")
```

**`HOME=/` 에서 가드가 열린다.** 정규화는 값이 한 글자보다 길 때만 후행 슬래시를 벗기므로(`len > 1`) `home_norm` 이 `"/"` 로 남고, 위 조건은 `path = "/" || starts_with path ~prefix:"//"` 가 되어 아무것도 막지 않는다. 원래의 베어 `prefix:"/"` 는 전부 막았다. home 이 설정되지 않은 채 root 로 도는 컨테이너는 `HOME=/` 를 쓴다.

닫은 판단이 맞았다. 재현해서 테스트로 고정했다.

## 변경

구분자 경계로 비교하되, **이미 구분자로 끝나면 덧붙이지 않는다.**

```ocaml
let home_prefix =
  if home_len > 0 && Char.equal home_norm.[home_len - 1] '/'
  then home_norm
  else home_norm ^ "/"
in
home_len > 0
&& (String.equal path home_norm
    || String.starts_with path ~prefix:home_prefix)
```

저장소가 이미 쓰는 형태다 — `server_routes_http_routes_workspace.ml:292-299` (`path_within`), `server_dashboard_http_keeper_api.ml:270-278`, `config/playground_paths.ml:93,151`.

## 검증 — 세 상태를 모두 실측했다

테스트를 **가드 수정 전에** 넣고 세 코드 상태에서 각각 돌렸다.

| 코드 | `HOME sibling allowed` | `HOME=/ blocks everything` |
|---|---|---|
| `origin/main` | **FAIL** | OK |
| #27570 형태 | OK | **FAIL** |
| 이 PR | OK | OK |

`HOME=/` 케이스가 #27570 형태에서 낸 실패:

```
> [FAIL]  guard  5  HOME=/ blocks everything.
ASSERT expected Test_isolation_breach with HOME=/, but wrote
       "/var/folders/.../masc-9021-root-31007.txt"
```

즉 새 테스트는 "고치려는 결함" 과 "고치다 열릴 수 있는 구멍" 을 둘 다 고정한다.

수정 후 7/7 통과, RC=0.

기존 4개 케이스(HOME 하위 차단 3건, 임시디렉터리 허용 1건)는 세 상태 모두에서 통과했다 — 이 변경이 기존에 덮인 동작을 바꾸지 않는다는 뜻이다.
