### PR TITLE
fix(benchmark): 케이스 category 를 필수로 — 거부 파서를 기본값이 우회하고 있었다

### DIFF
--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
@@ -135,9 +135,9 @@ let benchmark_case_of_yojson json =
   let* forbidden_selectors = selector_list_field json "forbidden_selectors" in
   let* required_selectors = selector_list_field json "required_selectors" in
   let* category =
-    Json_util.get_string json "category"
-    |> Option.value ~default:"tool_use"
-    |> case_category_of_string
+    match Json_util.get_string json "category" with
+    | Some raw -> case_category_of_string raw
+    | None -> Error "tool-call-quality case: category is required"
   in
   let* arg_check_items = list_field json "arg_checks" in
   let* arg_checks = map_m parse_arg_check arg_check_items in

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -1,6 +1,12 @@
 open Alcotest
 open Masc
 
+let contains_sub haystack needle =
+  let n = String.length needle and h = String.length haystack in
+  let rec go i = i + n <= h && (String.sub haystack i n = needle || go (i + 1)) in
+  n = 0 || go 0
+;;
+
 let fixture_cases repo_root =
   Tool_call_quality_benchmark.default_case_set_path ~repo_root
 
@@ -14,6 +20,22 @@ let fixture_runs repo_root =
    workspace source root as DUNE_SOURCEROOT; resolve fixtures against it and
    fall back to cwd for direct (non-dune) invocation. Mirrors
    test_disk_hygiene_script.ml / test_ci_run_tests_script.ml. *)
+let test_loader_requires_case_category () =
+  let path = Filename.temp_file "tcq_cases" ".json" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+       let oc = open_out path in
+       output_string
+         oc
+         {|{"cases":[{"id":"c","prompt":"p","keeper_profiles":["k"],"success_checks":[{"path":"$.status","equals":"completed"}],"expected_tools":[],"forbidden_tools":[],"arg_checks":[]}]}|};
+       close_out oc;
+       match Tool_call_quality_benchmark.load_cases_from_file path with
+       | Ok _ -> fail "a case without a category must not load"
+       | Error msg ->
+         check bool ("names category: " ^ msg) true (contains_sub msg "category"))
+;;
+
 let repo_source_root () =
   match Sys.getenv_opt "DUNE_SOURCEROOT" with Some root -> root | None -> Sys.getcwd ()
 
@@ -641,5 +663,7 @@ let () =
              test_case_selectors_resolve_to_live_descriptors;
            test_case "arg check paths exist in descriptor schema" `Quick
              test_arg_check_paths_exist_in_descriptor_schema;
+           test_case "loader requires a case category" `Quick
+             test_loader_requires_case_category;
          ]);
     ]


### PR DESCRIPTION
#27606 이 제기한 "로더가 malformed 필드를 조용히 강제한다"를 검증했다. **거부 파서가 이미 있는데 호출부가 무력화하는 지점**이 하나 있었다.

## 거부 파서를 기본값으로 우회한다

```ocaml
Json_util.get_string json "category"
|> Option.value ~default:"tool_use"     ← 여기서 무력화
|> case_category_of_string              ← 모르는 값은 거부하는 파서
```

`case_category_of_string` 은 미인식 카테고리를 `errorf` 로 거부한다. 그런데 **필드가 없으면 그 파서에 도달하기 전에 `"tool_use"` 가 채워진다.**

결과: 카테고리를 선언하지 않은 케이스가 **tool-use 케이스로 채점되고 아무 말이 없다.** "누락"과 `"tool_use"` 가 같은 입력이 된다.

## 데이터 영향 없음

`benchmarks/data/tool_call_quality_cases.json` 의 케이스 4개는 모두 `category` 를 선언한다(확인함). 필수화해도 기존 데이터는 그대로 로드된다.

## 회귀 방지

`category` 없는 케이스를 로드해 **실패하고 그 필드를 지목하는지** 검사한다. 기본값 형태로 되돌리면 라벨 없는 케이스가 통과해 테스트가 실패하는 것을 확인했다.

최소 유효 케이스를 만드는 데 필수 필드가 넷 더 있었다(`id`, `prompt`, `keeper_profiles`, `success_checks`) — 로더가 이미 그것들은 요구한다. `category` 만 예외였다.

## 범위

#27606 은 evidence 계약 전반(canary 산출물 미소비, 리스트 필드 관대 처리, 문자열 기반 성공 판정)을 다룬다. 이 PR 은 **거부 파서가 이미 존재하는데 우회당한 한 곳만** 고친다.

`Keeper_benchmark_canary` 관련 지적도 확인했다 — 140줄 모듈이 `test/tool_call_quality_benchmark_cli.ml` 에서만 호출되고 산출물 `keeper_model_recommendations.json` 은 저장소 전체에서 **읽는 곳이 0** 이다. 그건 그 이슈의 주제라 손대지 않았다.

## 검증

- `dune build @check`: EXIT=0
- `test_tool_call_quality_benchmark`(CI 배선): 18 케이스 통과
