### PR TITLE
refactor: make registered tool handlers total

### DIFF
--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -4,13 +4,8 @@
     {!Board_tool_handlers}, {!Board_tool_post}, {!Board_tool_curation},
     or {!Board_tool_sub_board}; and installs every schema from
     {!Board_tool_registry.tools} into the global {!Tool_dispatch}
-    registry via {!Tool_spec.register_all}.
-
-    Stage 10 split of lib/board_tool.ml. *)
-
-(* RFC-0189 PR-1b.4 — [handle_tool] is now typed end-to-end:
-   board handler modules (PR-1b.1/2/3) all return [Tool_result.result]
-   and the old per-arm projection pipes are gone. *)
+    registry via {!Tool_spec.register_all}. All handler arms return
+    {!Tool_result.result}. *)
 
 let handle_tool name args : Tool_result.result =
   let start_time = Time_compat.now () in
@@ -61,9 +56,7 @@ let handle_tool name args : Tool_result.result =
   | "masc_board_sub_board_delete" ->
     Board_tool_sub_board.handle_sub_board_delete ~tool_name:name ~start_time args
   | _ ->
-    (* RFC-0189 — unknown-tool fallback now carries an explicit
-       Workflow_rejection class (caller asked for a tool name not in
-       this dispatch table). *)
+    (* Direct callers receive a typed rejection for unrecognized names. *)
     Tool_result.make_err
       ~tool_name:name
       ~class_:Tool_result.Workflow_rejection
@@ -88,7 +81,7 @@ let register () =
       ~description:s.description
       ~module_tag:Tool_dispatch.Mod_inline
       ~input_schema:s.input_schema
-      ~handler_binding:(Shared handler)
+      ~handler_binding:(Registered handler)
       ~is_read_only:policy.readonly
       ~is_idempotent:policy.idempotent
       ~visibility:policy.visibility

--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -79,7 +79,7 @@ let tool_spec_read_only =
 ;;
 
 let register () =
-  let handler ~name ~args = Some (handle_tool name args) in
+  let handler ~name ~args = handle_tool name args in
   let make_spec board_name =
     let s = Board_tool_registry.schema_for_board_name board_name in
     let policy = Board_tool_registry.operation_policy board_name in

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -22,17 +22,6 @@ let with_dispatch_ro f = Eio_guard.with_mutex_ro dispatch_mu f
 let register ~tool_name ~(handler : handler) =
   with_dispatch_rw (fun () -> Hashtbl.replace registry tool_name handler)
 
-(** Bulk-register every tool name from a schema list to the same handler.
-    This is the primary registration path — it extracts names from the
-    module's published schemas, ensuring the registry is always in sync
-    with the advertised tool list. *)
-let register_module ~(schemas : Masc_domain.tool_schema list) ~(handler : handler) =
-  with_dispatch_rw (fun () ->
-    List.iter
-      (fun (schema : Masc_domain.tool_schema) ->
-        Hashtbl.replace registry schema.name handler)
-      schemas)
-
 (** {2 Dispatch Hooks And Observers}
 
     Pre-hooks run before the handler; observers run after the typed outcome is
@@ -40,7 +29,7 @@ let register_module ~(schemas : Masc_domain.tool_schema list) ~(handler : handle
     Multiple hooks are supported — they execute in registration order.
 
     - Pre-hook returning [Some result] short-circuits (handler is skipped).
-      Use case: permission checks (Sprint 3), request logging.
+      Use cases include permission checks and request logging.
     - Dispatch observers receive the final typed outcome for telemetry,
       metrics, and audit logging. *)
 
@@ -155,22 +144,13 @@ let run_dispatch_observers
     (result : Tool_result.result option) : unit =
   List.iter (fun hook -> hook outcome result) !dispatch_observers
 
-(** RFC-0084 §2.2 + RFC-0085 PR-14 — Single dispatch entry.
-
-    Inlines what used to be a three-step file-private chain
-    ([dispatch] -> [dispatch_structured] -> [guarded_dispatch]) into
-    one function so the lifecycle reads top-to-bottom:
+(** Single dispatch entry. The lifecycle is:
 
       1. injected span wrapper         (4-tuple emission; identity by default,
                                          [Tool_telemetry.with_span] at runtime)
       2. pre-hook chain                (reject / coerce-args)
       3. registry lookup + handler     (handler exception capture)
-      4. observer fan-out              ([run_dispatch_observers])
-
-    PR-11 already removed the three-step chain from the public mli.
-    PR-14 finishes the consolidation by removing the file-private
-    indirection — each step had exactly one caller, so the layering
-    was pure overhead. *)
+      4. observer fan-out              ([run_dispatch_observers]) *)
 let guarded_dispatch ~(token : Tool_token.t) ~args () : Tool_result.result option =
   let result, _outcome =
     (* Injected telemetry span wrapper (default identity). The composition

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -4,12 +4,10 @@
     registry. Mutable handler registrations remain only for dispatch
     execution; they are not used for token validation or discovery. *)
 
-(** Unified handler type: every tool call is [name * args -> result option].
-    [None] means "this handler does not know this tool" (should not happen
-    when lookups go through the registry, but kept for compatibility).
-    RFC-0189 PR-2: handlers return the typed {!Tool_result.result}; the
-    legacy {!Tool_result.result} record is gone. *)
-type handler = name:string -> args:Yojson.Safe.t -> Tool_result.result option
+(** Registered handlers are total for their exact registry key. Missing
+    handlers are represented by the registry lookup, not by a second optional
+    result returned from a matched handler. *)
+type handler = name:string -> args:Yojson.Safe.t -> Tool_result.result
 
 (** Central registry — populated once during server initialisation. *)
 let registry : (string, handler) Hashtbl.t = Hashtbl.create 256
@@ -190,7 +188,7 @@ let guarded_dispatch ~(token : Tool_token.t) ~args () : Tool_result.result optio
           (match Hashtbl.find_opt registry name with
            | Some handler ->
              let start_time = Time_compat.now () in
-             (try handler ~name ~args:coerced_args
+             (try Some (handler ~name ~args:coerced_args)
               with
               | Eio.Cancel.Cancelled _ as e -> raise e
               | exn -> Some (Tool_result.make_err_of_exn ~tool_name:name ~start_time exn))

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -5,11 +5,10 @@
     registry. Mutable handler registrations remain only for dispatch
     execution; they are not used for token validation or discovery. *)
 
-(** Unified handler type: every tool call is [name * args -> result option].
-    [None] means "this handler does not know this tool". Handlers return
-    the typed {!Tool_result.result} directly — the legacy {!Tool_result.result}
-    record was retired in PR-2 of RFC-0189. *)
-type handler = name:string -> args:Yojson.Safe.t -> Tool_result.result option
+(** Registered handlers are total for their exact registry key. Missing
+    handlers are represented by the registry lookup performed by
+    {!guarded_dispatch}, not by the handler result. *)
+type handler = name:string -> args:Yojson.Safe.t -> Tool_result.result
 
 (** {1 Registration} *)
 

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -15,15 +15,10 @@ type handler = name:string -> args:Yojson.Safe.t -> Tool_result.result
 val register : tool_name:string -> handler:handler -> unit
 (** Register a single tool name to handler mapping. *)
 
-val register_module : schemas:Masc_domain.tool_schema list -> handler:handler -> unit
-(** Bulk-register every tool name from a schema list to the same handler. *)
-
 (** {1 Dispatch} *)
 
-(* RFC-0084 PR-11/14 — [dispatch] and [dispatch_structured] were removed from
-   the public surface and the file-private chain. External callers MUST use
-   [guarded_dispatch], which owns telemetry, pre-hooks, handler execution,
-   result transformation, and dispatch observer fan-out. *)
+(** [guarded_dispatch] owns telemetry, pre-hooks, handler execution, result
+    transformation, and dispatch observer fan-out. *)
 
 val mint_token : name:string -> (Tool_token.t, string) Result.t
 (** Mint a [Tool_token.t] whose name is present in the tag registry.
@@ -121,13 +116,12 @@ val guarded_dispatch
   -> args:Yojson.Safe.t
   -> unit
   -> Tool_result.result option
-(** RFC-0084 §2.2 — Single dispatch entry with 4-label telemetry.
+(** Single dispatch entry with typed telemetry.
 
     Owns the injected span wrapper ({!set_span_wrapper}, registered with
     [Tool_telemetry.with_span] at the composition root), the pre-hook chain,
     handler lookup, exception capture, result transformation, and observer
-    fan-out. The dispatch return is typed [Tool_result.result option]; the old
-    [dispatch]/[dispatch_structured] entry points are gone. *)
+    fan-out. [None] means that the token has no directly registered handler. *)
 
 (** {1 Introspection} *)
 

--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -1,12 +1,9 @@
 (** Tool_spec — Unified tool specification with compile-time safety.
 
-    See [tool_spec.mli] for documentation.
-
-    @since 2.196.0 *)
+    See [tool_spec.mli] for documentation. *)
 
 type handler_binding =
-  | Direct of Tool_dispatch.handler
-  | Shared of Tool_dispatch.handler
+  | Registered of Tool_dispatch.handler
   | Tag_dispatch
 
 type t = {
@@ -91,9 +88,9 @@ let register (spec : t) =
   (* 2. Tag + schema registry. An unclassified tool cannot reach this point. *)
   Tool_dispatch.register_module_tag
     ~schemas:[ to_tool_schema spec ] ~tag:spec.module_tag;
-  (* 3. Handler binding — auto-register Direct/Shared into Tool_dispatch *)
+  (* 3. Handler binding. *)
   (match spec.handler_binding with
-   | Direct h | Shared h ->
+   | Registered h ->
      Tool_dispatch.register ~tool_name:spec.name ~handler:h
    | Tag_dispatch -> ())
 

--- a/lib/tool_surface/tool_spec.mli
+++ b/lib/tool_surface/tool_spec.mli
@@ -1,10 +1,8 @@
 
 (** Tool_spec — Unified tool specification with compile-time safety.
 
-    Replaces scattered registration across 6 separate systems with a single
-    builder function and registration call. Required fields (name, description,
-    module_tag, input_schema) are mandatory labeled arguments — omitting any
-    of them is a compile error. Optional fields use fail-closed defaults.
+    Required fields (name, description, module_tag, input_schema) are mandatory
+    labeled arguments. Optional fields use fail-closed defaults.
 
     {b Usage:}
     {[
@@ -17,16 +15,13 @@
         ~is_idempotent:true
         ()
       let () = Tool_spec.register spec
-    ]}
-
-    @since 2.196.0 *)
+    ]} *)
 
 (** {1 Types} *)
 
 (** How a tool's handler is bound to the dispatch registry. *)
 type handler_binding =
-  | Direct of Tool_dispatch.handler
-  | Shared of Tool_dispatch.handler
+  | Registered of Tool_dispatch.handler
   | Tag_dispatch
 
 type t = {

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -3257,14 +3257,13 @@ let register_registered_dispatch_probe () =
   Tool_dispatch.register
     ~tool_name:registered_dispatch_probe_tool
     ~handler:(fun ~name ~args:_ ->
-      Some
-        (tool_ok ~tool_name:name
-           (Yojson.Safe.to_string
-              (`Assoc
-                [ ("ok", `Bool true)
-                ; ("tool", `String name)
-                ; ("route", `String "registered")
-                ]))))
+      tool_ok ~tool_name:name
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ ("ok", `Bool true)
+             ; ("tool", `String name)
+             ; ("route", `String "registered")
+             ])))
 
 let workflow_rejection_probe_tool = "test_keeper_workflow_rejection_probe"
 
@@ -3273,18 +3272,17 @@ let register_workflow_rejection_probe () =
   Tool_dispatch.register
     ~tool_name:workflow_rejection_probe_tool
     ~handler:(fun ~name ~args:_ ->
-      Some
-        (Tool_result.error
-           ~failure_class:(Some Tool_result.Workflow_rejection)
-           ~tool_name:name
-           ~start_time:(Unix.gettimeofday ())
-           workflow_rejection_message))
+      Tool_result.error
+        ~failure_class:(Some Tool_result.Workflow_rejection)
+        ~tool_name:name
+        ~start_time:(Unix.gettimeofday ())
+        workflow_rejection_message)
 
 let register_typed_outcome_probe name make_result =
   register_probe_schema name;
   Tool_dispatch.register
     ~tool_name:name
-    ~handler:(fun ~name ~args:_ -> Some (make_result name))
+    ~handler:(fun ~name ~args:_ -> make_result name)
 ;;
 
 let execute_registered_probe ~fixture ~name ~make_result =

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -29,10 +29,10 @@ let make_schema ?(props = []) name =
       `Assoc [ "type", `String "object"; "properties", `Assoc prop_entries ] }
 
 (** Helper: a handler that returns a successful result with "ok:<name>". *)
-let echo_handler ~name ~args:_ = Some (tool_ok ~tool_name:name ("ok:" ^ name))
+let echo_handler ~name ~args:_ = tool_ok ~tool_name:name ("ok:" ^ name)
 
 (** Helper: a handler that returns (false, "fail"). *)
-let fail_handler ~name:_ ~args:_ = Some (tool_error "fail")
+let fail_handler ~name:_ ~args:_ = tool_error "fail"
 
 (** Helper: register a tool in handler, tag, and schema registries.
     The validation pre-hook is fail-closed for schema-less tools. *)

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -69,28 +69,6 @@ let () =
                   ~name:"__test_dispatch_nonexistent_xyz"
               in
               check bool "is Error" true (Result.is_error result));
-          test_case "register_module bulk registers" `Quick (fun () ->
-              let schemas =
-                List.map make_schema
-                  [ "__test_bulk_a"; "__test_bulk_b"; "__test_bulk_c" ]
-              in
-              Tool_dispatch.register_module ~schemas ~handler:echo_handler;
-              Tool_dispatch.register_module_tag ~schemas ~tag:Mod_misc;
-              List.iter
-                (fun name ->
-                  check bool (name ^ " registered") true
-                    (Tool_dispatch.is_registered name))
-                [ "__test_bulk_a"; "__test_bulk_b"; "__test_bulk_c" ]);
-          test_case "register_module dispatches each name" `Quick (fun () ->
-              let token = match Tool_dispatch.mint_token ~name:"__test_bulk_b" with Ok t -> t | Error e -> Alcotest.fail e in
-              let result =
-                Tool_dispatch.guarded_dispatch ~token ~args:`Null ()
-              in
-              let tr = Option.get result in
-              let ok = (Tool_result.is_success tr) in
-              let msg = (Tool_result.message tr) in
-              check bool "ok" true ok;
-              check string "msg" "ok:__test_bulk_b" msg);
           test_case "handler-only registration does not authorize token" `Quick
             (fun () ->
               let tool = "__test_dispatch_handler_only" in
@@ -121,14 +99,22 @@ let () =
       ( "registry_queries",
         [
           test_case "is_registered reflects state" `Quick (fun () ->
-              check bool "bulk_a exists" true
-                (Tool_dispatch.is_registered "__test_bulk_a");
+              let tool = "__test_query_registered" in
+              register_full ~tool_name:tool ~handler:echo_handler ();
+              check bool "registered tool exists" true
+                (Tool_dispatch.is_registered tool);
               check bool "unknown absent" false
                 (Tool_dispatch.is_registered "__test_query_unknown"));
           test_case "registered_count >= registered tools" `Quick (fun () ->
-              (* We registered at least 5 tools above *)
-              check bool "count >= 5" true
-                (Tool_dispatch.registered_count () >= 5));
+              let before = Tool_dispatch.registered_count () in
+              register_full
+                ~tool_name:"__test_count_increment"
+                ~handler:echo_handler
+                ();
+              check int
+                "registration increments count"
+                (before + 1)
+                (Tool_dispatch.registered_count ()));
           test_case "all_registered_names enumerates registry" `Quick (fun () ->
               register_full ~tool_name:"__enum_check_xyz" ~handler:echo_handler ();
               let all = Tool_dispatch.all_registered_names () in

--- a/test/test_tool_hooks.ml
+++ b/test/test_tool_hooks.ml
@@ -43,7 +43,7 @@ let test_pre_hook_observes () =
     ~tool_name:"__hook_test"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (tool_ok "ok"));
+      tool_ok "ok");
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
     Tool_dispatch.Pass);
@@ -60,7 +60,7 @@ let test_pre_hook_short_circuits () =
     ~tool_name:"__hook_blocked"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (tool_ok "should not reach"));
+      tool_ok "should not reach");
   Tool_dispatch.register_pre_hook (fun ~name ~args:_ ->
     log_call "pre_block";
     Tool_dispatch.Reject
@@ -88,7 +88,7 @@ let test_multiple_pre_hooks_first_wins () =
     ~tool_name:"__hook_multi"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (tool_ok "ok"));
+      tool_ok "ok");
   (* First hook: observe only *)
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre1";
@@ -122,7 +122,7 @@ let test_dispatch_observer_observes () =
     ~tool_name:"__hook_observer"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (tool_ok "original"));
+      tool_ok "original");
   Tool_dispatch.register_dispatch_observer (fun outcome result ->
     match outcome, result with
     | Dispatch_outcome.Handled, Some _ -> log_call "observer"
@@ -140,7 +140,7 @@ let test_dispatch_observers_chain () =
   register_test_tool
     ~tool_name:"__hook_chain"
     ~handler:(fun ~name:_ ~args:_ ->
-      Some (tool_ok "0"));
+      tool_ok "0");
   Tool_dispatch.register_dispatch_observer (fun outcome result ->
     match outcome, result with
     | Dispatch_outcome.Handled, Some _ -> log_call "observer1"
@@ -166,7 +166,7 @@ let test_full_lifecycle () =
     ~tool_name:"__hook_full"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (tool_ok "data"));
+      tool_ok "data");
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
     Tool_dispatch.Pass);
@@ -185,7 +185,7 @@ let test_no_hooks_default () =
   register_test_tool
     ~tool_name:"__hook_none"
     ~handler:(fun ~name ~args:_ ->
-      Some (tool_ok ~tool_name:name "plain"));
+      tool_ok ~tool_name:name "plain");
   let token = match Tool_dispatch.mint_token ~name:"__hook_none" with Ok t -> t | Error e -> Alcotest.fail e in
   match Tool_dispatch.guarded_dispatch ~token ~args:`Null () with
   | Some r ->

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -250,7 +250,7 @@ let test_message_json_roundtrip () =
 let test_dispatch_structured () =
   (* Register a test handler *)
   register_test_tool ~tool_name:"__test_tool" ~handler:(fun ~name ~args:_ ->
-    Some (tool_ok ~tool_name:name {|{"result":"ok"}|}));
+    tool_ok ~tool_name:name {|{"result":"ok"}|});
   let token =
     match Tool_dispatch.mint_token ~name:"__test_tool" with
     | Ok t -> t

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -263,7 +263,7 @@ let () =
                 ~description:"direct handler test"
                 ~module_tag:Tool_dispatch.Mod_misc
                 ~input_schema:empty_schema
-                ~handler_binding:(Direct (fun ~name:_ ~args:_ -> Some (tool_ok "ok")))
+                ~handler_binding:(Direct (fun ~name:_ ~args:_ -> tool_ok "ok"))
                 ()
             in
             register_test_metadata name;

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -255,15 +255,15 @@ let () =
                not put a name in the handler registry. *)
             check bool "Tag_dispatch registers no direct handler" false
               (Tool_dispatch.is_registered "__test_spec_tag_dispatch"));
-          test_case "Direct binding registers handler" `Quick (fun () ->
-            let name = "__test_spec_direct_handler" in
+          test_case "registered binding registers handler" `Quick (fun () ->
+            let name = "__test_spec_registered_handler" in
             let spec =
               Tool_spec.create
                 ~name
-                ~description:"direct handler test"
+                ~description:"registered handler test"
                 ~module_tag:Tool_dispatch.Mod_misc
                 ~input_schema:empty_schema
-                ~handler_binding:(Direct (fun ~name:_ ~args:_ -> tool_ok "ok"))
+                ~handler_binding:(Registered (fun ~name:_ ~args:_ -> tool_ok "ok"))
                 ()
             in
             register_test_metadata name;

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -95,7 +95,7 @@ let test_token_name_readable () =
 let test_mint_token_registered () =
   let tool = "__test_token_registered" in
   register_test_tool ~tool_name:tool
-    ~handler:(fun ~name:_ ~args:_ -> Some (tool_ok "ok"));
+    ~handler:(fun ~name:_ ~args:_ -> tool_ok "ok");
   match Tool_dispatch.mint_token ~name:tool with
   | Ok token -> check string "name" tool token.name
   | Error e -> fail (Printf.sprintf "mint_token failed for registered tool: %s" e)
@@ -108,7 +108,7 @@ let test_mint_token_unregistered () =
 let test_dispatch_with_token () =
   let tool = "__test_token_dispatch" in
   register_test_tool ~tool_name:tool
-    ~handler:(fun ~name ~args:_ -> Some (tool_ok ~tool_name:name ("dispatched:" ^ name)));
+    ~handler:(fun ~name ~args:_ -> tool_ok ~tool_name:name ("dispatched:" ^ name));
   match Tool_dispatch.mint_token ~name:tool with
   | Error e -> fail e
   | Ok token ->


### PR DESCRIPTION
## Summary
- make exact registered handlers return `Tool_result.result`
- keep `guarded_dispatch`'s outer option for a missing direct handler
- use one `Tool_spec.Registered` handler binding
- remove the caller-free `Tool_dispatch.register_module` surface
- keep changed production documentation current-only

## Validation
- `git diff --check`
- `ocamlformat --check` on all changed OCaml files
- exact-tree searches confirm no `Tool_spec.Direct`, `Tool_spec.Shared`, or `Tool_dispatch.register_module` remains
- focused `scripts/dune-local.sh build test/test_tool_dispatch.exe test/test_tool_spec.exe` was refused by the resource guard because five unrelated bare Dune processes were active; the guard was not bypassed
- fresh exact-head CI pending
