### PR TITLE
refactor: hard-cut public MCP surface facade

### DIFF
--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -466,9 +466,6 @@ end
 (* Public MCP surface — delegates to Tool_catalog_surfaces (SSOT)   *)
 (* ================================================================ *)
 
-(* Delegate to surfaces sub-module *)
-let public_mcp_tools = Tool_catalog_surfaces.public_mcp_surface_tools
-
 let public_mcp_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create 64 in
   List.iter (fun name -> Hashtbl.replace tbl name ())

--- a/lib/tool/tool_catalog.mli
+++ b/lib/tool/tool_catalog.mli
@@ -59,10 +59,6 @@ val hidden_active :
 
 (** {1 Public tool surface} *)
 
-val public_mcp_tools : string list
-(** Alias for [Tool_catalog_surfaces.public_mcp_surface_tools].
-    Prefer the surfaces module directly for new code. *)
-
 val is_public_mcp : string -> bool
 (** O(1) membership check against the public surface. *)
 

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -69,7 +69,9 @@ let summary_report ?(runtime_metrics = fun () -> `Null) () : Yojson.Safe.t =
   let total_count = List.length all_names in
   let visible_count = List.length allowed_names in
   let hidden_count = total_count - visible_count in
-  let public_count = List.length Tool_catalog.public_mcp_tools in
+  let public_count =
+    List.length Tool_catalog_surfaces.public_mcp_surface_tools
+  in
   let tool_dist =
     `Assoc [
       ("total", `Int total_count);

--- a/test/tool_matrix_manifest.ml
+++ b/test/tool_matrix_manifest.ml
@@ -13,7 +13,7 @@ let () =
     |> sorted_unique
   in
   let public_tool_names =
-    Tool_catalog.public_mcp_tools
+    Tool_catalog_surfaces.public_mcp_surface_tools
     |> sorted_unique
   in
   let contract_inventory =


### PR DESCRIPTION
## Summary

- remove the Tool_catalog.public_mcp_tools forwarding alias
- read public MCP membership directly from Tool_catalog_surfaces
- keep public surface policy in its canonical owner

## Why

Tool_catalog.public_mcp_tools was a facade over Tool_catalog_surfaces.public_mcp_surface_tools. Keeping both names made public-surface authority look duplicated and allowed future consumers to depend on the wrong module. This hard cut removes the facade rather than preserving compatibility.

## Validation

Not run locally. Exact-head CI is authoritative.
