### PR TITLE
refactor: type MCP runtime tool vocabulary

### DIFF
--- a/lib/mcp_tool_runtime.ml
+++ b/lib/mcp_tool_runtime.ml
@@ -41,19 +41,19 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.result option =
   let state = ctx.state in
   let arguments = ctx.arguments in
 
-  match name with
+  match Tool_schemas_misc.mcp_runtime_operation_of_tool_name name with
   (* ── Workspace lifecycle (delegated) ─────────────────────────────── *)
-  | "masc_start" ->
+  | Some Tool_schemas_misc.Start ->
       Mcp_tool_runtime_workspace.handle_start ~tool_name:name ~start_time:start ctx
 
   (* ── Communication (delegated) ──────────────────────────────── *)
-  | "masc_broadcast" ->
+  | Some Tool_schemas_misc.Broadcast ->
       Mcp_tool_runtime_comm.handle_broadcast ~tool_name:name ~start_time:start ctx
-  | "masc_messages" ->
+  | Some Tool_schemas_misc.Messages ->
       Mcp_tool_runtime_comm.handle_messages ~tool_name:name ~start_time:start ctx
 
   (* ── Fallthrough to extra dispatch ──────────────────────────── *)
-  | _ ->
+  | None ->
       Mcp_tool_runtime_board.dispatch ~config ~agent_name ~arguments ~state ~name ~start_time:start
 
 (* ================================================================ *)
@@ -69,29 +69,23 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.result option =
      them to Tool_spec.register requires authoring new input schemas
      and deciding visibility semantics for MCP exposure. *)
 
-let runtime_tool_specs =
-  [ "masc_start", false, true
-  ; "masc_broadcast", false, true
-  ; "masc_messages", true, true
-  ]
+let runtime_tool_policy = function
+  | Tool_schemas_misc.Start | Tool_schemas_misc.Broadcast -> false, true
+  | Tool_schemas_misc.Messages -> true, true
+;;
 
 let () =
-  runtime_tool_specs
-  |> List.iter (fun (name, is_read_only, mcp_context_required) ->
-    match
-      List.find_opt
-        (fun (s : Masc_domain.tool_schema) -> String.equal s.name name)
-        Tool_schemas_misc.mcp_runtime_schemas
-    with
-    | None -> invalid_arg ("missing MCP runtime schema: " ^ name)
-    | Some (schema : Masc_domain.tool_schema) ->
-      Tool_spec.register
-        (Tool_spec.create
-           ~name:schema.name
-           ~description:schema.description
-           ~module_tag:Tool_dispatch.Mod_inline
-           ~input_schema:schema.input_schema
-           ~handler_binding:Tag_dispatch
-           ~is_read_only
-           ~mcp_context_required
-           ()))
+  Tool_schemas_misc.mcp_runtime_operations
+  |> List.iter (fun operation ->
+    let schema = Tool_schemas_misc.mcp_runtime_schema operation in
+    let is_read_only, mcp_context_required = runtime_tool_policy operation in
+    Tool_spec.register
+      (Tool_spec.create
+         ~name:schema.name
+         ~description:schema.description
+         ~module_tag:Tool_dispatch.Mod_inline
+         ~input_schema:schema.input_schema
+         ~handler_binding:Tag_dispatch
+         ~is_read_only
+         ~mcp_context_required
+         ()))

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -32,14 +32,35 @@ let control_schemas = List.map control_schema control_operations
    knows they exist without duplicating their schema ownership. *)
 let schemas : tool_schema list = Tool_descriptors_gen.schemas
 
-let mcp_runtime_tool_names =
-  [ "masc_start"
-  ; "masc_broadcast"
-  ; "masc_messages"
-  ]
+type mcp_runtime_operation =
+  | Start
+  | Broadcast
+  | Messages
 
-let mcp_runtime_schemas =
-  List.filter
-    (fun (schema : tool_schema) ->
-       List.mem schema.name mcp_runtime_tool_names)
-    schemas
+let mcp_runtime_operations = [ Start; Broadcast; Messages ]
+
+let mcp_runtime_tool_name = function
+  | Start -> "masc_start"
+  | Broadcast -> "masc_broadcast"
+  | Messages -> "masc_messages"
+;;
+
+let mcp_runtime_operation_of_tool_name = function
+  | "masc_start" -> Some Start
+  | "masc_broadcast" -> Some Broadcast
+  | "masc_messages" -> Some Messages
+  | _ -> None
+;;
+
+let mcp_runtime_schema operation =
+  let name = mcp_runtime_tool_name operation in
+  match
+    List.find_opt
+      (fun (schema : tool_schema) -> String.equal schema.name name)
+      schemas
+  with
+  | Some schema -> schema
+  | None -> invalid_arg ("missing MCP runtime schema: " ^ name)
+;;
+
+let mcp_runtime_schemas = List.map mcp_runtime_schema mcp_runtime_operations

--- a/lib/tool_schemas/tool_schemas_misc.mli
+++ b/lib/tool_schemas/tool_schemas_misc.mli
@@ -53,8 +53,23 @@ val schemas : Masc_domain.tool_schema list
     [config_category_enum_strings] is the only [*_enum_strings] that module
     exports. *)
 
-val mcp_runtime_tool_names : string list
-(** Exact names dispatched by [Mcp_tool_runtime]. *)
+type mcp_runtime_operation =
+  | Start
+  | Broadcast
+  | Messages
+(** Closed vocabulary dispatched by [Mcp_tool_runtime]. *)
+
+val mcp_runtime_operations : mcp_runtime_operation list
+(** Exhaustive stable-order projection of MCP runtime operations. *)
+
+val mcp_runtime_tool_name : mcp_runtime_operation -> string
+(** Canonical wire name for an MCP runtime operation. *)
+
+val mcp_runtime_operation_of_tool_name : string -> mcp_runtime_operation option
+(** Parse a canonical MCP runtime wire name at the dispatch boundary. *)
+
+val mcp_runtime_schema : mcp_runtime_operation -> Masc_domain.tool_schema
+(** Canonical generated schema for an MCP runtime operation. *)
 
 val mcp_runtime_schemas : Masc_domain.tool_schema list
-(** Canonical schemas for {!mcp_runtime_tool_names}, projected from {!schemas}. *)
+(** Canonical schemas projected from {!mcp_runtime_operations}. *)

--- a/lib/unified_tool_registry.ml
+++ b/lib/unified_tool_registry.ml
@@ -45,7 +45,9 @@ let workspace_state_tool_names =
 let is_workspace_state_tool_name name = List.mem name workspace_state_tool_names
 
 let inline_runtime_tool_names =
-  Tool_schemas_misc.mcp_runtime_tool_names
+  List.map
+    Tool_schemas_misc.mcp_runtime_tool_name
+    Tool_schemas_misc.mcp_runtime_operations
 ;;
 
 let is_inline_runtime_tool_name name = List.mem name inline_runtime_tool_names


### PR DESCRIPTION
## Summary

- define the MCP inline runtime tool vocabulary as a closed operation type
- derive canonical wire names and schemas from that vocabulary
- make dispatch and registration exhaustive over the same operations
- remove the three parallel string lists/matches

## Why

masc_start, masc_broadcast, and masc_messages were independently declared in the dispatch match, registration policy list, and schema-name list. A tool could drift between those authorities while still compiling. This change authors each wire name once and makes dispatch/registration projections exhaustive.

## Validation

Not run locally. Exact-head CI is authoritative.
