### PR TITLE
docs: remove retired command runtime references

### DIFF
--- a/docs/EXECUTE-RUNBOOK.md
+++ b/docs/EXECUTE-RUNBOOK.md
@@ -8,7 +8,7 @@ code_refs:
   - lib/process/process_eio.ml
   - lib/exec/command_gate/shell_command_gate.ml
   - lib/exec_policy/exec_policy.ml
-  - lib/keeper/keeper_tool_command_runtime.ml
+  - lib/keeper/keeper_tool_execute_runtime.ml
 ---
 
 # Execute Runbook

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -48,8 +48,6 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_registered_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_shared_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_shared_runtime.mli` - execution-dispatch
-- `lib/keeper/keeper_tool_command_runtime.ml` - execution-dispatch
-- `lib/keeper/keeper_tool_command_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_task_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_task_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_voice_runtime.ml` - execution-dispatch


### PR DESCRIPTION
## Summary
- point the Execute runbook at the canonical `keeper_tool_execute_runtime` owner
- remove the deleted command-runtime facade from the Keeper boundary matrix

## Verification
- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `scripts/check-doc-code-refs.sh`
- `git diff --check`

This is the exact stale-reference prerequisite exposed by PR #27758 CI. No compatibility facade is restored.