### PR TITLE
fix: restore canonical build boundaries

### DIFF
--- a/lib/keeper_approval/audit.ml
+++ b/lib/keeper_approval/audit.ml
@@ -399,7 +399,7 @@ let audit_scan_window ?keeper_name n =
 
 let record_audit_read_failure ?keeper_name ?(metric_site = Keeper_approval_queue_failure_site.Audit_read_recent) ~site exn =
   Keeper_fd_pressure.note_exception ~site exn;
-  Otel_metric_store.inc_counter
+  Otel_metric_store_core.inc_counter
     Keeper_metrics.(to_string ApprovalQueueFailures)
     ~labels:
       [ "keeper",

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -514,10 +514,14 @@ let dashboard_gate_rule_delete_http_json ~base_path ~(args : Yojson.Safe.t)
   | Some id ->
     (match Keeper_approval_queue.delete_rule ~base_path ~id () with
      | Ok deleted ->
-         Keeper_approval.Audit.record_rule
+         Keeper_approval.Audit.record
            ~base_path
            ~event_type:Keeper_approval.Audit.Rule_deleted
-           deleted;
+           ~id:deleted.id
+           ~keeper_name:deleted.keeper_name
+           ~tool_name:deleted.tool_name
+           ?source_approval_id:deleted.source_approval_id
+           ();
          Ok (`Assoc [ "ok", `Bool true; "id", `String deleted.id ])
        | Error error ->
          Error (Keeper_approval_queue.rule_store_error_to_string error))

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -167,7 +167,7 @@ let () =
               let received_args = ref `Null in
               let capture_handler ~name:_ ~args =
                 received_args := args;
-                Some (tool_ok "captured")
+                tool_ok "captured"
               in
               register_full
                 ~tool_name:tool


### PR DESCRIPTION
## Summary
- call the canonical metric store core from the approval audit sublibrary
- cross the dashboard approval-rule boundary through the audit field API instead of record-type aliasing
- update the dispatch test handler to the total `Tool_dispatch.handler` contract

## Scope
This repairs the three compile errors currently present on `main`. It does not restore removed facades, option fallbacks, or legacy type aliases. Prompt behavior and documented operator contracts are unchanged, so no prompt or prose documentation is modified.

## Validation
- local build/tests not run; GitHub CI is authoritative