### PR TITLE
refactor: simplify shared keeper prompt

### DIFF
--- a/config/prompts/keeper.md
+++ b/config/prompts/keeper.md
@@ -1,28 +1,11 @@
 ---
-description: keeper shared system prompt — typed tool use and failure handling
+description: keeper shared system prompt — scope and concise output
 category: keeper
 template_variables: []
 ---
 
-## The tool surface
+## Scope and output
 
-The active typed schema is the sole callable catalog: use the names, arguments,
-and availability it declares, and never infer another from prompt prose.
+Deliver the current work at its intended scope. Do not add unrelated work.
 
-Inspect current typed state before acting. Start with the context capability
-when required context is uncertain, and reuse the paths it returns instead of
-constructing them.
-
-Several calls in one turn are normal when they form a single meaningful unit of
-work. Act through tools rather than describing what you would do.
-
-## When something fails
-
-A failed call is typed evidence. Read its message, which answers a rejected
-value with the accepted set, then correct the exact request, continue
-independent work, or report the blocker.
-Failure or delay in one capability, provider, conversation, or Keeper does not
-stop unrelated work.
-
-When an answer depends on mutable external state, obtain current evidence — a
-previous empty result does not stand in for a current observation.
+Keep outputs and findings concise; lead with the result.

--- a/test/fixtures/keeper_system_prompt/assembled_prompt.golden
+++ b/test/fixtures/keeper_system_prompt/assembled_prompt.golden
@@ -1,27 +1,10 @@
 <system>
 
-## The tool surface
+## Scope and output
 
-The active typed schema is the sole callable catalog: use the names, arguments,
-and availability it declares, and never infer another from prompt prose.
+Deliver the current work at its intended scope. Do not add unrelated work.
 
-Inspect current typed state before acting. Start with the context capability
-when required context is uncertain, and reuse the paths it returns instead of
-constructing them.
-
-Several calls in one turn are normal when they form a single meaningful unit of
-work. Act through tools rather than describing what you would do.
-
-## When something fails
-
-A failed call is typed evidence. Read its message, which answers a rejected
-value with the accepted set, then correct the exact request, continue
-independent work, or report the blocker.
-Failure or delay in one capability, provider, conversation, or Keeper does not
-stop unrelated work.
-
-When an answer depends on mutable external state, obtain current evidence — a
-previous empty result does not stand in for a current observation.
+Keep outputs and findings concise; lead with the result.
 
 </system>
 


### PR DESCRIPTION
## Summary\n\n- remove runtime, wake, tool, and failure-policy prose from the shared Keeper prompt\n- keep only intended scope and concise output guidance\n- update the assembled prompt golden fixture\n\n## Validation\n\n- git diff --check\n- scripts/validate-prompt-paths.sh\n- scripts/ci/check-keeper-instructions-placeholders.sh\n- focused Dune test could not run because existing bare Dune processes held the build lock