### PR TITLE
feat(dashboard): show official-client session evidence

### DIFF
--- a/dashboard/dev-fixtures/official-client-session-fixture.html
+++ b/dashboard/dev-fixtures/official-client-session-fixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Official client session recovery</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/demo/official-client-session-fixture.ts"></script>
+  </body>
+</html>

--- a/dashboard/e2e/official-client-session.mjs
+++ b/dashboard/e2e/official-client-session.mjs
@@ -1,5 +1,10 @@
 import { chromium } from 'playwright'
 
+// Visual interaction fixture only. The production CanAdmin -> store CAS ->
+// refreshed projection contract is exercised against the real HTTP server by
+// test_sse_storm_e2e; this route interception intentionally proves layout and
+// browser request shape, not backend authorization or persistence.
+
 const fixtureUrl = process.env.OFFICIAL_CLIENT_SESSION_FIXTURE_URL
 if (!fixtureUrl) throw new Error('OFFICIAL_CLIENT_SESSION_FIXTURE_URL is required')
 

--- a/dashboard/e2e/official-client-session.mjs
+++ b/dashboard/e2e/official-client-session.mjs
@@ -43,6 +43,8 @@ const recoveryPayload = {
 
 const resolvedPayload = {
   ...recoveryPayload,
+  resolution_application: 'applied',
+  audit: { recorded: true },
   session: {
     ...recoveryPayload.session,
     phase: {

--- a/dashboard/e2e/official-client-session.mjs
+++ b/dashboard/e2e/official-client-session.mjs
@@ -1,0 +1,107 @@
+import { chromium } from 'playwright'
+
+const fixtureUrl = process.env.OFFICIAL_CLIENT_SESSION_FIXTURE_URL
+if (!fixtureUrl) throw new Error('OFFICIAL_CLIENT_SESSION_FIXTURE_URL is required')
+
+const artifactDir = process.env.OFFICIAL_CLIENT_SESSION_ARTIFACT_DIR ?? '/tmp'
+const recoveryScreenshot = `${artifactDir}/official-client-session-recovery-required.png`
+const resolvedScreenshot = `${artifactDir}/official-client-session-recovery-resolved.png`
+const recoveryId = '018f3a4a-27f4-7c9a-8fd8-330c2a3845aa'
+let getRequests = 0
+let postedBody = null
+
+const recoveryPayload = {
+  schema: 'masc.dashboard.official-client-session.v1',
+  ok: true,
+  keeper_name: 'sangsu',
+  session: {
+    client_kind: 'codex',
+    runtime_id: 'codex.codex',
+    phase: {
+      kind: 'recovery_required',
+      recovery_id: recoveryId,
+      failure: 'protocol_failed',
+      detail: 'malformed app-server event after the durable claim',
+      required_at: 1786230000,
+      owner_epoch: '018f3a4a-27f4-7c9a-8fd8-330c2a3845ab',
+      observed_session_id: 'thread-observed',
+      observed_turn_id: null,
+      previous_settlement: null,
+    },
+    turn_count: 1,
+    tool_surface_sha256: 'a'.repeat(64),
+    last_recovery_resolution: null,
+    last_transient_release: null,
+    updated_at: 1786230000,
+  },
+}
+
+const resolvedPayload = {
+  ...recoveryPayload,
+  session: {
+    ...recoveryPayload.session,
+    phase: {
+      kind: 'settled',
+      session_id: 'thread-verified',
+      turn_id: 'turn-verified',
+    },
+    last_recovery_resolution: {
+      recovery_id: recoveryId,
+      failure: 'protocol_failed',
+      resolution: {
+        kind: 'adopt_verified',
+        settlement: { session_id: 'thread-verified', turn_id: 'turn-verified' },
+      },
+      resolved_by: 'dashboard',
+      resolved_at: 1786230060,
+    },
+    updated_at: 1786230060,
+  },
+}
+
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } })
+  await page.route('**/api/v1/dashboard/dev-token', route => route.fulfill({
+    json: { token: 'fixture-token', actor: 'dashboard', role: 'worker' },
+  }))
+  await page.route('**/api/v1/runtime/sessions/official-client?**', route => {
+    getRequests += 1
+    return route.fulfill({ json: recoveryPayload })
+  })
+  await page.route('**/api/v1/runtime/sessions/official-client/resolve', async route => {
+    postedBody = route.request().postDataJSON()
+    await route.fulfill({ json: resolvedPayload })
+  })
+
+  await page.goto(fixtureUrl)
+  await page.getByTestId('official-client-session-phase').getByText('recovery_required', { exact: true }).waitFor()
+  const recovery = page.getByTestId('official-client-session-recovery-required')
+  await recovery.getByText('protocol_failed', { exact: true }).waitFor()
+  await recovery.getByText('thread-observed', { exact: true }).waitFor()
+  await recovery.getByText(recoveryId, { exact: true }).waitFor()
+  if (getRequests !== 1) throw new Error(`expected one session GET, got ${getRequests}`)
+
+  await page.screenshot({ path: recoveryScreenshot, fullPage: true })
+  await page.getByTestId('official-client-session-adopt-session').fill('thread-verified')
+  await page.getByTestId('official-client-session-adopt-turn').fill('turn-verified')
+  await page.getByTestId('official-client-session-adopt-verified').click()
+  await page.getByTestId('official-client-session-phase').getByText('settled', { exact: true }).waitFor()
+  await page.getByTestId('official-client-session-last-resolution').getByText(/dashboard/).waitFor()
+
+  const expectedBody = {
+    keeper_name: 'sangsu',
+    recovery_id: recoveryId,
+    resolution: 'adopt_verified',
+    session_id: 'thread-verified',
+    turn_id: 'turn-verified',
+  }
+  if (JSON.stringify(postedBody) !== JSON.stringify(expectedBody)) {
+    throw new Error(`unexpected recovery body: ${JSON.stringify(postedBody)}`)
+  }
+  await page.screenshot({ path: resolvedScreenshot, fullPage: true })
+  process.stdout.write(`official_client_recovery_required_screenshot=${recoveryScreenshot}\n`)
+  process.stdout.write(`official_client_recovery_resolved_screenshot=${resolvedScreenshot}\n`)
+} finally {
+  await browser.close()
+}

--- a/dashboard/e2e/official-client-session.mjs
+++ b/dashboard/e2e/official-client-session.mjs
@@ -41,17 +41,12 @@ const resolvedPayload = {
   session: {
     ...recoveryPayload.session,
     phase: {
-      kind: 'settled',
-      session_id: 'thread-verified',
-      turn_id: 'turn-verified',
+      kind: 'ready',
     },
     last_recovery_resolution: {
       recovery_id: recoveryId,
       failure: 'protocol_failed',
-      resolution: {
-        kind: 'adopt_verified',
-        settlement: { session_id: 'thread-verified', turn_id: 'turn-verified' },
-      },
+      resolution: { kind: 'restart_fresh' },
       resolved_by: 'dashboard',
       resolved_at: 1786230060,
     },
@@ -83,18 +78,14 @@ try {
   if (getRequests !== 1) throw new Error(`expected one session GET, got ${getRequests}`)
 
   await page.screenshot({ path: recoveryScreenshot, fullPage: true })
-  await page.getByTestId('official-client-session-adopt-session').fill('thread-verified')
-  await page.getByTestId('official-client-session-adopt-turn').fill('turn-verified')
-  await page.getByTestId('official-client-session-adopt-verified').click()
-  await page.getByTestId('official-client-session-phase').getByText('settled', { exact: true }).waitFor()
+  await page.getByTestId('official-client-session-restart-fresh').click()
+  await page.getByTestId('official-client-session-phase').getByText('ready', { exact: true }).waitFor()
   await page.getByTestId('official-client-session-last-resolution').getByText(/dashboard/).waitFor()
 
   const expectedBody = {
     keeper_name: 'sangsu',
     recovery_id: recoveryId,
-    resolution: 'adopt_verified',
-    session_id: 'thread-verified',
-    turn_id: 'turn-verified',
+    resolution: 'restart_fresh',
   }
   if (JSON.stringify(postedBody) !== JSON.stringify(expectedBody)) {
     throw new Error(`unexpected recovery body: ${JSON.stringify(postedBody)}`)

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1141,9 +1141,7 @@ export interface DashboardOfficialClientSessionPhase {
 export interface DashboardOfficialClientRecoveryResolutionRecord {
   recovery_id: string
   failure: DashboardOfficialClientRecoveryFailure
-  resolution:
-    | { kind: 'retry_previous' | 'restart_fresh' }
-    | { kind: 'adopt_verified'; settlement: DashboardOfficialClientSettlement }
+  resolution: { kind: 'retry_previous' | 'restart_fresh' }
   resolved_by: string
   resolved_at: number
 }
@@ -1248,14 +1246,9 @@ function decodeOfficialClientResolutionRecord(raw: unknown): DashboardOfficialCl
   const resolved_at = asNumber(raw.resolved_at)
   const kind = asString(raw.resolution.kind)
   if (!recovery_id || !failure || !resolved_by || resolved_at == null) return null
-  const resolution = kind === 'adopt_verified'
-    ? (() => {
-        const settlement = decodeOfficialClientSettlement(raw.resolution.settlement)
-        return settlement ? { kind, settlement } as const : null
-      })()
-    : kind === 'retry_previous' || kind === 'restart_fresh'
-      ? { kind } as const
-      : null
+  const resolution = kind === 'retry_previous' || kind === 'restart_fresh'
+    ? { kind } as const
+    : null
   if (!resolution) return null
   return {
     recovery_id,

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1193,6 +1193,18 @@ export interface DashboardOfficialClientSessionResponse {
   session: DashboardOfficialClientSession | null
 }
 
+export type DashboardOfficialClientRecoveryApplication = 'applied' | 'replayed'
+
+export type DashboardOfficialClientAuditReceipt =
+  | { recorded: true }
+  | { recorded: false; error: string }
+
+export interface DashboardOfficialClientRecoveryResponse
+  extends DashboardOfficialClientSessionResponse {
+  resolution_application: DashboardOfficialClientRecoveryApplication
+  audit: DashboardOfficialClientAuditReceipt
+}
+
 export type DashboardOfficialClientRecoveryDecision =
   | { resolution: 'retry_previous' }
   | { resolution: 'restart_fresh' }
@@ -1448,6 +1460,44 @@ function decodeOfficialClientSessionResponse(raw: unknown): DashboardOfficialCli
   }
 }
 
+function decodeOfficialClientAuditReceipt(raw: unknown): DashboardOfficialClientAuditReceipt | null {
+  if (!isRecord(raw) || typeof raw.recorded !== 'boolean') return null
+  if (raw.recorded) {
+    return hasExactKeys(raw, ['recorded']) ? { recorded: true } : null
+  }
+  if (!hasExactKeys(raw, ['recorded', 'error'])) return null
+  const error = decodeOfficialClientNonEmptyString(raw.error)
+  return error ? { recorded: false, error } : null
+}
+
+function decodeOfficialClientRecoveryResponse(raw: unknown): DashboardOfficialClientRecoveryResponse | null {
+  if (
+    !isRecord(raw)
+    || !hasExactKeys(raw, [
+      'schema',
+      'ok',
+      'keeper_name',
+      'session',
+      'resolution_application',
+      'audit',
+    ])
+  ) return null
+  const session = decodeOfficialClientSessionResponse({
+    schema: raw.schema,
+    ok: raw.ok,
+    keeper_name: raw.keeper_name,
+    session: raw.session,
+  })
+  const resolution_application = raw.resolution_application === 'applied'
+    || raw.resolution_application === 'replayed'
+    ? raw.resolution_application
+    : null
+  const audit = decodeOfficialClientAuditReceipt(raw.audit)
+  return session && resolution_application && audit
+    ? { ...session, resolution_application, audit }
+    : null
+}
+
 function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
   const record = isRecord(raw) ? raw : {}
   return {
@@ -1484,14 +1534,14 @@ export async function resolveOfficialClientSession(
   keeperName: string,
   recoveryId: string,
   decision: DashboardOfficialClientRecoveryDecision,
-): Promise<DashboardOfficialClientSessionResponse> {
+): Promise<DashboardOfficialClientRecoveryResponse> {
   await ensureDevToken()
   const raw = await post<unknown>('/api/v1/runtime/sessions/official-client/resolve', {
     keeper_name: keeperName,
     recovery_id: recoveryId,
     ...decision,
   })
-  const decoded = decodeOfficialClientSessionResponse(raw)
+  const decoded = decodeOfficialClientRecoveryResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 official-client recovery payload')
   return decoded
 }

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1108,6 +1108,202 @@ function parseRuntimeTomlEditorProtocols(raw: unknown): RuntimeTomlEditorProtoco
   })
 }
 
+export type DashboardOfficialClientRecoveryFailure =
+  | 'transient_spawn_failed'
+  | 'transport_interrupted'
+  | 'protocol_failed'
+  | 'provider_rejected'
+  | 'host_hook_failed'
+  | 'state_persistence_failed'
+  | 'process_restarted'
+
+export type DashboardOfficialClientKind = 'codex' | 'claude_code' | 'antigravity'
+
+export interface DashboardOfficialClientSettlement {
+  session_id: string
+  turn_id: string
+}
+
+export interface DashboardOfficialClientSessionPhase {
+  kind: 'ready' | 'start' | 'active' | 'turn_inflight' | 'recovery_required' | 'settled'
+  session_id?: string | null
+  turn_id?: string | null
+  previous_settlement?: DashboardOfficialClientSettlement | null
+  recovery_id?: string | null
+  failure?: DashboardOfficialClientRecoveryFailure | null
+  detail?: string | null
+  required_at?: number | null
+  observed_session_id?: string | null
+  observed_turn_id?: string | null
+  owner_epoch?: string | null
+}
+
+export interface DashboardOfficialClientRecoveryResolutionRecord {
+  recovery_id: string
+  failure: DashboardOfficialClientRecoveryFailure
+  resolution: {
+    kind: 'retry_previous' | 'restart_fresh' | 'adopt_verified'
+    settlement?: DashboardOfficialClientSettlement | null
+  }
+  resolved_by: string
+  resolved_at: number
+}
+
+export interface DashboardOfficialClientTransientReleaseRecord {
+  failure: 'transient_spawn_failed'
+  owner_epoch: string
+  released_at: number
+}
+
+export interface DashboardOfficialClientSession {
+  client_kind: DashboardOfficialClientKind
+  runtime_id: string
+  phase: DashboardOfficialClientSessionPhase
+  turn_count: number
+  tool_surface_sha256: string
+  last_recovery_resolution: DashboardOfficialClientRecoveryResolutionRecord | null
+  last_transient_release: DashboardOfficialClientTransientReleaseRecord | null
+  updated_at: number
+}
+
+export interface DashboardOfficialClientSessionResponse {
+  schema: 'masc.dashboard.official-client-session.v1'
+  ok: true
+  keeper_name: string
+  session: DashboardOfficialClientSession | null
+}
+
+export type DashboardOfficialClientRecoveryDecision =
+  | { resolution: 'retry_previous' }
+  | { resolution: 'restart_fresh' }
+  | { resolution: 'adopt_verified'; session_id: string; turn_id: string }
+
+const OFFICIAL_CLIENT_RECOVERY_FAILURES = new Set<DashboardOfficialClientRecoveryFailure>([
+  'transient_spawn_failed',
+  'transport_interrupted',
+  'protocol_failed',
+  'provider_rejected',
+  'host_hook_failed',
+  'state_persistence_failed',
+  'process_restarted',
+])
+
+const OFFICIAL_CLIENT_KINDS = new Set<DashboardOfficialClientKind>([
+  'codex',
+  'claude_code',
+  'antigravity',
+])
+
+function decodeOfficialClientSettlement(raw: unknown): DashboardOfficialClientSettlement | null {
+  if (!isRecord(raw)) return null
+  const session_id = asString(raw.session_id)
+  const turn_id = asString(raw.turn_id)
+  return session_id && turn_id ? { session_id, turn_id } : null
+}
+
+function decodeOfficialClientFailure(raw: unknown): DashboardOfficialClientRecoveryFailure | null {
+  return typeof raw === 'string' && OFFICIAL_CLIENT_RECOVERY_FAILURES.has(raw as DashboardOfficialClientRecoveryFailure)
+    ? raw as DashboardOfficialClientRecoveryFailure
+    : null
+}
+
+function decodeOfficialClientPhase(raw: unknown): DashboardOfficialClientSessionPhase | null {
+  if (!isRecord(raw)) return null
+  const kind = asString(raw.kind)
+  if (!kind || !['ready', 'start', 'active', 'turn_inflight', 'recovery_required', 'settled'].includes(kind)) return null
+  const phase: DashboardOfficialClientSessionPhase = {
+    kind: kind as DashboardOfficialClientSessionPhase['kind'],
+    session_id: asNullableString(raw.session_id),
+    turn_id: asNullableString(raw.turn_id),
+    previous_settlement: raw.previous_settlement == null
+      ? null
+      : decodeOfficialClientSettlement(raw.previous_settlement),
+    recovery_id: asNullableString(raw.recovery_id),
+    failure: raw.failure == null ? null : decodeOfficialClientFailure(raw.failure),
+    detail: asNullableString(raw.detail),
+    required_at: asNumber(raw.required_at),
+    observed_session_id: asNullableString(raw.observed_session_id),
+    observed_turn_id: asNullableString(raw.observed_turn_id),
+    owner_epoch: asNullableString(raw.owner_epoch),
+  }
+  if (phase.kind === 'recovery_required' && (!phase.recovery_id || !phase.failure || phase.required_at == null)) return null
+  if (['start', 'active', 'turn_inflight', 'recovery_required'].includes(phase.kind) && !phase.owner_epoch) return null
+  if ((phase.kind === 'active' || phase.kind === 'turn_inflight') && !phase.session_id) return null
+  if (phase.kind === 'settled' && (!phase.session_id || !phase.turn_id)) return null
+  return phase
+}
+
+function decodeOfficialClientTransientRelease(raw: unknown): DashboardOfficialClientTransientReleaseRecord | null {
+  if (!isRecord(raw)) return null
+  const failure = asString(raw.failure)
+  const owner_epoch = asString(raw.owner_epoch)
+  const released_at = asNumber(raw.released_at)
+  if (failure !== 'transient_spawn_failed' || !owner_epoch || released_at == null) return null
+  return { failure, owner_epoch, released_at }
+}
+
+function decodeOfficialClientResolutionRecord(raw: unknown): DashboardOfficialClientRecoveryResolutionRecord | null {
+  if (!isRecord(raw) || !isRecord(raw.resolution)) return null
+  const recovery_id = asString(raw.recovery_id)
+  const failure = decodeOfficialClientFailure(raw.failure)
+  const resolved_by = asString(raw.resolved_by)
+  const resolved_at = asNumber(raw.resolved_at)
+  const kind = asString(raw.resolution.kind)
+  if (!recovery_id || !failure || !resolved_by || resolved_at == null) return null
+  if (kind !== 'retry_previous' && kind !== 'restart_fresh' && kind !== 'adopt_verified') return null
+  const settlement = raw.resolution.settlement == null
+    ? null
+    : decodeOfficialClientSettlement(raw.resolution.settlement)
+  if (kind === 'adopt_verified' && !settlement) return null
+  return {
+    recovery_id,
+    failure,
+    resolution: { kind, settlement },
+    resolved_by,
+    resolved_at,
+  }
+}
+
+function decodeOfficialClientSessionResponse(raw: unknown): DashboardOfficialClientSessionResponse | null {
+  if (!isRecord(raw) || raw.schema !== 'masc.dashboard.official-client-session.v1' || raw.ok !== true) return null
+  const keeper_name = asString(raw.keeper_name)
+  if (!keeper_name) return null
+  if (raw.session === null) {
+    return { schema: 'masc.dashboard.official-client-session.v1', ok: true, keeper_name, session: null }
+  }
+  if (!isRecord(raw.session)) return null
+  const client_kind = asString(raw.session.client_kind)
+  const runtime_id = asString(raw.session.runtime_id)
+  const phase = decodeOfficialClientPhase(raw.session.phase)
+  const turn_count = asNumber(raw.session.turn_count)
+  const tool_surface_sha256 = asString(raw.session.tool_surface_sha256)
+  const updated_at = asNumber(raw.session.updated_at)
+  const last_recovery_resolution = raw.session.last_recovery_resolution == null
+    ? null
+    : decodeOfficialClientResolutionRecord(raw.session.last_recovery_resolution)
+  const last_transient_release = raw.session.last_transient_release == null
+    ? null
+    : decodeOfficialClientTransientRelease(raw.session.last_transient_release)
+  if (!client_kind || !OFFICIAL_CLIENT_KINDS.has(client_kind as DashboardOfficialClientKind) || !runtime_id || !phase || turn_count == null || !Number.isInteger(turn_count) || turn_count < 0 || !tool_surface_sha256 || updated_at == null) return null
+  if (raw.session.last_recovery_resolution != null && !last_recovery_resolution) return null
+  if (raw.session.last_transient_release != null && !last_transient_release) return null
+  return {
+    schema: 'masc.dashboard.official-client-session.v1',
+    ok: true,
+    keeper_name,
+    session: {
+      client_kind: client_kind as DashboardOfficialClientKind,
+      runtime_id,
+      phase,
+      turn_count,
+      tool_surface_sha256,
+      last_recovery_resolution,
+      last_transient_release,
+      updated_at,
+    },
+  }
+}
+
 function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
   const record = isRecord(raw) ? raw : {}
   return {
@@ -1126,6 +1322,34 @@ function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
 export async function fetchRuntimeTomlConfig(): Promise<RuntimeTomlConfig> {
   await ensureDevToken()
   return get<unknown>('/api/v1/runtime/config/raw').then(normalizeRuntimeTomlConfig)
+}
+
+export async function fetchOfficialClientSession(
+  keeperName: string,
+  opts?: AbortableRequestOptions,
+): Promise<DashboardOfficialClientSessionResponse> {
+  await ensureDevToken()
+  const query = new URLSearchParams({ keeper_name: keeperName })
+  const raw = await get<unknown>(`/api/v1/runtime/sessions/official-client?${query}`, { signal: opts?.signal })
+  const decoded = decodeOfficialClientSessionResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 official-client session payload')
+  return decoded
+}
+
+export async function resolveOfficialClientSession(
+  keeperName: string,
+  recoveryId: string,
+  decision: DashboardOfficialClientRecoveryDecision,
+): Promise<DashboardOfficialClientSessionResponse> {
+  await ensureDevToken()
+  const raw = await post<unknown>('/api/v1/runtime/sessions/official-client/resolve', {
+    keeper_name: keeperName,
+    recovery_id: recoveryId,
+    ...decision,
+  })
+  const decoded = decodeOfficialClientSessionResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 official-client recovery payload')
+  return decoded
 }
 
 // Structured, already-resolved runtime defaults / model routing (runtime.toml

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1141,9 +1141,9 @@ export interface DashboardOfficialClientSessionPhase {
 export interface DashboardOfficialClientRecoveryResolutionRecord {
   recovery_id: string
   failure: DashboardOfficialClientRecoveryFailure
-  resolution: {
-    kind: 'retry_previous' | 'restart_fresh'
-  }
+  resolution:
+    | { kind: 'retry_previous' | 'restart_fresh' }
+    | { kind: 'adopt_verified'; settlement: DashboardOfficialClientSettlement }
   resolved_by: string
   resolved_at: number
 }
@@ -1248,11 +1248,19 @@ function decodeOfficialClientResolutionRecord(raw: unknown): DashboardOfficialCl
   const resolved_at = asNumber(raw.resolved_at)
   const kind = asString(raw.resolution.kind)
   if (!recovery_id || !failure || !resolved_by || resolved_at == null) return null
-  if (kind !== 'retry_previous' && kind !== 'restart_fresh') return null
+  const resolution = kind === 'adopt_verified'
+    ? (() => {
+        const settlement = decodeOfficialClientSettlement(raw.resolution.settlement)
+        return settlement ? { kind, settlement } as const : null
+      })()
+    : kind === 'retry_previous' || kind === 'restart_fresh'
+      ? { kind } as const
+      : null
+  if (!resolution) return null
   return {
     recovery_id,
     failure,
-    resolution: { kind },
+    resolution,
     resolved_by,
     resolved_at,
   }

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1142,8 +1142,7 @@ export interface DashboardOfficialClientRecoveryResolutionRecord {
   recovery_id: string
   failure: DashboardOfficialClientRecoveryFailure
   resolution: {
-    kind: 'retry_previous' | 'restart_fresh' | 'adopt_verified'
-    settlement?: DashboardOfficialClientSettlement | null
+    kind: 'retry_previous' | 'restart_fresh'
   }
   resolved_by: string
   resolved_at: number
@@ -1176,7 +1175,6 @@ export interface DashboardOfficialClientSessionResponse {
 export type DashboardOfficialClientRecoveryDecision =
   | { resolution: 'retry_previous' }
   | { resolution: 'restart_fresh' }
-  | { resolution: 'adopt_verified'; session_id: string; turn_id: string }
 
 const OFFICIAL_CLIENT_RECOVERY_FAILURES = new Set<DashboardOfficialClientRecoveryFailure>([
   'transient_spawn_failed',
@@ -1250,15 +1248,11 @@ function decodeOfficialClientResolutionRecord(raw: unknown): DashboardOfficialCl
   const resolved_at = asNumber(raw.resolved_at)
   const kind = asString(raw.resolution.kind)
   if (!recovery_id || !failure || !resolved_by || resolved_at == null) return null
-  if (kind !== 'retry_previous' && kind !== 'restart_fresh' && kind !== 'adopt_verified') return null
-  const settlement = raw.resolution.settlement == null
-    ? null
-    : decodeOfficialClientSettlement(raw.resolution.settlement)
-  if (kind === 'adopt_verified' && !settlement) return null
+  if (kind !== 'retry_previous' && kind !== 'restart_fresh') return null
   return {
     recovery_id,
     failure,
-    resolution: { kind, settlement },
+    resolution: { kind },
     resolved_by,
     resolved_at,
   }

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1124,19 +1124,42 @@ export interface DashboardOfficialClientSettlement {
   turn_id: string
 }
 
-export interface DashboardOfficialClientSessionPhase {
-  kind: 'ready' | 'start' | 'active' | 'turn_inflight' | 'recovery_required' | 'settled'
-  session_id?: string | null
-  turn_id?: string | null
-  previous_settlement?: DashboardOfficialClientSettlement | null
-  recovery_id?: string | null
-  failure?: DashboardOfficialClientRecoveryFailure | null
-  detail?: string | null
-  required_at?: number | null
-  observed_session_id?: string | null
-  observed_turn_id?: string | null
-  owner_epoch?: string | null
-}
+export type DashboardOfficialClientSessionPhase =
+  | { kind: 'ready' }
+  | {
+      kind: 'start'
+      owner_epoch: string
+      previous_settlement: DashboardOfficialClientSettlement | null
+    }
+  | {
+      kind: 'active'
+      owner_epoch: string
+      session_id: string
+      previous_settlement: DashboardOfficialClientSettlement | null
+    }
+  | {
+      kind: 'turn_inflight'
+      owner_epoch: string
+      session_id: string
+      turn_id: string | null
+      previous_settlement: DashboardOfficialClientSettlement | null
+    }
+  | {
+      kind: 'recovery_required'
+      recovery_id: string
+      failure: DashboardOfficialClientRecoveryFailure
+      detail: string
+      required_at: number
+      owner_epoch: string
+      observed_session_id: string | null
+      observed_turn_id: string | null
+      previous_settlement: DashboardOfficialClientSettlement | null
+    }
+  | {
+      kind: 'settled'
+      session_id: string
+      turn_id: string
+    }
 
 export interface DashboardOfficialClientRecoveryResolutionRecord {
   recovery_id: string
@@ -1190,11 +1213,39 @@ const OFFICIAL_CLIENT_KINDS = new Set<DashboardOfficialClientKind>([
   'antigravity',
 ])
 
+const OFFICIAL_CLIENT_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const OFFICIAL_CLIENT_SHA256 = /^[0-9a-f]{64}$/
+
+function hasExactKeys(raw: Record<string, unknown>, allowed: readonly string[]): boolean {
+  const keys = Object.keys(raw)
+  return keys.length === allowed.length && keys.every(key => allowed.includes(key))
+}
+
+function decodeOfficialClientUuid(raw: unknown): string | null {
+  return typeof raw === 'string' && OFFICIAL_CLIENT_UUID.test(raw) ? raw : null
+}
+
+function decodeOfficialClientNonEmptyString(raw: unknown): string | null {
+  return typeof raw === 'string' && raw.trim() !== '' ? raw : null
+}
+
+function decodeOfficialClientNullableString(raw: unknown): string | null | undefined {
+  if (raw === null) return null
+  return decodeOfficialClientNonEmptyString(raw) ?? undefined
+}
+
 function decodeOfficialClientSettlement(raw: unknown): DashboardOfficialClientSettlement | null {
-  if (!isRecord(raw)) return null
-  const session_id = asString(raw.session_id)
-  const turn_id = asString(raw.turn_id)
+  if (!isRecord(raw) || !hasExactKeys(raw, ['session_id', 'turn_id'])) return null
+  const session_id = decodeOfficialClientNonEmptyString(raw.session_id)
+  const turn_id = decodeOfficialClientNonEmptyString(raw.turn_id)
   return session_id && turn_id ? { session_id, turn_id } : null
+}
+
+function decodeOfficialClientNullableSettlement(
+  raw: unknown,
+): DashboardOfficialClientSettlement | null | undefined {
+  if (raw === null) return null
+  return decodeOfficialClientSettlement(raw) ?? undefined
 }
 
 function decodeOfficialClientFailure(raw: unknown): DashboardOfficialClientRecoveryFailure | null {
@@ -1205,46 +1256,111 @@ function decodeOfficialClientFailure(raw: unknown): DashboardOfficialClientRecov
 
 function decodeOfficialClientPhase(raw: unknown): DashboardOfficialClientSessionPhase | null {
   if (!isRecord(raw)) return null
-  const kind = asString(raw.kind)
-  if (!kind || !['ready', 'start', 'active', 'turn_inflight', 'recovery_required', 'settled'].includes(kind)) return null
-  const phase: DashboardOfficialClientSessionPhase = {
-    kind: kind as DashboardOfficialClientSessionPhase['kind'],
-    session_id: asNullableString(raw.session_id),
-    turn_id: asNullableString(raw.turn_id),
-    previous_settlement: raw.previous_settlement == null
-      ? null
-      : decodeOfficialClientSettlement(raw.previous_settlement),
-    recovery_id: asNullableString(raw.recovery_id),
-    failure: raw.failure == null ? null : decodeOfficialClientFailure(raw.failure),
-    detail: asNullableString(raw.detail),
-    required_at: asNumber(raw.required_at),
-    observed_session_id: asNullableString(raw.observed_session_id),
-    observed_turn_id: asNullableString(raw.observed_turn_id),
-    owner_epoch: asNullableString(raw.owner_epoch),
+  switch (raw.kind) {
+    case 'ready':
+      return hasExactKeys(raw, ['kind']) ? { kind: 'ready' } : null
+    case 'start': {
+      if (!hasExactKeys(raw, ['kind', 'owner_epoch', 'previous_settlement'])) return null
+      const owner_epoch = decodeOfficialClientUuid(raw.owner_epoch)
+      const previous_settlement = decodeOfficialClientNullableSettlement(raw.previous_settlement)
+      return owner_epoch && previous_settlement !== undefined
+        ? { kind: 'start', owner_epoch, previous_settlement }
+        : null
+    }
+    case 'active': {
+      if (!hasExactKeys(raw, ['kind', 'owner_epoch', 'session_id', 'previous_settlement'])) return null
+      const owner_epoch = decodeOfficialClientUuid(raw.owner_epoch)
+      const session_id = decodeOfficialClientNonEmptyString(raw.session_id)
+      const previous_settlement = decodeOfficialClientNullableSettlement(raw.previous_settlement)
+      return owner_epoch && session_id && previous_settlement !== undefined
+        ? { kind: 'active', owner_epoch, session_id, previous_settlement }
+        : null
+    }
+    case 'turn_inflight': {
+      if (!hasExactKeys(raw, ['kind', 'owner_epoch', 'session_id', 'turn_id', 'previous_settlement'])) return null
+      const owner_epoch = decodeOfficialClientUuid(raw.owner_epoch)
+      const session_id = decodeOfficialClientNonEmptyString(raw.session_id)
+      const turn_id = decodeOfficialClientNullableString(raw.turn_id)
+      const previous_settlement = decodeOfficialClientNullableSettlement(raw.previous_settlement)
+      return owner_epoch && session_id && turn_id !== undefined && previous_settlement !== undefined
+        ? { kind: 'turn_inflight', owner_epoch, session_id, turn_id, previous_settlement }
+        : null
+    }
+    case 'recovery_required': {
+      if (!hasExactKeys(raw, [
+        'kind',
+        'recovery_id',
+        'failure',
+        'detail',
+        'required_at',
+        'owner_epoch',
+        'observed_session_id',
+        'observed_turn_id',
+        'previous_settlement',
+      ])) return null
+      const recovery_id = decodeOfficialClientUuid(raw.recovery_id)
+      const failure = decodeOfficialClientFailure(raw.failure)
+      const detail = decodeOfficialClientNonEmptyString(raw.detail)
+      const required_at = asNumber(raw.required_at)
+      const owner_epoch = decodeOfficialClientUuid(raw.owner_epoch)
+      const observed_session_id = decodeOfficialClientNullableString(raw.observed_session_id)
+      const observed_turn_id = decodeOfficialClientNullableString(raw.observed_turn_id)
+      const previous_settlement = decodeOfficialClientNullableSettlement(raw.previous_settlement)
+      if (
+        !recovery_id
+        || !failure
+        || !detail
+        || required_at == null
+        || !owner_epoch
+        || observed_session_id === undefined
+        || observed_turn_id === undefined
+        || previous_settlement === undefined
+        || (observed_turn_id !== null && observed_session_id === null)
+      ) return null
+      return {
+        kind: 'recovery_required',
+        recovery_id,
+        failure,
+        detail,
+        required_at,
+        owner_epoch,
+        observed_session_id,
+        observed_turn_id,
+        previous_settlement,
+      }
+    }
+    case 'settled': {
+      if (!hasExactKeys(raw, ['kind', 'session_id', 'turn_id'])) return null
+      const session_id = decodeOfficialClientNonEmptyString(raw.session_id)
+      const turn_id = decodeOfficialClientNonEmptyString(raw.turn_id)
+      return session_id && turn_id ? { kind: 'settled', session_id, turn_id } : null
+    }
+    default:
+      return null
   }
-  if (phase.kind === 'recovery_required' && (!phase.recovery_id || !phase.failure || phase.required_at == null)) return null
-  if (['start', 'active', 'turn_inflight', 'recovery_required'].includes(phase.kind) && !phase.owner_epoch) return null
-  if ((phase.kind === 'active' || phase.kind === 'turn_inflight') && !phase.session_id) return null
-  if (phase.kind === 'settled' && (!phase.session_id || !phase.turn_id)) return null
-  return phase
 }
 
 function decodeOfficialClientTransientRelease(raw: unknown): DashboardOfficialClientTransientReleaseRecord | null {
-  if (!isRecord(raw)) return null
-  const failure = asString(raw.failure)
-  const owner_epoch = asString(raw.owner_epoch)
+  if (!isRecord(raw) || !hasExactKeys(raw, ['failure', 'owner_epoch', 'released_at'])) return null
+  const failure = typeof raw.failure === 'string' ? raw.failure : null
+  const owner_epoch = decodeOfficialClientUuid(raw.owner_epoch)
   const released_at = asNumber(raw.released_at)
   if (failure !== 'transient_spawn_failed' || !owner_epoch || released_at == null) return null
   return { failure, owner_epoch, released_at }
 }
 
 function decodeOfficialClientResolutionRecord(raw: unknown): DashboardOfficialClientRecoveryResolutionRecord | null {
-  if (!isRecord(raw) || !isRecord(raw.resolution)) return null
-  const recovery_id = asString(raw.recovery_id)
+  if (
+    !isRecord(raw)
+    || !hasExactKeys(raw, ['failure', 'recovery_id', 'resolution', 'resolved_at', 'resolved_by'])
+    || !isRecord(raw.resolution)
+    || !hasExactKeys(raw.resolution, ['kind'])
+  ) return null
+  const recovery_id = decodeOfficialClientUuid(raw.recovery_id)
   const failure = decodeOfficialClientFailure(raw.failure)
-  const resolved_by = asString(raw.resolved_by)
+  const resolved_by = decodeOfficialClientNonEmptyString(raw.resolved_by)
   const resolved_at = asNumber(raw.resolved_at)
-  const kind = asString(raw.resolution.kind)
+  const kind = typeof raw.resolution.kind === 'string' ? raw.resolution.kind : null
   if (!recovery_id || !failure || !resolved_by || resolved_at == null) return null
   const resolution = kind === 'retry_previous' || kind === 'restart_fresh'
     ? { kind } as const
@@ -1260,28 +1376,61 @@ function decodeOfficialClientResolutionRecord(raw: unknown): DashboardOfficialCl
 }
 
 function decodeOfficialClientSessionResponse(raw: unknown): DashboardOfficialClientSessionResponse | null {
-  if (!isRecord(raw) || raw.schema !== 'masc.dashboard.official-client-session.v1' || raw.ok !== true) return null
-  const keeper_name = asString(raw.keeper_name)
+  if (
+    !isRecord(raw)
+    || !hasExactKeys(raw, ['schema', 'ok', 'keeper_name', 'session'])
+    || raw.schema !== 'masc.dashboard.official-client-session.v1'
+    || raw.ok !== true
+  ) return null
+  const keeper_name = decodeOfficialClientNonEmptyString(raw.keeper_name)
   if (!keeper_name) return null
   if (raw.session === null) {
     return { schema: 'masc.dashboard.official-client-session.v1', ok: true, keeper_name, session: null }
   }
-  if (!isRecord(raw.session)) return null
-  const client_kind = asString(raw.session.client_kind)
-  const runtime_id = asString(raw.session.runtime_id)
+  if (
+    !isRecord(raw.session)
+    || !hasExactKeys(raw.session, [
+      'client_kind',
+      'runtime_id',
+      'phase',
+      'turn_count',
+      'tool_surface_sha256',
+      'last_recovery_resolution',
+      'last_transient_release',
+      'updated_at',
+    ])
+  ) return null
+  const client_kind = typeof raw.session.client_kind === 'string'
+    ? raw.session.client_kind
+    : null
+  const runtime_id = decodeOfficialClientNonEmptyString(raw.session.runtime_id)
   const phase = decodeOfficialClientPhase(raw.session.phase)
   const turn_count = asNumber(raw.session.turn_count)
-  const tool_surface_sha256 = asString(raw.session.tool_surface_sha256)
+  const tool_surface_sha256 = typeof raw.session.tool_surface_sha256 === 'string'
+    ? raw.session.tool_surface_sha256
+    : null
   const updated_at = asNumber(raw.session.updated_at)
-  const last_recovery_resolution = raw.session.last_recovery_resolution == null
+  const last_recovery_resolution = raw.session.last_recovery_resolution === null
     ? null
     : decodeOfficialClientResolutionRecord(raw.session.last_recovery_resolution)
-  const last_transient_release = raw.session.last_transient_release == null
+  const last_transient_release = raw.session.last_transient_release === null
     ? null
     : decodeOfficialClientTransientRelease(raw.session.last_transient_release)
-  if (!client_kind || !OFFICIAL_CLIENT_KINDS.has(client_kind as DashboardOfficialClientKind) || !runtime_id || !phase || turn_count == null || !Number.isInteger(turn_count) || turn_count < 0 || !tool_surface_sha256 || updated_at == null) return null
-  if (raw.session.last_recovery_resolution != null && !last_recovery_resolution) return null
-  if (raw.session.last_transient_release != null && !last_transient_release) return null
+  if (
+    !client_kind
+    || !OFFICIAL_CLIENT_KINDS.has(client_kind as DashboardOfficialClientKind)
+    || !runtime_id
+    || !phase
+    || turn_count == null
+    || !Number.isInteger(turn_count)
+    || turn_count < 0
+    || (turn_count === 0 && phase.kind !== 'ready')
+    || !tool_surface_sha256
+    || !OFFICIAL_CLIENT_SHA256.test(tool_surface_sha256)
+    || updated_at == null
+  ) return null
+  if (raw.session.last_recovery_resolution !== null && !last_recovery_resolution) return null
+  if (raw.session.last_transient_release !== null && !last_transient_release) return null
   return {
     schema: 'masc.dashboard.official-client-session.v1',
     ok: true,

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -39,6 +39,8 @@ import {
   fetchRuntimeTomlConfig,
   fetchRuntimeDefaults,
   fetchRuntimeModelMetrics,
+  fetchOfficialClientSession,
+  resolveOfficialClientSession,
   patchRuntimeAssignment,
   patchRuntimeMediaFailover,
   patchRuntimeRouting,
@@ -4152,5 +4154,95 @@ describe('fetchRuntimeDefaults', () => {
     expect(result.default_model).toBe('gpt-4o')
     expect(result.runtimes[0]?.is_default).toBe(true)
     expect(result.model_routing.cross_verifier_runtime_id).toBeNull()
+  })
+})
+
+describe('official-client session API', () => {
+  const recoveryPayload = {
+    schema: 'masc.dashboard.official-client-session.v1',
+    ok: true,
+    keeper_name: 'sangsu',
+    session: {
+      client_kind: 'codex',
+      runtime_id: 'codex.codex',
+      phase: {
+        kind: 'recovery_required',
+        recovery_id: '018f3a4a-27f4-7c9a-8fd8-330c2a3845aa',
+        failure: 'protocol_failed',
+        detail: 'malformed app-server event',
+        required_at: 1_786_230_000,
+        owner_epoch: '018f3a4a-27f4-7c9a-8fd8-330c2a3845ab',
+        observed_session_id: 'thread-1',
+        observed_turn_id: null,
+        previous_settlement: null,
+      },
+      turn_count: 1,
+      tool_surface_sha256: 'a'.repeat(64),
+      last_recovery_resolution: null,
+      last_transient_release: null,
+      updated_at: 1_786_230_000,
+    },
+  }
+
+  it('reads exact measured recovery evidence for one Keeper', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(recoveryPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchOfficialClientSession('sangsu')
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/runtime/sessions/official-client?keeper_name=sangsu')
+    expect(result.session?.phase.kind).toBe('recovery_required')
+    expect(result.session?.phase.failure).toBe('protocol_failed')
+    expect(result.session?.phase.observed_session_id).toBe('thread-1')
+  })
+
+  it('posts the recovery fence and verified adoption identities', async () => {
+    const settledPayload = {
+      ...recoveryPayload,
+      session: {
+        ...recoveryPayload.session,
+        phase: { kind: 'settled', session_id: 'thread-verified', turn_id: 'turn-verified' },
+        last_recovery_resolution: {
+          recovery_id: recoveryPayload.session.phase.recovery_id,
+          failure: 'protocol_failed',
+          resolution: {
+            kind: 'adopt_verified',
+            settlement: { session_id: 'thread-verified', turn_id: 'turn-verified' },
+          },
+          resolved_by: 'dashboard',
+          resolved_at: 1_786_230_010,
+        },
+      },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(settledPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await resolveOfficialClientSession(
+      'sangsu',
+      recoveryPayload.session.phase.recovery_id,
+      { resolution: 'adopt_verified', session_id: 'thread-verified', turn_id: 'turn-verified' },
+    )
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/runtime/sessions/official-client/resolve')
+    expect(JSON.parse(init.body as string)).toEqual({
+      keeper_name: 'sangsu',
+      recovery_id: recoveryPayload.session.phase.recovery_id,
+      resolution: 'adopt_verified',
+      session_id: 'thread-verified',
+      turn_id: 'turn-verified',
+    })
+    expect(result.session?.phase.kind).toBe('settled')
+    expect(result.session?.last_recovery_resolution?.resolved_by).toBe('dashboard')
   })
 })

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -4201,26 +4201,23 @@ describe('official-client session API', () => {
     expect(result.session?.phase.observed_session_id).toBe('thread-1')
   })
 
-  it('posts the recovery fence and verified adoption identities', async () => {
-    const settledPayload = {
+  it('posts the exact recovery fence and selected resolution', async () => {
+    const resolvedPayload = {
       ...recoveryPayload,
       session: {
         ...recoveryPayload.session,
-        phase: { kind: 'settled', session_id: 'thread-verified', turn_id: 'turn-verified' },
+        phase: { kind: 'ready' },
         last_recovery_resolution: {
           recovery_id: recoveryPayload.session.phase.recovery_id,
           failure: 'protocol_failed',
-          resolution: {
-            kind: 'adopt_verified',
-            settlement: { session_id: 'thread-verified', turn_id: 'turn-verified' },
-          },
+          resolution: { kind: 'restart_fresh' },
           resolved_by: 'dashboard',
           resolved_at: 1_786_230_010,
         },
       },
     }
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify(settledPayload), {
+      new Response(JSON.stringify(resolvedPayload), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }),
@@ -4230,7 +4227,7 @@ describe('official-client session API', () => {
     const result = await resolveOfficialClientSession(
       'sangsu',
       recoveryPayload.session.phase.recovery_id,
-      { resolution: 'adopt_verified', session_id: 'thread-verified', turn_id: 'turn-verified' },
+      { resolution: 'restart_fresh' },
     )
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
@@ -4238,11 +4235,9 @@ describe('official-client session API', () => {
     expect(JSON.parse(init.body as string)).toEqual({
       keeper_name: 'sangsu',
       recovery_id: recoveryPayload.session.phase.recovery_id,
-      resolution: 'adopt_verified',
-      session_id: 'thread-verified',
-      turn_id: 'turn-verified',
+      resolution: 'restart_fresh',
     })
-    expect(result.session?.phase.kind).toBe('settled')
+    expect(result.session?.phase.kind).toBe('ready')
     expect(result.session?.last_recovery_resolution?.resolved_by).toBe('dashboard')
   })
 })

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -4377,6 +4377,8 @@ describe('official-client session API', () => {
   it('posts the exact recovery fence and selected resolution', async () => {
     const resolvedPayload = {
       ...recoveryPayload,
+      resolution_application: 'applied',
+      audit: { recorded: true },
       session: {
         ...recoveryPayload.session,
         phase: { kind: 'ready' },
@@ -4412,5 +4414,47 @@ describe('official-client session API', () => {
     })
     expect(result.session?.phase.kind).toBe('ready')
     expect(result.session?.last_recovery_resolution?.resolved_by).toBe('dashboard')
+    expect(result.resolution_application).toBe('applied')
+    expect(result.audit).toEqual({ recorded: true })
+  })
+
+  it.each([
+    {
+      name: 'missing application',
+      payload: {
+        ...recoveryPayload,
+        audit: { recorded: true },
+      },
+    },
+    {
+      name: 'unknown application',
+      payload: {
+        ...recoveryPayload,
+        resolution_application: 'guessed',
+        audit: { recorded: true },
+      },
+    },
+    {
+      name: 'malformed audit receipt',
+      payload: {
+        ...recoveryPayload,
+        resolution_application: 'replayed',
+        audit: { recorded: false },
+      },
+    },
+  ])('rejects recovery operation drift: $name', async ({ payload }) => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(resolveOfficialClientSession(
+      'sangsu',
+      recoveryPayload.session.phase.recovery_id,
+      { resolution: 'restart_fresh' },
+    )).rejects.toThrow('유효하지 않은 official-client recovery payload')
   })
 })

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -4196,9 +4196,182 @@ describe('official-client session API', () => {
     const result = await fetchOfficialClientSession('sangsu')
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/runtime/sessions/official-client?keeper_name=sangsu')
-    expect(result.session?.phase.kind).toBe('recovery_required')
-    expect(result.session?.phase.failure).toBe('protocol_failed')
-    expect(result.session?.phase.observed_session_id).toBe('thread-1')
+    const phase = result.session?.phase
+    expect(phase?.kind).toBe('recovery_required')
+    if (phase?.kind !== 'recovery_required') throw new Error('expected recovery-required phase')
+    expect(phase.failure).toBe('protocol_failed')
+    expect(phase.observed_session_id).toBe('thread-1')
+  })
+
+  it.each([
+    {
+      kind: 'start',
+      phase: {
+        kind: 'start',
+        owner_epoch: recoveryPayload.session.phase.owner_epoch,
+        previous_settlement: null,
+      },
+    },
+    {
+      kind: 'active',
+      phase: {
+        kind: 'active',
+        owner_epoch: recoveryPayload.session.phase.owner_epoch,
+        session_id: 'thread-active',
+        previous_settlement: null,
+      },
+    },
+    {
+      kind: 'turn_inflight',
+      phase: {
+        kind: 'turn_inflight',
+        owner_epoch: recoveryPayload.session.phase.owner_epoch,
+        session_id: 'thread-active',
+        turn_id: null,
+        previous_settlement: null,
+      },
+    },
+    {
+      kind: 'settled',
+      phase: {
+        kind: 'settled',
+        session_id: 'thread-settled',
+        turn_id: 'turn-settled',
+      },
+    },
+  ])('accepts exact $kind phase', async ({ phase }) => {
+    const payload = {
+      ...recoveryPayload,
+      session: { ...recoveryPayload.session, phase },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchOfficialClientSession('sangsu')
+
+    expect(result.session?.phase.kind).toBe(phase.kind)
+  })
+
+  it('rejects phase, record, identity, and nullable-field drift', async () => {
+    const malformedPayloads: Array<{ name: string; payload: unknown }> = [
+      {
+        name: 'unknown response field',
+        payload: { ...recoveryPayload, extra: true },
+      },
+      {
+        name: 'unknown session field',
+        payload: {
+          ...recoveryPayload,
+          session: { ...recoveryPayload.session, extra: true },
+        },
+      },
+      {
+        name: 'unknown phase field',
+        payload: {
+          ...recoveryPayload,
+          session: {
+            ...recoveryPayload.session,
+            phase: { ...recoveryPayload.session.phase, extra: true },
+          },
+        },
+      },
+      {
+        name: 'missing required nullable phase field',
+        payload: {
+          ...recoveryPayload,
+          session: {
+            ...recoveryPayload.session,
+            phase: Object.fromEntries(
+              Object.entries(recoveryPayload.session.phase)
+                .filter(([key]) => key !== 'observed_turn_id'),
+            ),
+          },
+        },
+      },
+      {
+        name: 'invalid recovery UUID',
+        payload: {
+          ...recoveryPayload,
+          session: {
+            ...recoveryPayload.session,
+            phase: { ...recoveryPayload.session.phase, recovery_id: 'not-a-uuid' },
+          },
+        },
+      },
+      {
+        name: 'observed turn without observed session',
+        payload: {
+          ...recoveryPayload,
+          session: {
+            ...recoveryPayload.session,
+            phase: {
+              ...recoveryPayload.session.phase,
+              observed_session_id: null,
+              observed_turn_id: 'turn-without-session',
+            },
+          },
+        },
+      },
+      {
+        name: 'invalid lowercase SHA-256',
+        payload: {
+          ...recoveryPayload,
+          session: { ...recoveryPayload.session, tool_surface_sha256: 'A'.repeat(64) },
+        },
+      },
+      {
+        name: 'zero completed turns outside ready',
+        payload: {
+          ...recoveryPayload,
+          session: { ...recoveryPayload.session, turn_count: 0 },
+        },
+      },
+      {
+        name: 'ready phase carrying another phase field',
+        payload: {
+          ...recoveryPayload,
+          session: {
+            ...recoveryPayload.session,
+            phase: { kind: 'ready', owner_epoch: recoveryPayload.session.phase.owner_epoch },
+          },
+        },
+      },
+      {
+        name: 'settlement with an unknown field',
+        payload: {
+          ...recoveryPayload,
+          session: {
+            ...recoveryPayload.session,
+            phase: {
+              ...recoveryPayload.session.phase,
+              previous_settlement: {
+                session_id: 'thread-previous',
+                turn_id: 'turn-previous',
+                extra: true,
+              },
+            },
+          },
+        },
+      },
+    ]
+
+    for (const { name, payload } of malformedPayloads) {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(fetchOfficialClientSession('sangsu'), name)
+        .rejects.toThrow('유효하지 않은 official-client session payload')
+    }
   })
 
   it('posts the exact recovery fence and selected resolution', async () => {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -188,6 +188,9 @@ export type {
   DashboardOfficialClientTransientReleaseRecord,
   DashboardOfficialClientSession,
   DashboardOfficialClientSessionResponse,
+  DashboardOfficialClientRecoveryApplication,
+  DashboardOfficialClientAuditReceipt,
+  DashboardOfficialClientRecoveryResponse,
   DashboardOfficialClientRecoveryDecision,
 } from './dashboard-runtime'
 export {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -180,6 +180,15 @@ export type {
   RuntimeTomlConfig,
   RuntimeTomlEditorProtocol,
   RuntimeRoutingLane,
+  DashboardOfficialClientRecoveryFailure,
+  DashboardOfficialClientKind,
+  DashboardOfficialClientSettlement,
+  DashboardOfficialClientSessionPhase,
+  DashboardOfficialClientRecoveryResolutionRecord,
+  DashboardOfficialClientTransientReleaseRecord,
+  DashboardOfficialClientSession,
+  DashboardOfficialClientSessionResponse,
+  DashboardOfficialClientRecoveryDecision,
 } from './dashboard-runtime'
 export {
   fetchRuntimeProviders,
@@ -191,6 +200,8 @@ export {
   patchRuntimeAssignment,
   patchRuntimeMediaFailover,
   patchRuntimeRouting,
+  fetchOfficialClientSession,
+  resolveOfficialClientSession,
 } from './dashboard-runtime'
 
 export type {

--- a/dashboard/src/components/official-client-session-panel.test.ts
+++ b/dashboard/src/components/official-client-session-panel.test.ts
@@ -105,27 +105,4 @@ describe('OfficialClientSessionPanel', () => {
     })
   })
 
-  it('shows externally verified adoption as read-only evidence', async () => {
-    apiMocks.fetchOfficialClientSession.mockResolvedValueOnce({
-      ...resolvedResponse,
-      session: {
-        ...resolvedResponse.session,
-        last_recovery_resolution: {
-          ...resolvedResponse.session.last_recovery_resolution,
-          resolution: {
-            kind: 'adopt_verified' as const,
-            settlement: { session_id: 'session-verified', turn_id: 'turn-verified' },
-          },
-        },
-      },
-    })
-    const view = render(html`<${OfficialClientSessionPanel} />`)
-
-    await waitFor(() => {
-      expect(view.getByTestId('official-client-session-last-resolution').textContent).toContain(
-        'session-verified/turn-verified',
-      )
-    })
-    expect(view.queryByRole('button', { name: /adopt/i })).toBeNull()
-  })
 })

--- a/dashboard/src/components/official-client-session-panel.test.ts
+++ b/dashboard/src/components/official-client-session-panel.test.ts
@@ -40,6 +40,8 @@ const recoveryResponse = {
 
 const resolvedResponse = {
   ...recoveryResponse,
+  resolution_application: 'applied' as const,
+  audit: { recorded: true as const },
   session: {
     ...recoveryResponse.session,
     phase: {

--- a/dashboard/src/components/official-client-session-panel.test.ts
+++ b/dashboard/src/components/official-client-session-panel.test.ts
@@ -38,19 +38,17 @@ const recoveryResponse = {
   },
 }
 
-const settledResponse = {
+const resolvedResponse = {
   ...recoveryResponse,
   session: {
     ...recoveryResponse.session,
     phase: {
-      kind: 'settled' as const,
-      session_id: 'thread-verified',
-      turn_id: 'turn-verified',
+      kind: 'ready' as const,
     },
     last_recovery_resolution: {
       recovery_id: recoveryResponse.session.phase.recovery_id,
       failure: 'protocol_failed' as const,
-      resolution: { kind: 'adopt_verified' as const, settlement: { session_id: 'thread-verified', turn_id: 'turn-verified' } },
+      resolution: { kind: 'restart_fresh' as const },
       resolved_by: 'dashboard',
       resolved_at: 1_786_230_010,
     },
@@ -61,7 +59,7 @@ describe('OfficialClientSessionPanel', () => {
   beforeEach(() => {
     keepers.value = [{ name: 'sangsu', status: 'idle', runtime_id: 'codex.codex' }]
     apiMocks.fetchOfficialClientSession.mockReset().mockResolvedValue(recoveryResponse)
-    apiMocks.resolveOfficialClientSession.mockReset().mockResolvedValue(settledResponse)
+    apiMocks.resolveOfficialClientSession.mockReset().mockResolvedValue(resolvedResponse)
   })
 
   afterEach(() => {
@@ -89,33 +87,19 @@ describe('OfficialClientSessionPanel', () => {
     })
   })
 
-  it('requires both verified identities before adoption and shows the durable actor', async () => {
+  it('offers retry without accepting caller-supplied settlement identities', async () => {
     const view = render(html`<${OfficialClientSessionPanel} />`)
 
     await waitFor(() => {
-      expect(view.getByTestId('official-client-session-adopt-verified')).toBeTruthy()
+      expect(view.getByTestId('official-client-session-retry-previous')).toBeTruthy()
     })
-    const adoptButton = view.getByTestId('official-client-session-adopt-verified') as HTMLButtonElement
-    expect(adoptButton.disabled).toBe(true)
-
-    fireEvent.input(view.getByTestId('official-client-session-adopt-session'), {
-      target: { value: 'thread-verified' },
-    })
-    fireEvent.input(view.getByTestId('official-client-session-adopt-turn'), {
-      target: { value: 'turn-verified' },
-    })
-    expect(adoptButton.disabled).toBe(false)
-    fireEvent.click(adoptButton)
+    fireEvent.click(view.getByTestId('official-client-session-retry-previous'))
 
     await waitFor(() => {
       expect(apiMocks.resolveOfficialClientSession).toHaveBeenCalledWith(
         'sangsu',
         recoveryResponse.session.phase.recovery_id,
-        {
-          resolution: 'adopt_verified',
-          session_id: 'thread-verified',
-          turn_id: 'turn-verified',
-        },
+        { resolution: 'retry_previous' },
       )
       expect(view.getByTestId('official-client-session-last-resolution').textContent).toContain('dashboard')
     })

--- a/dashboard/src/components/official-client-session-panel.test.ts
+++ b/dashboard/src/components/official-client-session-panel.test.ts
@@ -104,4 +104,28 @@ describe('OfficialClientSessionPanel', () => {
       expect(view.getByTestId('official-client-session-last-resolution').textContent).toContain('dashboard')
     })
   })
+
+  it('shows externally verified adoption as read-only evidence', async () => {
+    apiMocks.fetchOfficialClientSession.mockResolvedValueOnce({
+      ...resolvedResponse,
+      session: {
+        ...resolvedResponse.session,
+        last_recovery_resolution: {
+          ...resolvedResponse.session.last_recovery_resolution,
+          resolution: {
+            kind: 'adopt_verified' as const,
+            settlement: { session_id: 'session-verified', turn_id: 'turn-verified' },
+          },
+        },
+      },
+    })
+    const view = render(html`<${OfficialClientSessionPanel} />`)
+
+    await waitFor(() => {
+      expect(view.getByTestId('official-client-session-last-resolution').textContent).toContain(
+        'session-verified/turn-verified',
+      )
+    })
+    expect(view.queryByRole('button', { name: /adopt/i })).toBeNull()
+  })
 })

--- a/dashboard/src/components/official-client-session-panel.test.ts
+++ b/dashboard/src/components/official-client-session-panel.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { fireEvent, render, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { keepers } from '../store'
+import { OfficialClientSessionPanel } from './official-client-session-panel'
+
+const apiMocks = vi.hoisted(() => ({
+  fetchOfficialClientSession: vi.fn(),
+  resolveOfficialClientSession: vi.fn(),
+}))
+
+vi.mock('../api/dashboard', () => apiMocks)
+
+const recoveryResponse = {
+  schema: 'masc.dashboard.official-client-session.v1' as const,
+  ok: true as const,
+  keeper_name: 'sangsu',
+  session: {
+    client_kind: 'codex' as const,
+    runtime_id: 'codex.codex',
+    phase: {
+      kind: 'recovery_required' as const,
+      recovery_id: '018f3a4a-27f4-7c9a-8fd8-330c2a3845aa',
+      failure: 'protocol_failed' as const,
+      detail: 'malformed app-server event',
+      required_at: 1_786_230_000,
+      owner_epoch: '018f3a4a-27f4-7c9a-8fd8-330c2a3845ab',
+      observed_session_id: 'thread-observed',
+      observed_turn_id: null,
+      previous_settlement: null,
+    },
+    turn_count: 1,
+    tool_surface_sha256: 'a'.repeat(64),
+    last_recovery_resolution: null,
+    last_transient_release: null,
+    updated_at: 1_786_230_000,
+  },
+}
+
+const settledResponse = {
+  ...recoveryResponse,
+  session: {
+    ...recoveryResponse.session,
+    phase: {
+      kind: 'settled' as const,
+      session_id: 'thread-verified',
+      turn_id: 'turn-verified',
+    },
+    last_recovery_resolution: {
+      recovery_id: recoveryResponse.session.phase.recovery_id,
+      failure: 'protocol_failed' as const,
+      resolution: { kind: 'adopt_verified' as const, settlement: { session_id: 'thread-verified', turn_id: 'turn-verified' } },
+      resolved_by: 'dashboard',
+      resolved_at: 1_786_230_010,
+    },
+  },
+}
+
+describe('OfficialClientSessionPanel', () => {
+  beforeEach(() => {
+    keepers.value = [{ name: 'sangsu', status: 'idle', runtime_id: 'codex.codex' }]
+    apiMocks.fetchOfficialClientSession.mockReset().mockResolvedValue(recoveryResponse)
+    apiMocks.resolveOfficialClientSession.mockReset().mockResolvedValue(settledResponse)
+  })
+
+  afterEach(() => {
+    keepers.value = []
+  })
+
+  it('shows measured recovery evidence and resolves the exact recovery fence', async () => {
+    const view = render(html`<${OfficialClientSessionPanel} />`)
+
+    await waitFor(() => {
+      expect(view.getByTestId('official-client-session-phase').textContent).toContain('recovery_required')
+    })
+    expect(view.getByTestId('official-client-session-evidence').textContent).toContain('codex.codex')
+    expect(view.getByTestId('official-client-session-recovery-required').textContent).toContain('protocol_failed')
+    expect(view.getByTestId('official-client-session-recovery-required').textContent).toContain('thread-observed')
+
+    fireEvent.click(view.getByTestId('official-client-session-restart-fresh'))
+
+    await waitFor(() => {
+      expect(apiMocks.resolveOfficialClientSession).toHaveBeenCalledWith(
+        'sangsu',
+        recoveryResponse.session.phase.recovery_id,
+        { resolution: 'restart_fresh' },
+      )
+    })
+  })
+
+  it('requires both verified identities before adoption and shows the durable actor', async () => {
+    const view = render(html`<${OfficialClientSessionPanel} />`)
+
+    await waitFor(() => {
+      expect(view.getByTestId('official-client-session-adopt-verified')).toBeTruthy()
+    })
+    const adoptButton = view.getByTestId('official-client-session-adopt-verified') as HTMLButtonElement
+    expect(adoptButton.disabled).toBe(true)
+
+    fireEvent.input(view.getByTestId('official-client-session-adopt-session'), {
+      target: { value: 'thread-verified' },
+    })
+    fireEvent.input(view.getByTestId('official-client-session-adopt-turn'), {
+      target: { value: 'turn-verified' },
+    })
+    expect(adoptButton.disabled).toBe(false)
+    fireEvent.click(adoptButton)
+
+    await waitFor(() => {
+      expect(apiMocks.resolveOfficialClientSession).toHaveBeenCalledWith(
+        'sangsu',
+        recoveryResponse.session.phase.recovery_id,
+        {
+          resolution: 'adopt_verified',
+          session_id: 'thread-verified',
+          turn_id: 'turn-verified',
+        },
+      )
+      expect(view.getByTestId('official-client-session-last-resolution').textContent).toContain('dashboard')
+    })
+  })
+})

--- a/dashboard/src/components/official-client-session-panel.ts
+++ b/dashboard/src/components/official-client-session-panel.ts
@@ -1,0 +1,258 @@
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import {
+  fetchOfficialClientSession,
+  resolveOfficialClientSession,
+  type DashboardOfficialClientRecoveryDecision,
+  type DashboardOfficialClientSessionResponse,
+} from '../api/dashboard'
+import { keepers } from '../store'
+import { errorToString } from '../lib/format-string'
+import { ActionButton } from './common/button'
+import { SectionCard } from './common/card'
+import { EmptyState } from './common/feedback-state'
+import { TextInput } from './common/input'
+import { Select } from './common/select'
+import { StatusChip } from './common/status-chip'
+
+function phaseTone(kind: string): 'ok' | 'warn' | 'bad' | 'info' | 'neutral' {
+  if (kind === 'settled' || kind === 'ready') return 'ok'
+  if (kind === 'recovery_required') return 'bad'
+  if (kind === 'active' || kind === 'turn_inflight') return 'info'
+  if (kind === 'start') return 'warn'
+  return 'neutral'
+}
+
+function timestampText(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '—'
+  return new Date(value * 1_000).toLocaleString()
+}
+
+function compactHash(value: string): string {
+  return value.length > 18 ? `${value.slice(0, 10)}…${value.slice(-8)}` : value
+}
+
+export function OfficialClientSessionPanel() {
+  const selectedKeeper = useSignal('')
+  const response = useSignal<DashboardOfficialClientSessionResponse | null>(null)
+  const loading = useSignal(false)
+  const resolving = useSignal(false)
+  const error = useSignal<string | null>(null)
+  const adoptSessionId = useSignal('')
+  const adoptTurnId = useSignal('')
+  const requestRevision = useSignal(0)
+
+  const keeperNames = keepers.value
+    .map(keeper => keeper.name)
+    .filter((name, index, names) => names.indexOf(name) === index)
+    .sort((left, right) => left.localeCompare(right))
+  const keeperKey = keeperNames.join('\u0000')
+
+  const load = async (keeperName: string) => {
+    if (!keeperName) {
+      response.value = null
+      return
+    }
+    const revision = requestRevision.value + 1
+    requestRevision.value = revision
+    response.value = null
+    loading.value = true
+    error.value = null
+    try {
+      const next = await fetchOfficialClientSession(keeperName)
+      if (requestRevision.value === revision) response.value = next
+    } catch (cause) {
+      if (requestRevision.value === revision) error.value = errorToString(cause)
+    } finally {
+      if (requestRevision.value === revision) loading.value = false
+    }
+  }
+
+  useEffect(() => {
+    const next = keeperNames.includes(selectedKeeper.value)
+      ? selectedKeeper.value
+      : (keeperNames[0] ?? '')
+    selectedKeeper.value = next
+    void load(next)
+  }, [keeperKey])
+
+  const resolve = async (decision: DashboardOfficialClientRecoveryDecision) => {
+    const keeperName = selectedKeeper.value
+    const recoveryId = response.value?.session?.phase.recovery_id
+    if (!keeperName || !recoveryId || resolving.value) return
+    resolving.value = true
+    error.value = null
+    try {
+      response.value = await resolveOfficialClientSession(keeperName, recoveryId, decision)
+      adoptSessionId.value = ''
+      adoptTurnId.value = ''
+    } catch (cause) {
+      error.value = errorToString(cause)
+      await load(keeperName)
+    } finally {
+      resolving.value = false
+    }
+  }
+
+  const session = response.value?.session ?? null
+  const phase = session?.phase ?? null
+  const recoveryRequired = phase?.kind === 'recovery_required'
+  const lastResolution = session?.last_recovery_resolution ?? null
+  const transientRelease = session?.last_transient_release ?? null
+  const canAdopt = adoptSessionId.value.trim() !== '' && adoptTurnId.value.trim() !== ''
+
+  return html`
+    <${SectionCard}
+      label="공식 클라이언트 세션"
+      status=${phase?.kind ?? (session ? 'unknown' : '')}
+      testId="official-client-session-panel"
+    >
+      <div class="flex flex-wrap items-center gap-2 mb-3">
+        <${Select}
+          class="max-w-72"
+          ariaLabel="Keeper 선택"
+          testId="official-client-session-keeper"
+          value=${selectedKeeper.value}
+          disabled=${keeperNames.length === 0 || loading.value || resolving.value}
+          placeholder="Keeper 없음"
+          options=${keeperNames}
+          onInput=${(keeperName: string) => {
+            selectedKeeper.value = keeperName
+            void load(keeperName)
+          }}
+        />
+        <${ActionButton}
+          variant="ghost"
+          size="sm"
+          testId="official-client-session-refresh"
+          disabled=${!selectedKeeper.value || loading.value || resolving.value}
+          ariaBusy=${loading.value}
+          onClick=${() => void load(selectedKeeper.value)}
+        >새로고침<//>
+        ${phase
+          ? html`<${StatusChip} tone=${phaseTone(phase.kind)} uppercase=${false} testId="official-client-session-phase">${phase.kind}<//>`
+          : null}
+      </div>
+
+      ${error.value
+        ? html`<div class="mb-3 rounded-[var(--r-1)] border border-[var(--danger-20)] bg-[var(--danger-10)] px-3 py-2 text-xs text-[var(--color-status-err)]" role="alert" data-testid="official-client-session-error">${error.value}</div>`
+        : null}
+      ${loading.value && !session
+        ? html`<div class="text-xs text-[var(--color-fg-muted)]" role="status">공식 클라이언트 세션 불러오는 중…</div>`
+        : null}
+      ${keeperNames.length === 0
+        ? html`<${EmptyState} message="운영할 Keeper가 없습니다." compact />`
+        : null}
+      ${keeperNames.length > 0 && !loading.value && !session
+        ? html`<${EmptyState} message="이 Keeper는 아직 공식 클라이언트 세션을 시작하지 않았습니다." compact />`
+        : null}
+
+      ${session && phase
+        ? html`
+          <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2 text-xs" data-testid="official-client-session-evidence">
+            <div><span class="text-[var(--color-fg-muted)]">keeper</span> · <span class="mono">${response.value?.keeper_name}</span></div>
+            <div><span class="text-[var(--color-fg-muted)]">client</span> · <span class="mono">${session.client_kind}</span></div>
+            <div><span class="text-[var(--color-fg-muted)]">runtime</span> · <span class="mono">${session.runtime_id}</span></div>
+            <div><span class="text-[var(--color-fg-muted)]">completed turns</span> · ${session.turn_count}</div>
+            <div><span class="text-[var(--color-fg-muted)]">updated</span> · ${timestampText(session.updated_at)}</div>
+            <div title=${session.tool_surface_sha256}><span class="text-[var(--color-fg-muted)]">tool surface</span> · <span class="mono">${compactHash(session.tool_surface_sha256)}</span></div>
+            ${phase.owner_epoch ? html`<div title=${phase.owner_epoch}><span class="text-[var(--color-fg-muted)]">process epoch</span> · <span class="mono">${compactHash(phase.owner_epoch)}</span></div>` : null}
+            ${phase.session_id ? html`<div><span class="text-[var(--color-fg-muted)]">session</span> · <span class="mono">${phase.session_id}</span></div>` : null}
+            ${phase.turn_id ? html`<div><span class="text-[var(--color-fg-muted)]">turn</span> · <span class="mono">${phase.turn_id}</span></div>` : null}
+          </div>
+          ${recoveryRequired
+            ? html`
+              <div class="mt-4 rounded-[var(--r-1)] border border-[var(--danger-20)] bg-[var(--danger-10)] p-3" data-testid="official-client-session-recovery-required">
+                <div class="flex flex-wrap items-center gap-2 mb-2">
+                  <${StatusChip} tone="bad" uppercase=${false}>operator resolution required<//>
+                  <span class="mono text-2xs">${phase.recovery_id}</span>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs mb-3">
+                  <div>failure · <span class="mono">${phase.failure}</span></div>
+                  <div>required · ${timestampText(phase.required_at)}</div>
+                  <div>observed session · <span class="mono">${phase.observed_session_id ?? '—'}</span></div>
+                  <div>observed turn · <span class="mono">${phase.observed_turn_id ?? '—'}</span></div>
+                </div>
+                <div class="mb-3 whitespace-pre-wrap break-words text-xs text-[var(--color-fg-secondary)]">${phase.detail}</div>
+                <div class="flex flex-wrap gap-2 mb-3">
+                  <${ActionButton}
+                    variant="warn"
+                    size="sm"
+                    testId="official-client-session-retry-previous"
+                    disabled=${resolving.value}
+                    ariaBusy=${resolving.value}
+                    onClick=${() => void resolve({ resolution: 'retry_previous' })}
+                  >이전 settlement에서 재시도<//>
+                  <${ActionButton}
+                    variant="danger"
+                    size="sm"
+                    testId="official-client-session-restart-fresh"
+                    disabled=${resolving.value}
+                    ariaBusy=${resolving.value}
+                    onClick=${() => void resolve({ resolution: 'restart_fresh' })}
+                  >새 session으로 재시작<//>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-[1fr_1fr_auto] gap-2 items-end">
+                  <label class="grid gap-1 text-2xs text-[var(--color-fg-muted)]">
+                    검증된 session ID
+                    <${TextInput}
+                      value=${adoptSessionId.value}
+                      ariaLabel="검증된 official-client session ID"
+                      testId="official-client-session-adopt-session"
+                      disabled=${resolving.value}
+                      onInput=${(event: Event) => { adoptSessionId.value = (event.target as HTMLInputElement).value }}
+                    />
+                  </label>
+                  <label class="grid gap-1 text-2xs text-[var(--color-fg-muted)]">
+                    검증된 turn ID
+                    <${TextInput}
+                      value=${adoptTurnId.value}
+                      ariaLabel="검증된 official-client turn ID"
+                      testId="official-client-session-adopt-turn"
+                      disabled=${resolving.value}
+                      onInput=${(event: Event) => { adoptTurnId.value = (event.target as HTMLInputElement).value }}
+                    />
+                  </label>
+                  <${ActionButton}
+                    variant="ok"
+                    size="sm"
+                    testId="official-client-session-adopt-verified"
+                    disabled=${resolving.value || !canAdopt}
+                    ariaBusy=${resolving.value}
+                    onClick=${() => void resolve({
+                      resolution: 'adopt_verified',
+                      session_id: adoptSessionId.value.trim(),
+                      turn_id: adoptTurnId.value.trim(),
+                    })}
+                  >검증 결과 채택<//>
+                </div>
+              </div>
+            `
+            : null}
+          ${lastResolution
+            ? html`
+              <div class="mt-3 border-t border-[var(--color-border-default)] pt-3 text-xs" data-testid="official-client-session-last-resolution">
+                <span class="text-[var(--color-fg-muted)]">last resolution</span>
+                · <span class="mono">${lastResolution.resolution.kind}</span>
+                · ${lastResolution.resolved_by}
+                · ${timestampText(lastResolution.resolved_at)}
+                · <span class="mono">${lastResolution.failure}</span>
+              </div>
+            `
+            : null}
+          ${transientRelease
+            ? html`
+              <div class="mt-3 border-t border-[var(--color-border-default)] pt-3 text-xs" data-testid="official-client-session-last-transient-release">
+                <span class="text-[var(--color-fg-muted)]">last transient release</span>
+                · <span class="mono">${transientRelease.failure}</span>
+                · ${timestampText(transientRelease.released_at)}
+                · <span class="mono" title=${transientRelease.owner_epoch}>${compactHash(transientRelease.owner_epoch)}</span>
+              </div>
+            `
+            : null}
+        `
+        : null}
+    <//>
+  `
+}

--- a/dashboard/src/components/official-client-session-panel.ts
+++ b/dashboard/src/components/official-client-session-panel.ts
@@ -198,6 +198,9 @@ export function OfficialClientSessionPanel() {
                 · ${lastResolution.resolved_by}
                 · ${timestampText(lastResolution.resolved_at)}
                 · <span class="mono">${lastResolution.failure}</span>
+                ${lastResolution.resolution.kind === 'adopt_verified'
+                  ? html` · verified <span class="mono">${lastResolution.resolution.settlement.session_id}/${lastResolution.resolution.settlement.turn_id}</span>`
+                  : null}
               </div>
             `
             : null}

--- a/dashboard/src/components/official-client-session-panel.ts
+++ b/dashboard/src/components/official-client-session-panel.ts
@@ -84,7 +84,11 @@ export function OfficialClientSessionPanel() {
     resolving.value = true
     error.value = null
     try {
-      response.value = await resolveOfficialClientSession(keeperName, recoveryId, decision)
+      const resolved = await resolveOfficialClientSession(keeperName, recoveryId, decision)
+      response.value = resolved
+      if (!resolved.audit.recorded) {
+        error.value = `복구는 ${resolved.resolution_application} 상태로 반영됐지만 audit 기록에 실패했습니다: ${resolved.audit.error}`
+      }
     } catch (cause) {
       error.value = errorToString(cause)
       await load(keeperName)

--- a/dashboard/src/components/official-client-session-panel.ts
+++ b/dashboard/src/components/official-client-session-panel.ts
@@ -12,7 +12,6 @@ import { errorToString } from '../lib/format-string'
 import { ActionButton } from './common/button'
 import { SectionCard } from './common/card'
 import { EmptyState } from './common/feedback-state'
-import { TextInput } from './common/input'
 import { Select } from './common/select'
 import { StatusChip } from './common/status-chip'
 
@@ -39,8 +38,6 @@ export function OfficialClientSessionPanel() {
   const loading = useSignal(false)
   const resolving = useSignal(false)
   const error = useSignal<string | null>(null)
-  const adoptSessionId = useSignal('')
-  const adoptTurnId = useSignal('')
   const requestRevision = useSignal(0)
 
   const keeperNames = keepers.value
@@ -85,8 +82,6 @@ export function OfficialClientSessionPanel() {
     error.value = null
     try {
       response.value = await resolveOfficialClientSession(keeperName, recoveryId, decision)
-      adoptSessionId.value = ''
-      adoptTurnId.value = ''
     } catch (cause) {
       error.value = errorToString(cause)
       await load(keeperName)
@@ -100,7 +95,6 @@ export function OfficialClientSessionPanel() {
   const recoveryRequired = phase?.kind === 'recovery_required'
   const lastResolution = session?.last_recovery_resolution ?? null
   const transientRelease = session?.last_transient_release ?? null
-  const canAdopt = adoptSessionId.value.trim() !== '' && adoptTurnId.value.trim() !== ''
 
   return html`
     <${SectionCard}
@@ -175,7 +169,7 @@ export function OfficialClientSessionPanel() {
                   <div>observed turn · <span class="mono">${phase.observed_turn_id ?? '—'}</span></div>
                 </div>
                 <div class="mb-3 whitespace-pre-wrap break-words text-xs text-[var(--color-fg-secondary)]">${phase.detail}</div>
-                <div class="flex flex-wrap gap-2 mb-3">
+                <div class="flex flex-wrap gap-2">
                   <${ActionButton}
                     variant="warn"
                     size="sm"
@@ -192,40 +186,6 @@ export function OfficialClientSessionPanel() {
                     ariaBusy=${resolving.value}
                     onClick=${() => void resolve({ resolution: 'restart_fresh' })}
                   >새 session으로 재시작<//>
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-[1fr_1fr_auto] gap-2 items-end">
-                  <label class="grid gap-1 text-2xs text-[var(--color-fg-muted)]">
-                    검증된 session ID
-                    <${TextInput}
-                      value=${adoptSessionId.value}
-                      ariaLabel="검증된 official-client session ID"
-                      testId="official-client-session-adopt-session"
-                      disabled=${resolving.value}
-                      onInput=${(event: Event) => { adoptSessionId.value = (event.target as HTMLInputElement).value }}
-                    />
-                  </label>
-                  <label class="grid gap-1 text-2xs text-[var(--color-fg-muted)]">
-                    검증된 turn ID
-                    <${TextInput}
-                      value=${adoptTurnId.value}
-                      ariaLabel="검증된 official-client turn ID"
-                      testId="official-client-session-adopt-turn"
-                      disabled=${resolving.value}
-                      onInput=${(event: Event) => { adoptTurnId.value = (event.target as HTMLInputElement).value }}
-                    />
-                  </label>
-                  <${ActionButton}
-                    variant="ok"
-                    size="sm"
-                    testId="official-client-session-adopt-verified"
-                    disabled=${resolving.value || !canAdopt}
-                    ariaBusy=${resolving.value}
-                    onClick=${() => void resolve({
-                      resolution: 'adopt_verified',
-                      session_id: adoptSessionId.value.trim(),
-                      turn_id: adoptTurnId.value.trim(),
-                    })}
-                  >검증 결과 채택<//>
                 </div>
               </div>
             `

--- a/dashboard/src/components/official-client-session-panel.ts
+++ b/dashboard/src/components/official-client-session-panel.ts
@@ -198,9 +198,6 @@ export function OfficialClientSessionPanel() {
                 · ${lastResolution.resolved_by}
                 · ${timestampText(lastResolution.resolved_at)}
                 · <span class="mono">${lastResolution.failure}</span>
-                ${lastResolution.resolution.kind === 'adopt_verified'
-                  ? html` · verified <span class="mono">${lastResolution.resolution.settlement.session_id}/${lastResolution.resolution.settlement.turn_id}</span>`
-                  : null}
               </div>
             `
             : null}

--- a/dashboard/src/components/official-client-session-panel.ts
+++ b/dashboard/src/components/official-client-session-panel.ts
@@ -76,7 +76,10 @@ export function OfficialClientSessionPanel() {
 
   const resolve = async (decision: DashboardOfficialClientRecoveryDecision) => {
     const keeperName = selectedKeeper.value
-    const recoveryId = response.value?.session?.phase.recovery_id
+    const currentPhase = response.value?.session?.phase
+    const recoveryId = currentPhase?.kind === 'recovery_required'
+      ? currentPhase.recovery_id
+      : null
     if (!keeperName || !recoveryId || resolving.value) return
     resolving.value = true
     error.value = null
@@ -92,7 +95,10 @@ export function OfficialClientSessionPanel() {
 
   const session = response.value?.session ?? null
   const phase = session?.phase ?? null
-  const recoveryRequired = phase?.kind === 'recovery_required'
+  const recovery = phase?.kind === 'recovery_required' ? phase : null
+  const ownerEpoch = phase && 'owner_epoch' in phase ? phase.owner_epoch : null
+  const sessionId = phase && 'session_id' in phase ? phase.session_id : null
+  const turnId = phase && 'turn_id' in phase ? phase.turn_id : null
   const lastResolution = session?.last_recovery_resolution ?? null
   const transientRelease = session?.last_transient_release ?? null
 
@@ -151,24 +157,24 @@ export function OfficialClientSessionPanel() {
             <div><span class="text-[var(--color-fg-muted)]">completed turns</span> · ${session.turn_count}</div>
             <div><span class="text-[var(--color-fg-muted)]">updated</span> · ${timestampText(session.updated_at)}</div>
             <div title=${session.tool_surface_sha256}><span class="text-[var(--color-fg-muted)]">tool surface</span> · <span class="mono">${compactHash(session.tool_surface_sha256)}</span></div>
-            ${phase.owner_epoch ? html`<div title=${phase.owner_epoch}><span class="text-[var(--color-fg-muted)]">process epoch</span> · <span class="mono">${compactHash(phase.owner_epoch)}</span></div>` : null}
-            ${phase.session_id ? html`<div><span class="text-[var(--color-fg-muted)]">session</span> · <span class="mono">${phase.session_id}</span></div>` : null}
-            ${phase.turn_id ? html`<div><span class="text-[var(--color-fg-muted)]">turn</span> · <span class="mono">${phase.turn_id}</span></div>` : null}
+            ${ownerEpoch ? html`<div title=${ownerEpoch}><span class="text-[var(--color-fg-muted)]">process epoch</span> · <span class="mono">${compactHash(ownerEpoch)}</span></div>` : null}
+            ${sessionId ? html`<div><span class="text-[var(--color-fg-muted)]">session</span> · <span class="mono">${sessionId}</span></div>` : null}
+            ${turnId ? html`<div><span class="text-[var(--color-fg-muted)]">turn</span> · <span class="mono">${turnId}</span></div>` : null}
           </div>
-          ${recoveryRequired
+          ${recovery
             ? html`
               <div class="mt-4 rounded-[var(--r-1)] border border-[var(--danger-20)] bg-[var(--danger-10)] p-3" data-testid="official-client-session-recovery-required">
                 <div class="flex flex-wrap items-center gap-2 mb-2">
                   <${StatusChip} tone="bad" uppercase=${false}>operator resolution required<//>
-                  <span class="mono text-2xs">${phase.recovery_id}</span>
+                  <span class="mono text-2xs">${recovery.recovery_id}</span>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs mb-3">
-                  <div>failure · <span class="mono">${phase.failure}</span></div>
-                  <div>required · ${timestampText(phase.required_at)}</div>
-                  <div>observed session · <span class="mono">${phase.observed_session_id ?? '—'}</span></div>
-                  <div>observed turn · <span class="mono">${phase.observed_turn_id ?? '—'}</span></div>
+                  <div>failure · <span class="mono">${recovery.failure}</span></div>
+                  <div>required · ${timestampText(recovery.required_at)}</div>
+                  <div>observed session · <span class="mono">${recovery.observed_session_id ?? '—'}</span></div>
+                  <div>observed turn · <span class="mono">${recovery.observed_turn_id ?? '—'}</span></div>
                 </div>
-                <div class="mb-3 whitespace-pre-wrap break-words text-xs text-[var(--color-fg-secondary)]">${phase.detail}</div>
+                <div class="mb-3 whitespace-pre-wrap break-words text-xs text-[var(--color-fg-secondary)]">${recovery.detail}</div>
                 <div class="flex flex-wrap gap-2">
                   <${ActionButton}
                     variant="warn"

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -34,6 +34,7 @@ import {
   runtimeCatalogRequestConfig as runtimeRequestConfigText,
   runtimeCatalogSnapshotFacts as runtimeSnapshotFactsText,
 } from '../lib/runtime-provider-summary'
+import { OfficialClientSessionPanel } from './official-client-session-panel'
 
 /**
  * Filters model metrics by case-insensitive substring match against
@@ -977,6 +978,8 @@ export function RuntimeMonitor() {
             : html`<${EmptyState} message="runtime snapshot이 없습니다." compact />`}
         </div>
       <//>
+
+      <${OfficialClientSessionPanel} />
 
       <${SectionCard} label="런타임 메트릭">
         <div class="grid grid-cols-3 gap-3 mb-4">

--- a/dashboard/src/demo/official-client-session-fixture.ts
+++ b/dashboard/src/demo/official-client-session-fixture.ts
@@ -1,0 +1,35 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { OfficialClientSessionPanel } from '../components/official-client-session-panel'
+import { keepers } from '../store'
+
+keepers.value = [
+  { name: 'sangsu', status: 'idle', runtime_id: 'codex.codex' },
+]
+
+function OfficialClientSessionFixture() {
+  return html`
+    <main class="min-h-screen px-5 py-6" style="background: var(--color-bg-page);">
+      <section class="mx-auto max-w-[1180px]">
+        <header class="mb-5">
+          <div class="text-2xs uppercase tracking-[0.16em] text-[var(--color-accent-fg)]">
+            MASC Runtime Control
+          </div>
+          <h1 class="mt-1 text-xl font-semibold text-[var(--color-fg-primary)]">
+            공식 클라이언트 세션 운영
+          </h1>
+          <p class="mt-1 text-xs text-[var(--color-fg-muted)]">
+            실제 claim phase와 recovery fence를 확인한 뒤 명시적으로 해소합니다.
+          </p>
+        </header>
+        <${OfficialClientSessionPanel} />
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) render(html`<${OfficialClientSessionFixture} />`, root)

--- a/scripts/harness_dashboard_official_client_session_e2e.sh
+++ b/scripts/harness_dashboard_official_client_session_e2e.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5192}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/official-client-session-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-official-client-session-recovery-vite-${PORT}.log"
+ARTIFACT_DIR="${OFFICIAL_CLIENT_SESSION_ARTIFACT_DIR:-${TMPDIR:-/tmp}/masc-official-client-session-e2e}"
+
+mkdir -p "${ARTIFACT_DIR}"
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    sed -n '1,160p' "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+OFFICIAL_CLIENT_SESSION_FIXTURE_URL="${FIXTURE_URL}" \
+OFFICIAL_CLIENT_SESSION_ARTIFACT_DIR="${ARTIFACT_DIR}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec node e2e/official-client-session.mjs
+
+printf 'Official client session recovery Playwright E2E passed\n'

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -1,5 +1,8 @@
 open Alcotest
 
+module Official_client_session_store =
+  Masc.Keeper_official_client_session_store
+
 type http_result = {
   status: int option;
   headers: (string * string) list;
@@ -685,35 +688,39 @@ let test_official_client_recovery_uses_real_admin_route () =
   with_server @@ fun ~port ~auth_token ~base_path ->
   let keeper_name = "official-client-http-fixture" in
   let claim =
-    Keeper_official_client_session_store.claim
+    Official_client_session_store.claim
       ~base_path
       ~keeper_name
       ~expected:None
-      ~client_kind:Keeper_official_client_session_store.Codex
+      ~client_kind:Official_client_session_store.Codex
       ~owner_epoch:"11111111-1111-4111-8111-111111111111"
       ~runtime_id:"codex.codex"
       ~tool_surface_sha256:
-        (Keeper_official_client_session_store.tool_surface_sha256 [])
+        (Official_client_session_store.tool_surface_sha256 [])
       ~updated_at:1.0
     |> Result.get_ok
   in
   let recovery =
-    Keeper_official_client_session_store.require_recovery
+    Official_client_session_store.require_recovery
       ~base_path
       ~keeper_name
       ~expected:claim
-      ~failure:Keeper_official_client_session_store.Protocol_failed
+      ~failure:Official_client_session_store.Protocol_failed
       ~detail:"real HTTP recovery fixture"
       ~required_at:2.0
     |> Result.get_ok
   in
   let recovery_id =
     match recovery.phase with
-    | Recovery_required required -> required.recovery_id
-    | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+    | Official_client_session_store.Recovery_required required -> required.recovery_id
+    | Official_client_session_store.Ready
+    | Official_client_session_store.Start _
+    | Official_client_session_store.Active _
+    | Official_client_session_store.Turn_inflight _
+    | Official_client_session_store.Settled _ ->
       fail "HTTP fixture did not enter recovery-required"
   in
-  let path =
+  let session_path =
     "/api/v1/runtime/sessions/official-client?keeper_name=" ^ keeper_name
   in
   let worker =
@@ -721,7 +728,7 @@ let test_official_client_recovery_uses_real_admin_route () =
       ~headers:[ "Authorization", "Bearer " ^ auth_token ]
       ~max_time:2.0
       ~port
-      ~path
+      ~path:session_path
       ()
   in
   check_status "Worker cannot read official-client recovery" 403 worker;
@@ -731,7 +738,9 @@ let test_official_client_recovery_uses_real_admin_route () =
     ; "Content-Type", "application/json"
     ]
   in
-  let before = run_curl ~headers:admin_headers ~max_time:2.0 ~port ~path () in
+  let before =
+    run_curl ~headers:admin_headers ~max_time:2.0 ~port ~path:session_path ()
+  in
   check_status "Admin reads official-client recovery" 200 before;
   let open Yojson.Safe.Util in
   check string
@@ -761,7 +770,9 @@ let test_official_client_recovery_uses_real_admin_route () =
       ()
   in
   check_status "Admin resolves official-client recovery" 200 resolved;
-  let refreshed = run_curl ~headers:admin_headers ~max_time:2.0 ~port ~path () in
+  let refreshed =
+    run_curl ~headers:admin_headers ~max_time:2.0 ~port ~path:session_path ()
+  in
   check_status "Admin refreshes official-client session" 200 refreshed;
   let refreshed_json = Yojson.Safe.from_string refreshed.body in
   check string

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -357,6 +357,8 @@ provider_ref = "deepseek"
 model_id = "deepseek-v4-flash"
 |}
 
+let main_eio_test_admin_token = "sse-storm-admin-token"
+
 let seed_server_config ~base_path =
   let masc_dir = Filename.concat base_path ".masc" in
   let config_dir = Filename.concat masc_dir "config" in
@@ -396,6 +398,7 @@ let with_server f =
       [
         ("MASC_BASE_PATH", base_path);
         ("MASC_BASE_PATH_INPUT", base_path);
+        ("MASC_ADMIN_TOKEN", main_eio_test_admin_token);
         ("MASC_KEEPER_AUTONOMOUS_ENABLED", "0");
         ("GRAPHQL_API_KEY", "");
         ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
@@ -677,6 +680,104 @@ let test_dashboard_dev_token_cannot_call_admin_route () =
       ()
   in
   check_status "dashboard Worker token denied CanAdmin route" 403 result
+
+let test_official_client_recovery_uses_real_admin_route () =
+  with_server @@ fun ~port ~auth_token ~base_path ->
+  let keeper_name = "official-client-http-fixture" in
+  let claim =
+    Keeper_official_client_session_store.claim
+      ~base_path
+      ~keeper_name
+      ~expected:None
+      ~client_kind:Keeper_official_client_session_store.Codex
+      ~owner_epoch:"11111111-1111-4111-8111-111111111111"
+      ~runtime_id:"codex.codex"
+      ~tool_surface_sha256:
+        (Keeper_official_client_session_store.tool_surface_sha256 [])
+      ~updated_at:1.0
+    |> Result.get_ok
+  in
+  let recovery =
+    Keeper_official_client_session_store.require_recovery
+      ~base_path
+      ~keeper_name
+      ~expected:claim
+      ~failure:Keeper_official_client_session_store.Protocol_failed
+      ~detail:"real HTTP recovery fixture"
+      ~required_at:2.0
+    |> Result.get_ok
+  in
+  let recovery_id =
+    match recovery.phase with
+    | Recovery_required required -> required.recovery_id
+    | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+      fail "HTTP fixture did not enter recovery-required"
+  in
+  let path =
+    "/api/v1/runtime/sessions/official-client?keeper_name=" ^ keeper_name
+  in
+  let worker =
+    run_curl
+      ~headers:[ "Authorization", "Bearer " ^ auth_token ]
+      ~max_time:2.0
+      ~port
+      ~path
+      ()
+  in
+  check_status "Worker cannot read official-client recovery" 403 worker;
+  let admin_headers =
+    [ "Accept", "application/json"
+    ; "Authorization", "Bearer " ^ main_eio_test_admin_token
+    ; "Content-Type", "application/json"
+    ]
+  in
+  let before = run_curl ~headers:admin_headers ~max_time:2.0 ~port ~path () in
+  check_status "Admin reads official-client recovery" 200 before;
+  let open Yojson.Safe.Util in
+  check string
+    "real route recovery phase"
+    "recovery_required"
+    (Yojson.Safe.from_string before.body
+     |> member "session"
+     |> member "phase"
+     |> member "kind"
+     |> to_string);
+  let body =
+    `Assoc
+      [ "keeper_name", `String keeper_name
+      ; "recovery_id", `String recovery_id
+      ; "resolution", `String "restart_fresh"
+      ]
+    |> Yojson.Safe.to_string
+  in
+  let resolved =
+    run_curl
+      ~headers:admin_headers
+      ~method_:"POST"
+      ~body
+      ~max_time:2.0
+      ~port
+      ~path:"/api/v1/runtime/sessions/official-client/resolve"
+      ()
+  in
+  check_status "Admin resolves official-client recovery" 200 resolved;
+  let refreshed = run_curl ~headers:admin_headers ~max_time:2.0 ~port ~path () in
+  check_status "Admin refreshes official-client session" 200 refreshed;
+  let refreshed_json = Yojson.Safe.from_string refreshed.body in
+  check string
+    "real route refreshed phase"
+    "ready"
+    (refreshed_json |> member "session" |> member "phase" |> member "kind"
+     |> to_string);
+  check string
+    "real route persisted recovery fence"
+    recovery_id
+    (refreshed_json
+     |> member "session"
+     |> member "last_recovery_resolution"
+     |> member "recovery_id"
+     |> to_string)
+
 let test_ag_ui_rejects_reconnect_then_recovers () =
   with_server @@ fun ~port ~auth_token ~base_path:_ ->
   let sid = initialize_mcp_session ~port ~auth_token in
@@ -761,6 +862,10 @@ let () =
             "dev-token cannot call admin route"
             `Slow
             test_dashboard_dev_token_cannot_call_admin_route
+        ; test_case
+            "official-client recovery uses real CanAdmin route"
+            `Slow
+            test_official_client_recovery_uses_real_admin_route
         ] )
     ; ("mcp", [test_case "follow-up reconnect accepted" `Slow test_mcp_reconnect_stays_accepted])
      ; ( "ag_ui"


### PR DESCRIPTION
## Summary
- show the selected Keeper's measured official-client kind, runtime, phase, completed turns, process epoch, session/turn identities, tool-surface fingerprint, and durable resolution records
- expose only `retry_previous` and `restart_fresh` while recovery is required
- decode the server payload fail-closed and clear stale evidence before every reload
- support official-client evidence through one provider-neutral panel with no runtime-prefix heuristics

## Verification
- dashboard API/component tests: 123 passed
- dashboard TypeScript typecheck passed
- real Playwright interaction passed: recovery-required evidence -> `restart_fresh` -> ready evidence
- before/after screenshots inspected for clipping and overlap
- `git diff --check` passed

## Boundaries
- no operator-supplied settlement identities
- no credentials or API-key controls
- no provider-specific alias panels
- no fabricated live session state; the panel reads the durable store API
