### PR TITLE
fix(audit): include 되지 않은 stanza 를 '선언됨'으로 세지 않는다

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -41,9 +41,13 @@ grep -oE '\(name test_[a-z_0-9]+\)' test/dune | sed 's/(name //;s/)//' >> "$decl
 # Explicitly named aliases, e.g. (alias runtest-dashboard-http-behavior-contracts).
 grep -oE '\(alias runtest-[a-z_0-9-]+\)' test/dune \
   | sed 's/(alias runtest-//;s/)//' >> "$declared"
-# Stanzas pulled in through include files.
+# Stanzas pulled in through include files. A .inc file that test/dune does not
+# (include ...) declares nothing: dune answers "Alias ... specified on the
+# command line is empty" for its target, which is the failure this check
+# exists to catch, so existence on disk is not enough.
 for inc in test/stanzas/*.inc; do
   [ -e "$inc" ] || continue
+  grep -qF "(include stanzas/$(basename "$inc"))" test/dune || continue
   grep -oE '\(name test_[a-z_0-9]+\)' "$inc" | sed 's/(name //;s/)//' >> "$declared"
 done
 sort -u -o "$declared" "$declared"


### PR DESCRIPTION
`audit-ci-test-targets.sh` 는 스스로 이렇게 선언한다.

> Fail when `ci.yml` names a test target that `test/dune` **cannot build**.

그런데 선언 수집이 `test/stanzas/*.inc` **파일 존재만** 본다.

```bash
for inc in test/stanzas/*.inc; do
  [ -e "$inc" ] || continue          ← test/dune 이 include 하는지는 안 본다
  grep -oE '\(name test_[a-z_0-9]+\)' "$inc" ...
```

`test/dune` 이 `(include stanzas/foo.inc)` 하지 않으면 그 파일은 **아무것도 선언하지 않는다.** dune 은 해당 타깃에 이렇게 답한다.

```
Alias "runtest-<name>" specified on the command line is empty
```

이게 바로 이 가드가 막겠다고 적어둔 실패다(주석이 두 사례 `#24332`, `#26921` 을 든다).

## 탐침으로 확정

include 되지 않은 `.inc` 와 그것을 참조하는 `ci.yml` 타깃을 만들고 양쪽을 돌렸다.

| | 수정 전 | 수정 후 |
|---|---|---|
| `audit-ci-test-targets.sh` | **OK — all declared in test/dune** | **FAIL**, 타깃 이름 지목 |
| `dune build @test/runtest-<name>` | EXIT=1 | EXIT=1 |

가드가 초록인데 빌드가 깨지는 상태였다.

## 오늘 타깃 변화는 없다

현재 트리의 모든 `.inc` 가 include 돼 있어 카운트는 148 그대로다. 즉 **잠재적 구멍만 메운다.**

(측정 중 149 로 보인 적이 있는데 탐침 잔여 때문이었고, 수정 전후 모두 148 임을 확인했다.)

## 검증

- `bash -n`: 통과
- `[ci-test-targets] OK - 148 CI targets, all declared in test/dune`
- `[ci-test-targets] OK - 706 suites unwired, at baseline`
