### PR TITLE
fix: restore current runtime contracts

### DIFF
--- a/lib/tool_surface/tool_shard_types_schemas_base.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_base.ml
@@ -10,7 +10,12 @@ let base_tools : Masc_domain.tool_schema list =
     ; description =
         "Get current server time. Returns now_iso (ISO8601) and now_unix (float). Use to \
          timestamp events, check elapsed time, or include current time in reports."
-    ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc []
+          ; "additionalProperties", `Bool false
+          ]
     }
   ; (* Context status *)
     { name = "keeper_context_status"
@@ -23,7 +28,12 @@ let base_tools : Masc_domain.tool_schema list =
          passed directly as path or cwd to keeper tools without prefix. Use when checking \
          checkpoint/session continuity or resolving a path without string-interpolating \
          your own keeper name."
-    ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc []
+          ; "additionalProperties", `Bool false
+          ]
     }
   ; (* Memory *)
     { name = "keeper_memory_search"
@@ -123,7 +133,12 @@ let base_tools : Masc_domain.tool_schema list =
          the limitation if a connector-wide registry is unavailable. Returns tool names \
          organized by category plus descriptor_surface metadata with executor, \
          schema-shape, and typed usage examples."
-    ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc []
+          ; "additionalProperties", `Bool false
+          ]
     }
   ]
 ;;

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -185,7 +185,8 @@ if require_ok "$r10" \
   && [[ "$r10" == *"$task_id"* ]] \
   && { [[ "$r10" == *"awaiting_verification"* ]] || [[ "$r10" == *"in_progress"* ]]; } \
   && [[ "$r10" == *"$AGENT_NAME"* ]]; then
-  CLEANUP_TASK_FINALIZED=1
+  # Submission is not terminal. Keep EXIT cleanup armed so a verifier rejection
+  # cannot leak this producer-owned task into the next contract scenario.
   step_pass
 else
   step_fail "post-submission projection did not retain producer credit"

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -336,6 +336,7 @@ else
     "masc_tasks: AwaitingVerification projection did not retain producer credit" \
     "$r_awaiting"
 fi
-CLEANUP_TASK_FINALIZED=1
+# Awaiting verification is nonterminal. EXIT cleanup must release this task even
+# after a successful sweep so later harnesses do not inherit producer ownership.
 
 echo "PASS: public MCP tool live sweep"

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -361,7 +361,7 @@ max-concurrent = 1
             && String.equal err.message
                  "unknown protocol \"openai-http\": expected one of \
                   messages-cli, messages-http, openai-compatible-cli, \
-                  openai-compatible-http, ollama-http")
+                  openai-compatible-http, ollama-http, codex-app-server")
          errors)
 
 let test_runtime_toml_accepts_messages_caching_capability () =


### PR DESCRIPTION
## Summary
- make all zero-argument base-tool advertised schemas closed objects, matching descriptor validation
- keep `openai-http` rejected while updating its assertion to the current canonical protocol inventory
- keep contract-harness cleanup armed for nonterminal verification submissions so one scenario cannot block the next

## Why
The non-cancelled Build and Test for #27758 compiled successfully, then exposed three current-main contract failures:

- `keeper_time_now` advertised schema omitted `additionalProperties=false`
- the legacy-protocol rejection assertion omitted the current `codex-app-server` canonical protocol
- the golden-path harness marked a rejected/nonterminal task as finalized, leaking producer ownership into the public-tool sweep

## Verification
- GitHub CI is authoritative
- no local build or tests run

## Prompts and docs
The existing descriptor prompt already says the zero-argument tools take "No arguments". This change makes the advertised JSON schema enforce that existing contract; no prompt text or runtime configuration semantics changed. The RFC mention of `openai-http` is a rejected design option, not accepted configuration, so it remains historically accurate.

## Compatibility
Hard cut only. No aliases, facade APIs, protocol migrations, heuristic guards, or silent fallback are introduced.
