### PR TITLE
fix(agent-core): close lifecycle outcome dispatch

### DIFF
--- a/packages/agent_core/lib/agent/agent_lifecycle_events.ml
+++ b/packages/agent_core/lib/agent/agent_lifecycle_events.ml
@@ -65,7 +65,7 @@ let publish_finished ~event_bus ~agent_name ~started ~current_run_id ~outcome ~e
           (Printf.sprintf "Event_bus.publish failed (%s)" label)
           [ Log.S ("error", Printexc.to_string exn) ]
     in
-    match outcome with
+    (match outcome with
      | Completed response ->
        publish
          "AgentCompleted"
@@ -86,7 +86,7 @@ let publish_finished ~event_bus ~agent_name ~started ~current_run_id ~outcome ~e
             { agent_name; task_id = started_run_id; result = Error error; elapsed });
        publish
          "AgentFailed"
-         (AgentFailed { agent_name; task_id = started_run_id; error; elapsed })
+         (AgentFailed { agent_name; task_id = started_run_id; error; elapsed }))
   | None, _ | Some _, None -> ()
 ;;
 


### PR DESCRIPTION
## Summary
- scope the nested lifecycle outcome match explicitly
- keep the no-bus and no-started-event arms on the outer match
- preserve typed completion, yield, input-required, and failure publication

## Validation
- `ocamlformat --check packages/agent_core/lib/agent/agent_lifecycle_events.ml`
- `scripts/dune-local.sh build packages/agent_core/test/test_agent_advanced.exe`
- `_build/default/packages/agent_core/test/test_agent_advanced.exe`: 17/17
- rebased onto current main `08867dcb22`; fresh exact-head CI pending
