### PR TITLE
fix(dashboard): widen keeper queue timeline cards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1932,6 +1932,21 @@ jobs:
           path: ${{ runner.temp }}/keeper-queued-stream/*.png
           if-no-files-found: warn
 
+      - name: Run Keeper lane-timeline Playwright E2E
+        id: keeper_lane_timeline_e2e
+        working-directory: dashboard
+        env:
+          KEEPER_LANE_TIMELINE_ARTIFACT_DIR: ${{ runner.temp }}/keeper-lane-timeline
+        run: pnpm test:e2e:keeper-lane
+
+      - name: Upload Keeper lane-timeline screenshots
+        if: ${{ always() && !cancelled() && steps.keeper_lane_timeline_e2e.outcome != 'skipped' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: keeper-lane-timeline-screenshots
+          path: ${{ runner.temp }}/keeper-lane-timeline/*.png
+          if-no-files-found: warn
+
   structure-ratchet:
     name: OCaml Structure Ratchet
     runs-on: ubuntu-latest

--- a/dashboard/dev-fixtures/keeper-lane-timeline-fixture.html
+++ b/dashboard/dev-fixtures/keeper-lane-timeline-fixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Keeper lane timeline contract</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/demo/keeper-lane-timeline-fixture.ts"></script>
+  </body>
+</html>

--- a/dashboard/e2e/keeper-lane-timeline.mjs
+++ b/dashboard/e2e/keeper-lane-timeline.mjs
@@ -30,13 +30,31 @@ try {
   }
   await timestamp.locator('time').waitFor()
 
-  await firstRow.getByText('Typed queue evidence', { exact: true }).click()
-  await firstRow.getByText('keeper_process_external_attention', { exact: true }).waitFor()
+  const evidence = firstRow.locator('details')
+  await evidence.getByText('Typed queue evidence', { exact: true }).click()
+  if (!(await evidence.evaluate((node) => node.open))) {
+    throw new Error('the typed queue evidence disclosure did not open')
+  }
+  await evidence.getByText('external_attention_store', { exact: true }).waitFor()
   await page.screenshot({ path: desktopScreenshot, fullPage: true })
 
-  await page.setViewportSize({ width: 390, height: 844 })
-  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth)
-  if (overflow > 1) throw new Error(`the timeline overflows the mobile viewport by ${overflow}px`)
+  for (const width of [390, 360, 320]) {
+    await page.setViewportSize({ width, height: 844 })
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth)
+    if (overflow > 1) throw new Error(`the page overflows the ${width}px viewport by ${overflow}px`)
+
+    const internalOverflow = await graph.evaluate((node) => node.scrollWidth - node.clientWidth)
+    if (internalOverflow > 1) {
+      throw new Error(`the timeline overflows its graph at ${width}px by ${internalOverflow}px`)
+    }
+
+    const overflowingRow = await rows.evaluateAll((nodes) =>
+      nodes.findIndex((node) => node.scrollWidth - node.clientWidth > 1),
+    )
+    if (overflowingRow !== -1) {
+      throw new Error(`queue row ${overflowingRow} overflows at ${width}px`)
+    }
+  }
   await page.screenshot({ path: mobileScreenshot, fullPage: true })
 
   process.stdout.write(`desktop_screenshot=${desktopScreenshot}\n`)

--- a/dashboard/e2e/keeper-lane-timeline.mjs
+++ b/dashboard/e2e/keeper-lane-timeline.mjs
@@ -1,0 +1,46 @@
+import { chromium } from 'playwright'
+
+const fixtureUrl = process.env.KEEPER_LANE_TIMELINE_FIXTURE_URL
+if (!fixtureUrl) throw new Error('KEEPER_LANE_TIMELINE_FIXTURE_URL is required')
+
+const artifactDir = process.env.KEEPER_LANE_TIMELINE_ARTIFACT_DIR ?? '/tmp'
+const desktopScreenshot = `${artifactDir}/keeper-lane-timeline-desktop.png`
+const mobileScreenshot = `${artifactDir}/keeper-lane-timeline-mobile.png`
+
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } })
+  await page.goto(fixtureUrl)
+
+  const graph = page.getByTestId('keeper-lane-graph')
+  await graph.waitFor()
+  const rows = page.getByTestId('keeper-lane-waiting-row')
+  if (await rows.count() !== 3) throw new Error('the fixture did not render all queue rows')
+
+  const firstRow = rows.first()
+  const card = firstRow.locator(':scope > div').nth(1)
+  const timestamp = page.getByTestId('keeper-lane-waiting-time').first()
+  if (!(await card.locator('[data-testid="keeper-lane-waiting-time"]').count())) {
+    throw new Error('the timestamp is not inside the widened queue card')
+  }
+  const rowBox = await firstRow.boundingBox()
+  const cardBox = await card.boundingBox()
+  if (!rowBox || !cardBox || cardBox.width / rowBox.width < 0.9) {
+    throw new Error('the queue card did not receive the timeline width')
+  }
+  await timestamp.locator('time').waitFor()
+
+  await firstRow.getByText('Typed queue evidence', { exact: true }).click()
+  await firstRow.getByText('keeper_process_external_attention', { exact: true }).waitFor()
+  await page.screenshot({ path: desktopScreenshot, fullPage: true })
+
+  await page.setViewportSize({ width: 390, height: 844 })
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth)
+  if (overflow > 1) throw new Error(`the timeline overflows the mobile viewport by ${overflow}px`)
+  await page.screenshot({ path: mobileScreenshot, fullPage: true })
+
+  process.stdout.write(`desktop_screenshot=${desktopScreenshot}\n`)
+  process.stdout.write(`mobile_screenshot=${mobileScreenshot}\n`)
+} finally {
+  await browser.close()
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -16,6 +16,7 @@
     "preview": "vite preview",
     "test": "vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1",
     "test:serial": "pnpm test",
+    "test:e2e:keeper-lane": "../scripts/harness_dashboard_keeper_lane_timeline_e2e.sh",
     "test:e2e:queued-stream": "../scripts/harness_dashboard_keeper_queued_stream_e2e.sh",
     "test:watch": "vitest",
     "tokens:build": "tsx design-system/tokens/build.ts",

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -200,6 +200,12 @@ describe('KeeperLaneStrip', () => {
       'discord-old',
     ])
     expect(el.querySelector('[data-testid="keeper-lane-graph"]')).not.toBeNull()
+    const renderedTimes = Array.from(el.querySelectorAll('[data-testid="keeper-lane-waiting-time"] time'))
+    expect(renderedTimes.map(time => time.getAttribute('datetime'))).toEqual([
+      '2026-08-08T10:12:03Z',
+      '2026-08-08T06:39:09Z',
+      '2026-08-06T03:59:42Z',
+    ])
     expect(el.textContent ?? '').toContain('최신 관측 → 오래된 관측')
     expect(el.textContent ?? '').toContain('처리 우선순위를 뜻하지 않습니다')
     expect(el.textContent ?? '').toContain('실행 예정')

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -178,14 +178,8 @@ function LaneWaitingRow({
       data-testid="keeper-lane-waiting-row"
       data-source=${row.source}
       data-waiting-on=${row.waiting_on}
-      class="grid grid-cols-[6.75rem_1.25rem_minmax(0,1fr)] gap-2"
+      class="grid grid-cols-[1.25rem_minmax(0,1fr)] gap-2"
     >
-      <div class="py-2 text-right text-3xs text-[var(--color-fg-muted)]">
-        ${row.since_iso == null
-          ? html`<span>시각 미기록</span>`
-          : html`<time dateTime=${row.since_iso}>${formatDateTimeKo(row.since_iso)}</time>`}
-        ${sinceRelative == null ? null : html`<span class="block">${sinceRelative}</span>`}
-      </div>
       <div class="relative min-h-full" aria-hidden="true">
         ${first ? null : html`<span class="absolute left-1/2 top-0 h-1/2 -translate-x-1/2 border-l border-[var(--color-border-default)]"></span>`}
         ${last ? null : html`<span class="absolute bottom-0 left-1/2 h-1/2 -translate-x-1/2 border-l border-[var(--color-border-default)]"></span>`}
@@ -195,6 +189,15 @@ function LaneWaitingRow({
         ></span>
       </div>
       <div class="my-1 grid min-w-0 gap-1.5 rounded-[var(--r-1)] border border-[var(--color-border-subtle)] bg-[var(--color-bg-page)] p-2">
+        <div
+          class="flex min-w-0 flex-wrap items-baseline justify-between gap-x-2 gap-y-0.5 text-3xs text-[var(--color-fg-muted)]"
+          data-testid="keeper-lane-waiting-time"
+        >
+          ${row.since_iso == null
+            ? html`<span>시각 미기록</span>`
+            : html`<time dateTime=${row.since_iso}>${formatDateTimeKo(row.since_iso)}</time>`}
+          ${sinceRelative == null ? null : html`<span>${sinceRelative}</span>`}
+        </div>
         <div class="flex min-w-0 flex-wrap items-center gap-1.5">
           <${StatusChip} tone=${sourceTone(row.source)} uppercase=${false} title=${row.source}>${laneSourceLabel(row.source)}<//>
           <span class="min-w-0 truncate font-mono text-xs text-[var(--color-fg-primary)]" title=${row.waiting_on}>${row.waiting_on}</span>

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -209,10 +209,10 @@ function LaneWaitingRow({
         ${row.due_at_iso == null
           ? null
           : html`<div class="text-2xs text-[var(--status-warn)]">실행 예정 · <time dateTime=${row.due_at_iso}>${formatDateTimeKo(row.due_at_iso)}</time> · ${formatTimeUntil(row.due_at_iso)}</div>`}
-        <details class="text-3xs text-[var(--color-fg-muted)]">
+        <details class="min-w-0 text-3xs text-[var(--color-fg-muted)]" style=${{ overflowWrap: 'anywhere' }}>
           <summary class="cursor-pointer select-none">Typed queue evidence</summary>
-          <div class="mt-2 grid gap-2">
-            <div class="flex flex-wrap gap-x-3">
+          <div class="mt-2 grid min-w-0 gap-2">
+            <div class="flex min-w-0 flex-wrap gap-x-3">
               <span>wake producer · <code>${row.wake_producer ?? '미기록'}</code></span>
               <span>source · <code>${row.source}</code></span>
             </div>

--- a/dashboard/src/demo/keeper-lane-timeline-fixture.ts
+++ b/dashboard/src/demo/keeper-lane-timeline-fixture.ts
@@ -1,0 +1,89 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { html } from 'htm/preact'
+import { render } from 'preact'
+
+import type { DashboardKeeperWaitingInventory } from '../api'
+import { KeeperLaneStrip } from '../components/keeper-workspace/keeper-lane-strip'
+import type { Keeper } from '../types'
+
+const keeper = { name: 'sangsu', agent_name: 'agent-sangsu' } as Keeper
+
+const inventory: DashboardKeeperWaitingInventory = {
+  schema: 'masc.dashboard.keeper_waiting_inventory.v3',
+  source: 'server_keeper_waiting_inventory',
+  generated_at: '2026-08-09T00:00:00Z',
+  supported_states: ['idle', 'busy', 'waiting', 'deferred'],
+  keeper_count_known: true,
+  keeper_count: 1,
+  waiting_keeper_count: 1,
+  row_count: 3,
+  keepers: [
+    {
+      keeper_name: 'sangsu',
+      state: 'waiting',
+      waiting_count: 3,
+      sources: { external_attention: 2, schedule_waiting: 1 },
+      next_action: 'keeper_process_external_attention',
+      waiting_on: [
+        {
+          keeper_name: 'sangsu',
+          source: 'external_attention',
+          waiting_on: 'discord:product-review',
+          wake_producer: 'keeper_process_external_attention',
+          since_iso: '2026-08-08T10:12:03Z',
+          next_action: 'keeper_process_external_attention',
+          detail: { event_id: 'evt-new', connector: 'discord' },
+        },
+        {
+          keeper_name: 'sangsu',
+          source: 'schedule_waiting',
+          waiting_on: 'masc.keeper_wake',
+          wake_producer: 'schedule_runner',
+          since_iso: '2026-08-08T06:39:09Z',
+          due_at_iso: '2026-08-09T07:29:34Z',
+          next_action: 'wait_until_due',
+          detail: { schedule_id: 'daily-news' },
+        },
+        {
+          keeper_name: 'sangsu',
+          source: 'external_attention',
+          waiting_on: 'discord:incident-room',
+          wake_producer: 'keeper_process_external_attention',
+          since_iso: '2026-08-06T03:59:42Z',
+          next_action: 'keeper_process_external_attention',
+          detail: { event_id: 'evt-old', connector: 'discord' },
+        },
+      ],
+    },
+  ],
+}
+
+const root = document.getElementById('app')
+if (root) {
+  render(
+    html`
+      <main
+        class="min-h-screen px-4 py-8"
+        style="background: var(--color-bg-page); color: var(--color-fg-primary);"
+        data-testid="keeper-lane-timeline-fixture"
+      >
+        <section
+          class="ctx-panel mx-auto max-w-[980px] rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4"
+        >
+          <${KeeperLaneStrip}
+            keeper=${keeper}
+            inventory=${inventory}
+            ready=${true}
+            loading=${false}
+            error=${null}
+            pushReady=${true}
+          />
+        </section>
+      </main>
+    `,
+    root,
+  )
+}

--- a/dashboard/src/demo/keeper-lane-timeline-fixture.ts
+++ b/dashboard/src/demo/keeper-lane-timeline-fixture.ts
@@ -26,13 +26,12 @@ const inventory: DashboardKeeperWaitingInventory = {
       state: 'waiting',
       waiting_count: 3,
       sources: { external_attention: 2, schedule_waiting: 1 },
-      next_action: 'keeper_process_external_attention',
       waiting_on: [
         {
           keeper_name: 'sangsu',
           source: 'external_attention',
           waiting_on: 'discord:product-review',
-          wake_producer: 'keeper_process_external_attention',
+          wake_producer: 'external_attention_store',
           since_iso: '2026-08-08T10:12:03Z',
           next_action: 'keeper_process_external_attention',
           detail: { event_id: 'evt-new', connector: 'discord' },
@@ -51,7 +50,7 @@ const inventory: DashboardKeeperWaitingInventory = {
           keeper_name: 'sangsu',
           source: 'external_attention',
           waiting_on: 'discord:incident-room',
-          wake_producer: 'keeper_process_external_attention',
+          wake_producer: 'external_attention_store',
           since_iso: '2026-08-06T03:59:42Z',
           next_action: 'keeper_process_external_attention',
           detail: { event_id: 'evt-old', connector: 'discord' },

--- a/scripts/harness_dashboard_keeper_lane_timeline_e2e.sh
+++ b/scripts/harness_dashboard_keeper_lane_timeline_e2e.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5190}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-lane-timeline-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-keeper-lane-timeline-vite-${PORT}.log"
+ARTIFACT_DIR="${KEEPER_LANE_TIMELINE_ARTIFACT_DIR:-${TMPDIR:-/tmp}}"
+
+mkdir -p "${ARTIFACT_DIR}"
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    sed -n '1,200p' "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+KEEPER_LANE_TIMELINE_FIXTURE_URL="${FIXTURE_URL}" \
+KEEPER_LANE_TIMELINE_ARTIFACT_DIR="${ARTIFACT_DIR}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec node e2e/keeper-lane-timeline.mjs
+
+printf 'keeper lane timeline Playwright E2E passed\n'


### PR DESCRIPTION
## What changed

- move each waiting item's absolute and relative timestamps into its card
- reserve the rail's left column only for the chronological graph spine
- keep exact `datetime` values available for ordering and inspection

## Why

The queue timeline lives in a 271px Keeper context rail. Its previous fixed 6.75rem timestamp column left roughly half the rail for the actual source, waiting value, next action, and typed evidence. Live Playwright screenshots showed severe wrapping and a multi-thousand-pixel expanded timeline.

This keeps the existing newest-to-oldest observation semantics while making each node readable in the real rail width.

## Validation

- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-workspace/keeper-lane-strip.test.ts` (13 passed)
- `pnpm typecheck`
- `pnpm build`
- live-backend Playwright against `127.0.0.1:8935` through this branch's Vite UI (2 passed: chronological queue interaction and retained RAW byte equality / JSON-tree switch)
