### PR TITLE
feat: add Dashboard checkpoint purge

### DIFF
--- a/dashboard/src/api/keeper-lifecycle.ts
+++ b/dashboard/src/api/keeper-lifecycle.ts
@@ -260,6 +260,32 @@ interface KeeperCheckpointDeleteResponse {
   inventory: KeeperCheckpointInventory
 }
 
+export interface KeeperCheckpointPurgeReport {
+  messages_before: number
+  messages_after: number
+  bytes_before: number
+  bytes_after: number
+  bytes_removed: number
+  duplicates_dropped: number
+  reasoning_blocks_stripped: number
+  reasoning_messages_dropped: number
+  tool_results_cleared: number
+}
+
+export interface KeeperCheckpointPurgeResponse {
+  schema: 'masc.keeper_checkpoint_purge.v1'
+  ok: true
+  action: 'preview_purge' | 'apply_purge'
+  keeper: string
+  trace_id: string
+  apply_allowed: boolean
+  applied: boolean
+  backup_path: string | null
+  report: KeeperCheckpointPurgeReport
+  warnings: string[]
+  inventory: KeeperCheckpointInventory
+}
+
 export async function fetchKeeperCheckpoints(
   name: string,
 ): Promise<KeeperCheckpointInventory> {
@@ -298,6 +324,42 @@ export async function deleteKeeperHistorySnapshots(
     throw new Error(`${name} 의 checkpoint history 삭제 실패 (${resp.status}): ${text}`)
   }
   return resp.json() as Promise<KeeperCheckpointDeleteResponse>
+}
+
+async function requestKeeperCheckpointPurge(
+  name: string,
+  action: 'preview_purge' | 'apply_purge',
+): Promise<KeeperCheckpointPurgeResponse> {
+  const path = `/api/v1/keepers/${encodeURIComponent(name)}/checkpoints`
+  const resp = await fetchControlPlane(path, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify({ action }),
+  })
+  if (!resp.ok) {
+    const payload = await safeJsonResponse<{ error?: string }>(
+      resp,
+      `${name} checkpoint purge 실패`,
+    )
+    throw new Error(
+      typeof payload.error === 'string' && payload.error.trim() !== ''
+        ? payload.error
+        : `${name} checkpoint purge 실패 (HTTP ${resp.status})`,
+    )
+  }
+  return resp.json() as Promise<KeeperCheckpointPurgeResponse>
+}
+
+export function previewKeeperCheckpointPurge(
+  name: string,
+): Promise<KeeperCheckpointPurgeResponse> {
+  return requestKeeperCheckpointPurge(name, 'preview_purge')
+}
+
+export function applyKeeperCheckpointPurge(
+  name: string,
+): Promise<KeeperCheckpointPurgeResponse> {
+  return requestKeeperCheckpointPurge(name, 'apply_purge')
 }
 
 export function pauseKeeper(

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -50,12 +50,14 @@ import {
   wakeKeeper,
 } from './keeper'
 import {
+  applyKeeperCheckpointPurge as applyKeeperCheckpointPurgeFromLifecycle,
   bootKeeper as bootKeeperFromLifecycle,
   bulkKeeperDirective as bulkKeeperDirectiveFromLifecycle,
   clearKeeper as clearKeeperFromLifecycle,
   deleteKeeperHistorySnapshots as deleteKeeperHistorySnapshotsFromLifecycle,
   fetchKeeperCheckpoints as fetchKeeperCheckpointsFromLifecycle,
   pauseKeeper as pauseKeeperFromLifecycle,
+  previewKeeperCheckpointPurge as previewKeeperCheckpointPurgeFromLifecycle,
   resetKeeper as resetKeeperFromLifecycle,
   resumeKeeper as resumeKeeperFromLifecycle,
   shutdownKeeper as shutdownKeeperFromLifecycle,
@@ -1803,6 +1805,65 @@ describe('keeper lifecycle', () => {
       snapshot_ids: ['oas-snapshot-1.json'],
     })
     expect(result.deleted_snapshot_ids).toEqual(['oas-snapshot-1.json'])
+  })
+
+  it('previews and applies current checkpoint purge through the same admin route', async () => {
+    const responseFor = (action: 'preview_purge' | 'apply_purge') => ({
+      schema: 'masc.keeper_checkpoint_purge.v1',
+      ok: true,
+      action,
+      keeper: 'keeper-test',
+      trace_id: 'trace-keeper-test',
+      apply_allowed: true,
+      applied: action === 'apply_purge',
+      backup_path: action === 'apply_purge' ? '/tmp/backup.json' : null,
+      report: {
+        messages_before: 10,
+        messages_after: 8,
+        bytes_before: 2048,
+        bytes_after: 1024,
+        bytes_removed: 1024,
+        duplicates_dropped: 2,
+        reasoning_blocks_stripped: 1,
+        reasoning_messages_dropped: 0,
+        tool_results_cleared: 3,
+      },
+      warnings: [],
+      inventory: {
+        keeper: 'keeper-test',
+        trace_id: 'trace-keeper-test',
+        session_dir: '/tmp/trace-keeper-test',
+        current: null,
+        current_status: 'missing',
+        current_error: null,
+        history: [],
+        history_errors: [],
+      },
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(responseFor('preview_purge')), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(responseFor('apply_purge')), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const preview = await previewKeeperCheckpointPurgeFromLifecycle('keeper-test')
+    const applied = await applyKeeperCheckpointPurgeFromLifecycle('keeper-test')
+
+    expect(preview.applied).toBe(false)
+    expect(applied.applied).toBe(true)
+    expect(applied.backup_path).toBe('/tmp/backup.json')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    for (const [index, action] of ['preview_purge', 'apply_purge'].entries()) {
+      const [url, init] = fetchMock.mock.calls[index]! as [string, RequestInit]
+      expect(url).toBe('/api/v1/keepers/keeper-test/checkpoints')
+      expect(init.method).toBe('POST')
+      expect(JSON.parse(String(init.body))).toEqual({ action })
+    }
   })
 
   it('sends POST with action=pause via directive endpoint', async () => {

--- a/dashboard/src/components/keeper-detail-history.test.ts
+++ b/dashboard/src/components/keeper-detail-history.test.ts
@@ -3,6 +3,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { render } from "preact"
 import { act } from "preact/test-utils"
 import { html } from "htm/preact"
+
+const { requestConfirmMock } = vi.hoisted(() => ({
+  requestConfirmMock: vi.fn(async () => true),
+}))
+
+vi.mock("./common/confirm-dialog", () => ({
+  requestConfirm: requestConfirmMock,
+}))
+
+beforeEach(() => {
+  requestConfirmMock.mockClear()
+})
 import {
   filterCheckpointHistory,
   KeeperCheckpointPanel,
@@ -130,6 +142,112 @@ describe("KeeperCheckpointPanel diagnostics", () => {
       expect(container.textContent).toContain("history-broken.json")
       expect(container.textContent).toContain("io_error")
       expect(container.textContent).not.toContain("저장된 checkpoint 없음")
+    } finally {
+      render(null, container)
+      document.body.removeChild(container)
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("previews then applies checkpoint purge with exact report and backup evidence", async () => {
+    const inventory = {
+      keeper: "keeper-test",
+      trace_id: "trace-test",
+      session_dir: "/tmp/trace-test",
+      current: {
+        snapshot_id: "trace-test.json",
+        source_kind: "oas_current",
+        is_current: true,
+        status: "available",
+        path: "/tmp/trace-test/trace-test.json",
+        created_at: 1700000000,
+        generation: 1,
+        message_count: 916,
+        system_prompt_present: true,
+        latest_preview: "latest",
+        file_stat: { size_bytes: 2367244, mtime: 1700000000 },
+      },
+      current_status: "available",
+      current_error: null,
+      history: [],
+      history_errors: [],
+    }
+    const purgeResponse = (action: "preview_purge" | "apply_purge") => ({
+      schema: "masc.keeper_checkpoint_purge.v1",
+      ok: true,
+      action,
+      keeper: "keeper-test",
+      trace_id: "trace-test",
+      apply_allowed: true,
+      applied: action === "apply_purge",
+      backup_path: action === "apply_purge" ? "/tmp/backups/trace-test.json" : null,
+      report: {
+        messages_before: 916,
+        messages_after: 857,
+        bytes_before: 2367244,
+        bytes_after: 1129051,
+        bytes_removed: 1238193,
+        duplicates_dropped: 59,
+        reasoning_blocks_stripped: 46,
+        reasoning_messages_dropped: 0,
+        tool_results_cleared: 437,
+      },
+      warnings: [],
+      inventory,
+    })
+    const requests: Array<{ url: string; body: unknown }> = []
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input, init) => {
+      const url = String(input)
+      const body = init?.body ? JSON.parse(String(init.body)) : null
+      requests.push({ url, body })
+      const payload = body?.action === "preview_purge"
+        ? purgeResponse("preview_purge")
+        : body?.action === "apply_purge"
+          ? purgeResponse("apply_purge")
+          : inventory
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    }
+
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    try {
+      await act(async () => {
+        render(
+          html`<${KeeperCheckpointPanel}
+            keeperName="keeper-test"
+            refreshToken=${0}
+          />`,
+          container,
+        )
+      })
+      await vi.waitFor(() => {
+        expect(container.querySelector('[data-testid="keeper-checkpoint-purge-preview"]')).toBeTruthy()
+      })
+
+      await act(async () => {
+        ;(container.querySelector('[data-testid="keeper-checkpoint-purge-preview"]') as HTMLButtonElement).click()
+      })
+      await vi.waitFor(() => {
+        expect(container.querySelector('[data-testid="keeper-checkpoint-purge-report"]')?.textContent).toContain("437")
+      })
+
+      await act(async () => {
+        ;(container.querySelector('[data-testid="keeper-checkpoint-purge-apply"]') as HTMLButtonElement).click()
+      })
+      await vi.waitFor(() => {
+        expect(container.querySelector('[data-testid="keeper-checkpoint-purge-backup"]')?.textContent).toContain("/tmp/backups/trace-test.json")
+      })
+
+      expect(requestConfirmMock).toHaveBeenCalledTimes(1)
+      expect(requests.map(request => request.body)).toEqual([
+        null,
+        { action: "preview_purge" },
+        { action: "apply_purge" },
+      ])
     } finally {
       render(null, container)
       document.body.removeChild(container)

--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -4,13 +4,16 @@ import { unixSecondsToDate } from '../lib/format-time'
 import { ActionButton } from './common/button'
 import { requestConfirm } from './common/confirm-dialog'
 import {
+  applyKeeperCheckpointPurge,
   deleteKeeperHistorySnapshots,
   fetchKeeperCheckpoints,
+  previewKeeperCheckpointPurge,
   type KeeperCheckpointCurrentError,
   type KeeperCheckpointHistoryError,
   type KeeperCheckpointInventory,
+  type KeeperCheckpointPurgeResponse,
   type KeeperCheckpointSummary,
-} from '../api/keeper'
+} from '../api/keeper-lifecycle'
 import { TextInput } from './common/input'
 import { Checkbox } from './common/checkbox'
 import { showToast } from './common/toast'
@@ -30,6 +33,12 @@ function formatCheckpointTime(timestamp: number): string {
   return unixSecondsToDate(timestamp).toLocaleString('ko-KR', {
     hour12: false,
   })
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '-'
+  if (bytes < 1024) return `${bytes} B`
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`
 }
 
 /**
@@ -167,6 +176,8 @@ export function KeeperCheckpointPanel({
   const [selectedIds, setSelectedIds] = useState<string[]>([])
   const [deleting, setDeleting] = useState(false)
   const [historyQuery, setHistoryQuery] = useState('')
+  const [purgePreview, setPurgePreview] = useState<KeeperCheckpointPurgeResponse | null>(null)
+  const [purgePending, setPurgePending] = useState<'preview' | 'apply' | null>(null)
 
   const loadInventory = () => {
     void (async () => {
@@ -189,6 +200,7 @@ export function KeeperCheckpointPanel({
   useEffect(() => {
     setInventory(null)
     setSelectedIds([])
+    setPurgePreview(null)
     loadInventory()
   }, [keeperName, refreshToken])
 
@@ -227,6 +239,53 @@ export function KeeperCheckpointPanel({
         showToast(err instanceof Error ? err.message : 'snapshot 삭제 실패', 'error')
       } finally {
         setDeleting(false)
+      }
+    })()
+  }
+
+  const previewPurge = () => {
+    void (async () => {
+      setPurgePending('preview')
+      try {
+        const result = await previewKeeperCheckpointPurge(keeperName)
+        setPurgePreview(result)
+        setInventory(result.inventory)
+      } catch (err) {
+        showToast(err instanceof Error ? err.message : 'checkpoint purge 미리보기 실패', 'error')
+      } finally {
+        setPurgePending(null)
+      }
+    })()
+  }
+
+  const applyPurge = () => {
+    void (async () => {
+      if (!purgePreview) return
+      const report = purgePreview.report
+      const confirmed = await requestConfirm({
+        title: '현재 checkpoint 청소',
+        message: `${keeperName}의 현재 checkpoint를 ${formatBytes(report.bytes_before)} → ${formatBytes(report.bytes_after)}로 정리합니다.\n원본은 byte-exact backup으로 먼저 저장됩니다.`,
+        tone: 'danger',
+        confirmText: '백업 후 청소',
+      })
+      if (!confirmed) return
+      setPurgePending('apply')
+      try {
+        const result = await applyKeeperCheckpointPurge(keeperName)
+        setPurgePreview(result)
+        setInventory(result.inventory)
+        if (result.applied) {
+          const warningSuffix = result.warnings.length > 0
+            ? ` · 경고 ${result.warnings.length}건`
+            : ''
+          showToast(`checkpoint 청소 완료 · ${formatBytes(result.report.bytes_removed)} 감소${warningSuffix}`, 'success')
+        } else {
+          showToast('checkpoint는 이미 정리된 상태입니다', 'success')
+        }
+      } catch (err) {
+        showToast(err instanceof Error ? err.message : 'checkpoint purge 적용 실패', 'error')
+      } finally {
+        setPurgePending(null)
       }
     })()
   }
@@ -291,6 +350,63 @@ export function KeeperCheckpointPanel({
         status=${inventory.current_status}
         error=${inventory.current_error}
       />
+
+      <div
+        class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-3 v2-monitoring-panel"
+        data-testid="keeper-checkpoint-purge"
+      >
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">현재 checkpoint 청소</div>
+            <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
+              닫힌 tool 결과, unsigned reasoning, 반복 메시지만 정리합니다. 대화 구조와 최근 20개 메시지는 보존합니다.
+            </div>
+          </div>
+          <div class="flex flex-wrap items-center gap-2">
+            <${ActionButton}
+              variant="ghost"
+              size="md"
+              disabled=${purgePending !== null || inventory.current_status !== 'available'}
+              ariaBusy=${purgePending === 'preview'}
+              testId="keeper-checkpoint-purge-preview"
+              onClick=${previewPurge}
+            >${purgePending === 'preview' ? '계산 중...' : '정리 미리보기'}<//>
+            <${ActionButton}
+              variant="danger"
+              size="md"
+              disabled=${
+                purgePending !== null
+                || !purgePreview
+                || !purgePreview.apply_allowed
+                || purgePreview.report.bytes_removed <= 0
+              }
+              ariaBusy=${purgePending === 'apply'}
+              testId="keeper-checkpoint-purge-apply"
+              onClick=${applyPurge}
+            >${purgePending === 'apply' ? '청소 중...' : '백업 후 청소'}<//>
+          </div>
+        </div>
+
+        ${purgePreview
+          ? html`
+              <div class="mt-3 grid grid-cols-2 gap-2 text-2xs md:grid-cols-4" data-testid="keeper-checkpoint-purge-report">
+                <div><span class="text-[var(--color-fg-muted)]">크기</span><div class="mt-0.5 font-mono text-[var(--color-fg-primary)]">${formatBytes(purgePreview.report.bytes_before)} → ${formatBytes(purgePreview.report.bytes_after)}</div></div>
+                <div><span class="text-[var(--color-fg-muted)]">tool 결과</span><div class="mt-0.5 font-mono text-[var(--color-fg-primary)]">${purgePreview.report.tool_results_cleared}</div></div>
+                <div><span class="text-[var(--color-fg-muted)]">reasoning</span><div class="mt-0.5 font-mono text-[var(--color-fg-primary)]">${purgePreview.report.reasoning_blocks_stripped}</div></div>
+                <div><span class="text-[var(--color-fg-muted)]">반복 메시지</span><div class="mt-0.5 font-mono text-[var(--color-fg-primary)]">${purgePreview.report.duplicates_dropped}</div></div>
+              </div>
+              ${!purgePreview.apply_allowed
+                ? html`<div class="mt-3 rounded-[var(--r-1)] border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-2xs text-[var(--color-fg-muted)]" role="status">적용하려면 먼저 상단의 종료 버튼으로 Keeper를 완전히 종료하세요. 미리보기는 현재 상태에서도 안전합니다.</div>`
+                : null}
+              ${purgePreview.backup_path
+                ? html`<div class="mt-3 break-all font-mono text-3xs text-[var(--color-fg-muted)]" data-testid="keeper-checkpoint-purge-backup">backup: ${purgePreview.backup_path}</div>`
+                : null}
+              ${purgePreview.warnings.length > 0
+                ? html`<div class="mt-3 rounded-[var(--r-1)] border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-2 text-2xs text-[var(--rose-light)]" role="alert">${purgePreview.warnings.join(' · ')}</div>`
+                : null}
+            `
+          : null}
+      </div>
 
       <${CheckpointHistoryFailures} failures=${inventory.history_errors} />
 

--- a/docs/CHECKPOINT-PURGE-RUNBOOK.md
+++ b/docs/CHECKPOINT-PURGE-RUNBOOK.md
@@ -1,9 +1,9 @@
 # Checkpoint Purge Runbook (RFC-0351 S1)
 
 RFC-0351:105 requires the operational cleanup procedure (backup included) to
-be documented before S2. This runbook covers `masc-checkpoint-purge`
-(#25537): the deterministic offline reduction of a keeper's canonical OAS
-checkpoint. No LLM is involved at any step.
+be documented before S2. This runbook covers the Dashboard action and
+`masc-checkpoint-purge` (#25537): the deterministic reduction of a stopped
+keeper's canonical OAS checkpoint. No LLM is involved at any step.
 
 ## What the tool does
 
@@ -23,6 +23,19 @@ the write boundary). `session_id`/`turn_count` are unchanged, so the save
 lands as an equal-watermark re-save through the locked validated store.
 
 ## Procedure
+
+### Dashboard
+
+1. Open the Keeper detail view and expand **Checkpoint & Snapshots**.
+2. Select **정리 미리보기**. Preview is read-only and may run while the
+   Keeper is active.
+3. Stop the Keeper completely, preview again, then select **백업 후 청소**.
+   Apply is unavailable while the Keeper is registered. The server takes the
+   same lifecycle key used by boot, writes and reads back a byte-exact backup,
+   then installs only against the exact checkpoint source reference it read.
+4. Keep the displayed backup path until the Keeper completes a healthy turn.
+
+### CLI
 
 1. **Confirm the keeper is stopped.** `masc_keeper_list` — the keeper must
    not be `active`/`keepalive_running`. A live keeper's next save overwrites
@@ -112,9 +125,9 @@ a decision before it is added.
 
 ## Relation to the sanctioned pipeline
 
-This tool is a one-shot operational lever, not a runtime mechanism: the
+Purge is an explicit operator action, not an automatic runtime mechanism. The
 runtime path stays compaction (until RFC-0351 S4 retires it) plus the S0
 settlement ceilings (#25536, #25541, #25544). If a purge is needed twice on
 the same keeper, that is a signal the inflow paths (#25462 wake markers,
-oversized tool results) are not closed — fix the inflow, do not schedule
-the purge.
+oversized tool results) are not closed — fix the inflow, do not schedule the
+purge.

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -89,6 +89,7 @@
   masc.attribution
   masc.exec_policy
   masc.keeper_registry
+  masc.keeper_checkpoint_ref
   masc.keeper_metrics
   masc.keeper_types
   masc.keeper_runtime

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -148,7 +148,7 @@ val state_diagram_runtime_fsm_mermaid :
 val handle_keeper_checkpoints_post :
   Mcp_server.server_state ->
   Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
-(** Handle [POST /checkpoints] (rollback / pin actions). *)
+(** Handle admin [POST /checkpoints] history deletion and checkpoint purge. *)
 
 (** {1 Keeper name validation} *)
 

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
@@ -187,6 +187,356 @@ let inventory_json (config : Workspace.config) (name : string)
         ] )
 ;;
 
+type purge_report =
+  { messages_before : int
+  ; messages_after : int
+  ; bytes_before : int
+  ; bytes_after : int
+  ; duplicates_dropped : int
+  ; reasoning_blocks_stripped : int
+  ; reasoning_messages_dropped : int
+  ; tool_results_cleared : int
+  }
+
+type purge_result =
+  { keeper : string
+  ; trace_id : string
+  ; apply_allowed : bool
+  ; applied : bool
+  ; backup_path : string option
+  ; report : purge_report
+  ; warnings : string list
+  }
+
+type purge_error =
+  | Purge_invalid_keeper_name of string
+  | Purge_keeper_not_found of string
+  | Purge_keeper_active of string
+  | Purge_checkpoint_unavailable of string
+  | Purge_checkpoint_invalid of string
+  | Purge_backup_failed of string
+  | Purge_source_changed
+  | Purge_install_failed of string
+
+let purge_error_to_string = function
+  | Purge_invalid_keeper_name keeper ->
+    Printf.sprintf "invalid keeper name: %s" keeper
+  | Purge_keeper_not_found keeper ->
+    Printf.sprintf "keeper %S not found" keeper
+  | Purge_keeper_active keeper ->
+    Printf.sprintf
+      "keeper %S is still registered; shut it down completely before applying checkpoint purge"
+      keeper
+  | Purge_checkpoint_unavailable detail ->
+    "checkpoint unavailable: " ^ detail
+  | Purge_checkpoint_invalid detail ->
+    "checkpoint purge refused: " ^ detail
+  | Purge_backup_failed detail ->
+    "checkpoint backup failed: " ^ detail
+  | Purge_source_changed ->
+    "checkpoint changed after preview; preview the current checkpoint again"
+  | Purge_install_failed detail ->
+    "checkpoint purge install failed: " ^ detail
+;;
+
+let checkpoint_load_error_to_string = function
+  | Keeper_checkpoint_store.Not_found -> "not found"
+  | Store_error detail -> "store error: " ^ detail
+  | Parse_error detail -> "parse error: " ^ detail
+  | Io_error detail -> "io error: " ^ detail
+  | Sdk_other_error detail -> "sdk error: " ^ detail
+;;
+
+let checkpoint_ref_create_error_to_string = function
+  | Keeper_checkpoint_ref.Negative_generation value ->
+    Printf.sprintf "negative generation %d" value
+  | Negative_turn_count value ->
+    Printf.sprintf "negative turn count %d" value
+  | Invalid_sha256 value ->
+    Printf.sprintf "invalid checkpoint sha256 %S" value
+;;
+
+let checkpoint_identity_error_to_string = function
+  | Keeper_checkpoint_store.Session_id_invalid detail ->
+    "invalid session id: " ^ detail
+  | Generation_missing -> "checkpoint generation missing"
+  | Generation_not_integer -> "checkpoint generation is not an integer"
+  | Ref_create_failed error -> checkpoint_ref_create_error_to_string error
+;;
+
+let checkpoint_ref_load_error_to_string = function
+  | Keeper_checkpoint_store.Ref_not_found -> "not found"
+  | Ref_read_failed error -> checkpoint_load_error_to_string error
+  | Ref_identity_invalid error -> checkpoint_identity_error_to_string error
+  | Ref_session_mismatch { expected; actual } ->
+    Printf.sprintf
+      "session mismatch expected=%s actual=%s"
+      (Keeper_id.Trace_id.to_string expected)
+      (Keeper_id.Trace_id.to_string actual)
+  | Ref_lock_failed detail -> "checkpoint lock failed: " ^ detail
+;;
+
+let checkpoint_cas_error_to_string = function
+  | Keeper_checkpoint_store.Source_unavailable error ->
+    "source unavailable: " ^ checkpoint_ref_load_error_to_string error
+  | Source_changed _ -> "source changed"
+  | Candidate_identity_invalid error ->
+    "candidate identity invalid: " ^ checkpoint_identity_error_to_string error
+  | Candidate_session_mismatch { expected; candidate } ->
+    Printf.sprintf
+      "candidate session mismatch expected=%s candidate=%s"
+      (Keeper_id.Trace_id.to_string expected)
+      (Keeper_id.Trace_id.to_string candidate)
+  | Candidate_generation_mismatch { expected; candidate } ->
+    Printf.sprintf
+      "candidate generation mismatch expected=%d candidate=%d"
+      expected
+      candidate
+  | Candidate_turn_regressed { source_turn; candidate_turn } ->
+    Printf.sprintf
+      "candidate turn regressed source=%d candidate=%d"
+      source_turn
+      candidate_turn
+  | Commit_not_installed error -> Keeper_fs.durable_write_error_to_string error
+;;
+
+let exception_detail (exn, _backtrace) = Printexc.to_string exn
+
+let checkpoint_installation_auxiliary_to_string = function
+  | Keeper_checkpoint_store.Commit_durability_unknown error ->
+    "commit durability unknown: " ^ Keeper_fs.durable_write_error_to_string error
+  | Commit_observer_failed failure ->
+    "commit observer failed: " ^ exception_detail failure
+  | Release_process_lock_failed error ->
+    "checkpoint lock release failed: "
+    ^ File_lock_eio.durable_lock_error_to_string error
+  | Post_commit_unwind_interrupted failure ->
+    "post-commit unwind interrupted: " ^ exception_detail failure
+  | History_write_failed failure ->
+    "history write failed: " ^ exception_detail failure
+;;
+
+let purge_report_json report =
+  `Assoc
+    [ "messages_before", `Int report.messages_before
+    ; "messages_after", `Int report.messages_after
+    ; "bytes_before", `Int report.bytes_before
+    ; "bytes_after", `Int report.bytes_after
+    ; "bytes_removed", `Int (report.bytes_before - report.bytes_after)
+    ; "duplicates_dropped", `Int report.duplicates_dropped
+    ; "reasoning_blocks_stripped", `Int report.reasoning_blocks_stripped
+    ; "reasoning_messages_dropped", `Int report.reasoning_messages_dropped
+    ; "tool_results_cleared", `Int report.tool_results_cleared
+    ]
+;;
+
+let purge_result_json ~action result =
+  `Assoc
+    [ "schema", `String "masc.keeper_checkpoint_purge.v1"
+    ; "ok", `Bool true
+    ; "action", `String action
+    ; "keeper", `String result.keeper
+    ; "trace_id", `String result.trace_id
+    ; "apply_allowed", `Bool result.apply_allowed
+    ; "applied", `Bool result.applied
+    ; "backup_path", Json_util.string_opt_to_json result.backup_path
+    ; "report", purge_report_json result.report
+    ; "warnings", Json_util.json_string_list result.warnings
+    ]
+;;
+
+let backup_path_for_source ~config ~trace_id
+      (source_ref : Keeper_checkpoint_ref.t) =
+  let backup_dir =
+    Filename.concat
+      (Workspace.masc_root_dir config)
+      (Printf.sprintf
+         "backups-checkpoint-purge-%s-%s"
+         trace_id
+         source_ref.sha256)
+  in
+  Filename.concat backup_dir (trace_id ^ ".json")
+;;
+
+let ensure_exact_backup ~config ~trace_id ~source_ref source_bytes =
+  let backup_path = backup_path_for_source ~config ~trace_id source_ref in
+  let read_back () =
+    try Ok (Fs_compat.load_file backup_path) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
+  in
+  match Fs_compat.load_file_opt backup_path with
+  | Some existing when String.equal existing source_bytes -> Ok backup_path
+  | Some _ ->
+    Error
+      (Printf.sprintf
+         "existing backup content does not match source ref %s"
+         source_ref.sha256)
+  | None ->
+    (match
+       Keeper_fs.save_bytes_durable_atomic
+         ~ownership_root:(Workspace.masc_root_dir config)
+         backup_path
+         source_bytes
+     with
+     | Error error -> Error (Keeper_fs.durable_write_error_to_string error)
+     | Ok () ->
+       (match read_back () with
+        | Ok exact when String.equal exact source_bytes -> Ok backup_path
+        | Ok _ -> Error "backup exact read-back mismatch"
+        | Error detail -> Error ("backup read-back failed: " ^ detail)))
+;;
+
+let checkpoint_purge_error_to_string = function
+  | Keeper_checkpoint_purge.Invalid_config detail -> "invalid config: " ^ detail
+  | Invalid_input_structure structural ->
+    Keeper_compaction_unit.show_structural_error structural
+  | Invalid_output_structure structural ->
+    "purge produced invalid structure: "
+    ^ Keeper_compaction_unit.show_structural_error structural
+;;
+
+let purge_current_unlocked config ~keeper_name ~apply =
+  match Keeper_meta_store.read_meta_resolved config keeper_name with
+  | Error detail -> Error (Purge_checkpoint_unavailable detail)
+  | Ok None -> Error (Purge_keeper_not_found keeper_name)
+  | Ok (Some (_, meta)) ->
+    if apply
+       && Keeper_registry.is_registered
+            ~base_path:config.Workspace.base_path
+            keeper_name
+    then Error (Purge_keeper_active keeper_name)
+    else
+      let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+      let session_dir = Keeper_types_support.keeper_session_dir config trace_id in
+      (match
+         Keeper_checkpoint_store.load_oas_exact_snapshot
+           ~session_dir
+           ~session_id:trace_id
+       with
+       | Error error ->
+         Error
+           (Purge_checkpoint_unavailable
+              (checkpoint_ref_load_error_to_string error))
+       | Ok snapshot ->
+         let source_ref = Keeper_checkpoint_store.exact_snapshot_reference snapshot in
+         let source_bytes =
+           Keeper_checkpoint_store.exact_snapshot_canonical_bytes snapshot
+         in
+         let purge_result =
+           Domain_pool_ref.submit_cpu_or_inline (fun () ->
+             match Agent_sdk.Checkpoint.of_string source_bytes with
+             | Error error ->
+               Error
+                 (Purge_checkpoint_invalid
+                    (Agent_sdk.Error.to_string error))
+             | Ok checkpoint ->
+               (match
+                  Keeper_checkpoint_purge.purge
+                    ~config:Keeper_checkpoint_purge.default_config
+                    checkpoint
+                with
+                | Error error ->
+                  Error
+                    (Purge_checkpoint_invalid
+                       (checkpoint_purge_error_to_string error))
+                | Ok (purged, purge_report) ->
+                  let purged_bytes = Agent_sdk.Checkpoint.to_string purged in
+                  Ok (purged, purged_bytes, purge_report)))
+         in
+         (match purge_result with
+          | Error _ as error -> error
+          | Ok (purged, purged_bytes, raw_report) ->
+            let report =
+              { messages_before = raw_report.messages_before
+              ; messages_after = raw_report.messages_after
+              ; bytes_before = String.length source_bytes
+              ; bytes_after = String.length purged_bytes
+              ; duplicates_dropped = raw_report.duplicates_dropped
+              ; reasoning_blocks_stripped = raw_report.reasoning_blocks_stripped
+              ; reasoning_messages_dropped = raw_report.reasoning_messages_dropped
+              ; tool_results_cleared = raw_report.tool_results_cleared
+              }
+            in
+            let apply_allowed =
+              not
+                (Keeper_registry.is_registered
+                   ~base_path:config.Workspace.base_path
+                   keeper_name)
+            in
+            if not apply
+            then
+              Ok
+                { keeper = keeper_name
+                ; trace_id
+                ; apply_allowed
+                ; applied = false
+                ; backup_path = None
+                ; report
+                ; warnings = []
+                }
+            else if String.equal source_bytes purged_bytes
+            then
+              Ok
+                { keeper = keeper_name
+                ; trace_id
+                ; apply_allowed = true
+                ; applied = false
+                ; backup_path = None
+                ; report
+                ; warnings = []
+                }
+            else
+              (match
+                 ensure_exact_backup
+                   ~config
+                   ~trace_id
+                   ~source_ref
+                   source_bytes
+               with
+               | Error detail -> Error (Purge_backup_failed detail)
+               | Ok backup_path ->
+                 (match
+                    Keeper_checkpoint_store.save_oas_if_source
+                      ~session_dir
+                      ~expected_source_ref:source_ref
+                      purged
+                  with
+                  | Keeper_checkpoint_store.Not_installed
+                      { cause = Source_changed _; _ } ->
+                    Error Purge_source_changed
+                  | Not_installed { cause; _ } ->
+                    Error
+                      (Purge_install_failed
+                         (checkpoint_cas_error_to_string cause))
+                  | Installed installed ->
+                    Ok
+                      { keeper = keeper_name
+                      ; trace_id
+                      ; apply_allowed = true
+                      ; applied = true
+                      ; backup_path = Some backup_path
+                      ; report
+                      ; warnings =
+                          List.map
+                            checkpoint_installation_auxiliary_to_string
+                            installed.auxiliary
+                      }))))
+;;
+
+let purge_current config ~keeper_name ~apply =
+  let keeper_name = String.trim keeper_name in
+  if not (Keeper_config.validate_name keeper_name)
+  then Error (Purge_invalid_keeper_name keeper_name)
+  else if apply
+  then
+    Keeper_lifecycle_reservation.with_key_lock
+      ~base_path:config.Workspace.base_path
+      ~keeper_name
+      (fun () -> purge_current_unlocked config ~keeper_name ~apply:true)
+  else purge_current_unlocked config ~keeper_name ~apply:false
+;;
+
 let linked_artifact_json ~kind path =
   `Assoc
     [ "kind", `String kind

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.mli
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.mli
@@ -23,4 +23,50 @@ val checkpoint_load_error_json :
     without mixing diagnostic rows into the compatibility fields. *)
 val inventory_json : Workspace.config -> string -> [ `Not_found | `OK ] * Yojson.Safe.t
 
+type purge_report =
+  { messages_before : int
+  ; messages_after : int
+  ; bytes_before : int
+  ; bytes_after : int
+  ; duplicates_dropped : int
+  ; reasoning_blocks_stripped : int
+  ; reasoning_messages_dropped : int
+  ; tool_results_cleared : int
+  }
+
+type purge_result =
+  { keeper : string
+  ; trace_id : string
+  ; apply_allowed : bool
+  ; applied : bool
+  ; backup_path : string option
+  ; report : purge_report
+  ; warnings : string list
+  }
+
+type purge_error =
+  | Purge_invalid_keeper_name of string
+  | Purge_keeper_not_found of string
+  | Purge_keeper_active of string
+  | Purge_checkpoint_unavailable of string
+  | Purge_checkpoint_invalid of string
+  | Purge_backup_failed of string
+  | Purge_source_changed
+  | Purge_install_failed of string
+
+val purge_error_to_string : purge_error -> string
+
+(** Deterministically preview or apply the fixed checkpoint purge policy.
+    Preview is read-only and reports whether apply is currently allowed.
+    Apply requires the Keeper to be fully absent from the runtime registry and
+    serializes that check with same-Keeper boot registration. The canonical
+    checkpoint is installed only if its exact source reference is unchanged. *)
+val purge_current :
+  Workspace.config ->
+  keeper_name:string ->
+  apply:bool ->
+  (purge_result, purge_error) result
+
+val purge_result_json : action:string -> purge_result -> Yojson.Safe.t
+
 val linked_artifact_json : kind:string -> string -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -304,6 +304,37 @@ let handle_keeper_checkpoints_post state req reqd body_str =
       let args = Yojson.Safe.from_string body_str in
       let action = Safe_ops.json_string ~default:"" "action" args in
       match action with
+      | ("preview_purge" | "apply_purge") as purge_action ->
+          let apply = String.equal purge_action "apply_purge" in
+          (match Checkpoints.purge_current config ~keeper_name:name ~apply with
+           | Error error ->
+             let status =
+               match error with
+               | Checkpoints.Purge_invalid_keeper_name _ -> `Bad_request
+               | Checkpoints.Purge_keeper_not_found _ -> `Not_found
+               | Purge_keeper_active _
+               | Purge_checkpoint_invalid _
+               | Purge_source_changed -> `Conflict
+               | Purge_checkpoint_unavailable _
+               | Purge_backup_failed _
+               | Purge_install_failed _ -> `Internal_server_error
+             in
+             respond_error
+               ~status
+               ~request:req
+               ~ok:false
+               reqd
+               (Checkpoints.purge_error_to_string error)
+           | Ok result ->
+             let (_status, inventory) =
+               keeper_checkpoint_inventory_json config name
+             in
+             let response =
+               match Checkpoints.purge_result_json ~action:purge_action result with
+               | `Assoc fields -> `Assoc (("inventory", inventory) :: fields)
+               | other -> other
+             in
+             Http.Response.json_value ~compress:true ~request:req response reqd)
       | "delete_history" ->
           let snapshot_ids =
             Safe_ops.json_string_list "snapshot_ids" args


### PR DESCRIPTION
## What changed

- add typed `preview_purge` and `apply_purge` actions to the existing admin Keeper checkpoint endpoint
- expose deterministic checkpoint purge preview, stopped-only apply, byte-exact backup evidence, and resulting inventory in the Dashboard
- reuse the existing purge transform, lifecycle key lock, and exact-source checkpoint CAS
- document the Dashboard procedure alongside the existing CLI procedure

## Why

A Keeper whose persisted OAS checkpoint exceeds the provider prompt limit can remain unable to complete a turn. The deterministic purge already exists as an offline operator tool, but recovery required shell access. This adds the same explicit operation to the existing Dashboard checkpoint surface without introducing a new state store, feature flag, compatibility facade, or automatic runtime policy.

## Operator impact

Operators can preview the exact reduction while the Keeper is active. Apply remains unavailable until the Keeper is fully stopped. The server writes and reads back a byte-exact backup before installing the purged checkpoint, and the Dashboard displays the backup path and purge evidence.

## Validation

- `scripts/dune-local.sh build lib/server/.masc_server.objs/byte/server_dashboard_http_keeper_api_checkpoints.cmo lib/server/.masc_server.objs/byte/server_dashboard_http_keeper_api_post.cmo`
- Dashboard TypeScript `tsc --noEmit`
- focused Vitest: 2 files, 71 tests passed
- `git diff --check`
