### PR TITLE
fix: align keeper tool boundary matrix

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -130,8 +130,6 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_execute_path.mli` - shell-surface
 - `lib/keeper_tool_execute_timeout/keeper_tool_execute_timeout.ml` - shell-surface
 - `lib/keeper_tool_execute_timeout/keeper_tool_execute_timeout.mli` - shell-surface
-- `lib/keeper/keeper_tool_alias.ml` - tool-surface-policy
-- `lib/keeper/keeper_tool_alias.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_execute_typed_input.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_execute_typed_input.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_boundary.ml` - tool-surface-policy
@@ -156,8 +154,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_progress_identity.mli` - tool-surface-policy
 - `lib/keeper_tool_response/keeper_tool_response.ml` - tool-surface-policy
 - `lib/keeper_tool_response/keeper_tool_response.mli` - tool-surface-policy
-- `lib/keeper/keeper_tool_resolution.ml` - tool-surface-policy
-- `lib/keeper/keeper_tool_resolution.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_route_telemetry.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_route_telemetry.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_surface.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_surface.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_surface_ops.ml` - tool-surface-policy


### PR DESCRIPTION
## Summary

- align the Keeper tool-boundary matrix with the exact current source inventory
- register route telemetry under the descriptor-owned tool-surface policy boundary
- restore the required matrix audit for every PR using current main

## Validation

- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `scripts/check-doc-truth.sh`
- `git diff --check`

# ci:skip-test-coverage
Reason: documentation inventory repair enforced by the executable boundary audit; runtime behavior is unchanged.
