### PR TITLE
feat(discord): add bound channel reads and preserve thread replies

### DIFF
--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -6,17 +6,35 @@
 
 type error =
   | Network of string
-  | Http_status of { code : int; body : string }
-  | Discord_api of { code : int; message : string }
-  | Other of string
+  | Http_status of { request_id : string; code : int; body_bytes : int }
+  | Discord_api of { request_id : string; code : int }
+  | Other of { request_id : string; reason : string; body_bytes : int }
 
 let pp_error fmt = function
   | Network msg -> Format.fprintf fmt "network: %s" msg
-  | Http_status { code; body } ->
-      Format.fprintf fmt "http %d: %s" code body
-  | Discord_api { code; message } ->
-      Format.fprintf fmt "discord %d: %s" code message
-  | Other msg -> Format.fprintf fmt "other: %s" msg
+  | Http_status { request_id; code; body_bytes } ->
+      Format.fprintf fmt "http request=%s status=%d body_bytes=%d"
+        request_id code body_bytes
+  | Discord_api { request_id; code } ->
+      Format.fprintf fmt "discord request=%s code=%d" request_id code
+  | Other { request_id; reason; body_bytes } ->
+      Format.fprintf fmt "other request=%s reason=%s body_bytes=%d"
+        request_id reason body_bytes
+
+let request_sequence = Atomic.make 0
+
+let next_request_id operation =
+  let sequence = Atomic.fetch_and_add request_sequence 1 in
+  Printf.sprintf "discord-%s-%d" operation sequence
+
+type snowflake = Snowflake of string
+
+let snowflake_of_string value =
+  if value = "" || not (String.for_all (fun c -> c >= '0' && c <= '9') value)
+  then Error "Discord snowflake must be a non-empty decimal string"
+  else Ok (Snowflake value)
+
+let snowflake_to_string (Snowflake value) = value
 
 (* Discord text-message content limit, in Unicode scalar units.
    Messages longer than this must be split into multiple payloads. *)
@@ -41,7 +59,7 @@ let build_request ~token ~channel_id ~content ?reply_to_message_id () =
   let url =
     Printf.sprintf
       "%s/channels/%s/messages"
-      api_base channel_id
+      api_base (snowflake_to_string channel_id)
   in
   let headers =
     ("Content-Type", "application/json") :: auth_headers ~token
@@ -51,7 +69,9 @@ let build_request ~token ~channel_id ~content ?reply_to_message_id () =
     match reply_to_message_id with
     | None -> fields
     | Some ref_id ->
-        ("message_reference", `Assoc [ "message_id", `String ref_id ])
+        ( "message_reference"
+        , `Assoc
+            [ "message_id", `String (snowflake_to_string ref_id) ] )
         :: fields
   in
   let body = Yojson.Safe.to_string (`Assoc fields) in
@@ -61,12 +81,14 @@ let build_typing_request ~token ~channel_id () =
   let url =
     Printf.sprintf
       "%s/channels/%s/typing"
-      api_base channel_id
+      api_base (snowflake_to_string channel_id)
   in
   (url, auth_headers ~token, "")
 
 let build_channel_request ~token ~channel_id () =
-  let url = Printf.sprintf "%s/channels/%s" api_base channel_id in
+  let url =
+    Printf.sprintf "%s/channels/%s" api_base (snowflake_to_string channel_id)
+  in
   (url, auth_headers ~token, "")
 
 let add_query_params url params =
@@ -80,13 +102,20 @@ let build_channel_messages_request
       ?limit
       ?before
       ?after
-      ()
+  ()
   =
-  let url = Printf.sprintf "%s/channels/%s/messages" api_base channel_id in
+  let url =
+    Printf.sprintf "%s/channels/%s/messages" api_base
+      (snowflake_to_string channel_id)
+  in
   let params =
     (match limit with Some value -> [ "limit", string_of_int value ] | None -> [])
-    @ (match before with Some value -> [ "before", value ] | None -> [])
-    @ (match after with Some value -> [ "after", value ] | None -> [])
+    @ (match before with
+       | Some value -> [ "before", snowflake_to_string value ]
+       | None -> [])
+    @ (match after with
+       | Some value -> [ "after", snowflake_to_string value ]
+       | None -> [])
   in
   (add_query_params url params, auth_headers ~token, "")
 
@@ -103,7 +132,10 @@ let build_guild_members_request
     | Some value when String.trim value <> "" -> "members/search"
     | Some _ | None -> "members"
   in
-  let url = Printf.sprintf "%s/guilds/%s/%s" api_base guild_id path in
+  let url =
+    Printf.sprintf "%s/guilds/%s/%s" api_base (snowflake_to_string guild_id)
+      path
+  in
   let params =
     (match query with
      | Some value when String.trim value <> "" -> [ "query", value ]
@@ -112,12 +144,17 @@ let build_guild_members_request
     @ (match query with
        | Some value when String.trim value <> "" -> []
        | Some _ | None ->
-         (match after with Some value -> [ "after", value ] | None -> []))
+         (match after with
+          | Some value -> [ "after", snowflake_to_string value ]
+          | None -> []))
   in
   (add_query_params url params, auth_headers ~token, "")
 
 let build_guild_member_request ~token ~guild_id ~user_id () =
-  let url = Printf.sprintf "%s/guilds/%s/members/%s" api_base guild_id user_id in
+  let url =
+    Printf.sprintf "%s/guilds/%s/members/%s" api_base
+      (snowflake_to_string guild_id) (snowflake_to_string user_id)
+  in
   (url, auth_headers ~token, "")
 
 let parse_json_safe s =
@@ -127,54 +164,104 @@ let field_opt name = function
   | `Assoc fields -> List.assoc_opt name fields
   | _ -> None
 
-let error_of_non2xx ~status ~body =
+let error_of_non2xx ~request_id ~status ~body =
   match parse_json_safe body with
-  | None -> Http_status { code = status; body }
+  | None ->
+    Http_status { request_id; code = status; body_bytes = String.length body }
   | Some json ->
       let code =
         match field_opt "code" json with
         | Some (`Int c) -> c
         | _ -> status
       in
-      let message =
-        match field_opt "message" json with
-        | Some (`String s) -> s
-        | _ -> body
-      in
-      Discord_api { code; message }
+      (match field_opt "message" json with
+       | Some (`String _) -> Discord_api { request_id; code }
+       | _ ->
+         Http_status
+           { request_id; code = status; body_bytes = String.length body })
 
-let parse_response ~status ~body =
+let parse_response ?request_id ~status ~body () =
+  let request_id =
+    match request_id with Some value -> value | None -> next_request_id "parse"
+  in
   if status >= 200 && status < 300 then
     match parse_json_safe body with
     | None ->
-        Error (Other ("2xx response body is not valid JSON: " ^ body))
+        Error
+          (Other
+             { request_id
+             ; reason = "2xx response body is not valid JSON"
+             ; body_bytes = String.length body
+             })
     | Some json ->
         (match field_opt "id" json with
          | Some (`String id) -> Ok id
-         | _ -> Error (Other "2xx response missing 'id' string"))
+         | _ ->
+           Error
+             (Other
+                { request_id
+                ; reason = "2xx response missing 'id' string"
+                ; body_bytes = String.length body
+                }))
   else
-    Error (error_of_non2xx ~status ~body)
+    Error (error_of_non2xx ~request_id ~status ~body)
 
-let parse_json_response ~status ~body =
+let parse_json_response ?request_id ~status ~body () =
+  let request_id =
+    match request_id with Some value -> value | None -> next_request_id "parse"
+  in
   if status >= 200 && status < 300 then
     match parse_json_safe body with
     | Some json -> Ok json
-    | None -> Error (Other ("2xx response body is not valid JSON: " ^ body))
+    | None ->
+      Error
+        (Other
+           { request_id
+           ; reason = "2xx response body is not valid JSON"
+           ; body_bytes = String.length body
+           })
   else
-    Error (error_of_non2xx ~status ~body)
+    Error (error_of_non2xx ~request_id ~status ~body)
 
-let parse_empty_response ~status ~body =
+let parse_empty_response ?request_id ~status ~body () =
+  let request_id =
+    match request_id with Some value -> value | None -> next_request_id "parse"
+  in
   if status >= 200 && status < 300 then Ok ()
-  else Error (error_of_non2xx ~status ~body)
+  else Error (error_of_non2xx ~request_id ~status ~body)
 
 let send_message ?clock ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
     ~token ~channel_id ~content ?reply_to_message_id () =
-  let (url, headers, body) =
-    build_request ~token ~channel_id ~content ?reply_to_message_id ()
-  in
-  match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
-  | Error msg -> Error (Network msg)
-  | Ok (status, body) -> parse_response ~status ~body
+  match snowflake_of_string channel_id with
+  | Error message -> Error (Network message)
+  | Ok channel_id ->
+    (match reply_to_message_id with
+     | Some value ->
+       (match snowflake_of_string value with
+        | Error message -> Error (Network message)
+        | Ok reply_to_message_id ->
+          let (url, headers, body) =
+            build_request ~token ~channel_id ~content ~reply_to_message_id ()
+          in
+          (match
+             Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body
+               ()
+           with
+           | Error msg -> Error (Network msg)
+           | Ok (status, body) ->
+             parse_response ~request_id:(next_request_id "send") ~status ~body
+               ()))
+     | None ->
+       let (url, headers, body) =
+         build_request ~token ~channel_id ~content ()
+       in
+       (match
+          Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body ()
+        with
+        | Error msg -> Error (Network msg)
+        | Ok (status, body) ->
+          parse_response ~request_id:(next_request_id "send") ~status ~body
+            ()))
 
 (* Byte length of the UTF-8 sequence whose lead byte is [c]. An invalid
    lead byte counts as 1 so iteration always makes progress. *)
@@ -229,7 +316,7 @@ let build_edit_request ~token ~channel_id ~message_id ~content () =
   let url =
     Printf.sprintf
       "%s/channels/%s/messages/%s"
-      api_base channel_id message_id
+      api_base (snowflake_to_string channel_id) (snowflake_to_string message_id)
   in
   let headers =
     ("Content-Type", "application/json") :: auth_headers ~token
@@ -242,29 +329,38 @@ let build_edit_request ~token ~channel_id ~message_id ~content () =
 
 let edit_message ?clock ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
     ~token ~channel_id ~message_id ~content () =
-  let (url, headers, body) =
-    build_edit_request ~token ~channel_id ~message_id ~content ()
-  in
-  match Masc_http_client.patch_sync ?clock ~timeout_sec ~url ~headers ~body () with
-  | Error msg -> Error (Network msg)
-  | Ok (status, body) -> parse_empty_response ~status ~body
+  match snowflake_of_string channel_id, snowflake_of_string message_id with
+  | Error message, _ | _, Error message -> Error (Network message)
+  | Ok channel_id, Ok message_id ->
+    let (url, headers, body) =
+      build_edit_request ~token ~channel_id ~message_id ~content ()
+    in
+    match Masc_http_client.patch_sync ?clock ~timeout_sec ~url ~headers ~body () with
+    | Error msg -> Error (Network msg)
+    | Ok (status, body) ->
+      parse_empty_response ~request_id:(next_request_id "edit") ~status ~body ()
 
 let trigger_typing ?clock ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
     ~token ~channel_id () =
-  let url, headers, body = build_typing_request ~token ~channel_id () in
-  match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
-  | Error msg -> Error (Network msg)
-  | Ok (status, body) -> parse_empty_response ~status ~body
+  match snowflake_of_string channel_id with
+  | Error message -> Error (Network message)
+  | Ok channel_id ->
+    let url, headers, body = build_typing_request ~token ~channel_id () in
+    match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
+    | Error msg -> Error (Network msg)
+    | Ok (status, body) ->
+      parse_empty_response ~request_id:(next_request_id "typing") ~status ~body ()
 
 let get_json ?clock ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
-    ~url ~headers () =
+    ~request_id ~url ~headers () =
   match Masc_http_client.get_sync ?clock ~timeout_sec ~url ~headers () with
   | Error msg -> Error (Network msg)
-  | Ok (status, body) -> parse_json_response ~status ~body
+  | Ok (status, body) -> parse_json_response ~request_id ~status ~body ()
 
 let get_channel ?clock ?timeout_sec ~token ~channel_id () =
   let url, headers, _ = build_channel_request ~token ~channel_id () in
-  get_json ?clock ?timeout_sec ~url ~headers ()
+  get_json ?clock ?timeout_sec ~request_id:(next_request_id "channel") ~url
+    ~headers ()
 
 let get_channel_messages
       ?clock
@@ -279,7 +375,8 @@ let get_channel_messages
   let url, headers, _ =
     build_channel_messages_request ~token ~channel_id ?limit ?before ?after ()
   in
-  get_json ?clock ?timeout_sec ~url ~headers ()
+  get_json ?clock ?timeout_sec ~request_id:(next_request_id "messages") ~url
+    ~headers ()
 
 let get_guild_members
       ?clock
@@ -294,11 +391,13 @@ let get_guild_members
   let url, headers, _ =
     build_guild_members_request ~token ~guild_id ?query ?limit ?after ()
   in
-  get_json ?clock ?timeout_sec ~url ~headers ()
+  get_json ?clock ?timeout_sec ~request_id:(next_request_id "members") ~url
+    ~headers ()
 
 let get_guild_member ?clock ?timeout_sec ~token ~guild_id ~user_id () =
   let url, headers, _ = build_guild_member_request ~token ~guild_id ~user_id () in
-  get_json ?clock ?timeout_sec ~url ~headers ()
+  get_json ?clock ?timeout_sec ~request_id:(next_request_id "member") ~url
+    ~headers ()
 
 (* ── Embed support ──────────────────────────────────────────────── *)
 
@@ -380,7 +479,7 @@ let build_embed_request ~token ~channel_id ~content ?embeds () =
   let url =
     Printf.sprintf
       "%s/channels/%s/messages"
-      api_base channel_id
+      api_base (snowflake_to_string channel_id)
   in
   let headers =
     ("Content-Type", "application/json") :: auth_headers ~token
@@ -403,7 +502,7 @@ let build_edit_embed_request ~token ~channel_id ~message_id
   let url =
     Printf.sprintf
       "%s/channels/%s/messages/%s"
-      api_base channel_id message_id
+      api_base (snowflake_to_string channel_id) (snowflake_to_string message_id)
   in
   let headers =
     ("Content-Type", "application/json") :: auth_headers ~token
@@ -424,9 +523,13 @@ let build_edit_embed_request ~token ~channel_id ~message_id
 let send_embed_message ?clock
     ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
     ~token ~channel_id ~content ?embeds () =
-  let (url, headers, body) =
-    build_embed_request ~token ~channel_id ~content ?embeds ()
-  in
-  match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
-  | Error msg -> Error (Network msg)
-  | Ok (status, body) -> parse_response ~status ~body
+  match snowflake_of_string channel_id with
+  | Error message -> Error (Network message)
+  | Ok channel_id ->
+    let (url, headers, body) =
+      build_embed_request ~token ~channel_id ~content ?embeds ()
+    in
+    match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
+    | Error msg -> Error (Network msg)
+    | Ok (status, body) ->
+      parse_response ~request_id:(next_request_id "embed") ~status ~body ()

--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -65,6 +65,61 @@ let build_typing_request ~token ~channel_id () =
   in
   (url, auth_headers ~token, "")
 
+let build_channel_request ~token ~channel_id () =
+  let url = Printf.sprintf "%s/channels/%s" api_base channel_id in
+  (url, auth_headers ~token, "")
+
+let add_query_params url params =
+  Uri.of_string url
+  |> fun uri -> Uri.add_query_params' uri params
+  |> Uri.to_string
+
+let build_channel_messages_request
+      ~token
+      ~channel_id
+      ?limit
+      ?before
+      ?after
+      ()
+  =
+  let url = Printf.sprintf "%s/channels/%s/messages" api_base channel_id in
+  let params =
+    (match limit with Some value -> [ "limit", string_of_int value ] | None -> [])
+    @ (match before with Some value -> [ "before", value ] | None -> [])
+    @ (match after with Some value -> [ "after", value ] | None -> [])
+  in
+  (add_query_params url params, auth_headers ~token, "")
+
+let build_guild_members_request
+      ~token
+      ~guild_id
+      ?query
+      ?limit
+      ?after
+      ()
+  =
+  let path =
+    match query with
+    | Some value when String.trim value <> "" -> "members/search"
+    | Some _ | None -> "members"
+  in
+  let url = Printf.sprintf "%s/guilds/%s/%s" api_base guild_id path in
+  let params =
+    (match query with
+     | Some value when String.trim value <> "" -> [ "query", value ]
+     | Some _ | None -> [])
+    @ (match limit with Some value -> [ "limit", string_of_int value ] | None -> [])
+    @ (match query with
+       | Some value when String.trim value <> "" -> []
+       | Some _ | None ->
+         (match after with Some value -> [ "after", value ] | None -> []))
+  in
+  (add_query_params url params, auth_headers ~token, "")
+
+let build_guild_member_request ~token ~guild_id ~user_id () =
+  let url = Printf.sprintf "%s/guilds/%s/members/%s" api_base guild_id user_id in
+  (url, auth_headers ~token, "")
+
 let parse_json_safe s =
   try Some (Yojson.Safe.from_string s) with Yojson.Json_error _ -> None
 
@@ -97,6 +152,14 @@ let parse_response ~status ~body =
         (match field_opt "id" json with
          | Some (`String id) -> Ok id
          | _ -> Error (Other "2xx response missing 'id' string"))
+  else
+    Error (error_of_non2xx ~status ~body)
+
+let parse_json_response ~status ~body =
+  if status >= 200 && status < 300 then
+    match parse_json_safe body with
+    | Some json -> Ok json
+    | None -> Error (Other ("2xx response body is not valid JSON: " ^ body))
   else
     Error (error_of_non2xx ~status ~body)
 
@@ -192,6 +255,50 @@ let trigger_typing ?clock ?(timeout_sec = Masc_http_client.default_request_timeo
   match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_empty_response ~status ~body
+
+let get_json ?clock ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
+    ~url ~headers () =
+  match Masc_http_client.get_sync ?clock ~timeout_sec ~url ~headers () with
+  | Error msg -> Error (Network msg)
+  | Ok (status, body) -> parse_json_response ~status ~body
+
+let get_channel ?clock ?timeout_sec ~token ~channel_id () =
+  let url, headers, _ = build_channel_request ~token ~channel_id () in
+  get_json ?clock ?timeout_sec ~url ~headers ()
+
+let get_channel_messages
+      ?clock
+      ?timeout_sec
+      ~token
+      ~channel_id
+      ?limit
+      ?before
+      ?after
+      ()
+  =
+  let url, headers, _ =
+    build_channel_messages_request ~token ~channel_id ?limit ?before ?after ()
+  in
+  get_json ?clock ?timeout_sec ~url ~headers ()
+
+let get_guild_members
+      ?clock
+      ?timeout_sec
+      ~token
+      ~guild_id
+      ?query
+      ?limit
+      ?after
+      ()
+  =
+  let url, headers, _ =
+    build_guild_members_request ~token ~guild_id ?query ?limit ?after ()
+  in
+  get_json ?clock ?timeout_sec ~url ~headers ()
+
+let get_guild_member ?clock ?timeout_sec ~token ~guild_id ~user_id () =
+  let url, headers, _ = build_guild_member_request ~token ~guild_id ~user_id () in
+  get_json ?clock ?timeout_sec ~url ~headers ()
 
 (* ── Embed support ──────────────────────────────────────────────── *)
 

--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -160,9 +160,13 @@ let build_guild_member_request ~token ~guild_id ~user_id () =
 let parse_json_safe s =
   try Some (Yojson.Safe.from_string s) with Yojson.Json_error _ -> None
 
-let field_opt name = function
-  | `Assoc fields -> List.assoc_opt name fields
-  | _ -> None
+let unique_field_opt name = function
+  | `Assoc fields ->
+    (match List.filter (fun (key, _) -> String.equal key name) fields with
+     | [] -> Ok None
+     | [ (_, value) ] -> Ok (Some value)
+     | _ -> Error (Printf.sprintf "duplicate response field %S" name))
+  | _ -> Ok None
 
 let error_of_non2xx ~request_id ~status ~body =
   match parse_json_safe body with
@@ -170,13 +174,13 @@ let error_of_non2xx ~request_id ~status ~body =
     Http_status { request_id; code = status; body_bytes = String.length body }
   | Some json ->
       let code =
-        match field_opt "code" json with
-        | Some (`Int c) -> c
-        | _ -> status
+        match unique_field_opt "code" json with
+        | Ok (Some (`Int c)) -> c
+        | Ok _ | Error _ -> status
       in
-      (match field_opt "message" json with
-       | Some (`String _) -> Discord_api { request_id; code }
-       | _ ->
+      (match unique_field_opt "message" json with
+       | Ok (Some (`String _)) -> Discord_api { request_id; code }
+       | Ok _ | Error _ ->
          Http_status
            { request_id; code = status; body_bytes = String.length body })
 
@@ -194,9 +198,16 @@ let parse_response ?request_id ~status ~body () =
              ; body_bytes = String.length body
              })
     | Some json ->
-        (match field_opt "id" json with
-         | Some (`String id) -> Ok id
-         | _ ->
+        (match unique_field_opt "id" json with
+         | Ok (Some (`String id)) -> Ok id
+         | Error reason ->
+           Error
+             (Other
+                { request_id
+                ; reason
+                ; body_bytes = String.length body
+                })
+         | Ok _ ->
            Error
              (Other
                 { request_id

--- a/lib/gate/discord_rest_client.mli
+++ b/lib/gate/discord_rest_client.mli
@@ -32,22 +32,25 @@ val truncate_to_limit : string -> string
 (** Truncate to {!message_content_limit} Unicode scalar values on a
     codepoint boundary (valid UTF-8). Used for PATCH edits. *)
 
-(** Typed error from Discord REST. Closed sum — anything Discord
-    returns that does not map to one of these becomes [Other]
-    (preserving the JSON for inspection) so we never silently consume
-    a new error variant. *)
+(** Typed error from Discord REST. Response bodies never cross this
+    boundary; failures retain only request correlation, status/code,
+    reason, and body byte count. *)
 type error =
   | Network of string
     (** Transport-level failure (DNS, TLS, timeout, body cap). *)
-  | Http_status of { code : int; body : string }
+  | Http_status of { request_id : string; code : int; body_bytes : int }
     (** Non-2xx HTTP status whose body did not parse as a Discord
         error envelope. *)
-  | Discord_api of { code : int; message : string }
-    (** Non-2xx HTTP status carrying a Discord error envelope
-        ({ "code": int, "message": string }). *)
-  | Other of string
-    (** 2xx response whose body did not contain an [id], or any
-        other unexpected shape. Always includes a one-line reason. *)
+  | Discord_api of { request_id : string; code : int }
+    (** Non-2xx HTTP status carrying a Discord error envelope. *)
+  | Other of { request_id : string; reason : string; body_bytes : int }
+    (** A response whose body or shape was not usable. *)
+
+type snowflake
+(** Validated Discord identifier: a non-empty decimal string. *)
+
+val snowflake_of_string : string -> (snowflake, string) result
+val snowflake_to_string : snowflake -> string
 
 val pp_error : Format.formatter -> error -> unit
 
@@ -108,7 +111,7 @@ val get_channel :
   ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   ?timeout_sec:float ->
   token:string ->
-  channel_id:string ->
+  channel_id:snowflake ->
   unit ->
   (Yojson.Safe.t, error) result
 (** Fetch the Discord channel object for [channel_id]. *)
@@ -117,10 +120,10 @@ val get_channel_messages :
   ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   ?timeout_sec:float ->
   token:string ->
-  channel_id:string ->
+  channel_id:snowflake ->
   ?limit:int ->
-  ?before:string ->
-  ?after:string ->
+  ?before:snowflake ->
+  ?after:snowflake ->
   unit ->
   (Yojson.Safe.t, error) result
 (** Fetch channel messages, newest first. [before] and [after] are mutually
@@ -130,10 +133,10 @@ val get_guild_members :
   ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   ?timeout_sec:float ->
   token:string ->
-  guild_id:string ->
+  guild_id:snowflake ->
   ?query:string ->
   ?limit:int ->
-  ?after:string ->
+  ?after:snowflake ->
   unit ->
   (Yojson.Safe.t, error) result
 (** List or search members of [guild_id]. A non-empty [query] uses Discord's
@@ -144,8 +147,8 @@ val get_guild_member :
   ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   ?timeout_sec:float ->
   token:string ->
-  guild_id:string ->
-  user_id:string ->
+  guild_id:snowflake ->
+  user_id:snowflake ->
   unit ->
   (Yojson.Safe.t, error) result
 (** Fetch one guild member, retaining the user's guild nickname and roles. *)
@@ -207,9 +210,9 @@ val send_embed_message :
 
 val build_request :
   token:string ->
-  channel_id:string ->
+  channel_id:snowflake ->
   content:string ->
-  ?reply_to_message_id:string ->
+  ?reply_to_message_id:snowflake ->
   unit ->
   string * (string * string) list * string
 (** [(url, headers, body) = build_request ~token ~channel_id ~content
@@ -220,7 +223,7 @@ val build_request :
 
 val build_typing_request :
   token:string ->
-  channel_id:string ->
+  channel_id:snowflake ->
   unit ->
   string * (string * string) list * string
 (** [(url, headers, body) = build_typing_request ~token ~channel_id ()].
@@ -228,39 +231,39 @@ val build_typing_request :
 
 val build_channel_request :
   token:string ->
-  channel_id:string ->
+  channel_id:snowflake ->
   unit ->
   string * (string * string) list * string
 
 val build_channel_messages_request :
   token:string ->
-  channel_id:string ->
+  channel_id:snowflake ->
   ?limit:int ->
-  ?before:string ->
-  ?after:string ->
+  ?before:snowflake ->
+  ?after:snowflake ->
   unit ->
   string * (string * string) list * string
 
 val build_guild_members_request :
   token:string ->
-  guild_id:string ->
+  guild_id:snowflake ->
   ?query:string ->
   ?limit:int ->
-  ?after:string ->
+  ?after:snowflake ->
   unit ->
   string * (string * string) list * string
 
 val build_guild_member_request :
   token:string ->
-  guild_id:string ->
-  user_id:string ->
+  guild_id:snowflake ->
+  user_id:snowflake ->
   unit ->
   string * (string * string) list * string
 
 val build_edit_request :
   token:string ->
-  channel_id:string ->
-  message_id:string ->
+  channel_id:snowflake ->
+  message_id:snowflake ->
   content:string ->
   unit ->
   string * (string * string) list * string
@@ -270,7 +273,7 @@ val build_edit_request :
 
 val build_embed_request :
   token:string ->
-  channel_id:string ->
+  channel_id:snowflake ->
   content:string ->
   ?embeds:embed list ->
   unit ->
@@ -280,8 +283,8 @@ val build_embed_request :
 
 val build_edit_embed_request :
   token:string ->
-  channel_id:string ->
-  message_id:string ->
+  channel_id:snowflake ->
+  message_id:snowflake ->
   content:string ->
   ?embeds:embed list ->
   unit ->
@@ -290,8 +293,10 @@ val build_edit_embed_request :
     updated content and/or embeds. Exposed for unit testing. *)
 
 val parse_response :
+  ?request_id:string ->
   status:int ->
   body:string ->
+  unit ->
   (string, error) result
 (** Classifies a Discord HTTP response:
     - 2xx with JSON object containing [id] string  → [Ok id]
@@ -300,8 +305,10 @@ val parse_response :
     - non-2xx without that envelope                → [Error (Http_status _)] *)
 
 val parse_empty_response :
+  ?request_id:string ->
   status:int ->
   body:string ->
+  unit ->
   (unit, error) result
 (** Classifies a Discord HTTP response for empty-success endpoints:
     - 2xx → [Ok ()]
@@ -309,8 +316,10 @@ val parse_empty_response :
     - non-2xx without that envelope → [Error (Http_status _)] *)
 
 val parse_json_response :
+  ?request_id:string ->
   status:int ->
   body:string ->
+  unit ->
   (Yojson.Safe.t, error) result
 (** Classifies a JSON Discord response without imposing an endpoint-specific
     top-level shape. *)

--- a/lib/gate/discord_rest_client.mli
+++ b/lib/gate/discord_rest_client.mli
@@ -102,6 +102,54 @@ val trigger_typing :
 
     @raise nothing — failures are surfaced as typed {!error}. *)
 
+(** {1 Read-only Discord resources} *)
+
+val get_channel :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  token:string ->
+  channel_id:string ->
+  unit ->
+  (Yojson.Safe.t, error) result
+(** Fetch the Discord channel object for [channel_id]. *)
+
+val get_channel_messages :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  token:string ->
+  channel_id:string ->
+  ?limit:int ->
+  ?before:string ->
+  ?after:string ->
+  unit ->
+  (Yojson.Safe.t, error) result
+(** Fetch channel messages, newest first. [before] and [after] are mutually
+    exclusive at the Discord API boundary. *)
+
+val get_guild_members :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  token:string ->
+  guild_id:string ->
+  ?query:string ->
+  ?limit:int ->
+  ?after:string ->
+  unit ->
+  (Yojson.Safe.t, error) result
+(** List or search members of [guild_id]. A non-empty [query] uses Discord's
+    guild-member search endpoint; without it, the paged member-list endpoint
+    is used. *)
+
+val get_guild_member :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  token:string ->
+  guild_id:string ->
+  user_id:string ->
+  unit ->
+  (Yojson.Safe.t, error) result
+(** Fetch one guild member, retaining the user's guild nickname and roles. *)
+
 (** {1 Embed support} *)
 
 type embed =
@@ -178,6 +226,37 @@ val build_typing_request :
 (** [(url, headers, body) = build_typing_request ~token ~channel_id ()].
     The body is empty; headers include Authorization and User-Agent. *)
 
+val build_channel_request :
+  token:string ->
+  channel_id:string ->
+  unit ->
+  string * (string * string) list * string
+
+val build_channel_messages_request :
+  token:string ->
+  channel_id:string ->
+  ?limit:int ->
+  ?before:string ->
+  ?after:string ->
+  unit ->
+  string * (string * string) list * string
+
+val build_guild_members_request :
+  token:string ->
+  guild_id:string ->
+  ?query:string ->
+  ?limit:int ->
+  ?after:string ->
+  unit ->
+  string * (string * string) list * string
+
+val build_guild_member_request :
+  token:string ->
+  guild_id:string ->
+  user_id:string ->
+  unit ->
+  string * (string * string) list * string
+
 val build_edit_request :
   token:string ->
   channel_id:string ->
@@ -228,3 +307,10 @@ val parse_empty_response :
     - 2xx → [Ok ()]
     - non-2xx with Discord error envelope → [Error (Discord_api _)]
     - non-2xx without that envelope → [Error (Http_status _)] *)
+
+val parse_json_response :
+  status:int ->
+  body:string ->
+  (Yojson.Safe.t, error) result
+(** Classifies a JSON Discord response without imposing an endpoint-specific
+    top-level shape. *)

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -356,7 +356,10 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
               if String.length acc_text = 0 then
                 Error
                   (Discord_rest_client.Other
-                     "primary final Discord reply contained no text")
+                     { request_id = "keeper_chat_discord.final_reply"
+                     ; reason = "primary final Discord reply contained no text"
+                     ; body_bytes = 0
+                     })
               else send_message ~content:acc_text
           | Some mid ->
               let head, overflow = final_head_and_overflow acc_text in

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -621,6 +621,9 @@ let run_keepalive_unified_turn
             | [ { Keeper_event_queue.payload = Fusion_completed completion; _ } ]
               when Keeper_continuation_channel.is_routable completion.channel ->
               Some completion.channel
+            | [ { Keeper_event_queue.payload = Connector_attention attention; _ } ]
+              when Keeper_continuation_channel.is_routable attention.channel ->
+              Some attention.channel
             | [] | [ _ ] | _ :: _ :: _ -> None
           in
           (* The event intake is the exact turn input. Keep its attribution in

--- a/lib/keeper/keeper_surface_post.ml
+++ b/lib/keeper/keeper_surface_post.ml
@@ -13,21 +13,27 @@ let resolve_target ~surface ~channel_id ?continuation_channel
     ?(bound_discord_channels = [])
     ?(bound_slack_channels = []) () : (post_target, string) result =
   let surface = String.trim surface in
-  let continuation_channel_id =
+  let continuation_channel_id, continuation_parent_channel_id =
     match continuation_channel with
-    | Some (Keeper_continuation_channel.Discord { channel_id; _ })
+    | Some
+        (Keeper_continuation_channel.Discord
+           { channel_id; parent_channel_id; thread_id; _ })
       when String.equal surface discord_label ->
-      Some channel_id
+      ( Some channel_id
+      , (match thread_id, parent_channel_id with
+         | Some thread_id, Some parent_channel_id
+           when String.equal thread_id channel_id -> Some parent_channel_id
+         | _ -> None) )
     | Some (Keeper_continuation_channel.Slack { channel_id; _ })
       when String.equal surface slack_label ->
-      Some channel_id
+      Some channel_id, None
     | Some
         ( Keeper_continuation_channel.Dashboard _
         | Keeper_continuation_channel.Discord _
         | Keeper_continuation_channel.Slack _
         | Keeper_continuation_channel.Unrouted _ )
     | None ->
-      None
+      None, None
   in
   let channel_id =
     match channel_id with
@@ -37,6 +43,15 @@ let resolve_target ~surface ~channel_id ?continuation_channel
   if String.equal surface dashboard_label then Ok To_dashboard
   else if String.equal surface discord_label then
     let bound = List.map String.trim bound_discord_channels in
+    let is_bound_channel requested =
+      List.exists (String.equal requested) bound
+      ||
+      match continuation_channel_id, continuation_parent_channel_id with
+      | Some continuation_id, Some parent_id
+        when String.equal requested continuation_id ->
+        List.exists (String.equal parent_id) bound
+      | _ -> false
+    in
     match (channel_id, bound) with
     | _, [] ->
         Error
@@ -51,7 +66,7 @@ let resolve_target ~surface ~channel_id ?continuation_channel
              (String.concat ", " bound))
     | Some requested, bound ->
         let requested = String.trim requested in
-        if List.exists (String.equal requested) bound then
+        if is_bound_channel requested then
           Ok (To_discord { channel_id = requested })
         else
           Error

--- a/lib/keeper/keeper_surface_post.mli
+++ b/lib/keeper/keeper_surface_post.mli
@@ -38,9 +38,10 @@ val resolve_target :
     - ["dashboard"] → [To_dashboard].
     - ["discord"] → the bound channel when exactly one exists; the
       given [channel_id], or the exact matching typed continuation channel,
-      when it is among the bindings; an error
-      naming the bound channels when ambiguous, unbound, or the id is
-      not bound.
+      when it is among the bindings. A typed Discord thread continuation
+      keeps its thread channel as the target while authorizing it through
+      the bound parent channel; an error names the bound channels when
+      ambiguous, unbound, or foreign.
     - ["slack"] → same semantics against [bound_slack_channels].
       A continuation for another connector never supplies an id.
     - any other label → error: P4 ships discord + dashboard + slack

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -995,14 +995,15 @@ let surface_read_schema =
     ; string_enum_property
         "mode"
         [ "local"; "channel"; "messages"; "members"; "member" ]
-        "Read mode. 'local' reads the keeper's persisted lane; the other modes \
-         query Discord live and require surface='discord'."
+        "Optional exact read mode. When absent, the request is exactly 'local' \
+         for the persisted lane; padded or unknown values are invalid. The \
+         other modes query Discord live and require surface='discord'."
     ; property
         "limit"
         "integer"
-        "Maximum messages or Discord members to return (messages: 1-100; \
-         members: 1-1000). The local participant roster covers the whole \
-         loaded lane."
+        "Maximum messages or Discord members to return (default 20; messages: \
+         1-100; members: 1-1000). The local participant roster covers the \
+         whole loaded lane."
     ; property
         "channel_id"
         "string"

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -992,11 +992,39 @@ let surface_read_schema =
          source: 'dashboard', 'discord', 'slack', or another connector's \
          channel label. Rows written before source labelling carry no label \
          and are not returned."
+    ; string_enum_property
+        "mode"
+        [ "local"; "channel"; "messages"; "members"; "member" ]
+        "Read mode. 'local' reads the keeper's persisted lane; the other modes \
+         query Discord live and require surface='discord'."
     ; property
         "limit"
         "integer"
-        "Maximum lane messages to return (default 20, max 100). The \
-         participant roster always covers the whole loaded lane."
+        "Maximum messages or Discord members to return (messages: 1-100; \
+         members: 1-1000). The local participant roster covers the whole \
+         loaded lane."
+    ; property
+        "channel_id"
+        "string"
+        "Bound Discord channel snowflake. Optional when this keeper has one \
+         bound channel; required when it has multiple."
+    ; property
+        "user_id"
+        "string"
+        "Discord user snowflake, required for mode='member'."
+    ; property
+        "query"
+        "string"
+        "Optional member username/nickname prefix for mode='members'."
+    ; property
+        "discord_before"
+        "string"
+        "Discord message snowflake for backward paging in mode='messages'."
+    ; property
+        "discord_after"
+        "string"
+        "Discord message/member snowflake for forward paging. Do not send it \
+         together with discord_before."
     ]
 ;;
 
@@ -1618,11 +1646,9 @@ let internal_descriptors : t list =
        ~description:
          "Read recent messages from one conversation endpoint (dashboard, \
           discord, slack, or another connector label) with speaker identity \
-          and a derived participant roster. Use when the user asks about a \
-          current connector lane, recent lane messages, or participants. This \
-          does not enumerate connector-wide channel registries; if asked for \
-          channels outside Connected Surfaces, read only visible lane evidence \
-          and state that the wider registry is unavailable."
+          and a derived participant roster. With mode='channel', 'messages', \
+          'members', or 'member', the Discord lane can also query its live \
+          channel and server read surface within the keeper's bound channels."
        ~input_schema:surface_read_schema
        ~policy:(read_only_in_process_policy ())
        ~handler:Tool_surface_read

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -443,13 +443,33 @@ let discord_require_shape mode json =
   | Local_lane, _ -> Ok ()
 ;;
 
-let discord_success ~resource ~channel_id ?guild_id data =
-  let fields =
-    [ "resource", `String resource
+let surface_read_mode_label = function
+  | Local_lane -> "local"
+  | Discord_channel -> "channel"
+  | Discord_messages -> "messages"
+  | Discord_members -> "members"
+  | Discord_member -> "member"
+;;
+
+let discord_result_count (data : Yojson.Safe.t) =
+  match data with
+  | `List values -> Some (List.length values)
+  | `Assoc _ | `Null | `Bool _ | `Float _ | `Int _ | `Intlit _ | `String _ -> None
+;;
+
+let discord_success ~mode ~resource ~channel_id ?guild_id
+    (data : Yojson.Safe.t) =
+  let fields : (string * Yojson.Safe.t) list =
+    [ "mode", `String (surface_read_mode_label mode)
+    ; "resource", `String resource
+    ; "scope", `String "bound_channel"
     ; "channel_id", `String channel_id
     ; "data", data
     ]
     @ match guild_id with Some id -> [ "guild_id", `String id ] | None -> []
+    @ match discord_result_count data with
+      | Some count -> [ "data_count", `Int count ]
+      | None -> []
   in
   Yojson.Safe.to_string (Tool_args.ok_assoc fields)
 ;;
@@ -465,11 +485,38 @@ let handle_discord_surface_read ~meta ~args ~mode =
       let clock = Eio_context.get_clock_opt () in
       let rest ?guild_id call resource =
         match call () with
-        | Error error -> discord_rest_error error
+        | Error error ->
+          Log.Keeper.warn
+            ~keeper_name:meta.name
+            "discord_surface_read failed mode=%s resource=%s channel=%s: %s"
+            (surface_read_mode_label mode)
+            resource
+            channel_id
+            (Format.asprintf "%a" Discord_rest_client.pp_error error);
+          discord_rest_error error
         | Ok data ->
           (match discord_require_shape mode data with
-           | Error message -> discord_tool_error ~code:Tool_args.Internal_error message
-           | Ok () -> discord_success ~resource ~channel_id ?guild_id data)
+           | Error message ->
+             Log.Keeper.warn
+               ~keeper_name:meta.name
+               "discord_surface_read invalid response mode=%s resource=%s channel=%s: %s"
+               (surface_read_mode_label mode)
+               resource
+               channel_id
+               message;
+             discord_tool_error ~code:Tool_args.Internal_error message
+           | Ok () ->
+             Log.Keeper.info
+               ~keeper_name:meta.name
+               "discord_surface_read mode=%s resource=%s channel=%s guild=%s count=%s"
+               (surface_read_mode_label mode)
+               resource
+               channel_id
+               (Option.value ~default:"-" guild_id)
+               (match discord_result_count data with
+                | Some count -> string_of_int count
+                | None -> "-");
+             discord_success ~mode ~resource ~channel_id ?guild_id data)
       in
       match mode with
       | Local_lane ->
@@ -503,7 +550,14 @@ let handle_discord_surface_read ~meta ~args ~mode =
                  "messages")
       | Discord_members | Discord_member ->
         (match Discord_rest_client.get_channel ?clock ~token ~channel_id () with
-         | Error error -> discord_rest_error error
+        | Error error ->
+          Log.Keeper.warn
+            ~keeper_name:meta.name
+            "discord_surface_read failed mode=%s resource=channel channel=%s: %s"
+            (surface_read_mode_label mode)
+            channel_id
+            (Format.asprintf "%a" Discord_rest_client.pp_error error);
+          discord_rest_error error
          | Ok channel ->
            (match discord_object_field_string "guild_id" channel with
             | Error message -> discord_tool_error ~code:Tool_args.Not_found message

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -335,7 +335,7 @@ let surface_read_mode_of_args args =
   | Error message -> Error message
   | Ok None -> Ok Local_lane
   | Ok (Some raw) ->
-    (match String.trim raw with
+    (match raw with
      | "local" -> Ok Local_lane
      | "channel" -> Ok Discord_channel
      | "messages" -> Ok Discord_messages
@@ -353,7 +353,7 @@ let strict_string_opt key args =
   | `Assoc fields ->
     (match List.assoc_opt key fields with
      | None -> Ok None
-     | Some (`String value) -> Ok (Some (String.trim value))
+     | Some (`String value) -> Ok (Some value)
      | Some _ -> Error (Printf.sprintf "%s must be a string" key))
   | _ -> Error "tool arguments must be a JSON object"
 ;;
@@ -423,24 +423,85 @@ let discord_token () =
   | Some _ | None -> Error "DISCORD_BOT_TOKEN is unset or empty"
 ;;
 
+let discord_snowflake ~field value =
+  match Discord_rest_client.snowflake_of_string value with
+  | Ok value -> Ok value
+  | Error message -> Error (Printf.sprintf "%s: %s" field message)
+
+let discord_optional_snowflake ~field = function
+  | None -> Ok None
+  | Some value ->
+    (match discord_snowflake ~field value with
+     | Ok value -> Ok (Some value)
+     | Error message -> Error message)
+
 let discord_object_field_string key = function
   | `Assoc fields ->
     (match List.assoc_opt key fields with
-     | Some (`String value) when String.trim value <> "" -> Ok (String.trim value)
+     | Some (`String value) when value <> "" -> Ok value
      | Some `Null | None -> Error (Printf.sprintf "Discord response has no %s" key)
      | Some _ -> Error (Printf.sprintf "Discord response field %s is not a string" key))
   | _ -> Error "Discord channel response is not an object"
 ;;
 
+let discord_required_snowflake_field ~field key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) -> discord_snowflake ~field value
+     | Some _ ->
+       Error (Printf.sprintf "Discord response field %s is not a string" key)
+     | None -> Error (Printf.sprintf "Discord response has no %s" key))
+  | _ -> Error "Discord response item is not an object"
+
+let discord_member_user_id json =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "user" fields with
+     | Some (`Assoc user_fields) ->
+       (match List.assoc_opt "id" user_fields with
+        | Some (`String value) -> discord_snowflake ~field:"user.id" value
+        | Some _ -> Error "Discord member user.id is not a string"
+        | None -> Error "Discord member user has no id")
+     | Some _ -> Error "Discord member user is not an object"
+     | None -> Error "Discord member has no user")
+  | _ -> Error "Discord member response item is not an object"
+
+let discord_require_items ~kind validate = function
+  | `List items ->
+    let rec loop index = function
+      | [] -> Ok ()
+      | item :: rest ->
+        (match validate item with
+         | Ok _ -> loop (index + 1) rest
+         | Error message ->
+           Error (Printf.sprintf "Discord %s item %d: %s" kind index message))
+    in
+    loop 0 items
+  | _ -> Error (Printf.sprintf "Discord %s response is not an array" kind)
+
 let discord_require_shape mode json =
-  match mode, json with
-  | (Discord_channel | Discord_member), `Assoc _ -> Ok ()
-  | (Discord_messages | Discord_members), `List _ -> Ok ()
-  | Discord_channel, _ -> Error "Discord channel response is not an object"
-  | Discord_member, _ -> Error "Discord member response is not an object"
-  | Discord_messages, _ -> Error "Discord messages response is not an array"
-  | Discord_members, _ -> Error "Discord members response is not an array"
-  | Local_lane, _ -> Ok ()
+  match mode with
+  | Discord_channel ->
+    (match json with
+     | `Assoc _ ->
+       (match discord_required_snowflake_field ~field:"id" "id" json with
+        | Ok _ -> Ok ()
+        | Error message -> Error ("Discord channel response: " ^ message))
+     | _ -> Error "Discord channel response is not an object")
+  | Discord_member ->
+    (match json with
+     | `Assoc _ ->
+       (match discord_member_user_id json with
+        | Ok _ -> Ok ()
+        | Error message -> Error ("Discord member response: " ^ message))
+     | _ -> Error "Discord member response is not an object")
+  | Discord_messages ->
+    discord_require_items ~kind:"message"
+      (fun item -> discord_required_snowflake_field ~field:"id" "id" item)
+      json
+  | Discord_members ->
+    discord_require_items ~kind:"member" discord_member_user_id json
+  | Local_lane -> Ok ()
 ;;
 
 let surface_read_mode_label = function
@@ -457,16 +518,20 @@ let discord_result_count (data : Yojson.Safe.t) =
   | `Assoc _ | `Null | `Bool _ | `Float _ | `Int _ | `Intlit _ | `String _ -> None
 ;;
 
-let discord_success ~mode ~resource ~channel_id ?guild_id
+let discord_success ~mode ~resource ~(channel_id : Discord_rest_client.snowflake)
+    ?guild_id
     (data : Yojson.Safe.t) =
   let fields : (string * Yojson.Safe.t) list =
     [ "mode", `String (surface_read_mode_label mode)
     ; "resource", `String resource
     ; "scope", `String "bound_channel"
-    ; "channel_id", `String channel_id
+    ; "channel_id", `String (Discord_rest_client.snowflake_to_string channel_id)
     ; "data", data
     ]
-    @ match guild_id with Some id -> [ "guild_id", `String id ] | None -> []
+    @ match guild_id with
+      | Some id ->
+        [ "guild_id", `String (Discord_rest_client.snowflake_to_string id) ]
+      | None -> []
     @ match discord_result_count data with
       | Some count -> [ "data_count", `Int count ]
       | None -> []
@@ -477,133 +542,193 @@ let discord_success ~mode ~resource ~channel_id ?guild_id
 let handle_discord_surface_read ~meta ~args ~mode =
   match strict_string_opt "surface" args with
   | Error message -> discord_tool_error ~code:Tool_args.Validation_error message
-  | Ok (Some surface) when String.equal surface "discord" ->
+  | Ok (Some "discord") ->
     (match discord_bound_channel ~meta ~args, discord_token () with
-    | Error message, _ -> discord_tool_error ~code:Tool_args.Precondition_failed message
-    | _, Error message -> discord_tool_error ~code:Tool_args.Auth_required message
-    | Ok channel_id, Ok token ->
-      let clock = Eio_context.get_clock_opt () in
-      let rest ?guild_id call resource =
-        match call () with
-        | Error error ->
-          Log.Keeper.warn
-            ~keeper_name:meta.name
-            "discord_surface_read failed mode=%s resource=%s channel=%s: %s"
-            (surface_read_mode_label mode)
-            resource
-            channel_id
-            (Format.asprintf "%a" Discord_rest_client.pp_error error);
-          discord_rest_error error
-        | Ok data ->
-          (match discord_require_shape mode data with
-           | Error message ->
-             Log.Keeper.warn
-               ~keeper_name:meta.name
-               "discord_surface_read invalid response mode=%s resource=%s channel=%s: %s"
-               (surface_read_mode_label mode)
-               resource
-               channel_id
-               message;
-             discord_tool_error ~code:Tool_args.Internal_error message
-           | Ok () ->
-             Log.Keeper.info
-               ~keeper_name:meta.name
-               "discord_surface_read mode=%s resource=%s channel=%s guild=%s count=%s"
-               (surface_read_mode_label mode)
-               resource
-               channel_id
-               (Option.value ~default:"-" guild_id)
-               (match discord_result_count data with
-                | Some count -> string_of_int count
-                | None -> "-");
-             discord_success ~mode ~resource ~channel_id ?guild_id data)
-      in
-      match mode with
-      | Local_lane ->
-        discord_tool_error ~code:Tool_args.Internal_error "invalid Discord read mode"
-      | Discord_channel ->
-        rest
-          (fun () -> Discord_rest_client.get_channel ?clock ~token ~channel_id ())
-          "channel"
-      | Discord_messages ->
-        (match strict_int_opt "limit" args, strict_string_opt "discord_before" args,
-               strict_string_opt "discord_after" args with
-         | Error message, _, _
-         | _, Error message, _
-         | _, _, Error message -> discord_tool_error ~code:Tool_args.Validation_error message
-         | Ok limit, Ok before, Ok after ->
-           if Option.is_some before && Option.is_some after then
-             discord_tool_error
-               ~code:Tool_args.Validation_error
-               "discord_before and discord_after are mutually exclusive"
-           else
-             let limit = Option.value ~default:20 limit in
-             if limit < 1 || limit > 100 then
-               discord_tool_error
-                 ~code:Tool_args.Validation_error
-                 "limit for Discord messages must be between 1 and 100"
-             else
-               rest
-                 (fun () ->
-                    Discord_rest_client.get_channel_messages
-                      ?clock ~token ~channel_id ~limit ?before ?after ())
-                 "messages")
-      | Discord_members | Discord_member ->
-        (match Discord_rest_client.get_channel ?clock ~token ~channel_id () with
-        | Error error ->
-          Log.Keeper.warn
-            ~keeper_name:meta.name
-            "discord_surface_read failed mode=%s resource=channel channel=%s: %s"
-            (surface_read_mode_label mode)
-            channel_id
-            (Format.asprintf "%a" Discord_rest_client.pp_error error);
-          discord_rest_error error
-         | Ok channel ->
-           (match discord_object_field_string "guild_id" channel with
-            | Error message -> discord_tool_error ~code:Tool_args.Not_found message
-            | Ok guild_id ->
-              match mode with
-              | Discord_members ->
-                (match strict_string_opt "query" args, strict_int_opt "limit" args,
-                       strict_string_opt "discord_after" args with
-                 | Error message, _, _
-                 | _, Error message, _
-                 | _, _, Error message ->
-                   discord_tool_error ~code:Tool_args.Validation_error message
-                 | Ok query, Ok limit, Ok after ->
-                   if Option.is_some query && Option.is_some after then
-                     discord_tool_error
-                       ~code:Tool_args.Validation_error
-                       "discord_after cannot be combined with a member search query"
-                   else
-                   let limit = Option.value ~default:25 limit in
-                   if limit < 1 || limit > 1000 then
-                     discord_tool_error
-                       ~code:Tool_args.Validation_error
-                       "limit for Discord members must be between 1 and 1000"
-                   else
-                     rest
-                       (fun () ->
-                          Discord_rest_client.get_guild_members
-                            ?clock ~token ~guild_id ?query ~limit ?after ())
-                       ~guild_id
-                       "members")
-              | Discord_member ->
-                (match strict_string_opt "user_id" args with
-                 | Error message -> discord_tool_error ~code:Tool_args.Validation_error message
-                 | Ok None | Ok (Some "") ->
-                   discord_tool_error
-                     ~code:Tool_args.Validation_error
-                     "user_id is required for mode='member'"
-                 | Ok (Some user_id) ->
-                   rest
-                     (fun () ->
-                        Discord_rest_client.get_guild_member
-                          ?clock ~token ~guild_id ~user_id ())
-                     ~guild_id
-                     "member")
-              | Local_lane | Discord_channel | Discord_messages ->
-                discord_tool_error ~code:Tool_args.Internal_error "invalid Discord read mode")))
+     | Error message, _ ->
+       discord_tool_error ~code:Tool_args.Precondition_failed message
+     | _, Error message -> discord_tool_error ~code:Tool_args.Auth_required message
+     | Ok raw_channel_id, Ok token ->
+       (match discord_snowflake ~field:"channel_id" raw_channel_id with
+        | Error message ->
+          discord_tool_error ~code:Tool_args.Precondition_failed message
+        | Ok channel_id ->
+          let clock = Eio_context.get_clock_opt () in
+          let rest ?guild_id call resource =
+            match call () with
+            | Error error ->
+              Log.Keeper.warn
+                ~keeper_name:meta.name
+                "discord_surface_read failed mode=%s resource=%s channel=%s: %s"
+                (surface_read_mode_label mode)
+                resource
+                (Discord_rest_client.snowflake_to_string channel_id)
+                (Format.asprintf "%a" Discord_rest_client.pp_error error);
+              discord_rest_error error
+            | Ok data ->
+              (match discord_require_shape mode data with
+               | Error message ->
+                 Log.Keeper.warn
+                   ~keeper_name:meta.name
+                   "discord_surface_read invalid response mode=%s resource=%s channel=%s: %s"
+                   (surface_read_mode_label mode)
+                   resource
+                   (Discord_rest_client.snowflake_to_string channel_id)
+                   message;
+                 discord_tool_error ~code:Tool_args.Internal_error message
+               | Ok () ->
+                 Log.Keeper.info
+                   ~keeper_name:meta.name
+                   "discord_surface_read mode=%s resource=%s channel=%s guild=%s count=%s"
+                   (surface_read_mode_label mode)
+                   resource
+                   (Discord_rest_client.snowflake_to_string channel_id)
+                   (match guild_id with
+                    | Some value -> Discord_rest_client.snowflake_to_string value
+                    | None -> "-")
+                   (match discord_result_count data with
+                    | Some count -> string_of_int count
+                    | None -> "-");
+                 discord_success ~mode ~resource ~channel_id ?guild_id data)
+          in
+          match mode with
+          | Local_lane ->
+            discord_tool_error ~code:Tool_args.Internal_error
+              "invalid Discord read mode"
+          | Discord_channel ->
+            rest
+              (fun () ->
+                 Discord_rest_client.get_channel ?clock ~token ~channel_id ())
+              "channel"
+          | Discord_messages ->
+            (match
+               strict_int_opt "limit" args,
+               strict_string_opt "discord_before" args,
+               strict_string_opt "discord_after" args
+             with
+             | Error message, _, _
+             | _, Error message, _
+             | _, _, Error message ->
+               discord_tool_error ~code:Tool_args.Validation_error message
+             | Ok limit, Ok before_raw, Ok after_raw ->
+               if Option.is_some before_raw && Option.is_some after_raw then
+                 discord_tool_error
+                   ~code:Tool_args.Validation_error
+                   "discord_before and discord_after are mutually exclusive"
+               else
+                 (match
+                    discord_optional_snowflake ~field:"discord_before" before_raw,
+                    discord_optional_snowflake ~field:"discord_after" after_raw
+                  with
+                  | Error message, _ | _, Error message ->
+                    discord_tool_error ~code:Tool_args.Validation_error message
+                  | Ok before, Ok after ->
+                    let limit =
+                      match limit with
+                      | Some value -> value
+                      | None -> Keeper_surface_read.default_limit
+                    in
+                    if limit < 1 || limit > 100 then
+                      discord_tool_error
+                        ~code:Tool_args.Validation_error
+                        "limit for Discord messages must be between 1 and 100"
+                    else
+                      rest
+                        (fun () ->
+                           Discord_rest_client.get_channel_messages
+                             ?clock ~token ~channel_id ~limit ?before ?after ())
+                        "messages"))
+          | Discord_members | Discord_member ->
+            (match
+               Discord_rest_client.get_channel ?clock ~token ~channel_id ()
+             with
+             | Error error ->
+               Log.Keeper.warn
+                 ~keeper_name:meta.name
+                 "discord_surface_read failed mode=%s resource=channel channel=%s: %s"
+                 (surface_read_mode_label mode)
+                 (Discord_rest_client.snowflake_to_string channel_id)
+                 (Format.asprintf "%a" Discord_rest_client.pp_error error);
+               discord_rest_error error
+             | Ok channel ->
+               (match discord_object_field_string "guild_id" channel with
+                | Error message ->
+                  discord_tool_error ~code:Tool_args.Not_found message
+                | Ok raw_guild_id ->
+                  (match discord_snowflake ~field:"guild_id" raw_guild_id with
+                   | Error message ->
+                     discord_tool_error ~code:Tool_args.Internal_error message
+                   | Ok guild_id ->
+                     match mode with
+                     | Discord_members ->
+                       (match
+                          strict_string_opt "query" args,
+                          strict_int_opt "limit" args,
+                          strict_string_opt "discord_after" args
+                        with
+                        | Error message, _, _
+                        | _, Error message, _
+                        | _, _, Error message ->
+                          discord_tool_error ~code:Tool_args.Validation_error message
+                        | Ok query, Ok limit, Ok after_raw ->
+                          let searching =
+                            match query with
+                            | Some value -> value <> ""
+                            | None -> false
+                          in
+                          if searching && Option.is_some after_raw then
+                            discord_tool_error
+                              ~code:Tool_args.Validation_error
+                              "discord_after cannot be combined with a member search query"
+                          else
+                            (match
+                               discord_optional_snowflake
+                                 ~field:"discord_after" after_raw
+                             with
+                             | Error message ->
+                               discord_tool_error
+                                 ~code:Tool_args.Validation_error message
+                             | Ok after ->
+                               let limit =
+                                 match limit with
+                                 | Some value -> value
+                                 | None -> Keeper_surface_read.default_limit
+                               in
+                               if limit < 1 || limit > 1000 then
+                                 discord_tool_error
+                                   ~code:Tool_args.Validation_error
+                                   "limit for Discord members must be between 1 and 1000"
+                               else
+                                 rest
+                                   (fun () ->
+                                      Discord_rest_client.get_guild_members
+                                        ?clock ~token ~guild_id ?query ~limit
+                                        ?after ())
+                                   ~guild_id
+                                   "members"))
+                     | Discord_member ->
+                       (match strict_string_opt "user_id" args with
+                        | Error message ->
+                          discord_tool_error
+                            ~code:Tool_args.Validation_error message
+                        | Ok None | Ok (Some "") ->
+                          discord_tool_error
+                            ~code:Tool_args.Validation_error
+                            "user_id is required for mode='member'"
+                        | Ok (Some user_id) ->
+                          (match discord_snowflake ~field:"user_id" user_id with
+                           | Error message ->
+                             discord_tool_error
+                               ~code:Tool_args.Validation_error message
+                           | Ok user_id ->
+                             rest
+                               (fun () ->
+                                  Discord_rest_client.get_guild_member
+                                    ?clock ~token ~guild_id ~user_id ())
+                               ~guild_id
+                               "member"))
+                     | Local_lane | Discord_channel | Discord_messages ->
+                       discord_tool_error ~code:Tool_args.Internal_error
+                         "invalid Discord read mode")))))
   | Ok _ ->
     discord_tool_error
       ~code:Tool_args.Validation_error

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -7,6 +7,8 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
+module String_set = Set.Make (String)
+
 let handle_time_now ~args:_ =
   let now_unix = Time_compat.now () in
   let now_iso = Masc_domain.now_iso () in
@@ -435,35 +437,78 @@ let discord_optional_snowflake ~field = function
      | Ok value -> Ok (Some value)
      | Error message -> Error message)
 
+let discord_validate_unique_fields ~context fields =
+  let rec loop seen = function
+    | [] -> Ok ()
+    | (key, _) :: rest ->
+      if String_set.mem key seen then
+        Error (Printf.sprintf "%s contains duplicate field %S" context key)
+      else loop (String_set.add key seen) rest
+  in
+  loop String_set.empty fields
+
+let discord_validate_unique_object ~context = function
+  | `Assoc fields -> discord_validate_unique_fields ~context fields
+  | _ -> Error (Printf.sprintf "%s is not an object" context)
+;;
+
 let discord_object_field_string key = function
   | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`String value) when value <> "" -> Ok value
-     | Some `Null | None -> Error (Printf.sprintf "Discord response has no %s" key)
-     | Some _ -> Error (Printf.sprintf "Discord response field %s is not a string" key))
+    (match
+       discord_validate_unique_fields ~context:"Discord response object" fields
+     with
+     | Error message -> Error message
+     | Ok () ->
+       (match List.assoc_opt key fields with
+        | Some (`String value) when value <> "" -> Ok value
+        | Some `Null | None ->
+          Error (Printf.sprintf "Discord response has no %s" key)
+        | Some _ ->
+          Error (Printf.sprintf "Discord response field %s is not a string" key)))
   | _ -> Error "Discord channel response is not an object"
 ;;
 
 let discord_required_snowflake_field ~field key = function
   | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`String value) -> discord_snowflake ~field value
-     | Some _ ->
-       Error (Printf.sprintf "Discord response field %s is not a string" key)
-     | None -> Error (Printf.sprintf "Discord response has no %s" key))
+    (match
+       discord_validate_unique_fields ~context:"Discord response object" fields
+     with
+     | Error message -> Error message
+     | Ok () ->
+       (match List.assoc_opt key fields with
+        | Some (`String value) -> discord_snowflake ~field value
+        | Some _ ->
+          Error (Printf.sprintf "Discord response field %s is not a string" key)
+        | None -> Error (Printf.sprintf "Discord response has no %s" key)))
   | _ -> Error "Discord response item is not an object"
+
+let discord_channel_guild_id json =
+  match discord_required_snowflake_field ~field:"id" "id" json with
+  | Error message -> Error ("Discord channel response: " ^ message)
+  | Ok _ -> discord_object_field_string "guild_id" json
 
 let discord_member_user_id json =
   match json with
   | `Assoc fields ->
-    (match List.assoc_opt "user" fields with
-     | Some (`Assoc user_fields) ->
-       (match List.assoc_opt "id" user_fields with
-        | Some (`String value) -> discord_snowflake ~field:"user.id" value
-        | Some _ -> Error "Discord member user.id is not a string"
-        | None -> Error "Discord member user has no id")
-     | Some _ -> Error "Discord member user is not an object"
-     | None -> Error "Discord member has no user")
+    (match
+       discord_validate_unique_fields ~context:"Discord member object" fields
+     with
+     | Error message -> Error message
+     | Ok () ->
+       (match List.assoc_opt "user" fields with
+        | Some (`Assoc user_fields) ->
+          (match
+             discord_validate_unique_fields
+               ~context:"Discord member user object" user_fields
+           with
+           | Error message -> Error message
+           | Ok () ->
+             (match List.assoc_opt "id" user_fields with
+              | Some (`String value) -> discord_snowflake ~field:"user.id" value
+              | Some _ -> Error "Discord member user.id is not a string"
+              | None -> Error "Discord member user has no id"))
+        | Some _ -> Error "Discord member user is not an object"
+        | None -> Error "Discord member has no user"))
   | _ -> Error "Discord member response item is not an object"
 
 let discord_require_items ~kind validate = function
@@ -650,7 +695,7 @@ let handle_discord_surface_read ~meta ~args ~mode =
                  (Format.asprintf "%a" Discord_rest_client.pp_error error);
                discord_rest_error error
              | Ok channel ->
-               (match discord_object_field_string "guild_id" channel with
+               (match discord_channel_guild_id channel with
                 | Error message ->
                   discord_tool_error ~code:Tool_args.Not_found message
                 | Ok raw_guild_id ->
@@ -736,32 +781,37 @@ let handle_discord_surface_read ~meta ~args ~mode =
 ;;
 
 let handle_surface_read ~config ~(meta : keeper_meta) ~args =
-  match surface_read_mode_of_args args with
+  match
+    discord_validate_unique_object ~context:"keeper_surface_read arguments" args
+  with
   | Error message -> discord_tool_error ~code:Tool_args.Validation_error message
-  | Ok (Discord_channel | Discord_messages | Discord_members | Discord_member as mode) ->
-    handle_discord_surface_read ~meta ~args ~mode
-  | Ok Local_lane ->
-  let surface = Safe_ops.json_string ~default:"" "surface" args in
-  let limit =
-    Safe_ops.json_int ~default:Keeper_surface_read.default_limit "limit" args
-  in
-  let before = Safe_ops.json_float_opt "before" args in
-  let page =
-    Keeper_chat_store.load_page
-      ~base_dir:config.Workspace.base_path
-      ~keeper_name:meta.name
-      ?before
-      ()
-  in
-  let notes =
-    Keeper_person_notes.notes
-      ~base_dir:config.Workspace.base_path
-      ~keeper_name:meta.name
-  in
-  Keeper_surface_read.respond ~surface ~limit
-    ~has_more:page.Keeper_chat_store.has_more
-    ~notes
-    page.Keeper_chat_store.messages
+  | Ok () ->
+    (match surface_read_mode_of_args args with
+     | Error message -> discord_tool_error ~code:Tool_args.Validation_error message
+     | Ok (Discord_channel | Discord_messages | Discord_members | Discord_member as mode) ->
+       handle_discord_surface_read ~meta ~args ~mode
+     | Ok Local_lane ->
+       let surface = Safe_ops.json_string ~default:"" "surface" args in
+       let limit =
+         Safe_ops.json_int ~default:Keeper_surface_read.default_limit "limit" args
+       in
+       let before = Safe_ops.json_float_opt "before" args in
+       let page =
+         Keeper_chat_store.load_page
+           ~base_dir:config.Workspace.base_path
+           ~keeper_name:meta.name
+           ?before
+           ()
+       in
+       let notes =
+         Keeper_person_notes.notes
+           ~base_dir:config.Workspace.base_path
+           ~keeper_name:meta.name
+       in
+       Keeper_surface_read.respond ~surface ~limit
+         ~has_more:page.Keeper_chat_store.has_more
+         ~notes
+         page.Keeper_chat_store.messages)
 ;;
 
 let handle_person_note_set_with_outcome ~config ~(meta : keeper_meta) ~args =

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -903,6 +903,25 @@ let handle_surface_post_with_outcome
   in
   let surface = String.trim (Safe_ops.json_string ~default:"" "surface" args) in
   let content = Safe_ops.json_string ~default:"" "content" args in
+  let continuation_channel =
+    Option.map
+      (fun channel ->
+         match channel with
+         | Keeper_continuation_channel.Discord
+             { channel_id; parent_channel_id = None; thread_id = None; _ } ->
+           (match
+              Channel_gate_discord_state.parent_channel_of_thread ~channel_id
+            with
+            | Some parent_channel_id ->
+              Keeper_continuation_channel.discord_thread_parent channel
+                ~parent_channel_id
+            | None -> channel)
+         | Keeper_continuation_channel.Discord _
+         | Keeper_continuation_channel.Dashboard _
+         | Keeper_continuation_channel.Slack _
+         | Keeper_continuation_channel.Unrouted _ -> channel)
+      continuation_channel
+  in
   let redaction =
     Keeper_secret_redaction.snapshot
       ~base_path:config.Workspace.base_path

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -314,7 +314,254 @@ let handle_library_read_with_outcome ~(meta : keeper_meta) ~args =
        args)
 ;;
 
+type surface_read_mode =
+  | Local_lane
+  | Discord_channel
+  | Discord_messages
+  | Discord_members
+  | Discord_member
+
+let surface_read_mode_of_args args =
+  let raw_mode =
+    match args with
+    | `Assoc fields ->
+      (match List.assoc_opt "mode" fields with
+       | None -> Ok None
+       | Some (`String value) -> Ok (Some value)
+       | Some _ -> Error "mode must be a string")
+    | _ -> Error "tool arguments must be a JSON object"
+  in
+  match raw_mode with
+  | Error message -> Error message
+  | Ok None -> Ok Local_lane
+  | Ok (Some raw) ->
+    (match String.trim raw with
+     | "local" -> Ok Local_lane
+     | "channel" -> Ok Discord_channel
+     | "messages" -> Ok Discord_messages
+     | "members" -> Ok Discord_members
+     | "member" -> Ok Discord_member
+     | other ->
+       Error
+         (Printf.sprintf
+            "mode %S is invalid; expected local, channel, messages, members, or member"
+            other))
+;;
+
+let strict_string_opt key args =
+  match args with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | None -> Ok None
+     | Some (`String value) -> Ok (Some (String.trim value))
+     | Some _ -> Error (Printf.sprintf "%s must be a string" key))
+  | _ -> Error "tool arguments must be a JSON object"
+;;
+
+let strict_int_opt key args =
+  match args with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | None -> Ok None
+     | Some (`Int value) -> Ok (Some value)
+     | Some _ -> Error (Printf.sprintf "%s must be an integer" key))
+  | _ -> Error "tool arguments must be a JSON object"
+;;
+
+let discord_tool_error ~code message =
+  Tool_args.error_response_typed ~code message
+;;
+
+let discord_rest_error error =
+  discord_tool_error
+    ~code:Tool_args.Internal_error
+    (Format.asprintf "Discord read failed: %a" Discord_rest_client.pp_error error)
+;;
+
+let discord_bound_channel ~meta ~args =
+  let requested = strict_string_opt "channel_id" args in
+  match requested with
+  | Error message -> Error message
+  | Ok requested ->
+    (match
+       Channel_gate_discord_state.bound_channels_result ~keeper_name:meta.name
+     with
+     | Error detail ->
+       Error (Channel_gate_discord_state.binding_lookup_error_to_string detail)
+     | Ok bound_channels ->
+       let allowed channel_id =
+         List.mem channel_id bound_channels
+         ||
+         match Channel_gate_discord_state.parent_channel_of_thread ~channel_id with
+         | Some parent -> List.mem parent bound_channels
+         | None -> false
+       in
+       match requested with
+       | Some channel_id when channel_id <> "" ->
+         if allowed channel_id then Ok channel_id
+         else
+           Error
+             (Printf.sprintf
+                "channel_id %S is not bound to keeper %s"
+                channel_id meta.name)
+       | Some _ -> Error "channel_id must not be empty"
+       | None ->
+         (match bound_channels with
+          | [ channel_id ] -> Ok channel_id
+          | [] -> Error "this keeper has no bound Discord channel"
+          | channels ->
+            Error
+              (Printf.sprintf
+                 "channel_id is required; this keeper has %d bound Discord channels: %s"
+                 (List.length channels)
+                 (String.concat ", " channels))))
+;;
+
+let discord_token () =
+  match Sys.getenv_opt "DISCORD_BOT_TOKEN" with
+  | Some token when String.trim token <> "" -> Ok token
+  | Some _ | None -> Error "DISCORD_BOT_TOKEN is unset or empty"
+;;
+
+let discord_object_field_string key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) when String.trim value <> "" -> Ok (String.trim value)
+     | Some `Null | None -> Error (Printf.sprintf "Discord response has no %s" key)
+     | Some _ -> Error (Printf.sprintf "Discord response field %s is not a string" key))
+  | _ -> Error "Discord channel response is not an object"
+;;
+
+let discord_require_shape mode json =
+  match mode, json with
+  | (Discord_channel | Discord_member), `Assoc _ -> Ok ()
+  | (Discord_messages | Discord_members), `List _ -> Ok ()
+  | Discord_channel, _ -> Error "Discord channel response is not an object"
+  | Discord_member, _ -> Error "Discord member response is not an object"
+  | Discord_messages, _ -> Error "Discord messages response is not an array"
+  | Discord_members, _ -> Error "Discord members response is not an array"
+  | Local_lane, _ -> Ok ()
+;;
+
+let discord_success ~resource ~channel_id ?guild_id data =
+  let fields =
+    [ "resource", `String resource
+    ; "channel_id", `String channel_id
+    ; "data", data
+    ]
+    @ match guild_id with Some id -> [ "guild_id", `String id ] | None -> []
+  in
+  Yojson.Safe.to_string (Tool_args.ok_assoc fields)
+;;
+
+let handle_discord_surface_read ~meta ~args ~mode =
+  match strict_string_opt "surface" args with
+  | Error message -> discord_tool_error ~code:Tool_args.Validation_error message
+  | Ok (Some surface) when String.equal surface "discord" ->
+    (match discord_bound_channel ~meta ~args, discord_token () with
+    | Error message, _ -> discord_tool_error ~code:Tool_args.Precondition_failed message
+    | _, Error message -> discord_tool_error ~code:Tool_args.Auth_required message
+    | Ok channel_id, Ok token ->
+      let clock = Eio_context.get_clock_opt () in
+      let rest ?guild_id call resource =
+        match call () with
+        | Error error -> discord_rest_error error
+        | Ok data ->
+          (match discord_require_shape mode data with
+           | Error message -> discord_tool_error ~code:Tool_args.Internal_error message
+           | Ok () -> discord_success ~resource ~channel_id ?guild_id data)
+      in
+      match mode with
+      | Local_lane ->
+        discord_tool_error ~code:Tool_args.Internal_error "invalid Discord read mode"
+      | Discord_channel ->
+        rest
+          (fun () -> Discord_rest_client.get_channel ?clock ~token ~channel_id ())
+          "channel"
+      | Discord_messages ->
+        (match strict_int_opt "limit" args, strict_string_opt "discord_before" args,
+               strict_string_opt "discord_after" args with
+         | Error message, _, _
+         | _, Error message, _
+         | _, _, Error message -> discord_tool_error ~code:Tool_args.Validation_error message
+         | Ok limit, Ok before, Ok after ->
+           if Option.is_some before && Option.is_some after then
+             discord_tool_error
+               ~code:Tool_args.Validation_error
+               "discord_before and discord_after are mutually exclusive"
+           else
+             let limit = Option.value ~default:20 limit in
+             if limit < 1 || limit > 100 then
+               discord_tool_error
+                 ~code:Tool_args.Validation_error
+                 "limit for Discord messages must be between 1 and 100"
+             else
+               rest
+                 (fun () ->
+                    Discord_rest_client.get_channel_messages
+                      ?clock ~token ~channel_id ~limit ?before ?after ())
+                 "messages")
+      | Discord_members | Discord_member ->
+        (match Discord_rest_client.get_channel ?clock ~token ~channel_id () with
+         | Error error -> discord_rest_error error
+         | Ok channel ->
+           (match discord_object_field_string "guild_id" channel with
+            | Error message -> discord_tool_error ~code:Tool_args.Not_found message
+            | Ok guild_id ->
+              match mode with
+              | Discord_members ->
+                (match strict_string_opt "query" args, strict_int_opt "limit" args,
+                       strict_string_opt "discord_after" args with
+                 | Error message, _, _
+                 | _, Error message, _
+                 | _, _, Error message ->
+                   discord_tool_error ~code:Tool_args.Validation_error message
+                 | Ok query, Ok limit, Ok after ->
+                   if Option.is_some query && Option.is_some after then
+                     discord_tool_error
+                       ~code:Tool_args.Validation_error
+                       "discord_after cannot be combined with a member search query"
+                   else
+                   let limit = Option.value ~default:25 limit in
+                   if limit < 1 || limit > 1000 then
+                     discord_tool_error
+                       ~code:Tool_args.Validation_error
+                       "limit for Discord members must be between 1 and 1000"
+                   else
+                     rest
+                       (fun () ->
+                          Discord_rest_client.get_guild_members
+                            ?clock ~token ~guild_id ?query ~limit ?after ())
+                       ~guild_id
+                       "members")
+              | Discord_member ->
+                (match strict_string_opt "user_id" args with
+                 | Error message -> discord_tool_error ~code:Tool_args.Validation_error message
+                 | Ok None | Ok (Some "") ->
+                   discord_tool_error
+                     ~code:Tool_args.Validation_error
+                     "user_id is required for mode='member'"
+                 | Ok (Some user_id) ->
+                   rest
+                     (fun () ->
+                        Discord_rest_client.get_guild_member
+                          ?clock ~token ~guild_id ~user_id ())
+                     ~guild_id
+                     "member")
+              | Local_lane | Discord_channel | Discord_messages ->
+                discord_tool_error ~code:Tool_args.Internal_error "invalid Discord read mode")))
+  | Ok _ ->
+    discord_tool_error
+      ~code:Tool_args.Validation_error
+      "Discord live read modes require surface='discord'"
+;;
+
 let handle_surface_read ~config ~(meta : keeper_meta) ~args =
+  match surface_read_mode_of_args args with
+  | Error message -> discord_tool_error ~code:Tool_args.Validation_error message
+  | Ok (Discord_channel | Discord_messages | Discord_members | Discord_member as mode) ->
+    handle_discord_surface_read ~meta ~args ~mode
+  | Ok Local_lane ->
   let surface = Safe_ops.json_string ~default:"" "surface" args in
   let limit =
     Safe_ops.json_int ~default:Keeper_surface_read.default_limit "limit" args

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -198,6 +198,7 @@ let run (ctx : ctx)
                  ~meta:run_meta
                  ~publication_recovery
                  ~profile_defaults
+                 ?continuation_channel:continuation_delivery_channel
                  ?continuation_delivery_channel
                  ?hitl_resolution
                  ~turn_ctx_cell

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -46,6 +46,19 @@ let discord ~guild_id ~channel_id ~parent_channel_id ~thread_id ~user_id =
   Ok (Discord { guild_id; channel_id; parent_channel_id; thread_id; user_id })
 ;;
 
+let discord_thread_parent t ~parent_channel_id =
+  match t with
+  | Discord { guild_id; channel_id; user_id; _ } ->
+    Discord
+      { guild_id
+      ; channel_id
+      ; parent_channel_id = Some parent_channel_id
+      ; thread_id = Some channel_id
+      ; user_id
+      }
+  | Dashboard _ | Slack _ | Unrouted _ -> t
+;;
+
 let slack ~team_id ~channel_id ~thread_ts ~user_id =
   let* team_id = validate_optional_nonblank "team_id" team_id in
   let* channel_id = validate_nonblank "channel_id" channel_id in

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -41,6 +41,11 @@ val discord :
   user_id:string ->
   (t, string) result
 
+(** [discord_thread_parent channel ~parent_channel_id] preserves a Discord
+    continuation's concrete channel and marks it as a thread whose parent is
+    [parent_channel_id]. Other connector continuations are unchanged. *)
+val discord_thread_parent : t -> parent_channel_id:string -> t
+
 val slack :
   team_id:string option ->
   channel_id:string ->

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -15,11 +15,9 @@ let surface_tools : Masc_domain.tool_schema list =
     ; description =
         "Read recent messages from one conversation endpoint (dashboard, \
          discord, slack, or another connector label) with speaker identity \
-         and a derived participant roster. Use when the user asks about a \
-         current connector lane, recent lane messages, or participants. This \
-         does not enumerate connector-wide channel registries; if asked for \
-         channels outside Connected Surfaces, read only visible lane evidence \
-         and state that the wider registry is unavailable."
+         and a derived participant roster. With mode='channel', 'messages', \
+         'members', or 'member', the Discord lane can also query its live \
+         channel and server read surface within the keeper's bound channels."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -53,6 +51,45 @@ let surface_tools : Masc_domain.tool_schema list =
                              previous call). Walk history by passing the \
                              oldest_ts of the previous response; stop when \
                              has_more is false." )
+                      ] )
+                ; ( "mode"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "enum"
+                        , `List
+                            (List.map
+                               (fun value -> `String value)
+                               [ "local"; "channel"; "messages"; "members"; "member" ]) )
+                      ; ( "description"
+                        , `String
+                            "Read mode: local persisted lane, or a live Discord channel/messages/members/member query" )
+                      ] )
+                ; ( "channel_id"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Bound Discord channel snowflake; optional when exactly one channel is bound" )
+                      ] )
+                ; ( "user_id"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description", `String "Discord user snowflake for mode='member'" )
+                      ] )
+                ; ( "query"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description", `String "Optional member username/nickname prefix" )
+                      ] )
+                ; ( "discord_before"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description", `String "Discord message snowflake for backward paging" )
+                      ] )
+                ; ( "discord_after"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description", `String "Discord paging cursor; do not combine with discord_before" )
                       ] )
                 ] )
           ; "required", `List [ `String "surface" ]

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -62,7 +62,7 @@ let surface_tools : Masc_domain.tool_schema list =
                                [ "local"; "channel"; "messages"; "members"; "member" ]) )
                       ; ( "description"
                         , `String
-                            "Read mode: local persisted lane, or a live Discord channel/messages/members/member query" )
+                            "Optional exact read mode. When absent, the request is exactly 'local' for the persisted lane; padded or unknown values are invalid. The other modes query Discord live and require surface='discord'." )
                       ] )
                 ; ( "channel_id"
                   , `Assoc

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -248,6 +248,26 @@ let test_same_route () =
   (* two Unrouted values never share a route (no destination to share) *)
   assert (not (same_route (unrouted "a") (unrouted "a")))
 
+let test_discord_thread_parent_preserves_thread_target () =
+  let channel =
+    discord_channel
+      ~guild_id:(Some "G1")
+      ~channel_id:"T1"
+      ~parent_channel_id:None
+      ~thread_id:None
+      ~user_id:"U1"
+  in
+  match discord_thread_parent channel ~parent_channel_id:"P1" with
+  | Discord
+      { channel_id; parent_channel_id; thread_id; guild_id; user_id } ->
+    assert (channel_id = "T1");
+    assert (parent_channel_id = Some "P1");
+    assert (thread_id = Some "T1");
+    assert (guild_id = Some "G1");
+    assert (user_id = "U1")
+  | Dashboard _ | Slack _ | Unrouted _ ->
+    failwith "Discord thread parent changed connector kind"
+
 let () =
   test_codec_roundtrip ();
   test_unknown_kind_is_error ();
@@ -261,4 +281,5 @@ let () =
   test_is_routable ();
   test_kind_label ();
   test_same_route ();
+  test_discord_thread_parent_preserves_thread_target ();
   print_endline "Keeper_continuation_channel: all tests passed"

--- a/test/test_discord_rest_client.ml
+++ b/test/test_discord_rest_client.ml
@@ -243,6 +243,17 @@ let test_parse_response_2xx_without_id_is_other () =
       failf "expected Other, got %s"
         (Format.asprintf "%a" R.pp_error e)
 
+let test_parse_response_rejects_duplicate_id () =
+  let body = {|{"id":"first","id":"second"}|} in
+  match R.parse_response ~status:200 ~body () with
+  | Error (R.Other { reason; _ }) ->
+    check bool "duplicate id is named" true
+      (contains_substring ~needle:"duplicate response field \"id\"" reason)
+  | Ok _ -> fail "duplicate response id must not be selected"
+  | Error error ->
+    failf "expected duplicate id rejection, got %s"
+      (Format.asprintf "%a" R.pp_error error)
+
 let test_parse_response_2xx_non_json_is_other () =
   match R.parse_response ~status:200 ~body:"<html>oops</html>" () with
   | Error (R.Other _) -> ()
@@ -589,6 +600,8 @@ let () =
             test_parse_response_2xx_with_id_returns_ok
         ; test_case "2xx without id => Other" `Quick
             test_parse_response_2xx_without_id_is_other
+        ; test_case "duplicate response id => Other" `Quick
+            test_parse_response_rejects_duplicate_id
         ; test_case "2xx non-JSON => Other" `Quick
             test_parse_response_2xx_non_json_is_other
         ; test_case "Discord error envelope => Discord_api" `Quick

--- a/test/test_discord_rest_client.ml
+++ b/test/test_discord_rest_client.ml
@@ -75,6 +75,64 @@ let test_build_typing_request_authorization_uses_bot_scheme () =
     (String.length ua >= 10
      && String.sub ua 0 10 = "DiscordBot")
 
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop offset =
+    if offset + needle_len > haystack_len then false
+    else if String.sub haystack offset needle_len = needle then true
+    else loop (offset + 1)
+  in
+  needle_len = 0 || loop 0
+
+let test_build_channel_read_request_url () =
+  let url, headers, body =
+    R.build_channel_request ~token:"sekret" ~channel_id:"CH123" ()
+  in
+  check string "channel read URL"
+    "https://discord.com/api/v10/channels/CH123" url;
+  check string "channel read auth" "Bot sekret"
+    (header_value headers "Authorization");
+  check string "channel read body" "" body
+
+let test_build_messages_read_request_query () =
+  let url, _, body =
+    R.build_channel_messages_request ~token:"t" ~channel_id:"CH"
+      ~limit:25 ~before:"MSG" ()
+  in
+  check bool "messages read path"
+    true (contains_substring ~needle:"/channels/CH/messages?" url);
+  check bool "messages limit" true
+    (contains_substring ~needle:"limit=25" url);
+  check bool "messages before" true
+    (contains_substring ~needle:"before=MSG" url);
+  check string "GET body" "" body
+
+let test_build_member_search_request_escapes_query () =
+  let url, _, _ =
+    R.build_guild_members_request ~token:"t" ~guild_id:"GUILD"
+      ~query:"min su" ~limit:10 ()
+  in
+  check bool "member search path" true
+    (contains_substring ~needle:"/guilds/GUILD/members/search?" url);
+  check bool "member search query" true
+    (contains_substring ~needle:"query=min%20su" url);
+  check bool "member search limit" true
+    (contains_substring ~needle:"limit=10" url)
+
+let test_build_member_request_url () =
+  let url, _, _ =
+    R.build_guild_member_request ~token:"t" ~guild_id:"GUILD" ~user_id:"USER" ()
+  in
+  check string "guild member URL"
+    "https://discord.com/api/v10/guilds/GUILD/members/USER" url
+
+let test_parse_json_response_accepts_array () =
+  match R.parse_json_response ~status:200 ~body:"[{\"id\":\"USER\"}]" with
+  | Ok (`List [ `Assoc [ ("id", `String "USER") ] ]) -> ()
+  | Ok json -> failf "unexpected JSON: %s" (Yojson.Safe.to_string json)
+  | Error _ -> fail "expected JSON response to parse"
+
 (* ---------------------------------------------------------------- *)
 (* build_edit_request                                               *)
 (* ---------------------------------------------------------------- *)
@@ -446,6 +504,14 @@ let () =
             test_build_typing_request_url_targets_channel
         ; test_case "typing Authorization uses Bot scheme" `Quick
             test_build_typing_request_authorization_uses_bot_scheme
+        ; test_case "channel read URL and headers" `Quick
+            test_build_channel_read_request_url
+        ; test_case "messages read query" `Quick
+            test_build_messages_read_request_query
+        ; test_case "member search query escaping" `Quick
+            test_build_member_search_request_escapes_query
+        ; test_case "guild member URL" `Quick
+            test_build_member_request_url
         ] )
     ; ( "build_edit_request"
       , [ test_case "URL targets channel/message" `Quick
@@ -512,5 +578,7 @@ let () =
             test_parse_empty_response_204_returns_ok
         ; test_case "empty non-2xx Discord envelope => Discord_api"
             `Quick test_parse_empty_response_discord_error_envelope
+        ; test_case "JSON response accepts array" `Quick
+            test_parse_json_response_accepts_array
         ] )
     ]

--- a/test/test_discord_rest_client.ml
+++ b/test/test_discord_rest_client.ml
@@ -7,6 +7,11 @@
 open Alcotest
 module R = Discord_rest_client
 
+let sf value =
+  match R.snowflake_of_string value with
+  | Ok value -> value
+  | Error message -> failf "invalid test snowflake: %s" message
+
 (* ---------------------------------------------------------------- *)
 (* build_request                                                    *)
 (* ---------------------------------------------------------------- *)
@@ -18,7 +23,7 @@ let header_value headers name =
 
 let test_build_request_url_targets_channel () =
   let url, _, _ =
-    R.build_request ~token:"abc" ~channel_id:"1234567890" ~content:"hi" ()
+    R.build_request ~token:"abc" ~channel_id:(sf "1234567890") ~content:"hi" ()
   in
   check string "v10 channel URL"
     "https://discord.com/api/v10/channels/1234567890/messages"
@@ -26,7 +31,7 @@ let test_build_request_url_targets_channel () =
 
 let test_build_request_authorization_uses_bot_scheme () =
   let _, headers, _ =
-    R.build_request ~token:"sekret" ~channel_id:"CH" ~content:"." ()
+    R.build_request ~token:"sekret" ~channel_id:(sf "123") ~content:"." ()
   in
   check string "Authorization header" "Bot sekret"
     (header_value headers "Authorization");
@@ -35,7 +40,7 @@ let test_build_request_authorization_uses_bot_scheme () =
 
 let test_build_request_user_agent_present () =
   let _, headers, _ =
-    R.build_request ~token:"t" ~channel_id:"c" ~content:"." ()
+    R.build_request ~token:"t" ~channel_id:(sf "1") ~content:"." ()
   in
   let ua = header_value headers "User-Agent" in
   (* Discord requires DiscordBot ($url, $version) shape. *)
@@ -45,7 +50,7 @@ let test_build_request_user_agent_present () =
 
 let test_build_request_body_is_content_object () =
   let _, _, body =
-    R.build_request ~token:"t" ~channel_id:"c" ~content:"hello \"world\"" ()
+    R.build_request ~token:"t" ~channel_id:(sf "1") ~content:"hello \"world\"" ()
   in
   let json = Yojson.Safe.from_string body in
   match json with
@@ -57,7 +62,7 @@ let test_build_request_body_is_content_object () =
 
 let test_build_typing_request_url_targets_channel () =
   let url, _, body =
-    R.build_typing_request ~token:"abc" ~channel_id:"1234567890" ()
+    R.build_typing_request ~token:"abc" ~channel_id:(sf "1234567890") ()
   in
   check string "v10 typing URL"
     "https://discord.com/api/v10/channels/1234567890/typing"
@@ -66,7 +71,7 @@ let test_build_typing_request_url_targets_channel () =
 
 let test_build_typing_request_authorization_uses_bot_scheme () =
   let _, headers, _ =
-    R.build_typing_request ~token:"sekret" ~channel_id:"CH" ()
+    R.build_typing_request ~token:"sekret" ~channel_id:(sf "123") ()
   in
   check string "Authorization header" "Bot sekret"
     (header_value headers "Authorization");
@@ -85,36 +90,55 @@ let contains_substring ~needle haystack =
   in
   needle_len = 0 || loop 0
 
+let test_snowflake_decoder_rejects_non_decimal_ids () =
+  List.iter
+    (fun value ->
+      match R.snowflake_of_string value with
+      | Ok _ -> failf "accepted invalid Discord snowflake %S" value
+      | Error _ -> ())
+    [ ""; " 123"; "123 "; "123/456"; "abc" ]
+
+let test_error_rendering_does_not_disclose_response_body () =
+  let secret = "gateway secret response" in
+  match R.parse_response ~request_id:"req-1" ~status:502 ~body:secret () with
+  | Ok _ -> fail "expected a redacted HTTP error"
+  | Error error ->
+    let rendered = Format.asprintf "%a" R.pp_error error in
+    check bool "raw response is not rendered" false
+      (contains_substring ~needle:secret rendered);
+    check bool "request correlation is rendered" true
+      (contains_substring ~needle:"req-1" rendered)
+
 let test_build_channel_read_request_url () =
   let url, headers, body =
-    R.build_channel_request ~token:"sekret" ~channel_id:"CH123" ()
+    R.build_channel_request ~token:"sekret" ~channel_id:(sf "123") ()
   in
   check string "channel read URL"
-    "https://discord.com/api/v10/channels/CH123" url;
+    "https://discord.com/api/v10/channels/123" url;
   check string "channel read auth" "Bot sekret"
     (header_value headers "Authorization");
   check string "channel read body" "" body
 
 let test_build_messages_read_request_query () =
   let url, _, body =
-    R.build_channel_messages_request ~token:"t" ~channel_id:"CH"
-      ~limit:25 ~before:"MSG" ()
+    R.build_channel_messages_request ~token:"t" ~channel_id:(sf "123")
+      ~limit:25 ~before:(sf "456") ()
   in
   check bool "messages read path"
-    true (contains_substring ~needle:"/channels/CH/messages?" url);
+    true (contains_substring ~needle:"/channels/123/messages?" url);
   check bool "messages limit" true
     (contains_substring ~needle:"limit=25" url);
   check bool "messages before" true
-    (contains_substring ~needle:"before=MSG" url);
+    (contains_substring ~needle:"before=456" url);
   check string "GET body" "" body
 
 let test_build_member_search_request_escapes_query () =
   let url, _, _ =
-    R.build_guild_members_request ~token:"t" ~guild_id:"GUILD"
+    R.build_guild_members_request ~token:"t" ~guild_id:(sf "123")
       ~query:"min su" ~limit:10 ()
   in
   check bool "member search path" true
-    (contains_substring ~needle:"/guilds/GUILD/members/search?" url);
+    (contains_substring ~needle:"/guilds/123/members/search?" url);
   check bool "member search query" true
     (contains_substring ~needle:"query=min%20su" url);
   check bool "member search limit" true
@@ -122,13 +146,14 @@ let test_build_member_search_request_escapes_query () =
 
 let test_build_member_request_url () =
   let url, _, _ =
-    R.build_guild_member_request ~token:"t" ~guild_id:"GUILD" ~user_id:"USER" ()
+    R.build_guild_member_request ~token:"t" ~guild_id:(sf "123")
+      ~user_id:(sf "456") ()
   in
   check string "guild member URL"
-    "https://discord.com/api/v10/guilds/GUILD/members/USER" url
+    "https://discord.com/api/v10/guilds/123/members/456" url
 
 let test_parse_json_response_accepts_array () =
-  match R.parse_json_response ~status:200 ~body:"[{\"id\":\"USER\"}]" with
+  match R.parse_json_response ~status:200 ~body:"[{\"id\":\"USER\"}]" () with
   | Ok (`List [ `Assoc [ ("id", `String "USER") ] ]) -> ()
   | Ok json -> failf "unexpected JSON: %s" (Yojson.Safe.to_string json)
   | Error _ -> fail "expected JSON response to parse"
@@ -139,17 +164,17 @@ let test_parse_json_response_accepts_array () =
 
 let test_build_edit_request_url_targets_message () =
   let url, _, _ =
-    R.build_edit_request ~token:"abc" ~channel_id:"CH123"
-      ~message_id:"MSG456" ~content:"hi" ()
+    R.build_edit_request ~token:"abc" ~channel_id:(sf "123")
+      ~message_id:(sf "456") ~content:"hi" ()
   in
   check string "v10 edit URL"
-    "https://discord.com/api/v10/channels/CH123/messages/MSG456"
+    "https://discord.com/api/v10/channels/123/messages/456"
     url
 
 let test_build_edit_request_authorization_uses_bot_scheme () =
   let _, headers, _ =
-    R.build_edit_request ~token:"sekret" ~channel_id:"c"
-      ~message_id:"m" ~content:"." ()
+    R.build_edit_request ~token:"sekret" ~channel_id:(sf "1")
+      ~message_id:(sf "2") ~content:"." ()
   in
   check string "Authorization header" "Bot sekret"
     (header_value headers "Authorization");
@@ -158,8 +183,8 @@ let test_build_edit_request_authorization_uses_bot_scheme () =
 
 let test_build_edit_request_body_is_content_object () =
   let _, _, body =
-    R.build_edit_request ~token:"t" ~channel_id:"c"
-      ~message_id:"m" ~content:"updated text" ()
+    R.build_edit_request ~token:"t" ~channel_id:(sf "1")
+      ~message_id:(sf "2") ~content:"updated text" ()
   in
   let json = Yojson.Safe.from_string body in
   match json with
@@ -172,8 +197,8 @@ let test_build_edit_request_body_is_content_object () =
 let test_build_edit_request_content_truncated_at_limit () =
   let long_content = String.make 2500 'x' in
   let _, _, body =
-    R.build_edit_request ~token:"t" ~channel_id:"c"
-      ~message_id:"m" ~content:long_content ()
+    R.build_edit_request ~token:"t" ~channel_id:(sf "1")
+      ~message_id:(sf "2") ~content:long_content ()
   in
   let json = Yojson.Safe.from_string body in
   match json with
@@ -185,8 +210,8 @@ let test_build_edit_request_content_truncated_at_limit () =
 let test_build_edit_request_short_content_not_truncated () =
   let short_content = "hello" in
   let _, _, body =
-    R.build_edit_request ~token:"t" ~channel_id:"c"
-      ~message_id:"m" ~content:short_content ()
+    R.build_edit_request ~token:"t" ~channel_id:(sf "1")
+      ~message_id:(sf "2") ~content:short_content ()
   in
   let json = Yojson.Safe.from_string body in
   match json with
@@ -202,7 +227,7 @@ let test_parse_response_2xx_with_id_returns_ok () =
   let body =
     {|{"id":"MSG123","channel_id":"CH","content":"hi","author":{"id":"BOT"}}|}
   in
-  match R.parse_response ~status:200 ~body with
+  match R.parse_response ~status:200 ~body () with
   | Ok "MSG123" -> ()
   | Ok other -> failf "expected MSG123, got %s" other
   | Error e ->
@@ -211,7 +236,7 @@ let test_parse_response_2xx_with_id_returns_ok () =
 
 let test_parse_response_2xx_without_id_is_other () =
   let body = {|{"foo":"bar"}|} in
-  match R.parse_response ~status:201 ~body with
+  match R.parse_response ~status:201 ~body () with
   | Error (R.Other _) -> ()
   | Ok _ -> fail "expected Error Other for 2xx without id"
   | Error e ->
@@ -219,7 +244,7 @@ let test_parse_response_2xx_without_id_is_other () =
         (Format.asprintf "%a" R.pp_error e)
 
 let test_parse_response_2xx_non_json_is_other () =
-  match R.parse_response ~status:200 ~body:"<html>oops</html>" with
+  match R.parse_response ~status:200 ~body:"<html>oops</html>" () with
   | Error (R.Other _) -> ()
   | _ -> fail "expected Error Other for 2xx non-JSON body"
 
@@ -229,41 +254,36 @@ let test_parse_response_discord_error_envelope () =
   let body =
     {|{"code":50007,"message":"Cannot send messages to this user"}|}
   in
-  match R.parse_response ~status:403 ~body with
+  match R.parse_response ~status:403 ~body () with
   | Error
-      (R.Discord_api
-        { code = 50007
-        ; message = "Cannot send messages to this user"
-        }) ->
+      (R.Discord_api { code = 50007; request_id = _ }) ->
       ()
   | _ -> fail "expected Discord_api { 50007; ... }"
 
 let test_parse_response_5xx_non_json_is_http_status () =
-  match R.parse_response ~status:502 ~body:"Bad Gateway" with
-  | Error (R.Http_status { code = 502; body = "Bad Gateway" }) -> ()
-  | _ -> fail "expected Http_status { 502; \"Bad Gateway\" }"
+  match R.parse_response ~status:502 ~body:"Bad Gateway" () with
+  | Error (R.Http_status { code = 502; body_bytes = 11; request_id = _ }) -> ()
+  | _ -> fail "expected redacted Http_status { 502; body_bytes=11 }"
 
-let test_parse_response_non2xx_json_without_envelope_falls_back () =
-  (* Non-2xx with a JSON object that has no Discord code/message —
-     parse_response falls back to (status, body) as code/message. *)
+let test_parse_response_non2xx_json_without_envelope_is_redacted () =
+  (* Non-2xx JSON without a Discord error envelope remains redacted. *)
   let body = {|{"hint":"bad request"}|} in
-  match R.parse_response ~status:400 ~body with
-  | Error (R.Discord_api { code = 400; _ }) -> ()
+  match R.parse_response ~status:400 ~body () with
+  | Error (R.Http_status { code = 400; body_bytes = 22; request_id = _ }) -> ()
   | _ ->
       fail
-        "expected Discord_api with code=400 fallback when JSON lacks \
-         'code' field"
+        "expected redacted Http_status when JSON lacks an error envelope"
 
 let test_parse_empty_response_204_returns_ok () =
-  match R.parse_empty_response ~status:204 ~body:"" with
+  match R.parse_empty_response ~status:204 ~body:"" () with
   | Ok () -> ()
   | Error e ->
       failf "expected Ok, got %s" (Format.asprintf "%a" R.pp_error e)
 
 let test_parse_empty_response_discord_error_envelope () =
   let body = {|{"code":50013,"message":"Missing Permissions"}|} in
-  match R.parse_empty_response ~status:403 ~body with
-  | Error (R.Discord_api { code = 50013; message = "Missing Permissions" }) ->
+  match R.parse_empty_response ~status:403 ~body () with
+  | Error (R.Discord_api { code = 50013; request_id = _ }) ->
       ()
   | Ok () -> fail "expected Discord_api error"
   | Error e ->
@@ -359,15 +379,15 @@ let test_image_embed_to_json () =
 
 let test_build_embed_request_url_targets_channel () =
   let url, _, _ =
-    R.build_embed_request ~token:"t" ~channel_id:"CH1"
+    R.build_embed_request ~token:"t" ~channel_id:(sf "1")
       ~content:"hi" ~embeds:[] ()
   in
   check string "URL targets channel"
-    "https://discord.com/api/v10/channels/CH1/messages" url
+    "https://discord.com/api/v10/channels/1/messages" url
 
 let test_build_embed_request_empty_content_omits_field () =
   let _, _, body =
-    R.build_embed_request ~token:"t" ~channel_id:"c"
+    R.build_embed_request ~token:"t" ~channel_id:(sf "1")
       ~content:"" ~embeds:[] ()
   in
   let json = Yojson.Safe.from_string body in
@@ -380,7 +400,7 @@ let test_build_embed_request_embeds_included () =
     { title = "T"; description = None; url = None; color = 1; image = None; fields = [] }
   in
   let _, _, body =
-    R.build_embed_request ~token:"t" ~channel_id:"c"
+    R.build_embed_request ~token:"t" ~channel_id:(sf "1")
       ~content:"" ~embeds:[embed] ()
   in
   let json = Yojson.Safe.from_string body in
@@ -398,11 +418,11 @@ let test_build_embed_request_embeds_included () =
 
 let test_build_edit_embed_request_url_targets_message () =
   let url, _, _ =
-    R.build_edit_embed_request ~token:"t" ~channel_id:"CH"
-      ~message_id:"MSG1" ~content:"hi" ~embeds:[] ()
+    R.build_edit_embed_request ~token:"t" ~channel_id:(sf "1")
+      ~message_id:(sf "9") ~content:"hi" ~embeds:[] ()
   in
   check string "URL targets message"
-    "https://discord.com/api/v10/channels/CH/messages/MSG1" url
+    "https://discord.com/api/v10/channels/1/messages/9" url
 
 let test_build_edit_embed_request_embeds_and_content () =
   let embed : R.embed =
@@ -410,8 +430,8 @@ let test_build_edit_embed_request_embeds_and_content () =
     ; image = None; fields = [] }
   in
   let _, _, body =
-    R.build_edit_embed_request ~token:"t" ~channel_id:"c"
-      ~message_id:"m" ~content:"ok" ~embeds:[embed] ()
+    R.build_edit_embed_request ~token:"t" ~channel_id:(sf "1")
+      ~message_id:(sf "2") ~content:"ok" ~embeds:[embed] ()
   in
   let json = Yojson.Safe.from_string body in
   match json with
@@ -491,7 +511,10 @@ let test_truncate_to_limit_korean_valid_utf8 () =
 
 let () =
   run "discord_rest_client"
-    [ ( "build_request"
+    [ ( "snowflake"
+      , [ test_case "rejects non-decimal IDs" `Quick
+            test_snowflake_decoder_rejects_non_decimal_ids ] )
+    ; ( "build_request"
       , [ test_case "URL targets channel" `Quick
             test_build_request_url_targets_channel
         ; test_case "Authorization uses Bot scheme" `Quick
@@ -572,8 +595,10 @@ let () =
             test_parse_response_discord_error_envelope
         ; test_case "5xx non-JSON => Http_status" `Quick
             test_parse_response_5xx_non_json_is_http_status
-        ; test_case "non-2xx JSON without envelope => Discord_api fallback"
-            `Quick test_parse_response_non2xx_json_without_envelope_falls_back
+        ; test_case "error rendering omits raw response body" `Quick
+            test_error_rendering_does_not_disclose_response_body
+        ; test_case "non-2xx JSON without envelope => redacted Http_status"
+            `Quick test_parse_response_non2xx_json_without_envelope_is_redacted
         ; test_case "empty 204 => Ok" `Quick
             test_parse_empty_response_204_returns_ok
         ; test_case "empty non-2xx Discord envelope => Discord_api"

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -76,6 +76,50 @@ let test_discord_continuation_selects_exact_bound_channel () =
     (resolve ~surface:"discord" ~channel_id:None ~continuation_channel
        ~bound_discord_channels:[ "111"; "222" ] ())
 
+let test_discord_thread_continuation_stays_in_thread () =
+  let continuation_channel =
+    match
+      Keeper_continuation_channel.discord
+        ~guild_id:(Some "guild")
+        ~channel_id:"thread-1"
+        ~parent_channel_id:(Some "parent-1")
+        ~thread_id:(Some "thread-1")
+        ~user_id:"user"
+    with
+    | Ok channel -> channel
+    | Error message -> fail message
+  in
+  check (result target string) "thread continuation selects thread channel"
+    (Ok (SP.To_discord { channel_id = "thread-1" }))
+    (resolve ~surface:"discord" ~channel_id:None ~continuation_channel
+       ~bound_discord_channels:[ "parent-1" ] ());
+  check (result target string) "explicit thread channel remains in thread"
+    (Ok (SP.To_discord { channel_id = "thread-1" }))
+    (resolve ~surface:"discord" ~channel_id:(Some "thread-1")
+       ~continuation_channel ~bound_discord_channels:[ "parent-1" ] ())
+
+let test_discord_thread_foreign_explicit_channel_is_error () =
+  let continuation_channel =
+    match
+      Keeper_continuation_channel.discord
+        ~guild_id:(Some "guild")
+        ~channel_id:"thread-1"
+        ~parent_channel_id:(Some "parent-1")
+        ~thread_id:(Some "thread-1")
+        ~user_id:"user"
+    with
+    | Ok channel -> channel
+    | Error message -> fail message
+  in
+  match
+    resolve ~surface:"discord" ~channel_id:(Some "thread-2")
+      ~continuation_channel ~bound_discord_channels:[ "parent-1" ] ()
+  with
+  | Error message ->
+      check bool "names the rejected channel" true
+        (Astring.String.is_infix ~affix:"thread-2" message)
+  | Ok _ -> fail "foreign explicit thread must not resolve"
+
 let test_mismatched_continuation_does_not_select_channel () =
   let continuation_channel =
     match
@@ -249,6 +293,10 @@ let () =
             test_discord_multiple_bindings_require_channel_id;
           test_case "Discord continuation selects exact bound channel" `Quick
             test_discord_continuation_selects_exact_bound_channel;
+          test_case "Discord thread continuation stays in thread" `Quick
+            test_discord_thread_continuation_stays_in_thread;
+          test_case "foreign explicit thread is an error" `Quick
+            test_discord_thread_foreign_explicit_channel_is_error;
           test_case "mismatched continuation stays ambiguous" `Quick
             test_mismatched_continuation_does_not_select_channel;
           test_case "foreign channel_id is an error" `Quick

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -328,6 +328,46 @@ let test_public_read_rejects_offset_without_enrichment () =
       check bool "validation names exact field" true
         (contains_substring result.raw_output "offset"))
 
+let test_surface_read_rejects_duplicate_dispatch_fields () =
+  with_exec_fixture
+    "keeper_tool_dispatch_runtime_surface_read_rejects_duplicates"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+      let run input =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~publication_recovery
+          ~ctx_work
+          ~name:"keeper_surface_read"
+          ~input
+          ()
+      in
+      let duplicate_mode =
+        run
+          (`Assoc
+             [ "surface", `String "discord"
+             ; "mode", `String "channel"
+             ; "mode", `String "local" ])
+      in
+      let duplicate_channel =
+        run
+          (`Assoc
+             [ "surface", `String "discord"
+             ; "mode", `String "channel"
+             ; "channel_id", `String "123"
+             ; "channel_id", `String "456" ])
+      in
+      check bool "duplicate fields produce validation output" true
+        (contains_substring duplicate_mode.raw_output "error_code");
+      check string "duplicate mode is named"
+        "keeper_surface_read arguments contains duplicate field \"mode\""
+        Yojson.Safe.Util.(member "message" (parse_json duplicate_mode.raw_output) |> to_string);
+      check bool "duplicate channel produces validation output" true
+        (contains_substring duplicate_channel.raw_output "error_code");
+      check string "duplicate channel is not silently selected"
+        "keeper_surface_read arguments contains duplicate field \"channel_id\""
+        Yojson.Safe.Util.(member "message" (parse_json duplicate_channel.raw_output) |> to_string))
+
 let test_board_runtime_rejects_unknown_route () =
   let meta = make_meta ~name:"keeper-board-runtime-guard" () in
   let raw =
@@ -4066,6 +4106,8 @@ let () =
         test_public_read_rejects_unsupported_range_fields;
       test_case "public Read rejects offset without dispatch enrichment" `Quick
         test_public_read_rejects_offset_without_enrichment;
+      test_case "surface Read rejects duplicate dispatch fields" `Quick
+        test_surface_read_rejects_duplicate_dispatch_fields;
       test_case "missing file is failure" `Quick
         test_execute_with_outcome_missing_file_is_failure;
       test_case "initializing recovery isolates only publication writes" `Quick


### PR DESCRIPTION
## What changed

- Expose bound Discord channel reads through `keeper_surface_read`:
  channel metadata, messages, guild member search/list, and exact member lookup.
- Preserve Discord thread channel targets through queued and autonomous Keeper turns.
- Keep thread authorization tied to the bound parent channel without posting the
  response in the parent channel.
- Add structured Discord read visibility: mode, resource, bound-channel scope,
  and list counts in the tool result; success, REST failure, and invalid-shape
  events are logged without message bodies or member data.

## Root cause

Discord inbound events carried the concrete thread channel, but autonomous
`Connector_attention` turns did not pass their continuation into the tool
runtime. Queued thread turns also lacked the parent coordinate needed by the
bound-channel resolver. The target now remains the thread channel while the
parent binding authorizes it.

## Validation

- `test_discord_rest_client.exe`: 38 tests passed.
- `test_keeper_surface_post.exe`: 18 tests passed.
- `test_keeper_continuation_channel.exe`: passed.
- Related dispatch target builds successfully.
- The broader dispatch executable still reports the existing 6 unrelated
  failures; those are not green proof and are called out for follow-up.
