### PR TITLE
refactor: name canonical tool projections truthfully

### DIFF
--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -270,15 +270,15 @@ let surface_tool_names_from (public_tool_source_schemas : Masc_domain.tool_schem
    PR-8 wires the MCP server; PR-9 wires tag-dispatch fallback.
    PR-11 removes the legacy [dispatch] and [dispatch_structured] entries
    once all callers migrate. *)
-let public_tool_schemas_from (public_tool_source_schemas : Masc_domain.tool_schema list) :
+let canonical_tool_schemas_from (public_tool_source_schemas : Masc_domain.tool_schema list) :
     Masc_domain.tool_schema list =
   require_unique_schemas ~label:"public tool catalog" public_tool_source_schemas
   |> Tool_help_registry.canonicalize_schemas
 
-let visible_public_tool_schemas_from
+let visible_tool_schemas_from
     ?(include_hidden = false)
     (public_tool_source_schemas : Masc_domain.tool_schema list) : Masc_domain.tool_schema list =
-  public_tool_schemas_from public_tool_source_schemas
+  canonical_tool_schemas_from public_tool_source_schemas
   |> List.filter (fun (schema : Masc_domain.tool_schema) ->
          Tool_catalog.is_visible ~include_hidden schema.name)
 
@@ -298,4 +298,3 @@ let surface_snapshot_json
       ("spawned_agent_mcp", surface_json Spawned_agent_mcp);
       ("keeper", surface_json Keeper);
     ]
-

--- a/lib/capability_registry.mli
+++ b/lib/capability_registry.mli
@@ -72,15 +72,16 @@ val all_capabilities_from :
 
 (** {1 Public surface accessors} *)
 
-val public_tool_schemas_from :
+val canonical_tool_schemas_from :
   Masc_domain.tool_schema list -> Masc_domain.tool_schema list
-(** Canonical public-MCP schemas. Duplicate names are rejected. *)
+(** Canonicalized full tool inventory. Duplicate names are rejected. Public
+    surface membership is projected separately through {!surface}. *)
 
-val visible_public_tool_schemas_from :
+val visible_tool_schemas_from :
   ?include_hidden:bool ->
   Masc_domain.tool_schema list ->
   Masc_domain.tool_schema list
-(** [public_tool_schemas_from] filtered through [Tool_catalog.is_visible].
+(** [canonical_tool_schemas_from] filtered through [Tool_catalog.is_visible].
     [include_hidden] defaults to [false]. *)
 
 (** {1 Spawned-agent tool naming} *)

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -80,7 +80,7 @@ let () = validate_schemas raw_all_tool_schemas
 
 let all_tool_schemas : Masc_domain.tool_schema list =
   let schemas =
-    Capability_registry.public_tool_schemas_from front_door_tool_schemas
+    Capability_registry.canonical_tool_schemas_from front_door_tool_schemas
   in
   validate_schemas schemas;
   schemas
@@ -104,5 +104,5 @@ let is_raw_tool_name name = Hashtbl.mem raw_tool_name_set name
 
 let visible_tool_schemas ?(include_hidden = false) () :
     Masc_domain.tool_schema list =
-  Capability_registry.visible_public_tool_schemas_from ~include_hidden
+  Capability_registry.visible_tool_schemas_from ~include_hidden
     front_door_tool_schemas

--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -6,7 +6,7 @@ open Alcotest
 
 let test_public_visible_surface_exposes_masc_transition () =
   let names =
-    Lib.Capability_registry.visible_public_tool_schemas_from
+    Lib.Capability_registry.visible_tool_schemas_from
       Lib.Config.raw_all_tool_schemas
     |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
   in

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -70,6 +70,35 @@ let test_schema_set_equals_tag_registry_set () =
     ~actual:schemas
 ;;
 
+let rec canonical_json = function
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       |> List.map (fun (name, value) -> name, canonical_json value)
+       |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | `List values -> `List (List.map canonical_json values)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as value ->
+    value
+;;
+
+let canonical_json_string value =
+  value |> canonical_json |> Yojson.Safe.to_string
+;;
+
+let test_schema_inventory_matches_dispatch_validation_registry () =
+  init ();
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+      match Tool_dispatch.lookup_schema schema.name with
+      | None -> Alcotest.failf "%s missing from dispatch schema registry" schema.name
+      | Some registered_schema ->
+        Alcotest.(check string)
+          (schema.name ^ " advertised and validation schemas match")
+          (canonical_json_string schema.input_schema)
+          (canonical_json_string registered_schema))
+    Config.raw_all_tool_schemas
+;;
+
 let test_workspace_schemas_route_to_state () =
   init ();
   Tool_schemas_workspace.schemas
@@ -227,6 +256,10 @@ let () =
     [ ( "registry_sets"
       , [ test_case "schema set equals tag_registry set" `Quick
             test_schema_set_equals_tag_registry_set
+        ; test_case
+            "schema inventory matches dispatch validation registry"
+            `Quick
+            test_schema_inventory_matches_dispatch_validation_registry
         ] )
     ; ( "workspace_tools"
       , [ test_case "workspace schemas route to Mod_state" `Quick


### PR DESCRIPTION
## Summary

- rename public_tool_schemas_from to canonical_tool_schemas_from
- rename visible_public_tool_schemas_from to visible_tool_schemas_from
- update Config and capability tests without compatibility aliases

## Why

These functions canonicalize and visibility-filter the full tool inventory; they do not apply Public_mcp surface membership. Their public_* names falsely advertised a second public-surface authority beside Capability_registry.surface and Tool_catalog_surfaces. This hard cut makes the API match its actual contract.

## Stack

Base: #27700.

## Validation

Not run locally. Exact-head CI is authoritative.
