### PR TITLE
fix(goal): render all unowned goal descendants

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -822,7 +822,7 @@ let backlog_statement_of_observation
   | Some _ ->
     if
       observation.unclaimed_task_count = 0
-      && observation.claimable_task_count = 0
+      && Keeper_world_observation.claimable_task_count observation = 0
       && observation.failed_task_count = 0
     then Backlog_readable_empty
     else Backlog_readable_with_rows
@@ -1026,19 +1026,19 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
           Buffer.add_string ubuf
             (Printf.sprintf "- Unclaimed tasks: %d\n"
                observation.unclaimed_task_count);
-        if observation.claimable_task_count > 0 then
+        if Keeper_world_observation.claimable_task_count observation > 0 then
           Buffer.add_string ubuf
             (Printf.sprintf "- Claimable tasks for this keeper: %d\n"
-               observation.claimable_task_count);
+               (Keeper_world_observation.claimable_task_count observation));
         if observation.unclaimed_task_count > 0
-           && observation.claimable_task_count = 0
+           && Keeper_world_observation.claimable_task_count observation = 0
         then
           Buffer.add_string ubuf
             "- Claimable tasks for this keeper: 0\n";
         let keeper_or_scope_blocked =
           max 0
             (observation.unclaimed_task_count
-             - observation.claimable_task_count)
+             - Keeper_world_observation.claimable_task_count observation)
         in
         if keeper_or_scope_blocked > 0 then
           Buffer.add_string ubuf

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -573,13 +573,6 @@ let combine_prompt_sections sections =
    and the tool that fetches the remainder. Nothing is silently dropped. *)
 let board_activity_render_budget_rows = 20
 
-(* Same reason as the Board budget above: expose enough typed identities for a
-   keeper to pick one, and say how many were held back rather than truncating
-   silently. *)
-let claimable_task_render_budget_rows = 10
-
-let take n xs = List.filteri (fun i _ -> i < n) xs
-
 let board_activity_render_budget
       (events : Keeper_world_observation.pending_board_event list)
   : Keeper_world_observation.pending_board_event list
@@ -827,10 +820,9 @@ let backlog_statement_of_observation
   match observation.backlog_revision with
   | None -> Backlog_unreadable
   | Some _ ->
-    let claimable_task_count = Keeper_world_observation.claimable_task_count observation in
     if
       observation.unclaimed_task_count = 0
-      && claimable_task_count = 0
+      && observation.claimable_task_count = 0
       && observation.failed_task_count = 0
     then Backlog_readable_empty
     else Backlog_readable_with_rows
@@ -927,8 +919,8 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
          list, because there taking the parent and taking the child are not two
          independent moves. A child whose parent is absent -- owned, terminal,
          or already served by a Task -- is its own invitation and stays at the
-         top level. Depth stops at one: [parent_goal_id] is a single link and
-         nesting further would trade the fact for a shape. *)
+         top level. Goal_store permits arbitrary parent depth, so the projection
+         follows the whole chain rather than dropping descendants. *)
       let unowned_block =
         match unowned_executing_goals_without_tasks ~config with
         | [] -> None
@@ -952,15 +944,29 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
             | None -> true
             | Some p -> not (List.exists (String.equal p) present)
           in
+          let rendered_ids = ref [] in
+          let rec render_subtree ~depth ((goal_id, _, _) as goal) =
+            if List.exists (String.equal goal_id) !rendered_ids
+            then []
+            else (
+              rendered_ids := goal_id :: !rendered_ids;
+              let indent = String.make (depth * 2) ' ' in
+              line ~indent goal
+              :: List.concat_map
+                   (render_subtree ~depth:(depth + 1))
+                   (children_of goal_id))
+          in
+          let rendered_roots =
+            goals
+            |> List.filter stands_alone
+            |> List.concat_map (render_subtree ~depth:0)
+          in
           let rendered =
-            List.concat_map
-              (fun ((goal_id, _, _) as goal) ->
-                 if not (stands_alone goal)
-                 then []
-                 else
-                   line ~indent:"" goal
-                   :: List.map (line ~indent:"  ") (children_of goal_id))
-              goals
+            rendered_roots
+            @ (goals
+               |> List.filter (fun (goal_id, _, _) ->
+                    not (List.exists (String.equal goal_id) !rendered_ids))
+               |> List.concat_map (render_subtree ~depth:0))
           in
           Some
             (Printf.sprintf
@@ -1007,9 +1013,6 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
     | Keeper_context_layers.Namespace_state ->
       Some (
         let ubuf = Buffer.create 256 in
-        let claimable_task_count =
-          Keeper_world_observation.claimable_task_count observation
-        in
         Buffer.add_string ubuf "### Namespace State\n";
         (match backlog_statement_of_observation observation with
          | Backlog_unreadable ->
@@ -1023,53 +1026,19 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
           Buffer.add_string ubuf
             (Printf.sprintf "- Unclaimed tasks: %d\n"
                observation.unclaimed_task_count);
-        if claimable_task_count > 0 then (
+        if observation.claimable_task_count > 0 then
           Buffer.add_string ubuf
             (Printf.sprintf "- Claimable tasks for this keeper: %d\n"
-               claimable_task_count);
-          (* The count says work exists; these say which. Without them a keeper
-             that wants to claim has to decide to spend a tool call first, and
-             one spent 286 turns reasoning about which tasks were open from a
-             12-hour-old memory rather than looking. The Goal blocks above name
-             their rows for the same reason.
-
-             Bounded like the Board activity render (#27369): a long backlog
-             would otherwise push the rest of the frame out, and the heading
-             says how many are shown against how many exist. *)
-          match observation.claimable_tasks with
-          | [] -> ()
-          | summaries ->
-            let shown = take claimable_task_render_budget_rows summaries in
-            Buffer.add_string ubuf
-              (String.concat ""
-                 (List.map
-                    (fun
-                      (summary :
-                        Keeper_world_observation_inputs.claimable_task_identity)
-                    ->
-                       Printf.sprintf
-                         "  - %s\n"
-                         (Yojson.Safe.to_string
-                            (`Assoc
-                               [ ( "task_id"
-                                 , `String
-                                     (Keeper_id.Task_id.to_string summary.task_id) )
-                               ])))
-                    shown));
-            if List.length summaries > List.length shown then
-              Buffer.add_string ubuf
-                (Printf.sprintf
-                   "  - (%d more — read them with keeper_tasks_list)\n"
-                   (List.length summaries - List.length shown)));
+               observation.claimable_task_count);
         if observation.unclaimed_task_count > 0
-           && claimable_task_count = 0
+           && observation.claimable_task_count = 0
         then
           Buffer.add_string ubuf
             "- Claimable tasks for this keeper: 0\n";
         let keeper_or_scope_blocked =
           max 0
             (observation.unclaimed_task_count
-             - claimable_task_count)
+             - observation.claimable_task_count)
         in
         if keeper_or_scope_blocked > 0 then
           Buffer.add_string ubuf

--- a/test/test_keeper_goal_phase_projection.ml
+++ b/test/test_keeper_goal_phase_projection.ml
@@ -381,6 +381,23 @@ let test_a_child_renders_under_its_parent () =
     (contains_in world "taking one is a move you can make (3)")
 ;;
 
+let test_all_descendants_render_at_their_full_depth () =
+  with_workspace @@ fun config ->
+  Goal_store.write_state config
+    { version = 1
+    ; updated_at = Masc_domain.now_iso ()
+    ; goals =
+        [ goal_in Goal_phase.Executing "goal-root" "root"
+        ; goal_child_of "goal-root" Goal_phase.Executing "goal-child" "child"
+        ; goal_child_of "goal-child" Goal_phase.Executing "goal-grandchild" "grandchild"
+        ]
+    };
+  let world = rendered_world_state config in
+  check bool "the complete parent chain is visible" true
+    (contains_in world
+       "- goal-root — root\n  - goal-child — child\n    - goal-grandchild — grandchild")
+;;
+
 (* A child whose parent is not in this list -- owned, terminal, or already served
    by a Task -- is its own invitation, so it must not be hidden by the nesting. *)
 let test_a_child_whose_parent_is_absent_stands_alone () =
@@ -433,6 +450,8 @@ let () =
             test_unowned_goals_reach_the_rendered_turn
         ; test_case "a child renders under its parent" `Quick
             test_a_child_renders_under_its_parent
+        ; test_case "all descendants render at their full depth" `Quick
+            test_all_descendants_render_at_their_full_depth
         ; test_case "a child whose parent is absent stands alone" `Quick
             test_a_child_whose_parent_is_absent_stands_alone
         ] )


### PR DESCRIPTION
## Summary

- render every descendant in the unowned-goal hierarchy
- preserve stored parent depth instead of dropping grandchildren
- keep rendering unparented residual goals without adding a depth or prompt gate

## Scope

- 2 files only
- no new constraint or admission check
- no prompt cap

## Verification

- local tests were not run; focused CI suites are the authority