### PR TITLE
refactor: remove public tool surface escape hatch

### DIFF
--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -219,9 +219,6 @@ masc_claim_next()
 `tools/list`는 기본 공개 surface만 보여준다. hidden/internal tool도 `tools/call`로는 호출 가능하다.
 
 ```bash
-# Add specific tools to the public surface
-MASC_PUBLIC_TOOLS_EXTRA=masc_board_search,masc_pause
-
 # Web search provider control
 MASC_WEB_SEARCH_PROVIDER=brave
 MASC_WEB_SEARCH_FALLBACKS=ddg,bing_rss

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -275,10 +275,6 @@ module Tools = struct
     let v = get_int ~default:512 "MASC_LIST_PAGE_SIZE" in
     max 10 (min 1024 v)
 
-  (** Extra public tools (comma-separated names). *)
-  let public_tools_extra_opt () =
-    Sys.getenv_opt "MASC_PUBLIC_TOOLS_EXTRA" |> trim_opt
-
   let web_search_provider_opt () =
     raw_value_opt "MASC_WEB_SEARCH_PROVIDER" |> trim_opt
 

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -106,7 +106,6 @@ end
 
 module Tools : sig
   val list_page_size : unit -> int
-  val public_tools_extra_opt : unit -> string option
   val web_search_provider_opt : unit -> string option
   val web_search_provider_order_opt : unit -> string option
   val web_search_fallbacks_opt : unit -> string option

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -470,8 +470,6 @@ let tool_entries =
       "Tool list page size (clamped 10-1024)";
     entry ~default:"(none)" "MASC_PLACEHOLDER_TOOLS_ENABLED"
       "Enable placeholder tool exposure";
-    entry ~default:"(none)" "MASC_PUBLIC_TOOLS_EXTRA"
-      "Extra public tools (comma-separated names); None when unset";
   ]
 
 let web_search_entries =

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -464,15 +464,6 @@ let public_mcp_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create 64 in
   List.iter (fun name -> Hashtbl.replace tbl name ())
     Tool_catalog_surfaces.public_mcp_surface_tools;
-  (* MASC_PUBLIC_TOOLS_EXTRA: comma-separated tool names to add at runtime.
-     Example: MASC_PUBLIC_TOOLS_EXTRA=masc_board_search,masc_pause *)
-  (match Env_config.Tools.public_tools_extra_opt () with
-   | Some raw ->
-       String.split_on_char ',' raw
-       |> List.iter (fun s ->
-              let name = String.trim s in
-              if not (String.equal name "") then Hashtbl.replace tbl name ())
-   | None -> ());
   tbl
 
 let is_public_mcp name = Hashtbl.mem public_mcp_set name

--- a/scripts/harness/contract/run_local_fresh_boot_contract.sh
+++ b/scripts/harness/contract/run_local_fresh_boot_contract.sh
@@ -205,7 +205,6 @@ env \
   -u MASC_CONFIG_DIR \
   -u MASC_HOST \
   -u MASC_PORT \
-  -u MASC_PUBLIC_TOOLS_EXTRA \
   bash "$RUN_LOCAL_SCRIPT" --target-dir "$BASE_PATH" --host 127.0.0.1 --port "$PORT" \
   --bootstrap-only >"$LOG_FILE" 2>&1
 
@@ -215,7 +214,6 @@ env \
     -u MASC_CONFIG_DIR \
     -u MASC_HOST \
     -u MASC_PORT \
-    -u MASC_PUBLIC_TOOLS_EXTRA \
     MASC_KEEPER_BOOTSTRAP_ENABLED=0 \
     bash "$RUN_LOCAL_SCRIPT" --target-dir "$BASE_PATH" --host 127.0.0.1 --port "$PORT"
 ) >"$LOG_FILE" 2>&1 &

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1503,6 +1503,17 @@ let test_public_mcp_surface_has_exact_dispatch_owner () =
       (String.concat ", " missing)
 ;;
 
+let test_public_mcp_membership_matches_surface_ssot () =
+  let surface = Tool_catalog_surfaces.public_mcp_surface_tools in
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+       Alcotest.(check bool)
+         (schema.name ^ " public membership matches the canonical surface")
+         (List.mem schema.name surface)
+         (Tool_catalog.is_public_mcp schema.name))
+    Masc.Config.raw_all_tool_schemas
+;;
+
 let () =
   Alcotest.run
     "keeper_tool_descriptor_registry_integrity"
@@ -1657,6 +1668,10 @@ let () =
             "public_mcp_surface_tools has an exact dispatch owner"
             `Quick
             test_public_mcp_surface_has_exact_dispatch_owner
+        ; test_case
+            "public MCP membership matches the canonical surface"
+            `Quick
+            test_public_mcp_membership_matches_surface_ssot
         ] )
     ; ( "policy-projection"
       , [ test_case


### PR DESCRIPTION
## Summary

- remove the untyped `MASC_PUBLIC_TOOLS_EXTRA` public-surface override
- delete its runtime config, snapshot, fresh-boot harness, and documentation remnants
- assert raw-schema public membership exactly matches `public_mcp_surface_tools`

## Why

The curated public surface is the declared membership SSOT. A comma-separated environment override could expose additional tools outside that authority and had no validation or contract tests.

## Validation

- exact-tree `MASC_PUBLIC_TOOLS_EXTRA` search: 0 hits
- `git diff --check`
- required CI is authoritative