### PR TITLE
docs: drop deleted command runtime reference

### DIFF
--- a/docs/EXECUTE-RUNBOOK.md
+++ b/docs/EXECUTE-RUNBOOK.md
@@ -8,7 +8,6 @@ code_refs:
   - lib/process/process_eio.ml
   - lib/exec/command_gate/shell_command_gate.ml
   - lib/exec_policy/exec_policy.ml
-  - lib/keeper/keeper_tool_command_runtime.ml
 ---
 
 # Execute Runbook


### PR DESCRIPTION
## What changed

- delete the `code_refs` entry for the removed `keeper_tool_command_runtime.ml` facade

## Why

Current `main` removed that dead runtime facade but retained its runbook reference. `check-doc-code-refs.sh` therefore fails Meta Guards for every PR based on current main.

No replacement alias or tombstone is introduced.

## Validation

- `scripts/check-doc-code-refs.sh`
- `git diff --check`

Closes #27729.
