### PR TITLE
feat(dashboard): configure Codex subscription runtime

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1032,9 +1032,80 @@ export interface RuntimeTomlConfig {
   file_name: string
   source_text: string
   reloaded: boolean
+  provider_protocols: RuntimeTomlEditorProtocol[]
   message?: string | null
   reason?: string | null
   issues?: unknown
+}
+
+export type RuntimeTomlEditorTransport = 'endpoint' | 'command'
+export type RuntimeTomlEditorSemantics = 'http_provider' | 'official_client'
+export type RuntimeTomlEditorCredentialPolicy = 'optional' | 'forbidden'
+
+export interface RuntimeTomlEditorProtocol {
+  protocol: string
+  transport: RuntimeTomlEditorTransport
+  semantics: RuntimeTomlEditorSemantics
+  credential_policy: RuntimeTomlEditorCredentialPolicy
+  requires_non_interactive: boolean
+}
+
+const RUNTIME_TOML_EDITOR_PROTOCOL_KEYS = [
+  'credential_policy',
+  'protocol',
+  'requires_non_interactive',
+  'semantics',
+  'transport',
+] as const
+
+function parseRuntimeTomlEditorProtocols(raw: unknown): RuntimeTomlEditorProtocol[] {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error('유효하지 않은 runtime provider protocol inventory')
+  }
+  const seen = new Set<string>()
+  return raw.map((entry) => {
+    if (!isRecord(entry)) throw new Error('유효하지 않은 runtime provider protocol entry')
+    const keys = Object.keys(entry).sort()
+    if (
+      keys.length !== RUNTIME_TOML_EDITOR_PROTOCOL_KEYS.length
+      || keys.some((key, index) => key !== RUNTIME_TOML_EDITOR_PROTOCOL_KEYS[index])
+    ) {
+      throw new Error('유효하지 않은 runtime provider protocol fields')
+    }
+    const protocol = entry.protocol
+    const transport = entry.transport
+    const semantics = entry.semantics
+    const credentialPolicy = entry.credential_policy
+    const requiresNonInteractive = entry.requires_non_interactive
+    if (
+      typeof protocol !== 'string'
+      || protocol === ''
+      || protocol.trim() !== protocol
+      || (transport !== 'endpoint' && transport !== 'command')
+      || (semantics !== 'http_provider' && semantics !== 'official_client')
+      || (credentialPolicy !== 'optional' && credentialPolicy !== 'forbidden')
+      || typeof requiresNonInteractive !== 'boolean'
+      || seen.has(protocol)
+    ) {
+      throw new Error('유효하지 않은 runtime provider protocol contract')
+    }
+    if (
+      (semantics === 'official_client'
+        && (transport !== 'command' || credentialPolicy !== 'forbidden' || !requiresNonInteractive))
+      || (semantics === 'http_provider'
+        && (transport !== 'endpoint' || credentialPolicy !== 'optional' || requiresNonInteractive))
+    ) {
+      throw new Error('일관되지 않은 runtime provider protocol contract')
+    }
+    seen.add(protocol)
+    return {
+      protocol,
+      transport,
+      semantics,
+      credential_policy: credentialPolicy,
+      requires_non_interactive: requiresNonInteractive,
+    }
+  })
 }
 
 function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
@@ -1045,6 +1116,7 @@ function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
     file_name: asString(record.file_name) ?? 'runtime.toml',
     source_text: asString(record.source_text, ''),
     reloaded: asBoolean(record.reloaded) ?? false,
+    provider_protocols: parseRuntimeTomlEditorProtocols(record.provider_protocols),
     message: asNullableString(record.message),
     reason: asNullableString(record.reason),
     issues: record.issues,

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -3149,6 +3149,23 @@ describe('dashboard runtime probe API', () => {
 })
 
 describe('runtime.toml raw config API', () => {
+  const providerProtocols = [
+    {
+      protocol: 'openai-compatible-http',
+      transport: 'endpoint',
+      semantics: 'http_provider',
+      credential_policy: 'optional',
+      requires_non_interactive: false,
+    },
+    {
+      protocol: 'codex-app-server',
+      transport: 'command',
+      semantics: 'official_client',
+      credential_policy: 'forbidden',
+      requires_non_interactive: true,
+    },
+  ]
+
   it('fetches and normalizes the raw runtime.toml source', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
@@ -3157,6 +3174,7 @@ describe('runtime.toml raw config API', () => {
         file_name: 'runtime.toml',
         source_text: '[runtime]\ndefault = "runpod_mtp.qwen"\n',
         reloaded: false,
+        provider_protocols: providerProtocols,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -3175,6 +3193,36 @@ describe('runtime.toml raw config API', () => {
     expect(result.file_name).toBe('runtime.toml')
     expect(result.source_text).toContain('[runtime]')
     expect(result.reloaded).toBe(false)
+    expect(result.provider_protocols).toEqual(providerProtocols)
+  })
+
+  it.each([
+    ['missing inventory', undefined],
+    ['empty inventory', []],
+    ['duplicate protocol', [providerProtocols[0], providerProtocols[0]]],
+    ['inconsistent official-client contract', [{
+      ...providerProtocols[1],
+      transport: 'endpoint',
+    }]],
+    ['unknown entry field', [{
+      ...providerProtocols[0],
+      client_owned: true,
+    }]],
+  ])('rejects %s from the backend protocol inventory', async (_label, inventory) => {
+    const payload: Record<string, unknown> = {
+      ok: true,
+      path: '/tmp/.masc/config/runtime.toml',
+      file_name: 'runtime.toml',
+      source_text: '[runtime]\n',
+      reloaded: false,
+    }
+    if (inventory !== undefined) payload.provider_protocols = inventory
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })))
+
+    await expect(fetchRuntimeTomlConfig()).rejects.toThrow(/runtime provider protocol/)
   })
 
   it('posts the full raw TOML source through source_text', async () => {
@@ -3186,6 +3234,7 @@ describe('runtime.toml raw config API', () => {
         file_name: 'runtime.toml',
         source_text: sourceText,
         reloaded: true,
+        provider_protocols: providerProtocols,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -3217,6 +3266,7 @@ describe('runtime.toml raw config API', () => {
         file_name: 'runtime.toml',
         source_text: sourceText,
         reloaded: true,
+        provider_protocols: providerProtocols,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -3246,6 +3296,7 @@ describe('runtime.toml raw config API', () => {
         file_name: 'runtime.toml',
         source_text: sourceText,
         reloaded: true,
+        provider_protocols: providerProtocols,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -3275,6 +3326,7 @@ describe('runtime.toml raw config API', () => {
         file_name: 'runtime.toml',
         source_text: sourceText,
         reloaded: true,
+        provider_protocols: providerProtocols,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -178,6 +178,7 @@ export type {
   LatencyBucket,
   DashboardRuntimeModelMetricsResponse,
   RuntimeTomlConfig,
+  RuntimeTomlEditorProtocol,
   RuntimeRoutingLane,
 } from './dashboard-runtime'
 export {

--- a/dashboard/src/components/runtime-environment-editor.test.ts
+++ b/dashboard/src/components/runtime-environment-editor.test.ts
@@ -2,7 +2,10 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { DashboardRuntimeProviderSnapshot } from '../api/dashboard'
+import type {
+  DashboardRuntimeProviderSnapshot,
+  RuntimeTomlEditorProtocol,
+} from '../api/dashboard'
 import { RuntimeEnvironmentEditor } from './runtime-environment-editor'
 import { keepers } from '../store'
 import type { Keeper } from '../types/core'
@@ -17,6 +20,16 @@ const runtimeCatalogMock = vi.hoisted(() => ({
   },
   loadRuntimeCatalog: vi.fn(),
 }))
+
+const providerProtocols: RuntimeTomlEditorProtocol[] = [
+  {
+    protocol: 'openai-compatible-http',
+    transport: 'endpoint',
+    semantics: 'http_provider',
+    credential_policy: 'optional',
+    requires_non_interactive: false,
+  },
+]
 
 vi.mock('../lib/runtime-catalog-resource', () => ({
   findRuntimeCatalogEntry: (
@@ -86,6 +99,7 @@ function mountEditor(
   render(
     html`<${RuntimeEnvironmentEditor}
       sourceText=${options.sourceText ?? sourceTextWithQuotedAssignments}
+      providerProtocols=${providerProtocols}
       section="assignments"
       onRoutingChange=${() => {}}
       onAssignmentChange=${options.onAssignmentChange ?? (() => {})}
@@ -236,6 +250,7 @@ function mountSection(
   render(
     html`<${RuntimeEnvironmentEditor}
       sourceText=${sourceText}
+      providerProtocols=${providerProtocols}
       section=${section}
       onRoutingChange=${() => {}}
       onAssignmentChange=${() => {}}

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -1,7 +1,10 @@
 import { html } from 'htm/preact'
 import { formatContextTokens } from '../lib/format-number'
 import { useEffect, useMemo, useState } from 'preact/hooks'
-import type { DashboardRuntimeProviderSnapshot } from '../api/dashboard'
+import type {
+  DashboardRuntimeProviderSnapshot,
+  RuntimeTomlEditorProtocol,
+} from '../api/dashboard'
 import {
   findRuntimeCatalogEntry,
   loadRuntimeCatalog,
@@ -15,14 +18,11 @@ import {
   runtimeCatalogSnapshotFacts,
 } from '../lib/runtime-provider-summary'
 import {
-  isRuntimeTomlOfficialClientProtocol,
   isReservedRuntimeTomlId,
   isValidRuntimeTomlIdFormat,
   parseRuntimeTomlEnvironment,
-  RUNTIME_TOML_CREATABLE_PROTOCOLS,
   type RuntimeTomlCredentialType,
   type RuntimeTomlEnvironment,
-  type RuntimeTomlProtocol,
   type RuntimeTomlProvider,
 } from '../lib/runtime-toml-config'
 import { keepers } from '../store'
@@ -52,7 +52,7 @@ export type RuntimeProviderTransportEditableField = 'endpoint' | 'command'
 export interface NewRuntimeProviderInput {
   id: string
   displayName: string
-  protocol: RuntimeTomlProtocol
+  protocol: string
   transportKind: 'endpoint' | 'command'
   transportValue: string
   credentialType: RuntimeTomlCredentialType
@@ -72,6 +72,7 @@ export interface NewRuntimeModelInput {
 
 interface RuntimeEnvironmentEditorProps {
   sourceText: string
+  providerProtocols: RuntimeTomlEditorProtocol[]
   section: RuntimeStructuredSection
   disabled?: boolean
   draftDirty?: boolean
@@ -125,7 +126,7 @@ function transportValue(provider: RuntimeTomlProvider): string {
 interface NewProviderDraft {
   id: string
   displayName: string
-  protocol: RuntimeTomlProtocol
+  protocol: string
   transportKind: 'endpoint' | 'command'
   transportValue: string
   credentialType: RuntimeTomlCredentialType
@@ -133,15 +134,17 @@ interface NewProviderDraft {
   isNonInteractive: boolean
 }
 
-const DEFAULT_NEW_PROVIDER: NewProviderDraft = {
-  id: '',
-  displayName: '',
-  protocol: RUNTIME_TOML_CREATABLE_PROTOCOLS[0],
-  transportKind: 'endpoint',
-  transportValue: '',
-  credentialType: 'env',
-  credentialValue: '',
-  isNonInteractive: false,
+function newProviderDraft(protocol: RuntimeTomlEditorProtocol): NewProviderDraft {
+  return {
+    id: '',
+    displayName: '',
+    protocol: protocol.protocol,
+    transportKind: protocol.transport,
+    transportValue: '',
+    credentialType: protocol.credential_policy === 'forbidden' ? 'none' : 'env',
+    credentialValue: '',
+    isNonInteractive: protocol.requires_non_interactive,
+  }
 }
 
 // jsonSupport as a 3-way string enum (not boolean|null) because <select> values
@@ -274,6 +277,7 @@ function keeperDotTone(status: string): string {
 
 export function RuntimeEnvironmentEditor({
   sourceText,
+  providerProtocols,
   section,
   disabled,
   draftDirty,
@@ -288,11 +292,19 @@ export function RuntimeEnvironmentEditor({
   onProviderTransportChange,
   onProviderCredentialChange,
 }: RuntimeEnvironmentEditorProps) {
+  const defaultProviderProtocol = providerProtocols[0]
+  if (!defaultProviderProtocol) {
+    throw new Error('runtime provider protocol inventory must not be empty')
+  }
+  const defaultProviderDraft = useMemo(
+    () => newProviderDraft(defaultProviderProtocol),
+    [defaultProviderProtocol],
+  )
   const environment = useMemo(() => parseRuntimeTomlEnvironment(sourceText), [sourceText])
   const [modelQuery, setModelQuery] = useState('')
 
   const [providerFormOpen, setProviderFormOpen] = useState(false)
-  const [newProvider, setNewProvider] = useState<NewProviderDraft>(DEFAULT_NEW_PROVIDER)
+  const [newProvider, setNewProvider] = useState<NewProviderDraft>(defaultProviderDraft)
   const [providerFormError, setProviderFormError] = useState<string | null>(null)
   const [providerDeleteError, setProviderDeleteError] = useState<string | null>(null)
 
@@ -380,9 +392,17 @@ export function RuntimeEnvironmentEditor({
       setProviderFormError(`${newProvider.transportKind}를 입력하세요`)
       return
     }
-    const officialClient = isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
-    if (officialClient && (newProvider.transportKind !== 'command' || newProvider.credentialType !== 'none' || !newProvider.isNonInteractive)) {
-      setProviderFormError('공식 구독 클라이언트는 command + credential 없음 + non-interactive=true가 필요합니다')
+    const protocol = providerProtocols.find(entry => entry.protocol === newProvider.protocol)
+    if (!protocol) {
+      setProviderFormError('백엔드 runtime protocol inventory에 없는 provider입니다')
+      return
+    }
+    if (
+      newProvider.transportKind !== protocol.transport
+      || newProvider.isNonInteractive !== protocol.requires_non_interactive
+      || (protocol.credential_policy === 'forbidden' && newProvider.credentialType !== 'none')
+    ) {
+      setProviderFormError('provider 설정이 백엔드 runtime protocol 계약과 일치하지 않습니다')
       return
     }
     const trimmedCredentialValue = newProvider.credentialValue.trim()
@@ -397,7 +417,7 @@ export function RuntimeEnvironmentEditor({
       transportValue,
       credentialValue: trimmedCredentialValue,
     })
-    setNewProvider(DEFAULT_NEW_PROVIDER)
+    setNewProvider(defaultProviderDraft)
     setProviderFormError(null)
     setProviderDeleteError(null)
     setProviderFormOpen(false)
@@ -447,24 +467,17 @@ export function RuntimeEnvironmentEditor({
       setBindingFormError('provider와 model을 모두 선택하세요')
       return
     }
-    // A binding pin is written as a top-level `[providerId.modelId]` table.
-    // bindingSections() on read already excludes RESERVED_TOP_LEVEL first
-    // segments (providers/models/runtime/...), so a provider id that collides
-    // with one of those is silently unreadable after save -- or worse, if the
-    // model id also matches an existing `[models.<id>]` model definition, the
-    // binding table collides with it outright. New providers can never get a
-    // reserved id (runtimeTomlIdError), but this dropdown lists whatever is
-    // already in environment.providers, which can include a legacy/hand-edited
-    // provider that predates that check -- so guard here too.
+    // Backend validation rejects this source on save. Keep the same reason at
+    // the draft boundary so the operator sees it before attempting the write.
     if (isReservedRuntimeTomlId(bindingProviderId)) {
       setBindingFormError(`"${bindingProviderId}"는 예약된 이름이라 바인딩 provider로 쓸 수 없습니다`)
       return
     }
-    // Generic command transports are not materializable. Official-client
-    // protocols are the typed exception: their backend runtime owns the CLI
-    // process and does not impersonate an OAS HTTP provider.
     const selectedProvider = environment.providers.find(p => p.id === bindingProviderId)
-    if (selectedProvider?.transportKind === 'command' && !isRuntimeTomlOfficialClientProtocol(selectedProvider.protocol)) {
+    const selectedProtocol = providerProtocols.find(
+      protocol => protocol.protocol === selectedProvider?.protocol,
+    )
+    if (selectedProvider?.transportKind === 'command' && selectedProtocol?.semantics !== 'official_client') {
       setBindingFormError(
         `"${bindingProviderId}"는 command(CLI) transport라 바인딩을 생성할 수 없습니다 (백엔드가 아직 CLI provider를 라우팅하지 못합니다)`,
       )
@@ -636,7 +649,9 @@ export function RuntimeEnvironmentEditor({
           ` : null}
           ${environment.providers.map(provider => {
             const providerTransportField = transportField(provider)
-            const officialClient = isRuntimeTomlOfficialClientProtocol(provider.protocol)
+            const officialClient = providerProtocols.find(
+              protocol => protocol.protocol === provider.protocol,
+            )?.semantics === 'official_client'
             return html`
             <div key=${provider.id} class="rt-card" data-testid=${`runtime-provider-${provider.id}`}>
               <div class="rt-card-h">
@@ -754,20 +769,20 @@ export function RuntimeEnvironmentEditor({
                     disabled=${isDisabled}
                     aria-label="새 provider protocol"
                     onChange=${(event: Event) => {
-                      const protocol = (event.currentTarget as HTMLSelectElement).value as RuntimeTomlProtocol
-                      const officialClient = isRuntimeTomlOfficialClientProtocol(protocol)
-                      setNewProvider({
-                        ...newProvider,
-                        protocol,
-                        transportKind: officialClient ? 'command' : 'endpoint',
-                        transportValue: '',
-                        credentialType: officialClient ? 'none' : 'env',
-                        credentialValue: '',
-                        isNonInteractive: officialClient,
-                      })
+                      const protocolName = (event.currentTarget as HTMLSelectElement).value
+                      const protocol = providerProtocols.find(entry => entry.protocol === protocolName)
+                      if (protocol) {
+                        setNewProvider({
+                          ...newProviderDraft(protocol),
+                          id: newProvider.id,
+                          displayName: newProvider.displayName,
+                        })
+                      }
                     }}
                   >
-                    ${RUNTIME_TOML_CREATABLE_PROTOCOLS.map(p => html`<option value=${p}>${p}</option>`)}
+                    ${providerProtocols.map(protocol => html`
+                      <option value=${protocol.protocol}>${protocol.protocol}</option>
+                    `)}
                   </select>
                 </div>
                 <div class="rt-field">
@@ -782,7 +797,7 @@ export function RuntimeEnvironmentEditor({
                   />
                 </div>
                 <div class="rt-note">
-                  ${isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
+                  ${providerProtocols.find(protocol => protocol.protocol === newProvider.protocol)?.semantics === 'official_client'
                     ? '공식 클라이언트의 기존 구독 로그인을 사용합니다. API key는 저장하지 않으며 non-interactive 실행을 강제합니다.'
                     : '일반 provider는 endpoint transport를 사용합니다.'}
                 </div>
@@ -791,7 +806,9 @@ export function RuntimeEnvironmentEditor({
                   <select
                     class="rt-select rt-select-narrow"
                     value=${newProvider.credentialType}
-                    disabled=${isDisabled || isRuntimeTomlOfficialClientProtocol(newProvider.protocol)}
+                    disabled=${isDisabled || providerProtocols.find(
+                      protocol => protocol.protocol === newProvider.protocol,
+                    )?.credential_policy === 'forbidden'}
                     aria-label="새 provider credential 종류"
                     onChange=${(event: Event) => setNewProvider({ ...newProvider, credentialType: (event.currentTarget as HTMLSelectElement).value as RuntimeTomlCredentialType })}
                   >
@@ -825,7 +842,7 @@ export function RuntimeEnvironmentEditor({
                     type="button"
                     class="rt-add-cancel"
                     disabled=${isDisabled}
-                    onClick=${() => { setProviderFormOpen(false); setNewProvider(DEFAULT_NEW_PROVIDER); setProviderFormError(null) }}
+                    onClick=${() => { setProviderFormOpen(false); setNewProvider(defaultProviderDraft); setProviderFormError(null) }}
                   >취소</button>
                 </div>
               </div>

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -16,6 +16,7 @@ import {
 } from '../lib/runtime-provider-summary'
 import {
   isRuntimeTomlNonMaterializableProtocol,
+  isRuntimeTomlOfficialClientProtocol,
   isReservedRuntimeTomlId,
   isValidRuntimeTomlIdFormat,
   parseRuntimeTomlEnvironment,
@@ -46,19 +47,18 @@ export type RuntimeProviderTransportEditableField = 'endpoint' | 'command'
 // ...) are deliberately excluded — those are semantically coupled to real,
 // per-model verified behavior (see runtime.toml's own inline caveats), not
 // something a generic add form can default safely. They stay raw-TOML-only.
-// transportKind is fixed to 'endpoint': CLI (`command`) transport providers
-// resolve to no provider_kind on the backend today and get silently dropped
-// from the live runtime list rather than failing the save (see
-// RUNTIME_TOML_CREATABLE_PROTOCOLS in lib/runtime-toml-config.ts). Until that
-// backend limitation is lifted, this form cannot offer command transport.
+// Generic providers use endpoint transport. A typed official-client protocol
+// may require command transport; that exception is selected by protocol and
+// never exposed as a free-form transport switch.
 export interface NewRuntimeProviderInput {
   id: string
   displayName: string
   protocol: RuntimeTomlProtocol
-  transportKind: 'endpoint'
+  transportKind: 'endpoint' | 'command'
   transportValue: string
   credentialType: RuntimeTomlCredentialType
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 export interface NewRuntimeModelInput {
@@ -127,10 +127,11 @@ interface NewProviderDraft {
   id: string
   displayName: string
   protocol: RuntimeTomlProtocol
-  transportKind: 'endpoint'
+  transportKind: 'endpoint' | 'command'
   transportValue: string
   credentialType: RuntimeTomlCredentialType
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 const DEFAULT_NEW_PROVIDER: NewProviderDraft = {
@@ -141,6 +142,7 @@ const DEFAULT_NEW_PROVIDER: NewProviderDraft = {
   transportValue: '',
   credentialType: 'env',
   credentialValue: '',
+  isNonInteractive: false,
 }
 
 // jsonSupport as a 3-way string enum (not boolean|null) because <select> values
@@ -376,7 +378,12 @@ export function RuntimeEnvironmentEditor({
     }
     const transportValue = newProvider.transportValue.trim()
     if (transportValue === '') {
-      setProviderFormError('endpoint를 입력하세요')
+      setProviderFormError(`${newProvider.transportKind}를 입력하세요`)
+      return
+    }
+    const officialClient = isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
+    if (officialClient && (newProvider.transportKind !== 'command' || newProvider.credentialType !== 'none' || !newProvider.isNonInteractive)) {
+      setProviderFormError('공식 구독 클라이언트는 command + credential 없음 + non-interactive=true가 필요합니다')
       return
     }
     const trimmedCredentialValue = newProvider.credentialValue.trim()
@@ -454,13 +461,11 @@ export function RuntimeEnvironmentEditor({
       setBindingFormError(`"${bindingProviderId}"는 예약된 이름이라 바인딩 provider로 쓸 수 없습니다`)
       return
     }
-    // A `command` transport provider always resolves to no provider_kind on the
-    // backend, so materialize_config's filter_map silently drops any binding
-    // pinned to it from the live runtime list. The add-provider form can no
-    // longer create one, but this dropdown lists every parsed provider,
-    // including a `command` one that already exists via raw TOML / legacy config.
+    // Generic command transports are not materializable. Official-client
+    // protocols are the typed exception: their backend runtime owns the CLI
+    // process and does not impersonate an OAS HTTP provider.
     const selectedProvider = environment.providers.find(p => p.id === bindingProviderId)
-    if (selectedProvider?.transportKind === 'command') {
+    if (selectedProvider?.transportKind === 'command' && !isRuntimeTomlOfficialClientProtocol(selectedProvider.protocol)) {
       setBindingFormError(
         `"${bindingProviderId}"는 command(CLI) transport라 바인딩을 생성할 수 없습니다 (백엔드가 아직 CLI provider를 라우팅하지 못합니다)`,
       )
@@ -641,12 +646,14 @@ export function RuntimeEnvironmentEditor({
           ` : null}
           ${environment.providers.map(provider => {
             const providerTransportField = transportField(provider)
+            const officialClient = isRuntimeTomlOfficialClientProtocol(provider.protocol)
             return html`
             <div key=${provider.id} class="rt-card" data-testid=${`runtime-provider-${provider.id}`}>
               <div class="rt-card-h">
                 <span class="rt-card-id mono">${provider.id}</span>
                 <span class="rt-card-name">${provider.displayName}</span>
                 <span class="rt-proto mono">${provider.protocol || '—'}</span>
+                ${officialClient ? html`<span class="rt-assign-tag pin mono">구독 CLI</span>` : null}
                 <button
                   type="button"
                   class="rt-delete-provider"
@@ -699,6 +706,15 @@ export function RuntimeEnvironmentEditor({
                   </span>
                   `}
               </div>
+              ${officialClient ? html`
+                <div class="rt-field" data-testid=${`runtime-provider-${provider.id}-subscription-boundary`}>
+                  <span class="sub-k">execution</span>
+                  <span class="mono">official client · ${provider.isNonInteractive ? 'non-interactive' : '설정 오류: interactive'}</span>
+                </div>
+                ${provider.credentialType !== 'none' ? html`
+                  <div class="rt-warn" role="alert">공식 구독 클라이언트에는 API credential을 선언할 수 없습니다.</div>
+                ` : null}
+              ` : null}
               ${/* Provider capability chips (mcp-tools/tool-events/mcp-http-headers)
                    had no live source and rendered as if confirmed. Removed until a
                    provider-capability source exists, rather than implying support
@@ -747,29 +763,45 @@ export function RuntimeEnvironmentEditor({
                     value=${newProvider.protocol}
                     disabled=${isDisabled}
                     aria-label="새 provider protocol"
-                    onChange=${(event: Event) => setNewProvider({ ...newProvider, protocol: (event.currentTarget as HTMLSelectElement).value as RuntimeTomlProtocol })}
+                    onChange=${(event: Event) => {
+                      const protocol = (event.currentTarget as HTMLSelectElement).value as RuntimeTomlProtocol
+                      const officialClient = isRuntimeTomlOfficialClientProtocol(protocol)
+                      setNewProvider({
+                        ...newProvider,
+                        protocol,
+                        transportKind: officialClient ? 'command' : 'endpoint',
+                        transportValue: '',
+                        credentialType: officialClient ? 'none' : 'env',
+                        credentialValue: '',
+                        isNonInteractive: officialClient,
+                      })
+                    }}
                   >
                     ${RUNTIME_TOML_CREATABLE_PROTOCOLS.map(p => html`<option value=${p}>${p}</option>`)}
                   </select>
                 </div>
                 <div class="rt-field">
-                  <span class="sub-k">endpoint</span>
+                  <span class="sub-k">${newProvider.transportKind}</span>
                   <input
                     class="rt-input mono"
                     value=${newProvider.transportValue}
-                    placeholder="https://..."
+                    placeholder=${newProvider.transportKind === 'command' ? '/absolute/path/to/codex' : 'https://...'}
                     disabled=${isDisabled}
                     aria-label="새 provider transport 값"
                     onInput=${(event: Event) => setNewProvider({ ...newProvider, transportValue: (event.currentTarget as HTMLInputElement).value })}
                   />
                 </div>
-                <div class="rt-note">CLI(command) provider는 현재 백엔드에서 라우팅되지 않아 이 폼에서 생성할 수 없습니다. raw TOML 탭을 이용하세요.</div>
+                <div class="rt-note">
+                  ${isRuntimeTomlOfficialClientProtocol(newProvider.protocol)
+                    ? '공식 클라이언트의 기존 구독 로그인을 사용합니다. API key는 저장하지 않으며 non-interactive 실행을 강제합니다.'
+                    : '일반 provider는 endpoint transport를 사용합니다.'}
+                </div>
                 <div class="rt-field">
                   <span class="sub-k">credential</span>
                   <select
                     class="rt-select rt-select-narrow"
                     value=${newProvider.credentialType}
-                    disabled=${isDisabled}
+                    disabled=${isDisabled || isRuntimeTomlOfficialClientProtocol(newProvider.protocol)}
                     aria-label="새 provider credential 종류"
                     onChange=${(event: Event) => setNewProvider({ ...newProvider, credentialType: (event.currentTarget as HTMLSelectElement).value as RuntimeTomlCredentialType })}
                   >

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -15,7 +15,6 @@ import {
   runtimeCatalogSnapshotFacts,
 } from '../lib/runtime-provider-summary'
 import {
-  isRuntimeTomlNonMaterializableProtocol,
   isRuntimeTomlOfficialClientProtocol,
   isReservedRuntimeTomlId,
   isValidRuntimeTomlIdFormat,
@@ -468,15 +467,6 @@ export function RuntimeEnvironmentEditor({
     if (selectedProvider?.transportKind === 'command' && !isRuntimeTomlOfficialClientProtocol(selectedProvider.protocol)) {
       setBindingFormError(
         `"${bindingProviderId}"는 command(CLI) transport라 바인딩을 생성할 수 없습니다 (백엔드가 아직 CLI provider를 라우팅하지 못합니다)`,
-      )
-      return
-    }
-    // Protocol-only non-materialization is limited to Messages_api. Other
-    // protocols, including openai-compatible-cli, are valid when the provider
-    // uses endpoint/HTTP transport.
-    if (selectedProvider && isRuntimeTomlNonMaterializableProtocol(selectedProvider.protocol)) {
-      setBindingFormError(
-        `"${bindingProviderId}"는 ${selectedProvider.protocol} protocol이라 바인딩을 생성할 수 없습니다 (백엔드가 아직 이 provider를 라우팅하지 못합니다)`,
       )
       return
     }

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -30,12 +30,51 @@ import { keepers } from '../store'
 
 const MOCK_RUNTIME_PATH = '/tmp/.masc/config/runtime.toml'
 
+const providerProtocols = [
+  {
+    protocol: 'messages-http',
+    transport: 'endpoint',
+    semantics: 'http_provider',
+    credential_policy: 'optional',
+    requires_non_interactive: false,
+  },
+  {
+    protocol: 'openai-compatible-http',
+    transport: 'endpoint',
+    semantics: 'http_provider',
+    credential_policy: 'optional',
+    requires_non_interactive: false,
+  },
+  {
+    protocol: 'ollama-http',
+    transport: 'endpoint',
+    semantics: 'http_provider',
+    credential_policy: 'optional',
+    requires_non_interactive: false,
+  },
+  {
+    protocol: 'codex-app-server',
+    transport: 'command',
+    semantics: 'official_client',
+    credential_policy: 'forbidden',
+    requires_non_interactive: true,
+  },
+  {
+    protocol: 'claude-code',
+    transport: 'command',
+    semantics: 'official_client',
+    credential_policy: 'forbidden',
+    requires_non_interactive: true,
+  },
+] as const
+
 const baseConfig = {
   ok: true,
   path: MOCK_RUNTIME_PATH,
   file_name: 'runtime.toml',
   source_text: '[runtime]\ndefault = "runpod_mtp.qwen"\n',
   reloaded: false,
+  provider_protocols: providerProtocols,
 }
 
 const richSourceText = `[runtime]
@@ -884,13 +923,14 @@ describe('RuntimeTomlEditor', () => {
       container.querySelectorAll('[aria-label="새 provider protocol"] option'),
     ).map(option => (option as HTMLOptionElement).value)
     expect(protocolOptions).toEqual([
+      'messages-http',
       'openai-compatible-http',
       'ollama-http',
-      'openai-compatible-cli',
-      'messages-http',
       'codex-app-server',
+      'claude-code',
     ])
     expect(protocolOptions).not.toContain('messages-cli')
+    expect(protocolOptions).not.toContain('openai-compatible-cli')
     // No transport-kind selector left to switch to 'command'.
     expect(container.querySelector('[aria-label="새 provider transport 종류"]')).toBeNull()
   })

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -870,7 +870,7 @@ describe('RuntimeTomlEditor', () => {
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
   })
 
-  it('does not offer messages protocols or command transport in the add-provider form', async () => {
+  it('offers only materializable HTTP protocols plus the typed Codex official client', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)
 
@@ -883,11 +883,67 @@ describe('RuntimeTomlEditor', () => {
     const protocolOptions = Array.from(
       container.querySelectorAll('[aria-label="새 provider protocol"] option'),
     ).map(option => (option as HTMLOptionElement).value)
-    expect(protocolOptions).toEqual(['openai-compatible-http', 'ollama-http', 'openai-compatible-cli'])
+    expect(protocolOptions).toEqual([
+      'openai-compatible-http',
+      'ollama-http',
+      'openai-compatible-cli',
+      'codex-app-server',
+    ])
     expect(protocolOptions).not.toContain('messages-http')
     expect(protocolOptions).not.toContain('messages-cli')
     // No transport-kind selector left to switch to 'command'.
     expect(container.querySelector('[aria-label="새 provider transport 종류"]')).toBeNull()
+  })
+
+  it('creates a Codex subscription provider and binding with the enforced no-key boundary', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-providers"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-providers"]') as HTMLButtonElement)
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-toggle"]') as HTMLButtonElement)
+    fireEvent.input(container.querySelector('[data-testid="runtime-add-provider-id"]') as HTMLInputElement, {
+      target: { value: 'codex_subscription' },
+    })
+    fireEvent.change(container.querySelector('[aria-label="새 provider protocol"]') as HTMLSelectElement, {
+      target: { value: 'codex-app-server' },
+    })
+
+    const credentialType = container.querySelector('[aria-label="새 provider credential 종류"]') as HTMLSelectElement
+    expect(credentialType.value).toBe('none')
+    expect(credentialType.disabled).toBe(true)
+    expect(container.querySelector('[aria-label="새 provider credential 값"]')).toBeNull()
+
+    fireEvent.input(container.querySelector('[aria-label="새 provider transport 값"]') as HTMLInputElement, {
+      target: { value: '/Users/dancer/.local/bin/codex' },
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-provider-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('[providers.codex_subscription]')
+      expect(source).toContain('protocol = "codex-app-server"')
+      expect(source).toContain('command = "/Users/dancer/.local/bin/codex"')
+      expect(source).toContain('is-non-interactive = true')
+      expect(source).not.toContain('[providers.codex_subscription.credentials]')
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-bindings"]') as HTMLButtonElement)
+    fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-provider"]') as HTMLSelectElement, {
+      target: { value: 'codex_subscription' },
+    })
+    fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-model"]') as HTMLSelectElement, {
+      target: { value: 'qwen' },
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-binding-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('[codex_subscription.qwen]')
+      expect(container.querySelector('[data-testid="runtime-add-binding-error"]')).toBeNull()
+    })
   })
 
   it('adds a new model through the form', async () => {

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -870,7 +870,7 @@ describe('RuntimeTomlEditor', () => {
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
   })
 
-  it('offers only materializable HTTP protocols plus the typed Codex official client', async () => {
+  it('offers backend-validated HTTP protocols plus the typed Codex official client', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)
 
@@ -887,9 +887,9 @@ describe('RuntimeTomlEditor', () => {
       'openai-compatible-http',
       'ollama-http',
       'openai-compatible-cli',
+      'messages-http',
       'codex-app-server',
     ])
-    expect(protocolOptions).not.toContain('messages-http')
     expect(protocolOptions).not.toContain('messages-cli')
     // No transport-kind selector left to switch to 'command'.
     expect(container.querySelector('[aria-label="새 provider transport 종류"]')).toBeNull()
@@ -1104,16 +1104,12 @@ command = "provider-runtime --serve"
     expect(sourceAfter).toBe(sourceBefore)
   })
 
-  it('rejects a binding to an existing non-materializable messages-http provider', async () => {
-    // Legacy/hand-edited data: messages-http providers parse and can be rendered
-    // in the structured binding dropdown, but Runtime_adapter currently returns
-    // no Provider_config for Messages_api, so materialize_config would silently
-    // drop a binding pinned to one.
+  it('defers messages-http compatibility to the backend provider registry', async () => {
     const configWithMessagesProvider = {
       ...richConfig,
       source_text: `${richConfig.source_text}
-[providers.messages_api]
-display-name = "Messages API"
+[providers.kimi]
+display-name = "Kimi"
 protocol = "messages-http"
 endpoint = "https://messages.example/v1"
 `,
@@ -1129,19 +1125,16 @@ endpoint = "https://messages.example/v1"
     const sourceBefore = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
 
     fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-provider"]') as HTMLSelectElement, {
-      target: { value: 'messages_api' },
+      target: { value: 'kimi' },
     })
     fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-model"]') as HTMLSelectElement, {
       target: { value: 'gpt' },
     })
     fireEvent.click(container.querySelector('[data-testid="runtime-add-binding-submit"]') as HTMLButtonElement)
 
-    await waitFor(() => {
-      expect(container.querySelector('[data-testid="runtime-add-binding-error"]')?.textContent).toContain(
-        'messages-http',
-      )
-    })
+    await waitFor(() => expect(container.querySelector('[data-testid="runtime-add-binding-error"]')).toBeNull())
     const sourceAfter = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
-    expect(sourceAfter).toBe(sourceBefore)
+    expect(sourceAfter).not.toBe(sourceBefore)
+    expect(sourceAfter).toContain('[kimi.gpt]')
   })
 })

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -310,6 +310,9 @@ export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps =
       let next = setRuntimeTomlProviderField(current, input.id, 'display-name', input.displayName || input.id)
       next = setRuntimeTomlProviderField(next, input.id, 'protocol', input.protocol)
       next = setRuntimeTomlProviderField(next, input.id, input.transportKind, input.transportValue)
+      if (input.isNonInteractive) {
+        next = setRuntimeTomlProviderField(next, input.id, 'is-non-interactive', true)
+      }
       if (input.credentialType !== 'none' && input.credentialValue.trim() !== '') {
         next = setRuntimeTomlProviderCredential(next, input.id, input.credentialType, input.credentialValue)
       }

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -624,8 +624,9 @@ export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps =
             ` : null}
 
             <div class=${structuredActive ? '' : 'hidden'} data-testid="runtime-toml-structured">
-              <${RuntimeEnvironmentEditor}
+              ${config ? html`<${RuntimeEnvironmentEditor}
                 sourceText=${draft}
+                providerProtocols=${config.provider_protocols}
                 section=${structuredSection}
                 disabled=${loadState !== 'loaded'}
                 draftDirty=${dirty}
@@ -643,7 +644,7 @@ export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps =
                 onDeleteProvider=${handleDeleteProvider}
                 onProviderTransportChange=${handleProviderTransportChange}
                 onProviderCredentialChange=${handleProviderCredentialChange}
-              />
+              />` : null}
             </div>
 
             <div class=${tomlActive ? 'flex flex-col gap-3' : 'hidden'} data-testid="runtime-toml-section">

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -29,6 +29,15 @@ import { tweaksDensity } from './tweaks-panel'
 import { notificationDeliveryError, notifyRules } from '../notifications'
 
 const MOCK_RUNTIME_PATH = 'fixture/config/runtime.toml'
+const runtimeProviderProtocols = [
+  {
+    protocol: 'openai-compatible-http',
+    transport: 'endpoint',
+    semantics: 'http_provider',
+    credential_policy: 'optional',
+    requires_non_interactive: false,
+  },
+] as const
 import { dashboardLoading, shellAuthSummary, shellConfigResolution, shellRuntimeResolution } from '../store'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
 import { resetDevTokenBootstrap } from '../api/dev-token'
@@ -351,6 +360,7 @@ function stubEmptyApi() {
     file_name: 'runtime.toml',
     source_text: '[runtime]\ndefault = "rt-a"\n',
     reloaded: false,
+    provider_protocols: runtimeProviderProtocols,
   })
   apiMock.patchRuntimeMediaFailover.mockImplementation(async () => ({
     ok: true,
@@ -358,6 +368,7 @@ function stubEmptyApi() {
     file_name: 'runtime.toml',
     source_text: '[runtime]\ndefault = "rt-a"\n',
     reloaded: true,
+    provider_protocols: runtimeProviderProtocols,
   }))
   apiMock.patchRuntimeRouting.mockImplementation(async () => ({
     ok: true,
@@ -365,6 +376,7 @@ function stubEmptyApi() {
     file_name: 'runtime.toml',
     source_text: '[runtime]\ndefault = "rt-a"\n',
     reloaded: true,
+    provider_protocols: runtimeProviderProtocols,
   }))
   apiMock.saveRuntimeTomlConfig.mockImplementation(async (sourceText: string) => ({
     ok: true,
@@ -372,6 +384,7 @@ function stubEmptyApi() {
     file_name: 'runtime.toml',
     source_text: sourceText,
     reloaded: true,
+    provider_protocols: runtimeProviderProtocols,
   }))
 }
 
@@ -936,6 +949,7 @@ describe('SettingsSurface', () => {
           file_name: 'runtime.toml',
           source_text: '[runtime]\ndefault = "rt-a"\n',
           reloaded: false,
+          provider_protocols: runtimeProviderProtocols,
         }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -1520,6 +1534,7 @@ describe('SettingsSurface', () => {
       file_name: 'runtime.toml',
       source_text: '[fusion]\nenabled = true\ndefault_preset = "trio"\n\n[fusion.presets.trio]\nmin_answered = 2\n',
       reloaded: false,
+      provider_protocols: runtimeProviderProtocols,
     })
     render(html`<${SettingsSurface} />`, container)
 
@@ -1542,6 +1557,7 @@ describe('SettingsSurface', () => {
       file_name: 'runtime.toml',
       source_text: '[runtime]\ndefault = "runpod_mtp.qwen"\n',
       reloaded: false,
+      provider_protocols: runtimeProviderProtocols,
     }
     apiMock.fetchRuntimeTomlConfig.mockResolvedValueOnce(runtimeConfig)
 

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -74,6 +74,33 @@ describe('runtime TOML dashboard editing helpers', () => {
     })
   })
 
+  it('projects the Codex official-client subscription boundary without credentials', () => {
+    const codexSource = `[runtime]
+default = "codex_subscription.spark"
+
+[providers.codex_subscription]
+display-name = "Codex Subscription"
+protocol = "codex-app-server"
+command = "/usr/local/bin/codex"
+is-non-interactive = true
+
+[models.spark]
+api-name = "gpt-5.3-codex-spark"
+max-context = 131072
+
+[codex_subscription.spark]
+`
+
+    const environment = parseRuntimeTomlEnvironment(codexSource)
+    expect(environment.providers[0]).toMatchObject({
+      protocol: 'codex-app-server',
+      transportKind: 'command',
+      command: '/usr/local/bin/codex',
+      credentialType: 'none',
+      isNonInteractive: true,
+    })
+  })
+
   it('projects runtime routing lanes and keeper assignments from runtime.toml source', () => {
     const withRouting = `${sourceText.replace(
       'default = "runpod_mtp.qwen"',

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -12,6 +12,7 @@ export interface RuntimeTomlProvider {
   credentialKey: string
   credentialPath: string
   credentialValue: string
+  isNonInteractive: boolean
 }
 
 export interface RuntimeTomlModel {
@@ -289,6 +290,7 @@ function providerFromDocument(document: TomlDocument, id: string): RuntimeTomlPr
     credentialKey: asString(credentials.key),
     credentialPath: asString(credentials.path),
     credentialValue: asString(credentials.value),
+    isNonInteractive: asBoolean(values['is-non-interactive']),
   }
 }
 
@@ -639,8 +641,8 @@ export function setRuntimeTomlDefault(sourceText: string, runtimeId: string): st
 export function setRuntimeTomlProviderField(
   sourceText: string,
   providerId: string,
-  field: 'display-name' | 'protocol' | 'endpoint' | 'command',
-  value: string,
+  field: 'display-name' | 'protocol' | 'endpoint' | 'command' | 'is-non-interactive',
+  value: string | boolean,
 ): string {
   const section = `providers.${providerId}`
   if (field === 'endpoint') {
@@ -722,14 +724,16 @@ export const RUNTIME_TOML_PROTOCOLS = [
   'openai-compatible-cli',
   'messages-http',
   'messages-cli',
+  'codex-app-server',
 ] as const
 
 export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
 
 // Subset of RUNTIME_TOML_PROTOCOLS the add-provider form is allowed to offer.
-// The add-provider form only creates endpoint-backed providers. Command
-// transport is blocked at the binding form via transportKind, while
-// `provider_kind_for_http_provider` still returns `None` for `Messages_api`.
+// HTTP protocols create endpoint-backed providers. A typed official-client
+// protocol creates the command-backed runtime its backend adapter owns, while
+// generic command providers remain blocked. `provider_kind_for_http_provider`
+// still returns `None` for `Messages_api`.
 // Messages providers parse and save, but resolve to no provider_kind and
 // `Runtime.materialize_config`'s `List.filter_map` silently drops their bindings
 // from the live runtime list instead of failing the save
@@ -740,12 +744,17 @@ export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
   'openai-compatible-http',
   'ollama-http',
   'openai-compatible-cli',
+  'codex-app-server',
 ] as const
 
 export type RuntimeTomlCreatableProtocol = (typeof RUNTIME_TOML_CREATABLE_PROTOCOLS)[number]
 
 export function isRuntimeTomlCreatableProtocol(protocol: string): protocol is RuntimeTomlCreatableProtocol {
   return (RUNTIME_TOML_CREATABLE_PROTOCOLS as readonly string[]).includes(protocol)
+}
+
+export function isRuntimeTomlOfficialClientProtocol(protocol: string): boolean {
+  return protocol === 'codex-app-server'
 }
 
 const RUNTIME_TOML_NON_MATERIALIZABLE_PROTOCOLS = new Set([

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -730,20 +730,17 @@ export const RUNTIME_TOML_PROTOCOLS = [
 export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
 
 // Subset of RUNTIME_TOML_PROTOCOLS the add-provider form is allowed to offer.
-// HTTP protocols create endpoint-backed providers. A typed official-client
-// protocol creates the command-backed runtime its backend adapter owns, while
-// generic command providers remain blocked. `provider_kind_for_http_provider`
-// still returns `None` for `Messages_api`.
-// Messages providers parse and save, but resolve to no provider_kind and
-// `Runtime.materialize_config`'s `List.filter_map` silently drops their bindings
-// from the live runtime list instead of failing the save
-// (lib/runtime/runtime_adapter.ml:183-203, lib/runtime/runtime.ml:239).
-// This is an allow-list of materializable endpoint protocols, so a future 6th
-// protocol defaults to non-creatable until reviewed.
+// HTTP protocols create endpoint-backed providers. Whether a messages-http
+// provider is compatible is owned by the backend provider registry and checked
+// by Runtime.materialize_config at save time; the Dashboard must not duplicate
+// that typed registry decision as a protocol-string heuristic. A typed
+// official-client protocol creates the command-backed runtime its backend
+// adapter owns, while generic command providers remain blocked.
 export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
   'openai-compatible-http',
   'ollama-http',
   'openai-compatible-cli',
+  'messages-http',
   'codex-app-server',
 ] as const
 
@@ -755,15 +752,6 @@ export function isRuntimeTomlCreatableProtocol(protocol: string): protocol is Ru
 
 export function isRuntimeTomlOfficialClientProtocol(protocol: string): boolean {
   return protocol === 'codex-app-server'
-}
-
-const RUNTIME_TOML_NON_MATERIALIZABLE_PROTOCOLS = new Set([
-  'messages-http',
-  'messages-cli',
-])
-
-export function isRuntimeTomlNonMaterializableProtocol(protocol: string): boolean {
-  return RUNTIME_TOML_NON_MATERIALIZABLE_PROTOCOLS.has(protocol)
 }
 
 // runtime.toml ids become TOML table headers ([providers.<id>], [models.<id>],

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -713,47 +713,6 @@ export function setRuntimeTomlBindingField(
   return setRuntimeTomlKey(sourceText, runtimeId, field, value)
 }
 
-// Closed set mirroring lib/runtime/runtime_toml.ml's api_format_of_protocol —
-// any other string fails runtime.toml *parse* validation on save
-// (Runtime.save_config_text re-parses via materialize_config). This does not
-// mean every member here can be safely offered by the add-provider form: see
-// RUNTIME_TOML_CREATABLE_PROTOCOLS below for the materialization gate.
-export const RUNTIME_TOML_PROTOCOLS = [
-  'openai-compatible-http',
-  'ollama-http',
-  'openai-compatible-cli',
-  'messages-http',
-  'messages-cli',
-  'codex-app-server',
-] as const
-
-export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
-
-// Subset of RUNTIME_TOML_PROTOCOLS the add-provider form is allowed to offer.
-// HTTP protocols create endpoint-backed providers. Whether a messages-http
-// provider is compatible is owned by the backend provider registry and checked
-// by Runtime.materialize_config at save time; the Dashboard must not duplicate
-// that typed registry decision as a protocol-string heuristic. A typed
-// official-client protocol creates the command-backed runtime its backend
-// adapter owns, while generic command providers remain blocked.
-export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
-  'openai-compatible-http',
-  'ollama-http',
-  'openai-compatible-cli',
-  'messages-http',
-  'codex-app-server',
-] as const
-
-export type RuntimeTomlCreatableProtocol = (typeof RUNTIME_TOML_CREATABLE_PROTOCOLS)[number]
-
-export function isRuntimeTomlCreatableProtocol(protocol: string): protocol is RuntimeTomlCreatableProtocol {
-  return (RUNTIME_TOML_CREATABLE_PROTOCOLS as readonly string[]).includes(protocol)
-}
-
-export function isRuntimeTomlOfficialClientProtocol(protocol: string): boolean {
-  return protocol === 'codex-app-server'
-}
-
 // runtime.toml ids become TOML table headers ([providers.<id>], [models.<id>],
 // and the binding pin [<providerId>.<modelId>]). parseDocument's section regex
 // and bindingSections' 2-part split both assume an id has no '.', so a bare-key

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -3,9 +3,8 @@
     Re-homed from the deleted [Runtime_declarative_parser]. Parses RFC-0058
     layers 1-3 plus [[runtime].default] into a self-standing
     {!Runtime_schema.config}. Reserved top-level namespaces: providers,
-    models, runtime, web_search (plus the dropped routing namespaces system,
-    routes, profiles, which are still reserved so they are never mistaken for a
-    provider table). Any other top-level table is a provider table, with
+    models, runtime, web_search. Dropped routing namespaces system, routes, and
+    profiles are rejected rather than ignored. Any other top-level table is a provider table, with
     sub-tables as model bindings.
 
     Routing layers are intentionally NOT parsed (see {!Runtime_toml} mli):
@@ -104,34 +103,105 @@ let partition_results
 
 (* --- Protocol string -> Runtime_schema.api_format --- *)
 
-let canonical_protocol_of_protocol = function
-  | "messages-cli" | "messages-http" | "openai-compatible-cli"
-  | "openai-compatible-http" | "ollama-http" | "codex-app-server"
-  | "claude-code" | "antigravity-cli" as protocol ->
-    Some protocol
-  | _ -> None
+type editor_transport =
+  | Endpoint
+  | Command
+
+type editor_semantics =
+  | Http_provider
+  | Official_client
+
+type editor_credential_policy =
+  | Credentials_optional
+  | Credentials_forbidden
+
+type editor_protocol =
+  { protocol : string
+  ; transport : editor_transport
+  ; semantics : editor_semantics
+  ; credential_policy : editor_credential_policy
+  ; requires_non_interactive : bool
+  }
+
+type protocol_declaration =
+  { protocol : string
+  ; api_format : Runtime_schema.api_format
+  ; editor : editor_protocol option
+  }
+
+let http_editor protocol =
+  Some
+    { protocol
+    ; transport = Endpoint
+    ; semantics = Http_provider
+    ; credential_policy = Credentials_optional
+    ; requires_non_interactive = false
+    }
+;;
+
+let official_client_editor protocol =
+  Some
+    { protocol
+    ; transport = Command
+    ; semantics = Official_client
+    ; credential_policy = Credentials_forbidden
+    ; requires_non_interactive = true
+    }
+;;
+
+let hidden_protocol protocol api_format =
+  { protocol; api_format; editor = None }
+;;
+
+let http_protocol protocol api_format =
+  { protocol; api_format; editor = http_editor protocol }
+;;
+
+let official_client_protocol protocol api_format =
+  { protocol; api_format; editor = official_client_editor protocol }
+;;
+
+let protocol_declarations =
+  [ hidden_protocol "messages-cli" Runtime_schema.Messages_api
+  ; http_protocol "messages-http" Runtime_schema.Messages_api
+  ; hidden_protocol "openai-compatible-cli" Runtime_schema.Chat_completions_api
+  ; http_protocol
+      "openai-compatible-http"
+      Runtime_schema.Chat_completions_api
+  ; http_protocol "ollama-http" Runtime_schema.Ollama_api
+  ; official_client_protocol
+      "codex-app-server"
+      Runtime_schema.Codex_app_server_runtime
+  ; official_client_protocol "claude-code" Runtime_schema.Claude_code_runtime
+  ; hidden_protocol "antigravity-cli" Runtime_schema.Antigravity_cli_runtime
+  ]
+;;
+
+let protocol_declaration protocol =
+  List.find_opt
+    (fun declaration -> String.equal declaration.protocol protocol)
+    protocol_declarations
+;;
+
+let editor_protocols = List.filter_map (fun declaration -> declaration.editor) protocol_declarations
+
+let canonical_protocol_of_protocol protocol =
+  Option.map (fun declaration -> declaration.protocol) (protocol_declaration protocol)
 ;;
 
 let unknown_protocol_error s =
   Printf.sprintf
-    "unknown protocol %S: expected one of messages-cli, messages-http, \
-     openai-compatible-cli, openai-compatible-http, ollama-http, \
-     codex-app-server, claude-code, antigravity-cli"
+    "unknown protocol %S: expected one of %s"
     s
+    (String.concat ", " (List.map (fun declaration -> declaration.protocol) protocol_declarations))
 ;;
 
 let api_format_of_protocol (s : string)
   : (Runtime_schema.api_format, string) result
   =
-  match s with
-  | "messages-cli" | "messages-http" -> Ok Runtime_schema.Messages_api
-  | "openai-compatible-cli" | "openai-compatible-http" ->
-    Ok Runtime_schema.Chat_completions_api
-  | "ollama-http" -> Ok Runtime_schema.Ollama_api
-  | "codex-app-server" -> Ok Runtime_schema.Codex_app_server_runtime
-  | "antigravity-cli" -> Ok Runtime_schema.Antigravity_cli_runtime
-  | "claude-code" -> Ok Runtime_schema.Claude_code_runtime
-  | _ -> Error (unknown_protocol_error s)
+  match protocol_declaration s with
+  | Some declaration -> Ok declaration.api_format
+  | None -> Error (unknown_protocol_error s)
 ;;
 
 (* --- Transport extraction --- *)
@@ -148,6 +218,45 @@ let transport_of_provider (tbl : Otoml.t) (id : string)
     Error (Printf.sprintf "provider %s: cannot specify both 'endpoint' and 'command'" id)
   | None, None ->
     Error (Printf.sprintf "provider %s: must specify either 'endpoint' or 'command'" id)
+;;
+
+let active_top_level_namespaces = [ "providers"; "models"; "runtime"; "web_search" ]
+let obsolete_top_level_namespaces = [ "system"; "routes"; "profiles" ]
+let reserved_namespaces = active_top_level_namespaces @ obsolete_top_level_namespaces
+let is_reserved name = List.mem name reserved_namespaces
+
+let valid_runtime_id_component value =
+  let length = String.length value in
+  length > 0
+  &&
+  let rec loop index =
+    if index = length
+    then true
+    else (
+      match value.[index] with
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> loop (index + 1)
+      | _ -> false)
+  in
+  loop 0
+;;
+
+let validate_runtime_id_component ~kind ~path value =
+  if not (valid_runtime_id_component value)
+  then
+    Error
+      (error
+         path
+         (Printf.sprintf "%s id must match [A-Za-z0-9_-]+" kind))
+  else if is_reserved value
+  then
+    Error
+      (error
+         path
+         (Printf.sprintf
+            "%s id %S collides with a reserved top-level runtime.toml namespace"
+            kind
+            value))
+  else Ok ()
 ;;
 
 (* --- Layer 1: Providers --- *)
@@ -495,7 +604,18 @@ let parse_providers (toml : Otoml.t)
   | None -> Ok []
   | Some providers_tbl ->
     let entries = Otoml.get_table providers_tbl in
-    partition_results (List.map (fun (id, tbl) -> parse_provider id tbl) entries)
+    partition_results
+      (List.map
+         (fun (id, tbl) ->
+            match
+              validate_runtime_id_component
+                ~kind:"provider"
+                ~path:("providers." ^ id)
+                id
+            with
+            | Error _ as error -> error
+            | Ok () -> parse_provider id tbl)
+         entries)
 ;;
 
 (* --- Layer 2: Models --- *)
@@ -860,20 +980,43 @@ let parse_models (toml : Otoml.t)
   | None -> Ok []
   | Some models_tbl ->
     let entries = Otoml.get_table models_tbl in
-    partition_results (List.map (fun (id, tbl) -> parse_model id tbl) entries)
+    partition_results
+      (List.map
+         (fun (id, tbl) ->
+            match
+              validate_runtime_id_component
+                ~kind:"model"
+                ~path:("models." ^ id)
+                id
+            with
+            | Error _ as error -> error
+            | Ok () -> parse_model id tbl)
+         entries)
 ;;
 
 (* --- Reserved namespace detection --- *)
 
-(* The dropped routing namespaces (system, routes, profiles) remain
-   reserved: keeping them out of the provider-table scan ensures a stale
-   [[routes]]/[[profiles]] table in an existing runtime.toml is silently
-   ignored rather than misread as a provider with bogus model bindings. *)
-let reserved_namespaces =
-  [ "providers"; "models"; "system"; "routes"; "profiles"; "runtime"; "web_search" ]
+let reject_obsolete_top_level_namespaces (toml : Otoml.t)
+  : (unit, parse_error list) result
+  =
+  let top_entries = Otoml.get_table toml in
+  let errors =
+    List.filter_map
+      (fun namespace ->
+         if List.mem_assoc namespace top_entries
+         then
+           Some
+             { path = namespace
+             ; message =
+                 (Printf.sprintf
+                    "obsolete top-level namespace %S is not supported"
+                    namespace)
+             }
+         else None)
+      obsolete_top_level_namespaces
+  in
+  if errors = [] then Ok () else Error errors
 ;;
-
-let is_reserved (name : string) : bool = List.mem name reserved_namespaces
 
 (* --- Layer 3: Bindings from provider tables --- *)
 
@@ -1310,6 +1453,7 @@ let parse_exact_output_lanes (toml : Otoml.t)
 ;;
 
 let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) result =
+  let obsolete_namespaces_result = reject_obsolete_top_level_namespaces toml in
   let providers_result = parse_providers toml in
   let models_result = parse_models toml in
   let runtime_section_result = parse_runtime_section toml in
@@ -1319,7 +1463,8 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
   let exact_output_lanes_result = parse_exact_output_lanes toml in
   let errs = function Ok _ -> [] | Error errs -> errs in
   let all_errors =
-    errs providers_result
+    errs obsolete_namespaces_result
+    @ errs providers_result
     @ errs models_result
     @ errs runtime_section_result
     @ errs assignments_result

--- a/lib/runtime/runtime_toml.mli
+++ b/lib/runtime/runtime_toml.mli
@@ -21,6 +21,31 @@ type parse_error =
   }
 [@@deriving show]
 
+type editor_transport =
+  | Endpoint
+  | Command
+
+type editor_semantics =
+  | Http_provider
+  | Official_client
+
+type editor_credential_policy =
+  | Credentials_optional
+  | Credentials_forbidden
+
+type editor_protocol =
+  { protocol : string
+  ; transport : editor_transport
+  ; semantics : editor_semantics
+  ; credential_policy : editor_credential_policy
+  ; requires_non_interactive : bool
+  }
+
+val editor_protocols : editor_protocol list
+(** Backend-owned protocols that the structured runtime editor may create.
+    Protocols that parse but cannot materialize as a production runtime are
+    deliberately absent. *)
+
 val parse_string : string -> (Runtime_schema.config, parse_error list) result
 (** Parse a TOML string into a Runtime config.
     Returns [Ok config] on success, [Error errors] with all

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -184,6 +184,31 @@ let handle_execute_output_stream ~sw ~clock request reqd =
     request
     reqd
 
+let runtime_editor_protocol_json (protocol : Runtime_toml.editor_protocol) =
+  let transport =
+    match protocol.transport with
+    | Runtime_toml.Endpoint -> "endpoint"
+    | Runtime_toml.Command -> "command"
+  in
+  let semantics =
+    match protocol.semantics with
+    | Runtime_toml.Http_provider -> "http_provider"
+    | Runtime_toml.Official_client -> "official_client"
+  in
+  let credential_policy =
+    match protocol.credential_policy with
+    | Runtime_toml.Credentials_optional -> "optional"
+    | Runtime_toml.Credentials_forbidden -> "forbidden"
+  in
+  `Assoc
+    [ "protocol", `String protocol.protocol
+    ; "transport", `String transport
+    ; "semantics", `String semantics
+    ; "credential_policy", `String credential_policy
+    ; "requires_non_interactive", `Bool protocol.requires_non_interactive
+    ]
+;;
+
 let runtime_config_raw_json ~path ~source_text ~reloaded =
   `Assoc
     [ ("ok", `Bool true)
@@ -191,6 +216,8 @@ let runtime_config_raw_json ~path ~source_text ~reloaded =
     ; ("file_name", `String "runtime.toml")
     ; ("source_text", `String source_text)
     ; ("reloaded", `Bool reloaded)
+    ; ( "provider_protocols"
+      , `List (List.map runtime_editor_protocol_json Runtime_toml.editor_protocols) )
     ]
 
 (* Line count for the audit [lines] metric. [String.split_on_char '\n'] counts a

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -366,6 +366,86 @@ max-concurrent = 1
                   claude-code, antigravity-cli")
          errors)
 
+let test_runtime_toml_editor_protocol_inventory_is_backend_owned () =
+  let render (protocol : Runtime_toml.editor_protocol) =
+    let transport =
+      match protocol.transport with
+      | Runtime_toml.Endpoint -> "endpoint"
+      | Runtime_toml.Command -> "command"
+    in
+    let semantics =
+      match protocol.semantics with
+      | Runtime_toml.Http_provider -> "http_provider"
+      | Runtime_toml.Official_client -> "official_client"
+    in
+    let credential_policy =
+      match protocol.credential_policy with
+      | Runtime_toml.Credentials_optional -> "optional"
+      | Runtime_toml.Credentials_forbidden -> "forbidden"
+    in
+    Printf.sprintf
+      "%s:%s:%s:%s:%b"
+      protocol.protocol
+      transport
+      semantics
+      credential_policy
+      protocol.requires_non_interactive
+  in
+  check
+    (list string)
+    "only production-materializable protocols are offered"
+    [ "messages-http:endpoint:http_provider:optional:false"
+    ; "openai-compatible-http:endpoint:http_provider:optional:false"
+    ; "ollama-http:endpoint:http_provider:optional:false"
+    ; "codex-app-server:command:official_client:forbidden:true"
+    ; "claude-code:command:official_client:forbidden:true"
+    ]
+    (List.map render Runtime_toml.editor_protocols)
+;;
+
+let test_runtime_toml_rejects_reserved_provider_and_model_ids () =
+  let cases =
+    [ ( "provider"
+      , "providers.runtime"
+      , {|
+[providers.runtime]
+display-name = "Reserved"
+protocol = "openai-compatible-http"
+endpoint = "https://example.invalid/v1"
+|} )
+    ; ( "model"
+      , "models.routes"
+      , {|
+[models.routes]
+api-name = "reserved"
+max-context = 1024
+|} )
+    ]
+  in
+  List.iter
+    (fun (kind, path, content) ->
+       match Runtime_toml.parse_string content with
+       | Ok _ -> failf "expected reserved %s id to fail" kind
+       | Error errors -> check_parse_error_contains errors path "reserved top-level")
+    cases
+;;
+
+let test_runtime_toml_rejects_obsolete_top_level_namespaces () =
+  List.iter
+    (fun namespace ->
+       let content = Printf.sprintf "[%s]\nlegacy = true\n" namespace in
+       match Runtime_toml.parse_string content with
+       | Ok _ -> failf "expected obsolete namespace %s to fail" namespace
+       | Error errors ->
+         check_parse_error
+           errors
+           namespace
+           (Printf.sprintf
+              "obsolete top-level namespace %S is not supported"
+              namespace))
+    [ "system"; "routes"; "profiles" ]
+;;
+
 let test_runtime_toml_accepts_messages_caching_capability () =
   let content =
     {|
@@ -1897,6 +1977,18 @@ let () =
             "runtime TOML rejects legacy protocol aliases"
             `Quick
             test_runtime_toml_rejects_legacy_protocol_aliases
+        ; test_case
+            "runtime TOML editor protocol inventory is backend-owned"
+            `Quick
+            test_runtime_toml_editor_protocol_inventory_is_backend_owned
+        ; test_case
+            "runtime TOML rejects reserved provider and model ids"
+            `Quick
+            test_runtime_toml_rejects_reserved_provider_and_model_ids
+        ; test_case
+            "runtime TOML rejects obsolete top-level namespaces"
+            `Quick
+            test_runtime_toml_rejects_obsolete_top_level_namespaces
         ; test_case
             "runtime TOML reads uses-messages-caching capability"
             `Quick


### PR DESCRIPTION
## Summary
- expose `codex-app-server` as a typed runtime kind in the dashboard editor
- edit the CLI path, model, timeout, and maximum context without credential fields
- preserve runtime assignments and ordered fallback configuration in generated `runtime.toml`

## Verification
- focused dashboard tests: 92 passed across runtime TOML parsing, editor, and environment editor
- dashboard TypeScript typecheck passed
- dashboard ESLint passed

## Boundaries
- no API-key fields or fallback
- this PR is configuration UI only; session status and recovery controls follow in separate PRs