### PR TITLE
refactor: remove local runtime reexports

### DIFF
--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -1,6 +1,6 @@
-(** Tool_local_runtime -- local model runtime management and benchmarking tools.
+(** Tool_local_runtime -- local model runtime MCP dispatch and schemas.
 
-    Facade module that re-exports sub-modules and provides MCP dispatch/schemas.
+    Handler implementations are split across:
     Implementation is split across:
     - Tool_local_runtime_core   : types, helpers, process discovery, model fetching
     - Tool_local_runtime_http   : HTTP helpers (curl wrappers, JSON member access)
@@ -12,13 +12,6 @@
 open Masc_domain
 
 module Core = Tool_local_runtime_core
-
-(* Re-export sub-module public values used by external callers *)
-let runtime_verify_json = Tool_local_runtime_verify.runtime_verify_json
-let runtime_ollama_probe_json = Tool_local_runtime_probe.runtime_ollama_probe_json
-let ollama_loaded_models_of_ps_json = Tool_local_runtime_probe.ollama_loaded_models_of_ps_json
-let ollama_probe_run_of_generate_json = Tool_local_runtime_probe.ollama_probe_run_of_generate_json
-let kv_cache_assessment_json = Tool_local_runtime_probe.kv_cache_assessment_json
 
 let ok_response ~tool_name ~start_time fields : Core.tool_result =
   Tool_result.make_ok
@@ -60,7 +53,8 @@ let handle_runtime_verify _ctx args : Core.tool_result =
     ~start_time
     [
       ( "result",
-        runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_model () );
+        Tool_local_runtime_verify.runtime_verify_json
+          ?runtime_pool ?expected_slots ?expected_ctx ?expected_model () );
     ]
 
 let run_runtime_ollama_probe ?timeout_sec args : Core.tool_result =
@@ -125,7 +119,8 @@ let run_runtime_ollama_probe ?timeout_sec args : Core.tool_result =
         ~start_time
         [
           ( "result",
-            runtime_ollama_probe_json ?server_url ?model ?prompt ?keep_alive
+            Tool_local_runtime_probe.runtime_ollama_probe_json
+              ?server_url ?model ?prompt ?keep_alive
               ~probe_runs ~max_tokens ~think_mode ?timeout_sec
               ~generate_when_unloaded ~run_generate () );
         ]

--- a/lib/tool_local_runtime.mli
+++ b/lib/tool_local_runtime.mli
@@ -20,35 +20,11 @@
     kept on {!Tool_local_runtime_core}; this top-level module no
     longer re-exports that surface.
 
-    Internal: the two [handle_*] functions [dispatch] routes to
+    The two [handle_*] functions [dispatch] routes to
     ([handle_runtime_verify], [handle_runtime_ollama_probe]) plus the
     [Tool_spec.register] side-effect block stay private.  The .mli pins
-    the dispatch / schemas contract — handler bodies are free to
-    refactor.
-
-    The re-exports left below are the ones tests reach through this
-    facade; the status / verify / bench adapters had no consumer at
-    all. *)
-
-(** {1 Status / verify / probe / bench re-exports} *)
-
-val ollama_loaded_models_of_ps_json :
-  Yojson.Safe.t -> [> `Assoc of (string * Yojson.Safe.t) list ] list
-(** Re-export of
-    {!Tool_local_runtime_probe.ollama_loaded_models_of_ps_json}. *)
-
-val ollama_probe_run_of_generate_json :
-  run_index:int ->
-  http_status:int option ->
-  wall_clock_ms:int ->
-  Yojson.Safe.t ->
-  Tool_local_runtime_probe.ollama_probe_run
-(** Re-export of
-    {!Tool_local_runtime_probe.ollama_probe_run_of_generate_json}. *)
-
-val kv_cache_assessment_json : Yojson.Safe.t list -> Yojson.Safe.t
-(** Re-export of
-    {!Tool_local_runtime_probe.kv_cache_assessment_json}. *)
+    the dispatch / schemas contract. Probe and verification helpers remain on
+    their owning modules instead of being re-exported here. *)
 
 (** {1 MCP dispatch contract} *)
 

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -21,7 +21,7 @@ let test_ollama_ps_parser_extracts_loaded_models () =
     Yojson.Safe.from_string
       {|{"models":[{"name":"qwen3.5:35b-a3b-coding-nvfp4","model":"qwen3.5:35b-a3b-coding-nvfp4","size_vram":21474836480,"context_length":262144,"expires_at":"2026-04-10T00:00:00Z"}]}|}
   in
-  let models = Masc.Tool_local_runtime.ollama_loaded_models_of_ps_json json in
+  let models = Masc.Tool_local_runtime_probe.ollama_loaded_models_of_ps_json json in
   let open Yojson.Safe.Util in
   check int "one loaded model" 1 (List.length models);
   let model = List.hd models in
@@ -39,7 +39,7 @@ let test_ollama_generate_parser_computes_tok_per_second () =
       {|{"response":"READY","done":true,"done_reason":"stop","total_duration":9104952708,"load_duration":3338399458,"prompt_eval_count":20,"prompt_eval_duration":337442459,"eval_count":311,"eval_duration":5428288000,"thinking":"hidden"}|}
   in
   let run_json =
-    Masc.Tool_local_runtime.ollama_probe_run_of_generate_json ~run_index:1
+    Masc.Tool_local_runtime_probe.ollama_probe_run_of_generate_json ~run_index:1
       ~http_status:(Some 200) ~wall_clock_ms:9120 json
   in
   let prompt_tps =
@@ -272,7 +272,7 @@ let test_kv_cache_assessment_detects_repeat_improvement () =
         ];
     ]
   in
-  let assessment = Masc.Tool_local_runtime.kv_cache_assessment_json runs in
+  let assessment = Masc.Tool_local_runtime_probe.kv_cache_assessment_json runs in
   let open Yojson.Safe.Util in
   check string "likely reuse" "likely_reused"
     (assessment |> member "signal" |> to_string);
@@ -284,7 +284,7 @@ let test_kv_cache_assessment_detects_repeat_improvement () =
 
 let test_kv_cache_assessment_requires_two_successful_runs () =
   let assessment =
-    Masc.Tool_local_runtime.kv_cache_assessment_json
+    Masc.Tool_local_runtime_probe.kv_cache_assessment_json
       [ `Assoc [ ("run_index", `Int 1) ] ]
   in
   let open Yojson.Safe.Util in


### PR DESCRIPTION
## Summary
- keep `Tool_local_runtime` focused on MCP dispatch and schema registration
- call verify/probe owners directly inside the dispatcher
- move probe tests from facade re-exports to `Tool_local_runtime_probe`
- remove three public probe re-exports

## Why
The removed bindings added no behavior and made tests depend on a forwarding surface rather than the module that owns probe parsing and assessment.

## Validation
- local build/tests not run; CI is authoritative