### PR TITLE
Keeper owner foundation and metadata hard cut

### DIFF
--- a/docs/EXECUTE-RUNBOOK.md
+++ b/docs/EXECUTE-RUNBOOK.md
@@ -1,6 +1,6 @@
 ---
 status: runbook
-last_verified: 2026-06-11
+last_verified: 2026-08-09
 code_refs:
   - lib/core/exec_buffer.ml
   - lib/exec_core.ml
@@ -8,7 +8,8 @@ code_refs:
   - lib/process/process_eio.ml
   - lib/exec/command_gate/shell_command_gate.ml
   - lib/exec_policy/exec_policy.ml
-  - lib/keeper/keeper_tool_command_runtime.ml
+  - lib/keeper/keeper_tool_execute_runtime.ml
+  - lib/keeper/keeper_workspace_ops.ml
 ---
 
 # Execute Runbook

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -1,7 +1,7 @@
 # Keeper Tool Boundary Matrix
 
 Status: P0 ratchet source for keeper agent tool boundaries.
-Last updated: 2026-07-12.
+Last updated: 2026-08-09.
 
 This matrix freezes the owner map for keeper modules that participate in the
 agent tool path. A new file in scope must be added here with exactly one owner
@@ -48,8 +48,6 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_registered_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_shared_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_shared_runtime.mli` - execution-dispatch
-- `lib/keeper/keeper_tool_command_runtime.ml` - execution-dispatch
-- `lib/keeper/keeper_tool_command_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_task_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_task_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_voice_runtime.ml` - execution-dispatch

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -165,7 +165,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0233 | Typed turn observability: TurnRecord prompt-block provenance + canonical tool... | Draft | - |
 | 0235 | Stale-base revert guard: block PRs that silently revert recently-merged work (`RFC-0235-stale-base-revert-guard.md`)<br>Voice output transport: browser-addressed audio delivery with device-routed p... (`RFC-0235-voice-output-browser-transport-device-routing.md`) | Draft<br>Draft | - |
 | 0236 | Voice input transport: browser-captured speech-to-text for the dashboard comp... | Draft | - |
-| 0237 | Eliminate the write_meta ~force escape hatch (route snapshot writes through C... | Draft | - |
+| 0237 | Eliminate the write_meta ~force escape hatch (route snapshot writes through C... | Implemented | - |
 | 0239 | Concurrency ownership model (per-site mutex/atomic → protection by construction) | Draft | - |
 | 0240 | Tool-pair invariant enforced at write-time (eliminate repair-on-read) | Draft | - |
 | 0243 | Memory OS confidence mutability via write-side fact upsert | Draft | - |

--- a/docs/rfc/RFC-0225-per-keeper-turn-single-flight.md
+++ b/docs/rfc/RFC-0225-per-keeper-turn-single-flight.md
@@ -4,6 +4,7 @@ title: "Per-keeper turn single-flight admission"
 status: Draft
 relates: "RFC-0153 (tier admission), 2026-06-10 voice repeat RCA (~/me/reports/2026-06-10-masc-voice-repeat-rca.md)"
 date: 2026-06-10
+updated: 2026-08-09
 ---
 
 # RFC-0225: Per-keeper turn single-flight admission
@@ -49,6 +50,18 @@ Measured on 2026-06-10 (sangsu, session `trace-1780648779957-00000`): a
 - Not a turn scheduler redesign; RFC-0153 tier admission stays as-is.
 
 ## 3. Design
+
+### 3.0 Current implementation boundary
+
+`Keeper_owner`, `Keeper_owner_reducer`, and `Keeper_owner_registry` now provide
+the per-Keeper actor core, bounded mailbox, immutable projection, and closed
+metadata command set. Server-root inventory installation and selected metadata
+writers are routed through that owner.
+
+The hard cut is not complete: `Keeper_owner.start_turn` has no production
+caller yet, and direct metadata writers remain. Therefore this RFC stays Draft;
+the existence of the actor core is not evidence that every heartbeat, chat,
+MCP, and board-reactive turn passes one admission point.
 
 ### 3.1 Single admission point
 

--- a/docs/rfc/RFC-0237-write-meta-force-escape-hatch-removal.md
+++ b/docs/rfc/RFC-0237-write-meta-force-escape-hatch-removal.md
@@ -1,15 +1,24 @@
 ---
 rfc: "0237"
 title: "Eliminate the write_meta ~force escape hatch (route snapshot writes through CAS+merge)"
-status: Draft
+status: Implemented
 created: 2026-06-14
-updated: 2026-06-14
+updated: 2026-08-09
 author: vincent
 supersedes: []
 related: ["RFC-0225"]
 ---
 
 # RFC-0237 — Eliminate the `write_meta ~force` escape hatch
+
+## Current authority
+
+The `~force` escape hatch is removed. CAS plus monotonic merge remains the
+persistence backstop for writers that have not yet moved, while the ongoing
+single-owner hard cut routes migrated mutations through closed
+`Keeper_owner_reducer.meta_command` values and publishes only after persistence
+succeeds. Direct `Keeper_meta_store` writers are migration inventory, not a
+second canonical mutation authority.
 
 ## §1 Problem (evidence-grounded)
 

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -26,6 +26,8 @@ Keeper는 MASC의 자율 에이전트 하네스(harness)다. OAS `Agent.run` 위
 
 Keeper 하나는 다음을 소유한다:
 - **identity**: `keeper_meta` 레코드 (이름, keeper, instructions, typed goal/task links)
+- **mutation serialization**: process-root `Keeper_owner` actor가 설치된 경로의
+  metadata command와 immutable projection
 - **context**: `working_context` (system prompt + messages + token count + OAS context)
 - **memory**: Memory OS fact/episode store (legacy memory bank 제거 — RFC keeper-memory-consolidation Stage 4)
 - **lifecycle**: heartbeat fiber + supervisor + checkpoint store
@@ -74,7 +76,19 @@ graph LR
 | Turn Execution | `keeper_agent_run.ml`, `keeper_unified_turn.ml`, `keeper_tools_oas.ml`, `keeper_hooks_oas.ml` | 4 |
 | Supervision | `keeper_supervisor.ml`, `keeper_keepalive.ml`, `keeper_world_observation.ml` | 3 |
 | MCP Surface | `keeper_turn.ml`, `keeper_status.ml`, `keeper_keeper.ml`, `keeper_schema.ml` | 4 |
+| Ownership | `keeper_owner.ml`, `keeper_owner_reducer.ml`, `keeper_owner_registry.ml` | 3 |
 | Alerting / Metrics | `keeper_alerting*.ml`, `keeper_status_runtime*.ml`, `keeper_status_detail.ml` | 6+ |
+
+### 2.2 Single-owner 전환 상태
+
+서버 root는 Keeper별 bounded-mailbox owner actor를 설치하고, task binding처럼
+전환된 metadata mutation은 closed `Keeper_owner_reducer.meta_command`를 통해
+persist 후 immutable projection으로 publish한다. 임의의 snapshot mutation 함수,
+호환 facade, dual-write 경로는 두지 않는다.
+
+이 전환은 아직 진행 중이다. `Keeper_owner.start_turn`의 production entry-point
+배선과 남은 direct `Keeper_meta_store` writer 제거가 끝나기 전에는 turn
+single-flight가 런타임 전체에 적용됐다고 간주하지 않는다.
 
 ---
 
@@ -271,6 +285,9 @@ Triage -> BudgetCheck -> (ModelDeliberation | DeterministicBaseline) -> Execute 
 3. `unified_turn.run_keeper_cycle` -> `build_prompt` + `run_turn`
 4. `update_metrics_from_result` -> keeper_meta 갱신
 5. `write_meta` -> 메타데이터 영속화
+
+현재 이 turn-result writer는 single-owner 전환 대상이다. 반면 task binding은
+이미 `Keeper_owner_registry.apply_meta`의 typed command를 통해 persist/publish된다.
 
 ### 5.3 OAS 통합 구성
 

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -41,9 +41,6 @@ type tool_surface_metrics =
 let owned_active_task_id_for_meta =
   Keeper_current_task_reconcile.owned_active_task_id_for_meta
 
-let merge_current_task_id =
-  Keeper_current_task_reconcile.merge_current_task_id
-
 let sync_current_task_id_from_backlog =
   Keeper_current_task_reconcile.sync_current_task_id_from_backlog
 

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -1,4 +1,4 @@
-(** Keeper turn-lane telemetry and backlog task reconciliation. *)
+(** Keeper turn-lane telemetry. *)
 
 (* Closed sum type for turn_lane.  Two producers emit values:
    - keeper_run_tools.ml emits the per-turn lanes
@@ -37,12 +37,3 @@ type tool_surface_metrics =
   ; config_root : string
   ; runtime_config_path : string option
   }
-
-let owned_active_task_id_for_meta =
-  Keeper_current_task_reconcile.owned_active_task_id_for_meta
-
-let sync_current_task_id_from_backlog =
-  Keeper_current_task_reconcile.sync_current_task_id_from_backlog
-
-let sync_current_task_id_for_agent_name =
-  Keeper_current_task_reconcile.sync_current_task_id_for_agent_name

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -1,4 +1,4 @@
-(** Keeper turn-lane telemetry and backlog task reconciliation. *)
+(** Keeper turn-lane telemetry. *)
 
 (** Per-turn lane classification.  Closed sum type; the OCaml side
     pins the alphabet emitted by keeper_run_tools
@@ -26,22 +26,3 @@ type tool_surface_metrics =
   ; config_root : string
   ; runtime_config_path : string option
   }
-
-(** Find the active task ID a keeper currently owns. *)
-val owned_active_task_id_for_meta :
-  config:Workspace.config ->
-  meta:Keeper_meta_contract.keeper_meta ->
-  Keeper_id.Task_id.t option
-
-(** Reconcile [meta.current_task_id] with the backlog. *)
-val sync_current_task_id_from_backlog :
-  config:Workspace.config ->
-  Keeper_meta_contract.keeper_meta ->
-  Keeper_meta_contract.keeper_meta
-
-(** Best-effort reconciliation for callers that only know an agent name.
-    No-ops for non-keeper agents. *)
-val sync_current_task_id_for_agent_name :
-  config:Workspace.config ->
-  agent_name:string ->
-  unit

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -33,12 +33,6 @@ val owned_active_task_id_for_meta :
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_id.Task_id.t option
 
-(** Field-level merge for [write_meta_with_merge]. *)
-val merge_current_task_id :
-  latest:Keeper_meta_contract.keeper_meta ->
-  caller:Keeper_meta_contract.keeper_meta ->
-  Keeper_meta_contract.keeper_meta
-
 (** Reconcile [meta.current_task_id] with the backlog. *)
 val sync_current_task_id_from_backlog :
   config:Workspace.config ->

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -247,63 +247,6 @@ val find_matching_rule :
   (rule_lookup, rule_store_error) result
 
 val generate_id : unit -> string
-val recent_resolved_history_limit : int
-val recent_resolved_max_limit : int
-val recent_resolved_default_window_minutes : int
-val recent_resolved_min_window_minutes : int
-val recent_resolved_max_window_minutes : int
-
-val read_recent_audit :
-  base_path:string -> ?keeper_name:string -> ?n:int -> unit -> Yojson.Safe.t list
-
-val audit_day_string_of_ts : float -> string
-(** Day key ["YYYY-MM-DD"] for the [YYYY-MM/DD.jsonl] audit layout. Exposed as
-    a pure function so the UTC invariant is testable: the write path
-    ([Jsonl_writer.dated_path]) picks the day file with [Unix.gmtime], so a
-    local-time key would read the wrong file for the hours where the two
-    calendars disagree. *)
-
-type resolved_history =
-  { resolved_rows : Yojson.Safe.t list
-  ; resolved_matched : int
-  ; resolved_limit : int
-  ; resolved_window_minutes : int
-  ; resolved_scan_exhausted : bool
-  }
-(** A page of resolved Gate decisions together with the bounds that produced
-    it. [resolved_rows] is newest first and holds at most [resolved_limit]
-    entries; [resolved_matched] counts every resolved decision the scan saw
-    inside the window, so [resolved_matched > resolved_limit] means the page is
-    a slice rather than the whole window. [resolved_scan_exhausted] reports the
-    second bound: the physical row cap stopped the scan before it reached the
-    window start, so even [resolved_matched] undercounts. Rendering only
-    [resolved_rows] reintroduces the silent truncation this type removes. *)
-
-val list_recent_resolved :
-  base_path:string ->
-  now_ts:float ->
-  ?limit:int ->
-  ?window_minutes:int ->
-  unit ->
-  resolved_history
-(** [list_recent_resolved ~base_path ~now_ts ()] returns resolved Gate decisions
-    from the last [window_minutes] (default
-    {!recent_resolved_default_window_minutes}, clamped to
-    [[recent_resolved_min_window_minutes, recent_resolved_max_window_minutes]]),
-    newest first, capped at [limit] (default
-    {!recent_resolved_history_limit}, clamped to
-    [[0, recent_resolved_max_limit]]).
-
-    [now_ts] is supplied by the caller rather than read here, matching
-    {!Dashboard_gate_metrics.tool_rejection_counts}: the observation boundary
-    captures the clock once for the whole projection, and this function stays
-    deterministic so a test can pin an exact window.
-
-    Rows without a [ts] are excluded: a wall-clock window cannot place an
-    undated decision, and dating it by guesswork would misreport history.
-
-    Storage failures are reported through the approval-queue failure metric and
-    yield an empty page rather than raising. *)
 
 module For_testing : sig
   type strict_snapshot_writer =

--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -138,14 +138,6 @@ let owned_active_task_id_for_meta ~(config : Workspace.config)
   | Ok task_id -> task_id
   | Error _ -> None
 
-let merge_current_task_id ~(latest : Keeper_meta_contract.keeper_meta)
-    ~(caller : Keeper_meta_contract.keeper_meta) =
-  {
-    latest with
-    current_task_id = caller.current_task_id;
-    updated_at = caller.updated_at;
-  }
-
 let sync_current_task_id_from_backlog ~(config : Workspace.config)
     (meta : Keeper_meta_contract.keeper_meta) =
   match owned_active_task_id_result_for_meta ~config ~meta with
@@ -163,42 +155,43 @@ let sync_current_task_id_from_backlog ~(config : Workspace.config)
     in
     if equal then meta
     else
-      let updated_meta =
-        { meta with current_task_id = desired; updated_at = Masc_domain.now_iso () }
-      in
-      Keeper_registry.update_meta ~base_path:config.base_path meta.name updated_meta;
       (match
-         Keeper_meta_store.write_meta_with_merge
-           ~merge:merge_current_task_id config updated_meta
+         Keeper_owner_registry.apply_meta
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           (Keeper_owner_reducer.Set_current_task
+              { task_id = desired; updated_at = Masc_domain.now_iso () })
        with
-       | Ok () -> ()
-       | Error msg ->
+       | Ok (Some updated_meta) ->
+         Log.Keeper.debug
+           ~keeper_name:meta.name
+           "reconciled current_task_id=%s from backlog ownership"
+           (match desired with
+            | Some task_id -> Keeper_id.Task_id.to_string task_id
+            | None -> "(cleared)");
+         updated_meta
+       | Ok None ->
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string WriteMetaFailures)
-           ~labels:[("keeper", meta.name); ("phase", "reconcile_task_id")]
+           ~labels:[ "keeper", meta.name; "phase", "reconcile_task_id" ]
            ();
-         Log.Keeper.warn ~keeper_name:meta.name
+         Log.Keeper.warn
+           ~keeper_name:meta.name
+           "owner removed metadata while reconciling current_task_id";
+         meta
+       | Error error ->
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string WriteMetaFailures)
+           ~labels:[ "keeper", meta.name; "phase", "reconcile_task_id" ]
+           ();
+         Log.Keeper.warn
+           ~keeper_name:meta.name
            "failed to persist reconciled current_task_id=%s: %s"
            (match desired with
             | Some task_id -> Keeper_id.Task_id.to_string task_id
             | None -> "(cleared)")
-           (Keeper_meta_store.write_meta_error_to_string msg));
-      (* RFC-0142 / audit 2026-05-21 §10.2: this is the success path of a
-         routine drift correction, firing on every observed delta between
-         keeper_meta.current_task_id and backlog ownership.  Live measurement
-         on 5/21 captured 1,183 events/day across the fleet — none of them
-         individually actionable (the WARN branch above + the
-         [metric_keeper_write_meta_failures] counter already cover the
-         failure case).  Demoted to DEBUG so the high-volume verbose path
-         no longer drowns the INFO stream; raise back to INFO only if a
-         per-keeper thrash investigation needs structured timing without
-         a debug-level subscription. *)
-      Log.Keeper.debug ~keeper_name:meta.name
-        "reconciled current_task_id=%s from backlog ownership"
-        (match desired with
-         | Some task_id -> Keeper_id.Task_id.to_string task_id
-         | None -> "(cleared)");
-      updated_meta
+           (Keeper_owner_registry.command_error_to_string error);
+         meta)
 
 let sync_current_task_id_for_agent_name ~(config : Workspace.config) ~agent_name =
   match

--- a/lib/keeper/keeper_current_task_reconcile.mli
+++ b/lib/keeper/keeper_current_task_reconcile.mli
@@ -45,12 +45,6 @@ val owned_active_task_id_for_meta :
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_id.Task_id.t option
 
-(** Field-level merge for [Keeper_meta_store.write_meta_with_merge]. *)
-val merge_current_task_id :
-  latest:Keeper_meta_contract.keeper_meta ->
-  caller:Keeper_meta_contract.keeper_meta ->
-  Keeper_meta_contract.keeper_meta
-
 (** Persist [meta.current_task_id] after comparing it with backlog ownership. *)
 val sync_current_task_id_from_backlog :
   config:Workspace.config ->

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -1486,9 +1486,15 @@ let observe_exact_rule_store_degraded (request : request) error =
     ()
 ;;
 
+let canonical_rule_match (rule_match : Keeper_approval_queue.rule_match)
+  : Keeper_approval_queue_rules_types.rule_match
+  =
+  { rule_id = rule_match.rule_id }
+;;
+
 let observe_exact_rule_expired
       (request : request)
-      (rule_match : Keeper_approval_queue.rule_match)
+      (rule_match : Keeper_approval_queue_rules_types.rule_match)
   =
   Log.Keeper.warn
     ~keeper_name:request.keeper_name
@@ -1553,6 +1559,7 @@ let decide_without_cycle_grant ~keeper_always_allow request =
           observe_exact_rule_store_degraded request error;
           decide_from_selected_mode request mode
         | Ok (Keeper_approval_queue.Rule_match_active rule_match) ->
+          let rule_match = canonical_rule_match rule_match in
           let source = Exact_always_rule rule_match.rule_id in
           audit_allow
             request
@@ -1561,6 +1568,7 @@ let decide_without_cycle_grant ~keeper_always_allow request =
             source;
           Allow { source }
         | Ok (Keeper_approval_queue.Rule_match_expired rule_match) ->
+          let rule_match = canonical_rule_match rule_match in
           observe_exact_rule_expired request rule_match;
           decide_from_selected_mode request mode
         | Ok Keeper_approval_queue.Rule_match_absent ->

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -208,21 +208,7 @@ let sync_keeper_presence
       ~labels:[ "keeper", meta_current.name ]
       ();
     note_turn_failures_preserved_after_heartbeat ~ctx ~meta:meta_current;
-    match
-      write_meta_with_merge
-        ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-        ctx.config
-        synced
-    with
-    | Ok () -> synced
-    | Error e ->
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string WriteMetaFailures)
-        ~labels:[ "keeper", synced.name; "phase", "heartbeat" ]
-        ();
-      Log.Keeper.warn "write_meta failed (heartbeat): %s"
-        (Keeper_meta_store.write_meta_error_to_string e);
-      synced
+    synced
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -21,6 +21,7 @@ type turn_request =
 
 type child_outcome =
   | Child_succeeded
+  | Child_cancelled of string
   | Child_failed of string
 
 type _ command =
@@ -107,17 +108,25 @@ let notify_child_finished t ~operation_id outcome =
 ;;
 
 let run_child t request =
-  let outcome =
+  let outcome, cancellation =
     match Eio.Switch.run (fun turn_sw -> request.run turn_sw) with
-    | () -> Child_succeeded
-    | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-    | exception exn -> Child_failed (Printexc.to_string exn)
+    | () -> Child_succeeded, None
+    | exception (Eio.Cancel.Cancelled cause as exn) ->
+      Child_cancelled (Printexc.to_string cause), Some exn
+    | exception exn -> Child_failed (Printexc.to_string exn), None
   in
-  notify_child_finished t ~operation_id:request.operation_id outcome
+  Eio.Cancel.protect (fun () ->
+    notify_child_finished t ~operation_id:request.operation_id outcome);
+  Option.iter Stdlib.raise cancellation
 ;;
 
 let log_child_failure operation_id = function
   | Child_succeeded -> ()
+  | Child_cancelled detail ->
+    Log.Keeper.info
+      "keeper_owner: child turn cancelled operation_id=%s reason=%s"
+      operation_id
+      detail
   | Child_failed detail ->
     Log.Keeper.error
       "keeper_owner: child turn failed operation_id=%s error=%s"

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -2,7 +2,7 @@ let mailbox_capacity = 128
 
 type store =
   { replace : Keeper_meta_contract.keeper_meta -> (unit, string) result
-  ; remove : unit -> (unit, string) result
+  ; remove : Keeper_meta_contract.keeper_meta -> (unit, string) result
   }
 
 type error =
@@ -70,8 +70,8 @@ let commit store transition =
     (match store.replace meta with
      | Ok () -> Ok transition.state
      | Error detail -> Error (Store_unavailable detail))
-  | Remove_snapshot ->
-    (match store.remove () with
+  | Remove_snapshot meta ->
+    (match store.remove meta with
      | Ok () -> Ok transition.state
      | Error detail -> Error (Store_unavailable detail))
 ;;

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -1,0 +1,223 @@
+let mailbox_capacity = 128
+
+type store =
+  { replace : Keeper_meta_contract.keeper_meta -> (unit, string) result
+  ; remove : unit -> (unit, string) result
+  }
+
+type error =
+  | Reducer_rejected of Keeper_owner_reducer.error
+  | Store_unavailable of string
+  | Owner_closed
+
+type turn_start =
+  | Started
+  | Busy of { running_operation_id : string }
+
+type turn_request =
+  { operation_id : string
+  ; run : Eio.Switch.t -> unit
+  }
+
+type child_outcome =
+  | Child_succeeded
+  | Child_failed of string
+
+type _ command =
+  | Exact_projection :
+      (Keeper_owner_reducer.projection, error) result command
+  | Apply_meta :
+      Keeper_owner_reducer.meta_command
+      -> (Keeper_meta_contract.keeper_meta option, error) result command
+  | Start_turn : turn_request -> (turn_start, error) result command
+  | Child_finished :
+      { operation_id : string
+      ; outcome : child_outcome
+      }
+      -> (unit, error) result command
+  | Begin_stopping : (unit, error) result command
+
+type packed_command =
+  | Command : 'response command * 'response Eio.Promise.u -> packed_command
+
+type t =
+  { mailbox : packed_command Eio.Stream.t
+  ; projection : Keeper_owner_reducer.projection Atomic.t
+  ; closed : bool Atomic.t
+  }
+
+let error_to_string = function
+  | Reducer_rejected error -> Keeper_owner_reducer.error_to_string error
+  | Store_unavailable detail -> "keeper owner store unavailable: " ^ detail
+  | Owner_closed -> "keeper owner is closed"
+;;
+
+let projection t = Atomic.get t.projection
+
+let request t command =
+  if Atomic.get t.closed
+  then Error Owner_closed
+  else (
+    let response, resolve = Eio.Promise.create () in
+    Eio.Stream.add t.mailbox (Command (command, resolve));
+    Eio.Promise.await response)
+;;
+
+let commit store transition =
+  match transition.Keeper_owner_reducer.persistence with
+  | Keeper_owner_reducer.No_persistence -> Ok transition.state
+  | Replace_snapshot meta ->
+    (match store.replace meta with
+     | Ok () -> Ok transition.state
+     | Error detail -> Error (Store_unavailable detail))
+  | Remove_snapshot ->
+    (match store.remove () with
+     | Ok () -> Ok transition.state
+     | Error detail -> Error (Store_unavailable detail))
+;;
+
+let publish_effect t = function
+  | Keeper_owner_reducer.Publish_projection projection ->
+    Atomic.set t.projection projection
+  | Start_turn_child _ -> ()
+;;
+
+let apply_transition t store old_state transition =
+  match commit store transition with
+  | Error error -> Error (old_state, error)
+  | Ok state ->
+    List.iter (publish_effect t) transition.effects;
+    Ok state
+;;
+
+let transition_starts_child transition operation_id =
+  List.exists
+    (function
+      | Keeper_owner_reducer.Start_turn_child { operation_id = effect_operation_id } ->
+        String.equal effect_operation_id operation_id
+      | Publish_projection _ -> false)
+    transition.Keeper_owner_reducer.effects
+;;
+
+let notify_child_finished t ~operation_id outcome =
+  match request t (Child_finished { operation_id; outcome }) with
+  | Ok () -> ()
+  | Error Owner_closed -> ()
+  | Error (Reducer_rejected _ | Store_unavailable _) -> ()
+;;
+
+let run_child t request =
+  let outcome =
+    match Eio.Switch.run (fun turn_sw -> request.run turn_sw) with
+    | () -> Child_succeeded
+    | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+    | exception exn -> Child_failed (Printexc.to_string exn)
+  in
+  notify_child_finished t ~operation_id:request.operation_id outcome
+;;
+
+let log_child_failure operation_id = function
+  | Child_succeeded -> ()
+  | Child_failed detail ->
+    Log.Keeper.error
+      "keeper_owner: child turn failed operation_id=%s error=%s"
+      operation_id
+      detail
+;;
+
+let start ~sw ~store ~initial_meta =
+  let initial_state = Keeper_owner_reducer.create initial_meta in
+  let t =
+    { mailbox = Eio.Stream.create mailbox_capacity
+    ; projection = Atomic.make (Keeper_owner_reducer.projection initial_state)
+    ; closed = Atomic.make false
+    }
+  in
+  Eio.Switch.on_release sw (fun () ->
+    Atomic.set t.closed true;
+    let projection = Atomic.get t.projection in
+    Atomic.set t.projection { projection with stopping = true });
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    Eio.Switch.run (fun child_sw ->
+      let rec loop state =
+        match Eio.Stream.take t.mailbox with
+        | Command (Exact_projection, resolve) ->
+          Eio.Promise.resolve resolve (Ok (Keeper_owner_reducer.projection state));
+          loop state
+        | Command (Apply_meta command, resolve) ->
+          (match Keeper_owner_reducer.apply_meta state command with
+           | Error error ->
+             Eio.Promise.resolve resolve (Error (Reducer_rejected error));
+             loop state
+           | Ok transition ->
+             (match apply_transition t store state transition with
+              | Error (state, error) ->
+                Eio.Promise.resolve resolve (Error error);
+                loop state
+              | Ok state ->
+                Eio.Promise.resolve
+                  resolve
+                  (Ok (Keeper_owner_reducer.projection state).meta);
+                loop state))
+        | Command (Start_turn request, resolve) ->
+          (match Keeper_owner_reducer.begin_turn state ~operation_id:request.operation_id with
+           | Error (Turn_already_running running_operation_id) ->
+             Eio.Promise.resolve resolve (Ok (Busy { running_operation_id }));
+             loop state
+           | Error error ->
+             Eio.Promise.resolve resolve (Error (Reducer_rejected error));
+             loop state
+           | Ok transition ->
+             (match apply_transition t store state transition with
+              | Error (state, error) ->
+                Eio.Promise.resolve resolve (Error error);
+                loop state
+              | Ok state ->
+                Eio.Promise.resolve resolve (Ok Started);
+                if transition_starts_child transition request.operation_id
+                then Eio.Fiber.fork ~sw:child_sw (fun () -> run_child t request);
+                loop state))
+        | Command (Child_finished { operation_id; outcome }, resolve) ->
+          log_child_failure operation_id outcome;
+          (match Keeper_owner_reducer.finish_turn state ~operation_id with
+           | Error error ->
+             Log.Keeper.error
+               "keeper_owner: rejected child completion operation_id=%s error=%s"
+               operation_id
+               (Keeper_owner_reducer.error_to_string error);
+             Eio.Promise.resolve resolve (Ok ());
+             loop state
+           | Ok transition ->
+             (match apply_transition t store state transition with
+              | Error (state, error) ->
+                Log.Keeper.error
+                  "keeper_owner: child completion projection failed operation_id=%s error=%s"
+                  operation_id
+                  (error_to_string error);
+                Eio.Promise.resolve resolve (Ok ());
+                loop state
+              | Ok state ->
+                Eio.Promise.resolve resolve (Ok ());
+                loop state))
+        | Command (Begin_stopping, resolve) ->
+          let transition = Keeper_owner_reducer.begin_stopping state in
+          (match apply_transition t store state transition with
+           | Error (state, error) ->
+             Eio.Promise.resolve resolve (Error error);
+             loop state
+           | Ok state ->
+             Eio.Promise.resolve resolve (Ok ());
+             loop state)
+      in
+      loop initial_state));
+  t
+;;
+
+let exact_projection t = request t Exact_projection
+let apply_meta t command = request t (Apply_meta command)
+let start_turn t ~operation_id ~run = request t (Start_turn { operation_id; run })
+let begin_stopping t = request t Begin_stopping
+
+module For_testing = struct
+  let mailbox_depth t = Eio.Stream.length t.mailbox
+end

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -1,0 +1,62 @@
+(** Single-fiber owner for one Keeper.
+
+    Producers communicate through a bounded mailbox.  [apply_meta],
+    [exact_projection], and [start_turn] apply backpressure when the mailbox is
+    full; commands are never dropped or coalesced.  Routine reads use
+    {!projection} and do not enter the mailbox. *)
+
+val mailbox_capacity : int
+
+type store =
+  { replace : Keeper_meta_contract.keeper_meta -> (unit, string) result
+  ; remove : unit -> (unit, string) result
+  }
+
+type error =
+  | Reducer_rejected of Keeper_owner_reducer.error
+  | Store_unavailable of string
+  | Owner_closed
+
+type turn_start =
+  | Started
+  | Busy of { running_operation_id : string }
+
+type t
+
+val start
+  :  sw:Eio.Switch.t
+  -> store:store
+  -> initial_meta:Keeper_meta_contract.keeper_meta option
+  -> t
+
+val projection : t -> Keeper_owner_reducer.projection
+(** Lock-free immutable snapshot. *)
+
+val exact_projection
+  :  t
+  -> (Keeper_owner_reducer.projection, error) result
+(** Mailbox-linearized projection for mutation and exact-operation paths. *)
+
+val apply_meta
+  :  t
+  -> Keeper_owner_reducer.meta_command
+  -> (Keeper_meta_contract.keeper_meta option, error) result
+
+val start_turn
+  :  t
+  -> operation_id:string
+  -> run:(Eio.Switch.t -> unit)
+  -> (turn_start, error) result
+(** Admit one child turn and return after actor admission, without waiting for
+    the child.  A child exception is contained by the owner and releases the
+    running slot. *)
+
+val begin_stopping : t -> (unit, error) result
+(** Reject future external commands.  The root switch remains the structured
+    cancellation and join authority for the actor and its current child. *)
+
+val error_to_string : error -> string
+
+module For_testing : sig
+  val mailbox_depth : t -> int
+end

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -9,7 +9,7 @@ val mailbox_capacity : int
 
 type store =
   { replace : Keeper_meta_contract.keeper_meta -> (unit, string) result
-  ; remove : unit -> (unit, string) result
+  ; remove : Keeper_meta_contract.keeper_meta -> (unit, string) result
   }
 
 type error =

--- a/lib/keeper/keeper_owner_reducer.ml
+++ b/lib/keeper/keeper_owner_reducer.ml
@@ -1,0 +1,360 @@
+type usage_delta =
+  { turns : int
+  ; input_tokens : int
+  ; output_tokens : int
+  ; total_tokens : int
+  ; cost_usd : float
+  ; last_turn_ts : float
+  ; last_input_tokens : int
+  ; last_output_tokens : int
+  ; last_total_tokens : int
+  ; last_usage_reported_at : float option
+  ; last_latency_ms : int
+  }
+
+type identity_handoff =
+  { keeper_id : Keeper_id.Uid.t option
+  ; agent_name : string
+  ; trace_id : Keeper_id.Trace_id.t
+  ; trace_history : string list
+  ; generation : int
+  ; updated_at : string
+  }
+
+type compaction_result =
+  { count_delta : int
+  ; at : float
+  ; before_tokens : int
+  ; after_tokens : int
+  ; checked_at : float
+  ; decision : Keeper_meta_contract.compaction_runtime_decision
+  ; updated_at : string
+  }
+
+type meta_command =
+  | Create of Keeper_meta_contract.keeper_meta
+  | Pause of
+      { reason : Keeper_latched_reason.t
+      ; updated_at : string
+      }
+  | Resume of { updated_at : string }
+  | Reset_latch of { updated_at : string }
+  | Set_autoboot of
+      { enabled : bool
+      ; updated_at : string
+      }
+  | Handoff_identity of identity_handoff
+  | Repair_trace_generation of
+      { trace_id : Keeper_id.Trace_id.t
+      ; trace_history : string list
+      ; generation : int
+      ; updated_at : string
+      }
+  | Delete
+  | Turn_started_projection of { updated_at : string }
+  | Turn_succeeded of
+      { usage : usage_delta
+      ; updated_at : string
+      }
+  | Turn_failed of
+      { blocker : Keeper_meta_contract.blocker_info
+      ; usage : usage_delta option
+      ; updated_at : string
+      }
+  | Add_usage of usage_delta
+  | Set_current_task of
+      { task_id : Keeper_id.Task_id.t option
+      ; updated_at : string
+      }
+  | Set_blocker of
+      { blocker : Keeper_meta_contract.blocker_info option
+      ; updated_at : string
+      }
+  | Record_compaction of compaction_result
+  | Ack_message_scope of
+      { message_id : string option
+      ; updated_at : string
+      }
+
+type state =
+  { meta : Keeper_meta_contract.keeper_meta option
+  ; running_operation_id : string option
+  ; stopping : bool
+  }
+
+type projection =
+  { meta : Keeper_meta_contract.keeper_meta option
+  ; running_operation_id : string option
+  ; stopping : bool
+  }
+
+type persistence_intent =
+  | No_persistence
+  | Replace_snapshot of Keeper_meta_contract.keeper_meta
+  | Remove_snapshot
+
+type post_commit_effect =
+  | Publish_projection of projection
+  | Start_turn_child of { operation_id : string }
+
+type transition =
+  { state : state
+  ; persistence : persistence_intent
+  ; effects : post_commit_effect list
+  }
+
+type error =
+  | Meta_missing
+  | Meta_already_exists
+  | Owner_stopping
+  | Turn_already_running of string
+  | Turn_not_running
+  | Turn_identity_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Invalid_delta of string
+
+let create meta : state = { meta; running_operation_id = None; stopping = false }
+
+let projection (state : state) : projection =
+  { meta = state.meta
+  ; running_operation_id = state.running_operation_id
+  ; stopping = state.stopping
+  }
+;;
+
+let publish_transition (state : state) persistence extra_effects =
+  let projection = projection state in
+  { state
+  ; persistence
+  ; effects = Publish_projection projection :: extra_effects
+  }
+;;
+
+let with_meta (state : state) meta =
+  let state = { state with meta = Some meta } in
+  publish_transition state (Replace_snapshot meta) []
+;;
+
+let validate_delta delta =
+  if delta.turns < 0
+  then Error (Invalid_delta "turns must be non-negative")
+  else if delta.input_tokens < 0
+  then Error (Invalid_delta "input_tokens must be non-negative")
+  else if delta.output_tokens < 0
+  then Error (Invalid_delta "output_tokens must be non-negative")
+  else if delta.total_tokens < 0
+  then Error (Invalid_delta "total_tokens must be non-negative")
+  else if delta.cost_usd < 0.0 || not (Float.is_finite delta.cost_usd)
+  then Error (Invalid_delta "cost_usd must be finite and non-negative")
+  else if not (Float.is_finite delta.last_turn_ts)
+  then Error (Invalid_delta "last_turn_ts must be finite")
+  else if delta.last_input_tokens < 0
+  then Error (Invalid_delta "last_input_tokens must be non-negative")
+  else if delta.last_output_tokens < 0
+  then Error (Invalid_delta "last_output_tokens must be non-negative")
+  else if delta.last_total_tokens < 0
+  then Error (Invalid_delta "last_total_tokens must be non-negative")
+  else if delta.last_latency_ms < 0
+  then Error (Invalid_delta "last_latency_ms must be non-negative")
+  else if
+    Option.fold
+      ~none:false
+      ~some:(fun observed_at -> not (Float.is_finite observed_at))
+      delta.last_usage_reported_at
+  then Error (Invalid_delta "last_usage_reported_at must be finite")
+  else Ok ()
+;;
+
+let checked_add field current delta =
+  if current > max_int - delta
+  then Error (Invalid_delta (field ^ " overflow"))
+  else Ok (current + delta)
+;;
+
+let ( let* ) result f = Result.bind result f
+
+let add_usage meta delta =
+  match validate_delta delta with
+  | Error _ as error -> error
+  | Ok () ->
+    let usage = meta.Keeper_meta_contract.runtime.usage in
+    let total_cost_usd = usage.total_cost_usd +. delta.cost_usd in
+    if not (Float.is_finite total_cost_usd)
+    then Error (Invalid_delta "total_cost_usd overflow")
+    else
+      let* total_turns = checked_add "total_turns" usage.total_turns delta.turns in
+      let* total_input_tokens =
+        checked_add "total_input_tokens" usage.total_input_tokens delta.input_tokens
+      in
+      let* total_output_tokens =
+        checked_add "total_output_tokens" usage.total_output_tokens delta.output_tokens
+      in
+      let* total_tokens = checked_add "total_tokens" usage.total_tokens delta.total_tokens in
+      let usage : Keeper_meta_contract.usage_metrics =
+        { total_turns
+        ; total_input_tokens
+        ; total_output_tokens
+        ; total_tokens
+        ; total_cost_usd
+        ; last_turn_ts = delta.last_turn_ts
+        ; last_input_tokens = delta.last_input_tokens
+        ; last_output_tokens = delta.last_output_tokens
+        ; last_total_tokens = delta.last_total_tokens
+        ; last_usage_reported_at = delta.last_usage_reported_at
+        ; last_latency_ms = delta.last_latency_ms
+        }
+      in
+      Ok (Keeper_meta_contract.map_usage (fun _ -> usage) meta)
+;;
+
+let update_usage meta usage =
+  match usage with
+  | None -> Ok meta
+  | Some delta -> add_usage meta delta
+;;
+
+let apply_existing (state : state) meta command =
+  match command with
+  | Create _ -> Error Meta_already_exists
+  | Delete ->
+    let state = { state with meta = None } in
+    Ok (publish_transition state Remove_snapshot [])
+  | Pause { reason; updated_at } ->
+    Ok (with_meta state { meta with paused = true; latched_reason = Some reason; updated_at })
+  | Resume { updated_at } ->
+    let resumed = Keeper_meta_contract.mark_resumed meta in
+    Ok (with_meta state { resumed with updated_at })
+  | Reset_latch { updated_at } ->
+    let runtime = { meta.runtime with last_blocker = None } in
+    Ok
+      (with_meta
+         state
+         { meta with paused = false; latched_reason = None; runtime; updated_at })
+  | Set_autoboot { enabled; updated_at } ->
+    Ok (with_meta state { meta with autoboot_enabled = enabled; updated_at })
+  | Handoff_identity handoff ->
+    let runtime =
+      { meta.runtime with
+        trace_id = handoff.trace_id
+      ; trace_history = handoff.trace_history
+      ; nonce = handoff.generation
+      }
+    in
+    Ok
+      (with_meta
+         state
+         { meta with
+           keeper_id = handoff.keeper_id
+         ; agent_name = handoff.agent_name
+         ; runtime
+         ; updated_at = handoff.updated_at
+         })
+  | Repair_trace_generation repair ->
+    let runtime =
+      { meta.runtime with
+        trace_id = repair.trace_id
+      ; trace_history = repair.trace_history
+      ; nonce = repair.generation
+      }
+    in
+    Ok (with_meta state { meta with runtime; updated_at = repair.updated_at })
+  | Turn_started_projection { updated_at } ->
+    Ok (with_meta state { meta with updated_at })
+  | Turn_succeeded { usage; updated_at } ->
+    (match add_usage meta usage with
+     | Error _ as error -> error
+     | Ok meta ->
+       let runtime = { meta.runtime with last_blocker = None } in
+       Ok (with_meta state { meta with runtime; updated_at }))
+  | Turn_failed { blocker; usage; updated_at } ->
+    (match update_usage meta usage with
+     | Error _ as error -> error
+     | Ok meta ->
+       let runtime = { meta.runtime with last_blocker = Some blocker } in
+       Ok (with_meta state { meta with runtime; updated_at }))
+  | Add_usage delta ->
+    (match add_usage meta delta with
+     | Error _ as error -> error
+     | Ok meta -> Ok (with_meta state meta))
+  | Set_current_task { task_id; updated_at } ->
+    Ok (with_meta state { meta with current_task_id = task_id; updated_at })
+  | Set_blocker { blocker; updated_at } ->
+    let runtime = { meta.runtime with last_blocker = blocker } in
+    Ok (with_meta state { meta with runtime; updated_at })
+  | Record_compaction result ->
+    if result.count_delta < 0
+    then Error (Invalid_delta "compaction count_delta must be non-negative")
+    else
+      let previous = meta.runtime.compaction_rt in
+      (match checked_add "compaction count" previous.count result.count_delta with
+       | Error _ as error -> error
+       | Ok count ->
+         let compaction_rt =
+           { Keeper_meta_contract.count
+           ; last_ts = result.at
+           ; last_before_tokens = result.before_tokens
+           ; last_after_tokens = result.after_tokens
+           ; last_check_ts = result.checked_at
+           ; last_decision = result.decision
+           }
+         in
+         let meta = Keeper_meta_contract.map_compaction_rt (fun _ -> compaction_rt) meta in
+         Ok (with_meta state { meta with updated_at = result.updated_at }))
+  | Ack_message_scope { message_id; updated_at } ->
+    let runtime = { meta.runtime with message_scope_ack_id = message_id } in
+    Ok (with_meta state { meta with runtime; updated_at })
+;;
+
+let apply_meta (state : state) command =
+  if state.stopping
+  then Error Owner_stopping
+  else
+    match state.meta, command with
+    | None, Create meta -> Ok (with_meta state meta)
+    | None, _ -> Error Meta_missing
+    | Some meta, command -> apply_existing state meta command
+;;
+
+let begin_turn (state : state) ~operation_id =
+  if state.stopping
+  then Error Owner_stopping
+  else
+    match state.running_operation_id with
+    | Some running -> Error (Turn_already_running running)
+    | None ->
+      let state = { state with running_operation_id = Some operation_id } in
+      Ok
+        (publish_transition
+           state
+           No_persistence
+           [ Start_turn_child { operation_id } ])
+;;
+
+let finish_turn (state : state) ~operation_id =
+  match state.running_operation_id with
+  | None -> Error Turn_not_running
+  | Some actual when String.equal actual operation_id ->
+    let state = { state with running_operation_id = None } in
+    Ok (publish_transition state No_persistence [])
+  | Some actual ->
+    Error (Turn_identity_mismatch { expected = operation_id; actual })
+;;
+
+let begin_stopping (state : state) =
+  let state = { state with stopping = true } in
+  publish_transition state No_persistence []
+;;
+
+let error_to_string = function
+  | Meta_missing -> "keeper metadata does not exist"
+  | Meta_already_exists -> "keeper metadata already exists"
+  | Owner_stopping -> "keeper owner is stopping"
+  | Turn_already_running operation_id ->
+    Printf.sprintf "keeper turn %s is already running" operation_id
+  | Turn_not_running -> "keeper has no running turn"
+  | Turn_identity_mismatch { expected; actual } ->
+    Printf.sprintf "turn identity mismatch: expected=%s actual=%s" expected actual
+  | Invalid_delta detail -> "invalid additive delta: " ^ detail
+;;

--- a/lib/keeper/keeper_owner_reducer.ml
+++ b/lib/keeper/keeper_owner_reducer.ml
@@ -91,7 +91,7 @@ type projection =
 type persistence_intent =
   | No_persistence
   | Replace_snapshot of Keeper_meta_contract.keeper_meta
-  | Remove_snapshot
+  | Remove_snapshot of Keeper_meta_contract.keeper_meta
 
 type post_commit_effect =
   | Publish_projection of projection
@@ -220,7 +220,7 @@ let apply_existing (state : state) meta command =
   | Create _ -> Error Meta_already_exists
   | Delete ->
     let state = { state with meta = None } in
-    Ok (publish_transition state Remove_snapshot [])
+    Ok (publish_transition state (Remove_snapshot meta) [])
   | Pause { reason; updated_at } ->
     Ok (with_meta state { meta with paused = true; latched_reason = Some reason; updated_at })
   | Resume { updated_at } ->

--- a/lib/keeper/keeper_owner_reducer.mli
+++ b/lib/keeper/keeper_owner_reducer.mli
@@ -1,0 +1,135 @@
+(** Pure state transition core for one Keeper owner.
+
+    This module contains no locks, fibers, persistence calls, clocks, or
+    callbacks.  Metadata changes are a closed command set: callers cannot
+    submit an arbitrary [keeper_meta -> keeper_meta] function. *)
+
+type usage_delta =
+  { turns : int
+  ; input_tokens : int
+  ; output_tokens : int
+  ; total_tokens : int
+  ; cost_usd : float
+  ; last_turn_ts : float
+  ; last_input_tokens : int
+  ; last_output_tokens : int
+  ; last_total_tokens : int
+  ; last_usage_reported_at : float option
+  ; last_latency_ms : int
+  }
+
+type identity_handoff =
+  { keeper_id : Keeper_id.Uid.t option
+  ; agent_name : string
+  ; trace_id : Keeper_id.Trace_id.t
+  ; trace_history : string list
+  ; generation : int
+  ; updated_at : string
+  }
+
+type compaction_result =
+  { count_delta : int
+  ; at : float
+  ; before_tokens : int
+  ; after_tokens : int
+  ; checked_at : float
+  ; decision : Keeper_meta_contract.compaction_runtime_decision
+  ; updated_at : string
+  }
+
+type meta_command =
+  | Create of Keeper_meta_contract.keeper_meta
+  | Pause of
+      { reason : Keeper_latched_reason.t
+      ; updated_at : string
+      }
+  | Resume of { updated_at : string }
+  | Reset_latch of { updated_at : string }
+  | Set_autoboot of
+      { enabled : bool
+      ; updated_at : string
+      }
+  | Handoff_identity of identity_handoff
+  | Repair_trace_generation of
+      { trace_id : Keeper_id.Trace_id.t
+      ; trace_history : string list
+      ; generation : int
+      ; updated_at : string
+      }
+  | Delete
+  | Turn_started_projection of { updated_at : string }
+  | Turn_succeeded of
+      { usage : usage_delta
+      ; updated_at : string
+      }
+  | Turn_failed of
+      { blocker : Keeper_meta_contract.blocker_info
+      ; usage : usage_delta option
+      ; updated_at : string
+      }
+  | Add_usage of usage_delta
+  | Set_current_task of
+      { task_id : Keeper_id.Task_id.t option
+      ; updated_at : string
+      }
+  | Set_blocker of
+      { blocker : Keeper_meta_contract.blocker_info option
+      ; updated_at : string
+      }
+  | Record_compaction of compaction_result
+  | Ack_message_scope of
+      { message_id : string option
+      ; updated_at : string
+      }
+
+type state
+
+type projection =
+  { meta : Keeper_meta_contract.keeper_meta option
+  ; running_operation_id : string option
+  ; stopping : bool
+  }
+
+type persistence_intent =
+  | No_persistence
+  | Replace_snapshot of Keeper_meta_contract.keeper_meta
+  | Remove_snapshot
+
+type post_commit_effect =
+  | Publish_projection of projection
+  | Start_turn_child of { operation_id : string }
+
+type transition =
+  { state : state
+  ; persistence : persistence_intent
+  ; effects : post_commit_effect list
+  }
+
+type error =
+  | Meta_missing
+  | Meta_already_exists
+  | Owner_stopping
+  | Turn_already_running of string
+  | Turn_not_running
+  | Turn_identity_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Invalid_delta of string
+
+val create : Keeper_meta_contract.keeper_meta option -> state
+val projection : state -> projection
+val apply_meta : state -> meta_command -> (transition, error) result
+
+val begin_turn
+  :  state
+  -> operation_id:string
+  -> (transition, error) result
+
+val finish_turn
+  :  state
+  -> operation_id:string
+  -> (transition, error) result
+
+val begin_stopping : state -> transition
+val error_to_string : error -> string

--- a/lib/keeper/keeper_owner_reducer.mli
+++ b/lib/keeper/keeper_owner_reducer.mli
@@ -93,7 +93,7 @@ type projection =
 type persistence_intent =
   | No_persistence
   | Replace_snapshot of Keeper_meta_contract.keeper_meta
-  | Remove_snapshot
+  | Remove_snapshot of Keeper_meta_contract.keeper_meta
 
 type post_commit_effect =
   | Publish_projection of projection

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -10,6 +10,10 @@ type lookup_error =
   | Owner_not_found of string
   | Inventory_stopping
 
+type command_error =
+  | Command_lookup_failed of lookup_error
+  | Command_rejected of Keeper_owner.error
+
 exception Install_failed of install_error
 
 type pool =
@@ -46,6 +50,11 @@ let lookup_error_to_string = function
   | Owner_not_found keeper_name ->
     Printf.sprintf "Keeper owner not found: %s" keeper_name
   | Inventory_stopping -> "Keeper owner inventory is stopping"
+;;
+
+let command_error_to_string = function
+  | Command_lookup_failed error -> lookup_error_to_string error
+  | Command_rejected error -> Keeper_owner.error_to_string error
 ;;
 
 let () =
@@ -213,6 +222,18 @@ let get ~base_path ~keeper_name =
       match Hashtbl.find_opt pool.owners keeper_name with
       | Some owner -> Ok owner
       | None -> Error (Owner_not_found keeper_name))
+;;
+
+let apply_meta ~base_path ~keeper_name command =
+  match get ~base_path ~keeper_name with
+  | Error error -> Error (Command_lookup_failed error)
+  | Ok owner ->
+    (match Keeper_owner.apply_meta owner command with
+     | Error error -> Error (Command_rejected error)
+     | Ok (Some meta) ->
+       Keeper_registry.update_meta_from_persisted ~base_path keeper_name meta;
+       Ok (Some meta)
+     | Ok None -> Ok None)
 ;;
 
 let all_projections ~base_path =

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -1,0 +1,231 @@
+type install_error =
+  | Inventory_already_installed of string
+  | Inventory_load_failed of
+      { keeper_name : string option
+      ; detail : string
+      }
+
+type lookup_error =
+  | Inventory_not_installed of string
+  | Owner_not_found of string
+  | Inventory_stopping
+
+exception Install_failed of install_error
+
+type pool =
+  { config : Workspace.config
+  ; sw : Eio.Switch.t
+  ; owners : (string, Keeper_owner.t) Hashtbl.t
+  ; owners_mu : Eio.Mutex.t
+  ; owner_handles : Keeper_owner.t list Atomic.t
+  ; stopping : bool Atomic.t
+  }
+
+let pools : (string, pool) Hashtbl.t = Hashtbl.create 4
+let pools_mu = Stdlib.Mutex.create ()
+
+let canonical_base_path base_path =
+  Keeper_registry_types.canonical_base_path_exn base_path
+;;
+
+let pool_key base_path = canonical_base_path base_path
+
+let install_error_to_string = function
+  | Inventory_already_installed base_path ->
+    Printf.sprintf "Keeper owner inventory already installed for BasePath %s" base_path
+  | Inventory_load_failed { keeper_name; detail } ->
+    (match keeper_name with
+     | None -> "failed to load Keeper owner inventory: " ^ detail
+     | Some keeper_name ->
+       Printf.sprintf "failed to load Keeper owner %s: %s" keeper_name detail)
+;;
+
+let lookup_error_to_string = function
+  | Inventory_not_installed base_path ->
+    Printf.sprintf "Keeper owner inventory is not installed for BasePath %s" base_path
+  | Owner_not_found keeper_name ->
+    Printf.sprintf "Keeper owner not found: %s" keeper_name
+  | Inventory_stopping -> "Keeper owner inventory is stopping"
+;;
+
+let () =
+  Printexc.register_printer (function
+    | Install_failed error -> Some (install_error_to_string error)
+    | _ -> None)
+;;
+
+let load_all config =
+  match Keeper_meta_store.keeper_names_result config with
+  | Error detail -> Error (Inventory_load_failed { keeper_name = None; detail })
+  | Ok names ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | keeper_name :: rest ->
+        (match Keeper_meta_store.read_meta config keeper_name with
+         | Error detail ->
+           Error (Inventory_load_failed { keeper_name = Some keeper_name; detail })
+         | Ok None ->
+           Error
+             (Inventory_load_failed
+                { keeper_name = Some keeper_name
+                ; detail = "metadata disappeared during strict owner inventory load"
+                })
+         | Ok (Some meta) -> loop (meta :: acc) rest)
+    in
+    loop [] names
+;;
+
+let remove_error_to_string error =
+  Keeper_meta_store.identity_remove_error_to_string error
+;;
+
+let store_for pool keeper_name : Keeper_owner.store =
+  { replace =
+      (fun meta ->
+         if not (String.equal meta.Keeper_meta_contract.name keeper_name)
+         then
+           Error
+             (Printf.sprintf
+                "owner snapshot identity mismatch: expected=%s actual=%s"
+                keeper_name
+                meta.name)
+         else Keeper_meta_store.persist_meta pool.config keeper_name meta)
+  ; remove =
+      (fun meta ->
+         match
+           Keeper_meta_store.remove_meta_if_identity
+             pool.config
+             ~name:keeper_name
+             ~trace_id:meta.runtime.trace_id
+             ~generation:meta.runtime.nonce
+         with
+         | Ok () -> Ok ()
+         | Error error -> Error (remove_error_to_string error))
+  }
+;;
+
+let refresh_owner_handles pool =
+  let owner_handles =
+    Hashtbl.to_seq_values pool.owners
+    |> List.of_seq
+    |> List.sort (fun left right ->
+      let name owner =
+        match (Keeper_owner.projection owner).Keeper_owner_reducer.meta with
+        | Some meta -> meta.name
+        | None -> ""
+      in
+      String.compare (name left) (name right))
+  in
+  Atomic.set pool.owner_handles owner_handles
+;;
+
+let ensure_in_pool pool meta =
+  if Atomic.get pool.stopping
+  then Error Inventory_stopping
+  else
+    Eio.Mutex.use_rw ~protect:true pool.owners_mu (fun () ->
+      match Hashtbl.find_opt pool.owners meta.Keeper_meta_contract.name with
+      | Some owner -> Ok owner
+      | None ->
+        let owner =
+          Keeper_owner.start
+            ~sw:pool.sw
+            ~store:(store_for pool meta.name)
+            ~initial_meta:(Some meta)
+        in
+        Hashtbl.add pool.owners meta.name owner;
+        refresh_owner_handles pool;
+        Ok owner)
+;;
+
+let install_from_store ~sw config =
+  let base_path = pool_key config.Workspace.base_path in
+  match load_all config with
+  | Error _ as error -> error
+  | Ok metas ->
+    let pool =
+      { config
+      ; sw
+      ; owners = Hashtbl.create (max 16 (List.length metas))
+      ; owners_mu = Eio.Mutex.create ()
+      ; owner_handles = Atomic.make []
+      ; stopping = Atomic.make false
+      }
+    in
+    let installed =
+      Stdlib.Mutex.protect pools_mu (fun () ->
+        if Hashtbl.mem pools base_path
+        then false
+        else (
+          Hashtbl.add pools base_path pool;
+          true))
+    in
+    if not installed
+    then Error (Inventory_already_installed base_path)
+    else (
+      Eio.Switch.on_release sw (fun () ->
+        Atomic.set pool.stopping true;
+        Stdlib.Mutex.protect pools_mu (fun () ->
+          match Hashtbl.find_opt pools base_path with
+          | Some current when current == pool -> Hashtbl.remove pools base_path
+          | Some _ | None -> ()));
+      let rec start_all count = function
+        | [] -> Ok count
+        | meta :: rest ->
+          (match ensure_in_pool pool meta with
+           | Ok _ -> start_all (count + 1) rest
+           | Error Inventory_stopping ->
+             Error
+               (Inventory_load_failed
+                  { keeper_name = Some meta.name
+                  ; detail = "root switch stopped during owner installation"
+                  })
+           | Error (Inventory_not_installed _ | Owner_not_found _) ->
+             Error
+               (Inventory_load_failed
+                  { keeper_name = Some meta.name
+                  ; detail = "owner inventory installation invariant failed"
+                  }))
+      in
+      start_all 0 metas)
+;;
+
+let find_pool base_path =
+  let base_path = pool_key base_path in
+  Stdlib.Mutex.protect pools_mu (fun () ->
+    match Hashtbl.find_opt pools base_path with
+    | None -> Error (Inventory_not_installed base_path)
+    | Some pool when Atomic.get pool.stopping -> Error Inventory_stopping
+    | Some pool -> Ok pool)
+;;
+
+let ensure ~base_path meta =
+  match find_pool base_path with
+  | Error _ as error -> error
+  | Ok pool -> ensure_in_pool pool meta
+;;
+
+let get ~base_path ~keeper_name =
+  match find_pool base_path with
+  | Error _ as error -> error
+  | Ok pool ->
+    Eio.Mutex.use_ro pool.owners_mu (fun () ->
+      match Hashtbl.find_opt pool.owners keeper_name with
+      | Some owner -> Ok owner
+      | None -> Error (Owner_not_found keeper_name))
+;;
+
+let all_projections ~base_path =
+  match find_pool base_path with
+  | Error _ as error -> error
+  | Ok pool ->
+    Ok (List.map Keeper_owner.projection (Atomic.get pool.owner_handles))
+;;
+
+module For_testing = struct
+  let installed_owner_count ~base_path =
+    match find_pool base_path with
+    | Error _ -> 0
+    | Ok pool -> Eio.Mutex.use_ro pool.owners_mu (fun () -> Hashtbl.length pool.owners)
+  ;;
+end

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -15,6 +15,10 @@ type lookup_error =
   | Owner_not_found of string
   | Inventory_stopping
 
+type command_error =
+  | Command_lookup_failed of lookup_error
+  | Command_rejected of Keeper_owner.error
+
 exception Install_failed of install_error
 
 val install_from_store
@@ -36,6 +40,14 @@ val get
   -> keeper_name:string
   -> (Keeper_owner.t, lookup_error) result
 
+val apply_meta
+  :  base_path:string
+  -> keeper_name:string
+  -> Keeper_owner_reducer.meta_command
+  -> (Keeper_meta_contract.keeper_meta option, command_error) result
+(** Mailbox-linearized metadata mutation.  Registry metadata is refreshed only
+    from the committed owner projection. *)
+
 val all_projections
   :  base_path:string
   -> (Keeper_owner_reducer.projection list, lookup_error) result
@@ -43,6 +55,7 @@ val all_projections
 
 val install_error_to_string : install_error -> string
 val lookup_error_to_string : lookup_error -> string
+val command_error_to_string : command_error -> string
 
 module For_testing : sig
   val installed_owner_count : base_path:string -> int

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -1,0 +1,49 @@
+(** Process-local inventory of per-Keeper owners.
+
+    The existing BasePath process lease remains the authority.  This module
+    adds no process lease, worker epoch, or persistent ownership record. *)
+
+type install_error =
+  | Inventory_already_installed of string
+  | Inventory_load_failed of
+      { keeper_name : string option
+      ; detail : string
+      }
+
+type lookup_error =
+  | Inventory_not_installed of string
+  | Owner_not_found of string
+  | Inventory_stopping
+
+exception Install_failed of install_error
+
+val install_from_store
+  :  sw:Eio.Switch.t
+  -> Workspace.config
+  -> (int, install_error) result
+(** Strictly load every persisted Keeper and start exactly one owner actor for
+    each under [sw].  Returns the installed owner count. *)
+
+val ensure
+  :  base_path:string
+  -> Keeper_meta_contract.keeper_meta
+  -> (Keeper_owner.t, lookup_error) result
+(** Start the owner for a newly created Keeper, or return the existing owner.
+    Name collisions never replace an existing actor. *)
+
+val get
+  :  base_path:string
+  -> keeper_name:string
+  -> (Keeper_owner.t, lookup_error) result
+
+val all_projections
+  :  base_path:string
+  -> (Keeper_owner_reducer.projection list, lookup_error) result
+(** Lock-free fleet projection. *)
+
+val install_error_to_string : install_error -> string
+val lookup_error_to_string : lookup_error -> string
+
+module For_testing : sig
+  val installed_owner_count : base_path:string -> int
+end

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -67,6 +67,12 @@ let build_keeper_system_prompt
          </workspace>\n"
         (String_util.escape_xml workspace_root)
   in
+  let runtime_state_block =
+    "\n<runtime_state>\n\
+     - Keeper metadata and current-task binding are runtime-owned projections.\n\
+     - Use typed Keeper and task tools; do not edit `.masc/keepers` state files directly.\n\
+     </runtime_state>\n"
+  in
   (* Prefix ordering: the shared block comes first for LLM KV cache sharing.
      All keepers share the same <system> text, so keeper-specific blocks come
      after it and the shared prefix stays maximal.
@@ -95,6 +101,7 @@ let build_keeper_system_prompt
       (* ── Keeper-specific blocks ─────────────────────────────── *)
       identity_block;
       workspace_block;
+      runtime_state_block;
       (* Operator instructions and the goals open right now. *)
       "<instructions>";
       custom;

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -52,7 +52,7 @@ let prepare_run_context
       ()
   =
   let receipt_started_at = Masc_domain.now_iso () in
-  let meta = Keeper_agent_tool_surface.sync_current_task_id_from_backlog ~config meta in
+  let meta = Keeper_current_task_reconcile.sync_current_task_id_from_backlog ~config meta in
   let validated_goal_ids =
     Keeper_runtime_contract.validate_active_goal_ids ~config ~meta ()
   in

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -1,9 +1,8 @@
 (** Docker/sandbox shell execution infrastructure.
 
-    Extracted from keeper_tool_command_runtime.ml — Docker container lifecycle,
-    sandbox profile resolution, and container invocation functions.
-    These are pure infrastructure; command dispatch remains in
-    keeper_tool_command_runtime.ml. *)
+    Owns Docker container lifecycle, sandbox profile resolution, and
+    container invocation. Typed command dispatch is owned by
+    [Keeper_tool_execute_runtime]. *)
 
 open Keeper_types
 open Keeper_meta_contract
@@ -47,13 +46,6 @@ let docker_mount_preflight_details
 
 (* ── Container naming ──────────────────────────────────── *)
 
-let keeper_sandbox_container_name =
-  Keeper_sandbox_docker_container_name.keeper_sandbox_container_name
-let keeper_private_container_root =
-  Keeper_sandbox_docker_container_name.keeper_private_container_root
-let docker_private_workspace_cwd =
-  Keeper_sandbox_docker_container_name.docker_private_workspace_cwd
-
 let rewrite_docker_command_paths ~(config : Workspace.config) ~(meta : keeper_meta) cmd =
   let raw_host_root =
     Keeper_sandbox.host_root_abs_of_meta ~config meta
@@ -62,7 +54,7 @@ let rewrite_docker_command_paths ~(config : Workspace.config) ~(meta : keeper_me
   let normalized_host_root =
     raw_host_root |> Keeper_alerting_path.normalize_path_for_check_stripped
   in
-  let container_root = keeper_private_container_root meta in
+  let container_root = Keeper_sandbox.container_root meta.name in
   let rewritten =
     Keeper_sandbox_runtime.rewrite_host_root_to_container_root
       ~host_root:raw_host_root
@@ -91,7 +83,8 @@ let rewrite_docker_command_paths_for_host_validation
     raw_host_root |> Keeper_alerting_path.normalize_path_for_check_stripped
   in
   let container_root =
-    keeper_private_container_root meta |> Keeper_alerting_path.strip_trailing_slashes
+    Keeper_sandbox.container_root meta.name
+    |> Keeper_alerting_path.strip_trailing_slashes
   in
   let rewritten =
     Keeper_sandbox_runtime.rewrite_host_root_to_container_root
@@ -113,12 +106,6 @@ let effective_sandbox_profile ~(meta : keeper_meta) =
   match meta.sandbox_profile with
   | Docker -> Docker, meta.network_mode
   | Local -> Local, meta.network_mode
-;;
-
-(* ── Sandbox runtime preflight ─────────────────────────── *)
-
-let ensure_keeper_sandbox_runtime ~timeout_sec =
-  Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec
 ;;
 
 (* ── Docker invocation ─────────────────────────────────── *)
@@ -424,9 +411,14 @@ let run_docker_shell_command_with_status_internal
           |> Keeper_alerting_path.normalize_path_for_check
           |> Keeper_alerting_path.strip_trailing_slashes
         in
-        let container_name = keeper_sandbox_container_name meta in
-              let container_root = keeper_private_container_root meta in
-              let container_cwd = docker_private_workspace_cwd ~config ~meta cwd in
+        let container_name =
+          Keeper_sandbox_docker_container_name.keeper_sandbox_container_name meta
+        in
+              let container_root = Keeper_sandbox.container_root meta.name in
+              let container_cwd =
+                Keeper_sandbox_docker_container_name.docker_private_workspace_cwd
+                  ~config ~meta cwd
+              in
               let network_args, network_label =
                 Keeper_sandbox_runtime.docker_network_args network_mode
               in
@@ -490,7 +482,7 @@ let run_docker_shell_command_with_status_internal
                     ~timeout_sec
                     ()
                 in
-                match ensure_keeper_sandbox_runtime ~timeout_sec with
+                match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
                 | Error err -> sandbox_error err
                 | Ok seccomp_args ->
                   (match ensure_docker_shell_image_available ~image ~timeout_sec with
@@ -633,7 +625,8 @@ let docker_result_to_bash_response ~config ~meta result =
       ~sandbox:(Keeper_sandbox.of_meta ~config ~meta)
       ~host_cwd:result.cwd
       ~container_cwd_for_docker:
-        (docker_private_workspace_cwd ~config ~meta result.cwd)
+        (Keeper_sandbox_docker_container_name.docker_private_workspace_cwd
+           ~config ~meta result.cwd)
   in
   docker_bash_response
     ~ok:(process_status_is_success result.status)

--- a/lib/keeper/keeper_sandbox_docker.mli
+++ b/lib/keeper/keeper_sandbox_docker.mli
@@ -1,28 +1,12 @@
 (** Docker / sandbox shell execution infrastructure.
 
-    Extracted from keeper_tool_command_runtime.ml — Docker container
-    lifecycle, sandbox profile resolution, and container invocation. Command
-    syntax belongs to the invoked CLI; this layer enforces sandbox and path
-    containment.
+    Owns Docker container lifecycle, sandbox profile resolution, and
+    container invocation. Command syntax belongs to the invoked CLI; this
+    layer enforces sandbox and path containment.
 
     Sandbox backend failure-message and failure-recording surfaces live
     in [Keeper_sandbox_exec_failure]. Call those qualified rather than
     relying on a re-export here. *)
-
-(** Per-invocation container name [masc-keeper-<safe>-<pid>-<ms>]. *)
-val keeper_sandbox_container_name :
-  Keeper_meta_contract.keeper_meta -> string
-
-val keeper_private_container_root : Keeper_meta_contract.keeper_meta -> string
-
-(** Translate a host cwd into the in-container path mirror,
-    falling back to the container root when [host_cwd] is outside
-    the keeper sandbox root. *)
-val docker_private_workspace_cwd :
-  config:Workspace.config ->
-  meta:Keeper_meta_contract.keeper_meta ->
-  string ->
-  string
 
 (** Translate keeper-private in-container absolute paths back to their host
     playground paths for host-side path validation. Actual Docker execution
@@ -39,12 +23,6 @@ val rewrite_docker_command_paths_for_host_validation :
 val effective_sandbox_profile :
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_types_profile_sandbox.sandbox_profile * Keeper_types_profile_sandbox.network_mode
-
-(** Re-export of [Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime]. *)
-val ensure_keeper_sandbox_runtime :
-  timeout_sec:float -> (string list, string) result
-(** Direct alias of [Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime];
-    returns the [--security-opt seccomp=...] argv fragment on success. *)
 
 (** [-v <host>:<container>:ro] mount list, or [[]] when [host] is
     blank or missing. *)

--- a/lib/keeper/keeper_sandbox_docker_container_name.ml
+++ b/lib/keeper/keeper_sandbox_docker_container_name.ml
@@ -9,18 +9,11 @@
     the millisecond-resolution collision window that 64 concurrent
     keepers could trigger.
 
-    [keeper_private_container_root] — thin alias to
-    [Keeper_sandbox.container_root] returning the fixed
-    per-keeper container-side mount point.
-
     [docker_private_workspace_cwd] — given a host_cwd absolute
     path, returns the corresponding container-side path. If
-    host_cwd is *inside* the sandbox host root, the suffix is
-    appended to container_root; otherwise the call falls back to
-    container_root so the keeper still lands inside its sandbox.
-
-    Verbatim extract from [Keeper_sandbox_docker]; all 3 functions
-    are exposed by the parent .mli at lines 37, 40, 45. *)
+    host_cwd is *inside* the sandbox host root, the suffix is appended to the
+    canonical [Keeper_sandbox.container_root]; otherwise the call falls back
+    to that root so the keeper still lands inside its sandbox. *)
 
 let oneshot_container_counter : int Atomic.t = Atomic.make 0
 
@@ -34,10 +27,6 @@ let keeper_sandbox_container_name (meta : Keeper_meta_contract.keeper_meta) =
     seq
 ;;
 
-let keeper_private_container_root (meta : Keeper_meta_contract.keeper_meta) =
-  Keeper_sandbox.container_root meta.name
-;;
-
 let docker_private_workspace_cwd
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -49,7 +38,7 @@ let docker_private_workspace_cwd
   let host_root =
     Keeper_sandbox.host_root_abs_of_meta ~config meta |> normalize_path_for_containment
   in
-  let container_root = keeper_private_container_root meta in
+  let container_root = Keeper_sandbox.container_root meta.name in
   let host_cwd = normalize_path_for_containment host_cwd in
   if host_cwd = host_root
   then container_root

--- a/lib/keeper/keeper_sandbox_docker_container_name.mli
+++ b/lib/keeper/keeper_sandbox_docker_container_name.mli
@@ -3,8 +3,6 @@
 
 val keeper_sandbox_container_name : Keeper_meta_contract.keeper_meta -> string
 
-val keeper_private_container_root : Keeper_meta_contract.keeper_meta -> string
-
 val docker_private_workspace_cwd
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -1,11 +1,10 @@
 (** See .mli for contract.
 
-    The current Docker invocation mirrors the hardened-Execute sandbox in
-    [keeper_tool_command_runtime.ml] (read-only rootfs, no caps, no network) with the
-    playground mounted read-only and the default read program reduced to a
-    single [cat]. The argv assembly is duplicated rather than shared so a
-    future surgical change to either path does not need to wade through the
-    other's flags. *)
+    The current Docker invocation mirrors the hardened Execute sandbox owned
+    by [Keeper_sandbox_docker] (read-only rootfs, no caps, no network), with
+    the playground mounted read-only and the default read program reduced to
+    a single [cat]. The argv assembly is duplicated rather than shared so a
+    future surgical change to either path does not couple the two surfaces. *)
 
 open Keeper_types
 open Keeper_meta_contract
@@ -50,7 +49,7 @@ let container_path_of_host ~config ~(meta : keeper_meta) ~host_path
          "container_path_of_host: %s is not inside playground %s"
          host_norm host_root)
 
-(* Argv prefix kept private — distinct from keeper_tool_command_runtime's bash
+(* Argv prefix kept private and distinct from [Keeper_sandbox_docker]'s shell
    argv to avoid coupling the two surfaces. The trailing
    [program ; arg1 ; ... ] is appended by the caller via
    [build_docker_argv ~command_argv]. *)

--- a/lib/keeper/keeper_sandbox_runner.ml
+++ b/lib/keeper/keeper_sandbox_runner.ml
@@ -100,8 +100,9 @@ let of_docker_result
 
 module Docker_backend = struct
   let effective_sandbox_profile = Keeper_sandbox_docker.effective_sandbox_profile
-  let ensure_runtime = Keeper_sandbox_docker.ensure_keeper_sandbox_runtime
-  let private_workspace_cwd = Keeper_sandbox_docker.docker_private_workspace_cwd
+  let ensure_runtime = Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime
+  let private_workspace_cwd =
+    Keeper_sandbox_docker_container_name.docker_private_workspace_cwd
 
   let run_shell_command_with_status ~config ~meta ~cwd ~timeout_sec ~cmd
       ~network_mode =

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -222,14 +222,6 @@ let find_task_goal_id config task_id =
   | Some [] | None -> None
 ;;
 
-let merge_current_task_id ~(latest : keeper_meta) ~(caller : keeper_meta) =
-  {
-    latest with
-    current_task_id = caller.current_task_id;
-    updated_at = caller.updated_at;
-  }
-;;
-
 let sync_keeper_meta_current_task
     ~(config : Workspace.config)
     ~(meta : keeper_meta)
@@ -241,22 +233,33 @@ let sync_keeper_meta_current_task
       "could not sync claimed task %s into current_task_id: %s"
       task_id msg
   | Ok current_task_id ->
-    let updated_meta =
-      { meta with current_task_id = Some current_task_id; updated_at = now_iso () }
-    in
-    Keeper_registry.update_meta ~base_path:config.base_path meta.name updated_meta;
     (match
-       Keeper_meta_store.write_meta_with_merge ~merge:merge_current_task_id config updated_meta
+       Keeper_owner_registry.apply_meta
+         ~base_path:config.base_path
+         ~keeper_name:meta.name
+         (Keeper_owner_reducer.Set_current_task
+            { task_id = Some current_task_id; updated_at = now_iso () })
      with
-     | Ok () -> ()
-     | Error msg ->
+     | Ok (Some _) -> ()
+     | Ok None ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string WriteMetaFailures)
-         ~labels:[("keeper", meta.name); ("phase", "claim_task_id")]
+         ~labels:[ "keeper", meta.name; "phase", "claim_task_id" ]
          ();
-       Log.Keeper.warn ~keeper_name:meta.name
+       Log.Keeper.warn
+         ~keeper_name:meta.name
+         "owner removed metadata while syncing claimed current_task_id=%s"
+         task_id
+     | Error error ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string WriteMetaFailures)
+         ~labels:[ "keeper", meta.name; "phase", "claim_task_id" ]
+         ();
+       Log.Keeper.warn
+         ~keeper_name:meta.name
          "failed to persist claimed current_task_id=%s: %s"
-         task_id (Keeper_meta_store.write_meta_error_to_string msg))
+         task_id
+         (Keeper_owner_registry.command_error_to_string error))
 ;;
 
 (* Cluster sub-dispatch via closed sum type — string [name] is converted

--- a/lib/keeper_approval/audit.ml
+++ b/lib/keeper_approval/audit.ml
@@ -399,7 +399,7 @@ let audit_scan_window ?keeper_name n =
 
 let record_audit_read_failure ?keeper_name ?(metric_site = Keeper_approval_queue_failure_site.Audit_read_recent) ~site exn =
   Keeper_fd_pressure.note_exception ~site exn;
-  Otel_metric_store.inc_counter
+  Otel_metric_store_core.inc_counter
     Keeper_metrics.(to_string ApprovalQueueFailures)
     ~labels:
       [ "keeper",

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1037,6 +1037,14 @@ let start_keeper_loops_owned
       f
   in
   let config = workspace_scope.Mcp_server.config in
+  let keeper_owner_count =
+    match Keeper_owner_registry.install_from_store ~sw config with
+    | Ok count -> count
+    | Error error -> raise (Keeper_owner_registry.Install_failed error)
+  in
+  Log.Keeper.info
+    "keeper_owner: installed %d single-owner actor(s) under server root switch"
+    keeper_owner_count;
   (* [claimed_persistence] can only be constructed by the typed one-shot claim
      boundary before readiness publication. No late exception can turn an
      already-visible HTTP state into a degraded bootstrap. *)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -514,10 +514,14 @@ let dashboard_gate_rule_delete_http_json ~base_path ~(args : Yojson.Safe.t)
   | Some id ->
     (match Keeper_approval_queue.delete_rule ~base_path ~id () with
      | Ok deleted ->
-         Keeper_approval.Audit.record_rule
+         Keeper_approval.Audit.record
            ~base_path
            ~event_type:Keeper_approval.Audit.Rule_deleted
-           deleted;
+           ~id:deleted.id
+           ~keeper_name:deleted.keeper_name
+           ~tool_name:deleted.tool_name
+           ?source_approval_id:deleted.source_approval_id
+           ();
          Ok (`Assoc [ "ok", `Bool true; "id", `String deleted.id ])
        | Error error ->
          Error (Keeper_approval_queue.rule_store_error_to_string error))

--- a/scripts/keeper-cwd-leak-gate.sh
+++ b/scripts/keeper-cwd-leak-gate.sh
@@ -65,7 +65,7 @@ if [ "${failures}" -gt 0 ]; then
   echo "Wire the response builder through Keeper_cwd_response.to_yojson_response." >&2
   echo "Reference: lib/keeper/keeper_cwd_response.mli (PR #11323), and the wiring patterns in" >&2
   echo "  lib/keeper/keeper_sandbox_docker.ml" >&2
-  echo "  lib/keeper/keeper_tool_command_runtime.ml (PR #11349)" >&2
+  echo "  lib/keeper/keeper_tool_execute_runtime.ml" >&2
   exit 1
 fi
 

--- a/test/dune
+++ b/test/dune
@@ -1820,6 +1820,7 @@
 (include stanzas/test_keeper_chat_coalescing.inc)
 
 (include stanzas/test_keeper_turn_admission.inc)
+(include stanzas/test_keeper_owner.inc)
 
 
 

--- a/test/fixtures/keeper_system_prompt/assembled_prompt.golden
+++ b/test/fixtures/keeper_system_prompt/assembled_prompt.golden
@@ -24,6 +24,11 @@ You must always respond as golden-keeper.
 - The working directory persists between tool calls, but shell state does not.
 - Prefer relative argv path operands. In Docker, host absolute paths are unavailable.
 </workspace>
+
+<runtime_state>
+- Keeper metadata and current-task binding are runtime-owned projections.
+- Use typed Keeper and task tools; do not edit `.masc/keepers` state files directly.
+</runtime_state>
 <instructions>
 Custom instructions:
 Golden custom instruction line one.

--- a/test/stanzas/test_keeper_owner.inc
+++ b/test/stanzas/test_keeper_owner.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_owner)
+ (modules test_keeper_owner)
+ (libraries masc_test_deps))

--- a/test/test_keeper_cwd_response.ml
+++ b/test/test_keeper_cwd_response.ml
@@ -6,8 +6,9 @@
 
     Background: PR #11080 removed [sandbox_host_root] /
     [playground_path] from [execution_context], but sibling
-    [cwd] fields in [keeper_sandbox_docker] / [keeper_tool_command_runtime]
-    response builders still echoed the host abs path. The Docker
+    [cwd] fields in [Keeper_sandbox_docker] and
+    [Keeper_tool_execute_runtime] response builders still echoed the host
+    absolute path. The Docker
     [--workdir] argument was translated via
     [docker_private_workspace_cwd], yet that translation was not
     propagated into the response JSON, so the LLM re-emitted

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -3,6 +3,7 @@ open Masc
 
 module Reducer = Keeper_owner_reducer
 module Owner = Keeper_owner
+module Owner_registry = Keeper_owner_registry
 
 let make_meta name =
   match
@@ -76,7 +77,7 @@ let test_actor_concurrent_commands_are_exact () =
   let owner =
     Owner.start
       ~sw
-      ~store:{ replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) }
+      ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
       ~initial_meta:(Some (make_meta "concurrent"))
   in
   let commands =
@@ -116,7 +117,7 @@ let test_mailbox_backpressures_without_drop () =
              Eio.Promise.resolve resolve_replace_entered ();
              Eio.Promise.await release_replace);
            Ok ())
-    ; remove = (fun () -> Ok ())
+    ; remove = (fun _ -> Ok ())
     }
   in
   let owner = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "mailbox")) in
@@ -170,7 +171,7 @@ let rec await_idle clock owner remaining =
 let test_child_isolation_and_per_keeper_parallelism () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
-  let store = { Owner.replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) } in
+  let store = { Owner.replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) } in
   let owner_a = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "a")) in
   let owner_b = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "b")) in
   let child_a_started, resolve_child_a_started = Eio.Promise.create () in
@@ -231,7 +232,7 @@ let test_store_failure_is_precommit () =
       ~sw
       ~store:
         { replace = (fun _ -> Error "disk unavailable")
-        ; remove = (fun () -> Error "disk unavailable")
+        ; remove = (fun _ -> Error "disk unavailable")
         }
       ~initial_meta:(Some (make_meta "store-failure"))
   in
@@ -255,7 +256,7 @@ let test_stopping_rejects_new_commands () =
   let owner =
     Owner.start
       ~sw
-      ~store:{ replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) }
+      ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
       ~initial_meta:(Some (make_meta "stopping"))
   in
   ignore (owner_ok (Owner.begin_stopping owner));
@@ -267,6 +268,67 @@ let test_stopping_rejects_new_commands () =
    | Error (Owner.Reducer_rejected Reducer.Owner_stopping) -> ()
    | Error error -> fail ("wrong stopping error: " ^ Owner.error_to_string error)
    | Ok _ -> fail "stopping owner accepted metadata mutation")
+;;
+
+let temp_dir () =
+  let path = Filename.temp_file "keeper-owner-registry-" "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+    then (
+      Array.iter
+        (fun child -> remove_tree (Filename.concat path child))
+        (Sys.readdir path);
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
+let test_root_inventory_loads_and_extends_exactly_once () =
+  Eio_main.run @@ fun env ->
+  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_path)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       let config = Workspace.default_config base_path in
+       ignore (Workspace.init config ~agent_name:(Some "owner-test"));
+       let first = make_meta "inventory-first" in
+       (match Keeper_meta_store.persist_meta config first.name first with
+        | Ok () -> ()
+        | Error detail -> fail ("failed to seed owner meta: " ^ detail));
+       (match Owner_registry.install_from_store ~sw config with
+        | Ok count -> check int "strict startup owner count" 1 count
+        | Error error -> fail (Owner_registry.install_error_to_string error));
+       let loaded =
+         match Owner_registry.get ~base_path ~keeper_name:first.name with
+         | Ok owner -> owner
+         | Error error -> fail (Owner_registry.lookup_error_to_string error)
+       in
+       let ensured =
+         match Owner_registry.ensure ~base_path (make_meta "inventory-second") with
+         | Ok owner -> owner
+         | Error error -> fail (Owner_registry.lookup_error_to_string error)
+       in
+       let loaded_again =
+         match Owner_registry.ensure ~base_path first with
+         | Ok owner -> owner
+         | Error error -> fail (Owner_registry.lookup_error_to_string error)
+       in
+       check bool "ensure preserves the existing actor" true (loaded == loaded_again);
+       check bool "different keeper receives a different actor" false (loaded == ensured);
+       check int
+         "dynamic owner extends inventory once"
+         2
+         (Owner_registry.For_testing.installed_owner_count ~base_path);
+       (match Owner_registry.all_projections ~base_path with
+        | Ok projections -> check int "fleet projection count" 2 (List.length projections)
+        | Error error -> fail (Owner_registry.lookup_error_to_string error)))
 ;;
 
 let () =
@@ -296,6 +358,10 @@ let () =
             "stopping rejects new commands"
             `Quick
             test_stopping_rejects_new_commands
+        ; test_case
+            "root inventory loads and extends exactly once"
+            `Quick
+            test_root_inventory_loads_and_extends_exactly_once
         ] )
     ]
 ;;

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -224,6 +224,38 @@ let test_child_isolation_and_per_keeper_parallelism () =
   ignore (owner_ok (Owner.exact_projection owner_a))
 ;;
 
+let test_cancelled_child_releases_turn_slot () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let owner =
+    Owner.start
+      ~sw
+      ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
+      ~initial_meta:(Some (make_meta "cancelled-child"))
+  in
+  let child_context, resolve_child_context = Eio.Promise.create () in
+  (match
+     owner_ok
+       (Owner.start_turn owner ~operation_id:"cancelled-op" ~run:(fun _turn_sw ->
+          Eio.Cancel.sub (fun cancellation ->
+            Eio.Promise.resolve resolve_child_context cancellation;
+            Eio.Fiber.await_cancel ())))
+   with
+   | Owner.Started -> ()
+   | Busy _ -> fail "owner unexpectedly busy before cancellation");
+  Eio.Cancel.cancel
+    (Eio.Promise.await child_context)
+    (Failure "synthetic child cancellation");
+  await_idle (Eio.Stdenv.clock env) owner 1_000;
+  (match
+     owner_ok
+       (Owner.start_turn owner ~operation_id:"after-cancel" ~run:(fun _ -> ()))
+   with
+   | Owner.Started -> ()
+   | Busy _ -> fail "cancelled child retained the turn slot");
+  await_idle (Eio.Stdenv.clock env) owner 1_000
+;;
+
 let test_store_failure_is_precommit () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
@@ -349,6 +381,10 @@ let () =
             "child isolation and per-keeper parallelism"
             `Quick
             test_child_isolation_and_per_keeper_parallelism
+        ; test_case
+            "cancelled child releases turn slot"
+            `Quick
+            test_cancelled_child_releases_turn_slot
         ; test_case
             "mailbox backpressures without drop"
             `Quick

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -1,0 +1,301 @@
+open Alcotest
+open Masc
+
+module Reducer = Keeper_owner_reducer
+module Owner = Keeper_owner
+
+let make_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name
+        ; "trace_id", `String ("trace-" ^ name)
+        ; "autoboot_enabled", `Bool false
+        ])
+  with
+  | Ok meta -> meta
+  | Error detail -> fail ("meta fixture failed: " ^ detail)
+;;
+
+let usage_delta ?(turns = 1) () : Reducer.usage_delta =
+  { turns
+  ; input_tokens = 2
+  ; output_tokens = 3
+  ; total_tokens = 5
+  ; cost_usd = 0.25
+  ; last_turn_ts = 42.0
+  ; last_input_tokens = 2
+  ; last_output_tokens = 3
+  ; last_total_tokens = 5
+  ; last_usage_reported_at = Some 42.0
+  ; last_latency_ms = 7
+  }
+;;
+
+let reducer_ok = function
+  | Ok transition -> transition.Reducer.state
+  | Error error -> fail (Reducer.error_to_string error)
+;;
+
+let owner_ok = function
+  | Ok value -> value
+  | Error error -> fail (Owner.error_to_string error)
+;;
+
+let test_pure_reducer_adds_deltas_and_preserves_pause () =
+  let state = ref (Reducer.create (Some (make_meta "pure"))) in
+  for index = 1 to 1_000 do
+    state := reducer_ok (Reducer.apply_meta !state (Add_usage (usage_delta ())));
+    if index = 500
+    then
+      state :=
+        reducer_ok
+          (Reducer.apply_meta
+             !state
+             (Pause
+                { reason =
+                    Keeper_latched_reason.Operator_paused
+                      { operator_actor = Keeper_latched_reason.Grpc_directive }
+                ; updated_at = "paused-at-500"
+                }))
+  done;
+  let projection = Reducer.projection !state in
+  let meta = Option.get projection.meta in
+  check int "all turn deltas retained" 1_000 meta.runtime.usage.total_turns;
+  check int "all input deltas retained" 2_000 meta.runtime.usage.total_input_tokens;
+  check int "all output deltas retained" 3_000 meta.runtime.usage.total_output_tokens;
+  check int "all total deltas retained" 5_000 meta.runtime.usage.total_tokens;
+  check (float 0.000_001) "all cost deltas retained" 250.0 meta.runtime.usage.total_cost_usd;
+  check bool "pause bit retained" true meta.paused;
+  check bool "pause latch retained" true (Option.is_some meta.latched_reason)
+;;
+
+let test_actor_concurrent_commands_are_exact () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let owner =
+    Owner.start
+      ~sw
+      ~store:{ replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) }
+      ~initial_meta:(Some (make_meta "concurrent"))
+  in
+  let commands =
+    List.init 1_000 (fun _ () ->
+      ignore (owner_ok (Owner.apply_meta owner (Add_usage (usage_delta ())))))
+  in
+  let pause () =
+    ignore
+      (owner_ok
+         (Owner.apply_meta
+            owner
+            (Pause
+               { reason =
+                   Keeper_latched_reason.Operator_paused
+                     { operator_actor = Keeper_latched_reason.Keeper_down }
+               ; updated_at = "concurrent-pause"
+               })))
+  in
+  Eio.Fiber.all (pause :: commands);
+  let projection = owner_ok (Owner.exact_projection owner) in
+  let meta = Option.get projection.meta in
+  check int "concurrent deltas are exact" 1_000 meta.runtime.usage.total_turns;
+  check bool "concurrent pause is preserved" true meta.paused
+;;
+
+let test_mailbox_backpressures_without_drop () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let replace_entered, resolve_replace_entered = Eio.Promise.create () in
+  let release_replace, resolve_release_replace = Eio.Promise.create () in
+  let first_replace = Atomic.make true in
+  let store =
+    { Owner.replace =
+        (fun _ ->
+           if Atomic.compare_and_set first_replace true false
+           then (
+             Eio.Promise.resolve resolve_replace_entered ();
+             Eio.Promise.await release_replace);
+           Ok ())
+    ; remove = (fun () -> Ok ())
+    }
+  in
+  let owner = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "mailbox")) in
+  let completed = Atomic.make 0 in
+  let all_completed, resolve_all_completed = Eio.Promise.create () in
+  let mark_completed () =
+    if Atomic.fetch_and_add completed 1 = 129
+    then Eio.Promise.resolve resolve_all_completed ()
+  in
+  let submit index () =
+    ignore
+      (owner_ok
+         (Owner.apply_meta
+            owner
+            (Set_autoboot
+               { enabled = index mod 2 = 0
+               ; updated_at = string_of_int index
+               })));
+    mark_completed ()
+  in
+  Eio.Fiber.fork ~sw (submit 0);
+  Eio.Promise.await replace_entered;
+  for index = 1 to 129 do
+    Eio.Fiber.fork ~sw (submit index)
+  done;
+  for _ = 1 to 10 do
+    Eio.Fiber.yield ()
+  done;
+  check int
+    "bounded mailbox reaches its exact capacity"
+    Owner.mailbox_capacity
+    (Owner.For_testing.mailbox_depth owner);
+  check int "no blocked command was dropped" 0 (Atomic.get completed);
+  Eio.Promise.resolve resolve_release_replace ();
+  Eio.Promise.await all_completed;
+  check int "all producers completed after capacity released" 130 (Atomic.get completed);
+  check int "mailbox drained" 0 (Owner.For_testing.mailbox_depth owner)
+;;
+
+let rec await_idle clock owner remaining =
+  if remaining = 0
+  then fail "owner did not return to idle"
+  else
+    match (Owner.projection owner).running_operation_id with
+    | None -> ()
+    | Some _ ->
+      Eio.Time.sleep clock 0.001;
+      await_idle clock owner (remaining - 1)
+;;
+
+let test_child_isolation_and_per_keeper_parallelism () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let store = { Owner.replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) } in
+  let owner_a = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "a")) in
+  let owner_b = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "b")) in
+  let child_a_started, resolve_child_a_started = Eio.Promise.create () in
+  let release_child_a, resolve_release_child_a = Eio.Promise.create () in
+  (match
+     owner_ok
+       (Owner.start_turn owner_a ~operation_id:"op-a" ~run:(fun _turn_sw ->
+          Eio.Promise.resolve resolve_child_a_started ();
+          Eio.Promise.await release_child_a))
+   with
+   | Owner.Started -> ()
+   | Busy _ -> fail "owner a unexpectedly busy");
+  Eio.Promise.await child_a_started;
+  (match
+     owner_ok
+       (Owner.start_turn owner_a ~operation_id:"op-a-2" ~run:(fun _ -> ()))
+   with
+   | Busy { running_operation_id } ->
+     check string "busy identifies current operation" "op-a" running_operation_id
+   | Started -> fail "second turn started concurrently on owner a");
+  let child_b_ran = Atomic.make false in
+  (match
+     owner_ok
+       (Owner.start_turn owner_b ~operation_id:"op-b" ~run:(fun _ ->
+          Atomic.set child_b_ran true))
+   with
+   | Started -> ()
+   | Busy _ -> fail "independent owner b was blocked by owner a");
+  await_idle (Eio.Stdenv.clock env) owner_b 1_000;
+  check bool "independent keeper ran concurrently" true (Atomic.get child_b_ran);
+  ignore
+    (owner_ok
+       (Owner.apply_meta
+          owner_a
+          (Set_autoboot { enabled = true; updated_at = "while-running" })));
+  check bool
+    "actor processed metadata while child was running"
+    true
+    (Option.get (Owner.projection owner_a).meta).autoboot_enabled;
+  Eio.Promise.resolve resolve_release_child_a ();
+  await_idle (Eio.Stdenv.clock env) owner_a 1_000;
+  (match
+     owner_ok
+       (Owner.start_turn owner_a ~operation_id:"op-exn" ~run:(fun _ ->
+          raise (Failure "synthetic child failure")))
+   with
+   | Started -> ()
+   | Busy _ -> fail "owner remained busy after first child");
+  await_idle (Eio.Stdenv.clock env) owner_a 1_000;
+  ignore (owner_ok (Owner.exact_projection owner_a))
+;;
+
+let test_store_failure_is_precommit () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let owner =
+    Owner.start
+      ~sw
+      ~store:
+        { replace = (fun _ -> Error "disk unavailable")
+        ; remove = (fun () -> Error "disk unavailable")
+        }
+      ~initial_meta:(Some (make_meta "store-failure"))
+  in
+  (match
+     Owner.apply_meta
+       owner
+       (Set_autoboot { enabled = true; updated_at = "must-not-publish" })
+   with
+   | Error (Owner.Store_unavailable "disk unavailable") -> ()
+   | Error error -> fail ("wrong store error: " ^ Owner.error_to_string error)
+   | Ok _ -> fail "store failure was reported as success");
+  check bool
+    "failed persistence leaves projection unchanged"
+    false
+    (Option.get (Owner.projection owner).meta).autoboot_enabled
+;;
+
+let test_stopping_rejects_new_commands () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let owner =
+    Owner.start
+      ~sw
+      ~store:{ replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) }
+      ~initial_meta:(Some (make_meta "stopping"))
+  in
+  ignore (owner_ok (Owner.begin_stopping owner));
+  (match
+     Owner.apply_meta
+       owner
+       (Set_autoboot { enabled = true; updated_at = "rejected" })
+   with
+   | Error (Owner.Reducer_rejected Reducer.Owner_stopping) -> ()
+   | Error error -> fail ("wrong stopping error: " ^ Owner.error_to_string error)
+   | Ok _ -> fail "stopping owner accepted metadata mutation")
+;;
+
+let () =
+  run
+    "keeper owner"
+    [ ( "reducer"
+      , [ test_case
+            "additive usage and pause are exact"
+            `Quick
+            test_pure_reducer_adds_deltas_and_preserves_pause
+        ] )
+    ; ( "actor"
+      , [ test_case
+            "concurrent commands are exact"
+            `Quick
+            test_actor_concurrent_commands_are_exact
+        ; test_case
+            "child isolation and per-keeper parallelism"
+            `Quick
+            test_child_isolation_and_per_keeper_parallelism
+        ; test_case
+            "mailbox backpressures without drop"
+            `Quick
+            test_mailbox_backpressures_without_drop
+        ; test_case "store failure is precommit" `Quick test_store_failure_is_precommit
+        ; test_case
+            "stopping rejects new commands"
+            `Quick
+            test_stopping_rejects_new_commands
+        ] )
+    ]
+;;

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -74,8 +74,8 @@ let test_container_path_translation_under_sandbox () =
       let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
       let host_cwd = Filename.concat host_root "repos/foo" in
       let container_cwd =
-        Keeper_sandbox_docker.docker_private_workspace_cwd ~config ~meta
-          host_cwd
+        Keeper_sandbox_docker_container_name.docker_private_workspace_cwd
+          ~config ~meta host_cwd
       in
       (* Sanity: translation produced an in-container path rooted
          at the SSOT container playground prefix. *)

--- a/test/test_keeper_system_prompt_bytes.ml
+++ b/test/test_keeper_system_prompt_bytes.ml
@@ -122,6 +122,8 @@ let test_assembled_prompt_carries_system_anchor () =
     (contains ("You are " ^ golden_keeper_name ^ "."));
   check bool "workspace block carries the sandbox root" true
     (contains golden_workspace_root);
+  check bool "runtime state ownership reaches the prompt" true
+    (contains "Keeper metadata and current-task binding are runtime-owned projections.");
   check bool "custom instructions reach the prompt" true
     (contains "Golden custom instruction line one.");
   check bool "active goals reach the prompt" true (contains "goal-golden-1")

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -167,7 +167,7 @@ let () =
               let received_args = ref `Null in
               let capture_handler ~name:_ ~args =
                 received_args := args;
-                Some (tool_ok "captured")
+                tool_ok "captured"
               in
               register_full
                 ~tool_name:tool


### PR DESCRIPTION
## What changed

- add a pure immutable Keeper owner reducer with a closed metadata command set
- add a per-Keeper Eio actor using a capacity-128 bounded mailbox and typed Promise request/response
- install the owner inventory under the server root switch
- route current-task metadata mutations through owner commands
- release the turn slot under protected settlement when a child is cancelled, then preserve cancellation propagation
- remove current-task reconciliation re-exports from `Keeper_agent_tool_surface`
- update the Keeper model-facing prompt, golden fixture, spec, and RFCs with the runtime-owned metadata contract

## Current boundary

This Draft is not the completed hard cut. `Keeper_owner.start_turn` still has no production caller, and direct `Keeper_meta_store` writers remain. Turn entry-point wiring, remaining metadata writer conversion/CAS removal, and public API/Dashboard projection hard cuts remain before Ready. No compatibility facade, migration path, feature flag, or dual-write path is introduced.

## Validation

- Previous head: `scripts/dune-local.sh exec test/test_keeper_owner.exe` passed 6/6 before the latest cancellation/prompt commit.
- Added a cancellation regression and updated the exact prompt golden, but local tests/build were not run by request; GitHub Actions is authoritative.
- Current base-derived stale command-runtime doc/matrix failures are addressed separately by #27726 and will be removed by rebasing after it merges.
- Keep Draft until current-head CI is green and production turn admission/direct-writer hard cuts are complete.