### PR TITLE
fix(tool): reject lossy schema parameter projection

### DIFF
--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -126,7 +126,35 @@ let oas_error_class_of_tool_failure_class = function
     as strings or reduced to the first union member. *)
 
 let params_of_json_schema schema =
-  Agent_sdk.Mcp.json_schema_to_params schema
+  let params =
+    match Agent_sdk.Mcp.json_schema_to_params_result schema with
+    | Ok params -> params
+    | Error detail -> invalid_arg detail
+  in
+  let unprojected_property =
+    match schema with
+    | `Assoc fields ->
+      (match List.assoc_opt "properties" fields with
+       | Some (`Assoc properties) ->
+         List.find_opt
+           (fun (name, _) ->
+              not
+                (List.exists
+                   (fun (param : Agent_sdk.Types.tool_param) ->
+                      String.equal param.name name)
+                   params))
+           properties
+       | None | Some `Null | Some _ -> None)
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+      None
+  in
+  match unprojected_property with
+  | None -> params
+  | Some (name, _) ->
+    invalid_arg
+      (Printf.sprintf
+         "property %S cannot be represented by the typed tool parameter surface"
+         name)
 ;;
 
 (** {1 OAS Tool.t Creation}


### PR DESCRIPTION
## Summary
- fail the params-only tool boundary when a top-level JSON Schema property cannot be represented
- preserve the authoritative input_schema path for complex schemas
- restore the existing ambiguous-union contract without adding a compatibility fallback

## Evidence
- current main CI fails test_tool_input_validation: ambiguous schema union must not select its first member
- #27616 and #27617 fail at the same baseline test