### PR TITLE
fix(config): fail closed on invalid agent transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1699,7 +1699,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_assertion_kind_mirror @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_keeper_catchup_digest @test/runtest-test_workspace_root_state_parity"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_assertion_kind_mirror @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_agent_transport_vocabulary @test/runtest-test_keeper_catchup_digest @test/runtest-test_workspace_root_state_parity"
 
       # Four more suites landed on main without a runtest target (persona name
       # via #26962, tool-result demotion via #27013, verification authority

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -36,6 +36,11 @@ val get_string : default:string -> string -> string
 val get_int : default:int -> string -> int
 val get_float : default:float -> string -> float
 val get_bool : default:bool -> string -> bool
+(** Report a value outside a knob's vocabulary: warns, and raises
+    {!Config_error} when [MASC_PARSE_WARN] escalates. Callers fall back to the
+    documented default afterwards. *)
+val reject_malformed_env : name:string -> raw:string -> type_name:string -> unit
+
 val get_bool_strict : default:bool -> string -> bool
 (** Like {!get_bool}, but a present non-empty malformed value always raises
     {!Config_error}. Missing and empty values still use [default]. Use at

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -36,11 +36,6 @@ val get_string : default:string -> string -> string
 val get_int : default:int -> string -> int
 val get_float : default:float -> string -> float
 val get_bool : default:bool -> string -> bool
-(** Report a value outside a knob's vocabulary: warns, and raises
-    {!Config_error} when [MASC_PARSE_WARN] escalates. Callers fall back to the
-    documented default afterwards. *)
-val reject_malformed_env : name:string -> raw:string -> type_name:string -> unit
-
 val get_bool_strict : default:bool -> string -> bool
 (** Like {!get_bool}, but a present non-empty malformed value always raises
     {!Config_error}. Missing and empty values still use [default]. Use at

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -160,7 +160,6 @@ module Transport = struct
     | Ws
     | Webrtc
     | Local
-    | Unknown_agent_transport of string
 
   let agent_transport_of_string raw =
     match normalize_token raw with
@@ -169,7 +168,15 @@ module Transport = struct
     | "ws" | "websocket" -> Ws
     | "webrtc" -> Webrtc
     | "local" -> Local
-    | other -> Unknown_agent_transport other
+    | _ ->
+      (* Carrying the raw text let an unrecognized setting reach
+         Masc_grpc_transport, which folded it into Local alongside "unset" —
+         a typo and a deliberate default became the same state. *)
+      Env_config_core.reject_malformed_env
+        ~name:"MASC_AGENT_TRANSPORT"
+        ~raw
+        ~type_name:"http|grpc|ws|websocket|webrtc|local";
+      Local
 
   let agent_transport_to_string = function
     | Http -> "http"
@@ -177,7 +184,6 @@ module Transport = struct
     | Ws -> "ws"
     | Webrtc -> "webrtc"
     | Local -> "local"
-    | Unknown_agent_transport value -> value
 
   (** gRPC server port. Default: 8936. *)
   let grpc_port = get_port ~default:8936 "MASC_GRPC_PORT"

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -154,37 +154,6 @@ module Transport = struct
     | H2_only -> "h2_only"
     | Unknown_h2_mode value -> value
 
-  type agent_transport =
-    | Http
-    | Grpc
-    | Ws
-    | Webrtc
-    | Local
-
-  let agent_transport_of_string raw =
-    match normalize_token raw with
-    | "http" -> Http
-    | "grpc" -> Grpc
-    | "ws" | "websocket" -> Ws
-    | "webrtc" -> Webrtc
-    | "local" -> Local
-    | _ ->
-      (* Carrying the raw text let an unrecognized setting reach
-         Masc_grpc_transport, which folded it into Local alongside "unset" —
-         a typo and a deliberate default became the same state. *)
-      Env_config_core.reject_malformed_env
-        ~name:"MASC_AGENT_TRANSPORT"
-        ~raw
-        ~type_name:"http|grpc|ws|websocket|webrtc|local";
-      Local
-
-  let agent_transport_to_string = function
-    | Http -> "http"
-    | Grpc -> "grpc"
-    | Ws -> "ws"
-    | Webrtc -> "webrtc"
-    | Local -> "local"
-
   (** gRPC server port. Default: 8936. *)
   let grpc_port = get_port ~default:8936 "MASC_GRPC_PORT"
 
@@ -212,12 +181,6 @@ module Transport = struct
     match Sys.getenv_opt "MASC_USE_H2" |> trim_opt with
     | Some raw -> h2_mode_of_string raw
     | None -> Auto
-
-  (** Agent transport type variant (e.g. "grpc", "http", "ws"). *)
-  let agent_transport_opt () =
-    Sys.getenv_opt "MASC_AGENT_TRANSPORT"
-    |> trim_opt
-    |> Option.map agent_transport_of_string
 
   (** Force strict auth for all HTTP endpoints. Default: false.
 

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -90,7 +90,6 @@ module Transport : sig
     | Ws
     | Webrtc
     | Local
-    | Unknown_agent_transport of string
 
   val agent_transport_of_string : string -> agent_transport
   val agent_transport_to_string : agent_transport -> string

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -84,16 +84,6 @@ module Transport : sig
   val h2_mode_of_string : string -> h2_mode
   val h2_mode_to_string : h2_mode -> string
 
-  type agent_transport =
-    | Http
-    | Grpc
-    | Ws
-    | Webrtc
-    | Local
-
-  val agent_transport_of_string : string -> agent_transport
-  val agent_transport_to_string : agent_transport -> string
-
   val grpc_port : int
   val grpc_enabled : unit -> bool
   val grpc_target_opt : unit -> string option
@@ -101,7 +91,6 @@ module Transport : sig
   val ws_enabled : unit -> bool
   val webrtc_enabled : unit -> bool
   val use_h2 : unit -> h2_mode
-  val agent_transport_opt : unit -> agent_transport option
   val http_auth_strict_env_enabled : unit -> bool
   val startup_watchdog_sec : unit -> float
 end

--- a/lib/config/masc_grpc_transport.ml
+++ b/lib/config/masc_grpc_transport.ml
@@ -7,14 +7,40 @@ type t =
   | Webrtc
   | Local
 
-let from_env () =
-  match Env_config.Transport.agent_transport_opt () with
-  | Some Env_config.Transport.Grpc -> Grpc
-  | Some Env_config.Transport.Http -> Http
-  | Some Env_config.Transport.Ws -> Ws
-  | Some Env_config.Transport.Webrtc -> Webrtc
-  | Some Env_config.Transport.Local -> Local
+let of_env_value raw =
+  match raw with
+  | "http" -> Http
+  | "grpc" -> Grpc
+  | "ws" -> Ws
+  | "webrtc" -> Webrtc
+  | "local" -> Local
+  | _ ->
+    raise
+      (Env_config_core.Config_error
+         (Printf.sprintf
+            "malformed env MASC_AGENT_TRANSPORT=%S (expected http|grpc|ws|webrtc|local)"
+            raw))
+;;
+
+let read_env () =
+  match Sys.getenv_opt "MASC_AGENT_TRANSPORT" with
   | None -> Local
+  | Some raw -> of_env_value raw
+;;
+
+let configured = Atomic.make None
+
+let configure_from_env () =
+  let transport = read_env () in
+  Atomic.set configured (Some transport);
+  transport
+;;
+
+let from_env () =
+  match Atomic.get configured with
+  | Some transport -> transport
+  | None -> read_env ()
+;;
 
 let to_string = function
   | Http -> "http"
@@ -22,3 +48,4 @@ let to_string = function
   | Ws -> "ws"
   | Webrtc -> "webrtc"
   | Local -> "local"
+;;

--- a/lib/config/masc_grpc_transport.ml
+++ b/lib/config/masc_grpc_transport.ml
@@ -30,10 +30,14 @@ let read_env () =
 
 let configured = Atomic.make None
 
-let configure_from_env () =
-  let transport = read_env () in
-  Atomic.set configured (Some transport);
-  transport
+let rec configure_from_env () =
+  match Atomic.get configured with
+  | Some transport -> transport
+  | None ->
+    let transport = read_env () in
+    if Atomic.compare_and_set configured None (Some transport)
+    then transport
+    else configure_from_env ()
 ;;
 
 let from_env () =

--- a/lib/config/masc_grpc_transport.ml
+++ b/lib/config/masc_grpc_transport.ml
@@ -14,7 +14,7 @@ let from_env () =
   | Some Env_config.Transport.Ws -> Ws
   | Some Env_config.Transport.Webrtc -> Webrtc
   | Some Env_config.Transport.Local -> Local
-  | Some (Env_config.Transport.Unknown_agent_transport _) | None -> Local
+  | None -> Local
 
 let to_string = function
   | Http -> "http"

--- a/lib/config/masc_grpc_transport.mli
+++ b/lib/config/masc_grpc_transport.mli
@@ -12,8 +12,10 @@ type t =
     present value must exactly match [http], [grpc], [ws], [webrtc], or [local]. *)
 val from_env : unit -> t
 
-(** Resolve [MASC_AGENT_TRANSPORT] and retain that typed value for subsequent
-    {!from_env} calls in this process. Server startup calls this once. *)
+(** Resolve [MASC_AGENT_TRANSPORT] and publish the first typed value for all
+    subsequent calls in this process. Concurrent or repeated calls return the
+    first published value. Server startup calls this before creating fibers or
+    listeners. *)
 val configure_from_env : unit -> t
 
 (** String representation for logging. *)

--- a/lib/config/masc_grpc_transport.mli
+++ b/lib/config/masc_grpc_transport.mli
@@ -1,14 +1,4 @@
-(** MASC Agent Transport — protocol selection for MASC workspace.
-
-    Agents communicate with the MASC workspace server via one of:
-    - [Http] — existing HTTP/SSE transport (default, backward compatible).
-    - [Grpc] — gRPC transport using grpc-direct h2c.
-    - [Local] — direct filesystem-based Workspace calls (in-process).
-
-    Selection order:
-    1. Explicit [~transport] parameter on API calls.
-    2. [MASC_AGENT_TRANSPORT] env var ("grpc", "http", "local").
-    3. Default: [Local] (file-based, same as before). *)
+(** MASC agent transport selection. *)
 
 (** Transport kind. *)
 type t =
@@ -18,9 +8,13 @@ type t =
   | Webrtc  (** WebRTC DataChannel for P2P agent communication. *)
   | Local   (** Direct Workspace filesystem calls (in-process). *)
 
-(** Resolve transport from env var [MASC_AGENT_TRANSPORT].
-    Returns [Local] when unset or unrecognized. *)
+(** Resolve [MASC_AGENT_TRANSPORT]. An absent variable selects [Local]; every
+    present value must exactly match [http], [grpc], [ws], [webrtc], or [local]. *)
 val from_env : unit -> t
+
+(** Resolve [MASC_AGENT_TRANSPORT] and retain that typed value for subsequent
+    {!from_env} calls in this process. Server startup calls this once. *)
+val configure_from_env : unit -> t
 
 (** String representation for logging. *)
 val to_string : t -> string

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1454,7 +1454,7 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
       Masc_grpc_server.start ~sw ~env ~workspace_config:(Mcp_server.workspace_config state)
         ~tool_dispatcher;
       (* Initialize gRPC client for keeper heartbeat when transport is gRPC *)
-      (match Masc_grpc_transport.from_env () with
+      (match Masc_grpc_transport.configure_from_env () with
        | Masc_grpc_transport.Grpc ->
            (try
               let client = Masc_grpc_client.create_from_env ~sw ~env in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1306,6 +1306,7 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
   let clock, mono_clock, net, domain_mgr, proc_mgr, fs =
     init_runtime_context env
   in
+  let configured_agent_transport = Masc_grpc_transport.configure_from_env () in
   (* Route OAS provider diagnostics into the structured log before any
      provider call runs (#25148). *)
   Agent_sdk_diag_sink.install ();
@@ -1454,7 +1455,7 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
       Masc_grpc_server.start ~sw ~env ~workspace_config:(Mcp_server.workspace_config state)
         ~tool_dispatcher;
       (* Initialize gRPC client for keeper heartbeat when transport is gRPC *)
-      (match Masc_grpc_transport.configure_from_env () with
+      (match configured_agent_transport with
        | Masc_grpc_transport.Grpc ->
            (try
               let client = Masc_grpc_client.create_from_env ~sw ~env in

--- a/test/dune
+++ b/test/dune
@@ -1634,6 +1634,8 @@
 ; add one (include stanzas/test_name.inc) line below,
 ; sorted alphabetically.
 
+(include stanzas/test_agent_transport_vocabulary.inc)
+
 (include stanzas/test_anti_rationalization_empty_reject.inc)
 (include stanzas/test_dedup_rules.inc)
 (include stanzas/test_jsonl_retention_window.inc)

--- a/test/stanzas/test_agent_transport_vocabulary.inc
+++ b/test/stanzas/test_agent_transport_vocabulary.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_agent_transport_vocabulary)
+ (modules test_agent_transport_vocabulary)
+ (libraries alcotest masc masc.config masc_test_deps))

--- a/test/test_agent_transport_vocabulary.ml
+++ b/test/test_agent_transport_vocabulary.ml
@@ -50,7 +50,9 @@ let configured_value_is_stable () =
   with_env (Some "grpc") (fun () ->
     check string "configured" "grpc" (T.configure_from_env () |> T.to_string));
   with_env (Some "local") (fun () ->
-    check string "retained" "grpc" (T.from_env () |> T.to_string))
+    check string "retained" "grpc" (T.from_env () |> T.to_string);
+    check string "configure is one-shot" "grpc"
+      (T.configure_from_env () |> T.to_string))
 ;;
 
 let () =

--- a/test/test_agent_transport_vocabulary.ml
+++ b/test/test_agent_transport_vocabulary.ml
@@ -1,51 +1,66 @@
-(** [MASC_AGENT_TRANSPORT] carries a closed vocabulary.
-
-    An unrecognized value used to become [Unknown_agent_transport raw].
-    Masc_grpc_transport folded that into [Local] on the same arm as [None], so
-    a typo and "operator did not set it" reached the runtime as the same
-    state, with nothing reported. *)
+(** Exact [MASC_AGENT_TRANSPORT] admission and process snapshot contract. *)
 
 open Alcotest
 
-module T = Env_config.Transport
+module T = Masc_grpc_transport
 
-let spelling s = T.agent_transport_to_string (T.agent_transport_of_string s)
+let with_env value_opt f =
+  let name = "MASC_AGENT_TRANSPORT" in
+  let previous = Sys.getenv_opt name in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some value -> Unix.putenv name value
+      | None -> Unix.unsetenv name)
+    (fun () ->
+      (match value_opt with
+       | Some value -> Unix.putenv name value
+       | None -> Unix.unsetenv name);
+      f ())
+;;
+
+let spelling () = T.from_env () |> T.to_string
 
 let accepted_spellings () =
   List.iter
-    (fun (raw, expected) -> check string raw expected (spelling raw))
-    [ "http", "http"
-    ; "grpc", "grpc"
-    ; "ws", "ws"
-    ; "websocket", "ws"
-    ; "webrtc", "webrtc"
-    ; "local", "local"
-    ; "  GRPC  ", "grpc"
-    ]
+    (fun raw ->
+       with_env (Some raw) (fun () -> check string raw raw (spelling ())))
+    [ "http"; "grpc"; "ws"; "webrtc"; "local" ]
 ;;
 
-(* Whatever the operator typed, the value leaving the parser must be one the
-   runtime knows. *)
-let unknown_input_stays_in_vocabulary () =
+let invalid_values_are_rejected () =
   List.iter
     (fun raw ->
-       check
-         bool
-         ("in vocabulary: " ^ raw)
-         true
-         (List.mem (spelling raw) [ "http"; "grpc"; "ws"; "webrtc"; "local" ]))
-    [ "gprc"; "web-rtc"; "tcp"; ""; "http2" ]
+       with_env (Some raw) (fun () ->
+         check_raises
+           ("reject " ^ raw)
+           (Env_config_core.Config_error
+              (Printf.sprintf
+                 "malformed env MASC_AGENT_TRANSPORT=%S (expected http|grpc|ws|webrtc|local)"
+                 raw))
+           (fun () -> ignore (T.from_env ()))))
+    [ ""; "gprc"; "websocket"; " GRPC "; "Grpc" ]
 ;;
 
-let unknown_reads_as_local () = check string "typo" "local" (spelling "gprc")
+let absent_value_selects_local () =
+  with_env None (fun () -> check string "absent" "local" (spelling ()))
+;;
+
+let configured_value_is_stable () =
+  with_env (Some "grpc") (fun () ->
+    check string "configured" "grpc" (T.configure_from_env () |> T.to_string));
+  with_env (Some "local") (fun () ->
+    check string "retained" "grpc" (T.from_env () |> T.to_string))
+;;
 
 let () =
   run
     "agent_transport_vocabulary"
     [ ( "vocabulary"
-      , [ test_case "accepted spellings map as documented" `Quick accepted_spellings
-        ; test_case "unknown input stays in vocabulary" `Quick unknown_input_stays_in_vocabulary
-        ; test_case "unknown input reads as local" `Quick unknown_reads_as_local
+      , [ test_case "accepted values" `Quick accepted_spellings
+        ; test_case "invalid present values fail" `Quick invalid_values_are_rejected
+        ; test_case "absent selects local" `Quick absent_value_selects_local
+        ; test_case "configured value is retained" `Quick configured_value_is_stable
         ] )
     ]
 ;;

--- a/test/test_agent_transport_vocabulary.ml
+++ b/test/test_agent_transport_vocabulary.ml
@@ -1,0 +1,51 @@
+(** [MASC_AGENT_TRANSPORT] carries a closed vocabulary.
+
+    An unrecognized value used to become [Unknown_agent_transport raw].
+    Masc_grpc_transport folded that into [Local] on the same arm as [None], so
+    a typo and "operator did not set it" reached the runtime as the same
+    state, with nothing reported. *)
+
+open Alcotest
+
+module T = Env_config.Transport
+
+let spelling s = T.agent_transport_to_string (T.agent_transport_of_string s)
+
+let accepted_spellings () =
+  List.iter
+    (fun (raw, expected) -> check string raw expected (spelling raw))
+    [ "http", "http"
+    ; "grpc", "grpc"
+    ; "ws", "ws"
+    ; "websocket", "ws"
+    ; "webrtc", "webrtc"
+    ; "local", "local"
+    ; "  GRPC  ", "grpc"
+    ]
+;;
+
+(* Whatever the operator typed, the value leaving the parser must be one the
+   runtime knows. *)
+let unknown_input_stays_in_vocabulary () =
+  List.iter
+    (fun raw ->
+       check
+         bool
+         ("in vocabulary: " ^ raw)
+         true
+         (List.mem (spelling raw) [ "http"; "grpc"; "ws"; "webrtc"; "local" ]))
+    [ "gprc"; "web-rtc"; "tcp"; ""; "http2" ]
+;;
+
+let unknown_reads_as_local () = check string "typo" "local" (spelling "gprc")
+
+let () =
+  run
+    "agent_transport_vocabulary"
+    [ ( "vocabulary"
+      , [ test_case "accepted spellings map as documented" `Quick accepted_spellings
+        ; test_case "unknown input stays in vocabulary" `Quick unknown_input_stays_in_vocabulary
+        ; test_case "unknown input reads as local" `Quick unknown_reads_as_local
+        ] )
+    ]
+;;

--- a/test/test_grpc_client.ml
+++ b/test/test_grpc_client.ml
@@ -169,13 +169,12 @@ let test_status_response_roundtrip () =
 (* ====== Transport selection tests ====== *)
 
 let test_transport_from_env_default () =
-  (* When MASC_AGENT_TRANSPORT is not set, should return Local *)
   let saved = Sys.getenv_opt "MASC_AGENT_TRANSPORT" in
-  Unix.putenv "MASC_AGENT_TRANSPORT" "";
+  Unix.unsetenv "MASC_AGENT_TRANSPORT";
   let t = Masc_grpc_transport.from_env () in
   (match saved with
    | Some v -> Unix.putenv "MASC_AGENT_TRANSPORT" v
-   | None -> Unix.putenv "MASC_AGENT_TRANSPORT" "");
+   | None -> Unix.unsetenv "MASC_AGENT_TRANSPORT");
   Alcotest.(check string) "default is local"
     "local" (Masc_grpc_transport.to_string t)
 


### PR DESCRIPTION
## Contract

`MASC_AGENT_TRANSPORT` has one owner: `Masc_grpc_transport`.

- absent: `Local`
- exact `http`, `grpc`, `ws`, `webrtc`, or `local`: the matching typed transport
- every other present value, including empty, differently cased, whitespace-padded, or alias text: unconditional `Config_error`

`server_runtime_bootstrap.run` publishes this typed value immediately after obtaining the runtime context and before it creates a socket, starts a fiber, or initializes owner/Keeper state. `configure_from_env` uses compare-and-set; the first published value wins and repeated or concurrent calls cannot overwrite it. All later `from_env` consumers read that process snapshot.

The duplicate `Env_config.Transport.agent_transport` type, parser, serializer, and facade mapping are removed.

## Verification

- `ocamlformat` on all changed OCaml sources: pass
- `ocamlc -stop-after parsing` on changed implementations and tests: pass
- `git diff --check`: pass
- focused Dune tests: not started because `scripts/dune-local.sh` detected unrelated bare Dune processes and refused to bypass the shared resource guard; fresh PR CI is the build authority

The focused suite covers every accepted value, absent input, invalid present values, and one-shot retention of the boot-resolved transport after the environment changes.
