### PR TITLE
refactor(runtime): type official client ownership

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -282,12 +282,15 @@ let validate_provider_request_cap ~runtime_id
 let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with
   | Some runtime ->
-    let* _request_body_cap =
-      validate_provider_request_cap
-        ~runtime_id:runtime.id
-        runtime.Runtime.provider_config
-    in
-    Ok runtime
+    (match runtime.Runtime.execution with
+     | Runtime_execution.Codex_app_server _ -> Ok runtime
+     | Runtime_execution.Agent_core provider_config ->
+       let* _request_body_cap =
+         validate_provider_request_cap
+           ~runtime_id:runtime.id
+           provider_config
+       in
+       Ok runtime)
   | None -> Error (runtime_candidate_missing_error id)
 
 let resolve_runtime_candidate_for_attempt ?on_missing id =
@@ -681,11 +684,23 @@ let run_named
           ~fallback_enable_thinking:enable_thinking
           ()
       in
-      match
-         match provider_config_transform with
-         | None -> Ok runtime.Runtime.provider_config
-         | Some transform -> transform runtime.Runtime.provider_config
-      with
+      match runtime.Runtime.execution with
+      | Runtime_execution.Codex_app_server _ ->
+        Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
+        ( Error
+            (Agent_sdk.Error.Config
+               (Agent_sdk.Error.InvalidConfig
+                  { field = "runtime_execution"
+                  ; detail =
+                      "codex-app-server is materialized as an official-client runtime but is not yet admitted by the Keeper turn driver"
+                  }))
+        , None )
+      | Runtime_execution.Agent_core runtime_provider_config ->
+       (match
+          match provider_config_transform with
+          | None -> Ok runtime_provider_config
+          | Some transform -> transform runtime_provider_config
+        with
       | Error err ->
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         Error err, None
@@ -771,7 +786,7 @@ let run_named
               ~replay_prefix_projection
               provider_result
           in
-          outcomes.turn_result, checkpoint_after))
+          outcomes.turn_result, checkpoint_after)))
     attempt_candidates
 
 

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -65,7 +65,8 @@ let message_of_request (req : Va.request) : Agent_sdk.Types.message =
         ()
     ]
 
-let vision_runtime_candidates () : (string * Runtime.t) list =
+let vision_runtime_candidates ()
+  : (string * Runtime.t * Llm_provider.Provider_config.t) list =
   (* Delegate image-capability admission to the RFC-0265 SSOT
      [Runtime_agent.caps_admit_required_modalities] so a runtime surfaced to the
      vision tool is exactly one the dispatch capability gate would admit. Do NOT
@@ -85,13 +86,16 @@ let vision_runtime_candidates () : (string * Runtime.t) list =
   in
   from_failover @ rest
   |> List.filter_map (fun (rt : Runtime.t) ->
-       let caps = Runtime_agent.input_capabilities_of_runtime rt in
-       if Runtime_agent.caps_admit_required_modalities caps [ "image" ]
-       then Some (rt.Runtime.id, rt)
-       else None)
+       match rt.Runtime.execution with
+       | Runtime_execution.Codex_app_server _ -> None
+       | Runtime_execution.Agent_core provider_config ->
+         let caps = Runtime_agent.input_capabilities_of_runtime rt in
+         if Runtime_agent.caps_admit_required_modalities caps [ "image" ]
+         then Some (rt.Runtime.id, rt, provider_config)
+         else None)
 
 let vision_runtime_ids () : string list =
-  List.map fst (vision_runtime_candidates ())
+  List.map (fun (runtime_id, _, _) -> runtime_id) (vision_runtime_candidates ())
 
 let first_vision_runtime_id () : (string, string) result =
   match vision_runtime_ids () with
@@ -307,7 +311,7 @@ let run_candidates_outcome
            { failure_class = failure_class_of_http_error err
            ; detail = Provider_http_error.to_message err
            })
-    | (runtime_id, rt) :: rest ->
+    | (runtime_id, rt, provider_config) :: rest ->
       let continue_with last_error =
         (if not (List.is_empty rest)
          then sleep_before_next_candidate ~clock ~attempt_index);
@@ -316,7 +320,7 @@ let run_candidates_outcome
           ~attempt_index:(attempt_index + 1)
           rest
       in
-      let config = provider_for_vision rt.Runtime.provider_config in
+      let config = provider_for_vision provider_config in
       match Runtime.validate_request_body_cap ~runtime_id config with
       | Error error ->
         record_vision_candidate_attempt

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -17,9 +17,10 @@ type t =
   ; provider : provider
   ; model : model_spec
   ; binding : binding
-  ; provider_config : Llm_provider.Provider_config.t
-    (** load 시점에 materialize 된 hot-path provider config. 소비자는
-        routing 없이 이걸 곧장 LLM dispatch 로 넘긴다. *)
+  ; execution : Runtime_execution.t
+    (** Turn owner materialized at load time. HTTP bindings become
+        [Agent_core]; official client runtimes remain distinct and can never
+        be dispatched as a fake LLM provider config. *)
   }
 
 (* id 파생의 단일 출처는 {!Runtime_schema.binding_key} — runtime 을 id 로
@@ -35,9 +36,9 @@ let id_of_binding (b : binding) : string = binding_key b
 let of_binding_result (cfg : config) (b : binding) : (t, string) result =
   match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
   | Some provider, Some model ->
-    (match Runtime_adapter.binding_to_provider_config cfg b with
-     | Ok provider_config ->
-       Ok { id = id_of_binding b; provider; model; binding = b; provider_config }
+    (match Runtime_adapter.binding_to_execution cfg b with
+     | Ok execution ->
+       Ok { id = id_of_binding b; provider; model; binding = b; execution }
      | Error reason -> Error reason)
   | None, _ -> Error (Printf.sprintf "provider not found: %s" b.provider_id)
   | Some _, None -> Error (Printf.sprintf "model not found: %s" b.model_id)
@@ -444,7 +445,10 @@ let startup_degradation_to_yojson = function
 ;;
 
 let capabilities_for_runtime (rt : t) =
-  Llm_provider.Provider_config.capabilities_for_config_model rt.provider_config
+  match rt.execution with
+  | Runtime_execution.Agent_core provider_config ->
+    Llm_provider.Provider_config.capabilities_for_config_model provider_config
+  | Runtime_execution.Codex_app_server _ -> None
 ;;
 
 type max_context_source =
@@ -501,7 +505,9 @@ let validate_runtime_max_context ~(config_path : string) (runtimes : t list)
           RFC-0206 §2.1)"
          config_path
          r.id
-         r.provider_config.model_id
+         (match Runtime_execution.model_id r.execution with
+          | Some model_id -> model_id
+          | None -> "<official-client-selected>")
          r.model.id)
 ;;
 
@@ -597,13 +603,16 @@ let validate_keeper_dispatch_request_caps
          match runtime_by_id id with
          | None -> None
          | Some runtime ->
-           (match
-              validate_request_body_cap
-                ~runtime_id:runtime.id
-                runtime.provider_config
-            with
-            | Ok _ -> None
-            | Error _ -> Some runtime))
+           (match runtime.execution with
+            | Runtime_execution.Codex_app_server _ -> None
+            | Runtime_execution.Agent_core provider_config ->
+              (match
+                 validate_request_body_cap
+                   ~runtime_id:runtime.id
+                   provider_config
+               with
+               | Ok _ -> None
+               | Error _ -> Some runtime)))
       ids
   with
   | None -> Ok ()
@@ -631,13 +640,14 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
   let missing_models =
     List.filter_map
       (fun (r : t) ->
-         match capabilities_for_runtime r with
-         | Some _ -> None
-         | None ->
+         match r.execution, capabilities_for_runtime r with
+         | Runtime_execution.Codex_app_server _, _ -> None
+         | Runtime_execution.Agent_core _, Some _ -> None
+         | Runtime_execution.Agent_core provider_config, None ->
            let provider_label =
-             Llm_provider.Provider_config.capability_provider_label r.provider_config
+             Llm_provider.Provider_config.capability_provider_label provider_config
            in
-           let model_id = r.provider_config.model_id in
+           let model_id = provider_config.model_id in
            Some
              { runtime_id = r.id
              ; provider_id = r.provider.id
@@ -1287,7 +1297,7 @@ let temperature_of_runtime_id (id : string) : float option =
 
 let top_p_of_runtime_id (id : string) : float option =
   match get_runtime_by_id id with
-  | Some rt -> rt.provider_config.top_p
+  | Some rt -> rt.model.top_p
   | None -> None
 ;;
 

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -12,7 +12,7 @@ type t =
   ; provider : provider
   ; model : model_spec
   ; binding : binding
-  ; provider_config : Llm_provider.Provider_config.t
+  ; execution : Runtime_execution.t
   }
 
 val id_of_binding : binding -> string

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -203,6 +203,12 @@ let messages_api_compatible_provider_kind = function
 let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.provider)
     : (Llm_provider.Provider_config.provider_kind, string) result =
   match provider.api_format with
+  | Codex_app_server_runtime ->
+    Error
+      (Printf.sprintf
+         "provider %S uses codex-app-server and cannot be materialized as an \
+          HTTP provider"
+         provider.id)
   | Ollama_api -> Ok Llm_provider.Provider_config.Ollama
   | Chat_completions_api ->
     (* Chat-completions keeps the historical OpenAI-compatible fallback when
@@ -452,4 +458,52 @@ let binding_to_provider_config (cfg : Runtime_schema.config) (binding : Runtime_
          ?max_request_body_bytes:binding.max_request_body_bytes
          provider
          spec)
+;;
+
+let codex_app_server_execution (provider : Runtime_schema.provider)
+    (spec : Runtime_schema.model_spec) : (Runtime_execution.t, string) result =
+  match provider.transport with
+  | Http _ ->
+    Error
+      (Printf.sprintf
+         "provider %S uses protocol codex-app-server but declares an HTTP endpoint; \
+          an official Codex CLI command is required"
+         provider.id)
+  | Cli command when String.trim command = "" ->
+    Error (Printf.sprintf "provider %S declares an empty Codex CLI command" provider.id)
+  | Cli command ->
+    (match provider.credentials with
+     | Some _ ->
+       Error
+         (Printf.sprintf
+            "provider %S uses codex-app-server and must not declare credentials; \
+             the official Codex client owns subscription login"
+            provider.id)
+     | None when not provider.is_non_interactive ->
+       Error
+         (Printf.sprintf
+            "provider %S uses codex-app-server and must declare \
+             is-non-interactive = true"
+            provider.id)
+     | None ->
+       Ok
+         (Runtime_execution.Codex_app_server
+            { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
+;;
+
+let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema.binding)
+    : (Runtime_execution.t, string) result =
+  match Runtime_schema.model_of_id cfg binding.model_id with
+  | None -> Error (Printf.sprintf "model not found: %s" binding.model_id)
+  | Some spec ->
+    (match Runtime_schema.provider_of_id cfg binding.provider_id with
+     | None -> Error (Printf.sprintf "provider not found: %s" binding.provider_id)
+     | Some provider ->
+       (match provider.api_format with
+        | Runtime_schema.Codex_app_server_runtime ->
+          codex_app_server_execution provider spec
+        | Messages_api | Chat_completions_api | Ollama_api ->
+          Result.map
+            (fun provider_config -> Runtime_execution.Agent_core provider_config)
+            (binding_to_provider_config cfg binding)))
 ;;

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -29,3 +29,12 @@ val binding_to_provider_config
     Returns [Error reason] (no silent fallback) when the provider or model id
     is unresolved, or when the provider transport/kind cannot be mapped to a
     concrete provider config. *)
+
+val binding_to_execution
+  :  Runtime_schema.config
+  -> Runtime_schema.binding
+  -> (Runtime_execution.t, string) result
+(** Materialize the owner of a complete turn. HTTP model APIs become
+    {!Runtime_execution.Agent_core}. The exact [codex-app-server] protocol over
+    a credential-free CLI transport becomes
+    {!Runtime_execution.Codex_app_server}. Other CLI protocols remain rejected. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -692,8 +692,15 @@ let input_capabilities_for_config (config : config) =
    provider caps overlaid with the model's declared media capabilities (the MASC
    SSOT, [apply_runtime_model_input_capabilities]). *)
 let input_capabilities_of_runtime (rt : Runtime.t) =
+  let provider_caps =
+    match rt.Runtime.execution with
+    | Runtime_execution.Agent_core provider_config ->
+      provider_caps_of_config provider_config
+    | Runtime_execution.Codex_app_server _ ->
+      Llm_provider.Capabilities.default_capabilities
+  in
   apply_runtime_model_input_capabilities
-    (provider_caps_of_config rt.Runtime.provider_config)
+    provider_caps
     (Option.value rt.Runtime.model.capabilities
        ~default:Runtime_schema.model_capabilities_default)
 

--- a/lib/runtime/runtime_execution.ml
+++ b/lib/runtime/runtime_execution.ml
@@ -1,0 +1,33 @@
+type codex_app_server =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
+type t =
+  | Agent_core of Llm_provider.Provider_config.t
+  | Codex_app_server of codex_app_server
+
+type checkpoint_owner =
+  | Masc_oas
+  | Official_client
+
+let agent_core_provider_config = function
+  | Agent_core config -> Some config
+  | Codex_app_server _ -> None
+;;
+
+let model_id = function
+  | Agent_core config -> Some config.Llm_provider.Provider_config.model_id
+  | Codex_app_server config -> config.model
+;;
+
+let label = function
+  | Agent_core _ -> "agent_core"
+  | Codex_app_server _ -> "codex_app_server"
+;;
+
+let checkpoint_owner = function
+  | Agent_core _ -> Masc_oas
+  | Codex_app_server _ -> Official_client
+;;

--- a/lib/runtime/runtime_execution.mli
+++ b/lib/runtime/runtime_execution.mli
@@ -1,0 +1,27 @@
+(** Typed owner of one Runtime turn.
+
+    [Agent_core] means MASC/OAS owns the model/tool/checkpoint loop.
+    [Codex_app_server] means the official Codex client owns the whole turn;
+    MASC owns admission, process lifetime, and result projection. *)
+
+type codex_app_server =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
+type t =
+  | Agent_core of Llm_provider.Provider_config.t
+  | Codex_app_server of codex_app_server
+
+type checkpoint_owner =
+  | Masc_oas
+  | Official_client
+
+val agent_core_provider_config : t -> Llm_provider.Provider_config.t option
+val model_id : t -> string option
+val label : t -> string
+val checkpoint_owner : t -> checkpoint_owner
+(** Typed owner of the runtime's resumable execution state. [Masc_oas]
+    requires an OAS checkpoint on every successful turn. [Official_client]
+    forbids projecting the client's session state into an OAS checkpoint. *)

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -80,13 +80,22 @@ let resolve_runtime_providers ~runtime_id () =
      was ignored here and is deleted;
      each resolved runtime carries exactly one provider_config. *)
   let runtime_id = String.trim runtime_id in
+  let provider_config_of_runtime rt =
+    match rt.Runtime.execution with
+    | Runtime_execution.Agent_core provider_config -> Ok provider_config
+    | Runtime_execution.Codex_app_server _ ->
+      Error
+        (Printf.sprintf
+           "runtime %S is owned by codex-app-server, not the OAS agent_core"
+           rt.Runtime.id)
+  in
   if String.equal runtime_id "" then
     match Runtime.get_default_runtime () with
     | None -> Error "no default runtime configured"
-    | Some rt -> Ok [ rt.Runtime.provider_config ]
+    | Some rt -> Result.map (fun provider_config -> [ provider_config ]) (provider_config_of_runtime rt)
   else
     match Runtime.get_runtime_by_id runtime_id with
-    | Some rt -> Ok [ rt.Runtime.provider_config ]
+    | Some rt -> Result.map (fun provider_config -> [ provider_config ]) (provider_config_of_runtime rt)
     | None ->
       Error
         (Printf.sprintf

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -13,6 +13,7 @@ type api_format =
   | Messages_api
   | Chat_completions_api
   | Ollama_api
+  | Codex_app_server_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -11,6 +11,7 @@ type api_format =
   | Messages_api
   | Chat_completions_api
   | Ollama_api
+  | Codex_app_server_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -106,14 +106,16 @@ let partition_results
 
 let canonical_protocol_of_protocol = function
   | "messages-cli" | "messages-http" | "openai-compatible-cli"
-  | "openai-compatible-http" | "ollama-http" as protocol -> Some protocol
+  | "openai-compatible-http" | "ollama-http" | "codex-app-server" as protocol ->
+    Some protocol
   | _ -> None
 ;;
 
 let unknown_protocol_error s =
   Printf.sprintf
     "unknown protocol %S: expected one of messages-cli, messages-http, \
-     openai-compatible-cli, openai-compatible-http, ollama-http"
+     openai-compatible-cli, openai-compatible-http, ollama-http, \
+     codex-app-server"
     s
 ;;
 
@@ -125,6 +127,7 @@ let api_format_of_protocol (s : string)
   | "openai-compatible-cli" | "openai-compatible-http" ->
     Ok Runtime_schema.Chat_completions_api
   | "ollama-http" -> Ok Runtime_schema.Ollama_api
+  | "codex-app-server" -> Ok Runtime_schema.Codex_app_server_runtime
   | _ -> Error (unknown_protocol_error s)
 ;;
 

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -774,15 +774,17 @@ let dashboard_runtime_append_probe_path base ~suffix =
 
 let dashboard_runtime_probe_url ~(api_format : Runtime_schema.api_format) base_url =
   match api_format with
+  | Runtime_schema.Codex_app_server_runtime -> None
   | Runtime_schema.Ollama_api ->
     let base = dashboard_runtime_trim_trailing_slashes base_url in
-    if String.ends_with ~suffix:"/api/tags" base
-    then base
-    else if String.ends_with ~suffix:"/api" base
-    then base ^ "/tags"
-    else base ^ "/api/tags"
+    Some
+      (if String.ends_with ~suffix:"/api/tags" base
+       then base
+       else if String.ends_with ~suffix:"/api" base
+       then base ^ "/tags"
+       else base ^ "/api/tags")
   | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
-      dashboard_runtime_append_probe_path base_url ~suffix:"/models"
+    Some (dashboard_runtime_append_probe_path base_url ~suffix:"/models")
 ;;
 
 let dashboard_runtime_url_for_json raw =
@@ -882,6 +884,7 @@ let dashboard_runtime_model_count_of_body ~(api_format : Runtime_schema.api_form
   try
     let json = Yojson.Safe.from_string body in
     match api_format with
+    | Runtime_schema.Codex_app_server_runtime -> None
     | Runtime_schema.Ollama_api -> dashboard_runtime_list_member_len "models" json
     | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
       (match dashboard_runtime_list_member_len "data" json with
@@ -981,19 +984,28 @@ let dashboard_runtime_provider_probe_json
       ~error:"CLI runtimes do not expose an HTTP reachability endpoint"
       ()
   | Runtime_schema.Http endpoint_url ->
-    let probe_url = dashboard_runtime_probe_url ~api_format:rt.provider.api_format endpoint_url in
-    let probe_url_json = dashboard_runtime_url_for_json probe_url in
-    if not (dashboard_runtime_http_url_valid probe_url)
-    then
+    begin match dashboard_runtime_probe_url ~api_format:rt.provider.api_format endpoint_url with
+     | None ->
       make
-        ~probe_url:probe_url_json
         ~auth_present:false
-        ~status:"invalid_endpoint"
+        ~status:"invalid_execution_transport"
         ~reachable:(Some false)
         ~skipped:false
-        ~error:"runtime endpoint is not an absolute http(s) URL"
+        ~error:"codex-app-server must use the official CLI transport"
         ()
-    else (
+     | Some probe_url ->
+      let probe_url_json = dashboard_runtime_url_for_json probe_url in
+      if not (dashboard_runtime_http_url_valid probe_url)
+      then
+        make
+          ~probe_url:probe_url_json
+          ~auth_present:false
+          ~status:"invalid_endpoint"
+          ~reachable:(Some false)
+          ~skipped:false
+          ~error:"runtime endpoint is not an absolute http(s) URL"
+          ()
+      else (
       match dashboard_runtime_probe_headers rt.provider with
       | Error error ->
         make
@@ -1042,6 +1054,7 @@ let dashboard_runtime_provider_probe_json
              ~skipped:false
              ~error
              ()))
+    end
 ;;
 
 let dashboard_runtime_probe_payload_json_of_runtimes ?default_id runtimes =
@@ -1524,8 +1537,17 @@ let response_format_json : Llm_provider.Types.response_format -> Yojson.Safe.t =
 ;;
 
 let runtime_request_config_json (rt : Runtime.t) =
-  let cfg = rt.provider_config in
-  `Assoc
+  match rt.execution with
+  | Runtime_execution.Codex_app_server config ->
+    `Assoc
+      [ "source", `String "official-client-runtime"
+      ; "execution", `String "codex_app_server"
+      ; "model", Json_util.string_opt_to_json config.model
+      ; "timeout_s", `Float config.timeout_s
+      ; "verified", `Bool false
+      ]
+  | Runtime_execution.Agent_core cfg ->
+    `Assoc
     [ "source", `String "oas-provider-config"
     ; "provider_kind", `String (Llm_provider.Provider_config.string_of_provider_kind cfg.kind)
     ; "request_path", `String cfg.request_path
@@ -1568,6 +1590,7 @@ let runtime_api_format_wire : Runtime_schema.api_format -> string = function
   | Runtime_schema.Messages_api -> "messages"
   | Runtime_schema.Chat_completions_api -> "chat-completions"
   | Runtime_schema.Ollama_api -> "ollama"
+  | Runtime_schema.Codex_app_server_runtime -> "codex-app-server"
 ;;
 
 let runtime_provider_behavior_capabilities_json
@@ -1670,7 +1693,15 @@ let runtime_declared_spec_json (rt : Runtime.t) =
 ;;
 
 let effective_capabilities_json (rt : Runtime.t) =
-  match Llm_provider.Provider_config.capabilities_for_config_model rt.provider_config with
+  match rt.execution with
+  | Runtime_execution.Codex_app_server _ ->
+    `Assoc
+      [ "source", `String "unverified"
+      ; "execution", `String "codex_app_server"
+      ; "verified", `Bool false
+      ]
+  | Runtime_execution.Agent_core provider_config ->
+   (match Llm_provider.Provider_config.capabilities_for_config_model provider_config with
   | None -> `Null
   | Some caps ->
     let accepted_reasoning_efforts =
@@ -1733,7 +1764,7 @@ let effective_capabilities_json (rt : Runtime.t) =
       ; "supports_code_execution", `Bool caps.supports_code_execution
       ; "emits_usage_tokens", `Bool caps.emits_usage_tokens
       ; "supported_models", supported_models
-      ]
+      ])
 ;;
 
 let runtime_parameter_policy_json (rt : Runtime.t) =
@@ -1743,19 +1774,26 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
     |> List.map Llm_provider.Capabilities.sampling_parameter_to_string
     |> Json_util.json_string_list
   in
-  let dialect = RD.for_provider_config rt.provider_config in
-  let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
-  let ignored_sampling_params =
-    List.filter
-      (fun field -> RD.ignores_sampling_param dialect ~enable_thinking:None field)
-      sampling_candidates
-  in
-  let always_ignored_sampling_params =
-    List.filter
-      (fun field -> RD.ignores_sampling_param dialect ~enable_thinking:(Some false) field)
-      sampling_candidates
-  in
-  `Assoc
+  match rt.execution with
+  | Runtime_execution.Codex_app_server _ ->
+    `Assoc
+      [ "source", `String "official-client-owned"
+      ; "execution", `String "codex_app_server"
+      ]
+  | Runtime_execution.Agent_core provider_config ->
+    let dialect = RD.for_provider_config provider_config in
+    let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
+    let ignored_sampling_params =
+      List.filter
+        (fun field -> RD.ignores_sampling_param dialect ~enable_thinking:None field)
+        sampling_candidates
+    in
+    let always_ignored_sampling_params =
+      List.filter
+        (fun field -> RD.ignores_sampling_param dialect ~enable_thinking:(Some false) field)
+        sampling_candidates
+    in
+    `Assoc
     [ "reasoning_toggle_wire", `String (RD.toggle_wire_to_string dialect.toggle_wire)
     ; "reasoning_replay_policy", `String (RD.replay_policy_to_string dialect.replay_policy)
     ; "requires_reasoning_replay_on_tool_call", `Bool (RD.requires_reasoning_replay_on_tool_call dialect)
@@ -1767,6 +1805,14 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
 
 let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
   let runtime_kind = runtime_kind_of_transport rt.provider.transport in
+  let is_official_client_runtime =
+    match rt.execution with
+    | Runtime_execution.Codex_app_server _ -> true
+    | Runtime_execution.Agent_core _ -> false
+  in
+  let runtime_status =
+    if is_official_client_runtime then "configured_unverified" else "configured"
+  in
   let models = [ rt.model.api_name ] in
   let capabilities_declared, caps =
     match rt.model.capabilities with
@@ -1790,13 +1836,13 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "kind", `String (runtime_dashboard_kind_of_runtime_kind runtime_kind)
     ; "runtime_kind", `String (runtime_kind_to_string runtime_kind)
     ; "auth_kind", `String (runtime_auth_kind_of_credential rt.provider.credentials)
-    ; "status", `String "configured"
-    ; "available", `Bool true
+    ; "status", `String runtime_status
+    ; "available", `Bool (not is_official_client_runtime)
     ; "is_default_runtime", `Bool (Option.equal String.equal default_id (Some rt.id))
     ; "max_context", `Int (Runtime.max_context_of_runtime rt)
-    ; "tools_support", `Bool rt.model.tools_support
-    ; "thinking_support", `Bool rt.model.thinking_support
-    ; "streaming", `Bool rt.model.streaming
+    ; "tools_support", `Bool (rt.model.tools_support && not is_official_client_runtime)
+    ; "thinking_support", `Bool (rt.model.thinking_support && not is_official_client_runtime)
+    ; "streaming", `Bool (rt.model.streaming && not is_official_client_runtime)
       (* Per-model sampling temperature override ([models.<id>].temperature).
          [`Null] when unset (the runtime keeps the fleet fallback). Read-only
          projection for the dashboard runtime capability card. *)
@@ -1840,6 +1886,16 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "effective_capabilities", effective_capabilities_json rt
     ; "parameter_policy", runtime_parameter_policy_json rt
     ; "request_config", runtime_request_config_json rt
+    ; ( "verification"
+      , if is_official_client_runtime
+        then
+          `Assoc
+            [ "status", `String "unverified"
+            ; "measured", `Bool false
+            ; "evidence", `Null
+            ; "reason", `String "no_successful_runtime_observation"
+            ]
+        else `Null )
     ; "declared_spec", runtime_declared_spec_json rt
     ; "model_count", `Int (List.length models)
     ; "models", Json_util.json_string_list models

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -88,21 +88,30 @@ let finalize_runtime_breakdown json =
         ]
   | _ -> json
 
-let validate_requested_model (runtime : Runtime.t) = function
-  | None -> Ok runtime
-  | Some requested_model ->
+let validate_requested_model (runtime : Runtime.t) requested_model =
+  match runtime.execution with
+  | Runtime_execution.Codex_app_server _ ->
+    Error
+      (Printf.sprintf
+         "runtime %S is owned by codex-app-server; local_runtime_bench only \
+          measures OAS agent_core providers"
+         runtime.id)
+  | Runtime_execution.Agent_core provider_config ->
+    (match requested_model with
+     | None -> Ok (runtime, provider_config)
+     | Some requested_model ->
       let requested_model = String.trim requested_model in
       if String.equal requested_model "" then
         Error "model must be a non-empty configured model id"
-      else if String.equal requested_model runtime.provider_config.model_id then
-        Ok runtime
+      else if String.equal requested_model provider_config.model_id then
+        Ok (runtime, provider_config)
       else
         Error
           (Printf.sprintf
              "runtime %S is configured for model %S, not requested model %S"
              runtime.id
-             runtime.provider_config.model_id
-             requested_model)
+             provider_config.model_id
+             requested_model))
 
 let resolve_runtime ?model_id = function
   | None ->
@@ -124,12 +133,13 @@ let resolve_runtime ?model_id = function
                   "runtime %S is not materialized from runtime.toml"
                   runtime_id))
 
-let ensure_runtime_reachable (runtime : Runtime.t) ~timeout_sec =
+let ensure_runtime_reachable (runtime : Runtime.t)
+    (provider_config : Llm_provider.Provider_config.t) ~timeout_sec =
   match runtime.provider.healthcheck_path with
   | None -> Ok ()
   | Some healthcheck_path ->
       let health_url =
-        runtime.provider_config.base_url
+        provider_config.Llm_provider.Provider_config.base_url
         |> Uri.of_string
         |> fun base -> Uri.with_path base healthcheck_path
         |> Uri.to_string
@@ -151,7 +161,9 @@ let ensure_runtime_reachable (runtime : Runtime.t) ~timeout_sec =
        | Error err ->
            Error (Printf.sprintf "runtime %S unavailable: %s" runtime.id err))
 
-let oas_completion_at (runtime : Runtime.t) ~prompt ~max_tokens ~timeout_sec () =
+let oas_completion_at (runtime : Runtime.t)
+    (provider_config : Llm_provider.Provider_config.t) ~prompt ~max_tokens
+    ~timeout_sec () =
   match Masc_eio_env.get_opt () with
   | None ->
       (* MASC-OAS boundary: raw curl fallback removed.
@@ -162,7 +174,7 @@ let oas_completion_at (runtime : Runtime.t) ~prompt ~max_tokens ~timeout_sec () 
   | Some env -> (
       let started = Time_compat.now () in
       let provider_config =
-        { runtime.provider_config with max_tokens = Some max_tokens }
+        { provider_config with max_tokens = Some max_tokens }
       in
           let messages : Oas_types.message list = [ Oas_types.user_msg prompt ] in
           let run_completion () =
@@ -193,8 +205,8 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
     ~timeout_sec () =
   match resolve_runtime ?model_id runtime_pool with
   | Error _ as err -> err
-  | Ok runtime ->
-    (match ensure_runtime_reachable runtime ~timeout_sec with
+  | Ok (runtime, provider_config) ->
+    (match ensure_runtime_reachable runtime provider_config ~timeout_sec with
      | Error _ as err -> err
      | Ok () ->
       let total = parallelism * rounds in
@@ -206,7 +218,8 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
           (List.init parallelism (fun fiber_idx ->
                fun () ->
                  let sample, runtime_id =
-                   oas_completion_at runtime ~prompt ~max_tokens ~timeout_sec ()
+                   oas_completion_at runtime provider_config ~prompt ~max_tokens
+                     ~timeout_sec ()
                  in
                  update_runtime_breakdown runtime_breakdown ~runtime_id ~sample;
                  results.(offset + fiber_idx) <- Some sample))
@@ -237,9 +250,9 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
       Ok
         (`Assoc
           [
-            ("server_url", `String runtime.provider_config.base_url);
+            ("server_url", `String provider_config.base_url);
             ("source", `String "oas_complete");
-            ("model_id", `String runtime.provider_config.model_id);
+            ("model_id", `String provider_config.model_id);
             ("runtime_pool", `String runtime.id);
             ("parallelism", `Int parallelism);
             ("rounds", `Int rounds);

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -576,10 +576,12 @@ let test_provider_for_vision_uses_runtime_temperature () =
       (match Runtime.get_runtime_by_id runtime_id with
        | None -> failwith "selected vision runtime should resolve"
        | Some runtime ->
-         let configured =
-           Vt.provider_for_vision runtime.Runtime.provider_config
-         in
-         assert (configured.temperature = Some 1.0)))
+         (match runtime.Runtime.execution with
+          | Runtime_execution.Codex_app_server _ ->
+            failwith "selected vision runtime should be agent_core"
+          | Runtime_execution.Agent_core provider_config ->
+            let configured = Vt.provider_for_vision provider_config in
+            assert (configured.temperature = Some 1.0))))
 
 let test_uncapped_vision_fallback_rejects_before_provider_call () =
   with_temp_runtime_toml uncapped_vision_fallback_runtime_toml (fun () ->

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -10,6 +10,13 @@ let parse_or_fail content =
   | Ok doc -> doc
   | Error msg -> failf "TOML parse failed: %s" msg
 
+let agent_core_provider_config (runtime : Runtime.t) =
+  match runtime.execution with
+  | Runtime_execution.Agent_core provider_config -> provider_config
+  | Runtime_execution.Codex_app_server _ ->
+    failf "runtime %s is not an agent_core provider" runtime.id
+;;
+
 let rec repo_root_from dir =
   let dune_project = Filename.concat dir "dune-project" in
   if Sys.file_exists dune_project then dir
@@ -309,7 +316,7 @@ let assert_ollama_cloud_seed_runtime runtimes case =
     check bool (case.runtime_id ^ " known to provider-qualified OAS catalog") true
       (Option.is_some
          (Llm_provider.Provider_config.capabilities_for_config_model
-            runtime.provider_config));
+            (agent_core_provider_config runtime)));
     (match runtime.model.capabilities with
      | None -> failf "expected capabilities for %s" case.runtime_id
      | Some caps ->
@@ -657,7 +664,7 @@ let test_repo_runtime_bindings_resolve_through_oas_provider_config () =
       (fun (runtime : Runtime.t) ->
          match
            Llm_provider.Provider_config.capabilities_for_config_model
-             runtime.provider_config
+             (agent_core_provider_config runtime)
          with
          | None ->
            failf
@@ -665,8 +672,8 @@ let test_repo_runtime_bindings_resolve_through_oas_provider_config () =
               OAS Provider_config"
              runtime.id
              (Llm_provider.Provider_config.capability_provider_label
-                runtime.provider_config)
-             runtime.provider_config.model_id
+                (agent_core_provider_config runtime))
+             (agent_core_provider_config runtime).model_id
          | Some _ ->
            if String.equal runtime.id "ollama_cloud.ollama-cloud-rnj-1-8b"
            then
@@ -674,7 +681,8 @@ let test_repo_runtime_bindings_resolve_through_oas_provider_config () =
                bool
                "runtime-local alias uses the typed Provider_config override"
                true
-               (Option.is_some runtime.provider_config.model_capabilities_override))
+               (Option.is_some
+                  (agent_core_provider_config runtime).model_capabilities_override))
       runtimes
 
 let test_deployment_oas_model_catalog_modality_priorities_resolve () =
@@ -839,7 +847,7 @@ List.iter
   config.exact_output_lane_decls);
     check (option (float 0.0)) "Ollama Cloud connect timeout override"
       (Some 600.0)
-      default.provider_config.connect_timeout_s;
+      (agent_core_provider_config default).connect_timeout_s;
     check int "public seed has no keeper assignments" 0
       (List.length assignments);
     let keeper_dispatch_ids =
@@ -859,7 +867,7 @@ List.iter
          with
          | None -> failf "expected bounded Keeper runtime in seed: %s" runtime_id
          | Some runtime ->
-           (match runtime.provider_config.max_request_body_bytes with
+           (match (agent_core_provider_config runtime).max_request_body_bytes with
             | Some cap when cap > 0 -> ()
             | None | Some _ ->
               failf
@@ -910,7 +918,7 @@ List.iter
      | Some runtime ->
        check (option (float 0.0)) "DeepSeek keeps OAS connect timeout default"
          None
-         runtime.provider_config.connect_timeout_s;
+         (agent_core_provider_config runtime).connect_timeout_s;
        (match runtime.model.capabilities with
         | Some caps ->
           check bool "DeepSeek Pro structured output disabled" false
@@ -964,7 +972,7 @@ List.iter
          runtime.model.api_name;
        check (option (float 0.0)) "native MiniMax M3 connect timeout"
          (Some 600.0)
-         runtime.provider_config.connect_timeout_s;
+         (agent_core_provider_config runtime).connect_timeout_s;
        (match runtime.model.capabilities with
        | Some caps ->
          check bool "native MiniMax M3 response_format json" true
@@ -2522,9 +2530,9 @@ let test_runtime_toml_max_concurrent_flows_to_provider_config () =
             (option int)
             (Printf.sprintf "%s provider_config max_concurrent_requests" id)
             expected
-            rt.Runtime.provider_config.max_concurrent_requests;
+            (agent_core_provider_config rt).max_concurrent_requests;
           let selected_provider_config =
-            Runtime_candidate.of_provider_config rt.Runtime.provider_config
+            Runtime_candidate.of_provider_config (agent_core_provider_config rt)
             |> Runtime_candidate.provider_cfg
           in
           check
@@ -3150,11 +3158,67 @@ let test_runtime_assignment_default_rider_resolves_to_default_runtime () =
              "local.good"
              (Runtime.get_default_runtime_id ())))
 
+let codex_app_server_runtime_toml ?credential () =
+  let credential = Option.value credential ~default:"" in
+  Printf.sprintf
+    "[providers.codex]\n\
+     protocol = \"codex-app-server\"\n\
+     command = \"codex\"\n\
+     is-non-interactive = true\n\
+     %s\n\
+     [models.codex]\n\
+     api-name = \"gpt-5.6-sol\"\n\
+     max-context = 400000\n\
+     \n\
+     [codex.codex]\n\
+     \n\
+     [runtime]\n\
+     default = \"codex.codex\"\n"
+    credential
+;;
+
+let test_codex_app_server_materializes_as_turn_runtime () =
+  with_temp_runtime_toml (codex_app_server_runtime_toml ()) (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error error -> failf "codex-app-server runtime should load: %s" error
+    | Ok (runtimes, default, _, _, _, _) ->
+      check int "one runtime" 1 (List.length runtimes);
+      check string "default id" "codex.codex" default.id;
+      (match default.execution with
+       | Runtime_execution.Agent_core _ ->
+         fail "codex-app-server was incorrectly materialized as agent_core"
+       | Runtime_execution.Codex_app_server config ->
+         check string "cli path" "codex" config.cli_path;
+         check (option string) "model" (Some "gpt-5.6-sol") config.model))
+;;
+
+let test_codex_app_server_rejects_declared_credentials () =
+  let credential =
+    "[providers.codex.credentials]\n\
+     type = \"env\"\n\
+     key = \"OPENAI_API_KEY\""
+  in
+  with_temp_runtime_toml
+    (codex_app_server_runtime_toml ~credential ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> fail "codex-app-server incorrectly admitted declared credentials"
+       | Error error ->
+         check bool "diagnostic names official subscription ownership" true
+           (String_util.contains_substring
+              error
+              "official Codex client owns subscription login"))
+;;
+
 let () =
   run "runtime_config_validity"
     [ ( "runtime TOML gate",
         [ test_case "runtime.json is not a repo config source" `Quick
             test_runtime_json_not_in_repo_config;
+          test_case "codex app-server is a distinct turn runtime" `Quick
+            test_codex_app_server_materializes_as_turn_runtime;
+          test_case "codex app-server rejects declared credentials" `Quick
+            test_codex_app_server_rejects_declared_credentials;
           test_case "deployment OAS catalog covers live RunPod MTP runtime" `Quick
             test_deployment_oas_model_catalog_covers_live_runpod_mtp;
           test_case

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -345,6 +345,36 @@ let with_runtime_initialized f =
   with_runtime_file (fun _path -> f ())
 ;;
 
+let codex_runtime_config =
+  {|[providers.codex]
+protocol = "codex-app-server"
+command = "codex"
+is-non-interactive = true
+
+[models.codex]
+api-name = "gpt-5.6-sol"
+max-context = 400000
+
+[codex.codex]
+
+[runtime]
+default = "codex.codex"
+|}
+;;
+
+let with_codex_runtime_initialized f =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       with_temp_dir "runtime-codex-dashboard" @@ fun dir ->
+       let path = Filename.concat dir "runtime.toml" in
+       write_file path codex_runtime_config;
+       match Runtime.init_default ~config_path:path with
+       | Error msg -> Alcotest.failf "Codex runtime init failed: %s" msg
+       | Ok () -> f ())
+;;
+
 let test_messages_http_runtime_loads_and_assignment_resolves () =
   let snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
@@ -490,6 +520,47 @@ let test_runtime_inventory_surfaces_assignment_status () =
       (match gpt |> J.member "temperature" with
        | `Null -> true
        | _ -> false))
+;;
+
+let test_codex_runtime_inventory_is_unverified_until_measured () =
+  with_codex_runtime_initialized (fun () ->
+    let entry =
+      Server_dashboard_http_runtime_info.runtime_inventory_json ()
+      |> J.member "providers"
+      |> J.to_list
+      |> List.find (fun entry ->
+        String.equal
+          "codex.codex"
+          (entry |> J.member "runtime_id" |> J.to_string))
+    in
+    Alcotest.(check string)
+      "status"
+      "configured_unverified"
+      (entry |> J.member "status" |> J.to_string);
+    Alcotest.(check bool)
+      "not available without runtime evidence"
+      false
+      (entry |> J.member "available" |> J.to_bool);
+    let verification = entry |> J.member "verification" in
+    Alcotest.(check bool)
+      "not measured"
+      false
+      (verification |> J.member "measured" |> J.to_bool);
+    Alcotest.(check string)
+      "reason"
+      "no_successful_runtime_observation"
+      (verification |> J.member "reason" |> J.to_string))
+;;
+
+let test_codex_runtime_cannot_enter_oas_runner () =
+  with_codex_runtime_initialized (fun () ->
+    match Runtime_oas_runner.resolve_runtime_providers ~runtime_id:"codex.codex" () with
+    | Ok _ -> Alcotest.fail "Codex official-client runtime entered the OAS runner"
+    | Error detail ->
+      Alcotest.(check bool)
+        "typed ownership diagnostic"
+        true
+        (string_contains detail "not the OAS agent_core"))
 ;;
 
 let test_runtime_inventory_surfaces_declared_model_capabilities () =
@@ -826,7 +897,10 @@ let test_get_runtime_by_id_resolves_and_fails_fast () =
 
 let provider_base_url_of_runtime_id runtime_id =
   match Runtime.get_runtime_by_id runtime_id with
-  | Some rt -> rt.Runtime.provider_config.Llm_provider.Provider_config.base_url
+  | Some { Runtime.execution = Runtime_execution.Agent_core provider_config; _ } ->
+    provider_config.Llm_provider.Provider_config.base_url
+  | Some rt ->
+    Alcotest.failf "fixture runtime %s is not agent_core" rt.Runtime.id
   | None -> Alcotest.failf "fixture runtime %s missing from catalog" runtime_id
 ;;
 
@@ -1818,6 +1892,10 @@ let () =
             `Quick
             test_runtime_inventory_surfaces_assignment_status
         ; Alcotest.test_case
+            "dashboard Codex runtime stays unavailable until measured"
+            `Quick
+            test_codex_runtime_inventory_is_unverified_until_measured
+        ; Alcotest.test_case
             "dashboard runtime inventory reports transport kind"
             `Quick
             test_runtime_inventory_reports_transport_kind
@@ -1891,6 +1969,10 @@ let () =
             "of_meta projection prefers the routed runtime"
             `Quick
             test_of_meta_projection_budgets_against_routed_runtime
+        ; Alcotest.test_case
+            "Codex official-client runtime cannot enter OAS runner"
+            `Quick
+            test_codex_runtime_cannot_enter_oas_runner
         ] )
     ; ( "per-model thinking gate"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- replace the fake universal provider-config field with typed `Agent_core | Codex_app_server` execution ownership
- materialize exact `protocol = "codex-app-server"` runtime config without credentials or HTTP transport
- reject official-client runtimes at OAS, vision, and local provider-benchmark boundaries
- project Codex dashboard state as `configured_unverified` until measured runtime evidence exists
- keep Keeper execution fail-closed for this stack; the following PR owns admission

## Evidence
- runtime config validity: 58/58 passed
- per-Keeper routing and dashboard contracts: 40/40 passed
- Keeper vision tool assertions: passed
- `git diff --check`: passed

## Stack
- base: #27685
- retarget after #27685 merges