### PR TITLE
refactor: hard-cut approval rule ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1314,12 +1314,27 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_observability_redact"
 
-      # The Gate is the boundary every external effect crosses, and its audit
-      # log is the only durable record of what it let through. Seven suites
-      # cover it (approval queue, rules, rules types, resolved history, audit
-      # timeline, gate effect coverage, gate replay) and none was named here, so
-      # none ran. This wires the audit-vocabulary suite, which is the one that
-      # pins what a reader of ~/.masc/audit-approvals can actually tell apart.
+      # Queue persistence, exact-rule storage, and their wire codecs form one
+      # Gate contract. Run all three owner suites together so an interface move
+      # cannot compile while its persisted representation or dispatch behavior
+      # diverges.
+      - name: Run approval owner contract suites
+        id: approval_owner_contract_suites
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . \
+            @test/runtest-test_keeper_approval_queue \
+            @test/runtest-test_keeper_approval_queue_rules \
+            @test/runtest-test_keeper_approval_queue_rules_types"
+
+      # The audit vocabulary is the durable operator-facing account of Gate
+      # decisions and must remain executable independently of the queue store.
       - name: Run approval audit vocabulary suite
         id: approval_audit_vocabulary_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -18,6 +18,7 @@ import type {
   KeeperResolvedApprovalItem,
   KeeperResolvedApprovalPage,
   KeeperApprovalQueueState,
+  KeeperApprovalRulesState,
   KeeperAutoJudgeRearmExpectation,
   GateDecisionSource,
   GateJudgeLane,
@@ -77,66 +78,147 @@ function normalizeApprovalQueueState(raw: unknown): KeeperApprovalQueueState {
 
 function normalizeKeeperApprovalRule(raw: unknown): KeeperApprovalRule | null {
   if (!isRecord(raw)) return null
-  const id = asString(raw.id, '').trim()
-  const keeperName = asString(raw.keeper_name, '').trim()
-  const toolName = asString(raw.tool_name, '').trim()
-  if (!id || !keeperName || !toolName) return null
+  const keys = Object.keys(raw).sort()
+  const expectedKeys = [
+    'created_at',
+    'created_by',
+    'expires_at',
+    'id',
+    'keeper_name',
+    'request_fingerprint',
+    'source_approval_id',
+    'tool_name',
+  ]
+  if (keys.length !== expectedKeys.length || keys.some((key, index) => key !== expectedKeys[index])) {
+    return null
+  }
+  const id = typeof raw.id === 'string' ? raw.id.trim() : ''
+  const keeperName = typeof raw.keeper_name === 'string' ? raw.keeper_name.trim() : ''
+  const toolName = typeof raw.tool_name === 'string' ? raw.tool_name.trim() : ''
+  const requestFingerprint = typeof raw.request_fingerprint === 'string'
+    ? raw.request_fingerprint
+    : ''
+  const createdAt = typeof raw.created_at === 'number' ? raw.created_at : Number.NaN
+  const createdBy = typeof raw.created_by === 'string' && raw.created_by.trim() !== ''
+    ? raw.created_by
+    : undefined
+  const sourceApprovalId =
+    typeof raw.source_approval_id === 'string' && raw.source_approval_id.trim() !== ''
+      ? raw.source_approval_id
+      : undefined
+  const expiresAt = raw.expires_at === null
+    ? null
+    : typeof raw.expires_at === 'number' && Number.isFinite(raw.expires_at)
+      ? raw.expires_at
+      : undefined
+  if (
+    !id
+    || !keeperName
+    || !toolName
+    || !/^[a-f0-9]{64}$/.test(requestFingerprint)
+    || !Number.isFinite(createdAt)
+    || createdAt < 0
+    || createdBy === undefined
+    || sourceApprovalId === undefined
+    || expiresAt === undefined
+    || (expiresAt !== null && expiresAt <= createdAt)
+  ) return null
   return {
     id,
     keeper_name: keeperName,
     tool_name: toolName,
-    request_fingerprint: asNullableString(raw.request_fingerprint) ?? undefined,
-    created_at: asNullableIsoTimestamp(raw.created_at),
-    created_by: asNullableString(raw.created_by),
-    source_approval_id: asNullableString(raw.source_approval_id),
+    request_fingerprint: requestFingerprint,
+    created_at: createdAt,
+    created_by: createdBy,
+    source_approval_id: sourceApprovalId,
+    expires_at: expiresAt,
   }
+}
+
+function normalizeApprovalRulesState(raw: unknown): KeeperApprovalRulesState {
+  if (!isRecord(raw)) return gateSnapshotProtocolDrift('approval_rules_state is not an object')
+  if (raw.state === 'ready' && Object.keys(raw).length === 1) return { state: 'ready' }
+  if (
+    raw.state === 'unavailable'
+    && typeof raw.error === 'string'
+    && raw.error.trim() !== ''
+    && Object.keys(raw).length === 2
+  ) {
+    return { state: 'unavailable', error: raw.error }
+  }
+  return gateSnapshotProtocolDrift('approval_rules_state is not a current closed variant')
 }
 
 function normalizeGateModeValue(raw: unknown): GateMode | null {
   return raw === 'manual' || raw === 'auto_judge' || raw === 'always_allow' ? raw : null
 }
 
-function normalizeGateMode(raw: unknown): GateModeStatus | undefined {
-  if (!isRecord(raw)) return undefined
-  const mode = normalizeGateModeValue(raw.mode)
-  if (!mode) {
-    return {
-      mode: 'manual',
-      state: 'invalid',
-      read_error: `unsupported Gate mode: ${String(raw.mode)}`,
-    }
-  }
-  return {
-    mode,
-    configured: asBoolean(raw.configured) ?? undefined,
-    state: asNullableString(raw.state) ?? undefined,
-    read_error: asNullableString(raw.read_error) ?? undefined,
-  }
+function hasExactKeys(raw: Record<string, unknown>, expected: string[]): boolean {
+  const keys = Object.keys(raw).sort()
+  const sortedExpected = [...expected].sort()
+  return keys.length === sortedExpected.length
+    && keys.every((key, index) => key === sortedExpected[index])
 }
 
-/** Parse the closed `judge_lane` variant emitted by `dashboard_gate.ml`.
- *  Returns undefined for an absent field (older server) or a shape outside
- *  the contract — the header then simply omits the judge model. */
-function normalizeGateJudgeLane(raw: unknown): GateJudgeLane | undefined {
-  if (!isRecord(raw)) return undefined
+function normalizeGateMode(raw: unknown): GateModeStatus {
+  if (!isRecord(raw)) return gateSnapshotProtocolDrift('hitl.gate_mode is not an object')
+  const mode = normalizeGateModeValue(raw.mode)
+  if (!mode || typeof raw.configured !== 'boolean') {
+    return gateSnapshotProtocolDrift('hitl.gate_mode has an invalid mode or configured flag')
+  }
+  if (raw.state === 'ready' && hasExactKeys(raw, ['mode', 'configured', 'state'])) {
+    return { mode, configured: raw.configured, state: 'ready' }
+  }
+  if (
+    mode === 'auto_judge'
+    && raw.state === 'unavailable'
+    && typeof raw.read_error === 'string'
+    && raw.read_error.trim() !== ''
+    && hasExactKeys(raw, ['mode', 'configured', 'state', 'read_error'])
+  ) {
+    return { mode, configured: raw.configured, state: 'unavailable', read_error: raw.read_error }
+  }
+  if (
+    mode === 'manual'
+    && raw.configured === true
+    && raw.state === 'invalid'
+    && typeof raw.read_error === 'string'
+    && raw.read_error.trim() !== ''
+    && hasExactKeys(raw, ['mode', 'configured', 'state', 'read_error'])
+  ) {
+    return { mode, configured: true, state: 'invalid', read_error: raw.read_error }
+  }
+  return gateSnapshotProtocolDrift('hitl.gate_mode is not a current closed variant')
+}
+
+function normalizeGateJudgeLane(raw: unknown): GateJudgeLane {
+  if (!isRecord(raw)) return gateSnapshotProtocolDrift('hitl.judge_lane is not an object')
   const laneId = asString(raw.lane_id, '').trim()
-  if (!laneId) return undefined
-  if (raw.status === 'available' && Array.isArray(raw.slots)) {
+  if (!laneId) return gateSnapshotProtocolDrift('hitl.judge_lane.lane_id is invalid')
+  if (
+    raw.status === 'available'
+    && Array.isArray(raw.slots)
+    && hasExactKeys(raw, ['status', 'lane_id', 'slots'])
+  ) {
     const slots = raw.slots.filter(
       (slot): slot is string => typeof slot === 'string' && slot.trim() !== '',
     )
-    if (slots.length === 0 || slots.length !== raw.slots.length) return undefined
+    if (slots.length === 0 || slots.length !== raw.slots.length) {
+      return gateSnapshotProtocolDrift('hitl.judge_lane.slots is invalid')
+    }
     return { status: 'available', lane_id: laneId, slots }
   }
-  if (raw.status === 'unavailable') {
+  if (raw.status === 'unavailable' && hasExactKeys(raw, ['status', 'lane_id', 'reason'])) {
     const reason = asString(raw.reason, '').trim()
-    return reason ? { status: 'unavailable', lane_id: laneId, reason } : undefined
+    if (reason) return { status: 'unavailable', lane_id: laneId, reason }
   }
-  return undefined
+  return gateSnapshotProtocolDrift('hitl.judge_lane is not a current closed variant')
 }
 
-function normalizeHitlStatus(raw: unknown): DashboardGateResponse['hitl'] | undefined {
-  if (!isRecord(raw)) return undefined
+function normalizeHitlStatus(raw: unknown): DashboardGateResponse['hitl'] {
+  if (!isRecord(raw) || !hasExactKeys(raw, ['gate_mode', 'judge_lane'])) {
+    return gateSnapshotProtocolDrift('hitl is not the current exact object')
+  }
   return {
     gate_mode: normalizeGateMode(raw.gate_mode),
     judge_lane: normalizeGateJudgeLane(raw.judge_lane),
@@ -285,11 +367,17 @@ export function fetchDashboardGate(
           .filter((item): item is KeeperResolvedApprovalItem => item !== null)
       : []
     const recentResolvedPage = normalizeKeeperResolvedApprovalPage(raw.recent_resolved_page)
-    const approvalRules = Array.isArray(raw.approval_rules)
-      ? raw.approval_rules
-          .map(item => normalizeKeeperApprovalRule(item))
-          .filter((item): item is KeeperApprovalRule => item !== null)
-      : []
+    const approvalRulesState = normalizeApprovalRulesState(raw.approval_rules_state)
+    if (!Array.isArray(raw.approval_rules)) {
+      return gateSnapshotProtocolDrift('approval_rules must be an array')
+    }
+    const approvalRules = raw.approval_rules.map(item => normalizeKeeperApprovalRule(item))
+    if (approvalRules.some(rule => rule === null)) {
+      return gateSnapshotProtocolDrift('approval_rules contains an invalid rule')
+    }
+    if (approvalRulesState.state === 'unavailable' && approvalRules.length !== 0) {
+      return gateSnapshotProtocolDrift('unavailable approval_rules must be empty')
+    }
     return {
       generated_at: asNullableIsoTimestamp(raw.generated_at) ?? undefined,
       note: typeof raw.note === 'string' && raw.note.trim() !== '' ? raw.note.trim() : undefined,
@@ -298,25 +386,33 @@ export function fetchDashboardGate(
       approval_queue_violations: approvalQueueViolations,
       recent_resolved: recentResolved,
       recent_resolved_page: recentResolvedPage,
-      approval_rules: approvalRules,
+      approval_rules: approvalRules as KeeperApprovalRule[],
+      approval_rules_state: approvalRulesState,
       hitl: normalizeHitlStatus(raw.hitl),
     }
   })
 }
 
+export type GateApprovalResolution =
+  | { decision: 'approve'; rememberRule: boolean; ruleExpiresAt?: number }
+  | { decision: 'reject'; reason: string }
+
 export function resolveGateApproval(
   id: string,
-  decision: 'approve' | 'reject',
-  rememberRule?: boolean,
-  reason?: string,
-  ruleExpiresAt?: number,
-): Promise<{ ok: boolean; id: string; decision: 'approve' | 'reject'; rule_id?: string | null }> {
+  resolution: GateApprovalResolution,
+): Promise<{
+  ok: boolean
+  id: string
+  decision: 'approve' | 'reject'
+  rule_id: string | null
+  rule_error: string | null
+}> {
   return post('/api/v1/dashboard/gate/resolve', {
     id,
-    decision,
-    remember_rule: rememberRule,
-    reason,
-    rule_expires_at: ruleExpiresAt,
+    decision: resolution.decision,
+    remember_rule: resolution.decision === 'approve' ? resolution.rememberRule : false,
+    reason: resolution.decision === 'reject' ? resolution.reason : undefined,
+    rule_expires_at: resolution.decision === 'approve' ? resolution.ruleExpiresAt : undefined,
   })
 }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1626,12 +1626,20 @@ describe('fetchDashboardMemory', () => {
 })
 
 describe('fetchDashboardGate', () => {
+  const gateHitl = {
+    gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+    judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
+  } as const
+
   it('requests a forced Gate snapshot when asked', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         approval_queue: [],
         approval_queue_state: { state: 'ready' },
         recent_resolved: [],
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1669,6 +1677,9 @@ describe('fetchDashboardGate', () => {
             resolved_at: 1_782_522_183,
           },
         ],
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1707,13 +1718,18 @@ describe('fetchDashboardGate', () => {
         approval_queue: [],
         approval_queue_state: { state: 'ready' },
         recent_resolved: [],
+        approval_rules_state: { state: 'ready' },
         approval_rules: [{
           id: 'rule-1',
           keeper_name: 'keeper-a',
           tool_name: 'fs_write',
-          request_fingerprint: 'abcdef1234567890',
+          request_fingerprint: 'a'.repeat(64),
           created_at: 1_783_123_200,
+          created_by: 'operator',
+          source_approval_id: 'appr-1',
+          expires_at: null,
         }],
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1725,10 +1741,58 @@ describe('fetchDashboardGate', () => {
 
     expect(result.approval_rules).toEqual([
       expect.objectContaining({
-        request_fingerprint: 'abcdef1234567890',
-        created_at: '2026-07-04T00:00:00.000Z',
+        request_fingerprint: 'a'.repeat(64),
+        created_at: 1_783_123_200,
+        expires_at: null,
       }),
     ])
+  })
+
+  it('preserves approval rule-store unavailability', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        approval_queue: [],
+        approval_queue_state: { state: 'ready' },
+        recent_resolved: [],
+        approval_rules: [],
+        approval_rules_state: {
+          state: 'unavailable',
+          error: 'approval rules store unreadable',
+        },
+        hitl: gateHitl,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+
+    const result = await fetchDashboardGate()
+
+    expect(result.approval_rules_state).toEqual({
+      state: 'unavailable',
+      error: 'approval rules store unreadable',
+    })
+  })
+
+  it('rejects a malformed approval rule instead of dropping it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        approval_queue: [],
+        approval_queue_state: { state: 'ready' },
+        recent_resolved: [],
+        approval_rules_state: { state: 'ready' },
+        approval_rules: [{
+          id: 'rule-invalid',
+          keeper_name: 'keeper-a',
+          tool_name: 'fs_write',
+          request_fingerprint: 'not-a-sha256',
+          created_at: 1_783_123_200,
+          created_by: null,
+          source_approval_id: null,
+          expires_at: null,
+        }],
+        hitl: gateHitl,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+
+    await expect(fetchDashboardGate()).rejects.toThrow('approval_rules contains an invalid rule')
   })
 
   // The resolved history is capped by the server. Without the page bounds a
@@ -1742,6 +1806,9 @@ describe('fetchDashboardGate', () => {
         approval_queue_state: { state: 'ready' },
         recent_resolved: [],
         recent_resolved_page: page,
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1820,6 +1887,9 @@ describe('fetchDashboardGate', () => {
           icon: '!',
         },
         recent_resolved: [],
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1895,6 +1965,9 @@ describe('fetchDashboardGate', () => {
         ],
         approval_queue_state: { state: 'ready' },
         recent_resolved: [],
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1910,7 +1983,7 @@ describe('fetchDashboardGate', () => {
     ])
   })
 
-  it('carries judge evidence on resolved rows and null for pre-enrichment events', async () => {
+  it('carries judge evidence on resolved rows', async () => {
     const judgeSummary = {
       summary_version: 2,
       generated_at: 1_782_522_120,
@@ -1947,17 +2020,10 @@ describe('fetchDashboardGate', () => {
               quarantine_cause: null,
             },
           },
-          {
-            id: 'appr-legacy',
-            keeper_name: 'keeper-a',
-            tool_name: 'fs_write',
-            decision: 'approve',
-            decision_kind: 'approve',
-            resolved_at: 1_782_522_100,
-            summary_status: null,
-            exact_attempt: null,
-          },
         ],
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1976,16 +2042,15 @@ describe('fetchDashboardGate', () => {
     expect(
       judged?.exact_attempt?.state === 'bound' ? judged.exact_attempt.slot_id : null,
     ).toBe('glm-coding.glm-5-turbo')
-    const legacy = result.recent_resolved?.find(item => item.id === 'appr-legacy')
-    expect(legacy?.summary_status).toBeNull()
-    expect(legacy?.exact_attempt).toBeNull()
   })
 
-  it('parses the closed judge_lane variant and drops shapes outside it', async () => {
+  it('parses the closed judge_lane variant and rejects shapes outside it', async () => {
     const snapshot = (judgeLane: unknown) => new Response(JSON.stringify({
       approval_queue: [],
       approval_queue_state: { state: 'ready' },
       recent_resolved: [],
+      approval_rules: [],
+      approval_rules_state: { state: 'ready' },
       hitl: {
         gate_mode: { mode: 'auto_judge', configured: false, state: 'ready' },
         judge_lane: judgeLane,
@@ -2022,7 +2087,7 @@ describe('fetchDashboardGate', () => {
       lane_id: 'hitl_auto_judge',
       slots: [],
     })))
-    expect((await fetchDashboardGate()).hitl?.judge_lane).toBeUndefined()
+    await expect(fetchDashboardGate()).rejects.toThrow('hitl.judge_lane.slots is invalid')
   })
 })
 

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -30,6 +30,19 @@ function queueItem(overrides: Partial<KeeperApprovalQueueItem> & { id: string })
   }
 }
 
+function approvalRule(
+  overrides: Partial<KeeperApprovalRule> & Pick<KeeperApprovalRule, 'id' | 'keeper_name' | 'tool_name'>,
+): KeeperApprovalRule {
+  return {
+    request_fingerprint: 'a'.repeat(64),
+    created_at: 1_782_525_723,
+    created_by: 'operator',
+    source_approval_id: 'appr-source',
+    expires_at: null,
+    ...overrides,
+  }
+}
+
 function completedExactAttempt(id: string, callId: string) {
   return {
     state: 'bound' as const,
@@ -58,12 +71,14 @@ function responseWithQueue(
   approval_rules: KeeperApprovalRule[] = [],
   hitl: DashboardGateResponse['hitl'] = {
     gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+    judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
   },
   approval_queue_state: DashboardGateResponse['approval_queue_state'] = {
     state: 'ready',
   },
   recent_resolved_page: DashboardGateResponse['recent_resolved_page'] = null,
   approval_queue_violations: DashboardGateResponse['approval_queue_violations'] = [],
+  approval_rules_state: DashboardGateResponse['approval_rules_state'] = { state: 'ready' },
 ): DashboardGateResponse {
   return {
     generated_at: '2026-06-19T00:00:00Z',
@@ -73,6 +88,7 @@ function responseWithQueue(
     recent_resolved,
     recent_resolved_page,
     approval_rules,
+    approval_rules_state,
     hitl,
   } as DashboardGateResponse
 }
@@ -89,14 +105,22 @@ async function loadSurface(
   },
   recent_resolved_page: DashboardGateResponse['recent_resolved_page'] = null,
   approval_queue_violations: DashboardGateResponse['approval_queue_violations'] = [],
+  approval_rules_state: DashboardGateResponse['approval_rules_state'] = { state: 'ready' },
 ) {
   vi.resetModules()
   const resolveGateApproval = vi
     .fn()
-    .mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' })
+    .mockResolvedValue({
+      ok: true,
+      id: 'appr-1',
+      decision: 'approve',
+      rule_id: null,
+      rule_error: null,
+    })
   const retryGateAutoJudge = vi
     .fn()
     .mockResolvedValue({ ok: true, id: 'appr-1' })
+  const deleteGateApprovalRule = vi.fn().mockResolvedValue({ ok: true, id: 'rule-1' })
   const setGateMode = vi
     .fn()
     .mockResolvedValue({
@@ -121,6 +145,7 @@ async function loadSurface(
         approval_queue_state,
         recent_resolved_page,
         approval_queue_violations,
+        approval_rules_state,
       )
     : responseWithQueue(
         approval_queue,
@@ -130,12 +155,13 @@ async function loadSurface(
         approval_queue_state,
         recent_resolved_page,
         approval_queue_violations,
+        approval_rules_state,
       )
   const apiMock = () => ({
     fetchDashboardGate: vi.fn().mockResolvedValue(response),
     resolveGateApproval,
     retryGateAutoJudge,
-    deleteGateApprovalRule: vi.fn().mockResolvedValue({ ok: true }),
+    deleteGateApprovalRule,
     setGateMode,
   })
   vi.doMock('../../api', apiMock)
@@ -149,13 +175,25 @@ async function loadSurface(
     navigate,
   }))
   const mod = await import('./approvals-surface')
-  return { ApprovalsSurface: mod.ApprovalsSurface, resolveGateApproval, retryGateAutoJudge, setGateMode, navigate }
+  return {
+    ApprovalsSurface: mod.ApprovalsSurface,
+    resolveGateApproval,
+    retryGateAutoJudge,
+    deleteGateApprovalRule,
+    setGateMode,
+    navigate,
+  }
 }
 
 describe('ApprovalsSurface', () => {
   let container: HTMLDivElement
 
   beforeEach(() => {
+    Object.defineProperty(window, 'prompt', {
+      value: vi.fn().mockReturnValue('operator rejected'),
+      configurable: true,
+      writable: true,
+    })
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -697,7 +735,7 @@ describe('ApprovalsSurface', () => {
     expect(history?.querySelector('.ap-history-at')?.textContent).toContain('2026')
   }, 20000)
 
-  it('unfolds judge evidence and slot on resolved rows that carry it, none on legacy rows', async () => {
+  it('unfolds judge evidence and slot only on rows that carry judge evidence', async () => {
     const { ApprovalsSurface } = await loadSurface(
       [],
       [
@@ -734,7 +772,7 @@ describe('ApprovalsSurface', () => {
           },
         },
         {
-          id: 'appr-legacy',
+          id: 'appr-plain',
           keeper_name: 'keeper-a',
           tool_name: 'fs_write',
           decision: 'approve',
@@ -760,9 +798,9 @@ describe('ApprovalsSurface', () => {
     expect(fold?.textContent).toContain('Keeper requested a read-only listing.')
     expect(fold?.textContent).toContain('Is the path inside the sandbox?')
     expect(fold?.textContent).toContain('Read-only and scoped.')
-    const legacy = container.querySelector('[data-approval-id="appr-legacy"]')
-    expect(legacy?.querySelector('[data-testid="approval-history-slot"]')).toBeNull()
-    expect(legacy?.querySelector('[data-testid="approval-history-judge"]')).toBeNull()
+    const plain = container.querySelector('[data-approval-id="appr-plain"]')
+    expect(plain?.querySelector('[data-testid="approval-history-slot"]')).toBeNull()
+    expect(plain?.querySelector('[data-testid="approval-history-judge"]')).toBeNull()
   }, 20000)
 
   it('shows contract-violating queue rows as a visible banner instead of a clean empty queue', async () => {
@@ -843,12 +881,16 @@ describe('ApprovalsSurface', () => {
         },
       ],
       [
-        {
+        approvalRule({
           id: 'rule-1',
           keeper_name: 'keeper-a',
           tool_name: 'fs_write',
-          request_fingerprint: 'abcdef1234567890',
-        },
+          request_fingerprint: 'a'.repeat(64),
+          created_at: 1782525723,
+          created_by: 'operator',
+          source_approval_id: 'appr-approved',
+          expires_at: null,
+        }),
       ],
     )
 
@@ -859,8 +901,7 @@ describe('ApprovalsSurface', () => {
     expect(aside?.textContent).toContain('Always Rules')
     expect(aside?.textContent).toContain('keeper-a')
     expect(aside?.textContent).toContain('fs_write')
-    expect(aside?.textContent).toContain('abcdef123456')
-    expect(aside?.textContent).not.toContain('abcdef1234567890')
+    expect(aside?.textContent).toContain('aaaaaaaaaaaa')
 
     container.querySelector<HTMLButtonElement>('.ap-viewbtn:not(.on)')?.click()
     await flushUi()
@@ -879,12 +920,12 @@ describe('ApprovalsSurface', () => {
   }, 20000)
 
   it('makes hidden Always rules explicit when the aside list overflows its cap', async () => {
-    const rules = Array.from({ length: 8 }, (_, i) => ({
+    const rules = Array.from({ length: 8 }, (_, i) => approvalRule({
       id: `rule-${i}`,
       keeper_name: 'keeper-a',
       tool_name: 'fs_write',
-      request_fingerprint: `fp-${i}`,
-    })) as KeeperApprovalRule[]
+      request_fingerprint: i.toString(16).padStart(64, '0'),
+    }))
     const { ApprovalsSurface } = await loadSurface([], [], rules)
 
     render(html`<${ApprovalsSurface} />`, container)
@@ -898,18 +939,61 @@ describe('ApprovalsSurface', () => {
   }, 20000)
 
   it('omits the rules overflow note when the list fits the cap', async () => {
-    const rules = Array.from({ length: 6 }, (_, i) => ({
+    const rules = Array.from({ length: 6 }, (_, i) => approvalRule({
       id: `rule-${i}`,
       keeper_name: 'k',
       tool_name: 't',
-      request_fingerprint: `fp-${i}`,
-    })) as KeeperApprovalRule[]
+      request_fingerprint: i.toString(16).padStart(64, '0'),
+    }))
     const { ApprovalsSurface } = await loadSurface([], [], rules)
 
     render(html`<${ApprovalsSurface} />`, container)
     await flushUi()
 
     expect(container.querySelector('[data-testid="approvals-rules-overflow"]')).toBeNull()
+  }, 20000)
+
+  it('renders rule-store unavailability instead of an empty rule list', async () => {
+    const { ApprovalsSurface } = await loadSurface(
+      [],
+      [],
+      [],
+      undefined,
+      { state: 'ready' },
+      null,
+      [],
+      { state: 'unavailable', error: 'approval rules store unreadable' },
+    )
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="approval-rules-unavailable"]')?.textContent)
+      .toContain('approval rules store unreadable')
+    expect(container.textContent).not.toContain('저장된 Always 규칙 없음')
+  }, 20000)
+
+  it('shows expired rules and deletes the exact rule through the live action', async () => {
+    const expiredRule = approvalRule({
+      id: 'rule-expired',
+      keeper_name: 'keeper-expired',
+      tool_name: 'fs_write',
+      created_at: 1_700_000_000,
+      expires_at: 1_700_000_100,
+    })
+    const { ApprovalsSurface, deleteGateApprovalRule } = await loadSurface([], [], [expiredRule])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="approval-rule-expiry"]')?.textContent)
+      .toContain('만료됨')
+    const deleteButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.getAttribute('aria-label') === 'fs_write Always 규칙 삭제')
+    deleteButton?.click()
+    await flushUi()
+
+    expect(deleteGateApprovalRule).toHaveBeenCalledWith('rule-expired')
   }, 20000)
 
   it('shows the empty state when no approvals are pending', async () => {
@@ -1028,7 +1112,10 @@ describe('ApprovalsSurface', () => {
     approveBtn?.click()
     await flushUi()
 
-    expect(resolveGateApproval).toHaveBeenCalledWith('appr-9', 'approve', false)
+    expect(resolveGateApproval).toHaveBeenCalledWith(
+      'appr-9',
+      { decision: 'approve', rememberRule: false },
+    )
   })
 
   it('routes the 거부 action through resolveGateApproval with the reject decision', async () => {
@@ -1039,10 +1126,16 @@ describe('ApprovalsSurface', () => {
     render(html`<${ApprovalsSurface} />`, container)
     await flushUi()
 
+    const prompt = vi.spyOn(window, 'prompt').mockReturnValueOnce('작업 범위를 벗어남')
     container.querySelector<HTMLButtonElement>('.ap-card .ap-act.deny')?.click()
     await flushUi()
 
-    expect(resolveGateApproval).toHaveBeenCalledWith('appr-r', 'reject', false)
+    expect(prompt).toHaveBeenCalledWith('승인 요청을 거부하는 이유를 입력하세요.')
+    expect(resolveGateApproval).toHaveBeenCalledWith(
+      'appr-r',
+      { decision: 'reject', reason: '작업 범위를 벗어남' },
+    )
+    prompt.mockRestore()
   })
 
   it('routes the 항상 승인 action through resolveGateApproval with rememberRule=true', async () => {
@@ -1056,12 +1149,16 @@ describe('ApprovalsSurface', () => {
     container.querySelector<HTMLButtonElement>('.ap-card .ap-act.always')?.click()
     await flushUi()
 
-    expect(resolveGateApproval).toHaveBeenCalledWith('appr-a', 'approve', true)
+    expect(resolveGateApproval).toHaveBeenCalledWith(
+      'appr-a',
+      { decision: 'approve', rememberRule: true },
+    )
   })
 
   it('binds the three non-hierarchical choices to hitl.gate_mode', async () => {
     const { ApprovalsSurface } = await loadSurface([], [], [], {
       gate_mode: { mode: 'auto_judge', configured: true, state: 'ready' },
+      judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
     })
 
     render(html`<${ApprovalsSurface} />`, container)
@@ -1080,6 +1177,7 @@ describe('ApprovalsSurface', () => {
   it('shows Human as the selected Gate mode when configured', async () => {
     const { ApprovalsSurface } = await loadSurface([], [], [], {
       gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+      judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
     })
 
     render(html`<${ApprovalsSurface} />`, container)
@@ -1093,6 +1191,7 @@ describe('ApprovalsSurface', () => {
   it('routes a Gate mode choice through setGateMode', async () => {
     const { ApprovalsSurface, setGateMode } = await loadSurface([], [], [], {
       gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+      judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
     })
 
     render(html`<${ApprovalsSurface} />`, container)

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -15,6 +15,7 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 import type {
   KeeperApprovalQueueItem,
   KeeperApprovalRule,
+  KeeperApprovalRulesState,
   KeeperResolvedApprovalItem,
   KeeperResolvedApprovalPage,
   GateDecisionSource,
@@ -41,6 +42,7 @@ import {
   gateLoading,
   gateApprovalActing,
   refreshGate,
+  deleteKeeperApprovalRule,
   respondToKeeperApproval,
   retryKeeperAutoJudge,
   setKeeperGateMode,
@@ -589,12 +591,26 @@ function ApprovalDetailPanel({
 }
 
 function ApprovalRuleRow({ rule }: { rule: KeeperApprovalRule }) {
-  const fingerprintPreview = rule.request_fingerprint?.slice(0, 12)
+  const fingerprintPreview = rule.request_fingerprint.slice(0, 12)
+  const expired = rule.expires_at !== null && rule.expires_at <= Date.now() / 1000
+  const expiryLabel = rule.expires_at === null
+    ? '만료 없음'
+    : `${expired ? '만료됨' : '만료'} ${formatDateTimeKo(rule.expires_at * 1000)}`
+  const deleting = gateApprovalActing.value === `rule:${rule.id}`
   return html`
     <li class="ap-rule-row" data-testid="approval-rule-row">
       <span class="ap-rule-keeper mono">${rule.keeper_name}</span>
       <span class="ap-rule-tool mono">${rule.tool_name}</span>
-      ${fingerprintPreview ? html`<span class="ap-rule-fingerprint mono">${fingerprintPreview}</span>` : null}
+      <span class="ap-rule-fingerprint mono">${fingerprintPreview}</span>
+      <span class="ap-rule-provenance mono">${rule.created_by} · ${rule.source_approval_id}</span>
+      <span class=${`ap-rule-expiry ${expired ? 'sev-bad' : ''}`} data-testid="approval-rule-expiry">${expiryLabel}</span>
+      <button
+        type="button"
+        class="ap-rule-delete"
+        disabled=${deleting}
+        onClick=${() => void deleteKeeperApprovalRule(rule.id)}
+        aria-label=${rule.tool_name + ' Always 규칙 삭제'}
+      >${deleting ? '삭제 중' : '삭제'}</button>
     </li>
   `
 }
@@ -609,10 +625,12 @@ function ApAside({
   openCount,
   resolvedItems,
   rules,
+  rulesState,
 }: {
   openCount: number
   resolvedItems: KeeperResolvedApprovalItem[]
   rules: KeeperApprovalRule[]
+  rulesState: KeeperApprovalRulesState
 }) {
   const hitl = gateData.value?.hitl
   const recent = [...resolvedItems]
@@ -649,7 +667,7 @@ function ApAside({
               `)}
             </div>
           </div>
-          <div class="wka-auto-stat">${rules.length.toLocaleString()}개 Always 규칙 · 열린 승인 ${openCount.toLocaleString()}건</div>
+          <div class="wka-auto-stat">${rulesState.state === 'ready' ? `${rules.length.toLocaleString()}개 Always 규칙` : 'Always 규칙 확인 불가'} · 열린 승인 ${openCount.toLocaleString()}건</div>
           <div class="wka-auto-note">
             Human은 사람이 판단하고, Auto Judge는 LLM이 판단하며, Always Allow는 workspace의 명시적 선택입니다.
           </div>
@@ -668,8 +686,8 @@ function ApAside({
                   </div>
                 `
             : null}
-          ${gateMode?.state === 'invalid' || gateMode?.state === 'unavailable' || gateMode?.read_error
-            ? html`<div class="ap-env-warn mono">Gate mode ${gateMode.state ?? 'invalid'}: ${gateMode.read_error ?? '상태 확인 실패'}</div>`
+          ${gateMode && gateMode.state !== 'ready'
+            ? html`<div class="ap-env-warn mono">Gate mode ${gateMode.state}: ${gateMode.read_error}</div>`
             : null}
         </div>
       </section>
@@ -679,7 +697,9 @@ function ApAside({
           <h3>Always Rules</h3>
           <span class="mono">${rules.length}</span>
         </div>
-        ${rules.length > 0
+        ${rulesState.state === 'unavailable'
+          ? html`<div class="ap-env-warn" role="alert" data-testid="approval-rules-unavailable">${rulesState.error}</div>`
+          : rules.length > 0
           ? html`
               <ul class="ap-rule-list">${rules.slice(0, ASIDE_RULES_LIMIT).map(rule => html`<${ApprovalRuleRow} key=${rule.id} rule=${rule} />`)}</ul>
               ${hiddenRules > 0
@@ -737,6 +757,7 @@ export function ApprovalsSurface() {
   const resolvedItems = gateData.value?.recent_resolved ?? []
   const resolvedPage = gateData.value?.recent_resolved_page ?? null
   const rules = gateData.value?.approval_rules ?? []
+  const rulesState = gateData.value?.approval_rules_state ?? null
   const queueViolations = gateData.value?.approval_queue_violations ?? []
   const error = gateError.value
   // First load only: gateResource is stale-while-revalidate, so a refetch
@@ -844,7 +865,7 @@ export function ApprovalsSurface() {
           </div>
           <div class="ov-kpi">
             <div class="ov-kpi-k">Always 규칙</div>
-            <div class="ov-kpi-v">${rules.length}</div>
+            <div class="ov-kpi-v">${rulesState?.state === 'ready' ? rules.length : '—'}</div>
           </div>
           <div class="ov-kpi">
             <div class="ov-kpi-k">처리 완료</div>
@@ -884,11 +905,12 @@ export function ApprovalsSurface() {
           : null}
       `}
       </div>
-      ${!firstLoad && !queueUnavailable && items !== null ? html`
+      ${!firstLoad && !queueUnavailable && items !== null && rulesState !== null ? html`
         <${ApAside}
           openCount=${items.length}
           resolvedItems=${resolvedItems}
           rules=${rules}
+          rulesState=${rulesState}
         />
       ` : null}
     </main>

--- a/dashboard/src/components/gate-actions.test.ts
+++ b/dashboard/src/components/gate-actions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   refreshGate: vi.fn(),
+  resolveGateApproval: vi.fn(),
   setGateMode: vi.fn(),
   retryGateAutoJudge: vi.fn(),
   showToast: vi.fn(),
@@ -13,7 +14,7 @@ vi.mock('./common/toast', () => ({
 
 vi.mock('../api/dashboard-gate', () => ({
   deleteGateApprovalRule: vi.fn(),
-  resolveGateApproval: vi.fn(),
+  resolveGateApproval: mocks.resolveGateApproval,
   retryGateAutoJudge: mocks.retryGateAutoJudge,
   setGateMode: mocks.setGateMode,
 }))
@@ -22,7 +23,11 @@ vi.mock('./gate-refresh', () => ({
   refreshGate: mocks.refreshGate,
 }))
 
-import { retryKeeperAutoJudge, setKeeperGateMode } from './gate-actions'
+import {
+  respondToKeeperApproval,
+  retryKeeperAutoJudge,
+  setKeeperGateMode,
+} from './gate-actions'
 import { gateApprovalActing, gateError } from './gate-signals'
 
 const baseResponse = {
@@ -39,12 +44,67 @@ const baseResponse = {
 } as const
 
 beforeEach(() => {
+  Object.defineProperty(window, 'prompt', {
+    value: vi.fn().mockReturnValue('operator rejected'),
+    configurable: true,
+    writable: true,
+  })
   mocks.refreshGate.mockReset().mockResolvedValue(undefined)
+  mocks.resolveGateApproval.mockReset().mockResolvedValue({
+    ok: true,
+    id: 'appr-1',
+    decision: 'approve',
+    rule_id: null,
+    rule_error: null,
+  })
   mocks.setGateMode.mockReset()
   mocks.retryGateAutoJudge.mockReset().mockResolvedValue({ ok: true, id: 'appr-1' })
   mocks.showToast.mockReset()
   gateApprovalActing.value = null
   gateError.value = ''
+})
+
+describe('respondToKeeperApproval rejection reason', () => {
+  it('sends the operator-entered reason unchanged', async () => {
+    const prompt = vi.spyOn(window, 'prompt').mockReturnValueOnce('  범위 밖 작업  ')
+
+    await respondToKeeperApproval('appr-1', 'reject')
+
+    expect(mocks.resolveGateApproval).toHaveBeenCalledWith(
+      'appr-1',
+      { decision: 'reject', reason: '  범위 밖 작업  ' },
+    )
+    expect(mocks.refreshGate).toHaveBeenCalledWith({ force: true })
+    prompt.mockRestore()
+  })
+
+  it('does not resolve without an operator-entered reason', async () => {
+    const prompt = vi.spyOn(window, 'prompt').mockReturnValueOnce('   ')
+
+    await respondToKeeperApproval('appr-1', 'reject')
+
+    expect(mocks.resolveGateApproval).not.toHaveBeenCalled()
+    expect(mocks.showToast).toHaveBeenCalledWith('거부 이유를 입력해야 합니다', 'warning')
+    prompt.mockRestore()
+  })
+
+  it('shows committed approval and failed rule persistence separately', async () => {
+    mocks.resolveGateApproval.mockResolvedValueOnce({
+      ok: true,
+      id: 'appr-1',
+      decision: 'approve',
+      rule_id: null,
+      rule_error: 'approval-rules.json: exact rule has a different expiry',
+    })
+
+    await respondToKeeperApproval('appr-1', 'approve', true)
+
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'keeper 승인 요청은 승인했지만 Always 규칙을 저장하지 못했습니다: '
+      + 'approval-rules.json: exact rule has a different expiry',
+      'warning',
+    )
+  })
 })
 
 describe('retryKeeperAutoJudge exact observation', () => {

--- a/dashboard/src/components/gate-actions.ts
+++ b/dashboard/src/components/gate-actions.ts
@@ -20,14 +20,26 @@ export async function respondToKeeperApproval(
   rememberRule = false,
 ) {
   if (!id) return
+  const resolution = (() => {
+    if (decision === 'approve') return { decision, rememberRule } as const
+    const reason = window.prompt('승인 요청을 거부하는 이유를 입력하세요.')
+    if (reason === null || reason.trim() === '') return null
+    return { decision, reason } as const
+  })()
+  if (resolution === null) {
+    showToast('거부 이유를 입력해야 합니다', 'warning')
+    return
+  }
   gateApprovalActing.value = id
   try {
-    await resolveGateApproval(id, decision, rememberRule)
-    const message =
-      decision === 'approve'
+    const result = await resolveGateApproval(id, resolution)
+    const ruleFailed = decision === 'approve' && rememberRule && result.rule_error !== null
+    const message = ruleFailed
+      ? `keeper 승인 요청은 승인했지만 Always 규칙을 저장하지 못했습니다: ${result.rule_error}`
+      : decision === 'approve'
         ? (rememberRule ? 'keeper 승인 요청을 승인하고 Always 규칙을 저장했습니다' : 'keeper 승인 요청을 승인했습니다')
         : 'keeper 승인 요청을 거부했습니다'
-    showToast(message, 'success')
+    showToast(message, ruleFailed ? 'warning' : 'success')
     await refreshGate({ force: true })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'keeper 승인 요청을 처리하지 못했습니다'

--- a/dashboard/src/components/gate-resource-swr.test.ts
+++ b/dashboard/src/components/gate-resource-swr.test.ts
@@ -36,6 +36,11 @@ function response(queue: KeeperApprovalQueueItem[]): DashboardGateResponse {
     approval_queue_state: { state: 'ready' },
     recent_resolved: [],
     approval_rules: [],
+    approval_rules_state: { state: 'ready' },
+    hitl: {
+      gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+      judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
+    },
   } as DashboardGateResponse
 }
 
@@ -120,6 +125,11 @@ describe('Gate resource (stale-while-revalidate)', () => {
       // unknown, and a zeroed page would render as "nothing was decided".
       recent_resolved_page: null,
       approval_rules: [],
+      approval_rules_state: {
+        state: 'unavailable',
+        error: 'Gate 새로고침 실패',
+      },
+      hitl: null,
     })
     expect(signals.gateError.value).toContain('Gate 새로고침 실패')
     expect(signals.gateLoading.value).toBe(false)

--- a/dashboard/src/components/gate-signals.ts
+++ b/dashboard/src/components/gate-signals.ts
@@ -20,6 +20,8 @@ export function gateObservationErrorSnapshot(operatorDetail: string): DashboardG
     // are unknown, and a zeroed page would read as "nothing was decided".
     recent_resolved_page: null,
     approval_rules: [],
+    approval_rules_state: { state: 'unavailable', error: operatorDetail },
+    hitl: null,
   }
 }
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -36,6 +36,11 @@ function gateResponse(queue: KeeperApprovalQueueItem[]): DashboardGateResponse {
     approval_queue_state: { state: 'ready' },
     recent_resolved: [],
     approval_rules: [],
+    approval_rules_state: { state: 'ready' },
+    hitl: {
+      gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+      judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
+    },
   } as DashboardGateResponse
 }
 

--- a/dashboard/src/types/gate.ts
+++ b/dashboard/src/types/gate.ts
@@ -198,20 +198,23 @@ export interface KeeperApprovalRule {
   id: string
   keeper_name: string
   tool_name: string
-  request_fingerprint?: string
-  created_at?: string | null
-  created_by?: string | null
-  source_approval_id?: string | null
+  request_fingerprint: string
+  created_at: number
+  created_by: string
+  source_approval_id: string
+  expires_at: number | null
 }
+
+export type KeeperApprovalRulesState =
+  | { state: 'ready' }
+  | { state: 'unavailable'; error: string }
 
 export type GateMode = 'manual' | 'auto_judge' | 'always_allow'
 
-export interface GateModeStatus {
-  mode: GateMode
-  configured?: boolean
-  state?: 'ready' | 'invalid' | string
-  read_error?: string
-}
+export type GateModeStatus =
+  | { mode: GateMode; configured: boolean; state: 'ready' }
+  | { mode: 'auto_judge'; configured: boolean; state: 'unavailable'; read_error: string }
+  | { mode: 'manual'; configured: true; state: 'invalid'; read_error: string }
 
 /**
  * Bounds that produced `recent_resolved`. Read them with the rows: `returned`
@@ -237,11 +240,12 @@ export interface DashboardGateResponse {
   approval_queue_violations?: KeeperApprovalQueueRowViolation[]
   recent_resolved?: KeeperResolvedApprovalItem[]
   recent_resolved_page?: KeeperResolvedApprovalPage | null
-  approval_rules?: KeeperApprovalRule[]
-  hitl?: {
-    gate_mode?: GateModeStatus
-    judge_lane?: GateJudgeLane
-  }
+  approval_rules: KeeperApprovalRule[]
+  approval_rules_state: KeeperApprovalRulesState
+  hitl: {
+    gate_mode: GateModeStatus
+    judge_lane: GateJudgeLane
+  } | null
 }
 
 export interface OperatorActionDescriptor {

--- a/docs/EXECUTE-RUNBOOK.md
+++ b/docs/EXECUTE-RUNBOOK.md
@@ -1,6 +1,6 @@
 ---
 status: runbook
-last_verified: 2026-06-11
+last_verified: 2026-08-09
 code_refs:
   - lib/core/exec_buffer.ml
   - lib/exec_core.ml
@@ -9,19 +9,18 @@ code_refs:
   - lib/exec/command_gate/shell_command_gate.ml
   - lib/exec_policy/exec_policy.ml
   - lib/keeper/keeper_tool_execute_runtime.ml
+  - lib/keeper/keeper_workspace_ops.ml
 ---
 
 # Execute Runbook
 
 This runbook documents the current operator surface for `Execute` and
 adjacent structured process routing. Execute is typed-only: callers provide
-one non-empty `argv` process vector or `pipeline`. Raw command strings and the old
-background task lifecycle are not part of the callable surface.
+one non-empty `argv` process vector or `pipeline`.
 
 ## Related Documents
 
 - [`ENV-CONTRACT.md`](./ENV-CONTRACT.md) §4 — authoritative flag matrix
-- `planning/graceful-panda/Legendary-Execute-plan.md` — historical source plan
 
 ## Scope
 
@@ -32,15 +31,6 @@ background task lifecycle are not part of the callable surface.
   tools.
 - Async boundary: the typed `Execute` callable surface is synchronous. There is
   no background shell lifecycle surface anywhere below it.
-
-## Current Rollout State
-
-| Phase | Feature | Default | Status |
-| --- | --- | --- | --- |
-| P1 | `semantic_exit` typed return code | **on** | flipped |
-| P3 | head+tail truncation | on | delivered |
-| P5 | Shell IR command gate | on | authoritative |
-| P6 | `verifiable_markers` emission | **on** | flipped |
 
 ## Flag Matrix
 
@@ -113,7 +103,7 @@ scripts/dune-local.sh build lib/exec/test/test_exec_dispatch_docker_streaming.ex
 ## Async Boundary Proof
 
 `Execute` remains synchronous at the callable-surface level. The public schema
-rejects legacy background flags and accepts only typed command fields:
+accepts only typed command fields:
 `executable`, `argv`, `pipeline`, `env`, `cwd`, `timeout_sec`, `stdin`,
 `stdout`, and `stderr`. It does not expose `job_id`, `request_id`, `poll`, or
 `cancel` fields.

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -1,7 +1,7 @@
 # Keeper Tool Boundary Matrix
 
 Status: P0 ratchet source for keeper agent tool boundaries.
-Last updated: 2026-07-12.
+Last updated: 2026-08-09.
 
 This matrix freezes the owner map for keeper modules that participate in the
 agent tool path. A new file in scope must be added here with exactly one owner

--- a/docs/security/approval-rules.md
+++ b/docs/security/approval-rules.md
@@ -1,59 +1,37 @@
 # Approval Rules
 
-Keeper approval rules are persisted allow rules. The authoritative path is
-`Keeper_approval_queue_rules.rules_path`, which resolves beneath
-`Workspace_utils.masc_dir_from_base_path`. They are only loaded when every rule
-entry parses as a complete rule. A malformed entry fails the whole load, is
-reported as a persistence read drop, and cannot match a future request or
-auto-approve a tool call.
+Keeper approval rules are persisted allow rules owned by
+`Keeper_approval_queue_rules`. The canonical data contract is
+`Keeper_approval_queue_rules_types`. Loading fails unless every entry satisfies
+that contract, so malformed state cannot match a request or authorize a tool
+call.
 
-## Fail-Closed Parse Policy
+## Persisted Contract
 
-The persisted file must be a JSON list. Each entry must be an object with these
-required fields:
+The persisted file is a JSON list. Every entry is an exact object containing:
 
 - `id`: non-blank string
 - `keeper_name`: non-blank string
 - `tool_name`: non-blank string
-- `request_fingerprint`: non-blank string
-- `created_at`: number
+- `request_fingerprint`: lowercase SHA-256 string
+- `created_at`: finite, non-negative number
+- `created_by`: non-blank authenticated actor string
+- `source_approval_id`: non-blank originating approval id
+- `expires_at`: null or finite Unix timestamp
 
-`created_by`, `source_approval_id`, and `expires_at` are optional and may be
-absent or null. `expires_at` is an absolute Unix timestamp: at and after that
-time the rule no longer authorizes. A malformed non-null `expires_at` fails
-the entry rather than silently becoming a permanent rule.
-
-No malformed required field receives a permissive default, and any unsupported
-or duplicate field rejects the whole file with `explicit re-approval is
-required`.
+Missing, duplicate, unknown, or invalid fields reject the whole file. No field
+receives a permissive default.
 
 ## Rule Expiry
 
-An exact Always Allowed rule with `expires_at` set stops matching at that
-timestamp. `find_matching_rule` then reports `Rule_match_expired` instead of
-applying the rule; the Gate logs the exclusion and appends a
-`gate_exact_rule_expired` audit event carrying the rule id, then falls back to
-the configured Gate mode. Expiry never deletes the rule: it stays in the store
-and dashboard listing until an operator removes it through the existing delete
-path. Rules without `expires_at` never expire, so pre-expiry persisted files
-keep their previous behavior.
+An exact rule with an `expires_at` timestamp stops matching at that timestamp.
+`find_matching_rule` returns `Rule_match_expired`, the Gate records the expired
+rule id, and the request continues through the configured Gate decision path.
+The expired rule remains visible until an operator deletes it. A null
+`expires_at` means that the rule does not expire.
 
-## Rejection Proof
+## Failure Visibility
 
-`test/test_keeper_approval_queue_rules.ml` writes a persisted rule entry with
-an unsupported field. The test verifies that:
-
-- `list_rules` rejects the whole rules file
-- the rejected entry increments the `keeper_approval_rules`
-  `invalid_payload` persistence-read-drop counter
-
-This pins the operational behavior: malformed persisted approval rules are not
-silently allowed or silently erased.
-
-## Error Variant Boundary
-
-The `InvalidRequest { message; _ }` patterns in keeper runtime/provider error
-handling preserve compatibility with the SDK error record shape. They do not
-load, parse, match, or serialize approval rules. Approval-rule fail-closed
-behavior is owned by `approval_rule_of_yojson`, `list_rules`, and
-`find_matching_rule`.
+Malformed persisted state increments the `keeper_approval_rules`
+`invalid_payload` persistence-read-drop metric and makes the rule store
+unavailable.

--- a/lib/dashboard/dashboard_gate.ml
+++ b/lib/dashboard/dashboard_gate.ml
@@ -81,13 +81,13 @@ let dashboard_json ~base_path ~limit ~window_minutes =
       ()
   in
   let approval_rules, approval_rules_state =
-    match Keeper_approval_queue.list_rules_dashboard_json ~base_path () with
+    match Keeper_approval_queue_rules.list_rules_dashboard_json ~base_path () with
     | Ok json -> json, `Assoc [ "state", `String "ready" ]
     | Error error ->
       ( `List []
       , `Assoc
           [ "state", `String "unavailable"
-          ; "error", `String (Keeper_approval_queue.rule_store_error_to_string error)
+          ; "error", `String (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
           ] )
   in
   `Assoc

--- a/lib/dashboard/dashboard_gate_metrics.ml
+++ b/lib/dashboard/dashboard_gate_metrics.ml
@@ -176,7 +176,7 @@ type approval_summary = {
 let approval_queue_summary_of_entries ~now_ts entries : approval_summary =
   let waits =
     List.map
-      (fun (entry : Keeper_approval_queue.pending_approval) ->
+      (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
         Float.max 0.0 (now_ts -. entry.requested_at))
       entries
   in

--- a/lib/dashboard/dashboard_gate_metrics.mli
+++ b/lib/dashboard/dashboard_gate_metrics.mli
@@ -82,7 +82,7 @@ val record_tool_skipped_with_append_for_testing :
 val gate_tool_events_json_with_pending_result_for_testing :
   now_ts:float ->
   window_minutes:int ->
-  ( Keeper_approval_queue.pending_approval list
+  ( Keeper_approval_queue_rules_types.pending_approval list
   , Keeper_approval_queue.storage_error )
   result ->
   Yojson.Safe.t

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -1,4 +1,5 @@
 open Keeper_approval_queue
+open Keeper_approval_queue_rules_types
 
 module Exact_output = Agent_sdk.Exact_output
 module Registry = Runtime_exact_output_registry

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -32,8 +32,8 @@ type spawn_outcome =
 
 val spawn
   :  sw:Eio.Switch.t
-  -> entry:Keeper_approval_queue.pending_approval
-  -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+  -> entry:Keeper_approval_queue_rules_types.pending_approval
+  -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
   -> on_finish:(finish_outcome -> unit)
   -> unit
   -> (spawn_outcome, string) result
@@ -46,31 +46,31 @@ val spawn
 
 module For_testing : sig
   val run_outcome_of_observed_summary
-    :  Keeper_approval_queue.hitl_context_summary option
+    :  Keeper_approval_queue_rules_types.hitl_context_summary option
     -> Exact_lane_run_registry.outcome * Yojson.Safe.t
 
   val system_prompt : unit -> (string, string) result
 
   val build_context_bundle
-    :  entry:Keeper_approval_queue.pending_approval
+    :  entry:Keeper_approval_queue_rules_types.pending_approval
     -> Yojson.Safe.t
 
   val parse_summary
     :  generated_at:float
     -> model_run_id:string
     -> Yojson.Safe.t
-    -> (Keeper_approval_queue.hitl_context_summary, string) result
+    -> (Keeper_approval_queue_rules_types.hitl_context_summary, string) result
 
   type prepared_flow
 
   val prepare_flow
-    :  entry:Keeper_approval_queue.pending_approval
+    :  entry:Keeper_approval_queue_rules_types.pending_approval
     -> (prepared_flow, string) result
 
   val execute_prepared_flow
     :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
     -> ?clock:_ Eio.Time.clock
-    -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+    -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
     -> prepared_flow
     -> execution_boundary
 
@@ -94,7 +94,7 @@ module For_testing : sig
     -> call_id:string
     -> plan_fingerprint:string
     -> request_body_sha256:string
-    -> summary:Keeper_approval_queue.hitl_context_summary
+    -> summary:Keeper_approval_queue_rules_types.hitl_context_summary
     -> ( Keeper_approval_queue.exact_attempt_transition
        , Keeper_approval_queue.exact_attempt_error )
        result
@@ -107,7 +107,7 @@ module For_testing : sig
     -> call_id:string
     -> plan_fingerprint:string
     -> request_body_sha256:string
-    -> cause:Keeper_approval_queue.exact_attempt_quarantine_cause
+    -> cause:Keeper_approval_queue_rules_types.exact_attempt_quarantine_cause
     -> ( Keeper_approval_queue.exact_attempt_transition
        , Keeper_approval_queue.exact_attempt_error )
        result
@@ -127,7 +127,7 @@ module For_testing : sig
     :  queue_ops:exact_queue_ops
     -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
     -> ?clock:_ Eio.Time.clock
-    -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+    -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
     -> prepared_flow
     -> execution_boundary
   (** The production flow with explicit durable queue transition authority.
@@ -137,8 +137,8 @@ module For_testing : sig
   val spawn_with_queue_ops
     :  queue_ops:exact_queue_ops
     -> sw:Eio.Switch.t
-    -> entry:Keeper_approval_queue.pending_approval
-    -> on_summary:(Keeper_approval_queue.hitl_context_summary -> unit)
+    -> entry:Keeper_approval_queue_rules_types.pending_approval
+    -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
     -> on_finish:(finish_outcome -> unit)
     -> unit
     -> (spawn_outcome, string) result

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1,6 +1,41 @@
 (** Durable, nonblocking HITL requests for Keeper external effects. *)
 
-include Keeper_approval_queue_rules
+open Keeper_approval_queue_rules_types
+
+module SMap = Set_util.StringMap
+
+let rec atomic_update atomic f =
+  let old_val = Atomic.get atomic in
+  let new_val = f old_val in
+  if Atomic.compare_and_set atomic old_val new_val then () else atomic_update atomic f
+;;
+
+let pending : pending_approval SMap.t Atomic.t = Atomic.make SMap.empty
+
+let record_queue_failure ~keeper_name ~site ?(id = "-") ?(event_type = "-") exn =
+  Otel_metric_store_core.inc_counter
+    Keeper_metrics.(to_string ApprovalQueueFailures)
+    ~labels:[ "keeper", keeper_name; "site", site ]
+    ();
+  Log.Keeper.warn
+    "approval_queue: %s failed keeper=%s id=%s event=%s err=%s"
+    site
+    keeper_name
+    id
+    event_type
+    (Printexc.to_string exn)
+;;
+
+let approval_id_rng = Random.State.make_self_init ()
+let approval_id_rng_mu = Stdlib.Mutex.create ()
+
+let make_approval_id () =
+  let uuid =
+    Stdlib.Mutex.protect approval_id_rng_mu (fun () ->
+      Uuidm.v4_gen approval_id_rng ())
+  in
+  "appr_" ^ Uuidm.to_string uuid
+;;
 
 type storage_error =
   { path : string
@@ -120,7 +155,7 @@ type persisted_delivery =
   ; source : decision_source
   ; remember_rule : bool
   ; rule_expires_at : float option
-  ; created_by : string option
+  ; created_by : string
   ; grant_consumed : bool
   ; replay_outcome : resolution_replay_outcome option
   }
@@ -285,7 +320,7 @@ let install_error_to_string = function
   | Install_storage_failed error -> storage_error_to_string error
 ;;
 
-let pending_store_version = 8
+let pending_store_version = 9
 let pending_store_surface = "keeper_gate_pending"
 let replay_results_store_version = 1
 let replay_results_store_surface = "keeper_gate_replay_results"
@@ -383,15 +418,12 @@ let report_replay_results_read_drop ~reason ~path ~detail =
 
 let exact_request_context_version = 1
 
-let pending_entry_to_yojson
-      ?(include_request_context = true)
-      (entry : pending_approval)
-  =
-  let request_context =
-    if include_request_context then entry.request_context else None
-  in
-  `Assoc
-    [ "id", `String entry.id
+type request_context_wire =
+  | Pending_request_context
+  | Delivery_without_request_context
+
+let pending_entry_fields_prefix (entry : pending_approval) =
+  [ "id", `String entry.id
     ; "keeper_name", `String entry.keeper_name
     ; "tool_name", `String entry.tool_name
     ; "input_hash", `String entry.input_hash
@@ -399,32 +431,47 @@ let pending_entry_to_yojson
     ; "sequence", `Int entry.sequence
     ; "requested_at", `Float entry.requested_at
     ; "turn_id", Json_util.int_opt_to_json entry.turn_id
-    ; ( "request_context"
-      , match request_context with
+  ]
+;;
+
+let pending_entry_fields_suffix (entry : pending_approval) =
+  [ "task_id", Json_util.string_opt_to_json entry.task_id
+    ; "goal_id", Json_util.string_opt_to_json entry.goal_id
+    ; "goal_ids", Json_util.json_string_list entry.goal_ids
+  ; "continuation_channel", Keeper_continuation_channel.to_yojson entry.continuation_channel
+  ; "summary_status", summary_status_to_yojson entry.summary_status
+  ; "exact_attempt", exact_attempt_state_to_yojson entry.exact_attempt
+  ; ( "summary_attempt_disposition"
+    , summary_attempt_disposition_to_yojson entry.summary_attempt_disposition )
+  ]
+;;
+
+let pending_entry_to_yojson (entry : pending_approval) =
+  let request_context_fields =
+    [ ( "request_context"
+      , match entry.request_context with
         | Some context -> context
         | None -> `Null )
     ; ( "request_context_version"
-      , match request_context with
+      , match entry.request_context with
         | Some _ -> `Int exact_request_context_version
         | None -> `Null )
-    ; "task_id", Json_util.string_opt_to_json entry.task_id
-    ; "goal_id", Json_util.string_opt_to_json entry.goal_id
-    ; "goal_ids", Json_util.json_string_list entry.goal_ids
-      ; "continuation_channel", Keeper_continuation_channel.to_yojson entry.continuation_channel
-      ; "summary_status", summary_status_to_yojson entry.summary_status
-      ; "exact_attempt", exact_attempt_state_to_yojson entry.exact_attempt
-      ; ( "summary_attempt_disposition"
-        , summary_attempt_disposition_to_yojson
-            entry.summary_attempt_disposition )
-      ]
+    ]
+  in
+  `Assoc
+    (pending_entry_fields_prefix entry
+     @ request_context_fields
+     @ pending_entry_fields_suffix entry)
+;;
+
+let persisted_delivery_entry_to_yojson (entry : pending_approval) =
+  `Assoc (pending_entry_fields_prefix entry @ pending_entry_fields_suffix entry)
 ;;
 
 let approval_decision_to_yojson = function
   | Decision.Approve -> `Assoc [ "kind", `String "approve" ]
   | Decision.Reject reason ->
     `Assoc [ "kind", `String "reject"; "reason", `String reason ]
-  | Decision.Edit input ->
-    `Assoc [ "kind", `String "edit"; "input", input ]
 ;;
 
 let resolution_replay_outcome_to_yojson = function
@@ -454,22 +501,16 @@ let resolution_replay_outcome_to_yojson = function
    causal evidence (bounded history lead-up, the triggering user message,
    current dynamic context, and completed tool calls) captured at request time.
    It is not the whole Keeper turn or its system prompts. Its only reader is
-   Hitl_summary_worker, which runs while the entry is still pending. A delivery
-   is already resolved, so the context is dead weight there — and it dominated
-   the store: 71 deliveries held ~30MB of duplicated context against 19 bytes
-   of decision each.
-
-   Dropping it on the delivery wire shape stays decode-compatible: the reader
-   treats [request_context] as optional and keys the version field off its
-   presence, so existing snapshots still load and re-save smaller. *)
+   Hitl_summary_worker, which runs while the entry is still pending. A resolved
+   delivery therefore has no request-context fields. *)
 let persisted_delivery_to_yojson delivery =
   `Assoc
-    [ "entry", pending_entry_to_yojson ~include_request_context:false delivery.entry
+    [ "entry", persisted_delivery_entry_to_yojson delivery.entry
     ; "decision", approval_decision_to_yojson delivery.decision
     ; "source", `String (decision_source_to_string delivery.source)
     ; "remember_rule", `Bool delivery.remember_rule
     ; "rule_expires_at", Json_util.float_opt_to_json delivery.rule_expires_at
-    ; "created_by", Json_util.string_opt_to_json delivery.created_by
+    ; "created_by", `String delivery.created_by
     ; "grant_consumed", `Bool delivery.grant_consumed
     ]
 ;;
@@ -483,9 +524,7 @@ let map_values_for_base ~base_path map project =
 let snapshot_to_yojson ~base_path ~next_sequence ~pending_map ~delivery_map =
   let pending_entries =
     map_values_for_base ~base_path pending_map Fun.id
-    (* Wrapped rather than passed bare: [pending_entry_to_yojson] now leads with
-       an optional argument, which OCaml only erases at application. *)
-    |> List.map (fun entry -> pending_entry_to_yojson entry)
+    |> List.map pending_entry_to_yojson
   in
   let delivery_entries =
     map_values_for_base ~base_path delivery_map (fun delivery -> delivery.entry)
@@ -687,7 +726,6 @@ let persist_snapshot_exact_unlocked
    sites in this module short. *)
 let reject_unknown_fields = Json_util.reject_unknown_fields
 let required_string = Json_util.require_field_string
-let required_float = Json_util.require_field_float
 let required_positive_int = Json_util.require_field_positive_int
 let required_string_list = Json_util.require_field_string_list
 
@@ -697,28 +735,32 @@ let required_member ~surface field fields =
   | None -> Error (Printf.sprintf "%s.%s is required" surface field)
 ;;
 
-let optional_string ~surface field fields =
+let required_nullable_string ~surface field fields =
   match List.assoc_opt field fields with
-  | None | Some `Null -> Ok None
+  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+  | Some `Null -> Ok None
   | Some (`String value) when String.trim value <> "" -> Ok (Some value)
   | Some (`String _) -> Error (Printf.sprintf "%s.%s must be non-blank" surface field)
   | Some _ -> Error (Printf.sprintf "%s.%s must be a string or null" surface field)
 ;;
 
-let optional_nonnegative_int ~surface field fields =
+let required_nullable_nonnegative_int ~surface field fields =
   match List.assoc_opt field fields with
-  | None | Some `Null -> Ok None
+  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+  | Some `Null -> Ok None
   | Some (`Int value) when value >= 0 -> Ok (Some value)
   | Some _ ->
     Error (Printf.sprintf "%s.%s must be a non-negative integer or null" surface field)
 ;;
 
-let optional_float ~surface field fields =
+let required_nullable_finite_float ~surface field fields =
   match List.assoc_opt field fields with
-  | None | Some `Null -> Ok None
-  | Some (`Float value) -> Ok (Some value)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+  | Some `Null -> Ok None
+  | Some (`Float value) when Float.is_finite value -> Ok (Some value)
   | Some (`Int value) -> Ok (Some (Float.of_int value))
-  | Some _ -> Error (Printf.sprintf "%s.%s must be a number or null" surface field)
+  | Some _ ->
+    Error (Printf.sprintf "%s.%s must be a finite number or null" surface field)
 ;;
 
 let exact_attempt_identity_matches
@@ -818,16 +860,21 @@ let summary_attempt_allows_exact_bind = function
     false
 ;;
 
-let pending_entry_of_yojson ~base_path json =
+let pending_entry_of_yojson ~base_path ~request_context_wire json =
   match json with
   | `Assoc fields ->
     let ( let* ) = Result.bind in
     let surface = "gate_pending.entry" in
+    let request_context_fields =
+      match request_context_wire with
+      | Pending_request_context -> [ "request_context"; "request_context_version" ]
+      | Delivery_without_request_context -> []
+    in
     let* () =
       reject_unknown_fields
         ~surface
         ~allowed:
-          [ "id"
+          ([ "id"
           ; "keeper_name"
           ; "tool_name"
           ; "input_hash"
@@ -835,16 +882,15 @@ let pending_entry_of_yojson ~base_path json =
           ; "sequence"
           ; "requested_at"
           ; "turn_id"
-          ; "request_context"
-          ; "request_context_version"
           ; "task_id"
           ; "goal_id"
           ; "goal_ids"
           ; "continuation_channel"
           ; "summary_status"
           ; "exact_attempt"
-          ; "summary_attempt_disposition"
-          ]
+           ; "summary_attempt_disposition"
+           ]
+           @ request_context_fields)
         fields
     in
     let* id = required_string ~surface "id" fields in
@@ -852,46 +898,57 @@ let pending_entry_of_yojson ~base_path json =
     let* tool_name = required_string ~surface "tool_name" fields in
     let* input_hash = required_string ~surface "input_hash" fields in
     let* input = required_member ~surface "input" fields in
-    let expected_hash = request_fingerprint input in
+    let expected_hash = Keeper_approval_queue_rules_types.request_fingerprint input in
     let* () =
       if String.equal input_hash expected_hash
       then Ok ()
       else Error (Printf.sprintf "%s.input_hash does not match input" surface)
     in
     let* sequence = required_positive_int ~surface "sequence" fields in
-    let* requested_at = required_float ~surface "requested_at" fields in
-    let* turn_id = optional_nonnegative_int ~surface "turn_id" fields in
-    let* request_context =
-      match
-        List.assoc_opt "request_context" fields,
-        List.assoc_opt "request_context_version" fields
-      with
-      | (None | Some `Null), (None | Some `Null) -> Ok None
-      | Some context, Some (`Int version)
-        when Int.equal version exact_request_context_version ->
-        Ok (Some context)
-      | Some _, (None | Some `Null) ->
-        Error (surface ^ ".request_context requires request_context_version")
-      | (None | Some `Null), Some (`Int version) ->
-        Error
-          (Printf.sprintf
-             "%s.request_context_version=%d requires request_context"
-             surface
-             version)
-      | Some _, Some (`Int version) ->
-        Error
-          (Printf.sprintf
-             "%s.request_context_version=%d is unsupported"
-             surface
-             version)
-      | _, Some _ ->
-        Error
-          (Printf.sprintf
-             "%s.request_context_version must be an integer or null"
-             surface)
+    let* requested_at =
+      match List.assoc_opt "requested_at" fields with
+      | Some (`Float value) when Float.is_finite value && value >= 0.0 -> Ok value
+      | Some (`Int value) when value >= 0 -> Ok (Float.of_int value)
+      | None | Some _ ->
+        Error (surface ^ ".requested_at must be a finite non-negative number")
     in
-    let* task_id = optional_string ~surface "task_id" fields in
-    let* goal_id = optional_string ~surface "goal_id" fields in
+    let* turn_id = required_nullable_nonnegative_int ~surface "turn_id" fields in
+    let* request_context =
+      match request_context_wire with
+      | Delivery_without_request_context -> Ok None
+      | Pending_request_context ->
+        (match
+           List.assoc_opt "request_context" fields,
+           List.assoc_opt "request_context_version" fields
+         with
+         | None, _ -> Error (surface ^ ".request_context is required")
+         | _, None -> Error (surface ^ ".request_context_version is required")
+         | Some `Null, Some `Null -> Ok None
+         | Some context, Some (`Int version)
+           when Int.equal version exact_request_context_version ->
+           Ok (Some context)
+         | Some _, Some `Null ->
+           Error (surface ^ ".request_context requires request_context_version")
+         | Some `Null, Some (`Int version) ->
+           Error
+             (Printf.sprintf
+                "%s.request_context_version=%d requires request_context"
+                surface
+                version)
+         | Some _, Some (`Int version) ->
+           Error
+             (Printf.sprintf
+                "%s.request_context_version=%d is unsupported"
+                surface
+                version)
+         | _, Some _ ->
+           Error
+             (Printf.sprintf
+                "%s.request_context_version must be an integer or null"
+                surface))
+    in
+    let* task_id = required_nullable_string ~surface "task_id" fields in
+    let* goal_id = required_nullable_string ~surface "goal_id" fields in
     let* goal_ids = required_string_list ~surface "goal_ids" fields in
     let* continuation_json = required_member ~surface "continuation_channel" fields in
     let* continuation_channel = Keeper_continuation_channel.of_yojson continuation_json in
@@ -960,15 +1017,6 @@ let approval_decision_of_yojson json =
        in
        let* reason = required_string ~surface:"gate_pending.decision" "reason" fields in
        Ok (Decision.Reject reason)
-     | "edit" ->
-       let* () =
-         reject_unknown_fields
-           ~surface:"gate_pending.decision"
-           ~allowed:[ "kind"; "input" ]
-           fields
-       in
-       let* input = required_member ~surface:"gate_pending.decision" "input" fields in
-       Ok (Decision.Edit input)
      | other -> Error (Printf.sprintf "gate_pending.decision kind %S is unknown" other))
   | _ -> Error "gate_pending.decision must be a JSON object"
 ;;
@@ -1068,7 +1116,12 @@ let persisted_delivery_of_yojson ~base_path json =
         fields
     in
     let* entry_json = required_member ~surface "entry" fields in
-    let* entry = pending_entry_of_yojson ~base_path entry_json in
+    let* entry =
+      pending_entry_of_yojson
+        ~base_path
+        ~request_context_wire:Delivery_without_request_context
+        entry_json
+    in
     let* decision_json = required_member ~surface "decision" fields in
     let* decision = approval_decision_of_yojson decision_json in
     let* source_raw = required_string ~surface "source" fields in
@@ -1083,8 +1136,10 @@ let persisted_delivery_of_yojson ~base_path json =
       | Some _ -> Error (surface ^ ".remember_rule must be a boolean")
       | None -> Error (surface ^ ".remember_rule is required")
     in
-    let* rule_expires_at = optional_float ~surface "rule_expires_at" fields in
-    let* created_by = optional_string ~surface "created_by" fields in
+    let* rule_expires_at =
+      required_nullable_finite_float ~surface "rule_expires_at" fields
+    in
+    let* created_by = required_string ~surface "created_by" fields in
     let* grant_consumed =
       match List.assoc_opt "grant_consumed" fields with
       | Some (`Bool value) -> Ok value
@@ -1094,9 +1149,21 @@ let persisted_delivery_of_yojson ~base_path json =
     let* () =
       match decision, grant_consumed with
       | Decision.Approve, (true | false) -> Ok ()
-      | (Decision.Reject _ | Decision.Edit _), false -> Ok ()
-      | (Decision.Reject _ | Decision.Edit _), true ->
+      | Decision.Reject _, false -> Ok ()
+      | Decision.Reject _, true ->
         Error (surface ^ ".grant_consumed is valid only for approve")
+    in
+    let* () =
+      match decision, remember_rule, rule_expires_at with
+      | Decision.Approve, true, (None | Some _) -> Ok ()
+      | Decision.Approve, false, None -> Ok ()
+      | Decision.Approve, false, Some _ ->
+        Error (surface ^ ".rule_expires_at requires remember_rule=true")
+      | Decision.Reject _, false, None -> Ok ()
+      | Decision.Reject _, true, _ ->
+        Error (surface ^ ".remember_rule is valid only for approve")
+      | Decision.Reject _, false, Some _ ->
+        Error (surface ^ ".rule_expires_at is valid only for approve")
     in
     Ok
       { entry
@@ -1262,7 +1329,9 @@ let snapshot_of_yojson ~base_path json =
     let* pending_entries =
       parse_list
         ~surface:"gate_pending.pending"
-        (pending_entry_of_yojson ~base_path)
+        (pending_entry_of_yojson
+           ~base_path
+           ~request_context_wire:Pending_request_context)
         pending_json
     in
     let* delivery_entries =
@@ -1445,8 +1514,7 @@ let attach_replay_results ~delivery_map replay_results =
               (Printf.sprintf
                  "gate_replay_results outcome %s requires a consumed approve grant"
                  approval_id)
-          | Some
-              { decision = (Decision.Reject _ | Decision.Edit _); _ } ->
+          | Some { decision = Decision.Reject _; _ } ->
             Error
               (Printf.sprintf
                  "gate_replay_results outcome %s belongs to a non-approved delivery"
@@ -1531,13 +1599,13 @@ let approval_sse_pending_event = "approval:pending"
 let approval_sse_resolved_event = "approval:resolved"
 let approval_sse_summary_event = "approval:summary_updated"
 
-let generate_id () = make_generated_id "appr"
+let generate_id = make_approval_id
 
 let default_continuation_channel () =
   Keeper_continuation_channel.unrouted "no originating connector"
 ;;
 
-let normalized_input_hash = request_fingerprint
+let normalized_input_hash = Keeper_approval_queue_rules_types.request_fingerprint
 
 type approved_delivery_lookup =
   | Approved_delivery_unconsumed of persisted_delivery
@@ -1570,7 +1638,7 @@ let approved_delivery_unlocked ~base_path ~id =
             if delivery.grant_consumed
             then Ok (Approved_delivery_consumed delivery)
             else Ok (Approved_delivery_unconsumed delivery)
-          | Decision.Reject _ | Decision.Edit _ ->
+          | Decision.Reject _ ->
             Error (Grant_resolution_not_approved id))
      | None ->
        (match SMap.find_opt id (Atomic.get pending) with
@@ -2820,7 +2888,6 @@ let commit_keeper_approval_resolution
 let hitl_resolution_decision_of_approval_decision = function
   | Decision.Approve -> Keeper_event_queue.Hitl_approved
   | Decision.Reject rationale -> Keeper_event_queue.Hitl_rejected rationale
-  | Decision.Edit input -> Keeper_event_queue.Hitl_edited input
 ;;
 
 let deliver_resolution ~base_path (entry : pending_approval) decision =
@@ -2837,6 +2904,7 @@ let resolve_entry
       ~base_path
       (entry : pending_approval)
       ~(source : decision_source)
+      ~actor
       (decision : decision)
   =
   let decision_str = approval_decision_to_string decision in
@@ -2857,6 +2925,7 @@ let resolve_entry
     ?goal_id:entry.goal_id
     ~goal_ids:entry.goal_ids
     ~decision_source:source
+    ~actor
     ~decision
     ~summary_status:entry.summary_status
     ~exact_attempt:entry.exact_attempt
@@ -3044,6 +3113,7 @@ let submit_pending
 (* ── Resolve (operator action) ────────────────────────────── *)
 
 type resolve_error =
+  | Invalid_resolution_policy of string
   | Not_found of string
   | Already_resolved of string
   | Delivery_failed of
@@ -3055,7 +3125,13 @@ type resolve_error =
       ; storage_error : storage_error
       }
 
+type resolution_result =
+  { remembered_rule : Keeper_approval_queue_rules_types.approval_rule option
+  ; remember_rule_error : storage_error option
+  }
+
 let resolve_error_to_string = function
+  | Invalid_resolution_policy reason -> reason
   | Not_found id -> Printf.sprintf "approval %s not found" id
   | Already_resolved id -> Printf.sprintf "approval %s already resolved" id
   | Delivery_failed { approval_id; reason } ->
@@ -3113,8 +3189,9 @@ let journal_resolution ~id ~decision ~source ~remember_rule ~rule_expires_at ~cr
     match SMap.find_opt id pending_map with
     | None -> Error Journal_not_found
     | Some entry ->
+      let delivery_entry = { entry with request_context = None } in
       let delivery =
-        { entry
+        { entry = delivery_entry
         ; decision
         ; source
         ; remember_rule
@@ -3159,54 +3236,38 @@ let approval_decision_equal left right =
   match left, right with
   | Decision.Approve, Decision.Approve -> true
   | Decision.Reject left, Decision.Reject right -> String.equal left right
-  | Decision.Edit left, Decision.Edit right -> Yojson.Safe.equal left right
-  | (Decision.Approve | Decision.Reject _ | Decision.Edit _),
-    (Decision.Approve | Decision.Reject _ | Decision.Edit _) ->
+  | (Decision.Approve | Decision.Reject _),
+    (Decision.Approve | Decision.Reject _) ->
     false
 ;;
 
-let remember_rule_for_entry ~base_path ?created_by ?rule_expires_at (entry : pending_approval) =
-  try
-    match
-      upsert_rule
-        ~base_path
-        ~keeper_name:entry.keeper_name
-        ~tool_name:entry.tool_name
-        ~input:entry.input
-        ?created_by
-        ~source_approval_id:entry.id
-        ?expires_at:rule_expires_at
-        ()
-    with
-    | Ok (rule, created) ->
-      if created
-      then
-        Keeper_approval.Audit.record_rule
-          ~base_path
-          ~event_type:Keeper_approval.Audit.Rule_created
-          rule;
-      Ok rule
-    | Error reason -> Error reason
+let remember_rule_for_entry
+      ~base_path
+      ~created_by
+      ~rule_expires_at
+      (entry : pending_approval)
+  =
+  match
+    Keeper_approval_queue_rules.upsert_rule
+      ~base_path
+      ~keeper_name:entry.keeper_name
+      ~tool_name:entry.tool_name
+      ~input:entry.input
+      ~created_by
+      ~source_approval_id:entry.id
+      ~expires_at:rule_expires_at
+      ()
   with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-    let reason = Printexc.to_string exn in
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string ApprovalQueueFailures)
-      ~labels:
-        [ "keeper", entry.keeper_name
-        ; "site", Keeper_approval_queue_failure_site.(to_label Remember_rule)
-        ]
-      ();
-    Log.Keeper.warn
-      "approval_queue: remember rule failed id=%s err=%s"
-      entry.id
-      reason;
-    Error
-      ({ path = rules_path ~base_path ()
-       ; reason
-       }
-       : rule_store_error)
+  | Ok (rule, created) ->
+    if created
+    then
+      Keeper_approval.Audit.record_rule
+        ~base_path
+        ~event_type:Keeper_approval.Audit.Rule_created
+        ~actor:rule.created_by
+        rule;
+    Ok rule
+  | Error reason -> Error reason
 ;;
 
 let remember_rule_for_delivery delivery =
@@ -3215,8 +3276,8 @@ let remember_rule_for_delivery delivery =
     (match
        remember_rule_for_entry
          ~base_path:delivery.entry.audit_base_path
-         ?created_by:delivery.created_by
-         ?rule_expires_at:delivery.rule_expires_at
+         ~created_by:delivery.created_by
+         ~rule_expires_at:delivery.rule_expires_at
          delivery.entry
      with
      | Ok rule -> Ok (Some rule)
@@ -3225,51 +3286,55 @@ let remember_rule_for_delivery delivery =
          { path = rule_error.path
          ; reason = rule_error.reason
          })
-  | (Decision.Approve | Decision.Reject _ | Decision.Edit _),
-    false ->
+  | (Decision.Approve | Decision.Reject _), false ->
     Ok None
-  | (Decision.Reject _ | Decision.Edit _), true -> Ok None
+  | Decision.Reject _, true -> Ok None
 ;;
 
 let complete_delivery delivery =
   let id = delivery.entry.id in
   let base_path = delivery.entry.audit_base_path in
+  let remember_rule_outcome () =
+    match remember_rule_for_delivery delivery with
+    | Ok remembered_rule -> remembered_rule, None
+    | Error storage_error -> None, Some storage_error
+  in
   match resolve_store_readiness_error ~base_path ~approval_id:id with
   | Error _ as error -> error
   | Ok () ->
     if delivery.grant_consumed
-    then Ok { remembered_rule = None }
+    then
+      let remembered_rule, remember_rule_error = remember_rule_outcome () in
+      Ok { remembered_rule; remember_rule_error }
     else
       (match deliver_resolution ~base_path delivery.entry delivery.decision with
        | Error reason -> Error (Delivery_failed { approval_id = id; reason })
        | Ok () ->
-         (match remember_rule_for_delivery delivery with
-          | Error storage_error ->
-            Error (Persistence_failed { approval_id = id; storage_error })
-          | Ok remembered_rule ->
-            let finish () =
-              resolve_entry
-                ~base_path
-                delivery.entry
-                ~source:delivery.source
-                delivery.decision;
-              signal_resolution_after_commit
-                ~base_path
-                ~keeper_name:delivery.entry.keeper_name
-                ~approval_id:id;
-              Ok { remembered_rule }
-            in
-            (match delivery.decision with
-             | Decision.Approve ->
-               (* Keep the resolved journal entry until the exact Gate request
-                  consumes it. The wake event is only a correlation message and
-                  cannot become a second authorization SSOT. *)
-               finish ()
-             | Decision.Reject _ | Decision.Edit _ ->
-               (match remove_delivery_from_store delivery with
-                | Error storage_error ->
-                  Error (Persistence_failed { approval_id = id; storage_error })
-               | Ok () -> finish ()))))
+         let remembered_rule, remember_rule_error = remember_rule_outcome () in
+         let finish () =
+           resolve_entry
+             ~base_path
+             delivery.entry
+             ~source:delivery.source
+             ~actor:delivery.created_by
+             delivery.decision;
+           signal_resolution_after_commit
+             ~base_path
+             ~keeper_name:delivery.entry.keeper_name
+             ~approval_id:id;
+           Ok { remembered_rule; remember_rule_error }
+         in
+         (match delivery.decision with
+          | Decision.Approve ->
+            (* Keep the resolved journal entry until the exact Gate request
+               consumes it. The wake event is only a correlation message and
+               cannot become a second authorization SSOT. *)
+            finish ()
+          | Decision.Reject _ ->
+            (match remove_delivery_from_store delivery with
+             | Error storage_error ->
+               Error (Persistence_failed { approval_id = id; storage_error })
+             | Ok () -> finish ())))
 ;;
 
 let delivery_wake_was_observed delivery =
@@ -3417,7 +3482,20 @@ let install_persistence_internal ~after_load ~base_path =
   match installed with
   | Error storage_error -> Error (Install_storage_failed storage_error)
   | Ok (loaded_pending, loaded_deliveries, replay_projection_error) ->
-    let rec replay count failures = function
+    let rec replay_rule_outcome count failures delivery rest =
+      match remember_rule_for_delivery delivery with
+      | Ok _ -> replay count failures rest
+      | Error storage_error ->
+        let failure =
+          { approval_id = delivery.entry.id
+          ; reason =
+              Printf.sprintf
+                "approval committed but remembered rule was not persisted: %s"
+                (storage_error_to_string storage_error)
+          }
+        in
+        replay count (failure :: failures) rest
+    and replay count failures = function
       | [] ->
         Ok
           { loaded_pending
@@ -3426,13 +3504,21 @@ let install_persistence_internal ~after_load ~base_path =
           ; replay_projection_error
           }
       | delivery :: rest ->
-        if delivery.grant_consumed
-        then replay count failures rest
-        else if delivery_wake_was_observed delivery
-        then replay count failures rest
+        if delivery.grant_consumed || delivery_wake_was_observed delivery
+        then replay_rule_outcome count failures delivery rest
         else
           (match complete_delivery delivery with
-           | Ok _ -> replay (count + 1) failures rest
+           | Ok { remember_rule_error = None; _ } -> replay (count + 1) failures rest
+           | Ok { remember_rule_error = Some storage_error; _ } ->
+             let failure =
+               { approval_id = delivery.entry.id
+               ; reason =
+                   Printf.sprintf
+                     "approval committed but remembered rule was not persisted: %s"
+                     (storage_error_to_string storage_error)
+               }
+             in
+             replay count (failure :: failures) rest
            | Error error ->
              let failure =
                { approval_id = delivery.entry.id
@@ -3454,6 +3540,9 @@ module For_testing = struct
 
   let with_pending_store_lock = with_pending_store_lock
   let get_pending_entry_unchecked = find_pending_entry_unchecked
+  let get_delivery_entry_unchecked ~id =
+    Option.map (fun delivery -> delivery.entry) (SMap.find_opt id (Atomic.get deliveries))
+  ;;
 
   let reset_runtime_state () =
     with_pending_store_lock (fun () ->
@@ -3471,7 +3560,6 @@ module For_testing = struct
 
   let pending_store_path = pending_store_path
   let replay_results_store_path = replay_results_store_path
-  let always_allowed_store_path ~base_path = rules_path ~base_path ()
 
   let bind_summary_exact_attempt_with_writer = bind_summary_exact_attempt_with
 
@@ -3492,13 +3580,40 @@ let resolve_with_policy
       ~base_path
       ~id
       ~(decision : decision)
-      ?(source = Human_operator)
-      ?(remember_rule = false)
-      ?rule_expires_at
-      ?created_by
+      ~source
+      ~remember_rule
+      ~rule_expires_at
+      ~created_by
       ()
   : (resolution_result, resolve_error) result
   =
+  let now = Unix.gettimeofday () in
+  let policy_validation =
+    match String.trim created_by with
+    | "" ->
+      Error (Invalid_resolution_policy "created_by must be a non-blank string")
+    | _ ->
+    match decision with
+    | Decision.Reject reason when String.trim reason = "" ->
+      Error (Invalid_resolution_policy "rejection reason must be a non-blank string")
+    | Decision.Approve | Decision.Reject _ ->
+    match decision, remember_rule, rule_expires_at with
+    | Decision.Approve, true, Some expires_at
+      when not (Float.is_finite expires_at) || expires_at <= now ->
+      Error (Invalid_resolution_policy "rule_expires_at must be a finite future timestamp")
+    | Decision.Approve, true, (None | Some _) -> Ok ()
+    | Decision.Approve, false, None -> Ok ()
+    | Decision.Approve, false, Some _ ->
+      Error (Invalid_resolution_policy "rule_expires_at requires remember_rule=true")
+    | Decision.Reject _, false, None -> Ok ()
+    | Decision.Reject _, true, _ ->
+      Error (Invalid_resolution_policy "remember_rule is valid only for approval")
+    | Decision.Reject _, false, Some _ ->
+      Error (Invalid_resolution_policy "rule_expires_at is valid only for approval")
+  in
+  match policy_validation with
+  | Error _ as error -> error
+  | Ok () ->
   match resolve_store_readiness_error ~base_path ~approval_id:id with
   | Error _ as error -> error
   | Ok () ->
@@ -3522,14 +3637,6 @@ let resolve_with_policy
            then Error (Not_found id)
            else match SMap.find_opt id (Atomic.get pending) with
            | Some _ ->
-             let remember_rule =
-               match decision with
-               | Decision.Approve -> remember_rule
-               | Decision.Reject _ | Decision.Edit _ -> false
-             in
-             let rule_expires_at =
-               if remember_rule then rule_expires_at else None
-             in
              (match
                 journal_resolution
                   ~id

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -4,7 +4,7 @@
     tool/product name. It records an exact request, accepts an explicit
     resolution, and wakes only the originating Keeper lane. *)
 
-include module type of Keeper_approval_queue_rules_types
+open Keeper_approval_queue_rules_types
 
 type storage_error =
   { path : string
@@ -138,7 +138,6 @@ type install_error = Install_storage_failed of storage_error
 val storage_error_to_string : storage_error -> string
 val approval_queue_unavailable_title : string
 val approval_queue_unavailable_severity : string
-val approval_queue_unavailable_icon : string
 val approval_queue_ready_state_json : Yojson.Safe.t
 val approval_queue_unavailable_state_json : storage_error -> Yojson.Safe.t
 val summary_transition_error_to_string : summary_transition_error -> string
@@ -207,103 +206,7 @@ val record_consumed_resolution_replay :
   outcome:resolution_replay_outcome ->
   (replay_recording, grant_error) result
 
-(** {1 Exact Always Allowed rules} *)
-
-val list_rules :
-  base_path:string -> unit -> (approval_rule list, rule_store_error) result
-
-val list_rules_dashboard_json :
-  base_path:string -> unit -> (Yojson.Safe.t, rule_store_error) result
-
-(** Insert or fetch the rule for the exact
-    [(keeper_name, tool_name, canonical complete input)] identity.
-    [expires_at] is an optional absolute Unix expiry; the identity match
-    ignores it, so an existing rule is returned unchanged. *)
-val upsert_rule :
-  base_path:string ->
-  keeper_name:string ->
-  tool_name:string ->
-  input:Yojson.Safe.t ->
-  ?created_by:string ->
-  ?source_approval_id:string ->
-  ?expires_at:float ->
-  unit ->
-  (approval_rule * bool, rule_store_error) result
-
-val delete_rule :
-  base_path:string -> id:string -> unit -> (approval_rule, rule_store_error) result
-
-(** Find the exact remembered request and report whether it authorizes at
-    [now] (defaults to the wall clock; inject for deterministic evaluation).
-    An expired rule is reported as [Rule_match_expired], never applied, and
-    never deleted. *)
-val find_matching_rule :
-  base_path:string ->
-  keeper_name:string ->
-  tool_name:string ->
-  input:Yojson.Safe.t ->
-  ?now:float ->
-  unit ->
-  (rule_lookup, rule_store_error) result
-
 val generate_id : unit -> string
-val recent_resolved_history_limit : int
-val recent_resolved_max_limit : int
-val recent_resolved_default_window_minutes : int
-val recent_resolved_min_window_minutes : int
-val recent_resolved_max_window_minutes : int
-
-val read_recent_audit :
-  base_path:string -> ?keeper_name:string -> ?n:int -> unit -> Yojson.Safe.t list
-
-val audit_day_string_of_ts : float -> string
-(** Day key ["YYYY-MM-DD"] for the [YYYY-MM/DD.jsonl] audit layout. Exposed as
-    a pure function so the UTC invariant is testable: the write path
-    ([Jsonl_writer.dated_path]) picks the day file with [Unix.gmtime], so a
-    local-time key would read the wrong file for the hours where the two
-    calendars disagree. *)
-
-type resolved_history =
-  { resolved_rows : Yojson.Safe.t list
-  ; resolved_matched : int
-  ; resolved_limit : int
-  ; resolved_window_minutes : int
-  ; resolved_scan_exhausted : bool
-  }
-(** A page of resolved Gate decisions together with the bounds that produced
-    it. [resolved_rows] is newest first and holds at most [resolved_limit]
-    entries; [resolved_matched] counts every resolved decision the scan saw
-    inside the window, so [resolved_matched > resolved_limit] means the page is
-    a slice rather than the whole window. [resolved_scan_exhausted] reports the
-    second bound: the physical row cap stopped the scan before it reached the
-    window start, so even [resolved_matched] undercounts. Rendering only
-    [resolved_rows] reintroduces the silent truncation this type removes. *)
-
-val list_recent_resolved :
-  base_path:string ->
-  now_ts:float ->
-  ?limit:int ->
-  ?window_minutes:int ->
-  unit ->
-  resolved_history
-(** [list_recent_resolved ~base_path ~now_ts ()] returns resolved Gate decisions
-    from the last [window_minutes] (default
-    {!recent_resolved_default_window_minutes}, clamped to
-    [[recent_resolved_min_window_minutes, recent_resolved_max_window_minutes]]),
-    newest first, capped at [limit] (default
-    {!recent_resolved_history_limit}, clamped to
-    [[0, recent_resolved_max_limit]]).
-
-    [now_ts] is supplied by the caller rather than read here, matching
-    {!Dashboard_gate_metrics.tool_rejection_counts}: the observation boundary
-    captures the clock once for the whole projection, and this function stays
-    deterministic so a test can pin an exact window.
-
-    Rows without a [ts] are excluded: a wall-clock window cannot place an
-    undated decision, and dating it by guesswork would misreport history.
-
-    Storage failures are reported through the approval-queue failure metric and
-    yield an empty page rather than raising. *)
 
 module For_testing : sig
   type strict_snapshot_writer =
@@ -312,13 +215,13 @@ module For_testing : sig
   val reset_runtime_state : unit -> unit
   val with_pending_store_lock : (unit -> 'a) -> 'a
   val get_pending_entry_unchecked : id:string -> pending_approval option
+  val get_delivery_entry_unchecked : id:string -> pending_approval option
   val install_persistence_with_after_load_hook :
     base_path:string ->
     after_load:(unit -> unit) ->
     (install_report, install_error) result
   val pending_store_path : base_path:string -> string
   val replay_results_store_path : base_path:string -> string
-  val always_allowed_store_path : base_path:string -> string
 
   val bind_summary_exact_attempt_with_writer :
     save_file_atomic_strict_staged:strict_snapshot_writer ->
@@ -388,6 +291,7 @@ val submit_pending :
   (string, storage_error) result
 
 type resolve_error =
+  | Invalid_resolution_policy of string
   | Not_found of string
   | Already_resolved of string
   | Delivery_failed of
@@ -399,12 +303,23 @@ type resolve_error =
       ; storage_error : storage_error
       }
 
+type resolution_result =
+  { remembered_rule : Keeper_approval_queue_rules_types.approval_rule option
+  ; remember_rule_error : storage_error option
+  }
+
 val resolve_error_to_string : resolve_error -> string
 
 (** Commit a resolution, optionally persist an exact Always Allowed rule for
     [Decision.Approve], then wake only the Keeper captured by the pending entry.
     [rule_expires_at] is an absolute Unix expiry applied to the remembered
-    rule; it is ignored unless [remember_rule] is [true].
+    rule. Invalid decision, remember-rule, and expiry combinations are rejected
+    before any resolution claim or journal mutation.
+
+    The approval commit is not rolled back when the separate rule store is
+    unavailable. In that case [remember_rule_error] is set, including on an
+    idempotent retry after the exact grant was consumed, so callers cannot
+    report a remembered rule that was never persisted.
 
     [base_path] is the authenticated caller workspace. The pending or
     in-progress delivery entry must belong to it exactly before any resolution
@@ -413,10 +328,10 @@ val resolve_with_policy :
   base_path:string ->
   id:string ->
   decision:decision ->
-  ?source:decision_source ->
-  ?remember_rule:bool ->
-  ?rule_expires_at:float ->
-  ?created_by:string ->
+  source:decision_source ->
+  remember_rule:bool ->
+  rule_expires_at:float option ->
+  created_by:string ->
   unit ->
   (resolution_result, resolve_error) result
 

--- a/lib/keeper/keeper_approval_queue_rules.ml
+++ b/lib/keeper/keeper_approval_queue_rules.ml
@@ -1,38 +1,4 @@
-(** Durable, nonblocking HITL queue state and exact Always Allowed rules.
-
-    This module does not classify an effect, interpret an operation name, or
-    own a Keeper lane. *)
-
-(** Types, conversions, and JSON serialization extracted to
-    [Keeper_approval_queue_rules_types].  State management below. *)
-
-include Keeper_approval_queue_rules_types
-
-let record_queue_failure ~keeper_name ~site ?(id = "-") ?(event_type = "-") exn =
-  Otel_metric_store.inc_counter
-    Keeper_metrics.(to_string ApprovalQueueFailures)
-    ~labels:[ "keeper", keeper_name; "site", site ]
-    ();
-  Log.Keeper.warn
-    "approval_queue: %s failed keeper=%s id=%s event=%s err=%s"
-    site
-    keeper_name
-    id
-    event_type
-    (Printexc.to_string exn)
-;;
-
-(* ── Global queue (Lock-free Atomic.t) ───────────────────── *)
-
-module SMap = Set_util.StringMap
-
-let rec atomic_update atomic f =
-  let old_val = Atomic.get atomic in
-  let new_val = f old_val in
-  if Atomic.compare_and_set atomic old_val new_val then () else atomic_update atomic f
-;;
-
-let pending : pending_approval SMap.t Atomic.t = Atomic.make SMap.empty
+open Keeper_approval_queue_rules_types
 
 let id_rng = Random.State.make_self_init ()
 let id_rng_mu = Stdlib.Mutex.create ()
@@ -53,7 +19,7 @@ let rules_mutex = Cross_context_mutex.create ()
 let with_rules_read_lock f = Cross_context_mutex.with_lock rules_mutex f
 let with_rules_write_lock f = Cross_context_mutex.with_durable_lock rules_mutex f
 
-let rules_path ~base_path () =
+let store_path ~base_path =
   Keeper_gate_path.always_allowed ~base_path
 ;;
 
@@ -62,8 +28,8 @@ let approval_rules_persistence_surface = "keeper_approval_rules"
 let report_rules_read_drop ~reason ~path ~detail =
   Safe_ops.report_persistence_read_drop
     ~on_drop:(fun () ->
-      Otel_metric_store.inc_counter
-        Otel_metric_store.metric_persistence_read_drops
+      Otel_metric_store_core.inc_counter
+        Otel_metric_names.metric_persistence_read_drops
         ~labels:[ "surface", approval_rules_persistence_surface; "reason", reason ]
         ())
     ~surface:approval_rules_persistence_surface
@@ -76,24 +42,12 @@ let rule_json_preview json =
   Yojson.Safe.to_string json |> String_util.utf8_prefix ~max_bytes:240
 ;;
 
-let rec canonical_request_json = function
-  | `Assoc fields ->
-    fields
-    |> List.map (fun (key, value) -> key, canonical_request_json value)
-    |> List.stable_sort (fun (left, _) (right, _) -> String.compare left right)
-    |> fun canonical -> `Assoc canonical
-  | `List items -> `List (List.map canonical_request_json items)
-  | other -> other
-;;
+let string_is_nonblank value = String.trim value <> ""
 
-let request_fingerprint (input : Yojson.Safe.t) =
-  let canonical_json = canonical_request_json input |> Yojson.Safe.to_string in
-  Digestif.SHA256.(digest_string canonical_json |> to_hex)
-;;
-
-let nonempty_string_opt = function
-  | Some value when String.trim value <> "" -> Some (String.trim value)
-  | _ -> None
+let require_nonblank_rule_field ~path field value =
+  if string_is_nonblank value
+  then Ok ()
+  else Error { path; reason = field ^ " must be a non-blank string" }
 ;;
 
 let rule_identity_matches left right =
@@ -121,7 +75,7 @@ let validate_unique_rules rules =
 ;;
 
 let load_rules_unlocked ~base_path () =
-  let path = rules_path ~base_path () in
+  let path = store_path ~base_path in
   let rec parse_entries index acc = function
     | [] ->
       let rules = List.rev acc in
@@ -185,7 +139,7 @@ let load_rules_unlocked ~base_path () =
 ;;
 
 let save_rules_unlocked ~base_path rules : (unit, rule_store_error) result =
-  let path = rules_path ~base_path () in
+  let path = store_path ~base_path in
   try
     Fs_compat.mkdir_p (Filename.dirname path);
     let json = `List (List.map approval_rule_to_yojson rules) in
@@ -197,8 +151,15 @@ let save_rules_unlocked ~base_path rules : (unit, rule_store_error) result =
   | exn -> Error { path; reason = Printexc.to_string exn }
 ;;
 
+let protect_store ~base_path f =
+  try f () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error { path = store_path ~base_path; reason = Printexc.to_string exn }
+;;
+
 let list_rules ~base_path () =
-  with_rules_read_lock (fun () -> load_rules_unlocked ~base_path ())
+  protect_store ~base_path (fun () ->
+    with_rules_read_lock (fun () -> load_rules_unlocked ~base_path ()))
 ;;
 
 let list_rules_dashboard_json ~base_path () =
@@ -216,34 +177,67 @@ let upsert_rule
       ~keeper_name
       ~tool_name
       ~input
-      ?created_by
-      ?source_approval_id
-      ?expires_at
+      ~created_by
+      ~source_approval_id
+      ~expires_at
       ()
   =
-  with_rules_write_lock (fun () ->
+  protect_store ~base_path (fun () ->
+    with_rules_write_lock (fun () ->
+    let path = store_path ~base_path in
+    let open Result.Syntax in
+    let* () = require_nonblank_rule_field ~path "keeper_name" keeper_name in
+    let* () = require_nonblank_rule_field ~path "tool_name" tool_name in
+    let* () = require_nonblank_rule_field ~path "created_by" created_by in
+    let* () = require_nonblank_rule_field ~path "source_approval_id" source_approval_id in
+    let now = Unix.gettimeofday () in
+    match expires_at with
+    | Some value when not (Float.is_finite value) ->
+      Error
+        { path
+        ; reason = "expires_at must be a finite number"
+        }
+    | Some value when value <= now ->
+      Error
+        { path
+        ; reason = "expires_at must be in the future"
+        }
+    | None | Some _ ->
     match load_rules_unlocked ~base_path () with
     | Error _ as error -> error
     | Ok rules ->
-      let request_fingerprint = request_fingerprint input in
+      let request_fingerprint =
+        Keeper_approval_queue_rules_types.request_fingerprint input
+      in
       let candidate =
         { id = make_generated_id "rule"
         ; keeper_name
         ; tool_name
         ; request_fingerprint
-        ; created_at = Unix.gettimeofday ()
+        ; created_at = now
         ; created_by
         ; source_approval_id
         ; expires_at
         }
       in
       (match List.find_opt (fun rule -> rule_identity_matches rule candidate) rules with
+       | Some existing when rule_expired ~now existing ->
+         Error
+           { path
+           ; reason = "the exact approval rule is expired; delete it before creating another"
+           }
+       | Some existing
+         when not (Option.equal Float.equal existing.expires_at candidate.expires_at) ->
+         Error
+           { path
+           ; reason = "the exact approval rule has a different expiry"
+           }
        | Some existing -> Ok (existing, false)
        | None ->
          (match save_rules_unlocked ~base_path (candidate :: rules) with
           | Ok () -> Ok (candidate, true)
           | Error error ->
-            Otel_metric_store.inc_counter
+            Otel_metric_store_core.inc_counter
               Keeper_metrics.(to_string ApprovalQueueFailures)
               ~labels:
                 [ "keeper", keeper_name
@@ -251,25 +245,26 @@ let upsert_rule
                 ]
               ();
             Log.Keeper.warn "upsert_rule: save failed: %s" (rule_store_error_to_string error);
-            Error error)))
+            Error error))))
 ;;
 
 let delete_rule ~base_path ~id () =
-  with_rules_write_lock (fun () ->
+  protect_store ~base_path (fun () ->
+    with_rules_write_lock (fun () ->
     match load_rules_unlocked ~base_path () with
     | Error _ as error -> error
     | Ok rules ->
       (match List.find_opt (fun rule -> String.equal rule.id id) rules with
        | None ->
          Error
-           { path = rules_path ~base_path ()
+           { path = store_path ~base_path
            ; reason = Printf.sprintf "approval rule %s not found" id
            }
        | Some deleted ->
          let remaining = List.filter (fun rule -> not (String.equal rule.id id)) rules in
          (match save_rules_unlocked ~base_path remaining with
           | Ok () -> Ok deleted
-          | Error _ as error -> error)))
+          | Error _ as error -> error))))
 ;;
 
 let find_matching_rule
@@ -281,11 +276,14 @@ let find_matching_rule
       ?(now = Unix.gettimeofday ())
       ()
   =
-  with_rules_read_lock (fun () ->
+  protect_store ~base_path (fun () ->
+    with_rules_read_lock (fun () ->
     match load_rules_unlocked ~base_path () with
     | Error _ as error -> error
     | Ok rules ->
-      let request_fingerprint = request_fingerprint input in
+      let request_fingerprint =
+        Keeper_approval_queue_rules_types.request_fingerprint input
+      in
       (match
          List.find_opt
            (fun rule ->
@@ -299,5 +297,9 @@ let find_matching_rule
          let matched = { rule_id = rule.id } in
          if rule_expired ~now rule
          then Ok (Rule_match_expired matched)
-         else Ok (Rule_match_active matched)))
+         else Ok (Rule_match_active matched))))
 ;;
+
+module For_testing = struct
+  let store_path = store_path
+end

--- a/lib/keeper/keeper_approval_queue_rules.mli
+++ b/lib/keeper/keeper_approval_queue_rules.mli
@@ -1,0 +1,47 @@
+val list_rules :
+  base_path:string ->
+  unit ->
+  ( Keeper_approval_queue_rules_types.approval_rule list
+  , Keeper_approval_queue_rules_types.rule_store_error )
+  result
+
+val list_rules_dashboard_json :
+  base_path:string ->
+  unit ->
+  (Yojson.Safe.t, Keeper_approval_queue_rules_types.rule_store_error) result
+
+val upsert_rule :
+  base_path:string ->
+  keeper_name:string ->
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  created_by:string ->
+  source_approval_id:string ->
+  expires_at:float option ->
+  unit ->
+  ( Keeper_approval_queue_rules_types.approval_rule * bool
+  , Keeper_approval_queue_rules_types.rule_store_error )
+  result
+
+val delete_rule :
+  base_path:string ->
+  id:string ->
+  unit ->
+  ( Keeper_approval_queue_rules_types.approval_rule
+  , Keeper_approval_queue_rules_types.rule_store_error )
+  result
+
+val find_matching_rule :
+  base_path:string ->
+  keeper_name:string ->
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  ?now:float ->
+  unit ->
+  ( Keeper_approval_queue_rules_types.rule_lookup
+  , Keeper_approval_queue_rules_types.rule_store_error )
+  result
+
+module For_testing : sig
+  val store_path : base_path:string -> string
+end

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -167,7 +167,7 @@ let cycle_grant_of_resolution (resolution : Keeper_event_queue.hitl_resolution) 
     Some
       (Atomic.make
          (Cycle_grant_available { approval_id = resolution.approval_id }))
-  | Keeper_event_queue.Hitl_rejected _ | Keeper_event_queue.Hitl_edited _ -> None
+  | Keeper_event_queue.Hitl_rejected _ -> None
 ;;
 
 let rec take_matching_cycle_grant grant request =
@@ -216,11 +216,11 @@ let deferred_reason_to_string = function
   | Human_requested -> "human_requested"
   | Judge_requested -> "judge_requested"
   | Auto_judge_unavailable _ ->
-    Keeper_approval_queue.summary_attempt_pre_worker_unavailable_code_to_string
-      Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+    Keeper_approval_queue_rules_types.summary_attempt_pre_worker_unavailable_code_to_string
+      Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
   | Mode_state_invalid _ ->
-    Keeper_approval_queue.summary_attempt_pre_worker_unavailable_code_to_string
-      Keeper_approval_queue.Summary_pre_worker_mode_state_invalid
+    Keeper_approval_queue_rules_types.summary_attempt_pre_worker_unavailable_code_to_string
+      Keeper_approval_queue_rules_types.Summary_pre_worker_mode_state_invalid
 ;;
 
 let unavailable_reason_to_string = function
@@ -338,14 +338,14 @@ type judgment_finalize_outcome =
   | Judgment_finalized
   | Judgment_skipped
 
-let resolve_judgment (entry : Keeper_approval_queue.pending_approval) ~approval_id
-      (summary : Keeper_approval_queue.hitl_context_summary) =
+let resolve_judgment (entry : Keeper_approval_queue_rules_types.pending_approval) ~approval_id
+      (summary : Keeper_approval_queue_rules_types.hitl_context_summary) =
   let decision =
-    match summary.Keeper_approval_queue.judgment with
-    | Keeper_approval_queue.Approve -> Some Keeper_approval_queue.Decision.Approve
-    | Keeper_approval_queue.Deny ->
-      Some (Keeper_approval_queue.Decision.Reject summary.rationale)
-    | Keeper_approval_queue.Require_human -> None
+    match summary.Keeper_approval_queue_rules_types.judgment with
+    | Keeper_approval_queue_rules_types.Approve -> Some Keeper_approval_queue_rules_types.Decision.Approve
+    | Keeper_approval_queue_rules_types.Deny ->
+      Some (Keeper_approval_queue_rules_types.Decision.Reject summary.rationale)
+    | Keeper_approval_queue_rules_types.Require_human -> None
   in
   match decision with
   | None -> Ok Judgment_skipped
@@ -355,7 +355,9 @@ let resolve_judgment (entry : Keeper_approval_queue.pending_approval) ~approval_
          ~base_path:entry.audit_base_path
          ~id:approval_id
          ~decision
-         ~source:Keeper_approval_queue.Auto_judge
+         ~source:Keeper_approval_queue_rules_types.Auto_judge
+         ~remember_rule:false
+         ~rule_expires_at:None
          ~created_by:("auto_judge:" ^ summary.model_run_id)
          ()
      with
@@ -385,7 +387,7 @@ end
 module Auto_judge_owners = Map.Make (Auto_judge_owner)
 module Auto_judge_owner_set = Set.Make (Auto_judge_owner)
 
-let auto_judge_owner (entry : Keeper_approval_queue.pending_approval) =
+let auto_judge_owner (entry : Keeper_approval_queue_rules_types.pending_approval) =
   entry.audit_base_path, entry.keeper_name
 ;;
 
@@ -395,7 +397,7 @@ let active_auto_judges : string Auto_judge_owners.t Atomic.t =
   Atomic.make Auto_judge_owners.empty
 ;;
 
-let rec claim_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+let rec claim_auto_judge (entry : Keeper_approval_queue_rules_types.pending_approval) =
   let active = Atomic.get active_auto_judges in
   let owner = auto_judge_owner entry in
   match Auto_judge_owners.find_opt owner active with
@@ -407,7 +409,7 @@ let rec claim_auto_judge (entry : Keeper_approval_queue.pending_approval) =
     else claim_auto_judge entry
 ;;
 
-let rec release_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+let rec release_auto_judge (entry : Keeper_approval_queue_rules_types.pending_approval) =
   let active = Atomic.get active_auto_judges in
   let owner = auto_judge_owner entry in
   match Auto_judge_owners.find_opt owner active with
@@ -427,30 +429,30 @@ let active_auto_judge_for_owner ~base_path ~keeper_name =
 type auto_judge_entry_class =
   | Auto_judge_not_requested
   | Auto_judge_pending_unbound
-  | Auto_judge_finalizable of Keeper_approval_queue.hitl_context_summary
+  | Auto_judge_finalizable of Keeper_approval_queue_rules_types.hitl_context_summary
   | Auto_judge_ineligible
 
 let classify_auto_judge_entry
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   match
     entry.summary_attempt_disposition,
     entry.exact_attempt,
     entry.summary_status
   with
-  | Keeper_approval_queue.Summary_attempt_ready,
-    Keeper_approval_queue.Exact_unbound,
-    Keeper_approval_queue.Summary_not_requested ->
+  | Keeper_approval_queue_rules_types.Summary_attempt_ready,
+    Keeper_approval_queue_rules_types.Exact_unbound,
+    Keeper_approval_queue_rules_types.Summary_not_requested ->
     Auto_judge_not_requested
-  | Keeper_approval_queue.Summary_attempt_ready,
-    Keeper_approval_queue.Exact_unbound,
-    Keeper_approval_queue.Summary_pending ->
+  | Keeper_approval_queue_rules_types.Summary_attempt_ready,
+    Keeper_approval_queue_rules_types.Exact_unbound,
+    Keeper_approval_queue_rules_types.Summary_pending ->
     Auto_judge_pending_unbound
-  | ( Keeper_approval_queue.Summary_attempt_settled
-    | Keeper_approval_queue.Summary_attempt_persistence_uncertain ),
-    Keeper_approval_queue.Exact_bound
-      { status = Keeper_approval_queue.Exact_completed; _ },
-    Keeper_approval_queue.Summary_available summary ->
+  | ( Keeper_approval_queue_rules_types.Summary_attempt_settled
+    | Keeper_approval_queue_rules_types.Summary_attempt_persistence_uncertain ),
+    Keeper_approval_queue_rules_types.Exact_bound
+      { status = Keeper_approval_queue_rules_types.Exact_completed; _ },
+    Keeper_approval_queue_rules_types.Summary_available summary ->
     Auto_judge_finalizable summary
   | _ ->
     Auto_judge_ineligible
@@ -467,8 +469,8 @@ let auto_judge_entry_ready entry =
 ;;
 
 let compare_auto_judge_entries
-      (left : Keeper_approval_queue.pending_approval)
-      (right : Keeper_approval_queue.pending_approval)
+      (left : Keeper_approval_queue_rules_types.pending_approval)
+      (right : Keeper_approval_queue_rules_types.pending_approval)
   =
   Int.compare left.sequence right.sequence
 ;;
@@ -478,7 +480,7 @@ let compare_auto_judge_entries
    Auto Judge may start. *)
 let owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries =
   entries
-  |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+  |> List.filter (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
     String.equal entry.audit_base_path base_path
     && String.equal entry.keeper_name keeper_name)
   |> List.sort compare_auto_judge_entries
@@ -486,7 +488,7 @@ let owner_auto_judges_in_fifo_order ~base_path ~keeper_name entries =
 
 let auto_judge_entry_has_start_reservation
       reserved_id
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   String.equal entry.id reserved_id
   &&
@@ -495,11 +497,11 @@ let auto_judge_entry_has_start_reservation
     entry.exact_attempt,
     entry.summary_attempt_disposition
   with
-  | Keeper_approval_queue.Summary_pending,
-    Keeper_approval_queue.Exact_unbound,
-    Keeper_approval_queue.Summary_attempt_pre_worker_unavailable
+  | Keeper_approval_queue_rules_types.Summary_pending,
+    Keeper_approval_queue_rules_types.Exact_unbound,
+    Keeper_approval_queue_rules_types.Summary_attempt_pre_worker_unavailable
       { reason_code =
-          Keeper_approval_queue.Summary_pre_worker_start_reserved
+          Keeper_approval_queue_rules_types.Summary_pre_worker_start_reserved
       ; _
       } ->
     true
@@ -527,7 +529,7 @@ let ready_auto_judges_for_owner
       ~keeper_name
       entries
   =
-  let startable (entry : Keeper_approval_queue.pending_approval) =
+  let startable (entry : Keeper_approval_queue_rules_types.pending_approval) =
     auto_judge_entry_ready entry
     ||
     (match reserved_id with
@@ -628,14 +630,14 @@ let drain_auto_judge_owners_with ~drain_owner owners =
 
 type hitl_worker_spawner =
   sw:Eio.Switch.t ->
-  entry:Keeper_approval_queue.pending_approval ->
-  on_summary:(Keeper_approval_queue.hitl_context_summary -> unit) ->
+  entry:Keeper_approval_queue_rules_types.pending_approval ->
+  on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit) ->
   on_finish:(Hitl_summary_worker.finish_outcome -> unit) ->
   unit ->
   (Hitl_summary_worker.spawn_outcome, string) result
 
 let mark_pre_worker_unavailable
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
       ~reason_code
       ~operator_detail
   =
@@ -659,12 +661,12 @@ let durable_pre_worker_unavailable_error reason = function
 ;;
 
 let reserve_pre_worker_start
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   match
     mark_pre_worker_unavailable
       entry
-      ~reason_code:Keeper_approval_queue.Summary_pre_worker_start_reserved
+      ~reason_code:Keeper_approval_queue_rules_types.Summary_pre_worker_start_reserved
       ~operator_detail:
         Keeper_approval_queue.summary_attempt_start_reserved_operator_detail
   with
@@ -679,7 +681,7 @@ let reserve_pre_worker_start
 
 let rec spawn_claimed_auto_judge_entry_with
       ~(spawn_worker : hitl_worker_spawner)
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   let approval_id = entry.id in
   let on_summary summary =
@@ -698,7 +700,7 @@ let rec spawn_claimed_auto_judge_entry_with
          mark_pre_worker_unavailable
            entry
            ~reason_code:
-             Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+             Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
            ~operator_detail:reason
          |> durable_pre_worker_unavailable_error reason
          |> Result.error)
@@ -774,7 +776,7 @@ and spawn_claimed_auto_judge_entry entry =
 
 and spawn_auto_judge_entry_with
       ~(spawn_worker : hitl_worker_spawner)
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   if claim_auto_judge entry
   then spawn_claimed_auto_judge_entry_with ~spawn_worker entry
@@ -791,7 +793,7 @@ and retry_auto_judge_entry
       ~expected_sequence
       ~expected_exact_attempt
       ~expected_disposition
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
   =
   match
     Keeper_approval_queue.reserve_summary_attempt_retry
@@ -811,7 +813,7 @@ and retry_auto_judge_entry
       mark_pre_worker_unavailable
         entry
         ~reason_code:
-          Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+          Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
         ~operator_detail:reason
       |> durable_pre_worker_unavailable_error reason
     in
@@ -863,7 +865,7 @@ and retry_auto_judge_entry
        in
        Error (reblock reason))
 
-and start_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+and start_auto_judge (entry : Keeper_approval_queue_rules_types.pending_approval) =
   if not (claim_auto_judge entry)
   then Ok Skipped
   else
@@ -876,7 +878,7 @@ and start_auto_judge (entry : Keeper_approval_queue.pending_approval) =
       Ok Skipped
     | Ok true -> spawn_claimed_auto_judge_entry entry
 
-and start_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+and start_auto_judge_entry (entry : Keeper_approval_queue_rules_types.pending_approval) =
   match
     Keeper_approval_queue.get_pending_entry_for_workspace
       ~base_path:entry.audit_base_path
@@ -959,7 +961,7 @@ and drain_auto_judge_owner_queue
       | Some reserved_id, [] ->
         (match
            List.exists
-             (fun (entry : Keeper_approval_queue.pending_approval) ->
+             (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
                 String.equal entry.id reserved_id)
              entries
          with
@@ -1020,7 +1022,7 @@ and drain_auto_judges ~base_path =
      | Ok entries ->
        let owners =
          List.fold_left
-           (fun owners (entry : Keeper_approval_queue.pending_approval) ->
+           (fun owners (entry : Keeper_approval_queue_rules_types.pending_approval) ->
               if auto_judge_entry_ready entry
               then Auto_judge_owner_set.add (auto_judge_owner entry) owners
               else owners)
@@ -1040,10 +1042,10 @@ and drain_auto_judges ~base_path =
 ;;
 
 type recovered_work =
-  | Activate_worker of Keeper_approval_queue.pending_approval
+  | Activate_worker of Keeper_approval_queue_rules_types.pending_approval
   | Finalize_judgment of
-      Keeper_approval_queue.pending_approval
-      * Keeper_approval_queue.hitl_context_summary
+      Keeper_approval_queue_rules_types.pending_approval
+      * Keeper_approval_queue_rules_types.hitl_context_summary
 
 let recovered_work_for_base_path ~base_path =
   let enabled =
@@ -1064,24 +1066,24 @@ let recovered_work_for_base_path ~base_path =
     |> Result.map (fun entries ->
     let owners =
       List.fold_left
-        (fun owners (entry : Keeper_approval_queue.pending_approval) ->
+        (fun owners (entry : Keeper_approval_queue_rules_types.pending_approval) ->
            Auto_judge_owner_set.add (auto_judge_owner entry) owners)
         Auto_judge_owner_set.empty
         entries
     in
     let recovered_work_for_entry
-          (entry : Keeper_approval_queue.pending_approval)
+          (entry : Keeper_approval_queue_rules_types.pending_approval)
       =
       match classify_auto_judge_entry entry with
       | Auto_judge_not_requested
       | Auto_judge_pending_unbound ->
         Some (Activate_worker entry)
       | Auto_judge_finalizable
-          ({ judgment = (Keeper_approval_queue.Approve | Keeper_approval_queue.Deny); _ }
+          ({ judgment = (Keeper_approval_queue_rules_types.Approve | Keeper_approval_queue_rules_types.Deny); _ }
            as summary) ->
         Some (Finalize_judgment (entry, summary))
       | Auto_judge_finalizable
-          { judgment = Keeper_approval_queue.Require_human; _ }
+          { judgment = Keeper_approval_queue_rules_types.Require_human; _ }
       | Auto_judge_ineligible ->
         None
     in
@@ -1107,7 +1109,7 @@ let recovered_work_for_base_path ~base_path =
         (entry_of_recovered_work right)))
 ;;
 
-let observe_recovered_work kind (entry : Keeper_approval_queue.pending_approval) =
+let observe_recovered_work kind (entry : Keeper_approval_queue_rules_types.pending_approval) =
   let event_type, outcome =
     match kind with
     | `Activate_worker ->
@@ -1205,7 +1207,7 @@ let retry_blocked_auto_judge
 
 let finalize_recovered_judgment
       ~complete_summary_exact_attempt
-      (entry : Keeper_approval_queue.pending_approval)
+      (entry : Keeper_approval_queue_rules_types.pending_approval)
       summary
   =
   let persistence_uncertain () =
@@ -1218,12 +1220,12 @@ let finalize_recovered_judgment
        : (bool, Keeper_approval_queue.exact_attempt_error) result)
   in
   match entry.exact_attempt with
-  | Keeper_approval_queue.Exact_unbound ->
+  | Keeper_approval_queue_rules_types.Exact_unbound ->
     Error
       ( Resume_identity_unbound
       , "Recovered Auto Judge output has no exact attempt identity; finalization is withheld." )
-  | Keeper_approval_queue.Exact_bound
-      ({ status = Keeper_approval_queue.Exact_completed; _ } as binding) ->
+  | Keeper_approval_queue_rules_types.Exact_bound
+      ({ status = Keeper_approval_queue_rules_types.Exact_completed; _ } as binding) ->
     (match
        complete_summary_exact_attempt
          ~id:entry.id
@@ -1263,7 +1265,7 @@ let finalize_recovered_judgment
        Error
          ( Resume_completion_rejected rejection
          , completion_rejection_operator_detail rejection ))
-  | Keeper_approval_queue.Exact_bound _ ->
+  | Keeper_approval_queue_rules_types.Exact_bound _ ->
     Error
       ( Resume_exact_state_not_completed
       , "Recovered Auto Judge entry is not a completed exact judgment." )
@@ -1366,7 +1368,7 @@ let request_operator_auto_judge_recovery ~base_path =
            | Ok entries ->
              let queued =
                List.fold_left
-                 (fun count (entry : Keeper_approval_queue.pending_approval) ->
+                 (fun count (entry : Keeper_approval_queue_rules_types.pending_approval) ->
                     if auto_judge_entry_ready entry then count + 1 else count)
                  0
                  entries
@@ -1446,7 +1448,7 @@ let defer request reason =
        (match
           persist_pre_worker_block
             ~reason_code:
-              Keeper_approval_queue.Summary_pre_worker_mode_state_invalid
+              Keeper_approval_queue_rules_types.Summary_pre_worker_mode_state_invalid
             detail
         with
         | Ok () -> Deferred { approval_id; reason }
@@ -1455,7 +1457,7 @@ let defer request reason =
        (match
           persist_pre_worker_block
             ~reason_code:
-              Keeper_approval_queue.Summary_pre_worker_auto_judge_unavailable
+              Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
             detail
         with
         | Ok () -> Deferred { approval_id; reason }
@@ -1464,7 +1466,7 @@ let defer request reason =
 ;;
 
 let observe_exact_rule_store_degraded (request : request) error =
-  let detail = Keeper_approval_queue.rule_store_error_to_string error in
+  let detail = Keeper_approval_queue_rules_types.rule_store_error_to_string error in
   Log.Keeper.error
     ~keeper_name:request.keeper_name
     "exact Always Allowed rule lookup unavailable operation=%s: %s; continuing configured Gate mode"
@@ -1488,7 +1490,7 @@ let observe_exact_rule_store_degraded (request : request) error =
 
 let observe_exact_rule_expired
       (request : request)
-      (rule_match : Keeper_approval_queue.rule_match)
+      (rule_match : Keeper_approval_queue_rules_types.rule_match)
   =
   Log.Keeper.warn
     ~keeper_name:request.keeper_name
@@ -1516,7 +1518,7 @@ let decide_from_selected_mode request = function
     let source = Workspace_always_allow in
     audit_allow
       request
-      ~decision_source:Keeper_approval_queue.Always_allowed
+      ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
       source;
     Allow { source }
 ;;
@@ -1527,7 +1529,7 @@ let decide_without_cycle_grant ~keeper_always_allow request =
     let source = Keeper_always_allow in
     audit_allow
       request
-      ~decision_source:Keeper_approval_queue.Always_allowed
+      ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
       source;
     Allow { source })
   else
@@ -1537,12 +1539,12 @@ let decide_without_cycle_grant ~keeper_always_allow request =
        let source = Workspace_always_allow in
        audit_allow
          request
-         ~decision_source:Keeper_approval_queue.Always_allowed
+         ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
          source;
        Allow { source }
      | Error _ | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Auto_judge) ->
        (match
-          Keeper_approval_queue.find_matching_rule
+          Keeper_approval_queue_rules.find_matching_rule
             ~base_path:request.base_path
             ~keeper_name:request.keeper_name
             ~tool_name:request.operation
@@ -1552,18 +1554,18 @@ let decide_without_cycle_grant ~keeper_always_allow request =
         | Error error ->
           observe_exact_rule_store_degraded request error;
           decide_from_selected_mode request mode
-        | Ok (Keeper_approval_queue.Rule_match_active rule_match) ->
+        | Ok (Keeper_approval_queue_rules_types.Rule_match_active rule_match) ->
           let source = Exact_always_rule rule_match.rule_id in
           audit_allow
             request
             ~rule_match
-            ~decision_source:Keeper_approval_queue.Always_allowed
+            ~decision_source:Keeper_approval_queue_rules_types.Always_allowed
             source;
           Allow { source }
-        | Ok (Keeper_approval_queue.Rule_match_expired rule_match) ->
+        | Ok (Keeper_approval_queue_rules_types.Rule_match_expired rule_match) ->
           observe_exact_rule_expired request rule_match;
           decide_from_selected_mode request mode
-        | Ok Keeper_approval_queue.Rule_match_absent ->
+        | Ok Keeper_approval_queue_rules_types.Rule_match_absent ->
           decide_from_selected_mode request mode))
 ;;
 
@@ -1613,7 +1615,7 @@ module For_testing = struct
     call_id:string ->
     plan_fingerprint:string ->
     request_body_sha256:string ->
-    summary:Keeper_approval_queue.hitl_context_summary ->
+    summary:Keeper_approval_queue_rules_types.hitl_context_summary ->
     ( Keeper_approval_queue.exact_attempt_transition
     , Keeper_approval_queue.exact_attempt_error )
       result

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -137,8 +137,8 @@ val retry_blocked_auto_judge :
   requested_by:string ->
   expected_input_hash:string ->
   expected_sequence:int ->
-  expected_exact_attempt:Keeper_approval_queue.exact_attempt_state ->
-  expected_disposition:Keeper_approval_queue.summary_attempt_disposition ->
+  expected_exact_attempt:Keeper_approval_queue_rules_types.exact_attempt_state ->
+  expected_disposition:Keeper_approval_queue_rules_types.summary_attempt_disposition ->
   string ->
   (unit, string) result
 (** Explicitly rearm one typed blocked Auto Judge summary. The configured Gate
@@ -170,7 +170,6 @@ val request_operator_auto_judge_recovery :
   base_path:string -> (operator_recovery_report, string) result
 
 val authorization_source_to_string : authorization_source -> string
-val deferred_reason_to_string : deferred_reason -> string
 val unavailable_reason_to_string : unavailable_reason -> string
 val decision_to_yojson : decision -> Yojson.Safe.t
 
@@ -183,22 +182,22 @@ module For_testing : sig
     call_id:string ->
     plan_fingerprint:string ->
     request_body_sha256:string ->
-    summary:Keeper_approval_queue.hitl_context_summary ->
+    summary:Keeper_approval_queue_rules_types.hitl_context_summary ->
     ( Keeper_approval_queue.exact_attempt_transition
     , Keeper_approval_queue.exact_attempt_error )
       result
 
   val auto_judge_entry_ready :
-    Keeper_approval_queue.pending_approval -> bool
+    Keeper_approval_queue_rules_types.pending_approval -> bool
 
   val ready_auto_judges_for_owner :
     base_path:string ->
     keeper_name:string ->
-    Keeper_approval_queue.pending_approval list ->
-    Keeper_approval_queue.pending_approval list
+    Keeper_approval_queue_rules_types.pending_approval list ->
+    Keeper_approval_queue_rules_types.pending_approval list
 
-  val claim_auto_judge : Keeper_approval_queue.pending_approval -> bool
-  val release_auto_judge : Keeper_approval_queue.pending_approval -> unit
+  val claim_auto_judge : Keeper_approval_queue_rules_types.pending_approval -> bool
+  val release_auto_judge : Keeper_approval_queue_rules_types.pending_approval -> unit
 
   type owner_drain_outcome =
     { started_id : string option
@@ -217,15 +216,15 @@ module For_testing : sig
 
   type hitl_worker_spawner =
     sw:Eio.Switch.t ->
-    entry:Keeper_approval_queue.pending_approval ->
-    on_summary:(Keeper_approval_queue.hitl_context_summary -> unit) ->
+    entry:Keeper_approval_queue_rules_types.pending_approval ->
+    on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit) ->
     on_finish:(Hitl_summary_worker.finish_outcome -> unit) ->
     unit ->
     (Hitl_summary_worker.spawn_outcome, string) result
 
   val spawn_auto_judge_entry_with_worker
     :  spawn_worker:hitl_worker_spawner
-    -> Keeper_approval_queue.pending_approval
+    -> Keeper_approval_queue_rules_types.pending_approval
     -> (bool, string) result
   (** Run the production atomic claim, active-owner lifecycle, cleanup, and
       conclusive-only drain with only the worker spawner injected. *)

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -688,26 +688,6 @@ let user_message_with_hitl_resolution ~base_path ~user_message = function
          ; Printf.sprintf "- rationale: %s" rationale
          ; "This resolution grants no authorization."
          ])
-  | Some
-      { Keeper_event_queue.approval_id
-      ; decision = Keeper_event_queue.Hitl_edited edited_input
-      ; _
-      } ->
-    let edited_input = Yojson.Safe.pretty_to_string edited_input in
-    plain_model_message
-      (String.concat
-         "\n"
-         [ user_message
-         ; ""
-         ; "Gate resolution delivered:"
-         ; Printf.sprintf "- approval_id: %s" approval_id
-         ; "- decision: edited"
-         ; "- edited input:"
-         ; "```json"
-         ; edited_input
-         ; "```"
-         ; "This edit grants no authorization; any external effect follows the ordinary Gate independently."
-         ])
   | None -> plain_model_message user_message
 ;;
 

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -438,12 +438,7 @@ let reconcile_spent_selection
          }
      | Error _ ->
        Ok Selection_actionable)
-  | Hitl_resolved
-      { decision =
-          ( Keeper_event_queue.Hitl_rejected _
-          | Keeper_event_queue.Hitl_edited _ )
-      ; _
-      }
+  | Hitl_resolved { decision = Keeper_event_queue.Hitl_rejected _; _ }
   | Board_signal _
   | Board_attention _
   | Bootstrap

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -107,8 +107,7 @@ let severity_of_approval_event (event : Keeper_approval.Audit.event)
          out as a rejection. *)
       match decision_kind with
       | Some Keeper_approval.Audit.Decision_reject -> "bad"
-      | Some (Keeper_approval.Audit.Decision_approve | Decision_edit) | None ->
-          "ok")
+      | Some Keeper_approval.Audit.Decision_approve | None -> "ok")
 
 let tool_call_timeline_event json =
   match json_float_opt_member "ts" json, json_string_opt_member "tool" json with

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -1,9 +1,8 @@
 (** Docker/sandbox shell execution infrastructure.
 
-    Extracted from keeper_tool_command_runtime.ml — Docker container lifecycle,
-    sandbox profile resolution, and container invocation functions.
-    These are pure infrastructure; command dispatch remains in
-    keeper_tool_command_runtime.ml. *)
+    This module owns Docker container lifecycle, sandbox profile resolution,
+    and container invocation. Command dispatch is owned by the typed Keeper
+    execution path. *)
 
 open Keeper_types
 open Keeper_meta_contract

--- a/lib/keeper/keeper_sandbox_docker.mli
+++ b/lib/keeper/keeper_sandbox_docker.mli
@@ -1,9 +1,8 @@
 (** Docker / sandbox shell execution infrastructure.
 
-    Extracted from keeper_tool_command_runtime.ml — Docker container
-    lifecycle, sandbox profile resolution, and container invocation. Command
-    syntax belongs to the invoked CLI; this layer enforces sandbox and path
-    containment.
+    This module owns Docker container lifecycle, sandbox profile resolution,
+    and container invocation. Command syntax belongs to the invoked CLI; this
+    layer enforces sandbox and path containment.
 
     Sandbox backend failure-message and failure-recording surfaces live
     in [Keeper_sandbox_exec_failure]. Call those qualified rather than
@@ -24,15 +23,6 @@ val docker_private_workspace_cwd :
   string ->
   string
 
-(** Translate keeper-private in-container absolute paths back to their host
-    playground paths for host-side path validation. Actual Docker execution
-    still receives the original container paths. *)
-val rewrite_docker_command_paths_for_host_validation :
-  config:Workspace.config ->
-  meta:Keeper_meta_contract.keeper_meta ->
-  string ->
-  string
-
 (** Resolve [(sandbox_profile, network_mode)] from the keeper's declared
     profile. The declared sandbox profile is the execution contract:
     [sandbox_profile=local] never becomes Docker because of call-site cwd. *)
@@ -45,13 +35,6 @@ val ensure_keeper_sandbox_runtime :
   timeout_sec:float -> (string list, string) result
 (** Direct alias of [Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime];
     returns the [--security-opt seccomp=...] argv fragment on success. *)
-
-(** [-v <host>:<container>:ro] mount list, or [[]] when [host] is
-    blank or missing. *)
-val optional_ro_mount :
-  host:string -> container:string -> string list
-
-
 
 (** Result envelope returned by [run_docker_shell_command_with_status]. *)
 type docker_shell_result =

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -1,11 +1,7 @@
 (** See .mli for contract.
 
-    The current Docker invocation mirrors the hardened-Execute sandbox in
-    [keeper_tool_command_runtime.ml] (read-only rootfs, no caps, no network) with the
-    playground mounted read-only and the default read program reduced to a
-    single [cat]. The argv assembly is duplicated rather than shared so a
-    future surgical change to either path does not need to wade through the
-    other's flags. *)
+    The Docker read invocation uses a read-only rootfs, no capabilities, no
+    network, a read-only playground mount, and a single [cat] program. *)
 
 open Keeper_types
 open Keeper_meta_contract
@@ -50,9 +46,7 @@ let container_path_of_host ~config ~(meta : keeper_meta) ~host_path
          "container_path_of_host: %s is not inside playground %s"
          host_norm host_root)
 
-(* Argv prefix kept private — distinct from keeper_tool_command_runtime's bash
-   argv to avoid coupling the two surfaces. The trailing
-   [program ; arg1 ; ... ] is appended by the caller via
+(* The trailing [program ; arg1 ; ... ] is appended by the caller via
    [build_docker_argv ~command_argv]. *)
 let build_docker_argv ~image ~container_name ~base_path ~host_root ~croot
     ~uid ~gid ~seccomp_args ~secret_args ~command_argv =

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -36,7 +36,7 @@ let pending_hitl_approval_counts config =
     |> List.filter_map (fun name ->
          let pending_count =
            List.fold_left
-             (fun count (entry : Keeper_approval_queue.pending_approval) ->
+             (fun count (entry : Keeper_approval_queue_rules_types.pending_approval) ->
                 if String.equal entry.keeper_name name
                 then count + 1
                 else count)

--- a/lib/keeper_approval/audit.ml
+++ b/lib/keeper_approval/audit.ml
@@ -189,19 +189,16 @@ let event_of_string = function
 type decision_kind =
   | Decision_approve
   | Decision_reject
-  | Decision_edit
 
 let decision_kind_to_string = function
   | Decision_approve -> "approve"
   | Decision_reject -> "reject"
-  | Decision_edit -> "edit"
 ;;
 
 let decision_kind_of_string value =
   match String.trim value with
   | "approve" -> Some Decision_approve
   | "reject" -> Some Decision_reject
-  | "edit" -> Some Decision_edit
   | _ -> None
 ;;
 
@@ -213,7 +210,6 @@ let non_empty_reason reason =
 let approval_decision_kind_and_reason = function
   | Decision.Approve -> Decision_approve, None
   | Decision.Reject reason -> Decision_reject, non_empty_reason reason
-  | Decision.Edit _ -> Decision_edit, None
 ;;
 
 let keeper_audit_metric_label = function
@@ -375,14 +371,15 @@ let record
           ~event_type:(event_to_string event_type) exn)
 ;;
 
-let record_rule ~base_path ~event_type (rule : approval_rule) =
+let record_rule ~base_path ~event_type ~actor (rule : approval_rule) =
   record
     ~base_path
     ~event_type
     ~id:rule.id
     ~keeper_name:rule.keeper_name
     ~tool_name:rule.tool_name
-    ?source_approval_id:rule.source_approval_id
+    ~source_approval_id:rule.source_approval_id
+    ~actor
     ()
 ;;
 
@@ -399,7 +396,7 @@ let audit_scan_window ?keeper_name n =
 
 let record_audit_read_failure ?keeper_name ?(metric_site = Keeper_approval_queue_failure_site.Audit_read_recent) ~site exn =
   Keeper_fd_pressure.note_exception ~site exn;
-  Otel_metric_store.inc_counter
+  Otel_metric_store_core.inc_counter
     Keeper_metrics.(to_string ApprovalQueueFailures)
     ~labels:
       [ "keeper",

--- a/lib/keeper_approval/audit.mli
+++ b/lib/keeper_approval/audit.mli
@@ -23,7 +23,6 @@ val event_of_string : string -> event option
 type decision_kind =
   | Decision_approve
   | Decision_reject
-  | Decision_edit
 
 val decision_kind_to_string : decision_kind -> string
 val decision_kind_of_string : string -> decision_kind option
@@ -52,7 +51,8 @@ val record :
   unit ->
   unit
 
-val record_rule : base_path:string -> event_type:event -> approval_rule -> unit
+val record_rule :
+  base_path:string -> event_type:event -> actor:string -> approval_rule -> unit
 
 val recent_resolved_history_limit : int
 val recent_resolved_max_limit : int

--- a/lib/keeper_contract/dune
+++ b/lib/keeper_contract/dune
@@ -15,6 +15,7 @@
   (:standard -w +4 -w +33))
  (libraries
   eio
+  digestif
   masc.keeper_registry
   masc.keeper_runtime
   masc.keeper_metrics

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -121,7 +121,6 @@ module Decision = struct
   type t =
     | Approve
     | Reject of string
-    | Edit of Yojson.Safe.t
 end
 
 type decision = Decision.t
@@ -143,8 +142,8 @@ type approval_rule =
   ; tool_name : string
   ; request_fingerprint : string
   ; created_at : float
-  ; created_by : string option
-  ; source_approval_id : string option
+  ; created_by : string
+  ; source_approval_id : string
   ; expires_at : float option
   }
 
@@ -161,8 +160,6 @@ type rule_store_error =
   { path : string
   ; reason : string
   }
-
-type resolution_result = { remembered_rule : approval_rule option }
 
 let advisory_judgment_to_string = function
   | Approve -> "approve"
@@ -184,7 +181,6 @@ let advisory_judgment_of_string = function
 let approval_decision_to_string = function
   | Decision.Approve -> "approve"
   | Decision.Reject reason -> "reject:" ^ reason
-  | Decision.Edit _ -> "edit"
 ;;
 
 let decision_source_to_string = function
@@ -215,17 +211,19 @@ let authorization_source_of_string = function
   | _ -> None
 ;;
 
-let string_opt_of_json = function
-  | `String value ->
-    let trimmed = String.trim value in
-    if String.equal trimmed "" then None else Some trimmed
-  | _ -> None
+let rec canonical_request_json = function
+  | `Assoc fields ->
+    fields
+    |> List.map (fun (key, value) -> key, canonical_request_json value)
+    |> List.stable_sort (fun (left, _) (right, _) -> String.compare left right)
+    |> fun canonical -> `Assoc canonical
+  | `List items -> `List (List.map canonical_request_json items)
+  | other -> other
 ;;
 
-let bool_member key json ~default =
-  match Json_util.assoc_member_opt key json with
-  | Some (`Bool value) -> value
-  | _ -> default
+let request_fingerprint input =
+  let canonical_json = canonical_request_json input |> Yojson.Safe.to_string in
+  Digestif.SHA256.(digest_string canonical_json |> to_hex)
 ;;
 
 let rule_match_to_yojson (matched : rule_match) =
@@ -249,8 +247,8 @@ let approval_rule_to_yojson (rule : approval_rule) =
     ; "tool_name", `String rule.tool_name
     ; "request_fingerprint", `String rule.request_fingerprint
     ; "created_at", `Float rule.created_at
-    ; "created_by", Json_util.string_opt_to_json rule.created_by
-    ; "source_approval_id", Json_util.string_opt_to_json rule.source_approval_id
+    ; "created_by", `String rule.created_by
+    ; "source_approval_id", `String rule.source_approval_id
     ; "expires_at", Json_util.float_opt_to_json rule.expires_at
     ]
 ;;
@@ -704,19 +702,32 @@ let approval_rule_of_yojson_with_error json =
     let* keeper_name = require "keeper_name" in
     let* tool_name = require "tool_name" in
     let* request_fingerprint = require "request_fingerprint" in
+    let* () =
+      if is_lowercase_sha256 request_fingerprint
+      then Ok ()
+      else Error "request_fingerprint must be a lowercase SHA-256"
+    in
     let* created_at =
       match Json_util.get_float json "created_at" with
-      | Some value -> Ok value
-      | None -> Error "created_at must be a number"
+      | Some value when Float.is_finite value && value >= 0.0 -> Ok value
+      | Some _ -> Error "created_at must be a finite non-negative number"
+      | None -> Error "created_at must be a finite non-negative number"
     in
-    let created_by = Json_util.get_string json "created_by" in
-    let source_approval_id = Json_util.get_string json "source_approval_id" in
+    let* created_by = require "created_by" in
+    let* source_approval_id = require "source_approval_id" in
     let* expires_at =
       match List.assoc_opt "expires_at" fields with
-      | None | Some `Null -> Ok None
-      | Some (`Float value) -> Ok (Some value)
+      | None -> Error "expires_at is required"
+      | Some `Null -> Ok None
+      | Some (`Float value) when Float.is_finite value -> Ok (Some value)
       | Some (`Int value) -> Ok (Some (Float.of_int value))
-      | Some _ -> Error "expires_at must be a number or null"
+      | Some _ -> Error "expires_at must be a finite number or null"
+    in
+    let* () =
+      match expires_at with
+      | None -> Ok ()
+      | Some value when value > created_at -> Ok ()
+      | Some _ -> Error "expires_at must be later than created_at or null"
     in
     Ok
       { id
@@ -729,10 +740,4 @@ let approval_rule_of_yojson_with_error json =
       ; expires_at
       }
   | _ -> Error "approval rule must be a JSON object"
-;;
-
-let approval_rule_of_yojson json =
-  match approval_rule_of_yojson_with_error json with
-  | Ok rule -> Some rule
-  | Error _ -> None
 ;;

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -121,7 +121,6 @@ module Decision : sig
   type t =
     | Approve
     | Reject of string
-    | Edit of Yojson.Safe.t
 end
 
 type decision = Decision.t
@@ -157,8 +156,8 @@ type approval_rule =
   ; tool_name : string
   ; request_fingerprint : string
   ; created_at : float
-  ; created_by : string option
-  ; source_approval_id : string option
+  ; created_by : string
+  ; source_approval_id : string
   ; expires_at : float option
   }
 
@@ -176,8 +175,6 @@ type rule_store_error =
   ; reason : string
   }
 
-type resolution_result = { remembered_rule : approval_rule option }
-
 val advisory_judgment_to_string : advisory_judgment -> string
 val advisory_judgment_values : string list
 val advisory_judgment_of_string : string -> advisory_judgment option
@@ -186,8 +183,7 @@ val decision_source_to_string : decision_source -> string
 val decision_source_of_string : string -> decision_source option
 val authorization_source_to_string : authorization_source -> string
 val authorization_source_of_string : string -> authorization_source option
-val string_opt_of_json : Yojson.Safe.t -> string option
-val bool_member : string -> Yojson.Safe.t -> default:bool -> bool
+val request_fingerprint : Yojson.Safe.t -> string
 val rule_match_to_yojson : rule_match -> Yojson.Safe.t
 
 val rule_expired : now:float -> approval_rule -> bool
@@ -223,5 +219,3 @@ val summary_attempt_disposition_of_yojson_with_error :
 val approval_rule_of_yojson_with_error :
   Yojson.Safe.t -> (approval_rule, string) Stdlib.result
 (** Parse an approval rule, returning the first validation failure reason. *)
-
-val approval_rule_of_yojson : Yojson.Safe.t -> approval_rule option

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -104,7 +104,6 @@ and fusion_terminal =
 and hitl_resolution_decision =
   | Hitl_approved
   | Hitl_rejected of string
-  | Hitl_edited of Yojson.Safe.t
 
 and hitl_resolution = {
   approval_id : string;
@@ -192,7 +191,6 @@ let task_cancellation_post_id (cancellation : task_cancellation) =
 let hitl_resolution_decision_to_string = function
   | Hitl_approved -> "approve"
   | Hitl_rejected _ -> "reject"
-  | Hitl_edited _ -> "edit"
 
 type stimulus = {
   post_id : post_id;
@@ -544,8 +542,7 @@ let payload_to_yojson = function
        @
        match r.decision with
        | Hitl_approved -> []
-       | Hitl_rejected rationale -> [ "rationale", `String rationale ]
-       | Hitl_edited input -> [ "edited_input", input ])
+       | Hitl_rejected rationale -> [ "rationale", `String rationale ])
   | Manual_compaction_requested ->
     `Assoc [ "kind", `String "manual_compaction_requested" ]
   | Goal_assigned ga ->
@@ -712,9 +709,6 @@ let payload_of_yojson json =
       | "reject" ->
         let* rationale = string_field ~context "rationale" fields in
         Ok (Hitl_rejected rationale)
-      | "edit" ->
-        let* input = required_field ~context "edited_input" fields in
-        Ok (Hitl_edited input)
       | other -> Error (Printf.sprintf "unknown hitl_resolution decision: %s" other)
     in
     let* channel = continuation_channel_field fields in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -141,7 +141,6 @@ and fusion_terminal =
 and hitl_resolution_decision =
   | Hitl_approved
   | Hitl_rejected of string
-  | Hitl_edited of Yojson.Safe.t
 
 and hitl_resolution = {
   approval_id : string;
@@ -150,9 +149,9 @@ and hitl_resolution = {
 }
 (** Payload for [Hitl_resolved]: [approval_id] is the correlation identity.
     The durable Gate journal remains the SSOT for an approved exact request.
-    Rejection rationale and edited input are resolution output, not
-    authorization state, and travel durably in the event so the wake is
-    actionable. Only [Hitl_approved] can produce a one-shot grant. *)
+    Rejection rationale is resolution output, not authorization state, and
+    travels durably in the event so the wake is actionable. Only
+    [Hitl_approved] can produce a one-shot grant. *)
 
 and connector_attention = {
   event_id : string;

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -330,7 +330,6 @@ let approval_resolve_approve_name = "approve"
 let approval_resolve_reject_name = "reject"
 let approval_resolve_decision_required_message = "decision is required"
 let approval_resolve_decision_invalid_message = "decision must be 'approve' or 'reject'"
-let approval_resolve_default_reject_reason = "dashboard rejected approval"
 
 type approval_resolve_decision =
   | Approval_resolve_approve
@@ -342,24 +341,24 @@ let approval_resolve_decision_name = function
 ;;
 
 let approval_resolve_decision_to_queue_decision = function
-  | Approval_resolve_approve -> Keeper_approval_queue.Decision.Approve
-  | Approval_resolve_reject reason -> Keeper_approval_queue.Decision.Reject reason
+  | Approval_resolve_approve -> Keeper_approval_queue_rules_types.Decision.Approve
+  | Approval_resolve_reject reason -> Keeper_approval_queue_rules_types.Decision.Reject reason
 ;;
 
-let approval_resolve_decision_of_json args =
-  match Safe_ops.json_string_opt approval_resolve_decision_field args with
+let approval_resolve_decision_of_fields fields =
+  match List.assoc_opt approval_resolve_decision_field fields with
   | None -> Error (Bad_request approval_resolve_decision_required_message)
-  | Some raw ->
-    (match raw |> String.trim |> String.lowercase_ascii with
-     | name when String.equal name approval_resolve_approve_name ->
-       Ok Approval_resolve_approve
-     | name when String.equal name approval_resolve_reject_name ->
-       let reason =
-         Safe_ops.json_string_opt approval_resolve_reason_field args
-         |> Option.value ~default:approval_resolve_default_reject_reason
-       in
+  | Some (`String name) when String.equal name approval_resolve_approve_name ->
+    (match List.assoc_opt approval_resolve_reason_field fields with
+     | None -> Ok Approval_resolve_approve
+     | Some _ -> Error (Bad_request "reason is valid only for rejection"))
+  | Some (`String name) when String.equal name approval_resolve_reject_name ->
+    (match List.assoc_opt approval_resolve_reason_field fields with
+     | None -> Error (Bad_request "reason is required for rejection")
+     | Some (`String reason) when String.trim reason <> "" ->
        Ok (Approval_resolve_reject reason)
-     | _ -> Error (Bad_request approval_resolve_decision_invalid_message))
+     | Some _ -> Error (Bad_request "reason must be a non-blank string"))
+  | Some _ -> Error (Bad_request approval_resolve_decision_invalid_message)
 ;;
 
 let approval_resolve_http_error_to_string = function
@@ -371,53 +370,71 @@ let approval_resolve_http_error_to_string = function
 let dashboard_gate_resolve_http_json ~base_path ~created_by ~(args : Yojson.Safe.t)
   : (Yojson.Safe.t, approval_resolve_http_error) result
   =
-  match Safe_ops.json_string_opt "id" args with
-  | None -> Error (Bad_request "id is required")
-  | Some id ->
-    let remember_rule =
-      Safe_ops.json_bool_opt "remember_rule" args |> Option.value ~default:false
-    in
-    let rule_expires_at = Safe_ops.json_float_opt "rule_expires_at" args in
-    (* RFC-0305: a missing [decision] field must not default to approve — this
-       resolves a pending HITL approval, so an omitted/malformed decision is a
-       bad request, not a silent grant. Mirrors the [id]-required check above. *)
-    (* Carry the canonical name alongside the decision so the success response
-       echoes what was applied without re-matching [approval_decision] (whose
-       [Edit] arm is never produced here). *)
-    (match approval_resolve_decision_of_json args with
-     | Error _ as err -> err
-     | Ok decision ->
-       let decision_name = approval_resolve_decision_name decision in
-       let decision = approval_resolve_decision_to_queue_decision decision in
-       (match
-          Keeper_approval_queue.resolve_with_policy
-            ~base_path
-            ~id
-            ~decision
-            ~remember_rule
-            ?rule_expires_at
-            ~created_by
-            ()
-        with
-        | Ok result ->
-          Ok
-            (`Assoc
-                [ "ok", `Bool true
-                ; "id", `String id
-                ; "decision", `String decision_name
-                ; ( "rule_id"
-                  , match result.remembered_rule with
-                    | Some rule -> `String rule.id
-                    | None -> `Null )
-                ])
-        | Error (Keeper_approval_queue.Delivery_failed _ as err) ->
-          Error (Unavailable err)
-        | Error (Keeper_approval_queue.Persistence_failed _ as err) ->
-          Error (Unavailable err)
-        | Error
-            (( Keeper_approval_queue.Not_found _
-             | Keeper_approval_queue.Already_resolved _ ) as err) ->
-          Error (Gone err)))
+  let ( let* ) = Result.bind in
+  let* fields =
+    match args with
+    | `Assoc fields -> Ok fields
+    | _ -> Error (Bad_request "resolve request must be an object")
+  in
+  let allowed = [ "id"; "decision"; "reason"; "remember_rule"; "rule_expires_at" ] in
+  let* () =
+    Json_util.reject_unknown_fields ~surface:"resolve request" ~allowed fields
+    |> Result.map_error (fun reason -> Bad_request reason)
+  in
+  let* id =
+    match List.assoc_opt "id" fields with
+    | Some (`String value) when String.trim value <> "" -> Ok value
+    | _ -> Error (Bad_request "id must be a non-blank string")
+  in
+  let* remember_rule =
+    match List.assoc_opt "remember_rule" fields with
+    | Some (`Bool value) -> Ok value
+    | None | Some _ -> Error (Bad_request "remember_rule must be a boolean")
+  in
+  let* rule_expires_at =
+    match List.assoc_opt "rule_expires_at" fields with
+    | None -> Ok None
+    | Some (`Float value) -> Ok (Some value)
+    | Some (`Int value) -> Ok (Some (Float.of_int value))
+    | Some _ -> Error (Bad_request "rule_expires_at must be a number")
+  in
+  let* decision = approval_resolve_decision_of_fields fields in
+  let decision_name = approval_resolve_decision_name decision in
+  let decision = approval_resolve_decision_to_queue_decision decision in
+  match
+    Keeper_approval_queue.resolve_with_policy
+      ~base_path
+      ~id
+      ~decision
+      ~source:Keeper_approval_queue_rules_types.Human_operator
+      ~remember_rule
+      ~rule_expires_at
+      ~created_by
+      ()
+  with
+  | Ok result ->
+    Ok
+      (`Assoc
+          [ "ok", `Bool true
+          ; "id", `String id
+          ; "decision", `String decision_name
+          ; ( "rule_id"
+            , match result.remembered_rule with
+              | Some rule -> `String rule.id
+              | None -> `Null )
+          ; ( "rule_error"
+            , match result.remember_rule_error with
+              | Some error -> `String (Keeper_approval_queue.storage_error_to_string error)
+              | None -> `Null )
+          ])
+  | Error (Keeper_approval_queue.Delivery_failed _ as err) -> Error (Unavailable err)
+  | Error (Keeper_approval_queue.Persistence_failed _ as err) -> Error (Unavailable err)
+  | Error (Keeper_approval_queue.Invalid_resolution_policy reason) ->
+    Error (Bad_request reason)
+  | Error
+      (( Keeper_approval_queue.Not_found _
+       | Keeper_approval_queue.Already_resolved _ ) as err) ->
+    Error (Gone err)
 ;;
 
 let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe.t) =
@@ -463,7 +480,7 @@ let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe
   let* input_hash_json = required "input_hash" in
   let* expected_input_hash =
     match input_hash_json with
-    | `String value when Keeper_approval_queue.is_lowercase_sha256 value ->
+    | `String value when Keeper_approval_queue_rules_types.is_lowercase_sha256 value ->
       Ok value
     | _ -> Error "retry request.input_hash must be a lowercase SHA-256"
   in
@@ -475,20 +492,20 @@ let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe
   in
   let* exact_attempt_json = required "exact_attempt" in
   let* expected_exact_attempt =
-    Keeper_approval_queue.exact_attempt_state_of_yojson_with_error
+    Keeper_approval_queue_rules_types.exact_attempt_state_of_yojson_with_error
       exact_attempt_json
   in
   let* disposition_json = required "summary_attempt_disposition" in
   let* expected_disposition =
-    Keeper_approval_queue.summary_attempt_disposition_of_yojson_with_error
+    Keeper_approval_queue_rules_types.summary_attempt_disposition_of_yojson_with_error
       disposition_json
   in
   let* () =
     match expected_disposition with
-    | Keeper_approval_queue.Summary_attempt_identity_unbound
-    | Keeper_approval_queue.Summary_attempt_persistence_uncertain ->
+    | Keeper_approval_queue_rules_types.Summary_attempt_identity_unbound
+    | Keeper_approval_queue_rules_types.Summary_attempt_persistence_uncertain ->
       Ok ()
-    | Keeper_approval_queue.Summary_attempt_pre_worker_unavailable _ ->
+    | Keeper_approval_queue_rules_types.Summary_attempt_pre_worker_unavailable _ ->
       Ok ()
     | _ -> Error "retry request disposition is not operator-rearmable"
   in
@@ -506,21 +523,27 @@ let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe
   | Ok () -> Ok (`Assoc [ "ok", `Bool true; "id", `String id ])
 ;;
 
-let dashboard_gate_rule_delete_http_json ~base_path ~(args : Yojson.Safe.t)
+let dashboard_gate_rule_delete_http_json ~base_path ~deleted_by ~(args : Yojson.Safe.t)
   : (Yojson.Safe.t, string) result
   =
-  match Safe_ops.json_string_opt "id" args with
-  | None -> Error "id is required"
-  | Some id ->
-    (match Keeper_approval_queue.delete_rule ~base_path ~id () with
+  let open Result.Syntax in
+  let* fields =
+    match args with
+    | `Assoc fields -> Ok fields
+    | _ -> Error "rule delete request must be an object"
+  in
+  let* () = Json_util.reject_unknown_fields ~surface:"rule delete request" ~allowed:[ "id" ] fields in
+  let* id = Json_util.require_field_string ~surface:"rule delete request" "id" fields in
+    (match Keeper_approval_queue_rules.delete_rule ~base_path ~id () with
      | Ok deleted ->
          Keeper_approval.Audit.record_rule
            ~base_path
            ~event_type:Keeper_approval.Audit.Rule_deleted
+           ~actor:deleted_by
            deleted;
          Ok (`Assoc [ "ok", `Bool true; "id", `String deleted.id ])
        | Error error ->
-         Error (Keeper_approval_queue.rule_store_error_to_string error))
+         Error (Keeper_approval_queue_rules_types.rule_store_error_to_string error))
 ;;
 
 let dashboard_schedule_prune_http_json

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -45,8 +45,6 @@ type approval_resolve_http_error =
 val approval_resolve_http_error_to_string :
   approval_resolve_http_error -> string
 
-val approval_resolve_decision_required_message : string
-
 (** {1 Board / memory / Gate HTTP entries} *)
 
 val handle_repository_observation_snapshot :
@@ -55,20 +53,6 @@ val handle_repository_observation_snapshot :
   Httpun.Request.t ->
   Httpun.Reqd.t ->
   unit
-
-val dashboard_board_json :
-  ?config:Workspace.config ->
-  ?hearth:string ->
-  ?author_filter:string ->
-  ?sort_by:Board_dispatch.sort_order ->
-  ?exclude_system:bool ->
-  ?exclude_automation:bool ->
-  ?limit:int ->
-  ?offset:int ->
-  ?voter:string ->
-  ?blind_votes:bool ->
-  unit ->
-  Yojson.Safe.t
 
 val dashboard_memory_http_json :
   ?config:Workspace.config -> Httpun.Request.t -> Yojson.Safe.t
@@ -96,6 +80,7 @@ val dashboard_gate_retry_http_json :
 
 val dashboard_gate_rule_delete_http_json :
   base_path:string ->
+  deleted_by:string ->
   args:Yojson.Safe.t ->
   (Yojson.Safe.t, string) result
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -574,11 +574,16 @@ let handle_gate_retry_body state operator_name request reqd body_str =
       (operator_error_json (Printf.sprintf "invalid json: %s" message))
 ;;
 
-let handle_gate_rule_delete_body state request reqd body_str =
+let handle_gate_rule_delete_body state operator_name request reqd body_str =
   try
     let args = Yojson.Safe.from_string body_str in
     let base_path = (Mcp_server.workspace_config state).base_path in
-    match dashboard_gate_rule_delete_http_json ~base_path ~args with
+    match
+      dashboard_gate_rule_delete_http_json
+        ~base_path
+        ~deleted_by:operator_name
+        ~args
+    with
     | Ok json -> respond_json_value_with_cors request reqd json
     | Error message ->
       respond_json_value_with_cors
@@ -1220,9 +1225,9 @@ let add_routes ~sw ~clock router =
          request reqd)
   |> Http.Router.post "/api/v1/dashboard/gate/rules/delete" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
-         (fun state _operator_name _req reqd ->
+         (fun state operator_name _req reqd ->
            Http.Request.read_body_async reqd
-             (handle_gate_rule_delete_body state request reqd))
+             (handle_gate_rule_delete_body state operator_name request reqd))
          request reqd)
 
   |> Http.Router.get "/api/v1/operator" (fun request reqd ->

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -464,9 +464,9 @@ let turn_admission_rows ~base_path keeper_name =
 
 let hitl_rows keeper_name pending =
   pending
-  |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+  |> List.filter (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
     String.equal entry.keeper_name keeper_name)
-  |> List.map (fun (entry : Keeper_approval_queue.pending_approval) ->
+  |> List.map (fun (entry : Keeper_approval_queue_rules_types.pending_approval) ->
     { keeper_name = Some keeper_name
     ; source = Hitl_pending
     ; waiting_on = entry.tool_name
@@ -478,10 +478,10 @@ let hitl_rows keeper_name pending =
         `Assoc
           [ "approval_id", `String entry.id
           ; "tool_name", `String entry.tool_name
-          ; "summary_status", Keeper_approval_queue.summary_status_to_yojson entry.summary_status
-          ; "exact_attempt", Keeper_approval_queue.exact_attempt_state_to_yojson entry.exact_attempt
+          ; "summary_status", Keeper_approval_queue_rules_types.summary_status_to_yojson entry.summary_status
+          ; "exact_attempt", Keeper_approval_queue_rules_types.exact_attempt_state_to_yojson entry.exact_attempt
           ; ( "summary_attempt_disposition"
-            , Keeper_approval_queue.summary_attempt_disposition_to_yojson
+            , Keeper_approval_queue_rules_types.summary_attempt_disposition_to_yojson
                 entry.summary_attempt_disposition )
           ; "turn_id", Json_util.int_opt_to_json entry.turn_id
           ; "task_id", Json_util.string_opt_to_json entry.task_id

--- a/lib/server_keeper_waiting_inventory.mli
+++ b/lib/server_keeper_waiting_inventory.mli
@@ -13,7 +13,7 @@ module For_testing : sig
   val dashboard_json_with_pending_reader :
     read_pending:
       (base_path:string ->
-      ( Keeper_approval_queue.pending_approval list
+      ( Keeper_approval_queue_rules_types.pending_approval list
       , Keeper_approval_queue.storage_error )
       result) ->
     Workspace.config ->

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -95,7 +95,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # test_tool_workspace_coverage while it was open. Measured on the merged tree --
 # the audit reported "706 unwired, 707 baseline" so 707 would have passed while
 # leaving the ratchet a notch loose.
-UNWIRED_BASELINE=706
+UNWIRED_BASELINE=701
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -552,7 +552,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # Removing a live export and its only call site leaves the dead count where it
 # was. Measured with --exports on the merged tree -- 563 - 1 assumed the export
 # was dead, and it was not.
-DEAD_EXPORT_BASELINE = 556
+DEAD_EXPORT_BASELINE = 544
 
 
 def run_ratchet(count: int) -> int:

--- a/scripts/audit-sublib-cycle.py
+++ b/scripts/audit-sublib-cycle.py
@@ -64,6 +64,7 @@ DEFAULT_LEAVES: tuple[str, ...] = (
     # RFC-0056 Phase 1N: Keeper deterministic lifecycle FSM cluster.
     "masc.keeper_registry",
     "masc.keeper_contract",
+    "masc.keeper_approval",
     "masc.keeper_runtime",
     "masc.keeper_tooling",
     # Model inference aggregate domain and its runtime label boundary.
@@ -101,7 +102,6 @@ DEFAULT_LEAVES: tuple[str, ...] = (
     "masc.keeper_binding_health_config",
     "masc.keeper_transition_audit_types",
     "masc.keeper_path_rejection",
-    "masc.keeper_approval_queue_rules_types",
     "masc.keeper_toml_parser",
     "masc.keeper_toml_loader",
     "masc.keeper_runtime_config",

--- a/scripts/check-execute-async-surface.sh
+++ b/scripts/check-execute-async-surface.sh
@@ -29,26 +29,14 @@ require_normalized_text() {
   fi
 }
 
-reject_text() {
-  local file="$1"
-  local needle="$2"
-  local label="$3"
-
-  if grep -Fq -- "$needle" "${ROOT}/${file}"; then
-    echo "execute-async-surface: forbidden ${label}: ${file}" >&2
-    echo "  forbidden text: ${needle}" >&2
-    exit 1
-  fi
-}
-
 require_text \
   "docs/EXECUTE-RUNBOOK.md" \
   "Execute is typed-only: callers provide" \
   "typed-only Execute runbook claim"
 require_normalized_text \
   "docs/EXECUTE-RUNBOOK.md" \
-  "old background task lifecycle are not part of the callable surface" \
-  "background lifecycle exclusion in Execute runbook"
+  "no background shell lifecycle surface anywhere below it" \
+  "synchronous Execute boundary in runbook"
 require_normalized_text \
   "docs/EXECUTE-RUNBOOK.md" \
   "It does not expose \`job_id\`, \`request_id\`, \`poll\`, or \`cancel\` fields." \
@@ -62,39 +50,18 @@ require_normalized_text \
   "lib/tool_surface/tool_shard_types_schemas_execute.ml" \
   "this tool does not expose background task lifecycle tools" \
   "typed Execute background lifecycle exclusion"
-reject_text \
-  "lib/tool_surface/tool_shard_types_schemas_execute.ml" \
-  "run_in_background" \
-  "legacy Execute background flag"
-reject_text \
-  "lib/tool_surface/tool_shard_types_schemas_execute.ml" \
-  "job_id" \
-  "Execute async job id field"
-reject_text \
-  "lib/tool_surface/tool_shard_types_schemas_execute.ml" \
-  "backgroundTaskId" \
-  "Execute legacy background task id field"
-
 require_text \
   "test/test_tool_input_validation.ml" \
-  "legacy background flag not exposed" \
-  "schema rejection proof"
+  "test_tool_execute_schema_exposes_typed_boundary" \
+  "typed schema proof"
 require_text \
   "test/test_tool_input_validation.ml" \
-  "test_validate_args_tool_execute_rejects_background_flag" \
-  "validation rejection proof"
+  "test_validate_args_tool_execute_accepts_typed_exec" \
+  "typed exec validation proof"
 require_text \
   "test/test_tool_input_validation.ml" \
-  "test_validate_args_tool_execute_rejects_async_lifecycle_fields" \
-  "async lifecycle field rejection proof"
-require_text \
-  "test/test_tool_input_validation.ml" \
-  "job_id" \
-  "async job id rejection proof"
-require_text \
-  "test/test_tool_input_validation.ml" \
-  "backgroundTaskId" \
-  "legacy background task id rejection proof"
+  "test_validate_args_tool_execute_accepts_typed_pipeline" \
+  "typed pipeline validation proof"
 
 require_text \
   "lib/keeper/keeper_msg_async.mli" \

--- a/scripts/keeper-cwd-leak-gate.sh
+++ b/scripts/keeper-cwd-leak-gate.sh
@@ -63,9 +63,9 @@ if [ "${failures}" -gt 0 ]; then
   echo "" >&2
   echo "${failures} host_cwd leak(s) detected near a (\"via\", \`String \"docker\") tag." >&2
   echo "Wire the response builder through Keeper_cwd_response.to_yojson_response." >&2
-  echo "Reference: lib/keeper/keeper_cwd_response.mli (PR #11323), and the wiring patterns in" >&2
+  echo "Reference: lib/keeper/keeper_cwd_response.mli and the wiring patterns in" >&2
   echo "  lib/keeper/keeper_sandbox_docker.ml" >&2
-  echo "  lib/keeper/keeper_tool_command_runtime.ml (PR #11349)" >&2
+  echo "  lib/keeper/keeper_tool_execute_runtime.ml" >&2
   exit 1
 fi
 

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2658,7 +2658,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
               ~keeper_name:meta.name)
              .snapshot_shutdown_operation_id);
       (match Approval_queue.For_testing.get_pending_entry_unchecked ~id:approval_id with
-       | Some { summary_status = Approval_queue.Summary_pending; _ } -> ()
+       | Some { summary_status = Keeper_approval_queue_rules_types.Summary_pending; _ } -> ()
        | Some _ | None -> fail "retain-meta shutdown changed pending summary");
       match Keeper_meta_store.read_meta config meta.name with
       | Ok (Some retained) ->
@@ -2796,7 +2796,7 @@ let test_destructive_shutdown_drains_bound_summary_then_completes () =
                  ~call_id:"shutdown-call"
                  ~plan_fingerprint:(String.make 64 'p')
                  ~request_body_sha256:(String.make 64 'a')
-                 ~cause:Approval_queue.Exact_flow_execution_failed
+                 ~cause:Keeper_approval_queue_rules_types.Exact_flow_execution_failed
              with
              | Ok _ -> ()
              | Error error ->

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -272,7 +272,7 @@ let test_parse_typed_judgments () =
          | Error reason -> fail reason
        in
        check bool wire true (summary.judgment = expected))
-    [ "approve", Q.Approve; "deny", Q.Deny; "require_human", Q.Require_human ]
+    [ "approve", Keeper_approval_queue_rules_types.Approve; "deny", Keeper_approval_queue_rules_types.Deny; "require_human", Keeper_approval_queue_rules_types.Require_human ]
 ;;
 
 let test_invalid_judgment_fails_loud () =
@@ -493,9 +493,9 @@ let test_flow_order_completion_and_replay () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
         | Some
             { exact_attempt =
-                Q.Exact_bound
-                  { slot_id = "hitl-first"; status = Q.Exact_completed; _ }
-            ; summary_status = Q.Summary_available _
+                Keeper_approval_queue_rules_types.Exact_bound
+                  { slot_id = "hitl-first"; status = Keeper_approval_queue_rules_types.Exact_completed; _ }
+            ; summary_status = Keeper_approval_queue_rules_types.Summary_available _
             ; _
             } ->
           ()
@@ -565,8 +565,8 @@ let test_predispatch_failure_advances_only_to_oas_successor () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
-                 { slot_id = "hitl-successor"; status = Q.Exact_completed; _ }
+               Keeper_approval_queue_rules_types.Exact_bound
+                 { slot_id = "hitl-successor"; status = Keeper_approval_queue_rules_types.Exact_completed; _ }
            ; _
            } ->
          ()
@@ -642,12 +642,12 @@ let test_cancellation_between_candidates_terminalizes_released_identity () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
+               Keeper_approval_queue_rules_types.Exact_bound
                  { slot_id = "hitl-cancel-between-unreachable"
-                 ; status = Q.Exact_quarantined Q.Exact_cancellation
+                 ; status = Keeper_approval_queue_rules_types.Exact_quarantined Keeper_approval_queue_rules_types.Exact_cancellation
                  ; _
                  }
-           ; summary_attempt_disposition = Q.Summary_attempt_settled
+           ; summary_attempt_disposition = Keeper_approval_queue_rules_types.Summary_attempt_settled
            ; _
            } ->
          ()
@@ -735,10 +735,10 @@ let test_json_syntax_candidate_is_admitted_without_structured_capability () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
-                 { status = Q.Exact_quarantined Q.Exact_flow_execution_failed; _ }
-           ; summary_status = Q.Summary_failed _
-           ; summary_attempt_disposition = Q.Summary_attempt_settled
+               Keeper_approval_queue_rules_types.Exact_bound
+                 { status = Keeper_approval_queue_rules_types.Exact_quarantined Keeper_approval_queue_rules_types.Exact_flow_execution_failed; _ }
+           ; summary_status = Keeper_approval_queue_rules_types.Summary_failed _
+           ; summary_attempt_disposition = Keeper_approval_queue_rules_types.Summary_attempt_settled
            ; _
            } ->
          ()
@@ -779,9 +779,9 @@ let test_visible_bind_blocks_dispatch () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
+               Keeper_approval_queue_rules_types.Exact_bound
                  { status =
-                     Q.Exact_quarantined Q.Exact_terminal_persistence_failure
+                     Keeper_approval_queue_rules_types.Exact_quarantined Keeper_approval_queue_rules_types.Exact_terminal_persistence_failure
                  ; _
                  }
            ; _
@@ -827,9 +827,9 @@ let test_visible_advance_blocks_successor () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
+               Keeper_approval_queue_rules_types.Exact_bound
                  { status =
-                     Q.Exact_quarantined Q.Exact_terminal_persistence_failure
+                     Keeper_approval_queue_rules_types.Exact_quarantined Keeper_approval_queue_rules_types.Exact_terminal_persistence_failure
                  ; _
                  }
            ; _
@@ -880,8 +880,8 @@ let test_visible_completion_blocks_gate_delivery () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound { status = Q.Exact_completed; _ }
-           ; summary_status = Q.Summary_available _
+               Keeper_approval_queue_rules_types.Exact_bound { status = Keeper_approval_queue_rules_types.Exact_completed; _ }
+           ; summary_status = Keeper_approval_queue_rules_types.Summary_available _
            ; _
            } ->
          ()
@@ -901,8 +901,8 @@ let test_visible_completion_blocks_gate_delivery () =
        check int "restart did not dispatch successor" 1 (F.post_count server);
        (match Q.For_testing.get_pending_entry_unchecked ~id:successor.id with
         | Some
-            { exact_attempt = Q.Exact_unbound
-            ; summary_status = Q.Summary_pending
+            { exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound
+            ; summary_status = Keeper_approval_queue_rules_types.Summary_pending
             ; _
             } ->
           ()
@@ -937,7 +937,7 @@ let test_completion_identity_conflict_stays_deterministic () =
        let replacement_call_id = "replacement-call" in
        let replace_bound_identity () =
          match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
-         | Some { exact_attempt = Q.Exact_bound binding; _ } ->
+         | Some { exact_attempt = Keeper_approval_queue_rules_types.Exact_bound binding; _ } ->
            let transition_exn operation = function
              | Ok { Q.write_outcome = Q.Fsync_completed; _ } -> ()
              | Ok { Q.write_outcome = Q.Visible_sync_unconfirmed detail; _ } ->
@@ -966,7 +966,7 @@ let test_completion_identity_conflict_stays_deterministic () =
              ~plan_fingerprint:(String.make 64 'a')
              ~request_body_sha256:(String.make 64 'b')
            |> transition_exn "bind replacement identity"
-         | Some { exact_attempt = Q.Exact_unbound; _ } ->
+         | Some { exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound; _ } ->
            fail "after_bind observed an unbound exact attempt"
          | None -> fail "after_bind lost the pending approval"
        in
@@ -999,9 +999,9 @@ let test_completion_identity_conflict_stays_deterministic () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound { call_id; status = Q.Exact_dispatch_uncertain; _ }
-           ; summary_status = Q.Summary_pending
-           ; summary_attempt_disposition = Q.Summary_attempt_in_flight
+               Keeper_approval_queue_rules_types.Exact_bound { call_id; status = Keeper_approval_queue_rules_types.Exact_dispatch_uncertain; _ }
+           ; summary_status = Keeper_approval_queue_rules_types.Summary_pending
+           ; summary_attempt_disposition = Keeper_approval_queue_rules_types.Summary_attempt_in_flight
            ; _
            } ->
          check string
@@ -1042,14 +1042,14 @@ let test_flow_execution_failure_quarantines_and_allows_successor () =
         | Some
             { input_hash
             ; sequence
-            ; summary_status = Q.Summary_failed { reason }
+            ; summary_status = Keeper_approval_queue_rules_types.Summary_failed { reason }
             ; exact_attempt =
-                Q.Exact_bound
+                Keeper_approval_queue_rules_types.Exact_bound
                   { slot_id
                   ; call_id
                   ; plan_fingerprint
                   ; request_body_sha256
-                  ; status = Q.Exact_quarantined Q.Exact_flow_execution_failed
+                  ; status = Keeper_approval_queue_rules_types.Exact_quarantined Keeper_approval_queue_rules_types.Exact_flow_execution_failed
                   ; _
                   }
             ; _
@@ -1111,7 +1111,7 @@ let test_manual_resolution_race_is_conclusive () =
        install_queue base_path;
        Prompt_registry.set_markdown_dir
          (Masc_test_deps.source_path "config/prompts");
-       let in_flight_entry : Q.pending_approval option ref = ref None in
+       let in_flight_entry : Keeper_approval_queue_rules_types.pending_approval option ref = ref None in
        let server =
          F.start_server
            ~on_request_before_reply:(fun () ->
@@ -1122,7 +1122,11 @@ let test_manual_resolution_race_is_conclusive () =
                   Q.resolve_with_policy
                     ~base_path
                     ~id:entry.id
-                    ~decision:(Q.Decision.Reject "manual operator resolution")
+                    ~decision:(Keeper_approval_queue_rules_types.Decision.Reject "manual operator resolution")
+                    ~source:Keeper_approval_queue_rules_types.Human_operator
+                    ~remember_rule:false
+                    ~rule_expires_at:None
+                    ~created_by:"test-operator"
                     ()
                 with
                 | Ok _ -> ()
@@ -1215,8 +1219,8 @@ let test_cancellation_after_dispatch_is_terminal () =
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound
-                 { status = Q.Exact_quarantined Q.Exact_cancellation; _ }
+               Keeper_approval_queue_rules_types.Exact_bound
+                 { status = Keeper_approval_queue_rules_types.Exact_quarantined Keeper_approval_queue_rules_types.Exact_cancellation; _ }
            ; _
            } ->
          ()
@@ -1402,19 +1406,19 @@ let test_prebind_cancellation_withholds_production_gate_drain () =
               (F.post_count server);
             (match Q.For_testing.get_pending_entry_unchecked ~id:cancelled.id with
              | Some
-                 { exact_attempt = Q.Exact_unbound
-                 ; summary_status = Q.Summary_pending
+                 { exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound
+                 ; summary_status = Keeper_approval_queue_rules_types.Summary_pending
                  ; summary_attempt_disposition =
-                     Q.Summary_attempt_identity_unbound
+                     Keeper_approval_queue_rules_types.Summary_attempt_identity_unbound
                  ; _
                  } ->
                ()
              | _ -> fail "Gate drained or mutated the cancelled pending entry");
             match Q.For_testing.get_pending_entry_unchecked ~id:successor.id with
             | Some
-                { exact_attempt = Q.Exact_unbound
-                ; summary_status = Q.Summary_pending
-                ; summary_attempt_disposition = Q.Summary_attempt_ready
+                { exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound
+                ; summary_status = Keeper_approval_queue_rules_types.Summary_pending
+                ; summary_attempt_disposition = Keeper_approval_queue_rules_types.Summary_attempt_ready
                 ; _
                 } ->
               ()
@@ -1512,8 +1516,8 @@ let test_bound_cancellation_cleanup_uncertainty_preserves_origin () =
               (F.post_count server);
             match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
             | Some
-                { exact_attempt = Q.Exact_bound _
-                ; summary_status = Q.Summary_pending
+                { exact_attempt = Keeper_approval_queue_rules_types.Exact_bound _
+                ; summary_status = Keeper_approval_queue_rules_types.Summary_pending
                 ; _
                 } ->
               ()
@@ -1547,12 +1551,12 @@ let test_pre_worker_start_failure_preserves_unbound_pending () =
         | Ok _ -> fail "pre-worker failure was reported as a successful start");
        (match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
-           { exact_attempt = Q.Exact_unbound
-           ; summary_status = Q.Summary_pending
+           { exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound
+           ; summary_status = Keeper_approval_queue_rules_types.Summary_pending
            ; summary_attempt_disposition =
-               Q.Summary_attempt_pre_worker_unavailable
+               Keeper_approval_queue_rules_types.Summary_attempt_pre_worker_unavailable
                  { reason_code =
-                     Q.Summary_pre_worker_auto_judge_unavailable
+                     Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
                  ; operator_detail = "no usable exact-output lane slots"
                  }
            ; _
@@ -1633,18 +1637,18 @@ let test_visible_uncertainty_withholds_production_drain () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:uncertain.id with
        | Some
            { exact_attempt =
-               Q.Exact_bound { status = Q.Exact_completed; _ }
-           ; summary_status = Q.Summary_available _
+               Keeper_approval_queue_rules_types.Exact_bound { status = Keeper_approval_queue_rules_types.Exact_completed; _ }
+           ; summary_status = Keeper_approval_queue_rules_types.Summary_available _
            ; summary_attempt_disposition =
-               Q.Summary_attempt_persistence_uncertain
+               Keeper_approval_queue_rules_types.Summary_attempt_persistence_uncertain
            ; _
            } ->
          ()
        | _ -> fail "uncertain completion did not remain durably visible");
        (match Q.For_testing.get_pending_entry_unchecked ~id:successor.id with
         | Some
-            { exact_attempt = Q.Exact_unbound
-            ; summary_status = Q.Summary_pending
+            { exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound
+            ; summary_status = Keeper_approval_queue_rules_types.Summary_pending
             ; _
             } ->
           ()
@@ -1716,8 +1720,8 @@ let test_owner_fifo_atomic_drain_is_nonsharing () =
          (F.post_count server);
        (match Q.For_testing.get_pending_entry_unchecked ~id:second.id with
         | Some
-            { exact_attempt = Q.Exact_unbound
-            ; summary_status = Q.Summary_pending
+            { exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound
+            ; summary_status = Keeper_approval_queue_rules_types.Summary_pending
             ; _
             } ->
           ()
@@ -1802,10 +1806,10 @@ let test_require_human_head_does_not_stop_owner_drain () =
        (match Q.For_testing.get_pending_entry_unchecked ~id:head.id with
         | Some
             { exact_attempt =
-                Q.Exact_bound { status = Q.Exact_completed; _ }
+                Keeper_approval_queue_rules_types.Exact_bound { status = Keeper_approval_queue_rules_types.Exact_completed; _ }
             ; summary_status =
-                Q.Summary_available { judgment = Q.Require_human; _ }
-            ; summary_attempt_disposition = Q.Summary_attempt_settled
+                Keeper_approval_queue_rules_types.Summary_available { judgment = Keeper_approval_queue_rules_types.Require_human; _ }
+            ; summary_attempt_disposition = Keeper_approval_queue_rules_types.Summary_attempt_settled
             ; _
             } ->
           ()
@@ -1834,13 +1838,13 @@ let test_judge_effect_prompt_comes_from_registry () =
    Both arms are pinned here because the decision is now a named function and
    the outcome type has a variant for each. *)
 
-let summary_fixture () : Q.hitl_context_summary =
-  { summary_version = Q.current_hitl_context_summary_version
+let summary_fixture () : Keeper_approval_queue_rules_types.hitl_context_summary =
+  { summary_version = Keeper_approval_queue_rules_types.current_hitl_context_summary_version
   ; generated_at = 1000.0
   ; model_run_id = "run-fixture"
   ; context_summary = "context"
   ; key_questions = [ "q1" ]
-  ; judgment = Q.Approve
+  ; judgment = Keeper_approval_queue_rules_types.Approve
   ; rationale = "because"
   }
 ;;

--- a/test/test_keeper_approval_audit_timeline.ml
+++ b/test/test_keeper_approval_audit_timeline.ml
@@ -147,12 +147,7 @@ let test_resolution_reads_the_decision_kind () =
     (option string)
     "approve"
     (Some "ok")
-    (field "severity" (rendered ~decision_kind:Audit.Decision_approve Audit.Resolved));
-  check
-    (option string)
-    "edit"
-    (Some "ok")
-    (field "severity" (rendered ~decision_kind:Audit.Decision_edit Audit.Resolved))
+    (field "severity" (rendered ~decision_kind:Audit.Decision_approve Audit.Resolved))
 ;;
 
 (* The old reader scanned the rendered decision for "reject", so an approval
@@ -204,15 +199,15 @@ let test_unknown_spelling_says_so () =
    came from the workspace being in Always_allow mode and 2,100 from a per-keeper
    blanket, while operator-approved exact rules accounted for none. *)
 let every_authorization_source =
-  [ Q.One_shot_resolution
-  ; Q.Exact_always_rule
-  ; Q.Keeper_always_allow
-  ; Q.Workspace_always_allow
+  [ Keeper_approval_queue_rules_types.One_shot_resolution
+  ; Keeper_approval_queue_rules_types.Exact_always_rule
+  ; Keeper_approval_queue_rules_types.Keeper_always_allow
+  ; Keeper_approval_queue_rules_types.Workspace_always_allow
   ]
 ;;
 
 let test_authorization_sources_are_distinct () =
-  let rendered = List.map Q.authorization_source_to_string every_authorization_source in
+  let rendered = List.map Keeper_approval_queue_rules_types.authorization_source_to_string every_authorization_source in
   check (list string) "each authority renders as itself"
     [ "one_shot_resolution"; "exact_always_rule"; "keeper_always_allow";
       "workspace_always_allow" ]
@@ -225,16 +220,16 @@ let test_authorization_sources_are_distinct () =
 let test_authorization_source_round_trips () =
   List.iter
     (fun source ->
-      let spelling = Q.authorization_source_to_string source in
+      let spelling = Keeper_approval_queue_rules_types.authorization_source_to_string source in
       check (option string) ("round-trips: " ^ spelling) (Some spelling)
-        (Option.map Q.authorization_source_to_string
-           (Q.authorization_source_of_string spelling)))
+        (Option.map Keeper_approval_queue_rules_types.authorization_source_to_string
+           (Keeper_approval_queue_rules_types.authorization_source_of_string spelling)))
     every_authorization_source
 ;;
 
 let test_unknown_authorization_source_is_none () =
   check bool "an unknown spelling is not coerced to a default" true
-    (Option.is_none (Q.authorization_source_of_string "always_allowed"))
+    (Option.is_none (Keeper_approval_queue_rules_types.authorization_source_of_string "always_allowed"))
 ;;
 
 let () =

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1,6 +1,7 @@
 module AQ = Masc.Keeper_approval_queue
+module Rules = Masc.Keeper_approval_queue_rules
 
-let reserve_retry_exact ~base_path (entry : AQ.pending_approval) =
+let reserve_retry_exact ~base_path (entry : Keeper_approval_queue_rules_types.pending_approval) =
   AQ.reserve_summary_attempt_retry
     ~base_path
     ~id:entry.id
@@ -21,11 +22,19 @@ module Registry_queue = Masc.Keeper_registry_event_queue
 module Event_queue_persistence = Keeper_event_queue_persistence
 module Reaction_ledger = Masc.Keeper_reaction_ledger
 
-(* Test-local shim for the excised [Keeper_approval_queue.resolve] wrapper:
-   reproduces its unit projection over [resolve_with_policy] so these
-   assertions keep exercising the production resolution path. *)
+(* Unit projection used by assertions that do not inspect the remembered rule. *)
 let aq_resolve ~base_path ~id ~decision =
-  match AQ.resolve_with_policy ~base_path ~id ~decision () with
+  match
+    AQ.resolve_with_policy
+      ~base_path
+      ~id
+      ~decision
+      ~source:Keeper_approval_queue_rules_types.Human_operator
+      ~remember_rule:false
+      ~rule_expires_at:None
+      ~created_by:"test-operator"
+      ()
+  with
   | Ok _ -> Ok ()
   | Error _ as error -> error
 ;;
@@ -139,7 +148,7 @@ let submit ~base_path ~keeper_name ~input =
 ;;
 
 let reject_and_cleanup ~base_path id =
-  match aq_resolve ~base_path ~id ~decision:(AQ.Decision.Reject "test cleanup") with
+  match aq_resolve ~base_path ~id ~decision:(Keeper_approval_queue_rules_types.Decision.Reject "test cleanup") with
   | Ok () -> ()
   | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
 ;;
@@ -407,14 +416,14 @@ let expect_summary_rejection label = function
 ;;
 
 let exact_summary ?(context_summary = "Exact attempt summary") model_run_id :
-    AQ.hitl_context_summary
+    Keeper_approval_queue_rules_types.hitl_context_summary
   =
   { summary_version = 2
   ; generated_at = Unix.gettimeofday ()
   ; model_run_id
   ; context_summary
   ; key_questions = []
-  ; judgment = AQ.Approve
+  ; judgment = Keeper_approval_queue_rules_types.Approve
   ; rationale = "The exact durable attempt supports this judgment."
   }
 ;;
@@ -443,7 +452,7 @@ let delivery_json ~entry ~remember_rule =
     ; "source", `String "human_operator"
     ; "remember_rule", `Bool remember_rule
     ; "rule_expires_at", `Null
-    ; "created_by", `Null
+    ; "created_by", `String "operator"
     ; "grant_consumed", `Bool false
     ]
 ;;
@@ -459,7 +468,7 @@ let test_install_serializes_snapshot_read_with_same_base_mutation () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-             [ "version", `Int 8
+             [ "version", `Int 9
             ; "next_sequence", `Int 1
             ; "pending", `List []
             ; "deliveries", `List []
@@ -610,7 +619,7 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
         | None -> Alcotest.fail "pending request missing"
         | Some entry ->
           Alcotest.(check bool) "summary is not started by queue" true
-            (entry.summary_status = AQ.Summary_not_requested);
+            (entry.summary_status = Keeper_approval_queue_rules_types.Summary_not_requested);
           Alcotest.check (Alcotest.option yojson)
             "exact outer-turn context"
             (Some request_context)
@@ -682,7 +691,7 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
          |> List.concat_map (fun base_path ->
               AQ.list_pending_entries_for_workspace ~base_path
               |> require_ok "read workspace-local FIFO")
-         |> List.map (fun (entry : AQ.pending_approval) -> entry.id)
+         |> List.map (fun (entry : Keeper_approval_queue_rules_types.pending_approval) -> entry.id)
        in
        Alcotest.(check (list string))
          "workspace projections compose deterministic FIFO"
@@ -709,20 +718,20 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
    the oldest for 2416s. *)
 let head_of_line_owner = "head-of-line-owner"
 
-let require_human_summary () : AQ.hitl_context_summary =
-  { summary_version = AQ.current_hitl_context_summary_version
+let require_human_summary () : Keeper_approval_queue_rules_types.hitl_context_summary =
+  { summary_version = Keeper_approval_queue_rules_types.current_hitl_context_summary_version
   ; generated_at = 1.0
   ; model_run_id = "model-run-head-of-line"
   ; context_summary = "head approval was handed to a human"
   ; key_questions = []
-  ; judgment = AQ.Require_human
+  ; judgment = Keeper_approval_queue_rules_types.Require_human
   ; rationale = "operator decision required"
   }
 ;;
 
-let completed_exact_binding (entry : AQ.pending_approval) =
-  AQ.exact_attempt_binding_with_status
-    (AQ.make_exact_attempt_binding
+let completed_exact_binding (entry : Keeper_approval_queue_rules_types.pending_approval) =
+  Keeper_approval_queue_rules_types.exact_attempt_binding_with_status
+    (Keeper_approval_queue_rules_types.make_exact_attempt_binding
        ~approval_id:entry.id
        ~input_hash:entry.input_hash
        ~sequence:entry.sequence
@@ -731,7 +740,7 @@ let completed_exact_binding (entry : AQ.pending_approval) =
        ~plan_fingerprint:"plan-head-of-line"
        ~request_body_sha256:"sha256-head-of-line"
        ())
-    AQ.Exact_completed
+    Keeper_approval_queue_rules_types.Exact_completed
 ;;
 
 let check_owner_selection label ~base_path ~expected entries =
@@ -742,7 +751,7 @@ let check_owner_selection label ~base_path ~expected entries =
       entries
   with
   | [ selected ] ->
-    Alcotest.(check string) label expected selected.AQ.id
+    Alcotest.(check string) label expected selected.id
   | [] -> Alcotest.failf "%s: owner selection returned nothing" label
   | selected ->
     Alcotest.failf "%s: expected one entry, got %d" label (List.length selected)
@@ -776,9 +785,10 @@ let test_terminal_head_does_not_stall_owner_queue () =
          [ follower; head ];
        let judged_head =
          { head with
-           AQ.summary_status = AQ.Summary_available (require_human_summary ())
-         ; AQ.summary_attempt_disposition = AQ.Summary_attempt_settled
-         ; AQ.exact_attempt = AQ.Exact_bound (completed_exact_binding head)
+           Keeper_approval_queue_rules_types.summary_status = Keeper_approval_queue_rules_types.Summary_available (require_human_summary ())
+         ; Keeper_approval_queue_rules_types.summary_attempt_disposition = Keeper_approval_queue_rules_types.Summary_attempt_settled
+         ; Keeper_approval_queue_rules_types.exact_attempt =
+             Keeper_approval_queue_rules_types.Exact_bound (completed_exact_binding head)
          }
        in
        check_owner_selection
@@ -788,10 +798,10 @@ let test_terminal_head_does_not_stall_owner_queue () =
          [ judged_head; follower ];
        let blocked_head =
          { head with
-           AQ.summary_status = AQ.Summary_pending
-         ; AQ.summary_attempt_disposition =
-             AQ.Summary_attempt_pre_worker_unavailable
-               { reason_code = AQ.Summary_pre_worker_auto_judge_unavailable
+           Keeper_approval_queue_rules_types.summary_status = Keeper_approval_queue_rules_types.Summary_pending
+         ; Keeper_approval_queue_rules_types.summary_attempt_disposition =
+             Keeper_approval_queue_rules_types.Summary_attempt_pre_worker_unavailable
+               { reason_code = Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
                ; operator_detail =
                    "HITL summary: exact outer-turn request context is unavailable"
                }
@@ -944,9 +954,16 @@ let test_delivery_wire_shape_drops_request_context () =
            ~input:(`Assoc [ "target", `String "document" ])
            ()
        in
-       (match aq_resolve ~base_path ~id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id ~decision:Keeper_approval_queue_rules_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
+       (match AQ.For_testing.get_delivery_entry_unchecked ~id with
+        | Some entry ->
+          Alcotest.(check bool)
+            "live delivery drops the summary-only request context"
+            true
+            (Option.is_none entry.request_context)
+        | None -> Alcotest.fail "approved request did not create a live delivery");
        let open Yojson.Safe.Util in
        let delivery_entry =
          read_pending_snapshot ~base_path
@@ -959,14 +976,15 @@ let test_delivery_wire_shape_drops_request_context () =
        (match delivery_entry with
         | None -> Alcotest.fail "approved request did not persist a delivery"
         | Some delivery_entry ->
-          Alcotest.check yojson
-            "delivery drops the summary-only request context"
-            `Null
-            (delivery_entry |> member "request_context");
-          Alcotest.check yojson
-            "delivery drops the context version marker"
-            `Null
-            (delivery_entry |> member "request_context_version"));
+          let fields = to_assoc delivery_entry in
+          Alcotest.(check bool)
+            "delivery omits the summary-only request context"
+            true
+            (Option.is_none (List.assoc_opt "request_context" fields));
+          Alcotest.(check bool)
+            "delivery omits the context version marker"
+            true
+            (Option.is_none (List.assoc_opt "request_context_version" fields)));
        let snapshot_bytes = String.length (read_pending_snapshot_bytes ~base_path) in
        Alcotest.(check bool)
          (Printf.sprintf
@@ -975,10 +993,65 @@ let test_delivery_wire_shape_drops_request_context () =
             context_bytes)
          true
          (snapshot_bytes < context_bytes);
-       (* The trimmed delivery shape must still load: the reader keys the
-          version field off request_context presence, so absent is legal. *)
+       (* The delivery reader accepts exactly the context-free delivery shape. *)
        AQ.For_testing.reset_runtime_state ();
        ignore (install_exn ~base_path))
+;;
+
+let test_delivery_rejects_request_context_fields () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       ignore (install_exn ~base_path);
+       let id =
+         submit_with_context
+           ~turn_id:7
+           ~request_context:(`Assoc [ "initial", `Assoc [] ])
+           ~base_path
+           ~keeper_name:"queue-context-free-delivery"
+           ~input:(`Assoc [ "target", `String "document" ])
+           ()
+       in
+       (match
+          aq_resolve
+            ~base_path
+            ~id
+            ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+        with
+        | Ok () -> ()
+        | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
+       let snapshot = read_pending_snapshot ~base_path in
+       let with_request_context =
+         match snapshot with
+         | `Assoc snapshot_fields ->
+           let deliveries =
+             match List.assoc_opt "deliveries" snapshot_fields with
+             | Some (`List [ `Assoc delivery_fields ]) ->
+               let entry =
+                 match List.assoc_opt "entry" delivery_fields with
+                 | Some (`Assoc entry_fields) ->
+                   `Assoc
+                     (("request_context", `Null)
+                      :: ("request_context_version", `Null)
+                      :: entry_fields)
+                 | _ -> Alcotest.fail "delivery entry fixture is missing"
+               in
+               `List
+                 [ `Assoc (("entry", entry) :: List.remove_assoc "entry" delivery_fields) ]
+             | _ -> Alcotest.fail "delivery fixture is missing"
+           in
+           `Assoc
+             (("deliveries", deliveries) :: List.remove_assoc "deliveries" snapshot_fields)
+         | _ -> Alcotest.fail "pending snapshot fixture is not an object"
+       in
+       write_pending_snapshot ~base_path with_request_context;
+       AQ.For_testing.reset_runtime_state ();
+       match AQ.install_persistence ~base_path with
+       | Ok _ -> Alcotest.fail "delivery request-context fields must be rejected"
+       | Error (AQ.Install_storage_failed _) -> ())
 ;;
 
 let test_resolution_is_durable_and_origin_scoped () =
@@ -997,8 +1070,10 @@ let test_resolution_is_durable_and_origin_scoped () =
          AQ.resolve_with_policy
            ~base_path
            ~id
-           ~decision:AQ.Decision.Approve
+           ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+           ~source:Keeper_approval_queue_rules_types.Human_operator
            ~remember_rule:true
+           ~rule_expires_at:None
            ~created_by:"operator"
            ()
        in
@@ -1018,7 +1093,7 @@ let test_resolution_is_durable_and_origin_scoped () =
        in
        (match resolution.decision with
         | Keeper_event_queue.Hitl_approved -> ()
-        | Keeper_event_queue.Hitl_rejected _ | Keeper_event_queue.Hitl_edited _ ->
+        | Keeper_event_queue.Hitl_rejected _ ->
           Alcotest.fail "expected approved resolution");
        (match AQ.approved_resolution_request ~base_path ~id with
         | Ok (Some request) ->
@@ -1036,16 +1111,16 @@ let test_resolution_is_durable_and_origin_scoped () =
                ~approval_id:id));
        Alcotest.(check bool) "exact remembered request matches" true
          (match
-            AQ.find_matching_rule
+            Rules.find_matching_rule
               ~base_path
               ~keeper_name
               ~tool_name:"external-effect"
               ~input
               ()
           with
-          | Ok (AQ.Rule_match_active _) -> true
-          | Ok (AQ.Rule_match_expired _ | AQ.Rule_match_absent) -> false
-          | Error error -> Alcotest.fail (AQ.rule_store_error_to_string error));
+          | Ok (Keeper_approval_queue_rules_types.Rule_match_active _) -> true
+          | Ok (Keeper_approval_queue_rules_types.Rule_match_expired _ | Keeper_approval_queue_rules_types.Rule_match_absent) -> false
+          | Error error -> Alcotest.fail (Keeper_approval_queue_rules_types.rule_store_error_to_string error));
        (match
           AQ.consume_approved_resolution
             ~base_path
@@ -1148,7 +1223,7 @@ let test_resolution_is_durable_and_origin_scoped () =
          true
          (replay_outcome_wire |> member "output_ref" <> `Null);
        Alcotest.(check bool)
-         "current sidecar carries no raw legacy output field"
+         "current sidecar carries no unexpected output field"
          true
          (replay_outcome_wire |> member "output" = `Null);
        let fresh_replay_message =
@@ -1267,17 +1342,23 @@ let test_remembered_rule_carries_requested_expiry () =
          AQ.resolve_with_policy
            ~base_path
            ~id
-           ~decision:AQ.Decision.Approve
+           ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+           ~source:Keeper_approval_queue_rules_types.Human_operator
            ~remember_rule:true
-           ~rule_expires_at:expires_at
+           ~rule_expires_at:(Some expires_at)
            ~created_by:"operator"
            ()
        in
        (match result with
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
-        | Ok { remembered_rule = None } ->
+        | Ok { remembered_rule = None; remember_rule_error = None } ->
           Alcotest.fail "approved remember_rule resolution must persist a rule"
-        | Ok { remembered_rule = Some rule } ->
+        | Ok { remembered_rule = None; remember_rule_error = Some error } ->
+          Alcotest.fail
+            ("remembered rule persistence failed: " ^ AQ.storage_error_to_string error)
+        | Ok { remembered_rule = Some _; remember_rule_error = Some _ } ->
+          Alcotest.fail "remembered rule and persistence error cannot coexist"
+        | Ok { remembered_rule = Some rule; remember_rule_error = None } ->
           Alcotest.(check (option (float 0.0)))
             "rule carries requested expiry"
             (Some expires_at)
@@ -1287,9 +1368,10 @@ let test_remembered_rule_carries_requested_expiry () =
           AQ.resolve_with_policy
             ~base_path
             ~id
-            ~decision:AQ.Decision.Approve
+            ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+            ~source:Keeper_approval_queue_rules_types.Human_operator
             ~remember_rule:true
-            ~rule_expires_at:expires_at
+            ~rule_expires_at:(Some expires_at)
             ~created_by:"operator"
             ()
         with
@@ -1298,8 +1380,8 @@ let test_remembered_rule_carries_requested_expiry () =
           Alcotest.fail
             ("identical expiry re-resolution must be idempotent: "
              ^ AQ.resolve_error_to_string error));
-       match AQ.list_rules ~base_path () with
-       | Error error -> Alcotest.fail (AQ.rule_store_error_to_string error)
+       match Rules.list_rules ~base_path () with
+       | Error error -> Alcotest.fail (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
        | Ok [ rule ] ->
          Alcotest.(check (option (float 0.0)))
            "persisted rule carries requested expiry"
@@ -1337,7 +1419,7 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
            ~input
            ()
        in
-       (match aq_resolve ~base_path ~id:approval_id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id:approval_id ~decision:Keeper_approval_queue_rules_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
@@ -1492,8 +1574,8 @@ let test_exact_binding_codec_validates_entry_identity () =
          |> List.hd
          |> member "exact_attempt"
        in
-       (match AQ.exact_attempt_state_of_yojson_with_error exact_json with
-        | Ok (AQ.Exact_bound binding) ->
+       (match Keeper_approval_queue_rules_types.exact_attempt_state_of_yojson_with_error exact_json with
+        | Ok (Keeper_approval_queue_rules_types.Exact_bound binding) ->
           Alcotest.(check string)
             "codec approval identity"
             identity.approval_id_arg
@@ -1516,7 +1598,7 @@ let test_exact_binding_codec_validates_entry_identity () =
        check_exact_update
          "quarantine exact codec fixture"
          true
-         (quarantine_exact identity AQ.Exact_flow_execution_failed);
+         (quarantine_exact identity Keeper_approval_queue_rules_types.Exact_flow_execution_failed);
        let quarantined_exact_json =
          read_pending_snapshot ~base_path
          |> member "pending"
@@ -1531,13 +1613,13 @@ let test_exact_binding_codec_validates_entry_identity () =
           |> member "quarantine_cause"
           |> to_string);
        (match
-          AQ.exact_attempt_state_of_yojson_with_error quarantined_exact_json
+          Keeper_approval_queue_rules_types.exact_attempt_state_of_yojson_with_error quarantined_exact_json
         with
         | Ok
-            (AQ.Exact_bound
+            (Keeper_approval_queue_rules_types.Exact_bound
               { status =
-                  AQ.Exact_quarantined
-                    AQ.Exact_flow_execution_failed
+                  Keeper_approval_queue_rules_types.Exact_quarantined
+                    Keeper_approval_queue_rules_types.Exact_flow_execution_failed
               ; _
               }) ->
           ()
@@ -1545,26 +1627,17 @@ let test_exact_binding_codec_validates_entry_identity () =
           Alcotest.fail
             "flow execution failure decoded as another exact state"
         | Error reason -> Alcotest.fail reason);
-       List.iter
-         (fun removed_cause ->
-            match
-              AQ.exact_attempt_state_of_yojson_with_error
-                (replace_field
-                   "quarantine_cause"
-                   (`String removed_cause)
-                   quarantined_exact_json)
-            with
-            | Error _ -> ()
-            | Ok _ ->
-              Alcotest.failf
-                "removed quarantine cause %s was decoded"
-                removed_cause)
-         [ "post_dispatch_failure"
-         ; "provenance_mismatch"
-         ; "restart_uncertainty"
-         ];
        (match
-          AQ.exact_attempt_state_of_yojson_with_error
+          Keeper_approval_queue_rules_types.exact_attempt_state_of_yojson_with_error
+            (replace_field
+               "quarantine_cause"
+               (`String "unexpected")
+               quarantined_exact_json)
+        with
+        | Error _ -> ()
+        | Ok _ -> Alcotest.fail "unknown quarantine cause was decoded");
+       (match
+          Keeper_approval_queue_rules_types.exact_attempt_state_of_yojson_with_error
             (replace_field "call_id" (`String " ") exact_json)
         with
         | Error _ -> ()
@@ -1572,7 +1645,7 @@ let test_exact_binding_codec_validates_entry_identity () =
        List.iter
          (fun (label, hash) ->
             match
-              AQ.exact_attempt_state_of_yojson_with_error
+              Keeper_approval_queue_rules_types.exact_attempt_state_of_yojson_with_error
                 (replace_field
                    "request_body_sha256"
                    (`String hash)
@@ -1691,18 +1764,18 @@ let test_exact_attempt_binding_release_and_conflicts () =
          "bound restart is not rearmed"
          false
          (reserve_retry_exact ~base_path (pending_entry_exn id));
-       let quarantine_cause = AQ.Exact_domain_invalid_output in
+       let quarantine_cause = Keeper_approval_queue_rules_types.Exact_domain_invalid_output in
        check_exact_update
          "quarantine replacement"
          true
          (quarantine_exact replacement quarantine_cause);
        (match pending_entry_exn id with
-        | { summary_status = AQ.Summary_failed { reason }
+        | { summary_status = Keeper_approval_queue_rules_types.Summary_failed { reason }
           ; exact_attempt =
-              AQ.Exact_bound
+              Keeper_approval_queue_rules_types.Exact_bound
                 { status =
-                    AQ.Exact_quarantined
-                      AQ.Exact_domain_invalid_output
+                    Keeper_approval_queue_rules_types.Exact_quarantined
+                      Keeper_approval_queue_rules_types.Exact_domain_invalid_output
                 ; _
                 }
           ; _
@@ -1716,7 +1789,7 @@ let test_exact_attempt_binding_release_and_conflicts () =
          "same quarantine cause is idempotent"
          false
          (quarantine_exact replacement quarantine_cause);
-       (match quarantine_exact replacement AQ.Exact_cancellation with
+       (match quarantine_exact replacement Keeper_approval_queue_rules_types.Exact_cancellation with
         | Error
             (AQ.Exact_attempt_rejected
               (AQ.Exact_attempt_status_conflict _)) ->
@@ -1778,9 +1851,9 @@ let test_restart_classifies_uncertain_and_released_recovery () =
          (reserve_retry_exact ~base_path (pending_entry_exn released_id));
        (match pending_entry_exn released_id with
         | { exact_attempt =
-              AQ.Exact_bound
-                { status = AQ.Exact_released_before_dispatch; _ }
-          ; summary_status = AQ.Summary_pending
+              Keeper_approval_queue_rules_types.Exact_bound
+                { status = Keeper_approval_queue_rules_types.Exact_released_before_dispatch; _ }
+          ; summary_status = Keeper_approval_queue_rules_types.Summary_pending
           ; _
           } ->
           ()
@@ -1790,8 +1863,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
        let assert_restart_states label =
          (match pending_entry_exn uncertain_id with
           | { exact_attempt =
-                AQ.Exact_bound
-                  { status = AQ.Exact_restart_quarantined
+                Keeper_approval_queue_rules_types.Exact_bound
+                  { status = Keeper_approval_queue_rules_types.Exact_restart_quarantined
                   ; slot_id
                   ; call_id
                   ; _
@@ -1811,8 +1884,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
               (label ^ " did not quarantine dispatch-uncertain attempt"));
          match pending_entry_exn released_id with
          | { exact_attempt =
-               AQ.Exact_bound
-                 { status = AQ.Exact_released_recovery_required
+               Keeper_approval_queue_rules_types.Exact_bound
+                 { status = Keeper_approval_queue_rules_types.Exact_released_recovery_required
                  ; slot_id
                  ; call_id
                  ; _
@@ -1848,8 +1921,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
          true
          (reserve_retry_exact ~base_path (pending_entry_exn released_id));
        (match pending_entry_exn released_id with
-        | { summary_status = AQ.Summary_pending
-          ; exact_attempt = AQ.Exact_unbound
+        | { summary_status = Keeper_approval_queue_rules_types.Summary_pending
+          ; exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound
           ; _
           } ->
           ()
@@ -1870,8 +1943,8 @@ let test_restart_classifies_uncertain_and_released_recovery () =
          true
          (reserve_retry_exact ~base_path (pending_entry_exn bulk_id));
        match pending_entry_exn bulk_id with
-       | { summary_status = AQ.Summary_pending
-         ; exact_attempt = AQ.Exact_unbound
+       | { summary_status = Keeper_approval_queue_rules_types.Summary_pending
+         ; exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound
          ; _
          } ->
          ()
@@ -1920,9 +1993,9 @@ let test_exact_attempt_completion_is_atomic () =
         | Error error -> Alcotest.fail (AQ.exact_attempt_error_to_string error)
         | Ok _ -> Alcotest.fail "mismatched completion provenance was accepted");
        (match pending_entry_exn id with
-        | { summary_status = AQ.Summary_pending
+        | { summary_status = Keeper_approval_queue_rules_types.Summary_pending
           ; exact_attempt =
-              AQ.Exact_bound { status = AQ.Exact_dispatch_uncertain; _ }
+              Keeper_approval_queue_rules_types.Exact_bound { status = Keeper_approval_queue_rules_types.Exact_dispatch_uncertain; _ }
           ; _
           } ->
           ()
@@ -1933,9 +2006,9 @@ let test_exact_attempt_completion_is_atomic () =
          true
          (complete_exact identity summary);
        (match pending_entry_exn id with
-        | { summary_status = AQ.Summary_available durable_summary
+        | { summary_status = Keeper_approval_queue_rules_types.Summary_available durable_summary
           ; exact_attempt =
-              AQ.Exact_bound { status = AQ.Exact_completed; _ }
+              Keeper_approval_queue_rules_types.Exact_bound { status = Keeper_approval_queue_rules_types.Exact_completed; _ }
           ; _
           } ->
           Alcotest.(check string)
@@ -2006,7 +2079,7 @@ let test_exact_attempt_bind_storage_failure_is_not_success () =
         | Error error -> Alcotest.fail (AQ.exact_attempt_error_to_string error)
         | Ok _ -> Alcotest.fail "failed exact binding persistence reported success");
        match pending_entry_exn id with
-       | { exact_attempt = AQ.Exact_unbound; _ } -> ()
+       | { exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound; _ } -> ()
        | _ -> Alcotest.fail "failed exact binding persistence mutated memory")
 ;;
 
@@ -2034,11 +2107,11 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
        in
        let assert_status label id expected =
          match pending_entry_exn id with
-         | { exact_attempt = AQ.Exact_bound { status; _ }; _ } ->
+         | { exact_attempt = Keeper_approval_queue_rules_types.Exact_bound { status; _ }; _ } ->
            Alcotest.(check string)
              label
              expected
-             (AQ.exact_attempt_status_to_string status)
+             (Keeper_approval_queue_rules_types.exact_attempt_status_to_string status)
          | _ -> Alcotest.failf "%s did not retain an exact binding" label
        in
        let resolved_id =
@@ -2051,7 +2124,11 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
           AQ.resolve_with_policy
             ~base_path
             ~id:resolved_id
-            ~decision:AQ.Decision.Approve
+            ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+            ~source:Keeper_approval_queue_rules_types.Human_operator
+            ~remember_rule:false
+            ~rule_expires_at:None
+            ~created_by:"test-operator"
             ()
         with
         | Ok _ -> ()
@@ -2108,7 +2185,11 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
             AQ.resolve_with_policy
               ~base_path
               ~id:resolved_id
-              ~decision:AQ.Decision.Approve
+              ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+              ~source:Keeper_approval_queue_rules_types.Human_operator
+              ~remember_rule:false
+              ~rule_expires_at:None
+              ~created_by:"test-operator"
               ()
           with
           | Error (AQ.Persistence_failed _) -> ()
@@ -2119,7 +2200,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          AQ.For_testing.reset_runtime_state ();
          ignore (install_exn ~base_path);
          (match pending_entry_exn before_id with
-          | { exact_attempt = AQ.Exact_unbound; _ } -> ()
+          | { exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound; _ } -> ()
           | _ -> Alcotest.fail "pre-rename failure mutated exact binding memory");
          let cancel_before_id, cancel_before_identity =
            prepare "cancel-before-rename"
@@ -2162,7 +2243,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
           | Ok _ ->
             Alcotest.fail "pre-rename cancellation reported a write outcome");
          (match pending_entry_exn cancel_before_id with
-          | { exact_attempt = AQ.Exact_unbound; _ } -> ()
+          | { exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound; _ } -> ()
           | _ -> Alcotest.fail "pre-rename cancellation mutated exact memory");
          let cancel_after_id, cancel_after_identity =
            prepare "cancel-after-rename"
@@ -2214,8 +2295,8 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
               Alcotest.failf
                 "released binding accepted %s"
                 label)
-         [ "domain-invalid output", AQ.Exact_domain_invalid_output
-         ; "attempt replay", AQ.Exact_attempt_replay
+         [ "domain-invalid output", Keeper_approval_queue_rules_types.Exact_domain_invalid_output
+         ; "attempt replay", Keeper_approval_queue_rules_types.Exact_attempt_replay
          ];
        assert_status
          "rejected causes preserve release"
@@ -2226,7 +2307,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          true
          (quarantine_exact
             release_identity
-            AQ.Exact_terminal_persistence_failure);
+            Keeper_approval_queue_rules_types.Exact_terminal_persistence_failure);
        assert_status "release terminal memory" release_id "quarantined";
        let terminalize_released label cause =
          let id, identity = prepare label in
@@ -2248,8 +2329,8 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
            (quarantine_exact identity cause);
          match pending_entry_exn id with
          | { exact_attempt =
-               AQ.Exact_bound
-                 { status = AQ.Exact_quarantined actual; _ }
+               Keeper_approval_queue_rules_types.Exact_bound
+                 { status = Keeper_approval_queue_rules_types.Exact_quarantined actual; _ }
            ; _
            } when actual = cause ->
            ()
@@ -2260,10 +2341,10 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
        in
        terminalize_released
          "release-cancellation"
-         AQ.Exact_cancellation;
+         Keeper_approval_queue_rules_types.Exact_cancellation;
        terminalize_released
          "release-flow-execution-failed"
-         AQ.Exact_flow_execution_failed;
+         Keeper_approval_queue_rules_types.Exact_flow_execution_failed;
        let quarantine_id, quarantine_identity = prepare "quarantine" in
        check_exact_update
          "bind quarantine fixture"
@@ -2281,7 +2362,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
             ~call_id:quarantine_identity.call_id_arg
             ~plan_fingerprint:quarantine_identity.plan_fingerprint_arg
             ~request_body_sha256:quarantine_identity.request_body_sha256_arg
-            ~cause:AQ.Exact_flow_execution_failed);
+            ~cause:Keeper_approval_queue_rules_types.Exact_flow_execution_failed);
        assert_status
          "visible quarantine memory"
          quarantine_id
@@ -2291,7 +2372,7 @@ let test_exact_attempt_staged_durability_and_idempotent_rewrite () =
          false
          (quarantine_exact
             quarantine_identity
-            AQ.Exact_flow_execution_failed);
+            Keeper_approval_queue_rules_types.Exact_flow_execution_failed);
        let complete_id, complete_identity = prepare "complete" in
        check_exact_update
          "bind completion fixture"
@@ -2356,7 +2437,7 @@ let test_exact_completed_restart_requires_fsync_confirmation () =
              ~call_id
              ~plan_fingerprint
              ~request_body_sha256
-             ~summary:(actual_summary : AQ.hitl_context_summary)
+             ~summary:(actual_summary : Keeper_approval_queue_rules_types.hitl_context_summary)
          =
          incr observed_calls;
          Alcotest.(check string) "recovery approval identity" id actual_id;
@@ -2418,7 +2499,7 @@ let test_exact_completed_restart_requires_fsync_confirmation () =
           Alcotest.fail
             "deterministic completion rejection lost its typed recovery code");
        (match AQ.For_testing.get_pending_entry_unchecked ~id with
-        | Some { summary_attempt_disposition = AQ.Summary_attempt_settled; _ } ->
+        | Some { summary_attempt_disposition = Keeper_approval_queue_rules_types.Summary_attempt_settled; _ } ->
           ()
         | _ ->
           Alcotest.fail
@@ -2542,8 +2623,8 @@ let test_current_snapshot_rejects_unbound_available_summary () =
                      then
                        `Assoc
                          (("summary_status",
-                            AQ.summary_status_to_yojson
-                              (AQ.Summary_available summary))
+                            Keeper_approval_queue_rules_types.summary_status_to_yojson
+                              (Keeper_approval_queue_rules_types.Summary_available summary))
                           :: List.remove_assoc "summary_status" entry_fields)
                      else entry_json
                    | entry_json -> entry_json)
@@ -2608,7 +2689,7 @@ let test_blocked_disposition_requires_operator_rearm_before_bind () =
         | Error
             (AQ.Exact_attempt_rejected
                (AQ.Exact_attempt_disposition_conflict
-                  { disposition = AQ.Summary_attempt_identity_unbound; _ })) ->
+                  { disposition = Keeper_approval_queue_rules_types.Summary_attempt_identity_unbound; _ })) ->
           ()
         | Error error ->
           Alcotest.fail
@@ -2656,11 +2737,11 @@ let test_blocked_disposition_requires_operator_rearm_before_bind () =
          (reserve_retry_exact ~base_path retryable_entry);
        (match AQ.For_testing.get_pending_entry_unchecked ~id with
         | Some
-            { summary_status = AQ.Summary_pending
-            ; exact_attempt = AQ.Exact_unbound
+            { summary_status = Keeper_approval_queue_rules_types.Summary_pending
+            ; exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound
             ; summary_attempt_disposition =
-                AQ.Summary_attempt_pre_worker_unavailable
-                  { reason_code = AQ.Summary_pre_worker_start_reserved
+                Keeper_approval_queue_rules_types.Summary_attempt_pre_worker_unavailable
+                  { reason_code = Keeper_approval_queue_rules_types.Summary_pre_worker_start_reserved
                   ; operator_detail
                   }
             ; _
@@ -2714,18 +2795,18 @@ let test_operator_recovery_skips_terminal_exact_failure () =
          true
          (quarantine_exact
             quarantined_identity
-            AQ.Exact_flow_execution_failed);
+            Keeper_approval_queue_rules_types.Exact_flow_execution_failed);
        check_rearm
          "explicit operator action cannot reopen exact quarantine"
          false
          (reserve_retry_exact ~base_path (pending_entry_exn quarantined_id));
        (match AQ.For_testing.get_pending_entry_unchecked ~id:quarantined_id with
         | Some
-            { summary_status = AQ.Summary_failed _
+            { summary_status = Keeper_approval_queue_rules_types.Summary_failed _
             ; exact_attempt =
-                AQ.Exact_bound
+                Keeper_approval_queue_rules_types.Exact_bound
                   { status =
-                      AQ.Exact_quarantined AQ.Exact_flow_execution_failed
+                      Keeper_approval_queue_rules_types.Exact_quarantined Keeper_approval_queue_rules_types.Exact_flow_execution_failed
                   ; _
                   }
             ; _
@@ -2782,8 +2863,8 @@ let test_summary_owner_retirement_is_atomic_and_owner_scoped () =
         | Ok _ -> Alcotest.fail "bound owner retirement succeeded");
        (match AQ.For_testing.get_pending_entry_unchecked ~id:bound with
         | Some
-            { summary_status = AQ.Summary_pending
-            ; exact_attempt = AQ.Exact_bound binding
+            { summary_status = Keeper_approval_queue_rules_types.Summary_pending
+            ; exact_attempt = Keeper_approval_queue_rules_types.Exact_bound binding
             ; _
             } ->
           Alcotest.(check string)
@@ -2793,7 +2874,7 @@ let test_summary_owner_retirement_is_atomic_and_owner_scoped () =
         | Some _ | None ->
           Alcotest.fail "bound entry changed on failed retirement");
        (match AQ.For_testing.get_pending_entry_unchecked ~id:sibling with
-        | Some { summary_status = AQ.Summary_pending; _ } -> ()
+        | Some { summary_status = Keeper_approval_queue_rules_types.Summary_pending; _ } -> ()
         | Some _ | None ->
           Alcotest.fail "blocked retirement partially mutated");
        (match
@@ -2812,7 +2893,7 @@ let test_summary_owner_retirement_is_atomic_and_owner_scoped () =
             ids);
        match AQ.For_testing.get_pending_entry_unchecked ~id:retirable with
        | Some
-           { summary_status = AQ.Summary_failed { reason = "retired" }
+           { summary_status = Keeper_approval_queue_rules_types.Summary_failed { reason = "retired" }
            ; _
            } ->
          ()
@@ -2839,6 +2920,11 @@ let test_dashboard_resolve_rejects_cross_workspace_approval () =
        in
        ignore (install_exn ~base_path:base_b);
        let resolve ~decision ~remember_rule =
+         let decision_fields =
+           if String.equal decision "reject"
+           then [ "reason", `String "wrong workspace" ]
+           else []
+         in
          Server_dashboard_http.dashboard_gate_resolve_http_json
            ~base_path:base_b
            ~created_by:"operator-b"
@@ -2847,7 +2933,8 @@ let test_dashboard_resolve_rejects_cross_workspace_approval () =
                  [ "id", `String approval_id
                  ; "decision", `String decision
                  ; "remember_rule", `Bool remember_rule
-                 ])
+                 ]
+                @ decision_fields)
        in
        List.iter
          (fun (decision, remember_rule) ->
@@ -2874,10 +2961,254 @@ let test_dashboard_resolve_rejects_cross_workspace_approval () =
               "cross-workspace resolve did not persist a rule"
               false
               (Sys.file_exists
-                 (AQ.For_testing.always_allowed_store_path ~base_path)))
+                 (Rules.For_testing.store_path ~base_path)))
          [ base_a; base_b ];
        ignore (install_exn ~base_path:base_a);
        reject_and_cleanup ~base_path:base_a approval_id)
+;;
+
+let test_dashboard_resolve_rejects_malformed_contract_fields () =
+  let base =
+    [ "id", `String "appr-contract"
+    ; "decision", `String "approve"
+    ; "remember_rule", `Bool false
+    ]
+  in
+  let replace field value =
+    (field, value) :: List.remove_assoc field base
+  in
+  let cases =
+    [ ( "decision is exact"
+      , replace "decision" (`String " APPROVE ")
+      , "decision must be 'approve' or 'reject'" )
+    ; ( "remember_rule has exact type"
+      , ("remember_rule", `String "false") :: base
+      , "remember_rule must be a boolean" )
+    ; ( "remember_rule is required"
+      , List.remove_assoc "remember_rule" base
+      , "remember_rule must be a boolean" )
+    ; ( "expiry has exact type"
+      , ("rule_expires_at", `String "tomorrow") :: base
+      , "rule_expires_at must be a number" )
+    ; ( "expiry is finite"
+      , ("rule_expires_at", `Float Float.nan) :: base
+      , "rule_expires_at must be a finite future timestamp" )
+    ; ( "expiry does not accept null"
+      , ("rule_expires_at", `Null) :: base
+      , "rule_expires_at must be a number" )
+    ; ( "expiry requires remembered approval"
+      , ("rule_expires_at", `Float 4102444800.0) :: base
+      , "rule_expires_at requires remember_rule=true" )
+    ; ( "approval has no rejection reason"
+      , ("reason", `String "not applicable") :: base
+      , "reason is valid only for rejection" )
+    ; ( "rejection reason has exact type"
+      , [ "id", `String "appr-contract"
+        ; "decision", `String "reject"
+        ; "reason", `Null
+        ; "remember_rule", `Bool false
+        ]
+      , "reason must be a non-blank string" )
+    ; ( "rejection reason is required"
+      , [ "id", `String "appr-contract"
+        ; "decision", `String "reject"
+        ; "remember_rule", `Bool false
+        ]
+      , "reason is required for rejection" )
+    ; ( "unknown field is rejected"
+      , ("mode", `String "other") :: base
+      , "resolve request contains unsupported field mode" )
+    ; ( "duplicate field is rejected"
+      , ("id", `String "duplicate") :: base
+      , "resolve request contains duplicate field id" )
+    ]
+  in
+  List.iter
+    (fun (label, fields, expected) ->
+       match
+         Server_dashboard_http.dashboard_gate_resolve_http_json
+           ~base_path:"/not-used"
+           ~created_by:"operator"
+           ~args:(`Assoc fields)
+       with
+       | Error (Server_dashboard_http.Bad_request reason) ->
+         Alcotest.(check string) label expected reason
+       | Error error ->
+         Alcotest.fail
+           (Server_dashboard_http.approval_resolve_http_error_to_string error)
+       | Ok _ -> Alcotest.fail (label ^ " must be rejected"))
+    cases
+;;
+
+let test_queue_rejects_invalid_resolution_policy_before_mutation () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       let id =
+         submit
+           ~base_path
+           ~keeper_name:"queue-policy-validation"
+           ~input:(`Assoc [ "request", `String "exact" ])
+       in
+       let future = Unix.gettimeofday () +. 600.0 in
+       let cases =
+         [ ( "blank creator"
+           , fun () ->
+               AQ.resolve_with_policy
+                 ~base_path
+                 ~id
+                 ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+                 ~source:Keeper_approval_queue_rules_types.Human_operator
+                 ~remember_rule:false
+                 ~rule_expires_at:None
+                 ~created_by:" "
+                 () )
+         ; ( "blank rejection reason"
+           , fun () ->
+               AQ.resolve_with_policy
+                 ~base_path
+                 ~id
+                 ~decision:(Keeper_approval_queue_rules_types.Decision.Reject " ")
+                 ~source:Keeper_approval_queue_rules_types.Human_operator
+                 ~remember_rule:false
+                 ~rule_expires_at:None
+                 ~created_by:"test-operator"
+                 () )
+         ; ( "expiry without remembered rule"
+           , fun () ->
+               AQ.resolve_with_policy
+                 ~base_path
+                 ~id
+                 ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+                 ~source:Keeper_approval_queue_rules_types.Human_operator
+                 ~remember_rule:false
+                 ~rule_expires_at:(Some future)
+                 ~created_by:"test-operator"
+                 () )
+         ; ( "remembered rejection"
+           , fun () ->
+               AQ.resolve_with_policy
+                 ~base_path
+                 ~id
+                 ~decision:(Keeper_approval_queue_rules_types.Decision.Reject "operator")
+                 ~source:Keeper_approval_queue_rules_types.Human_operator
+                 ~remember_rule:true
+                 ~rule_expires_at:None
+                 ~created_by:"test-operator"
+                 () )
+         ; ( "non-finite expiry"
+           , fun () ->
+               AQ.resolve_with_policy
+                 ~base_path
+                 ~id
+                 ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+                 ~source:Keeper_approval_queue_rules_types.Human_operator
+                 ~remember_rule:true
+                 ~rule_expires_at:(Some Float.nan)
+                 ~created_by:"test-operator"
+                 () )
+         ]
+       in
+       List.iter
+         (fun (label, resolve) ->
+            (match resolve () with
+             | Error (AQ.Invalid_resolution_policy _) -> ()
+             | Error error ->
+               Alcotest.failf "%s returned %s" label (AQ.resolve_error_to_string error)
+             | Ok _ -> Alcotest.fail (label ^ " must be rejected"));
+            Alcotest.(check bool)
+              (label ^ " keeps pending entry")
+              true
+              (Option.is_some (AQ.For_testing.get_pending_entry_unchecked ~id));
+            Alcotest.(check bool)
+              (label ^ " creates no delivery")
+              true
+              (Option.is_none (AQ.For_testing.get_delivery_entry_unchecked ~id)))
+         cases;
+       match
+         AQ.resolve_with_policy
+           ~base_path
+           ~id
+           ~decision:(Keeper_approval_queue_rules_types.Decision.Reject "operator rejected")
+           ~source:Keeper_approval_queue_rules_types.Human_operator
+           ~remember_rule:false
+           ~rule_expires_at:None
+           ~created_by:"test-operator"
+           ()
+       with
+       | Ok _ -> ()
+       | Error error ->
+         Alcotest.fail
+           ("invalid policy attempt retained a resolution claim: "
+            ^ AQ.resolve_error_to_string error))
+;;
+
+let test_dashboard_resolve_reports_committed_rule_failure () =
+  let base_path = temp_dir () in
+  let keeper_name = "queue-partial-rule-failure" in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       let input = `Assoc [ "request", `String "exact" ] in
+       let id = submit ~base_path ~keeper_name ~input in
+       let rules_path = Rules.For_testing.store_path ~base_path in
+       ensure_dir (Filename.dirname rules_path);
+       Unix.mkdir rules_path 0o755;
+       let resolve () =
+         Server_dashboard_http.dashboard_gate_resolve_http_json
+           ~base_path
+           ~created_by:"operator"
+           ~args:
+             (`Assoc
+                 [ "id", `String id
+                 ; "decision", `String "approve"
+                 ; "remember_rule", `Bool true
+                 ])
+       in
+       let check_partial label = function
+         | Error error ->
+           Alcotest.fail
+             (label ^ ": "
+              ^ Server_dashboard_http.approval_resolve_http_error_to_string error)
+         | Ok json ->
+           let open Yojson.Safe.Util in
+           Alcotest.(check bool) (label ^ " committed") true (json |> member "ok" |> to_bool);
+           Alcotest.(check bool)
+             (label ^ " has no rule id")
+             true
+             Yojson.Safe.(equal (json |> member "rule_id") `Null);
+           Alcotest.(check bool)
+             (label ^ " exposes rule failure")
+             true
+             (String.trim (json |> member "rule_error" |> to_string) <> "")
+       in
+       check_partial "initial resolution" (resolve ());
+       Alcotest.(check bool)
+         "approval reaches the owner despite rule failure"
+         true
+         (Option.is_some (durable_resolution_opt ~base_path ~keeper_name ~approval_id:id));
+       (match
+          AQ.consume_approved_resolution
+            ~base_path
+            ~id
+            ~keeper_name
+            ~tool_name:"external-effect"
+            ~input
+        with
+        | Ok AQ.Consumption_committed -> ()
+        | Ok (AQ.Consumption_already_committed | AQ.Consumption_not_matching) ->
+          Alcotest.fail "committed approval was not consumable"
+        | Error error -> Alcotest.fail (AQ.grant_error_to_string error));
+       check_partial "consumed retry" (resolve ()))
 ;;
 
 let test_malformed_snapshot_fails_install_and_is_observed () =
@@ -2891,7 +3222,7 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 8
+            [ "version", `Int 9
             ; "next_sequence", `Int 1
             ; "pending", `List [ `String "malformed-entry" ]
             ; "deliveries", `List []
@@ -2926,7 +3257,7 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
          (Yojson.Safe.equal
             persisted
             (`Assoc
-               [ "version", `Int 8
+               [ "version", `Int 9
                ; "next_sequence", `Int 1
                ; "pending", `List [ `String "malformed-entry" ]
                ; "deliveries", `List []
@@ -2940,6 +3271,78 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
        Alcotest.(check bool) "malformed snapshot observed" true (after -. before >= 1.0))
 ;;
 
+let test_current_snapshot_requires_nullable_fields () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       ignore
+         (submit
+            ~base_path
+            ~keeper_name:"queue-required-nullable"
+            ~input:(`Assoc [ "request", `String "required-nullable" ]));
+       let pending_entry =
+         match read_pending_snapshot ~base_path with
+         | `Assoc fields ->
+           (match List.assoc_opt "pending" fields with
+            | Some (`List [ entry ]) -> entry
+            | _ -> Alcotest.fail "expected one persisted pending entry")
+         | _ -> Alcotest.fail "expected pending snapshot object"
+       in
+       let delivery_entry =
+         match pending_entry with
+         | `Assoc fields ->
+           `Assoc
+             (fields
+              |> List.remove_assoc "request_context"
+              |> List.remove_assoc "request_context_version")
+         | _ -> Alcotest.fail "expected pending entry object"
+       in
+       let expect_invalid_snapshot label snapshot =
+         AQ.For_testing.reset_runtime_state ();
+         write_pending_snapshot ~base_path snapshot;
+         match AQ.install_persistence ~base_path with
+         | Error (AQ.Install_storage_failed _) -> ()
+         | Ok _ -> Alcotest.fail (label ^ " must reject a missing current field")
+       in
+       List.iter
+         (fun field ->
+            let entry =
+              match pending_entry with
+              | `Assoc fields -> `Assoc (List.remove_assoc field fields)
+              | _ -> assert false
+            in
+            expect_invalid_snapshot
+              ("pending." ^ field)
+              (`Assoc
+                  [ "version", `Int 9
+                  ; "next_sequence", `Int 2
+                  ; "pending", `List [ entry ]
+                  ; "deliveries", `List []
+                  ]))
+         [ "turn_id"; "task_id"; "goal_id" ];
+       List.iter
+         (fun field ->
+            let delivery =
+              match delivery_json ~entry:delivery_entry ~remember_rule:false with
+              | `Assoc fields -> `Assoc (List.remove_assoc field fields)
+              | _ -> assert false
+            in
+            expect_invalid_snapshot
+              ("delivery." ^ field)
+              (`Assoc
+                  [ "version", `Int 9
+                  ; "next_sequence", `Int 2
+                  ; "pending", `List []
+                  ; "deliveries", `List [ delivery ]
+                  ]))
+         [ "rule_expires_at"; "created_by" ])
+;;
+
 let test_unsupported_version_snapshot_requires_runtime_reset () =
   let base_path = temp_dir () in
   Fun.protect
@@ -2951,7 +3354,7 @@ let test_unsupported_version_snapshot_requires_runtime_reset () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 7
+            [ "version", `Int 8
             ; "pending", `List []
             ; "deliveries", `List []
             ]);
@@ -2961,7 +3364,7 @@ let test_unsupported_version_snapshot_requires_runtime_reset () =
         | Error
             (AQ.Install_storage_failed
               { reason =
-                  "gate_pending.version 7 is unsupported (current 8); reset \
+                  "gate_pending.version 8 is unsupported (current 9); reset \
                    runtime state before restarting MASC"
               ; _
               }) ->
@@ -3041,7 +3444,7 @@ let test_malformed_replay_sidecar_is_scoped_and_preserved () =
          (In_channel.with_open_bin sidecar_path In_channel.input_all))
 ;;
 
-let test_replay_sidecar_rejects_raw_output_wire () =
+let test_replay_sidecar_rejects_unknown_output_field () =
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
@@ -3064,7 +3467,7 @@ let test_replay_sidecar_rejects_raw_output_wire () =
                       ; ( "outcome"
                         , `Assoc
                             [ "kind", `String "applied"
-                            ; "output", `String "legacy raw output"
+                            ; "unexpected_output", `String "unexpected"
                             ] )
                       ]
                   ] )
@@ -3078,10 +3481,10 @@ let test_replay_sidecar_rejects_raw_output_wire () =
             sidecar_path
             path
         | Ok _ ->
-          Alcotest.fail "raw replay output wire was not rejected"
+          Alcotest.fail "unknown replay output field was not rejected"
         | Error error ->
           Alcotest.fail
-            ("raw replay output wire blocked the authorization store: "
+            ("unknown replay output field blocked the authorization store: "
              ^ AQ.install_error_to_string error));
        let keeper_name = "queue-ready-despite-raw-replay-wire" in
        let input = `Assoc [ "target", `String "current" ] in
@@ -3090,7 +3493,7 @@ let test_replay_sidecar_rejects_raw_output_wire () =
           aq_resolve
             ~base_path
             ~id:approval_id
-            ~decision:AQ.Decision.Approve
+            ~decision:Keeper_approval_queue_rules_types.Decision.Approve
         with
         | Ok () -> ()
         | Error error ->
@@ -3134,14 +3537,14 @@ let test_replay_sidecar_rejects_raw_output_wire () =
           Alcotest.fail "invalid projection was overwritten automatically");
        let persisted = Yojson.Safe.from_file sidecar_path in
        Alcotest.(check string)
-         "rejected raw output remains untouched"
-         "legacy raw output"
+         "rejected unknown output remains untouched"
+         "unexpected"
          Yojson.Safe.Util.(
            persisted
            |> member "outcomes"
            |> index 0
            |> member "outcome"
-           |> member "output"
+           |> member "unexpected_output"
            |> to_string))
 ;;
 
@@ -3169,20 +3572,30 @@ let test_persisted_delivery_replays_before_origin_wake () =
             | _ -> Alcotest.fail "expected one persisted pending entry")
          | _ -> Alcotest.fail "expected pending snapshot object"
        in
+       let delivery_entry =
+         match pending_entry with
+         | `Assoc fields ->
+           `Assoc
+             (fields
+              |> List.remove_assoc "request_context"
+              |> List.remove_assoc "request_context_version")
+         | _ -> Alcotest.fail "expected pending entry object"
+       in
        write_pending_snapshot
          ~base_path
          (`Assoc
-             [ "version", `Int 8
+             [ "version", `Int 9
             ; "next_sequence", `Int 2
             ; "pending", `List []
             ; ( "deliveries"
               , `List
                   [ `Assoc
-                      [ "entry", pending_entry
+                      [ "entry", delivery_entry
                       ; "decision", `Assoc [ "kind", `String "approve" ]
                       ; "source", `String "human_operator"
                       ; "remember_rule", `Bool false
-                      ; "created_by", `Null
+                      ; "rule_expires_at", `Null
+                      ; "created_by", `String "operator"
                       ; "grant_consumed", `Bool false
                       ]
                   ] )
@@ -3237,14 +3650,23 @@ let test_observed_delivery_preserves_grant_without_replaying_wake () =
        AQ.For_testing.reset_runtime_state ();
        ignore (install_exn ~base_path);
        let id = submit ~base_path ~keeper_name ~input in
+       let rules_path = Rules.For_testing.store_path ~base_path in
+       ensure_dir (Filename.dirname rules_path);
+       Unix.mkdir rules_path 0o755;
        (match
-          aq_resolve
+          AQ.resolve_with_policy
             ~base_path
             ~id
-            ~decision:AQ.Decision.Approve
+            ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+            ~source:Keeper_approval_queue_rules_types.Human_operator
+            ~remember_rule:true
+            ~rule_expires_at:None
+            ~created_by:"operator"
+            ()
         with
-        | Ok () -> ()
-       | Error error ->
+        | Ok { remembered_rule = None; remember_rule_error = Some _ } -> ()
+        | Ok _ -> Alcotest.fail "unavailable rule store was reported as remembered"
+        | Error error ->
           Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
          match
@@ -3303,12 +3725,28 @@ let test_observed_delivery_preserves_grant_without_replaying_wake () =
           Alcotest.fail
             (Reaction_ledger.event_queue_reaction_evidence_error_to_string
                error));
+       Unix.rmdir rules_path;
        AQ.For_testing.reset_runtime_state ();
        let report = install_exn ~base_path in
        Alcotest.(check int)
          "observed wake is not replayed"
          0
          report.replayed_deliveries;
+       Alcotest.(check int)
+         "recovered rule store has no replay failure"
+         0
+         (List.length report.delivery_replay_failures);
+       (match Rules.list_rules ~base_path () with
+        | Ok [ rule ] ->
+          Alcotest.(check (option string))
+            "rule recovered"
+            (Some id)
+            rule.source_approval_id
+        | Ok rules ->
+          Alcotest.failf "one recovered rule expected, got %d" (List.length rules)
+        | Error error ->
+          Alcotest.fail
+            (Keeper_approval_queue_rules_types.rule_store_error_to_string error));
        Alcotest.(check bool)
          "observed wake stays absent after ack"
          true
@@ -3381,7 +3819,7 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-             [ "version", `Int 8
+             [ "version", `Int 9
             ; "next_sequence", `Int 4
             ; "pending", `List []
             ; ( "deliveries"
@@ -3397,7 +3835,7 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
                       ~remember_rule:false
                   ] )
             ]);
-       let rules_path = AQ.For_testing.always_allowed_store_path ~base_path in
+       let rules_path = Rules.For_testing.store_path ~base_path in
        ensure_dir (Filename.dirname rules_path);
        Unix.mkdir rules_path 0o755;
        AQ.For_testing.reset_runtime_state ();
@@ -3479,12 +3917,12 @@ let test_default_auto_judge_defers_without_blocking () =
            (String.length detail > 0);
          (match AQ.For_testing.get_pending_entry_unchecked ~id:approval_id with
           | Some
-              { summary_status = AQ.Summary_pending
-              ; exact_attempt = AQ.Exact_unbound
+              { summary_status = Keeper_approval_queue_rules_types.Summary_pending
+              ; exact_attempt = Keeper_approval_queue_rules_types.Exact_unbound
               ; summary_attempt_disposition =
-                  AQ.Summary_attempt_pre_worker_unavailable
+                  Keeper_approval_queue_rules_types.Summary_attempt_pre_worker_unavailable
                     { reason_code =
-                        AQ.Summary_pre_worker_auto_judge_unavailable
+                        Keeper_approval_queue_rules_types.Summary_pre_worker_auto_judge_unavailable
                     ; operator_detail
                     }
               ; _
@@ -3522,7 +3960,7 @@ let test_unavailable_cycle_grant_never_falls_through () =
     (fun () ->
        ignore (install_exn ~base_path);
        let approval_id = submit ~base_path ~keeper_name ~input in
-       (match aq_resolve ~base_path ~id:approval_id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id:approval_id ~decision:Keeper_approval_queue_rules_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
@@ -3564,7 +4002,7 @@ let test_unavailable_cycle_grant_never_falls_through () =
        drop_resolution ~base_path ~keeper_name resolution)
 ;;
 
-let test_nonapproved_resolution_payload_is_delivered () =
+let test_rejection_payload_is_delivered () =
   let base_path = temp_dir () in
   let keeper_name = "queue-resolution-payload" in
   Fun.protect
@@ -3584,7 +4022,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
           aq_resolve
             ~base_path
             ~id:reject_id
-            ~decision:(AQ.Decision.Reject rationale)
+            ~decision:(Keeper_approval_queue_rules_types.Decision.Reject rationale)
         with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
@@ -3603,35 +4041,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
          "rejection is not a grant"
          true
          (Option.is_none (Gate.cycle_grant_of_resolution rejected));
-       let edit_id =
-         submit
-           ~base_path
-           ~keeper_name
-           ~input:(`Assoc [ "target", `String "before" ])
-       in
-       let edited_input =
-         `Assoc [ "target", `String "after"; "confirmed", `Bool true ]
-       in
-       (match aq_resolve ~base_path ~id:edit_id ~decision:(AQ.Decision.Edit edited_input) with
-        | Ok () -> ()
-        | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
-       let edited =
-         durable_resolution_opt ~base_path ~keeper_name ~approval_id:edit_id
-         |> require_some "edited resolution was not delivered"
-       in
-       (match edited.decision with
-        | Keeper_event_queue.Hitl_edited actual ->
-          Alcotest.(check bool)
-            "edited input"
-            true
-            (Yojson.Safe.equal edited_input actual)
-        | _ -> Alcotest.fail "edited resolution lost its typed input");
-       Alcotest.(check bool)
-         "edit is not a grant"
-         true
-         (Option.is_none (Gate.cycle_grant_of_resolution edited));
-       drop_resolution ~base_path ~keeper_name rejected;
-       drop_resolution ~base_path ~keeper_name edited)
+       drop_resolution ~base_path ~keeper_name rejected)
 ;;
 
 (* #26126: resolution writes the judge evidence the entry carried onto the
@@ -3649,7 +4059,7 @@ let test_resolved_audit_event_carries_judge_evidence () =
        let id =
          submit ~base_path ~keeper_name ~input:(`Assoc [ "target", `String "doc" ])
        in
-       (match aq_resolve ~base_path ~id ~decision:AQ.Decision.Approve with
+       (match aq_resolve ~base_path ~id ~decision:Keeper_approval_queue_rules_types.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let history =
@@ -3674,7 +4084,7 @@ let test_resolved_audit_event_carries_judge_evidence () =
            (row |> member "summary_status");
          Alcotest.check yojson
            "exact_attempt recorded at resolution"
-           (AQ.exact_attempt_state_to_yojson AQ.Exact_unbound)
+           (Keeper_approval_queue_rules_types.exact_attempt_state_to_yojson Keeper_approval_queue_rules_types.Exact_unbound)
            (row |> member "exact_attempt"))
 ;;
 
@@ -3763,6 +4173,18 @@ let () =
             `Quick
             test_dashboard_resolve_rejects_cross_workspace_approval
         ; Alcotest.test_case
+            "dashboard resolve rejects malformed contract fields"
+            `Quick
+            test_dashboard_resolve_rejects_malformed_contract_fields
+        ; Alcotest.test_case
+            "queue rejects invalid resolution policy before mutation"
+            `Quick
+            test_queue_rejects_invalid_resolution_policy_before_mutation
+        ; Alcotest.test_case
+            "dashboard resolve exposes committed rule failure"
+            `Quick
+            test_dashboard_resolve_reports_committed_rule_failure
+        ; Alcotest.test_case
             "operator recovery skips terminal exact failures"
             `Quick
             test_operator_recovery_skips_terminal_exact_failure
@@ -3791,6 +4213,10 @@ let () =
             `Quick
             test_unsupported_version_snapshot_requires_runtime_reset
         ; Alcotest.test_case
+            "current snapshot requires nullable fields"
+            `Quick
+            test_current_snapshot_requires_nullable_fields
+        ; Alcotest.test_case
             "unreadable current snapshot is preserved"
             `Quick
             test_unreadable_snapshot_fails_closed_and_is_preserved
@@ -3799,9 +4225,9 @@ let () =
             `Quick
             test_malformed_replay_sidecar_is_scoped_and_preserved
         ; Alcotest.test_case
-            "raw replay output wire is rejected"
+            "unknown replay output field is rejected"
             `Quick
-            test_replay_sidecar_rejects_raw_output_wire
+            test_replay_sidecar_rejects_unknown_output_field
         ; Alcotest.test_case
             "delivery journal replays"
             `Quick
@@ -3827,13 +4253,17 @@ let () =
             `Quick
             test_unavailable_cycle_grant_never_falls_through
         ; Alcotest.test_case
-            "non-approved resolution payload is delivered"
+            "rejection payload is delivered"
             `Quick
-            test_nonapproved_resolution_payload_is_delivered
+            test_rejection_payload_is_delivered
         ; Alcotest.test_case
             "delivery wire shape drops the request context"
             `Quick
             test_delivery_wire_shape_drops_request_context
+        ; Alcotest.test_case
+            "delivery rejects request-context fields"
+            `Quick
+            test_delivery_rejects_request_context_fields
         ] )
     ]
 ;;

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -3,6 +3,7 @@ open Alcotest
 module AQ = Masc.Keeper_approval_queue
 module Gate = Masc.Keeper_gate
 module Gate_mode = Masc.Keeper_gate_mode
+module Rules = Masc.Keeper_approval_queue_rules
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_approval_queue_rules_" "" in
@@ -32,7 +33,7 @@ let rec ensure_dir path =
 ;;
 
 let write_rules ~base_path json =
-  let path = AQ.For_testing.always_allowed_store_path ~base_path in
+  let path = Rules.For_testing.store_path ~base_path in
   ensure_dir (Filename.dirname path);
   Out_channel.with_open_text path (fun channel ->
     output_string channel (Yojson.Safe.pretty_to_string json))
@@ -40,20 +41,39 @@ let write_rules ~base_path json =
 
 let upsert_exn ~base_path ~input =
   match
-    AQ.upsert_rule
+    Rules.upsert_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
       ~input
+      ~created_by:"operator"
+      ~source_approval_id:"approval-test"
+      ~expires_at:None
       ()
   with
   | Ok result -> result
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
+;;
+
+let upsert_with_expiry_exn ~base_path ~input ~expires_at =
+  match
+    Rules.upsert_rule
+      ~base_path
+      ~keeper_name:"keeper"
+      ~tool_name:"external-effect"
+      ~input
+      ~created_by:"operator"
+      ~source_approval_id:"approval-test"
+      ~expires_at:(Some expires_at)
+      ()
+  with
+  | Ok result -> result
+  | Error error -> fail (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
 ;;
 
 let find ~base_path ~input =
   match
-    AQ.find_matching_rule
+    Rules.find_matching_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
@@ -61,13 +81,13 @@ let find ~base_path ~input =
       ()
   with
   | Ok lookup -> lookup
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
 ;;
 
 let find_active_opt ~base_path ~input =
   match find ~base_path ~input with
-  | AQ.Rule_match_active matched -> Some matched
-  | AQ.Rule_match_expired _ | AQ.Rule_match_absent -> None
+  | Keeper_approval_queue_rules_types.Rule_match_active matched -> Some matched
+  | Keeper_approval_queue_rules_types.Rule_match_expired _ | Keeper_approval_queue_rules_types.Rule_match_absent -> None
 ;;
 
 let test_rule_matches_only_complete_exact_request () =
@@ -101,16 +121,16 @@ let test_rule_matches_only_complete_exact_request () =
          (Option.is_none (find_active_opt ~base_path ~input:changed_nonce));
        check bool "different operation identity cannot match" true
          (match
-            AQ.find_matching_rule
+            Rules.find_matching_rule
               ~base_path
               ~keeper_name:"keeper"
               ~tool_name:"another-effect"
               ~input
               ()
           with
-          | Ok AQ.Rule_match_absent -> true
-          | Ok (AQ.Rule_match_active _ | AQ.Rule_match_expired _) -> false
-          | Error error -> fail (AQ.rule_store_error_to_string error)))
+          | Ok Keeper_approval_queue_rules_types.Rule_match_absent -> true
+          | Ok (Keeper_approval_queue_rules_types.Rule_match_active _ | Keeper_approval_queue_rules_types.Rule_match_expired _) -> false
+          | Error error -> fail (Keeper_approval_queue_rules_types.rule_store_error_to_string error)))
 ;;
 
 let test_equivalent_upsert_is_idempotent () =
@@ -124,6 +144,79 @@ let test_equivalent_upsert_is_idempotent () =
        check bool "first created" true first_created;
        check bool "second reused" false second_created;
        check string "same rule id" first.id second.id)
+;;
+
+let test_existing_rule_requires_the_requested_expiry () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let input = `Assoc [ "request", `String "exact" ] in
+       let expires_at = Unix.gettimeofday () +. 3600.0 in
+       let first, created = upsert_with_expiry_exn ~base_path ~input ~expires_at in
+       check bool "created" true created;
+       let same, same_created = upsert_with_expiry_exn ~base_path ~input ~expires_at in
+       check bool "same expiry reuses" false same_created;
+       check string "same expiry id" first.id same.id;
+       match
+         Rules.upsert_rule
+           ~base_path
+           ~keeper_name:"keeper"
+           ~tool_name:"external-effect"
+           ~input
+           ~created_by:"operator"
+           ~source_approval_id:"approval-test"
+           ~expires_at:None
+           ()
+       with
+       | Ok _ -> fail "different expiry policy must not report success"
+       | Error error ->
+         check
+           string
+           "expiry conflict is explicit"
+           "the exact approval rule has a different expiry"
+           error.reason)
+;;
+
+let test_expired_existing_rule_is_not_reused () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let input = `Assoc [ "request", `String "exact" ] in
+       let active, _ =
+         upsert_with_expiry_exn
+           ~base_path
+           ~input
+           ~expires_at:(Unix.gettimeofday () +. 3600.0)
+       in
+       let expired =
+         { active with
+           Keeper_approval_queue_rules_types.expires_at =
+             Some (Unix.gettimeofday () -. 1.0)
+         }
+       in
+       write_rules
+         ~base_path
+         (`List [ Keeper_approval_queue_rules_types.approval_rule_to_yojson expired ]);
+       match
+         Rules.upsert_rule
+           ~base_path
+           ~keeper_name:"keeper"
+           ~tool_name:"external-effect"
+           ~input
+           ~created_by:"operator"
+           ~source_approval_id:"approval-test"
+           ~expires_at:None
+           ()
+       with
+       | Ok _ -> fail "expired exact rule must not report remembered success"
+       | Error error ->
+         check
+           string
+           "expired conflict is explicit"
+           "the exact approval rule is expired; delete it before creating another"
+           error.reason)
 ;;
 
 let test_gate_allows_only_the_exact_persisted_rule () =
@@ -158,23 +251,9 @@ let test_gate_allows_only_the_exact_persisted_rule () =
          fail (Gate.unavailable_reason_to_string reason))
 ;;
 
-let upsert_with_expiry_exn ~base_path ~input ~expires_at =
-  match
-    AQ.upsert_rule
-      ~base_path
-      ~keeper_name:"keeper"
-      ~tool_name:"external-effect"
-      ~input
-      ~expires_at
-      ()
-  with
-  | Ok result -> result
-  | Error error -> fail (AQ.rule_store_error_to_string error)
-;;
-
 let find_at ~base_path ~input ~now =
   match
-    AQ.find_matching_rule
+    Rules.find_matching_rule
       ~base_path
       ~keeper_name:"keeper"
       ~tool_name:"external-effect"
@@ -183,7 +262,7 @@ let find_at ~base_path ~input ~now =
       ()
   with
   | Ok lookup -> lookup
-  | Error error -> fail (AQ.rule_store_error_to_string error)
+  | Error error -> fail (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
 ;;
 
 let test_unexpired_rule_matches_with_injected_now () =
@@ -192,17 +271,18 @@ let test_unexpired_rule_matches_with_injected_now () =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
        let input = `Assoc [ "request", `String "exact" ] in
+       let expires_at = Unix.gettimeofday () +. 3600.0 in
        let rule, created =
-         upsert_with_expiry_exn ~base_path ~input ~expires_at:2000.0
+         upsert_with_expiry_exn ~base_path ~input ~expires_at
        in
        check bool "created" true created;
-       check (option (float 0.0)) "expiry persisted on rule" (Some 2000.0)
+       check (option (float 0.0)) "expiry persisted on rule" (Some expires_at)
          rule.expires_at;
-       match find_at ~base_path ~input ~now:1999.0 with
-       | AQ.Rule_match_active matched ->
+       match find_at ~base_path ~input ~now:(expires_at -. 1.0) with
+       | Keeper_approval_queue_rules_types.Rule_match_active matched ->
          check string "unexpired rule matches" rule.id matched.rule_id
-       | AQ.Rule_match_expired _ -> fail "unexpired rule reported as expired"
-       | AQ.Rule_match_absent -> fail "unexpired rule did not match")
+       | Keeper_approval_queue_rules_types.Rule_match_expired _ -> fail "unexpired rule reported as expired"
+       | Keeper_approval_queue_rules_types.Rule_match_absent -> fail "unexpired rule did not match")
 ;;
 
 let test_expired_rule_is_reported_and_retained () =
@@ -211,25 +291,26 @@ let test_expired_rule_is_reported_and_retained () =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
        let input = `Assoc [ "request", `String "exact" ] in
-       let rule, _ = upsert_with_expiry_exn ~base_path ~input ~expires_at:2000.0 in
-       (match find_at ~base_path ~input ~now:2000.0 with
-        | AQ.Rule_match_expired matched ->
+       let expires_at = Unix.gettimeofday () +. 3600.0 in
+       let rule, _ = upsert_with_expiry_exn ~base_path ~input ~expires_at in
+       (match find_at ~base_path ~input ~now:expires_at with
+        | Keeper_approval_queue_rules_types.Rule_match_expired matched ->
           check string "expiry boundary is expired" rule.id matched.rule_id
-        | AQ.Rule_match_active _ -> fail "expired rule still matched"
-        | AQ.Rule_match_absent -> fail "expired rule must be reported, not absent");
-       (match find_at ~base_path ~input ~now:2001.0 with
-        | AQ.Rule_match_expired matched ->
+        | Keeper_approval_queue_rules_types.Rule_match_active _ -> fail "expired rule still matched"
+        | Keeper_approval_queue_rules_types.Rule_match_absent -> fail "expired rule must be reported, not absent");
+       (match find_at ~base_path ~input ~now:(expires_at +. 1.0) with
+        | Keeper_approval_queue_rules_types.Rule_match_expired matched ->
           check string "after expiry is expired" rule.id matched.rule_id
-        | AQ.Rule_match_active _ -> fail "expired rule still matched"
-        | AQ.Rule_match_absent -> fail "expired rule must be reported, not absent");
+        | Keeper_approval_queue_rules_types.Rule_match_active _ -> fail "expired rule still matched"
+        | Keeper_approval_queue_rules_types.Rule_match_absent -> fail "expired rule must be reported, not absent");
        let stored =
-         match AQ.list_rules ~base_path () with
+         match Rules.list_rules ~base_path () with
          | Ok rules -> rules
-         | Error error -> fail (AQ.rule_store_error_to_string error)
+         | Error error -> fail (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
        in
        check bool "expired rule is retained for operator cleanup" true
-         (List.exists (fun (stored : AQ.approval_rule) ->
-            String.equal stored.id rule.id && stored.expires_at = Some 2000.0)
+         (List.exists (fun (stored : Keeper_approval_queue_rules_types.approval_rule) ->
+            String.equal stored.id rule.id && stored.expires_at = Some expires_at)
             stored))
 ;;
 
@@ -242,10 +323,146 @@ let test_rule_without_expiry_matches_at_any_now () =
        let rule, _ = upsert_exn ~base_path ~input in
        check (option (float 0.0)) "no expiry by default" None rule.expires_at;
        match find_at ~base_path ~input ~now:1e12 with
-       | AQ.Rule_match_active matched ->
+       | Keeper_approval_queue_rules_types.Rule_match_active matched ->
          check string "rule without expiry stays active" rule.id matched.rule_id
-       | AQ.Rule_match_expired _ -> fail "rule without expiry reported as expired"
-       | AQ.Rule_match_absent -> fail "rule without expiry did not match")
+       | Keeper_approval_queue_rules_types.Rule_match_expired _ -> fail "rule without expiry reported as expired"
+       | Keeper_approval_queue_rules_types.Rule_match_absent -> fail "rule without expiry did not match")
+;;
+
+let test_nonfinite_expiry_is_rejected () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       match
+         Rules.upsert_rule
+           ~base_path
+           ~keeper_name:"keeper"
+           ~tool_name:"external-effect"
+           ~input:(`Assoc [ "request", `String "exact" ])
+           ~created_by:"operator"
+           ~source_approval_id:"approval-test"
+           ~expires_at:(Some Float.nan)
+           ()
+       with
+       | Ok _ -> fail "non-finite expiry must be rejected"
+       | Error error ->
+         check
+           string
+           "typed rejection"
+           "expires_at must be a finite number"
+           error.reason)
+;;
+
+let test_past_expiry_is_rejected () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       match
+         Rules.upsert_rule
+           ~base_path
+           ~keeper_name:"keeper"
+           ~tool_name:"external-effect"
+           ~input:(`Assoc [ "request", `String "exact" ])
+           ~created_by:"operator"
+           ~source_approval_id:"approval-test"
+           ~expires_at:(Some 1.0)
+           ()
+       with
+       | Ok _ -> fail "past expiry must be rejected"
+       | Error error ->
+         check string "typed rejection" "expires_at must be in the future" error.reason)
+;;
+
+let test_upsert_validates_persisted_string_contract () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let input = `Assoc [ "request", `String "exact" ] in
+       let expect_rejection label expected result =
+         match result with
+         | Ok _ -> fail (label ^ " must be rejected")
+         | Error error -> check string label expected error.reason
+       in
+       expect_rejection
+         "blank keeper_name"
+         "keeper_name must be a non-blank string"
+         (Rules.upsert_rule
+            ~base_path
+            ~keeper_name:" "
+            ~tool_name:"external-effect"
+            ~input
+            ~created_by:"operator"
+            ~source_approval_id:"approval-test"
+            ~expires_at:None
+            ());
+       expect_rejection
+         "blank tool_name"
+         "tool_name must be a non-blank string"
+         (Rules.upsert_rule
+            ~base_path
+            ~keeper_name:"keeper"
+            ~tool_name:""
+            ~input
+            ~created_by:"operator"
+            ~source_approval_id:"approval-test"
+            ~expires_at:None
+            ());
+       expect_rejection
+         "blank created_by"
+         "created_by must be a non-blank string"
+         (Rules.upsert_rule
+            ~base_path
+            ~keeper_name:"keeper"
+            ~tool_name:"external-effect"
+            ~input
+            ~created_by:"\t"
+            ~source_approval_id:"approval-test"
+            ~expires_at:None
+            ());
+       expect_rejection
+         "blank source_approval_id"
+         "source_approval_id must be a non-blank string"
+         (Rules.upsert_rule
+            ~base_path
+            ~keeper_name:"keeper"
+            ~tool_name:"external-effect"
+            ~input
+            ~created_by:"operator"
+            ~source_approval_id:"  "
+            ~expires_at:None
+            ());
+       let created_by = "operator" in
+       let source_approval_id = "approval-1" in
+       (match
+          Rules.upsert_rule
+            ~base_path
+            ~keeper_name:"keeper"
+            ~tool_name:"external-effect"
+            ~input
+            ~created_by
+            ~source_approval_id
+            ~expires_at:None
+            ()
+        with
+        | Error error ->
+          fail (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
+        | Ok (written, true) ->
+          (match Rules.list_rules ~base_path () with
+           | Error error ->
+             fail (Keeper_approval_queue_rules_types.rule_store_error_to_string error)
+           | Ok [ loaded ] ->
+             check string "roundtrip id" written.id loaded.id;
+             check string "roundtrip created_by" created_by loaded.created_by;
+             check
+               string
+               "roundtrip source approval"
+               source_approval_id
+               loaded.source_approval_id
+           | Ok _ -> fail "expected exactly one persisted rule")
+        | Ok (_, false) -> fail "first valid rule must be newly created"))
 ;;
 
 let test_unknown_persisted_shape_is_reported_and_rejected () =
@@ -255,10 +472,10 @@ let test_unknown_persisted_shape_is_reported_and_rejected () =
     (fun () ->
        let input = `Assoc [ "request", `String "exact" ] in
        let rule, _ = upsert_exn ~base_path ~input in
-       let json = AQ.approval_rule_to_yojson rule in
+       let json = Keeper_approval_queue_rules_types.approval_rule_to_yojson rule in
        let extended =
          match json with
-         | `Assoc fields -> `Assoc (("classification", `String "legacy") :: fields)
+         | `Assoc fields -> `Assoc (("classification", `String "unsupported") :: fields)
          | other -> other
        in
        let before =
@@ -271,7 +488,7 @@ let test_unknown_persisted_shape_is_reported_and_rejected () =
            ()
        in
        write_rules ~base_path (`List [ json; extended ]);
-       (match AQ.list_rules ~base_path () with
+       (match Rules.list_rules ~base_path () with
         | Ok _ -> fail "unsupported entry must fail the whole rules file"
         | Error _ -> ());
        let after =
@@ -286,7 +503,7 @@ let test_unknown_persisted_shape_is_reported_and_rejected () =
        check bool "rejection is observed" true (after -. before >= 1.0))
 ;;
 
-let with_rule_id id (rule : AQ.approval_rule) = { rule with id }
+let with_rule_id id (rule : Keeper_approval_queue_rules_types.approval_rule) = { rule with id }
 
 let test_duplicate_persisted_rules_reject_whole_store () =
   let base_path = temp_dir () in
@@ -302,10 +519,10 @@ let test_duplicate_persisted_rules_reject_whole_store () =
        write_rules
          ~base_path
          (`List
-             [ AQ.approval_rule_to_yojson first
-             ; AQ.approval_rule_to_yojson (with_rule_id first.id second)
+             [ Keeper_approval_queue_rules_types.approval_rule_to_yojson first
+             ; Keeper_approval_queue_rules_types.approval_rule_to_yojson (with_rule_id first.id second)
              ]);
-       (match AQ.list_rules ~base_path () with
+       (match Rules.list_rules ~base_path () with
         | Ok _ -> fail "duplicate rule ids must fail the whole rules store"
         | Error error ->
           check bool "duplicate id named" true
@@ -315,10 +532,10 @@ let test_duplicate_persisted_rules_reject_whole_store () =
        write_rules
          ~base_path
          (`List
-             [ AQ.approval_rule_to_yojson first
-             ; AQ.approval_rule_to_yojson (with_rule_id "different-id" first)
+             [ Keeper_approval_queue_rules_types.approval_rule_to_yojson first
+             ; Keeper_approval_queue_rules_types.approval_rule_to_yojson (with_rule_id "different-id" first)
              ]);
-       match AQ.list_rules ~base_path () with
+       match Rules.list_rules ~base_path () with
        | Ok _ -> fail "duplicate exact identities must fail the whole rules store"
        | Error error ->
          check bool "duplicate identity named" true
@@ -362,13 +579,13 @@ let exact_rule_lookup_failure_count () =
     ()
 ;;
 
-let eligibility_summary : AQ.hitl_context_summary =
+let eligibility_summary : Keeper_approval_queue_rules_types.hitl_context_summary =
   { summary_version = 2
   ; generated_at = 1.0
   ; model_run_id = "gate-eligibility-judge"
   ; context_summary = "The exact request is supported by the visible context."
   ; key_questions = []
-  ; judgment = AQ.Approve
+  ; judgment = Keeper_approval_queue_rules_types.Approve
   ; rationale = "The request is safe to finalize."
   }
 ;;
@@ -422,7 +639,7 @@ let exact_identity label =
   }
 ;;
 
-let bind_exact_entry (entry : AQ.pending_approval) identity =
+let bind_exact_entry (entry : Keeper_approval_queue_rules_types.pending_approval) identity =
   exact_update_exn
     "bind exact attempt"
     (AQ.bind_summary_exact_attempt
@@ -484,7 +701,7 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
            ~call_id:identity.call_id
            ~plan_fingerprint:identity.plan_fingerprint
            ~request_body_sha256:identity.request_body_sha256
-           ~cause:AQ.Exact_flow_execution_failed))
+           ~cause:Keeper_approval_queue_rules_types.Exact_flow_execution_failed))
   in
   let completed =
     make_bound "completed" (fun entry identity ->
@@ -503,24 +720,24 @@ let test_gate_auto_judge_worker_eligibility_ssot () =
                model_run_id = identity.call_id
              }))
   in
-let with_exact_status (entry : AQ.pending_approval) status =
+let with_exact_status (entry : Keeper_approval_queue_rules_types.pending_approval) status =
     match entry.exact_attempt with
-    | AQ.Exact_bound binding ->
+    | Keeper_approval_queue_rules_types.Exact_bound binding ->
       { entry with
         exact_attempt =
-          AQ.Exact_bound
-            (AQ.exact_attempt_binding_with_status binding status)
+          Keeper_approval_queue_rules_types.Exact_bound
+            (Keeper_approval_queue_rules_types.exact_attempt_binding_with_status binding status)
       }
-    | AQ.Exact_unbound ->
+    | Keeper_approval_queue_rules_types.Exact_unbound ->
       fail "bound exact eligibility fixture became unbound"
   in
   let released_recovery_required =
     with_exact_status
       released_before_dispatch
-      AQ.Exact_released_recovery_required
+      Keeper_approval_queue_rules_types.Exact_released_recovery_required
   in
   let restart_quarantined =
-    with_exact_status dispatch_uncertain AQ.Exact_restart_quarantined
+    with_exact_status dispatch_uncertain Keeper_approval_queue_rules_types.Exact_restart_quarantined
   in
   let check_ready label expected entry =
     check bool label expected (Gate.For_testing.auto_judge_entry_ready entry)
@@ -543,13 +760,13 @@ let with_exact_status (entry : AQ.pending_approval) status =
     restart_quarantined;
   check_ready "completed binding is finalize-only" false completed;
   (match quarantined.exact_attempt with
-   | AQ.Exact_bound { status = AQ.Exact_quarantined AQ.Exact_flow_execution_failed; _ } ->
+   | Keeper_approval_queue_rules_types.Exact_bound { status = Keeper_approval_queue_rules_types.Exact_quarantined Keeper_approval_queue_rules_types.Exact_flow_execution_failed; _ } ->
      ()
-   | AQ.Exact_unbound
-   | AQ.Exact_bound _ ->
+   | Keeper_approval_queue_rules_types.Exact_unbound
+   | Keeper_approval_queue_rules_types.Exact_bound _ ->
      fail "typed quarantine cause was not persisted");
   (match completed.exact_attempt, completed.summary_status with
-   | AQ.Exact_bound { status = AQ.Exact_completed; _ }, AQ.Summary_available _ -> ()
+   | Keeper_approval_queue_rules_types.Exact_bound { status = Keeper_approval_queue_rules_types.Exact_completed; _ }, Keeper_approval_queue_rules_types.Summary_available _ -> ()
    | _ -> fail "exact completion did not atomically persist its available summary");
   let other_owner =
     submit_eligibility_entry ~base_path ~keeper_name:"other-keeper" "other-owner"
@@ -572,7 +789,7 @@ let with_exact_status (entry : AQ.pending_approval) status =
   check int "operator recovery exposes only the FIFO head" 1 (List.length ready);
   check (list string) "operator recovery cannot skip the FIFO head"
     [ not_requested.id ]
-    (List.map (fun (entry : AQ.pending_approval) -> entry.id) ready)
+    (List.map (fun (entry : Keeper_approval_queue_rules_types.pending_approval) -> entry.id) ready)
 ;;
 
 let test_completed_exact_judgment_finalizes_without_worker () =
@@ -605,7 +822,7 @@ let test_completed_exact_judgment_finalizes_without_worker () =
    | Error error -> fail (AQ.install_error_to_string error));
   let completed = approval_entry_exn completed.id in
   (match completed.exact_attempt, completed.summary_status with
-   | AQ.Exact_bound { status = AQ.Exact_completed; _ }, AQ.Summary_available _ -> ()
+   | Keeper_approval_queue_rules_types.Exact_bound { status = Keeper_approval_queue_rules_types.Exact_completed; _ }, Keeper_approval_queue_rules_types.Summary_available _ -> ()
    | _ -> fail "completed available judgment did not survive restart");
   check bool "completed available judgment is finalize-only" false
     (Gate.For_testing.auto_judge_entry_ready completed);
@@ -717,12 +934,20 @@ let test_gate_defers_and_observes_expired_exact_rule () =
    | Ok _ -> ()
    | Error reason -> fail reason);
   let input = `Assoc [ "target", `String "exact" ] in
-  let rule, _ =
+  let active_rule, _ =
     upsert_with_expiry_exn
       ~base_path
       ~input
-      ~expires_at:(Unix.gettimeofday () -. 60.0)
+      ~expires_at:(Unix.gettimeofday () +. 3600.0)
   in
+  let rule =
+    { active_rule with
+      Keeper_approval_queue_rules_types.expires_at = Some (Unix.gettimeofday () -. 60.0)
+    }
+  in
+  write_rules
+    ~base_path
+    (`List [ Keeper_approval_queue_rules_types.approval_rule_to_yojson rule ]);
   (match Gate.decide ~keeper_always_allow:false (gate_request ~base_path) with
    | Gate.Deferred { reason = Gate.Human_requested; _ } -> ()
    | Gate.Deferred _ -> fail "expired exact rule used the wrong deferred reason"
@@ -795,6 +1020,14 @@ let () =
             test_rule_matches_only_complete_exact_request
         ; test_case "idempotent upsert" `Quick test_equivalent_upsert_is_idempotent
         ; test_case
+            "existing rule requires requested expiry"
+            `Quick
+            test_existing_rule_requires_the_requested_expiry
+        ; test_case
+            "expired existing rule is not reused"
+            `Quick
+            test_expired_existing_rule_is_not_reused
+        ; test_case
             "Gate consumes exact persisted rule"
             `Quick
             test_gate_allows_only_the_exact_persisted_rule
@@ -810,6 +1043,15 @@ let () =
             "rule without expiry matches at any now"
             `Quick
             test_rule_without_expiry_matches_at_any_now
+        ; test_case
+            "non-finite expiry is rejected"
+            `Quick
+            test_nonfinite_expiry_is_rejected
+        ; test_case "past expiry is rejected" `Quick test_past_expiry_is_rejected
+        ; test_case
+            "upsert validates its persisted string contract"
+            `Quick
+            test_upsert_validates_persisted_string_contract
         ; test_case
             "Gate allows unexpired exact rule"
             `Quick

--- a/test/test_keeper_approval_queue_rules_types.ml
+++ b/test/test_keeper_approval_queue_rules_types.ml
@@ -8,10 +8,10 @@ let sample_rule =
   { Q.id = "rule-1"
   ; keeper_name = "keeper"
   ; tool_name = "external-effect"
-  ; request_fingerprint = "abcdef1234567890"
+  ; request_fingerprint = String.make 64 'a'
   ; created_at = 1780587600.0
-  ; created_by = Some "operator"
-  ; source_approval_id = Some "approval-1"
+  ; created_by = "operator"
+  ; source_approval_id = "approval-1"
   ; expires_at = None
   }
 ;;
@@ -58,12 +58,16 @@ let without_field field = function
   | json -> json
 ;;
 
+let parse_rule json =
+  match Q.approval_rule_of_yojson_with_error json with
+  | Ok rule -> rule
+  | Error reason -> fail reason
+;;
+
 let test_approval_rule_json_round_trip () =
-  match Q.approval_rule_of_yojson (Q.approval_rule_to_yojson sample_rule) with
-  | None -> fail "expected exact approval rule to parse"
-  | Some parsed ->
-    check string "id" sample_rule.id parsed.id;
-    check string "fingerprint" sample_rule.request_fingerprint parsed.request_fingerprint
+  let parsed = Q.approval_rule_to_yojson sample_rule |> parse_rule in
+  check string "id" sample_rule.id parsed.id;
+  check string "fingerprint" sample_rule.request_fingerprint parsed.request_fingerprint
 ;;
 
 let test_approval_rule_expiry_round_trip () =
@@ -71,21 +75,23 @@ let test_approval_rule_expiry_round_trip () =
   let json = Q.approval_rule_to_yojson rule in
   check yojson "expires_at persisted" (`Float 1780591200.0)
     (Yojson.Safe.Util.member "expires_at" json);
-  match Q.approval_rule_of_yojson json with
-  | None -> fail "expected expiring approval rule to parse"
-  | Some parsed ->
-    check (option (float 0.0)) "expires_at round trip" rule.expires_at parsed.expires_at
+  let parsed = parse_rule json in
+  check (option (float 0.0)) "expires_at round trip" rule.expires_at parsed.expires_at
 ;;
 
 let test_approval_rule_without_expiry_round_trip () =
   let json = Q.approval_rule_to_yojson sample_rule in
   check yojson "expires_at serialized as null" `Null
     (Yojson.Safe.Util.member "expires_at" json);
-  let legacy = without_field "expires_at" json in
-  match Q.approval_rule_of_yojson legacy with
-  | None -> fail "pre-expiry persisted rule must still parse"
-  | Some parsed ->
-    check (option (float 0.0)) "missing expires_at is no expiry" None parsed.expires_at
+  let parsed = parse_rule json in
+  check (option (float 0.0)) "null expires_at is no expiry" None parsed.expires_at
+;;
+
+let test_approval_rule_requires_expiry_field () =
+  let json = Q.approval_rule_to_yojson sample_rule |> without_field "expires_at" in
+  match Q.approval_rule_of_yojson_with_error json with
+  | Ok _ -> fail "missing expires_at must be rejected"
+  | Error reason -> check string "failure names expires_at" "expires_at is required" reason
 ;;
 
 let test_rule_parser_rejects_malformed_expiry () =
@@ -98,8 +104,56 @@ let test_rule_parser_rejects_malformed_expiry () =
   match Q.approval_rule_of_yojson_with_error malformed with
   | Ok _ -> fail "malformed expires_at must not silently become a permanent rule"
   | Error reason ->
-    check string "failure names expires_at" "expires_at must be a number or null"
+    check string "failure names expires_at" "expires_at must be a finite number or null"
       reason
+;;
+
+let test_rule_parser_requires_exact_nullable_fields () =
+  let valid = Q.approval_rule_to_yojson sample_rule in
+  let replace field value =
+    match valid with
+    | `Assoc fields -> `Assoc ((field, value) :: List.remove_assoc field fields)
+    | json -> json
+  in
+  let cases =
+    [ ( "missing created_by"
+      , without_field "created_by" valid
+      , "created_by is required" )
+    ; ( "invalid created_by"
+      , replace "created_by" (`Int 1)
+      , "created_by must be a non-blank string" )
+    ; ( "blank created_by"
+      , replace "created_by" (`String " ")
+      , "created_by must be a non-blank string" )
+    ; ( "missing source_approval_id"
+      , without_field "source_approval_id" valid
+      , "source_approval_id is required" )
+    ; ( "invalid source_approval_id"
+      , replace "source_approval_id" (`Bool false)
+      , "source_approval_id must be a non-blank string" )
+    ; ( "invalid request fingerprint"
+      , replace "request_fingerprint" (`String "abc")
+      , "request_fingerprint must be a lowercase SHA-256" )
+    ; ( "non-finite creation time"
+      , replace "created_at" (`Float Float.nan)
+      , "created_at must be a finite non-negative number" )
+    ; ( "non-finite expiry"
+      , replace "expires_at" (`Float Float.infinity)
+      , "expires_at must be a finite number or null" )
+    ; ( "expiry before creation"
+      , replace "expires_at" (`Float (sample_rule.created_at -. 1.0))
+      , "expires_at must be later than created_at or null" )
+    ; ( "expiry at creation"
+      , replace "expires_at" (`Float sample_rule.created_at)
+      , "expires_at must be later than created_at or null" )
+    ]
+  in
+  List.iter
+    (fun (label, json, expected) ->
+       match Q.approval_rule_of_yojson_with_error json with
+       | Ok _ -> fail (label ^ " must be rejected")
+       | Error reason -> check string label expected reason)
+    cases
 ;;
 
 let test_rule_expired_is_deterministic () =
@@ -112,14 +166,12 @@ let test_rule_expired_is_deterministic () =
 
 let test_rule_parser_is_closed_and_explicit () =
   let valid = Q.approval_rule_to_yojson sample_rule in
-  check
-    (option reject)
-    "missing identity"
-    None
-    (Q.approval_rule_of_yojson (without_field "keeper_name" valid));
+  (match Q.approval_rule_of_yojson_with_error (without_field "keeper_name" valid) with
+   | Ok _ -> fail "missing identity must be rejected"
+   | Error _ -> ());
   let extended =
     match valid with
-    | `Assoc fields -> `Assoc (("classification", `String "legacy") :: fields)
+    | `Assoc fields -> `Assoc (("classification", `String "unsupported") :: fields)
     | json -> json
   in
   match Q.approval_rule_of_yojson_with_error extended with
@@ -148,42 +200,6 @@ let test_rule_parser_rejects_duplicate_fields () =
       reason
 ;;
 
-let test_summary_failed_has_no_retryable () =
-  let failed = Q.Summary_failed { reason = "provider down" } in
-  (match Q.summary_status_to_yojson failed with
-   | `Assoc fields ->
-     check
-       (list string)
-       "serialized fields"
-       [ "status"; "reason" ]
-       (List.map fst fields)
-   | _ -> fail "Summary_failed must serialize as an object");
-  let decode json = Q.summary_status_of_yojson_with_error json in
-  (match
-     decode (`Assoc [ "status", `String "failed"; "reason", `String "provider down" ])
-   with
-   | Ok status -> check bool "modern decode" true (status = failed)
-   | Error e -> fail e);
-  List.iter
-    (fun retryable ->
-       match
-         decode
-           (`Assoc
-               [ "status", `String "failed"
-               ; "reason", `String "provider down"
-               ; "retryable", retryable
-               ])
-       with
-       | Ok _ -> fail "removed retryable field must reject"
-       | Error reason ->
-         check
-           string
-           "removed field is explicit"
-           "summary_status contains unsupported field retryable"
-           reason)
-    [ `Bool true; `String "yes" ]
-;;
-
 let () =
   run
     "Keeper_approval_queue_rules_types"
@@ -191,23 +207,25 @@ let () =
       , [ test_case "typed judgment round trip" `Quick test_advisory_judgment_round_trip
         ; test_case "summary has no hierarchy" `Quick test_summary_json_is_nonhierarchical
         ] )
-    ; ( "summary status"
-      , [ test_case
-            "retryable is rejected by the current contract"
-            `Quick
-            test_summary_failed_has_no_retryable
-        ] )
     ; ( "exact rule"
       , [ test_case "JSON round trip" `Quick test_approval_rule_json_round_trip
         ; test_case "expiry JSON round trip" `Quick test_approval_rule_expiry_round_trip
         ; test_case
-            "missing expiry parses as no expiry"
+            "null expiry parses as no expiry"
             `Quick
             test_approval_rule_without_expiry_round_trip
+        ; test_case
+            "expiry field is required"
+            `Quick
+            test_approval_rule_requires_expiry_field
         ; test_case
             "malformed expiry rejected"
             `Quick
             test_rule_parser_rejects_malformed_expiry
+        ; test_case
+            "nullable fields and numbers are exact"
+            `Quick
+            test_rule_parser_requires_exact_nullable_fields
         ; test_case "expiry check is deterministic" `Quick test_rule_expired_is_deterministic
         ; test_case "closed explicit parser" `Quick test_rule_parser_is_closed_and_explicit
         ; test_case

--- a/test/test_keeper_cwd_response.ml
+++ b/test/test_keeper_cwd_response.ml
@@ -1,23 +1,9 @@
 (** Property tests for [Keeper_cwd_response].
 
-    These pin the contract that LLM-facing JSON responses
-    constructed via {!Keeper_cwd_response.to_yojson_response}
-    never reveal the host abs path of a Docker-backend keeper.
-
-    Background: PR #11080 removed [sandbox_host_root] /
-    [playground_path] from [execution_context], but sibling
-    [cwd] fields in [keeper_sandbox_docker] / [keeper_tool_command_runtime]
-    response builders still echoed the host abs path. The Docker
-    [--workdir] argument was translated via
-    [docker_private_workspace_cwd], yet that translation was not
-    propagated into the response JSON, so the LLM re-emitted
-    [cd /Users/...] on the next turn — invalid inside the
-    container.
-
-    These tests are the layer-1 guard: they pin the audience
-    semantics of the [Keeper_cwd_response] module itself. The
-    layer-2/3 guards (response builders + MLI gate) live in
-    follow-up PRs. *)
+    LLM-facing JSON responses constructed via
+    {!Keeper_cwd_response.to_yojson_response} never reveal the host absolute
+    path of a Docker-backed Keeper. Docker responses expose the translated
+    in-container working directory. *)
 
 open Alcotest
 open Masc

--- a/test/test_keeper_hitl_resolution_prompt.ml
+++ b/test/test_keeper_hitl_resolution_prompt.ml
@@ -35,54 +35,7 @@ let test_rejection_rationale_is_actionable_without_grant () =
     (Option.is_none (Keeper_gate.cycle_grant_of_resolution resolution))
 ;;
 
-let test_edited_input_is_durable_and_not_a_grant () =
-  let edited_input =
-    `Assoc [ "destination", `String "project"; "payload", `Int 7 ]
-  in
-  let resolution : Keeper_event_queue.hitl_resolution =
-    { approval_id = "approval-edited"
-    ; decision = Hitl_edited edited_input
-    ; channel
-    }
-  in
-  let stimulus : Keeper_event_queue.stimulus =
-    { post_id = Keeper_event_queue.hitl_resolution_post_id resolution
-    ; urgency = Immediate
-    ; arrived_at = 1.0
-    ; payload = Hitl_resolved resolution
-    }
-  in
-  let restored =
-    Keeper_event_queue.stimulus_to_yojson stimulus
-    |> Keeper_event_queue.stimulus_of_yojson
-  in
-  (match restored with
-   | Ok { payload = Hitl_resolved { decision = Hitl_edited actual; _ }; _ } ->
-     check bool "edited JSON survives durable codec" true (Yojson.Safe.equal edited_input actual)
-   | Ok _ -> fail "restored stimulus lost edited resolution"
-   | Error error -> fail ("edited resolution codec failed: " ^ error));
-  let message =
-    Keeper_gate_replay.user_message_with_hitl_resolution
-      ~base_path:"/tmp"
-      ~user_message:"continue"
-      (Some resolution)
-    |> fun message -> message.Keeper_gate_replay.text
-  in
-  check bool
-    "edited JSON reaches model input"
-    true
-    (contains ~needle:"\"destination\": \"project\"" message);
-  check bool
-    "edit explicitly grants nothing"
-    true
-    (contains ~needle:"grants no authorization" message);
-  check bool
-    "edit cannot mint a cycle grant"
-    true
-    (Option.is_none (Keeper_gate.cycle_grant_of_resolution resolution))
-;;
-
-let test_large_rejection_and_edit_remain_exact () =
+let test_large_rejection_remains_exact () =
   let exact_tail =
     "RESOLUTION-BEGIN\n"
     ^ String.make (512 * 1024) 'x'
@@ -98,19 +51,15 @@ let test_large_rejection_and_edit_remain_exact () =
       (Some resolution)
     |> fun message -> message.Keeper_gate_replay.text
   in
-  List.iter
-    (fun (label, rendered) ->
-       check bool
-         (label ^ " retains the full exact tail")
-         true
-         (contains ~needle:"RESOLUTION-END" rendered);
-       check bool
-         (label ^ " is not replaced with an opaque blob marker")
-         false
-         (contains ~needle:"[masc:blob " rendered))
-    [ "rejection", message (Hitl_rejected exact_tail)
-    ; "edit", message (Hitl_edited (`Assoc [ "payload", `String exact_tail ]))
-    ]
+  let rendered = message (Hitl_rejected exact_tail) in
+  check bool
+    "rejection retains the full exact tail"
+    true
+    (contains ~needle:"RESOLUTION-END" rendered);
+  check bool
+    "rejection is not replaced with an opaque blob marker"
+    false
+    (contains ~needle:"[masc:blob " rendered)
 ;;
 
 let approved_message ~tool_name =
@@ -165,13 +114,9 @@ let () =
             `Quick
             test_rejection_rationale_is_actionable_without_grant
         ; test_case
-            "edited input is durable and not authorization"
+            "large rejection remains exact"
             `Quick
-            test_edited_input_is_durable_and_not_a_grant
-        ; test_case
-            "large rejection and edit remain exact"
-            `Quick
-            test_large_rejection_and_edit_remain_exact
+            test_large_rejection_remains_exact
         ] )
     ; ( "approved resolution"
       , [ test_case

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -28,10 +28,19 @@ module Process_switch = Masc.Keeper_process_switch
 module Tool_accumulator = Masc.Keeper_tool_emission_hook
 module Latched_reason = Keeper_latched_reason
 
-(* Test-local shim for the excised [Keeper_approval_queue.resolve] wrapper:
-   unit projection over [resolve_with_policy] (production resolution path). *)
+(* Unit projection used by assertions that do not inspect the remembered rule. *)
 let aq_resolve ~base_path ~id ~decision =
-  match AQ.resolve_with_policy ~base_path ~id ~decision () with
+  match
+    AQ.resolve_with_policy
+      ~base_path
+      ~id
+      ~decision
+      ~source:Keeper_approval_queue_rules_types.Human_operator
+      ~remember_rule:false
+      ~rule_expires_at:None
+      ~created_by:"test-operator"
+      ()
+  with
   | Ok _ -> Ok ()
   | Error _ as error -> error
 ;;
@@ -349,7 +358,7 @@ let test_pending_hitl_approval_keeper_names_filters_persisted_pending () =
             (aq_resolve
                ~base_path:base_dir
                ~id
-               ~decision:(AQ.Decision.Reject "test cleanup")))
+               ~decision:(Keeper_approval_queue_rules_types.Decision.Reject "test cleanup")))
         !approval_ids;
       cleanup_dir base_dir)
     (fun () ->
@@ -1092,7 +1101,7 @@ let test_sweep_reports_pending_hitl_approval () =
              (aq_resolve
                 ~base_path:base_dir
                 ~id
-                ~decision:(AQ.Decision.Reject "test cleanup")))
+                ~decision:(Keeper_approval_queue_rules_types.Decision.Reject "test cleanup")))
         !approval_id;
       Reg.For_testing.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
@@ -1144,7 +1153,7 @@ let test_sweep_reports_pending_hitl_approval () =
            ~keeper_name:name
          |> Result.get_ok
          |> fun count -> count > 0);
-      (match aq_resolve ~base_path:base_dir ~id ~decision:AQ.Decision.Approve with
+      (match aq_resolve ~base_path:base_dir ~id ~decision:Keeper_approval_queue_rules_types.Decision.Approve with
        | Ok () -> approval_id := None
        | Error err -> fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
       check bool "resolution removes pending request" false

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -2262,8 +2262,11 @@ let test_approved_web_search_grant_executes_exact_request () =
          Masc.Keeper_approval_queue.resolve_with_policy
            ~base_path:config.base_path
            ~id:approval_id
-           ~decision:Masc.Keeper_approval_queue.Decision.Approve
-           ~source:Masc.Keeper_approval_queue.Auto_judge
+           ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+           ~source:Keeper_approval_queue_rules_types.Auto_judge
+           ~remember_rule:false
+           ~rule_expires_at:None
+           ~created_by:"test-operator"
            ()
        with
        | Ok _ -> ()
@@ -2365,8 +2368,11 @@ let test_approved_web_search_replays_without_model_resubmission () =
          Masc.Keeper_approval_queue.resolve_with_policy
            ~base_path:config.base_path
            ~id:approval_id
-           ~decision:Masc.Keeper_approval_queue.Decision.Approve
-           ~source:Masc.Keeper_approval_queue.Auto_judge
+           ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+           ~source:Keeper_approval_queue_rules_types.Auto_judge
+           ~remember_rule:false
+           ~rule_expires_at:None
+           ~created_by:"test-operator"
            ()
        with
        | Ok _ -> ()
@@ -2563,8 +2569,11 @@ let approved_web_search_resolution
      Masc.Keeper_approval_queue.resolve_with_policy
        ~base_path:config.base_path
        ~id:approval_id
-       ~decision:Masc.Keeper_approval_queue.Decision.Approve
-       ~source:Masc.Keeper_approval_queue.Auto_judge
+       ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+       ~source:Keeper_approval_queue_rules_types.Auto_judge
+       ~remember_rule:false
+       ~rule_expires_at:None
+       ~created_by:"test-operator"
        ()
    with
    | Ok _ -> ()
@@ -2978,8 +2987,11 @@ let test_unsupported_approved_operation_retains_exact_model_issued_path () =
           Masc.Keeper_approval_queue.resolve_with_policy
             ~base_path:config.base_path
             ~id:approval_id
-            ~decision:Masc.Keeper_approval_queue.Decision.Approve
-            ~source:Masc.Keeper_approval_queue.Auto_judge
+            ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+            ~source:Keeper_approval_queue_rules_types.Auto_judge
+            ~remember_rule:false
+            ~rule_expires_at:None
+            ~created_by:"test-operator"
             ()
         with
         | Ok _ -> ()

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -1843,7 +1843,11 @@ let approved_grant_fixture ~base_path ~keeper_name ~input =
      Keeper_approval_queue.resolve_with_policy
        ~base_path
        ~id:approval_id
-       ~decision:Keeper_approval_queue.Decision.Approve
+       ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+       ~source:Keeper_approval_queue_rules_types.Human_operator
+       ~remember_rule:false
+       ~rule_expires_at:None
+       ~created_by:"test-operator"
        ()
    with
    | Ok _ -> ()


### PR DESCRIPTION
## Summary

- make `Keeper_approval_queue_rules_types` the approval contract owner
- make `Keeper_approval_queue_rules` the bounded rule-store owner
- keep queue mutation and rule persistence APIs separate
- require current rule provenance and exact nullable expiry fields
- remove the producerless edit decision from queue and wake persistence
- make Dashboard rule, rule-state, Gate-mode, and judge-lane decoding fail closed

## Product impact

- User-visible change: approval rules expose exact provenance and expiry state; malformed Gate metadata is shown as protocol drift instead of disappearing.

## Evidence

- `git diff --check`
- changed OCaml interfaces and implementations parse successfully
- dead-surface ratchet: 544 at baseline
- sublibrary cycle audit: 35 leaf libraries clean
- CI target audit: 154 declared targets, 701 unwired at baseline
- Dashboard TypeScript typecheck
- focused Dashboard Vitest: 5 files, 180 tests

Focused Dune is not yet authoritative because the repo wrapper detected unrelated bare Dune processes and exited 75; the guard was not bypassed. Approval audit persistence also requires the durable stack tracked in #27756, so this draft must not be marked ready or merged yet.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

## GOAL LOOP ACT checklist

- [x] Observe — facade ownership, producerless variant, and silent rule-state projection were traced source to consumer
- [x] Orient — exact owner and dashboard boundary findings are captured in this draft
- [x] Decide — bounded owner split lands before the durable audit stack
- [x] Act — owner interfaces, consumers, codecs, and focused tests changed together
- [ ] Verify — focused OCaml build remains blocked by unrelated bare Dune processes; Dashboard checks pass
- [x] Loop — durable audit work is linked in #27756

## Review evidence

- Fresh adversarial source review confirmed `Rules_types -> Rules -> Queue` and `Audit -> Rules_types` with no approval-owner facade include.
- The same review keeps this draft blocked on approval-audit write/read failures.

## Linked issue

- Relates #27756
- Relates #27712

## Variant addition checklist

- [x] **OCaml** — removed the producerless edit decision from the type, codecs, and exhaustive consumers
- [x] **TypeScript** — current Gate mode and judge-lane unions are exact and fail closed
- [ ] **TLA+ spec** — N/A: the removed decision is outside the current TLA domain
- [x] **Event / JSON schema** — queue and wake codecs no longer accept or emit the removed decision
- [ ] **`make check-variants` passes** — pending local resource availability

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/approval-owner-hardcut-20260809` → `main` · 1 commit(s) · synced 2026-08-09T01:41:18Z

| sha | subject | date |
|---|---|---|
| `8048d88d9` | refactor: hard-cut approval rule ownership | 2026-08-09 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->