### PR TITLE
refactor: type Context JSON decode failures

### DIFF
--- a/packages/agent_core/lib/base/context.ml
+++ b/packages/agent_core/lib/base/context.ml
@@ -31,6 +31,12 @@ type concurrency_backend =
   | Stdlib_mutex
   | Eio_mutex
 
+type decode_error = Expected_object
+
+let decode_error_to_string = function
+  | Expected_object -> "Context.of_json: expected JSON object"
+;;
+
 let create () : t = { mu = Eio_mu (Eio.Mutex.create ()); tbl = Hashtbl.create 16 }
 let create_sync () : t = { mu = Stdlib_mu (Mutex.create ()); tbl = Hashtbl.create 16 }
 
@@ -131,13 +137,13 @@ let to_json (ctx : t) : Yojson.Safe.t =
   `Assoc pairs
 ;;
 
-let of_json ?(eio = false) (json : Yojson.Safe.t) : t =
+let of_json ?(eio = false) (json : Yojson.Safe.t) : (t, decode_error) result =
   match json with
   | `Assoc pairs ->
     let ctx = if eio then create () else create_sync () in
     List.iter (fun (k, v) -> Hashtbl.replace ctx.tbl k v) pairs;
-    ctx
-  | _ -> invalid_arg "Context.of_json: expected JSON object"
+    Ok ctx
+  | _ -> Error Expected_object
 ;;
 
 let copy ?eio (ctx : t) : t =

--- a/packages/agent_core/lib/base/context.mli
+++ b/packages/agent_core/lib/base/context.mli
@@ -24,6 +24,10 @@ type concurrency_backend =
   | Stdlib_mutex
   | Eio_mutex
 
+type decode_error = Expected_object
+
+val decode_error_to_string : decode_error -> string
+
 (** Create a new context using {!Eio.Mutex}.
 
     This is the default for agent execution paths where the context may be
@@ -54,9 +58,9 @@ val concurrency_backend : t -> concurrency_backend
 (** Deserialize from a JSON object.
 
     [~eio:true] rehydrates the context with an {!Eio.Mutex}; the default
-    [~eio:false] is for synchronous decoding/storage code. Raises
-    [Invalid_argument] if [json] is not a JSON object. *)
-val of_json : ?eio:bool -> Yojson.Safe.t -> t
+    [~eio:false] is for synchronous decoding/storage code. Returns
+    [Error Expected_object] if [json] is not a JSON object. *)
+val of_json : ?eio:bool -> Yojson.Safe.t -> (t, decode_error) result
 
 (** Shallow-copy all entries into a fresh context.
     Values are [Yojson.Safe.t] (structurally immutable), so shallow copy

--- a/packages/agent_core/lib/checkpoint_codec.ml
+++ b/packages/agent_core/lib/checkpoint_codec.ml
@@ -781,13 +781,15 @@ let decode_current_json json =
     and* tools =
       json |> member "tools" |> to_list |> List.map tool_schema_of_json |> result_all
     and* context =
-      match json |> member "context" with
-      | `Assoc _ as value -> Ok (Context.of_json value)
-      | _ ->
-        Error
-          (Error.Serialization
-             (JsonParseError
-                { detail = "Checkpoint.of_json: context must be a JSON object" }))
+      Context.of_json (json |> member "context")
+      |> Result.map_error (fun error ->
+        Error.Serialization
+          (JsonParseError
+             { detail =
+                 Printf.sprintf
+                   "Checkpoint.of_json: %s"
+                   (Context.decode_error_to_string error)
+             }))
     and* mcp_sessions =
       match json |> member "mcp_sessions" with
       | `List _ as lst -> Mcp_session.info_list_of_json lst

--- a/packages/agent_core/lib/session.ml
+++ b/packages/agent_core/lib/session.ml
@@ -75,12 +75,17 @@ let to_json t =
 ;;
 
 let of_json json =
+  let ( let* ) = Result.bind in
   try
     let open Yojson.Safe.Util in
-    let metadata =
+    let* metadata =
       match json |> member "metadata" with
-      | `Null -> Context.create_sync ()
-      | v -> Context.of_json v
+      | `Null -> Ok (Context.create_sync ())
+      | value ->
+        Context.of_json value
+        |> Result.map_error (fun error ->
+          Error.Serialization
+            (JsonParseError { detail = Context.decode_error_to_string error }))
     in
     Ok
       { id = json |> member "id" |> to_string

--- a/packages/agent_core/test/test_context.ml
+++ b/packages/agent_core/test/test_context.ml
@@ -159,22 +159,21 @@ let test_to_json () =
 
 let test_of_json_roundtrip () =
   let json = `Assoc [ "x", `Int 10; "y", `String "hello" ] in
-  let ctx = Context.of_json json in
+  let ctx = Context.of_json json |> Result.get_ok in
   check bool "x restored" true (Context.get ctx "x" = Some (`Int 10));
   check bool "y restored" true (Context.get ctx "y" = Some (`String "hello"))
 ;;
 
 let test_of_json_non_assoc () =
-  check_raises
-    "non-Assoc rejected"
-    (Invalid_argument "Context.of_json: expected JSON object")
-    (fun () -> ignore (Context.of_json (`String "invalid") : Context.t))
+  match Context.of_json (`String "invalid") with
+  | Error Context.Expected_object -> ()
+  | Ok _ -> fail "non-Assoc context must return Expected_object"
 ;;
 
 let test_of_json_eio_backend () =
   Eio_main.run
   @@ fun _env ->
-  let ctx = Context.of_json ~eio:true (`Assoc [ "x", `Int 1 ]) in
+  let ctx = Context.of_json ~eio:true (`Assoc [ "x", `Int 1 ]) |> Result.get_ok in
   check_backend "eio backend" Context.Eio_mutex ctx;
   check bool "value restored" true (Context.get ctx "x" = Some (`Int 1))
 ;;

--- a/packages/agent_core/test/test_context_properties.ml
+++ b/packages/agent_core/test/test_context_properties.ml
@@ -70,10 +70,12 @@ let test_json_roundtrip =
        let ctx = Context.create_sync () in
        List.iter (fun (k, v) -> Context.set ctx k v) pairs;
        let json = Context.to_json ctx in
-       let restored = Context.of_json json in
-       let original_snapshot = Context.snapshot ctx in
-       let restored_snapshot = Context.snapshot restored in
-       original_snapshot = restored_snapshot)
+       match Context.of_json json with
+       | Error _ -> false
+       | Ok restored ->
+         let original_snapshot = Context.snapshot ctx in
+         let restored_snapshot = Context.snapshot restored in
+         original_snapshot = restored_snapshot)
 ;;
 
 (* ── Property 3: Scope Isolation — No Leakage ─────────── *)


### PR DESCRIPTION
## What changed

- replace Context.of_json Invalid_argument with a typed Expected_object result
- map Context decode failures into the existing Session and checkpoint serialization errors
- update unit and property tests to consume the typed result

## Why

Context JSON is external or persisted input. A wrong JSON shape crossed that boundary through an exception even though both production consumers already use typed result-based decoders.

## Impact

This is a hard cut of the Context.of_json API. No exception-raising compatibility wrapper remains. Valid object decoding and mutex-backend selection are unchanged.

## Validation

- Local build/tests not run per workflow; CI is authoritative.
- Existing Context roundtrip, backend, property, Session, and checkpoint suites cover the changed boundary.
