### PR TITLE
feat(runtime): add Claude Code subscription client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1567,7 +1567,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_runtime_codex_app_server @test/runtest-test_official_client_session_store"
+          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_runtime_codex_app_server @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${official_client_targets}"
 
       - name: Run host FD pressure contract suite

--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -35,6 +35,7 @@
   masc.types_boundary
   time_compat
   masc.dated_jsonl
+  masc_random_id
   masc.masc_process
   masc.otel_spans
   masc.otel_metric_store

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -1,0 +1,1042 @@
+type subscription =
+  { auth_method : string
+  ; subscription_type : string
+  ; api_provider : string
+  }
+
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string option
+  ; system_prompt : string option
+  ; timeout_s : float
+  }
+
+let default_timeout_s = 300.0
+let process_termination_grace_s = 2.0
+let stderr_chunk_bytes = 4096
+let stderr_tail_bytes = 4096
+let max_wire_line_bytes = 8 * 1024 * 1024
+let mcp_server_name = "masc"
+
+let default_config ~cwd =
+  { cli_path = "claude"
+  ; cwd
+  ; model = None
+  ; system_prompt = None
+  ; timeout_s = default_timeout_s
+  }
+;;
+
+type session_mode =
+  | Start
+  | Resume of { session_id : string }
+
+type rate_limit =
+  { status : string
+  ; rate_limit_type : string option
+  ; resets_at : int option
+  ; overage_status : string option
+  ; overage_disabled_reason : string option
+  }
+
+type turn_result =
+  { session_id : string
+  ; turn_id : string
+  ; model : string
+  ; text : string
+  ; dynamic_tool_calls : int
+  ; subscription : subscription
+  ; rate_limit : rate_limit option
+  ; resumed : bool
+  }
+
+type dynamic_tool_result =
+  { success : bool
+  ; content : string
+  }
+
+type dynamic_tool =
+  { name : string
+  ; description : string
+  ; input_schema : Yojson.Safe.t
+  ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | Subscription_required of string
+  | Unsupported_control_request of string
+  | Turn_failed of string
+  | Quota_blocked of
+      { api_error_status : int option
+      ; rate_limit : rate_limit option
+      }
+  | Process_exited of string
+  | Timeout of float
+
+let error_to_string = function
+  | Invalid_config detail -> "invalid Claude Code config: " ^ detail
+  | Spawn_failed detail -> "failed to start Claude Code: " ^ detail
+  | Protocol_error { stage; detail } ->
+    Printf.sprintf "Claude Code protocol error during %s: %s" stage detail
+  | Subscription_required detail ->
+    "Claude Code subscription login required: " ^ detail
+  | Unsupported_control_request subtype ->
+    "Claude Code requested unsupported control action: " ^ subtype
+  | Turn_failed detail -> "Claude Code turn failed: " ^ detail
+  | Quota_blocked { api_error_status; rate_limit } ->
+    let status =
+      Option.fold
+        ~none:"unknown"
+        ~some:(fun value -> value.status)
+        rate_limit
+    in
+    let api_status =
+      Option.fold ~none:"unknown" ~some:string_of_int api_error_status
+    in
+    Printf.sprintf
+      "Claude Code subscription quota blocked (rate_limit=%s api_status=%s)"
+      status
+      api_status
+  | Process_exited detail ->
+    "Claude Code exited before terminal result: " ^ detail
+  | Timeout seconds ->
+    Printf.sprintf "Claude Code turn timed out after %.3fs" seconds
+;;
+
+let error_kind = function
+  | Invalid_config _ -> "invalid_config"
+  | Spawn_failed _ -> "spawn_failed"
+  | Protocol_error _ -> "protocol_error"
+  | Subscription_required _ -> "subscription_required"
+  | Unsupported_control_request _ -> "unsupported_control_request"
+  | Turn_failed _ -> "turn_failed"
+  | Quota_blocked _ -> "quota_blocked"
+  | Process_exited _ -> "process_exited"
+  | Timeout _ -> "timeout"
+;;
+
+let protocol_error stage detail = Error (Protocol_error { stage; detail })
+let ( let* ) result f = Result.bind result f
+
+let rec validate_unique_object_keys ~stage ~path = function
+  | `Assoc fields ->
+    let rec loop seen = function
+      | [] -> Ok ()
+      | (name, value) :: rest ->
+        if List.mem name seen
+        then
+          protocol_error
+            stage
+            (Printf.sprintf "duplicate object key %S at %s" name path)
+        else
+          let* () =
+            validate_unique_object_keys
+              ~stage
+              ~path:(path ^ "." ^ name)
+              value
+          in
+          loop (name :: seen) rest
+    in
+    loop [] fields
+  | `List values ->
+    let rec loop index = function
+      | [] -> Ok ()
+      | value :: rest ->
+        let* () =
+          validate_unique_object_keys
+            ~stage
+            ~path:(Printf.sprintf "%s[%d]" path index)
+            value
+        in
+        loop (index + 1) rest
+    in
+    loop 0 values
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
+;;
+
+let parse_json ~stage text =
+  let parsed =
+    try Ok (Yojson.Safe.from_string text) with
+    | Yojson.Json_error detail -> protocol_error stage ("invalid JSON: " ^ detail)
+  in
+  let* json = parsed in
+  let* () = validate_unique_object_keys ~stage ~path:"$" json in
+  Ok json
+;;
+
+let assoc_at stage = function
+  | `Assoc fields -> Ok fields
+  | _ -> protocol_error stage "expected a JSON object"
+;;
+
+let required_member stage name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_string stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) when String.trim value <> "" -> Ok value
+  | Some _ ->
+    protocol_error stage (Printf.sprintf "field %S must be a non-empty string" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let optional_string stage name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ ->
+    protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
+;;
+
+let required_bool stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`Bool value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a boolean" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let optional_int stage name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`Int value) -> Ok (Some value)
+  | Some _ ->
+    protocol_error stage (Printf.sprintf "field %S must be an integer or null" name)
+;;
+
+let env_key entry =
+  match String.index_opt entry '=' with
+  | Some index -> String.sub entry 0 index
+  | None -> entry
+;;
+
+let subscription_only_environment () =
+  let blocked =
+    [ "ANTHROPIC_API_KEY"
+    ; "ANTHROPIC_AUTH_TOKEN"
+    ; "CLAUDE_CODE_OAUTH_TOKEN"
+    ; "CLAUDECODE"
+    ; "CLAUDE_CODE_ENTRYPOINT"
+    ; "CLAUDE_AGENT_SDK_VERSION"
+    ]
+  in
+  Unix.environment ()
+  |> Array.to_list
+  |> List.filter (fun entry -> not (List.mem (env_key entry) blocked))
+  |> fun inherited ->
+  ("CLAUDE_CODE_ENTRYPOINT=masc" :: "CLAUDE_AGENT_SDK_VERSION=masc-ocaml" :: inherited)
+  |> Array.of_list
+;;
+
+let parse_subscription json =
+  let stage = "auth status" in
+  let* fields = assoc_at stage json in
+  let* logged_in = required_bool stage "loggedIn" fields in
+  if not logged_in
+  then Error (Subscription_required "claude auth status reported loggedIn=false")
+  else
+    let* auth_method = required_string stage "authMethod" fields in
+    let* subscription_type = required_string stage "subscriptionType" fields in
+    let* api_provider = required_string stage "apiProvider" fields in
+    if auth_method <> "claude.ai"
+    then
+      Error
+        (Subscription_required
+           (Printf.sprintf "authMethod must be claude.ai, got %S" auth_method))
+    else if api_provider <> "firstParty"
+    then
+      Error
+        (Subscription_required
+           (Printf.sprintf "apiProvider must be firstParty, got %S" api_provider))
+    else Ok { auth_method; subscription_type; api_provider }
+;;
+
+let read_subscription ~mgr ~cwd config =
+  try
+    Eio.Process.parse_out
+      mgr
+      Eio.Buf_read.take_all
+      ~cwd
+      ~env:(subscription_only_environment ())
+      [ config.cli_path; "auth"; "status"; "--json" ]
+    |> String.trim
+    |> parse_json ~stage:"auth status"
+    |> fun result -> Result.bind result parse_subscription
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Subscription_required (Printexc.to_string exn))
+;;
+
+let dynamic_tool_spec (tool : dynamic_tool) =
+  `Assoc
+    [ "name", `String tool.name
+    ; "description", `String tool.description
+    ; "inputSchema", tool.input_schema
+    ]
+;;
+
+let find_dynamic_tool tools name =
+  List.find_opt (fun (tool : dynamic_tool) -> String.equal tool.name name) tools
+;;
+
+type io =
+  { send : Yojson.Safe.t -> unit
+  ; receive : unit -> (Yojson.Safe.t, error) result
+  }
+
+let jsonrpc_response ~id result =
+  `Assoc [ "jsonrpc", `String "2.0"; "id", id; "result", result ]
+;;
+
+let jsonrpc_error ~id ~code message =
+  `Assoc
+    [ "jsonrpc", `String "2.0"
+    ; "id", id
+    ; "error", `Assoc [ "code", `Int code; "message", `String message ]
+    ]
+;;
+
+let jsonrpc_id_to_call_id = function
+  | `String id when String.trim id <> "" -> Ok id
+  | `Int id -> Ok (string_of_int id)
+  | _ -> protocol_error "MCP tools/call" "request id must be a string or integer"
+;;
+
+let mcp_initialize ~id =
+  jsonrpc_response
+    ~id
+    (`Assoc
+       [ "protocolVersion", `String "2024-11-05"
+       ; "capabilities", `Assoc [ "tools", `Assoc [] ]
+       ; ( "serverInfo"
+         , `Assoc
+             [ "name", `String mcp_server_name
+             ; "version", `String "1.0.0"
+             ] )
+       ])
+;;
+
+let mcp_tools_list ~id tools =
+  jsonrpc_response
+    ~id
+    (`Assoc [ "tools", `List (List.map dynamic_tool_spec tools) ])
+;;
+
+let mcp_tool_result ~id (result : dynamic_tool_result) =
+  jsonrpc_response
+    ~id
+    (`Assoc
+       ([ ( "content"
+          , `List
+              [ `Assoc
+                  [ "type", `String "text"
+                  ; "text", `String result.content
+                  ] ] )
+        ]
+        @ if result.success then [] else [ "isError", `Bool true ]))
+;;
+
+let mcp_tools_call ~id ~params ~tools ~tool_call_count =
+  let stage = "MCP tools/call" in
+  let* call_id = jsonrpc_id_to_call_id id in
+  let* fields = assoc_at stage params in
+  let* name = required_string stage "name" fields in
+  let arguments =
+    match List.assoc_opt "arguments" fields with
+    | None -> Ok (`Assoc [])
+    | Some (`Assoc _ as arguments) -> Ok arguments
+    | Some _ -> protocol_error stage "field \"arguments\" must be an object"
+  in
+  let* arguments = arguments in
+  match find_dynamic_tool tools name with
+  | None ->
+    Ok
+      (jsonrpc_error
+         ~id
+         ~code:(-32602)
+         (Printf.sprintf "unknown MASC tool %S" name))
+  | Some tool ->
+    let result =
+      try tool.call ~call_id arguments with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        Log.Runtime_agent.warn
+          "Claude Code MCP tool handler raised (tool=%s error=%s)"
+          name
+          (Printexc.to_string exn);
+        { success = false; content = "MASC tool handler raised" }
+    in
+    incr tool_call_count;
+    Ok (mcp_tool_result ~id result)
+;;
+
+let handle_mcp_message ~tools ~tool_call_count message =
+  let stage = "MCP message" in
+  let* fields = assoc_at stage message in
+  let* jsonrpc = required_string stage "jsonrpc" fields in
+  if jsonrpc <> "2.0"
+  then protocol_error stage (Printf.sprintf "unsupported jsonrpc %S" jsonrpc)
+  else
+    let* method_ = required_string stage "method" fields in
+    let id = Option.value (List.assoc_opt "id" fields) ~default:`Null in
+    let params = Option.value (List.assoc_opt "params" fields) ~default:(`Assoc []) in
+    match method_ with
+    | "initialize" when id <> `Null -> Ok (mcp_initialize ~id)
+    | "tools/list" when id <> `Null -> Ok (mcp_tools_list ~id tools)
+    | "tools/call" when id <> `Null ->
+      mcp_tools_call ~id ~params ~tools ~tool_call_count
+    | "notifications/initialized" when id = `Null ->
+      Ok (`Assoc [ "jsonrpc", `String "2.0"; "result", `Assoc [] ])
+    | _ ->
+      Ok
+        (jsonrpc_error
+           ~id
+           ~code:(-32601)
+           (Printf.sprintf "MCP method %S is not supported" method_))
+;;
+
+let send_control_success io ~request_id response =
+  io.send
+    (`Assoc
+       [ "type", `String "control_response"
+       ; ( "response"
+         , `Assoc
+             [ "subtype", `String "success"
+             ; "request_id", `String request_id
+             ; "response", response
+             ] )
+       ])
+;;
+
+let send_control_error io ~request_id detail =
+  io.send
+    (`Assoc
+       [ "type", `String "control_response"
+       ; ( "response"
+         , `Assoc
+             [ "subtype", `String "error"
+             ; "request_id", `String request_id
+             ; "error", `String detail
+             ] )
+       ])
+;;
+
+let handle_control_request io ~tools ~tool_call_count fields =
+  let stage = "control request" in
+  let* request_id = required_string stage "request_id" fields in
+  let* request = required_member stage "request" fields in
+  let* request_fields = assoc_at stage request in
+  let* subtype = required_string stage "subtype" request_fields in
+  match subtype with
+  | "mcp_message" ->
+    let* server_name = required_string stage "server_name" request_fields in
+    if server_name <> mcp_server_name
+    then
+      let detail = Printf.sprintf "unknown SDK MCP server %S" server_name in
+      send_control_error io ~request_id detail;
+      Error (Unsupported_control_request subtype)
+    else
+      let* message = required_member stage "message" request_fields in
+      let* mcp_response = handle_mcp_message ~tools ~tool_call_count message in
+      send_control_success
+        io
+        ~request_id
+        (`Assoc [ "mcp_response", mcp_response ]);
+      Ok ()
+  | unsupported ->
+    send_control_error
+      io
+      ~request_id
+      (Printf.sprintf "MASC does not support control request %S" unsupported);
+    Error (Unsupported_control_request unsupported)
+;;
+
+let parse_wire_line line = parse_json ~stage:"stream-json message" line
+
+let wire_fields json =
+  let stage = "stream-json message" in
+  let* fields = assoc_at stage json in
+  let* type_ = required_string stage "type" fields in
+  Ok (type_, fields)
+;;
+
+let initialize_request request_id =
+  `Assoc
+    [ "type", `String "control_request"
+    ; "request_id", `String request_id
+    ; ( "request"
+      , `Assoc [ "subtype", `String "initialize"; "hooks", `Null ] )
+    ]
+;;
+
+let parse_control_response ~expected_request_id fields =
+  let stage = "initialize control response" in
+  let* response = required_member stage "response" fields in
+  let* response_fields = assoc_at stage response in
+  let* request_id = required_string stage "request_id" response_fields in
+  if request_id <> expected_request_id
+  then
+    protocol_error
+      stage
+      (Printf.sprintf
+         "response request_id %S does not match %S"
+         request_id
+         expected_request_id)
+  else
+    let* subtype = required_string stage "subtype" response_fields in
+    match subtype with
+    | "success" -> Ok ()
+    | "error" ->
+      let* detail = required_string stage "error" response_fields in
+      Error (Turn_failed ("control initialization failed: " ^ detail))
+    | other ->
+      protocol_error stage (Printf.sprintf "unknown response subtype %S" other)
+;;
+
+let rec await_initialize io ~tools ~tool_call_count ~request_id ~ignored =
+  let* json = io.receive () in
+  let* type_, fields = wire_fields json in
+  match type_ with
+  | "control_response" ->
+    parse_control_response ~expected_request_id:request_id fields
+  | "control_request" ->
+    let* () = handle_control_request io ~tools ~tool_call_count fields in
+    await_initialize io ~tools ~tool_call_count ~request_id ~ignored
+  | ("system" | "rate_limit_event") when ignored < 32 ->
+    await_initialize io ~tools ~tool_call_count ~request_id ~ignored:(ignored + 1)
+  | other ->
+    protocol_error
+      "initialize"
+      (Printf.sprintf "unexpected message type %S before control response" other)
+;;
+
+let invoke_state_callback ~stage callback =
+  try
+    match callback () with
+    | Ok () -> Ok ()
+    | Error detail -> protocol_error stage detail
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> protocol_error stage (Printexc.to_string exn)
+;;
+
+let user_message prompt =
+  `Assoc
+    [ "type", `String "user"
+    ; "message", `Assoc [ "role", `String "user"; "content", `String prompt ]
+    ; "parent_tool_use_id", `Null
+    ; "session_id", `String "default"
+    ]
+;;
+
+let parse_rate_limit ~expected_session_id fields =
+  let stage = "rate_limit_event" in
+  let* session_id = required_string stage "session_id" fields in
+  let* () =
+    if session_id = expected_session_id
+    then Ok ()
+    else protocol_error stage "session_id does not match the active Claude session"
+  in
+  let* info = required_member stage "rate_limit_info" fields in
+  let* info_fields = assoc_at stage info in
+  let* status = required_string stage "status" info_fields in
+  if not (List.mem status [ "allowed"; "allowed_warning"; "rejected" ])
+  then protocol_error stage (Printf.sprintf "unknown status %S" status)
+  else
+    let* rate_limit_type = optional_string stage "rateLimitType" info_fields in
+    let* resets_at = optional_int stage "resetsAt" info_fields in
+    let* overage_status = optional_string stage "overageStatus" info_fields in
+    let* overage_disabled_reason =
+      optional_string stage "overageDisabledReason" info_fields
+    in
+    Ok
+      { status
+      ; rate_limit_type
+      ; resets_at
+      ; overage_status
+      ; overage_disabled_reason
+      }
+;;
+
+let text_blocks ~stage content =
+  match content with
+  | `List blocks ->
+    let rec loop texts = function
+      | [] -> Ok (List.rev texts)
+      | `Assoc fields :: rest ->
+        let* type_ = required_string stage "type" fields in
+        (match type_ with
+         | "text" ->
+           let* text = required_string stage "text" fields in
+           loop (text :: texts) rest
+         | "thinking" | "tool_use" -> loop texts rest
+         | other ->
+           protocol_error
+             stage
+             (Printf.sprintf "unsupported assistant content type %S" other))
+      | _ :: _ -> protocol_error stage "assistant content block must be an object"
+    in
+    loop [] blocks
+  | _ -> protocol_error stage "assistant content must be an array"
+;;
+
+let parse_assistant ~expected_session_id fields =
+  let stage = "assistant message" in
+  let* session_id = required_string stage "session_id" fields in
+  if session_id <> expected_session_id
+  then protocol_error stage "session_id does not match the active Claude session"
+  else
+    let* uuid = required_string stage "uuid" fields in
+    let* message = required_member stage "message" fields in
+    let* message_fields = assoc_at stage message in
+    let* model = required_string stage "model" message_fields in
+    let* content = required_member stage "content" message_fields in
+    let* texts = text_blocks ~stage content in
+    Ok (uuid, model, texts)
+;;
+
+let parse_result ~expected_session_id ~rate_limit fields =
+  let stage = "result message" in
+  let* subtype = required_string stage "subtype" fields in
+  let* is_error = required_bool stage "is_error" fields in
+  let* session_id = required_string stage "session_id" fields in
+  if session_id <> expected_session_id
+  then protocol_error stage "session_id does not match the active Claude session"
+  else
+    let* turn_id = required_string stage "uuid" fields in
+    let* api_error_status = optional_int stage "api_error_status" fields in
+    let result =
+      match List.assoc_opt "result" fields with
+      | None | Some `Null -> Ok None
+      | Some (`String value) -> Ok (Some value)
+      | Some _ -> protocol_error stage "field \"result\" must be a string or null"
+    in
+    let* result = result in
+    if is_error
+    then
+      let structurally_quota_blocked =
+        Option.equal Int.equal api_error_status (Some 429)
+        || Option.exists
+             (fun (limit : rate_limit) -> limit.status = "rejected")
+             rate_limit
+      in
+      if structurally_quota_blocked
+      then Error (Quota_blocked { api_error_status; rate_limit })
+      else
+        Error
+          (Turn_failed
+             (Printf.sprintf
+                "terminal subtype=%s api_status=%s"
+                subtype
+                (Option.fold
+                   ~none:"unknown"
+                   ~some:string_of_int
+                   api_error_status)))
+    else if subtype <> "success"
+    then Error (Turn_failed (Printf.sprintf "terminal subtype=%s" subtype))
+    else Ok (turn_id, result)
+;;
+
+let max_ignored_messages = 256
+
+let rec await_terminal io ~tools ~tool_call_count ~expected_session_id
+    ~subscription ~resumed ~rate_limit ~assistant_model ~assistant_texts
+    ~on_turn_started ~ignored =
+  let* json = io.receive () in
+  let* type_, fields = wire_fields json in
+  match type_ with
+  | "control_request" ->
+    let* () = handle_control_request io ~tools ~tool_call_count fields in
+    await_terminal
+      io ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
+      ~rate_limit ~assistant_model ~assistant_texts ~on_turn_started ~ignored
+  | "control_response" ->
+    protocol_error "turn" "received an unsolicited control response"
+  | "assistant" ->
+    let* _uuid, model, texts = parse_assistant ~expected_session_id fields in
+    await_terminal
+      io ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
+      ~rate_limit ~assistant_model:(Some model)
+      ~assistant_texts:(assistant_texts @ texts)
+      ~on_turn_started ~ignored
+  | "rate_limit_event" ->
+    let* rate_limit = parse_rate_limit ~expected_session_id fields in
+    await_terminal
+      io ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
+      ~rate_limit:(Some rate_limit) ~assistant_model ~assistant_texts
+      ~on_turn_started ~ignored
+  | "result" ->
+    let* turn_id, result =
+      parse_result ~expected_session_id ~rate_limit fields
+    in
+    let* () =
+      invoke_state_callback ~stage:"turn started callback" (fun () ->
+        on_turn_started ~session_id:expected_session_id ~turn_id)
+    in
+    let* model =
+      match assistant_model with
+      | Some model -> Ok model
+      | None -> protocol_error "result message" "no measured assistant model"
+    in
+    let text =
+      match result with
+      | Some text when String.trim text <> "" -> Some text
+      | None | Some _ ->
+        assistant_texts
+        |> String.concat "\n"
+        |> String.trim
+        |> fun value -> if value = "" then None else Some value
+    in
+    let* text =
+      match text with
+      | Some text -> Ok text
+      | None -> protocol_error "result message" "successful turn has no text"
+    in
+    Ok
+      { session_id = expected_session_id
+      ; turn_id
+      ; model
+      ; text
+      ; dynamic_tool_calls = !tool_call_count
+      ; subscription
+      ; rate_limit
+      ; resumed
+      }
+  | ("system" | "user") when ignored < max_ignored_messages ->
+    await_terminal
+      io ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
+      ~rate_limit ~assistant_model ~assistant_texts ~on_turn_started
+      ~ignored:(ignored + 1)
+  | other ->
+    protocol_error
+      "turn"
+      (Printf.sprintf "unsupported stream message type %S" other)
+;;
+
+let mcp_config tools =
+  match tools with
+  | [] -> None
+  | _ ->
+    Some
+      (Yojson.Safe.to_string
+         (`Assoc
+            [ ( "mcpServers"
+              , `Assoc
+                  [ ( mcp_server_name
+                    , `Assoc
+                        [ "type", `String "sdk"
+                        ; "name", `String mcp_server_name
+                        ] )
+                  ] )
+            ]))
+;;
+
+let allowed_tool_name (tool : dynamic_tool) =
+  Printf.sprintf "mcp__%s__%s" mcp_server_name tool.name
+;;
+
+let reasoning_args = function
+  | None -> Ok []
+  | Some Llm_provider.Reasoning_effort.None_ ->
+    Ok [ "--thinking"; "disabled" ]
+  | Some Llm_provider.Reasoning_effort.Minimal ->
+    Error
+      (Invalid_config
+         "Claude Code does not admit reasoning effort minimal; use low, medium, high, xhigh, max, or none")
+  | Some effort ->
+    Ok [ "--effort"; Llm_provider.Reasoning_effort.to_string effort ]
+;;
+
+let command config ~dynamic_tools ~reasoning_effort ~session_mode ~session_id =
+  let* reasoning_args = reasoning_args reasoning_effort in
+  let args =
+    [ config.cli_path
+    ; "--output-format"
+    ; "stream-json"
+    ; "--verbose"
+    ; "--system-prompt"
+    ; Option.value config.system_prompt ~default:""
+    ; "--tools"
+    ; ""
+    ]
+    @ (match dynamic_tools with
+       | [] -> []
+       | tools ->
+         [ "--allowedTools"
+         ; String.concat "," (List.map allowed_tool_name tools)
+         ])
+    @ (match config.model with
+       | None -> []
+       | Some model -> [ "--model"; model ])
+    @ [ "--permission-mode"; "dontAsk" ]
+    @ (match session_mode with
+       | Start -> [ "--session-id=" ^ session_id ]
+       | Resume { session_id } -> [ "--resume=" ^ session_id ])
+    @ (match mcp_config dynamic_tools with
+       | None -> []
+       | Some value -> [ "--mcp-config"; value; "--strict-mcp-config" ])
+    @ [ "--setting-sources=" ]
+    @ reasoning_args
+    @ [ "--input-format"; "stream-json" ]
+  in
+  Ok args
+;;
+
+let bounded_tail ~limit current addition =
+  let combined = current ^ addition in
+  let length = String.length combined in
+  if length <= limit then combined else String.sub combined (length - limit) limit
+;;
+
+let drain_stderr flow tail =
+  let chunk = Cstruct.create stderr_chunk_bytes in
+  try
+    while true do
+      let count = Eio.Flow.single_read flow chunk in
+      let text = Cstruct.to_string (Cstruct.sub chunk 0 count) in
+      tail := bounded_tail ~limit:stderr_tail_bytes !tail text
+    done
+  with
+  | End_of_file -> ()
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Runtime_agent.debug
+      "Claude Code stderr drain failed: %s"
+      (Printexc.to_string exn)
+;;
+
+let terminate_spawned_process ~clock proc stdin_w =
+  let owning_switch_cancelled = Eio.Fiber.is_cancelled () in
+  Eio.Cancel.protect (fun () ->
+    (try Eio.Flow.close stdin_w with
+     | exn ->
+       Log.Runtime_agent.debug
+         "Claude Code stdin close failed: %s"
+         (Printexc.to_string exn));
+    (try Eio.Process.signal proc Sys.sigterm with
+     | exn ->
+       Log.Runtime_agent.debug
+         "Claude Code termination signal failed: %s"
+         (Printexc.to_string exn));
+    if not owning_switch_cancelled
+    then
+      try
+        Eio.Time.with_timeout_exn clock process_termination_grace_s (fun () ->
+          Eio.Process.await proc |> ignore)
+      with
+      | Eio.Time.Timeout ->
+        (try
+           Eio.Process.signal proc Sys.sigkill;
+           Eio.Process.await proc |> ignore
+         with
+         | exn ->
+           Log.Runtime_agent.warn
+             "Claude Code forced reap failed: %s"
+             (Printexc.to_string exn))
+      | exn ->
+        Log.Runtime_agent.debug
+          "Claude Code reap observed an already-closed process: %s"
+          (Printexc.to_string exn))
+;;
+
+let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
+    ~prompt ~on_session_ready ~on_turn_starting ~on_turn_started =
+  let tool_call_count = ref 0 in
+  let initialize_id = Random_id.prefixed ~prefix:"masc-init-" ~bytes:12 in
+  io.send (initialize_request initialize_id);
+  let* () =
+    await_initialize
+      io
+      ~tools:dynamic_tools
+      ~tool_call_count
+      ~request_id:initialize_id
+      ~ignored:0
+  in
+  let* () =
+    invoke_state_callback ~stage:"session ready callback" (fun () ->
+      on_session_ready ~session_id)
+  in
+  let* () =
+    invoke_state_callback ~stage:"turn starting callback" (fun () ->
+      on_turn_starting ~session_id)
+  in
+  io.send (user_message prompt);
+  await_terminal
+    io
+    ~tools:dynamic_tools
+    ~tool_call_count
+    ~expected_session_id:session_id
+    ~subscription
+    ~resumed:
+      (match session_mode with
+       | Start -> false
+       | Resume _ -> true)
+    ~rate_limit:None
+    ~assistant_model:None
+    ~assistant_texts:[]
+    ~on_turn_started
+    ~ignored:0
+;;
+
+let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
+    ~session_mode ~session_id ~subscription ~prompt ~on_session_ready
+    ~on_turn_starting ~on_turn_started =
+  let* argv =
+    command config ~dynamic_tools ~reasoning_effort ~session_mode ~session_id
+  in
+  Eio.Switch.run (fun sw ->
+    let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
+    let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
+    let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
+    let stderr_tail = ref "" in
+    let proc =
+      Eio.Process.spawn
+        ~sw
+        mgr
+        ~cwd
+        ~env:(subscription_only_environment ())
+        ~stdin:stdin_r
+        ~stdout:stdout_w
+        ~stderr:stderr_w
+        argv
+    in
+    Eio.Flow.close stdin_r;
+    Eio.Flow.close stdout_w;
+    Eio.Flow.close stderr_w;
+    Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
+    let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
+    let send json =
+      Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
+      Eio.Flow.copy_string "\n" stdin_w
+    in
+    let receive () =
+      try parse_wire_line (Eio.Buf_read.line reader) with
+      | End_of_file ->
+        let detail = String.trim !stderr_tail in
+        Error (Process_exited (if detail = "" then "stdout closed" else detail))
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn -> protocol_error "stdout read" (Printexc.to_string exn)
+    in
+    Fun.protect
+      ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
+      (fun () ->
+        Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+          run_protocol
+            { send; receive }
+            ~dynamic_tools
+            ~subscription
+            ~session_mode
+            ~session_id
+            ~prompt
+            ~on_session_ready
+            ~on_turn_starting
+            ~on_turn_started)))
+;;
+
+let validate_config config ~session_mode ~prompt =
+  if String.trim config.cli_path = ""
+  then Error (Invalid_config "cli_path must not be empty")
+  else if String.trim config.cwd = "" || Filename.is_relative config.cwd
+  then Error (Invalid_config "cwd must be an absolute path")
+  else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
+  then Error (Invalid_config "timeout_s must be positive and finite")
+  else if String.trim prompt = ""
+  then Error (Invalid_config "prompt must not be empty")
+  else
+    match session_mode with
+    | Resume { session_id } when String.trim session_id = "" ->
+      Error (Invalid_config "resume session_id must not be empty")
+    | Start | Resume _ -> Ok ()
+;;
+
+let validate_dynamic_tools tools =
+  let valid_tool_character = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> true
+    | _ -> false
+  in
+  let rec loop seen = function
+    | [] -> Ok ()
+    | (tool : dynamic_tool) :: rest ->
+      let name = String.trim tool.name in
+      if name = ""
+      then Error (Invalid_config "dynamic tool name must not be empty")
+      else if List.mem name seen
+      then
+        Error
+          (Invalid_config (Printf.sprintf "duplicate dynamic tool name %S" name))
+      else if not (String.for_all valid_tool_character name)
+      then
+        Error
+          (Invalid_config
+             (Printf.sprintf
+                "dynamic tool name %S contains a character unsupported by Claude Code allowedTools"
+                name))
+      else loop (name :: seen) rest
+  in
+  loop [] tools
+;;
+
+let validate_turn ?(dynamic_tools = []) ?(session_mode = Start) config ~prompt =
+  let* () = validate_config config ~session_mode ~prompt in
+  validate_dynamic_tools dynamic_tools
+;;
+
+let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
+    ~mgr ~clock ~cwd ?(on_session_ready = fun ~session_id:_ -> Ok ())
+    ?(on_turn_starting = fun ~session_id:_ -> Ok ())
+    ?(on_turn_started = fun ~session_id:_ ~turn_id:_ -> Ok ()) config
+    ~prompt =
+  let result =
+    let* () = validate_turn ~dynamic_tools ~session_mode config ~prompt in
+    let* _ = reasoning_args reasoning_effort in
+    let* subscription = read_subscription ~mgr ~cwd config in
+    let session_id =
+      match session_mode with
+      | Start -> Random_id.uuid_v7 ()
+      | Resume { session_id } -> session_id
+    in
+    Log.Runtime_agent.info
+      "Claude Code subscription turn starting (subscription_type=%s)"
+      subscription.subscription_type;
+    try
+      run_spawned
+        ~mgr
+        ~clock
+        ~cwd
+        config
+        ~dynamic_tools
+        ~reasoning_effort
+        ~session_mode
+        ~session_id
+        ~subscription
+        ~prompt
+        ~on_session_ready
+        ~on_turn_starting
+        ~on_turn_started
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+    | exn -> Error (Spawn_failed (Printexc.to_string exn))
+  in
+  (match result with
+   | Ok turn ->
+     Log.Runtime_agent.info
+       "Claude Code subscription turn completed (session_id=%s turn_id=%s model=%s)"
+       turn.session_id
+       turn.turn_id
+       turn.model
+   | Error error ->
+     Log.Runtime_agent.warn
+       "Claude Code subscription turn failed (kind=%s)"
+       (error_kind error));
+  result
+;;

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -32,8 +32,19 @@ type session_mode =
   | Start
   | Resume of { session_id : string }
 
+type rate_limit_status =
+  | Allowed
+  | Allowed_warning
+  | Rejected
+
+let rate_limit_status_to_string = function
+  | Allowed -> "allowed"
+  | Allowed_warning -> "allowed_warning"
+  | Rejected -> "rejected"
+;;
+
 type rate_limit =
-  { status : string
+  { status : rate_limit_status
   ; rate_limit_type : string option
   ; resets_at : int option
   ; overage_status : string option
@@ -94,7 +105,7 @@ let error_to_string = function
     let status =
       Option.fold
         ~none:"unknown"
-        ~some:(fun value -> value.status)
+        ~some:(fun value -> rate_limit_status_to_string value.status)
         rate_limit
     in
     let api_status =
@@ -562,10 +573,14 @@ let parse_rate_limit ~expected_session_id fields =
   in
   let* info = required_member stage "rate_limit_info" fields in
   let* info_fields = assoc_at stage info in
-  let* status = required_string stage "status" info_fields in
-  if not (List.mem status [ "allowed"; "allowed_warning"; "rejected" ])
-  then protocol_error stage (Printf.sprintf "unknown status %S" status)
-  else
+  let* status_wire = required_string stage "status" info_fields in
+  let* status =
+    match status_wire with
+    | "allowed" -> Ok Allowed
+    | "allowed_warning" -> Ok Allowed_warning
+    | "rejected" -> Ok Rejected
+    | unknown -> protocol_error stage (Printf.sprintf "unknown status %S" unknown)
+  in
     let* rate_limit_type = optional_string stage "rateLimitType" info_fields in
     let* resets_at = optional_int stage "resetsAt" info_fields in
     let* overage_status = optional_string stage "overageStatus" info_fields in
@@ -640,7 +655,7 @@ let parse_result ~expected_session_id ~rate_limit fields =
       let structurally_quota_blocked =
         Option.equal Int.equal api_error_status (Some 429)
         || Option.exists
-             (fun (limit : rate_limit) -> limit.status = "rejected")
+             (fun (limit : rate_limit) -> limit.status = Rejected)
              rate_limit
       in
       if structurally_quota_blocked

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -213,35 +213,26 @@ let optional_int stage name fields =
     protocol_error stage (Printf.sprintf "field %S must be an integer or null" name)
 ;;
 
-let env_key entry =
-  match String.index_opt entry '=' with
-  | Some index -> String.sub entry 0 index
-  | None -> entry
-;;
-
 let subscription_only_environment () =
-  let blocked =
-    [ "ANTHROPIC_API_KEY"
-    ; "ANTHROPIC_AUTH_TOKEN"
-    ; "ANTHROPIC_API_URL"
-    ; "ANTHROPIC_BASE_URL"
-    ; "ANTHROPIC_BEDROCK_BASE_URL"
-    ; "ANTHROPIC_VERTEX_BASE_URL"
-    ; "ANTHROPIC_VERTEX_PROJECT_ID"
-    ; "CLAUDE_CODE_OAUTH_TOKEN"
-    ; "CLAUDE_CODE_SKIP_BEDROCK_AUTH"
-    ; "CLAUDE_CODE_SKIP_VERTEX_AUTH"
-    ; "CLAUDE_CODE_USE_BEDROCK"
-    ; "CLAUDE_CODE_USE_VERTEX"
-    ; "CLAUDECODE"
-    ; "CLAUDE_CODE_ENTRYPOINT"
-    ; "CLAUDE_AGENT_SDK_VERSION"
-    ; "CLOUD_ML_REGION"
+  let inherited_names =
+    [ "HOME"
+    ; "PATH"
+    ; "TMPDIR"
+    ; "XDG_CONFIG_HOME"
+    ; "XDG_DATA_HOME"
+    ; "XDG_CACHE_HOME"
+    ; "SSL_CERT_FILE"
+    ; "SSL_CERT_DIR"
+    ; "LANG"
+    ; "LC_ALL"
+    ; "LC_CTYPE"
+    ; "TERM"
+    ; "NO_COLOR"
     ]
   in
-  Unix.environment ()
-  |> Array.to_list
-  |> List.filter (fun entry -> not (List.mem (env_key entry) blocked))
+  inherited_names
+  |> List.filter_map (fun name ->
+    Option.map (fun value -> name ^ "=" ^ value) (Sys.getenv_opt name))
   |> fun inherited ->
   ("CLAUDE_CODE_ENTRYPOINT=masc" :: "CLAUDE_AGENT_SDK_VERSION=masc-ocaml" :: inherited)
   |> Array.of_list

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -223,10 +223,20 @@ let subscription_only_environment () =
   let blocked =
     [ "ANTHROPIC_API_KEY"
     ; "ANTHROPIC_AUTH_TOKEN"
+    ; "ANTHROPIC_API_URL"
+    ; "ANTHROPIC_BASE_URL"
+    ; "ANTHROPIC_BEDROCK_BASE_URL"
+    ; "ANTHROPIC_VERTEX_BASE_URL"
+    ; "ANTHROPIC_VERTEX_PROJECT_ID"
     ; "CLAUDE_CODE_OAUTH_TOKEN"
+    ; "CLAUDE_CODE_SKIP_BEDROCK_AUTH"
+    ; "CLAUDE_CODE_SKIP_VERTEX_AUTH"
+    ; "CLAUDE_CODE_USE_BEDROCK"
+    ; "CLAUDE_CODE_USE_VERTEX"
     ; "CLAUDECODE"
     ; "CLAUDE_CODE_ENTRYPOINT"
     ; "CLAUDE_AGENT_SDK_VERSION"
+    ; "CLOUD_ML_REGION"
     ]
   in
   Unix.environment ()
@@ -379,6 +389,10 @@ let mcp_tools_call ~id ~params ~tools ~tool_call_count =
     Ok (mcp_tool_result ~id result)
 ;;
 
+type mcp_dispatch =
+  | Mcp_response of Yojson.Safe.t
+  | Mcp_notification
+
 let handle_mcp_message ~tools ~tool_call_count message =
   let stage = "MCP message" in
   let* fields = assoc_at stage message in
@@ -390,18 +404,24 @@ let handle_mcp_message ~tools ~tool_call_count message =
     let id = Option.value (List.assoc_opt "id" fields) ~default:`Null in
     let params = Option.value (List.assoc_opt "params" fields) ~default:(`Assoc []) in
     match method_ with
-    | "initialize" when id <> `Null -> Ok (mcp_initialize ~id)
-    | "tools/list" when id <> `Null -> Ok (mcp_tools_list ~id tools)
+    | "initialize" when id <> `Null -> Ok (Mcp_response (mcp_initialize ~id))
+    | "tools/list" when id <> `Null -> Ok (Mcp_response (mcp_tools_list ~id tools))
     | "tools/call" when id <> `Null ->
-      mcp_tools_call ~id ~params ~tools ~tool_call_count
+      let* response = mcp_tools_call ~id ~params ~tools ~tool_call_count in
+      Ok (Mcp_response response)
     | "notifications/initialized" when id = `Null ->
-      Ok (`Assoc [ "jsonrpc", `String "2.0"; "result", `Assoc [] ])
+      Ok Mcp_notification
+    | _ when id = `Null ->
+      protocol_error
+        stage
+        (Printf.sprintf "MCP notification %S is not supported" method_)
     | _ ->
       Ok
-        (jsonrpc_error
-           ~id
-           ~code:(-32601)
-           (Printf.sprintf "MCP method %S is not supported" method_))
+        (Mcp_response
+           (jsonrpc_error
+              ~id
+              ~code:(-32601)
+              (Printf.sprintf "MCP method %S is not supported" method_)))
 ;;
 
 let send_control_success io ~request_id response =
@@ -446,12 +466,15 @@ let handle_control_request io ~tools ~tool_call_count fields =
       Error (Unsupported_control_request subtype)
     else
       let* message = required_member stage "message" request_fields in
-      let* mcp_response = handle_mcp_message ~tools ~tool_call_count message in
-      send_control_success
-        io
-        ~request_id
-        (`Assoc [ "mcp_response", mcp_response ]);
-      Ok ()
+      let* dispatch = handle_mcp_message ~tools ~tool_call_count message in
+      (match dispatch with
+       | Mcp_notification -> Ok ()
+       | Mcp_response mcp_response ->
+         send_control_success
+           io
+           ~request_id
+           (`Assoc [ "mcp_response", mcp_response ]);
+         Ok ())
   | unsupported ->
     send_control_error
       io

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -1,0 +1,101 @@
+(** A single-turn client for the official Claude Code CLI.
+
+    This is not an Anthropic HTTP provider and it does not read API keys.
+    Claude Code owns the subscription session and model loop. MASC owns the
+    child lifetime, exact SDK-control/MCP bridge, and terminal projection. *)
+
+type subscription =
+  { auth_method : string
+  ; subscription_type : string
+  ; api_provider : string
+  }
+
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string option
+  ; system_prompt : string option
+  ; timeout_s : float
+  }
+
+val default_config : cwd:string -> config
+
+type session_mode =
+  | Start
+  | Resume of { session_id : string }
+
+type rate_limit =
+  { status : string
+  ; rate_limit_type : string option
+  ; resets_at : int option
+  ; overage_status : string option
+  ; overage_disabled_reason : string option
+  }
+
+type turn_result =
+  { session_id : string
+  ; turn_id : string
+  ; model : string
+  ; text : string
+  ; dynamic_tool_calls : int
+  ; subscription : subscription
+  ; rate_limit : rate_limit option
+  ; resumed : bool
+  }
+
+type dynamic_tool_result =
+  { success : bool
+  ; content : string
+  }
+
+type dynamic_tool =
+  { name : string
+  ; description : string
+  ; input_schema : Yojson.Safe.t
+  ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | Subscription_required of string
+  | Unsupported_control_request of string
+  | Turn_failed of string
+  | Quota_blocked of
+      { api_error_status : int option
+      ; rate_limit : rate_limit option
+      }
+  | Process_exited of string
+  | Timeout of float
+
+val error_to_string : error -> string
+
+val validate_turn :
+  ?dynamic_tools:dynamic_tool list ->
+  ?session_mode:session_mode ->
+  config ->
+  prompt:string ->
+  (unit, error) result
+
+val run_turn :
+  ?dynamic_tools:dynamic_tool list ->
+  ?reasoning_effort:Llm_provider.Reasoning_effort.t ->
+  ?session_mode:session_mode ->
+  mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  cwd:Eio.Fs.dir_ty Eio.Path.t ->
+  ?on_session_ready:(session_id:string -> (unit, string) result) ->
+  ?on_turn_starting:(session_id:string -> (unit, string) result) ->
+  ?on_turn_started:(session_id:string -> turn_id:string -> (unit, string) result) ->
+  config ->
+  prompt:string ->
+  (turn_result, error) result
+(** Execute one turn through Claude Code's stream-json control protocol.
+
+    API-key and token environment variables are removed from the child. The
+    preflight requires [claude auth status --json] to report a logged-in
+    [claude.ai] subscription served by [firstParty]. *)

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -24,8 +24,15 @@ type session_mode =
   | Start
   | Resume of { session_id : string }
 
+type rate_limit_status =
+  | Allowed
+  | Allowed_warning
+  | Rejected
+
+val rate_limit_status_to_string : rate_limit_status -> string
+
 type rate_limit =
-  { status : string
+  { status : rate_limit_status
   ; rate_limit_type : string option
   ; resets_at : int option
   ; overage_status : string option

--- a/test/dune
+++ b/test/dune
@@ -1942,6 +1942,7 @@
 (include stanzas/test_runtime_agent_close_cancel_source.inc)
 
 (include stanzas/test_runtime_codex_app_server.inc)
+(include stanzas/test_runtime_claude_code.inc)
 (include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/stanzas/test_runtime_claude_code.inc
+++ b/test/stanzas/test_runtime_claude_code.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_claude_code)
+ (modules test_runtime_claude_code)
+ (libraries masc masc_test_deps))

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -20,19 +20,32 @@ let result =
 type fixture_step =
   | Emit of string
   | Emit_and_read of string
+  | Emit_and_expect_request_id of string * string
 
 let fixture_script ?(auth_json = auth_subscription) steps =
   let path = Filename.temp_file "masc-claude-code-" ".sh" in
   let output = open_out_bin path in
   output_string output "#!/bin/sh\n";
   output_string output "set -eu\n";
+  List.iter
+    (fun name ->
+       output_string output
+         (Printf.sprintf "[ \"${%s+x}\" != x ] || exit 90\n" name))
+    [ "ANTHROPIC_API_KEY"
+    ; "ANTHROPIC_AUTH_TOKEN"
+    ; "ANTHROPIC_API_URL"
+    ; "ANTHROPIC_BASE_URL"
+    ; "ANTHROPIC_BEDROCK_BASE_URL"
+    ; "ANTHROPIC_VERTEX_BASE_URL"
+    ; "ANTHROPIC_VERTEX_PROJECT_ID"
+    ; "CLAUDE_CODE_OAUTH_TOKEN"
+    ; "CLAUDE_CODE_SKIP_BEDROCK_AUTH"
+    ; "CLAUDE_CODE_SKIP_VERTEX_AUTH"
+    ; "CLAUDE_CODE_USE_BEDROCK"
+    ; "CLAUDE_CODE_USE_VERTEX"
+    ; "CLOUD_ML_REGION"
+    ];
   output_string output "if [ \"${1-}\" = auth ]; then\n";
-  output_string output
-    "  [ \"${ANTHROPIC_API_KEY+x}\" != x ] || exit 91\n";
-  output_string output
-    "  [ \"${ANTHROPIC_AUTH_TOKEN+x}\" != x ] || exit 92\n";
-  output_string output
-    "  [ \"${CLAUDE_CODE_OAUTH_TOKEN+x}\" != x ] || exit 93\n";
   output_string output
     ("  printf '%s\\n' " ^ shell_quote auth_json ^ "\n");
   output_string output "  exit 0\n";
@@ -59,7 +72,14 @@ let fixture_script ?(auth_json = auth_subscription) steps =
         output_string output ("emit " ^ shell_quote line ^ "\n")
       | Emit_and_read line ->
         output_string output ("emit " ^ shell_quote line ^ "\n");
-        output_string output "IFS= read -r ignored_response\n")
+        output_string output "IFS= read -r ignored_response\n"
+      | Emit_and_expect_request_id (line, request_id) ->
+        output_string output ("emit " ^ shell_quote line ^ "\n");
+        output_string output "IFS= read -r control_response\n";
+        output_string output
+          (Printf.sprintf
+             "printf '%%s' \"$control_response\" | grep -F '\"request_id\":\"%s\"' >/dev/null || exit 96\n"
+             request_id))
     steps;
   output_string output "while IFS= read -r ignored; do :; done\n";
   close_out output;
@@ -101,6 +121,22 @@ let test_validation_is_process_free () =
 ;;
 
 let test_subscription_turn_and_env_scrub () =
+  List.iter
+    (fun name -> Unix.putenv name "hostile-fixture-value")
+    [ "ANTHROPIC_API_KEY"
+    ; "ANTHROPIC_AUTH_TOKEN"
+    ; "ANTHROPIC_API_URL"
+    ; "ANTHROPIC_BASE_URL"
+    ; "ANTHROPIC_BEDROCK_BASE_URL"
+    ; "ANTHROPIC_VERTEX_BASE_URL"
+    ; "ANTHROPIC_VERTEX_PROJECT_ID"
+    ; "CLAUDE_CODE_OAUTH_TOKEN"
+    ; "CLAUDE_CODE_SKIP_BEDROCK_AUTH"
+    ; "CLAUDE_CODE_SKIP_VERTEX_AUTH"
+    ; "CLAUDE_CODE_USE_BEDROCK"
+    ; "CLAUDE_CODE_USE_VERTEX"
+    ; "CLOUD_ML_REGION"
+    ];
   with_fixture [ Emit assistant; Emit result ] (fun path ->
     match run_fixture path with
     | Error error -> fail (Runtime_claude_code.error_to_string error)
@@ -151,6 +187,14 @@ let mcp_list =
   {|{"type":"control_request","request_id":"mcp-list-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}}}|}
 ;;
 
+let mcp_initialized_notification =
+  {|{"type":"control_request","request_id":"mcp-notify-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}}}|}
+;;
+
+let mcp_list_after_notification =
+  {|{"type":"control_request","request_id":"mcp-list-after-notification","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}}}|}
+;;
+
 let mcp_call =
   {|{"type":"control_request","request_id":"mcp-call-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"masc_probe","arguments":{"marker":"from-claude"}}}}}|}
 ;;
@@ -190,6 +234,20 @@ let test_dynamic_tool_callback () =
           "arguments"
           {|{"marker":"from-claude"}|}
           (Yojson.Safe.to_string !observed_input))
+;;
+
+let test_mcp_notification_has_no_response () =
+  with_fixture
+    [ Emit mcp_initialized_notification
+    ; Emit_and_expect_request_id
+        (mcp_list_after_notification, "mcp-list-after-notification")
+    ; Emit assistant
+    ; Emit result
+    ]
+    (fun path ->
+      match run_fixture path with
+      | Error error -> fail (Runtime_claude_code.error_to_string error)
+      | Ok turn -> check string "text" "MASC_CLAUDE_OK" turn.text)
 ;;
 
 let test_malformed_json_fails_closed () =
@@ -312,6 +370,10 @@ let () =
         ] )
     ; ( "mcp"
       , [ test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
+        ; test_case
+            "notification has no response"
+            `Quick
+            test_mcp_notification_has_no_response
         ; test_case
             "unsupported control request fails closed"
             `Quick

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -1,0 +1,333 @@
+open Alcotest
+open Masc
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let auth_subscription =
+  {|{"loggedIn":true,"authMethod":"claude.ai","subscriptionType":"team","apiProvider":"firstParty"}|}
+;;
+
+let assistant =
+  {|{"type":"assistant","session_id":"__SESSION__","uuid":"assistant-fixture-1","message":{"role":"assistant","model":"claude-fixture","content":[{"type":"text","text":"MASC_CLAUDE_OK"}]}}|}
+;;
+
+let result =
+  {|{"type":"result","subtype":"success","is_error":false,"session_id":"__SESSION__","uuid":"turn-fixture-1","result":"MASC_CLAUDE_OK","api_error_status":null}|}
+;;
+
+type fixture_step =
+  | Emit of string
+  | Emit_and_read of string
+
+let fixture_script ?(auth_json = auth_subscription) steps =
+  let path = Filename.temp_file "masc-claude-code-" ".sh" in
+  let output = open_out_bin path in
+  output_string output "#!/bin/sh\n";
+  output_string output "set -eu\n";
+  output_string output "if [ \"${1-}\" = auth ]; then\n";
+  output_string output
+    "  [ \"${ANTHROPIC_API_KEY+x}\" != x ] || exit 91\n";
+  output_string output
+    "  [ \"${ANTHROPIC_AUTH_TOKEN+x}\" != x ] || exit 92\n";
+  output_string output
+    "  [ \"${CLAUDE_CODE_OAUTH_TOKEN+x}\" != x ] || exit 93\n";
+  output_string output
+    ("  printf '%s\\n' " ^ shell_quote auth_json ^ "\n");
+  output_string output "  exit 0\n";
+  output_string output "fi\n";
+  output_string output "session=''\n";
+  output_string output "for arg in \"$@\"; do\n";
+  output_string output "  case \"$arg\" in\n";
+  output_string output "    --session-id=*) session=${arg#--session-id=} ;;\n";
+  output_string output "    --resume=*) session=${arg#--resume=} ;;\n";
+  output_string output "  esac\n";
+  output_string output "done\n";
+  output_string output "[ -n \"$session\" ] || exit 94\n";
+  output_string output "emit() { printf '%s\\n' \"$1\" | sed \"s/__SESSION__/$session/g\"; }\n";
+  output_string output "IFS= read -r initialize\n";
+  output_string output
+    "request_id=$(printf '%s' \"$initialize\" | sed -n 's/.*\"request_id\":\"\\([^\"]*\\)\".*/\\1/p')\n";
+  output_string output "[ -n \"$request_id\" ] || exit 95\n";
+  output_string output
+    "printf '{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\",\"request_id\":\"%s\",\"response\":{}}}\\n' \"$request_id\"\n";
+  output_string output "IFS= read -r user_message\n";
+  List.iter
+    (function
+      | Emit line ->
+        output_string output ("emit " ^ shell_quote line ^ "\n")
+      | Emit_and_read line ->
+        output_string output ("emit " ^ shell_quote line ^ "\n");
+        output_string output "IFS= read -r ignored_response\n")
+    steps;
+  output_string output "while IFS= read -r ignored; do :; done\n";
+  close_out output;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let with_fixture ?auth_json steps f =
+  let path = fixture_script ?auth_json steps in
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let run_fixture ?(dynamic_tools = []) ?session_mode path =
+  Eio_main.run (fun env ->
+    let config =
+      { (Runtime_claude_code.default_config ~cwd:"/tmp") with
+        cli_path = path
+      ; timeout_s = 2.0
+      }
+    in
+    Runtime_claude_code.run_turn
+      ~mgr:(Eio.Stdenv.process_mgr env)
+      ~clock:(Eio.Stdenv.clock env)
+      ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+      ~dynamic_tools
+      ?session_mode
+      config
+      ~prompt:"Return the fixture marker")
+;;
+
+let test_validation_is_process_free () =
+  let config =
+    { (Runtime_claude_code.default_config ~cwd:"/tmp") with cli_path = "" }
+  in
+  match Runtime_claude_code.validate_turn config ~prompt:"fixture" with
+  | Error (Runtime_claude_code.Invalid_config "cli_path must not be empty") -> ()
+  | Error error -> fail (Runtime_claude_code.error_to_string error)
+  | Ok () -> fail "invalid Claude Code config passed admission"
+;;
+
+let test_subscription_turn_and_env_scrub () =
+  with_fixture [ Emit assistant; Emit result ] (fun path ->
+    match run_fixture path with
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok turn ->
+      check string "text" "MASC_CLAUDE_OK" turn.text;
+      check string "turn" "turn-fixture-1" turn.turn_id;
+      check string "model" "claude-fixture" turn.model;
+      check string "subscription" "team" turn.subscription.subscription_type;
+      check bool "new session" false turn.resumed)
+;;
+
+let test_non_subscription_auth_is_rejected () =
+  let auth_json =
+    {|{"loggedIn":true,"authMethod":"apiKey","subscriptionType":"api","apiProvider":"firstParty"}|}
+  in
+  with_fixture ~auth_json [] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Subscription_required _) -> ()
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "API-key Claude auth was admitted as subscription")
+;;
+
+let rate_limit_rejected =
+  {|{"type":"rate_limit_event","session_id":"__SESSION__","uuid":"limit-1","rate_limit_info":{"status":"rejected","rateLimitType":"seven_day","resetsAt":1786356000,"overageStatus":"rejected","overageDisabledReason":"org_level_disabled_until"}}|}
+;;
+
+let quota_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-quota-1","result":"not inspected","api_error_status":429,"terminal_reason":"api_error"}|}
+;;
+
+let test_quota_is_structurally_classified () =
+  with_fixture [ Emit rate_limit_rejected; Emit quota_result ] (fun path ->
+    match run_fixture path with
+    | Error
+        (Runtime_claude_code.Quota_blocked
+          { api_error_status = Some 429
+          ; rate_limit = Some { status = "rejected"; _ }
+          }) -> ()
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "typed quota rejection was reported as completion")
+;;
+
+let mcp_initialize =
+  {|{"type":"control_request","request_id":"mcp-init-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}}}|}
+;;
+
+let mcp_list =
+  {|{"type":"control_request","request_id":"mcp-list-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}}}|}
+;;
+
+let mcp_call =
+  {|{"type":"control_request","request_id":"mcp-call-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"masc_probe","arguments":{"marker":"from-claude"}}}}}|}
+;;
+
+let test_dynamic_tool_callback () =
+  let observed_call_id = ref None in
+  let observed_input = ref `Null in
+  let tool : Runtime_claude_code.dynamic_tool =
+    { name = "masc_probe"
+    ; description = "Return a fixture marker"
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc [ "marker", `Assoc [ "type", `String "string" ] ]
+          ]
+    ; call =
+        (fun ~call_id input ->
+          observed_call_id := Some call_id;
+          observed_input := input;
+          { success = true; content = "MASC_TOOL_RESULT" })
+    }
+  in
+  with_fixture
+    [ Emit_and_read mcp_initialize
+    ; Emit_and_read mcp_list
+    ; Emit_and_read mcp_call
+    ; Emit assistant
+    ; Emit result
+    ]
+    (fun path ->
+      match run_fixture ~dynamic_tools:[ tool ] path with
+      | Error error -> fail (Runtime_claude_code.error_to_string error)
+      | Ok turn ->
+        check int "measured calls" 1 turn.dynamic_tool_calls;
+        check (option string) "call id" (Some "call-1") !observed_call_id;
+        check string
+          "arguments"
+          {|{"marker":"from-claude"}|}
+          (Yojson.Safe.to_string !observed_input))
+;;
+
+let test_malformed_json_fails_closed () =
+  with_fixture [ Emit "not-json" ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Protocol_error _) -> ()
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "malformed stream JSON was admitted")
+;;
+
+let test_duplicate_keys_fail_closed () =
+  let duplicate =
+    {|{"type":"assistant","type":"result","session_id":"__SESSION__","uuid":"duplicate-1"}|}
+  in
+  with_fixture [ Emit duplicate ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Protocol_error _) -> ()
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "duplicate stream JSON key was admitted")
+;;
+
+let test_unsupported_control_request_fails_closed () =
+  let request =
+    {|{"type":"control_request","request_id":"permission-1","request":{"subtype":"can_use_tool","tool_name":"Bash","input":{}}}|}
+  in
+  with_fixture [ Emit request ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Unsupported_control_request "can_use_tool") -> ()
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "unsupported permission request was admitted")
+;;
+
+let test_unknown_stream_type_fails_closed () =
+  let unknown =
+    {|{"type":"future_magic","session_id":"__SESSION__","uuid":"future-1"}|}
+  in
+  with_fixture [ Emit unknown ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Protocol_error _) -> ()
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "unknown stream type was silently ignored")
+;;
+
+let test_allowed_tools_tokenizer_chars_are_validated () =
+  let tool : Runtime_claude_code.dynamic_tool =
+    { name = "bad,tool"
+    ; description = "invalid fixture"
+    ; input_schema = `Assoc []
+    ; call = (fun ~call_id:_ _ -> { success = true; content = "unused" })
+    }
+  in
+  let config = Runtime_claude_code.default_config ~cwd:"/tmp" in
+  match
+    Runtime_claude_code.validate_turn
+      ~dynamic_tools:[ tool ]
+      config
+      ~prompt:"fixture"
+  with
+  | Error (Runtime_claude_code.Invalid_config _) -> ()
+  | Error error -> fail (Runtime_claude_code.error_to_string error)
+  | Ok () -> fail "allowedTools delimiter was admitted in a tool name"
+;;
+
+let test_resume_preserves_session_identity () =
+  with_fixture [ Emit assistant; Emit result ] (fun path ->
+    match
+      run_fixture
+        ~session_mode:
+          (Runtime_claude_code.Resume { session_id = "fixture-session-resume" })
+        path
+    with
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok turn ->
+      check string "session" "fixture-session-resume" turn.session_id;
+      check bool "resumed" true turn.resumed)
+;;
+
+let test_live_subscription () =
+  if Sys.getenv_opt "MASC_CLAUDE_CODE_LIVE" <> Some "1"
+  then Alcotest.skip ()
+  else
+    let outcome =
+      Eio_main.run (fun env ->
+        let config =
+          { (Runtime_claude_code.default_config ~cwd:"/tmp") with timeout_s = 60.0 }
+        in
+        Runtime_claude_code.run_turn
+          ~mgr:(Eio.Stdenv.process_mgr env)
+          ~clock:(Eio.Stdenv.clock env)
+          ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+          config
+          ~prompt:"Reply with exactly MASC_CLAUDE_LIVE_OK")
+    in
+    match outcome with
+    | Ok turn -> check string "live response" "MASC_CLAUDE_LIVE_OK" turn.text
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+;;
+
+let () =
+  run
+    "runtime_claude_code"
+    [ ( "admission"
+      , [ test_case "validation is process-free" `Quick test_validation_is_process_free
+        ; test_case
+            "subscription auth and env scrub"
+            `Quick
+            test_subscription_turn_and_env_scrub
+        ; test_case
+            "non-subscription rejected"
+            `Quick
+            test_non_subscription_auth_is_rejected
+        ] )
+    ; ( "terminal"
+      , [ test_case
+            "quota is structurally classified"
+            `Quick
+            test_quota_is_structurally_classified
+        ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
+        ; test_case "duplicate keys fail closed" `Quick test_duplicate_keys_fail_closed
+        ] )
+    ; ( "mcp"
+      , [ test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
+        ; test_case
+            "unsupported control request fails closed"
+            `Quick
+            test_unsupported_control_request_fails_closed
+        ; test_case
+            "allowedTools tokenizer chars validated"
+            `Quick
+            test_allowed_tools_tokenizer_chars_are_validated
+        ] )
+    ; ( "hard-cut"
+      , [ test_case
+            "unknown stream type fails closed"
+            `Quick
+            test_unknown_stream_type_fails_closed
+        ] )
+    ; "session", [ test_case "resume identity" `Quick test_resume_preserves_session_identity ]
+    ; "live", [ test_case "subscription turn" `Slow test_live_subscription ]
+    ]
+;;

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -180,7 +180,7 @@ let test_quota_is_structurally_classified () =
     | Error
         (Runtime_claude_code.Quota_blocked
           { api_error_status = Some 429
-          ; rate_limit = Some { status = "rejected"; _ }
+          ; rate_limit = Some { status = Runtime_claude_code.Rejected; _ }
           }) -> ()
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "typed quota rejection was reported as completion")

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -44,7 +44,13 @@ let fixture_script ?(auth_json = auth_subscription) steps =
     ; "CLAUDE_CODE_USE_BEDROCK"
     ; "CLAUDE_CODE_USE_VERTEX"
     ; "CLOUD_ML_REGION"
+    ; "MASC_CLAUDE_SECRET_CANARY"
     ];
+  output_string output "[ -n \"${HOME-}\" ] || exit 91\n";
+  output_string output
+    "[ \"${CLAUDE_CODE_ENTRYPOINT-}\" = masc ] || exit 92\n";
+  output_string output
+    "[ \"${CLAUDE_AGENT_SDK_VERSION-}\" = masc-ocaml ] || exit 93\n";
   output_string output "if [ \"${1-}\" = auth ]; then\n";
   output_string output
     ("  printf '%s\\n' " ^ shell_quote auth_json ^ "\n");
@@ -136,6 +142,7 @@ let test_subscription_turn_and_env_scrub () =
     ; "CLAUDE_CODE_USE_BEDROCK"
     ; "CLAUDE_CODE_USE_VERTEX"
     ; "CLOUD_ML_REGION"
+    ; "MASC_CLAUDE_SECRET_CANARY"
     ];
   with_fixture [ Emit assistant; Emit result ] (fun path ->
     match run_fixture path with


### PR DESCRIPTION
## What changed

- Add a direct `Runtime_claude_code` official-CLI boundary using Claude Code stream-json control protocol.
- Admit only stored `claude.ai` / `firstParty` subscription login from `claude auth status --json`.
- Strip Anthropic API/token environment variables from both auth preflight and turn processes.
- Host MASC dynamic tools through the typed SDK MCP `initialize`, `tools/list`, and `tools/call` control path.
- Preserve exact Claude session identity for start/resume and classify terminal quota state from typed rate-limit fields and HTTP status.

## Why

Claude Code subscription execution is an agent runtime, not an Anthropic HTTP provider. Keeping it outside `agent_core` avoids inventing an API-key provider or ACP facade while preserving official-client session ownership.

## Impact

This PR adds the standalone protocol core only. It does not yet admit `claude-code` in runtime.toml, route Keeper turns, or change dashboard surfaces; those remain separate follow-up PRs so this boundary can be reviewed independently.

## Validation

- Claude fixture suite: 11 passed, 1 live case skipped by default.
- Test coverage policy: passed.
- OCaml formatting and `git diff --check`: passed.
- Real local Claude Code 2.1.226 reached the terminal path with stored Team login and returned typed `rate_limit.status=rejected`, `api_error_status=429`; the client classified it as `quota_blocked`. A successful live completion remains blocked by the account individual spend limit.