### PR TITLE
fix(benchmark): enforce exact run outcome contract

### DIFF
--- a/lib/keeper_benchmark_canary.ml
+++ b/lib/keeper_benchmark_canary.ml
@@ -21,7 +21,7 @@ let row_to_recommendation
   | Some provider, Some model, Some keeper_profile
     when row.cases_total > 0
          && row.cases_passed = row.cases_total
-         && row.unsupported_runs = 0
+         && row.executed_failed_runs = 0
          && row.runtime_unreachable_runs = 0 ->
       Some
         {

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
@@ -17,12 +17,15 @@ let rec map_m f = function
       let* ys = map_m f xs in
       Ok (y :: ys)
 
+(* Every summary compares status by equality against a known constructor, so a
+   status outside this set leaves the run out of every total. Reject it here,
+   the way the sibling category parser below does. *)
 let run_status_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
-  | "" | "ok" -> Run_ok
-  | "unsupported" -> Run_unsupported
-  | "runtime_unreachable" -> Run_runtime_unreachable
-  | other -> Run_other other
+  | "" | "ok" -> Ok Run_ok
+  | "unsupported" -> Ok Run_unsupported
+  | "runtime_unreachable" -> Ok Run_runtime_unreachable
+  | other -> errorf "unknown tool-call-quality run status: %s" other
 
 let case_category_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
@@ -179,6 +182,9 @@ let evidence_run_of_yojson json =
   let* model = required_string_field json "model" in
   let* keeper_profile = required_string_field json "keeper_profile" in
   let* tool_call_items = list_field json "tool_calls" in
+  let* status =
+    Json_util.get_string json "status" |> Option.value ~default:"ok" |> run_status_of_string
+  in
   Ok {
     case_id;
     provider;
@@ -194,9 +200,7 @@ let evidence_run_of_yojson json =
     input_tokens = Json_util.get_int json "input_tokens";
     output_tokens = Json_util.get_int json "output_tokens";
     cost_usd = Json_util.get_float json "cost_usd";
-    status =
-      Json_util.get_string json "status" |> Option.value ~default:"ok"
-      |> run_status_of_string;
+    status;
     tool_calls = List.map tool_call_of_yojson tool_call_items;
   }
 

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
@@ -17,15 +17,12 @@ let rec map_m f = function
       let* ys = map_m f xs in
       Ok (y :: ys)
 
-(* Every summary compares status by equality against a known constructor, so a
-   status outside this set leaves the run out of every total. Reject it here,
-   the way the sibling category parser below does. *)
 let run_status_of_string raw =
-  match String.trim (String.lowercase_ascii raw) with
-  | "" | "ok" -> Ok Run_ok
-  | "unsupported" -> Ok Run_unsupported
+  match raw with
+  | "ok" -> Ok Run_ok
+  | "executed_failed" -> Ok Run_executed_failed
   | "runtime_unreachable" -> Ok Run_runtime_unreachable
-  | other -> errorf "unknown tool-call-quality run status: %s" other
+  | other -> errorf "unknown tool-call-quality run status: %S" other
 
 let case_category_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
@@ -86,9 +83,7 @@ let parse_arg_check json =
         (match Eval_tool_selector.of_yojson value with
          | Ok selector -> Ok selector
          | Error msg -> errorf "invalid arg_check selector: %s" msg)
-    | None ->
-        let* tool_name = required_string_field json "tool_name" in
-        Ok (Eval_tool_selector.Tool_name tool_name)
+    | None -> errorf "missing required selector field"
   in
   let* path = required_string_field json "path" in
   Ok {
@@ -164,11 +159,9 @@ let benchmark_case_of_yojson json =
   }
 
 let tool_call_of_yojson json =
-  {
-    tool_name =
-      (match Json_util.get_string json "tool_name" with
-       | Some value -> value
-       | None -> Json_util.get_string_with_default json ~key:"tool" ~default:"");
+  let* tool_name = required_string_field json "tool_name" in
+  Ok {
+    tool_name;
     success = Json_util.get_bool json "success" |> Option.value ~default:false;
     input = (match member_opt "input" json with Some value -> value | None -> `Assoc []);
     output = member_opt "output" json;
@@ -182,8 +175,12 @@ let evidence_run_of_yojson json =
   let* model = required_string_field json "model" in
   let* keeper_profile = required_string_field json "keeper_profile" in
   let* tool_call_items = list_field json "tool_calls" in
+  let* tool_calls = map_m tool_call_of_yojson tool_call_items in
   let* status =
-    Json_util.get_string json "status" |> Option.value ~default:"ok" |> run_status_of_string
+    match member_opt "status" json with
+    | Some (`String value) -> run_status_of_string value
+    | Some _ -> errorf "field status must be a string"
+    | None -> errorf "missing required string field status"
   in
   Ok {
     case_id;
@@ -201,15 +198,18 @@ let evidence_run_of_yojson json =
     output_tokens = Json_util.get_int json "output_tokens";
     cost_usd = Json_util.get_float json "cost_usd";
     status;
-    tool_calls = List.map tool_call_of_yojson tool_call_items;
+    tool_calls;
   }
 
 let load_cases_from_file path =
   let* json = read_json_file path in
   let* cases =
     match json with
-    | `List items -> Ok items
-    | `Assoc _ -> list_field json "cases"
+    | `Assoc _ ->
+        (match member_opt "cases" json with
+         | Some (`List items) -> Ok items
+         | Some _ -> errorf "field cases must be a list"
+         | None -> errorf "missing required list field cases")
     | _ -> errorf "invalid benchmark case set at %s" path
   in
   map_m benchmark_case_of_yojson cases
@@ -218,8 +218,11 @@ let load_runs_from_file path =
   let* json = read_json_file path in
   let* runs =
     match json with
-    | `List items -> Ok items
-    | `Assoc _ -> list_field json "runs"
+    | `Assoc _ ->
+        (match member_opt "runs" json with
+         | Some (`List items) -> Ok items
+         | Some _ -> errorf "field runs must be a list"
+         | None -> errorf "missing required list field runs")
     | _ -> errorf "invalid benchmark evidence set at %s" path
   in
   map_m evidence_run_of_yojson runs

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.mli
@@ -29,11 +29,8 @@ val load_cases_from_file :
   string ->
   (Tool_call_quality_benchmark_types.benchmark_case list, string)
   Result.t
-(** [load_cases_from_file path] reads the benchmark case set.
-    Accepts both shapes:
-    - [`List items] — the items are the cases directly.
-    - [`Assoc fields] with a [cases] field — the wrapped
-      shape used by older fixtures.
+(** [load_cases_from_file path] reads an object with a required
+    [cases] list.
 
     {2 Per-case validation}
 
@@ -50,8 +47,8 @@ val load_cases_from_file :
       category: <other>"]
     - [forbidden_tools] / [forbidden_selectors] /
       [required_selectors] / [arg_checks] default to empty lists.
-      [arg_checks] accepts either legacy [tool_name] or a structured
-      [selector] using the same schema as [required_selectors].
+      Every [arg_checks] entry requires a structured [selector]
+      using the same schema as [required_selectors].
     - [recovery_policy] defaults to [None] (case has no recovery
       requirement)
 
@@ -63,14 +60,19 @@ val load_runs_from_file :
   string ->
   (Tool_call_quality_benchmark_types.evidence_run list, string)
   Result.t
-(** [load_runs_from_file path] reads the evidence-runs file with
-    the same `List` / `Assoc[runs]` accept shapes as
-    {!load_cases_from_file}.
+(** [load_runs_from_file path] reads an object with a required
+    [runs] list.
 
     {2 Per-run required fields}
 
     [case_id] / [provider] / [model] / [keeper_profile] (all
     non-empty trimmed strings).
+
+    {2 Status contract}
+
+    [status] is required and must be exactly one of [["ok"]],
+    [["executed_failed"]], or [["runtime_unreachable"]]. Missing,
+    non-string, empty, normalized, and unknown values are rejected.
 
     {2 Optional fields with defaults}
 
@@ -79,21 +81,15 @@ val load_runs_from_file :
     | [run_id] / [repeat_index] / [prompt_fingerprint] | [None] |
     | [task_success] / [final_output] / [final_result] | [None] |
     | [latency_ms] / [input_tokens] / [output_tokens] / [cost_usd] | [None] |
-    | [status] | parsed via {!run_status_of_string} from string field, default [["ok"]] |
     | [tool_calls] | empty list, then per-call defaults |
 
     {2 Per-tool-call defaults}
 
     | Field | Default |
     |---|---|
-    | [tool_name] | [tool_name] field, then [tool] field, then [""] |
+    | [tool_name] | required non-empty string |
     | [success] | [false] |
     | [input] | [`Assoc []] |
     | [output] | [None] |
     | [route_evidence] | [None] |
-    | [duration_ms] | [None] |
-
-    The [tool_name] vs [tool] alias is intentional — older
-    fixtures use [tool], newer ones use [tool_name].  Pinning
-    at the contract seam so a future "drop legacy tool field"
-    PR must touch this explicitly. *)
+    | [duration_ms] | [None] | *)

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_render.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_render.ml
@@ -72,7 +72,7 @@ let summary_row_to_yojson (row : summary_row) =
       ("avg_output_tokens", `Float row.avg_output_tokens);
       ("avg_cost_usd", `Float row.avg_cost_usd);
       ("composite_score", `Float row.composite_score);
-      ("unsupported_runs", `Int row.unsupported_runs);
+      ("executed_failed_runs", `Int row.executed_failed_runs);
       ("runtime_unreachable_runs", `Int row.runtime_unreachable_runs);
       ("stability_score", Option.fold ~none:`Null ~some:(fun value -> `Float value) row.stability_score);
       ( "tool_sequence_consistency_rate",
@@ -93,7 +93,7 @@ let benchmark_summary_to_yojson (summary : benchmark_summary) =
       ("cases_total", `Int summary.cases_total);
       ("runs_total", `Int summary.runs_total);
       ("scored_runs", `Int summary.scored_runs);
-      ("unsupported_runs", `Int summary.unsupported_runs);
+      ("executed_failed_runs", `Int summary.executed_failed_runs);
       ("runtime_unreachable_runs", `Int summary.runtime_unreachable_runs);
       ("unknown_case_runs", `Int summary.unknown_case_runs);
       ( "grouped_by_provider_model_keeper",
@@ -144,7 +144,7 @@ let summary_rows_to_csv ~view summary =
       "avg_output_tokens";
       "avg_cost_usd";
       "composite_score";
-      "unsupported_runs";
+      "executed_failed_runs";
       "runtime_unreachable_runs";
       "stability_score";
       "tool_sequence_consistency_rate";
@@ -171,7 +171,7 @@ let summary_rows_to_csv ~view summary =
       Printf.sprintf "%.1f" row.avg_output_tokens;
       Printf.sprintf "%.6f" row.avg_cost_usd;
       Printf.sprintf "%.2f" row.composite_score;
-      Int.to_string row.unsupported_runs;
+      Int.to_string row.executed_failed_runs;
       Int.to_string row.runtime_unreachable_runs;
       string_of_float_option row.stability_score;
       string_of_float_option row.tool_sequence_consistency_rate;

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_render.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_render.mli
@@ -55,7 +55,7 @@ val summary_row_to_yojson :
     [recovery_rate] / [unnecessary_tool_rate] / [avg_tool_calls] /
     [p95_latency_ms] / [avg_input_tokens] / [avg_output_tokens] /
     [avg_cost_usd] / [composite_score] (per-row metrics) +
-    [unsupported_runs] / [runtime_unreachable_runs] (failure
+    [executed_failed_runs] / [runtime_unreachable_runs] (failure
     classification) + [stability_score] /
     [tool_sequence_consistency_rate] /
     [prompt_fingerprint_consistency_rate] / [pass_consistency_rate]

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.ml
@@ -177,6 +177,11 @@ let build_summary_rows view runs scores =
       let current = Hashtbl.find_opt scores_by_key key |> Option.value ~default:[] in
       Hashtbl.replace scores_by_key key (score :: current))
     scores;
+  List.iter
+    (fun run ->
+      let key = summary_key_of_run view run in
+      if not (Hashtbl.mem scores_by_key key) then Hashtbl.add scores_by_key key [])
+    runs;
   Hashtbl.fold
     (fun (provider, model, keeper_profile as key)
          (grouped_scores : case_score list) acc ->
@@ -187,9 +192,9 @@ let build_summary_rows view runs scores =
                (=) run_key key)
       in
       let grouped_scores_by_case = group_scores_by_case grouped_scores in
-      let unsupported_runs =
+      let executed_failed_runs =
         grouped_runs
-        |> List.filter (fun run -> (=) run.status Run_unsupported)
+        |> List.filter (fun run -> (=) run.status Run_executed_failed)
         |> List.length
       in
       let runtime_unreachable_runs =
@@ -258,7 +263,7 @@ let build_summary_rows view runs scores =
           composite_score =
             grouped_scores |> List.map (fun (score : case_score) -> score.composite_score)
             |> avg_float;
-          unsupported_runs;
+          executed_failed_runs;
           runtime_unreachable_runs;
           stability_score;
           tool_sequence_consistency_rate;
@@ -283,8 +288,10 @@ let summarize ~cases ~runs ?model_filters ?keeper_filters () =
     filtered_runs
     |> List.filter_map (Tool_call_quality_benchmark_scoring.score_run ~cases)
   in
-  let unsupported_runs =
-    filtered_runs |> List.filter (fun run -> (=) run.status Run_unsupported) |> List.length
+  let executed_failed_runs =
+    filtered_runs
+    |> List.filter (fun run -> (=) run.status Run_executed_failed)
+    |> List.length
   in
   let runtime_unreachable_runs =
     filtered_runs
@@ -302,7 +309,7 @@ let summarize ~cases ~runs ?model_filters ?keeper_filters () =
     cases_total = List.length cases;
     runs_total = List.length filtered_runs;
     scored_runs = List.length score_results;
-    unsupported_runs;
+    executed_failed_runs;
     runtime_unreachable_runs;
     unknown_case_runs;
     grouped_by_provider_model_keeper =

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.mli
@@ -42,11 +42,11 @@ val summarize :
     Filter strings are normalised (trim + lowercase) before
     comparison.
 
-    {b Status counters} ({!benchmark_summary.unsupported_runs} /
+    {b Status counters} ({!benchmark_summary.executed_failed_runs} /
     {!benchmark_summary.runtime_unreachable_runs} /
     {!benchmark_summary.unknown_case_runs}) reflect filtered runs:
 
-    - [unsupported_runs]: [run.status = Run_unsupported].
+    - [executed_failed_runs]: [run.status = Run_executed_failed].
     - [runtime_unreachable_runs]: [run.status = Run_runtime_unreachable].
     - [unknown_case_runs]: [run.status = Run_ok] AND
       [run.case_id] not in [cases].

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml
@@ -54,7 +54,6 @@ type run_status =
   | Run_ok
   | Run_unsupported
   | Run_runtime_unreachable
-  | Run_other of string
 
 type evidence_run = {
   case_id : string;

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml
@@ -52,7 +52,7 @@ type tool_call = {
 
 type run_status =
   | Run_ok
-  | Run_unsupported
+  | Run_executed_failed
   | Run_runtime_unreachable
 
 type evidence_run = {
@@ -133,7 +133,7 @@ type summary_row = {
   avg_output_tokens : float;
   avg_cost_usd : float;
   composite_score : float;
-  unsupported_runs : int;
+  executed_failed_runs : int;
   runtime_unreachable_runs : int;
   stability_score : float option;
   tool_sequence_consistency_rate : float option;
@@ -146,7 +146,7 @@ type benchmark_summary = {
   cases_total : int;
   runs_total : int;
   scored_runs : int;
-  unsupported_runs : int;
+  executed_failed_runs : int;
   runtime_unreachable_runs : int;
   unknown_case_runs : int;
   grouped_by_provider_model_keeper : summary_row list;

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.mli
@@ -53,7 +53,7 @@ type tool_call = {
 
 type run_status =
   | Run_ok
-  | Run_unsupported
+  | Run_executed_failed
   | Run_runtime_unreachable
 
 type evidence_run = {
@@ -134,7 +134,7 @@ type summary_row = {
   avg_output_tokens : float;
   avg_cost_usd : float;
   composite_score : float;
-  unsupported_runs : int;
+  executed_failed_runs : int;
   runtime_unreachable_runs : int;
   stability_score : float option;
   tool_sequence_consistency_rate : float option;
@@ -147,7 +147,7 @@ type benchmark_summary = {
   cases_total : int;
   runs_total : int;
   scored_runs : int;
-  unsupported_runs : int;
+  executed_failed_runs : int;
   runtime_unreachable_runs : int;
   unknown_case_runs : int;
   grouped_by_provider_model_keeper : summary_row list;

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.mli
@@ -55,7 +55,6 @@ type run_status =
   | Run_ok
   | Run_unsupported
   | Run_runtime_unreachable
-  | Run_other of string
 
 type evidence_run = {
   case_id : string;

--- a/scripts/harness_tool_call_quality.sh
+++ b/scripts/harness_tool_call_quality.sh
@@ -527,19 +527,6 @@ task_success_from_final_result() {
   esac
 }
 
-classify_status() {
-  local text
-  text="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
-  case "${text}" in
-    *"not supported"*|*"unsupported"*|*"invalid_request_error"*|*"unknown model"*|*"model_not_found"*)
-      printf 'unsupported'
-      ;;
-    *)
-      printf 'executed_failed'
-      ;;
-  esac
-}
-
 create_keeper_status_snapshot() {
   local keeper_name="$1"
   local run_dir="$2"
@@ -610,7 +597,7 @@ run_live_case() {
       --arg keeper_profile "${keeper_profile}" \
       --arg run_id "${keeper_name}" \
       --argjson repeat_index "${repeat_index}" \
-      --arg status "$(classify_status "${create_error}")" \
+      --arg status "executed_failed" \
       --arg final_output "${create_error}" \
       '{
         case_id: $case_id,
@@ -647,7 +634,7 @@ run_live_case() {
       --arg keeper_profile "${keeper_profile}" \
       --arg run_id "${keeper_name}" \
       --argjson repeat_index "${repeat_index}" \
-      --arg status "$(classify_status "${msg_error}")" \
+      --arg status "executed_failed" \
       --arg final_output "${msg_error}" \
       --arg keeper_name "${keeper_name}" \
       --arg tool_surface_fingerprint "${tool_surface_fingerprint}" \
@@ -789,13 +776,7 @@ run_live_case() {
       task_success=true
     fi
   else
-    local failure_text
-    failure_text="$(printf '%s' "${result_json}" | jq -r '
-        if (.result | type) == "string" then .result
-        else (.result | tostring)
-        end
-      ')"
-    run_status="$(classify_status "${failure_text}")"
+    run_status="executed_failed"
     final_result_json='null'
   fi
 

--- a/test/fixtures/tool_call_quality_benchmark/evidence_runs.json
+++ b/test/fixtures/tool_call_quality_benchmark/evidence_runs.json
@@ -303,7 +303,7 @@
       "repeat_index": 1,
       "prompt_fingerprint": "fp-executor-board",
       "task_success": false,
-      "status": "unsupported",
+      "status": "executed_failed",
       "tool_calls": []
     }
   ]

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -20,23 +20,44 @@ let fixture_runs repo_root =
    workspace source root as DUNE_SOURCEROOT; resolve fixtures against it and
    fall back to cwd for direct (non-dune) invocation. Mirrors
    test_disk_hygiene_script.ml / test_ci_run_tests_script.ml. *)
-(* Every summary compares status by equality against a known constructor, so a
-   status outside the vocabulary used to leave the run out of every total
-   instead of failing the load. *)
-let test_loader_rejects_unknown_run_status () =
+let load_single_run_status status_field =
   let path = Filename.temp_file "tcq_runs" ".json" in
   Fun.protect
     ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
     (fun () ->
        let oc = open_out path in
-       output_string
-         oc
-         {|{"runs":[{"case_id":"c","provider":"p","model":"m","keeper_profile":"k","status":"okay","tool_calls":[]}]}|};
+       Printf.fprintf oc
+         {|{"runs":[{"case_id":"c","provider":"p","model":"m","keeper_profile":"k",%s"tool_calls":[]}]}|}
+         status_field;
        close_out oc;
-       match Tool_call_quality_benchmark.load_runs_from_file path with
-       | Ok _ -> fail "an unknown run status must not load"
+       Tool_call_quality_benchmark.load_runs_from_file path)
+;;
+
+let test_loader_requires_exact_run_status () =
+  let rejected =
+    [ ("unknown", {|"status":"okay",|}, "okay")
+    ; ("missing", "", "missing required string field status")
+    ; ("null", {|"status":null,|}, "field status must be a string")
+    ; ("number", {|"status":1,|}, "field status must be a string")
+    ; ("empty", {|"status":"",|}, {|""|})
+    ; ("case", {|"status":"OK",|}, "OK")
+    ; ("space", {|"status":" ok ",|}, " ok ")
+    ]
+  in
+  List.iter
+    (fun (label, field, expected) ->
+       match load_single_run_status field with
+       | Ok _ -> failf "%s status must not load" label
        | Error msg ->
-         check bool ("names the status: " ^ msg) true (contains_sub msg "okay"))
+         check bool (label ^ " error: " ^ msg) true (contains_sub msg expected))
+    rejected;
+  List.iter
+    (fun status ->
+       match load_single_run_status (Printf.sprintf {|"status":"%s",|} status) with
+       | Ok [ _ ] -> ()
+       | Ok _ -> failf "%s did not load exactly one run" status
+       | Error msg -> failf "%s must load: %s" status msg)
+    [ "ok"; "executed_failed"; "runtime_unreachable" ]
 ;;
 
 let repo_source_root () =
@@ -146,7 +167,7 @@ let test_summary_rollups_and_stability () =
   check int "cases total" 4 summary.cases_total;
   check int "runs total" 7 summary.runs_total;
   check int "scored runs" 6 summary.scored_runs;
-  check int "unsupported runs" 1 summary.unsupported_runs;
+  check int "executed failed runs" 1 summary.executed_failed_runs;
   check int "runtime unreachable runs" 0 summary.runtime_unreachable_runs;
   let analyst_row =
     find_row
@@ -194,7 +215,16 @@ let test_summary_rollups_and_stability () =
       summary.grouped_by_provider_model
   in
   check int "provider rollup unique cases" 2 provider_row.cases_total;
-  check int "provider rollup passed cases" 1 provider_row.cases_passed
+  check int "provider rollup passed cases" 1 provider_row.cases_passed;
+  let failed_row =
+    find_row
+      ~provider:(Some "anthropic")
+      ~model:(Some "claude-sonnet-latest")
+      ~keeper:(Some "bench-executor")
+      summary.grouped_by_provider_model_keeper
+  in
+  check int "failed-only group has no scored cases" 0 failed_row.cases_total;
+  check int "failed-only group reports the run" 1 failed_row.executed_failed_runs
 
 let test_csv_render_has_headers () =
   let cases, runs = load_fixture () in
@@ -439,54 +469,6 @@ let test_loader_parses_selector_backed_case_fields () =
                (List.length cases))
       | Error msg -> fail ("load_cases_from_file failed: " ^ msg))
 
-(* Regression guard for the legacy [tool_name] arg_check shape: case JSON that
-   predates typed selectors carries a bare ["tool_name"] field instead of a
-   ["selector"] object. parse_arg_check must keep parsing it as
-   [Eval_tool_selector.Tool_name], so removing that fallback fails here. *)
-let test_loader_parses_legacy_tool_name_arg_check () =
-  let path = Filename.temp_file "tool-call-quality-legacy" ".json" in
-  Fun.protect
-    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
-    (fun () ->
-      Fs_compat.save_file path
-        {|{
-  "cases": [
-    {
-      "id": "legacy_arg_check_case",
-      "prompt": "synthetic legacy arg_check case",
-      "category": "tool_use",
-      "keeper_profiles": ["bench-selector"],
-      "forbidden_tools": [],
-      "forbidden_selectors": [],
-      "required_selectors": [],
-      "max_tool_calls": 3,
-      "success_checks": [
-        {"path": "$.status", "equals": "completed"}
-      ],
-      "arg_checks": [
-        {
-          "tool_name": "tool_read_file",
-          "path": "$.path",
-          "contains": "keeper_tool_call_log"
-        }
-      ]
-    }
-  ]
-}|};
-      match Tool_call_quality_benchmark.load_cases_from_file path with
-      | Ok [ case ] ->
-          check int "arg check count" 1
-            (List.length case.Tool_call_quality_benchmark.arg_checks);
-          let arg_check = List.hd case.Tool_call_quality_benchmark.arg_checks in
-          check string "legacy tool_name selector" "tool_name:tool_read_file"
-            (Eval_tool_selector.label
-               arg_check.Tool_call_quality_benchmark.selector)
-      | Ok cases ->
-          fail
-            (Printf.sprintf "expected one parsed case, got %d"
-               (List.length cases))
-      | Error msg -> fail ("load_cases_from_file failed: " ^ msg))
-
 (* When a case uses semantic selectors but none of the run's tool calls carry
    usable route_evidence, scoring cannot distinguish "wrong tool" from
    "missing evidence". Per the evidence-quality contract, such runs are excluded
@@ -656,8 +638,6 @@ let () =
              test_route_evidence_quality_reports_semantic_case_gaps;
            test_case "loader parses selector-backed case fields" `Quick
              test_loader_parses_selector_backed_case_fields;
-           test_case "loader parses legacy tool_name arg check" `Quick
-             test_loader_parses_legacy_tool_name_arg_check;
            test_case "route evidence quality treats empty fields as missing"
              `Quick test_route_evidence_quality_treats_empty_evidence_as_missing;
            test_case "unavailable route evidence excludes run from scoring"
@@ -666,7 +646,7 @@ let () =
              test_case_selectors_resolve_to_live_descriptors;
            test_case "arg check paths exist in descriptor schema" `Quick
              test_arg_check_paths_exist_in_descriptor_schema;
-           test_case "loader rejects an unknown run status" `Quick
-             test_loader_rejects_unknown_run_status;
+           test_case "loader requires an exact run status" `Quick
+             test_loader_requires_exact_run_status;
          ]);
     ]

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -1,6 +1,12 @@
 open Alcotest
 open Masc
 
+let contains_sub haystack needle =
+  let n = String.length needle and h = String.length haystack in
+  let rec go i = i + n <= h && (String.sub haystack i n = needle || go (i + 1)) in
+  n = 0 || go 0
+;;
+
 let fixture_cases repo_root =
   Tool_call_quality_benchmark.default_case_set_path ~repo_root
 
@@ -14,6 +20,25 @@ let fixture_runs repo_root =
    workspace source root as DUNE_SOURCEROOT; resolve fixtures against it and
    fall back to cwd for direct (non-dune) invocation. Mirrors
    test_disk_hygiene_script.ml / test_ci_run_tests_script.ml. *)
+(* Every summary compares status by equality against a known constructor, so a
+   status outside the vocabulary used to leave the run out of every total
+   instead of failing the load. *)
+let test_loader_rejects_unknown_run_status () =
+  let path = Filename.temp_file "tcq_runs" ".json" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+       let oc = open_out path in
+       output_string
+         oc
+         {|{"runs":[{"case_id":"c","provider":"p","model":"m","keeper_profile":"k","status":"okay","tool_calls":[]}]}|};
+       close_out oc;
+       match Tool_call_quality_benchmark.load_runs_from_file path with
+       | Ok _ -> fail "an unknown run status must not load"
+       | Error msg ->
+         check bool ("names the status: " ^ msg) true (contains_sub msg "okay"))
+;;
+
 let repo_source_root () =
   match Sys.getenv_opt "DUNE_SOURCEROOT" with Some root -> root | None -> Sys.getcwd ()
 
@@ -641,5 +666,7 @@ let () =
              test_case_selectors_resolve_to_live_descriptors;
            test_case "arg check paths exist in descriptor schema" `Quick
              test_arg_check_paths_exist_in_descriptor_schema;
+           test_case "loader rejects an unknown run status" `Quick
+             test_loader_rejects_unknown_run_status;
          ]);
     ]


### PR DESCRIPTION
## Contract

The live harness and report loader now share one closed run-outcome vocabulary:

- `ok`
- `executed_failed`
- `runtime_unreachable`

Every harness execution path emits one of these exact values. Provider and tool error text remains diagnostic output only; it no longer controls classification.

The loader requires a string `status` and rejects missing, null, non-string, empty, case-normalized, whitespace-normalized, and unknown values. Case sets and evidence sets require their canonical object envelopes, argument checks require typed selectors, and tool calls require `tool_name`.

## Reporting

`executed_failed_runs` and `runtime_unreachable_runs` are present in aggregate JSON, grouped rows, CSV, and canary admission. Group rows are created from all runs, so a group containing only failed executions remains visible.

## Verification

- `ocamlformat` on all changed OCaml files
- `ocamlc -stop-after parsing` on all changed OCaml files
- `bash -n scripts/harness_tool_call_quality.sh`
- `jq -e .` on the case and evidence fixtures
- `git diff --check`
- focused Dune target requested but deferred to PR CI because the repository wrapper detected unrelated active bare-Dune processes and correctly refused concurrent execution
