### PR TITLE
feat(runtime): materialize Claude Code runtimes

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -284,7 +284,8 @@ let resolve_runtime_candidate id =
   | Some runtime ->
     (match runtime.Runtime.execution with
      | Runtime_execution.Codex_app_server _
-     | Runtime_execution.Antigravity_cli _ -> Ok runtime
+     | Runtime_execution.Antigravity_cli _
+     | Runtime_execution.Claude_code _ -> Ok runtime
      | Runtime_execution.Agent_core provider_config ->
        let* _request_body_cap =
          validate_provider_request_cap
@@ -790,6 +791,16 @@ let run_named
              on_runtime_observation
          | Error _ -> ());
         antigravity_result, None
+      | Runtime_execution.Claude_code _ ->
+        ( Error
+            (Agent_sdk.Error.Config
+               (Agent_sdk.Error.InvalidConfig
+                  { field = "claude_code"
+                  ; detail =
+                      "claude-code runtime is configured, but this stack layer does not yet \
+                       contain its Keeper driver"
+                  }))
+        , None )
       | Runtime_execution.Agent_core runtime_provider_config ->
        (match
           match provider_config_transform with

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -88,7 +88,8 @@ let vision_runtime_candidates ()
   |> List.filter_map (fun (rt : Runtime.t) ->
        match rt.Runtime.execution with
        | Runtime_execution.Codex_app_server _
-       | Runtime_execution.Antigravity_cli _ -> None
+       | Runtime_execution.Antigravity_cli _
+       | Runtime_execution.Claude_code _ -> None
        | Runtime_execution.Agent_core provider_config ->
          let caps = Runtime_agent.input_capabilities_of_runtime rt in
          if Runtime_agent.caps_admit_required_modalities caps [ "image" ]

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -448,7 +448,9 @@ let capabilities_for_runtime (rt : t) =
   match rt.execution with
   | Runtime_execution.Agent_core provider_config ->
     Llm_provider.Provider_config.capabilities_for_config_model provider_config
-  | Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _ -> None
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Antigravity_cli _
+  | Runtime_execution.Claude_code _ -> None
 ;;
 
 type max_context_source =
@@ -605,7 +607,8 @@ let validate_keeper_dispatch_request_caps
          | Some runtime ->
            (match runtime.execution with
             | Runtime_execution.Codex_app_server _
-            | Runtime_execution.Antigravity_cli _ -> None
+            | Runtime_execution.Antigravity_cli _
+            | Runtime_execution.Claude_code _ -> None
             | Runtime_execution.Agent_core provider_config ->
               (match
                  validate_request_body_cap
@@ -642,7 +645,9 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
     List.filter_map
       (fun (r : t) ->
          match r.execution, capabilities_for_runtime r with
-         | (Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _), _ -> None
+         | ( Runtime_execution.Codex_app_server _
+           | Runtime_execution.Antigravity_cli _
+           | Runtime_execution.Claude_code _ ), _ -> None
          | Runtime_execution.Agent_core _, Some _ -> None
          | Runtime_execution.Agent_core provider_config, None ->
            let provider_label =

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -203,7 +203,7 @@ let messages_api_compatible_provider_kind = function
 let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.provider)
     : (Llm_provider.Provider_config.provider_kind, string) result =
   match provider.api_format with
-  | Codex_app_server_runtime | Antigravity_cli_runtime ->
+  | Codex_app_server_runtime | Antigravity_cli_runtime | Claude_code_runtime ->
     Error
       (Printf.sprintf
          "provider %S uses official CLI protocol %s and cannot be materialized as an \
@@ -523,6 +523,37 @@ let antigravity_cli_execution (provider : Runtime_schema.provider)
             { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
 ;;
 
+let claude_code_execution (provider : Runtime_schema.provider)
+    (spec : Runtime_schema.model_spec) : (Runtime_execution.t, string) result =
+  match provider.transport with
+  | Http _ ->
+    Error
+      (Printf.sprintf
+         "provider %S uses protocol claude-code but declares an HTTP endpoint; \
+          an official Claude Code CLI command is required"
+         provider.id)
+  | Cli command when String.trim command = "" ->
+    Error (Printf.sprintf "provider %S declares an empty Claude Code CLI command" provider.id)
+  | Cli command ->
+    (match provider.credentials with
+     | Some _ ->
+       Error
+         (Printf.sprintf
+            "provider %S uses claude-code and must not declare credentials; \
+             the official Claude Code client owns subscription login"
+            provider.id)
+     | None when not provider.is_non_interactive ->
+       Error
+         (Printf.sprintf
+            "provider %S uses claude-code and must declare \
+             is-non-interactive = true"
+            provider.id)
+     | None ->
+       Ok
+         (Runtime_execution.Claude_code
+            { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
+;;
+
 let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema.binding)
     : (Runtime_execution.t, string) result =
   match Runtime_schema.model_of_id cfg binding.model_id with
@@ -536,6 +567,7 @@ let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema
           codex_app_server_execution provider spec
         | Runtime_schema.Antigravity_cli_runtime ->
           antigravity_cli_execution provider spec
+        | Runtime_schema.Claude_code_runtime -> claude_code_execution provider spec
         | Messages_api | Chat_completions_api | Ollama_api ->
           Result.map
             (fun provider_config -> Runtime_execution.Agent_core provider_config)

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -38,5 +38,6 @@ val binding_to_execution
     {!Runtime_execution.Agent_core}. The exact [codex-app-server] protocol over
     a credential-free CLI transport becomes
     {!Runtime_execution.Codex_app_server} and the exact [antigravity-cli]
-    protocol materializes as {!Runtime_execution.Antigravity_cli}. Other CLI
+    protocol materializes as {!Runtime_execution.Antigravity_cli}; the exact
+    [claude-code] protocol materializes as {!Runtime_execution.Claude_code}. Other CLI
     protocols remain rejected. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -684,7 +684,8 @@ let input_capabilities_of_runtime (rt : Runtime.t) =
     | Runtime_execution.Agent_core provider_config ->
       provider_caps_of_config provider_config
     | Runtime_execution.Codex_app_server _
-    | Runtime_execution.Antigravity_cli _ ->
+    | Runtime_execution.Antigravity_cli _
+    | Runtime_execution.Claude_code _ ->
       Llm_provider.Capabilities.default_capabilities
   in
   apply_runtime_model_input_capabilities

--- a/lib/runtime/runtime_execution.ml
+++ b/lib/runtime/runtime_execution.ml
@@ -10,10 +10,17 @@ type antigravity_cli =
   ; timeout_s : float
   }
 
+type claude_code =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
   | Antigravity_cli of antigravity_cli
+  | Claude_code of claude_code
 
 type checkpoint_owner =
   | Masc_oas
@@ -21,22 +28,24 @@ type checkpoint_owner =
 
 let agent_core_provider_config = function
   | Agent_core config -> Some config
-  | Codex_app_server _ | Antigravity_cli _ -> None
+  | Codex_app_server _ | Antigravity_cli _ | Claude_code _ -> None
 ;;
 
 let model_id = function
   | Agent_core config -> Some config.Llm_provider.Provider_config.model_id
   | Codex_app_server config -> config.model
   | Antigravity_cli config -> config.model
+  | Claude_code config -> config.model
 ;;
 
 let label = function
   | Agent_core _ -> "agent_core"
   | Codex_app_server _ -> "codex_app_server"
   | Antigravity_cli _ -> "antigravity_cli"
+  | Claude_code _ -> "claude_code"
 ;;
 
 let checkpoint_owner = function
   | Agent_core _ -> Masc_oas
-  | Codex_app_server _ | Antigravity_cli _ -> Official_client
+  | Codex_app_server _ | Antigravity_cli _ | Claude_code _ -> Official_client
 ;;

--- a/lib/runtime/runtime_execution.mli
+++ b/lib/runtime/runtime_execution.mli
@@ -4,7 +4,8 @@
     [Codex_app_server] means the official Codex client owns the whole turn;
     MASC owns admission, process lifetime, and result projection.
     [Antigravity_cli] has the same official-client ownership boundary, with
-    Antigravity's built-in tool loop fixed to plan+sandbox execution. *)
+    Antigravity's built-in tool loop fixed to plan+sandbox execution.
+    [Claude_code] fixes Claude Code to plan mode and a read-only tool set. *)
 
 type codex_app_server =
   { cli_path : string
@@ -18,10 +19,17 @@ type antigravity_cli =
   ; timeout_s : float
   }
 
+type claude_code =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
   | Antigravity_cli of antigravity_cli
+  | Claude_code of claude_code
 
 type checkpoint_owner =
   | Masc_oas

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -84,7 +84,8 @@ let resolve_runtime_providers ~runtime_id () =
     match rt.Runtime.execution with
     | Runtime_execution.Agent_core provider_config -> Ok provider_config
     | Runtime_execution.Codex_app_server _
-    | Runtime_execution.Antigravity_cli _ ->
+    | Runtime_execution.Antigravity_cli _
+    | Runtime_execution.Claude_code _ ->
       Error
         (Printf.sprintf
            "runtime %S is owned by an official CLI client, not the OAS agent_core"

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -15,6 +15,7 @@ type api_format =
   | Ollama_api
   | Codex_app_server_runtime
   | Antigravity_cli_runtime
+  | Claude_code_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -13,6 +13,7 @@ type api_format =
   | Ollama_api
   | Codex_app_server_runtime
   | Antigravity_cli_runtime
+  | Claude_code_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -107,7 +107,7 @@ let partition_results
 let canonical_protocol_of_protocol = function
   | "messages-cli" | "messages-http" | "openai-compatible-cli"
   | "openai-compatible-http" | "ollama-http" | "codex-app-server"
-  | "antigravity-cli" as protocol ->
+  | "antigravity-cli" | "claude-code" as protocol ->
     Some protocol
   | _ -> None
 ;;
@@ -116,7 +116,7 @@ let unknown_protocol_error s =
   Printf.sprintf
     "unknown protocol %S: expected one of messages-cli, messages-http, \
      openai-compatible-cli, openai-compatible-http, ollama-http, \
-     codex-app-server, antigravity-cli"
+     codex-app-server, antigravity-cli, claude-code"
     s
 ;;
 
@@ -130,6 +130,7 @@ let api_format_of_protocol (s : string)
   | "ollama-http" -> Ok Runtime_schema.Ollama_api
   | "codex-app-server" -> Ok Runtime_schema.Codex_app_server_runtime
   | "antigravity-cli" -> Ok Runtime_schema.Antigravity_cli_runtime
+  | "claude-code" -> Ok Runtime_schema.Claude_code_runtime
   | _ -> Error (unknown_protocol_error s)
 ;;
 

--- a/lib/runtime/runtime_toml.mli
+++ b/lib/runtime/runtime_toml.mli
@@ -35,7 +35,7 @@ val api_format_of_protocol : string -> (Runtime_schema.api_format, string) resul
 (** Map a TOML protocol string to a {!Runtime_schema.api_format} variant. Only
     the canonical labels are accepted: [messages-cli], [messages-http],
     [openai-compatible-cli], [openai-compatible-http], [ollama-http],
-    [codex-app-server], and [antigravity-cli]. The
+    [codex-app-server], [antigravity-cli], and [claude-code]. The
     deprecated provider-letter aliases [provider_d-http] / [provider-d-cli]
     (renamed in v0.19.43) are rejected with an "unknown protocol" error — they
     are NOT silently canonicalized — so a checked-in config still using them

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -775,7 +775,8 @@ let dashboard_runtime_append_probe_path base ~suffix =
 let dashboard_runtime_probe_url ~(api_format : Runtime_schema.api_format) base_url =
   match api_format with
   | Runtime_schema.Codex_app_server_runtime
-  | Runtime_schema.Antigravity_cli_runtime -> None
+  | Runtime_schema.Antigravity_cli_runtime
+  | Runtime_schema.Claude_code_runtime -> None
   | Runtime_schema.Ollama_api ->
     let base = dashboard_runtime_trim_trailing_slashes base_url in
     Some
@@ -886,7 +887,8 @@ let dashboard_runtime_model_count_of_body ~(api_format : Runtime_schema.api_form
     let json = Yojson.Safe.from_string body in
     match api_format with
     | Runtime_schema.Codex_app_server_runtime
-    | Runtime_schema.Antigravity_cli_runtime -> None
+    | Runtime_schema.Antigravity_cli_runtime
+    | Runtime_schema.Claude_code_runtime -> None
     | Runtime_schema.Ollama_api -> dashboard_runtime_list_member_len "models" json
     | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
       (match dashboard_runtime_list_member_len "data" json with
@@ -1558,6 +1560,16 @@ let runtime_request_config_json (rt : Runtime.t) =
       ; "tool_owner", `String "official_client"
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Claude_code config ->
+    `Assoc
+      [ "source", `String "official-client-runtime"
+      ; "execution", `String "claude_code"
+      ; "model", Json_util.string_opt_to_json config.model
+      ; "timeout_s", `Float config.timeout_s
+      ; "execution_mode", `String "plan_read_only"
+      ; "tool_owner", `String "official_client"
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core cfg ->
     `Assoc
     [ "source", `String "oas-provider-config"
@@ -1604,6 +1616,7 @@ let runtime_api_format_wire : Runtime_schema.api_format -> string = function
   | Runtime_schema.Ollama_api -> "ollama"
   | Runtime_schema.Codex_app_server_runtime -> "codex-app-server"
   | Runtime_schema.Antigravity_cli_runtime -> "antigravity-cli"
+  | Runtime_schema.Claude_code_runtime -> "claude-code"
 ;;
 
 let runtime_provider_behavior_capabilities_json
@@ -1721,6 +1734,14 @@ let effective_capabilities_json (rt : Runtime.t) =
       ; "tool_owner", `String "official_client"
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Claude_code _ ->
+    `Assoc
+      [ "source", `String "unverified"
+      ; "execution", `String "claude_code"
+      ; "execution_mode", `String "plan_read_only"
+      ; "tool_owner", `String "official_client"
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core provider_config ->
    (match Llm_provider.Provider_config.capabilities_for_config_model provider_config with
   | None -> `Null
@@ -1808,6 +1829,13 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
       ; "execution_mode", `String "plan_sandbox"
       ; "tool_owner", `String "official_client"
       ]
+  | Runtime_execution.Claude_code _ ->
+    `Assoc
+      [ "source", `String "official-client-owned"
+      ; "execution", `String "claude_code"
+      ; "execution_mode", `String "plan_read_only"
+      ; "tool_owner", `String "official_client"
+      ]
   | Runtime_execution.Agent_core provider_config ->
     let dialect = RD.for_provider_config provider_config in
     let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
@@ -1836,7 +1864,8 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
   let is_official_client_runtime =
     match rt.execution with
     | Runtime_execution.Codex_app_server _
-    | Runtime_execution.Antigravity_cli _ -> true
+    | Runtime_execution.Antigravity_cli _
+    | Runtime_execution.Claude_code _ -> true
     | Runtime_execution.Agent_core _ -> false
   in
   let runtime_status =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -91,7 +91,8 @@ let finalize_runtime_breakdown json =
 let validate_requested_model (runtime : Runtime.t) requested_model =
   match runtime.execution with
   | Runtime_execution.Codex_app_server _
-  | Runtime_execution.Antigravity_cli _ ->
+  | Runtime_execution.Antigravity_cli _
+  | Runtime_execution.Claude_code _ ->
     Error
       (Printf.sprintf
          "runtime %S is owned by an official CLI client; local_runtime_bench only \

--- a/test/dune
+++ b/test/dune
@@ -1944,6 +1944,7 @@
 (include stanzas/test_runtime_codex_app_server.inc)
 (include stanzas/test_runtime_antigravity_cli.inc)
 (include stanzas/test_runtime_claude_code_cli.inc)
+(include stanzas/test_runtime_claude_code_config.inc)
 (include stanzas/test_keeper_antigravity_runtime.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/stanzas/test_runtime_claude_code_config.inc
+++ b/test/stanzas/test_runtime_claude_code_config.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_claude_code_config)
+ (modules test_runtime_claude_code_config)
+ (libraries alcotest masc.runtime))

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -578,7 +578,8 @@ let test_provider_for_vision_uses_runtime_temperature () =
        | Some runtime ->
          (match runtime.Runtime.execution with
           | Runtime_execution.Codex_app_server _
-          | Runtime_execution.Antigravity_cli _ ->
+          | Runtime_execution.Antigravity_cli _
+          | Runtime_execution.Claude_code _ ->
             failwith "selected vision runtime should be agent_core"
           | Runtime_execution.Agent_core provider_config ->
             let configured = Vt.provider_for_vision provider_config in

--- a/test/test_runtime_claude_code_config.ml
+++ b/test/test_runtime_claude_code_config.ml
@@ -1,0 +1,89 @@
+open Alcotest
+
+let contains_substring value needle =
+  let value_length = String.length value in
+  let needle_length = String.length needle in
+  let rec scan index =
+    index + needle_length <= value_length
+    && (String.equal (String.sub value index needle_length) needle || scan (index + 1))
+  in
+  needle_length = 0 || scan 0
+;;
+
+let runtime_toml ?credential () =
+  let credential = Option.value credential ~default:"" in
+  Printf.sprintf
+    "[providers.claude]\n\
+     protocol = \"claude-code\"\n\
+     command = \"claude\"\n\
+     is-non-interactive = true\n\
+     %s\n\
+     [models.opus]\n\
+     api-name = \"claude-opus-5\"\n\
+     max-context = 128000\n\
+     \n\
+     [claude.opus]\n\
+     \n\
+     [runtime]\n\
+     default = \"claude.opus\"\n"
+    credential
+;;
+
+let with_runtime_toml content f =
+  let path = Filename.temp_file "masc-claude-code-config-" ".toml" in
+  let channel = open_out_bin path in
+  output_string channel content;
+  close_out channel;
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let test_materializes_as_official_client_runtime () =
+  with_runtime_toml (runtime_toml ()) (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error error -> failf "claude-code runtime should load: %s" error
+    | Ok (runtimes, default, _, _, _, _) ->
+      check int "one runtime" 1 (List.length runtimes);
+      check string "default id" "claude.opus" default.id;
+      (match default.execution with
+       | Runtime_execution.Claude_code config ->
+         check string "cli path" "claude" config.cli_path;
+         check (option string) "model" (Some "claude-opus-5") config.model;
+         check string "typed owner label" "claude_code"
+           (Runtime_execution.label default.execution);
+         check bool "agent_core config absent" true
+           (Option.is_none
+              (Runtime_execution.agent_core_provider_config default.execution))
+       | Runtime_execution.Agent_core _
+       | Runtime_execution.Codex_app_server _
+       | Runtime_execution.Antigravity_cli _ ->
+         fail "claude-code was materialized through the wrong execution owner"))
+;;
+
+let test_rejects_declared_credentials () =
+  let credential =
+    "[providers.claude.credentials]\n\
+     type = \"env\"\n\
+     key = \"ANTHROPIC_API_KEY\""
+  in
+  with_runtime_toml (runtime_toml ~credential ()) (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Ok _ -> fail "claude-code incorrectly admitted declared credentials"
+    | Error error ->
+      check bool "official login owns authentication" true
+        (contains_substring
+           error
+           "official Claude Code client owns subscription login"))
+;;
+
+let () =
+  run
+    "runtime Claude Code config"
+    [ ( "typed config boundary"
+      , [ test_case
+            "official-client materialization"
+            `Quick
+            test_materializes_as_official_client_runtime
+        ; test_case "credentials rejected" `Quick test_rejects_declared_credentials
+        ] )
+    ]
+;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -14,7 +14,8 @@ let agent_core_provider_config (runtime : Runtime.t) =
   match runtime.execution with
   | Runtime_execution.Agent_core provider_config -> provider_config
   | Runtime_execution.Codex_app_server _
-  | Runtime_execution.Antigravity_cli _ ->
+  | Runtime_execution.Antigravity_cli _
+  | Runtime_execution.Claude_code _ ->
     failf "runtime %s is not an agent_core provider" runtime.id
 ;;
 
@@ -3192,7 +3193,9 @@ let test_codex_app_server_materializes_as_turn_runtime () =
          check string "cli path" "codex" config.cli_path;
          check (option string) "model" (Some "gpt-5.6-sol") config.model
        | Runtime_execution.Antigravity_cli _ ->
-         fail "codex-app-server was incorrectly materialized as antigravity-cli"))
+         fail "codex-app-server was incorrectly materialized as antigravity-cli"
+       | Runtime_execution.Claude_code _ ->
+         fail "codex-app-server was incorrectly materialized as claude-code"))
 ;;
 
 let test_codex_app_server_rejects_declared_credentials () =
@@ -3244,7 +3247,9 @@ let test_antigravity_cli_materializes_as_turn_runtime () =
          check string "cli path" "agy" config.cli_path;
          check (option string) "model" (Some "gemini-3.6-flash-low") config.model
        | Runtime_execution.Agent_core _ | Runtime_execution.Codex_app_server _ ->
-         fail "antigravity-cli was materialized through the wrong execution owner"))
+         fail "antigravity-cli was materialized through the wrong execution owner"
+       | Runtime_execution.Claude_code _ ->
+         fail "antigravity-cli was incorrectly materialized as claude-code"))
 ;;
 
 let test_antigravity_cli_rejects_declared_credentials () =

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -362,7 +362,7 @@ max-concurrent = 1
                   "unknown protocol \"openai-http\": expected one of \
                    messages-cli, messages-http, openai-compatible-cli, \
                   openai-compatible-http, ollama-http, codex-app-server, \
-                  antigravity-cli")
+                  antigravity-cli, claude-code")
          errors)
 
 let test_runtime_toml_accepts_messages_caching_capability () =


### PR DESCRIPTION
## Outcome

Adds the exact `claude-code` runtime protocol and materializes it as a distinct official-client execution owner. It does not pass Claude Code through `agent_core` and it does not accept API credentials in `runtime.toml`.

Example:

```toml
[providers.claude]
protocol = "claude-code"
command = "claude"
is-non-interactive = true

[models.opus]
api-name = "claude-opus-5"
max-context = 128000

[claude.opus]

[runtime]
default = "claude.opus"
```

## Typed boundary

- adds `Runtime_schema.Claude_code_runtime`
- adds `Runtime_execution.Claude_code`
- rejects HTTP transport, empty command, interactive declaration, and all declared credentials
- marks checkpoints as official-client-owned
- excludes the runtime from OAS/agent_core/local-benchmark and image-runtime paths
- projects the configured runtime to the dashboard backend as `claude_code`, `plan_read_only`, `official_client`

This stack layer intentionally returns an explicit configuration error if Keeper dispatch is attempted. The next small PR replaces that branch with the durable Claude Code Keeper driver; there is no fallback to `agent_core`.

## Verification

```text
test_runtime_claude_code_config.exe: 2/2 passed
test_runtime_claude_code_cli.exe: 10/10 passed
```

Changed runtime, Keeper exhaustiveness, and dashboard runtime-info modules were also compiled as focused Dune object targets.

Full `dune build .` is not claimed: the stack base currently fails in existing Keeper approval modules (`Otel_metric_store`, approval queue interface/type mismatches), outside this diff.

## Stack

- base PR: #27743
- base SHA: `aed5143e25df2022b7c66bda6444aeaf2ef4771d`
