### PR TITLE
feat(runtime): run Codex subscriptions through Keeper

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -344,9 +344,19 @@ let finalize
        assistant_msg;
      capture_replay_response ~response_text
    | _ -> ());
-  let saved_checkpoint_result =
-    match result.checkpoint with
-    | Some result_checkpoint ->
+  let checkpoint_owner_result =
+    match Runtime.get_runtime_by_id runtime_id_string with
+    | Some runtime -> Ok (Runtime_execution.checkpoint_owner runtime.execution)
+    | None ->
+      Error
+        (checkpoint_persistence_error
+           ~keeper_name:meta.name
+           ~detail:
+             (Printf.sprintf
+                "runtime disappeared before checkpoint finalization: %s"
+                runtime_id_string))
+  in
+  let save_oas_checkpoint result_checkpoint =
       let checkpoint, source_already_persisted =
         select_finalization_checkpoint
           ~last_persisted_checkpoint
@@ -440,7 +450,8 @@ let finalize
            (checkpoint_persistence_error
               ~keeper_name:meta.name
               ~detail:("OAS checkpoint save failed: " ^ e))))
-    | None ->
+  in
+  let missing_oas_checkpoint () =
       Log.Keeper.error ~keeper_name:meta.name
         "runtime=%s missing OAS checkpoint after run"
         (Keeper_meta_contract.runtime_id_of_meta meta);
@@ -452,6 +463,29 @@ let finalize
         (checkpoint_persistence_error
            ~keeper_name:meta.name
            ~detail:"missing OAS checkpoint after run")
+  in
+  let unexpected_oas_checkpoint () =
+    Log.Keeper.error ~keeper_name:meta.name
+      "runtime=%s official-client runtime returned an OAS checkpoint"
+      (Keeper_meta_contract.runtime_id_of_meta meta);
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string CheckpointFailures)
+      ~labels:[ "keeper", meta.name; "site", "owner_mismatch" ]
+      ();
+    Error
+      (checkpoint_persistence_error
+         ~keeper_name:meta.name
+         ~detail:"official-client runtime returned an OAS checkpoint")
+  in
+  let saved_checkpoint_result =
+    match checkpoint_owner_result, result.checkpoint with
+    | Error error, _ -> Error error
+    | Ok Runtime_execution.Masc_oas, Some result_checkpoint ->
+      save_oas_checkpoint result_checkpoint
+    | Ok Runtime_execution.Masc_oas, None -> missing_oas_checkpoint ()
+    | Ok Runtime_execution.Official_client, Some _ ->
+      unexpected_oas_checkpoint ()
+    | Ok Runtime_execution.Official_client, None -> Ok None
   in
   match saved_checkpoint_result with
   | Error e -> Error e

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -1,0 +1,548 @@
+open Result.Syntax
+
+let config_error ~field detail =
+  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })
+;;
+
+let internal_error detail = Agent_sdk.Error.Internal detail
+
+let text_of_blocks ~field blocks =
+  let rec loop texts = function
+    | [] -> Ok (String.concat "\n" (List.rev texts))
+    | Agent_sdk.Types.Text text :: rest -> loop (text :: texts) rest
+    | _ :: _ ->
+      Error
+        (config_error
+           ~field
+           "codex-app-server Keeper projection currently admits text blocks only")
+  in
+  loop [] blocks
+;;
+
+let project_messages messages =
+  let rec loop developer history = function
+    | [] -> Ok (List.rev developer, List.rev history)
+    | (message : Agent_sdk.Types.message) :: rest ->
+      let* text = text_of_blocks ~field:"initial_messages" message.content in
+      (match message.role with
+       | Agent_sdk.Types.System -> loop (text :: developer) history rest
+       | Agent_sdk.Types.User ->
+         loop developer
+           ({ Runtime_codex_app_server.role = User; text } :: history)
+           rest
+       | Agent_sdk.Types.Assistant ->
+         loop developer
+           ({ Runtime_codex_app_server.role = Assistant; text } :: history)
+           rest
+       | Agent_sdk.Types.Tool ->
+         Error
+           (config_error
+              ~field:"initial_messages"
+              "codex-app-server history injection does not admit OAS tool messages"))
+  in
+  loop [] [] messages
+;;
+
+let user_message text : Agent_sdk.Types.message =
+  { role = User
+  ; content = [ Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let system_message text : Agent_sdk.Types.message =
+  { role = System
+  ; content = [ Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let last_tool_results messages =
+  messages
+  |> List.rev
+  |> List.find_map (fun (message : Agent_sdk.Types.message) ->
+    match message.role with
+    | Tool ->
+      Some
+        (List.filter_map
+           (function
+             | Agent_sdk.Types.ToolResult { content; outcome; _ } ->
+               Some (Agent_sdk.Types.tool_result_of_outcome ~content outcome)
+             | _ -> None)
+           message.content)
+    | System | User | Assistant -> None)
+  |> Option.value ~default:[]
+;;
+
+let hook_error ~hook_name ~stage detail =
+  internal_error
+    (Printf.sprintf
+       "Codex runtime %s hook failed at %s: %s"
+       hook_name
+       (Agent_sdk.Hooks.hook_stage_to_string stage)
+       detail)
+;;
+
+let illegal_hook_decision ~hook_name decision =
+  config_error
+    ~field:"hooks"
+    (Printf.sprintf
+       "Codex runtime %s hook returned unsupported decision %s"
+       hook_name
+       (Agent_sdk.Hooks.decision_kind_to_string
+          (Agent_sdk.Hooks.classify_decision decision)))
+;;
+
+let invoke_turn_hook ~keeper_name ~hook_name hook event =
+  Agent_sdk.Agent_tools.invoke_hook
+    ~tracer:Agent_sdk.Tracing.null
+    ~agent_name:keeper_name
+    ~turn_count:1
+    ~hook_name
+    hook
+    event
+;;
+
+type prepared_turn =
+  { messages : Agent_sdk.Types.message list
+  ; system_prompt : string
+  ; tools : Agent_sdk.Tool.t list
+  ; reasoning_effort : Llm_provider.Reasoning_effort.t option
+  }
+
+let prepare_turn ~keeper_name ~system_prompt ~tools ~initial_messages
+    ~model_input_projection ~hooks ~enable_thinking =
+  let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
+  let before_turn =
+    invoke_turn_hook
+      ~keeper_name
+      ~hook_name:"before_turn"
+      hooks.before_turn
+      (Agent_sdk.Hooks.BeforeTurn { turn = 1; messages = initial_messages })
+  in
+  let* messages =
+    match before_turn with
+    | Continue -> Ok initial_messages
+    | Nudge text -> Ok (initial_messages @ [ user_message text ])
+    | HookFailed { stage; detail } -> Error (hook_error ~hook_name:"before_turn" ~stage detail)
+    | decision -> Error (illegal_hook_decision ~hook_name:"before_turn" decision)
+  in
+  let current_params =
+    { Agent_sdk.Hooks.default_turn_params with enable_thinking }
+  in
+  let before_turn_params =
+    invoke_turn_hook
+      ~keeper_name
+      ~hook_name:"before_turn_params"
+      hooks.before_turn_params
+      (Agent_sdk.Hooks.BeforeTurnParams
+         { turn = 1
+         ; messages
+         ; last_tool_results = last_tool_results messages
+         ; current_params
+         ; reasoning = Agent_sdk.Hooks.empty_reasoning_summary
+         })
+  in
+  let* turn_params =
+    match before_turn_params with
+    | Continue -> Ok current_params
+    | AdjustParams params -> Ok params
+    | HookFailed { stage; detail } ->
+      Error (hook_error ~hook_name:"before_turn_params" ~stage detail)
+    | decision -> Error (illegal_hook_decision ~hook_name:"before_turn_params" decision)
+  in
+  let messages =
+    match turn_params.extra_system_context with
+    | None -> messages
+    | Some text -> messages @ [ system_message text ]
+  in
+  let* messages =
+    match model_input_projection with
+    | None -> Ok messages
+    | Some project ->
+      (try
+         match project messages with
+         | Ok projected -> Ok projected
+         | Error detail -> Error (config_error ~field:"model_input_projection" detail)
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn ->
+         Error
+           (internal_error
+              ("Codex runtime model input projection raised: "
+               ^ Printexc.to_string exn)))
+  in
+  let system_prompt =
+    Option.value turn_params.system_prompt_override ~default:system_prompt
+  in
+  let unsupported_parameter field value =
+    match value with
+    | None -> Ok ()
+    | Some _ ->
+      Error
+        (config_error
+           ~field
+           "codex-app-server does not yet project this turn parameter; refusing to ignore it")
+  in
+  let* () = unsupported_parameter "temperature" turn_params.temperature in
+  let* () = unsupported_parameter "thinking_budget" turn_params.thinking_budget in
+  let* () = unsupported_parameter "preserve_thinking" turn_params.preserve_thinking in
+  let* reasoning_effort =
+    match turn_params.enable_thinking, turn_params.reasoning_effort with
+    | Some false, Some Llm_provider.Reasoning_effort.None_
+    | Some false, None -> Ok (Some Llm_provider.Reasoning_effort.None_)
+    | Some false, Some _ ->
+      Error
+        (config_error
+           ~field:"reasoning_effort"
+           "enable_thinking=false conflicts with a non-none reasoning effort")
+    | Some true, Some Llm_provider.Reasoning_effort.None_ ->
+      Error
+        (config_error
+           ~field:"reasoning_effort"
+           "enable_thinking=true conflicts with reasoning effort none")
+    | (Some true | None), reasoning_effort -> Ok reasoning_effort
+  in
+  let* tools =
+    match turn_params.tool_choice with
+    | None | Some Auto -> Ok tools
+    | Some None_ -> Ok []
+    | Some (Any | Tool _) as choice ->
+      Error
+        (config_error
+           ~field:"tool_choice"
+           (Printf.sprintf
+              "Codex dynamic tools do not support forced tool choice %s"
+              (Yojson.Safe.to_string
+                 (Agent_sdk.Types.tool_choice_to_json (Option.get choice)))))
+  in
+  Ok { messages; system_prompt; tools; reasoning_effort }
+;;
+
+let tool_hook_error_to_string = function
+  | Agent_sdk.Agent_tools.Hook_execution_failed
+      { hook_name; stage; tool_name; detail; _ } ->
+    Printf.sprintf
+      "%s hook failed at %s for tool %s: %s"
+      hook_name
+      (Agent_sdk.Hooks.hook_stage_to_string stage)
+      tool_name
+      detail
+;;
+
+let record_terminal_error terminal_error detail =
+  if Option.is_none !terminal_error then terminal_error := Some detail
+;;
+
+let apply_context_injection ~terminal_error ~context ~context_injector ~tool_name
+    ~input ~content ~outcome =
+  match context_injector with
+  | None -> ()
+  | Some inject ->
+    let output = Agent_sdk.Types.tool_result_of_outcome ~content outcome in
+    (try
+       match inject ~tool_name ~input ~output with
+       | None -> ()
+       | Some (injection : Agent_sdk.Hooks.injection) ->
+         List.iter (fun (key, value) -> Agent_sdk.Context.set context key value)
+           injection.context_updates;
+         if injection.extra_messages <> []
+         then
+           record_terminal_error
+             terminal_error
+             "Codex dynamic tool context injection produced extra_messages, which cannot be projected into an active app-server turn"
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       record_terminal_error
+         terminal_error
+         ("Codex dynamic tool context injection raised after execution: "
+          ^ Printexc.to_string exn))
+;;
+
+let dynamic_tool_of_oas ~keeper_name ~context ~tools
+    ~(hooks : Agent_sdk.Hooks.hooks) ~event_bus ~context_injector ~terminal_error
+    (tool : Agent_sdk.Tool.t) =
+  { Runtime_codex_app_server.name = tool.schema.name
+  ; description = tool.schema.description
+  ; input_schema = Agent_sdk.Types.params_to_input_schema tool.schema.parameters
+  ; call =
+      (fun ~call_id input ->
+        let schedule : Agent_sdk.Tool_contract.schedule =
+          { planned_index = 0
+          ; batch_index = 0
+          ; batch_size = 1
+          ; execution_mode = Agent_sdk.Tool.execution_mode tool
+          }
+        in
+        let invocation =
+          Agent_sdk.Tool_contract.Invocation.create
+            ~tool_use_id:call_id
+            ~turn:1
+            ~schedule
+            ~completion:(Agent_sdk.Tool.completion tool)
+        in
+        let pre_tool_use =
+          invoke_turn_hook
+            ~keeper_name
+            ~hook_name:"pre_tool_use"
+            hooks.pre_tool_use
+            (Agent_sdk.Hooks.PreToolUse
+               { invocation
+               ; tool_name = tool.schema.name
+               ; input
+               ; accumulated_cost_usd = 0.0
+               })
+        in
+        match pre_tool_use with
+        | Block detail -> { Runtime_codex_app_server.success = false; content = detail }
+        | HookFailed { stage; detail } ->
+          let detail =
+            Printf.sprintf
+              "pre_tool_use hook failed at %s: %s"
+              (Agent_sdk.Hooks.hook_stage_to_string stage)
+              detail
+          in
+          { Runtime_codex_app_server.success = false; content = detail }
+        | (ElicitToolApproval _ | ElicitInput _) as decision ->
+          let detail =
+            Printf.sprintf
+              "Codex dynamic tool cannot settle hook decision %s without a host approval callback"
+              (Agent_sdk.Hooks.decision_kind_to_string
+                 (Agent_sdk.Hooks.classify_decision decision))
+          in
+          record_terminal_error terminal_error detail;
+          { Runtime_codex_app_server.success = false; content = detail }
+        | (AdjustParams _ | Nudge _) as decision ->
+          let detail =
+            Printf.sprintf
+              "Codex dynamic tool received illegal pre_tool_use decision %s"
+              (Agent_sdk.Hooks.decision_kind_to_string
+                 (Agent_sdk.Hooks.classify_decision decision))
+          in
+          record_terminal_error terminal_error detail;
+          { Runtime_codex_app_server.success = false; content = detail }
+        | Continue ->
+          (match
+             Agent_sdk.Agent_tools.find_and_execute_tool
+               ~context
+               ~tools
+               ~hooks
+               ~event_bus
+               ~tracer:Agent_sdk.Tracing.null
+               ~agent_name:keeper_name
+               ~invocation
+               tool.schema.name
+               input
+           with
+           | Ok result ->
+             apply_context_injection
+               ~terminal_error
+               ~context
+               ~context_injector
+               ~tool_name:result.tool_name
+               ~input:result.input
+               ~content:result.content
+               ~outcome:result.outcome;
+             { Runtime_codex_app_server.success =
+                 not (Agent_sdk.Types.tool_result_outcome_is_error result.outcome)
+             ; content = result.content
+             }
+           | Error error ->
+             let detail = tool_hook_error_to_string error in
+             (match error with
+              | Agent_sdk.Agent_tools.Hook_execution_failed
+                  { stage = (Post_tool_use | Post_tool_use_failure); _ } ->
+                record_terminal_error terminal_error detail;
+                { Runtime_codex_app_server.success = true
+                ; content = "Tool completed, but its post-execution hook failed; do not retry"
+                }
+              | Agent_sdk.Agent_tools.Hook_execution_failed _ ->
+                { Runtime_codex_app_server.success = false; content = detail })))
+  }
+;;
+
+let dynamic_tools ~keeper_name ~tools ~hooks ~event_bus ~context_injector ~context
+    ~terminal_error =
+  match tools, context with
+  | [], _ -> Ok []
+  | _ :: _, None ->
+    Error
+      (config_error
+         ~field:"context"
+         "Codex dynamic tools require the Keeper shared context")
+  | tools, Some context ->
+    Ok
+      (List.map
+         (dynamic_tool_of_oas
+            ~keeper_name
+            ~context
+            ~tools
+            ~hooks
+            ~event_bus
+            ~context_injector
+            ~terminal_error)
+         tools)
+;;
+
+let codex_error_to_sdk_error = function
+  | Runtime_codex_app_server.Invalid_config detail ->
+    config_error ~field:"codex_app_server" detail
+  | Runtime_codex_app_server.Subscription_required detail ->
+    config_error ~field:"codex_subscription" detail
+  | error -> Agent_sdk.Error.Internal (Runtime_codex_app_server.error_to_string error)
+;;
+
+let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~tools
+    ~initial_messages ~model_input_projection ~hooks ~context_injector ~context ~event_bus
+    ~enable_thinking ~(config : Runtime_execution.codex_app_server) =
+  match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
+  | None, _ ->
+    Error
+      (config_error
+         ~field:"eio_env"
+         "Codex app-server runtime requires the initialized Eio standard environment")
+  | _, None ->
+    Error
+      (config_error
+         ~field:"eio_clock"
+         "Codex app-server runtime requires the initialized Eio clock")
+  | Some env, Some clock ->
+    let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
+    let* prepared =
+      prepare_turn
+        ~keeper_name
+        ~system_prompt
+        ~tools
+        ~initial_messages
+        ~model_input_projection
+        ~hooks:(Some hooks)
+        ~enable_thinking
+    in
+    let* developer_messages, history = project_messages prepared.messages in
+    let* prompt =
+      match goal_blocks with
+      | None -> Ok goal
+      | Some blocks -> text_of_blocks ~field:"goal_blocks" blocks
+    in
+    let developer_instructions =
+      prepared.system_prompt :: developer_messages
+      |> List.filter (fun text -> String.trim text <> "")
+      |> String.concat "\n\n"
+      |> String_util.trim_to_option
+    in
+    let client_config =
+      { Runtime_codex_app_server.cli_path = config.cli_path
+      ; cwd = base_path
+      ; model = config.model
+      ; developer_instructions
+      ; timeout_s = config.timeout_s
+      }
+    in
+    let terminal_error = ref None in
+    let* dynamic_tools =
+      dynamic_tools
+        ~keeper_name
+        ~tools:prepared.tools
+        ~hooks
+        ~event_bus
+        ~context_injector
+        ~context
+        ~terminal_error
+    in
+    let started_at = Time_compat.now () in
+    (match
+       Runtime_codex_app_server.run_turn
+         ~mgr:(Eio.Stdenv.process_mgr env)
+         ~clock
+         ~dynamic_tools
+         ?reasoning_effort:prepared.reasoning_effort
+         ~history
+         client_config
+         ~prompt
+     with
+     | Error error -> Error (codex_error_to_sdk_error error)
+     | Ok _ when Option.is_some !terminal_error ->
+       Error (internal_error (Option.get !terminal_error))
+     | Ok turn ->
+       let latency_ms = Int.of_float ((Time_compat.now () -. started_at) *. 1000.0) in
+       let response =
+         { Agent_sdk.Types.id = turn.turn_id
+         ; model = turn.model
+         ; stop_reason = EndTurn
+         ; content = [ Text turn.text ]
+         ; usage = None
+         ; telemetry =
+             Some
+               { Agent_sdk.Types.default_inference_telemetry with
+                 request_latency_ms = Some latency_ms
+               ; canonical_model_id = Some turn.model
+               }
+         }
+       in
+       let after_turn =
+         invoke_turn_hook
+           ~keeper_name
+           ~hook_name:"after_turn"
+           hooks.after_turn
+           (Agent_sdk.Hooks.AfterTurn { turn = 1; response })
+       in
+       let* () =
+         match after_turn with
+         | Continue -> Ok ()
+         | HookFailed { stage; detail } ->
+           Error (hook_error ~hook_name:"after_turn" ~stage detail)
+         | decision -> Error (illegal_hook_decision ~hook_name:"after_turn" decision)
+       in
+       let on_stop =
+         invoke_turn_hook
+           ~keeper_name
+           ~hook_name:"on_stop"
+           hooks.on_stop
+           (Agent_sdk.Hooks.OnStop { reason = response.stop_reason; response })
+       in
+       let* () =
+         match on_stop with
+         | Continue -> Ok ()
+         | HookFailed { stage; detail } ->
+           Error (hook_error ~hook_name:"on_stop" ~stage detail)
+         | decision -> Error (illegal_hook_decision ~hook_name:"on_stop" decision)
+       in
+       let capture, _metrics =
+         Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
+       in
+       Runtime_observation.record_attempt_terminal
+         capture
+         ~model_id:turn.model
+         ~latency_ms:(Some latency_ms)
+         ~error:None;
+       let runtime_observation =
+         Runtime_observation.runtime_observation_with_metrics
+           ~runtime_id
+           ~strategy:"official_client_runtime"
+           ~configured_labels:
+             [ "codex_app_server"
+             ; Printf.sprintf "dynamic_tool_calls=%d" turn.dynamic_tool_calls
+             ]
+           ~candidate_count:1
+           ~selected_model_raw:(Some turn.model)
+           ~capture
+           ~attempt_details_source:"codex_app_server"
+           ~oas_internal_runtime_allowed:false
+           ()
+       in
+       Ok
+         { Runtime_agent.response
+         ; checkpoint = None
+         ; session_id = turn.thread_id
+         ; turns = 1
+         ; trace_ref = None
+         ; run_validation = None
+         ; runtime_observation = Some runtime_observation
+         ; stop_reason = Completed
+         })
+;;

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -1,0 +1,19 @@
+(** Keeper projection for the official Codex app-server turn runtime. *)
+
+val run :
+  runtime_id:string ->
+  keeper_name:string ->
+  base_path:string ->
+  goal:string ->
+  goal_blocks:Agent_sdk.Types.content_block list option ->
+  system_prompt:string ->
+  tools:Agent_sdk.Tool.t list ->
+  initial_messages:Agent_sdk.Types.message list ->
+  model_input_projection:Agent_sdk.Agent.model_input_projection option ->
+  hooks:Agent_sdk.Hooks.hooks option ->
+  context_injector:Agent_sdk.Hooks.context_injector option ->
+  context:Agent_sdk.Context.t option ->
+  event_bus:Agent_sdk.Event_bus.t option ->
+  enable_thinking:bool option ->
+  config:Runtime_execution.codex_app_server ->
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -282,12 +282,15 @@ let validate_provider_request_cap ~runtime_id
 let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with
   | Some runtime ->
-    let* _request_body_cap =
-      validate_provider_request_cap
-        ~runtime_id:runtime.id
-        runtime.Runtime.provider_config
-    in
-    Ok runtime
+    (match runtime.Runtime.execution with
+     | Runtime_execution.Codex_app_server _ -> Ok runtime
+     | Runtime_execution.Agent_core provider_config ->
+       let* _request_body_cap =
+         validate_provider_request_cap
+           ~runtime_id:runtime.id
+           provider_config
+       in
+       Ok runtime)
   | None -> Error (runtime_candidate_missing_error id)
 
 let resolve_runtime_candidate_for_attempt ?on_missing id =
@@ -681,11 +684,23 @@ let run_named
           ~fallback_enable_thinking:enable_thinking
           ()
       in
-      match
-         match provider_config_transform with
-         | None -> Ok runtime.Runtime.provider_config
-         | Some transform -> transform runtime.Runtime.provider_config
-      with
+      match runtime.Runtime.execution with
+      | Runtime_execution.Codex_app_server _ ->
+        Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
+        ( Error
+            (Agent_sdk.Error.Config
+               (Agent_sdk.Error.InvalidConfig
+                  { field = "runtime_execution"
+                  ; detail =
+                      "codex-app-server is materialized as an official-client runtime but is not yet admitted by the Keeper turn driver"
+                  }))
+        , None )
+      | Runtime_execution.Agent_core runtime_provider_config ->
+       (match
+          match provider_config_transform with
+          | None -> Ok runtime_provider_config
+          | Some transform -> transform runtime_provider_config
+        with
       | Error err ->
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         Error err, None
@@ -771,7 +786,7 @@ let run_named
               ~replay_prefix_projection
               provider_result
           in
-          outcomes.turn_result, checkpoint_after))
+          outcomes.turn_result, checkpoint_after)))
     attempt_candidates
 
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -685,16 +685,60 @@ let run_named
           ()
       in
       match runtime.Runtime.execution with
-      | Runtime_execution.Codex_app_server _ ->
+      | Runtime_execution.Codex_app_server config ->
+        let codex_result =
+          match provider_config_transform, oas_checkpoint with
+          | Some _, _ ->
+            Error
+              (Agent_sdk.Error.Config
+                 (Agent_sdk.Error.InvalidConfig
+                    { field = "provider_config_transform"
+                    ; detail =
+                        "provider config transforms cannot target a \
+                         codex-app-server runtime"
+                    }))
+          | None, Some _ ->
+            Error
+              (Agent_sdk.Error.Config
+                 (Agent_sdk.Error.InvalidConfig
+                    { field = "oas_checkpoint"
+                    ; detail =
+                        "an OAS agent_core checkpoint cannot resume through a \
+                         codex-app-server runtime"
+                    }))
+          | None, None ->
+            Keeper_codex_runtime.run
+              ~runtime_id:attempt_runtime_id
+              ~keeper_name
+              ~base_path
+              ~goal
+              ~goal_blocks
+              ~system_prompt
+              ~tools
+              ~initial_messages
+              ~model_input_projection
+              ~hooks
+              ~context_injector
+              ~context
+              ~event_bus
+              ~enable_thinking:inference_policy.attempt_enable_thinking
+              ~config
+        in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
-        ( Error
-            (Agent_sdk.Error.Config
-               (Agent_sdk.Error.InvalidConfig
-                  { field = "runtime_execution"
-                  ; detail =
-                      "codex-app-server is materialized as an official-client runtime but is not yet admitted by the Keeper turn driver"
-                  }))
-        , None )
+        let codex_result =
+          Result.bind codex_result (fun run_result ->
+            Keeper_turn_driver_try_provider.apply_accept
+              ~runtime_id:attempt_runtime_id
+              ~accept
+              run_result)
+        in
+        (match codex_result with
+         | Ok run_result ->
+           Option.iter
+             (fun observe -> Option.iter observe run_result.Runtime_agent.runtime_observation)
+             on_runtime_observation
+         | Error _ -> ());
+        codex_result, None
       | Runtime_execution.Agent_core runtime_provider_config ->
        (match
           match provider_config_transform with
@@ -786,7 +830,8 @@ let run_named
               ~replay_prefix_projection
               provider_result
           in
-          outcomes.turn_result, checkpoint_after)))
+          outcomes.turn_result, checkpoint_after))
+       )
     attempt_candidates
 
 

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -56,6 +56,12 @@ type try_provider_ctx =
   ; seq_ref : int ref
   }
 
+val apply_accept :
+  runtime_id:string ->
+  accept:(Agent_sdk.Types.api_response -> bool) ->
+  Runtime_agent.run_result ->
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
+
 val observe_checkpoint_stage :
   bool Atomic.t -> Agent_sdk.Agent.checkpoint_stage -> unit
 

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -65,7 +65,8 @@ let message_of_request (req : Va.request) : Agent_sdk.Types.message =
         ()
     ]
 
-let vision_runtime_candidates () : (string * Runtime.t) list =
+let vision_runtime_candidates ()
+  : (string * Runtime.t * Llm_provider.Provider_config.t) list =
   (* Delegate image-capability admission to the RFC-0265 SSOT
      [Runtime_agent.caps_admit_required_modalities] so a runtime surfaced to the
      vision tool is exactly one the dispatch capability gate would admit. Do NOT
@@ -85,13 +86,16 @@ let vision_runtime_candidates () : (string * Runtime.t) list =
   in
   from_failover @ rest
   |> List.filter_map (fun (rt : Runtime.t) ->
-       let caps = Runtime_agent.input_capabilities_of_runtime rt in
-       if Runtime_agent.caps_admit_required_modalities caps [ "image" ]
-       then Some (rt.Runtime.id, rt)
-       else None)
+       match rt.Runtime.execution with
+       | Runtime_execution.Codex_app_server _ -> None
+       | Runtime_execution.Agent_core provider_config ->
+         let caps = Runtime_agent.input_capabilities_of_runtime rt in
+         if Runtime_agent.caps_admit_required_modalities caps [ "image" ]
+         then Some (rt.Runtime.id, rt, provider_config)
+         else None)
 
 let vision_runtime_ids () : string list =
-  List.map fst (vision_runtime_candidates ())
+  List.map (fun (runtime_id, _, _) -> runtime_id) (vision_runtime_candidates ())
 
 let first_vision_runtime_id () : (string, string) result =
   match vision_runtime_ids () with
@@ -307,7 +311,7 @@ let run_candidates_outcome
            { failure_class = failure_class_of_http_error err
            ; detail = Provider_http_error.to_message err
            })
-    | (runtime_id, rt) :: rest ->
+    | (runtime_id, rt, provider_config) :: rest ->
       let continue_with last_error =
         (if not (List.is_empty rest)
          then sleep_before_next_candidate ~clock ~attempt_index);
@@ -316,7 +320,7 @@ let run_candidates_outcome
           ~attempt_index:(attempt_index + 1)
           rest
       in
-      let config = provider_for_vision rt.Runtime.provider_config in
+      let config = provider_for_vision provider_config in
       match Runtime.validate_request_body_cap ~runtime_id config with
       | Error error ->
         record_vision_candidate_attempt

--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -6,6 +6,7 @@
  (wrapped false)
  (libraries
   yojson
+  cstruct
   otoml
   masc.toml_line_editor
   base64

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -17,9 +17,10 @@ type t =
   ; provider : provider
   ; model : model_spec
   ; binding : binding
-  ; provider_config : Llm_provider.Provider_config.t
-    (** load 시점에 materialize 된 hot-path provider config. 소비자는
-        routing 없이 이걸 곧장 LLM dispatch 로 넘긴다. *)
+  ; execution : Runtime_execution.t
+    (** Turn owner materialized at load time. HTTP bindings become
+        [Agent_core]; official client runtimes remain distinct and can never
+        be dispatched as a fake LLM provider config. *)
   }
 
 (* id 파생의 단일 출처는 {!Runtime_schema.binding_key} — runtime 을 id 로
@@ -35,9 +36,9 @@ let id_of_binding (b : binding) : string = binding_key b
 let of_binding_result (cfg : config) (b : binding) : (t, string) result =
   match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
   | Some provider, Some model ->
-    (match Runtime_adapter.binding_to_provider_config cfg b with
-     | Ok provider_config ->
-       Ok { id = id_of_binding b; provider; model; binding = b; provider_config }
+    (match Runtime_adapter.binding_to_execution cfg b with
+     | Ok execution ->
+       Ok { id = id_of_binding b; provider; model; binding = b; execution }
      | Error reason -> Error reason)
   | None, _ -> Error (Printf.sprintf "provider not found: %s" b.provider_id)
   | Some _, None -> Error (Printf.sprintf "model not found: %s" b.model_id)
@@ -444,7 +445,10 @@ let startup_degradation_to_yojson = function
 ;;
 
 let capabilities_for_runtime (rt : t) =
-  Llm_provider.Provider_config.capabilities_for_config_model rt.provider_config
+  match rt.execution with
+  | Runtime_execution.Agent_core provider_config ->
+    Llm_provider.Provider_config.capabilities_for_config_model provider_config
+  | Runtime_execution.Codex_app_server _ -> None
 ;;
 
 type max_context_source =
@@ -501,7 +505,9 @@ let validate_runtime_max_context ~(config_path : string) (runtimes : t list)
           RFC-0206 §2.1)"
          config_path
          r.id
-         r.provider_config.model_id
+         (match Runtime_execution.model_id r.execution with
+          | Some model_id -> model_id
+          | None -> "<official-client-selected>")
          r.model.id)
 ;;
 
@@ -597,13 +603,16 @@ let validate_keeper_dispatch_request_caps
          match runtime_by_id id with
          | None -> None
          | Some runtime ->
-           (match
-              validate_request_body_cap
-                ~runtime_id:runtime.id
-                runtime.provider_config
-            with
-            | Ok _ -> None
-            | Error _ -> Some runtime))
+           (match runtime.execution with
+            | Runtime_execution.Codex_app_server _ -> None
+            | Runtime_execution.Agent_core provider_config ->
+              (match
+                 validate_request_body_cap
+                   ~runtime_id:runtime.id
+                   provider_config
+               with
+               | Ok _ -> None
+               | Error _ -> Some runtime)))
       ids
   with
   | None -> Ok ()
@@ -631,13 +640,14 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
   let missing_models =
     List.filter_map
       (fun (r : t) ->
-         match capabilities_for_runtime r with
-         | Some _ -> None
-         | None ->
+         match r.execution, capabilities_for_runtime r with
+         | Runtime_execution.Codex_app_server _, _ -> None
+         | Runtime_execution.Agent_core _, Some _ -> None
+         | Runtime_execution.Agent_core provider_config, None ->
            let provider_label =
-             Llm_provider.Provider_config.capability_provider_label r.provider_config
+             Llm_provider.Provider_config.capability_provider_label provider_config
            in
-           let model_id = r.provider_config.model_id in
+           let model_id = provider_config.model_id in
            Some
              { runtime_id = r.id
              ; provider_id = r.provider.id
@@ -1287,7 +1297,7 @@ let temperature_of_runtime_id (id : string) : float option =
 
 let top_p_of_runtime_id (id : string) : float option =
   match get_runtime_by_id id with
-  | Some rt -> rt.provider_config.top_p
+  | Some rt -> rt.model.top_p
   | None -> None
 ;;
 

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -12,7 +12,7 @@ type t =
   ; provider : provider
   ; model : model_spec
   ; binding : binding
-  ; provider_config : Llm_provider.Provider_config.t
+  ; execution : Runtime_execution.t
   }
 
 val id_of_binding : binding -> string

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -203,6 +203,12 @@ let messages_api_compatible_provider_kind = function
 let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.provider)
     : (Llm_provider.Provider_config.provider_kind, string) result =
   match provider.api_format with
+  | Codex_app_server_runtime ->
+    Error
+      (Printf.sprintf
+         "provider %S uses codex-app-server and cannot be materialized as an \
+          HTTP provider"
+         provider.id)
   | Ollama_api -> Ok Llm_provider.Provider_config.Ollama
   | Chat_completions_api ->
     (* Chat-completions keeps the historical OpenAI-compatible fallback when
@@ -452,4 +458,52 @@ let binding_to_provider_config (cfg : Runtime_schema.config) (binding : Runtime_
          ?max_request_body_bytes:binding.max_request_body_bytes
          provider
          spec)
+;;
+
+let codex_app_server_execution (provider : Runtime_schema.provider)
+    (spec : Runtime_schema.model_spec) : (Runtime_execution.t, string) result =
+  match provider.transport with
+  | Http _ ->
+    Error
+      (Printf.sprintf
+         "provider %S uses protocol codex-app-server but declares an HTTP endpoint; \
+          an official Codex CLI command is required"
+         provider.id)
+  | Cli command when String.trim command = "" ->
+    Error (Printf.sprintf "provider %S declares an empty Codex CLI command" provider.id)
+  | Cli command ->
+    (match provider.credentials with
+     | Some _ ->
+       Error
+         (Printf.sprintf
+            "provider %S uses codex-app-server and must not declare credentials; \
+             the official Codex client owns subscription login"
+            provider.id)
+     | None when not provider.is_non_interactive ->
+       Error
+         (Printf.sprintf
+            "provider %S uses codex-app-server and must declare \
+             is-non-interactive = true"
+            provider.id)
+     | None ->
+       Ok
+         (Runtime_execution.Codex_app_server
+            { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
+;;
+
+let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema.binding)
+    : (Runtime_execution.t, string) result =
+  match Runtime_schema.model_of_id cfg binding.model_id with
+  | None -> Error (Printf.sprintf "model not found: %s" binding.model_id)
+  | Some spec ->
+    (match Runtime_schema.provider_of_id cfg binding.provider_id with
+     | None -> Error (Printf.sprintf "provider not found: %s" binding.provider_id)
+     | Some provider ->
+       (match provider.api_format with
+        | Runtime_schema.Codex_app_server_runtime ->
+          codex_app_server_execution provider spec
+        | Messages_api | Chat_completions_api | Ollama_api ->
+          Result.map
+            (fun provider_config -> Runtime_execution.Agent_core provider_config)
+            (binding_to_provider_config cfg binding)))
 ;;

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -29,3 +29,12 @@ val binding_to_provider_config
     Returns [Error reason] (no silent fallback) when the provider or model id
     is unresolved, or when the provider transport/kind cannot be mapped to a
     concrete provider config. *)
+
+val binding_to_execution
+  :  Runtime_schema.config
+  -> Runtime_schema.binding
+  -> (Runtime_execution.t, string) result
+(** Materialize the owner of a complete turn. HTTP model APIs become
+    {!Runtime_execution.Agent_core}. The exact [codex-app-server] protocol over
+    a credential-free CLI transport becomes
+    {!Runtime_execution.Codex_app_server}. Other CLI protocols remain rejected. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -692,8 +692,15 @@ let input_capabilities_for_config (config : config) =
    provider caps overlaid with the model's declared media capabilities (the MASC
    SSOT, [apply_runtime_model_input_capabilities]). *)
 let input_capabilities_of_runtime (rt : Runtime.t) =
+  let provider_caps =
+    match rt.Runtime.execution with
+    | Runtime_execution.Agent_core provider_config ->
+      provider_caps_of_config provider_config
+    | Runtime_execution.Codex_app_server _ ->
+      Llm_provider.Capabilities.default_capabilities
+  in
   apply_runtime_model_input_capabilities
-    (provider_caps_of_config rt.Runtime.provider_config)
+    provider_caps
     (Option.value rt.Runtime.model.capabilities
        ~default:Runtime_schema.model_capabilities_default)
 

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -175,7 +175,7 @@ let parse_wire_line line =
        Ok (Response { id; result }))
   | Some _, None -> protocol_error stage "response id must be an integer"
   | None, Some (`String method_) ->
-    let params = Option.value ~default:`Null (List.assoc_opt "params" fields) in
+    let* params = required_member stage "params" fields in
     Ok (Notification { method_; params })
   | Some _, Some _ | None, Some _ -> protocol_error stage "method must be a string"
   | None, None -> protocol_error stage "message has neither id nor method"
@@ -553,10 +553,7 @@ let run_turn ~mgr ~clock config ~prompt =
     match validate_config config ~prompt with
     | Error _ as error -> error
     | Ok () ->
-      let model = Option.value config.model ~default:"default" in
-      Log.Runtime_agent.info
-        "Codex app-server subscription turn starting (model=%s)"
-        model;
+      Log.Runtime_agent.info "Codex app-server subscription turn starting";
       (try run_spawned ~mgr ~clock config ~prompt with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | Eio.Time.Timeout -> Error (Timeout config.timeout_s)

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -73,6 +73,19 @@ let error_to_string = function
     Printf.sprintf "Codex app-server turn timed out after %.3fs" seconds
 ;;
 
+let error_kind = function
+  | Invalid_config _ -> "invalid_config"
+  | Spawn_failed _ -> "spawn_failed"
+  | Protocol_error _ -> "protocol_error"
+  | Rpc_error _ -> "rpc_error"
+  | Subscription_required _ -> "subscription_required"
+  | Unsupported_server_request _ -> "unsupported_server_request"
+  | Turn_failed _ -> "turn_failed"
+  | Turn_interrupted -> "turn_interrupted"
+  | Process_exited _ -> "process_exited"
+  | Timeout _ -> "timeout"
+;;
+
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
 
 let assoc_at stage = function
@@ -452,6 +465,37 @@ let drain_stderr flow tail =
   | _ -> ()
 ;;
 
+let terminate_spawned_process ~clock proc stdin_w =
+  let owning_switch_cancelled = Eio.Fiber.is_cancelled () in
+  Eio.Cancel.protect (fun () ->
+    (try Eio.Flow.close stdin_w with
+     | exn ->
+       Log.Runtime_agent.debug
+         "Codex app-server stdin close failed: %s"
+         (Printexc.to_string exn));
+    (try Eio.Process.signal proc Sys.sigterm with
+     | exn ->
+       Log.Runtime_agent.debug
+         "Codex app-server termination signal failed: %s"
+         (Printexc.to_string exn));
+    if not owning_switch_cancelled
+    then
+      try Eio.Time.with_timeout_exn clock 2.0 (fun () -> Eio.Process.await proc |> ignore) with
+      | Eio.Time.Timeout ->
+        (try
+           Eio.Process.signal proc Sys.sigkill;
+           Eio.Process.await proc |> ignore
+         with
+         | exn ->
+           Log.Runtime_agent.warn
+             "Codex app-server forced reap failed: %s"
+             (Printexc.to_string exn))
+      | exn ->
+        Log.Runtime_agent.debug
+          "Codex app-server reap observed an already-closed process: %s"
+          (Printexc.to_string exn))
+;;
+
 let run_spawned ~mgr ~clock config ~prompt =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
@@ -481,10 +525,12 @@ let run_spawned ~mgr ~clock config ~prompt =
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> protocol_error "stdout read" (Printexc.to_string exn)
     in
+    (* Cleanup must run before [Switch.run] waits for the stderr drainer. The
+       child can be waiting for more stdin on typed early returns, so a switch
+       release hook alone deadlocks. [Eio.Cancel.protect] inside the finalizer
+       preserves cleanup across fiber cancellation. *)
     Fun.protect
-      ~finally:(fun () ->
-        (try Eio.Flow.close stdin_w with _ -> ());
-        (try Eio.Process.signal proc Sys.sigterm with _ -> ()))
+      ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
         Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
           run_protocol { send; receive } config ~prompt)))
@@ -503,11 +549,29 @@ let validate_config config ~prompt =
 ;;
 
 let run_turn ~mgr ~clock config ~prompt =
-  match validate_config config ~prompt with
-  | Error _ as error -> error
-  | Ok () ->
-    (try run_spawned ~mgr ~clock config ~prompt with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
-     | exn -> Error (Spawn_failed (Printexc.to_string exn)))
+  let result =
+    match validate_config config ~prompt with
+    | Error _ as error -> error
+    | Ok () ->
+      let model = Option.value config.model ~default:"default" in
+      Log.Runtime_agent.info
+        "Codex app-server subscription turn starting (model=%s)"
+        model;
+      (try run_spawned ~mgr ~clock config ~prompt with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+       | exn -> Error (Spawn_failed (Printexc.to_string exn)))
+  in
+  (match result with
+   | Ok turn ->
+     Log.Runtime_agent.info
+       "Codex app-server subscription turn completed (thread_id=%s turn_id=%s model=%s)"
+       turn.thread_id
+       turn.turn_id
+       turn.model
+   | Error error ->
+     Log.Runtime_agent.warn
+       "Codex app-server subscription turn failed (kind=%s)"
+       (error_kind error));
+  result
 ;;

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -31,8 +31,30 @@ type turn_result =
   ; turn_id : string
   ; model : string
   ; text : string
+  ; dynamic_tool_calls : int
   ; subscription : subscription
   ; user_agent : string option
+  }
+
+type dynamic_tool_result =
+  { success : bool
+  ; content : string
+  }
+
+type dynamic_tool =
+  { name : string
+  ; description : string
+  ; input_schema : Yojson.Safe.t
+  ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
+  }
+
+type history_role =
+  | User
+  | Assistant
+
+type history_message =
+  { role : history_role
+  ; text : string
   }
 
 type error =
@@ -146,6 +168,7 @@ type wire_message =
   | Server_request of
       { id : Yojson.Safe.t
       ; method_ : string
+      ; params : Yojson.Safe.t
       }
 
 let parse_rpc_error id fields =
@@ -166,7 +189,9 @@ let parse_wire_line line =
   let* json = json_result in
   let* fields = assoc_at stage json in
   match List.assoc_opt "id" fields, List.assoc_opt "method" fields with
-  | Some id, Some (`String method_) -> Ok (Server_request { id; method_ })
+  | Some id, Some (`String method_) ->
+    let* params = required_member stage "params" fields in
+    Ok (Server_request { id; method_; params })
   | Some (`Int id), None ->
     (match List.assoc_opt "error" fields with
      | Some _ -> parse_rpc_error id fields
@@ -204,6 +229,70 @@ let reject_server_request io id =
        ])
 ;;
 
+let dynamic_tool_spec (tool : dynamic_tool) =
+  `Assoc
+    [ "type", `String "function"
+    ; "name", `String tool.name
+    ; "description", `String tool.description
+    ; "inputSchema", tool.input_schema
+    ; "deferLoading", `Bool false
+    ]
+;;
+
+let find_dynamic_tool tools name =
+  List.find_opt (fun (tool : dynamic_tool) -> String.equal tool.name name) tools
+;;
+
+let send_dynamic_tool_response io ~id (result : dynamic_tool_result) =
+  io.send
+    (`Assoc
+       [ "id", id
+       ; ( "result"
+         , `Assoc
+             [ "success", `Bool result.success
+             ; ( "contentItems"
+               , `List
+                   [ `Assoc
+                       [ "type", `String "inputText"
+                       ; "text", `String result.content
+                       ]
+                   ] )
+             ] )
+       ])
+;;
+
+let handle_dynamic_tool_call io ~tools ~thread_id ~turn_id ~tool_call_count ~id params =
+  let stage = "item/tool/call" in
+  let* fields = assoc_at stage params in
+  let* request_thread_id = required_string stage "threadId" fields in
+  let* request_turn_id = required_string stage "turnId" fields in
+  let* call_id = required_string stage "callId" fields in
+  let* tool_name = required_string stage "tool" fields in
+  let* namespace = optional_string stage "namespace" fields in
+  let* arguments = required_member stage "arguments" fields in
+  if request_thread_id <> thread_id || request_turn_id <> turn_id
+  then protocol_error stage "tool call identity does not match the active turn"
+  else if Option.is_some namespace
+  then protocol_error stage "function tool call unexpectedly declared a namespace"
+  else
+    match find_dynamic_tool tools tool_name with
+    | None -> protocol_error stage (Printf.sprintf "unknown dynamic tool %S" tool_name)
+    | Some tool ->
+      let result =
+        try tool.call ~call_id arguments with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
+          Log.Runtime_agent.warn
+            "Codex dynamic tool handler raised (tool=%s error=%s)"
+            tool_name
+            (Printexc.to_string exn);
+          { success = false; content = "dynamic tool handler raised" }
+      in
+      incr tool_call_count;
+      send_dynamic_tool_response io ~id result;
+      Ok ()
+;;
+
 let rec await_response io ~id ~method_ =
   let* message = io.receive () in
   match message with
@@ -217,7 +306,7 @@ let rec await_response io ~id ~method_ =
     protocol_error method_
       (Printf.sprintf "received error response id %d while waiting for %d" response_id id)
   | Notification _ -> await_response io ~id ~method_
-  | Server_request { id; method_ = requested_method } ->
+  | Server_request { id; method_ = requested_method; _ } ->
     reject_server_request io id;
     Error (Unsupported_server_request requested_method)
 ;;
@@ -336,12 +425,32 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
       | other -> protocol_error stage (Printf.sprintf "unknown turn status %S" other)
 ;;
 
-let rec await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback =
+let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen_final
+    ~seen_fallback =
   let* message = io.receive () in
   match message with
   | Response _ | Response_error _ ->
     protocol_error "turn" "received an unsolicited JSON-RPC response"
-  | Server_request { id; method_ } ->
+  | Server_request { id; method_ = "item/tool/call"; params } ->
+    let* () =
+      handle_dynamic_tool_call
+        io
+        ~tools
+        ~thread_id
+        ~turn_id
+        ~tool_call_count
+        ~id
+        params
+    in
+    await_turn_terminal
+      io
+      ~tools
+      ~tool_call_count
+      ~thread_id
+      ~turn_id
+      ~seen_final
+      ~seen_fallback
+  | Server_request { id; method_; _ } ->
     reject_server_request io id;
     Error (Unsupported_server_request method_)
   | Notification { method_ = "item/completed"; params } ->
@@ -360,13 +469,28 @@ let rec await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback =
         | Some (_, text) -> seen_final, Some text
         | None -> seen_final, seen_fallback
       in
-      await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+      await_turn_terminal
+        io
+        ~tools
+        ~tool_call_count
+        ~thread_id
+        ~turn_id
+        ~seen_final
+        ~seen_fallback
   | Notification { method_ = "error"; params } ->
     let stage = "error notification" in
     let* fields = assoc_at stage params in
     let* will_retry = required_bool stage "willRetry" fields in
     if will_retry
-    then await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+    then
+      await_turn_terminal
+        io
+        ~tools
+        ~tool_call_count
+        ~thread_id
+        ~turn_id
+        ~seen_final
+        ~seen_fallback
     else
       let* error_json = required_member stage "error" fields in
       let* error_fields = assoc_at stage error_json in
@@ -375,7 +499,14 @@ let rec await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback =
   | Notification { method_ = "turn/completed"; params } ->
     terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params
   | Notification _ ->
-    await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+    await_turn_terminal
+      io
+      ~tools
+      ~tool_call_count
+      ~thread_id
+      ~turn_id
+      ~seen_final
+      ~seen_fallback
 ;;
 
 let optional_field name = function
@@ -383,7 +514,26 @@ let optional_field name = function
   | Some value -> [ name, `String value ]
 ;;
 
-let run_protocol io config ~prompt =
+let history_item (message : history_message) =
+  let role, content_type =
+    match message.role with
+    | User -> "user", "input_text"
+    | Assistant -> "assistant", "output_text"
+  in
+  `Assoc
+    [ "type", `String "message"
+    ; "role", `String role
+    ; ( "content"
+      , `List
+          [ `Assoc
+              [ "type", `String content_type
+              ; "text", `String message.text
+              ]
+          ] )
+    ]
+;;
+
+let run_protocol io config ~dynamic_tools ~history ~prompt =
   send_request io ~id:1 ~method_:"initialize"
     ~params:
       (`Assoc
@@ -410,23 +560,57 @@ let run_protocol io config ~prompt =
     ]
     @ optional_field "model" config.model
     @ optional_field "developerInstructions" config.developer_instructions
+    @
+    match dynamic_tools with
+    | [] -> []
+    | tools -> [ "dynamicTools", `List (List.map dynamic_tool_spec tools) ]
   in
   send_request io ~id:3 ~method_:"thread/start" ~params:(`Assoc thread_fields);
   let* thread = await_response io ~id:3 ~method_:"thread/start" in
   let* thread_id, model = parse_thread_start thread in
-  send_request io ~id:4 ~method_:"turn/start"
+  let turn_request_id =
+    match history with
+    | [] -> Ok 4
+    | messages ->
+      send_request io ~id:4 ~method_:"thread/inject_items"
+        ~params:
+          (`Assoc
+             [ "threadId", `String thread_id
+             ; "items", `List (List.map history_item messages)
+             ]);
+      let* _ = await_response io ~id:4 ~method_:"thread/inject_items" in
+      Ok 5
+  in
+  let* turn_request_id = turn_request_id in
+  send_request io ~id:turn_request_id ~method_:"turn/start"
     ~params:
       (`Assoc
          [ "threadId", `String thread_id
          ; ( "input"
            , `List [ `Assoc [ "type", `String "text"; "text", `String prompt ] ] )
          ]);
-  let* turn = await_response io ~id:4 ~method_:"turn/start" in
+  let* turn = await_response io ~id:turn_request_id ~method_:"turn/start" in
   let* turn_id = parse_turn_start turn in
+  let tool_call_count = ref 0 in
   let* text =
-    await_turn_terminal io ~thread_id ~turn_id ~seen_final:None ~seen_fallback:None
+    await_turn_terminal
+      io
+      ~tools:dynamic_tools
+      ~tool_call_count
+      ~thread_id
+      ~turn_id
+      ~seen_final:None
+      ~seen_fallback:None
   in
-  Ok { thread_id; turn_id; model; text; subscription; user_agent }
+  Ok
+    { thread_id
+    ; turn_id
+    ; model
+    ; text
+    ; dynamic_tool_calls = !tool_call_count
+    ; subscription
+    ; user_agent
+    }
 ;;
 
 let env_key entry =
@@ -496,7 +680,7 @@ let terminate_spawned_process ~clock proc stdin_w =
           (Printexc.to_string exn))
 ;;
 
-let run_spawned ~mgr ~clock config ~prompt =
+let run_spawned ~mgr ~clock config ~dynamic_tools ~history ~prompt =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -533,7 +717,7 @@ let run_spawned ~mgr ~clock config ~prompt =
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
         Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
-          run_protocol { send; receive } config ~prompt)))
+          run_protocol { send; receive } config ~dynamic_tools ~history ~prompt)))
 ;;
 
 let validate_config config ~prompt =
@@ -548,16 +732,33 @@ let validate_config config ~prompt =
   else Ok ()
 ;;
 
-let run_turn ~mgr ~clock config ~prompt =
+let validate_dynamic_tools tools =
+  let rec loop seen = function
+    | [] -> Ok ()
+    | (tool : dynamic_tool) :: rest ->
+      let name = String.trim tool.name in
+      if name = ""
+      then Error (Invalid_config "dynamic tool name must not be empty")
+      else if List.mem name seen
+      then Error (Invalid_config (Printf.sprintf "duplicate dynamic tool name %S" name))
+      else loop (name :: seen) rest
+  in
+  loop [] tools
+;;
+
+let run_turn ?(dynamic_tools = []) ~mgr ~clock ?(history = []) config ~prompt =
   let result =
     match validate_config config ~prompt with
     | Error _ as error -> error
     | Ok () ->
+      (match validate_dynamic_tools dynamic_tools with
+       | Error _ as error -> error
+       | Ok () ->
       Log.Runtime_agent.info "Codex app-server subscription turn starting";
-      (try run_spawned ~mgr ~clock config ~prompt with
+      (try run_spawned ~mgr ~clock config ~dynamic_tools ~history ~prompt with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
-       | exn -> Error (Spawn_failed (Printexc.to_string exn)))
+       | exn -> Error (Spawn_failed (Printexc.to_string exn))))
   in
   (match result with
    | Ok turn ->

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -17,12 +17,21 @@ type config =
   ; timeout_s : float
   }
 
+let default_timeout_s = 300.0
+let process_termination_grace_s = 2.0
+let stderr_chunk_bytes = 4096
+let stderr_tail_bytes = 4096
+let max_wire_line_bytes = 8 * 1024 * 1024
+let approval_policy = "never"
+let sandbox_mode = "read-only"
+let ephemeral_thread = true
+
 let default_config ~cwd =
   { cli_path = "codex"
   ; cwd
   ; model = None
   ; developer_instructions = None
-  ; timeout_s = 300.0
+  ; timeout_s = default_timeout_s
   }
 ;;
 
@@ -109,6 +118,43 @@ let error_kind = function
 ;;
 
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
+let ( let* ) result f = Result.bind result f
+
+let rec validate_unique_object_keys ~stage ~path = function
+  | `Assoc fields ->
+    let rec loop seen = function
+      | [] -> Ok ()
+      | (name, value) :: rest ->
+        if List.mem name seen
+        then
+          protocol_error
+            stage
+            (Printf.sprintf "duplicate object key %S at %s" name path)
+        else
+          let* () =
+            validate_unique_object_keys
+              ~stage
+              ~path:(path ^ "." ^ name)
+              value
+          in
+          loop (name :: seen) rest
+    in
+    loop [] fields
+  | `List values ->
+    let rec loop index = function
+      | [] -> Ok ()
+      | value :: rest ->
+        let* () =
+          validate_unique_object_keys
+            ~stage
+            ~path:(Printf.sprintf "%s[%d]" path index)
+            value
+        in
+        loop (index + 1) rest
+    in
+    loop 0 values
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
+;;
 
 let assoc_at stage = function
   | `Assoc fields -> Ok fields
@@ -149,8 +195,6 @@ let required_int stage name fields =
   | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
 ;;
 
-let ( let* ) result f = Result.bind result f
-
 type wire_message =
   | Response of
       { id : int
@@ -187,6 +231,7 @@ let parse_wire_line line =
     | Yojson.Json_error detail -> protocol_error stage ("invalid JSON: " ^ detail)
   in
   let* json = json_result in
+  let* () = validate_unique_object_keys ~stage ~path:"$" json in
   let* fields = assoc_at stage json in
   match List.assoc_opt "id" fields, List.assoc_opt "method" fields with
   | Some id, Some (`String method_) ->
@@ -425,8 +470,11 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
       | other -> protocol_error stage (Printf.sprintf "unknown turn status %S" other)
 ;;
 
+let max_retry_notifications = 3
+let max_unknown_notifications = 128
+
 let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen_final
-    ~seen_fallback =
+    ~seen_fallback ~retry_notifications ~unknown_notifications =
   let* message = io.receive () in
   match message with
   | Response _ | Response_error _ ->
@@ -450,6 +498,8 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~turn_id
       ~seen_final
       ~seen_fallback
+      ~retry_notifications
+      ~unknown_notifications
   | Server_request { id; method_; _ } ->
     reject_server_request io id;
     Error (Unsupported_server_request method_)
@@ -477,11 +527,13 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~turn_id
         ~seen_final
         ~seen_fallback
+        ~retry_notifications
+        ~unknown_notifications
   | Notification { method_ = "error"; params } ->
     let stage = "error notification" in
     let* fields = assoc_at stage params in
     let* will_retry = required_bool stage "willRetry" fields in
-    if will_retry
+    if will_retry && retry_notifications < max_retry_notifications
     then
       await_turn_terminal
         io
@@ -491,6 +543,10 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~turn_id
         ~seen_final
         ~seen_fallback
+        ~retry_notifications:(retry_notifications + 1)
+        ~unknown_notifications
+    else if will_retry
+    then Error (Turn_failed "app-server retry notification limit exceeded")
     else
       let* error_json = required_member stage "error" fields in
       let* error_fields = assoc_at stage error_json in
@@ -498,7 +554,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       Error (Turn_failed message)
   | Notification { method_ = "turn/completed"; params } ->
     terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params
-  | Notification _ ->
+  | Notification _ when unknown_notifications < max_unknown_notifications ->
     await_turn_terminal
       io
       ~tools
@@ -507,6 +563,14 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~turn_id
       ~seen_final
       ~seen_fallback
+      ~retry_notifications
+      ~unknown_notifications:(unknown_notifications + 1)
+  | Notification { method_; _ } ->
+    protocol_error
+      "turn"
+      (Printf.sprintf
+         "unknown notification limit exceeded (last method %S)"
+         method_)
 ;;
 
 let optional_field name = function
@@ -533,7 +597,7 @@ let history_item (message : history_message) =
     ]
 ;;
 
-let run_protocol io config ~dynamic_tools ~history ~prompt =
+let run_protocol io config ~dynamic_tools ~reasoning_effort ~history ~prompt =
   send_request io ~id:1 ~method_:"initialize"
     ~params:
       (`Assoc
@@ -554,9 +618,9 @@ let run_protocol io config ~dynamic_tools ~history ~prompt =
   let* subscription = parse_subscription account in
   let thread_fields =
     [ "cwd", `String config.cwd
-    ; "approvalPolicy", `String "never"
-    ; "sandbox", `String "read-only"
-    ; "ephemeral", `Bool true
+    ; "approvalPolicy", `String approval_policy
+    ; "sandbox", `String sandbox_mode
+    ; "ephemeral", `Bool ephemeral_thread
     ]
     @ optional_field "model" config.model
     @ optional_field "developerInstructions" config.developer_instructions
@@ -585,10 +649,13 @@ let run_protocol io config ~dynamic_tools ~history ~prompt =
   send_request io ~id:turn_request_id ~method_:"turn/start"
     ~params:
       (`Assoc
-         [ "threadId", `String thread_id
-         ; ( "input"
-           , `List [ `Assoc [ "type", `String "text"; "text", `String prompt ] ] )
-         ]);
+         ([ "threadId", `String thread_id
+          ; ( "input"
+            , `List [ `Assoc [ "type", `String "text"; "text", `String prompt ] ] )
+          ]
+          @ optional_field
+              "effort"
+              (Option.map Llm_provider.Reasoning_effort.to_string reasoning_effort)));
   let* turn = await_response io ~id:turn_request_id ~method_:"turn/start" in
   let* turn_id = parse_turn_start turn in
   let tool_call_count = ref 0 in
@@ -601,6 +668,8 @@ let run_protocol io config ~dynamic_tools ~history ~prompt =
       ~turn_id
       ~seen_final:None
       ~seen_fallback:None
+      ~retry_notifications:0
+      ~unknown_notifications:0
   in
   Ok
     { thread_id
@@ -636,17 +705,20 @@ let bounded_tail ~limit current addition =
 ;;
 
 let drain_stderr flow tail =
-  let chunk = Cstruct.create 4096 in
+  let chunk = Cstruct.create stderr_chunk_bytes in
   try
     while true do
       let count = Eio.Flow.single_read flow chunk in
       let text = Cstruct.to_string (Cstruct.sub chunk 0 count) in
-      tail := bounded_tail ~limit:4096 !tail text
+      tail := bounded_tail ~limit:stderr_tail_bytes !tail text
     done
   with
   | End_of_file -> ()
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | _ -> ()
+  | exn ->
+    Log.Runtime_agent.debug
+      "Codex app-server stderr drain failed: %s"
+      (Printexc.to_string exn)
 ;;
 
 let terminate_spawned_process ~clock proc stdin_w =
@@ -664,7 +736,10 @@ let terminate_spawned_process ~clock proc stdin_w =
          (Printexc.to_string exn));
     if not owning_switch_cancelled
     then
-      try Eio.Time.with_timeout_exn clock 2.0 (fun () -> Eio.Process.await proc |> ignore) with
+      try
+        Eio.Time.with_timeout_exn clock process_termination_grace_s (fun () ->
+          Eio.Process.await proc |> ignore)
+      with
       | Eio.Time.Timeout ->
         (try
            Eio.Process.signal proc Sys.sigkill;
@@ -680,7 +755,7 @@ let terminate_spawned_process ~clock proc stdin_w =
           (Printexc.to_string exn))
 ;;
 
-let run_spawned ~mgr ~clock config ~dynamic_tools ~history ~prompt =
+let run_spawned ~mgr ~clock config ~dynamic_tools ~reasoning_effort ~history ~prompt =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -696,7 +771,7 @@ let run_spawned ~mgr ~clock config ~dynamic_tools ~history ~prompt =
     Eio.Flow.close stdout_w;
     Eio.Flow.close stderr_w;
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
-    let reader = Eio.Buf_read.of_flow ~max_size:(8 * 1024 * 1024) stdout_r in
+    let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
     let send json =
       Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
       Eio.Flow.copy_string "\n" stdin_w
@@ -717,7 +792,13 @@ let run_spawned ~mgr ~clock config ~dynamic_tools ~history ~prompt =
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
         Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
-          run_protocol { send; receive } config ~dynamic_tools ~history ~prompt)))
+          run_protocol
+            { send; receive }
+            config
+            ~dynamic_tools
+            ~reasoning_effort
+            ~history
+            ~prompt)))
 ;;
 
 let validate_config config ~prompt =
@@ -746,7 +827,8 @@ let validate_dynamic_tools tools =
   loop [] tools
 ;;
 
-let run_turn ?(dynamic_tools = []) ~mgr ~clock ?(history = []) config ~prompt =
+let run_turn ?(dynamic_tools = []) ?reasoning_effort ~mgr ~clock ?(history = []) config
+    ~prompt =
   let result =
     match validate_config config ~prompt with
     | Error _ as error -> error
@@ -755,7 +837,16 @@ let run_turn ?(dynamic_tools = []) ~mgr ~clock ?(history = []) config ~prompt =
        | Error _ as error -> error
        | Ok () ->
       Log.Runtime_agent.info "Codex app-server subscription turn starting";
-      (try run_spawned ~mgr ~clock config ~dynamic_tools ~history ~prompt with
+      (try
+         run_spawned
+           ~mgr
+           ~clock
+           config
+           ~dynamic_tools
+           ~reasoning_effort
+           ~history
+           ~prompt
+       with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
        | exn -> Error (Spawn_failed (Printexc.to_string exn))))

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -1,0 +1,513 @@
+(** Native Codex app-server single-turn execution.
+
+    The official CLI keeps ownership of ChatGPT credentials. We deliberately
+    remove API-key fallback variables from the child environment and then gate
+    on [account/read = chatgpt] before starting a thread. *)
+
+type subscription =
+  { plan_type : string
+  ; email : string option
+  }
+
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string option
+  ; developer_instructions : string option
+  ; timeout_s : float
+  }
+
+let default_config ~cwd =
+  { cli_path = "codex"
+  ; cwd
+  ; model = None
+  ; developer_instructions = None
+  ; timeout_s = 300.0
+  }
+;;
+
+type turn_result =
+  { thread_id : string
+  ; turn_id : string
+  ; model : string
+  ; text : string
+  ; subscription : subscription
+  ; user_agent : string option
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | Rpc_error of
+      { method_ : string
+      ; code : int option
+      ; message : string
+      }
+  | Subscription_required of string
+  | Unsupported_server_request of string
+  | Turn_failed of string
+  | Turn_interrupted
+  | Process_exited of string
+  | Timeout of float
+
+let error_to_string = function
+  | Invalid_config detail -> "invalid Codex app-server config: " ^ detail
+  | Spawn_failed detail -> "failed to start Codex app-server: " ^ detail
+  | Protocol_error { stage; detail } ->
+    Printf.sprintf "Codex app-server protocol error during %s: %s" stage detail
+  | Rpc_error { method_; code; message } ->
+    let code = Option.fold ~none:"" ~some:(Printf.sprintf " (code %d)") code in
+    Printf.sprintf "Codex app-server RPC %s failed%s: %s" method_ code message
+  | Subscription_required detail ->
+    "Codex ChatGPT subscription login required: " ^ detail
+  | Unsupported_server_request method_ ->
+    "Codex app-server requested unsupported host action: " ^ method_
+  | Turn_failed detail -> "Codex app-server turn failed: " ^ detail
+  | Turn_interrupted -> "Codex app-server turn was interrupted"
+  | Process_exited detail -> "Codex app-server exited before completion: " ^ detail
+  | Timeout seconds ->
+    Printf.sprintf "Codex app-server turn timed out after %.3fs" seconds
+;;
+
+let protocol_error stage detail = Error (Protocol_error { stage; detail })
+
+let assoc_at stage = function
+  | `Assoc fields -> Ok fields
+  | _ -> protocol_error stage "expected a JSON object"
+;;
+
+let required_member stage name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_string stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) when String.trim value <> "" -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a non-empty string" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let optional_string stage name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
+;;
+
+let required_bool stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`Bool value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a boolean" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_int stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be an integer" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let ( let* ) result f = Result.bind result f
+
+type wire_message =
+  | Response of
+      { id : int
+      ; result : Yojson.Safe.t
+      }
+  | Response_error of
+      { id : int
+      ; code : int option
+      ; message : string
+      }
+  | Notification of
+      { method_ : string
+      ; params : Yojson.Safe.t
+      }
+  | Server_request of
+      { id : Yojson.Safe.t
+      ; method_ : string
+      }
+
+let parse_rpc_error id fields =
+  let stage = "JSON-RPC error" in
+  let* error_json = required_member stage "error" fields in
+  let* error_fields = assoc_at stage error_json in
+  let* message = required_string stage "message" error_fields in
+  let* code = required_int stage "code" error_fields in
+  Ok (Response_error { id; code = Some code; message })
+;;
+
+let parse_wire_line line =
+  let stage = "JSON-RPC message" in
+  let json_result =
+    try Ok (Yojson.Safe.from_string line) with
+    | Yojson.Json_error detail -> protocol_error stage ("invalid JSON: " ^ detail)
+  in
+  let* json = json_result in
+  let* fields = assoc_at stage json in
+  match List.assoc_opt "id" fields, List.assoc_opt "method" fields with
+  | Some id, Some (`String method_) -> Ok (Server_request { id; method_ })
+  | Some (`Int id), None ->
+    (match List.assoc_opt "error" fields with
+     | Some _ -> parse_rpc_error id fields
+     | None ->
+       let* result = required_member stage "result" fields in
+       Ok (Response { id; result }))
+  | Some _, None -> protocol_error stage "response id must be an integer"
+  | None, Some (`String method_) ->
+    let params = Option.value ~default:`Null (List.assoc_opt "params" fields) in
+    Ok (Notification { method_; params })
+  | Some _, Some _ | None, Some _ -> protocol_error stage "method must be a string"
+  | None, None -> protocol_error stage "message has neither id nor method"
+;;
+
+type io =
+  { send : Yojson.Safe.t -> unit
+  ; receive : unit -> (wire_message, error) result
+  }
+
+let send_request io ~id ~method_ ~params =
+  io.send (`Assoc [ "id", `Int id; "method", `String method_; "params", params ])
+;;
+
+let send_notification io method_ = io.send (`Assoc [ "method", `String method_ ])
+
+let reject_server_request io id =
+  io.send
+    (`Assoc
+       [ "id", id
+       ; ( "error"
+         , `Assoc
+             [ "code", `Int (-32601)
+             ; "message", `String "MASC does not support this app-server host request"
+             ] )
+       ])
+;;
+
+let rec await_response io ~id ~method_ =
+  let* message = io.receive () in
+  match message with
+  | Response { id = response_id; result } when response_id = id -> Ok result
+  | Response { id = response_id; _ } ->
+    protocol_error method_
+      (Printf.sprintf "received response id %d while waiting for %d" response_id id)
+  | Response_error { id = response_id; code; message } when response_id = id ->
+    Error (Rpc_error { method_; code; message })
+  | Response_error { id = response_id; _ } ->
+    protocol_error method_
+      (Printf.sprintf "received error response id %d while waiting for %d" response_id id)
+  | Notification _ -> await_response io ~id ~method_
+  | Server_request { id; method_ = requested_method } ->
+    reject_server_request io id;
+    Error (Unsupported_server_request requested_method)
+;;
+
+let parse_initialize result =
+  let stage = "initialize" in
+  let* fields = assoc_at stage result in
+  optional_string stage "userAgent" fields
+;;
+
+let parse_subscription result =
+  let stage = "account/read" in
+  let* fields = assoc_at stage result in
+  let* _requires_auth = required_bool stage "requiresOpenaiAuth" fields in
+  let* account = required_member stage "account" fields in
+  match account with
+  | `Null -> Error (Subscription_required "the official CLI has no active account")
+  | `Assoc account_fields ->
+    let* account_type = required_string stage "type" account_fields in
+    if account_type <> "chatgpt"
+    then
+      Error
+        (Subscription_required
+           (Printf.sprintf "account/read reported account type %S" account_type))
+    else
+      let* plan_type = required_string stage "planType" account_fields in
+      let* email = optional_string stage "email" account_fields in
+      Ok { plan_type; email }
+  | _ -> protocol_error stage "account must be an object or null"
+;;
+
+let parse_thread_start result =
+  let stage = "thread/start" in
+  let* fields = assoc_at stage result in
+  let* thread_json = required_member stage "thread" fields in
+  let* thread_fields = assoc_at stage thread_json in
+  let* thread_id = required_string stage "id" thread_fields in
+  let* model = required_string stage "model" fields in
+  Ok (thread_id, model)
+;;
+
+let parse_turn_start result =
+  let stage = "turn/start" in
+  let* fields = assoc_at stage result in
+  let* turn_json = required_member stage "turn" fields in
+  let* turn_fields = assoc_at stage turn_json in
+  required_string stage "id" turn_fields
+;;
+
+let agent_message_of_item ~stage item =
+  let* fields = assoc_at stage item in
+  match List.assoc_opt "type" fields with
+  | Some (`String "agentMessage") ->
+    let* text = required_string stage "text" fields in
+    let* phase = optional_string stage "phase" fields in
+    Ok (Some (phase, text))
+  | Some (`String _) -> Ok None
+  | Some _ -> protocol_error stage "item type must be a string"
+  | None -> protocol_error stage "item is missing type"
+;;
+
+let messages_of_items ~stage = function
+  | `List items ->
+    let rec loop final fallback = function
+      | [] -> Ok (final, fallback)
+      | item :: rest ->
+        let* message = agent_message_of_item ~stage item in
+        (match message with
+         | Some (Some "final_answer", text) -> loop (Some text) fallback rest
+         | Some (_, text) -> loop final (Some text) rest
+         | None -> loop final fallback rest)
+    in
+    loop None None items
+  | _ -> protocol_error stage "turn items must be an array"
+;;
+
+let turn_error_message fields =
+  match List.assoc_opt "error" fields with
+  | Some (`Assoc error_fields) ->
+    (match List.assoc_opt "message" error_fields with
+     | Some (`String message) when String.trim message <> "" -> message
+     | _ -> "turn failed without a typed error message")
+  | _ -> "turn failed without an error object"
+;;
+
+let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
+  let stage = "turn/completed" in
+  let* fields = assoc_at stage params in
+  let* terminal_thread_id = required_string stage "threadId" fields in
+  if terminal_thread_id <> thread_id
+  then protocol_error stage "terminal threadId does not match thread/start"
+  else
+    let* turn_json = required_member stage "turn" fields in
+    let* turn_fields = assoc_at stage turn_json in
+    let* terminal_turn_id = required_string stage "id" turn_fields in
+    if terminal_turn_id <> turn_id
+    then protocol_error stage "terminal turn id does not match turn/start"
+    else
+      let* status = required_string stage "status" turn_fields in
+      match status with
+      | "failed" -> Error (Turn_failed (turn_error_message turn_fields))
+      | "interrupted" -> Error Turn_interrupted
+      | "inProgress" -> protocol_error stage "terminal notification carried inProgress status"
+      | "completed" ->
+        let* items = required_member stage "items" turn_fields in
+        let* terminal_final, terminal_fallback = messages_of_items ~stage items in
+        let text =
+          match terminal_final, seen_final, terminal_fallback, seen_fallback with
+          | Some text, _, _, _ | None, Some text, _, _
+          | None, None, Some text, _ | None, None, None, Some text -> Some text
+          | None, None, None, None -> None
+        in
+        (match text with
+         | Some text -> Ok text
+         | None -> protocol_error stage "completed turn has no assistant message")
+      | other -> protocol_error stage (Printf.sprintf "unknown turn status %S" other)
+;;
+
+let rec await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback =
+  let* message = io.receive () in
+  match message with
+  | Response _ | Response_error _ ->
+    protocol_error "turn" "received an unsolicited JSON-RPC response"
+  | Server_request { id; method_ } ->
+    reject_server_request io id;
+    Error (Unsupported_server_request method_)
+  | Notification { method_ = "item/completed"; params } ->
+    let stage = "item/completed" in
+    let* fields = assoc_at stage params in
+    let* item_thread_id = required_string stage "threadId" fields in
+    let* item_turn_id = required_string stage "turnId" fields in
+    if item_thread_id <> thread_id || item_turn_id <> turn_id
+    then protocol_error stage "item identity does not match the active turn"
+    else
+      let* item = required_member stage "item" fields in
+      let* message = agent_message_of_item ~stage item in
+      let seen_final, seen_fallback =
+        match message with
+        | Some (Some "final_answer", text) -> Some text, seen_fallback
+        | Some (_, text) -> seen_final, Some text
+        | None -> seen_final, seen_fallback
+      in
+      await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+  | Notification { method_ = "error"; params } ->
+    let stage = "error notification" in
+    let* fields = assoc_at stage params in
+    let* will_retry = required_bool stage "willRetry" fields in
+    if will_retry
+    then await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+    else
+      let* error_json = required_member stage "error" fields in
+      let* error_fields = assoc_at stage error_json in
+      let* message = required_string stage "message" error_fields in
+      Error (Turn_failed message)
+  | Notification { method_ = "turn/completed"; params } ->
+    terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params
+  | Notification _ ->
+    await_turn_terminal io ~thread_id ~turn_id ~seen_final ~seen_fallback
+;;
+
+let optional_field name = function
+  | None -> []
+  | Some value -> [ name, `String value ]
+;;
+
+let run_protocol io config ~prompt =
+  send_request io ~id:1 ~method_:"initialize"
+    ~params:
+      (`Assoc
+         [ ( "clientInfo"
+           , `Assoc
+               [ "name", `String "masc"
+               ; "title", `String "MASC"
+               ; "version", `String "dev"
+               ] )
+         ; "capabilities", `Assoc [ "experimentalApi", `Bool true ]
+         ]);
+  let* initialize = await_response io ~id:1 ~method_:"initialize" in
+  let* user_agent = parse_initialize initialize in
+  send_notification io "initialized";
+  send_request io ~id:2 ~method_:"account/read"
+    ~params:(`Assoc [ "refreshToken", `Bool false ]);
+  let* account = await_response io ~id:2 ~method_:"account/read" in
+  let* subscription = parse_subscription account in
+  let thread_fields =
+    [ "cwd", `String config.cwd
+    ; "approvalPolicy", `String "never"
+    ; "sandbox", `String "read-only"
+    ; "ephemeral", `Bool true
+    ]
+    @ optional_field "model" config.model
+    @ optional_field "developerInstructions" config.developer_instructions
+  in
+  send_request io ~id:3 ~method_:"thread/start" ~params:(`Assoc thread_fields);
+  let* thread = await_response io ~id:3 ~method_:"thread/start" in
+  let* thread_id, model = parse_thread_start thread in
+  send_request io ~id:4 ~method_:"turn/start"
+    ~params:
+      (`Assoc
+         [ "threadId", `String thread_id
+         ; ( "input"
+           , `List [ `Assoc [ "type", `String "text"; "text", `String prompt ] ] )
+         ]);
+  let* turn = await_response io ~id:4 ~method_:"turn/start" in
+  let* turn_id = parse_turn_start turn in
+  let* text =
+    await_turn_terminal io ~thread_id ~turn_id ~seen_final:None ~seen_fallback:None
+  in
+  Ok { thread_id; turn_id; model; text; subscription; user_agent }
+;;
+
+let env_key entry =
+  match String.index_opt entry '=' with
+  | Some index -> String.sub entry 0 index
+  | None -> entry
+;;
+
+let subscription_only_environment () =
+  Unix.environment ()
+  |> Array.to_list
+  |> List.filter (fun entry ->
+    match env_key entry with
+    | "OPENAI_API_KEY" | "CODEX_API_KEY" -> false
+    | _ -> true)
+  |> Array.of_list
+;;
+
+let bounded_tail ~limit current addition =
+  let combined = current ^ addition in
+  let length = String.length combined in
+  if length <= limit then combined else String.sub combined (length - limit) limit
+;;
+
+let drain_stderr flow tail =
+  let chunk = Cstruct.create 4096 in
+  try
+    while true do
+      let count = Eio.Flow.single_read flow chunk in
+      let text = Cstruct.to_string (Cstruct.sub chunk 0 count) in
+      tail := bounded_tail ~limit:4096 !tail text
+    done
+  with
+  | End_of_file -> ()
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | _ -> ()
+;;
+
+let run_spawned ~mgr ~clock config ~prompt =
+  Eio.Switch.run (fun sw ->
+    let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
+    let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
+    let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
+    let stderr_tail = ref "" in
+    let proc =
+      Eio.Process.spawn ~sw mgr
+        ~env:(subscription_only_environment ())
+        ~stdin:stdin_r ~stdout:stdout_w ~stderr:stderr_w
+        [ config.cli_path; "app-server"; "--stdio" ]
+    in
+    Eio.Flow.close stdin_r;
+    Eio.Flow.close stdout_w;
+    Eio.Flow.close stderr_w;
+    Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
+    let reader = Eio.Buf_read.of_flow ~max_size:(8 * 1024 * 1024) stdout_r in
+    let send json =
+      Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
+      Eio.Flow.copy_string "\n" stdin_w
+    in
+    let receive () =
+      try parse_wire_line (Eio.Buf_read.line reader) with
+      | End_of_file ->
+        let detail = String.trim !stderr_tail in
+        Error (Process_exited (if detail = "" then "stdout closed" else detail))
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn -> protocol_error "stdout read" (Printexc.to_string exn)
+    in
+    Fun.protect
+      ~finally:(fun () ->
+        (try Eio.Flow.close stdin_w with _ -> ());
+        (try Eio.Process.signal proc Sys.sigterm with _ -> ()))
+      (fun () ->
+        Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+          run_protocol { send; receive } config ~prompt)))
+;;
+
+let validate_config config ~prompt =
+  if String.trim config.cli_path = ""
+  then Error (Invalid_config "cli_path must not be empty")
+  else if String.trim config.cwd = "" || Filename.is_relative config.cwd
+  then Error (Invalid_config "cwd must be an absolute path")
+  else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
+  then Error (Invalid_config "timeout_s must be positive and finite")
+  else if String.trim prompt = ""
+  then Error (Invalid_config "prompt must not be empty")
+  else Ok ()
+;;
+
+let run_turn ~mgr ~clock config ~prompt =
+  match validate_config config ~prompt with
+  | Error _ as error -> error
+  | Ok () ->
+    (try run_spawned ~mgr ~clock config ~prompt with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+     | exn -> Error (Spawn_failed (Printexc.to_string exn)))
+;;

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -24,8 +24,30 @@ type turn_result =
   ; turn_id : string
   ; model : string
   ; text : string
+  ; dynamic_tool_calls : int
   ; subscription : subscription
   ; user_agent : string option
+  }
+
+type dynamic_tool_result =
+  { success : bool
+  ; content : string
+  }
+
+type dynamic_tool =
+  { name : string
+  ; description : string
+  ; input_schema : Yojson.Safe.t
+  ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
+  }
+
+type history_role =
+  | User
+  | Assistant
+
+type history_message =
+  { role : history_role
+  ; text : string
   }
 
 type error =
@@ -50,8 +72,10 @@ type error =
 val error_to_string : error -> string
 
 val run_turn :
+  ?dynamic_tools:dynamic_tool list ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
+  ?history:history_message list ->
   config ->
   prompt:string ->
   (turn_result, error) result

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -1,0 +1,57 @@
+(** A single-turn Codex app-server client.
+
+    This is an agent-runtime boundary, not an {!Llm_provider.Llm_transport}
+    implementation. Codex owns the whole turn. MASC owns process lifetime,
+    subscription admission, and terminal projection. *)
+
+type subscription =
+  { plan_type : string
+  ; email : string option
+  }
+
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string option
+  ; developer_instructions : string option
+  ; timeout_s : float
+  }
+
+val default_config : cwd:string -> config
+
+type turn_result =
+  { thread_id : string
+  ; turn_id : string
+  ; model : string
+  ; text : string
+  ; subscription : subscription
+  ; user_agent : string option
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | Rpc_error of
+      { method_ : string
+      ; code : int option
+      ; message : string
+      }
+  | Subscription_required of string
+  | Unsupported_server_request of string
+  | Turn_failed of string
+  | Turn_interrupted
+  | Process_exited of string
+  | Timeout of float
+
+val error_to_string : error -> string
+
+val run_turn :
+  mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  config ->
+  prompt:string ->
+  (turn_result, error) result

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -73,6 +73,7 @@ val error_to_string : error -> string
 
 val run_turn :
   ?dynamic_tools:dynamic_tool list ->
+  ?reasoning_effort:Llm_provider.Reasoning_effort.t ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   ?history:history_message list ->

--- a/lib/runtime/runtime_execution.ml
+++ b/lib/runtime/runtime_execution.ml
@@ -1,0 +1,33 @@
+type codex_app_server =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
+type t =
+  | Agent_core of Llm_provider.Provider_config.t
+  | Codex_app_server of codex_app_server
+
+type checkpoint_owner =
+  | Masc_oas
+  | Official_client
+
+let agent_core_provider_config = function
+  | Agent_core config -> Some config
+  | Codex_app_server _ -> None
+;;
+
+let model_id = function
+  | Agent_core config -> Some config.Llm_provider.Provider_config.model_id
+  | Codex_app_server config -> config.model
+;;
+
+let label = function
+  | Agent_core _ -> "agent_core"
+  | Codex_app_server _ -> "codex_app_server"
+;;
+
+let checkpoint_owner = function
+  | Agent_core _ -> Masc_oas
+  | Codex_app_server _ -> Official_client
+;;

--- a/lib/runtime/runtime_execution.mli
+++ b/lib/runtime/runtime_execution.mli
@@ -1,0 +1,27 @@
+(** Typed owner of one Runtime turn.
+
+    [Agent_core] means MASC/OAS owns the model/tool/checkpoint loop.
+    [Codex_app_server] means the official Codex client owns the whole turn;
+    MASC owns admission, process lifetime, and result projection. *)
+
+type codex_app_server =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
+type t =
+  | Agent_core of Llm_provider.Provider_config.t
+  | Codex_app_server of codex_app_server
+
+type checkpoint_owner =
+  | Masc_oas
+  | Official_client
+
+val agent_core_provider_config : t -> Llm_provider.Provider_config.t option
+val model_id : t -> string option
+val label : t -> string
+val checkpoint_owner : t -> checkpoint_owner
+(** Typed owner of the runtime's resumable execution state. [Masc_oas]
+    requires an OAS checkpoint on every successful turn. [Official_client]
+    forbids projecting the client's session state into an OAS checkpoint. *)

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -80,13 +80,22 @@ let resolve_runtime_providers ~runtime_id () =
      was ignored here and is deleted;
      each resolved runtime carries exactly one provider_config. *)
   let runtime_id = String.trim runtime_id in
+  let provider_config_of_runtime rt =
+    match rt.Runtime.execution with
+    | Runtime_execution.Agent_core provider_config -> Ok provider_config
+    | Runtime_execution.Codex_app_server _ ->
+      Error
+        (Printf.sprintf
+           "runtime %S is owned by codex-app-server, not the OAS agent_core"
+           rt.Runtime.id)
+  in
   if String.equal runtime_id "" then
     match Runtime.get_default_runtime () with
     | None -> Error "no default runtime configured"
-    | Some rt -> Ok [ rt.Runtime.provider_config ]
+    | Some rt -> Result.map (fun provider_config -> [ provider_config ]) (provider_config_of_runtime rt)
   else
     match Runtime.get_runtime_by_id runtime_id with
-    | Some rt -> Ok [ rt.Runtime.provider_config ]
+    | Some rt -> Result.map (fun provider_config -> [ provider_config ]) (provider_config_of_runtime rt)
     | None ->
       Error
         (Printf.sprintf

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -13,6 +13,7 @@ type api_format =
   | Messages_api
   | Chat_completions_api
   | Ollama_api
+  | Codex_app_server_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -11,6 +11,7 @@ type api_format =
   | Messages_api
   | Chat_completions_api
   | Ollama_api
+  | Codex_app_server_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -106,14 +106,16 @@ let partition_results
 
 let canonical_protocol_of_protocol = function
   | "messages-cli" | "messages-http" | "openai-compatible-cli"
-  | "openai-compatible-http" | "ollama-http" as protocol -> Some protocol
+  | "openai-compatible-http" | "ollama-http" | "codex-app-server" as protocol ->
+    Some protocol
   | _ -> None
 ;;
 
 let unknown_protocol_error s =
   Printf.sprintf
     "unknown protocol %S: expected one of messages-cli, messages-http, \
-     openai-compatible-cli, openai-compatible-http, ollama-http"
+     openai-compatible-cli, openai-compatible-http, ollama-http, \
+     codex-app-server"
     s
 ;;
 
@@ -125,6 +127,7 @@ let api_format_of_protocol (s : string)
   | "openai-compatible-cli" | "openai-compatible-http" ->
     Ok Runtime_schema.Chat_completions_api
   | "ollama-http" -> Ok Runtime_schema.Ollama_api
+  | "codex-app-server" -> Ok Runtime_schema.Codex_app_server_runtime
   | _ -> Error (unknown_protocol_error s)
 ;;
 

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -774,15 +774,17 @@ let dashboard_runtime_append_probe_path base ~suffix =
 
 let dashboard_runtime_probe_url ~(api_format : Runtime_schema.api_format) base_url =
   match api_format with
+  | Runtime_schema.Codex_app_server_runtime -> None
   | Runtime_schema.Ollama_api ->
     let base = dashboard_runtime_trim_trailing_slashes base_url in
-    if String.ends_with ~suffix:"/api/tags" base
-    then base
-    else if String.ends_with ~suffix:"/api" base
-    then base ^ "/tags"
-    else base ^ "/api/tags"
+    Some
+      (if String.ends_with ~suffix:"/api/tags" base
+       then base
+       else if String.ends_with ~suffix:"/api" base
+       then base ^ "/tags"
+       else base ^ "/api/tags")
   | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
-      dashboard_runtime_append_probe_path base_url ~suffix:"/models"
+    Some (dashboard_runtime_append_probe_path base_url ~suffix:"/models")
 ;;
 
 let dashboard_runtime_url_for_json raw =
@@ -882,6 +884,7 @@ let dashboard_runtime_model_count_of_body ~(api_format : Runtime_schema.api_form
   try
     let json = Yojson.Safe.from_string body in
     match api_format with
+    | Runtime_schema.Codex_app_server_runtime -> None
     | Runtime_schema.Ollama_api -> dashboard_runtime_list_member_len "models" json
     | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
       (match dashboard_runtime_list_member_len "data" json with
@@ -981,19 +984,28 @@ let dashboard_runtime_provider_probe_json
       ~error:"CLI runtimes do not expose an HTTP reachability endpoint"
       ()
   | Runtime_schema.Http endpoint_url ->
-    let probe_url = dashboard_runtime_probe_url ~api_format:rt.provider.api_format endpoint_url in
-    let probe_url_json = dashboard_runtime_url_for_json probe_url in
-    if not (dashboard_runtime_http_url_valid probe_url)
-    then
+    begin match dashboard_runtime_probe_url ~api_format:rt.provider.api_format endpoint_url with
+     | None ->
       make
-        ~probe_url:probe_url_json
         ~auth_present:false
-        ~status:"invalid_endpoint"
+        ~status:"invalid_execution_transport"
         ~reachable:(Some false)
         ~skipped:false
-        ~error:"runtime endpoint is not an absolute http(s) URL"
+        ~error:"codex-app-server must use the official CLI transport"
         ()
-    else (
+     | Some probe_url ->
+      let probe_url_json = dashboard_runtime_url_for_json probe_url in
+      if not (dashboard_runtime_http_url_valid probe_url)
+      then
+        make
+          ~probe_url:probe_url_json
+          ~auth_present:false
+          ~status:"invalid_endpoint"
+          ~reachable:(Some false)
+          ~skipped:false
+          ~error:"runtime endpoint is not an absolute http(s) URL"
+          ()
+      else (
       match dashboard_runtime_probe_headers rt.provider with
       | Error error ->
         make
@@ -1042,6 +1054,7 @@ let dashboard_runtime_provider_probe_json
              ~skipped:false
              ~error
              ()))
+    end
 ;;
 
 let dashboard_runtime_probe_payload_json_of_runtimes ?default_id runtimes =
@@ -1524,8 +1537,17 @@ let response_format_json : Llm_provider.Types.response_format -> Yojson.Safe.t =
 ;;
 
 let runtime_request_config_json (rt : Runtime.t) =
-  let cfg = rt.provider_config in
-  `Assoc
+  match rt.execution with
+  | Runtime_execution.Codex_app_server config ->
+    `Assoc
+      [ "source", `String "official-client-runtime"
+      ; "execution", `String "codex_app_server"
+      ; "model", Json_util.string_opt_to_json config.model
+      ; "timeout_s", `Float config.timeout_s
+      ; "verified", `Bool false
+      ]
+  | Runtime_execution.Agent_core cfg ->
+    `Assoc
     [ "source", `String "oas-provider-config"
     ; "provider_kind", `String (Llm_provider.Provider_config.string_of_provider_kind cfg.kind)
     ; "request_path", `String cfg.request_path
@@ -1568,6 +1590,7 @@ let runtime_api_format_wire : Runtime_schema.api_format -> string = function
   | Runtime_schema.Messages_api -> "messages"
   | Runtime_schema.Chat_completions_api -> "chat-completions"
   | Runtime_schema.Ollama_api -> "ollama"
+  | Runtime_schema.Codex_app_server_runtime -> "codex-app-server"
 ;;
 
 let runtime_provider_behavior_capabilities_json
@@ -1670,7 +1693,15 @@ let runtime_declared_spec_json (rt : Runtime.t) =
 ;;
 
 let effective_capabilities_json (rt : Runtime.t) =
-  match Llm_provider.Provider_config.capabilities_for_config_model rt.provider_config with
+  match rt.execution with
+  | Runtime_execution.Codex_app_server _ ->
+    `Assoc
+      [ "source", `String "unverified"
+      ; "execution", `String "codex_app_server"
+      ; "verified", `Bool false
+      ]
+  | Runtime_execution.Agent_core provider_config ->
+   (match Llm_provider.Provider_config.capabilities_for_config_model provider_config with
   | None -> `Null
   | Some caps ->
     let accepted_reasoning_efforts =
@@ -1733,7 +1764,7 @@ let effective_capabilities_json (rt : Runtime.t) =
       ; "supports_code_execution", `Bool caps.supports_code_execution
       ; "emits_usage_tokens", `Bool caps.emits_usage_tokens
       ; "supported_models", supported_models
-      ]
+      ])
 ;;
 
 let runtime_parameter_policy_json (rt : Runtime.t) =
@@ -1743,19 +1774,26 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
     |> List.map Llm_provider.Capabilities.sampling_parameter_to_string
     |> Json_util.json_string_list
   in
-  let dialect = RD.for_provider_config rt.provider_config in
-  let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
-  let ignored_sampling_params =
-    List.filter
-      (fun field -> RD.ignores_sampling_param dialect ~enable_thinking:None field)
-      sampling_candidates
-  in
-  let always_ignored_sampling_params =
-    List.filter
-      (fun field -> RD.ignores_sampling_param dialect ~enable_thinking:(Some false) field)
-      sampling_candidates
-  in
-  `Assoc
+  match rt.execution with
+  | Runtime_execution.Codex_app_server _ ->
+    `Assoc
+      [ "source", `String "official-client-owned"
+      ; "execution", `String "codex_app_server"
+      ]
+  | Runtime_execution.Agent_core provider_config ->
+    let dialect = RD.for_provider_config provider_config in
+    let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
+    let ignored_sampling_params =
+      List.filter
+        (fun field -> RD.ignores_sampling_param dialect ~enable_thinking:None field)
+        sampling_candidates
+    in
+    let always_ignored_sampling_params =
+      List.filter
+        (fun field -> RD.ignores_sampling_param dialect ~enable_thinking:(Some false) field)
+        sampling_candidates
+    in
+    `Assoc
     [ "reasoning_toggle_wire", `String (RD.toggle_wire_to_string dialect.toggle_wire)
     ; "reasoning_replay_policy", `String (RD.replay_policy_to_string dialect.replay_policy)
     ; "requires_reasoning_replay_on_tool_call", `Bool (RD.requires_reasoning_replay_on_tool_call dialect)
@@ -1767,6 +1805,14 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
 
 let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
   let runtime_kind = runtime_kind_of_transport rt.provider.transport in
+  let is_official_client_runtime =
+    match rt.execution with
+    | Runtime_execution.Codex_app_server _ -> true
+    | Runtime_execution.Agent_core _ -> false
+  in
+  let runtime_status =
+    if is_official_client_runtime then "configured_unverified" else "configured"
+  in
   let models = [ rt.model.api_name ] in
   let capabilities_declared, caps =
     match rt.model.capabilities with
@@ -1790,13 +1836,13 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "kind", `String (runtime_dashboard_kind_of_runtime_kind runtime_kind)
     ; "runtime_kind", `String (runtime_kind_to_string runtime_kind)
     ; "auth_kind", `String (runtime_auth_kind_of_credential rt.provider.credentials)
-    ; "status", `String "configured"
-    ; "available", `Bool true
+    ; "status", `String runtime_status
+    ; "available", `Bool (not is_official_client_runtime)
     ; "is_default_runtime", `Bool (Option.equal String.equal default_id (Some rt.id))
     ; "max_context", `Int (Runtime.max_context_of_runtime rt)
-    ; "tools_support", `Bool rt.model.tools_support
-    ; "thinking_support", `Bool rt.model.thinking_support
-    ; "streaming", `Bool rt.model.streaming
+    ; "tools_support", `Bool (rt.model.tools_support && not is_official_client_runtime)
+    ; "thinking_support", `Bool (rt.model.thinking_support && not is_official_client_runtime)
+    ; "streaming", `Bool (rt.model.streaming && not is_official_client_runtime)
       (* Per-model sampling temperature override ([models.<id>].temperature).
          [`Null] when unset (the runtime keeps the fleet fallback). Read-only
          projection for the dashboard runtime capability card. *)
@@ -1840,6 +1886,16 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "effective_capabilities", effective_capabilities_json rt
     ; "parameter_policy", runtime_parameter_policy_json rt
     ; "request_config", runtime_request_config_json rt
+    ; ( "verification"
+      , if is_official_client_runtime
+        then
+          `Assoc
+            [ "status", `String "unverified"
+            ; "measured", `Bool false
+            ; "evidence", `Null
+            ; "reason", `String "no_successful_runtime_observation"
+            ]
+        else `Null )
     ; "declared_spec", runtime_declared_spec_json rt
     ; "model_count", `Int (List.length models)
     ; "models", Json_util.json_string_list models

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -88,21 +88,30 @@ let finalize_runtime_breakdown json =
         ]
   | _ -> json
 
-let validate_requested_model (runtime : Runtime.t) = function
-  | None -> Ok runtime
-  | Some requested_model ->
+let validate_requested_model (runtime : Runtime.t) requested_model =
+  match runtime.execution with
+  | Runtime_execution.Codex_app_server _ ->
+    Error
+      (Printf.sprintf
+         "runtime %S is owned by codex-app-server; local_runtime_bench only \
+          measures OAS agent_core providers"
+         runtime.id)
+  | Runtime_execution.Agent_core provider_config ->
+    (match requested_model with
+     | None -> Ok (runtime, provider_config)
+     | Some requested_model ->
       let requested_model = String.trim requested_model in
       if String.equal requested_model "" then
         Error "model must be a non-empty configured model id"
-      else if String.equal requested_model runtime.provider_config.model_id then
-        Ok runtime
+      else if String.equal requested_model provider_config.model_id then
+        Ok (runtime, provider_config)
       else
         Error
           (Printf.sprintf
              "runtime %S is configured for model %S, not requested model %S"
              runtime.id
-             runtime.provider_config.model_id
-             requested_model)
+             provider_config.model_id
+             requested_model))
 
 let resolve_runtime ?model_id = function
   | None ->
@@ -124,12 +133,13 @@ let resolve_runtime ?model_id = function
                   "runtime %S is not materialized from runtime.toml"
                   runtime_id))
 
-let ensure_runtime_reachable (runtime : Runtime.t) ~timeout_sec =
+let ensure_runtime_reachable (runtime : Runtime.t)
+    (provider_config : Llm_provider.Provider_config.t) ~timeout_sec =
   match runtime.provider.healthcheck_path with
   | None -> Ok ()
   | Some healthcheck_path ->
       let health_url =
-        runtime.provider_config.base_url
+        provider_config.Llm_provider.Provider_config.base_url
         |> Uri.of_string
         |> fun base -> Uri.with_path base healthcheck_path
         |> Uri.to_string
@@ -151,7 +161,9 @@ let ensure_runtime_reachable (runtime : Runtime.t) ~timeout_sec =
        | Error err ->
            Error (Printf.sprintf "runtime %S unavailable: %s" runtime.id err))
 
-let oas_completion_at (runtime : Runtime.t) ~prompt ~max_tokens ~timeout_sec () =
+let oas_completion_at (runtime : Runtime.t)
+    (provider_config : Llm_provider.Provider_config.t) ~prompt ~max_tokens
+    ~timeout_sec () =
   match Masc_eio_env.get_opt () with
   | None ->
       (* MASC-OAS boundary: raw curl fallback removed.
@@ -162,7 +174,7 @@ let oas_completion_at (runtime : Runtime.t) ~prompt ~max_tokens ~timeout_sec () 
   | Some env -> (
       let started = Time_compat.now () in
       let provider_config =
-        { runtime.provider_config with max_tokens = Some max_tokens }
+        { provider_config with max_tokens = Some max_tokens }
       in
           let messages : Oas_types.message list = [ Oas_types.user_msg prompt ] in
           let run_completion () =
@@ -193,8 +205,8 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
     ~timeout_sec () =
   match resolve_runtime ?model_id runtime_pool with
   | Error _ as err -> err
-  | Ok runtime ->
-    (match ensure_runtime_reachable runtime ~timeout_sec with
+  | Ok (runtime, provider_config) ->
+    (match ensure_runtime_reachable runtime provider_config ~timeout_sec with
      | Error _ as err -> err
      | Ok () ->
       let total = parallelism * rounds in
@@ -206,7 +218,8 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
           (List.init parallelism (fun fiber_idx ->
                fun () ->
                  let sample, runtime_id =
-                   oas_completion_at runtime ~prompt ~max_tokens ~timeout_sec ()
+                   oas_completion_at runtime provider_config ~prompt ~max_tokens
+                     ~timeout_sec ()
                  in
                  update_runtime_breakdown runtime_breakdown ~runtime_id ~sample;
                  results.(offset + fiber_idx) <- Some sample))
@@ -237,9 +250,9 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
       Ok
         (`Assoc
           [
-            ("server_url", `String runtime.provider_config.base_url);
+            ("server_url", `String provider_config.base_url);
             ("source", `String "oas_complete");
-            ("model_id", `String runtime.provider_config.model_id);
+            ("model_id", `String provider_config.model_id);
             ("runtime_pool", `String runtime.id);
             ("parallelism", `Int parallelism);
             ("rounds", `Int rounds);

--- a/test/dune
+++ b/test/dune
@@ -1943,6 +1943,8 @@
 
 (include stanzas/test_runtime_agent_checkpoint.inc)
 
+(include stanzas/test_runtime_codex_app_server.inc)
+
 (include stanzas/test_runtime_provider_projection_boundary.inc)
 
 (include stanzas/test_openapi_api_e2e.inc)

--- a/test/stanzas/test_runtime_codex_app_server.inc
+++ b/test/stanzas/test_runtime_codex_app_server.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_codex_app_server)
+ (modules test_runtime_codex_app_server)
+ (libraries masc_test_deps))

--- a/test/stanzas/test_runtime_codex_app_server.inc
+++ b/test/stanzas/test_runtime_codex_app_server.inc
@@ -1,4 +1,4 @@
 (test
  (name test_runtime_codex_app_server)
  (modules test_runtime_codex_app_server)
- (libraries masc_test_deps))
+ (libraries masc masc_test_deps))

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -576,10 +576,12 @@ let test_provider_for_vision_uses_runtime_temperature () =
       (match Runtime.get_runtime_by_id runtime_id with
        | None -> failwith "selected vision runtime should resolve"
        | Some runtime ->
-         let configured =
-           Vt.provider_for_vision runtime.Runtime.provider_config
-         in
-         assert (configured.temperature = Some 1.0)))
+         (match runtime.Runtime.execution with
+          | Runtime_execution.Codex_app_server _ ->
+            failwith "selected vision runtime should be agent_core"
+          | Runtime_execution.Agent_core provider_config ->
+            let configured = Vt.provider_for_vision provider_config in
+            assert (configured.temperature = Some 1.0))))
 
 let test_uncapped_vision_fallback_rejects_before_provider_call () =
   with_temp_runtime_toml uncapped_vision_fallback_runtime_toml (fun () ->

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -60,7 +60,7 @@ let with_fixture lines f =
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
-let run_fixture path =
+let run_fixture ?(dynamic_tools = []) ?(history = []) path =
   Eio_main.run (fun env ->
     let config =
       { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
@@ -71,8 +71,77 @@ let run_fixture path =
     Runtime_codex_app_server.run_turn
       ~mgr:(Eio.Stdenv.process_mgr env)
       ~clock:(Eio.Stdenv.clock env)
+      ~dynamic_tools
+      ~history
       config
       ~prompt:"Return the fixture marker")
+;;
+
+let tool_call_request =
+  {|{"id":"tool-request-1","method":"item/tool/call","params":{"threadId":"thread-1","turnId":"turn-1","callId":"call-1","tool":"masc_probe","namespace":null,"arguments":{"marker":"from-codex"}}}|}
+;;
+
+let test_dynamic_tool_callback () =
+  let call_id = ref None in
+  let arguments = ref `Null in
+  let tool : Runtime_codex_app_server.dynamic_tool =
+    { name = "masc_probe"
+    ; description = "Return a deterministic fixture marker"
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc [ "marker", `Assoc [ "type", `String "string" ] ]
+          ; "required", `List [ `String "marker" ]
+          ]
+    ; call =
+        (fun ~call_id:id input ->
+          call_id := Some id;
+          arguments := input;
+          { success = true; content = "MASC_TOOL_RESULT" })
+    }
+  in
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; tool_call_request
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun path ->
+       match run_fixture ~dynamic_tools:[ tool ] path with
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok result ->
+         check int "measured tool calls" 1 result.dynamic_tool_calls;
+         check (option string) "call id" (Some "call-1") !call_id;
+         check string
+           "arguments"
+           {|{"marker":"from-codex"}|}
+           (Yojson.Safe.to_string !arguments))
+;;
+
+let test_history_is_injected_before_turn () =
+  let injected = {|{"id":4,"result":{}}|} in
+  let turn_after_injection = {|{"id":5,"result":{"turn":{"id":"turn-1"}}}|} in
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; injected
+    ; turn_after_injection
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun path ->
+       let history =
+         [ { Runtime_codex_app_server.role = User; text = "previous user" }
+         ; { Runtime_codex_app_server.role = Assistant; text = "previous assistant" }
+         ]
+       in
+       match run_fixture ~history path with
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok result -> check string "text" "MASC_SUBSCRIPTION_OK" result.text)
 ;;
 
 let test_chatgpt_subscription_turn () =
@@ -178,6 +247,71 @@ let test_live_chatgpt_subscription () =
         (String.trim result.subscription.plan_type <> "")
 ;;
 
+let test_live_dynamic_tool_subscription () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let tool_calls = ref 0 in
+    let tool : Runtime_codex_app_server.dynamic_tool =
+      { name = "masc_probe"
+      ; description = "Return the exact marker MASC_TOOL_RESULT"
+      ; input_schema =
+          `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+      ; call =
+          (fun ~call_id:_ _ ->
+            incr tool_calls;
+            { success = true; content = "MASC_TOOL_RESULT" })
+      }
+    in
+    let result =
+      Eio_main.run (fun env ->
+        let config =
+          { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+            timeout_s = 60.0
+          }
+        in
+        Runtime_codex_app_server.run_turn
+          ~mgr:(Eio.Stdenv.process_mgr env)
+          ~clock:(Eio.Stdenv.clock env)
+          ~dynamic_tools:[ tool ]
+          config
+          ~prompt:
+            "Call masc_probe exactly once, then reply with exactly MASC_TOOL_OK.")
+    in
+    match result with
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+    | Ok result ->
+      check int "live dynamic tool calls" 1 !tool_calls;
+      check int "live measured tool calls" 1 result.dynamic_tool_calls;
+      check string "live tool response" "MASC_TOOL_OK" result.text
+;;
+
+let test_live_history_injection_subscription () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let result =
+      Eio_main.run (fun env ->
+        let config =
+          { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+            timeout_s = 60.0
+          }
+        in
+        Runtime_codex_app_server.run_turn
+          ~mgr:(Eio.Stdenv.process_mgr env)
+          ~clock:(Eio.Stdenv.clock env)
+          ~history:
+            [ { role = User; text = "The continuity marker is MASC_HISTORY_OK." }
+            ; { role = Assistant; text = "I will retain that marker." }
+            ]
+          config
+          ~prompt:"Reply with exactly the continuity marker from the prior history.")
+    in
+    match result with
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+    | Ok result -> check string "live history response" "MASC_HISTORY_OK" result.text
+;;
+
 let () =
   run "runtime codex app-server"
     [ ( "subscription boundary"
@@ -190,12 +324,22 @@ let () =
             test_notification_without_params_fails_closed
         ; test_case "server request fails closed" `Quick test_server_request_fails_closed
         ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
+        ; test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
+        ; test_case "history injects before turn" `Quick test_history_is_injected_before_turn
         ] )
     ; ( "live subscription"
       , [ test_case
             "official Codex app-server"
             `Slow
             test_live_chatgpt_subscription
+        ; test_case
+            "official Codex dynamic tool"
+            `Slow
+            test_live_dynamic_tool_subscription
+        ; test_case
+            "official Codex history injection"
+            `Slow
+            test_live_history_injection_subscription
         ] )
     ]
 ;;

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -112,6 +112,17 @@ let test_malformed_json_fails_closed () =
       | Ok _ -> fail "malformed JSON incorrectly admitted")
 ;;
 
+let test_notification_without_params_fails_closed () =
+  let missing_params = {|{"method":"item/completed"}|} in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; missing_params ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "notification without params incorrectly admitted")
+;;
+
 let test_server_request_fails_closed () =
   let request =
     {|{"id":"approval-1","method":"item/commandExecution/requestApproval","params":{}}|}
@@ -173,6 +184,10 @@ let () =
       , [ test_case "ChatGPT turn completes" `Quick test_chatgpt_subscription_turn
         ; test_case "API key is rejected" `Quick test_api_key_account_is_rejected
         ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
+        ; test_case
+            "notification without params fails closed"
+            `Quick
+            test_notification_without_params_fails_closed
         ; test_case "server request fails closed" `Quick test_server_request_fails_closed
         ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
         ] )

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -1,4 +1,5 @@
 open Alcotest
+open Masc
 
 let init_result =
   {|{"id":1,"result":{"userAgent":"fixture/0.147.0","codexHome":"/tmp/codex","platformFamily":"unix","platformOs":"linux"}}|}
@@ -181,6 +182,34 @@ let test_malformed_json_fails_closed () =
       | Ok _ -> fail "malformed JSON incorrectly admitted")
 ;;
 
+let test_duplicate_object_keys_fail_closed () =
+  let assert_protocol_error label lines =
+    with_fixture lines (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+      | Error error -> fail (label ^ ": " ^ Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail (label ^ ": duplicate key incorrectly admitted"))
+  in
+  assert_protocol_error
+    "top-level"
+    [ {|{"id":1,"id":1,"result":{"userAgent":"fixture/0.147.0","codexHome":"/tmp/codex","platformFamily":"unix","platformOs":"linux"}}|}
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; item_completed
+    ; turn_completed
+    ];
+  assert_protocol_error
+    "nested"
+    [ init_result
+    ; {|{"id":2,"result":{"account":{"type":"chatgpt","type":"apiKey","email":"fixture@example.test","planType":"pro"},"requiresOpenaiAuth":true}}|}
+    ; thread_result
+    ; turn_result
+    ; item_completed
+    ; turn_completed
+    ]
+;;
+
 let test_notification_without_params_fails_closed () =
   let missing_params = {|{"method":"item/completed"}|} in
   with_fixture
@@ -221,6 +250,408 @@ let test_failed_turn_is_not_completion () =
       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
       | Ok _ -> fail "failed turn incorrectly reported as completed")
 ;;
+
+let test_retry_notifications_are_bounded () =
+  let retry = {|{"method":"error","params":{"willRetry":true}}|} in
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; retry
+    ; retry
+    ; retry
+    ; retry
+    ]
+    (fun path ->
+       match run_fixture path with
+       | Error
+           (Runtime_codex_app_server.Turn_failed
+             "app-server retry notification limit exceeded") -> ()
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok _ -> fail "retry notifications were unbounded")
+;;
+
+let test_unknown_notifications_are_bounded () =
+  let unknown = {|{"method":"fixture/unknown","params":{}}|} in
+  let lines =
+    [ init_result; account_chatgpt; thread_result; turn_result ]
+    @ List.init 129 (fun _ -> unknown)
+  in
+  with_fixture lines (fun path ->
+    match run_fixture path with
+    | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+    | Ok _ -> fail "unknown notifications were unbounded")
+;;
+
+let codex_runtime_toml ~model cli_path =
+  Printf.sprintf
+    "[providers.codex]\n\
+     protocol = \"codex-app-server\"\n\
+     command = %S\n\
+     is-non-interactive = true\n\
+     \n\
+     [models.codex]\n\
+     api-name = %S\n\
+     max-context = 400000\n\
+     \n\
+     [codex.codex]\n\
+     \n\
+     [runtime]\n\
+     default = \"codex.codex\"\n"
+    cli_path
+    model
+;;
+
+let with_runtime_config ~model cli_path f =
+  let path = Filename.temp_file "masc-codex-runtime-" ".toml" in
+  let output = open_out_bin path in
+  output_string output (codex_runtime_toml ~model cli_path);
+  close_out output;
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let keeper_response_text (result : Runtime_agent.run_result) =
+  result.response.content
+  |> List.filter_map (function Agent_sdk.Types.Text text -> Some text | _ -> None)
+  |> String.concat ""
+;;
+
+let temp_workspace prefix =
+  let path = Filename.temp_file prefix "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let cleanup_tree root =
+  let rec remove path =
+    if Sys.file_exists path
+    then if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try remove root with
+  | _ -> ()
+;;
+
+let production_keeper_meta ~base_path =
+  let name = "codex-production-fixture" in
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [ "name", `String name
+         ; "agent_name", `String (Keeper_identity.keeper_agent_name name)
+         ; "trace_id", `String "codex-production-fixture-trace"
+         ; "allowed_paths", `List [ `String base_path ]
+         ])
+  with
+  | Ok meta -> meta
+  | Error detail -> fail ("production Keeper meta fixture failed: " ^ detail)
+;;
+
+let run_production_keeper_turn ~cli_path ~model =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       with_runtime_config ~model cli_path (fun runtime_path ->
+         let base_path = temp_workspace "masc-codex-production-" in
+         Fun.protect
+           ~finally:(fun () -> cleanup_tree base_path)
+           (fun () ->
+              Eio_main.run (fun env ->
+                Eio.Switch.run (fun sw ->
+                  Fs_compat.set_fs (Eio.Stdenv.fs env);
+                  Eio_context.set_env env;
+                  Eio_context.with_test_env
+                    ~net:(Eio.Stdenv.net env)
+                    ~clock:(Eio.Stdenv.clock env)
+                    ~mono_clock:(Eio.Stdenv.mono_clock env)
+                    ~sw
+                    (fun () ->
+                       match Runtime.init_default ~config_path:runtime_path with
+                       | Error error -> fail error
+                       | Ok () ->
+                         let config = Workspace.default_config base_path in
+                         let meta = production_keeper_meta ~base_path in
+                         ignore
+                           (Keeper_registry.For_testing.register
+                              ~base_path
+                              meta.name
+                              meta);
+                         Eio.Switch.on_release sw (fun () ->
+                           Keeper_registry.For_testing.unregister
+                             ~base_path
+                             meta.name);
+                         Masc_test_deps.with_publication_recovery_registry
+                           ~sw
+                           ~fs:(Eio.Stdenv.fs env)
+                           ~registry_root:base_path
+                           (fun publication_recovery_registry ->
+                              let publication_recovery =
+                                { Keeper_publication_recovery_availability.provider =
+                                    Masc_test_deps.publication_recovery_provider
+                                      publication_recovery_registry
+                                ; keeper_name = meta.name
+                                }
+                              in
+                              Keeper_agent_run.run_turn
+                                ~config
+                                ~meta
+                                ~publication_recovery
+                                ~profile_defaults:
+                                  Keeper_types_profile_defaults.empty_keeper_profile_defaults
+                                ~turn_ctx_cell:
+                                  (Keeper_tool_call_log.create_turn_ctx_cell ())
+                                ~base_dir:(Filename.concat base_path "keeper-sessions")
+                                ~max_context:400_000
+                                ~build_turn_prompt:
+                                  (fun ~base_system_prompt ~messages:_ ->
+                                    { Keeper_agent_run.system_prompt = base_system_prompt
+                                    ; dynamic_context = ""
+                                    })
+                                ~user_message:
+                                  "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools."
+                                ~turn_kind:Turn_record.Direct
+                                ~runtime_id:"codex.codex"
+                                ~generation:1
+                                ())))))))
+;;
+
+let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projection
+    ?(goal = "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.")
+    ~cli_path ~model () =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       with_runtime_config ~model cli_path (fun runtime_path ->
+         Eio_main.run (fun env ->
+           Eio.Switch.run (fun sw ->
+             Eio_context.set_env env;
+             Eio_context.with_test_env
+               ~net:(Eio.Stdenv.net env)
+               ~clock:(Eio.Stdenv.clock env)
+               ~mono_clock:(Eio.Stdenv.mono_clock env)
+               ~sw
+               (fun () ->
+                  match Runtime.init_default ~config_path:runtime_path with
+                  | Error error -> fail error
+                  | Ok () ->
+                    let context =
+                      match tools with
+                      | [] -> None
+                      | _ :: _ -> Some (Agent_sdk.Context.create ())
+                    in
+                    Keeper_turn_driver.run_named
+                      ~runtime_id:"codex.codex"
+                      ~keeper_name:"codex-fixture"
+                      ~base_path:"/tmp"
+                      ~goal
+                      ~tools
+                      ~initial_messages:[]
+                      ?model_input_projection
+                      ?hooks
+                      ?context_injector
+                      ?context
+                      ~sw
+                      ~net:(Eio.Stdenv.net env)
+                      ())))))
+;;
+
+let test_keeper_dispatches_codex_turn_runtime () =
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; item_completed; turn_completed ]
+    (fun cli_path ->
+       match run_keeper_turn ~cli_path ~model:"gpt-fixture" () with
+       | Error error -> fail (Agent_sdk.Error.to_string error)
+       | Ok result ->
+         check string "Keeper response" "MASC_SUBSCRIPTION_OK" (keeper_response_text result);
+         check bool "measured observation" true (Option.is_some result.runtime_observation))
+;;
+
+let assert_production_keeper_result result =
+  check string
+    "production Keeper response"
+    "MASC_SUBSCRIPTION_OK"
+    result.Keeper_agent_run.response_text;
+  check int "production Keeper turn count" 1 result.turn_count;
+  check int "production after-turn ordinal" 1 result.final_oas_turn_ordinal;
+  check bool "production measured observation" true
+    (Option.is_some result.runtime_observation);
+  check bool "official client does not fabricate OAS checkpoint" true
+    (Option.is_none result.checkpoint)
+;;
+
+let test_production_keeper_dispatches_codex_runtime () =
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun cli_path ->
+       match run_production_keeper_turn ~cli_path ~model:"gpt-fixture" with
+       | Error error -> fail (Agent_sdk.Error.to_string error)
+       | Ok result -> assert_production_keeper_result result)
+;;
+
+let test_keeper_projects_typed_tools_and_hooks () =
+  let tool_calls = ref 0 in
+  let before_turn_calls = ref 0 in
+  let before_params_calls = ref 0 in
+  let pre_tool_calls = ref 0 in
+  let post_tool_calls = ref 0 in
+  let after_turn_calls = ref 0 in
+  let on_stop_calls = ref 0 in
+  let projection_saw_context = ref false in
+  let injector_calls = ref 0 in
+  let tool =
+    Agent_sdk.Tool.create
+      ~name:"masc_probe"
+      ~description:"Return a deterministic Keeper fixture marker"
+      ~parameters:
+        [ { Agent_sdk.Types.name = "marker"
+          ; description = "Fixture marker"
+          ; param_type = String
+          ; required = true
+          }
+        ]
+      (fun input ->
+        incr tool_calls;
+        check string
+          "typed tool input"
+          "from-codex"
+          Yojson.Safe.Util.(input |> member "marker" |> to_string);
+        Ok { Agent_sdk.Types.content = "MASC_TOOL_RESULT"; _meta = None })
+  in
+  let hooks : Agent_sdk.Hooks.hooks =
+    { Agent_sdk.Hooks.empty with
+      before_turn =
+        Some
+          (fun _ ->
+            incr before_turn_calls;
+            Continue)
+    ; before_turn_params =
+        Some
+          (function
+            | BeforeTurnParams { current_params; _ } ->
+              incr before_params_calls;
+              AdjustParams
+                { current_params with extra_system_context = Some "fixture-context" }
+            | _ -> Continue)
+    ; pre_tool_use =
+        Some
+          (fun _ ->
+            incr pre_tool_calls;
+            Continue)
+    ; post_tool_use =
+        Some
+          (fun _ ->
+            incr post_tool_calls;
+            Continue)
+    ; after_turn =
+        Some
+          (fun _ ->
+            incr after_turn_calls;
+            Continue)
+    ; on_stop =
+        Some
+          (fun _ ->
+            incr on_stop_calls;
+            Continue)
+    }
+  in
+  let model_input_projection messages =
+    projection_saw_context :=
+      List.exists
+        (fun (message : Agent_sdk.Types.message) ->
+          message.role = System
+          && String.equal
+               "fixture-context"
+               (Agent_sdk.Types.text_of_content message.content))
+        messages;
+    Ok messages
+  in
+  let context_injector ~tool_name:_ ~input:_ ~output:_ =
+    incr injector_calls;
+    Some
+      { Agent_sdk.Hooks.context_updates = [ "fixture_tool_seen", `Bool true ]
+      ; extra_messages = []
+      }
+  in
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; tool_call_request
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun cli_path ->
+       match
+         run_keeper_turn
+           ~tools:[ tool ]
+           ~hooks
+           ~context_injector
+           ~model_input_projection
+           ~cli_path
+           ~model:"gpt-fixture"
+           ()
+       with
+       | Error error -> fail (Agent_sdk.Error.to_string error)
+       | Ok result ->
+         check string "Keeper response" "MASC_SUBSCRIPTION_OK" (keeper_response_text result);
+         List.iter
+           (fun (label, expected, actual) -> check int label expected !actual)
+           [ "tool handler", 1, tool_calls
+           ; "before turn hook", 1, before_turn_calls
+           ; "before params hook", 1, before_params_calls
+           ; "pre tool hook", 1, pre_tool_calls
+           ; "post tool hook", 1, post_tool_calls
+           ; "after turn hook", 1, after_turn_calls
+           ; "on stop hook", 1, on_stop_calls
+           ; "context injector", 1, injector_calls
+           ];
+         check bool "projection saw hook context" true !projection_saw_context)
+;;
+
+let test_keeper_rejects_unprojected_turn_parameters () =
+  let hooks : Agent_sdk.Hooks.hooks =
+    { Agent_sdk.Hooks.empty with
+      before_turn_params =
+        Some
+          (function
+            | BeforeTurnParams { current_params; _ } ->
+              AdjustParams { current_params with temperature = Some 0.2 }
+            | _ -> Continue)
+    }
+  in
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun cli_path ->
+       match run_keeper_turn ~hooks ~cli_path ~model:"gpt-fixture" () with
+       | Error
+           (Agent_sdk.Error.Config
+             (Agent_sdk.Error.InvalidConfig { field; detail = _ })) ->
+         check string "rejected parameter" "temperature" field
+       | Error error -> fail (Agent_sdk.Error.to_string error)
+       | Ok _ -> fail "unprojected temperature was silently ignored")
+;;
+
 
 let test_live_chatgpt_subscription () =
   if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
@@ -312,6 +743,54 @@ let test_live_history_injection_subscription () =
     | Ok result -> check string "live history response" "MASC_HISTORY_OK" result.text
 ;;
 
+let test_live_keeper_chatgpt_subscription () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    match run_keeper_turn ~cli_path:"codex" ~model:"gpt-5.6-sol" () with
+    | Error error -> fail (Agent_sdk.Error.to_string error)
+    | Ok result ->
+      check string "live Keeper response" "MASC_SUBSCRIPTION_OK" (keeper_response_text result)
+;;
+
+let test_live_keeper_dynamic_tool_subscription () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let tool_calls = ref 0 in
+    let tool =
+      Agent_sdk.Tool.create
+        ~name:"masc_probe"
+        ~description:"Return the exact marker MASC_TOOL_RESULT"
+        ~parameters:[]
+        (fun _ ->
+          incr tool_calls;
+          Ok { Agent_sdk.Types.content = "MASC_TOOL_RESULT"; _meta = None })
+    in
+    match
+      run_keeper_turn
+        ~tools:[ tool ]
+        ~goal:
+          "Call the dynamic tool masc_probe exactly once. After it returns, reply with exactly MASC_TOOL_OK and no other text."
+        ~cli_path:"codex"
+        ~model:"gpt-5.6-sol"
+        ()
+    with
+    | Error error -> fail (Agent_sdk.Error.to_string error)
+    | Ok result ->
+      check int "live typed tool calls" 1 !tool_calls;
+      check string "live tool Keeper response" "MASC_TOOL_OK" (keeper_response_text result)
+;;
+
+let test_live_production_keeper_subscription () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    match run_production_keeper_turn ~cli_path:"codex" ~model:"gpt-5.6-sol" with
+    | Error error -> fail (Agent_sdk.Error.to_string error)
+    | Ok result -> assert_production_keeper_result result
+;;
+
 let () =
   run "runtime codex app-server"
     [ ( "subscription boundary"
@@ -319,13 +798,41 @@ let () =
         ; test_case "API key is rejected" `Quick test_api_key_account_is_rejected
         ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
         ; test_case
+            "duplicate object keys fail closed"
+            `Quick
+            test_duplicate_object_keys_fail_closed
+        ; test_case
             "notification without params fails closed"
             `Quick
             test_notification_without_params_fails_closed
         ; test_case "server request fails closed" `Quick test_server_request_fails_closed
         ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
+        ; test_case
+            "retry notifications are bounded"
+            `Quick
+            test_retry_notifications_are_bounded
+        ; test_case
+            "unknown notifications are bounded"
+            `Quick
+            test_unknown_notifications_are_bounded
         ; test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
         ; test_case "history injects before turn" `Quick test_history_is_injected_before_turn
+        ; test_case
+            "Keeper dispatches Codex runtime"
+            `Quick
+            test_keeper_dispatches_codex_turn_runtime
+        ; test_case
+            "production Keeper dispatches Codex runtime"
+            `Quick
+            test_production_keeper_dispatches_codex_runtime
+        ; test_case
+            "Keeper projects typed tools and hooks"
+            `Quick
+            test_keeper_projects_typed_tools_and_hooks
+        ; test_case
+            "Keeper rejects unprojected turn parameters"
+            `Quick
+            test_keeper_rejects_unprojected_turn_parameters
         ] )
     ; ( "live subscription"
       , [ test_case
@@ -340,6 +847,18 @@ let () =
             "official Codex history injection"
             `Slow
             test_live_history_injection_subscription
+        ; test_case
+            "Keeper through official Codex app-server"
+            `Slow
+            test_live_keeper_chatgpt_subscription
+        ; test_case
+            "Keeper typed tool through official Codex app-server"
+            `Slow
+            test_live_keeper_dynamic_tool_subscription
+        ; test_case
+            "production Keeper through official Codex app-server"
+            `Slow
+            test_live_production_keeper_subscription
         ] )
     ]
 ;;

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -1,0 +1,186 @@
+open Alcotest
+
+let init_result =
+  {|{"id":1,"result":{"userAgent":"fixture/0.147.0","codexHome":"/tmp/codex","platformFamily":"unix","platformOs":"linux"}}|}
+;;
+
+let account_chatgpt =
+  {|{"id":2,"result":{"account":{"type":"chatgpt","email":"fixture@example.test","planType":"pro"},"requiresOpenaiAuth":true}}|}
+;;
+
+let thread_result =
+  {|{"id":3,"result":{"thread":{"id":"thread-1"},"model":"gpt-fixture"}}|}
+;;
+
+let turn_result = {|{"id":4,"result":{"turn":{"id":"turn-1"}}}|}
+
+let item_completed =
+  {|{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-1","completedAtMs":1,"item":{"type":"agentMessage","id":"message-1","text":"MASC_SUBSCRIPTION_OK","phase":"final_answer"}}}|}
+;;
+
+let turn_completed =
+  {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[{"type":"agentMessage","id":"message-1","text":"MASC_SUBSCRIPTION_OK","phase":"final_answer"}],"status":"completed"}}}|}
+;;
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let rec drop count values =
+  if count <= 0
+  then values
+  else
+    match values with
+    | [] -> []
+    | _ :: rest -> drop (count - 1) rest
+;;
+
+let fixture_script lines =
+  let path = Filename.temp_file "masc-codex-app-server-" ".sh" in
+  let output = open_out_bin path in
+  output_string output "#!/bin/sh\n";
+  output_string output "IFS= read -r ignored\n";
+  output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 0) ^ "\n");
+  output_string output "IFS= read -r ignored\n";
+  output_string output "IFS= read -r ignored\n";
+  output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 1) ^ "\n");
+  output_string output "IFS= read -r ignored\n";
+  output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 2) ^ "\n");
+  output_string output "IFS= read -r ignored\n";
+  List.iter
+    (fun line -> output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
+    (drop 3 lines);
+  close_out output;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let with_fixture lines f =
+  let path = fixture_script lines in
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let run_fixture path =
+  Eio_main.run (fun env ->
+    let config =
+      { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+        cli_path = path
+      ; timeout_s = 2.0
+      }
+    in
+    Runtime_codex_app_server.run_turn
+      ~mgr:(Eio.Stdenv.process_mgr env)
+      ~clock:(Eio.Stdenv.clock env)
+      config
+      ~prompt:"Return the fixture marker")
+;;
+
+let test_chatgpt_subscription_turn () =
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; item_completed; turn_completed ]
+    (fun path ->
+      match run_fixture path with
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok result ->
+        check string "text" "MASC_SUBSCRIPTION_OK" result.text;
+        check string "thread" "thread-1" result.thread_id;
+        check string "turn" "turn-1" result.turn_id;
+        check string "model" "gpt-fixture" result.model;
+        check string "plan" "pro" result.subscription.plan_type)
+;;
+
+let test_api_key_account_is_rejected () =
+  let api_key_account =
+    {|{"id":2,"result":{"account":{"type":"apiKey"},"requiresOpenaiAuth":true}}|}
+  in
+  with_fixture
+    [ init_result; api_key_account; thread_result; turn_result; item_completed; turn_completed ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Subscription_required _) -> ()
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "API-key account incorrectly admitted as subscription")
+;;
+
+let test_malformed_json_fails_closed () =
+  with_fixture
+    [ "not-json"; account_chatgpt; thread_result; turn_result; item_completed; turn_completed ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "malformed JSON incorrectly admitted")
+;;
+
+let test_server_request_fails_closed () =
+  let request =
+    {|{"id":"approval-1","method":"item/commandExecution/requestApproval","params":{}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; request ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Unsupported_server_request method_) ->
+        check string
+          "method"
+          "item/commandExecution/requestApproval"
+          method_
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "unsupported server request incorrectly admitted")
+;;
+
+let test_failed_turn_is_not_completion () =
+  let failed =
+    {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"fixture failure"}}}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; failed ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Turn_failed "fixture failure") -> ()
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "failed turn incorrectly reported as completed")
+;;
+
+let test_live_chatgpt_subscription () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let result =
+      Eio_main.run (fun env ->
+        let config =
+          { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+            timeout_s = 60.0
+          }
+        in
+        Runtime_codex_app_server.run_turn
+          ~mgr:(Eio.Stdenv.process_mgr env)
+          ~clock:(Eio.Stdenv.clock env)
+          config
+          ~prompt:"Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.")
+    in
+    match result with
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+    | Ok result ->
+      check string "live response" "MASC_SUBSCRIPTION_OK" result.text;
+      check bool "subscription plan is present" true
+        (String.trim result.subscription.plan_type <> "")
+;;
+
+let () =
+  run "runtime codex app-server"
+    [ ( "subscription boundary"
+      , [ test_case "ChatGPT turn completes" `Quick test_chatgpt_subscription_turn
+        ; test_case "API key is rejected" `Quick test_api_key_account_is_rejected
+        ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
+        ; test_case "server request fails closed" `Quick test_server_request_fails_closed
+        ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
+        ] )
+    ; ( "live subscription"
+      , [ test_case
+            "official Codex app-server"
+            `Slow
+            test_live_chatgpt_subscription
+        ] )
+    ]
+;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -10,6 +10,13 @@ let parse_or_fail content =
   | Ok doc -> doc
   | Error msg -> failf "TOML parse failed: %s" msg
 
+let agent_core_provider_config (runtime : Runtime.t) =
+  match runtime.execution with
+  | Runtime_execution.Agent_core provider_config -> provider_config
+  | Runtime_execution.Codex_app_server _ ->
+    failf "runtime %s is not an agent_core provider" runtime.id
+;;
+
 let rec repo_root_from dir =
   let dune_project = Filename.concat dir "dune-project" in
   if Sys.file_exists dune_project then dir
@@ -309,7 +316,7 @@ let assert_ollama_cloud_seed_runtime runtimes case =
     check bool (case.runtime_id ^ " known to provider-qualified OAS catalog") true
       (Option.is_some
          (Llm_provider.Provider_config.capabilities_for_config_model
-            runtime.provider_config));
+            (agent_core_provider_config runtime)));
     (match runtime.model.capabilities with
      | None -> failf "expected capabilities for %s" case.runtime_id
      | Some caps ->
@@ -657,7 +664,7 @@ let test_repo_runtime_bindings_resolve_through_oas_provider_config () =
       (fun (runtime : Runtime.t) ->
          match
            Llm_provider.Provider_config.capabilities_for_config_model
-             runtime.provider_config
+             (agent_core_provider_config runtime)
          with
          | None ->
            failf
@@ -665,8 +672,8 @@ let test_repo_runtime_bindings_resolve_through_oas_provider_config () =
               OAS Provider_config"
              runtime.id
              (Llm_provider.Provider_config.capability_provider_label
-                runtime.provider_config)
-             runtime.provider_config.model_id
+                (agent_core_provider_config runtime))
+             (agent_core_provider_config runtime).model_id
          | Some _ ->
            if String.equal runtime.id "ollama_cloud.ollama-cloud-rnj-1-8b"
            then
@@ -674,7 +681,8 @@ let test_repo_runtime_bindings_resolve_through_oas_provider_config () =
                bool
                "runtime-local alias uses the typed Provider_config override"
                true
-               (Option.is_some runtime.provider_config.model_capabilities_override))
+               (Option.is_some
+                  (agent_core_provider_config runtime).model_capabilities_override))
       runtimes
 
 let test_deployment_oas_model_catalog_modality_priorities_resolve () =
@@ -839,7 +847,7 @@ List.iter
   config.exact_output_lane_decls);
     check (option (float 0.0)) "Ollama Cloud connect timeout override"
       (Some 600.0)
-      default.provider_config.connect_timeout_s;
+      (agent_core_provider_config default).connect_timeout_s;
     check int "public seed has no keeper assignments" 0
       (List.length assignments);
     let keeper_dispatch_ids =
@@ -859,7 +867,7 @@ List.iter
          with
          | None -> failf "expected bounded Keeper runtime in seed: %s" runtime_id
          | Some runtime ->
-           (match runtime.provider_config.max_request_body_bytes with
+           (match (agent_core_provider_config runtime).max_request_body_bytes with
             | Some cap when cap > 0 -> ()
             | None | Some _ ->
               failf
@@ -910,7 +918,7 @@ List.iter
      | Some runtime ->
        check (option (float 0.0)) "DeepSeek keeps OAS connect timeout default"
          None
-         runtime.provider_config.connect_timeout_s;
+         (agent_core_provider_config runtime).connect_timeout_s;
        (match runtime.model.capabilities with
         | Some caps ->
           check bool "DeepSeek Pro structured output disabled" false
@@ -964,7 +972,7 @@ List.iter
          runtime.model.api_name;
        check (option (float 0.0)) "native MiniMax M3 connect timeout"
          (Some 600.0)
-         runtime.provider_config.connect_timeout_s;
+         (agent_core_provider_config runtime).connect_timeout_s;
        (match runtime.model.capabilities with
        | Some caps ->
          check bool "native MiniMax M3 response_format json" true
@@ -2522,9 +2530,9 @@ let test_runtime_toml_max_concurrent_flows_to_provider_config () =
             (option int)
             (Printf.sprintf "%s provider_config max_concurrent_requests" id)
             expected
-            rt.Runtime.provider_config.max_concurrent_requests;
+            (agent_core_provider_config rt).max_concurrent_requests;
           let selected_provider_config =
-            Runtime_candidate.of_provider_config rt.Runtime.provider_config
+            Runtime_candidate.of_provider_config (agent_core_provider_config rt)
             |> Runtime_candidate.provider_cfg
           in
           check
@@ -3150,11 +3158,67 @@ let test_runtime_assignment_default_rider_resolves_to_default_runtime () =
              "local.good"
              (Runtime.get_default_runtime_id ())))
 
+let codex_app_server_runtime_toml ?credential () =
+  let credential = Option.value credential ~default:"" in
+  Printf.sprintf
+    "[providers.codex]\n\
+     protocol = \"codex-app-server\"\n\
+     command = \"codex\"\n\
+     is-non-interactive = true\n\
+     %s\n\
+     [models.codex]\n\
+     api-name = \"gpt-5.6-sol\"\n\
+     max-context = 400000\n\
+     \n\
+     [codex.codex]\n\
+     \n\
+     [runtime]\n\
+     default = \"codex.codex\"\n"
+    credential
+;;
+
+let test_codex_app_server_materializes_as_turn_runtime () =
+  with_temp_runtime_toml (codex_app_server_runtime_toml ()) (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error error -> failf "codex-app-server runtime should load: %s" error
+    | Ok (runtimes, default, _, _, _, _) ->
+      check int "one runtime" 1 (List.length runtimes);
+      check string "default id" "codex.codex" default.id;
+      (match default.execution with
+       | Runtime_execution.Agent_core _ ->
+         fail "codex-app-server was incorrectly materialized as agent_core"
+       | Runtime_execution.Codex_app_server config ->
+         check string "cli path" "codex" config.cli_path;
+         check (option string) "model" (Some "gpt-5.6-sol") config.model))
+;;
+
+let test_codex_app_server_rejects_declared_credentials () =
+  let credential =
+    "[providers.codex.credentials]\n\
+     type = \"env\"\n\
+     key = \"OPENAI_API_KEY\""
+  in
+  with_temp_runtime_toml
+    (codex_app_server_runtime_toml ~credential ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> fail "codex-app-server incorrectly admitted declared credentials"
+       | Error error ->
+         check bool "diagnostic names official subscription ownership" true
+           (String_util.contains_substring
+              error
+              "official Codex client owns subscription login"))
+;;
+
 let () =
   run "runtime_config_validity"
     [ ( "runtime TOML gate",
         [ test_case "runtime.json is not a repo config source" `Quick
             test_runtime_json_not_in_repo_config;
+          test_case "codex app-server is a distinct turn runtime" `Quick
+            test_codex_app_server_materializes_as_turn_runtime;
+          test_case "codex app-server rejects declared credentials" `Quick
+            test_codex_app_server_rejects_declared_credentials;
           test_case "deployment OAS catalog covers live RunPod MTP runtime" `Quick
             test_deployment_oas_model_catalog_covers_live_runpod_mtp;
           test_case

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -345,6 +345,36 @@ let with_runtime_initialized f =
   with_runtime_file (fun _path -> f ())
 ;;
 
+let codex_runtime_config =
+  {|[providers.codex]
+protocol = "codex-app-server"
+command = "codex"
+is-non-interactive = true
+
+[models.codex]
+api-name = "gpt-5.6-sol"
+max-context = 400000
+
+[codex.codex]
+
+[runtime]
+default = "codex.codex"
+|}
+;;
+
+let with_codex_runtime_initialized f =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       with_temp_dir "runtime-codex-dashboard" @@ fun dir ->
+       let path = Filename.concat dir "runtime.toml" in
+       write_file path codex_runtime_config;
+       match Runtime.init_default ~config_path:path with
+       | Error msg -> Alcotest.failf "Codex runtime init failed: %s" msg
+       | Ok () -> f ())
+;;
+
 let test_messages_http_runtime_loads_and_assignment_resolves () =
   let snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
@@ -490,6 +520,47 @@ let test_runtime_inventory_surfaces_assignment_status () =
       (match gpt |> J.member "temperature" with
        | `Null -> true
        | _ -> false))
+;;
+
+let test_codex_runtime_inventory_is_unverified_until_measured () =
+  with_codex_runtime_initialized (fun () ->
+    let entry =
+      Server_dashboard_http_runtime_info.runtime_inventory_json ()
+      |> J.member "providers"
+      |> J.to_list
+      |> List.find (fun entry ->
+        String.equal
+          "codex.codex"
+          (entry |> J.member "runtime_id" |> J.to_string))
+    in
+    Alcotest.(check string)
+      "status"
+      "configured_unverified"
+      (entry |> J.member "status" |> J.to_string);
+    Alcotest.(check bool)
+      "not available without runtime evidence"
+      false
+      (entry |> J.member "available" |> J.to_bool);
+    let verification = entry |> J.member "verification" in
+    Alcotest.(check bool)
+      "not measured"
+      false
+      (verification |> J.member "measured" |> J.to_bool);
+    Alcotest.(check string)
+      "reason"
+      "no_successful_runtime_observation"
+      (verification |> J.member "reason" |> J.to_string))
+;;
+
+let test_codex_runtime_cannot_enter_oas_runner () =
+  with_codex_runtime_initialized (fun () ->
+    match Runtime_oas_runner.resolve_runtime_providers ~runtime_id:"codex.codex" () with
+    | Ok _ -> Alcotest.fail "Codex official-client runtime entered the OAS runner"
+    | Error detail ->
+      Alcotest.(check bool)
+        "typed ownership diagnostic"
+        true
+        (string_contains detail "not the OAS agent_core"))
 ;;
 
 let test_runtime_inventory_surfaces_declared_model_capabilities () =
@@ -826,7 +897,10 @@ let test_get_runtime_by_id_resolves_and_fails_fast () =
 
 let provider_base_url_of_runtime_id runtime_id =
   match Runtime.get_runtime_by_id runtime_id with
-  | Some rt -> rt.Runtime.provider_config.Llm_provider.Provider_config.base_url
+  | Some { Runtime.execution = Runtime_execution.Agent_core provider_config; _ } ->
+    provider_config.Llm_provider.Provider_config.base_url
+  | Some rt ->
+    Alcotest.failf "fixture runtime %s is not agent_core" rt.Runtime.id
   | None -> Alcotest.failf "fixture runtime %s missing from catalog" runtime_id
 ;;
 
@@ -1818,6 +1892,10 @@ let () =
             `Quick
             test_runtime_inventory_surfaces_assignment_status
         ; Alcotest.test_case
+            "dashboard Codex runtime stays unavailable until measured"
+            `Quick
+            test_codex_runtime_inventory_is_unverified_until_measured
+        ; Alcotest.test_case
             "dashboard runtime inventory reports transport kind"
             `Quick
             test_runtime_inventory_reports_transport_kind
@@ -1891,6 +1969,10 @@ let () =
             "of_meta projection prefers the routed runtime"
             `Quick
             test_of_meta_projection_budgets_against_routed_runtime
+        ; Alcotest.test_case
+            "Codex official-client runtime cannot enter OAS runner"
+            `Quick
+            test_codex_runtime_cannot_enter_oas_runner
         ] )
     ; ( "per-model thinking gate"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Why

The earlier foundation PRs were closed because an exported app-server client without a production caller was not a mergeable runtime feature. This reslice is the minimum vertical Codex runtime: typed runtime selection, official subscription admission, Keeper execution, typed tools/hooks, measured observation, and official-client checkpoint ownership.

## What

- run the official codex app-server with ChatGPT subscription credentials only
- reject API-key fallback, duplicate JSON object keys, unsupported host requests, ambiguous notifications, and unbounded retry/unknown notification streams
- project MASC typed tools and lifecycle hooks into Codex dynamic tools
- keep agent_core and official-client checkpoint ownership disjoint
- route a production Keeper turn through the typed Codex runtime
- expose dashboard capability state only as configured_unverified until a successful observation exists

## Evidence

- deterministic focused suite: 15/15 in 5.017s
- official ChatGPT subscription with OPENAI_API_KEY and CODEX_API_KEY removed: 21/21 in 50.039s
- includes direct app-server, dynamic tool, history injection, Keeper, typed tool, and production Keeper paths

## Deliberate exclusions

This proves one production turn only. Persisted thread resume, multi-turn ordinal ownership, account switching, usage/reset telemetry, dashboard editing, Claude Code, and Antigravity remain follow-up PRs. No continuity claim is made here.

Supersedes closed PRs #27672, #27685, and #27686.