### PR TITLE
feat(runtime): resume Codex subscription sessions

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -64,6 +64,41 @@ Runtime assignment lives only in `runtime.toml` under
 supplies the current tool schemas separately for each turn, so `AGENT.md`
 should describe behavior and boundaries without copying a tool catalog.
 
+An official Codex subscription runtime declares a CLI transport and no
+credentials. The Codex CLI owns ChatGPT login; MASC removes API-key variables
+from the child environment and refuses non-subscription accounts. Model IDs
+containing dots must be quoted as TOML table keys.
+
+```toml
+[providers.codex_subscription]
+display-name = "Codex ChatGPT Subscription"
+protocol = "codex-app-server"
+command = "codex"
+is-non-interactive = true
+
+[models."gpt-5.3-codex-spark"]
+api-name = "gpt-5.3-codex-spark"
+max-context = 131072
+tools-support = true
+
+[codex_subscription."gpt-5.3-codex-spark"]
+
+# A Keeper assignment must still name a materialized runtime. To add ordered
+# failover, give the lane the same ID; runtime resolution prefers the lane.
+[runtime.lanes."codex_subscription.gpt-5.3-codex-spark"]
+strategy = "ordered"
+candidates = [
+  "codex_subscription.gpt-5.3-codex-spark",
+  "glm-coding.glm-5-turbo",
+]
+
+[runtime.assignments]
+sangsu = "codex_subscription.gpt-5.3-codex-spark"
+```
+
+The fallback candidate must already be a valid binding in the same file.
+There is intentionally no `[providers.codex_subscription.credentials]` table.
+
 ## Creation and update
 
 `masc_keeper_up` accepts `name` and, for first creation or an explicit prompt

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -527,7 +527,6 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     in
     let client_config =
       { Runtime_codex_app_server.cli_path = config.cli_path
-      ; cwd = base_path
       ; model = config.model
       ; developer_instructions
       ; timeout_s = config.timeout_s
@@ -550,6 +549,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         Runtime_codex_app_server.validate_turn
           ~dynamic_tools
           ~thread_mode
+          ~cwd:Eio.Path.(Eio.Stdenv.fs env / base_path)
           client_config
           ~prompt
       with

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -97,11 +97,11 @@ let illegal_hook_decision ~hook_name decision =
           (Agent_sdk.Hooks.classify_decision decision)))
 ;;
 
-let invoke_turn_hook ~keeper_name ~hook_name hook event =
+let invoke_turn_hook ~keeper_name ~turn_count ~hook_name hook event =
   Agent_sdk.Agent_tools.invoke_hook
     ~tracer:Agent_sdk.Tracing.null
     ~agent_name:keeper_name
-    ~turn_count:1
+    ~turn_count
     ~hook_name
     hook
     event
@@ -114,15 +114,16 @@ type prepared_turn =
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
   }
 
-let prepare_turn ~keeper_name ~system_prompt ~tools ~initial_messages
+let prepare_turn ~keeper_name ~turn_count ~system_prompt ~tools ~initial_messages
     ~model_input_projection ~hooks ~enable_thinking =
   let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
   let before_turn =
     invoke_turn_hook
       ~keeper_name
+      ~turn_count
       ~hook_name:"before_turn"
       hooks.before_turn
-      (Agent_sdk.Hooks.BeforeTurn { turn = 1; messages = initial_messages })
+      (Agent_sdk.Hooks.BeforeTurn { turn = turn_count; messages = initial_messages })
   in
   let* messages =
     match before_turn with
@@ -137,10 +138,11 @@ let prepare_turn ~keeper_name ~system_prompt ~tools ~initial_messages
   let before_turn_params =
     invoke_turn_hook
       ~keeper_name
+      ~turn_count
       ~hook_name:"before_turn_params"
       hooks.before_turn_params
       (Agent_sdk.Hooks.BeforeTurnParams
-         { turn = 1
+         { turn = turn_count
          ; messages
          ; last_tool_results = last_tool_results messages
          ; current_params
@@ -264,7 +266,7 @@ let apply_context_injection ~terminal_error ~context ~context_injector ~tool_nam
           ^ Printexc.to_string exn))
 ;;
 
-let dynamic_tool_of_oas ~keeper_name ~context ~tools
+let dynamic_tool_of_oas ~keeper_name ~turn_count ~context ~tools
     ~(hooks : Agent_sdk.Hooks.hooks) ~event_bus ~context_injector ~terminal_error
     (tool : Agent_sdk.Tool.t) =
   { Runtime_codex_app_server.name = tool.schema.name
@@ -282,13 +284,14 @@ let dynamic_tool_of_oas ~keeper_name ~context ~tools
         let invocation =
           Agent_sdk.Tool_contract.Invocation.create
             ~tool_use_id:call_id
-            ~turn:1
+            ~turn:turn_count
             ~schedule
             ~completion:(Agent_sdk.Tool.completion tool)
         in
         let pre_tool_use =
           invoke_turn_hook
             ~keeper_name
+            ~turn_count
             ~hook_name:"pre_tool_use"
             hooks.pre_tool_use
             (Agent_sdk.Hooks.PreToolUse
@@ -366,8 +369,8 @@ let dynamic_tool_of_oas ~keeper_name ~context ~tools
   }
 ;;
 
-let dynamic_tools ~keeper_name ~tools ~hooks ~event_bus ~context_injector ~context
-    ~terminal_error =
+let dynamic_tools ~keeper_name ~turn_count ~tools ~hooks ~event_bus ~context_injector
+    ~context ~terminal_error =
   match tools, context with
   | [], _ -> Ok []
   | _ :: _, None ->
@@ -380,6 +383,7 @@ let dynamic_tools ~keeper_name ~tools ~hooks ~event_bus ~context_injector ~conte
       (List.map
          (dynamic_tool_of_oas
             ~keeper_name
+            ~turn_count
             ~context
             ~tools
             ~hooks
@@ -397,9 +401,27 @@ let codex_error_to_sdk_error = function
   | error -> Agent_sdk.Error.Internal (Runtime_codex_app_server.error_to_string error)
 ;;
 
-let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~tools
-    ~initial_messages ~model_input_projection ~hooks ~context_injector ~context ~event_bus
-    ~enable_thinking ~(config : Runtime_execution.codex_app_server) =
+let recovery_failure_of_client_error = function
+  | Runtime_codex_app_server.Spawn_failed _ ->
+    Keeper_official_client_session_store.Transient_spawn_failed
+  | Runtime_codex_app_server.Turn_interrupted
+  | Runtime_codex_app_server.Process_exited _
+  | Runtime_codex_app_server.Timeout _ ->
+    Keeper_official_client_session_store.Transport_interrupted
+  | Runtime_codex_app_server.Invalid_config _
+  | Runtime_codex_app_server.Protocol_error _
+  | Runtime_codex_app_server.Rpc_error _
+  | Runtime_codex_app_server.Unsupported_server_request _ ->
+    Keeper_official_client_session_store.Protocol_failed
+  | Runtime_codex_app_server.Subscription_required _
+  | Runtime_codex_app_server.Turn_failed _ ->
+    Keeper_official_client_session_store.Provider_rejected
+;;
+
+let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
+    ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
+    ~context_injector ~context ~event_bus ~enable_thinking
+    ~(config : Runtime_execution.codex_app_server) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
     Error
@@ -413,15 +435,83 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
          "Codex app-server runtime requires the initialized Eio clock")
   | Some env, Some clock ->
     let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
+    let owner_epoch = Keeper_official_client_session_store.process_epoch () in
+    let* stored_session =
+      match Keeper_official_client_session_store.load ~base_path ~keeper_name with
+      | Ok session -> Ok session
+      | Error detail ->
+        Error (internal_error ("Codex session binding load failed: " ^ detail))
+    in
+    let* stored_session =
+      match stored_session with
+      | Some
+          ({ phase = (Start _ | Active _ | Turn_inflight _); _ } as expected) ->
+        (match
+           Keeper_official_client_session_store.reconcile_process_restart
+             ~base_path
+             ~keeper_name
+             ~expected
+             ~current_owner_epoch:owner_epoch
+             ~required_at:(Time_compat.now ())
+         with
+         | Ok reconciled -> Ok (Some reconciled)
+         | Error detail ->
+           Error
+             (config_error
+                ~field:"official_client_session.phase"
+                detail))
+      | None | Some { phase = (Ready | Recovery_required _ | Settled _); _ } ->
+        Ok stored_session
+    in
+    let* claim_plan =
+      match
+        Keeper_official_client_session_store.plan_claim
+          ~expected:stored_session
+          ~client_kind:Codex
+          ~runtime_id
+      with
+      | Ok plan -> Ok plan
+      | Error detail ->
+        Error
+          (config_error
+             ~field:"official_client_session.claim"
+             detail)
+    in
+    let thread_mode =
+      match claim_plan.previous_settlement with
+      | None -> Runtime_codex_app_server.Start
+      | Some { session_id; _ } ->
+        Runtime_codex_app_server.Resume { thread_id = session_id }
+    in
+    let turn_count = claim_plan.turn_count in
     let* prepared =
       prepare_turn
         ~keeper_name
+        ~turn_count
         ~system_prompt
         ~tools
         ~initial_messages
         ~model_input_projection
         ~hooks:(Some hooks)
         ~enable_thinking
+    in
+    let tool_surface_sha256 =
+      Keeper_official_client_session_store.tool_surface_sha256 prepared.tools
+    in
+    let* () =
+      match claim_plan.required_tool_surface_sha256 with
+      | None -> Ok ()
+      | Some stored_tool_surface_sha256
+        when String.equal stored_tool_surface_sha256 tool_surface_sha256 ->
+        Ok ()
+      | Some stored_tool_surface_sha256 ->
+        Error
+          (config_error
+             ~field:"official_client_session.tool_surface_sha256"
+             (Printf.sprintf
+                "stored official-client tool surface %s does not match current surface %s"
+                stored_tool_surface_sha256
+                tool_surface_sha256))
     in
     let* developer_messages, history = project_messages prepared.messages in
     let* prompt =
@@ -447,6 +537,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
     let* dynamic_tools =
       dynamic_tools
         ~keeper_name
+        ~turn_count
         ~tools:prepared.tools
         ~hooks
         ~event_bus
@@ -454,21 +545,155 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
         ~context
         ~terminal_error
     in
+    let* () =
+      match
+        Runtime_codex_app_server.validate_turn
+          ~dynamic_tools
+          ~thread_mode
+          client_config
+          ~prompt
+      with
+      | Ok () -> Ok ()
+      | Error error -> Error (codex_error_to_sdk_error error)
+    in
+    let* claimed_session =
+      match
+        Keeper_official_client_session_store.claim
+          ~base_path
+          ~keeper_name
+          ~expected:stored_session
+          ~client_kind:Codex
+          ~owner_epoch
+          ~runtime_id
+          ~tool_surface_sha256
+          ~updated_at:(Time_compat.now ())
+      with
+      | Ok session -> Ok session
+      | Error detail ->
+        Error (internal_error ("Codex session claim failed: " ^ detail))
+    in
+    let session_state = ref claimed_session in
+    let recovery_failure =
+      ref Keeper_official_client_session_store.Transport_interrupted
+    in
+    let update_session label transition =
+      match transition !session_state with
+      | Ok next ->
+        session_state := next;
+        Ok ()
+      | Error detail ->
+        recovery_failure := Keeper_official_client_session_store.State_persistence_failed;
+        Error (Printf.sprintf "Codex session %s failed: %s" label detail)
+    in
+    let require_recovery detail =
+      match !session_state with
+      | { Keeper_official_client_session_store.phase =
+            (Ready | Settled _ | Recovery_required _)
+        ; _
+        } ->
+        Ok ()
+      | expected ->
+        (match
+           Keeper_official_client_session_store.require_recovery
+             ~base_path
+             ~keeper_name
+             ~expected
+             ~failure:!recovery_failure
+             ~detail
+             ~required_at:(Time_compat.now ())
+         with
+         | Ok recovery ->
+           session_state := recovery;
+           Ok ()
+         | Error detail -> Error detail)
+    in
+    let settle_failed_claim detail =
+      match
+        Keeper_official_client_session_store.failure_disposition
+          !recovery_failure
+      with
+      | Transient ->
+        (match !session_state with
+         | { phase = (Ready | Settled _ | Recovery_required _); _ } -> Ok ()
+         | expected ->
+           (match
+              Keeper_official_client_session_store.release_transient
+                ~base_path
+                ~keeper_name
+                ~expected
+                ~failure:!recovery_failure
+                ~released_at:(Time_compat.now ())
+            with
+            | Ok released ->
+              session_state := released;
+              Ok ()
+            | Error detail -> Error detail))
+      | Ambiguous | Fatal -> require_recovery detail
+    in
     let started_at = Time_compat.now () in
-    (match
+    let turn_result =
+      try
+        (match
        Runtime_codex_app_server.run_turn
          ~mgr:(Eio.Stdenv.process_mgr env)
          ~clock
+         ~cwd:Eio.Path.(Eio.Stdenv.fs env / base_path)
          ~dynamic_tools
          ?reasoning_effort:prepared.reasoning_effort
+         ~thread_mode
          ~history
+         ~on_thread_ready:(fun ~thread_id ->
+           update_session "active transition" (fun expected ->
+             Keeper_official_client_session_store.mark_active
+               ~base_path
+               ~keeper_name
+               ~expected
+               ~session_id:thread_id
+               ~updated_at:(Time_compat.now ())))
+         ~on_turn_starting:(fun ~thread_id ->
+           update_session "turn-starting transition" (fun expected ->
+             Keeper_official_client_session_store.mark_turn_starting
+               ~base_path
+               ~keeper_name
+               ~expected
+               ~session_id:thread_id
+               ~updated_at:(Time_compat.now ())))
+         ~on_turn_started:(fun ~thread_id ~turn_id ->
+           update_session "turn-started transition" (fun expected ->
+             Keeper_official_client_session_store.mark_turn_started
+               ~base_path
+               ~keeper_name
+               ~expected
+               ~session_id:thread_id
+               ~turn_id
+               ~updated_at:(Time_compat.now ())))
          client_config
          ~prompt
      with
-     | Error error -> Error (codex_error_to_sdk_error error)
-     | Ok _ when Option.is_some !terminal_error ->
-       Error (internal_error (Option.get !terminal_error))
+     | Error error ->
+       recovery_failure := recovery_failure_of_client_error error;
+       Error (codex_error_to_sdk_error error)
      | Ok turn ->
+       recovery_failure := Keeper_official_client_session_store.Protocol_failed;
+       let expected_resumed =
+         match thread_mode with
+         | Runtime_codex_app_server.Start -> false
+         | Runtime_codex_app_server.Resume _ -> true
+       in
+       let* () =
+         if Bool.equal expected_resumed turn.resumed
+         then Ok ()
+         else
+           Error
+             (internal_error
+                "Codex app-server reported a thread mode different from the requested session plan")
+       in
+       recovery_failure := Keeper_official_client_session_store.Host_hook_failed;
+       let* () =
+         match !terminal_error with
+         | None -> Ok ()
+         | Some detail -> Error (internal_error detail)
+       in
        let latency_ms = Int.of_float ((Time_compat.now () -. started_at) *. 1000.0) in
        let response =
          { Agent_sdk.Types.id = turn.turn_id
@@ -487,9 +712,10 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
        let after_turn =
          invoke_turn_hook
            ~keeper_name
+           ~turn_count
            ~hook_name:"after_turn"
            hooks.after_turn
-           (Agent_sdk.Hooks.AfterTurn { turn = 1; response })
+           (Agent_sdk.Hooks.AfterTurn { turn = turn_count; response })
        in
        let* () =
          match after_turn with
@@ -501,6 +727,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
        let on_stop =
          invoke_turn_hook
            ~keeper_name
+           ~turn_count
            ~hook_name:"on_stop"
            hooks.on_stop
            (Agent_sdk.Hooks.OnStop { reason = response.stop_reason; response })
@@ -511,6 +738,23 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
          | HookFailed { stage; detail } ->
            Error (hook_error ~hook_name:"on_stop" ~stage detail)
          | decision -> Error (illegal_hook_decision ~hook_name:"on_stop" decision)
+       in
+       recovery_failure := Keeper_official_client_session_store.State_persistence_failed;
+       let* () =
+         match
+           Keeper_official_client_session_store.settle
+             ~base_path
+             ~keeper_name
+             ~expected:!session_state
+             ~session_id:turn.thread_id
+             ~turn_id:turn.turn_id
+             ~updated_at:(Time_compat.now ())
+         with
+         | Ok settled ->
+           session_state := settled;
+           Ok ()
+         | Error detail ->
+           Error (internal_error ("Codex session settlement failed: " ^ detail))
        in
        let capture, _metrics =
          Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
@@ -527,6 +771,8 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
            ~configured_labels:
              [ "codex_app_server"
              ; Printf.sprintf "dynamic_tool_calls=%d" turn.dynamic_tool_calls
+             ; Printf.sprintf "resumed=%b" turn.resumed
+             ; Printf.sprintf "turn_count=%d" turn_count
              ]
            ~candidate_count:1
            ~selected_model_raw:(Some turn.model)
@@ -539,10 +785,37 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt ~t
          { Runtime_agent.response
          ; checkpoint = None
          ; session_id = turn.thread_id
-         ; turns = 1
+         ; turns = turn_count
          ; trace_ref = None
          ; run_validation = None
          ; runtime_observation = Some runtime_observation
          ; stop_reason = Completed
          })
+      with
+      | Eio.Cancel.Cancelled _ as exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        recovery_failure := Keeper_official_client_session_store.Transport_interrupted;
+        let detail = "Codex turn cancelled: " ^ Printexc.to_string exn in
+        (match Eio.Cancel.protect (fun () -> settle_failed_claim detail) with
+         | Ok () -> ()
+         | Error recovery_detail ->
+           Log.Keeper.error
+             ~keeper_name
+             "Codex cancellation recovery persistence failed: %s"
+             recovery_detail);
+        Printexc.raise_with_backtrace exn backtrace
+    in
+    (match turn_result with
+     | Ok _ -> turn_result
+     | Error original_error ->
+       let original_detail = Agent_sdk.Error.to_string original_error in
+       (match Eio.Cancel.protect (fun () -> settle_failed_claim original_detail) with
+        | Ok () -> turn_result
+        | Error recovery_detail ->
+          Error
+            (internal_error
+               (Printf.sprintf
+                  "Codex turn failed and recovery state persistence also failed: original=%s recovery=%s"
+                  original_detail
+                  recovery_detail))))
 ;;

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -67,7 +67,6 @@ type phase =
 type recovery_resolution =
   | Retry_previous
   | Restart_fresh
-  | Adopt_verified of settlement
 
 type recovery_resolution_record =
   { recovery_id : string
@@ -224,7 +223,6 @@ let validate_recovery (recovery : recovery_required) =
 
 let validate_recovery_resolution = function
   | Retry_previous | Restart_fresh -> Ok ()
-  | Adopt_verified settlement -> validate_settlement settlement
 ;;
 
 let validate_recovery_resolution_record (record : recovery_resolution_record) =
@@ -361,22 +359,12 @@ let client_kind_of_string = function
 let recovery_resolution_to_yojson = function
   | Retry_previous -> `Assoc [ "kind", `String "retry_previous" ]
   | Restart_fresh -> `Assoc [ "kind", `String "restart_fresh" ]
-  | Adopt_verified settlement ->
-    `Assoc
-      [ "kind", `String "adopt_verified"
-      ; "settlement", settlement_to_yojson settlement
-      ]
 ;;
 
 let recovery_resolution_of_yojson = function
   | `Assoc [ "kind", `String "retry_previous" ] -> Ok Retry_previous
   | `Assoc [ "kind", `String "restart_fresh" ] -> Ok Restart_fresh
-  | `Assoc fields ->
-    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
-     | [ "kind", `String "adopt_verified"; "settlement", settlement_json ] ->
-       Result.map (fun settlement -> Adopt_verified settlement)
-         (settlement_of_yojson settlement_json)
-     | _ -> Error "official-client recovery resolution fields are not exact")
+  | `Assoc _ -> Error "official-client recovery resolution fields are not exact"
   | _ -> Error "official-client recovery resolution must be a JSON object"
 ;;
 
@@ -984,9 +972,6 @@ let resolve_recovery ~base_path ~keeper_name ~expected ~recovery_id ~resolution
            | Some settlement -> Settled settlement)
         , completed_turn_count )
     | Restart_fresh -> Ok (Ready, completed_turn_count)
-    | Adopt_verified settlement ->
-      let* () = validate_settlement settlement in
-      Ok (Settled settlement, expected.turn_count)
   in
   let* resolved =
     transition
@@ -1014,7 +999,6 @@ let resolve_recovery ~base_path ~keeper_name ~expected ~recovery_id ~resolution
     resolved_by
     (match resolution with
      | Retry_previous -> "retry_previous"
-     | Restart_fresh -> "restart_fresh"
-     | Adopt_verified _ -> "adopt_verified");
+     | Restart_fresh -> "restart_fresh");
   Ok resolved
 ;;

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -1,0 +1,1020 @@
+type client_kind =
+  | Codex
+  | Claude_code
+  | Antigravity
+
+type settlement =
+  { session_id : string
+  ; turn_id : string
+  }
+
+type recovery_failure =
+  | Transient_spawn_failed
+  | Transport_interrupted
+  | Protocol_failed
+  | Provider_rejected
+  | Host_hook_failed
+  | State_persistence_failed
+  | Process_restarted
+
+type failure_disposition =
+  | Transient
+  | Ambiguous
+  | Fatal
+
+let failure_disposition = function
+  | Transient_spawn_failed -> Transient
+  | Transport_interrupted
+  | Protocol_failed
+  | Host_hook_failed
+  | State_persistence_failed
+  | Process_restarted ->
+    Ambiguous
+  | Provider_rejected -> Fatal
+;;
+
+type recovery_required =
+  { recovery_id : string
+  ; previous_settlement : settlement option
+  ; observed_session_id : string option
+  ; observed_turn_id : string option
+  ; owner_epoch : string
+  ; failure : recovery_failure
+  ; detail : string
+  ; required_at : float
+  }
+
+type phase =
+  | Ready
+  | Start of
+      { owner_epoch : string
+      ; previous_settlement : settlement option
+      }
+  | Active of
+      { owner_epoch : string
+      ; session_id : string
+      ; previous_settlement : settlement option
+      }
+  | Turn_inflight of
+      { owner_epoch : string
+      ; session_id : string
+      ; turn_id : string option
+      ; previous_settlement : settlement option
+      }
+  | Recovery_required of recovery_required
+  | Settled of settlement
+
+type recovery_resolution =
+  | Retry_previous
+  | Restart_fresh
+  | Adopt_verified of settlement
+
+type recovery_resolution_record =
+  { recovery_id : string
+  ; failure : recovery_failure
+  ; resolution : recovery_resolution
+  ; resolved_by : string
+  ; resolved_at : float
+  }
+
+type transient_release_record =
+  { failure : recovery_failure
+  ; owner_epoch : string
+  ; released_at : float
+  }
+
+type t =
+  { client_kind : client_kind
+  ; runtime_id : string
+  ; phase : phase
+  ; turn_count : int
+  ; tool_surface_sha256 : string
+  ; last_recovery_resolution : recovery_resolution_record option
+  ; last_transient_release : transient_release_record option
+  ; updated_at : float
+  }
+
+type claim_plan =
+  { previous_settlement : settlement option
+  ; turn_count : int
+  ; required_tool_surface_sha256 : string option
+  }
+
+let ( let* ) = Result.bind
+let schema = "masc.keeper.official-client-session.v1"
+let filename = "session.json"
+let state_dirname = "official-client-runtime"
+let lock_filename = "session.lock"
+let recovery_rng = Random.State.make_self_init ()
+let recovery_rng_mutex = Stdlib.Mutex.create ()
+
+let fresh_recovery_id () =
+  Stdlib.Mutex.protect recovery_rng_mutex (fun () ->
+    Uuidm.v4_gen recovery_rng () |> Uuidm.to_string)
+;;
+
+let process_epoch_value = lazy (fresh_recovery_id ())
+let process_epoch () = Lazy.force process_epoch_value
+
+let state_dir ~base_path ~keeper_name =
+  if not (Safe_identifier.is_portable_name keeper_name)
+  then Error (Printf.sprintf "invalid official-client Keeper name %S" keeper_name)
+  else
+    Ok
+      (Filename.concat
+         (Filename.concat
+            (Common.keepers_runtime_dir_of_base ~base_path)
+            keeper_name)
+         state_dirname)
+;;
+
+let path ~base_path ~keeper_name =
+  Result.map
+    (fun directory -> Filename.concat directory filename)
+    (state_dir ~base_path ~keeper_name)
+;;
+
+let rec canonical_json = function
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       |> List.map (fun (name, value) -> name, canonical_json value)
+       |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | `List values -> `List (List.map canonical_json values)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as value ->
+    value
+;;
+
+let tool_surface_sha256 tools =
+  let tool_json (tool : Agent_sdk.Tool.t) =
+    let parameters =
+      List.sort
+        (fun (left : Agent_sdk.Types.tool_param) right ->
+           String.compare left.name right.name)
+        tool.schema.parameters
+    in
+    `Assoc
+      [ "description", `String tool.schema.description
+      ; "input_schema", Agent_sdk.Types.params_to_input_schema parameters
+      ; "name", `String tool.schema.name
+      ]
+    |> canonical_json
+  in
+  tools
+  |> List.sort (fun (left : Agent_sdk.Tool.t) right ->
+    String.compare left.schema.name right.schema.name)
+  |> List.map tool_json
+  |> fun tools -> Yojson.Safe.to_string (`List tools)
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
+let valid_sha256 value =
+  String.length value = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value
+;;
+
+let non_empty field value =
+  if String.equal (String.trim value) ""
+  then Error (Printf.sprintf "official-client session %s must not be empty" field)
+  else Ok ()
+;;
+
+let validate_uuid field value =
+  if Option.is_some (Uuidm.of_string value)
+  then Ok ()
+  else Error (Printf.sprintf "official-client session %s must be a UUID" field)
+;;
+
+let validate_settlement { session_id; turn_id } =
+  let* () = non_empty "session_id" session_id in
+  non_empty "turn_id" turn_id
+;;
+
+let validate_settlement_opt = function
+  | None -> Ok ()
+  | Some settlement -> validate_settlement settlement
+;;
+
+let validate_recovery (recovery : recovery_required) =
+  let* () = validate_uuid "recovery_id" recovery.recovery_id in
+  let* () = validate_uuid "owner_epoch" recovery.owner_epoch in
+  let* () = validate_settlement_opt recovery.previous_settlement in
+  let* () =
+    match recovery.observed_session_id with
+    | None -> Ok ()
+    | Some session_id -> non_empty "observed_session_id" session_id
+  in
+  let* () =
+    match recovery.observed_turn_id, recovery.observed_session_id with
+    | None, _ -> Ok ()
+    | Some turn_id, Some _ -> non_empty "observed_turn_id" turn_id
+    | Some _, None ->
+      Error "official-client recovery observed_turn_id requires observed_session_id"
+  in
+  let* () = non_empty "recovery detail" recovery.detail in
+  if Float.is_finite recovery.required_at
+  then Ok ()
+  else Error "official-client recovery required_at must be finite"
+;;
+
+let validate_recovery_resolution = function
+  | Retry_previous | Restart_fresh -> Ok ()
+  | Adopt_verified settlement -> validate_settlement settlement
+;;
+
+let validate_recovery_resolution_record (record : recovery_resolution_record) =
+  let* () = validate_uuid "resolved recovery_id" record.recovery_id in
+  let* () = validate_recovery_resolution record.resolution in
+  let* () = non_empty "resolved_by" record.resolved_by in
+  if Float.is_finite record.resolved_at
+  then Ok ()
+  else Error "official-client recovery resolved_at must be finite"
+;;
+
+let validate_transient_release_record (record : transient_release_record) =
+  let* () =
+    match failure_disposition record.failure with
+    | Transient -> Ok ()
+    | Ambiguous | Fatal ->
+      Error "official-client transient release must contain a transient failure"
+  in
+  let* () = validate_uuid "transient owner_epoch" record.owner_epoch in
+  if Float.is_finite record.released_at
+  then Ok ()
+  else Error "official-client transient released_at must be finite"
+;;
+
+let validate_phase = function
+  | Ready -> Ok ()
+  | Start { owner_epoch; previous_settlement } ->
+    let* () = validate_uuid "owner_epoch" owner_epoch in
+    validate_settlement_opt previous_settlement
+  | Active { owner_epoch; session_id; previous_settlement }
+  | Turn_inflight
+      { owner_epoch; session_id; turn_id = None; previous_settlement } ->
+    let* () = validate_uuid "owner_epoch" owner_epoch in
+    let* () = non_empty "session_id" session_id in
+    validate_settlement_opt previous_settlement
+  | Turn_inflight
+      { owner_epoch
+      ; session_id
+      ; turn_id = Some turn_id
+      ; previous_settlement
+      } ->
+    let* () = validate_uuid "owner_epoch" owner_epoch in
+    let* () = non_empty "session_id" session_id in
+    let* () = non_empty "turn_id" turn_id in
+    validate_settlement_opt previous_settlement
+  | Recovery_required recovery -> validate_recovery recovery
+  | Settled settlement -> validate_settlement settlement
+;;
+
+let validate binding =
+  let* () = non_empty "runtime_id" binding.runtime_id in
+  let* () = validate_phase binding.phase in
+  let* () =
+    match binding.last_recovery_resolution with
+    | None -> Ok ()
+    | Some record -> validate_recovery_resolution_record record
+  in
+  let* () =
+    match binding.last_transient_release with
+    | None -> Ok ()
+    | Some record -> validate_transient_release_record record
+  in
+  if binding.turn_count < 0
+  then Error "official-client session turn_count must be non-negative"
+  else if binding.turn_count = 0 && binding.phase <> Ready
+  then Error "only a ready official-client session may have zero completed turns"
+  else if not (valid_sha256 binding.tool_surface_sha256)
+  then Error "official-client session tool_surface_sha256 must be lowercase SHA-256"
+  else if not (Float.is_finite binding.updated_at)
+  then Error "official-client session updated_at must be finite"
+  else Ok ()
+;;
+
+let settlement_to_yojson settlement =
+  `Assoc
+    [ "session_id", `String settlement.session_id
+    ; "turn_id", `String settlement.turn_id
+    ]
+;;
+
+let settlement_opt_to_yojson = function
+  | None -> `Null
+  | Some settlement -> settlement_to_yojson settlement
+;;
+
+let settlement_of_yojson = function
+  | `Assoc [ "session_id", `String session_id; "turn_id", `String turn_id ]
+  | `Assoc [ "turn_id", `String turn_id; "session_id", `String session_id ] ->
+    let settlement = { session_id; turn_id } in
+    let* () = validate_settlement settlement in
+    Ok settlement
+  | _ -> Error "official-client settlement fields are not exact"
+;;
+
+let settlement_opt_of_yojson = function
+  | `Null -> Ok None
+  | json -> Result.map Option.some (settlement_of_yojson json)
+;;
+
+let recovery_failure_to_string = function
+  | Transient_spawn_failed -> "transient_spawn_failed"
+  | Transport_interrupted -> "transport_interrupted"
+  | Protocol_failed -> "protocol_failed"
+  | Provider_rejected -> "provider_rejected"
+  | Host_hook_failed -> "host_hook_failed"
+  | State_persistence_failed -> "state_persistence_failed"
+  | Process_restarted -> "process_restarted"
+;;
+
+let recovery_failure_of_string = function
+  | "transient_spawn_failed" -> Ok Transient_spawn_failed
+  | "transport_interrupted" -> Ok Transport_interrupted
+  | "protocol_failed" -> Ok Protocol_failed
+  | "provider_rejected" -> Ok Provider_rejected
+  | "host_hook_failed" -> Ok Host_hook_failed
+  | "state_persistence_failed" -> Ok State_persistence_failed
+  | "process_restarted" -> Ok Process_restarted
+  | _ -> Error "unknown official-client recovery failure"
+;;
+
+let client_kind_to_string = function
+  | Codex -> "codex"
+  | Claude_code -> "claude_code"
+  | Antigravity -> "antigravity"
+;;
+
+let client_kind_of_string = function
+  | "codex" -> Ok Codex
+  | "claude_code" -> Ok Claude_code
+  | "antigravity" -> Ok Antigravity
+  | _ -> Error "unknown official-client kind"
+;;
+
+let recovery_resolution_to_yojson = function
+  | Retry_previous -> `Assoc [ "kind", `String "retry_previous" ]
+  | Restart_fresh -> `Assoc [ "kind", `String "restart_fresh" ]
+  | Adopt_verified settlement ->
+    `Assoc
+      [ "kind", `String "adopt_verified"
+      ; "settlement", settlement_to_yojson settlement
+      ]
+;;
+
+let recovery_resolution_of_yojson = function
+  | `Assoc [ "kind", `String "retry_previous" ] -> Ok Retry_previous
+  | `Assoc [ "kind", `String "restart_fresh" ] -> Ok Restart_fresh
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "kind", `String "adopt_verified"; "settlement", settlement_json ] ->
+       Result.map (fun settlement -> Adopt_verified settlement)
+         (settlement_of_yojson settlement_json)
+     | _ -> Error "official-client recovery resolution fields are not exact")
+  | _ -> Error "official-client recovery resolution must be a JSON object"
+;;
+
+let recovery_resolution_record_to_yojson
+    (record : recovery_resolution_record) =
+  `Assoc
+    [ "failure", `String (recovery_failure_to_string record.failure)
+    ; "recovery_id", `String record.recovery_id
+    ; "resolution", recovery_resolution_to_yojson record.resolution
+    ; "resolved_at", `Float record.resolved_at
+    ; "resolved_by", `String record.resolved_by
+    ]
+;;
+
+let recovery_resolution_record_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "failure", `String failure; "recovery_id", `String recovery_id
+       ; "resolution", resolution_json; "resolved_at", `Float resolved_at
+       ; "resolved_by", `String resolved_by ] ->
+       let* failure = recovery_failure_of_string failure in
+       let* resolution = recovery_resolution_of_yojson resolution_json in
+       let record =
+         { recovery_id; failure; resolution; resolved_by; resolved_at }
+       in
+       let* () = validate_recovery_resolution_record record in
+       Ok record
+     | _ -> Error "official-client recovery resolution record fields are not exact")
+  | _ -> Error "official-client recovery resolution record must be a JSON object"
+;;
+
+let recovery_resolution_record_opt_to_yojson = function
+  | None -> `Null
+  | Some record -> recovery_resolution_record_to_yojson record
+;;
+
+let recovery_resolution_record_opt_of_yojson = function
+  | `Null -> Ok None
+  | json ->
+    Result.map Option.some (recovery_resolution_record_of_yojson json)
+;;
+
+let transient_release_record_to_yojson (record : transient_release_record) =
+  `Assoc
+    [ "failure", `String (recovery_failure_to_string record.failure)
+    ; "owner_epoch", `String record.owner_epoch
+    ; "released_at", `Float record.released_at
+    ]
+;;
+
+let transient_release_record_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "failure", `String failure; "owner_epoch", `String owner_epoch
+       ; "released_at", `Float released_at ] ->
+       let* failure = recovery_failure_of_string failure in
+       let record = { failure; owner_epoch; released_at } in
+       let* () = validate_transient_release_record record in
+       Ok record
+     | _ -> Error "official-client transient release fields are not exact")
+  | _ -> Error "official-client transient release must be a JSON object"
+;;
+
+let transient_release_record_opt_to_yojson = function
+  | None -> `Null
+  | Some record -> transient_release_record_to_yojson record
+;;
+
+let transient_release_record_opt_of_yojson = function
+  | `Null -> Ok None
+  | json -> Result.map Option.some (transient_release_record_of_yojson json)
+;;
+
+let string_opt_to_yojson = function
+  | None -> `Null
+  | Some value -> `String value
+;;
+
+let string_opt_of_yojson field = function
+  | `Null -> Ok None
+  | `String value ->
+    let* () = non_empty field value in
+    Ok (Some value)
+  | _ -> Error (Printf.sprintf "official-client recovery %s must be string or null" field)
+;;
+
+let phase_to_yojson = function
+  | Ready -> `Assoc [ "kind", `String "ready" ]
+  | Start { owner_epoch; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "start"
+      ; "owner_epoch", `String owner_epoch
+      ; "previous_settlement", settlement_opt_to_yojson previous_settlement
+      ]
+  | Active { owner_epoch; session_id; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "active"
+      ; "owner_epoch", `String owner_epoch
+      ; "previous_settlement", settlement_opt_to_yojson previous_settlement
+      ; "session_id", `String session_id
+      ]
+  | Turn_inflight { owner_epoch; session_id; turn_id; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "turn_inflight"
+      ; "owner_epoch", `String owner_epoch
+      ; "previous_settlement", settlement_opt_to_yojson previous_settlement
+      ; "session_id", `String session_id
+      ; ( "turn_id"
+        , Option.fold ~none:`Null ~some:(fun turn_id -> `String turn_id) turn_id )
+      ]
+  | Recovery_required recovery ->
+    `Assoc
+      [ "detail", `String recovery.detail
+      ; "failure", `String (recovery_failure_to_string recovery.failure)
+      ; "kind", `String "recovery_required"
+      ; "observed_session_id", string_opt_to_yojson recovery.observed_session_id
+      ; "observed_turn_id", string_opt_to_yojson recovery.observed_turn_id
+      ; "owner_epoch", `String recovery.owner_epoch
+      ; ( "previous_settlement"
+        , settlement_opt_to_yojson recovery.previous_settlement )
+      ; "recovery_id", `String recovery.recovery_id
+      ; "required_at", `Float recovery.required_at
+      ]
+  | Settled { session_id; turn_id } ->
+    `Assoc
+      [ "kind", `String "settled"
+      ; "session_id", `String session_id
+      ; "turn_id", `String turn_id
+      ]
+;;
+
+let phase_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "kind", `String "ready" ] -> Ok Ready
+     | [ "kind", `String "start"; "owner_epoch", `String owner_epoch
+       ; "previous_settlement", previous ] ->
+       let* previous_settlement = settlement_opt_of_yojson previous in
+       Ok (Start { owner_epoch; previous_settlement })
+     | [ "kind", `String "active"; "owner_epoch", `String owner_epoch
+       ; "previous_settlement", previous
+       ; "session_id", `String session_id ] ->
+       let* previous_settlement = settlement_opt_of_yojson previous in
+       Ok (Active { owner_epoch; session_id; previous_settlement })
+     | [ "kind", `String "turn_inflight"; "owner_epoch", `String owner_epoch
+       ; "previous_settlement", previous
+       ; "session_id", `String session_id; "turn_id", turn_id_json ] ->
+       let* previous_settlement = settlement_opt_of_yojson previous in
+       let* turn_id = string_opt_of_yojson "observed_turn_id" turn_id_json in
+       Ok (Turn_inflight { owner_epoch; session_id; turn_id; previous_settlement })
+     | [ "detail", `String detail; "failure", `String failure
+       ; "kind", `String "recovery_required"
+       ; "observed_session_id", observed_session_json
+       ; "observed_turn_id", observed_turn_json
+       ; "owner_epoch", `String owner_epoch
+       ; "previous_settlement", previous_json
+       ; "recovery_id", `String recovery_id; "required_at", `Float required_at
+       ] ->
+       let* failure = recovery_failure_of_string failure in
+       let* observed_session_id =
+         string_opt_of_yojson "observed_session_id" observed_session_json
+       in
+       let* observed_turn_id =
+         string_opt_of_yojson "observed_turn_id" observed_turn_json
+       in
+       let* previous_settlement = settlement_opt_of_yojson previous_json in
+       let recovery =
+         { recovery_id
+         ; previous_settlement
+         ; observed_session_id
+         ; observed_turn_id
+         ; owner_epoch
+         ; failure
+         ; detail
+         ; required_at
+         }
+       in
+       let* () = validate_recovery recovery in
+       Ok (Recovery_required recovery)
+     | [ "kind", `String "settled"; "session_id", `String session_id
+       ; "turn_id", `String turn_id ] ->
+       Ok (Settled { session_id; turn_id })
+     | _ -> Error "official-client session phase fields are not exact")
+  | _ -> Error "official-client session phase must be a JSON object"
+;;
+
+let to_yojson binding =
+  `Assoc
+    [ "client_kind", `String (client_kind_to_string binding.client_kind)
+    ; ( "last_recovery_resolution"
+      , recovery_resolution_record_opt_to_yojson
+          binding.last_recovery_resolution )
+    ; ( "last_transient_release"
+      , transient_release_record_opt_to_yojson binding.last_transient_release )
+    ; "runtime_id", `String binding.runtime_id
+    ; "phase", phase_to_yojson binding.phase
+    ; "schema", `String schema
+    ; "tool_surface_sha256", `String binding.tool_surface_sha256
+    ; "turn_count", `Int binding.turn_count
+    ; "updated_at", `Float binding.updated_at
+    ]
+;;
+
+let of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "client_kind", `String client_kind_json
+       ; "last_recovery_resolution", last_resolution_json
+       ; "last_transient_release", last_transient_release_json
+       ; "phase", phase_json
+       ; "runtime_id", `String runtime_id
+       ; "schema", `String encoded_schema
+       ; "tool_surface_sha256", `String tool_surface_sha256
+       ; "turn_count", `Int turn_count
+       ; "updated_at", `Float updated_at
+       ] ->
+       if not (String.equal encoded_schema schema)
+       then Error "unsupported official-client session schema"
+       else
+         let* client_kind = client_kind_of_string client_kind_json in
+         let* phase = phase_of_yojson phase_json in
+         let* last_recovery_resolution =
+           recovery_resolution_record_opt_of_yojson last_resolution_json
+         in
+         let* last_transient_release =
+           transient_release_record_opt_of_yojson last_transient_release_json
+         in
+         let binding =
+           { client_kind
+           ; runtime_id
+           ; phase
+           ; turn_count
+           ; tool_surface_sha256
+           ; last_recovery_resolution
+           ; last_transient_release
+           ; updated_at
+           }
+         in
+         let* () = validate binding in
+         Ok binding
+     | _ -> Error "official-client session fields are not exact")
+  | _ -> Error "official-client session must be a JSON object"
+;;
+
+let equal left right =
+  left.client_kind = right.client_kind
+  && String.equal left.runtime_id right.runtime_id
+  && left.phase = right.phase
+  && Int.equal left.turn_count right.turn_count
+  && String.equal left.tool_surface_sha256 right.tool_surface_sha256
+  && left.last_recovery_resolution = right.last_recovery_resolution
+  && left.last_transient_release = right.last_transient_release
+  && Float.equal left.updated_at right.updated_at
+;;
+
+let load_path state_path =
+  if not (Fs_compat.file_exists state_path)
+  then Ok None
+  else
+    let* json = Safe_ops.read_json_file_safe state_path in
+    let* binding = of_yojson json in
+    Ok (Some binding)
+;;
+
+let load ~base_path ~keeper_name =
+  let* state_path = path ~base_path ~keeper_name in
+  load_path state_path
+;;
+
+let save_path ~state_dir binding =
+  let* () = validate binding in
+  let state_path = Filename.concat state_dir filename in
+  let* () =
+    match
+      Keeper_fs.save_json_durable_atomic
+        ~ownership_root:state_dir
+        ~pretty:false
+        state_path
+        (to_yojson binding)
+    with
+    | Ok () -> Ok ()
+    | Error error -> Error (Keeper_fs.durable_write_error_to_string error)
+  in
+  let* persisted = load_path state_path in
+  match persisted with
+  | Some persisted when equal persisted binding -> Ok ()
+  | Some _ -> Error "official-client session changed after durable write"
+  | None -> Error "official-client session missing after durable write"
+;;
+
+let prepare_state_dir ~base_path ~keeper_name =
+  let* directory = state_dir ~base_path ~keeper_name in
+  try
+    let (_ : string) = Keeper_fs.ensure_dir directory in
+    Ok directory
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let with_store_lock ~base_path ~keeper_name f =
+  let* directory = prepare_state_dir ~base_path ~keeper_name in
+  match
+    File_lock_eio.with_durable_lock
+      ~lock_path:(Filename.concat directory lock_filename)
+      (fun () -> f directory)
+  with
+  | Ok result -> result
+  | Error error -> Error (File_lock_eio.durable_lock_error_to_string error)
+;;
+
+let transition ~base_path ~keeper_name ~expected next =
+  let* () = validate next in
+  with_store_lock ~base_path ~keeper_name (fun directory ->
+    let* current = load_path (Filename.concat directory filename) in
+    if Option.equal equal current expected
+    then save_path ~state_dir:directory next |> Result.map (fun () -> next)
+    else Error "official-client session changed before durable transition")
+;;
+
+let plan_claim ~expected ~client_kind ~runtime_id =
+  let* () = non_empty "runtime_id" runtime_id in
+  let* previous_settlement, turn_count, required_tool_surface_sha256 =
+    match expected with
+    | None -> Ok (None, 1, None)
+    | Some ({ phase = Ready; _ } as binding)
+      when binding.client_kind <> client_kind
+           || not (String.equal binding.runtime_id runtime_id) ->
+      Ok (None, 1, None)
+    | Some { phase = Ready; turn_count; _ } when turn_count < Int.max_int ->
+      Ok (None, turn_count + 1, None)
+    | Some ({ phase = Settled _; _ } as binding)
+      when binding.client_kind <> client_kind
+           || not (String.equal binding.runtime_id runtime_id) ->
+      Ok (None, 1, None)
+    | Some
+        { phase = Settled settlement
+        ; turn_count
+        ; tool_surface_sha256
+        ; _
+        }
+      when turn_count < Int.max_int ->
+      Ok (Some settlement, turn_count + 1, Some tool_surface_sha256)
+    | Some { phase = Ready | Settled _; _ } ->
+      Error "settled official-client session turn count cannot be incremented"
+    | Some { phase = Start _; _ } ->
+      Error "official-client session has an incomplete start; refusing duplicate execution"
+    | Some { phase = Active _; _ } ->
+      Error "official-client session has an active unsettled attempt; refusing duplicate execution"
+    | Some { phase = Turn_inflight _; _ } ->
+      Error "official-client session has an in-flight turn; refusing duplicate execution"
+    | Some { phase = Recovery_required recovery; _ } ->
+      Error
+        (Printf.sprintf
+           "official-client session recovery %s must be resolved before another execution"
+           recovery.recovery_id)
+  in
+  Ok { previous_settlement; turn_count; required_tool_surface_sha256 }
+;;
+
+let claim ~base_path ~keeper_name ~expected ~client_kind ~owner_epoch ~runtime_id
+    ~tool_surface_sha256 ~updated_at =
+  let* () = validate_uuid "owner_epoch" owner_epoch in
+  let* plan = plan_claim ~expected ~client_kind ~runtime_id in
+  let* () =
+    match plan.required_tool_surface_sha256 with
+    | None -> Ok ()
+    | Some stored when String.equal stored tool_surface_sha256 -> Ok ()
+    | Some _ -> Error "official-client tool surface changed before session resume"
+  in
+  let last_recovery_resolution =
+    Option.bind expected (fun binding -> binding.last_recovery_resolution)
+  in
+  transition
+    ~base_path
+    ~keeper_name
+    ~expected
+    { client_kind
+    ; runtime_id
+    ; phase = Start { owner_epoch; previous_settlement = plan.previous_settlement }
+    ; turn_count = plan.turn_count
+    ; tool_surface_sha256
+    ; last_recovery_resolution
+    ; last_transient_release = Option.bind expected (fun binding -> binding.last_transient_release)
+    ; updated_at
+    }
+;;
+
+let mark_active ~base_path ~keeper_name ~expected ~session_id ~updated_at =
+  match expected.phase with
+  | Start { owner_epoch; previous_settlement } ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase = Active { owner_epoch; session_id; previous_settlement }
+      ; updated_at
+      }
+  | Ready | Active _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+    Error "official-client session can become active only from start"
+;;
+
+let mark_turn_starting ~base_path ~keeper_name ~expected ~session_id ~updated_at =
+  match expected.phase with
+  | Active { owner_epoch; session_id = active_session_id; previous_settlement }
+    when String.equal active_session_id session_id ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase =
+          Turn_inflight
+            { owner_epoch; session_id; turn_id = None; previous_settlement }
+      ; updated_at
+      }
+  | Active _ -> Error "official-client session identity changed before turn start"
+  | Ready | Start _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+    Error "official-client turn can start only from an active session"
+;;
+
+let mark_turn_started ~base_path ~keeper_name ~expected ~session_id ~turn_id
+    ~updated_at =
+  match expected.phase with
+  | Turn_inflight
+      { owner_epoch
+      ; session_id = inflight_session_id
+      ; turn_id = None
+      ; previous_settlement
+      }
+    when String.equal inflight_session_id session_id ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase =
+          Turn_inflight
+            { owner_epoch
+            ; session_id
+            ; turn_id = Some turn_id
+            ; previous_settlement
+            }
+      ; updated_at
+      }
+  | Turn_inflight { turn_id = None; _ } ->
+    Error "official-client in-flight session identity changed after turn start"
+  | Turn_inflight { turn_id = Some _; _ } ->
+    Error "official-client in-flight turn already has an identity"
+  | Ready | Start _ | Active _ | Recovery_required _ | Settled _ ->
+    Error "official-client turn identity can be recorded only for an in-flight turn"
+;;
+
+let settle ~base_path ~keeper_name ~expected ~session_id ~turn_id ~updated_at =
+  match expected.phase with
+  | Turn_inflight
+      { session_id = inflight_session_id
+      ; turn_id = Some inflight_turn_id
+      ; previous_settlement = _
+      }
+    when String.equal inflight_session_id session_id
+         && String.equal inflight_turn_id turn_id ->
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with phase = Settled { session_id; turn_id }; updated_at }
+  | Turn_inflight _ ->
+    Error "official-client terminal turn identity changed before settlement"
+  | Ready | Start _ | Active _ | Recovery_required _ | Settled _ ->
+    Error "official-client session can settle only from an identified in-flight turn"
+;;
+
+let require_recovery ~base_path ~keeper_name ~expected ~failure ~detail
+    ~required_at =
+  let* () = non_empty "recovery detail" detail in
+  let* () =
+    match failure_disposition failure with
+    | Ambiguous | Fatal -> Ok ()
+    | Transient ->
+      Error "transient official-client failures must use release_transient"
+  in
+  let* owner_epoch, previous_settlement, observed_session_id, observed_turn_id =
+    match expected.phase with
+    | Start { owner_epoch; previous_settlement } ->
+      Ok (owner_epoch, previous_settlement, None, None)
+    | Active { owner_epoch; session_id; previous_settlement } ->
+      Ok (owner_epoch, previous_settlement, Some session_id, None)
+    | Turn_inflight { owner_epoch; session_id; turn_id; previous_settlement } ->
+      Ok (owner_epoch, previous_settlement, Some session_id, turn_id)
+    | Ready | Settled _ ->
+      Error "a settled official-client session cannot require claim recovery"
+    | Recovery_required _ ->
+      Error "official-client session already requires recovery"
+  in
+  let recovery =
+    { recovery_id = fresh_recovery_id ()
+    ; previous_settlement
+    ; observed_session_id
+    ; observed_turn_id
+    ; owner_epoch
+    ; failure
+    ; detail
+    ; required_at
+    }
+  in
+  let* () = validate_recovery recovery in
+  transition
+    ~base_path
+    ~keeper_name
+    ~expected:(Some expected)
+    { expected with phase = Recovery_required recovery; updated_at = required_at }
+;;
+
+let incomplete_claim = function
+  | Start { owner_epoch; previous_settlement } ->
+    Some (owner_epoch, previous_settlement)
+  | Active { owner_epoch; previous_settlement; _ }
+  | Turn_inflight { owner_epoch; previous_settlement; _ } ->
+    Some (owner_epoch, previous_settlement)
+  | Ready | Recovery_required _ | Settled _ -> None
+;;
+
+let restored_phase previous_settlement =
+  match previous_settlement with
+  | None -> Ready
+  | Some settlement -> Settled settlement
+;;
+
+let release_transient ~base_path ~keeper_name ~expected ~failure ~released_at =
+  let* () =
+    match failure_disposition failure with
+    | Transient -> Ok ()
+    | Ambiguous | Fatal ->
+      Error "only transient official-client failures may release automatically"
+  in
+  let* owner_epoch, previous_settlement =
+    match incomplete_claim expected.phase with
+    | Some claim -> Ok claim
+    | None -> Error "official-client session has no incomplete claim to release"
+  in
+  let turn_count = max 0 (expected.turn_count - 1) in
+  let* released =
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase = restored_phase previous_settlement
+      ; turn_count
+      ; last_transient_release = Some { failure; owner_epoch; released_at }
+      ; updated_at = released_at
+      }
+  in
+  Log.Keeper.info
+    ~keeper_name
+    "auto-released transient official-client claim owner_epoch=%s failure=%s"
+    owner_epoch
+    (recovery_failure_to_string failure);
+  Ok released
+;;
+
+let reconcile_process_restart ~base_path ~keeper_name ~expected
+    ~current_owner_epoch ~required_at =
+  let* () = validate_uuid "current_owner_epoch" current_owner_epoch in
+  match incomplete_claim expected.phase with
+  | None -> Ok expected
+  | Some (owner_epoch, _) when String.equal owner_epoch current_owner_epoch ->
+    Error "official-client claim is still owned by the current process epoch"
+  | Some (owner_epoch, _) ->
+    require_recovery
+      ~base_path
+      ~keeper_name
+      ~expected
+      ~failure:Process_restarted
+      ~detail:
+        (Printf.sprintf
+           "MASC process epoch changed while an official-client claim was incomplete: previous=%s current=%s"
+           owner_epoch
+           current_owner_epoch)
+      ~required_at
+;;
+
+let resolve_recovery ~base_path ~keeper_name ~expected ~recovery_id ~resolution
+    ~resolved_by ~resolved_at =
+  let* () = non_empty "resolved_by" resolved_by in
+  let* recovery =
+    match expected.phase with
+    | Recovery_required recovery
+      when String.equal recovery.recovery_id recovery_id ->
+      Ok recovery
+    | Recovery_required _ ->
+      Error "official-client recovery identity changed before resolution"
+    | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+      Error "official-client session is not awaiting recovery"
+  in
+  let completed_turn_count = max 0 (expected.turn_count - 1) in
+  let* phase, turn_count =
+    match resolution with
+    | Retry_previous ->
+      Ok
+        ( (match recovery.previous_settlement with
+           | None -> Ready
+           | Some settlement -> Settled settlement)
+        , completed_turn_count )
+    | Restart_fresh -> Ok (Ready, completed_turn_count)
+    | Adopt_verified settlement ->
+      let* () = validate_settlement settlement in
+      Ok (Settled settlement, expected.turn_count)
+  in
+  let* resolved =
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected:(Some expected)
+      { expected with
+        phase
+      ; turn_count
+      ; last_recovery_resolution =
+          Some
+            { recovery_id
+            ; failure = recovery.failure
+            ; resolution
+            ; resolved_by
+            ; resolved_at
+            }
+      ; updated_at = resolved_at
+      }
+  in
+  Log.Keeper.info
+    ~keeper_name
+    "resolved official-client session recovery=%s actor=%s decision=%s"
+    recovery_id
+    resolved_by
+    (match resolution with
+     | Retry_previous -> "retry_previous"
+     | Restart_fresh -> "restart_fresh"
+     | Adopt_verified _ -> "adopt_verified");
+  Ok resolved
+;;

--- a/lib/keeper/keeper_official_client_session_store.mli
+++ b/lib/keeper/keeper_official_client_session_store.mli
@@ -65,7 +65,6 @@ type phase =
 type recovery_resolution =
   | Retry_previous
   | Restart_fresh
-  | Adopt_verified of settlement
 
 type recovery_resolution_record =
   { recovery_id : string
@@ -213,7 +212,6 @@ val resolve_recovery :
   (t, string) result
 (** Resolve one exact recovery claim with compare-and-swap authority.
     [Retry_previous] restores the last settled session, [Restart_fresh] makes
-    the next claim start a new session, and [Adopt_verified] records an
-    operator-verified terminal turn. *)
+    the next claim start a new session. *)
 (** Every phase change is a process-safe durable compare-and-swap followed by
     exact read-back. Any incomplete phase blocks a later automatic claim. *)

--- a/lib/keeper/keeper_official_client_session_store.mli
+++ b/lib/keeper/keeper_official_client_session_store.mli
@@ -1,0 +1,219 @@
+(** Durable current-owner state between one Keeper and one official subscription
+    client session.
+
+    This is not an OAS checkpoint. The external client owns its transcript;
+    MASC owns the exact claim, observation, recovery, and settlement phase needed
+    to avoid silently duplicating an externally admitted turn. *)
+
+type client_kind =
+  | Codex
+  | Claude_code
+  | Antigravity
+
+type settlement =
+  { session_id : string
+  ; turn_id : string
+  }
+
+type recovery_failure =
+  | Transient_spawn_failed
+  | Transport_interrupted
+  | Protocol_failed
+  | Provider_rejected
+  | Host_hook_failed
+  | State_persistence_failed
+  | Process_restarted
+
+type failure_disposition =
+  | Transient
+  | Ambiguous
+  | Fatal
+
+val failure_disposition : recovery_failure -> failure_disposition
+
+type recovery_required =
+  { recovery_id : string
+  ; previous_settlement : settlement option
+  ; observed_session_id : string option
+  ; observed_turn_id : string option
+  ; owner_epoch : string
+  ; failure : recovery_failure
+  ; detail : string
+  ; required_at : float
+  }
+
+type phase =
+  | Ready
+  | Start of
+      { owner_epoch : string
+      ; previous_settlement : settlement option
+      }
+  | Active of
+      { owner_epoch : string
+      ; session_id : string
+      ; previous_settlement : settlement option
+      }
+  | Turn_inflight of
+      { owner_epoch : string
+      ; session_id : string
+      ; turn_id : string option
+      ; previous_settlement : settlement option
+      }
+  | Recovery_required of recovery_required
+  | Settled of settlement
+
+type recovery_resolution =
+  | Retry_previous
+  | Restart_fresh
+  | Adopt_verified of settlement
+
+type recovery_resolution_record =
+  { recovery_id : string
+  ; failure : recovery_failure
+  ; resolution : recovery_resolution
+  ; resolved_by : string
+  ; resolved_at : float
+  }
+
+type transient_release_record =
+  { failure : recovery_failure
+  ; owner_epoch : string
+  ; released_at : float
+  }
+
+type t =
+  { client_kind : client_kind
+  ; runtime_id : string
+  ; phase : phase
+  ; turn_count : int
+  ; tool_surface_sha256 : string
+  ; last_recovery_resolution : recovery_resolution_record option
+  ; last_transient_release : transient_release_record option
+  ; updated_at : float
+  }
+
+type claim_plan =
+  { previous_settlement : settlement option
+  ; turn_count : int
+  ; required_tool_surface_sha256 : string option
+  }
+
+val process_epoch : unit -> string
+(** One UUID for the current MASC process. A durable incomplete claim owned by
+    another epoch is a restart ambiguity, not an active same-process turn. *)
+
+val path : base_path:string -> keeper_name:string -> (string, string) result
+
+val tool_surface_sha256 : Agent_sdk.Tool.t list -> string
+(** Stable digest of the exact typed dynamic-tool surface. Tool order,
+    parameter order, and JSON object field order do not affect the digest;
+    names, descriptions, parameter semantics, and input schemas do. *)
+
+val load : base_path:string -> keeper_name:string -> (t option, string) result
+(** Missing state is [Ok None]. Malformed, retired, or ambiguous state is an
+    error and never degrades to a new session. *)
+
+val plan_claim :
+  expected:t option ->
+  client_kind:client_kind ->
+  runtime_id:string ->
+  (claim_plan, string) result
+(** Pure claim planning shared by every official-client adapter. The plan is
+    the SSOT for fresh versus resumed execution, the next turn ordinal, and
+    whether the prepared tool surface must match a settled session. *)
+
+val claim :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t option ->
+  client_kind:client_kind ->
+  owner_epoch:string ->
+  runtime_id:string ->
+  tool_surface_sha256:string ->
+  updated_at:float ->
+  (t, string) result
+(** Claim the next exact turn. A terminal binding may start fresh when its
+    declared client kind or runtime id changes. Resuming the same settled
+    client/runtime requires an identical tool surface. Incomplete and recovery
+    phases always reject another claim regardless of configuration changes. *)
+
+val mark_active :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  session_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val mark_turn_starting :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  session_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val mark_turn_started :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  session_id:string ->
+  turn_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val settle :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  session_id:string ->
+  turn_id:string ->
+  updated_at:float ->
+  (t, string) result
+
+val require_recovery :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  failure:recovery_failure ->
+  detail:string ->
+  required_at:float ->
+  (t, string) result
+(** Convert the exact incomplete claim into an explicit operator-visible
+    recovery state. This never retries or clears a possibly executed turn. *)
+
+val release_transient :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  failure:recovery_failure ->
+  released_at:float ->
+  (t, string) result
+(** Release one exact incomplete claim only when [failure] is classified
+    [Transient]. The previous settlement, if any, is restored atomically. *)
+
+val reconcile_process_restart :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  current_owner_epoch:string ->
+  required_at:float ->
+  (t, string) result
+(** Convert an incomplete claim owned by a different process epoch into an
+    explicit ambiguous recovery. Same-epoch claims remain occupied. *)
+
+val resolve_recovery :
+  base_path:string ->
+  keeper_name:string ->
+  expected:t ->
+  recovery_id:string ->
+  resolution:recovery_resolution ->
+  resolved_by:string ->
+  resolved_at:float ->
+  (t, string) result
+(** Resolve one exact recovery claim with compare-and-swap authority.
+    [Retry_previous] restores the last settled session, [Restart_fresh] makes
+    the next claim start a new session, and [Adopt_verified] records an
+    operator-verified terminal turn. *)
+(** Every phase change is a process-safe durable compare-and-swap followed by
+    exact read-back. Any incomplete phase blocks a later automatic claim. *)

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -656,6 +656,10 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~histor
         ]
         @ optional_field "model" config.model
         @ optional_field "developerInstructions" config.developer_instructions
+        @
+        (match dynamic_tools with
+         | [] -> []
+         | tools -> [ "dynamicTools", `List (List.map dynamic_tool_spec tools) ])
       , true )
   in
   send_request io ~id:3 ~method_:thread_method ~params:(`Assoc thread_fields);

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -24,7 +24,7 @@ let stderr_tail_bytes = 4096
 let max_wire_line_bytes = 8 * 1024 * 1024
 let approval_policy = "never"
 let sandbox_mode = "read-only"
-let ephemeral_thread = true
+let thread_is_ephemeral = false
 
 let default_config ~cwd =
   { cli_path = "codex"
@@ -35,6 +35,10 @@ let default_config ~cwd =
   }
 ;;
 
+type thread_mode =
+  | Start
+  | Resume of { thread_id : string }
+
 type turn_result =
   { thread_id : string
   ; turn_id : string
@@ -43,6 +47,7 @@ type turn_result =
   ; dynamic_tool_calls : int
   ; subscription : subscription
   ; user_agent : string option
+  ; resumed : bool
   }
 
 type dynamic_tool_result =
@@ -383,8 +388,7 @@ let parse_subscription result =
   | _ -> protocol_error stage "account must be an object or null"
 ;;
 
-let parse_thread_start result =
-  let stage = "thread/start" in
+let parse_thread_response ~stage result =
   let* fields = assoc_at stage result in
   let* thread_json = required_member stage "thread" fields in
   let* thread_fields = assoc_at stage thread_json in
@@ -597,7 +601,18 @@ let history_item (message : history_message) =
     ]
 ;;
 
-let run_protocol io config ~dynamic_tools ~reasoning_effort ~history ~prompt =
+let invoke_state_callback ~stage callback =
+  try
+    match callback () with
+    | Ok () -> Ok ()
+    | Error detail -> protocol_error stage detail
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> protocol_error stage (Printexc.to_string exn)
+;;
+
+let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~history ~prompt
+    ~on_thread_ready ~on_turn_starting ~on_turn_started =
   send_request io ~id:1 ~method_:"initialize"
     ~params:
       (`Assoc
@@ -616,26 +631,52 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~history ~prompt =
     ~params:(`Assoc [ "refreshToken", `Bool false ]);
   let* account = await_response io ~id:2 ~method_:"account/read" in
   let* subscription = parse_subscription account in
-  let thread_fields =
-    [ "cwd", `String config.cwd
-    ; "approvalPolicy", `String approval_policy
-    ; "sandbox", `String sandbox_mode
-    ; "ephemeral", `Bool ephemeral_thread
-    ]
-    @ optional_field "model" config.model
-    @ optional_field "developerInstructions" config.developer_instructions
-    @
-    match dynamic_tools with
-    | [] -> []
-    | tools -> [ "dynamicTools", `List (List.map dynamic_tool_spec tools) ]
+  let thread_method, thread_fields, resumed =
+    match thread_mode with
+    | Start ->
+      ( "thread/start"
+      , ([ "cwd", `String config.cwd
+         ; "approvalPolicy", `String approval_policy
+         ; "sandbox", `String sandbox_mode
+         ; "ephemeral", `Bool thread_is_ephemeral
+         ]
+         @ optional_field "model" config.model
+         @ optional_field "developerInstructions" config.developer_instructions
+         @
+         match dynamic_tools with
+         | [] -> []
+         | tools -> [ "dynamicTools", `List (List.map dynamic_tool_spec tools) ])
+      , false )
+    | Resume { thread_id } ->
+      ( "thread/resume"
+      , [ "threadId", `String thread_id
+        ; "cwd", `String config.cwd
+        ; "approvalPolicy", `String approval_policy
+        ; "sandbox", `String sandbox_mode
+        ]
+        @ optional_field "model" config.model
+        @ optional_field "developerInstructions" config.developer_instructions
+      , true )
   in
-  send_request io ~id:3 ~method_:"thread/start" ~params:(`Assoc thread_fields);
-  let* thread = await_response io ~id:3 ~method_:"thread/start" in
-  let* thread_id, model = parse_thread_start thread in
+  send_request io ~id:3 ~method_:thread_method ~params:(`Assoc thread_fields);
+  let* thread = await_response io ~id:3 ~method_:thread_method in
+  let* thread_id, model = parse_thread_response ~stage:thread_method thread in
+  let* () =
+    match thread_mode with
+    | Start -> Ok ()
+    | Resume { thread_id = expected } when String.equal expected thread_id -> Ok ()
+    | Resume { thread_id = expected } ->
+      protocol_error
+        thread_method
+        (Printf.sprintf
+           "resumed thread id mismatch: requested %S but server returned %S"
+           expected
+           thread_id)
+  in
   let turn_request_id =
-    match history with
-    | [] -> Ok 4
-    | messages ->
+    match thread_mode, history with
+    | Resume _, _ | Start, [] -> Ok 4
+    | Start, messages ->
       send_request io ~id:4 ~method_:"thread/inject_items"
         ~params:
           (`Assoc
@@ -646,6 +687,14 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~history ~prompt =
       Ok 5
   in
   let* turn_request_id = turn_request_id in
+  let* () =
+    invoke_state_callback ~stage:"thread ready callback" (fun () ->
+      on_thread_ready ~thread_id)
+  in
+  let* () =
+    invoke_state_callback ~stage:"turn starting callback" (fun () ->
+      on_turn_starting ~thread_id)
+  in
   send_request io ~id:turn_request_id ~method_:"turn/start"
     ~params:
       (`Assoc
@@ -658,6 +707,10 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~history ~prompt =
               (Option.map Llm_provider.Reasoning_effort.to_string reasoning_effort)));
   let* turn = await_response io ~id:turn_request_id ~method_:"turn/start" in
   let* turn_id = parse_turn_start turn in
+  let* () =
+    invoke_state_callback ~stage:"turn started callback" (fun () ->
+      on_turn_started ~thread_id ~turn_id)
+  in
   let tool_call_count = ref 0 in
   let* text =
     await_turn_terminal
@@ -679,6 +732,7 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~history ~prompt =
     ; dynamic_tool_calls = !tool_call_count
     ; subscription
     ; user_agent
+    ; resumed
     }
 ;;
 
@@ -755,14 +809,15 @@ let terminate_spawned_process ~clock proc stdin_w =
           (Printexc.to_string exn))
 ;;
 
-let run_spawned ~mgr ~clock config ~dynamic_tools ~reasoning_effort ~history ~prompt =
+let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort ~thread_mode ~history
+    ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_started =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
     let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
     let stderr_tail = ref "" in
     let proc =
-      Eio.Process.spawn ~sw mgr
+      Eio.Process.spawn ~sw mgr ~cwd
         ~env:(subscription_only_environment ())
         ~stdin:stdin_r ~stdout:stdout_w ~stderr:stderr_w
         [ config.cli_path; "app-server"; "--stdio" ]
@@ -797,11 +852,15 @@ let run_spawned ~mgr ~clock config ~dynamic_tools ~reasoning_effort ~history ~pr
             config
             ~dynamic_tools
             ~reasoning_effort
+            ~thread_mode
             ~history
-            ~prompt)))
+            ~prompt
+            ~on_thread_ready
+            ~on_turn_starting
+            ~on_turn_started)))
 ;;
 
-let validate_config config ~prompt =
+let validate_config config ~thread_mode ~prompt =
   if String.trim config.cli_path = ""
   then Error (Invalid_config "cli_path must not be empty")
   else if String.trim config.cwd = "" || Filename.is_relative config.cwd
@@ -810,7 +869,11 @@ let validate_config config ~prompt =
   then Error (Invalid_config "timeout_s must be positive and finite")
   else if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
-  else Ok ()
+  else
+    match thread_mode with
+    | Resume { thread_id } when String.equal (String.trim thread_id) "" ->
+      Error (Invalid_config "resume thread_id must not be empty")
+    | Start | Resume _ -> Ok ()
 ;;
 
 let validate_dynamic_tools tools =
@@ -827,29 +890,39 @@ let validate_dynamic_tools tools =
   loop [] tools
 ;;
 
-let run_turn ?(dynamic_tools = []) ?reasoning_effort ~mgr ~clock ?(history = []) config
-    ~prompt =
+let validate_turn ?(dynamic_tools = []) ?(thread_mode = Start) config ~prompt =
+  match validate_config config ~thread_mode ~prompt with
+  | Error _ as error -> error
+  | Ok () -> validate_dynamic_tools dynamic_tools
+;;
+
+let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr ~clock ~cwd
+    ?(history = []) ?(on_thread_ready = fun ~thread_id:_ -> Ok ())
+    ?(on_turn_starting = fun ~thread_id:_ -> Ok ())
+    ?(on_turn_started = fun ~thread_id:_ ~turn_id:_ -> Ok ()) config ~prompt =
   let result =
-    match validate_config config ~prompt with
+    match validate_turn ~dynamic_tools ~thread_mode config ~prompt with
     | Error _ as error -> error
     | Ok () ->
-      (match validate_dynamic_tools dynamic_tools with
-       | Error _ as error -> error
-       | Ok () ->
       Log.Runtime_agent.info "Codex app-server subscription turn starting";
       (try
          run_spawned
            ~mgr
            ~clock
+           ~cwd
            config
            ~dynamic_tools
            ~reasoning_effort
+           ~thread_mode
            ~history
            ~prompt
+           ~on_thread_ready
+           ~on_turn_starting
+           ~on_turn_started
        with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
-       | exn -> Error (Spawn_failed (Printexc.to_string exn))))
+       | exn -> Error (Spawn_failed (Printexc.to_string exn)))
   in
   (match result with
    | Ok turn ->

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -11,7 +11,6 @@ type subscription =
 
 type config =
   { cli_path : string
-  ; cwd : string
   ; model : string option
   ; developer_instructions : string option
   ; timeout_s : float
@@ -23,12 +22,11 @@ let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 4096
 let max_wire_line_bytes = 8 * 1024 * 1024
 let approval_policy = "never"
-let sandbox_mode = "read-only"
+let permissions_profile = ":read-only"
 let thread_is_ephemeral = false
 
-let default_config ~cwd =
+let default_config () =
   { cli_path = "codex"
-  ; cwd
   ; model = None
   ; developer_instructions = None
   ; timeout_s = default_timeout_s
@@ -611,8 +609,8 @@ let invoke_state_callback ~stage callback =
   | exn -> protocol_error stage (Printexc.to_string exn)
 ;;
 
-let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~history ~prompt
-    ~on_thread_ready ~on_turn_starting ~on_turn_started =
+let run_protocol io config ~protocol_cwd ~dynamic_tools ~reasoning_effort ~thread_mode
+    ~history ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_started =
   send_request io ~id:1 ~method_:"initialize"
     ~params:
       (`Assoc
@@ -620,7 +618,7 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~histor
            , `Assoc
                [ "name", `String "masc"
                ; "title", `String "MASC"
-               ; "version", `String "dev"
+               ; "version", `String Version.version
                ] )
          ; "capabilities", `Assoc [ "experimentalApi", `Bool true ]
          ]);
@@ -635,9 +633,9 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~histor
     match thread_mode with
     | Start ->
       ( "thread/start"
-      , ([ "cwd", `String config.cwd
+      , ([ "cwd", `String protocol_cwd
          ; "approvalPolicy", `String approval_policy
-         ; "sandbox", `String sandbox_mode
+         ; "permissions", `String permissions_profile
          ; "ephemeral", `Bool thread_is_ephemeral
          ]
          @ optional_field "model" config.model
@@ -650,9 +648,9 @@ let run_protocol io config ~dynamic_tools ~reasoning_effort ~thread_mode ~histor
     | Resume { thread_id } ->
       ( "thread/resume"
       , [ "threadId", `String thread_id
-        ; "cwd", `String config.cwd
+        ; "cwd", `String protocol_cwd
         ; "approvalPolicy", `String approval_policy
-        ; "sandbox", `String sandbox_mode
+        ; "permissions", `String permissions_profile
         ]
         @ optional_field "model" config.model
         @ optional_field "developerInstructions" config.developer_instructions
@@ -746,13 +744,28 @@ let env_key entry =
   | None -> entry
 ;;
 
+let child_environment_key_allowed = function
+  | "HOME"
+  | "PATH"
+  | "TMPDIR"
+  | "CODEX_HOME"
+  | "XDG_CONFIG_HOME"
+  | "XDG_DATA_HOME"
+  | "XDG_CACHE_HOME"
+  | "SSL_CERT_FILE"
+  | "SSL_CERT_DIR"
+  | "LANG"
+  | "LC_ALL"
+  | "LC_CTYPE"
+  | "TERM"
+  | "NO_COLOR" -> true
+  | _ -> false
+;;
+
 let subscription_only_environment () =
   Unix.environment ()
   |> Array.to_list
-  |> List.filter (fun entry ->
-    match env_key entry with
-    | "OPENAI_API_KEY" | "CODEX_API_KEY" -> false
-    | _ -> true)
+  |> List.filter (fun entry -> child_environment_key_allowed (env_key entry))
   |> Array.of_list
 ;;
 
@@ -813,8 +826,8 @@ let terminate_spawned_process ~clock proc stdin_w =
           (Printexc.to_string exn))
 ;;
 
-let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort ~thread_mode ~history
-    ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_started =
+let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools ~reasoning_effort
+    ~thread_mode ~history ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_started =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -854,6 +867,7 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort ~thread
           run_protocol
             { send; receive }
             config
+            ~protocol_cwd
             ~dynamic_tools
             ~reasoning_effort
             ~thread_mode
@@ -864,20 +878,32 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort ~thread
             ~on_turn_started)))
 ;;
 
-let validate_config config ~thread_mode ~prompt =
+let native_cwd cwd =
+  try
+    let cwd = Eio.Path.native_exn cwd in
+    if String.trim cwd = "" || Filename.is_relative cwd
+    then Error (Invalid_config "cwd must be an absolute native path")
+    else Ok cwd
+  with
+  | exn ->
+    Error
+      (Invalid_config
+         ("cwd must be a native filesystem path: " ^ Printexc.to_string exn))
+;;
+
+let validate_config config ~cwd ~thread_mode ~prompt =
   if String.trim config.cli_path = ""
   then Error (Invalid_config "cli_path must not be empty")
-  else if String.trim config.cwd = "" || Filename.is_relative config.cwd
-  then Error (Invalid_config "cwd must be an absolute path")
   else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
   then Error (Invalid_config "timeout_s must be positive and finite")
   else if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
   else
+    let* cwd = native_cwd cwd in
     match thread_mode with
     | Resume { thread_id } when String.equal (String.trim thread_id) "" ->
       Error (Invalid_config "resume thread_id must not be empty")
-    | Start | Resume _ -> Ok ()
+    | Start | Resume _ -> Ok cwd
 ;;
 
 let validate_dynamic_tools tools =
@@ -894,10 +920,18 @@ let validate_dynamic_tools tools =
   loop [] tools
 ;;
 
-let validate_turn ?(dynamic_tools = []) ?(thread_mode = Start) config ~prompt =
-  match validate_config config ~thread_mode ~prompt with
+let validate_turn_input ~dynamic_tools ~thread_mode ~cwd config ~prompt =
+  match validate_config config ~cwd ~thread_mode ~prompt with
   | Error _ as error -> error
-  | Ok () -> validate_dynamic_tools dynamic_tools
+  | Ok protocol_cwd ->
+    (match validate_dynamic_tools dynamic_tools with
+     | Error _ as error -> error
+     | Ok () -> Ok protocol_cwd)
+;;
+
+let validate_turn ?(dynamic_tools = []) ?(thread_mode = Start) ~cwd config ~prompt =
+  validate_turn_input ~dynamic_tools ~thread_mode ~cwd config ~prompt
+  |> Result.map (fun _ -> ())
 ;;
 
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr ~clock ~cwd
@@ -905,15 +939,16 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr
     ?(on_turn_starting = fun ~thread_id:_ -> Ok ())
     ?(on_turn_started = fun ~thread_id:_ ~turn_id:_ -> Ok ()) config ~prompt =
   let result =
-    match validate_turn ~dynamic_tools ~thread_mode config ~prompt with
+    match validate_turn_input ~dynamic_tools ~thread_mode ~cwd config ~prompt with
     | Error _ as error -> error
-    | Ok () ->
+    | Ok protocol_cwd ->
       Log.Runtime_agent.info "Codex app-server subscription turn starting";
       (try
          run_spawned
            ~mgr
            ~clock
            ~cwd
+           ~protocol_cwd
            config
            ~dynamic_tools
            ~reasoning_effort

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -19,6 +19,10 @@ type config =
 
 val default_config : cwd:string -> config
 
+type thread_mode =
+  | Start
+  | Resume of { thread_id : string }
+
 type turn_result =
   { thread_id : string
   ; turn_id : string
@@ -27,6 +31,7 @@ type turn_result =
   ; dynamic_tool_calls : int
   ; subscription : subscription
   ; user_agent : string option
+  ; resumed : bool
   }
 
 type dynamic_tool_result =
@@ -71,12 +76,27 @@ type error =
 
 val error_to_string : error -> string
 
+val validate_turn :
+  ?dynamic_tools:dynamic_tool list ->
+  ?thread_mode:thread_mode ->
+  config ->
+  prompt:string ->
+  (unit, error) result
+(** Validate every deterministic client-side admission condition. Keeper calls
+    this before it durably claims a session; [run_turn] repeats the same check
+    at the process boundary. *)
+
 val run_turn :
   ?dynamic_tools:dynamic_tool list ->
   ?reasoning_effort:Llm_provider.Reasoning_effort.t ->
+  ?thread_mode:thread_mode ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
+  cwd:Eio.Fs.dir_ty Eio.Path.t ->
   ?history:history_message list ->
+  ?on_thread_ready:(thread_id:string -> (unit, string) result) ->
+  ?on_turn_starting:(thread_id:string -> (unit, string) result) ->
+  ?on_turn_started:(thread_id:string -> turn_id:string -> (unit, string) result) ->
   config ->
   prompt:string ->
   (turn_result, error) result

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -11,13 +11,12 @@ type subscription =
 
 type config =
   { cli_path : string
-  ; cwd : string
   ; model : string option
   ; developer_instructions : string option
   ; timeout_s : float
   }
 
-val default_config : cwd:string -> config
+val default_config : unit -> config
 
 type thread_mode =
   | Start
@@ -79,6 +78,7 @@ val error_to_string : error -> string
 val validate_turn :
   ?dynamic_tools:dynamic_tool list ->
   ?thread_mode:thread_mode ->
+  cwd:Eio.Fs.dir_ty Eio.Path.t ->
   config ->
   prompt:string ->
   (unit, error) result

--- a/test/dune
+++ b/test/dune
@@ -1942,6 +1942,7 @@
 (include stanzas/test_runtime_agent_close_cancel_source.inc)
 
 (include stanzas/test_runtime_codex_app_server.inc)
+(include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)
 

--- a/test/stanzas/test_official_client_session_store.inc
+++ b/test/stanzas/test_official_client_session_store.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_official_client_session_store)
+ (modules test_official_client_session_store)
+ (libraries alcotest masc masc_test_deps unix))

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -361,7 +361,7 @@ let test_restart_recovery_and_transient_release () =
     | None -> fail "transient release evidence was not persisted")
 ;;
 
-let test_exact_recovery_resolution () =
+let test_exact_recovery_restart () =
   with_workspace "masc-official-client-store-resolution-" (fun base_path ->
     let keeper_name = "resolution" in
     let claimed =
@@ -401,24 +401,23 @@ let test_exact_recovery_resolution () =
      with
      | Error _ -> ()
      | Ok _ -> fail "wrong recovery fence was accepted");
-    let settlement = { session_id = "verified-session"; turn_id = "verified-turn" } in
-    let adopted =
+    let restarted =
       resolve_recovery
         ~base_path
         ~keeper_name
         ~expected:recovery
         ~recovery_id
-        ~resolution:(Adopt_verified settlement)
+        ~resolution:Restart_fresh
         ~resolved_by:"operator"
         ~resolved_at:4.0
       |> Result.get_ok
     in
-    check int "adopt counts verified turn" 1 adopted.turn_count;
-    (match adopted.phase with
-     | Settled observed -> check bool "verified settlement" true (observed = settlement)
-     | Ready | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
-       fail "verified terminal identity was not adopted");
-    match adopted.last_recovery_resolution with
+    check int "restart drops incomplete turn" 0 restarted.turn_count;
+    (match restarted.phase with
+     | Ready -> ()
+     | Settled _ | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+       fail "fresh restart did not return the binding to Ready");
+    match restarted.last_recovery_resolution with
     | Some record ->
       check string "durable actor" "operator" record.resolved_by;
       check string "recovery fence" recovery_id record.recovery_id
@@ -508,7 +507,7 @@ let () =
             "restart recovery and transient release"
             `Quick
             test_restart_recovery_and_transient_release
-        ; test_case "exact recovery resolution" `Quick test_exact_recovery_resolution
+        ; test_case "exact recovery restart" `Quick test_exact_recovery_restart
         ; test_case "ambiguous JSON rejected" `Quick test_ambiguous_json_is_rejected
         ; test_case
             "tool surface fingerprint canonical"

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -1,0 +1,519 @@
+open Alcotest
+open Masc
+open Keeper_official_client_session_store
+
+let temp_workspace prefix =
+  let path = Filename.temp_file prefix "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let cleanup_tree root =
+  let rec remove path =
+    if Sys.file_exists path
+    then if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try remove root with
+  | _ -> ()
+;;
+
+let with_workspace prefix f =
+  let base_path = temp_workspace prefix in
+  Fun.protect ~finally:(fun () -> cleanup_tree base_path) (fun () -> f base_path)
+;;
+
+let owner_epoch = "11111111-1111-4111-8111-111111111111"
+let next_owner_epoch = "22222222-2222-4222-8222-222222222222"
+let empty_surface = tool_surface_sha256 []
+
+let claim_new ~base_path ~keeper_name ~client_kind ~runtime_id ~owner_epoch ~at =
+  claim
+    ~base_path
+    ~keeper_name
+    ~expected:None
+    ~client_kind
+    ~owner_epoch
+    ~runtime_id
+    ~tool_surface_sha256:empty_surface
+    ~updated_at:at
+  |> Result.get_ok
+;;
+
+let test_roundtrip_and_settlement () =
+  with_workspace "masc-official-client-store-roundtrip-" (fun base_path ->
+    let keeper_name = "roundtrip" in
+    check bool "missing" true (load ~base_path ~keeper_name = Ok None);
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    (match
+       claim
+         ~base_path
+         ~keeper_name
+         ~expected:(Some claimed)
+         ~client_kind:Claude_code
+         ~owner_epoch
+         ~runtime_id:"claude-code.default"
+         ~tool_surface_sha256:empty_surface
+         ~updated_at:1.5
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "incomplete claim changed official client identity");
+    let active =
+      mark_active
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~session_id:"session-1"
+        ~updated_at:2.0
+      |> Result.get_ok
+    in
+    let starting =
+      mark_turn_starting
+        ~base_path
+        ~keeper_name
+        ~expected:active
+        ~session_id:"session-1"
+        ~updated_at:3.0
+      |> Result.get_ok
+    in
+    let inflight =
+      mark_turn_started
+        ~base_path
+        ~keeper_name
+        ~expected:starting
+        ~session_id:"session-1"
+        ~turn_id:"turn-1"
+        ~updated_at:4.0
+      |> Result.get_ok
+    in
+    let settled =
+      settle
+        ~base_path
+        ~keeper_name
+        ~expected:inflight
+        ~session_id:"session-1"
+        ~turn_id:"turn-1"
+        ~updated_at:5.0
+      |> Result.get_ok
+    in
+    let resume_plan =
+      plan_claim
+        ~expected:(Some settled)
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+      |> Result.get_ok
+    in
+    check int "resume ordinal" 2 resume_plan.turn_count;
+    check bool
+      "resume settlement"
+      true
+      (resume_plan.previous_settlement
+       = Some { session_id = "session-1"; turn_id = "turn-1" });
+    check
+      (option string)
+      "resume surface requirement"
+      (Some empty_surface)
+      resume_plan.required_tool_surface_sha256;
+    match load ~base_path ~keeper_name with
+    | Error detail -> fail detail
+    | Ok None -> fail "durable session disappeared"
+    | Ok (Some loaded) ->
+      check bool "exact read-back" true (loaded = settled);
+      check bool "client kind" true (loaded.client_kind = Codex);
+      check int "completed turns" 1 loaded.turn_count;
+      (match loaded.phase with
+       | Settled { session_id; turn_id } ->
+         check string "session" "session-1" session_id;
+         check string "turn" "turn-1" turn_id
+       | Ready | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+         fail "terminal turn was not settled"))
+;;
+
+let test_duplicate_claim_and_cas_are_fail_closed () =
+  with_workspace "masc-official-client-store-cas-" (fun base_path ->
+    let keeper_name = "cas" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    (match
+       claim
+         ~base_path
+         ~keeper_name
+         ~expected:(Some claimed)
+         ~client_kind:Codex
+         ~owner_epoch
+         ~runtime_id:"codex.default"
+         ~tool_surface_sha256:empty_surface
+         ~updated_at:2.0
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "incomplete claim admitted duplicate execution");
+    let active =
+      mark_active
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~session_id:"session-cas"
+        ~updated_at:3.0
+      |> Result.get_ok
+    in
+    (match
+       mark_turn_starting
+         ~base_path
+         ~keeper_name
+         ~expected:claimed
+         ~session_id:"session-cas"
+         ~updated_at:4.0
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "stale expected state bypassed compare-and-swap");
+    match load ~base_path ~keeper_name with
+    | Ok (Some loaded) -> check bool "active preserved" true (loaded = active)
+    | Error detail -> fail detail
+    | Ok None -> fail "CAS failure removed durable state")
+;;
+
+let test_terminal_identity_switch_starts_fresh () =
+  with_workspace "masc-official-client-store-switch-" (fun base_path ->
+    let keeper_name = "switch" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    let active =
+      mark_active
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~session_id:"codex-session"
+        ~updated_at:2.0
+      |> Result.get_ok
+    in
+    let starting =
+      mark_turn_starting
+        ~base_path
+        ~keeper_name
+        ~expected:active
+        ~session_id:"codex-session"
+        ~updated_at:3.0
+      |> Result.get_ok
+    in
+    let inflight =
+      mark_turn_started
+        ~base_path
+        ~keeper_name
+        ~expected:starting
+        ~session_id:"codex-session"
+        ~turn_id:"codex-turn"
+        ~updated_at:4.0
+      |> Result.get_ok
+    in
+    let settled =
+      settle
+        ~base_path
+        ~keeper_name
+        ~expected:inflight
+        ~session_id:"codex-session"
+        ~turn_id:"codex-turn"
+        ~updated_at:5.0
+      |> Result.get_ok
+    in
+    (match
+       claim
+         ~base_path
+         ~keeper_name
+         ~expected:(Some settled)
+         ~client_kind:Codex
+         ~owner_epoch
+         ~runtime_id:"codex.default"
+         ~tool_surface_sha256:(String.make 64 'a')
+         ~updated_at:6.0
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "same settled session resumed with a changed tool surface");
+    let switched =
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some settled)
+        ~client_kind:Claude_code
+        ~owner_epoch
+        ~runtime_id:"claude-code.sonnet"
+        ~tool_surface_sha256:(String.make 64 'b')
+        ~updated_at:7.0
+      |> Result.get_ok
+    in
+    check bool "new client" true (switched.client_kind = Claude_code);
+    check string "new runtime" "claude-code.sonnet" switched.runtime_id;
+    check int "fresh ordinal" 1 switched.turn_count;
+    match switched.phase with
+    | Start { previous_settlement = None; _ } -> ()
+    | Start { previous_settlement = Some _; _ }
+    | Ready | Active _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+      fail "terminal client switch inherited the old external session")
+;;
+
+let test_restart_recovery_and_transient_release () =
+  with_workspace "masc-official-client-store-restart-" (fun base_path ->
+    let keeper_name = "restart" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Antigravity
+        ~runtime_id:"antigravity.gemini"
+        ~owner_epoch
+        ~at:1.0
+    in
+    (match
+       reconcile_process_restart
+         ~base_path
+         ~keeper_name
+         ~expected:claimed
+         ~current_owner_epoch:owner_epoch
+         ~required_at:2.0
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "same process epoch was classified as a restart");
+    let recovery =
+      reconcile_process_restart
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~current_owner_epoch:next_owner_epoch
+        ~required_at:3.0
+      |> Result.get_ok
+    in
+    let recovery_id =
+      match recovery.phase with
+      | Recovery_required required ->
+        check bool "restart class" true (required.failure = Process_restarted);
+        check bool "ambiguous" true (failure_disposition required.failure = Ambiguous);
+        check string "claim epoch" owner_epoch required.owner_epoch;
+        required.recovery_id
+      | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+        fail "old process claim did not enter recovery"
+    in
+    let ready =
+      resolve_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:recovery
+        ~recovery_id
+        ~resolution:Restart_fresh
+        ~resolved_by:"operator"
+        ~resolved_at:4.0
+      |> Result.get_ok
+    in
+    let reclaimed =
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some ready)
+        ~client_kind:Antigravity
+        ~owner_epoch:next_owner_epoch
+        ~runtime_id:"antigravity.gemini"
+        ~tool_surface_sha256:empty_surface
+        ~updated_at:5.0
+      |> Result.get_ok
+    in
+    let released =
+      release_transient
+        ~base_path
+        ~keeper_name
+        ~expected:reclaimed
+        ~failure:Transient_spawn_failed
+        ~released_at:6.0
+      |> Result.get_ok
+    in
+    check int "transient does not count" 0 released.turn_count;
+    (match released.phase with
+     | Ready -> ()
+     | Start _ | Active _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+       fail "transient failure did not release the claim");
+    match released.last_transient_release with
+    | Some record ->
+      check bool "transient evidence" true (record.failure = Transient_spawn_failed);
+      check string "release epoch" next_owner_epoch record.owner_epoch
+    | None -> fail "transient release evidence was not persisted")
+;;
+
+let test_exact_recovery_resolution () =
+  with_workspace "masc-official-client-store-resolution-" (fun base_path ->
+    let keeper_name = "resolution" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Claude_code
+        ~runtime_id:"claude-code.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    let recovery =
+      require_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~failure:Protocol_failed
+        ~detail:"ambiguous client protocol failure"
+        ~required_at:2.0
+      |> Result.get_ok
+    in
+    let recovery_id =
+      match recovery.phase with
+      | Recovery_required required -> required.recovery_id
+      | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+        fail "ambiguous failure did not require recovery"
+    in
+    (match
+       resolve_recovery
+         ~base_path
+         ~keeper_name
+         ~expected:recovery
+         ~recovery_id:"33333333-3333-4333-8333-333333333333"
+         ~resolution:Restart_fresh
+         ~resolved_by:"operator"
+         ~resolved_at:3.0
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "wrong recovery fence was accepted");
+    let settlement = { session_id = "verified-session"; turn_id = "verified-turn" } in
+    let adopted =
+      resolve_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:recovery
+        ~recovery_id
+        ~resolution:(Adopt_verified settlement)
+        ~resolved_by:"operator"
+        ~resolved_at:4.0
+      |> Result.get_ok
+    in
+    check int "adopt counts verified turn" 1 adopted.turn_count;
+    (match adopted.phase with
+     | Settled observed -> check bool "verified settlement" true (observed = settlement)
+     | Ready | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+       fail "verified terminal identity was not adopted");
+    match adopted.last_recovery_resolution with
+    | Some record ->
+      check string "durable actor" "operator" record.resolved_by;
+      check string "recovery fence" recovery_id record.recovery_id
+    | None -> fail "recovery resolution evidence was not persisted")
+;;
+
+let write_file path content =
+  let output = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr output)
+    (fun () -> output_string output content)
+;;
+
+let test_ambiguous_json_is_rejected () =
+  with_workspace "masc-official-client-store-json-" (fun base_path ->
+    let keeper_name = "ambiguous-json" in
+    let state_path = path ~base_path ~keeper_name |> Result.get_ok in
+    let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname state_path) in
+    write_file
+      state_path
+      {|{"client_kind":"codex","last_recovery_resolution":null,"last_transient_release":null,"phase":{"kind":"settled","session_id":"session-1","turn_id":"turn-1"},"runtime_id":"codex.default","runtime_id":"codex.other","schema":"masc.keeper.official-client-session.v1","tool_surface_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","turn_count":1,"updated_at":1.0}|};
+    match load ~base_path ~keeper_name with
+    | Error _ -> ()
+    | Ok _ -> fail "duplicate JSON keys were accepted")
+;;
+
+let fixture_tool ?(parameters = []) ~name ~description () =
+  Agent_sdk.Tool.create
+    ~name
+    ~description
+    ~parameters
+    (fun _ -> Ok { Agent_sdk.Types.content = "fixture"; _meta = None })
+;;
+
+let test_tool_surface_fingerprint_is_canonical () =
+  let alpha = fixture_tool ~name:"alpha" ~description:"first" () in
+  let beta = fixture_tool ~name:"beta" ~description:"second" () in
+  let changed = fixture_tool ~name:"alpha" ~description:"changed" () in
+  let first : Agent_sdk.Types.tool_param =
+    { name = "first"; description = "first"; param_type = String; required = true }
+  in
+  let second : Agent_sdk.Types.tool_param =
+    { name = "second"; description = "second"; param_type = Integer; required = true }
+  in
+  let ordered =
+    fixture_tool
+      ~parameters:[ first; second ]
+      ~name:"ordered"
+      ~description:"same"
+      ()
+  in
+  let reordered =
+    fixture_tool
+      ~parameters:[ second; first ]
+      ~name:"ordered"
+      ~description:"same"
+      ()
+  in
+  check string
+    "tool order"
+    (tool_surface_sha256 [ alpha; beta ])
+    (tool_surface_sha256 [ beta; alpha ]);
+  check string
+    "parameter order"
+    (tool_surface_sha256 [ ordered ])
+    (tool_surface_sha256 [ reordered ]);
+  check bool
+    "description participates"
+    true
+    (not (String.equal (tool_surface_sha256 [ alpha ]) (tool_surface_sha256 [ changed ])))
+;;
+
+let () =
+  run
+    "official client session store"
+    [ ( "durable owner"
+      , [ test_case "roundtrip and settlement" `Quick test_roundtrip_and_settlement
+        ; test_case
+            "duplicate claim and CAS fail closed"
+            `Quick
+            test_duplicate_claim_and_cas_are_fail_closed
+        ; test_case
+            "terminal identity switch starts fresh"
+            `Quick
+            test_terminal_identity_switch_starts_fresh
+        ; test_case
+            "restart recovery and transient release"
+            `Quick
+            test_restart_recovery_and_transient_release
+        ; test_case "exact recovery resolution" `Quick test_exact_recovery_resolution
+        ; test_case "ambiguous JSON rejected" `Quick test_ambiguous_json_is_rejected
+        ; test_case
+            "tool surface fingerprint canonical"
+            `Quick
+            test_tool_surface_fingerprint_is_canonical
+        ] )
+    ]
+;;

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -46,18 +46,27 @@ let rec drop count values =
     | _ :: rest -> drop (count - 1) rest
 ;;
 
-let fixture_script lines =
+let fixture_script ?capture_path lines =
   let path = Filename.temp_file "masc-codex-app-server-" ".sh" in
   let output = open_out_bin path in
+  let read_request () =
+    output_string output "IFS= read -r ignored\n";
+    Option.iter
+      (fun capture_path ->
+         output_string
+           output
+           ("printf '%s\\n' \"$ignored\" >> " ^ shell_quote capture_path ^ "\n"))
+      capture_path
+  in
   output_string output "#!/bin/sh\n";
-  output_string output "IFS= read -r ignored\n";
+  read_request ();
   output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 0) ^ "\n");
-  output_string output "IFS= read -r ignored\n";
-  output_string output "IFS= read -r ignored\n";
+  read_request ();
+  read_request ();
   output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 1) ^ "\n");
-  output_string output "IFS= read -r ignored\n";
+  read_request ();
   output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 2) ^ "\n");
-  output_string output "IFS= read -r ignored\n";
+  read_request ();
   List.iter
     (fun line -> output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
     (drop 3 lines);
@@ -67,8 +76,8 @@ let fixture_script lines =
   path
 ;;
 
-let with_fixture lines f =
-  let path = fixture_script lines in
+let with_fixture ?capture_path lines f =
+  let path = fixture_script ?capture_path lines in
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
@@ -200,6 +209,53 @@ let test_thread_resume_skips_history_injection () =
        | Ok result ->
          check bool "resumed" true result.resumed;
          check string "thread" "thread-1" result.thread_id)
+;;
+
+let test_thread_resume_sends_dynamic_tools () =
+  let capture_path = Filename.temp_file "masc-codex-resume-requests-" ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove capture_path)
+    (fun () ->
+       let tool : Runtime_codex_app_server.dynamic_tool =
+         { name = "masc_probe"
+         ; description = "Return a deterministic fixture marker"
+         ; input_schema = `Assoc [ "type", `String "object" ]
+         ; call = (fun ~call_id:_ _ -> { success = true; content = "unused" })
+         }
+       in
+       with_fixture
+         ~capture_path
+         [ init_result; account_chatgpt; thread_result; turn_result; item_completed; turn_completed ]
+         (fun path ->
+            match
+              run_fixture
+                ~dynamic_tools:[ tool ]
+                ~thread_mode:(Runtime_codex_app_server.Resume { thread_id = "thread-1" })
+                path
+            with
+            | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+            | Ok _ -> ());
+       let requests =
+         In_channel.with_open_bin capture_path (fun input ->
+           In_channel.input_lines input |> List.map Yojson.Safe.from_string)
+       in
+       let resume_request =
+         List.find
+           (fun json -> Yojson.Safe.Util.member "id" json = `Int 3)
+           requests
+       in
+       let dynamic_tools =
+         resume_request
+         |> Yojson.Safe.Util.member "params"
+         |> Yojson.Safe.Util.member "dynamicTools"
+         |> Yojson.Safe.Util.to_list
+       in
+       check int "resume tool count" 1 (List.length dynamic_tools);
+       check string "resume tool name" "masc_probe"
+         (dynamic_tools
+          |> List.hd
+          |> Yojson.Safe.Util.member "name"
+          |> Yojson.Safe.Util.to_string))
 ;;
 
 let test_thread_resume_rejects_identity_mismatch () =
@@ -1253,6 +1309,10 @@ let () =
             "thread resume skips history injection"
             `Quick
             test_thread_resume_skips_history_injection
+        ; test_case
+            "thread resume sends dynamic tools"
+            `Quick
+            test_thread_resume_sends_dynamic_tools
         ; test_case
             "thread resume rejects identity mismatch"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -84,7 +84,7 @@ let with_fixture ?capture_path lines f =
 let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp") path =
   Eio_main.run (fun env ->
     let config =
-      { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+      { (Runtime_codex_app_server.default_config ()) with
         cli_path = path
       ; timeout_s = 2.0
       }
@@ -102,12 +102,18 @@ let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp
 
 let test_turn_admission_validation_is_process_free () =
   let config =
-    { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with cli_path = "" }
+    { (Runtime_codex_app_server.default_config ()) with cli_path = "" }
   in
-  match Runtime_codex_app_server.validate_turn config ~prompt:"fixture" with
-  | Error (Runtime_codex_app_server.Invalid_config "cli_path must not be empty") -> ()
-  | Error error -> fail (Runtime_codex_app_server.error_to_string error)
-  | Ok () -> fail "invalid deterministic client config passed admission"
+  Eio_main.run (fun env ->
+    match
+      Runtime_codex_app_server.validate_turn
+        ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+        config
+        ~prompt:"fixture"
+    with
+    | Error (Runtime_codex_app_server.Invalid_config "cli_path must not be empty") -> ()
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+    | Ok () -> fail "invalid deterministic client config passed admission")
 ;;
 
 let tool_call_request =
@@ -494,6 +500,105 @@ let test_declared_cwd_reaches_spawn () =
                    "spawn cwd"
                    (Unix.realpath workspace)
                    (Unix.realpath observed))))
+;;
+
+let test_protocol_uses_spawn_cwd_and_named_permissions () =
+  let workspace = temp_workspace "masc-codex-protocol-cwd-" in
+  let capture_path = Filename.temp_file "masc-codex-protocol-" ".jsonl" in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_tree workspace;
+      Sys.remove capture_path)
+    (fun () ->
+       with_fixture
+         ~capture_path
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun fixture ->
+            match run_fixture ~cwd:workspace fixture with
+            | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+            | Ok _ -> ());
+       let requests =
+         In_channel.with_open_bin capture_path (fun input ->
+           In_channel.input_lines input |> List.map Yojson.Safe.from_string)
+       in
+       let initialize =
+         List.find
+           (fun json -> Yojson.Safe.Util.member "id" json = `Int 1)
+           requests
+       in
+       let thread_start =
+         List.find
+           (fun json -> Yojson.Safe.Util.member "id" json = `Int 3)
+           requests
+       in
+       let client_info =
+         initialize
+         |> Yojson.Safe.Util.member "params"
+         |> Yojson.Safe.Util.member "clientInfo"
+       in
+       let params = Yojson.Safe.Util.member "params" thread_start in
+       check string
+         "client version SSOT"
+         Version.version
+         (client_info |> Yojson.Safe.Util.member "version" |> Yojson.Safe.Util.to_string);
+       check string
+         "protocol cwd"
+         (Unix.realpath workspace)
+         (params
+          |> Yojson.Safe.Util.member "cwd"
+          |> Yojson.Safe.Util.to_string
+          |> Unix.realpath);
+       check string
+         "named permissions"
+         ":read-only"
+         (params |> Yojson.Safe.Util.member "permissions" |> Yojson.Safe.Util.to_string);
+       check bool
+         "legacy sandbox omitted"
+         true
+         (Yojson.Safe.Util.member "sandbox" params = `Null))
+;;
+
+let test_child_environment_is_allowlisted () =
+  let canary = "MASC_CODEX_SECRET_CANARY" in
+  let previous = Sys.getenv_opt canary in
+  Unix.putenv canary "must-not-reach-child";
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some value -> Unix.putenv canary value
+      | None -> Unix.putenv canary "")
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun fixture ->
+            let wrapper = Filename.temp_file "masc-codex-env-wrapper-" ".sh" in
+            Fun.protect
+              ~finally:(fun () -> Sys.remove wrapper)
+              (fun () ->
+                 let output = open_out_bin wrapper in
+                 output_string output "#!/bin/sh\n";
+                 output_string output
+                   "if [ \"${MASC_CODEX_SECRET_CANARY+set}\" = set ]; then exit 71; fi\n";
+                 output_string output "if [ -z \"${HOME:-}\" ]; then exit 72; fi\n";
+                 output_string output ("exec " ^ shell_quote fixture ^ " \"$@\"\n");
+                 close_out output;
+                 Unix.chmod wrapper 0o700;
+                 match run_fixture wrapper with
+                 | Error error ->
+                   fail (Runtime_codex_app_server.error_to_string error)
+                 | Ok _ -> ())))
 ;;
 
 let write_fixture_file path content =
@@ -1088,7 +1193,7 @@ let test_live_chatgpt_subscription () =
     let result =
       Eio_main.run (fun env ->
         let config =
-          { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+          { (Runtime_codex_app_server.default_config ()) with
             timeout_s = 60.0
           }
         in
@@ -1126,7 +1231,7 @@ let test_live_dynamic_tool_subscription () =
     let result =
       Eio_main.run (fun env ->
         let config =
-          { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+          { (Runtime_codex_app_server.default_config ()) with
             timeout_s = 60.0
           }
         in
@@ -1154,7 +1259,7 @@ let test_live_history_injection_subscription () =
     let result =
       Eio_main.run (fun env ->
         let config =
-          { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+          { (Runtime_codex_app_server.default_config ()) with
             timeout_s = 60.0
           }
         in
@@ -1279,6 +1384,14 @@ let () =
     [ ( "subscription boundary"
       , [ test_case "ChatGPT turn completes" `Quick test_chatgpt_subscription_turn
         ; test_case "declared cwd reaches spawn" `Quick test_declared_cwd_reaches_spawn
+        ; test_case
+            "protocol and spawn share cwd authority"
+            `Quick
+            test_protocol_uses_spawn_cwd_and_named_permissions
+        ; test_case
+            "child environment is allowlisted"
+            `Quick
+            test_child_environment_is_allowlisted
         ; test_case "API key is rejected" `Quick test_api_key_account_is_rejected
         ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
         ; test_case

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -23,6 +23,16 @@ let turn_completed =
   {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[{"type":"agentMessage","id":"message-1","text":"MASC_SUBSCRIPTION_OK","phase":"final_answer"}],"status":"completed"}}}|}
 ;;
 
+let resumed_turn_result = {|{"id":4,"result":{"turn":{"id":"turn-2"}}}|}
+
+let resumed_item_completed =
+  {|{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-2","completedAtMs":2,"item":{"type":"agentMessage","id":"message-2","text":"MASC_RESUMED_OK","phase":"final_answer"}}}|}
+;;
+
+let resumed_turn_completed =
+  {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-2","items":[{"type":"agentMessage","id":"message-2","text":"MASC_RESUMED_OK","phase":"final_answer"}],"status":"completed"}}}|}
+;;
+
 let shell_quote value =
   "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
 ;;
@@ -51,6 +61,7 @@ let fixture_script lines =
   List.iter
     (fun line -> output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
     (drop 3 lines);
+  output_string output "while IFS= read -r ignored; do :; done\n";
   close_out output;
   Unix.chmod path 0o700;
   path
@@ -61,7 +72,7 @@ let with_fixture lines f =
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
-let run_fixture ?(dynamic_tools = []) ?(history = []) path =
+let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp") path =
   Eio_main.run (fun env ->
     let config =
       { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
@@ -72,10 +83,22 @@ let run_fixture ?(dynamic_tools = []) ?(history = []) path =
     Runtime_codex_app_server.run_turn
       ~mgr:(Eio.Stdenv.process_mgr env)
       ~clock:(Eio.Stdenv.clock env)
+      ~cwd:Eio.Path.(Eio.Stdenv.fs env / cwd)
       ~dynamic_tools
+      ?thread_mode
       ~history
       config
       ~prompt:"Return the fixture marker")
+;;
+
+let test_turn_admission_validation_is_process_free () =
+  let config =
+    { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with cli_path = "" }
+  in
+  match Runtime_codex_app_server.validate_turn config ~prompt:"fixture" with
+  | Error (Runtime_codex_app_server.Invalid_config "cli_path must not be empty") -> ()
+  | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+  | Ok () -> fail "invalid deterministic client config passed admission"
 ;;
 
 let tool_call_request =
@@ -156,7 +179,44 @@ let test_chatgpt_subscription_turn () =
         check string "thread" "thread-1" result.thread_id;
         check string "turn" "turn-1" result.turn_id;
         check string "model" "gpt-fixture" result.model;
-        check string "plan" "pro" result.subscription.plan_type)
+        check string "plan" "pro" result.subscription.plan_type;
+        check bool "new thread" false result.resumed)
+;;
+
+let test_thread_resume_skips_history_injection () =
+  let history =
+    [ { Runtime_codex_app_server.role = User; text = "already in official thread" } ]
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; item_completed; turn_completed ]
+    (fun path ->
+       match
+         run_fixture
+           ~thread_mode:(Runtime_codex_app_server.Resume { thread_id = "thread-1" })
+           ~history
+           path
+       with
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok result ->
+         check bool "resumed" true result.resumed;
+         check string "thread" "thread-1" result.thread_id)
+;;
+
+let test_thread_resume_rejects_identity_mismatch () =
+  let wrong_thread =
+    {|{"id":3,"result":{"thread":{"id":"thread-other"},"model":"gpt-fixture"}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; wrong_thread; turn_result; item_completed; turn_completed ]
+    (fun path ->
+       match
+         run_fixture
+           ~thread_mode:(Runtime_codex_app_server.Resume { thread_id = "thread-1" })
+           path
+       with
+       | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok _ -> fail "thread/resume admitted a different returned thread id")
 ;;
 
 let test_api_key_account_is_rejected () =
@@ -338,14 +398,71 @@ let cleanup_tree root =
   | _ -> ()
 ;;
 
-let production_keeper_meta ~base_path =
+let test_declared_cwd_reaches_spawn () =
+  let workspace = temp_workspace "masc-codex-cwd-" in
+  let marker = Filename.concat workspace "spawn-cwd.txt" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree workspace)
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun fixture ->
+            let wrapper = Filename.temp_file "masc-codex-cwd-wrapper-" ".sh" in
+            Fun.protect
+              ~finally:(fun () -> Sys.remove wrapper)
+              (fun () ->
+                 let output = open_out_bin wrapper in
+                 output_string output "#!/bin/sh\n";
+                 output_string output ("pwd > " ^ shell_quote marker ^ "\n");
+                 output_string output
+                   ("exec " ^ shell_quote fixture ^ " \"$@\"\n");
+                 close_out output;
+                 Unix.chmod wrapper 0o700;
+                 (match run_fixture ~cwd:workspace wrapper with
+                  | Error error ->
+                    fail (Runtime_codex_app_server.error_to_string error)
+                  | Ok _ -> ());
+                 let input = open_in_bin marker in
+                 let observed =
+                   Fun.protect
+                     ~finally:(fun () -> close_in input)
+                     (fun () -> input_line input)
+                 in
+                 check string
+                   "spawn cwd"
+                   (Unix.realpath workspace)
+                   (Unix.realpath observed))))
+;;
+
+let write_fixture_file path content =
+  let output = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr output)
+    (fun () -> output_string output content)
+;;
+
+let fixture_tool ?(parameters = []) ~name ~description () =
+  Agent_sdk.Tool.create
+    ~name
+    ~description
+    ~parameters
+    (fun _ -> Ok { Agent_sdk.Types.content = "fixture"; _meta = None })
+;;
+
+let production_keeper_meta ~base_path ~trace_id =
   let name = "codex-production-fixture" in
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
          [ "name", `String name
          ; "agent_name", `String (Keeper_identity.keeper_agent_name name)
-         ; "trace_id", `String "codex-production-fixture-trace"
+         ; "trace_id", `String trace_id
          ; "allowed_paths", `List [ `String base_path ]
          ])
   with
@@ -353,17 +470,13 @@ let production_keeper_meta ~base_path =
   | Error detail -> fail ("production Keeper meta fixture failed: " ^ detail)
 ;;
 
-let run_production_keeper_turn ~cli_path ~model =
+let run_production_keeper_turn ~base_path ~trace_id ~user_message ~cli_path ~model =
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
     ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
     (fun () ->
        with_runtime_config ~model cli_path (fun runtime_path ->
-         let base_path = temp_workspace "masc-codex-production-" in
-         Fun.protect
-           ~finally:(fun () -> cleanup_tree base_path)
-           (fun () ->
-              Eio_main.run (fun env ->
+         Eio_main.run (fun env ->
                 Eio.Switch.run (fun sw ->
                   Fs_compat.set_fs (Eio.Stdenv.fs env);
                   Eio_context.set_env env;
@@ -377,7 +490,7 @@ let run_production_keeper_turn ~cli_path ~model =
                        | Error error -> fail error
                        | Ok () ->
                          let config = Workspace.default_config base_path in
-                         let meta = production_keeper_meta ~base_path in
+                         let meta = production_keeper_meta ~base_path ~trace_id in
                          ignore
                            (Keeper_registry.For_testing.register
                               ~base_path
@@ -414,20 +527,26 @@ let run_production_keeper_turn ~cli_path ~model =
                                     { Keeper_agent_run.system_prompt = base_system_prompt
                                     ; dynamic_context = ""
                                     })
-                                ~user_message:
-                                  "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools."
+                                ~user_message
                                 ~turn_kind:Turn_record.Direct
                                 ~runtime_id:"codex.codex"
                                 ~generation:1
-                                ())))))))
+                                ()))))))
 ;;
 
 let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projection
-    ?(goal = "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.")
-    ~cli_path ~model () =
+    ?base_path
+    ?(goal = "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.") ~cli_path
+    ~model () =
+  let owns_base_path = Option.is_none base_path in
+  let base_path =
+    Option.value base_path ~default:(temp_workspace "masc-codex-session-")
+  in
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
-    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      if owns_base_path then cleanup_tree base_path)
     (fun () ->
        with_runtime_config ~model cli_path (fun runtime_path ->
          Eio_main.run (fun env ->
@@ -450,7 +569,7 @@ let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projecti
                     Keeper_turn_driver.run_named
                       ~runtime_id:"codex.codex"
                       ~keeper_name:"codex-fixture"
-                      ~base_path:"/tmp"
+                      ~base_path
                       ~goal
                       ~tools
                       ~initial_messages:[]
@@ -474,6 +593,184 @@ let test_keeper_dispatches_codex_turn_runtime () =
          check bool "measured observation" true (Option.is_some result.runtime_observation))
 ;;
 
+let test_keeper_protocol_failure_enters_recovery () =
+  let base_path = temp_workspace "masc-codex-runtime-recovery-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ "not-json"
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            (match
+               run_keeper_turn
+                 ~base_path
+                 ~cli_path
+                 ~model:"gpt-fixture"
+                 ()
+             with
+             | Error _ -> ()
+             | Ok _ -> fail "malformed official-client response completed the Keeper turn");
+            let recovery =
+              match
+                Keeper_official_client_session_store.load
+                  ~base_path
+                  ~keeper_name:"codex-fixture"
+              with
+              | Error detail -> fail detail
+              | Ok None -> fail "failed Codex turn left no durable recovery state"
+              | Ok (Some state) -> state
+            in
+            (match recovery.phase with
+             | Recovery_required required ->
+               check bool
+                 "runtime failure class"
+                 true
+                 (required.failure = Protocol_failed);
+               check (option string) "no observed session" None required.observed_session_id
+             | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+               fail "failed Codex runtime claim was not converted to recovery-required");
+            (match
+               run_keeper_turn
+                 ~base_path
+                 ~cli_path
+                 ~model:"gpt-fixture"
+                 ()
+             with
+             | Error
+                 (Agent_sdk.Error.Config
+                   (Agent_sdk.Error.InvalidConfig { field; _ })) ->
+               check string "recovery gate field" "official_client_session.claim" field
+             | Error error -> fail (Agent_sdk.Error.to_string error)
+             | Ok _ -> fail "unresolved Codex recovery admitted a duplicate turn")))
+;;
+
+let test_keeper_resumes_persisted_codex_thread () =
+  let base_path = temp_workspace "masc-codex-resume-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~base_path
+                ~cli_path
+                ~model:"gpt-fixture"
+                ()
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok result -> check int "initial turn count" 1 result.turns);
+       let before_turn_ordinal = ref 0 in
+       let after_turn_ordinal = ref 0 in
+       let hooks : Agent_sdk.Hooks.hooks =
+         { Agent_sdk.Hooks.empty with
+           before_turn =
+             Some
+               (function
+                 | BeforeTurn { turn; _ } ->
+                   before_turn_ordinal := turn;
+                   Continue
+                 | _ -> Continue)
+         ; after_turn =
+             Some
+               (function
+                 | AfterTurn { turn; _ } ->
+                   after_turn_ordinal := turn;
+                   Continue
+                 | _ -> Continue)
+         }
+       in
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; resumed_turn_result
+         ; resumed_item_completed
+         ; resumed_turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~base_path
+                ~hooks
+                ~goal:"Return the resumed fixture marker"
+                ~cli_path
+                ~model:"gpt-fixture"
+                ()
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok result ->
+              check string "resumed response" "MASC_RESUMED_OK" (keeper_response_text result);
+              check string "official thread" "thread-1" result.session_id;
+              check int "cumulative turns" 2 result.turns;
+              check int "before-turn ordinal" 2 !before_turn_ordinal;
+              check int "after-turn ordinal" 2 !after_turn_ordinal);
+       match
+         Keeper_official_client_session_store.load
+           ~base_path
+           ~keeper_name:"codex-fixture"
+       with
+       | Error detail -> fail detail
+       | Ok None -> fail "resumed Codex binding disappeared"
+       | Ok (Some binding) -> check int "stored turns" 2 binding.turn_count)
+;;
+
+let test_keeper_rejects_changed_tool_surface_on_resume () =
+  let base_path = temp_workspace "masc-codex-tool-change-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            (match
+               run_keeper_turn
+                 ~base_path
+                 ~cli_path
+                 ~model:"gpt-fixture"
+                 ()
+             with
+             | Error error -> fail (Agent_sdk.Error.to_string error)
+             | Ok _ -> ());
+            let tool = fixture_tool ~name:"new_tool" ~description:"new surface" () in
+            match
+              run_keeper_turn
+                ~base_path
+                ~tools:[ tool ]
+                ~cli_path
+                ~model:"gpt-fixture"
+                ()
+            with
+            | Error
+                (Agent_sdk.Error.Config
+                  (Agent_sdk.Error.InvalidConfig { field; _ })) ->
+              check string
+                "fingerprint field"
+                "official_client_session.tool_surface_sha256"
+                field
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok _ -> fail "changed tool surface silently resumed the Codex thread"))
+;;
+
 let assert_production_keeper_result result =
   check string
     "production Keeper response"
@@ -488,18 +785,93 @@ let assert_production_keeper_result result =
 ;;
 
 let test_production_keeper_dispatches_codex_runtime () =
-  with_fixture
-    [ init_result
-    ; account_chatgpt
-    ; thread_result
-    ; turn_result
-    ; item_completed
-    ; turn_completed
-    ]
-    (fun cli_path ->
-       match run_production_keeper_turn ~cli_path ~model:"gpt-fixture" with
-       | Error error -> fail (Agent_sdk.Error.to_string error)
-       | Ok result -> assert_production_keeper_result result)
+  let base_path = temp_workspace "masc-codex-production-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_production_keeper_turn
+                ~base_path
+                ~trace_id:"codex-production-trace-1"
+                ~user_message:
+                  "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools."
+                ~cli_path
+                ~model:"gpt-fixture"
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok result -> assert_production_keeper_result result))
+;;
+
+let test_production_keeper_resumes_across_trace_rotation () =
+  let base_path = temp_workspace "masc-codex-production-resume-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_production_keeper_turn
+                ~base_path
+                ~trace_id:"codex-production-trace-1"
+                ~user_message:"Start the production fixture thread."
+                ~cli_path
+                ~model:"gpt-fixture"
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok _ -> ());
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; resumed_turn_result
+         ; resumed_item_completed
+         ; resumed_turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_production_keeper_turn
+                ~base_path
+                ~trace_id:"codex-production-trace-2"
+                ~user_message:"Resume the production fixture thread."
+                ~cli_path
+                ~model:"gpt-fixture"
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok result ->
+              check string
+                "production resumed response"
+                "MASC_RESUMED_OK"
+                result.Keeper_agent_run.response_text);
+       match
+         Keeper_official_client_session_store.load
+           ~base_path
+           ~keeper_name:"codex-production-fixture"
+       with
+       | Error detail -> fail detail
+       | Ok None -> fail "production Codex current-owner state disappeared"
+       | Ok (Some state) ->
+         check int "production cumulative turns" 2 state.turn_count;
+         (match state.phase with
+          | Settled { session_id; _ } ->
+            check string "production thread" "thread-1" session_id
+          | Ready | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+            fail "production Codex state did not settle"))
 ;;
 
 let test_keeper_projects_typed_tools_and_hooks () =
@@ -667,6 +1039,7 @@ let test_live_chatgpt_subscription () =
         Runtime_codex_app_server.run_turn
           ~mgr:(Eio.Stdenv.process_mgr env)
           ~clock:(Eio.Stdenv.clock env)
+          ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
           config
           ~prompt:"Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.")
     in
@@ -704,6 +1077,7 @@ let test_live_dynamic_tool_subscription () =
         Runtime_codex_app_server.run_turn
           ~mgr:(Eio.Stdenv.process_mgr env)
           ~clock:(Eio.Stdenv.clock env)
+          ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
           ~dynamic_tools:[ tool ]
           config
           ~prompt:
@@ -731,6 +1105,7 @@ let test_live_history_injection_subscription () =
         Runtime_codex_app_server.run_turn
           ~mgr:(Eio.Stdenv.process_mgr env)
           ~clock:(Eio.Stdenv.clock env)
+          ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
           ~history:
             [ { role = User; text = "The continuity marker is MASC_HISTORY_OK." }
             ; { role = Assistant; text = "I will retain that marker." }
@@ -782,19 +1157,72 @@ let test_live_keeper_dynamic_tool_subscription () =
       check string "live tool Keeper response" "MASC_TOOL_OK" (keeper_response_text result)
 ;;
 
+let test_live_keeper_resumes_official_thread () =
+  if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let base_path = temp_workspace "masc-codex-live-resume-" in
+    Fun.protect
+      ~finally:(fun () -> cleanup_tree base_path)
+      (fun () ->
+         (match
+            run_keeper_turn
+              ~base_path
+              ~goal:
+                "Remember marker MASC_RESUME_MEMORY. Reply exactly MASC_RESUME_FIRST."
+              ~cli_path:"codex"
+              ~model:"gpt-5.6-sol"
+              ()
+          with
+          | Error error -> fail (Agent_sdk.Error.to_string error)
+          | Ok result ->
+            check string
+              "first live response"
+              "MASC_RESUME_FIRST"
+              (keeper_response_text result));
+         match
+           run_keeper_turn
+             ~base_path
+             ~goal:"Reply exactly with the remembered marker."
+             ~cli_path:"codex"
+             ~model:"gpt-5.6-sol"
+             ()
+         with
+         | Error error -> fail (Agent_sdk.Error.to_string error)
+         | Ok result ->
+           check string
+             "resumed live response"
+             "MASC_RESUME_MEMORY"
+             (keeper_response_text result);
+           check int "resumed live turn count" 2 result.turns)
+;;
+
 let test_live_production_keeper_subscription () =
   if Sys.getenv_opt "MASC_CODEX_APP_SERVER_LIVE" <> Some "1"
   then Alcotest.skip ()
   else
-    match run_production_keeper_turn ~cli_path:"codex" ~model:"gpt-5.6-sol" with
-    | Error error -> fail (Agent_sdk.Error.to_string error)
-    | Ok result -> assert_production_keeper_result result
+    let base_path = temp_workspace "masc-codex-live-production-" in
+    Fun.protect
+      ~finally:(fun () -> cleanup_tree base_path)
+      (fun () ->
+         match
+           run_production_keeper_turn
+             ~base_path
+             ~trace_id:"codex-live-production-trace"
+             ~user_message:
+               "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools."
+             ~cli_path:"codex"
+             ~model:"gpt-5.6-sol"
+         with
+         | Error error -> fail (Agent_sdk.Error.to_string error)
+         | Ok result -> assert_production_keeper_result result)
 ;;
 
 let () =
   run "runtime codex app-server"
     [ ( "subscription boundary"
       , [ test_case "ChatGPT turn completes" `Quick test_chatgpt_subscription_turn
+        ; test_case "declared cwd reaches spawn" `Quick test_declared_cwd_reaches_spawn
         ; test_case "API key is rejected" `Quick test_api_key_account_is_rejected
         ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
         ; test_case
@@ -815,16 +1243,44 @@ let () =
             "unknown notifications are bounded"
             `Quick
             test_unknown_notifications_are_bounded
+        ; test_case
+            "turn admission validation is process-free"
+            `Quick
+            test_turn_admission_validation_is_process_free
         ; test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
         ; test_case "history injects before turn" `Quick test_history_is_injected_before_turn
+        ; test_case
+            "thread resume skips history injection"
+            `Quick
+            test_thread_resume_skips_history_injection
+        ; test_case
+            "thread resume rejects identity mismatch"
+            `Quick
+            test_thread_resume_rejects_identity_mismatch
         ; test_case
             "Keeper dispatches Codex runtime"
             `Quick
             test_keeper_dispatches_codex_turn_runtime
         ; test_case
+            "Keeper protocol failure enters recovery"
+            `Quick
+            test_keeper_protocol_failure_enters_recovery
+        ; test_case
+            "Keeper resumes persisted Codex thread"
+            `Quick
+            test_keeper_resumes_persisted_codex_thread
+        ; test_case
+            "Keeper rejects changed Codex tool surface"
+            `Quick
+            test_keeper_rejects_changed_tool_surface_on_resume
+        ; test_case
             "production Keeper dispatches Codex runtime"
             `Quick
             test_production_keeper_dispatches_codex_runtime
+        ; test_case
+            "production Keeper resumes across trace rotation"
+            `Quick
+            test_production_keeper_resumes_across_trace_rotation
         ; test_case
             "Keeper projects typed tools and hooks"
             `Quick
@@ -855,6 +1311,10 @@ let () =
             "Keeper typed tool through official Codex app-server"
             `Slow
             test_live_keeper_dynamic_tool_subscription
+        ; test_case
+            "Keeper resumes official Codex thread"
+            `Slow
+            test_live_keeper_resumes_official_thread
         ; test_case
             "production Keeper through official Codex app-server"
             `Slow


### PR DESCRIPTION
## Summary
- run Keeper turns through the official Codex app-server using an existing ChatGPT subscription login
- persist thread/turn ownership through the shared official-client session store and resume only after exact settlement
- validate the full turn before durable claim, fail closed on protocol or tool-surface drift, and require explicit recovery for ambiguous outcomes
- document a credential-free `runtime.toml` example for sangsu using `gpt-5.3-codex-spark` with a GLM-5 fallback

## Verification
- `dune exec --root . ./test/test_runtime_codex_app_server.exe`
  - 23 focused tests passed
  - 7 live subscription tests skipped because this PR does not claim a logged-in live run

## Boundaries
- no API-key configuration or fallback
- no legacy session compatibility layer
- Claude Code and Antigravity/Gemini adapters remain separate follow-up PRs
- dashboard operations will land after the runtime adapters share this typed store