### PR TITLE
refactor: centralize canonical tool name resolution

### DIFF
--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -46,49 +46,6 @@ let routing_table : (string, route) Hashtbl.t =
 (** [is_known_public name] is [true] when [name] has a routing entry. *)
 let is_known_public name = Hashtbl.mem routing_table name
 
-let is_masc_mcp_descriptor (d : Keeper_tool_descriptor.t) =
-  match d.runtime_handler with
-  | Tool_board_dispatch
-  | Tool_masc_task_dispatch
-  | Tool_masc_plan_dispatch
-  | Tool_masc_run_dispatch
-  | Tool_masc_agent_dispatch
-  | Tool_masc_workspace_dispatch
-  | Tool_masc_misc_dispatch
-  | Tool_masc_control_dispatch
-  | Tool_masc_agent_timeline_dispatch
-  | Tool_masc_schedule_dispatch
-  | Tool_masc_keeper_dispatch
-  | Tool_masc_library_dispatch
-  | Tool_masc_local_runtime_dispatch -> true
-  | Tool_execute
-  | Tool_search_files
-  | Tool_read_file
-  | Tool_edit_file
-  | Tool_write_file
-  | Tool_time_now
-  | Tool_tools_list
-  | Tool_context_status
-  | Tool_artifact_read
-  | Tool_memory_search
-  | Tool_memory_write
-  | Tool_library_search
-  | Tool_library_read
-  | Tool_surface_read
-  | Tool_surface_post
-  | Tool_person_note_set
-  | Tool_ide_annotate
-  | Tool_voice_dispatch
-  | Tool_task_dispatch
-  (* masc_fusion / masc_fusion_status are keeper-native in-process tools (own
-     orchestrator / registry read), not masc-MCP coordination proxies. *)
-  | Tool_masc_fusion_dispatch
-  | Tool_masc_fusion_status
-  | Tool_web_search
-  | Tool_web_fetch
-  | Tool_analyze_image -> false
-;;
-
 let add_internal_names t (d : Keeper_tool_descriptor.t) =
   List.iter
     (fun internal_name -> Hashtbl.replace t internal_name ())
@@ -108,9 +65,8 @@ let known_internal_names_tbl : (string, unit) Hashtbl.t =
     descriptors. *)
 let known_runtime_names_tbl : (string, unit) Hashtbl.t =
   let t = Hashtbl.create 128 in
-  List.iter (add_internal_names t) Keeper_tool_descriptor.public_descriptors;
   List.iter
-    (fun d -> if is_masc_mcp_descriptor d then add_internal_names t d)
+    (add_internal_names t)
     (Keeper_tool_descriptor.all_descriptors ());
   List.iter
     (fun (schema : Masc_domain.tool_schema) -> Hashtbl.replace t schema.name ())
@@ -172,34 +128,6 @@ let route name =
 let public_names = Keeper_tool_descriptor.public_names
 
 let public_name_for_internal = Keeper_tool_descriptor.public_name_for_internal
-
-(* ── MCP prefix normalisation ────────────────────────────────────── *)
-
-let strip_mcp_masc_prefix name =
-  if String.starts_with ~prefix:"mcp__masc__" name
-  then String.sub name 11 (String.length name - 11)
-  else name
-;;
-
-type canonical_resolution =
-  | Public_name of { internal : string }
-  | Internal of { canonical : string }
-  | Unknown
-
-let canonical_resolution name =
-  let stripped = strip_mcp_masc_prefix name in
-  match route stripped with
-  | Some r -> Public_name { internal = r.internal_name }
-  | None ->
-    if is_known_runtime_name stripped then Internal { canonical = stripped } else Unknown
-;;
-
-let canonical_internal_name name =
-  match canonical_resolution name with
-  | Public_name { internal } -> Some internal
-  | Internal { canonical } -> Some canonical
-  | Unknown -> None
-;;
 
 (** [public_input_schema public_name] returns the LLM-facing JSON schema
     for a known public tool name. [None] means no tailored schema exists. *)

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -56,28 +56,6 @@ val public_name_for_internal : string -> string option
     [result] is ["ok"] for a successful route or ["miss"] for an unknown name. *)
 val record_route_outcome : tool:string -> routed_to:string -> result:string -> unit
 
-(** {1 MCP prefix normalisation} *)
-
-(** [strip_mcp_masc_prefix name] removes the ["mcp__masc__"] prefix if
-    present. *)
-val strip_mcp_masc_prefix : string -> string
-
-(** Pure canonical routing result for set-logic and routing callers. *)
-type canonical_resolution =
-  | Public_name of { internal : string }
-  | Internal of { canonical : string }
-  | Unknown
-
-(** [canonical_resolution name] applies MCP-prefix stripping, descriptor-backed
-    public-name routing, and known-internal detection. *)
-val canonical_resolution : string -> canonical_resolution
-
-(** [canonical_internal_name name] returns the internal keeper/MASC tool name
-    used for pure set-logic comparisons after applying the same descriptor
-    public-name and MCP-prefix routing rules used by runtime dispatch. [None]
-    means the name is not a recognised public or internal tool. *)
-val canonical_internal_name : string -> string option
-
 (** {1 Public schemas} *)
 
 (** [public_input_schema public_name] returns the LLM-facing JSON schema

--- a/lib/keeper/keeper_tool_descriptor_resolution.ml
+++ b/lib/keeper/keeper_tool_descriptor_resolution.ml
@@ -1,25 +1,27 @@
+let strip_transport_prefix name =
+  if String.starts_with ~prefix:"mcp__masc__" name
+  then String.sub name 11 (String.length name - 11)
+  else name
+;;
+
 let descriptor_for_tool_name tool_name =
-  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  let stripped = strip_transport_prefix tool_name in
   match Keeper_tool_descriptor.find_public stripped with
   | Some descriptor -> Some descriptor
   | None ->
     (match Keeper_tool_descriptor.descriptors_for_internal stripped with
      | descriptor :: _ -> Some descriptor
-     | [] ->
-       let internal_name =
-         match Keeper_tool_alias.canonical_internal_name tool_name with
-         | Some internal_name -> internal_name
-         | None -> stripped
-       in
-       (match Keeper_tool_descriptor.descriptors_for_internal internal_name with
-        | descriptor :: _ -> Some descriptor
-        | [] -> None))
+     | [] -> None)
 ;;
 
 let canonical_internal_name_for_tool_name tool_name =
   match descriptor_for_tool_name tool_name with
   | Some descriptor -> Some descriptor.Keeper_tool_descriptor.internal_name
-  | None -> Keeper_tool_alias.canonical_internal_name tool_name
+  | None ->
+    let stripped = strip_transport_prefix tool_name in
+    Option.map
+      Tool_schemas_misc.mcp_runtime_tool_name
+      (Tool_schemas_misc.mcp_runtime_operation_of_tool_name stripped)
 ;;
 
 let public_names_for_internal internal_name =
@@ -66,7 +68,7 @@ let capability_has kind tool_name =
 ;;
 
 let descriptor_and_input_for_tool_call ~tool_name ~input =
-  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  let stripped = strip_transport_prefix tool_name in
   match Keeper_tool_descriptor.find_public stripped with
   | Some descriptor ->
     Some
@@ -75,19 +77,11 @@ let descriptor_and_input_for_tool_call ~tool_name ~input =
   | None ->
     (match Keeper_tool_descriptor.descriptors_for_internal stripped with
      | descriptor :: _ -> Some (descriptor, input)
-     | [] ->
-       let internal_name =
-         match Keeper_tool_alias.canonical_internal_name tool_name with
-         | Some internal_name -> internal_name
-         | None -> stripped
-       in
-       (match Keeper_tool_descriptor.descriptors_for_internal internal_name with
-        | descriptor :: _ -> Some (descriptor, input)
-        | [] -> None))
+     | [] -> None)
 ;;
 
 let public_descriptor_and_name_for_tool_call tool_name =
-  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  let stripped = strip_transport_prefix tool_name in
   match Keeper_tool_descriptor.find_public stripped with
   | Some descriptor -> Some (stripped, descriptor)
   | None -> None
@@ -163,10 +157,21 @@ type runtime_decision_outcome =
   | Miss
 
 let runtime_decision name =
-  match Keeper_tool_alias.canonical_resolution name with
-  | Keeper_tool_alias.Public_name { internal } -> Route_hit { internal }
-  | Keeper_tool_alias.Internal { canonical } -> Already_internal { canonical }
-  | Keeper_tool_alias.Unknown -> Miss
+  let stripped = strip_transport_prefix name in
+  match Keeper_tool_alias.route stripped with
+  | Some route -> Route_hit { internal = route.internal_name }
+  | None ->
+    (match descriptor_for_tool_name stripped with
+     | Some descriptor ->
+       Already_internal { canonical = descriptor.internal_name }
+     | None ->
+       (match
+          Tool_schemas_misc.mcp_runtime_operation_of_tool_name stripped
+        with
+        | Some operation ->
+          Already_internal
+            { canonical = Tool_schemas_misc.mcp_runtime_tool_name operation }
+        | None -> Miss))
 ;;
 
 let canonical_tool_name name =
@@ -177,7 +182,7 @@ let canonical_tool_name name =
 ;;
 
 let canonical_tool_name_observed name =
-  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
+  let stripped = strip_transport_prefix name in
   match runtime_decision name with
   | Route_hit { internal } ->
     Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";


### PR DESCRIPTION
## Summary

- move MCP transport-prefix normalization and runtime-name decisions into Keeper_tool_descriptor_resolution
- resolve descriptor-backed internal names directly from the descriptor registry
- resolve inline MCP runtime names from the typed mcp_runtime_operation vocabulary
- remove canonical_resolution and canonical_internal_name from Keeper_tool_alias
- derive bounded telemetry names from all descriptors instead of a hand-maintained runtime-handler subset

## Why

Canonical tool-name authority remained split after the facade hard cut: Keeper_tool_alias still owned prefix stripping, a parallel resolution sum type, and an exhaustive runtime-handler classifier. This change makes descriptor resolution the single canonicalization boundary and deletes the manually synchronized handler subset.

## Validation

Not run locally. Exact-head CI is authoritative.
