### PR TITLE
ci: run the OAS schema boundary suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1388,7 +1388,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          constraint_targets="@test/runtest-test_tool_schema_constraint_enforcement @test/runtest-test_keeper_artifact_read_request @test/runtest-test_tool_input_validation"
+          constraint_targets="@test/runtest-test_tool_schema_constraint_enforcement @test/runtest-test_keeper_artifact_read_request @test/runtest-test_tool_input_validation @test/runtest-test_tool_schema_oas_boundary"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${constraint_targets}"
 
       # The tool-call quality benchmark scores keeper runs against selectors


### PR DESCRIPTION
## 문제

`test_tool_schema_oas_boundary` 는 keeper 모델 도구 스키마 전부가 MASC/OAS 경계를 통과하는지 단언한다. `test/dune` 에 등록돼 있지만 **`ci.yml` 이 이름을 부르지 않는다.**

```
$ rg -c 'test_tool_schema_oas_boundary' test/dune                          → 2
$ rg -c 'runtest-test_tool_schema_oas_boundary' .github/workflows/ci.yml   → 0
```

masc 는 catch-all `dune test` 를 제거했으므로 이름을 안 적은 스위트는 **컴파일만 되고 실행되지 않는다.**

## 왜 지금 필요한가

`lib/tool_bridge.ml` 에 스키마 불일치를 값이 아니라 예외로 바꾸는 자리가 둘이다.

```ocaml
:226   let parameters = params_of_json_schema input_schema in   (* Invalid_argument 를 던진다 *)

:257   match Agent_sdk.Types.tool_schema_of_input_schema … with
:258   | Ok schema -> Agent_sdk.Base.Tool.of_schema ?descriptor schema oas_handler
:259   | Error detail -> invalid_arg (Printf.sprintf "tool %S schema invalid: %s" name detail)
```

둘 다 `keeper_tools_oas_bundle` 이 `model_visible_descriptors` 를 도는 `List.map` 안에서 호출된다. **descriptor 하나의 스키마가 어긋나면 그 keeper 의 도구 번들 생성 전체가 예외로 죽는다.**

상류 필터가 막아주지 않는다. `model_schema_errors`(masc)는 최상위 object 여부와 property/required 이름만 보고, oas 의 `tool_schema_of_input_schema` 는 추가로 중첩 중복 키·명시적 non-object 인자·malformed projectable field 를 거부한다. **masc 쪽이 더 관대하다.**

이 두 자리는 "배포 전에 CI 가 잡는다" 는 전제 위에서만 정당하다. 그 전제를 만드는 게 이 한 줄이다.

## 변경

`ci.yml:1391` 의 `constraint_targets` 에 `@test/runtest-test_tool_schema_oas_boundary` 추가. 그것뿐이다.

## 범위에 대한 정직한 진술

- 이 스위트는 현재 **`params_of_json_schema` 경로만** 검사한다(`test_tool_schema_oas_boundary.ml:41`). `:257` 의 `tool_schema_of_input_schema` 경로 케이스는 **후속**이다. 지금은 커버리지 0 → 1 이고, 2 가 아니다.
- 스위트가 실패하면 그건 **기존 descriptor 중 하나가 이미 경계를 통과하지 못한다**는 뜻이다. 그 경우 이 PR 이 결함을 만든 게 아니라 드러낸 것이므로, 해당 descriptor 를 고치는 게 맞다.
- 로컬 빌드는 돌리지 않았다. 저장소 방침대로 CI 가 권위다.

## 배경

`#27463` 이 이 배선을 포함했으나, `#27619`(agent core import)로 핀 기계가 사라지면서 superseded 로 닫혔고 배선도 함께 사라졌다.
