### PR TITLE
fix(operator): hard-cut pending confirm contract

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -166,7 +166,7 @@ describe('normalizePendingConfirmation (board)', () => {
     expect(normalizePendingConfirmation(null)).toBeNull()
   })
 
-  it('returns null when no confirm_token or token', () => {
+  it('returns null when confirm_token is missing', () => {
     expect(normalizePendingConfirmation({ actor: 'a1' })).toBeNull()
   })
 
@@ -175,9 +175,8 @@ describe('normalizePendingConfirmation (board)', () => {
     expect(result!.confirm_token).toBe('tok-1')
   })
 
-  it('falls back to token field', () => {
-    const result = normalizePendingConfirmation({ token: 'tok-fallback' })
-    expect(result!.confirm_token).toBe('tok-fallback')
+  it('rejects a token-only item', () => {
+    expect(normalizePendingConfirmation({ token: 'noncanonical' })).toBeNull()
   })
 
   it('extracts all optional fields', () => {

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -1,5 +1,28 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeOperatorDigest, normalizeOperatorSnapshot } from './operator-normalizers'
+import {
+  normalizeOperatorDigest,
+  normalizeOperatorSnapshot as normalizeOperatorSnapshotWire,
+} from './operator-normalizers'
+
+const emptyPendingConfirmEnvelope = {
+  items: [],
+  summary: {
+    actor_filter: null,
+    filter_active: false,
+    visible_count: 0,
+    total_count: 0,
+    hidden_count: 0,
+    hidden_actors: [],
+    confirm_required_actions: [],
+  },
+}
+
+function normalizeOperatorSnapshot(raw: Record<string, unknown>) {
+  return normalizeOperatorSnapshotWire({
+    pending_confirm_envelope: emptyPendingConfirmEnvelope,
+    ...raw,
+  })
+}
 
 // ================================================================
 // normalizeOperatorDigest
@@ -143,20 +166,12 @@ describe('normalizeOperatorDigest', () => {
 // ================================================================
 
 describe('normalizeOperatorSnapshot', () => {
-  it('returns safe defaults for null', () => {
-    const result = normalizeOperatorSnapshot(null)
-    expect(result.root).toEqual({})
-    expect(result.keepers).toEqual([])
-    expect(result.persistent_agents).toEqual([])
-    expect(result.inference_inflight).toBeNull()
-    expect(result.recent_messages).toEqual([])
-    expect(result.pending_confirms).toEqual([])
-    expect(result.available_actions).toEqual([])
+  it('rejects null', () => {
+    expect(() => normalizeOperatorSnapshotWire(null)).toThrow('invalid operator snapshot')
   })
 
-  it('returns safe defaults for undefined', () => {
-    const result = normalizeOperatorSnapshot(undefined)
-    expect(result.keepers).toEqual([])
+  it('rejects undefined', () => {
+    expect(() => normalizeOperatorSnapshotWire(undefined)).toThrow('invalid operator snapshot')
   })
 
   it('extracts root namespace', () => {
@@ -467,29 +482,42 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.recent_messages[0]!.id).toBe('msg-1')
   })
 
-  it('derives pending_confirms from envelope items', () => {
+  it('keeps pending confirmations inside the envelope', () => {
     const result = normalizeOperatorSnapshot({
       pending_confirm_envelope: {
         items: [
           { confirm_token: 'tok-1', actor: 'agent-1', action_type: 'pause' },
         ],
-        summary: { visible_count: 1, total_count: 1 },
+        summary: {
+          ...emptyPendingConfirmEnvelope.summary,
+          visible_count: 1,
+          total_count: 1,
+        },
       },
     })
-    expect(result.pending_confirms).toHaveLength(1)
-    expect(result.pending_confirms[0]!.confirm_token).toBe('tok-1')
+    expect(result.pending_confirm_envelope.items).toHaveLength(1)
+    expect(result.pending_confirm_envelope.items[0]!.confirm_token).toBe('tok-1')
   })
 
-  it('filters envelope items without token', () => {
-    const result = normalizeOperatorSnapshot({
+  it('rejects a snapshot with an invalid envelope item', () => {
+    expect(() => normalizeOperatorSnapshotWire({
       pending_confirm_envelope: {
         items: [
-          { actor: 'agent-1' }, // no token
+          { actor: 'agent-1' },
         ],
-        summary: { visible_count: 1, total_count: 1 },
+        summary: {
+          ...emptyPendingConfirmEnvelope.summary,
+          visible_count: 1,
+          total_count: 1,
+        },
       },
-    })
-    expect(result.pending_confirms).toEqual([])
+    })).toThrow('invalid pending_confirm_envelope')
+  })
+
+  it('rejects a snapshot without the canonical envelope', () => {
+    expect(() => normalizeOperatorSnapshotWire({})).toThrow(
+      'invalid pending_confirm_envelope',
+    )
   })
 
   it('extracts available_actions', () => {
@@ -543,13 +571,14 @@ describe('normalizeOperatorSnapshot', () => {
           { confirm_token: 'tok-e1', actor: 'agent-1' },
         ],
         summary: {
+          ...emptyPendingConfirmEnvelope.summary,
           visible_count: 1,
           total_count: 5,
         },
       },
     })
-    expect(result.pending_confirms).toHaveLength(1)
-    expect(result.pending_confirms[0]!.confirm_token).toBe('tok-e1')
+    expect(result.pending_confirm_envelope.items).toHaveLength(1)
+    expect(result.pending_confirm_envelope.items[0]!.confirm_token).toBe('tok-e1')
   })
 
   it('extracts top-level needs_attention, attention_reason and next_human_action from keeper payload', () => {

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -179,8 +179,10 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
 }
 
 export function normalizeOperatorSnapshot(raw: unknown): OperatorSnapshot {
-  const root = isRecord(raw) ? raw : {}
+  if (!isRecord(raw)) throw new Error('invalid operator snapshot')
+  const root = raw
   const pendingConfirmEnvelope = normalizePendingConfirmEnvelope(root.pending_confirm_envelope)
+  if (!pendingConfirmEnvelope) throw new Error('invalid pending_confirm_envelope')
   return {
     root: normalizeNamespace(root.root),
     keepers: extractArray(root.keepers, ['items', 'keepers'])
@@ -193,9 +195,7 @@ export function normalizeOperatorSnapshot(raw: unknown): OperatorSnapshot {
     recent_messages: extractArray(root.recent_messages, ['messages'])
       .map(normalizeMessage)
       .filter((item): item is Message => item !== null),
-    pending_confirms: pendingConfirmEnvelope?.items ?? [],
-    pending_confirm_envelope: pendingConfirmEnvelope ?? undefined,
-    pending_confirm_summary: pendingConfirmEnvelope?.summary,
+    pending_confirm_envelope: pendingConfirmEnvelope,
     available_actions: extractArray(root.available_actions, ['actions'])
       .map(normalizeOperatorActionDescriptor)
       .filter((item): item is OperatorActionDescriptor => item !== null),

--- a/dashboard/src/pending-confirm.test.ts
+++ b/dashboard/src/pending-confirm.test.ts
@@ -4,8 +4,17 @@ import {
   normalizePendingConfirmation,
   normalizePendingConfirmSummary,
   normalizePendingConfirmEnvelope,
-  selectPendingConfirmState,
 } from './pending-confirm'
+
+const emptyPendingConfirmSummary = {
+  actor_filter: null,
+  filter_active: false,
+  visible_count: 0,
+  total_count: 0,
+  hidden_count: 0,
+  hidden_actors: [],
+  confirm_required_actions: [],
+}
 
 // ================================================================
 // normalizeOperatorActionDescriptor
@@ -76,7 +85,7 @@ describe('normalizePendingConfirmation', () => {
     expect(normalizePendingConfirmation(42)).toBeNull()
   })
 
-  it('returns null when no confirm_token or token', () => {
+  it('returns null when confirm_token is missing', () => {
     expect(normalizePendingConfirmation({ actor: 'agent-1' })).toBeNull()
   })
 
@@ -88,19 +97,8 @@ describe('normalizePendingConfirmation', () => {
     expect(result!.confirm_token).toBe('tok-1')
   })
 
-  it('falls back to token field', () => {
-    const result = normalizePendingConfirmation({
-      token: 'tok-fallback',
-    })
-    expect(result!.confirm_token).toBe('tok-fallback')
-  })
-
-  it('prefers confirm_token over token', () => {
-    const result = normalizePendingConfirmation({
-      confirm_token: 'primary',
-      token: 'secondary',
-    })
-    expect(result!.confirm_token).toBe('primary')
+  it('rejects a token-only item', () => {
+    expect(normalizePendingConfirmation({ token: 'noncanonical' })).toBeNull()
   })
 
   it('extracts all fields', () => {
@@ -144,16 +142,8 @@ describe('normalizePendingConfirmSummary', () => {
     expect(normalizePendingConfirmSummary('invalid')).toBeNull()
   })
 
-  it('returns defaults for empty record', () => {
-    const result = normalizePendingConfirmSummary({})
-    expect(result).not.toBeNull()
-    expect(result!.actor_filter).toBeNull()
-    expect(result!.filter_active).toBe(false)
-    expect(result!.visible_count).toBe(0)
-    expect(result!.total_count).toBe(0)
-    expect(result!.hidden_count).toBe(0)
-    expect(result!.hidden_actors).toEqual([])
-    expect(result!.confirm_required_actions).toEqual([])
+  it('rejects an incomplete summary', () => {
+    expect(normalizePendingConfirmSummary({})).toBeNull()
   })
 
   it('extracts all fields', () => {
@@ -177,13 +167,13 @@ describe('normalizePendingConfirmSummary', () => {
     expect(result!.confirm_required_actions).toHaveLength(1)
   })
 
-  it('filters invalid confirm_required_actions', () => {
-    const result = normalizePendingConfirmSummary({
+  it('rejects invalid confirm_required_actions', () => {
+    expect(normalizePendingConfirmSummary({
+      ...emptyPendingConfirmSummary,
       confirm_required_actions: [
-        { action_type: 'pause' }, // missing target_type
+        { action_type: 'pause' },
       ],
-    })
-    expect(result!.confirm_required_actions).toEqual([])
+    })).toBeNull()
   })
 })
 
@@ -204,160 +194,62 @@ describe('normalizePendingConfirmEnvelope', () => {
     expect(normalizePendingConfirmEnvelope({})).toBeNull()
   })
 
-  it('extracts items from array', () => {
+  it('extracts the complete envelope', () => {
     const result = normalizePendingConfirmEnvelope({
       items: [
         { confirm_token: 'tok-1' },
         { confirm_token: 'tok-2' },
       ],
+      summary: {
+        actor_filter: null,
+        filter_active: false,
+        visible_count: 2,
+        total_count: 2,
+        hidden_count: 0,
+        hidden_actors: [],
+        confirm_required_actions: [],
+      },
     })
     expect(result).not.toBeNull()
     expect(result!.items).toHaveLength(2)
     expect(result!.items[0]!.confirm_token).toBe('tok-1')
   })
 
-  it('extracts items from nested confirms', () => {
-    const result = normalizePendingConfirmEnvelope({
-      items: {
-        confirms: [
-          { confirm_token: 'nested-1' },
-        ],
-      },
-    })
-    expect(result!.items).toHaveLength(1)
-    expect(result!.items[0]!.confirm_token).toBe('nested-1')
+  it('rejects a non-array items field', () => {
+    expect(normalizePendingConfirmEnvelope({
+      items: { confirms: [{ confirm_token: 'nested-1' }] },
+      summary: {},
+    })).toBeNull()
   })
 
-  it('filters items without confirm_token', () => {
-    const result = normalizePendingConfirmEnvelope({
+  it('rejects the whole envelope when an item is invalid', () => {
+    expect(normalizePendingConfirmEnvelope({
       items: [
         { confirm_token: 'tok-1' },
-        { actor: 'agent-1' }, // no token
+        { actor: 'agent-1' },
       ],
-    })
-    expect(result!.items).toHaveLength(1)
-  })
-
-  it('extracts summary', () => {
-    const result = normalizePendingConfirmEnvelope({
-      items: [{ confirm_token: 'tok-1' }],
       summary: {
-        visible_count: 1,
-        total_count: 3,
-      },
-    })
-    expect(result!.summary.visible_count).toBe(1)
-    expect(result!.summary.total_count).toBe(3)
-  })
-
-  it('synthesizes summary when only items present', () => {
-    const result = normalizePendingConfirmEnvelope({
-      items: [
-        { confirm_token: 'tok-1' },
-        { confirm_token: 'tok-2' },
-      ],
-    })
-    expect(result!.summary.visible_count).toBe(2)
-    expect(result!.summary.total_count).toBe(2)
-    expect(result!.summary.hidden_count).toBe(0)
-    expect(result!.summary.confirm_required_actions).toEqual([])
-  })
-
-  it('returns envelope with summary but no items', () => {
-    const result = normalizePendingConfirmEnvelope({
-      summary: { visible_count: 0, total_count: 5 },
-    })
-    expect(result).not.toBeNull()
-    expect(result!.items).toEqual([])
-    expect(result!.summary.total_count).toBe(5)
-  })
-})
-
-// ================================================================
-// selectPendingConfirmState
-// ================================================================
-
-describe('selectPendingConfirmState', () => {
-  it('returns defaults for null', () => {
-    const result = selectPendingConfirmState(null)
-    expect(result.items).toEqual([])
-    expect(result.actor_filter).toBeNull()
-    expect(result.visible_count).toBe(0)
-    expect(result.total_count).toBe(0)
-    expect(result.hidden_count).toBe(0)
-    expect(result.hidden_actors).toEqual([])
-    expect(result.confirm_required_actions).toEqual([])
-  })
-
-  it('returns defaults for undefined', () => {
-    const result = selectPendingConfirmState(undefined)
-    expect(result.items).toEqual([])
-  })
-
-  it('returns defaults for empty source', () => {
-    const result = selectPendingConfirmState({})
-    expect(result.items).toEqual([])
-  })
-
-  it('uses envelope items', () => {
-    const result = selectPendingConfirmState({
-      pending_confirm_envelope: {
-        items: [{ confirm_token: 'tok-1', actor: 'a1', action_type: 'pause', target_type: 'keeper', target_id: null, delegated_tool: undefined, created_at: undefined, preview: undefined }],
-        summary: {
-          actor_filter: null,
-          filter_active: false,
-          visible_count: 1,
-          total_count: 1,
-          hidden_count: 0,
-          hidden_actors: [],
-          confirm_required_actions: [],
-        },
-      },
-    })
-    expect(result.items).toHaveLength(1)
-    expect(result.items[0]!.confirm_token).toBe('tok-1')
-  })
-
-  it('falls back to pending_confirms when no envelope', () => {
-    const result = selectPendingConfirmState({
-      pending_confirms: [
-        { confirm_token: 'tok-raw', actor: 'a1', action_type: 'pause', target_type: 'keeper', target_id: null, delegated_tool: undefined, created_at: undefined, preview: undefined },
-      ],
-    })
-    expect(result.items).toHaveLength(1)
-    expect(result.items[0]!.confirm_token).toBe('tok-raw')
-  })
-
-  it('uses available_actions for confirm_required_actions', () => {
-    const result = selectPendingConfirmState({
-      available_actions: [
-        { action_type: 'pause', target_type: 'keeper', confirm_required: true },
-        { action_type: 'broadcast', target_type: 'workspace', confirm_required: false },
-      ],
-    })
-    expect(result.confirm_required_actions).toHaveLength(1)
-    expect(result.confirm_required_actions[0]!.action_type).toBe('pause')
-  })
-
-  it('trims whitespace from actor_filter', () => {
-    const result = selectPendingConfirmState({
-      pending_confirm_summary: {
-        actor_filter: '  agent-1  ',
+        actor_filter: null,
         filter_active: false,
-        visible_count: 1,
-        total_count: 1,
+        visible_count: 2,
+        total_count: 2,
         hidden_count: 0,
         hidden_actors: [],
         confirm_required_actions: [],
       },
-    })
-    expect(result.actor_filter).toBe('agent-1')
+    })).toBeNull()
   })
 
-  it('returns null actor_filter for empty string', () => {
-    const result = selectPendingConfirmState({
-      pending_confirm_summary: {
-        actor_filter: '   ',
+  it('rejects an envelope without a summary', () => {
+    expect(normalizePendingConfirmEnvelope({
+      items: [{ confirm_token: 'tok-1' }],
+    })).toBeNull()
+  })
+
+  it('rejects an envelope without items', () => {
+    expect(normalizePendingConfirmEnvelope({
+      summary: {
+        actor_filter: null,
         filter_active: false,
         visible_count: 0,
         total_count: 0,
@@ -365,7 +257,6 @@ describe('selectPendingConfirmState', () => {
         hidden_actors: [],
         confirm_required_actions: [],
       },
-    })
-    expect(result.actor_filter).toBeNull()
+    })).toBeNull()
   })
 })

--- a/dashboard/src/pending-confirm.ts
+++ b/dashboard/src/pending-confirm.ts
@@ -1,4 +1,4 @@
-import { asBoolean, asNumber, asString, asStringArray, extractArray, isRecord } from './components/common/normalize'
+import { asBoolean, asString, isRecord } from './components/common/normalize'
 import type {
   OperatorActionDescriptor,
   PendingConfirmEnvelope,
@@ -21,7 +21,7 @@ export function normalizeOperatorActionDescriptor(raw: unknown): OperatorActionD
 
 export function normalizePendingConfirmation(raw: unknown): PendingConfirmation | null {
   if (!isRecord(raw)) return null
-  const confirmToken = asString(raw.confirm_token) ?? asString(raw.token)
+  const confirmToken = asString(raw.confirm_token)
   if (!confirmToken) return null
   return {
     confirm_token: confirmToken,
@@ -37,81 +37,41 @@ export function normalizePendingConfirmation(raw: unknown): PendingConfirmation 
 
 export function normalizePendingConfirmSummary(raw: unknown): PendingConfirmSummary | null {
   if (!isRecord(raw)) return null
+  const actorFilter = raw.actor_filter === null ? null : asString(raw.actor_filter)
+  const filterActive = asBoolean(raw.filter_active)
+  const counts = [raw.visible_count, raw.total_count, raw.hidden_count]
+  const hiddenActors = raw.hidden_actors
+  const actions = raw.confirm_required_actions
+  if (
+    actorFilter === undefined
+    || filterActive === undefined
+    || !counts.every(value => typeof value === 'number' && Number.isSafeInteger(value) && value >= 0)
+    || !Array.isArray(hiddenActors)
+    || !hiddenActors.every(value => typeof value === 'string' && value.trim() !== '')
+    || !Array.isArray(actions)
+  ) return null
+  const normalizedActions = actions.map(normalizeOperatorActionDescriptor)
+  if (normalizedActions.some(action => action === null)) return null
   return {
-    actor_filter: asString(raw.actor_filter) ?? null,
-    filter_active: asBoolean(raw.filter_active) ?? false,
-    visible_count: asNumber(raw.visible_count) ?? 0,
-    total_count: asNumber(raw.total_count) ?? 0,
-    hidden_count: asNumber(raw.hidden_count) ?? 0,
-    hidden_actors: asStringArray(raw.hidden_actors),
-    confirm_required_actions: extractArray(raw.confirm_required_actions)
-      .map(normalizeOperatorActionDescriptor)
-      .filter((item): item is OperatorActionDescriptor => item !== null),
+    actor_filter: actorFilter,
+    filter_active: filterActive,
+    visible_count: counts[0] as number,
+    total_count: counts[1] as number,
+    hidden_count: counts[2] as number,
+    hidden_actors: hiddenActors,
+    confirm_required_actions: normalizedActions as OperatorActionDescriptor[],
   }
 }
 
 export function normalizePendingConfirmEnvelope(raw: unknown): PendingConfirmEnvelope | null {
   if (!isRecord(raw)) return null
-  const items = extractArray(raw.items, ['confirms'])
-    .map(normalizePendingConfirmation)
-    .filter((item): item is PendingConfirmation => item !== null)
+  if (!Array.isArray(raw.items)) return null
+  const items = raw.items.map(normalizePendingConfirmation)
+  if (items.some(item => item === null)) return null
   const summary = normalizePendingConfirmSummary(raw.summary)
-  if (!summary && items.length === 0) return null
+  if (!summary) return null
   return {
-    items,
-    summary: summary ?? {
-      actor_filter: null,
-      filter_active: false,
-      visible_count: items.length,
-      total_count: items.length,
-      hidden_count: 0,
-      hidden_actors: [],
-      confirm_required_actions: [],
-    },
-  }
-}
-
-interface PendingConfirmSource {
-  pending_confirm_envelope?: PendingConfirmEnvelope | null
-  pending_confirms?: PendingConfirmation[] | null
-  pending_confirm_summary?: PendingConfirmSummary | null
-  available_actions?: OperatorActionDescriptor[] | null
-}
-
-interface PendingConfirmState {
-  items: PendingConfirmation[]
-  summary: PendingConfirmSummary
-  actor_filter: string | null
-  visible_count: number
-  total_count: number
-  hidden_count: number
-  hidden_actors: string[]
-  confirm_required_actions: OperatorActionDescriptor[]
-}
-
-export function selectPendingConfirmState(source: PendingConfirmSource | null | undefined): PendingConfirmState {
-  const envelope = source?.pending_confirm_envelope ?? null
-  const items = envelope?.items ?? source?.pending_confirms ?? []
-  const summary = envelope?.summary ?? source?.pending_confirm_summary ?? {
-    actor_filter: null,
-    filter_active: false,
-    visible_count: items.length,
-    total_count: items.length,
-    hidden_count: 0,
-    hidden_actors: [],
-    confirm_required_actions: source?.available_actions?.filter(action => action.confirm_required) ?? [],
-  }
-  return {
-    items,
+    items: items as PendingConfirmation[],
     summary,
-    actor_filter: summary.actor_filter?.trim() || null,
-    visible_count: summary.visible_count ?? items.length,
-    total_count: summary.total_count ?? items.length,
-    hidden_count: summary.hidden_count ?? 0,
-    hidden_actors: summary.hidden_actors ?? [],
-    confirm_required_actions:
-      summary.confirm_required_actions?.length
-        ? summary.confirm_required_actions
-        : (source?.available_actions?.filter(action => action.confirm_required) ?? []),
   }
 }

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -7,7 +7,7 @@ import type {
   MissionSignalTruth,
   MissionEvidenceSource,
 } from './core'
-import type { PendingConfirmEnvelope, PendingConfirmation, PendingConfirmSummary, OperatorActionDescriptor } from './gate'
+import type { PendingConfirmEnvelope, PendingConfirmation, OperatorActionDescriptor } from './gate'
 
 export interface DashboardMissionSummary {
   workspace_health?: string
@@ -363,9 +363,7 @@ export interface OperatorSnapshot {
   inference_inflight?: InferenceInflightSnapshot | null
   persistent_agents?: OperatorKeeperSnapshot[]
   recent_messages: Message[]
-  pending_confirms: PendingConfirmation[]
-  pending_confirm_envelope?: PendingConfirmEnvelope | null
-  pending_confirm_summary?: PendingConfirmSummary
+  pending_confirm_envelope: PendingConfirmEnvelope
   available_actions: OperatorActionDescriptor[]
 }
 

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -46,6 +46,15 @@ type pending_confirm_scope = {
   hidden_entries : pending_confirm list;
 }
 
+exception Store_error of string
+
+let () =
+  Printexc.register_printer (function
+    | Store_error _ -> Some "Operator_pending_confirm.Store_error"
+    | _ -> None)
+
+let raise_store_error reason = raise (Store_error reason)
+
 type available_action = {
   action_type : string;
   tool_name : string;
@@ -88,57 +97,88 @@ let preview_of_pending_confirm (entry : pending_confirm) =
       ("payload", entry.payload);
     ]
 
+let pending_confirm_common_fields (entry : pending_confirm) =
+  [
+    ("trace_id", `String entry.trace_id);
+    ("actor", `String entry.actor);
+    ("action_type", `String entry.action_type);
+    ("target_type", `String entry.target_type);
+    ("target_id", Json_util.string_option_to_yojson entry.target_id);
+    ("payload", entry.payload);
+    ("delegated_tool", `String entry.delegated_tool);
+    ("created_at", `String entry.created_at);
+    ("expires_at", Json_util.string_option_to_yojson entry.expires_at);
+  ]
+
 let pending_confirm_to_yojson (entry : pending_confirm) =
   `Assoc
-    [
-      ("token", `String entry.token);
-      ("confirm_token", `String entry.token);
-      ("trace_id", `String entry.trace_id);
-      ("actor", `String entry.actor);
-      ("action_type", `String entry.action_type);
-      ("target_type", `String entry.target_type);
-      ("target_id", Json_util.string_option_to_yojson entry.target_id);
-      ("payload", entry.payload);
-      ("delegated_tool", `String entry.delegated_tool);
-      ("created_at", `String entry.created_at);
-      ("expires_at", Json_util.string_option_to_yojson entry.expires_at);
-      ("preview", preview_of_pending_confirm entry);
-    ]
+    ( ("confirm_token", `String entry.token)
+    :: pending_confirm_common_fields entry
+    @ [ ("preview", preview_of_pending_confirm entry) ] )
 
-let pending_confirm_of_yojson json =
-  try
-    let token = Json_util.get_string_with_default json ~key:"token" ~default:"" in
-    let trace_id =
-      match Json_util.get_string json "trace_id" with
-      | Some value -> value
-      | None -> trace_id "opc"
+let pending_confirm_store_to_yojson (entry : pending_confirm) =
+  `Assoc (("confirm_token", `String entry.token) :: pending_confirm_common_fields entry)
+
+let pending_confirm_of_yojson = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let surface = "pending_confirm" in
+    let* () =
+      Json_util.reject_unknown_fields
+        ~surface
+        ~allowed:
+          [ "confirm_token"
+          ; "trace_id"
+          ; "actor"
+          ; "action_type"
+          ; "target_type"
+          ; "target_id"
+          ; "payload"
+          ; "delegated_tool"
+          ; "created_at"
+          ; "expires_at"
+          ]
+        fields
     in
-    let actor = Json_util.get_string_with_default json ~key:"actor" ~default:"" in
-    let action_type = Json_util.get_string_with_default json ~key:"action_type" ~default:"" in
-    let target_type = Json_util.get_string_with_default json ~key:"target_type" ~default:"" in
-    let target_id = Json_util.get_string json "target_id" in
-    let payload =
-      match Json_util.get_object json "payload" with
-      | Some payload -> payload
-      | None -> `Assoc []
+    let required_string field =
+      Json_util.require_field_string ~surface field fields
     in
-    let delegated_tool = Json_util.get_string_with_default json ~key:"delegated_tool" ~default:"" in
-    let created_at = Json_util.get_string_with_default json ~key:"created_at" ~default:"" in
-    let expires_at = Json_util.get_string json "expires_at" in
+    let required_nullable_string field =
+      match List.assoc_opt field fields with
+      | Some `Null -> Ok None
+      | Some (`String value) -> Ok (Some value)
+      | Some _ ->
+        Error (Printf.sprintf "%s.%s must be a string or null" surface field)
+      | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+    in
+    let* token = required_string "confirm_token" in
+    let* trace_id = required_string "trace_id" in
+    let* actor = required_string "actor" in
+    let* action_type = required_string "action_type" in
+    let* target_type = required_string "target_type" in
+    let* target_id = required_nullable_string "target_id" in
+    let* payload =
+      match List.assoc_opt "payload" fields with
+      | Some (`Assoc _ as payload) -> Ok payload
+      | Some _ -> Error "pending_confirm.payload must be an object"
+      | None -> Error "pending_confirm.payload is required"
+    in
+    let* delegated_tool = required_string "delegated_tool" in
+    let* created_at = required_string "created_at" in
+    let* expires_at = required_nullable_string "expires_at" in
     Ok
-      {
-        token;
-        trace_id;
-        actor;
-        action_type;
-        target_type;
-        target_id;
-        payload;
-        delegated_tool;
-        created_at;
-        expires_at;
+      { token
+      ; trace_id
+      ; actor
+      ; action_type
+      ; target_type
+      ; target_id
+      ; payload
+      ; delegated_tool
+      ; created_at
+      ; expires_at
       }
-  with Failure msg -> Error msg
+  | _ -> Error "pending_confirm must be a JSON object"
 
 let decode_pending_confirm_entries entries =
   let rec loop index acc = function
@@ -168,12 +208,10 @@ let raw_pending_confirms_result config : (pending_confirm list, string) result =
 let raw_pending_confirms config : pending_confirm list =
   match raw_pending_confirms_result config with
   | Ok entries -> entries
-  | Error msg ->
-    Log.Misc.warn "[operator_pending_confirm] %s" msg;
-    []
+  | Error msg -> raise_store_error msg
 
 let pending_confirms_to_yojson entries =
-  `List (List.map pending_confirm_to_yojson entries)
+  `List (List.map pending_confirm_store_to_yojson entries)
 
 let write_pending_confirms config (entries : pending_confirm list) =
   Workspace_utils.write_json_result config (pending_confirms_path config)
@@ -210,9 +248,7 @@ let read_pending_confirms_result config =
 let read_pending_confirms config : pending_confirm list =
   match read_pending_confirms_result config with
   | Ok entries -> entries
-  | Error msg ->
-    Log.Misc.warn "[operator_pending_confirm] %s" msg;
-    []
+  | Error msg -> raise_store_error msg
 
 let upsert_pending_confirm config entry =
   with_store_lock config (fun () ->

--- a/lib/operator/operator_pending_confirm.mli
+++ b/lib/operator/operator_pending_confirm.mli
@@ -25,6 +25,8 @@ type pending_confirm_scope = {
   hidden_entries : pending_confirm list;
 }
 
+exception Store_error of string
+
 type available_action = {
   action_type : string;
   tool_name : string;

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -568,7 +568,7 @@ let pending_confirm_row ?keeper_name
   ; next_action = "operator_confirm_action"
   ; detail =
       `Assoc
-        [ "token", `String entry.token
+        [ "confirm_token", `String entry.token
         ; "trace_id", `String entry.trace_id
         ; "actor", `String entry.actor
         ; "target_type", `String entry.target_type

--- a/test/test_dashboard_briefing.ml
+++ b/test/test_dashboard_briefing.ml
@@ -67,7 +67,6 @@ let write_pending_confirm config _session_id =
       [
         `Assoc
           [
-            ("token", `String "confirm-mission-test");
             ("confirm_token", `String "confirm-mission-test");
             ("trace_id", `String "ops_fixture_mission");
             ("actor", `String "dashboard-fixture");

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -940,7 +940,8 @@ let test_global_pending_confirm_is_actionable_row () =
       (json_string_member "wake_producer" row);
     check string "next action" "operator_confirm_action"
       (json_string_member "next_action" row);
-    check string "token" "confirm-goal-1" U.(detail |> member "token" |> to_string);
+    check string "confirm token" "confirm-goal-1"
+      U.(detail |> member "confirm_token" |> to_string);
     check string "trace_id" "trace-goal-1" U.(detail |> member "trace_id" |> to_string);
     check string "target_type" "goal" U.(detail |> member "target_type" |> to_string);
     check string "target_id" "goal-123" U.(detail |> member "target_id" |> to_string);

--- a/test/test_operator_control_confirm.ml
+++ b/test/test_operator_control_confirm.ml
@@ -24,7 +24,7 @@ let test_confirm_rejects_expired_token () =
                  [
                    `Assoc
                      [
-                       ("token", `String "expired-token");
+                       ("confirm_token", `String "expired-token");
                        ("trace_id", `String "ops_expired");
                        ("actor", `String "operator");
                        ("action_type", `String "namespace_pause");

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -304,7 +304,7 @@ let test_confirm_consumes_pending_token_before_delegated_action_fails () =
       let entry_json =
         `Assoc
           [
-            ("token", `String token);
+            ("confirm_token", `String token);
             ("trace_id", `String "trace-retry");
             ("actor", `String "operator");
             ("action_type", `String "missing_action_type");

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -1327,6 +1327,50 @@ let test_last_compaction_ago_s_removed_from_backend_serializers () =
              (Option.is_none (last_substring_index text "last_compaction_ago_s")))
     files
 
+let assert_snapshot_rejects_pending_confirm_store store_json =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      ignore (Workspace.init config ~agent_name:(Some "operator"));
+      Workspace_utils.mkdir_p (Operator_control.operator_dir config);
+      (match
+         Workspace_utils.write_json_result config
+           (Operator_control.pending_confirms_path config)
+           store_json
+       with
+       | Ok () -> ()
+       | Error error -> Alcotest.fail error);
+      match
+        Operator_control.snapshot_json
+          (operator_ctx env sw config "operator")
+      with
+      | _ -> Alcotest.fail "malformed pending-confirm store must reject snapshot"
+      | exception Operator_control.Store_error _ -> ())
+
+let test_snapshot_rejects_non_list_pending_confirm_store () =
+  assert_snapshot_rejects_pending_confirm_store (`Assoc [])
+
+let test_snapshot_rejects_pending_confirm_without_confirm_token () =
+  assert_snapshot_rejects_pending_confirm_store
+    (`List
+      [ `Assoc
+          [ "trace_id", `String "trace-missing-token"
+          ; "actor", `String "operator"
+          ; "action_type", `String "namespace_pause"
+          ; "target_type", `String "workspace"
+          ; "target_id", `Null
+          ; "payload", `Assoc []
+          ; "delegated_tool", `String "masc_pause"
+          ; "created_at", `String "2026-08-08T00:00:00Z"
+          ; "expires_at", `Null
+          ]
+      ])
+
 let () =
   Alcotest.run
     "operator_control_snapshot"
@@ -1365,6 +1409,16 @@ let () =
             "backend serializers do not emit last_compaction_ago_s"
             `Quick
             test_last_compaction_ago_s_removed_from_backend_serializers
+        ] );
+      ( "pending-confirm store"
+      , [ Alcotest.test_case
+            "non-list store rejects snapshot"
+            `Quick
+            test_snapshot_rejects_non_list_pending_confirm_store
+        ; Alcotest.test_case
+            "missing confirm token rejects snapshot"
+            `Quick
+            test_snapshot_rejects_pending_confirm_without_confirm_token
         ] );
     ]
 ;;


### PR DESCRIPTION
## Summary

- keep one canonical `confirm_token` key in pending-confirm persistence and wire payloads
- reject malformed pending-confirm stores instead of inventing an empty operator state
- keep pending confirmations and summary only inside the required dashboard envelope
- remove dead flat selectors and token aliases from dashboard normalization

## Verification

- `npx tsc --noEmit --pretty`
- `npx vitest run src/pending-confirm.test.ts src/operator-normalizers.test.ts src/api/board.test.ts src/mission-normalizers.test.ts` (178 tests)
- `ocamlformat --check` on changed OCaml files
- `git diff --check`
- focused OCaml build requested through `scripts/dune-local.sh`; resource guard blocked it because two unrelated bare Dune processes are active
