### PR TITLE
test: respect provider-scoped catalog identity

### DIFF
--- a/packages/agent_core/test/test_pipeline.ml
+++ b/packages/agent_core/test/test_pipeline.ml
@@ -359,9 +359,11 @@ let test_effective_provider_config_drives_lifecycle_and_pricing () =
     }
   in
   let carrier =
+    (* An explicit [provider_id] selects provider-scoped catalog rows. This
+       fixture exercises the native Anthropic wire kind and its bare model
+       catalog row, so it must remain an anonymous native config. *)
     Llm_provider.Provider_config.make
       ~kind:Anthropic
-      ~provider_id:"anthropic"
       ~model_id:"carrier-model-without-pricing"
       ~base_url:"https://api.anthropic.com"
       ~request_path:"/v1/messages"


### PR DESCRIPTION
## Summary

- keep explicit `provider_id` bound to provider-scoped model catalog rows
- make the effective-model Pipeline fixture an anonymous native Anthropic config
- preserve the test's lifecycle, wire-model, and pricing assertions

## Evidence

- reproduced the failure on clean `origin/main` (`67477972a4`)
- `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build @packages/agent_core/test/runtest-test_pipeline` (59/59)
- `git diff --check`

## Boundary

This is a test-fixture correction only. It adds no provider alias, fallback, or compatibility path.
