### PR TITLE
fix(audit): 미배선 가드 스캔이 놓치던 3종을 세게 하고 dead-surface 래칫을 조인다

### DIFF
--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -552,7 +552,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # Removing a live export and its only call site leaves the dead count where it
 # was. Measured with --exports on the merged tree -- 563 - 1 assumed the export
 # was dead, and it was not.
-DEAD_EXPORT_BASELINE = 561
+DEAD_EXPORT_BASELINE = 557
 
 
 def run_ratchet(count: int) -> int:

--- a/scripts/audit-unwired-audits.sh
+++ b/scripts/audit-unwired-audits.sh
@@ -21,26 +21,35 @@ set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-UNWIRED_BASELINE=9
+# Measured, not computed: 14 is what the widened scan reports on main. The
+# previous 9 came from a narrower pattern that skipped scripts/ci/ entirely
+# and did not match lint-* names, so three self-declared gates
+# (check-logging-consistency, lint-cancel-guard, tla-mutation-lint-ratchet)
+# were invisible to it. See #27626.
+UNWIRED_BASELINE=14
 
 all="$(mktemp)"
 called="$(mktemp)"
 trap 'rm -f "$all" "$called"' EXIT
 
-ls scripts/*.sh scripts/*.py 2>/dev/null | xargs -n1 basename | sort -u > "$all"
+# scripts/ci/ holds guards too — check-logging-consistency.sh lives there
+# and was invisible to this count.
+ls scripts/*.sh scripts/*.py scripts/ci/*.sh scripts/ci/*.py 2>/dev/null \
+  | xargs -n1 basename | sort -u > "$all"
 
 # Names appear either as scripts/<name> or bare inside a for-loop list.
-grep -ohE "scripts/[a-z0-9_.-]+\.(sh|py)|^[[:space:]]+(audit|check|verify|guard)[a-z0-9_.-]*\.(sh|py)" \
-  .github/workflows/*.yml 2>/dev/null \
-  | sed 's|scripts/||; s/^[[:space:]]*//' \
+grep -ohE "scripts/(ci/)?[a-z0-9_.-]+\.(sh|py)|^[[:space:]]+(audit|check|verify|guard|lint)[a-z0-9_.-]*\.(sh|py)" \
+  .github/workflows/*.yml scripts/ci/run-lint-suite.sh 2>/dev/null \
+  | sed 's|scripts/ci/||; s|scripts/||; s/^[[:space:]]*//' \
   | sort -u > "$called"
 
-unwired="$(comm -23 "$all" "$called" | grep -cE '^(audit|check|verify|guard)' || true)"
+GUARD_NAME_RE='^(audit|check|verify|guard|lint)|lint'
+unwired="$(comm -23 "$all" "$called" | grep -cE "$GUARD_NAME_RE" || true)"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then
   echo "[unwired-audits] FAIL - ${unwired} audit scripts are never run by CI (baseline ${UNWIRED_BASELINE})"
   echo
-  comm -23 "$all" "$called" | grep -E '^(audit|check|verify|guard)' | sed 's/^/  - /'
+  comm -23 "$all" "$called" | grep -E "$GUARD_NAME_RE" | sed 's/^/  - /'
   echo
   echo "A guard CI does not run cannot fail, so it does not guard anything."
   echo "Wire it into .github/workflows/ci.yml, or record here why it cannot run"


### PR DESCRIPTION
`audit-unwired-audits.sh` 는 **CI 가 안 돌리는 가드를 잡으려고** 존재한다. 그런데 자기 탐지가 세 부류를 놓치고 있었다.

## 사각지대 3종

**1. `scripts/ci/` 를 후보 목록에 안 넣는다**

```bash
ls scripts/*.sh scripts/*.py | xargs -n1 basename | sort -u > "$all"
```

`scripts/ci/check-logging-consistency.sh` 는 **파일 둘째 줄이 `# CI gate: logging-method consistency`** 인데 애초에 셀 수가 없었다.

**2. 이름 패턴이 `^(audit|check|verify|guard)`**

`lint-cancel-guard.sh`, `tla-mutation-lint-ratchet.sh`, `tla-mutation-lint.sh` 가 전부 미매칭이다.

**3. 세는 패턴과 출력 패턴이 다르다**

카운트는 한 정규식, 목록 출력은 다른 정규식이라 **세어놓고 안 보여주는** 이름이 생긴다.

## 결과: 9 → 14

넓히자 14개가 드러났다. 그중 둘은 **돌리면 실패한다**.

| 가드 | 현재 / baseline |
|---|---|
| `check-logging-consistency.sh` | 29 / **0** |
| `tla-mutation-lint-ratchet.sh` | 374 / 163 |

baseline 을 **14로 실측 반영**했다(계산이 아니라 넓힌 스캔이 main 에서 보고한 값). 이 가드들을 배선할지 폐기할지는 **#27626** 의 주제이고, 이 PR 은 **그 수가 다시 조용히 늘지 못하게** 만든다.

## 오탐을 하나 잡았다

처음 넓혔을 때 40이 나왔는데, `sed 's|scripts/||'` 가 `scripts/ci/foo.sh` 를 `ci/foo.sh` 로만 만들어 basename 과 대조가 깨진 탓이었다. `check-determinism-contract.sh` 와 `check-ignore-without-comment-diff.sh` 는 **실제로 CI 가 호출한다**. 순서를 고쳐 40 → 14.

## 함께 조인 래칫

`DEAD_EXPORT_BASELINE` 561 → 557. 래칫 자신이 지시한 것이다.

```
[dead-surface] OK - 557 dead exports, 561 baseline - lower DEAD_EXPORT_BASELINE to hold the 4 you removed
```

## 검증

- `audit-unwired-audits.sh`: `OK - 14 audit scripts unwired, at baseline`
- `audit-dead-surface.py --exports --ratchet`: `OK - 557 dead exports, at baseline`
- `bash -n`: 통과
