### PR TITLE
feat(runtime): materialize Claude Code subscription runtimes

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -99,6 +99,22 @@ endpoint = "http://localhost:11434"
 [providers.ollama.healthcheck]
 path = "/api/tags"
 
+# Official Claude Code subscription runtime example. This stays commented so
+# a fresh install does not claim the local CLI is installed or logged in.
+# There is deliberately no credentials table: Claude Code owns its stored
+# claude.ai login, and MASC removes API/token environment fallbacks.
+# [providers.claude_code]
+# display-name = "Claude Code Subscription"
+# protocol = "claude-code"
+# command = "claude"
+# is-non-interactive = true
+#
+# [models.claude-code-sonnet]
+# api-name = "claude-sonnet-4-5"
+# max-context = 200000
+#
+# [claude_code.claude-code-sonnet]
+
 [models.deepseek-v4-pro]
 api-name = "deepseek-v4-pro"
 max-context = 1000000

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -283,7 +283,8 @@ let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with
   | Some runtime ->
     (match runtime.Runtime.execution with
-     | Runtime_execution.Codex_app_server _ -> Ok runtime
+     | Runtime_execution.Codex_app_server _
+     | Runtime_execution.Claude_code _ -> Ok runtime
      | Runtime_execution.Agent_core provider_config ->
        let* _request_body_cap =
          validate_provider_request_cap
@@ -739,6 +740,15 @@ let run_named
              on_runtime_observation
          | Error _ -> ());
         codex_result, None
+      | Runtime_execution.Claude_code _ ->
+        ( Error
+            (Agent_sdk.Error.Config
+               (Agent_sdk.Error.InvalidConfig
+                  { field = "claude_code"
+                  ; detail =
+                      "claude-code runtime is configured, but this stack layer does not yet contain its Keeper driver"
+                  }))
+        , None )
       | Runtime_execution.Agent_core runtime_provider_config ->
        (match
           match provider_config_transform with

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -87,7 +87,8 @@ let vision_runtime_candidates ()
   from_failover @ rest
   |> List.filter_map (fun (rt : Runtime.t) ->
        match rt.Runtime.execution with
-       | Runtime_execution.Codex_app_server _ -> None
+       | Runtime_execution.Codex_app_server _
+       | Runtime_execution.Claude_code _ -> None
        | Runtime_execution.Agent_core provider_config ->
          let caps = Runtime_agent.input_capabilities_of_runtime rt in
          if Runtime_agent.caps_admit_required_modalities caps [ "image" ]

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -448,7 +448,8 @@ let capabilities_for_runtime (rt : t) =
   match rt.execution with
   | Runtime_execution.Agent_core provider_config ->
     Llm_provider.Provider_config.capabilities_for_config_model provider_config
-  | Runtime_execution.Codex_app_server _ -> None
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Claude_code _ -> None
 ;;
 
 type max_context_source =
@@ -604,7 +605,8 @@ let validate_keeper_dispatch_request_caps
          | None -> None
          | Some runtime ->
            (match runtime.execution with
-            | Runtime_execution.Codex_app_server _ -> None
+            | Runtime_execution.Codex_app_server _
+            | Runtime_execution.Claude_code _ -> None
             | Runtime_execution.Agent_core provider_config ->
               (match
                  validate_request_body_cap
@@ -641,7 +643,8 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
     List.filter_map
       (fun (r : t) ->
          match r.execution, capabilities_for_runtime r with
-         | Runtime_execution.Codex_app_server _, _ -> None
+         | ( Runtime_execution.Codex_app_server _
+           | Runtime_execution.Claude_code _ ), _ -> None
          | Runtime_execution.Agent_core _, Some _ -> None
          | Runtime_execution.Agent_core provider_config, None ->
            let provider_label =

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -203,12 +203,13 @@ let messages_api_compatible_provider_kind = function
 let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.provider)
     : (Llm_provider.Provider_config.provider_kind, string) result =
   match provider.api_format with
-  | Codex_app_server_runtime ->
+  | Codex_app_server_runtime | Claude_code_runtime ->
     Error
       (Printf.sprintf
-         "provider %S uses codex-app-server and cannot be materialized as an \
+         "provider %S uses official CLI protocol %s and cannot be materialized as an \
           HTTP provider"
-         provider.id)
+         provider.id
+         provider.protocol)
   | Ollama_api -> Ok Llm_provider.Provider_config.Ollama
   | Chat_completions_api ->
     (* Chat-completions keeps the historical OpenAI-compatible fallback when
@@ -491,6 +492,43 @@ let codex_app_server_execution (provider : Runtime_schema.provider)
             { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
 ;;
 
+let claude_code_execution (provider : Runtime_schema.provider)
+    (spec : Runtime_schema.model_spec) : (Runtime_execution.t, string) result =
+  match provider.transport with
+  | Http _ ->
+    Error
+      (Printf.sprintf
+         "provider %S uses protocol claude-code but declares an HTTP endpoint; \
+          an official Claude Code CLI command is required"
+         provider.id)
+  | Cli command when String.trim command = "" ->
+    Error
+      (Printf.sprintf
+         "provider %S declares an empty Claude Code CLI command"
+         provider.id)
+  | Cli command ->
+    (match provider.credentials with
+     | Some _ ->
+       Error
+         (Printf.sprintf
+            "provider %S uses claude-code and must not declare credentials; \
+             the official Claude Code client owns subscription login"
+            provider.id)
+     | None when not provider.is_non_interactive ->
+       Error
+         (Printf.sprintf
+            "provider %S uses claude-code and must declare \
+             is-non-interactive = true"
+            provider.id)
+     | None ->
+       Ok
+         (Runtime_execution.Claude_code
+            { cli_path = command
+            ; model = Some spec.api_name
+            ; timeout_s = 300.0
+            }))
+;;
+
 let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema.binding)
     : (Runtime_execution.t, string) result =
   match Runtime_schema.model_of_id cfg binding.model_id with
@@ -502,6 +540,8 @@ let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema
        (match provider.api_format with
         | Runtime_schema.Codex_app_server_runtime ->
           codex_app_server_execution provider spec
+        | Runtime_schema.Claude_code_runtime ->
+          claude_code_execution provider spec
         | Messages_api | Chat_completions_api | Ollama_api ->
           Result.map
             (fun provider_config -> Runtime_execution.Agent_core provider_config)

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -37,4 +37,5 @@ val binding_to_execution
 (** Materialize the owner of a complete turn. HTTP model APIs become
     {!Runtime_execution.Agent_core}. The exact [codex-app-server] protocol over
     a credential-free CLI transport becomes
-    {!Runtime_execution.Codex_app_server}. Other CLI protocols remain rejected. *)
+    {!Runtime_execution.Codex_app_server}; [claude-code] becomes
+    {!Runtime_execution.Claude_code}. Other CLI protocols remain rejected. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -683,7 +683,8 @@ let input_capabilities_of_runtime (rt : Runtime.t) =
     match rt.Runtime.execution with
     | Runtime_execution.Agent_core provider_config ->
       provider_caps_of_config provider_config
-    | Runtime_execution.Codex_app_server _ ->
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _ ->
       Llm_provider.Capabilities.default_capabilities
   in
   apply_runtime_model_input_capabilities

--- a/lib/runtime/runtime_execution.ml
+++ b/lib/runtime/runtime_execution.ml
@@ -4,9 +4,16 @@ type codex_app_server =
   ; timeout_s : float
   }
 
+type claude_code =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
+  | Claude_code of claude_code
 
 type checkpoint_owner =
   | Masc_oas
@@ -14,20 +21,22 @@ type checkpoint_owner =
 
 let agent_core_provider_config = function
   | Agent_core config -> Some config
-  | Codex_app_server _ -> None
+  | Codex_app_server _ | Claude_code _ -> None
 ;;
 
 let model_id = function
   | Agent_core config -> Some config.Llm_provider.Provider_config.model_id
   | Codex_app_server config -> config.model
+  | Claude_code config -> config.model
 ;;
 
 let label = function
   | Agent_core _ -> "agent_core"
   | Codex_app_server _ -> "codex_app_server"
+  | Claude_code _ -> "claude_code"
 ;;
 
 let checkpoint_owner = function
   | Agent_core _ -> Masc_oas
-  | Codex_app_server _ -> Official_client
+  | Codex_app_server _ | Claude_code _ -> Official_client
 ;;

--- a/lib/runtime/runtime_execution.mli
+++ b/lib/runtime/runtime_execution.mli
@@ -2,6 +2,7 @@
 
     [Agent_core] means MASC/OAS owns the model/tool/checkpoint loop.
     [Codex_app_server] means the official Codex client owns the whole turn;
+    [Claude_code] means the same for the official Claude Code client.
     MASC owns admission, process lifetime, and result projection. *)
 
 type codex_app_server =
@@ -10,9 +11,16 @@ type codex_app_server =
   ; timeout_s : float
   }
 
+type claude_code =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
+  | Claude_code of claude_code
 
 type checkpoint_owner =
   | Masc_oas

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -83,10 +83,11 @@ let resolve_runtime_providers ~runtime_id () =
   let provider_config_of_runtime rt =
     match rt.Runtime.execution with
     | Runtime_execution.Agent_core provider_config -> Ok provider_config
-    | Runtime_execution.Codex_app_server _ ->
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _ ->
       Error
         (Printf.sprintf
-           "runtime %S is owned by codex-app-server, not the OAS agent_core"
+           "runtime %S is owned by an official CLI client, not the OAS agent_core"
            rt.Runtime.id)
   in
   if String.equal runtime_id "" then

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -14,6 +14,7 @@ type api_format =
   | Chat_completions_api
   | Ollama_api
   | Codex_app_server_runtime
+  | Claude_code_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -12,6 +12,7 @@ type api_format =
   | Chat_completions_api
   | Ollama_api
   | Codex_app_server_runtime
+  | Claude_code_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -106,7 +106,8 @@ let partition_results
 
 let canonical_protocol_of_protocol = function
   | "messages-cli" | "messages-http" | "openai-compatible-cli"
-  | "openai-compatible-http" | "ollama-http" | "codex-app-server" as protocol ->
+  | "openai-compatible-http" | "ollama-http" | "codex-app-server"
+  | "claude-code" as protocol ->
     Some protocol
   | _ -> None
 ;;
@@ -115,7 +116,7 @@ let unknown_protocol_error s =
   Printf.sprintf
     "unknown protocol %S: expected one of messages-cli, messages-http, \
      openai-compatible-cli, openai-compatible-http, ollama-http, \
-     codex-app-server"
+     codex-app-server, claude-code"
     s
 ;;
 
@@ -128,6 +129,7 @@ let api_format_of_protocol (s : string)
     Ok Runtime_schema.Chat_completions_api
   | "ollama-http" -> Ok Runtime_schema.Ollama_api
   | "codex-app-server" -> Ok Runtime_schema.Codex_app_server_runtime
+  | "claude-code" -> Ok Runtime_schema.Claude_code_runtime
   | _ -> Error (unknown_protocol_error s)
 ;;
 

--- a/lib/runtime/runtime_toml.mli
+++ b/lib/runtime/runtime_toml.mli
@@ -34,7 +34,8 @@ val parse_file : string -> (Runtime_schema.config, parse_error list) result
 val api_format_of_protocol : string -> (Runtime_schema.api_format, string) result
 (** Map a TOML protocol string to a {!Runtime_schema.api_format} variant. Only
     the canonical labels are accepted: [messages-cli], [messages-http],
-    [openai-compatible-cli], [openai-compatible-http], [ollama-http]. The
+    [openai-compatible-cli], [openai-compatible-http], [ollama-http],
+    [codex-app-server], and [claude-code]. The
     deprecated provider-letter aliases [provider_d-http] / [provider-d-cli]
     (renamed in v0.19.43) are rejected with an "unknown protocol" error — they
     are NOT silently canonicalized — so a checked-in config still using them

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -774,7 +774,8 @@ let dashboard_runtime_append_probe_path base ~suffix =
 
 let dashboard_runtime_probe_url ~(api_format : Runtime_schema.api_format) base_url =
   match api_format with
-  | Runtime_schema.Codex_app_server_runtime -> None
+  | Runtime_schema.Codex_app_server_runtime
+  | Runtime_schema.Claude_code_runtime -> None
   | Runtime_schema.Ollama_api ->
     let base = dashboard_runtime_trim_trailing_slashes base_url in
     Some
@@ -884,7 +885,8 @@ let dashboard_runtime_model_count_of_body ~(api_format : Runtime_schema.api_form
   try
     let json = Yojson.Safe.from_string body in
     match api_format with
-    | Runtime_schema.Codex_app_server_runtime -> None
+    | Runtime_schema.Codex_app_server_runtime
+    | Runtime_schema.Claude_code_runtime -> None
     | Runtime_schema.Ollama_api -> dashboard_runtime_list_member_len "models" json
     | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
       (match dashboard_runtime_list_member_len "data" json with
@@ -1546,6 +1548,16 @@ let runtime_request_config_json (rt : Runtime.t) =
       ; "timeout_s", `Float config.timeout_s
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Claude_code config ->
+    `Assoc
+      [ "source", `String "official-client-runtime"
+      ; "execution", `String "claude_code"
+      ; "model", Json_util.string_opt_to_json config.model
+      ; "timeout_s", `Float config.timeout_s
+      ; "execution_mode", `String "masc_mcp_only"
+      ; "tool_owner", `String "masc_mcp"
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core cfg ->
     `Assoc
     [ "source", `String "oas-provider-config"
@@ -1591,6 +1603,7 @@ let runtime_api_format_wire : Runtime_schema.api_format -> string = function
   | Runtime_schema.Chat_completions_api -> "chat-completions"
   | Runtime_schema.Ollama_api -> "ollama"
   | Runtime_schema.Codex_app_server_runtime -> "codex-app-server"
+  | Runtime_schema.Claude_code_runtime -> "claude-code"
 ;;
 
 let runtime_provider_behavior_capabilities_json
@@ -1700,6 +1713,14 @@ let effective_capabilities_json (rt : Runtime.t) =
       ; "execution", `String "codex_app_server"
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Claude_code _ ->
+    `Assoc
+      [ "source", `String "unverified"
+      ; "execution", `String "claude_code"
+      ; "execution_mode", `String "masc_mcp_only"
+      ; "tool_owner", `String "masc_mcp"
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core provider_config ->
    (match Llm_provider.Provider_config.capabilities_for_config_model provider_config with
   | None -> `Null
@@ -1780,6 +1801,13 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
       [ "source", `String "official-client-owned"
       ; "execution", `String "codex_app_server"
       ]
+  | Runtime_execution.Claude_code _ ->
+    `Assoc
+      [ "source", `String "official-client-owned"
+      ; "execution", `String "claude_code"
+      ; "execution_mode", `String "masc_mcp_only"
+      ; "tool_owner", `String "masc_mcp"
+      ]
   | Runtime_execution.Agent_core provider_config ->
     let dialect = RD.for_provider_config provider_config in
     let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
@@ -1807,7 +1835,8 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
   let runtime_kind = runtime_kind_of_transport rt.provider.transport in
   let is_official_client_runtime =
     match rt.execution with
-    | Runtime_execution.Codex_app_server _ -> true
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _ -> true
     | Runtime_execution.Agent_core _ -> false
   in
   let runtime_status =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -90,10 +90,11 @@ let finalize_runtime_breakdown json =
 
 let validate_requested_model (runtime : Runtime.t) requested_model =
   match runtime.execution with
-  | Runtime_execution.Codex_app_server _ ->
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Claude_code _ ->
     Error
       (Printf.sprintf
-         "runtime %S is owned by codex-app-server; local_runtime_bench only \
+         "runtime %S is owned by an official CLI client; local_runtime_bench only \
           measures OAS agent_core providers"
          runtime.id)
   | Runtime_execution.Agent_core provider_config ->

--- a/test/dune
+++ b/test/dune
@@ -1943,6 +1943,7 @@
 
 (include stanzas/test_runtime_codex_app_server.inc)
 (include stanzas/test_runtime_claude_code.inc)
+(include stanzas/test_runtime_claude_code_config.inc)
 (include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/stanzas/test_runtime_claude_code_config.inc
+++ b/test/stanzas/test_runtime_claude_code_config.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_claude_code_config)
+ (modules test_runtime_claude_code_config)
+ (libraries alcotest masc.runtime))

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -577,7 +577,8 @@ let test_provider_for_vision_uses_runtime_temperature () =
        | None -> failwith "selected vision runtime should resolve"
        | Some runtime ->
          (match runtime.Runtime.execution with
-          | Runtime_execution.Codex_app_server _ ->
+          | Runtime_execution.Codex_app_server _
+          | Runtime_execution.Claude_code _ ->
             failwith "selected vision runtime should be agent_core"
           | Runtime_execution.Agent_core provider_config ->
             let configured = Vt.provider_for_vision provider_config in

--- a/test/test_runtime_claude_code_config.ml
+++ b/test/test_runtime_claude_code_config.ml
@@ -1,0 +1,105 @@
+open Alcotest
+
+let runtime_toml ?credential ?(transport = "command = \"claude\"")
+    ?(non_interactive = true) () =
+  let credential = Option.value credential ~default:"" in
+  Printf.sprintf
+    "[providers.claude_code]\n\
+     protocol = \"claude-code\"\n\
+     %s\n\
+     is-non-interactive = %b\n\
+     %s\n\
+     [models.claude-code-sonnet]\n\
+     api-name = \"claude-sonnet-4-5\"\n\
+     max-context = 200000\n\
+     \n\
+     [claude_code.claude-code-sonnet]\n\
+     \n\
+     [runtime]\n\
+     default = \"claude_code.claude-code-sonnet\"\n"
+    transport
+    non_interactive
+    credential
+;;
+
+let with_runtime_toml content f =
+  let path = Filename.temp_file "masc-claude-code-config-" ".toml" in
+  let channel = open_out_bin path in
+  output_string channel content;
+  close_out channel;
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let load content =
+  with_runtime_toml content (fun path -> Runtime.load_list ~config_path:path)
+;;
+
+let test_materializes_official_client_owner () =
+  match load (runtime_toml ()) with
+  | Error error -> failf "claude-code runtime should load: %s" error
+  | Ok (runtimes, default, _, _, _, _) ->
+    check int "one runtime" 1 (List.length runtimes);
+    check string "default" "claude_code.claude-code-sonnet" default.id;
+    (match default.execution with
+     | Runtime_execution.Claude_code config ->
+       check string "CLI" "claude" config.cli_path;
+       check (option string)
+         "model"
+         (Some "claude-sonnet-4-5")
+         config.model;
+       check (float 0.001) "timeout" 300.0 config.timeout_s
+     | Runtime_execution.Agent_core _
+     | Runtime_execution.Codex_app_server _ ->
+       fail "claude-code was materialized as the wrong execution owner")
+;;
+
+let test_declared_credentials_are_rejected () =
+  let credential =
+    "[providers.claude_code.credentials]\n\
+     type = \"env\"\n\
+     key = \"ANTHROPIC_API_KEY\"\n"
+  in
+  match load (runtime_toml ~credential ()) with
+  | Error _ -> ()
+  | Ok _ -> fail "claude-code admitted a declared API credential"
+;;
+
+let test_http_transport_is_rejected () =
+  match load (runtime_toml ~transport:"endpoint = \"https://api.anthropic.com\"" ()) with
+  | Error _ -> ()
+  | Ok _ -> fail "claude-code admitted an HTTP transport"
+;;
+
+let test_interactive_provider_is_rejected () =
+  match load (runtime_toml ~non_interactive:false ()) with
+  | Error _ -> ()
+  | Ok _ -> fail "claude-code admitted an interactive provider declaration"
+;;
+
+let test_protocol_name_is_exact () =
+  match Runtime_toml.api_format_of_protocol "claude_code" with
+  | Error _ -> ()
+  | Ok _ -> fail "underscore protocol alias was silently accepted"
+;;
+
+let () =
+  run
+    "runtime_claude_code_config"
+    [ ( "typed config"
+      , [ test_case
+            "materializes official-client owner"
+            `Quick
+            test_materializes_official_client_owner
+        ; test_case
+            "declared credentials rejected"
+            `Quick
+            test_declared_credentials_are_rejected
+        ; test_case "HTTP transport rejected" `Quick test_http_transport_is_rejected
+        ; test_case
+            "interactive provider rejected"
+            `Quick
+            test_interactive_provider_is_rejected
+        ; test_case "protocol name exact" `Quick test_protocol_name_is_exact
+        ] )
+    ]
+;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -13,7 +13,8 @@ let parse_or_fail content =
 let agent_core_provider_config (runtime : Runtime.t) =
   match runtime.execution with
   | Runtime_execution.Agent_core provider_config -> provider_config
-  | Runtime_execution.Codex_app_server _ ->
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Claude_code _ ->
     failf "runtime %s is not an agent_core provider" runtime.id
 ;;
 
@@ -3185,7 +3186,8 @@ let test_codex_app_server_materializes_as_turn_runtime () =
       check int "one runtime" 1 (List.length runtimes);
       check string "default id" "codex.codex" default.id;
       (match default.execution with
-       | Runtime_execution.Agent_core _ ->
+       | Runtime_execution.Agent_core _
+       | Runtime_execution.Claude_code _ ->
          fail "codex-app-server was incorrectly materialized as agent_core"
        | Runtime_execution.Codex_app_server config ->
          check string "cli path" "codex" config.cli_path;


### PR DESCRIPTION
## What changed

- Add exact `protocol = "claude-code"` parsing and a typed `Runtime_execution.Claude_code` owner.
- Materialize only credential-free, non-interactive CLI declarations.
- Keep Claude Code out of agent_core/OAS, local benchmark, and vision-provider paths.
- Expose the configured official-client shape in the runtime dashboard inventory as unverified.
- Add a commented runtime.toml example with no credential or API-key field.

## Why

The official Claude Code client owns subscription login and session execution. This layer makes that ownership explicit in runtime.toml without routing turns before the durable Keeper driver lands.

## Impact

A configured Claude Code runtime is visible and typed, but Keeper dispatch returns an explicit `claude_code` not-yet-wired error in this stack layer. The next PR replaces that branch with the durable shared-session driver.

## Validation

- Claude config suite: 5 passed.
- Existing runtime validity and Keeper vision test executables compile.
- `masc.runtime`, `masc`, and `masc.server` libraries compile.
- Test coverage policy, OCaml formatting, and `git diff --check`: passed.

The example uses `max-context = 200000`, the standard Claude Sonnet context boundary; it does not assume the optional 1M long-context mode.