### PR TITLE
fix: use canonical public tool surface in manifest

### DIFF
--- a/bin/public_tool_manifest.ml
+++ b/bin/public_tool_manifest.ml
@@ -6,7 +6,7 @@ let json_list values =
 
 let () =
   let public_tool_names =
-    Tool_catalog.public_mcp_tools
+    Tool_catalog_surfaces.public_mcp_surface_tools
     |> sorted_unique
   in
   `Assoc [ ("public_tool_names", json_list public_tool_names) ]


### PR DESCRIPTION
## Summary

- fix main compilation after removal of Tool_catalog.public_mcp_tools
- make public_tool_manifest consume Tool_catalog_surfaces.public_mcp_surface_tools directly
- preserve the hard cut without restoring the forwarding facade

## Cause

PR #27692 searched lib/test/scripts consumers but missed the bin/public_tool_manifest.ml executable. The removed facade therefore remained referenced on main.

## Validation

User-observed failure: dune build . reports Unbound value Tool_catalog.public_mcp_tools at bin/public_tool_manifest.ml:9. Not rerun locally; exact-head CI is authoritative.
