### PR TITLE
fix(keeper): 읽히지 않는 operator note 가 조용히 사라지지 않게

### DIFF
--- a/lib/keeper/keeper_operator_note.ml
+++ b/lib/keeper/keeper_operator_note.ml
@@ -151,7 +151,14 @@ let pending ~config ~keeper =
 
 let mark_consumed ~config ~keeper ~absolute_turn =
   match read ~config ~keeper with
-  | Error _ -> ()
+  (* Nothing to stamp is the ordinary case; anything else means the note is
+     there and unreadable, which the save arm below already reports. *)
+  | Error No_note -> ()
+  | Error err ->
+    Log.Keeper.warn
+      ~keeper_name:keeper
+      "operator note consumption stamp skipped: %s"
+      (read_error_to_string err)
   | Ok note ->
     let stamped =
       { note with consumed_at = Some (Time_compat.now ()); consumed_turn = Some absolute_turn }

--- a/test/test_keeper_operator_note.ml
+++ b/test/test_keeper_operator_note.ml
@@ -69,6 +69,28 @@ let test_renders_once_then_never_again () =
     | Some _ -> Alcotest.fail "a consumed note must not render on the next turn")
 ;;
 
+(* mark_consumed used to swallow every read error the same way it swallows
+   "there is no note". An unreadable note then left no trace at all, while the
+   save arm beside it reports its failures. *)
+let test_consumption_is_quiet_only_when_there_is_no_note () =
+  with_workspace (fun config ->
+    (* No note: the ordinary case, and nothing to report. *)
+    Note.mark_consumed ~config ~keeper ~absolute_turn:1;
+    (match Note.read ~config ~keeper with
+     | Error Note.No_note -> ()
+     | Error other ->
+       Alcotest.failf "expected No_note, got %s" (Note.read_error_to_string other)
+     | Ok _ -> Alcotest.fail "no note was written");
+    (* An invalid keeper name is a read error, not an absent note. It must not
+       reach the same arm. *)
+    Note.mark_consumed ~config ~keeper:"../escape" ~absolute_turn:2;
+    match Note.read ~config ~keeper:"../escape" with
+    | Error (Note.Read_unknown_keeper _) -> ()
+    | Error other ->
+      Alcotest.failf "expected Read_unknown_keeper, got %s" (Note.read_error_to_string other)
+    | Ok _ -> Alcotest.fail "an invalid keeper name must not read a note")
+;;
+
 (* Deleting the note on consumption would make these two states identical, and
    the first thing an operator asks is whether it went in. *)
 let test_consumption_leaves_a_delivery_record () =
@@ -185,7 +207,9 @@ let () =
   Alcotest.run
     "keeper operator note"
     [ ( "lifetime"
-      , [ Alcotest.test_case "renders once then never again" `Quick
+      , [ Alcotest.test_case "consumption is quiet only when there is no note" `Quick
+            test_consumption_is_quiet_only_when_there_is_no_note
+        ; Alcotest.test_case "renders once then never again" `Quick
             test_renders_once_then_never_again
         ; Alcotest.test_case "consumption leaves a delivery record" `Quick
             test_consumption_leaves_a_delivery_record


### PR DESCRIPTION
`mark_consumed` 가 읽기 실패를 전부 한 arm 으로 삼켰다.

```ocaml
match read ~config ~keeper with
| Error _ -> ()          ← No_note 도, 파싱 실패도 여기로
| Ok note -> ...
  (match save config keeper stamped with
   | Error detail -> Log.Keeper.warn ... detail)   ← 저장 실패는 보고한다
```

"노트가 없음"(`No_note`)은 정상이지만 `Read_unknown_keeper` 와 `Malformed` 도 같은 곳으로 간다. **노트가 존재하는데 읽히지 않으면 아무 흔적 없이 소비 스탬프가 누락된다.** 같은 함수의 아래 절반은 실패를 보고하는데 위 절반만 조용했다.

`No_note` 만 조용히 두고 나머지는 `read_error_to_string` 으로 보고한다.

## 발견 경로

`scripts/anti-fake-audit.sh --production-scan` — RFC-0098 §3.4 의 silent-failure 게이트다. **CI 에 배선돼 있지 않고**, 돌려보면 origin/main 에서 7건 실패한다.

7건을 전수 확인해 판정을 갈랐다.

- **정당** — `keeper_chat_discord.ml:297` 은 바로 위에서 `Log.Keeper.warn` 을 찍은 뒤의 arm, `keeper_gate.ml:751` 은 `Eio.Cancel.protect` 안의 취소 경로
- **결함** — 이 PR 이 고치는 한 건

게이트 배선과 grandfather 목록 문제(11개 항목이 전부 무효한 줄을 가리킴)는 **#27623** 에 기록했다.

## 회귀 방지

`No_note` 와 `Read_unknown_keeper` 가 **다른 답**임을 고정한다. 노트 없이 `mark_consumed` 를 부른 뒤 여전히 `No_note` 인지, 무효한 keeper 이름으로 부른 뒤 `Read_unknown_keeper` 인지 검사한다.

## 검증

- `dune build @check`: EXIT=0
- `test_keeper_operator_note`(CI 배선): 통과
- `--production-scan` 위반: 7 → **6**
- determinism gate, ignore-diff lint: 통과
