### PR TITLE
ci: drop removed OAS contract target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,7 +953,6 @@ jobs:
             @test/runtest-test_keepers_runtime_dir_ssot \
             @test/runtest-test_mcp_h1_h2_admission_parity \
             @test/runtest-test_nickname_words_ssot \
-            @test/runtest-test_oas_canonical_delegation_contract \
             @test/runtest-test_oas_message_constructor_contract \
             @test/runtest-test_otel_port_ssot \
             @test/runtest-test_release_train_guard_script \


### PR DESCRIPTION
## Summary

- remove the CI invocation of `test_oas_canonical_delegation_contract`, deleted by #27638

## Product impact

- User-visible change: none.
- Restores full CI target resolution on current `main` and unblocks dependent PRs.

## Evidence

- `bash scripts/audit-ci-test-targets.sh` — 152 CI targets, all declared in `test/dune`
- `scripts/lint/yaml-syntax.sh` — 20 workflow files parsed
- `python3 scripts/ci/check-yaml-syntax.py .github/workflows/ci.yml` — 38 YAML files valid
- `git diff --check`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/4
provenance: direct
stages:
  - name: ci-target-audit
    result: pass
  - name: workflow-yaml-lint
    result: pass
  - name: repository-yaml-validation
    result: pass
  - name: diff-integrity
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — Meta Guards failed at `Check CI test targets`
- [x] Orient — #27638 deleted the test and Dune declaration but left the CI invocation
- [x] Decide — fix in a separate one-line PR instead of mixing it into #27636
- [x] Act — delete only the stale workflow target
- [x] Verify — CI target audit and both YAML validators pass
- [x] Loop — rebase and unblock #27636 after this lands

## Review evidence

- Adversarial self-review: the test source and Dune declaration are absent; restoring them would violate the #27638 hard cut.
- Cross-model review not run: exact one-line stale-target deletion with repository audit proof.

## Linked issue

- Closes # N/A
- Relates #27638

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant changed
- [ ] **TypeScript** — N/A: no TypeScript union changed
- [ ] **TLA+ spec** — N/A: no TLA+ domain changed
- [ ] **Event / JSON schema** — N/A: no event or schema enum changed
- [ ] **`make check-variants` passes** — N/A: workflow-only one-line deletion

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/removed-oas-ci-target-20260808` → `main` · 1 commit(s) · synced 2026-08-08T14:26:46Z

| sha | subject | date |
|---|---|---|
| `a4cd537cd` | ci: drop removed OAS contract target | 2026-08-08 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->