### PR TITLE
feat(keeper): add full-tool internal research boundary

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -50,6 +50,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_shared_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_task_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_task_runtime.mli` - execution-dispatch
+- `lib/keeper/keeper_tool_terminal_boundary.ml` - execution-dispatch
+- `lib/keeper/keeper_tool_terminal_boundary.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_voice_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_voice_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_dispatch_runtime.ml` - execution-dispatch

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -314,21 +314,7 @@ let turn_record_raw_trace_run_ref
       }
 ;;
 
-let terminal_effect_boundary_decision = function
-  | Keeper_tools_oas.Terminal_effect_open -> Ok Runtime_agent.Continue
-  | Keeper_tools_oas.Deferred_tool_result ->
-    Ok (Runtime_agent.Yield Runtime_agent.Durable_stimulus_waiting)
-  | Keeper_tools_oas.External_effect_deferred ->
-    Ok (Runtime_agent.Yield Runtime_agent.External_effect_deferred)
-  | Keeper_tools_oas.Terminal_effect_completed ->
-    Ok (Runtime_agent.Yield Runtime_agent.Terminal_tool_completed)
-  | Keeper_tools_oas.Terminal_effect_failed
-      { failure_class; effect_disposition; diagnostic } ->
-    Error
-      (Keeper_internal_error.sdk_error_of_masc_internal_error
-         (Keeper_internal_error.Terminal_effect_failed
-            { failure_class; effect_disposition; diagnostic }))
-;;
+let terminal_effect_boundary_decision = Keeper_tool_terminal_boundary.decision
 
 module For_testing = struct
   let sse_event_progress_kind = Turn_helpers.sse_event_progress_kind

--- a/lib/keeper/keeper_internal_research.ml
+++ b/lib/keeper/keeper_internal_research.ml
@@ -1,0 +1,637 @@
+type owner =
+  | Librarian
+  | Hitl_auto_judge
+  | Board_attention
+  | Compaction
+  | Completion_authority
+
+module Execution_id = struct
+  type t = string
+
+  let generate () = Random_id.prefixed ~prefix:"internal-research-" ~bytes:16
+
+  let to_string value = value
+end
+
+type raw_trace_sink_outcome =
+  | Raw_trace_ready of Agent_sdk.Raw_trace.t
+  | Raw_trace_degraded of Agent_sdk.Error.sdk_error
+
+let create_raw_trace_sink
+      ~before_create
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~execution_id
+  =
+  let path_result =
+    try Ok (Keeper_types_support.keeper_raw_trace_turn_path config meta.name) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Agent_sdk.Error.Internal (Printexc.to_string exn))
+  in
+  match path_result with
+  | Error error -> Raw_trace_degraded error
+  | Ok path ->
+    before_create path;
+    (match
+       Agent_sdk.Raw_trace.create
+         ~session_id:(Execution_id.to_string execution_id)
+         ~path
+         ()
+     with
+     | Ok sink -> Raw_trace_ready sink
+     | Error error -> Raw_trace_degraded error)
+;;
+
+type request =
+  { owner : owner
+  ; execution_id : Execution_id.t
+  ; runtime_id : string
+  ; frozen_system_prompt : string
+  ; frozen_prompt : string
+  ; frozen_input : Yojson.Safe.t
+  ; evidence_budget_bytes : int
+  ; config : Workspace.config
+  ; meta : Keeper_meta_contract.keeper_meta
+  ; publication_recovery :
+      Keeper_publication_recovery_availability.turn_context
+  ; ctx_snapshot : Keeper_types.working_context
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t
+  ; net : Eio_context.eio_net
+  ; continuation_channel : Keeper_continuation_channel.t option
+  ; raw_trace : Agent_sdk.Raw_trace.t option
+  }
+
+type tool_call_result =
+  | Executed of Agent_sdk.Types.tool_result
+  | Rejected_before_execution of string
+
+type tool_call =
+  { invocation : Agent_sdk.Tool_contract.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; started_at : float
+  ; finished_at : float
+  ; duration_ms : float
+  ; result : tool_call_result
+  }
+
+type bounded_evidence =
+  { text : string
+  ; original_bytes : int
+  ; retained_bytes : int
+  ; truncated : bool
+  }
+
+type execution_outcome =
+  | Research_completed of
+      { evidence : bounded_evidence
+      ; session_id : string
+      ; turns : int
+      ; stop_reason : Runtime_agent.stop_reason
+      }
+  | Research_failed of Agent_sdk.Error.sdk_error
+
+type cleanup_outcome =
+  | Cleanup_succeeded
+  | Cleanup_failed of string
+
+type receipt =
+  { owner : owner
+  ; execution_id : Execution_id.t
+  ; runtime_id : string
+  ; frozen_system_prompt : string
+  ; frozen_prompt : string
+  ; frozen_input : Yojson.Safe.t
+  ; started_at : float
+  ; finished_at : float
+  ; duration_ms : float
+  ; tool_names : string list
+  ; tool_calls : tool_call list
+  ; terminal_effect : Keeper_tools_oas.terminal_effect_state
+  ; cleanup : cleanup_outcome
+  ; outcome : execution_outcome
+  ; trace_ref : Agent_sdk.Raw_trace.run_ref option
+  }
+
+let owner_label = function
+  | Librarian -> "librarian"
+  | Hitl_auto_judge -> "hitl_auto_judge"
+  | Board_attention -> "board_attention"
+  | Compaction -> "compaction"
+  | Completion_authority -> "completion_authority"
+;;
+
+let execution_mode_label = function
+  | Agent_sdk.Tool_contract.Concurrent -> "concurrent"
+  | Agent_sdk.Tool_contract.Serial -> "serial"
+;;
+
+let completion_to_yojson = function
+  | Agent_sdk.Tool_contract.Continue_after_success ->
+    `Assoc [ "kind", `String "continue_after_success" ]
+  | Agent_sdk.Tool_contract.Terminal_after_success disposition ->
+    `Assoc
+      [ "kind", `String "terminal_after_success"
+      ; ( "failure_effect_disposition"
+        , `String
+            (Agent_sdk.Tool_contract.show_failure_effect_disposition disposition) )
+      ]
+;;
+
+let invocation_to_yojson invocation =
+  let schedule = Agent_sdk.Tool_contract.Invocation.schedule invocation in
+  `Assoc
+    [ "tool_use_id"
+    , `String (Agent_sdk.Tool_contract.Invocation.tool_use_id invocation)
+    ; "turn", `Int (Agent_sdk.Tool_contract.Invocation.turn invocation)
+    ; "planned_index", `Int schedule.planned_index
+    ; "batch_index", `Int schedule.batch_index
+    ; "batch_size", `Int schedule.batch_size
+    ; "execution_mode", `String (execution_mode_label schedule.execution_mode)
+    ; ( "completion"
+      , completion_to_yojson
+          (Agent_sdk.Tool_contract.Invocation.completion invocation) )
+    ]
+;;
+
+let tool_error_class_to_yojson = function
+  | None -> `Null
+  | Some value -> `String (Agent_sdk.Types.show_tool_error_class value)
+;;
+
+let tool_call_result_to_yojson = function
+  | Executed (Ok { content; _meta }) ->
+    `Assoc
+      [ "kind", `String "executed"
+      ; "outcome", `String "succeeded"
+      ; "content", `String content
+      ; "metadata", Option.value ~default:`Null _meta
+      ]
+  | Executed (Error { message; recoverable; error_class }) ->
+    `Assoc
+      [ "kind", `String "executed"
+      ; "outcome", `String "failed"
+      ; "message", `String message
+      ; "recoverable", `Bool recoverable
+      ; "error_class", tool_error_class_to_yojson error_class
+      ]
+  | Rejected_before_execution detail ->
+    `Assoc
+      [ "kind", `String "rejected_before_execution"
+      ; "detail", `String detail
+      ]
+;;
+
+let tool_call_to_yojson call =
+  `Assoc
+    [ "invocation", invocation_to_yojson call.invocation
+    ; "tool_name", `String call.tool_name
+    ; "input", call.input
+    ; "started_at", `Float call.started_at
+    ; "finished_at", `Float call.finished_at
+    ; "duration_ms", `Float call.duration_ms
+    ; "result", tool_call_result_to_yojson call.result
+    ]
+;;
+
+let runtime_stop_reason_to_yojson = function
+  | Runtime_agent.Completed -> `Assoc [ "kind", `String "completed" ]
+  | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
+    `Assoc
+      [ "kind", `String "yielded_to_chat_waiting"
+      ; "turns_used", `Int turns_used
+      ]
+  | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
+    `Assoc
+      [ "kind", `String "yielded_to_durable_stimulus"
+      ; "turns_used", `Int turns_used
+      ]
+  | Runtime_agent.Awaiting_external_effect { turns_used } ->
+    `Assoc
+      [ "kind", `String "awaiting_external_effect"
+      ; "turns_used", `Int turns_used
+      ]
+  | Runtime_agent.Yielded_after_repeated_tool_call
+      { turns_used; tool_name; repeated_count } ->
+    `Assoc
+      [ "kind", `String "yielded_after_repeated_tool_call"
+      ; "turns_used", `Int turns_used
+      ; "tool_name", `String tool_name
+      ; "repeated_count", `Int repeated_count
+      ]
+  | Runtime_agent.InputRequired { turns_used; request } ->
+    `Assoc
+      [ "kind", `String "input_required"
+      ; "turns_used", `Int turns_used
+      ; "request_id", `String request.request_id
+      ]
+;;
+
+let terminal_effect_to_yojson = function
+  | Keeper_tools_oas.Terminal_effect_open ->
+    `Assoc [ "kind", `String "open" ]
+  | Keeper_tools_oas.Deferred_tool_result ->
+    `Assoc [ "kind", `String "deferred_tool_result" ]
+  | Keeper_tools_oas.External_effect_deferred ->
+    `Assoc [ "kind", `String "external_effect_deferred" ]
+  | Keeper_tools_oas.Terminal_effect_completed ->
+    `Assoc [ "kind", `String "completed" ]
+  | Keeper_tools_oas.Terminal_effect_failed
+      { failure_class; effect_disposition; diagnostic } ->
+    `Assoc
+      [ "kind", `String "failed"
+      ; "failure_class", Tool_result.tool_failure_class_to_yojson failure_class
+      ; ( "effect_disposition"
+        , `String
+            (Tool_result.failure_effect_disposition_to_string effect_disposition) )
+      ; "diagnostic", `String diagnostic
+      ]
+;;
+
+let cleanup_to_yojson = function
+  | Cleanup_succeeded -> `Assoc [ "kind", `String "succeeded" ]
+  | Cleanup_failed detail ->
+    `Assoc [ "kind", `String "failed"; "detail", `String detail ]
+;;
+
+let bounded_evidence_to_yojson evidence =
+  `Assoc
+    [ "text", `String evidence.text
+    ; "original_bytes", `Int evidence.original_bytes
+    ; "retained_bytes", `Int evidence.retained_bytes
+    ; "truncated", `Bool evidence.truncated
+    ]
+;;
+
+let execution_outcome_to_yojson = function
+  | Research_completed { evidence; session_id; turns; stop_reason } ->
+    `Assoc
+      [ "kind", `String "completed"
+      ; "evidence", bounded_evidence_to_yojson evidence
+      ; "session_id", `String session_id
+      ; "turns", `Int turns
+      ; "stop_reason", runtime_stop_reason_to_yojson stop_reason
+      ]
+  | Research_failed error ->
+    `Assoc
+      [ "kind", `String "failed"
+      ; "category", `String (Agent_sdk.Error.category_label (Agent_sdk.Error.category error))
+      ; "detail", `String (Agent_sdk.Error.to_string error)
+      ; "retryable", `Bool (Agent_sdk.Error.is_retryable error)
+      ]
+;;
+
+let trace_ref_to_yojson = function
+  | None -> `Null
+  | Some (trace : Agent_sdk.Raw_trace.run_ref) ->
+    `Assoc
+      [ "worker_run_id", `String trace.worker_run_id
+      ; "path", `String trace.path
+      ; "start_seq", `Int trace.start_seq
+      ; "end_seq", `Int trace.end_seq
+      ; "agent_name", `String trace.agent_name
+      ; ( "session_id"
+        , Option.fold ~none:`Null ~some:(fun value -> `String value) trace.session_id )
+      ]
+;;
+
+let receipt_to_yojson receipt =
+  `Assoc
+    [ "owner", `String (owner_label receipt.owner)
+    ; "execution_id", `String (Execution_id.to_string receipt.execution_id)
+    ; "runtime_id", `String receipt.runtime_id
+    ; "frozen_system_prompt", `String receipt.frozen_system_prompt
+    ; "frozen_prompt", `String receipt.frozen_prompt
+    ; "frozen_input", receipt.frozen_input
+    ; "started_at", `Float receipt.started_at
+    ; "finished_at", `Float receipt.finished_at
+    ; "duration_ms", `Float receipt.duration_ms
+    ; "tool_names", Json_util.json_string_list receipt.tool_names
+    ; "tool_calls", `List (List.map tool_call_to_yojson receipt.tool_calls)
+    ; "terminal_effect", terminal_effect_to_yojson receipt.terminal_effect
+    ; "cleanup", cleanup_to_yojson receipt.cleanup
+    ; "outcome", execution_outcome_to_yojson receipt.outcome
+    ; "trace_ref", trace_ref_to_yojson receipt.trace_ref
+    ]
+;;
+
+let finalizer_evidence_to_yojson receipt =
+  let outcome =
+    match receipt.outcome with
+    | Research_completed { evidence; session_id = _; turns; stop_reason } ->
+      `Assoc
+        [ "kind", `String "completed"
+        ; "evidence", bounded_evidence_to_yojson evidence
+        ; "turns", `Int turns
+        ; "stop_reason", runtime_stop_reason_to_yojson stop_reason
+        ]
+    | Research_failed error -> execution_outcome_to_yojson (Research_failed error)
+  in
+  `Assoc
+    [ "owner", `String (owner_label receipt.owner)
+    ; "execution_id", `String (Execution_id.to_string receipt.execution_id)
+    ; "runtime_id", `String receipt.runtime_id
+    ; "started_at", `Float receipt.started_at
+    ; "finished_at", `Float receipt.finished_at
+    ; "duration_ms", `Float receipt.duration_ms
+    ; "tool_calls"
+    , `List
+        (List.map
+           (fun call ->
+              `Assoc
+                [ "invocation", invocation_to_yojson call.invocation
+                ; "tool_name", `String call.tool_name
+                ; "started_at", `Float call.started_at
+                ; "finished_at", `Float call.finished_at
+                ])
+           receipt.tool_calls)
+    ; "terminal_effect", terminal_effect_to_yojson receipt.terminal_effect
+    ; "cleanup", cleanup_to_yojson receipt.cleanup
+    ; "outcome", outcome
+    ]
+;;
+
+type observed_call =
+  { ordinal : int
+  ; invocation : Agent_sdk.Tool_contract.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; started_at : float
+  ; mutable terminal : (float * float * tool_call_result) option
+  }
+
+type recorder =
+  { mutex : Eio.Mutex.t
+  ; mutable next_ordinal : int
+  ; mutable calls : observed_call list
+  ; by_tool_use_id : (string, observed_call) Hashtbl.t
+  }
+
+let create_recorder () =
+  { mutex = Eio.Mutex.create ()
+  ; next_ordinal = 0
+  ; calls = []
+  ; by_tool_use_id = Hashtbl.create 16
+  }
+;;
+
+let with_recorder recorder f = Eio_guard.with_mutex recorder.mutex f
+
+let observe_started recorder ~now ~invocation ~tool_name ~input =
+  with_recorder recorder (fun () ->
+    let ordinal = recorder.next_ordinal in
+    recorder.next_ordinal <- ordinal + 1;
+    let call =
+      { ordinal; invocation; tool_name; input; started_at = now; terminal = None }
+    in
+    recorder.calls <- call :: recorder.calls;
+    Hashtbl.replace
+      recorder.by_tool_use_id
+      (Agent_sdk.Tool_contract.Invocation.tool_use_id invocation)
+      call)
+;;
+
+let observe_terminal
+      recorder
+      ~now
+      ~invocation
+      ~tool_name
+      ~input
+      ~duration_ms
+      ~result
+  =
+  with_recorder recorder (fun () ->
+    let tool_use_id = Agent_sdk.Tool_contract.Invocation.tool_use_id invocation in
+    let call =
+      match Hashtbl.find_opt recorder.by_tool_use_id tool_use_id with
+      | Some call -> call
+      | None ->
+        let ordinal = recorder.next_ordinal in
+        recorder.next_ordinal <- ordinal + 1;
+        let call =
+          { ordinal
+          ; invocation
+          ; tool_name
+          ; input
+          ; started_at = now -. (duration_ms /. 1000.0)
+          ; terminal = None
+          }
+        in
+        recorder.calls <- call :: recorder.calls;
+        Hashtbl.replace recorder.by_tool_use_id tool_use_id call;
+        call
+    in
+    match call.terminal with
+    | Some _ -> ()
+    | None -> call.terminal <- Some (now, duration_ms, result))
+;;
+
+let recorder_hooks recorder =
+  let pre_tool_use = function
+    | Agent_sdk.Hooks.PreToolUse { invocation; tool_name; input; _ } ->
+      observe_started recorder ~now:(Time_compat.now ()) ~invocation ~tool_name ~input;
+      Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue
+  in
+  let post_tool_use = function
+    | Agent_sdk.Hooks.PostToolUse
+        { invocation; tool_name; input; output; duration_ms; _ } ->
+      observe_terminal
+        recorder
+        ~now:(Time_compat.now ())
+        ~invocation
+        ~tool_name
+        ~input
+        ~duration_ms
+        ~result:(Executed output);
+      Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue
+  in
+  let post_tool_use_failure = function
+    | Agent_sdk.Hooks.PostToolUseFailure { invocation; tool_name; input; error } ->
+      observe_terminal
+        recorder
+        ~now:(Time_compat.now ())
+        ~invocation
+        ~tool_name
+        ~input
+        ~duration_ms:0.0
+        ~result:(Rejected_before_execution error);
+      Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue
+  in
+  { Agent_sdk.Hooks.empty with
+    pre_tool_use = Some pre_tool_use
+  ; post_tool_use = Some post_tool_use
+  ; post_tool_use_failure = Some post_tool_use_failure
+  }
+;;
+
+let freeze_calls recorder =
+  with_recorder recorder (fun () ->
+    recorder.calls
+    |> List.sort (fun left right -> Int.compare left.ordinal right.ordinal)
+    |> List.map (fun call ->
+      match call.terminal with
+      | Some (finished_at, duration_ms, result) ->
+        { invocation = call.invocation
+        ; tool_name = call.tool_name
+        ; input = call.input
+        ; started_at = call.started_at
+        ; finished_at
+        ; duration_ms
+        ; result
+        }
+      | None ->
+        let finished_at = Time_compat.now () in
+        { invocation = call.invocation
+        ; tool_name = call.tool_name
+        ; input = call.input
+        ; started_at = call.started_at
+        ; finished_at
+        ; duration_ms = (finished_at -. call.started_at) *. 1000.0
+        ; result = Rejected_before_execution "tool invocation did not reach a terminal hook"
+        }))
+;;
+
+let make_bundle (request : request) =
+  let gate_context =
+    Keeper_gate_causal_context.create
+      ~turn_id:None
+      ~initial:
+        (`Assoc
+           [ "internal_research_execution_id"
+           , `String (Execution_id.to_string request.execution_id)
+           ; "owner", `String (owner_label request.owner)
+           ; "frozen_input", request.frozen_input
+           ])
+  in
+  Keeper_tools_oas_bundle.make_tool_bundle
+    ~config:request.config
+    ~meta:request.meta
+    ~publication_recovery:request.publication_recovery
+    ~ctx_snapshot:request.ctx_snapshot
+    ~clock:request.clock
+    ?continuation_channel:request.continuation_channel
+    ~gate_context
+    ()
+;;
+
+let protect_with_cleanup ~cleanup ~on_cleanup body =
+  Eio_guard.protect
+    ~finally:(fun () ->
+      let outcome =
+        try
+          cleanup ();
+          Cleanup_succeeded
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn -> Cleanup_failed (Printexc.to_string exn)
+      in
+      on_cleanup outcome)
+    body
+;;
+
+let bounded_evidence ~max_bytes text =
+  if max_bytes < 0
+  then invalid_arg "internal research evidence budget must be non-negative";
+  let original_bytes = String.length text in
+  let text, truncated = Keeper_text_processing.truncate_utf8_prefix ~max_bytes text in
+  { text
+  ; original_bytes
+  ; retained_bytes = String.length text
+  ; truncated
+  }
+;;
+
+let run (request : request) =
+  let started_at = Time_compat.now () in
+  let bundle = make_bundle request in
+  let recorder = create_recorder () in
+  let hooks = recorder_hooks recorder in
+  let tool_names =
+    List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) bundle.tools
+  in
+  let cleanup_outcome = ref None in
+  let run_result =
+    protect_with_cleanup
+      ~cleanup:bundle.cleanup
+      ~on_cleanup:(fun outcome -> cleanup_outcome := Some outcome)
+      (fun () ->
+         try
+           Keeper_turn_driver.run_named
+             ~runtime_id:request.runtime_id
+             ~keeper_name:request.meta.name
+             ~base_path:request.config.base_path
+             ~goal:request.frozen_prompt
+             ~system_prompt:request.frozen_system_prompt
+             ~tools:bundle.tools
+             ~hooks
+             ?raw_trace:request.raw_trace
+             ~cooperative_yield_probe:(fun _ ->
+               Keeper_tool_terminal_boundary.decision
+                 (bundle.terminal_effect_state ()))
+             ~net:request.net
+             ()
+         with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | exn -> Error (Agent_sdk.Error.Internal (Printexc.to_string exn)))
+  in
+  let cleanup =
+    match !cleanup_outcome with
+    | Some outcome -> outcome
+    | None -> failwith "internal research cleanup invariant violated"
+  in
+  let outcome, trace_ref =
+    match run_result with
+    | Ok result ->
+      let raw_evidence = Agent_sdk.Types.text_of_response result.response in
+      let evidence =
+        bounded_evidence ~max_bytes:request.evidence_budget_bytes raw_evidence
+      in
+      ( Research_completed
+          { evidence
+          ; session_id = result.session_id
+          ; turns = result.turns
+          ; stop_reason = result.stop_reason
+          }
+      , result.trace_ref )
+    | Error error -> Research_failed error, None
+  in
+  let finished_at = Time_compat.now () in
+  { owner = request.owner
+  ; execution_id = request.execution_id
+  ; runtime_id = request.runtime_id
+  ; frozen_system_prompt = request.frozen_system_prompt
+  ; frozen_prompt = request.frozen_prompt
+  ; frozen_input = request.frozen_input
+  ; started_at
+  ; finished_at
+  ; duration_ms = max 0.0 ((finished_at -. started_at) *. 1000.0)
+  ; tool_names
+  ; tool_calls = freeze_calls recorder
+  ; terminal_effect = bundle.terminal_effect_state ()
+  ; cleanup
+  ; outcome
+  ; trace_ref
+  }
+;;
+
+module For_testing = struct
+  let protect_with_cleanup = protect_with_cleanup
+
+  let tool_names_for_request request =
+    let bundle = make_bundle request in
+    let names =
+      List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) bundle.tools
+    in
+    let cleanup = ref None in
+    protect_with_cleanup
+      ~cleanup:bundle.cleanup
+      ~on_cleanup:(fun outcome -> cleanup := Some outcome)
+      (fun () -> ());
+    match !cleanup with
+    | Some outcome -> names, outcome
+    | None -> failwith "internal research cleanup invariant violated"
+  ;;
+end

--- a/lib/keeper/keeper_internal_research.mli
+++ b/lib/keeper/keeper_internal_research.mli
@@ -1,0 +1,124 @@
+(** Tool-capable research phase shared by internal exact-output roles.
+
+    Research receives the complete Keeper model-visible tool bundle. Its typed
+    receipt is evidence for a later tool-free exact finalizer; it is never a
+    replacement finalization authority. *)
+
+type owner =
+  | Librarian
+  | Hitl_auto_judge
+  | Board_attention
+  | Compaction
+  | Completion_authority
+
+module Execution_id : sig
+  type t
+
+  val generate : unit -> t
+  val to_string : t -> string
+end
+
+type raw_trace_sink_outcome =
+  | Raw_trace_ready of Agent_sdk.Raw_trace.t
+  | Raw_trace_degraded of Agent_sdk.Error.sdk_error
+
+(** Create a fresh retained-trace candidate for one internal research phase.
+    The caller registers [Agent_sdk.Raw_trace.file_path] as a durable reachability
+    root before dispatch. Sink failure is observable but does not block the
+    internal agent. *)
+val create_raw_trace_sink
+  :  before_create:(string -> unit)
+  -> config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> execution_id:Execution_id.t
+  -> raw_trace_sink_outcome
+
+type request =
+  { owner : owner
+  ; execution_id : Execution_id.t
+  ; runtime_id : string
+  ; frozen_system_prompt : string
+  ; frozen_prompt : string
+  ; frozen_input : Yojson.Safe.t
+  ; evidence_budget_bytes : int
+  ; config : Workspace.config
+  ; meta : Keeper_meta_contract.keeper_meta
+  ; publication_recovery :
+      Keeper_publication_recovery_availability.turn_context
+  ; ctx_snapshot : Keeper_types.working_context
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t
+  ; net : Eio_context.eio_net
+  ; continuation_channel : Keeper_continuation_channel.t option
+  ; raw_trace : Agent_sdk.Raw_trace.t option
+  }
+
+type tool_call_result =
+  | Executed of Agent_sdk.Types.tool_result
+  | Rejected_before_execution of string
+
+type tool_call =
+  { invocation : Agent_sdk.Tool_contract.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; started_at : float
+  ; finished_at : float
+  ; duration_ms : float
+  ; result : tool_call_result
+  }
+
+type bounded_evidence =
+  { text : string
+  ; original_bytes : int
+  ; retained_bytes : int
+  ; truncated : bool
+  }
+
+type execution_outcome =
+  | Research_completed of
+      { evidence : bounded_evidence
+      ; session_id : string
+      ; turns : int
+      ; stop_reason : Runtime_agent.stop_reason
+      }
+  | Research_failed of Agent_sdk.Error.sdk_error
+
+type cleanup_outcome =
+  | Cleanup_succeeded
+  | Cleanup_failed of string
+
+type receipt =
+  { owner : owner
+  ; execution_id : Execution_id.t
+  ; runtime_id : string
+  ; frozen_system_prompt : string
+  ; frozen_prompt : string
+  ; frozen_input : Yojson.Safe.t
+  ; started_at : float
+  ; finished_at : float
+  ; duration_ms : float
+  ; tool_names : string list
+  ; tool_calls : tool_call list
+  ; terminal_effect : Keeper_tools_oas.terminal_effect_state
+  ; cleanup : cleanup_outcome
+  ; outcome : execution_outcome
+  ; trace_ref : Agent_sdk.Raw_trace.run_ref option
+  }
+
+val run : request -> receipt
+
+(** Full receipt for durable/raw observation. Exact inputs and tool results are
+    retained here; the finalizer projection below is deliberately bounded. *)
+val receipt_to_yojson : receipt -> Yojson.Safe.t
+
+(** Bounded evidence projection consumed by the later exact-output phase. *)
+val finalizer_evidence_to_yojson : receipt -> Yojson.Safe.t
+
+module For_testing : sig
+  val protect_with_cleanup
+    :  cleanup:(unit -> unit)
+    -> on_cleanup:(cleanup_outcome -> unit)
+    -> (unit -> 'a)
+    -> 'a
+
+  val tool_names_for_request : request -> string list * cleanup_outcome
+end

--- a/lib/keeper/keeper_tool_terminal_boundary.ml
+++ b/lib/keeper/keeper_tool_terminal_boundary.ml
@@ -1,0 +1,15 @@
+let decision = function
+  | Keeper_tools_oas.Terminal_effect_open -> Ok Runtime_agent.Continue
+  | Keeper_tools_oas.Deferred_tool_result ->
+    Ok (Runtime_agent.Yield Runtime_agent.Durable_stimulus_waiting)
+  | Keeper_tools_oas.External_effect_deferred ->
+    Ok (Runtime_agent.Yield Runtime_agent.External_effect_deferred)
+  | Keeper_tools_oas.Terminal_effect_completed ->
+    Ok (Runtime_agent.Yield Runtime_agent.Terminal_tool_completed)
+  | Keeper_tools_oas.Terminal_effect_failed
+      { failure_class; effect_disposition; diagnostic } ->
+    Error
+      (Keeper_internal_error.sdk_error_of_masc_internal_error
+         (Keeper_internal_error.Terminal_effect_failed
+            { failure_class; effect_disposition; diagnostic }))
+;;

--- a/lib/keeper/keeper_tool_terminal_boundary.mli
+++ b/lib/keeper/keeper_tool_terminal_boundary.mli
@@ -1,0 +1,6 @@
+(** Typed projection from a Keeper tool bundle's terminal-effect state to the
+    Agent Core cooperative-yield boundary. *)
+
+val decision
+  :  Keeper_tools_oas.terminal_effect_state
+  -> (Runtime_agent.cooperative_yield_decision, Agent_sdk.Error.sdk_error) result

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -205,6 +205,151 @@ let test_bundle_exactly_matches_model_visible_descriptors () =
           check int "bundle contains no duplicate model names" (List.length actual_names)
             (List.length bundle.tools)))
 
+let test_internal_research_bundle_exactly_matches_model_visible_descriptors () =
+  ignore (init_registry ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_test_internal_research_bundle_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      try Unix.rmdir dir with
+      | _ -> ())
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Eio.Switch.run
+       @@ fun sw ->
+       let config = Workspace.default_config dir in
+       let meta = make_meta ~name:"test-internal-research-bundle" () in
+       let ctx_snapshot =
+         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
+       in
+       Masc_test_deps.with_publication_recovery_registry
+         ~sw
+         ~fs:(Eio.Stdenv.fs env)
+         ~registry_root:dir
+       @@ fun publication_recovery_registry ->
+       let publication_recovery =
+         publication_recovery_turn_context
+           ~registry:publication_recovery_registry
+           ~keeper_name:meta.name
+       in
+       let request : Keeper_internal_research.request =
+         { owner = Librarian
+         ; execution_id = Keeper_internal_research.Execution_id.generate ()
+         ; runtime_id = "test-runtime"
+         ; frozen_system_prompt = "test"
+         ; frozen_prompt = "test"
+         ; frozen_input = `Assoc [ "test", `Bool true ]
+         ; evidence_budget_bytes = 1024
+         ; config
+         ; meta
+         ; publication_recovery
+         ; ctx_snapshot
+         ; clock = Eio.Stdenv.clock env
+         ; net = Eio.Stdenv.net env
+         ; continuation_channel = None
+         ; raw_trace = None
+         }
+       in
+       let actual_names, cleanup =
+         Keeper_internal_research.For_testing.tool_names_for_request request
+       in
+       let expected_names =
+         Keeper_tool_descriptor.model_visible_descriptors ()
+         |> List.concat_map Keeper_tool_descriptor.keeper_model_names
+         |> List.sort_uniq String.compare
+       in
+       check
+         (list string)
+         "research runner receives the complete descriptor projection"
+         expected_names
+         (List.sort_uniq String.compare actual_names);
+       check int
+         "research runner bundle contains no duplicates"
+         (List.length expected_names)
+         (List.length actual_names);
+       match cleanup with
+       | Keeper_internal_research.Cleanup_succeeded -> ()
+       | Cleanup_failed detail -> failf "research bundle cleanup failed: %s" detail)
+;;
+
+let test_internal_research_cleanup_contract () =
+  let first_execution_id =
+    Keeper_internal_research.Execution_id.generate ()
+    |> Keeper_internal_research.Execution_id.to_string
+  in
+  let second_execution_id =
+    Keeper_internal_research.Execution_id.generate ()
+    |> Keeper_internal_research.Execution_id.to_string
+  in
+  check bool
+    "generated research execution id names its phase"
+    true
+    (String.starts_with ~prefix:"internal-research-" first_execution_id);
+  check bool
+    "generated research execution ids are distinct"
+    false
+    (String.equal first_execution_id second_execution_id);
+  let cleanup_count = ref 0 in
+  let observed = ref None in
+  let value =
+    Keeper_internal_research.For_testing.protect_with_cleanup
+      ~cleanup:(fun () -> incr cleanup_count)
+      ~on_cleanup:(fun outcome -> observed := Some outcome)
+      (fun () -> 42)
+  in
+  check int "success body result" 42 value;
+  check int "success cleanup exactly once" 1 !cleanup_count;
+  (match !observed with
+   | Some Keeper_internal_research.Cleanup_succeeded -> ()
+   | _ -> fail "successful cleanup outcome was not recorded");
+  let raised = ref false in
+  (try
+     ignore
+       (Keeper_internal_research.For_testing.protect_with_cleanup
+          ~cleanup:(fun () -> incr cleanup_count)
+          ~on_cleanup:(fun outcome -> observed := Some outcome)
+          (fun () -> raise (Failure "research failed"))
+        : unit)
+   with
+   | Failure detail when String.equal detail "research failed" -> raised := true
+   | _ -> ());
+  check bool "body failure propagated" true !raised;
+  check int "failure cleanup exactly once" 2 !cleanup_count;
+  let cancelled = ref false in
+  (try
+     ignore
+       (Keeper_internal_research.For_testing.protect_with_cleanup
+          ~cleanup:(fun () -> incr cleanup_count)
+          ~on_cleanup:(fun outcome -> observed := Some outcome)
+          (fun () -> raise (Eio.Cancel.Cancelled (Failure "cancel research")))
+        : unit)
+   with
+   | Eio.Cancel.Cancelled _ -> cancelled := true);
+  check bool "cancellation propagated" true !cancelled;
+  check int "cancellation cleanup exactly once" 3 !cleanup_count;
+  let cleanup_failure = ref None in
+  let value =
+    Keeper_internal_research.For_testing.protect_with_cleanup
+      ~cleanup:(fun () -> raise (Failure "cleanup failed"))
+      ~on_cleanup:(fun outcome -> cleanup_failure := Some outcome)
+      (fun () -> 7)
+  in
+  check int "cleanup failure does not replace body result" 7 value;
+  match !cleanup_failure with
+  | Some (Keeper_internal_research.Cleanup_failed detail) ->
+    check bool
+      "cleanup failure detail retained"
+      true
+      (string_contains detail "cleanup failed")
+  | _ -> fail "cleanup failure outcome was not recorded"
+;;
+
 let test_missing_current_task_reconciled_before_transition_hint () =
   ignore (init_registry ());
   let dir =
@@ -436,6 +581,10 @@ let () =
             test_fusion_default_descriptor_is_bundle_visible;
           test_case "bundle exactly matches model-visible descriptors" `Quick
             test_bundle_exactly_matches_model_visible_descriptors;
+          test_case "internal research bundle matches model-visible descriptors" `Quick
+            test_internal_research_bundle_exactly_matches_model_visible_descriptors;
+          test_case "internal research cleanup covers success error cancellation" `Quick
+            test_internal_research_cleanup_contract;
           test_case "missing current task reconciles before transition hint" `Quick
             test_missing_current_task_reconciled_before_transition_hint;
           test_case "bundle assembly does not emit assignment" `Quick


### PR DESCRIPTION
## Summary

- add a typed research phase for Librarian, HITL auto-judge, Board attention, compaction, and Completion Authority
- assemble the complete Keeper model-visible tool bundle through the canonical OAS bundle owner
- retain frozen prompts/input, wall-clock execution timing, ordered exact tool inputs/results/timestamps, terminal effect, cleanup outcome, bounded finalizer evidence, and raw-trace reference in one generated execution receipt
- provide a pre-create trace callback so consumers can durably register reachability before any asynchronous trace file exists
- share Keeper terminal-effect projection with the ordinary Keeper run path; exact-output finalizers remain tool-free

## Scope

This PR establishes the common research/receipt boundary. Consumer wiring is separate; Librarian is implemented in child PR #27737.

Stacked on #27730 → #27726.

## Validation

Current stack head `bc00895af19bc4f11a1097bd9660721d9ce0949a`:

- focused downstream server build — PASS
- `test_warn_root_causes.exe` — 11/11 PASS, including full descriptor projection, duplicate rejection, generated execution IDs, and cleanup on success/error/cancellation
- `ocamlformat --check` on all changed OCaml files — PASS
- `scripts/audit-keeper-tool-boundary-matrix.sh` — PASS, 117/117 scoped files covered
- `scripts/ocaml-structure-ratchet.sh` — PASS
- `git diff --check` — PASS
- GitHub Actions reran after the parent-only test amendment; current completion is reported by the checks, not assumed here

## Contract

- Exact-output runtimes still reject tool use by design.
- Tool-capable research emits a typed receipt.
- A later tool-free finalizer consumes only the bounded evidence projection.
- Correlation uses a generated `internal-research-*` execution ID; no name/time/string inference.

Relates #27658