### PR TITLE
refactor: remove keeper tool prefix inference

### DIFF
--- a/lib/tool/tool_registry.ml
+++ b/lib/tool/tool_registry.ml
@@ -65,12 +65,8 @@ let stats_catalog_tool_names : StringSet.t Eio.Lazy.t =
       explicit_metadata_names)
 ;;
 
-let is_keeper_internal_tool_name tool_name =
-  String.starts_with ~prefix:"keeper_" tool_name
-
 let is_stats_known_tool tool_name =
   StringSet.mem tool_name (Eio.Lazy.force stats_catalog_tool_names)
-  || is_keeper_internal_tool_name tool_name
 
 let is_known_tool = is_stats_known_tool
 

--- a/test/test_tool_registry.ml
+++ b/test/test_tool_registry.ml
@@ -80,6 +80,14 @@ let () =
               ~duration_ms:1
               ();
             check int "total" 0 (Tool_registry.total_calls ()))
+        ; test_case "keeper prefix does not invent tool identity" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call_if_known
+              ~tool_name:"keeper_totally_unknown"
+              ~disposition:(Tool_result.Failed ())
+              ~duration_ms:1
+              ();
+            check int "total" 0 (Tool_registry.total_calls ()))
         ; test_case "gated recording includes keeper-internal tools" `Quick (fun () ->
             Tool_registry.reset ();
             Tool_registry.record_call_if_known


### PR DESCRIPTION
## Summary
- derive telemetry-known tool identity only from explicit catalog metadata
- remove the `keeper_*` prefix inference fallback
- prove real cataloged Keeper tools remain recordable while unknown prefixed names are rejected

## Why
A string prefix must not invent tool identity outside the canonical catalog. The existing Keeper schemas already own explicit metadata, so the fallback only admitted unknown names.

## Validation
- not run locally; CI is authoritative