### PR TITLE
ci: audit generated coverage test manifest

### DIFF
--- a/docs/audit/2026-06-21-productization-blockers-adversarial-audit.md
+++ b/docs/audit/2026-06-21-productization-blockers-adversarial-audit.md
@@ -2,7 +2,7 @@
 status: reference
 last_verified: 2026-06-21
 code_refs:
-  - lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+  - lib/keeper_tooling/execute_shell_ir.ml
   - lib/keeper/keeper_tool_execute_runtime.ml
   - lib/exec_policy/exec_policy.ml
   - lib/config/env_config_core.ml

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fail when ci.yml names a test target that test/dune cannot build.
+# Fail when ci.yml names a test target that the Dune test declarations cannot build.
 #
 # CI runs a hand-maintained allowlist of @test/runtest-<name> targets. Deleting
 # the test behind one is a normal cleanup, and nothing in the deleting PR looks
@@ -14,8 +14,8 @@
 #
 # This turns that into a seconds-long check the deleting PR sees.
 #
-# A target is buildable when test/dune declares it, either as a test name
-# under (names ...) / (name ...) or as an explicit (alias runtest-<name>).
+# A target is buildable when test/dune declares it directly, its dynamic
+# coverage-test manifest declares it, or an explicit alias declares it.
 set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -38,6 +38,17 @@ awk '/^[[:space:]]+test_[a-z_0-9]+/ {
        }
      }' test/dune > "$declared"
 grep -oE '\(name test_[a-z_0-9]+\)' test/dune | sed 's/(name //;s/)//' >> "$declared"
+# Coverage tests are generated through Dune's dynamic_include. The manifest is
+# the source of truth; the generated stanza is a build artifact and must not be
+# checked in or reverse-parsed here.
+coverage_manifest="test/stanzas/coverage_test_names.txt"
+if grep -qF '(dynamic_include stanzas/coverage_tests.inc)' test/dune; then
+  if [ ! -f "$coverage_manifest" ]; then
+    echo "[ci-test-targets] FAIL - dynamic coverage manifest is missing: $coverage_manifest"
+    exit 2
+  fi
+  cat "$coverage_manifest" >> "$declared"
+fi
 # Explicitly named aliases, e.g. (alias runtest-dashboard-http-behavior-contracts).
 grep -oE '\(alias runtest-[a-z_0-9-]+\)' test/dune \
   | sed 's/(alias runtest-//;s/)//' >> "$declared"
@@ -59,7 +70,7 @@ grep -oE '@test/runtest-[a-z_0-9-]+' .github/workflows/ci.yml \
 missing="$(comm -23 "$referenced" "$declared")"
 
 if [ -n "$missing" ]; then
-  echo "[ci-test-targets] FAIL - ci.yml names targets test/dune does not declare"
+  echo "[ci-test-targets] FAIL - ci.yml names targets Dune does not declare"
   echo
   printf '%s\n' "$missing" | sed 's/^/  - /'
   echo
@@ -74,7 +85,7 @@ if [ -n "$missing" ]; then
   exit 2
 fi
 
-echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in test/dune"
+echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # 714 -> 710: this PR wires test_tool_input_validation, and #27429,
 # #27433 and #27441 each wired a suite test/dune already declared without
@@ -93,7 +104,7 @@ if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then
   echo
   echo "$((unwired - UNWIRED_BASELINE)) more than the baseline. The full unwired"
   echo "set is large, so diff it against main rather than reading it here:"
-  echo "  comm -13 <(ci targets) <(test/dune names)"
+  echo "  comm -13 <(ci targets) <(Dune test names)"
   echo
   echo "A suite outside ci.yml is compile-only: it never executes, so its"
   echo "assertions can outlive the code they pin. Add a @test/runtest-<name>"

--- a/scripts/verify-test-registration.py
+++ b/scripts/verify-test-registration.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Verify every test_*.ml file under test/ is registered in a dune or .inc file.
+"""Verify every test_*.ml file under test/ is registered in a Dune input.
 
 Parses dune S-expressions properly (handling multiline, nested forms, strings,
-and comments) to avoid the false-positive flood from regex-based approaches.
+and comments) and consumes generated-stanza name manifests directly.
 """
 
 import sys
@@ -165,6 +165,15 @@ def extract_includes(tokens):
     return includes
 
 
+def extract_name_manifest(content: str):
+    """Extract one Dune executable name per non-comment line."""
+    return {
+        line
+        for raw_line in content.splitlines()
+        if (line := raw_line.partition("#")[0].strip())
+    }
+
+
 def main():
     repo_root = Path(".").resolve()
     test_dir = repo_root / "test"
@@ -177,7 +186,7 @@ def main():
     ml_files = sorted(test_dir.rglob("test_*.ml"))
     ml_names = {f.stem for f in ml_files}
 
-    # 2. Parse all dune and .inc files under test/
+    # 2. Parse all static Dune inputs under test/.
     registered = set()
     files_to_parse = []
     files_to_parse.extend(sorted(test_dir.rglob("dune")))
@@ -206,18 +215,31 @@ def main():
             if inc_path.exists() and inc_path not in parsed_paths:
                 pending.append(inc_path)
 
+    # coverage_tests.inc is generated at Dune evaluation time and therefore is
+    # absent from a clean checkout. Its source manifest is the authoritative
+    # registration input; audits must consume that SSOT rather than duplicate
+    # its names or pretend the generated file is available.
+    coverage_manifest = test_dir / "stanzas" / "coverage_test_names.txt"
+    if not coverage_manifest.exists():
+        print(
+            f"error: Dune test-name manifest not found: {coverage_manifest}",
+            file=sys.stderr,
+        )
+        return 1
+    registered.update(extract_name_manifest(coverage_manifest.read_text()))
+
     # 3. Compare
     unregistered = sorted(ml_names - registered)
     # Only flag orphaned registrations that look like test files
     orphaned = sorted({r for r in (registered - ml_names) if r.startswith("test_")})
 
     print(f"test_*.ml files found:    {len(ml_names)}")
-    print(f"Registered in dune/.inc:  {len(registered)}")
+    print(f"Registered in Dune inputs: {len(registered)}")
     print(f"Unregistered:             {len(unregistered)}")
     print(f"Orphaned registrations:   {len(orphaned)}")
 
     if unregistered:
-        print("\nUnregistered test_*.ml files (no dune registration found):")
+        print("\nUnregistered test_*.ml files (no Dune registration found):")
         for name in unregistered:
             print(f"  {name}")
 


### PR DESCRIPTION
## Summary
- read the canonical coverage-test manifest when Dune dynamically includes its generated stanza
- fail closed when the declared manifest is missing
- keep CI target auditing aligned with the merged test-name SSOT

## Context
Corrective follow-up to #27642. Its Meta Guards job exposed that the audit still parsed only literal names in test/dune.

## Validation
- not run locally; CI is authoritative