### PR TITLE
feat(runtime): dispatch Antigravity subscription turns

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -96,6 +96,30 @@ candidates = [
 sangsu = "codex_subscription.gpt-5.3-codex-spark"
 ```
 
+An Antigravity subscription runtime follows the same no-API-key rule. Its
+official CLI owns login, conversation state, and built-in tool execution.
+MASC currently fixes this boundary to `plan` + sandbox mode and records the
+reported permission mode, tool-call count, and token usage; those built-in
+tools are not MASC Gate executions.
+
+```toml
+[providers.antigravity_subscription]
+display-name = "Antigravity Gemini Subscription"
+protocol = "antigravity-cli"
+command = "agy"
+is-non-interactive = true
+
+[models."gemini-3.6-flash-low"]
+api-name = "gemini-3.6-flash-low"
+max-context = 128000
+tools-support = true
+
+[antigravity_subscription."gemini-3.6-flash-low"]
+
+[runtime.assignments]
+sangsu = "antigravity_subscription.gemini-3.6-flash-low"
+```
+
 The fallback candidate must already be a valid binding in the same file.
 There is intentionally no `[providers.codex_subscription.credentials]` table.
 

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -1,0 +1,387 @@
+open Result.Syntax
+
+let config_error ~field detail =
+  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })
+;;
+
+let internal_error detail = Agent_sdk.Error.Internal detail
+
+let text_of_blocks ~field blocks =
+  let rec loop texts = function
+    | [] -> Ok (String.concat "\n" (List.rev texts))
+    | Agent_sdk.Types.Text text :: rest -> loop (text :: texts) rest
+    | _ :: _ ->
+      Error
+        (config_error
+           ~field
+           "antigravity-cli Keeper projection currently admits text blocks only")
+  in
+  loop [] blocks
+;;
+
+let user_message text : Agent_sdk.Types.message =
+  { role = User
+  ; content = [ Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let hook_error ~hook_name ~stage detail =
+  internal_error
+    (Printf.sprintf
+       "Antigravity runtime %s hook failed at %s: %s"
+       hook_name
+       (Agent_sdk.Hooks.hook_stage_to_string stage)
+       detail)
+;;
+
+let illegal_hook_decision ~hook_name decision =
+  config_error
+    ~field:"hooks"
+    (Printf.sprintf
+       "Antigravity runtime %s hook returned unsupported decision %s"
+       hook_name
+       (Agent_sdk.Hooks.decision_kind_to_string
+          (Agent_sdk.Hooks.classify_decision decision)))
+;;
+
+let invoke_turn_hook ~keeper_name ~turn_count ~hook_name hook event =
+  Agent_sdk.Agent_tools.invoke_hook
+    ~tracer:Agent_sdk.Tracing.null
+    ~agent_name:keeper_name
+    ~turn_count
+    ~hook_name
+    hook
+    event
+;;
+
+let render_message (message : Agent_sdk.Types.message) =
+  let* text = text_of_blocks ~field:"initial_messages" message.content in
+  let role =
+    match message.role with
+    | System -> "SYSTEM"
+    | User -> "USER"
+    | Assistant -> "ASSISTANT"
+    | Tool -> "TOOL"
+  in
+  if message.role = Tool
+  then
+    Error
+      (config_error
+         ~field:"initial_messages"
+         "antigravity-cli history projection does not admit OAS tool messages")
+  else Ok (Printf.sprintf "%s:\n%s" role text)
+;;
+
+let render_messages messages =
+  let rec loop acc = function
+    | [] -> Ok (String.concat "\n\n" (List.rev acc))
+    | message :: rest ->
+      let* rendered = render_message message in
+      loop (rendered :: acc) rest
+  in
+  loop [] messages
+;;
+
+let prepare_prompt ~keeper_name ~turn_count ~is_resume ~goal ~system_prompt
+    ~initial_messages ~model_input_projection ~hooks =
+  let input_messages =
+    if is_resume then [ user_message goal ] else initial_messages @ [ user_message goal ]
+  in
+  let before_turn =
+    invoke_turn_hook
+      ~keeper_name
+      ~turn_count
+      ~hook_name:"before_turn"
+      hooks.Agent_sdk.Hooks.before_turn
+      (Agent_sdk.Hooks.BeforeTurn { turn = turn_count; messages = input_messages })
+  in
+  let* messages =
+    match before_turn with
+    | Continue -> Ok input_messages
+    | Nudge text -> Ok (input_messages @ [ user_message text ])
+    | HookFailed { stage; detail } -> Error (hook_error ~hook_name:"before_turn" ~stage detail)
+    | decision -> Error (illegal_hook_decision ~hook_name:"before_turn" decision)
+  in
+  let before_turn_params =
+    invoke_turn_hook
+      ~keeper_name
+      ~turn_count
+      ~hook_name:"before_turn_params"
+      hooks.before_turn_params
+      (Agent_sdk.Hooks.BeforeTurnParams
+         { turn = turn_count
+         ; messages
+         ; last_tool_results = []
+         ; current_params = Agent_sdk.Hooks.default_turn_params
+         ; reasoning = Agent_sdk.Hooks.empty_reasoning_summary
+         })
+  in
+  let* params =
+    match before_turn_params with
+    | Continue -> Ok Agent_sdk.Hooks.default_turn_params
+    | AdjustParams params -> Ok params
+    | HookFailed { stage; detail } ->
+      Error (hook_error ~hook_name:"before_turn_params" ~stage detail)
+    | decision -> Error (illegal_hook_decision ~hook_name:"before_turn_params" decision)
+  in
+  let unsupported field value =
+    match value with
+    | None -> Ok ()
+    | Some _ ->
+      Error
+        (config_error
+           ~field
+           "antigravity-cli does not project this OAS turn parameter; select an exact Antigravity model id")
+  in
+  let* () = unsupported "temperature" params.temperature in
+  let* () = unsupported "thinking_budget" params.thinking_budget in
+  let* () = unsupported "reasoning_effort" params.reasoning_effort in
+  let* () = unsupported "enable_thinking" params.enable_thinking in
+  let* () = unsupported "preserve_thinking" params.preserve_thinking in
+  let* () = unsupported "tool_choice" params.tool_choice in
+  let* messages =
+    match model_input_projection with
+    | None -> Ok messages
+    | Some project ->
+      (try
+         match project messages with
+         | Ok projected -> Ok projected
+         | Error detail -> Error (config_error ~field:"model_input_projection" detail)
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn ->
+         Error
+           (internal_error
+              ("Antigravity runtime model input projection raised: "
+               ^ Printexc.to_string exn)))
+  in
+  let* rendered = render_messages messages in
+  let system_prompt =
+    Option.value params.system_prompt_override ~default:system_prompt
+  in
+  let system_context =
+    [ (if is_resume then None else String_util.trim_to_option system_prompt)
+    ; Option.bind params.extra_system_context String_util.trim_to_option
+    ]
+    |> List.filter_map Fun.id
+  in
+  Ok (String.concat "\n\n" (system_context @ [ rendered ]))
+;;
+
+let antigravity_error_to_sdk_error = function
+  | Runtime_antigravity_cli.Invalid_config detail ->
+    config_error ~field:"antigravity_cli" detail
+  | error -> Agent_sdk.Error.Internal (Runtime_antigravity_cli.error_to_string error)
+;;
+
+let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
+    ~initial_messages ~model_input_projection ~hooks
+    ~(config : Runtime_execution.antigravity_cli) =
+  let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
+  let* goal =
+    match goal_blocks with
+    | None -> Ok goal
+    | Some blocks -> text_of_blocks ~field:"goal_blocks" blocks
+  in
+  let* stored_session =
+    match Keeper_antigravity_session_store.load ~base_path ~keeper_name with
+    | Ok session -> Ok session
+    | Error detail ->
+      Error (internal_error ("Antigravity session binding load failed: " ^ detail))
+  in
+  let* session_mode, turn_count =
+    match stored_session with
+    | None -> Ok (Runtime_antigravity_cli.Start, 1)
+    | Some session when not (String.equal session.runtime_id runtime_id) ->
+      Error
+        (config_error
+           ~field:"antigravity_session.runtime_id"
+           (Printf.sprintf
+              "stored runtime %S does not match selected runtime %S"
+              session.runtime_id
+              runtime_id))
+    | Some { phase = Settled { conversation_id }; turn_count; _ }
+      when turn_count < Int.max_int ->
+      Ok (Runtime_antigravity_cli.Resume { conversation_id }, turn_count + 1)
+    | Some { phase = Settled _; _ } ->
+      Error
+        (config_error
+           ~field:"antigravity_session.turn_count"
+           "stored Antigravity session turn count cannot be incremented")
+    | Some { phase = Claimed _; _ } ->
+      Error
+        (config_error
+           ~field:"antigravity_session.phase"
+           "stored Antigravity session has an unsettled claim; refusing duplicate execution")
+  in
+  let is_resume =
+    match session_mode with
+    | Runtime_antigravity_cli.Start -> false
+    | Runtime_antigravity_cli.Resume _ -> true
+  in
+  let* prompt =
+    prepare_prompt
+      ~keeper_name
+      ~turn_count
+      ~is_resume
+      ~goal
+      ~system_prompt
+      ~initial_messages
+      ~model_input_projection
+      ~hooks
+  in
+  let client_config : Runtime_antigravity_cli.config =
+    { cli_path = config.cli_path
+    ; cwd = base_path
+    ; model = config.model
+    ; timeout_s = config.timeout_s
+    }
+  in
+  let* () =
+    match Runtime_antigravity_cli.validate_run ~session_mode client_config ~prompt with
+    | Ok () -> Ok ()
+    | Error error -> Error (antigravity_error_to_sdk_error error)
+  in
+  let* claimed =
+    match
+      Keeper_antigravity_session_store.claim
+        ~base_path
+        ~keeper_name
+        ~expected:stored_session
+        ~runtime_id
+        ~updated_at:(Time_compat.now ())
+    with
+    | Ok session -> Ok session
+    | Error detail -> Error (internal_error ("Antigravity session claim failed: " ^ detail))
+  in
+  let started_at = Time_compat.now () in
+  match Runtime_antigravity_cli.run_turn ~session_mode client_config ~prompt with
+  | Error error -> Error (antigravity_error_to_sdk_error error)
+  | Ok turn ->
+    let* () =
+      if turn.num_turns = turn_count
+      then Ok ()
+      else
+        Error
+          (internal_error
+             (Printf.sprintf
+                "Antigravity CLI reported turn count %d but durable session expected %d"
+                turn.num_turns
+                turn_count))
+    in
+    let latency_ms = Int.of_float ((Time_compat.now () -. started_at) *. 1000.0) in
+    let usage : Agent_sdk.Types.api_usage =
+      { input_tokens = turn.usage.input_tokens
+      ; output_tokens = turn.usage.output_tokens
+      ; cache_creation_input_tokens = 0
+      ; cache_read_input_tokens = turn.usage.cache_read_tokens
+      ; cost_usd = None
+      }
+    in
+    let response =
+      { Agent_sdk.Types.id =
+          Printf.sprintf "%s:%d" turn.conversation_id turn.num_turns
+      ; model = turn.model
+      ; stop_reason = EndTurn
+      ; content = [ Text turn.text ]
+      ; usage = Some usage
+      ; telemetry =
+          Some
+            { Agent_sdk.Types.default_inference_telemetry with
+              request_latency_ms = Some latency_ms
+            ; canonical_model_id = Some turn.model
+            }
+      }
+    in
+    let after_turn =
+      invoke_turn_hook
+        ~keeper_name
+        ~turn_count
+        ~hook_name:"after_turn"
+        hooks.after_turn
+        (Agent_sdk.Hooks.AfterTurn { turn = turn_count; response })
+    in
+    let* () =
+      match after_turn with
+      | Continue -> Ok ()
+      | HookFailed { stage; detail } ->
+        Error (hook_error ~hook_name:"after_turn" ~stage detail)
+      | decision -> Error (illegal_hook_decision ~hook_name:"after_turn" decision)
+    in
+    let on_stop =
+      invoke_turn_hook
+        ~keeper_name
+        ~turn_count
+        ~hook_name:"on_stop"
+        hooks.on_stop
+        (Agent_sdk.Hooks.OnStop { reason = response.stop_reason; response })
+    in
+    let* () =
+      match on_stop with
+      | Continue -> Ok ()
+      | HookFailed { stage; detail } ->
+        Error (hook_error ~hook_name:"on_stop" ~stage detail)
+      | decision -> Error (illegal_hook_decision ~hook_name:"on_stop" decision)
+    in
+    let* _settled =
+      match
+        Keeper_antigravity_session_store.settle
+          ~base_path
+          ~keeper_name
+          ~expected:claimed
+          ~conversation_id:turn.conversation_id
+          ~usage:turn.usage
+          ~updated_at:(Time_compat.now ())
+      with
+      | Ok session -> Ok session
+      | Error detail ->
+        Error (internal_error ("Antigravity session settlement failed: " ^ detail))
+    in
+    let capture, _metrics =
+      Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
+    in
+    Runtime_observation.record_attempt_terminal
+      capture
+      ~model_id:turn.model
+      ~latency_ms:(Some latency_ms)
+      ~error:None;
+    let runtime_observation =
+      Runtime_observation.runtime_observation_with_metrics
+        ~runtime_id
+        ~strategy:"official_client_runtime"
+        ~configured_labels:
+          [ "antigravity_cli"
+          ; "execution_mode=plan_sandbox"
+          ; "tool_owner=official_client"
+          ; "masc_tool_hooks=unavailable"
+          ; Printf.sprintf "permission_mode=%s" turn.permission_mode
+          ; Printf.sprintf "tool_calls=%d" turn.tool_calls
+          ; Printf.sprintf "resumed=%b" turn.resumed
+          ; Printf.sprintf "turn_count=%d" turn_count
+          ; Printf.sprintf "input_tokens=%d" turn.usage.input_tokens
+          ; Printf.sprintf "output_tokens=%d" turn.usage.output_tokens
+          ; Printf.sprintf "thinking_tokens=%d" turn.usage.thinking_tokens
+          ; Printf.sprintf "cache_read_tokens=%d" turn.usage.cache_read_tokens
+          ; Printf.sprintf "total_tokens=%d" turn.usage.total_tokens
+          ]
+        ~candidate_count:1
+        ~selected_model_raw:(Some turn.model)
+        ~capture
+        ~attempt_details_source:"antigravity_cli"
+        ~oas_internal_runtime_allowed:false
+        ()
+    in
+    Ok
+      { Runtime_agent.response
+      ; checkpoint = None
+      ; session_id = turn.conversation_id
+      ; turns = turn_count
+      ; trace_ref = None
+      ; run_validation = None
+      ; runtime_observation = Some runtime_observation
+      ; stop_reason = Completed
+      }
+;;

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -1,0 +1,17 @@
+(** Keeper projection for the official Antigravity CLI turn runtime.
+
+    Antigravity owns its built-in tool loop. This boundary deliberately does
+    not project MASC tools, Gate callbacks, or OAS checkpoints into that loop. *)
+
+val run :
+  runtime_id:string ->
+  keeper_name:string ->
+  base_path:string ->
+  goal:string ->
+  goal_blocks:Agent_sdk.Types.content_block list option ->
+  system_prompt:string ->
+  initial_messages:Agent_sdk.Types.message list ->
+  model_input_projection:Agent_sdk.Agent.model_input_projection option ->
+  hooks:Agent_sdk.Hooks.hooks option ->
+  config:Runtime_execution.antigravity_cli ->
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_antigravity_session_store.ml
+++ b/lib/keeper/keeper_antigravity_session_store.ml
@@ -1,0 +1,306 @@
+type phase =
+  | Claimed of { previous_conversation_id : string option }
+  | Settled of { conversation_id : string }
+
+type t =
+  { runtime_id : string
+  ; phase : phase
+  ; turn_count : int
+  ; last_usage : Runtime_antigravity_cli.usage option
+  ; updated_at : float
+  }
+
+let ( let* ) = Result.bind
+let schema = "masc.keeper.antigravity-session.v1"
+let filename = "antigravity-session.json"
+let state_dirname = "official-client-runtime"
+let lock_filename = "antigravity-session.lock"
+
+let state_dir ~base_path ~keeper_name =
+  if not (Safe_identifier.is_portable_name keeper_name)
+  then Error (Printf.sprintf "invalid Antigravity session Keeper name %S" keeper_name)
+  else
+    Ok
+      (Filename.concat
+         (Filename.concat
+            (Common.keepers_runtime_dir_of_base ~base_path)
+            keeper_name)
+         state_dirname)
+;;
+
+let path ~base_path ~keeper_name =
+  Result.map
+    (fun directory -> Filename.concat directory filename)
+    (state_dir ~base_path ~keeper_name)
+;;
+
+let non_empty field value =
+  if String.trim value = ""
+  then Error (Printf.sprintf "Antigravity session %s must not be empty" field)
+  else Ok ()
+;;
+
+let validate_usage (usage : Runtime_antigravity_cli.usage) =
+  if
+    usage.input_tokens < 0
+    || usage.output_tokens < 0
+    || usage.thinking_tokens < 0
+    || usage.cache_read_tokens < 0
+    || usage.total_tokens < 0
+  then Error "Antigravity session usage must be non-negative"
+  else if usage.input_tokens > Int.max_int - usage.output_tokens
+  then Error "Antigravity session usage total overflowed"
+  else if usage.total_tokens <> usage.input_tokens + usage.output_tokens
+  then Error "Antigravity session usage total is inconsistent"
+  else Ok ()
+;;
+
+let validate_phase = function
+  | Claimed { previous_conversation_id = None } -> Ok ()
+  | Claimed { previous_conversation_id = Some conversation_id }
+  | Settled { conversation_id } -> non_empty "conversation_id" conversation_id
+;;
+
+let validate state =
+  let* () = non_empty "runtime_id" state.runtime_id in
+  let* () = validate_phase state.phase in
+  let* () =
+    match state.last_usage with
+    | None -> Ok ()
+    | Some usage -> validate_usage usage
+  in
+  if state.turn_count <= 0
+  then Error "Antigravity session turn_count must be positive"
+  else if not (Float.is_finite state.updated_at)
+  then Error "Antigravity session updated_at must be finite"
+  else Ok ()
+;;
+
+let phase_to_yojson = function
+  | Claimed { previous_conversation_id } ->
+    `Assoc
+      [ "kind", `String "claimed"
+      ; ( "previous_conversation_id"
+        , Option.fold
+            ~none:`Null
+            ~some:(fun conversation_id -> `String conversation_id)
+            previous_conversation_id )
+      ]
+  | Settled { conversation_id } ->
+    `Assoc
+      [ "kind", `String "settled"
+      ; "conversation_id", `String conversation_id
+      ]
+;;
+
+let phase_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "kind", `String "claimed"; "previous_conversation_id", `Null ] ->
+       Ok (Claimed { previous_conversation_id = None })
+     | [ "kind", `String "claimed"
+       ; "previous_conversation_id", `String conversation_id
+       ] ->
+       Ok (Claimed { previous_conversation_id = Some conversation_id })
+     | [ "conversation_id", `String conversation_id
+       ; "kind", `String "settled"
+       ] -> Ok (Settled { conversation_id })
+     | _ -> Error "Antigravity session phase fields are not exact")
+  | _ -> Error "Antigravity session phase must be a JSON object"
+;;
+
+let usage_to_yojson (usage : Runtime_antigravity_cli.usage) =
+  `Assoc
+    [ "cache_read_tokens", `Int usage.cache_read_tokens
+    ; "input_tokens", `Int usage.input_tokens
+    ; "output_tokens", `Int usage.output_tokens
+    ; "thinking_tokens", `Int usage.thinking_tokens
+    ; "total_tokens", `Int usage.total_tokens
+    ]
+;;
+
+let usage_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "cache_read_tokens", `Int cache_read_tokens
+       ; "input_tokens", `Int input_tokens
+       ; "output_tokens", `Int output_tokens
+       ; "thinking_tokens", `Int thinking_tokens
+       ; "total_tokens", `Int total_tokens
+       ] ->
+       let usage : Runtime_antigravity_cli.usage =
+         { input_tokens
+         ; output_tokens
+         ; thinking_tokens
+         ; cache_read_tokens
+         ; total_tokens
+         }
+       in
+       let* () = validate_usage usage in
+       Ok usage
+     | _ -> Error "Antigravity session usage fields are not exact")
+  | _ -> Error "Antigravity session usage must be a JSON object"
+;;
+
+let to_yojson state =
+  `Assoc
+    [ ( "last_usage"
+      , Option.fold ~none:`Null ~some:usage_to_yojson state.last_usage )
+    ; "phase", phase_to_yojson state.phase
+    ; "runtime_id", `String state.runtime_id
+    ; "schema", `String schema
+    ; "turn_count", `Int state.turn_count
+    ; "updated_at", `Float state.updated_at
+    ]
+;;
+
+let of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "last_usage", last_usage_json
+       ; "phase", phase_json
+       ; "runtime_id", `String runtime_id
+       ; "schema", `String encoded_schema
+       ; "turn_count", `Int turn_count
+       ; "updated_at", `Float updated_at
+       ] ->
+       if encoded_schema <> schema
+       then Error "unsupported Antigravity session schema"
+       else
+         let* phase = phase_of_yojson phase_json in
+         let* last_usage =
+           match last_usage_json with
+           | `Null -> Ok None
+           | json -> Result.map Option.some (usage_of_yojson json)
+         in
+         let state = { runtime_id; phase; turn_count; last_usage; updated_at } in
+         let* () = validate state in
+         Ok state
+     | _ -> Error "Antigravity session fields are not exact")
+  | _ -> Error "Antigravity session must be a JSON object"
+;;
+
+let equal left right =
+  String.equal left.runtime_id right.runtime_id
+  && left.phase = right.phase
+  && Int.equal left.turn_count right.turn_count
+  && left.last_usage = right.last_usage
+  && Float.equal left.updated_at right.updated_at
+;;
+
+let load_path state_path =
+  if not (Fs_compat.file_exists state_path)
+  then Ok None
+  else
+    let* json = Safe_ops.read_json_file_safe state_path in
+    let* state = of_yojson json in
+    Ok (Some state)
+;;
+
+let load ~base_path ~keeper_name =
+  let* state_path = path ~base_path ~keeper_name in
+  load_path state_path
+;;
+
+let save_path ~state_dir state =
+  let* () = validate state in
+  let state_path = Filename.concat state_dir filename in
+  let* () =
+    match
+      Keeper_fs.save_json_durable_atomic
+        ~ownership_root:state_dir
+        ~pretty:false
+        state_path
+        (to_yojson state)
+    with
+    | Ok () -> Ok ()
+    | Error error -> Error (Keeper_fs.durable_write_error_to_string error)
+  in
+  let* persisted = load_path state_path in
+  match persisted with
+  | Some persisted when equal persisted state -> Ok ()
+  | Some _ -> Error "Antigravity session changed after durable write"
+  | None -> Error "Antigravity session missing after durable write"
+;;
+
+let prepare_state_dir ~base_path ~keeper_name =
+  let* directory = state_dir ~base_path ~keeper_name in
+  try
+    let (_ : string) = Keeper_fs.ensure_dir directory in
+    Ok directory
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let with_store_lock ~base_path ~keeper_name f =
+  let* directory = prepare_state_dir ~base_path ~keeper_name in
+  match
+    File_lock_eio.with_durable_lock
+      ~lock_path:(Filename.concat directory lock_filename)
+      (fun () -> f directory)
+  with
+  | Ok result -> result
+  | Error error -> Error (File_lock_eio.durable_lock_error_to_string error)
+;;
+
+let transition ~base_path ~keeper_name ~expected next =
+  let* () = validate next in
+  with_store_lock ~base_path ~keeper_name (fun directory ->
+    let* current = load_path (Filename.concat directory filename) in
+    if Option.equal equal current expected
+    then save_path ~state_dir:directory next |> Result.map (fun () -> next)
+    else Error "Antigravity session changed before durable transition")
+;;
+
+let claim ~base_path ~keeper_name ~expected ~runtime_id ~updated_at =
+  let* () =
+    match expected with
+    | Some state when not (String.equal state.runtime_id runtime_id) ->
+      Error "Antigravity session runtime_id cannot change during claim"
+    | None | Some _ -> Ok ()
+  in
+  let* previous_conversation_id, turn_count, last_usage =
+    match expected with
+    | None -> Ok (None, 1, None)
+    | Some { phase = Settled { conversation_id }; turn_count; last_usage; _ }
+      when turn_count < Int.max_int ->
+      Ok (Some conversation_id, turn_count + 1, last_usage)
+    | Some { phase = Settled _; _ } ->
+      Error "settled Antigravity session turn count cannot be incremented"
+    | Some { phase = Claimed _; _ } ->
+      Error "Antigravity session has an unsettled claim; refusing duplicate execution"
+  in
+  transition
+    ~base_path
+    ~keeper_name
+    ~expected
+    { runtime_id
+    ; phase = Claimed { previous_conversation_id }
+    ; turn_count
+    ; last_usage
+    ; updated_at
+    }
+;;
+
+let settle ~base_path ~keeper_name ~expected ~conversation_id ~usage ~updated_at =
+  match expected.phase with
+  | Settled _ -> Error "Antigravity session can settle only from a claim"
+  | Claimed { previous_conversation_id } ->
+    let* () =
+      match previous_conversation_id with
+      | None when expected.turn_count = 1 -> Ok ()
+      | Some previous when expected.turn_count >= 2 && String.equal previous conversation_id ->
+        Ok ()
+      | None | Some _ -> Error "Antigravity settlement conversation identity changed"
+    in
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase = Settled { conversation_id }
+      ; last_usage = Some usage
+      ; updated_at
+      }
+;;

--- a/lib/keeper/keeper_antigravity_session_store.mli
+++ b/lib/keeper/keeper_antigravity_session_store.mli
@@ -1,0 +1,33 @@
+(** Durable per-Keeper Antigravity conversation binding. *)
+
+type phase =
+  | Claimed of { previous_conversation_id : string option }
+  | Settled of { conversation_id : string }
+
+type t =
+  { runtime_id : string
+  ; phase : phase
+  ; turn_count : int
+  ; last_usage : Runtime_antigravity_cli.usage option
+  ; updated_at : float
+  }
+
+val path : base_path:string -> keeper_name:string -> (string, string) result
+val load : base_path:string -> keeper_name:string -> (t option, string) result
+
+val claim :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t option ->
+  runtime_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val settle :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  conversation_id:string ->
+  usage:Runtime_antigravity_cli.usage ->
+  updated_at:float ->
+  (t, string) result

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -283,7 +283,8 @@ let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with
   | Some runtime ->
     (match runtime.Runtime.execution with
-     | Runtime_execution.Codex_app_server _ -> Ok runtime
+     | Runtime_execution.Codex_app_server _
+     | Runtime_execution.Antigravity_cli _ -> Ok runtime
      | Runtime_execution.Agent_core provider_config ->
        let* _request_body_cap =
          validate_provider_request_cap
@@ -740,6 +741,55 @@ let run_named
              on_runtime_observation
          | Error _ -> ());
         codex_result, None
+      | Runtime_execution.Antigravity_cli config ->
+        let antigravity_result =
+          match provider_config_transform, oas_checkpoint with
+          | Some _, _ ->
+            Error
+              (Agent_sdk.Error.Config
+                 (Agent_sdk.Error.InvalidConfig
+                    { field = "provider_config_transform"
+                    ; detail =
+                        "provider config transforms cannot target an \
+                         antigravity-cli runtime"
+                    }))
+          | None, Some _ ->
+            Error
+              (Agent_sdk.Error.Config
+                 (Agent_sdk.Error.InvalidConfig
+                    { field = "oas_checkpoint"
+                    ; detail =
+                        "an OAS agent_core checkpoint cannot resume through an \
+                         antigravity-cli runtime"
+                    }))
+          | None, None ->
+            Keeper_antigravity_runtime.run
+              ~runtime_id:attempt_runtime_id
+              ~keeper_name
+              ~base_path
+              ~goal
+              ~goal_blocks
+              ~system_prompt
+              ~initial_messages
+              ~model_input_projection
+              ~hooks
+              ~config
+        in
+        Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
+        let antigravity_result =
+          Result.bind antigravity_result (fun run_result ->
+            Keeper_turn_driver_try_provider.apply_accept
+              ~runtime_id:attempt_runtime_id
+              ~accept
+              run_result)
+        in
+        (match antigravity_result with
+         | Ok run_result ->
+           Option.iter
+             (fun observe -> Option.iter observe run_result.Runtime_agent.runtime_observation)
+             on_runtime_observation
+         | Error _ -> ());
+        antigravity_result, None
       | Runtime_execution.Agent_core runtime_provider_config ->
        (match
           match provider_config_transform with

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -87,7 +87,8 @@ let vision_runtime_candidates ()
   from_failover @ rest
   |> List.filter_map (fun (rt : Runtime.t) ->
        match rt.Runtime.execution with
-       | Runtime_execution.Codex_app_server _ -> None
+       | Runtime_execution.Codex_app_server _
+       | Runtime_execution.Antigravity_cli _ -> None
        | Runtime_execution.Agent_core provider_config ->
          let caps = Runtime_agent.input_capabilities_of_runtime rt in
          if Runtime_agent.caps_admit_required_modalities caps [ "image" ]

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -448,7 +448,7 @@ let capabilities_for_runtime (rt : t) =
   match rt.execution with
   | Runtime_execution.Agent_core provider_config ->
     Llm_provider.Provider_config.capabilities_for_config_model provider_config
-  | Runtime_execution.Codex_app_server _ -> None
+  | Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _ -> None
 ;;
 
 type max_context_source =
@@ -604,7 +604,8 @@ let validate_keeper_dispatch_request_caps
          | None -> None
          | Some runtime ->
            (match runtime.execution with
-            | Runtime_execution.Codex_app_server _ -> None
+            | Runtime_execution.Codex_app_server _
+            | Runtime_execution.Antigravity_cli _ -> None
             | Runtime_execution.Agent_core provider_config ->
               (match
                  validate_request_body_cap
@@ -641,7 +642,7 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
     List.filter_map
       (fun (r : t) ->
          match r.execution, capabilities_for_runtime r with
-         | Runtime_execution.Codex_app_server _, _ -> None
+         | (Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _), _ -> None
          | Runtime_execution.Agent_core _, Some _ -> None
          | Runtime_execution.Agent_core provider_config, None ->
            let provider_label =

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -203,12 +203,13 @@ let messages_api_compatible_provider_kind = function
 let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.provider)
     : (Llm_provider.Provider_config.provider_kind, string) result =
   match provider.api_format with
-  | Codex_app_server_runtime ->
+  | Codex_app_server_runtime | Antigravity_cli_runtime ->
     Error
       (Printf.sprintf
-         "provider %S uses codex-app-server and cannot be materialized as an \
+         "provider %S uses official CLI protocol %s and cannot be materialized as an \
           HTTP provider"
-         provider.id)
+         provider.id
+         provider.protocol)
   | Ollama_api -> Ok Llm_provider.Provider_config.Ollama
   | Chat_completions_api ->
     (* Chat-completions keeps the historical OpenAI-compatible fallback when
@@ -491,6 +492,37 @@ let codex_app_server_execution (provider : Runtime_schema.provider)
             { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
 ;;
 
+let antigravity_cli_execution (provider : Runtime_schema.provider)
+    (spec : Runtime_schema.model_spec) : (Runtime_execution.t, string) result =
+  match provider.transport with
+  | Http _ ->
+    Error
+      (Printf.sprintf
+         "provider %S uses protocol antigravity-cli but declares an HTTP endpoint; \
+          an official Antigravity CLI command is required"
+         provider.id)
+  | Cli command when String.trim command = "" ->
+    Error (Printf.sprintf "provider %S declares an empty Antigravity CLI command" provider.id)
+  | Cli command ->
+    (match provider.credentials with
+     | Some _ ->
+       Error
+         (Printf.sprintf
+            "provider %S uses antigravity-cli and must not declare credentials; \
+             the official Antigravity client owns subscription login"
+            provider.id)
+     | None when not provider.is_non_interactive ->
+       Error
+         (Printf.sprintf
+            "provider %S uses antigravity-cli and must declare \
+             is-non-interactive = true"
+            provider.id)
+     | None ->
+       Ok
+         (Runtime_execution.Antigravity_cli
+            { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
+;;
+
 let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema.binding)
     : (Runtime_execution.t, string) result =
   match Runtime_schema.model_of_id cfg binding.model_id with
@@ -502,6 +534,8 @@ let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema
        (match provider.api_format with
         | Runtime_schema.Codex_app_server_runtime ->
           codex_app_server_execution provider spec
+        | Runtime_schema.Antigravity_cli_runtime ->
+          antigravity_cli_execution provider spec
         | Messages_api | Chat_completions_api | Ollama_api ->
           Result.map
             (fun provider_config -> Runtime_execution.Agent_core provider_config)

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -37,4 +37,6 @@ val binding_to_execution
 (** Materialize the owner of a complete turn. HTTP model APIs become
     {!Runtime_execution.Agent_core}. The exact [codex-app-server] protocol over
     a credential-free CLI transport becomes
-    {!Runtime_execution.Codex_app_server}. Other CLI protocols remain rejected. *)
+    {!Runtime_execution.Codex_app_server} and the exact [antigravity-cli]
+    protocol materializes as {!Runtime_execution.Antigravity_cli}. Other CLI
+    protocols remain rejected. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -683,7 +683,8 @@ let input_capabilities_of_runtime (rt : Runtime.t) =
     match rt.Runtime.execution with
     | Runtime_execution.Agent_core provider_config ->
       provider_caps_of_config provider_config
-    | Runtime_execution.Codex_app_server _ ->
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Antigravity_cli _ ->
       Llm_provider.Capabilities.default_capabilities
   in
   apply_runtime_model_input_capabilities

--- a/lib/runtime/runtime_antigravity_cli.ml
+++ b/lib/runtime/runtime_antigravity_cli.ml
@@ -368,6 +368,10 @@ let validate_config (config : config) ~session_mode ~prompt =
     | Start | Resume _ -> Ok ()
 ;;
 
+let validate_run ?(session_mode = Start) config ~prompt =
+  validate_config config ~session_mode ~prompt
+;;
+
 let argv config ~session_mode ~prompt =
   let base =
     [ config.cli_path
@@ -406,7 +410,7 @@ let status_detail status stderr =
 ;;
 
 let run_turn ?(session_mode = Start) config ~prompt =
-  match validate_config config ~session_mode ~prompt with
+  match validate_run ~session_mode config ~prompt with
   | Error _ as error -> error
   | Ok () ->
     let cwd = Unix.realpath config.cwd in

--- a/lib/runtime/runtime_antigravity_cli.mli
+++ b/lib/runtime/runtime_antigravity_cli.mli
@@ -48,6 +48,14 @@ type error =
 
 val error_to_string : error -> string
 
+val validate_run :
+  ?session_mode:session_mode ->
+  config ->
+  prompt:string ->
+  (unit, error) result
+(** Validate the exact process boundary before a caller persists an execution
+    claim. [run_turn] delegates to this same function. *)
+
 val run_turn :
   ?session_mode:session_mode ->
   config ->

--- a/lib/runtime/runtime_execution.ml
+++ b/lib/runtime/runtime_execution.ml
@@ -4,9 +4,16 @@ type codex_app_server =
   ; timeout_s : float
   }
 
+type antigravity_cli =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
+  | Antigravity_cli of antigravity_cli
 
 type checkpoint_owner =
   | Masc_oas
@@ -14,20 +21,22 @@ type checkpoint_owner =
 
 let agent_core_provider_config = function
   | Agent_core config -> Some config
-  | Codex_app_server _ -> None
+  | Codex_app_server _ | Antigravity_cli _ -> None
 ;;
 
 let model_id = function
   | Agent_core config -> Some config.Llm_provider.Provider_config.model_id
   | Codex_app_server config -> config.model
+  | Antigravity_cli config -> config.model
 ;;
 
 let label = function
   | Agent_core _ -> "agent_core"
   | Codex_app_server _ -> "codex_app_server"
+  | Antigravity_cli _ -> "antigravity_cli"
 ;;
 
 let checkpoint_owner = function
   | Agent_core _ -> Masc_oas
-  | Codex_app_server _ -> Official_client
+  | Codex_app_server _ | Antigravity_cli _ -> Official_client
 ;;

--- a/lib/runtime/runtime_execution.mli
+++ b/lib/runtime/runtime_execution.mli
@@ -2,9 +2,17 @@
 
     [Agent_core] means MASC/OAS owns the model/tool/checkpoint loop.
     [Codex_app_server] means the official Codex client owns the whole turn;
-    MASC owns admission, process lifetime, and result projection. *)
+    MASC owns admission, process lifetime, and result projection.
+    [Antigravity_cli] has the same official-client ownership boundary, with
+    Antigravity's built-in tool loop fixed to plan+sandbox execution. *)
 
 type codex_app_server =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
+type antigravity_cli =
   { cli_path : string
   ; model : string option
   ; timeout_s : float
@@ -13,6 +21,7 @@ type codex_app_server =
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
+  | Antigravity_cli of antigravity_cli
 
 type checkpoint_owner =
   | Masc_oas

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -83,10 +83,11 @@ let resolve_runtime_providers ~runtime_id () =
   let provider_config_of_runtime rt =
     match rt.Runtime.execution with
     | Runtime_execution.Agent_core provider_config -> Ok provider_config
-    | Runtime_execution.Codex_app_server _ ->
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Antigravity_cli _ ->
       Error
         (Printf.sprintf
-           "runtime %S is owned by codex-app-server, not the OAS agent_core"
+           "runtime %S is owned by an official CLI client, not the OAS agent_core"
            rt.Runtime.id)
   in
   if String.equal runtime_id "" then

--- a/lib/runtime/runtime_observation.ml
+++ b/lib/runtime/runtime_observation.ml
@@ -182,7 +182,7 @@ let runtime_observation_of_candidates ~runtime_id ?strategy ~configured_labels
   {
     runtime_id;
     strategy;
-    configured_labels = [];
+    configured_labels;
     candidate_models;
     primary_model;
     selected_model;

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -14,6 +14,7 @@ type api_format =
   | Chat_completions_api
   | Ollama_api
   | Codex_app_server_runtime
+  | Antigravity_cli_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -12,6 +12,7 @@ type api_format =
   | Chat_completions_api
   | Ollama_api
   | Codex_app_server_runtime
+  | Antigravity_cli_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -106,7 +106,8 @@ let partition_results
 
 let canonical_protocol_of_protocol = function
   | "messages-cli" | "messages-http" | "openai-compatible-cli"
-  | "openai-compatible-http" | "ollama-http" | "codex-app-server" as protocol ->
+  | "openai-compatible-http" | "ollama-http" | "codex-app-server"
+  | "antigravity-cli" as protocol ->
     Some protocol
   | _ -> None
 ;;
@@ -115,7 +116,7 @@ let unknown_protocol_error s =
   Printf.sprintf
     "unknown protocol %S: expected one of messages-cli, messages-http, \
      openai-compatible-cli, openai-compatible-http, ollama-http, \
-     codex-app-server"
+     codex-app-server, antigravity-cli"
     s
 ;;
 
@@ -128,6 +129,7 @@ let api_format_of_protocol (s : string)
     Ok Runtime_schema.Chat_completions_api
   | "ollama-http" -> Ok Runtime_schema.Ollama_api
   | "codex-app-server" -> Ok Runtime_schema.Codex_app_server_runtime
+  | "antigravity-cli" -> Ok Runtime_schema.Antigravity_cli_runtime
   | _ -> Error (unknown_protocol_error s)
 ;;
 

--- a/lib/runtime/runtime_toml.mli
+++ b/lib/runtime/runtime_toml.mli
@@ -34,7 +34,8 @@ val parse_file : string -> (Runtime_schema.config, parse_error list) result
 val api_format_of_protocol : string -> (Runtime_schema.api_format, string) result
 (** Map a TOML protocol string to a {!Runtime_schema.api_format} variant. Only
     the canonical labels are accepted: [messages-cli], [messages-http],
-    [openai-compatible-cli], [openai-compatible-http], [ollama-http]. The
+    [openai-compatible-cli], [openai-compatible-http], [ollama-http],
+    [codex-app-server], and [antigravity-cli]. The
     deprecated provider-letter aliases [provider_d-http] / [provider-d-cli]
     (renamed in v0.19.43) are rejected with an "unknown protocol" error — they
     are NOT silently canonicalized — so a checked-in config still using them

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -774,7 +774,8 @@ let dashboard_runtime_append_probe_path base ~suffix =
 
 let dashboard_runtime_probe_url ~(api_format : Runtime_schema.api_format) base_url =
   match api_format with
-  | Runtime_schema.Codex_app_server_runtime -> None
+  | Runtime_schema.Codex_app_server_runtime
+  | Runtime_schema.Antigravity_cli_runtime -> None
   | Runtime_schema.Ollama_api ->
     let base = dashboard_runtime_trim_trailing_slashes base_url in
     Some
@@ -884,7 +885,8 @@ let dashboard_runtime_model_count_of_body ~(api_format : Runtime_schema.api_form
   try
     let json = Yojson.Safe.from_string body in
     match api_format with
-    | Runtime_schema.Codex_app_server_runtime -> None
+    | Runtime_schema.Codex_app_server_runtime
+    | Runtime_schema.Antigravity_cli_runtime -> None
     | Runtime_schema.Ollama_api -> dashboard_runtime_list_member_len "models" json
     | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
       (match dashboard_runtime_list_member_len "data" json with
@@ -991,7 +993,7 @@ let dashboard_runtime_provider_probe_json
         ~status:"invalid_execution_transport"
         ~reachable:(Some false)
         ~skipped:false
-        ~error:"codex-app-server must use the official CLI transport"
+        ~error:"official-client runtimes must use their CLI transport"
         ()
      | Some probe_url ->
       let probe_url_json = dashboard_runtime_url_for_json probe_url in
@@ -1546,6 +1548,16 @@ let runtime_request_config_json (rt : Runtime.t) =
       ; "timeout_s", `Float config.timeout_s
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Antigravity_cli config ->
+    `Assoc
+      [ "source", `String "official-client-runtime"
+      ; "execution", `String "antigravity_cli"
+      ; "model", Json_util.string_opt_to_json config.model
+      ; "timeout_s", `Float config.timeout_s
+      ; "execution_mode", `String "plan_sandbox"
+      ; "tool_owner", `String "official_client"
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core cfg ->
     `Assoc
     [ "source", `String "oas-provider-config"
@@ -1591,6 +1603,7 @@ let runtime_api_format_wire : Runtime_schema.api_format -> string = function
   | Runtime_schema.Chat_completions_api -> "chat-completions"
   | Runtime_schema.Ollama_api -> "ollama"
   | Runtime_schema.Codex_app_server_runtime -> "codex-app-server"
+  | Runtime_schema.Antigravity_cli_runtime -> "antigravity-cli"
 ;;
 
 let runtime_provider_behavior_capabilities_json
@@ -1700,6 +1713,14 @@ let effective_capabilities_json (rt : Runtime.t) =
       ; "execution", `String "codex_app_server"
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Antigravity_cli _ ->
+    `Assoc
+      [ "source", `String "unverified"
+      ; "execution", `String "antigravity_cli"
+      ; "execution_mode", `String "plan_sandbox"
+      ; "tool_owner", `String "official_client"
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core provider_config ->
    (match Llm_provider.Provider_config.capabilities_for_config_model provider_config with
   | None -> `Null
@@ -1780,6 +1801,13 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
       [ "source", `String "official-client-owned"
       ; "execution", `String "codex_app_server"
       ]
+  | Runtime_execution.Antigravity_cli _ ->
+    `Assoc
+      [ "source", `String "official-client-owned"
+      ; "execution", `String "antigravity_cli"
+      ; "execution_mode", `String "plan_sandbox"
+      ; "tool_owner", `String "official_client"
+      ]
   | Runtime_execution.Agent_core provider_config ->
     let dialect = RD.for_provider_config provider_config in
     let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
@@ -1807,7 +1835,8 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
   let runtime_kind = runtime_kind_of_transport rt.provider.transport in
   let is_official_client_runtime =
     match rt.execution with
-    | Runtime_execution.Codex_app_server _ -> true
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Antigravity_cli _ -> true
     | Runtime_execution.Agent_core _ -> false
   in
   let runtime_status =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -90,10 +90,11 @@ let finalize_runtime_breakdown json =
 
 let validate_requested_model (runtime : Runtime.t) requested_model =
   match runtime.execution with
-  | Runtime_execution.Codex_app_server _ ->
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Antigravity_cli _ ->
     Error
       (Printf.sprintf
-         "runtime %S is owned by codex-app-server; local_runtime_bench only \
+         "runtime %S is owned by an official CLI client; local_runtime_bench only \
           measures OAS agent_core providers"
          runtime.id)
   | Runtime_execution.Agent_core provider_config ->

--- a/test/dune
+++ b/test/dune
@@ -1943,6 +1943,7 @@
 
 (include stanzas/test_runtime_codex_app_server.inc)
 (include stanzas/test_runtime_antigravity_cli.inc)
+(include stanzas/test_keeper_antigravity_runtime.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)
 

--- a/test/stanzas/test_keeper_antigravity_runtime.inc
+++ b/test/stanzas/test_keeper_antigravity_runtime.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_antigravity_runtime)
+ (modules test_keeper_antigravity_runtime)
+ (libraries masc masc_test_deps))

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -1,0 +1,230 @@
+open Alcotest
+open Masc
+
+let conversation_id = "9971bfe0-4e21-40f9-8b5d-715ec5096965"
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let temp_workspace prefix =
+  let path = Filename.temp_file prefix "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  Unix.realpath path
+;;
+
+let cleanup_tree root =
+  let rec remove path =
+    if Sys.file_exists path
+    then if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try remove root with
+  | _ -> ()
+;;
+
+let fixture_script ~workspace =
+  let path = Filename.temp_file "masc-agy-keeper-" ".sh" in
+  let output = open_out_bin path in
+  output_string output "#!/bin/sh\n";
+  output_string output
+    ("test \"$PWD\" = " ^ shell_quote workspace ^ " || exit 71\n");
+  output_string output ("conversation=" ^ shell_quote conversation_id ^ "\n");
+  output_string output "turns=1\nresponse=MASC_AGY_KEEPER_START\n";
+  output_string output
+    "while test \"$#\" -gt 0; do case \"$1\" in --conversation) shift; conversation=\"$1\"; turns=2; response=MASC_AGY_KEEPER_RESUME ;; esac; shift; done\n";
+  output_string output
+    "printf '%s\\n' \"{\\\"event\\\":\\\"init\\\",\\\"conversation_id\\\":\\\"$conversation\\\",\\\"init\\\":{\\\"model\\\":\\\"gemini-fixture\\\",\\\"cwd\\\":\\\"$PWD\\\",\\\"tools\\\":[\\\"run_command\\\"],\\\"permission_mode\\\":\\\"always-proceed\\\"}}\"\n";
+  output_string output
+    "printf '%s\\n' \"{\\\"event\\\":\\\"step_update\\\",\\\"step_update\\\":{\\\"conversation_id\\\":\\\"$conversation\\\",\\\"step_index\\\":1,\\\"state\\\":\\\"DONE\\\",\\\"step_type\\\":\\\"tool\\\"}}\"\n";
+  output_string output
+    "printf '%s\\n' \"{\\\"event\\\":\\\"result\\\",\\\"result\\\":{\\\"conversation_id\\\":\\\"$conversation\\\",\\\"status\\\":\\\"SUCCESS\\\",\\\"response\\\":\\\"$response\\\",\\\"num_turns\\\":$turns,\\\"usage\\\":{\\\"input_tokens\\\":21,\\\"output_tokens\\\":4,\\\"thinking_tokens\\\":2,\\\"cache_read_tokens\\\":7,\\\"total_tokens\\\":25}}}\"\n";
+  close_out output;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let runtime_toml ~cli_path =
+  Printf.sprintf
+    "[providers.antigravity]\n\
+     protocol = \"antigravity-cli\"\n\
+     command = %S\n\
+     is-non-interactive = true\n\
+     \n\
+     [models.gemini-fixture]\n\
+     api-name = \"gemini-fixture\"\n\
+     max-context = 128000\n\
+     \n\
+     [antigravity.gemini-fixture]\n\
+     \n\
+     [runtime]\n\
+     default = \"antigravity.gemini-fixture\"\n"
+    cli_path
+;;
+
+let with_runtime_config ~cli_path f =
+  let path = Filename.temp_file "masc-agy-keeper-runtime-" ".toml" in
+  let output = open_out_bin path in
+  output_string output (runtime_toml ~cli_path);
+  close_out output;
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let response_text (result : Runtime_agent.run_result) =
+  result.response.content
+  |> List.filter_map (function Agent_sdk.Types.Text text -> Some text | _ -> None)
+  |> String.concat ""
+;;
+
+let run_turn ~base_path ~cli_path ~goal =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       with_runtime_config ~cli_path (fun runtime_path ->
+         Eio_main.run (fun env ->
+           Eio.Switch.run (fun sw ->
+             Eio_context.set_env env;
+             Process_eio.init
+               ~cwd_default:Eio.Path.(Eio.Stdenv.fs env / ".")
+               ~proc_mgr:(Eio.Stdenv.process_mgr env)
+               ~clock:(Eio.Stdenv.clock env);
+             Fun.protect
+               ~finally:Process_eio.reset_for_testing
+               (fun () ->
+                  Eio_context.with_test_env
+                    ~net:(Eio.Stdenv.net env)
+                    ~clock:(Eio.Stdenv.clock env)
+                    ~mono_clock:(Eio.Stdenv.mono_clock env)
+                    ~sw
+                    (fun () ->
+                       match Runtime.init_default ~config_path:runtime_path with
+                       | Error error -> fail error
+                       | Ok () ->
+                         Keeper_turn_driver.run_named
+                           ~runtime_id:"antigravity.gemini-fixture"
+                           ~keeper_name:"agy-fixture"
+                           ~base_path
+                           ~goal
+                           ~initial_messages:[]
+                           ~sw
+                           ~net:(Eio.Stdenv.net env)
+                           ()))))))
+;;
+
+let test_session_store_roundtrip_and_duplicate_claim () =
+  let base_path = temp_workspace "masc-agy-store-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       let usage : Runtime_antigravity_cli.usage =
+         { input_tokens = 10
+         ; output_tokens = 3
+         ; thinking_tokens = 2
+         ; cache_read_tokens = 4
+         ; total_tokens = 13
+         }
+       in
+       let claim =
+         Keeper_antigravity_session_store.claim
+           ~base_path
+           ~keeper_name:"store"
+           ~expected:None
+           ~runtime_id:"antigravity.gemini-fixture"
+           ~updated_at:1.0
+         |> Result.get_ok
+       in
+       (match
+          Keeper_antigravity_session_store.claim
+            ~base_path
+            ~keeper_name:"store"
+            ~expected:(Some claim)
+            ~runtime_id:claim.runtime_id
+            ~updated_at:2.0
+        with
+        | Error _ -> ()
+        | Ok _ -> fail "unsettled Antigravity claim admitted duplicate execution");
+       let settled =
+         Keeper_antigravity_session_store.settle
+           ~base_path
+           ~keeper_name:"store"
+           ~expected:claim
+           ~conversation_id
+           ~usage
+           ~updated_at:3.0
+         |> Result.get_ok
+       in
+       match Keeper_antigravity_session_store.load ~base_path ~keeper_name:"store" with
+       | Error detail -> fail detail
+       | Ok None -> fail "settled Antigravity session disappeared"
+       | Ok (Some loaded) ->
+         check int "turn count" 1 loaded.turn_count;
+         check bool "settled state" true (loaded = settled);
+         check (option int) "measured input" (Some 10)
+           (Option.map (fun usage -> usage.Runtime_antigravity_cli.input_tokens) loaded.last_usage))
+;;
+
+let test_keeper_start_resume_and_measured_observation () =
+  let base_path = temp_workspace "masc-agy-keeper-" in
+  let cli_path = fixture_script ~workspace:base_path in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove cli_path; cleanup_tree base_path)
+    (fun () ->
+       let first =
+         match run_turn ~base_path ~cli_path ~goal:"fixture start" with
+         | Ok result -> result
+         | Error error -> fail (Agent_sdk.Error.to_string error)
+       in
+       check string "first response" "MASC_AGY_KEEPER_START" (response_text first);
+       check int "first turn" 1 first.turns;
+       check string "conversation session" conversation_id first.session_id;
+       (match first.response.usage with
+        | None -> fail "provider-reported usage was dropped"
+        | Some usage ->
+          check int "input usage" 21 usage.input_tokens;
+          check int "output usage" 4 usage.output_tokens;
+          check int "cache usage" 7 usage.cache_read_input_tokens);
+       (match first.runtime_observation with
+        | None -> fail "measured runtime observation was not emitted"
+        | Some observation ->
+          List.iter
+            (fun label ->
+              check bool label true (List.mem label observation.configured_labels))
+            [ "tool_owner=official_client"
+            ; "execution_mode=plan_sandbox"
+            ; "permission_mode=always-proceed"
+            ; "tool_calls=1"
+            ; "thinking_tokens=2"
+            ]);
+       let resumed =
+         match run_turn ~base_path ~cli_path ~goal:"fixture resume" with
+         | Ok result -> result
+         | Error error -> fail (Agent_sdk.Error.to_string error)
+       in
+       check string "resume response" "MASC_AGY_KEEPER_RESUME" (response_text resumed);
+       check int "resume turn" 2 resumed.turns;
+       match Keeper_antigravity_session_store.load ~base_path ~keeper_name:"agy-fixture" with
+       | Error detail -> fail detail
+       | Ok None -> fail "resumed Antigravity session disappeared"
+       | Ok (Some session) -> check int "stored turn count" 2 session.turn_count)
+;;
+
+let () =
+  run
+    "Keeper Antigravity official-client runtime"
+    [ ( "durable session and dispatch"
+      , [ test_case
+            "session store roundtrip and duplicate claim"
+            `Quick
+            test_session_store_roundtrip_and_duplicate_claim
+        ; test_case
+            "start resume and measured observation"
+            `Quick
+            test_keeper_start_resume_and_measured_observation
+        ] )
+    ]
+;;

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -577,7 +577,8 @@ let test_provider_for_vision_uses_runtime_temperature () =
        | None -> failwith "selected vision runtime should resolve"
        | Some runtime ->
          (match runtime.Runtime.execution with
-          | Runtime_execution.Codex_app_server _ ->
+          | Runtime_execution.Codex_app_server _
+          | Runtime_execution.Antigravity_cli _ ->
             failwith "selected vision runtime should be agent_core"
           | Runtime_execution.Agent_core provider_config ->
             let configured = Vt.provider_for_vision provider_config in

--- a/test/test_runtime_antigravity_cli.ml
+++ b/test/test_runtime_antigravity_cli.ml
@@ -260,6 +260,33 @@ let test_subscription_environment_key_set_is_exact () =
     (Runtime_subscription_cli_env.is_metered_api_credential "PATH")
 ;;
 
+let test_runtime_observation_retains_internal_measured_labels () =
+  let capture, _metrics =
+    Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
+  in
+  Runtime_observation.record_attempt_terminal
+    capture
+    ~model_id:"gemini-3.6-flash-low"
+    ~latency_ms:(Some 12)
+    ~error:None;
+  let labels =
+    [ "tool_owner=official_client"
+    ; "permission_mode=always-proceed"
+    ; "thinking_tokens=2"
+    ]
+  in
+  let observation =
+    Runtime_observation.runtime_observation_with_metrics
+      ~runtime_id:"antigravity.gemini"
+      ~configured_labels:labels
+      ~candidate_count:1
+      ~selected_model_raw:(Some "gemini-3.6-flash-low")
+      ~capture
+      ()
+  in
+  check (list string) "internal measured labels" labels observation.configured_labels
+;;
+
 let () =
   run "runtime antigravity CLI"
     [ ( "typed stream-json boundary"
@@ -269,6 +296,10 @@ let () =
         ; test_case "failed status" `Quick test_failed_status_is_not_completion
         ; test_case "process start and resume" `Quick test_process_boundary_start_and_resume
         ; test_case "subscription env key set" `Quick test_subscription_environment_key_set_is_exact
+        ; test_case
+            "runtime observation keeps measured labels"
+            `Quick
+            test_runtime_observation_retains_internal_measured_labels
         ] )
     ; ( "live subscription"
       , [ test_case "official Antigravity CLI" `Slow test_live_subscription_client ] )

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -13,7 +13,8 @@ let parse_or_fail content =
 let agent_core_provider_config (runtime : Runtime.t) =
   match runtime.execution with
   | Runtime_execution.Agent_core provider_config -> provider_config
-  | Runtime_execution.Codex_app_server _ ->
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Antigravity_cli _ ->
     failf "runtime %s is not an agent_core provider" runtime.id
 ;;
 
@@ -3189,7 +3190,9 @@ let test_codex_app_server_materializes_as_turn_runtime () =
          fail "codex-app-server was incorrectly materialized as agent_core"
        | Runtime_execution.Codex_app_server config ->
          check string "cli path" "codex" config.cli_path;
-         check (option string) "model" (Some "gpt-5.6-sol") config.model))
+         check (option string) "model" (Some "gpt-5.6-sol") config.model
+       | Runtime_execution.Antigravity_cli _ ->
+         fail "codex-app-server was incorrectly materialized as antigravity-cli"))
 ;;
 
 let test_codex_app_server_rejects_declared_credentials () =
@@ -3210,6 +3213,58 @@ let test_codex_app_server_rejects_declared_credentials () =
               "official Codex client owns subscription login"))
 ;;
 
+let antigravity_cli_runtime_toml ?credential () =
+  let credential = Option.value credential ~default:"" in
+  Printf.sprintf
+    "[providers.antigravity]\n\
+     protocol = \"antigravity-cli\"\n\
+     command = \"agy\"\n\
+     is-non-interactive = true\n\
+     %s\n\
+     [models.gemini]\n\
+     api-name = \"gemini-3.6-flash-low\"\n\
+     max-context = 128000\n\
+     \n\
+     [antigravity.gemini]\n\
+     \n\
+     [runtime]\n\
+     default = \"antigravity.gemini\"\n"
+    credential
+;;
+
+let test_antigravity_cli_materializes_as_turn_runtime () =
+  with_temp_runtime_toml (antigravity_cli_runtime_toml ()) (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error error -> failf "antigravity-cli runtime should load: %s" error
+    | Ok (runtimes, default, _, _, _, _) ->
+      check int "one runtime" 1 (List.length runtimes);
+      check string "default id" "antigravity.gemini" default.id;
+      (match default.execution with
+       | Runtime_execution.Antigravity_cli config ->
+         check string "cli path" "agy" config.cli_path;
+         check (option string) "model" (Some "gemini-3.6-flash-low") config.model
+       | Runtime_execution.Agent_core _ | Runtime_execution.Codex_app_server _ ->
+         fail "antigravity-cli was materialized through the wrong execution owner"))
+;;
+
+let test_antigravity_cli_rejects_declared_credentials () =
+  let credential =
+    "[providers.antigravity.credentials]\n\
+     type = \"env\"\n\
+     key = \"GEMINI_API_KEY\""
+  in
+  with_temp_runtime_toml
+    (antigravity_cli_runtime_toml ~credential ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> fail "antigravity-cli incorrectly admitted declared credentials"
+       | Error error ->
+         check bool "diagnostic names official subscription ownership" true
+           (String_util.contains_substring
+              error
+              "official Antigravity client owns subscription login"))
+;;
+
 let () =
   run "runtime_config_validity"
     [ ( "runtime TOML gate",
@@ -3219,6 +3274,10 @@ let () =
             test_codex_app_server_materializes_as_turn_runtime;
           test_case "codex app-server rejects declared credentials" `Quick
             test_codex_app_server_rejects_declared_credentials;
+          test_case "antigravity CLI is a distinct turn runtime" `Quick
+            test_antigravity_cli_materializes_as_turn_runtime;
+          test_case "antigravity CLI rejects declared credentials" `Quick
+            test_antigravity_cli_rejects_declared_credentials;
           test_case "deployment OAS catalog covers live RunPod MTP runtime" `Quick
             test_deployment_oas_model_catalog_covers_live_runpod_mtp;
           test_case

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -359,9 +359,10 @@ max-concurrent = 1
          (fun (err : Runtime_toml.parse_error) ->
             String.equal err.path "providers.legacy_openai_compat.protocol"
             && String.equal err.message
-                 "unknown protocol \"openai-http\": expected one of \
-                  messages-cli, messages-http, openai-compatible-cli, \
-                  openai-compatible-http, ollama-http")
+                  "unknown protocol \"openai-http\": expected one of \
+                   messages-cli, messages-http, openai-compatible-cli, \
+                  openai-compatible-http, ollama-http, codex-app-server, \
+                  antigravity-cli")
          errors)
 
 let test_runtime_toml_accepts_messages_caching_capability () =


### PR DESCRIPTION
## Summary
- materialize `antigravity-cli` as a typed official-client runtime and dispatch it through Keeper
- persist exact durable conversation identity, turn count, and provider-reported usage with locked CAS transitions
- expose measured runtime evidence (`plan_sandbox`, official-client tool ownership, permission mode, tool calls, token usage) without claiming MASC Gate ownership
- document an API-key-free `runtime.toml` example

## Verification
- `dune exec --root . ./test/test_runtime_antigravity_cli.exe` (6 passed, live test skipped by env)
- affected runtime, Keeper, server, and test modules compile individually
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/audit-ci-test-targets.sh`
- `git diff --check`

## Current base blocker
The new Keeper test module compiles. Linking/running the full Keeper executable is currently blocked by pre-existing approval type/interface failures in the stacked base (`keeper_approval_queue`, `keeper_gate`, `keeper_approval/audit`). This PR does not mask or copy those fixes.