### PR TITLE
feat(prompt): 백로그 revision 을 프레임에 — 낡은 결론이 반박될 수 있게

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -1019,6 +1019,24 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
            Buffer.add_string ubuf
              "- Task backlog: readable; it holds 0 unclaimed tasks, 0 claimable tasks for this keeper, and 0 failed tasks.\n"
          | Backlog_readable_with_rows -> ());
+        (* The counts and ids below describe a set; they do not say whether it
+           is the set the last turn described. A keeper that concluded "nothing
+           actionable" reads "3 unclaimed" the same way whether those are the
+           same three tasks or three different ones, so the conclusion outlives
+           whatever made it true. [taskmaster] -- whose instructions are to take
+           unclaimed work on sight -- repeated one verbatim across every turn of
+           a day while its stated reason, that the three were blocked, appeared
+           nowhere in the backlog (#27629).
+
+           The revision is what changes when the backlog does. It is an int the
+           snapshot already carries and until now spent only on a presence check
+           in [backlog_statement_of_observation], so nothing new is read and no
+           keeper-authored text crosses into the frame. *)
+        (match observation.backlog_revision with
+         | None -> ()
+         | Some revision ->
+           Buffer.add_string ubuf
+             (Printf.sprintf "- Backlog revision: %d\n" revision));
         if observation.unclaimed_task_count > 0 then
           Buffer.add_string ubuf
             (Printf.sprintf "- Unclaimed tasks: %d\n"

--- a/test/test_claimable_task_summaries.ml
+++ b/test/test_claimable_task_summaries.ml
@@ -167,9 +167,83 @@ let test_invalid_stored_task_id_makes_snapshot_non_authoritative () =
     | Ok _ -> fail "malformed task identity reached the typed boundary")
 ;;
 
+
+(* A count and a set of ids describe the backlog; they do not say whether it is
+   the backlog the last turn described. [taskmaster], whose instructions are to
+   take unclaimed work on sight, repeated one "nothing actionable" verbatim
+   across a day of turns -- and the reason it gave, that the three tasks were
+   blocked, appears nowhere in their records (#27629). Nothing in its frame
+   could contradict a conclusion it already held.
+
+   The revision is the value that moves when the backlog does. These cases
+   assert it reaches the rendered frame and that it is the snapshot's, not a
+   constant: a render that printed any fixed number would satisfy "a line is
+   present" and still leave two different backlogs looking identical. *)
+let frame config meta =
+  (* [observe] collects Board events, which needs an Eio context; the rest of
+     this suite reads the backlog directly and does not. *)
+  let observation =
+    Eio_main.run (fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Keeper_world_observation.observe ~pending_board_events:None ~config ~meta)
+  in
+  let parts =
+    Keeper_unified_prompt.build_prompt_preview
+      ~meta
+      ~config
+      ~current_task:Keeper_world_observation_inputs.No_current_task
+      ~observation
+      ()
+  in
+  parts.Keeper_unified_prompt.world_state
+;;
+
+let revision_line_of frame =
+  String.split_on_char '\n' frame
+  |> List.find_opt (fun line ->
+    String.length line > 20 && String.equal (String.sub line 0 20) "- Backlog revision: ")
+;;
+
+let test_the_frame_states_the_backlog_revision () =
+  with_config (fun config meta ->
+    let _ = add config ~title:"Something to claim" ~created_by:"someone-else" in
+    let rendered = frame config meta in
+    match revision_line_of rendered with
+    | None ->
+      failf "the frame states no backlog revision. frame was:\n%s" rendered
+    | Some line ->
+      let observed = (snapshot config meta).revision in
+      check
+        (option string)
+        "the stated revision is the snapshot's"
+        (Option.map (Printf.sprintf "- Backlog revision: %d") observed)
+        (Some line))
+;;
+
+let test_the_stated_revision_moves_with_the_backlog () =
+  with_config (fun config meta ->
+    let _ = add config ~title:"First" ~created_by:"someone-else" in
+    let before = revision_line_of (frame config meta) in
+    let _ = add config ~title:"Second" ~created_by:"someone-else" in
+    let after = revision_line_of (frame config meta) in
+    check bool "a revision is stated before" true (Option.is_some before);
+    check bool "a revision is stated after" true (Option.is_some after);
+    check
+      bool
+      "the two turns do not state the same revision"
+      false
+      (Option.equal String.equal before after))
+;;
+
 let () =
   run "claimable_task_summaries"
-    [ ( "rows"
+    [ ( "revision"
+      , [ test_case "the frame states the backlog revision" `Quick
+            test_the_frame_states_the_backlog_revision
+        ; test_case "the stated revision moves with the backlog" `Quick
+            test_the_stated_revision_moves_with_the_backlog
+        ] )
+    ; ( "rows"
       , [ test_case "a claimable task is named" `Quick test_a_claimable_task_is_named
         ; test_case "the list and the count agree" `Quick
             test_the_list_and_the_count_agree


### PR DESCRIPTION
Refs #27629

## 무엇을

Namespace State 에 백로그 revision 한 줄을 싣습니다.

```
### Namespace State
+ - Backlog revision: 41
  - Unclaimed tasks: 3
  - Claimable tasks for this keeper: 3
    - {"task_id":"task-210"}
```

## 왜

개수와 id 집합은 백로그를 *기술*하지만, **지난 턴이 기술한 그 백로그인지**는 말하지
않습니다. 그래서 한 번 내린 결론이 그것을 참으로 만들던 조건보다 오래 삽니다.

`taskmaster` 는 instructions 가 "unclaimed task와 stale task를 본 순간 무조건
달려든다. '나중에 하자'는 없다" 인데, 하루 종일 같은 문장을 반복합니다:

```
21:40:58  "백로그 3 unclaimed (210, 212, 213) — task-213 HITL sandbox infra,
           210/212 downstream blocked. … nothing actionable."
21:41:53  (동일)
21:42:35  (동일)
```

그 근거는 **레코드에 없습니다** — 세 건 다 평범한 `todo` 이고 `blocked`/`blocker`/
의존성 필드가 없습니다. task-213 은 그날 만들어진 priority 1 입니다.

#27546 이 id 를 프레임에 넣었지만 taskmaster 의 낡은 결론이 이미 "210, 212, 213" 을
문자 그대로 나열하고 있어, **정보가 늘지 않았습니다**(#27629 측정). 프레임 안에
그 결론과 모순될 수 있는 값이 없습니다.

## 왜 revision 인가

- 백로그가 바뀌면 **반드시** 바뀌는 값입니다.
- `observation.backlog_revision` 에 **이미 있습니다.** 지금까지
  `backlog_statement_of_observation` 의 존재 검사(`None` → unreadable)에만 쓰이고
  값은 버려졌습니다. 새로 읽는 것이 없습니다.
- **int 입니다.** keeper 가 쓴 자유 텍스트가 아니므로 #27546 이 title 을 뺀 이유
  (인젝션 표면)에 해당하지 않습니다.

## 검증

```
dune build @check @fmt                                통과
@test/runtest-test_claimable_task_summaries           8 tests, Test Successful
```

새 케이스 2개:
- `the frame states the backlog revision` — 렌더된 값이 **스냅샷의 revision 과 동일**
- `the stated revision moves with the backlog` — task 추가 전후 두 프레임이 **같은
  revision 을 말하지 않음**

두 번째가 없으면 "줄이 있다"만 보므로 고정값도 통과합니다.

**뮤테이션** — `revision` 을 `revision * 0` 으로 고정하면:

```
[FAIL] revision 0  the frame states the backlog revision
[FAIL] revision 1  the stated revision moves with the backlog
```

CI 배선 확인: `.github/workflows/ci.yml:978`.

## 이것이 고치는 것과 아닌 것

**고칩니다**: 프레임이 "같은 백로그인가"에 답할 재료를 갖습니다.

**모릅니다**: taskmaster 가 그 재료를 쓸지. 그 keeper 는 current memory fact 가
**0개**(revision 1148)라 축적 자체가 없고, 매 턴이 첫 턴입니다(#27527). 이 변경 후에도
같은 문장이 반복되면 병목은 프레임이 아니라 메모리 쪽입니다 — #27629 가 두 후보로
적어둔 것을 가르는 실험입니다.

판정: 머지 후 taskmaster raw-trace 의 `nothing actionable` 반복이 끊기는지.

RFC-WAIVED: 프롬프트 프레임에 이미 관측된 int 한 줄을 추가하는 변경으로,
credential/identity/operator-control/sandbox/hooks 어디에도 해당하지 않습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
