### PR TITLE
fix: declare public tool manifest dependency

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -124,7 +124,11 @@
 (executable
  (name public_tool_manifest)
  (modules public_tool_manifest)
- (libraries masc masc.masc_tool_dispatch yojson))
+ (libraries
+  masc
+  masc.masc_tool_dispatch
+  masc.tool_catalog_surfaces
+  yojson))
 
 ;; runtime_materialize (RFC-0058 §9 Phase 9.3): retired. The CLI's only
 ;; purpose was to pre-write the old derived JSON artifact.


### PR DESCRIPTION
## Summary
- declare the canonical tool catalog surface library as a direct dependency of `public_tool_manifest`
- keep the removed `Tool_catalog.public_mcp_tools` facade deleted

## Why
Dune does not expose transitive library modules. The manifest now names `Tool_catalog_surfaces` directly, so its executable must link `masc.tool_catalog_surfaces` directly.

## Validation
- not run locally; reported full build failure is the target and CI is authoritative