### PR TITLE
fix(test): use total tool dispatch handler

### DIFF
--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -167,7 +167,7 @@ let () =
               let received_args = ref `Null in
               let capture_handler ~name:_ ~args =
                 received_args := args;
-                Some (tool_ok "captured")
+                tool_ok "captured"
               in
               register_full
                 ~tool_name:tool


### PR DESCRIPTION
## Summary
- update the stale `test_tool_dispatch` capture handler to return `Tool_result.result` directly
- keep the test aligned with the canonical total `Tool_dispatch.handler` contract
- do not restore the retired optional handler result

## Why
The current `main` Build and Test compilation fails because this one test handler still returns `Tool_result.result option`, while registered handlers were hard-cut to a total result in #27713.

## Verification
- GitHub CI is authoritative
- no local build or test run

## Docs and prompts
No runtime or agent-facing semantics change. The production handler contract is already documented in `Tool_dispatch`; this PR only removes a stale test wrapper, so no prompt/doc copy is added.
