### PR TITLE
docs(verification): 판정자와 Keeper 는 다른 카탈로그를 읽는 게 맞다

### DIFF
--- a/lib/verification_authority_tools.ml
+++ b/lib/verification_authority_tools.ml
@@ -55,9 +55,15 @@ let ownership_root t = t.ownership_root
 (* Schemas                                                          *)
 (* ================================================================ *)
 
-(* The keeper catalog is the source. Restating a description here would let a
-   judge and a producer read different documentation for the same tool, and the
-   one that drifts is always the copy. *)
+(* [Tool_shard] is the source because it documents handler inputs, and [run]
+   below calls those handlers directly. Restating a description here would let
+   this surface drift from the arguments the handlers actually read.
+
+   It is not the catalog a Keeper is shown. Those two disagree on purpose:
+   [handle_read_file_with_outcome] reads "path", the Keeper's descriptor asks
+   for "file_path". Sourcing this from [Keeper_tool_descriptor] to make the two
+   descriptions match compiles, and turns every judge read into "path" resolving
+   to its ~default:"" — an empty path, inspected without error (#27563). *)
 let schema_of_tool tool : Types_core.tool_schema option =
   List.find_opt
     (fun (schema : Types_core.tool_schema) ->

--- a/lib/verification_authority_tools.mli
+++ b/lib/verification_authority_tools.mli
@@ -78,9 +78,21 @@ val ownership_root : t -> string
     calls resolve through the sandbox jail rather than this string. *)
 
 val schemas : t -> Types_core.tool_schema list
-(** The tool schemas to hand the evaluator, in a stable order. These are the
-    keeper schemas verbatim: a judge and a producer read the same description of
-    the same tool. *)
+(** The tool schemas to hand the evaluator, in a stable order.
+
+    These come from [Tool_shard], which documents handler inputs, because
+    [dispatch] calls the runtime handlers directly. That is a different entry
+    point from a Keeper's, and the two spell the same work differently:
+    [Keeper_tool_filesystem_runtime.handle_read_file_with_outcome] reads
+    ["path"], while the descriptor a Keeper is shown asks for ["file_path"] and
+    offers [cwd], [offset] and [limit] — arguments no caller on this path can
+    supply.
+
+    A judge and a Keeper are therefore shown different text for the same tool
+    name, and the descriptions differ because the arguments do. Serving these
+    from [Keeper_tool_descriptor] instead type-checks and builds; it also makes
+    every judge read resolve ["path"] to its [~default:""] and inspect nothing
+    (#27563). Read the handler before assuming the two catalogs should agree. *)
 
 val dispatch : t -> name:string -> args:Yojson.Safe.t -> (string, string) result
 (** Run one call against the producer's tree. [Error] carries a message meant

--- a/test/test_verification_authority_tools.ml
+++ b/test/test_verification_authority_tools.ml
@@ -113,6 +113,84 @@ let test_schemas_are_the_keeper_schemas () =
       offered)
 ;;
 
+(* The argument name the surface advertises has to be the one the handler
+   reads, and only a call proves that. [test_schemas_are_the_keeper_schemas]
+   above compares the offered schema to [Tool_shard] -- the same list
+   [schema_of_tool] reads -- so it pins the source and says nothing about
+   whether that source describes the handler behind [dispatch].
+
+   It does, and the other catalog does not. [handle_read_file_with_outcome]
+   reads "path"; the descriptor a Keeper is shown asks for "file_path".
+   Sourcing [schemas] from [Keeper_tool_descriptor] to make a judge and a Keeper
+   read one description compiles and passes every case that only inspects
+   schemas: the advertised name would become "file_path", the handler would
+   resolve "path" through its [~default:""], and each read would inspect an
+   empty path and report it as a result (#27563).
+
+   So this reads a real file under the producer's playground both ways. The
+   advertised name returns its contents; the descriptor's name is not a second
+   spelling that happens to work. *)
+let test_the_advertised_argument_is_the_one_the_handler_reads () =
+  with_surface (fun config surface ->
+    let playground =
+      Keeper_sandbox_config.host_root_abs_of_agent
+        ~base_path:
+          (Workspace_verification_store.project_root_of_base_path config.base_path)
+        ~agent_name:producer
+    in
+    let rec mkdir_p path =
+      if not (Sys.file_exists path)
+      then (
+        mkdir_p (Filename.dirname path);
+        try Unix.mkdir path 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+    in
+    mkdir_p playground;
+    let file = Filename.concat playground "advertised-argument-probe.txt" in
+    let contents = "written by the probe" in
+    (try Out_channel.with_open_text file (fun oc -> output_string oc contents) with
+     | Sys_error err -> Alcotest.failf "probe file could not be written: %s" err);
+    let read key =
+      VAT.dispatch
+        surface
+        ~name:"tool_read_file"
+        ~args:(`Assoc [ key, `String "advertised-argument-probe.txt" ])
+    in
+    let required_name =
+      match
+        List.find_opt
+          (fun (schema : Masc_domain.tool_schema) ->
+             String.equal schema.name "tool_read_file")
+          (VAT.schemas surface)
+      with
+      | Some { input_schema = `Assoc fields; _ } ->
+        (match List.assoc_opt "required" fields with
+         | Some (`List (`String name :: _)) -> name
+         | _ -> Alcotest.fail "tool_read_file advertises no required argument")
+      | _ -> Alcotest.fail "tool_read_file is not offered"
+    in
+    (match read required_name with
+     | Error detail ->
+       Alcotest.failf
+         "the advertised required argument %S did not reach the handler: %s"
+         required_name
+         detail
+     | Ok output ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%S returns the file's contents" required_name)
+         true
+         (Astring.String.is_infix ~affix:contents output));
+    let other = if String.equal required_name "path" then "file_path" else "path" in
+    match read other with
+    | Error _ -> ()
+    | Ok output when Astring.String.is_infix ~affix:contents output ->
+      Alcotest.failf
+        "%S also reads the file, so the advertised name %S is not load-bearing \
+         and a catalog swap would go unnoticed"
+        other
+        required_name
+    | Ok _ -> ())
+;;
+
 (* A judge that calls a name this surface does not offer must be told so. A
    dropped call would read to the model as a tool that returned nothing. *)
 let test_unknown_tool_name_is_an_error () =
@@ -305,6 +383,8 @@ let () =
     [ ( "surface"
       , [ Alcotest.test_case "schemas are the keeper schemas" `Quick
             test_schemas_are_the_keeper_schemas
+        ; Alcotest.test_case "the advertised argument is the one the handler reads"
+            `Quick test_the_advertised_argument_is_the_one_the_handler_reads
         ; Alcotest.test_case "unknown producer yields no surface" `Quick
             test_unknown_producer_yields_no_surface
         ] )


### PR DESCRIPTION
## 무엇을

판정자(`Verification_authority_tools.schemas`)가 왜 `Tool_shard` 를 읽는지 문서화하고,
그 이유를 테스트로 고정합니다. 동작 변경 없음.

## 왜

`verification_authority_tools.mli:81` 이 이렇게 주장합니다:

```
"These are the keeper schemas verbatim: a judge and a producer read the same
 description of the same tool."
```

**이 문장은 사실이 아니고, 사실이어서도 안 됩니다.** 저는 이 주장을 계약으로 믿고
`schema_of_tool` 이 `Keeper_tool_descriptor` 를 읽도록 고쳤습니다. **빌드가 통과했습니다.**

```
tool_read_file
  descriptor 속성: file_path(required), cwd, offset, limit
  shard      속성: path(required), max_bytes
```

그런데 `dispatch` 가 부르는 핸들러는:

```ocaml
(* keeper_tool_filesystem_runtime.ml:257 *)
let path = Safe_ops.json_string ~default:"" "path" args in
```

핸들러는 `path` 를 읽습니다. descriptor 스키마를 광고했다면 모델은 `file_path` 를 보내고,
`~default:""` 때문에 **에러 없이 빈 경로**를 읽습니다. 판정자가 아무것도 안 보고
"봤다"고 답하는 상태입니다.

판정자는 런타임 핸들러를 **직접** 부르므로 handler-input 카탈로그가 맞는 출처입니다.
Keeper 는 `file_path` 를 쓰는 다른 진입점으로 같은 핸들러에 도달합니다. **같은 이름의
두 도구가 아니라 같은 핸들러로 가는 두 진입점**이고, 인자가 다르니 설명도 달라야 합니다.

## 변경

1. `.mli` 의 `schemas` 문서를 실제 관계로 교체 — 어느 카탈로그를 왜 읽는지, 바꾸면 무엇이
   깨지는지.
2. `ml:58-60` 주석도 같이 정정 (현재 "the keeper catalog is the source" 라 다음 사람이
   같은 판단을 하게 됩니다).
3. 테스트 추가: **광고한 필수 인자 이름이 핸들러가 실제로 읽는 이름인지** 를 호출로 증명.

기존 `test_schemas_are_the_keeper_schemas` 는 `Tool_shard` 와 비교하는데, 그건
`schema_of_tool` 이 읽는 **같은 리스트**입니다. 출처는 고정하지만 그 출처가 핸들러를
기술하는지는 말하지 않습니다. 새 테스트는 producer playground 에 실제 파일을 쓰고,
광고된 required 이름으로 읽어 내용이 오는지 확인하고, 반대쪽 이름이 우연히 통하지 않는지도
확인합니다.

## 검증

```
dune build @check @fmt                                    통과
@test/runtest-test_verification_authority_tools           9 tests, Test Successful
```

**뮤테이션 테스트** — `schema_of_tool` 을 `Keeper_tool_descriptor` 로 바꾸면:

```
[FAIL]  surface  0  schemas are the keeper schemas
[FAIL]  surface  1  the advertised argument is the one the handler reads
```

새 테스트가 빨개집니다. 되돌리면 다시 초록.

CI 배선 확인: `.github/workflows/ci.yml:935` 및 `:1717` 에서 이 스위트가 실행됩니다.

## 남는 것

#27563 은 "두 카탈로그가 중복이니 합치자"로 열렸는데, 그 전제가 틀렸습니다. 이슈에 정정을
남겼고 방향을 문서 수정으로 바꿨습니다. 이 PR 이 그 절반입니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
