### PR TITLE
feat(keeper): run Claude Code subscription turns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1559,7 +1559,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_keeper_official_client_host @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code"
+          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_keeper_official_client_host @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code @test/runtest-test_runtime_claude_code_config @test/runtest-test_keeper_claude_code_runtime"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${official_client_targets}"
 
       - name: Run host FD pressure contract suite

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -99,6 +99,22 @@ endpoint = "http://localhost:11434"
 [providers.ollama.healthcheck]
 path = "/api/tags"
 
+# Official Claude Code subscription runtime example. This stays commented so
+# a fresh install does not claim the local CLI is installed or logged in.
+# There is deliberately no credentials table: Claude Code owns its stored
+# claude.ai login, and MASC removes API/token environment fallbacks.
+# [providers.claude_code]
+# display-name = "Claude Code Subscription"
+# protocol = "claude-code"
+# command = "claude"
+# is-non-interactive = true
+#
+# [models.claude-code-sonnet]
+# api-name = "claude-sonnet-4-5"
+# max-context = 200000
+#
+# [claude_code.claude-code-sonnet]
+
 [models.deepseek-v4-pro]
 api-name = "deepseek-v4-pro"
 max-context = 1000000

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -92,6 +92,12 @@ let claude_error_to_sdk_error = function
     Agent_sdk.Error.Provider
       (Llm_provider.Error.ProviderUnavailable
          { provider = "claude_code"; detail })
+  | Runtime_claude_code.Turn_transport_interrupted _ as error ->
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.ProviderUnavailable
+         { provider = "claude_code"
+         ; detail = Runtime_claude_code.error_to_string error
+         })
   | Runtime_claude_code.Protocol_error { stage; detail } ->
     Agent_sdk.Error.Provider
       (Llm_provider.Error.ParseError
@@ -105,6 +111,8 @@ let claude_error_to_sdk_error = function
 let recovery_failure_of_client_error = function
   | Runtime_claude_code.Spawn_failed _ -> Session_store.Transient_spawn_failed
   | Runtime_claude_code.Process_exited _ | Runtime_claude_code.Timeout _ ->
+    Session_store.Transport_interrupted
+  | Runtime_claude_code.Turn_transport_interrupted _ ->
     Session_store.Transport_interrupted
   | Runtime_claude_code.Invalid_config _
   | Runtime_claude_code.Protocol_error _

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -248,6 +248,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~context_injector
         ~context
         ~terminal_error
+        ~raw_trace_run:None
     in
     let dynamic_tools = List.map claude_dynamic_tool host_dynamic_tools in
     let* () =

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -1,0 +1,568 @@
+open Result.Syntax
+
+let config_error ~field detail =
+  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })
+;;
+
+let internal_error detail = Agent_sdk.Error.Internal detail
+
+module Host = Keeper_official_client_host
+module Session_store = Keeper_official_client_session_store
+
+let runtime_label = "Claude Code"
+
+type history_message =
+  { role : string
+  ; text : string
+  }
+
+let project_messages messages =
+  let rec loop system history = function
+    | [] -> Ok (List.rev system, List.rev history)
+    | (message : Agent_sdk.Types.message) :: rest ->
+      let* text =
+        Host.text_of_blocks
+          ~runtime_label
+          ~field:"initial_messages"
+          message.content
+      in
+      (match message.role with
+       | Agent_sdk.Types.System -> loop (text :: system) history rest
+       | Agent_sdk.Types.User -> loop system ({ role = "user"; text } :: history) rest
+       | Agent_sdk.Types.Assistant ->
+         loop system ({ role = "assistant"; text } :: history) rest
+       | Agent_sdk.Types.Tool ->
+         Error
+           (config_error
+              ~field:"initial_messages"
+              "claude-code history injection does not admit OAS tool messages"))
+  in
+  loop [] [] messages
+;;
+
+let initial_turn_prompt ~history ~goal =
+  match history with
+  | [] -> goal
+  | _ :: _ ->
+    `Assoc
+      [ "schema", `String "masc.claude-code.initial-turn.v1"
+      ; ( "history"
+        , `List
+            (List.map
+               (fun message ->
+                 `Assoc
+                   [ "role", `String message.role
+                   ; "text", `String message.text
+                   ])
+               history) )
+      ; "current_goal", `String goal
+      ]
+    |> Yojson.Safe.to_string
+;;
+
+let claude_dynamic_tool (tool : Host.dynamic_tool) : Runtime_claude_code.dynamic_tool =
+  { name = tool.name
+  ; description = tool.description
+  ; input_schema = tool.input_schema
+  ; call =
+      (fun ~call_id input ->
+        let result = tool.call ~call_id input in
+        { Runtime_claude_code.success = result.success; content = result.content })
+  }
+;;
+
+let retry_after_of_rate_limit = function
+  | None -> None
+  | Some ({ resets_at = None; _ } : Runtime_claude_code.rate_limit) -> None
+  | Some { resets_at = Some timestamp; _ } ->
+    Some (Float.max 0.0 (Float.of_int timestamp -. Time_compat.now ()))
+;;
+
+let claude_error_to_sdk_error = function
+  | Runtime_claude_code.Invalid_config detail ->
+    config_error ~field:"claude_code" detail
+  | Runtime_claude_code.Subscription_required detail ->
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.AuthError { provider = "claude_code"; detail })
+  | Runtime_claude_code.Quota_blocked ({ rate_limit; _ } as blocked) ->
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.HardQuota
+         { provider = "claude_code"
+         ; retry_after = retry_after_of_rate_limit rate_limit
+         ; detail = Runtime_claude_code.error_to_string (Quota_blocked blocked)
+         })
+  | Runtime_claude_code.Turn_failed detail ->
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.ProviderReportedError
+         { provider = "claude_code"; error_type = Some "turn_failed"; detail })
+  | Runtime_claude_code.Timeout seconds ->
+    Agent_sdk.Error.Api
+      (Agent_sdk.Retry.Timeout
+         { message = Printf.sprintf "Claude Code turn timed out after %.3fs" seconds
+         ; phase = None
+         })
+  | Runtime_claude_code.Spawn_failed detail
+  | Runtime_claude_code.Process_exited detail ->
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.ProviderUnavailable
+         { provider = "claude_code"; detail })
+  | Runtime_claude_code.Protocol_error { stage; detail } ->
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.ParseError
+         { detail = Printf.sprintf "%s: %s" stage detail })
+  | Runtime_claude_code.Unsupported_control_request subtype ->
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.UnknownVariant
+         { type_name = "claude_code.control_request"; value = subtype })
+;;
+
+let recovery_failure_of_client_error = function
+  | Runtime_claude_code.Spawn_failed _ -> Session_store.Transient_spawn_failed
+  | Runtime_claude_code.Process_exited _ | Runtime_claude_code.Timeout _ ->
+    Session_store.Transport_interrupted
+  | Runtime_claude_code.Invalid_config _
+  | Runtime_claude_code.Protocol_error _
+  | Runtime_claude_code.Unsupported_control_request _ ->
+    Session_store.Protocol_failed
+  | Runtime_claude_code.Subscription_required _
+  | Runtime_claude_code.Turn_failed _
+  | Runtime_claude_code.Quota_blocked _ ->
+    Session_store.Provider_rejected
+;;
+
+let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
+    ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
+    ~context ~event_bus ~enable_thinking
+    ~(config : Runtime_execution.claude_code) =
+  match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
+  | None, _ ->
+    Error
+      (config_error
+         ~field:"eio_env"
+         "Claude Code runtime requires the initialized Eio standard environment")
+  | _, None ->
+    Error
+      (config_error
+         ~field:"eio_clock"
+         "Claude Code runtime requires the initialized Eio clock")
+  | Some env, Some clock ->
+    let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
+    let owner_epoch = Session_store.process_epoch () in
+    let* stored_session =
+      match Session_store.load ~base_path ~keeper_name with
+      | Ok session -> Ok session
+      | Error detail ->
+        Error (internal_error ("Claude Code session binding load failed: " ^ detail))
+    in
+    let* stored_session =
+      match stored_session with
+      | Some ({ phase = (Start _ | Active _ | Turn_inflight _); _ } as expected) ->
+        (match
+           Session_store.reconcile_process_restart
+             ~base_path
+             ~keeper_name
+             ~expected
+             ~current_owner_epoch:owner_epoch
+             ~required_at:(Time_compat.now ())
+         with
+         | Ok reconciled -> Ok (Some reconciled)
+         | Error detail ->
+           Error (config_error ~field:"official_client_session.phase" detail))
+      | None | Some { phase = (Ready | Recovery_required _ | Settled _); _ } ->
+        Ok stored_session
+    in
+    let* claim_plan =
+      match
+        Session_store.plan_claim
+          ~expected:stored_session
+          ~client_kind:Claude_code
+          ~runtime_id
+      with
+      | Ok plan -> Ok plan
+      | Error detail ->
+        Error (config_error ~field:"official_client_session.claim" detail)
+    in
+    let session_mode =
+      match claim_plan.previous_settlement with
+      | None -> Runtime_claude_code.Start
+      | Some { session_id; _ } -> Runtime_claude_code.Resume { session_id }
+    in
+    let turn_count = claim_plan.turn_count in
+    let* prepared =
+      Host.prepare_turn
+        ~runtime_label
+        ~keeper_name
+        ~turn_count
+        ~system_prompt
+        ~tools
+        ~initial_messages
+        ~model_input_projection
+        ~hooks:(Some hooks)
+        ~enable_thinking
+    in
+    let tool_surface_sha256 = Session_store.tool_surface_sha256 prepared.tools in
+    let* () =
+      match claim_plan.required_tool_surface_sha256 with
+      | None -> Ok ()
+      | Some stored when String.equal stored tool_surface_sha256 -> Ok ()
+      | Some stored ->
+        Error
+          (config_error
+             ~field:"official_client_session.tool_surface_sha256"
+             (Printf.sprintf
+                "stored official-client tool surface %s does not match current surface %s"
+                stored
+                tool_surface_sha256))
+    in
+    let* system_messages, history = project_messages prepared.messages in
+    let* goal =
+      match goal_blocks with
+      | None -> Ok goal
+      | Some blocks -> Host.text_of_blocks ~runtime_label ~field:"goal_blocks" blocks
+    in
+    let prompt =
+      match session_mode with
+      | Runtime_claude_code.Start -> initial_turn_prompt ~history ~goal
+      | Runtime_claude_code.Resume _ -> goal
+    in
+    let system_prompt =
+      prepared.system_prompt :: system_messages
+      |> List.filter (fun text -> String.trim text <> "")
+      |> String.concat "\n\n"
+      |> String_util.trim_to_option
+    in
+    let client_config : Runtime_claude_code.config =
+      { cli_path = config.cli_path
+      ; cwd = base_path
+      ; model = config.model
+      ; system_prompt
+      ; timeout_s = config.timeout_s
+      }
+    in
+    let terminal_error = ref None in
+    let* host_dynamic_tools =
+      Host.dynamic_tools
+        ~runtime_label
+        ~keeper_name
+        ~turn_count
+        ~tools:prepared.tools
+        ~hooks
+        ~event_bus
+        ~context_injector
+        ~context
+        ~terminal_error
+    in
+    let dynamic_tools = List.map claude_dynamic_tool host_dynamic_tools in
+    let* () =
+      match
+        Runtime_claude_code.validate_turn
+          ~dynamic_tools
+          ~session_mode
+          client_config
+          ~prompt
+      with
+      | Ok () -> Ok ()
+      | Error error -> Error (claude_error_to_sdk_error error)
+    in
+    let process_mgr = Eio.Stdenv.process_mgr env in
+    let process_cwd = Eio.Path.(Eio.Stdenv.fs env / base_path) in
+    let* admitted_subscription =
+      match
+        Runtime_claude_code.probe_subscription
+          ~mgr:process_mgr
+          ~cwd:process_cwd
+          client_config
+      with
+      | Ok subscription -> Ok subscription
+      | Error error -> Error (claude_error_to_sdk_error error)
+    in
+    let* claimed_session =
+      match
+        Session_store.claim
+          ~base_path
+          ~keeper_name
+          ~expected:stored_session
+          ~client_kind:Claude_code
+          ~owner_epoch
+          ~runtime_id
+          ~tool_surface_sha256
+          ~updated_at:(Time_compat.now ())
+      with
+      | Ok session -> Ok session
+      | Error detail ->
+        Error (internal_error ("Claude Code session claim failed: " ^ detail))
+    in
+    let session_state = ref claimed_session in
+    let recovery_failure = ref Session_store.Transport_interrupted in
+    let state_persistence_failed = ref false in
+    let update_session label transition =
+      match transition !session_state with
+      | Ok next ->
+        session_state := next;
+        Ok ()
+      | Error detail ->
+        state_persistence_failed := true;
+        recovery_failure := Session_store.State_persistence_failed;
+        Error (Printf.sprintf "Claude Code session %s failed: %s" label detail)
+    in
+    let require_recovery detail =
+      match !session_state with
+      | { Session_store.phase = (Ready | Settled _ | Recovery_required _); _ } ->
+        Ok ()
+      | expected ->
+        (match
+           Session_store.require_recovery
+             ~base_path
+             ~keeper_name
+             ~expected
+             ~failure:!recovery_failure
+             ~detail
+             ~required_at:(Time_compat.now ())
+         with
+         | Ok recovery ->
+           session_state := recovery;
+           Ok ()
+         | Error detail -> Error detail)
+    in
+    let settle_failed_claim detail =
+      match Session_store.failure_disposition !recovery_failure with
+      | Transient ->
+        (match !session_state with
+         | { phase = (Ready | Settled _ | Recovery_required _); _ } -> Ok ()
+         | expected ->
+           (match
+              Session_store.release_transient
+                ~base_path
+                ~keeper_name
+                ~expected
+                ~failure:!recovery_failure
+                ~released_at:(Time_compat.now ())
+            with
+            | Ok released ->
+              session_state := released;
+              Ok ()
+            | Error detail -> Error detail))
+      | Ambiguous | Fatal -> require_recovery detail
+    in
+    let started_at = Time_compat.now () in
+    let turn_result =
+      try
+        (match
+           Runtime_claude_code.run_turn
+             ~mgr:process_mgr
+             ~clock
+             ~cwd:process_cwd
+             ~dynamic_tools
+             ?reasoning_effort:prepared.reasoning_effort
+             ~session_mode
+             ~admitted_subscription
+             ~on_session_ready:(fun ~session_id ->
+               update_session "active transition" (fun expected ->
+                 Session_store.mark_active
+                   ~base_path
+                   ~keeper_name
+                   ~expected
+                   ~session_id
+                   ~updated_at:(Time_compat.now ())))
+             ~on_turn_starting:(fun ~session_id ->
+               update_session "turn-starting transition" (fun expected ->
+                 Session_store.mark_turn_starting
+                   ~base_path
+                   ~keeper_name
+                   ~expected
+                   ~session_id
+                   ~updated_at:(Time_compat.now ())))
+             ~on_turn_started:(fun ~session_id ~turn_id ->
+               update_session "turn-started transition" (fun expected ->
+                 Session_store.mark_turn_started
+                   ~base_path
+                   ~keeper_name
+                   ~expected
+                   ~session_id
+                   ~turn_id
+                   ~updated_at:(Time_compat.now ())))
+             client_config
+             ~prompt
+         with
+         | Error error ->
+           if not !state_persistence_failed
+           then recovery_failure := recovery_failure_of_client_error error;
+           Error (claude_error_to_sdk_error error)
+         | Ok turn ->
+           recovery_failure := Session_store.Protocol_failed;
+           let expected_resumed =
+             match session_mode with
+             | Runtime_claude_code.Start -> false
+             | Runtime_claude_code.Resume _ -> true
+           in
+           let* () =
+             if Bool.equal expected_resumed turn.resumed
+             then Ok ()
+             else
+               Error
+                 (internal_error
+                    "Claude Code reported a session mode different from the durable claim plan")
+           in
+           recovery_failure := Session_store.Host_hook_failed;
+           let* () =
+             match !terminal_error with
+             | None -> Ok ()
+             | Some detail -> Error (internal_error detail)
+           in
+           let latency_ms =
+             Int.of_float ((Time_compat.now () -. started_at) *. 1000.0)
+           in
+           let response =
+             { Agent_sdk.Types.id = turn.turn_id
+             ; model = turn.model
+             ; stop_reason = EndTurn
+             ; content = [ Text turn.text ]
+             ; usage = None
+             ; telemetry =
+                 Some
+                   { Agent_sdk.Types.default_inference_telemetry with
+                     request_latency_ms = Some latency_ms
+                   ; canonical_model_id = Some turn.model
+                   }
+             }
+           in
+           let after_turn =
+             Host.invoke_turn_hook
+               ~keeper_name
+               ~turn_count
+               ~hook_name:"after_turn"
+               hooks.after_turn
+               (Agent_sdk.Hooks.AfterTurn { turn = turn_count; response })
+           in
+           let* () =
+             match after_turn with
+             | Continue -> Ok ()
+             | HookFailed { stage; detail } ->
+               Error
+                 (Host.hook_error
+                    ~runtime_label
+                    ~hook_name:"after_turn"
+                    ~stage
+                    detail)
+             | decision ->
+               Error
+                 (Host.illegal_hook_decision
+                    ~runtime_label
+                    ~hook_name:"after_turn"
+                    decision)
+           in
+           let on_stop =
+             Host.invoke_turn_hook
+               ~keeper_name
+               ~turn_count
+               ~hook_name:"on_stop"
+               hooks.on_stop
+               (Agent_sdk.Hooks.OnStop { reason = response.stop_reason; response })
+           in
+           let* () =
+             match on_stop with
+             | Continue -> Ok ()
+             | HookFailed { stage; detail } ->
+               Error
+                 (Host.hook_error
+                    ~runtime_label
+                    ~hook_name:"on_stop"
+                    ~stage
+                    detail)
+             | decision ->
+               Error
+                 (Host.illegal_hook_decision
+                    ~runtime_label
+                    ~hook_name:"on_stop"
+                    decision)
+           in
+           recovery_failure := Session_store.State_persistence_failed;
+           let* () =
+             match
+               Session_store.settle
+                 ~base_path
+                 ~keeper_name
+                 ~expected:!session_state
+                 ~session_id:turn.session_id
+                 ~turn_id:turn.turn_id
+                 ~updated_at:(Time_compat.now ())
+             with
+             | Ok settled ->
+               session_state := settled;
+               Ok ()
+             | Error detail ->
+               Error
+                 (internal_error
+                    ("Claude Code session settlement failed: " ^ detail))
+           in
+           let capture, _metrics =
+             Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
+           in
+           Runtime_observation.record_attempt_terminal
+             capture
+             ~model_id:turn.model
+             ~latency_ms:(Some latency_ms)
+             ~error:None;
+           let configured_labels =
+             [ "claude_code"
+             ; Printf.sprintf "dynamic_tool_calls=%d" turn.dynamic_tool_calls
+             ; Printf.sprintf "resumed=%b" turn.resumed
+             ; Printf.sprintf "turn_count=%d" turn_count
+             ; "auth_method=" ^ turn.subscription.auth_method
+             ; "subscription_type=" ^ turn.subscription.subscription_type
+             ]
+             @
+             match turn.rate_limit with
+             | None -> []
+             | Some rate_limit -> [ "rate_limit_status=" ^ rate_limit.status ]
+           in
+           let runtime_observation =
+             Runtime_observation.runtime_observation_with_metrics
+               ~runtime_id
+               ~strategy:"official_client_runtime"
+               ~configured_labels
+               ~candidate_count:1
+               ~selected_model_raw:(Some turn.model)
+               ~capture
+               ~attempt_details_source:"claude_code"
+               ~oas_internal_runtime_allowed:false
+               ()
+           in
+           Ok
+             { Runtime_agent.response
+             ; checkpoint = None
+             ; session_id = turn.session_id
+             ; turns = turn_count
+             ; trace_ref = None
+             ; run_validation = None
+             ; runtime_observation = Some runtime_observation
+             ; stop_reason = Completed
+             })
+      with
+      | Eio.Cancel.Cancelled _ as exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        recovery_failure := Session_store.Transport_interrupted;
+        let detail = "Claude Code turn cancelled: " ^ Printexc.to_string exn in
+        (match Eio.Cancel.protect (fun () -> settle_failed_claim detail) with
+         | Ok () -> ()
+         | Error recovery_detail ->
+           Log.Keeper.error
+             ~keeper_name
+             "Claude Code cancellation recovery persistence failed: %s"
+             recovery_detail);
+        Printexc.raise_with_backtrace exn backtrace
+    in
+    (match turn_result with
+     | Ok _ -> turn_result
+     | Error original_error ->
+       let original_detail = Agent_sdk.Error.to_string original_error in
+       (match Eio.Cancel.protect (fun () -> settle_failed_claim original_detail) with
+        | Ok () -> turn_result
+        | Error recovery_detail ->
+          Error
+            (internal_error
+               (Printf.sprintf
+                  "Claude Code turn failed and recovery state persistence also failed: original=%s recovery=%s"
+                  original_detail
+                  recovery_detail))))
+;;

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -514,7 +514,10 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
              @
              match turn.rate_limit with
              | None -> []
-             | Some rate_limit -> [ "rate_limit_status=" ^ rate_limit.status ]
+             | Some rate_limit ->
+               [ "rate_limit_status="
+                 ^ Runtime_claude_code.rate_limit_status_to_string rate_limit.status
+               ]
            in
            let runtime_observation =
              Runtime_observation.runtime_observation_with_metrics

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -118,7 +118,7 @@ let recovery_failure_of_client_error = function
 
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~enable_thinking
+    ~context ~event_bus
     ~(config : Runtime_execution.claude_code) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
@@ -188,7 +188,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~initial_messages
         ~model_input_projection
         ~hooks:(Some hooks)
-        ~enable_thinking
     in
     let tool_surface_sha256 = Session_store.tool_surface_sha256 prepared.tools in
     let* () =
@@ -562,7 +561,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~enable_thinking ~config =
+    ~context ~event_bus ~config =
   Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
     run_without_lifecycle
       ~runtime_id
@@ -578,6 +577,5 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       ~context_injector
       ~context
       ~event_bus
-      ~enable_thinking
       ~config)
 ;;

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -146,7 +146,11 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
          ~field:"eio_clock"
          "Claude Code runtime requires the initialized Eio clock")
   | Some env, Some clock ->
-    let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
+    let hooks =
+      match hooks with
+      | Some hooks -> hooks
+      | None -> Agent_sdk.Hooks.empty
+    in
     let owner_epoch = Session_store.process_epoch () in
     let* stored_session =
       match Session_store.load ~base_path ~keeper_name with

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -11,31 +11,24 @@ module Session_store = Keeper_official_client_session_store
 
 let runtime_label = "Claude Code"
 
-type history_message =
-  { role : string
-  ; text : string
-  }
-
 let project_messages messages =
   let rec loop system history = function
     | [] -> Ok (List.rev system, List.rev history)
     | (message : Agent_sdk.Types.message) :: rest ->
-      let* text =
-        Host.text_of_blocks
-          ~runtime_label
-          ~field:"initial_messages"
-          message.content
-      in
       (match message.role with
-       | Agent_sdk.Types.System -> loop (text :: system) history rest
-       | Agent_sdk.Types.User -> loop system ({ role = "user"; text } :: history) rest
-       | Agent_sdk.Types.Assistant ->
-         loop system ({ role = "assistant"; text } :: history) rest
-       | Agent_sdk.Types.Tool ->
-         Error
-           (config_error
-              ~field:"initial_messages"
-              "claude-code history injection does not admit OAS tool messages"))
+       | Agent_sdk.Types.System ->
+         let* text =
+           Host.text_of_blocks
+             ~runtime_label
+             ~field:"initial_messages"
+             message.content
+         in
+         loop (text :: system) history rest
+       | Agent_sdk.Types.User | Agent_sdk.Types.Assistant | Agent_sdk.Types.Tool ->
+         loop
+           system
+           (Keeper_context_core.message_to_json message :: history)
+           rest)
   in
   loop [] [] messages
 ;;
@@ -47,14 +40,7 @@ let initial_turn_prompt ~history ~goal =
     `Assoc
       [ "schema", `String "masc.claude-code.initial-turn.v1"
       ; ( "history"
-        , `List
-            (List.map
-               (fun message ->
-                 `Assoc
-                   [ "role", `String message.role
-                   ; "text", `String message.text
-                   ])
-               history) )
+        , `List history )
       ; "current_goal", `String goal
       ]
     |> Yojson.Safe.to_string
@@ -130,7 +116,7 @@ let recovery_failure_of_client_error = function
     Session_store.Provider_rejected
 ;;
 
-let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
+let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
     ~context ~event_bus ~enable_thinking
     ~(config : Runtime_execution.claude_code) =
@@ -572,4 +558,26 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
                   "Claude Code turn failed and recovery state persistence also failed: original=%s recovery=%s"
                   original_detail
                   recovery_detail))))
+;;
+
+let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
+    ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
+    ~context ~event_bus ~enable_thinking ~config =
+  Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
+    run_without_lifecycle
+      ~runtime_id
+      ~keeper_name
+      ~base_path
+      ~goal
+      ~goal_blocks
+      ~system_prompt
+      ~tools
+      ~initial_messages
+      ~model_input_projection
+      ~hooks
+      ~context_injector
+      ~context
+      ~event_bus
+      ~enable_thinking
+      ~config)
 ;;

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -14,6 +14,5 @@ val run :
   context_injector:Agent_sdk.Hooks.context_injector option ->
   context:Agent_sdk.Context.t option ->
   event_bus:Agent_sdk.Event_bus.t option ->
-  enable_thinking:bool option ->
   config:Runtime_execution.claude_code ->
   (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -1,0 +1,19 @@
+(** Keeper projection for the official Claude Code subscription runtime. *)
+
+val run :
+  runtime_id:string ->
+  keeper_name:string ->
+  base_path:string ->
+  goal:string ->
+  goal_blocks:Agent_sdk.Types.content_block list option ->
+  system_prompt:string ->
+  tools:Agent_sdk.Tool.t list ->
+  initial_messages:Agent_sdk.Types.message list ->
+  model_input_projection:Agent_sdk.Agent.model_input_projection option ->
+  hooks:Agent_sdk.Hooks.hooks option ->
+  context_injector:Agent_sdk.Hooks.context_injector option ->
+  context:Agent_sdk.Context.t option ->
+  event_bus:Agent_sdk.Event_bus.t option ->
+  enable_thinking:bool option ->
+  config:Runtime_execution.claude_code ->
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -592,5 +592,6 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ~context_injector
       ~context
       ~event_bus
+      ~raw_trace:None
       ~config)
 ;;

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -124,7 +124,7 @@ let recovery_failure_of_client_error = function
     Keeper_official_client_session_store.Provider_rejected
 ;;
 
-let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
+let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
     ~context_injector ~context ~event_bus ~raw_trace
     ~(config : Runtime_execution.codex_app_server) =
@@ -565,11 +565,33 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
        let original_detail = Agent_sdk.Error.to_string original_error in
        (match Eio.Cancel.protect (fun () -> settle_failed_claim original_detail) with
         | Ok () -> turn_result
-        | Error recovery_detail ->
-          Error
+      | Error recovery_detail ->
+        Error
             (internal_error
                (Printf.sprintf
                   "Codex turn failed and recovery state persistence also failed: original=%s recovery=%s"
-                  original_detail
-                  recovery_detail))))
+               original_detail
+               recovery_detail))))
+;;
+
+let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
+    ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
+    ~context_injector ~context ~event_bus ~enable_thinking ~config =
+  Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
+    run_without_lifecycle
+      ~runtime_id
+      ~keeper_name
+      ~base_path
+      ~goal
+      ~goal_blocks
+      ~system_prompt
+      ~tools
+      ~initial_messages
+      ~model_input_projection
+      ~hooks
+      ~context_injector
+      ~context
+      ~event_bus
+      ~enable_thinking
+      ~config)
 ;;

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -576,7 +576,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
-    ~context_injector ~context ~event_bus ~enable_thinking ~config =
+    ~context_injector ~context ~event_bus ~config =
   Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
     run_without_lifecycle
       ~runtime_id
@@ -592,6 +592,5 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ~context_injector
       ~context
       ~event_bus
-      ~enable_thinking
       ~config)
 ;;

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -576,7 +576,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
-    ~context_injector ~context ~event_bus ~config =
+    ~context_injector ~context ~event_bus ~raw_trace ~config =
   Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
     run_without_lifecycle
       ~runtime_id
@@ -592,6 +592,6 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ~context_injector
       ~context
       ~event_bus
-      ~raw_trace:None
+      ~raw_trace
       ~config)
 ;;

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -136,6 +136,31 @@ let invoke_turn_hook ~keeper_name ~turn_count ~hook_name hook event =
     event
 ;;
 
+let lifecycle_outcome = function
+  | Error error -> Agent_sdk.Agent_lifecycle_events.Failed error
+  | Ok ({ response; stop_reason; _ } : Runtime_agent.run_result) ->
+    (match stop_reason with
+     | Runtime_agent.Completed ->
+       Agent_sdk.Agent_lifecycle_events.Completed response
+     | Runtime_agent.InputRequired { request; _ } ->
+       Agent_sdk.Agent_lifecycle_events.Input_required request
+     | Runtime_agent.Yielded_to_chat_waiting { turns_used }
+     | Runtime_agent.Yielded_to_durable_stimulus { turns_used }
+     | Runtime_agent.Awaiting_external_effect { turns_used }
+     | Runtime_agent.Yielded_after_repeated_tool_call { turns_used; _ } ->
+       Agent_sdk.Agent_lifecycle_events.Yielded { turn = turns_used })
+;;
+
+let with_run_lifecycle_events ~event_bus ~keeper_name run =
+  Agent_sdk.Agent_lifecycle_events.with_run_lifecycle_events
+    ~event_bus
+    ~agent_name:keeper_name
+    ~raw_trace:None
+    ~current_run_id:(fun () -> None)
+    ~classify:lifecycle_outcome
+    run
+;;
+
 type prepared_turn =
   { messages : Agent_sdk.Types.message list
   ; system_prompt : string

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -116,3 +116,12 @@ val dynamic_tools :
   terminal_error:string option ref ->
   raw_trace_run:Agent_sdk.Raw_trace.active_run option ->
   (dynamic_tool list, Agent_sdk.Error.sdk_error) result
+
+val with_run_lifecycle_events :
+  event_bus:Agent_sdk.Event_bus.t option ->
+  keeper_name:string ->
+  (unit -> (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result) ->
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
+(** Publish the same typed start and terminal lifecycle owned by Agent Core.
+    Official clients own their internal model loop, so this host boundary is
+    the single MASC owner for those events. *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -284,7 +284,8 @@ let resolve_runtime_candidate id =
   | Some runtime ->
     (match runtime.Runtime.execution with
      | Runtime_execution.Codex_app_server _
-     | Runtime_execution.Claude_code _ -> Ok runtime
+     | Runtime_execution.Claude_code _
+     | Runtime_execution.Antigravity_cli _ -> Ok runtime
      | Runtime_execution.Agent_core provider_config ->
        let* _request_body_cap =
          validate_provider_request_cap

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -822,7 +822,6 @@ let run_named
             ~context_injector
             ~context
             ~event_bus
-            ~enable_thinking:inference_policy.attempt_enable_thinking
             ~config
         in
         let claude_result =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -807,6 +807,24 @@ let run_named
                   }))
         , None )
       | Runtime_execution.Claude_code config ->
+        let run_claude ~initial_messages () =
+          Keeper_claude_code_runtime.run
+            ~runtime_id:attempt_runtime_id
+            ~keeper_name
+            ~base_path
+            ~goal
+            ~goal_blocks
+            ~system_prompt
+            ~tools
+            ~initial_messages
+            ~model_input_projection
+            ~hooks
+            ~context_injector
+            ~context
+            ~event_bus
+            ~enable_thinking:inference_policy.attempt_enable_thinking
+            ~config
+        in
         let claude_result =
           match provider_config_transform, oas_checkpoint with
           | Some _, _ ->
@@ -818,30 +836,20 @@ let run_named
                         "provider config transforms cannot target a claude-code runtime"
                     }))
           | None, Some _ ->
-            Error
-              (Agent_sdk.Error.Config
-                 (Agent_sdk.Error.InvalidConfig
-                    { field = "oas_checkpoint"
-                    ; detail =
-                        "an OAS agent_core checkpoint cannot resume through a claude-code runtime"
-                    }))
-          | None, None ->
-            Keeper_claude_code_runtime.run
-              ~runtime_id:attempt_runtime_id
-              ~keeper_name
-              ~base_path
-              ~goal
-              ~goal_blocks
-              ~system_prompt
-              ~tools
-              ~initial_messages
-              ~model_input_projection
-              ~hooks
-              ~context_injector
-              ~context
-              ~event_bus
-              ~enable_thinking:inference_policy.attempt_enable_thinking
-              ~config
+            Log.Keeper.info
+              "%s: starting official-client runtime %s without OAS checkpoint history"
+              keeper_name
+              attempt_runtime_id;
+            emit_runtime_manifest
+              ~status:"fresh_session"
+              ~decision:
+                (`Assoc
+                  [ ("routing_action", `String "official_client_fresh_session")
+                  ; ("routing_reason", `String "official_client_owns_session_state")
+                  ])
+              Keeper_runtime_manifest.Runtime_routed;
+            run_claude ~initial_messages:[] ()
+          | None, None -> run_claude ~initial_messages ()
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let claude_result =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -836,7 +836,7 @@ let run_named
                     }))
           | None, Some _ ->
             Log.Keeper.info
-              "%s: starting official-client runtime %s without OAS checkpoint history"
+              "%s: starting official-client runtime %s without OAS resume while importing canonical history"
               keeper_name
               attempt_runtime_id;
             emit_runtime_manifest
@@ -847,7 +847,7 @@ let run_named
                   ; ("routing_reason", `String "official_client_owns_session_state")
                   ])
               Keeper_runtime_manifest.Runtime_routed;
-            run_claude ~initial_messages:[] ()
+            run_claude ~initial_messages ()
           | None, None -> run_claude ~initial_messages ()
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -285,6 +285,8 @@ let resolve_runtime_candidate id =
     (match runtime.Runtime.execution with
      | Runtime_execution.Codex_app_server _
      | Runtime_execution.Antigravity_cli _ -> Ok runtime
+     | Runtime_execution.Codex_app_server _
+     | Runtime_execution.Claude_code _ -> Ok runtime
      | Runtime_execution.Agent_core provider_config ->
        let* _request_body_cap =
          validate_provider_request_cap
@@ -804,6 +806,15 @@ let run_named
                   { field = "runtime_execution"
                   ; detail =
                       "antigravity-cli is configured but Keeper dispatch is not admitted"
+                  }))
+        , None )
+      | Runtime_execution.Claude_code _ ->
+        ( Error
+            (Agent_sdk.Error.Config
+               (Agent_sdk.Error.InvalidConfig
+                  { field = "claude_code"
+                  ; detail =
+                      "claude-code runtime is configured, but this stack layer does not yet contain its Keeper driver"
                   }))
         , None )
       | Runtime_execution.Agent_core runtime_provider_config ->

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -284,8 +284,6 @@ let resolve_runtime_candidate id =
   | Some runtime ->
     (match runtime.Runtime.execution with
      | Runtime_execution.Codex_app_server _
-     | Runtime_execution.Antigravity_cli _ -> Ok runtime
-     | Runtime_execution.Codex_app_server _
      | Runtime_execution.Claude_code _ -> Ok runtime
      | Runtime_execution.Agent_core provider_config ->
        let* _request_body_cap =
@@ -808,15 +806,59 @@ let run_named
                       "antigravity-cli is configured but Keeper dispatch is not admitted"
                   }))
         , None )
-      | Runtime_execution.Claude_code _ ->
-        ( Error
-            (Agent_sdk.Error.Config
-               (Agent_sdk.Error.InvalidConfig
-                  { field = "claude_code"
-                  ; detail =
-                      "claude-code runtime is configured, but this stack layer does not yet contain its Keeper driver"
-                  }))
-        , None )
+      | Runtime_execution.Claude_code config ->
+        let claude_result =
+          match provider_config_transform, oas_checkpoint with
+          | Some _, _ ->
+            Error
+              (Agent_sdk.Error.Config
+                 (Agent_sdk.Error.InvalidConfig
+                    { field = "provider_config_transform"
+                    ; detail =
+                        "provider config transforms cannot target a claude-code runtime"
+                    }))
+          | None, Some _ ->
+            Error
+              (Agent_sdk.Error.Config
+                 (Agent_sdk.Error.InvalidConfig
+                    { field = "oas_checkpoint"
+                    ; detail =
+                        "an OAS agent_core checkpoint cannot resume through a claude-code runtime"
+                    }))
+          | None, None ->
+            Keeper_claude_code_runtime.run
+              ~runtime_id:attempt_runtime_id
+              ~keeper_name
+              ~base_path
+              ~goal
+              ~goal_blocks
+              ~system_prompt
+              ~tools
+              ~initial_messages
+              ~model_input_projection
+              ~hooks
+              ~context_injector
+              ~context
+              ~event_bus
+              ~enable_thinking:inference_policy.attempt_enable_thinking
+              ~config
+        in
+        Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
+        let claude_result =
+          Result.bind claude_result (fun run_result ->
+            Keeper_turn_driver_try_provider.apply_accept
+              ~runtime_id:attempt_runtime_id
+              ~accept
+              run_result)
+        in
+        (match claude_result with
+         | Ok run_result ->
+           Option.iter
+             (fun observe ->
+               Option.iter observe run_result.Runtime_agent.runtime_observation)
+             on_runtime_observation
+         | Error _ -> ());
+        claude_result, None
       | Runtime_execution.Agent_core runtime_provider_config ->
        (match
           match provider_config_transform with

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -89,6 +89,8 @@ let vision_runtime_candidates ()
        match rt.Runtime.execution with
        | Runtime_execution.Codex_app_server _
        | Runtime_execution.Antigravity_cli _ -> None
+       | Runtime_execution.Codex_app_server _
+       | Runtime_execution.Claude_code _ -> None
        | Runtime_execution.Agent_core provider_config ->
          let caps = Runtime_agent.input_capabilities_of_runtime rt in
          if Runtime_agent.caps_admit_required_modalities caps [ "image" ]

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -88,9 +88,8 @@ let vision_runtime_candidates ()
   |> List.filter_map (fun (rt : Runtime.t) ->
        match rt.Runtime.execution with
        | Runtime_execution.Codex_app_server _
+       | Runtime_execution.Claude_code _
        | Runtime_execution.Antigravity_cli _ -> None
-       | Runtime_execution.Codex_app_server _
-       | Runtime_execution.Claude_code _ -> None
        | Runtime_execution.Agent_core provider_config ->
          let caps = Runtime_agent.input_capabilities_of_runtime rt in
          if Runtime_agent.caps_admit_required_modalities caps [ "image" ]

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -449,6 +449,8 @@ let capabilities_for_runtime (rt : t) =
   | Runtime_execution.Agent_core provider_config ->
     Llm_provider.Provider_config.capabilities_for_config_model provider_config
   | Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _ -> None
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Claude_code _ -> None
 ;;
 
 type max_context_source =
@@ -606,6 +608,8 @@ let validate_keeper_dispatch_request_caps
            (match runtime.execution with
             | Runtime_execution.Codex_app_server _
             | Runtime_execution.Antigravity_cli _ -> None
+            | Runtime_execution.Codex_app_server _
+            | Runtime_execution.Claude_code _ -> None
             | Runtime_execution.Agent_core provider_config ->
               (match
                  validate_request_body_cap
@@ -644,6 +648,8 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
          match r.execution, capabilities_for_runtime r with
          | (Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _), _ ->
            None
+         | ( Runtime_execution.Codex_app_server _
+           | Runtime_execution.Claude_code _ ), _ -> None
          | Runtime_execution.Agent_core _, Some _ -> None
          | Runtime_execution.Agent_core provider_config, None ->
            let provider_label =

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -448,9 +448,9 @@ let capabilities_for_runtime (rt : t) =
   match rt.execution with
   | Runtime_execution.Agent_core provider_config ->
     Llm_provider.Provider_config.capabilities_for_config_model provider_config
-  | Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _ -> None
   | Runtime_execution.Codex_app_server _
-  | Runtime_execution.Claude_code _ -> None
+  | Runtime_execution.Claude_code _
+  | Runtime_execution.Antigravity_cli _ -> None
 ;;
 
 type max_context_source =
@@ -607,9 +607,8 @@ let validate_keeper_dispatch_request_caps
          | Some runtime ->
            (match runtime.execution with
             | Runtime_execution.Codex_app_server _
+            | Runtime_execution.Claude_code _
             | Runtime_execution.Antigravity_cli _ -> None
-            | Runtime_execution.Codex_app_server _
-            | Runtime_execution.Claude_code _ -> None
             | Runtime_execution.Agent_core provider_config ->
               (match
                  validate_request_body_cap
@@ -646,10 +645,9 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
     List.filter_map
       (fun (r : t) ->
          match r.execution, capabilities_for_runtime r with
-         | (Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _), _ ->
-           None
          | ( Runtime_execution.Codex_app_server _
-           | Runtime_execution.Claude_code _ ), _ -> None
+           | Runtime_execution.Claude_code _
+           | Runtime_execution.Antigravity_cli _ ), _ -> None
          | Runtime_execution.Agent_core _, Some _ -> None
          | Runtime_execution.Agent_core provider_config, None ->
            let provider_label =

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -490,7 +490,10 @@ let codex_app_server_execution (provider : Runtime_schema.provider)
      | None ->
        Ok
          (Runtime_execution.Codex_app_server
-            { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
+            { cli_path = command
+            ; model = Some spec.api_name
+            ; timeout_s = Runtime_codex_app_server.default_timeout_s
+            }))
 ;;
 
 let runtime_antigravity_effort = function
@@ -585,7 +588,7 @@ let claude_code_execution (provider : Runtime_schema.provider)
          (Runtime_execution.Claude_code
             { cli_path = command
             ; model = Some spec.api_name
-            ; timeout_s = 300.0
+            ; timeout_s = Runtime_claude_code.default_timeout_s
             }))
 ;;
 

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -203,8 +203,7 @@ let messages_api_compatible_provider_kind = function
 let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.provider)
     : (Llm_provider.Provider_config.provider_kind, string) result =
   match provider.api_format with
-  | Codex_app_server_runtime | Antigravity_cli_runtime ->
-  | Codex_app_server_runtime | Claude_code_runtime ->
+  | Codex_app_server_runtime | Claude_code_runtime | Antigravity_cli_runtime ->
     Error
       (Printf.sprintf
          "provider %S uses official CLI protocol %s and cannot be materialized as an \

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -204,6 +204,7 @@ let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.p
     : (Llm_provider.Provider_config.provider_kind, string) result =
   match provider.api_format with
   | Codex_app_server_runtime | Antigravity_cli_runtime ->
+  | Codex_app_server_runtime | Claude_code_runtime ->
     Error
       (Printf.sprintf
          "provider %S uses official CLI protocol %s and cannot be materialized as an \
@@ -551,6 +552,43 @@ let antigravity_cli_execution (provider : Runtime_schema.provider)
             }))
 ;;
 
+let claude_code_execution (provider : Runtime_schema.provider)
+    (spec : Runtime_schema.model_spec) : (Runtime_execution.t, string) result =
+  match provider.transport with
+  | Http _ ->
+    Error
+      (Printf.sprintf
+         "provider %S uses protocol claude-code but declares an HTTP endpoint; \
+          an official Claude Code CLI command is required"
+         provider.id)
+  | Cli command when String.trim command = "" ->
+    Error
+      (Printf.sprintf
+         "provider %S declares an empty Claude Code CLI command"
+         provider.id)
+  | Cli command ->
+    (match provider.credentials with
+     | Some _ ->
+       Error
+         (Printf.sprintf
+            "provider %S uses claude-code and must not declare credentials; \
+             the official Claude Code client owns subscription login"
+            provider.id)
+     | None when not provider.is_non_interactive ->
+       Error
+         (Printf.sprintf
+            "provider %S uses claude-code and must declare \
+             is-non-interactive = true"
+            provider.id)
+     | None ->
+       Ok
+         (Runtime_execution.Claude_code
+            { cli_path = command
+            ; model = Some spec.api_name
+            ; timeout_s = 300.0
+            }))
+;;
+
 let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema.binding)
     : (Runtime_execution.t, string) result =
   match Runtime_schema.model_of_id cfg binding.model_id with
@@ -564,6 +602,8 @@ let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema
           codex_app_server_execution provider spec
         | Runtime_schema.Antigravity_cli_runtime ->
           antigravity_cli_execution provider spec
+        | Runtime_schema.Claude_code_runtime ->
+          claude_code_execution provider spec
         | Messages_api | Chat_completions_api | Ollama_api ->
           Result.map
             (fun provider_config -> Runtime_execution.Agent_core provider_config)

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -39,3 +39,5 @@ val binding_to_execution
     a credential-free CLI transport becomes
     {!Runtime_execution.Codex_app_server}; [antigravity-cli] becomes a typed
     {!Runtime_execution.Antigravity_cli}. Other CLI protocols remain rejected. *)
+    {!Runtime_execution.Codex_app_server}; [claude-code] becomes
+    {!Runtime_execution.Claude_code}. Other CLI protocols remain rejected. *)

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -37,7 +37,6 @@ val binding_to_execution
 (** Materialize the owner of a complete turn. HTTP model APIs become
     {!Runtime_execution.Agent_core}. The exact [codex-app-server] protocol over
     a credential-free CLI transport becomes
-    {!Runtime_execution.Codex_app_server}; [antigravity-cli] becomes a typed
-    {!Runtime_execution.Antigravity_cli}. Other CLI protocols remain rejected. *)
     {!Runtime_execution.Codex_app_server}; [claude-code] becomes
-    {!Runtime_execution.Claude_code}. Other CLI protocols remain rejected. *)
+    {!Runtime_execution.Claude_code}; and [antigravity-cli] becomes
+    {!Runtime_execution.Antigravity_cli}. Other CLI protocols remain rejected. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -685,6 +685,8 @@ let input_capabilities_of_runtime (rt : Runtime.t) =
       provider_caps_of_config provider_config
     | Runtime_execution.Codex_app_server _
     | Runtime_execution.Antigravity_cli _ ->
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _ ->
       Llm_provider.Capabilities.default_capabilities
   in
   apply_runtime_model_input_capabilities

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -684,9 +684,8 @@ let input_capabilities_of_runtime (rt : Runtime.t) =
     | Runtime_execution.Agent_core provider_config ->
       provider_caps_of_config provider_config
     | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _
     | Runtime_execution.Antigravity_cli _ ->
-    | Runtime_execution.Codex_app_server _
-    | Runtime_execution.Claude_code _ ->
       Llm_provider.Capabilities.default_capabilities
   in
   apply_runtime_model_input_capabilities

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -288,7 +288,7 @@ let read_subscription ~mgr ~cwd config =
   | Eio.Exn.Io
       (Eio.Process.E (Eio.Process.Executable_not_found executable), _) ->
     Error (Spawn_failed (Printf.sprintf "executable %S was not found" executable))
-  | exn -> Error (Subscription_required (Printexc.to_string exn))
+  | exn -> Error (Spawn_failed (Printexc.to_string exn))
 ;;
 
 let dynamic_tool_spec (tool : dynamic_tool) =

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -285,6 +285,9 @@ let read_subscription ~mgr ~cwd config =
     |> fun result -> Result.bind result parse_subscription
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Eio.Exn.Io
+      (Eio.Process.E (Eio.Process.Executable_not_found executable), _) ->
+    Error (Spawn_failed (Printf.sprintf "executable %S was not found" executable))
   | exn -> Error (Subscription_required (Printexc.to_string exn))
 ;;
 
@@ -893,14 +896,19 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
             ~on_turn_started)))
 ;;
 
-let validate_config config ~session_mode ~prompt =
+let validate_process_config config =
   if String.trim config.cli_path = ""
   then Error (Invalid_config "cli_path must not be empty")
   else if String.trim config.cwd = "" || Filename.is_relative config.cwd
   then Error (Invalid_config "cwd must be an absolute path")
   else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
   then Error (Invalid_config "timeout_s must be positive and finite")
-  else if String.trim prompt = ""
+  else Ok ()
+;;
+
+let validate_config config ~session_mode ~prompt =
+  let* () = validate_process_config config in
+  if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
   else
     match session_mode with
@@ -941,7 +949,13 @@ let validate_turn ?(dynamic_tools = []) ?(session_mode = Start) config ~prompt =
   validate_dynamic_tools dynamic_tools
 ;;
 
+let probe_subscription ~mgr ~cwd config =
+  let* () = validate_process_config config in
+  read_subscription ~mgr ~cwd config
+;;
+
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
+    ?admitted_subscription
     ~mgr ~clock ~cwd ?(on_session_ready = fun ~session_id:_ -> Ok ())
     ?(on_turn_starting = fun ~session_id:_ -> Ok ())
     ?(on_turn_started = fun ~session_id:_ ~turn_id:_ -> Ok ()) config
@@ -949,7 +963,11 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
   let result =
     let* () = validate_turn ~dynamic_tools ~session_mode config ~prompt in
     let* _ = reasoning_args reasoning_effort in
-    let* subscription = read_subscription ~mgr ~cwd config in
+    let* subscription =
+      match admitted_subscription with
+      | Some subscription -> Ok subscription
+      | None -> probe_subscription ~mgr ~cwd config
+    in
     let session_id =
       match session_mode with
       | Start -> Random_id.uuid_v7 ()

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -83,6 +83,11 @@ type error =
       }
   | Subscription_required of string
   | Unsupported_control_request of string
+  | Turn_transport_interrupted of
+      { stage : string
+      ; tool_effect_attempted : bool
+      ; detail : string
+      }
   | Turn_failed of string
   | Quota_blocked of
       { api_error_status : int option
@@ -100,6 +105,12 @@ let error_to_string = function
     "Claude Code subscription login required: " ^ detail
   | Unsupported_control_request subtype ->
     "Claude Code requested unsupported control action: " ^ subtype
+  | Turn_transport_interrupted { stage; tool_effect_attempted; detail } ->
+    Printf.sprintf
+      "Claude Code turn transport interrupted during %s (tool_effect_attempted=%b): %s"
+      stage
+      tool_effect_attempted
+      detail
   | Turn_failed detail -> "Claude Code turn failed: " ^ detail
   | Quota_blocked { api_error_status; rate_limit } ->
     let status =
@@ -127,6 +138,7 @@ let error_kind = function
   | Protocol_error _ -> "protocol_error"
   | Subscription_required _ -> "subscription_required"
   | Unsupported_control_request _ -> "unsupported_control_request"
+  | Turn_transport_interrupted _ -> "turn_transport_interrupted"
   | Turn_failed _ -> "turn_failed"
   | Quota_blocked _ -> "quota_blocked"
   | Process_exited _ -> "process_exited"
@@ -334,7 +346,40 @@ let send_control_error io ~request_id detail =
        ])
 ;;
 
-let handle_control_request io ~mcp_session ~tools ~tool_call_count fields =
+type control_phase =
+  | Before_turn_admission
+  | Turn_admitted
+
+let send_control_response
+      io
+      ~control_phase
+      ~stage
+      ~tool_effect_attempted
+      response
+  =
+  try
+    response ();
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    let detail = Printexc.to_string exn in
+    (match control_phase with
+     | Before_turn_admission -> protocol_error stage detail
+     | Turn_admitted ->
+       Error
+         (Turn_transport_interrupted
+            { stage; tool_effect_attempted; detail }))
+;;
+
+let handle_control_request
+      io
+      ~control_phase
+      ~mcp_session
+      ~tools
+      ~tool_call_count
+      fields
+  =
   let stage = "control request" in
   let* request_id = required_string stage "request_id" fields in
   let* request = required_member stage "request" fields in
@@ -346,7 +391,14 @@ let handle_control_request io ~mcp_session ~tools ~tool_call_count fields =
     if server_name <> mcp_server_name
     then
       let detail = Printf.sprintf "unknown SDK MCP server %S" server_name in
-      send_control_error io ~request_id detail;
+      let* () =
+        send_control_response
+          io
+          ~control_phase
+          ~stage:"control error response"
+          ~tool_effect_attempted:false
+          (fun () -> send_control_error io ~request_id detail)
+      in
       Error (Unsupported_control_request subtype)
     else
       let* message = required_member stage "message" request_fields in
@@ -374,6 +426,11 @@ let handle_control_request io ~mcp_session ~tools ~tool_call_count fields =
         Runtime_official_client_mcp.handle_message
           ~session:mcp_session
           ~server_name:mcp_server_name
+          ~tool_call_policy:
+            (match control_phase with
+             | Before_turn_admission ->
+               Runtime_official_client_mcp.Reject_tool_calls
+             | Turn_admitted -> Runtime_official_client_mcp.Allow_tool_calls)
           ~tool_specs
           ~call_tool
           message
@@ -384,16 +441,29 @@ let handle_control_request io ~mcp_session ~tools ~tool_call_count fields =
       (match dispatch.response with
        | None -> Ok ()
        | Some mcp_response ->
-         send_control_success
+         send_control_response
            io
-           ~request_id
-           (`Assoc [ "mcp_response", mcp_response ]);
-         Ok ())
+           ~control_phase
+           ~stage:"control success response"
+           ~tool_effect_attempted:dispatch.tool_called
+           (fun () ->
+             send_control_success
+               io
+               ~request_id
+               (`Assoc [ "mcp_response", mcp_response ])))
   | unsupported ->
-    send_control_error
-      io
-      ~request_id
-      (Printf.sprintf "MASC does not support control request %S" unsupported);
+    let* () =
+      send_control_response
+        io
+        ~control_phase
+        ~stage:"control error response"
+        ~tool_effect_attempted:false
+        (fun () ->
+          send_control_error
+            io
+            ~request_id
+            (Printf.sprintf "MASC does not support control request %S" unsupported))
+    in
     Error (Unsupported_control_request unsupported)
 ;;
 
@@ -447,7 +517,13 @@ let rec await_initialize io ~mcp_session ~tools ~tool_call_count ~request_id ~ig
     parse_control_response ~expected_request_id:request_id fields
   | "control_request" ->
     let* () =
-      handle_control_request io ~mcp_session ~tools ~tool_call_count fields
+      handle_control_request
+        io
+        ~control_phase:Before_turn_admission
+        ~mcp_session
+        ~tools
+        ~tool_call_count
+        fields
     in
     await_initialize io ~mcp_session ~tools ~tool_call_count ~request_id ~ignored
   | ("system" | "rate_limit_event") when ignored < 32 ->
@@ -570,26 +646,25 @@ let parse_result ~expected_session_id ~rate_limit fields =
       | Some _ -> protocol_error stage "field \"result\" must be a string or null"
     in
     let* result = result in
-    if is_error
+    let structurally_quota_blocked =
+      Option.equal Int.equal api_error_status (Some 429)
+      || Option.exists
+           (fun (limit : rate_limit) -> limit.status = Rejected)
+           rate_limit
+    in
+    if structurally_quota_blocked
+    then Error (Quota_blocked { api_error_status; rate_limit })
+    else if is_error
     then
-      let structurally_quota_blocked =
-        Option.equal Int.equal api_error_status (Some 429)
-        || Option.exists
-             (fun (limit : rate_limit) -> limit.status = Rejected)
-             rate_limit
-      in
-      if structurally_quota_blocked
-      then Error (Quota_blocked { api_error_status; rate_limit })
-      else
-        Error
-          (Turn_failed
-             (Printf.sprintf
-                "terminal subtype=%s api_status=%s"
-                subtype
-                (Option.fold
-                   ~none:"unknown"
-                   ~some:string_of_int
-                   api_error_status)))
+      Error
+        (Turn_failed
+           (Printf.sprintf
+              "terminal subtype=%s api_status=%s"
+              subtype
+              (Option.fold
+                 ~none:"unknown"
+                 ~some:string_of_int
+                 api_error_status)))
     else if subtype <> "success"
     then Error (Turn_failed (Printf.sprintf "terminal subtype=%s" subtype))
     else Ok (turn_id, result)
@@ -605,7 +680,13 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
   match type_ with
   | "control_request" ->
     let* () =
-      handle_control_request io ~mcp_session ~tools ~tool_call_count fields
+      handle_control_request
+        io
+        ~control_phase:Turn_admitted
+        ~mcp_session
+        ~tools
+        ~tool_call_count
+        fields
     in
     await_terminal
       io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
@@ -822,7 +903,20 @@ let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
     invoke_state_callback ~stage:"turn starting callback" (fun () ->
       on_turn_starting ~session_id)
   in
-  io.send (user_message prompt);
+  let* () =
+    try
+      io.send (user_message prompt);
+      Ok ()
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (Turn_transport_interrupted
+           { stage = "user message write"
+           ; tool_effect_attempted = false
+           ; detail = Printexc.to_string exn
+           })
+  in
   await_terminal
     io
     ~mcp_session

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -72,6 +72,11 @@ type error =
       }
   | Subscription_required of string
   | Unsupported_control_request of string
+  | Turn_transport_interrupted of
+      { stage : string
+      ; tool_effect_attempted : bool
+      ; detail : string
+      }
   | Turn_failed of string
   | Quota_blocked of
       { api_error_status : int option

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -18,6 +18,7 @@ type config =
   ; timeout_s : float
   }
 
+val default_timeout_s : float
 val default_config : cwd:string -> config
 
 type session_mode =

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -4,7 +4,7 @@
     Claude Code owns the subscription session and model loop. MASC owns the
     child lifetime, exact SDK-control/MCP bridge, and terminal projection. *)
 
-type subscription =
+type subscription = private
   { auth_method : string
   ; subscription_type : string
   ; api_provider : string
@@ -86,10 +86,19 @@ val validate_turn :
   prompt:string ->
   (unit, error) result
 
+val probe_subscription :
+  mgr:_ Eio.Process.mgr ->
+  cwd:Eio.Fs.dir_ty Eio.Path.t ->
+  config ->
+  (subscription, error) result
+(** Measure the official CLI login without submitting a model turn. The child
+    receives the same credential-scrubbed environment as [run_turn]. *)
+
 val run_turn :
   ?dynamic_tools:dynamic_tool list ->
   ?reasoning_effort:Llm_provider.Reasoning_effort.t ->
   ?session_mode:session_mode ->
+  ?admitted_subscription:subscription ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -29,6 +29,8 @@ type rate_limit_status =
   | Allowed_warning
   | Rejected
 
+val rate_limit_status_to_string : rate_limit_status -> string
+
 type rate_limit =
   { status : rate_limit_status
   ; rate_limit_type : string option

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -16,6 +16,7 @@ type config =
   ; timeout_s : float
   }
 
+val default_timeout_s : float
 val default_config : unit -> config
 
 type thread_mode =

--- a/lib/runtime/runtime_execution.ml
+++ b/lib/runtime/runtime_execution.ml
@@ -15,10 +15,17 @@ type antigravity_cli =
   ; timeout_s : float
   }
 
+type claude_code =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
   | Antigravity_cli of antigravity_cli
+  | Claude_code of claude_code
 
 type checkpoint_owner =
   | Masc_oas
@@ -27,21 +34,25 @@ type checkpoint_owner =
 let agent_core_provider_config = function
   | Agent_core config -> Some config
   | Codex_app_server _ | Antigravity_cli _ -> None
+  | Codex_app_server _ | Claude_code _ -> None
 ;;
 
 let model_id = function
   | Agent_core config -> Some config.Llm_provider.Provider_config.model_id
   | Codex_app_server config -> config.model
   | Antigravity_cli config -> Some config.model
+  | Claude_code config -> config.model
 ;;
 
 let label = function
   | Agent_core _ -> "agent_core"
   | Codex_app_server _ -> "codex_app_server"
   | Antigravity_cli _ -> "antigravity_cli"
+  | Claude_code _ -> "claude_code"
 ;;
 
 let checkpoint_owner = function
   | Agent_core _ -> Masc_oas
   | Codex_app_server _ | Antigravity_cli _ -> Official_client
+  | Codex_app_server _ | Claude_code _ -> Official_client
 ;;

--- a/lib/runtime/runtime_execution.ml
+++ b/lib/runtime/runtime_execution.ml
@@ -33,8 +33,7 @@ type checkpoint_owner =
 
 let agent_core_provider_config = function
   | Agent_core config -> Some config
-  | Codex_app_server _ | Antigravity_cli _ -> None
-  | Codex_app_server _ | Claude_code _ -> None
+  | Codex_app_server _ | Claude_code _ | Antigravity_cli _ -> None
 ;;
 
 let model_id = function
@@ -53,6 +52,5 @@ let label = function
 
 let checkpoint_owner = function
   | Agent_core _ -> Masc_oas
-  | Codex_app_server _ | Antigravity_cli _ -> Official_client
-  | Codex_app_server _ | Claude_code _ -> Official_client
+  | Codex_app_server _ | Claude_code _ | Antigravity_cli _ -> Official_client
 ;;

--- a/lib/runtime/runtime_execution.mli
+++ b/lib/runtime/runtime_execution.mli
@@ -2,11 +2,10 @@
 
     [Agent_core] means MASC/OAS owns the model/tool/checkpoint loop.
     [Codex_app_server] means the official Codex client owns the whole turn;
+    [Claude_code] means the same for the official Claude Code client; and
     [Antigravity_cli] means the official Antigravity client owns its model and
     built-in tool loop. MASC owns admission, process lifetime, durable session
     identity, and result projection. *)
-    [Claude_code] means the same for the official Claude Code client.
-    MASC owns admission, process lifetime, and result projection. *)
 
 type codex_app_server =
   { cli_path : string

--- a/lib/runtime/runtime_execution.mli
+++ b/lib/runtime/runtime_execution.mli
@@ -5,6 +5,8 @@
     [Antigravity_cli] means the official Antigravity client owns its model and
     built-in tool loop. MASC owns admission, process lifetime, durable session
     identity, and result projection. *)
+    [Claude_code] means the same for the official Claude Code client.
+    MASC owns admission, process lifetime, and result projection. *)
 
 type codex_app_server =
   { cli_path : string
@@ -23,10 +25,17 @@ type antigravity_cli =
   ; timeout_s : float
   }
 
+type claude_code =
+  { cli_path : string
+  ; model : string option
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
   | Antigravity_cli of antigravity_cli
+  | Claude_code of claude_code
 
 type checkpoint_owner =
   | Masc_oas

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -84,15 +84,11 @@ let resolve_runtime_providers ~runtime_id () =
     match rt.Runtime.execution with
     | Runtime_execution.Agent_core provider_config -> Ok provider_config
     | Runtime_execution.Codex_app_server _
-    | Runtime_execution.Claude_code _ ->
-      Error
-        (Printf.sprintf
-           "runtime %S is owned by an official CLI client, not the OAS agent_core"
-           rt.Runtime.id)
+    | Runtime_execution.Claude_code _
     | Runtime_execution.Antigravity_cli _ ->
       Error
         (Printf.sprintf
-           "runtime %S is owned by antigravity-cli, not the OAS agent_core"
+           "runtime %S is owned by an official CLI client, not the OAS agent_core"
            rt.Runtime.id)
   in
   if String.equal runtime_id "" then

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -83,10 +83,11 @@ let resolve_runtime_providers ~runtime_id () =
   let provider_config_of_runtime rt =
     match rt.Runtime.execution with
     | Runtime_execution.Agent_core provider_config -> Ok provider_config
-    | Runtime_execution.Codex_app_server _ ->
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _ ->
       Error
         (Printf.sprintf
-           "runtime %S is owned by codex-app-server, not the OAS agent_core"
+           "runtime %S is owned by an official CLI client, not the OAS agent_core"
            rt.Runtime.id)
     | Runtime_execution.Antigravity_cli _ ->
       Error

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -13,6 +13,10 @@ type dispatch =
   ; tool_called : bool
   }
 
+type tool_call_policy =
+  | Reject_tool_calls
+  | Allow_tool_calls
+
 type phase =
   | Awaiting_initialize
   | Awaiting_initialized
@@ -240,7 +244,14 @@ let decode_message message =
     Ok { method_name; request_id; params }
 ;;
 
-let dispatch_message ~session ~server_name ~tool_specs ~call_tool message =
+let dispatch_message
+      ~session
+      ~server_name
+      ~tool_call_policy
+      ~tool_specs
+      ~call_tool
+      message
+  =
   match message.method_name, message.request_id with
     | "initialize", Some request_id ->
       let* () = require_phase session ~stage:"MCP initialize" Awaiting_initialize in
@@ -270,10 +281,16 @@ let dispatch_message ~session ~server_name ~tool_specs ~call_tool message =
         }
     | "tools/call", Some request_id ->
       let* () = require_phase session ~stage:"MCP tools/call" Ready in
-      tools_call
-        ~id:(Mcp_transport_protocol.request_id_to_yojson request_id)
-        ~params:message.params
-        ~call_tool
+      (match tool_call_policy with
+       | Reject_tool_calls ->
+         error
+           "MCP tools/call"
+           "tool calls are not admitted before the owning turn is durable"
+       | Allow_tool_calls ->
+         tools_call
+           ~id:(Mcp_transport_protocol.request_id_to_yojson request_id)
+           ~params:message.params
+           ~call_tool)
     | "notifications/initialized", None ->
       let* () =
         transition_phase
@@ -300,7 +317,20 @@ let dispatch_message ~session ~server_name ~tool_specs ~call_tool message =
         }
 ;;
 
-let handle_message ~session ~server_name ~tool_specs ~call_tool message_json =
+let handle_message
+      ~session
+      ~server_name
+      ~tool_call_policy
+      ~tool_specs
+      ~call_tool
+      message_json
+  =
   let* message = decode_message message_json in
-  dispatch_message ~session ~server_name ~tool_specs ~call_tool message
+  dispatch_message
+    ~session
+    ~server_name
+    ~tool_call_policy
+    ~tool_specs
+    ~call_tool
+    message
 ;;

--- a/lib/runtime/runtime_official_client_mcp.mli
+++ b/lib/runtime/runtime_official_client_mcp.mli
@@ -20,6 +20,10 @@ type dispatch =
   ; tool_called : bool
   }
 
+type tool_call_policy =
+  | Reject_tool_calls
+  | Allow_tool_calls
+
 type session
 
 val create_session : unit -> session
@@ -28,6 +32,7 @@ val create_session : unit -> session
 val handle_message :
   session:session ->
   server_name:string ->
+  tool_call_policy:tool_call_policy ->
   tool_specs:(unit -> Yojson.Safe.t list) ->
   call_tool:
     (name:string ->

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -15,6 +15,7 @@ type api_format =
   | Ollama_api
   | Codex_app_server_runtime
   | Antigravity_cli_runtime
+  | Claude_code_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -13,6 +13,7 @@ type api_format =
   | Ollama_api
   | Codex_app_server_runtime
   | Antigravity_cli_runtime
+  | Claude_code_runtime
 [@@deriving show, eq]
 
 type transport =

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -107,9 +107,7 @@ let partition_results
 let canonical_protocol_of_protocol = function
   | "messages-cli" | "messages-http" | "openai-compatible-cli"
   | "openai-compatible-http" | "ollama-http" | "codex-app-server"
-  | "antigravity-cli" as protocol ->
-  | "openai-compatible-http" | "ollama-http" | "codex-app-server"
-  | "claude-code" as protocol ->
+  | "claude-code" | "antigravity-cli" as protocol ->
     Some protocol
   | _ -> None
 ;;
@@ -118,8 +116,7 @@ let unknown_protocol_error s =
   Printf.sprintf
     "unknown protocol %S: expected one of messages-cli, messages-http, \
      openai-compatible-cli, openai-compatible-http, ollama-http, \
-     codex-app-server, antigravity-cli"
-     codex-app-server, claude-code"
+     codex-app-server, claude-code, antigravity-cli"
     s
 ;;
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -108,6 +108,8 @@ let canonical_protocol_of_protocol = function
   | "messages-cli" | "messages-http" | "openai-compatible-cli"
   | "openai-compatible-http" | "ollama-http" | "codex-app-server"
   | "antigravity-cli" as protocol ->
+  | "openai-compatible-http" | "ollama-http" | "codex-app-server"
+  | "claude-code" as protocol ->
     Some protocol
   | _ -> None
 ;;
@@ -117,6 +119,7 @@ let unknown_protocol_error s =
     "unknown protocol %S: expected one of messages-cli, messages-http, \
      openai-compatible-cli, openai-compatible-http, ollama-http, \
      codex-app-server, antigravity-cli"
+     codex-app-server, claude-code"
     s
 ;;
 
@@ -130,6 +133,7 @@ let api_format_of_protocol (s : string)
   | "ollama-http" -> Ok Runtime_schema.Ollama_api
   | "codex-app-server" -> Ok Runtime_schema.Codex_app_server_runtime
   | "antigravity-cli" -> Ok Runtime_schema.Antigravity_cli_runtime
+  | "claude-code" -> Ok Runtime_schema.Claude_code_runtime
   | _ -> Error (unknown_protocol_error s)
 ;;
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -374,7 +374,11 @@ let antigravity_cli_options ~(path : string) (tbl : Otoml.t)
                ; disable_slash_commands
                ; timeout_s
                })))
-  | Messages_api | Chat_completions_api | Ollama_api | Codex_app_server_runtime ->
+  | Messages_api
+  | Chat_completions_api
+  | Ollama_api
+  | Codex_app_server_runtime
+  | Claude_code_runtime ->
     (match
        List.find_opt
          (fun key -> Option.is_some (Otoml.find_opt tbl Fun.id [ key ]))

--- a/lib/runtime/runtime_toml.mli
+++ b/lib/runtime/runtime_toml.mli
@@ -34,7 +34,8 @@ val parse_file : string -> (Runtime_schema.config, parse_error list) result
 val api_format_of_protocol : string -> (Runtime_schema.api_format, string) result
 (** Map a TOML protocol string to a {!Runtime_schema.api_format} variant. Only
     the canonical labels are accepted: [messages-cli], [messages-http],
-    [openai-compatible-cli], [openai-compatible-http], [ollama-http]. The
+    [openai-compatible-cli], [openai-compatible-http], [ollama-http],
+    [codex-app-server], and [claude-code]. The
     deprecated provider-letter aliases [provider_d-http] / [provider-d-cli]
     (renamed in v0.19.43) are rejected with an "unknown protocol" error — they
     are NOT silently canonicalized — so a checked-in config still using them

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -776,6 +776,8 @@ let dashboard_runtime_probe_url ~(api_format : Runtime_schema.api_format) base_u
   match api_format with
   | Runtime_schema.Codex_app_server_runtime
   | Runtime_schema.Antigravity_cli_runtime -> None
+  | Runtime_schema.Codex_app_server_runtime
+  | Runtime_schema.Claude_code_runtime -> None
   | Runtime_schema.Ollama_api ->
     let base = dashboard_runtime_trim_trailing_slashes base_url in
     Some
@@ -887,6 +889,8 @@ let dashboard_runtime_model_count_of_body ~(api_format : Runtime_schema.api_form
     match api_format with
     | Runtime_schema.Codex_app_server_runtime
     | Runtime_schema.Antigravity_cli_runtime -> None
+    | Runtime_schema.Codex_app_server_runtime
+    | Runtime_schema.Claude_code_runtime -> None
     | Runtime_schema.Ollama_api -> dashboard_runtime_list_member_len "models" json
     | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
       (match dashboard_runtime_list_member_len "data" json with
@@ -1572,6 +1576,16 @@ let runtime_request_config_json (rt : Runtime.t) =
       ; "timeout_s", `Float config.timeout_s
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Claude_code config ->
+    `Assoc
+      [ "source", `String "official-client-runtime"
+      ; "execution", `String "claude_code"
+      ; "model", Json_util.string_opt_to_json config.model
+      ; "timeout_s", `Float config.timeout_s
+      ; "execution_mode", `String "masc_mcp_only"
+      ; "tool_owner", `String "masc_mcp"
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core cfg ->
     `Assoc
     [ "source", `String "oas-provider-config"
@@ -1618,6 +1632,7 @@ let runtime_api_format_wire : Runtime_schema.api_format -> string = function
   | Runtime_schema.Ollama_api -> "ollama"
   | Runtime_schema.Codex_app_server_runtime -> "codex-app-server"
   | Runtime_schema.Antigravity_cli_runtime -> "antigravity-cli"
+  | Runtime_schema.Claude_code_runtime -> "claude-code"
 ;;
 
 let runtime_provider_behavior_capabilities_json
@@ -1733,6 +1748,14 @@ let effective_capabilities_json (rt : Runtime.t) =
       ; "execution", `String "antigravity_cli"
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Claude_code _ ->
+    `Assoc
+      [ "source", `String "unverified"
+      ; "execution", `String "claude_code"
+      ; "execution_mode", `String "masc_mcp_only"
+      ; "tool_owner", `String "masc_mcp"
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core provider_config ->
    (match Llm_provider.Provider_config.capabilities_for_config_model provider_config with
   | None -> `Null
@@ -1818,6 +1841,13 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
       [ "source", `String "official-client-owned"
       ; "execution", `String "antigravity_cli"
       ]
+  | Runtime_execution.Claude_code _ ->
+    `Assoc
+      [ "source", `String "official-client-owned"
+      ; "execution", `String "claude_code"
+      ; "execution_mode", `String "masc_mcp_only"
+      ; "tool_owner", `String "masc_mcp"
+      ]
   | Runtime_execution.Agent_core provider_config ->
     let dialect = RD.for_provider_config provider_config in
     let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
@@ -1847,6 +1877,8 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     match rt.execution with
     | Runtime_execution.Codex_app_server _
     | Runtime_execution.Antigravity_cli _ -> true
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _ -> true
     | Runtime_execution.Agent_core _ -> false
   in
   let runtime_status =

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -775,9 +775,8 @@ let dashboard_runtime_append_probe_path base ~suffix =
 let dashboard_runtime_probe_url ~(api_format : Runtime_schema.api_format) base_url =
   match api_format with
   | Runtime_schema.Codex_app_server_runtime
+  | Runtime_schema.Claude_code_runtime
   | Runtime_schema.Antigravity_cli_runtime -> None
-  | Runtime_schema.Codex_app_server_runtime
-  | Runtime_schema.Claude_code_runtime -> None
   | Runtime_schema.Ollama_api ->
     let base = dashboard_runtime_trim_trailing_slashes base_url in
     Some
@@ -888,9 +887,8 @@ let dashboard_runtime_model_count_of_body ~(api_format : Runtime_schema.api_form
     let json = Yojson.Safe.from_string body in
     match api_format with
     | Runtime_schema.Codex_app_server_runtime
+    | Runtime_schema.Claude_code_runtime
     | Runtime_schema.Antigravity_cli_runtime -> None
-    | Runtime_schema.Codex_app_server_runtime
-    | Runtime_schema.Claude_code_runtime -> None
     | Runtime_schema.Ollama_api -> dashboard_runtime_list_member_len "models" json
     | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
       (match dashboard_runtime_list_member_len "data" json with
@@ -1876,9 +1874,8 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
   let is_official_client_runtime =
     match rt.execution with
     | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _
     | Runtime_execution.Antigravity_cli _ -> true
-    | Runtime_execution.Codex_app_server _
-    | Runtime_execution.Claude_code _ -> true
     | Runtime_execution.Agent_core _ -> false
   in
   let runtime_status =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -90,10 +90,11 @@ let finalize_runtime_breakdown json =
 
 let validate_requested_model (runtime : Runtime.t) requested_model =
   match runtime.execution with
-  | Runtime_execution.Codex_app_server _ ->
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Claude_code _ ->
     Error
       (Printf.sprintf
-         "runtime %S is owned by codex-app-server; local_runtime_bench only \
+         "runtime %S is owned by an official CLI client; local_runtime_bench only \
           measures OAS agent_core providers"
          runtime.id)
   | Runtime_execution.Antigravity_cli _ ->

--- a/packages/agent_core/lib/agent_sdk.ml
+++ b/packages/agent_core/lib/agent_sdk.ml
@@ -96,6 +96,7 @@ module Raw_trace_query = Raw_trace_query
 module Handoff = Handoff
 module Agent_types = Agent_types
 module Agent_lifecycle = Agent_lifecycle
+module Agent_lifecycle_events = Agent_lifecycle_events
 module Agent_turn = Agent_turn
 module Agent_tools = Agent_tools
 module Agent_checkpoint = Agent_checkpoint

--- a/packages/agent_core/lib/agent_sdk.mli
+++ b/packages/agent_core/lib/agent_sdk.mli
@@ -65,6 +65,7 @@ module Handoff = Handoff
 
 module Agent_types = Agent_types
 module Agent_lifecycle = Agent_lifecycle
+module Agent_lifecycle_events = Agent_lifecycle_events
 module Agent_turn = Agent_turn
 module Agent_tools = Agent_tools
 module Agent_checkpoint = Agent_checkpoint

--- a/test/dune
+++ b/test/dune
@@ -1952,6 +1952,7 @@
 (include stanzas/test_runtime_claude_code.inc)
 (include stanzas/test_runtime_antigravity.inc)
 (include stanzas/test_runtime_claude_code_config.inc)
+(include stanzas/test_keeper_claude_code_runtime.inc)
 (include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/dune
+++ b/test/dune
@@ -1951,6 +1951,7 @@
 (include stanzas/test_runtime_codex_app_server.inc)
 (include stanzas/test_runtime_claude_code.inc)
 (include stanzas/test_runtime_antigravity.inc)
+(include stanzas/test_runtime_claude_code_config.inc)
 (include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/stanzas/test_keeper_claude_code_runtime.inc
+++ b/test/stanzas/test_keeper_claude_code_runtime.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_claude_code_runtime)
+ (modules test_keeper_claude_code_runtime)
+ (libraries masc masc_test_deps))

--- a/test/stanzas/test_runtime_claude_code_config.inc
+++ b/test/stanzas/test_runtime_claude_code_config.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_claude_code_config)
+ (modules test_runtime_claude_code_config)
+ (libraries alcotest masc.runtime))

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -32,7 +32,11 @@ let quota_result =
 ;;
 
 let mcp_initialize =
-  {|{"type":"control_request","request_id":"mcp-init-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}}}|}
+  {|{"type":"control_request","request_id":"mcp-init-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"claude-code-fixture","version":"1"}}}}}|}
+;;
+
+let mcp_initialized_notification =
+  {|{"type":"control_request","request_id":"mcp-notify-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}}}|}
 ;;
 
 let mcp_list =
@@ -42,6 +46,11 @@ let mcp_list =
 let mcp_call =
   {|{"type":"control_request","request_id":"mcp-call-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"masc_probe","arguments":{"marker":"from-claude"}}}}}|}
 ;;
+
+type fixture_step =
+  | Emit of string
+  | Emit_and_read of string
+  | Emit_after_closing_input of string
 
 let fixture_script ?prompt_marker ?(remove_after_auth = false) lines =
   let path = Filename.temp_file "masc-keeper-claude-code-" ".sh" in
@@ -77,7 +86,14 @@ let fixture_script ?prompt_marker ?(remove_after_auth = false) lines =
         ("printf '%s\\n' \"$user_message\" > " ^ shell_quote marker ^ "\n"))
     prompt_marker;
   List.iter
-    (fun line -> output_string output ("emit " ^ shell_quote line ^ "\n"))
+    (function
+      | Emit line -> output_string output ("emit " ^ shell_quote line ^ "\n")
+      | Emit_and_read line ->
+        output_string output ("emit " ^ shell_quote line ^ "\n");
+        output_string output "IFS= read -r ignored_response\n"
+      | Emit_after_closing_input line ->
+        output_string output "exec 0<&-\n";
+        output_string output ("emit " ^ shell_quote line ^ "\n"))
     lines;
   output_string output "while IFS= read -r ignored; do :; done\n";
   close_out output;
@@ -253,8 +269,8 @@ let test_oas_checkpoint_starts_official_client_turn () =
     (fun () ->
        with_fixture
          ~prompt_marker
-         [ assistant ~turn_id:"turn-checkpoint-1" "MASC_CLAUDE_CHECKPOINT"
-         ; result ~turn_id:"turn-checkpoint-1" "MASC_CLAUDE_CHECKPOINT"
+         [ Emit (assistant ~turn_id:"turn-checkpoint-1" "MASC_CLAUDE_CHECKPOINT")
+         ; Emit (result ~turn_id:"turn-checkpoint-1" "MASC_CLAUDE_CHECKPOINT")
          ]
          (fun cli_path ->
             match
@@ -276,10 +292,22 @@ let test_oas_checkpoint_starts_official_client_turn () =
        let raw =
          Fun.protect ~finally:(fun () -> close_in input) (fun () -> input_line input)
        in
+       let projected =
+         content_of_wire_message raw |> Yojson.Safe.from_string
+       in
+       let open Yojson.Safe.Util in
        check string
-         "checkpoint history is not imported"
+         "typed initial-turn schema"
+         "masc.claude-code.initial-turn.v1"
+         (projected |> member "schema" |> to_string);
+       check string
+         "current goal"
          "CHECKPOINT_GOAL"
-         (content_of_wire_message raw))
+         (projected |> member "current_goal" |> to_string);
+       check int
+         "canonical history length"
+         2
+         (projected |> member "history" |> to_list |> List.length))
 ;;
 
 let test_keeper_projects_typed_tool_history_and_lifecycle () =
@@ -320,8 +348,8 @@ let test_keeper_projects_typed_tool_history_and_lifecycle () =
        in
        with_fixture
          ~prompt_marker
-         [ assistant ~turn_id:"turn-history-1" "MASC_CLAUDE_HISTORY"
-         ; result ~turn_id:"turn-history-1" "MASC_CLAUDE_HISTORY"
+         [ Emit (assistant ~turn_id:"turn-history-1" "MASC_CLAUDE_HISTORY")
+         ; Emit (result ~turn_id:"turn-history-1" "MASC_CLAUDE_HISTORY")
          ]
          (fun cli_path ->
             match
@@ -403,11 +431,12 @@ let test_keeper_projects_masc_tool () =
     ~finally:(fun () -> cleanup_tree base_path)
     (fun () ->
        with_fixture
-         [ mcp_initialize
-         ; mcp_list
-         ; mcp_call
-         ; assistant ~turn_id:"turn-tool-1" "MASC_CLAUDE_TOOL"
-         ; result ~turn_id:"turn-tool-1" "MASC_CLAUDE_TOOL"
+         [ Emit_and_read mcp_initialize
+         ; Emit mcp_initialized_notification
+         ; Emit_and_read mcp_list
+         ; Emit_and_read mcp_call
+         ; Emit (assistant ~turn_id:"turn-tool-1" "MASC_CLAUDE_TOOL")
+         ; Emit (result ~turn_id:"turn-tool-1" "MASC_CLAUDE_TOOL")
          ]
          (fun cli_path ->
            match
@@ -441,6 +470,55 @@ let load_state base_path =
   | Ok (Some state) -> state
 ;;
 
+let test_post_effect_transport_enters_recovery () =
+  let base_path = temp_workspace () in
+  let call_count = ref 0 in
+  let marker_param : Agent_sdk.Types.tool_param =
+    { name = "marker"
+    ; description = "Fixture marker"
+    ; param_type = String
+    ; required = true
+    }
+  in
+  let tool =
+    Agent_sdk.Tool.create
+      ~name:"masc_probe"
+      ~description:"Record one deterministic fixture effect"
+      ~parameters:[ marker_param ]
+      (fun _input ->
+        incr call_count;
+        Ok { Agent_sdk.Types.content = "MASC_TOOL_RESULT"; _meta = None })
+  in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ Emit_and_read mcp_initialize
+         ; Emit mcp_initialized_notification
+         ; Emit_and_read mcp_list
+         ; Emit_after_closing_input mcp_call
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~tools:[ tool ]
+                ~base_path
+                ~cli_path
+                ~goal:"USE_TOOL_ONCE"
+                ()
+            with
+            | Error
+                (Agent_sdk.Error.Provider
+                  (Llm_provider.Error.ProviderUnavailable _)) -> ()
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok _ -> fail "post-effect response failure completed the Keeper turn");
+       check int "tool effect count" 1 !call_count;
+       let state = load_state base_path in
+       match state.phase with
+       | Recovery_required { failure = Transport_interrupted; _ } -> ()
+       | _ -> fail "post-effect transport failure released the durable claim")
+;;
+
 let test_keeper_settles_and_resumes () =
   let base_path = temp_workspace () in
   let prompt_marker = Filename.concat base_path "resume-prompt.json" in
@@ -448,8 +526,8 @@ let test_keeper_settles_and_resumes () =
     ~finally:(fun () -> cleanup_tree base_path)
     (fun () ->
        with_fixture
-         [ assistant ~turn_id:"turn-1" "MASC_CLAUDE_FIRST"
-         ; result ~turn_id:"turn-1" "MASC_CLAUDE_FIRST"
+         [ Emit (assistant ~turn_id:"turn-1" "MASC_CLAUDE_FIRST")
+         ; Emit (result ~turn_id:"turn-1" "MASC_CLAUDE_FIRST")
          ]
          (fun cli_path ->
            match
@@ -476,8 +554,8 @@ let test_keeper_settles_and_resumes () =
        in
        with_fixture
          ~prompt_marker
-         [ assistant ~turn_id:"turn-2" "MASC_CLAUDE_SECOND"
-         ; result ~turn_id:"turn-2" "MASC_CLAUDE_SECOND"
+         [ Emit (assistant ~turn_id:"turn-2" "MASC_CLAUDE_SECOND")
+         ; Emit (result ~turn_id:"turn-2" "MASC_CLAUDE_SECOND")
          ]
          (fun cli_path ->
            match
@@ -517,7 +595,7 @@ let test_quota_enters_typed_recovery () =
   Fun.protect
     ~finally:(fun () -> cleanup_tree base_path)
     (fun () ->
-       with_fixture [ rate_limit_rejected; quota_result ] (fun cli_path ->
+       with_fixture [ Emit rate_limit_rejected; Emit quota_result ] (fun cli_path ->
          (match run_keeper_turn ~base_path ~cli_path ~goal:"QUOTA_GOAL" () with
           | Error (Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _)) -> ()
           | Error error -> fail (Agent_sdk.Error.to_string error)
@@ -571,6 +649,10 @@ let () =
             `Quick
             test_keeper_projects_typed_tool_history_and_lifecycle
         ; test_case "projects MASC tool" `Quick test_keeper_projects_masc_tool
+        ; test_case
+            "post-effect transport enters recovery"
+            `Quick
+            test_post_effect_transport_enters_recovery
         ; test_case "quota enters recovery" `Quick test_quota_enters_typed_recovery
         ; test_case
             "spawn failure releases claim"

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -1,0 +1,385 @@
+open Alcotest
+open Masc
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let auth_subscription =
+  {|{"loggedIn":true,"authMethod":"claude.ai","subscriptionType":"team","apiProvider":"firstParty"}|}
+;;
+
+let assistant ~turn_id text =
+  Printf.sprintf
+    {|{"type":"assistant","session_id":"__SESSION__","uuid":"assistant-%s","message":{"role":"assistant","model":"claude-fixture","content":[{"type":"text","text":%S}]}}|}
+    turn_id
+    text
+;;
+
+let result ~turn_id text =
+  Printf.sprintf
+    {|{"type":"result","subtype":"success","is_error":false,"session_id":"__SESSION__","uuid":%S,"result":%S,"api_error_status":null}|}
+    turn_id
+    text
+;;
+
+let rate_limit_rejected =
+  {|{"type":"rate_limit_event","session_id":"__SESSION__","uuid":"limit-1","rate_limit_info":{"status":"rejected","rateLimitType":"seven_day","resetsAt":1786356000,"overageStatus":"rejected","overageDisabledReason":"org_level_disabled_until"}}|}
+;;
+
+let quota_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-quota-1","result":"not inspected","api_error_status":429,"terminal_reason":"api_error"}|}
+;;
+
+let mcp_initialize =
+  {|{"type":"control_request","request_id":"mcp-init-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}}}|}
+;;
+
+let mcp_list =
+  {|{"type":"control_request","request_id":"mcp-list-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}}}|}
+;;
+
+let mcp_call =
+  {|{"type":"control_request","request_id":"mcp-call-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"masc_probe","arguments":{"marker":"from-claude"}}}}}|}
+;;
+
+let fixture_script ?prompt_marker ?(remove_after_auth = false) lines =
+  let path = Filename.temp_file "masc-keeper-claude-code-" ".sh" in
+  let output = open_out_bin path in
+  output_string output "#!/bin/sh\n";
+  output_string output "set -eu\n";
+  output_string output "if [ \"${1-}\" = auth ]; then\n";
+  output_string output ("  printf '%s\\n' " ^ shell_quote auth_subscription ^ "\n");
+  if remove_after_auth
+  then output_string output "  rm -- \"$0\"\n";
+  output_string output "  exit 0\n";
+  output_string output "fi\n";
+  output_string output "session=''\n";
+  output_string output "for arg in \"$@\"; do\n";
+  output_string output "  case \"$arg\" in\n";
+  output_string output "    --session-id=*) session=${arg#--session-id=} ;;\n";
+  output_string output "    --resume=*) session=${arg#--resume=} ;;\n";
+  output_string output "  esac\n";
+  output_string output "done\n";
+  output_string output "[ -n \"$session\" ] || exit 94\n";
+  output_string output
+    "emit() { printf '%s\\n' \"$1\" | sed \"s/__SESSION__/$session/g\"; }\n";
+  output_string output "IFS= read -r initialize\n";
+  output_string output
+    "request_id=$(printf '%s' \"$initialize\" | sed -n 's/.*\"request_id\":\"\\([^\"]*\\)\".*/\\1/p')\n";
+  output_string output "[ -n \"$request_id\" ] || exit 95\n";
+  output_string output
+    "printf '{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\",\"request_id\":\"%s\",\"response\":{}}}\\n' \"$request_id\"\n";
+  output_string output "IFS= read -r user_message\n";
+  Option.iter
+    (fun marker ->
+      output_string output
+        ("printf '%s\\n' \"$user_message\" > " ^ shell_quote marker ^ "\n"))
+    prompt_marker;
+  List.iter
+    (fun line -> output_string output ("emit " ^ shell_quote line ^ "\n"))
+    lines;
+  output_string output "while IFS= read -r ignored; do :; done\n";
+  close_out output;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let with_fixture ?prompt_marker ?remove_after_auth lines f =
+  let path = fixture_script ?prompt_marker ?remove_after_auth lines in
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () -> f path)
+;;
+
+let runtime_toml cli_path =
+  Printf.sprintf
+    "[providers.claude]\n\
+     protocol = \"claude-code\"\n\
+     command = %S\n\
+     is-non-interactive = true\n\
+     \n\
+     [models.claude]\n\
+     api-name = \"claude-fixture\"\n\
+     max-context = 200000\n\
+     \n\
+     [claude.claude]\n\
+     \n\
+     [runtime]\n\
+     default = \"claude.claude\"\n"
+    cli_path
+;;
+
+let with_runtime_config cli_path f =
+  let path = Filename.temp_file "masc-keeper-claude-runtime-" ".toml" in
+  let output = open_out_bin path in
+  output_string output (runtime_toml cli_path);
+  close_out output;
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let temp_workspace () =
+  let path = Filename.temp_file "masc-keeper-claude-" "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let cleanup_tree root =
+  let rec remove path =
+    if Sys.file_exists path
+    then if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try remove root with
+  | _ -> ()
+;;
+
+let keeper_response_text (result : Runtime_agent.run_result) =
+  result.response.content
+  |> List.filter_map (function Agent_sdk.Types.Text text -> Some text | _ -> None)
+  |> String.concat ""
+;;
+
+let message role text : Agent_sdk.Types.message =
+  { role; content = [ Text text ]; name = None; tool_call_id = None; metadata = [] }
+;;
+
+let run_keeper_turn ?(tools = []) ?(initial_messages = []) ~base_path ~cli_path
+    ~goal () =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       with_runtime_config cli_path (fun runtime_path ->
+         Eio_main.run (fun env ->
+           Eio.Switch.run (fun sw ->
+             Eio_context.set_env env;
+             Eio_context.with_test_env
+               ~net:(Eio.Stdenv.net env)
+               ~clock:(Eio.Stdenv.clock env)
+               ~mono_clock:(Eio.Stdenv.mono_clock env)
+               ~sw
+               (fun () ->
+                  match Runtime.init_default ~config_path:runtime_path with
+                  | Error error -> fail error
+                  | Ok () ->
+                    let context =
+                      match tools with
+                      | [] -> None
+                      | _ :: _ -> Some (Agent_sdk.Context.create ())
+                    in
+                    Keeper_turn_driver.run_named
+                      ~runtime_id:"claude.claude"
+                      ~keeper_name:"claude-fixture"
+                      ~base_path
+                      ~goal
+                      ~tools
+                      ~initial_messages
+                      ?context
+                      ~sw
+                      ~net:(Eio.Stdenv.net env)
+                      ())))))
+;;
+
+let test_keeper_projects_masc_tool () =
+  let base_path = temp_workspace () in
+  let observed = ref `Null in
+  let marker_param : Agent_sdk.Types.tool_param =
+    { name = "marker"
+    ; description = "Fixture marker"
+    ; param_type = String
+    ; required = true
+    }
+  in
+  let tool =
+    Agent_sdk.Tool.create
+      ~name:"masc_probe"
+      ~description:"Return a deterministic fixture marker"
+      ~parameters:[ marker_param ]
+      (fun input ->
+        observed := input;
+        Ok { Agent_sdk.Types.content = "MASC_TOOL_RESULT"; _meta = None })
+  in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ mcp_initialize
+         ; mcp_list
+         ; mcp_call
+         ; assistant ~turn_id:"turn-tool-1" "MASC_CLAUDE_TOOL"
+         ; result ~turn_id:"turn-tool-1" "MASC_CLAUDE_TOOL"
+         ]
+         (fun cli_path ->
+           match
+             run_keeper_turn
+               ~tools:[ tool ]
+               ~base_path
+               ~cli_path
+               ~goal:"USE_TOOL"
+               ()
+           with
+           | Error error -> fail (Agent_sdk.Error.to_string error)
+           | Ok turn ->
+             check string
+               "tool response"
+               "MASC_CLAUDE_TOOL"
+               (keeper_response_text turn);
+             check string
+               "tool arguments"
+               {|{"marker":"from-claude"}|}
+               (Yojson.Safe.to_string !observed)))
+;;
+
+let load_state base_path =
+  match
+    Keeper_official_client_session_store.load
+      ~base_path
+      ~keeper_name:"claude-fixture"
+  with
+  | Error detail -> fail detail
+  | Ok None -> fail "Claude Code current-owner state disappeared"
+  | Ok (Some state) -> state
+;;
+
+let content_of_wire_message raw =
+  Yojson.Safe.from_string raw
+  |> Yojson.Safe.Util.member "message"
+  |> Yojson.Safe.Util.member "content"
+  |> Yojson.Safe.Util.to_string
+;;
+
+let test_keeper_settles_and_resumes () =
+  let base_path = temp_workspace () in
+  let prompt_marker = Filename.concat base_path "resume-prompt.json" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ assistant ~turn_id:"turn-1" "MASC_CLAUDE_FIRST"
+         ; result ~turn_id:"turn-1" "MASC_CLAUDE_FIRST"
+         ]
+         (fun cli_path ->
+           match
+             run_keeper_turn
+               ~initial_messages:
+                 [ message User "earlier user"; message Assistant "earlier assistant" ]
+               ~base_path
+               ~cli_path
+               ~goal:"FIRST_GOAL"
+               ()
+           with
+           | Error error -> fail (Agent_sdk.Error.to_string error)
+           | Ok turn ->
+             check string
+               "first response"
+               "MASC_CLAUDE_FIRST"
+               (keeper_response_text turn);
+             check int "first turn" 1 turn.turns);
+       let first = load_state base_path in
+       let session_id =
+         match first.phase with
+         | Settled { session_id; turn_id = "turn-1" } -> session_id
+         | _ -> fail "first Claude Code turn did not settle"
+       in
+       with_fixture
+         ~prompt_marker
+         [ assistant ~turn_id:"turn-2" "MASC_CLAUDE_SECOND"
+         ; result ~turn_id:"turn-2" "MASC_CLAUDE_SECOND"
+         ]
+         (fun cli_path ->
+           match
+             run_keeper_turn
+               ~initial_messages:[ message User "ALREADY_IN_OFFICIAL_SESSION" ]
+               ~base_path
+               ~cli_path
+               ~goal:"SECOND_GOAL"
+               ()
+           with
+           | Error error -> fail (Agent_sdk.Error.to_string error)
+           | Ok turn ->
+             check string "session identity" session_id turn.session_id;
+             check int "resumed turn" 2 turn.turns;
+             check string
+               "second response"
+               "MASC_CLAUDE_SECOND"
+               (keeper_response_text turn));
+       let input = open_in_bin prompt_marker in
+       let raw =
+         Fun.protect ~finally:(fun () -> close_in input) (fun () -> input_line input)
+       in
+       check string
+         "resume sends only current goal"
+         "SECOND_GOAL"
+         (content_of_wire_message raw);
+       let second = load_state base_path in
+       check int "durable cumulative turns" 2 second.turn_count;
+       match second.phase with
+       | Settled { session_id = settled_session; turn_id = "turn-2" } ->
+         check string "settled session" session_id settled_session
+       | _ -> fail "resumed Claude Code turn did not settle")
+;;
+
+let test_quota_enters_typed_recovery () =
+  let base_path = temp_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture [ rate_limit_rejected; quota_result ] (fun cli_path ->
+         (match run_keeper_turn ~base_path ~cli_path ~goal:"QUOTA_GOAL" () with
+          | Error (Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _)) -> ()
+          | Error error -> fail (Agent_sdk.Error.to_string error)
+          | Ok _ -> fail "quota rejection completed the Keeper turn");
+         let state = load_state base_path in
+         match state.phase with
+         | Recovery_required required ->
+           check bool
+             "provider rejection"
+             true
+             (required.failure = Provider_rejected);
+           check bool
+             "measured session"
+             true
+             (Option.is_some required.observed_session_id);
+           check (option string) "no fabricated turn" None required.observed_turn_id
+         | _ -> fail "quota rejection did not require explicit recovery"))
+;;
+
+let test_spawn_failure_releases_claim () =
+  let base_path = temp_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture ~remove_after_auth:true [] (fun cli_path ->
+         (match run_keeper_turn ~base_path ~cli_path ~goal:"SPAWN_GOAL" () with
+          | Error (Agent_sdk.Error.Provider (Llm_provider.Error.ProviderUnavailable _)) ->
+            ()
+          | Error error -> fail (Agent_sdk.Error.to_string error)
+          | Ok _ -> fail "removed CLI unexpectedly completed the Keeper turn");
+         let state = load_state base_path in
+         (match state.phase with
+          | Ready -> ()
+          | _ -> fail "transient spawn failure left the claim occupied");
+         match state.last_transient_release with
+         | Some { failure = Transient_spawn_failed; _ } -> ()
+         | _ -> fail "transient release evidence was not persisted"))
+;;
+
+let () =
+  run
+    "keeper_claude_code_runtime"
+    [ ( "lifecycle"
+      , [ test_case "settles and resumes" `Quick test_keeper_settles_and_resumes
+        ; test_case "projects MASC tool" `Quick test_keeper_projects_masc_tool
+        ; test_case "quota enters recovery" `Quick test_quota_enters_typed_recovery
+        ; test_case
+            "spawn failure releases claim"
+            `Quick
+            test_spawn_failure_releases_claim
+        ] )
+    ]
+;;

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -398,7 +398,7 @@ let test_keeper_projects_typed_tool_history_and_lifecycle () =
             "assistant"
             Yojson.Safe.Util.(assistant_history |> member "role" |> to_string);
           let tool_use_block =
-            Yojson.Safe.Util.(assistant_history |> member "content" |> to_list)
+            Yojson.Safe.Util.(assistant_history |> member "content_blocks" |> to_list)
             |> List.hd
           in
           check string

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -194,7 +194,10 @@ let run_keeper_turn ?(tools = []) ?(initial_messages = []) ?event_bus
                       ())))))
 ;;
 
-let checkpoint_with_messages messages : Agent_sdk.Checkpoint.t =
+let checkpoint_with_messages
+      (messages : Agent_sdk.Types.message list)
+  : Agent_sdk.Checkpoint.t
+  =
   { version = Agent_sdk.Checkpoint.checkpoint_version
   ; session_id = "oas-session"
   ; agent_name = "oas-agent"

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -229,7 +229,7 @@ let checkpoint_with_messages
 let test_oas_checkpoint_starts_official_client_turn () =
   let base_path = temp_workspace () in
   let prompt_marker = Filename.concat base_path "checkpoint-prompt.json" in
-  let checkpoint_history =
+  let checkpoint_history : Agent_sdk.Types.message list =
     [ { role = Assistant
       ; content =
           [ ToolUse

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -172,7 +172,7 @@ let content_of_wire_message raw =
 ;;
 
 let run_keeper_turn ?(tools = []) ?(initial_messages = []) ?event_bus
-    ?oas_checkpoint ~base_path ~cli_path ~goal () =
+    ?event_capture ?oas_checkpoint ~base_path ~cli_path ~goal () =
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
     ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
@@ -195,19 +195,40 @@ let run_keeper_turn ?(tools = []) ?(initial_messages = []) ?event_bus
                       | [] -> None
                       | _ :: _ -> Some (Agent_sdk.Context.create ())
                     in
-                    Keeper_turn_driver.run_named
-                      ~runtime_id:"claude.claude"
-                      ~keeper_name:"claude-fixture"
-                      ~base_path
-                      ~goal
-                      ~tools
-                      ~initial_messages
-                      ?context
-                      ?event_bus
-                      ?oas_checkpoint
-                      ~sw
-                      ~net:(Eio.Stdenv.net env)
-                      ())))))
+                    let run () =
+                      Keeper_turn_driver.run_named
+                        ~runtime_id:"claude.claude"
+                        ~keeper_name:"claude-fixture"
+                        ~base_path
+                        ~goal
+                        ~tools
+                        ~initial_messages
+                        ?context
+                        ?event_bus
+                        ?oas_checkpoint
+                        ~sw
+                        ~net:(Eio.Stdenv.net env)
+                        ()
+                    in
+                    (match event_bus, event_capture with
+                     | Some bus, Some capture ->
+                       let subscription =
+                         Runtime_event_bus.subscribe
+                           ~capacity:16
+                           ~overflow:Agent_sdk.Event_bus.Drop_oldest
+                           ~purpose:"claude-code-lifecycle-test"
+                           bus
+                       in
+                       Fun.protect
+                         ~finally:(fun () ->
+                           Runtime_event_bus.unsubscribe bus subscription)
+                         (fun () ->
+                            let result = run () in
+                            capture := Runtime_event_bus.drain subscription;
+                            result)
+                     | _, None -> run ()
+                     | None, Some _ ->
+                       invalid_arg "event_capture requires event_bus"))))))
 ;;
 
 let checkpoint_with_messages
@@ -314,17 +335,9 @@ let test_keeper_projects_typed_tool_history_and_lifecycle () =
   let base_path = temp_workspace () in
   let prompt_marker = Filename.concat base_path "typed-history-prompt.json" in
   let bus = Agent_sdk.Event_bus.create () in
-  let subscription =
-    Runtime_event_bus.subscribe
-      ~capacity:16
-      ~overflow:Agent_sdk.Event_bus.Drop_oldest
-      ~purpose:"claude-code-lifecycle-test"
-      bus
-  in
+  let captured_events = ref [] in
   Fun.protect
-    ~finally:(fun () ->
-      Runtime_event_bus.unsubscribe bus subscription;
-      cleanup_tree base_path)
+    ~finally:(fun () -> cleanup_tree base_path)
     (fun () ->
        let tool_use : Agent_sdk.Types.message =
          { role = Assistant
@@ -356,6 +369,7 @@ let test_keeper_projects_typed_tool_history_and_lifecycle () =
               run_keeper_turn
                 ~initial_messages:[ tool_use; tool_result ]
                 ~event_bus:bus
+                ~event_capture:captured_events
                 ~base_path
                 ~cli_path
                 ~goal:"CURRENT_GOAL"
@@ -397,7 +411,7 @@ let test_keeper_projects_typed_tool_history_and_lifecycle () =
             Yojson.Safe.Util.(tool_history |> member "role" |> to_string)
         | _ -> fail "typed history projection did not preserve the tool cycle");
        let lifecycle_kinds =
-         Runtime_event_bus.drain subscription
+         !captured_events
          |> List.map (fun event ->
            Agent_sdk.Event_bus.payload_kind event.Agent_sdk.Event_bus.payload)
        in

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -148,8 +148,15 @@ let message role text : Agent_sdk.Types.message =
   { role; content = [ Text text ]; name = None; tool_call_id = None; metadata = [] }
 ;;
 
-let run_keeper_turn ?(tools = []) ?(initial_messages = []) ~base_path ~cli_path
-    ~goal () =
+let content_of_wire_message raw =
+  Yojson.Safe.from_string raw
+  |> Yojson.Safe.Util.member "message"
+  |> Yojson.Safe.Util.member "content"
+  |> Yojson.Safe.Util.to_string
+;;
+
+let run_keeper_turn ?(tools = []) ?(initial_messages = []) ?event_bus
+    ?oas_checkpoint ~base_path ~cli_path ~goal () =
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
     ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
@@ -180,9 +187,194 @@ let run_keeper_turn ?(tools = []) ?(initial_messages = []) ~base_path ~cli_path
                       ~tools
                       ~initial_messages
                       ?context
+                      ?event_bus
+                      ?oas_checkpoint
                       ~sw
                       ~net:(Eio.Stdenv.net env)
                       ())))))
+;;
+
+let checkpoint_with_messages messages : Agent_sdk.Checkpoint.t =
+  { version = Agent_sdk.Checkpoint.checkpoint_version
+  ; session_id = "oas-session"
+  ; agent_name = "oas-agent"
+  ; model = "oas-model"
+  ; system_prompt = None
+  ; messages
+  ; usage = Agent_sdk.Types.empty_usage
+  ; turn_count = 1
+  ; created_at = 1.0
+  ; tools = []
+  ; tool_choice = None
+  ; disable_parallel_tool_use = false
+  ; temperature = None
+  ; top_p = None
+  ; top_k = None
+  ; min_p = None
+  ; enable_thinking = None
+  ; preserve_thinking = None
+  ; response_format = Off
+  ; thinking_budget = None
+  ; reasoning_effort = None
+  ; cache_system_prompt = false
+  ; context = Agent_sdk.Context.create ()
+  ; mcp_sessions = []
+  ; working_context = None
+  }
+;;
+
+let test_oas_checkpoint_starts_official_client_turn () =
+  let base_path = temp_workspace () in
+  let prompt_marker = Filename.concat base_path "checkpoint-prompt.json" in
+  let checkpoint_history =
+    [ { role = Assistant
+      ; content =
+          [ ToolUse
+              { id = "oas-tool-call"
+              ; name = "oas_tool"
+              ; input = `Assoc []
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ; Agent_sdk.Types.tool_result_msg
+        ~tool_use_id:"oas-tool-call"
+        ~content:"oas tool result"
+        ()
+    ]
+  in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         ~prompt_marker
+         [ assistant ~turn_id:"turn-checkpoint-1" "MASC_CLAUDE_CHECKPOINT"
+         ; result ~turn_id:"turn-checkpoint-1" "MASC_CLAUDE_CHECKPOINT"
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~initial_messages:checkpoint_history
+                ~oas_checkpoint:(checkpoint_with_messages checkpoint_history)
+                ~base_path
+                ~cli_path
+                ~goal:"CHECKPOINT_GOAL"
+                ()
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok turn ->
+              check string
+                "checkpoint response"
+                "MASC_CLAUDE_CHECKPOINT"
+                (keeper_response_text turn));
+       let input = open_in_bin prompt_marker in
+       let raw =
+         Fun.protect ~finally:(fun () -> close_in input) (fun () -> input_line input)
+       in
+       check string
+         "checkpoint history is not imported"
+         "CHECKPOINT_GOAL"
+         (content_of_wire_message raw))
+;;
+
+let test_keeper_projects_typed_tool_history_and_lifecycle () =
+  let base_path = temp_workspace () in
+  let prompt_marker = Filename.concat base_path "typed-history-prompt.json" in
+  let bus = Agent_sdk.Event_bus.create () in
+  let subscription =
+    Runtime_event_bus.subscribe
+      ~capacity:16
+      ~overflow:Agent_sdk.Event_bus.Drop_oldest
+      ~purpose:"claude-code-lifecycle-test"
+      bus
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime_event_bus.unsubscribe bus subscription;
+      cleanup_tree base_path)
+    (fun () ->
+       let tool_use : Agent_sdk.Types.message =
+         { role = Assistant
+         ; content =
+             [ ToolUse
+                 { id = "prior-tool-call"
+                 ; name = "prior_tool"
+                 ; input = `Assoc [ "path", `String "README.md" ]
+                 }
+             ]
+         ; name = None
+         ; tool_call_id = None
+         ; metadata = []
+         }
+       in
+       let tool_result =
+         Agent_sdk.Types.tool_result_msg
+           ~tool_use_id:"prior-tool-call"
+           ~content:"prior result"
+           ()
+       in
+       with_fixture
+         ~prompt_marker
+         [ assistant ~turn_id:"turn-history-1" "MASC_CLAUDE_HISTORY"
+         ; result ~turn_id:"turn-history-1" "MASC_CLAUDE_HISTORY"
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~initial_messages:[ tool_use; tool_result ]
+                ~event_bus:bus
+                ~base_path
+                ~cli_path
+                ~goal:"CURRENT_GOAL"
+                ()
+            with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok turn ->
+              check string
+                "history response"
+                "MASC_CLAUDE_HISTORY"
+                (keeper_response_text turn));
+       let input = open_in_bin prompt_marker in
+       let raw =
+         Fun.protect ~finally:(fun () -> close_in input) (fun () -> input_line input)
+       in
+       let history =
+         content_of_wire_message raw
+         |> Yojson.Safe.from_string
+         |> Yojson.Safe.Util.member "history"
+         |> Yojson.Safe.Util.to_list
+       in
+       (match history with
+        | [ assistant_history; tool_history ] ->
+          check string
+            "assistant history role"
+            "assistant"
+            Yojson.Safe.Util.(assistant_history |> member "role" |> to_string);
+          let tool_use_block =
+            Yojson.Safe.Util.(assistant_history |> member "content" |> to_list)
+            |> List.hd
+          in
+          check string
+            "typed tool use"
+            "tool_use"
+            Yojson.Safe.Util.(tool_use_block |> member "type" |> to_string);
+          check string
+            "tool result history role"
+            "tool"
+            Yojson.Safe.Util.(tool_history |> member "role" |> to_string)
+        | _ -> fail "typed history projection did not preserve the tool cycle");
+       let lifecycle_kinds =
+         Runtime_event_bus.drain subscription
+         |> List.map (fun event ->
+           Agent_sdk.Event_bus.payload_kind event.Agent_sdk.Event_bus.payload)
+       in
+       check
+         (list string)
+         "official-client lifecycle"
+         [ "agent_started"; "agent_completed" ]
+         lifecycle_kinds)
 ;;
 
 let test_keeper_projects_masc_tool () =
@@ -244,13 +436,6 @@ let load_state base_path =
   | Error detail -> fail detail
   | Ok None -> fail "Claude Code current-owner state disappeared"
   | Ok (Some state) -> state
-;;
-
-let content_of_wire_message raw =
-  Yojson.Safe.from_string raw
-  |> Yojson.Safe.Util.member "message"
-  |> Yojson.Safe.Util.member "content"
-  |> Yojson.Safe.Util.to_string
 ;;
 
 let test_keeper_settles_and_resumes () =
@@ -374,6 +559,14 @@ let () =
     "keeper_claude_code_runtime"
     [ ( "lifecycle"
       , [ test_case "settles and resumes" `Quick test_keeper_settles_and_resumes
+        ; test_case
+            "OAS checkpoint starts official-client turn"
+            `Quick
+            test_oas_checkpoint_starts_official_client_turn
+        ; test_case
+            "projects typed tool history and lifecycle"
+            `Quick
+            test_keeper_projects_typed_tool_history_and_lifecycle
         ; test_case "projects MASC tool" `Quick test_keeper_projects_masc_tool
         ; test_case "quota enters recovery" `Quick test_quota_enters_typed_recovery
         ; test_case

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -579,6 +579,8 @@ let test_provider_for_vision_uses_runtime_temperature () =
          (match runtime.Runtime.execution with
           | Runtime_execution.Codex_app_server _
           | Runtime_execution.Antigravity_cli _ ->
+          | Runtime_execution.Codex_app_server _
+          | Runtime_execution.Claude_code _ ->
             failwith "selected vision runtime should be agent_core"
           | Runtime_execution.Agent_core provider_config ->
             let configured = Vt.provider_for_vision provider_config in

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -578,9 +578,8 @@ let test_provider_for_vision_uses_runtime_temperature () =
        | Some runtime ->
          (match runtime.Runtime.execution with
           | Runtime_execution.Codex_app_server _
+          | Runtime_execution.Claude_code _
           | Runtime_execution.Antigravity_cli _ ->
-          | Runtime_execution.Codex_app_server _
-          | Runtime_execution.Claude_code _ ->
             failwith "selected vision runtime should be agent_core"
           | Runtime_execution.Agent_core provider_config ->
             let configured = Vt.provider_for_vision provider_config in

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -21,10 +21,31 @@ type fixture_step =
   | Emit of string
   | Emit_and_read of string
   | Emit_and_expect_request_id of string * string
+  | Emit_after_closing_input of string
 
-let fixture_script ?(auth_json = auth_subscription) steps =
+let fixture_script
+      ?(auth_json = auth_subscription)
+      ?(before_initialize_response = [])
+      steps
+  =
   let path = Filename.temp_file "masc-claude-code-" ".sh" in
   let output = open_out_bin path in
+  let write_step = function
+    | Emit line -> output_string output ("emit " ^ shell_quote line ^ "\n")
+    | Emit_and_read line ->
+      output_string output ("emit " ^ shell_quote line ^ "\n");
+      output_string output "IFS= read -r ignored_response\n"
+    | Emit_and_expect_request_id (line, request_id) ->
+      output_string output ("emit " ^ shell_quote line ^ "\n");
+      output_string output "IFS= read -r control_response\n";
+      output_string output
+        (Printf.sprintf
+           "printf '%%s' \"$control_response\" | grep -F '\"request_id\":\"%s\"' >/dev/null || exit 96\n"
+           request_id)
+    | Emit_after_closing_input line ->
+      output_string output "exec 0<&-\n";
+      output_string output ("emit " ^ shell_quote line ^ "\n")
+  in
   output_string output "#!/bin/sh\n";
   output_string output "set -eu\n";
   List.iter
@@ -69,32 +90,19 @@ let fixture_script ?(auth_json = auth_subscription) steps =
   output_string output
     "request_id=$(printf '%s' \"$initialize\" | sed -n 's/.*\"request_id\":\"\\([^\"]*\\)\".*/\\1/p')\n";
   output_string output "[ -n \"$request_id\" ] || exit 95\n";
+  List.iter write_step before_initialize_response;
   output_string output
     "printf '{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\",\"request_id\":\"%s\",\"response\":{}}}\\n' \"$request_id\"\n";
   output_string output "IFS= read -r user_message\n";
-  List.iter
-    (function
-      | Emit line ->
-        output_string output ("emit " ^ shell_quote line ^ "\n")
-      | Emit_and_read line ->
-        output_string output ("emit " ^ shell_quote line ^ "\n");
-        output_string output "IFS= read -r ignored_response\n"
-      | Emit_and_expect_request_id (line, request_id) ->
-        output_string output ("emit " ^ shell_quote line ^ "\n");
-        output_string output "IFS= read -r control_response\n";
-        output_string output
-          (Printf.sprintf
-             "printf '%%s' \"$control_response\" | grep -F '\"request_id\":\"%s\"' >/dev/null || exit 96\n"
-             request_id))
-    steps;
+  List.iter write_step steps;
   output_string output "while IFS= read -r ignored; do :; done\n";
   close_out output;
   Unix.chmod path 0o700;
   path
 ;;
 
-let with_fixture ?auth_json steps f =
-  let path = fixture_script ?auth_json steps in
+let with_fixture ?auth_json ?before_initialize_response steps f =
+  let path = fixture_script ?auth_json ?before_initialize_response steps in
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
@@ -193,6 +201,10 @@ let quota_result =
   {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-quota-1","result":"not inspected","api_error_status":429,"terminal_reason":"api_error"}|}
 ;;
 
+let quota_result_with_success_flag =
+  {|{"type":"result","subtype":"success","is_error":false,"session_id":"__SESSION__","uuid":"turn-quota-flag-1","result":"must not settle","api_error_status":null}|}
+;;
+
 let test_quota_is_structurally_classified () =
   with_fixture [ Emit rate_limit_rejected; Emit quota_result ] (fun path ->
     match run_fixture path with
@@ -203,6 +215,18 @@ let test_quota_is_structurally_classified () =
           }) -> ()
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "typed quota rejection was reported as completion")
+;;
+
+let test_rejected_rate_limit_overrides_success_flag () =
+  with_fixture [ Emit rate_limit_rejected; Emit quota_result_with_success_flag ] (fun path ->
+    match run_fixture path with
+    | Error
+        (Runtime_claude_code.Quota_blocked
+          { api_error_status = None
+          ; rate_limit = Some { status = Runtime_claude_code.Rejected; _ }
+          }) -> ()
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "typed quota rejection was overridden by is_error=false")
 ;;
 
 let mcp_initialize =
@@ -223,6 +247,53 @@ let mcp_list_after_notification =
 
 let mcp_call =
   {|{"type":"control_request","request_id":"mcp-call-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"masc_probe","arguments":{"marker":"from-claude"}}}}}|}
+;;
+
+let probe_tool call_count : Runtime_claude_code.dynamic_tool =
+  { name = "masc_probe"
+  ; description = "Return a fixture marker"
+  ; input_schema = `Assoc [ "type", `String "object" ]
+  ; call =
+      (fun ~call_id:_ _ ->
+        incr call_count;
+        { success = true; content = "MASC_TOOL_RESULT" })
+  }
+;;
+
+let test_tool_call_before_turn_admission_is_rejected () =
+  let call_count = ref 0 in
+  with_fixture
+    ~before_initialize_response:
+      [ Emit_and_read mcp_initialize
+      ; Emit mcp_initialized_notification
+      ; Emit_and_read mcp_call
+      ]
+    []
+    (fun path ->
+      match run_fixture ~dynamic_tools:[ probe_tool call_count ] path with
+      | Error (Runtime_claude_code.Protocol_error { stage = "MCP tools/call"; _ }) ->
+        check int "tool effect count" 0 !call_count
+      | Error error -> fail (Runtime_claude_code.error_to_string error)
+      | Ok _ -> fail "tool call ran before durable turn admission")
+;;
+
+let test_post_effect_response_failure_requires_recovery () =
+  let call_count = ref 0 in
+  with_fixture
+    [ Emit_and_read mcp_initialize
+    ; Emit mcp_initialized_notification
+    ; Emit_after_closing_input mcp_call
+    ]
+    (fun path ->
+      match run_fixture ~dynamic_tools:[ probe_tool call_count ] path with
+      | Error
+          (Runtime_claude_code.Turn_transport_interrupted
+            { stage = "control success response"
+            ; tool_effect_attempted = true
+            ; _
+            }) -> check int "tool effect count" 1 !call_count
+      | Error error -> fail (Runtime_claude_code.error_to_string error)
+      | Ok _ -> fail "post-effect response failure completed the turn")
 ;;
 
 let test_dynamic_tool_callback () =
@@ -297,6 +368,7 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
     Runtime_official_client_mcp.handle_message
       ~session
       ~server_name:"masc"
+      ~tool_call_policy:Runtime_official_client_mcp.Allow_tool_calls
       ~tool_specs
       ~call_tool
       json
@@ -313,6 +385,7 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
       Runtime_official_client_mcp.handle_message
         ~session:fresh_session
         ~server_name:"masc"
+        ~tool_call_policy:Runtime_official_client_mcp.Allow_tool_calls
         ~tool_specs
         ~call_tool:guarded_call_tool
         message
@@ -346,6 +419,7 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
     Runtime_official_client_mcp.handle_message
       ~session:fresh_session
       ~server_name:"masc"
+      ~tool_call_policy:Runtime_official_client_mcp.Allow_tool_calls
       ~tool_specs
       ~call_tool:guarded_call_tool
       (`Assoc
@@ -442,6 +516,7 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
      Runtime_official_client_mcp.handle_message
        ~session
        ~server_name:"masc"
+       ~tool_call_policy:Runtime_official_client_mcp.Allow_tool_calls
        ~tool_specs
        ~call_tool
        (`Assoc
@@ -458,6 +533,7 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
       Runtime_official_client_mcp.handle_message
         ~session
         ~server_name:"masc"
+        ~tool_call_policy:Runtime_official_client_mcp.Allow_tool_calls
         ~tool_specs
         ~call_tool
         message
@@ -530,6 +606,7 @@ let test_shared_mcp_protocol_is_negotiated () =
     Runtime_official_client_mcp.handle_message
       ~session:(Runtime_official_client_mcp.create_session ())
       ~server_name:"masc"
+      ~tool_call_policy:Runtime_official_client_mcp.Allow_tool_calls
       ~tool_specs
       ~call_tool
       message
@@ -703,11 +780,23 @@ let () =
             "quota is structurally classified"
             `Quick
             test_quota_is_structurally_classified
+        ; test_case
+            "rejected rate limit overrides success flag"
+            `Quick
+            test_rejected_rate_limit_overrides_success_flag
         ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
         ; test_case "duplicate keys fail closed" `Quick test_duplicate_keys_fail_closed
         ] )
     ; ( "mcp"
       , [ test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
+        ; test_case
+            "pre-admission tool call is rejected"
+            `Quick
+            test_tool_call_before_turn_admission_is_rejected
+        ; test_case
+            "post-effect response failure requires recovery"
+            `Quick
+            test_post_effect_response_failure_requires_recovery
         ; test_case
             "shared bridge owns exact dispatch"
             `Quick

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -166,6 +166,25 @@ let test_non_subscription_auth_is_rejected () =
     | Ok _ -> fail "API-key Claude auth was admitted as subscription")
 ;;
 
+let test_missing_cli_is_not_reported_as_logout () =
+  let outcome =
+    Eio_main.run (fun env ->
+      let config =
+        { (Runtime_claude_code.default_config ~cwd:"/tmp") with
+          cli_path = "/definitely/missing/masc-claude-fixture"
+        }
+      in
+      Runtime_claude_code.probe_subscription
+        ~mgr:(Eio.Stdenv.process_mgr env)
+        ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+        config)
+  in
+  match outcome with
+  | Error (Runtime_claude_code.Spawn_failed _) -> ()
+  | Error error -> fail (Runtime_claude_code.error_to_string error)
+  | Ok _ -> fail "missing Claude CLI was reported as a valid login"
+;;
+
 let rate_limit_rejected =
   {|{"type":"rate_limit_event","session_id":"__SESSION__","uuid":"limit-1","rate_limit_info":{"status":"rejected","rateLimitType":"seven_day","resetsAt":1786356000,"overageStatus":"rejected","overageDisabledReason":"org_level_disabled_until"}}|}
 ;;
@@ -674,6 +693,10 @@ let () =
             "non-subscription rejected"
             `Quick
             test_non_subscription_auth_is_rejected
+        ; test_case
+            "missing CLI differs from logout"
+            `Quick
+            test_missing_cli_is_not_reported_as_logout
         ] )
     ; ( "terminal"
       , [ test_case

--- a/test/test_runtime_claude_code_config.ml
+++ b/test/test_runtime_claude_code_config.ml
@@ -1,0 +1,105 @@
+open Alcotest
+
+let runtime_toml ?credential ?(transport = "command = \"claude\"")
+    ?(non_interactive = true) () =
+  let credential = Option.value credential ~default:"" in
+  Printf.sprintf
+    "[providers.claude_code]\n\
+     protocol = \"claude-code\"\n\
+     %s\n\
+     is-non-interactive = %b\n\
+     %s\n\
+     [models.claude-code-sonnet]\n\
+     api-name = \"claude-sonnet-4-5\"\n\
+     max-context = 200000\n\
+     \n\
+     [claude_code.claude-code-sonnet]\n\
+     \n\
+     [runtime]\n\
+     default = \"claude_code.claude-code-sonnet\"\n"
+    transport
+    non_interactive
+    credential
+;;
+
+let with_runtime_toml content f =
+  let path = Filename.temp_file "masc-claude-code-config-" ".toml" in
+  let channel = open_out_bin path in
+  output_string channel content;
+  close_out channel;
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let load content =
+  with_runtime_toml content (fun path -> Runtime.load_list ~config_path:path)
+;;
+
+let test_materializes_official_client_owner () =
+  match load (runtime_toml ()) with
+  | Error error -> failf "claude-code runtime should load: %s" error
+  | Ok (runtimes, default, _, _, _, _) ->
+    check int "one runtime" 1 (List.length runtimes);
+    check string "default" "claude_code.claude-code-sonnet" default.id;
+    (match default.execution with
+     | Runtime_execution.Claude_code config ->
+       check string "CLI" "claude" config.cli_path;
+       check (option string)
+         "model"
+         (Some "claude-sonnet-4-5")
+         config.model;
+       check (float 0.001) "timeout" 300.0 config.timeout_s
+     | Runtime_execution.Agent_core _
+     | Runtime_execution.Codex_app_server _ ->
+       fail "claude-code was materialized as the wrong execution owner")
+;;
+
+let test_declared_credentials_are_rejected () =
+  let credential =
+    "[providers.claude_code.credentials]\n\
+     type = \"env\"\n\
+     key = \"ANTHROPIC_API_KEY\"\n"
+  in
+  match load (runtime_toml ~credential ()) with
+  | Error _ -> ()
+  | Ok _ -> fail "claude-code admitted a declared API credential"
+;;
+
+let test_http_transport_is_rejected () =
+  match load (runtime_toml ~transport:"endpoint = \"https://api.anthropic.com\"" ()) with
+  | Error _ -> ()
+  | Ok _ -> fail "claude-code admitted an HTTP transport"
+;;
+
+let test_interactive_provider_is_rejected () =
+  match load (runtime_toml ~non_interactive:false ()) with
+  | Error _ -> ()
+  | Ok _ -> fail "claude-code admitted an interactive provider declaration"
+;;
+
+let test_protocol_name_is_exact () =
+  match Runtime_toml.api_format_of_protocol "claude_code" with
+  | Error _ -> ()
+  | Ok _ -> fail "underscore protocol alias was silently accepted"
+;;
+
+let () =
+  run
+    "runtime_claude_code_config"
+    [ ( "typed config"
+      , [ test_case
+            "materializes official-client owner"
+            `Quick
+            test_materializes_official_client_owner
+        ; test_case
+            "declared credentials rejected"
+            `Quick
+            test_declared_credentials_are_rejected
+        ; test_case "HTTP transport rejected" `Quick test_http_transport_is_rejected
+        ; test_case
+            "interactive provider rejected"
+            `Quick
+            test_interactive_provider_is_rejected
+        ; test_case "protocol name exact" `Quick test_protocol_name_is_exact
+        ] )
+    ]
+;;

--- a/test/test_runtime_claude_code_config.ml
+++ b/test/test_runtime_claude_code_config.ml
@@ -49,7 +49,8 @@ let test_materializes_official_client_owner () =
          config.model;
        check (float 0.001) "timeout" 300.0 config.timeout_s
      | Runtime_execution.Agent_core _
-     | Runtime_execution.Codex_app_server _ ->
+     | Runtime_execution.Codex_app_server _
+     | Runtime_execution.Antigravity_cli _ ->
        fail "claude-code was materialized as the wrong execution owner")
 ;;
 

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -14,9 +14,8 @@ let agent_core_provider_config (runtime : Runtime.t) =
   match runtime.execution with
   | Runtime_execution.Agent_core provider_config -> provider_config
   | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Claude_code _
   | Runtime_execution.Antigravity_cli _ ->
-  | Runtime_execution.Codex_app_server _
-  | Runtime_execution.Claude_code _ ->
     failf "runtime %s is not an agent_core provider" runtime.id
 ;;
 
@@ -3254,7 +3253,9 @@ let test_antigravity_cli_materializes_typed_process_options () =
             check bool "sandbox" true config.sandbox;
             check bool "slash commands" false config.disable_slash_commands;
             check (float 0.0) "timeout" 45.0 config.timeout_s
-          | Runtime_execution.Agent_core _ | Runtime_execution.Codex_app_server _ ->
+          | Runtime_execution.Agent_core _
+          | Runtime_execution.Codex_app_server _
+          | Runtime_execution.Claude_code _ ->
             fail "antigravity-cli was materialized through the wrong execution owner"))
 ;;
 
@@ -3271,7 +3272,9 @@ let test_antigravity_cli_defaults_are_explicit () =
          check bool "sandbox opt-in" false config.sandbox;
          check bool "slash expansion disabled" true config.disable_slash_commands;
          check (float 0.0) "timeout" 300.0 config.timeout_s
-       | Runtime_execution.Agent_core _ | Runtime_execution.Codex_app_server _ ->
+       | Runtime_execution.Agent_core _
+       | Runtime_execution.Codex_app_server _
+       | Runtime_execution.Claude_code _ ->
          fail "antigravity-cli was materialized through the wrong execution owner"))
 ;;
 

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -15,6 +15,8 @@ let agent_core_provider_config (runtime : Runtime.t) =
   | Runtime_execution.Agent_core provider_config -> provider_config
   | Runtime_execution.Codex_app_server _
   | Runtime_execution.Antigravity_cli _ ->
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Claude_code _ ->
     failf "runtime %s is not an agent_core provider" runtime.id
 ;;
 
@@ -3188,7 +3190,8 @@ let test_codex_app_server_materializes_as_turn_runtime () =
       check int "one runtime" 1 (List.length runtimes);
       check string "default id" "codex.codex" default.id;
       (match default.execution with
-       | Runtime_execution.Agent_core _ ->
+       | Runtime_execution.Agent_core _
+       | Runtime_execution.Claude_code _ ->
          fail "codex-app-server was incorrectly materialized as agent_core"
        | Runtime_execution.Codex_app_server config ->
          check string "cli path" "codex" config.cli_path;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -363,7 +363,7 @@ max-concurrent = 1
                  "unknown protocol \"openai-http\": expected one of \
                   messages-cli, messages-http, openai-compatible-cli, \
                   openai-compatible-http, ollama-http, codex-app-server, \
-                  antigravity-cli")
+                  claude-code, antigravity-cli")
          errors)
 
 let test_runtime_toml_accepts_messages_caching_capability () =


### PR DESCRIPTION
## Outcome

Claude Code subscription runtimes now execute through the production Keeper turn path with MASC-owned dynamic tools and durable official-client session settlement.

## Hard cuts

- probes `claude auth status --json` before claiming a durable turn
- admits only the credential-scrubbed `claude.ai` first-party subscription result from the typed client
- rejects OAS checkpoints and provider transforms at the official-client boundary
- injects prior user/assistant history only for a new official session; resume sends only the current goal
- persists claim -> active -> turn_inflight -> settled using measured Claude session/turn UUIDs
- records quota/provider rejection as explicit recovery-required; transient spawn failure releases the claim
- projects MASC tools through the shared official-client host, including hooks and typed tool outcomes

## Verification

- `test_keeper_claude_code_runtime.exe`: 4 passed
  - settle + resume
  - MASC tool call
  - quota -> typed recovery
  - spawn failure -> transient release
- `test_runtime_claude_code.exe`: 12 passed, 1 live test skipped
- `python3 scripts/check_test_coverage.py`
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`

## Stack

Depends on #27774.