### PR TITLE
test: handle typed context decode

### DIFF
--- a/test/test_keeper_context_isolation.ml
+++ b/test/test_keeper_context_isolation.ml
@@ -25,6 +25,11 @@ let ctx_get_string ctx k =
   | Some (`String s) -> s
   | _ -> failwith ("expected string for key: " ^ k)
 
+let decode_ctx json =
+  match Ctx.of_json json with
+  | Ok ctx -> ctx
+  | Error error -> failf "context roundtrip decode failed: %s" (Ctx.decode_error_to_string error)
+
 (* ── Test: Basic Isolation ───────────────────────── *)
 
 let test_basic_isolation () =
@@ -55,8 +60,8 @@ let test_checkpoint_roundtrip_isolation () =
   let json_a = Ctx.to_json ctx_a in
   let json_b = Ctx.to_json ctx_b in
   (* Simulate resume: deserialize *)
-  let restored_a = Ctx.of_json json_a in
-  let restored_b = Ctx.of_json json_b in
+  let restored_a = decode_ctx json_a in
+  let restored_b = decode_ctx json_b in
   (* Mutate restored_a — should not affect restored_b *)
   Ctx.set restored_a "state" (`String "compacting");
   Ctx.set restored_a "new_key" (`String "from_a");


### PR DESCRIPTION
## Summary

- unwrap `Context.of_json` explicitly in the checkpoint isolation test
- fail with the typed `decode_error` detail if a supposedly valid roundtrip cannot decode

## Product impact

- User-visible change: none.
- Restores compilation and preserves fail-closed evidence after #27643 changed context decoding to return `result`.

## Evidence

- `scripts/dune-local.sh build test/test_keeper_context_isolation.exe`
- `test_keeper_context_isolation.exe` — 7/7
- `ocamlformat --check test/test_keeper_context_isolation.ml`
- `git diff --check origin/main...HEAD`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/4
provenance: direct
stages:
  - name: focused-build
    result: pass
  - name: context-isolation-suite
    result: 7/7
  - name: formatting
    result: pass
  - name: diff-integrity
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — compiler rejected `Ctx.set restored_a` because `restored_a` was a `result`
- [x] Orient — #27643 typed `Context.of_json` failures but this test retained the old direct-return assumption
- [x] Decide — unwrap only valid roundtrip fixtures and surface the typed error; no fallback or compatibility shim
- [x] Act — one test file, one helper, two call-site updates
- [x] Verify — focused compile and all seven isolation assertions pass
- [x] Loop — Agent Core namespace hard cut remains separate

## Review evidence

- Adversarial self-review: no `Result.get_ok`, exception swallowing, or default context fallback; invalid decode fails the test with the domain error.
- Cross-model review not run: one-file typed test adaptation with compile/runtime proof.

## Linked issue

- Closes # N/A
- Relates #27643

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant changed
- [ ] **TypeScript** — N/A: no TypeScript union changed
- [ ] **TLA+ spec** — N/A: no TLA+ domain changed
- [ ] **Event / JSON schema** — N/A: no event or schema enum changed
- [ ] **`make check-variants` passes** — N/A: test adaptation only

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/context-isolation-typed-decode-20260808` → `main` · 1 commit(s) · synced 2026-08-08T15:11:05Z

| sha | subject | date |
|---|---|---|
| `62f66e5de` | test: handle typed context decode | 2026-08-08 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->