### PR TITLE
fix(link-preview): 페처가 가져갈 모든 URL 을 승인 대상으로 (#27574 대체)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -924,6 +924,15 @@ jobs:
             @test/runtest-test_tool_task_coverage \
             @test/runtest-test_tool_workspace_coverage
 
+      - name: Run link preview address admission suite
+        # The admission decides whether a dashboard-supplied URL may leave the
+        # process, and it now runs on every redirect hop rather than the first
+        # URL only. @check compiles these cases but does not run them, and the
+        # suite had no address cases at all before this.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_dashboard_link_preview
+
       - name: Run completion-authority lookup surface suite
         # The judge's lookup tools reach the filesystem and Git inside a
         # producer's root. @check compiles the containment cases but does not

--- a/lib/server/server_dashboard_http_link_preview.ml
+++ b/lib/server/server_dashboard_http_link_preview.ml
@@ -74,7 +74,27 @@ let is_http_scheme = function
 let is_loopback_or_unspecified_host host =
   Server_auth.is_loopback_host host || Server_auth.is_unspecified_host host
 
-let ipaddr_is_private_or_reserved = function
+(* An IPv4 address carried inside a V6 one is invisible to the V6 range checks
+   below, because those match on the rendered text and every carrier form
+   renders starting with "::".  [::ffff:169.254.169.254] renders as
+   "::ffff:169.254.169.254", matches no prefix in that list, and so passed a
+   filter whose V4 rules reject 169.254.0.0/16.  Hand both the mapped form and
+   the deprecated compatible form (RFC 4291 §2.5.5.1) back to the V4 rules
+   rather than restating those ranges here. *)
+let embedded_v4 addr =
+  match Ipaddr.v4_of_v6 addr with
+  | Some _ as mapped -> mapped
+  | None ->
+    let octets = Ipaddr.V6.to_octets addr in
+    let rec leading_zeros i = i >= 12 || (Char.code octets.[i] = 0 && leading_zeros (i + 1)) in
+    if leading_zeros 0
+    then (
+      match Ipaddr.V4.of_octets (String.sub octets 12 4) with
+      | Ok v4 -> Some v4
+      | Error _ -> None)
+    else None
+
+let rec ipaddr_is_private_or_reserved = function
   | Ipaddr.V4 addr ->
       let octets = Ipaddr.V4.to_octets addr in
       let byte idx = Char.code octets.[idx] in
@@ -92,17 +112,20 @@ let ipaddr_is_private_or_reserved = function
       || (b0 = 203 && b1 = 0)
       || b0 >= 224
   | Ipaddr.V6 addr ->
-      let text = Ipaddr.V6.to_string addr |> String.lowercase_ascii in
-      Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0
-      || Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
-      || String.starts_with ~prefix:"fc" text
-      || String.starts_with ~prefix:"fd" text
-      || String.starts_with ~prefix:"fe8" text
-      || String.starts_with ~prefix:"fe9" text
-      || String.starts_with ~prefix:"fea" text
-      || String.starts_with ~prefix:"feb" text
-      || String.starts_with ~prefix:"ff" text
-      || String.starts_with ~prefix:"2001:db8" text
+    (match embedded_v4 addr with
+     | Some v4 -> ipaddr_is_private_or_reserved (Ipaddr.V4 v4)
+     | None ->
+       let text = Ipaddr.V6.to_string addr |> String.lowercase_ascii in
+       Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0
+       || Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
+       || String.starts_with ~prefix:"fc" text
+       || String.starts_with ~prefix:"fd" text
+       || String.starts_with ~prefix:"fe8" text
+       || String.starts_with ~prefix:"fe9" text
+       || String.starts_with ~prefix:"fea" text
+       || String.starts_with ~prefix:"feb" text
+       || String.starts_with ~prefix:"ff" text
+       || String.starts_with ~prefix:"2001:db8" text)
 
 let eio_ipaddr_is_private_or_reserved ip =
   let rendered = Fmt.str "%a" Eio.Net.Ipaddr.pp ip in
@@ -269,16 +292,33 @@ let fetch_response ~net:_ ~url =
       ]
     ()
 
+(* A [Location] target is a URL this process will fetch, so it has to clear the
+   same admission the caller-supplied URL cleared. Only the first URL was
+   checked, so a public host could answer 302 and send the fetch to an address
+   the filter exists to keep it away from. Scheme and userinfo are re-checked
+   too: [normalize_request_url] guards those for the first URL only, and a
+   redirect can name any scheme. *)
+let admit_redirect_target ~net ~base_url location =
+  let next_url = resolve_relative_url ~base_url location in
+  match normalize_request_url next_url with
+  | Error reason -> Error reason
+  | Ok normalized -> (
+      match validate_resolved_host ~net (Uri.of_string normalized) with
+      | Error reason -> Error reason
+      | Ok () -> Ok normalized)
+
 let rec fetch_response_following_redirects ~net ~url ~remaining_redirects =
   match fetch_response ~net ~url with
   | Error _ as error -> error
   | Ok response when is_redirect_status response.status && remaining_redirects > 0
     ->
       (match list_header_ci response.headers "location" with
-       | Some location when Option.is_some (String_util.trim_to_option location) ->
-           let next_url = resolve_relative_url ~base_url:url location in
-           fetch_response_following_redirects ~net ~url:next_url
-             ~remaining_redirects:(remaining_redirects - 1)
+       | Some location when Option.is_some (String_util.trim_to_option location) -> (
+           match admit_redirect_target ~net ~base_url:url location with
+           | Error reason -> Error reason
+           | Ok next_url ->
+               fetch_response_following_redirects ~net ~url:next_url
+                 ~remaining_redirects:(remaining_redirects - 1))
        | _ -> Ok response)
   | Ok response -> Ok response
 

--- a/lib/server/server_dashboard_http_link_preview.mli
+++ b/lib/server/server_dashboard_http_link_preview.mli
@@ -39,6 +39,33 @@ type preview_extract = {
 
 (** {1 URL helpers} *)
 
+val ipaddr_is_private_or_reserved : Ipaddr.t -> bool
+(** [true] when the address must not be fetched: loopback,
+    RFC 1918, link-local, carrier-grade NAT, multicast, and
+    the documentation ranges.  A [false] here is what lets a
+    request leave the process.
+
+    A V6 address carrying an IPv4 one — the mapped
+    [::ffff:a.b.c.d] form or the deprecated compatible
+    [::a.b.c.d] form — is judged by the IPv4 rules, since the
+    V6 ranges cannot see the address inside it. *)
+
+val admit_redirect_target
+  :  net:_ Eio.Net.t
+  -> base_url:string
+  -> string
+  -> (string, string) result
+(** [admit_redirect_target ~net ~base_url location] resolves a
+    [Location] value against [base_url] and applies the same
+    admission the first URL gets: http/https only, no
+    userinfo, and no resolved address that
+    {!ipaddr_is_private_or_reserved} rejects.  Returns the
+    absolute URL to fetch next, or [Error reason].
+
+    The fetcher follows redirects, so each hop passes through
+    here; checking only the first URL let a public host
+    redirect the fetch to an internal address. *)
+
 val normalize_request_url : string -> (string, string) result
 (** Trims, parses, and normalizes a request URL.  Returns
     [Error reason] when the input is empty, missing a host,

--- a/test/dune
+++ b/test/dune
@@ -623,7 +623,8 @@
   test_workspace_handoff_boundary
   test_exec_command_gate_log_sink)
  (libraries
-  masc_test_deps masc_schedule multimodal bigstringaf masc.keeper_checkpoint_ref))
+  masc_test_deps masc_schedule multimodal bigstringaf masc.keeper_checkpoint_ref
+  ipaddr eio_main))
 
 ; Repository catalog tests depend only on the focused repo_manager library.
 (test

--- a/test/test_dashboard_link_preview.ml
+++ b/test/test_dashboard_link_preview.ml
@@ -50,6 +50,73 @@ let test_normalize_request_url_rejects_non_http () =
   | Ok value ->
       failf "expected non-http URL to be rejected, got %s" value
 
+module LP = Server_dashboard_http_link_preview
+
+let check_addr expected raw =
+  match Ipaddr.of_string raw with
+  | Error _ -> failf "test input %S did not parse as an IP address" raw
+  | Ok ip ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s blocked" raw)
+        expected
+        (LP.ipaddr_is_private_or_reserved ip)
+
+(* The V6 arm matched on the rendered address, and every IPv4-carrying form
+   renders starting with "::", so none of its prefixes could see the address
+   inside. ::ffff:169.254.169.254 passed a filter whose V4 arm rejects
+   169.254.0.0/16. *)
+let test_v4_inside_v6_is_blocked () =
+  List.iter (check_addr true)
+    [
+      "::ffff:127.0.0.1";
+      "::ffff:169.254.169.254";
+      "::ffff:10.0.0.1";
+      "::ffff:192.168.1.1";
+      "::ffff:172.16.0.1";
+      "::ffff:100.64.0.1";
+      "::127.0.0.1";
+    ]
+
+let test_native_v6_ranges_stay_blocked () =
+  List.iter (check_addr true)
+    [ "::1"; "::"; "fe80::1"; "febf::1"; "fc00::1"; "fd00::1"; "ff02::1"; "2001:db8::1" ]
+
+let test_public_addresses_stay_allowed () =
+  List.iter (check_addr false)
+    [ "8.8.8.8"; "1.1.1.1"; "2001:4860:4860::8888"; "::ffff:8.8.8.8" ]
+
+(* Literal addresses only, so [getaddrinfo] answers locally and the suite does
+   not reach the network. Nothing is fetched here -- admission runs before the
+   request. *)
+let with_net f = Eio_main.run (fun env -> f (Eio.Stdenv.net env))
+
+let base = "http://example.invalid/page"
+
+let test_redirect_to_blocked_target_is_rejected () =
+  with_net (fun net ->
+      List.iter
+        (fun location ->
+          match LP.admit_redirect_target ~net ~base_url:base location with
+          | Error _ -> ()
+          | Ok next ->
+              Alcotest.failf
+                "expected redirect to %S to be rejected, admitted as %S" location
+                next)
+        [
+          "http://127.0.0.1/";
+          "http://169.254.169.254/latest/meta-data/";
+          "http://10.0.0.1/";
+          "file:///etc/passwd";
+          "http://user:pw@8.8.8.8/";
+        ])
+
+let test_redirect_to_public_target_is_admitted () =
+  with_net (fun net ->
+      match LP.admit_redirect_target ~net ~base_url:base "http://8.8.8.8/next" with
+      | Ok _ -> ()
+      | Error reason ->
+          Alcotest.failf "expected public redirect target to be admitted: %s" reason)
+
 let () =
   Alcotest.run "dashboard_link_preview"
     [
@@ -60,5 +127,15 @@ let () =
           test_case "image url detection" `Quick test_image_url_detection;
           test_case "normalize rejects non-http" `Quick
             test_normalize_request_url_rejects_non_http;
+          test_case "IPv4 inside IPv6 is blocked" `Quick
+            test_v4_inside_v6_is_blocked;
+          test_case "native v6 ranges stay blocked" `Quick
+            test_native_v6_ranges_stay_blocked;
+          test_case "public addresses stay allowed" `Quick
+            test_public_addresses_stay_allowed;
+          test_case "redirect to blocked target is rejected" `Quick
+            test_redirect_to_blocked_target_is_rejected;
+          test_case "redirect to public target is admitted" `Quick
+            test_redirect_to_public_target_is_admitted;
         ] );
     ]


### PR DESCRIPTION
## 이 PR 은 #27574 를 대체한다

#27574 는 P0 NON-PASS 로 닫혔다. **판정이 맞다.** 나는 주소 분류의 구멍 하나를 막고 SSRF 를 고쳤다고 썼지만, 정작 큰 구멍은 그대로였다.

```ocaml
(* fetch_preview:316 — 첫 URL 만 검사 *)
match validate_resolved_host ~net (Uri.of_string normalized_url) with
...
(* :328 — 그리고 2 홉을 무검사로 따라간다 *)
fetch_response_following_redirects ~net ~url:normalized_url ~remaining_redirects:2
```

`fetch_response_following_redirects:272-283` 는 `Location` 을 `resolve_relative_url` 로 절대화한 뒤 **곧바로 다시 가져온다.** 공인 호스트가 302 로 `169.254.169.254` 를 가리키면 따라간다.

## 변경 1 — 모든 홉을 승인 대상으로

`admit_redirect_target` 이 첫 URL 과 **같은 세 검사**를 홉마다 적용한다.

- http/https 만 (`normalize_request_url`)
- userinfo 금지 (동)
- 해석된 주소가 `ipaddr_is_private_or_reserved` 에 걸리지 않을 것 (`validate_resolved_host`)

scheme 과 userinfo 를 다시 보는 이유는 `normalize_request_url` 이 첫 URL 에만 걸리기 때문이다. 리다이렉트는 어떤 scheme 이든 지목할 수 있다.

## 변경 2 — 필터가 v6 안의 IPv4 를 보게

V6 분기가 렌더된 문자열 접두사를 비교했고, IPv4 를 품은 형태는 전부 `"::"` 로 시작해 어떤 접두사에도 안 걸렸다. 지난 회차에 `Ipaddr` 로 직접 실측한 값이다.

```
::ffff:169.254.169.254  render="::ffff:169.254.169.254"  blocked=false
::ffff:127.0.0.1        render="::ffff:127.0.0.1"        blocked=false
::127.0.0.1             render="::7f00:1"                blocked=false
```

mapped 형태와 폐기된 compatible 형태를 V4 규칙으로 돌려보낸다. **`Ipaddr.is_private` 로 교체하지 않았다** — 실측상 `fc00::1` 과 `2001:db8::1` 에 `false` 를 주므로 위임하면 필터가 넓어진다.

## 검증 — 증명한 것과 못 한 것을 구분한다

**증명한 것**

- 8/8 통과, `@check` RC=0.
- 리다이렉트 승인 자체: `admit_redirect_target` 이 `127.0.0.1`, `169.254.169.254`, `10.0.0.1`, `file:///etc/passwd`, `user:pw@` 를 거부하고 `8.8.8.8` 을 통과시킨다. 리터럴 주소만 써서 `getaddrinfo` 가 로컬로 답하므로 네트워크에 나가지 않고, 승인은 요청 이전이라 아무것도 가져오지 않는다.
- 주소 분류: mapped/compatible 7종 차단, 네이티브 v6 8종 차단 유지, 공인 4종 통과 유지.

**증명하지 못한 것 (중요)**

- **배선을 end-to-end 로 테스트하지 못했다.** `admit_redirect_target` 은 새 함수라 수정 전 트리에 존재하지 않고, 따라서 "수정 전에 실패한다" 는 확인이 성립하지 않는다. `fetch_response_following_redirects` 가 실제로 이 함수를 부르는지는 **diff 의 단일 호출 지점**으로만 보증된다.
- 302 를 내는 가짜 서버를 띄워 홉 전체를 도는 테스트는 만들지 않았다. 그 테스트는 수정 전후 모두 `Error` 를 내고 **사유 문자열로만** 구분되므로 별도 설계가 필요하다. 필요하다면 후속으로 만들겠다.
- DNS rebinding 은 이 PR 의 범위 밖이다. `validate_resolved_host` 가 해석한 뒤 `fetch_response` 가 다시 해석하므로 TOCTOU 가 남는다. 기존 구조에 이미 있던 성질이고 이 변경이 바꾸지 않는다.

## CI 배선

이 스위트는 `test/dune` 에 선언돼 있으나 `ci.yml` 의 runtest 목록에 없어 **여태 컴파일만 되고 실행된 적이 없다.** 전용 스텝을 추가했다. `test/dune` 병합 블록에 `ipaddr` 와 `eio_main` 을 더했다.

## 리뷰 요청

보안 경로다. 특히 위 "증명하지 못한 것" 의 첫 항목 — 배선 보증이 diff 읽기에 의존한다는 점 — 을 받아들일 수 있는지 판단해 주기 바란다.
