### PR TITLE
refactor: make tool dispatch registration canonical

### DIFF
--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -64,12 +64,6 @@ let to_tool_schema (spec : t) : Masc_domain.tool_schema =
     input_schema = spec.input_schema }
 
 (* ================================================================ *)
-(* Registration tracking                                            *)
-(* ================================================================ *)
-
-let registered_names : (string, unit) Hashtbl.t = Hashtbl.create 256
-
-(* ================================================================ *)
 (* Registration                                                     *)
 (* ================================================================ *)
 
@@ -103,8 +97,6 @@ let register (spec : t) =
   (* 2. Tag + schema registry. An unclassified tool cannot reach this point. *)
   Tool_dispatch.register_module_tag
     ~schemas:[ to_tool_schema spec ] ~tag:spec.module_tag;
-  (* Track only successfully classified and registered specs. *)
-  Hashtbl.replace registered_names spec.name ();
   (* 3. Handler binding — auto-register Direct/Shared into Tool_dispatch *)
   (match spec.handler_binding with
    | Direct h | Shared h ->
@@ -113,6 +105,3 @@ let register (spec : t) =
 
 let register_all (specs : t list) =
   List.iter register specs
-
-let all_registered_names () =
-  Hashtbl.fold (fun name () acc -> name :: acc) registered_names []

--- a/lib/tool_surface/tool_spec.mli
+++ b/lib/tool_surface/tool_spec.mli
@@ -88,5 +88,3 @@ val register_all : t list -> unit
 
 val to_tool_schema : t -> Masc_domain.tool_schema
 (** Convert to [Masc_domain.tool_schema] for interop with existing schema-based APIs. *)
-
-val all_registered_names : unit -> string list

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -120,7 +120,7 @@ let test_workspace_schemas_have_tool_spec_metadata () =
   let workspace_names = workspace_schema_names () in
   let missing_tool_specs =
     List.filter
-      (fun name -> not (List.mem name (Tool_spec.all_registered_names ())))
+      (fun name -> not (List.mem name (Tool_dispatch.all_registered_names ())))
       workspace_names
   in
   Alcotest.(check (list string))


### PR DESCRIPTION
## Summary

- remove the Tool_spec-local registered-name mirror
- use Tool_dispatch as the sole runtime registration inventory
- keep Tool_spec as a declaration/registration adapter without parallel authority

## Why

Tool_spec.register already commits tag and schema registration to Tool_dispatch, but also copied each name into a second private hash table. The consistency test then treated that mirror as an independent source of truth. This hard cut removes the redundant registry instead of synchronizing it.

## Validation

Not run locally. Exact-head CI is authoritative.
