### PR TITLE
refactor: require explicit tool failure classes

### DIFF
--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -52,7 +52,13 @@ let dispatch
   : Tool_result.result option
   =
   let start_time = Time_compat.now () in
-  let err msg = Tool_result.error ~tool_name:name ~start_time msg in
+  let err msg =
+    Tool_result.error
+      ~failure_class:Tool_result.Runtime_failure
+      ~tool_name:name
+      ~start_time
+      msg
+  in
   (* RFC-0189: separate *deliberate caller-misuse rejections* (wrong
      client, wrong surface, deprecated tool) from *runtime/dispatch
      errors* (Tool_local_runtime non-zero exit, try-catch fallback).
@@ -62,7 +68,7 @@ let dispatch
      boundary has no typed failure variant; message text remains opaque. *)
   let workflow_err msg =
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name:name ~start_time msg
   in
   (* Wrap dispatch in try-catch to normalize exceptions into error results.

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -552,7 +552,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     | Eio.Cancel.Cancelled _ as e -> raise e
     | Auth.Auth_config_error _ ->
       Tool_result.error
-        ~failure_class:(Some Tool_result.Runtime_failure)
+        ~failure_class:Tool_result.Runtime_failure
         ~tool_name:name
         ~start_time
         "Authentication configuration unavailable"
@@ -561,7 +561,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
          System NotInitialized.  [Runtime_failure] (caller
          cannot fix; the operator must initialise MASC). *)
       Tool_result.error
-        ~failure_class:(Some Tool_result.Runtime_failure)
+        ~failure_class:Tool_result.Runtime_failure
         ~tool_name:name ~start_time
         (Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
     | exn ->
@@ -576,7 +576,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
             now blanket Runtime preserves operator-visible
             severity (the existing log line stays ERROR). *)
          Tool_result.error
-           ~failure_class:(Some Tool_result.Runtime_failure)
+           ~failure_class:Tool_result.Runtime_failure
            ~tool_name:name ~start_time
            (Printf.sprintf "Internal error: %s" err_detail))
   in

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -399,7 +399,7 @@ let execute_tool_eio
                  | Mod_keeper_task ->
                    Some
                      (Tool_result.error
-                        ~failure_class:(Some Tool_result.Workflow_rejection)
+                        ~failure_class:Tool_result.Workflow_rejection
                         ~tool_name:name
                         ~start_time
                         (Printf.sprintf

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -30,7 +30,7 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
        The producer supplies [Workflow_rejection] explicitly; message text
        never participates in classification. *)
     Some (Tool_result.error
-            ~failure_class:(Some Tool_result.Workflow_rejection)
+            ~failure_class:Tool_result.Workflow_rejection
             ~tool_name ~start_time
             "Broadcast message cannot be empty")
   else
@@ -42,7 +42,7 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
        [tool_misc_web_fetch] / [tool_misc_web_search] for rate
        limits. *)
     Some (Tool_result.error
-            ~failure_class:(Some Tool_result.Transient_error)
+            ~failure_class:Tool_result.Transient_error
             ~tool_name ~start_time
             (Printf.sprintf "Rate limited. %d sec remaining." wait_secs))
   else

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2003,7 +2003,11 @@ let process_single_turn ~user_row_origin ~submission
           push_worker_event
             (Stream_terminal
                { status = Stream_error; body = detail; queued_outcome });
-          Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail
+          Tool_result.error
+            ~failure_class:Tool_result.Runtime_failure
+            ~tool_name:"masc_keeper_msg"
+            ~start_time
+            detail
         in
         let on_admitted =
           if queued_turn then Some on_queue_turn_admitted else None
@@ -2074,7 +2078,11 @@ let process_single_turn ~user_row_origin ~submission
                  ; body = detail
                  ; queued_outcome = None
                  });
-            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail
+            Tool_result.error
+              ~failure_class:Tool_result.Runtime_failure
+              ~tool_name:"masc_keeper_msg"
+              ~start_time
+              detail
         | None, Ok (`Deferred rejection) ->
             push_worker_event (Stream_queued_turn_deferred rejection);
             Tool_result.make_ok
@@ -2113,7 +2121,11 @@ let process_single_turn ~user_row_origin ~submission
                     ; body = detail
                     ; queued_outcome = None
                     });
-               Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail)
+               Tool_result.error
+                 ~failure_class:Tool_result.Runtime_failure
+                 ~tool_name:"masc_keeper_msg"
+                 ~start_time
+                 detail)
         | None, Ok (`Ran (true, body)) ->
           (match canonical_reply_payload_of_body ~redact_text body with
            | Error error ->
@@ -2181,7 +2193,11 @@ let process_single_turn ~user_row_origin ~submission
                       ; body = err
                       ; queued_outcome
                       });
-                 Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
+                 Tool_result.error
+                   ~failure_class:Tool_result.Runtime_failure
+                   ~tool_name:"masc_keeper_msg"
+                   ~start_time
+                   err
              | None ->
                  let tool_calls =
                    Keeper_stream_tool_accum.to_tool_calls worker_tool_accum
@@ -2362,6 +2378,7 @@ let process_single_turn ~user_row_origin ~submission
                            ; queued_outcome
                            });
                       Tool_result.error
+                        ~failure_class:Tool_result.Runtime_failure
                         ~tool_name:"masc_keeper_msg"
                         ~start_time
                         persist_error
@@ -2374,7 +2391,11 @@ let process_single_turn ~user_row_origin ~submission
                            ; body = detail
                            ; queued_outcome
                       });
-                      Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail
+                      Tool_result.error
+                        ~failure_class:Tool_result.Runtime_failure
+                        ~tool_name:"masc_keeper_msg"
+                        ~start_time
+                        detail
                   | Some (Deferred { rejection }) ->
                       push_worker_event (Stream_queued_turn_deferred rejection);
                       Tool_result.make_ok
@@ -2413,7 +2434,11 @@ let process_single_turn ~user_row_origin ~submission
                  ; body = err
                  ; queued_outcome = None
                  });
-            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
+            Tool_result.error
+              ~failure_class:Tool_result.Runtime_failure
+              ~tool_name:"masc_keeper_msg"
+              ~start_time
+              err
         | None, Ok (`Ran (false, err)) ->
             let persisted = persist_failure_reply err in
             let queued_outcome =
@@ -2431,7 +2456,11 @@ let process_single_turn ~user_row_origin ~submission
             push_worker_event
               (Stream_terminal
                  { status = Stream_error; body = err; queued_outcome });
-            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
+            Tool_result.error
+              ~failure_class:Tool_result.Runtime_failure
+              ~tool_name:"masc_keeper_msg"
+              ~start_time
+              err
         | None, Error err when queued_turn_not_started () ->
             push_worker_event
               (Stream_terminal
@@ -2439,7 +2468,11 @@ let process_single_turn ~user_row_origin ~submission
                  ; body = err
                  ; queued_outcome = None
                  });
-            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
+            Tool_result.error
+              ~failure_class:Tool_result.Runtime_failure
+              ~tool_name:"masc_keeper_msg"
+              ~start_time
+              err
         | None, Error err ->
             let persisted = persist_failure_reply err in
             let queued_outcome =
@@ -2457,7 +2490,11 @@ let process_single_turn ~user_row_origin ~submission
             push_worker_event
               (Stream_terminal
                  { status = Stream_error; body = err; queued_outcome });
-            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
+            Tool_result.error
+              ~failure_class:Tool_result.Runtime_failure
+              ~tool_name:"masc_keeper_msg"
+              ~start_time
+              err
   in
   let publish_inline_completion () =
     match !staged_completion with

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -89,7 +89,7 @@ and handle_transition ~tool_name ~start_time ctx args =
     (* RFC-0189: schema-rejection — operator passed an unknown
        argument name. [Workflow_rejection]. *)
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       (Printf.sprintf "Unknown argument(s): %s. Valid: %s"
         names (String.concat ", " transition_known_args))
@@ -102,7 +102,7 @@ and handle_transition ~tool_name ~start_time ctx args =
   if String.equal action_raw "" then
     (* RFC-0189: required-field violation. [Workflow_rejection]. *)
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       (Printf.sprintf "action is required (%s)" (String.concat ", " Masc_domain.valid_task_action_strings))
   else
@@ -110,7 +110,7 @@ and handle_transition ~tool_name ~start_time ctx args =
   | Error msg ->
       (* RFC-0189: caller passed an unknown action enum value. *)
       Tool_result.error
-        ~failure_class:(Some Tool_result.Workflow_rejection)
+        ~failure_class:Tool_result.Workflow_rejection
         ~tool_name ~start_time msg
   | Ok action ->
   let action_s = Masc_domain.task_action_to_string action in
@@ -218,7 +218,7 @@ and handle_transition ~tool_name ~start_time ctx args =
       (* RFC-0189: handoff_context parse error — caller passed
          malformed payload. *)
       Tool_result.error
-        ~failure_class:(Some Tool_result.Workflow_rejection)
+        ~failure_class:Tool_result.Workflow_rejection
         ~tool_name ~start_time error
   | Ok handoff_context ->
   if (=) action Masc_domain.Release && strict_release_requires_handoff task_opt
@@ -226,7 +226,7 @@ and handle_transition ~tool_name ~start_time ctx args =
   then
     (* RFC-0189: strict-release-without-handoff = workflow violation. *)
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       "Strict task release requires handoff_context.summary"
   else
@@ -413,38 +413,38 @@ let handle_update_priority ~tool_name ~start_time ctx args =
       (Printf.sprintf "Task %s priority: P%d → P%d" task_id old_priority new_priority)
   | Ok (Workspace.Not_found { task_id }) ->
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name
       ~start_time
       (Printf.sprintf "Task %s not found" task_id)
   | Error Workspace.Not_initialized ->
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name
       ~start_time
       "MASC workspace is not initialized"
   | Error (Workspace.Backlog_read_error detail) ->
     Tool_result.error
-      ~failure_class:(Some Tool_result.Transient_error)
+      ~failure_class:Tool_result.Transient_error
       ~tool_name
       ~start_time
       (Printf.sprintf "Task priority update could not read the backlog: %s" detail)
   | Error (Workspace.Backlog_write_error detail) ->
     Tool_result.error
-      ~failure_class:(Some Tool_result.Transient_error)
+      ~failure_class:Tool_result.Transient_error
       ~tool_name
       ~start_time
       (Printf.sprintf "Task priority update could not commit the backlog: %s" detail)
   | Error (Workspace.Lock_error error) ->
     Tool_result.error
-      ~failure_class:(Some Tool_result.Transient_error)
+      ~failure_class:Tool_result.Transient_error
       ~tool_name
       ~start_time
       (Printf.sprintf "Task priority update could not acquire the backlog lock: %s"
          (Masc_domain.masc_error_to_string error))
   | Error (Workspace.Unexpected_error detail) ->
     Tool_result.error
-      ~failure_class:(Some Tool_result.Runtime_failure)
+      ~failure_class:Tool_result.Runtime_failure
       ~tool_name
       ~start_time
       (Printf.sprintf "Task priority update failed: %s" detail)

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -67,7 +67,7 @@ let result_to_response ~tool_name ~start_time = function
   | Ok msg -> Tool_result.ok ~tool_name ~start_time msg
   | Error e ->
       Tool_result.error
-        ~failure_class:(Some Tool_result.Workflow_rejection)
+        ~failure_class:Tool_result.Workflow_rejection
         ~tool_name ~start_time
         (Masc_domain.masc_error_to_string e)
 
@@ -131,7 +131,7 @@ let handle_add_task ?created_by ~tool_name ~start_time ctx args =
     (* RFC-0189: schema rejection — operator passed unknown
        argument names. [Workflow_rejection]. *)
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       (Printf.sprintf
         "Unknown argument(s): %s. Valid: %s"
@@ -161,12 +161,12 @@ let handle_add_task ?created_by ~tool_name ~start_time ctx args =
      caller-input violations. [Workflow_rejection]. *)
   if String.equal trimmed_title "" then
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       "Task title cannot be empty or whitespace-only"
   else if priority < 1 || priority > 5 then
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       (Printf.sprintf "Priority must be between 1 and 5, got %d" priority)
   else if Option.is_some goal_id
@@ -180,7 +180,7 @@ let handle_add_task ?created_by ~tool_name ~start_time ctx args =
                        String.equal goal.id (Option.value ~default:"" goal_id)))
   then
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       (* DET-OK: same guarded branch — goal_id is [Some _]. *)
       (Printf.sprintf "Unknown goal_id '%s'" (Option.value ~default:"" goal_id))
@@ -188,7 +188,7 @@ let handle_add_task ?created_by ~tool_name ~start_time ctx args =
     match contract_result with
     | Error error ->
         Tool_result.error
-          ~failure_class:(Some Tool_result.Workflow_rejection)
+          ~failure_class:Tool_result.Workflow_rejection
           ~tool_name ~start_time error
     | Ok contract ->
         let add_result =
@@ -223,7 +223,7 @@ let handle_add_task ?created_by ~tool_name ~start_time ctx args =
              ()
          | Error err ->
            Tool_result.error
-             ~failure_class:(Some Tool_result.Workflow_rejection)
+             ~failure_class:Tool_result.Workflow_rejection
              ~tool_name
              ~start_time
              (Workspace.add_task_error_to_string err))
@@ -237,7 +237,7 @@ let handle_set_goal ~tool_name ~start_time ctx args =
   let unknown = unknown_args ~valid_keys args in
   if Stdlib.List.length unknown > 0 then
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       (Printf.sprintf "Unknown argument(s): %s. Valid: %s"
         (String.concat ", " unknown)
@@ -247,12 +247,12 @@ let handle_set_goal ~tool_name ~start_time ctx args =
     let goal_id = String.trim (get_string args "goal_id" "") in
     if String.equal task_id "" then
       Tool_result.error
-        ~failure_class:(Some Tool_result.Workflow_rejection)
+        ~failure_class:Tool_result.Workflow_rejection
         ~tool_name ~start_time
         "task_id is required and cannot be empty"
     else if String.equal goal_id "" then
       Tool_result.error
-        ~failure_class:(Some Tool_result.Workflow_rejection)
+        ~failure_class:Tool_result.Workflow_rejection
         ~tool_name ~start_time
         "goal_id is required and cannot be empty"
     else (
@@ -270,7 +270,7 @@ let handle_set_goal ~tool_name ~start_time ctx args =
           ()
       | Error err ->
         Tool_result.error
-          ~failure_class:(Some Tool_result.Workflow_rejection)
+          ~failure_class:Tool_result.Workflow_rejection
           ~tool_name ~start_time
           (Task_goal_assignment.set_task_goal_error_to_string err))
 
@@ -282,7 +282,7 @@ let handle_batch_add_tasks ?created_by ~tool_name ~start_time ctx args =
   in
   if Stdlib.List.length tasks_json = 0 then
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       "tasks array is empty or missing"
   else
@@ -334,7 +334,7 @@ let handle_batch_add_tasks ?created_by ~tool_name ~start_time ctx args =
   let errors = List.filter_map (function Error e -> Some e | Ok _ -> None) validated in
   if Stdlib.List.length errors > 0 then
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       (Printf.sprintf "Validation failed:\n%s" (String.concat "\n" errors))
   else
@@ -365,7 +365,7 @@ let handle_batch_add_tasks ?created_by ~tool_name ~start_time ctx args =
          ()
      | Error err ->
        Tool_result.error
-         ~failure_class:(Some Tool_result.Workflow_rejection)
+         ~failure_class:Tool_result.Workflow_rejection
          ~tool_name
          ~start_time
          (Workspace.batch_add_tasks_error_to_string err))
@@ -379,7 +379,7 @@ let handle_claim ~tool_name ~start_time ctx args =
      agent_name alone; gate added no real authorization. *)
   if Option.is_some (Json_util.assoc_member_opt "agent_role" args) then
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       "agent_role is no longer supported"
   else
@@ -493,7 +493,7 @@ let handle_claim_next ~tool_name ~start_time ctx _args =
        "no claimable task", "agent not allowed", "permission denied"
        — all caller-actionable. [Workflow_rejection]. *)
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time
       (Printf.sprintf "Error: %s" e)
 
@@ -513,13 +513,13 @@ let handle_release ~tool_name ~start_time ctx args =
    | Error error ->
        (* RFC-0189: handoff_context parse error from caller payload. *)
        Tool_result.error
-         ~failure_class:(Some Tool_result.Workflow_rejection)
+         ~failure_class:Tool_result.Workflow_rejection
          ~tool_name ~start_time error
    | Ok handoff_context ->
        if strict_release_requires_handoff task_opt && Option.is_none handoff_context
        then
          Tool_result.error
-           ~failure_class:(Some Tool_result.Workflow_rejection)
+           ~failure_class:Tool_result.Workflow_rejection
            ~tool_name ~start_time
            "Strict task release requires handoff_context.summary"
        else

--- a/lib/tool_types/tool_args.ml
+++ b/lib/tool_types/tool_args.ml
@@ -133,7 +133,11 @@ let ok_response fields =
 let error_result ?tool_name ?start_time msg =
   let tool_name = Option.value ~default:"" tool_name in
   let start_time = Option.value ~default:(Time_compat.now ()) start_time in
-  Tool_result.error ~tool_name ~start_time msg
+  Tool_result.error
+    ~failure_class:Tool_result.Workflow_rejection
+    ~tool_name
+    ~start_time
+    msg
 
 (** [Tool_result.result] error with machine-readable error code. *)
 let error_result_typed ?tool_name ?start_time ~code msg =
@@ -186,7 +190,12 @@ let get_int_required args key =
 let ( let*! ) r f =
   match r with
   | Ok v -> f v
-  | Error e -> Tool_result.error ~tool_name:"" ~start_time:(Time_compat.now ()) e
+  | Error e ->
+    Tool_result.error
+      ~failure_class:Tool_result.Workflow_rejection
+      ~tool_name:""
+      ~start_time:(Time_compat.now ())
+      e
 
 (** {1 Structured Field Validation}
 

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -215,12 +215,11 @@ let ok ~tool_name ~start_time message_str : result =
   Completed { data = `String message_str; metadata = None; tool_name; duration_ms }
 ;;
 
-let error ?(failure_class = None) ~tool_name ~start_time message_str : result =
+let error ~failure_class ~tool_name ~start_time message_str : result =
   let end_time = Time_compat.now () in
   let duration_ms = (end_time -. start_time) *. 1000.0 in
-  let class_ = Option.value ~default:Runtime_failure failure_class in
   Failed
-    { class_
+    { class_ = failure_class
     ; message = message_str
     ; data = `String message_str
     ; tool_name

--- a/lib/tool_types/tool_result.mli
+++ b/lib/tool_types/tool_result.mli
@@ -139,10 +139,10 @@ val is_failed : result -> bool
     must use {!make_ok} and pass [~data] directly. *)
 val ok : tool_name:string -> start_time:float -> string -> result
 
-(** Failure result with an opaque string body.  An absent explicit class
-    defaults to [Runtime_failure]; message contents never affect the class. *)
+(** Failure result with an opaque string body.  The producer must supply the
+    failure class explicitly; message contents never affect the class. *)
 val error
-  :  ?failure_class:tool_failure_class option
+  :  failure_class:tool_failure_class
   -> tool_name:string
   -> start_time:float
   -> string

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -494,7 +494,7 @@ let handle_heartbeat ~tool_name ~start_time ctx _args =
        resolve (bind the session, refresh credentials).
        [Workflow_rejection]. *)
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name ~start_time message
 ;;
 

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -329,7 +329,10 @@ let install () =
       let start_time = Time_compat.now () in
       match lookup_dispatch with
       | None ->
-        Tool_result.error ~tool_name:name ~start_time
+        Tool_result.error
+          ~failure_class:Tool_result.Workflow_rejection
+          ~tool_name:name
+          ~start_time
           (Printf.sprintf
              "unknown tool %s; this review offers only %s"
              name
@@ -337,7 +340,12 @@ let install () =
       | Some dispatch ->
         (match dispatch ~name ~args with
          | Ok output -> Tool_result.ok ~tool_name:name ~start_time output
-         | Error detail -> Tool_result.error ~tool_name:name ~start_time detail)
+         | Error detail ->
+           Tool_result.error
+             ~failure_class:Tool_result.Runtime_failure
+             ~tool_name:name
+             ~start_time
+             detail)
     in
     let dispatch_verdict ~name ~args =
       let start_time = Time_compat.now () in
@@ -350,6 +358,7 @@ let install () =
         in
         protocol_error_ref := Some detail;
         Tool_result.error
+          ~failure_class:Tool_result.Workflow_rejection
           ~tool_name:name
           ~start_time
           detail
@@ -369,6 +378,7 @@ let install () =
              "[anti-rationalization] structured verdict parse failed: %s"
              msg;
            Tool_result.error
+             ~failure_class:Tool_result.Workflow_rejection
              ~tool_name:name
              ~start_time
              (Printf.sprintf "Invalid verdict format: %s" msg))

--- a/test/test_dispatch_observer_validation_failure.ml
+++ b/test/test_dispatch_observer_validation_failure.ml
@@ -22,7 +22,7 @@ let mk_validation_failure ~tool_name =
   (* Mirrors the result Tool_input_validation.validate_args returns: an
      Error with class_ = Policy_rejection. *)
   Tool_result.error
-    ~failure_class:(Some Tool_result.Policy_rejection)
+    ~failure_class:Tool_result.Policy_rejection
     ~tool_name
     ~start_time:(Unix.gettimeofday ())
     "validation_failed: missing required field"

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -3052,6 +3052,7 @@ let workflow_rejection_message =
 let test_tool_result_does_not_infer_task_fsm_rejections_from_message () =
   let result =
     Tool_result.error
+      ~failure_class:Tool_result.Runtime_failure
       ~tool_name:"masc_transition"
       ~start_time:(Unix.gettimeofday ())
       workflow_rejection_message
@@ -3273,7 +3274,7 @@ let register_workflow_rejection_probe () =
     ~tool_name:workflow_rejection_probe_tool
     ~handler:(fun ~name ~args:_ ->
       Tool_result.error
-        ~failure_class:(Some Tool_result.Workflow_rejection)
+        ~failure_class:Tool_result.Workflow_rejection
         ~tool_name:name
         ~start_time:(Unix.gettimeofday ())
         workflow_rejection_message)

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -165,7 +165,7 @@ let test_to_oas_typed_error_ignores_json_metadata () =
 let test_to_oas_typed_result_preserves_workflow_rejection () =
   let tr =
     Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~failure_class:Tool_result.Workflow_rejection
       ~tool_name:"masc_transition"
       ~start_time:0.0
       "Invalid task state: submit_for_verification requires verification evidence"
@@ -181,7 +181,7 @@ let test_to_oas_typed_result_preserves_workflow_rejection () =
 let test_to_oas_typed_result_preserves_transient_failure_class () =
   let tr =
     Tool_result.error
-      ~failure_class:(Some Tool_result.Transient_error)
+      ~failure_class:Tool_result.Transient_error
       ~tool_name:"tool_search_files"
       ~start_time:0.0
       {|{"ok":false,"error":"mutex contention","failure_class":"transient_error","recoverable":true,"error_class":"transient_mutex_contention"}|}

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -48,6 +48,7 @@ let test_error_plain_string () =
   let start = Time_compat.now () in
   let r =
     Tool_result.error
+      ~failure_class:Tool_result.Runtime_failure
       ~tool_name:"masc_transition"
       ~start_time:start
       "Something went wrong"
@@ -63,6 +64,7 @@ let test_error_plain_string () =
 let test_plain_dispatch_failure_does_not_infer_from_message () =
   let r =
     Tool_result.error
+      ~failure_class:Tool_result.Runtime_failure
       ~tool_name:"masc_transition"
       ~start_time:0.0
       "[SystemError] IO error: Failed to acquire distributed lock for key: tasks:.backlog (50 attempts exhausted)"
@@ -79,7 +81,7 @@ let test_plain_dispatch_failure_does_not_infer_from_message () =
 let test_plain_dispatch_failure_honors_explicit_failure_class () =
   let r =
     Tool_result.error
-      ~failure_class:(Some Tool_result.Transient_error)
+      ~failure_class:Tool_result.Transient_error
       ~tool_name:"masc_transition"
       ~start_time:0.0
       "[SystemError] IO error: Failed to acquire distributed lock for key: tasks:.backlog"
@@ -134,6 +136,7 @@ let test_error_message_cannot_override_failure_class () =
   in
   let r =
     Tool_result.error
+      ~failure_class:Tool_result.Runtime_failure
       ~tool_name:"keeper_task_done"
       ~start_time:0.0
       message


### PR DESCRIPTION
## Summary
- make `Tool_result.error` require a concrete `tool_failure_class`
- remove every optional `Some` wrapper from failure-class arguments
- make validation/protocol rejections explicit and preserve existing runtime classifications at internal failure boundaries

## Why
A missing class previously silently became `Runtime_failure`, allowing producers to avoid committing to the canonical typed failure contract.

## Validation
- local build/tests not run; CI is authoritative