### PR TITLE
feat(dashboard): operate Codex subscription sessions

### DIFF
--- a/dashboard/dev-fixtures/codex-session-recovery-fixture.html
+++ b/dashboard/dev-fixtures/codex-session-recovery-fixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex session recovery</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/demo/codex-session-recovery-fixture.ts"></script>
+  </body>
+</html>

--- a/dashboard/e2e/codex-session-recovery.mjs
+++ b/dashboard/e2e/codex-session-recovery.mjs
@@ -1,0 +1,104 @@
+import { chromium } from 'playwright'
+
+const fixtureUrl = process.env.CODEX_SESSION_RECOVERY_FIXTURE_URL
+if (!fixtureUrl) throw new Error('CODEX_SESSION_RECOVERY_FIXTURE_URL is required')
+
+const artifactDir = process.env.CODEX_SESSION_RECOVERY_ARTIFACT_DIR ?? '/tmp'
+const recoveryScreenshot = `${artifactDir}/codex-session-recovery-required.png`
+const resolvedScreenshot = `${artifactDir}/codex-session-recovery-resolved.png`
+const recoveryId = '018f3a4a-27f4-7c9a-8fd8-330c2a3845aa'
+let getRequests = 0
+let postedBody = null
+
+const recoveryPayload = {
+  schema: 'masc.dashboard.codex-session.v1',
+  ok: true,
+  keeper_name: 'sangsu',
+  session: {
+    runtime_id: 'codex.codex',
+    phase: {
+      kind: 'recovery_required',
+      recovery_id: recoveryId,
+      failure: 'protocol_failed',
+      detail: 'malformed app-server event after the durable claim',
+      required_at: 1786230000,
+      observed_thread_id: 'thread-observed',
+      observed_turn_id: null,
+      previous_settlement: null,
+    },
+    turn_count: 1,
+    tool_surface_sha256: 'a'.repeat(64),
+    last_recovery_resolution: null,
+    updated_at: 1786230000,
+  },
+}
+
+const resolvedPayload = {
+  ...recoveryPayload,
+  session: {
+    ...recoveryPayload.session,
+    phase: {
+      kind: 'settled',
+      thread_id: 'thread-verified',
+      turn_id: 'turn-verified',
+    },
+    last_recovery_resolution: {
+      recovery_id: recoveryId,
+      failure: 'protocol_failed',
+      resolution: {
+        kind: 'adopt_verified',
+        settlement: { thread_id: 'thread-verified', turn_id: 'turn-verified' },
+      },
+      resolved_by: 'dashboard',
+      resolved_at: 1786230060,
+    },
+    updated_at: 1786230060,
+  },
+}
+
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } })
+  await page.route('**/api/v1/dashboard/dev-token', route => route.fulfill({
+    json: { token: 'fixture-token', actor: 'dashboard', role: 'worker' },
+  }))
+  await page.route('**/api/v1/runtime/sessions/codex?**', route => {
+    getRequests += 1
+    return route.fulfill({ json: recoveryPayload })
+  })
+  await page.route('**/api/v1/runtime/sessions/codex/resolve', async route => {
+    postedBody = route.request().postDataJSON()
+    await route.fulfill({ json: resolvedPayload })
+  })
+
+  await page.goto(fixtureUrl)
+  await page.getByTestId('codex-session-phase').getByText('recovery_required', { exact: true }).waitFor()
+  const recovery = page.getByTestId('codex-session-recovery-required')
+  await recovery.getByText('protocol_failed', { exact: true }).waitFor()
+  await recovery.getByText('thread-observed', { exact: true }).waitFor()
+  await recovery.getByText(recoveryId, { exact: true }).waitFor()
+  if (getRequests !== 1) throw new Error(`expected one session GET, got ${getRequests}`)
+
+  await page.screenshot({ path: recoveryScreenshot, fullPage: true })
+  await page.getByTestId('codex-session-adopt-thread').fill('thread-verified')
+  await page.getByTestId('codex-session-adopt-turn').fill('turn-verified')
+  await page.getByTestId('codex-session-adopt-verified').click()
+  await page.getByTestId('codex-session-phase').getByText('settled', { exact: true }).waitFor()
+  await page.getByTestId('codex-session-last-resolution').getByText(/dashboard/).waitFor()
+
+  const expectedBody = {
+    keeper_name: 'sangsu',
+    recovery_id: recoveryId,
+    resolution: 'adopt_verified',
+    thread_id: 'thread-verified',
+    turn_id: 'turn-verified',
+  }
+  if (JSON.stringify(postedBody) !== JSON.stringify(expectedBody)) {
+    throw new Error(`unexpected recovery body: ${JSON.stringify(postedBody)}`)
+  }
+  await page.screenshot({ path: resolvedScreenshot, fullPage: true })
+  process.stdout.write(`codex_recovery_required_screenshot=${recoveryScreenshot}\n`)
+  process.stdout.write(`codex_recovery_resolved_screenshot=${resolvedScreenshot}\n`)
+} finally {
+  await browser.close()
+}

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1037,6 +1037,162 @@ export interface RuntimeTomlConfig {
   issues?: unknown
 }
 
+export type DashboardCodexRecoveryFailure =
+  | 'transport_interrupted'
+  | 'protocol_failed'
+  | 'provider_rejected'
+  | 'host_hook_failed'
+  | 'state_persistence_failed'
+
+export interface DashboardCodexSettlement {
+  thread_id: string
+  turn_id: string
+}
+
+export interface DashboardCodexSessionPhase {
+  kind: 'ready' | 'start' | 'active' | 'turn_inflight' | 'recovery_required' | 'settled'
+  thread_id?: string | null
+  turn_id?: string | null
+  previous_settlement?: DashboardCodexSettlement | null
+  recovery_id?: string | null
+  failure?: DashboardCodexRecoveryFailure | null
+  detail?: string | null
+  required_at?: number | null
+  observed_thread_id?: string | null
+  observed_turn_id?: string | null
+}
+
+export interface DashboardCodexRecoveryResolutionRecord {
+  recovery_id: string
+  failure: DashboardCodexRecoveryFailure
+  resolution: {
+    kind: 'retry_previous' | 'restart_fresh' | 'adopt_verified'
+    settlement?: DashboardCodexSettlement | null
+  }
+  resolved_by: string
+  resolved_at: number
+}
+
+export interface DashboardCodexSession {
+  runtime_id: string
+  phase: DashboardCodexSessionPhase
+  turn_count: number
+  tool_surface_sha256: string
+  last_recovery_resolution: DashboardCodexRecoveryResolutionRecord | null
+  updated_at: number
+}
+
+export interface DashboardCodexSessionResponse {
+  schema: 'masc.dashboard.codex-session.v1'
+  ok: true
+  keeper_name: string
+  session: DashboardCodexSession | null
+}
+
+export type DashboardCodexRecoveryDecision =
+  | { resolution: 'retry_previous' }
+  | { resolution: 'restart_fresh' }
+  | { resolution: 'adopt_verified'; thread_id: string; turn_id: string }
+
+const CODEX_RECOVERY_FAILURES = new Set<DashboardCodexRecoveryFailure>([
+  'transport_interrupted',
+  'protocol_failed',
+  'provider_rejected',
+  'host_hook_failed',
+  'state_persistence_failed',
+])
+
+function decodeCodexSettlement(raw: unknown): DashboardCodexSettlement | null {
+  if (!isRecord(raw)) return null
+  const thread_id = asString(raw.thread_id)
+  const turn_id = asString(raw.turn_id)
+  return thread_id && turn_id ? { thread_id, turn_id } : null
+}
+
+function decodeCodexFailure(raw: unknown): DashboardCodexRecoveryFailure | null {
+  return typeof raw === 'string' && CODEX_RECOVERY_FAILURES.has(raw as DashboardCodexRecoveryFailure)
+    ? raw as DashboardCodexRecoveryFailure
+    : null
+}
+
+function decodeCodexPhase(raw: unknown): DashboardCodexSessionPhase | null {
+  if (!isRecord(raw)) return null
+  const kind = asString(raw.kind)
+  if (!kind || !['ready', 'start', 'active', 'turn_inflight', 'recovery_required', 'settled'].includes(kind)) return null
+  const phase: DashboardCodexSessionPhase = {
+    kind: kind as DashboardCodexSessionPhase['kind'],
+    thread_id: asNullableString(raw.thread_id),
+    turn_id: asNullableString(raw.turn_id),
+    previous_settlement: raw.previous_settlement == null
+      ? null
+      : decodeCodexSettlement(raw.previous_settlement),
+    recovery_id: asNullableString(raw.recovery_id),
+    failure: raw.failure == null ? null : decodeCodexFailure(raw.failure),
+    detail: asNullableString(raw.detail),
+    required_at: asNumber(raw.required_at),
+    observed_thread_id: asNullableString(raw.observed_thread_id),
+    observed_turn_id: asNullableString(raw.observed_turn_id),
+  }
+  if (phase.kind === 'recovery_required' && (!phase.recovery_id || !phase.failure || phase.required_at == null)) return null
+  if (phase.kind === 'settled' && (!phase.thread_id || !phase.turn_id)) return null
+  return phase
+}
+
+function decodeCodexResolutionRecord(raw: unknown): DashboardCodexRecoveryResolutionRecord | null {
+  if (!isRecord(raw) || !isRecord(raw.resolution)) return null
+  const recovery_id = asString(raw.recovery_id)
+  const failure = decodeCodexFailure(raw.failure)
+  const resolved_by = asString(raw.resolved_by)
+  const resolved_at = asNumber(raw.resolved_at)
+  const kind = asString(raw.resolution.kind)
+  if (!recovery_id || !failure || !resolved_by || resolved_at == null) return null
+  if (kind !== 'retry_previous' && kind !== 'restart_fresh' && kind !== 'adopt_verified') return null
+  const settlement = raw.resolution.settlement == null
+    ? null
+    : decodeCodexSettlement(raw.resolution.settlement)
+  if (kind === 'adopt_verified' && !settlement) return null
+  return {
+    recovery_id,
+    failure,
+    resolution: { kind, settlement },
+    resolved_by,
+    resolved_at,
+  }
+}
+
+function decodeCodexSessionResponse(raw: unknown): DashboardCodexSessionResponse | null {
+  if (!isRecord(raw) || raw.schema !== 'masc.dashboard.codex-session.v1' || raw.ok !== true) return null
+  const keeper_name = asString(raw.keeper_name)
+  if (!keeper_name) return null
+  if (raw.session === null) {
+    return { schema: 'masc.dashboard.codex-session.v1', ok: true, keeper_name, session: null }
+  }
+  if (!isRecord(raw.session)) return null
+  const runtime_id = asString(raw.session.runtime_id)
+  const phase = decodeCodexPhase(raw.session.phase)
+  const turn_count = asNumber(raw.session.turn_count)
+  const tool_surface_sha256 = asString(raw.session.tool_surface_sha256)
+  const updated_at = asNumber(raw.session.updated_at)
+  const last_recovery_resolution = raw.session.last_recovery_resolution == null
+    ? null
+    : decodeCodexResolutionRecord(raw.session.last_recovery_resolution)
+  if (!runtime_id || !phase || turn_count == null || !Number.isInteger(turn_count) || turn_count < 0 || !tool_surface_sha256 || updated_at == null) return null
+  if (raw.session.last_recovery_resolution != null && !last_recovery_resolution) return null
+  return {
+    schema: 'masc.dashboard.codex-session.v1',
+    ok: true,
+    keeper_name,
+    session: {
+      runtime_id,
+      phase,
+      turn_count,
+      tool_surface_sha256,
+      last_recovery_resolution,
+      updated_at,
+    },
+  }
+}
+
 function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
   const record = isRecord(raw) ? raw : {}
   return {
@@ -1054,6 +1210,34 @@ function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
 export async function fetchRuntimeTomlConfig(): Promise<RuntimeTomlConfig> {
   await ensureDevToken()
   return get<unknown>('/api/v1/runtime/config/raw').then(normalizeRuntimeTomlConfig)
+}
+
+export async function fetchCodexSession(
+  keeperName: string,
+  opts?: AbortableRequestOptions,
+): Promise<DashboardCodexSessionResponse> {
+  await ensureDevToken()
+  const query = new URLSearchParams({ keeper_name: keeperName })
+  const raw = await get<unknown>(`/api/v1/runtime/sessions/codex?${query}`, { signal: opts?.signal })
+  const decoded = decodeCodexSessionResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 Codex session payload')
+  return decoded
+}
+
+export async function resolveCodexSession(
+  keeperName: string,
+  recoveryId: string,
+  decision: DashboardCodexRecoveryDecision,
+): Promise<DashboardCodexSessionResponse> {
+  await ensureDevToken()
+  const raw = await post<unknown>('/api/v1/runtime/sessions/codex/resolve', {
+    keeper_name: keeperName,
+    recovery_id: recoveryId,
+    ...decision,
+  })
+  const decoded = decodeCodexSessionResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 Codex recovery payload')
+  return decoded
 }
 
 // Structured, already-resolved runtime defaults / model routing (runtime.toml

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -39,6 +39,8 @@ import {
   fetchRuntimeTomlConfig,
   fetchRuntimeDefaults,
   fetchRuntimeModelMetrics,
+  fetchCodexSession,
+  resolveCodexSession,
   patchRuntimeAssignment,
   patchRuntimeMediaFailover,
   patchRuntimeRouting,
@@ -3016,6 +3018,93 @@ describe('runtime.toml raw config API', () => {
       runtime_id: null,
     })
     expect(result.source_text).toBe(sourceText)
+  })
+})
+
+describe('Codex official-client session API', () => {
+  const recoveryPayload = {
+    schema: 'masc.dashboard.codex-session.v1',
+    ok: true,
+    keeper_name: 'sangsu',
+    session: {
+      runtime_id: 'codex.codex',
+      phase: {
+        kind: 'recovery_required',
+        recovery_id: '018f3a4a-27f4-7c9a-8fd8-330c2a3845aa',
+        failure: 'protocol_failed',
+        detail: 'malformed app-server event',
+        required_at: 1_786_230_000,
+        observed_thread_id: 'thread-1',
+        observed_turn_id: null,
+        previous_settlement: null,
+      },
+      turn_count: 1,
+      tool_surface_sha256: 'a'.repeat(64),
+      last_recovery_resolution: null,
+      updated_at: 1_786_230_000,
+    },
+  }
+
+  it('reads exact measured recovery evidence for one Keeper', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(recoveryPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchCodexSession('sangsu')
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/runtime/sessions/codex?keeper_name=sangsu')
+    expect(result.session?.phase.kind).toBe('recovery_required')
+    expect(result.session?.phase.failure).toBe('protocol_failed')
+    expect(result.session?.phase.observed_thread_id).toBe('thread-1')
+  })
+
+  it('posts the recovery fence and verified adoption identities', async () => {
+    const settledPayload = {
+      ...recoveryPayload,
+      session: {
+        ...recoveryPayload.session,
+        phase: { kind: 'settled', thread_id: 'thread-verified', turn_id: 'turn-verified' },
+        last_recovery_resolution: {
+          recovery_id: recoveryPayload.session.phase.recovery_id,
+          failure: 'protocol_failed',
+          resolution: {
+            kind: 'adopt_verified',
+            settlement: { thread_id: 'thread-verified', turn_id: 'turn-verified' },
+          },
+          resolved_by: 'dashboard',
+          resolved_at: 1_786_230_010,
+        },
+      },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(settledPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await resolveCodexSession(
+      'sangsu',
+      recoveryPayload.session.phase.recovery_id,
+      { resolution: 'adopt_verified', thread_id: 'thread-verified', turn_id: 'turn-verified' },
+    )
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/runtime/sessions/codex/resolve')
+    expect(JSON.parse(init.body as string)).toEqual({
+      keeper_name: 'sangsu',
+      recovery_id: recoveryPayload.session.phase.recovery_id,
+      resolution: 'adopt_verified',
+      thread_id: 'thread-verified',
+      turn_id: 'turn-verified',
+    })
+    expect(result.session?.phase.kind).toBe('settled')
+    expect(result.session?.last_recovery_resolution?.resolved_by).toBe('dashboard')
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -178,6 +178,13 @@ export type {
   DashboardRuntimeModelMetricsResponse,
   RuntimeTomlConfig,
   RuntimeRoutingLane,
+  DashboardCodexRecoveryFailure,
+  DashboardCodexSettlement,
+  DashboardCodexSessionPhase,
+  DashboardCodexRecoveryResolutionRecord,
+  DashboardCodexSession,
+  DashboardCodexSessionResponse,
+  DashboardCodexRecoveryDecision,
 } from './dashboard-runtime'
 export {
   fetchRuntimeProviders,
@@ -189,6 +196,8 @@ export {
   patchRuntimeAssignment,
   patchRuntimeMediaFailover,
   patchRuntimeRouting,
+  fetchCodexSession,
+  resolveCodexSession,
 } from './dashboard-runtime'
 
 export type {

--- a/dashboard/src/components/codex-session-recovery-panel.test.ts
+++ b/dashboard/src/components/codex-session-recovery-panel.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { fireEvent, render, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { keepers } from '../store'
+import { CodexSessionRecoveryPanel } from './codex-session-recovery-panel'
+
+const apiMocks = vi.hoisted(() => ({
+  fetchCodexSession: vi.fn(),
+  resolveCodexSession: vi.fn(),
+}))
+
+vi.mock('../api/dashboard', () => apiMocks)
+
+const recoveryResponse = {
+  schema: 'masc.dashboard.codex-session.v1' as const,
+  ok: true as const,
+  keeper_name: 'sangsu',
+  session: {
+    runtime_id: 'codex.codex',
+    phase: {
+      kind: 'recovery_required' as const,
+      recovery_id: '018f3a4a-27f4-7c9a-8fd8-330c2a3845aa',
+      failure: 'protocol_failed' as const,
+      detail: 'malformed app-server event',
+      required_at: 1_786_230_000,
+      observed_thread_id: 'thread-observed',
+      observed_turn_id: null,
+      previous_settlement: null,
+    },
+    turn_count: 1,
+    tool_surface_sha256: 'a'.repeat(64),
+    last_recovery_resolution: null,
+    updated_at: 1_786_230_000,
+  },
+}
+
+const settledResponse = {
+  ...recoveryResponse,
+  session: {
+    ...recoveryResponse.session,
+    phase: {
+      kind: 'settled' as const,
+      thread_id: 'thread-verified',
+      turn_id: 'turn-verified',
+    },
+    last_recovery_resolution: {
+      recovery_id: recoveryResponse.session.phase.recovery_id,
+      failure: 'protocol_failed' as const,
+      resolution: { kind: 'adopt_verified' as const, settlement: { thread_id: 'thread-verified', turn_id: 'turn-verified' } },
+      resolved_by: 'dashboard',
+      resolved_at: 1_786_230_010,
+    },
+  },
+}
+
+describe('CodexSessionRecoveryPanel', () => {
+  beforeEach(() => {
+    keepers.value = [{ name: 'sangsu', status: 'idle', runtime_id: 'codex.codex' }]
+    apiMocks.fetchCodexSession.mockReset().mockResolvedValue(recoveryResponse)
+    apiMocks.resolveCodexSession.mockReset().mockResolvedValue(settledResponse)
+  })
+
+  afterEach(() => {
+    keepers.value = []
+  })
+
+  it('shows measured recovery evidence and resolves the exact recovery fence', async () => {
+    const view = render(html`<${CodexSessionRecoveryPanel} />`)
+
+    await waitFor(() => {
+      expect(view.getByTestId('codex-session-phase').textContent).toContain('recovery_required')
+    })
+    expect(view.getByTestId('codex-session-evidence').textContent).toContain('codex.codex')
+    expect(view.getByTestId('codex-session-recovery-required').textContent).toContain('protocol_failed')
+    expect(view.getByTestId('codex-session-recovery-required').textContent).toContain('thread-observed')
+
+    fireEvent.click(view.getByTestId('codex-session-restart-fresh'))
+
+    await waitFor(() => {
+      expect(apiMocks.resolveCodexSession).toHaveBeenCalledWith(
+        'sangsu',
+        recoveryResponse.session.phase.recovery_id,
+        { resolution: 'restart_fresh' },
+      )
+    })
+  })
+
+  it('requires both verified identities before adoption and shows the durable actor', async () => {
+    const view = render(html`<${CodexSessionRecoveryPanel} />`)
+
+    await waitFor(() => {
+      expect(view.getByTestId('codex-session-adopt-verified')).toBeTruthy()
+    })
+    const adoptButton = view.getByTestId('codex-session-adopt-verified') as HTMLButtonElement
+    expect(adoptButton.disabled).toBe(true)
+
+    fireEvent.input(view.getByTestId('codex-session-adopt-thread'), {
+      target: { value: 'thread-verified' },
+    })
+    fireEvent.input(view.getByTestId('codex-session-adopt-turn'), {
+      target: { value: 'turn-verified' },
+    })
+    expect(adoptButton.disabled).toBe(false)
+    fireEvent.click(adoptButton)
+
+    await waitFor(() => {
+      expect(apiMocks.resolveCodexSession).toHaveBeenCalledWith(
+        'sangsu',
+        recoveryResponse.session.phase.recovery_id,
+        {
+          resolution: 'adopt_verified',
+          thread_id: 'thread-verified',
+          turn_id: 'turn-verified',
+        },
+      )
+      expect(view.getByTestId('codex-session-last-resolution').textContent).toContain('dashboard')
+    })
+  })
+})

--- a/dashboard/src/components/codex-session-recovery-panel.ts
+++ b/dashboard/src/components/codex-session-recovery-panel.ts
@@ -1,0 +1,245 @@
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import {
+  fetchCodexSession,
+  resolveCodexSession,
+  type DashboardCodexRecoveryDecision,
+  type DashboardCodexSessionResponse,
+} from '../api/dashboard'
+import { keepers } from '../store'
+import { errorToString } from '../lib/format-string'
+import { ActionButton } from './common/button'
+import { SectionCard } from './common/card'
+import { EmptyState } from './common/feedback-state'
+import { TextInput } from './common/input'
+import { Select } from './common/select'
+import { StatusChip } from './common/status-chip'
+
+function phaseTone(kind: string): 'ok' | 'warn' | 'bad' | 'info' | 'neutral' {
+  if (kind === 'settled' || kind === 'ready') return 'ok'
+  if (kind === 'recovery_required') return 'bad'
+  if (kind === 'active' || kind === 'turn_inflight') return 'info'
+  if (kind === 'start') return 'warn'
+  return 'neutral'
+}
+
+function timestampText(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '—'
+  return new Date(value * 1_000).toLocaleString()
+}
+
+function compactHash(value: string): string {
+  return value.length > 18 ? `${value.slice(0, 10)}…${value.slice(-8)}` : value
+}
+
+export function CodexSessionRecoveryPanel() {
+  const selectedKeeper = useSignal('')
+  const response = useSignal<DashboardCodexSessionResponse | null>(null)
+  const loading = useSignal(false)
+  const resolving = useSignal(false)
+  const error = useSignal<string | null>(null)
+  const adoptThreadId = useSignal('')
+  const adoptTurnId = useSignal('')
+  const requestRevision = useSignal(0)
+
+  const codexKeepers = keepers.value
+    .filter(keeper => keeper.runtime_id?.startsWith('codex.') === true)
+    .map(keeper => keeper.name)
+    .filter((name, index, names) => names.indexOf(name) === index)
+    .sort((left, right) => left.localeCompare(right))
+  const keeperKey = codexKeepers.join('\u0000')
+
+  const load = async (keeperName: string) => {
+    if (!keeperName) {
+      response.value = null
+      return
+    }
+    const revision = requestRevision.value + 1
+    requestRevision.value = revision
+    loading.value = true
+    error.value = null
+    try {
+      const next = await fetchCodexSession(keeperName)
+      if (requestRevision.value === revision) response.value = next
+    } catch (cause) {
+      if (requestRevision.value === revision) error.value = errorToString(cause)
+    } finally {
+      if (requestRevision.value === revision) loading.value = false
+    }
+  }
+
+  useEffect(() => {
+    const next = codexKeepers.includes(selectedKeeper.value)
+      ? selectedKeeper.value
+      : (codexKeepers[0] ?? '')
+    selectedKeeper.value = next
+    void load(next)
+  }, [keeperKey])
+
+  const resolve = async (decision: DashboardCodexRecoveryDecision) => {
+    const keeperName = selectedKeeper.value
+    const recoveryId = response.value?.session?.phase.recovery_id
+    if (!keeperName || !recoveryId || resolving.value) return
+    resolving.value = true
+    error.value = null
+    try {
+      response.value = await resolveCodexSession(keeperName, recoveryId, decision)
+      adoptThreadId.value = ''
+      adoptTurnId.value = ''
+    } catch (cause) {
+      error.value = errorToString(cause)
+      await load(keeperName)
+    } finally {
+      resolving.value = false
+    }
+  }
+
+  const session = response.value?.session ?? null
+  const phase = session?.phase ?? null
+  const recoveryRequired = phase?.kind === 'recovery_required'
+  const lastResolution = session?.last_recovery_resolution ?? null
+  const canAdopt = adoptThreadId.value.trim() !== '' && adoptTurnId.value.trim() !== ''
+
+  return html`
+    <${SectionCard}
+      label="Codex 공식 클라이언트 세션"
+      status=${phase?.kind ?? (session ? 'unknown' : '')}
+      testId="codex-session-recovery-panel"
+    >
+      <div class="flex flex-wrap items-center gap-2 mb-3">
+        <${Select}
+          class="max-w-72"
+          ariaLabel="Codex Keeper 선택"
+          testId="codex-session-keeper"
+          value=${selectedKeeper.value}
+          disabled=${codexKeepers.length === 0 || loading.value || resolving.value}
+          placeholder="Codex Keeper 없음"
+          options=${codexKeepers}
+          onInput=${(keeperName: string) => {
+            selectedKeeper.value = keeperName
+            void load(keeperName)
+          }}
+        />
+        <${ActionButton}
+          variant="ghost"
+          size="sm"
+          testId="codex-session-refresh"
+          disabled=${!selectedKeeper.value || loading.value || resolving.value}
+          ariaBusy=${loading.value}
+          onClick=${() => void load(selectedKeeper.value)}
+        >새로고침<//>
+        ${phase
+          ? html`<${StatusChip} tone=${phaseTone(phase.kind)} uppercase=${false} testId="codex-session-phase">${phase.kind}<//>`
+          : null}
+      </div>
+
+      ${error.value
+        ? html`<div class="mb-3 rounded-[var(--r-1)] border border-[var(--danger-20)] bg-[var(--danger-10)] px-3 py-2 text-xs text-[var(--color-status-err)]" role="alert" data-testid="codex-session-error">${error.value}</div>`
+        : null}
+      ${loading.value && !session
+        ? html`<div class="text-xs text-[var(--color-fg-muted)]" role="status">Codex 세션 불러오는 중…</div>`
+        : null}
+      ${codexKeepers.length === 0
+        ? html`<${EmptyState} message="Codex runtime이 배정된 Keeper가 없습니다. runtime.toml 배정에서 먼저 선택하세요." compact />`
+        : null}
+      ${codexKeepers.length > 0 && !loading.value && !session
+        ? html`<${EmptyState} message="이 Keeper는 아직 공식 Codex 세션을 시작하지 않았습니다." compact />`
+        : null}
+
+      ${session && phase
+        ? html`
+          <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2 text-xs" data-testid="codex-session-evidence">
+            <div><span class="text-[var(--color-fg-muted)]">keeper</span> · <span class="mono">${response.value?.keeper_name}</span></div>
+            <div><span class="text-[var(--color-fg-muted)]">runtime</span> · <span class="mono">${session.runtime_id}</span></div>
+            <div><span class="text-[var(--color-fg-muted)]">completed turns</span> · ${session.turn_count}</div>
+            <div><span class="text-[var(--color-fg-muted)]">updated</span> · ${timestampText(session.updated_at)}</div>
+            <div title=${session.tool_surface_sha256}><span class="text-[var(--color-fg-muted)]">tool surface</span> · <span class="mono">${compactHash(session.tool_surface_sha256)}</span></div>
+            ${phase.thread_id ? html`<div><span class="text-[var(--color-fg-muted)]">thread</span> · <span class="mono">${phase.thread_id}</span></div>` : null}
+            ${phase.turn_id ? html`<div><span class="text-[var(--color-fg-muted)]">turn</span> · <span class="mono">${phase.turn_id}</span></div>` : null}
+          </div>
+          ${recoveryRequired
+            ? html`
+              <div class="mt-4 rounded-[var(--r-1)] border border-[var(--danger-20)] bg-[var(--danger-10)] p-3" data-testid="codex-session-recovery-required">
+                <div class="flex flex-wrap items-center gap-2 mb-2">
+                  <${StatusChip} tone="bad" uppercase=${false}>operator resolution required<//>
+                  <span class="mono text-2xs">${phase.recovery_id}</span>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs mb-3">
+                  <div>failure · <span class="mono">${phase.failure}</span></div>
+                  <div>required · ${timestampText(phase.required_at)}</div>
+                  <div>observed thread · <span class="mono">${phase.observed_thread_id ?? '—'}</span></div>
+                  <div>observed turn · <span class="mono">${phase.observed_turn_id ?? '—'}</span></div>
+                </div>
+                <div class="mb-3 whitespace-pre-wrap break-words text-xs text-[var(--color-fg-secondary)]">${phase.detail}</div>
+                <div class="flex flex-wrap gap-2 mb-3">
+                  <${ActionButton}
+                    variant="warn"
+                    size="sm"
+                    testId="codex-session-retry-previous"
+                    disabled=${resolving.value}
+                    ariaBusy=${resolving.value}
+                    onClick=${() => void resolve({ resolution: 'retry_previous' })}
+                  >이전 settlement에서 재시도<//>
+                  <${ActionButton}
+                    variant="danger"
+                    size="sm"
+                    testId="codex-session-restart-fresh"
+                    disabled=${resolving.value}
+                    ariaBusy=${resolving.value}
+                    onClick=${() => void resolve({ resolution: 'restart_fresh' })}
+                  >새 thread로 재시작<//>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-[1fr_1fr_auto] gap-2 items-end">
+                  <label class="grid gap-1 text-2xs text-[var(--color-fg-muted)]">
+                    검증된 thread ID
+                    <${TextInput}
+                      value=${adoptThreadId.value}
+                      ariaLabel="검증된 Codex thread ID"
+                      testId="codex-session-adopt-thread"
+                      disabled=${resolving.value}
+                      onInput=${(event: Event) => { adoptThreadId.value = (event.target as HTMLInputElement).value }}
+                    />
+                  </label>
+                  <label class="grid gap-1 text-2xs text-[var(--color-fg-muted)]">
+                    검증된 turn ID
+                    <${TextInput}
+                      value=${adoptTurnId.value}
+                      ariaLabel="검증된 Codex turn ID"
+                      testId="codex-session-adopt-turn"
+                      disabled=${resolving.value}
+                      onInput=${(event: Event) => { adoptTurnId.value = (event.target as HTMLInputElement).value }}
+                    />
+                  </label>
+                  <${ActionButton}
+                    variant="ok"
+                    size="sm"
+                    testId="codex-session-adopt-verified"
+                    disabled=${resolving.value || !canAdopt}
+                    ariaBusy=${resolving.value}
+                    onClick=${() => void resolve({
+                      resolution: 'adopt_verified',
+                      thread_id: adoptThreadId.value.trim(),
+                      turn_id: adoptTurnId.value.trim(),
+                    })}
+                  >검증 결과 채택<//>
+                </div>
+              </div>
+            `
+            : null}
+          ${lastResolution
+            ? html`
+              <div class="mt-3 border-t border-[var(--color-border-default)] pt-3 text-xs" data-testid="codex-session-last-resolution">
+                <span class="text-[var(--color-fg-muted)]">last resolution</span>
+                · <span class="mono">${lastResolution.resolution.kind}</span>
+                · ${lastResolution.resolved_by}
+                · ${timestampText(lastResolution.resolved_at)}
+                · <span class="mono">${lastResolution.failure}</span>
+              </div>
+            `
+            : null}
+        `
+        : null}
+    <//>
+  `
+}

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -16,6 +16,7 @@ import {
 } from '../lib/runtime-provider-summary'
 import {
   isRuntimeTomlNonMaterializableProtocol,
+  isRuntimeTomlOfficialClientProtocol,
   isReservedRuntimeTomlId,
   isValidRuntimeTomlIdFormat,
   parseRuntimeTomlEnvironment,
@@ -46,19 +47,18 @@ export type RuntimeProviderTransportEditableField = 'endpoint' | 'command'
 // ...) are deliberately excluded — those are semantically coupled to real,
 // per-model verified behavior (see runtime.toml's own inline caveats), not
 // something a generic add form can default safely. They stay raw-TOML-only.
-// transportKind is fixed to 'endpoint': CLI (`command`) transport providers
-// resolve to no provider_kind on the backend today and get silently dropped
-// from the live runtime list rather than failing the save (see
-// RUNTIME_TOML_CREATABLE_PROTOCOLS in lib/runtime-toml-config.ts). Until that
-// backend limitation is lifted, this form cannot offer command transport.
+// Generic providers use endpoint transport. A typed official-client protocol
+// may require command transport; that exception is selected by protocol and
+// never exposed as a free-form transport switch.
 export interface NewRuntimeProviderInput {
   id: string
   displayName: string
   protocol: RuntimeTomlProtocol
-  transportKind: 'endpoint'
+  transportKind: 'endpoint' | 'command'
   transportValue: string
   credentialType: RuntimeTomlCredentialType
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 export interface NewRuntimeModelInput {
@@ -127,10 +127,11 @@ interface NewProviderDraft {
   id: string
   displayName: string
   protocol: RuntimeTomlProtocol
-  transportKind: 'endpoint'
+  transportKind: 'endpoint' | 'command'
   transportValue: string
   credentialType: RuntimeTomlCredentialType
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 const DEFAULT_NEW_PROVIDER: NewProviderDraft = {
@@ -141,6 +142,7 @@ const DEFAULT_NEW_PROVIDER: NewProviderDraft = {
   transportValue: '',
   credentialType: 'env',
   credentialValue: '',
+  isNonInteractive: false,
 }
 
 // jsonSupport as a 3-way string enum (not boolean|null) because <select> values
@@ -376,7 +378,12 @@ export function RuntimeEnvironmentEditor({
     }
     const transportValue = newProvider.transportValue.trim()
     if (transportValue === '') {
-      setProviderFormError('endpoint를 입력하세요')
+      setProviderFormError(`${newProvider.transportKind}를 입력하세요`)
+      return
+    }
+    const officialClient = isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
+    if (officialClient && (newProvider.transportKind !== 'command' || newProvider.credentialType !== 'none' || !newProvider.isNonInteractive)) {
+      setProviderFormError('공식 구독 클라이언트는 command + credential 없음 + non-interactive=true가 필요합니다')
       return
     }
     const trimmedCredentialValue = newProvider.credentialValue.trim()
@@ -454,13 +461,11 @@ export function RuntimeEnvironmentEditor({
       setBindingFormError(`"${bindingProviderId}"는 예약된 이름이라 바인딩 provider로 쓸 수 없습니다`)
       return
     }
-    // A `command` transport provider always resolves to no provider_kind on the
-    // backend, so materialize_config's filter_map silently drops any binding
-    // pinned to it from the live runtime list. The add-provider form can no
-    // longer create one, but this dropdown lists every parsed provider,
-    // including a `command` one that already exists via raw TOML / legacy config.
+    // Generic command transports are not materializable. Official-client
+    // protocols are the typed exception: their backend runtime owns the CLI
+    // process and does not impersonate an OAS HTTP provider.
     const selectedProvider = environment.providers.find(p => p.id === bindingProviderId)
-    if (selectedProvider?.transportKind === 'command') {
+    if (selectedProvider?.transportKind === 'command' && !isRuntimeTomlOfficialClientProtocol(selectedProvider.protocol)) {
       setBindingFormError(
         `"${bindingProviderId}"는 command(CLI) transport라 바인딩을 생성할 수 없습니다 (백엔드가 아직 CLI provider를 라우팅하지 못합니다)`,
       )
@@ -641,12 +646,14 @@ export function RuntimeEnvironmentEditor({
           ` : null}
           ${environment.providers.map(provider => {
             const providerTransportField = transportField(provider)
+            const officialClient = isRuntimeTomlOfficialClientProtocol(provider.protocol)
             return html`
             <div key=${provider.id} class="rt-card" data-testid=${`runtime-provider-${provider.id}`}>
               <div class="rt-card-h">
                 <span class="rt-card-id mono">${provider.id}</span>
                 <span class="rt-card-name">${provider.displayName}</span>
                 <span class="rt-proto mono">${provider.protocol || '—'}</span>
+                ${officialClient ? html`<span class="rt-assign-tag pin mono">구독 CLI</span>` : null}
                 <button
                   type="button"
                   class="rt-delete-provider"
@@ -699,6 +706,15 @@ export function RuntimeEnvironmentEditor({
                   </span>
                   `}
               </div>
+              ${officialClient ? html`
+                <div class="rt-field" data-testid=${`runtime-provider-${provider.id}-subscription-boundary`}>
+                  <span class="sub-k">execution</span>
+                  <span class="mono">official client · ${provider.isNonInteractive ? 'non-interactive' : '설정 오류: interactive'}</span>
+                </div>
+                ${provider.credentialType !== 'none' ? html`
+                  <div class="rt-warn" role="alert">공식 구독 클라이언트에는 API credential을 선언할 수 없습니다.</div>
+                ` : null}
+              ` : null}
               ${/* Provider capability chips (mcp-tools/tool-events/mcp-http-headers)
                    had no live source and rendered as if confirmed. Removed until a
                    provider-capability source exists, rather than implying support
@@ -747,29 +763,45 @@ export function RuntimeEnvironmentEditor({
                     value=${newProvider.protocol}
                     disabled=${isDisabled}
                     aria-label="새 provider protocol"
-                    onChange=${(event: Event) => setNewProvider({ ...newProvider, protocol: (event.currentTarget as HTMLSelectElement).value as RuntimeTomlProtocol })}
+                    onChange=${(event: Event) => {
+                      const protocol = (event.currentTarget as HTMLSelectElement).value as RuntimeTomlProtocol
+                      const officialClient = isRuntimeTomlOfficialClientProtocol(protocol)
+                      setNewProvider({
+                        ...newProvider,
+                        protocol,
+                        transportKind: officialClient ? 'command' : 'endpoint',
+                        transportValue: '',
+                        credentialType: officialClient ? 'none' : 'env',
+                        credentialValue: '',
+                        isNonInteractive: officialClient,
+                      })
+                    }}
                   >
                     ${RUNTIME_TOML_CREATABLE_PROTOCOLS.map(p => html`<option value=${p}>${p}</option>`)}
                   </select>
                 </div>
                 <div class="rt-field">
-                  <span class="sub-k">endpoint</span>
+                  <span class="sub-k">${newProvider.transportKind}</span>
                   <input
                     class="rt-input mono"
                     value=${newProvider.transportValue}
-                    placeholder="https://..."
+                    placeholder=${newProvider.transportKind === 'command' ? '/absolute/path/to/codex' : 'https://...'}
                     disabled=${isDisabled}
                     aria-label="새 provider transport 값"
                     onInput=${(event: Event) => setNewProvider({ ...newProvider, transportValue: (event.currentTarget as HTMLInputElement).value })}
                   />
                 </div>
-                <div class="rt-note">CLI(command) provider는 현재 백엔드에서 라우팅되지 않아 이 폼에서 생성할 수 없습니다. raw TOML 탭을 이용하세요.</div>
+                <div class="rt-note">
+                  ${isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
+                    ? '공식 클라이언트의 기존 구독 로그인을 사용합니다. API key는 저장하지 않으며 non-interactive 실행을 강제합니다.'
+                    : '일반 provider는 endpoint transport를 사용합니다.'}
+                </div>
                 <div class="rt-field">
                   <span class="sub-k">credential</span>
                   <select
                     class="rt-select rt-select-narrow"
                     value=${newProvider.credentialType}
-                    disabled=${isDisabled}
+                    disabled=${isDisabled || isRuntimeTomlOfficialClientProtocol(newProvider.protocol)}
                     aria-label="새 provider credential 종류"
                     onChange=${(event: Event) => setNewProvider({ ...newProvider, credentialType: (event.currentTarget as HTMLSelectElement).value as RuntimeTomlCredentialType })}
                   >

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -34,6 +34,7 @@ import {
   runtimeCatalogRequestConfig as runtimeRequestConfigText,
   runtimeCatalogSnapshotFacts as runtimeSnapshotFactsText,
 } from '../lib/runtime-provider-summary'
+import { CodexSessionRecoveryPanel } from './codex-session-recovery-panel'
 
 /**
  * Filters model metrics by case-insensitive substring match against
@@ -977,6 +978,8 @@ export function RuntimeMonitor() {
             : html`<${EmptyState} message="runtime snapshot이 없습니다." compact />`}
         </div>
       <//>
+
+      <${CodexSessionRecoveryPanel} />
 
       <${SectionCard} label="런타임 메트릭">
         <div class="grid grid-cols-3 gap-3 mb-4">

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -870,7 +870,7 @@ describe('RuntimeTomlEditor', () => {
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
   })
 
-  it('does not offer messages protocols or command transport in the add-provider form', async () => {
+  it('offers only materializable HTTP protocols plus the typed Codex official client', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)
 
@@ -883,11 +883,67 @@ describe('RuntimeTomlEditor', () => {
     const protocolOptions = Array.from(
       container.querySelectorAll('[aria-label="새 provider protocol"] option'),
     ).map(option => (option as HTMLOptionElement).value)
-    expect(protocolOptions).toEqual(['openai-compatible-http', 'ollama-http', 'openai-compatible-cli'])
+    expect(protocolOptions).toEqual([
+      'openai-compatible-http',
+      'ollama-http',
+      'openai-compatible-cli',
+      'codex-app-server',
+    ])
     expect(protocolOptions).not.toContain('messages-http')
     expect(protocolOptions).not.toContain('messages-cli')
     // No transport-kind selector left to switch to 'command'.
     expect(container.querySelector('[aria-label="새 provider transport 종류"]')).toBeNull()
+  })
+
+  it('creates a Codex subscription provider and binding with the enforced no-key boundary', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-providers"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-providers"]') as HTMLButtonElement)
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-toggle"]') as HTMLButtonElement)
+    fireEvent.input(container.querySelector('[data-testid="runtime-add-provider-id"]') as HTMLInputElement, {
+      target: { value: 'codex_subscription' },
+    })
+    fireEvent.change(container.querySelector('[aria-label="새 provider protocol"]') as HTMLSelectElement, {
+      target: { value: 'codex-app-server' },
+    })
+
+    const credentialType = container.querySelector('[aria-label="새 provider credential 종류"]') as HTMLSelectElement
+    expect(credentialType.value).toBe('none')
+    expect(credentialType.disabled).toBe(true)
+    expect(container.querySelector('[aria-label="새 provider credential 값"]')).toBeNull()
+
+    fireEvent.input(container.querySelector('[aria-label="새 provider transport 값"]') as HTMLInputElement, {
+      target: { value: '/Users/dancer/.local/bin/codex' },
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('[providers.codex_subscription]')
+      expect(source).toContain('protocol = "codex-app-server"')
+      expect(source).toContain('command = "/Users/dancer/.local/bin/codex"')
+      expect(source).toContain('is-non-interactive = true')
+      expect(source).not.toContain('[providers.codex_subscription.credentials]')
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-bindings"]') as HTMLButtonElement)
+    fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-provider"]') as HTMLSelectElement, {
+      target: { value: 'codex_subscription' },
+    })
+    fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-model"]') as HTMLSelectElement, {
+      target: { value: 'qwen' },
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-binding-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('[codex_subscription.qwen]')
+      expect(container.querySelector('[data-testid="runtime-add-binding-error"]')).toBeNull()
+    })
   })
 
   it('adds a new model through the form', async () => {

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -310,6 +310,9 @@ export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps =
       let next = setRuntimeTomlProviderField(current, input.id, 'display-name', input.displayName || input.id)
       next = setRuntimeTomlProviderField(next, input.id, 'protocol', input.protocol)
       next = setRuntimeTomlProviderField(next, input.id, input.transportKind, input.transportValue)
+      if (input.isNonInteractive) {
+        next = setRuntimeTomlProviderField(next, input.id, 'is-non-interactive', true)
+      }
       if (input.credentialType !== 'none' && input.credentialValue.trim() !== '') {
         next = setRuntimeTomlProviderCredential(next, input.id, input.credentialType, input.credentialValue)
       }

--- a/dashboard/src/demo/codex-session-recovery-fixture.ts
+++ b/dashboard/src/demo/codex-session-recovery-fixture.ts
@@ -1,0 +1,35 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { CodexSessionRecoveryPanel } from '../components/codex-session-recovery-panel'
+import { keepers } from '../store'
+
+keepers.value = [
+  { name: 'sangsu', status: 'idle', runtime_id: 'codex.codex' },
+]
+
+function CodexSessionRecoveryFixture() {
+  return html`
+    <main class="min-h-screen px-5 py-6" style="background: var(--color-bg-page);">
+      <section class="mx-auto max-w-[1180px]">
+        <header class="mb-5">
+          <div class="text-2xs uppercase tracking-[0.16em] text-[var(--color-accent-fg)]">
+            MASC Runtime Control
+          </div>
+          <h1 class="mt-1 text-xl font-semibold text-[var(--color-fg-primary)]">
+            Codex 공식 세션 복구
+          </h1>
+          <p class="mt-1 text-xs text-[var(--color-fg-muted)]">
+            실제 claim phase와 recovery fence를 확인한 뒤 명시적으로 해소합니다.
+          </p>
+        </header>
+        <${CodexSessionRecoveryPanel} />
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) render(html`<${CodexSessionRecoveryFixture} />`, root)

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -74,6 +74,33 @@ describe('runtime TOML dashboard editing helpers', () => {
     })
   })
 
+  it('projects the Codex official-client subscription boundary without credentials', () => {
+    const codexSource = `[runtime]
+default = "codex_subscription.spark"
+
+[providers.codex_subscription]
+display-name = "Codex Subscription"
+protocol = "codex-app-server"
+command = "/usr/local/bin/codex"
+is-non-interactive = true
+
+[models.spark]
+api-name = "gpt-5.3-codex-spark"
+max-context = 131072
+
+[codex_subscription.spark]
+`
+
+    const environment = parseRuntimeTomlEnvironment(codexSource)
+    expect(environment.providers[0]).toMatchObject({
+      protocol: 'codex-app-server',
+      transportKind: 'command',
+      command: '/usr/local/bin/codex',
+      credentialType: 'none',
+      isNonInteractive: true,
+    })
+  })
+
   it('projects runtime routing lanes and keeper assignments from runtime.toml source', () => {
     const withRouting = `${sourceText.replace(
       'default = "runpod_mtp.qwen"',

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -12,6 +12,7 @@ export interface RuntimeTomlProvider {
   credentialKey: string
   credentialPath: string
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 export interface RuntimeTomlModel {
@@ -289,6 +290,7 @@ function providerFromDocument(document: TomlDocument, id: string): RuntimeTomlPr
     credentialKey: asString(credentials.key),
     credentialPath: asString(credentials.path),
     credentialValue: asString(credentials.value),
+    isNonInteractive: asBoolean(values['is-non-interactive']),
   }
 }
 
@@ -639,8 +641,8 @@ export function setRuntimeTomlDefault(sourceText: string, runtimeId: string): st
 export function setRuntimeTomlProviderField(
   sourceText: string,
   providerId: string,
-  field: 'display-name' | 'protocol' | 'endpoint' | 'command',
-  value: string,
+  field: 'display-name' | 'protocol' | 'endpoint' | 'command' | 'is-non-interactive',
+  value: string | boolean,
 ): string {
   const section = `providers.${providerId}`
   if (field === 'endpoint') {
@@ -722,14 +724,16 @@ export const RUNTIME_TOML_PROTOCOLS = [
   'openai-compatible-cli',
   'messages-http',
   'messages-cli',
+  'codex-app-server',
 ] as const
 
 export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
 
 // Subset of RUNTIME_TOML_PROTOCOLS the add-provider form is allowed to offer.
-// The add-provider form only creates endpoint-backed providers. Command
-// transport is blocked at the binding form via transportKind, while
-// `provider_kind_for_http_provider` still returns `None` for `Messages_api`.
+// HTTP protocols create endpoint-backed providers. A typed official-client
+// protocol creates the command-backed runtime its backend adapter owns, while
+// generic command providers remain blocked. `provider_kind_for_http_provider`
+// still returns `None` for `Messages_api`.
 // Messages providers parse and save, but resolve to no provider_kind and
 // `Runtime.materialize_config`'s `List.filter_map` silently drops their bindings
 // from the live runtime list instead of failing the save
@@ -740,12 +744,17 @@ export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
   'openai-compatible-http',
   'ollama-http',
   'openai-compatible-cli',
+  'codex-app-server',
 ] as const
 
 export type RuntimeTomlCreatableProtocol = (typeof RUNTIME_TOML_CREATABLE_PROTOCOLS)[number]
 
 export function isRuntimeTomlCreatableProtocol(protocol: string): protocol is RuntimeTomlCreatableProtocol {
   return (RUNTIME_TOML_CREATABLE_PROTOCOLS as readonly string[]).includes(protocol)
+}
+
+export function isRuntimeTomlOfficialClientProtocol(protocol: string): boolean {
+  return protocol === 'codex-app-server'
 }
 
 const RUNTIME_TOML_NON_MATERIALIZABLE_PROTOCOLS = new Set([

--- a/lib/server/server_dashboard_codex_session.ml
+++ b/lib/server/server_dashboard_codex_session.ml
@@ -1,0 +1,271 @@
+type error_kind =
+  | Bad_request
+  | Conflict
+  | Service_unavailable
+
+type error =
+  { kind : error_kind
+  ; code : string
+  ; message : string
+  }
+
+let ( let* ) = Result.bind
+let schema = "masc.dashboard.codex-session.v1"
+
+let error kind code message = Error { kind; code; message }
+
+let failure_to_string = function
+  | Keeper_codex_session_store.Transport_interrupted -> "transport_interrupted"
+  | Protocol_failed -> "protocol_failed"
+  | Provider_rejected -> "provider_rejected"
+  | Host_hook_failed -> "host_hook_failed"
+  | State_persistence_failed -> "state_persistence_failed"
+;;
+
+let settlement_json (settlement : Keeper_codex_session_store.settlement) =
+  `Assoc
+    [ "thread_id", `String settlement.thread_id
+    ; "turn_id", `String settlement.turn_id
+    ]
+;;
+
+let settlement_opt_json = function
+  | None -> `Null
+  | Some settlement -> settlement_json settlement
+;;
+
+let string_opt_json = function
+  | None -> `Null
+  | Some value -> `String value
+;;
+
+let resolution_json = function
+  | Keeper_codex_session_store.Retry_previous ->
+    `Assoc [ "kind", `String "retry_previous" ]
+  | Restart_fresh -> `Assoc [ "kind", `String "restart_fresh" ]
+  | Adopt_verified settlement ->
+    `Assoc
+      [ "kind", `String "adopt_verified"
+      ; "settlement", settlement_json settlement
+      ]
+;;
+
+let resolution_record_json
+    (record : Keeper_codex_session_store.recovery_resolution_record) =
+  `Assoc
+    [ "failure", `String (failure_to_string record.failure)
+    ; "recovery_id", `String record.recovery_id
+    ; "resolution", resolution_json record.resolution
+    ; "resolved_at", `Float record.resolved_at
+    ; "resolved_by", `String record.resolved_by
+    ]
+;;
+
+let phase_json = function
+  | Keeper_codex_session_store.Ready -> `Assoc [ "kind", `String "ready" ]
+  | Start { previous_settlement } ->
+    `Assoc
+      [ "kind", `String "start"
+      ; "previous_settlement", settlement_opt_json previous_settlement
+      ]
+  | Active { thread_id; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "active"
+      ; "thread_id", `String thread_id
+      ; "previous_settlement", settlement_opt_json previous_settlement
+      ]
+  | Turn_inflight { thread_id; turn_id; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "turn_inflight"
+      ; "thread_id", `String thread_id
+      ; "turn_id", string_opt_json turn_id
+      ; "previous_settlement", settlement_opt_json previous_settlement
+      ]
+  | Recovery_required recovery ->
+    `Assoc
+      [ "kind", `String "recovery_required"
+      ; "recovery_id", `String recovery.recovery_id
+      ; "failure", `String (failure_to_string recovery.failure)
+      ; "detail", `String recovery.detail
+      ; "required_at", `Float recovery.required_at
+      ; "observed_thread_id", string_opt_json recovery.observed_thread_id
+      ; "observed_turn_id", string_opt_json recovery.observed_turn_id
+      ; ( "previous_settlement"
+        , settlement_opt_json recovery.previous_settlement )
+      ]
+  | Settled settlement ->
+    `Assoc
+      [ "kind", `String "settled"
+      ; "thread_id", `String settlement.thread_id
+      ; "turn_id", `String settlement.turn_id
+      ]
+;;
+
+let binding_json (binding : Keeper_codex_session_store.t) =
+  `Assoc
+    [ "runtime_id", `String binding.runtime_id
+    ; "phase", phase_json binding.phase
+    ; "turn_count", `Int binding.turn_count
+    ; "tool_surface_sha256", `String binding.tool_surface_sha256
+    ; ( "last_recovery_resolution"
+      , Option.fold
+          ~none:`Null
+          ~some:resolution_record_json
+          binding.last_recovery_resolution )
+    ; "updated_at", `Float binding.updated_at
+    ]
+;;
+
+let response_json ~keeper_name session =
+  `Assoc
+    [ "schema", `String schema
+    ; "ok", `Bool true
+    ; "keeper_name", `String keeper_name
+    ; "session", Option.fold ~none:`Null ~some:binding_json session
+    ]
+;;
+
+let validate_keeper_name keeper_name =
+  let keeper_name = String.trim keeper_name in
+  if keeper_name = ""
+  then error Bad_request "keeper_name_required" "keeper_name is required"
+  else if not (Keeper_config.validate_name keeper_name)
+  then
+    error
+      Bad_request
+      "keeper_name_invalid"
+      (Printf.sprintf "invalid keeper_name %S" keeper_name)
+  else Ok keeper_name
+;;
+
+let load ~base_path ~keeper_name =
+  match Keeper_codex_session_store.load ~base_path ~keeper_name with
+  | Ok session -> Ok session
+  | Error message ->
+    error
+      Service_unavailable
+      "codex_session_load_failed"
+      message
+;;
+
+let snapshot ~base_path ~keeper_name =
+  let* keeper_name = validate_keeper_name keeper_name in
+  let* session = load ~base_path ~keeper_name in
+  Ok (response_json ~keeper_name session)
+;;
+
+type request =
+  { keeper_name : string
+  ; recovery_id : string
+  ; resolution : Keeper_codex_session_store.recovery_resolution
+  }
+
+let non_empty field value =
+  let value = String.trim value in
+  if value = ""
+  then error Bad_request (field ^ "_required") (field ^ " is required")
+  else Ok value
+;;
+
+let parse_body body =
+  let* json =
+    try Ok (Yojson.Safe.from_string body) with
+    | Yojson.Json_error message ->
+      error Bad_request "invalid_json" ("invalid JSON: " ^ message)
+  in
+  match json with
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "keeper_name", `String keeper_name
+       ; "recovery_id", `String recovery_id
+       ; "resolution", `String ("retry_previous" as resolution) ]
+     | [ "keeper_name", `String keeper_name
+       ; "recovery_id", `String recovery_id
+       ; "resolution", `String ("restart_fresh" as resolution) ] ->
+       let* keeper_name = validate_keeper_name keeper_name in
+       let* recovery_id = non_empty "recovery_id" recovery_id in
+       let resolution =
+         if String.equal resolution "retry_previous"
+         then Keeper_codex_session_store.Retry_previous
+         else Restart_fresh
+       in
+       Ok { keeper_name; recovery_id; resolution }
+     | [ "keeper_name", `String keeper_name
+       ; "recovery_id", `String recovery_id
+       ; "resolution", `String "adopt_verified"
+       ; "thread_id", `String thread_id; "turn_id", `String turn_id ] ->
+       let* keeper_name = validate_keeper_name keeper_name in
+       let* recovery_id = non_empty "recovery_id" recovery_id in
+       let* thread_id = non_empty "thread_id" thread_id in
+       let* turn_id = non_empty "turn_id" turn_id in
+       Ok
+         { keeper_name
+         ; recovery_id
+         ; resolution =
+             Keeper_codex_session_store.Adopt_verified
+               { thread_id; turn_id }
+         }
+     | _ ->
+       error
+         Bad_request
+         "request_fields_invalid"
+         "expected exact keeper_name, recovery_id, resolution fields; adopt_verified also requires thread_id and turn_id")
+  | _ -> error Bad_request "request_not_object" "request body must be a JSON object"
+;;
+
+let conflict code message = error Conflict code message
+
+let resolve_body ~base_path ~actor ~body =
+  let* request = parse_body body in
+  let* actor = non_empty "actor" actor in
+  let* current = load ~base_path ~keeper_name:request.keeper_name in
+  let* current =
+    match current with
+    | None ->
+      conflict
+        "codex_session_missing"
+        "Keeper has no durable Codex session"
+    | Some current -> Ok current
+  in
+  let* () =
+    match current.phase with
+    | Keeper_codex_session_store.Recovery_required recovery
+      when String.equal recovery.recovery_id request.recovery_id ->
+      Ok ()
+    | Recovery_required _ ->
+      conflict
+        "recovery_id_changed"
+        "Codex recovery identity changed before resolution"
+    | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+      conflict
+        "recovery_not_required"
+        "Codex session is not awaiting recovery"
+  in
+  match
+    Keeper_codex_session_store.resolve_recovery
+      ~base_path
+      ~keeper_name:request.keeper_name
+      ~expected:current
+      ~recovery_id:request.recovery_id
+      ~resolution:request.resolution
+      ~resolved_by:actor
+      ~resolved_at:(Time_compat.now ())
+  with
+  | Ok resolved ->
+    Ok (response_json ~keeper_name:request.keeper_name (Some resolved))
+  | Error message ->
+    (match load ~base_path ~keeper_name:request.keeper_name with
+     | Ok (Some observed) when observed <> current ->
+       conflict
+         "codex_session_changed"
+         "Codex session changed before recovery resolution"
+     | Ok None ->
+       conflict
+         "codex_session_disappeared"
+         "Codex session disappeared before recovery resolution"
+     | Ok (Some _) | Error _ ->
+       error
+         Service_unavailable
+         "codex_session_resolution_failed"
+         message)
+;;

--- a/lib/server/server_dashboard_codex_session.mli
+++ b/lib/server/server_dashboard_codex_session.mli
@@ -1,0 +1,24 @@
+(** Authenticated dashboard projection and operator resolution for the durable
+    per-Keeper Codex official-client session owner. *)
+
+type error_kind =
+  | Bad_request
+  | Conflict
+  | Service_unavailable
+
+type error =
+  { kind : error_kind
+  ; code : string
+  ; message : string
+  }
+
+val snapshot :
+  base_path:string ->
+  keeper_name:string ->
+  (Yojson.Safe.t, error) result
+
+val resolve_body :
+  base_path:string ->
+  actor:string ->
+  body:string ->
+  (Yojson.Safe.t, error) result

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -14,6 +14,7 @@ include Server_routes_http_routes_dashboard_setup
 module Keeper_chat_pending = Server_dashboard_http_keeper_chat_pending
 module Keeper_event_queue_operator =
   Server_dashboard_http_keeper_event_queue_operator
+module Codex_session = Server_dashboard_codex_session
 
 let config_cache_ttl_s = Server_dashboard_http_core_cache.config_cache_ttl_s
 let standard_cache_ttl_s = Server_dashboard_http_core_cache.standard_cache_ttl_s
@@ -44,6 +45,26 @@ let respond_dashboard_ok ?request reqd =
   Http.Response.json_value ?request ~compress:true
     (`Assoc [ ("ok", `Bool true) ])
     reqd
+
+let respond_codex_session_result request reqd = function
+  | Ok json -> Http.Response.json_value ~compress:true ~request json reqd
+  | Error ({ Codex_session.kind; code; message } : Codex_session.error) ->
+    let status =
+      match kind with
+      | Bad_request -> `Bad_request
+      | Conflict -> `Conflict
+      | Service_unavailable -> `Service_unavailable
+    in
+    Http.Response.json_value
+      ~status
+      ~request
+      (`Assoc
+        [ "schema", `String "masc.dashboard.codex-session.error.v1"
+        ; "ok", `Bool false
+        ; "error_code", `String code
+        ; "error", `String message
+        ])
+      reqd
 
 let execute_output_heartbeat_s = 15.0
 
@@ -783,6 +804,33 @@ let add_routes ~sw ~clock router =
              ~config:(Mcp_server.workspace_config state)
          in
          Http.Response.json_value ~compress:true ~request:req json reqd)
+         request reqd)
+  |> Http.Router.get "/api/v1/runtime/sessions/codex" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state _agent_name req reqd ->
+           let keeper_name =
+             Option.value
+               (Server_utils.query_param req "keeper_name")
+               ~default:""
+           in
+           let base_path = (Mcp_server.workspace_config state).base_path in
+           respond_codex_session_result
+             req
+             reqd
+             (Codex_session.snapshot ~base_path ~keeper_name))
+         request reqd)
+  |> Http.Router.post "/api/v1/runtime/sessions/codex/resolve" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body ->
+             let base_path = (Mcp_server.workspace_config state).base_path in
+             respond_codex_session_result
+               req
+               reqd
+               (Codex_session.resolve_body
+                  ~base_path
+                  ~actor:agent_name
+                  ~body)))
          request reqd)
   |> Http.Router.get "/api/v1/runtime/config/raw" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin

--- a/scripts/harness_dashboard_codex_session_recovery_e2e.sh
+++ b/scripts/harness_dashboard_codex_session_recovery_e2e.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5192}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/codex-session-recovery-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-codex-session-recovery-vite-${PORT}.log"
+ARTIFACT_DIR="${CODEX_SESSION_RECOVERY_ARTIFACT_DIR:-${TMPDIR:-/tmp}/masc-codex-session-recovery-e2e}"
+
+mkdir -p "${ARTIFACT_DIR}"
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    sed -n '1,160p' "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+CODEX_SESSION_RECOVERY_FIXTURE_URL="${FIXTURE_URL}" \
+CODEX_SESSION_RECOVERY_ARTIFACT_DIR="${ARTIFACT_DIR}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec node e2e/codex-session-recovery.mjs
+
+printf 'Codex session recovery Playwright E2E passed\n'

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -883,6 +883,105 @@ let test_codex_recovery_retry_and_adopt_paths () =
           fail "adopt-verified did not settle the verified turn"))
 ;;
 
+let test_dashboard_codex_recovery_projection_and_resolution () =
+  let base_path = temp_workspace "masc-codex-dashboard-recovery-" in
+  let keeper_name = "dashboard-codex" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       let claim =
+         Keeper_codex_session_store.claim
+           ~base_path
+           ~keeper_name
+           ~expected:None
+           ~runtime_id:"codex.codex"
+           ~tool_surface_sha256:
+             (Keeper_codex_session_store.tool_surface_sha256 [])
+           ~updated_at:1.0
+         |> Result.get_ok
+       in
+       let recovery =
+         Keeper_codex_session_store.require_recovery
+           ~base_path
+           ~keeper_name
+           ~expected:claim
+           ~failure:Keeper_codex_session_store.Protocol_failed
+           ~detail:"malformed app-server event"
+           ~required_at:2.0
+         |> Result.get_ok
+       in
+       let recovery_id =
+         match recovery.phase with
+         | Recovery_required required -> required.recovery_id
+         | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+           fail "dashboard recovery fixture was not recovery-required"
+       in
+       let snapshot =
+         Server_dashboard_codex_session.snapshot ~base_path ~keeper_name
+         |> Result.get_ok
+       in
+       let open Yojson.Safe.Util in
+       check string
+         "dashboard schema"
+         "masc.dashboard.codex-session.v1"
+         (snapshot |> member "schema" |> to_string);
+       check string
+         "dashboard recovery phase"
+         "recovery_required"
+         (snapshot |> member "session" |> member "phase" |> member "kind" |> to_string);
+       check string
+         "dashboard recovery fence"
+         recovery_id
+         (snapshot
+          |> member "session"
+          |> member "phase"
+          |> member "recovery_id"
+          |> to_string);
+       let body =
+         `Assoc
+           [ "keeper_name", `String keeper_name
+           ; "recovery_id", `String recovery_id
+           ; "resolution", `String "restart_fresh"
+           ]
+         |> Yojson.Safe.to_string
+       in
+       let resolved =
+         Server_dashboard_codex_session.resolve_body
+           ~base_path
+           ~actor:"dashboard-admin"
+           ~body
+         |> Result.get_ok
+       in
+       check string
+         "dashboard resolved phase"
+         "ready"
+         (resolved |> member "session" |> member "phase" |> member "kind" |> to_string);
+       check string
+         "dashboard resolution actor"
+         "dashboard-admin"
+         (resolved
+          |> member "session"
+          |> member "last_recovery_resolution"
+          |> member "resolved_by"
+          |> to_string);
+       let duplicate_body =
+         Printf.sprintf
+           {|{"keeper_name":%S,"keeper_name":%S,"recovery_id":%S,"resolution":"restart_fresh"}|}
+           keeper_name
+           keeper_name
+           recovery_id
+       in
+       match
+         Server_dashboard_codex_session.resolve_body
+           ~base_path
+           ~actor:"dashboard-admin"
+           ~body:duplicate_body
+       with
+       | Error { kind = Bad_request; _ } -> ()
+       | Error _ -> fail "duplicate dashboard request had the wrong error class"
+       | Ok _ -> fail "duplicate dashboard request fields were admitted")
+;;
+
 let test_codex_tool_surface_fingerprint_is_exact () =
   let alpha = fixture_tool ~name:"alpha" ~description:"first" () in
   let beta = fixture_tool ~name:"beta" ~description:"second" () in
@@ -1739,6 +1838,10 @@ let () =
             "Codex recovery retry and adopt paths"
             `Quick
             test_codex_recovery_retry_and_adopt_paths
+        ; test_case
+            "dashboard Codex recovery projection and resolution"
+            `Quick
+            test_dashboard_codex_recovery_projection_and_resolution
         ; test_case
             "Codex tool fingerprint is exact"
             `Quick


### PR DESCRIPTION
## Summary

- add Codex official-client runtime configuration to the runtime.toml editor without API-key fields
- expose the durable per-Keeper Codex session phase and measured thread, turn, tool-surface, and timestamp evidence to CanAdmin
- require the exact recovery ID for retry_previous, restart_fresh, or adopt_verified and persist the resolving actor
- add a Runtime dashboard panel for inspection and explicit recovery operations
- add focused API, component, OCaml contract, and Playwright coverage

## Stack

- base: #27755
- this PR only adds dashboard configuration and operations on top of the typed Codex session owner

## Verification

- dune build --root "$PWD" .
- dune exec --root "$PWD" ./test/test_runtime_codex_app_server.exe: 29 passed; 7 live subscription cases skipped because opt-in was not enabled
- pnpm --dir dashboard typecheck
- pnpm --dir dashboard lint
- focused Vitest: 5 files, 218 passed
- pnpm --dir dashboard build
- scripts/harness_dashboard_codex_session_recovery_e2e.sh: Playwright passed and captured recovery-required plus resolved states

## Boundary

No API key is accepted or configured. The dashboard uses the local official Codex client subscription boundary. Live subscription proof remains separate and is not claimed by this PR.