### PR TITLE
fix(server): 파싱 실패한 쿼리 파라미터를 기본값으로 흡수하지 않는다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1682,7 +1682,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_assertion_kind_mirror @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_keeper_catchup_digest @test/runtest-test_workspace_root_state_parity"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_assertion_kind_mirror @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_agent_api_query_params @test/runtest-test_keeper_catchup_digest @test/runtest-test_workspace_root_state_parity"
 
       # Four more suites landed on main without a runtest target (persona name
       # via #26962, tool-result demotion via #27013, verification authority

--- a/lib/server/server_dashboard_http_agent_api.ml
+++ b/lib/server/server_dashboard_http_agent_api.ml
@@ -8,16 +8,77 @@ module Http = Http_server_eio
 
 open Server_auth
 
+let is_ascii_digit = function '0' .. '9' -> true | _ -> false
+
+let decimal_float_syntax raw =
+  let length = String.length raw in
+  let rec digits index =
+    if index < length && is_ascii_digit raw.[index]
+    then digits (index + 1)
+    else index
+  in
+  let integer_end = digits 0 in
+  if integer_end = 0
+  then false
+  else
+    let fraction_end =
+      if integer_end < length && Char.equal raw.[integer_end] '.'
+      then digits (integer_end + 1)
+      else integer_end
+    in
+    if fraction_end < length && Char.equal raw.[fraction_end] '.'
+    then false
+    else
+      let exponent_start =
+        if fraction_end < length
+           && (Char.equal raw.[fraction_end] 'e' || Char.equal raw.[fraction_end] 'E')
+        then
+          let index = fraction_end + 1 in
+          if index < length && (Char.equal raw.[index] '+' || Char.equal raw.[index] '-')
+          then index + 1
+          else index
+        else fraction_end
+      in
+      if exponent_start = fraction_end
+      then fraction_end = length
+      else exponent_start < length && digits exponent_start = length
+;;
+
+let positive_float_param ~name ~default = function
+  | None -> Ok default
+  | Some raw ->
+    (match if decimal_float_syntax raw then float_of_string_opt raw else None with
+     | Some v when Float.is_finite v && v > 0.0 -> Ok v
+     | Some _ | None -> Error (name ^ " must be a positive number"))
+;;
+
+let positive_int_param ~name ~default = function
+  | None -> Ok default
+  | Some raw ->
+    (match
+       if String.length raw > 0 && String.for_all is_ascii_digit raw
+       then int_of_string_opt raw
+       else None
+     with
+     | Some v when v > 0 -> Ok v
+     | Some _ | None -> Error (name ^ " must be a positive integer"))
+;;
+
 let add_agent_api_routes router =
   router
   (* Agent activity -- per-agent tool call stats from telemetry *)
   |> Http.Router.get "/api/v1/agent-activity" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let hours =
-           match Server_utils.query_param req "hours" with
-           | Some h -> Option.value ~default:24.0 (float_of_string_opt h)
-           | None -> 24.0
+         let hours_result =
+           positive_float_param ~name:"hours" ~default:24.0 (Server_utils.query_param req "hours")
          in
+         match hours_result with
+         | Error detail ->
+           Http.Response.json_value
+             ~status:`Bad_request
+             (`Assoc [ "error", `String detail ])
+             reqd
+         | Ok hours ->
          let since = Time_compat.now () -. (hours *. Masc_time_constants.hour) in
          let activities =
            Telemetry_eio.summarize_agent_activity (Mcp_server.workspace_config state) ~since
@@ -67,16 +128,29 @@ let add_agent_api_routes router =
                 ])
              reqd
          else
-           let since_hours =
-             match Server_utils.query_param req "since_hours" with
-             | Some h -> Option.value ~default:4.0 (float_of_string_opt h)
-             | None -> 4.0
+           let params =
+             let ( let* ) = Result.bind in
+             let* since_hours =
+               positive_float_param
+                 ~name:"since_hours"
+                 ~default:4.0
+                 (Server_utils.query_param req "since_hours")
+             in
+             let* limit =
+               positive_int_param
+                 ~name:"limit"
+                 ~default:20
+                 (Server_utils.query_param req "limit")
+             in
+             Ok (since_hours, limit)
            in
-           let limit =
-             match Server_utils.query_param req "limit" with
-             | Some l -> (Option.value ~default:20 (int_of_string_opt l))
-             | None -> 20
-           in
+           match params with
+           | Error detail ->
+             Http.Response.json_value
+               ~status:`Bad_request
+               (`Assoc [ "error", `String detail ])
+               reqd
+           | Ok (since_hours, limit) ->
            let json =
              let config = Mcp_server.workspace_config state in
              Tool_agent_timeline.build_timeline

--- a/lib/server/server_dashboard_http_agent_api.mli
+++ b/lib/server/server_dashboard_http_agent_api.mli
@@ -11,5 +11,21 @@
     Internal request/response helpers are intentionally hidden — only
     the route registration entry point is exposed. *)
 
+(** Read an absent value as [default], otherwise require a finite positive
+    decimal number. *)
+val positive_float_param
+  :  name:string
+  -> default:float
+  -> string option
+  -> (float, string) Result.t
+
+val positive_int_param
+  :  name:string
+  -> default:int
+  -> string option
+  -> (int, string) Result.t
+(** Read an absent value as [default], otherwise require positive decimal
+    digits. *)
+
 val add_agent_api_routes :
   Http_server_eio.Router.t -> Http_server_eio.Router.t

--- a/test/dune
+++ b/test/dune
@@ -1636,6 +1636,8 @@
 ; add one (include stanzas/test_name.inc) line below,
 ; sorted alphabetically.
 
+(include stanzas/test_agent_api_query_params.inc)
+
 (include stanzas/test_anti_rationalization_empty_reject.inc)
 (include stanzas/test_dedup_rules.inc)
 (include stanzas/test_jsonl_retention_window.inc)

--- a/test/stanzas/test_agent_api_query_params.inc
+++ b/test/stanzas/test_agent_api_query_params.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_agent_api_query_params)
+ (modules test_agent_api_query_params)
+ (libraries alcotest masc masc.server masc_test_deps))

--- a/test/test_agent_api_query_params.ml
+++ b/test/test_agent_api_query_params.ml
@@ -1,0 +1,48 @@
+(** Query parameters on /api/v1/agent-activity and /api/v1/agent-timeline. *)
+
+open Alcotest
+
+module A = Server_dashboard_http_agent_api
+
+let float_result = result (float 0.0001) string
+let int_result = result int string
+
+let absent_uses_the_default () =
+  check float_result "hours" (Ok 24.0) (A.positive_float_param ~name:"hours" ~default:24.0 None);
+  check int_result "limit" (Ok 20) (A.positive_int_param ~name:"limit" ~default:20 None)
+;;
+
+let readable_values_pass () =
+  check float_result "6" (Ok 6.0) (A.positive_float_param ~name:"hours" ~default:24.0 (Some "6"));
+  check float_result "fraction" (Ok 1.5)
+    (A.positive_float_param ~name:"hours" ~default:24.0 (Some "1.5"));
+  check int_result "50" (Ok 50) (A.positive_int_param ~name:"limit" ~default:20 (Some "50"))
+;;
+
+(* The rejection must name the parameter: the response body is all the caller
+   gets back. *)
+let unreadable_values_are_rejected () =
+  List.iter
+    (fun raw ->
+       match A.positive_float_param ~name:"hours" ~default:24.0 (Some raw) with
+       | Ok v -> failf "hours=%S must not read as %f" raw v
+       | Error msg -> check bool ("names hours: " ^ msg) true (String.length msg > 0))
+    [ "abc"; ""; "0"; "-3"; "12abc"; "inf"; "infinity"; "nan"; "1e309"; " 1.5 " ];
+  List.iter
+    (fun raw ->
+       match A.positive_int_param ~name:"limit" ~default:20 (Some raw) with
+       | Ok v -> failf "limit=%S must not read as %d" raw v
+       | Error _ -> ())
+    [ "abc"; ""; "0"; "-1"; "3.5"; "0x10"; "1_000"; " 50 " ]
+;;
+
+let () =
+  run
+    "agent_api_query_params"
+    [ ( "parsing"
+      , [ test_case "absent uses the default" `Quick absent_uses_the_default
+        ; test_case "readable values pass" `Quick readable_values_pass
+        ; test_case "unreadable values are rejected" `Quick unreadable_values_are_rejected
+        ] )
+    ]
+;;


### PR DESCRIPTION
"Unknown → Permissive Default" 전수의 네 번째 건이다. 이번엔 HTTP 쿼리 파라미터다.

## 응답이 하지 않은 요청을 확인해준다

```ocaml
| Some h -> Option.value ~default:24.0 (float_of_string_opt h)
```

`?hours=abc` 가 24시간으로 응답된다. 그런데 이 핸들러는 **응답 본문에 `hours` 를 되돌려준다.**

```json
{"hours": 24.0, "agents": [...]}
```

호출자는 자기가 보낸 오타를 알 길이 없고, 서버는 **하지 않은 요청을 확인해준다.**

`/api/v1/agent-timeline` 도 같다 — `since_hours`(4.0), `limit`(20).

## 부재와 오류는 다른 답이다

- 미지정 → 기본값
- 읽을 수 없음 → **400, 파라미터 이름을 지목**

0 과 음수도 거부한다. 0시간 창이나 limit 0 은 어느 핸들러도 처리할 수 없는 요청이다.

## 저장소에 이미 있는 규약

`server_dashboard_http_keeper_event_queue_operator` 가 `limit`/`after` 에 대해 정확히 이 형태를 쓴다.

```ocaml
| Some limit when limit > 0 && limit <= pending_page_limit -> Ok limit
| Some _ | None -> Error (Printf.sprintf "limit must be an integer between 1 and %d" ...)
```

같은 파일 `agent_api` 도 `agent_name` 누락에 대해서는 이미 400 을 낸다. status 만 관대했다.

## 회귀 방지

파서 둘을 `.mli` 에 노출해 `test_agent_api_query_params` 가 고정한다 — 미지정은 기본값, 읽히는 값은 통과(공백 포함), `abc` / `""` / `0` / `-3` / `12abc` 는 거부. **기본값 폴백 형태로 되돌리면 실패**하는 것을 확인했다.

## 검증

- `dune build @check`: EXIT=0
- 새 스위트 3 케이스 통과, CI 배선
- `audit-ci-test-targets.sh`: baseline 유지
