### PR TITLE
refactor: remove dormant tool alias metadata

### DIFF
--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -89,12 +89,6 @@ let require_unique_projections ~label projections =
 let prefixed_tool_names names =
   names |> List.map (fun name -> "mcp__masc__" ^ name)
 
-let canonical_capability_id tool_name =
-  match (Tool_catalog.metadata tool_name).Tool_catalog.canonical_name with
-  | Some canonical_name -> canonical_name
-  | None -> tool_name
-
-
 let surface_to_string = function
   | Public_mcp -> "public_mcp"
   | Spawned_agent_mcp -> "spawned_agent_mcp"
@@ -114,8 +108,7 @@ let make_seed ?capability_id
   let backend_tool_name = Option.value ~default:schema.name backend_tool_name in
   {
     capability_id =
-      Option.value ~default:(canonical_capability_id backend_tool_name)
-        capability_id;
+      Option.value ~default:backend_tool_name capability_id;
     audiences;
     supports_audit_evidence;
     supports_direct_user_discovery;

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -585,8 +585,6 @@ let register_keeper_surface_schema (s : Masc_domain.tool_schema) =
        ~is_idempotent:policy.is_idempotent
        ~visibility:metadata.visibility
        ~implementation_status:metadata.implementation_status
-       ?canonical_name:metadata.canonical_name
-       ?replacement:metadata.replacement
        ?reason:metadata.reason
        ~allow_direct_call_when_hidden:metadata.allow_direct_call_when_hidden
        ())

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -31,8 +31,6 @@ type metadata = {
   visibility : visibility;
   lifecycle : lifecycle;
   implementation_status : implementation_status;
-  canonical_name : string option;
-  replacement : string option;
   reason : string option;
   allow_direct_call_when_hidden : bool;
   readonly : bool option;
@@ -105,8 +103,6 @@ let default_metadata ~required_permission =
     visibility = Default;
     lifecycle = Active;
     implementation_status = Real;
-    canonical_name = None;
-    replacement = None;
     reason = None;
     allow_direct_call_when_hidden = false;
     readonly = None;
@@ -124,14 +120,12 @@ let placeholder_tools_enabled () =
   | Some "false" | Some "0" -> false
   | _ -> true
 
-let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden = true)
+let hidden_active ?(allow_direct_call_when_hidden = true)
     ?(implementation_status = Real) ~required_permission reason =
   {
     visibility = Hidden;
     lifecycle = Active;
     implementation_status;
-    canonical_name;
-    replacement;
     reason = Some reason;
     allow_direct_call_when_hidden;
     readonly = None;
@@ -521,11 +515,6 @@ let implementation_status name =
   let meta = metadata name in
   meta.implementation_status
 
-let canonical_tool_name name =
-  match (metadata name).canonical_name with
-  | Some canonical_name -> canonical_name
-  | None -> name
-
 let is_placeholder name =
   match implementation_status name with
   | Placeholder -> true
@@ -564,20 +553,10 @@ let metadata_to_fields name =
       , `String (Masc_domain.permission_to_string meta.required_permission) );
     ]
   in
-  let with_canonical =
-    match meta.canonical_name with
-    | Some canonical_name -> ("canonicalName", `String canonical_name) :: base
-    | None -> base
-  in
-  let with_replacement =
-    match meta.replacement with
-    | Some replacement -> ("replacement", `String replacement) :: with_canonical
-    | None -> with_canonical
-  in
   let with_reason =
     match meta.reason with
-    | Some reason -> ("reason", `String reason) :: with_replacement
-    | None -> with_replacement
+    | Some reason -> ("reason", `String reason) :: base
+    | None -> base
   in
   let with_mcp_context_required =
     match meta.mcp_context_required with

--- a/lib/tool/tool_catalog.mli
+++ b/lib/tool/tool_catalog.mli
@@ -20,8 +20,6 @@ type metadata = {
   visibility : visibility;
   lifecycle : lifecycle;
   implementation_status : implementation_status;
-  canonical_name : string option;
-  replacement : string option;
   reason : string option;
   allow_direct_call_when_hidden : bool;
   readonly : bool option;
@@ -52,7 +50,6 @@ type execution_policy_error =
 val default_metadata : required_permission:Masc_domain.permission -> metadata
 
 val hidden_active :
-  ?canonical_name:string -> ?replacement:string ->
   ?allow_direct_call_when_hidden:bool ->
   ?implementation_status:implementation_status ->
   required_permission:Masc_domain.permission -> string -> metadata
@@ -69,7 +66,6 @@ val execution_policy_of_metadata :
   tool_name:string -> metadata -> (execution_policy, execution_policy_error) result
 val execution_policy_error_to_string : execution_policy_error -> string
 val implementation_status : string -> implementation_status
-val canonical_tool_name : string -> string
 val is_visible : ?include_hidden:bool -> string -> bool
 val allow_direct_call : string -> bool
 

--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -20,8 +20,6 @@ type t = {
   is_idempotent : bool;
   visibility : Tool_catalog.visibility;
   implementation_status : Tool_catalog.implementation_status;
-  canonical_name : string option;
-  replacement : string option;
   reason : string option;
   allow_direct_call_when_hidden : bool;
   title : string option;
@@ -42,8 +40,6 @@ let create
     ?(is_idempotent = false)
     ?(visibility = Tool_catalog.Default)
     ?(implementation_status = Tool_catalog.Real)
-    ?canonical_name
-    ?replacement
     ?reason
     ?(allow_direct_call_when_hidden = false)
     ?title
@@ -51,7 +47,7 @@ let create
   { name; description; module_tag; input_schema; handler_binding;
     is_read_only; mcp_context_required; is_idempotent;
     visibility; implementation_status;
-    canonical_name; replacement; reason;
+    reason;
     allow_direct_call_when_hidden; title }
 
 (* ================================================================ *)
@@ -83,8 +79,6 @@ let register (spec : t) =
          { authority with
            visibility = spec.visibility;
            implementation_status = spec.implementation_status;
-           canonical_name = spec.canonical_name;
-           replacement = spec.replacement;
            reason = spec.reason;
            allow_direct_call_when_hidden = spec.allow_direct_call_when_hidden;
            readonly = Some spec.is_read_only;

--- a/lib/tool_surface/tool_spec.mli
+++ b/lib/tool_surface/tool_spec.mli
@@ -40,8 +40,6 @@ type t = {
   is_idempotent : bool;
   visibility : Tool_catalog.visibility;
   implementation_status : Tool_catalog.implementation_status;
-  canonical_name : string option;
-  replacement : string option;
   reason : string option;
   allow_direct_call_when_hidden : bool;
   title : string option;
@@ -60,8 +58,6 @@ val create :
   ?is_idempotent:bool ->
   ?visibility:Tool_catalog.visibility ->
   ?implementation_status:Tool_catalog.implementation_status ->
-  ?canonical_name:string ->
-  ?replacement:string ->
   ?reason:string ->
   ?allow_direct_call_when_hidden:bool ->
   ?title:string ->

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -42,8 +42,6 @@ let () =
               spec.mcp_context_required;
             check bool "is_idempotent default" false spec.is_idempotent;
             check bool "allow_direct_call default" false spec.allow_direct_call_when_hidden;
-            check bool "canonical_name default" true (Option.is_none spec.canonical_name);
-            check bool "replacement default" true (Option.is_none spec.replacement);
             check bool "reason default" true (Option.is_none spec.reason);
             check bool "title default" true (Option.is_none spec.title));
           test_case "create with optional args" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- remove unused `canonical_name` and `replacement` fields from tool catalog metadata and tool specs
- delete the dormant catalog canonical-name projection path
- derive default capability identity directly from the backend tool name
- remove Keeper registration forwarding for the deleted metadata

## Why
No production tool supplied either field, but the metadata and projection path preserved an inactive alias mechanism that could become a second naming authority. Canonical public/internal routing remains descriptor-owned.

## Validation
- not run locally; CI is authoritative