### PR TITLE
refactor: isolate tag-only tool registration

### DIFF
--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -246,11 +246,6 @@ let register_module_tag ~(schemas : Masc_domain.tool_schema list) ~tag =
       Hashtbl.replace tag_registry s.name tag;
       Hashtbl.replace schema_registry s.name s.input_schema) schemas)
 
-module For_testing = struct
-  let register_name_tag ~tool_name ~tag =
-    with_dispatch_rw (fun () -> Hashtbl.replace tag_registry tool_name tag)
-end
-
 let lookup_tag name = with_dispatch_ro (fun () -> Hashtbl.find_opt tag_registry name)
 
 let lookup_schema name = with_dispatch_ro (fun () -> Hashtbl.find_opt schema_registry name)

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -246,9 +246,10 @@ let register_module_tag ~(schemas : Masc_domain.tool_schema list) ~tag =
       Hashtbl.replace tag_registry s.name tag;
       Hashtbl.replace schema_registry s.name s.input_schema) schemas)
 
-(** Register a single tool name with a tag (for modules without schema exports). *)
-let register_name_tag ~tool_name ~tag =
-  with_dispatch_rw (fun () -> Hashtbl.replace tag_registry tool_name tag)
+module For_testing = struct
+  let register_name_tag ~tool_name ~tag =
+    with_dispatch_rw (fun () -> Hashtbl.replace tag_registry tool_name tag)
+end
 
 let lookup_tag name = with_dispatch_ro (fun () -> Hashtbl.find_opt tag_registry name)
 

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -161,8 +161,11 @@ type module_tag =
 val register_module_tag : schemas:Masc_domain.tool_schema list -> tag:module_tag -> unit
 (** Register tool names from a schema list with a module tag. *)
 
-val register_name_tag : tool_name:string -> tag:module_tag -> unit
-(** Register a single tool name with a tag. *)
+module For_testing : sig
+  val register_name_tag : tool_name:string -> tag:module_tag -> unit
+  (** Register a tag without a schema for isolated dispatch-hook tests. This
+      deliberately cannot be called through the production API surface. *)
+end
 
 val lookup_tag : string -> module_tag option
 (** Look up the module tag for a tool name. *)

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -161,12 +161,6 @@ type module_tag =
 val register_module_tag : schemas:Masc_domain.tool_schema list -> tag:module_tag -> unit
 (** Register tool names from a schema list with a module tag. *)
 
-module For_testing : sig
-  val register_name_tag : tool_name:string -> tag:module_tag -> unit
-  (** Register a tag without a schema for isolated dispatch-hook tests. This
-      deliberately cannot be called through the production API surface. *)
-end
-
 val lookup_tag : string -> module_tag option
 (** Look up the module tag for a tool name. *)
 

--- a/test/test_tool_hooks.ml
+++ b/test/test_tool_hooks.ml
@@ -14,6 +14,23 @@ let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
 ;;
 
+let test_schema tool_name : Masc_domain.tool_schema =
+  { name = tool_name
+  ; description = "dispatch hook test"
+  ; input_schema =
+      `Assoc
+        [ "type", `String "object"
+        ; "properties", `Assoc []
+        ; "required", `List []
+        ]
+  }
+;;
+
+let register_test_tool ~tool_name ~handler =
+  Tool_dispatch.register ~tool_name ~handler;
+  Tool_dispatch.register_module_tag ~schemas:[ test_schema tool_name ] ~tag:Mod_misc
+;;
+
 let setup () =
   reset_log ();
   Tool_dispatch.clear_hooks ()
@@ -22,12 +39,11 @@ let setup () =
 
 let test_pre_hook_observes () =
   setup ();
-  Tool_dispatch.register
+  register_test_tool
     ~tool_name:"__hook_test"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (tool_ok "ok"));
-  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_test" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
     Tool_dispatch.Pass);
@@ -40,12 +56,11 @@ let test_pre_hook_observes () =
 
 let test_pre_hook_short_circuits () =
   setup ();
-  Tool_dispatch.register
+  register_test_tool
     ~tool_name:"__hook_blocked"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (tool_ok "should not reach"));
-  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_blocked" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name ~args:_ ->
     log_call "pre_block";
     Tool_dispatch.Reject
@@ -69,12 +84,11 @@ let test_pre_hook_short_circuits () =
 
 let test_multiple_pre_hooks_first_wins () =
   setup ();
-  Tool_dispatch.register
+  register_test_tool
     ~tool_name:"__hook_multi"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (tool_ok "ok"));
-  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_multi" ~tag:Mod_misc;
   (* First hook: observe only *)
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre1";
@@ -104,12 +118,11 @@ let test_multiple_pre_hooks_first_wins () =
 
 let test_dispatch_observer_observes () =
   setup ();
-  Tool_dispatch.register
+  register_test_tool
     ~tool_name:"__hook_observer"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (tool_ok "original"));
-  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_observer" ~tag:Mod_misc;
   Tool_dispatch.register_dispatch_observer (fun outcome result ->
     match outcome, result with
     | Dispatch_outcome.Handled, Some _ -> log_call "observer"
@@ -124,11 +137,10 @@ let test_dispatch_observer_observes () =
 
 let test_dispatch_observers_chain () =
   setup ();
-  Tool_dispatch.register
+  register_test_tool
     ~tool_name:"__hook_chain"
     ~handler:(fun ~name:_ ~args:_ ->
       Some (tool_ok "0"));
-  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_chain" ~tag:Mod_misc;
   Tool_dispatch.register_dispatch_observer (fun outcome result ->
     match outcome, result with
     | Dispatch_outcome.Handled, Some _ -> log_call "observer1"
@@ -150,12 +162,11 @@ let test_dispatch_observers_chain () =
 
 let test_full_lifecycle () =
   setup ();
-  Tool_dispatch.register
+  register_test_tool
     ~tool_name:"__hook_full"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (tool_ok "data"));
-  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_full" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
     Tool_dispatch.Pass);
@@ -171,11 +182,10 @@ let test_full_lifecycle () =
 let test_no_hooks_default () =
   setup ();
   (* No hooks registered *)
-  Tool_dispatch.register
+  register_test_tool
     ~tool_name:"__hook_none"
     ~handler:(fun ~name ~args:_ ->
       Some (tool_ok ~tool_name:name "plain"));
-  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_none" ~tag:Mod_misc;
   let token = match Tool_dispatch.mint_token ~name:"__hook_none" with Ok t -> t | Error e -> Alcotest.fail e in
   match Tool_dispatch.guarded_dispatch ~token ~args:`Null () with
   | Some r ->

--- a/test/test_tool_hooks.ml
+++ b/test/test_tool_hooks.ml
@@ -27,7 +27,7 @@ let test_pre_hook_observes () =
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (tool_ok "ok"));
-  Tool_dispatch.register_name_tag ~tool_name:"__hook_test" ~tag:Mod_misc;
+  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_test" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
     Tool_dispatch.Pass);
@@ -45,7 +45,7 @@ let test_pre_hook_short_circuits () =
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (tool_ok "should not reach"));
-  Tool_dispatch.register_name_tag ~tool_name:"__hook_blocked" ~tag:Mod_misc;
+  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_blocked" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name ~args:_ ->
     log_call "pre_block";
     Tool_dispatch.Reject
@@ -74,7 +74,7 @@ let test_multiple_pre_hooks_first_wins () =
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (tool_ok "ok"));
-  Tool_dispatch.register_name_tag ~tool_name:"__hook_multi" ~tag:Mod_misc;
+  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_multi" ~tag:Mod_misc;
   (* First hook: observe only *)
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre1";
@@ -109,7 +109,7 @@ let test_dispatch_observer_observes () =
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (tool_ok "original"));
-  Tool_dispatch.register_name_tag ~tool_name:"__hook_observer" ~tag:Mod_misc;
+  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_observer" ~tag:Mod_misc;
   Tool_dispatch.register_dispatch_observer (fun outcome result ->
     match outcome, result with
     | Dispatch_outcome.Handled, Some _ -> log_call "observer"
@@ -128,7 +128,7 @@ let test_dispatch_observers_chain () =
     ~tool_name:"__hook_chain"
     ~handler:(fun ~name:_ ~args:_ ->
       Some (tool_ok "0"));
-  Tool_dispatch.register_name_tag ~tool_name:"__hook_chain" ~tag:Mod_misc;
+  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_chain" ~tag:Mod_misc;
   Tool_dispatch.register_dispatch_observer (fun outcome result ->
     match outcome, result with
     | Dispatch_outcome.Handled, Some _ -> log_call "observer1"
@@ -155,7 +155,7 @@ let test_full_lifecycle () =
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
       Some (tool_ok "data"));
-  Tool_dispatch.register_name_tag ~tool_name:"__hook_full" ~tag:Mod_misc;
+  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_full" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
     Tool_dispatch.Pass);
@@ -175,7 +175,7 @@ let test_no_hooks_default () =
     ~tool_name:"__hook_none"
     ~handler:(fun ~name ~args:_ ->
       Some (tool_ok ~tool_name:name "plain"));
-  Tool_dispatch.register_name_tag ~tool_name:"__hook_none" ~tag:Mod_misc;
+  Tool_dispatch.For_testing.register_name_tag ~tool_name:"__hook_none" ~tag:Mod_misc;
   let token = match Tool_dispatch.mint_token ~name:"__hook_none" with Ok t -> t | Error e -> Alcotest.fail e in
   match Tool_dispatch.guarded_dispatch ~token ~args:`Null () with
   | Some r ->


### PR DESCRIPTION
## Summary

- delete tag-only registration from `Tool_dispatch`
- make isolated hook tests use the production registration contract
- register each test tool with name, validation schema, and module tag together

## Why

Production registration must keep tag and validation schema ownership together. A public tag-only helper can mint a dispatch-authorized name without a schema, even when nested under a module named `For_testing`.

## Validation

- `git diff --check`
- `ocamlformat --check lib/tool/tool_dispatch.ml lib/tool/tool_dispatch.mli test/test_tool_hooks.ml`
- exact-tree `register_name_tag` and `Tool_dispatch.For_testing` search: 0 hits
- focused Dune was deferred because the repository resource guard detected five unrelated bare Dune processes; required CI is authoritative