### PR TITLE
feat(runtime): own official-client sessions durably

### DIFF
--- a/docs/EXECUTE-RUNBOOK.md
+++ b/docs/EXECUTE-RUNBOOK.md
@@ -8,7 +8,7 @@ code_refs:
   - lib/process/process_eio.ml
   - lib/exec/command_gate/shell_command_gate.ml
   - lib/exec_policy/exec_policy.ml
-  - lib/keeper/keeper_tool_command_runtime.ml
+  - lib/keeper/keeper_tool_execute_runtime.ml
 ---
 
 # Execute Runbook

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -48,8 +48,6 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_registered_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_shared_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_shared_runtime.mli` - execution-dispatch
-- `lib/keeper/keeper_tool_command_runtime.ml` - execution-dispatch
-- `lib/keeper/keeper_tool_command_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_task_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_task_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_voice_runtime.ml` - execution-dispatch

--- a/lib/dashboard/dashboard_gate.ml
+++ b/lib/dashboard/dashboard_gate.ml
@@ -81,13 +81,13 @@ let dashboard_json ~base_path ~limit ~window_minutes =
       ()
   in
   let approval_rules, approval_rules_state =
-    match Keeper_approval_queue.list_rules_dashboard_json ~base_path () with
+    match Keeper_approval_queue_rules.list_rules_dashboard_json ~base_path () with
     | Ok json -> json, `Assoc [ "state", `String "ready" ]
     | Error error ->
       ( `List []
       , `Assoc
           [ "state", `String "unavailable"
-          ; "error", `String (Keeper_approval_queue.rule_store_error_to_string error)
+          ; "error", `String (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
           ] )
   in
   `Assoc

--- a/lib/dashboard/dashboard_gate_metrics.ml
+++ b/lib/dashboard/dashboard_gate_metrics.ml
@@ -176,7 +176,7 @@ type approval_summary = {
 let approval_queue_summary_of_entries ~now_ts entries : approval_summary =
   let waits =
     List.map
-      (fun (entry : Keeper_approval_queue.pending_approval) ->
+      (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
         Float.max 0.0 (now_ts -. entry.requested_at))
       entries
   in

--- a/lib/dashboard/dashboard_gate_metrics.mli
+++ b/lib/dashboard/dashboard_gate_metrics.mli
@@ -82,7 +82,7 @@ val record_tool_skipped_with_append_for_testing :
 val gate_tool_events_json_with_pending_result_for_testing :
   now_ts:float ->
   window_minutes:int ->
-  ( Keeper_approval_queue.pending_approval list
+  ( Keeper_approval_queue_rules_types.pending_approval list
   , Keeper_approval_queue.storage_error )
   result ->
   Yojson.Safe.t

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -1,4 +1,5 @@
 open Keeper_approval_queue
+open Keeper_approval_queue_rules_types
 
 module Exact_output = Agent_sdk.Exact_output
 module Registry = Runtime_exact_output_registry

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -32,8 +32,8 @@ type spawn_outcome =
 
 val spawn
   :  sw:Eio.Switch.t
-  -> entry:Keeper_approval_queue.pending_approval
-  -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+  -> entry:Keeper_approval_queue_rules_types.pending_approval
+  -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
   -> on_finish:(finish_outcome -> unit)
   -> unit
   -> (spawn_outcome, string) result
@@ -46,31 +46,31 @@ val spawn
 
 module For_testing : sig
   val run_outcome_of_observed_summary
-    :  Keeper_approval_queue.hitl_context_summary option
+    :  Keeper_approval_queue_rules_types.hitl_context_summary option
     -> Exact_lane_run_registry.outcome * Yojson.Safe.t
 
   val system_prompt : unit -> (string, string) result
 
   val build_context_bundle
-    :  entry:Keeper_approval_queue.pending_approval
+    :  entry:Keeper_approval_queue_rules_types.pending_approval
     -> Yojson.Safe.t
 
   val parse_summary
     :  generated_at:float
     -> model_run_id:string
     -> Yojson.Safe.t
-    -> (Keeper_approval_queue.hitl_context_summary, string) result
+    -> (Keeper_approval_queue_rules_types.hitl_context_summary, string) result
 
   type prepared_flow
 
   val prepare_flow
-    :  entry:Keeper_approval_queue.pending_approval
+    :  entry:Keeper_approval_queue_rules_types.pending_approval
     -> (prepared_flow, string) result
 
   val execute_prepared_flow
     :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
     -> ?clock:_ Eio.Time.clock
-    -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+    -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
     -> prepared_flow
     -> execution_boundary
 
@@ -94,7 +94,7 @@ module For_testing : sig
     -> call_id:string
     -> plan_fingerprint:string
     -> request_body_sha256:string
-    -> summary:Keeper_approval_queue.hitl_context_summary
+    -> summary:Keeper_approval_queue_rules_types.hitl_context_summary
     -> ( Keeper_approval_queue.exact_attempt_transition
        , Keeper_approval_queue.exact_attempt_error )
        result
@@ -107,7 +107,7 @@ module For_testing : sig
     -> call_id:string
     -> plan_fingerprint:string
     -> request_body_sha256:string
-    -> cause:Keeper_approval_queue.exact_attempt_quarantine_cause
+    -> cause:Keeper_approval_queue_rules_types.exact_attempt_quarantine_cause
     -> ( Keeper_approval_queue.exact_attempt_transition
        , Keeper_approval_queue.exact_attempt_error )
        result
@@ -127,7 +127,7 @@ module For_testing : sig
     :  queue_ops:exact_queue_ops
     -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
     -> ?clock:_ Eio.Time.clock
-    -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+    -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
     -> prepared_flow
     -> execution_boundary
   (** The production flow with explicit durable queue transition authority.
@@ -137,8 +137,8 @@ module For_testing : sig
   val spawn_with_queue_ops
     :  queue_ops:exact_queue_ops
     -> sw:Eio.Switch.t
-    -> entry:Keeper_approval_queue.pending_approval
-    -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+    -> entry:Keeper_approval_queue_rules_types.pending_approval
+    -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
     -> on_finish:(finish_outcome -> unit)
     -> unit
     -> (spawn_outcome, string) result

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1,6 +1,7 @@
 (** Durable, nonblocking HITL requests for Keeper external effects. *)
 
-include Keeper_approval_queue_rules
+open Keeper_approval_queue_rules_types
+open Keeper_approval_queue_rules
 
 type storage_error =
   { path : string
@@ -3168,7 +3169,7 @@ let approval_decision_equal left right =
 let remember_rule_for_entry ~base_path ?created_by ?rule_expires_at (entry : pending_approval) =
   try
     match
-      upsert_rule
+      Keeper_approval_queue_rules.upsert_rule
         ~base_path
         ~keeper_name:entry.keeper_name
         ~tool_name:entry.tool_name

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -4,7 +4,7 @@
     tool/product name. It records an exact request, accepts an explicit
     resolution, and wakes only the originating Keeper lane. *)
 
-include module type of Keeper_approval_queue_rules_types
+open Keeper_approval_queue_rules_types
 
 type storage_error =
   { path : string
@@ -207,103 +207,7 @@ val record_consumed_resolution_replay :
   outcome:resolution_replay_outcome ->
   (replay_recording, grant_error) result
 
-(** {1 Exact Always Allowed rules} *)
-
-val list_rules :
-  base_path:string -> unit -> (approval_rule list, rule_store_error) result
-
-val list_rules_dashboard_json :
-  base_path:string -> unit -> (Yojson.Safe.t, rule_store_error) result
-
-(** Insert or fetch the rule for the exact
-    [(keeper_name, tool_name, canonical complete input)] identity.
-    [expires_at] is an optional absolute Unix expiry; the identity match
-    ignores it, so an existing rule is returned unchanged. *)
-val upsert_rule :
-  base_path:string ->
-  keeper_name:string ->
-  tool_name:string ->
-  input:Yojson.Safe.t ->
-  ?created_by:string ->
-  ?source_approval_id:string ->
-  ?expires_at:float ->
-  unit ->
-  (approval_rule * bool, rule_store_error) result
-
-val delete_rule :
-  base_path:string -> id:string -> unit -> (approval_rule, rule_store_error) result
-
-(** Find the exact remembered request and report whether it authorizes at
-    [now] (defaults to the wall clock; inject for deterministic evaluation).
-    An expired rule is reported as [Rule_match_expired], never applied, and
-    never deleted. *)
-val find_matching_rule :
-  base_path:string ->
-  keeper_name:string ->
-  tool_name:string ->
-  input:Yojson.Safe.t ->
-  ?now:float ->
-  unit ->
-  (rule_lookup, rule_store_error) result
-
 val generate_id : unit -> string
-val recent_resolved_history_limit : int
-val recent_resolved_max_limit : int
-val recent_resolved_default_window_minutes : int
-val recent_resolved_min_window_minutes : int
-val recent_resolved_max_window_minutes : int
-
-val read_recent_audit :
-  base_path:string -> ?keeper_name:string -> ?n:int -> unit -> Yojson.Safe.t list
-
-val audit_day_string_of_ts : float -> string
-(** Day key ["YYYY-MM-DD"] for the [YYYY-MM/DD.jsonl] audit layout. Exposed as
-    a pure function so the UTC invariant is testable: the write path
-    ([Jsonl_writer.dated_path]) picks the day file with [Unix.gmtime], so a
-    local-time key would read the wrong file for the hours where the two
-    calendars disagree. *)
-
-type resolved_history =
-  { resolved_rows : Yojson.Safe.t list
-  ; resolved_matched : int
-  ; resolved_limit : int
-  ; resolved_window_minutes : int
-  ; resolved_scan_exhausted : bool
-  }
-(** A page of resolved Gate decisions together with the bounds that produced
-    it. [resolved_rows] is newest first and holds at most [resolved_limit]
-    entries; [resolved_matched] counts every resolved decision the scan saw
-    inside the window, so [resolved_matched > resolved_limit] means the page is
-    a slice rather than the whole window. [resolved_scan_exhausted] reports the
-    second bound: the physical row cap stopped the scan before it reached the
-    window start, so even [resolved_matched] undercounts. Rendering only
-    [resolved_rows] reintroduces the silent truncation this type removes. *)
-
-val list_recent_resolved :
-  base_path:string ->
-  now_ts:float ->
-  ?limit:int ->
-  ?window_minutes:int ->
-  unit ->
-  resolved_history
-(** [list_recent_resolved ~base_path ~now_ts ()] returns resolved Gate decisions
-    from the last [window_minutes] (default
-    {!recent_resolved_default_window_minutes}, clamped to
-    [[recent_resolved_min_window_minutes, recent_resolved_max_window_minutes]]),
-    newest first, capped at [limit] (default
-    {!recent_resolved_history_limit}, clamped to
-    [[0, recent_resolved_max_limit]]).
-
-    [now_ts] is supplied by the caller rather than read here, matching
-    {!Dashboard_gate_metrics.tool_rejection_counts}: the observation boundary
-    captures the clock once for the whole projection, and this function stays
-    deterministic so a test can pin an exact window.
-
-    Rows without a [ts] are excluded: a wall-clock window cannot place an
-    undated decision, and dating it by guesswork would misreport history.
-
-    Storage failures are reported through the approval-queue failure metric and
-    yield an empty page rather than raising. *)
 
 module For_testing : sig
   type strict_snapshot_writer =

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -216,11 +216,11 @@ let deferred_reason_to_string = function
   | Human_requested -> "human_requested"
   | Judge_requested -> "judge_requested"
   | Auto_judge_unavailable _ ->
-    Keeper_approval_queue.summary_attempt_pre_worker_unavailable_code_to_string
-      Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+    Keeper_approval_queue_rules_types.summary_attempt_pre_worker_unavailable_code_to_string
+      Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
   | Mode_state_invalid _ ->
-    Keeper_approval_queue.summary_attempt_pre_worker_unavailable_code_to_string
-      Keeper_approval_queue.Summary_pre_worker_mode_state_invalid
+    Keeper_approval_queue_rules_types.summary_attempt_pre_worker_unavailable_code_to_string
+      Keeper_approval_queue_rules_types.Summary_pre_worker_mode_state_invalid
 ;;
 
 let unavailable_reason_to_string = function
@@ -338,14 +338,14 @@ type judgment_finalize_outcome =
   | Judgment_finalized
   | Judgment_skipped
 
-let resolve_judgment (entry : Keeper_approval_queue.pending_approval) ~approval_id
-      (summary : Keeper_approval_queue.hitl_context_summary) =
+let resolve_judgment (entry : Keeper_approval_queue_rules_types.pending_approval) ~approval_id
+      (summary : Keeper_approval_queue_rules_types.hitl_context_summary) =
   let decision =
-    match summary.Keeper_approval_queue.judgment with
-    | Keeper_approval_queue.Approve -> Some Keeper_approval_queue.Decision.Approve
-    | Keeper_approval_queue.Deny ->
-      Some (Keeper_approval_queue.Decision.Reject summary.rationale)
-    | Keeper_approval_queue.Require_human -> None
+    match summary.Keeper_approval_queue_rules_types.judgment with
+    | Keeper_approval_queue_rules_types.Approve -> Some Keeper_approval_queue_rules_types.Decision.Approve
+    | Keeper_approval_queue_rules_types.Deny ->
+      Some (Keeper_approval_queue_rules_types.Decision.Reject summary.rationale)
+    | Keeper_approval_queue_rules_types.Require_human -> None
   in
   match decision with
   | None -> Ok Judgment_skipped
@@ -355,7 +355,7 @@ let resolve_judgment (entry : Keeper_approval_queue.pending_approval) ~approval_
          ~base_path:entry.audit_base_path
          ~id:approval_id
          ~decision
-         ~source:Keeper_approval_queue.Auto_judge
+         ~source:Keeper_approval_queue_rules_types.Auto_judge
          ~created_by:("auto_judge:" ^ summary.model_run_id)
          ()
      with
@@ -385,7 +385,7 @@ end
 module Auto_judge_owners = Map.Make (Auto_judge_owner)
 module Auto_judge_owner_set = Set.Make (Auto_judge_owner)
 
-let auto_judge_owner (entry : Keeper_approval_queue.pending_approval) =
+let auto_judge_owner (entry : Keeper_approval_queue_rules_types.pending_approval) =
   entry.audit_base_path, entry.keeper_name
 ;;
 
@@ -395,7 +395,7 @@ let active_auto_judges : string Auto_judge_owners.t Atomic.t =
   Atomic.make Auto_judge_owners.empty
 ;;
 
-let rec claim_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+let rec claim_auto_judge (entry : Keeper_approval_queue_rules_types.pending_approval) =
   let active = Atomic.get active_auto_judges in
   let owner = auto_judge_owner entry in
   match Auto_judge_owners.find_opt owner active with
@@ -407,7 +407,7 @@ let rec claim_auto_judge (entry : Keeper_approval_queue.pending_approval) =
     else claim_auto_judge entry
 ;;
 
-let rec release_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+let rec release_auto_judge (entry : Keeper_approval_queue_rules_types.pending_approval) =
   let active = Atomic.get active_auto_judges in
   let owner = auto_judge_owner entry in
   match Auto_judge_owners.find_opt owner active with
@@ -427,30 +427,30 @@ let active_auto_judge_for_owner ~base_path ~keeper_name =
 type auto_judge_entry_class =
   | Auto_judge_not_requested
   | Auto_judge_pending_unbound
-  | Auto_judge_finalizable of Keeper_approval_queue.hitl_context_summary
+  | Auto_judge_finalizable of Keeper_approval_queue_rules_types.hitl_context_summary
   | Auto_judge_ineligible
 
 let classify_auto_judge_entry
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   match
     entry.summary_attempt_disposition,
     entry.exact_attempt,
     entry.summary_status
   with
-  | Keeper_approval_queue.Summary_attempt_ready,
-    Keeper_approval_queue.Exact_unbound,
-    Keeper_approval_queue.Summary_not_requested ->
+  | Keeper_approval_queue_rules_types.Summary_attempt_ready,
+    Keeper_approval_queue_rules_types.Exact_unbound,
+    Keeper_approval_queue_rules_types.Summary_not_requested ->
     Auto_judge_not_requested
-  | Keeper_approval_queue.Summary_attempt_ready,
-    Keeper_approval_queue.Exact_unbound,
-    Keeper_approval_queue.Summary_pending ->
+  | Keeper_approval_queue_rules_types.Summary_attempt_ready,
+    Keeper_approval_queue_rules_types.Exact_unbound,
+    Keeper_approval_queue_rules_types.Summary_pending ->
     Auto_judge_pending_unbound
-  | ( Keeper_approval_queue.Summary_attempt_settled
-    | Keeper_approval_queue.Summary_attempt_persistence_uncertain ),
-    Keeper_approval_queue.Exact_bound
-      { status = Keeper_approval_queue.Exact_completed; _ },
-    Keeper_approval_queue.Summary_available summary ->
+  | ( Keeper_approval_queue_rules_types.Summary_attempt_settled
+    | Keeper_approval_queue_rules_types.Summary_attempt_persistence_uncertain ),
+    Keeper_approval_queue_rules_types.Exact_bound
+      { status = Keeper_approval_queue_rules_types.Exact_completed; _ },
+    Keeper_approval_queue_rules_types.Summary_available summary ->
     Auto_judge_finalizable summary
   | _ ->
     Auto_judge_ineligible
@@ -467,8 +467,8 @@ let auto_judge_entry_ready entry =
 ;;
 
 let compare_auto_judge_entries
-      (left : Keeper_approval_queue.pending_approval)
-      (right : Keeper_approval_queue.pending_approval)
+      (left : Keeper_approval_queue_rules_types.pending_approval)
+      (right : Keeper_approval_queue_rules_types.pending_approval)
   =
   Int.compare left.sequence right.sequence
 ;;
@@ -478,7 +478,7 @@ let compare_auto_judge_entries
    Auto Judge may start. *)
 let owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries =
   entries
-  |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+  |> List.filter (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
     String.equal entry.audit_base_path base_path
     && String.equal entry.keeper_name keeper_name)
   |> List.sort compare_auto_judge_entries
@@ -486,7 +486,7 @@ let owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries =
 
 let auto_judge_entry_has_start_reservation
       reserved_id
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   String.equal entry.id reserved_id
   &&
@@ -495,11 +495,11 @@ let auto_judge_entry_has_start_reservation
     entry.exact_attempt,
     entry.summary_attempt_disposition
   with
-  | Keeper_approval_queue.Summary_pending,
-    Keeper_approval_queue.Exact_unbound,
-    Keeper_approval_queue.Summary_attempt_pre_worker_unavailable
+  | Keeper_approval_queue_rules_types.Summary_pending,
+    Keeper_approval_queue_rules_types.Exact_unbound,
+    Keeper_approval_queue_rules_types.Summary_attempt_pre_worker_unavailable
       { reason_code =
-          Keeper_approval_queue.Summary_pre_worker_start_reserved
+          Keeper_approval_queue_rules_types.Summary_pre_worker_start_reserved
       ; _
       } ->
     true
@@ -527,7 +527,7 @@ let ready_auto_judges_for_owner
       ~keeper_name
       entries
   =
-  let startable (entry : Keeper_approval_queue.pending_approval) =
+  let startable (entry : Keeper_approval_queue_rules_types.pending_approval) =
     auto_judge_entry_ready entry
     ||
     (match reserved_id with
@@ -628,14 +628,14 @@ let drain_auto_judge_owners_with ~drain_owner owners =
 
 type hitl_worker_spawner =
   sw:Eio.Switch.t ->
-  entry:Keeper_approval_queue.pending_approval ->
-  on_summary:(Keeper_approval_queue.hitl_context_summary -> unit) ->
+  entry:Keeper_approval_queue_rules_types.pending_approval ->
+  on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit) ->
   on_finish:(Hitl_summary_worker.finish_outcome -> unit) ->
   unit ->
   (Hitl_summary_worker.spawn_outcome, string) result
 
 let mark_pre_worker_unavailable
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
       ~reason_code
       ~operator_detail
   =
@@ -659,12 +659,12 @@ let durable_pre_worker_unavailable_error reason = function
 ;;
 
 let reserve_pre_worker_start
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   match
     mark_pre_worker_unavailable
       entry
-      ~reason_code:Keeper_approval_queue.Summary_pre_worker_start_reserved
+      ~reason_code:Keeper_approval_queue_rules_types.Summary_pre_worker_start_reserved
       ~operator_detail:
         Keeper_approval_queue.summary_attempt_start_reserved_operator_detail
   with
@@ -679,7 +679,7 @@ let reserve_pre_worker_start
 
 let rec spawn_claimed_auto_judge_entry_with
       ~(spawn_worker : hitl_worker_spawner)
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   let approval_id = entry.id in
   let on_summary summary =
@@ -698,7 +698,7 @@ let rec spawn_claimed_auto_judge_entry_with
          mark_pre_worker_unavailable
            entry
            ~reason_code:
-             Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+             Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
            ~operator_detail:reason
          |> durable_pre_worker_unavailable_error reason
          |> Result.error)
@@ -774,7 +774,7 @@ and spawn_claimed_auto_judge_entry entry =
 
 and spawn_auto_judge_entry_with
       ~(spawn_worker : hitl_worker_spawner)
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   if claim_auto_judge entry
   then spawn_claimed_auto_judge_entry_with ~spawn_worker entry
@@ -791,7 +791,7 @@ and retry_auto_judge_entry
       ~expected_sequence
       ~expected_exact_attempt
       ~expected_disposition
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   match
     Keeper_approval_queue.reserve_summary_attempt_retry
@@ -811,7 +811,7 @@ and retry_auto_judge_entry
       mark_pre_worker_unavailable
         entry
         ~reason_code:
-          Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+          Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
         ~operator_detail:reason
       |> durable_pre_worker_unavailable_error reason
     in
@@ -863,7 +863,7 @@ and retry_auto_judge_entry
        in
        Error (reblock reason))
 
-and start_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+and start_auto_judge (entry : Keeper_approval_queue_rules_types.pending_approval) =
   if not (claim_auto_judge entry)
   then Ok Skipped
   else
@@ -876,7 +876,7 @@ and start_auto_judge (entry : Keeper_approval_queue.pending_approval) =
       Ok Skipped
     | Ok true -> spawn_claimed_auto_judge_entry entry
 
-and start_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+and start_auto_judge_entry (entry : Keeper_approval_queue_rules_types.pending_approval) =
   match
     Keeper_approval_queue.get_pending_entry_for_workspace
       ~base_path:entry.audit_base_path
@@ -959,7 +959,7 @@ and drain_auto_judge_owner_queue
       | Some reserved_id, [] ->
         (match
            List.exists
-             (fun (entry : Keeper_approval_queue.pending_approval) ->
+             (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
                 String.equal entry.id reserved_id)
              entries
          with
@@ -1020,7 +1020,7 @@ and drain_auto_judges ~base_path =
      | Ok entries ->
        let owners =
          List.fold_left
-           (fun owners (entry : Keeper_approval_queue.pending_approval) ->
+           (fun owners (entry : Keeper_approval_queue_rules_types.pending_approval) ->
               if auto_judge_entry_ready entry
               then Auto_judge_owner_set.add (auto_judge_owner entry) owners
               else owners)
@@ -1040,10 +1040,10 @@ and drain_auto_judges ~base_path =
 ;;
 
 type recovered_work =
-  | Activate_worker of Keeper_approval_queue.pending_approval
+  | Activate_worker of Keeper_approval_queue_rules_types.pending_approval
   | Finalize_judgment of
-      Keeper_approval_queue.pending_approval
-      * Keeper_approval_queue.hitl_context_summary
+      Keeper_approval_queue_rules_types.pending_approval
+      * Keeper_approval_queue_rules_types.hitl_context_summary
 
 let recovered_work_for_base_path ~base_path =
   let enabled =
@@ -1064,24 +1064,24 @@ let recovered_work_for_base_path ~base_path =
     |> Result.map (fun entries ->
     let owners =
       List.fold_left
-        (fun owners (entry : Keeper_approval_queue.pending_approval) ->
+        (fun owners (entry : Keeper_approval_queue_rules_types.pending_approval) ->
            Auto_judge_owner_set.add (auto_judge_owner entry) owners)
         Auto_judge_owner_set.empty
         entries
     in
     let recovered_work_for_entry
-          (entry : Keeper_approval_queue.pending_approval)
+          (entry : Keeper_approval_queue_rules_types.pending_approval)
       =
       match classify_auto_judge_entry entry with
       | Auto_judge_not_requested
       | Auto_judge_pending_unbound ->
         Some (Activate_worker entry)
       | Auto_judge_finalizable
-          ({ judgment = (Keeper_approval_queue.Approve | Keeper_approval_queue.Deny); _ }
+          ({ judgment = (Keeper_approval_queue_rules_types.Approve | Keeper_approval_queue_rules_types.Deny); _ }
            as summary) ->
         Some (Finalize_judgment (entry, summary))
       | Auto_judge_finalizable
-          { judgment = Keeper_approval_queue.Require_human; _ }
+          { judgment = Keeper_approval_queue_rules_types.Require_human; _ }
       | Auto_judge_ineligible ->
         None
     in
@@ -1107,7 +1107,7 @@ let recovered_work_for_base_path ~base_path =
         (entry_of_recovered_work right)))
 ;;
 
-let observe_recovered_work kind (entry : Keeper_approval_queue.pending_approval) =
+let observe_recovered_work kind (entry : Keeper_approval_queue_rules_types.pending_approval) =
   let event_type, outcome =
     match kind with
     | `Activate_worker ->
@@ -1205,7 +1205,7 @@ let retry_blocked_auto_judge
 
 let finalize_recovered_judgment
       ~complete_summary_exact_attempt
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
       summary
   =
   let persistence_uncertain () =
@@ -1218,12 +1218,12 @@ let finalize_recovered_judgment
        : (bool, Keeper_approval_queue.exact_attempt_error) result)
   in
   match entry.exact_attempt with
-  | Keeper_approval_queue.Exact_unbound ->
+  | Keeper_approval_queue_rules_types.Exact_unbound ->
     Error
       ( Resume_identity_unbound
       , "Recovered Auto Judge output has no exact attempt identity; finalization is withheld." )
-  | Keeper_approval_queue.Exact_bound
-      ({ status = Keeper_approval_queue.Exact_completed; _ } as binding) ->
+  | Keeper_approval_queue_rules_types.Exact_bound
+      ({ status = Keeper_approval_queue_rules_types.Exact_completed; _ } as binding) ->
     (match
        complete_summary_exact_attempt
          ~id:entry.id
@@ -1263,7 +1263,7 @@ let finalize_recovered_judgment
        Error
          ( Resume_completion_rejected rejection
          , completion_rejection_operator_detail rejection ))
-  | Keeper_approval_queue.Exact_bound _ ->
+  | Keeper_approval_queue_rules_types.Exact_bound _ ->
     Error
       ( Resume_exact_state_not_completed
       , "Recovered Auto Judge entry is not a completed exact judgment." )
@@ -1366,7 +1366,7 @@ let request_operator_auto_judge_recovery ~base_path =
            | Ok entries ->
              let queued =
                List.fold_left
-                 (fun count (entry : Keeper_approval_queue.pending_approval) ->
+                 (fun count (entry : Keeper_approval_queue_rules_types.pending_approval) ->
                     if auto_judge_entry_ready entry then count + 1 else count)
                  0
                  entries
@@ -1434,7 +1434,7 @@ let defer request reason =
              "Auto Judge pre-worker block observation superseded approval=%s \
               reason_code=%s reason=%s"
              approval_id
-             (Keeper_approval_queue
+             (Keeper_approval_queue_rules_types
               .summary_attempt_pre_worker_unavailable_code_to_string
                 reason_code)
              (Keeper_approval_queue.exact_attempt_error_to_string
@@ -1446,7 +1446,7 @@ let defer request reason =
        (match
           persist_pre_worker_block
             ~reason_code:
-              Keeper_approval_queue.Summary_pre_worker_mode_state_invalid
+              Keeper_approval_queue_rules_types.Summary_pre_worker_mode_state_invalid
             detail
         with
         | Ok () -> Deferred { approval_id; reason }
@@ -1455,7 +1455,7 @@ let defer request reason =
        (match
           persist_pre_worker_block
             ~reason_code:
-              Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+              Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
             detail
         with
         | Ok () -> Deferred { approval_id; reason }
@@ -1464,7 +1464,7 @@ let defer request reason =
 ;;
 
 let observe_exact_rule_store_degraded (request : request) error =
-  let detail = Keeper_approval_queue.rule_store_error_to_string error in
+  let detail = Keeper_approval_queue_rules_types.rule_store_error_to_string error in
   Log.Keeper.error
     ~keeper_name:request.keeper_name
     "exact Always Allowed rule lookup unavailable operation=%s: %s; continuing configured Gate mode"
@@ -1488,7 +1488,7 @@ let observe_exact_rule_store_degraded (request : request) error =
 
 let observe_exact_rule_expired
       (request : request)
-      (rule_match : Keeper_approval_queue.rule_match)
+      (rule_match : Keeper_approval_queue_rules_types.rule_match)
   =
   Log.Keeper.warn
     ~keeper_name:request.keeper_name
@@ -1516,7 +1516,7 @@ let decide_from_selected_mode request = function
     let source = Workspace_always_allow in
     audit_allow
       request
-      ~decision_source:Keeper_approval_queue.Always_allowed
+      ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
       source;
     Allow { source }
 ;;
@@ -1527,7 +1527,7 @@ let decide_without_cycle_grant ~keeper_always_allow request =
     let source = Keeper_always_allow in
     audit_allow
       request
-      ~decision_source:Keeper_approval_queue.Always_allowed
+      ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
       source;
     Allow { source })
   else
@@ -1537,12 +1537,12 @@ let decide_without_cycle_grant ~keeper_always_allow request =
        let source = Workspace_always_allow in
        audit_allow
          request
-         ~decision_source:Keeper_approval_queue.Always_allowed
+         ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
          source;
        Allow { source }
      | Error _ | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Auto_judge) ->
        (match
-          Keeper_approval_queue.find_matching_rule
+          Keeper_approval_queue_rules.find_matching_rule
             ~base_path:request.base_path
             ~keeper_name:request.keeper_name
             ~tool_name:request.operation
@@ -1552,18 +1552,18 @@ let decide_without_cycle_grant ~keeper_always_allow request =
         | Error error ->
           observe_exact_rule_store_degraded request error;
           decide_from_selected_mode request mode
-        | Ok (Keeper_approval_queue.Rule_match_active rule_match) ->
+        | Ok (Keeper_approval_queue_rules_types.Rule_match_active rule_match) ->
           let source = Exact_always_rule rule_match.rule_id in
           audit_allow
             request
             ~rule_match
-            ~decision_source:Keeper_approval_queue.Always_allowed
+            ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
             source;
           Allow { source }
-        | Ok (Keeper_approval_queue.Rule_match_expired rule_match) ->
+        | Ok (Keeper_approval_queue_rules_types.Rule_match_expired rule_match) ->
           observe_exact_rule_expired request rule_match;
           decide_from_selected_mode request mode
-        | Ok Keeper_approval_queue.Rule_match_absent ->
+        | Ok Keeper_approval_queue_rules_types.Rule_match_absent ->
           decide_from_selected_mode request mode))
 ;;
 
@@ -1613,7 +1613,7 @@ module For_testing = struct
     call_id:string ->
     plan_fingerprint:string ->
     request_body_sha256:string ->
-    summary:Keeper_approval_queue.hitl_context_summary ->
+    summary:Keeper_approval_queue_rules_types.hitl_context_summary ->
     ( Keeper_approval_queue.exact_attempt_transition
     , Keeper_approval_queue.exact_attempt_error )
       result

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -137,8 +137,8 @@ val retry_blocked_auto_judge :
   requested_by:string ->
   expected_input_hash:string ->
   expected_sequence:int ->
-  expected_exact_attempt:Keeper_approval_queue.exact_attempt_state ->
-  expected_disposition:Keeper_approval_queue.summary_attempt_disposition ->
+  expected_exact_attempt:Keeper_approval_queue_rules_types.exact_attempt_state ->
+  expected_disposition:Keeper_approval_queue_rules_types.summary_attempt_disposition ->
   string ->
   (unit, string) result
 (** Explicitly rearm one typed blocked Auto Judge summary. The configured Gate
@@ -183,22 +183,22 @@ module For_testing : sig
     call_id:string ->
     plan_fingerprint:string ->
     request_body_sha256:string ->
-    summary:Keeper_approval_queue.hitl_context_summary ->
+    summary:Keeper_approval_queue_rules_types.hitl_context_summary ->
     ( Keeper_approval_queue.exact_attempt_transition
     , Keeper_approval_queue.exact_attempt_error )
       result
 
   val auto_judge_entry_ready :
-    Keeper_approval_queue.pending_approval -> bool
+    Keeper_approval_queue_rules_types.pending_approval -> bool
 
   val ready_auto_judges_for_owner :
     base_path:string ->
     keeper_name:string ->
-    Keeper_approval_queue.pending_approval list ->
-    Keeper_approval_queue.pending_approval list
+    Keeper_approval_queue_rules_types.pending_approval list ->
+    Keeper_approval_queue_rules_types.pending_approval list
 
-  val claim_auto_judge : Keeper_approval_queue.pending_approval -> bool
-  val release_auto_judge : Keeper_approval_queue.pending_approval -> unit
+  val claim_auto_judge : Keeper_approval_queue_rules_types.pending_approval -> bool
+  val release_auto_judge : Keeper_approval_queue_rules_types.pending_approval -> unit
 
   type owner_drain_outcome =
     { started_id : string option
@@ -217,15 +217,15 @@ module For_testing : sig
 
   type hitl_worker_spawner =
     sw:Eio.Switch.t ->
-    entry:Keeper_approval_queue.pending_approval ->
-    on_summary:(Keeper_approval_queue.hitl_context_summary -> unit) ->
+    entry:Keeper_approval_queue_rules_types.pending_approval ->
+    on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit) ->
     on_finish:(Hitl_summary_worker.finish_outcome -> unit) ->
     unit ->
     (Hitl_summary_worker.spawn_outcome, string) result
 
   val spawn_auto_judge_entry_with_worker
     :  spawn_worker:hitl_worker_spawner
-    -> Keeper_approval_queue.pending_approval
+    -> Keeper_approval_queue_rules_types.pending_approval
     -> (bool, string) result
   (** Run the production atomic claim, active-owner lifecycle, cleanup, and
       conclusive-only drain with only the worker spawner injected. *)

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -1,0 +1,1020 @@
+type client_kind =
+  | Codex
+  | Claude_code
+  | Antigravity
+
+type settlement =
+  { session_id : string
+  ; turn_id : string
+  }
+
+type recovery_failure =
+  | Transient_spawn_failed
+  | Transport_interrupted
+  | Protocol_failed
+  | Provider_rejected
+  | Host_hook_failed
+  | State_persistence_failed
+  | Process_restarted
+
+type failure_disposition =
+  | Transient
+  | Ambiguous
+  | Fatal
+
+let failure_disposition = function
+  | Transient_spawn_failed -> Transient
+  | Transport_interrupted
+  | Protocol_failed
+  | Host_hook_failed
+  | State_persistence_failed
+  | Process_restarted ->
+    Ambiguous
+  | Provider_rejected -> Fatal
+;;
+
+type recovery_required =
+  { recovery_id : string
+  ; previous_settlement : settlement option
+  ; observed_session_id : string option
+  ; observed_turn_id : string option
+  ; owner_epoch : string
+  ; failure : recovery_failure
+  ; detail : string
+  ; required_at : float
+  }
+
+type phase =
+  | Ready
+  | Start of
+      { owner_epoch : string
+      ; previous_settlement : settlement option
+      }
+  | Active of
+      { owner_epoch : string
+      ; session_id : string
+      ; previous_settlement : settlement option
+      }
+  | Turn_inflight of
+      { owner_epoch : string
+      ; session_id : string
+      ; turn_id : string option
+      ; previous_settlement : settlement option
+      }
+  | Recovery_required of recovery_required
+  | Settled of settlement
+
+type recovery_resolution =
+  | Retry_previous
+  | Restart_fresh
+  | Adopt_verified of settlement
+
+type recovery_resolution_record =
+  { recovery_id : string
+  ; failure : recovery_failure
+  ; resolution : recovery_resolution
+  ; resolved_by : string
+  ; resolved_at : float
+  }
+
+type transient_release_record =
+  { failure : recovery_failure
+  ; owner_epoch : string
+  ; released_at : float
+  }
+
+type t =
+  { client_kind : client_kind
+  ; runtime_id : string
+  ; phase : phase
+  ; turn_count : int
+  ; tool_surface_sha256 : string
+  ; last_recovery_resolution : recovery_resolution_record option
+  ; last_transient_release : transient_release_record option
+  ; updated_at : float
+  }
+
+type claim_plan =
+  { previous_settlement : settlement option
+  ; turn_count : int
+  ; required_tool_surface_sha256 : string option
+  }
+
+let ( let* ) = Result.bind
+let schema = "masc.keeper.official-client-session.v1"
+let filename = "session.json"
+let state_dirname = "official-client-runtime"
+let lock_filename = "session.lock"
+let recovery_rng = Random.State.make_self_init ()
+let recovery_rng_mutex = Stdlib.Mutex.create ()
+
+let fresh_recovery_id () =
+  Stdlib.Mutex.protect recovery_rng_mutex (fun () ->
+    Uuidm.v4_gen recovery_rng () |> Uuidm.to_string)
+;;
+
+let process_epoch_value = lazy (fresh_recovery_id ())
+let process_epoch () = Lazy.force process_epoch_value
+
+let state_dir ~base_path ~keeper_name =
+  if not (Safe_identifier.is_portable_name keeper_name)
+  then Error (Printf.sprintf "invalid official-client Keeper name %S" keeper_name)
+  else
+    Ok
+      (Filename.concat
+         (Filename.concat
+            (Common.keepers_runtime_dir_of_base ~base_path)
+            keeper_name)
+         state_dirname)
+;;
+
+let path ~base_path ~keeper_name =
+  Result.map
+    (fun directory -> Filename.concat directory filename)
+    (state_dir ~base_path ~keeper_name)
+;;
+
+let rec canonical_json = function
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       |> List.map (fun (name, value) -> name, canonical_json value)
+       |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | `List values -> `List (List.map canonical_json values)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as value ->
+    value
+;;
+
+let tool_surface_sha256 tools =
+  let tool_json (tool : Agent_sdk.Tool.t) =
+    let parameters =
+      List.sort
+        (fun (left : Agent_sdk.Types.tool_param) right ->
+           String.compare left.name right.name)
+        tool.schema.parameters
+    in
+    `Assoc
+      [ "description", `String tool.schema.description
+      ; "input_schema", Agent_sdk.Types.params_to_input_schema parameters
+      ; "name", `String tool.schema.name
+      ]
+    |> canonical_json
+  in
+  tools
+  |> List.sort (fun (left : Agent_sdk.Tool.t) right ->
+    String.compare left.schema.name right.schema.name)
+  |> List.map tool_json
+  |> fun tools -> Yojson.Safe.to_string (`List tools)
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
+let valid_sha256 value =
+  String.length value = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value
+;;
+
+let non_empty field value =
+  if String.equal (String.trim value) ""
+  then Error (Printf.sprintf "official-client session %s must not be empty" field)
+  else Ok ()
+;;
+
+let validate_uuid field value =
+  if Option.is_some (Uuidm.of_string value)
+  then Ok ()
+  else Error (Printf.sprintf "official-client session %s must be a UUID" field)
+;;
+
+let validate_settlement { session_id; turn_id } =
+  let* () = non_empty "session_id" session_id in
+  non_empty "turn_id" turn_id
+;;
+
+let validate_settlement_opt = function
+  | None -> Ok ()
+  | Some settlement -> validate_settlement settlement
+;;
+
+let validate_recovery (recovery : recovery_required) =
+  let* () = validate_uuid "recovery_id" recovery.recovery_id in
+  let* () = validate_uuid "owner_epoch" recovery.owner_epoch in
+  let* () = validate_settlement_opt recovery.previous_settlement in
+  let* () =
+    match recovery.observed_session_id with
+    | None -> Ok ()
+    | Some session_id -> non_empty "observed_session_id" session_id
+  in
+  let* () =
+    match recovery.observed_turn_id, recovery.observed_session_id with
+    | None, _ -> Ok ()
+    | Some turn_id, Some _ -> non_empty "observed_turn_id" turn_id
+    | Some _, None ->
+      Error "official-client recovery observed_turn_id requires observed_session_id"
+  in
+  let* () = non_empty "recovery detail" recovery.detail in
+  if Float.is_finite recovery.required_at
+  then Ok ()
+  else Error "official-client recovery required_at must be finite"
+;;
+
+let validate_recovery_resolution = function
+  | Retry_previous | Restart_fresh -> Ok ()
+  | Adopt_verified settlement -> validate_settlement settlement
+;;
+
+let validate_recovery_resolution_record (record : recovery_resolution_record) =
+  let* () = validate_uuid "resolved recovery_id" record.recovery_id in
+  let* () = validate_recovery_resolution record.resolution in
+  let* () = non_empty "resolved_by" record.resolved_by in
+  if Float.is_finite record.resolved_at
+  then Ok ()
+  else Error "official-client recovery resolved_at must be finite"
+;;
+
+let validate_transient_release_record (record : transient_release_record) =
+  let* () =
+    match failure_disposition record.failure with
+    | Transient -> Ok ()
+    | Ambiguous | Fatal ->
+      Error "official-client transient release must contain a transient failure"
+  in
+  let* () = validate_uuid "transient owner_epoch" record.owner_epoch in
+  if Float.is_finite record.released_at
+  then Ok ()
+  else Error "official-client transient released_at must be finite"
+;;
+
+let validate_phase = function
+  | Ready -> Ok ()
+  | Start { owner_epoch; previous_settlement } ->
+    let* () = validate_uuid "owner_epoch" owner_epoch in
+    validate_settlement_opt previous_settlement
+  | Active { owner_epoch; session_id; previous_settlement }
+  | Turn_inflight
+      { owner_epoch; session_id; turn_id = None; previous_settlement } ->
+    let* () = validate_uuid "owner_epoch" owner_epoch in
+    let* () = non_empty "session_id" session_id in
+    validate_settlement_opt previous_settlement
+  | Turn_inflight
+      { owner_epoch
+      ; session_id
+      ; turn_id = Some turn_id
+      ; previous_settlement
+      } ->
+    let* () = validate_uuid "owner_epoch" owner_epoch in
+    let* () = non_empty "session_id" session_id in
+    let* () = non_empty "turn_id" turn_id in
+    validate_settlement_opt previous_settlement
+  | Recovery_required recovery -> validate_recovery recovery
+  | Settled settlement -> validate_settlement settlement
+;;
+
+let validate binding =
+  let* () = non_empty "runtime_id" binding.runtime_id in
+  let* () = validate_phase binding.phase in
+  let* () =
+    match binding.last_recovery_resolution with
+    | None -> Ok ()
+    | Some record -> validate_recovery_resolution_record record
+  in
+  let* () =
+    match binding.last_transient_release with
+    | None -> Ok ()
+    | Some record -> validate_transient_release_record record
+  in
+  if binding.turn_count < 0
+  then Error "official-client session turn_count must be non-negative"
+  else if binding.turn_count = 0 && binding.phase <> Ready
+  then Error "only a ready official-client session may have zero completed turns"
+  else if not (valid_sha256 binding.tool_surface_sha256)
+  then Error "official-client session tool_surface_sha256 must be lowercase SHA-256"
+  else if not (Float.is_finite binding.updated_at)
+  then Error "official-client session updated_at must be finite"
+  else Ok ()
+;;
+
+let settlement_to_yojson settlement =
+  `Assoc
+    [ "session_id", `String settlement.session_id
+    ; "turn_id", `String settlement.turn_id
+    ]
+;;
+
+let settlement_opt_to_yojson = function
+  | None -> `Null
+  | Some settlement -> settlement_to_yojson settlement
+;;
+
+let settlement_of_yojson = function
+  | `Assoc [ "session_id", `String session_id; "turn_id", `String turn_id ]
+  | `Assoc [ "turn_id", `String turn_id; "session_id", `String session_id ] ->
+    let settlement = { session_id; turn_id } in
+    let* () = validate_settlement settlement in
+    Ok settlement
+  | _ -> Error "official-client settlement fields are not exact"
+;;
+
+let settlement_opt_of_yojson = function
+  | `Null -> Ok None
+  | json -> Result.map Option.some (settlement_of_yojson json)
+;;
+
+let recovery_failure_to_string = function
+  | Transient_spawn_failed -> "transient_spawn_failed"
+  | Transport_interrupted -> "transport_interrupted"
+  | Protocol_failed -> "protocol_failed"
+  | Provider_rejected -> "provider_rejected"
+  | Host_hook_failed -> "host_hook_failed"
+  | State_persistence_failed -> "state_persistence_failed"
+  | Process_restarted -> "process_restarted"
+;;
+
+let recovery_failure_of_string = function
+  | "transient_spawn_failed" -> Ok Transient_spawn_failed
+  | "transport_interrupted" -> Ok Transport_interrupted
+  | "protocol_failed" -> Ok Protocol_failed
+  | "provider_rejected" -> Ok Provider_rejected
+  | "host_hook_failed" -> Ok Host_hook_failed
+  | "state_persistence_failed" -> Ok State_persistence_failed
+  | "process_restarted" -> Ok Process_restarted
+  | _ -> Error "unknown official-client recovery failure"
+;;
+
+let client_kind_to_string = function
+  | Codex -> "codex"
+  | Claude_code -> "claude_code"
+  | Antigravity -> "antigravity"
+;;
+
+let client_kind_of_string = function
+  | "codex" -> Ok Codex
+  | "claude_code" -> Ok Claude_code
+  | "antigravity" -> Ok Antigravity
+  | _ -> Error "unknown official-client kind"
+;;
+
+let recovery_resolution_to_yojson = function
+  | Retry_previous -> `Assoc [ "kind", `String "retry_previous" ]
+  | Restart_fresh -> `Assoc [ "kind", `String "restart_fresh" ]
+  | Adopt_verified settlement ->
+    `Assoc
+      [ "kind", `String "adopt_verified"
+      ; "settlement", settlement_to_yojson settlement
+      ]
+;;
+
+let recovery_resolution_of_yojson = function
+  | `Assoc [ "kind", `String "retry_previous" ] -> Ok Retry_previous
+  | `Assoc [ "kind", `String "restart_fresh" ] -> Ok Restart_fresh
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "kind", `String "adopt_verified"; "settlement", settlement_json ] ->
+       Result.map (fun settlement -> Adopt_verified settlement)
+         (settlement_of_yojson settlement_json)
+     | _ -> Error "official-client recovery resolution fields are not exact")
+  | _ -> Error "official-client recovery resolution must be a JSON object"
+;;
+
+let recovery_resolution_record_to_yojson
+    (record : recovery_resolution_record) =
+  `Assoc
+    [ "failure", `String (recovery_failure_to_string record.failure)
+    ; "recovery_id", `String record.recovery_id
+    ; "resolution", recovery_resolution_to_yojson record.resolution
+    ; "resolved_at", `Float record.resolved_at
+    ; "resolved_by", `String record.resolved_by
+    ]
+;;
+
+let recovery_resolution_record_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "failure", `String failure; "recovery_id", `String recovery_id
+       ; "resolution", resolution_json; "resolved_at", `Float resolved_at
+       ; "resolved_by", `String resolved_by ] ->
+       let* failure = recovery_failure_of_string failure in
+       let* resolution = recovery_resolution_of_yojson resolution_json in
+       let record =
+         { recovery_id; failure; resolution; resolved_by; resolved_at }
+       in
+       let* () = validate_recovery_resolution_record record in
+       Ok record
+     | _ -> Error "official-client recovery resolution record fields are not exact")
+  | _ -> Error "official-client recovery resolution record must be a JSON object"
+;;
+
+let recovery_resolution_record_opt_to_yojson = function
+  | None -> `Null
+  | Some record -> recovery_resolution_record_to_yojson record
+;;
+
+let recovery_resolution_record_opt_of_yojson = function
+  | `Null -> Ok None
+  | json ->
+    Result.map Option.some (recovery_resolution_record_of_yojson json)
+;;
+
+let transient_release_record_to_yojson (record : transient_release_record) =
+  `Assoc
+    [ "failure", `String (recovery_failure_to_string record.failure)
+    ; "owner_epoch", `String record.owner_epoch
+    ; "released_at", `Float record.released_at
+    ]
+;;
+
+let transient_release_record_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "failure", `String failure; "owner_epoch", `String owner_epoch
+       ; "released_at", `Float released_at ] ->
+       let* failure = recovery_failure_of_string failure in
+       let record = { failure; owner_epoch; released_at } in
+       let* () = validate_transient_release_record record in
+       Ok record
+     | _ -> Error "official-client transient release fields are not exact")
+  | _ -> Error "official-client transient release must be a JSON object"
+;;
+
+let transient_release_record_opt_to_yojson = function
+  | None -> `Null
+  | Some record -> transient_release_record_to_yojson record
+;;
+
+let transient_release_record_opt_of_yojson = function
+  | `Null -> Ok None
+  | json -> Result.map Option.some (transient_release_record_of_yojson json)
+;;
+
+let string_opt_to_yojson = function
+  | None -> `Null
+  | Some value -> `String value
+;;
+
+let string_opt_of_yojson field = function
+  | `Null -> Ok None
+  | `String value ->
+    let* () = non_empty field value in
+    Ok (Some value)
+  | _ -> Error (Printf.sprintf "official-client recovery %s must be string or null" field)
+;;
+
+let phase_to_yojson = function
+  | Ready -> `Assoc [ "kind", `String "ready" ]
+  | Start { owner_epoch; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "start"
+      ; "owner_epoch", `String owner_epoch
+      ; "previous_settlement", settlement_opt_to_yojson previous_settlement
+      ]
+  | Active { owner_epoch; session_id; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "active"
+      ; "owner_epoch", `String owner_epoch
+      ; "previous_settlement", settlement_opt_to_yojson previous_settlement
+      ; "session_id", `String session_id
+      ]
+  | Turn_inflight { owner_epoch; session_id; turn_id; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "turn_inflight"
+      ; "owner_epoch", `String owner_epoch
+      ; "previous_settlement", settlement_opt_to_yojson previous_settlement
+      ; "session_id", `String session_id
+      ; ( "turn_id"
+        , Option.fold ~none:`Null ~some:(fun turn_id -> `String turn_id) turn_id )
+      ]
+  | Recovery_required recovery ->
+    `Assoc
+      [ "detail", `String recovery.detail
+      ; "failure", `String (recovery_failure_to_string recovery.failure)
+      ; "kind", `String "recovery_required"
+      ; "observed_session_id", string_opt_to_yojson recovery.observed_session_id
+      ; "observed_turn_id", string_opt_to_yojson recovery.observed_turn_id
+      ; "owner_epoch", `String recovery.owner_epoch
+      ; ( "previous_settlement"
+        , settlement_opt_to_yojson recovery.previous_settlement )
+      ; "recovery_id", `String recovery.recovery_id
+      ; "required_at", `Float recovery.required_at
+      ]
+  | Settled { session_id; turn_id } ->
+    `Assoc
+      [ "kind", `String "settled"
+      ; "session_id", `String session_id
+      ; "turn_id", `String turn_id
+      ]
+;;
+
+let phase_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "kind", `String "ready" ] -> Ok Ready
+     | [ "kind", `String "start"; "owner_epoch", `String owner_epoch
+       ; "previous_settlement", previous ] ->
+       let* previous_settlement = settlement_opt_of_yojson previous in
+       Ok (Start { owner_epoch; previous_settlement })
+     | [ "kind", `String "active"; "owner_epoch", `String owner_epoch
+       ; "previous_settlement", previous
+       ; "session_id", `String session_id ] ->
+       let* previous_settlement = settlement_opt_of_yojson previous in
+       Ok (Active { owner_epoch; session_id; previous_settlement })
+     | [ "kind", `String "turn_inflight"; "owner_epoch", `String owner_epoch
+       ; "previous_settlement", previous
+       ; "session_id", `String session_id; "turn_id", turn_id_json ] ->
+       let* previous_settlement = settlement_opt_of_yojson previous in
+       let* turn_id = string_opt_of_yojson "observed_turn_id" turn_id_json in
+       Ok (Turn_inflight { owner_epoch; session_id; turn_id; previous_settlement })
+     | [ "detail", `String detail; "failure", `String failure
+       ; "kind", `String "recovery_required"
+       ; "observed_session_id", observed_session_json
+       ; "observed_turn_id", observed_turn_json
+       ; "owner_epoch", `String owner_epoch
+       ; "previous_settlement", previous_json
+       ; "recovery_id", `String recovery_id; "required_at", `Float required_at
+       ] ->
+       let* failure = recovery_failure_of_string failure in
+       let* observed_session_id =
+         string_opt_of_yojson "observed_session_id" observed_session_json
+       in
+       let* observed_turn_id =
+         string_opt_of_yojson "observed_turn_id" observed_turn_json
+       in
+       let* previous_settlement = settlement_opt_of_yojson previous_json in
+       let recovery =
+         { recovery_id
+         ; previous_settlement
+         ; observed_session_id
+         ; observed_turn_id
+         ; owner_epoch
+         ; failure
+         ; detail
+         ; required_at
+         }
+       in
+       let* () = validate_recovery recovery in
+       Ok (Recovery_required recovery)
+     | [ "kind", `String "settled"; "session_id", `String session_id
+       ; "turn_id", `String turn_id ] ->
+       Ok (Settled { session_id; turn_id })
+     | _ -> Error "official-client session phase fields are not exact")
+  | _ -> Error "official-client session phase must be a JSON object"
+;;
+
+let to_yojson binding =
+  `Assoc
+    [ "client_kind", `String (client_kind_to_string binding.client_kind)
+    ; ( "last_recovery_resolution"
+      , recovery_resolution_record_opt_to_yojson
+          binding.last_recovery_resolution )
+    ; ( "last_transient_release"
+      , transient_release_record_opt_to_yojson binding.last_transient_release )
+    ; "runtime_id", `String binding.runtime_id
+    ; "phase", phase_to_yojson binding.phase
+    ; "schema", `String schema
+    ; "tool_surface_sha256", `String binding.tool_surface_sha256
+    ; "turn_count", `Int binding.turn_count
+    ; "updated_at", `Float binding.updated_at
+    ]
+;;
+
+let of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "client_kind", `String client_kind_json
+       ; "last_recovery_resolution", last_resolution_json
+       ; "last_transient_release", last_transient_release_json
+       ; "phase", phase_json
+       ; "runtime_id", `String runtime_id
+       ; "schema", `String encoded_schema
+       ; "tool_surface_sha256", `String tool_surface_sha256
+       ; "turn_count", `Int turn_count
+       ; "updated_at", `Float updated_at
+       ] ->
+       if not (String.equal encoded_schema schema)
+       then Error "unsupported official-client session schema"
+       else
+         let* client_kind = client_kind_of_string client_kind_json in
+         let* phase = phase_of_yojson phase_json in
+         let* last_recovery_resolution =
+           recovery_resolution_record_opt_of_yojson last_resolution_json
+         in
+         let* last_transient_release =
+           transient_release_record_opt_of_yojson last_transient_release_json
+         in
+         let binding =
+           { client_kind
+           ; runtime_id
+           ; phase
+           ; turn_count
+           ; tool_surface_sha256
+           ; last_recovery_resolution
+           ; last_transient_release
+           ; updated_at
+           }
+         in
+         let* () = validate binding in
+         Ok binding
+     | _ -> Error "official-client session fields are not exact")
+  | _ -> Error "official-client session must be a JSON object"
+;;
+
+let equal left right =
+  left.client_kind = right.client_kind
+  && String.equal left.runtime_id right.runtime_id
+  && left.phase = right.phase
+  && Int.equal left.turn_count right.turn_count
+  && String.equal left.tool_surface_sha256 right.tool_surface_sha256
+  && left.last_recovery_resolution = right.last_recovery_resolution
+  && left.last_transient_release = right.last_transient_release
+  && Float.equal left.updated_at right.updated_at
+;;
+
+let load_path state_path =
+  if not (Fs_compat.file_exists state_path)
+  then Ok None
+  else
+    let* json = Safe_ops.read_json_file_safe state_path in
+    let* binding = of_yojson json in
+    Ok (Some binding)
+;;
+
+let load ~base_path ~keeper_name =
+  let* state_path = path ~base_path ~keeper_name in
+  load_path state_path
+;;
+
+let save_path ~state_dir binding =
+  let* () = validate binding in
+  let state_path = Filename.concat state_dir filename in
+  let* () =
+    match
+      Keeper_fs.save_json_durable_atomic
+        ~ownership_root:state_dir
+        ~pretty:false
+        state_path
+        (to_yojson binding)
+    with
+    | Ok () -> Ok ()
+    | Error error -> Error (Keeper_fs.durable_write_error_to_string error)
+  in
+  let* persisted = load_path state_path in
+  match persisted with
+  | Some persisted when equal persisted binding -> Ok ()
+  | Some _ -> Error "official-client session changed after durable write"
+  | None -> Error "official-client session missing after durable write"
+;;
+
+let prepare_state_dir ~base_path ~keeper_name =
+  let* directory = state_dir ~base_path ~keeper_name in
+  try
+    let (_ : string) = Keeper_fs.ensure_dir directory in
+    Ok directory
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let with_store_lock ~base_path ~keeper_name f =
+  let* directory = prepare_state_dir ~base_path ~keeper_name in
+  match
+    File_lock_eio.with_durable_lock
+      ~lock_path:(Filename.concat directory lock_filename)
+      (fun () -> f directory)
+  with
+  | Ok result -> result
+  | Error error -> Error (File_lock_eio.durable_lock_error_to_string error)
+;;
+
+let transition ~base_path ~keeper_name ~expected next =
+  let* () = validate next in
+  with_store_lock ~base_path ~keeper_name (fun directory ->
+    let* current = load_path (Filename.concat directory filename) in
+    if Option.equal equal current expected
+    then save_path ~state_dir:directory next |> Result.map (fun () -> next)
+    else Error "official-client session changed before durable transition")
+;;
+
+let plan_claim ~expected ~client_kind ~runtime_id =
+  let* () = non_empty "runtime_id" runtime_id in
+  let* previous_settlement, turn_count, required_tool_surface_sha256 =
+    match expected with
+    | None -> Ok (None, 1, None)
+    | Some ({ phase = Ready; _ } as binding)
+      when binding.client_kind <> client_kind
+           || not (String.equal binding.runtime_id runtime_id) ->
+      Ok (None, 1, None)
+    | Some { phase = Ready; turn_count; _ } when turn_count < Int.max_int ->
+      Ok (None, turn_count + 1, None)
+    | Some ({ phase = Settled _; _ } as binding)
+      when binding.client_kind <> client_kind
+           || not (String.equal binding.runtime_id runtime_id) ->
+      Ok (None, 1, None)
+    | Some
+        { phase = Settled settlement
+        ; turn_count
+        ; tool_surface_sha256
+        ; _
+        }
+      when turn_count < Int.max_int ->
+      Ok (Some settlement, turn_count + 1, Some tool_surface_sha256)
+    | Some { phase = Ready | Settled _; _ } ->
+      Error "settled official-client session turn count cannot be incremented"
+    | Some { phase = Start _; _ } ->
+      Error "official-client session has an incomplete start; refusing duplicate execution"
+    | Some { phase = Active _; _ } ->
+      Error "official-client session has an active unsettled attempt; refusing duplicate execution"
+    | Some { phase = Turn_inflight _; _ } ->
+      Error "official-client session has an in-flight turn; refusing duplicate execution"
+    | Some { phase = Recovery_required recovery; _ } ->
+      Error
+        (Printf.sprintf
+           "official-client session recovery %s must be resolved before another execution"
+           recovery.recovery_id)
+  in
+  Ok { previous_settlement; turn_count; required_tool_surface_sha256 }
+;;
+
+let claim ~base_path ~keeper_name ~expected ~client_kind ~owner_epoch ~runtime_id
+    ~tool_surface_sha256 ~updated_at =
+  let* () = validate_uuid "owner_epoch" owner_epoch in
+  let* plan = plan_claim ~expected ~client_kind ~runtime_id in
+  let* () =
+    match plan.required_tool_surface_sha256 with
+    | None -> Ok ()
+    | Some stored when String.equal stored tool_surface_sha256 -> Ok ()
+    | Some _ -> Error "official-client tool surface changed before session resume"
+  in
+  let last_recovery_resolution =
+    Option.bind expected (fun binding -> binding.last_recovery_resolution)
+  in
+  transition
+    ~base_path
+    ~keeper_name
+    ~expected
+    { client_kind
+    ; runtime_id
+    ; phase = Start { owner_epoch; previous_settlement = plan.previous_settlement }
+    ; turn_count = plan.turn_count
+    ; tool_surface_sha256
+    ; last_recovery_resolution
+    ; last_transient_release = Option.bind expected (fun binding -> binding.last_transient_release)
+    ; updated_at
+    }
+;;
+
+let mark_active ~base_path ~keeper_name ~expected ~session_id ~updated_at =
+  match expected.phase with
+  | Start { owner_epoch; previous_settlement } ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase = Active { owner_epoch; session_id; previous_settlement }
+      ; updated_at
+      }
+  | Ready | Active _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+    Error "official-client session can become active only from start"
+;;
+
+let mark_turn_starting ~base_path ~keeper_name ~expected ~session_id ~updated_at =
+  match expected.phase with
+  | Active { owner_epoch; session_id = active_session_id; previous_settlement }
+    when String.equal active_session_id session_id ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase =
+          Turn_inflight
+            { owner_epoch; session_id; turn_id = None; previous_settlement }
+      ; updated_at
+      }
+  | Active _ -> Error "official-client session identity changed before turn start"
+  | Ready | Start _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+    Error "official-client turn can start only from an active session"
+;;
+
+let mark_turn_started ~base_path ~keeper_name ~expected ~session_id ~turn_id
+    ~updated_at =
+  match expected.phase with
+  | Turn_inflight
+      { owner_epoch
+      ; session_id = inflight_session_id
+      ; turn_id = None
+      ; previous_settlement
+      }
+    when String.equal inflight_session_id session_id ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase =
+          Turn_inflight
+            { owner_epoch
+            ; session_id
+            ; turn_id = Some turn_id
+            ; previous_settlement
+            }
+      ; updated_at
+      }
+  | Turn_inflight { turn_id = None; _ } ->
+    Error "official-client in-flight session identity changed after turn start"
+  | Turn_inflight { turn_id = Some _; _ } ->
+    Error "official-client in-flight turn already has an identity"
+  | Ready | Start _ | Active _ | Recovery_required _ | Settled _ ->
+    Error "official-client turn identity can be recorded only for an in-flight turn"
+;;
+
+let settle ~base_path ~keeper_name ~expected ~session_id ~turn_id ~updated_at =
+  match expected.phase with
+  | Turn_inflight
+      { session_id = inflight_session_id
+      ; turn_id = Some inflight_turn_id
+      ; previous_settlement = _
+      }
+    when String.equal inflight_session_id session_id
+         && String.equal inflight_turn_id turn_id ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with phase = Settled { session_id; turn_id }; updated_at }
+  | Turn_inflight _ ->
+    Error "official-client terminal turn identity changed before settlement"
+  | Ready | Start _ | Active _ | Recovery_required _ | Settled _ ->
+    Error "official-client session can settle only from an identified in-flight turn"
+;;
+
+let require_recovery ~base_path ~keeper_name ~expected ~failure ~detail
+    ~required_at =
+  let* () = non_empty "recovery detail" detail in
+  let* () =
+    match failure_disposition failure with
+    | Ambiguous | Fatal -> Ok ()
+    | Transient ->
+      Error "transient official-client failures must use release_transient"
+  in
+  let* owner_epoch, previous_settlement, observed_session_id, observed_turn_id =
+    match expected.phase with
+    | Start { owner_epoch; previous_settlement } ->
+      Ok (owner_epoch, previous_settlement, None, None)
+    | Active { owner_epoch; session_id; previous_settlement } ->
+      Ok (owner_epoch, previous_settlement, Some session_id, None)
+    | Turn_inflight { owner_epoch; session_id; turn_id; previous_settlement } ->
+      Ok (owner_epoch, previous_settlement, Some session_id, turn_id)
+    | Ready | Settled _ ->
+      Error "a settled official-client session cannot require claim recovery"
+    | Recovery_required _ ->
+      Error "official-client session already requires recovery"
+  in
+  let recovery =
+    { recovery_id = fresh_recovery_id ()
+    ; previous_settlement
+    ; observed_session_id
+    ; observed_turn_id
+    ; owner_epoch
+    ; failure
+    ; detail
+    ; required_at
+    }
+  in
+  let* () = validate_recovery recovery in
+  transition
+    ~base_path
+    ~keeper_name
+    ~expected:(Some expected)
+    { expected with phase = Recovery_required recovery; updated_at = required_at }
+;;
+
+let incomplete_claim = function
+  | Start { owner_epoch; previous_settlement } ->
+    Some (owner_epoch, previous_settlement)
+  | Active { owner_epoch; previous_settlement; _ }
+  | Turn_inflight { owner_epoch; previous_settlement; _ } ->
+    Some (owner_epoch, previous_settlement)
+  | Ready | Recovery_required _ | Settled _ -> None
+;;
+
+let restored_phase previous_settlement =
+  match previous_settlement with
+  | None -> Ready
+  | Some settlement -> Settled settlement
+;;
+
+let release_transient ~base_path ~keeper_name ~expected ~failure ~released_at =
+  let* () =
+    match failure_disposition failure with
+    | Transient -> Ok ()
+    | Ambiguous | Fatal ->
+      Error "only transient official-client failures may release automatically"
+  in
+  let* owner_epoch, previous_settlement =
+    match incomplete_claim expected.phase with
+    | Some claim -> Ok claim
+    | None -> Error "official-client session has no incomplete claim to release"
+  in
+  let turn_count = max 0 (expected.turn_count - 1) in
+  let* released =
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase = restored_phase previous_settlement
+      ; turn_count
+      ; last_transient_release = Some { failure; owner_epoch; released_at }
+      ; updated_at = released_at
+      }
+  in
+  Log.Keeper.info
+    ~keeper_name
+    "auto-released transient official-client claim owner_epoch=%s failure=%s"
+    owner_epoch
+    (recovery_failure_to_string failure);
+  Ok released
+;;
+
+let reconcile_process_restart ~base_path ~keeper_name ~expected
+    ~current_owner_epoch ~required_at =
+  let* () = validate_uuid "current_owner_epoch" current_owner_epoch in
+  match incomplete_claim expected.phase with
+  | None -> Ok expected
+  | Some (owner_epoch, _) when String.equal owner_epoch current_owner_epoch ->
+    Error "official-client claim is still owned by the current process epoch"
+  | Some (owner_epoch, _) ->
+    require_recovery
+      ~base_path
+      ~keeper_name
+      ~expected
+      ~failure:Process_restarted
+      ~detail:
+        (Printf.sprintf
+           "MASC process epoch changed while an official-client claim was incomplete: previous=%s current=%s"
+           owner_epoch
+           current_owner_epoch)
+      ~required_at
+;;
+
+let resolve_recovery ~base_path ~keeper_name ~expected ~recovery_id ~resolution
+    ~resolved_by ~resolved_at =
+  let* () = non_empty "resolved_by" resolved_by in
+  let* recovery =
+    match expected.phase with
+    | Recovery_required recovery
+      when String.equal recovery.recovery_id recovery_id ->
+      Ok recovery
+    | Recovery_required _ ->
+      Error "official-client recovery identity changed before resolution"
+    | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+      Error "official-client session is not awaiting recovery"
+  in
+  let completed_turn_count = max 0 (expected.turn_count - 1) in
+  let* phase, turn_count =
+    match resolution with
+    | Retry_previous ->
+      Ok
+        ( (match recovery.previous_settlement with
+           | None -> Ready
+           | Some settlement -> Settled settlement)
+        , completed_turn_count )
+    | Restart_fresh -> Ok (Ready, completed_turn_count)
+    | Adopt_verified settlement ->
+      let* () = validate_settlement settlement in
+      Ok (Settled settlement, expected.turn_count)
+  in
+  let* resolved =
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase
+      ; turn_count
+      ; last_recovery_resolution =
+          Some
+            { recovery_id
+            ; failure = recovery.failure
+            ; resolution
+            ; resolved_by
+            ; resolved_at
+            }
+      ; updated_at = resolved_at
+      }
+  in
+  Log.Keeper.info
+    ~keeper_name
+    "resolved official-client session recovery=%s actor=%s decision=%s"
+    recovery_id
+    resolved_by
+    (match resolution with
+     | Retry_previous -> "retry_previous"
+     | Restart_fresh -> "restart_fresh"
+     | Adopt_verified _ -> "adopt_verified");
+  Ok resolved
+;;

--- a/lib/keeper/keeper_official_client_session_store.mli
+++ b/lib/keeper/keeper_official_client_session_store.mli
@@ -1,0 +1,219 @@
+(** Durable current-owner state between one Keeper and one official subscription
+    client session.
+
+    This is not an OAS checkpoint. The external client owns its transcript;
+    MASC owns the exact claim, observation, recovery, and settlement phase needed
+    to avoid silently duplicating an externally admitted turn. *)
+
+type client_kind =
+  | Codex
+  | Claude_code
+  | Antigravity
+
+type settlement =
+  { session_id : string
+  ; turn_id : string
+  }
+
+type recovery_failure =
+  | Transient_spawn_failed
+  | Transport_interrupted
+  | Protocol_failed
+  | Provider_rejected
+  | Host_hook_failed
+  | State_persistence_failed
+  | Process_restarted
+
+type failure_disposition =
+  | Transient
+  | Ambiguous
+  | Fatal
+
+val failure_disposition : recovery_failure -> failure_disposition
+
+type recovery_required =
+  { recovery_id : string
+  ; previous_settlement : settlement option
+  ; observed_session_id : string option
+  ; observed_turn_id : string option
+  ; owner_epoch : string
+  ; failure : recovery_failure
+  ; detail : string
+  ; required_at : float
+  }
+
+type phase =
+  | Ready
+  | Start of
+      { owner_epoch : string
+      ; previous_settlement : settlement option
+      }
+  | Active of
+      { owner_epoch : string
+      ; session_id : string
+      ; previous_settlement : settlement option
+      }
+  | Turn_inflight of
+      { owner_epoch : string
+      ; session_id : string
+      ; turn_id : string option
+      ; previous_settlement : settlement option
+      }
+  | Recovery_required of recovery_required
+  | Settled of settlement
+
+type recovery_resolution =
+  | Retry_previous
+  | Restart_fresh
+  | Adopt_verified of settlement
+
+type recovery_resolution_record =
+  { recovery_id : string
+  ; failure : recovery_failure
+  ; resolution : recovery_resolution
+  ; resolved_by : string
+  ; resolved_at : float
+  }
+
+type transient_release_record =
+  { failure : recovery_failure
+  ; owner_epoch : string
+  ; released_at : float
+  }
+
+type t =
+  { client_kind : client_kind
+  ; runtime_id : string
+  ; phase : phase
+  ; turn_count : int
+  ; tool_surface_sha256 : string
+  ; last_recovery_resolution : recovery_resolution_record option
+  ; last_transient_release : transient_release_record option
+  ; updated_at : float
+  }
+
+type claim_plan =
+  { previous_settlement : settlement option
+  ; turn_count : int
+  ; required_tool_surface_sha256 : string option
+  }
+
+val process_epoch : unit -> string
+(** One UUID for the current MASC process. A durable incomplete claim owned by
+    another epoch is a restart ambiguity, not an active same-process turn. *)
+
+val path : base_path:string -> keeper_name:string -> (string, string) result
+
+val tool_surface_sha256 : Agent_sdk.Tool.t list -> string
+(** Stable digest of the exact typed dynamic-tool surface. Tool order,
+    parameter order, and JSON object field order do not affect the digest;
+    names, descriptions, parameter semantics, and input schemas do. *)
+
+val load : base_path:string -> keeper_name:string -> (t option, string) result
+(** Missing state is [Ok None]. Malformed, retired, or ambiguous state is an
+    error and never degrades to a new session. *)
+
+val plan_claim :
+  expected:t option ->
+  client_kind:client_kind ->
+  runtime_id:string ->
+  (claim_plan, string) result
+(** Pure claim planning shared by every official-client adapter. The plan is
+    the SSOT for fresh versus resumed execution, the next turn ordinal, and
+    whether the prepared tool surface must match a settled session. *)
+
+val claim :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t option ->
+  client_kind:client_kind ->
+  owner_epoch:string ->
+  runtime_id:string ->
+  tool_surface_sha256:string ->
+  updated_at:float ->
+  (t, string) result
+(** Claim the next exact turn. A terminal binding may start fresh when its
+    declared client kind or runtime id changes. Resuming the same settled
+    client/runtime requires an identical tool surface. Incomplete and recovery
+    phases always reject another claim regardless of configuration changes. *)
+
+val mark_active :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  session_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val mark_turn_starting :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  session_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val mark_turn_started :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  session_id:string ->
+  turn_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val settle :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  session_id:string ->
+  turn_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val require_recovery :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  failure:recovery_failure ->
+  detail:string ->
+  required_at:float ->
+  (t, string) result
+(** Convert the exact incomplete claim into an explicit operator-visible
+    recovery state. This never retries or clears a possibly executed turn. *)
+
+val release_transient :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  failure:recovery_failure ->
+  released_at:float ->
+  (t, string) result
+(** Release one exact incomplete claim only when [failure] is classified
+    [Transient]. The previous settlement, if any, is restored atomically. *)
+
+val reconcile_process_restart :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  current_owner_epoch:string ->
+  required_at:float ->
+  (t, string) result
+(** Convert an incomplete claim owned by a different process epoch into an
+    explicit ambiguous recovery. Same-epoch claims remain occupied. *)
+
+val resolve_recovery :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  recovery_id:string ->
+  resolution:recovery_resolution ->
+  resolved_by:string ->
+  resolved_at:float ->
+  (t, string) result
+(** Resolve one exact recovery claim with compare-and-swap authority.
+    [Retry_previous] restores the last settled session, [Restart_fresh] makes
+    the next claim start a new session, and [Adopt_verified] records an
+    operator-verified terminal turn. *)
+(** Every phase change is a process-safe durable compare-and-swap followed by
+    exact read-back. Any incomplete phase blocks a later automatic claim. *)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -36,7 +36,7 @@ let pending_hitl_approval_counts config =
     |> List.filter_map (fun name ->
          let pending_count =
            List.fold_left
-             (fun count (entry : Keeper_approval_queue.pending_approval) ->
+             (fun count (entry : Keeper_approval_queue_rules_types.pending_approval) ->
                 if String.equal entry.keeper_name name
                 then count + 1
                 else count)

--- a/lib/keeper_approval/audit.ml
+++ b/lib/keeper_approval/audit.ml
@@ -399,7 +399,7 @@ let audit_scan_window ?keeper_name n =
 
 let record_audit_read_failure ?keeper_name ?(metric_site = Keeper_approval_queue_failure_site.Audit_read_recent) ~site exn =
   Keeper_fd_pressure.note_exception ~site exn;
-  Otel_metric_store.inc_counter
+  Otel_metric_store_core.inc_counter
     Keeper_metrics.(to_string ApprovalQueueFailures)
     ~labels:
       [ "keeper",

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -342,8 +342,8 @@ let approval_resolve_decision_name = function
 ;;
 
 let approval_resolve_decision_to_queue_decision = function
-  | Approval_resolve_approve -> Keeper_approval_queue.Decision.Approve
-  | Approval_resolve_reject reason -> Keeper_approval_queue.Decision.Reject reason
+  | Approval_resolve_approve -> Keeper_approval_queue_rules_types.Decision.Approve
+  | Approval_resolve_reject reason -> Keeper_approval_queue_rules_types.Decision.Reject reason
 ;;
 
 let approval_resolve_decision_of_json args =
@@ -463,7 +463,7 @@ let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe
   let* input_hash_json = required "input_hash" in
   let* expected_input_hash =
     match input_hash_json with
-    | `String value when Keeper_approval_queue.is_lowercase_sha256 value ->
+    | `String value when Keeper_approval_queue_rules_types.is_lowercase_sha256 value ->
       Ok value
     | _ -> Error "retry request.input_hash must be a lowercase SHA-256"
   in
@@ -475,20 +475,20 @@ let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe
   in
   let* exact_attempt_json = required "exact_attempt" in
   let* expected_exact_attempt =
-    Keeper_approval_queue.exact_attempt_state_of_yojson_with_error
+    Keeper_approval_queue_rules_types.exact_attempt_state_of_yojson_with_error
       exact_attempt_json
   in
   let* disposition_json = required "summary_attempt_disposition" in
   let* expected_disposition =
-    Keeper_approval_queue.summary_attempt_disposition_of_yojson_with_error
+    Keeper_approval_queue_rules_types.summary_attempt_disposition_of_yojson_with_error
       disposition_json
   in
   let* () =
     match expected_disposition with
-    | Keeper_approval_queue.Summary_attempt_identity_unbound
-    | Keeper_approval_queue.Summary_attempt_persistence_uncertain ->
+    | Keeper_approval_queue_rules_types.Summary_attempt_identity_unbound
+    | Keeper_approval_queue_rules_types.Summary_attempt_persistence_uncertain ->
       Ok ()
-    | Keeper_approval_queue.Summary_attempt_pre_worker_unavailable _ ->
+    | Keeper_approval_queue_rules_types.Summary_attempt_pre_worker_unavailable _ ->
       Ok ()
     | _ -> Error "retry request disposition is not operator-rearmable"
   in
@@ -512,7 +512,7 @@ let dashboard_gate_rule_delete_http_json ~base_path ~(args : Yojson.Safe.t)
   match Safe_ops.json_string_opt "id" args with
   | None -> Error "id is required"
   | Some id ->
-    (match Keeper_approval_queue.delete_rule ~base_path ~id () with
+    (match Keeper_approval_queue_rules.delete_rule ~base_path ~id () with
      | Ok deleted ->
          Keeper_approval.Audit.record_rule
            ~base_path
@@ -520,7 +520,7 @@ let dashboard_gate_rule_delete_http_json ~base_path ~(args : Yojson.Safe.t)
            deleted;
          Ok (`Assoc [ "ok", `Bool true; "id", `String deleted.id ])
        | Error error ->
-         Error (Keeper_approval_queue.rule_store_error_to_string error))
+         Error (Keeper_approval_queue_rules_types.rule_store_error_to_string error))
 ;;
 
 let dashboard_schedule_prune_http_json

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -464,9 +464,9 @@ let turn_admission_rows ~base_path keeper_name =
 
 let hitl_rows keeper_name pending =
   pending
-  |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+  |> List.filter (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
     String.equal entry.keeper_name keeper_name)
-  |> List.map (fun (entry : Keeper_approval_queue.pending_approval) ->
+  |> List.map (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
     { keeper_name = Some keeper_name
     ; source = Hitl_pending
     ; waiting_on = entry.tool_name
@@ -478,10 +478,10 @@ let hitl_rows keeper_name pending =
         `Assoc
           [ "approval_id", `String entry.id
           ; "tool_name", `String entry.tool_name
-          ; "summary_status", Keeper_approval_queue.summary_status_to_yojson entry.summary_status
-          ; "exact_attempt", Keeper_approval_queue.exact_attempt_state_to_yojson entry.exact_attempt
+          ; "summary_status", Keeper_approval_queue_rules_types.summary_status_to_yojson entry.summary_status
+          ; "exact_attempt", Keeper_approval_queue_rules_types.exact_attempt_state_to_yojson entry.exact_attempt
           ; ( "summary_attempt_disposition"
-            , Keeper_approval_queue.summary_attempt_disposition_to_yojson
+            , Keeper_approval_queue_rules_types.summary_attempt_disposition_to_yojson
                 entry.summary_attempt_disposition )
           ; "turn_id", Json_util.int_opt_to_json entry.turn_id
           ; "task_id", Json_util.string_opt_to_json entry.task_id

--- a/lib/server_keeper_waiting_inventory.mli
+++ b/lib/server_keeper_waiting_inventory.mli
@@ -13,7 +13,7 @@ module For_testing : sig
   val dashboard_json_with_pending_reader :
     read_pending:
       (base_path:string ->
-      ( Keeper_approval_queue.pending_approval list
+      ( Keeper_approval_queue_rules_types.pending_approval list
       , Keeper_approval_queue.storage_error )
       result) ->
     Workspace.config ->

--- a/test/dune
+++ b/test/dune
@@ -1942,6 +1942,7 @@
 (include stanzas/test_runtime_agent_close_cancel_source.inc)
 
 (include stanzas/test_runtime_codex_app_server.inc)
+(include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)
 

--- a/test/stanzas/test_official_client_session_store.inc
+++ b/test/stanzas/test_official_client_session_store.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_official_client_session_store)
+ (modules test_official_client_session_store)
+ (libraries alcotest masc masc_test_deps unix))

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -32,6 +32,7 @@ module Shutdown_finalize = Masc.Keeper_shutdown_finalize
 module Shutdown_runtime = Masc.Keeper_shutdown_runtime
 module Shutdown_supersession = Masc.Keeper_shutdown_supersession
 module Approval_queue = Masc.Keeper_approval_queue
+module Approval_types = Keeper_approval_queue_rules_types
 module Turn_up_args = Masc.Keeper_turn_up_args
 module Turn_up_update = Masc.Keeper_turn_up_update
 module Keeper_meta_contract = Masc.Keeper_meta_contract
@@ -2658,7 +2659,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
               ~keeper_name:meta.name)
              .snapshot_shutdown_operation_id);
       (match Approval_queue.For_testing.get_pending_entry_unchecked ~id:approval_id with
-       | Some { summary_status = Approval_queue.Summary_pending; _ } -> ()
+       | Some { summary_status = Approval_types.Summary_pending; _ } -> ()
        | Some _ | None -> fail "retain-meta shutdown changed pending summary");
       match Keeper_meta_store.read_meta config meta.name with
       | Ok (Some retained) ->
@@ -2796,7 +2797,7 @@ let test_destructive_shutdown_drains_bound_summary_then_completes () =
                  ~call_id:"shutdown-call"
                  ~plan_fingerprint:(String.make 64 'p')
                  ~request_body_sha256:(String.make 64 'a')
-                 ~cause:Approval_queue.Exact_flow_execution_failed
+                 ~cause:Approval_types.Exact_flow_execution_failed
              with
              | Ok _ -> ()
              | Error error ->

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -4,6 +4,7 @@ module EO = Agent_sdk.Exact_output
 module F = Compaction_exact_output_fixture
 module Gate = Masc.Keeper_gate
 module Q = Masc.Keeper_approval_queue
+module QT = Keeper_approval_queue_rules_types
 module Schema = Masc.Keeper_structured_output_schema
 module Worker = Masc.Hitl_summary_worker
 
@@ -272,7 +273,7 @@ let test_parse_typed_judgments () =
          | Error reason -> fail reason
        in
        check bool wire true (summary.judgment = expected))
-    [ "approve", Q.Approve; "deny", Q.Deny; "require_human", Q.Require_human ]
+    [ "approve", QT.Approve; "deny", QT.Deny; "require_human", QT.Require_human ]
 ;;
 
 let test_invalid_judgment_fails_loud () =
@@ -493,9 +494,9 @@ let test_flow_order_completion_and_replay () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
         | Some
             { exact_attempt =
-                Q.Exact_bound
-                  { slot_id = "hitl-first"; status = Q.Exact_completed; _ }
-            ; summary_status = Q.Summary_available _
+                QT.Exact_bound
+                  { slot_id = "hitl-first"; status = QT.Exact_completed; _ }
+            ; summary_status = QT.Summary_available _
             ; _
             } ->
           ()
@@ -565,8 +566,8 @@ let test_predispatch_failure_advances_only_to_oas_successor () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
-                 { slot_id = "hitl-successor"; status = Q.Exact_completed; _ }
+               QT.Exact_bound
+                 { slot_id = "hitl-successor"; status = QT.Exact_completed; _ }
            ; _
            } ->
          ()
@@ -642,12 +643,12 @@ let test_cancellation_between_candidates_terminalizes_released_identity () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
+               QT.Exact_bound
                  { slot_id = "hitl-cancel-between-unreachable"
-                 ; status = Q.Exact_quarantined Q.Exact_cancellation
+                 ; status = QT.Exact_quarantined QT.Exact_cancellation
                  ; _
                  }
-           ; summary_attempt_disposition = Q.Summary_attempt_settled
+           ; summary_attempt_disposition = QT.Summary_attempt_settled
            ; _
            } ->
          ()
@@ -735,10 +736,10 @@ let test_json_syntax_candidate_is_admitted_without_structured_capability () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
-                 { status = Q.Exact_quarantined Q.Exact_flow_execution_failed; _ }
-           ; summary_status = Q.Summary_failed _
-           ; summary_attempt_disposition = Q.Summary_attempt_settled
+               QT.Exact_bound
+                 { status = QT.Exact_quarantined QT.Exact_flow_execution_failed; _ }
+           ; summary_status = QT.Summary_failed _
+           ; summary_attempt_disposition = QT.Summary_attempt_settled
            ; _
            } ->
          ()
@@ -779,9 +780,9 @@ let test_visible_bind_blocks_dispatch () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
+               QT.Exact_bound
                  { status =
-                     Q.Exact_quarantined Q.Exact_terminal_persistence_failure
+                     QT.Exact_quarantined QT.Exact_terminal_persistence_failure
                  ; _
                  }
            ; _
@@ -827,9 +828,9 @@ let test_visible_advance_blocks_successor () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
+               QT.Exact_bound
                  { status =
-                     Q.Exact_quarantined Q.Exact_terminal_persistence_failure
+                     QT.Exact_quarantined QT.Exact_terminal_persistence_failure
                  ; _
                  }
            ; _
@@ -880,8 +881,8 @@ let test_visible_completion_blocks_gate_delivery () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound { status = Q.Exact_completed; _ }
-           ; summary_status = Q.Summary_available _
+               QT.Exact_bound { status = QT.Exact_completed; _ }
+           ; summary_status = QT.Summary_available _
            ; _
            } ->
          ()
@@ -901,8 +902,8 @@ let test_visible_completion_blocks_gate_delivery () =
        check int "restart did not dispatch successor" 1 (F.post_count server);
        (match Q.For_testing.get_pending_entry_unchecked ~id:successor.id with
         | Some
-            { exact_attempt = Q.Exact_unbound
-            ; summary_status = Q.Summary_pending
+            { exact_attempt = QT.Exact_unbound
+            ; summary_status = QT.Summary_pending
             ; _
             } ->
           ()
@@ -937,7 +938,7 @@ let test_completion_identity_conflict_stays_deterministic () =
        let replacement_call_id = "replacement-call" in
        let replace_bound_identity () =
          match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
-         | Some { exact_attempt = Q.Exact_bound binding; _ } ->
+         | Some { exact_attempt = QT.Exact_bound binding; _ } ->
            let transition_exn operation = function
              | Ok { Q.write_outcome = Q.Fsync_completed; _ } -> ()
              | Ok { Q.write_outcome = Q.Visible_sync_unconfirmed detail; _ } ->
@@ -966,7 +967,7 @@ let test_completion_identity_conflict_stays_deterministic () =
              ~plan_fingerprint:(String.make 64 'a')
              ~request_body_sha256:(String.make 64 'b')
            |> transition_exn "bind replacement identity"
-         | Some { exact_attempt = Q.Exact_unbound; _ } ->
+         | Some { exact_attempt = QT.Exact_unbound; _ } ->
            fail "after_bind observed an unbound exact attempt"
          | None -> fail "after_bind lost the pending approval"
        in
@@ -999,9 +1000,9 @@ let test_completion_identity_conflict_stays_deterministic () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound { call_id; status = Q.Exact_dispatch_uncertain; _ }
-           ; summary_status = Q.Summary_pending
-           ; summary_attempt_disposition = Q.Summary_attempt_in_flight
+               QT.Exact_bound { call_id; status = QT.Exact_dispatch_uncertain; _ }
+           ; summary_status = QT.Summary_pending
+           ; summary_attempt_disposition = QT.Summary_attempt_in_flight
            ; _
            } ->
          check string
@@ -1042,14 +1043,14 @@ let test_flow_execution_failure_quarantines_and_allows_successor () =
         | Some
             { input_hash
             ; sequence
-            ; summary_status = Q.Summary_failed { reason }
+            ; summary_status = QT.Summary_failed { reason }
             ; exact_attempt =
-                Q.Exact_bound
+                QT.Exact_bound
                   { slot_id
                   ; call_id
                   ; plan_fingerprint
                   ; request_body_sha256
-                  ; status = Q.Exact_quarantined Q.Exact_flow_execution_failed
+                  ; status = QT.Exact_quarantined QT.Exact_flow_execution_failed
                   ; _
                   }
             ; _
@@ -1111,7 +1112,7 @@ let test_manual_resolution_race_is_conclusive () =
        install_queue base_path;
        Prompt_registry.set_markdown_dir
          (Masc_test_deps.source_path "config/prompts");
-       let in_flight_entry : Q.pending_approval option ref = ref None in
+       let in_flight_entry : QT.pending_approval option ref = ref None in
        let server =
          F.start_server
            ~on_request_before_reply:(fun () ->
@@ -1122,7 +1123,7 @@ let test_manual_resolution_race_is_conclusive () =
                   Q.resolve_with_policy
                     ~base_path
                     ~id:entry.id
-                    ~decision:(Q.Decision.Reject "manual operator resolution")
+                    ~decision:(QT.Decision.Reject "manual operator resolution")
                     ()
                 with
                 | Ok _ -> ()
@@ -1215,8 +1216,8 @@ let test_cancellation_after_dispatch_is_terminal () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
-                 { status = Q.Exact_quarantined Q.Exact_cancellation; _ }
+               QT.Exact_bound
+                 { status = QT.Exact_quarantined QT.Exact_cancellation; _ }
            ; _
            } ->
          ()
@@ -1402,19 +1403,19 @@ let test_prebind_cancellation_withholds_production_gate_drain () =
               (F.post_count server);
             (match Q.For_testing.get_pending_entry_unchecked ~id:cancelled.id with
              | Some
-                 { exact_attempt = Q.Exact_unbound
-                 ; summary_status = Q.Summary_pending
+                 { exact_attempt = QT.Exact_unbound
+                 ; summary_status = QT.Summary_pending
                  ; summary_attempt_disposition =
-                     Q.Summary_attempt_identity_unbound
+                     QT.Summary_attempt_identity_unbound
                  ; _
                  } ->
                ()
              | _ -> fail "Gate drained or mutated the cancelled pending entry");
             match Q.For_testing.get_pending_entry_unchecked ~id:successor.id with
             | Some
-                { exact_attempt = Q.Exact_unbound
-                ; summary_status = Q.Summary_pending
-                ; summary_attempt_disposition = Q.Summary_attempt_ready
+                { exact_attempt = QT.Exact_unbound
+                ; summary_status = QT.Summary_pending
+                ; summary_attempt_disposition = QT.Summary_attempt_ready
                 ; _
                 } ->
               ()
@@ -1512,8 +1513,8 @@ let test_bound_cancellation_cleanup_uncertainty_preserves_origin () =
               (F.post_count server);
             match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
             | Some
-                { exact_attempt = Q.Exact_bound _
-                ; summary_status = Q.Summary_pending
+                { exact_attempt = QT.Exact_bound _
+                ; summary_status = QT.Summary_pending
                 ; _
                 } ->
               ()
@@ -1547,12 +1548,12 @@ let test_pre_worker_start_failure_preserves_unbound_pending () =
         | Ok _ -> fail "pre-worker failure was reported as a successful start");
        (match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
-           { exact_attempt = Q.Exact_unbound
-           ; summary_status = Q.Summary_pending
+           { exact_attempt = QT.Exact_unbound
+           ; summary_status = QT.Summary_pending
            ; summary_attempt_disposition =
-               Q.Summary_attempt_pre_worker_unavailable
+               QT.Summary_attempt_pre_worker_unavailable
                  { reason_code =
-                     Q.Summary_pre_worker_auto_judge_unavailable
+                     QT.Summary_pre_worker_auto_judge_unavailable
                  ; operator_detail = "no usable exact-output lane slots"
                  }
            ; _
@@ -1633,18 +1634,18 @@ let test_visible_uncertainty_withholds_production_drain () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:uncertain.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound { status = Q.Exact_completed; _ }
-           ; summary_status = Q.Summary_available _
+               QT.Exact_bound { status = QT.Exact_completed; _ }
+           ; summary_status = QT.Summary_available _
            ; summary_attempt_disposition =
-               Q.Summary_attempt_persistence_uncertain
+               QT.Summary_attempt_persistence_uncertain
            ; _
            } ->
          ()
        | _ -> fail "uncertain completion did not remain durably visible");
        (match Q.For_testing.get_pending_entry_unchecked ~id:successor.id with
         | Some
-            { exact_attempt = Q.Exact_unbound
-            ; summary_status = Q.Summary_pending
+            { exact_attempt = QT.Exact_unbound
+            ; summary_status = QT.Summary_pending
             ; _
             } ->
           ()
@@ -1716,8 +1717,8 @@ let test_owner_fifo_atomic_drain_is_nonsharing () =
          (F.post_count server);
        (match Q.For_testing.get_pending_entry_unchecked ~id:second.id with
         | Some
-            { exact_attempt = Q.Exact_unbound
-            ; summary_status = Q.Summary_pending
+            { exact_attempt = QT.Exact_unbound
+            ; summary_status = QT.Summary_pending
             ; _
             } ->
           ()
@@ -1802,10 +1803,10 @@ let test_require_human_head_does_not_stop_owner_drain () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:head.id with
         | Some
             { exact_attempt =
-                Q.Exact_bound { status = Q.Exact_completed; _ }
+                QT.Exact_bound { status = QT.Exact_completed; _ }
             ; summary_status =
-                Q.Summary_available { judgment = Q.Require_human; _ }
-            ; summary_attempt_disposition = Q.Summary_attempt_settled
+                QT.Summary_available { judgment = QT.Require_human; _ }
+            ; summary_attempt_disposition = QT.Summary_attempt_settled
             ; _
             } ->
           ()
@@ -1834,13 +1835,13 @@ let test_judge_effect_prompt_comes_from_registry () =
    Both arms are pinned here because the decision is now a named function and
    the outcome type has a variant for each. *)
 
-let summary_fixture () : Q.hitl_context_summary =
-  { summary_version = Q.current_hitl_context_summary_version
+let summary_fixture () : QT.hitl_context_summary =
+  { summary_version = QT.current_hitl_context_summary_version
   ; generated_at = 1000.0
   ; model_run_id = "run-fixture"
   ; context_summary = "context"
   ; key_questions = [ "q1" ]
-  ; judgment = Q.Approve
+  ; judgment = QT.Approve
   ; rationale = "because"
   }
 ;;

--- a/test/test_keeper_approval_audit_timeline.ml
+++ b/test/test_keeper_approval_audit_timeline.ml
@@ -13,7 +13,7 @@
     agree. These cases pin what that agreement renders — in particular that the
     success path and the failure path are no longer the same event. *)
 
-module Q = Masc.Keeper_approval_queue
+module Q = Keeper_approval_queue_rules_types
 module Audit = Keeper_approval.Audit
 module Timeline = Masc.Keeper_runtime_trust_timeline
 open Alcotest

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1,6 +1,8 @@
 module AQ = Masc.Keeper_approval_queue
+module Rules = Masc.Keeper_approval_queue_rules
+module Rule_types = Keeper_approval_queue_rules_types
 
-let reserve_retry_exact ~base_path (entry : AQ.pending_approval) =
+let reserve_retry_exact ~base_path (entry : Rule_types.pending_approval) =
   AQ.reserve_summary_attempt_retry
     ~base_path
     ~id:entry.id
@@ -139,7 +141,7 @@ let submit ~base_path ~keeper_name ~input =
 ;;
 
 let reject_and_cleanup ~base_path id =
-  match aq_resolve ~base_path ~id ~decision:(AQ.Decision.Reject "test cleanup") with
+  match aq_resolve ~base_path ~id ~decision:(Rule_types.Decision.Reject "test cleanup") with
   | Ok () -> ()
   | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
 ;;
@@ -407,14 +409,14 @@ let expect_summary_rejection label = function
 ;;
 
 let exact_summary ?(context_summary = "Exact attempt summary") model_run_id :
-    AQ.hitl_context_summary
+    Rule_types.hitl_context_summary
   =
   { summary_version = 2
   ; generated_at = Unix.gettimeofday ()
   ; model_run_id
   ; context_summary
   ; key_questions = []
-  ; judgment = AQ.Approve
+  ; judgment = Rule_types.Approve
   ; rationale = "The exact durable attempt supports this judgment."
   }
 ;;
@@ -610,7 +612,7 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
         | None -> Alcotest.fail "pending request missing"
         | Some entry ->
           Alcotest.(check bool) "summary is not started by queue" true
-            (entry.summary_status = AQ.Summary_not_requested);
+            (entry.summary_status = Rule_types.Summary_not_requested);
           Alcotest.check (Alcotest.option yojson)
             "exact outer-turn context"
             (Some request_context)
@@ -682,7 +684,7 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
          |> List.concat_map (fun base_path ->
               AQ.list_pending_entries_for_workspace ~base_path
               |> require_ok "read workspace-local FIFO")
-         |> List.map (fun (entry : AQ.pending_approval) -> entry.id)
+         |> List.map (fun (entry : Rule_types.pending_approval) -> entry.id)
        in
        Alcotest.(check (list string))
          "workspace projections compose deterministic FIFO"
@@ -709,20 +711,20 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
    the oldest for 2416s. *)
 let head_of_line_owner = "head-of-line-owner"
 
-let require_human_summary () : AQ.hitl_context_summary =
-  { summary_version = AQ.current_hitl_context_summary_version
+let require_human_summary () : Rule_types.hitl_context_summary =
+  { summary_version = Rule_types.current_hitl_context_summary_version
   ; generated_at = 1.0
   ; model_run_id = "model-run-head-of-line"
   ; context_summary = "head approval was handed to a human"
   ; key_questions = []
-  ; judgment = AQ.Require_human
+  ; judgment = Rule_types.Require_human
   ; rationale = "operator decision required"
   }
 ;;
 
-let completed_exact_binding (entry : AQ.pending_approval) =
-  AQ.exact_attempt_binding_with_status
-    (AQ.make_exact_attempt_binding
+let completed_exact_binding (entry : Rule_types.pending_approval) =
+  Rule_types.exact_attempt_binding_with_status
+    (Rule_types.make_exact_attempt_binding
        ~approval_id:entry.id
        ~input_hash:entry.input_hash
        ~sequence:entry.sequence
@@ -731,7 +733,7 @@ let completed_exact_binding (entry : AQ.pending_approval) =
        ~plan_fingerprint:"plan-head-of-line"
        ~request_body_sha256:"sha256-head-of-line"
        ())
-    AQ.Exact_completed
+    Rule_types.Exact_completed
 ;;
 
 let check_owner_selection label ~base_path ~expected entries =
@@ -742,7 +744,7 @@ let check_owner_selection label ~base_path ~expected entries =
       entries
   with
   | [ selected ] ->
-    Alcotest.(check string) label expected selected.AQ.id
+    Alcotest.(check string) label expected selected.Rule_types.id
   | [] -> Alcotest.failf "%s: owner selection returned nothing" label
   | selected ->
     Alcotest.failf "%s: expected one entry, got %d" label (List.length selected)
@@ -776,9 +778,9 @@ let test_terminal_head_does_not_stall_owner_queue () =
          [ follower; head ];
        let judged_head =
          { head with
-           AQ.summary_status = AQ.Summary_available (require_human_summary ())
-         ; AQ.summary_attempt_disposition = AQ.Summary_attempt_settled
-         ; AQ.exact_attempt = AQ.Exact_bound (completed_exact_binding head)
+           Rule_types.summary_status = Rule_types.Summary_available (require_human_summary ())
+         ; Rule_types.summary_attempt_disposition = Rule_types.Summary_attempt_settled
+         ; Rule_types.exact_attempt = Rule_types.Exact_bound (completed_exact_binding head)
          }
        in
        check_owner_selection
@@ -788,10 +790,10 @@ let test_terminal_head_does_not_stall_owner_queue () =
          [ judged_head; follower ];
        let blocked_head =
          { head with
-           AQ.summary_status = AQ.Summary_pending
-         ; AQ.summary_attempt_disposition =
-             AQ.Summary_attempt_pre_worker_unavailable
-               { reason_code = AQ.Summary_pre_worker_auto_judge_unavailable
+           Rule_types.summary_status = Rule_types.Summary_pending
+         ; Rule_types.summary_attempt_disposition =
+             Rule_types.Summary_attempt_pre_worker_unavailable
+               { reason_code = Rule_types.Summary_pre_worker_auto_judge_unavailable
                ; operator_detail =
                    "HITL summary: exact outer-turn request context is unavailable"
                }
@@ -944,7 +946,7 @@ let test_delivery_wire_shape_drops_request_context () =
            ~input:(`Assoc [ "target", `String "document" ])
            ()
        in
-       (match aq_resolve ~base_path ~id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id ~decision:Rule_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let open Yojson.Safe.Util in
@@ -997,7 +999,7 @@ let test_resolution_is_durable_and_origin_scoped () =
          AQ.resolve_with_policy
            ~base_path
            ~id
-           ~decision:AQ.Decision.Approve
+           ~decision:Rule_types.Decision.Approve
            ~remember_rule:true
            ~created_by:"operator"
            ()
@@ -1036,16 +1038,16 @@ let test_resolution_is_durable_and_origin_scoped () =
                ~approval_id:id));
        Alcotest.(check bool) "exact remembered request matches" true
          (match
-            AQ.find_matching_rule
+            Rules.find_matching_rule
               ~base_path
               ~keeper_name
               ~tool_name:"external-effect"
               ~input
               ()
           with
-          | Ok (AQ.Rule_match_active _) -> true
-          | Ok (AQ.Rule_match_expired _ | AQ.Rule_match_absent) -> false
-          | Error error -> Alcotest.fail (AQ.rule_store_error_to_string error));
+          | Ok (Rule_types.Rule_match_active _) -> true
+          | Ok (Rule_types.Rule_match_expired _ | Rule_types.Rule_match_absent) -> false
+          | Error error -> Alcotest.fail (Rule_types.rule_store_error_to_string error));
        (match
           AQ.consume_approved_resolution
             ~base_path
@@ -1267,7 +1269,7 @@ let test_remembered_rule_carries_requested_expiry () =
          AQ.resolve_with_policy
            ~base_path
            ~id
-           ~decision:AQ.Decision.Approve
+           ~decision:Rule_types.Decision.Approve
            ~remember_rule:true
            ~rule_expires_at:expires_at
            ~created_by:"operator"
@@ -1287,7 +1289,7 @@ let test_remembered_rule_carries_requested_expiry () =
           AQ.resolve_with_policy
             ~base_path
             ~id
-            ~decision:AQ.Decision.Approve
+            ~decision:Rule_types.Decision.Approve
             ~remember_rule:true
             ~rule_expires_at:expires_at
             ~created_by:"operator"
@@ -1298,8 +1300,8 @@ let test_remembered_rule_carries_requested_expiry () =
           Alcotest.fail
             ("identical expiry re-resolution must be idempotent: "
              ^ AQ.resolve_error_to_string error));
-       match AQ.list_rules ~base_path () with
-       | Error error -> Alcotest.fail (AQ.rule_store_error_to_string error)
+       match Rules.list_rules ~base_path () with
+       | Error error -> Alcotest.fail (Rule_types.rule_store_error_to_string error)
        | Ok [ rule ] ->
          Alcotest.(check (option (float 0.0)))
            "persisted rule carries requested expiry"
@@ -1337,7 +1339,7 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
            ~input
            ()
        in
-       (match aq_resolve ~base_path ~id:approval_id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id:approval_id ~decision:Rule_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
@@ -1492,8 +1494,8 @@ let test_exact_binding_codec_validates_entry_identity () =
          |> List.hd
          |> member "exact_attempt"
        in
-       (match AQ.exact_attempt_state_of_yojson_with_error exact_json with
-        | Ok (AQ.Exact_bound binding) ->
+       (match Rule_types.exact_attempt_state_of_yojson_with_error exact_json with
+        | Ok (Rule_types.Exact_bound binding) ->
           Alcotest.(check string)
             "codec approval identity"
             identity.approval_id_arg
@@ -1516,7 +1518,7 @@ let test_exact_binding_codec_validates_entry_identity () =
        check_exact_update
          "quarantine exact codec fixture"
          true
-         (quarantine_exact identity AQ.Exact_flow_execution_failed);
+         (quarantine_exact identity Rule_types.Exact_flow_execution_failed);
        let quarantined_exact_json =
          read_pending_snapshot ~base_path
          |> member "pending"
@@ -1531,13 +1533,13 @@ let test_exact_binding_codec_validates_entry_identity () =
           |> member "quarantine_cause"
           |> to_string);
        (match
-          AQ.exact_attempt_state_of_yojson_with_error quarantined_exact_json
+          Rule_types.exact_attempt_state_of_yojson_with_error quarantined_exact_json
         with
         | Ok
-            (AQ.Exact_bound
+            (Rule_types.Exact_bound
               { status =
-                  AQ.Exact_quarantined
-                    AQ.Exact_flow_execution_failed
+                  Rule_types.Exact_quarantined
+                    Rule_types.Exact_flow_execution_failed
               ; _
               }) ->
           ()
@@ -1548,7 +1550,7 @@ let test_exact_binding_codec_validates_entry_identity () =
        List.iter
          (fun removed_cause ->
             match
-              AQ.exact_attempt_state_of_yojson_with_error
+              Rule_types.exact_attempt_state_of_yojson_with_error
                 (replace_field
                    "quarantine_cause"
                    (`String removed_cause)
@@ -1564,7 +1566,7 @@ let test_exact_binding_codec_validates_entry_identity () =
          ; "restart_uncertainty"
          ];
        (match
-          AQ.exact_attempt_state_of_yojson_with_error
+          Rule_types.exact_attempt_state_of_yojson_with_error
             (replace_field "call_id" (`String " ") exact_json)
         with
         | Error _ -> ()
@@ -1572,7 +1574,7 @@ let test_exact_binding_codec_validates_entry_identity () =
        List.iter
          (fun (label, hash) ->
             match
-              AQ.exact_attempt_state_of_yojson_with_error
+              Rule_types.exact_attempt_state_of_yojson_with_error
                 (replace_field
                    "request_body_sha256"
                    (`String hash)
@@ -1691,18 +1693,18 @@ let test_exact_attempt_binding_release_and_conflicts () =
          "bound restart is not rearmed"
          false
          (reserve_retry_exact ~base_path (pending_entry_exn id));
-       let quarantine_cause = AQ.Exact_domain_invalid_output in
+       let quarantine_cause = Rule_types.Exact_domain_invalid_output in
        check_exact_update
          "quarantine replacement"
          true
          (quarantine_exact replacement quarantine_cause);
        (match pending_entry_exn id with
-        | { summary_status = AQ.Summary_failed { reason }
+        | { summary_status = Rule_types.Summary_failed { reason }
           ; exact_attempt =
-              AQ.Exact_bound
+              Rule_types.Exact_bound
                 { status =
-                    AQ.Exact_quarantined
-                      AQ.Exact_domain_invalid_output
+                    Rule_types.Exact_quarantined
+                      Rule_types.Exact_domain_invalid_output
                 ; _
                 }
           ; _
@@ -1716,7 +1718,7 @@ let test_exact_attempt_binding_release_and_conflicts () =
          "same quarantine cause is idempotent"
          false
          (quarantine_exact replacement quarantine_cause);
-       (match quarantine_exact replacement AQ.Exact_cancellation with
+       (match quarantine_exact replacement Rule_types.Exact_cancellation with
         | Error
             (AQ.Exact_attempt_rejected
               (AQ.Exact_attempt_status_conflict _)) ->
@@ -1778,9 +1780,9 @@ let test_restart_classifies_uncertain_and_released_recovery () =
          (reserve_retry_exact ~base_path (pending_entry_exn released_id));
        (match pending_entry_exn released_id with
         | { exact_attempt =
-              AQ.Exact_bound
-                { status = AQ.Exact_released_before_dispatch; _ }
-          ; summary_status = AQ.Summary_pending
+              Rule_types.Exact_bound
+                { status = Rule_types.Exact_released_before_dispatch; _ }
+          ; summary_status = Rule_types.Summary_pending
           ; _
           } ->
           ()
@@ -1790,8 +1792,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
        let assert_restart_states label =
          (match pending_entry_exn uncertain_id with
           | { exact_attempt =
-                AQ.Exact_bound
-                  { status = AQ.Exact_restart_quarantined
+                Rule_types.Exact_bound
+                  { status = Rule_types.Exact_restart_quarantined
                   ; slot_id
                   ; call_id
                   ; _
@@ -1811,8 +1813,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
               (label ^ " did not quarantine dispatch-uncertain attempt"));
          match pending_entry_exn released_id with
          | { exact_attempt =
-               AQ.Exact_bound
-                 { status = AQ.Exact_released_recovery_required
+               Rule_types.Exact_bound
+                 { status = Rule_types.Exact_released_recovery_required
                  ; slot_id
                  ; call_id
                  ; _
@@ -1848,8 +1850,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
          true
          (reserve_retry_exact ~base_path (pending_entry_exn released_id));
        (match pending_entry_exn released_id with
-        | { summary_status = AQ.Summary_pending
-          ; exact_attempt = AQ.Exact_unbound
+        | { summary_status = Rule_types.Summary_pending
+          ; exact_attempt = Rule_types.Exact_unbound
           ; _
           } ->
           ()
@@ -1870,8 +1872,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
          true
          (reserve_retry_exact ~base_path (pending_entry_exn bulk_id));
        match pending_entry_exn bulk_id with
-       | { summary_status = AQ.Summary_pending
-         ; exact_attempt = AQ.Exact_unbound
+       | { summary_status = Rule_types.Summary_pending
+         ; exact_attempt = Rule_types.Exact_unbound
          ; _
          } ->
          ()
@@ -1920,9 +1922,9 @@ let test_exact_attempt_completion_is_atomic () =
         | Error error -> Alcotest.fail (AQ.exact_attempt_error_to_string error)
         | Ok _ -> Alcotest.fail "mismatched completion provenance was accepted");
        (match pending_entry_exn id with
-        | { summary_status = AQ.Summary_pending
+        | { summary_status = Rule_types.Summary_pending
           ; exact_attempt =
-              AQ.Exact_bound { status = AQ.Exact_dispatch_uncertain; _ }
+              Rule_types.Exact_bound { status = Rule_types.Exact_dispatch_uncertain; _ }
           ; _
           } ->
           ()
@@ -1933,9 +1935,9 @@ let test_exact_attempt_completion_is_atomic () =
          true
          (complete_exact identity summary);
        (match pending_entry_exn id with
-        | { summary_status = AQ.Summary_available durable_summary
+        | { summary_status = Rule_types.Summary_available durable_summary
           ; exact_attempt =
-              AQ.Exact_bound { status = AQ.Exact_completed; _ }
+              Rule_types.Exact_bound { status = Rule_types.Exact_completed; _ }
           ; _
           } ->
           Alcotest.(check string)
@@ -2006,7 +2008,7 @@ let test_exact_attempt_bind_storage_failure_is_not_success () =
         | Error error -> Alcotest.fail (AQ.exact_attempt_error_to_string error)
         | Ok _ -> Alcotest.fail "failed exact binding persistence reported success");
        match pending_entry_exn id with
-       | { exact_attempt = AQ.Exact_unbound; _ } -> ()
+       | { exact_attempt = Rule_types.Exact_unbound; _ } -> ()
        | _ -> Alcotest.fail "failed exact binding persistence mutated memory")
 ;;
 
@@ -2034,11 +2036,11 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
        in
        let assert_status label id expected =
          match pending_entry_exn id with
-         | { exact_attempt = AQ.Exact_bound { status; _ }; _ } ->
+         | { exact_attempt = Rule_types.Exact_bound { status; _ }; _ } ->
            Alcotest.(check string)
              label
              expected
-             (AQ.exact_attempt_status_to_string status)
+             (Rule_types.exact_attempt_status_to_string status)
          | _ -> Alcotest.failf "%s did not retain an exact binding" label
        in
        let resolved_id =
@@ -2051,7 +2053,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
           AQ.resolve_with_policy
             ~base_path
             ~id:resolved_id
-            ~decision:AQ.Decision.Approve
+            ~decision:Rule_types.Decision.Approve
             ()
         with
         | Ok _ -> ()
@@ -2108,7 +2110,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
             AQ.resolve_with_policy
               ~base_path
               ~id:resolved_id
-              ~decision:AQ.Decision.Approve
+              ~decision:Rule_types.Decision.Approve
               ()
           with
           | Error (AQ.Persistence_failed _) -> ()
@@ -2119,7 +2121,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          AQ.For_testing.reset_runtime_state ();
          ignore (install_exn ~base_path);
          (match pending_entry_exn before_id with
-          | { exact_attempt = AQ.Exact_unbound; _ } -> ()
+          | { exact_attempt = Rule_types.Exact_unbound; _ } -> ()
           | _ -> Alcotest.fail "pre-rename failure mutated exact binding memory");
          let cancel_before_id, cancel_before_identity =
            prepare "cancel-before-rename"
@@ -2162,7 +2164,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
           | Ok _ ->
             Alcotest.fail "pre-rename cancellation reported a write outcome");
          (match pending_entry_exn cancel_before_id with
-          | { exact_attempt = AQ.Exact_unbound; _ } -> ()
+          | { exact_attempt = Rule_types.Exact_unbound; _ } -> ()
           | _ -> Alcotest.fail "pre-rename cancellation mutated exact memory");
          let cancel_after_id, cancel_after_identity =
            prepare "cancel-after-rename"
@@ -2214,8 +2216,8 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
               Alcotest.failf
                 "released binding accepted %s"
                 label)
-         [ "domain-invalid output", AQ.Exact_domain_invalid_output
-         ; "attempt replay", AQ.Exact_attempt_replay
+         [ "domain-invalid output", Rule_types.Exact_domain_invalid_output
+         ; "attempt replay", Rule_types.Exact_attempt_replay
          ];
        assert_status
          "rejected causes preserve release"
@@ -2226,7 +2228,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          true
          (quarantine_exact
             release_identity
-            AQ.Exact_terminal_persistence_failure);
+            Rule_types.Exact_terminal_persistence_failure);
        assert_status "release terminal memory" release_id "quarantined";
        let terminalize_released label cause =
          let id, identity = prepare label in
@@ -2248,8 +2250,8 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
            (quarantine_exact identity cause);
          match pending_entry_exn id with
          | { exact_attempt =
-               AQ.Exact_bound
-                 { status = AQ.Exact_quarantined actual; _ }
+               Rule_types.Exact_bound
+                 { status = Rule_types.Exact_quarantined actual; _ }
            ; _
            } when actual = cause ->
            ()
@@ -2260,10 +2262,10 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
        in
        terminalize_released
          "release-cancellation"
-         AQ.Exact_cancellation;
+         Rule_types.Exact_cancellation;
        terminalize_released
          "release-flow-execution-failed"
-         AQ.Exact_flow_execution_failed;
+         Rule_types.Exact_flow_execution_failed;
        let quarantine_id, quarantine_identity = prepare "quarantine" in
        check_exact_update
          "bind quarantine fixture"
@@ -2281,7 +2283,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
             ~call_id:quarantine_identity.call_id_arg
             ~plan_fingerprint:quarantine_identity.plan_fingerprint_arg
             ~request_body_sha256:quarantine_identity.request_body_sha256_arg
-            ~cause:AQ.Exact_flow_execution_failed);
+            ~cause:Rule_types.Exact_flow_execution_failed);
        assert_status
          "visible quarantine memory"
          quarantine_id
@@ -2291,7 +2293,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          false
          (quarantine_exact
             quarantine_identity
-            AQ.Exact_flow_execution_failed);
+            Rule_types.Exact_flow_execution_failed);
        let complete_id, complete_identity = prepare "complete" in
        check_exact_update
          "bind completion fixture"
@@ -2356,7 +2358,7 @@ let test_exact_completed_restart_requires_fsync_confirmation () =
              ~call_id
              ~plan_fingerprint
              ~request_body_sha256
-             ~summary:(actual_summary : AQ.hitl_context_summary)
+             ~summary:(actual_summary : Rule_types.hitl_context_summary)
          =
          incr observed_calls;
          Alcotest.(check string) "recovery approval identity" id actual_id;
@@ -2418,7 +2420,7 @@ let test_exact_completed_restart_requires_fsync_confirmation () =
           Alcotest.fail
             "deterministic completion rejection lost its typed recovery code");
        (match AQ.For_testing.get_pending_entry_unchecked ~id with
-        | Some { summary_attempt_disposition = AQ.Summary_attempt_settled; _ } ->
+        | Some { summary_attempt_disposition = Rule_types.Summary_attempt_settled; _ } ->
           ()
         | _ ->
           Alcotest.fail
@@ -2542,8 +2544,8 @@ let test_current_snapshot_rejects_unbound_available_summary () =
                      then
                        `Assoc
                          (("summary_status",
-                            AQ.summary_status_to_yojson
-                              (AQ.Summary_available summary))
+                            Rule_types.summary_status_to_yojson
+                              (Rule_types.Summary_available summary))
                           :: List.remove_assoc "summary_status" entry_fields)
                      else entry_json
                    | entry_json -> entry_json)
@@ -2608,7 +2610,7 @@ let test_blocked_disposition_requires_operator_rearm_before_bind () =
         | Error
             (AQ.Exact_attempt_rejected
                (AQ.Exact_attempt_disposition_conflict
-                  { disposition = AQ.Summary_attempt_identity_unbound; _ })) ->
+                  { disposition = Rule_types.Summary_attempt_identity_unbound; _ })) ->
           ()
         | Error error ->
           Alcotest.fail
@@ -2656,11 +2658,11 @@ let test_blocked_disposition_requires_operator_rearm_before_bind () =
          (reserve_retry_exact ~base_path retryable_entry);
        (match AQ.For_testing.get_pending_entry_unchecked ~id with
         | Some
-            { summary_status = AQ.Summary_pending
-            ; exact_attempt = AQ.Exact_unbound
+            { summary_status = Rule_types.Summary_pending
+            ; exact_attempt = Rule_types.Exact_unbound
             ; summary_attempt_disposition =
-                AQ.Summary_attempt_pre_worker_unavailable
-                  { reason_code = AQ.Summary_pre_worker_start_reserved
+                Rule_types.Summary_attempt_pre_worker_unavailable
+                  { reason_code = Rule_types.Summary_pre_worker_start_reserved
                   ; operator_detail
                   }
             ; _
@@ -2714,18 +2716,18 @@ let test_operator_recovery_skips_terminal_exact_failure () =
          true
          (quarantine_exact
             quarantined_identity
-            AQ.Exact_flow_execution_failed);
+            Rule_types.Exact_flow_execution_failed);
        check_rearm
          "explicit operator action cannot reopen exact quarantine"
          false
          (reserve_retry_exact ~base_path (pending_entry_exn quarantined_id));
        (match AQ.For_testing.get_pending_entry_unchecked ~id:quarantined_id with
         | Some
-            { summary_status = AQ.Summary_failed _
+            { summary_status = Rule_types.Summary_failed _
             ; exact_attempt =
-                AQ.Exact_bound
+                Rule_types.Exact_bound
                   { status =
-                      AQ.Exact_quarantined AQ.Exact_flow_execution_failed
+                      Rule_types.Exact_quarantined Rule_types.Exact_flow_execution_failed
                   ; _
                   }
             ; _
@@ -2782,8 +2784,8 @@ let test_summary_owner_retirement_is_atomic_and_owner_scoped () =
         | Ok _ -> Alcotest.fail "bound owner retirement succeeded");
        (match AQ.For_testing.get_pending_entry_unchecked ~id:bound with
         | Some
-            { summary_status = AQ.Summary_pending
-            ; exact_attempt = AQ.Exact_bound binding
+            { summary_status = Rule_types.Summary_pending
+            ; exact_attempt = Rule_types.Exact_bound binding
             ; _
             } ->
           Alcotest.(check string)
@@ -2793,7 +2795,7 @@ let test_summary_owner_retirement_is_atomic_and_owner_scoped () =
         | Some _ | None ->
           Alcotest.fail "bound entry changed on failed retirement");
        (match AQ.For_testing.get_pending_entry_unchecked ~id:sibling with
-        | Some { summary_status = AQ.Summary_pending; _ } -> ()
+        | Some { summary_status = Rule_types.Summary_pending; _ } -> ()
         | Some _ | None ->
           Alcotest.fail "blocked retirement partially mutated");
        (match
@@ -2812,7 +2814,7 @@ let test_summary_owner_retirement_is_atomic_and_owner_scoped () =
             ids);
        match AQ.For_testing.get_pending_entry_unchecked ~id:retirable with
        | Some
-           { summary_status = AQ.Summary_failed { reason = "retired" }
+           { summary_status = Rule_types.Summary_failed { reason = "retired" }
            ; _
            } ->
          ()
@@ -3090,7 +3092,7 @@ let test_replay_sidecar_rejects_raw_output_wire () =
           aq_resolve
             ~base_path
             ~id:approval_id
-            ~decision:AQ.Decision.Approve
+            ~decision:Rule_types.Decision.Approve
         with
         | Ok () -> ()
         | Error error ->
@@ -3241,7 +3243,7 @@ let test_observed_delivery_preserves_grant_without_replaying_wake () =
           aq_resolve
             ~base_path
             ~id
-            ~decision:AQ.Decision.Approve
+            ~decision:Rule_types.Decision.Approve
         with
         | Ok () -> ()
        | Error error ->
@@ -3479,12 +3481,12 @@ let test_default_auto_judge_defers_without_blocking () =
            (String.length detail > 0);
          (match AQ.For_testing.get_pending_entry_unchecked ~id:approval_id with
           | Some
-              { summary_status = AQ.Summary_pending
-              ; exact_attempt = AQ.Exact_unbound
+              { summary_status = Rule_types.Summary_pending
+              ; exact_attempt = Rule_types.Exact_unbound
               ; summary_attempt_disposition =
-                  AQ.Summary_attempt_pre_worker_unavailable
+                  Rule_types.Summary_attempt_pre_worker_unavailable
                     { reason_code =
-                        AQ.Summary_pre_worker_auto_judge_unavailable
+                        Rule_types.Summary_pre_worker_auto_judge_unavailable
                     ; operator_detail
                     }
               ; _
@@ -3522,7 +3524,7 @@ let test_unavailable_cycle_grant_never_falls_through () =
     (fun () ->
        ignore (install_exn ~base_path);
        let approval_id = submit ~base_path ~keeper_name ~input in
-       (match aq_resolve ~base_path ~id:approval_id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id:approval_id ~decision:Rule_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
@@ -3584,7 +3586,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
           aq_resolve
             ~base_path
             ~id:reject_id
-            ~decision:(AQ.Decision.Reject rationale)
+            ~decision:(Rule_types.Decision.Reject rationale)
         with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
@@ -3612,7 +3614,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
        let edited_input =
          `Assoc [ "target", `String "after"; "confirmed", `Bool true ]
        in
-       (match aq_resolve ~base_path ~id:edit_id ~decision:(AQ.Decision.Edit edited_input) with
+       (match aq_resolve ~base_path ~id:edit_id ~decision:(Rule_types.Decision.Edit edited_input) with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let edited =
@@ -3649,7 +3651,7 @@ let test_resolved_audit_event_carries_judge_evidence () =
        let id =
          submit ~base_path ~keeper_name ~input:(`Assoc [ "target", `String "doc" ])
        in
-       (match aq_resolve ~base_path ~id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id ~decision:Rule_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let history =
@@ -3674,7 +3676,7 @@ let test_resolved_audit_event_carries_judge_evidence () =
            (row |> member "summary_status");
          Alcotest.check yojson
            "exact_attempt recorded at resolution"
-           (AQ.exact_attempt_state_to_yojson AQ.Exact_unbound)
+           (Rule_types.exact_attempt_state_to_yojson Rule_types.Exact_unbound)
            (row |> member "exact_attempt"))
 ;;
 

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -1,6 +1,8 @@
 open Alcotest
 
 module AQ = Masc.Keeper_approval_queue
+module Rules = Masc.Keeper_approval_queue_rules
+module Rule_types = Keeper_approval_queue_rules_types
 module Gate = Masc.Keeper_gate
 module Gate_mode = Masc.Keeper_gate_mode
 
@@ -40,7 +42,7 @@ let write_rules ~base_path json =
 
 let upsert_exn ~base_path ~input =
   match
-    AQ.upsert_rule
+    Rules.upsert_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
@@ -48,12 +50,12 @@ let upsert_exn ~base_path ~input =
       ()
   with
   | Ok result -> result
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Rule_types.rule_store_error_to_string error)
 ;;
 
 let find ~base_path ~input =
   match
-    AQ.find_matching_rule
+    Rules.find_matching_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
@@ -61,13 +63,13 @@ let find ~base_path ~input =
       ()
   with
   | Ok lookup -> lookup
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Rule_types.rule_store_error_to_string error)
 ;;
 
 let find_active_opt ~base_path ~input =
   match find ~base_path ~input with
-  | AQ.Rule_match_active matched -> Some matched
-  | AQ.Rule_match_expired _ | AQ.Rule_match_absent -> None
+  | Rule_types.Rule_match_active matched -> Some matched
+  | Rule_types.Rule_match_expired _ | Rule_types.Rule_match_absent -> None
 ;;
 
 let test_rule_matches_only_complete_exact_request () =
@@ -101,16 +103,16 @@ let test_rule_matches_only_complete_exact_request () =
          (Option.is_none (find_active_opt ~base_path ~input:changed_nonce));
        check bool "different operation identity cannot match" true
          (match
-            AQ.find_matching_rule
+            Rules.find_matching_rule
               ~base_path
               ~keeper_name:"keeper"
               ~tool_name:"another-effect"
               ~input
               ()
           with
-          | Ok AQ.Rule_match_absent -> true
-          | Ok (AQ.Rule_match_active _ | AQ.Rule_match_expired _) -> false
-          | Error error -> fail (AQ.rule_store_error_to_string error)))
+          | Ok Rule_types.Rule_match_absent -> true
+          | Ok (Rule_types.Rule_match_active _ | Rule_types.Rule_match_expired _) -> false
+          | Error error -> fail (Rule_types.rule_store_error_to_string error)))
 ;;
 
 let test_equivalent_upsert_is_idempotent () =
@@ -160,7 +162,7 @@ let test_gate_allows_only_the_exact_persisted_rule () =
 
 let upsert_with_expiry_exn ~base_path ~input ~expires_at =
   match
-    AQ.upsert_rule
+    Rules.upsert_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
@@ -169,12 +171,12 @@ let upsert_with_expiry_exn ~base_path ~input ~expires_at =
       ()
   with
   | Ok result -> result
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Rule_types.rule_store_error_to_string error)
 ;;
 
 let find_at ~base_path ~input ~now =
   match
-    AQ.find_matching_rule
+    Rules.find_matching_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
@@ -183,7 +185,7 @@ let find_at ~base_path ~input ~now =
       ()
   with
   | Ok lookup -> lookup
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Rule_types.rule_store_error_to_string error)
 ;;
 
 let test_unexpired_rule_matches_with_injected_now () =
@@ -199,10 +201,10 @@ let test_unexpired_rule_matches_with_injected_now () =
        check (option (float 0.0)) "expiry persisted on rule" (Some 2000.0)
          rule.expires_at;
        match find_at ~base_path ~input ~now:1999.0 with
-       | AQ.Rule_match_active matched ->
+       | Rule_types.Rule_match_active matched ->
          check string "unexpired rule matches" rule.id matched.rule_id
-       | AQ.Rule_match_expired _ -> fail "unexpired rule reported as expired"
-       | AQ.Rule_match_absent -> fail "unexpired rule did not match")
+       | Rule_types.Rule_match_expired _ -> fail "unexpired rule reported as expired"
+       | Rule_types.Rule_match_absent -> fail "unexpired rule did not match")
 ;;
 
 let test_expired_rule_is_reported_and_retained () =
@@ -213,22 +215,22 @@ let test_expired_rule_is_reported_and_retained () =
        let input = `Assoc [ "request", `String "exact" ] in
        let rule, _ = upsert_with_expiry_exn ~base_path ~input ~expires_at:2000.0 in
        (match find_at ~base_path ~input ~now:2000.0 with
-        | AQ.Rule_match_expired matched ->
+        | Rule_types.Rule_match_expired matched ->
           check string "expiry boundary is expired" rule.id matched.rule_id
-        | AQ.Rule_match_active _ -> fail "expired rule still matched"
-        | AQ.Rule_match_absent -> fail "expired rule must be reported, not absent");
+        | Rule_types.Rule_match_active _ -> fail "expired rule still matched"
+        | Rule_types.Rule_match_absent -> fail "expired rule must be reported, not absent");
        (match find_at ~base_path ~input ~now:2001.0 with
-        | AQ.Rule_match_expired matched ->
+        | Rule_types.Rule_match_expired matched ->
           check string "after expiry is expired" rule.id matched.rule_id
-        | AQ.Rule_match_active _ -> fail "expired rule still matched"
-        | AQ.Rule_match_absent -> fail "expired rule must be reported, not absent");
+        | Rule_types.Rule_match_active _ -> fail "expired rule still matched"
+        | Rule_types.Rule_match_absent -> fail "expired rule must be reported, not absent");
        let stored =
-         match AQ.list_rules ~base_path () with
+         match Rules.list_rules ~base_path () with
          | Ok rules -> rules
-         | Error error -> fail (AQ.rule_store_error_to_string error)
+         | Error error -> fail (Rule_types.rule_store_error_to_string error)
        in
        check bool "expired rule is retained for operator cleanup" true
-         (List.exists (fun (stored : AQ.approval_rule) ->
+         (List.exists (fun (stored : Rule_types.approval_rule) ->
             String.equal stored.id rule.id && stored.expires_at = Some 2000.0)
             stored))
 ;;
@@ -242,10 +244,10 @@ let test_rule_without_expiry_matches_at_any_now () =
        let rule, _ = upsert_exn ~base_path ~input in
        check (option (float 0.0)) "no expiry by default" None rule.expires_at;
        match find_at ~base_path ~input ~now:1e12 with
-       | AQ.Rule_match_active matched ->
+       | Rule_types.Rule_match_active matched ->
          check string "rule without expiry stays active" rule.id matched.rule_id
-       | AQ.Rule_match_expired _ -> fail "rule without expiry reported as expired"
-       | AQ.Rule_match_absent -> fail "rule without expiry did not match")
+       | Rule_types.Rule_match_expired _ -> fail "rule without expiry reported as expired"
+       | Rule_types.Rule_match_absent -> fail "rule without expiry did not match")
 ;;
 
 let test_unknown_persisted_shape_is_reported_and_rejected () =
@@ -255,7 +257,7 @@ let test_unknown_persisted_shape_is_reported_and_rejected () =
     (fun () ->
        let input = `Assoc [ "request", `String "exact" ] in
        let rule, _ = upsert_exn ~base_path ~input in
-       let json = AQ.approval_rule_to_yojson rule in
+       let json = Rule_types.approval_rule_to_yojson rule in
        let extended =
          match json with
          | `Assoc fields -> `Assoc (("classification", `String "legacy") :: fields)
@@ -271,7 +273,7 @@ let test_unknown_persisted_shape_is_reported_and_rejected () =
            ()
        in
        write_rules ~base_path (`List [ json; extended ]);
-       (match AQ.list_rules ~base_path () with
+       (match Rules.list_rules ~base_path () with
         | Ok _ -> fail "unsupported entry must fail the whole rules file"
         | Error _ -> ());
        let after =
@@ -286,7 +288,7 @@ let test_unknown_persisted_shape_is_reported_and_rejected () =
        check bool "rejection is observed" true (after -. before >= 1.0))
 ;;
 
-let with_rule_id id (rule : AQ.approval_rule) = { rule with id }
+let with_rule_id id (rule : Rule_types.approval_rule) = { rule with id }
 
 let test_duplicate_persisted_rules_reject_whole_store () =
   let base_path = temp_dir () in
@@ -302,10 +304,10 @@ let test_duplicate_persisted_rules_reject_whole_store () =
        write_rules
          ~base_path
          (`List
-             [ AQ.approval_rule_to_yojson first
-             ; AQ.approval_rule_to_yojson (with_rule_id first.id second)
+             [ Rule_types.approval_rule_to_yojson first
+             ; Rule_types.approval_rule_to_yojson (with_rule_id first.id second)
              ]);
-       (match AQ.list_rules ~base_path () with
+       (match Rules.list_rules ~base_path () with
         | Ok _ -> fail "duplicate rule ids must fail the whole rules store"
         | Error error ->
           check bool "duplicate id named" true
@@ -315,10 +317,10 @@ let test_duplicate_persisted_rules_reject_whole_store () =
        write_rules
          ~base_path
          (`List
-             [ AQ.approval_rule_to_yojson first
-             ; AQ.approval_rule_to_yojson (with_rule_id "different-id" first)
+             [ Rule_types.approval_rule_to_yojson first
+             ; Rule_types.approval_rule_to_yojson (with_rule_id "different-id" first)
              ]);
-       match AQ.list_rules ~base_path () with
+       match Rules.list_rules ~base_path () with
        | Ok _ -> fail "duplicate exact identities must fail the whole rules store"
        | Error error ->
          check bool "duplicate identity named" true
@@ -362,13 +364,13 @@ let exact_rule_lookup_failure_count () =
     ()
 ;;
 
-let eligibility_summary : AQ.hitl_context_summary =
+let eligibility_summary : Rule_types.hitl_context_summary =
   { summary_version = 2
   ; generated_at = 1.0
   ; model_run_id = "gate-eligibility-judge"
   ; context_summary = "The exact request is supported by the visible context."
   ; key_questions = []
-  ; judgment = AQ.Approve
+  ; judgment = Rule_types.Approve
   ; rationale = "The request is safe to finalize."
   }
 ;;
@@ -422,7 +424,7 @@ let exact_identity label =
   }
 ;;
 
-let bind_exact_entry (entry : AQ.pending_approval) identity =
+let bind_exact_entry (entry : Rule_types.pending_approval) identity =
   exact_update_exn
     "bind exact attempt"
     (AQ.bind_summary_exact_attempt
@@ -484,7 +486,7 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
            ~call_id:identity.call_id
            ~plan_fingerprint:identity.plan_fingerprint
            ~request_body_sha256:identity.request_body_sha256
-           ~cause:AQ.Exact_flow_execution_failed))
+           ~cause:Rule_types.Exact_flow_execution_failed))
   in
   let completed =
     make_bound "completed" (fun entry identity ->
@@ -503,24 +505,24 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
                model_run_id = identity.call_id
              }))
   in
-let with_exact_status (entry : AQ.pending_approval) status =
+let with_exact_status (entry : Rule_types.pending_approval) status =
     match entry.exact_attempt with
-    | AQ.Exact_bound binding ->
+    | Rule_types.Exact_bound binding ->
       { entry with
         exact_attempt =
-          AQ.Exact_bound
-            (AQ.exact_attempt_binding_with_status binding status)
+          Rule_types.Exact_bound
+            (Rule_types.exact_attempt_binding_with_status binding status)
       }
-    | AQ.Exact_unbound ->
+    | Rule_types.Exact_unbound ->
       fail "bound exact eligibility fixture became unbound"
   in
   let released_recovery_required =
     with_exact_status
       released_before_dispatch
-      AQ.Exact_released_recovery_required
+      Rule_types.Exact_released_recovery_required
   in
   let restart_quarantined =
-    with_exact_status dispatch_uncertain AQ.Exact_restart_quarantined
+    with_exact_status dispatch_uncertain Rule_types.Exact_restart_quarantined
   in
   let check_ready label expected entry =
     check bool label expected (Gate.For_testing.auto_judge_entry_ready entry)
@@ -543,13 +545,13 @@ let with_exact_status (entry : AQ.pending_approval) status =
     restart_quarantined;
   check_ready "completed binding is finalize-only" false completed;
   (match quarantined.exact_attempt with
-   | AQ.Exact_bound { status = AQ.Exact_quarantined AQ.Exact_flow_execution_failed; _ } ->
+   | Rule_types.Exact_bound { status = Rule_types.Exact_quarantined Rule_types.Exact_flow_execution_failed; _ } ->
      ()
-   | AQ.Exact_unbound
-   | AQ.Exact_bound _ ->
+   | Rule_types.Exact_unbound
+   | Rule_types.Exact_bound _ ->
      fail "typed quarantine cause was not persisted");
   (match completed.exact_attempt, completed.summary_status with
-   | AQ.Exact_bound { status = AQ.Exact_completed; _ }, AQ.Summary_available _ -> ()
+   | Rule_types.Exact_bound { status = Rule_types.Exact_completed; _ }, Rule_types.Summary_available _ -> ()
    | _ -> fail "exact completion did not atomically persist its available summary");
   let other_owner =
     submit_eligibility_entry ~base_path ~keeper_name:"other-keeper" "other-owner"
@@ -572,7 +574,7 @@ let with_exact_status (entry : AQ.pending_approval) status =
   check int "operator recovery exposes only the FIFO head" 1 (List.length ready);
   check (list string) "operator recovery cannot skip the FIFO head"
     [ not_requested.id ]
-    (List.map (fun (entry : AQ.pending_approval) -> entry.id) ready)
+    (List.map (fun (entry : Rule_types.pending_approval) -> entry.id) ready)
 ;;
 
 let test_completed_exact_judgment_finalizes_without_worker () =
@@ -605,7 +607,7 @@ let test_completed_exact_judgment_finalizes_without_worker () =
    | Error error -> fail (AQ.install_error_to_string error));
   let completed = approval_entry_exn completed.id in
   (match completed.exact_attempt, completed.summary_status with
-   | AQ.Exact_bound { status = AQ.Exact_completed; _ }, AQ.Summary_available _ -> ()
+   | Rule_types.Exact_bound { status = Rule_types.Exact_completed; _ }, Rule_types.Summary_available _ -> ()
    | _ -> fail "completed available judgment did not survive restart");
   check bool "completed available judgment is finalize-only" false
     (Gate.For_testing.auto_judge_entry_ready completed);

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -12,6 +12,7 @@ module Reg = Masc.Keeper_registry
 module KT = Keeper_types
 module KR = Masc.Keeper_runtime
 module AQ = Masc.Keeper_approval_queue
+module AQT = Keeper_approval_queue_rules_types
 module KSM = Keeper_state_machine
 module KLH = Masc.Keeper_lifecycle_hooks
 module KA = Masc.Keeper_keepalive
@@ -349,7 +350,7 @@ let test_pending_hitl_approval_keeper_names_filters_persisted_pending () =
             (aq_resolve
                ~base_path:base_dir
                ~id
-               ~decision:(AQ.Decision.Reject "test cleanup")))
+               ~decision:(AQT.Decision.Reject "test cleanup")))
         !approval_ids;
       cleanup_dir base_dir)
     (fun () ->
@@ -1092,7 +1093,7 @@ let test_sweep_reports_pending_hitl_approval () =
              (aq_resolve
                 ~base_path:base_dir
                 ~id
-                ~decision:(AQ.Decision.Reject "test cleanup")))
+                ~decision:(AQT.Decision.Reject "test cleanup")))
         !approval_id;
       Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
@@ -1144,7 +1145,7 @@ let test_sweep_reports_pending_hitl_approval () =
            ~keeper_name:name
          |> Result.get_ok
          |> fun count -> count > 0);
-      (match aq_resolve ~base_path:base_dir ~id ~decision:AQ.Decision.Approve with
+      (match aq_resolve ~base_path:base_dir ~id ~decision:AQT.Decision.Approve with
        | Ok () -> approval_id := None
        | Error err -> fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
       check bool "resolution removes pending request" false

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -2262,8 +2262,8 @@ let test_approved_web_search_grant_executes_exact_request () =
          Masc.Keeper_approval_queue.resolve_with_policy
            ~base_path:config.base_path
            ~id:approval_id
-           ~decision:Masc.Keeper_approval_queue.Decision.Approve
-           ~source:Masc.Keeper_approval_queue.Auto_judge
+           ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+           ~source:Keeper_approval_queue_rules_types.Auto_judge
            ()
        with
        | Ok _ -> ()
@@ -2365,8 +2365,8 @@ let test_approved_web_search_replays_without_model_resubmission () =
          Masc.Keeper_approval_queue.resolve_with_policy
            ~base_path:config.base_path
            ~id:approval_id
-           ~decision:Masc.Keeper_approval_queue.Decision.Approve
-           ~source:Masc.Keeper_approval_queue.Auto_judge
+           ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+           ~source:Keeper_approval_queue_rules_types.Auto_judge
            ()
        with
        | Ok _ -> ()
@@ -2563,8 +2563,8 @@ let approved_web_search_resolution
      Masc.Keeper_approval_queue.resolve_with_policy
        ~base_path:config.base_path
        ~id:approval_id
-       ~decision:Masc.Keeper_approval_queue.Decision.Approve
-       ~source:Masc.Keeper_approval_queue.Auto_judge
+       ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+       ~source:Keeper_approval_queue_rules_types.Auto_judge
        ()
    with
    | Ok _ -> ()
@@ -2978,8 +2978,8 @@ let test_unsupported_approved_operation_retains_exact_model_issued_path () =
           Masc.Keeper_approval_queue.resolve_with_policy
             ~base_path:config.base_path
             ~id:approval_id
-            ~decision:Masc.Keeper_approval_queue.Decision.Approve
-            ~source:Masc.Keeper_approval_queue.Auto_judge
+            ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+            ~source:Keeper_approval_queue_rules_types.Auto_judge
             ()
         with
         | Ok _ -> ()

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -1,0 +1,519 @@
+open Alcotest
+open Masc
+open Keeper_official_client_session_store
+
+let temp_workspace prefix =
+  let path = Filename.temp_file prefix "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let cleanup_tree root =
+  let rec remove path =
+    if Sys.file_exists path
+    then if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try remove root with
+  | _ -> ()
+;;
+
+let with_workspace prefix f =
+  let base_path = temp_workspace prefix in
+  Fun.protect ~finally:(fun () -> cleanup_tree base_path) (fun () -> f base_path)
+;;
+
+let owner_epoch = "11111111-1111-4111-8111-111111111111"
+let next_owner_epoch = "22222222-2222-4222-8222-222222222222"
+let empty_surface = tool_surface_sha256 []
+
+let claim_new ~base_path ~keeper_name ~client_kind ~runtime_id ~owner_epoch ~at =
+  claim
+    ~base_path
+    ~keeper_name
+    ~expected:None
+    ~client_kind
+    ~owner_epoch
+    ~runtime_id
+    ~tool_surface_sha256:empty_surface
+    ~updated_at:at
+  |> Result.get_ok
+;;
+
+let test_roundtrip_and_settlement () =
+  with_workspace "masc-official-client-store-roundtrip-" (fun base_path ->
+    let keeper_name = "roundtrip" in
+    check bool "missing" true (load ~base_path ~keeper_name = Ok None);
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    (match
+       claim
+         ~base_path
+         ~keeper_name
+         ~expected:(Some claimed)
+         ~client_kind:Claude_code
+         ~owner_epoch
+         ~runtime_id:"claude-code.default"
+         ~tool_surface_sha256:empty_surface
+         ~updated_at:1.5
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "incomplete claim changed official client identity");
+    let active =
+      mark_active
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~session_id:"session-1"
+        ~updated_at:2.0
+      |> Result.get_ok
+    in
+    let starting =
+      mark_turn_starting
+        ~base_path
+        ~keeper_name
+        ~expected:active
+        ~session_id:"session-1"
+        ~updated_at:3.0
+      |> Result.get_ok
+    in
+    let inflight =
+      mark_turn_started
+        ~base_path
+        ~keeper_name
+        ~expected:starting
+        ~session_id:"session-1"
+        ~turn_id:"turn-1"
+        ~updated_at:4.0
+      |> Result.get_ok
+    in
+    let settled =
+      settle
+        ~base_path
+        ~keeper_name
+        ~expected:inflight
+        ~session_id:"session-1"
+        ~turn_id:"turn-1"
+        ~updated_at:5.0
+      |> Result.get_ok
+    in
+    let resume_plan =
+      plan_claim
+        ~expected:(Some settled)
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+      |> Result.get_ok
+    in
+    check int "resume ordinal" 2 resume_plan.turn_count;
+    check bool
+      "resume settlement"
+      true
+      (resume_plan.previous_settlement
+       = Some { session_id = "session-1"; turn_id = "turn-1" });
+    check
+      (option string)
+      "resume surface requirement"
+      (Some empty_surface)
+      resume_plan.required_tool_surface_sha256;
+    match load ~base_path ~keeper_name with
+    | Error detail -> fail detail
+    | Ok None -> fail "durable session disappeared"
+    | Ok (Some loaded) ->
+      check bool "exact read-back" true (loaded = settled);
+      check bool "client kind" true (loaded.client_kind = Codex);
+      check int "completed turns" 1 loaded.turn_count;
+      (match loaded.phase with
+       | Settled { session_id; turn_id } ->
+         check string "session" "session-1" session_id;
+         check string "turn" "turn-1" turn_id
+       | Ready | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+         fail "terminal turn was not settled"))
+;;
+
+let test_duplicate_claim_and_cas_are_fail_closed () =
+  with_workspace "masc-official-client-store-cas-" (fun base_path ->
+    let keeper_name = "cas" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    (match
+       claim
+         ~base_path
+         ~keeper_name
+         ~expected:(Some claimed)
+         ~client_kind:Codex
+         ~owner_epoch
+         ~runtime_id:"codex.default"
+         ~tool_surface_sha256:empty_surface
+         ~updated_at:2.0
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "incomplete claim admitted duplicate execution");
+    let active =
+      mark_active
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~session_id:"session-cas"
+        ~updated_at:3.0
+      |> Result.get_ok
+    in
+    (match
+       mark_turn_starting
+         ~base_path
+         ~keeper_name
+         ~expected:claimed
+         ~session_id:"session-cas"
+         ~updated_at:4.0
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "stale expected state bypassed compare-and-swap");
+    match load ~base_path ~keeper_name with
+    | Ok (Some loaded) -> check bool "active preserved" true (loaded = active)
+    | Error detail -> fail detail
+    | Ok None -> fail "CAS failure removed durable state")
+;;
+
+let test_terminal_identity_switch_starts_fresh () =
+  with_workspace "masc-official-client-store-switch-" (fun base_path ->
+    let keeper_name = "switch" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    let active =
+      mark_active
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~session_id:"codex-session"
+        ~updated_at:2.0
+      |> Result.get_ok
+    in
+    let starting =
+      mark_turn_starting
+        ~base_path
+        ~keeper_name
+        ~expected:active
+        ~session_id:"codex-session"
+        ~updated_at:3.0
+      |> Result.get_ok
+    in
+    let inflight =
+      mark_turn_started
+        ~base_path
+        ~keeper_name
+        ~expected:starting
+        ~session_id:"codex-session"
+        ~turn_id:"codex-turn"
+        ~updated_at:4.0
+      |> Result.get_ok
+    in
+    let settled =
+      settle
+        ~base_path
+        ~keeper_name
+        ~expected:inflight
+        ~session_id:"codex-session"
+        ~turn_id:"codex-turn"
+        ~updated_at:5.0
+      |> Result.get_ok
+    in
+    (match
+       claim
+         ~base_path
+         ~keeper_name
+         ~expected:(Some settled)
+         ~client_kind:Codex
+         ~owner_epoch
+         ~runtime_id:"codex.default"
+         ~tool_surface_sha256:(String.make 64 'a')
+         ~updated_at:6.0
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "same settled session resumed with a changed tool surface");
+    let switched =
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some settled)
+        ~client_kind:Claude_code
+        ~owner_epoch
+        ~runtime_id:"claude-code.sonnet"
+        ~tool_surface_sha256:(String.make 64 'b')
+        ~updated_at:7.0
+      |> Result.get_ok
+    in
+    check bool "new client" true (switched.client_kind = Claude_code);
+    check string "new runtime" "claude-code.sonnet" switched.runtime_id;
+    check int "fresh ordinal" 1 switched.turn_count;
+    match switched.phase with
+    | Start { previous_settlement = None; _ } -> ()
+    | Start { previous_settlement = Some _; _ }
+    | Ready | Active _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+      fail "terminal client switch inherited the old external session")
+;;
+
+let test_restart_recovery_and_transient_release () =
+  with_workspace "masc-official-client-store-restart-" (fun base_path ->
+    let keeper_name = "restart" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Antigravity
+        ~runtime_id:"antigravity.gemini"
+        ~owner_epoch
+        ~at:1.0
+    in
+    (match
+       reconcile_process_restart
+         ~base_path
+         ~keeper_name
+         ~expected:claimed
+         ~current_owner_epoch:owner_epoch
+         ~required_at:2.0
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "same process epoch was classified as a restart");
+    let recovery =
+      reconcile_process_restart
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~current_owner_epoch:next_owner_epoch
+        ~required_at:3.0
+      |> Result.get_ok
+    in
+    let recovery_id =
+      match recovery.phase with
+      | Recovery_required required ->
+        check bool "restart class" true (required.failure = Process_restarted);
+        check bool "ambiguous" true (failure_disposition required.failure = Ambiguous);
+        check string "claim epoch" owner_epoch required.owner_epoch;
+        required.recovery_id
+      | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+        fail "old process claim did not enter recovery"
+    in
+    let ready =
+      resolve_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:recovery
+        ~recovery_id
+        ~resolution:Restart_fresh
+        ~resolved_by:"operator"
+        ~resolved_at:4.0
+      |> Result.get_ok
+    in
+    let reclaimed =
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some ready)
+        ~client_kind:Antigravity
+        ~owner_epoch:next_owner_epoch
+        ~runtime_id:"antigravity.gemini"
+        ~tool_surface_sha256:empty_surface
+        ~updated_at:5.0
+      |> Result.get_ok
+    in
+    let released =
+      release_transient
+        ~base_path
+        ~keeper_name
+        ~expected:reclaimed
+        ~failure:Transient_spawn_failed
+        ~released_at:6.0
+      |> Result.get_ok
+    in
+    check int "transient does not count" 0 released.turn_count;
+    (match released.phase with
+     | Ready -> ()
+     | Start _ | Active _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+       fail "transient failure did not release the claim");
+    match released.last_transient_release with
+    | Some record ->
+      check bool "transient evidence" true (record.failure = Transient_spawn_failed);
+      check string "release epoch" next_owner_epoch record.owner_epoch
+    | None -> fail "transient release evidence was not persisted")
+;;
+
+let test_exact_recovery_resolution () =
+  with_workspace "masc-official-client-store-resolution-" (fun base_path ->
+    let keeper_name = "resolution" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Claude_code
+        ~runtime_id:"claude-code.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    let recovery =
+      require_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~failure:Protocol_failed
+        ~detail:"ambiguous client protocol failure"
+        ~required_at:2.0
+      |> Result.get_ok
+    in
+    let recovery_id =
+      match recovery.phase with
+      | Recovery_required required -> required.recovery_id
+      | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+        fail "ambiguous failure did not require recovery"
+    in
+    (match
+       resolve_recovery
+         ~base_path
+         ~keeper_name
+         ~expected:recovery
+         ~recovery_id:"33333333-3333-4333-8333-333333333333"
+         ~resolution:Restart_fresh
+         ~resolved_by:"operator"
+         ~resolved_at:3.0
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "wrong recovery fence was accepted");
+    let settlement = { session_id = "verified-session"; turn_id = "verified-turn" } in
+    let adopted =
+      resolve_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:recovery
+        ~recovery_id
+        ~resolution:(Adopt_verified settlement)
+        ~resolved_by:"operator"
+        ~resolved_at:4.0
+      |> Result.get_ok
+    in
+    check int "adopt counts verified turn" 1 adopted.turn_count;
+    (match adopted.phase with
+     | Settled observed -> check bool "verified settlement" true (observed = settlement)
+     | Ready | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+       fail "verified terminal identity was not adopted");
+    match adopted.last_recovery_resolution with
+    | Some record ->
+      check string "durable actor" "operator" record.resolved_by;
+      check string "recovery fence" recovery_id record.recovery_id
+    | None -> fail "recovery resolution evidence was not persisted")
+;;
+
+let write_file path content =
+  let output = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr output)
+    (fun () -> output_string output content)
+;;
+
+let test_ambiguous_json_is_rejected () =
+  with_workspace "masc-official-client-store-json-" (fun base_path ->
+    let keeper_name = "ambiguous-json" in
+    let state_path = path ~base_path ~keeper_name |> Result.get_ok in
+    let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname state_path) in
+    write_file
+      state_path
+      {|{"client_kind":"codex","last_recovery_resolution":null,"last_transient_release":null,"phase":{"kind":"settled","session_id":"session-1","turn_id":"turn-1"},"runtime_id":"codex.default","runtime_id":"codex.other","schema":"masc.keeper.official-client-session.v1","tool_surface_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","turn_count":1,"updated_at":1.0}|};
+    match load ~base_path ~keeper_name with
+    | Error _ -> ()
+    | Ok _ -> fail "duplicate JSON keys were accepted")
+;;
+
+let fixture_tool ?(parameters = []) ~name ~description () =
+  Agent_sdk.Tool.create
+    ~name
+    ~description
+    ~parameters
+    (fun _ -> Ok { Agent_sdk.Types.content = "fixture"; _meta = None })
+;;
+
+let test_tool_surface_fingerprint_is_canonical () =
+  let alpha = fixture_tool ~name:"alpha" ~description:"first" () in
+  let beta = fixture_tool ~name:"beta" ~description:"second" () in
+  let changed = fixture_tool ~name:"alpha" ~description:"changed" () in
+  let first : Agent_sdk.Types.tool_param =
+    { name = "first"; description = "first"; param_type = String; required = true }
+  in
+  let second : Agent_sdk.Types.tool_param =
+    { name = "second"; description = "second"; param_type = Integer; required = true }
+  in
+  let ordered =
+    fixture_tool
+      ~parameters:[ first; second ]
+      ~name:"ordered"
+      ~description:"same"
+      ()
+  in
+  let reordered =
+    fixture_tool
+      ~parameters:[ second; first ]
+      ~name:"ordered"
+      ~description:"same"
+      ()
+  in
+  check string
+    "tool order"
+    (tool_surface_sha256 [ alpha; beta ])
+    (tool_surface_sha256 [ beta; alpha ]);
+  check string
+    "parameter order"
+    (tool_surface_sha256 [ ordered ])
+    (tool_surface_sha256 [ reordered ]);
+  check bool
+    "description participates"
+    true
+    (not (String.equal (tool_surface_sha256 [ alpha ]) (tool_surface_sha256 [ changed ])))
+;;
+
+let () =
+  run
+    "official client session store"
+    [ ( "durable owner"
+      , [ test_case "roundtrip and settlement" `Quick test_roundtrip_and_settlement
+        ; test_case
+            "duplicate claim and CAS fail closed"
+            `Quick
+            test_duplicate_claim_and_cas_are_fail_closed
+        ; test_case
+            "terminal identity switch starts fresh"
+            `Quick
+            test_terminal_identity_switch_starts_fresh
+        ; test_case
+            "restart recovery and transient release"
+            `Quick
+            test_restart_recovery_and_transient_release
+        ; test_case "exact recovery resolution" `Quick test_exact_recovery_resolution
+        ; test_case "ambiguous JSON rejected" `Quick test_ambiguous_json_is_rejected
+        ; test_case
+            "tool surface fingerprint canonical"
+            `Quick
+            test_tool_surface_fingerprint_is_canonical
+        ] )
+    ]
+;;

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -1843,7 +1843,7 @@ let approved_grant_fixture ~base_path ~keeper_name ~input =
      Keeper_approval_queue.resolve_with_policy
        ~base_path
        ~id:approval_id
-       ~decision:Keeper_approval_queue.Decision.Approve
+       ~decision:Keeper_approval_queue_rules_types.Decision.Approve
        ()
    with
    | Ok _ -> ()


### PR DESCRIPTION
## Summary
- add one typed durable session owner shared by Codex, Claude Code, and Antigravity/Gemini
- enforce process-safe claim/CAS/read-back, exact session and turn settlement, and explicit ambiguous recovery
- auto-release only typed transient spawn failures while retaining durable evidence
- allow an explicit terminal runtime/client reassignment to start fresh, while requiring an identical tool surface for same-session resume
- reject duplicate JSON keys, stale expected state, incomplete duplicate claims, and client switches during incomplete work

## Verification
- `dune build --root . @test/runtest-test_official_client_session_store` — 7/7 passed
- `git diff --check`

## Scope
This PR contains only the shared durable owner and its focused tests. It does not add a Codex, Claude Code, or Gemini process adapter, dashboard surface, compatibility alias, or OAS checkpoint.