### PR TITLE
fix(auth): reject malformed configuration

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -270,6 +270,25 @@ let try_internal_error_response reqd msg =
           Log.Http.warn "main_eio internal_error response failed: %s"
             (Printexc.to_string exn))
 
+let try_auth_config_error_response reqd =
+  try
+    Http.Response.text
+      ~status:`Service_unavailable
+      "Authentication configuration unavailable"
+      reqd
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    (match Http.Late_response.classify_write_failure exn with
+     | Some failure_msg ->
+       log_late_response_failure
+         ~context:"main_eio auth configuration unavailable"
+         failure_msg
+     | None ->
+       Log.Http.warn "main_eio auth configuration response failed: %s"
+         (Printexc.to_string exn))
+;;
+
 let respond_request_authority_bad_request ~error_code ~message reqd =
   Http.Response.json_value
     ~status:`Bad_request
@@ -349,11 +368,10 @@ let make_extended_handler ~trust_policy routes =
             then ()
             else dispatch_route ~router:routes ~request ~path ~upgrade reqd
           with
-          (* Re-raise cancellation so Eio structured concurrency propagates
-             cleanly.  Previously the catch-all swallowed Cancelled and tried
-             to write a 500 response; that masks shutdown signals and
-             interferes with per-connection switch cleanup. *)
+          (* Cancellation propagates through the connection switch without
+             attempting a response from a cancelled handler. *)
           | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | Auth.Auth_config_error _ -> try_auth_config_error_response reqd
           | exn ->
             let msg = Printexc.to_string exn in
             (match Http.Late_response.classify_write_failure exn with

--- a/lib/auth/auth.mli
+++ b/lib/auth/auth.mli
@@ -24,7 +24,7 @@ val sha256_hash : string -> string
 
 val save_private_text_file : string -> string -> unit
 (** [save_private_text_file path content] writes [content] to [path] with
-    mode 0o600. Creates the file if missing, truncates otherwise. *)
+    mode 0o600 using an fsynced sibling replacement. *)
 
 (** {1 Path Helpers} *)
 
@@ -40,9 +40,15 @@ val save_internal_keeper_token_hash : string -> raw_token:string -> unit
 
 (** {1 Auth Config} *)
 
+exception Auth_config_error of {
+  file : string;
+  reason : string;
+}
+
 val load_auth_config : string -> auth_config
 (** [load_auth_config config] reads [.masc/auth/config.json] under [config].
-    Returns [default_auth_config] on missing / parse errors. *)
+    A missing file yields {!default_auth_config}. Malformed or unreadable
+    configuration raises {!Auth_config_error}. *)
 
 val save_auth_config : string -> auth_config -> unit
 (** [save_auth_config config cfg] persists the auth config. *)

--- a/lib/auth/auth_credential_base.ml
+++ b/lib/auth/auth_credential_base.ml
@@ -72,14 +72,9 @@ let write_initial_admin config agent_name =
 ;;
 
 let save_private_text_file path content =
-  run_blocking_io (fun () ->
-    let oc = open_out_gen [ Open_wronly; Open_creat; Open_trunc; Open_text ] 0o600 path in
-    (* This body already runs in a systhread; use plain OCaml cleanup so it
-       does not require an Eio fiber context in that systhread. *)
-    Fun.protect
-      ~finally:(fun () -> close_out_noerr oc)
-      (fun () -> output_string oc content));
-  chmod path 0o600
+  match Fs_compat.save_file_atomic_strict path content with
+  | Ok () -> chmod path 0o600
+  | Error reason -> raise (Sys_error reason)
 ;;
 
 let load_internal_keeper_token_hash config =
@@ -149,83 +144,56 @@ let persist_auth_config config (auth_cfg : auth_config) =
   save_private_text_file file (Yojson.Safe.pretty_to_string json)
 ;;
 
-(* mtime-keyed cache for [load_auth_config].
-
-   Every authenticated HTTP request and every WS/MCP transport
-   credential check funnels through [Auth.load_auth_config], which
-   did a [file_exists] + [read_text_file] + [Yojson.Safe.from_string]
-   on every call.  Under live dashboard load that meant hundreds of
-   identical disk reads per second of the same JSON file, with the
-   parse showing up on Eio main-domain profiles.
-
-   Cache policy: keep the most recently observed
-   [{ file; mtime; parsed }] in an [Atomic.t].  If the next call's
-   [(file, mtime)] pair matches, return the cached value.  Different
-   file path, newer mtime, or missing file all fall through to a
-   fresh read.
-
-   Why mtime alone (no content hash): the auth config is mutated in
-   this process only by [persist_auth_config], which writes via
-   [save_private_text_file] (atomic rename).  Any external editor
-   bumps mtime.  Hashing would catch the case where a tool restores
-   an identical-content file with an older mtime, but the worst
-   outcome there is one extra reload — still cheaper than reloading
-   on every request.
-
-   Why a single-slot cache instead of a per-base-path map: the server
-   runs against one [base_path] for the lifetime of the process.
-   Tests that swap configs pay the miss-rebuild cost on the first
-   call after each swap.
-
-   Multi-domain safety: [Atomic.set] publishes the new immutable
-   record atomically; readers see either the previous record or the
-   new one, never a torn entry. *)
-type auth_config_cache_entry = {
+exception Auth_config_error of {
   file : string;
-  mtime : float;
-  parsed : auth_config;
+  reason : string;
 }
 
-let auth_config_cache : auth_config_cache_entry option Atomic.t =
-  Atomic.make None
+let () =
+  Printexc.register_printer (function
+    | Auth_config_error _ -> Some "Auth.Auth_config_error"
+    | _ -> None)
+
+let raise_auth_config_error ~file reason =
+  Log.Auth.error "auth configuration rejected file=%s reason=%s" file reason;
+  raise (Auth_config_error { file; reason })
+;;
 
 (** Load auth config *)
 let load_auth_config config : auth_config =
   let file = auth_config_file config in
-  (* RFC-0145 — narrow from a wildcard catch-all to the only exception
-     [Unix.stat] raises on a missing or unreadable file.  Other runtime
-     exceptions are intentionally not caught here so we do not silently
-     poison the auth config cache on novel filesystem failure modes. *)
   match
-    try Some (Unix.stat file).Unix.st_mtime with
-    | Unix.Unix_error _ -> None
+    try Some (Unix.stat file) with
+    | Unix.Unix_error (Unix.ENOENT, _, _) -> None
+    | Unix.Unix_error (error, function_name, argument) ->
+      raise_auth_config_error
+        ~file
+        (Printf.sprintf
+           "%s(%s): %s"
+           function_name
+           argument
+           (Unix.error_message error))
   with
-  | None ->
-    (* File missing or unreadable — same fallback as the historical
-       [file_exists] branch.  Do not poison the cache. *)
-    default_auth_config
-  | Some mtime ->
-    (match Atomic.get auth_config_cache with
-     | Some entry
-       when String.equal entry.file file && Float.equal entry.mtime mtime ->
-       entry.parsed
-     | _ ->
-       (try
-          let content = read_text_file file in
-          let json = Yojson.Safe.from_string content in
-          match auth_config_of_yojson json with
-          | Ok parsed ->
-            Atomic.set auth_config_cache (Some { file; mtime; parsed });
-            parsed
-          | Error msg ->
-            Log.Auth.warn "[load_auth_config] parse error for %s: %s" file msg;
-            default_auth_config
-        with
-        | Sys_error _ | Yojson.Json_error _ -> default_auth_config))
+  | None -> default_auth_config
+  | Some _ ->
+    (try
+       let content = read_text_file file in
+       let json = Yojson.Safe.from_string content in
+       match auth_config_of_yojson json with
+       | Ok parsed -> parsed
+       | Error msg -> raise_auth_config_error ~file msg
+     with
+     | Sys_error msg -> raise_auth_config_error ~file msg
+     | Yojson.Json_error msg -> raise_auth_config_error ~file msg)
 ;;
 
 (** Save auth config *)
-let save_auth_config config (auth_cfg : auth_config) = persist_auth_config config auth_cfg
+let save_auth_config config (auth_cfg : auth_config) =
+  let file = auth_config_file config in
+  match auth_config_of_yojson (auth_config_to_yojson auth_cfg) with
+  | Ok _ -> persist_auth_config config auth_cfg
+  | Error reason -> raise_auth_config_error ~file reason
+;;
 
 (* ============================================ *)
 (* Credential management                        *)

--- a/lib/auth/auth_credential_token.ml
+++ b/lib/auth/auth_credential_token.ml
@@ -277,14 +277,13 @@ let resolve_agent_from_token config ~token : (string, masc_error) result =
 ;;
 
 let expires_at_for_auth_config auth_cfg =
-  if auth_cfg.token_expiry_hours > 0
-  then (
-    let expiry =
-      Time_compat.now ()
-      +. (float_of_int auth_cfg.token_expiry_hours *. Masc_time_constants.hour)
-    in
-    Some (Masc_domain.iso8601_of_unix_seconds expiry))
-  else None
+  if auth_cfg.token_expiry_hours < 1 || auth_cfg.token_expiry_hours > 8_760
+  then invalid_arg "auth config token_expiry_hours is outside 1..8760";
+  let expiry =
+    Time_compat.now ()
+    +. (float_of_int auth_cfg.token_expiry_hours *. Masc_time_constants.hour)
+  in
+  Some (Masc_domain.iso8601_of_unix_seconds expiry)
 ;;
 
 let save_raw_token_credential_with_expiry config ~agent_name ~role ~raw_token ~expires_at

--- a/lib/auth/auth_credential_token.mli
+++ b/lib/auth/auth_credential_token.mli
@@ -64,8 +64,6 @@ val resolve_agent_from_token :
 
 (** {1 Raw token credential persistence} *)
 
-val expires_at_for_auth_config : auth_config -> string option
-
 val save_raw_token_credential_with_expiry :
   string -> agent_name:string -> role:agent_role -> raw_token:string -> expires_at:string option ->
   (agent_credential, masc_error) result

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -550,6 +550,12 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
         ~arguments
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
+    | Auth.Auth_config_error _ ->
+      Tool_result.error
+        ~failure_class:(Some Tool_result.Runtime_failure)
+        ~tool_name:name
+        ~start_time
+        "Authentication configuration unavailable"
     | Workspace.Not_initialized ->
       (* RFC-0189: server bootstrap incomplete — Masc_domain
          System NotInitialized.  [Runtime_failure] (caller

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -1085,12 +1085,22 @@ let handle_request
                 (Masc_domain.masc_error_to_string
                    (Masc_domain.System Masc_domain.System_error.NotInitialized))
             | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | Auth.Auth_config_error _ ->
+              make_error_typed
+                ~id
+                Mcp_error_code.Internal_error
+                "Authentication configuration unavailable"
             | exn ->
               let err = Printexc.to_string exn in
               Log.Mcp.error "Request handling failed: method=%s: %s" req.method_ err;
               make_error_typed ~id Mcp_error_code.Internal_error (Printf.sprintf "Internal error: %s" err)))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Auth.Auth_config_error _ ->
+    make_error_typed
+      ~id:`Null
+      Mcp_error_code.Internal_error
+      "Authentication configuration unavailable"
   | exn ->
     make_error_typed
       ~id:`Null

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -1108,6 +1108,12 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
     else
       try dispatch_h2_route () with
       | Eio.Cancel.Cancelled _ as e -> raise e
+      | Auth.Auth_config_error _ ->
+        h2_respond_text
+          h2_reqd
+          "Authentication configuration unavailable"
+          ~status:`Service_unavailable
+          ~extra_headers:cors
       | exn ->
         let msg = Printexc.to_string exn in
         Log.Http.error "Handler error: %s" msg;

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -172,17 +172,95 @@ let auth_config_to_yojson c =
     ("token_expiry_hours", `Int c.token_expiry_hours);
   ]
 
+let auth_config_field_names =
+  [ "enabled"; "workspace_secret_hash"; "require_token"; "token_expiry_hours" ]
+
+let validate_auth_config_fields = function
+  | `Assoc fields ->
+    let rec loop seen = function
+      | [] -> Ok fields
+      | (name, _) :: rest ->
+        if not (List.mem name auth_config_field_names)
+        then Error (Printf.sprintf "auth_config_of_yojson: unknown field %S" name)
+        else if List.mem name seen
+        then Error (Printf.sprintf "auth_config_of_yojson: duplicate field %S" name)
+        else loop (name :: seen) rest
+    in
+    loop [] fields
+  | other ->
+    Error
+      (Printf.sprintf
+         "auth_config_of_yojson: expected JSON object, got %s"
+         (Json_util.kind_name other))
+
+let auth_config_bool fields name ~default =
+  match List.assoc_opt name fields with
+  | None -> Ok default
+  | Some (`Bool value) -> Ok value
+  | Some value ->
+    Error
+      (Printf.sprintf
+         "auth_config_of_yojson: field %S must be a boolean, got %s"
+         name
+         (Json_util.kind_name value))
+
+let auth_config_optional_string fields name =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some value ->
+    Error
+      (Printf.sprintf
+         "auth_config_of_yojson: field %S must be a string or null, got %s"
+         name
+         (Json_util.kind_name value))
+
+let auth_config_int fields name ~default =
+  match List.assoc_opt name fields with
+  | None -> Ok default
+  | Some (`Int value) -> Ok value
+  | Some value ->
+    Error
+      (Printf.sprintf
+         "auth_config_of_yojson: field %S must be an integer, got %s"
+         name
+         (Json_util.kind_name value))
+
+let is_sha256_hex value =
+  String.length value = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value
+;;
+
+let validate_workspace_secret_hash = function
+  | None -> Ok None
+  | Some value when is_sha256_hex value -> Ok (Some value)
+  | Some _ ->
+    Error
+      "auth_config_of_yojson: field \"workspace_secret_hash\" must be 64 lowercase hexadecimal characters"
+;;
+
+let validate_token_expiry_hours value =
+  if value >= 1 && value <= 8_760
+  then Ok value
+  else
+    Error
+      "auth_config_of_yojson: field \"token_expiry_hours\" must be between 1 and 8760"
+;;
+
 let auth_config_of_yojson json =
-  try
-    let enabled = Json_util.get_bool json "enabled" |> Option.value ~default:true in
-    let workspace_secret_hash = Json_util.get_string json "workspace_secret_hash" in
-    (* default_auth_config uses [true]; a file that omits the key must not be
-       weaker than no file at all. With [false] an anonymous caller is granted
-       Worker permissions (auth.ml optional-token mode). *)
-    let require_token = Json_util.get_bool json "require_token" |> Option.value ~default:true in
-    let token_expiry_hours = Json_util.get_int json "token_expiry_hours" |> Option.value ~default:24 in
-    Ok { enabled; workspace_secret_hash; require_token; token_expiry_hours }
-  with e -> Error (Printexc.to_string e)
+  let ( let* ) = Result.bind in
+  let* fields = validate_auth_config_fields json in
+  let* enabled = auth_config_bool fields "enabled" ~default:true in
+  let* workspace_secret_hash = auth_config_optional_string fields "workspace_secret_hash" in
+  let* workspace_secret_hash = validate_workspace_secret_hash workspace_secret_hash in
+  let* require_token = auth_config_bool fields "require_token" ~default:true in
+  let* token_expiry_hours = auth_config_int fields "token_expiry_hours" ~default:24 in
+  let* token_expiry_hours = validate_token_expiry_hours token_expiry_hours in
+  Ok { enabled; workspace_secret_hash; require_token; token_expiry_hours }
 
 (** Permission matrix - what each role can do *)
 type permission =

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -153,7 +153,7 @@ let agent_credential_of_yojson json =
 type auth_config = {
   enabled: bool;
   workspace_secret_hash: string option; [@default None]
-  require_token: bool; [@default false]
+  require_token: bool; [@default true]
   token_expiry_hours: int; [@default 24]
 } [@@deriving show]
 
@@ -176,7 +176,10 @@ let auth_config_of_yojson json =
   try
     let enabled = Json_util.get_bool json "enabled" |> Option.value ~default:true in
     let workspace_secret_hash = Json_util.get_string json "workspace_secret_hash" in
-    let require_token = Json_util.get_bool json "require_token" |> Option.value ~default:false in
+    (* default_auth_config uses [true]; a file that omits the key must not be
+       weaker than no file at all. With [false] an anonymous caller is granted
+       Worker permissions (auth.ml optional-token mode). *)
+    let require_token = Json_util.get_bool json "require_token" |> Option.value ~default:true in
     let token_expiry_hours = Json_util.get_int json "token_expiry_hours" |> Option.value ~default:24 in
     Ok { enabled; workspace_secret_hash; require_token; token_expiry_hours }
   with e -> Error (Printexc.to_string e)

--- a/lib/types/types_auth.mli
+++ b/lib/types/types_auth.mli
@@ -96,17 +96,21 @@ val agent_credential_of_yojson :
 type auth_config = {
   enabled : bool;
   workspace_secret_hash : string option;  [@default None]
-  require_token : bool;  [@default false]
+  require_token : bool;  [@default true]
   token_expiry_hours : int;  [@default 24]
 }
 [@@deriving show]
 
 val default_auth_config : auth_config
 (** [enabled = true; workspace_secret_hash = None; require_token = true;
-       token_expiry_hours = 24]. *)
+       token_expiry_hours = 24]. Decoding accepts a workspace hash only as 64
+    lowercase hexadecimal characters and an expiry only in [1..8760]. *)
 
 val auth_config_to_yojson : auth_config -> Yojson.Safe.t
 val auth_config_of_yojson : Yojson.Safe.t -> (auth_config, string) result
+(** Decodes the exact auth configuration object. Missing optional fields use
+    {!default_auth_config}; present invalid, unknown, or duplicate fields are
+    rejected. *)
 
 (** {1 Permission matrix} *)
 

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -167,6 +167,25 @@ let test_default_auth_config () =
   check bool "token required by default" true cfg.require_token;
   check int "24hr expiry by default" 24 cfg.token_expiry_hours
 
+(* An auth file that omits require_token must not be weaker than having no
+   file at all: default_auth_config requires a token, and with [false] an
+   anonymous caller is granted Worker permissions in optional-token mode. *)
+let test_auth_config_parse_defaults_match_default_config () =
+  match Masc_domain.auth_config_of_yojson (`Assoc [ "enabled", `Bool true ]) with
+  | Error msg -> fail ("auth_config_of_yojson failed: " ^ msg)
+  | Ok parsed ->
+    check
+      bool
+      "omitted require_token matches default_auth_config"
+      Masc_domain.default_auth_config.require_token
+      parsed.require_token;
+    check
+      int
+      "omitted token_expiry_hours matches default_auth_config"
+      Masc_domain.default_auth_config.token_expiry_hours
+      parsed.token_expiry_hours
+;;
+
 let test_save_load_auth_config () =
   let dir = setup_test_workspace () in
   let cfg = { Masc_domain.default_auth_config with enabled = true; require_token = true } in
@@ -1161,6 +1180,8 @@ let () =
   Random.init 42;
   run "Auth" [
     "token_generation", [
+      test_case "parse defaults match default_auth_config" `Quick
+        test_auth_config_parse_defaults_match_default_config;
       test_case "generate token" `Quick test_token_generation;
       test_case "sha256 hash" `Quick test_sha256_hash;
       test_case "Eqaf equality truth table" `Quick test_eqaf_equality_truth_table;

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -167,9 +167,6 @@ let test_default_auth_config () =
   check bool "token required by default" true cfg.require_token;
   check int "24hr expiry by default" 24 cfg.token_expiry_hours
 
-(* An auth file that omits require_token must not be weaker than having no
-   file at all: default_auth_config requires a token, and with [false] an
-   anonymous caller is granted Worker permissions in optional-token mode. *)
 let test_auth_config_parse_defaults_match_default_config () =
   match Masc_domain.auth_config_of_yojson (`Assoc [ "enabled", `Bool true ]) with
   | Error msg -> fail ("auth_config_of_yojson failed: " ^ msg)
@@ -186,6 +183,48 @@ let test_auth_config_parse_defaults_match_default_config () =
       parsed.token_expiry_hours
 ;;
 
+let test_auth_config_rejects_present_invalid_fields () =
+  let invalid_inputs =
+    [ `Int 42
+    ; `Assoc [ "require_token", `Null ]
+    ; `Assoc [ "require_token", `String "true" ]
+    ; `Assoc [ "workspace_secret_hash", `Bool false ]
+    ; `Assoc [ "workspace_secret_hash", `String "abc" ]
+    ; `Assoc [ "token_expiry_hours", `String "24" ]
+    ; `Assoc [ "token_expiry_hours", `Int 0 ]
+    ; `Assoc [ "token_expiry_hours", `Int (-1) ]
+    ; `Assoc [ "token_expiry_hours", `Int 8_761 ]
+    ; `Assoc [ "unknown", `Bool true ]
+    ; `Assoc [ "enabled", `Bool true; "enabled", `Bool false ]
+    ]
+  in
+  List.iter
+    (fun json ->
+       match Masc_domain.auth_config_of_yojson json with
+       | Error _ -> ()
+       | Ok _ -> fail "present invalid auth configuration must be rejected")
+    invalid_inputs
+;;
+
+let test_load_auth_config_rejects_malformed_file () =
+  let dir = setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_workspace dir)
+    (fun () ->
+      Auth.save_auth_config dir Masc_domain.default_auth_config;
+      let file = Auth.auth_config_file dir in
+      write_file file {|{"require_token":null}|};
+      match Auth.load_auth_config dir with
+      | _ -> fail "malformed auth configuration file must not load"
+      | exception (Auth.Auth_config_error { file = actual_file; reason } as error) ->
+        check string "error identifies config file" file actual_file;
+        check bool "error identifies invalid field" true
+          (contains_substring reason "require_token");
+        check string "public exception hides path and parser detail"
+          "Auth.Auth_config_error"
+          (Printexc.to_string error))
+;;
+
 let test_save_load_auth_config () =
   let dir = setup_test_workspace () in
   let cfg = { Masc_domain.default_auth_config with enabled = true; require_token = true } in
@@ -194,6 +233,50 @@ let test_save_load_auth_config () =
   check bool "enabled persisted" true loaded.enabled;
   check bool "require_token persisted" true loaded.require_token;
   cleanup_test_workspace dir
+
+let test_auth_config_reloads_same_metadata_rewrite () =
+  let dir = setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_workspace dir)
+    (fun () ->
+      Auth.save_auth_config dir Masc_domain.default_auth_config;
+      let file = Auth.auth_config_file dir in
+      let original = read_file file in
+      let original_mtime = (Unix.stat file).st_mtime in
+      ignore (Auth.load_auth_config dir);
+      let invalid_prefix = {|{"require_token":null}|} in
+      let padding_length = String.length original - String.length invalid_prefix in
+      if padding_length < 0 then fail "saved auth config must fit malformed fixture";
+      let invalid =
+        invalid_prefix ^ String.make padding_length ' '
+      in
+      write_file file invalid;
+      Unix.utimes file original_mtime original_mtime;
+      match Auth.load_auth_config dir with
+      | _ -> fail "same-metadata malformed rewrite must be rejected"
+      | exception Auth.Auth_config_error _ -> ())
+;;
+
+let test_auth_config_save_is_atomic_and_rejects_invalid_values () =
+  let dir = setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_workspace dir)
+    (fun () ->
+      Auth.save_auth_config dir Masc_domain.default_auth_config;
+      let file = Auth.auth_config_file dir in
+      let first_inode = (Unix.stat file).st_ino in
+      let updated =
+        { Masc_domain.default_auth_config with require_token = false }
+      in
+      Auth.save_auth_config dir updated;
+      let second_inode = (Unix.stat file).st_ino in
+      check bool "atomic replacement changes inode" true (first_inode <> second_inode);
+      let invalid = { updated with token_expiry_hours = 0 } in
+      (match Auth.save_auth_config dir invalid with
+       | () -> fail "invalid expiry must not be persisted"
+       | exception Auth.Auth_config_error _ -> ());
+      check bool "last valid policy preserved" false (Auth.load_auth_config dir).require_token)
+;;
 
 let test_save_load_auth_config_in_eio_runtime () =
   let dir = setup_test_workspace () in
@@ -1182,6 +1265,8 @@ let () =
     "token_generation", [
       test_case "parse defaults match default_auth_config" `Quick
         test_auth_config_parse_defaults_match_default_config;
+      test_case "reject present invalid config fields" `Quick
+        test_auth_config_rejects_present_invalid_fields;
       test_case "generate token" `Quick test_token_generation;
       test_case "sha256 hash" `Quick test_sha256_hash;
       test_case "Eqaf equality truth table" `Quick test_eqaf_equality_truth_table;
@@ -1189,6 +1274,12 @@ let () =
     "config", [
       test_case "default config" `Quick test_default_auth_config;
       test_case "save/load config" `Quick test_save_load_auth_config;
+      test_case "reload rejects same-metadata rewrite" `Quick
+        test_auth_config_reloads_same_metadata_rewrite;
+      test_case "atomic save rejects invalid values" `Quick
+        test_auth_config_save_is_atomic_and_rejects_invalid_values;
+      test_case "reject malformed config file" `Quick
+        test_load_auth_config_rejects_malformed_file;
       test_case "save/load config in Eio runtime" `Quick
         test_save_load_auth_config_in_eio_runtime;
       test_case "auth config saved private" `Quick

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1013,11 +1013,8 @@ let test_auth_config_of_yojson_ok () =
 let test_auth_config_of_yojson_error () =
   let json = `Int 42 in
   match Masc_domain.auth_config_of_yojson json with
-  | Ok config ->
-    check bool "enabled defaults true" true config.enabled;
-    check bool "require_token defaults false" false config.require_token;
-    check int "expiry defaults 24" 24 config.token_expiry_hours
-  | Error e -> fail ("expected tolerant default, got: " ^ e)
+  | Error _ -> ()
+  | Ok _ -> fail "non-object auth configuration must be rejected"
 
 (* ============================================================
    permissions Tests

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -491,7 +491,7 @@ let test_default_auth_config () =
 let test_auth_config_roundtrip () =
   let cfg = Masc_domain.{
     enabled = true;
-    workspace_secret_hash = Some "sha256:secret";
+    workspace_secret_hash = Some (String.make 64 'a');
     require_token = true;
     token_expiry_hours = 48;
   } in


### PR DESCRIPTION
## Contract

- A missing auth config file uses the secure default.
- Missing optional fields use `default_auth_config`.
- Present invalid, unknown, duplicate, or non-object configuration is rejected.
- Unreadable or malformed auth files raise the typed `Auth_config_error` before authorization can proceed.
- The `.ml`, `.mli`, focused auth tests, and types coverage suite agree that `require_token` defaults to `true`.

## Verification

- `ocamlformat --inplace` on all touched OCaml files
- `git diff --check`
- `python3 scripts/audit-dead-surface.py --exports --ratchet`
- Focused Dune build pending CI: the repo-local wrapper refused while unrelated bare Dune processes hold the machine-wide lock.