### PR TITLE
fix(verification): bind authority tools to exact descriptors

### DIFF
--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -478,6 +478,20 @@ let process_task_once
       ();
     process_outcome
   in
+  let reject_contract ~reason ~detail =
+    complete
+      (commit_verdict
+         runtime
+         task
+         ~assignee
+         ~verification_id
+         ~authority
+         ~verdict:(Masc_domain.Verdict_rejected { reason })
+         ~notes:reason
+         ~verdict_label:"rejected_contract"
+         ~on_commit:(Verification_run_registry.Contract_rejected { detail })
+         ~evaluator_runtime:None)
+  in
   try
     match
       prepare_review
@@ -489,64 +503,36 @@ let process_task_once
     with
     | Error reason ->
       let rejection_reason = "completion evidence contract invalid: " ^ reason in
-      complete
-        (commit_verdict
-           runtime
-           task
-           ~assignee
-           ~verification_id
-           ~authority
-           ~verdict:(Masc_domain.Verdict_rejected { reason = rejection_reason })
-           ~notes:rejection_reason
-           ~verdict_label:"rejected_contract"
-           ~on_commit:
-             (Verification_run_registry.Contract_rejected { detail = reason })
-             (* The evidence contract was rejected before any evaluator ran, so
-                this verdict has no judging runtime to name. *)
-           ~evaluator_runtime:None)
+      reject_contract ~reason:rejection_reason ~detail:reason
     | Ok prepared ->
-      (* The lookup surface borrows the producer's own keeper meta, so the same
-         judge reaches a different tree on the next task. [assignee] is the
-         worker the evidence snapshot was materialized against — [prepare_review]
-         rejects the request when it disagrees with [request.worker], so the
-         two cannot name different trees.
-
-         A producer with no readable meta leaves the judge on the snapshot
-         alone. The prompt says so in that case rather than advertising tools
-         whose every call would fail, and the reason is logged: a review that
-         could not reach the tree is a different event from one that chose not
-         to look. *)
-      let lookup =
-        match
-          Verification_authority_tools.create
-            ~config:runtime.config
-            ~producer:assignee
-        with
-        | Ok lookup_tools ->
-          Task.Anti_rationalization.Lookup_tools
-            { schemas = Verification_authority_tools.schemas lookup_tools
-            ; dispatch = Verification_authority_tools.dispatch lookup_tools
-            }
-        | Error reason ->
-          Log.Task.warn
-            "[verification-lookup] surface unavailable producer=%s: %s"
-            assignee
-            reason;
-          Task.Anti_rationalization.No_lookup_surface
-      in
-      let result =
-        Task.Anti_rationalization.review
-          ~base_path:runtime.config.base_path
-          ~sw:(Some runtime.sw)
-          ~lookup
-          ?completion_contract:prepared.completion_contract
-          ~required_evidence:prepared.required_artifacts
-          ~verify_gate_evidence:[]
-          ~on_tool_result
-          prepared.review_request
-      in
-      let evaluator_runtime = result.evaluator_runtime in
-      (match result.verdict with
+      (match
+         Verification_authority_tools.create
+           ~config:runtime.config
+           ~producer:assignee
+       with
+       | Error reason ->
+         let rejection_reason = "completion lookup contract invalid: " ^ reason in
+         reject_contract ~reason:rejection_reason ~detail:reason
+       | Ok lookup_tools ->
+         let lookup =
+           Task.Anti_rationalization.Lookup_tools
+             { schemas = Verification_authority_tools.schemas lookup_tools
+             ; dispatch = Verification_authority_tools.dispatch lookup_tools
+             }
+         in
+         let result =
+           Task.Anti_rationalization.review
+             ~base_path:runtime.config.base_path
+             ~sw:(Some runtime.sw)
+             ~lookup
+             ?completion_contract:prepared.completion_contract
+             ~required_evidence:prepared.required_artifacts
+             ~verify_gate_evidence:[]
+             ~on_tool_result
+             prepared.review_request
+         in
+         let evaluator_runtime = result.evaluator_runtime in
+         match result.verdict with
        | None ->
          let gate = Task.Anti_rationalization.gate_to_string result.gate in
          (* Both arms are real descriptions, not a default standing in for an

--- a/lib/verification_authority_tools.ml
+++ b/lib/verification_authority_tools.ml
@@ -55,14 +55,29 @@ let ownership_root t = t.ownership_root
 (* Schemas                                                          *)
 (* ================================================================ *)
 
-(* The keeper catalog is the source. Restating a description here would let a
-   judge and a producer read different documentation for the same tool, and the
-   one that drifts is always the copy. *)
+(* [Keeper_tool_descriptor] owns what a model is shown, and a judge is a model
+   looking at these tools. Sourcing the surface anywhere else gives the same
+   handler two model-facing vocabularies, and the one that drifts is always the
+   second: reading [Tool_shard.all_keeper_tool_schemas] here — which documents
+   handler inputs, not model exposure — had already left the judge asking for
+   "path" while a Keeper asked for "file_path" (#27605).
+
+   Naming stays internal. [tool_name] is what [tool_of_name] parses back and
+   what the model is told to call, so the two halves of dispatch cannot drift
+   apart into a public spelling the reverse lookup does not know. *)
+let descriptor_of_tool tool =
+  match Keeper_tool_descriptor.descriptors_for_internal (tool_name tool) with
+  | [ descriptor ] -> Some descriptor
+  | [] | _ :: _ :: _ -> None
+;;
+
 let schema_of_tool tool : Types_core.tool_schema option =
-  List.find_opt
-    (fun (schema : Types_core.tool_schema) ->
-       String.equal schema.name (tool_name tool))
-    Tool_shard.all_keeper_tool_schemas
+  descriptor_of_tool tool
+  |> Option.map (fun (descriptor : Keeper_tool_descriptor.t) ->
+    { Types_core.name = tool_name tool
+    ; description = descriptor.description
+    ; input_schema = descriptor.input_schema
+    })
 ;;
 
 let schemas _t = List.filter_map schema_of_tool all_tools
@@ -79,17 +94,19 @@ type lookup_outcome =
   | Rejected
   | Unknown_tool
   | Missing_schema
+  | Invalid_input
 
 let lookup_outcome_label = function
   | Resolved -> "resolved"
   | Rejected -> "rejected"
   | Unknown_tool -> "unknown_tool"
   | Missing_schema -> "missing_schema"
+  | Invalid_input -> "invalid_input"
 ;;
 
 let lookup_outcome_level = function
   | Resolved -> Log.Info
-  | Rejected | Unknown_tool | Missing_schema -> Log.Warn
+  | Rejected | Unknown_tool | Missing_schema | Invalid_input -> Log.Warn
 ;;
 
 (* What the judge ran, and whether it got an answer. An operator reading the
@@ -160,25 +177,49 @@ let dispatch t ~name ~args =
     log_call t ~name ~argument:"" ~outcome:Unknown_tool;
     Error detail
   | Some tool ->
-    (* A tool the evaluator was never offered cannot be answered here either:
-       [schemas] filters on the keeper catalog, so a name that resolves to a
-       constructor but has no schema was not in the surface the model saw. *)
-    (match schema_of_tool tool with
+    (* A tool the evaluator was never offered cannot be answered here either: a
+       name that resolves to a constructor but to no descriptor was not in the
+       surface the model saw. *)
+    (match descriptor_of_tool tool with
      | None ->
        let detail =
          Printf.sprintf
-           "tool %s is not in the keeper schema catalog for this build"
+           "tool %s is not in the keeper descriptor registry for this build"
            name
        in
        log_call t ~name ~argument:"" ~outcome:Missing_schema;
        Error detail
-     | Some _ ->
+     | Some descriptor ->
        let argument = Yojson.Safe.to_string args in
-       let result = run t tool ~args in
-       log_call
-         t
-         ~name
-         ~argument
-         ~outcome:(match result with Ok _ -> Resolved | Error _ -> Rejected);
-       result)
+       (* The same validation and translation a Keeper's call passes through.
+          [run] hands the arguments to the runtime handlers directly, and those
+          read the handler-native spelling: [handle_read_file_with_outcome] takes
+          "path", which [translate_input_for_descriptor] produces from the
+          "file_path" the schema above advertises.
+
+          Skipping this step was the defect. Untranslated arguments reach the
+          handler as absent ones, and the handlers default a missing required
+          string to "" rather than refusing — so a judge read resolved an empty
+          path and returned [Ok], and a verdict reached without opening the file
+          was indistinguishable from one reached by reading it (#27605). The
+          schema validation here is what turns that into a refusal the model is
+          told about. *)
+       (match
+          Keeper_tool_descriptor_resolution.prepare_model_input_for_descriptor
+            ~tool_name:name
+            descriptor
+            ~input:args
+        with
+        | Error rejection ->
+          let detail = Tool_result.message rejection in
+          log_call t ~name ~argument ~outcome:Invalid_input;
+          Error detail
+        | Ok prepared_args ->
+          let result = run t tool ~args:prepared_args in
+          log_call
+            t
+            ~name
+            ~argument
+            ~outcome:(match result with Ok _ -> Resolved | Error _ -> Rejected);
+          result))
 ;;

--- a/lib/verification_authority_tools.ml
+++ b/lib/verification_authority_tools.ml
@@ -17,36 +17,58 @@ let tool_name = function
 
 let all_tools = [ Read_file; Search_files; Execute ]
 
-let tool_of_name name =
-  List.find_opt (fun tool -> String.equal (tool_name tool) name) all_tools
-;;
-
 type t =
   { ownership_root : string
   ; config : Workspace.config
   ; producer_meta : Keeper_meta_contract.keeper_meta
+  ; tools : (tool * Keeper_tool_descriptor.t) list
   }
 
-let create ~config ~producer =
-  match Keeper_meta_store.read_meta config producer with
-  | Error message ->
-    Error (Printf.sprintf "producer %s meta unreadable: %s" producer message)
-  | Ok None ->
+let descriptor_of_tool tool =
+  match Keeper_tool_descriptor.descriptors_for_internal (tool_name tool) with
+  | [ descriptor ] -> Ok (tool, descriptor)
+  | [] ->
     Error
       (Printf.sprintf
-         "producer %s has no keeper meta; there is no tree to inspect"
-         producer)
-  | Ok (Some producer_meta) ->
-    let project_root =
-      Workspace_verification_store.project_root_of_base_path config.base_path
-    in
-    let ownership_root =
-      Keeper_sandbox_config.host_root_abs_of_agent
-        ~base_path:project_root
-        ~agent_name:producer
-      |> Env_config_core.strip_trailing_slashes
-    in
-    Ok { ownership_root; config; producer_meta }
+         "tool %s is missing from the keeper descriptor registry"
+         (tool_name tool))
+  | descriptors ->
+    Error
+      (Printf.sprintf
+         "tool %s has %d keeper descriptors"
+         (tool_name tool)
+         (List.length descriptors))
+;;
+
+let rec resolve_tools = function
+  | [] -> Ok []
+  | tool :: rest ->
+    let open Result.Syntax in
+    let* descriptor = descriptor_of_tool tool in
+    let* descriptors = resolve_tools rest in
+    Ok (descriptor :: descriptors)
+;;
+
+let create ~config ~producer =
+  let open Result.Syntax in
+  let* tools = resolve_tools all_tools in
+  let* producer_meta =
+    match Keeper_meta_store.read_meta config producer with
+    | Error message ->
+      Error (Printf.sprintf "producer %s meta unreadable: %s" producer message)
+    | Ok None -> Error (Printf.sprintf "producer %s has no keeper meta" producer)
+    | Ok (Some producer_meta) -> Ok producer_meta
+  in
+  let project_root =
+    Workspace_verification_store.project_root_of_base_path config.base_path
+  in
+  let ownership_root =
+    Keeper_sandbox_config.host_root_abs_of_agent
+      ~base_path:project_root
+      ~agent_name:producer
+    |> Env_config_core.strip_trailing_slashes
+  in
+  Ok { ownership_root; config; producer_meta; tools }
 ;;
 
 let ownership_root t = t.ownership_root
@@ -55,32 +77,14 @@ let ownership_root t = t.ownership_root
 (* Schemas                                                          *)
 (* ================================================================ *)
 
-(* [Keeper_tool_descriptor] owns what a model is shown, and a judge is a model
-   looking at these tools. Sourcing the surface anywhere else gives the same
-   handler two model-facing vocabularies, and the one that drifts is always the
-   second: reading [Tool_shard.all_keeper_tool_schemas] here — which documents
-   handler inputs, not model exposure — had already left the judge asking for
-   "path" while a Keeper asked for "file_path" (#27605).
-
-   Naming stays internal. [tool_name] is what [tool_of_name] parses back and
-   what the model is told to call, so the two halves of dispatch cannot drift
-   apart into a public spelling the reverse lookup does not know. *)
-let descriptor_of_tool tool =
-  match Keeper_tool_descriptor.descriptors_for_internal (tool_name tool) with
-  | [ descriptor ] -> Some descriptor
-  | [] | _ :: _ :: _ -> None
+let schema_of_tool (tool, (descriptor : Keeper_tool_descriptor.t)) : Types_core.tool_schema =
+  { Types_core.name = tool_name tool
+  ; description = descriptor.description
+  ; input_schema = descriptor.input_schema
+  }
 ;;
 
-let schema_of_tool tool : Types_core.tool_schema option =
-  descriptor_of_tool tool
-  |> Option.map (fun (descriptor : Keeper_tool_descriptor.t) ->
-    { Types_core.name = tool_name tool
-    ; description = descriptor.description
-    ; input_schema = descriptor.input_schema
-    })
-;;
-
-let schemas _t = List.filter_map schema_of_tool all_tools
+let schemas t = List.map schema_of_tool t.tools
 
 (* ================================================================ *)
 (* Dispatch                                                         *)
@@ -93,20 +97,18 @@ type lookup_outcome =
   | Resolved
   | Rejected
   | Unknown_tool
-  | Missing_schema
   | Invalid_input
 
 let lookup_outcome_label = function
   | Resolved -> "resolved"
   | Rejected -> "rejected"
   | Unknown_tool -> "unknown_tool"
-  | Missing_schema -> "missing_schema"
   | Invalid_input -> "invalid_input"
 ;;
 
 let lookup_outcome_level = function
   | Resolved -> Log.Info
-  | Rejected | Unknown_tool | Missing_schema | Invalid_input -> Log.Warn
+  | Rejected | Unknown_tool | Invalid_input -> Log.Warn
 ;;
 
 (* What the judge ran, and whether it got an answer. An operator reading the
@@ -166,7 +168,7 @@ let run t tool ~args =
 ;;
 
 let dispatch t ~name ~args =
-  match tool_of_name name with
+  match List.find_opt (fun (tool, _) -> String.equal (tool_name tool) name) t.tools with
   | None ->
     let detail =
       Printf.sprintf
@@ -176,50 +178,24 @@ let dispatch t ~name ~args =
     in
     log_call t ~name ~argument:"" ~outcome:Unknown_tool;
     Error detail
-  | Some tool ->
-    (* A tool the evaluator was never offered cannot be answered here either: a
-       name that resolves to a constructor but to no descriptor was not in the
-       surface the model saw. *)
-    (match descriptor_of_tool tool with
-     | None ->
-       let detail =
-         Printf.sprintf
-           "tool %s is not in the keeper descriptor registry for this build"
-           name
-       in
-       log_call t ~name ~argument:"" ~outcome:Missing_schema;
+  | Some (tool, descriptor) ->
+    let argument = Yojson.Safe.to_string args in
+    (match
+       Keeper_tool_descriptor_resolution.prepare_model_input_for_descriptor
+         ~tool_name:name
+         descriptor
+         ~input:args
+     with
+     | Error rejection ->
+       let detail = Tool_result.message rejection in
+       log_call t ~name ~argument ~outcome:Invalid_input;
        Error detail
-     | Some descriptor ->
-       let argument = Yojson.Safe.to_string args in
-       (* The same validation and translation a Keeper's call passes through.
-          [run] hands the arguments to the runtime handlers directly, and those
-          read the handler-native spelling: [handle_read_file_with_outcome] takes
-          "path", which [translate_input_for_descriptor] produces from the
-          "file_path" the schema above advertises.
-
-          Skipping this step was the defect. Untranslated arguments reach the
-          handler as absent ones, and the handlers default a missing required
-          string to "" rather than refusing — so a judge read resolved an empty
-          path and returned [Ok], and a verdict reached without opening the file
-          was indistinguishable from one reached by reading it (#27605). The
-          schema validation here is what turns that into a refusal the model is
-          told about. *)
-       (match
-          Keeper_tool_descriptor_resolution.prepare_model_input_for_descriptor
-            ~tool_name:name
-            descriptor
-            ~input:args
-        with
-        | Error rejection ->
-          let detail = Tool_result.message rejection in
-          log_call t ~name ~argument ~outcome:Invalid_input;
-          Error detail
-        | Ok prepared_args ->
-          let result = run t tool ~args:prepared_args in
-          log_call
-            t
-            ~name
-            ~argument
-            ~outcome:(match result with Ok _ -> Resolved | Error _ -> Rejected);
-          result))
+     | Ok prepared_args ->
+       let result = run t tool ~args:prepared_args in
+       log_call
+         t
+         ~name
+         ~argument
+         ~outcome:(match result with Ok _ -> Resolved | Error _ -> Rejected);
+       result)
 ;;

--- a/lib/verification_authority_tools.mli
+++ b/lib/verification_authority_tools.mli
@@ -1,89 +1,15 @@
-(** The producer's own tool surface, lent to the completion authority
-    (RFC-0361 D1).
-
-    The judge decides whether submitted work is real. Until now its only tool
-    was [report_review_verdict], so the submitter's evidence snapshot was the
-    upper bound of what could be judged: a reference the submitter did not
-    include did not exist as far as the judge was concerned. RFC-0361's live
-    case is task-136 — the judge approved an uncommitted working tree and had
-    no way to observe that the work was not committed anywhere.
-
-    {1 The same instruments, not a smaller set}
-
-    The tools here are the keeper tools the producer itself ran — [tool_read_file],
-    [tool_search_files], [tool_execute] — bound to the producer's meta rather
-    than to a judge of its own. Nothing is re-implemented.
-
-    A curated read-only surface was the earlier design and it was wrong twice
-    over. A hand-written tool answers only the question its author anticipated,
-    so every new question costs a release; and the questions that decide a
-    verdict are not a fixed set. "Do the tests pass" cannot be answered by
-    reading files at all — it needs the build to run. A judge that can only read
-    the claim that tests pass is judging the claim, not the work.
-
-    The judge therefore holds the producer's execution authority, writes
-    included. That is a deliberate trade: it can repair what it should reject,
-    and nothing verifies that repair. What makes the trade payable is that every
-    call it makes is recorded — {!Verification_run_registry} keeps the tool
-    observations on the run, so a verdict reached after the judge changed the
-    tree is visible as such instead of being indistinguishable from one reached
-    by reading.
-
-    {1 Containment}
-
-    Paths resolve through the producer's own sandbox jail, which is what the
-    keeper runtimes already enforce for the producer. Borrowing the producer's
-    meta borrows its jail: the judge reaches exactly the tree the work happened
-    in, and nothing outside it.
-
-    This is also why the surface is not rooted at
-    [Keeper_sandbox_config.host_root_abs_of_agent]. That root is the bundle
-    directory; the checkout the producer commits in lives below it under
-    [repos/]. A tool rooted there would answer "not a repository" for every
-    producer while looking like a working check. The sandbox jail resolves to
-    where the producer actually worked.
-
-    {1 The Gate posture is the producer's}
-
-    [tool_execute] submits through the external-effect Gate, and the Gate reads
-    [meta.always_allow] — the producer's switch, since the producer's meta is
-    what this surface carries. A producer that runs effects without approval
-    gives its judge the same, and a producer whose effects queue for approval
-    gives its judge a queued effect too.
-
-    That second case is a dead end, and deliberately so rather than by
-    oversight. A queued effect resolves by waking the keeper that submitted it;
-    the judge is one review with no wake path, so it receives the deferral as a
-    failed call and has to reach a verdict without that answer. Granting the
-    judge a bypass would let it run effects on a tree whose owner is not
-    allowed to, which is a larger hole than the one it closes.
-
-    {1 Not a keeper}
-
-    Borrowing a producer's meta does not enrol the judge as a keeper: no
-    registry entry, no sandbox of its own, no lifecycle, no persona, and none of
-    the task, board, memory, or voice tools. It holds three instruments pointed
-    at someone else's tree for the length of one review. *)
+(** Completion-authority access to one producer's typed filesystem and command
+    descriptors. Descriptor registry drift and unreadable producer state reject
+    surface construction. Every dispatched call is validated and translated by
+    the same descriptor that was advertised. *)
 
 type t
 
 val create :
   config:Workspace.config -> producer:string -> (t, string) result
-(** Bind a surface to one producer by loading that producer's keeper meta.
-    [Error] when the producer has no readable meta — a judge with no tree to
-    look at is told so rather than handed a surface that fails on every call. *)
 
 val ownership_root : t -> string
-(** The producer's bundle root, for naming the boundary in the prompt. Tool
-    calls resolve through the sandbox jail rather than this string. *)
 
 val schemas : t -> Types_core.tool_schema list
-(** The tool schemas to hand the evaluator, in a stable order. These are the
-    keeper schemas verbatim: a judge and a producer read the same description of
-    the same tool. *)
 
 val dispatch : t -> name:string -> args:Yojson.Safe.t -> (string, string) result
-(** Run one call against the producer's tree. [Error] carries a message meant
-    for the model: an unknown tool name, or the runtime's own failure text.
-    Every outcome is one of those two constructors — a call never resolves to a
-    plausible-looking empty result. *)

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -552,7 +552,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # Removing a live export and its only call site leaves the dead count where it
 # was. Measured with --exports on the merged tree -- 563 - 1 assumed the export
 # was dead, and it was not.
-DEAD_EXPORT_BASELINE = 561
+DEAD_EXPORT_BASELINE = 557
 
 
 def run_ratchet(count: int) -> int:

--- a/test/test_verification_authority_tools.ml
+++ b/test/test_verification_authority_tools.ml
@@ -233,23 +233,6 @@ let test_unknown_tool_name_is_an_error () =
         (Astring.String.is_infix ~affix:"tool_execute" detail))
 ;;
 
-(* Every advertised schema must reach an implementation. Advertising a name
-   dispatch does not know would put a tool in the model's list that always
-   fails with "unknown tool". *)
-let test_every_schema_name_dispatches () =
-  with_surface (fun _config surface ->
-    List.iter
-      (fun (schema : Masc_domain.tool_schema) ->
-         match VAT.dispatch surface ~name:schema.name ~args:(`Assoc []) with
-         | Ok _ -> ()
-         | Error detail ->
-           Alcotest.(check bool)
-             (Printf.sprintf "%s is not reported as unknown" schema.name)
-             false
-             (Astring.String.is_infix ~affix:"unknown tool" detail))
-      (VAT.schemas surface))
-;;
-
 (* Where the judge's process would run is the safety property this layer owns.
    The keeper runtime resolves it and reports the resolution back, so the
    assertion is on that resolution rather than on process output: whether the
@@ -309,9 +292,7 @@ let test_execute_cannot_escape_the_producer_playground () =
         (Astring.String.is_infix ~affix:"\"scope\":\"playground_root\"" detail))
 ;;
 
-(* A run that failed must not read like a run that produced nothing. Handing
-   back [raw_output] on both paths would let a build that never started look
-   like one with no findings — the exact shape that made task-136 approvable. *)
+(* A failed process is a failed lookup result. *)
 let test_a_failed_run_is_an_error_not_empty_output () =
   with_surface (fun _config surface ->
     match
@@ -423,8 +404,6 @@ let () =
     ; ( "dispatch"
       , [ Alcotest.test_case "unknown tool name is an error" `Quick
             test_unknown_tool_name_is_an_error
-        ; Alcotest.test_case "every schema name dispatches" `Quick
-            test_every_schema_name_dispatches
         ] )
     ; ( "execution"
       , [ Alcotest.test_case "execute resolves inside the producer playground" `Quick

--- a/test/test_verification_authority_tools.ml
+++ b/test/test_verification_authority_tools.ml
@@ -1,11 +1,5 @@
-(* RFC-0361 D1: the completion authority runs the producer's own tools.
-
-   The properties under test are the ones that decide whether a judge can be
-   trusted with the surface: it offers exactly the keeper schemas rather than a
-   restatement of them, every advertised name reaches an implementation, a
-   producer with no meta yields no surface instead of one that fails on every
-   call, and a failed run reaches the model as a failure rather than as output
-   that could be mistaken for a clean result. *)
+(* Completion-authority descriptor, validation, dispatch, and containment
+   contracts. *)
 
 module Keeper_meta_store = Masc.Keeper_meta_store
 module Descriptor = Masc.Keeper_tool_descriptor
@@ -38,13 +32,8 @@ let rec rm_rf path =
    canonical [Keeper_identity.keeper_agent_name], so this fixture cannot drift
    from the identity rule the meta parser enforces.
 
-   [always_allow] is the producer's own Gate posture, and the judge borrows it
-   with the meta — [Keeper_tool_execute_runtime] reads
-   [meta.always_allow] and nothing else. It is set here because a deferred
-   effect is not an answer: the judge is one review with no wake path, so a
-   producer that defers gives it a dead end rather than a result. That is the
-   real behaviour for a non-always-allow producer and it is stated in the
-   surface docs; these cases exercise the branch where the effect runs. *)
+   [always_allow] is the producer's Gate posture. These cases exercise the
+   immediate execution branch. *)
 let ensure_producer config name =
   match
     Result.bind
@@ -82,11 +71,25 @@ let with_surface f =
   | Ok surface -> f config surface
 ;;
 
-(* The judge and the producer must read one description of one tool, and
-   [Keeper_tool_descriptor] is where a model-facing description lives. Sourcing
-   this surface from [Tool_shard] instead gave the same handlers two model
-   vocabularies -- the judge was shown "path" and a Keeper "file_path" -- and
-   the copy is always the one that drifts. *)
+(* Create the producer playground used to resolve relative tool paths. *)
+let producer_playground (config : Workspace_core.config) =
+  let path =
+    Keeper_sandbox_config.host_root_abs_of_agent
+      ~base_path:
+        (Workspace_verification_store.project_root_of_base_path config.base_path)
+      ~agent_name:producer
+  in
+  let rec mkdir_p dir =
+    if not (Sys.file_exists dir)
+    then (
+      mkdir_p (Filename.dirname dir);
+      try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  in
+  mkdir_p path;
+  path
+;;
+
+(* The judge and producer share the descriptor-owned model surface. *)
 let test_schemas_are_the_descriptor_schemas () =
   with_surface (fun _config surface ->
     let offered = VAT.schemas surface in
@@ -117,34 +120,11 @@ let test_schemas_are_the_descriptor_schemas () =
       offered)
 ;;
 
-(* Every argument the surface advertises is the model's, not the handler's, and
-   the gap between them is real: [handle_read_file_with_outcome] reads "path"
-   while the advertised schema asks for "file_path". [dispatch] closes it by
-   running the descriptor's own validation and translation, the same pair a
-   Keeper's call passes through.
-
-   Both halves are asserted because either alone passes for the wrong reason. A
-   read that succeeds proves translation happened; it does not prove a bad call
-   is refused. And "the bad call returned no contents" is not refusal -- that
-   was the state this replaces, where the handler defaulted the missing required
-   string to "" and returned Ok, so a verdict reached without opening the file
-   looked exactly like one reached by reading it (#27605). The malformed case
-   therefore asserts [Error], not merely the absence of the file's text. *)
+(* A successful read proves descriptor translation reaches the runtime handler;
+   a missing required argument must be rejected at the same boundary. *)
 let test_read_translates_the_advertised_argument_and_refuses_a_malformed_one () =
   with_surface (fun config surface ->
-    let playground =
-      Keeper_sandbox_config.host_root_abs_of_agent
-        ~base_path:
-          (Workspace_verification_store.project_root_of_base_path config.base_path)
-        ~agent_name:producer
-    in
-    let rec mkdir_p path =
-      if not (Sys.file_exists path)
-      then (
-        mkdir_p (Filename.dirname path);
-        try Unix.mkdir path 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-    in
-    mkdir_p playground;
+    let playground = producer_playground config in
     let name = "advertised-argument-probe.txt" in
     let contents = "written by the probe" in
     (try
@@ -191,6 +171,53 @@ let test_read_translates_the_advertised_argument_and_refuses_a_malformed_one () 
         "the refusal names the missing argument"
         true
         (Astring.String.is_infix ~affix:required detail))
+;;
+
+(* A search requires an explicit non-empty pattern. *)
+let test_search_refuses_a_call_without_its_required_pattern () =
+  with_surface (fun config surface ->
+    ignore (producer_playground config);
+    (match
+       VAT.dispatch surface ~name:"tool_search_files" ~args:(`Assoc [])
+     with
+     | Ok output ->
+       Alcotest.failf
+         "a search with no pattern resolved instead of being refused: %s"
+         output
+     | Error detail ->
+       Alcotest.(check bool)
+         "the refusal names the missing argument"
+         true
+         (Astring.String.is_infix ~affix:"pattern" detail));
+    match
+      VAT.dispatch
+        surface
+        ~name:"tool_search_files"
+        ~args:(`Assoc [ "pattern", `String "advertised" ])
+    with
+    | Ok _ -> ()
+    | Error detail ->
+      Alcotest.failf "a search carrying its pattern was refused: %s" detail)
+;;
+
+(* [argv] is a process vector, never a shell-line string. *)
+let test_execute_refuses_argv_that_is_not_a_process_vector () =
+  with_surface (fun _config surface ->
+    match
+      VAT.dispatch
+        surface
+        ~name:"tool_execute"
+        ~args:(`Assoc [ "argv", `String "echo durable-marker" ])
+    with
+    | Ok output ->
+      Alcotest.failf
+        "argv as a bare string resolved instead of being refused: %s"
+        output
+    | Error detail ->
+      Alcotest.(check bool)
+        "the refusal names argv"
+        true
+        (Astring.String.is_infix ~affix:"argv" detail))
 ;;
 
 (* A judge that calls a name this surface does not offer must be told so. A
@@ -324,10 +351,7 @@ let test_unknown_producer_yields_no_surface () =
       (Astring.String.is_infix ~affix:"no-such-producer" reason)
 ;;
 
-(* RFC-0361 D2. The prompt states what the evaluator can do, and the two
-   surfaces are different claims. Rendering the toolless text for a
-   tool-carrying review is the exact gap D1 exists to close, and the tool text
-   must not repeat the read-only promise this surface no longer keeps. *)
+(* The prompt states the exact tools attached to the review request. *)
 let test_prompt_states_the_available_surface () =
   with_surface (fun _config surface ->
     let request : AR.review_request =
@@ -389,6 +413,10 @@ let () =
             "read translates the advertised argument and refuses a malformed one"
             `Quick
             test_read_translates_the_advertised_argument_and_refuses_a_malformed_one
+        ; Alcotest.test_case "search refuses a call without its required pattern"
+            `Quick test_search_refuses_a_call_without_its_required_pattern
+        ; Alcotest.test_case "execute refuses argv that is not a process vector"
+            `Quick test_execute_refuses_argv_that_is_not_a_process_vector
         ; Alcotest.test_case "unknown producer yields no surface" `Quick
             test_unknown_producer_yields_no_surface
         ] )

--- a/test/test_verification_authority_tools.ml
+++ b/test/test_verification_authority_tools.ml
@@ -8,7 +8,7 @@
    that could be mistaken for a clean result. *)
 
 module Keeper_meta_store = Masc.Keeper_meta_store
-module Tool_shard = Masc.Tool_shard
+module Descriptor = Masc.Keeper_tool_descriptor
 module VAT = Masc.Verification_authority_tools
 module AR = Masc.Task.Anti_rationalization
 
@@ -82,10 +82,12 @@ let with_surface f =
   | Ok surface -> f config surface
 ;;
 
-(* The judge and the producer must read one description of one tool. A schema
-   restated here would drift from the catalog, and the copy is always the one
-   that drifts. *)
-let test_schemas_are_the_keeper_schemas () =
+(* The judge and the producer must read one description of one tool, and
+   [Keeper_tool_descriptor] is where a model-facing description lives. Sourcing
+   this surface from [Tool_shard] instead gave the same handlers two model
+   vocabularies -- the judge was shown "path" and a Keeper "file_path" -- and
+   the copy is always the one that drifts. *)
+let test_schemas_are_the_descriptor_schemas () =
   with_surface (fun _config surface ->
     let offered = VAT.schemas surface in
     let names =
@@ -97,20 +99,98 @@ let test_schemas_are_the_keeper_schemas () =
       names;
     List.iter
       (fun (schema : Masc_domain.tool_schema) ->
-         match
-           List.find_opt
-             (fun (catalog : Masc_domain.tool_schema) ->
-                String.equal catalog.name schema.name)
-             Tool_shard.all_keeper_tool_schemas
-         with
-         | None ->
-           Alcotest.failf "%s is not in the keeper catalog" schema.name
-         | Some catalog ->
+         match Descriptor.descriptors_for_internal schema.name with
+         | [ descriptor ] ->
            Alcotest.(check string)
-             (schema.name ^ " description is the catalog's")
-             catalog.description
-             schema.description)
+             (schema.name ^ " description is the descriptor's")
+             descriptor.Descriptor.description
+             schema.description;
+           Alcotest.(check bool)
+             (schema.name ^ " input schema is the descriptor's")
+             true
+             (Yojson.Safe.equal descriptor.Descriptor.input_schema schema.input_schema)
+         | found ->
+           Alcotest.failf
+             "%s resolves to %d descriptors; the surface needs exactly one"
+             schema.name
+             (List.length found))
       offered)
+;;
+
+(* Every argument the surface advertises is the model's, not the handler's, and
+   the gap between them is real: [handle_read_file_with_outcome] reads "path"
+   while the advertised schema asks for "file_path". [dispatch] closes it by
+   running the descriptor's own validation and translation, the same pair a
+   Keeper's call passes through.
+
+   Both halves are asserted because either alone passes for the wrong reason. A
+   read that succeeds proves translation happened; it does not prove a bad call
+   is refused. And "the bad call returned no contents" is not refusal -- that
+   was the state this replaces, where the handler defaulted the missing required
+   string to "" and returned Ok, so a verdict reached without opening the file
+   looked exactly like one reached by reading it (#27605). The malformed case
+   therefore asserts [Error], not merely the absence of the file's text. *)
+let test_read_translates_the_advertised_argument_and_refuses_a_malformed_one () =
+  with_surface (fun config surface ->
+    let playground =
+      Keeper_sandbox_config.host_root_abs_of_agent
+        ~base_path:
+          (Workspace_verification_store.project_root_of_base_path config.base_path)
+        ~agent_name:producer
+    in
+    let rec mkdir_p path =
+      if not (Sys.file_exists path)
+      then (
+        mkdir_p (Filename.dirname path);
+        try Unix.mkdir path 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+    in
+    mkdir_p playground;
+    let name = "advertised-argument-probe.txt" in
+    let contents = "written by the probe" in
+    (try
+       Out_channel.with_open_text (Filename.concat playground name) (fun oc ->
+         output_string oc contents)
+     with
+     | Sys_error err -> Alcotest.failf "probe file could not be written: %s" err);
+    let read key =
+      VAT.dispatch surface ~name:"tool_read_file" ~args:(`Assoc [ key, `String name ])
+    in
+    let required =
+      match
+        List.find_opt
+          (fun (schema : Masc_domain.tool_schema) ->
+             String.equal schema.name "tool_read_file")
+          (VAT.schemas surface)
+      with
+      | Some { input_schema = `Assoc fields; _ } ->
+        (match List.assoc_opt "required" fields with
+         | Some (`List (`String field :: _)) -> field
+         | _ -> Alcotest.fail "tool_read_file advertises no required argument")
+      | _ -> Alcotest.fail "tool_read_file is not offered"
+    in
+    (match read required with
+     | Error detail ->
+       Alcotest.failf
+         "the advertised required argument %S did not reach the handler: %s"
+         required
+         detail
+     | Ok output ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%S returns the file's contents" required)
+         true
+         (Astring.String.is_infix ~affix:contents output));
+    match VAT.dispatch surface ~name:"tool_read_file" ~args:(`Assoc []) with
+    | Ok output ->
+      Alcotest.failf
+        "a read with no %S resolved instead of being refused, so an unopened \
+         file reads as an answer: %s"
+        required
+        output
+    | Error detail ->
+      Alcotest.(check bool)
+        "the refusal names the missing argument"
+        true
+        (Astring.String.is_infix ~affix:required detail))
 ;;
 
 (* A judge that calls a name this surface does not offer must be told so. A
@@ -303,8 +383,12 @@ let () =
   Alcotest.run
     "verification authority tools"
     [ ( "surface"
-      , [ Alcotest.test_case "schemas are the keeper schemas" `Quick
-            test_schemas_are_the_keeper_schemas
+      , [ Alcotest.test_case "schemas are the descriptor schemas" `Quick
+            test_schemas_are_the_descriptor_schemas
+        ; Alcotest.test_case
+            "read translates the advertised argument and refuses a malformed one"
+            `Quick
+            test_read_translates_the_advertised_argument_and_refuses_a_malformed_one
         ; Alcotest.test_case "unknown producer yields no surface" `Quick
             test_unknown_producer_yields_no_surface
         ] )


### PR DESCRIPTION
## Contract

- Surface construction requires exactly one Keeper descriptor for each authority tool.
- Advertised schemas and dispatch use the same captured descriptor values.
- Every model input is validated and translated before the handler boundary.
- Unknown tools, invalid input, runtime rejection, and unreadable producer state are explicit errors.

## Verification

- `ocamlformat --inplace` on touched OCaml and interface files
- `git diff --check`
- `python3 scripts/audit-dead-surface.py --exports --ratchet` (557, exact branch baseline)
- Focused Dune build pending CI: repo-local wrapper refused while unrelated bare Dune processes hold the machine-wide lock.