### PR TITLE
fix(lint): 존재하지 않는 확장자만 스캔하던 fabricated-telemetry 가드

### DIFF
--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -530,7 +530,7 @@ export class LspConnection {
     }
     const delayMs =
       Math.min(this.reconnectDelayMs, TRANSPORT_RETRY_MAX_MS)
-      + Math.random() * TRANSPORT_RETRY_JITTER_MS
+      + Math.random() * TRANSPORT_RETRY_JITTER_MS // real-randomness-needed: transport retry jitter
     this.reconnectAttempts += 1
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -541,7 +541,7 @@ function scheduleReconnect(): void {
   reconnectAttempts += 1
   const exp = Math.min(reconnectAttempts, WS_RECONNECT_MAX_EXP)
   const backoff = Math.min(RECONNECT_MAX_MS, WS_RECONNECT_BASE_MS * Math.pow(2, exp))
-  const jitter = Math.random() * RECONNECT_JITTER_MS
+  const jitter = Math.random() * RECONNECT_JITTER_MS // real-randomness-needed: spreads simultaneous retries
   const delay = backoff + jitter
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null

--- a/dashboard/src/keeper-chat-store.ts
+++ b/dashboard/src/keeper-chat-store.ts
@@ -95,7 +95,7 @@ export function enqueueInput(
     if (existing) return existing
   }
   const msg: QueuedMessage = {
-    id: `${keeperName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    id: `${keeperName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, // real-randomness-needed: local queue id, never a measurement
     content,
     timestamp: Date.now(),
     sequence: ++_nextQueueSequence,

--- a/scripts/lint/no-fabricated-telemetry.sh
+++ b/scripts/lint/no-fabricated-telemetry.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Detect Math.random() inside dashboard React components (.jsx/.tsx).
+# Detect Math.random() inside dashboard component sources.
 #
 # Why this gate exists:
 #   `fundamental_roadmap.md` Phase 4-1 cites Math.random() driving fake
@@ -7,11 +7,11 @@
 #   remove fabricated telemetry placeholders) removed those, but the
 #   pattern is easy to reintroduce when stubbing UI in isolation.
 #
-# Why .jsx/.tsx only:
-#   Plain .ts files legitimately use Math.random() for ephemeral IDs
-#   (e.g. dashboard/src/sse.ts:53 SSE client id,
-#   dashboard/src/components/common/command-bar.ts:61 listId). Restricting
-#   to component files (.jsx/.tsx) keeps the signal precise.
+# Scope:
+#   The dashboard has no .jsx/.tsx files — components are .ts modules
+#   rendering html`` templates — so a .jsx/.tsx-only scan read nothing.
+#   .ts is scanned; the legitimate uses (retry jitter, ephemeral ids) carry
+#   a `real-randomness-needed:` line comment. Tests are excluded.
 #
 # Allowed (never flagged):
 #   - Lines marked `// real-randomness-needed: <reason>`
@@ -57,7 +57,7 @@ for root in "${ROOTS[@]}"; do
 
     report+=("${key}: ${content}")
     violations=$((violations + 1))
-  done < <(rg --no-heading --line-number --color=never -g '*.jsx' -g '*.tsx' 'Math\.random' "${root}" 2>/dev/null || true)
+  done < <(rg --no-heading --line-number --color=never -g '*.ts' -g '*.jsx' -g '*.tsx' -g '!*.test.ts' 'Math\.random' "${root}" 2>/dev/null || true)
 done
 
 if [[ ${violations} -gt 0 ]]; then


### PR DESCRIPTION
`no-fabricated-telemetry.sh` 는 `-g '*.jsx' -g '*.tsx'` 로만 스캔한다.

```
$ rg --files dashboard/src --glob '*.tsx' | wc -l
0
$ rg --files dashboard/src --glob '*.jsx' | wc -l
0
$ rg --files dashboard/src --glob '*.ts' | wc -l
1283
```

**대시보드에 그 확장자 파일이 하나도 없다.** 컴포넌트는 `.ts` 모듈이 `html``` 템플릿을 렌더하는 구조다(3185곳). 이 lint 는 아무것도 읽지 않아 왔다.

## 탐침

main 에서 컴포넌트에 가짜 스파크라인을 심었다.

```ts
const fakeSparkline = () => Math.random() * 100
```

| | 수정 전 | 수정 후 |
|---|---|---|
| lint | `no-fabricated-telemetry: clean` | **error, 파일·줄 지목** |

lint 헤더가 인용하는 `#12986`("remove fabricated telemetry placeholders")의 바로 그 형태다.

## 기존 4건은 전부 정당하다

범위를 넓혀도 오탐이 없다 — 실제 `Math.random()` 사용처는 넷이고 전부 jitter/ID 다.

| 위치 | 용도 |
|---|---|
| `dashboard-ws.ts:544` | reconnect jitter |
| `ide-lsp-client.ts:533` | transport retry jitter |
| `keeper-chat-store.ts:98` | 로컬 큐 id |
| `cb-shared-telemetry-source.test.ts` | 테스트(제외) |

lint 가 이미 지원하는 `real-randomness-needed:` 마커를 달았다. **마커는 매치된 줄에 있어야 한다** — 면제 검사가 매치 내용만 보고 주변 줄은 안 본다(처음에 위에 달았다가 계속 잡혀서 확인했다).

## 검증

- 탐침: 수정 전 clean → 수정 후 지목
- `no-fabricated-telemetry: clean` (실제 트리)
- dashboard: `tsc --noEmit` EXIT=0, 636 파일 / 8799 테스트 통과
