### PR TITLE
feat(dashboard): configure Codex subscription runtime

### DIFF
--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -16,6 +16,7 @@ import {
 } from '../lib/runtime-provider-summary'
 import {
   isRuntimeTomlNonMaterializableProtocol,
+  isRuntimeTomlOfficialClientProtocol,
   isReservedRuntimeTomlId,
   isValidRuntimeTomlIdFormat,
   parseRuntimeTomlEnvironment,
@@ -46,19 +47,18 @@ export type RuntimeProviderTransportEditableField = 'endpoint' | 'command'
 // ...) are deliberately excluded — those are semantically coupled to real,
 // per-model verified behavior (see runtime.toml's own inline caveats), not
 // something a generic add form can default safely. They stay raw-TOML-only.
-// transportKind is fixed to 'endpoint': CLI (`command`) transport providers
-// resolve to no provider_kind on the backend today and get silently dropped
-// from the live runtime list rather than failing the save (see
-// RUNTIME_TOML_CREATABLE_PROTOCOLS in lib/runtime-toml-config.ts). Until that
-// backend limitation is lifted, this form cannot offer command transport.
+// Generic providers use endpoint transport. A typed official-client protocol
+// may require command transport; that exception is selected by protocol and
+// never exposed as a free-form transport switch.
 export interface NewRuntimeProviderInput {
   id: string
   displayName: string
   protocol: RuntimeTomlProtocol
-  transportKind: 'endpoint'
+  transportKind: 'endpoint' | 'command'
   transportValue: string
   credentialType: RuntimeTomlCredentialType
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 export interface NewRuntimeModelInput {
@@ -127,10 +127,11 @@ interface NewProviderDraft {
   id: string
   displayName: string
   protocol: RuntimeTomlProtocol
-  transportKind: 'endpoint'
+  transportKind: 'endpoint' | 'command'
   transportValue: string
   credentialType: RuntimeTomlCredentialType
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 const DEFAULT_NEW_PROVIDER: NewProviderDraft = {
@@ -141,6 +142,7 @@ const DEFAULT_NEW_PROVIDER: NewProviderDraft = {
   transportValue: '',
   credentialType: 'env',
   credentialValue: '',
+  isNonInteractive: false,
 }
 
 // jsonSupport as a 3-way string enum (not boolean|null) because <select> values
@@ -376,7 +378,12 @@ export function RuntimeEnvironmentEditor({
     }
     const transportValue = newProvider.transportValue.trim()
     if (transportValue === '') {
-      setProviderFormError('endpoint를 입력하세요')
+      setProviderFormError(`${newProvider.transportKind}를 입력하세요`)
+      return
+    }
+    const officialClient = isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
+    if (officialClient && (newProvider.transportKind !== 'command' || newProvider.credentialType !== 'none' || !newProvider.isNonInteractive)) {
+      setProviderFormError('공식 구독 클라이언트는 command + credential 없음 + non-interactive=true가 필요합니다')
       return
     }
     const trimmedCredentialValue = newProvider.credentialValue.trim()
@@ -454,13 +461,11 @@ export function RuntimeEnvironmentEditor({
       setBindingFormError(`"${bindingProviderId}"는 예약된 이름이라 바인딩 provider로 쓸 수 없습니다`)
       return
     }
-    // A `command` transport provider always resolves to no provider_kind on the
-    // backend, so materialize_config's filter_map silently drops any binding
-    // pinned to it from the live runtime list. The add-provider form can no
-    // longer create one, but this dropdown lists every parsed provider,
-    // including a `command` one that already exists via raw TOML / legacy config.
+    // Generic command transports are not materializable. Official-client
+    // protocols are the typed exception: their backend runtime owns the CLI
+    // process and does not impersonate an OAS HTTP provider.
     const selectedProvider = environment.providers.find(p => p.id === bindingProviderId)
-    if (selectedProvider?.transportKind === 'command') {
+    if (selectedProvider?.transportKind === 'command' && !isRuntimeTomlOfficialClientProtocol(selectedProvider.protocol)) {
       setBindingFormError(
         `"${bindingProviderId}"는 command(CLI) transport라 바인딩을 생성할 수 없습니다 (백엔드가 아직 CLI provider를 라우팅하지 못합니다)`,
       )
@@ -641,12 +646,14 @@ export function RuntimeEnvironmentEditor({
           ` : null}
           ${environment.providers.map(provider => {
             const providerTransportField = transportField(provider)
+            const officialClient = isRuntimeTomlOfficialClientProtocol(provider.protocol)
             return html`
             <div key=${provider.id} class="rt-card" data-testid=${`runtime-provider-${provider.id}`}>
               <div class="rt-card-h">
                 <span class="rt-card-id mono">${provider.id}</span>
                 <span class="rt-card-name">${provider.displayName}</span>
                 <span class="rt-proto mono">${provider.protocol || '—'}</span>
+                ${officialClient ? html`<span class="rt-assign-tag pin mono">구독 CLI</span>` : null}
                 <button
                   type="button"
                   class="rt-delete-provider"
@@ -699,6 +706,15 @@ export function RuntimeEnvironmentEditor({
                   </span>
                   `}
               </div>
+              ${officialClient ? html`
+                <div class="rt-field" data-testid=${`runtime-provider-${provider.id}-subscription-boundary`}>
+                  <span class="sub-k">execution</span>
+                  <span class="mono">official client · ${provider.isNonInteractive ? 'non-interactive' : '설정 오류: interactive'}</span>
+                </div>
+                ${provider.credentialType !== 'none' ? html`
+                  <div class="rt-warn" role="alert">공식 구독 클라이언트에는 API credential을 선언할 수 없습니다.</div>
+                ` : null}
+              ` : null}
               ${/* Provider capability chips (mcp-tools/tool-events/mcp-http-headers)
                    had no live source and rendered as if confirmed. Removed until a
                    provider-capability source exists, rather than implying support
@@ -747,29 +763,45 @@ export function RuntimeEnvironmentEditor({
                     value=${newProvider.protocol}
                     disabled=${isDisabled}
                     aria-label="새 provider protocol"
-                    onChange=${(event: Event) => setNewProvider({ ...newProvider, protocol: (event.currentTarget as HTMLSelectElement).value as RuntimeTomlProtocol })}
+                    onChange=${(event: Event) => {
+                      const protocol = (event.currentTarget as HTMLSelectElement).value as RuntimeTomlProtocol
+                      const officialClient = isRuntimeTomlOfficialClientProtocol(protocol)
+                      setNewProvider({
+                        ...newProvider,
+                        protocol,
+                        transportKind: officialClient ? 'command' : 'endpoint',
+                        transportValue: '',
+                        credentialType: officialClient ? 'none' : 'env',
+                        credentialValue: '',
+                        isNonInteractive: officialClient,
+                      })
+                    }}
                   >
                     ${RUNTIME_TOML_CREATABLE_PROTOCOLS.map(p => html`<option value=${p}>${p}</option>`)}
                   </select>
                 </div>
                 <div class="rt-field">
-                  <span class="sub-k">endpoint</span>
+                  <span class="sub-k">${newProvider.transportKind}</span>
                   <input
                     class="rt-input mono"
                     value=${newProvider.transportValue}
-                    placeholder="https://..."
+                    placeholder=${newProvider.transportKind === 'command' ? '/absolute/path/to/codex' : 'https://...'}
                     disabled=${isDisabled}
                     aria-label="새 provider transport 값"
                     onInput=${(event: Event) => setNewProvider({ ...newProvider, transportValue: (event.currentTarget as HTMLInputElement).value })}
                   />
                 </div>
-                <div class="rt-note">CLI(command) provider는 현재 백엔드에서 라우팅되지 않아 이 폼에서 생성할 수 없습니다. raw TOML 탭을 이용하세요.</div>
+                <div class="rt-note">
+                  ${isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
+                    ? '공식 클라이언트의 기존 구독 로그인을 사용합니다. API key는 저장하지 않으며 non-interactive 실행을 강제합니다.'
+                    : '일반 provider는 endpoint transport를 사용합니다.'}
+                </div>
                 <div class="rt-field">
                   <span class="sub-k">credential</span>
                   <select
                     class="rt-select rt-select-narrow"
                     value=${newProvider.credentialType}
-                    disabled=${isDisabled}
+                    disabled=${isDisabled || isRuntimeTomlOfficialClientProtocol(newProvider.protocol)}
                     aria-label="새 provider credential 종류"
                     onChange=${(event: Event) => setNewProvider({ ...newProvider, credentialType: (event.currentTarget as HTMLSelectElement).value as RuntimeTomlCredentialType })}
                   >

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -870,7 +870,7 @@ describe('RuntimeTomlEditor', () => {
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
   })
 
-  it('does not offer messages protocols or command transport in the add-provider form', async () => {
+  it('offers only materializable HTTP protocols plus the typed Codex official client', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)
 
@@ -883,11 +883,67 @@ describe('RuntimeTomlEditor', () => {
     const protocolOptions = Array.from(
       container.querySelectorAll('[aria-label="새 provider protocol"] option'),
     ).map(option => (option as HTMLOptionElement).value)
-    expect(protocolOptions).toEqual(['openai-compatible-http', 'ollama-http', 'openai-compatible-cli'])
+    expect(protocolOptions).toEqual([
+      'openai-compatible-http',
+      'ollama-http',
+      'openai-compatible-cli',
+      'codex-app-server',
+    ])
     expect(protocolOptions).not.toContain('messages-http')
     expect(protocolOptions).not.toContain('messages-cli')
     // No transport-kind selector left to switch to 'command'.
     expect(container.querySelector('[aria-label="새 provider transport 종류"]')).toBeNull()
+  })
+
+  it('creates a Codex subscription provider and binding with the enforced no-key boundary', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-providers"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-providers"]') as HTMLButtonElement)
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-toggle"]') as HTMLButtonElement)
+    fireEvent.input(container.querySelector('[data-testid="runtime-add-provider-id"]') as HTMLInputElement, {
+      target: { value: 'codex_subscription' },
+    })
+    fireEvent.change(container.querySelector('[aria-label="새 provider protocol"]') as HTMLSelectElement, {
+      target: { value: 'codex-app-server' },
+    })
+
+    const credentialType = container.querySelector('[aria-label="새 provider credential 종류"]') as HTMLSelectElement
+    expect(credentialType.value).toBe('none')
+    expect(credentialType.disabled).toBe(true)
+    expect(container.querySelector('[aria-label="새 provider credential 값"]')).toBeNull()
+
+    fireEvent.input(container.querySelector('[aria-label="새 provider transport 값"]') as HTMLInputElement, {
+      target: { value: '/Users/dancer/.local/bin/codex' },
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('[providers.codex_subscription]')
+      expect(source).toContain('protocol = "codex-app-server"')
+      expect(source).toContain('command = "/Users/dancer/.local/bin/codex"')
+      expect(source).toContain('is-non-interactive = true')
+      expect(source).not.toContain('[providers.codex_subscription.credentials]')
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-bindings"]') as HTMLButtonElement)
+    fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-provider"]') as HTMLSelectElement, {
+      target: { value: 'codex_subscription' },
+    })
+    fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-model"]') as HTMLSelectElement, {
+      target: { value: 'qwen' },
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-binding-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('[codex_subscription.qwen]')
+      expect(container.querySelector('[data-testid="runtime-add-binding-error"]')).toBeNull()
+    })
   })
 
   it('adds a new model through the form', async () => {

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -310,6 +310,9 @@ export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps =
       let next = setRuntimeTomlProviderField(current, input.id, 'display-name', input.displayName || input.id)
       next = setRuntimeTomlProviderField(next, input.id, 'protocol', input.protocol)
       next = setRuntimeTomlProviderField(next, input.id, input.transportKind, input.transportValue)
+      if (input.isNonInteractive) {
+        next = setRuntimeTomlProviderField(next, input.id, 'is-non-interactive', true)
+      }
       if (input.credentialType !== 'none' && input.credentialValue.trim() !== '') {
         next = setRuntimeTomlProviderCredential(next, input.id, input.credentialType, input.credentialValue)
       }

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -74,6 +74,33 @@ describe('runtime TOML dashboard editing helpers', () => {
     })
   })
 
+  it('projects the Codex official-client subscription boundary without credentials', () => {
+    const codexSource = `[runtime]
+default = "codex_subscription.spark"
+
+[providers.codex_subscription]
+display-name = "Codex Subscription"
+protocol = "codex-app-server"
+command = "/usr/local/bin/codex"
+is-non-interactive = true
+
+[models.spark]
+api-name = "gpt-5.3-codex-spark"
+max-context = 131072
+
+[codex_subscription.spark]
+`
+
+    const environment = parseRuntimeTomlEnvironment(codexSource)
+    expect(environment.providers[0]).toMatchObject({
+      protocol: 'codex-app-server',
+      transportKind: 'command',
+      command: '/usr/local/bin/codex',
+      credentialType: 'none',
+      isNonInteractive: true,
+    })
+  })
+
   it('projects runtime routing lanes and keeper assignments from runtime.toml source', () => {
     const withRouting = `${sourceText.replace(
       'default = "runpod_mtp.qwen"',

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -12,6 +12,7 @@ export interface RuntimeTomlProvider {
   credentialKey: string
   credentialPath: string
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 export interface RuntimeTomlModel {
@@ -289,6 +290,7 @@ function providerFromDocument(document: TomlDocument, id: string): RuntimeTomlPr
     credentialKey: asString(credentials.key),
     credentialPath: asString(credentials.path),
     credentialValue: asString(credentials.value),
+    isNonInteractive: asBoolean(values['is-non-interactive']),
   }
 }
 
@@ -639,8 +641,8 @@ export function setRuntimeTomlDefault(sourceText: string, runtimeId: string): st
 export function setRuntimeTomlProviderField(
   sourceText: string,
   providerId: string,
-  field: 'display-name' | 'protocol' | 'endpoint' | 'command',
-  value: string,
+  field: 'display-name' | 'protocol' | 'endpoint' | 'command' | 'is-non-interactive',
+  value: string | boolean,
 ): string {
   const section = `providers.${providerId}`
   if (field === 'endpoint') {
@@ -722,14 +724,16 @@ export const RUNTIME_TOML_PROTOCOLS = [
   'openai-compatible-cli',
   'messages-http',
   'messages-cli',
+  'codex-app-server',
 ] as const
 
 export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
 
 // Subset of RUNTIME_TOML_PROTOCOLS the add-provider form is allowed to offer.
-// The add-provider form only creates endpoint-backed providers. Command
-// transport is blocked at the binding form via transportKind, while
-// `provider_kind_for_http_provider` still returns `None` for `Messages_api`.
+// HTTP protocols create endpoint-backed providers. A typed official-client
+// protocol creates the command-backed runtime its backend adapter owns, while
+// generic command providers remain blocked. `provider_kind_for_http_provider`
+// still returns `None` for `Messages_api`.
 // Messages providers parse and save, but resolve to no provider_kind and
 // `Runtime.materialize_config`'s `List.filter_map` silently drops their bindings
 // from the live runtime list instead of failing the save
@@ -740,12 +744,17 @@ export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
   'openai-compatible-http',
   'ollama-http',
   'openai-compatible-cli',
+  'codex-app-server',
 ] as const
 
 export type RuntimeTomlCreatableProtocol = (typeof RUNTIME_TOML_CREATABLE_PROTOCOLS)[number]
 
 export function isRuntimeTomlCreatableProtocol(protocol: string): protocol is RuntimeTomlCreatableProtocol {
   return (RUNTIME_TOML_CREATABLE_PROTOCOLS as readonly string[]).includes(protocol)
+}
+
+export function isRuntimeTomlOfficialClientProtocol(protocol: string): boolean {
+  return protocol === 'codex-app-server'
 }
 
 const RUNTIME_TOML_NON_MATERIALIZABLE_PROTOCOLS = new Set([


### PR DESCRIPTION
## Summary
- expose `codex-app-server` as a typed official-client protocol in the structured runtime editor
- enforce `command` transport, no credentials, and `is-non-interactive = true` for subscription execution
- allow the typed Codex command runtime through binding, Keeper assignment, and lane configuration while generic command providers remain rejected
- render the official-client boundary explicitly instead of presenting it as an HTTP/API-key provider

## Stack
- base: #27731 (`feat/codex-session-resume-20260809`)
- this PR is intentionally dashboard-only and should be retargeted to `main` after #27731 merges

## Verification
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/lib/runtime-toml-config.test.ts src/components/runtime-environment-editor.test.ts src/components/runtime-toml-editor.test.ts` (92 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`

## Follow-up boundary
Installation/auth probes, durable session phase, measured usage, and quota will be added from backend evidence in separate small PRs; this PR does not infer those states from TOML.