### PR TITLE
feat(dashboard): support official subscription runtimes

### DIFF
--- a/dashboard/dev-fixtures/official-client-runtime-fixture.html
+++ b/dashboard/dev-fixtures/official-client-runtime-fixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Official client runtime evidence</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/demo/official-client-runtime-fixture.ts"></script>
+  </body>
+</html>

--- a/dashboard/e2e/official-client-runtime.mjs
+++ b/dashboard/e2e/official-client-runtime.mjs
@@ -12,11 +12,11 @@ let forcedProbeRequests = 0
 const providersPayload = {
   updated_at: '2026-08-09T07:30:00Z',
   summary: {
-    providers: 2,
-    runtimes: 2,
+    providers: 3,
+    runtimes: 3,
     local_models: 0,
     cloud_models: 0,
-    cli_models: 2,
+    cli_models: 3,
     default_runtime_id: 'antigravity_subscription.flash',
   },
   config_path: '/home/operator/.masc/runtime.toml',
@@ -59,8 +59,57 @@ const providersPayload = {
               input_tokens: 21,
               output_tokens: 4,
               thinking_tokens: 2,
-              cache_read_tokens: 7,
+              cache_creation_input_tokens: null,
+              cache_read_input_tokens: 7,
               total_tokens: 25,
+              total_cost_usd: null,
+            },
+          },
+        },
+      },
+    },
+    {
+      provider: 'claude.opus',
+      runtime_id: 'claude.opus',
+      provider_id: 'claude',
+      model_id: 'opus',
+      model_api_name: 'claude-opus-5',
+      protocol: 'claude-code',
+      transport: 'cli',
+      runtime_kind: 'cli',
+      auth_kind: 'none',
+      kind: 'cli',
+      status: 'verified',
+      available: true,
+      is_default_runtime: false,
+      max_context: 128000,
+      models: ['claude-opus-5'],
+      verification: {
+        status: 'verified',
+        measured: true,
+        observed_at: 1786239060,
+        reason: null,
+        evidence: {
+          runtime_id: 'claude.opus',
+          observed_at: 1786239060,
+          outcome: 'success',
+          measurement: {
+            client: 'claude_code',
+            execution_mode: 'plan_read_only',
+            tool_owner: 'official_client',
+            permission_mode: 'plan',
+            session_bound: true,
+            resumed: true,
+            turn_count: 2,
+            tool_calls: 1,
+            usage: {
+              input_tokens: 21,
+              output_tokens: 4,
+              thinking_tokens: null,
+              cache_creation_input_tokens: 2,
+              cache_read_input_tokens: 7,
+              total_tokens: null,
+              total_cost_usd: 0.0125,
             },
           },
         },
@@ -106,7 +155,7 @@ const probePayload = {
   generated_at: '2026-08-09T07:30:00Z',
   refresh_state: 'fresh',
   probe: {
-    summary: { runtimes: 2, reachable: 0, failed: 0, skipped: 2 },
+    summary: { runtimes: 3, reachable: 0, failed: 0, skipped: 3 },
     providers: [],
   },
 }
@@ -131,14 +180,23 @@ try {
   })
 
   await page.goto(fixtureUrl)
-  await page.getByText('공식 구독 CLI · 실측 turn 성공', { exact: true }).waitFor()
+  await page.getByText('공식 구독 CLI · 실측 turn 성공', { exact: true }).first().waitFor()
   await page.getByText('공식 구독 CLI · 아직 실측 없음', { exact: true }).waitFor()
 
   const measured = page.getByTestId('official-client-evidence-antigravity_subscription.flash')
   await measured.getByText('client · antigravity', { exact: true }).waitFor()
   await measured.getByText('turn · 2 · resumed', { exact: true }).waitFor()
   await measured.getByText(
-    'provider usage · in 21 · out 4 · thinking 2 · cache 7 · total 25',
+    'provider usage · in 21 · out 4 · thinking 2 · cache read 7 · total 25',
+    { exact: true },
+  ).waitFor()
+
+  const claude = page.getByTestId('official-client-evidence-claude.opus')
+  await claude.getByText('client · claude_code', { exact: true }).waitFor()
+  await claude.getByText('mode · plan_read_only', { exact: true }).waitFor()
+  await claude.getByText('permission · plan', { exact: true }).waitFor()
+  await claude.getByText(
+    'provider usage · in 21 · out 4 · cache write 2 · cache read 7 · cost $0.0125',
     { exact: true },
   ).waitFor()
 
@@ -148,7 +206,7 @@ try {
   await page.getByLabel('시간 윈도우 선택').selectOption('60')
   await page.getByText('60m', { exact: true }).waitFor()
   await page.getByRole('button', { name: 'runtime snapshot 새로고침' }).click()
-  await page.getByText('공식 구독 CLI · 실측 turn 성공', { exact: true }).waitFor()
+  await page.getByText('공식 구독 CLI · 실측 turn 성공', { exact: true }).first().waitFor()
 
   if (providersRequests < 3) {
     throw new Error(`expected provider reloads after interactions, got ${providersRequests}`)

--- a/dashboard/e2e/official-client-runtime.mjs
+++ b/dashboard/e2e/official-client-runtime.mjs
@@ -1,0 +1,167 @@
+import { chromium } from 'playwright'
+
+const fixtureUrl = process.env.OFFICIAL_CLIENT_RUNTIME_FIXTURE_URL
+if (!fixtureUrl) throw new Error('OFFICIAL_CLIENT_RUNTIME_FIXTURE_URL is required')
+
+const artifactDir = process.env.OFFICIAL_CLIENT_RUNTIME_ARTIFACT_DIR ?? '/tmp'
+const screenshot = `${artifactDir}/official-client-runtime-evidence.png`
+let providersRequests = 0
+let metricsRequests = 0
+let forcedProbeRequests = 0
+
+const providersPayload = {
+  updated_at: '2026-08-09T07:30:00Z',
+  summary: {
+    providers: 2,
+    runtimes: 2,
+    local_models: 0,
+    cloud_models: 0,
+    cli_models: 2,
+    default_runtime_id: 'antigravity_subscription.flash',
+  },
+  config_path: '/home/operator/.masc/runtime.toml',
+  providers: [
+    {
+      provider: 'antigravity_subscription.flash',
+      runtime_id: 'antigravity_subscription.flash',
+      provider_id: 'antigravity_subscription',
+      model_id: 'flash',
+      model_api_name: 'gemini-3.6-flash-low',
+      protocol: 'antigravity-cli',
+      transport: 'cli',
+      runtime_kind: 'cli',
+      auth_kind: 'none',
+      kind: 'cli',
+      status: 'verified',
+      available: true,
+      is_default_runtime: true,
+      max_context: 128000,
+      models: ['gemini-3.6-flash-low'],
+      verification: {
+        status: 'verified',
+        measured: true,
+        observed_at: 1786239000,
+        reason: null,
+        evidence: {
+          runtime_id: 'antigravity_subscription.flash',
+          observed_at: 1786239000,
+          outcome: 'success',
+          measurement: {
+            client: 'antigravity',
+            execution_mode: 'plan_sandbox',
+            tool_owner: 'official_client',
+            permission_mode: 'always-proceed',
+            session_bound: true,
+            resumed: true,
+            turn_count: 2,
+            tool_calls: 1,
+            usage: {
+              input_tokens: 21,
+              output_tokens: 4,
+              thinking_tokens: 2,
+              cache_read_tokens: 7,
+              total_tokens: 25,
+            },
+          },
+        },
+      },
+    },
+    {
+      provider: 'codex_subscription.spark',
+      runtime_id: 'codex_subscription.spark',
+      provider_id: 'codex_subscription',
+      model_id: 'spark',
+      model_api_name: 'gpt-5.3-codex-spark',
+      protocol: 'codex-app-server',
+      transport: 'cli',
+      runtime_kind: 'cli',
+      auth_kind: 'none',
+      kind: 'cli',
+      status: 'configured_unverified',
+      available: null,
+      is_default_runtime: false,
+      max_context: 128000,
+      models: ['gpt-5.3-codex-spark'],
+      verification: {
+        status: 'unverified',
+        measured: false,
+        observed_at: null,
+        reason: 'no_successful_runtime_observation',
+        evidence: null,
+      },
+    },
+  ],
+}
+
+const metricsPayload = {
+  window_minutes: 30,
+  bucket_minutes: 5,
+  total_entries: 0,
+  total_error_entries: 0,
+  latency_buckets: [],
+  models: [],
+}
+
+const probePayload = {
+  generated_at: '2026-08-09T07:30:00Z',
+  refresh_state: 'fresh',
+  probe: {
+    summary: { runtimes: 2, reachable: 0, failed: 0, skipped: 2 },
+    providers: [],
+  },
+}
+
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } })
+  await page.route('**/api/v1/providers', async route => {
+    providersRequests += 1
+    await route.fulfill({ json: providersPayload })
+  })
+  await page.route('**/api/v1/models/metrics**', async route => {
+    metricsRequests += 1
+    const url = new URL(route.request().url())
+    const windowMinutes = Number(url.searchParams.get('window') ?? 30)
+    await route.fulfill({ json: { ...metricsPayload, window_minutes: windowMinutes } })
+  })
+  await page.route('**/api/v1/dashboard/runtime-probe**', async route => {
+    const url = new URL(route.request().url())
+    if (url.searchParams.get('force') === '1') forcedProbeRequests += 1
+    await route.fulfill({ json: probePayload })
+  })
+
+  await page.goto(fixtureUrl)
+  await page.getByText('공식 구독 CLI · 실측 turn 성공', { exact: true }).waitFor()
+  await page.getByText('공식 구독 CLI · 아직 실측 없음', { exact: true }).waitFor()
+
+  const measured = page.getByTestId('official-client-evidence-antigravity_subscription.flash')
+  await measured.getByText('client · antigravity', { exact: true }).waitFor()
+  await measured.getByText('turn · 2 · resumed', { exact: true }).waitFor()
+  await measured.getByText(
+    'provider usage · in 21 · out 4 · thinking 2 · cache 7 · total 25',
+    { exact: true },
+  ).waitFor()
+
+  const unmeasured = page.getByTestId('official-client-evidence-codex_subscription.spark')
+  await unmeasured.getByText('auth / usage / session unknown', { exact: true }).waitFor()
+
+  await page.getByLabel('시간 윈도우 선택').selectOption('60')
+  await page.getByText('60m', { exact: true }).waitFor()
+  await page.getByRole('button', { name: 'runtime snapshot 새로고침' }).click()
+  await page.getByText('공식 구독 CLI · 실측 turn 성공', { exact: true }).waitFor()
+
+  if (providersRequests < 3) {
+    throw new Error(`expected provider reloads after interactions, got ${providersRequests}`)
+  }
+  if (metricsRequests < 3) {
+    throw new Error(`expected metrics reloads after interactions, got ${metricsRequests}`)
+  }
+  if (forcedProbeRequests !== 1) {
+    throw new Error(`expected one forced live probe, got ${forcedProbeRequests}`)
+  }
+
+  await page.screenshot({ path: screenshot, fullPage: true })
+  process.stdout.write(`official_client_runtime_screenshot=${screenshot}\n`)
+} finally {
+  await browser.close()
+}

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -145,6 +145,41 @@ export interface DashboardRuntimeDeclaredSpec {
   binding?: DashboardRuntimeDeclaredBindingSpec | null
 }
 
+export interface DashboardOfficialClientUsage {
+  input_tokens: number
+  output_tokens: number
+  thinking_tokens: number
+  cache_read_tokens: number
+  total_tokens: number
+}
+
+export interface DashboardOfficialClientMeasurement {
+  client: 'codex' | 'antigravity'
+  execution_mode: 'app_server' | 'plan_sandbox'
+  tool_owner: 'masc' | 'official_client'
+  permission_mode?: string | null
+  session_bound: boolean
+  resumed: boolean
+  turn_count: number
+  tool_calls: number
+  usage?: DashboardOfficialClientUsage | null
+}
+
+export interface DashboardOfficialClientEvidence {
+  runtime_id: string
+  observed_at: number
+  outcome: 'success' | 'failure' | 'rejected'
+  measurement: DashboardOfficialClientMeasurement
+}
+
+export interface DashboardRuntimeVerification {
+  status: 'verified' | 'unverified' | 'failed' | 'rejected'
+  measured: boolean
+  observed_at?: number | null
+  evidence?: DashboardOfficialClientEvidence | null
+  reason?: string | null
+}
+
 export interface DashboardRuntimeReasoningStreamingFormat {
   kind?: string | null
   field?: string | null
@@ -251,6 +286,7 @@ export interface DashboardRuntimeProviderSnapshot {
   parameter_policy?: DashboardRuntimeParameterPolicy | null
   request_config?: DashboardRuntimeRequestConfig | null
   declared_spec?: DashboardRuntimeDeclaredSpec | null
+  verification?: DashboardRuntimeVerification | null
   model_count?: number | null
   models: string[]
   source?: string | null
@@ -616,6 +652,113 @@ function decodeRuntimeDeclaredSpec(raw: unknown): DashboardRuntimeDeclaredSpec |
   }
 }
 
+function decodeOfficialClientUsage(raw: unknown): DashboardOfficialClientUsage | null {
+  if (!isRecord(raw)) return null
+  const inputTokens = asNumber(raw.input_tokens)
+  const outputTokens = asNumber(raw.output_tokens)
+  const thinkingTokens = asNumber(raw.thinking_tokens)
+  const cacheReadTokens = asNumber(raw.cache_read_tokens)
+  const totalTokens = asNumber(raw.total_tokens)
+  if (
+    inputTokens == null
+    || outputTokens == null
+    || thinkingTokens == null
+    || cacheReadTokens == null
+    || totalTokens == null
+    || ![inputTokens, outputTokens, thinkingTokens, cacheReadTokens, totalTokens]
+      .every(value => Number.isSafeInteger(value) && value >= 0)
+  ) return null
+  return {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    thinking_tokens: thinkingTokens,
+    cache_read_tokens: cacheReadTokens,
+    total_tokens: totalTokens,
+  }
+}
+
+function decodeOfficialClientMeasurement(raw: unknown): DashboardOfficialClientMeasurement | null {
+  if (!isRecord(raw)) return null
+  const client = asString(raw.client)
+  const executionMode = asString(raw.execution_mode)
+  const toolOwner = asString(raw.tool_owner)
+  const sessionBound = asBoolean(raw.session_bound)
+  const resumed = asBoolean(raw.resumed)
+  const turnCount = asNumber(raw.turn_count)
+  const toolCalls = asNumber(raw.tool_calls)
+  if (
+    (client !== 'codex' && client !== 'antigravity')
+    || (executionMode !== 'app_server' && executionMode !== 'plan_sandbox')
+    || (toolOwner !== 'masc' && toolOwner !== 'official_client')
+    || sessionBound == null
+    || resumed == null
+    || turnCount == null
+    || toolCalls == null
+    || !Number.isSafeInteger(turnCount)
+    || turnCount < 1
+    || !Number.isSafeInteger(toolCalls)
+    || toolCalls < 0
+  ) return null
+  const usage = raw.usage == null ? null : decodeOfficialClientUsage(raw.usage)
+  if (raw.usage != null && usage == null) return null
+  return {
+    client,
+    execution_mode: executionMode,
+    tool_owner: toolOwner,
+    permission_mode: asNullableString(raw.permission_mode),
+    session_bound: sessionBound,
+    resumed,
+    turn_count: turnCount,
+    tool_calls: toolCalls,
+    usage,
+  }
+}
+
+function decodeOfficialClientEvidence(raw: unknown): DashboardOfficialClientEvidence | null {
+  if (!isRecord(raw)) return null
+  const runtimeId = asString(raw.runtime_id)
+  const observedAt = asNumber(raw.observed_at)
+  const outcome = asString(raw.outcome)
+  const measurement = decodeOfficialClientMeasurement(raw.measurement)
+  if (
+    !runtimeId
+    || observedAt == null
+    || (outcome !== 'success' && outcome !== 'failure' && outcome !== 'rejected')
+    || !measurement
+  ) return null
+  return { runtime_id: runtimeId, observed_at: observedAt, outcome, measurement }
+}
+
+function decodeRuntimeVerification(raw: unknown): DashboardRuntimeVerification | null {
+  if (!isRecord(raw)) return null
+  const status = asString(raw.status)
+  const measured = asBoolean(raw.measured)
+  if (
+    (status !== 'verified' && status !== 'unverified' && status !== 'failed' && status !== 'rejected')
+    || measured == null
+  ) return null
+  const evidence = raw.evidence == null ? null : decodeOfficialClientEvidence(raw.evidence)
+  if (raw.evidence != null && evidence == null) return null
+  let expectedOutcome: DashboardOfficialClientEvidence['outcome'] | null = null
+  if (status === 'verified') expectedOutcome = 'success'
+  if (status === 'failed') expectedOutcome = 'failure'
+  if (status === 'rejected') expectedOutcome = 'rejected'
+  if (
+    (status === 'unverified' && (measured || evidence != null))
+    || (status !== 'unverified' && (!measured || evidence == null))
+    || (expectedOutcome != null && evidence?.outcome !== expectedOutcome)
+  ) return null
+  const observedAt = asNumber(raw.observed_at) ?? null
+  if (evidence != null && observedAt !== evidence.observed_at) return null
+  return {
+    status,
+    measured,
+    observed_at: observedAt,
+    evidence,
+    reason: asNullableString(raw.reason),
+  }
+}
+
 function decodeNullableStringArray(raw: unknown): string[] | null {
   return Array.isArray(raw) ? asStringArray(raw) : null
 }
@@ -685,6 +828,8 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
   if (!isRecord(raw)) return null
   const provider = asString(raw.provider)
   if (!provider) return null
+  const verification = raw.verification == null ? null : decodeRuntimeVerification(raw.verification)
+  if (raw.verification != null && verification == null) return null
   return {
     provider,
     runtime_id: asNullableString(raw.runtime_id),
@@ -738,6 +883,7 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
     parameter_policy: decodeRuntimeParameterPolicy(raw.parameter_policy),
     request_config: decodeRuntimeRequestConfig(raw.request_config),
     declared_spec: decodeRuntimeDeclaredSpec(raw.declared_spec),
+    verification,
     model_count: asNumber(raw.model_count) ?? null,
     models: asStringArray(raw.models),
     source: asNullableString(raw.source),
@@ -860,6 +1006,9 @@ function decodeRuntimeStartupDegradation(raw: unknown): DashboardRuntimeStartupD
 function decodeRuntimeProvidersResponse(raw: unknown): DashboardRuntimeProvidersResponse | null {
   if (!isRecord(raw)) return null
   const summary = isRecord(raw.summary) ? raw.summary : null
+  const rawProviders = asRecordArray(raw.providers)
+  const providers = rawProviders.map(decodeRuntimeProviderSnapshot)
+  if (providers.some(provider => provider == null)) return null
   return {
     updated_at: asString(raw.updated_at),
     summary: summary
@@ -872,9 +1021,7 @@ function decodeRuntimeProvidersResponse(raw: unknown): DashboardRuntimeProviders
           default_runtime_id: asNullableString(summary.default_runtime_id),
         }
       : null,
-    providers: asRecordArray(raw.providers)
-      .map(decodeRuntimeProviderSnapshot)
-      .filter((provider): provider is DashboardRuntimeProviderSnapshot => provider !== null),
+    providers: providers as DashboardRuntimeProviderSnapshot[],
     assignment_status: decodeRuntimeAssignmentStatus(raw.assignment_status),
     startup_degradation: decodeRuntimeStartupDegradation(raw.startup_degradation),
     config_path: asNullableString(raw.config_path),

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -148,14 +148,16 @@ export interface DashboardRuntimeDeclaredSpec {
 export interface DashboardOfficialClientUsage {
   input_tokens: number
   output_tokens: number
-  thinking_tokens: number
-  cache_read_tokens: number
-  total_tokens: number
+  thinking_tokens?: number | null
+  cache_creation_input_tokens?: number | null
+  cache_read_input_tokens: number
+  total_tokens?: number | null
+  total_cost_usd?: number | null
 }
 
 export interface DashboardOfficialClientMeasurement {
-  client: 'codex' | 'antigravity'
-  execution_mode: 'app_server' | 'plan_sandbox'
+  client: 'codex' | 'antigravity' | 'claude_code'
+  execution_mode: 'app_server' | 'plan_sandbox' | 'plan_read_only'
   tool_owner: 'masc' | 'official_client'
   permission_mode?: string | null
   session_bound: boolean
@@ -656,24 +658,31 @@ function decodeOfficialClientUsage(raw: unknown): DashboardOfficialClientUsage |
   if (!isRecord(raw)) return null
   const inputTokens = asNumber(raw.input_tokens)
   const outputTokens = asNumber(raw.output_tokens)
-  const thinkingTokens = asNumber(raw.thinking_tokens)
-  const cacheReadTokens = asNumber(raw.cache_read_tokens)
-  const totalTokens = asNumber(raw.total_tokens)
+  const thinkingTokens = raw.thinking_tokens == null ? null : asNumber(raw.thinking_tokens)
+  const cacheCreationInputTokens = raw.cache_creation_input_tokens == null
+    ? null
+    : asNumber(raw.cache_creation_input_tokens)
+  const cacheReadInputTokens = asNumber(raw.cache_read_input_tokens)
+  const totalTokens = raw.total_tokens == null ? null : asNumber(raw.total_tokens)
+  const totalCostUsd = raw.total_cost_usd == null ? null : asNumber(raw.total_cost_usd)
+  const optionalTokenCounts = [thinkingTokens, cacheCreationInputTokens, totalTokens]
   if (
     inputTokens == null
     || outputTokens == null
-    || thinkingTokens == null
-    || cacheReadTokens == null
-    || totalTokens == null
-    || ![inputTokens, outputTokens, thinkingTokens, cacheReadTokens, totalTokens]
+    || cacheReadInputTokens == null
+    || ![inputTokens, outputTokens, cacheReadInputTokens]
       .every(value => Number.isSafeInteger(value) && value >= 0)
+    || !optionalTokenCounts.every(value => value == null || (Number.isSafeInteger(value) && value >= 0))
+    || (totalCostUsd != null && (!Number.isFinite(totalCostUsd) || totalCostUsd < 0))
   ) return null
   return {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
     thinking_tokens: thinkingTokens,
-    cache_read_tokens: cacheReadTokens,
+    cache_creation_input_tokens: cacheCreationInputTokens,
+    cache_read_input_tokens: cacheReadInputTokens,
     total_tokens: totalTokens,
+    total_cost_usd: totalCostUsd,
   }
 }
 
@@ -687,8 +696,8 @@ function decodeOfficialClientMeasurement(raw: unknown): DashboardOfficialClientM
   const turnCount = asNumber(raw.turn_count)
   const toolCalls = asNumber(raw.tool_calls)
   if (
-    (client !== 'codex' && client !== 'antigravity')
-    || (executionMode !== 'app_server' && executionMode !== 'plan_sandbox')
+    (client !== 'codex' && client !== 'antigravity' && client !== 'claude_code')
+    || (executionMode !== 'app_server' && executionMode !== 'plan_sandbox' && executionMode !== 'plan_read_only')
     || (toolOwner !== 'masc' && toolOwner !== 'official_client')
     || sessionBound == null
     || resumed == null

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -3426,6 +3426,97 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.effective_capabilities?.thinking_control_format).toBe('ollama-think')
     expect(result.providers[1]?.effective_capabilities?.thinking_control_format).toBe('future-undocumented-wire')
   })
+
+  it('decodes typed official-client measurement without inferring missing fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        providers: [{
+          provider: 'antigravity.flash',
+          runtime_id: 'antigravity.flash',
+          models: ['gemini-3.6-flash-low'],
+          verification: {
+            status: 'verified',
+            measured: true,
+            observed_at: 1786239000,
+            reason: null,
+            evidence: {
+              runtime_id: 'antigravity.flash',
+              observed_at: 1786239000,
+              outcome: 'success',
+              measurement: {
+                client: 'antigravity',
+                execution_mode: 'plan_sandbox',
+                tool_owner: 'official_client',
+                permission_mode: 'always-proceed',
+                session_bound: true,
+                resumed: false,
+                turn_count: 1,
+                tool_calls: 2,
+                usage: {
+                  input_tokens: 20,
+                  output_tokens: 3,
+                  thinking_tokens: 1,
+                  cache_read_tokens: 5,
+                  total_tokens: 23,
+                },
+              },
+            },
+          },
+        }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchRuntimeProviders()
+    const verification = result.providers[0]?.verification
+    expect(verification?.status).toBe('verified')
+    expect(verification?.evidence?.measurement).toMatchObject({
+      client: 'antigravity',
+      execution_mode: 'plan_sandbox',
+      tool_owner: 'official_client',
+      permission_mode: 'always-proceed',
+      session_bound: true,
+      turn_count: 1,
+      tool_calls: 2,
+    })
+    expect(verification?.evidence?.measurement.usage?.thinking_tokens).toBe(1)
+  })
+
+  it('rejects verified official-client payloads whose typed evidence disagrees', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        providers: [{
+          provider: 'antigravity.flash',
+          runtime_id: 'antigravity.flash',
+          models: ['gemini-3.6-flash-low'],
+          verification: {
+            status: 'verified',
+            measured: true,
+            observed_at: 1786239000,
+            evidence: {
+              runtime_id: 'antigravity.flash',
+              observed_at: 1786239000,
+              outcome: 'failure',
+              measurement: {
+                client: 'antigravity',
+                execution_mode: 'plan_sandbox',
+                tool_owner: 'official_client',
+                permission_mode: 'always-proceed',
+                session_bound: true,
+                resumed: false,
+                turn_count: 1,
+                tool_calls: 0,
+                usage: null,
+              },
+            },
+          },
+        }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchRuntimeProviders()).rejects.toThrow('유효하지 않은 runtime lanes payload')
+  })
 })
 
 describe('fetchRuntimeModelMetrics', () => {

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -3456,8 +3456,10 @@ describe('fetchRuntimeProviders', () => {
                   input_tokens: 20,
                   output_tokens: 3,
                   thinking_tokens: 1,
-                  cache_read_tokens: 5,
+                  cache_creation_input_tokens: null,
+                  cache_read_input_tokens: 5,
                   total_tokens: 23,
+                  total_cost_usd: null,
                 },
               },
             },
@@ -3480,6 +3482,61 @@ describe('fetchRuntimeProviders', () => {
       tool_calls: 2,
     })
     expect(verification?.evidence?.measurement.usage?.thinking_tokens).toBe(1)
+  })
+
+  it('decodes Claude Code cache and cost evidence through the hard-cut contract', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        providers: [{
+          provider: 'claude.opus',
+          runtime_id: 'claude.opus',
+          models: ['claude-opus-5'],
+          verification: {
+            status: 'verified',
+            measured: true,
+            observed_at: 1786239000,
+            evidence: {
+              runtime_id: 'claude.opus',
+              observed_at: 1786239000,
+              outcome: 'success',
+              measurement: {
+                client: 'claude_code',
+                execution_mode: 'plan_read_only',
+                tool_owner: 'official_client',
+                permission_mode: 'plan',
+                session_bound: true,
+                resumed: true,
+                turn_count: 2,
+                tool_calls: 1,
+                usage: {
+                  input_tokens: 21,
+                  output_tokens: 4,
+                  thinking_tokens: null,
+                  cache_creation_input_tokens: 2,
+                  cache_read_input_tokens: 7,
+                  total_tokens: null,
+                  total_cost_usd: 0.0125,
+                },
+              },
+            },
+          },
+        }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchRuntimeProviders()
+    const measurement = result.providers[0]?.verification?.evidence?.measurement
+    expect(measurement).toMatchObject({
+      client: 'claude_code',
+      execution_mode: 'plan_read_only',
+      permission_mode: 'plan',
+    })
+    expect(measurement?.usage).toMatchObject({
+      cache_creation_input_tokens: 2,
+      cache_read_input_tokens: 7,
+      total_cost_usd: 0.0125,
+    })
   })
 
   it('rejects verified official-client payloads whose typed evidence disagrees', async () => {

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -178,6 +178,10 @@ function transportField(provider: RuntimeTomlProvider): RuntimeProviderTransport
   return provider.transportKind === 'command' ? 'command' : 'endpoint'
 }
 
+function officialClientCommandPlaceholder(protocol: RuntimeTomlProtocol): string {
+  return protocol === 'antigravity-cli' ? '/absolute/path/to/agy' : '/absolute/path/to/codex'
+}
+
 // Prototype rt-model-ctx label (runtime-editor.jsx:176) — now via the shared
 // formatContextTokens SSOT so 1M-class contexts read '1M ctx', not '1000k ctx'.
 function protoContext(value: number | null | undefined): string {
@@ -785,7 +789,9 @@ export function RuntimeEnvironmentEditor({
                   <input
                     class="rt-input mono"
                     value=${newProvider.transportValue}
-                    placeholder=${newProvider.transportKind === 'command' ? '/absolute/path/to/codex' : 'https://...'}
+                    placeholder=${newProvider.transportKind === 'command'
+                      ? officialClientCommandPlaceholder(newProvider.protocol)
+                      : 'https://...'}
                     disabled=${isDisabled}
                     aria-label="새 provider transport 값"
                     onInput=${(event: Event) => setNewProvider({ ...newProvider, transportValue: (event.currentTarget as HTMLInputElement).value })}

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -179,7 +179,16 @@ function transportField(provider: RuntimeTomlProvider): RuntimeProviderTransport
 }
 
 function officialClientCommandPlaceholder(protocol: RuntimeTomlProtocol): string {
-  return protocol === 'antigravity-cli' ? '/absolute/path/to/agy' : '/absolute/path/to/codex'
+  if (protocol === 'antigravity-cli') return '/absolute/path/to/agy'
+  if (protocol === 'claude-code') return '/absolute/path/to/claude'
+  return '/absolute/path/to/codex'
+}
+
+function officialClientBoundaryText(protocol: RuntimeTomlProtocol): string {
+  if (protocol === 'claude-code') {
+    return '기존 Claude Code 구독 로그인을 사용합니다. plan + 읽기 전용 도구, 최대 12 client turns로 실행하며 API key는 저장하지 않습니다.'
+  }
+  return '공식 클라이언트의 기존 구독 로그인을 사용합니다. API key는 저장하지 않으며 non-interactive 실행을 강제합니다.'
 }
 
 // Prototype rt-model-ctx label (runtime-editor.jsx:176) — now via the shared
@@ -799,7 +808,7 @@ export function RuntimeEnvironmentEditor({
                 </div>
                 <div class="rt-note">
                   ${isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
-                    ? '공식 클라이언트의 기존 구독 로그인을 사용합니다. API key는 저장하지 않으며 non-interactive 실행을 강제합니다.'
+                    ? officialClientBoundaryText(newProvider.protocol)
                     : '일반 provider는 endpoint transport를 사용합니다.'}
                 </div>
                 <div class="rt-field">

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -16,6 +16,7 @@ import {
 } from '../lib/runtime-provider-summary'
 import {
   isRuntimeTomlNonMaterializableProtocol,
+  isRuntimeTomlOfficialClientProtocol,
   isReservedRuntimeTomlId,
   isValidRuntimeTomlIdFormat,
   parseRuntimeTomlEnvironment,
@@ -46,19 +47,18 @@ export type RuntimeProviderTransportEditableField = 'endpoint' | 'command'
 // ...) are deliberately excluded — those are semantically coupled to real,
 // per-model verified behavior (see runtime.toml's own inline caveats), not
 // something a generic add form can default safely. They stay raw-TOML-only.
-// transportKind is fixed to 'endpoint': CLI (`command`) transport providers
-// resolve to no provider_kind on the backend today and get silently dropped
-// from the live runtime list rather than failing the save (see
-// RUNTIME_TOML_CREATABLE_PROTOCOLS in lib/runtime-toml-config.ts). Until that
-// backend limitation is lifted, this form cannot offer command transport.
+// Generic providers use endpoint transport. A typed official-client protocol
+// may require command transport; that exception is selected by protocol and
+// never exposed as a free-form transport switch.
 export interface NewRuntimeProviderInput {
   id: string
   displayName: string
   protocol: RuntimeTomlProtocol
-  transportKind: 'endpoint'
+  transportKind: 'endpoint' | 'command'
   transportValue: string
   credentialType: RuntimeTomlCredentialType
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 export interface NewRuntimeModelInput {
@@ -127,10 +127,11 @@ interface NewProviderDraft {
   id: string
   displayName: string
   protocol: RuntimeTomlProtocol
-  transportKind: 'endpoint'
+  transportKind: 'endpoint' | 'command'
   transportValue: string
   credentialType: RuntimeTomlCredentialType
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 const DEFAULT_NEW_PROVIDER: NewProviderDraft = {
@@ -141,6 +142,7 @@ const DEFAULT_NEW_PROVIDER: NewProviderDraft = {
   transportValue: '',
   credentialType: 'env',
   credentialValue: '',
+  isNonInteractive: false,
 }
 
 // jsonSupport as a 3-way string enum (not boolean|null) because <select> values
@@ -376,7 +378,12 @@ export function RuntimeEnvironmentEditor({
     }
     const transportValue = newProvider.transportValue.trim()
     if (transportValue === '') {
-      setProviderFormError('endpoint를 입력하세요')
+      setProviderFormError(`${newProvider.transportKind}를 입력하세요`)
+      return
+    }
+    const officialClient = isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
+    if (officialClient && (newProvider.transportKind !== 'command' || newProvider.credentialType !== 'none' || !newProvider.isNonInteractive)) {
+      setProviderFormError('공식 구독 클라이언트는 command + credential 없음 + non-interactive=true가 필요합니다')
       return
     }
     const trimmedCredentialValue = newProvider.credentialValue.trim()
@@ -454,13 +461,11 @@ export function RuntimeEnvironmentEditor({
       setBindingFormError(`"${bindingProviderId}"는 예약된 이름이라 바인딩 provider로 쓸 수 없습니다`)
       return
     }
-    // A `command` transport provider always resolves to no provider_kind on the
-    // backend, so materialize_config's filter_map silently drops any binding
-    // pinned to it from the live runtime list. The add-provider form can no
-    // longer create one, but this dropdown lists every parsed provider,
-    // including a `command` one that already exists via raw TOML / legacy config.
+    // Generic command transports are not materializable. Official-client
+    // protocols are the typed exception: their backend runtime owns the CLI
+    // process and does not impersonate an OAS HTTP provider.
     const selectedProvider = environment.providers.find(p => p.id === bindingProviderId)
-    if (selectedProvider?.transportKind === 'command') {
+    if (selectedProvider?.transportKind === 'command' && !isRuntimeTomlOfficialClientProtocol(selectedProvider.protocol)) {
       setBindingFormError(
         `"${bindingProviderId}"는 command(CLI) transport라 바인딩을 생성할 수 없습니다 (백엔드가 아직 CLI provider를 라우팅하지 못합니다)`,
       )
@@ -641,12 +646,14 @@ export function RuntimeEnvironmentEditor({
           ` : null}
           ${environment.providers.map(provider => {
             const providerTransportField = transportField(provider)
+            const officialClient = isRuntimeTomlOfficialClientProtocol(provider.protocol)
             return html`
             <div key=${provider.id} class="rt-card" data-testid=${`runtime-provider-${provider.id}`}>
               <div class="rt-card-h">
                 <span class="rt-card-id mono">${provider.id}</span>
                 <span class="rt-card-name">${provider.displayName}</span>
                 <span class="rt-proto mono">${provider.protocol || '—'}</span>
+                ${officialClient ? html`<span class="rt-assign-tag pin mono">구독 CLI</span>` : null}
                 <button
                   type="button"
                   class="rt-delete-provider"
@@ -699,6 +706,15 @@ export function RuntimeEnvironmentEditor({
                   </span>
                   `}
               </div>
+              ${officialClient ? html`
+                <div class="rt-field" data-testid=${`runtime-provider-${provider.id}-subscription-boundary`}>
+                  <span class="sub-k">execution</span>
+                  <span class="mono">official client · ${provider.isNonInteractive ? 'non-interactive' : '설정 오류: interactive'}</span>
+                </div>
+                ${provider.credentialType !== 'none' ? html`
+                  <div class="rt-warn" role="alert">공식 구독 클라이언트에는 API credential을 선언할 수 없습니다.</div>
+                ` : null}
+              ` : null}
               ${/* Provider capability chips (mcp-tools/tool-events/mcp-http-headers)
                    had no live source and rendered as if confirmed. Removed until a
                    provider-capability source exists, rather than implying support
@@ -747,29 +763,45 @@ export function RuntimeEnvironmentEditor({
                     value=${newProvider.protocol}
                     disabled=${isDisabled}
                     aria-label="새 provider protocol"
-                    onChange=${(event: Event) => setNewProvider({ ...newProvider, protocol: (event.currentTarget as HTMLSelectElement).value as RuntimeTomlProtocol })}
+                    onChange=${(event: Event) => {
+                      const protocol = (event.currentTarget as HTMLSelectElement).value as RuntimeTomlProtocol
+                      const officialClient = isRuntimeTomlOfficialClientProtocol(protocol)
+                      setNewProvider({
+                        ...newProvider,
+                        protocol,
+                        transportKind: officialClient ? 'command' : 'endpoint',
+                        transportValue: '',
+                        credentialType: officialClient ? 'none' : 'env',
+                        credentialValue: '',
+                        isNonInteractive: officialClient,
+                      })
+                    }}
                   >
                     ${RUNTIME_TOML_CREATABLE_PROTOCOLS.map(p => html`<option value=${p}>${p}</option>`)}
                   </select>
                 </div>
                 <div class="rt-field">
-                  <span class="sub-k">endpoint</span>
+                  <span class="sub-k">${newProvider.transportKind}</span>
                   <input
                     class="rt-input mono"
                     value=${newProvider.transportValue}
-                    placeholder="https://..."
+                    placeholder=${newProvider.transportKind === 'command' ? '/absolute/path/to/codex' : 'https://...'}
                     disabled=${isDisabled}
                     aria-label="새 provider transport 값"
                     onInput=${(event: Event) => setNewProvider({ ...newProvider, transportValue: (event.currentTarget as HTMLInputElement).value })}
                   />
                 </div>
-                <div class="rt-note">CLI(command) provider는 현재 백엔드에서 라우팅되지 않아 이 폼에서 생성할 수 없습니다. raw TOML 탭을 이용하세요.</div>
+                <div class="rt-note">
+                  ${isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
+                    ? '공식 클라이언트의 기존 구독 로그인을 사용합니다. API key는 저장하지 않으며 non-interactive 실행을 강제합니다.'
+                    : '일반 provider는 endpoint transport를 사용합니다.'}
+                </div>
                 <div class="rt-field">
                   <span class="sub-k">credential</span>
                   <select
                     class="rt-select rt-select-narrow"
                     value=${newProvider.credentialType}
-                    disabled=${isDisabled}
+                    disabled=${isDisabled || isRuntimeTomlOfficialClientProtocol(newProvider.protocol)}
                     aria-label="새 provider credential 종류"
                     onChange=${(event: Event) => setNewProvider({ ...newProvider, credentialType: (event.currentTarget as HTMLSelectElement).value as RuntimeTomlCredentialType })}
                   >

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -339,6 +339,150 @@ describe('RuntimeMonitor', () => {
     expect(container.querySelector('article.v2-monitoring-card')).not.toBeNull()
   })
 
+  it('renders typed official-client session and provider usage evidence', async () => {
+    apiMocks.fetchRuntimeProviders.mockResolvedValueOnce({
+      updated_at: '2026-08-09T06:30:00Z',
+      summary: { providers: 1, runtimes: 1, local_models: 0, cloud_models: 0, cli_models: 1 },
+      providers: [{
+        provider: 'antigravity_subscription.flash',
+        runtime_id: 'antigravity_subscription.flash',
+        provider_id: 'antigravity_subscription',
+        model_api_name: 'gemini-3.6-flash-low',
+        protocol: 'antigravity-cli',
+        transport: 'cli',
+        runtime_kind: 'cli',
+        auth_kind: 'none',
+        status: 'verified',
+        models: ['gemini-3.6-flash-low'],
+        verification: {
+          status: 'verified',
+          measured: true,
+          observed_at: 1786239000,
+          evidence: {
+            runtime_id: 'antigravity_subscription.flash',
+            observed_at: 1786239000,
+            outcome: 'success',
+            measurement: {
+              client: 'antigravity',
+              execution_mode: 'plan_sandbox',
+              tool_owner: 'official_client',
+              permission_mode: 'always-proceed',
+              session_bound: true,
+              resumed: true,
+              turn_count: 2,
+              tool_calls: 1,
+              usage: {
+                input_tokens: 21,
+                output_tokens: 4,
+                thinking_tokens: 2,
+                cache_read_tokens: 7,
+                total_tokens: 25,
+              },
+            },
+          },
+          reason: null,
+        },
+      }],
+    })
+    apiMocks.fetchDashboardRuntimeProbe.mockResolvedValueOnce({
+      probe: { summary: { runtimes: 1, reachable: 0, failed: 0, skipped: 1 }, providers: [] },
+    })
+    const { RuntimeMonitor } = await import('./runtime-monitor')
+
+    render(h(RuntimeMonitor, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('공식 구독 CLI · 실측 turn 성공') ?? false,
+      'official client evidence',
+    )
+
+    expect(container.textContent).toContain('measured')
+    expect(container.textContent).toContain('client · antigravity')
+    expect(container.textContent).toContain('mode · plan_sandbox')
+    expect(container.textContent).toContain('tool owner · official_client')
+    expect(container.textContent).toContain('permission · always-proceed')
+    expect(container.textContent).toContain('session · bound')
+    expect(container.textContent).toContain('turn · 2 · resumed')
+    expect(container.textContent).toContain('auth · official session measured')
+    expect(container.textContent).toContain('provider usage · in 21 · out 4 · thinking 2 · cache 7 · total 25')
+  })
+
+  it('labels configured official clients as unmeasured instead of inferring auth', async () => {
+    apiMocks.fetchRuntimeProviders.mockResolvedValueOnce({
+      providers: [{
+        provider: 'codex_subscription.spark',
+        runtime_id: 'codex_subscription.spark',
+        provider_id: 'codex_subscription',
+        model_api_name: 'gpt-5.3-codex-spark',
+        protocol: 'codex-app-server',
+        transport: 'cli',
+        runtime_kind: 'cli',
+        auth_kind: 'none',
+        status: 'configured_unverified',
+        models: ['gpt-5.3-codex-spark'],
+        verification: {
+          status: 'unverified',
+          measured: false,
+          observed_at: null,
+          evidence: null,
+          reason: 'no_successful_runtime_observation',
+        },
+      }],
+    })
+    const { RuntimeMonitor } = await import('./runtime-monitor')
+    render(h(RuntimeMonitor, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('공식 구독 CLI · 아직 실측 없음') ?? false,
+      'unmeasured official client',
+    )
+
+    expect(container.textContent).toContain('not measured')
+    expect(container.textContent).toContain('auth / usage / session unknown')
+    expect(container.textContent).toContain('auth · unknown until measured turn')
+    expect(container.textContent).not.toContain('auth evidence · successful official turn')
+  })
+
+  it('does not claim successful auth evidence for a rejected official-client turn', async () => {
+    apiMocks.fetchRuntimeProviders.mockResolvedValueOnce({
+      providers: [{
+        provider: 'codex_subscription.spark',
+        runtime_id: 'codex_subscription.spark',
+        status: 'configured_observed_failure',
+        models: ['gpt-5.3-codex-spark'],
+        verification: {
+          status: 'rejected',
+          measured: true,
+          observed_at: 1786239000,
+          evidence: {
+            runtime_id: 'codex_subscription.spark',
+            observed_at: 1786239000,
+            outcome: 'rejected',
+            measurement: {
+              client: 'codex',
+              execution_mode: 'app_server',
+              tool_owner: 'masc',
+              permission_mode: null,
+              session_bound: true,
+              resumed: false,
+              turn_count: 1,
+              tool_calls: 0,
+              usage: null,
+            },
+          },
+        },
+      }],
+    })
+    const { RuntimeMonitor } = await import('./runtime-monitor')
+    render(h(RuntimeMonitor, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('공식 구독 CLI · 실측 turn 거부') ?? false,
+      'rejected official client evidence',
+    )
+
+    expect(container.textContent).toContain('auth · not established (rejected turn)')
+    expect(container.textContent).toContain('auth evidence · not established by rejected turn')
+    expect(container.textContent).not.toContain('auth evidence · successful turn at observed time')
+  })
+
   it('surfaces declared and effective provider/model parameter facts', async () => {
     const { RuntimeMonitor } = await import('./runtime-monitor')
 

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -375,8 +375,10 @@ describe('RuntimeMonitor', () => {
                 input_tokens: 21,
                 output_tokens: 4,
                 thinking_tokens: 2,
-                cache_read_tokens: 7,
+                cache_creation_input_tokens: null,
+                cache_read_input_tokens: 7,
                 total_tokens: 25,
+                total_cost_usd: null,
               },
             },
           },
@@ -403,7 +405,57 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('session · bound')
     expect(container.textContent).toContain('turn · 2 · resumed')
     expect(container.textContent).toContain('auth · official session measured')
-    expect(container.textContent).toContain('provider usage · in 21 · out 4 · thinking 2 · cache 7 · total 25')
+    expect(container.textContent).toContain('provider usage · in 21 · out 4 · thinking 2 · cache read 7 · total 25')
+  })
+
+  it('renders Claude Code plan, cache, and cost evidence', async () => {
+    apiMocks.fetchRuntimeProviders.mockResolvedValueOnce({
+      providers: [{
+        provider: 'claude.opus',
+        runtime_id: 'claude.opus',
+        provider_id: 'claude',
+        protocol: 'claude-code',
+        status: 'verified',
+        models: ['claude-opus-5'],
+        verification: {
+          status: 'verified',
+          measured: true,
+          evidence: {
+            runtime_id: 'claude.opus',
+            observed_at: 1786239000,
+            outcome: 'success',
+            measurement: {
+              client: 'claude_code',
+              execution_mode: 'plan_read_only',
+              tool_owner: 'official_client',
+              permission_mode: 'plan',
+              session_bound: true,
+              resumed: true,
+              turn_count: 2,
+              tool_calls: 1,
+              usage: {
+                input_tokens: 21,
+                output_tokens: 4,
+                thinking_tokens: null,
+                cache_creation_input_tokens: 2,
+                cache_read_input_tokens: 7,
+                total_tokens: null,
+                total_cost_usd: 0.0125,
+              },
+            },
+          },
+        },
+      }],
+    })
+    const { RuntimeMonitor } = await import('./runtime-monitor')
+    render(h(RuntimeMonitor, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('client · claude_code') ?? false,
+      'Claude Code official client evidence',
+    )
+    expect(container.textContent).toContain('mode · plan_read_only')
+    expect(container.textContent).toContain('permission · plan')
+    expect(container.textContent).toContain('cache write 2 · cache read 7 · cost $0.0125')
   })
 
   it('labels configured official clients as unmeasured instead of inferring auth', async () => {

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -146,6 +146,9 @@ async function loadRuntimeData(
 // performance (success_rate, cooldown). Both signals can be shown together
 // without being duplicates.
 function runtimeProviderTone(provider: DashboardRuntimeProviderSnapshot): string {
+  if (provider.verification?.status === 'verified') return 'ok'
+  if (provider.verification?.status === 'failed' || provider.verification?.status === 'rejected') return 'bad'
+  if (provider.verification?.status === 'unverified') return 'warn'
   const advertised = provider.status?.trim().toLowerCase()
   if (advertised === 'missing_auth' || advertised === 'unsupported' || advertised === 'offline') {
     return 'bad'
@@ -159,6 +162,10 @@ function runtimeProviderTone(provider: DashboardRuntimeProviderSnapshot): string
 }
 
 function runtimeStatusLabel(provider: DashboardRuntimeProviderSnapshot): string {
+  if (provider.verification?.status === 'verified') return 'measured'
+  if (provider.verification?.status === 'failed') return 'measured failure'
+  if (provider.verification?.status === 'rejected') return 'measured rejected'
+  if (provider.verification?.status === 'unverified') return 'not measured'
   const advertised = provider.status?.trim().toLowerCase()
   if (advertised === 'missing_auth') return 'missing auth'
   if (advertised === 'unsupported') return 'unsupported'
@@ -166,6 +173,87 @@ function runtimeStatusLabel(provider: DashboardRuntimeProviderSnapshot): string 
   if (provider.available === true) return 'available'
   if (provider.available === false) return 'unavailable'
   return 'unknown'
+}
+
+function officialClientUsageText(provider: DashboardRuntimeProviderSnapshot): string | null {
+  const usage = provider.verification?.evidence?.measurement.usage
+  if (!usage) return null
+  return [
+    `in ${formatNumber(usage.input_tokens)}`,
+    `out ${formatNumber(usage.output_tokens)}`,
+    `thinking ${formatNumber(usage.thinking_tokens)}`,
+    `cache ${formatNumber(usage.cache_read_tokens)}`,
+    `total ${formatNumber(usage.total_tokens)}`,
+  ].join(' · ')
+}
+
+function OfficialClientEvidence({ provider }: { provider: DashboardRuntimeProviderSnapshot }) {
+  const verification = provider.verification
+  if (!verification) return null
+  const evidence = verification.evidence
+  if (!verification.measured || !evidence) {
+    return html`
+      <div
+        class="mt-1 rounded-[var(--r-1)] border border-[var(--status-warn)]/40 bg-[var(--status-warn)]/5 px-3 py-2"
+        data-testid=${`official-client-evidence-${provider.runtime_id ?? provider.provider}`}
+      >
+        <div class="flex items-center justify-between gap-2 text-2xs">
+          <strong class="text-[var(--status-warn)]">공식 구독 CLI · 아직 실측 없음</strong>
+          <span class="font-mono text-[var(--color-fg-muted)]">auth / usage / session unknown</span>
+        </div>
+        <div class="mt-1 text-3xs text-[var(--color-fg-muted)]">
+          설정만으로 설치·로그인·쿼터를 추정하지 않습니다. 이 서버 프로세스에서 성공한 turn이 생기면 증거가 표시됩니다.
+        </div>
+      </div>
+    `
+  }
+  const measurement = evidence.measurement
+  const usage = officialClientUsageText(provider)
+  const succeeded = verification.status === 'verified' && evidence.outcome === 'success'
+  const evidenceClass = succeeded
+    ? 'mt-1 rounded-[var(--r-1)] border border-[var(--status-ok)]/40 bg-[var(--status-ok)]/5 px-3 py-3'
+    : 'mt-1 rounded-[var(--r-1)] border border-[var(--status-bad)]/40 bg-[var(--status-bad)]/5 px-3 py-3'
+  const headingClass = succeeded
+    ? 'text-xs text-[var(--status-ok)]'
+    : 'text-xs text-[var(--status-bad)]'
+  let heading = '공식 구독 CLI · 실측 turn 실패'
+  if (succeeded) heading = '공식 구독 CLI · 실측 turn 성공'
+  if (evidence.outcome === 'rejected') heading = '공식 구독 CLI · 실측 turn 거부'
+  const authEvidence = succeeded
+    ? 'successful turn at observed time'
+    : `not established by ${evidence.outcome} turn`
+  return html`
+    <div
+      class=${evidenceClass}
+      data-testid=${`official-client-evidence-${provider.runtime_id ?? provider.provider}`}
+    >
+      <div class="flex items-center justify-between gap-2 flex-wrap">
+        <strong class=${headingClass}>${heading}</strong>
+        <span class="font-mono text-3xs text-[var(--color-fg-muted)]">
+          ${formatTimeHms(evidence.observed_at)} · ${evidence.outcome}
+        </span>
+      </div>
+      <div class="mt-2 grid grid-cols-2 lg:grid-cols-4 gap-x-3 gap-y-1 text-2xs text-[var(--color-fg-secondary)]">
+        <div>client · <span class="font-mono">${measurement.client}</span></div>
+        <div>mode · <span class="font-mono">${measurement.execution_mode}</span></div>
+        <div>tool owner · <span class="font-mono">${measurement.tool_owner}</span></div>
+        <div>permission · <span class="font-mono">${measurement.permission_mode ?? 'not reported'}</span></div>
+        <div>session · ${measurement.session_bound ? 'bound' : 'not bound'}</div>
+        <div>turn · ${formatNumber(measurement.turn_count)} · ${measurement.resumed ? 'resumed' : 'started'}</div>
+        <div>tool calls · ${formatNumber(measurement.tool_calls)}</div>
+        <div>auth evidence · ${authEvidence}</div>
+      </div>
+      ${usage ? html`
+        <div class="mt-2 border-t border-[var(--status-ok)]/20 pt-2 font-mono text-2xs text-[var(--color-fg-secondary)]">
+          provider usage · ${usage}
+        </div>
+      ` : html`
+        <div class="mt-2 border-t border-[var(--status-ok)]/20 pt-2 text-2xs text-[var(--color-fg-muted)]">
+          provider usage · not reported by this official client boundary
+        </div>
+      `}
+    </div>
+  `
 }
 
 function runtimeRequestToolChoiceText(provider: DashboardRuntimeProviderSnapshot): string | null {
@@ -245,6 +333,10 @@ function runtimeProviderAuthText(
   provider: DashboardRuntimeProviderSnapshot,
   probe: DashboardRuntimeProviderProbe | null | undefined,
 ): string {
+  if (provider.verification?.status === 'verified') return 'official session measured'
+  if (provider.verification?.status === 'unverified') return 'unknown until measured turn'
+  if (provider.verification?.status === 'failed') return 'not established (failed turn)'
+  if (provider.verification?.status === 'rejected') return 'not established (rejected turn)'
   if (probe) return runtimeProbeAuthLabel(probe)
   return provider.auth_kind ?? MISSING_DATA_DASH
 }
@@ -838,7 +930,7 @@ export function RuntimeMonitor() {
     <div class="v2-monitoring-surface flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <${Select}
-          class="px-2 py-1 text-xs"
+          class="!w-28 px-2 py-1 text-xs"
           value=${String(windowMinutes.value)}
           ariaLabel="시간 윈도우 선택"
           options=${[
@@ -924,6 +1016,7 @@ export function RuntimeMonitor() {
                     <div>models · ${formatNumber(runtimeProviderModelCount(provider, liveProbe))}</div>
                     <div>auth · ${runtimeProviderAuthText(provider, liveProbe)}</div>
                   </div>
+                  <${OfficialClientEvidence} provider=${provider} />
                   ${snapshotFacts
                     ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${snapshotFacts}>
                         snapshot · ${snapshotFacts}

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -178,13 +178,18 @@ function runtimeStatusLabel(provider: DashboardRuntimeProviderSnapshot): string 
 function officialClientUsageText(provider: DashboardRuntimeProviderSnapshot): string | null {
   const usage = provider.verification?.evidence?.measurement.usage
   if (!usage) return null
-  return [
+  const values = [
     `in ${formatNumber(usage.input_tokens)}`,
     `out ${formatNumber(usage.output_tokens)}`,
-    `thinking ${formatNumber(usage.thinking_tokens)}`,
-    `cache ${formatNumber(usage.cache_read_tokens)}`,
-    `total ${formatNumber(usage.total_tokens)}`,
-  ].join(' · ')
+  ]
+  if (usage.thinking_tokens != null) values.push(`thinking ${formatNumber(usage.thinking_tokens)}`)
+  if (usage.cache_creation_input_tokens != null) {
+    values.push(`cache write ${formatNumber(usage.cache_creation_input_tokens)}`)
+  }
+  values.push(`cache read ${formatNumber(usage.cache_read_input_tokens)}`)
+  if (usage.total_tokens != null) values.push(`total ${formatNumber(usage.total_tokens)}`)
+  if (usage.total_cost_usd != null) values.push(`cost $${usage.total_cost_usd.toFixed(4)}`)
+  return values.join(' · ')
 }
 
 function OfficialClientEvidence({ provider }: { provider: DashboardRuntimeProviderSnapshot }) {

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -870,7 +870,7 @@ describe('RuntimeTomlEditor', () => {
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
   })
 
-  it('offers only materializable HTTP protocols plus the typed Codex official client', async () => {
+  it('offers materializable HTTP protocols plus typed official clients', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)
 
@@ -888,11 +888,44 @@ describe('RuntimeTomlEditor', () => {
       'ollama-http',
       'openai-compatible-cli',
       'codex-app-server',
+      'antigravity-cli',
     ])
     expect(protocolOptions).not.toContain('messages-http')
     expect(protocolOptions).not.toContain('messages-cli')
     // No transport-kind selector left to switch to 'command'.
     expect(container.querySelector('[aria-label="새 provider transport 종류"]')).toBeNull()
+  })
+
+  it('creates an Antigravity subscription provider with the enforced no-key boundary', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-providers"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-providers"]') as HTMLButtonElement)
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-toggle"]') as HTMLButtonElement)
+    fireEvent.input(container.querySelector('[data-testid="runtime-add-provider-id"]') as HTMLInputElement, {
+      target: { value: 'antigravity_subscription' },
+    })
+    fireEvent.change(container.querySelector('[aria-label="새 provider protocol"]') as HTMLSelectElement, {
+      target: { value: 'antigravity-cli' },
+    })
+
+    const command = container.querySelector('[aria-label="새 provider transport 값"]') as HTMLInputElement
+    expect(command.placeholder).toBe('/absolute/path/to/agy')
+    expect((container.querySelector('[aria-label="새 provider credential 종류"]') as HTMLSelectElement).value).toBe('none')
+    fireEvent.input(command, { target: { value: '/opt/masc/bin/agy' } })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('[providers.antigravity_subscription]')
+      expect(source).toContain('protocol = "antigravity-cli"')
+      expect(source).toContain('command = "/opt/masc/bin/agy"')
+      expect(source).toContain('is-non-interactive = true')
+      expect(source).not.toContain('[providers.antigravity_subscription.credentials]')
+    })
   })
 
   it('creates a Codex subscription provider and binding with the enforced no-key boundary', async () => {
@@ -917,7 +950,7 @@ describe('RuntimeTomlEditor', () => {
     expect(container.querySelector('[aria-label="새 provider credential 값"]')).toBeNull()
 
     fireEvent.input(container.querySelector('[aria-label="새 provider transport 값"]') as HTMLInputElement, {
-      target: { value: '/Users/dancer/.local/bin/codex' },
+      target: { value: '/opt/masc/bin/codex' },
     })
     fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-submit"]') as HTMLButtonElement)
 
@@ -925,7 +958,7 @@ describe('RuntimeTomlEditor', () => {
       const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
       expect(source).toContain('[providers.codex_subscription]')
       expect(source).toContain('protocol = "codex-app-server"')
-      expect(source).toContain('command = "/Users/dancer/.local/bin/codex"')
+      expect(source).toContain('command = "/opt/masc/bin/codex"')
       expect(source).toContain('is-non-interactive = true')
       expect(source).not.toContain('[providers.codex_subscription.credentials]')
     })

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -870,7 +870,7 @@ describe('RuntimeTomlEditor', () => {
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
   })
 
-  it('does not offer messages protocols or command transport in the add-provider form', async () => {
+  it('offers only materializable HTTP protocols plus the typed Codex official client', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)
 
@@ -883,11 +883,67 @@ describe('RuntimeTomlEditor', () => {
     const protocolOptions = Array.from(
       container.querySelectorAll('[aria-label="새 provider protocol"] option'),
     ).map(option => (option as HTMLOptionElement).value)
-    expect(protocolOptions).toEqual(['openai-compatible-http', 'ollama-http', 'openai-compatible-cli'])
+    expect(protocolOptions).toEqual([
+      'openai-compatible-http',
+      'ollama-http',
+      'openai-compatible-cli',
+      'codex-app-server',
+    ])
     expect(protocolOptions).not.toContain('messages-http')
     expect(protocolOptions).not.toContain('messages-cli')
     // No transport-kind selector left to switch to 'command'.
     expect(container.querySelector('[aria-label="새 provider transport 종류"]')).toBeNull()
+  })
+
+  it('creates a Codex subscription provider and binding with the enforced no-key boundary', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-providers"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-providers"]') as HTMLButtonElement)
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-toggle"]') as HTMLButtonElement)
+    fireEvent.input(container.querySelector('[data-testid="runtime-add-provider-id"]') as HTMLInputElement, {
+      target: { value: 'codex_subscription' },
+    })
+    fireEvent.change(container.querySelector('[aria-label="새 provider protocol"]') as HTMLSelectElement, {
+      target: { value: 'codex-app-server' },
+    })
+
+    const credentialType = container.querySelector('[aria-label="새 provider credential 종류"]') as HTMLSelectElement
+    expect(credentialType.value).toBe('none')
+    expect(credentialType.disabled).toBe(true)
+    expect(container.querySelector('[aria-label="새 provider credential 값"]')).toBeNull()
+
+    fireEvent.input(container.querySelector('[aria-label="새 provider transport 값"]') as HTMLInputElement, {
+      target: { value: '/Users/dancer/.local/bin/codex' },
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('[providers.codex_subscription]')
+      expect(source).toContain('protocol = "codex-app-server"')
+      expect(source).toContain('command = "/Users/dancer/.local/bin/codex"')
+      expect(source).toContain('is-non-interactive = true')
+      expect(source).not.toContain('[providers.codex_subscription.credentials]')
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-bindings"]') as HTMLButtonElement)
+    fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-provider"]') as HTMLSelectElement, {
+      target: { value: 'codex_subscription' },
+    })
+    fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-model"]') as HTMLSelectElement, {
+      target: { value: 'qwen' },
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-binding-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('[codex_subscription.qwen]')
+      expect(container.querySelector('[data-testid="runtime-add-binding-error"]')).toBeNull()
+    })
   })
 
   it('adds a new model through the form', async () => {

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -889,6 +889,7 @@ describe('RuntimeTomlEditor', () => {
       'openai-compatible-cli',
       'codex-app-server',
       'antigravity-cli',
+      'claude-code',
     ])
     expect(protocolOptions).not.toContain('messages-http')
     expect(protocolOptions).not.toContain('messages-cli')
@@ -925,6 +926,41 @@ describe('RuntimeTomlEditor', () => {
       expect(source).toContain('command = "/opt/masc/bin/agy"')
       expect(source).toContain('is-non-interactive = true')
       expect(source).not.toContain('[providers.antigravity_subscription.credentials]')
+    })
+  })
+
+  it('creates a Claude Code subscription provider with no credential input', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-providers"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-providers"]') as HTMLButtonElement)
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-toggle"]') as HTMLButtonElement)
+    fireEvent.input(container.querySelector('[data-testid="runtime-add-provider-id"]') as HTMLInputElement, {
+      target: { value: 'claude' },
+    })
+    fireEvent.change(container.querySelector('[aria-label="새 provider protocol"]') as HTMLSelectElement, {
+      target: { value: 'claude-code' },
+    })
+
+    const command = container.querySelector('[aria-label="새 provider transport 값"]') as HTMLInputElement
+    const credential = container.querySelector('[aria-label="새 provider credential 종류"]') as HTMLSelectElement
+    expect(command.placeholder).toBe('/absolute/path/to/claude')
+    expect(credential.value).toBe('none')
+    expect(credential.disabled).toBe(true)
+    expect(container.textContent).toContain('plan + 읽기 전용 도구, 최대 12 client turns')
+    fireEvent.input(command, { target: { value: '/Users/operator/.local/bin/claude' } })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('[providers.claude]')
+      expect(source).toContain('protocol = "claude-code"')
+      expect(source).toContain('command = "/Users/operator/.local/bin/claude"')
+      expect(source).toContain('is-non-interactive = true')
+      expect(source).not.toContain('[providers.claude.credentials]')
     })
   })
 

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -310,6 +310,9 @@ export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps =
       let next = setRuntimeTomlProviderField(current, input.id, 'display-name', input.displayName || input.id)
       next = setRuntimeTomlProviderField(next, input.id, 'protocol', input.protocol)
       next = setRuntimeTomlProviderField(next, input.id, input.transportKind, input.transportValue)
+      if (input.isNonInteractive) {
+        next = setRuntimeTomlProviderField(next, input.id, 'is-non-interactive', true)
+      }
       if (input.credentialType !== 'none' && input.credentialValue.trim() !== '') {
         next = setRuntimeTomlProviderCredential(next, input.id, input.credentialType, input.credentialValue)
       }

--- a/dashboard/src/demo/official-client-runtime-fixture.ts
+++ b/dashboard/src/demo/official-client-runtime-fixture.ts
@@ -1,0 +1,34 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { RuntimeMonitor } from '../components/runtime-monitor'
+
+function OfficialClientRuntimeFixture() {
+  return html`
+    <main
+      class="min-h-screen px-5 py-6"
+      style="background: var(--color-bg-page);"
+      data-official-client-runtime-fixture
+    >
+      <section class="mx-auto max-w-[1180px]">
+        <header class="mb-5">
+          <div class="text-2xs uppercase tracking-[0.16em] text-[var(--color-accent-fg)]">
+            MASC Runtime Control
+          </div>
+          <h1 class="mt-1 text-xl font-semibold text-[var(--color-fg-primary)]">
+            공식 구독 CLI 실측 증거
+          </h1>
+          <p class="mt-1 text-xs text-[var(--color-fg-muted)]">
+            설정 상태와 이 서버 프로세스에서 관측된 실행 결과를 분리합니다.
+          </p>
+        </header>
+        <${RuntimeMonitor} />
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) render(html`<${OfficialClientRuntimeFixture} />`, root)

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -101,6 +101,31 @@ max-context = 131072
     })
   })
 
+  it('projects the Antigravity official-client subscription boundary without credentials', () => {
+    const environment = parseRuntimeTomlEnvironment(`[runtime]
+default = "antigravity_subscription.flash"
+
+[providers.antigravity_subscription]
+display-name = "Antigravity Subscription"
+protocol = "antigravity-cli"
+command = "/opt/masc/bin/agy"
+is-non-interactive = true
+
+[models.flash]
+api-name = "gemini-3.6-flash-low"
+max-context = 128000
+
+[antigravity_subscription.flash]
+`)
+    expect(environment.providers[0]).toMatchObject({
+      protocol: 'antigravity-cli',
+      transportKind: 'command',
+      command: '/opt/masc/bin/agy',
+      credentialType: 'none',
+      isNonInteractive: true,
+    })
+  })
+
   it('projects runtime routing lanes and keeper assignments from runtime.toml source', () => {
     const withRouting = `${sourceText.replace(
       'default = "runpod_mtp.qwen"',

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -74,6 +74,33 @@ describe('runtime TOML dashboard editing helpers', () => {
     })
   })
 
+  it('projects the Codex official-client subscription boundary without credentials', () => {
+    const codexSource = `[runtime]
+default = "codex_subscription.spark"
+
+[providers.codex_subscription]
+display-name = "Codex Subscription"
+protocol = "codex-app-server"
+command = "/usr/local/bin/codex"
+is-non-interactive = true
+
+[models.spark]
+api-name = "gpt-5.3-codex-spark"
+max-context = 131072
+
+[codex_subscription.spark]
+`
+
+    const environment = parseRuntimeTomlEnvironment(codexSource)
+    expect(environment.providers[0]).toMatchObject({
+      protocol: 'codex-app-server',
+      transportKind: 'command',
+      command: '/usr/local/bin/codex',
+      credentialType: 'none',
+      isNonInteractive: true,
+    })
+  })
+
   it('projects runtime routing lanes and keeper assignments from runtime.toml source', () => {
     const withRouting = `${sourceText.replace(
       'default = "runpod_mtp.qwen"',

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -126,6 +126,35 @@ max-context = 128000
     })
   })
 
+  it('projects the Claude Code subscription boundary without credentials', () => {
+    const environment = parseRuntimeTomlEnvironment(`[runtime]
+default = "claude.opus"
+
+[providers.claude]
+display-name = "Claude Code Subscription"
+protocol = "claude-code"
+command = "/Users/operator/.local/bin/claude"
+is-non-interactive = true
+
+[models.opus]
+api-name = "claude-opus-5"
+max-context = 128000
+
+[claude.opus]
+`)
+    expect(environment.providers[0]).toMatchObject({
+      protocol: 'claude-code',
+      transportKind: 'command',
+      command: '/Users/operator/.local/bin/claude',
+      credentialType: 'none',
+      isNonInteractive: true,
+    })
+    expect(environment.models[0]).toMatchObject({
+      apiName: 'claude-opus-5',
+      maxContext: 128000,
+    })
+  })
+
   it('projects runtime routing lanes and keeper assignments from runtime.toml source', () => {
     const withRouting = `${sourceText.replace(
       'default = "runpod_mtp.qwen"',

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -12,6 +12,7 @@ export interface RuntimeTomlProvider {
   credentialKey: string
   credentialPath: string
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 export interface RuntimeTomlModel {
@@ -289,6 +290,7 @@ function providerFromDocument(document: TomlDocument, id: string): RuntimeTomlPr
     credentialKey: asString(credentials.key),
     credentialPath: asString(credentials.path),
     credentialValue: asString(credentials.value),
+    isNonInteractive: asBoolean(values['is-non-interactive']),
   }
 }
 
@@ -639,8 +641,8 @@ export function setRuntimeTomlDefault(sourceText: string, runtimeId: string): st
 export function setRuntimeTomlProviderField(
   sourceText: string,
   providerId: string,
-  field: 'display-name' | 'protocol' | 'endpoint' | 'command',
-  value: string,
+  field: 'display-name' | 'protocol' | 'endpoint' | 'command' | 'is-non-interactive',
+  value: string | boolean,
 ): string {
   const section = `providers.${providerId}`
   if (field === 'endpoint') {
@@ -722,14 +724,16 @@ export const RUNTIME_TOML_PROTOCOLS = [
   'openai-compatible-cli',
   'messages-http',
   'messages-cli',
+  'codex-app-server',
 ] as const
 
 export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
 
 // Subset of RUNTIME_TOML_PROTOCOLS the add-provider form is allowed to offer.
-// The add-provider form only creates endpoint-backed providers. Command
-// transport is blocked at the binding form via transportKind, while
-// `provider_kind_for_http_provider` still returns `None` for `Messages_api`.
+// HTTP protocols create endpoint-backed providers. A typed official-client
+// protocol creates the command-backed runtime its backend adapter owns, while
+// generic command providers remain blocked. `provider_kind_for_http_provider`
+// still returns `None` for `Messages_api`.
 // Messages providers parse and save, but resolve to no provider_kind and
 // `Runtime.materialize_config`'s `List.filter_map` silently drops their bindings
 // from the live runtime list instead of failing the save
@@ -740,12 +744,17 @@ export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
   'openai-compatible-http',
   'ollama-http',
   'openai-compatible-cli',
+  'codex-app-server',
 ] as const
 
 export type RuntimeTomlCreatableProtocol = (typeof RUNTIME_TOML_CREATABLE_PROTOCOLS)[number]
 
 export function isRuntimeTomlCreatableProtocol(protocol: string): protocol is RuntimeTomlCreatableProtocol {
   return (RUNTIME_TOML_CREATABLE_PROTOCOLS as readonly string[]).includes(protocol)
+}
+
+export function isRuntimeTomlOfficialClientProtocol(protocol: string): boolean {
+  return protocol === 'codex-app-server'
 }
 
 const RUNTIME_TOML_NON_MATERIALIZABLE_PROTOCOLS = new Set([

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -725,6 +725,7 @@ export const RUNTIME_TOML_PROTOCOLS = [
   'messages-http',
   'messages-cli',
   'codex-app-server',
+  'antigravity-cli',
 ] as const
 
 export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
@@ -745,6 +746,7 @@ export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
   'ollama-http',
   'openai-compatible-cli',
   'codex-app-server',
+  'antigravity-cli',
 ] as const
 
 export type RuntimeTomlCreatableProtocol = (typeof RUNTIME_TOML_CREATABLE_PROTOCOLS)[number]
@@ -754,7 +756,7 @@ export function isRuntimeTomlCreatableProtocol(protocol: string): protocol is Ru
 }
 
 export function isRuntimeTomlOfficialClientProtocol(protocol: string): boolean {
-  return protocol === 'codex-app-server'
+  return protocol === 'codex-app-server' || protocol === 'antigravity-cli'
 }
 
 const RUNTIME_TOML_NON_MATERIALIZABLE_PROTOCOLS = new Set([

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -726,6 +726,7 @@ export const RUNTIME_TOML_PROTOCOLS = [
   'messages-cli',
   'codex-app-server',
   'antigravity-cli',
+  'claude-code',
 ] as const
 
 export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
@@ -739,7 +740,7 @@ export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
 // `Runtime.materialize_config`'s `List.filter_map` silently drops their bindings
 // from the live runtime list instead of failing the save
 // (lib/runtime/runtime_adapter.ml:183-203, lib/runtime/runtime.ml:239).
-// This is an allow-list of materializable endpoint protocols, so a future 6th
+// This is an allow-list of materializable endpoint protocols, so a future 7th
 // protocol defaults to non-creatable until reviewed.
 export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
   'openai-compatible-http',
@@ -747,6 +748,7 @@ export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
   'openai-compatible-cli',
   'codex-app-server',
   'antigravity-cli',
+  'claude-code',
 ] as const
 
 export type RuntimeTomlCreatableProtocol = (typeof RUNTIME_TOML_CREATABLE_PROTOCOLS)[number]
@@ -756,7 +758,9 @@ export function isRuntimeTomlCreatableProtocol(protocol: string): protocol is Ru
 }
 
 export function isRuntimeTomlOfficialClientProtocol(protocol: string): boolean {
-  return protocol === 'codex-app-server' || protocol === 'antigravity-cli'
+  return protocol === 'codex-app-server'
+    || protocol === 'antigravity-cli'
+    || protocol === 'claude-code'
 }
 
 const RUNTIME_TOML_NON_MATERIALIZABLE_PROTOCOLS = new Set([

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -349,9 +349,29 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       ~latency_ms:(Some latency_ms)
       ~error:None;
     let runtime_observation =
+      let official_client : Runtime_observation.official_client_measurement =
+        { client = Antigravity
+        ; execution_mode = Plan_sandbox
+        ; tool_owner = Official_client
+        ; permission_mode = Some turn.permission_mode
+        ; session_bound = true
+        ; resumed = turn.resumed
+        ; turn_count
+        ; tool_calls = turn.tool_calls
+        ; usage =
+            Some
+              { input_tokens = turn.usage.input_tokens
+              ; output_tokens = turn.usage.output_tokens
+              ; thinking_tokens = turn.usage.thinking_tokens
+              ; cache_read_tokens = turn.usage.cache_read_tokens
+              ; total_tokens = turn.usage.total_tokens
+              }
+        }
+      in
       Runtime_observation.runtime_observation_with_metrics
         ~runtime_id
         ~strategy:"official_client_runtime"
+        ~official_client
         ~configured_labels:
           [ "antigravity_cli"
           ; "execution_mode=plan_sandbox"

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -362,9 +362,11 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
             Some
               { input_tokens = turn.usage.input_tokens
               ; output_tokens = turn.usage.output_tokens
-              ; thinking_tokens = turn.usage.thinking_tokens
-              ; cache_read_tokens = turn.usage.cache_read_tokens
-              ; total_tokens = turn.usage.total_tokens
+              ; thinking_tokens = Some turn.usage.thinking_tokens
+              ; cache_creation_input_tokens = None
+              ; cache_read_input_tokens = turn.usage.cache_read_tokens
+              ; total_tokens = Some turn.usage.total_tokens
+              ; total_cost_usd = None
               }
         }
       in

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -361,9 +361,32 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       ~latency_ms:(Some latency_ms)
       ~error:None;
     let runtime_observation =
+      let official_client : Runtime_observation.official_client_measurement =
+        { client = Claude_code
+        ; execution_mode = Plan_read_only
+        ; tool_owner = Official_client
+        ; permission_mode = Some turn.permission_mode
+        ; session_bound = true
+        ; resumed = turn.resumed
+        ; turn_count
+        ; tool_calls = turn.tool_calls
+        ; usage =
+            Some
+              { input_tokens = turn.usage.input_tokens
+              ; output_tokens = turn.usage.output_tokens
+              ; thinking_tokens = None
+              ; cache_creation_input_tokens =
+                  Some turn.usage.cache_creation_input_tokens
+              ; cache_read_input_tokens = turn.usage.cache_read_input_tokens
+              ; total_tokens = None
+              ; total_cost_usd = Some turn.usage.total_cost_usd
+              }
+        }
+      in
       Runtime_observation.runtime_observation_with_metrics
         ~runtime_id
         ~strategy:"official_client_runtime"
+        ~official_client
         ~configured_labels:
           [ "claude_code"
           ; "execution_mode=plan_read_only"

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -670,9 +670,22 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
          ~latency_ms:(Some latency_ms)
          ~error:None;
        let runtime_observation =
+         let official_client : Runtime_observation.official_client_measurement =
+           { client = Codex
+           ; execution_mode = App_server
+           ; tool_owner = Masc
+           ; permission_mode = None
+           ; session_bound = true
+           ; resumed = turn.resumed
+           ; turn_count
+           ; tool_calls = turn.dynamic_tool_calls
+           ; usage = None
+           }
+         in
          Runtime_observation.runtime_observation_with_metrics
            ~runtime_id
            ~strategy:"official_client_runtime"
+           ~official_client
            ~configured_labels:
              [ "codex_app_server"
              ; Printf.sprintf "dynamic_tool_calls=%d" turn.dynamic_tool_calls

--- a/lib/runtime/runtime_observation.ml
+++ b/lib/runtime/runtime_observation.ml
@@ -14,10 +14,12 @@
 type official_client_kind =
   | Codex
   | Antigravity
+  | Claude_code
 
 type official_client_execution_mode =
   | App_server
   | Plan_sandbox
+  | Plan_read_only
 
 type official_client_tool_owner =
   | Masc
@@ -26,9 +28,11 @@ type official_client_tool_owner =
 type official_client_usage =
   { input_tokens : int
   ; output_tokens : int
-  ; thinking_tokens : int
-  ; cache_read_tokens : int
-  ; total_tokens : int
+  ; thinking_tokens : int option
+  ; cache_creation_input_tokens : int option
+  ; cache_read_input_tokens : int
+  ; total_tokens : int option
+  ; total_cost_usd : float option
   }
 
 type official_client_measurement =
@@ -468,11 +472,13 @@ let runtime_observation_with_metrics ~runtime_id ?strategy ~configured_labels
 let official_client_kind_to_string = function
   | Codex -> "codex"
   | Antigravity -> "antigravity"
+  | Claude_code -> "claude_code"
 ;;
 
 let official_client_execution_mode_to_string = function
   | App_server -> "app_server"
   | Plan_sandbox -> "plan_sandbox"
+  | Plan_read_only -> "plan_read_only"
 ;;
 
 let official_client_tool_owner_to_string = function
@@ -484,9 +490,12 @@ let official_client_usage_to_json (usage : official_client_usage) =
   `Assoc
     [ "input_tokens", `Int usage.input_tokens
     ; "output_tokens", `Int usage.output_tokens
-    ; "thinking_tokens", `Int usage.thinking_tokens
-    ; "cache_read_tokens", `Int usage.cache_read_tokens
-    ; "total_tokens", `Int usage.total_tokens
+    ; "thinking_tokens", Json_util.int_opt_to_json usage.thinking_tokens
+    ; ( "cache_creation_input_tokens"
+      , Json_util.int_opt_to_json usage.cache_creation_input_tokens )
+    ; "cache_read_input_tokens", `Int usage.cache_read_input_tokens
+    ; "total_tokens", Json_util.int_opt_to_json usage.total_tokens
+    ; "total_cost_usd", Json_util.float_opt_to_json usage.total_cost_usd
     ]
 ;;
 

--- a/lib/runtime/runtime_observation.ml
+++ b/lib/runtime/runtime_observation.ml
@@ -11,10 +11,43 @@
 (* Runtime types                                                     *)
 (* ================================================================ *)
 
+type official_client_kind =
+  | Codex
+  | Antigravity
+
+type official_client_execution_mode =
+  | App_server
+  | Plan_sandbox
+
+type official_client_tool_owner =
+  | Masc
+  | Official_client
+
+type official_client_usage =
+  { input_tokens : int
+  ; output_tokens : int
+  ; thinking_tokens : int
+  ; cache_read_tokens : int
+  ; total_tokens : int
+  }
+
+type official_client_measurement =
+  { client : official_client_kind
+  ; execution_mode : official_client_execution_mode
+  ; tool_owner : official_client_tool_owner
+  ; permission_mode : string option
+  ; session_bound : bool
+  ; resumed : bool
+  ; turn_count : int
+  ; tool_calls : int
+  ; usage : official_client_usage option
+  }
+
 type runtime_observation = {
   runtime_id : string;
   strategy : string option;
   configured_labels : string list;
+  official_client : official_client_measurement option;
   candidate_models : string list;
   primary_model : string option;
   selected_model : string option;
@@ -147,6 +180,7 @@ let model_label_of_config (cfg : Llm_provider.Provider_config.t) =
 (* ================================================================ *)
 
 let runtime_observation_of_candidates ~runtime_id ?strategy ~configured_labels
+    ?official_client
     ~(candidate_count : int)
     ~(selected_model_raw : string option)
     ?(attempts = [])
@@ -183,6 +217,7 @@ let runtime_observation_of_candidates ~runtime_id ?strategy ~configured_labels
     runtime_id;
     strategy;
     configured_labels;
+    official_client;
     candidate_models;
     primary_model;
     selected_model;
@@ -404,6 +439,7 @@ let runtime_metrics_for_candidates ~candidate_count:(_ : int) () =
   (capture, metrics)
 
 let runtime_observation_with_metrics ~runtime_id ?strategy ~configured_labels
+    ?official_client
     ~(candidate_count : int)
     ~(selected_model_raw : string option) ~(capture : runtime_metrics_capture)
     ?(attempt_details_source = "oas_metrics_callbacks")
@@ -413,6 +449,7 @@ let runtime_observation_with_metrics ~runtime_id ?strategy ~configured_labels
     streaming_metrics_of_capture capture.streaming
   in
   runtime_observation_of_candidates ~runtime_id ?strategy ~configured_labels
+    ?official_client
     ~candidate_count ~selected_model_raw
     ~attempts:(List.rev capture.attempts_rev)
     ~fallback_events:(List.rev capture.fallback_events_rev)
@@ -428,6 +465,51 @@ let runtime_observation_with_metrics ~runtime_id ?strategy ~configured_labels
 (* JSON serialization                                                *)
 (* ================================================================ *)
 
+let official_client_kind_to_string = function
+  | Codex -> "codex"
+  | Antigravity -> "antigravity"
+;;
+
+let official_client_execution_mode_to_string = function
+  | App_server -> "app_server"
+  | Plan_sandbox -> "plan_sandbox"
+;;
+
+let official_client_tool_owner_to_string = function
+  | Masc -> "masc"
+  | Official_client -> "official_client"
+;;
+
+let official_client_usage_to_json (usage : official_client_usage) =
+  `Assoc
+    [ "input_tokens", `Int usage.input_tokens
+    ; "output_tokens", `Int usage.output_tokens
+    ; "thinking_tokens", `Int usage.thinking_tokens
+    ; "cache_read_tokens", `Int usage.cache_read_tokens
+    ; "total_tokens", `Int usage.total_tokens
+    ]
+;;
+
+let official_client_measurement_to_json (measurement : official_client_measurement) =
+  `Assoc
+    [ "client", `String (official_client_kind_to_string measurement.client)
+    ; ( "execution_mode"
+      , `String
+          (official_client_execution_mode_to_string measurement.execution_mode) )
+    ; "tool_owner", `String (official_client_tool_owner_to_string measurement.tool_owner)
+    ; "permission_mode", Json_util.string_opt_to_json measurement.permission_mode
+    ; "session_bound", `Bool measurement.session_bound
+    ; "resumed", `Bool measurement.resumed
+    ; "turn_count", `Int measurement.turn_count
+    ; "tool_calls", `Int measurement.tool_calls
+    ; ( "usage"
+      , Option.fold
+          ~none:`Null
+          ~some:official_client_usage_to_json
+          measurement.usage )
+    ]
+;;
+
 let runtime_observation_to_json (obs : runtime_observation) : Yojson.Safe.t =
   let runtime_id =
     obs.runtime_id
@@ -438,6 +520,11 @@ let runtime_observation_to_json (obs : runtime_observation) : Yojson.Safe.t =
       ("strategy", Json_util.string_opt_to_json obs.strategy);
       ( "configured_labels",
         `List (List.map (fun label -> `String label) obs.configured_labels) );
+      ( "official_client",
+        Option.fold
+          ~none:`Null
+          ~some:official_client_measurement_to_json
+          obs.official_client );
       ( "candidate_models",
         `List (List.map (fun label -> `String label) obs.candidate_models) );
       ("primary_model", Json_util.string_opt_to_json obs.primary_model);
@@ -587,6 +674,35 @@ type state = {
   audit_store : Dated_jsonl.t option;
 }
 
+type official_client_snapshot =
+  { runtime_id : string
+  ; observed_at : float
+  ; outcome : [ `Success | `Failure | `Rejected ]
+  ; measurement : official_client_measurement
+  }
+
+let official_client_snapshots = Atomic.make StringMap.empty
+
+let rec publish_official_client_snapshot snapshot =
+  let current = Atomic.get official_client_snapshots in
+  let next = StringMap.add snapshot.runtime_id snapshot current in
+  if not (Atomic.compare_and_set official_client_snapshots current next)
+  then publish_official_client_snapshot snapshot
+;;
+
+let latest_official_client_snapshot ~runtime_id =
+  StringMap.find_opt runtime_id (Atomic.get official_client_snapshots)
+;;
+
+let official_client_snapshot_to_json snapshot =
+  `Assoc
+    [ "runtime_id", `String snapshot.runtime_id
+    ; "observed_at", `Float snapshot.observed_at
+    ; "outcome", `String (runtime_outcome_to_string snapshot.outcome)
+    ; "measurement", official_client_measurement_to_json snapshot.measurement
+    ]
+;;
+
 let stream = Eio.Stream.create 1024
 
 let handle_record state ~now ~keeper_name ~runtime_id ~observation ~outcome =
@@ -733,6 +849,11 @@ let start_actor_if_needed ~sw =
 
 let record_runtime ?keeper_name ~observation ~runtime_id ~outcome () =
   let now = Time_compat.now () in
+  Option.iter
+    (fun measurement ->
+      publish_official_client_snapshot
+        { runtime_id; observed_at = now; outcome; measurement })
+    (Option.bind observation (fun observed -> observed.official_client));
   Eio.Stream.add stream
     (Record_runtime { keeper_name; runtime_id; observation; outcome; now })
 

--- a/lib/runtime/runtime_observation.mli
+++ b/lib/runtime/runtime_observation.mli
@@ -60,10 +60,12 @@ type runtime_fallback_event = {
 type official_client_kind =
   | Codex
   | Antigravity
+  | Claude_code
 
 type official_client_execution_mode =
   | App_server
   | Plan_sandbox
+  | Plan_read_only
 
 type official_client_tool_owner =
   | Masc
@@ -72,9 +74,11 @@ type official_client_tool_owner =
 type official_client_usage =
   { input_tokens : int
   ; output_tokens : int
-  ; thinking_tokens : int
-  ; cache_read_tokens : int
-  ; total_tokens : int
+  ; thinking_tokens : int option
+  ; cache_creation_input_tokens : int option
+  ; cache_read_input_tokens : int
+  ; total_tokens : int option
+  ; total_cost_usd : float option
   }
 
 type official_client_measurement =

--- a/lib/runtime/runtime_observation.mli
+++ b/lib/runtime/runtime_observation.mli
@@ -57,10 +57,43 @@ type runtime_fallback_event = {
   reason : string;
 }
 
+type official_client_kind =
+  | Codex
+  | Antigravity
+
+type official_client_execution_mode =
+  | App_server
+  | Plan_sandbox
+
+type official_client_tool_owner =
+  | Masc
+  | Official_client
+
+type official_client_usage =
+  { input_tokens : int
+  ; output_tokens : int
+  ; thinking_tokens : int
+  ; cache_read_tokens : int
+  ; total_tokens : int
+  }
+
+type official_client_measurement =
+  { client : official_client_kind
+  ; execution_mode : official_client_execution_mode
+  ; tool_owner : official_client_tool_owner
+  ; permission_mode : string option
+  ; session_bound : bool
+  ; resumed : bool
+  ; turn_count : int
+  ; tool_calls : int
+  ; usage : official_client_usage option
+  }
+
 type runtime_observation = {
   runtime_id : string;
   strategy : string option;
   configured_labels : string list;
+  official_client : official_client_measurement option;
   candidate_models : string list;
   primary_model : string option;
   selected_model : string option;
@@ -160,6 +193,7 @@ val runtime_observation_with_metrics :
   runtime_id:string ->
   ?strategy:string ->
   configured_labels:string list ->
+  ?official_client:official_client_measurement ->
   candidate_count:int ->
   selected_model_raw:string option ->
   capture:runtime_metrics_capture ->
@@ -224,3 +258,18 @@ val runtime_observation_to_json :
     [attempts] / [fallback_events] / outcome metadata
     into a single [`Assoc].  Pinned because the runtime-
     include consumer ([Runtime_agent]) re-exposes it. *)
+
+type official_client_snapshot =
+  { runtime_id : string
+  ; observed_at : float
+  ; outcome : [ `Success | `Failure | `Rejected ]
+  ; measurement : official_client_measurement
+  }
+
+val latest_official_client_snapshot :
+  runtime_id:string -> official_client_snapshot option
+(** Latest typed in-process official-client evidence. Raw session identifiers
+    are deliberately absent from this public dashboard boundary. *)
+
+val official_client_snapshot_to_json :
+  official_client_snapshot -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1860,6 +1860,42 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
     ]
 ;;
 
+let runtime_official_client_snapshot (rt : Runtime.t) =
+  match rt.execution with
+  | Runtime_execution.Agent_core _ -> None
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Antigravity_cli _ ->
+    Runtime_observation.latest_official_client_snapshot ~runtime_id:rt.id
+;;
+
+let runtime_official_client_verification_json (rt : Runtime.t) =
+  match rt.execution, runtime_official_client_snapshot rt with
+  | Runtime_execution.Agent_core _, _ -> `Null
+  | (Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _), None ->
+    `Assoc
+      [ "status", `String "unverified"
+      ; "measured", `Bool false
+      ; "observed_at", `Null
+      ; "evidence", `Null
+      ; "reason", `String "no_successful_runtime_observation"
+      ]
+  | ( Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _
+    ), Some snapshot ->
+    let status =
+      match snapshot.outcome with
+      | `Success -> "verified"
+      | `Failure -> "failed"
+      | `Rejected -> "rejected"
+    in
+    `Assoc
+      [ "status", `String status
+      ; "measured", `Bool true
+      ; "observed_at", `Float snapshot.observed_at
+      ; "evidence", Runtime_observation.official_client_snapshot_to_json snapshot
+      ; "reason", `Null
+      ]
+;;
+
 let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
   let runtime_kind = runtime_kind_of_transport rt.provider.transport in
   let is_official_client_runtime =
@@ -1870,7 +1906,11 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     | Runtime_execution.Agent_core _ -> false
   in
   let runtime_status =
-    if is_official_client_runtime then "configured_unverified" else "configured"
+    match runtime_official_client_snapshot rt with
+    | Some { outcome = `Success; _ } -> "verified"
+    | Some { outcome = (`Failure | `Rejected); _ } -> "configured_observed_failure"
+    | None when is_official_client_runtime -> "configured_unverified"
+    | None -> "configured"
   in
   let models = [ rt.model.api_name ] in
   let capabilities_declared, caps =
@@ -1946,15 +1986,7 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "parameter_policy", runtime_parameter_policy_json rt
     ; "request_config", runtime_request_config_json rt
     ; ( "verification"
-      , if is_official_client_runtime
-        then
-          `Assoc
-            [ "status", `String "unverified"
-            ; "measured", `Bool false
-            ; "evidence", `Null
-            ; "reason", `String "no_successful_runtime_observation"
-            ]
-        else `Null )
+      , runtime_official_client_verification_json rt )
     ; "declared_spec", runtime_declared_spec_json rt
     ; "model_count", `Int (List.length models)
     ; "models", Json_util.json_string_list models

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1864,14 +1864,17 @@ let runtime_official_client_snapshot (rt : Runtime.t) =
   match rt.execution with
   | Runtime_execution.Agent_core _ -> None
   | Runtime_execution.Codex_app_server _
-  | Runtime_execution.Antigravity_cli _ ->
+  | Runtime_execution.Antigravity_cli _
+  | Runtime_execution.Claude_code _ ->
     Runtime_observation.latest_official_client_snapshot ~runtime_id:rt.id
 ;;
 
 let runtime_official_client_verification_json (rt : Runtime.t) =
   match rt.execution, runtime_official_client_snapshot rt with
   | Runtime_execution.Agent_core _, _ -> `Null
-  | (Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _), None ->
+  | ( Runtime_execution.Codex_app_server _
+    | Runtime_execution.Antigravity_cli _
+    | Runtime_execution.Claude_code _ ), None ->
     `Assoc
       [ "status", `String "unverified"
       ; "measured", `Bool false
@@ -1879,7 +1882,9 @@ let runtime_official_client_verification_json (rt : Runtime.t) =
       ; "evidence", `Null
       ; "reason", `String "no_successful_runtime_observation"
       ]
-  | ( Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _
+  | ( Runtime_execution.Codex_app_server _
+    | Runtime_execution.Antigravity_cli _
+    | Runtime_execution.Claude_code _
     ), Some snapshot ->
     let status =
       match snapshot.outcome with

--- a/scripts/harness_dashboard_official_client_runtime_e2e.sh
+++ b/scripts/harness_dashboard_official_client_runtime_e2e.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5191}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/official-client-runtime-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-official-client-runtime-vite-${PORT}.log"
+ARTIFACT_DIR="${OFFICIAL_CLIENT_RUNTIME_ARTIFACT_DIR:-${TMPDIR:-/tmp}}"
+
+mkdir -p "${ARTIFACT_DIR}"
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+OFFICIAL_CLIENT_RUNTIME_FIXTURE_URL="${FIXTURE_URL}" \
+OFFICIAL_CLIENT_RUNTIME_ARTIFACT_DIR="${ARTIFACT_DIR}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec node e2e/official-client-runtime.mjs
+
+printf 'official client runtime Playwright E2E passed\n'

--- a/test/stanzas/test_runtime_antigravity_cli.inc
+++ b/test/stanzas/test_runtime_antigravity_cli.inc
@@ -1,4 +1,4 @@
 (test
  (name test_runtime_antigravity_cli)
  (modules test_runtime_antigravity_cli)
- (libraries alcotest masc.runtime masc.masc_process eio eio_main unix))
+ (libraries alcotest yojson masc.runtime masc.masc_process eio eio_main unix))

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -197,6 +197,22 @@ let test_keeper_start_resume_and_measured_observation () =
        (match first.runtime_observation with
         | None -> fail "measured runtime observation was not emitted"
         | Some observation ->
+          (match observation.official_client with
+           | Some
+               { client = Claude_code
+               ; execution_mode = Plan_read_only
+               ; tool_owner = Official_client
+               ; permission_mode = Some "plan"
+               ; usage = Some usage
+               ; _
+               } ->
+             check int "typed cache creation" 2
+               (Option.value usage.cache_creation_input_tokens ~default:(-1));
+             check int "typed cache read" 7 usage.cache_read_input_tokens;
+             check (option (float 0.000001)) "typed cost" (Some 0.0125)
+               usage.total_cost_usd
+           | Some _ -> fail "Claude Code official-client evidence was misclassified"
+           | None -> fail "typed official-client evidence was not emitted");
           List.iter
             (fun label ->
               check bool label true (List.mem label observation.configured_labels))

--- a/test/test_runtime_antigravity_cli.ml
+++ b/test/test_runtime_antigravity_cli.ml
@@ -287,6 +287,59 @@ let test_runtime_observation_retains_internal_measured_labels () =
   check (list string) "internal measured labels" labels observation.configured_labels
 ;;
 
+let test_runtime_observation_publishes_typed_official_client_snapshot () =
+  let capture, _metrics =
+    Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
+  in
+  let official_client : Runtime_observation.official_client_measurement =
+    { client = Antigravity
+    ; execution_mode = Plan_sandbox
+    ; tool_owner = Official_client
+    ; permission_mode = Some "always-proceed"
+    ; session_bound = true
+    ; resumed = false
+    ; turn_count = 1
+    ; tool_calls = 2
+    ; usage =
+        Some
+          { input_tokens = 20
+          ; output_tokens = 3
+          ; thinking_tokens = 1
+          ; cache_read_tokens = 5
+          ; total_tokens = 23
+          }
+    }
+  in
+  let observation =
+    Runtime_observation.runtime_observation_with_metrics
+      ~runtime_id:"antigravity.typed-snapshot"
+      ~configured_labels:[]
+      ~official_client
+      ~candidate_count:1
+      ~selected_model_raw:(Some "gemini-3.6-flash-low")
+      ~capture
+      ()
+  in
+  Runtime_observation.record_runtime
+    ~observation:(Some observation)
+    ~runtime_id:"antigravity.typed-snapshot"
+    ~outcome:`Success
+    ();
+  match
+    Runtime_observation.latest_official_client_snapshot
+      ~runtime_id:"antigravity.typed-snapshot"
+  with
+  | None -> fail "typed official-client snapshot was not published"
+  | Some snapshot ->
+    check string "runtime" "antigravity.typed-snapshot" snapshot.runtime_id;
+    check bool "measurement" true (snapshot.measurement = official_client);
+    let json = Runtime_observation.official_client_snapshot_to_json snapshot in
+    check string
+      "tool owner wire"
+      "official_client"
+      Yojson.Safe.Util.(json |> member "measurement" |> member "tool_owner" |> to_string)
+;;
+
 let () =
   run "runtime antigravity CLI"
     [ ( "typed stream-json boundary"
@@ -300,6 +353,10 @@ let () =
             "runtime observation keeps measured labels"
             `Quick
             test_runtime_observation_retains_internal_measured_labels
+        ; test_case
+            "runtime observation publishes typed official-client snapshot"
+            `Quick
+            test_runtime_observation_publishes_typed_official_client_snapshot
         ] )
     ; ( "live subscription"
       , [ test_case "official Antigravity CLI" `Slow test_live_subscription_client ] )


### PR DESCRIPTION
## Outcome

Adds first-class dashboard configuration and measured evidence for Codex, Antigravity, and Claude Code official subscription clients.

This replaces closed-without-merge draft #27741; that PR is not reopened.

## Dashboard setup

- offers exact `claude-code` alongside `codex-app-server` and `antigravity-cli`
- uses command transport, forces `is-non-interactive = true`, disables credentials, and never renders an API-key input for official clients
- shows `/absolute/path/to/claude` guidance
- explains the measured Claude boundary: existing official login, `plan`, fixed read-only tools, and 12 client turns
- supports a 128,000-context Claude model through the existing typed model form
- saves to the normal MASC runtime TOML boundary (`<base-path>/.masc/runtime.toml`; typically `~/.masc/runtime.toml`)

## Measured evidence

- extends the typed runtime observation with `claude_code` and `plan_read_only`
- hard-cuts usage fields to input/output, optional thinking, optional cache creation, cache read, optional total, and optional cost
- publishes Claude Keeper session/resume, tool calls, permission mode, token/cache usage, and cost
- exposes verified, failed, rejected, and configured-but-unmeasured states without inferring auth from configuration or a rejected turn
- never exposes the raw official-client session identifier

## Verification

- four focused dashboard suites: 225/225 passed
- `pnpm typecheck`: passed
- `pnpm lint`: passed
- `pnpm build`: passed (existing font/dynamic-import/chunk-size warnings remain)
- interactive Playwright E2E: passed after 30m → 60m and forced refresh
- screenshot inspected: `/tmp/masc-claude-dashboard-e2e/official-client-runtime-evidence.png`
- focused OCaml object compilation passed for Runtime observation, Codex/Antigravity/Claude Keeper producers, dashboard runtime-info, and the Claude Keeper test object

Full `dune build .` is not claimed because the stack base still has the previously reported Keeper approval build failures outside this diff.

## Stack

- base PR: #27745
- base SHA: `0de5b7389a`
- includes only dashboard/typed-observation commits above that base
