### PR TITLE
fix(keeper): restore approval contract boundaries

### DIFF
--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -4,7 +4,32 @@
     tool/product name. It records an exact request, accepts an explicit
     resolution, and wakes only the originating Keeper lane. *)
 
-include module type of Keeper_approval_queue_rules_types
+include
+  module type of Keeper_approval_queue_rules_types
+    with module Decision = Keeper_approval_queue_rules_types.Decision
+     and type advisory_judgment = Keeper_approval_queue_rules_types.advisory_judgment
+     and type hitl_context_summary = Keeper_approval_queue_rules_types.hitl_context_summary
+     and type summary_status = Keeper_approval_queue_rules_types.summary_status
+     and type exact_attempt_quarantine_cause =
+      Keeper_approval_queue_rules_types.exact_attempt_quarantine_cause
+     and type exact_attempt_status = Keeper_approval_queue_rules_types.exact_attempt_status
+     and type exact_attempt_binding = Keeper_approval_queue_rules_types.exact_attempt_binding
+     and type exact_attempt_state = Keeper_approval_queue_rules_types.exact_attempt_state
+     and type summary_attempt_pre_worker_unavailable_code =
+      Keeper_approval_queue_rules_types.summary_attempt_pre_worker_unavailable_code
+     and type summary_attempt_pre_worker_unavailable =
+      Keeper_approval_queue_rules_types.summary_attempt_pre_worker_unavailable
+     and type summary_attempt_disposition =
+      Keeper_approval_queue_rules_types.summary_attempt_disposition
+     and type pending_approval = Keeper_approval_queue_rules_types.pending_approval
+     and type decision = Keeper_approval_queue_rules_types.decision
+     and type decision_source = Keeper_approval_queue_rules_types.decision_source
+     and type authorization_source = Keeper_approval_queue_rules_types.authorization_source
+     and type approval_rule = Keeper_approval_queue_rules_types.approval_rule
+     and type rule_match = Keeper_approval_queue_rules_types.rule_match
+     and type rule_lookup = Keeper_approval_queue_rules_types.rule_lookup
+     and type rule_store_error = Keeper_approval_queue_rules_types.rule_store_error
+     and type resolution_result = Keeper_approval_queue_rules_types.resolution_result
 
 type storage_error =
   { path : string

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1,4 +1,15 @@
 module AQ = Masc.Keeper_approval_queue
+module Rule_contract = Keeper_approval_queue_rules_types
+
+let test_rule_contract_types_are_shared_by_identity () =
+  let through_queue : AQ.rule_match = { rule_id = "rule-shared" } in
+  let through_owner : Rule_contract.rule_match = through_queue in
+  let round_trip : AQ.rule_match = through_owner in
+  Alcotest.(check string)
+    "canonical rule contract identity"
+    "rule-shared"
+    round_trip.rule_id
+;;
 
 let reserve_retry_exact ~base_path (entry : AQ.pending_approval) =
   AQ.reserve_summary_attempt_retry
@@ -3683,6 +3694,10 @@ let () =
     "Keeper_approval_queue"
     [ ( "nonhierarchical queue"
       , [ Alcotest.test_case
+            "rule contract types share identity"
+            `Quick
+            test_rule_contract_types_are_shared_by_identity
+        ; Alcotest.test_case
             "durable lock serializes Eio fibers"
             `Quick
             test_pending_store_lock_serializes_eio_fibers


### PR DESCRIPTION
## Summary

- make `Keeper_approval_queue` expose the canonical approval-rule contract types by identity instead of minting nominally distinct copies
- remove audit/history declarations that moved to `Keeper_approval.Audit`; no forwarding facade is restored
- add a compile-time round-trip test proving `rule_match` crosses the queue/contract boundary without conversion

## Product impact

This repairs the approval queue interface boundary. Runtime approval behavior and wire schemas are unchanged. The metric-store and dashboard call-site build repairs are already owned by upstream #27735 on the base branch.

## Validation

Exact head `d41ca5887b7665e56db9451863f39f1e1ef56ae9`:

- focused `test_keeper_approval_queue.exe` build — PASS
- direct executable run — 39/39 PASS
- `ocamlformat --check` on the changed interface and test — PASS
- `git diff --check` — PASS

## Contract

- canonical rule types are shared by type identity
- dead audit exports stay deleted
- no aliases, conversion shims, fallback branches, or facade forwarding were added

Relates #27721
Relates #27689