### PR TITLE
fix: restore extracted approval build boundaries

### DIFF
--- a/lib/dashboard/dune
+++ b/lib/dashboard/dune
@@ -75,6 +75,7 @@
   masc.discovery_cache
   masc.local_runtime_pool
   masc.keeper_contract
+  masc.keeper_approval
   masc.compaction_trigger
   masc.bounded_event_dedupe
   masc.tool_catalog_surfaces

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -3179,7 +3179,12 @@ let remember_rule_for_entry ~base_path ?created_by ?rule_expires_at (entry : pen
         ()
     with
     | Ok (rule, created) ->
-      if created then audit_rule_event ~base_path ~event_type:Keeper_approval.Audit.Rule_created rule;
+      if created
+      then
+        Keeper_approval.Audit.record_rule
+          ~base_path
+          ~event_type:Keeper_approval.Audit.Rule_created
+          rule;
       Ok rule
     | Error reason -> Error reason
   with

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -280,12 +280,14 @@ let decision_to_yojson = function
    what it is missing is the tag. Map to the payload-free contract variant
    rather than a string, so a new Gate authority cannot reach the audit log
    without this match being updated. *)
-let audit_authorization_source : authorization_source -> Keeper_approval_queue.authorization_source
+let audit_authorization_source
+  : authorization_source -> Keeper_approval_queue_rules_types.authorization_source
   = function
-  | One_shot_resolution _ -> Keeper_approval_queue.One_shot_resolution
-  | Exact_always_rule _ -> Keeper_approval_queue.Exact_always_rule
-  | Keeper_always_allow -> Keeper_approval_queue.Keeper_always_allow
-  | Workspace_always_allow -> Keeper_approval_queue.Workspace_always_allow
+  | One_shot_resolution _ -> Keeper_approval_queue_rules_types.One_shot_resolution
+  | Exact_always_rule _ -> Keeper_approval_queue_rules_types.Exact_always_rule
+  | Keeper_always_allow -> Keeper_approval_queue_rules_types.Keeper_always_allow
+  | Workspace_always_allow ->
+    Keeper_approval_queue_rules_types.Workspace_always_allow
 ;;
 
 let audit_allow request ?rule_match ?source_approval_id ?decision_source source =

--- a/lib/keeper_approval/audit.ml
+++ b/lib/keeper_approval/audit.ml
@@ -234,7 +234,7 @@ let audit_today_path base_dir =
 let get_audit_store ~base_path () =
   let report_failure exn =
     Keeper_fd_pressure.note_exception ~site:"approval_audit.store_create" exn;
-    Otel_metric_store.inc_counter
+    Otel_metric_store_core.inc_counter
       Keeper_metrics.(to_string ApprovalQueueFailures)
       ~labels:
         [ "keeper", "aggregate"

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -29,6 +29,7 @@
   ;; through Keeper_compaction_evidence.exact_evidence_key; dune does not
   ;; re-export it through the masc dep, so masc_server lists it explicitly.
   masc.keeper_compaction_evidence
+  masc.keeper_approval
   ;; RFC-0266 Phase 4: GET /api/v1/dashboard/fusion-runs names
   ;; Fusion_run_registry directly; dune does not re-export it through the masc
   ;; dep, so masc_server lists masc.fusion_core explicitly.

--- a/packages/agent_core/lib/agent/agent_lifecycle_events.ml
+++ b/packages/agent_core/lib/agent/agent_lifecycle_events.ml
@@ -65,7 +65,7 @@ let publish_finished ~event_bus ~agent_name ~started ~current_run_id ~outcome ~e
           (Printf.sprintf "Event_bus.publish failed (%s)" label)
           [ Log.S ("error", Printexc.to_string exn) ]
     in
-    match outcome with
+    (match outcome with
      | Completed response ->
        publish
          "AgentCompleted"
@@ -86,7 +86,7 @@ let publish_finished ~event_bus ~agent_name ~started ~current_run_id ~outcome ~e
             { agent_name; task_id = started_run_id; result = Error error; elapsed });
        publish
          "AgentFailed"
-         (AgentFailed { agent_name; task_id = started_run_id; error; elapsed })
+         (AgentFailed { agent_name; task_id = started_run_id; error; elapsed }))
   | None, _ | Some _, None -> ()
 ;;
 


### PR DESCRIPTION
## Summary
- delimit the nested Agent lifecycle outcome match so outer option arms type-check
- keep extracted approval audit on its declared metric-core dependency
- project Gate authorization into the shared typed audit vocabulary
- route remembered-rule audit through the extracted `Keeper_approval.Audit` owner
- declare direct approval-library dependencies for Dashboard and Server consumers

## Evidence
- `ocamlformat` passed on changed OCaml files
- `git diff --check` passed
- user full build exposed and this patch addresses all seven reported compile sites
- focused/full compile is pending because another workspace build held the shared Dune lock; required CI remains authoritative

## Scope
Small compile-boundary hotfix only. No runtime behavior/config migration or compatibility shim.