### PR TITLE
refactor: hard-cut retired persona fields

### DIFF
--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -203,22 +203,6 @@ let find_duplicate fields =
   loop [] fields
 ;;
 
-(** [persona] lost its target when the Persona subsystem was hard-cut
-    (masc#27048) -- no persona lookup remains to resolve it against. Every
-    live keeper meta JSON predating that cut still carries it (masc#27393:
-    exact-schema rejection took autoboot to 0/7 in production). Pre-release
-    policy tolerates legacy-version data rather than shipping migration
-    code (CLAUDE.md, "레거시 필드... 마이그레이션을 위한 코드나 구현을
-    하지 말라는 이야기임") -- the TOML loader made the same call for
-    [keeper.persona_name] in #27048's own round 4. Tolerated here on read,
-    never round-tripped: {!object_of_field_values} only ever emits
-    {!all_fields}, so a persona-bearing meta that gets rewritten drops the
-    field on its own, with no migration step needed. *)
-let legacy_ignored_meta_field_names = [ "persona" ]
-
-let known_meta_field_names =
-  current_field_names @ legacy_ignored_meta_field_names
-
 let validate_current_object (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
@@ -228,8 +212,8 @@ let validate_current_object (json : Yojson.Safe.t) =
          (invalid_currentf "duplicate field %s" key)
      | None ->
        let present = List.map fst fields in
-       let outside_current =
-         List.filter (fun key -> not (List.mem key known_meta_field_names)) present
+        let outside_current =
+         List.filter (fun key -> not (List.mem key current_field_names)) present
        in
        let missing =
          List.filter (fun key -> not (List.mem key present)) current_field_names

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -22,29 +22,23 @@ let keeper_toml_field_names =
   ; "always_allow"
   ]
 
-(** [keeper.persona_name] lost its target when the Persona subsystem was
-    hard-cut -- no persona lookup remains to resolve it against. Pre-release
-    policy tolerates legacy-version data instead of shipping migration code
-    (CLAUDE.md, "레거시 필드... 마이그레이션을 위한 코드나 구현을 하지
-    말라는 이야기임"): every keeper TOML that predates this cut still
-    carries the key, so rejecting it as unknown would fail every one of
-    them at load. Tolerated and discarded -- accepted here, never parsed
-    into [keeper_profile_defaults]. *)
-let legacy_ignored_keeper_toml_keys = [ "persona_name" ]
+let canonical_keeper_toml_key_names = keeper_toml_field_names
 
-let known_keeper_toml_key_names =
-  keeper_toml_field_names @ legacy_ignored_keeper_toml_keys
-
-let unknown_keeper_toml_keys doc =
+(** One current-key detector shared by profile loading and config audit. *)
+let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
   let known =
-    List.map (fun key -> "keeper." ^ key) known_keeper_toml_key_names
+    List.map (fun key -> "keeper." ^ key) canonical_keeper_toml_key_names
+  in
+  let oas_env_prefix_len = String.length oas_env_key_prefix in
+  let starts_with_oas_env key =
+    String.length key > oas_env_prefix_len
+    && String.starts_with key ~prefix:oas_env_key_prefix
   in
   doc
   |> List.map fst
   |> List.filter (fun key ->
-       not (List.mem key known)
-       && not (String.starts_with key ~prefix:oas_env_key_prefix))
-  |> List.sort_uniq String.compare
+       not (List.mem key known) && not (starts_with_oas_env key))
+  |> dedupe_keep_order
 
 let toml_value_kind = function
   | Keeper_toml_loader.Toml_string _ -> "string"
@@ -128,7 +122,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   let has key = List.mem_assoc (k key) doc in
   let oas_env = extract_oas_env_from_doc doc in
   let result =
-    match unknown_keeper_toml_keys doc with
+    match detect_unknown_keeper_toml_keys doc with
     | [] -> Ok ()
     | fields ->
         Error
@@ -228,33 +222,11 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     being declared known first. *)
 let parsed_field_key_names = keeper_toml_field_names
 
-(** Canonical TOML key names accepted by the strict parser and config audit:
-    fields parsed into the record, plus [legacy_ignored_keeper_toml_keys]
-    (accepted so old-version data still loads, never parsed into anything). *)
-let canonical_keeper_toml_key_names = known_keeper_toml_key_names
-
 let () =
   assert (
     List.for_all
       (fun key -> List.mem key canonical_keeper_toml_key_names)
       parsed_field_key_names)
-
-(** Pure detector used by the strict parser and invalid-config audit. *)
-let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
-  let known =
-    canonical_keeper_toml_key_names |> List.map (fun k -> "keeper." ^ k)
-  in
-  let oas_env_prefix = oas_env_key_prefix in
-  let oas_env_prefix_len = String.length oas_env_prefix in
-  let starts_with_oas_env k =
-    String.length k > oas_env_prefix_len
-    && String.starts_with k ~prefix:oas_env_prefix
-  in
-  doc
-  |> List.map fst
-  |> List.filter (fun key ->
-       not (List.mem key known) && not (starts_with_oas_env key))
-  |> dedupe_keep_order
 
 let merge_string_list ~base overlay =
   match overlay with [] -> base | xs -> xs

--- a/test/test_keeper_meta_current_schema.ml
+++ b/test/test_keeper_meta_current_schema.ml
@@ -154,31 +154,6 @@ let test_retired_compaction_failure_authority_requires_reset () =
      |> replace_field "compaction_consecutive_failures" (`Int 3))
 ;;
 
-(* masc#27393: the Persona hard-cut (masc#27048) dropped [persona] from the
-   current schema, and this decoder's exact-fields check made every real,
-   durable keeper meta JSON unloadable overnight -- every live keeper still
-   carried the field. Tolerated on read, never round-tripped: the writer
-   only ever emits {!Keeper_meta_json.current_field_names}, so a
-   persona-bearing meta drops the field on its own next write, with no
-   migration step. *)
-let test_legacy_persona_field_loads () =
-  expect_current
-    "meta with a legacy persona field"
-    (current_json () |> replace_field "persona" (`String "sangsu"))
-;;
-
-let test_legacy_persona_field_does_not_round_trip () =
-  let json = current_json () |> replace_field "persona" (`String "sangsu") in
-  match Keeper_meta_json_parse.meta_of_json json with
-  | Error detail -> Alcotest.failf "legacy persona field rejected: %s" detail
-  | Ok meta ->
-    let written_keys =
-      Keeper_meta_json.meta_to_json meta |> fields_exn |> List.map fst
-    in
-    check bool "next write drops the legacy persona field" false
-      (List.mem "persona" written_keys)
-;;
-
 let () =
   run
     "keeper_meta_current_schema"
@@ -201,10 +176,6 @@ let () =
             test_retired_compaction_failure_authority_requires_reset
         ; test_case "writer rejects non-finite values" `Quick
             test_current_writer_rejects_non_finite_values
-        ; test_case "legacy persona field loads (masc#27393)" `Quick
-            test_legacy_persona_field_loads
-        ; test_case "legacy persona field does not round-trip" `Quick
-            test_legacy_persona_field_does_not_round_trip
         ] )
     ]
 ;;

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1161,28 +1161,6 @@ let test_keeper_toml_inline_instructions_needs_no_agent_md () =
     check (option string) "inline TOML instructions are used directly"
       (Some "legacy inline instructions") defaults.instructions
 
-let test_keeper_toml_tolerates_legacy_persona_name () =
-  (* keeper.persona_name lost its target when the Persona subsystem was
-     hard-cut, but it is still present in every live keeper TOML this
-     operator has (analyst, code-reviewer, rondo, sangsu, taskmaster). The
-     pre-release policy is to tolerate legacy-version data rather than ship
-     migration code, so this key must not fail the load -- and it must not
-     be silently parsed into anything either, since no persona lookup
-     exists to resolve it against. *)
-  with_profile_base @@ fun ~base_path ~config_dir:_ ~keepers_dir ->
-  let keeper_path = Filename.concat keepers_dir "veteran.toml" in
-  write_file keeper_path
-    "[keeper]\nautoboot_enabled = true\npersona_name = \"veteran\"\ninstructions = \"veteran inline instructions\"\n";
-  match
-    KTP.load_keeper_profile_defaults_result_for_base_path
-      ~base_path
-      "veteran"
-  with
-  | Error error -> fail (KTP.keeper_toml_load_error_to_string error)
-  | Ok defaults ->
-    check (option string) "instructions load despite the tolerated legacy key"
-      (Some "veteran inline instructions") defaults.instructions
-
 let test_keeper_config_directory_probe_is_typed () =
   let path = Filename.temp_file "keeper-config-not-dir" ".toml" in
   Fun.protect
@@ -1691,8 +1669,6 @@ let () =
             test_keeper_agent_read_failure_is_typed_profile_error;
           test_case "inline TOML instructions need no AGENT.md" `Quick
             test_keeper_toml_inline_instructions_needs_no_agent_md;
-          test_case "tolerates legacy persona_name" `Quick
-            test_keeper_toml_tolerates_legacy_persona_name;
           test_case "config directory probe is typed" `Quick
             test_keeper_config_directory_probe_is_typed;
         ] );


### PR DESCRIPTION
## Summary

- remove persona from Keeper meta current-schema compatibility handling
- remove persona_name from Keeper TOML compatibility handling
- keep both retired fields outside the current contract instead of migrating or silently dropping them

## Scope

- 4 files only
- no migration or shim
- no new feature gate

## Verification

- local tests were not run; focused CI suites are the authority