### PR TITLE
fix(goal): render all unowned goal descendants

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -827,7 +827,9 @@ let backlog_statement_of_observation
   match observation.backlog_revision with
   | None -> Backlog_unreadable
   | Some _ ->
-    let claimable_task_count = Keeper_world_observation.claimable_task_count observation in
+    let claimable_task_count =
+      Keeper_world_observation.claimable_task_count observation
+    in
     if
       observation.unclaimed_task_count = 0
       && claimable_task_count = 0
@@ -927,8 +929,8 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
          list, because there taking the parent and taking the child are not two
          independent moves. A child whose parent is absent -- owned, terminal,
          or already served by a Task -- is its own invitation and stays at the
-         top level. Depth stops at one: [parent_goal_id] is a single link and
-         nesting further would trade the fact for a shape. *)
+         top level. Goal_store permits arbitrary parent depth, so the projection
+         follows the whole chain rather than dropping descendants. *)
       let unowned_block =
         match unowned_executing_goals_without_tasks ~config with
         | [] -> None
@@ -952,15 +954,29 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
             | None -> true
             | Some p -> not (List.exists (String.equal p) present)
           in
+          let rendered_ids = ref [] in
+          let rec render_subtree ~depth ((goal_id, _, _) as goal) =
+            if List.exists (String.equal goal_id) !rendered_ids
+            then []
+            else (
+              rendered_ids := goal_id :: !rendered_ids;
+              let indent = String.make (depth * 2) ' ' in
+              line ~indent goal
+              :: List.concat_map
+                   (render_subtree ~depth:(depth + 1))
+                   (children_of goal_id))
+          in
+          let rendered_roots =
+            goals
+            |> List.filter stands_alone
+            |> List.concat_map (render_subtree ~depth:0)
+          in
           let rendered =
-            List.concat_map
-              (fun ((goal_id, _, _) as goal) ->
-                 if not (stands_alone goal)
-                 then []
-                 else
-                   line ~indent:"" goal
-                   :: List.map (line ~indent:"  ") (children_of goal_id))
-              goals
+            rendered_roots
+            @ (goals
+               |> List.filter (fun (goal_id, _, _) ->
+                    not (List.exists (String.equal goal_id) !rendered_ids))
+               |> List.concat_map (render_subtree ~depth:0))
           in
           Some
             (Printf.sprintf

--- a/test/test_keeper_goal_phase_projection.ml
+++ b/test/test_keeper_goal_phase_projection.ml
@@ -381,6 +381,23 @@ let test_a_child_renders_under_its_parent () =
     (contains_in world "taking one is a move you can make (3)")
 ;;
 
+let test_all_descendants_render_at_their_full_depth () =
+  with_workspace @@ fun config ->
+  Goal_store.write_state config
+    { version = 1
+    ; updated_at = Masc_domain.now_iso ()
+    ; goals =
+        [ goal_in Goal_phase.Executing "goal-root" "root"
+        ; goal_child_of "goal-root" Goal_phase.Executing "goal-child" "child"
+        ; goal_child_of "goal-child" Goal_phase.Executing "goal-grandchild" "grandchild"
+        ]
+    };
+  let world = rendered_world_state config in
+  check bool "the complete parent chain is visible" true
+    (contains_in world
+       "- goal-root — root\n  - goal-child — child\n    - goal-grandchild — grandchild")
+;;
+
 (* A child whose parent is not in this list -- owned, terminal, or already served
    by a Task -- is its own invitation, so it must not be hidden by the nesting. *)
 let test_a_child_whose_parent_is_absent_stands_alone () =
@@ -433,6 +450,8 @@ let () =
             test_unowned_goals_reach_the_rendered_turn
         ; test_case "a child renders under its parent" `Quick
             test_a_child_renders_under_its_parent
+        ; test_case "all descendants render at their full depth" `Quick
+            test_all_descendants_render_at_their_full_depth
         ; test_case "a child whose parent is absent stands alone" `Quick
             test_a_child_whose_parent_is_absent_stands_alone
         ] )


### PR DESCRIPTION
## Summary

- render every descendant in the unowned-goal hierarchy at its actual depth
- preserve the existing typed claimable-task identity projection unchanged
- render parentless/cyclic residual goals once without adding a prompt gate

## Verification

- `ocamlformat --check lib/keeper/keeper_unified_prompt.ml test/test_keeper_goal_phase_projection.ml`
- `git diff --check`
- source guard: `observation.claimable_tasks` and `claimable_task_render_budget_rows` remain in the prompt projection
- focused OCaml build requested through `scripts/dune-local.sh`; resource guard blocked it because two unrelated bare Dune processes are active
