### PR TITLE
fix: use extracted tool catalog in profile test

### DIFF
--- a/lib/capability_registry.mli
+++ b/lib/capability_registry.mli
@@ -7,8 +7,7 @@
 
     Internal helpers ([StringSet] / [StringMap], [require_unique_schemas],
     [require_unique_projections], [prefixed_tool_names],
-    [canonical_capability_id], [projection_to_schema], [make_seed],
-    [public_projection_seeds_from],
+    [projection_to_schema], [make_seed], [public_projection_seeds_from],
     [keeper_projection_seeds], [surface_tool_schemas_from],
     [surface_tool_names_from], [oauth_login_stage], the surface-name lists
     [spawned_agent_public_tool_names]) are hidden — callers consume the

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -174,14 +174,14 @@ let test_full_profile_admission_uses_catalog_direct_call_policy () =
   let hidden_disallowed = ref 0 in
   List.iter
     (fun (schema : Masc_domain.tool_schema) ->
-      let metadata = Masc.Tool_catalog.metadata schema.name in
+      let metadata = Tool_catalog.metadata schema.name in
       if
-        metadata.visibility = Masc.Tool_catalog.Hidden
+        metadata.visibility = Tool_catalog.Hidden
         && not metadata.allow_direct_call_when_hidden
       then incr hidden_disallowed;
       let expected =
-        Masc.Tool_catalog.is_visible ~include_hidden:true schema.name
-        && Masc.Tool_catalog.allow_direct_call schema.name
+        Tool_catalog.is_visible ~include_hidden:true schema.name
+        && Tool_catalog.allow_direct_call schema.name
       in
       check
         bool


### PR DESCRIPTION
## Summary
- reference the extracted bare `Tool_catalog` module from the profile capability test
- remove the stale interface reference to the deleted alias helper

## Why
`Tool_catalog` lives in an unwrapped extracted sublibrary and is not exported as `Masc.Tool_catalog`; the new full-profile ratchet therefore failed the full build.

## Validation
- not rerun locally; the reported compiler error is the target and CI is authoritative