### PR TITLE
feat(runtime): bridge Codex dynamic tools

### DIFF
--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -6,6 +6,7 @@
  (wrapped false)
  (libraries
   yojson
+  cstruct
   otoml
   masc.toml_line_editor
   base64

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -175,7 +175,7 @@ let parse_wire_line line =
        Ok (Response { id; result }))
   | Some _, None -> protocol_error stage "response id must be an integer"
   | None, Some (`String method_) ->
-    let params = Option.value ~default:`Null (List.assoc_opt "params" fields) in
+    let* params = required_member stage "params" fields in
     Ok (Notification { method_; params })
   | Some _, Some _ | None, Some _ -> protocol_error stage "method must be a string"
   | None, None -> protocol_error stage "message has neither id nor method"
@@ -553,10 +553,7 @@ let run_turn ~mgr ~clock config ~prompt =
     match validate_config config ~prompt with
     | Error _ as error -> error
     | Ok () ->
-      let model = Option.value config.model ~default:"default" in
-      Log.Runtime_agent.info
-        "Codex app-server subscription turn starting (model=%s)"
-        model;
+      Log.Runtime_agent.info "Codex app-server subscription turn starting";
       (try run_spawned ~mgr ~clock config ~prompt with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | Eio.Time.Timeout -> Error (Timeout config.timeout_s)

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -73,6 +73,19 @@ let error_to_string = function
     Printf.sprintf "Codex app-server turn timed out after %.3fs" seconds
 ;;
 
+let error_kind = function
+  | Invalid_config _ -> "invalid_config"
+  | Spawn_failed _ -> "spawn_failed"
+  | Protocol_error _ -> "protocol_error"
+  | Rpc_error _ -> "rpc_error"
+  | Subscription_required _ -> "subscription_required"
+  | Unsupported_server_request _ -> "unsupported_server_request"
+  | Turn_failed _ -> "turn_failed"
+  | Turn_interrupted -> "turn_interrupted"
+  | Process_exited _ -> "process_exited"
+  | Timeout _ -> "timeout"
+;;
+
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
 
 let assoc_at stage = function
@@ -452,6 +465,37 @@ let drain_stderr flow tail =
   | _ -> ()
 ;;
 
+let terminate_spawned_process ~clock proc stdin_w =
+  let owning_switch_cancelled = Eio.Fiber.is_cancelled () in
+  Eio.Cancel.protect (fun () ->
+    (try Eio.Flow.close stdin_w with
+     | exn ->
+       Log.Runtime_agent.debug
+         "Codex app-server stdin close failed: %s"
+         (Printexc.to_string exn));
+    (try Eio.Process.signal proc Sys.sigterm with
+     | exn ->
+       Log.Runtime_agent.debug
+         "Codex app-server termination signal failed: %s"
+         (Printexc.to_string exn));
+    if not owning_switch_cancelled
+    then
+      try Eio.Time.with_timeout_exn clock 2.0 (fun () -> Eio.Process.await proc |> ignore) with
+      | Eio.Time.Timeout ->
+        (try
+           Eio.Process.signal proc Sys.sigkill;
+           Eio.Process.await proc |> ignore
+         with
+         | exn ->
+           Log.Runtime_agent.warn
+             "Codex app-server forced reap failed: %s"
+             (Printexc.to_string exn))
+      | exn ->
+        Log.Runtime_agent.debug
+          "Codex app-server reap observed an already-closed process: %s"
+          (Printexc.to_string exn))
+;;
+
 let run_spawned ~mgr ~clock config ~prompt =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
@@ -481,10 +525,12 @@ let run_spawned ~mgr ~clock config ~prompt =
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> protocol_error "stdout read" (Printexc.to_string exn)
     in
+    (* Cleanup must run before [Switch.run] waits for the stderr drainer. The
+       child can be waiting for more stdin on typed early returns, so a switch
+       release hook alone deadlocks. [Eio.Cancel.protect] inside the finalizer
+       preserves cleanup across fiber cancellation. *)
     Fun.protect
-      ~finally:(fun () ->
-        (try Eio.Flow.close stdin_w with _ -> ());
-        (try Eio.Process.signal proc Sys.sigterm with _ -> ()))
+      ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
         Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
           run_protocol { send; receive } config ~prompt)))
@@ -503,11 +549,29 @@ let validate_config config ~prompt =
 ;;
 
 let run_turn ~mgr ~clock config ~prompt =
-  match validate_config config ~prompt with
-  | Error _ as error -> error
-  | Ok () ->
-    (try run_spawned ~mgr ~clock config ~prompt with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
-     | exn -> Error (Spawn_failed (Printexc.to_string exn)))
+  let result =
+    match validate_config config ~prompt with
+    | Error _ as error -> error
+    | Ok () ->
+      let model = Option.value config.model ~default:"default" in
+      Log.Runtime_agent.info
+        "Codex app-server subscription turn starting (model=%s)"
+        model;
+      (try run_spawned ~mgr ~clock config ~prompt with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+       | exn -> Error (Spawn_failed (Printexc.to_string exn)))
+  in
+  (match result with
+   | Ok turn ->
+     Log.Runtime_agent.info
+       "Codex app-server subscription turn completed (thread_id=%s turn_id=%s model=%s)"
+       turn.thread_id
+       turn.turn_id
+       turn.model
+   | Error error ->
+     Log.Runtime_agent.warn
+       "Codex app-server subscription turn failed (kind=%s)"
+       (error_kind error));
+  result
 ;;

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -31,8 +31,30 @@ type turn_result =
   ; turn_id : string
   ; model : string
   ; text : string
+  ; dynamic_tool_calls : int
   ; subscription : subscription
   ; user_agent : string option
+  }
+
+type dynamic_tool_result =
+  { success : bool
+  ; content : string
+  }
+
+type dynamic_tool =
+  { name : string
+  ; description : string
+  ; input_schema : Yojson.Safe.t
+  ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
+  }
+
+type history_role =
+  | User
+  | Assistant
+
+type history_message =
+  { role : history_role
+  ; text : string
   }
 
 type error =
@@ -146,6 +168,7 @@ type wire_message =
   | Server_request of
       { id : Yojson.Safe.t
       ; method_ : string
+      ; params : Yojson.Safe.t
       }
 
 let parse_rpc_error id fields =
@@ -166,7 +189,9 @@ let parse_wire_line line =
   let* json = json_result in
   let* fields = assoc_at stage json in
   match List.assoc_opt "id" fields, List.assoc_opt "method" fields with
-  | Some id, Some (`String method_) -> Ok (Server_request { id; method_ })
+  | Some id, Some (`String method_) ->
+    let* params = required_member stage "params" fields in
+    Ok (Server_request { id; method_; params })
   | Some (`Int id), None ->
     (match List.assoc_opt "error" fields with
      | Some _ -> parse_rpc_error id fields
@@ -204,6 +229,70 @@ let reject_server_request io id =
        ])
 ;;
 
+let dynamic_tool_spec (tool : dynamic_tool) =
+  `Assoc
+    [ "type", `String "function"
+    ; "name", `String tool.name
+    ; "description", `String tool.description
+    ; "inputSchema", tool.input_schema
+    ; "deferLoading", `Bool false
+    ]
+;;
+
+let find_dynamic_tool tools name =
+  List.find_opt (fun (tool : dynamic_tool) -> String.equal tool.name name) tools
+;;
+
+let send_dynamic_tool_response io ~id (result : dynamic_tool_result) =
+  io.send
+    (`Assoc
+       [ "id", id
+       ; ( "result"
+         , `Assoc
+             [ "success", `Bool result.success
+             ; ( "contentItems"
+               , `List
+                   [ `Assoc
+                       [ "type", `String "inputText"
+                       ; "text", `String result.content
+                       ]
+                   ] )
+             ] )
+       ])
+;;
+
+let handle_dynamic_tool_call io ~tools ~thread_id ~turn_id ~tool_call_count ~id params =
+  let stage = "item/tool/call" in
+  let* fields = assoc_at stage params in
+  let* request_thread_id = required_string stage "threadId" fields in
+  let* request_turn_id = required_string stage "turnId" fields in
+  let* call_id = required_string stage "callId" fields in
+  let* tool_name = required_string stage "tool" fields in
+  let* namespace = optional_string stage "namespace" fields in
+  let* arguments = required_member stage "arguments" fields in
+  if request_thread_id <> thread_id || request_turn_id <> turn_id
+  then protocol_error stage "tool call identity does not match the active turn"
+  else if Option.is_some namespace
+  then protocol_error stage "function tool call unexpectedly declared a namespace"
+  else
+    match find_dynamic_tool tools tool_name with
+    | None -> protocol_error stage (Printf.sprintf "unknown dynamic tool %S" tool_name)
+    | Some tool ->
+      let result =
+        try tool.call ~call_id arguments with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
+          Log.Runtime_agent.warn
+            "Codex dynamic tool handler raised (tool=%s error=%s)"
+            tool_name
+            (Printexc.to_string exn);
+          { success = false; content = "dynamic tool handler raised" }
+      in
+      incr tool_call_count;
+      send_dynamic_tool_response io ~id result;
+      Ok ()
+;;
+
 let rec await_response io ~id ~method_ =
   let* message = io.receive () in
   match message with
@@ -217,7 +306,7 @@ let rec await_response io ~id ~method_ =
     protocol_error method_
       (Printf.sprintf "received error response id %d while waiting for %d" response_id id)
   | Notification _ -> await_response io ~id ~method_
-  | Server_request { id; method_ = requested_method } ->
+  | Server_request { id; method_ = requested_method; _ } ->
     reject_server_request io id;
     Error (Unsupported_server_request requested_method)
 ;;
@@ -336,12 +425,32 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
       | other -> protocol_error stage (Printf.sprintf "unknown turn status %S" other)
 ;;
 
-let rec await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback =
+let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen_final
+    ~seen_fallback =
   let* message = io.receive () in
   match message with
   | Response _ | Response_error _ ->
     protocol_error "turn" "received an unsolicited JSON-RPC response"
-  | Server_request { id; method_ } ->
+  | Server_request { id; method_ = "item/tool/call"; params } ->
+    let* () =
+      handle_dynamic_tool_call
+        io
+        ~tools
+        ~thread_id
+        ~turn_id
+        ~tool_call_count
+        ~id
+        params
+    in
+    await_turn_terminal
+      io
+      ~tools
+      ~tool_call_count
+      ~thread_id
+      ~turn_id
+      ~seen_final
+      ~seen_fallback
+  | Server_request { id; method_; _ } ->
     reject_server_request io id;
     Error (Unsupported_server_request method_)
   | Notification { method_ = "item/completed"; params } ->
@@ -360,13 +469,28 @@ let rec await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback =
         | Some (_, text) -> seen_final, Some text
         | None -> seen_final, seen_fallback
       in
-      await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+      await_turn_terminal
+        io
+        ~tools
+        ~tool_call_count
+        ~thread_id
+        ~turn_id
+        ~seen_final
+        ~seen_fallback
   | Notification { method_ = "error"; params } ->
     let stage = "error notification" in
     let* fields = assoc_at stage params in
     let* will_retry = required_bool stage "willRetry" fields in
     if will_retry
-    then await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+    then
+      await_turn_terminal
+        io
+        ~tools
+        ~tool_call_count
+        ~thread_id
+        ~turn_id
+        ~seen_final
+        ~seen_fallback
     else
       let* error_json = required_member stage "error" fields in
       let* error_fields = assoc_at stage error_json in
@@ -375,7 +499,14 @@ let rec await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback =
   | Notification { method_ = "turn/completed"; params } ->
     terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params
   | Notification _ ->
-    await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+    await_turn_terminal
+      io
+      ~tools
+      ~tool_call_count
+      ~thread_id
+      ~turn_id
+      ~seen_final
+      ~seen_fallback
 ;;
 
 let optional_field name = function
@@ -383,7 +514,26 @@ let optional_field name = function
   | Some value -> [ name, `String value ]
 ;;
 
-let run_protocol io config ~prompt =
+let history_item (message : history_message) =
+  let role, content_type =
+    match message.role with
+    | User -> "user", "input_text"
+    | Assistant -> "assistant", "output_text"
+  in
+  `Assoc
+    [ "type", `String "message"
+    ; "role", `String role
+    ; ( "content"
+      , `List
+          [ `Assoc
+              [ "type", `String content_type
+              ; "text", `String message.text
+              ]
+          ] )
+    ]
+;;
+
+let run_protocol io config ~dynamic_tools ~history ~prompt =
   send_request io ~id:1 ~method_:"initialize"
     ~params:
       (`Assoc
@@ -410,23 +560,57 @@ let run_protocol io config ~prompt =
     ]
     @ optional_field "model" config.model
     @ optional_field "developerInstructions" config.developer_instructions
+    @
+    match dynamic_tools with
+    | [] -> []
+    | tools -> [ "dynamicTools", `List (List.map dynamic_tool_spec tools) ]
   in
   send_request io ~id:3 ~method_:"thread/start" ~params:(`Assoc thread_fields);
   let* thread = await_response io ~id:3 ~method_:"thread/start" in
   let* thread_id, model = parse_thread_start thread in
-  send_request io ~id:4 ~method_:"turn/start"
+  let turn_request_id =
+    match history with
+    | [] -> Ok 4
+    | messages ->
+      send_request io ~id:4 ~method_:"thread/inject_items"
+        ~params:
+          (`Assoc
+             [ "threadId", `String thread_id
+             ; "items", `List (List.map history_item messages)
+             ]);
+      let* _ = await_response io ~id:4 ~method_:"thread/inject_items" in
+      Ok 5
+  in
+  let* turn_request_id = turn_request_id in
+  send_request io ~id:turn_request_id ~method_:"turn/start"
     ~params:
       (`Assoc
          [ "threadId", `String thread_id
          ; ( "input"
            , `List [ `Assoc [ "type", `String "text"; "text", `String prompt ] ] )
          ]);
-  let* turn = await_response io ~id:4 ~method_:"turn/start" in
+  let* turn = await_response io ~id:turn_request_id ~method_:"turn/start" in
   let* turn_id = parse_turn_start turn in
+  let tool_call_count = ref 0 in
   let* text =
-    await_turn_terminal io ~thread_id ~turn_id ~seen_final:None ~seen_fallback:None
+    await_turn_terminal
+      io
+      ~tools:dynamic_tools
+      ~tool_call_count
+      ~thread_id
+      ~turn_id
+      ~seen_final:None
+      ~seen_fallback:None
   in
-  Ok { thread_id; turn_id; model; text; subscription; user_agent }
+  Ok
+    { thread_id
+    ; turn_id
+    ; model
+    ; text
+    ; dynamic_tool_calls = !tool_call_count
+    ; subscription
+    ; user_agent
+    }
 ;;
 
 let env_key entry =
@@ -496,7 +680,7 @@ let terminate_spawned_process ~clock proc stdin_w =
           (Printexc.to_string exn))
 ;;
 
-let run_spawned ~mgr ~clock config ~prompt =
+let run_spawned ~mgr ~clock config ~dynamic_tools ~history ~prompt =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -533,7 +717,7 @@ let run_spawned ~mgr ~clock config ~prompt =
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
         Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
-          run_protocol { send; receive } config ~prompt)))
+          run_protocol { send; receive } config ~dynamic_tools ~history ~prompt)))
 ;;
 
 let validate_config config ~prompt =
@@ -548,16 +732,33 @@ let validate_config config ~prompt =
   else Ok ()
 ;;
 
-let run_turn ~mgr ~clock config ~prompt =
+let validate_dynamic_tools tools =
+  let rec loop seen = function
+    | [] -> Ok ()
+    | (tool : dynamic_tool) :: rest ->
+      let name = String.trim tool.name in
+      if name = ""
+      then Error (Invalid_config "dynamic tool name must not be empty")
+      else if List.mem name seen
+      then Error (Invalid_config (Printf.sprintf "duplicate dynamic tool name %S" name))
+      else loop (name :: seen) rest
+  in
+  loop [] tools
+;;
+
+let run_turn ?(dynamic_tools = []) ~mgr ~clock ?(history = []) config ~prompt =
   let result =
     match validate_config config ~prompt with
     | Error _ as error -> error
     | Ok () ->
+      (match validate_dynamic_tools dynamic_tools with
+       | Error _ as error -> error
+       | Ok () ->
       Log.Runtime_agent.info "Codex app-server subscription turn starting";
-      (try run_spawned ~mgr ~clock config ~prompt with
+      (try run_spawned ~mgr ~clock config ~dynamic_tools ~history ~prompt with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
-       | exn -> Error (Spawn_failed (Printexc.to_string exn)))
+       | exn -> Error (Spawn_failed (Printexc.to_string exn))))
   in
   (match result with
    | Ok turn ->

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -1,0 +1,513 @@
+(** Native Codex app-server single-turn execution.
+
+    The official CLI keeps ownership of ChatGPT credentials. We deliberately
+    remove API-key fallback variables from the child environment and then gate
+    on [account/read = chatgpt] before starting a thread. *)
+
+type subscription =
+  { plan_type : string
+  ; email : string option
+  }
+
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string option
+  ; developer_instructions : string option
+  ; timeout_s : float
+  }
+
+let default_config ~cwd =
+  { cli_path = "codex"
+  ; cwd
+  ; model = None
+  ; developer_instructions = None
+  ; timeout_s = 300.0
+  }
+;;
+
+type turn_result =
+  { thread_id : string
+  ; turn_id : string
+  ; model : string
+  ; text : string
+  ; subscription : subscription
+  ; user_agent : string option
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | Rpc_error of
+      { method_ : string
+      ; code : int option
+      ; message : string
+      }
+  | Subscription_required of string
+  | Unsupported_server_request of string
+  | Turn_failed of string
+  | Turn_interrupted
+  | Process_exited of string
+  | Timeout of float
+
+let error_to_string = function
+  | Invalid_config detail -> "invalid Codex app-server config: " ^ detail
+  | Spawn_failed detail -> "failed to start Codex app-server: " ^ detail
+  | Protocol_error { stage; detail } ->
+    Printf.sprintf "Codex app-server protocol error during %s: %s" stage detail
+  | Rpc_error { method_; code; message } ->
+    let code = Option.fold ~none:"" ~some:(Printf.sprintf " (code %d)") code in
+    Printf.sprintf "Codex app-server RPC %s failed%s: %s" method_ code message
+  | Subscription_required detail ->
+    "Codex ChatGPT subscription login required: " ^ detail
+  | Unsupported_server_request method_ ->
+    "Codex app-server requested unsupported host action: " ^ method_
+  | Turn_failed detail -> "Codex app-server turn failed: " ^ detail
+  | Turn_interrupted -> "Codex app-server turn was interrupted"
+  | Process_exited detail -> "Codex app-server exited before completion: " ^ detail
+  | Timeout seconds ->
+    Printf.sprintf "Codex app-server turn timed out after %.3fs" seconds
+;;
+
+let protocol_error stage detail = Error (Protocol_error { stage; detail })
+
+let assoc_at stage = function
+  | `Assoc fields -> Ok fields
+  | _ -> protocol_error stage "expected a JSON object"
+;;
+
+let required_member stage name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_string stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) when String.trim value <> "" -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a non-empty string" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let optional_string stage name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
+;;
+
+let required_bool stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`Bool value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a boolean" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_int stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be an integer" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let ( let* ) result f = Result.bind result f
+
+type wire_message =
+  | Response of
+      { id : int
+      ; result : Yojson.Safe.t
+      }
+  | Response_error of
+      { id : int
+      ; code : int option
+      ; message : string
+      }
+  | Notification of
+      { method_ : string
+      ; params : Yojson.Safe.t
+      }
+  | Server_request of
+      { id : Yojson.Safe.t
+      ; method_ : string
+      }
+
+let parse_rpc_error id fields =
+  let stage = "JSON-RPC error" in
+  let* error_json = required_member stage "error" fields in
+  let* error_fields = assoc_at stage error_json in
+  let* message = required_string stage "message" error_fields in
+  let* code = required_int stage "code" error_fields in
+  Ok (Response_error { id; code = Some code; message })
+;;
+
+let parse_wire_line line =
+  let stage = "JSON-RPC message" in
+  let json_result =
+    try Ok (Yojson.Safe.from_string line) with
+    | Yojson.Json_error detail -> protocol_error stage ("invalid JSON: " ^ detail)
+  in
+  let* json = json_result in
+  let* fields = assoc_at stage json in
+  match List.assoc_opt "id" fields, List.assoc_opt "method" fields with
+  | Some id, Some (`String method_) -> Ok (Server_request { id; method_ })
+  | Some (`Int id), None ->
+    (match List.assoc_opt "error" fields with
+     | Some _ -> parse_rpc_error id fields
+     | None ->
+       let* result = required_member stage "result" fields in
+       Ok (Response { id; result }))
+  | Some _, None -> protocol_error stage "response id must be an integer"
+  | None, Some (`String method_) ->
+    let params = Option.value ~default:`Null (List.assoc_opt "params" fields) in
+    Ok (Notification { method_; params })
+  | Some _, Some _ | None, Some _ -> protocol_error stage "method must be a string"
+  | None, None -> protocol_error stage "message has neither id nor method"
+;;
+
+type io =
+  { send : Yojson.Safe.t -> unit
+  ; receive : unit -> (wire_message, error) result
+  }
+
+let send_request io ~id ~method_ ~params =
+  io.send (`Assoc [ "id", `Int id; "method", `String method_; "params", params ])
+;;
+
+let send_notification io method_ = io.send (`Assoc [ "method", `String method_ ])
+
+let reject_server_request io id =
+  io.send
+    (`Assoc
+       [ "id", id
+       ; ( "error"
+         , `Assoc
+             [ "code", `Int (-32601)
+             ; "message", `String "MASC does not support this app-server host request"
+             ] )
+       ])
+;;
+
+let rec await_response io ~id ~method_ =
+  let* message = io.receive () in
+  match message with
+  | Response { id = response_id; result } when response_id = id -> Ok result
+  | Response { id = response_id; _ } ->
+    protocol_error method_
+      (Printf.sprintf "received response id %d while waiting for %d" response_id id)
+  | Response_error { id = response_id; code; message } when response_id = id ->
+    Error (Rpc_error { method_; code; message })
+  | Response_error { id = response_id; _ } ->
+    protocol_error method_
+      (Printf.sprintf "received error response id %d while waiting for %d" response_id id)
+  | Notification _ -> await_response io ~id ~method_
+  | Server_request { id; method_ = requested_method } ->
+    reject_server_request io id;
+    Error (Unsupported_server_request requested_method)
+;;
+
+let parse_initialize result =
+  let stage = "initialize" in
+  let* fields = assoc_at stage result in
+  optional_string stage "userAgent" fields
+;;
+
+let parse_subscription result =
+  let stage = "account/read" in
+  let* fields = assoc_at stage result in
+  let* _requires_auth = required_bool stage "requiresOpenaiAuth" fields in
+  let* account = required_member stage "account" fields in
+  match account with
+  | `Null -> Error (Subscription_required "the official CLI has no active account")
+  | `Assoc account_fields ->
+    let* account_type = required_string stage "type" account_fields in
+    if account_type <> "chatgpt"
+    then
+      Error
+        (Subscription_required
+           (Printf.sprintf "account/read reported account type %S" account_type))
+    else
+      let* plan_type = required_string stage "planType" account_fields in
+      let* email = optional_string stage "email" account_fields in
+      Ok { plan_type; email }
+  | _ -> protocol_error stage "account must be an object or null"
+;;
+
+let parse_thread_start result =
+  let stage = "thread/start" in
+  let* fields = assoc_at stage result in
+  let* thread_json = required_member stage "thread" fields in
+  let* thread_fields = assoc_at stage thread_json in
+  let* thread_id = required_string stage "id" thread_fields in
+  let* model = required_string stage "model" fields in
+  Ok (thread_id, model)
+;;
+
+let parse_turn_start result =
+  let stage = "turn/start" in
+  let* fields = assoc_at stage result in
+  let* turn_json = required_member stage "turn" fields in
+  let* turn_fields = assoc_at stage turn_json in
+  required_string stage "id" turn_fields
+;;
+
+let agent_message_of_item ~stage item =
+  let* fields = assoc_at stage item in
+  match List.assoc_opt "type" fields with
+  | Some (`String "agentMessage") ->
+    let* text = required_string stage "text" fields in
+    let* phase = optional_string stage "phase" fields in
+    Ok (Some (phase, text))
+  | Some (`String _) -> Ok None
+  | Some _ -> protocol_error stage "item type must be a string"
+  | None -> protocol_error stage "item is missing type"
+;;
+
+let messages_of_items ~stage = function
+  | `List items ->
+    let rec loop final fallback = function
+      | [] -> Ok (final, fallback)
+      | item :: rest ->
+        let* message = agent_message_of_item ~stage item in
+        (match message with
+         | Some (Some "final_answer", text) -> loop (Some text) fallback rest
+         | Some (_, text) -> loop final (Some text) rest
+         | None -> loop final fallback rest)
+    in
+    loop None None items
+  | _ -> protocol_error stage "turn items must be an array"
+;;
+
+let turn_error_message fields =
+  match List.assoc_opt "error" fields with
+  | Some (`Assoc error_fields) ->
+    (match List.assoc_opt "message" error_fields with
+     | Some (`String message) when String.trim message <> "" -> message
+     | _ -> "turn failed without a typed error message")
+  | _ -> "turn failed without an error object"
+;;
+
+let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
+  let stage = "turn/completed" in
+  let* fields = assoc_at stage params in
+  let* terminal_thread_id = required_string stage "threadId" fields in
+  if terminal_thread_id <> thread_id
+  then protocol_error stage "terminal threadId does not match thread/start"
+  else
+    let* turn_json = required_member stage "turn" fields in
+    let* turn_fields = assoc_at stage turn_json in
+    let* terminal_turn_id = required_string stage "id" turn_fields in
+    if terminal_turn_id <> turn_id
+    then protocol_error stage "terminal turn id does not match turn/start"
+    else
+      let* status = required_string stage "status" turn_fields in
+      match status with
+      | "failed" -> Error (Turn_failed (turn_error_message turn_fields))
+      | "interrupted" -> Error Turn_interrupted
+      | "inProgress" -> protocol_error stage "terminal notification carried inProgress status"
+      | "completed" ->
+        let* items = required_member stage "items" turn_fields in
+        let* terminal_final, terminal_fallback = messages_of_items ~stage items in
+        let text =
+          match terminal_final, seen_final, terminal_fallback, seen_fallback with
+          | Some text, _, _, _ | None, Some text, _, _
+          | None, None, Some text, _ | None, None, None, Some text -> Some text
+          | None, None, None, None -> None
+        in
+        (match text with
+         | Some text -> Ok text
+         | None -> protocol_error stage "completed turn has no assistant message")
+      | other -> protocol_error stage (Printf.sprintf "unknown turn status %S" other)
+;;
+
+let rec await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback =
+  let* message = io.receive () in
+  match message with
+  | Response _ | Response_error _ ->
+    protocol_error "turn" "received an unsolicited JSON-RPC response"
+  | Server_request { id; method_ } ->
+    reject_server_request io id;
+    Error (Unsupported_server_request method_)
+  | Notification { method_ = "item/completed"; params } ->
+    let stage = "item/completed" in
+    let* fields = assoc_at stage params in
+    let* item_thread_id = required_string stage "threadId" fields in
+    let* item_turn_id = required_string stage "turnId" fields in
+    if item_thread_id <> thread_id || item_turn_id <> turn_id
+    then protocol_error stage "item identity does not match the active turn"
+    else
+      let* item = required_member stage "item" fields in
+      let* message = agent_message_of_item ~stage item in
+      let seen_final, seen_fallback =
+        match message with
+        | Some (Some "final_answer", text) -> Some text, seen_fallback
+        | Some (_, text) -> seen_final, Some text
+        | None -> seen_final, seen_fallback
+      in
+      await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+  | Notification { method_ = "error"; params } ->
+    let stage = "error notification" in
+    let* fields = assoc_at stage params in
+    let* will_retry = required_bool stage "willRetry" fields in
+    if will_retry
+    then await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+    else
+      let* error_json = required_member stage "error" fields in
+      let* error_fields = assoc_at stage error_json in
+      let* message = required_string stage "message" error_fields in
+      Error (Turn_failed message)
+  | Notification { method_ = "turn/completed"; params } ->
+    terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params
+  | Notification _ ->
+    await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+;;
+
+let optional_field name = function
+  | None -> []
+  | Some value -> [ name, `String value ]
+;;
+
+let run_protocol io config ~prompt =
+  send_request io ~id:1 ~method_:"initialize"
+    ~params:
+      (`Assoc
+         [ ( "clientInfo"
+           , `Assoc
+               [ "name", `String "masc"
+               ; "title", `String "MASC"
+               ; "version", `String "dev"
+               ] )
+         ; "capabilities", `Assoc [ "experimentalApi", `Bool true ]
+         ]);
+  let* initialize = await_response io ~id:1 ~method_:"initialize" in
+  let* user_agent = parse_initialize initialize in
+  send_notification io "initialized";
+  send_request io ~id:2 ~method_:"account/read"
+    ~params:(`Assoc [ "refreshToken", `Bool false ]);
+  let* account = await_response io ~id:2 ~method_:"account/read" in
+  let* subscription = parse_subscription account in
+  let thread_fields =
+    [ "cwd", `String config.cwd
+    ; "approvalPolicy", `String "never"
+    ; "sandbox", `String "read-only"
+    ; "ephemeral", `Bool true
+    ]
+    @ optional_field "model" config.model
+    @ optional_field "developerInstructions" config.developer_instructions
+  in
+  send_request io ~id:3 ~method_:"thread/start" ~params:(`Assoc thread_fields);
+  let* thread = await_response io ~id:3 ~method_:"thread/start" in
+  let* thread_id, model = parse_thread_start thread in
+  send_request io ~id:4 ~method_:"turn/start"
+    ~params:
+      (`Assoc
+         [ "threadId", `String thread_id
+         ; ( "input"
+           , `List [ `Assoc [ "type", `String "text"; "text", `String prompt ] ] )
+         ]);
+  let* turn = await_response io ~id:4 ~method_:"turn/start" in
+  let* turn_id = parse_turn_start turn in
+  let* text =
+    await_turn_terminal io ~thread_id ~turn_id ~seen_final:None ~seen_fallback:None
+  in
+  Ok { thread_id; turn_id; model; text; subscription; user_agent }
+;;
+
+let env_key entry =
+  match String.index_opt entry '=' with
+  | Some index -> String.sub entry 0 index
+  | None -> entry
+;;
+
+let subscription_only_environment () =
+  Unix.environment ()
+  |> Array.to_list
+  |> List.filter (fun entry ->
+    match env_key entry with
+    | "OPENAI_API_KEY" | "CODEX_API_KEY" -> false
+    | _ -> true)
+  |> Array.of_list
+;;
+
+let bounded_tail ~limit current addition =
+  let combined = current ^ addition in
+  let length = String.length combined in
+  if length <= limit then combined else String.sub combined (length - limit) limit
+;;
+
+let drain_stderr flow tail =
+  let chunk = Cstruct.create 4096 in
+  try
+    while true do
+      let count = Eio.Flow.single_read flow chunk in
+      let text = Cstruct.to_string (Cstruct.sub chunk 0 count) in
+      tail := bounded_tail ~limit:4096 !tail text
+    done
+  with
+  | End_of_file -> ()
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | _ -> ()
+;;
+
+let run_spawned ~mgr ~clock config ~prompt =
+  Eio.Switch.run (fun sw ->
+    let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
+    let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
+    let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
+    let stderr_tail = ref "" in
+    let proc =
+      Eio.Process.spawn ~sw mgr
+        ~env:(subscription_only_environment ())
+        ~stdin:stdin_r ~stdout:stdout_w ~stderr:stderr_w
+        [ config.cli_path; "app-server"; "--stdio" ]
+    in
+    Eio.Flow.close stdin_r;
+    Eio.Flow.close stdout_w;
+    Eio.Flow.close stderr_w;
+    Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
+    let reader = Eio.Buf_read.of_flow ~max_size:(8 * 1024 * 1024) stdout_r in
+    let send json =
+      Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
+      Eio.Flow.copy_string "\n" stdin_w
+    in
+    let receive () =
+      try parse_wire_line (Eio.Buf_read.line reader) with
+      | End_of_file ->
+        let detail = String.trim !stderr_tail in
+        Error (Process_exited (if detail = "" then "stdout closed" else detail))
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn -> protocol_error "stdout read" (Printexc.to_string exn)
+    in
+    Fun.protect
+      ~finally:(fun () ->
+        (try Eio.Flow.close stdin_w with _ -> ());
+        (try Eio.Process.signal proc Sys.sigterm with _ -> ()))
+      (fun () ->
+        Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+          run_protocol { send; receive } config ~prompt)))
+;;
+
+let validate_config config ~prompt =
+  if String.trim config.cli_path = ""
+  then Error (Invalid_config "cli_path must not be empty")
+  else if String.trim config.cwd = "" || Filename.is_relative config.cwd
+  then Error (Invalid_config "cwd must be an absolute path")
+  else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
+  then Error (Invalid_config "timeout_s must be positive and finite")
+  else if String.trim prompt = ""
+  then Error (Invalid_config "prompt must not be empty")
+  else Ok ()
+;;
+
+let run_turn ~mgr ~clock config ~prompt =
+  match validate_config config ~prompt with
+  | Error _ as error -> error
+  | Ok () ->
+    (try run_spawned ~mgr ~clock config ~prompt with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+     | exn -> Error (Spawn_failed (Printexc.to_string exn)))
+;;

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -24,8 +24,30 @@ type turn_result =
   ; turn_id : string
   ; model : string
   ; text : string
+  ; dynamic_tool_calls : int
   ; subscription : subscription
   ; user_agent : string option
+  }
+
+type dynamic_tool_result =
+  { success : bool
+  ; content : string
+  }
+
+type dynamic_tool =
+  { name : string
+  ; description : string
+  ; input_schema : Yojson.Safe.t
+  ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
+  }
+
+type history_role =
+  | User
+  | Assistant
+
+type history_message =
+  { role : history_role
+  ; text : string
   }
 
 type error =
@@ -50,8 +72,10 @@ type error =
 val error_to_string : error -> string
 
 val run_turn :
+  ?dynamic_tools:dynamic_tool list ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
+  ?history:history_message list ->
   config ->
   prompt:string ->
   (turn_result, error) result

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -1,0 +1,57 @@
+(** A single-turn Codex app-server client.
+
+    This is an agent-runtime boundary, not an {!Llm_provider.Llm_transport}
+    implementation. Codex owns the whole turn. MASC owns process lifetime,
+    subscription admission, and terminal projection. *)
+
+type subscription =
+  { plan_type : string
+  ; email : string option
+  }
+
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string option
+  ; developer_instructions : string option
+  ; timeout_s : float
+  }
+
+val default_config : cwd:string -> config
+
+type turn_result =
+  { thread_id : string
+  ; turn_id : string
+  ; model : string
+  ; text : string
+  ; subscription : subscription
+  ; user_agent : string option
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | Rpc_error of
+      { method_ : string
+      ; code : int option
+      ; message : string
+      }
+  | Subscription_required of string
+  | Unsupported_server_request of string
+  | Turn_failed of string
+  | Turn_interrupted
+  | Process_exited of string
+  | Timeout of float
+
+val error_to_string : error -> string
+
+val run_turn :
+  mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  config ->
+  prompt:string ->
+  (turn_result, error) result

--- a/test/dune
+++ b/test/dune
@@ -1943,6 +1943,8 @@
 
 (include stanzas/test_runtime_agent_checkpoint.inc)
 
+(include stanzas/test_runtime_codex_app_server.inc)
+
 (include stanzas/test_runtime_provider_projection_boundary.inc)
 
 (include stanzas/test_openapi_api_e2e.inc)

--- a/test/stanzas/test_runtime_codex_app_server.inc
+++ b/test/stanzas/test_runtime_codex_app_server.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_codex_app_server)
+ (modules test_runtime_codex_app_server)
+ (libraries masc_test_deps))

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -60,7 +60,7 @@ let with_fixture lines f =
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
-let run_fixture path =
+let run_fixture ?(dynamic_tools = []) ?(history = []) path =
   Eio_main.run (fun env ->
     let config =
       { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
@@ -71,8 +71,77 @@ let run_fixture path =
     Runtime_codex_app_server.run_turn
       ~mgr:(Eio.Stdenv.process_mgr env)
       ~clock:(Eio.Stdenv.clock env)
+      ~dynamic_tools
+      ~history
       config
       ~prompt:"Return the fixture marker")
+;;
+
+let tool_call_request =
+  {|{"id":"tool-request-1","method":"item/tool/call","params":{"threadId":"thread-1","turnId":"turn-1","callId":"call-1","tool":"masc_probe","namespace":null,"arguments":{"marker":"from-codex"}}}|}
+;;
+
+let test_dynamic_tool_callback () =
+  let call_id = ref None in
+  let arguments = ref `Null in
+  let tool : Runtime_codex_app_server.dynamic_tool =
+    { name = "masc_probe"
+    ; description = "Return a deterministic fixture marker"
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc [ "marker", `Assoc [ "type", `String "string" ] ]
+          ; "required", `List [ `String "marker" ]
+          ]
+    ; call =
+        (fun ~call_id:id input ->
+          call_id := Some id;
+          arguments := input;
+          { success = true; content = "MASC_TOOL_RESULT" })
+    }
+  in
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; tool_call_request
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun path ->
+       match run_fixture ~dynamic_tools:[ tool ] path with
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok result ->
+         check int "measured tool calls" 1 result.dynamic_tool_calls;
+         check (option string) "call id" (Some "call-1") !call_id;
+         check string
+           "arguments"
+           {|{"marker":"from-codex"}|}
+           (Yojson.Safe.to_string !arguments))
+;;
+
+let test_history_is_injected_before_turn () =
+  let injected = {|{"id":4,"result":{}}|} in
+  let turn_after_injection = {|{"id":5,"result":{"turn":{"id":"turn-1"}}}|} in
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; injected
+    ; turn_after_injection
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun path ->
+       let history =
+         [ { Runtime_codex_app_server.role = User; text = "previous user" }
+         ; { Runtime_codex_app_server.role = Assistant; text = "previous assistant" }
+         ]
+       in
+       match run_fixture ~history path with
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok result -> check string "text" "MASC_SUBSCRIPTION_OK" result.text)
 ;;
 
 let test_chatgpt_subscription_turn () =
@@ -178,6 +247,71 @@ let test_live_chatgpt_subscription () =
         (String.trim result.subscription.plan_type <> "")
 ;;
 
+let test_live_dynamic_tool_subscription () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let tool_calls = ref 0 in
+    let tool : Runtime_codex_app_server.dynamic_tool =
+      { name = "masc_probe"
+      ; description = "Return the exact marker MASC_TOOL_RESULT"
+      ; input_schema =
+          `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+      ; call =
+          (fun ~call_id:_ _ ->
+            incr tool_calls;
+            { success = true; content = "MASC_TOOL_RESULT" })
+      }
+    in
+    let result =
+      Eio_main.run (fun env ->
+        let config =
+          { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+            timeout_s = 60.0
+          }
+        in
+        Runtime_codex_app_server.run_turn
+          ~mgr:(Eio.Stdenv.process_mgr env)
+          ~clock:(Eio.Stdenv.clock env)
+          ~dynamic_tools:[ tool ]
+          config
+          ~prompt:
+            "Call masc_probe exactly once, then reply with exactly MASC_TOOL_OK.")
+    in
+    match result with
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+    | Ok result ->
+      check int "live dynamic tool calls" 1 !tool_calls;
+      check int "live measured tool calls" 1 result.dynamic_tool_calls;
+      check string "live tool response" "MASC_TOOL_OK" result.text
+;;
+
+let test_live_history_injection_subscription () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let result =
+      Eio_main.run (fun env ->
+        let config =
+          { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+            timeout_s = 60.0
+          }
+        in
+        Runtime_codex_app_server.run_turn
+          ~mgr:(Eio.Stdenv.process_mgr env)
+          ~clock:(Eio.Stdenv.clock env)
+          ~history:
+            [ { role = User; text = "The continuity marker is MASC_HISTORY_OK." }
+            ; { role = Assistant; text = "I will retain that marker." }
+            ]
+          config
+          ~prompt:"Reply with exactly the continuity marker from the prior history.")
+    in
+    match result with
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+    | Ok result -> check string "live history response" "MASC_HISTORY_OK" result.text
+;;
+
 let () =
   run "runtime codex app-server"
     [ ( "subscription boundary"
@@ -190,12 +324,22 @@ let () =
             test_notification_without_params_fails_closed
         ; test_case "server request fails closed" `Quick test_server_request_fails_closed
         ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
+        ; test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
+        ; test_case "history injects before turn" `Quick test_history_is_injected_before_turn
         ] )
     ; ( "live subscription"
       , [ test_case
             "official Codex app-server"
             `Slow
             test_live_chatgpt_subscription
+        ; test_case
+            "official Codex dynamic tool"
+            `Slow
+            test_live_dynamic_tool_subscription
+        ; test_case
+            "official Codex history injection"
+            `Slow
+            test_live_history_injection_subscription
         ] )
     ]
 ;;

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -112,6 +112,17 @@ let test_malformed_json_fails_closed () =
       | Ok _ -> fail "malformed JSON incorrectly admitted")
 ;;
 
+let test_notification_without_params_fails_closed () =
+  let missing_params = {|{"method":"item/completed"}|} in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; missing_params ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "notification without params incorrectly admitted")
+;;
+
 let test_server_request_fails_closed () =
   let request =
     {|{"id":"approval-1","method":"item/commandExecution/requestApproval","params":{}}|}
@@ -173,6 +184,10 @@ let () =
       , [ test_case "ChatGPT turn completes" `Quick test_chatgpt_subscription_turn
         ; test_case "API key is rejected" `Quick test_api_key_account_is_rejected
         ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
+        ; test_case
+            "notification without params fails closed"
+            `Quick
+            test_notification_without_params_fails_closed
         ; test_case "server request fails closed" `Quick test_server_request_fails_closed
         ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
         ] )

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -1,0 +1,186 @@
+open Alcotest
+
+let init_result =
+  {|{"id":1,"result":{"userAgent":"fixture/0.147.0","codexHome":"/tmp/codex","platformFamily":"unix","platformOs":"linux"}}|}
+;;
+
+let account_chatgpt =
+  {|{"id":2,"result":{"account":{"type":"chatgpt","email":"fixture@example.test","planType":"pro"},"requiresOpenaiAuth":true}}|}
+;;
+
+let thread_result =
+  {|{"id":3,"result":{"thread":{"id":"thread-1"},"model":"gpt-fixture"}}|}
+;;
+
+let turn_result = {|{"id":4,"result":{"turn":{"id":"turn-1"}}}|}
+
+let item_completed =
+  {|{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-1","completedAtMs":1,"item":{"type":"agentMessage","id":"message-1","text":"MASC_SUBSCRIPTION_OK","phase":"final_answer"}}}|}
+;;
+
+let turn_completed =
+  {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[{"type":"agentMessage","id":"message-1","text":"MASC_SUBSCRIPTION_OK","phase":"final_answer"}],"status":"completed"}}}|}
+;;
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let rec drop count values =
+  if count <= 0
+  then values
+  else
+    match values with
+    | [] -> []
+    | _ :: rest -> drop (count - 1) rest
+;;
+
+let fixture_script lines =
+  let path = Filename.temp_file "masc-codex-app-server-" ".sh" in
+  let output = open_out_bin path in
+  output_string output "#!/bin/sh\n";
+  output_string output "IFS= read -r ignored\n";
+  output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 0) ^ "\n");
+  output_string output "IFS= read -r ignored\n";
+  output_string output "IFS= read -r ignored\n";
+  output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 1) ^ "\n");
+  output_string output "IFS= read -r ignored\n";
+  output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 2) ^ "\n");
+  output_string output "IFS= read -r ignored\n";
+  List.iter
+    (fun line -> output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
+    (drop 3 lines);
+  close_out output;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let with_fixture lines f =
+  let path = fixture_script lines in
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let run_fixture path =
+  Eio_main.run (fun env ->
+    let config =
+      { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+        cli_path = path
+      ; timeout_s = 2.0
+      }
+    in
+    Runtime_codex_app_server.run_turn
+      ~mgr:(Eio.Stdenv.process_mgr env)
+      ~clock:(Eio.Stdenv.clock env)
+      config
+      ~prompt:"Return the fixture marker")
+;;
+
+let test_chatgpt_subscription_turn () =
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; item_completed; turn_completed ]
+    (fun path ->
+      match run_fixture path with
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok result ->
+        check string "text" "MASC_SUBSCRIPTION_OK" result.text;
+        check string "thread" "thread-1" result.thread_id;
+        check string "turn" "turn-1" result.turn_id;
+        check string "model" "gpt-fixture" result.model;
+        check string "plan" "pro" result.subscription.plan_type)
+;;
+
+let test_api_key_account_is_rejected () =
+  let api_key_account =
+    {|{"id":2,"result":{"account":{"type":"apiKey"},"requiresOpenaiAuth":true}}|}
+  in
+  with_fixture
+    [ init_result; api_key_account; thread_result; turn_result; item_completed; turn_completed ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Subscription_required _) -> ()
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "API-key account incorrectly admitted as subscription")
+;;
+
+let test_malformed_json_fails_closed () =
+  with_fixture
+    [ "not-json"; account_chatgpt; thread_result; turn_result; item_completed; turn_completed ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "malformed JSON incorrectly admitted")
+;;
+
+let test_server_request_fails_closed () =
+  let request =
+    {|{"id":"approval-1","method":"item/commandExecution/requestApproval","params":{}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; request ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Unsupported_server_request method_) ->
+        check string
+          "method"
+          "item/commandExecution/requestApproval"
+          method_
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "unsupported server request incorrectly admitted")
+;;
+
+let test_failed_turn_is_not_completion () =
+  let failed =
+    {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"fixture failure"}}}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; failed ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Turn_failed "fixture failure") -> ()
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "failed turn incorrectly reported as completed")
+;;
+
+let test_live_chatgpt_subscription () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let result =
+      Eio_main.run (fun env ->
+        let config =
+          { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+            timeout_s = 60.0
+          }
+        in
+        Runtime_codex_app_server.run_turn
+          ~mgr:(Eio.Stdenv.process_mgr env)
+          ~clock:(Eio.Stdenv.clock env)
+          config
+          ~prompt:"Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.")
+    in
+    match result with
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+    | Ok result ->
+      check string "live response" "MASC_SUBSCRIPTION_OK" result.text;
+      check bool "subscription plan is present" true
+        (String.trim result.subscription.plan_type <> "")
+;;
+
+let () =
+  run "runtime codex app-server"
+    [ ( "subscription boundary"
+      , [ test_case "ChatGPT turn completes" `Quick test_chatgpt_subscription_turn
+        ; test_case "API key is rejected" `Quick test_api_key_account_is_rejected
+        ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
+        ; test_case "server request fails closed" `Quick test_server_request_fails_closed
+        ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
+        ] )
+    ; ( "live subscription"
+      , [ test_case
+            "official Codex app-server"
+            `Slow
+            test_live_chatgpt_subscription
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- project typed dynamic tool schemas into official Codex app-server threads
- execute host callbacks and return protocol-valid tool results
- inject canonical prior user/assistant history through `thread/inject_items`
- count measured tool calls in the terminal result

## Evidence
- deterministic suite: 8/8 passed in 2.355s
- official ChatGPT subscription, no API key env: 11/11 passed in 21.888s
- live dynamic tool callback: exactly 1 call, exact `MASC_TOOL_OK` response
- live history injection: exact `MASC_HISTORY_OK` recall

## Stack
- base: #27672
- retarget to `main` after #27672 merges