### PR TITLE
feat(runtime): add Antigravity subscription client

### DIFF
--- a/lib/runtime/runtime_antigravity_cli.ml
+++ b/lib/runtime/runtime_antigravity_cli.ml
@@ -1,0 +1,434 @@
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
+type session_mode =
+  | Start
+  | Resume of { conversation_id : string }
+
+type usage =
+  { input_tokens : int
+  ; output_tokens : int
+  ; thinking_tokens : int
+  ; cache_read_tokens : int
+  ; total_tokens : int
+  }
+
+type turn_result =
+  { conversation_id : string
+  ; model : string
+  ; text : string
+  ; num_turns : int
+  ; usage : usage
+  ; tool_calls : int
+  ; permission_mode : string
+  ; resumed : bool
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | Turn_failed of string
+  | Process_exited of string
+  | Timeout of float
+
+let error_to_string = function
+  | Invalid_config detail -> "invalid Antigravity CLI config: " ^ detail
+  | Spawn_failed detail -> "failed to start Antigravity CLI: " ^ detail
+  | Protocol_error { stage; detail } ->
+    Printf.sprintf "Antigravity CLI protocol error during %s: %s" stage detail
+  | Turn_failed detail -> "Antigravity CLI turn failed: " ^ detail
+  | Process_exited detail -> "Antigravity CLI process failed: " ^ detail
+  | Timeout seconds ->
+    Printf.sprintf "Antigravity CLI turn timed out after %.3fs" seconds
+;;
+
+let ( let* ) = Result.bind
+
+let protocol_error stage detail = Error (Protocol_error { stage; detail })
+
+let rec validate_unique_object_keys ~stage ~path = function
+  | `Assoc fields ->
+    let rec loop seen = function
+      | [] -> Ok ()
+      | (name, value) :: rest ->
+        if List.mem name seen
+        then protocol_error stage (Printf.sprintf "duplicate object key %S at %s" name path)
+        else
+          let* () =
+            validate_unique_object_keys ~stage ~path:(path ^ "." ^ name) value
+          in
+          loop (name :: seen) rest
+    in
+    loop [] fields
+  | `List values ->
+    let rec loop index = function
+      | [] -> Ok ()
+      | value :: rest ->
+        let* () =
+          validate_unique_object_keys
+            ~stage
+            ~path:(Printf.sprintf "%s[%d]" path index)
+            value
+        in
+        loop (index + 1) rest
+    in
+    loop 0 values
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
+;;
+
+let assoc stage = function
+  | `Assoc fields -> Ok fields
+  | _ -> protocol_error stage "expected a JSON object"
+;;
+
+let required_string stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) when String.trim value <> "" -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a non-empty string" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_plain_string stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_int stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be an integer" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let nonnegative_int stage name fields =
+  let* value = required_int stage name fields in
+  if value < 0
+  then protocol_error stage (Printf.sprintf "field %S must be non-negative" name)
+  else Ok value
+;;
+
+let optional_object stage name fields =
+  match List.assoc_opt name fields with
+  | None -> Ok None
+  | Some (`Assoc nested) -> Ok (Some nested)
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be an object" name)
+;;
+
+let usage_of_fields stage fields =
+  let* input_tokens = nonnegative_int stage "input_tokens" fields in
+  let* output_tokens = nonnegative_int stage "output_tokens" fields in
+  let* thinking_tokens = nonnegative_int stage "thinking_tokens" fields in
+  let* cache_read_tokens = nonnegative_int stage "cache_read_tokens" fields in
+  let* total_tokens = nonnegative_int stage "total_tokens" fields in
+  if input_tokens > Int.max_int - output_tokens
+  then protocol_error stage "input_tokens + output_tokens overflowed"
+  else if total_tokens <> input_tokens + output_tokens
+  then protocol_error stage "total_tokens must equal input_tokens + output_tokens"
+  else
+    Ok
+      { input_tokens
+      ; output_tokens
+      ; thinking_tokens
+      ; cache_read_tokens
+      ; total_tokens
+      }
+;;
+
+let parse_json_line ~line_number line =
+  let stage = Printf.sprintf "stdout line %d" line_number in
+  if String.length line > 8 * 1024 * 1024
+  then protocol_error stage "NDJSON line exceeds 8 MiB"
+  else
+    try
+      let json = Yojson.Safe.from_string line in
+      let* () = validate_unique_object_keys ~stage ~path:"$" json in
+      Ok (stage, json)
+    with
+    | Yojson.Json_error detail -> protocol_error stage detail
+;;
+
+type init =
+  { conversation_id : string
+  ; model : string
+  ; cwd : string
+  ; permission_mode : string
+  }
+
+type terminal =
+  { conversation_id : string
+  ; status : string
+  ; response : string
+  ; num_turns : int
+  ; usage : usage
+  }
+
+let parse_init stage top_fields =
+  let* conversation_id = required_string stage "conversation_id" top_fields in
+  let* init_json =
+    match List.assoc_opt "init" top_fields with
+    | Some value -> Ok value
+    | None -> protocol_error stage "missing field \"init\""
+  in
+  let* init_fields = assoc stage init_json in
+  let* model = required_string stage "model" init_fields in
+  let* cwd = required_string stage "cwd" init_fields in
+  let* permission_mode = required_string stage "permission_mode" init_fields in
+  (match List.assoc_opt "tools" init_fields with
+   | Some (`List tools) ->
+     let rec validate_tools = function
+       | [] -> Ok ()
+       | `String name :: rest when String.trim name <> "" -> validate_tools rest
+       | _ -> protocol_error stage "init.tools must contain non-empty strings"
+     in
+     let* () = validate_tools tools in
+     Ok { conversation_id; model; cwd; permission_mode }
+   | Some _ -> protocol_error stage "init.tools must be an array"
+   | None -> protocol_error stage "missing field \"tools\"")
+;;
+
+let parse_step_update stage top_fields =
+  let* update_json =
+    match List.assoc_opt "step_update" top_fields with
+    | Some value -> Ok value
+    | None -> protocol_error stage "missing field \"step_update\""
+  in
+  let* fields = assoc stage update_json in
+  let* conversation_id = required_string stage "conversation_id" fields in
+  let* step_index = nonnegative_int stage "step_index" fields in
+  let* state = required_string stage "state" fields in
+  let* step_type = required_string stage "step_type" fields in
+  let* usage_fields = optional_object stage "usage" fields in
+  let* () =
+    match usage_fields with
+    | None -> Ok ()
+    | Some usage_fields -> usage_of_fields stage usage_fields |> Result.map ignore
+  in
+  Ok (conversation_id, step_index, state, step_type)
+;;
+
+let parse_terminal stage top_fields =
+  let* result_json =
+    match List.assoc_opt "result" top_fields with
+    | Some value -> Ok value
+    | None -> protocol_error stage "missing field \"result\""
+  in
+  let* fields = assoc stage result_json in
+  let* conversation_id = required_string stage "conversation_id" fields in
+  let* status = required_string stage "status" fields in
+  let* response = required_plain_string stage "response" fields in
+  let* num_turns = required_int stage "num_turns" fields in
+  if num_turns <= 0
+  then protocol_error stage "num_turns must be positive"
+  else
+    let* usage_json =
+      match List.assoc_opt "usage" fields with
+      | Some value -> Ok value
+      | None -> protocol_error stage "missing field \"usage\""
+    in
+    let* usage_fields = assoc stage usage_json in
+    let* usage = usage_of_fields stage usage_fields in
+    Ok { conversation_id; status; response; num_turns; usage }
+;;
+
+let parse_output ~expected_model ~expected_cwd ~session_mode output =
+  let lines =
+    output
+    |> String.split_on_char '\n'
+    |> List.filter (fun line -> String.trim line <> "")
+  in
+  if List.length lines > 16_384
+  then protocol_error "stdout" "NDJSON event count exceeds 16384"
+  else
+    let rec loop line_number init terminal tool_steps = function
+      | [] -> Ok (init, terminal, tool_steps)
+      | _ :: _ when Option.is_some terminal ->
+        protocol_error "stdout" "events appeared after the terminal result"
+      | line :: rest ->
+        let* stage, json = parse_json_line ~line_number line in
+        let* top_fields = assoc stage json in
+        let* event = required_string stage "event" top_fields in
+        (match event with
+         | "init" ->
+           if Option.is_some init
+           then protocol_error stage "duplicate init event"
+           else
+             let* parsed = parse_init stage top_fields in
+             loop (line_number + 1) (Some parsed) terminal tool_steps rest
+         | "step_update" ->
+           let* conversation_id, step_index, state, step_type =
+             parse_step_update stage top_fields
+           in
+           (match init with
+            | None -> protocol_error stage "step_update arrived before init"
+            | Some init when not (String.equal init.conversation_id conversation_id) ->
+              protocol_error stage "step_update conversation_id changed"
+            | Some _ ->
+              let tool_steps =
+                if String.equal step_type "tool" && String.equal state "DONE"
+                then if List.mem step_index tool_steps then tool_steps else step_index :: tool_steps
+                else tool_steps
+              in
+              loop (line_number + 1) init terminal tool_steps rest)
+         | "result" ->
+           (match init with
+            | None -> protocol_error stage "result arrived before init"
+            | Some _ ->
+              let* parsed = parse_terminal stage top_fields in
+              loop (line_number + 1) init (Some parsed) tool_steps rest)
+         | other -> protocol_error stage (Printf.sprintf "unsupported event %S" other))
+    in
+    let* init, terminal, tool_steps = loop 1 None None [] lines in
+    let* init =
+      match init with
+      | Some init -> Ok init
+      | None -> protocol_error "stdout" "missing init event"
+    in
+    let* terminal =
+      match terminal with
+      | Some terminal -> Ok terminal
+      | None -> protocol_error "stdout" "missing terminal result"
+    in
+    let* () =
+      if String.equal init.conversation_id terminal.conversation_id
+      then Ok ()
+      else protocol_error "result" "terminal conversation_id changed"
+    in
+    let* () =
+      match expected_model with
+      | None -> Ok ()
+      | Some expected when String.equal expected init.model -> Ok ()
+      | Some _ -> protocol_error "init" "reported model differs from requested model"
+    in
+    let* () =
+      if String.equal expected_cwd init.cwd
+      then Ok ()
+      else protocol_error "init" "reported cwd differs from configured cwd"
+    in
+    let* resumed =
+      match session_mode with
+      | Start when terminal.num_turns = 1 -> Ok false
+      | Start -> protocol_error "result" "new conversation did not report num_turns=1"
+      | Resume { conversation_id }
+        when String.equal conversation_id init.conversation_id
+             && terminal.num_turns >= 2 -> Ok true
+      | Resume { conversation_id } when not (String.equal conversation_id init.conversation_id) ->
+        protocol_error "init" "resumed conversation_id differs from requested identity"
+      | Resume _ -> protocol_error "result" "resumed conversation did not advance turn count"
+    in
+    if not (String.equal terminal.status "SUCCESS")
+    then Error (Turn_failed terminal.status)
+    else if String.trim terminal.response = ""
+    then protocol_error "result" "successful response must not be empty"
+    else
+      Ok
+        { conversation_id = terminal.conversation_id
+        ; model = init.model
+        ; text = terminal.response
+        ; num_turns = terminal.num_turns
+        ; usage = terminal.usage
+        ; tool_calls = List.length tool_steps
+        ; permission_mode = init.permission_mode
+        ; resumed
+        }
+;;
+
+let validate_config (config : config) ~session_mode ~prompt =
+  let cwd_is_directory =
+    try Sys.file_exists config.cwd && Sys.is_directory config.cwd with
+    | Sys_error _ -> false
+  in
+  if String.trim config.cli_path = ""
+  then Error (Invalid_config "cli_path must not be empty")
+  else if Filename.is_relative config.cwd || String.trim config.cwd = ""
+  then Error (Invalid_config "cwd must be an absolute path")
+  else if not cwd_is_directory
+  then Error (Invalid_config "cwd must name an existing directory")
+  else if not (Process_eio.is_initialized ())
+  then Error (Invalid_config "initialized Process_eio runtime is required")
+  else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
+  then Error (Invalid_config "timeout_s must be positive and finite")
+  else if Option.exists (fun model -> String.trim model = "") config.model
+  then Error (Invalid_config "model must not be empty when provided")
+  else if String.trim prompt = ""
+  then Error (Invalid_config "prompt must not be empty")
+  else
+    match session_mode with
+    | Resume { conversation_id } when String.trim conversation_id = "" ->
+      Error (Invalid_config "resume conversation_id must not be empty")
+    | Start | Resume _ -> Ok ()
+;;
+
+let argv config ~session_mode ~prompt =
+  let base =
+    [ config.cli_path
+    ; "--print"
+    ; prompt
+    ; "--output-format"
+    ; "stream-json"
+    ; "--mode"
+    ; "plan"
+    ; "--sandbox"
+    ; "--disable-slash-commands"
+    ; "--print-timeout"
+    ; Printf.sprintf "%.3fs" config.timeout_s
+    ]
+  in
+  let base =
+    match config.model with
+    | None -> base
+    | Some model -> base @ [ "--model"; model ]
+  in
+  match session_mode with
+  | Start -> base
+  | Resume { conversation_id } -> base @ [ "--conversation"; conversation_id ]
+;;
+
+let status_detail status stderr =
+  let status =
+    match status with
+    | Unix.WEXITED code -> Printf.sprintf "exit %d" code
+    | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
+    | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
+  in
+  match String.trim stderr with
+  | "" -> status
+  | stderr -> status ^ ": " ^ stderr
+;;
+
+let run_turn ?(session_mode = Start) config ~prompt =
+  match validate_config config ~session_mode ~prompt with
+  | Error _ as error -> error
+  | Ok () ->
+    let cwd = Unix.realpath config.cwd in
+    let config = { config with cwd } in
+    (try
+       let status, stdout, stderr =
+         Process_eio.run_argv_with_status_split
+           ~timeout_sec:config.timeout_s
+           ~env:(Runtime_subscription_cli_env.environment ())
+           ~cwd
+           (argv config ~session_mode ~prompt)
+       in
+       match status with
+       | Unix.WEXITED 0 ->
+         parse_output ~expected_model:config.model ~expected_cwd:cwd ~session_mode stdout
+       | Unix.WEXITED 124 -> Error (Timeout config.timeout_s)
+       | _ -> Error (Process_exited (status_detail status stderr))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Spawn_failed (Printexc.to_string exn)))
+;;
+
+module For_testing = struct
+  let parse_output = parse_output
+end

--- a/lib/runtime/runtime_antigravity_cli.mli
+++ b/lib/runtime/runtime_antigravity_cli.mli
@@ -1,0 +1,64 @@
+(** Official Antigravity CLI one-turn boundary.
+
+    Antigravity owns its model/tool loop and subscription credentials. MASC
+    owns argv construction, process lifetime, strict NDJSON decoding, session
+    identity, and measured usage projection. This initial boundary is fixed to
+    [plan + sandbox]; it never passes the dangerous permission-bypass flag. *)
+
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
+type session_mode =
+  | Start
+  | Resume of { conversation_id : string }
+
+type usage =
+  { input_tokens : int
+  ; output_tokens : int
+  ; thinking_tokens : int
+  ; cache_read_tokens : int
+  ; total_tokens : int
+  }
+
+type turn_result =
+  { conversation_id : string
+  ; model : string
+  ; text : string
+  ; num_turns : int
+  ; usage : usage
+  ; tool_calls : int
+  ; permission_mode : string
+  ; resumed : bool
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | Turn_failed of string
+  | Process_exited of string
+  | Timeout of float
+
+val error_to_string : error -> string
+
+val run_turn :
+  ?session_mode:session_mode ->
+  config ->
+  prompt:string ->
+  (turn_result, error) result
+
+module For_testing : sig
+  val parse_output :
+    expected_model:string option ->
+    expected_cwd:string ->
+    session_mode:session_mode ->
+    string ->
+    (turn_result, error) result
+end

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -736,22 +736,6 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~histor
     }
 ;;
 
-let env_key entry =
-  match String.index_opt entry '=' with
-  | Some index -> String.sub entry 0 index
-  | None -> entry
-;;
-
-let subscription_only_environment () =
-  Unix.environment ()
-  |> Array.to_list
-  |> List.filter (fun entry ->
-    match env_key entry with
-    | "OPENAI_API_KEY" | "CODEX_API_KEY" -> false
-    | _ -> true)
-  |> Array.of_list
-;;
-
 let bounded_tail ~limit current addition =
   let combined = current ^ addition in
   let length = String.length combined in
@@ -818,7 +802,7 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort ~thread
     let stderr_tail = ref "" in
     let proc =
       Eio.Process.spawn ~sw mgr ~cwd
-        ~env:(subscription_only_environment ())
+        ~env:(Runtime_subscription_cli_env.environment ())
         ~stdin:stdin_r ~stdout:stdout_w ~stderr:stderr_w
         [ config.cli_path; "app-server"; "--stdio" ]
     in

--- a/lib/runtime/runtime_subscription_cli_env.ml
+++ b/lib/runtime/runtime_subscription_cli_env.ml
@@ -1,0 +1,21 @@
+let env_key entry =
+  match String.index_opt entry '=' with
+  | Some index -> String.sub entry 0 index
+  | None -> entry
+;;
+
+let is_metered_api_credential = function
+  | "OPENAI_API_KEY"
+  | "CODEX_API_KEY"
+  | "GEMINI_API_KEY"
+  | "GOOGLE_API_KEY"
+  | "ANTHROPIC_API_KEY" -> true
+  | _ -> false
+;;
+
+let environment () =
+  Unix.environment ()
+  |> Array.to_list
+  |> List.filter (fun entry -> not (is_metered_api_credential (env_key entry)))
+  |> Array.of_list
+;;

--- a/lib/runtime/runtime_subscription_cli_env.mli
+++ b/lib/runtime/runtime_subscription_cli_env.mli
@@ -1,0 +1,7 @@
+(** Environment projection for official subscription CLIs.
+
+    Metered API credentials are removed so a configured subscription runtime
+    cannot silently fall back to pay-per-token API authentication. *)
+
+val environment : unit -> string array
+val is_metered_api_credential : string -> bool

--- a/test/dune
+++ b/test/dune
@@ -1942,6 +1942,7 @@
 (include stanzas/test_runtime_agent_close_cancel_source.inc)
 
 (include stanzas/test_runtime_codex_app_server.inc)
+(include stanzas/test_runtime_antigravity_cli.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)
 

--- a/test/stanzas/test_runtime_antigravity_cli.inc
+++ b/test/stanzas/test_runtime_antigravity_cli.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_antigravity_cli)
+ (modules test_runtime_antigravity_cli)
+ (libraries alcotest masc.runtime masc.masc_process eio eio_main unix))

--- a/test/test_runtime_antigravity_cli.ml
+++ b/test/test_runtime_antigravity_cli.ml
@@ -1,0 +1,276 @@
+open Alcotest
+
+let conversation_id = "9971bfe0-4e21-40f9-8b5d-715ec5096965"
+
+let init_line ~cwd =
+  Printf.sprintf
+    {|{"event":"init","conversation_id":%S,"init":{"model":"gemini-3.6-flash-low","cwd":%S,"tools":["run_command","write_to_file"],"permission_mode":"always-proceed"}}|}
+    conversation_id
+    cwd
+;;
+
+let user_step =
+  Printf.sprintf
+    {|{"event":"step_update","step_update":{"conversation_id":%S,"step_index":0,"state":"DONE","step_type":"user_input"}}|}
+    conversation_id
+;;
+
+let tool_step =
+  Printf.sprintf
+    {|{"event":"step_update","step_update":{"conversation_id":%S,"step_index":1,"state":"DONE","step_type":"tool","tool_name":"run_command","usage":{"input_tokens":10,"output_tokens":2,"thinking_tokens":0,"cache_read_tokens":4,"total_tokens":12}}}|}
+    conversation_id
+;;
+
+let result_line ?(status = "SUCCESS") ?(turns = 1) () =
+  Printf.sprintf
+    {|{"event":"result","result":{"conversation_id":%S,"status":%S,"response":"MASC_AGY_OK\n","duration_seconds":1.25,"num_turns":%d,"usage":{"input_tokens":20,"output_tokens":3,"thinking_tokens":0,"cache_read_tokens":5,"total_tokens":23}}}|}
+    conversation_id
+    status
+    turns
+;;
+
+let output ~cwd ?status ?turns () =
+  String.concat "\n"
+    [ init_line ~cwd; user_step; tool_step; result_line ?status ?turns (); "" ]
+;;
+
+let parse ~cwd ?(session_mode = Runtime_antigravity_cli.Start) value =
+  Runtime_antigravity_cli.For_testing.parse_output
+    ~expected_model:(Some "gemini-3.6-flash-low")
+    ~expected_cwd:cwd
+    ~session_mode
+    value
+;;
+
+let test_strict_success_projection () =
+  let result = parse ~cwd:"/tmp" (output ~cwd:"/tmp" ()) |> Result.get_ok in
+  check string "conversation" conversation_id result.conversation_id;
+  check string "model" "gemini-3.6-flash-low" result.model;
+  check string "response" "MASC_AGY_OK\n" result.text;
+  check int "turns" 1 result.num_turns;
+  check int "tool calls" 1 result.tool_calls;
+  check int "input usage" 20 result.usage.input_tokens;
+  check int "output usage" 3 result.usage.output_tokens;
+  check int "cache usage" 5 result.usage.cache_read_tokens;
+  check bool "start is not resumed" false result.resumed
+;;
+
+let test_resume_requires_exact_identity () =
+  let result =
+    parse
+      ~cwd:"/tmp"
+      ~session_mode:(Runtime_antigravity_cli.Resume { conversation_id })
+      (output ~cwd:"/tmp" ~turns:2 ())
+    |> Result.get_ok
+  in
+  check bool "resumed" true result.resumed;
+  match
+    parse
+      ~cwd:"/tmp"
+      ~session_mode:
+        (Runtime_antigravity_cli.Resume { conversation_id = "different" })
+      (output ~cwd:"/tmp" ~turns:2 ())
+  with
+  | Error (Runtime_antigravity_cli.Protocol_error _) -> ()
+  | Error error -> fail (Runtime_antigravity_cli.error_to_string error)
+  | Ok _ -> fail "conversation identity mismatch was accepted"
+;;
+
+let test_duplicate_keys_fail_closed () =
+  let duplicate =
+    String.concat "\n"
+      [ Printf.sprintf
+          {|{"event":"init","event":"init","conversation_id":%S,"init":{"model":"gemini-3.6-flash-low","cwd":"/tmp","tools":[],"permission_mode":"always-proceed"}}|}
+          conversation_id
+      ; result_line ()
+      ]
+  in
+  match parse ~cwd:"/tmp" duplicate with
+  | Error (Runtime_antigravity_cli.Protocol_error _) -> ()
+  | Error error -> fail (Runtime_antigravity_cli.error_to_string error)
+  | Ok _ -> fail "duplicate JSON keys were accepted"
+;;
+
+let test_failed_status_is_not_completion () =
+  match parse ~cwd:"/tmp" (output ~cwd:"/tmp" ~status:"FAILED" ()) with
+  | Error (Runtime_antigravity_cli.Turn_failed "FAILED") -> ()
+  | Error error -> fail (Runtime_antigravity_cli.error_to_string error)
+  | Ok _ -> fail "failed Antigravity result was accepted"
+;;
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let temp_workspace () =
+  let path = Filename.temp_file "masc-agy-runtime-" "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let cleanup_tree root =
+  let rec remove path =
+    if Sys.file_exists path
+    then if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try remove root with
+  | _ -> ()
+;;
+
+let fixture_script ~workspace =
+  let path = Filename.temp_file "masc-agy-runtime-fixture-" ".sh" in
+  let output_channel = open_out_bin path in
+  let emit line =
+    output_string output_channel
+      ("printf '%s\\n' " ^ shell_quote line ^ "\n")
+  in
+  output_string output_channel "#!/bin/sh\n";
+  output_string output_channel
+    ("test \"$PWD\" = " ^ shell_quote workspace
+     ^ " || { printf 'pwd=%s expected=%s\\n' \"$PWD\" "
+     ^ shell_quote workspace ^ " >&2; exit 71; }\n");
+  output_string output_channel
+    "test -z \"$OPENAI_API_KEY$CODEX_API_KEY$GEMINI_API_KEY$GOOGLE_API_KEY$ANTHROPIC_API_KEY\" || exit 72\n";
+  output_string output_channel "conversation='";
+  output_string output_channel conversation_id;
+  output_string output_channel "'\nturns=1\n";
+  output_string output_channel "mode=\nsandbox=\ndangerous=\n";
+  output_string output_channel
+    "while test \"$#\" -gt 0; do case \"$1\" in --conversation) shift; conversation=\"$1\"; turns=2 ;; --mode) shift; mode=\"$1\" ;; --sandbox) sandbox=1 ;; --dangerously-skip-permissions) dangerous=1 ;; esac; shift; done\n";
+  output_string output_channel
+    "test \"$mode\" = plan && test \"$sandbox\" = 1 && test -z \"$dangerous\" || exit 73\n";
+  emit (init_line ~cwd:workspace);
+  emit user_step;
+  output_string output_channel
+    ("printf '%s\\n' \"{\\\"event\\\":\\\"result\\\",\\\"result\\\":{\\\"conversation_id\\\":\\\"$conversation\\\",\\\"status\\\":\\\"SUCCESS\\\",\\\"response\\\":\\\"MASC_AGY_PROCESS_OK\\\\n\\\",\\\"duration_seconds\\\":1.0,\\\"num_turns\\\":$turns,\\\"usage\\\":{\\\"input_tokens\\\":7,\\\"output_tokens\\\":2,\\\"thinking_tokens\\\":0,\\\"cache_read_tokens\\\":3,\\\"total_tokens\\\":9}}}\"\n");
+  close_out output_channel;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let with_api_key_environment f =
+  let keys =
+    [ "OPENAI_API_KEY"; "CODEX_API_KEY"; "GEMINI_API_KEY"; "GOOGLE_API_KEY"
+    ; "ANTHROPIC_API_KEY"
+    ]
+  in
+  let previous = List.map (fun key -> key, Sys.getenv_opt key) keys in
+  List.iter (fun key -> Unix.putenv key "METERED_KEY_MUST_NOT_REACH_CHILD") keys;
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter
+        (fun (key, value) -> Unix.putenv key (Option.value value ~default:""))
+        previous)
+    f
+;;
+
+let with_initialized_process_eio f =
+  Eio_main.run (fun env ->
+    Process_eio.init
+      ~cwd_default:Eio.Path.(Eio.Stdenv.fs env / ".")
+      ~proc_mgr:(Eio.Stdenv.process_mgr env)
+      ~clock:(Eio.Stdenv.clock env);
+    Fun.protect ~finally:Process_eio.reset_for_testing f)
+;;
+
+let test_process_boundary_start_and_resume () =
+  let workspace = temp_workspace () |> Unix.realpath in
+  let script = fixture_script ~workspace in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove script; cleanup_tree workspace)
+    (fun () ->
+       with_api_key_environment (fun () ->
+         with_initialized_process_eio (fun () ->
+                let config : Runtime_antigravity_cli.config =
+                  { cli_path = script
+                  ; cwd = workspace
+                  ; model = Some "gemini-3.6-flash-low"
+                  ; timeout_s = 5.0
+                  }
+                in
+                let expect_ok = function
+                  | Ok value -> value
+                  | Error error ->
+                    fail (Runtime_antigravity_cli.error_to_string error)
+                in
+                let first =
+                  Runtime_antigravity_cli.run_turn config ~prompt:"fixture start"
+                  |> expect_ok
+                in
+                check string
+                  "process response"
+                  "MASC_AGY_PROCESS_OK\n"
+                  first.text;
+                check bool "process start" false first.resumed;
+                let resumed =
+                  Runtime_antigravity_cli.run_turn
+                    ~session_mode:(Resume { conversation_id })
+                    config
+                    ~prompt:"fixture resume"
+                  |> expect_ok
+                in
+                check bool "process resume" true resumed.resumed;
+                check int "process turn count" 2 resumed.num_turns)))
+;;
+
+let test_live_subscription_client () =
+  if Sys.getenv_opt "MASC_ANTIGRAVITY_CLI_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let cli_path =
+      match Sys.getenv_opt "MASC_ANTIGRAVITY_CLI_PATH" with
+      | Some path when String.trim path <> "" -> path
+      | _ -> fail "MASC_ANTIGRAVITY_CLI_PATH is required for the live test"
+    in
+    let cwd = Sys.getcwd () |> Unix.realpath in
+    with_initialized_process_eio (fun () ->
+      let config : Runtime_antigravity_cli.config =
+        { cli_path
+        ; cwd
+        ; model = Some "gemini-3.6-flash-low"
+        ; timeout_s = 60.0
+        }
+      in
+      match
+        Runtime_antigravity_cli.run_turn
+          config
+          ~prompt:"Reply exactly MASC_AGY_NATIVE_OK and nothing else."
+      with
+      | Error error -> fail (Runtime_antigravity_cli.error_to_string error)
+      | Ok result ->
+        check string "live response" "MASC_AGY_NATIVE_OK" (String.trim result.text);
+        check bool "measured input usage" true (result.usage.input_tokens > 0);
+        check bool "measured output usage" true (result.usage.output_tokens > 0))
+;;
+
+let test_subscription_environment_key_set_is_exact () =
+  List.iter
+    (fun key ->
+      check bool key true
+        (Runtime_subscription_cli_env.is_metered_api_credential key))
+    [ "OPENAI_API_KEY"; "CODEX_API_KEY"; "GEMINI_API_KEY"; "GOOGLE_API_KEY"
+    ; "ANTHROPIC_API_KEY"
+    ];
+  check bool "unrelated env survives" false
+    (Runtime_subscription_cli_env.is_metered_api_credential "PATH")
+;;
+
+let () =
+  run "runtime antigravity CLI"
+    [ ( "typed stream-json boundary"
+      , [ test_case "strict success projection" `Quick test_strict_success_projection
+        ; test_case "resume identity" `Quick test_resume_requires_exact_identity
+        ; test_case "duplicate keys" `Quick test_duplicate_keys_fail_closed
+        ; test_case "failed status" `Quick test_failed_status_is_not_completion
+        ; test_case "process start and resume" `Quick test_process_boundary_start_and_resume
+        ; test_case "subscription env key set" `Quick test_subscription_environment_key_set_is_exact
+        ] )
+    ; ( "live subscription"
+      , [ test_case "official Antigravity CLI" `Slow test_live_subscription_client ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add a native typed client for the official `agy --output-format stream-json` boundary
- pin the initial execution contract to `--mode plan --sandbox`; never pass `--dangerously-skip-permissions`
- decode init/step/result NDJSON fail-closed, including exact conversation resume identity and measured input/output/thinking/cache usage
- force subscription auth by removing OpenAI, Codex, Gemini, Google, and Anthropic API-key variables from official-client subprocesses
- share that subscription-only environment with the Codex app-server client

## Ownership boundary
Antigravity owns its built-in model/tool loop. Live evidence shows headless plan mode reports `permission_mode=always-proceed` and can execute sandboxed tools, so this PR does not claim MASC Gate ownership or project MASC tools. Keeper integration will surface that owner explicitly.

## Stack
- base: #27731 (`feat/codex-session-resume-20260809`)
- runtime transport only; Keeper durable session and dashboard producer follow separately

## Verification
- `MASC_ANTIGRAVITY_CLI_LIVE=1 MASC_ANTIGRAVITY_CLI_PATH=/Users/dancer/.local/bin/agy dune exec --root . ./test/test_runtime_antigravity_cli.exe` (7/7, including official subscription live turn)
- `dune build --root . lib/runtime/masc_runtime.cmxa`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/audit-ci-test-targets.sh`
- `git diff --check`

## Live facts
- live native response: `MASC_AGY_NATIVE_OK`
- model: `gemini-3.6-flash-low`
- usage fields were provider-reported and positive; no usage is inferred from prompt length
- a separate nonzero-thinking probe confirmed `thinking_tokens` is a measured sub-field while `total_tokens = input_tokens + output_tokens`