### PR TITLE
fix: align full tool listing with call policy

### DIFF
--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -61,7 +61,8 @@ let tool_schemas_for_profile ?(include_hidden = false)
         let full_profile_tools =
           List.filter
             (fun (schema : Masc_domain.tool_schema) ->
-              show_all || Tool_catalog.is_public_mcp schema.name)
+              Tool_catalog.allow_direct_call schema.name
+              && (show_all || Tool_catalog.is_public_mcp schema.name))
             all
         in
         full_profile_tools

--- a/lib/mcp_server_eio_tool_profile.mli
+++ b/lib/mcp_server_eio_tool_profile.mli
@@ -73,7 +73,8 @@ val tool_schemas_for_profile :
       state profile] returns the schema
     list visible on [profile]:
 
-    - [Full]: [Config.visible_tool_schemas] (gated by [include_hidden]).
+    - [Full]: [Config.visible_tool_schemas] gated by [include_hidden], public
+      surface membership, and [Tool_catalog.allow_direct_call].
     - [Managed_agent]: SDK tool contract +
       [managed_agent_passthrough_tool_names] subset.
     - [Operator_remote]: pinned [Tool_operator.remote_schemas].

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -171,6 +171,13 @@ let test_full_profile_admission_uses_catalog_direct_call_policy () =
     Masc.Mcp_server.For_testing.create_state
       ~base_path:(Filename.get_temp_dir_name ())
   in
+  let advertised_names =
+    Masc.Mcp_server_eio_tool_profile.tool_schemas_for_profile
+      ~include_hidden:true
+      state
+      Masc.Mcp_server_eio_tool_profile.Full
+    |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
+  in
   let hidden_disallowed = ref 0 in
   List.iter
     (fun (schema : Masc_domain.tool_schema) ->
@@ -190,7 +197,12 @@ let test_full_profile_admission_uses_catalog_direct_call_policy () =
         (Masc.Mcp_server_eio_tool_profile.tool_allowed_in_profile
            state
            Masc.Mcp_server_eio_tool_profile.Full
-           schema.name))
+           schema.name);
+      check
+        bool
+        (schema.name ^ " Full-profile advertisement matches admission")
+        expected
+        (List.mem schema.name advertised_names))
     Masc.Config.raw_all_tool_schemas;
   check
     bool


### PR DESCRIPTION
## Summary
- exclude direct-call-denied tools from the Full profile tool listing
- keep `include_hidden` as a visibility switch, not a call-policy bypass
- assert every raw tool is advertised by Full exactly when Full admits its call

## Why
The Full profile already rejected hidden operator-only calls, but `tools/list` with `include_hidden=true` still advertised them. MCP discovery and call admission must project the same canonical profile policy.

## Validation
- not run locally; CI is authoritative