### PR TITLE
refactor: isolate keeper replay checkpoints

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -61,27 +61,23 @@ let finalize
       ()
   in
   receipt_response_text_present_ref := raw_response_text_present;
-  let replay_response_text =
-    Keeper_replay_checkpoint.replay_response_text_for_persistence
+  let assistant_msg =
+    Keeper_replay_checkpoint.consume_replay_response
       ~suppress_visible_response
       ~response_text
-  in
-  let assistant_msg =
-    Option.map
-      (fun replay_response_text ->
-         Agent_sdk.Types.make_message
+      ~consume:(fun ~response_text ->
+        let assistant_msg =
+          Agent_sdk.Types.make_message
            ~role:Agent_sdk.Types.Assistant
-           [ Agent_sdk.Types.Text replay_response_text ])
-      replay_response_text
+           [ Agent_sdk.Types.Text response_text ]
+        in
+        Keeper_context_runtime.persist_message
+          ~source:history_assistant_source
+          session
+          assistant_msg;
+        capture_replay_response ~response_text;
+        assistant_msg)
   in
-  (match replay_response_text, assistant_msg with
-   | Some response_text, Some assistant_msg ->
-     Keeper_context_runtime.persist_message
-       ~source:history_assistant_source
-       session
-       assistant_msg;
-     capture_replay_response ~response_text
-   | _ -> ());
   let checkpoint_owner_result =
     match Runtime.get_runtime_by_id runtime_id_string with
     | Some runtime -> Ok (Runtime_execution.checkpoint_owner runtime.execution)
@@ -95,7 +91,7 @@ let finalize
                 runtime_id_string))
   in
   let save_oas_checkpoint result_checkpoint =
-      let checkpoint, source_already_persisted =
+    let checkpoint, source_already_persisted =
         Keeper_replay_checkpoint.select_finalization_checkpoint
           ~last_persisted_checkpoint
           result_checkpoint

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -9,269 +9,6 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_agent_result
 
-type replay_suffix_prune_reason =
-  | Canonical_success_replay
-
-let replay_suffix_prune_reason_to_string = function
-  | Canonical_success_replay -> "canonical_success_replay"
-;;
-
-let replay_response_text_for_capture ~suppress_visible_response ~response_text =
-  if suppress_visible_response || String.trim response_text = ""
-  then None
-  else Some response_text
-;;
-
-let replay_response_text_for_persistence ~suppress_visible_response ~response_text =
-  replay_response_text_for_capture ~suppress_visible_response ~response_text
-;;
-
-type wire_capture_response_suppression_reason =
-  | Control_checkpoint
-
-let wire_capture_response_suppression_reasons ~control_checkpoint =
-  if control_checkpoint then [ Control_checkpoint ] else []
-;;
-
-let wire_capture_response_suppression_reason_label = function
-  | Control_checkpoint -> "control_checkpoint"
-;;
-
-let emit_wire_capture_response_suppressed_metric ~keeper_name reason =
-  Otel_metric_store.inc_counter
-    Keeper_metrics.(to_string WireCaptureResponseSuppressed)
-    ~labels:
-      [ ("keeper", keeper_name)
-      ; ("reason", wire_capture_response_suppression_reason_label reason)
-      ]
-    ()
-;;
-
-let emit_wire_capture_response_suppressed_metrics ~keeper_name reasons =
-  List.iter
-    (emit_wire_capture_response_suppressed_metric ~keeper_name)
-    reasons
-;;
-
-let is_trailing_blank_assistant (message : Agent_sdk.Types.message) =
-  match message.role, message.content with
-  | Agent_sdk.Types.Assistant, [] -> true
-  | Agent_sdk.Types.Assistant, blocks ->
-    List.for_all
-      (function
-        | Agent_sdk.Types.Text text -> String.trim text = ""
-        | _ -> false)
-      blocks
-  | _, _ -> false
-;;
-
-let drop_trailing_blank_assistants messages =
-  let rec drop dropped = function
-    | message :: rest when is_trailing_blank_assistant message -> drop true rest
-    | reversed -> List.rev reversed, dropped
-  in
-  drop false (List.rev messages)
-;;
-
-let canonical_success_replay_checkpoint
-      ~(history_messages : Agent_sdk.Types.message list)
-      ~(session_id : string)
-      ~(response_text : string)
-      (checkpoint : Agent_sdk.Checkpoint.t)
-  =
-  match
-    Keeper_replay_prefix.split
-      ~prefix:history_messages
-      checkpoint.Agent_sdk.Checkpoint.messages
-  with
-  | Ok current_suffix ->
-       (* A blank visible response is not authority to erase typed replay. The
-          suffix may contain an actual user input, ToolUse/ToolResult pair,
-          thinking, or media whose effect has already happened. Remove only an
-          inert trailing Assistant shell; the typed skipped-wake rule above owns
-          the autonomous marker independently. *)
-       let current_suffix, blank_assistant_dropped =
-         if String.trim response_text = ""
-         then drop_trailing_blank_assistants current_suffix
-         else current_suffix, false
-       in
-       let replay_suffix_pruned =
-         if blank_assistant_dropped
-         then Some Canonical_success_replay
-         else None
-       in
-       let checkpoint =
-         if String.trim response_text = ""
-         then
-           { checkpoint with
-             Agent_sdk.Checkpoint.session_id
-           ; messages = history_messages @ current_suffix
-           ; working_context = None
-           }
-         else
-           (* [split] already proved that [checkpoint.messages] is exactly the
-              validated history prefix followed by [current_suffix]. Keep that
-              immutable list when no replay edit is required: rebuilding the
-              prefix here hid that the pipeline checkpoint had already been
-              durably persisted. *)
-           let base_messages = checkpoint.messages in
-           let messages =
-             if
-               List.exists
-                 (fun (msg : Agent_sdk.Types.message) ->
-                    msg.role = Agent_sdk.Types.Assistant)
-                 current_suffix
-             then base_messages
-             else
-               base_messages
-               @
-               [ Agent_sdk.Types.make_message
-                   ~role:Agent_sdk.Types.Assistant
-                   [ Agent_sdk.Types.Text response_text ]
-               ]
-           in
-           Keeper_context_core.patch_checkpoint_last_assistant
-             { checkpoint with Agent_sdk.Checkpoint.messages }
-             ~session_id
-             ~response_text
-       in
-       Ok
-         ( checkpoint
-         , replay_suffix_pruned )
-  | Error _ ->
-    Error
-      "refusing to save checkpoint: canonical replay persistence requires \
-       checkpoint messages to match pre-turn history prefix"
-;;
-
-let observation_replay_checkpoint
-      ~(history_messages : Agent_sdk.Types.message list)
-      ~(session_id : string)
-      (checkpoint : Agent_sdk.Checkpoint.t)
-  =
-  match
-    Keeper_replay_prefix.split
-      ~prefix:history_messages
-      checkpoint.Agent_sdk.Checkpoint.messages
-  with
-  | Ok _ ->
-    Ok
-      ( { checkpoint with
-          Agent_sdk.Checkpoint.session_id
-        }
-      , None )
-  | Error _ ->
-    Error
-      "refusing to save execution-observation checkpoint: messages do not match pre-turn history prefix"
-;;
-
-let checkpoint_for_replay_persistence
-      ~(history_messages : Agent_sdk.Types.message list)
-      ~(session_id : string)
-      ~(response_text : string)
-      ?(stop_reason = Runtime_agent.Completed)
-      (checkpoint : Agent_sdk.Checkpoint.t)
-  =
-  match stop_reason with
-  | Runtime_agent.InputRequired _ ->
-    (* The elicitation request can follow a current-turn tool result. Blank
-       response canonicalization and completion-contract pruning must not
-       remove that suffix; prefix validation still fails closed. *)
-    (match
-       Keeper_replay_prefix.split
-         ~prefix:history_messages
-         checkpoint.Agent_sdk.Checkpoint.messages
-     with
-     | Ok (_ :: _) ->
-       Ok
-         ( { checkpoint with
-             Agent_sdk.Checkpoint.session_id
-           }
-         , None )
-     | Ok [] ->
-       Error
-         "refusing to save input-required checkpoint without a current-turn \
-          replay suffix"
-     | Error _ ->
-       Error
-         "refusing to save input-required checkpoint: messages do not match \
-          pre-turn history prefix")
-  | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _
-  | Runtime_agent.Awaiting_external_effect _
-  | Runtime_agent.Yielded_after_repeated_tool_call _ ->
-    (* A control-boundary checkpoint retains the current-turn tool result so
-       resumption cannot repeat an already committed effect. *)
-    observation_replay_checkpoint ~history_messages ~session_id checkpoint
-  | Runtime_agent.Completed ->
-    canonical_success_replay_checkpoint
-      ~history_messages
-      ~session_id
-      ~response_text
-      checkpoint
-;;
-
-(* OAS constructs the mutation-boundary checkpoint and then installs the same
-   immutable message values on the agent state. The list spines are rebuilt, so
-   list physical equality is too strict; comparing each message record by
-   identity proves the state boundary without hashing or scanning large text and
-   tool-result bodies. *)
-let rec messages_share_values_by_identity left right =
-  match left, right with
-  | [], [] -> true
-  | left_message :: left_rest, right_message :: right_rest
-    when left_message == right_message ->
-    messages_share_values_by_identity left_rest right_rest
-  | _ -> false
-;;
-
-let select_finalization_checkpoint
-    ~(last_persisted_checkpoint : Agent_sdk.Checkpoint.t option)
-    (result_checkpoint : Agent_sdk.Checkpoint.t) =
-  match last_persisted_checkpoint with
-  | Some persisted
-    when Int.equal persisted.turn_count result_checkpoint.turn_count
-         && messages_share_values_by_identity
-              persisted.messages
-              result_checkpoint.messages ->
-    persisted, true
-  | Some _ | None -> result_checkpoint, false
-;;
-
-let finalization_checkpoint_already_persisted
-    ~source_already_persisted
-    ~(source : Agent_sdk.Checkpoint.t)
-    ~(patched : Agent_sdk.Checkpoint.t)
-    ~replay_suffix_pruned =
-  source_already_persisted
-  && Option.is_none replay_suffix_pruned
-  && String.equal source.session_id patched.session_id
-  && source.messages == patched.messages
-  && source.working_context == patched.working_context
-;;
-
-module For_testing = struct
-  let replay_suffix_prune_reason_to_string =
-    replay_suffix_prune_reason_to_string
-
-  let checkpoint_for_replay_persistence = checkpoint_for_replay_persistence
-  let replay_response_text_for_capture = replay_response_text_for_capture
-  let replay_response_text_for_persistence = replay_response_text_for_persistence
-  let select_finalization_checkpoint = select_finalization_checkpoint
-
-  let finalization_checkpoint_already_persisted =
-    finalization_checkpoint_already_persisted
-
-  let wire_capture_response_suppression_reasons =
-    wire_capture_response_suppression_reasons
-
-  let wire_capture_response_suppression_reason_label =
-    wire_capture_response_suppression_reason_label
-
-  let emit_wire_capture_response_suppressed_metrics =
-    emit_wire_capture_response_suppressed_metrics
-end
-
 let finalize
     ~config
     ~meta
@@ -306,13 +43,14 @@ let finalize
       result.stop_reason
   in
   let suppression_reasons =
-    wire_capture_response_suppression_reasons ~control_checkpoint
+    Keeper_replay_checkpoint.wire_capture_response_suppression_reasons
+      ~control_checkpoint
   in
   let suppress_visible_response = suppression_reasons <> [] in
   let raw_response_text_present =
     String.trim raw_response_text <> ""
   in
-  emit_wire_capture_response_suppressed_metrics
+  Keeper_replay_checkpoint.emit_wire_capture_response_suppressed_metrics
     ~keeper_name:meta.name
     suppression_reasons;
   let { Keeper_agent_run_response_text.response_text } =
@@ -324,7 +62,7 @@ let finalize
   in
   receipt_response_text_present_ref := raw_response_text_present;
   let replay_response_text =
-    replay_response_text_for_persistence
+    Keeper_replay_checkpoint.replay_response_text_for_persistence
       ~suppress_visible_response
       ~response_text
   in
@@ -358,12 +96,12 @@ let finalize
   in
   let save_oas_checkpoint result_checkpoint =
       let checkpoint, source_already_persisted =
-        select_finalization_checkpoint
+        Keeper_replay_checkpoint.select_finalization_checkpoint
           ~last_persisted_checkpoint
           result_checkpoint
       in
       let checkpoint_for_save_result =
-        checkpoint_for_replay_persistence
+        Keeper_replay_checkpoint.checkpoint_for_replay_persistence
           ~history_messages
           ~session_id:
             (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
@@ -379,7 +117,7 @@ let finalize
               ~detail)
        | Ok (patched, replay_suffix_pruned) ->
          let already_persisted =
-           finalization_checkpoint_already_persisted
+           Keeper_replay_checkpoint.finalization_checkpoint_already_persisted
              ~source_already_persisted
              ~source:checkpoint
              ~patched
@@ -415,7 +153,9 @@ let finalize
                 ( "replay_suffix_prune_reason"
                 , (match replay_suffix_pruned with
                    | Some reason ->
-                     `String (replay_suffix_prune_reason_to_string reason)
+                     `String
+                       (Keeper_replay_checkpoint
+                        .replay_suffix_prune_reason_to_string reason)
                    | None -> `Null) );
                 ("pipeline_checkpoint_reused", `Bool already_persisted);
                 ( "completion_contract_result"

--- a/lib/keeper/keeper_replay_checkpoint.ml
+++ b/lib/keeper/keeper_replay_checkpoint.ml
@@ -1,0 +1,240 @@
+(** Canonical replay checkpoint projection and response-capture policy. *)
+
+type replay_suffix_prune_reason =
+  | Canonical_success_replay
+
+let replay_suffix_prune_reason_to_string = function
+  | Canonical_success_replay -> "canonical_success_replay"
+;;
+
+let replay_response_text_for_capture ~suppress_visible_response ~response_text =
+  if suppress_visible_response || String.trim response_text = ""
+  then None
+  else Some response_text
+;;
+
+let replay_response_text_for_persistence ~suppress_visible_response ~response_text =
+  replay_response_text_for_capture ~suppress_visible_response ~response_text
+;;
+
+type wire_capture_response_suppression_reason =
+  | Control_checkpoint
+
+let wire_capture_response_suppression_reasons ~control_checkpoint =
+  if control_checkpoint then [ Control_checkpoint ] else []
+;;
+
+let wire_capture_response_suppression_reason_label = function
+  | Control_checkpoint -> "control_checkpoint"
+;;
+
+let emit_wire_capture_response_suppressed_metric ~keeper_name reason =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string WireCaptureResponseSuppressed)
+    ~labels:
+      [ ("keeper", keeper_name)
+      ; ("reason", wire_capture_response_suppression_reason_label reason)
+      ]
+    ()
+;;
+
+let emit_wire_capture_response_suppressed_metrics ~keeper_name reasons =
+  List.iter
+    (emit_wire_capture_response_suppressed_metric ~keeper_name)
+    reasons
+;;
+
+let is_trailing_blank_assistant (message : Agent_sdk.Types.message) =
+  match message.role, message.content with
+  | Agent_sdk.Types.Assistant, [] -> true
+  | Agent_sdk.Types.Assistant, blocks ->
+    List.for_all
+      (function
+        | Agent_sdk.Types.Text text -> String.trim text = ""
+        | _ -> false)
+      blocks
+  | _, _ -> false
+;;
+
+let drop_trailing_blank_assistants messages =
+  let rec drop dropped = function
+    | message :: rest when is_trailing_blank_assistant message -> drop true rest
+    | reversed -> List.rev reversed, dropped
+  in
+  drop false (List.rev messages)
+;;
+
+let canonical_success_replay_checkpoint
+      ~(history_messages : Agent_sdk.Types.message list)
+      ~(session_id : string)
+      ~(response_text : string)
+      (checkpoint : Agent_sdk.Checkpoint.t)
+  =
+  match
+    Keeper_replay_prefix.split
+      ~prefix:history_messages
+      checkpoint.Agent_sdk.Checkpoint.messages
+  with
+  | Ok current_suffix ->
+       (* A blank visible response is not authority to erase typed replay. The
+          suffix may contain an actual user input, ToolUse/ToolResult pair,
+          thinking, or media whose effect has already happened. Remove only an
+          inert trailing Assistant shell; the typed skipped-wake rule above owns
+          the autonomous marker independently. *)
+       let current_suffix, blank_assistant_dropped =
+         if String.trim response_text = ""
+         then drop_trailing_blank_assistants current_suffix
+         else current_suffix, false
+       in
+       let replay_suffix_pruned =
+         if blank_assistant_dropped
+         then Some Canonical_success_replay
+         else None
+       in
+       let checkpoint =
+         if String.trim response_text = ""
+         then
+           { checkpoint with
+             Agent_sdk.Checkpoint.session_id
+           ; messages = history_messages @ current_suffix
+           ; working_context = None
+           }
+         else
+           (* [split] already proved that [checkpoint.messages] is exactly the
+              validated history prefix followed by [current_suffix]. Keep that
+              immutable list when no replay edit is required: rebuilding the
+              prefix here hid that the pipeline checkpoint had already been
+              durably persisted. *)
+           let base_messages = checkpoint.messages in
+           let messages =
+             if
+               List.exists
+                 (fun (msg : Agent_sdk.Types.message) ->
+                    msg.role = Agent_sdk.Types.Assistant)
+                 current_suffix
+             then base_messages
+             else
+               base_messages
+               @
+               [ Agent_sdk.Types.make_message
+                   ~role:Agent_sdk.Types.Assistant
+                   [ Agent_sdk.Types.Text response_text ]
+               ]
+           in
+           Keeper_context_core.patch_checkpoint_last_assistant
+             { checkpoint with Agent_sdk.Checkpoint.messages }
+             ~session_id
+             ~response_text
+       in
+       Ok (checkpoint, replay_suffix_pruned)
+  | Error _ ->
+    Error
+      "refusing to save checkpoint: canonical replay persistence requires \
+       checkpoint messages to match pre-turn history prefix"
+;;
+
+let observation_replay_checkpoint
+      ~(history_messages : Agent_sdk.Types.message list)
+      ~(session_id : string)
+      (checkpoint : Agent_sdk.Checkpoint.t)
+  =
+  match
+    Keeper_replay_prefix.split
+      ~prefix:history_messages
+      checkpoint.Agent_sdk.Checkpoint.messages
+  with
+  | Ok _ ->
+    Ok
+      ( { checkpoint with
+          Agent_sdk.Checkpoint.session_id
+        }
+      , None )
+  | Error _ ->
+    Error
+      "refusing to save execution-observation checkpoint: messages do not match pre-turn history prefix"
+;;
+
+let checkpoint_for_replay_persistence
+      ~(history_messages : Agent_sdk.Types.message list)
+      ~(session_id : string)
+      ~(response_text : string)
+      ?(stop_reason = Runtime_agent.Completed)
+      (checkpoint : Agent_sdk.Checkpoint.t)
+  =
+  match stop_reason with
+  | Runtime_agent.InputRequired _ ->
+    (* The elicitation request can follow a current-turn tool result. Blank
+       response canonicalization and completion-contract pruning must not
+       remove that suffix; prefix validation still fails closed. *)
+    (match
+       Keeper_replay_prefix.split
+         ~prefix:history_messages
+         checkpoint.Agent_sdk.Checkpoint.messages
+     with
+     | Ok (_ :: _) ->
+       Ok
+         ( { checkpoint with
+             Agent_sdk.Checkpoint.session_id
+           }
+         , None )
+     | Ok [] ->
+       Error
+         "refusing to save input-required checkpoint without a current-turn \
+          replay suffix"
+     | Error _ ->
+       Error
+         "refusing to save input-required checkpoint: messages do not match \
+          pre-turn history prefix")
+  | Runtime_agent.Yielded_to_chat_waiting _
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Awaiting_external_effect _
+  | Runtime_agent.Yielded_after_repeated_tool_call _ ->
+    (* A control-boundary checkpoint retains the current-turn tool result so
+       resumption cannot repeat an already committed effect. *)
+    observation_replay_checkpoint ~history_messages ~session_id checkpoint
+  | Runtime_agent.Completed ->
+    canonical_success_replay_checkpoint
+      ~history_messages
+      ~session_id
+      ~response_text
+      checkpoint
+;;
+
+(* OAS constructs the mutation-boundary checkpoint and then installs the same
+   immutable message values on the agent state. The list spines are rebuilt, so
+   list physical equality is too strict; comparing each message record by
+   identity proves the state boundary without hashing or scanning large text and
+   tool-result bodies. *)
+let rec messages_share_values_by_identity left right =
+  match left, right with
+  | [], [] -> true
+  | left_message :: left_rest, right_message :: right_rest
+    when left_message == right_message ->
+    messages_share_values_by_identity left_rest right_rest
+  | _ -> false
+;;
+
+let select_finalization_checkpoint
+    ~(last_persisted_checkpoint : Agent_sdk.Checkpoint.t option)
+    (result_checkpoint : Agent_sdk.Checkpoint.t) =
+  match last_persisted_checkpoint with
+  | Some persisted
+    when Int.equal persisted.turn_count result_checkpoint.turn_count
+         && messages_share_values_by_identity
+              persisted.messages
+              result_checkpoint.messages ->
+    persisted, true
+  | Some _ | None -> result_checkpoint, false
+;;
+
+let finalization_checkpoint_already_persisted
+    ~source_already_persisted
+    ~(source : Agent_sdk.Checkpoint.t)
+    ~(patched : Agent_sdk.Checkpoint.t)
+    ~replay_suffix_pruned =
+  source_already_persisted
+  && Option.is_none replay_suffix_pruned
+  && String.equal source.session_id patched.session_id
+  && source.messages == patched.messages
+  && source.working_context == patched.working_context
+;;

--- a/lib/keeper/keeper_replay_checkpoint.ml
+++ b/lib/keeper/keeper_replay_checkpoint.ml
@@ -13,6 +13,16 @@ let replay_response_text_for_persistence ~suppress_visible_response ~response_te
   else Some response_text
 ;;
 
+let consume_replay_response
+    ~suppress_visible_response
+    ~response_text
+    ~consume =
+  replay_response_text_for_persistence
+    ~suppress_visible_response
+    ~response_text
+  |> Option.map (fun response_text -> consume ~response_text)
+;;
+
 type wire_capture_response_suppression_reason =
   | Control_checkpoint
 

--- a/lib/keeper/keeper_replay_checkpoint.ml
+++ b/lib/keeper/keeper_replay_checkpoint.ml
@@ -7,14 +7,10 @@ let replay_suffix_prune_reason_to_string = function
   | Canonical_success_replay -> "canonical_success_replay"
 ;;
 
-let replay_response_text_for_capture ~suppress_visible_response ~response_text =
+let replay_response_text_for_persistence ~suppress_visible_response ~response_text =
   if suppress_visible_response || String.trim response_text = ""
   then None
   else Some response_text
-;;
-
-let replay_response_text_for_persistence ~suppress_visible_response ~response_text =
-  replay_response_text_for_capture ~suppress_visible_response ~response_text
 ;;
 
 type wire_capture_response_suppression_reason =

--- a/lib/keeper/keeper_replay_checkpoint.mli
+++ b/lib/keeper/keeper_replay_checkpoint.mli
@@ -5,8 +5,11 @@ type replay_suffix_prune_reason
 val replay_suffix_prune_reason_to_string :
   replay_suffix_prune_reason -> string
 
-val replay_response_text_for_persistence :
-  suppress_visible_response:bool -> response_text:string -> string option
+val consume_replay_response :
+  suppress_visible_response:bool ->
+  response_text:string ->
+  consume:(response_text:string -> 'a) ->
+  'a option
 
 type wire_capture_response_suppression_reason
 

--- a/lib/keeper/keeper_replay_checkpoint.mli
+++ b/lib/keeper/keeper_replay_checkpoint.mli
@@ -1,0 +1,43 @@
+(** Canonical replay checkpoint projection and response-capture policy. *)
+
+type replay_suffix_prune_reason
+
+val replay_suffix_prune_reason_to_string :
+  replay_suffix_prune_reason -> string
+
+val replay_response_text_for_capture :
+  suppress_visible_response:bool -> response_text:string -> string option
+
+val replay_response_text_for_persistence :
+  suppress_visible_response:bool -> response_text:string -> string option
+
+type wire_capture_response_suppression_reason
+
+val wire_capture_response_suppression_reasons :
+  control_checkpoint:bool -> wire_capture_response_suppression_reason list
+
+val wire_capture_response_suppression_reason_label :
+  wire_capture_response_suppression_reason -> string
+
+val emit_wire_capture_response_suppressed_metrics :
+  keeper_name:string -> wire_capture_response_suppression_reason list -> unit
+
+val checkpoint_for_replay_persistence :
+  history_messages:Agent_sdk.Types.message list ->
+  session_id:string ->
+  response_text:string ->
+  ?stop_reason:Runtime_agent.stop_reason ->
+  Agent_sdk.Checkpoint.t ->
+  (Agent_sdk.Checkpoint.t * replay_suffix_prune_reason option, string) result
+
+val select_finalization_checkpoint :
+  last_persisted_checkpoint:Agent_sdk.Checkpoint.t option ->
+  Agent_sdk.Checkpoint.t ->
+  Agent_sdk.Checkpoint.t * bool
+
+val finalization_checkpoint_already_persisted :
+  source_already_persisted:bool ->
+  source:Agent_sdk.Checkpoint.t ->
+  patched:Agent_sdk.Checkpoint.t ->
+  replay_suffix_pruned:replay_suffix_prune_reason option ->
+  bool

--- a/lib/keeper/keeper_replay_checkpoint.mli
+++ b/lib/keeper/keeper_replay_checkpoint.mli
@@ -5,9 +5,6 @@ type replay_suffix_prune_reason
 val replay_suffix_prune_reason_to_string :
   replay_suffix_prune_reason -> string
 
-val replay_response_text_for_capture :
-  suppress_visible_response:bool -> response_text:string -> string option
-
 val replay_response_text_for_persistence :
   suppress_visible_response:bool -> response_text:string -> string option
 

--- a/test/stanzas/test_keeper_wire_capture_suppression.inc
+++ b/test/stanzas/test_keeper_wire_capture_suppression.inc
@@ -1,10 +1,5 @@
-; Behavioral coverage for the wire-capture response-suppression surface
-; (Keeper_replay_checkpoint.wire_capture_response_suppression_reasons
-; + emit_wire_capture_response_suppressed_metrics + replay_response_text_for_capture,
-; Keeper_agent_run_response_text budget/attention auto-suppress). Restored after
-; PR #23929's [STATE]/BDI purge deleted test/test_keeper_state_snapshot_json.ml
-; and swept this unrelated, still-live coverage out with it (post-merge audit P1
-; finding: 0 remaining behavioral test consumers).
+; Behavioral coverage for typed control-checkpoint response suppression,
+; persistence selection, and the emitted suppression metric.
 
 (test
  (name test_keeper_wire_capture_suppression)

--- a/test/stanzas/test_keeper_wire_capture_suppression.inc
+++ b/test/stanzas/test_keeper_wire_capture_suppression.inc
@@ -1,5 +1,5 @@
 ; Behavioral coverage for the wire-capture response-suppression surface
-; (Keeper_agent_run_finalize_response.wire_capture_response_suppression_reasons
+; (Keeper_replay_checkpoint.wire_capture_response_suppression_reasons
 ; + emit_wire_capture_response_suppressed_metrics + replay_response_text_for_capture,
 ; Keeper_agent_run_response_text budget/attention auto-suppress). Restored after
 ; PR #23929's [STATE]/BDI purge deleted test/test_keeper_state_snapshot_json.ml

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -508,9 +508,10 @@ let test_autonomous_response_is_durable_conversation () =
   Alcotest.(check (option string))
     "assistant response is durable without an external effect"
     (Some "I will inspect the queue next.")
-    (Finalize.replay_response_text_for_persistence
+    (Finalize.consume_replay_response
        ~suppress_visible_response:false
-       ~response_text:"I will inspect the queue next.")
+       ~response_text:"I will inspect the queue next."
+       ~consume:(fun ~response_text -> response_text))
 ;;
 
 let test_autonomous_turn_persists_cue_and_assistant () =

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -4,7 +4,7 @@
     assistant response is durable conversation state even when the autonomous
     cycle has no external effect. *)
 
-module Finalize = Masc.Keeper_agent_run_finalize_response.For_testing
+module Finalize = Masc.Keeper_replay_checkpoint
 module Replay_prefix = Masc.Keeper_replay_prefix
 
 let message role content =

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -614,15 +614,24 @@ let capture_response_uses_finalized_replay_text () =
     | Some n -> n
     | None -> Alcotest.fail "replay_response_text_for_persistence use not found"
   in
+  let persist_line =
+    match last_line_of finalize_path "Keeper_context_runtime.persist_message" with
+    | Some n -> n
+    | None -> Alcotest.fail "persist_message invocation not found"
+  in
   let capture_callback_line =
     match last_line_of finalize_path "capture_replay_response ~response_text" with
     | Some n -> n
     | None -> Alcotest.fail "capture_replay_response invocation not found"
   in
   Alcotest.(check bool)
-    "capture callback runs after replay-visible response decision"
+    "persisted assistant uses the replay persistence decision"
     true
-    (capture_callback_line > replay_decision_line)
+    (persist_line > replay_decision_line);
+  Alcotest.(check bool)
+    "capture callback runs after assistant persistence"
+    true
+    (capture_callback_line > persist_line)
 
 let () =
   Alcotest.run "keeper_wire_capture"

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -610,9 +610,9 @@ let capture_response_uses_finalized_replay_text () =
       "lib/keeper/keeper_agent_run_finalize_response.ml"
   in
   let replay_decision_line =
-    match last_line_of finalize_path "replay_response_text_for_capture" with
+    match last_line_of finalize_path "replay_response_text_for_persistence" with
     | Some n -> n
-    | None -> Alcotest.fail "replay_response_text_for_capture use not found"
+    | None -> Alcotest.fail "replay_response_text_for_persistence use not found"
   in
   let capture_callback_line =
     match last_line_of finalize_path "capture_replay_response ~response_text" with

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -135,48 +135,6 @@ let check_metric_delta label name ~labels f =
 let write_failures_metric = Keeper_metrics.(to_string WireCaptureWriteFailures)
 let record_skipped_metric = Keeper_metrics.(to_string WireCaptureRecordSkipped)
 
-(* Regression guard: verify in [Keeper_agent_run.run_turn] that the response
-   capture happens after normalization and uses the normalized identifier.
-
-   Dune test actions run in a sandbox, so we locate the source tree via
-   [DUNE_SOURCEROOT] (set by Dune for all actions). *)
-let repo_root () =
-  match Sys.getenv_opt "DUNE_SOURCEROOT" with
-  | Some root -> root
-  | None ->
-    Alcotest.fail "DUNE_SOURCEROOT is not set; cannot locate source file"
-
-let first_line_of path needle =
-  let ic = open_in path in
-  Fun.protect
-    ~finally:(fun () -> close_in ic)
-    (fun () ->
-       let rec loop line_num =
-         match input_line ic with
-         | line ->
-           if contains ~needle line then Some line_num else loop (line_num + 1)
-         | exception End_of_file -> None
-       in
-       loop 1)
-;;
-
-let last_line_of path needle =
-  let ic = open_in path in
-  Fun.protect
-    ~finally:(fun () -> close_in ic)
-    (fun () ->
-       let rec loop line_num last_seen =
-         match input_line ic with
-         | line ->
-           let last_seen =
-             if contains ~needle line then Some line_num else last_seen
-           in
-           loop (line_num + 1) last_seen
-         | exception End_of_file -> last_seen
-       in
-       loop 1 None)
-;;
-
 let projected_secret = "wire-capture-projected-secret-value"
 
 let install_projected_secret ~base_path ~keeper_name =
@@ -580,58 +538,31 @@ let response_capture_matches_replayed_history_text () =
       (contains ~needle:raw_response content))
 
 let capture_response_uses_finalized_replay_text () =
-  let run_path = Filename.concat (repo_root ()) "lib/keeper/keeper_agent_run.ml" in
-  let capture_line =
-    match first_line_of run_path "Keeper_wire_capture.capture_response" with
-    | Some n -> n
-    | None -> Alcotest.fail "Keeper_wire_capture.capture_response call not found"
+  let captured = ref [] in
+  let consume ~suppress_visible_response ~response_text =
+    Masc.Keeper_replay_checkpoint.consume_replay_response
+      ~suppress_visible_response
+      ~response_text
+      ~consume:(fun ~response_text ->
+        captured := response_text :: !captured;
+        response_text)
   in
-  let normalize_line =
-    match first_line_of run_path "normalize_response_text_for_finalization" with
-    | Some n -> n
-    | None ->
-      Alcotest.fail "normalize_response_text_for_finalization call not found"
-  in
-  Alcotest.(check bool)
-    "capture_response occurs after normalize_response_text_for_finalization"
-    true
-    (capture_line > normalize_line);
-  let finalizer_line =
-    match first_line_of run_path "Keeper_agent_run_finalize_response.finalize" with
-    | Some n -> n
-    | None -> Alcotest.fail "Keeper_agent_run_finalize_response.finalize call not found"
-  in
-  Alcotest.(check bool)
-    "capture_response is delegated through finalize callback"
-    true
-    (capture_line > finalizer_line);
-  let finalize_path =
-    Filename.concat (repo_root ())
-      "lib/keeper/keeper_agent_run_finalize_response.ml"
-  in
-  let replay_decision_line =
-    match last_line_of finalize_path "replay_response_text_for_persistence" with
-    | Some n -> n
-    | None -> Alcotest.fail "replay_response_text_for_persistence use not found"
-  in
-  let persist_line =
-    match last_line_of finalize_path "Keeper_context_runtime.persist_message" with
-    | Some n -> n
-    | None -> Alcotest.fail "persist_message invocation not found"
-  in
-  let capture_callback_line =
-    match last_line_of finalize_path "capture_replay_response ~response_text" with
-    | Some n -> n
-    | None -> Alcotest.fail "capture_replay_response invocation not found"
-  in
-  Alcotest.(check bool)
-    "persisted assistant uses the replay persistence decision"
-    true
-    (persist_line > replay_decision_line);
-  Alcotest.(check bool)
-    "capture callback runs after assistant persistence"
-    true
-    (capture_callback_line > persist_line)
+  Alcotest.(check (option string))
+    "visible response reaches the consumer"
+    (Some "visible")
+    (consume ~suppress_visible_response:false ~response_text:"visible");
+  Alcotest.(check (option string))
+    "suppressed response does not reach the consumer"
+    None
+    (consume ~suppress_visible_response:true ~response_text:"suppressed");
+  Alcotest.(check (option string))
+    "blank response does not reach the consumer"
+    None
+    (consume ~suppress_visible_response:false ~response_text:"  ");
+  Alcotest.(check (list string))
+    "consumer observes only the persistable response"
+    [ "visible" ]
+    (List.rev !captured)
 
 let () =
   Alcotest.run "keeper_wire_capture"

--- a/test/test_keeper_wire_capture_suppression.ml
+++ b/test/test_keeper_wire_capture_suppression.ml
@@ -50,13 +50,13 @@ let test_wire_capture_suppression_reasons_emit_control_metric () =
     (metric_value ~labels:control_labels)
 ;;
 
-(* ── replay_response_text_for_capture ────────────────────────────────── *)
+(* ── replay_response_text_for_persistence ────────────────────────────────── *)
 
 let test_replay_capture_keeps_visible_response_text () =
   Alcotest.(check (option string))
     "visible response is captured verbatim"
     (Some "Visible reply")
-    (Finalize.replay_response_text_for_capture
+    (Finalize.replay_response_text_for_persistence
        ~suppress_visible_response:false
        ~response_text:"Visible reply")
 ;;
@@ -65,7 +65,7 @@ let test_replay_capture_omits_suppressed_response_text () =
   Alcotest.(check (option string))
     "suppressed response is not captured even when response_text is non-empty"
     None
-    (Finalize.replay_response_text_for_capture
+    (Finalize.replay_response_text_for_persistence
        ~suppress_visible_response:true
        ~response_text:"leftover text")
 ;;
@@ -74,7 +74,7 @@ let test_replay_capture_omits_blank_response_text () =
   Alcotest.(check (option string))
     "blank replay response is not captured"
     None
-    (Finalize.replay_response_text_for_capture
+    (Finalize.replay_response_text_for_persistence
        ~suppress_visible_response:false
        ~response_text:"   ")
 ;;
@@ -93,7 +93,7 @@ let test_replay_capture_preserves_model_reply_before_visible_capture () =
   Alcotest.(check (option string))
     "visible finalized response is captured"
     (Some "First line from model\nVisible reply")
-    (Finalize.replay_response_text_for_capture
+    (Finalize.replay_response_text_for_persistence
        ~suppress_visible_response:false
        ~response_text:finalized.response_text)
 ;;
@@ -140,7 +140,7 @@ let () =
             `Quick
             test_wire_capture_suppression_reasons_emit_control_metric
         ] )
-    ; ( "replay_response_text_for_capture"
+    ; ( "replay_response_text_for_persistence"
       , [ Alcotest.test_case
             "keeps visible response text"
             `Quick

--- a/test/test_keeper_wire_capture_suppression.ml
+++ b/test/test_keeper_wire_capture_suppression.ml
@@ -1,7 +1,7 @@
 (** Response suppression is restricted to typed control checkpoints. Runtime
     budget and completion-contract observations preserve model output. *)
 
-module Finalize = Masc.Keeper_agent_run_finalize_response.For_testing
+module Finalize = Masc.Keeper_replay_checkpoint
 module Response_text = Masc.Keeper_agent_run_response_text
 module Keeper_metrics = Keeper_metrics
 module Metrics = Masc.Otel_metric_store

--- a/test/test_keeper_wire_capture_suppression.ml
+++ b/test/test_keeper_wire_capture_suppression.ml
@@ -50,13 +50,20 @@ let test_wire_capture_suppression_reasons_emit_control_metric () =
     (metric_value ~labels:control_labels)
 ;;
 
-(* ── replay_response_text_for_persistence ────────────────────────────────── *)
+(* ── consume_replay_response ────────────────────────────────── *)
+
+let consume_response ~suppress_visible_response ~response_text =
+  Finalize.consume_replay_response
+    ~suppress_visible_response
+    ~response_text
+    ~consume:(fun ~response_text -> response_text)
+;;
 
 let test_replay_capture_keeps_visible_response_text () =
   Alcotest.(check (option string))
     "visible response is captured verbatim"
     (Some "Visible reply")
-    (Finalize.replay_response_text_for_persistence
+    (consume_response
        ~suppress_visible_response:false
        ~response_text:"Visible reply")
 ;;
@@ -65,7 +72,7 @@ let test_replay_capture_omits_suppressed_response_text () =
   Alcotest.(check (option string))
     "suppressed response is not captured even when response_text is non-empty"
     None
-    (Finalize.replay_response_text_for_persistence
+    (consume_response
        ~suppress_visible_response:true
        ~response_text:"leftover text")
 ;;
@@ -74,7 +81,7 @@ let test_replay_capture_omits_blank_response_text () =
   Alcotest.(check (option string))
     "blank replay response is not captured"
     None
-    (Finalize.replay_response_text_for_persistence
+    (consume_response
        ~suppress_visible_response:false
        ~response_text:"   ")
 ;;
@@ -93,7 +100,7 @@ let test_replay_capture_preserves_model_reply_before_visible_capture () =
   Alcotest.(check (option string))
     "visible finalized response is captured"
     (Some "First line from model\nVisible reply")
-    (Finalize.replay_response_text_for_persistence
+    (consume_response
        ~suppress_visible_response:false
        ~response_text:finalized.response_text)
 ;;
@@ -140,7 +147,7 @@ let () =
             `Quick
             test_wire_capture_suppression_reasons_emit_control_metric
         ] )
-    ; ( "replay_response_text_for_persistence"
+    ; ( "consume_replay_response"
       , [ Alcotest.test_case
             "keeps visible response text"
             `Quick


### PR DESCRIPTION
## Summary
- make `Keeper_replay_checkpoint` the typed owner of replay canonicalization and control-checkpoint suppression
- route finalization through a typed consumer that receives only persistable visible responses
- verify visible, suppressed, and blank callback behavior without reading production source text

## Validation
- local build/tests not run; GitHub CI is authoritative
- exact-head CI pending for `5fd0acdbc5`