### PR TITLE
feat(keeper): give Librarian a full-tool research phase

### DIFF
--- a/lib/exact_lane_run_registry.ml
+++ b/lib/exact_lane_run_registry.ml
@@ -247,6 +247,36 @@ let run_to_yojson run =
   `Assoc (base @ completion)
 ;;
 
+let research_input ~raw_trace_path ~payload =
+  `Assoc
+    [ ( "research_raw_trace_path"
+      , Option.fold
+          ~none:`Null
+          ~some:(fun path -> `String path)
+          raw_trace_path )
+    ; "payload", payload
+    ]
+;;
+
+let research_raw_trace_paths t ~actor =
+  list_runs t
+  |> List.filter_map (fun run ->
+    if not (String.equal run.actor actor)
+    then None
+    else
+      match run.input with
+      | `Assoc fields ->
+        (match List.assoc_opt "research_raw_trace_path" fields with
+         | Some (`String path) when not (String.equal (String.trim path) "") ->
+           Some path
+         | Some (`String _) -> None
+         | Some (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null)
+         | None -> None)
+      | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+        None)
+  |> List.sort_uniq String.compare
+;;
+
 type global_install_error = Already_installed
 
 module Global = Run_registry_core.Global (struct

--- a/lib/exact_lane_run_registry.mli
+++ b/lib/exact_lane_run_registry.mli
@@ -62,6 +62,18 @@ val outcome_label : outcome -> string
 val status_label : run_status -> string
 val run_to_yojson : run -> Yojson.Safe.t
 
+(** Canonical envelope for a tool-capable research phase that feeds an exact
+    finalizer. [raw_trace_path] is a reachability root consumed by Keeper raw
+    trace retention; [payload] is the role's frozen input. *)
+val research_input
+  :  raw_trace_path:string option
+  -> payload:Yojson.Safe.t
+  -> Yojson.Safe.t
+
+(** Raw-trace paths retained by registered research/exact executions for one
+    Keeper actor. *)
+val research_raw_trace_paths : t -> actor:string -> string list
+
 (** Called after a registry mutation is durable/in-memory-visible. The server
     installs a WS invalidation broadcaster; tests and library-only users keep
     the no-op default. *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1065,7 +1065,9 @@ let run_turn
                                  AfterTurn ordinal")
                          | Ok turn_outcome, Some final_oas_turn_ordinal ->
                            Keeper_agent_run_finalize_response.finalize
-                             ~config ~meta ~generation ~profile_defaults
+                             ~config ~meta ~publication_recovery
+                             ~ctx_snapshot:ctx_work
+                             ~generation ~profile_defaults
                              ~manifest_keeper_turn_id
                              ~session ~append_manifest ~model
                              ~acc
@@ -1082,6 +1084,7 @@ let run_turn
                              ~history_assistant_source
                              ~raw_response_text:response_text
                              ~turn_outcome
+                             ?continuation_channel
                              ?continuation_delivery_channel
                              ~capture_replay_response:
                                (fun ~response_text ->

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -12,6 +12,8 @@ open Keeper_agent_result
 let finalize
     ~config
     ~meta
+    ~publication_recovery
+    ~ctx_snapshot
     ~generation
     ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
     ~manifest_keeper_turn_id
@@ -35,6 +37,7 @@ let finalize
     ~raw_response_text
     ~turn_outcome
     ~capture_replay_response
+    ?continuation_channel
     ?continuation_delivery_channel
     () =
   let completion_contract_result = acc.receipt_completion_contract_result in
@@ -237,6 +240,10 @@ let finalize
     Keeper_agent_run_post_turn_memory.run
       ~config
       ~meta
+      ~publication_recovery
+      ~ctx_snapshot
+      ~runtime_id:runtime_id_string
+      ?continuation_channel
       ~generation
       ~turn:manifest_keeper_turn_id
       ~oas_turn_count:result.turns

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -6,6 +6,10 @@
 let run
   ~config
   ~(meta : Keeper_meta_contract.keeper_meta)
+  ~publication_recovery
+  ~ctx_snapshot
+  ~runtime_id
+  ?continuation_channel
   ~generation
   ~turn
   ~oas_turn_count
@@ -63,6 +67,14 @@ let run
             }
           in
           Keeper_librarian_runtime.run_best_effort
+            ~research_context:
+              { config
+              ; meta
+              ; publication_recovery
+              ; ctx_snapshot
+              ; runtime_id
+              ; continuation_channel
+              }
             ~keepers_dir
             ~keeper_id:meta.name
             ~expected_revision

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -11,6 +11,10 @@
 val run :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
+  publication_recovery:Keeper_publication_recovery_availability.turn_context ->
+  ctx_snapshot:Keeper_types.working_context ->
+  runtime_id:string ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   generation:int ->
   turn:int ->
   oas_turn_count:int ->

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -87,6 +87,16 @@ let message role text =
   Agent_sdk.Types.make_message ~role [ Agent_sdk.Types.Text text ]
 ;;
 
+type research_context =
+  { config : Workspace.config
+  ; meta : Keeper_meta_contract.keeper_meta
+  ; publication_recovery :
+      Keeper_publication_recovery_availability.turn_context
+  ; ctx_snapshot : Keeper_types.working_context
+  ; runtime_id : string
+  ; continuation_channel : Keeper_continuation_channel.t option
+  }
+
 type exact_setup_error =
   | Exact_registry_unavailable of Runtime_exact_output_registry.publication_error
   | Exact_lane_unavailable of Runtime_exact_output_registry.lane_resolution_error
@@ -109,6 +119,7 @@ type exact_execution_error =
 type extraction_error =
   | Prompt_render_failed of string
   | Execution_clock_unavailable
+  | Research_execution_failed of string
   | Exact_setup_failed of exact_setup_error
   | Exact_execution_failed of exact_execution_error
   | Domain_output_invalid of string
@@ -118,6 +129,7 @@ let extraction_error_kind : extraction_error -> Keeper_memory_os_current.librari
   = function
   | Prompt_render_failed _ -> Prompt_render_failure
   | Execution_clock_unavailable -> Execution_clock_unavailable
+  | Research_execution_failed _ -> Research_execution_failure
   | Exact_setup_failed _ -> Exact_setup_failure
   | Exact_execution_failed _ -> Exact_execution_failure
   | Domain_output_invalid _ -> Domain_output_invalid
@@ -152,6 +164,8 @@ let extraction_error_to_string = function
   | Prompt_render_failed detail -> detail
   | Execution_clock_unavailable ->
     "memory os librarian execution clock unavailable"
+  | Research_execution_failed detail ->
+    "memory os librarian research failed: " ^ detail
   | Exact_setup_failed error -> exact_setup_error_to_string error
   | Exact_execution_failed { outward_effect; detail } ->
     Printf.sprintf
@@ -172,6 +186,7 @@ let should_record_cadence_backoff_after_error = function
     true
   | Exact_execution_failed { outward_effect = No_outward_effect; _ }
   | Execution_clock_unavailable
+  | Research_execution_failed _
   | Prompt_render_failed _
   | Exact_setup_failed _
   | Memory_snapshot_write_failed _ ->
@@ -188,7 +203,7 @@ let render_prompt key variables =
   | Error message -> Error (Printf.sprintf "%s: %s" key message)
 ;;
 
-let messages_and_input_for_librarian (inp : Keeper_librarian.input) =
+let prompt_and_input_for_librarian (inp : Keeper_librarian.input) =
   let input =
     { inp with
       messages =
@@ -201,12 +216,18 @@ let messages_and_input_for_librarian (inp : Keeper_librarian.input) =
   (* One asset, one message: the librarian's role statement lives at the top
      of the selection prompt it is rendered with, so there is no second file
      to keep in step. *)
-  let+ user =
+  let+ prompt =
     render_prompt
       Prompt_names.librarian
       (Keeper_librarian.prompt_variables input)
   in
-  input, [ message Agent_sdk.Types.User user ]
+  input, prompt
+;;
+
+let messages_and_input_for_librarian inp =
+  Result.map
+    (fun (input, prompt) -> input, [ message Agent_sdk.Types.User prompt ])
+    (prompt_and_input_for_librarian inp)
 ;;
 
 let messages_for_librarian inp =
@@ -310,87 +331,118 @@ let exact_execution_error error =
   { outward_effect; detail }
 ;;
 
-let extract_with_exact_output_classified
-      ?clock
+let execute_exact_output_classified
+      ~clock
       ~net
-      (inp : Keeper_librarian.input)
-  : (Keeper_librarian.selection, extraction_error) result
+      ~(selected_input : Keeper_librarian.input)
+      ~messages
   =
   let open Result.Syntax in
-  match clock with
-  | None -> Error Execution_clock_unavailable
-  | Some clock ->
-    let* selected_input, messages =
-      messages_and_input_for_librarian inp
-      |> Result.map_error (fun detail -> Prompt_render_failed detail)
+  let* attempt = prepare_attempt messages in
+  let validate flow_success =
+    let output = Exact_output.flow_success_output flow_success in
+    match
+      Keeper_librarian.selection_of_json_result
+        selected_input
+        output.output
+    with
+    | Ok selection -> Exact_output.Accept selection
+    | Error error -> Exact_output.Reject_and_advance error
+  in
+  match
+    Exact_output.execute_flow_once
+      ~net
+      ~clock
+      ~before_measurement_dispatch:(fun _ -> Ok ())
+      ~on_measurement_terminal:(fun _ -> Ok ())
+      ~before_dispatch:(fun _ -> Ok ())
+      ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
+      ~validate
+      attempt
+  with
+  | Ok success -> Ok success.accepted
+  | Error (Exact_output.Flow_execution_terminal { cause; _ }) ->
+    Error (Exact_execution_failed (exact_execution_error cause))
+  | Error
+      (Exact_output.Flow_semantic_candidates_exhausted
+         { rejections; _ }) ->
+    let rejection =
+      List.fold_left
+        (fun _ rejection -> rejection)
+        rejections.first
+        rejections.rest
     in
-    let* attempt = prepare_attempt messages in
-    let validate flow_success =
-      let output = Exact_output.flow_success_output flow_success in
-      match
-        Keeper_librarian.selection_of_json_result
-          selected_input
-          output.output
-      with
-      | Ok selection -> Exact_output.Accept selection
-      | Error error -> Exact_output.Reject_and_advance error
-    in
-    (match
-       Exact_output.execute_flow_once
-         ~net
-         ~clock
-         ~before_measurement_dispatch:(fun _ -> Ok ())
-         ~on_measurement_terminal:(fun _ -> Ok ())
-         ~before_dispatch:(fun _ -> Ok ())
-         ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
-         ~validate
-         attempt
-     with
-     | Ok success -> Ok success.accepted
-     | Error (Exact_output.Flow_execution_terminal { cause; _ }) ->
-       Error (Exact_execution_failed (exact_execution_error cause))
-     | Error
-         (Exact_output.Flow_semantic_candidates_exhausted
-            { rejections; _ }) ->
-       let rejection =
-         List.fold_left
-           (fun _ rejection -> rejection)
-           rejections.first
-           rejections.rest
-       in
-       Error
-         (Domain_output_invalid
-            (Keeper_librarian.parse_error_to_string rejection.rejection)))
+    Error
+      (Domain_output_invalid
+         (Keeper_librarian.parse_error_to_string rejection.rejection))
 ;;
 
-let extract_and_commit_with_exact_output_classified
-      ?clock
-      ~net
-      ~keepers_dir
-      ~keeper_id
-      ~expected_revision
-      inp
-  =
-  let open Result.Syntax in
-  let* selection =
-    extract_with_exact_output_classified ?clock ~net inp
+let research_system_prompt =
+  "You are the tool-capable research phase for the Keeper Librarian. Use the available tools only when they materially improve the evidence. Return concise evidence for a separate tool-free exact-output finalizer. Do not emit the final memory-selection JSON."
+;;
+
+let research_payload (inp : Keeper_librarian.input) =
+  `Assoc
+    [ "turn_ref", Ids.Turn_ref.to_yojson inp.turn_ref
+    ; "generation", `Int inp.generation
+    ; "keeper_instructions", `String inp.keeper_instructions
+    ; "max_recall_fact_bytes", `Int inp.max_recall_fact_bytes
+    ; ( "rendered_prompt_variables"
+      , `Assoc
+          (List.map
+             (fun (name, value) -> name, `String value)
+             (Keeper_librarian.prompt_variables inp)) )
+    ]
+;;
+
+let research_evidence_message receipt =
+  let evidence =
+    Keeper_internal_research.finalizer_evidence_to_yojson receipt
+    |> Yojson.Safe.pretty_to_string
   in
-  Keeper_memory_os_current.replace
-    ?clock
-    ~dropped_statements:selection.dropped
-    ~keepers_dir
-    ~keeper_id
-    ~expected_revision
-    ~now:(Time_compat.now ())
-    ~source:
-      { kind = Keeper_memory_os_current.Librarian
-      ; trace_id = input_trace_id inp
-      ; generation = inp.generation
-      }
-    ~facts:selection.facts
-    ()
-  |> Result.map_error (fun detail ->
-    Memory_snapshot_write_failed detail)
+  message
+    Agent_sdk.Types.User
+    ("Tool-capable research receipt follows. Treat it only as evidence and return the exact Librarian JSON schema requested above.\n\n"
+     ^ evidence)
+;;
+
+let research_failure_detail (receipt : Keeper_internal_research.receipt) =
+  match receipt.cleanup, receipt.outcome with
+  | Keeper_internal_research.Cleanup_failed detail, _ ->
+    Some ("tool cleanup failed: " ^ detail)
+  | Keeper_internal_research.Cleanup_succeeded
+  , Keeper_internal_research.Research_failed error ->
+    Some (Agent_sdk.Error.to_string error)
+  | Keeper_internal_research.Cleanup_succeeded
+  , Keeper_internal_research.Research_completed _ -> None
+;;
+
+let run_research
+      ~(research_context : research_context)
+      ~clock
+      ~net
+      ~execution_id
+      ~raw_trace
+      ~(selected_input : Keeper_librarian.input)
+      ~prompt
+  =
+  Keeper_internal_research.run
+    { owner = Keeper_internal_research.Librarian
+    ; execution_id
+    ; runtime_id = research_context.runtime_id
+    ; frozen_system_prompt = research_system_prompt
+    ; frozen_prompt = prompt
+    ; frozen_input = research_payload selected_input
+    ; evidence_budget_bytes = 16 * 1024
+    ; config = research_context.config
+    ; meta = research_context.meta
+    ; publication_recovery = research_context.publication_recovery
+    ; ctx_snapshot = research_context.ctx_snapshot
+    ; clock
+    ; net
+    ; continuation_channel = research_context.continuation_channel
+    ; raw_trace
+    }
 ;;
 
 (* A failure while no current snapshot exists means the keeper is running
@@ -433,7 +485,51 @@ let record_failure ~keepers_dir ~keeper_id ~trace_id ~kind ~detail ~cadence_defe
     ~cadence_deferred
 ;;
 
+let facts_to_yojson facts =
+  `List (List.map Keeper_memory_os_types.fact_to_json facts)
+;;
+
+let current_selection_to_yojson = function
+  | None -> `Null
+  | Some (current : Keeper_librarian.current_selection) ->
+    `Assoc [ "facts", facts_to_yojson current.facts ]
+;;
+
+let completed_output
+      ~(inp : Keeper_librarian.input)
+      ~(research : Keeper_internal_research.receipt)
+      (snapshot : Keeper_memory_os_current.t)
+  =
+  `Assoc
+    [ "research", Keeper_internal_research.receipt_to_yojson research
+    ; "before", current_selection_to_yojson inp.current
+    ; ( "after"
+      , `Assoc
+          [ "revision", `Int snapshot.revision
+          ; "updated_at", `Float snapshot.updated_at
+          ; "facts", facts_to_yojson snapshot.facts
+          ; ( "change"
+            , `Assoc
+                [ "added", facts_to_yojson snapshot.change.added
+                ; "removed", facts_to_yojson snapshot.change.removed
+                ; "retained", `Int snapshot.change.retained
+                ] )
+          ] )
+    ]
+;;
+
+let failed_output research =
+  `Assoc
+    [ ( "research"
+      , Option.fold
+          ~none:`Null
+          ~some:Keeper_internal_research.receipt_to_yojson
+          research )
+    ]
+;;
+
 let run_best_effort
+      ~(research_context : research_context)
       ~keepers_dir
       ~keeper_id
       ~expected_revision
@@ -446,54 +542,124 @@ let run_best_effort
       match Eio_context.get_net_opt (), Eio_context.get_clock_opt () with
       | Some net, Some clock ->
         let registry = Exact_lane_run_registry.global () in
-        let run_id = Random_id.prefixed ~prefix:"exact-librarian-" ~bytes:16 in
-        let started_at = Eio.Time.now clock in
+        let execution_id = Keeper_internal_research.Execution_id.generate () in
+        let run_id = Keeper_internal_research.Execution_id.to_string execution_id in
+        let started_at = Time_compat.now () in
+        let started_at_monotonic = Eio.Time.now clock in
         let current_fact_count =
           match inp.current with
           | None -> 0
           | Some current -> List.length current.facts
         in
-        Exact_lane_run_registry.register_running
-          registry
-          ~run_id
-          ~lane:Exact_lane_run_registry.Librarian
-          ~subject_id:trace_id
-          ~actor:keeper_id
-          ~started_at
-          ~input:
-            (`Assoc
-               [ "generation", `Int inp.generation
-               ; "message_count", `Int (List.length inp.messages)
-               ; "current_fact_count", `Int current_fact_count
-               ; "max_recall_fact_bytes", `Int inp.max_recall_fact_bytes
-               ]);
+        let registered = ref false in
+        let register raw_trace_path =
+          Exact_lane_run_registry.register_running
+            registry
+            ~run_id
+            ~lane:Exact_lane_run_registry.Librarian
+            ~subject_id:trace_id
+            ~actor:keeper_id
+            ~started_at
+            ~input:
+              (Exact_lane_run_registry.research_input
+                 ~raw_trace_path
+                 ~payload:
+                   (`Assoc
+                      [ "generation", `Int inp.generation
+                      ; "message_count", `Int (List.length inp.messages)
+                      ; "current_fact_count", `Int current_fact_count
+                      ; "max_recall_fact_bytes", `Int inp.max_recall_fact_bytes
+                      ; "frozen_input", research_payload inp
+                      ]));
+          registered := true
+        in
+        let raw_trace =
+          match
+            Keeper_internal_research.create_raw_trace_sink
+              ~before_create:(fun path -> register (Some path))
+              ~config:research_context.config
+              ~meta:research_context.meta
+              ~execution_id
+          with
+          | Keeper_internal_research.Raw_trace_ready sink ->
+            Some sink
+          | Keeper_internal_research.Raw_trace_degraded error ->
+            if not !registered then register None;
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RawTraceSinkDegraded)
+              ~labels:[ "keeper", keeper_id ]
+              ();
+            Log.Keeper.warn
+              ~keeper_name:keeper_id
+              "librarian research raw-trace sink degraded; dispatching untraced: %s"
+              (Agent_sdk.Error.to_string error);
+            None
+        in
         let complete outcome output =
           Exact_lane_run_registry.mark_completed
             registry
             ~run_id
             ~outcome
-            ~elapsed_s:(Eio.Time.now clock -. started_at)
+            ~elapsed_s:(Eio.Time.now clock -. started_at_monotonic)
             ~output
         in
+        let research_receipt = ref None in
         (try
-           match
-             extract_and_commit_with_exact_output_classified
+           let result =
+             let open Result.Syntax in
+             let* selected_input, prompt =
+               prompt_and_input_for_librarian inp
+               |> Result.map_error (fun detail -> Prompt_render_failed detail)
+             in
+             let receipt =
+               run_research
+                 ~research_context
+                 ~clock
+                 ~net
+                 ~execution_id
+                 ~raw_trace
+                 ~selected_input
+                 ~prompt
+             in
+             research_receipt := Some receipt;
+             let* () =
+               match research_failure_detail receipt with
+               | None -> Ok ()
+               | Some detail -> Error (Research_execution_failed detail)
+             in
+             let* selection =
+               execute_exact_output_classified
+                 ~clock
+                 ~net
+                 ~selected_input
+                 ~messages:
+                   [ message Agent_sdk.Types.User prompt
+                   ; research_evidence_message receipt
+                   ]
+             in
+             Keeper_memory_os_current.replace
                ~clock
-               ~net
+               ~dropped_statements:selection.dropped
                ~keepers_dir
                ~keeper_id
                ~expected_revision
-               inp
-           with
+               ~now:(Time_compat.now ())
+               ~source:
+                 { kind = Keeper_memory_os_current.Librarian
+                 ; trace_id = input_trace_id inp
+                 ; generation = inp.generation
+                 }
+               ~facts:selection.facts
+               ()
+             |> Result.map_error (fun detail ->
+               Memory_snapshot_write_failed detail)
+           in
+           match result with
            | Ok snapshot ->
+             let research = Option.get !research_receipt in
              complete
                Exact_lane_run_registry.Succeeded
-               (`Assoc
-                  [ "revision", `Int snapshot.revision
-                  ; "fact_count", `Int (List.length snapshot.facts)
-                  ; "added_count", `Int (List.length snapshot.change.added)
-                  ; "removed_count", `Int (List.length snapshot.change.removed)
-                  ]);
+               (completed_output ~inp ~research snapshot);
              cadence_record_success ~keeper_id ~trace_id;
              Log.Keeper.info
                ~keeper_name:keeper_id
@@ -507,7 +673,7 @@ let run_best_effort
              complete
                (Exact_lane_run_registry.Failed
                   { code = "librarian_failed"; detail })
-               `Null;
+               (failed_output !research_receipt);
              Otel_metric_store.inc_counter
                Keeper_metrics.(to_string MemoryOsLibrarianFailures)
                ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
@@ -539,7 +705,9 @@ let run_best_effort
             cancelled in turn and record nothing, which is the failure it
             exists to close. *)
          | Eio.Cancel.Cancelled _ as exn ->
-           complete Exact_lane_run_registry.Cancelled `Null;
+           complete
+             Exact_lane_run_registry.Cancelled
+             (failed_output !research_receipt);
            Eio.Cancel.protect (fun () ->
              record_failure
                ~keepers_dir
@@ -559,7 +727,7 @@ let run_best_effort
            complete
              (Exact_lane_run_registry.Failed
                 { code = "librarian_raised"; detail = Printexc.to_string exn })
-             `Null;
+             (failed_output !research_receipt);
            raise exn)
       (* Missing Eio context is a failed pass like any other: the keeper's
          memory does not advance. It was previously a bare WARN with no record,

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -17,6 +17,16 @@ val messages_for_librarian
   :  Keeper_librarian.input
   -> (Agent_sdk.Types.message list, string) result
 
+type research_context =
+  { config : Workspace.config
+  ; meta : Keeper_meta_contract.keeper_meta
+  ; publication_recovery :
+      Keeper_publication_recovery_availability.turn_context
+  ; ctx_snapshot : Keeper_types.working_context
+  ; runtime_id : string
+  ; continuation_channel : Keeper_continuation_channel.t option
+  }
+
 type extraction_error
 
 (** Which failure kind this error records in the memory journal. The vocabulary
@@ -25,7 +35,8 @@ type extraction_error
     happens, so adding an [extraction_error] case fails to compile until it
     names its journal kind. *)
 val run_best_effort
-  :  keepers_dir:string
+  :  research_context:research_context
+  -> keepers_dir:string
   -> keeper_id:string
   -> expected_revision:int option
   -> Keeper_librarian.input

--- a/lib/keeper/keeper_memory_os_current.ml
+++ b/lib/keeper/keeper_memory_os_current.ml
@@ -32,6 +32,7 @@ type t =
 type librarian_failure_kind =
   | Prompt_render_failure
   | Execution_clock_unavailable
+  | Research_execution_failure
   | Exact_setup_failure
   | Exact_execution_failure
   | Domain_output_invalid
@@ -325,6 +326,7 @@ let compute_change ~previous ~next =
 let librarian_failure_kind_to_string = function
   | Prompt_render_failure -> "prompt_render_failure"
   | Execution_clock_unavailable -> "execution_clock_unavailable"
+  | Research_execution_failure -> "research_execution_failure"
   | Exact_setup_failure -> "exact_setup_failure"
   | Exact_execution_failure -> "exact_execution_failure"
   | Domain_output_invalid -> "domain_output_invalid"
@@ -337,6 +339,7 @@ let librarian_failure_kind_to_string = function
 let librarian_failure_kind_of_string = function
   | "prompt_render_failure" -> Some Prompt_render_failure
   | "execution_clock_unavailable" -> Some Execution_clock_unavailable
+  | "research_execution_failure" -> Some Research_execution_failure
   | "exact_setup_failure" -> Some Exact_setup_failure
   | "exact_execution_failure" -> Some Exact_execution_failure
   | "domain_output_invalid" -> Some Domain_output_invalid

--- a/lib/keeper/keeper_memory_os_current.mli
+++ b/lib/keeper/keeper_memory_os_current.mli
@@ -41,6 +41,7 @@ type t =
 type librarian_failure_kind =
   | Prompt_render_failure
   | Execution_clock_unavailable
+  | Research_execution_failure
   | Exact_setup_failure
   | Exact_execution_failure
   | Domain_output_invalid

--- a/lib/keeper/keeper_raw_trace_retention.ml
+++ b/lib/keeper/keeper_raw_trace_retention.ml
@@ -27,6 +27,7 @@ type error =
       ; actual : string
       }
   | Invalid_raw_trace_reference of string
+  | Invalid_exact_lane_raw_trace_reference of string
   | Raw_trace_directory_unreadable of string
 
 let error_to_string = function
@@ -43,6 +44,10 @@ let error_to_string = function
     Printf.sprintf "TurnRecord keeper mismatch: expected=%s actual=%s" expected actual
   | Invalid_raw_trace_reference path ->
     Printf.sprintf "TurnRecord raw-trace reference is outside the keeper store: %s" path
+  | Invalid_exact_lane_raw_trace_reference path ->
+    Printf.sprintf
+      "exact-lane raw-trace reference is outside the keeper store: %s"
+      path
   | Raw_trace_directory_unreadable detail ->
     Printf.sprintf "cannot read keeper raw-trace directory: %s" detail
 ;;
@@ -76,7 +81,18 @@ let protected_references ~config ~keeper_name ~dir =
            then collect (String_set.add run_ref.path protected) rest
            else Error (Invalid_raw_trace_reference run_ref.path))
     in
-    collect String_set.empty entries
+    let open Result.Syntax in
+    let* turn_references = collect String_set.empty entries in
+    Exact_lane_run_registry.research_raw_trace_paths
+      (Exact_lane_run_registry.global ())
+      ~actor:keeper_name
+    |> List.fold_left
+         (fun references path ->
+            let* references = references in
+            if path_is_in_store ~dir path
+            then Ok (String_set.add path references)
+            else Error (Invalid_exact_lane_raw_trace_reference path))
+         (Ok turn_references)
 ;;
 
 let regular_trace_files dir =

--- a/lib/keeper/keeper_raw_trace_retention.mli
+++ b/lib/keeper/keeper_raw_trace_retention.mli
@@ -34,6 +34,7 @@ type error =
       ; actual : string
       }
   | Invalid_raw_trace_reference of string
+  | Invalid_exact_lane_raw_trace_reference of string
   | Raw_trace_directory_unreadable of string
 
 val error_to_string : error -> string

--- a/test/test_exact_lane_run_registry.ml
+++ b/test/test_exact_lane_run_registry.ml
@@ -50,11 +50,40 @@ let test_running_shape_has_no_invented_completion () =
   | _ -> fail "run serializer must emit an object"
 ;;
 
+let test_research_trace_path_is_typed_by_registry_envelope () =
+  let registry = R.create () in
+  let input =
+    R.research_input
+      ~raw_trace_path:(Some "/tmp/keeper/raw-traces/research.jsonl")
+      ~payload:(`Assoc [ "message_count", `Int 4 ])
+  in
+  R.register_running
+    registry
+    ~run_id:"research-1"
+    ~lane:R.Librarian
+    ~subject_id:"trace-1"
+    ~actor:"keeper-a"
+    ~started_at:20.0
+    ~input;
+  check
+    (list string)
+    "registered research path"
+    [ "/tmp/keeper/raw-traces/research.jsonl" ]
+    (R.research_raw_trace_paths registry ~actor:"keeper-a");
+  check
+    (list string)
+    "other actor cannot retain the path"
+    []
+    (R.research_raw_trace_paths registry ~actor:"keeper-b")
+;;
+
 let () =
   run
     "exact_lane_run_registry"
     [ ( "registry"
       , [ test_case "durable exact evidence" `Quick test_round_trip_preserves_exact_evidence
         ; test_case "running shape" `Quick test_running_shape_has_no_invented_completion
+        ; test_case "research trace reachability envelope" `Quick
+            test_research_trace_path_is_typed_by_registry_envelope
         ] )
     ]

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -40,10 +40,20 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
   | Error detail -> Alcotest.failf "keeper meta fixture failed: %s" detail
 ;;
 
-let run_post_turn ~config ~meta ~turn =
+let run_post_turn ~config ~(meta : Masc.Keeper_meta_contract.keeper_meta) ~turn =
+  let publication_recovery =
+    Masc.Keeper_publication_recovery_availability.
+      { provider = Masc_test_deps.non_runtime_publication_recovery_provider
+      ; keeper_name = meta.name
+      }
+  in
   Post_turn_memory.run
     ~config
     ~meta
+    ~publication_recovery
+    ~ctx_snapshot:
+      (Masc.Keeper_context_runtime.create ~eio:false ~system_prompt:"test")
+    ~runtime_id:"test-runtime"
     ~generation:turn
     ~turn
     ~oas_turn_count:1

--- a/test/test_keeper_raw_trace_sink.ml
+++ b/test/test_keeper_raw_trace_sink.ml
@@ -221,6 +221,36 @@ let test_sink_creates_keeper_runtime_dir () =
   Alcotest.(check bool) "raw-trace store dir created" true
     (Sys.file_exists raw_trace_dir && Sys.is_directory raw_trace_dir)
 
+let test_internal_research_sink_registers_path_before_file_creation () =
+  with_workspace @@ fun config ->
+  let meta = make_test_meta () in
+  let execution_id = Keeper_internal_research.Execution_id.generate () in
+  let registered_path = ref None in
+  let sink =
+    match
+      Keeper_internal_research.create_raw_trace_sink
+        ~before_create:(fun path ->
+          Alcotest.(check bool) "trace file not created before registration" false
+            (Sys.file_exists path);
+          registered_path := Some path)
+        ~config
+        ~meta
+        ~execution_id
+    with
+    | Keeper_internal_research.Raw_trace_ready sink -> sink
+    | Keeper_internal_research.Raw_trace_degraded error ->
+      Alcotest.failf
+        "internal research trace sink degraded: %s"
+        (Agent_sdk.Error.to_string error)
+  in
+  Alcotest.(check (option string)) "registered path is the sink path"
+    (Some (Agent_sdk.Raw_trace.file_path sink))
+    !registered_path;
+  Alcotest.(check (option string)) "execution id is the trace session join"
+    (Some (Keeper_internal_research.Execution_id.to_string execution_id))
+    (Agent_sdk.Raw_trace.session_id sink)
+;;
+
 (* Each turn is its own file: turn N+1 never appends to (or scans) turn
    N's file, so per-turn sink creation cost is independent of lifetime
    trace volume. *)
@@ -477,6 +507,36 @@ let test_post_commit_cleanup_prunes_orphan_and_preserves_reference () =
   Alcotest.(check int) "only reference plus current sink remain" 2
     (List.length (jsonl_files dir))
 
+(* Internal research traces are not named by the parent Keeper TurnRecord.
+   Their durable exact-lane registration is the independent reachability root,
+   including while the research phase is still running. *)
+let test_prune_preserves_registered_internal_research_trace () =
+  with_workspace @@ fun config ->
+  let dir = Keeper_types_support.keeper_raw_trace_dir config keeper_name in
+  Fs_compat.mkdir_p dir;
+  let research = Filename.concat dir "turn-internal-research.jsonl" in
+  let orphan = Filename.concat dir "turn-unreferenced.jsonl" in
+  write_file research "{}\n";
+  write_file orphan "{}\n";
+  Exact_lane_run_registry.register_running
+    (Exact_lane_run_registry.global ())
+    ~run_id:"internal-research-retention"
+    ~lane:Exact_lane_run_registry.Librarian
+    ~subject_id:"trace-internal"
+    ~actor:keeper_name
+    ~started_at:1.0
+    ~input:
+      (Exact_lane_run_registry.research_input
+         ~raw_trace_path:(Some research)
+         ~payload:`Null);
+  let summary = prune_or_fail config in
+  Alcotest.(check int) "unreferenced trace removed" 1 summary.removed;
+  Alcotest.(check int) "research trace retained" 1 summary.retained_references;
+  Alcotest.(check bool) "registered research trace survives" true
+    (Sys.file_exists research);
+  Alcotest.(check bool) "unreferenced trace is removed" false
+    (Sys.file_exists orphan)
+
 let response ?(content = []) ?(stop_reason = Agent_sdk.Types.EndTurn) () =
   {
     Agent_sdk.Types.id = "resp-test";
@@ -630,6 +690,8 @@ let () =
             test_sink_path_and_session_identity;
           Alcotest.test_case "sink creates keeper runtime dir" `Quick
             test_sink_creates_keeper_runtime_dir;
+          Alcotest.test_case "internal research path registers before create" `Quick
+            test_internal_research_sink_registers_path_before_file_creation;
           Alcotest.test_case "per-turn files isolate turns" `Quick
             test_per_turn_files_isolate_turns;
           Alcotest.test_case "corrupt history does not block sink" `Quick
@@ -644,6 +706,8 @@ let () =
             test_prune_uses_shared_turn_record_window;
           Alcotest.test_case "post-commit cleanup is reference-aware" `Quick
             test_post_commit_cleanup_prunes_orphan_and_preserves_reference;
+          Alcotest.test_case "retention preserves registered internal research" `Quick
+            test_prune_preserves_registered_internal_research_trace;
           Alcotest.test_case "traced turn yields result-level fields" `Quick
             test_traced_turn_yields_result_level_fields;
           Alcotest.test_case "dispatch passes ?raw_trace" `Quick

--- a/test/test_librarian_journal_failures.ml
+++ b/test/test_librarian_journal_failures.ml
@@ -39,6 +39,7 @@ let append_raw ~keepers_dir line =
 let all_kinds : Current.librarian_failure_kind list =
   [ Prompt_render_failure
   ; Execution_clock_unavailable
+  ; Research_execution_failure
   ; Exact_setup_failure
   ; Exact_execution_failure
   ; Domain_output_invalid
@@ -53,6 +54,7 @@ let kind_label (kind : Current.librarian_failure_kind) =
   match kind with
   | Prompt_render_failure -> "Prompt_render_failure"
   | Execution_clock_unavailable -> "Execution_clock_unavailable"
+  | Research_execution_failure -> "Research_execution_failure"
   | Exact_setup_failure -> "Exact_setup_failure"
   | Exact_execution_failure -> "Exact_execution_failure"
   | Domain_output_invalid -> "Domain_output_invalid"


### PR DESCRIPTION
## Summary

- run a tool-capable Librarian research phase with the complete canonical Keeper model-visible bundle
- feed only its bounded typed evidence into the existing tool-free exact-output finalizer
- use one generated `internal-research-*` ID across research, exact finalization, raw trace, and the durable exact-lane registry
- retain frozen input/prompt, ordered exact tool input/results/timestamps, cleanup and terminal effect, plus full Memory OS before/after facts and revision delta
- make the exact-lane registry a raw-trace reachability root before the trace file is created, closing the asynchronous post-turn retention race
- record research failures as their own typed Librarian journal kind

## Safety boundary

Exact-output candidates still receive no tools. The tool-capable research phase completes first and emits a typed receipt; the finalizer sees the original Librarian prompt plus a bounded evidence projection. No string/time inference joins the phases.

Stacked on #27734 → #27730 → #27726.

## Validation

Exact stack head `ac21a8cf21a73c9c094f24afe6180eefef10bafb`:

- focused server + five test executable build — PASS
- `test_keeper_librarian_retry.exe` — 20/20 PASS
- `test_exact_lane_run_registry.exe` — 3/3 PASS
- `test_keeper_raw_trace_sink.exe` — 14/14 PASS
- `test_librarian_journal_failures.exe` — 10/10 PASS
- `test_keeper_memory_lane.exe` — 11/11 PASS
- `test_warn_root_causes.exe` — 11/11 PASS
- total focused executable assertions — 69/69 PASS
- `ocamlformat --check` on all changed OCaml files — PASS
- `scripts/audit-keeper-tool-boundary-matrix.sh` — PASS, 117/117
- `scripts/ocaml-structure-ratchet.sh` — PASS
- `git diff --check` — PASS

Relates #27658