### PR TITLE
feat(keeper): run durable Claude Code sessions

### DIFF
--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -1,0 +1,404 @@
+open Result.Syntax
+
+let config_error ~field detail =
+  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })
+;;
+
+let internal_error detail = Agent_sdk.Error.Internal detail
+
+(* NDT-OK: the UUID is an opaque official-client session identity. *)
+let session_rng = Random.State.make_self_init ()
+let session_rng_mutex = Stdlib.Mutex.create ()
+
+let fresh_session_id () =
+  Stdlib.Mutex.protect session_rng_mutex (fun () ->
+    Uuidm.v4_gen session_rng () |> Uuidm.to_string)
+;;
+
+let text_of_blocks ~field blocks =
+  let rec loop texts = function
+    | [] -> Ok (String.concat "\n" (List.rev texts))
+    | Agent_sdk.Types.Text text :: rest -> loop (text :: texts) rest
+    | _ :: _ ->
+      Error
+        (config_error
+           ~field
+           "claude-code Keeper projection currently admits text blocks only")
+  in
+  loop [] blocks
+;;
+
+let user_message text : Agent_sdk.Types.message =
+  { role = User
+  ; content = [ Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let hook_error ~hook_name ~stage detail =
+  internal_error
+    (Printf.sprintf
+       "Claude Code runtime %s hook failed at %s: %s"
+       hook_name
+       (Agent_sdk.Hooks.hook_stage_to_string stage)
+       detail)
+;;
+
+let illegal_hook_decision ~hook_name decision =
+  config_error
+    ~field:"hooks"
+    (Printf.sprintf
+       "Claude Code runtime %s hook returned unsupported decision %s"
+       hook_name
+       (Agent_sdk.Hooks.decision_kind_to_string
+          (Agent_sdk.Hooks.classify_decision decision)))
+;;
+
+let invoke_turn_hook ~keeper_name ~turn_count ~hook_name hook event =
+  Agent_sdk.Agent_tools.invoke_hook
+    ~tracer:Agent_sdk.Tracing.null
+    ~agent_name:keeper_name
+    ~turn_count
+    ~hook_name
+    hook
+    event
+;;
+
+let render_message (message : Agent_sdk.Types.message) =
+  let* text = text_of_blocks ~field:"initial_messages" message.content in
+  let role =
+    match message.role with
+    | System -> "SYSTEM"
+    | User -> "USER"
+    | Assistant -> "ASSISTANT"
+    | Tool -> "TOOL"
+  in
+  if message.role = Tool
+  then
+    Error
+      (config_error
+         ~field:"initial_messages"
+         "claude-code history projection does not admit OAS tool messages")
+  else Ok (Printf.sprintf "%s:\n%s" role text)
+;;
+
+let render_messages messages =
+  let rec loop acc = function
+    | [] -> Ok (String.concat "\n\n" (List.rev acc))
+    | message :: rest ->
+      let* rendered = render_message message in
+      loop (rendered :: acc) rest
+  in
+  loop [] messages
+;;
+
+let prepare_prompt ~keeper_name ~turn_count ~is_resume ~goal ~system_prompt
+    ~initial_messages ~model_input_projection ~hooks =
+  let input_messages =
+    if is_resume then [ user_message goal ] else initial_messages @ [ user_message goal ]
+  in
+  let before_turn =
+    invoke_turn_hook
+      ~keeper_name
+      ~turn_count
+      ~hook_name:"before_turn"
+      hooks.Agent_sdk.Hooks.before_turn
+      (Agent_sdk.Hooks.BeforeTurn { turn = turn_count; messages = input_messages })
+  in
+  let* messages =
+    match before_turn with
+    | Continue -> Ok input_messages
+    | Nudge text -> Ok (input_messages @ [ user_message text ])
+    | HookFailed { stage; detail } -> Error (hook_error ~hook_name:"before_turn" ~stage detail)
+    | decision -> Error (illegal_hook_decision ~hook_name:"before_turn" decision)
+  in
+  let before_turn_params =
+    invoke_turn_hook
+      ~keeper_name
+      ~turn_count
+      ~hook_name:"before_turn_params"
+      hooks.before_turn_params
+      (Agent_sdk.Hooks.BeforeTurnParams
+         { turn = turn_count
+         ; messages
+         ; last_tool_results = []
+         ; current_params = Agent_sdk.Hooks.default_turn_params
+         ; reasoning = Agent_sdk.Hooks.empty_reasoning_summary
+         })
+  in
+  let* params =
+    match before_turn_params with
+    | Continue -> Ok Agent_sdk.Hooks.default_turn_params
+    | AdjustParams params -> Ok params
+    | HookFailed { stage; detail } ->
+      Error (hook_error ~hook_name:"before_turn_params" ~stage detail)
+    | decision -> Error (illegal_hook_decision ~hook_name:"before_turn_params" decision)
+  in
+  let unsupported field value =
+    match value with
+    | None -> Ok ()
+    | Some _ ->
+      Error
+        (config_error
+           ~field
+           "claude-code does not project this OAS turn parameter; select an exact Claude Code model id")
+  in
+  let* () = unsupported "temperature" params.temperature in
+  let* () = unsupported "thinking_budget" params.thinking_budget in
+  let* () = unsupported "reasoning_effort" params.reasoning_effort in
+  let* () = unsupported "enable_thinking" params.enable_thinking in
+  let* () = unsupported "preserve_thinking" params.preserve_thinking in
+  let* () = unsupported "tool_choice" params.tool_choice in
+  let* messages =
+    match model_input_projection with
+    | None -> Ok messages
+    | Some project ->
+      (try
+         match project messages with
+         | Ok projected -> Ok projected
+         | Error detail -> Error (config_error ~field:"model_input_projection" detail)
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn ->
+         Error
+           (internal_error
+              ("Claude Code runtime model input projection raised: "
+               ^ Printexc.to_string exn)))
+  in
+  let* rendered = render_messages messages in
+  let system_prompt =
+    Option.value params.system_prompt_override ~default:system_prompt
+  in
+  let system_context =
+    [ (if is_resume then None else String_util.trim_to_option system_prompt)
+    ; Option.bind params.extra_system_context String_util.trim_to_option
+    ]
+    |> List.filter_map Fun.id
+  in
+  Ok (String.concat "\n\n" (system_context @ [ rendered ]))
+;;
+
+let claude_code_error_to_sdk_error = function
+  | Runtime_claude_code_cli.Invalid_config detail ->
+    config_error ~field:"claude_code" detail
+  | Runtime_claude_code_cli.Turn_rejected { reset_at; detail; _ } ->
+    let retry_after =
+      Option.map
+        (fun timestamp -> Float.max 0.0 (Float.of_int timestamp -. Time_compat.now ()))
+        reset_at
+    in
+    Agent_sdk.Error.Api (Agent_sdk.Retry.RateLimited { retry_after; message = detail })
+  | Runtime_claude_code_cli.Timeout seconds ->
+    Agent_sdk.Error.Api
+      (Agent_sdk.Retry.Timeout
+         { message = Printf.sprintf "Claude Code turn timed out after %.3fs" seconds
+         ; phase = None
+         })
+  | error -> Agent_sdk.Error.Internal (Runtime_claude_code_cli.error_to_string error)
+;;
+
+let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
+    ~initial_messages ~model_input_projection ~hooks
+    ~(config : Runtime_execution.claude_code) =
+  let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
+  let* goal =
+    match goal_blocks with
+    | None -> Ok goal
+    | Some blocks -> text_of_blocks ~field:"goal_blocks" blocks
+  in
+  let* stored_session =
+    match Keeper_claude_code_session_store.load ~base_path ~keeper_name with
+    | Ok session -> Ok session
+    | Error detail ->
+      Error (internal_error ("Claude Code session binding load failed: " ^ detail))
+  in
+  let* session_mode, turn_count =
+    match stored_session with
+    | None -> Ok (Runtime_claude_code_cli.Start { session_id = fresh_session_id () }, 1)
+    | Some session when not (String.equal session.runtime_id runtime_id) ->
+      Error
+        (config_error
+           ~field:"claude_code_session.runtime_id"
+           (Printf.sprintf
+              "stored runtime %S does not match selected runtime %S"
+              session.runtime_id
+              runtime_id))
+    | Some { phase = Settled { session_id }; turn_count; _ }
+      when turn_count < Int.max_int ->
+      Ok (Runtime_claude_code_cli.Resume { session_id }, turn_count + 1)
+    | Some { phase = Settled _; _ } ->
+      Error
+        (config_error
+           ~field:"claude_code_session.turn_count"
+           "stored Claude Code session turn count cannot be incremented")
+    | Some { phase = Claimed _; _ } ->
+      Error
+        (config_error
+           ~field:"claude_code_session.phase"
+           "stored Claude Code session has an unsettled claim; refusing duplicate execution")
+  in
+  let is_resume =
+    match session_mode with
+    | Runtime_claude_code_cli.Start _ -> false
+    | Runtime_claude_code_cli.Resume _ -> true
+  in
+  let* prompt =
+    prepare_prompt
+      ~keeper_name
+      ~turn_count
+      ~is_resume
+      ~goal
+      ~system_prompt
+      ~initial_messages
+      ~model_input_projection
+      ~hooks
+  in
+  let client_config : Runtime_claude_code_cli.config =
+    { cli_path = config.cli_path
+    ; cwd = base_path
+    ; model = config.model
+    ; timeout_s = config.timeout_s
+    ; max_turns = config.max_turns
+    }
+  in
+  let* () =
+    match Runtime_claude_code_cli.validate_run ~session_mode client_config ~prompt with
+    | Ok () -> Ok ()
+    | Error error -> Error (claude_code_error_to_sdk_error error)
+  in
+  let* claimed =
+    match
+      Keeper_claude_code_session_store.claim
+        ~base_path
+        ~keeper_name
+        ~expected:stored_session
+        ~runtime_id
+        ~updated_at:(Time_compat.now ())
+    with
+    | Ok session -> Ok session
+    | Error detail -> Error (internal_error ("Claude Code session claim failed: " ^ detail))
+  in
+  let started_at = Time_compat.now () in
+  match Runtime_claude_code_cli.run_turn ~session_mode client_config ~prompt with
+  | Error error -> Error (claude_code_error_to_sdk_error error)
+  | Ok turn ->
+    let latency_ms = Int.of_float ((Time_compat.now () -. started_at) *. 1000.0) in
+    let usage : Agent_sdk.Types.api_usage =
+      { input_tokens = turn.usage.input_tokens
+      ; output_tokens = turn.usage.output_tokens
+      ; cache_creation_input_tokens = turn.usage.cache_creation_input_tokens
+      ; cache_read_input_tokens = turn.usage.cache_read_input_tokens
+      ; cost_usd = Some turn.usage.total_cost_usd
+      }
+    in
+    let response =
+      { Agent_sdk.Types.id =
+          Printf.sprintf "%s:%d" turn.session_id turn_count
+      ; model = turn.model
+      ; stop_reason = EndTurn
+      ; content = [ Text turn.text ]
+      ; usage = Some usage
+      ; telemetry =
+          Some
+            { Agent_sdk.Types.default_inference_telemetry with
+              request_latency_ms = Some latency_ms
+            ; canonical_model_id = Some turn.model
+            }
+      }
+    in
+    let after_turn =
+      invoke_turn_hook
+        ~keeper_name
+        ~turn_count
+        ~hook_name:"after_turn"
+        hooks.after_turn
+        (Agent_sdk.Hooks.AfterTurn { turn = turn_count; response })
+    in
+    let* () =
+      match after_turn with
+      | Continue -> Ok ()
+      | HookFailed { stage; detail } ->
+        Error (hook_error ~hook_name:"after_turn" ~stage detail)
+      | decision -> Error (illegal_hook_decision ~hook_name:"after_turn" decision)
+    in
+    let on_stop =
+      invoke_turn_hook
+        ~keeper_name
+        ~turn_count
+        ~hook_name:"on_stop"
+        hooks.on_stop
+        (Agent_sdk.Hooks.OnStop { reason = response.stop_reason; response })
+    in
+    let* () =
+      match on_stop with
+      | Continue -> Ok ()
+      | HookFailed { stage; detail } ->
+        Error (hook_error ~hook_name:"on_stop" ~stage detail)
+      | decision -> Error (illegal_hook_decision ~hook_name:"on_stop" decision)
+    in
+    let* _settled =
+      match
+        Keeper_claude_code_session_store.settle
+          ~base_path
+          ~keeper_name
+          ~expected:claimed
+          ~session_id:turn.session_id
+          ~usage:turn.usage
+          ~updated_at:(Time_compat.now ())
+      with
+      | Ok session -> Ok session
+      | Error detail ->
+        Error (internal_error ("Claude Code session settlement failed: " ^ detail))
+    in
+    let capture, _metrics =
+      Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
+    in
+    Runtime_observation.record_attempt_terminal
+      capture
+      ~model_id:turn.model
+      ~latency_ms:(Some latency_ms)
+      ~error:None;
+    let runtime_observation =
+      Runtime_observation.runtime_observation_with_metrics
+        ~runtime_id
+        ~strategy:"official_client_runtime"
+        ~configured_labels:
+          [ "claude_code"
+          ; "execution_mode=plan_read_only"
+          ; "tool_owner=official_client"
+          ; "masc_tool_hooks=unavailable"
+          ; Printf.sprintf "permission_mode=%s" turn.permission_mode
+          ; Printf.sprintf "tool_calls=%d" turn.tool_calls
+          ; Printf.sprintf "resumed=%b" turn.resumed
+          ; Printf.sprintf "turn_count=%d" turn_count
+          ; Printf.sprintf "client_turns=%d" turn.num_turns
+          ; Printf.sprintf "input_tokens=%d" turn.usage.input_tokens
+          ; Printf.sprintf "output_tokens=%d" turn.usage.output_tokens
+          ; Printf.sprintf
+              "cache_creation_input_tokens=%d"
+              turn.usage.cache_creation_input_tokens
+          ; Printf.sprintf
+              "cache_read_input_tokens=%d"
+              turn.usage.cache_read_input_tokens
+          ; Printf.sprintf "total_cost_usd=%.12g" turn.usage.total_cost_usd
+          ]
+        ~candidate_count:1
+        ~selected_model_raw:(Some turn.model)
+        ~capture
+        ~attempt_details_source:"claude_code"
+        ~oas_internal_runtime_allowed:false
+        ()
+    in
+    Ok
+      { Runtime_agent.response
+      ; checkpoint = None
+      ; session_id = turn.session_id
+      ; turns = turn_count
+      ; trace_ref = None
+      ; run_validation = None
+      ; runtime_observation = Some runtime_observation
+      ; stop_reason = Completed
+      }
+;;

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -1,0 +1,17 @@
+(** Keeper projection for the official Claude Code CLI turn runtime.
+
+    Claude Code owns its built-in tool loop. This boundary deliberately does
+    not project MASC tools, Gate callbacks, or OAS checkpoints into that loop. *)
+
+val run :
+  runtime_id:string ->
+  keeper_name:string ->
+  base_path:string ->
+  goal:string ->
+  goal_blocks:Agent_sdk.Types.content_block list option ->
+  system_prompt:string ->
+  initial_messages:Agent_sdk.Types.message list ->
+  model_input_projection:Agent_sdk.Agent.model_input_projection option ->
+  hooks:Agent_sdk.Hooks.hooks option ->
+  config:Runtime_execution.claude_code ->
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_claude_code_session_store.ml
+++ b/lib/keeper/keeper_claude_code_session_store.ml
@@ -1,0 +1,309 @@
+type phase =
+  | Claimed of { previous_session_id : string option }
+  | Settled of { session_id : string }
+
+type t =
+  { runtime_id : string
+  ; phase : phase
+  ; turn_count : int
+  ; last_usage : Runtime_claude_code_cli.usage option
+  ; updated_at : float
+  }
+
+let ( let* ) = Result.bind
+let schema = "masc.keeper.claude-code-session.v1"
+let filename = "claude-code-session.json"
+let state_dirname = "official-client-runtime"
+let lock_filename = "claude-code-session.lock"
+
+let state_dir ~base_path ~keeper_name =
+  if not (Safe_identifier.is_portable_name keeper_name)
+  then Error (Printf.sprintf "invalid Claude Code session Keeper name %S" keeper_name)
+  else
+    Ok
+      (Filename.concat
+         (Filename.concat
+            (Common.keepers_runtime_dir_of_base ~base_path)
+            keeper_name)
+         state_dirname)
+;;
+
+let path ~base_path ~keeper_name =
+  Result.map
+    (fun directory -> Filename.concat directory filename)
+    (state_dir ~base_path ~keeper_name)
+;;
+
+let non_empty field value =
+  if String.trim value = ""
+  then Error (Printf.sprintf "Claude Code session %s must not be empty" field)
+  else Ok ()
+;;
+
+let valid_session_id value =
+  if String.length value = 36 && Option.is_some (Uuidm.of_string value)
+  then Ok ()
+  else Error "Claude Code session_id must be a UUID"
+;;
+
+let validate_usage (usage : Runtime_claude_code_cli.usage) =
+  if
+    usage.input_tokens < 0
+    || usage.output_tokens < 0
+    || usage.cache_creation_input_tokens < 0
+    || usage.cache_read_input_tokens < 0
+  then Error "Claude Code session usage must be non-negative"
+  else if not (Float.is_finite usage.total_cost_usd) || usage.total_cost_usd < 0.0
+  then Error "Claude Code session cost must be finite and non-negative"
+  else Ok ()
+;;
+
+let validate_phase = function
+  | Claimed { previous_session_id = None } -> Ok ()
+  | Claimed { previous_session_id = Some session_id }
+  | Settled { session_id } -> valid_session_id session_id
+;;
+
+let validate state =
+  let* () = non_empty "runtime_id" state.runtime_id in
+  let* () = validate_phase state.phase in
+  let* () =
+    match state.last_usage with
+    | None -> Ok ()
+    | Some usage -> validate_usage usage
+  in
+  if state.turn_count <= 0
+  then Error "Claude Code session turn_count must be positive"
+  else if not (Float.is_finite state.updated_at)
+  then Error "Claude Code session updated_at must be finite"
+  else Ok ()
+;;
+
+let phase_to_yojson = function
+  | Claimed { previous_session_id } ->
+    `Assoc
+      [ "kind", `String "claimed"
+      ; ( "previous_session_id"
+        , Option.fold
+            ~none:`Null
+            ~some:(fun session_id -> `String session_id)
+            previous_session_id )
+      ]
+  | Settled { session_id } ->
+    `Assoc
+      [ "kind", `String "settled"
+      ; "session_id", `String session_id
+      ]
+;;
+
+let phase_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "kind", `String "claimed"; "previous_session_id", `Null ] ->
+       Ok (Claimed { previous_session_id = None })
+     | [ "kind", `String "claimed"
+       ; "previous_session_id", `String session_id
+       ] ->
+       Ok (Claimed { previous_session_id = Some session_id })
+     | [ "session_id", `String session_id
+       ; "kind", `String "settled"
+       ] -> Ok (Settled { session_id })
+     | _ -> Error "Claude Code session phase fields are not exact")
+  | _ -> Error "Claude Code session phase must be a JSON object"
+;;
+
+let usage_to_yojson (usage : Runtime_claude_code_cli.usage) =
+  `Assoc
+    [ "cache_creation_input_tokens", `Int usage.cache_creation_input_tokens
+    ; "cache_read_input_tokens", `Int usage.cache_read_input_tokens
+    ; "input_tokens", `Int usage.input_tokens
+    ; "output_tokens", `Int usage.output_tokens
+    ; "total_cost_usd", `Float usage.total_cost_usd
+    ]
+;;
+
+let usage_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "cache_creation_input_tokens", `Int cache_creation_input_tokens
+       ; "cache_read_input_tokens", `Int cache_read_input_tokens
+       ; "input_tokens", `Int input_tokens
+       ; "output_tokens", `Int output_tokens
+       ; "total_cost_usd", `Float total_cost_usd
+       ] ->
+       let usage : Runtime_claude_code_cli.usage =
+         { input_tokens
+         ; output_tokens
+         ; cache_creation_input_tokens
+         ; cache_read_input_tokens
+         ; total_cost_usd
+         }
+       in
+       let* () = validate_usage usage in
+       Ok usage
+     | _ -> Error "Claude Code session usage fields are not exact")
+  | _ -> Error "Claude Code session usage must be a JSON object"
+;;
+
+let to_yojson state =
+  `Assoc
+    [ ( "last_usage"
+      , Option.fold ~none:`Null ~some:usage_to_yojson state.last_usage )
+    ; "phase", phase_to_yojson state.phase
+    ; "runtime_id", `String state.runtime_id
+    ; "schema", `String schema
+    ; "turn_count", `Int state.turn_count
+    ; "updated_at", `Float state.updated_at
+    ]
+;;
+
+let of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "last_usage", last_usage_json
+       ; "phase", phase_json
+       ; "runtime_id", `String runtime_id
+       ; "schema", `String encoded_schema
+       ; "turn_count", `Int turn_count
+       ; "updated_at", `Float updated_at
+       ] ->
+       if encoded_schema <> schema
+       then Error "unsupported Claude Code session schema"
+       else
+         let* phase = phase_of_yojson phase_json in
+         let* last_usage =
+           match last_usage_json with
+           | `Null -> Ok None
+           | json -> Result.map Option.some (usage_of_yojson json)
+         in
+         let state = { runtime_id; phase; turn_count; last_usage; updated_at } in
+         let* () = validate state in
+         Ok state
+     | _ -> Error "Claude Code session fields are not exact")
+  | _ -> Error "Claude Code session must be a JSON object"
+;;
+
+let equal left right =
+  String.equal left.runtime_id right.runtime_id
+  && left.phase = right.phase
+  && Int.equal left.turn_count right.turn_count
+  && left.last_usage = right.last_usage
+  && Float.equal left.updated_at right.updated_at
+;;
+
+let load_path state_path =
+  if not (Fs_compat.file_exists state_path)
+  then Ok None
+  else
+    let* json = Safe_ops.read_json_file_safe state_path in
+    let* state = of_yojson json in
+    Ok (Some state)
+;;
+
+let load ~base_path ~keeper_name =
+  let* state_path = path ~base_path ~keeper_name in
+  load_path state_path
+;;
+
+let save_path ~state_dir state =
+  let* () = validate state in
+  let state_path = Filename.concat state_dir filename in
+  let* () =
+    match
+      Keeper_fs.save_json_durable_atomic
+        ~ownership_root:state_dir
+        ~pretty:false
+        state_path
+        (to_yojson state)
+    with
+    | Ok () -> Ok ()
+    | Error error -> Error (Keeper_fs.durable_write_error_to_string error)
+  in
+  let* persisted = load_path state_path in
+  match persisted with
+  | Some persisted when equal persisted state -> Ok ()
+  | Some _ -> Error "Claude Code session changed after durable write"
+  | None -> Error "Claude Code session missing after durable write"
+;;
+
+let prepare_state_dir ~base_path ~keeper_name =
+  let* directory = state_dir ~base_path ~keeper_name in
+  try
+    let (_ : string) = Keeper_fs.ensure_dir directory in
+    Ok directory
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let with_store_lock ~base_path ~keeper_name f =
+  let* directory = prepare_state_dir ~base_path ~keeper_name in
+  match
+    File_lock_eio.with_durable_lock
+      ~lock_path:(Filename.concat directory lock_filename)
+      (fun () -> f directory)
+  with
+  | Ok result -> result
+  | Error error -> Error (File_lock_eio.durable_lock_error_to_string error)
+;;
+
+let transition ~base_path ~keeper_name ~expected next =
+  let* () = validate next in
+  with_store_lock ~base_path ~keeper_name (fun directory ->
+    let* current = load_path (Filename.concat directory filename) in
+    if Option.equal equal current expected
+    then save_path ~state_dir:directory next |> Result.map (fun () -> next)
+    else Error "Claude Code session changed before durable transition")
+;;
+
+let claim ~base_path ~keeper_name ~expected ~runtime_id ~updated_at =
+  let* () =
+    match expected with
+    | Some state when not (String.equal state.runtime_id runtime_id) ->
+      Error "Claude Code session runtime_id cannot change during claim"
+    | None | Some _ -> Ok ()
+  in
+  let* previous_session_id, turn_count, last_usage =
+    match expected with
+    | None -> Ok (None, 1, None)
+    | Some { phase = Settled { session_id }; turn_count; last_usage; _ }
+      when turn_count < Int.max_int ->
+      Ok (Some session_id, turn_count + 1, last_usage)
+    | Some { phase = Settled _; _ } ->
+      Error "settled Claude Code session turn count cannot be incremented"
+    | Some { phase = Claimed _; _ } ->
+      Error "Claude Code session has an unsettled claim; refusing duplicate execution"
+  in
+  transition
+    ~base_path
+    ~keeper_name
+    ~expected
+    { runtime_id
+    ; phase = Claimed { previous_session_id }
+    ; turn_count
+    ; last_usage
+    ; updated_at
+    }
+;;
+
+let settle ~base_path ~keeper_name ~expected ~session_id ~usage ~updated_at =
+  match expected.phase with
+  | Settled _ -> Error "Claude Code session can settle only from a claim"
+  | Claimed { previous_session_id } ->
+    let* () =
+      match previous_session_id with
+      | None when expected.turn_count = 1 -> Ok ()
+      | Some previous when expected.turn_count >= 2 && String.equal previous session_id ->
+        Ok ()
+      | None | Some _ -> Error "Claude Code settlement session identity changed"
+    in
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase = Settled { session_id }
+      ; last_usage = Some usage
+      ; updated_at
+      }
+;;

--- a/lib/keeper/keeper_claude_code_session_store.mli
+++ b/lib/keeper/keeper_claude_code_session_store.mli
@@ -1,0 +1,33 @@
+(** Durable per-Keeper Claude Code session binding. *)
+
+type phase =
+  | Claimed of { previous_session_id : string option }
+  | Settled of { session_id : string }
+
+type t =
+  { runtime_id : string
+  ; phase : phase
+  ; turn_count : int
+  ; last_usage : Runtime_claude_code_cli.usage option
+  ; updated_at : float
+  }
+
+val path : base_path:string -> keeper_name:string -> (string, string) result
+val load : base_path:string -> keeper_name:string -> (t option, string) result
+
+val claim :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t option ->
+  runtime_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val settle :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  session_id:string ->
+  usage:Runtime_claude_code_cli.usage ->
+  updated_at:float ->
+  (t, string) result

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -791,16 +791,53 @@ let run_named
              on_runtime_observation
          | Error _ -> ());
         antigravity_result, None
-      | Runtime_execution.Claude_code _ ->
-        ( Error
-            (Agent_sdk.Error.Config
-               (Agent_sdk.Error.InvalidConfig
-                  { field = "claude_code"
-                  ; detail =
-                      "claude-code runtime is configured, but this stack layer does not yet \
-                       contain its Keeper driver"
-                  }))
-        , None )
+      | Runtime_execution.Claude_code config ->
+        let claude_code_result =
+          match provider_config_transform, oas_checkpoint with
+          | Some _, _ ->
+            Error
+              (Agent_sdk.Error.Config
+                 (Agent_sdk.Error.InvalidConfig
+                    { field = "provider_config_transform"
+                    ; detail =
+                        "provider config transforms cannot target a claude-code runtime"
+                    }))
+          | None, Some _ ->
+            Error
+              (Agent_sdk.Error.Config
+                 (Agent_sdk.Error.InvalidConfig
+                    { field = "oas_checkpoint"
+                    ; detail =
+                        "an OAS agent_core checkpoint cannot resume through a claude-code runtime"
+                    }))
+          | None, None ->
+            Keeper_claude_code_runtime.run
+              ~runtime_id:attempt_runtime_id
+              ~keeper_name
+              ~base_path
+              ~goal
+              ~goal_blocks
+              ~system_prompt
+              ~initial_messages
+              ~model_input_projection
+              ~hooks
+              ~config
+        in
+        Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
+        let claude_code_result =
+          Result.bind claude_code_result (fun run_result ->
+            Keeper_turn_driver_try_provider.apply_accept
+              ~runtime_id:attempt_runtime_id
+              ~accept
+              run_result)
+        in
+        (match claude_code_result with
+         | Ok run_result ->
+           Option.iter
+             (fun observe -> Option.iter observe run_result.Runtime_agent.runtime_observation)
+             on_runtime_observation
+         | Error _ -> ());
+        claude_code_result, None
       | Runtime_execution.Agent_core runtime_provider_config ->
        (match
           match provider_config_transform with

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -551,7 +551,11 @@ let claude_code_execution (provider : Runtime_schema.provider)
      | None ->
        Ok
          (Runtime_execution.Claude_code
-            { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
+            { cli_path = command
+            ; model = Some spec.api_name
+            ; timeout_s = 300.0
+            ; max_turns = 12
+            }))
 ;;
 
 let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema.binding)

--- a/lib/runtime/runtime_execution.ml
+++ b/lib/runtime/runtime_execution.ml
@@ -14,6 +14,7 @@ type claude_code =
   { cli_path : string
   ; model : string option
   ; timeout_s : float
+  ; max_turns : int
   }
 
 type t =

--- a/lib/runtime/runtime_execution.mli
+++ b/lib/runtime/runtime_execution.mli
@@ -23,6 +23,7 @@ type claude_code =
   { cli_path : string
   ; model : string option
   ; timeout_s : float
+  ; max_turns : int
   }
 
 type t =

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1566,6 +1566,7 @@ let runtime_request_config_json (rt : Runtime.t) =
       ; "execution", `String "claude_code"
       ; "model", Json_util.string_opt_to_json config.model
       ; "timeout_s", `Float config.timeout_s
+      ; "max_turns", `Int config.max_turns
       ; "execution_mode", `String "plan_read_only"
       ; "tool_owner", `String "official_client"
       ; "verified", `Bool false

--- a/test/dune
+++ b/test/dune
@@ -1946,6 +1946,7 @@
 (include stanzas/test_runtime_claude_code_cli.inc)
 (include stanzas/test_runtime_claude_code_config.inc)
 (include stanzas/test_keeper_antigravity_runtime.inc)
+(include stanzas/test_keeper_claude_code_runtime.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)
 

--- a/test/stanzas/test_keeper_claude_code_runtime.inc
+++ b/test/stanzas/test_keeper_claude_code_runtime.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_claude_code_runtime)
+ (modules test_keeper_claude_code_runtime)
+ (libraries masc masc_test_deps))

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -1,0 +1,237 @@
+open Alcotest
+open Masc
+
+let session_id = "9971bfe0-4e21-40f9-8b5d-715ec5096965"
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let temp_workspace prefix =
+  let path = Filename.temp_file prefix "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  Unix.realpath path
+;;
+
+let cleanup_tree root =
+  let rec remove path =
+    if Sys.file_exists path
+    then if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try remove root with
+  | _ -> ()
+;;
+
+let fixture_script ~workspace =
+  let path = Filename.temp_file "masc-claude-keeper-" ".sh" in
+  let output = open_out_bin path in
+  output_string output "#!/bin/sh\n";
+  output_string output
+    ("test \"$PWD\" = " ^ shell_quote workspace ^ " || exit 71\n");
+  output_string output "session=\nresponse=MASC_CLAUDE_KEEPER_START\n";
+  output_string output
+    "permission= tools= output_format= max_turns= safe= slash= chrome= verbose=\n";
+  output_string output
+    "while test \"$#\" -gt 0; do case \"$1\" in --session-id) shift; session=\"$1\" ;; --resume) shift; session=\"$1\"; response=MASC_CLAUDE_KEEPER_RESUME ;; --permission-mode) shift; permission=\"$1\" ;; --tools) shift; tools=\"$1\" ;; --output-format) shift; output_format=\"$1\" ;; --max-turns) shift; max_turns=\"$1\" ;; --safe-mode) safe=1 ;; --disable-slash-commands) slash=1 ;; --no-chrome) chrome=1 ;; --verbose) verbose=1 ;; esac; shift; done\n";
+  output_string output
+    "test -n \"$session\" && test \"$permission\" = plan && test \"$tools\" = 'Glob,Grep,Read,WebFetch,WebSearch' && test \"$output_format\" = stream-json && test \"$max_turns\" = 12 && test \"$safe$slash$chrome$verbose\" = 1111 || exit 72\n";
+  output_string output
+    "printf '%s\\n' \"{\\\"type\\\":\\\"system\\\",\\\"subtype\\\":\\\"init\\\",\\\"cwd\\\":\\\"$PWD\\\",\\\"session_id\\\":\\\"$session\\\",\\\"tools\\\":[\\\"Glob\\\",\\\"Grep\\\",\\\"Read\\\",\\\"WebFetch\\\",\\\"WebSearch\\\"],\\\"model\\\":\\\"claude-opus-5\\\",\\\"permissionMode\\\":\\\"plan\\\",\\\"apiKeySource\\\":\\\"none\\\"}\"\n";
+  output_string output
+    "printf '%s\\n' \"{\\\"type\\\":\\\"assistant\\\",\\\"message\\\":{\\\"model\\\":\\\"claude-opus-5\\\",\\\"role\\\":\\\"assistant\\\",\\\"content\\\":[{\\\"type\\\":\\\"tool_use\\\",\\\"id\\\":\\\"tool-1\\\",\\\"name\\\":\\\"Read\\\",\\\"input\\\":{}}]},\\\"session_id\\\":\\\"$session\\\"}\"\n";
+  output_string output
+    "printf '%s\\n' \"{\\\"type\\\":\\\"result\\\",\\\"subtype\\\":\\\"success\\\",\\\"is_error\\\":false,\\\"num_turns\\\":1,\\\"result\\\":\\\"$response\\\",\\\"session_id\\\":\\\"$session\\\",\\\"total_cost_usd\\\":0.0125,\\\"usage\\\":{\\\"input_tokens\\\":21,\\\"output_tokens\\\":4,\\\"cache_creation_input_tokens\\\":2,\\\"cache_read_input_tokens\\\":7},\\\"terminal_reason\\\":null,\\\"api_error_status\\\":null}\"\n";
+  close_out output;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let runtime_toml ~cli_path =
+  Printf.sprintf
+    "[providers.claude]\n\
+     protocol = \"claude-code\"\n\
+     command = %S\n\
+     is-non-interactive = true\n\
+     \n\
+     [models.opus]\n\
+     api-name = \"claude-opus-5\"\n\
+     max-context = 128000\n\
+     \n\
+     [claude.opus]\n\
+     \n\
+     [runtime]\n\
+     default = \"claude.opus\"\n"
+    cli_path
+;;
+
+let with_runtime_config ~cli_path f =
+  let path = Filename.temp_file "masc-claude-keeper-runtime-" ".toml" in
+  let output = open_out_bin path in
+  output_string output (runtime_toml ~cli_path);
+  close_out output;
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let response_text (result : Runtime_agent.run_result) =
+  result.response.content
+  |> List.filter_map (function Agent_sdk.Types.Text text -> Some text | _ -> None)
+  |> String.concat ""
+;;
+
+let run_turn ~base_path ~cli_path ~goal =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       with_runtime_config ~cli_path (fun runtime_path ->
+         Eio_main.run (fun env ->
+           Eio.Switch.run (fun sw ->
+             Eio_context.set_env env;
+             Process_eio.init
+               ~cwd_default:Eio.Path.(Eio.Stdenv.fs env / ".")
+               ~proc_mgr:(Eio.Stdenv.process_mgr env)
+               ~clock:(Eio.Stdenv.clock env);
+             Fun.protect
+               ~finally:Process_eio.reset_for_testing
+               (fun () ->
+                  Eio_context.with_test_env
+                    ~net:(Eio.Stdenv.net env)
+                    ~clock:(Eio.Stdenv.clock env)
+                    ~mono_clock:(Eio.Stdenv.mono_clock env)
+                    ~sw
+                    (fun () ->
+                       match Runtime.init_default ~config_path:runtime_path with
+                       | Error error -> fail error
+                       | Ok () ->
+                         Keeper_turn_driver.run_named
+                           ~runtime_id:"claude.opus"
+                           ~keeper_name:"claude-fixture"
+                           ~base_path
+                           ~goal
+                           ~initial_messages:[]
+                           ~sw
+                           ~net:(Eio.Stdenv.net env)
+                           ()))))))
+;;
+
+let test_session_store_roundtrip_and_duplicate_claim () =
+  let base_path = temp_workspace "masc-claude-store-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       let usage : Runtime_claude_code_cli.usage =
+         { input_tokens = 10
+         ; output_tokens = 3
+         ; cache_creation_input_tokens = 2
+         ; cache_read_input_tokens = 4
+         ; total_cost_usd = 0.02
+         }
+       in
+       let claim =
+         Keeper_claude_code_session_store.claim
+           ~base_path
+           ~keeper_name:"store"
+           ~expected:None
+           ~runtime_id:"claude.opus"
+           ~updated_at:1.0
+         |> Result.get_ok
+       in
+       (match
+          Keeper_claude_code_session_store.claim
+            ~base_path
+            ~keeper_name:"store"
+            ~expected:(Some claim)
+            ~runtime_id:claim.runtime_id
+            ~updated_at:2.0
+        with
+        | Error _ -> ()
+        | Ok _ -> fail "unsettled Claude Code claim admitted duplicate execution");
+       let settled =
+         Keeper_claude_code_session_store.settle
+           ~base_path
+           ~keeper_name:"store"
+           ~expected:claim
+           ~session_id
+           ~usage
+           ~updated_at:3.0
+         |> Result.get_ok
+       in
+       match Keeper_claude_code_session_store.load ~base_path ~keeper_name:"store" with
+       | Error detail -> fail detail
+       | Ok None -> fail "settled Claude Code session disappeared"
+       | Ok (Some loaded) ->
+         check int "turn count" 1 loaded.turn_count;
+         check bool "settled state" true (loaded = settled);
+         check (option int) "measured input" (Some 10)
+           (Option.map (fun usage -> usage.Runtime_claude_code_cli.input_tokens) loaded.last_usage))
+;;
+
+let test_keeper_start_resume_and_measured_observation () =
+  let base_path = temp_workspace "masc-claude-keeper-" in
+  let cli_path = fixture_script ~workspace:base_path in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove cli_path; cleanup_tree base_path)
+    (fun () ->
+       let first =
+         match run_turn ~base_path ~cli_path ~goal:"fixture start" with
+         | Ok result -> result
+         | Error error -> fail (Agent_sdk.Error.to_string error)
+       in
+       check string "first response" "MASC_CLAUDE_KEEPER_START" (response_text first);
+       check int "first turn" 1 first.turns;
+       check bool "generated UUID session" true
+         (Option.is_some (Uuidm.of_string first.session_id));
+       (match first.response.usage with
+        | None -> fail "provider-reported usage was dropped"
+        | Some usage ->
+          check int "input usage" 21 usage.input_tokens;
+          check int "output usage" 4 usage.output_tokens;
+          check int "cache creation" 2 usage.cache_creation_input_tokens;
+          check int "cache read" 7 usage.cache_read_input_tokens;
+          check (option (float 0.000001)) "cost" (Some 0.0125) usage.cost_usd);
+       (match first.runtime_observation with
+        | None -> fail "measured runtime observation was not emitted"
+        | Some observation ->
+          List.iter
+            (fun label ->
+              check bool label true (List.mem label observation.configured_labels))
+            [ "tool_owner=official_client"
+            ; "execution_mode=plan_read_only"
+            ; "permission_mode=plan"
+            ; "tool_calls=1"
+            ; "cache_creation_input_tokens=2"
+            ]);
+       let resumed =
+         match run_turn ~base_path ~cli_path ~goal:"fixture resume" with
+         | Ok result -> result
+         | Error error -> fail (Agent_sdk.Error.to_string error)
+       in
+       check string "resume response" "MASC_CLAUDE_KEEPER_RESUME" (response_text resumed);
+       check int "resume turn" 2 resumed.turns;
+       check string "resume kept session" first.session_id resumed.session_id;
+       match Keeper_claude_code_session_store.load ~base_path ~keeper_name:"claude-fixture" with
+       | Error detail -> fail detail
+       | Ok None -> fail "resumed Claude Code session disappeared"
+       | Ok (Some session) -> check int "stored turn count" 2 session.turn_count)
+;;
+
+let () =
+  run
+    "Keeper Claude Code official-client runtime"
+    [ ( "durable session and dispatch"
+      , [ test_case
+            "session store roundtrip and duplicate claim"
+            `Quick
+            test_session_store_roundtrip_and_duplicate_claim
+        ; test_case
+            "start resume and measured observation"
+            `Quick
+            test_keeper_start_resume_and_measured_observation
+        ] )
+    ]
+;;

--- a/test/test_runtime_claude_code_config.ml
+++ b/test/test_runtime_claude_code_config.ml
@@ -48,6 +48,7 @@ let test_materializes_as_official_client_runtime () =
        | Runtime_execution.Claude_code config ->
          check string "cli path" "claude" config.cli_path;
          check (option string) "model" (Some "claude-opus-5") config.model;
+         check int "default client turns" 12 config.max_turns;
          check string "typed owner label" "claude_code"
            (Runtime_execution.label default.execution);
          check bool "agent_core config absent" true


### PR DESCRIPTION
## Outcome

Replaces the temporary `claude-code` Keeper rejection with a durable official-client turn driver.

## Execution contract

- generates a UUID for the first official-client session and resumes that exact identity
- claims and settles per-Keeper state with a durable lock plus compare-and-swap
- refuses runtime identity drift and duplicate execution from an unsettled claim
- projects only text history; OAS tool messages/checkpoints and provider-config transforms are rejected
- keeps the Claude Code tool loop official-client-owned under `plan` plus the fixed read-only tool set
- configures a bounded default of 12 client turns per Keeper invocation
- maps structured Claude rate rejection to typed SDK `RateLimited`, preserving reset time for failover policy
- records model, latency, tokens, cache usage, cost, tool-call count, client-turn count, permission mode, and resume state on successful settlement

The durable claim remains unsettled after an ambiguous process failure. This is deliberate: MASC will not silently replay a possibly executed official-client turn.

## Verification

Passed:

```text
test_runtime_claude_code_cli.exe: 10/10
test_runtime_claude_code_config.exe: 2/2
```

Also passed focused Dune object compilation for:

- Claude session store
- Claude Keeper runtime
- Keeper turn driver
- runtime adapter/execution
- dashboard runtime-info projection
- Keeper integration test module (typed test object)

The full Keeper test executable and `dune build .` are not claimed. Linking the full `masc` library is currently stopped first by existing stack-base Keeper approval failures (`Otel_metric_store`, queue interface/type mismatches), outside this diff.

## Stack

- base PR: #27744
- base SHA: `d2597f542e`
