### PR TITLE
fix(build): exclude refutation scratch from Dune graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ all_comments_*.txt
 test-integration-*.txt
 tmp_edit/
 .tmp/
+/refute_tmp/
 
 # Runtime data directories (not source)
 data/economy/

--- a/dune
+++ b/dune
@@ -4,6 +4,8 @@
   .worktrees
   worktrees
   _build_codex_trpg
+  ; Ad hoc refutation probes are operator scratch, never project source.
+  refute_tmp
   archive
   dashboard_bonsai))
 


### PR DESCRIPTION
## Problem

`dune build .` recursively admitted an untracked operator scratch directory named `refute_tmp/`. Its ad hoc executable referenced `Fs_compat` outside the supported package boundary and broke the repository-wide build even though no tracked main source depended on that probe.

## Contract

- `refute_tmp/` is operator scratch, not project source.
- Root Dune discovery excludes it before parsing its local `dune` file.
- Git ignores the same directory.
- No `Fs_compat` alias, compatibility shim, or legacy probe is restored.

## Verification

- Local build not rerun; CI is the authority for this draft.
