### PR TITLE
feat(keeper): give HITL Auto Judge full-tool research

### DIFF
--- a/lib/keeper/hitl_research_registry.ml
+++ b/lib/keeper/hitl_research_registry.ml
@@ -1,0 +1,27 @@
+module String_map = Map.Make (String)
+
+let runners : Hitl_summary_worker.research_runner String_map.t Atomic.t =
+  Atomic.make String_map.empty
+;;
+
+let rec install ~base_path runner =
+  let current = Atomic.get runners in
+  let updated = String_map.add base_path runner current in
+  if not (Atomic.compare_and_set runners current updated)
+  then install ~base_path runner
+;;
+
+let resolve ~base_path =
+  match String_map.find_opt base_path (Atomic.get runners) with
+  | Some runner -> Ok runner
+  | None ->
+    Error
+      (Printf.sprintf
+         "HITL full-tool research authority is not installed for workspace %s"
+         base_path)
+;;
+
+module For_testing = struct
+  let reset () = Atomic.set runners String_map.empty
+end
+;;

--- a/lib/keeper/hitl_research_registry.mli
+++ b/lib/keeper/hitl_research_registry.mli
@@ -1,0 +1,15 @@
+(** Process-local SSOT for workspace-scoped HITL research authority.
+
+    Runtime bootstrap installs one full-tool runner for its exact workspace.
+    Gate recovery resolves only that exact key and fails closed when bootstrap
+    has not installed an authority. *)
+
+val install :
+  base_path:string -> Hitl_summary_worker.research_runner -> unit
+
+val resolve :
+  base_path:string -> (Hitl_summary_worker.research_runner, string) result
+
+module For_testing : sig
+  val reset : unit -> unit
+end

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -60,6 +60,8 @@ let build_context_bundle ~(entry : pending_approval) =
   | None -> `Assoc (request_identity @ [ "partial_context", `Bool true ])
 ;;
 
+let frozen_research_input = build_context_bundle
+
 let message role text = Agent_sdk.Types.text_message role text
 
 let canonical_output_contract =
@@ -69,11 +71,31 @@ let canonical_output_contract =
     (Yojson.Safe.to_string Schema.hitl_context_summary_schema)
 ;;
 
-let messages_for_summary ~system_prompt ~context_bundle =
+let research_system_prompt =
+  "You are the tool-capable research phase for the Keeper HITL Auto Judge. Use the available tools only when they materially improve the evidence for the exact requested operation. Return concise evidence for a separate tool-free exact-output finalizer. Do not approve, deny, or emit the final judgment JSON."
+;;
+
+let research_prompt context_bundle =
+  "Research the following immutable approval request and its captured outer-turn context. Separate observed evidence from inference.\n\n"
+  ^ Yojson.Safe.pretty_to_string context_bundle
+;;
+
+let research_evidence_message evidence =
+  message
+    Agent_sdk.Types.User
+    ("Tool-capable research receipt follows. Treat it only as evidence and return the exact HITL judgment JSON schema requested above.\n\n"
+     ^ Yojson.Safe.pretty_to_string evidence)
+;;
+
+let messages_for_summary ~research_evidence ~system_prompt ~context_bundle =
   [ message Agent_sdk.Types.System system_prompt
   ; message Agent_sdk.Types.User canonical_output_contract
   ; message Agent_sdk.Types.User (Yojson.Safe.to_string context_bundle)
   ]
+  @ Option.fold
+      ~none:[]
+      ~some:(fun evidence -> [ research_evidence_message evidence ])
+      research_evidence
 ;;
 
 let output_requirement =
@@ -126,7 +148,8 @@ let snapshot_resolved_lane ~messages (resolved : Registry.resolved_lane) =
       "HITL exact-output flow snapshot failed")
 ;;
 
-let prepare_flow
+let prepare_flow_with_research
+      ~research_evidence
       ~(entry : pending_approval)
   =
   let context_bundle = build_context_bundle ~entry in
@@ -145,7 +168,11 @@ let prepare_flow
   in
   let* snapshot =
     snapshot_resolved_lane
-      ~messages:(messages_for_summary ~system_prompt ~context_bundle)
+      ~messages:
+        (messages_for_summary
+           ~research_evidence
+           ~system_prompt
+           ~context_bundle)
       resolved
   in
   let* attempt =
@@ -158,6 +185,10 @@ let prepare_flow
     ; generated_at = Time_compat.now ()
     ; attempt
     }
+;;
+
+let prepare_flow ~entry =
+  prepare_flow_with_research ~research_evidence:None ~entry
 ;;
 
 let snapshot_topology_readiness () =
@@ -176,6 +207,7 @@ let snapshot_topology_readiness () =
       ~rest
       ~messages:
         (messages_for_summary
+           ~research_evidence:None
            ~system_prompt
            ~context_bundle:(`Assoc []))
       output_requirement
@@ -1179,10 +1211,102 @@ type finish_outcome =
 type spawn_outcome =
   | Worker_forked
 
+let execute_and_finish
+      ~queue_ops
+      ~net
+      ?clock
+      ~prepared
+      ~observed_summary
+      ~on_summary
+      ~on_finish
+      ~complete
+      ~completed_output
+  =
+  let execution_outcome =
+    try
+      match
+        execute_prepared_flow_with_queue_ops
+          ~queue_ops
+          ~net
+          ?clock
+          ~on_summary
+          prepared
+      with
+      | Executed -> `Completed
+      | Identity_unbound_blocked -> `Identity_unbound
+      | Exact_rejection_blocked rejection -> `Rejected rejection
+    with
+    | Cancelled_identity_unbound (cancellation, cancellation_backtrace) ->
+      `Cancelled_identity_unbound (cancellation, cancellation_backtrace)
+    | Cancelled_exact_rejected
+        (cancellation, cancellation_backtrace, rejection) ->
+      `Cancelled_rejected (cancellation, cancellation_backtrace, rejection)
+    | Cancelled_uncertain (cancellation, cancellation_backtrace, detail) ->
+      `Cancelled_uncertain (cancellation, cancellation_backtrace, detail)
+    | Eio.Cancel.Cancelled _ as cancellation ->
+      `Cancelled (cancellation, Printexc.get_raw_backtrace ())
+    | Exact_terminalization_persistence_failed _ as uncertainty ->
+      `Uncertain uncertainty
+    | Exact_terminalization_rejected rejection -> `Rejected rejection
+    | exn -> `Uncertain exn
+  in
+  match execution_outcome with
+  | `Completed ->
+    let outcome, judgment =
+      run_outcome_of_observed_summary !observed_summary
+    in
+    complete outcome (completed_output judgment);
+    on_finish Conclusive_terminalization
+  | `Cancelled (cancellation, cancellation_backtrace) ->
+    complete Exact_lane_run_registry.Cancelled `Null;
+    on_finish Terminalization_persistence_uncertain;
+    Printexc.raise_with_backtrace cancellation cancellation_backtrace
+  | `Cancelled_uncertain (cancellation, cancellation_backtrace, _detail) ->
+    complete Exact_lane_run_registry.Cancelled `Null;
+    on_finish Terminalization_persistence_uncertain;
+    Printexc.raise_with_backtrace cancellation cancellation_backtrace
+  | `Cancelled_identity_unbound (cancellation, cancellation_backtrace) ->
+    complete Exact_lane_run_registry.Cancelled `Null;
+    on_finish Terminalization_identity_unbound;
+    Printexc.raise_with_backtrace cancellation cancellation_backtrace
+  | `Cancelled_rejected (cancellation, cancellation_backtrace, _rejection) ->
+    complete Exact_lane_run_registry.Cancelled `Null;
+    on_finish Terminalization_rejected;
+    Printexc.raise_with_backtrace cancellation cancellation_backtrace
+  | `Identity_unbound ->
+    complete
+      (Exact_lane_run_registry.Failed
+         { code = "terminalization_identity_unbound"
+         ; detail = "exact attempt identity was not durably bound"
+         })
+      `Null;
+    on_finish Terminalization_identity_unbound
+  | `Rejected rejection ->
+    let detail =
+      Keeper_approval_queue.exact_attempt_error_to_string
+        (Exact_attempt_rejected rejection)
+    in
+    complete
+      (Exact_lane_run_registry.Failed
+         { code = "terminalization_rejected"; detail })
+      `Null;
+    on_finish Terminalization_rejected
+  | `Uncertain uncertainty ->
+    complete
+      (Exact_lane_run_registry.Failed
+         { code = "terminalization_persistence_uncertain"
+         ; detail = Printexc.to_string uncertainty
+         })
+      `Null;
+    on_finish Terminalization_persistence_uncertain;
+    raise uncertainty
+;;
+
 let spawn_with
       ~queue_ops
       ~prepare_flow
       ~sw
+      ~research_runner:_
       ~(entry : pending_approval)
       ~on_summary
       ~on_finish
@@ -1230,112 +1354,251 @@ let spawn_with
         ~output
     in
     Eio.Fiber.fork ~sw (fun () ->
-    let execution_outcome =
-      try
-        match
-          execute_prepared_flow_with_queue_ops
-            ~queue_ops
-            ~net
-            ?clock
-            ~on_summary
-            prepared
-        with
-        | Executed -> `Completed
-        | Identity_unbound_blocked -> `Identity_unbound
-        | Exact_rejection_blocked rejection -> `Rejected rejection
-      with
-      | Cancelled_identity_unbound
-          (cancellation, cancellation_backtrace) ->
-        `Cancelled_identity_unbound
-          (cancellation, cancellation_backtrace)
-      | Cancelled_exact_rejected
-          (cancellation, cancellation_backtrace, rejection) ->
-        `Cancelled_rejected
-          (cancellation, cancellation_backtrace, rejection)
-      | Cancelled_uncertain (cancellation, cancellation_backtrace, detail) ->
-        `Cancelled_uncertain
-          (cancellation, cancellation_backtrace, detail)
-      | Eio.Cancel.Cancelled _ as cancellation ->
-        `Cancelled (cancellation, Printexc.get_raw_backtrace ())
-      | Exact_terminalization_persistence_failed _ as uncertainty ->
-        `Uncertain uncertainty
-      | Exact_terminalization_rejected rejection ->
-        `Rejected rejection
-      | exn -> `Uncertain exn
-    in
-    match execution_outcome with
-    | `Completed ->
-      (* The flow can reach here without ever producing a summary: when every
-         candidate is rejected, [Flow_semantic_candidates_exhausted] routes to
-         [handle_semantic_exhaustion], which quarantines the candidate and
-         returns [Executed] like a judged run. Recording [Succeeded] with a
-         synthesised output made a run that judged nothing indistinguishable
-         from one that did, and the .mli already says a summary reaches
-         [on_summary] only after validation, provenance and fsync. So the
-         absence of one is the failure, and the outcome type has a variant for
-         it.
-
-         [on_finish] is unchanged: whether an exhausted flow should still
-         permit draining later owner work is a separate contract question. *)
-      let outcome, output = run_outcome_of_observed_summary !observed_summary in
-      complete outcome output;
-      on_finish Conclusive_terminalization
-    | `Cancelled (cancellation, cancellation_backtrace) ->
-      complete Exact_lane_run_registry.Cancelled `Null;
-      on_finish Terminalization_persistence_uncertain;
-      Printexc.raise_with_backtrace cancellation cancellation_backtrace
-    | `Cancelled_uncertain
-        (cancellation, cancellation_backtrace, _detail) ->
-      complete Exact_lane_run_registry.Cancelled `Null;
-      on_finish Terminalization_persistence_uncertain;
-      Printexc.raise_with_backtrace cancellation cancellation_backtrace
-    | `Cancelled_identity_unbound
-        (cancellation, cancellation_backtrace) ->
-      complete Exact_lane_run_registry.Cancelled `Null;
-      on_finish Terminalization_identity_unbound;
-      Printexc.raise_with_backtrace cancellation cancellation_backtrace
-    | `Cancelled_rejected
-        (cancellation, cancellation_backtrace, _rejection) ->
-      complete Exact_lane_run_registry.Cancelled `Null;
-      on_finish Terminalization_rejected;
-      Printexc.raise_with_backtrace cancellation cancellation_backtrace
-    | `Identity_unbound ->
-      complete
-        (Exact_lane_run_registry.Failed
-           { code = "terminalization_identity_unbound"
-           ; detail = "exact attempt identity was not durably bound"
-           })
-        `Null;
-      on_finish Terminalization_identity_unbound
-    | `Rejected rejection ->
-      let detail =
-        Keeper_approval_queue.exact_attempt_error_to_string
-          (Exact_attempt_rejected rejection)
-      in
-      complete
-        (Exact_lane_run_registry.Failed
-           { code = "terminalization_rejected"; detail })
-        `Null;
-      on_finish Terminalization_rejected
-    | `Uncertain uncertainty ->
-      complete
-        (Exact_lane_run_registry.Failed
-           { code = "terminalization_persistence_uncertain"
-           ; detail = Printexc.to_string uncertainty
-           })
-        `Null;
-      on_finish Terminalization_persistence_uncertain;
-      raise uncertainty);
+      execute_and_finish
+        ~queue_ops
+        ~net
+        ?clock
+        ~prepared
+        ~observed_summary
+        ~on_summary
+        ~on_finish
+        ~complete
+        ~completed_output:Fun.id);
     Ok Worker_forked
 ;;
 
-let spawn =
-  spawn_with
-    ~queue_ops:production_exact_queue_ops
-    ~prepare_flow
+type research_result =
+  { run_id : string
+  ; receipt : Yojson.Safe.t
+  ; finalizer_evidence : Yojson.Safe.t
+  }
+
+type research_runner =
+  register:(run_id:string -> raw_trace_path:string option -> unit) ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  net:Eio_context.eio_net ->
+  entry:pending_approval ->
+  (research_result, string) result
+
+let spawn
+      ~sw
+      ~research_runner
+      ~(entry : pending_approval)
+      ~on_summary
+      ~on_finish
+      ()
+  =
+  let* net =
+    Eio_context.get_net_opt ()
+    |> Option.to_result
+         ~none:"HITL research flow: Eio net is unavailable"
+  in
+  let* clock =
+    Eio_context.get_clock_opt ()
+    |> Option.to_result
+         ~none:"HITL research flow: Eio clock is unavailable"
+  in
+  let* () = snapshot_topology_readiness () in
+  let registry = Exact_lane_run_registry.global () in
+  let started_at = Time_compat.now () in
+  let started_at_monotonic = Eio.Time.now clock in
+  let context_bundle = build_context_bundle ~entry in
+  let registered_run_id = ref None in
+  let register ~run_id ~raw_trace_path =
+    match !registered_run_id with
+    | Some current when String.equal current run_id -> ()
+    | Some _ -> invalid_arg "HITL research attempted to replace its run identity"
+    | None ->
+      Exact_lane_run_registry.register_running
+        registry
+        ~run_id
+        ~lane:Exact_lane_run_registry.Hitl_auto_judge
+        ~subject_id:entry.id
+        ~actor:entry.keeper_name
+        ~started_at
+        ~input:
+          (Exact_lane_run_registry.research_input
+             ~raw_trace_path
+             ~payload:
+               (`Assoc
+                  [ "tool_name", `String entry.tool_name
+                  ; "turn_id", Json_util.int_opt_to_json entry.turn_id
+                  ; "task_id", Json_util.string_opt_to_json entry.task_id
+                  ; "goal_id", Json_util.string_opt_to_json entry.goal_id
+                  ; ( "goal_ids"
+                    , `List (List.map (fun goal -> `String goal) entry.goal_ids) )
+                  ; "partial_context", `Bool (Option.is_none entry.request_context)
+                  ; "frozen_input", context_bundle
+                  ]));
+      registered_run_id := Some run_id
+  in
+  let ensure_registered () =
+    match !registered_run_id with
+    | Some run_id -> run_id
+    | None ->
+      let run_id = Random_id.prefixed ~prefix:"hitl-research-setup-" ~bytes:16 in
+      register ~run_id ~raw_trace_path:None;
+      run_id
+  in
+  let complete outcome output =
+    Exact_lane_run_registry.mark_completed
+      registry
+      ~run_id:(ensure_registered ())
+      ~outcome
+      ~elapsed_s:(Eio.Time.now clock -. started_at_monotonic)
+      ~output
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    let exact_started = ref false in
+    let run_pipeline () =
+    match research_runner ~register ~clock ~net ~entry with
+    | Error detail ->
+      ignore (ensure_registered ());
+      (match persist_identity_unbound entry with
+       | Ok () | Error `Transition_not_applied ->
+         complete
+           (Exact_lane_run_registry.Failed
+              { code = "research_setup_failed"; detail })
+           (`Assoc [ "research", `Null; "judgment", `Null ]);
+         on_finish Terminalization_identity_unbound
+       | Error (`Rejected rejection) ->
+         complete
+           (Exact_lane_run_registry.Failed
+              { code = "terminalization_rejected"
+              ; detail =
+                  Keeper_approval_queue.exact_attempt_error_to_string
+                    (Exact_attempt_rejected rejection)
+              })
+           (`Assoc [ "research", `Null; "judgment", `Null ]);
+         on_finish Terminalization_rejected
+       | Error (`Storage_failed persistence_detail) ->
+         complete
+           (Exact_lane_run_registry.Failed
+              { code = "terminalization_persistence_uncertain"
+              ; detail = persistence_detail
+              })
+           (`Assoc [ "research", `Null; "judgment", `Null ]);
+         on_finish Terminalization_persistence_uncertain)
+    | Ok research ->
+    (match !registered_run_id with
+     | Some run_id when String.equal run_id research.run_id -> ()
+     | Some _ ->
+       invalid_arg "HITL research receipt does not own the registered run identity"
+     | None ->
+       invalid_arg "HITL research returned without registering its run identity");
+    match
+      prepare_flow_with_research
+        ~research_evidence:(Some research.finalizer_evidence)
+        ~entry
+    with
+    | Error detail ->
+      (match persist_identity_unbound entry with
+       | Ok () | Error `Transition_not_applied ->
+         complete
+           (Exact_lane_run_registry.Failed
+              { code = "exact_setup_failed"; detail })
+           (`Assoc [ "research", research.receipt; "judgment", `Null ]);
+         on_finish Terminalization_identity_unbound
+       | Error (`Rejected rejection) ->
+         complete
+           (Exact_lane_run_registry.Failed
+              { code = "terminalization_rejected"
+              ; detail =
+                  Keeper_approval_queue.exact_attempt_error_to_string
+                    (Exact_attempt_rejected rejection)
+              })
+           (`Assoc [ "research", research.receipt; "judgment", `Null ]);
+         on_finish Terminalization_rejected
+       | Error (`Storage_failed persistence_detail) ->
+         complete
+           (Exact_lane_run_registry.Failed
+              { code = "terminalization_persistence_uncertain"
+              ; detail = persistence_detail
+              })
+           (`Assoc [ "research", research.receipt; "judgment", `Null ]);
+         on_finish Terminalization_persistence_uncertain)
+    | Ok prepared ->
+      exact_started := true;
+      let observed_summary = ref None in
+      let observed_on_summary summary =
+        observed_summary := Some summary;
+        on_summary summary
+      in
+      execute_and_finish
+        ~queue_ops:production_exact_queue_ops
+        ~net
+        ~clock
+        ~prepared
+        ~observed_summary
+        ~on_summary:observed_on_summary
+        ~on_finish
+        ~complete
+        ~completed_output:(fun judgment ->
+          `Assoc [ "research", research.receipt; "judgment", judgment ])
+    in
+    try run_pipeline () with
+    | Eio.Cancel.Cancelled _ as cancellation when !exact_started ->
+      Printexc.raise_with_backtrace cancellation (Printexc.get_raw_backtrace ())
+    | Eio.Cancel.Cancelled _ as cancellation ->
+      let cancellation_backtrace = Printexc.get_raw_backtrace () in
+      Eio.Cancel.protect (fun () ->
+        ignore (ensure_registered ());
+        match persist_identity_unbound entry with
+        | Ok () | Error `Transition_not_applied ->
+          complete Exact_lane_run_registry.Cancelled `Null;
+          on_finish Terminalization_identity_unbound
+        | Error (`Rejected _) ->
+          complete Exact_lane_run_registry.Cancelled `Null;
+          on_finish Terminalization_rejected
+        | Error (`Storage_failed _) ->
+          complete Exact_lane_run_registry.Cancelled `Null;
+          on_finish Terminalization_persistence_uncertain);
+      Printexc.raise_with_backtrace cancellation cancellation_backtrace
+    | exn when !exact_started ->
+      Printexc.raise_with_backtrace exn (Printexc.get_raw_backtrace ())
+    | exn ->
+      let detail = Printexc.to_string exn in
+      ignore (ensure_registered ());
+      (match persist_identity_unbound entry with
+       | Ok () | Error `Transition_not_applied ->
+         complete
+           (Exact_lane_run_registry.Failed
+              { code = "research_runtime_crashed"; detail })
+           (`Assoc [ "research", `Null; "judgment", `Null ]);
+         on_finish Terminalization_identity_unbound
+       | Error (`Rejected _) ->
+         complete
+           (Exact_lane_run_registry.Failed
+              { code = "terminalization_rejected"; detail })
+           (`Assoc [ "research", `Null; "judgment", `Null ]);
+         on_finish Terminalization_rejected
+       | Error (`Storage_failed persistence_detail) ->
+         complete
+           (Exact_lane_run_registry.Failed
+              { code = "terminalization_persistence_uncertain"
+              ; detail = persistence_detail
+              })
+           (`Assoc [ "research", `Null; "judgment", `Null ]);
+         on_finish Terminalization_persistence_uncertain));
+  Ok Worker_forked
 ;;
 
 module For_testing = struct
+  let passthrough_research_runner ~register ~clock:_ ~net:_ ~entry =
+    let run_id = Random_id.prefixed ~prefix:"test-hitl-research-" ~bytes:8 in
+    register ~run_id ~raw_trace_path:None;
+    Ok
+      { run_id
+      ; receipt =
+          `Assoc
+            [ "owner", `String "hitl_auto_judge"
+            ; "test_passthrough", `Bool true
+            ; "frozen_input", build_context_bundle ~entry
+            ]
+      ; finalizer_evidence = `Assoc [ "test_passthrough", `Bool true ]
+      }
+  ;;
+
   let run_outcome_of_observed_summary = run_outcome_of_observed_summary
 
   type nonrec prepared_flow = prepared_flow
@@ -1384,6 +1647,7 @@ module For_testing = struct
   let spawn_with_queue_ops
         ~queue_ops
         ~sw
+        ~research_runner
         ~entry
         ~on_summary
         ~on_finish
@@ -1393,6 +1657,7 @@ module For_testing = struct
       ~queue_ops
       ~prepare_flow
       ~sw
+      ~research_runner
       ~entry
       ~on_summary
       ~on_finish

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -16,6 +16,12 @@ val snapshot_topology_readiness : unit -> (unit, string) result
 
 exception Exact_terminalization_persistence_failed of string
 
+val frozen_research_input :
+  entry:Keeper_approval_queue.pending_approval -> Yojson.Safe.t
+
+val research_system_prompt : string
+val research_prompt : Yojson.Safe.t -> string
+
 type execution_boundary =
   | Executed
   | Identity_unbound_blocked
@@ -30,21 +36,40 @@ type finish_outcome =
 type spawn_outcome =
   | Worker_forked
 
+type research_result =
+  { run_id : string
+  ; receipt : Yojson.Safe.t
+  ; finalizer_evidence : Yojson.Safe.t
+  }
+
+type research_runner =
+  register:(run_id:string -> raw_trace_path:string option -> unit) ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  net:Eio_context.eio_net ->
+  entry:Keeper_approval_queue.pending_approval ->
+  (research_result, string) result
+
 val spawn
   :  sw:Eio.Switch.t
+  -> research_runner:research_runner
   -> entry:Keeper_approval_queue.pending_approval
   -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
   -> on_finish:(finish_outcome -> unit)
   -> unit
   -> (spawn_outcome, string) result
-(** Freeze and admit the whole ordered flow before forking. The production OAS
-    callbacks bind/release the real candidate receipt in the durable approval
-    queue. A summary reaches [on_summary] only after domain validation, exact
-    receipt/provenance verification, and [Fsync_completed] completion.
+(** Verify finalizer topology and runtime resources before forking. The worker
+    then runs the tool-capable research phase, freezes its bounded evidence into
+    a separate tool-free exact-output flow, and preserves the research receipt
+    under the same run identity. The production OAS callbacks bind/release the
+    real candidate receipt in the durable approval queue. A summary reaches
+    [on_summary] only after domain validation, exact receipt/provenance
+    verification, and [Fsync_completed] completion.
     [on_finish] always permits active-owner cleanup, but only
     [Conclusive_terminalization] permits the caller to drain later owner work. *)
 
 module For_testing : sig
+  val passthrough_research_runner : research_runner
+
   val run_outcome_of_observed_summary
     :  Keeper_approval_queue.hitl_context_summary option
     -> Exact_lane_run_registry.outcome * Yojson.Safe.t
@@ -137,6 +162,7 @@ module For_testing : sig
   val spawn_with_queue_ops
     :  queue_ops:exact_queue_ops
     -> sw:Eio.Switch.t
+    -> research_runner:research_runner
     -> entry:Keeper_approval_queue.pending_approval
     -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
     -> on_finish:(finish_outcome -> unit)

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -628,6 +628,7 @@ let drain_auto_judge_owners_with ~drain_owner owners =
 
 type hitl_worker_spawner =
   sw:Eio.Switch.t ->
+  research_runner:Hitl_summary_worker.research_runner ->
   entry:Keeper_approval_queue.pending_approval ->
   on_summary:(Keeper_approval_queue.hitl_context_summary -> unit) ->
   on_finish:(Hitl_summary_worker.finish_outcome -> unit) ->
@@ -679,6 +680,7 @@ let reserve_pre_worker_start
 
 let rec spawn_claimed_auto_judge_entry_with
       ~(spawn_worker : hitl_worker_spawner)
+      ~research_runner
       (entry : Keeper_approval_queue.pending_approval)
   =
   let approval_id = entry.id in
@@ -710,6 +712,7 @@ let rec spawn_claimed_auto_judge_entry_with
        match
          spawn_worker
            ~sw
+           ~research_runner
            ~entry
            ~on_summary
            ~on_finish:(fun finish_outcome ->
@@ -718,6 +721,7 @@ let rec spawn_claimed_auto_judge_entry_with
              | Hitl_summary_worker.Conclusive_terminalization ->
                ignore
                  (drain_auto_judge_owner
+                    ~research_runner
                     ~base_path:entry.audit_base_path
                     ~keeper_name:entry.keeper_name
                     ())
@@ -767,25 +771,36 @@ let rec spawn_claimed_auto_judge_entry_with
     release_auto_judge entry;
     Error reason
 
-and spawn_claimed_auto_judge_entry entry =
+and spawn_claimed_auto_judge_entry
+      ~research_runner
+      entry
+  =
   spawn_claimed_auto_judge_entry_with
     ~spawn_worker:Hitl_summary_worker.spawn
+    ~research_runner
     entry
 
 and spawn_auto_judge_entry_with
       ~(spawn_worker : hitl_worker_spawner)
+      ~research_runner
       (entry : Keeper_approval_queue.pending_approval)
   =
   if claim_auto_judge entry
-  then spawn_claimed_auto_judge_entry_with ~spawn_worker entry
+  then
+    spawn_claimed_auto_judge_entry_with
+      ~spawn_worker
+      ~research_runner
+      entry
   else Ok Skipped
 
-and spawn_auto_judge_entry entry =
+and spawn_auto_judge_entry ~research_runner entry =
   spawn_auto_judge_entry_with
     ~spawn_worker:Hitl_summary_worker.spawn
+    ~research_runner
     entry
 
 and retry_auto_judge_entry
+      ~research_runner
       ~requested_by
       ~expected_input_hash
       ~expected_sequence
@@ -818,6 +833,7 @@ and retry_auto_judge_entry
     (try
        match
          drain_auto_judge_owner
+           ~research_runner
            ~reserved_id:entry.id
            ~base_path:entry.audit_base_path
            ~keeper_name:entry.keeper_name
@@ -863,7 +879,10 @@ and retry_auto_judge_entry
        in
        Error (reblock reason))
 
-and start_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+and start_auto_judge
+      ~research_runner
+      (entry : Keeper_approval_queue.pending_approval)
+  =
   if not (claim_auto_judge entry)
   then Ok Skipped
   else
@@ -874,9 +893,15 @@ and start_auto_judge (entry : Keeper_approval_queue.pending_approval) =
     | Ok false ->
       release_auto_judge entry;
       Ok Skipped
-    | Ok true -> spawn_claimed_auto_judge_entry entry
+    | Ok true ->
+      spawn_claimed_auto_judge_entry
+        ~research_runner
+        entry
 
-and start_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+and start_auto_judge_entry
+      ~research_runner
+      (entry : Keeper_approval_queue.pending_approval)
+  =
   match
     Keeper_approval_queue.get_pending_entry_for_workspace
       ~base_path:entry.audit_base_path
@@ -887,13 +912,16 @@ and start_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
   | Ok None -> Ok Skipped
   | Ok (Some current) ->
     (match classify_auto_judge_entry current with
-     | Auto_judge_not_requested -> start_auto_judge current
-     | Auto_judge_pending_unbound -> spawn_auto_judge_entry current
+     | Auto_judge_not_requested ->
+       start_auto_judge ~research_runner current
+     | Auto_judge_pending_unbound ->
+       spawn_auto_judge_entry ~research_runner current
      | Auto_judge_finalizable _
      | Auto_judge_ineligible ->
        Ok Skipped)
 
 and drain_auto_judge_owner_queue
+      ~research_runner
       ?reserved_id
       ~base_path
       ~keeper_name
@@ -910,8 +938,9 @@ and drain_auto_judge_owner_queue
         match reserved_id with
         | Some reserved_id
           when auto_judge_entry_has_start_reservation reserved_id entry ->
-          spawn_auto_judge_entry entry
-        | Some _ | None -> start_auto_judge_entry entry
+          spawn_auto_judge_entry ~research_runner entry
+        | Some _ | None ->
+          start_auto_judge_entry ~research_runner entry
       in
       (match start_result with
        | Ok Started ->
@@ -970,6 +999,7 @@ and drain_auto_judge_owner_queue
     loop [] blocker selected)
 
 and drain_auto_judge_owner
+      ~research_runner
       ?reserved_id
       ~base_path
       ~keeper_name
@@ -978,6 +1008,7 @@ and drain_auto_judge_owner
   match Keeper_gate_mode.read ~base_path with
   | Ok Keeper_gate_mode.Auto_judge ->
     drain_auto_judge_owner_queue
+      ~research_runner
       ?reserved_id
       ~base_path
       ~keeper_name
@@ -1003,7 +1034,7 @@ and drain_auto_judge_owner
       detail;
     Error detail
 
-and drain_auto_judges ~base_path =
+and drain_auto_judges ~research_runner ~base_path =
   match Keeper_gate_mode.read ~base_path with
   | Error detail ->
     Log.Keeper.error
@@ -1030,7 +1061,11 @@ and drain_auto_judges ~base_path =
        Ok
          (drain_auto_judge_owners_with
             ~drain_owner:(fun ~base_path ~keeper_name ->
-              drain_auto_judge_owner_queue ~base_path ~keeper_name ()
+              drain_auto_judge_owner_queue
+                ~research_runner
+                ~base_path
+                ~keeper_name
+                ()
               |> Result.map
                    (fun (outcome : auto_judge_drain_outcome) ->
                       outcome.started_id, outcome.failures)
@@ -1141,6 +1176,7 @@ let observe_recovered_work kind (entry : Keeper_approval_queue.pending_approval)
 ;;
 
 let retry_blocked_auto_judge
+      ~research_runner
       ~base_path
       ~requested_by
       ~expected_input_hash
@@ -1165,6 +1201,7 @@ let retry_blocked_auto_judge
      | Ok (Some entry) ->
        (match
           retry_auto_judge_entry
+            ~research_runner
             ~requested_by
             ~expected_input_hash
             ~expected_sequence
@@ -1271,6 +1308,7 @@ let finalize_recovered_judgment
 
 let resume_persisted_auto_judges_with
       ~complete_summary_exact_attempt
+      ~research_runner
       ~base_path
   =
   match recovered_work_for_base_path ~base_path with
@@ -1291,7 +1329,11 @@ let resume_persisted_auto_judges_with
            match work with
            | Activate_worker entry ->
              observe_recovered_work `Activate_worker entry;
-             entry, `Start (start_auto_judge_entry entry)
+             ( entry
+             , `Start
+                 (start_auto_judge_entry
+                    ~research_runner
+                    entry) )
              | Finalize_judgment (entry, summary) ->
                observe_recovered_work `Finalize_judgment entry;
                ( entry
@@ -1334,10 +1376,11 @@ let resume_persisted_auto_judges_with
     }
 ;;
 
-let resume_persisted_auto_judges =
+let resume_persisted_auto_judges ~research_runner =
   resume_persisted_auto_judges_with
     ~complete_summary_exact_attempt:
       Keeper_approval_queue.complete_summary_exact_attempt
+    ~research_runner
 ;;
 
 type operator_recovery_report =
@@ -1346,7 +1389,10 @@ type operator_recovery_report =
   ; failures : auto_judge_owner_failure list
   }
 
-let request_operator_auto_judge_recovery ~base_path =
+let request_operator_auto_judge_recovery
+      ~research_runner
+      ~base_path
+  =
   match Keeper_gate_mode.read ~base_path with
   | Error detail -> Error detail
   | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) ->
@@ -1355,7 +1401,11 @@ let request_operator_auto_judge_recovery ~base_path =
     (match Hitl_summary_worker.snapshot_topology_readiness () with
      | Error detail -> Error detail
      | Ok () ->
-       (match drain_auto_judges ~base_path with
+       (match
+          drain_auto_judges
+            ~research_runner
+            ~base_path
+        with
        | Error detail -> Error detail
        | Ok drain_report ->
           (match
@@ -1386,17 +1436,32 @@ let defer request reason =
       match reason with
       | Judge_requested ->
         let drained =
-          try
-            drain_auto_judge_owner
-              ~base_path:request.base_path
-              ~keeper_name:request.keeper_name
-              ()
-          with
-          | Eio.Cancel.Cancelled _ as exn -> raise exn
-          | exn ->
-            Error
-              ("Auto Judge start failed before worker launch: "
-               ^ Printexc.to_string exn)
+          match Hitl_research_registry.resolve ~base_path:request.base_path with
+          | Error detail ->
+            let detail =
+              match Keeper_approval_queue.mark_summary_pending ~id:approval_id with
+              | Ok true -> detail
+              | Ok false ->
+                detail ^ "; summary pending transition was not applied"
+              | Error error ->
+                detail
+                ^ "; summary pending transition failed: "
+                ^ Keeper_approval_queue.summary_transition_error_to_string error
+            in
+            Error detail
+          | Ok research_runner ->
+            (try
+               drain_auto_judge_owner
+                 ~research_runner
+                 ~base_path:request.base_path
+                 ~keeper_name:request.keeper_name
+                 ()
+             with
+             | Eio.Cancel.Cancelled _ as exn -> raise exn
+             | exn ->
+               Error
+                 ("Auto Judge start failed before worker launch: "
+                  ^ Printexc.to_string exn))
         in
         (match drained with
          | Error detail -> Auto_judge_unavailable detail
@@ -1515,9 +1580,12 @@ let observe_exact_rule_expired
 ;;
 
 let decide_from_selected_mode request = function
-  | Error detail -> defer request (Mode_state_invalid detail)
-  | Ok Keeper_gate_mode.Manual -> defer request Human_requested
-  | Ok Keeper_gate_mode.Auto_judge -> defer request Judge_requested
+  | Error detail ->
+    defer request (Mode_state_invalid detail)
+  | Ok Keeper_gate_mode.Manual ->
+    defer request Human_requested
+  | Ok Keeper_gate_mode.Auto_judge ->
+    defer request Judge_requested
   | Ok Keeper_gate_mode.Always_allow ->
     let source = Workspace_always_allow in
     audit_allow
@@ -1527,7 +1595,10 @@ let decide_from_selected_mode request = function
     Allow { source }
 ;;
 
-let decide_without_cycle_grant ~keeper_always_allow request =
+let decide_without_cycle_grant
+      ~keeper_always_allow
+      request
+  =
   if keeper_always_allow
   then (
     let source = Keeper_always_allow in
@@ -1575,7 +1646,11 @@ let decide_without_cycle_grant ~keeper_always_allow request =
           decide_from_selected_mode request mode))
 ;;
 
-let decide ?cycle_grant ~keeper_always_allow request =
+let decide
+      ?cycle_grant
+      ~keeper_always_allow
+      request
+  =
   let grant_result =
     match cycle_grant with
     | None -> Cycle_grant_not_applicable
@@ -1587,7 +1662,9 @@ let decide ?cycle_grant ~keeper_always_allow request =
     audit_allow request ~source_approval_id:approval_id source;
     Allow { source }
   | Cycle_grant_not_applicable ->
-    decide_without_cycle_grant ~keeper_always_allow request
+    decide_without_cycle_grant
+      ~keeper_always_allow
+      request
   | Cycle_grant_temporarily_unavailable (approval_id, reason) ->
     Log.Keeper.warn
       ~keeper_name:request.keeper_name
@@ -1651,8 +1728,17 @@ module For_testing = struct
 
   type nonrec hitl_worker_spawner = hitl_worker_spawner
 
-  let spawn_auto_judge_entry_with_worker ~spawn_worker entry =
-    match spawn_auto_judge_entry_with ~spawn_worker entry with
+  let spawn_auto_judge_entry_with_worker
+        ~spawn_worker
+        ~research_runner
+        entry
+    =
+    match
+      spawn_auto_judge_entry_with
+        ~spawn_worker
+        ~research_runner
+        entry
+    with
     | Ok Started -> Ok true
     | Ok Skipped -> Ok false
     | Error reason -> Error reason

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -130,9 +130,12 @@ val decide :
     merely because a process restarted. Every recovery candidate id has an
     explicit started, finalized, skipped, or failed outcome. *)
 val resume_persisted_auto_judges :
-  base_path:string -> auto_judge_resume_report
+  research_runner:Hitl_summary_worker.research_runner ->
+  base_path:string ->
+  auto_judge_resume_report
 
 val retry_blocked_auto_judge :
+  research_runner:Hitl_summary_worker.research_runner ->
   base_path:string ->
   requested_by:string ->
   expected_input_hash:string ->
@@ -167,7 +170,9 @@ type operator_recovery_report =
     Exact-bound entries remain operator-visible but are never reconstructed or
     reopened. *)
 val request_operator_auto_judge_recovery :
-  base_path:string -> (operator_recovery_report, string) result
+  research_runner:Hitl_summary_worker.research_runner ->
+  base_path:string ->
+  (operator_recovery_report, string) result
 
 val authorization_source_to_string : authorization_source -> string
 val deferred_reason_to_string : deferred_reason -> string
@@ -217,6 +222,7 @@ module For_testing : sig
 
   type hitl_worker_spawner =
     sw:Eio.Switch.t ->
+    research_runner:Hitl_summary_worker.research_runner ->
     entry:Keeper_approval_queue.pending_approval ->
     on_summary:(Keeper_approval_queue.hitl_context_summary -> unit) ->
     on_finish:(Hitl_summary_worker.finish_outcome -> unit) ->
@@ -225,6 +231,7 @@ module For_testing : sig
 
   val spawn_auto_judge_entry_with_worker
     :  spawn_worker:hitl_worker_spawner
+    -> research_runner:Hitl_summary_worker.research_runner
     -> Keeper_approval_queue.pending_approval
     -> (bool, string) result
   (** Run the production atomic claim, active-owner lifecycle, cleanup, and
@@ -232,6 +239,7 @@ module For_testing : sig
 
   val resume_persisted_auto_judges_with_exact_completion :
     complete_summary_exact_attempt:exact_completion ->
+    research_runner:Hitl_summary_worker.research_runner ->
     base_path:string ->
     auto_judge_resume_report
 end

--- a/lib/keeper/keeper_hitl_research_runtime.ml
+++ b/lib/keeper/keeper_hitl_research_runtime.ml
@@ -1,0 +1,89 @@
+let make_runner
+      ~(config : Workspace.config)
+      ~publication_recovery_provider
+      ~register
+      ~clock
+      ~net
+      ~(entry : Keeper_approval_queue.pending_approval)
+  =
+  let open Result.Syntax in
+  let* () =
+    if String.equal config.base_path entry.audit_base_path
+    then Ok ()
+    else Error "HITL research config does not match the approval workspace"
+  in
+  let* resources =
+    Keeper_publication_recovery_scope.resolve_turn_resources
+      ~provider:publication_recovery_provider
+      ~base_path:entry.audit_base_path
+      ~keeper_name:entry.keeper_name
+    |> Result.map_error (fun failure ->
+      "HITL research context unavailable: "
+      ^ Keeper_publication_recovery_scope.failure_to_string failure)
+  in
+  let frozen_input = Hitl_summary_worker.frozen_research_input ~entry in
+  let ctx_snapshot =
+    Keeper_context_runtime.create
+      ~eio:true
+      ~system_prompt:Hitl_summary_worker.research_system_prompt
+    |> fun ctx ->
+    Keeper_context_runtime.append
+      ctx
+      (Agent_sdk.Types.text_message
+         Agent_sdk.Types.User
+         (Yojson.Safe.to_string frozen_input))
+  in
+  let execution_id = Keeper_internal_research.Execution_id.generate () in
+  let run_id = Keeper_internal_research.Execution_id.to_string execution_id in
+  let registered = ref false in
+  let register_once raw_trace_path =
+    if not !registered
+    then (
+      register ~run_id ~raw_trace_path;
+      registered := true)
+  in
+  let raw_trace =
+    match
+      Keeper_internal_research.create_raw_trace_sink
+        ~before_create:(fun path -> register_once (Some path))
+        ~config
+        ~meta:resources.entry.meta
+        ~execution_id
+    with
+    | Keeper_internal_research.Raw_trace_ready sink -> Some sink
+    | Keeper_internal_research.Raw_trace_degraded error ->
+      register_once None;
+      Log.Keeper.warn
+        ~keeper_name:entry.keeper_name
+        "HITL research raw-trace sink degraded; dispatching untraced: %s"
+        (Agent_sdk.Error.to_string error);
+      None
+  in
+  register_once None;
+  let receipt =
+    Keeper_internal_research.run
+      { owner = Keeper_internal_research.Hitl_auto_judge
+      ; execution_id
+      ; runtime_id =
+          Keeper_meta_contract.runtime_id_of_meta resources.entry.meta
+      ; frozen_system_prompt = Hitl_summary_worker.research_system_prompt
+      ; frozen_prompt = Hitl_summary_worker.research_prompt frozen_input
+      ; frozen_input
+      ; evidence_budget_bytes = 16 * 1024
+      ; config
+      ; meta = resources.entry.meta
+      ; publication_recovery = resources.publication_recovery
+      ; ctx_snapshot
+      ; clock
+      ; net
+      ; continuation_channel = Some entry.continuation_channel
+      ; raw_trace
+      }
+  in
+  Ok
+    { Hitl_summary_worker.run_id = run_id
+    ; receipt = Keeper_internal_research.receipt_to_yojson receipt
+    ; finalizer_evidence =
+        Keeper_internal_research.finalizer_evidence_to_yojson receipt
+    }
+;;

--- a/lib/keeper/keeper_hitl_research_runtime.mli
+++ b/lib/keeper/keeper_hitl_research_runtime.mli
@@ -1,0 +1,12 @@
+(** Late-bound full-tool research adapter for the HITL Auto Judge.
+
+    [Hitl_summary_worker] is upstream of the Keeper runtime and therefore owns
+    only the neutral runner contract. This adapter lives beside the complete
+    tool bundle and closes over the runtime capabilities required by that
+    contract. *)
+
+val make_runner :
+  config:Workspace.config ->
+  publication_recovery_provider:
+    Keeper_publication_recovery_availability.provider ->
+  Hitl_summary_worker.research_runner

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -420,7 +420,12 @@ let dashboard_gate_resolve_http_json ~base_path ~created_by ~(args : Yojson.Safe
           Error (Gone err)))
 ;;
 
-let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe.t) =
+let dashboard_gate_retry_http_json
+      ~research_runner
+      ~base_path
+      ~requested_by
+      ~(args : Yojson.Safe.t)
+  =
   let ( let* ) = Result.bind in
   let* fields =
     match args with
@@ -494,6 +499,7 @@ let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe
   in
   match
     Keeper_gate.retry_blocked_auto_judge
+      ~research_runner
       ~base_path
       ~requested_by
       ~expected_input_hash

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -89,6 +89,7 @@ val dashboard_gate_resolve_http_json :
   (Yojson.Safe.t, approval_resolve_http_error) result
 
 val dashboard_gate_retry_http_json :
+  research_runner:Hitl_summary_worker.research_runner ->
   base_path:string ->
   requested_by:string ->
   args:Yojson.Safe.t ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -486,6 +486,11 @@ let handle_gate_mode_body state operator_name request reqd body_str =
               | Keeper_gate_mode.Auto_judge ->
                 (match
                    Keeper_gate.request_operator_auto_judge_recovery
+                     ~research_runner:
+                       (Keeper_hitl_research_runtime.make_runner
+                          ~config
+                          ~publication_recovery_provider:
+                            (Mcp_server.publication_recovery_availability_provider state))
                      ~base_path:config.base_path
                  with
                  | Ok report -> Recovery_completed report
@@ -556,8 +561,19 @@ let handle_gate_resolve_body state operator_name request reqd body_str =
 let handle_gate_retry_body state operator_name request reqd body_str =
   try
     let args = Yojson.Safe.from_string body_str in
-    let base_path = (Mcp_server.workspace_config state).base_path in
-    match dashboard_gate_retry_http_json ~base_path ~requested_by:operator_name ~args with
+    let config = Mcp_server.workspace_config state in
+    let base_path = config.base_path in
+    match
+      dashboard_gate_retry_http_json
+        ~research_runner:
+          (Keeper_hitl_research_runtime.make_runner
+             ~config
+             ~publication_recovery_provider:
+               (Mcp_server.publication_recovery_availability_provider state))
+        ~base_path
+        ~requested_by:operator_name
+        ~args
+    with
     | Ok json -> respond_json_value_with_cors request reqd json
     | Error message ->
       respond_json_value_with_cors

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1208,7 +1208,15 @@ let start_post_ready_owner_lanes
   Server_bootstrap_loops.start_background_maintenance ~sw ~clock ~env state
 
 let install_keeper_gate_persistence state =
-  let base_path = (Mcp_server.workspace_config state).base_path in
+  let config = Mcp_server.workspace_config state in
+  let base_path = config.base_path in
+  let research_runner =
+    Keeper_hitl_research_runtime.make_runner
+      ~config
+      ~publication_recovery_provider:
+        (Mcp_server.publication_recovery_availability_provider state)
+  in
+  Hitl_research_registry.install ~base_path research_runner;
   match Keeper_approval_queue.install_persistence ~base_path with
   | Error error ->
     (* Gate persistence is lane-local. Keep unrelated server subsystems
@@ -1239,7 +1247,11 @@ let install_keeper_gate_persistence state =
            failure.approval_id
            failure.reason)
       report.delivery_replay_failures;
-    let resume_report = Keeper_gate.resume_persisted_auto_judges ~base_path in
+    let resume_report =
+      Keeper_gate.resume_persisted_auto_judges
+        ~research_runner
+        ~base_path
+    in
     (match resume_report.queue_error with
      | Some error ->
        Log.Server.error

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -6,6 +6,29 @@ module Gate = Masc.Keeper_gate
 module Q = Masc.Keeper_approval_queue
 module Schema = Masc.Keeper_structured_output_schema
 module Worker = Masc.Hitl_summary_worker
+module Research_registry = Masc.Hitl_research_registry
+
+let test_research_runner = Worker.For_testing.passthrough_research_runner
+
+let test_research_registry_is_exact_workspace_scoped () =
+  Research_registry.For_testing.reset ();
+  check bool
+    "uninstalled workspace fails closed"
+    true
+    (Result.is_error (Research_registry.resolve ~base_path:"/workspace/a"));
+  Research_registry.install
+    ~base_path:"/workspace/a"
+    test_research_runner;
+  check bool
+    "installed workspace resolves"
+    true
+    (Result.is_ok (Research_registry.resolve ~base_path:"/workspace/a"));
+  check bool
+    "different workspace does not inherit authority"
+    true
+    (Result.is_error (Research_registry.resolve ~base_path:"/workspace/b"));
+  Research_registry.For_testing.reset ()
+;;
 
 let yojson = testable Yojson.Safe.pretty_print Yojson.Safe.equal
 
@@ -887,7 +910,11 @@ let test_visible_completion_blocks_gate_delivery () =
          ()
        | _ -> fail "visible completion did not retain recoverable completed state");
        install_queue base_path;
-       let recovery = Gate.resume_persisted_auto_judges ~base_path in
+       let recovery =
+         Gate.resume_persisted_auto_judges
+           ~research_runner:test_research_runner
+           ~base_path
+       in
        check
          (list string)
          "restart finalizes only the uncertain oldest entry"
@@ -1087,7 +1114,11 @@ let test_flow_execution_failure_quarantines_and_allows_successor () =
               ; base_url = successor_server.base_url
               }
             ]);
-       let resumed = Gate.resume_persisted_auto_judges ~base_path in
+       let resumed =
+         Gate.resume_persisted_auto_judges
+           ~research_runner:test_research_runner
+           ~base_path
+       in
        check
          (list string)
          "quarantined entry does not stall a later owner entry"
@@ -1143,6 +1174,7 @@ let test_manual_resolution_race_is_conclusive () =
        let finish_outcome = ref None in
        (match
           Worker.For_testing.spawn_with_queue_ops
+            ~research_runner:test_research_runner
             ~queue_ops:(exact_queue_ops ())
             ~sw
             ~entry
@@ -1265,6 +1297,7 @@ let test_spawn_preserves_cancellation_origin_backtrace () =
                 @@ fun worker_sw ->
                 match
                   Worker.For_testing.spawn_with_queue_ops
+                    ~research_runner:test_research_runner
                     ~queue_ops:(exact_queue_ops ~bind_writer ())
                     ~sw:worker_sw
                     ~entry
@@ -1356,9 +1389,11 @@ let test_prebind_cancellation_withholds_production_gate_drain () =
                 Eio_context.set_switch worker_sw;
                 match
                   Gate.For_testing.spawn_auto_judge_entry_with_worker
+                    ~research_runner:test_research_runner
                     ~spawn_worker:
-                      (fun ~sw ~entry ~on_summary ~on_finish () ->
+                      (fun ~sw ~research_runner ~entry ~on_summary ~on_finish () ->
                          Worker.For_testing.spawn_with_queue_ops
+                           ~research_runner
                            ~queue_ops:
                              (exact_queue_ops
                                 ~bind_writer:(fun _path _body ->
@@ -1462,6 +1497,7 @@ let test_bound_cancellation_cleanup_uncertainty_preserves_origin () =
                 @@ fun worker_sw ->
                 match
                   Worker.For_testing.spawn_with_queue_ops
+                    ~research_runner:test_research_runner
                     ~queue_ops:
                       (exact_queue_ops
                          ~quarantine_writer:unknown_writer
@@ -1533,8 +1569,9 @@ let test_pre_worker_start_failure_preserves_unbound_pending () =
        let entry = pending_entry ~base_path () in
        (match
           Gate.For_testing.spawn_auto_judge_entry_with_worker
+            ~research_runner:test_research_runner
             ~spawn_worker:
-              (fun ~sw:_ ~entry:_ ~on_summary:_ ~on_finish:_ () ->
+              (fun ~sw:_ ~research_runner:_ ~entry:_ ~on_summary:_ ~on_finish:_ () ->
                  Error "no usable exact-output lane slots")
             entry
         with
@@ -1604,9 +1641,11 @@ let test_visible_uncertainty_withholds_production_drain () =
            @@ fun () ->
            (match
               Gate.For_testing.spawn_auto_judge_entry_with_worker
+                ~research_runner:test_research_runner
                 ~spawn_worker:
-            (fun ~sw ~entry ~on_summary ~on_finish () ->
+            (fun ~sw ~research_runner ~entry ~on_summary ~on_finish () ->
                      Worker.For_testing.spawn_with_queue_ops
+                       ~research_runner
                        ~queue_ops:
                          (exact_queue_ops ~complete_writer:visible_writer ())
                        ~sw
@@ -1696,14 +1735,22 @@ let test_owner_fifo_atomic_drain_is_nonsharing () =
          "FIFO head reproduces absent causal context"
          None
          first.request_context;
-       let initial = Gate.resume_persisted_auto_judges ~base_path in
+       let initial =
+         Gate.resume_persisted_auto_judges
+           ~research_runner:test_research_runner
+           ~base_path
+       in
        check
          (list string)
          "production recovery claims the oldest owner entry"
          [ first.id ]
          initial.started_ids;
        F.await_first_request server;
-       let concurrent = Gate.resume_persisted_auto_judges ~base_path in
+       let concurrent =
+         Gate.resume_persisted_auto_judges
+           ~research_runner:test_research_runner
+           ~base_path
+       in
        check
          (list string)
          "concurrent drain cannot claim the same owner"
@@ -1781,7 +1828,11 @@ let test_require_human_head_does_not_stop_owner_drain () =
        select_auto_judge_mode base_path;
        let head = pending_entry ~input_tag:"require-human-head" ~base_path () in
        let successor = pending_entry ~input_tag:"successor" ~base_path () in
-       let recovery = Gate.resume_persisted_auto_judges ~base_path in
+       let recovery =
+         Gate.resume_persisted_auto_judges
+           ~research_runner:test_research_runner
+           ~base_path
+       in
        check
          (list string)
          "recovery starts the oldest owner entry"
@@ -1820,6 +1871,93 @@ let test_judge_effect_prompt_comes_from_registry () =
   match Worker.For_testing.system_prompt () with
   | Error detail -> fail ("Gate judgment prompt unavailable: " ^ detail)
   | Ok prompt -> check bool "prompt is non-empty" true (String.trim prompt <> "")
+;;
+
+let test_production_spawn_links_research_raw_and_exact_judgment () =
+  run_eio @@ fun ~sw ~net ~clock ->
+  with_temp_dir "hitl-research-exact-link" @@ fun base_path ->
+  Fun.protect
+    ~finally:Q.For_testing.reset_runtime_state
+    (fun () ->
+       install_queue base_path;
+       Prompt_registry.set_markdown_dir
+         (Masc_test_deps.source_path "config/prompts");
+       let server =
+         F.start_server
+           ~sw
+           ~net
+           ~clock
+           (F.Reply (F.openai_response (judgment_json "approve")))
+       in
+       publish_lane
+         [ "hitl-research-exact-link" ]
+         (F.resolver_snapshot
+            ~source:"hitl-research-exact-link"
+            [ { id = "hitl-research-exact-link"; base_url = server.base_url } ]);
+       let entry = pending_entry ~base_path () in
+       let research_run_id = "test-hitl-linked-research" in
+       let raw_trace_path = Filename.concat base_path "linked-raw.jsonl" in
+       let research_runner ~register ~clock:_ ~net:_ ~entry:_ =
+         register ~run_id:research_run_id ~raw_trace_path:(Some raw_trace_path);
+         Ok
+           { Worker.run_id = research_run_id
+           ; receipt = `Assoc [ "research_marker", `String "full-tool-receipt" ]
+           ; finalizer_evidence =
+               `Assoc [ "evidence_marker", `String "bounded-tool-evidence" ]
+           }
+       in
+       let delivered = ref None in
+       let finish_outcome = ref None in
+       (match
+          Worker.spawn
+            ~sw
+            ~research_runner
+            ~entry
+            ~on_summary:(fun summary -> delivered := Some summary)
+            ~on_finish:(fun outcome -> finish_outcome := Some outcome)
+            ()
+        with
+        | Ok Worker.Worker_forked -> ()
+        | Error detail -> fail detail);
+       await_condition
+         ~clock
+         ~remaining:100
+         ~failure:"research followed by exact judgment did not finish"
+         (fun () -> Option.is_some !finish_outcome);
+       check bool "validated exact judgment delivered" true (Option.is_some !delivered);
+       check bool
+         "research evidence reaches the exact finalizer request"
+         true
+         (F.request_bodies server
+          |> List.exists (Astring.String.is_infix ~affix:"bounded-tool-evidence"));
+       match
+         Masc.Exact_lane_run_registry.get
+           (Masc.Exact_lane_run_registry.global ())
+           ~run_id:research_run_id
+       with
+       | None -> fail "linked HITL research run was not registered"
+       | Some run ->
+         let open Yojson.Safe.Util in
+         check string
+           "raw trace remains linked from frozen input"
+           raw_trace_path
+           (run.input |> member "research_raw_trace_path" |> to_string);
+         (match run.status with
+          | Masc.Exact_lane_run_registry.Running ->
+            fail "linked HITL research run did not complete"
+          | Completed { outcome = Succeeded; output; _ } ->
+            check string
+              "full research receipt remains visible"
+              "full-tool-receipt"
+              (output |> member "research" |> member "research_marker" |> to_string);
+            check string
+              "exact judgment remains visible beside research"
+              "approve"
+              (output |> member "judgment" |> member "judgment" |> to_string)
+          | Completed { outcome = Cancelled; _ } ->
+            fail "linked HITL research run was cancelled"
+          | Completed { outcome = Failed { code; detail }; _ } ->
+            failf "linked HITL research run failed: %s: %s" code detail))
 ;;
 
 
@@ -1896,6 +2034,14 @@ let () =
             "prompt is registry-owned"
             `Quick
             test_judge_effect_prompt_comes_from_registry
+        ; test_case
+            "research authority is exact-workspace scoped"
+            `Quick
+            test_research_registry_is_exact_workspace_scoped
+        ; test_case
+            "production spawn links research raw and exact judgment"
+            `Quick
+            test_production_spawn_links_research_raw_and_exact_judgment
         ] )
     ; ( "production exact flow"
       , [ test_case

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1,5 +1,10 @@
 module AQ = Masc.Keeper_approval_queue
 module Rule_contract = Keeper_approval_queue_rules_types
+module Hitl_worker = Masc.Hitl_summary_worker
+
+let test_research_runner =
+  Hitl_worker.For_testing.passthrough_research_runner
+;;
 
 let test_rule_contract_types_are_shared_by_identity () =
   let through_queue : AQ.rule_match = { rule_id = "rule-shared" } in
@@ -2403,6 +2408,7 @@ let test_exact_completed_restart_requires_fsync_confirmation () =
        in
        let deterministic_report =
          Gate.For_testing.resume_persisted_auto_judges_with_exact_completion
+           ~research_runner:test_research_runner
            ~complete_summary_exact_attempt:
              (fun
                ~id:_
@@ -2436,6 +2442,7 @@ let test_exact_completed_restart_requires_fsync_confirmation () =
             "deterministic completion rejection changed durable disposition");
        let visible_report =
          Gate.For_testing.resume_persisted_auto_judges_with_exact_completion
+           ~research_runner:test_research_runner
            ~complete_summary_exact_attempt:
              (injected_completion
                 (AQ.Visible_sync_unconfirmed
@@ -2455,6 +2462,7 @@ let test_exact_completed_restart_requires_fsync_confirmation () =
          (Option.is_some (AQ.For_testing.get_pending_entry_unchecked ~id));
        let error_report =
          Gate.For_testing.resume_persisted_auto_judges_with_exact_completion
+           ~research_runner:test_research_runner
            ~complete_summary_exact_attempt:
              (fun
                ~id:_
@@ -2480,7 +2488,11 @@ let test_exact_completed_restart_requires_fsync_confirmation () =
          (List.length error_report.failures);
        Alcotest.(check bool) "error recovery keeps pending" true
          (Option.is_some (AQ.For_testing.get_pending_entry_unchecked ~id));
-       let durable_report = Gate.resume_persisted_auto_judges ~base_path in
+       let durable_report =
+         Gate.resume_persisted_auto_judges
+           ~research_runner:test_research_runner
+           ~base_path
+       in
        Alcotest.(check (list string))
          "fsync-confirmed recovery finalizes once"
          [ id ]

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -3,6 +3,11 @@ open Alcotest
 module AQ = Masc.Keeper_approval_queue
 module Gate = Masc.Keeper_gate
 module Gate_mode = Masc.Keeper_gate_mode
+module Hitl_worker = Masc.Hitl_summary_worker
+
+let test_research_runner =
+  Hitl_worker.For_testing.passthrough_research_runner
+;;
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_approval_queue_rules_" "" in
@@ -609,7 +614,11 @@ let test_completed_exact_judgment_finalizes_without_worker () =
    | _ -> fail "completed available judgment did not survive restart");
   check bool "completed available judgment is finalize-only" false
     (Gate.For_testing.auto_judge_entry_ready completed);
-  let report = Gate.resume_persisted_auto_judges ~base_path in
+  let report =
+    Gate.resume_persisted_auto_judges
+      ~research_runner:test_research_runner
+      ~base_path
+  in
   let expected_ids = [ completed.id ] in
   check int "one completed exact judgment considered" 1 report.requested;
   check (list string) "completed exact judgment finalized" expected_ids

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -238,44 +238,52 @@ let test_internal_research_bundle_exactly_matches_model_visible_descriptors () =
            ~registry:publication_recovery_registry
            ~keeper_name:meta.name
        in
-       let request : Keeper_internal_research.request =
-         { owner = Librarian
-         ; execution_id = Keeper_internal_research.Execution_id.generate ()
-         ; runtime_id = "test-runtime"
-         ; frozen_system_prompt = "test"
-         ; frozen_prompt = "test"
-         ; frozen_input = `Assoc [ "test", `Bool true ]
-         ; evidence_budget_bytes = 1024
-         ; config
-         ; meta
-         ; publication_recovery
-         ; ctx_snapshot
-         ; clock = Eio.Stdenv.clock env
-         ; net = Eio.Stdenv.net env
-         ; continuation_channel = None
-         ; raw_trace = None
-         }
-       in
-       let actual_names, cleanup =
-         Keeper_internal_research.For_testing.tool_names_for_request request
-       in
        let expected_names =
          Keeper_tool_descriptor.model_visible_descriptors ()
          |> List.concat_map Keeper_tool_descriptor.keeper_model_names
          |> List.sort_uniq String.compare
        in
-       check
-         (list string)
-         "research runner receives the complete descriptor projection"
-         expected_names
-         (List.sort_uniq String.compare actual_names);
-       check int
-         "research runner bundle contains no duplicates"
-         (List.length expected_names)
-         (List.length actual_names);
-       match cleanup with
-       | Keeper_internal_research.Cleanup_succeeded -> ()
-       | Cleanup_failed detail -> failf "research bundle cleanup failed: %s" detail)
+       [ "librarian", Keeper_internal_research.Librarian
+       ; "hitl_auto_judge", Keeper_internal_research.Hitl_auto_judge
+       ; "board_attention", Keeper_internal_research.Board_attention
+       ; "compaction", Keeper_internal_research.Compaction
+       ; "completion_authority", Keeper_internal_research.Completion_authority
+       ]
+       |> List.iter (fun (owner_label, owner) ->
+         let request : Keeper_internal_research.request =
+           { owner
+           ; execution_id = Keeper_internal_research.Execution_id.generate ()
+           ; runtime_id = "test-runtime"
+           ; frozen_system_prompt = "test"
+           ; frozen_prompt = "test"
+           ; frozen_input = `Assoc [ "test", `Bool true ]
+           ; evidence_budget_bytes = 1024
+           ; config
+           ; meta
+           ; publication_recovery
+           ; ctx_snapshot
+           ; clock = Eio.Stdenv.clock env
+           ; net = Eio.Stdenv.net env
+           ; continuation_channel = None
+           ; raw_trace = None
+           }
+         in
+         let actual_names, cleanup =
+           Keeper_internal_research.For_testing.tool_names_for_request request
+         in
+         check
+           (list string)
+           (owner_label ^ " receives the complete descriptor projection")
+           expected_names
+           (List.sort_uniq String.compare actual_names);
+         check int
+           (owner_label ^ " research bundle contains no duplicates")
+           (List.length expected_names)
+           (List.length actual_names);
+         match cleanup with
+         | Keeper_internal_research.Cleanup_succeeded -> ()
+         | Cleanup_failed detail ->
+           failf "%s research bundle cleanup failed: %s" owner_label detail))
 ;;
 
 let test_internal_research_cleanup_contract () =


### PR DESCRIPTION
## Summary
- run a full Keeper tool bundle research phase before the HITL Auto Judge exact-output finalizer
- bind research receipt, bounded finalizer evidence, RAW trace path, and exact judgment to one run identity
- install workspace-scoped research authority at server bootstrap and thread it through restart/operator recovery paths
- assert all internal research owners receive the complete model-visible Keeper tool descriptor projection

## Stack
- base: #27737 (`feat/librarian-full-tools-20260809`)
- common research boundary: #27734
- tracking: #27658

## Verification
- `scripts/dune-local.sh build lib/masc.cmxa`
- `test_hitl_summary_worker.exe`: 30/30
- `test_keeper_approval_queue.exe`: 39/39
- `test_keeper_approval_queue_rules.exe`: 17/17
- `test_keeper_gate_effect_coverage.exe`: 8/8
- `test_warn_root_causes.exe`: 11/11
- `test_keeper_raw_trace_sink.exe`: 14/14
- total focused tests: 119
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`

## Runtime boundary
The live Keeper process is not restarted by this PR. Live proof of the new HITL research phase therefore requires this stack to merge and the runtime to be rebuilt/restarted; current live state is measured separately.