### PR TITLE
fix(keeper): complete approval audit boundary split

### DIFF
--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -247,63 +247,6 @@ val find_matching_rule :
   (rule_lookup, rule_store_error) result
 
 val generate_id : unit -> string
-val recent_resolved_history_limit : int
-val recent_resolved_max_limit : int
-val recent_resolved_default_window_minutes : int
-val recent_resolved_min_window_minutes : int
-val recent_resolved_max_window_minutes : int
-
-val read_recent_audit :
-  base_path:string -> ?keeper_name:string -> ?n:int -> unit -> Yojson.Safe.t list
-
-val audit_day_string_of_ts : float -> string
-(** Day key ["YYYY-MM-DD"] for the [YYYY-MM/DD.jsonl] audit layout. Exposed as
-    a pure function so the UTC invariant is testable: the write path
-    ([Jsonl_writer.dated_path]) picks the day file with [Unix.gmtime], so a
-    local-time key would read the wrong file for the hours where the two
-    calendars disagree. *)
-
-type resolved_history =
-  { resolved_rows : Yojson.Safe.t list
-  ; resolved_matched : int
-  ; resolved_limit : int
-  ; resolved_window_minutes : int
-  ; resolved_scan_exhausted : bool
-  }
-(** A page of resolved Gate decisions together with the bounds that produced
-    it. [resolved_rows] is newest first and holds at most [resolved_limit]
-    entries; [resolved_matched] counts every resolved decision the scan saw
-    inside the window, so [resolved_matched > resolved_limit] means the page is
-    a slice rather than the whole window. [resolved_scan_exhausted] reports the
-    second bound: the physical row cap stopped the scan before it reached the
-    window start, so even [resolved_matched] undercounts. Rendering only
-    [resolved_rows] reintroduces the silent truncation this type removes. *)
-
-val list_recent_resolved :
-  base_path:string ->
-  now_ts:float ->
-  ?limit:int ->
-  ?window_minutes:int ->
-  unit ->
-  resolved_history
-(** [list_recent_resolved ~base_path ~now_ts ()] returns resolved Gate decisions
-    from the last [window_minutes] (default
-    {!recent_resolved_default_window_minutes}, clamped to
-    [[recent_resolved_min_window_minutes, recent_resolved_max_window_minutes]]),
-    newest first, capped at [limit] (default
-    {!recent_resolved_history_limit}, clamped to
-    [[0, recent_resolved_max_limit]]).
-
-    [now_ts] is supplied by the caller rather than read here, matching
-    {!Dashboard_gate_metrics.tool_rejection_counts}: the observation boundary
-    captures the clock once for the whole projection, and this function stays
-    deterministic so a test can pin an exact window.
-
-    Rows without a [ts] are excluded: a wall-clock window cannot place an
-    undated decision, and dating it by guesswork would misreport history.
-
-    Storage failures are reported through the approval-queue failure metric and
-    yield an empty page rather than raising. *)
 
 module For_testing : sig
   type strict_snapshot_writer =

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -290,6 +290,13 @@ let audit_authorization_source
     Keeper_approval_queue_rules_types.Workspace_always_allow
 ;;
 
+let audit_rule_match
+      (rule_match : Keeper_approval_queue.rule_match)
+  : Keeper_approval_queue_rules_types.rule_match
+  =
+  { rule_id = rule_match.rule_id }
+;;
+
 let audit_allow request ?rule_match ?source_approval_id ?decision_source source =
   Keeper_approval.Audit.record
     ~base_path:request.base_path
@@ -306,7 +313,7 @@ let audit_allow request ?rule_match ?source_approval_id ?decision_source source 
     ?turn_id:(request_turn_id request)
     ?task_id:request.task_id
     ~goal_ids:request.goal_ids
-    ?rule_match
+    ?rule_match:(Option.map audit_rule_match rule_match)
     ?source_approval_id
     ?decision_source
     ()
@@ -1504,7 +1511,7 @@ let observe_exact_rule_expired
     ?turn_id:(request_turn_id request)
     ?task_id:request.task_id
     ~goal_ids:request.goal_ids
-    ~rule_match
+    ~rule_match:(audit_rule_match rule_match)
     ()
 ;;
 
@@ -1516,7 +1523,7 @@ let decide_from_selected_mode request = function
     let source = Workspace_always_allow in
     audit_allow
       request
-      ~decision_source:Keeper_approval_queue.Always_allowed
+      ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
       source;
     Allow { source }
 ;;
@@ -1527,7 +1534,7 @@ let decide_without_cycle_grant ~keeper_always_allow request =
     let source = Keeper_always_allow in
     audit_allow
       request
-      ~decision_source:Keeper_approval_queue.Always_allowed
+      ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
       source;
     Allow { source })
   else
@@ -1537,7 +1544,7 @@ let decide_without_cycle_grant ~keeper_always_allow request =
        let source = Workspace_always_allow in
        audit_allow
          request
-         ~decision_source:Keeper_approval_queue.Always_allowed
+         ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
          source;
        Allow { source }
      | Error _ | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Auto_judge) ->
@@ -1557,7 +1564,7 @@ let decide_without_cycle_grant ~keeper_always_allow request =
           audit_allow
             request
             ~rule_match
-            ~decision_source:Keeper_approval_queue.Always_allowed
+            ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
             source;
           Allow { source }
         | Ok (Keeper_approval_queue.Rule_match_expired rule_match) ->

--- a/lib/keeper_approval/audit.ml
+++ b/lib/keeper_approval/audit.ml
@@ -399,7 +399,7 @@ let audit_scan_window ?keeper_name n =
 
 let record_audit_read_failure ?keeper_name ?(metric_site = Keeper_approval_queue_failure_site.Audit_read_recent) ~site exn =
   Keeper_fd_pressure.note_exception ~site exn;
-  Otel_metric_store.inc_counter
+  Otel_metric_store_core.inc_counter
     Keeper_metrics.(to_string ApprovalQueueFailures)
     ~labels:
       [ "keeper",

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -514,10 +514,21 @@ let dashboard_gate_rule_delete_http_json ~base_path ~(args : Yojson.Safe.t)
   | Some id ->
     (match Keeper_approval_queue.delete_rule ~base_path ~id () with
      | Ok deleted ->
+         let audit_rule : Keeper_approval_queue_rules_types.approval_rule =
+           { id = deleted.id
+           ; keeper_name = deleted.keeper_name
+           ; tool_name = deleted.tool_name
+           ; request_fingerprint = deleted.request_fingerprint
+           ; created_at = deleted.created_at
+           ; created_by = deleted.created_by
+           ; source_approval_id = deleted.source_approval_id
+           ; expires_at = deleted.expires_at
+           }
+         in
          Keeper_approval.Audit.record_rule
            ~base_path
            ~event_type:Keeper_approval.Audit.Rule_deleted
-           deleted;
+           audit_rule;
          Ok (`Assoc [ "ok", `Bool true; "id", `String deleted.id ])
        | Error error ->
          Error (Keeper_approval_queue.rule_store_error_to_string error))

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -126,6 +126,61 @@ let test_equivalent_upsert_is_idempotent () =
        check string "same rule id" first.id second.id)
 ;;
 
+let test_dashboard_rule_delete_audits_typed_rule () =
+  let base_path = temp_dir () in
+  Keeper_approval.Audit.For_testing.reset_store ();
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_approval.Audit.For_testing.reset_store ();
+      cleanup_dir base_path)
+    (fun () ->
+       let rule, _ =
+         upsert_exn
+           ~base_path
+           ~input:(`Assoc [ "request", `String "delete-from-dashboard" ])
+       in
+       (match
+          Server_dashboard_http.dashboard_gate_rule_delete_http_json
+            ~base_path
+            ~args:(`Assoc [ "id", `String rule.id ])
+        with
+        | Ok (`Assoc fields) ->
+          check
+            (option string)
+            "deleted id response"
+            (Some rule.id)
+            (match List.assoc_opt "id" fields with
+             | Some (`String id) -> Some id
+             | Some _ | None -> None)
+        | Ok _ -> fail "dashboard delete returned a non-object response"
+        | Error error -> fail error);
+       let deleted_audit =
+         Keeper_approval.Audit.read_recent
+           ~base_path
+           ~keeper_name:rule.keeper_name
+           ~n:20
+           ()
+         |> List.find_opt (fun json ->
+           String.equal
+             "rule_deleted"
+             (Safe_ops.json_string ~default:"" "event" json)
+           && String.equal rule.id (Safe_ops.json_string ~default:"" "id" json))
+       in
+       match deleted_audit with
+       | None -> fail "dashboard deletion did not persist the typed rule audit"
+       | Some json ->
+         check
+           string
+           "audit keeper"
+           rule.keeper_name
+           (Safe_ops.json_string ~default:"" "keeper" json);
+         check
+           string
+           "audit tool"
+           rule.tool_name
+           (Safe_ops.json_string ~default:"" "tool" json))
+;;
+
 let test_gate_allows_only_the_exact_persisted_rule () =
   let base_path = temp_dir () in
   Fun.protect
@@ -794,6 +849,10 @@ let () =
             `Quick
             test_rule_matches_only_complete_exact_request
         ; test_case "idempotent upsert" `Quick test_equivalent_upsert_is_idempotent
+        ; test_case
+            "dashboard deletion audits typed rule"
+            `Quick
+            test_dashboard_rule_delete_audits_typed_rule
         ; test_case
             "Gate consumes exact persisted rule"
             `Quick

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -167,7 +167,7 @@ let () =
               let received_args = ref `Null in
               let capture_handler ~name:_ ~args =
                 received_args := args;
-                Some (tool_ok "captured")
+                tool_ok "captured"
               in
               register_full
                 ~tool_name:tool


### PR DESCRIPTION
## Summary
- route the remaining approval audit read-failure counter through `Otel_metric_store_core`
- project Gate-owned rule matches and dashboard-owned deleted rules into the typed approval audit contract
- remove resolved-history declarations left behind on the old queue interface; `Keeper_approval.Audit` remains the sole owner
- cover dashboard delete -> queue mutation -> typed `rule_deleted` audit identity end to end

## Verification
- `opam exec -- ocamlformat -i lib/keeper/keeper_gate.ml lib/keeper/keeper_approval_queue.mli lib/server/server_dashboard_http.ml test/test_keeper_approval_queue_rules.ml`
- `git diff --check`
- `DUNE_CACHE=disabled dune build --root . -j 2 lib/keeper_approval/.keeper_approval.objs/native/keeper_approval__Audit.cmx`
- `DUNE_CACHE=disabled dune build --root . -j 2 lib/.masc.objs/native/masc__Keeper_gate.cmx lib/.masc.objs/native/masc__Keeper_approval_queue.cmx`
- `DUNE_CACHE=disabled dune build --root . -j 2 lib/server/.masc_server.objs/native/server_dashboard_http.cmx`
- `DUNE_CACHE=disabled dune exec --root . -j 2 ./test/test_keeper_approval_queue_rules.exe` — 18/18 passed

Full workspace build is left to the repository build/CI run.