### PR TITLE
refactor: make pending-confirm envelope the SSOT

### DIFF
--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -467,21 +467,27 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.recent_messages[0]!.id).toBe('msg-1')
   })
 
-  it('extracts pending_confirms with confirm_token', () => {
+  it('derives pending_confirms from envelope items', () => {
     const result = normalizeOperatorSnapshot({
-      pending_confirms: [
-        { confirm_token: 'tok-1', actor: 'agent-1', action_type: 'pause' },
-      ],
+      pending_confirm_envelope: {
+        items: [
+          { confirm_token: 'tok-1', actor: 'agent-1', action_type: 'pause' },
+        ],
+        summary: { visible_count: 1, total_count: 1 },
+      },
     })
     expect(result.pending_confirms).toHaveLength(1)
     expect(result.pending_confirms[0]!.confirm_token).toBe('tok-1')
   })
 
-  it('filters pending_confirms without token', () => {
+  it('filters envelope items without token', () => {
     const result = normalizeOperatorSnapshot({
-      pending_confirms: [
-        { actor: 'agent-1' }, // no token
-      ],
+      pending_confirm_envelope: {
+        items: [
+          { actor: 'agent-1' }, // no token
+        ],
+        summary: { visible_count: 1, total_count: 1 },
+      },
     })
     expect(result.pending_confirms).toEqual([])
   })
@@ -544,16 +550,6 @@ describe('normalizeOperatorSnapshot', () => {
     })
     expect(result.pending_confirms).toHaveLength(1)
     expect(result.pending_confirms[0]!.confirm_token).toBe('tok-e1')
-  })
-
-  it('falls back to pending_confirms when no envelope', () => {
-    const result = normalizeOperatorSnapshot({
-      pending_confirms: [
-        { confirm_token: 'tok-raw', actor: 'system' },
-      ],
-    })
-    expect(result.pending_confirms).toHaveLength(1)
-    expect(result.pending_confirms[0]!.confirm_token).toBe('tok-raw')
   })
 
   it('extracts top-level needs_attention, attention_reason and next_human_action from keeper payload', () => {

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -1,9 +1,7 @@
 import { isRecord, asString, asNumber, asBoolean, asStringArray, extractArray } from './components/common/normalize'
 import {
   normalizeOperatorActionDescriptor,
-  normalizePendingConfirmation,
   normalizePendingConfirmEnvelope,
-  normalizePendingConfirmSummary,
 } from './pending-confirm'
 import {
   normalizeKeeperContextMetricsUnavailable,
@@ -26,7 +24,6 @@ import type {
   OperatorRecommendedAction,
   OperatorSnapshot,
   OperatorNamespaceSnapshot,
-  PendingConfirmation,
 } from './types'
 import { SYSTEM_ACTOR_NAME } from './types/core'
 
@@ -196,15 +193,9 @@ export function normalizeOperatorSnapshot(raw: unknown): OperatorSnapshot {
     recent_messages: extractArray(root.recent_messages, ['messages'])
       .map(normalizeMessage)
       .filter((item): item is Message => item !== null),
-    pending_confirms: pendingConfirmEnvelope?.items
-      ?? extractArray(root.pending_confirms, ['items', 'confirms'])
-        .map(normalizePendingConfirmation)
-        .filter((item): item is PendingConfirmation => item !== null),
+    pending_confirms: pendingConfirmEnvelope?.items ?? [],
     pending_confirm_envelope: pendingConfirmEnvelope ?? undefined,
-    pending_confirm_summary:
-      pendingConfirmEnvelope?.summary
-      ?? normalizePendingConfirmSummary(root.pending_confirm_summary)
-      ?? undefined,
+    pending_confirm_summary: pendingConfirmEnvelope?.summary,
     available_actions: extractArray(root.available_actions, ['actions'])
       .map(normalizeOperatorActionDescriptor)
       .filter((item): item is OperatorActionDescriptor => item !== null),

--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -198,10 +198,13 @@ let json ?actor ~config ~sw ~clock ~proc_mgr
       ]
   in
   let operator_targets_json =
+    let pending_confirm_envelope =
+      member_assoc "pending_confirm_envelope" projection.snapshot_json
+    in
     `Assoc
       [
         ("keepers", `List projection.keeper_briefs);
-        ("pending_confirms", member_assoc "pending_confirms" projection.snapshot_json);
+        ("pending_confirms", member_assoc "items" pending_confirm_envelope);
         ("available_actions", member_assoc "available_actions" projection.snapshot_json);
       ]
   in

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -690,9 +690,7 @@ in
          @ (let confirm_scope =
               timed "pending_confirms" (fun () -> pending_confirm_scope ?actor config)
             in
-            [ ( "pending_confirms"
-              , `List (List.map pending_confirm_to_yojson confirm_scope.visible_entries) )
-            ; ( "pending_confirm_envelope"
+            [ ( "pending_confirm_envelope"
               , `Assoc
                   [ ( "items"
                     , `List
@@ -700,8 +698,6 @@ in
                     )
                   ; "summary", pending_confirm_summary_json_of_scope confirm_scope
                   ] )
-            ; ( "pending_confirm_summary"
-              , pending_confirm_summary_json_of_scope confirm_scope )
             ])
          @ [ "available_actions", available_actions_json
            ; ( "recent_actions"

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -301,10 +301,6 @@ let pending_confirm_scope_of_entries ?actor entries =
 let pending_confirm_scope ?actor config =
   pending_confirm_scope_of_entries ?actor (read_pending_confirms config)
 
-let pending_confirms_json ?actor config =
-  let scope = pending_confirm_scope ?actor config in
-  `List (List.map pending_confirm_to_yojson scope.visible_entries)
-
 let available_actions : available_action list =
   [
     make_available_action ~action_type:"broadcast" ~tool_name:"masc_broadcast"
@@ -370,11 +366,3 @@ let pending_confirm_summary_json_of_scope scope =
 
 let pending_confirm_summary_json ?actor config =
   pending_confirm_summary_json_of_scope (pending_confirm_scope ?actor config)
-
-let pending_confirm_envelope_json ?actor config =
-  let scope = pending_confirm_scope ?actor config in
-  `Assoc
-    [
-      ("items", `List (List.map pending_confirm_to_yojson scope.visible_entries));
-      ("summary", pending_confirm_summary_json_of_scope scope);
-    ]

--- a/lib/operator/operator_pending_confirm.mli
+++ b/lib/operator/operator_pending_confirm.mli
@@ -63,10 +63,8 @@ val remove_pending_confirms_by_typed_target :
 val normalize_pending_confirm_actor_filter : string option -> string option
 val pending_confirm_scope_of_entries : ?actor:string -> pending_confirm list -> pending_confirm_scope
 val pending_confirm_scope : ?actor:string -> Workspace.config -> pending_confirm_scope
-val pending_confirms_json : ?actor:string -> Workspace.config -> Yojson.Safe.t
 val available_actions : available_action list
 val available_action_to_yojson : available_action -> Yojson.Safe.t
 val available_actions_json : Yojson.Safe.t
 val pending_confirm_summary_json_of_scope : pending_confirm_scope -> Yojson.Safe.t
 val pending_confirm_summary_json : ?actor:string -> Workspace.config -> Yojson.Safe.t
-val pending_confirm_envelope_json : ?actor:string -> Workspace.config -> Yojson.Safe.t

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -114,7 +114,8 @@ let test_task_inject_executes_after_confirmation () =
       in
       let snapshot = Operator_control.snapshot_json ~actor:"operator" ctx in
       let pending_confirms =
-        snapshot |> Yojson.Safe.Util.member "pending_confirms"
+        snapshot |> Yojson.Safe.Util.member "pending_confirm_envelope"
+        |> Yojson.Safe.Util.member "items"
         |> Yojson.Safe.Util.to_list
       in
       Alcotest.(check int) "pending confirm count" 1 (List.length pending_confirms);
@@ -143,7 +144,8 @@ let test_task_inject_executes_after_confirmation () =
         (Yojson.Safe.Util.member "result" confirm_json <> `Null);
       let snapshot = Operator_control.snapshot_json ~actor:"operator" ctx in
       let pending_confirms =
-        snapshot |> Yojson.Safe.Util.member "pending_confirms"
+        snapshot |> Yojson.Safe.Util.member "pending_confirm_envelope"
+        |> Yojson.Safe.Util.member "items"
         |> Yojson.Safe.Util.to_list
       in
       Alcotest.(check int) "pending confirm removed" 0

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -321,8 +321,7 @@ let test_confirm_consumes_pending_token_before_delegated_action_fails () =
        | Ok () -> ()
        | Error err -> Alcotest.failf "failed to persist pending confirm fixture: %s" err);
       let initial_pending_confirms =
-        Operator_control.pending_confirms_json ~actor:"operator" config
-        |> Yojson.Safe.Util.to_list
+        (Operator_control.pending_confirm_scope ~actor:"operator" config).visible_entries
       in
       Alcotest.(check int)
         "pending confirm fixture persisted" 1
@@ -336,8 +335,7 @@ let test_confirm_consumes_pending_token_before_delegated_action_fails () =
       | Error err ->
           Alcotest.(check bool) "non-empty error" true (String.length err > 0));
       let pending_confirms =
-        Operator_control.pending_confirms_json ~actor:"operator" config
-        |> Yojson.Safe.Util.to_list
+        (Operator_control.pending_confirm_scope ~actor:"operator" config).visible_entries
       in
       Alcotest.(check int) "pending confirm consumed" 0 (List.length pending_confirms))
 

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -758,8 +758,8 @@ let test_snapshot_has_expected_sections () =
         (Yojson.Safe.Util.member "keepers" json <> `Null);
       Alcotest.(check bool) "recent_messages present" true
         (Yojson.Safe.Util.member "recent_messages" json <> `Null);
-      Alcotest.(check bool) "pending_confirms present" true
-        (Yojson.Safe.Util.member "pending_confirms" json <> `Null);
+      Alcotest.(check bool) "pending-confirm envelope present" true
+        (Yojson.Safe.Util.member "pending_confirm_envelope" json <> `Null);
       Alcotest.(check bool) "trace_id present" true
         (json |> Yojson.Safe.Util.member "trace_id" |> Yojson.Safe.Util.to_string
        <> "");
@@ -815,7 +815,9 @@ let test_snapshot_pending_confirm_summary_tracks_actor_scope () =
       request_namespace_pause "operator-a";
       request_namespace_pause "operator-b";
       let snapshot = Operator_control.snapshot_json ~actor:"operator-a" ctx in
-      let summary = Yojson.Safe.Util.(snapshot |> member "pending_confirm_summary") in
+      let summary =
+        Yojson.Safe.Util.(snapshot |> member "pending_confirm_envelope" |> member "summary")
+      in
       Alcotest.(check string) "actor filter" "operator-a"
         Yojson.Safe.Util.(summary |> member "actor_filter" |> to_string);
       Alcotest.(check bool) "filter active" true


### PR DESCRIPTION
## Summary

- emit one pending-confirm envelope from the operator snapshot
- derive mission and dashboard item lists from envelope.items
- remove duplicate flat and standalone summary producers
- remove dead pending-confirm JSON facade helpers

## Scope

- 9 files
- no compatibility fallback
- no new approval or confirmation gate

## Verification

- local tests were not run; focused CI suites are the authority