### PR TITLE
fix: publish live official-client runtime evidence

### DIFF
--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -41,6 +41,17 @@ let degraded_retry_runtime_of_wire ~keeper_name raw =
           raw;
       None
 
+let runtime_record_outcome = function
+  | Ok _ -> `Success
+  | Error
+      (Agent_sdk.Error.Api
+         (Llm_provider.Retry.RateLimited _
+         | Llm_provider.Retry.AuthError _
+         | Llm_provider.Retry.AuthorizationError _
+         | Llm_provider.Retry.PaymentRequired _)) ->
+    `Rejected
+  | Error _ -> `Failure
+
 let finalize
     ~config
     ~meta
@@ -110,6 +121,12 @@ let finalize
   let runtime_observation : Runtime_observation.runtime_observation option =
     !receipt_runtime_observation_ref
   in
+  Runtime_observation.record_runtime
+    ~keeper_name:meta.name
+    ~observation:runtime_observation
+    ~runtime_id
+    ~outcome:(runtime_record_outcome turn_result)
+    ();
   (* #20936: the before_turn_params hook snapshots the final injected
      extra_system_context (digest + byte size) into the accumulator each
      SDK turn; the receipt reports the last SDK turn's values. The SDK

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -199,8 +199,79 @@ let claude_code_error_to_sdk_error = function
   | error -> Agent_sdk.Error.Internal (Runtime_claude_code_cli.error_to_string error)
 ;;
 
+let runtime_observation
+    ~runtime_id
+    ~turn_count
+    ~latency_ms
+    ~attempt_error
+    ~model
+    ~num_turns
+    ~(usage : Runtime_claude_code_cli.usage)
+    ~tool_calls
+    ~permission_mode
+    ~resumed
+  =
+  let capture, _metrics =
+    Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
+  in
+  Runtime_observation.record_attempt_terminal
+    capture
+    ~model_id:model
+    ~latency_ms:(Some latency_ms)
+    ~error:attempt_error;
+  let official_client : Runtime_observation.official_client_measurement =
+    { client = Claude_code
+    ; execution_mode = Plan_read_only
+    ; tool_owner = Official_client
+    ; permission_mode = Some permission_mode
+    ; session_bound = true
+    ; resumed
+    ; turn_count
+    ; tool_calls
+    ; usage =
+        Some
+          { input_tokens = usage.input_tokens
+          ; output_tokens = usage.output_tokens
+          ; thinking_tokens = None
+          ; cache_creation_input_tokens = Some usage.cache_creation_input_tokens
+          ; cache_read_input_tokens = usage.cache_read_input_tokens
+          ; total_tokens = None
+          ; total_cost_usd = Some usage.total_cost_usd
+          }
+    }
+  in
+  Runtime_observation.runtime_observation_with_metrics
+    ~runtime_id
+    ~strategy:"official_client_runtime"
+    ~official_client
+    ~configured_labels:
+      [ "claude_code"
+      ; "execution_mode=plan_read_only"
+      ; "tool_owner=official_client"
+      ; "masc_tool_hooks=unavailable"
+      ; Printf.sprintf "permission_mode=%s" permission_mode
+      ; Printf.sprintf "tool_calls=%d" tool_calls
+      ; Printf.sprintf "resumed=%b" resumed
+      ; Printf.sprintf "turn_count=%d" turn_count
+      ; Printf.sprintf "client_turns=%d" num_turns
+      ; Printf.sprintf "input_tokens=%d" usage.input_tokens
+      ; Printf.sprintf "output_tokens=%d" usage.output_tokens
+      ; Printf.sprintf
+          "cache_creation_input_tokens=%d"
+          usage.cache_creation_input_tokens
+      ; Printf.sprintf "cache_read_input_tokens=%d" usage.cache_read_input_tokens
+      ; Printf.sprintf "total_cost_usd=%.12g" usage.total_cost_usd
+      ]
+    ~candidate_count:1
+    ~selected_model_raw:(Some model)
+    ~capture
+    ~attempt_details_source:"claude_code"
+    ~oas_internal_runtime_allowed:false
+    ()
+;;
+
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
-    ~initial_messages ~model_input_projection ~hooks
+    ~initial_messages ~model_input_projection ~hooks ~on_runtime_observation
     ~(config : Runtime_execution.claude_code) =
   let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
   let* goal =
@@ -282,6 +353,41 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
   in
   let started_at = Time_compat.now () in
   match Runtime_claude_code_cli.run_turn ~session_mode client_config ~prompt with
+  | Error (Turn_rejected rejection as error) ->
+    let latency_ms = Int.of_float ((Time_compat.now () -. started_at) *. 1000.0) in
+    let observation =
+      runtime_observation
+        ~runtime_id
+        ~turn_count
+        ~latency_ms
+        ~attempt_error:(Some "claude_code_rejected")
+        ~model:rejection.model
+        ~num_turns:rejection.num_turns
+        ~usage:rejection.usage
+        ~tool_calls:rejection.tool_calls
+        ~permission_mode:rejection.permission_mode
+        ~resumed:rejection.resumed
+    in
+    Option.iter (fun observe -> observe observation) on_runtime_observation;
+    let session_id =
+      match session_mode with
+      | Runtime_claude_code_cli.Start { session_id }
+      | Runtime_claude_code_cli.Resume { session_id } -> session_id
+    in
+    (match
+       Keeper_claude_code_session_store.settle
+         ~base_path
+         ~keeper_name
+         ~expected:claimed
+         ~session_id
+         ~usage:rejection.usage
+         ~updated_at:(Time_compat.now ())
+     with
+     | Ok _ -> Error (claude_code_error_to_sdk_error error)
+     | Error detail ->
+       Error
+         (internal_error
+            ("Claude Code rejected-session settlement failed: " ^ detail)))
   | Error error -> Error (claude_code_error_to_sdk_error error)
   | Ok turn ->
     let latency_ms = Int.of_float ((Time_compat.now () -. started_at) *. 1000.0) in
@@ -352,67 +458,18 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       | Error detail ->
         Error (internal_error ("Claude Code session settlement failed: " ^ detail))
     in
-    let capture, _metrics =
-      Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
-    in
-    Runtime_observation.record_attempt_terminal
-      capture
-      ~model_id:turn.model
-      ~latency_ms:(Some latency_ms)
-      ~error:None;
     let runtime_observation =
-      let official_client : Runtime_observation.official_client_measurement =
-        { client = Claude_code
-        ; execution_mode = Plan_read_only
-        ; tool_owner = Official_client
-        ; permission_mode = Some turn.permission_mode
-        ; session_bound = true
-        ; resumed = turn.resumed
-        ; turn_count
-        ; tool_calls = turn.tool_calls
-        ; usage =
-            Some
-              { input_tokens = turn.usage.input_tokens
-              ; output_tokens = turn.usage.output_tokens
-              ; thinking_tokens = None
-              ; cache_creation_input_tokens =
-                  Some turn.usage.cache_creation_input_tokens
-              ; cache_read_input_tokens = turn.usage.cache_read_input_tokens
-              ; total_tokens = None
-              ; total_cost_usd = Some turn.usage.total_cost_usd
-              }
-        }
-      in
-      Runtime_observation.runtime_observation_with_metrics
+      runtime_observation
         ~runtime_id
-        ~strategy:"official_client_runtime"
-        ~official_client
-        ~configured_labels:
-          [ "claude_code"
-          ; "execution_mode=plan_read_only"
-          ; "tool_owner=official_client"
-          ; "masc_tool_hooks=unavailable"
-          ; Printf.sprintf "permission_mode=%s" turn.permission_mode
-          ; Printf.sprintf "tool_calls=%d" turn.tool_calls
-          ; Printf.sprintf "resumed=%b" turn.resumed
-          ; Printf.sprintf "turn_count=%d" turn_count
-          ; Printf.sprintf "client_turns=%d" turn.num_turns
-          ; Printf.sprintf "input_tokens=%d" turn.usage.input_tokens
-          ; Printf.sprintf "output_tokens=%d" turn.usage.output_tokens
-          ; Printf.sprintf
-              "cache_creation_input_tokens=%d"
-              turn.usage.cache_creation_input_tokens
-          ; Printf.sprintf
-              "cache_read_input_tokens=%d"
-              turn.usage.cache_read_input_tokens
-          ; Printf.sprintf "total_cost_usd=%.12g" turn.usage.total_cost_usd
-          ]
-        ~candidate_count:1
-        ~selected_model_raw:(Some turn.model)
-        ~capture
-        ~attempt_details_source:"claude_code"
-        ~oas_internal_runtime_allowed:false
-        ()
+        ~turn_count
+        ~latency_ms
+        ~attempt_error:None
+        ~model:turn.model
+        ~num_turns:turn.num_turns
+        ~usage:turn.usage
+        ~tool_calls:turn.tool_calls
+        ~permission_mode:turn.permission_mode
+        ~resumed:turn.resumed
     in
     Ok
       { Runtime_agent.response

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -13,5 +13,6 @@ val run :
   initial_messages:Agent_sdk.Types.message list ->
   model_input_projection:Agent_sdk.Agent.model_input_projection option ->
   hooks:Agent_sdk.Hooks.hooks option ->
+  on_runtime_observation:(Runtime_observation.runtime_observation -> unit) option ->
   config:Runtime_execution.claude_code ->
   (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_claude_code_session_store.ml
+++ b/lib/keeper/keeper_claude_code_session_store.ml
@@ -105,8 +105,8 @@ let phase_of_yojson = function
        ; "previous_session_id", `String session_id
        ] ->
        Ok (Claimed { previous_session_id = Some session_id })
-     | [ "session_id", `String session_id
-       ; "kind", `String "settled"
+     | [ "kind", `String "settled"
+       ; "session_id", `String session_id
        ] -> Ok (Settled { session_id })
      | _ -> Error "Claude Code session phase fields are not exact")
   | _ -> Error "Claude Code session phase must be a JSON object"

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -821,6 +821,7 @@ let run_named
               ~initial_messages
               ~model_input_projection
               ~hooks
+              ~on_runtime_observation
               ~config
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;

--- a/lib/runtime/runtime_claude_code_cli.ml
+++ b/lib/runtime/runtime_claude_code_cli.ml
@@ -33,6 +33,12 @@ type rejection =
   { status : string
   ; reset_at : int option
   ; detail : string
+  ; model : string
+  ; num_turns : int
+  ; usage : usage
+  ; tool_calls : int
+  ; permission_mode : string
+  ; resumed : bool
   }
 
 type error =
@@ -52,7 +58,7 @@ let error_to_string = function
   | Spawn_failed detail -> "failed to start Claude Code CLI: " ^ detail
   | Protocol_error { stage; detail } ->
     Printf.sprintf "Claude Code CLI protocol error during %s: %s" stage detail
-  | Turn_rejected { status; reset_at; detail } ->
+  | Turn_rejected { status; reset_at; detail; _ } ->
     let reset =
       match reset_at with
       | None -> ""
@@ -423,13 +429,24 @@ let parse_output ~expected_model ~expected_cwd ~session_mode output =
         then Ok ()
         else protocol_error "init" "reported cwd differs from configured cwd"
       in
+      let rejected_turn ~status ~reset_at =
+        Turn_rejected
+          { status
+          ; reset_at
+          ; detail = terminal.result
+          ; model = init.model
+          ; num_turns = terminal.num_turns
+          ; usage = terminal.usage
+          ; tool_calls
+          ; permission_mode = init.permission_mode
+          ; resumed
+          }
+      in
       (match rejection, terminal.api_error_status with
        | Some (status, reset_at), _ ->
-         Error (Turn_rejected { status; reset_at; detail = terminal.result })
+         Error (rejected_turn ~status ~reset_at)
        | None, Some 429 ->
-         Error
-           (Turn_rejected
-              { status = "http_429"; reset_at = None; detail = terminal.result })
+         Error (rejected_turn ~status:"http_429" ~reset_at:None)
        | None, Some _ when not terminal.is_error ->
          protocol_error "result" "api_error_status requires is_error=true"
        | None, None

--- a/lib/runtime/runtime_claude_code_cli.mli
+++ b/lib/runtime/runtime_claude_code_cli.mli
@@ -40,6 +40,12 @@ type rejection =
   { status : string
   ; reset_at : int option
   ; detail : string
+  ; model : string
+  ; num_turns : int
+  ; usage : usage
+  ; tool_calls : int
+  ; permission_mode : string
+  ; resumed : bool
   }
 
 type error =

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -27,7 +27,7 @@ let cleanup_tree root =
   | _ -> ()
 ;;
 
-let fixture_script ~workspace =
+let fixture_script ~reject ~workspace =
   let path = Filename.temp_file "masc-claude-keeper-" ".sh" in
   let output = open_out_bin path in
   output_string output "#!/bin/sh\n";
@@ -44,8 +44,15 @@ let fixture_script ~workspace =
     "printf '%s\\n' \"{\\\"type\\\":\\\"system\\\",\\\"subtype\\\":\\\"init\\\",\\\"cwd\\\":\\\"$PWD\\\",\\\"session_id\\\":\\\"$session\\\",\\\"tools\\\":[\\\"Glob\\\",\\\"Grep\\\",\\\"Read\\\",\\\"WebFetch\\\",\\\"WebSearch\\\"],\\\"model\\\":\\\"claude-opus-5\\\",\\\"permissionMode\\\":\\\"plan\\\",\\\"apiKeySource\\\":\\\"none\\\"}\"\n";
   output_string output
     "printf '%s\\n' \"{\\\"type\\\":\\\"assistant\\\",\\\"message\\\":{\\\"model\\\":\\\"claude-opus-5\\\",\\\"role\\\":\\\"assistant\\\",\\\"content\\\":[{\\\"type\\\":\\\"tool_use\\\",\\\"id\\\":\\\"tool-1\\\",\\\"name\\\":\\\"Read\\\",\\\"input\\\":{}}]},\\\"session_id\\\":\\\"$session\\\"}\"\n";
-  output_string output
-    "printf '%s\\n' \"{\\\"type\\\":\\\"result\\\",\\\"subtype\\\":\\\"success\\\",\\\"is_error\\\":false,\\\"num_turns\\\":1,\\\"result\\\":\\\"$response\\\",\\\"session_id\\\":\\\"$session\\\",\\\"total_cost_usd\\\":0.0125,\\\"usage\\\":{\\\"input_tokens\\\":21,\\\"output_tokens\\\":4,\\\"cache_creation_input_tokens\\\":2,\\\"cache_read_input_tokens\\\":7},\\\"terminal_reason\\\":null,\\\"api_error_status\\\":null}\"\n";
+  if reject
+  then (
+    output_string output
+      "printf '%s\\n' \"{\\\"type\\\":\\\"rate_limit_event\\\",\\\"rate_limit_info\\\":{\\\"status\\\":\\\"rejected\\\",\\\"resetsAt\\\":1786356000,\\\"rateLimitType\\\":\\\"seven_day\\\"},\\\"session_id\\\":\\\"$session\\\"}\"\n";
+    output_string output
+      "printf '%s\\n' \"{\\\"type\\\":\\\"result\\\",\\\"subtype\\\":\\\"success\\\",\\\"is_error\\\":true,\\\"num_turns\\\":1,\\\"result\\\":\\\"subscription limit\\\",\\\"session_id\\\":\\\"$session\\\",\\\"total_cost_usd\\\":0.0,\\\"usage\\\":{\\\"input_tokens\\\":0,\\\"output_tokens\\\":0,\\\"cache_creation_input_tokens\\\":0,\\\"cache_read_input_tokens\\\":0},\\\"terminal_reason\\\":\\\"api_error\\\",\\\"api_error_status\\\":429}\"\n")
+  else
+    output_string output
+      "printf '%s\\n' \"{\\\"type\\\":\\\"result\\\",\\\"subtype\\\":\\\"success\\\",\\\"is_error\\\":false,\\\"num_turns\\\":1,\\\"result\\\":\\\"$response\\\",\\\"session_id\\\":\\\"$session\\\",\\\"total_cost_usd\\\":0.0125,\\\"usage\\\":{\\\"input_tokens\\\":21,\\\"output_tokens\\\":4,\\\"cache_creation_input_tokens\\\":2,\\\"cache_read_input_tokens\\\":7},\\\"terminal_reason\\\":null,\\\"api_error_status\\\":null}\"\n";
   close_out output;
   Unix.chmod path 0o700;
   path
@@ -83,7 +90,7 @@ let response_text (result : Runtime_agent.run_result) =
   |> String.concat ""
 ;;
 
-let run_turn ~base_path ~cli_path ~goal =
+let run_turn ?on_runtime_observation ~base_path ~cli_path ~goal () =
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
     ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
@@ -114,6 +121,7 @@ let run_turn ~base_path ~cli_path ~goal =
                            ~base_path
                            ~goal
                            ~initial_messages:[]
+                           ?on_runtime_observation
                            ~sw
                            ~net:(Eio.Stdenv.net env)
                            ()))))))
@@ -173,12 +181,12 @@ let test_session_store_roundtrip_and_duplicate_claim () =
 
 let test_keeper_start_resume_and_measured_observation () =
   let base_path = temp_workspace "masc-claude-keeper-" in
-  let cli_path = fixture_script ~workspace:base_path in
+  let cli_path = fixture_script ~reject:false ~workspace:base_path in
   Fun.protect
     ~finally:(fun () -> Sys.remove cli_path; cleanup_tree base_path)
     (fun () ->
        let first =
-         match run_turn ~base_path ~cli_path ~goal:"fixture start" with
+         match run_turn ~base_path ~cli_path ~goal:"fixture start" () with
          | Ok result -> result
          | Error error -> fail (Agent_sdk.Error.to_string error)
        in
@@ -223,7 +231,7 @@ let test_keeper_start_resume_and_measured_observation () =
             ; "cache_creation_input_tokens=2"
             ]);
        let resumed =
-         match run_turn ~base_path ~cli_path ~goal:"fixture resume" with
+         match run_turn ~base_path ~cli_path ~goal:"fixture resume" () with
          | Ok result -> result
          | Error error -> fail (Agent_sdk.Error.to_string error)
        in
@@ -234,6 +242,54 @@ let test_keeper_start_resume_and_measured_observation () =
        | Error detail -> fail detail
        | Ok None -> fail "resumed Claude Code session disappeared"
        | Ok (Some session) -> check int "stored turn count" 2 session.turn_count)
+;;
+
+let test_keeper_rejection_preserves_measurement_and_settles_session () =
+  let base_path = temp_workspace "masc-claude-rejected-" in
+  let cli_path = fixture_script ~reject:true ~workspace:base_path in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove cli_path; cleanup_tree base_path)
+    (fun () ->
+       let observed = ref None in
+       (match
+          run_turn
+            ~on_runtime_observation:(fun observation -> observed := Some observation)
+            ~base_path
+            ~cli_path
+            ~goal:"fixture rejected"
+            ()
+        with
+        | Error (Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _)) -> ()
+        | Error error -> fail (Agent_sdk.Error.to_string error)
+        | Ok _ -> fail "rate-limited Claude Code turn was accepted");
+       (match !observed with
+        | Some
+            { Runtime_observation.official_client =
+                Some
+                  { client = Claude_code
+                  ; execution_mode = Plan_read_only
+                  ; permission_mode = Some "plan"
+                  ; usage = Some usage
+                  ; _
+                  }
+            ; attempts = [ { error = Some "claude_code_rejected"; _ } ]
+            ; _
+            } ->
+          check int "rejected measured input" 0 usage.input_tokens;
+          check int "rejected measured output" 0 usage.output_tokens
+        | Some _ -> fail "rejected Claude Code evidence was misclassified"
+        | None -> fail "rejected Claude Code evidence was dropped");
+       match
+         Keeper_claude_code_session_store.load
+           ~base_path
+           ~keeper_name:"claude-fixture"
+       with
+       | Error detail -> fail detail
+       | Ok None -> fail "rejected Claude Code session disappeared"
+       | Ok (Some { phase = Settled _; turn_count; _ }) ->
+         check int "rejected session settled at first turn" 1 turn_count
+       | Ok (Some { phase = Claimed _; _ }) ->
+         fail "terminal rejection left the Claude Code session claimed")
 ;;
 
 let () =
@@ -248,6 +304,10 @@ let () =
             "start resume and measured observation"
             `Quick
             test_keeper_start_resume_and_measured_observation
+        ; test_case
+            "rejection measurement and settlement"
+            `Quick
+            test_keeper_rejection_preserves_measurement_and_settles_session
         ] )
     ]
 ;;

--- a/test/test_runtime_claude_code_cli.ml
+++ b/test/test_runtime_claude_code_cli.ml
@@ -128,8 +128,24 @@ let test_rate_limit_rejection_beats_success_subtype () =
   match parse ~cwd:"/tmp" output with
   | Error
       (Runtime_claude_code_cli.Turn_rejected
-         { status = "rejected"; reset_at = Some 1786356000; detail }) ->
-    check string "detail" "individual spend limit" detail
+         { status = "rejected"
+         ; reset_at = Some 1786356000
+         ; detail
+         ; model
+         ; num_turns
+         ; usage
+         ; tool_calls
+         ; permission_mode
+         ; resumed
+         }) ->
+    check string "detail" "individual spend limit" detail;
+    check string "measured model" "claude-opus-5" model;
+    check int "measured client turns" 1 num_turns;
+    check int "measured input" 20 usage.input_tokens;
+    check int "measured output" 4 usage.output_tokens;
+    check int "measured tool calls" 0 tool_calls;
+    check string "measured permission" "plan" permission_mode;
+    check bool "measured start" false resumed
   | Error error -> fail (Runtime_claude_code_cli.error_to_string error)
   | Ok _ -> fail "rate-limit result with subtype=success was accepted"
 ;;

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -892,7 +892,18 @@ let assert_production_keeper_result result =
   check bool "production measured observation" true
     (Option.is_some result.runtime_observation);
   check bool "official client does not fabricate OAS checkpoint" true
-    (Option.is_none result.checkpoint)
+    (Option.is_none result.checkpoint);
+  match
+    Runtime_observation.latest_official_client_snapshot ~runtime_id:"codex.codex"
+  with
+  | Some
+      { outcome = `Success
+      ; measurement = { client = Codex; execution_mode = App_server; _ }
+      ; _
+      } ->
+    ()
+  | Some _ -> fail "production receipt published a misclassified runtime snapshot"
+  | None -> fail "production receipt did not publish its official-client snapshot"
 ;;
 
 let test_production_keeper_dispatches_codex_runtime () =


### PR DESCRIPTION
## Summary
- record production Keeper runtime observations so the dashboard receives real official-client snapshots
- retain typed Claude Code terminal evidence on 429 rejection and settle the verified session before failover
- fix the Claude session JSON reader/writer contract and prove production receipt publication

## Verification
- full `dune build --root "$PWD" .`
- Claude Code CLI: 10/10
- Keeper Claude start/resume/rejection: 3/3
- production Keeper receipt to official-client snapshot: 1/1

## Stack
- base: Keeper hard-cut build PR
- follows dashboard observability #27746