### PR TITLE
fix(keeper): quiet capacity release 가 취소까지 삼키지 않게

### DIFF
--- a/lib/keeper/keeper_turn_driver_admission.ml
+++ b/lib/keeper/keeper_turn_driver_admission.ml
@@ -5,12 +5,15 @@
     Used by the keeper turn driver's [run_named] entry to map providers
     to runtime candidates with deterministic admission keys. *)
 
+(* "Quietly" covers a release that fails, not a turn that was cancelled:
+   swallowing Cancelled here would let the fiber keep running past its
+   cancellation point. *)
 let release_client_capacity_quietly = function
   | None -> ()
   | Some release ->
-      (match release () with
-       | () -> ()
-       | exception _ -> ())
+      (try release () with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | _ -> ())
 
 let provider_config_identity_key (cfg : Llm_provider.Provider_config.t) =
   Hashtbl.hash


### PR DESCRIPTION
`release_client_capacity_quietly` 가 `release ()` 의 모든 예외를 삼켰다.

```ocaml
(match release () with
 | () -> ()
 | exception _ -> ())      ← Cancelled 도 여기로
```

`Eio.Cancel.Cancelled` 가 이 arm 을 타면 **취소된 턴이 취소 지점을 지나 계속 실행된다.** "quietly" 는 release 가 실패하는 경우를 뜻하지 취소된 fiber 를 뜻하지 않는다.

## 근거

저장소는 **1078곳**에서 `Eio.Cancel.Cancelled` 를 명시 가드한다. 관용구도 일정하다.

```ocaml
| Eio.Cancel.Cancelled _ as e -> raise e
```

CLAUDE.md 는 이 패턴을 **TLA+ 버그 모델로 검증했다**고 기록한다 — `KeeperOASAdvanced.tla` 의 `CancelledAbsorbed` action 과 `CancelledNeverAbsorbed` invariant. 스타일 취향이 아니라 이미 명명된 결함 형태다.

## 4건 중 이 하나만 고친 이유

`scripts/lint-cancel-guard.sh` 가 4곳을 지목하는데, 나머지 셋은 판단이 갈린다.

| 위치 | 성격 |
|---|---|
| `auth.ml:135` | 파일 읽기 술어 — 실패를 `false` 로 |
| `session_lifecycle_event.ml:219` | observer publish, **"Swallow + log" 근거 주석 있음** |
| `server_runtime_bootstrap.ml:1476` | JSON member 조회 |
| `keeper_turn_driver_admission.ml:13` | **의도가 명확 → 이 PR** |

## 가드가 CI 에 없다

`lint-cancel-guard.sh` 는 배선돼 있지 않다. 같은 상태의 자칭 게이트 3종(로깅 일관성, TLA mutation 래칫 포함)을 **#27626** 에 정리했다.

## 검증

- `dune build @check`: EXIT=0
- `test_keeper_turn_driver_accept`, `test_keeper_turn_driver_failover`: 통과
- `lint-cancel-guard.sh`: 4 → **3**
- determinism gate: 통과
