### PR TITLE
fix: repair Discord chat test inline-record pattern

### DIFF
--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -186,9 +186,9 @@ let test_adapter_empty_terminal_is_local_error () =
   in
   check int "empty terminal makes no Discord call" 0 !sends;
   match outcomes with
-  | [ Error (Discord_rest_client.Other message) ] ->
+  | [ Error (Discord_rest_client.Other { reason; _ }) ] ->
     check bool "empty terminal failure is explicit" true
-      (contains message "contained no text")
+      (contains reason "contained no text")
   | _ -> fail "empty terminal settles once with a local delivery error"
 
 let test_completed_external_effect_settles_without_duplicate_send () =


### PR DESCRIPTION
## What changed

- Pattern-match the `Discord_rest_client.Other` inline record in the Discord keeper chat test.
- Read the `reason` field directly instead of binding the inline record as an escaping value.

## Why

The error variant now carries an inline record. Binding that record to `message` in the test triggers OCaml's `type of the inlined record could escape` compiler error.

## Validation

- `ocamlformat --check test/test_keeper_chat_discord.ml`
- `ocamlc -stop-after parsing test/test_keeper_chat_discord.ml`
- `git diff --check`

The full local Dune build was left for the user to run; CI is the PR build authority.
