### PR TITLE
refactor: canonicalize tool handler bindings

### DIFF
--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -88,7 +88,7 @@ let register () =
       ~description:s.description
       ~module_tag:Tool_dispatch.Mod_inline
       ~input_schema:s.input_schema
-      ~handler_binding:(Shared handler)
+      ~handler_binding:(Registered handler)
       ~is_read_only:policy.readonly
       ~is_idempotent:policy.idempotent
       ~visibility:policy.visibility

--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -5,8 +5,7 @@
     @since 2.196.0 *)
 
 type handler_binding =
-  | Direct of Tool_dispatch.handler
-  | Shared of Tool_dispatch.handler
+  | Registered of Tool_dispatch.handler
   | Tag_dispatch
 
 type t = {
@@ -91,9 +90,9 @@ let register (spec : t) =
   (* 2. Tag + schema registry. An unclassified tool cannot reach this point. *)
   Tool_dispatch.register_module_tag
     ~schemas:[ to_tool_schema spec ] ~tag:spec.module_tag;
-  (* 3. Handler binding — auto-register Direct/Shared into Tool_dispatch *)
+  (* 3. Handler binding — register exact handlers into Tool_dispatch. *)
   (match spec.handler_binding with
-   | Direct h | Shared h ->
+   | Registered h ->
      Tool_dispatch.register ~tool_name:spec.name ~handler:h
    | Tag_dispatch -> ())
 

--- a/lib/tool_surface/tool_spec.mli
+++ b/lib/tool_surface/tool_spec.mli
@@ -25,8 +25,7 @@
 
 (** How a tool's handler is bound to the dispatch registry. *)
 type handler_binding =
-  | Direct of Tool_dispatch.handler
-  | Shared of Tool_dispatch.handler
+  | Registered of Tool_dispatch.handler
   | Tag_dispatch
 
 type t = {

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -255,7 +255,7 @@ let () =
                not put a name in the handler registry. *)
             check bool "Tag_dispatch registers no direct handler" false
               (Tool_dispatch.is_registered "__test_spec_tag_dispatch"));
-          test_case "Direct binding registers handler" `Quick (fun () ->
+          test_case "Registered binding registers handler" `Quick (fun () ->
             let name = "__test_spec_direct_handler" in
             let spec =
               Tool_spec.create
@@ -263,7 +263,7 @@ let () =
                 ~description:"direct handler test"
                 ~module_tag:Tool_dispatch.Mod_misc
                 ~input_schema:empty_schema
-                ~handler_binding:(Direct (fun ~name:_ ~args:_ -> tool_ok "ok"))
+                ~handler_binding:(Registered (fun ~name:_ ~args:_ -> tool_ok "ok"))
                 ()
             in
             register_test_metadata name;


### PR DESCRIPTION
## Summary
- replace behaviorally identical `Direct` and `Shared` handler bindings with one `Registered` constructor
- keep `Tag_dispatch` as the only structurally distinct routing mode
- update Board registration and the binding contract test

## Why
`Direct` and `Shared` carried the same handler type and executed the same `Tool_dispatch.register` branch, so the distinction was descriptive only and could drift from runtime truth.

## Validation
- local build/tests not run; CI is authoritative