### PR TITLE
fix(guards): resolve HOME containment in pathname order

### DIFF
--- a/lib/config/dune
+++ b/lib/config/dune
@@ -32,4 +32,4 @@
  ; 4 ignores it.
  (flags
   (:standard -w +4 -w +33 -w +37))
- (libraries masc_core masc_log yojson otoml uri ipaddr unix))
+ (libraries masc_core masc_log path_containment yojson otoml uri ipaddr unix))

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -427,21 +427,26 @@ let base_path_prod_guard path =
       match home_dir_opt () with
       | None -> path
       | Some home ->
-        let home_norm = normalize_masc_base_path_input home in
-        if home_norm <> "" && String.length path >= String.length home_norm
-           && String.sub path 0 (String.length home_norm) = home_norm
-        then
+        let breach detail =
           raise (Config_error
             (Printf.sprintf
                "#9903 test isolation breach: Env_config_core.base_path() \
-                resolved to %S under HOME=%S in test executable %S. This \
+                resolved to %S — %s (HOME=%S) in test executable %S. This \
                 indicates a MASC_BASE_PATH override failure — writing to \
                 the production ledger under HOME would corrupt real data. \
                 Fix the override path in the test, or set \
                 MASC_TEST_ALLOW_HOME_BASE_PATH=1 to bypass (not \
                 recommended)."
-               path home_norm (Filename.basename Sys.executable_name)))
-        else path
+               path detail home (Filename.basename Sys.executable_name)))
+        in
+        (* Same owner as the Fs_compat mutation guard, so the two cannot drift
+           again. Undecidable takes the Inside exit: a base path whose
+           destination cannot be resolved is not known to be outside HOME. *)
+        (match Path_containment.classify ~root:home ~path with
+         | Path_containment.Outside -> path
+         | Path_containment.Inside -> breach "resolves under HOME"
+         | Path_containment.Undecidable reason ->
+           breach (Printf.sprintf "containment undecidable (%s)" reason))
   end
 
 (** Project base path. [MASC_BASE_PATH] is required. *)

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -267,9 +267,6 @@ let masc_host () =
   | Some host -> host
   | None -> default_host
 
-(* RFC-0085 PR-10 — [assets_dir_opt] removed (caller 0 after migration).
-   Readers use [(Host_config.from_env ()).assets_dir]. *)
-
 let cluster_name_opt () =
   raw_value_opt "MASC_CLUSTER_NAME" |> trim_opt
 
@@ -390,37 +387,17 @@ let running_under_test_executable () =
   in
   String.length basename >= 5 && String.starts_with ~prefix:"test_" basename
 
-(** #9903: production base-path safeguard for test executables.
-
-    Without this, a test whose [MASC_BASE_PATH] override fails to
-    take effect (due to any combination of dune env precedence,
-    module init-time caching, or Eio.Path absolute-path
-    interpretation) silently falls through to the operator's HOME
-    and appends fixture data to the live ledger — the exact
-    failure mode diagnosed on [<base-path>/.masc/board_votes.jsonl]
-    (112 hot-voter-* rows overwrote real keeper votes).
-
-    The safeguard is lossy by design: a test that resolves
-    [base_path] to a [HOME] prefix raises [Config_error]
-    immediately. Loss of a test run is strictly better than loss
-    of production data.
-
-    Escape hatch: set [MASC_TEST_ALLOW_HOME_BASE_PATH=1] for tests
-    that legitimately need HOME-relative paths (none known today;
-    the env var exists only so a reviewer can turn it on
-    temporarily while investigating a new breach).
-
-    Non-test executables (the MCP server) skip the check — HOME
-    fallback is the correct production behavior. *)
+(** Test executables must not use a base path that resolves under [HOME]. The
+    exact [MASC_TEST_ALLOW_HOME_BASE_PATH=1] setting permits an explicitly
+    scoped test. *)
 let test_allow_home_base_path_env = "MASC_TEST_ALLOW_HOME_BASE_PATH"
 
 let base_path_prod_guard path =
   if not (running_under_test_executable ()) then path
   else begin
     let allow =
-      match raw_value_opt test_allow_home_base_path_env |> trim_opt with
-      | Some v -> v = "1" || v = "true"
-      | None -> false
+      Path_containment.home_guard_bypass_enabled
+        (raw_value_opt test_allow_home_base_path_env)
     in
     if allow then path
     else
@@ -430,17 +407,14 @@ let base_path_prod_guard path =
         let breach detail =
           raise (Config_error
             (Printf.sprintf
-               "#9903 test isolation breach: Env_config_core.base_path() \
-                resolved to %S — %s (HOME=%S) in test executable %S. This \
-                indicates a MASC_BASE_PATH override failure — writing to \
-                the production ledger under HOME would corrupt real data. \
-                Fix the override path in the test, or set \
-                MASC_TEST_ALLOW_HOME_BASE_PATH=1 to bypass (not \
-                recommended)."
+               "test isolation breach: Env_config_core.base_path() resolved \
+                to %S — %s (HOME=%S) in test executable %S. Fix the test \
+                setup or set MASC_TEST_ALLOW_HOME_BASE_PATH=1 explicitly for \
+                this test."
                path detail home (Filename.basename Sys.executable_name)))
         in
-        (* Same owner as the Fs_compat mutation guard, so the two cannot drift
-           again. Undecidable takes the Inside exit: a base path whose
+        (* Same owner as the Fs_compat mutation guard. Undecidable takes the
+           Inside exit: a base path whose
            destination cannot be resolved is not known to be outside HOME. *)
         (match Path_containment.classify ~root:home ~path with
          | Path_containment.Outside -> path

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -97,11 +97,6 @@ val normalize_masc_base_path_input : string -> string
 val existing_dir : string -> bool
 val existing_file : string -> bool
 
-(* RFC-0085 PR-10 — [home_dir_opt] removed from the public surface;
-   callers read from [(Host_config.from_env ()).home] instead.  The
-   function is retained file-private because [base_path] /
-   [sb_path_opt] still call it internally. *)
-
 (** {1 HTTP host + port (SSOT for issue 8352)} *)
 
 val host_env_key : string
@@ -113,10 +108,6 @@ val default_host : string
 val masc_host : unit -> string
 
 (** {1 Assets / cluster name} *)
-
-(* RFC-0085 PR-10 — [assets_dir_opt] removed completely.  Caller 0
-   after PR-10 migration; readers use
-   [(Host_config.from_env ()).assets_dir]. *)
 
 val cluster_name_opt : unit -> string option
 val cluster_name : unit -> string
@@ -157,13 +148,8 @@ val base_path_env_key : string
 val base_path_input_env_key : string
 val base_path_source_opt : unit -> (string * string) option
 
-(* RFC-0085 PR-9 — [base_path_raw_opt] and [base_path_opt] are no
-   longer part of the public surface.  External callers read the
-   normalised env-derived base_path from
-   [(Host_config.from_env ()).base_path] instead.  The two functions
-   remain file-private inside [env_config_core.ml] because
-   [base_path] / [sb_path_opt] still reach for the raw value
-   internally; a follow-up RFC migrates those too. *)
+(* Raw base-path readers are private. External callers use
+   [(Host_config.from_env ()).base_path]. *)
 
 val running_under_test_executable : unit -> bool
 val test_allow_home_base_path_env : string

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -37,6 +37,7 @@
   (:standard -w +4))
  (libraries
   fs_compat_internal
+  path_containment
   eio
   eio.unix
   unix

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -98,29 +98,26 @@ let test_exec_home_guard ~op path =
       match Sys.getenv_opt "HOME" with
       | None | Some "" -> ()
       | Some home ->
-        let home_norm =
-          let trimmed = String.trim home in
-          let len = String.length trimmed in
-          if len > 1 && Char.equal trimmed.[len - 1] '/'
-          then String.sub trimmed 0 (len - 1)
-          else trimmed
-        in
-        let home_len = String.length home_norm in
-        if
-          home_len > 0
-          && String.length path >= home_len
-          && String.starts_with path ~prefix:home_norm
-        then
+        let breach detail =
           raise
             (Test_isolation_breach
                (Printf.sprintf
-                  "#9921 %s blocked under HOME=%S (path=%S) in test executable %S. \
+                  "#9921 %s blocked: %s (HOME=%S, path=%S) in test executable %S. \
                    MASC_BASE_PATH override did not apply — fix the test setup or set \
                    MASC_TEST_ALLOW_HOME_BASE_PATH=1."
                   op
-                  home_norm
+                  detail
+                  home
                   path
-                  (Stdlib.Filename.basename Stdlib.Sys.executable_name)))))
+                  (Stdlib.Filename.basename Stdlib.Sys.executable_name)))
+        in
+        (* Undecidable takes the same exit as Inside: a path whose destination
+           cannot be resolved is not known to be outside HOME. *)
+        (match Path_containment.classify ~root:home ~path with
+         | Path_containment.Outside -> ()
+         | Path_containment.Inside -> breach "resolves under HOME"
+         | Path_containment.Undecidable reason ->
+           breach (Printf.sprintf "containment undecidable (%s)" reason))))
 ;;
 
 let with_fs_or_fallback ~path ~fallback f =

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1,17 +1,10 @@
-(** Filesystem Compatibility Layer - Eio-native I/O with fallback
-
-    Provides a unified filesystem API for gradual migration from
-    blocking Unix I/O to Eio.Path operations.
+(** Filesystem access through Eio when configured and Unix I/O otherwise.
 
     Usage:
     1. At server startup: [Fs_compat.set_fs (Eio.Stdenv.fs env)]
     2. In code: [Fs_compat.load_file path] instead of [open_in ...]
 
-    When fs is not set (non-Eio contexts), falls back to blocking Unix I/O.
-    This allows incremental migration without changing all call sites at once.
-
-    @since 2026-02 - Keeper Emergent Identity v2.0
-*)
+    When fs is not set, calls execute through blocking Unix I/O. *)
 
 open Fs_compat_internal
 
@@ -56,23 +49,9 @@ let with_io ~path f =
     raise (Sys_error (Printf.sprintf "%s: %s" path (Printexc.to_string e)))
 ;;
 
-(* #9921: defense-in-depth write-boundary guard.
-
-   [Env_config_core.base_path_prod_guard] stops test-time writes when path
-   resolution points under HOME.  Any code that caches a stale [base_path ()]
-   result or builds a HOME-relative path directly hits this gate before the
-   write lands on the production ledger.
-
-   The prod ledger observed 106 test-pattern rows
-   ([hot-voter-*], [flipper], [same-voter], [judge]) written pre-#9920.
-   This guard prevents regression if any new code path slips past the
-   resolution guard.
-
-   Active only for test executables (basename starts with [test_]).
-   Escape hatch [MASC_TEST_ALLOW_HOME_BASE_PATH=1] matches
-   [base_path_prod_guard] for the rare test that legitimately writes
-   under HOME.  Reads remain unguarded — this is about preventing
-   silent corruption, not restricting observability. *)
+(* Test executables must not mutate paths that resolve under HOME. Reads remain
+   available, and the exact [MASC_TEST_ALLOW_HOME_BASE_PATH=1] setting permits
+   an explicitly scoped test. *)
 exception Test_isolation_breach of string
 
 let test_exec_home_guard ~op path =
@@ -86,11 +65,8 @@ let test_exec_home_guard ~op path =
   then ()
   else (
     let allow =
-      match Sys.getenv_opt "MASC_TEST_ALLOW_HOME_BASE_PATH" with
-      | Some v ->
-        let v = String.lowercase_ascii (String.trim v) in
-        String.equal v "1" || String.equal v "true" || String.equal v "yes"
-      | None -> false
+      Path_containment.home_guard_bypass_enabled
+        (Sys.getenv_opt "MASC_TEST_ALLOW_HOME_BASE_PATH")
     in
     if allow
     then ()
@@ -102,8 +78,8 @@ let test_exec_home_guard ~op path =
           raise
             (Test_isolation_breach
                (Printf.sprintf
-                  "#9921 %s blocked: %s (HOME=%S, path=%S) in test executable %S. \
-                   MASC_BASE_PATH override did not apply — fix the test setup or set \
+                  "test isolation breach: %s blocked: %s (HOME=%S, path=%S) in \
+                   test executable %S. Fix the test setup or set \
                    MASC_TEST_ALLOW_HOME_BASE_PATH=1."
                   op
                   detail

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -1,7 +1,4 @@
-(** Filesystem Compatibility Layer - Eio-native I/O with fallback
-
-    @since 2026-02 - Keeper Emergent Identity v2.0
-*)
+(** Filesystem access through Eio when configured and Unix I/O otherwise. *)
 
 open Fs_compat_internal
 
@@ -9,9 +6,8 @@ module Atomic_orphan_size_class = Atomic_orphan_size_class
 
 (** Capability-scoped observation of one immutable regular-file snapshot.
 
-    This module owns no digest, schema, history, migration, scan, retry, repair,
-    or deletion policy. It pins the supplied parent capability and dispatches
-    exactly one single-component leaf open.
+    It pins the supplied parent capability and dispatches exactly one
+    single-component leaf open.
 
     Before allocation, [read] proves non-negative [expected_length <=
     max_length], representability, regular-file kind, one link, mode [0600]
@@ -99,10 +95,8 @@ module Capability_exact_read : sig
     (observation, failure) result
 end
 
-(** #9921: raised by mutating [Fs_compat] entry points
-    ([append_file], [save_file], [mkdir_p]) when the target path falls
-    under [HOME] and the process is a test executable. Defense in depth
-    behind [Env_config_core.base_path_prod_guard]. Bypass with
+(** Raised by mutating entry points when a test executable targets a path that
+    resolves under [HOME]. Bypass with the exact setting
     [MASC_TEST_ALLOW_HOME_BASE_PATH=1]. *)
 exception Test_isolation_breach of string
 

--- a/lib/path_containment/dune
+++ b/lib/path_containment/dune
@@ -1,0 +1,12 @@
+(include_subdirs no)
+
+; Leaf on purpose. Both HOME guards must reach it, and they sit on opposite
+; sides of the graph: masc_config depends on masc_core, which depends on
+; fs_compat. Owning containment in either of those would make fs_compat depend
+; on something that depends on fs_compat.
+(library
+ (name path_containment)
+ (public_name masc.path_containment)
+ (wrapped true)
+ (modules path_containment)
+ (libraries unix))

--- a/lib/path_containment/path_containment.ml
+++ b/lib/path_containment/path_containment.ml
@@ -1,0 +1,70 @@
+type t =
+  | Inside
+  | Outside
+  | Undecidable of string
+
+(* Lexical pass: drop empty and ["."] components, fold [".."] against what has
+   been accumulated. Folding past the root keeps the root, matching how the
+   kernel treats ["/.."]. *)
+let split_normalized absolute =
+  let fold acc component =
+    match component with
+    | "" | "." -> acc
+    | ".." -> (match acc with _ :: rest -> rest | [] -> [])
+    | _ -> component :: acc
+  in
+  String.split_on_char '/' absolute |> List.fold_left fold [] |> List.rev
+
+let join segments = "/" ^ String.concat "/" segments
+
+(* [Unix.realpath] raises when the path does not exist, and a write target
+   usually does not exist yet. Resolve the longest existing prefix so a symlink
+   anywhere along it is followed, then put the components that do not exist back
+   on top: they cannot be symlinks, because they are not there. *)
+let resolve_existing_prefix segments =
+  let rec walk prefix tail =
+    match Unix.realpath (join prefix) with
+    | resolved -> Ok (split_normalized resolved @ tail)
+    | exception (Unix.Unix_error _ | Sys_error _) -> (
+        match prefix with
+        | [] -> Error (Printf.sprintf "no existing prefix resolves for %S" (join segments))
+        | _ ->
+            let dropped = List.nth prefix (List.length prefix - 1) in
+            let shorter = List.filteri (fun i _ -> i < List.length prefix - 1) prefix in
+            walk shorter (dropped :: tail))
+  in
+  walk segments []
+
+let absolutize raw =
+  let trimmed = String.trim raw in
+  if String.length trimmed = 0 then Error "empty path"
+  else if Char.equal trimmed.[0] '/' then Ok trimmed
+  else
+    match Sys.getcwd () with
+    | cwd -> Ok (Filename.concat cwd trimmed)
+    | exception (Sys_error msg | Unix.Unix_error (_, _, msg)) ->
+        Error (Printf.sprintf "relative path %S with no reachable cwd: %s" trimmed msg)
+
+let canonical_segments raw =
+  match absolutize raw with
+  | Error _ as error -> error
+  | Ok absolute -> resolve_existing_prefix (split_normalized absolute)
+
+(* Component-wise, so a sibling that merely extends the root's spelling does not
+   count as contained. *)
+let rec starts_with_components ~prefix segments =
+  match prefix, segments with
+  | [], _ -> true
+  | _, [] -> false
+  | p :: prest, s :: srest ->
+      String.equal p s && starts_with_components ~prefix:prest srest
+
+let classify ~root ~path =
+  match canonical_segments root with
+  | Error reason -> Undecidable (Printf.sprintf "root: %s" reason)
+  | Ok root_segments -> (
+      match canonical_segments path with
+      | Error reason -> Undecidable (Printf.sprintf "path: %s" reason)
+      | Ok path_segments ->
+          if starts_with_components ~prefix:root_segments path_segments then Inside
+          else Outside)

--- a/lib/path_containment/path_containment.ml
+++ b/lib/path_containment/path_containment.ml
@@ -3,55 +3,70 @@ type t =
   | Outside
   | Undecidable of string
 
-(* Lexical pass: drop empty and ["."] components, fold [".."] against what has
-   been accumulated. Folding past the root keeps the root, matching how the
-   kernel treats ["/.."]. *)
-let split_normalized absolute =
-  let fold acc component =
-    match component with
-    | "" | "." -> acc
-    | ".." -> (match acc with _ :: rest -> rest | [] -> [])
-    | _ -> component :: acc
-  in
-  String.split_on_char '/' absolute |> List.fold_left fold [] |> List.rev
+let home_guard_bypass_enabled = function
+  | Some ("1" | "true") -> true
+  | Some _ | None -> false
 
-let join segments = "/" ^ String.concat "/" segments
+let split_components path = String.split_on_char '/' path
 
-(* [Unix.realpath] raises when the path does not exist, and a write target
-   usually does not exist yet. Resolve the longest existing prefix so a symlink
-   anywhere along it is followed, then put the components that do not exist back
-   on top: they cannot be symlinks, because they are not there. *)
-let resolve_existing_prefix segments =
-  let rec walk prefix tail =
-    match Unix.realpath (join prefix) with
-    | resolved -> Ok (split_normalized resolved @ tail)
-    | exception (Unix.Unix_error _ | Sys_error _) -> (
-        match prefix with
-        | [] -> Error (Printf.sprintf "no existing prefix resolves for %S" (join segments))
-        | _ ->
-            let dropped = List.nth prefix (List.length prefix - 1) in
-            let shorter = List.filteri (fun i _ -> i < List.length prefix - 1) prefix in
-            walk shorter (dropped :: tail))
-  in
-  walk segments []
+let join_absolute segments = "/" ^ String.concat "/" segments
 
-let absolutize raw =
-  let trimmed = String.trim raw in
-  if String.length trimmed = 0 then Error "empty path"
-  else if Char.equal trimmed.[0] '/' then Ok trimmed
+let absolute_components raw =
+  if String.equal raw "" then Error "empty path"
+  else if Char.equal raw.[0] '/' then Ok (split_components raw)
   else
     match Sys.getcwd () with
-    | cwd -> Ok (Filename.concat cwd trimmed)
+    | cwd -> Ok (split_components cwd @ split_components raw)
     | exception (Sys_error msg | Unix.Unix_error (_, _, msg)) ->
-        Error (Printf.sprintf "relative path %S with no reachable cwd: %s" trimmed msg)
+        Error (Printf.sprintf "relative path %S with no reachable cwd: %s" raw msg)
 
-let canonical_segments raw =
-  match absolutize raw with
-  | Error _ as error -> error
-  | Ok absolute -> resolve_existing_prefix (split_normalized absolute)
+let resolve raw =
+  let ( let* ) = Result.bind in
+  let* components = absolute_components raw in
+  let rec walk ~symlink_hops resolved_rev pending =
+    match pending with
+    | [] -> Ok (List.rev resolved_rev)
+    | ("" | ".") :: rest -> walk ~symlink_hops resolved_rev rest
+    | ".." :: rest ->
+        let parent_rev = match resolved_rev with _ :: parent -> parent | [] -> [] in
+        walk ~symlink_hops parent_rev rest
+    | component :: rest ->
+        let candidate =
+          join_absolute (List.rev_append resolved_rev [ component ])
+        in
+        (match Unix.lstat candidate with
+         | { Unix.st_kind = Unix.S_LNK; _ } ->
+             if symlink_hops >= 40 then
+               Error (Printf.sprintf "too many symbolic links while resolving %S" raw)
+             else
+               (match Unix.readlink candidate with
+                | target ->
+                    let target_components = split_components target in
+                    let target_base =
+                      if Filename.is_relative target then resolved_rev else []
+                    in
+                    walk ~symlink_hops:(symlink_hops + 1) target_base
+                      (target_components @ rest)
+                | exception (Unix.Unix_error (error, fn, arg)) ->
+                    Error
+                      (Printf.sprintf "%s(%S): %s" fn arg
+                         (Unix.error_message error))
+                | exception Sys_error msg -> Error msg)
+         | { Unix.st_kind; _ }
+           when (not (List.is_empty rest)) && st_kind <> Unix.S_DIR ->
+             Error
+               (Printf.sprintf "%S is not a directory while resolving %S"
+                  candidate raw)
+         | _ -> walk ~symlink_hops (component :: resolved_rev) rest
+         | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+             walk ~symlink_hops (component :: resolved_rev) rest
+         | exception Unix.Unix_error (error, fn, arg) ->
+             Error
+               (Printf.sprintf "%s(%S): %s" fn arg (Unix.error_message error))
+         | exception Sys_error msg -> Error msg)
+  in
+  walk ~symlink_hops:0 [] components
 
-(* Component-wise, so a sibling that merely extends the root's spelling does not
-   count as contained. *)
 let rec starts_with_components ~prefix segments =
   match prefix, segments with
   | [], _ -> true
@@ -60,11 +75,12 @@ let rec starts_with_components ~prefix segments =
       String.equal p s && starts_with_components ~prefix:prest srest
 
 let classify ~root ~path =
-  match canonical_segments root with
+  match resolve root with
   | Error reason -> Undecidable (Printf.sprintf "root: %s" reason)
-  | Ok root_segments -> (
-      match canonical_segments path with
-      | Error reason -> Undecidable (Printf.sprintf "path: %s" reason)
-      | Ok path_segments ->
-          if starts_with_components ~prefix:root_segments path_segments then Inside
-          else Outside)
+  | Ok root_segments ->
+      (match resolve path with
+       | Error reason -> Undecidable (Printf.sprintf "path: %s" reason)
+       | Ok path_segments ->
+           if starts_with_components ~prefix:root_segments path_segments then
+             Inside
+           else Outside)

--- a/lib/path_containment/path_containment.mli
+++ b/lib/path_containment/path_containment.mli
@@ -1,0 +1,37 @@
+(** Path_containment — the single answer to "is this path inside that root?".
+
+    Two guards used to answer it independently by comparing unnormalized
+    strings, and they disagreed: a sibling whose name extends the root's shares
+    the root's prefix without being inside it, and a relative path, a [..]
+    segment, a duplicate separator, or a symlink hides the destination from a
+    prefix comparison entirely.
+
+    Deciding needs the filesystem, so the answer is three-valued.  {!Undecidable}
+    is not a failure to be smoothed over: a caller that cannot resolve a path
+    does not know where the write lands, and every caller here treats it the
+    same way it treats {!Inside}. Collapsing it into {!Outside} would turn an
+    unreadable path into a permitted one. *)
+
+type t =
+  | Inside
+      (** [path] resolves to [root] itself or to something under it. *)
+  | Outside  (** [path] resolves somewhere [root] does not contain. *)
+  | Undecidable of string
+      (** The question could not be answered — a relative path with no
+          reachable cwd, or a root whose existing prefix does not resolve.
+          Carries the reason for the operator-facing message. *)
+
+val classify : root:string -> path:string -> t
+(** [classify ~root ~path] decides containment by destination rather than by
+    spelling.
+
+    Both arguments are made absolute (against the process cwd), normalized
+    lexically ([""] and ["."] dropped, [".."] folded), and then resolved with
+    {!Unix.realpath} as far as they exist — the longest existing prefix is
+    resolved and the remaining components are appended, because the write
+    target usually does not exist yet.  Comparison is by path component, so
+    ["/home/runner-cache"] is {!Outside} ["/home/runner"] while
+    ["/home/runner"] itself is {!Inside}.
+
+    A root that trims to [""] is {!Undecidable}, not a root that contains
+    everything. *)

--- a/lib/path_containment/path_containment.mli
+++ b/lib/path_containment/path_containment.mli
@@ -1,37 +1,24 @@
-(** Path_containment — the single answer to "is this path inside that root?".
-
-    Two guards used to answer it independently by comparing unnormalized
-    strings, and they disagreed: a sibling whose name extends the root's shares
-    the root's prefix without being inside it, and a relative path, a [..]
-    segment, a duplicate separator, or a symlink hides the destination from a
-    prefix comparison entirely.
-
-    Deciding needs the filesystem, so the answer is three-valued.  {!Undecidable}
-    is not a failure to be smoothed over: a caller that cannot resolve a path
-    does not know where the write lands, and every caller here treats it the
-    same way it treats {!Inside}. Collapsing it into {!Outside} would turn an
-    unreadable path into a permitted one. *)
+(** Filesystem-aware containment for mutation guards. *)
 
 type t =
   | Inside
       (** [path] resolves to [root] itself or to something under it. *)
   | Outside  (** [path] resolves somewhere [root] does not contain. *)
   | Undecidable of string
-      (** The question could not be answered — a relative path with no
-          reachable cwd, or a root whose existing prefix does not resolve.
-          Carries the reason for the operator-facing message. *)
+      (** The destination could not be resolved safely. Mutation guards treat
+          this result as a breach. *)
+
+val home_guard_bypass_enabled : string option -> bool
+(** [home_guard_bypass_enabled raw] accepts only the exact configured values
+    ["1"] and ["true"]. *)
 
 val classify : root:string -> path:string -> t
-(** [classify ~root ~path] decides containment by destination rather than by
-    spelling.
+(** [classify ~root ~path] resolves pathname components in kernel order,
+    including symbolic links followed by later [..] components, then compares
+    the resolved components.
 
-    Both arguments are made absolute (against the process cwd), normalized
-    lexically ([""] and ["."] dropped, [".."] folded), and then resolved with
-    {!Unix.realpath} as far as they exist — the longest existing prefix is
-    resolved and the remaining components are appended, because the write
-    target usually does not exist yet.  Comparison is by path component, so
-    ["/home/runner-cache"] is {!Outside} ["/home/runner"] while
-    ["/home/runner"] itself is {!Inside}.
-
-    A root that trims to [""] is {!Undecidable}, not a root that contains
-    everything. *)
+    A missing ordinary component is retained because mutation targets commonly
+    do not exist yet. A symbolic link is resolved even when its target is
+    missing. Resolution errors other than a missing ordinary component, and
+    symbolic-link cycles, produce {!Undecidable}. Empty strings are
+    {!Undecidable}; leading and trailing spaces are valid pathname bytes. *)

--- a/test/test_fs_compat_home_guard.ml
+++ b/test/test_fs_compat_home_guard.ml
@@ -69,6 +69,122 @@ let test_tmp_write_allowed () =
   (try Sys.remove path with Sys_error _ -> ());
   (try Unix.rmdir dir with Unix.Unix_error _ -> ())
 
+(* --- #27596: containment is decided by destination, not by spelling. --- *)
+
+let with_home new_home f =
+  let real = home () in
+  Fun.protect
+    ~finally:(fun () -> Unix.putenv "HOME" real)
+    (fun () ->
+      Unix.putenv "HOME" new_home;
+      f ())
+
+let fresh_base label =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-27596-%s-%d" label (Unix.getpid ()))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let expect_blocked what f =
+  try
+    f ();
+    Alcotest.failf "expected Test_isolation_breach: %s" what
+  with FC.Test_isolation_breach _ -> ()
+
+let expect_allowed what f =
+  try f () with
+  | FC.Test_isolation_breach msg -> Alcotest.failf "%s: %s" what msg
+
+(* A path that lands under HOME while spelled so a prefix comparison misses it.
+   [<base>/other/../home/x] never shares HOME's prefix as a string. *)
+let test_dotdot_reentry_is_blocked () =
+  disable_escape_hatch ();
+  let base = fresh_base "dotdot" in
+  let fake_home = Filename.concat base "home" in
+  (try Unix.mkdir fake_home 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let other = Filename.concat base "other" in
+  (try Unix.mkdir other 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  with_home fake_home (fun () ->
+    expect_blocked "<base>/other/../home/probe re-enters HOME" (fun () ->
+      FC.append_file (Filename.concat other "../home/probe.jsonl") "x\n"));
+  expect_blocked "duplicate separators still land under HOME" (fun () ->
+    with_home fake_home (fun () ->
+      FC.append_file (fake_home ^ "//probe2.jsonl") "x\n"))
+
+(* A symlink outside HOME whose target is inside it. The destination is what
+   matters; the spelling shares nothing with HOME. *)
+let test_symlink_into_home_is_blocked () =
+  disable_escape_hatch ();
+  let base = fresh_base "symlink" in
+  let fake_home = Filename.concat base "home" in
+  (try Unix.mkdir fake_home 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let link = Filename.concat base "link" in
+  (try Unix.symlink fake_home link with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  with_home fake_home (fun () ->
+    expect_blocked "<base>/link -> HOME" (fun () ->
+      FC.append_file (Filename.concat link "probe.jsonl") "x\n"))
+
+(* HOME=/ with a relative path: it resolves under the cwd, which is under /. *)
+let test_home_root_blocks_relative_path () =
+  disable_escape_hatch ();
+  with_home "/" (fun () ->
+    expect_blocked "relative path under HOME=/" (fun () ->
+      FC.append_file "masc-27596-relative-probe.jsonl" "x\n"))
+
+(* A sibling whose name merely extends HOME's is not under HOME. *)
+let test_sibling_allowed () =
+  disable_escape_hatch ();
+  let base = fresh_base "sibling" in
+  let fake_home = Filename.concat base "home" in
+  (try Unix.mkdir fake_home 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let sibling = fake_home ^ "-cache" in
+  with_home fake_home (fun () ->
+    expect_allowed "sibling of HOME" (fun () ->
+      FC.mkdir_p sibling;
+      FC.append_file (Filename.concat sibling "probe.txt") "ok\n"))
+
+(* HOME=/ makes every absolute path contained. Appending a separator to the
+   root would look for "//" and block nothing. *)
+let test_home_root_blocks_absolute_path () =
+  disable_escape_hatch ();
+  let path =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-27596-abs-%d.txt" (Unix.getpid ()))
+  in
+  with_home "/" (fun () ->
+    expect_blocked "absolute path under HOME=/" (fun () ->
+      FC.append_file path "x\n"))
+
+(* HOME itself, not just what is under it. *)
+let test_home_itself_is_blocked () =
+  disable_escape_hatch ();
+  let base = fresh_base "exact" in
+  let fake_home = Filename.concat base "home" in
+  (try Unix.mkdir fake_home 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  with_home fake_home (fun () ->
+    expect_blocked "HOME itself" (fun () -> FC.mkdir_p fake_home))
+
+(* The second entrypoint has to answer the same way. *)
+let test_base_path_guard_agrees () =
+  disable_escape_hatch ();
+  let base = fresh_base "cfgguard" in
+  let fake_home = Filename.concat base "home" in
+  (try Unix.mkdir fake_home 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let sibling = fake_home ^ "-cache" in
+  with_home fake_home (fun () ->
+    (match Env_config_core.base_path_prod_guard sibling with
+     | _ -> ()
+     | exception Env_config_core.Config_error msg ->
+       Alcotest.failf "sibling %S rejected by base_path guard: %s" sibling msg);
+    let inside = Filename.concat fake_home "ledger" in
+    match Env_config_core.base_path_prod_guard inside with
+    | value ->
+      Alcotest.failf "expected Config_error for %S, got %S" inside value
+    | exception Env_config_core.Config_error _ -> ())
+
 let test_escape_hatch_allows_home () =
   Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" "1";
   let path = guard_path "_9921_guard_probe_bypass.jsonl" in
@@ -101,6 +217,20 @@ let () =
         test_mkdir_under_home_raises;
       Alcotest.test_case "tmp write allowed" `Quick
         test_tmp_write_allowed;
+      Alcotest.test_case "sibling of HOME allowed" `Quick
+        test_sibling_allowed;
+      Alcotest.test_case "HOME=/ blocks absolute path" `Quick
+        test_home_root_blocks_absolute_path;
+      Alcotest.test_case "HOME itself blocked" `Quick
+        test_home_itself_is_blocked;
+      Alcotest.test_case "dotdot re-entry blocked" `Quick
+        test_dotdot_reentry_is_blocked;
+      Alcotest.test_case "symlink into HOME blocked" `Quick
+        test_symlink_into_home_is_blocked;
+      Alcotest.test_case "HOME=/ blocks relative path" `Quick
+        test_home_root_blocks_relative_path;
+      Alcotest.test_case "base_path guard agrees" `Quick
+        test_base_path_guard_agrees;
       Alcotest.test_case "escape hatch allows HOME" `Quick
         test_escape_hatch_allows_home;
     ];

--- a/test/test_fs_compat_home_guard.ml
+++ b/test/test_fs_compat_home_guard.ml
@@ -1,11 +1,4 @@
-(* #9921: write-boundary guard complementing the #9903 path-resolution
-   guard.  If any code path bypasses [Env_config_core.base_path()] and
-   asks [Fs_compat] to write under HOME, the guard raises
-   [Fs_compat.Test_isolation_breach] so the test crashes loud instead
-   of silently corrupting the production ledger.  The real production
-   ledger was observed to hold 106 test-pattern voter rows
-   ([hot-voter-*], [flipper], [same-voter], [judge]) written before the
-   #9920 partial fix landed. *)
+(* Every mutation entry point rejects a test destination under HOME. *)
 
 module FC = Fs_compat
 
@@ -22,16 +15,16 @@ let guard_path name =
 
 let test_append_under_home_raises () =
   disable_escape_hatch ();
-  let path = guard_path "_9921_guard_probe.jsonl" in
+  let path = guard_path "append-probe.jsonl" in
   try
     FC.append_file path "{\"probe\":1}\n";
     Alcotest.failf "expected Test_isolation_breach, but write succeeded to %S" path
   with FC.Test_isolation_breach msg ->
     Alcotest.(check bool)
-      "message references #9921"
+      "message names the isolation breach"
       true
       (let m = String.lowercase_ascii msg in
-       let needle = "#9921" in
+       let needle = "test isolation breach" in
        let nlen = String.length needle in
        let rec scan i =
          if i + nlen > String.length m then false
@@ -41,7 +34,7 @@ let test_append_under_home_raises () =
 
 let test_save_under_home_raises () =
   disable_escape_hatch ();
-  let path = guard_path "_9921_guard_probe_save.txt" in
+  let path = guard_path "save-probe.txt" in
   try
     FC.save_file path "probe";
     Alcotest.fail "expected Test_isolation_breach on save_file"
@@ -49,7 +42,7 @@ let test_save_under_home_raises () =
 
 let test_mkdir_under_home_raises () =
   disable_escape_hatch ();
-  let path = guard_path "_9921_guard_probe_dir" in
+  let path = guard_path "mkdir-probe" in
   try
     FC.mkdir_p path;
     Alcotest.fail "expected Test_isolation_breach on mkdir_p"
@@ -59,7 +52,7 @@ let test_tmp_write_allowed () =
   disable_escape_hatch ();
   let dir =
     Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-9921-guard-allow-%d" (Unix.getpid ()))
+      (Printf.sprintf "masc-home-guard-allow-%d" (Unix.getpid ()))
   in
   FC.mkdir_p dir;
   let path = Filename.concat dir "probe.txt" in
@@ -68,8 +61,6 @@ let test_tmp_write_allowed () =
   (* clean up *)
   (try Sys.remove path with Sys_error _ -> ());
   (try Unix.rmdir dir with Unix.Unix_error _ -> ())
-
-(* --- #27596: containment is decided by destination, not by spelling. --- *)
 
 let with_home new_home f =
   let real = home () in
@@ -83,7 +74,7 @@ let fresh_base label =
   let dir =
     Filename.concat
       (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-27596-%s-%d" label (Unix.getpid ()))
+      (Printf.sprintf "masc-home-containment-%s-%d" label (Unix.getpid ()))
   in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   dir
@@ -127,12 +118,79 @@ let test_symlink_into_home_is_blocked () =
     expect_blocked "<base>/link -> HOME" (fun () ->
       FC.append_file (Filename.concat link "probe.jsonl") "x\n"))
 
+let test_dangling_symlink_into_home_is_blocked () =
+  disable_escape_hatch ();
+  let base = fresh_base "dangling-symlink" in
+  let fake_home = Filename.concat base "home" in
+  (try Unix.mkdir fake_home 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let target = Filename.concat fake_home "new.jsonl" in
+  let link = Filename.concat base "out" in
+  (try Unix.symlink target link with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Alcotest.(check bool) "target starts missing" false (Sys.file_exists target);
+  with_home fake_home (fun () ->
+    expect_blocked "dangling link resolves into HOME" (fun () ->
+      FC.append_file link "x\n"));
+  Alcotest.(check bool) "blocked write did not create target" false
+    (Sys.file_exists target)
+
+let test_symlink_then_dotdot_into_home_is_blocked () =
+  disable_escape_hatch ();
+  let base = fresh_base "symlink-dotdot" in
+  let fake_home = Filename.concat base "home" in
+  let subdir = Filename.concat fake_home "subdir" in
+  FC.mkdir_p fake_home;
+  FC.mkdir_p subdir;
+  let link = Filename.concat base "link" in
+  (try Unix.symlink subdir link with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  with_home fake_home (fun () ->
+    expect_blocked "symlink is resolved before the following dotdot" (fun () ->
+      FC.append_file (Filename.concat link "../victim.jsonl") "x\n"))
+
+let test_symlink_cycle_is_blocked () =
+  disable_escape_hatch ();
+  let base = fresh_base "symlink-cycle" in
+  let fake_home = Filename.concat base "home" in
+  (try Unix.mkdir fake_home 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let loop = Filename.concat base "loop" in
+  (try Unix.symlink "loop" loop with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  with_home fake_home (fun () ->
+    expect_blocked "unresolvable symlink cycle" (fun () ->
+      FC.append_file loop "x\n"))
+
+let test_path_space_is_not_trimmed () =
+  disable_escape_hatch ();
+  let base = fresh_base "space" in
+  let fake_home = Filename.concat base "home" in
+  (try Unix.mkdir fake_home 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let outside = Filename.concat base "outside " in
+  with_home fake_home (fun () ->
+    expect_allowed "trailing space remains part of the path" (fun () ->
+      FC.mkdir_p outside));
+  Alcotest.(check bool) "directory with trailing space exists" true
+    (Sys.file_exists outside);
+  Unix.rmdir outside
+
+let test_escape_hatch_vocabulary_is_exact () =
+  let check_value raw expected =
+    Alcotest.(check bool)
+      (match raw with None -> "unset" | Some value -> Printf.sprintf "%S" value)
+      expected
+      (Path_containment.home_guard_bypass_enabled raw)
+  in
+  check_value None false;
+  check_value (Some "") false;
+  check_value (Some "1") true;
+  check_value (Some "true") true;
+  check_value (Some "yes") false;
+  check_value (Some "TRUE") false;
+  check_value (Some " true ") false
+
 (* HOME=/ with a relative path: it resolves under the cwd, which is under /. *)
 let test_home_root_blocks_relative_path () =
   disable_escape_hatch ();
   with_home "/" (fun () ->
     expect_blocked "relative path under HOME=/" (fun () ->
-      FC.append_file "masc-27596-relative-probe.jsonl" "x\n"))
+      FC.append_file "masc-home-relative-probe.jsonl" "x\n"))
 
 (* A sibling whose name merely extends HOME's is not under HOME. *)
 let test_sibling_allowed () =
@@ -152,7 +210,7 @@ let test_home_root_blocks_absolute_path () =
   disable_escape_hatch ();
   let path =
     Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-27596-abs-%d.txt" (Unix.getpid ()))
+      (Printf.sprintf "masc-home-absolute-%d.txt" (Unix.getpid ()))
   in
   with_home "/" (fun () ->
     expect_blocked "absolute path under HOME=/" (fun () ->
@@ -187,7 +245,7 @@ let test_base_path_guard_agrees () =
 
 let test_escape_hatch_allows_home () =
   Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" "1";
-  let path = guard_path "_9921_guard_probe_bypass.jsonl" in
+  let path = guard_path "bypass-probe.jsonl" in
   let parent = Filename.dirname path in
   let parent_existed = Sys.file_exists parent in
   Fun.protect
@@ -227,6 +285,16 @@ let () =
         test_dotdot_reentry_is_blocked;
       Alcotest.test_case "symlink into HOME blocked" `Quick
         test_symlink_into_home_is_blocked;
+      Alcotest.test_case "dangling symlink into HOME blocked" `Quick
+        test_dangling_symlink_into_home_is_blocked;
+      Alcotest.test_case "symlink then dotdot into HOME blocked" `Quick
+        test_symlink_then_dotdot_into_home_is_blocked;
+      Alcotest.test_case "symlink cycle blocked" `Quick
+        test_symlink_cycle_is_blocked;
+      Alcotest.test_case "path spaces are preserved" `Quick
+        test_path_space_is_not_trimmed;
+      Alcotest.test_case "escape hatch vocabulary is exact" `Quick
+        test_escape_hatch_vocabulary_is_exact;
       Alcotest.test_case "HOME=/ blocks relative path" `Quick
         test_home_root_blocks_relative_path;
       Alcotest.test_case "base_path guard agrees" `Quick


### PR DESCRIPTION
Closes #27596.

## Contract

`Path_containment.classify` is the single destination classifier used by both the base-path admission guard and every guarded filesystem mutation. It returns `Inside | Outside | Undecidable`; both consumers fail closed on `Inside` and `Undecidable`.

Resolution processes components in kernel order with `lstat` and `readlink`:

- symbolic links are expanded before following `..` components
- dangling links retain and resolve their target path
- missing ordinary mutation targets are retained
- symlink cycles and non-`ENOENT` resolution errors are `Undecidable`
- leading and trailing spaces remain pathname bytes
- containment comparison is component-based

The shared escape-hatch parser accepts only exact `1` and `true`; both guards use that same owner.

## Focused proof

Added consumer-boundary cases for a dangling link into HOME, symlink followed by `..`, a symlink cycle, pathname spaces, and the exact escape-hatch vocabulary. Existing sibling, root, relative, duplicate-separator, ordinary symlink, and both-entrypoint cases remain.

Local verification:

- `ocamlformat` on all changed OCaml files
- `ocamlc -stop-after parsing` on all changed OCaml files
- standalone interface/implementation compilation for `Path_containment`
- direct source execution: dangling=`Inside`, symlink+dotdot=`Inside`, cycle=`Undecidable`, spaced sibling=`Outside`
- `git diff --check`
- focused Dune target requested but deferred to PR CI because the repository wrapper detected unrelated active bare-Dune processes and correctly refused concurrent execution
