### PR TITLE
fix: restore canonical approval and runtime contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1314,13 +1314,9 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_observability_redact"
 
-      # The Gate is the boundary every external effect crosses, and its audit
-      # log is the only durable record of what it let through. Seven suites
-      # cover it (approval queue, rules, rules types, resolved history, audit
-      # timeline, gate effect coverage, gate replay) and none was named here, so
-      # none ran. This wires the audit-vocabulary suite, which is the one that
-      # pins what a reader of ~/.masc/audit-approvals can actually tell apart.
-      - name: Run approval audit vocabulary suite
+      # Approval persistence, typed terminal decisions, Keeper prompt
+      # projection, and audit vocabulary form one current Gate contract.
+      - name: Run approval Gate contract suites
         id: approval_audit_vocabulary_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}
         env:
@@ -1330,7 +1326,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_approval_audit_timeline"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_approval_queue @test/runtest-test_keeper_hitl_resolution_prompt @test/runtest-test_keeper_approval_audit_timeline"
 
       - name: Run verification behavior suite
         id: verification_behavior_suite

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -2,10 +2,10 @@
 
 module StringSet = Set_util.StringSet
 
-(* Project every descriptor-owned masc_* backend schema into the substrate so
-   the keeper tool universe knows the tool exists.  This includes the web
-   backends (masc_web_search / masc_web_fetch), which the LLM reaches via their
-   WebSearch / WebFetch public_names.
+(* Project every descriptor-owned internal schema into the substrate so the
+   keeper tool universe and dispatch validation share one exact contract. This
+   includes structured runtime handlers such as [tool_read_file] as well as the
+   masc_* web backends reached through public descriptor names.
 
    Do NOT trim "keeper-only" tools out of this projection to keep them off the
    operator MCP surface.  [raw_all_tool_schemas] feeds both the keeper universe
@@ -15,21 +15,29 @@ module StringSet = Set_util.StringSet
    The Keeper model surface itself comes directly from descriptors. *)
 let descriptor_owned_internal_tool_schemas : Masc_domain.tool_schema list =
   Keeper_tool_descriptor.public_descriptors
-  |> List.filter_map (fun (descriptor : Keeper_tool_descriptor.t) ->
-    if String.starts_with ~prefix:"masc_" descriptor.internal_name
-    then
-      Some
-        { Masc_domain.name = descriptor.internal_name
-        ; description = descriptor.description
-        ; input_schema = descriptor.input_schema
-        }
-    else None)
+  |> List.map (fun (descriptor : Keeper_tool_descriptor.t) ->
+    { Masc_domain.name = descriptor.internal_name
+    ; description = descriptor.description
+    ; input_schema = descriptor.input_schema
+    })
+
+let descriptor_owned_internal_names =
+  descriptor_owned_internal_tool_schemas
+  |> List.fold_left
+       (fun names (schema : Masc_domain.tool_schema) ->
+          StringSet.add schema.name names)
+       StringSet.empty
+
+let non_descriptor_keeper_tool_schemas =
+  Tool_shard.all_keeper_tool_schemas
+  |> List.filter (fun (schema : Masc_domain.tool_schema) ->
+    not (StringSet.mem schema.name descriptor_owned_internal_names))
 
 let raw_all_tool_schemas : Masc_domain.tool_schema list =
-  Tool_shard.all_keeper_tool_schemas
+  non_descriptor_keeper_tool_schemas
+  @ descriptor_owned_internal_tool_schemas
   @ Tools.raw_schemas
   @ Tool_schemas_misc.schemas
-  @ descriptor_owned_internal_tool_schemas
   @ Board_tool.tools
   @ Keeper_schema.schemas
   @ Tool_local_runtime.schemas

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -2,10 +2,11 @@
 
 module StringSet = Set_util.StringSet
 
-(* Project every descriptor-owned internal schema into the substrate so the
-   keeper tool universe and dispatch validation share one exact contract. This
-   includes structured runtime handlers such as [tool_read_file] as well as the
-   masc_* web backends reached through public descriptor names.
+(* Keep the internal runtime schemas for descriptor-backed shard tools.  Their
+   public Keeper descriptors may deliberately expose a different shape that is
+   validated before translation (for example, Edit.file_path becomes the
+   runtime tool_edit_file.path).  Only project a descriptor-owned schema when
+   no shard runtime schema exists for that internal name.
 
    Do NOT trim "keeper-only" tools out of this projection to keep them off the
    operator MCP surface.  [raw_all_tool_schemas] feeds both the keeper universe
@@ -13,29 +14,30 @@ module StringSet = Set_util.StringSet
    exclusion is enforced separately and downstream by [Tool_catalog.is_public_mcp]
    / [public_mcp_surface_tools] (contract stated in tool_schemas_misc.mli).
    The Keeper model surface itself comes directly from descriptors. *)
-let descriptor_owned_internal_tool_schemas : Masc_domain.tool_schema list =
-  Keeper_tool_descriptor.public_descriptors
-  |> List.map (fun (descriptor : Keeper_tool_descriptor.t) ->
-    { Masc_domain.name = descriptor.internal_name
-    ; description = descriptor.description
-    ; input_schema = descriptor.input_schema
-    })
+let keeper_runtime_tool_schemas = Tool_shard.all_keeper_tool_schemas
 
-let descriptor_owned_internal_names =
-  descriptor_owned_internal_tool_schemas
+let keeper_runtime_tool_names =
+  keeper_runtime_tool_schemas
   |> List.fold_left
        (fun names (schema : Masc_domain.tool_schema) ->
           StringSet.add schema.name names)
        StringSet.empty
 
-let non_descriptor_keeper_tool_schemas =
-  Tool_shard.all_keeper_tool_schemas
-  |> List.filter (fun (schema : Masc_domain.tool_schema) ->
-    not (StringSet.mem schema.name descriptor_owned_internal_names))
+let descriptor_only_internal_tool_schemas : Masc_domain.tool_schema list =
+  Keeper_tool_descriptor.public_descriptors
+  |> List.filter_map (fun (descriptor : Keeper_tool_descriptor.t) ->
+    if StringSet.mem descriptor.internal_name keeper_runtime_tool_names
+    then None
+    else
+      Some
+        { Masc_domain.name = descriptor.internal_name
+        ; description = descriptor.description
+        ; input_schema = descriptor.input_schema
+        })
 
 let raw_all_tool_schemas : Masc_domain.tool_schema list =
-  non_descriptor_keeper_tool_schemas
-  @ descriptor_owned_internal_tool_schemas
+  keeper_runtime_tool_schemas
+  @ descriptor_only_internal_tool_schemas
   @ Tools.raw_schemas
   @ Tool_schemas_misc.schemas
   @ Board_tool.tools

--- a/lib/dashboard/dashboard_gate.ml
+++ b/lib/dashboard/dashboard_gate.ml
@@ -81,13 +81,13 @@ let dashboard_json ~base_path ~limit ~window_minutes =
       ()
   in
   let approval_rules, approval_rules_state =
-    match Keeper_approval_queue.list_rules_dashboard_json ~base_path () with
+    match Keeper_approval_queue_rules.list_rules_dashboard_json ~base_path () with
     | Ok json -> json, `Assoc [ "state", `String "ready" ]
     | Error error ->
       ( `List []
       , `Assoc
           [ "state", `String "unavailable"
-          ; "error", `String (Keeper_approval_queue.rule_store_error_to_string error)
+          ; "error", `String (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
           ] )
   in
   `Assoc

--- a/lib/dashboard/dashboard_gate_metrics.ml
+++ b/lib/dashboard/dashboard_gate_metrics.ml
@@ -176,7 +176,7 @@ type approval_summary = {
 let approval_queue_summary_of_entries ~now_ts entries : approval_summary =
   let waits =
     List.map
-      (fun (entry : Keeper_approval_queue.pending_approval) ->
+      (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
         Float.max 0.0 (now_ts -. entry.requested_at))
       entries
   in

--- a/lib/dashboard/dashboard_gate_metrics.mli
+++ b/lib/dashboard/dashboard_gate_metrics.mli
@@ -82,7 +82,7 @@ val record_tool_skipped_with_append_for_testing :
 val gate_tool_events_json_with_pending_result_for_testing :
   now_ts:float ->
   window_minutes:int ->
-  ( Keeper_approval_queue.pending_approval list
+  ( Keeper_approval_queue_rules_types.pending_approval list
   , Keeper_approval_queue.storage_error )
   result ->
   Yojson.Safe.t

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -1,4 +1,5 @@
 open Keeper_approval_queue
+open Keeper_approval_queue_rules_types
 
 module Exact_output = Agent_sdk.Exact_output
 module Registry = Runtime_exact_output_registry

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -32,8 +32,8 @@ type spawn_outcome =
 
 val spawn
   :  sw:Eio.Switch.t
-  -> entry:Keeper_approval_queue.pending_approval
-  -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+  -> entry:Keeper_approval_queue_rules_types.pending_approval
+  -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
   -> on_finish:(finish_outcome -> unit)
   -> unit
   -> (spawn_outcome, string) result
@@ -46,31 +46,31 @@ val spawn
 
 module For_testing : sig
   val run_outcome_of_observed_summary
-    :  Keeper_approval_queue.hitl_context_summary option
+    :  Keeper_approval_queue_rules_types.hitl_context_summary option
     -> Exact_lane_run_registry.outcome * Yojson.Safe.t
 
   val system_prompt : unit -> (string, string) result
 
   val build_context_bundle
-    :  entry:Keeper_approval_queue.pending_approval
+    :  entry:Keeper_approval_queue_rules_types.pending_approval
     -> Yojson.Safe.t
 
   val parse_summary
     :  generated_at:float
     -> model_run_id:string
     -> Yojson.Safe.t
-    -> (Keeper_approval_queue.hitl_context_summary, string) result
+    -> (Keeper_approval_queue_rules_types.hitl_context_summary, string) result
 
   type prepared_flow
 
   val prepare_flow
-    :  entry:Keeper_approval_queue.pending_approval
+    :  entry:Keeper_approval_queue_rules_types.pending_approval
     -> (prepared_flow, string) result
 
   val execute_prepared_flow
     :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
     -> ?clock:_ Eio.Time.clock
-    -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+    -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
     -> prepared_flow
     -> execution_boundary
 
@@ -94,7 +94,7 @@ module For_testing : sig
     -> call_id:string
     -> plan_fingerprint:string
     -> request_body_sha256:string
-    -> summary:Keeper_approval_queue.hitl_context_summary
+    -> summary:Keeper_approval_queue_rules_types.hitl_context_summary
     -> ( Keeper_approval_queue.exact_attempt_transition
        , Keeper_approval_queue.exact_attempt_error )
        result
@@ -107,7 +107,7 @@ module For_testing : sig
     -> call_id:string
     -> plan_fingerprint:string
     -> request_body_sha256:string
-    -> cause:Keeper_approval_queue.exact_attempt_quarantine_cause
+    -> cause:Keeper_approval_queue_rules_types.exact_attempt_quarantine_cause
     -> ( Keeper_approval_queue.exact_attempt_transition
        , Keeper_approval_queue.exact_attempt_error )
        result
@@ -127,7 +127,7 @@ module For_testing : sig
     :  queue_ops:exact_queue_ops
     -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
     -> ?clock:_ Eio.Time.clock
-    -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+    -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
     -> prepared_flow
     -> execution_boundary
   (** The production flow with explicit durable queue transition authority.
@@ -137,8 +137,8 @@ module For_testing : sig
   val spawn_with_queue_ops
     :  queue_ops:exact_queue_ops
     -> sw:Eio.Switch.t
-    -> entry:Keeper_approval_queue.pending_approval
-    -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+    -> entry:Keeper_approval_queue_rules_types.pending_approval
+    -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
     -> on_finish:(finish_outcome -> unit)
     -> unit
     -> (spawn_outcome, string) result

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -424,8 +424,6 @@ let approval_decision_to_yojson = function
   | Decision.Approve -> `Assoc [ "kind", `String "approve" ]
   | Decision.Reject reason ->
     `Assoc [ "kind", `String "reject"; "reason", `String reason ]
-  | Decision.Edit input ->
-    `Assoc [ "kind", `String "edit"; "input", input ]
 ;;
 
 let resolution_replay_outcome_to_yojson = function
@@ -961,15 +959,6 @@ let approval_decision_of_yojson json =
        in
        let* reason = required_string ~surface:"gate_pending.decision" "reason" fields in
        Ok (Decision.Reject reason)
-     | "edit" ->
-       let* () =
-         reject_unknown_fields
-           ~surface:"gate_pending.decision"
-           ~allowed:[ "kind"; "input" ]
-           fields
-       in
-       let* input = required_member ~surface:"gate_pending.decision" "input" fields in
-       Ok (Decision.Edit input)
      | other -> Error (Printf.sprintf "gate_pending.decision kind %S is unknown" other))
   | _ -> Error "gate_pending.decision must be a JSON object"
 ;;
@@ -1095,8 +1084,8 @@ let persisted_delivery_of_yojson ~base_path json =
     let* () =
       match decision, grant_consumed with
       | Decision.Approve, (true | false) -> Ok ()
-      | (Decision.Reject _ | Decision.Edit _), false -> Ok ()
-      | (Decision.Reject _ | Decision.Edit _), true ->
+      | Decision.Reject _, false -> Ok ()
+      | Decision.Reject _, true ->
         Error (surface ^ ".grant_consumed is valid only for approve")
     in
     Ok
@@ -1447,7 +1436,7 @@ let attach_replay_results ~delivery_map replay_results =
                  "gate_replay_results outcome %s requires a consumed approve grant"
                  approval_id)
           | Some
-              { decision = (Decision.Reject _ | Decision.Edit _); _ } ->
+              { decision = Decision.Reject _; _ } ->
             Error
               (Printf.sprintf
                  "gate_replay_results outcome %s belongs to a non-approved delivery"
@@ -1571,7 +1560,7 @@ let approved_delivery_unlocked ~base_path ~id =
             if delivery.grant_consumed
             then Ok (Approved_delivery_consumed delivery)
             else Ok (Approved_delivery_unconsumed delivery)
-          | Decision.Reject _ | Decision.Edit _ ->
+          | Decision.Reject _ ->
             Error (Grant_resolution_not_approved id))
      | None ->
        (match SMap.find_opt id (Atomic.get pending) with
@@ -2821,7 +2810,6 @@ let commit_keeper_approval_resolution
 let hitl_resolution_decision_of_approval_decision = function
   | Decision.Approve -> Keeper_event_queue.Hitl_approved
   | Decision.Reject rationale -> Keeper_event_queue.Hitl_rejected rationale
-  | Decision.Edit input -> Keeper_event_queue.Hitl_edited input
 ;;
 
 let deliver_resolution ~base_path (entry : pending_approval) decision =
@@ -3160,9 +3148,8 @@ let approval_decision_equal left right =
   match left, right with
   | Decision.Approve, Decision.Approve -> true
   | Decision.Reject left, Decision.Reject right -> String.equal left right
-  | Decision.Edit left, Decision.Edit right -> Yojson.Safe.equal left right
-  | (Decision.Approve | Decision.Reject _ | Decision.Edit _),
-    (Decision.Approve | Decision.Reject _ | Decision.Edit _) ->
+  | (Decision.Approve | Decision.Reject _),
+    (Decision.Approve | Decision.Reject _) ->
     false
 ;;
 
@@ -3226,10 +3213,10 @@ let remember_rule_for_delivery delivery =
          { path = rule_error.path
          ; reason = rule_error.reason
          })
-  | (Decision.Approve | Decision.Reject _ | Decision.Edit _),
+  | (Decision.Approve | Decision.Reject _),
     false ->
     Ok None
-  | (Decision.Reject _ | Decision.Edit _), true -> Ok None
+  | Decision.Reject _, true -> Ok None
 ;;
 
 let complete_delivery delivery =
@@ -3266,7 +3253,7 @@ let complete_delivery delivery =
                   consumes it. The wake event is only a correlation message and
                   cannot become a second authorization SSOT. *)
                finish ()
-             | Decision.Reject _ | Decision.Edit _ ->
+             | Decision.Reject _ ->
                (match remove_delivery_from_store delivery with
                 | Error storage_error ->
                   Error (Persistence_failed { approval_id = id; storage_error })
@@ -3526,7 +3513,7 @@ let resolve_with_policy
              let remember_rule =
                match decision with
                | Decision.Approve -> remember_rule
-               | Decision.Reject _ | Decision.Edit _ -> false
+               | Decision.Reject _ -> false
              in
              let rule_expires_at =
                if remember_rule then rule_expires_at else None

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1,6 +1,7 @@
 (** Durable, nonblocking HITL requests for Keeper external effects. *)
 
-include Keeper_approval_queue_rules
+open Keeper_approval_queue_rules_types
+open Keeper_approval_queue_rules
 
 type storage_error =
   { path : string
@@ -3168,7 +3169,7 @@ let approval_decision_equal left right =
 let remember_rule_for_entry ~base_path ?created_by ?rule_expires_at (entry : pending_approval) =
   try
     match
-      upsert_rule
+      Keeper_approval_queue_rules.upsert_rule
         ~base_path
         ~keeper_name:entry.keeper_name
         ~tool_name:entry.tool_name

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -4,7 +4,7 @@
     tool/product name. It records an exact request, accepts an explicit
     resolution, and wakes only the originating Keeper lane. *)
 
-include module type of Keeper_approval_queue_rules_types
+open Keeper_approval_queue_rules_types
 
 type storage_error =
   { path : string
@@ -207,103 +207,7 @@ val record_consumed_resolution_replay :
   outcome:resolution_replay_outcome ->
   (replay_recording, grant_error) result
 
-(** {1 Exact Always Allowed rules} *)
-
-val list_rules :
-  base_path:string -> unit -> (approval_rule list, rule_store_error) result
-
-val list_rules_dashboard_json :
-  base_path:string -> unit -> (Yojson.Safe.t, rule_store_error) result
-
-(** Insert or fetch the rule for the exact
-    [(keeper_name, tool_name, canonical complete input)] identity.
-    [expires_at] is an optional absolute Unix expiry; the identity match
-    ignores it, so an existing rule is returned unchanged. *)
-val upsert_rule :
-  base_path:string ->
-  keeper_name:string ->
-  tool_name:string ->
-  input:Yojson.Safe.t ->
-  ?created_by:string ->
-  ?source_approval_id:string ->
-  ?expires_at:float ->
-  unit ->
-  (approval_rule * bool, rule_store_error) result
-
-val delete_rule :
-  base_path:string -> id:string -> unit -> (approval_rule, rule_store_error) result
-
-(** Find the exact remembered request and report whether it authorizes at
-    [now] (defaults to the wall clock; inject for deterministic evaluation).
-    An expired rule is reported as [Rule_match_expired], never applied, and
-    never deleted. *)
-val find_matching_rule :
-  base_path:string ->
-  keeper_name:string ->
-  tool_name:string ->
-  input:Yojson.Safe.t ->
-  ?now:float ->
-  unit ->
-  (rule_lookup, rule_store_error) result
-
 val generate_id : unit -> string
-val recent_resolved_history_limit : int
-val recent_resolved_max_limit : int
-val recent_resolved_default_window_minutes : int
-val recent_resolved_min_window_minutes : int
-val recent_resolved_max_window_minutes : int
-
-val read_recent_audit :
-  base_path:string -> ?keeper_name:string -> ?n:int -> unit -> Yojson.Safe.t list
-
-val audit_day_string_of_ts : float -> string
-(** Day key ["YYYY-MM-DD"] for the [YYYY-MM/DD.jsonl] audit layout. Exposed as
-    a pure function so the UTC invariant is testable: the write path
-    ([Jsonl_writer.dated_path]) picks the day file with [Unix.gmtime], so a
-    local-time key would read the wrong file for the hours where the two
-    calendars disagree. *)
-
-type resolved_history =
-  { resolved_rows : Yojson.Safe.t list
-  ; resolved_matched : int
-  ; resolved_limit : int
-  ; resolved_window_minutes : int
-  ; resolved_scan_exhausted : bool
-  }
-(** A page of resolved Gate decisions together with the bounds that produced
-    it. [resolved_rows] is newest first and holds at most [resolved_limit]
-    entries; [resolved_matched] counts every resolved decision the scan saw
-    inside the window, so [resolved_matched > resolved_limit] means the page is
-    a slice rather than the whole window. [resolved_scan_exhausted] reports the
-    second bound: the physical row cap stopped the scan before it reached the
-    window start, so even [resolved_matched] undercounts. Rendering only
-    [resolved_rows] reintroduces the silent truncation this type removes. *)
-
-val list_recent_resolved :
-  base_path:string ->
-  now_ts:float ->
-  ?limit:int ->
-  ?window_minutes:int ->
-  unit ->
-  resolved_history
-(** [list_recent_resolved ~base_path ~now_ts ()] returns resolved Gate decisions
-    from the last [window_minutes] (default
-    {!recent_resolved_default_window_minutes}, clamped to
-    [[recent_resolved_min_window_minutes, recent_resolved_max_window_minutes]]),
-    newest first, capped at [limit] (default
-    {!recent_resolved_history_limit}, clamped to
-    [[0, recent_resolved_max_limit]]).
-
-    [now_ts] is supplied by the caller rather than read here, matching
-    {!Dashboard_gate_metrics.tool_rejection_counts}: the observation boundary
-    captures the clock once for the whole projection, and this function stays
-    deterministic so a test can pin an exact window.
-
-    Rows without a [ts] are excluded: a wall-clock window cannot place an
-    undated decision, and dating it by guesswork would misreport history.
-
-    Storage failures are reported through the approval-queue failure metric and
-    yield an empty page rather than raising. *)
 
 module For_testing : sig
   type strict_snapshot_writer =

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -167,7 +167,7 @@ let cycle_grant_of_resolution (resolution : Keeper_event_queue.hitl_resolution) 
     Some
       (Atomic.make
          (Cycle_grant_available { approval_id = resolution.approval_id }))
-  | Keeper_event_queue.Hitl_rejected _ | Keeper_event_queue.Hitl_edited _ -> None
+  | Keeper_event_queue.Hitl_rejected _ -> None
 ;;
 
 let rec take_matching_cycle_grant grant request =

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -216,11 +216,11 @@ let deferred_reason_to_string = function
   | Human_requested -> "human_requested"
   | Judge_requested -> "judge_requested"
   | Auto_judge_unavailable _ ->
-    Keeper_approval_queue.summary_attempt_pre_worker_unavailable_code_to_string
-      Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+    Keeper_approval_queue_rules_types.summary_attempt_pre_worker_unavailable_code_to_string
+      Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
   | Mode_state_invalid _ ->
-    Keeper_approval_queue.summary_attempt_pre_worker_unavailable_code_to_string
-      Keeper_approval_queue.Summary_pre_worker_mode_state_invalid
+    Keeper_approval_queue_rules_types.summary_attempt_pre_worker_unavailable_code_to_string
+      Keeper_approval_queue_rules_types.Summary_pre_worker_mode_state_invalid
 ;;
 
 let unavailable_reason_to_string = function
@@ -338,14 +338,14 @@ type judgment_finalize_outcome =
   | Judgment_finalized
   | Judgment_skipped
 
-let resolve_judgment (entry : Keeper_approval_queue.pending_approval) ~approval_id
-      (summary : Keeper_approval_queue.hitl_context_summary) =
+let resolve_judgment (entry : Keeper_approval_queue_rules_types.pending_approval) ~approval_id
+      (summary : Keeper_approval_queue_rules_types.hitl_context_summary) =
   let decision =
-    match summary.Keeper_approval_queue.judgment with
-    | Keeper_approval_queue.Approve -> Some Keeper_approval_queue.Decision.Approve
-    | Keeper_approval_queue.Deny ->
-      Some (Keeper_approval_queue.Decision.Reject summary.rationale)
-    | Keeper_approval_queue.Require_human -> None
+    match summary.Keeper_approval_queue_rules_types.judgment with
+    | Keeper_approval_queue_rules_types.Approve -> Some Keeper_approval_queue_rules_types.Decision.Approve
+    | Keeper_approval_queue_rules_types.Deny ->
+      Some (Keeper_approval_queue_rules_types.Decision.Reject summary.rationale)
+    | Keeper_approval_queue_rules_types.Require_human -> None
   in
   match decision with
   | None -> Ok Judgment_skipped
@@ -355,7 +355,7 @@ let resolve_judgment (entry : Keeper_approval_queue.pending_approval) ~approval_
          ~base_path:entry.audit_base_path
          ~id:approval_id
          ~decision
-         ~source:Keeper_approval_queue.Auto_judge
+         ~source:Keeper_approval_queue_rules_types.Auto_judge
          ~created_by:("auto_judge:" ^ summary.model_run_id)
          ()
      with
@@ -385,7 +385,7 @@ end
 module Auto_judge_owners = Map.Make (Auto_judge_owner)
 module Auto_judge_owner_set = Set.Make (Auto_judge_owner)
 
-let auto_judge_owner (entry : Keeper_approval_queue.pending_approval) =
+let auto_judge_owner (entry : Keeper_approval_queue_rules_types.pending_approval) =
   entry.audit_base_path, entry.keeper_name
 ;;
 
@@ -395,7 +395,7 @@ let active_auto_judges : string Auto_judge_owners.t Atomic.t =
   Atomic.make Auto_judge_owners.empty
 ;;
 
-let rec claim_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+let rec claim_auto_judge (entry : Keeper_approval_queue_rules_types.pending_approval) =
   let active = Atomic.get active_auto_judges in
   let owner = auto_judge_owner entry in
   match Auto_judge_owners.find_opt owner active with
@@ -407,7 +407,7 @@ let rec claim_auto_judge (entry : Keeper_approval_queue.pending_approval) =
     else claim_auto_judge entry
 ;;
 
-let rec release_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+let rec release_auto_judge (entry : Keeper_approval_queue_rules_types.pending_approval) =
   let active = Atomic.get active_auto_judges in
   let owner = auto_judge_owner entry in
   match Auto_judge_owners.find_opt owner active with
@@ -427,30 +427,30 @@ let active_auto_judge_for_owner ~base_path ~keeper_name =
 type auto_judge_entry_class =
   | Auto_judge_not_requested
   | Auto_judge_pending_unbound
-  | Auto_judge_finalizable of Keeper_approval_queue.hitl_context_summary
+  | Auto_judge_finalizable of Keeper_approval_queue_rules_types.hitl_context_summary
   | Auto_judge_ineligible
 
 let classify_auto_judge_entry
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   match
     entry.summary_attempt_disposition,
     entry.exact_attempt,
     entry.summary_status
   with
-  | Keeper_approval_queue.Summary_attempt_ready,
-    Keeper_approval_queue.Exact_unbound,
-    Keeper_approval_queue.Summary_not_requested ->
+  | Keeper_approval_queue_rules_types.Summary_attempt_ready,
+    Keeper_approval_queue_rules_types.Exact_unbound,
+    Keeper_approval_queue_rules_types.Summary_not_requested ->
     Auto_judge_not_requested
-  | Keeper_approval_queue.Summary_attempt_ready,
-    Keeper_approval_queue.Exact_unbound,
-    Keeper_approval_queue.Summary_pending ->
+  | Keeper_approval_queue_rules_types.Summary_attempt_ready,
+    Keeper_approval_queue_rules_types.Exact_unbound,
+    Keeper_approval_queue_rules_types.Summary_pending ->
     Auto_judge_pending_unbound
-  | ( Keeper_approval_queue.Summary_attempt_settled
-    | Keeper_approval_queue.Summary_attempt_persistence_uncertain ),
-    Keeper_approval_queue.Exact_bound
-      { status = Keeper_approval_queue.Exact_completed; _ },
-    Keeper_approval_queue.Summary_available summary ->
+  | ( Keeper_approval_queue_rules_types.Summary_attempt_settled
+    | Keeper_approval_queue_rules_types.Summary_attempt_persistence_uncertain ),
+    Keeper_approval_queue_rules_types.Exact_bound
+      { status = Keeper_approval_queue_rules_types.Exact_completed; _ },
+    Keeper_approval_queue_rules_types.Summary_available summary ->
     Auto_judge_finalizable summary
   | _ ->
     Auto_judge_ineligible
@@ -467,8 +467,8 @@ let auto_judge_entry_ready entry =
 ;;
 
 let compare_auto_judge_entries
-      (left : Keeper_approval_queue.pending_approval)
-      (right : Keeper_approval_queue.pending_approval)
+      (left : Keeper_approval_queue_rules_types.pending_approval)
+      (right : Keeper_approval_queue_rules_types.pending_approval)
   =
   Int.compare left.sequence right.sequence
 ;;
@@ -478,7 +478,7 @@ let compare_auto_judge_entries
    Auto Judge may start. *)
 let owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries =
   entries
-  |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+  |> List.filter (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
     String.equal entry.audit_base_path base_path
     && String.equal entry.keeper_name keeper_name)
   |> List.sort compare_auto_judge_entries
@@ -486,7 +486,7 @@ let owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries =
 
 let auto_judge_entry_has_start_reservation
       reserved_id
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   String.equal entry.id reserved_id
   &&
@@ -495,11 +495,11 @@ let auto_judge_entry_has_start_reservation
     entry.exact_attempt,
     entry.summary_attempt_disposition
   with
-  | Keeper_approval_queue.Summary_pending,
-    Keeper_approval_queue.Exact_unbound,
-    Keeper_approval_queue.Summary_attempt_pre_worker_unavailable
+  | Keeper_approval_queue_rules_types.Summary_pending,
+    Keeper_approval_queue_rules_types.Exact_unbound,
+    Keeper_approval_queue_rules_types.Summary_attempt_pre_worker_unavailable
       { reason_code =
-          Keeper_approval_queue.Summary_pre_worker_start_reserved
+          Keeper_approval_queue_rules_types.Summary_pre_worker_start_reserved
       ; _
       } ->
     true
@@ -527,7 +527,7 @@ let ready_auto_judges_for_owner
       ~keeper_name
       entries
   =
-  let startable (entry : Keeper_approval_queue.pending_approval) =
+  let startable (entry : Keeper_approval_queue_rules_types.pending_approval) =
     auto_judge_entry_ready entry
     ||
     (match reserved_id with
@@ -628,14 +628,14 @@ let drain_auto_judge_owners_with ~drain_owner owners =
 
 type hitl_worker_spawner =
   sw:Eio.Switch.t ->
-  entry:Keeper_approval_queue.pending_approval ->
-  on_summary:(Keeper_approval_queue.hitl_context_summary -> unit) ->
+  entry:Keeper_approval_queue_rules_types.pending_approval ->
+  on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit) ->
   on_finish:(Hitl_summary_worker.finish_outcome -> unit) ->
   unit ->
   (Hitl_summary_worker.spawn_outcome, string) result
 
 let mark_pre_worker_unavailable
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
       ~reason_code
       ~operator_detail
   =
@@ -659,12 +659,12 @@ let durable_pre_worker_unavailable_error reason = function
 ;;
 
 let reserve_pre_worker_start
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   match
     mark_pre_worker_unavailable
       entry
-      ~reason_code:Keeper_approval_queue.Summary_pre_worker_start_reserved
+      ~reason_code:Keeper_approval_queue_rules_types.Summary_pre_worker_start_reserved
       ~operator_detail:
         Keeper_approval_queue.summary_attempt_start_reserved_operator_detail
   with
@@ -679,7 +679,7 @@ let reserve_pre_worker_start
 
 let rec spawn_claimed_auto_judge_entry_with
       ~(spawn_worker : hitl_worker_spawner)
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   let approval_id = entry.id in
   let on_summary summary =
@@ -698,7 +698,7 @@ let rec spawn_claimed_auto_judge_entry_with
          mark_pre_worker_unavailable
            entry
            ~reason_code:
-             Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+             Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
            ~operator_detail:reason
          |> durable_pre_worker_unavailable_error reason
          |> Result.error)
@@ -774,7 +774,7 @@ and spawn_claimed_auto_judge_entry entry =
 
 and spawn_auto_judge_entry_with
       ~(spawn_worker : hitl_worker_spawner)
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   if claim_auto_judge entry
   then spawn_claimed_auto_judge_entry_with ~spawn_worker entry
@@ -791,7 +791,7 @@ and retry_auto_judge_entry
       ~expected_sequence
       ~expected_exact_attempt
       ~expected_disposition
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   match
     Keeper_approval_queue.reserve_summary_attempt_retry
@@ -811,7 +811,7 @@ and retry_auto_judge_entry
       mark_pre_worker_unavailable
         entry
         ~reason_code:
-          Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+          Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
         ~operator_detail:reason
       |> durable_pre_worker_unavailable_error reason
     in
@@ -863,7 +863,7 @@ and retry_auto_judge_entry
        in
        Error (reblock reason))
 
-and start_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+and start_auto_judge (entry : Keeper_approval_queue_rules_types.pending_approval) =
   if not (claim_auto_judge entry)
   then Ok Skipped
   else
@@ -876,7 +876,7 @@ and start_auto_judge (entry : Keeper_approval_queue.pending_approval) =
       Ok Skipped
     | Ok true -> spawn_claimed_auto_judge_entry entry
 
-and start_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+and start_auto_judge_entry (entry : Keeper_approval_queue_rules_types.pending_approval) =
   match
     Keeper_approval_queue.get_pending_entry_for_workspace
       ~base_path:entry.audit_base_path
@@ -959,7 +959,7 @@ and drain_auto_judge_owner_queue
       | Some reserved_id, [] ->
         (match
            List.exists
-             (fun (entry : Keeper_approval_queue.pending_approval) ->
+             (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
                 String.equal entry.id reserved_id)
              entries
          with
@@ -1020,7 +1020,7 @@ and drain_auto_judges ~base_path =
      | Ok entries ->
        let owners =
          List.fold_left
-           (fun owners (entry : Keeper_approval_queue.pending_approval) ->
+           (fun owners (entry : Keeper_approval_queue_rules_types.pending_approval) ->
               if auto_judge_entry_ready entry
               then Auto_judge_owner_set.add (auto_judge_owner entry) owners
               else owners)
@@ -1040,10 +1040,10 @@ and drain_auto_judges ~base_path =
 ;;
 
 type recovered_work =
-  | Activate_worker of Keeper_approval_queue.pending_approval
+  | Activate_worker of Keeper_approval_queue_rules_types.pending_approval
   | Finalize_judgment of
-      Keeper_approval_queue.pending_approval
-      * Keeper_approval_queue.hitl_context_summary
+      Keeper_approval_queue_rules_types.pending_approval
+      * Keeper_approval_queue_rules_types.hitl_context_summary
 
 let recovered_work_for_base_path ~base_path =
   let enabled =
@@ -1064,24 +1064,24 @@ let recovered_work_for_base_path ~base_path =
     |> Result.map (fun entries ->
     let owners =
       List.fold_left
-        (fun owners (entry : Keeper_approval_queue.pending_approval) ->
+        (fun owners (entry : Keeper_approval_queue_rules_types.pending_approval) ->
            Auto_judge_owner_set.add (auto_judge_owner entry) owners)
         Auto_judge_owner_set.empty
         entries
     in
     let recovered_work_for_entry
-          (entry : Keeper_approval_queue.pending_approval)
+          (entry : Keeper_approval_queue_rules_types.pending_approval)
       =
       match classify_auto_judge_entry entry with
       | Auto_judge_not_requested
       | Auto_judge_pending_unbound ->
         Some (Activate_worker entry)
       | Auto_judge_finalizable
-          ({ judgment = (Keeper_approval_queue.Approve | Keeper_approval_queue.Deny); _ }
+          ({ judgment = (Keeper_approval_queue_rules_types.Approve | Keeper_approval_queue_rules_types.Deny); _ }
            as summary) ->
         Some (Finalize_judgment (entry, summary))
       | Auto_judge_finalizable
-          { judgment = Keeper_approval_queue.Require_human; _ }
+          { judgment = Keeper_approval_queue_rules_types.Require_human; _ }
       | Auto_judge_ineligible ->
         None
     in
@@ -1107,7 +1107,7 @@ let recovered_work_for_base_path ~base_path =
         (entry_of_recovered_work right)))
 ;;
 
-let observe_recovered_work kind (entry : Keeper_approval_queue.pending_approval) =
+let observe_recovered_work kind (entry : Keeper_approval_queue_rules_types.pending_approval) =
   let event_type, outcome =
     match kind with
     | `Activate_worker ->
@@ -1205,7 +1205,7 @@ let retry_blocked_auto_judge
 
 let finalize_recovered_judgment
       ~complete_summary_exact_attempt
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
       summary
   =
   let persistence_uncertain () =
@@ -1218,12 +1218,12 @@ let finalize_recovered_judgment
        : (bool, Keeper_approval_queue.exact_attempt_error) result)
   in
   match entry.exact_attempt with
-  | Keeper_approval_queue.Exact_unbound ->
+  | Keeper_approval_queue_rules_types.Exact_unbound ->
     Error
       ( Resume_identity_unbound
       , "Recovered Auto Judge output has no exact attempt identity; finalization is withheld." )
-  | Keeper_approval_queue.Exact_bound
-      ({ status = Keeper_approval_queue.Exact_completed; _ } as binding) ->
+  | Keeper_approval_queue_rules_types.Exact_bound
+      ({ status = Keeper_approval_queue_rules_types.Exact_completed; _ } as binding) ->
     (match
        complete_summary_exact_attempt
          ~id:entry.id
@@ -1263,7 +1263,7 @@ let finalize_recovered_judgment
        Error
          ( Resume_completion_rejected rejection
          , completion_rejection_operator_detail rejection ))
-  | Keeper_approval_queue.Exact_bound _ ->
+  | Keeper_approval_queue_rules_types.Exact_bound _ ->
     Error
       ( Resume_exact_state_not_completed
       , "Recovered Auto Judge entry is not a completed exact judgment." )
@@ -1366,7 +1366,7 @@ let request_operator_auto_judge_recovery ~base_path =
            | Ok entries ->
              let queued =
                List.fold_left
-                 (fun count (entry : Keeper_approval_queue.pending_approval) ->
+                 (fun count (entry : Keeper_approval_queue_rules_types.pending_approval) ->
                     if auto_judge_entry_ready entry then count + 1 else count)
                  0
                  entries
@@ -1434,7 +1434,7 @@ let defer request reason =
              "Auto Judge pre-worker block observation superseded approval=%s \
               reason_code=%s reason=%s"
              approval_id
-             (Keeper_approval_queue
+             (Keeper_approval_queue_rules_types
               .summary_attempt_pre_worker_unavailable_code_to_string
                 reason_code)
              (Keeper_approval_queue.exact_attempt_error_to_string
@@ -1446,7 +1446,7 @@ let defer request reason =
        (match
           persist_pre_worker_block
             ~reason_code:
-              Keeper_approval_queue.Summary_pre_worker_mode_state_invalid
+              Keeper_approval_queue_rules_types.Summary_pre_worker_mode_state_invalid
             detail
         with
         | Ok () -> Deferred { approval_id; reason }
@@ -1455,7 +1455,7 @@ let defer request reason =
        (match
           persist_pre_worker_block
             ~reason_code:
-              Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+              Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
             detail
         with
         | Ok () -> Deferred { approval_id; reason }
@@ -1464,7 +1464,7 @@ let defer request reason =
 ;;
 
 let observe_exact_rule_store_degraded (request : request) error =
-  let detail = Keeper_approval_queue.rule_store_error_to_string error in
+  let detail = Keeper_approval_queue_rules_types.rule_store_error_to_string error in
   Log.Keeper.error
     ~keeper_name:request.keeper_name
     "exact Always Allowed rule lookup unavailable operation=%s: %s; continuing configured Gate mode"
@@ -1488,7 +1488,7 @@ let observe_exact_rule_store_degraded (request : request) error =
 
 let observe_exact_rule_expired
       (request : request)
-      (rule_match : Keeper_approval_queue.rule_match)
+      (rule_match : Keeper_approval_queue_rules_types.rule_match)
   =
   Log.Keeper.warn
     ~keeper_name:request.keeper_name
@@ -1516,7 +1516,7 @@ let decide_from_selected_mode request = function
     let source = Workspace_always_allow in
     audit_allow
       request
-      ~decision_source:Keeper_approval_queue.Always_allowed
+      ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
       source;
     Allow { source }
 ;;
@@ -1527,7 +1527,7 @@ let decide_without_cycle_grant ~keeper_always_allow request =
     let source = Keeper_always_allow in
     audit_allow
       request
-      ~decision_source:Keeper_approval_queue.Always_allowed
+      ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
       source;
     Allow { source })
   else
@@ -1537,12 +1537,12 @@ let decide_without_cycle_grant ~keeper_always_allow request =
        let source = Workspace_always_allow in
        audit_allow
          request
-         ~decision_source:Keeper_approval_queue.Always_allowed
+         ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
          source;
        Allow { source }
      | Error _ | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Auto_judge) ->
        (match
-          Keeper_approval_queue.find_matching_rule
+          Keeper_approval_queue_rules.find_matching_rule
             ~base_path:request.base_path
             ~keeper_name:request.keeper_name
             ~tool_name:request.operation
@@ -1552,18 +1552,18 @@ let decide_without_cycle_grant ~keeper_always_allow request =
         | Error error ->
           observe_exact_rule_store_degraded request error;
           decide_from_selected_mode request mode
-        | Ok (Keeper_approval_queue.Rule_match_active rule_match) ->
+        | Ok (Keeper_approval_queue_rules_types.Rule_match_active rule_match) ->
           let source = Exact_always_rule rule_match.rule_id in
           audit_allow
             request
             ~rule_match
-            ~decision_source:Keeper_approval_queue.Always_allowed
+            ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
             source;
           Allow { source }
-        | Ok (Keeper_approval_queue.Rule_match_expired rule_match) ->
+        | Ok (Keeper_approval_queue_rules_types.Rule_match_expired rule_match) ->
           observe_exact_rule_expired request rule_match;
           decide_from_selected_mode request mode
-        | Ok Keeper_approval_queue.Rule_match_absent ->
+        | Ok Keeper_approval_queue_rules_types.Rule_match_absent ->
           decide_from_selected_mode request mode))
 ;;
 
@@ -1613,7 +1613,7 @@ module For_testing = struct
     call_id:string ->
     plan_fingerprint:string ->
     request_body_sha256:string ->
-    summary:Keeper_approval_queue.hitl_context_summary ->
+    summary:Keeper_approval_queue_rules_types.hitl_context_summary ->
     ( Keeper_approval_queue.exact_attempt_transition
     , Keeper_approval_queue.exact_attempt_error )
       result

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -137,8 +137,8 @@ val retry_blocked_auto_judge :
   requested_by:string ->
   expected_input_hash:string ->
   expected_sequence:int ->
-  expected_exact_attempt:Keeper_approval_queue.exact_attempt_state ->
-  expected_disposition:Keeper_approval_queue.summary_attempt_disposition ->
+  expected_exact_attempt:Keeper_approval_queue_rules_types.exact_attempt_state ->
+  expected_disposition:Keeper_approval_queue_rules_types.summary_attempt_disposition ->
   string ->
   (unit, string) result
 (** Explicitly rearm one typed blocked Auto Judge summary. The configured Gate
@@ -183,22 +183,22 @@ module For_testing : sig
     call_id:string ->
     plan_fingerprint:string ->
     request_body_sha256:string ->
-    summary:Keeper_approval_queue.hitl_context_summary ->
+    summary:Keeper_approval_queue_rules_types.hitl_context_summary ->
     ( Keeper_approval_queue.exact_attempt_transition
     , Keeper_approval_queue.exact_attempt_error )
       result
 
   val auto_judge_entry_ready :
-    Keeper_approval_queue.pending_approval -> bool
+    Keeper_approval_queue_rules_types.pending_approval -> bool
 
   val ready_auto_judges_for_owner :
     base_path:string ->
     keeper_name:string ->
-    Keeper_approval_queue.pending_approval list ->
-    Keeper_approval_queue.pending_approval list
+    Keeper_approval_queue_rules_types.pending_approval list ->
+    Keeper_approval_queue_rules_types.pending_approval list
 
-  val claim_auto_judge : Keeper_approval_queue.pending_approval -> bool
-  val release_auto_judge : Keeper_approval_queue.pending_approval -> unit
+  val claim_auto_judge : Keeper_approval_queue_rules_types.pending_approval -> bool
+  val release_auto_judge : Keeper_approval_queue_rules_types.pending_approval -> unit
 
   type owner_drain_outcome =
     { started_id : string option
@@ -217,15 +217,15 @@ module For_testing : sig
 
   type hitl_worker_spawner =
     sw:Eio.Switch.t ->
-    entry:Keeper_approval_queue.pending_approval ->
-    on_summary:(Keeper_approval_queue.hitl_context_summary -> unit) ->
+    entry:Keeper_approval_queue_rules_types.pending_approval ->
+    on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit) ->
     on_finish:(Hitl_summary_worker.finish_outcome -> unit) ->
     unit ->
     (Hitl_summary_worker.spawn_outcome, string) result
 
   val spawn_auto_judge_entry_with_worker
     :  spawn_worker:hitl_worker_spawner
-    -> Keeper_approval_queue.pending_approval
+    -> Keeper_approval_queue_rules_types.pending_approval
     -> (bool, string) result
   (** Run the production atomic claim, active-owner lifecycle, cleanup, and
       conclusive-only drain with only the worker spawner injected. *)

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -688,26 +688,6 @@ let user_message_with_hitl_resolution ~base_path ~user_message = function
          ; Printf.sprintf "- rationale: %s" rationale
          ; "This resolution grants no authorization."
          ])
-  | Some
-      { Keeper_event_queue.approval_id
-      ; decision = Keeper_event_queue.Hitl_edited edited_input
-      ; _
-      } ->
-    let edited_input = Yojson.Safe.pretty_to_string edited_input in
-    plain_model_message
-      (String.concat
-         "\n"
-         [ user_message
-         ; ""
-         ; "Gate resolution delivered:"
-         ; Printf.sprintf "- approval_id: %s" approval_id
-         ; "- decision: edited"
-         ; "- edited input:"
-         ; "```json"
-         ; edited_input
-         ; "```"
-         ; "This edit grants no authorization; any external effect follows the ordinary Gate independently."
-         ])
   | None -> plain_model_message user_message
 ;;
 

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -438,12 +438,7 @@ let reconcile_spent_selection
          }
      | Error _ ->
        Ok Selection_actionable)
-  | Hitl_resolved
-      { decision =
-          ( Keeper_event_queue.Hitl_rejected _
-          | Keeper_event_queue.Hitl_edited _ )
-      ; _
-      }
+  | Hitl_resolved { decision = Keeper_event_queue.Hitl_rejected _; _ }
   | Board_signal _
   | Board_attention _
   | Bootstrap

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -107,8 +107,7 @@ let severity_of_approval_event (event : Keeper_approval.Audit.event)
          out as a rejection. *)
       match decision_kind with
       | Some Keeper_approval.Audit.Decision_reject -> "bad"
-      | Some (Keeper_approval.Audit.Decision_approve | Decision_edit) | None ->
-          "ok")
+      | Some Keeper_approval.Audit.Decision_approve | None -> "ok")
 
 let tool_call_timeline_event json =
   match json_float_opt_member "ts" json, json_string_opt_member "tool" json with

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -36,7 +36,7 @@ let pending_hitl_approval_counts config =
     |> List.filter_map (fun name ->
          let pending_count =
            List.fold_left
-             (fun count (entry : Keeper_approval_queue.pending_approval) ->
+             (fun count (entry : Keeper_approval_queue_rules_types.pending_approval) ->
                 if String.equal entry.keeper_name name
                 then count + 1
                 else count)

--- a/lib/keeper_approval/audit.ml
+++ b/lib/keeper_approval/audit.ml
@@ -399,7 +399,7 @@ let audit_scan_window ?keeper_name n =
 
 let record_audit_read_failure ?keeper_name ?(metric_site = Keeper_approval_queue_failure_site.Audit_read_recent) ~site exn =
   Keeper_fd_pressure.note_exception ~site exn;
-  Otel_metric_store.inc_counter
+  Otel_metric_store_core.inc_counter
     Keeper_metrics.(to_string ApprovalQueueFailures)
     ~labels:
       [ "keeper",

--- a/lib/keeper_approval/audit.ml
+++ b/lib/keeper_approval/audit.ml
@@ -189,19 +189,16 @@ let event_of_string = function
 type decision_kind =
   | Decision_approve
   | Decision_reject
-  | Decision_edit
 
 let decision_kind_to_string = function
   | Decision_approve -> "approve"
   | Decision_reject -> "reject"
-  | Decision_edit -> "edit"
 ;;
 
 let decision_kind_of_string value =
   match String.trim value with
   | "approve" -> Some Decision_approve
   | "reject" -> Some Decision_reject
-  | "edit" -> Some Decision_edit
   | _ -> None
 ;;
 
@@ -213,7 +210,6 @@ let non_empty_reason reason =
 let approval_decision_kind_and_reason = function
   | Decision.Approve -> Decision_approve, None
   | Decision.Reject reason -> Decision_reject, non_empty_reason reason
-  | Decision.Edit _ -> Decision_edit, None
 ;;
 
 let keeper_audit_metric_label = function

--- a/lib/keeper_approval/audit.mli
+++ b/lib/keeper_approval/audit.mli
@@ -23,7 +23,6 @@ val event_of_string : string -> event option
 type decision_kind =
   | Decision_approve
   | Decision_reject
-  | Decision_edit
 
 val decision_kind_to_string : decision_kind -> string
 val decision_kind_of_string : string -> decision_kind option

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -121,7 +121,6 @@ module Decision = struct
   type t =
     | Approve
     | Reject of string
-    | Edit of Yojson.Safe.t
 end
 
 type decision = Decision.t
@@ -184,7 +183,6 @@ let advisory_judgment_of_string = function
 let approval_decision_to_string = function
   | Decision.Approve -> "approve"
   | Decision.Reject reason -> "reject:" ^ reason
-  | Decision.Edit _ -> "edit"
 ;;
 
 let decision_source_to_string = function

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -121,7 +121,6 @@ module Decision : sig
   type t =
     | Approve
     | Reject of string
-    | Edit of Yojson.Safe.t
 end
 
 type decision = Decision.t

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -104,7 +104,6 @@ and fusion_terminal =
 and hitl_resolution_decision =
   | Hitl_approved
   | Hitl_rejected of string
-  | Hitl_edited of Yojson.Safe.t
 
 and hitl_resolution = {
   approval_id : string;
@@ -192,7 +191,6 @@ let task_cancellation_post_id (cancellation : task_cancellation) =
 let hitl_resolution_decision_to_string = function
   | Hitl_approved -> "approve"
   | Hitl_rejected _ -> "reject"
-  | Hitl_edited _ -> "edit"
 
 type stimulus = {
   post_id : post_id;
@@ -544,8 +542,7 @@ let payload_to_yojson = function
        @
        match r.decision with
        | Hitl_approved -> []
-       | Hitl_rejected rationale -> [ "rationale", `String rationale ]
-       | Hitl_edited input -> [ "edited_input", input ])
+       | Hitl_rejected rationale -> [ "rationale", `String rationale ])
   | Manual_compaction_requested ->
     `Assoc [ "kind", `String "manual_compaction_requested" ]
   | Goal_assigned ga ->
@@ -712,9 +709,6 @@ let payload_of_yojson json =
       | "reject" ->
         let* rationale = string_field ~context "rationale" fields in
         Ok (Hitl_rejected rationale)
-      | "edit" ->
-        let* input = required_field ~context "edited_input" fields in
-        Ok (Hitl_edited input)
       | other -> Error (Printf.sprintf "unknown hitl_resolution decision: %s" other)
     in
     let* channel = continuation_channel_field fields in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -141,7 +141,6 @@ and fusion_terminal =
 and hitl_resolution_decision =
   | Hitl_approved
   | Hitl_rejected of string
-  | Hitl_edited of Yojson.Safe.t
 
 and hitl_resolution = {
   approval_id : string;

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -342,8 +342,8 @@ let approval_resolve_decision_name = function
 ;;
 
 let approval_resolve_decision_to_queue_decision = function
-  | Approval_resolve_approve -> Keeper_approval_queue.Decision.Approve
-  | Approval_resolve_reject reason -> Keeper_approval_queue.Decision.Reject reason
+  | Approval_resolve_approve -> Keeper_approval_queue_rules_types.Decision.Approve
+  | Approval_resolve_reject reason -> Keeper_approval_queue_rules_types.Decision.Reject reason
 ;;
 
 let approval_resolve_decision_of_json args =
@@ -463,7 +463,7 @@ let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe
   let* input_hash_json = required "input_hash" in
   let* expected_input_hash =
     match input_hash_json with
-    | `String value when Keeper_approval_queue.is_lowercase_sha256 value ->
+    | `String value when Keeper_approval_queue_rules_types.is_lowercase_sha256 value ->
       Ok value
     | _ -> Error "retry request.input_hash must be a lowercase SHA-256"
   in
@@ -475,20 +475,20 @@ let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe
   in
   let* exact_attempt_json = required "exact_attempt" in
   let* expected_exact_attempt =
-    Keeper_approval_queue.exact_attempt_state_of_yojson_with_error
+    Keeper_approval_queue_rules_types.exact_attempt_state_of_yojson_with_error
       exact_attempt_json
   in
   let* disposition_json = required "summary_attempt_disposition" in
   let* expected_disposition =
-    Keeper_approval_queue.summary_attempt_disposition_of_yojson_with_error
+    Keeper_approval_queue_rules_types.summary_attempt_disposition_of_yojson_with_error
       disposition_json
   in
   let* () =
     match expected_disposition with
-    | Keeper_approval_queue.Summary_attempt_identity_unbound
-    | Keeper_approval_queue.Summary_attempt_persistence_uncertain ->
+    | Keeper_approval_queue_rules_types.Summary_attempt_identity_unbound
+    | Keeper_approval_queue_rules_types.Summary_attempt_persistence_uncertain ->
       Ok ()
-    | Keeper_approval_queue.Summary_attempt_pre_worker_unavailable _ ->
+    | Keeper_approval_queue_rules_types.Summary_attempt_pre_worker_unavailable _ ->
       Ok ()
     | _ -> Error "retry request disposition is not operator-rearmable"
   in
@@ -512,7 +512,7 @@ let dashboard_gate_rule_delete_http_json ~base_path ~(args : Yojson.Safe.t)
   match Safe_ops.json_string_opt "id" args with
   | None -> Error "id is required"
   | Some id ->
-    (match Keeper_approval_queue.delete_rule ~base_path ~id () with
+    (match Keeper_approval_queue_rules.delete_rule ~base_path ~id () with
      | Ok deleted ->
          Keeper_approval.Audit.record_rule
            ~base_path
@@ -520,7 +520,7 @@ let dashboard_gate_rule_delete_http_json ~base_path ~(args : Yojson.Safe.t)
            deleted;
          Ok (`Assoc [ "ok", `Bool true; "id", `String deleted.id ])
        | Error error ->
-         Error (Keeper_approval_queue.rule_store_error_to_string error))
+         Error (Keeper_approval_queue_rules_types.rule_store_error_to_string error))
 ;;
 
 let dashboard_schedule_prune_http_json

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -464,9 +464,9 @@ let turn_admission_rows ~base_path keeper_name =
 
 let hitl_rows keeper_name pending =
   pending
-  |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+  |> List.filter (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
     String.equal entry.keeper_name keeper_name)
-  |> List.map (fun (entry : Keeper_approval_queue.pending_approval) ->
+  |> List.map (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
     { keeper_name = Some keeper_name
     ; source = Hitl_pending
     ; waiting_on = entry.tool_name
@@ -478,10 +478,10 @@ let hitl_rows keeper_name pending =
         `Assoc
           [ "approval_id", `String entry.id
           ; "tool_name", `String entry.tool_name
-          ; "summary_status", Keeper_approval_queue.summary_status_to_yojson entry.summary_status
-          ; "exact_attempt", Keeper_approval_queue.exact_attempt_state_to_yojson entry.exact_attempt
+          ; "summary_status", Keeper_approval_queue_rules_types.summary_status_to_yojson entry.summary_status
+          ; "exact_attempt", Keeper_approval_queue_rules_types.exact_attempt_state_to_yojson entry.exact_attempt
           ; ( "summary_attempt_disposition"
-            , Keeper_approval_queue.summary_attempt_disposition_to_yojson
+            , Keeper_approval_queue_rules_types.summary_attempt_disposition_to_yojson
                 entry.summary_attempt_disposition )
           ; "turn_id", Json_util.int_opt_to_json entry.turn_id
           ; "task_id", Json_util.string_opt_to_json entry.task_id

--- a/lib/server_keeper_waiting_inventory.mli
+++ b/lib/server_keeper_waiting_inventory.mli
@@ -13,7 +13,7 @@ module For_testing : sig
   val dashboard_json_with_pending_reader :
     read_pending:
       (base_path:string ->
-      ( Keeper_approval_queue.pending_approval list
+      ( Keeper_approval_queue_rules_types.pending_approval list
       , Keeper_approval_queue.storage_error )
       result) ->
     Workspace.config ->

--- a/lib/tool_surface/tool_shard_types_schemas_base.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_base.ml
@@ -10,7 +10,12 @@ let base_tools : Masc_domain.tool_schema list =
     ; description =
         "Get current server time. Returns now_iso (ISO8601) and now_unix (float). Use to \
          timestamp events, check elapsed time, or include current time in reports."
-    ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc []
+          ; "additionalProperties", `Bool false
+          ]
     }
   ; (* Context status *)
     { name = "keeper_context_status"
@@ -23,7 +28,12 @@ let base_tools : Masc_domain.tool_schema list =
          passed directly as path or cwd to keeper tools without prefix. Use when checking \
          checkpoint/session continuity or resolving a path without string-interpolating \
          your own keeper name."
-    ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc []
+          ; "additionalProperties", `Bool false
+          ]
     }
   ; (* Memory *)
     { name = "keeper_memory_search"
@@ -123,7 +133,12 @@ let base_tools : Masc_domain.tool_schema list =
          the limitation if a connector-wide registry is unavailable. Returns tool names \
          organized by category plus descriptor_surface metadata with executor, \
          schema-shape, and typed usage examples."
-    ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc []
+          ; "additionalProperties", `Bool false
+          ]
     }
   ]
 ;;

--- a/lib/unified_tool_registry.ml
+++ b/lib/unified_tool_registry.ml
@@ -132,17 +132,25 @@ let register_visible_raw_schemas () =
            invalid_arg
              ("visible tool schema has no exact dispatch owner: " ^ schema.name))
 
-(** 2. Register each descriptor's internal handler name with the schema owned
-    by that descriptor. Model aliases are canonicalised before dispatch and
-    never receive fabricated placeholder schemas. *)
+(** 2. Register each descriptor's internal handler name with its exact runtime
+    schema.  [Config.raw_all_tool_schemas] owns translated runtime shapes;
+    descriptor schemas remain the model-facing, pre-translation contract. *)
 let register_descriptor_handlers () =
   Keeper_tool_descriptor.all_descriptors ()
   |> List.iter (fun (descriptor : Keeper_tool_descriptor.t) ->
-         let schema : Masc_domain.tool_schema =
-           { name = descriptor.internal_name
-           ; description = descriptor.description
-           ; input_schema = descriptor.input_schema
-           }
+         let schema =
+           match
+             List.find_opt
+               (fun (schema : Masc_domain.tool_schema) ->
+                  String.equal schema.name descriptor.internal_name)
+               Config.raw_all_tool_schemas
+           with
+           | Some schema -> schema
+           | None ->
+             { Masc_domain.name = descriptor.internal_name
+             ; description = descriptor.description
+             ; input_schema = descriptor.input_schema
+             }
          in
          register_canonical_schema
            schema

--- a/lib/unified_tool_registry.ml
+++ b/lib/unified_tool_registry.ml
@@ -110,11 +110,14 @@ let tag_of_name name : TD.module_tag option =
        | None -> None)
     | _ :: _ :: _ -> invalid_arg ("duplicate tool descriptors for " ^ name)
 
-(** Register a tag + schema only if the name is not already in the tag
-    registry. Existing [Tool_spec] registrations are preserved. *)
-let register_schema_if_missing (schema : Masc_domain.tool_schema) tag =
-  if Option.is_none (TD.lookup_tag schema.name)
-  then TD.register_module_tag ~schemas:[ schema ] ~tag
+(** Register the canonical schema while preserving an existing precise tag. *)
+let register_canonical_schema (schema : Masc_domain.tool_schema) default_tag =
+  let tag =
+    match TD.lookup_tag schema.name with
+    | Some registered_tag -> registered_tag
+    | None -> default_tag
+  in
+  TD.register_module_tag ~schemas:[ schema ] ~tag
 
 (** 1. Register every LLM-visible schema from [Config.raw_all_tool_schemas]
     that does not already have a tag. *)
@@ -124,7 +127,7 @@ let register_visible_raw_schemas () =
        if Tool_catalog.is_visible schema.name
        then
          match tag_of_name schema.name with
-         | Some tag -> register_schema_if_missing schema tag
+         | Some tag -> register_canonical_schema schema tag
          | None ->
            invalid_arg
              ("visible tool schema has no exact dispatch owner: " ^ schema.name))
@@ -141,7 +144,7 @@ let register_descriptor_handlers () =
            ; input_schema = descriptor.input_schema
            }
          in
-         register_schema_if_missing
+         register_canonical_schema
            schema
            (tag_of_runtime_handler descriptor.runtime_handler))
 

--- a/packages/agent_core/test/test_builder.ml
+++ b/packages/agent_core/test/test_builder.ml
@@ -283,6 +283,9 @@ let exact_provider_config () =
     { Llm_provider.Capabilities.openai_compat_chat_capabilities with
       supports_tools = true
     ; supports_structured_output = true
+    ; supports_top_k = true
+    ; supports_min_p = true
+    ; supports_seed = true
     }
   in
   Llm_provider.Provider_config.make

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -87,15 +87,8 @@ fi
 
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
-# 714 -> 710: this PR wires test_tool_input_validation, and #27429,
-# #27433 and #27441 each wired a suite test/dune already declared without
-# lowering this number. Measured on the merged tree after all four, not
-# computed -- #27441 landed between this branch's first push and now.
-# 708 -> 706: this branch wires test_keeper_catchup_digest and #27525 wired
-# test_tool_workspace_coverage while it was open. Measured on the merged tree --
-# the audit reported "706 unwired, 707 baseline" so 707 would have passed while
-# leaving the ratchet a notch loose.
-UNWIRED_BASELINE=706
+# Exact current count. Adding an unwired suite is a regression.
+UNWIRED_BASELINE=702
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then
@@ -112,11 +105,8 @@ if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then
   exit 2
 fi
 
-# Below the baseline is an improvement, not a defect, so it reports and passes.
-# Failing here made every suite-wiring PR turn main red until someone edited
-# this number: 748 went red, #27181 set 747, and 746 was red again within the
-# hour. scripts/ocaml-structure-ratchet.sh already treats its own drift-down
-# this way ("baseline can be lowered", exit 0); this now matches it.
+# A lower count is accepted so the exact baseline can be tightened in the same
+# change that wires more current suites.
 if [ "$unwired" -lt "$UNWIRED_BASELINE" ]; then
   echo "[ci-test-targets] OK - ${unwired} suites unwired, ${UNWIRED_BASELINE} baseline — lower UNWIRED_BASELINE in $0 to hold the gain"
 else

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -534,25 +534,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-# The count `--exports` reports, frozen so it can only fall. Not a target of
-# zero: the docstring above lists five categories where unreachable is not
-# removable, so some of this number is load-bearing and the audit cannot tell
-# which. What the ratchet buys is that the number stops growing while nobody is
-# looking.
-#
-# Lower it in the PR that earns the reduction. Raising it needs a reason in the
-# PR body -- a new export with no caller is usually a surface someone meant to
-# wire and did not.
-# 658 -> 585: batch 4 removes 73 exports with no consumer. Measured on the
-# merged tree after main's batch-1..3 landed, not computed from the batch
-# size -- the merge also dropped should_use_dict, which lost its last
-# caller when batch 1 removed the dictionary helpers around it.
-# Unchanged at 561: workspace_recommendations had a caller
-# (operator_control_snapshot.ml), so it was never counted as a dead export.
-# Removing a live export and its only call site leaves the dead count where it
-# was. Measured with --exports on the merged tree -- 563 - 1 assumed the export
-# was dead, and it was not.
-DEAD_EXPORT_BASELINE = 556
+# Exact current count. The audit's documented categories explain why every
+# reported entry is not mechanically removable; the ratchet still forbids
+# adding another dead public export.
+DEAD_EXPORT_BASELINE = 551
 
 
 def run_ratchet(count: int) -> int:

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -185,7 +185,8 @@ if require_ok "$r10" \
   && [[ "$r10" == *"$task_id"* ]] \
   && { [[ "$r10" == *"awaiting_verification"* ]] || [[ "$r10" == *"in_progress"* ]]; } \
   && [[ "$r10" == *"$AGENT_NAME"* ]]; then
-  CLEANUP_TASK_FINALIZED=1
+  # Submission is not terminal. Keep EXIT cleanup armed so a verifier rejection
+  # cannot leak this producer-owned task into the next contract scenario.
   step_pass
 else
   step_fail "post-submission projection did not retain producer credit"

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -324,16 +324,17 @@ next_step "masc_transition submit for verification"
 r_submitted="$(call_tool 5037 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" --arg notes "$done_notes" --arg summary "$done_summary" --arg evidence_ref "$evidence_ref" '{task_id:$task_id,agent_name:$agent_name,action:"submit_for_verification",notes:$notes,handoff_context:{summary:$summary,evidence_refs:[$evidence_ref]}}')")"
 expect_ok "masc_transition submit for verification" "$r_submitted"
 
-next_step "masc_tasks awaiting-verification producer credit"
-r_awaiting="$(call_tool 5038 "masc_tasks" '{"status":"awaiting_verification"}')"
+next_step "masc_tasks post-submission producer credit"
+r_awaiting="$(call_tool 5038 "masc_tasks" '{}')"
 if response_tool_ok "$r_awaiting" \
   && [[ "$r_awaiting" == *"$task_id"* ]] \
-  && [[ "$r_awaiting" == *"awaiting_verification"* ]] \
+  && { [[ "$r_awaiting" == *"awaiting_verification"* ]] \
+    || [[ "$r_awaiting" == *"in_progress"* ]]; } \
   && [[ "$r_awaiting" == *"$AGENT_NAME"* ]]; then
-  echo "  PASS: masc_tasks awaiting-verification producer credit"
+  echo "  PASS: masc_tasks post-submission producer credit"
 else
   mcp_fail_with_context \
-    "masc_tasks: AwaitingVerification projection did not retain producer credit" \
+    "masc_tasks: post-submission projection did not retain producer credit" \
     "$r_awaiting"
 fi
 # Awaiting verification is nonterminal. EXIT cleanup must release this task even

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -336,6 +336,7 @@ else
     "masc_tasks: AwaitingVerification projection did not retain producer credit" \
     "$r_awaiting"
 fi
-CLEANUP_TASK_FINALIZED=1
+# Awaiting verification is nonterminal. EXIT cleanup must release this task even
+# after a successful sweep so later harnesses do not inherit producer ownership.
 
 echo "PASS: public MCP tool live sweep"

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -32,6 +32,7 @@ module Shutdown_finalize = Masc.Keeper_shutdown_finalize
 module Shutdown_runtime = Masc.Keeper_shutdown_runtime
 module Shutdown_supersession = Masc.Keeper_shutdown_supersession
 module Approval_queue = Masc.Keeper_approval_queue
+module Approval_types = Keeper_approval_queue_rules_types
 module Turn_up_args = Masc.Keeper_turn_up_args
 module Turn_up_update = Masc.Keeper_turn_up_update
 module Keeper_meta_contract = Masc.Keeper_meta_contract
@@ -2658,7 +2659,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
               ~keeper_name:meta.name)
              .snapshot_shutdown_operation_id);
       (match Approval_queue.For_testing.get_pending_entry_unchecked ~id:approval_id with
-       | Some { summary_status = Approval_queue.Summary_pending; _ } -> ()
+       | Some { summary_status = Approval_types.Summary_pending; _ } -> ()
        | Some _ | None -> fail "retain-meta shutdown changed pending summary");
       match Keeper_meta_store.read_meta config meta.name with
       | Ok (Some retained) ->
@@ -2796,7 +2797,7 @@ let test_destructive_shutdown_drains_bound_summary_then_completes () =
                  ~call_id:"shutdown-call"
                  ~plan_fingerprint:(String.make 64 'p')
                  ~request_body_sha256:(String.make 64 'a')
-                 ~cause:Approval_queue.Exact_flow_execution_failed
+                 ~cause:Approval_types.Exact_flow_execution_failed
              with
              | Ok _ -> ()
              | Error error ->

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -4,6 +4,7 @@ module EO = Agent_sdk.Exact_output
 module F = Compaction_exact_output_fixture
 module Gate = Masc.Keeper_gate
 module Q = Masc.Keeper_approval_queue
+module QT = Keeper_approval_queue_rules_types
 module Schema = Masc.Keeper_structured_output_schema
 module Worker = Masc.Hitl_summary_worker
 
@@ -272,7 +273,7 @@ let test_parse_typed_judgments () =
          | Error reason -> fail reason
        in
        check bool wire true (summary.judgment = expected))
-    [ "approve", Q.Approve; "deny", Q.Deny; "require_human", Q.Require_human ]
+    [ "approve", QT.Approve; "deny", QT.Deny; "require_human", QT.Require_human ]
 ;;
 
 let test_invalid_judgment_fails_loud () =
@@ -493,9 +494,9 @@ let test_flow_order_completion_and_replay () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
         | Some
             { exact_attempt =
-                Q.Exact_bound
-                  { slot_id = "hitl-first"; status = Q.Exact_completed; _ }
-            ; summary_status = Q.Summary_available _
+                QT.Exact_bound
+                  { slot_id = "hitl-first"; status = QT.Exact_completed; _ }
+            ; summary_status = QT.Summary_available _
             ; _
             } ->
           ()
@@ -565,8 +566,8 @@ let test_predispatch_failure_advances_only_to_oas_successor () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
-                 { slot_id = "hitl-successor"; status = Q.Exact_completed; _ }
+               QT.Exact_bound
+                 { slot_id = "hitl-successor"; status = QT.Exact_completed; _ }
            ; _
            } ->
          ()
@@ -642,12 +643,12 @@ let test_cancellation_between_candidates_terminalizes_released_identity () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
+               QT.Exact_bound
                  { slot_id = "hitl-cancel-between-unreachable"
-                 ; status = Q.Exact_quarantined Q.Exact_cancellation
+                 ; status = QT.Exact_quarantined QT.Exact_cancellation
                  ; _
                  }
-           ; summary_attempt_disposition = Q.Summary_attempt_settled
+           ; summary_attempt_disposition = QT.Summary_attempt_settled
            ; _
            } ->
          ()
@@ -735,10 +736,10 @@ let test_json_syntax_candidate_is_admitted_without_structured_capability () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
-                 { status = Q.Exact_quarantined Q.Exact_flow_execution_failed; _ }
-           ; summary_status = Q.Summary_failed _
-           ; summary_attempt_disposition = Q.Summary_attempt_settled
+               QT.Exact_bound
+                 { status = QT.Exact_quarantined QT.Exact_flow_execution_failed; _ }
+           ; summary_status = QT.Summary_failed _
+           ; summary_attempt_disposition = QT.Summary_attempt_settled
            ; _
            } ->
          ()
@@ -779,9 +780,9 @@ let test_visible_bind_blocks_dispatch () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
+               QT.Exact_bound
                  { status =
-                     Q.Exact_quarantined Q.Exact_terminal_persistence_failure
+                     QT.Exact_quarantined QT.Exact_terminal_persistence_failure
                  ; _
                  }
            ; _
@@ -827,9 +828,9 @@ let test_visible_advance_blocks_successor () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
+               QT.Exact_bound
                  { status =
-                     Q.Exact_quarantined Q.Exact_terminal_persistence_failure
+                     QT.Exact_quarantined QT.Exact_terminal_persistence_failure
                  ; _
                  }
            ; _
@@ -880,8 +881,8 @@ let test_visible_completion_blocks_gate_delivery () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound { status = Q.Exact_completed; _ }
-           ; summary_status = Q.Summary_available _
+               QT.Exact_bound { status = QT.Exact_completed; _ }
+           ; summary_status = QT.Summary_available _
            ; _
            } ->
          ()
@@ -901,8 +902,8 @@ let test_visible_completion_blocks_gate_delivery () =
        check int "restart did not dispatch successor" 1 (F.post_count server);
        (match Q.For_testing.get_pending_entry_unchecked ~id:successor.id with
         | Some
-            { exact_attempt = Q.Exact_unbound
-            ; summary_status = Q.Summary_pending
+            { exact_attempt = QT.Exact_unbound
+            ; summary_status = QT.Summary_pending
             ; _
             } ->
           ()
@@ -937,7 +938,7 @@ let test_completion_identity_conflict_stays_deterministic () =
        let replacement_call_id = "replacement-call" in
        let replace_bound_identity () =
          match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
-         | Some { exact_attempt = Q.Exact_bound binding; _ } ->
+         | Some { exact_attempt = QT.Exact_bound binding; _ } ->
            let transition_exn operation = function
              | Ok { Q.write_outcome = Q.Fsync_completed; _ } -> ()
              | Ok { Q.write_outcome = Q.Visible_sync_unconfirmed detail; _ } ->
@@ -966,7 +967,7 @@ let test_completion_identity_conflict_stays_deterministic () =
              ~plan_fingerprint:(String.make 64 'a')
              ~request_body_sha256:(String.make 64 'b')
            |> transition_exn "bind replacement identity"
-         | Some { exact_attempt = Q.Exact_unbound; _ } ->
+         | Some { exact_attempt = QT.Exact_unbound; _ } ->
            fail "after_bind observed an unbound exact attempt"
          | None -> fail "after_bind lost the pending approval"
        in
@@ -999,9 +1000,9 @@ let test_completion_identity_conflict_stays_deterministic () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound { call_id; status = Q.Exact_dispatch_uncertain; _ }
-           ; summary_status = Q.Summary_pending
-           ; summary_attempt_disposition = Q.Summary_attempt_in_flight
+               QT.Exact_bound { call_id; status = QT.Exact_dispatch_uncertain; _ }
+           ; summary_status = QT.Summary_pending
+           ; summary_attempt_disposition = QT.Summary_attempt_in_flight
            ; _
            } ->
          check string
@@ -1042,14 +1043,14 @@ let test_flow_execution_failure_quarantines_and_allows_successor () =
         | Some
             { input_hash
             ; sequence
-            ; summary_status = Q.Summary_failed { reason }
+            ; summary_status = QT.Summary_failed { reason }
             ; exact_attempt =
-                Q.Exact_bound
+                QT.Exact_bound
                   { slot_id
                   ; call_id
                   ; plan_fingerprint
                   ; request_body_sha256
-                  ; status = Q.Exact_quarantined Q.Exact_flow_execution_failed
+                  ; status = QT.Exact_quarantined QT.Exact_flow_execution_failed
                   ; _
                   }
             ; _
@@ -1111,7 +1112,7 @@ let test_manual_resolution_race_is_conclusive () =
        install_queue base_path;
        Prompt_registry.set_markdown_dir
          (Masc_test_deps.source_path "config/prompts");
-       let in_flight_entry : Q.pending_approval option ref = ref None in
+       let in_flight_entry : QT.pending_approval option ref = ref None in
        let server =
          F.start_server
            ~on_request_before_reply:(fun () ->
@@ -1122,7 +1123,7 @@ let test_manual_resolution_race_is_conclusive () =
                   Q.resolve_with_policy
                     ~base_path
                     ~id:entry.id
-                    ~decision:(Q.Decision.Reject "manual operator resolution")
+                    ~decision:(QT.Decision.Reject "manual operator resolution")
                     ()
                 with
                 | Ok _ -> ()
@@ -1215,8 +1216,8 @@ let test_cancellation_after_dispatch_is_terminal () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
-                 { status = Q.Exact_quarantined Q.Exact_cancellation; _ }
+               QT.Exact_bound
+                 { status = QT.Exact_quarantined QT.Exact_cancellation; _ }
            ; _
            } ->
          ()
@@ -1402,19 +1403,19 @@ let test_prebind_cancellation_withholds_production_gate_drain () =
               (F.post_count server);
             (match Q.For_testing.get_pending_entry_unchecked ~id:cancelled.id with
              | Some
-                 { exact_attempt = Q.Exact_unbound
-                 ; summary_status = Q.Summary_pending
+                 { exact_attempt = QT.Exact_unbound
+                 ; summary_status = QT.Summary_pending
                  ; summary_attempt_disposition =
-                     Q.Summary_attempt_identity_unbound
+                     QT.Summary_attempt_identity_unbound
                  ; _
                  } ->
                ()
              | _ -> fail "Gate drained or mutated the cancelled pending entry");
             match Q.For_testing.get_pending_entry_unchecked ~id:successor.id with
             | Some
-                { exact_attempt = Q.Exact_unbound
-                ; summary_status = Q.Summary_pending
-                ; summary_attempt_disposition = Q.Summary_attempt_ready
+                { exact_attempt = QT.Exact_unbound
+                ; summary_status = QT.Summary_pending
+                ; summary_attempt_disposition = QT.Summary_attempt_ready
                 ; _
                 } ->
               ()
@@ -1512,8 +1513,8 @@ let test_bound_cancellation_cleanup_uncertainty_preserves_origin () =
               (F.post_count server);
             match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
             | Some
-                { exact_attempt = Q.Exact_bound _
-                ; summary_status = Q.Summary_pending
+                { exact_attempt = QT.Exact_bound _
+                ; summary_status = QT.Summary_pending
                 ; _
                 } ->
               ()
@@ -1547,12 +1548,12 @@ let test_pre_worker_start_failure_preserves_unbound_pending () =
         | Ok _ -> fail "pre-worker failure was reported as a successful start");
        (match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
-           { exact_attempt = Q.Exact_unbound
-           ; summary_status = Q.Summary_pending
+           { exact_attempt = QT.Exact_unbound
+           ; summary_status = QT.Summary_pending
            ; summary_attempt_disposition =
-               Q.Summary_attempt_pre_worker_unavailable
+               QT.Summary_attempt_pre_worker_unavailable
                  { reason_code =
-                     Q.Summary_pre_worker_auto_judge_unavailable
+                     QT.Summary_pre_worker_auto_judge_unavailable
                  ; operator_detail = "no usable exact-output lane slots"
                  }
            ; _
@@ -1633,18 +1634,18 @@ let test_visible_uncertainty_withholds_production_drain () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:uncertain.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound { status = Q.Exact_completed; _ }
-           ; summary_status = Q.Summary_available _
+               QT.Exact_bound { status = QT.Exact_completed; _ }
+           ; summary_status = QT.Summary_available _
            ; summary_attempt_disposition =
-               Q.Summary_attempt_persistence_uncertain
+               QT.Summary_attempt_persistence_uncertain
            ; _
            } ->
          ()
        | _ -> fail "uncertain completion did not remain durably visible");
        (match Q.For_testing.get_pending_entry_unchecked ~id:successor.id with
         | Some
-            { exact_attempt = Q.Exact_unbound
-            ; summary_status = Q.Summary_pending
+            { exact_attempt = QT.Exact_unbound
+            ; summary_status = QT.Summary_pending
             ; _
             } ->
           ()
@@ -1716,8 +1717,8 @@ let test_owner_fifo_atomic_drain_is_nonsharing () =
          (F.post_count server);
        (match Q.For_testing.get_pending_entry_unchecked ~id:second.id with
         | Some
-            { exact_attempt = Q.Exact_unbound
-            ; summary_status = Q.Summary_pending
+            { exact_attempt = QT.Exact_unbound
+            ; summary_status = QT.Summary_pending
             ; _
             } ->
           ()
@@ -1802,10 +1803,10 @@ let test_require_human_head_does_not_stop_owner_drain () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:head.id with
         | Some
             { exact_attempt =
-                Q.Exact_bound { status = Q.Exact_completed; _ }
+                QT.Exact_bound { status = QT.Exact_completed; _ }
             ; summary_status =
-                Q.Summary_available { judgment = Q.Require_human; _ }
-            ; summary_attempt_disposition = Q.Summary_attempt_settled
+                QT.Summary_available { judgment = QT.Require_human; _ }
+            ; summary_attempt_disposition = QT.Summary_attempt_settled
             ; _
             } ->
           ()
@@ -1834,13 +1835,13 @@ let test_judge_effect_prompt_comes_from_registry () =
    Both arms are pinned here because the decision is now a named function and
    the outcome type has a variant for each. *)
 
-let summary_fixture () : Q.hitl_context_summary =
-  { summary_version = Q.current_hitl_context_summary_version
+let summary_fixture () : QT.hitl_context_summary =
+  { summary_version = QT.current_hitl_context_summary_version
   ; generated_at = 1000.0
   ; model_run_id = "run-fixture"
   ; context_summary = "context"
   ; key_questions = [ "q1" ]
-  ; judgment = Q.Approve
+  ; judgment = QT.Approve
   ; rationale = "because"
   }
 ;;

--- a/test/test_keeper_approval_audit_timeline.ml
+++ b/test/test_keeper_approval_audit_timeline.ml
@@ -13,7 +13,7 @@
     agree. These cases pin what that agreement renders — in particular that the
     success path and the failure path are no longer the same event. *)
 
-module Q = Masc.Keeper_approval_queue
+module Q = Keeper_approval_queue_rules_types
 module Audit = Keeper_approval.Audit
 module Timeline = Masc.Keeper_runtime_trust_timeline
 open Alcotest

--- a/test/test_keeper_approval_audit_timeline.ml
+++ b/test/test_keeper_approval_audit_timeline.ml
@@ -147,12 +147,7 @@ let test_resolution_reads_the_decision_kind () =
     (option string)
     "approve"
     (Some "ok")
-    (field "severity" (rendered ~decision_kind:Audit.Decision_approve Audit.Resolved));
-  check
-    (option string)
-    "edit"
-    (Some "ok")
-    (field "severity" (rendered ~decision_kind:Audit.Decision_edit Audit.Resolved))
+    (field "severity" (rendered ~decision_kind:Audit.Decision_approve Audit.Resolved))
 ;;
 
 (* The old reader scanned the rendered decision for "reject", so an approval

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1,6 +1,8 @@
 module AQ = Masc.Keeper_approval_queue
+module Rules = Masc.Keeper_approval_queue_rules
+module Rule_types = Keeper_approval_queue_rules_types
 
-let reserve_retry_exact ~base_path (entry : AQ.pending_approval) =
+let reserve_retry_exact ~base_path (entry : Rule_types.pending_approval) =
   AQ.reserve_summary_attempt_retry
     ~base_path
     ~id:entry.id
@@ -139,7 +141,7 @@ let submit ~base_path ~keeper_name ~input =
 ;;
 
 let reject_and_cleanup ~base_path id =
-  match aq_resolve ~base_path ~id ~decision:(AQ.Decision.Reject "test cleanup") with
+  match aq_resolve ~base_path ~id ~decision:(Rule_types.Decision.Reject "test cleanup") with
   | Ok () -> ()
   | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
 ;;
@@ -407,14 +409,14 @@ let expect_summary_rejection label = function
 ;;
 
 let exact_summary ?(context_summary = "Exact attempt summary") model_run_id :
-    AQ.hitl_context_summary
+    Rule_types.hitl_context_summary
   =
   { summary_version = 2
   ; generated_at = Unix.gettimeofday ()
   ; model_run_id
   ; context_summary
   ; key_questions = []
-  ; judgment = AQ.Approve
+  ; judgment = Rule_types.Approve
   ; rationale = "The exact durable attempt supports this judgment."
   }
 ;;
@@ -610,7 +612,7 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
         | None -> Alcotest.fail "pending request missing"
         | Some entry ->
           Alcotest.(check bool) "summary is not started by queue" true
-            (entry.summary_status = AQ.Summary_not_requested);
+            (entry.summary_status = Rule_types.Summary_not_requested);
           Alcotest.check (Alcotest.option yojson)
             "exact outer-turn context"
             (Some request_context)
@@ -682,7 +684,7 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
          |> List.concat_map (fun base_path ->
               AQ.list_pending_entries_for_workspace ~base_path
               |> require_ok "read workspace-local FIFO")
-         |> List.map (fun (entry : AQ.pending_approval) -> entry.id)
+         |> List.map (fun (entry : Rule_types.pending_approval) -> entry.id)
        in
        Alcotest.(check (list string))
          "workspace projections compose deterministic FIFO"
@@ -709,20 +711,20 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
    the oldest for 2416s. *)
 let head_of_line_owner = "head-of-line-owner"
 
-let require_human_summary () : AQ.hitl_context_summary =
-  { summary_version = AQ.current_hitl_context_summary_version
+let require_human_summary () : Rule_types.hitl_context_summary =
+  { summary_version = Rule_types.current_hitl_context_summary_version
   ; generated_at = 1.0
   ; model_run_id = "model-run-head-of-line"
   ; context_summary = "head approval was handed to a human"
   ; key_questions = []
-  ; judgment = AQ.Require_human
+  ; judgment = Rule_types.Require_human
   ; rationale = "operator decision required"
   }
 ;;
 
-let completed_exact_binding (entry : AQ.pending_approval) =
-  AQ.exact_attempt_binding_with_status
-    (AQ.make_exact_attempt_binding
+let completed_exact_binding (entry : Rule_types.pending_approval) =
+  Rule_types.exact_attempt_binding_with_status
+    (Rule_types.make_exact_attempt_binding
        ~approval_id:entry.id
        ~input_hash:entry.input_hash
        ~sequence:entry.sequence
@@ -731,7 +733,7 @@ let completed_exact_binding (entry : AQ.pending_approval) =
        ~plan_fingerprint:"plan-head-of-line"
        ~request_body_sha256:"sha256-head-of-line"
        ())
-    AQ.Exact_completed
+    Rule_types.Exact_completed
 ;;
 
 let check_owner_selection label ~base_path ~expected entries =
@@ -742,7 +744,7 @@ let check_owner_selection label ~base_path ~expected entries =
       entries
   with
   | [ selected ] ->
-    Alcotest.(check string) label expected selected.AQ.id
+    Alcotest.(check string) label expected selected.Rule_types.id
   | [] -> Alcotest.failf "%s: owner selection returned nothing" label
   | selected ->
     Alcotest.failf "%s: expected one entry, got %d" label (List.length selected)
@@ -776,9 +778,9 @@ let test_terminal_head_does_not_stall_owner_queue () =
          [ follower; head ];
        let judged_head =
          { head with
-           AQ.summary_status = AQ.Summary_available (require_human_summary ())
-         ; AQ.summary_attempt_disposition = AQ.Summary_attempt_settled
-         ; AQ.exact_attempt = AQ.Exact_bound (completed_exact_binding head)
+           Rule_types.summary_status = Rule_types.Summary_available (require_human_summary ())
+         ; Rule_types.summary_attempt_disposition = Rule_types.Summary_attempt_settled
+         ; Rule_types.exact_attempt = Rule_types.Exact_bound (completed_exact_binding head)
          }
        in
        check_owner_selection
@@ -788,10 +790,10 @@ let test_terminal_head_does_not_stall_owner_queue () =
          [ judged_head; follower ];
        let blocked_head =
          { head with
-           AQ.summary_status = AQ.Summary_pending
-         ; AQ.summary_attempt_disposition =
-             AQ.Summary_attempt_pre_worker_unavailable
-               { reason_code = AQ.Summary_pre_worker_auto_judge_unavailable
+           Rule_types.summary_status = Rule_types.Summary_pending
+         ; Rule_types.summary_attempt_disposition =
+             Rule_types.Summary_attempt_pre_worker_unavailable
+               { reason_code = Rule_types.Summary_pre_worker_auto_judge_unavailable
                ; operator_detail =
                    "HITL summary: exact outer-turn request context is unavailable"
                }
@@ -944,7 +946,7 @@ let test_delivery_wire_shape_drops_request_context () =
            ~input:(`Assoc [ "target", `String "document" ])
            ()
        in
-       (match aq_resolve ~base_path ~id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id ~decision:Rule_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let open Yojson.Safe.Util in
@@ -997,7 +999,7 @@ let test_resolution_is_durable_and_origin_scoped () =
          AQ.resolve_with_policy
            ~base_path
            ~id
-           ~decision:AQ.Decision.Approve
+           ~decision:Rule_types.Decision.Approve
            ~remember_rule:true
            ~created_by:"operator"
            ()
@@ -1036,16 +1038,16 @@ let test_resolution_is_durable_and_origin_scoped () =
                ~approval_id:id));
        Alcotest.(check bool) "exact remembered request matches" true
          (match
-            AQ.find_matching_rule
+            Rules.find_matching_rule
               ~base_path
               ~keeper_name
               ~tool_name:"external-effect"
               ~input
               ()
           with
-          | Ok (AQ.Rule_match_active _) -> true
-          | Ok (AQ.Rule_match_expired _ | AQ.Rule_match_absent) -> false
-          | Error error -> Alcotest.fail (AQ.rule_store_error_to_string error));
+          | Ok (Rule_types.Rule_match_active _) -> true
+          | Ok (Rule_types.Rule_match_expired _ | Rule_types.Rule_match_absent) -> false
+          | Error error -> Alcotest.fail (Rule_types.rule_store_error_to_string error));
        (match
           AQ.consume_approved_resolution
             ~base_path
@@ -1267,7 +1269,7 @@ let test_remembered_rule_carries_requested_expiry () =
          AQ.resolve_with_policy
            ~base_path
            ~id
-           ~decision:AQ.Decision.Approve
+           ~decision:Rule_types.Decision.Approve
            ~remember_rule:true
            ~rule_expires_at:expires_at
            ~created_by:"operator"
@@ -1287,7 +1289,7 @@ let test_remembered_rule_carries_requested_expiry () =
           AQ.resolve_with_policy
             ~base_path
             ~id
-            ~decision:AQ.Decision.Approve
+            ~decision:Rule_types.Decision.Approve
             ~remember_rule:true
             ~rule_expires_at:expires_at
             ~created_by:"operator"
@@ -1298,8 +1300,8 @@ let test_remembered_rule_carries_requested_expiry () =
           Alcotest.fail
             ("identical expiry re-resolution must be idempotent: "
              ^ AQ.resolve_error_to_string error));
-       match AQ.list_rules ~base_path () with
-       | Error error -> Alcotest.fail (AQ.rule_store_error_to_string error)
+       match Rules.list_rules ~base_path () with
+       | Error error -> Alcotest.fail (Rule_types.rule_store_error_to_string error)
        | Ok [ rule ] ->
          Alcotest.(check (option (float 0.0)))
            "persisted rule carries requested expiry"
@@ -1337,7 +1339,7 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
            ~input
            ()
        in
-       (match aq_resolve ~base_path ~id:approval_id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id:approval_id ~decision:Rule_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
@@ -1492,8 +1494,8 @@ let test_exact_binding_codec_validates_entry_identity () =
          |> List.hd
          |> member "exact_attempt"
        in
-       (match AQ.exact_attempt_state_of_yojson_with_error exact_json with
-        | Ok (AQ.Exact_bound binding) ->
+       (match Rule_types.exact_attempt_state_of_yojson_with_error exact_json with
+        | Ok (Rule_types.Exact_bound binding) ->
           Alcotest.(check string)
             "codec approval identity"
             identity.approval_id_arg
@@ -1516,7 +1518,7 @@ let test_exact_binding_codec_validates_entry_identity () =
        check_exact_update
          "quarantine exact codec fixture"
          true
-         (quarantine_exact identity AQ.Exact_flow_execution_failed);
+         (quarantine_exact identity Rule_types.Exact_flow_execution_failed);
        let quarantined_exact_json =
          read_pending_snapshot ~base_path
          |> member "pending"
@@ -1531,13 +1533,13 @@ let test_exact_binding_codec_validates_entry_identity () =
           |> member "quarantine_cause"
           |> to_string);
        (match
-          AQ.exact_attempt_state_of_yojson_with_error quarantined_exact_json
+          Rule_types.exact_attempt_state_of_yojson_with_error quarantined_exact_json
         with
         | Ok
-            (AQ.Exact_bound
+            (Rule_types.Exact_bound
               { status =
-                  AQ.Exact_quarantined
-                    AQ.Exact_flow_execution_failed
+                  Rule_types.Exact_quarantined
+                    Rule_types.Exact_flow_execution_failed
               ; _
               }) ->
           ()
@@ -1548,7 +1550,7 @@ let test_exact_binding_codec_validates_entry_identity () =
        List.iter
          (fun removed_cause ->
             match
-              AQ.exact_attempt_state_of_yojson_with_error
+              Rule_types.exact_attempt_state_of_yojson_with_error
                 (replace_field
                    "quarantine_cause"
                    (`String removed_cause)
@@ -1564,7 +1566,7 @@ let test_exact_binding_codec_validates_entry_identity () =
          ; "restart_uncertainty"
          ];
        (match
-          AQ.exact_attempt_state_of_yojson_with_error
+          Rule_types.exact_attempt_state_of_yojson_with_error
             (replace_field "call_id" (`String " ") exact_json)
         with
         | Error _ -> ()
@@ -1572,7 +1574,7 @@ let test_exact_binding_codec_validates_entry_identity () =
        List.iter
          (fun (label, hash) ->
             match
-              AQ.exact_attempt_state_of_yojson_with_error
+              Rule_types.exact_attempt_state_of_yojson_with_error
                 (replace_field
                    "request_body_sha256"
                    (`String hash)
@@ -1691,18 +1693,18 @@ let test_exact_attempt_binding_release_and_conflicts () =
          "bound restart is not rearmed"
          false
          (reserve_retry_exact ~base_path (pending_entry_exn id));
-       let quarantine_cause = AQ.Exact_domain_invalid_output in
+       let quarantine_cause = Rule_types.Exact_domain_invalid_output in
        check_exact_update
          "quarantine replacement"
          true
          (quarantine_exact replacement quarantine_cause);
        (match pending_entry_exn id with
-        | { summary_status = AQ.Summary_failed { reason }
+        | { summary_status = Rule_types.Summary_failed { reason }
           ; exact_attempt =
-              AQ.Exact_bound
+              Rule_types.Exact_bound
                 { status =
-                    AQ.Exact_quarantined
-                      AQ.Exact_domain_invalid_output
+                    Rule_types.Exact_quarantined
+                      Rule_types.Exact_domain_invalid_output
                 ; _
                 }
           ; _
@@ -1716,7 +1718,7 @@ let test_exact_attempt_binding_release_and_conflicts () =
          "same quarantine cause is idempotent"
          false
          (quarantine_exact replacement quarantine_cause);
-       (match quarantine_exact replacement AQ.Exact_cancellation with
+       (match quarantine_exact replacement Rule_types.Exact_cancellation with
         | Error
             (AQ.Exact_attempt_rejected
               (AQ.Exact_attempt_status_conflict _)) ->
@@ -1778,9 +1780,9 @@ let test_restart_classifies_uncertain_and_released_recovery () =
          (reserve_retry_exact ~base_path (pending_entry_exn released_id));
        (match pending_entry_exn released_id with
         | { exact_attempt =
-              AQ.Exact_bound
-                { status = AQ.Exact_released_before_dispatch; _ }
-          ; summary_status = AQ.Summary_pending
+              Rule_types.Exact_bound
+                { status = Rule_types.Exact_released_before_dispatch; _ }
+          ; summary_status = Rule_types.Summary_pending
           ; _
           } ->
           ()
@@ -1790,8 +1792,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
        let assert_restart_states label =
          (match pending_entry_exn uncertain_id with
           | { exact_attempt =
-                AQ.Exact_bound
-                  { status = AQ.Exact_restart_quarantined
+                Rule_types.Exact_bound
+                  { status = Rule_types.Exact_restart_quarantined
                   ; slot_id
                   ; call_id
                   ; _
@@ -1811,8 +1813,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
               (label ^ " did not quarantine dispatch-uncertain attempt"));
          match pending_entry_exn released_id with
          | { exact_attempt =
-               AQ.Exact_bound
-                 { status = AQ.Exact_released_recovery_required
+               Rule_types.Exact_bound
+                 { status = Rule_types.Exact_released_recovery_required
                  ; slot_id
                  ; call_id
                  ; _
@@ -1848,8 +1850,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
          true
          (reserve_retry_exact ~base_path (pending_entry_exn released_id));
        (match pending_entry_exn released_id with
-        | { summary_status = AQ.Summary_pending
-          ; exact_attempt = AQ.Exact_unbound
+        | { summary_status = Rule_types.Summary_pending
+          ; exact_attempt = Rule_types.Exact_unbound
           ; _
           } ->
           ()
@@ -1870,8 +1872,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
          true
          (reserve_retry_exact ~base_path (pending_entry_exn bulk_id));
        match pending_entry_exn bulk_id with
-       | { summary_status = AQ.Summary_pending
-         ; exact_attempt = AQ.Exact_unbound
+       | { summary_status = Rule_types.Summary_pending
+         ; exact_attempt = Rule_types.Exact_unbound
          ; _
          } ->
          ()
@@ -1920,9 +1922,9 @@ let test_exact_attempt_completion_is_atomic () =
         | Error error -> Alcotest.fail (AQ.exact_attempt_error_to_string error)
         | Ok _ -> Alcotest.fail "mismatched completion provenance was accepted");
        (match pending_entry_exn id with
-        | { summary_status = AQ.Summary_pending
+        | { summary_status = Rule_types.Summary_pending
           ; exact_attempt =
-              AQ.Exact_bound { status = AQ.Exact_dispatch_uncertain; _ }
+              Rule_types.Exact_bound { status = Rule_types.Exact_dispatch_uncertain; _ }
           ; _
           } ->
           ()
@@ -1933,9 +1935,9 @@ let test_exact_attempt_completion_is_atomic () =
          true
          (complete_exact identity summary);
        (match pending_entry_exn id with
-        | { summary_status = AQ.Summary_available durable_summary
+        | { summary_status = Rule_types.Summary_available durable_summary
           ; exact_attempt =
-              AQ.Exact_bound { status = AQ.Exact_completed; _ }
+              Rule_types.Exact_bound { status = Rule_types.Exact_completed; _ }
           ; _
           } ->
           Alcotest.(check string)
@@ -2006,7 +2008,7 @@ let test_exact_attempt_bind_storage_failure_is_not_success () =
         | Error error -> Alcotest.fail (AQ.exact_attempt_error_to_string error)
         | Ok _ -> Alcotest.fail "failed exact binding persistence reported success");
        match pending_entry_exn id with
-       | { exact_attempt = AQ.Exact_unbound; _ } -> ()
+       | { exact_attempt = Rule_types.Exact_unbound; _ } -> ()
        | _ -> Alcotest.fail "failed exact binding persistence mutated memory")
 ;;
 
@@ -2034,11 +2036,11 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
        in
        let assert_status label id expected =
          match pending_entry_exn id with
-         | { exact_attempt = AQ.Exact_bound { status; _ }; _ } ->
+         | { exact_attempt = Rule_types.Exact_bound { status; _ }; _ } ->
            Alcotest.(check string)
              label
              expected
-             (AQ.exact_attempt_status_to_string status)
+             (Rule_types.exact_attempt_status_to_string status)
          | _ -> Alcotest.failf "%s did not retain an exact binding" label
        in
        let resolved_id =
@@ -2051,7 +2053,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
           AQ.resolve_with_policy
             ~base_path
             ~id:resolved_id
-            ~decision:AQ.Decision.Approve
+            ~decision:Rule_types.Decision.Approve
             ()
         with
         | Ok _ -> ()
@@ -2108,7 +2110,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
             AQ.resolve_with_policy
               ~base_path
               ~id:resolved_id
-              ~decision:AQ.Decision.Approve
+              ~decision:Rule_types.Decision.Approve
               ()
           with
           | Error (AQ.Persistence_failed _) -> ()
@@ -2119,7 +2121,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          AQ.For_testing.reset_runtime_state ();
          ignore (install_exn ~base_path);
          (match pending_entry_exn before_id with
-          | { exact_attempt = AQ.Exact_unbound; _ } -> ()
+          | { exact_attempt = Rule_types.Exact_unbound; _ } -> ()
           | _ -> Alcotest.fail "pre-rename failure mutated exact binding memory");
          let cancel_before_id, cancel_before_identity =
            prepare "cancel-before-rename"
@@ -2162,7 +2164,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
           | Ok _ ->
             Alcotest.fail "pre-rename cancellation reported a write outcome");
          (match pending_entry_exn cancel_before_id with
-          | { exact_attempt = AQ.Exact_unbound; _ } -> ()
+          | { exact_attempt = Rule_types.Exact_unbound; _ } -> ()
           | _ -> Alcotest.fail "pre-rename cancellation mutated exact memory");
          let cancel_after_id, cancel_after_identity =
            prepare "cancel-after-rename"
@@ -2214,8 +2216,8 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
               Alcotest.failf
                 "released binding accepted %s"
                 label)
-         [ "domain-invalid output", AQ.Exact_domain_invalid_output
-         ; "attempt replay", AQ.Exact_attempt_replay
+         [ "domain-invalid output", Rule_types.Exact_domain_invalid_output
+         ; "attempt replay", Rule_types.Exact_attempt_replay
          ];
        assert_status
          "rejected causes preserve release"
@@ -2226,7 +2228,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          true
          (quarantine_exact
             release_identity
-            AQ.Exact_terminal_persistence_failure);
+            Rule_types.Exact_terminal_persistence_failure);
        assert_status "release terminal memory" release_id "quarantined";
        let terminalize_released label cause =
          let id, identity = prepare label in
@@ -2248,8 +2250,8 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
            (quarantine_exact identity cause);
          match pending_entry_exn id with
          | { exact_attempt =
-               AQ.Exact_bound
-                 { status = AQ.Exact_quarantined actual; _ }
+               Rule_types.Exact_bound
+                 { status = Rule_types.Exact_quarantined actual; _ }
            ; _
            } when actual = cause ->
            ()
@@ -2260,10 +2262,10 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
        in
        terminalize_released
          "release-cancellation"
-         AQ.Exact_cancellation;
+         Rule_types.Exact_cancellation;
        terminalize_released
          "release-flow-execution-failed"
-         AQ.Exact_flow_execution_failed;
+         Rule_types.Exact_flow_execution_failed;
        let quarantine_id, quarantine_identity = prepare "quarantine" in
        check_exact_update
          "bind quarantine fixture"
@@ -2281,7 +2283,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
             ~call_id:quarantine_identity.call_id_arg
             ~plan_fingerprint:quarantine_identity.plan_fingerprint_arg
             ~request_body_sha256:quarantine_identity.request_body_sha256_arg
-            ~cause:AQ.Exact_flow_execution_failed);
+            ~cause:Rule_types.Exact_flow_execution_failed);
        assert_status
          "visible quarantine memory"
          quarantine_id
@@ -2291,7 +2293,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          false
          (quarantine_exact
             quarantine_identity
-            AQ.Exact_flow_execution_failed);
+            Rule_types.Exact_flow_execution_failed);
        let complete_id, complete_identity = prepare "complete" in
        check_exact_update
          "bind completion fixture"
@@ -2356,7 +2358,7 @@ let test_exact_completed_restart_requires_fsync_confirmation () =
              ~call_id
              ~plan_fingerprint
              ~request_body_sha256
-             ~summary:(actual_summary : AQ.hitl_context_summary)
+             ~summary:(actual_summary : Rule_types.hitl_context_summary)
          =
          incr observed_calls;
          Alcotest.(check string) "recovery approval identity" id actual_id;
@@ -2418,7 +2420,7 @@ let test_exact_completed_restart_requires_fsync_confirmation () =
           Alcotest.fail
             "deterministic completion rejection lost its typed recovery code");
        (match AQ.For_testing.get_pending_entry_unchecked ~id with
-        | Some { summary_attempt_disposition = AQ.Summary_attempt_settled; _ } ->
+        | Some { summary_attempt_disposition = Rule_types.Summary_attempt_settled; _ } ->
           ()
         | _ ->
           Alcotest.fail
@@ -2542,8 +2544,8 @@ let test_current_snapshot_rejects_unbound_available_summary () =
                      then
                        `Assoc
                          (("summary_status",
-                            AQ.summary_status_to_yojson
-                              (AQ.Summary_available summary))
+                            Rule_types.summary_status_to_yojson
+                              (Rule_types.Summary_available summary))
                           :: List.remove_assoc "summary_status" entry_fields)
                      else entry_json
                    | entry_json -> entry_json)
@@ -2608,7 +2610,7 @@ let test_blocked_disposition_requires_operator_rearm_before_bind () =
         | Error
             (AQ.Exact_attempt_rejected
                (AQ.Exact_attempt_disposition_conflict
-                  { disposition = AQ.Summary_attempt_identity_unbound; _ })) ->
+                  { disposition = Rule_types.Summary_attempt_identity_unbound; _ })) ->
           ()
         | Error error ->
           Alcotest.fail
@@ -2656,11 +2658,11 @@ let test_blocked_disposition_requires_operator_rearm_before_bind () =
          (reserve_retry_exact ~base_path retryable_entry);
        (match AQ.For_testing.get_pending_entry_unchecked ~id with
         | Some
-            { summary_status = AQ.Summary_pending
-            ; exact_attempt = AQ.Exact_unbound
+            { summary_status = Rule_types.Summary_pending
+            ; exact_attempt = Rule_types.Exact_unbound
             ; summary_attempt_disposition =
-                AQ.Summary_attempt_pre_worker_unavailable
-                  { reason_code = AQ.Summary_pre_worker_start_reserved
+                Rule_types.Summary_attempt_pre_worker_unavailable
+                  { reason_code = Rule_types.Summary_pre_worker_start_reserved
                   ; operator_detail
                   }
             ; _
@@ -2714,18 +2716,18 @@ let test_operator_recovery_skips_terminal_exact_failure () =
          true
          (quarantine_exact
             quarantined_identity
-            AQ.Exact_flow_execution_failed);
+            Rule_types.Exact_flow_execution_failed);
        check_rearm
          "explicit operator action cannot reopen exact quarantine"
          false
          (reserve_retry_exact ~base_path (pending_entry_exn quarantined_id));
        (match AQ.For_testing.get_pending_entry_unchecked ~id:quarantined_id with
         | Some
-            { summary_status = AQ.Summary_failed _
+            { summary_status = Rule_types.Summary_failed _
             ; exact_attempt =
-                AQ.Exact_bound
+                Rule_types.Exact_bound
                   { status =
-                      AQ.Exact_quarantined AQ.Exact_flow_execution_failed
+                      Rule_types.Exact_quarantined Rule_types.Exact_flow_execution_failed
                   ; _
                   }
             ; _
@@ -2782,8 +2784,8 @@ let test_summary_owner_retirement_is_atomic_and_owner_scoped () =
         | Ok _ -> Alcotest.fail "bound owner retirement succeeded");
        (match AQ.For_testing.get_pending_entry_unchecked ~id:bound with
         | Some
-            { summary_status = AQ.Summary_pending
-            ; exact_attempt = AQ.Exact_bound binding
+            { summary_status = Rule_types.Summary_pending
+            ; exact_attempt = Rule_types.Exact_bound binding
             ; _
             } ->
           Alcotest.(check string)
@@ -2793,7 +2795,7 @@ let test_summary_owner_retirement_is_atomic_and_owner_scoped () =
         | Some _ | None ->
           Alcotest.fail "bound entry changed on failed retirement");
        (match AQ.For_testing.get_pending_entry_unchecked ~id:sibling with
-        | Some { summary_status = AQ.Summary_pending; _ } -> ()
+        | Some { summary_status = Rule_types.Summary_pending; _ } -> ()
         | Some _ | None ->
           Alcotest.fail "blocked retirement partially mutated");
        (match
@@ -2812,7 +2814,7 @@ let test_summary_owner_retirement_is_atomic_and_owner_scoped () =
             ids);
        match AQ.For_testing.get_pending_entry_unchecked ~id:retirable with
        | Some
-           { summary_status = AQ.Summary_failed { reason = "retired" }
+           { summary_status = Rule_types.Summary_failed { reason = "retired" }
            ; _
            } ->
          ()
@@ -3090,7 +3092,7 @@ let test_replay_sidecar_rejects_raw_output_wire () =
           aq_resolve
             ~base_path
             ~id:approval_id
-            ~decision:AQ.Decision.Approve
+            ~decision:Rule_types.Decision.Approve
         with
         | Ok () -> ()
         | Error error ->
@@ -3241,7 +3243,7 @@ let test_observed_delivery_preserves_grant_without_replaying_wake () =
           aq_resolve
             ~base_path
             ~id
-            ~decision:AQ.Decision.Approve
+            ~decision:Rule_types.Decision.Approve
         with
         | Ok () -> ()
        | Error error ->
@@ -3479,12 +3481,12 @@ let test_default_auto_judge_defers_without_blocking () =
            (String.length detail > 0);
          (match AQ.For_testing.get_pending_entry_unchecked ~id:approval_id with
           | Some
-              { summary_status = AQ.Summary_pending
-              ; exact_attempt = AQ.Exact_unbound
+              { summary_status = Rule_types.Summary_pending
+              ; exact_attempt = Rule_types.Exact_unbound
               ; summary_attempt_disposition =
-                  AQ.Summary_attempt_pre_worker_unavailable
+                  Rule_types.Summary_attempt_pre_worker_unavailable
                     { reason_code =
-                        AQ.Summary_pre_worker_auto_judge_unavailable
+                        Rule_types.Summary_pre_worker_auto_judge_unavailable
                     ; operator_detail
                     }
               ; _
@@ -3522,7 +3524,7 @@ let test_unavailable_cycle_grant_never_falls_through () =
     (fun () ->
        ignore (install_exn ~base_path);
        let approval_id = submit ~base_path ~keeper_name ~input in
-       (match aq_resolve ~base_path ~id:approval_id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id:approval_id ~decision:Rule_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
@@ -3584,7 +3586,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
           aq_resolve
             ~base_path
             ~id:reject_id
-            ~decision:(AQ.Decision.Reject rationale)
+            ~decision:(Rule_types.Decision.Reject rationale)
         with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
@@ -3612,7 +3614,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
        let edited_input =
          `Assoc [ "target", `String "after"; "confirmed", `Bool true ]
        in
-       (match aq_resolve ~base_path ~id:edit_id ~decision:(AQ.Decision.Edit edited_input) with
+       (match aq_resolve ~base_path ~id:edit_id ~decision:(Rule_types.Decision.Edit edited_input) with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let edited =
@@ -3649,7 +3651,7 @@ let test_resolved_audit_event_carries_judge_evidence () =
        let id =
          submit ~base_path ~keeper_name ~input:(`Assoc [ "target", `String "doc" ])
        in
-       (match aq_resolve ~base_path ~id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id ~decision:Rule_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let history =
@@ -3674,7 +3676,7 @@ let test_resolved_audit_event_carries_judge_evidence () =
            (row |> member "summary_status");
          Alcotest.check yojson
            "exact_attempt recorded at resolution"
-           (AQ.exact_attempt_state_to_yojson AQ.Exact_unbound)
+           (Rule_types.exact_attempt_state_to_yojson Rule_types.Exact_unbound)
            (row |> member "exact_attempt"))
 ;;
 

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1020,7 +1020,7 @@ let test_resolution_is_durable_and_origin_scoped () =
        in
        (match resolution.decision with
         | Keeper_event_queue.Hitl_approved -> ()
-        | Keeper_event_queue.Hitl_rejected _ | Keeper_event_queue.Hitl_edited _ ->
+        | Keeper_event_queue.Hitl_rejected _ ->
           Alcotest.fail "expected approved resolution");
        (match AQ.approved_resolution_request ~base_path ~id with
         | Ok (Some request) ->
@@ -3605,35 +3605,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
          "rejection is not a grant"
          true
          (Option.is_none (Gate.cycle_grant_of_resolution rejected));
-       let edit_id =
-         submit
-           ~base_path
-           ~keeper_name
-           ~input:(`Assoc [ "target", `String "before" ])
-       in
-       let edited_input =
-         `Assoc [ "target", `String "after"; "confirmed", `Bool true ]
-       in
-       (match aq_resolve ~base_path ~id:edit_id ~decision:(Rule_types.Decision.Edit edited_input) with
-        | Ok () -> ()
-        | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
-       let edited =
-         durable_resolution_opt ~base_path ~keeper_name ~approval_id:edit_id
-         |> require_some "edited resolution was not delivered"
-       in
-       (match edited.decision with
-        | Keeper_event_queue.Hitl_edited actual ->
-          Alcotest.(check bool)
-            "edited input"
-            true
-            (Yojson.Safe.equal edited_input actual)
-        | _ -> Alcotest.fail "edited resolution lost its typed input");
-       Alcotest.(check bool)
-         "edit is not a grant"
-         true
-         (Option.is_none (Gate.cycle_grant_of_resolution edited));
-       drop_resolution ~base_path ~keeper_name rejected;
-       drop_resolution ~base_path ~keeper_name edited)
+       drop_resolution ~base_path ~keeper_name rejected)
 ;;
 
 (* #26126: resolution writes the judge evidence the entry carried onto the

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -1,6 +1,8 @@
 open Alcotest
 
 module AQ = Masc.Keeper_approval_queue
+module Rules = Masc.Keeper_approval_queue_rules
+module Rule_types = Keeper_approval_queue_rules_types
 module Gate = Masc.Keeper_gate
 module Gate_mode = Masc.Keeper_gate_mode
 
@@ -40,7 +42,7 @@ let write_rules ~base_path json =
 
 let upsert_exn ~base_path ~input =
   match
-    AQ.upsert_rule
+    Rules.upsert_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
@@ -48,12 +50,12 @@ let upsert_exn ~base_path ~input =
       ()
   with
   | Ok result -> result
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Rule_types.rule_store_error_to_string error)
 ;;
 
 let find ~base_path ~input =
   match
-    AQ.find_matching_rule
+    Rules.find_matching_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
@@ -61,13 +63,13 @@ let find ~base_path ~input =
       ()
   with
   | Ok lookup -> lookup
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Rule_types.rule_store_error_to_string error)
 ;;
 
 let find_active_opt ~base_path ~input =
   match find ~base_path ~input with
-  | AQ.Rule_match_active matched -> Some matched
-  | AQ.Rule_match_expired _ | AQ.Rule_match_absent -> None
+  | Rule_types.Rule_match_active matched -> Some matched
+  | Rule_types.Rule_match_expired _ | Rule_types.Rule_match_absent -> None
 ;;
 
 let test_rule_matches_only_complete_exact_request () =
@@ -101,16 +103,16 @@ let test_rule_matches_only_complete_exact_request () =
          (Option.is_none (find_active_opt ~base_path ~input:changed_nonce));
        check bool "different operation identity cannot match" true
          (match
-            AQ.find_matching_rule
+            Rules.find_matching_rule
               ~base_path
               ~keeper_name:"keeper"
               ~tool_name:"another-effect"
               ~input
               ()
           with
-          | Ok AQ.Rule_match_absent -> true
-          | Ok (AQ.Rule_match_active _ | AQ.Rule_match_expired _) -> false
-          | Error error -> fail (AQ.rule_store_error_to_string error)))
+          | Ok Rule_types.Rule_match_absent -> true
+          | Ok (Rule_types.Rule_match_active _ | Rule_types.Rule_match_expired _) -> false
+          | Error error -> fail (Rule_types.rule_store_error_to_string error)))
 ;;
 
 let test_equivalent_upsert_is_idempotent () =
@@ -160,7 +162,7 @@ let test_gate_allows_only_the_exact_persisted_rule () =
 
 let upsert_with_expiry_exn ~base_path ~input ~expires_at =
   match
-    AQ.upsert_rule
+    Rules.upsert_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
@@ -169,12 +171,12 @@ let upsert_with_expiry_exn ~base_path ~input ~expires_at =
       ()
   with
   | Ok result -> result
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Rule_types.rule_store_error_to_string error)
 ;;
 
 let find_at ~base_path ~input ~now =
   match
-    AQ.find_matching_rule
+    Rules.find_matching_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
@@ -183,7 +185,7 @@ let find_at ~base_path ~input ~now =
       ()
   with
   | Ok lookup -> lookup
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Rule_types.rule_store_error_to_string error)
 ;;
 
 let test_unexpired_rule_matches_with_injected_now () =
@@ -199,10 +201,10 @@ let test_unexpired_rule_matches_with_injected_now () =
        check (option (float 0.0)) "expiry persisted on rule" (Some 2000.0)
          rule.expires_at;
        match find_at ~base_path ~input ~now:1999.0 with
-       | AQ.Rule_match_active matched ->
+       | Rule_types.Rule_match_active matched ->
          check string "unexpired rule matches" rule.id matched.rule_id
-       | AQ.Rule_match_expired _ -> fail "unexpired rule reported as expired"
-       | AQ.Rule_match_absent -> fail "unexpired rule did not match")
+       | Rule_types.Rule_match_expired _ -> fail "unexpired rule reported as expired"
+       | Rule_types.Rule_match_absent -> fail "unexpired rule did not match")
 ;;
 
 let test_expired_rule_is_reported_and_retained () =
@@ -213,22 +215,22 @@ let test_expired_rule_is_reported_and_retained () =
        let input = `Assoc [ "request", `String "exact" ] in
        let rule, _ = upsert_with_expiry_exn ~base_path ~input ~expires_at:2000.0 in
        (match find_at ~base_path ~input ~now:2000.0 with
-        | AQ.Rule_match_expired matched ->
+        | Rule_types.Rule_match_expired matched ->
           check string "expiry boundary is expired" rule.id matched.rule_id
-        | AQ.Rule_match_active _ -> fail "expired rule still matched"
-        | AQ.Rule_match_absent -> fail "expired rule must be reported, not absent");
+        | Rule_types.Rule_match_active _ -> fail "expired rule still matched"
+        | Rule_types.Rule_match_absent -> fail "expired rule must be reported, not absent");
        (match find_at ~base_path ~input ~now:2001.0 with
-        | AQ.Rule_match_expired matched ->
+        | Rule_types.Rule_match_expired matched ->
           check string "after expiry is expired" rule.id matched.rule_id
-        | AQ.Rule_match_active _ -> fail "expired rule still matched"
-        | AQ.Rule_match_absent -> fail "expired rule must be reported, not absent");
+        | Rule_types.Rule_match_active _ -> fail "expired rule still matched"
+        | Rule_types.Rule_match_absent -> fail "expired rule must be reported, not absent");
        let stored =
-         match AQ.list_rules ~base_path () with
+         match Rules.list_rules ~base_path () with
          | Ok rules -> rules
-         | Error error -> fail (AQ.rule_store_error_to_string error)
+         | Error error -> fail (Rule_types.rule_store_error_to_string error)
        in
        check bool "expired rule is retained for operator cleanup" true
-         (List.exists (fun (stored : AQ.approval_rule) ->
+         (List.exists (fun (stored : Rule_types.approval_rule) ->
             String.equal stored.id rule.id && stored.expires_at = Some 2000.0)
             stored))
 ;;
@@ -242,10 +244,10 @@ let test_rule_without_expiry_matches_at_any_now () =
        let rule, _ = upsert_exn ~base_path ~input in
        check (option (float 0.0)) "no expiry by default" None rule.expires_at;
        match find_at ~base_path ~input ~now:1e12 with
-       | AQ.Rule_match_active matched ->
+       | Rule_types.Rule_match_active matched ->
          check string "rule without expiry stays active" rule.id matched.rule_id
-       | AQ.Rule_match_expired _ -> fail "rule without expiry reported as expired"
-       | AQ.Rule_match_absent -> fail "rule without expiry did not match")
+       | Rule_types.Rule_match_expired _ -> fail "rule without expiry reported as expired"
+       | Rule_types.Rule_match_absent -> fail "rule without expiry did not match")
 ;;
 
 let test_unknown_persisted_shape_is_reported_and_rejected () =
@@ -255,7 +257,7 @@ let test_unknown_persisted_shape_is_reported_and_rejected () =
     (fun () ->
        let input = `Assoc [ "request", `String "exact" ] in
        let rule, _ = upsert_exn ~base_path ~input in
-       let json = AQ.approval_rule_to_yojson rule in
+       let json = Rule_types.approval_rule_to_yojson rule in
        let extended =
          match json with
          | `Assoc fields -> `Assoc (("classification", `String "legacy") :: fields)
@@ -271,7 +273,7 @@ let test_unknown_persisted_shape_is_reported_and_rejected () =
            ()
        in
        write_rules ~base_path (`List [ json; extended ]);
-       (match AQ.list_rules ~base_path () with
+       (match Rules.list_rules ~base_path () with
         | Ok _ -> fail "unsupported entry must fail the whole rules file"
         | Error _ -> ());
        let after =
@@ -286,7 +288,7 @@ let test_unknown_persisted_shape_is_reported_and_rejected () =
        check bool "rejection is observed" true (after -. before >= 1.0))
 ;;
 
-let with_rule_id id (rule : AQ.approval_rule) = { rule with id }
+let with_rule_id id (rule : Rule_types.approval_rule) = { rule with id }
 
 let test_duplicate_persisted_rules_reject_whole_store () =
   let base_path = temp_dir () in
@@ -302,10 +304,10 @@ let test_duplicate_persisted_rules_reject_whole_store () =
        write_rules
          ~base_path
          (`List
-             [ AQ.approval_rule_to_yojson first
-             ; AQ.approval_rule_to_yojson (with_rule_id first.id second)
+             [ Rule_types.approval_rule_to_yojson first
+             ; Rule_types.approval_rule_to_yojson (with_rule_id first.id second)
              ]);
-       (match AQ.list_rules ~base_path () with
+       (match Rules.list_rules ~base_path () with
         | Ok _ -> fail "duplicate rule ids must fail the whole rules store"
         | Error error ->
           check bool "duplicate id named" true
@@ -315,10 +317,10 @@ let test_duplicate_persisted_rules_reject_whole_store () =
        write_rules
          ~base_path
          (`List
-             [ AQ.approval_rule_to_yojson first
-             ; AQ.approval_rule_to_yojson (with_rule_id "different-id" first)
+             [ Rule_types.approval_rule_to_yojson first
+             ; Rule_types.approval_rule_to_yojson (with_rule_id "different-id" first)
              ]);
-       match AQ.list_rules ~base_path () with
+       match Rules.list_rules ~base_path () with
        | Ok _ -> fail "duplicate exact identities must fail the whole rules store"
        | Error error ->
          check bool "duplicate identity named" true
@@ -362,13 +364,13 @@ let exact_rule_lookup_failure_count () =
     ()
 ;;
 
-let eligibility_summary : AQ.hitl_context_summary =
+let eligibility_summary : Rule_types.hitl_context_summary =
   { summary_version = 2
   ; generated_at = 1.0
   ; model_run_id = "gate-eligibility-judge"
   ; context_summary = "The exact request is supported by the visible context."
   ; key_questions = []
-  ; judgment = AQ.Approve
+  ; judgment = Rule_types.Approve
   ; rationale = "The request is safe to finalize."
   }
 ;;
@@ -422,7 +424,7 @@ let exact_identity label =
   }
 ;;
 
-let bind_exact_entry (entry : AQ.pending_approval) identity =
+let bind_exact_entry (entry : Rule_types.pending_approval) identity =
   exact_update_exn
     "bind exact attempt"
     (AQ.bind_summary_exact_attempt
@@ -484,7 +486,7 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
            ~call_id:identity.call_id
            ~plan_fingerprint:identity.plan_fingerprint
            ~request_body_sha256:identity.request_body_sha256
-           ~cause:AQ.Exact_flow_execution_failed))
+           ~cause:Rule_types.Exact_flow_execution_failed))
   in
   let completed =
     make_bound "completed" (fun entry identity ->
@@ -503,24 +505,24 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
                model_run_id = identity.call_id
              }))
   in
-let with_exact_status (entry : AQ.pending_approval) status =
+let with_exact_status (entry : Rule_types.pending_approval) status =
     match entry.exact_attempt with
-    | AQ.Exact_bound binding ->
+    | Rule_types.Exact_bound binding ->
       { entry with
         exact_attempt =
-          AQ.Exact_bound
-            (AQ.exact_attempt_binding_with_status binding status)
+          Rule_types.Exact_bound
+            (Rule_types.exact_attempt_binding_with_status binding status)
       }
-    | AQ.Exact_unbound ->
+    | Rule_types.Exact_unbound ->
       fail "bound exact eligibility fixture became unbound"
   in
   let released_recovery_required =
     with_exact_status
       released_before_dispatch
-      AQ.Exact_released_recovery_required
+      Rule_types.Exact_released_recovery_required
   in
   let restart_quarantined =
-    with_exact_status dispatch_uncertain AQ.Exact_restart_quarantined
+    with_exact_status dispatch_uncertain Rule_types.Exact_restart_quarantined
   in
   let check_ready label expected entry =
     check bool label expected (Gate.For_testing.auto_judge_entry_ready entry)
@@ -543,13 +545,13 @@ let with_exact_status (entry : AQ.pending_approval) status =
     restart_quarantined;
   check_ready "completed binding is finalize-only" false completed;
   (match quarantined.exact_attempt with
-   | AQ.Exact_bound { status = AQ.Exact_quarantined AQ.Exact_flow_execution_failed; _ } ->
+   | Rule_types.Exact_bound { status = Rule_types.Exact_quarantined Rule_types.Exact_flow_execution_failed; _ } ->
      ()
-   | AQ.Exact_unbound
-   | AQ.Exact_bound _ ->
+   | Rule_types.Exact_unbound
+   | Rule_types.Exact_bound _ ->
      fail "typed quarantine cause was not persisted");
   (match completed.exact_attempt, completed.summary_status with
-   | AQ.Exact_bound { status = AQ.Exact_completed; _ }, AQ.Summary_available _ -> ()
+   | Rule_types.Exact_bound { status = Rule_types.Exact_completed; _ }, Rule_types.Summary_available _ -> ()
    | _ -> fail "exact completion did not atomically persist its available summary");
   let other_owner =
     submit_eligibility_entry ~base_path ~keeper_name:"other-keeper" "other-owner"
@@ -572,7 +574,7 @@ let with_exact_status (entry : AQ.pending_approval) status =
   check int "operator recovery exposes only the FIFO head" 1 (List.length ready);
   check (list string) "operator recovery cannot skip the FIFO head"
     [ not_requested.id ]
-    (List.map (fun (entry : AQ.pending_approval) -> entry.id) ready)
+    (List.map (fun (entry : Rule_types.pending_approval) -> entry.id) ready)
 ;;
 
 let test_completed_exact_judgment_finalizes_without_worker () =
@@ -605,7 +607,7 @@ let test_completed_exact_judgment_finalizes_without_worker () =
    | Error error -> fail (AQ.install_error_to_string error));
   let completed = approval_entry_exn completed.id in
   (match completed.exact_attempt, completed.summary_status with
-   | AQ.Exact_bound { status = AQ.Exact_completed; _ }, AQ.Summary_available _ -> ()
+   | Rule_types.Exact_bound { status = Rule_types.Exact_completed; _ }, Rule_types.Summary_available _ -> ()
    | _ -> fail "completed available judgment did not survive restart");
   check bool "completed available judgment is finalize-only" false
     (Gate.For_testing.auto_judge_entry_ready completed);

--- a/test/test_keeper_hitl_resolution_prompt.ml
+++ b/test/test_keeper_hitl_resolution_prompt.ml
@@ -35,54 +35,7 @@ let test_rejection_rationale_is_actionable_without_grant () =
     (Option.is_none (Keeper_gate.cycle_grant_of_resolution resolution))
 ;;
 
-let test_edited_input_is_durable_and_not_a_grant () =
-  let edited_input =
-    `Assoc [ "destination", `String "project"; "payload", `Int 7 ]
-  in
-  let resolution : Keeper_event_queue.hitl_resolution =
-    { approval_id = "approval-edited"
-    ; decision = Hitl_edited edited_input
-    ; channel
-    }
-  in
-  let stimulus : Keeper_event_queue.stimulus =
-    { post_id = Keeper_event_queue.hitl_resolution_post_id resolution
-    ; urgency = Immediate
-    ; arrived_at = 1.0
-    ; payload = Hitl_resolved resolution
-    }
-  in
-  let restored =
-    Keeper_event_queue.stimulus_to_yojson stimulus
-    |> Keeper_event_queue.stimulus_of_yojson
-  in
-  (match restored with
-   | Ok { payload = Hitl_resolved { decision = Hitl_edited actual; _ }; _ } ->
-     check bool "edited JSON survives durable codec" true (Yojson.Safe.equal edited_input actual)
-   | Ok _ -> fail "restored stimulus lost edited resolution"
-   | Error error -> fail ("edited resolution codec failed: " ^ error));
-  let message =
-    Keeper_gate_replay.user_message_with_hitl_resolution
-      ~base_path:"/tmp"
-      ~user_message:"continue"
-      (Some resolution)
-    |> fun message -> message.Keeper_gate_replay.text
-  in
-  check bool
-    "edited JSON reaches model input"
-    true
-    (contains ~needle:"\"destination\": \"project\"" message);
-  check bool
-    "edit explicitly grants nothing"
-    true
-    (contains ~needle:"grants no authorization" message);
-  check bool
-    "edit cannot mint a cycle grant"
-    true
-    (Option.is_none (Keeper_gate.cycle_grant_of_resolution resolution))
-;;
-
-let test_large_rejection_and_edit_remain_exact () =
+let test_large_rejection_remains_exact () =
   let exact_tail =
     "RESOLUTION-BEGIN\n"
     ^ String.make (512 * 1024) 'x'
@@ -98,19 +51,15 @@ let test_large_rejection_and_edit_remain_exact () =
       (Some resolution)
     |> fun message -> message.Keeper_gate_replay.text
   in
-  List.iter
-    (fun (label, rendered) ->
-       check bool
-         (label ^ " retains the full exact tail")
-         true
-         (contains ~needle:"RESOLUTION-END" rendered);
-       check bool
-         (label ^ " is not replaced with an opaque blob marker")
-         false
-         (contains ~needle:"[masc:blob " rendered))
-    [ "rejection", message (Hitl_rejected exact_tail)
-    ; "edit", message (Hitl_edited (`Assoc [ "payload", `String exact_tail ]))
-    ]
+  let rendered = message (Hitl_rejected exact_tail) in
+  check bool
+    "rejection retains the full exact tail"
+    true
+    (contains ~needle:"RESOLUTION-END" rendered);
+  check bool
+    "rejection is not replaced with an opaque blob marker"
+    false
+    (contains ~needle:"[masc:blob " rendered)
 ;;
 
 let approved_message ~tool_name =
@@ -165,13 +114,9 @@ let () =
             `Quick
             test_rejection_rationale_is_actionable_without_grant
         ; test_case
-            "edited input is durable and not authorization"
+            "large rejection remains exact"
             `Quick
-            test_edited_input_is_durable_and_not_a_grant
-        ; test_case
-            "large rejection and edit remain exact"
-            `Quick
-            test_large_rejection_and_edit_remain_exact
+            test_large_rejection_remains_exact
         ] )
     ; ( "approved resolution"
       , [ test_case

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -12,6 +12,7 @@ module Reg = Masc.Keeper_registry
 module KT = Keeper_types
 module KR = Masc.Keeper_runtime
 module AQ = Masc.Keeper_approval_queue
+module AQT = Keeper_approval_queue_rules_types
 module KSM = Keeper_state_machine
 module KLH = Masc.Keeper_lifecycle_hooks
 module KA = Masc.Keeper_keepalive
@@ -349,7 +350,7 @@ let test_pending_hitl_approval_keeper_names_filters_persisted_pending () =
             (aq_resolve
                ~base_path:base_dir
                ~id
-               ~decision:(AQ.Decision.Reject "test cleanup")))
+               ~decision:(AQT.Decision.Reject "test cleanup")))
         !approval_ids;
       cleanup_dir base_dir)
     (fun () ->
@@ -1092,7 +1093,7 @@ let test_sweep_reports_pending_hitl_approval () =
              (aq_resolve
                 ~base_path:base_dir
                 ~id
-                ~decision:(AQ.Decision.Reject "test cleanup")))
+                ~decision:(AQT.Decision.Reject "test cleanup")))
         !approval_id;
       Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
@@ -1144,7 +1145,7 @@ let test_sweep_reports_pending_hitl_approval () =
            ~keeper_name:name
          |> Result.get_ok
          |> fun count -> count > 0);
-      (match aq_resolve ~base_path:base_dir ~id ~decision:AQ.Decision.Approve with
+      (match aq_resolve ~base_path:base_dir ~id ~decision:AQT.Decision.Approve with
        | Ok () -> approval_id := None
        | Error err -> fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
       check bool "resolution removes pending request" false

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -2262,8 +2262,8 @@ let test_approved_web_search_grant_executes_exact_request () =
          Masc.Keeper_approval_queue.resolve_with_policy
            ~base_path:config.base_path
            ~id:approval_id
-           ~decision:Masc.Keeper_approval_queue.Decision.Approve
-           ~source:Masc.Keeper_approval_queue.Auto_judge
+           ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+           ~source:Keeper_approval_queue_rules_types.Auto_judge
            ()
        with
        | Ok _ -> ()
@@ -2365,8 +2365,8 @@ let test_approved_web_search_replays_without_model_resubmission () =
          Masc.Keeper_approval_queue.resolve_with_policy
            ~base_path:config.base_path
            ~id:approval_id
-           ~decision:Masc.Keeper_approval_queue.Decision.Approve
-           ~source:Masc.Keeper_approval_queue.Auto_judge
+           ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+           ~source:Keeper_approval_queue_rules_types.Auto_judge
            ()
        with
        | Ok _ -> ()
@@ -2563,8 +2563,8 @@ let approved_web_search_resolution
      Masc.Keeper_approval_queue.resolve_with_policy
        ~base_path:config.base_path
        ~id:approval_id
-       ~decision:Masc.Keeper_approval_queue.Decision.Approve
-       ~source:Masc.Keeper_approval_queue.Auto_judge
+       ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+       ~source:Keeper_approval_queue_rules_types.Auto_judge
        ()
    with
    | Ok _ -> ()
@@ -2978,8 +2978,8 @@ let test_unsupported_approved_operation_retains_exact_model_issued_path () =
           Masc.Keeper_approval_queue.resolve_with_policy
             ~base_path:config.base_path
             ~id:approval_id
-            ~decision:Masc.Keeper_approval_queue.Decision.Approve
-            ~source:Masc.Keeper_approval_queue.Auto_judge
+            ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+            ~source:Keeper_approval_queue_rules_types.Auto_judge
             ()
         with
         | Ok _ -> ()

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -361,7 +361,7 @@ max-concurrent = 1
             && String.equal err.message
                  "unknown protocol \"openai-http\": expected one of \
                   messages-cli, messages-http, openai-compatible-cli, \
-                  openai-compatible-http, ollama-http")
+                  openai-compatible-http, ollama-http, codex-app-server")
          errors)
 
 let test_runtime_toml_accepts_messages_caching_capability () =

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -1843,7 +1843,7 @@ let approved_grant_fixture ~base_path ~keeper_name ~input =
      Keeper_approval_queue.resolve_with_policy
        ~base_path
        ~id:approval_id
-       ~decision:Keeper_approval_queue.Decision.Approve
+       ~decision:Keeper_approval_queue_rules_types.Decision.Approve
        ()
    with
    | Ok _ -> ()

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -540,7 +540,7 @@ let assert_policy_validation_payload ~label result =
 let test_registered_hook_tool_edit_file_patch_args () =
   let args =
     `Assoc
-      [ "file_path", `String "repos/masc/.worktrees/task/lib/foo.ml"
+      [ "path", `String "repos/masc/.worktrees/task/lib/foo.ml"
       ; "mode", `String "patch"
       ; "old_string", `String "let x = 1"
       ; "new_string", `String "let x = 2"

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -540,7 +540,7 @@ let assert_policy_validation_payload ~label result =
 let test_registered_hook_tool_edit_file_patch_args () =
   let args =
     `Assoc
-      [ "path", `String "repos/masc/.worktrees/task/lib/foo.ml"
+      [ "file_path", `String "repos/masc/.worktrees/task/lib/foo.ml"
       ; "mode", `String "patch"
       ; "old_string", `String "let x = 1"
       ; "new_string", `String "let x = 2"

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -99,6 +99,44 @@ let test_schema_inventory_matches_dispatch_validation_registry () =
     Config.raw_all_tool_schemas
 ;;
 
+let schema_property_names schema =
+  match Json_util.assoc_member_opt "properties" schema with
+  | Some (`Assoc properties) -> List.map fst properties
+  | _ -> []
+;;
+
+let test_translated_descriptor_keeps_distinct_runtime_schema () =
+  init ();
+  let edit_descriptor =
+    match Keeper_tool_descriptor.find_public "Edit" with
+    | Some descriptor -> descriptor
+    | None -> Alcotest.fail "Edit descriptor missing"
+  in
+  let runtime_schema =
+    match Tool_dispatch.lookup_schema "tool_edit_file" with
+    | Some schema -> schema
+    | None -> Alcotest.fail "tool_edit_file runtime schema missing"
+  in
+  let public_properties = schema_property_names edit_descriptor.input_schema in
+  let runtime_properties = schema_property_names runtime_schema in
+  Alcotest.(check bool)
+    "Edit public schema owns file_path"
+    true
+    (List.mem "file_path" public_properties);
+  Alcotest.(check bool)
+    "Edit public schema does not expose runtime path"
+    false
+    (List.mem "path" public_properties);
+  Alcotest.(check bool)
+    "tool_edit_file runtime schema owns translated path"
+    true
+    (List.mem "path" runtime_properties);
+  Alcotest.(check bool)
+    "tool_edit_file runtime schema does not reuse public file_path"
+    false
+    (List.mem "file_path" runtime_properties)
+;;
+
 let test_workspace_schemas_route_to_state () =
   init ();
   Tool_schemas_workspace.schemas
@@ -260,6 +298,10 @@ let () =
             "schema inventory matches dispatch validation registry"
             `Quick
             test_schema_inventory_matches_dispatch_validation_registry
+        ; test_case
+            "translated descriptors keep distinct runtime schemas"
+            `Quick
+            test_translated_descriptor_keeps_distinct_runtime_schema
         ] )
     ; ( "workspace_tools"
       , [ test_case "workspace schemas route to Mod_state" `Quick


### PR DESCRIPTION
## Summary
- remove the `Keeper_approval_queue` rule and audit re-export surfaces
- route rule types/codecs to `Keeper_approval_queue_rules_types` and rule CRUD to `Keeper_approval_queue_rules`
- make the unified registry publish each canonical schema while preserving an existing precise dispatch tag
- keep Agent Core provider-config fixtures internally consistent with their declared sampling capabilities
- validate `tool_edit_file` through its public `file_path` contract
- update dashboard, Gate, server, and tests to consume the canonical owners directly

## Verification
- approval rule types/rules/queue focused suites: 65/65 passed before the latest CI-only contract repair
- targeted compile previously passed for `test_heartbeat_integration.exe`, `test_keeper_approval_audit_timeline.exe`, `test_hitl_summary_worker.exe`, and `test_keeper_supervisor.exe`
- latest changed OCaml files pass parse checks and ocamlformat
- `git diff --check`

The latest focused Dune attempt exited 75 because the repository resource guard detected three unrelated bare Dune processes. The guard was not bypassed; exact-head PR CI is authoritative for the three repaired failures.

## Contract
This is a hard cut. It does not restore compatibility aliases, duplicate schema owners, or queue-level facade APIs.
