### PR TITLE
fix: make approval audit reads fail visible

### DIFF
--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -272,7 +272,11 @@ function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprov
     && raw.goal_ids.every(value => typeof value === 'string' && value.trim() !== '')
     ? raw.goal_ids as string[]
     : null
-  const actor = typeof raw.actor === 'string' ? raw.actor.trim() : ''
+  const actor = raw.actor === null
+    ? null
+    : typeof raw.actor === 'string' && raw.actor.trim() !== ''
+      ? raw.actor.trim()
+      : undefined
   const decisionSource = normalizeGateDecisionSource(raw.decision_source)
   const summaryStatus = normalizeHitlSummaryStatus(raw.summary_status)
   const exactAttempt = normalizeKeeperExactAttempt(raw.exact_attempt)
@@ -291,7 +295,7 @@ function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprov
     || (taskId !== null && !taskId)
     || (goalId !== null && !goalId)
     || goalIds === null
-    || !actor
+    || actor === undefined
     || !decisionSource
     || summaryStatus === null
     || exactAttempt === null

--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -17,7 +17,9 @@ import type {
   KeeperApprovalQueueRowViolation,
   KeeperResolvedApprovalItem,
   KeeperResolvedApprovalPage,
+  KeeperResolvedApprovalState,
   KeeperApprovalQueueState,
+  KeeperApprovalRulesState,
   KeeperAutoJudgeRearmExpectation,
   GateDecisionSource,
   GateJudgeLane,
@@ -77,66 +79,147 @@ function normalizeApprovalQueueState(raw: unknown): KeeperApprovalQueueState {
 
 function normalizeKeeperApprovalRule(raw: unknown): KeeperApprovalRule | null {
   if (!isRecord(raw)) return null
-  const id = asString(raw.id, '').trim()
-  const keeperName = asString(raw.keeper_name, '').trim()
-  const toolName = asString(raw.tool_name, '').trim()
-  if (!id || !keeperName || !toolName) return null
+  const keys = Object.keys(raw).sort()
+  const expectedKeys = [
+    'created_at',
+    'created_by',
+    'expires_at',
+    'id',
+    'keeper_name',
+    'request_fingerprint',
+    'source_approval_id',
+    'tool_name',
+  ]
+  if (keys.length !== expectedKeys.length || keys.some((key, index) => key !== expectedKeys[index])) {
+    return null
+  }
+  const id = typeof raw.id === 'string' ? raw.id.trim() : ''
+  const keeperName = typeof raw.keeper_name === 'string' ? raw.keeper_name.trim() : ''
+  const toolName = typeof raw.tool_name === 'string' ? raw.tool_name.trim() : ''
+  const requestFingerprint = typeof raw.request_fingerprint === 'string'
+    ? raw.request_fingerprint
+    : ''
+  const createdAt = typeof raw.created_at === 'number' ? raw.created_at : Number.NaN
+  const createdBy = typeof raw.created_by === 'string' && raw.created_by.trim() !== ''
+    ? raw.created_by
+    : undefined
+  const sourceApprovalId =
+    typeof raw.source_approval_id === 'string' && raw.source_approval_id.trim() !== ''
+      ? raw.source_approval_id
+      : undefined
+  const expiresAt = raw.expires_at === null
+    ? null
+    : typeof raw.expires_at === 'number' && Number.isFinite(raw.expires_at)
+      ? raw.expires_at
+      : undefined
+  if (
+    !id
+    || !keeperName
+    || !toolName
+    || !/^[a-f0-9]{64}$/.test(requestFingerprint)
+    || !Number.isFinite(createdAt)
+    || createdAt < 0
+    || createdBy === undefined
+    || sourceApprovalId === undefined
+    || expiresAt === undefined
+    || (expiresAt !== null && expiresAt <= createdAt)
+  ) return null
   return {
     id,
     keeper_name: keeperName,
     tool_name: toolName,
-    request_fingerprint: asNullableString(raw.request_fingerprint) ?? undefined,
-    created_at: asNullableIsoTimestamp(raw.created_at),
-    created_by: asNullableString(raw.created_by),
-    source_approval_id: asNullableString(raw.source_approval_id),
+    request_fingerprint: requestFingerprint,
+    created_at: createdAt,
+    created_by: createdBy,
+    source_approval_id: sourceApprovalId,
+    expires_at: expiresAt,
   }
+}
+
+function normalizeApprovalRulesState(raw: unknown): KeeperApprovalRulesState {
+  if (!isRecord(raw)) return gateSnapshotProtocolDrift('approval_rules_state is not an object')
+  if (raw.state === 'ready' && Object.keys(raw).length === 1) return { state: 'ready' }
+  if (
+    raw.state === 'unavailable'
+    && typeof raw.error === 'string'
+    && raw.error.trim() !== ''
+    && Object.keys(raw).length === 2
+  ) {
+    return { state: 'unavailable', error: raw.error }
+  }
+  return gateSnapshotProtocolDrift('approval_rules_state is not a current closed variant')
 }
 
 function normalizeGateModeValue(raw: unknown): GateMode | null {
   return raw === 'manual' || raw === 'auto_judge' || raw === 'always_allow' ? raw : null
 }
 
-function normalizeGateMode(raw: unknown): GateModeStatus | undefined {
-  if (!isRecord(raw)) return undefined
-  const mode = normalizeGateModeValue(raw.mode)
-  if (!mode) {
-    return {
-      mode: 'manual',
-      state: 'invalid',
-      read_error: `unsupported Gate mode: ${String(raw.mode)}`,
-    }
-  }
-  return {
-    mode,
-    configured: asBoolean(raw.configured) ?? undefined,
-    state: asNullableString(raw.state) ?? undefined,
-    read_error: asNullableString(raw.read_error) ?? undefined,
-  }
+function hasExactKeys(raw: Record<string, unknown>, expected: string[]): boolean {
+  const keys = Object.keys(raw).sort()
+  const sortedExpected = [...expected].sort()
+  return keys.length === sortedExpected.length
+    && keys.every((key, index) => key === sortedExpected[index])
 }
 
-/** Parse the closed `judge_lane` variant emitted by `dashboard_gate.ml`.
- *  Returns undefined for an absent field (older server) or a shape outside
- *  the contract — the header then simply omits the judge model. */
-function normalizeGateJudgeLane(raw: unknown): GateJudgeLane | undefined {
-  if (!isRecord(raw)) return undefined
+function normalizeGateMode(raw: unknown): GateModeStatus {
+  if (!isRecord(raw)) return gateSnapshotProtocolDrift('hitl.gate_mode is not an object')
+  const mode = normalizeGateModeValue(raw.mode)
+  if (!mode || typeof raw.configured !== 'boolean') {
+    return gateSnapshotProtocolDrift('hitl.gate_mode has an invalid mode or configured flag')
+  }
+  if (raw.state === 'ready' && hasExactKeys(raw, ['mode', 'configured', 'state'])) {
+    return { mode, configured: raw.configured, state: 'ready' }
+  }
+  if (
+    mode === 'auto_judge'
+    && raw.state === 'unavailable'
+    && typeof raw.read_error === 'string'
+    && raw.read_error.trim() !== ''
+    && hasExactKeys(raw, ['mode', 'configured', 'state', 'read_error'])
+  ) {
+    return { mode, configured: raw.configured, state: 'unavailable', read_error: raw.read_error }
+  }
+  if (
+    mode === 'manual'
+    && raw.configured === true
+    && raw.state === 'invalid'
+    && typeof raw.read_error === 'string'
+    && raw.read_error.trim() !== ''
+    && hasExactKeys(raw, ['mode', 'configured', 'state', 'read_error'])
+  ) {
+    return { mode, configured: true, state: 'invalid', read_error: raw.read_error }
+  }
+  return gateSnapshotProtocolDrift('hitl.gate_mode is not a current closed variant')
+}
+
+function normalizeGateJudgeLane(raw: unknown): GateJudgeLane {
+  if (!isRecord(raw)) return gateSnapshotProtocolDrift('hitl.judge_lane is not an object')
   const laneId = asString(raw.lane_id, '').trim()
-  if (!laneId) return undefined
-  if (raw.status === 'available' && Array.isArray(raw.slots)) {
+  if (!laneId) return gateSnapshotProtocolDrift('hitl.judge_lane.lane_id is invalid')
+  if (
+    raw.status === 'available'
+    && Array.isArray(raw.slots)
+    && hasExactKeys(raw, ['status', 'lane_id', 'slots'])
+  ) {
     const slots = raw.slots.filter(
       (slot): slot is string => typeof slot === 'string' && slot.trim() !== '',
     )
-    if (slots.length === 0 || slots.length !== raw.slots.length) return undefined
+    if (slots.length === 0 || slots.length !== raw.slots.length) {
+      return gateSnapshotProtocolDrift('hitl.judge_lane.slots is invalid')
+    }
     return { status: 'available', lane_id: laneId, slots }
   }
-  if (raw.status === 'unavailable') {
+  if (raw.status === 'unavailable' && hasExactKeys(raw, ['status', 'lane_id', 'reason'])) {
     const reason = asString(raw.reason, '').trim()
-    return reason ? { status: 'unavailable', lane_id: laneId, reason } : undefined
+    if (reason) return { status: 'unavailable', lane_id: laneId, reason }
   }
-  return undefined
+  return gateSnapshotProtocolDrift('hitl.judge_lane is not a current closed variant')
 }
 
-function normalizeHitlStatus(raw: unknown): DashboardGateResponse['hitl'] | undefined {
-  if (!isRecord(raw)) return undefined
+function normalizeHitlStatus(raw: unknown): DashboardGateResponse['hitl'] {
+  if (!isRecord(raw) || !hasExactKeys(raw, ['gate_mode', 'judge_lane'])) {
+    return gateSnapshotProtocolDrift('hitl is not the current exact object')
+  }
   return {
     gate_mode: normalizeGateMode(raw.gate_mode),
     judge_lane: normalizeGateJudgeLane(raw.judge_lane),
@@ -151,48 +234,82 @@ function normalizeGateDecisionSource(raw: unknown): GateDecisionSource | null {
 
 function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprovalItem | null {
   if (!isRecord(raw)) return null
+  if (!hasExactKeys(raw, [
+    'id',
+    'event',
+    'keeper_name',
+    'tool_name',
+    'decision',
+    'decision_kind',
+    'decision_reason',
+    'resolved_at',
+    'turn_id',
+    'task_id',
+    'goal_id',
+    'goal_ids',
+    'actor',
+    'decision_source',
+    'summary_status',
+    'exact_attempt',
+  ])) return null
   const id = asString(raw.id, '').trim()
   const keeperName = asString(raw.keeper_name, '').trim()
   const toolName = asString(raw.tool_name, '').trim()
-  if (!id || !keeperName || !toolName) return null
-  const ruleMatch = isRecord(raw.rule_match)
-    ? {
-        rule_id: asNullableString(raw.rule_match.rule_id),
-      }
+  const decisionRaw = typeof raw.decision === 'string' ? raw.decision.trim() : ''
+  const decision = normalizeKeeperResolvedApprovalDecision(
+    typeof raw.decision_kind === 'string' ? raw.decision_kind : null,
+  )
+  const decisionReason = raw.decision_reason === null
+    ? null
+    : typeof raw.decision_reason === 'string' && raw.decision_reason.trim() !== ''
+      ? raw.decision_reason.trim()
+      : undefined
+  const resolvedAt = asNullableIsoTimestamp(raw.resolved_at)
+  const turnId = raw.turn_id === null ? null : asInt(raw.turn_id)
+  const taskId = raw.task_id === null ? null : asNullableString(raw.task_id)
+  const goalId = raw.goal_id === null ? null : asNullableString(raw.goal_id)
+  const goalIds = Array.isArray(raw.goal_ids)
+    && raw.goal_ids.every(value => typeof value === 'string' && value.trim() !== '')
+    ? raw.goal_ids as string[]
     : null
-  const decisionRaw = asNullableString(raw.decision)
-  const decisionKind = asNullableString(raw.decision_kind)
-  const decisionReason = asNullableString(raw.decision_reason)
-  // Judge evidence rides on resolved audit events written since #26126;
-  // older events project the members as null. Absent stays null (nothing was
-  // recorded); a present-but-malformed blob rejects the row like any other
-  // contract violation instead of silently degrading to "not recorded".
-  let summaryStatus: KeeperResolvedApprovalItem['summary_status'] = null
-  if (raw.summary_status !== undefined && raw.summary_status !== null) {
-    summaryStatus = normalizeHitlSummaryStatus(raw.summary_status)
-    if (summaryStatus === null) return null
-  }
-  let exactAttempt: KeeperResolvedApprovalItem['exact_attempt'] = null
-  if (raw.exact_attempt !== undefined && raw.exact_attempt !== null) {
-    exactAttempt = normalizeKeeperExactAttempt(raw.exact_attempt)
-    if (exactAttempt === null) return null
-  }
+  const actor = typeof raw.actor === 'string' ? raw.actor.trim() : ''
+  const decisionSource = normalizeGateDecisionSource(raw.decision_source)
+  const summaryStatus = normalizeHitlSummaryStatus(raw.summary_status)
+  const exactAttempt = normalizeKeeperExactAttempt(raw.exact_attempt)
+  if (
+    raw.event !== 'resolved'
+    || !id
+    || !keeperName
+    || !toolName
+    || !decisionRaw
+    || !decision
+    || decisionReason === undefined
+    || (decision === 'approve' && decisionReason !== null)
+    || (decision === 'reject' && decisionReason === null)
+    || resolvedAt === null
+    || (turnId !== null && (turnId === undefined || turnId < 0))
+    || (taskId !== null && !taskId)
+    || (goalId !== null && !goalId)
+    || goalIds === null
+    || !actor
+    || !decisionSource
+    || summaryStatus === null
+    || exactAttempt === null
+  ) return null
   return {
     id,
     keeper_name: keeperName,
     tool_name: toolName,
-    decision: normalizeKeeperResolvedApprovalDecision(decisionKind),
+    decision,
     decision_raw: decisionRaw,
     decision_reason: decisionReason,
-    resolved_at: asNullableIsoTimestamp(raw.resolved_at),
-    turn_id: asInt(raw.turn_id),
-    task_id: asNullableString(raw.task_id),
-    goal_id: asNullableString(raw.goal_id),
-    goal_ids: Array.isArray(raw.goal_ids)
-      ? raw.goal_ids.filter((value): value is string => typeof value === 'string')
-      : [],
-    decision_source: normalizeGateDecisionSource(raw.decision_source),
-    rule_match: ruleMatch,
+    resolved_at: resolvedAt,
+    turn_id: turnId,
+    task_id: taskId,
+    goal_id: goalId,
+    goal_ids: goalIds,
+    actor,
+    decision_source: decisionSource,
     summary_status: summaryStatus,
     exact_attempt: exactAttempt,
   }
@@ -237,6 +354,21 @@ function normalizeKeeperResolvedApprovalPage(
   }
 }
 
+function normalizeKeeperResolvedApprovalState(raw: unknown): KeeperResolvedApprovalState {
+  if (!isRecord(raw)) return gateSnapshotProtocolDrift('recent_resolved_state is not an object')
+  if (raw.state === 'ready' && hasExactKeys(raw, ['state'])) return { state: 'ready' }
+  if (
+    raw.state === 'unavailable'
+    && raw.stage === 'list_recent_resolved'
+    && typeof raw.error === 'string'
+    && raw.error.trim() !== ''
+    && hasExactKeys(raw, ['state', 'stage', 'error'])
+  ) {
+    return { state: 'unavailable', stage: raw.stage, error: raw.error.trim() }
+  }
+  return gateSnapshotProtocolDrift('recent_resolved_state is not a current closed variant')
+}
+
 export function fetchDashboardGate(
   opts?: FetchDashboardGateOptions,
 ): Promise<DashboardGateResponse> {
@@ -279,17 +411,43 @@ export function fetchDashboardGate(
       })
       approvalQueue = accepted
     }
-    const recentResolved = Array.isArray(raw.recent_resolved)
-      ? raw.recent_resolved
-          .map(item => normalizeKeeperResolvedApprovalItem(item))
-          .filter((item): item is KeeperResolvedApprovalItem => item !== null)
-      : []
-    const recentResolvedPage = normalizeKeeperResolvedApprovalPage(raw.recent_resolved_page)
-    const approvalRules = Array.isArray(raw.approval_rules)
-      ? raw.approval_rules
-          .map(item => normalizeKeeperApprovalRule(item))
-          .filter((item): item is KeeperApprovalRule => item !== null)
-      : []
+    const recentResolvedState = normalizeKeeperResolvedApprovalState(raw.recent_resolved_state)
+    let recentResolved: KeeperResolvedApprovalItem[] | null
+    let recentResolvedPage: KeeperResolvedApprovalPage | null
+    if (recentResolvedState.state === 'unavailable') {
+      if (raw.recent_resolved !== null || raw.recent_resolved_page !== null) {
+        return gateSnapshotProtocolDrift('unavailable resolved history must use null rows and page')
+      }
+      recentResolved = null
+      recentResolvedPage = null
+    } else {
+      if (!Array.isArray(raw.recent_resolved)) {
+        return gateSnapshotProtocolDrift('ready recent_resolved must be an array')
+      }
+      const normalized = raw.recent_resolved.map(item => normalizeKeeperResolvedApprovalItem(item))
+      if (normalized.some(item => item === null)) {
+        return gateSnapshotProtocolDrift('recent_resolved contains an invalid row')
+      }
+      recentResolved = normalized as KeeperResolvedApprovalItem[]
+      recentResolvedPage = normalizeKeeperResolvedApprovalPage(raw.recent_resolved_page)
+      if (recentResolvedPage === null) {
+        return gateSnapshotProtocolDrift('ready recent_resolved_page is invalid')
+      }
+      if (recentResolvedPage.returned !== recentResolved.length) {
+        return gateSnapshotProtocolDrift('recent_resolved_page.returned does not match row count')
+      }
+    }
+    const approvalRulesState = normalizeApprovalRulesState(raw.approval_rules_state)
+    if (!Array.isArray(raw.approval_rules)) {
+      return gateSnapshotProtocolDrift('approval_rules must be an array')
+    }
+    const approvalRules = raw.approval_rules.map(item => normalizeKeeperApprovalRule(item))
+    if (approvalRules.some(rule => rule === null)) {
+      return gateSnapshotProtocolDrift('approval_rules contains an invalid rule')
+    }
+    if (approvalRulesState.state === 'unavailable' && approvalRules.length !== 0) {
+      return gateSnapshotProtocolDrift('unavailable approval_rules must be empty')
+    }
     return {
       generated_at: asNullableIsoTimestamp(raw.generated_at) ?? undefined,
       note: typeof raw.note === 'string' && raw.note.trim() !== '' ? raw.note.trim() : undefined,
@@ -298,25 +456,34 @@ export function fetchDashboardGate(
       approval_queue_violations: approvalQueueViolations,
       recent_resolved: recentResolved,
       recent_resolved_page: recentResolvedPage,
-      approval_rules: approvalRules,
+      recent_resolved_state: recentResolvedState,
+      approval_rules: approvalRules as KeeperApprovalRule[],
+      approval_rules_state: approvalRulesState,
       hitl: normalizeHitlStatus(raw.hitl),
     }
   })
 }
 
+export type GateApprovalResolution =
+  | { decision: 'approve'; rememberRule: boolean; ruleExpiresAt?: number }
+  | { decision: 'reject'; reason: string }
+
 export function resolveGateApproval(
   id: string,
-  decision: 'approve' | 'reject',
-  rememberRule?: boolean,
-  reason?: string,
-  ruleExpiresAt?: number,
-): Promise<{ ok: boolean; id: string; decision: 'approve' | 'reject'; rule_id?: string | null }> {
+  resolution: GateApprovalResolution,
+): Promise<{
+  ok: boolean
+  id: string
+  decision: 'approve' | 'reject'
+  rule_id: string | null
+  rule_error: string | null
+}> {
   return post('/api/v1/dashboard/gate/resolve', {
     id,
-    decision,
-    remember_rule: rememberRule,
-    reason,
-    rule_expires_at: ruleExpiresAt,
+    decision: resolution.decision,
+    remember_rule: resolution.decision === 'approve' ? resolution.rememberRule : false,
+    reason: resolution.decision === 'reject' ? resolution.reason : undefined,
+    rule_expires_at: resolution.decision === 'approve' ? resolution.ruleExpiresAt : undefined,
   })
 }
 

--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -315,14 +315,7 @@ function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprov
   }
 }
 
-/**
- * Page bounds for the resolved history. Returns null when the server did not
- * send them or sent them incompletely — an older server during a rolling
- * deploy, for instance. Null must render as "completeness unknown", never as
- * "this is everything": presenting a slice as the whole history is the defect
- * this field exists to remove, so a partial page is rejected outright rather
- * than filled in with defaults.
- */
+/** Decode the exact page bounds that make resolved-history completeness explicit. */
 function normalizeKeeperResolvedApprovalPage(
   raw: unknown,
 ): KeeperResolvedApprovalPage | null {
@@ -389,11 +382,8 @@ export function fetchDashboardGate(
       if (!Array.isArray(raw.approval_queue)) {
         return gateSnapshotProtocolDrift('ready approval_queue must be an array')
       }
-      // A contract-violating row is quarantined as a visible placeholder
-      // instead of failing the whole snapshot (#26094): one drifted row used
-      // to blank the entire queue — the surface an operator needs precisely
-      // when rows are drifting. Identity fields are best-effort salvage so
-      // the placeholder still names the pending request.
+      // Preserve the exact valid rows and expose every invalid row as a typed
+      // violation with the identity fields that can be decoded safely.
       const accepted: KeeperApprovalQueueItem[] = []
       raw.approval_queue.forEach((item, index) => {
         const normalized = normalizeKeeperApprovalQueueItem(item)

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1626,12 +1626,56 @@ describe('fetchDashboardMemory', () => {
 })
 
 describe('fetchDashboardGate', () => {
+  const gateHitl = {
+    gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+    judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
+  } as const
+
+  const emptyResolvedHistory = {
+    recent_resolved: [],
+    recent_resolved_page: {
+      returned: 0,
+      matched: 0,
+      limit: 20,
+      window_minutes: 1440,
+      truncated: false,
+      scan_exhausted: false,
+    },
+    recent_resolved_state: { state: 'ready' },
+  } as const
+
+  function currentResolvedRow(overrides: Record<string, unknown> = {}) {
+    const decisionKind = overrides.decision_kind === 'reject' ? 'reject' : 'approve'
+    return {
+      id: 'appr-current',
+      event: 'resolved',
+      keeper_name: 'keeper-a',
+      tool_name: 'fs_write',
+      decision: decisionKind === 'approve' ? 'approve' : 'reject:operator denied',
+      decision_kind: decisionKind,
+      decision_reason: decisionKind === 'approve' ? null : 'operator denied',
+      resolved_at: 1_782_522_123,
+      turn_id: null,
+      task_id: null,
+      goal_id: null,
+      goal_ids: [],
+      actor: 'operator',
+      decision_source: 'human_operator',
+      summary_status: 'not_requested',
+      exact_attempt: { state: 'unbound' },
+      ...overrides,
+    }
+  }
+
   it('requests a forced Gate snapshot when asked', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         approval_queue: [],
         approval_queue_state: { state: 'ready' },
-        recent_resolved: [],
+        ...emptyResolvedHistory,
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1651,7 +1695,7 @@ describe('fetchDashboardGate', () => {
         approval_queue: [],
         approval_queue_state: { state: 'ready' },
         recent_resolved: [
-          {
+          currentResolvedRow({
             id: 'appr-done',
             keeper_name: 'keeper-a',
             tool_name: 'fs_write',
@@ -1659,16 +1703,28 @@ describe('fetchDashboardGate', () => {
             decision_kind: 'reject',
             decision_reason: 'operator denied',
             resolved_at: 1_782_522_123,
-          },
-          {
+          }),
+          currentResolvedRow({
             id: 'appr-approved',
             keeper_name: 'keeper-a',
             tool_name: 'shell_exec',
             decision: 'approve',
             decision_kind: 'approve',
             resolved_at: 1_782_522_183,
-          },
+          }),
         ],
+        recent_resolved_page: {
+          returned: 2,
+          matched: 2,
+          limit: 20,
+          window_minutes: 1440,
+          truncated: false,
+          scan_exhausted: false,
+        },
+        recent_resolved_state: { state: 'ready' },
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1706,14 +1762,19 @@ describe('fetchDashboardGate', () => {
       new Response(JSON.stringify({
         approval_queue: [],
         approval_queue_state: { state: 'ready' },
-        recent_resolved: [],
+        ...emptyResolvedHistory,
+        approval_rules_state: { state: 'ready' },
         approval_rules: [{
           id: 'rule-1',
           keeper_name: 'keeper-a',
           tool_name: 'fs_write',
-          request_fingerprint: 'abcdef1234567890',
+          request_fingerprint: 'a'.repeat(64),
           created_at: 1_783_123_200,
+          created_by: 'operator',
+          source_approval_id: 'appr-1',
+          expires_at: null,
         }],
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1725,16 +1786,61 @@ describe('fetchDashboardGate', () => {
 
     expect(result.approval_rules).toEqual([
       expect.objectContaining({
-        request_fingerprint: 'abcdef1234567890',
-        created_at: '2026-07-04T00:00:00.000Z',
+        request_fingerprint: 'a'.repeat(64),
+        created_at: 1_783_123_200,
+        expires_at: null,
       }),
     ])
   })
 
-  // The resolved history is capped by the server. Without the page bounds a
-  // client renders a slice as the whole history, so a page that is absent or
-  // incomplete must normalize to null ("completeness unknown") rather than to
-  // a zeroed record that reads as "this is everything".
+  it('preserves approval rule-store unavailability', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        approval_queue: [],
+        approval_queue_state: { state: 'ready' },
+        ...emptyResolvedHistory,
+        approval_rules: [],
+        approval_rules_state: {
+          state: 'unavailable',
+          error: 'approval rules store unreadable',
+        },
+        hitl: gateHitl,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+
+    const result = await fetchDashboardGate()
+
+    expect(result.approval_rules_state).toEqual({
+      state: 'unavailable',
+      error: 'approval rules store unreadable',
+    })
+  })
+
+  it('rejects a malformed approval rule instead of dropping it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        approval_queue: [],
+        approval_queue_state: { state: 'ready' },
+        ...emptyResolvedHistory,
+        approval_rules_state: { state: 'ready' },
+        approval_rules: [{
+          id: 'rule-invalid',
+          keeper_name: 'keeper-a',
+          tool_name: 'fs_write',
+          request_fingerprint: 'not-a-sha256',
+          created_at: 1_783_123_200,
+          created_by: null,
+          source_approval_id: null,
+          expires_at: null,
+        }],
+        hitl: gateHitl,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+
+    await expect(fetchDashboardGate()).rejects.toThrow('approval_rules contains an invalid rule')
+  })
+
+  // Rows, bounds, and availability form one exact current snapshot contract.
   function gateResponseWithPage(page: unknown) {
     return vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
@@ -1742,6 +1848,10 @@ describe('fetchDashboardGate', () => {
         approval_queue_state: { state: 'ready' },
         recent_resolved: [],
         recent_resolved_page: page,
+        recent_resolved_state: { state: 'ready' },
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1751,27 +1861,27 @@ describe('fetchDashboardGate', () => {
 
   it('normalizes a complete resolved-history page', async () => {
     vi.stubGlobal('fetch', gateResponseWithPage({
-      returned: 20,
-      matched: 149,
+      returned: 0,
+      matched: 0,
       limit: 20,
       window_minutes: 1440,
-      truncated: true,
+      truncated: false,
       scan_exhausted: false,
     }))
 
     const result = await fetchDashboardGate()
 
     expect(result.recent_resolved_page).toEqual({
-      returned: 20,
-      matched: 149,
+      returned: 0,
+      matched: 0,
       limit: 20,
       window_minutes: 1440,
-      truncated: true,
+      truncated: false,
       scan_exhausted: false,
     })
   })
 
-  it('rejects a partial resolved-history page instead of defaulting it', async () => {
+  it('rejects a partial resolved-history page', async () => {
     vi.stubGlobal('fetch', gateResponseWithPage({
       returned: 20,
       matched: 149,
@@ -1779,17 +1889,13 @@ describe('fetchDashboardGate', () => {
       // window_minutes and the two flags are missing: an older server, or drift.
     }))
 
-    const result = await fetchDashboardGate()
-
-    expect(result.recent_resolved_page).toBeNull()
+    await expect(fetchDashboardGate()).rejects.toThrow('ready recent_resolved_page is invalid')
   })
 
-  it('reports an absent resolved-history page as unknown, not as a full history', async () => {
+  it('rejects an absent resolved-history page', async () => {
     vi.stubGlobal('fetch', gateResponseWithPage(undefined))
 
-    const result = await fetchDashboardGate()
-
-    expect(result.recent_resolved_page).toBeNull()
+    await expect(fetchDashboardGate()).rejects.toThrow('ready recent_resolved_page is invalid')
   })
 
   it('rejects a resolved-history page with a nonsensical window', async () => {
@@ -1802,9 +1908,35 @@ describe('fetchDashboardGate', () => {
       scan_exhausted: false,
     }))
 
+    await expect(fetchDashboardGate()).rejects.toThrow('ready recent_resolved_page is invalid')
+  })
+
+  it('preserves resolved-history storage unavailability', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        approval_queue: [],
+        approval_queue_state: { state: 'ready' },
+        recent_resolved: null,
+        recent_resolved_page: null,
+        recent_resolved_state: {
+          state: 'unavailable',
+          stage: 'list_recent_resolved',
+          error: 'audit JSONL unreadable',
+        },
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+
     const result = await fetchDashboardGate()
 
-    expect(result.recent_resolved_page).toBeNull()
+    expect(result.recent_resolved).toBeNull()
+    expect(result.recent_resolved_state).toEqual({
+      state: 'unavailable',
+      stage: 'list_recent_resolved',
+      error: 'audit JSONL unreadable',
+    })
   })
 
   it('preserves typed unavailable queue state without fabricating an empty ready queue', async () => {
@@ -1819,7 +1951,10 @@ describe('fetchDashboardGate', () => {
           severity: 'bad',
           icon: '!',
         },
-        recent_resolved: [],
+        ...emptyResolvedHistory,
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1894,7 +2029,10 @@ describe('fetchDashboardGate', () => {
           },
         ],
         approval_queue_state: { state: 'ready' },
-        recent_resolved: [],
+        ...emptyResolvedHistory,
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1910,7 +2048,7 @@ describe('fetchDashboardGate', () => {
     ])
   })
 
-  it('carries judge evidence on resolved rows and null for pre-enrichment events', async () => {
+  it('carries judge evidence on resolved rows', async () => {
     const judgeSummary = {
       summary_version: 2,
       generated_at: 1_782_522_120,
@@ -1925,7 +2063,7 @@ describe('fetchDashboardGate', () => {
         approval_queue: [],
         approval_queue_state: { state: 'ready' },
         recent_resolved: [
-          {
+          currentResolvedRow({
             id: 'appr-judged',
             keeper_name: 'keeper-a',
             tool_name: 'shell_exec',
@@ -1946,18 +2084,20 @@ describe('fetchDashboardGate', () => {
               status: 'completed',
               quarantine_cause: null,
             },
-          },
-          {
-            id: 'appr-legacy',
-            keeper_name: 'keeper-a',
-            tool_name: 'fs_write',
-            decision: 'approve',
-            decision_kind: 'approve',
-            resolved_at: 1_782_522_100,
-            summary_status: null,
-            exact_attempt: null,
-          },
+          }),
         ],
+        recent_resolved_page: {
+          returned: 1,
+          matched: 1,
+          limit: 20,
+          window_minutes: 1440,
+          truncated: false,
+          scan_exhausted: false,
+        },
+        recent_resolved_state: { state: 'ready' },
+        approval_rules: [],
+        approval_rules_state: { state: 'ready' },
+        hitl: gateHitl,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1976,16 +2116,15 @@ describe('fetchDashboardGate', () => {
     expect(
       judged?.exact_attempt?.state === 'bound' ? judged.exact_attempt.slot_id : null,
     ).toBe('glm-coding.glm-5-turbo')
-    const legacy = result.recent_resolved?.find(item => item.id === 'appr-legacy')
-    expect(legacy?.summary_status).toBeNull()
-    expect(legacy?.exact_attempt).toBeNull()
   })
 
-  it('parses the closed judge_lane variant and drops shapes outside it', async () => {
+  it('parses the closed judge_lane variant and rejects shapes outside it', async () => {
     const snapshot = (judgeLane: unknown) => new Response(JSON.stringify({
       approval_queue: [],
       approval_queue_state: { state: 'ready' },
-      recent_resolved: [],
+      ...emptyResolvedHistory,
+      approval_rules: [],
+      approval_rules_state: { state: 'ready' },
       hitl: {
         gate_mode: { mode: 'auto_judge', configured: false, state: 'ready' },
         judge_lane: judgeLane,
@@ -2022,7 +2161,7 @@ describe('fetchDashboardGate', () => {
       lane_id: 'hitl_auto_judge',
       slots: [],
     })))
-    expect((await fetchDashboardGate()).hitl?.judge_lane).toBeUndefined()
+    await expect(fetchDashboardGate()).rejects.toThrow('hitl.judge_lane.slots is invalid')
   })
 })
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1710,6 +1710,7 @@ describe('fetchDashboardGate', () => {
             tool_name: 'shell_exec',
             decision: 'approve',
             decision_kind: 'approve',
+            actor: null,
             resolved_at: 1_782_522_183,
           }),
         ],
@@ -1751,6 +1752,7 @@ describe('fetchDashboardGate', () => {
         decision: 'approve',
         decision_raw: 'approve',
         decision_reason: null,
+        actor: null,
         resolved_at: '2026-06-27T01:03:03.000Z',
       }),
     ])

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -30,6 +30,19 @@ function queueItem(overrides: Partial<KeeperApprovalQueueItem> & { id: string })
   }
 }
 
+function approvalRule(
+  overrides: Partial<KeeperApprovalRule> & Pick<KeeperApprovalRule, 'id' | 'keeper_name' | 'tool_name'>,
+): KeeperApprovalRule {
+  return {
+    request_fingerprint: 'a'.repeat(64),
+    created_at: 1_782_525_723,
+    created_by: 'operator',
+    source_approval_id: 'appr-source',
+    expires_at: null,
+    ...overrides,
+  }
+}
+
 function completedExactAttempt(id: string, callId: string) {
   return {
     state: 'bound' as const,
@@ -52,27 +65,66 @@ function releasedRecoveryAttempt(id: string) {
   }
 }
 
+function resolvedApproval(
+  overrides: Partial<KeeperResolvedApprovalItem> = {},
+): KeeperResolvedApprovalItem {
+  const decision = overrides.decision ?? 'approve'
+  return {
+    id: 'appr-resolved',
+    keeper_name: 'keeper-a',
+    tool_name: 'fs_write',
+    decision,
+    decision_raw: decision === 'approve' ? 'approve' : 'reject:operator rejected',
+    decision_reason: decision === 'approve' ? null : 'operator rejected',
+    resolved_at: '2026-07-28T09:10:00Z',
+    turn_id: null,
+    task_id: null,
+    goal_id: null,
+    goal_ids: [],
+    actor: 'operator',
+    decision_source: 'human_operator',
+    summary_status: { status: 'not_requested' },
+    exact_attempt: { state: 'unbound' },
+    ...overrides,
+  }
+}
+
 function responseWithQueue(
   approval_queue: KeeperApprovalQueueItem[] | null,
-  recent_resolved: KeeperResolvedApprovalItem[] = [],
+  recent_resolved: KeeperResolvedApprovalItem[] | null = [],
   approval_rules: KeeperApprovalRule[] = [],
   hitl: DashboardGateResponse['hitl'] = {
     gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+    judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
   },
   approval_queue_state: DashboardGateResponse['approval_queue_state'] = {
     state: 'ready',
   },
-  recent_resolved_page: DashboardGateResponse['recent_resolved_page'] = null,
+  recent_resolved_page?: DashboardGateResponse['recent_resolved_page'],
   approval_queue_violations: DashboardGateResponse['approval_queue_violations'] = [],
+  approval_rules_state: DashboardGateResponse['approval_rules_state'] = { state: 'ready' },
+  recent_resolved_state: DashboardGateResponse['recent_resolved_state'] = { state: 'ready' },
 ): DashboardGateResponse {
+  const resolvedPage = recent_resolved_state.state === 'ready'
+    ? recent_resolved_page ?? {
+        returned: recent_resolved?.length ?? 0,
+        matched: recent_resolved?.length ?? 0,
+        limit: 20,
+        window_minutes: 1440,
+        truncated: false,
+        scan_exhausted: false,
+      }
+    : null
   return {
     generated_at: '2026-06-19T00:00:00Z',
     approval_queue,
     approval_queue_state,
     approval_queue_violations,
     recent_resolved,
-    recent_resolved_page,
+    recent_resolved_page: resolvedPage,
+    recent_resolved_state,
     approval_rules,
+    approval_rules_state,
     hitl,
   } as DashboardGateResponse
 }
@@ -81,22 +133,31 @@ function responseWithQueue(
 // registry.
 async function loadSurface(
   approval_queue: KeeperApprovalQueueItem[] | null,
-  recent_resolved: KeeperResolvedApprovalItem[] = [],
+  recent_resolved: KeeperResolvedApprovalItem[] | null = [],
   approval_rules: KeeperApprovalRule[] = [],
   hitl?: DashboardGateResponse['hitl'],
   approval_queue_state: DashboardGateResponse['approval_queue_state'] = {
     state: 'ready',
   },
-  recent_resolved_page: DashboardGateResponse['recent_resolved_page'] = null,
+  recent_resolved_page?: DashboardGateResponse['recent_resolved_page'],
   approval_queue_violations: DashboardGateResponse['approval_queue_violations'] = [],
+  approval_rules_state: DashboardGateResponse['approval_rules_state'] = { state: 'ready' },
+  recent_resolved_state: DashboardGateResponse['recent_resolved_state'] = { state: 'ready' },
 ) {
   vi.resetModules()
   const resolveGateApproval = vi
     .fn()
-    .mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' })
+    .mockResolvedValue({
+      ok: true,
+      id: 'appr-1',
+      decision: 'approve',
+      rule_id: null,
+      rule_error: null,
+    })
   const retryGateAutoJudge = vi
     .fn()
     .mockResolvedValue({ ok: true, id: 'appr-1' })
+  const deleteGateApprovalRule = vi.fn().mockResolvedValue({ ok: true, id: 'rule-1' })
   const setGateMode = vi
     .fn()
     .mockResolvedValue({
@@ -121,6 +182,8 @@ async function loadSurface(
         approval_queue_state,
         recent_resolved_page,
         approval_queue_violations,
+        approval_rules_state,
+        recent_resolved_state,
       )
     : responseWithQueue(
         approval_queue,
@@ -130,12 +193,14 @@ async function loadSurface(
         approval_queue_state,
         recent_resolved_page,
         approval_queue_violations,
+        approval_rules_state,
+        recent_resolved_state,
       )
   const apiMock = () => ({
     fetchDashboardGate: vi.fn().mockResolvedValue(response),
     resolveGateApproval,
     retryGateAutoJudge,
-    deleteGateApprovalRule: vi.fn().mockResolvedValue({ ok: true }),
+    deleteGateApprovalRule,
     setGateMode,
   })
   vi.doMock('../../api', apiMock)
@@ -149,13 +214,25 @@ async function loadSurface(
     navigate,
   }))
   const mod = await import('./approvals-surface')
-  return { ApprovalsSurface: mod.ApprovalsSurface, resolveGateApproval, retryGateAutoJudge, setGateMode, navigate }
+  return {
+    ApprovalsSurface: mod.ApprovalsSurface,
+    resolveGateApproval,
+    retryGateAutoJudge,
+    deleteGateApprovalRule,
+    setGateMode,
+    navigate,
+  }
 }
 
 describe('ApprovalsSurface', () => {
   let container: HTMLDivElement
 
   beforeEach(() => {
+    Object.defineProperty(window, 'prompt', {
+      value: vi.fn().mockReturnValue('operator rejected'),
+      configurable: true,
+      writable: true,
+    })
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -414,13 +491,13 @@ describe('ApprovalsSurface', () => {
     const { ApprovalsSurface } = await loadSurface(
       null,
       [
-        {
+        resolvedApproval({
           id: 'appr-resolved-during-reset',
           keeper_name: 'keeper-a',
           tool_name: 'fs_write',
           decision: 'reject',
           resolved_at: '2026-07-27T00:00:00Z',
-        },
+        }),
       ],
       [],
       undefined,
@@ -570,17 +647,15 @@ describe('ApprovalsSurface', () => {
     expect(container.textContent).not.toContain('처리이력')
   }, 20000)
 
-  // The history list is a server-capped page. These four cases pin that the
-  // screen states its scope: a slice must never read as the whole history, and
-  // an unreported page must read as unknown rather than complete.
-  const resolvedRow: KeeperResolvedApprovalItem = {
+  // The history list always travels with its exact server page bounds.
+  const resolvedRow: KeeperResolvedApprovalItem = resolvedApproval({
     id: 'appr-1',
     keeper_name: 'rondo',
     tool_name: 'tool_execute',
     decision: 'approve',
     decision_source: 'auto_judge',
     resolved_at: '2026-07-28T02:53:47Z',
-  }
+  })
 
   async function openHistory(page: DashboardGateResponse['recent_resolved_page']) {
     const { ApprovalsSurface } = await loadSurface(
@@ -642,12 +717,28 @@ describe('ApprovalsSurface', () => {
     expect(scope?.className).toContain('warn')
   }, 20000)
 
-  it('reports unknown scope rather than completeness when the server sent no page', async () => {
-    const scope = await openHistory(null)
+  it('renders audit-store unavailability instead of an empty history', async () => {
+    const { ApprovalsSurface } = await loadSurface(
+      [],
+      null,
+      [],
+      undefined,
+      { state: 'ready' },
+      null,
+      [],
+      { state: 'ready' },
+      {
+        state: 'unavailable',
+        stage: 'list_recent_resolved',
+        error: 'audit JSONL unreadable',
+      },
+    )
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
 
-    expect(scope?.textContent).toContain('확인할 수 없습니다')
-    // Must not make the completeness claim the complete branch makes.
-    expect(scope?.textContent).not.toContain('건 전체')
+    const alert = container.querySelector('[data-testid="approvals-history-unavailable"]')
+    expect(alert?.textContent).toContain('audit JSONL unreadable')
+    expect(container.querySelector('[data-testid="approvals-history-count"]')).toBeNull()
   }, 20000)
 
   it('counts resolved decisions on the history tab so the default screen shows they exist', async () => {
@@ -666,15 +757,16 @@ describe('ApprovalsSurface', () => {
     const { ApprovalsSurface } = await loadSurface(
       [],
       [
-        {
+        resolvedApproval({
           id: 'appr-done',
           keeper_name: 'masc-improver',
           tool_name: 'fs_write',
           decision: 'reject',
           decision_source: 'human_operator',
           decision_raw: 'reject:operator denied',
+          decision_reason: 'operator denied',
           resolved_at: '2026-06-27T01:02:03Z',
-        },
+        }),
       ],
     )
 
@@ -697,11 +789,11 @@ describe('ApprovalsSurface', () => {
     expect(history?.querySelector('.ap-history-at')?.textContent).toContain('2026')
   }, 20000)
 
-  it('unfolds judge evidence and slot on resolved rows that carry it, none on legacy rows', async () => {
+  it('unfolds judge evidence and slot only on rows that carry judge evidence', async () => {
     const { ApprovalsSurface } = await loadSurface(
       [],
       [
-        {
+        resolvedApproval({
           id: 'appr-judged',
           keeper_name: 'keeper-a',
           tool_name: 'shell_exec',
@@ -732,16 +824,14 @@ describe('ApprovalsSurface', () => {
             status: 'completed',
             quarantine_cause: null,
           },
-        },
-        {
-          id: 'appr-legacy',
+        }),
+        resolvedApproval({
+          id: 'appr-plain',
           keeper_name: 'keeper-a',
           tool_name: 'fs_write',
           decision: 'approve',
           resolved_at: '2026-07-28T09:10:00Z',
-          summary_status: null,
-          exact_attempt: null,
-        },
+        }),
       ],
     )
 
@@ -760,9 +850,9 @@ describe('ApprovalsSurface', () => {
     expect(fold?.textContent).toContain('Keeper requested a read-only listing.')
     expect(fold?.textContent).toContain('Is the path inside the sandbox?')
     expect(fold?.textContent).toContain('Read-only and scoped.')
-    const legacy = container.querySelector('[data-approval-id="appr-legacy"]')
-    expect(legacy?.querySelector('[data-testid="approval-history-slot"]')).toBeNull()
-    expect(legacy?.querySelector('[data-testid="approval-history-judge"]')).toBeNull()
+    const plain = container.querySelector('[data-approval-id="appr-plain"]')
+    expect(plain?.querySelector('[data-testid="approval-history-slot"]')).toBeNull()
+    expect(plain?.querySelector('[data-testid="approval-history-judge"]')).toBeNull()
   }, 20000)
 
   it('shows contract-violating queue rows as a visible banner instead of a clean empty queue', async () => {
@@ -820,35 +910,38 @@ describe('ApprovalsSurface', () => {
     expect(unavailable?.textContent).toContain('registry_not_published')
   }, 20000)
 
-  it('filters resolved approval history and surfaces Always-rule evidence', async () => {
+  it('filters resolved approval history and renders current rules separately', async () => {
     const { ApprovalsSurface } = await loadSurface(
       [],
       [
-        {
+        resolvedApproval({
           id: 'appr-approved',
           keeper_name: 'keeper-a',
           tool_name: 'fs_write',
           decision: 'approve',
-          decision_source: 'always_allowed',
+          decision_source: 'human_operator',
           resolved_at: '2026-06-27T02:02:03Z',
-          rule_match: { rule_id: 'rule-1' },
-        },
-        {
+        }),
+        resolvedApproval({
           id: 'appr-rejected',
           keeper_name: 'keeper-b',
           tool_name: 'shell',
           decision: 'reject',
           decision_source: 'auto_judge',
           resolved_at: '2026-06-27T01:02:03Z',
-        },
+        }),
       ],
       [
-        {
+        approvalRule({
           id: 'rule-1',
           keeper_name: 'keeper-a',
           tool_name: 'fs_write',
-          request_fingerprint: 'abcdef1234567890',
-        },
+          request_fingerprint: 'a'.repeat(64),
+          created_at: 1782525723,
+          created_by: 'operator',
+          source_approval_id: 'appr-approved',
+          expires_at: null,
+        }),
       ],
     )
 
@@ -859,14 +952,10 @@ describe('ApprovalsSurface', () => {
     expect(aside?.textContent).toContain('Always Rules')
     expect(aside?.textContent).toContain('keeper-a')
     expect(aside?.textContent).toContain('fs_write')
-    expect(aside?.textContent).toContain('abcdef123456')
-    expect(aside?.textContent).not.toContain('abcdef1234567890')
+    expect(aside?.textContent).toContain('aaaaaaaaaaaa')
 
     container.querySelector<HTMLButtonElement>('.ap-viewbtn:not(.on)')?.click()
     await flushUi()
-
-    expect(container.querySelector('[data-testid="approvals-history-view"]')?.textContent)
-      .toContain('rule rule-1')
 
     const rejectFilter = Array.from(container.querySelectorAll<HTMLButtonElement>('.ap-hist-f'))
       .find(button => button.textContent === '거부')
@@ -879,12 +968,12 @@ describe('ApprovalsSurface', () => {
   }, 20000)
 
   it('makes hidden Always rules explicit when the aside list overflows its cap', async () => {
-    const rules = Array.from({ length: 8 }, (_, i) => ({
+    const rules = Array.from({ length: 8 }, (_, i) => approvalRule({
       id: `rule-${i}`,
       keeper_name: 'keeper-a',
       tool_name: 'fs_write',
-      request_fingerprint: `fp-${i}`,
-    })) as KeeperApprovalRule[]
+      request_fingerprint: i.toString(16).padStart(64, '0'),
+    }))
     const { ApprovalsSurface } = await loadSurface([], [], rules)
 
     render(html`<${ApprovalsSurface} />`, container)
@@ -898,18 +987,61 @@ describe('ApprovalsSurface', () => {
   }, 20000)
 
   it('omits the rules overflow note when the list fits the cap', async () => {
-    const rules = Array.from({ length: 6 }, (_, i) => ({
+    const rules = Array.from({ length: 6 }, (_, i) => approvalRule({
       id: `rule-${i}`,
       keeper_name: 'k',
       tool_name: 't',
-      request_fingerprint: `fp-${i}`,
-    })) as KeeperApprovalRule[]
+      request_fingerprint: i.toString(16).padStart(64, '0'),
+    }))
     const { ApprovalsSurface } = await loadSurface([], [], rules)
 
     render(html`<${ApprovalsSurface} />`, container)
     await flushUi()
 
     expect(container.querySelector('[data-testid="approvals-rules-overflow"]')).toBeNull()
+  }, 20000)
+
+  it('renders rule-store unavailability instead of an empty rule list', async () => {
+    const { ApprovalsSurface } = await loadSurface(
+      [],
+      [],
+      [],
+      undefined,
+      { state: 'ready' },
+      null,
+      [],
+      { state: 'unavailable', error: 'approval rules store unreadable' },
+    )
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="approval-rules-unavailable"]')?.textContent)
+      .toContain('approval rules store unreadable')
+    expect(container.textContent).not.toContain('저장된 Always 규칙 없음')
+  }, 20000)
+
+  it('shows expired rules and deletes the exact rule through the live action', async () => {
+    const expiredRule = approvalRule({
+      id: 'rule-expired',
+      keeper_name: 'keeper-expired',
+      tool_name: 'fs_write',
+      created_at: 1_700_000_000,
+      expires_at: 1_700_000_100,
+    })
+    const { ApprovalsSurface, deleteGateApprovalRule } = await loadSurface([], [], [expiredRule])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="approval-rule-expiry"]')?.textContent)
+      .toContain('만료됨')
+    const deleteButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.getAttribute('aria-label') === 'fs_write Always 규칙 삭제')
+    deleteButton?.click()
+    await flushUi()
+
+    expect(deleteGateApprovalRule).toHaveBeenCalledWith('rule-expired')
   }, 20000)
 
   it('shows the empty state when no approvals are pending', async () => {
@@ -1028,7 +1160,10 @@ describe('ApprovalsSurface', () => {
     approveBtn?.click()
     await flushUi()
 
-    expect(resolveGateApproval).toHaveBeenCalledWith('appr-9', 'approve', false)
+    expect(resolveGateApproval).toHaveBeenCalledWith(
+      'appr-9',
+      { decision: 'approve', rememberRule: false },
+    )
   })
 
   it('routes the 거부 action through resolveGateApproval with the reject decision', async () => {
@@ -1039,10 +1174,16 @@ describe('ApprovalsSurface', () => {
     render(html`<${ApprovalsSurface} />`, container)
     await flushUi()
 
+    const prompt = vi.spyOn(window, 'prompt').mockReturnValueOnce('작업 범위를 벗어남')
     container.querySelector<HTMLButtonElement>('.ap-card .ap-act.deny')?.click()
     await flushUi()
 
-    expect(resolveGateApproval).toHaveBeenCalledWith('appr-r', 'reject', false)
+    expect(prompt).toHaveBeenCalledWith('승인 요청을 거부하는 이유를 입력하세요.')
+    expect(resolveGateApproval).toHaveBeenCalledWith(
+      'appr-r',
+      { decision: 'reject', reason: '작업 범위를 벗어남' },
+    )
+    prompt.mockRestore()
   })
 
   it('routes the 항상 승인 action through resolveGateApproval with rememberRule=true', async () => {
@@ -1056,12 +1197,16 @@ describe('ApprovalsSurface', () => {
     container.querySelector<HTMLButtonElement>('.ap-card .ap-act.always')?.click()
     await flushUi()
 
-    expect(resolveGateApproval).toHaveBeenCalledWith('appr-a', 'approve', true)
+    expect(resolveGateApproval).toHaveBeenCalledWith(
+      'appr-a',
+      { decision: 'approve', rememberRule: true },
+    )
   })
 
   it('binds the three non-hierarchical choices to hitl.gate_mode', async () => {
     const { ApprovalsSurface } = await loadSurface([], [], [], {
       gate_mode: { mode: 'auto_judge', configured: true, state: 'ready' },
+      judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
     })
 
     render(html`<${ApprovalsSurface} />`, container)
@@ -1080,6 +1225,7 @@ describe('ApprovalsSurface', () => {
   it('shows Human as the selected Gate mode when configured', async () => {
     const { ApprovalsSurface } = await loadSurface([], [], [], {
       gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+      judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
     })
 
     render(html`<${ApprovalsSurface} />`, container)
@@ -1093,6 +1239,7 @@ describe('ApprovalsSurface', () => {
   it('routes a Gate mode choice through setGateMode', async () => {
     const { ApprovalsSurface, setGateMode } = await loadSurface([], [], [], {
       gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+      judge_lane: { status: 'available', lane_id: 'gate-judge', slots: ['judge'] },
     })
 
     render(html`<${ApprovalsSurface} />`, container)

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -765,6 +765,7 @@ describe('ApprovalsSurface', () => {
           decision_source: 'human_operator',
           decision_raw: 'reject:operator denied',
           decision_reason: 'operator denied',
+          actor: null,
           resolved_at: '2026-06-27T01:02:03Z',
         }),
       ],
@@ -783,6 +784,7 @@ describe('ApprovalsSurface', () => {
     expect(history?.textContent).toContain('fs_write')
     expect(history?.textContent).toContain('masc-improver')
     expect(history?.textContent).toContain('Human')
+    expect(history?.textContent).toContain('unattributed')
     expect(history?.textContent).toContain('appr-done')
     expect(history?.querySelector('.ap-history-decision')?.className).toContain('decision-reject')
     expect(history?.querySelector('.ap-history-decision')?.className).not.toContain('operator denied')

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -131,7 +131,7 @@ function ResolvedApprovalItem({ item }: { item: KeeperResolvedApprovalItem }) {
       <span class="ap-history-tool mono">${item.tool_name}</span>
       <span class="ap-history-keeper">${item.keeper_name}</span>
       <span class="ap-history-source">${decisionSourceLabel(item.decision_source)}</span>
-      <span class="ap-history-actor">${item.actor}</span>
+      <span class="ap-history-actor">${item.actor ?? 'unattributed'}</span>
       <span class="ap-history-id mono">${item.id}</span>
       ${judgeSlot
         ? html`<span class="ap-history-slot mono" data-testid="approval-history-slot">${judgeSlot}</span>`

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -676,8 +676,8 @@ function ApAside({
                   </div>
                 `
             : null}
-          ${gateMode?.state === 'invalid' || gateMode?.state === 'unavailable' || gateMode?.read_error
-            ? html`<div class="ap-env-warn mono">Gate mode ${gateMode.state ?? 'invalid'}: ${gateMode.read_error ?? '상태 확인 실패'}</div>`
+          ${gateMode?.state === 'invalid' || gateMode?.state === 'unavailable'
+            ? html`<div class="ap-env-warn mono">Gate mode ${gateMode.state}: ${gateMode.read_error}</div>`
             : null}
         </div>
       </section>

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -15,6 +15,7 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 import type {
   KeeperApprovalQueueItem,
   KeeperApprovalRule,
+  KeeperApprovalRulesState,
   KeeperResolvedApprovalItem,
   KeeperResolvedApprovalPage,
   GateDecisionSource,
@@ -40,6 +41,7 @@ import {
   gateError,
   gateLoading,
   gateApprovalActing,
+  deleteKeeperApprovalRule,
   refreshGate,
   respondToKeeperApproval,
   retryKeeperAutoJudge,
@@ -47,7 +49,7 @@ import {
 } from '../gate-store'
 
 type ApprovalsView = 'queue' | 'history'
-type ApprovalHistoryFilter = 'all' | KeeperResolvedApprovalDecision | 'rule'
+type ApprovalHistoryFilter = 'all' | KeeperResolvedApprovalDecision
 
 const APPROVAL_HISTORY_FILTERS: ReadonlyArray<{
   id: ApprovalHistoryFilter
@@ -57,9 +59,6 @@ const APPROVAL_HISTORY_FILTERS: ReadonlyArray<{
   { id: 'all', label: '전체', predicate: () => true },
   { id: 'approve', label: '승인', predicate: item => item.decision === 'approve' },
   { id: 'reject', label: '거부', predicate: item => item.decision === 'reject' },
-  { id: 'edit', label: '수정됨', predicate: item => item.decision === 'edit' },
-  { id: 'unknown', label: '처리됨', predicate: item => item.decision === 'unknown' },
-  { id: 'rule', label: 'Always 규칙', predicate: item => item.rule_match != null },
 ]
 const DEFAULT_APPROVAL_HISTORY_FILTER = APPROVAL_HISTORY_FILTERS[0]!
 
@@ -118,9 +117,6 @@ function decisionSourceLabel(source: GateDecisionSource | null | undefined): str
 
 function ResolvedApprovalItem({ item }: { item: KeeperResolvedApprovalItem }) {
   const decision = keeperResolvedApprovalDecisionLabel(item.decision)
-  // Judge evidence recorded at resolution time (#26126). Older audit events
-  // carry none, so the row renders without the fold rather than implying a
-  // judgment that was never recorded.
   const judgeSummary =
     item.summary_status?.status === 'available' ? item.summary_status.summary : null
   const judgeSlot =
@@ -135,12 +131,10 @@ function ResolvedApprovalItem({ item }: { item: KeeperResolvedApprovalItem }) {
       <span class="ap-history-tool mono">${item.tool_name}</span>
       <span class="ap-history-keeper">${item.keeper_name}</span>
       <span class="ap-history-source">${decisionSourceLabel(item.decision_source)}</span>
+      <span class="ap-history-actor">${item.actor}</span>
       <span class="ap-history-id mono">${item.id}</span>
       ${judgeSlot
         ? html`<span class="ap-history-slot mono" data-testid="approval-history-slot">${judgeSlot}</span>`
-        : null}
-      ${item.rule_match?.rule_id
-        ? html`<span class="ap-history-rule mono">rule ${item.rule_match.rule_id}</span>`
         : null}
       ${item.resolved_at
         ? html`<span class="ap-history-at">${formatDateTimeKo(item.resolved_at)}</span>`
@@ -232,7 +226,6 @@ function ApHistory({
   const counts = useMemo(() => ({
     approve: sorted.filter(item => item.decision === 'approve').length,
     reject: sorted.filter(item => item.decision === 'reject').length,
-    rule: sorted.filter(item => item.rule_match != null).length,
     keepers: new Set(sorted.map(item => item.keeper_name)).size,
   }), [sorted])
 
@@ -242,7 +235,6 @@ function ApHistory({
       <div class="ap-hist-summary" aria-label="승인 이력 요약">
         <div class="ap-hist-stat"><b class="mono ok">${counts.approve}</b> 승인</div>
         <div class="ap-hist-stat"><b class="mono bad">${counts.reject}</b> 거부</div>
-        <div class="ap-hist-stat"><b class="mono">${counts.rule}</b> Rule</div>
         <div class="ap-hist-stat"><b class="mono">${counts.keepers}</b> 관련 키퍼</div>
       </div>
       <div class="ap-hist-filters" role="tablist" aria-label="승인 이력 필터">
@@ -589,12 +581,26 @@ function ApprovalDetailPanel({
 }
 
 function ApprovalRuleRow({ rule }: { rule: KeeperApprovalRule }) {
-  const fingerprintPreview = rule.request_fingerprint?.slice(0, 12)
+  const fingerprintPreview = rule.request_fingerprint.slice(0, 12)
+  const expired = rule.expires_at !== null && rule.expires_at <= Date.now() / 1000
+  const expiryLabel = rule.expires_at === null
+    ? '만료 없음'
+    : `${expired ? '만료됨' : '만료'} ${formatDateTimeKo(rule.expires_at * 1000)}`
+  const deleting = gateApprovalActing.value === `rule:${rule.id}`
   return html`
     <li class="ap-rule-row" data-testid="approval-rule-row">
       <span class="ap-rule-keeper mono">${rule.keeper_name}</span>
       <span class="ap-rule-tool mono">${rule.tool_name}</span>
-      ${fingerprintPreview ? html`<span class="ap-rule-fingerprint mono">${fingerprintPreview}</span>` : null}
+      <span class="ap-rule-fingerprint mono">${fingerprintPreview}</span>
+      <span class="ap-rule-provenance mono">${rule.created_by} · ${rule.source_approval_id}</span>
+      <span class=${`ap-rule-expiry ${expired ? 'sev-bad' : ''}`} data-testid="approval-rule-expiry">${expiryLabel}</span>
+      <button
+        type="button"
+        class="ap-rule-delete"
+        disabled=${deleting}
+        onClick=${() => void deleteKeeperApprovalRule(rule.id)}
+        aria-label=${rule.tool_name + ' Always 규칙 삭제'}
+      >${deleting ? '삭제 중' : '삭제'}</button>
     </li>
   `
 }
@@ -609,10 +615,12 @@ function ApAside({
   openCount,
   resolvedItems,
   rules,
+  rulesState,
 }: {
   openCount: number
   resolvedItems: KeeperResolvedApprovalItem[]
   rules: KeeperApprovalRule[]
+  rulesState: KeeperApprovalRulesState
 }) {
   const hitl = gateData.value?.hitl
   const recent = [...resolvedItems]
@@ -649,7 +657,7 @@ function ApAside({
               `)}
             </div>
           </div>
-          <div class="wka-auto-stat">${rules.length.toLocaleString()}개 Always 규칙 · 열린 승인 ${openCount.toLocaleString()}건</div>
+          <div class="wka-auto-stat">${rulesState.state === 'ready' ? `${rules.length.toLocaleString()}개 Always 규칙` : 'Always 규칙 확인 불가'} · 열린 승인 ${openCount.toLocaleString()}건</div>
           <div class="wka-auto-note">
             Human은 사람이 판단하고, Auto Judge는 LLM이 판단하며, Always Allow는 workspace의 명시적 선택입니다.
           </div>
@@ -679,7 +687,9 @@ function ApAside({
           <h3>Always Rules</h3>
           <span class="mono">${rules.length}</span>
         </div>
-        ${rules.length > 0
+        ${rulesState.state === 'unavailable'
+          ? html`<div class="ap-env-warn" role="alert" data-testid="approval-rules-unavailable">${rulesState.error}</div>`
+          : rules.length > 0
           ? html`
               <ul class="ap-rule-list">${rules.slice(0, ASIDE_RULES_LIMIT).map(rule => html`<${ApprovalRuleRow} key=${rule.id} rule=${rule} />`)}</ul>
               ${hiddenRules > 0
@@ -734,9 +744,13 @@ export function ApprovalsSurface() {
     approvalQueueState && approvalQueueState.state !== 'ready'
       ? approvalQueueState
       : null
+  const resolvedState = gateData.value?.recent_resolved_state ?? null
   const resolvedItems = gateData.value?.recent_resolved ?? []
   const resolvedPage = gateData.value?.recent_resolved_page ?? null
+  const resolvedUnavailable =
+    resolvedState?.state === 'unavailable' ? resolvedState : null
   const rules = gateData.value?.approval_rules ?? []
+  const rulesState = gateData.value?.approval_rules_state ?? null
   const queueViolations = gateData.value?.approval_queue_violations ?? []
   const error = gateError.value
   // First load only: gateResource is stale-while-revalidate, so a refetch
@@ -795,6 +809,14 @@ export function ApprovalsSurface() {
         </header>
 
         ${error ? html`<div class="ap-error" role="alert" data-testid="approvals-error">${error}</div>` : null}
+        ${resolvedUnavailable
+          ? html`
+              <div class="ap-error sev-bad" role="alert" data-testid="approvals-history-unavailable">
+                <strong><span aria-hidden="true">!</span> 승인 처리 이력을 읽을 수 없습니다</strong>
+                <span>${resolvedUnavailable.error}</span>
+              </div>
+            `
+          : null}
         ${queueViolations.length > 0
           ? html`
               <div class="ap-error sev-warn" role="alert" data-testid="approvals-queue-violations">
@@ -829,7 +851,9 @@ export function ApprovalsSurface() {
         ${firstLoad
           ? html`<${LoadingState}>Gate 큐 불러오는 중...<//>`
           : view === 'history'
-            ? html`<${ApHistory} items=${resolvedItems} page=${resolvedPage} />`
+            ? resolvedUnavailable
+              ? null
+              : html`<${ApHistory} items=${resolvedItems} page=${resolvedPage} />`
           : queueUnavailable || items === null
             ? null
           : html`
@@ -848,7 +872,7 @@ export function ApprovalsSurface() {
           </div>
           <div class="ov-kpi">
             <div class="ov-kpi-k">처리 완료</div>
-            <div class="ov-kpi-v volt">${resolvedItems.length}</div>
+            <div class="ov-kpi-v volt">${resolvedUnavailable ? '—' : resolvedItems.length}</div>
           </div>
         </section>
 
@@ -884,11 +908,12 @@ export function ApprovalsSurface() {
           : null}
       `}
       </div>
-      ${!firstLoad && !queueUnavailable && items !== null ? html`
+      ${!firstLoad && !queueUnavailable && !resolvedUnavailable && items !== null && rulesState !== null ? html`
         <${ApAside}
           openCount=${items.length}
           resolvedItems=${resolvedItems}
           rules=${rules}
+          rulesState=${rulesState}
         />
       ` : null}
     </main>

--- a/dashboard/src/components/gate-actions.ts
+++ b/dashboard/src/components/gate-actions.ts
@@ -20,14 +20,26 @@ export async function respondToKeeperApproval(
   rememberRule = false,
 ) {
   if (!id) return
+  const resolution = (() => {
+    if (decision === 'approve') return { decision, rememberRule } as const
+    const reason = window.prompt('승인 요청을 거부하는 이유를 입력하세요.')
+    if (reason === null || reason.trim() === '') return null
+    return { decision, reason } as const
+  })()
+  if (resolution === null) {
+    showToast('거부 이유를 입력해야 합니다', 'warning')
+    return
+  }
   gateApprovalActing.value = id
   try {
-    await resolveGateApproval(id, decision, rememberRule)
-    const message =
-      decision === 'approve'
+    const result = await resolveGateApproval(id, resolution)
+    const ruleFailed = decision === 'approve' && rememberRule && result.rule_error !== null
+    const message = ruleFailed
+      ? `keeper 승인 요청은 승인했지만 Always 규칙을 저장하지 못했습니다: ${result.rule_error}`
+      : decision === 'approve'
         ? (rememberRule ? 'keeper 승인 요청을 승인하고 Always 규칙을 저장했습니다' : 'keeper 승인 요청을 승인했습니다')
         : 'keeper 승인 요청을 거부했습니다'
-    showToast(message, 'success')
+    showToast(message, ruleFailed ? 'warning' : 'success')
     await refreshGate({ force: true })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'keeper 승인 요청을 처리하지 못했습니다'

--- a/dashboard/src/components/gate-resource-swr.test.ts
+++ b/dashboard/src/components/gate-resource-swr.test.ts
@@ -35,6 +35,15 @@ function response(queue: KeeperApprovalQueueItem[]): DashboardGateResponse {
     approval_queue: queue,
     approval_queue_state: { state: 'ready' },
     recent_resolved: [],
+    recent_resolved_page: {
+      returned: 0,
+      matched: 0,
+      limit: 20,
+      window_minutes: 1440,
+      truncated: false,
+      scan_exhausted: false,
+    },
+    recent_resolved_state: { state: 'ready' },
     approval_rules: [],
   } as DashboardGateResponse
 }
@@ -115,10 +124,13 @@ describe('Gate resource (stale-while-revalidate)', () => {
         severity: 'bad',
         icon: '!',
       },
-      recent_resolved: [],
-      // Null, not a zeroed page: an observation error leaves the history bounds
-      // unknown, and a zeroed page would render as "nothing was decided".
+      recent_resolved: null,
       recent_resolved_page: null,
+      recent_resolved_state: {
+        state: 'unavailable',
+        stage: 'list_recent_resolved',
+        error: 'Gate 새로고침 실패',
+      },
       approval_rules: [],
     })
     expect(signals.gateError.value).toContain('Gate 새로고침 실패')

--- a/dashboard/src/components/gate-resource-swr.test.ts
+++ b/dashboard/src/components/gate-resource-swr.test.ts
@@ -45,7 +45,12 @@ function response(queue: KeeperApprovalQueueItem[]): DashboardGateResponse {
     },
     recent_resolved_state: { state: 'ready' },
     approval_rules: [],
-  } as DashboardGateResponse
+    approval_rules_state: { state: 'ready' },
+    hitl: {
+      gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+      judge_lane: { status: 'available', lane_id: 'keeper_gate_judge', slots: ['keeper_gate_judge'] },
+    },
+  }
 }
 
 async function loadGate() {
@@ -132,6 +137,11 @@ describe('Gate resource (stale-while-revalidate)', () => {
         error: 'Gate 새로고침 실패',
       },
       approval_rules: [],
+      approval_rules_state: {
+        state: 'unavailable',
+        error: 'Gate 새로고침 실패',
+      },
+      hitl: null,
     })
     expect(signals.gateError.value).toContain('Gate 새로고침 실패')
     expect(signals.gateLoading.value).toBe(false)

--- a/dashboard/src/components/gate-signals.ts
+++ b/dashboard/src/components/gate-signals.ts
@@ -23,6 +23,8 @@ export function gateObservationErrorSnapshot(operatorDetail: string): DashboardG
       error: operatorDetail,
     },
     approval_rules: [],
+    approval_rules_state: { state: 'unavailable', error: operatorDetail },
+    hitl: null,
   }
 }
 

--- a/dashboard/src/components/gate-signals.ts
+++ b/dashboard/src/components/gate-signals.ts
@@ -15,10 +15,13 @@ export function gateObservationErrorSnapshot(operatorDetail: string): DashboardG
   return {
     approval_queue: null,
     approval_queue_state: gateObservationErrorState(operatorDetail),
-    recent_resolved: [],
-    // Null, not a zeroed page: an observation error means the history bounds
-    // are unknown, and a zeroed page would read as "nothing was decided".
+    recent_resolved: null,
     recent_resolved_page: null,
+    recent_resolved_state: {
+      state: 'unavailable',
+      stage: 'list_recent_resolved',
+      error: operatorDetail,
+    },
     approval_rules: [],
   }
 }

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -35,6 +35,15 @@ function gateResponse(queue: KeeperApprovalQueueItem[]): DashboardGateResponse {
     approval_queue: queue,
     approval_queue_state: { state: 'ready' },
     recent_resolved: [],
+    recent_resolved_page: {
+      returned: 0,
+      matched: 0,
+      limit: 20,
+      window_minutes: 1440,
+      truncated: false,
+      scan_exhausted: false,
+    },
+    recent_resolved_state: { state: 'ready' },
     approval_rules: [],
   } as DashboardGateResponse
 }

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -45,7 +45,12 @@ function gateResponse(queue: KeeperApprovalQueueItem[]): DashboardGateResponse {
     },
     recent_resolved_state: { state: 'ready' },
     approval_rules: [],
-  } as DashboardGateResponse
+    approval_rules_state: { state: 'ready' },
+    hitl: {
+      gate_mode: { mode: 'manual', configured: true, state: 'ready' },
+      judge_lane: { status: 'available', lane_id: 'keeper_gate_judge', slots: ['keeper_gate_judge'] },
+    },
+  }
 }
 
 async function loadChat() {

--- a/dashboard/src/lib/keeper-approval-decision.ts
+++ b/dashboard/src/lib/keeper-approval-decision.ts
@@ -1,8 +1,6 @@
 export const KEEPER_RESOLVED_APPROVAL_DECISIONS = [
   'approve',
   'reject',
-  'edit',
-  'unknown',
 ] as const
 
 export type KeeperResolvedApprovalDecision =
@@ -12,18 +10,13 @@ const KEEPER_RESOLVED_APPROVAL_DECISION_LABELS:
   Record<KeeperResolvedApprovalDecision, string> = {
     approve: '승인',
     reject: '거부',
-    edit: '수정됨',
-    unknown: '처리됨',
   }
 
 export function normalizeKeeperResolvedApprovalDecision(
   raw: string | null | undefined,
-): KeeperResolvedApprovalDecision {
-  const value = raw?.trim()
-  if (value === 'approve') return 'approve'
-  if (value === 'reject') return 'reject'
-  if (value === 'edit') return 'edit'
-  return 'unknown'
+): KeeperResolvedApprovalDecision | null {
+  if (raw === 'approve' || raw === 'reject') return raw
+  return null
 }
 
 export function keeperResolvedApprovalDecisionLabel(

--- a/dashboard/src/types/gate.ts
+++ b/dashboard/src/types/gate.ts
@@ -167,7 +167,7 @@ export interface KeeperResolvedApprovalItem {
   task_id: string | null
   goal_id: string | null
   goal_ids: string[]
-  actor: string
+  actor: string | null
   decision_source: GateDecisionSource
   summary_status: HitlSummaryStatus
   exact_attempt: KeeperExactAttemptState

--- a/dashboard/src/types/gate.ts
+++ b/dashboard/src/types/gate.ts
@@ -160,21 +160,17 @@ export interface KeeperResolvedApprovalItem {
   keeper_name: string
   tool_name: string
   decision: KeeperResolvedApprovalDecision
-  decision_raw?: string | null
-  decision_reason?: string | null
-  resolved_at?: string | null
-  turn_id?: number | null
-  task_id?: string | null
-  goal_id?: string | null
-  goal_ids?: string[]
-  decision_source?: GateDecisionSource | null
-  rule_match?: {
-    rule_id?: string | null
-  } | null
-  /** Judge evidence recorded on the resolved audit event at resolution time
-   *  (#26126). `null` on events written before that enrichment existed. */
-  summary_status?: HitlSummaryStatus | null
-  exact_attempt?: KeeperExactAttemptState | null
+  decision_raw: string
+  decision_reason: string | null
+  resolved_at: string
+  turn_id: number | null
+  task_id: string | null
+  goal_id: string | null
+  goal_ids: string[]
+  actor: string
+  decision_source: GateDecisionSource
+  summary_status: HitlSummaryStatus
+  exact_attempt: KeeperExactAttemptState
 }
 
 /** An approval_queue row the server sent but the client contract rejected.
@@ -198,20 +194,23 @@ export interface KeeperApprovalRule {
   id: string
   keeper_name: string
   tool_name: string
-  request_fingerprint?: string
-  created_at?: string | null
-  created_by?: string | null
-  source_approval_id?: string | null
+  request_fingerprint: string
+  created_at: number
+  created_by: string
+  source_approval_id: string
+  expires_at: number | null
 }
+
+export type KeeperApprovalRulesState =
+  | { state: 'ready' }
+  | { state: 'unavailable'; error: string }
 
 export type GateMode = 'manual' | 'auto_judge' | 'always_allow'
 
-export interface GateModeStatus {
-  mode: GateMode
-  configured?: boolean
-  state?: 'ready' | 'invalid' | string
-  read_error?: string
-}
+export type GateModeStatus =
+  | { mode: GateMode; configured: boolean; state: 'ready' }
+  | { mode: 'auto_judge'; configured: boolean; state: 'unavailable'; read_error: string }
+  | { mode: 'manual'; configured: true; state: 'invalid'; read_error: string }
 
 /**
  * Bounds that produced `recent_resolved`. Read them with the rows: `returned`
@@ -229,19 +228,25 @@ export interface KeeperResolvedApprovalPage {
   scan_exhausted: boolean
 }
 
+export type KeeperResolvedApprovalState =
+  | { state: 'ready' }
+  | { state: 'unavailable'; stage: 'list_recent_resolved'; error: string }
+
 export interface DashboardGateResponse {
   generated_at?: string
   note?: string
   approval_queue: KeeperApprovalQueueItem[] | null
   approval_queue_state: KeeperApprovalQueueState
   approval_queue_violations?: KeeperApprovalQueueRowViolation[]
-  recent_resolved?: KeeperResolvedApprovalItem[]
-  recent_resolved_page?: KeeperResolvedApprovalPage | null
-  approval_rules?: KeeperApprovalRule[]
-  hitl?: {
-    gate_mode?: GateModeStatus
-    judge_lane?: GateJudgeLane
-  }
+  recent_resolved: KeeperResolvedApprovalItem[] | null
+  recent_resolved_page: KeeperResolvedApprovalPage | null
+  recent_resolved_state: KeeperResolvedApprovalState
+  approval_rules: KeeperApprovalRule[]
+  approval_rules_state: KeeperApprovalRulesState
+  hitl: {
+    gate_mode: GateModeStatus
+    judge_lane: GateJudgeLane
+  } | null
 }
 
 export interface OperatorActionDescriptor {

--- a/lib/dashboard/dashboard_gate.ml
+++ b/lib/dashboard/dashboard_gate.ml
@@ -72,13 +72,27 @@ let dashboard_json ~base_path ~limit ~window_minutes =
   (* NDT-OK: HTTP observation boundary; captured once for the pure projection,
      matching [Dashboard_gate_metrics.gate_tool_events_json]. *)
   let now_ts = Unix.gettimeofday () in
-  let resolved_history =
-    Keeper_approval.Audit.list_recent_resolved
-      ~base_path
-      ~now_ts
-      ~limit
-      ~window_minutes
-      ()
+  let recent_resolved, recent_resolved_page, recent_resolved_state =
+    match
+      Keeper_approval.Audit.list_recent_resolved
+        ~base_path
+        ~now_ts
+        ~limit
+        ~window_minutes
+        ()
+    with
+    | Ok history ->
+      ( `List history.resolved_rows
+      , recent_resolved_page_json history
+      , `Assoc [ "state", `String "ready" ] )
+    | Error error ->
+      ( `Null
+      , `Null
+      , `Assoc
+          [ "state", `String "unavailable"
+          ; "stage", `String (Keeper_approval.Audit.read_stage_to_string error.stage)
+          ; "error", `String error.detail
+          ] )
   in
   let approval_rules, approval_rules_state =
     match Keeper_approval_queue_rules.list_rules_dashboard_json ~base_path () with
@@ -97,8 +111,9 @@ let dashboard_json ~base_path ~limit ~window_minutes =
           "External effects use exact Always Allowed, Auto Judge, or nonblocking human HITL." )
     ; "approval_queue", approval_queue
     ; "approval_queue_state", approval_queue_state
-    ; "recent_resolved", `List resolved_history.resolved_rows
-    ; "recent_resolved_page", recent_resolved_page_json resolved_history
+    ; "recent_resolved", recent_resolved
+    ; "recent_resolved_page", recent_resolved_page
+    ; "recent_resolved_state", recent_resolved_state
     ; "approval_rules", approval_rules
     ; "approval_rules_state", approval_rules_state
     ; "hitl", hitl_status_json ~base_path

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -230,27 +230,22 @@ let unresolved_pending_approval row =
   | _ -> false
 
 let latest_pending_approval ~base_path ~keeper_name =
-  let rows =
-    try
-      Keeper_approval.Audit.read_recent
-        ~base_path ~keeper_name ~n:128 ()
-    with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn ->
-        Log.Dashboard.warn
-          "keeper dashboard approval activity read failed for %s: %s"
-          keeper_name (Printexc.to_string exn);
-        []
-  in
-  latest_rows_by_approval_id rows
-  |> List.filter unresolved_pending_approval
-  |> List.fold_left
-       (fun acc row ->
-         match acc with
-         | None -> Some row
-         | Some existing when approval_row_newer row existing -> Some row
-         | Some _ -> acc)
-       None
+  match
+    Keeper_approval.Audit.read_recent
+      ~base_path ~keeper_name ~n:128 ()
+  with
+  | Error _ as error -> error
+  | Ok rows ->
+    Ok
+      (latest_rows_by_approval_id rows
+       |> List.filter unresolved_pending_approval
+       |> List.fold_left
+            (fun acc row ->
+              match acc with
+              | None -> Some row
+              | Some existing when approval_row_newer row existing -> Some row
+              | Some _ -> acc)
+            None)
 
 let freshest_activity_source ~meta_ts ~latest_tool ~pending_approval =
   let candidates =
@@ -409,8 +404,22 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                 m.runtime.compaction_rt.last_ts; created_ts ]
           in
           let latest_tool_activity = latest_keeper_tool_activity m.name in
-          let pending_approval =
-            latest_pending_approval ~base_path:config.base_path ~keeper_name:m.name
+          let pending_approval, approval_audit_state =
+            match
+              latest_pending_approval
+                ~base_path:config.base_path
+                ~keeper_name:m.name
+            with
+            | Ok pending -> pending, `Assoc [ "state", `String "ready" ]
+            | Error error ->
+              ( None
+              , `Assoc
+                  [ "state", `String "unavailable"
+                  ; ( "stage"
+                    , `String
+                        (Keeper_approval.Audit.read_stage_to_string error.stage) )
+                  ; "error", `String error.detail
+                  ] )
           in
           let activity_source =
             freshest_activity_source
@@ -447,6 +456,7 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
               ("last_activity_at", activity_at_json last_activity_ts);
               ("live_activity", activity_json);
               ("current_gate", gate_json);
+              ("approval_audit_state", approval_audit_state);
             ]
             @
             (match pending_approval with

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -695,6 +695,14 @@ let latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
   |> sort_timeline_events
   |> fun events -> latest_causal_from_timeline (`List events)
 
+let approval_audit_rows_or_fail = function
+  | Ok rows -> rows
+  | Error error ->
+    failwith
+      ("approval audit unavailable: "
+       ^ Keeper_approval.Audit.read_error_to_string error)
+;;
+
 let summary_json ~(config : Workspace.config) ~(meta : keeper_meta) =
   let latest_decision = latest_decision_json ~config ~keeper_name:meta.name in
   let latest_tool_call = latest_tool_call_json ~keeper_name:meta.name in
@@ -703,6 +711,7 @@ let summary_json ~(config : Workspace.config) ~(meta : keeper_meta) =
     match
       Keeper_approval.Audit.read_recent ~base_path:config.base_path
         ~keeper_name:meta.name ~n:1 ()
+      |> approval_audit_rows_or_fail
     with
     | json :: _ -> Some json
     | [] -> None
@@ -804,6 +813,7 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
   let approval_events =
     Keeper_approval.Audit.read_recent ~base_path ~keeper_name:meta.name
       ~n:8 ()
+    |> approval_audit_rows_or_fail
     |> List.filter_map approval_event_timeline_event
   in
   let transition_events =
@@ -907,6 +917,7 @@ let snapshot_json_inner_with_pending_reader
     match
       Keeper_approval.Audit.read_recent ~base_path:config.base_path
         ~keeper_name:meta.name ~n:1 ()
+      |> approval_audit_rows_or_fail
     with
     | json :: _ -> Some json
     | [] -> None

--- a/lib/keeper_approval/audit.ml
+++ b/lib/keeper_approval/audit.ml
@@ -1,5 +1,23 @@
 open Keeper_approval_queue_rules_types
 
+type read_stage =
+  | Read_recent
+  | List_recent_resolved
+
+type read_error =
+  { stage : read_stage
+  ; detail : string
+  }
+
+let read_stage_to_string = function
+  | Read_recent -> "read_recent"
+  | List_recent_resolved -> "list_recent_resolved"
+;;
+
+let read_error_to_string error =
+  Printf.sprintf "%s: %s" (read_stage_to_string error.stage) error.detail
+;;
+
 let record_failure ~keeper_name ~site ?(id = "-") ?(event_type = "-") exn =
   Keeper_fd_pressure.note_exception ~site:("approval_audit." ^ site) exn;
   Otel_metric_store_core.inc_counter
@@ -24,21 +42,6 @@ let audit_stores_mu = Stdlib.Mutex.create ()
 let audit_io_mutex = Cross_context_mutex.create ()
 let audit_stores : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 
-(* Runtime trust asks for per-keeper latest audit state across the same global
-   audit tail. Cache the raw tail briefly so a keeper snapshot does one shared
-   JSONL read instead of N identical scans. *)
-type recent_audit_cache_entry =
-  { rows : Yojson.Safe.t list
-  ; observed_at : float
-  }
-;;
-
-let recent_audit_cache_mu = Stdlib.Mutex.create ()
-let recent_audit_cache : (string, recent_audit_cache_entry) Hashtbl.t =
-  Hashtbl.create 4
-;;
-
-let recent_audit_cache_ttl_sec = 1.0
 let recent_resolved_history_limit = 20
 let audit_wide_scan_min_rows = 500
 let audit_wide_scan_multiplier = 64
@@ -81,35 +84,29 @@ type resolved_history =
       (* the row cap stopped the scan before it reached the window start *)
   }
 
-let recent_audit_cache_key store limit =
-  Printf.sprintf "%s:%d" (Dated_jsonl.base_dir store) limit
-;;
-
-let invalidate_recent_audit_cache_for_store store =
-  let prefix = Dated_jsonl.base_dir store ^ ":" in
-  Stdlib.Mutex.protect recent_audit_cache_mu (fun () ->
-    Hashtbl.filter_map_inplace
-      (fun key entry -> if String.starts_with ~prefix key then None else Some entry)
-      recent_audit_cache)
+let parsed_rows ~stage entries =
+  let rec collect acc = function
+    | [] -> Ok (List.rev acc)
+    | Dated_jsonl.Parsed row :: rest -> collect (row :: acc) rest
+    | Dated_jsonl.Malformed_json { path; line_number; detail } :: _ ->
+      let location =
+        match line_number with
+        | Some line -> Printf.sprintf "%s:%d" path line
+        | None -> path
+      in
+      Error { stage; detail = Printf.sprintf "%s: %s" location detail }
+  in
+  collect [] entries
 ;;
 
 let read_recent_audit_raw store limit =
-  let key = recent_audit_cache_key store limit in
-  let now = Unix.gettimeofday () in
-  let cached =
-    Stdlib.Mutex.protect recent_audit_cache_mu (fun () ->
-      match Hashtbl.find_opt recent_audit_cache key with
-      | Some entry when now -. entry.observed_at <= recent_audit_cache_ttl_sec ->
-        Some entry.rows
-      | _ -> None)
-  in
-  match cached with
-  | Some rows -> rows
-  | None ->
-    let rows = Dated_jsonl.read_recent store limit in
-    Stdlib.Mutex.protect recent_audit_cache_mu (fun () ->
-      Hashtbl.replace recent_audit_cache key { rows; observed_at = now });
-    rows
+  match Dated_jsonl.read_recent_result store limit with
+  | Error error ->
+    Error
+      { stage = Read_recent
+      ; detail = Dated_jsonl.read_error_to_string error
+      }
+  | Ok entries -> parsed_rows ~stage:Read_recent entries
 ;;
 
 (* The vocabulary of the [event] field in the approval audit log. Every writer
@@ -212,11 +209,6 @@ let approval_decision_kind_and_reason = function
   | Decision.Reject reason -> Decision_reject, non_empty_reason reason
 ;;
 
-let keeper_audit_metric_label = function
-  | Some keeper when String.trim keeper <> "" -> keeper
-  | Some _ | None -> "aggregate"
-;;
-
 let audit_today_path base_dir =
   let open Unix in
   let tm = gmtime (gettimeofday ()) in
@@ -240,7 +232,7 @@ let get_audit_store ~base_path () =
     Log.Keeper.warn
       "approval_queue: audit store creation failed: %s"
       (Printexc.to_string exn);
-    None
+    Error (Printexc.to_string exn)
   in
   try
     match
@@ -248,8 +240,8 @@ let get_audit_store ~base_path () =
         try
           Ok
             (match Hashtbl.find_opt audit_stores base_path with
-             | Some store -> Some store
-             | None ->
+               | Some store -> store
+               | None ->
                let dir =
                  Filename.concat
                    (Common.masc_dir_from_base_path ~base_path)
@@ -257,12 +249,12 @@ let get_audit_store ~base_path () =
                in
                let store = Dated_jsonl.create ~base_dir:dir () in
                Hashtbl.replace audit_stores base_path store;
-               Some store)
+               store)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn -> Error exn)
     with
-    | Ok store -> store
+    | Ok store -> Ok store
     | Error exn -> report_failure exn
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -306,8 +298,8 @@ let record
     | None -> Unix.gettimeofday ()
   in
   match get_audit_store ~base_path () with
-  | None -> ()
-  | Some store ->
+  | Error _ -> ()
+  | Ok store ->
     let json =
       `Assoc
         ([ "ts", `Float timestamp
@@ -332,39 +324,36 @@ let record
            , match authorization_source with
              | Some source -> `String (authorization_source_to_string source)
              | None -> `Null )
+         ; ( "rule_match"
+           , match rule_match with
+             | Some matched -> rule_match_to_yojson matched
+             | None -> `Null )
+         ; "source_approval_id", Json_util.string_opt_to_json source_approval_id
+         ; ( "decision_kind"
+           , match decision_kind with
+             | Some kind -> `String (decision_kind_to_string kind)
+             | None -> `Null )
+         ; "decision_reason", Json_util.string_opt_to_json decision_reason
+         ; ( "summary_status"
+           , match summary_status with
+             | Some status -> summary_status_to_yojson status
+             | None -> `Null )
+         ; ( "exact_attempt"
+           , match exact_attempt with
+             | Some attempt -> exact_attempt_state_to_yojson attempt
+             | None -> `Null )
+         ; ( "summary_attempt_disposition"
+           , match summary_attempt_disposition with
+             | Some disposition ->
+               summary_attempt_disposition_to_yojson disposition
+             | None -> `Null )
          ]
-         @ (match rule_match with
-            | Some matched -> [ "rule_match", rule_match_to_yojson matched ]
-            | None -> [])
-         @ (match source_approval_id with
-            | Some approval_id -> [ "source_approval_id", `String approval_id ]
-            | None -> [])
-         @ (match decision_kind with
-            | Some kind ->
-              [ "decision_kind", `String (decision_kind_to_string kind) ]
-            | None -> [])
-         @ (match decision_reason with
-            | Some reason -> [ "decision_reason", `String reason ]
-            | None -> [])
-         @ (match summary_status with
-            | Some status -> [ "summary_status", summary_status_to_yojson status ]
-            | None -> [])
-         @ (match exact_attempt with
-            | Some attempt ->
-              [ "exact_attempt", exact_attempt_state_to_yojson attempt ]
-            | None -> [])
-         @ (match summary_attempt_disposition with
-            | Some disposition ->
-              [ ( "summary_attempt_disposition"
-                , summary_attempt_disposition_to_yojson disposition ) ]
-            | None -> [])
          @ extra_fields
          )
     in
     Cross_context_mutex.with_durable_lock audit_io_mutex (fun () ->
       try
-        Fs_compat.append_jsonl (audit_today_path (Dated_jsonl.base_dir store)) json;
-        invalidate_recent_audit_cache_for_store store
+        Fs_compat.append_jsonl (audit_today_path (Dated_jsonl.base_dir store)) json
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn -> record_failure ~keeper_name ~site:"audit_append" ~id
@@ -393,54 +382,27 @@ let audit_scan_window ?keeper_name n =
 ;;
 
 
-let record_audit_read_failure ?keeper_name ?(metric_site = Keeper_approval_queue_failure_site.Audit_read_recent) ~site exn =
-  Keeper_fd_pressure.note_exception ~site exn;
-  Otel_metric_store_core.inc_counter
-    Keeper_metrics.(to_string ApprovalQueueFailures)
-    ~labels:
-      [ "keeper",
-        keeper_audit_metric_label keeper_name;
-        "site",
-        Keeper_approval_queue_failure_site.to_label metric_site
-      ]
-    ()
-;;
-
-let read_recent ~base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list =
+let read_recent ~base_path ?keeper_name ?(n = 20) ()
+  : (Yojson.Safe.t list, read_error) result
+  =
   if n <= 0
-  then []
+  then Ok []
   else (
     match get_audit_store ~base_path () with
-    | None -> []
-    | Some store ->
-      try
-        let raw = read_recent_audit_raw store (audit_scan_window ?keeper_name n) in
-        let filtered =
-          match keeper_name with
-          | None -> raw
-          | Some name ->
-            raw
-            |> List.filter (fun json ->
-              String.equal name (Safe_ops.json_string ~default:"" "keeper" json))
-        in
-        filtered |> List.rev |> List.filteri (fun idx _ -> idx < n)
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        record_audit_read_failure ?keeper_name ~site:"approval_audit.read_recent" exn;
-        [])
-;;
-
-let json_member_or_null key json =
-  match Json_util.assoc_member_opt key json with
-  | Some value -> value
-  | None -> `Null
-;;
-
-let resolved_approval_decision_kind json =
-  Option.bind
-    (Safe_ops.json_string_opt "decision_kind" json)
-    decision_kind_of_string
+    | Error detail -> Error { stage = Read_recent; detail }
+    | Ok store ->
+      (match read_recent_audit_raw store (audit_scan_window ?keeper_name n) with
+       | Error _ as error -> error
+       | Ok raw ->
+         let filtered =
+           match keeper_name with
+           | None -> raw
+           | Some name ->
+             raw
+             |> List.filter (fun json ->
+               String.equal name (Safe_ops.json_string ~default:"" "keeper" json))
+         in
+         Ok (filtered |> List.rev |> List.filteri (fun idx _ -> idx < n))))
 ;;
 
 let resolved_history_event json =
@@ -449,30 +411,165 @@ let resolved_history_event json =
   | None -> false
 ;;
 
+let resolved_audit_fields =
+  [ "ts"
+  ; "event"
+  ; "id"
+  ; "keeper"
+  ; "tool"
+  ; "decision"
+  ; "turn_id"
+  ; "task_id"
+  ; "goal_id"
+  ; "goal_ids"
+  ; "actor"
+  ; "decision_source"
+  ; "authorization_source"
+  ; "rule_match"
+  ; "source_approval_id"
+  ; "decision_kind"
+  ; "decision_reason"
+  ; "summary_status"
+  ; "exact_attempt"
+  ; "summary_attempt_disposition"
+  ]
+;;
+
+let required_member ~surface key fields =
+  match List.assoc_opt key fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "%s.%s is required" surface key)
+;;
+
+let required_nonblank_string ~surface key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) when String.trim value <> "" -> Ok value
+  | Some (`String _) -> Error (Printf.sprintf "%s.%s must be non-blank" surface key)
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a string" surface key)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface key)
+;;
+
+let required_nullable_string ~surface key fields =
+  match List.assoc_opt key fields with
+  | Some `Null -> Ok `Null
+  | Some (`String value) when String.trim value <> "" -> Ok (`String value)
+  | Some (`String _) -> Error (Printf.sprintf "%s.%s must be non-blank" surface key)
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a string or null" surface key)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface key)
+;;
+
+let required_nullable_nonnegative_int ~surface key fields =
+  match List.assoc_opt key fields with
+  | Some `Null -> Ok `Null
+  | Some (`Int value) when value >= 0 -> Ok (`Int value)
+  | Some _ ->
+    Error (Printf.sprintf "%s.%s must be a non-negative integer or null" surface key)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface key)
+;;
+
+let required_finite_timestamp ~surface key fields =
+  match List.assoc_opt key fields with
+  | Some (`Float value) when Float.is_finite value && value >= 0.0 -> Ok value
+  | Some (`Int value) when value >= 0 -> Ok (float_of_int value)
+  | Some _ ->
+    Error (Printf.sprintf "%s.%s must be a finite non-negative number" surface key)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface key)
+;;
+
+let required_string_list_json ~surface key fields =
+  match List.assoc_opt key fields with
+  | Some (`List values) ->
+    let rec loop acc = function
+      | [] -> Ok (`List (List.rev acc))
+      | `String value :: rest when String.trim value <> "" ->
+        loop (`String value :: acc) rest
+      | _ -> Error (Printf.sprintf "%s.%s must contain non-blank strings" surface key)
+    in
+    loop [] values
+  | Some _ -> Error (Printf.sprintf "%s.%s must be an array" surface key)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface key)
+;;
+
 let resolved_approval_json_of_audit_event json =
-  let resolved_at = Safe_ops.json_float_opt "ts" json in
-  `Assoc
-    [ "id", `String (Safe_ops.json_string ~default:"" "id" json)
-    ; "event", `String (Safe_ops.json_string ~default:"" "event" json)
-    ; "keeper_name", `String (Safe_ops.json_string ~default:"" "keeper" json)
-    ; "tool_name", `String (Safe_ops.json_string ~default:"" "tool" json)
-    ; "decision", Json_util.string_opt_to_json_trimmed (Safe_ops.json_string_opt "decision" json)
-    ; "decision_kind", Json_util.string_opt_to_json_trimmed
-        (Option.map decision_kind_to_string (resolved_approval_decision_kind json))
-    ; "decision_reason", json_member_or_null "decision_reason" json
-    ; "resolved_at", Json_util.float_opt_to_json resolved_at
-    ; "turn_id", json_member_or_null "turn_id" json
-    ; "task_id", json_member_or_null "task_id" json
-    ; "goal_id", json_member_or_null "goal_id" json
-    ; "goal_ids", json_member_or_null "goal_ids" json
-    ; "actor", json_member_or_null "actor" json
-    ; "decision_source", json_member_or_null "decision_source" json
-    ; "rule_match", json_member_or_null "rule_match" json
-      (* Judge evidence recorded at resolution time (#26126). Events written
-         before that enrichment have no such members and project as [`Null]. *)
-    ; "summary_status", json_member_or_null "summary_status" json
-    ; "exact_attempt", json_member_or_null "exact_attempt" json
-    ]
+  let ( let* ) = Result.bind in
+  let surface = "resolved_approval_audit" in
+  match json with
+  | `Assoc fields ->
+    let* () = Json_util.reject_unknown_fields ~surface ~allowed:resolved_audit_fields fields in
+    let* event = required_nonblank_string ~surface "event" fields in
+    let* () =
+      if String.equal event (event_to_string Resolved)
+      then Ok ()
+      else Error (Printf.sprintf "%s.event must be resolved" surface)
+    in
+    let* id = required_nonblank_string ~surface "id" fields in
+    let* keeper_name = required_nonblank_string ~surface "keeper" fields in
+    let* tool_name = required_nonblank_string ~surface "tool" fields in
+    let* decision = required_nonblank_string ~surface "decision" fields in
+    let* decision_kind_raw = required_nonblank_string ~surface "decision_kind" fields in
+    let* decision_kind =
+      match decision_kind_of_string decision_kind_raw with
+      | Some kind -> Ok kind
+      | None -> Error (Printf.sprintf "%s.decision_kind is invalid" surface)
+    in
+    let* decision_reason = required_nullable_string ~surface "decision_reason" fields in
+    let* () =
+      match decision_kind, decision_reason with
+      | Decision_approve, `Null -> Ok ()
+      | Decision_reject, `String _ -> Ok ()
+      | Decision_approve, `String _ ->
+        Error (Printf.sprintf "%s.approve decision cannot carry a reason" surface)
+      | Decision_reject, `Null ->
+        Error (Printf.sprintf "%s.reject decision requires a reason" surface)
+      | _, _ -> assert false
+    in
+    let* resolved_at = required_finite_timestamp ~surface "ts" fields in
+    let* turn_id = required_nullable_nonnegative_int ~surface "turn_id" fields in
+    let* task_id = required_nullable_string ~surface "task_id" fields in
+    let* goal_id = required_nullable_string ~surface "goal_id" fields in
+    let* goal_ids = required_string_list_json ~surface "goal_ids" fields in
+    let* actor = required_nonblank_string ~surface "actor" fields in
+    let* decision_source_raw = required_nonblank_string ~surface "decision_source" fields in
+    let* () =
+      match decision_source_of_string decision_source_raw with
+      | Some _ -> Ok ()
+      | None -> Error (Printf.sprintf "%s.decision_source is invalid" surface)
+    in
+    let* authorization_source = required_member ~surface "authorization_source" fields in
+    let* rule_match = required_member ~surface "rule_match" fields in
+    let* source_approval_id = required_member ~surface "source_approval_id" fields in
+    let* summary_status = required_member ~surface "summary_status" fields in
+    let* exact_attempt = required_member ~surface "exact_attempt" fields in
+    let* summary_attempt_disposition =
+      required_member ~surface "summary_attempt_disposition" fields
+    in
+    let* () =
+      match authorization_source, rule_match, source_approval_id, summary_attempt_disposition with
+      | `Null, `Null, `Null, `Null -> Ok ()
+      | _ -> Error (Printf.sprintf "%s contains fields outside the resolved contract" surface)
+    in
+    let* () = summary_status_of_yojson_with_error summary_status |> Result.map ignore in
+    let* () = exact_attempt_state_of_yojson_with_error exact_attempt |> Result.map ignore in
+    Ok
+      (`Assoc
+          [ "id", `String id
+          ; "event", `String event
+          ; "keeper_name", `String keeper_name
+          ; "tool_name", `String tool_name
+          ; "decision", `String decision
+          ; "decision_kind", `String (decision_kind_to_string decision_kind)
+          ; "decision_reason", decision_reason
+          ; "resolved_at", `Float resolved_at
+          ; "turn_id", turn_id
+          ; "task_id", task_id
+          ; "goal_id", goal_id
+          ; "goal_ids", goal_ids
+          ; "actor", `String actor
+          ; "decision_source", `String decision_source_raw
+          ; "summary_status", summary_status
+          ; "exact_attempt", exact_attempt
+          ])
+  | _ -> Error (Printf.sprintf "%s must be an object" surface)
 ;;
 
 (* Day key for the [YYYY-MM/DD.jsonl] layout. The reasoning this comment used
@@ -493,13 +590,24 @@ let resolved_history_empty ~limit ~window_minutes =
   }
 ;;
 
+let project_resolved_rows rows =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | row :: rest ->
+      (match resolved_approval_json_of_audit_event row with
+       | Ok projected -> loop (projected :: acc) rest
+       | Error detail -> Error { stage = List_recent_resolved; detail })
+  in
+  loop [] rows
+;;
+
 let list_recent_resolved
       ~base_path
       ~now_ts
       ?(limit = recent_resolved_history_limit)
       ?(window_minutes = recent_resolved_default_window_minutes)
       ()
-  : resolved_history
+  : (resolved_history, read_error) result
   =
   let limit = clamp_int limit ~low:0 ~high:recent_resolved_max_limit in
   let window_minutes =
@@ -510,24 +618,25 @@ let list_recent_resolved
   in
   let empty = resolved_history_empty ~limit ~window_minutes in
   if limit <= 0
-  then empty
+  then Ok empty
   else (
     match get_audit_store ~base_path () with
-    | None -> empty
-    | Some store ->
-      (try
-         let window_start =
-           now_ts -. (float_of_int window_minutes *. Masc_time_constants.minute)
-         in
-         let scan_rows = resolved_history_scan_rows limit in
-         (* Chronological, oldest first, tail-bounded to [scan_rows]. *)
-         let scanned =
-           Dated_jsonl.read_range_recent
-             store
-             ~since:(day_string_of_ts window_start)
-             ~until:(day_string_of_ts now_ts)
-             scan_rows
-         in
+    | Error detail -> Error { stage = List_recent_resolved; detail }
+    | Ok store ->
+      let window_start =
+        now_ts -. (float_of_int window_minutes *. Masc_time_constants.minute)
+      in
+      let scan_rows = resolved_history_scan_rows limit in
+      (match Dated_jsonl.read_recent_result store scan_rows with
+       | Error error ->
+         Error
+           { stage = List_recent_resolved
+           ; detail = Dated_jsonl.read_error_to_string error
+           }
+       | Ok entries ->
+         (match parsed_rows ~stage:List_recent_resolved entries with
+          | Error _ as error -> error
+          | Ok scanned ->
          let scanned_count = List.length scanned in
          (* The row cap only hides decisions when it stopped us before we
             reached back to the window start. If the oldest row we read is
@@ -564,31 +673,23 @@ let list_recent_resolved
            |> List.stable_sort (fun (left, _) (right, _) -> Float.compare right left)
            |> List.map snd
          in
-         let rows =
-           matched_rows
-           |> List.filteri (fun idx _ -> idx < limit)
-           |> List.map resolved_approval_json_of_audit_event
+         let selected_rows =
+           matched_rows |> List.filteri (fun idx _ -> idx < limit)
          in
-         { resolved_rows = rows
-         ; resolved_matched = List.length matched_rows
-         ; resolved_limit = limit
-         ; resolved_window_minutes = window_minutes
-         ; resolved_scan_exhausted = scan_exhausted
-         }
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-         record_audit_read_failure
-           ~metric_site:Keeper_approval_queue_failure_site.Audit_list_recent_resolved
-           ~site:"approval_audit.list_recent_resolved"
-           exn;
-         empty))
+         (match project_resolved_rows selected_rows with
+          | Error _ as error -> error
+          | Ok rows ->
+            Ok
+              { resolved_rows = rows
+              ; resolved_matched = List.length matched_rows
+              ; resolved_limit = limit
+              ; resolved_window_minutes = window_minutes
+              ; resolved_scan_exhausted = scan_exhausted
+              }))))
 ;;
 
 module For_testing = struct
   let reset_store () =
-    Stdlib.Mutex.protect audit_stores_mu (fun () -> Hashtbl.clear audit_stores);
-    Stdlib.Mutex.protect recent_audit_cache_mu (fun () ->
-      Hashtbl.clear recent_audit_cache)
+    Stdlib.Mutex.protect audit_stores_mu (fun () -> Hashtbl.clear audit_stores)
   ;;
 end

--- a/lib/keeper_approval/audit.ml
+++ b/lib/keeper_approval/audit.ml
@@ -514,21 +514,25 @@ let resolved_approval_json_of_audit_event json =
     in
     let* decision_reason = required_nullable_string ~surface "decision_reason" fields in
     let* () =
-      match decision_kind, decision_reason with
-      | Decision_approve, `Null -> Ok ()
-      | Decision_reject, `String _ -> Ok ()
-      | Decision_approve, `String _ ->
-        Error (Printf.sprintf "%s.approve decision cannot carry a reason" surface)
-      | Decision_reject, `Null ->
-        Error (Printf.sprintf "%s.reject decision requires a reason" surface)
-      | _, _ -> assert false
+      match decision_kind with
+      | Decision_approve ->
+        (match decision_reason with
+         | `Null -> Ok ()
+         | `String _ ->
+           Error (Printf.sprintf "%s.approve decision cannot carry a reason" surface)
+         | _ -> assert false)
+      | Decision_reject ->
+        (match decision_reason with
+         | `String _ -> Ok ()
+         | `Null -> Error (Printf.sprintf "%s.reject decision requires a reason" surface)
+         | _ -> assert false)
     in
     let* resolved_at = required_finite_timestamp ~surface "ts" fields in
     let* turn_id = required_nullable_nonnegative_int ~surface "turn_id" fields in
     let* task_id = required_nullable_string ~surface "task_id" fields in
     let* goal_id = required_nullable_string ~surface "goal_id" fields in
     let* goal_ids = required_string_list_json ~surface "goal_ids" fields in
-    let* actor = required_nonblank_string ~surface "actor" fields in
+    let* actor = required_nullable_string ~surface "actor" fields in
     let* decision_source_raw = required_nonblank_string ~surface "decision_source" fields in
     let* () =
       match decision_source_of_string decision_source_raw with
@@ -564,7 +568,7 @@ let resolved_approval_json_of_audit_event json =
           ; "task_id", task_id
           ; "goal_id", goal_id
           ; "goal_ids", goal_ids
-          ; "actor", `String actor
+          ; "actor", actor
           ; "decision_source", `String decision_source_raw
           ; "summary_status", summary_status
           ; "exact_attempt", exact_attempt

--- a/lib/keeper_approval/audit.mli
+++ b/lib/keeper_approval/audit.mli
@@ -1,5 +1,17 @@
 open Keeper_approval_queue_rules_types
 
+type read_stage =
+  | Read_recent
+  | List_recent_resolved
+
+type read_error =
+  { stage : read_stage
+  ; detail : string
+  }
+
+val read_stage_to_string : read_stage -> string
+val read_error_to_string : read_error -> string
+
 (** Typed approval audit events persisted under the workspace MASC root. *)
 type event =
   | Pending
@@ -60,7 +72,11 @@ val recent_resolved_min_window_minutes : int
 val recent_resolved_max_window_minutes : int
 
 val read_recent :
-  base_path:string -> ?keeper_name:string -> ?n:int -> unit -> Yojson.Safe.t list
+  base_path:string ->
+  ?keeper_name:string ->
+  ?n:int ->
+  unit ->
+  (Yojson.Safe.t list, read_error) result
 
 val day_string_of_ts : float -> string
 
@@ -78,7 +94,7 @@ val list_recent_resolved :
   ?limit:int ->
   ?window_minutes:int ->
   unit ->
-  resolved_history
+  (resolved_history, read_error) result
 
 module For_testing : sig
   val reset_store : unit -> unit

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -34,6 +34,11 @@ let aq_resolve ~base_path ~id ~decision =
 
 let yojson = Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal
 
+let resolved_history_exn = function
+  | Ok history -> history
+  | Error error -> Alcotest.fail (Keeper_approval.Audit.read_error_to_string error)
+;;
+
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_approval_queue_" "" in
   Unix.unlink dir;
@@ -3632,6 +3637,7 @@ let test_resolved_audit_event_carries_judge_evidence () =
            ~now_ts:(Unix.gettimeofday ())
            ~window_minutes:60
            ()
+         |> resolved_history_exn
        in
        let open Yojson.Safe.Util in
        let row =

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -6,6 +6,11 @@ module Rule_types = Keeper_approval_queue_rules_types
 module Gate = Masc.Keeper_gate
 module Gate_mode = Masc.Keeper_gate_mode
 
+let audit_rows_exn = function
+  | Ok rows -> rows
+  | Error error -> Alcotest.fail (Keeper_approval.Audit.read_error_to_string error)
+;;
+
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_approval_queue_rules_" "" in
   Unix.unlink dir;
@@ -648,6 +653,7 @@ let test_manual_mode_continues_when_rule_store_is_unavailable () =
   check bool "rule lookup degradation is metered" true (after -. before >= 1.0);
   let audited =
     Keeper_approval.Audit.read_recent ~base_path ~keeper_name:"keeper" ~n:20 ()
+    |> audit_rows_exn
     |> List.exists (fun json ->
       String.equal
         "gate_exact_rule_store_degraded"
@@ -735,6 +741,7 @@ let test_gate_defers_and_observes_expired_exact_rule () =
         ^ Gate.unavailable_reason_to_string reason));
   let audited =
     Keeper_approval.Audit.read_recent ~base_path ~keeper_name:"keeper" ~n:20 ()
+    |> audit_rows_exn
     |> List.exists (fun json ->
       String.equal
         "gate_exact_rule_expired"

--- a/test/test_keeper_approval_resolved_history.ml
+++ b/test/test_keeper_approval_resolved_history.ml
@@ -9,7 +9,17 @@
 
 open Alcotest
 
-module AQ = Keeper_approval.Audit
+module Audit = Keeper_approval.Audit
+
+module AQ = struct
+  include Audit
+
+  let list_recent_resolved ~base_path ~now_ts ?limit ?window_minutes () =
+    match Audit.list_recent_resolved ~base_path ~now_ts ?limit ?window_minutes () with
+    | Ok history -> history
+    | Error error -> failwith (Audit.read_error_to_string error)
+  ;;
+end
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_approval_resolved_history_" "" in
@@ -59,21 +69,37 @@ let append_row ~base_path ~ts (row : Yojson.Safe.t) =
     (fun () -> output_string oc (Yojson.Safe.to_string row ^ "\n"))
 ;;
 
-(* A resolved decision as the audit writer records it. [?ts_field:false] drops
-   the timestamp to exercise the undated-row boundary. *)
 let seed_resolved ~base_path ~ts ~id ?(keeper = "rondo") ?(tool = "tool_execute")
-      ?(decision = "approve") ?(source = "auto_judge") ?(ts_field = true) ()
+      ?(decision = "approve") ?(source = "auto_judge") ()
   =
+  let decision_kind, decision_reason =
+    if String.equal decision "approve"
+    then `String "approve", `Null
+    else `String "reject", `String "operator rejected"
+  in
   let fields =
-    [ "event", `String "resolved"
+    [ "ts", `Float ts
+    ; "event", `String "resolved"
     ; "id", `String id
     ; "keeper", `String keeper
     ; "tool", `String tool
     ; "decision", `String decision
+    ; "turn_id", `Null
+    ; "task_id", `Null
+    ; "goal_id", `Null
+    ; "goal_ids", `List []
+    ; "actor", `String "operator"
     ; "decision_source", `String source
+    ; "authorization_source", `Null
+    ; "rule_match", `Null
+    ; "source_approval_id", `Null
+    ; "decision_kind", decision_kind
+    ; "decision_reason", decision_reason
+    ; "summary_status", `String "not_requested"
+    ; "exact_attempt", `Assoc [ "state", `String "unbound" ]
+    ; "summary_attempt_disposition", `Null
     ]
   in
-  let fields = if ts_field then ("ts", `Float ts) :: fields else fields in
   append_row ~base_path ~ts (`Assoc fields)
 ;;
 
@@ -207,14 +233,34 @@ let test_limit_zero_returns_empty_page base_path =
   check bool "scan not claimed exhausted" false history.resolved_scan_exhausted
 ;;
 
-(* An undated decision cannot be placed in a wall-clock window. It is excluded
-   rather than dated by guesswork, and it must not inflate [matched] either. *)
-let test_undated_decision_is_excluded base_path =
-  seed_resolved ~base_path ~ts:(now -. minutes 5) ~id:"dated" ();
-  seed_resolved ~base_path ~ts:(now -. minutes 5) ~id:"undated" ~ts_field:false ();
-  let history = AQ.list_recent_resolved ~base_path ~now_ts:now ~window_minutes:1440 () in
-  check (list string) "only the dated decision" [ "dated" ] (ids history);
-  check int "matched excludes the undated row" 1 history.resolved_matched
+let test_resolved_row_missing_current_field_is_rejected base_path =
+  let row =
+    `Assoc
+      [ "ts", `Float (now -. minutes 5)
+      ; "event", `String "resolved"
+      ; "id", `String "missing-actor"
+      ]
+  in
+  append_row ~base_path ~ts:(now -. minutes 5) row;
+  match Audit.list_recent_resolved ~base_path ~now_ts:now () with
+  | Error { stage = List_recent_resolved; detail } ->
+    check bool "missing current field is named" true (String.length detail > 0)
+  | Error _ -> fail "wrong audit read stage"
+  | Ok _ -> fail "incomplete resolved row was accepted"
+;;
+
+let test_malformed_jsonl_is_unavailable base_path =
+  let path = audit_day_file ~base_path (now -. minutes 5) in
+  Out_channel.with_open_gen
+    [ Open_append; Open_creat; Open_wronly ]
+    0o644
+    path
+    (fun channel -> output_string channel "{not-json\n");
+  match Audit.list_recent_resolved ~base_path ~now_ts:now () with
+  | Error { stage = List_recent_resolved; detail } ->
+    check bool "physical parse failure is named" true (String.length detail > 0)
+  | Error _ -> fail "wrong audit read stage"
+  | Ok _ -> fail "malformed audit JSONL was reported as ready"
 ;;
 
 let test_empty_store_is_an_empty_page base_path =
@@ -226,9 +272,6 @@ let test_empty_store_is_an_empty_page base_path =
   check bool "scan not exhausted" false history.resolved_scan_exhausted
 ;;
 
-(* #26126: judge evidence recorded on the resolved audit event at resolution
-   time must survive projection verbatim; events written before the enrichment
-   project the members as [`Null] rather than being dropped or invented. *)
 let yojson = testable Yojson.Safe.pretty_print Yojson.Safe.equal
 
 let test_judge_evidence_passes_through base_path =
@@ -246,11 +289,21 @@ let test_judge_evidence_passes_through base_path =
         ; "keeper", `String "rondo"
         ; "tool", `String "tool_execute"
         ; "decision", `String "approve"
+        ; "turn_id", `Null
+        ; "task_id", `Null
+        ; "goal_id", `Null
+        ; "goal_ids", `List []
+        ; "actor", `String "operator"
         ; "decision_source", `String "auto_judge"
+        ; "authorization_source", `Null
+        ; "rule_match", `Null
+        ; "source_approval_id", `Null
+        ; "decision_kind", `String "approve"
+        ; "decision_reason", `Null
         ; "summary_status", summary_status
         ; "exact_attempt", exact_attempt
+        ; "summary_attempt_disposition", `Null
         ]);
-  seed_resolved ~base_path ~ts:(now -. minutes 10) ~id:"legacy" ();
   let history = AQ.list_recent_resolved ~base_path ~now_ts:now ~window_minutes:60 () in
   let member name row =
     match row with
@@ -269,9 +322,7 @@ let test_judge_evidence_passes_through base_path =
     yojson
     "exact_attempt passes through"
     exact_attempt
-    (member "exact_attempt" (find "with-judge"));
-  check yojson "legacy summary_status is null" `Null (member "summary_status" (find "legacy"));
-  check yojson "legacy exact_attempt is null" `Null (member "exact_attempt" (find "legacy"))
+    (member "exact_attempt" (find "with-judge"))
 ;;
 
 let test_bounds_are_clamped base_path =
@@ -307,13 +358,15 @@ let () =
             (with_store test_bounds_are_clamped)
         ] )
     ; ( "boundaries"
-      , [ test_case "undated decision is excluded" `Quick
-            (with_store test_undated_decision_is_excluded)
+      , [ test_case "missing current resolved field is rejected" `Quick
+            (with_store test_resolved_row_missing_current_field_is_rejected)
+        ; test_case "malformed JSONL is unavailable" `Quick
+            (with_store test_malformed_jsonl_is_unavailable)
         ; test_case "empty store is an empty page" `Quick
             (with_store test_empty_store_is_an_empty_page)
         ] )
     ; ( "judge evidence"
-      , [ test_case "judge evidence passes through, legacy rows project null" `Quick
+      , [ test_case "judge evidence passes through" `Quick
             (with_store test_judge_evidence_passes_through)
         ] )
     ]


### PR DESCRIPTION
## Summary

- make approval audit reads return typed storage errors instead of empty history
- publish exact ready or unavailable history state through Gate and Keeper snapshots
- reject malformed current resolved rows as protocol drift
- accept explicit null actor from the current writer and render it visibly as unattributed
- keep rule-store availability, rule provenance, expiry, and delete actions exact at the same Dashboard boundary

## Verification at 895e1912ed

- focused OCaml build passed for resolved history, approval queue, and approval rules
- test_keeper_approval_resolved_history: 11 passed
- test_keeper_approval_queue: 38 passed
- test_keeper_approval_queue_rules: 17 passed
- Dashboard TypeScript typecheck passed
- focused Dashboard Vitest: 162 passed
- ocamlformat and git diff check passed

## Stack

Base: #27758. This PR remains Draft and do-not-merge until exact-head CI is authoritative.

## Remaining separate tranche

Resolution audit append still returns unit and can be lost after the durable approval transition. This PR makes the read and consumer boundary truthful; it does not claim to close that write-side durability gap.