### PR TITLE
feat(runtime): add Claude Code subscription transport

### DIFF
--- a/lib/runtime/runtime_claude_code_cli.ml
+++ b/lib/runtime/runtime_claude_code_cli.ml
@@ -1,0 +1,611 @@
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string option
+  ; timeout_s : float
+  ; max_turns : int
+  }
+
+type session_mode =
+  | Start of { session_id : string }
+  | Resume of { session_id : string }
+
+type usage =
+  { input_tokens : int
+  ; output_tokens : int
+  ; cache_creation_input_tokens : int
+  ; cache_read_input_tokens : int
+  ; total_cost_usd : float
+  }
+
+type turn_result =
+  { session_id : string
+  ; model : string
+  ; text : string
+  ; num_turns : int
+  ; usage : usage
+  ; tool_calls : int
+  ; permission_mode : string
+  ; resumed : bool
+  }
+
+type rejection =
+  { status : string
+  ; reset_at : int option
+  ; detail : string
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | Turn_rejected of rejection
+  | Turn_failed of string
+  | Process_exited of string
+  | Timeout of float
+
+let error_to_string = function
+  | Invalid_config detail -> "invalid Claude Code CLI config: " ^ detail
+  | Spawn_failed detail -> "failed to start Claude Code CLI: " ^ detail
+  | Protocol_error { stage; detail } ->
+    Printf.sprintf "Claude Code CLI protocol error during %s: %s" stage detail
+  | Turn_rejected { status; reset_at; detail } ->
+    let reset =
+      match reset_at with
+      | None -> ""
+      | Some timestamp -> Printf.sprintf " (reset_at=%d)" timestamp
+    in
+    Printf.sprintf "Claude Code CLI turn rejected [%s]%s: %s" status reset detail
+  | Turn_failed detail -> "Claude Code CLI turn failed: " ^ detail
+  | Process_exited detail -> "Claude Code CLI process failed: " ^ detail
+  | Timeout seconds -> Printf.sprintf "Claude Code CLI turn timed out after %.3fs" seconds
+;;
+
+let ( let* ) = Result.bind
+
+let protocol_error stage detail = Error (Protocol_error { stage; detail })
+
+let rec validate_unique_object_keys ~stage ~path = function
+  | `Assoc fields ->
+    let rec loop seen = function
+      | [] -> Ok ()
+      | (name, value) :: rest ->
+        if List.mem name seen
+        then protocol_error stage (Printf.sprintf "duplicate object key %S at %s" name path)
+        else
+          let* () = validate_unique_object_keys ~stage ~path:(path ^ "." ^ name) value in
+          loop (name :: seen) rest
+    in
+    loop [] fields
+  | `List values ->
+    let rec loop index = function
+      | [] -> Ok ()
+      | value :: rest ->
+        let* () =
+          validate_unique_object_keys
+            ~stage
+            ~path:(Printf.sprintf "%s[%d]" path index)
+            value
+        in
+        loop (index + 1) rest
+    in
+    loop 0 values
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
+;;
+
+let assoc stage = function
+  | `Assoc fields -> Ok fields
+  | _ -> protocol_error stage "expected a JSON object"
+;;
+
+let required_json stage name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_string stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) when String.trim value <> "" -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a non-empty string" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_plain_string stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_bool stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`Bool value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a boolean" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_int stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be an integer" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let nonnegative_int stage name fields =
+  let* value = required_int stage name fields in
+  if value < 0
+  then protocol_error stage (Printf.sprintf "field %S must be non-negative" name)
+  else Ok value
+;;
+
+let optional_int stage name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`Int value) -> Ok (Some value)
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be an integer or null" name)
+;;
+
+let optional_nonnegative_int stage name fields =
+  let* value = optional_int stage name fields in
+  match value with
+  | None -> Ok None
+  | Some value when value >= 0 -> Ok (Some value)
+  | Some _ ->
+    protocol_error stage (Printf.sprintf "field %S must be non-negative when present" name)
+;;
+
+let optional_string stage name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
+;;
+
+let required_nonnegative_float stage name fields =
+  let value =
+    match List.assoc_opt name fields with
+    | Some (`Int value) -> Some (Float.of_int value)
+    | Some (`Float value) -> Some value
+    | Some _ | None -> None
+  in
+  match value with
+  | Some value when Float.is_finite value && value >= 0.0 -> Ok value
+  | _ -> protocol_error stage (Printf.sprintf "field %S must be a finite non-negative number" name)
+;;
+
+let parse_json_line ~line_number line =
+  let stage = Printf.sprintf "stdout line %d" line_number in
+  if String.length line > 8 * 1024 * 1024
+  then protocol_error stage "stream-json line exceeds 8 MiB"
+  else
+    try
+      let json = Yojson.Safe.from_string line in
+      let* () = validate_unique_object_keys ~stage ~path:"$" json in
+      Ok (stage, json)
+    with
+    | Yojson.Json_error detail -> protocol_error stage detail
+;;
+
+let expected_tools = [ "Glob"; "Grep"; "Read"; "WebFetch"; "WebSearch" ]
+
+let parse_tools stage fields =
+  let* json = required_json stage "tools" fields in
+  match json with
+  | `List values ->
+    let rec loop seen = function
+      | [] -> Ok (List.sort String.compare seen)
+      | `String name :: rest when String.trim name <> "" && not (List.mem name seen) ->
+        loop (name :: seen) rest
+      | `String name :: _ when List.mem name seen ->
+        protocol_error stage (Printf.sprintf "duplicate tool %S" name)
+      | _ -> protocol_error stage "tools must contain unique non-empty strings"
+    in
+    let* tools = loop [] values in
+    if tools = expected_tools
+    then Ok ()
+    else protocol_error stage "reported tools differ from the fixed read-only tool boundary"
+  | _ -> protocol_error stage "field \"tools\" must be an array"
+;;
+
+type init =
+  { session_id : string
+  ; model : string
+  ; cwd : string
+  ; permission_mode : string
+  }
+
+type terminal =
+  { session_id : string
+  ; subtype : string
+  ; is_error : bool
+  ; result : string
+  ; num_turns : int
+  ; usage : usage
+  ; terminal_reason : string option
+  ; api_error_status : int option
+  }
+
+let parse_init stage fields =
+  let* subtype = required_string stage "subtype" fields in
+  if not (String.equal subtype "init")
+  then protocol_error stage (Printf.sprintf "unsupported system subtype %S" subtype)
+  else
+    let* session_id = required_string stage "session_id" fields in
+    let* model = required_string stage "model" fields in
+    let* cwd = required_string stage "cwd" fields in
+    let* permission_mode = required_string stage "permissionMode" fields in
+    let* api_key_source = required_string stage "apiKeySource" fields in
+    let* () = parse_tools stage fields in
+    if not (String.equal permission_mode "plan")
+    then protocol_error stage "Claude Code did not retain permission mode plan"
+    else if not (String.equal api_key_source "none")
+    then protocol_error stage "Claude Code selected a non-subscription API credential source"
+    else Ok { session_id; model; cwd; permission_mode }
+;;
+
+let usage_of_fields stage fields =
+  let* input_tokens = nonnegative_int stage "input_tokens" fields in
+  let* output_tokens = nonnegative_int stage "output_tokens" fields in
+  let* cache_creation_input_tokens =
+    nonnegative_int stage "cache_creation_input_tokens" fields
+  in
+  let* cache_read_input_tokens = nonnegative_int stage "cache_read_input_tokens" fields in
+  Ok
+    { input_tokens
+    ; output_tokens
+    ; cache_creation_input_tokens
+    ; cache_read_input_tokens
+    ; total_cost_usd = 0.0
+    }
+;;
+
+let parse_terminal stage fields =
+  let* subtype = required_string stage "subtype" fields in
+  let* session_id = required_string stage "session_id" fields in
+  let* is_error = required_bool stage "is_error" fields in
+  let* result = required_plain_string stage "result" fields in
+  let* num_turns = required_int stage "num_turns" fields in
+  let* terminal_reason = optional_string stage "terminal_reason" fields in
+  let* api_error_status = optional_nonnegative_int stage "api_error_status" fields in
+  if num_turns <= 0
+  then protocol_error stage "num_turns must be positive"
+  else
+    let* usage_json = required_json stage "usage" fields in
+    let* usage_fields = assoc stage usage_json in
+    let* usage = usage_of_fields stage usage_fields in
+    let* total_cost_usd = required_nonnegative_float stage "total_cost_usd" fields in
+    Ok
+      { session_id
+      ; subtype
+      ; is_error
+      ; result
+      ; num_turns
+      ; usage = { usage with total_cost_usd }
+      ; terminal_reason
+      ; api_error_status
+      }
+;;
+
+let session_id_of_event stage fields =
+  match List.assoc_opt "session_id" fields with
+  | None -> Ok None
+  | Some (`String value) when String.trim value <> "" -> Ok (Some value)
+  | Some _ -> protocol_error stage "field \"session_id\" must be a non-empty string"
+;;
+
+let count_assistant_tool_calls stage fields =
+  let* message_json = required_json stage "message" fields in
+  let* message_fields = assoc stage message_json in
+  let* content_json = required_json stage "content" message_fields in
+  match content_json with
+  | `List blocks ->
+    List.fold_left
+      (fun result block ->
+        let* count = result in
+        let* block_fields = assoc stage block in
+        let* block_type = required_string stage "type" block_fields in
+        Ok (if String.equal block_type "tool_use" then count + 1 else count))
+      (Ok 0)
+      blocks
+  | _ -> protocol_error stage "assistant message content must be an array"
+;;
+
+let parse_rate_limit stage fields =
+  let* info_json = required_json stage "rate_limit_info" fields in
+  let* info_fields = assoc stage info_json in
+  let* status = required_string stage "status" info_fields in
+  let* reset_at = optional_nonnegative_int stage "resetsAt" info_fields in
+  Ok (status, reset_at)
+;;
+
+let validate_session_id stage ~expected = function
+  | None -> Ok ()
+  | Some actual when String.equal actual expected -> Ok ()
+  | Some _ -> protocol_error stage "event session_id changed"
+;;
+
+let parse_output ~expected_model ~expected_cwd ~session_mode output =
+  if String.length output > 16 * 1024 * 1024
+  then protocol_error "stdout" "stream-json output exceeds 16 MiB"
+  else
+    let lines =
+      output
+      |> String.split_on_char '\n'
+      |> List.filter (fun line -> String.trim line <> "")
+    in
+    if List.length lines > 16_384
+    then protocol_error "stdout" "stream-json event count exceeds 16384"
+    else
+      let expected_session_id, resumed =
+        match session_mode with
+        | Start { session_id } -> session_id, false
+        | Resume { session_id } -> session_id, true
+      in
+      let rec loop line_number init terminal tool_calls rejection = function
+        | [] -> Ok (init, terminal, tool_calls, rejection)
+        | _ :: _ when Option.is_some terminal ->
+          protocol_error "stdout" "events appeared after the terminal result"
+        | line :: rest ->
+          let* stage, json = parse_json_line ~line_number line in
+          let* fields = assoc stage json in
+          let* event_type = required_string stage "type" fields in
+          let* () =
+            if String.equal event_type "system" || Option.is_some init
+            then Ok ()
+            else protocol_error stage "event appeared before the init boundary"
+          in
+          (match event_type with
+           | "system" ->
+             if Option.is_some init
+             then protocol_error stage "duplicate init event"
+             else
+               let* parsed = parse_init stage fields in
+               loop (line_number + 1) (Some parsed) terminal tool_calls rejection rest
+           | "assistant" ->
+             let* event_session_id = session_id_of_event stage fields in
+             let* () = validate_session_id stage ~expected:expected_session_id event_session_id in
+             let* count = count_assistant_tool_calls stage fields in
+             loop
+               (line_number + 1)
+               init
+               terminal
+               (tool_calls + count)
+               rejection
+               rest
+           | "user" ->
+             let* event_session_id = session_id_of_event stage fields in
+             let* () = validate_session_id stage ~expected:expected_session_id event_session_id in
+             loop (line_number + 1) init terminal tool_calls rejection rest
+           | "rate_limit_event" ->
+             let* event_session_id = session_id_of_event stage fields in
+             let* () = validate_session_id stage ~expected:expected_session_id event_session_id in
+             let* status, reset_at = parse_rate_limit stage fields in
+             let rejection =
+               if String.equal status "rejected"
+               then Some (status, reset_at)
+               else rejection
+             in
+             loop (line_number + 1) init terminal tool_calls rejection rest
+           | "result" ->
+             let* parsed = parse_terminal stage fields in
+             loop (line_number + 1) init (Some parsed) tool_calls rejection rest
+           | other -> protocol_error stage (Printf.sprintf "unsupported event type %S" other))
+      in
+      let* init, terminal, tool_calls, rejection = loop 1 None None 0 None lines in
+      let* init =
+        match init with
+        | Some init -> Ok init
+        | None -> protocol_error "stdout" "missing init event"
+      in
+      let* terminal =
+        match terminal with
+        | Some terminal -> Ok terminal
+        | None -> protocol_error "stdout" "missing terminal result"
+      in
+      let* () =
+        if String.equal init.session_id expected_session_id
+           && String.equal terminal.session_id expected_session_id
+        then Ok ()
+        else protocol_error "session" "reported session_id differs from requested identity"
+      in
+      let* () =
+        match expected_model with
+        | None -> Ok ()
+        | Some expected when String.equal expected init.model -> Ok ()
+        | Some _ -> protocol_error "init" "reported model differs from requested model"
+      in
+      let* () =
+        if String.equal expected_cwd init.cwd
+        then Ok ()
+        else protocol_error "init" "reported cwd differs from configured cwd"
+      in
+      (match rejection, terminal.api_error_status with
+       | Some (status, reset_at), _ ->
+         Error (Turn_rejected { status; reset_at; detail = terminal.result })
+       | None, Some 429 ->
+         Error
+           (Turn_rejected
+              { status = "http_429"; reset_at = None; detail = terminal.result })
+       | None, Some _ when not terminal.is_error ->
+         protocol_error "result" "api_error_status requires is_error=true"
+       | None, None
+         when (match terminal.terminal_reason with
+               | Some "api_error" -> not terminal.is_error
+               | Some _ | None -> false) ->
+         protocol_error "result" "terminal_reason=api_error requires is_error=true"
+       | None, _ when terminal.is_error ->
+         let reason = Option.value terminal.terminal_reason ~default:terminal.subtype in
+         Error (Turn_failed (reason ^ ": " ^ terminal.result))
+       | None, _ when not (String.equal terminal.subtype "success") ->
+         Error (Turn_failed terminal.subtype)
+       | None, _ when String.trim terminal.result = "" ->
+         protocol_error "result" "successful result must not be empty"
+       | None, _ ->
+         Ok
+           { session_id = terminal.session_id
+           ; model = init.model
+           ; text = terminal.result
+           ; num_turns = terminal.num_turns
+           ; usage = terminal.usage
+           ; tool_calls
+           ; permission_mode = init.permission_mode
+           ; resumed
+           })
+;;
+
+let session_id = function
+  | Start { session_id } | Resume { session_id } -> session_id
+;;
+
+let is_hex_digit = function
+  | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
+  | _ -> false
+;;
+
+let is_canonical_uuid value =
+  let rec valid_at index =
+    if index = String.length value
+    then true
+    else
+      let valid_character =
+        match index with
+        | 8 | 13 | 18 | 23 -> Char.equal value.[index] '-'
+        | _ -> is_hex_digit value.[index]
+      in
+      valid_character && valid_at (index + 1)
+  in
+  String.length value = 36 && valid_at 0
+;;
+
+let validate_config (config : config) ~session_mode ~prompt =
+  let cwd_is_directory =
+    try Sys.file_exists config.cwd && Sys.is_directory config.cwd with
+    | Sys_error _ -> false
+  in
+  if String.trim config.cli_path = ""
+  then Error (Invalid_config "cli_path must not be empty")
+  else if Filename.is_relative config.cwd || String.trim config.cwd = ""
+  then Error (Invalid_config "cwd must be an absolute path")
+  else if not cwd_is_directory
+  then Error (Invalid_config "cwd must name an existing directory")
+  else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
+  then Error (Invalid_config "timeout_s must be positive and finite")
+  else if config.max_turns <= 0
+  then Error (Invalid_config "max_turns must be positive")
+  else if Option.exists (fun model -> String.trim model = "") config.model
+  then Error (Invalid_config "model must not be empty when provided")
+  else if not (is_canonical_uuid (session_id session_mode))
+  then Error (Invalid_config "session_id must be a canonical UUID")
+  else if String.trim prompt = ""
+  then Error (Invalid_config "prompt must not be empty")
+  else if not (Process_eio.is_initialized ())
+  then Error (Invalid_config "initialized Process_eio runtime is required")
+  else Ok ()
+;;
+
+let validate_run config ~session_mode ~prompt =
+  validate_config config ~session_mode ~prompt
+;;
+
+let argv config ~session_mode ~prompt =
+  let base =
+    [ config.cli_path
+    ; "--print"
+    ; "--safe-mode"
+    ; "--disable-slash-commands"
+    ; "--no-chrome"
+    ; "--permission-mode"
+    ; "plan"
+    ; "--tools"
+    ; String.concat "," expected_tools
+    ; "--max-turns"
+    ; string_of_int config.max_turns
+    ; "--output-format"
+    ; "stream-json"
+    ; "--verbose"
+    ]
+  in
+  let base =
+    match config.model with
+    | None -> base
+    | Some model -> base @ [ "--model"; model ]
+  in
+  let base =
+    match session_mode with
+    | Start { session_id } -> base @ [ "--session-id"; session_id ]
+    | Resume { session_id } -> base @ [ "--resume"; session_id ]
+  in
+  base @ [ prompt ]
+;;
+
+let env_key entry =
+  match String.index_opt entry '=' with
+  | Some index -> String.sub entry 0 index
+  | None -> entry
+;;
+
+let is_disallowed_environment_override = function
+  | "ANTHROPIC_AUTH_TOKEN"
+  | "ANTHROPIC_BASE_URL"
+  | "CLAUDE_CODE_USE_BEDROCK"
+  | "CLAUDE_CODE_USE_VERTEX"
+  | "CLAUDE_CODE_USE_FOUNDRY" -> true
+  | key -> Runtime_subscription_cli_env.is_metered_api_credential key
+;;
+
+let environment () =
+  Unix.environment ()
+  |> Array.to_list
+  |> List.filter (fun entry -> not (is_disallowed_environment_override (env_key entry)))
+  |> Array.of_list
+;;
+
+let status_detail status stderr =
+  let status =
+    match status with
+    | Unix.WEXITED code -> Printf.sprintf "exit %d" code
+    | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
+    | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
+  in
+  let stderr = String.trim stderr in
+  if String.equal stderr ""
+  then status
+  else
+    let stderr =
+      if String.length stderr <= 4096 then stderr else String.sub stderr 0 4096 ^ "..."
+    in
+    status ^ ": " ^ stderr
+;;
+
+let run_turn config ~session_mode ~prompt =
+  match validate_run config ~session_mode ~prompt with
+  | Error _ as error -> error
+  | Ok () ->
+    let cwd = Unix.realpath config.cwd in
+    let config = { config with cwd } in
+    (try
+       let status, stdout, stderr =
+         Process_eio.run_argv_with_status_split
+           ~timeout_sec:config.timeout_s
+           ~env:(environment ())
+           ~cwd
+           (argv config ~session_mode ~prompt)
+       in
+       match status with
+       | Unix.WEXITED 0 ->
+         parse_output ~expected_model:config.model ~expected_cwd:cwd ~session_mode stdout
+       | Unix.WEXITED 124 -> Error (Timeout config.timeout_s)
+       | _ -> Error (Process_exited (status_detail status stderr))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Spawn_failed (Printexc.to_string exn)))
+;;
+
+module For_testing = struct
+  let parse_output = parse_output
+  let is_disallowed_environment_override = is_disallowed_environment_override
+end

--- a/lib/runtime/runtime_claude_code_cli.mli
+++ b/lib/runtime/runtime_claude_code_cli.mli
@@ -1,0 +1,74 @@
+(** Official Claude Code CLI one-turn boundary.
+
+    The official client owns model execution and its read-only tool loop. MASC
+    owns argv construction, process lifetime, strict stream-json decoding, and
+    exact session identity. The child inherits the user's existing Claude Code
+    login; metered API credentials and endpoint overrides are removed. *)
+
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string option
+  ; timeout_s : float
+  ; max_turns : int
+  }
+
+type session_mode =
+  | Start of { session_id : string }
+  | Resume of { session_id : string }
+
+type usage =
+  { input_tokens : int
+  ; output_tokens : int
+  ; cache_creation_input_tokens : int
+  ; cache_read_input_tokens : int
+  ; total_cost_usd : float
+  }
+
+type turn_result =
+  { session_id : string
+  ; model : string
+  ; text : string
+  ; num_turns : int
+  ; usage : usage
+  ; tool_calls : int
+  ; permission_mode : string
+  ; resumed : bool
+  }
+
+type rejection =
+  { status : string
+  ; reset_at : int option
+  ; detail : string
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | Turn_rejected of rejection
+  | Turn_failed of string
+  | Process_exited of string
+  | Timeout of float
+
+val error_to_string : error -> string
+
+val validate_run : config -> session_mode:session_mode -> prompt:string -> (unit, error) result
+(** Validate the exact process boundary before a caller persists an execution
+    claim. [run_turn] delegates to this same function. *)
+
+val run_turn : config -> session_mode:session_mode -> prompt:string -> (turn_result, error) result
+
+module For_testing : sig
+  val parse_output :
+    expected_model:string option ->
+    expected_cwd:string ->
+    session_mode:session_mode ->
+    string ->
+    (turn_result, error) result
+
+  val is_disallowed_environment_override : string -> bool
+end

--- a/test/dune
+++ b/test/dune
@@ -1943,6 +1943,7 @@
 
 (include stanzas/test_runtime_codex_app_server.inc)
 (include stanzas/test_runtime_antigravity_cli.inc)
+(include stanzas/test_runtime_claude_code_cli.inc)
 (include stanzas/test_keeper_antigravity_runtime.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/stanzas/test_runtime_claude_code_cli.inc
+++ b/test/stanzas/test_runtime_claude_code_cli.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_claude_code_cli)
+ (modules test_runtime_claude_code_cli)
+ (libraries alcotest masc.runtime masc.masc_process eio eio_main unix))

--- a/test/test_runtime_claude_code_cli.ml
+++ b/test/test_runtime_claude_code_cli.ml
@@ -1,0 +1,383 @@
+open Alcotest
+
+let session_id = "f72353c2-4462-476f-8398-82105a7f9cae"
+
+let init_line ~cwd ?(api_key_source = "none") ?(permission_mode = "plan") () =
+  Printf.sprintf
+    {|{"type":"system","subtype":"init","cwd":%S,"session_id":%S,"tools":["Glob","Grep","Read","WebFetch","WebSearch"],"model":"claude-opus-5","permissionMode":%S,"apiKeySource":%S}|}
+    cwd
+    session_id
+    permission_mode
+    api_key_source
+;;
+
+let assistant_line =
+  Printf.sprintf
+    {|{"type":"assistant","message":{"model":"claude-opus-5","role":"assistant","content":[{"type":"text","text":"checking"},{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"README.md"}}]},"session_id":%S}|}
+    session_id
+;;
+
+let user_line =
+  Printf.sprintf
+    {|{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":"ok"}]},"session_id":%S}|}
+    session_id
+;;
+
+let result_line ?(is_error = false) ?(subtype = "success")
+    ?(result = "MASC_CLAUDE_OK") ?terminal_reason ?api_error_status () =
+  let terminal_reason =
+    match terminal_reason with
+    | None -> "null"
+    | Some value -> Printf.sprintf "%S" value
+  in
+  let api_error_status =
+    match api_error_status with
+    | None -> "null"
+    | Some value -> string_of_int value
+  in
+  Printf.sprintf
+    {|{"type":"result","subtype":%S,"is_error":%b,"duration_ms":1250,"duration_api_ms":900,"num_turns":1,"result":%S,"session_id":%S,"total_cost_usd":0.0125,"usage":{"input_tokens":20,"cache_creation_input_tokens":3,"cache_read_input_tokens":5,"output_tokens":4},"terminal_reason":%s,"api_error_status":%s}|}
+    subtype
+    is_error
+    result
+    session_id
+    terminal_reason
+    api_error_status
+;;
+
+let rate_limit_line ?(status = "rejected") () =
+  Printf.sprintf
+    {|{"type":"rate_limit_event","rate_limit_info":{"status":%S,"resetsAt":1786356000,"rateLimitType":"seven_day"},"session_id":%S}|}
+    status
+    session_id
+;;
+
+let success_output ~cwd ?api_key_source ?permission_mode () =
+  String.concat
+    "\n"
+    [ init_line ~cwd ?api_key_source ?permission_mode ()
+    ; assistant_line
+    ; user_line
+    ; result_line ()
+    ; ""
+    ]
+;;
+
+let parse ~cwd ?(mode = Runtime_claude_code_cli.Start { session_id }) value =
+  Runtime_claude_code_cli.For_testing.parse_output
+    ~expected_model:(Some "claude-opus-5")
+    ~expected_cwd:cwd
+    ~session_mode:mode
+    value
+;;
+
+let test_strict_success_projection () =
+  let result = parse ~cwd:"/tmp" (success_output ~cwd:"/tmp" ()) |> Result.get_ok in
+  check string "session" session_id result.session_id;
+  check string "model" "claude-opus-5" result.model;
+  check string "response" "MASC_CLAUDE_OK" result.text;
+  check int "agent loop turns" 1 result.num_turns;
+  check int "tool calls" 1 result.tool_calls;
+  check int "input usage" 20 result.usage.input_tokens;
+  check int "output usage" 4 result.usage.output_tokens;
+  check int "cache creation" 3 result.usage.cache_creation_input_tokens;
+  check int "cache read" 5 result.usage.cache_read_input_tokens;
+  check (float 0.000001) "cost" 0.0125 result.usage.total_cost_usd;
+  check bool "start" false result.resumed
+;;
+
+let test_resume_requires_exact_identity () =
+  let resumed =
+    parse
+      ~cwd:"/tmp"
+      ~mode:(Runtime_claude_code_cli.Resume { session_id })
+      (success_output ~cwd:"/tmp" ())
+    |> Result.get_ok
+  in
+  check bool "resumed" true resumed.resumed;
+  match
+    Runtime_claude_code_cli.For_testing.parse_output
+      ~expected_model:(Some "claude-opus-5")
+      ~expected_cwd:"/tmp"
+      ~session_mode:(Resume { session_id = "different" })
+      (success_output ~cwd:"/tmp" ())
+  with
+  | Error (Runtime_claude_code_cli.Protocol_error _) -> ()
+  | Error error -> fail (Runtime_claude_code_cli.error_to_string error)
+  | Ok _ -> fail "session identity mismatch was accepted"
+;;
+
+let test_rate_limit_rejection_beats_success_subtype () =
+  let output =
+    String.concat
+      "\n"
+      [ init_line ~cwd:"/tmp" ()
+      ; rate_limit_line ()
+      ; Printf.sprintf
+          {|{"type":"assistant","message":{"model":"<synthetic>","role":"assistant","content":[{"type":"text","text":"limit"}]},"session_id":%S}|}
+          session_id
+      ; result_line
+          ~is_error:true
+          ~subtype:"success"
+          ~result:"individual spend limit"
+          ~terminal_reason:"api_error"
+          ~api_error_status:429
+          ()
+      ]
+  in
+  match parse ~cwd:"/tmp" output with
+  | Error
+      (Runtime_claude_code_cli.Turn_rejected
+         { status = "rejected"; reset_at = Some 1786356000; detail }) ->
+    check string "detail" "individual spend limit" detail
+  | Error error -> fail (Runtime_claude_code_cli.error_to_string error)
+  | Ok _ -> fail "rate-limit result with subtype=success was accepted"
+;;
+
+let test_api_key_source_and_permission_fail_closed () =
+  let expect_protocol_error output =
+    match parse ~cwd:"/tmp" output with
+    | Error (Runtime_claude_code_cli.Protocol_error _) -> ()
+    | Error error -> fail (Runtime_claude_code_cli.error_to_string error)
+    | Ok _ -> fail "invalid init boundary was accepted"
+  in
+  expect_protocol_error (success_output ~cwd:"/tmp" ~api_key_source:"ANTHROPIC_API_KEY" ());
+  expect_protocol_error (success_output ~cwd:"/tmp" ~permission_mode:"default" ())
+;;
+
+let test_duplicate_keys_fail_closed () =
+  let duplicate =
+    String.concat
+      "\n"
+      [ Printf.sprintf
+          {|{"type":"system","type":"system","subtype":"init","cwd":"/tmp","session_id":%S,"tools":["Glob","Grep","Read","WebFetch","WebSearch"],"model":"claude-opus-5","permissionMode":"plan","apiKeySource":"none"}|}
+          session_id
+      ; result_line ()
+      ]
+  in
+  match parse ~cwd:"/tmp" duplicate with
+  | Error (Runtime_claude_code_cli.Protocol_error _) -> ()
+  | Error error -> fail (Runtime_claude_code_cli.error_to_string error)
+  | Ok _ -> fail "duplicate JSON keys were accepted"
+;;
+
+let test_init_must_precede_stream_events () =
+  let output = String.concat "\n" [ assistant_line; init_line ~cwd:"/tmp" (); result_line () ] in
+  match parse ~cwd:"/tmp" output with
+  | Error (Runtime_claude_code_cli.Protocol_error _) -> ()
+  | Error error -> fail (Runtime_claude_code_cli.error_to_string error)
+  | Ok _ -> fail "assistant event before init was accepted"
+;;
+
+let test_success_cannot_carry_api_error () =
+  let output =
+    String.concat
+      "\n"
+      [ init_line ~cwd:"/tmp" ()
+      ; result_line ~terminal_reason:"api_error" ~api_error_status:500 ()
+      ]
+  in
+  match parse ~cwd:"/tmp" output with
+  | Error (Runtime_claude_code_cli.Protocol_error _) -> ()
+  | Error error -> fail (Runtime_claude_code_cli.error_to_string error)
+  | Ok _ -> fail "successful result carrying API error metadata was accepted"
+;;
+
+let test_session_id_must_be_canonical_uuid () =
+  let config : Runtime_claude_code_cli.config =
+    { cli_path = "claude"
+    ; cwd = "/tmp"
+    ; model = None
+    ; timeout_s = 5.0
+    ; max_turns = 1
+    }
+  in
+  match
+    Runtime_claude_code_cli.validate_run
+      config
+      ~session_mode:(Start { session_id = "not-a-uuid" })
+      ~prompt:"hello"
+  with
+  | Error (Runtime_claude_code_cli.Invalid_config _) -> ()
+  | Error error -> fail (Runtime_claude_code_cli.error_to_string error)
+  | Ok () -> fail "non-UUID session identity was accepted"
+;;
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let temp_workspace () =
+  let path = Filename.temp_file "masc-claude-runtime-" "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let cleanup_tree root =
+  let rec remove path =
+    if Sys.file_exists path
+    then if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try remove root with
+  | _ -> ()
+;;
+
+let fixture_script ~workspace =
+  let path = Filename.temp_file "masc-claude-runtime-fixture-" ".sh" in
+  let output_channel = open_out_bin path in
+  let emit line =
+    output_string output_channel ("printf '%s\\n' " ^ shell_quote line ^ "\n")
+  in
+  output_string output_channel "#!/bin/sh\n";
+  output_string output_channel
+    ("test \"$PWD\" = " ^ shell_quote workspace ^ " || exit 71\n");
+  output_string output_channel
+    "test -z \"$OPENAI_API_KEY$CODEX_API_KEY$GEMINI_API_KEY$GOOGLE_API_KEY$ANTHROPIC_API_KEY$ANTHROPIC_AUTH_TOKEN$ANTHROPIC_BASE_URL$CLAUDE_CODE_USE_BEDROCK$CLAUDE_CODE_USE_VERTEX$CLAUDE_CODE_USE_FOUNDRY\" || exit 72\n";
+  output_string output_channel
+    "session= mode= permission= tools= safe= slash= chrome= verbose= output= max_turns=\n";
+  output_string output_channel
+    "while test \"$#\" -gt 0; do case \"$1\" in --session-id) shift; session=\"$1\"; mode=start ;; --resume) shift; session=\"$1\"; mode=resume ;; --permission-mode) shift; permission=\"$1\" ;; --tools) shift; tools=\"$1\" ;; --max-turns) shift; max_turns=\"$1\" ;; --output-format) shift; output=\"$1\" ;; --safe-mode) safe=1 ;; --disable-slash-commands) slash=1 ;; --no-chrome) chrome=1 ;; --verbose) verbose=1 ;; esac; shift; done\n";
+  output_string output_channel
+    "test \"$session\" = 'f72353c2-4462-476f-8398-82105a7f9cae' && test -n \"$mode\" && test \"$permission\" = plan && test \"$tools\" = 'Glob,Grep,Read,WebFetch,WebSearch' && test \"$max_turns\" = 4 && test \"$output\" = stream-json && test \"$safe$slash$chrome$verbose\" = 1111 || exit 73\n";
+  emit (init_line ~cwd:workspace ());
+  emit
+    (Printf.sprintf
+       {|{"type":"assistant","message":{"model":"claude-opus-5","role":"assistant","content":[{"type":"text","text":"MASC_CLAUDE_PROCESS_OK"}]},"session_id":%S}|}
+       session_id);
+  emit (result_line ~result:"MASC_CLAUDE_PROCESS_OK" ());
+  close_out output_channel;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let with_disallowed_environment f =
+  let keys =
+    [ "OPENAI_API_KEY"
+    ; "CODEX_API_KEY"
+    ; "GEMINI_API_KEY"
+    ; "GOOGLE_API_KEY"
+    ; "ANTHROPIC_API_KEY"
+    ; "ANTHROPIC_AUTH_TOKEN"
+    ; "ANTHROPIC_BASE_URL"
+    ; "CLAUDE_CODE_USE_BEDROCK"
+    ; "CLAUDE_CODE_USE_VERTEX"
+    ; "CLAUDE_CODE_USE_FOUNDRY"
+    ]
+  in
+  let previous = List.map (fun key -> key, Sys.getenv_opt key) keys in
+  List.iter (fun key -> Unix.putenv key "DISALLOWED_OVERRIDE") keys;
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter
+        (fun (key, value) -> Unix.putenv key (Option.value value ~default:""))
+        previous)
+    f
+;;
+
+let with_initialized_process_eio f =
+  Eio_main.run (fun env ->
+    Process_eio.init
+      ~cwd_default:Eio.Path.(Eio.Stdenv.fs env / ".")
+      ~proc_mgr:(Eio.Stdenv.process_mgr env)
+      ~clock:(Eio.Stdenv.clock env);
+    Fun.protect ~finally:Process_eio.reset_for_testing f)
+;;
+
+let test_process_boundary_start_and_resume () =
+  let workspace = temp_workspace () |> Unix.realpath in
+  let script = fixture_script ~workspace in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove script; cleanup_tree workspace)
+    (fun () ->
+       with_disallowed_environment (fun () ->
+         with_initialized_process_eio (fun () ->
+           let config : Runtime_claude_code_cli.config =
+             { cli_path = script
+             ; cwd = workspace
+             ; model = Some "claude-opus-5"
+             ; timeout_s = 5.0
+             ; max_turns = 4
+             }
+           in
+           let expect_ok = function
+             | Ok value -> value
+             | Error error -> fail (Runtime_claude_code_cli.error_to_string error)
+           in
+           let first =
+             Runtime_claude_code_cli.run_turn
+               config
+               ~session_mode:(Start { session_id })
+               ~prompt:"fixture start"
+             |> expect_ok
+           in
+           check string "process response" "MASC_CLAUDE_PROCESS_OK" first.text;
+           check bool "process start" false first.resumed;
+           let resumed =
+             Runtime_claude_code_cli.run_turn
+               config
+               ~session_mode:(Resume { session_id })
+               ~prompt:"fixture resume"
+             |> expect_ok
+           in
+           check bool "process resume" true resumed.resumed)))
+;;
+
+let test_environment_override_set_is_exact () =
+  List.iter
+    (fun key ->
+      check bool key true
+        (Runtime_claude_code_cli.For_testing.is_disallowed_environment_override key))
+    [ "ANTHROPIC_API_KEY"
+    ; "ANTHROPIC_AUTH_TOKEN"
+    ; "ANTHROPIC_BASE_URL"
+    ; "CLAUDE_CODE_USE_BEDROCK"
+    ; "CLAUDE_CODE_USE_VERTEX"
+    ; "CLAUDE_CODE_USE_FOUNDRY"
+    ];
+  check bool "OAuth subscription token remains official-client owned" false
+    (Runtime_claude_code_cli.For_testing.is_disallowed_environment_override
+       "CLAUDE_CODE_OAUTH_TOKEN");
+  check bool "unrelated env survives" false
+    (Runtime_claude_code_cli.For_testing.is_disallowed_environment_override "PATH")
+;;
+
+let () =
+  run
+    "runtime Claude Code CLI"
+    [ ( "typed stream-json boundary"
+      , [ test_case "strict success projection" `Quick test_strict_success_projection
+        ; test_case "resume identity" `Quick test_resume_requires_exact_identity
+        ; test_case
+            "rate limit beats success subtype"
+            `Quick
+            test_rate_limit_rejection_beats_success_subtype
+        ; test_case
+            "auth and permission boundary"
+            `Quick
+            test_api_key_source_and_permission_fail_closed
+        ; test_case "duplicate keys" `Quick test_duplicate_keys_fail_closed
+        ; test_case "init precedes events" `Quick test_init_must_precede_stream_events
+        ; test_case
+            "success cannot carry API error"
+            `Quick
+            test_success_cannot_carry_api_error
+        ; test_case
+            "canonical UUID session"
+            `Quick
+            test_session_id_must_be_canonical_uuid
+        ; test_case
+            "process start and resume"
+            `Quick
+            test_process_boundary_start_and_resume
+        ; test_case
+            "environment override set"
+            `Quick
+            test_environment_override_set_is_exact
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Outcome

Adds a typed, fail-closed process boundary for running one Claude Code CLI turn from the user's existing official-client login. This PR intentionally stops at the transport/parser boundary; Keeper dispatch and dashboard projection follow as separate small PRs.

## Runtime boundary

- invokes `claude --print --output-format stream-json --verbose`
- fixes permission mode to `plan` and the tool set to `Glob,Grep,Read,WebFetch,WebSearch`
- supports exact UUID start/resume identities
- removes metered API credentials and endpoint/cloud overrides from the child environment
- leaves `CLAUDE_CODE_OAUTH_TOKEN` official-client-owned; MASC neither reads nor manufactures credentials
- validates init cwd/model/session, permission mode, tools, and `apiKeySource=none`
- parses usage, cost, tool-call count, terminal failure, and rate-limit rejection as typed outcomes
- rejects duplicate JSON keys, oversized/unordered streams, identity drift, and contradictory terminal metadata

## Measured evidence

Measured locally with Claude Code `2.1.226` and `ANTHROPIC_API_KEY` removed:

- official CLI init reported `apiKeySource: none`, `permissionMode: plan`, and the exact read-only tool set
- the current account was rate-limited and emitted `rate_limit_event.status=rejected`, HTTP 429, and `is_error=true`
- the terminal event also reported `subtype=success`; this parser deliberately gives the measured rejection/error fields authority over that misleading subtype

This is evidence for authentication/protocol rejection handling, not a successful model turn claim.

## Verification

```text
dune exec --root . --build-dir /private/tmp/masc-claude-code-runtime-build-20260809 ./test/test_runtime_claude_code_cli.exe
10 tests run; all successful
```

The focused suite covers strict success projection, exact resume identity, measured 429 precedence, auth/permission boundaries, duplicate keys, init ordering, contradictory success metadata, UUID validation, real subprocess argv/environment behavior, and override classification.

Full `dune build .` is not claimed here.

## Stack note

Base: `feat/antigravity-keeper-runtime-20260809` at `e214f22257`.

The earlier stack PRs were manually closed without merge, so this PR does not claim those changes are on `main` and does not reopen them.
