### PR TITLE
feat(runtime): settle Codex Keeper threads across traces

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -64,6 +64,41 @@ Runtime assignment lives only in `runtime.toml` under
 supplies the current tool schemas separately for each turn, so `AGENT.md`
 should describe behavior and boundaries without copying a tool catalog.
 
+An official Codex subscription runtime declares a CLI transport and no
+credentials. The Codex CLI owns ChatGPT login; MASC removes API-key variables
+from the child environment and refuses non-subscription accounts. Model IDs
+containing dots must be quoted as TOML table keys.
+
+```toml
+[providers.codex_subscription]
+display-name = "Codex ChatGPT Subscription"
+protocol = "codex-app-server"
+command = "codex"
+is-non-interactive = true
+
+[models."gpt-5.3-codex-spark"]
+api-name = "gpt-5.3-codex-spark"
+max-context = 131072
+tools-support = true
+
+[codex_subscription."gpt-5.3-codex-spark"]
+
+# A Keeper assignment must still name a materialized runtime. To add ordered
+# failover, give the lane the same ID; runtime resolution prefers the lane.
+[runtime.lanes."codex_subscription.gpt-5.3-codex-spark"]
+strategy = "ordered"
+candidates = [
+  "codex_subscription.gpt-5.3-codex-spark",
+  "glm-coding.glm-5-turbo",
+]
+
+[runtime.assignments]
+sangsu = "codex_subscription.gpt-5.3-codex-spark"
+```
+
+The fallback candidate must already be a valid binding in the same file.
+There is intentionally no `[providers.codex_subscription.credentials]` table.
+
 ## Creation and update
 
 `masc_keeper_up` accepts `name` and, for first creation or an explicit prompt

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -904,6 +904,7 @@ let run_turn
                       ?goal_blocks:user_blocks
                       ~session_id:
                         (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                      ~keeper_session_dir:session.session_dir
                       ?raw_trace
                       ~system_prompt:turn_system_prompt
                       ~tools

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -547,6 +547,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
        Runtime_codex_app_server.run_turn
          ~mgr:(Eio.Stdenv.process_mgr env)
          ~clock
+         ~cwd:Eio.Path.(Eio.Stdenv.fs env / base_path)
          ~dynamic_tools
          ?reasoning_effort:prepared.reasoning_effort
          ~thread_mode

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -97,11 +97,11 @@ let illegal_hook_decision ~hook_name decision =
           (Agent_sdk.Hooks.classify_decision decision)))
 ;;
 
-let invoke_turn_hook ~keeper_name ~hook_name hook event =
+let invoke_turn_hook ~keeper_name ~turn_count ~hook_name hook event =
   Agent_sdk.Agent_tools.invoke_hook
     ~tracer:Agent_sdk.Tracing.null
     ~agent_name:keeper_name
-    ~turn_count:1
+    ~turn_count
     ~hook_name
     hook
     event
@@ -114,15 +114,16 @@ type prepared_turn =
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
   }
 
-let prepare_turn ~keeper_name ~system_prompt ~tools ~initial_messages
+let prepare_turn ~keeper_name ~turn_count ~system_prompt ~tools ~initial_messages
     ~model_input_projection ~hooks ~enable_thinking =
   let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
   let before_turn =
     invoke_turn_hook
       ~keeper_name
+      ~turn_count
       ~hook_name:"before_turn"
       hooks.before_turn
-      (Agent_sdk.Hooks.BeforeTurn { turn = 1; messages = initial_messages })
+      (Agent_sdk.Hooks.BeforeTurn { turn = turn_count; messages = initial_messages })
   in
   let* messages =
     match before_turn with
@@ -137,10 +138,11 @@ let prepare_turn ~keeper_name ~system_prompt ~tools ~initial_messages
   let before_turn_params =
     invoke_turn_hook
       ~keeper_name
+      ~turn_count
       ~hook_name:"before_turn_params"
       hooks.before_turn_params
       (Agent_sdk.Hooks.BeforeTurnParams
-         { turn = 1
+         { turn = turn_count
          ; messages
          ; last_tool_results = last_tool_results messages
          ; current_params
@@ -264,7 +266,7 @@ let apply_context_injection ~terminal_error ~context ~context_injector ~tool_nam
           ^ Printexc.to_string exn))
 ;;
 
-let dynamic_tool_of_oas ~keeper_name ~context ~tools
+let dynamic_tool_of_oas ~keeper_name ~turn_count ~context ~tools
     ~(hooks : Agent_sdk.Hooks.hooks) ~event_bus ~context_injector ~terminal_error
     (tool : Agent_sdk.Tool.t) =
   { Runtime_codex_app_server.name = tool.schema.name
@@ -282,13 +284,14 @@ let dynamic_tool_of_oas ~keeper_name ~context ~tools
         let invocation =
           Agent_sdk.Tool_contract.Invocation.create
             ~tool_use_id:call_id
-            ~turn:1
+            ~turn:turn_count
             ~schedule
             ~completion:(Agent_sdk.Tool.completion tool)
         in
         let pre_tool_use =
           invoke_turn_hook
             ~keeper_name
+            ~turn_count
             ~hook_name:"pre_tool_use"
             hooks.pre_tool_use
             (Agent_sdk.Hooks.PreToolUse
@@ -366,8 +369,8 @@ let dynamic_tool_of_oas ~keeper_name ~context ~tools
   }
 ;;
 
-let dynamic_tools ~keeper_name ~tools ~hooks ~event_bus ~context_injector ~context
-    ~terminal_error =
+let dynamic_tools ~keeper_name ~turn_count ~tools ~hooks ~event_bus ~context_injector
+    ~context ~terminal_error =
   match tools, context with
   | [], _ -> Ok []
   | _ :: _, None ->
@@ -380,6 +383,7 @@ let dynamic_tools ~keeper_name ~tools ~hooks ~event_bus ~context_injector ~conte
       (List.map
          (dynamic_tool_of_oas
             ~keeper_name
+            ~turn_count
             ~context
             ~tools
             ~hooks
@@ -397,9 +401,10 @@ let codex_error_to_sdk_error = function
   | error -> Agent_sdk.Error.Internal (Runtime_codex_app_server.error_to_string error)
 ;;
 
-let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~tools
-    ~initial_messages ~model_input_projection ~hooks ~context_injector ~context ~event_bus
-    ~enable_thinking ~(config : Runtime_execution.codex_app_server) =
+let run ~runtime_id ~keeper_name ~base_path ~session_dir ~goal ~goal_blocks
+    ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
+    ~context_injector ~context ~event_bus ~enable_thinking
+    ~(config : Runtime_execution.codex_app_server) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
     Error
@@ -413,15 +418,61 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
          "Codex app-server runtime requires the initialized Eio clock")
   | Some env, Some clock ->
     let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
+    let* stored_session =
+      match Keeper_codex_session_store.load ~session_dir with
+      | Ok session -> Ok session
+      | Error detail ->
+        Error (internal_error ("Codex session binding load failed: " ^ detail))
+    in
+    let* thread_mode, turn_count =
+      match stored_session with
+      | None -> Ok (Runtime_codex_app_server.Start, 1)
+      | Some session when not (String.equal session.runtime_id runtime_id) ->
+        Error
+          (config_error
+             ~field:"codex_session.runtime_id"
+             (Printf.sprintf
+                "stored runtime %S does not match selected runtime %S"
+                session.runtime_id
+                runtime_id))
+      | Some session when session.turn_count = Int.max_int ->
+        Error
+          (config_error
+             ~field:"codex_session.turn_count"
+             "stored Codex session turn count cannot be incremented")
+      | Some session ->
+        Ok
+          ( Runtime_codex_app_server.Resume { thread_id = session.thread_id }
+          , session.turn_count + 1 )
+    in
     let* prepared =
       prepare_turn
         ~keeper_name
+        ~turn_count
         ~system_prompt
         ~tools
         ~initial_messages
         ~model_input_projection
         ~hooks:(Some hooks)
         ~enable_thinking
+    in
+    let tool_surface_sha256 =
+      Keeper_codex_session_store.tool_surface_sha256 prepared.tools
+    in
+    let* () =
+      match stored_session with
+      | None -> Ok ()
+      | Some session
+        when String.equal session.tool_surface_sha256 tool_surface_sha256 ->
+        Ok ()
+      | Some session ->
+        Error
+          (config_error
+             ~field:"codex_session.tool_surface_sha256"
+             (Printf.sprintf
+                "stored Codex thread tool surface %s does not match current surface %s; explicit session reset or migration is required"
+                session.tool_surface_sha256
+                tool_surface_sha256))
     in
     let* developer_messages, history = project_messages prepared.messages in
     let* prompt =
@@ -447,6 +498,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
     let* dynamic_tools =
       dynamic_tools
         ~keeper_name
+        ~turn_count
         ~tools:prepared.tools
         ~hooks
         ~event_bus
@@ -461,14 +513,46 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
          ~clock
          ~dynamic_tools
          ?reasoning_effort:prepared.reasoning_effort
+         ~thread_mode
          ~history
          client_config
          ~prompt
      with
      | Error error -> Error (codex_error_to_sdk_error error)
-     | Ok _ when Option.is_some !terminal_error ->
-       Error (internal_error (Option.get !terminal_error))
      | Ok turn ->
+       let expected_resumed =
+         match thread_mode with
+         | Runtime_codex_app_server.Start -> false
+         | Runtime_codex_app_server.Resume _ -> true
+       in
+       let* () =
+         if Bool.equal expected_resumed turn.resumed
+         then Ok ()
+         else
+           Error
+             (internal_error
+                "Codex app-server reported a thread mode different from the requested session plan")
+       in
+       let* () =
+         match
+           Keeper_codex_session_store.save
+             ~session_dir
+             { runtime_id
+             ; thread_id = turn.thread_id
+             ; turn_count
+             ; tool_surface_sha256
+             ; updated_at = Time_compat.now ()
+             }
+         with
+         | Ok () -> Ok ()
+         | Error detail ->
+           Error (internal_error ("Codex session binding save failed: " ^ detail))
+       in
+       let* () =
+         match !terminal_error with
+         | None -> Ok ()
+         | Some detail -> Error (internal_error detail)
+       in
        let latency_ms = Int.of_float ((Time_compat.now () -. started_at) *. 1000.0) in
        let response =
          { Agent_sdk.Types.id = turn.turn_id
@@ -487,9 +571,10 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
        let after_turn =
          invoke_turn_hook
            ~keeper_name
+           ~turn_count
            ~hook_name:"after_turn"
            hooks.after_turn
-           (Agent_sdk.Hooks.AfterTurn { turn = 1; response })
+           (Agent_sdk.Hooks.AfterTurn { turn = turn_count; response })
        in
        let* () =
          match after_turn with
@@ -501,6 +586,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
        let on_stop =
          invoke_turn_hook
            ~keeper_name
+           ~turn_count
            ~hook_name:"on_stop"
            hooks.on_stop
            (Agent_sdk.Hooks.OnStop { reason = response.stop_reason; response })
@@ -527,6 +613,8 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
            ~configured_labels:
              [ "codex_app_server"
              ; Printf.sprintf "dynamic_tool_calls=%d" turn.dynamic_tool_calls
+             ; Printf.sprintf "resumed=%b" turn.resumed
+             ; Printf.sprintf "turn_count=%d" turn_count
              ]
            ~candidate_count:1
            ~selected_model_raw:(Some turn.model)
@@ -539,7 +627,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
          { Runtime_agent.response
          ; checkpoint = None
          ; session_id = turn.thread_id
-         ; turns = 1
+         ; turns = turn_count
          ; trace_ref = None
          ; run_validation = None
          ; runtime_observation = Some runtime_observation

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -401,7 +401,7 @@ let codex_error_to_sdk_error = function
   | error -> Agent_sdk.Error.Internal (Runtime_codex_app_server.error_to_string error)
 ;;
 
-let run ~runtime_id ~keeper_name ~base_path ~session_dir ~goal ~goal_blocks
+let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
     ~context_injector ~context ~event_bus ~enable_thinking
     ~(config : Runtime_execution.codex_app_server) =
@@ -419,7 +419,7 @@ let run ~runtime_id ~keeper_name ~base_path ~session_dir ~goal ~goal_blocks
   | Some env, Some clock ->
     let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
     let* stored_session =
-      match Keeper_codex_session_store.load ~session_dir with
+      match Keeper_codex_session_store.load ~base_path ~keeper_name with
       | Ok session -> Ok session
       | Error detail ->
         Error (internal_error ("Codex session binding load failed: " ^ detail))
@@ -435,15 +435,29 @@ let run ~runtime_id ~keeper_name ~base_path ~session_dir ~goal ~goal_blocks
                 "stored runtime %S does not match selected runtime %S"
                 session.runtime_id
                 runtime_id))
-      | Some session when session.turn_count = Int.max_int ->
+      | Some { phase = Settled _; turn_count; _ } when turn_count = Int.max_int ->
         Error
           (config_error
              ~field:"codex_session.turn_count"
              "stored Codex session turn count cannot be incremented")
-      | Some session ->
+      | Some { phase = Settled { thread_id; _ }; turn_count; _ } ->
         Ok
-          ( Runtime_codex_app_server.Resume { thread_id = session.thread_id }
-          , session.turn_count + 1 )
+          (Runtime_codex_app_server.Resume { thread_id }, turn_count + 1)
+      | Some { phase = Start _; _ } ->
+        Error
+          (config_error
+             ~field:"codex_session.phase"
+             "stored Codex session has an incomplete thread start; refusing duplicate execution")
+      | Some { phase = Active _; _ } ->
+        Error
+          (config_error
+             ~field:"codex_session.phase"
+             "stored Codex session has an active unsettled attempt; refusing duplicate execution")
+      | Some { phase = Turn_inflight _; _ } ->
+        Error
+          (config_error
+             ~field:"codex_session.phase"
+             "stored Codex session has an in-flight turn; refusing duplicate execution")
     in
     let* prepared =
       prepare_turn
@@ -470,7 +484,7 @@ let run ~runtime_id ~keeper_name ~base_path ~session_dir ~goal ~goal_blocks
           (config_error
              ~field:"codex_session.tool_surface_sha256"
              (Printf.sprintf
-                "stored Codex thread tool surface %s does not match current surface %s; explicit session reset or migration is required"
+                "stored Codex thread tool surface %s does not match current surface %s"
                 session.tool_surface_sha256
                 tool_surface_sha256))
     in
@@ -506,6 +520,28 @@ let run ~runtime_id ~keeper_name ~base_path ~session_dir ~goal ~goal_blocks
         ~context
         ~terminal_error
     in
+    let* claimed_session =
+      match
+        Keeper_codex_session_store.claim
+          ~base_path
+          ~keeper_name
+          ~expected:stored_session
+          ~runtime_id
+          ~tool_surface_sha256
+          ~updated_at:(Time_compat.now ())
+      with
+      | Ok session -> Ok session
+      | Error detail ->
+        Error (internal_error ("Codex session claim failed: " ^ detail))
+    in
+    let session_state = ref claimed_session in
+    let update_session label transition =
+      match transition !session_state with
+      | Ok next ->
+        session_state := next;
+        Ok ()
+      | Error detail -> Error (Printf.sprintf "Codex session %s failed: %s" label detail)
+    in
     let started_at = Time_compat.now () in
     (match
        Runtime_codex_app_server.run_turn
@@ -515,6 +551,31 @@ let run ~runtime_id ~keeper_name ~base_path ~session_dir ~goal ~goal_blocks
          ?reasoning_effort:prepared.reasoning_effort
          ~thread_mode
          ~history
+         ~on_thread_ready:(fun ~thread_id ->
+           update_session "active transition" (fun expected ->
+             Keeper_codex_session_store.mark_active
+               ~base_path
+               ~keeper_name
+               ~expected
+               ~thread_id
+               ~updated_at:(Time_compat.now ())))
+         ~on_turn_starting:(fun ~thread_id ->
+           update_session "turn-starting transition" (fun expected ->
+             Keeper_codex_session_store.mark_turn_starting
+               ~base_path
+               ~keeper_name
+               ~expected
+               ~thread_id
+               ~updated_at:(Time_compat.now ())))
+         ~on_turn_started:(fun ~thread_id ~turn_id ->
+           update_session "turn-started transition" (fun expected ->
+             Keeper_codex_session_store.mark_turn_started
+               ~base_path
+               ~keeper_name
+               ~expected
+               ~thread_id
+               ~turn_id
+               ~updated_at:(Time_compat.now ())))
          client_config
          ~prompt
      with
@@ -532,21 +593,6 @@ let run ~runtime_id ~keeper_name ~base_path ~session_dir ~goal ~goal_blocks
            Error
              (internal_error
                 "Codex app-server reported a thread mode different from the requested session plan")
-       in
-       let* () =
-         match
-           Keeper_codex_session_store.save
-             ~session_dir
-             { runtime_id
-             ; thread_id = turn.thread_id
-             ; turn_count
-             ; tool_surface_sha256
-             ; updated_at = Time_compat.now ()
-             }
-         with
-         | Ok () -> Ok ()
-         | Error detail ->
-           Error (internal_error ("Codex session binding save failed: " ^ detail))
        in
        let* () =
          match !terminal_error with
@@ -597,6 +643,22 @@ let run ~runtime_id ~keeper_name ~base_path ~session_dir ~goal ~goal_blocks
          | HookFailed { stage; detail } ->
            Error (hook_error ~hook_name:"on_stop" ~stage detail)
          | decision -> Error (illegal_hook_decision ~hook_name:"on_stop" decision)
+       in
+       let* () =
+         match
+           Keeper_codex_session_store.settle
+             ~base_path
+             ~keeper_name
+             ~expected:!session_state
+             ~thread_id:turn.thread_id
+             ~turn_id:turn.turn_id
+             ~updated_at:(Time_compat.now ())
+         with
+         | Ok settled ->
+           session_state := settled;
+           Ok ()
+         | Error detail ->
+           Error (internal_error ("Codex session settlement failed: " ^ detail))
        in
        let capture, _metrics =
          Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -4,7 +4,6 @@ val run :
   runtime_id:string ->
   keeper_name:string ->
   base_path:string ->
-  session_dir:string ->
   goal:string ->
   goal_blocks:Agent_sdk.Types.content_block list option ->
   system_prompt:string ->

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -4,6 +4,7 @@ val run :
   runtime_id:string ->
   keeper_name:string ->
   base_path:string ->
+  session_dir:string ->
   goal:string ->
   goal_blocks:Agent_sdk.Types.content_block list option ->
   system_prompt:string ->

--- a/lib/keeper/keeper_codex_session_store.ml
+++ b/lib/keeper/keeper_codex_session_store.ml
@@ -1,0 +1,134 @@
+type t =
+  { runtime_id : string
+  ; thread_id : string
+  ; turn_count : int
+  ; tool_surface_sha256 : string
+  ; updated_at : float
+  }
+
+let ( let* ) = Result.bind
+let schema = "masc.keeper.codex-session.v1"
+let filename = "codex-session.json"
+
+let path ~session_dir = Filename.concat session_dir filename
+
+let tool_surface_sha256 tools =
+  let tool_json (tool : Agent_sdk.Tool.t) =
+    `Assoc
+      [ "description", `String tool.schema.description
+      ; "input_schema", Agent_sdk.Types.params_to_input_schema tool.schema.parameters
+      ; "name", `String tool.schema.name
+      ]
+  in
+  tools
+  |> List.sort (fun (left : Agent_sdk.Tool.t) right ->
+    String.compare left.schema.name right.schema.name)
+  |> List.map tool_json
+  |> fun tools -> Yojson.Safe.to_string (`List tools)
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
+let valid_sha256 value =
+  String.length value = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value
+;;
+
+let validate binding =
+  if String.equal (String.trim binding.runtime_id) ""
+  then Error "Codex session runtime_id must not be empty"
+  else if String.equal (String.trim binding.thread_id) ""
+  then Error "Codex session thread_id must not be empty"
+  else if binding.turn_count <= 0
+  then Error "Codex session turn_count must be positive"
+  else if not (valid_sha256 binding.tool_surface_sha256)
+  then Error "Codex session tool_surface_sha256 must be lowercase SHA-256"
+  else if not (Float.is_finite binding.updated_at)
+  then Error "Codex session updated_at must be finite"
+  else Ok ()
+;;
+
+let to_yojson binding =
+  `Assoc
+    [ "runtime_id", `String binding.runtime_id
+    ; "schema", `String schema
+    ; "thread_id", `String binding.thread_id
+    ; "tool_surface_sha256", `String binding.tool_surface_sha256
+    ; "turn_count", `Int binding.turn_count
+    ; "updated_at", `Float binding.updated_at
+    ]
+;;
+
+let of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "runtime_id", `String runtime_id
+       ; "schema", `String encoded_schema
+       ; "thread_id", `String thread_id
+       ; "tool_surface_sha256", `String tool_surface_sha256
+       ; "turn_count", `Int turn_count
+       ; "updated_at", `Float updated_at
+       ] ->
+       if not (String.equal encoded_schema schema)
+       then Error "unsupported Codex session schema"
+       else
+         let binding =
+           { runtime_id; thread_id; turn_count; tool_surface_sha256; updated_at }
+         in
+         let* () = validate binding in
+         Ok binding
+     | _ -> Error "Codex session fields are not exact")
+  | _ -> Error "Codex session must be a JSON object"
+;;
+
+let equal left right =
+  String.equal left.runtime_id right.runtime_id
+  && String.equal left.thread_id right.thread_id
+  && Int.equal left.turn_count right.turn_count
+  && String.equal left.tool_surface_sha256 right.tool_surface_sha256
+  && Float.equal left.updated_at right.updated_at
+;;
+
+let load ~session_dir =
+  let state_path = path ~session_dir in
+  if not (Fs_compat.file_exists state_path)
+  then Ok None
+  else
+    let* json = Safe_ops.read_json_file_safe state_path in
+    let* binding = of_yojson json in
+    Ok (Some binding)
+;;
+
+let save ~session_dir binding =
+  let* () = validate binding in
+  let prepared =
+    try
+      ignore (Keeper_fs.ensure_dir session_dir : string);
+      Ok ()
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
+  in
+  let* () = prepared in
+  let state_path = path ~session_dir in
+  let* () =
+    match
+      Keeper_fs.save_json_durable_atomic
+        ~ownership_root:session_dir
+        ~pretty:false
+        state_path
+        (to_yojson binding)
+    with
+    | Ok () -> Ok ()
+    | Error error -> Error (Keeper_fs.durable_write_error_to_string error)
+  in
+  let* persisted = load ~session_dir in
+  match persisted with
+  | Some persisted when equal persisted binding -> Ok ()
+  | Some _ -> Error "Codex session changed after durable write"
+  | None -> Error "Codex session missing after durable write"
+;;

--- a/lib/keeper/keeper_codex_session_store.ml
+++ b/lib/keeper/keeper_codex_session_store.ml
@@ -12,13 +12,31 @@ let filename = "codex-session.json"
 
 let path ~session_dir = Filename.concat session_dir filename
 
+let rec canonical_json = function
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       |> List.map (fun (name, value) -> name, canonical_json value)
+       |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | `List values -> `List (List.map canonical_json values)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as value ->
+    value
+;;
+
 let tool_surface_sha256 tools =
   let tool_json (tool : Agent_sdk.Tool.t) =
+    let parameters =
+      List.sort
+        (fun (left : Agent_sdk.Types.tool_param) right ->
+           String.compare left.name right.name)
+        tool.schema.parameters
+    in
     `Assoc
       [ "description", `String tool.schema.description
-      ; "input_schema", Agent_sdk.Types.params_to_input_schema tool.schema.parameters
+      ; "input_schema", Agent_sdk.Types.params_to_input_schema parameters
       ; "name", `String tool.schema.name
       ]
+    |> canonical_json
   in
   tools
   |> List.sort (fun (left : Agent_sdk.Tool.t) right ->
@@ -107,7 +125,7 @@ let save ~session_dir binding =
   let* () = validate binding in
   let prepared =
     try
-      ignore (Keeper_fs.ensure_dir session_dir : string);
+      let (_ : string) = Keeper_fs.ensure_dir session_dir in
       Ok ()
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/keeper/keeper_codex_session_store.ml
+++ b/lib/keeper/keeper_codex_session_store.ml
@@ -1,16 +1,46 @@
+type phase =
+  | Start of { previous_thread_id : string option }
+  | Active of { thread_id : string }
+  | Turn_inflight of
+      { thread_id : string
+      ; turn_id : string option
+      }
+  | Settled of
+      { thread_id : string
+      ; turn_id : string
+      }
+
 type t =
   { runtime_id : string
-  ; thread_id : string
+  ; phase : phase
   ; turn_count : int
   ; tool_surface_sha256 : string
   ; updated_at : float
   }
 
 let ( let* ) = Result.bind
-let schema = "masc.keeper.codex-session.v1"
+let schema = "masc.keeper.codex-session.v2"
 let filename = "codex-session.json"
+let state_dirname = "official-client-runtime"
+let lock_filename = "codex-session.lock"
 
-let path ~session_dir = Filename.concat session_dir filename
+let state_dir ~base_path ~keeper_name =
+  if not (Safe_identifier.is_portable_name keeper_name)
+  then Error (Printf.sprintf "invalid Codex session Keeper name %S" keeper_name)
+  else
+    Ok
+      (Filename.concat
+         (Filename.concat
+            (Common.keepers_runtime_dir_of_base ~base_path)
+            keeper_name)
+         state_dirname)
+;;
+
+let path ~base_path ~keeper_name =
+  Result.map
+    (fun directory -> Filename.concat directory filename)
+    (state_dir ~base_path ~keeper_name)
+;;
 
 let rec canonical_json = function
   | `Assoc fields ->
@@ -56,12 +86,28 @@ let valid_sha256 value =
        value
 ;;
 
+let non_empty field value =
+  if String.equal (String.trim value) ""
+  then Error (Printf.sprintf "Codex session %s must not be empty" field)
+  else Ok ()
+;;
+
+let validate_phase = function
+  | Start { previous_thread_id = None } -> Ok ()
+  | Start { previous_thread_id = Some thread_id }
+  | Active { thread_id }
+  | Turn_inflight { thread_id; turn_id = None } ->
+    non_empty "thread_id" thread_id
+  | Turn_inflight { thread_id; turn_id = Some turn_id }
+  | Settled { thread_id; turn_id } ->
+    let* () = non_empty "thread_id" thread_id in
+    non_empty "turn_id" turn_id
+;;
+
 let validate binding =
-  if String.equal (String.trim binding.runtime_id) ""
-  then Error "Codex session runtime_id must not be empty"
-  else if String.equal (String.trim binding.thread_id) ""
-  then Error "Codex session thread_id must not be empty"
-  else if binding.turn_count <= 0
+  let* () = non_empty "runtime_id" binding.runtime_id in
+  let* () = validate_phase binding.phase in
+  if binding.turn_count <= 0
   then Error "Codex session turn_count must be positive"
   else if not (valid_sha256 binding.tool_surface_sha256)
   then Error "Codex session tool_surface_sha256 must be lowercase SHA-256"
@@ -70,11 +116,60 @@ let validate binding =
   else Ok ()
 ;;
 
+let phase_to_yojson = function
+  | Start { previous_thread_id } ->
+    `Assoc
+      [ "kind", `String "start"
+      ; ( "previous_thread_id"
+        , Option.fold
+            ~none:`Null
+            ~some:(fun thread_id -> `String thread_id)
+            previous_thread_id )
+      ]
+  | Active { thread_id } ->
+    `Assoc [ "kind", `String "active"; "thread_id", `String thread_id ]
+  | Turn_inflight { thread_id; turn_id } ->
+    `Assoc
+      [ "kind", `String "turn_inflight"
+      ; "thread_id", `String thread_id
+      ; ( "turn_id"
+        , Option.fold ~none:`Null ~some:(fun turn_id -> `String turn_id) turn_id )
+      ]
+  | Settled { thread_id; turn_id } ->
+    `Assoc
+      [ "kind", `String "settled"
+      ; "thread_id", `String thread_id
+      ; "turn_id", `String turn_id
+      ]
+;;
+
+let phase_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "kind", `String "start"; "previous_thread_id", `Null ] ->
+       Ok (Start { previous_thread_id = None })
+     | [ "kind", `String "start"; "previous_thread_id", `String thread_id ] ->
+       Ok (Start { previous_thread_id = Some thread_id })
+     | [ "kind", `String "active"; "thread_id", `String thread_id ] ->
+       Ok (Active { thread_id })
+     | [ "kind", `String "turn_inflight"; "thread_id", `String thread_id
+       ; "turn_id", `Null ] ->
+       Ok (Turn_inflight { thread_id; turn_id = None })
+     | [ "kind", `String "turn_inflight"; "thread_id", `String thread_id
+       ; "turn_id", `String turn_id ] ->
+       Ok (Turn_inflight { thread_id; turn_id = Some turn_id })
+     | [ "kind", `String "settled"; "thread_id", `String thread_id
+       ; "turn_id", `String turn_id ] ->
+       Ok (Settled { thread_id; turn_id })
+     | _ -> Error "Codex session phase fields are not exact")
+  | _ -> Error "Codex session phase must be a JSON object"
+;;
+
 let to_yojson binding =
   `Assoc
     [ "runtime_id", `String binding.runtime_id
+    ; "phase", phase_to_yojson binding.phase
     ; "schema", `String schema
-    ; "thread_id", `String binding.thread_id
     ; "tool_surface_sha256", `String binding.tool_surface_sha256
     ; "turn_count", `Int binding.turn_count
     ; "updated_at", `Float binding.updated_at
@@ -84,9 +179,9 @@ let to_yojson binding =
 let of_yojson = function
   | `Assoc fields ->
     (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
-     | [ "runtime_id", `String runtime_id
+     | [ "phase", phase_json
+       ; "runtime_id", `String runtime_id
        ; "schema", `String encoded_schema
-       ; "thread_id", `String thread_id
        ; "tool_surface_sha256", `String tool_surface_sha256
        ; "turn_count", `Int turn_count
        ; "updated_at", `Float updated_at
@@ -94,8 +189,9 @@ let of_yojson = function
        if not (String.equal encoded_schema schema)
        then Error "unsupported Codex session schema"
        else
+         let* phase = phase_of_yojson phase_json in
          let binding =
-           { runtime_id; thread_id; turn_count; tool_surface_sha256; updated_at }
+           { runtime_id; phase; turn_count; tool_surface_sha256; updated_at }
          in
          let* () = validate binding in
          Ok binding
@@ -105,14 +201,13 @@ let of_yojson = function
 
 let equal left right =
   String.equal left.runtime_id right.runtime_id
-  && String.equal left.thread_id right.thread_id
+  && left.phase = right.phase
   && Int.equal left.turn_count right.turn_count
   && String.equal left.tool_surface_sha256 right.tool_surface_sha256
   && Float.equal left.updated_at right.updated_at
 ;;
 
-let load ~session_dir =
-  let state_path = path ~session_dir in
+let load_path state_path =
   if not (Fs_compat.file_exists state_path)
   then Ok None
   else
@@ -121,22 +216,18 @@ let load ~session_dir =
     Ok (Some binding)
 ;;
 
-let save ~session_dir binding =
+let load ~base_path ~keeper_name =
+  let* state_path = path ~base_path ~keeper_name in
+  load_path state_path
+;;
+
+let save_path ~state_dir binding =
   let* () = validate binding in
-  let prepared =
-    try
-      let (_ : string) = Keeper_fs.ensure_dir session_dir in
-      Ok ()
-    with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Printexc.to_string exn)
-  in
-  let* () = prepared in
-  let state_path = path ~session_dir in
+  let state_path = Filename.concat state_dir filename in
   let* () =
     match
       Keeper_fs.save_json_durable_atomic
-        ~ownership_root:session_dir
+        ~ownership_root:state_dir
         ~pretty:false
         state_path
         (to_yojson binding)
@@ -144,9 +235,129 @@ let save ~session_dir binding =
     | Ok () -> Ok ()
     | Error error -> Error (Keeper_fs.durable_write_error_to_string error)
   in
-  let* persisted = load ~session_dir in
+  let* persisted = load_path state_path in
   match persisted with
   | Some persisted when equal persisted binding -> Ok ()
   | Some _ -> Error "Codex session changed after durable write"
   | None -> Error "Codex session missing after durable write"
+;;
+
+let prepare_state_dir ~base_path ~keeper_name =
+  let* directory = state_dir ~base_path ~keeper_name in
+  try
+    let (_ : string) = Keeper_fs.ensure_dir directory in
+    Ok directory
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let with_store_lock ~base_path ~keeper_name f =
+  let* directory = prepare_state_dir ~base_path ~keeper_name in
+  match
+    File_lock_eio.with_durable_lock
+      ~lock_path:(Filename.concat directory lock_filename)
+      (fun () -> f directory)
+  with
+  | Ok result -> result
+  | Error error -> Error (File_lock_eio.durable_lock_error_to_string error)
+;;
+
+let transition ~base_path ~keeper_name ~expected next =
+  let* () = validate next in
+  with_store_lock ~base_path ~keeper_name (fun directory ->
+    let* current = load_path (Filename.concat directory filename) in
+    if Option.equal equal current expected
+    then save_path ~state_dir:directory next |> Result.map (fun () -> next)
+    else Error "Codex session changed before durable transition")
+;;
+
+let claim ~base_path ~keeper_name ~expected ~runtime_id ~tool_surface_sha256
+    ~updated_at =
+  let* phase, turn_count =
+    match expected with
+    | None -> Ok (Start { previous_thread_id = None }, 1)
+    | Some { phase = Settled { thread_id; _ }; turn_count; _ }
+      when turn_count < Int.max_int ->
+      Ok (Start { previous_thread_id = Some thread_id }, turn_count + 1)
+    | Some { phase = Settled _; _ } ->
+      Error "settled Codex session turn count cannot be incremented"
+    | Some { phase = Start _; _ } ->
+      Error "Codex session has an incomplete thread start; refusing duplicate execution"
+    | Some { phase = Active _; _ } ->
+      Error "Codex session has an active unsettled attempt; refusing duplicate execution"
+    | Some { phase = Turn_inflight _; _ } ->
+      Error "Codex session has an in-flight turn; refusing duplicate execution"
+  in
+  transition
+    ~base_path
+    ~keeper_name
+    ~expected
+    { runtime_id; phase; turn_count; tool_surface_sha256; updated_at }
+;;
+
+let mark_active ~base_path ~keeper_name ~expected ~thread_id ~updated_at =
+  match expected.phase with
+  | Start _ ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with phase = Active { thread_id }; updated_at }
+  | Active _ | Turn_inflight _ | Settled _ ->
+    Error "Codex session can become active only from start"
+;;
+
+let mark_turn_starting ~base_path ~keeper_name ~expected ~thread_id ~updated_at =
+  match expected.phase with
+  | Active { thread_id = active_thread_id }
+    when String.equal active_thread_id thread_id ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase = Turn_inflight { thread_id; turn_id = None }
+      ; updated_at
+      }
+  | Active _ -> Error "Codex active thread identity changed before turn start"
+  | Start _ | Turn_inflight _ | Settled _ ->
+    Error "Codex turn can start only from an active session"
+;;
+
+let mark_turn_started ~base_path ~keeper_name ~expected ~thread_id ~turn_id
+    ~updated_at =
+  match expected.phase with
+  | Turn_inflight { thread_id = inflight_thread_id; turn_id = None }
+    when String.equal inflight_thread_id thread_id ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase = Turn_inflight { thread_id; turn_id = Some turn_id }
+      ; updated_at
+      }
+  | Turn_inflight { turn_id = None; _ } ->
+    Error "Codex in-flight thread identity changed after turn start"
+  | Turn_inflight { turn_id = Some _; _ } ->
+    Error "Codex in-flight turn already has an identity"
+  | Start _ | Active _ | Settled _ ->
+    Error "Codex turn identity can be recorded only for an in-flight turn"
+;;
+
+let settle ~base_path ~keeper_name ~expected ~thread_id ~turn_id ~updated_at =
+  match expected.phase with
+  | Turn_inflight
+      { thread_id = inflight_thread_id; turn_id = Some inflight_turn_id }
+    when String.equal inflight_thread_id thread_id
+         && String.equal inflight_turn_id turn_id ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with phase = Settled { thread_id; turn_id }; updated_at }
+  | Turn_inflight _ -> Error "Codex terminal turn identity changed before settlement"
+  | Start _ | Active _ | Settled _ ->
+    Error "Codex session can settle only from an identified in-flight turn"
 ;;

--- a/lib/keeper/keeper_codex_session_store.mli
+++ b/lib/keeper/keeper_codex_session_store.mli
@@ -1,26 +1,81 @@
-(** Durable binding between one Keeper trace and one official Codex thread.
+(** Durable current-owner state between one Keeper and one official Codex thread.
 
     This is not an OAS checkpoint. Codex owns the thread transcript; MASC owns
-    only the exact identity needed to resume it on the next Keeper turn. *)
+    the exact settlement phase needed to resume without silently duplicating an
+    externally admitted turn. *)
+
+type phase =
+  | Start of { previous_thread_id : string option }
+  | Active of { thread_id : string }
+  | Turn_inflight of
+      { thread_id : string
+      ; turn_id : string option
+      }
+  | Settled of
+      { thread_id : string
+      ; turn_id : string
+      }
 
 type t =
   { runtime_id : string
-  ; thread_id : string
+  ; phase : phase
   ; turn_count : int
   ; tool_surface_sha256 : string
   ; updated_at : float
   }
 
-val path : session_dir:string -> string
+val path : base_path:string -> keeper_name:string -> (string, string) result
 
 val tool_surface_sha256 : Agent_sdk.Tool.t list -> string
 (** Stable digest of the exact typed dynamic-tool surface. Tool order,
     parameter order, and JSON object field order do not affect the digest;
     names, descriptions, parameter semantics, and input schemas do. *)
 
-val load : session_dir:string -> (t option, string) result
+val load : base_path:string -> keeper_name:string -> (t option, string) result
 (** Missing state is [Ok None]. Malformed, retired, or ambiguous state is an
     error and never degrades to a new thread. *)
 
-val save : session_dir:string -> t -> (unit, string) result
-(** Strict durable atomic replacement followed by an exact read-back check. *)
+val claim :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t option ->
+  runtime_id:string ->
+  tool_surface_sha256:string ->
+  updated_at:float ->
+  (t, string) result
+
+val mark_active :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  thread_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val mark_turn_starting :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  thread_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val mark_turn_started :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  thread_id:string ->
+  turn_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val settle :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  thread_id:string ->
+  turn_id:string ->
+  updated_at:float ->
+  (t, string) result
+(** Every phase change is a process-safe durable compare-and-swap followed by
+    exact read-back. Any incomplete phase blocks a later automatic claim. *)

--- a/lib/keeper/keeper_codex_session_store.mli
+++ b/lib/keeper/keeper_codex_session_store.mli
@@ -14,8 +14,9 @@ type t =
 val path : session_dir:string -> string
 
 val tool_surface_sha256 : Agent_sdk.Tool.t list -> string
-(** Stable digest of the exact typed dynamic-tool surface. Tool order does not
-    affect the digest; names, descriptions, and input schemas do. *)
+(** Stable digest of the exact typed dynamic-tool surface. Tool order,
+    parameter order, and JSON object field order do not affect the digest;
+    names, descriptions, parameter semantics, and input schemas do. *)
 
 val load : session_dir:string -> (t option, string) result
 (** Missing state is [Ok None]. Malformed, retired, or ambiguous state is an

--- a/lib/keeper/keeper_codex_session_store.mli
+++ b/lib/keeper/keeper_codex_session_store.mli
@@ -1,0 +1,25 @@
+(** Durable binding between one Keeper trace and one official Codex thread.
+
+    This is not an OAS checkpoint. Codex owns the thread transcript; MASC owns
+    only the exact identity needed to resume it on the next Keeper turn. *)
+
+type t =
+  { runtime_id : string
+  ; thread_id : string
+  ; turn_count : int
+  ; tool_surface_sha256 : string
+  ; updated_at : float
+  }
+
+val path : session_dir:string -> string
+
+val tool_surface_sha256 : Agent_sdk.Tool.t list -> string
+(** Stable digest of the exact typed dynamic-tool surface. Tool order does not
+    affect the digest; names, descriptions, and input schemas do. *)
+
+val load : session_dir:string -> (t option, string) result
+(** Missing state is [Ok None]. Malformed, retired, or ambiguous state is an
+    error and never degrades to a new thread. *)
+
+val save : session_dir:string -> t -> (unit, string) result
+(** Strict durable atomic replacement followed by an exact read-back check. *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -371,6 +371,7 @@ let run_named
     ~goal
     ?goal_blocks
     ?session_id
+    ?keeper_session_dir
     ?(system_prompt = "")
     ?(tools = [])
     ?(initial_messages = [])
@@ -707,10 +708,23 @@ let run_named
                          codex-app-server runtime"
                     }))
           | None, None ->
+            let* session_dir =
+              match keeper_session_dir with
+              | Some session_dir -> Ok session_dir
+              | None ->
+                Error
+                  (Agent_sdk.Error.Config
+                     (Agent_sdk.Error.InvalidConfig
+                        { field = "keeper_session_dir"
+                        ; detail =
+                            "codex-app-server runtime requires the Keeper trace session directory"
+                        }))
+            in
             Keeper_codex_runtime.run
               ~runtime_id:attempt_runtime_id
               ~keeper_name
               ~base_path
+              ~session_dir
               ~goal
               ~goal_blocks
               ~system_prompt

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -708,23 +708,10 @@ let run_named
                          codex-app-server runtime"
                     }))
           | None, None ->
-            let* session_dir =
-              match keeper_session_dir with
-              | Some session_dir -> Ok session_dir
-              | None ->
-                Error
-                  (Agent_sdk.Error.Config
-                     (Agent_sdk.Error.InvalidConfig
-                        { field = "keeper_session_dir"
-                        ; detail =
-                            "codex-app-server runtime requires the Keeper trace session directory"
-                        }))
-            in
             Keeper_codex_runtime.run
               ~runtime_id:attempt_runtime_id
               ~keeper_name
               ~base_path
-              ~session_dir
               ~goal
               ~goal_blocks
               ~system_prompt

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -87,6 +87,7 @@ val run_named :
   goal:string ->
   ?goal_blocks:Agent_sdk.Types.content_block list ->
   ?session_id:string ->
+  ?keeper_session_dir:string ->
   ?system_prompt:string ->
   ?tools:Agent_sdk.Tool.t list ->
   ?initial_messages:Agent_sdk.Types.message list ->

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -24,7 +24,7 @@ let stderr_tail_bytes = 4096
 let max_wire_line_bytes = 8 * 1024 * 1024
 let approval_policy = "never"
 let sandbox_mode = "read-only"
-let ephemeral_thread = true
+let thread_is_ephemeral = false
 
 let default_config ~cwd =
   { cli_path = "codex"
@@ -35,6 +35,10 @@ let default_config ~cwd =
   }
 ;;
 
+type thread_mode =
+  | Start
+  | Resume of { thread_id : string }
+
 type turn_result =
   { thread_id : string
   ; turn_id : string
@@ -43,6 +47,7 @@ type turn_result =
   ; dynamic_tool_calls : int
   ; subscription : subscription
   ; user_agent : string option
+  ; resumed : bool
   }
 
 type dynamic_tool_result =
@@ -383,8 +388,7 @@ let parse_subscription result =
   | _ -> protocol_error stage "account must be an object or null"
 ;;
 
-let parse_thread_start result =
-  let stage = "thread/start" in
+let parse_thread_response ~stage result =
   let* fields = assoc_at stage result in
   let* thread_json = required_member stage "thread" fields in
   let* thread_fields = assoc_at stage thread_json in
@@ -597,7 +601,7 @@ let history_item (message : history_message) =
     ]
 ;;
 
-let run_protocol io config ~dynamic_tools ~reasoning_effort ~history ~prompt =
+let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~history ~prompt =
   send_request io ~id:1 ~method_:"initialize"
     ~params:
       (`Assoc
@@ -616,26 +620,52 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~history ~prompt =
     ~params:(`Assoc [ "refreshToken", `Bool false ]);
   let* account = await_response io ~id:2 ~method_:"account/read" in
   let* subscription = parse_subscription account in
-  let thread_fields =
-    [ "cwd", `String config.cwd
-    ; "approvalPolicy", `String approval_policy
-    ; "sandbox", `String sandbox_mode
-    ; "ephemeral", `Bool ephemeral_thread
-    ]
-    @ optional_field "model" config.model
-    @ optional_field "developerInstructions" config.developer_instructions
-    @
-    match dynamic_tools with
-    | [] -> []
-    | tools -> [ "dynamicTools", `List (List.map dynamic_tool_spec tools) ]
+  let thread_method, thread_fields, resumed =
+    match thread_mode with
+    | Start ->
+      ( "thread/start"
+      , ([ "cwd", `String config.cwd
+         ; "approvalPolicy", `String approval_policy
+         ; "sandbox", `String sandbox_mode
+         ; "ephemeral", `Bool thread_is_ephemeral
+         ]
+         @ optional_field "model" config.model
+         @ optional_field "developerInstructions" config.developer_instructions
+         @
+         match dynamic_tools with
+         | [] -> []
+         | tools -> [ "dynamicTools", `List (List.map dynamic_tool_spec tools) ])
+      , false )
+    | Resume { thread_id } ->
+      ( "thread/resume"
+      , [ "threadId", `String thread_id
+        ; "cwd", `String config.cwd
+        ; "approvalPolicy", `String approval_policy
+        ; "sandbox", `String sandbox_mode
+        ]
+        @ optional_field "model" config.model
+        @ optional_field "developerInstructions" config.developer_instructions
+      , true )
   in
-  send_request io ~id:3 ~method_:"thread/start" ~params:(`Assoc thread_fields);
-  let* thread = await_response io ~id:3 ~method_:"thread/start" in
-  let* thread_id, model = parse_thread_start thread in
+  send_request io ~id:3 ~method_:thread_method ~params:(`Assoc thread_fields);
+  let* thread = await_response io ~id:3 ~method_:thread_method in
+  let* thread_id, model = parse_thread_response ~stage:thread_method thread in
+  let* () =
+    match thread_mode with
+    | Start -> Ok ()
+    | Resume { thread_id = expected } when String.equal expected thread_id -> Ok ()
+    | Resume { thread_id = expected } ->
+      protocol_error
+        thread_method
+        (Printf.sprintf
+           "resumed thread id mismatch: requested %S but server returned %S"
+           expected
+           thread_id)
+  in
   let turn_request_id =
-    match history with
-    | [] -> Ok 4
-    | messages ->
+    match thread_mode, history with
+    | Resume _, _ | Start, [] -> Ok 4
+    | Start, messages ->
       send_request io ~id:4 ~method_:"thread/inject_items"
         ~params:
           (`Assoc
@@ -679,6 +709,7 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~history ~prompt =
     ; dynamic_tool_calls = !tool_call_count
     ; subscription
     ; user_agent
+    ; resumed
     }
 ;;
 
@@ -755,7 +786,8 @@ let terminate_spawned_process ~clock proc stdin_w =
           (Printexc.to_string exn))
 ;;
 
-let run_spawned ~mgr ~clock config ~dynamic_tools ~reasoning_effort ~history ~prompt =
+let run_spawned ~mgr ~clock config ~dynamic_tools ~reasoning_effort ~thread_mode ~history
+    ~prompt =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -797,11 +829,12 @@ let run_spawned ~mgr ~clock config ~dynamic_tools ~reasoning_effort ~history ~pr
             config
             ~dynamic_tools
             ~reasoning_effort
+            ~thread_mode
             ~history
             ~prompt)))
 ;;
 
-let validate_config config ~prompt =
+let validate_config config ~thread_mode ~prompt =
   if String.trim config.cli_path = ""
   then Error (Invalid_config "cli_path must not be empty")
   else if String.trim config.cwd = "" || Filename.is_relative config.cwd
@@ -810,7 +843,11 @@ let validate_config config ~prompt =
   then Error (Invalid_config "timeout_s must be positive and finite")
   else if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
-  else Ok ()
+  else
+    match thread_mode with
+    | Resume { thread_id } when String.equal (String.trim thread_id) "" ->
+      Error (Invalid_config "resume thread_id must not be empty")
+    | Start | Resume _ -> Ok ()
 ;;
 
 let validate_dynamic_tools tools =
@@ -827,10 +864,10 @@ let validate_dynamic_tools tools =
   loop [] tools
 ;;
 
-let run_turn ?(dynamic_tools = []) ?reasoning_effort ~mgr ~clock ?(history = []) config
-    ~prompt =
+let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr ~clock
+    ?(history = []) config ~prompt =
   let result =
-    match validate_config config ~prompt with
+    match validate_config config ~thread_mode ~prompt with
     | Error _ as error -> error
     | Ok () ->
       (match validate_dynamic_tools dynamic_tools with
@@ -844,6 +881,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ~mgr ~clock ?(history = [])
            config
            ~dynamic_tools
            ~reasoning_effort
+           ~thread_mode
            ~history
            ~prompt
        with

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -601,7 +601,18 @@ let history_item (message : history_message) =
     ]
 ;;
 
-let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~history ~prompt =
+let invoke_state_callback ~stage callback =
+  try
+    match callback () with
+    | Ok () -> Ok ()
+    | Error detail -> protocol_error stage detail
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> protocol_error stage (Printexc.to_string exn)
+;;
+
+let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~history ~prompt
+    ~on_thread_ready ~on_turn_starting ~on_turn_started =
   send_request io ~id:1 ~method_:"initialize"
     ~params:
       (`Assoc
@@ -676,6 +687,14 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~histor
       Ok 5
   in
   let* turn_request_id = turn_request_id in
+  let* () =
+    invoke_state_callback ~stage:"thread ready callback" (fun () ->
+      on_thread_ready ~thread_id)
+  in
+  let* () =
+    invoke_state_callback ~stage:"turn starting callback" (fun () ->
+      on_turn_starting ~thread_id)
+  in
   send_request io ~id:turn_request_id ~method_:"turn/start"
     ~params:
       (`Assoc
@@ -688,6 +707,10 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~histor
               (Option.map Llm_provider.Reasoning_effort.to_string reasoning_effort)));
   let* turn = await_response io ~id:turn_request_id ~method_:"turn/start" in
   let* turn_id = parse_turn_start turn in
+  let* () =
+    invoke_state_callback ~stage:"turn started callback" (fun () ->
+      on_turn_started ~thread_id ~turn_id)
+  in
   let tool_call_count = ref 0 in
   let* text =
     await_turn_terminal
@@ -787,7 +810,7 @@ let terminate_spawned_process ~clock proc stdin_w =
 ;;
 
 let run_spawned ~mgr ~clock config ~dynamic_tools ~reasoning_effort ~thread_mode ~history
-    ~prompt =
+    ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_started =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -831,7 +854,10 @@ let run_spawned ~mgr ~clock config ~dynamic_tools ~reasoning_effort ~thread_mode
             ~reasoning_effort
             ~thread_mode
             ~history
-            ~prompt)))
+            ~prompt
+            ~on_thread_ready
+            ~on_turn_starting
+            ~on_turn_started)))
 ;;
 
 let validate_config config ~thread_mode ~prompt =
@@ -865,7 +891,9 @@ let validate_dynamic_tools tools =
 ;;
 
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr ~clock
-    ?(history = []) config ~prompt =
+    ?(history = []) ?(on_thread_ready = fun ~thread_id:_ -> Ok ())
+    ?(on_turn_starting = fun ~thread_id:_ -> Ok ())
+    ?(on_turn_started = fun ~thread_id:_ ~turn_id:_ -> Ok ()) config ~prompt =
   let result =
     match validate_config config ~thread_mode ~prompt with
     | Error _ as error -> error
@@ -884,6 +912,9 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr
            ~thread_mode
            ~history
            ~prompt
+           ~on_thread_ready
+           ~on_turn_starting
+           ~on_turn_started
        with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | Eio.Time.Timeout -> Error (Timeout config.timeout_s)

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -809,7 +809,7 @@ let terminate_spawned_process ~clock proc stdin_w =
           (Printexc.to_string exn))
 ;;
 
-let run_spawned ~mgr ~clock config ~dynamic_tools ~reasoning_effort ~thread_mode ~history
+let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort ~thread_mode ~history
     ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_started =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
@@ -817,7 +817,7 @@ let run_spawned ~mgr ~clock config ~dynamic_tools ~reasoning_effort ~thread_mode
     let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
     let stderr_tail = ref "" in
     let proc =
-      Eio.Process.spawn ~sw mgr
+      Eio.Process.spawn ~sw mgr ~cwd
         ~env:(subscription_only_environment ())
         ~stdin:stdin_r ~stdout:stdout_w ~stderr:stderr_w
         [ config.cli_path; "app-server"; "--stdio" ]
@@ -890,7 +890,7 @@ let validate_dynamic_tools tools =
   loop [] tools
 ;;
 
-let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr ~clock
+let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr ~clock ~cwd
     ?(history = []) ?(on_thread_ready = fun ~thread_id:_ -> Ok ())
     ?(on_turn_starting = fun ~thread_id:_ -> Ok ())
     ?(on_turn_started = fun ~thread_id:_ ~turn_id:_ -> Ok ()) config ~prompt =
@@ -906,6 +906,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr
          run_spawned
            ~mgr
            ~clock
+           ~cwd
            config
            ~dynamic_tools
            ~reasoning_effort

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -82,6 +82,7 @@ val run_turn :
   ?thread_mode:thread_mode ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
+  cwd:Eio.Fs.dir_ty Eio.Path.t ->
   ?history:history_message list ->
   ?on_thread_ready:(thread_id:string -> (unit, string) result) ->
   ?on_turn_starting:(thread_id:string -> (unit, string) result) ->

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -83,6 +83,9 @@ val run_turn :
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   ?history:history_message list ->
+  ?on_thread_ready:(thread_id:string -> (unit, string) result) ->
+  ?on_turn_starting:(thread_id:string -> (unit, string) result) ->
+  ?on_turn_started:(thread_id:string -> turn_id:string -> (unit, string) result) ->
   config ->
   prompt:string ->
   (turn_result, error) result

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -19,6 +19,10 @@ type config =
 
 val default_config : cwd:string -> config
 
+type thread_mode =
+  | Start
+  | Resume of { thread_id : string }
+
 type turn_result =
   { thread_id : string
   ; turn_id : string
@@ -27,6 +31,7 @@ type turn_result =
   ; dynamic_tool_calls : int
   ; subscription : subscription
   ; user_agent : string option
+  ; resumed : bool
   }
 
 type dynamic_tool_result =
@@ -74,6 +79,7 @@ val error_to_string : error -> string
 val run_turn :
   ?dynamic_tools:dynamic_tool list ->
   ?reasoning_effort:Llm_provider.Reasoning_effort.t ->
+  ?thread_mode:thread_mode ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   ?history:history_message list ->

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -23,6 +23,16 @@ let turn_completed =
   {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[{"type":"agentMessage","id":"message-1","text":"MASC_SUBSCRIPTION_OK","phase":"final_answer"}],"status":"completed"}}}|}
 ;;
 
+let resumed_turn_result = {|{"id":4,"result":{"turn":{"id":"turn-2"}}}|}
+
+let resumed_item_completed =
+  {|{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-2","completedAtMs":2,"item":{"type":"agentMessage","id":"message-2","text":"MASC_RESUMED_OK","phase":"final_answer"}}}|}
+;;
+
+let resumed_turn_completed =
+  {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-2","items":[{"type":"agentMessage","id":"message-2","text":"MASC_RESUMED_OK","phase":"final_answer"}],"status":"completed"}}}|}
+;;
+
 let shell_quote value =
   "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
 ;;
@@ -51,6 +61,7 @@ let fixture_script lines =
   List.iter
     (fun line -> output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
     (drop 3 lines);
+  output_string output "while IFS= read -r ignored; do :; done\n";
   close_out output;
   Unix.chmod path 0o700;
   path
@@ -61,7 +72,7 @@ let with_fixture lines f =
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
-let run_fixture ?(dynamic_tools = []) ?(history = []) path =
+let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) path =
   Eio_main.run (fun env ->
     let config =
       { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
@@ -73,6 +84,7 @@ let run_fixture ?(dynamic_tools = []) ?(history = []) path =
       ~mgr:(Eio.Stdenv.process_mgr env)
       ~clock:(Eio.Stdenv.clock env)
       ~dynamic_tools
+      ?thread_mode
       ~history
       config
       ~prompt:"Return the fixture marker")
@@ -156,7 +168,44 @@ let test_chatgpt_subscription_turn () =
         check string "thread" "thread-1" result.thread_id;
         check string "turn" "turn-1" result.turn_id;
         check string "model" "gpt-fixture" result.model;
-        check string "plan" "pro" result.subscription.plan_type)
+        check string "plan" "pro" result.subscription.plan_type;
+        check bool "new thread" false result.resumed)
+;;
+
+let test_thread_resume_skips_history_injection () =
+  let history =
+    [ { Runtime_codex_app_server.role = User; text = "already in official thread" } ]
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; item_completed; turn_completed ]
+    (fun path ->
+       match
+         run_fixture
+           ~thread_mode:(Runtime_codex_app_server.Resume { thread_id = "thread-1" })
+           ~history
+           path
+       with
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok result ->
+         check bool "resumed" true result.resumed;
+         check string "thread" "thread-1" result.thread_id)
+;;
+
+let test_thread_resume_rejects_identity_mismatch () =
+  let wrong_thread =
+    {|{"id":3,"result":{"thread":{"id":"thread-other"},"model":"gpt-fixture"}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; wrong_thread; turn_result; item_completed; turn_completed ]
+    (fun path ->
+       match
+         run_fixture
+           ~thread_mode:(Runtime_codex_app_server.Resume { thread_id = "thread-1" })
+           path
+       with
+       | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok _ -> fail "thread/resume admitted a different returned thread id")
 ;;
 
 let test_api_key_account_is_rejected () =
@@ -338,6 +387,78 @@ let cleanup_tree root =
   | _ -> ()
 ;;
 
+let write_fixture_file path content =
+  let output = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr output)
+    (fun () -> output_string output content)
+;;
+
+let fixture_tool ~name ~description =
+  Agent_sdk.Tool.create
+    ~name
+    ~description
+    ~parameters:[]
+    (fun _ -> Ok { Agent_sdk.Types.content = "fixture"; _meta = None })
+;;
+
+let test_codex_session_store_roundtrip () =
+  let session_dir = temp_workspace "masc-codex-store-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree session_dir)
+    (fun () ->
+       let binding : Keeper_codex_session_store.t =
+         { runtime_id = "codex.codex"
+         ; thread_id = "thread-1"
+         ; turn_count = 2
+         ; tool_surface_sha256 = Keeper_codex_session_store.tool_surface_sha256 []
+         ; updated_at = 42.5
+         }
+       in
+       (match Keeper_codex_session_store.load ~session_dir with
+        | Ok None -> ()
+        | Ok (Some _) -> fail "missing Codex session was reported as present"
+        | Error detail -> fail detail);
+       (match Keeper_codex_session_store.save ~session_dir binding with
+        | Ok () -> ()
+        | Error detail -> fail detail);
+       match Keeper_codex_session_store.load ~session_dir with
+       | Error detail -> fail detail
+       | Ok None -> fail "saved Codex session disappeared"
+       | Ok (Some loaded) ->
+         check string "runtime" binding.runtime_id loaded.runtime_id;
+         check string "thread" binding.thread_id loaded.thread_id;
+         check int "turn count" binding.turn_count loaded.turn_count;
+         check string
+           "tool surface"
+           binding.tool_surface_sha256
+           loaded.tool_surface_sha256;
+         check (float 0.0) "updated at" binding.updated_at loaded.updated_at)
+;;
+
+let test_codex_session_store_rejects_ambiguous_json () =
+  let session_dir = temp_workspace "masc-codex-store-invalid-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree session_dir)
+    (fun () ->
+       write_fixture_file
+         (Keeper_codex_session_store.path ~session_dir)
+         {|{"runtime_id":"codex.codex","runtime_id":"codex.other","schema":"masc.keeper.codex-session.v1","thread_id":"thread-1","tool_surface_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","turn_count":1,"updated_at":1.0}|};
+       match Keeper_codex_session_store.load ~session_dir with
+       | Error _ -> ()
+       | Ok _ -> fail "ambiguous Codex session JSON was admitted")
+;;
+
+let test_codex_tool_surface_fingerprint_is_exact () =
+  let alpha = fixture_tool ~name:"alpha" ~description:"first" in
+  let beta = fixture_tool ~name:"beta" ~description:"second" in
+  let changed = fixture_tool ~name:"alpha" ~description:"changed" in
+  let digest tools = Keeper_codex_session_store.tool_surface_sha256 tools in
+  check string "order independent" (digest [ alpha; beta ]) (digest [ beta; alpha ]);
+  check bool "description participates" true
+    (not (String.equal (digest [ alpha ]) (digest [ changed ])))
+;;
+
 let production_keeper_meta ~base_path =
   let name = "codex-production-fixture" in
   match
@@ -423,11 +544,18 @@ let run_production_keeper_turn ~cli_path ~model =
 ;;
 
 let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projection
-    ?(goal = "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.")
-    ~cli_path ~model () =
+    ?session_dir
+    ?(goal = "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.") ~cli_path
+    ~model () =
+  let owns_session_dir = Option.is_none session_dir in
+  let session_dir =
+    Option.value session_dir ~default:(temp_workspace "masc-codex-session-")
+  in
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
-    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      if owns_session_dir then cleanup_tree session_dir)
     (fun () ->
        with_runtime_config ~model cli_path (fun runtime_path ->
          Eio_main.run (fun env ->
@@ -452,6 +580,7 @@ let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projecti
                       ~keeper_name:"codex-fixture"
                       ~base_path:"/tmp"
                       ~goal
+                      ~keeper_session_dir:session_dir
                       ~tools
                       ~initial_messages:[]
                       ?model_input_projection
@@ -472,6 +601,123 @@ let test_keeper_dispatches_codex_turn_runtime () =
        | Ok result ->
          check string "Keeper response" "MASC_SUBSCRIPTION_OK" (keeper_response_text result);
          check bool "measured observation" true (Option.is_some result.runtime_observation))
+;;
+
+let test_keeper_resumes_persisted_codex_thread () =
+  let session_dir = temp_workspace "masc-codex-resume-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree session_dir)
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~session_dir
+                ~cli_path
+                ~model:"gpt-fixture"
+                ()
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok result -> check int "initial turn count" 1 result.turns);
+       let before_turn_ordinal = ref 0 in
+       let after_turn_ordinal = ref 0 in
+       let hooks : Agent_sdk.Hooks.hooks =
+         { Agent_sdk.Hooks.empty with
+           before_turn =
+             Some
+               (function
+                 | BeforeTurn { turn; _ } ->
+                   before_turn_ordinal := turn;
+                   Continue
+                 | _ -> Continue)
+         ; after_turn =
+             Some
+               (function
+                 | AfterTurn { turn; _ } ->
+                   after_turn_ordinal := turn;
+                   Continue
+                 | _ -> Continue)
+         }
+       in
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; resumed_turn_result
+         ; resumed_item_completed
+         ; resumed_turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~session_dir
+                ~hooks
+                ~goal:"Return the resumed fixture marker"
+                ~cli_path
+                ~model:"gpt-fixture"
+                ()
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok result ->
+              check string "resumed response" "MASC_RESUMED_OK" (keeper_response_text result);
+              check string "official thread" "thread-1" result.session_id;
+              check int "cumulative turns" 2 result.turns;
+              check int "before-turn ordinal" 2 !before_turn_ordinal;
+              check int "after-turn ordinal" 2 !after_turn_ordinal);
+       match Keeper_codex_session_store.load ~session_dir with
+       | Error detail -> fail detail
+       | Ok None -> fail "resumed Codex binding disappeared"
+       | Ok (Some binding) -> check int "stored turns" 2 binding.turn_count)
+;;
+
+let test_keeper_rejects_changed_tool_surface_on_resume () =
+  let session_dir = temp_workspace "masc-codex-tool-change-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree session_dir)
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            (match
+               run_keeper_turn
+                 ~session_dir
+                 ~cli_path
+                 ~model:"gpt-fixture"
+                 ()
+             with
+             | Error error -> fail (Agent_sdk.Error.to_string error)
+             | Ok _ -> ());
+            let tool = fixture_tool ~name:"new_tool" ~description:"new surface" in
+            match
+              run_keeper_turn
+                ~session_dir
+                ~tools:[ tool ]
+                ~cli_path
+                ~model:"gpt-fixture"
+                ()
+            with
+            | Error
+                (Agent_sdk.Error.Config
+                  (Agent_sdk.Error.InvalidConfig { field; _ })) ->
+              check string
+                "fingerprint field"
+                "codex_session.tool_surface_sha256"
+                field
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok _ -> fail "changed tool surface silently resumed the Codex thread"))
 ;;
 
 let assert_production_keeper_result result =
@@ -782,6 +1028,46 @@ let test_live_keeper_dynamic_tool_subscription () =
       check string "live tool Keeper response" "MASC_TOOL_OK" (keeper_response_text result)
 ;;
 
+let test_live_keeper_resumes_official_thread () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let session_dir = temp_workspace "masc-codex-live-resume-" in
+    Fun.protect
+      ~finally:(fun () -> cleanup_tree session_dir)
+      (fun () ->
+         (match
+            run_keeper_turn
+              ~session_dir
+              ~goal:
+                "Remember marker MASC_RESUME_MEMORY. Reply exactly MASC_RESUME_FIRST."
+              ~cli_path:"codex"
+              ~model:"gpt-5.6-sol"
+              ()
+          with
+          | Error error -> fail (Agent_sdk.Error.to_string error)
+          | Ok result ->
+            check string
+              "first live response"
+              "MASC_RESUME_FIRST"
+              (keeper_response_text result));
+         match
+           run_keeper_turn
+             ~session_dir
+             ~goal:"Reply exactly with the remembered marker."
+             ~cli_path:"codex"
+             ~model:"gpt-5.6-sol"
+             ()
+         with
+         | Error error -> fail (Agent_sdk.Error.to_string error)
+         | Ok result ->
+           check string
+             "resumed live response"
+             "MASC_RESUME_MEMORY"
+             (keeper_response_text result);
+           check int "resumed live turn count" 2 result.turns)
+;;
+
 let test_live_production_keeper_subscription () =
   if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
   then Alcotest.skip ()
@@ -818,9 +1104,37 @@ let () =
         ; test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
         ; test_case "history injects before turn" `Quick test_history_is_injected_before_turn
         ; test_case
+            "thread resume skips history injection"
+            `Quick
+            test_thread_resume_skips_history_injection
+        ; test_case
+            "thread resume rejects identity mismatch"
+            `Quick
+            test_thread_resume_rejects_identity_mismatch
+        ; test_case
+            "Codex session store roundtrip"
+            `Quick
+            test_codex_session_store_roundtrip
+        ; test_case
+            "Codex session store rejects ambiguous JSON"
+            `Quick
+            test_codex_session_store_rejects_ambiguous_json
+        ; test_case
+            "Codex tool fingerprint is exact"
+            `Quick
+            test_codex_tool_surface_fingerprint_is_exact
+        ; test_case
             "Keeper dispatches Codex runtime"
             `Quick
             test_keeper_dispatches_codex_turn_runtime
+        ; test_case
+            "Keeper resumes persisted Codex thread"
+            `Quick
+            test_keeper_resumes_persisted_codex_thread
+        ; test_case
+            "Keeper rejects changed Codex tool surface"
+            `Quick
+            test_keeper_rejects_changed_tool_surface_on_resume
         ; test_case
             "production Keeper dispatches Codex runtime"
             `Quick
@@ -855,6 +1169,10 @@ let () =
             "Keeper typed tool through official Codex app-server"
             `Slow
             test_live_keeper_dynamic_tool_subscription
+        ; test_case
+            "Keeper resumes official Codex thread"
+            `Slow
+            test_live_keeper_resumes_official_thread
         ; test_case
             "production Keeper through official Codex app-server"
             `Slow

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -403,31 +403,70 @@ let fixture_tool ?(parameters = []) ~name ~description () =
 ;;
 
 let test_codex_session_store_roundtrip () =
-  let session_dir = temp_workspace "masc-codex-store-" in
+  let base_path = temp_workspace "masc-codex-store-" in
+  let keeper_name = "roundtrip" in
   Fun.protect
-    ~finally:(fun () -> cleanup_tree session_dir)
+    ~finally:(fun () -> cleanup_tree base_path)
     (fun () ->
-       let binding : Keeper_codex_session_store.t =
-         { runtime_id = "codex.codex"
-         ; thread_id = "thread-1"
-         ; turn_count = 2
-         ; tool_surface_sha256 = Keeper_codex_session_store.tool_surface_sha256 []
-         ; updated_at = 42.5
-         }
-       in
-       (match Keeper_codex_session_store.load ~session_dir with
+       (match Keeper_codex_session_store.load ~base_path ~keeper_name with
         | Ok None -> ()
         | Ok (Some _) -> fail "missing Codex session was reported as present"
         | Error detail -> fail detail);
-       (match Keeper_codex_session_store.save ~session_dir binding with
-        | Ok () -> ()
-        | Error detail -> fail detail);
-       match Keeper_codex_session_store.load ~session_dir with
+       let claim =
+         Keeper_codex_session_store.claim
+           ~base_path
+           ~keeper_name
+           ~expected:None
+           ~runtime_id:"codex.codex"
+           ~tool_surface_sha256:
+             (Keeper_codex_session_store.tool_surface_sha256 [])
+           ~updated_at:40.0
+         |> Result.get_ok
+       in
+       let active =
+         Keeper_codex_session_store.mark_active
+           ~base_path
+           ~keeper_name
+           ~expected:claim
+           ~thread_id:"thread-1"
+           ~updated_at:41.0
+         |> Result.get_ok
+       in
+       let starting =
+         Keeper_codex_session_store.mark_turn_starting
+           ~base_path
+           ~keeper_name
+           ~expected:active
+           ~thread_id:"thread-1"
+           ~updated_at:41.5
+         |> Result.get_ok
+       in
+       let started =
+         Keeper_codex_session_store.mark_turn_started
+           ~base_path
+           ~keeper_name
+           ~expected:starting
+           ~thread_id:"thread-1"
+           ~turn_id:"turn-1"
+           ~updated_at:42.0
+         |> Result.get_ok
+       in
+       let binding =
+         Keeper_codex_session_store.settle
+           ~base_path
+           ~keeper_name
+           ~expected:started
+           ~thread_id:"thread-1"
+           ~turn_id:"turn-1"
+           ~updated_at:42.5
+         |> Result.get_ok
+       in
+       match Keeper_codex_session_store.load ~base_path ~keeper_name with
        | Error detail -> fail detail
        | Ok None -> fail "saved Codex session disappeared"
        | Ok (Some loaded) ->
          check string "runtime" binding.runtime_id loaded.runtime_id;
-         check string "thread" binding.thread_id loaded.thread_id;
+         check bool "phase" true (binding.phase = loaded.phase);
          check int "turn count" binding.turn_count loaded.turn_count;
          check string
            "tool surface"
@@ -437,16 +476,73 @@ let test_codex_session_store_roundtrip () =
 ;;
 
 let test_codex_session_store_rejects_ambiguous_json () =
-  let session_dir = temp_workspace "masc-codex-store-invalid-" in
+  let base_path = temp_workspace "masc-codex-store-invalid-" in
+  let keeper_name = "ambiguous" in
   Fun.protect
-    ~finally:(fun () -> cleanup_tree session_dir)
+    ~finally:(fun () -> cleanup_tree base_path)
     (fun () ->
+       let state_path =
+         Keeper_codex_session_store.path ~base_path ~keeper_name |> Result.get_ok
+       in
+       let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname state_path) in
        write_fixture_file
-         (Keeper_codex_session_store.path ~session_dir)
-         {|{"runtime_id":"codex.codex","runtime_id":"codex.other","schema":"masc.keeper.codex-session.v1","thread_id":"thread-1","tool_surface_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","turn_count":1,"updated_at":1.0}|};
-       match Keeper_codex_session_store.load ~session_dir with
+         state_path
+         {|{"runtime_id":"codex.codex","runtime_id":"codex.other","phase":{"kind":"settled","thread_id":"thread-1","turn_id":"turn-1"},"schema":"masc.keeper.codex-session.v2","tool_surface_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","turn_count":1,"updated_at":1.0}|};
+       match Keeper_codex_session_store.load ~base_path ~keeper_name with
        | Error _ -> ()
        | Ok _ -> fail "ambiguous Codex session JSON was admitted")
+;;
+
+let test_codex_inflight_session_blocks_duplicate_claim () =
+  let base_path = temp_workspace "masc-codex-store-inflight-" in
+  let keeper_name = "inflight" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       let claim =
+         Keeper_codex_session_store.claim
+           ~base_path
+           ~keeper_name
+           ~expected:None
+           ~runtime_id:"codex.codex"
+           ~tool_surface_sha256:
+             (Keeper_codex_session_store.tool_surface_sha256 [])
+           ~updated_at:1.0
+         |> Result.get_ok
+       in
+       let active =
+         Keeper_codex_session_store.mark_active
+           ~base_path
+           ~keeper_name
+           ~expected:claim
+           ~thread_id:"thread-1"
+           ~updated_at:2.0
+         |> Result.get_ok
+       in
+       let inflight =
+         Keeper_codex_session_store.mark_turn_starting
+           ~base_path
+           ~keeper_name
+           ~expected:active
+           ~thread_id:"thread-1"
+           ~updated_at:3.0
+         |> Result.get_ok
+       in
+       (match
+          Keeper_codex_session_store.claim
+            ~base_path
+            ~keeper_name
+            ~expected:(Some inflight)
+            ~runtime_id:"codex.codex"
+            ~tool_surface_sha256:inflight.tool_surface_sha256
+            ~updated_at:4.0
+        with
+        | Error _ -> ()
+        | Ok _ -> fail "in-flight Codex session admitted a duplicate claim");
+       match Keeper_codex_session_store.load ~base_path ~keeper_name with
+       | Ok (Some { phase = Turn_inflight { turn_id = None; _ }; _ }) -> ()
+       | Error detail -> fail detail
+       | Ok None | Ok (Some _) -> fail "duplicate claim changed the in-flight phase")
 ;;
 
 let test_codex_tool_surface_fingerprint_is_exact () =
@@ -487,14 +583,14 @@ let test_codex_tool_surface_fingerprint_is_exact () =
     (not (String.equal (digest [ alpha ]) (digest [ changed ])))
 ;;
 
-let production_keeper_meta ~base_path =
+let production_keeper_meta ~base_path ~trace_id =
   let name = "codex-production-fixture" in
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
          [ "name", `String name
          ; "agent_name", `String (Keeper_identity.keeper_agent_name name)
-         ; "trace_id", `String "codex-production-fixture-trace"
+         ; "trace_id", `String trace_id
          ; "allowed_paths", `List [ `String base_path ]
          ])
   with
@@ -502,17 +598,13 @@ let production_keeper_meta ~base_path =
   | Error detail -> fail ("production Keeper meta fixture failed: " ^ detail)
 ;;
 
-let run_production_keeper_turn ~cli_path ~model =
+let run_production_keeper_turn ~base_path ~trace_id ~user_message ~cli_path ~model =
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
     ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
     (fun () ->
        with_runtime_config ~model cli_path (fun runtime_path ->
-         let base_path = temp_workspace "masc-codex-production-" in
-         Fun.protect
-           ~finally:(fun () -> cleanup_tree base_path)
-           (fun () ->
-              Eio_main.run (fun env ->
+         Eio_main.run (fun env ->
                 Eio.Switch.run (fun sw ->
                   Fs_compat.set_fs (Eio.Stdenv.fs env);
                   Eio_context.set_env env;
@@ -526,7 +618,7 @@ let run_production_keeper_turn ~cli_path ~model =
                        | Error error -> fail error
                        | Ok () ->
                          let config = Workspace.default_config base_path in
-                         let meta = production_keeper_meta ~base_path in
+                         let meta = production_keeper_meta ~base_path ~trace_id in
                          ignore
                            (Keeper_registry.For_testing.register
                               ~base_path
@@ -563,27 +655,26 @@ let run_production_keeper_turn ~cli_path ~model =
                                     { Keeper_agent_run.system_prompt = base_system_prompt
                                     ; dynamic_context = ""
                                     })
-                                ~user_message:
-                                  "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools."
+                                ~user_message
                                 ~turn_kind:Turn_record.Direct
                                 ~runtime_id:"codex.codex"
                                 ~generation:1
-                                ())))))))
+                                ()))))))
 ;;
 
 let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projection
-    ?session_dir
+    ?base_path
     ?(goal = "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.") ~cli_path
     ~model () =
-  let owns_session_dir = Option.is_none session_dir in
-  let session_dir =
-    Option.value session_dir ~default:(temp_workspace "masc-codex-session-")
+  let owns_base_path = Option.is_none base_path in
+  let base_path =
+    Option.value base_path ~default:(temp_workspace "masc-codex-session-")
   in
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
     ~finally:(fun () ->
       Runtime.For_testing.restore runtime_snapshot;
-      if owns_session_dir then cleanup_tree session_dir)
+      if owns_base_path then cleanup_tree base_path)
     (fun () ->
        with_runtime_config ~model cli_path (fun runtime_path ->
          Eio_main.run (fun env ->
@@ -606,9 +697,8 @@ let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projecti
                     Keeper_turn_driver.run_named
                       ~runtime_id:"codex.codex"
                       ~keeper_name:"codex-fixture"
-                      ~base_path:"/tmp"
+                      ~base_path
                       ~goal
-                      ~keeper_session_dir:session_dir
                       ~tools
                       ~initial_messages:[]
                       ?model_input_projection
@@ -632,9 +722,9 @@ let test_keeper_dispatches_codex_turn_runtime () =
 ;;
 
 let test_keeper_resumes_persisted_codex_thread () =
-  let session_dir = temp_workspace "masc-codex-resume-" in
+  let base_path = temp_workspace "masc-codex-resume-" in
   Fun.protect
-    ~finally:(fun () -> cleanup_tree session_dir)
+    ~finally:(fun () -> cleanup_tree base_path)
     (fun () ->
        with_fixture
          [ init_result
@@ -647,7 +737,7 @@ let test_keeper_resumes_persisted_codex_thread () =
          (fun cli_path ->
             match
               run_keeper_turn
-                ~session_dir
+                ~base_path
                 ~cli_path
                 ~model:"gpt-fixture"
                 ()
@@ -685,7 +775,7 @@ let test_keeper_resumes_persisted_codex_thread () =
          (fun cli_path ->
             match
               run_keeper_turn
-                ~session_dir
+                ~base_path
                 ~hooks
                 ~goal:"Return the resumed fixture marker"
                 ~cli_path
@@ -699,16 +789,20 @@ let test_keeper_resumes_persisted_codex_thread () =
               check int "cumulative turns" 2 result.turns;
               check int "before-turn ordinal" 2 !before_turn_ordinal;
               check int "after-turn ordinal" 2 !after_turn_ordinal);
-       match Keeper_codex_session_store.load ~session_dir with
+       match
+         Keeper_codex_session_store.load
+           ~base_path
+           ~keeper_name:"codex-fixture"
+       with
        | Error detail -> fail detail
        | Ok None -> fail "resumed Codex binding disappeared"
        | Ok (Some binding) -> check int "stored turns" 2 binding.turn_count)
 ;;
 
 let test_keeper_rejects_changed_tool_surface_on_resume () =
-  let session_dir = temp_workspace "masc-codex-tool-change-" in
+  let base_path = temp_workspace "masc-codex-tool-change-" in
   Fun.protect
-    ~finally:(fun () -> cleanup_tree session_dir)
+    ~finally:(fun () -> cleanup_tree base_path)
     (fun () ->
        with_fixture
          [ init_result
@@ -721,7 +815,7 @@ let test_keeper_rejects_changed_tool_surface_on_resume () =
          (fun cli_path ->
             (match
                run_keeper_turn
-                 ~session_dir
+                 ~base_path
                  ~cli_path
                  ~model:"gpt-fixture"
                  ()
@@ -731,7 +825,7 @@ let test_keeper_rejects_changed_tool_surface_on_resume () =
             let tool = fixture_tool ~name:"new_tool" ~description:"new surface" () in
             match
               run_keeper_turn
-                ~session_dir
+                ~base_path
                 ~tools:[ tool ]
                 ~cli_path
                 ~model:"gpt-fixture"
@@ -762,18 +856,93 @@ let assert_production_keeper_result result =
 ;;
 
 let test_production_keeper_dispatches_codex_runtime () =
-  with_fixture
-    [ init_result
-    ; account_chatgpt
-    ; thread_result
-    ; turn_result
-    ; item_completed
-    ; turn_completed
-    ]
-    (fun cli_path ->
-       match run_production_keeper_turn ~cli_path ~model:"gpt-fixture" with
-       | Error error -> fail (Agent_sdk.Error.to_string error)
-       | Ok result -> assert_production_keeper_result result)
+  let base_path = temp_workspace "masc-codex-production-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_production_keeper_turn
+                ~base_path
+                ~trace_id:"codex-production-trace-1"
+                ~user_message:
+                  "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools."
+                ~cli_path
+                ~model:"gpt-fixture"
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok result -> assert_production_keeper_result result))
+;;
+
+let test_production_keeper_resumes_across_trace_rotation () =
+  let base_path = temp_workspace "masc-codex-production-resume-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_production_keeper_turn
+                ~base_path
+                ~trace_id:"codex-production-trace-1"
+                ~user_message:"Start the production fixture thread."
+                ~cli_path
+                ~model:"gpt-fixture"
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok _ -> ());
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; resumed_turn_result
+         ; resumed_item_completed
+         ; resumed_turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_production_keeper_turn
+                ~base_path
+                ~trace_id:"codex-production-trace-2"
+                ~user_message:"Resume the production fixture thread."
+                ~cli_path
+                ~model:"gpt-fixture"
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok result ->
+              check string
+                "production resumed response"
+                "MASC_RESUMED_OK"
+                result.Keeper_agent_run.response_text);
+       match
+         Keeper_codex_session_store.load
+           ~base_path
+           ~keeper_name:"codex-production-fixture"
+       with
+       | Error detail -> fail detail
+       | Ok None -> fail "production Codex current-owner state disappeared"
+       | Ok (Some state) ->
+         check int "production cumulative turns" 2 state.turn_count;
+         (match state.phase with
+          | Settled { thread_id; _ } ->
+            check string "production thread" "thread-1" thread_id
+          | Start _ | Active _ | Turn_inflight _ ->
+            fail "production Codex state did not settle"))
 ;;
 
 let test_keeper_projects_typed_tools_and_hooks () =
@@ -1060,13 +1229,13 @@ let test_live_keeper_resumes_official_thread () =
   if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
   then Alcotest.skip ()
   else
-    let session_dir = temp_workspace "masc-codex-live-resume-" in
+    let base_path = temp_workspace "masc-codex-live-resume-" in
     Fun.protect
-      ~finally:(fun () -> cleanup_tree session_dir)
+      ~finally:(fun () -> cleanup_tree base_path)
       (fun () ->
          (match
             run_keeper_turn
-              ~session_dir
+              ~base_path
               ~goal:
                 "Remember marker MASC_RESUME_MEMORY. Reply exactly MASC_RESUME_FIRST."
               ~cli_path:"codex"
@@ -1081,7 +1250,7 @@ let test_live_keeper_resumes_official_thread () =
               (keeper_response_text result));
          match
            run_keeper_turn
-             ~session_dir
+             ~base_path
              ~goal:"Reply exactly with the remembered marker."
              ~cli_path:"codex"
              ~model:"gpt-5.6-sol"
@@ -1100,9 +1269,21 @@ let test_live_production_keeper_subscription () =
   if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
   then Alcotest.skip ()
   else
-    match run_production_keeper_turn ~cli_path:"codex" ~model:"gpt-5.6-sol" with
-    | Error error -> fail (Agent_sdk.Error.to_string error)
-    | Ok result -> assert_production_keeper_result result
+    let base_path = temp_workspace "masc-codex-live-production-" in
+    Fun.protect
+      ~finally:(fun () -> cleanup_tree base_path)
+      (fun () ->
+         match
+           run_production_keeper_turn
+             ~base_path
+             ~trace_id:"codex-live-production-trace"
+             ~user_message:
+               "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools."
+             ~cli_path:"codex"
+             ~model:"gpt-5.6-sol"
+         with
+         | Error error -> fail (Agent_sdk.Error.to_string error)
+         | Ok result -> assert_production_keeper_result result)
 ;;
 
 let () =
@@ -1148,6 +1329,10 @@ let () =
             `Quick
             test_codex_session_store_rejects_ambiguous_json
         ; test_case
+            "Codex in-flight session blocks duplicate claim"
+            `Quick
+            test_codex_inflight_session_blocks_duplicate_claim
+        ; test_case
             "Codex tool fingerprint is exact"
             `Quick
             test_codex_tool_surface_fingerprint_is_exact
@@ -1167,6 +1352,10 @@ let () =
             "production Keeper dispatches Codex runtime"
             `Quick
             test_production_keeper_dispatches_codex_runtime
+        ; test_case
+            "production Keeper resumes across trace rotation"
+            `Quick
+            test_production_keeper_resumes_across_trace_rotation
         ; test_case
             "Keeper projects typed tools and hooks"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -394,11 +394,11 @@ let write_fixture_file path content =
     (fun () -> output_string output content)
 ;;
 
-let fixture_tool ~name ~description =
+let fixture_tool ?(parameters = []) ~name ~description () =
   Agent_sdk.Tool.create
     ~name
     ~description
-    ~parameters:[]
+    ~parameters
     (fun _ -> Ok { Agent_sdk.Types.content = "fixture"; _meta = None })
 ;;
 
@@ -450,11 +450,39 @@ let test_codex_session_store_rejects_ambiguous_json () =
 ;;
 
 let test_codex_tool_surface_fingerprint_is_exact () =
-  let alpha = fixture_tool ~name:"alpha" ~description:"first" in
-  let beta = fixture_tool ~name:"beta" ~description:"second" in
-  let changed = fixture_tool ~name:"alpha" ~description:"changed" in
+  let alpha = fixture_tool ~name:"alpha" ~description:"first" () in
+  let beta = fixture_tool ~name:"beta" ~description:"second" () in
+  let changed = fixture_tool ~name:"alpha" ~description:"changed" () in
+  let first_param : Agent_sdk.Types.tool_param =
+    { name = "first"; description = "first parameter"; param_type = String; required = true }
+  in
+  let second_param : Agent_sdk.Types.tool_param =
+    { name = "second"
+    ; description = "second parameter"
+    ; param_type = Integer
+    ; required = true
+    }
+  in
+  let ordered =
+    fixture_tool
+      ~parameters:[ first_param; second_param ]
+      ~name:"ordered"
+      ~description:"same semantic schema"
+      ()
+  in
+  let reordered =
+    fixture_tool
+      ~parameters:[ second_param; first_param ]
+      ~name:"ordered"
+      ~description:"same semantic schema"
+      ()
+  in
   let digest tools = Keeper_codex_session_store.tool_surface_sha256 tools in
   check string "order independent" (digest [ alpha; beta ]) (digest [ beta; alpha ]);
+  check string
+    "parameter and property order independent"
+    (digest [ ordered ])
+    (digest [ reordered ]);
   check bool "description participates" true
     (not (String.equal (digest [ alpha ]) (digest [ changed ])))
 ;;
@@ -700,7 +728,7 @@ let test_keeper_rejects_changed_tool_surface_on_resume () =
              with
              | Error error -> fail (Agent_sdk.Error.to_string error)
              | Ok _ -> ());
-            let tool = fixture_tool ~name:"new_tool" ~description:"new surface" in
+            let tool = fixture_tool ~name:"new_tool" ~description:"new surface" () in
             match
               run_keeper_turn
                 ~session_dir

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -72,7 +72,7 @@ let with_fixture lines f =
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
-let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) path =
+let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp") path =
   Eio_main.run (fun env ->
     let config =
       { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
@@ -83,6 +83,7 @@ let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) path =
     Runtime_codex_app_server.run_turn
       ~mgr:(Eio.Stdenv.process_mgr env)
       ~clock:(Eio.Stdenv.clock env)
+      ~cwd:Eio.Path.(Eio.Stdenv.fs env / cwd)
       ~dynamic_tools
       ?thread_mode
       ~history
@@ -385,6 +386,45 @@ let cleanup_tree root =
   in
   try remove root with
   | _ -> ()
+;;
+
+let test_declared_cwd_reaches_spawn () =
+  let workspace = temp_workspace "masc-codex-cwd-" in
+  let marker = Filename.concat workspace "spawn-cwd.txt" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree workspace)
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun fixture ->
+            let wrapper = Filename.temp_file "masc-codex-cwd-wrapper-" ".sh" in
+            Fun.protect
+              ~finally:(fun () -> Sys.remove wrapper)
+              (fun () ->
+                 let output = open_out_bin wrapper in
+                 output_string output "#!/bin/sh\n";
+                 output_string output ("pwd > " ^ shell_quote marker ^ "\n");
+                 output_string output
+                   ("exec " ^ shell_quote fixture ^ " \"$@\"\n");
+                 close_out output;
+                 Unix.chmod wrapper 0o700;
+                 (match run_fixture ~cwd:workspace wrapper with
+                  | Error error ->
+                    fail (Runtime_codex_app_server.error_to_string error)
+                  | Ok _ -> ());
+                 let input = open_in_bin marker in
+                 let observed =
+                   Fun.protect
+                     ~finally:(fun () -> close_in input)
+                     (fun () -> input_line input)
+                 in
+                 check string "spawn cwd" workspace observed)))
 ;;
 
 let write_fixture_file path content =
@@ -1110,6 +1150,7 @@ let test_live_chatgpt_subscription () =
         Runtime_codex_app_server.run_turn
           ~mgr:(Eio.Stdenv.process_mgr env)
           ~clock:(Eio.Stdenv.clock env)
+          ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
           config
           ~prompt:"Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.")
     in
@@ -1147,6 +1188,7 @@ let test_live_dynamic_tool_subscription () =
         Runtime_codex_app_server.run_turn
           ~mgr:(Eio.Stdenv.process_mgr env)
           ~clock:(Eio.Stdenv.clock env)
+          ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
           ~dynamic_tools:[ tool ]
           config
           ~prompt:
@@ -1174,6 +1216,7 @@ let test_live_history_injection_subscription () =
         Runtime_codex_app_server.run_turn
           ~mgr:(Eio.Stdenv.process_mgr env)
           ~clock:(Eio.Stdenv.clock env)
+          ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
           ~history:
             [ { role = User; text = "The continuity marker is MASC_HISTORY_OK." }
             ; { role = Assistant; text = "I will retain that marker." }
@@ -1290,6 +1333,7 @@ let () =
   run "runtime codex app-server"
     [ ( "subscription boundary"
       , [ test_case "ChatGPT turn completes" `Quick test_chatgpt_subscription_turn
+        ; test_case "declared cwd reaches spawn" `Quick test_declared_cwd_reaches_spawn
         ; test_case "API key is rejected" `Quick test_api_key_account_is_rejected
         ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
         ; test_case


### PR DESCRIPTION
## Summary
- persist the current Codex official-client owner per Keeper, outside trace-local checkpoints
- hard-cut session state to `Start`, `Active`, `Turn_inflight`, and `Settled`
- claim and transition state durably around `thread/start`, `thread/resume`, and `turn/start`
- settle only after the terminal result and Keeper hooks succeed
- block automatic replay when an external turn may have advanced but local settlement is incomplete
- keep tool-surface identity recursively canonical and fail visibly on drift
- document a credential-free Codex subscription runtime with Spark 128K and ordered GLM failover

## Production boundary

The binding lives at `<base>/.masc/keepers/<keeper>/official-client-runtime/codex-session.json`; it is not owned by a rotating trace directory and it is not an OAS checkpoint. The state schema is current-only: malformed, stale, in-flight, and incompatible state is rejected without a migration or silent reset path.

The app-server adapter exposes typed callback boundaries for thread readiness, turn admission, returned turn identity, and settlement. `Settled` is written only after `terminal_error` validation, `after_turn`, and `on_stop` complete.

## Validation

- deterministic Codex app-server/Keeper suite: 24/24 passed on current branch after rebase onto `8954ed0a3b`
- includes two real `Keeper_agent_run.run_turn` calls with different trace IDs and one stable Keeper owner
- incomplete `Turn_inflight` state rejects a duplicate automatic claim
- `ocamlformat --check` passed for every changed OCaml file
- `git diff --check origin/main...HEAD` passed
- 7 opt-in live subscription cases skipped because `MASC_CODEX_APP_SERVER_LIVE` was not set

## Dependency

Current `main` contains unrelated approval-boundary compile failures. #27727 fixes those without adding them to this PR. Required current-head CI remains authoritative after that hotfix lands.