### PR TITLE
feat(runtime): probe official subscription login

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -58,6 +58,7 @@
  (package masc)
  (libraries
   masc
+  masc.runtime
   masc.crypto_rng
   masc.server
   masc.config

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1186,7 +1186,7 @@ let setup_gc () =
 
 let cmd =
   let doc = "MASC MCP Server and operator diagnostics" in
-  let info = Cmd.info "masc" ~version:Masc.Version.version ~doc in
+  let info = Cmd.info "masc" ~version:Version.version ~doc in
   Cmd.group ~default:Term.(const run_cmd_exit $ host $ port $ run_base_path)
     info
     [ init_cmd

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1186,7 +1186,7 @@ let setup_gc () =
 
 let cmd =
   let doc = "MASC MCP Server and operator diagnostics" in
-  let info = Cmd.info "masc" ~version:Version.version ~doc in
+  let info = Cmd.info "masc" ~version:Runtime_build_version.current ~doc in
   Cmd.group ~default:Term.(const run_cmd_exit $ host $ port $ run_base_path)
     info
     [ init_cmd

--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -151,7 +151,7 @@ let run_cmd cli_base_path =
 
 let cmd =
   let doc = "MASC MCP Server (stdio, Eio)" in
-  let info = Cmd.info "masc-stdio" ~version:Masc.Version.version ~doc in
+  let info = Cmd.info "masc-stdio" ~version:Version.version ~doc in
   Cmd.v info Term.(const run_cmd $ base_path)
 
 let () = exit (Cmd.eval cmd)

--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -151,7 +151,7 @@ let run_cmd cli_base_path =
 
 let cmd =
   let doc = "MASC MCP Server (stdio, Eio)" in
-  let info = Cmd.info "masc-stdio" ~version:Version.version ~doc in
+  let info = Cmd.info "masc-stdio" ~version:Runtime_build_version.current ~doc in
   Cmd.v info Term.(const run_cmd $ base_path)
 
 let () = exit (Cmd.eval cmd)

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -319,8 +319,8 @@ let repo_head_commit_unix_ts = probe_commit_unix_ts commit_resolution.repo_head_
 
 let current () =
   let now = Unix.gettimeofday () in
-  { release_version = Version.version
-  ; binary_version = Version.version
+  { release_version = Runtime_build_version.current
+  ; binary_version = Runtime_build_version.current
   ; repo_version
   ; commit = commit_resolution.commit
   ; commit_source = commit_resolution.commit_source

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -4,11 +4,7 @@
  (name masc_core)
  (public_name masc.masc_core)
  (wrapped false)
- ; RFC-0071 §3.4 Phase 5 bootstrap: warning 4 (fragile pattern match) on. + unused-value ratchet (warning 32)
- ; All 13 catch-all sites in this sublib match Yojson.Safe.t (poly variant),
- ; which warning 4 ignores by design — so flipping +4 here is a no-op for
- ; existing code but locks in the type-level guarantee for any future closed
- ; concrete variant. Smallest justifiable scope to prove Phase 5 end-to-end.
+ ; Closed variants must remain exhaustive; unused declarations are build errors.
  (flags
   (:standard -w +4 -w +33 -w +37))
  (modules

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -71,7 +71,7 @@ let workspace_status_json (config : Workspace.config) : Yojson.Safe.t =
     ; "project", `String project
     ; "tempo_interval_s", `Float tempo.current_interval_s
     ; "paused", `Bool paused
-    ; "version", `String Version.version
+    ; "version", `String Runtime_build_version.current
     ]
 ;;
 

--- a/lib/dashboard/dashboard_execution_fixture.ml
+++ b/lib/dashboard/dashboard_execution_fixture.ml
@@ -35,7 +35,7 @@ let execution_smoke_fixture_json () =
             ("project", `String "execution-smoke");
             ("tempo_interval_s", `Float 300.0);
             ("paused", `Bool false);
-            ("version", `String Version.version);
+            ("version", `String Runtime_build_version.current);
           ] );
       ( "execution_queue",
         `List

--- a/lib/env_config_introspect.ml
+++ b/lib/env_config_introspect.ml
@@ -15,7 +15,7 @@ let server_meta () =
   in
   `Assoc
     [
-      ("version", `String Version.version);
+      ("version", `String Runtime_build_version.current);
       ("git_commit", Json_util.string_opt_to_json git_commit);
       ("ocaml_version", `String Sys.ocaml_version);
       ("uptime_seconds", `Float (Server_startup_state.elapsed_since_start ()));

--- a/lib/env_config_introspect.mli
+++ b/lib/env_config_introspect.mli
@@ -5,7 +5,7 @@
     attribution live in [Env_config_snapshot] inside the
     [masc_config] sub-library. This wrapper adds root-runtime
     metadata that is only available from the main server library
-    ([Version.version], [Server_startup_state.elapsed_since_start],
+    ([Runtime_build_version.current], [Server_startup_state.elapsed_since_start],
     [Sys.ocaml_version], the live PID, and [MASC_BUILD_GIT_COMMIT]).
 
     Internal helper [server_meta] is hidden — callers consume only

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -268,6 +268,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       match
         Runtime_claude_code.probe_subscription
           ~mgr:process_mgr
+          ~clock
           ~cwd:process_cwd
           client_config
       with

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -91,7 +91,7 @@ let server_info =
     [
       ("name", `String "masc");
       ("title", `String "MASC MCP Server");
-      ("version", `String Version.version);
+      ("version", `String Runtime_build_version.current);
       ( "description",
         `String
           "Multi-agent MCP server exposing MASC workspace state, tools, prompts, and resources." );

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -237,7 +237,7 @@ let handle_initialize_eio ?(profile = Full) id params =
              ; ( "_meta"
                , `Assoc
                    [ "serverStartedAt", `String (Masc_domain.now_iso ())
-                   ; "serverVersion", `String Version.version
+                   ; "serverVersion", `String Runtime_build_version.current
                    ; ( "profile"
                      , `String
                          (match profile with

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -1043,9 +1043,14 @@ let validate_turn ?(dynamic_tools = []) ?(session_mode = Start) config ~prompt =
   validate_dynamic_tools dynamic_tools
 ;;
 
-let probe_subscription ~mgr ~cwd config =
+let probe_subscription ~mgr ~clock ~cwd config =
   let* () = validate_process_config config in
-  read_subscription ~mgr ~cwd config
+  try
+    Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+      read_subscription ~mgr ~cwd config)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
 ;;
 
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
@@ -1060,7 +1065,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
     let* subscription =
       match admitted_subscription with
       | Some subscription -> Ok subscription
-      | None -> probe_subscription ~mgr ~cwd config
+      | None -> probe_subscription ~mgr ~clock ~cwd config
     in
     let session_id =
       match session_mode with

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -96,6 +96,7 @@ val validate_turn :
 
 val probe_subscription :
   mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   config ->
   (subscription, error) result

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -9,6 +9,11 @@ type subscription =
   ; email : string option
   }
 
+type probe_result =
+  { subscription : subscription
+  ; user_agent : string option
+  }
+
 type config =
   { cli_path : string
   ; model : string option
@@ -386,6 +391,34 @@ let parse_subscription result =
       let* email = optional_string stage "email" account_fields in
       Ok { plan_type; email }
   | _ -> protocol_error stage "account must be an object or null"
+;;
+
+let probe_protocol io =
+  send_request
+    io
+    ~id:1
+    ~method_:"initialize"
+    ~params:
+      (`Assoc
+         [ ( "clientInfo"
+           , `Assoc
+               [ "name", `String "masc"
+               ; "title", `String "MASC"
+               ; "version", `String Version.version
+               ] )
+         ; "capabilities", `Assoc [ "experimentalApi", `Bool true ]
+         ]);
+  let* initialize = await_response io ~id:1 ~method_:"initialize" in
+  let* user_agent = parse_initialize initialize in
+  send_notification io "initialized";
+  send_request
+    io
+    ~id:2
+    ~method_:"account/read"
+    ~params:(`Assoc [ "refreshToken", `Bool false ]);
+  let* account = await_response io ~id:2 ~method_:"account/read" in
+  let* subscription = parse_subscription account in
+  Ok { subscription; user_agent }
 ;;
 
 let parse_thread_response ~stage result =
@@ -860,8 +893,7 @@ let terminate_spawned_process ~clock proc stdin_w =
           (Printexc.to_string exn))
 ;;
 
-let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools ~reasoning_effort
-    ~thread_mode ~history ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_started =
+let with_spawned_client ~mgr ~clock ~cwd config run =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -898,18 +930,25 @@ let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools ~reasoning_
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
         Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
-          run_protocol
-            { send; receive }
-            config
-            ~protocol_cwd
-            ~dynamic_tools
-            ~reasoning_effort
-            ~thread_mode
-            ~history
-            ~prompt
-            ~on_thread_ready
-            ~on_turn_starting
-            ~on_turn_started)))
+          run { send; receive })))
+;;
+
+let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
+    ~reasoning_effort ~thread_mode ~history ~prompt ~on_thread_ready
+    ~on_turn_starting ~on_turn_started =
+  with_spawned_client ~mgr ~clock ~cwd config (fun io ->
+    run_protocol
+      io
+      config
+      ~protocol_cwd
+      ~dynamic_tools
+      ~reasoning_effort
+      ~thread_mode
+      ~history
+      ~prompt
+      ~on_thread_ready
+      ~on_turn_starting
+      ~on_turn_started)
 ;;
 
 let native_cwd cwd =
@@ -925,12 +964,17 @@ let native_cwd cwd =
          ("cwd must be a native filesystem path: " ^ Printexc.to_string exn))
 ;;
 
-let validate_config config ~cwd ~thread_mode ~prompt =
+let validate_process_config config =
   if String.trim config.cli_path = ""
   then Error (Invalid_config "cli_path must not be empty")
   else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
   then Error (Invalid_config "timeout_s must be positive and finite")
-  else if String.trim prompt = ""
+  else Ok ()
+;;
+
+let validate_config config ~cwd ~thread_mode ~prompt =
+  let* () = validate_process_config config in
+  if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
   else
     let* cwd = native_cwd cwd in
@@ -966,6 +1010,24 @@ let validate_turn_input ~dynamic_tools ~thread_mode ~cwd config ~prompt =
 let validate_turn ?(dynamic_tools = []) ?(thread_mode = Start) ~cwd config ~prompt =
   validate_turn_input ~dynamic_tools ~thread_mode ~cwd config ~prompt
   |> Result.map (fun _ -> ())
+;;
+
+let probe_subscription ~mgr ~clock ~cwd config =
+  let result =
+    let* () = validate_process_config config in
+    let* _ = native_cwd cwd in
+    try with_spawned_client ~mgr ~clock ~cwd config probe_protocol with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+    | exn -> Error (Spawn_failed (Printexc.to_string exn))
+  in
+  (match result with
+   | Ok _ -> Log.Runtime_agent.info "Codex app-server subscription probe completed"
+   | Error error ->
+     Log.Runtime_agent.warn
+       "Codex app-server subscription probe failed (kind=%s)"
+       (error_kind error));
+  result
 ;;
 
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr ~clock ~cwd

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -404,7 +404,7 @@ let probe_protocol io =
            , `Assoc
                [ "name", `String "masc"
                ; "title", `String "MASC"
-               ; "version", `String Version.version
+               ; "version", `String Runtime_build_version.current
                ] )
          ; "capabilities", `Assoc [ "experimentalApi", `Bool true ]
          ]);

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -9,6 +9,11 @@ type subscription =
   ; email : string option
   }
 
+type probe_result =
+  { subscription : subscription
+  ; user_agent : string option
+  }
+
 type config =
   { cli_path : string
   ; model : string option
@@ -86,6 +91,15 @@ val validate_turn :
 (** Validate every deterministic client-side admission condition. Keeper calls
     this before it durably claims a session; [run_turn] repeats the same check
     at the process boundary. *)
+
+val probe_subscription :
+  mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  cwd:Eio.Fs.dir_ty Eio.Path.t ->
+  config ->
+  (probe_result, error) result
+(** Start the official app-server and measure only [initialize] plus
+    [account/read]. No thread or model turn is created. *)
 
 val run_turn :
   ?dynamic_tools:dynamic_tool list ->

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -629,7 +629,7 @@ module Rest = struct
           `Assoc
             [
               ("title", `String "MASC Agent Control Contract");
-              ("version", `String Version.version);
+              ("version", `String Runtime_build_version.current);
               ( "description",
                 `String
                   "Internal OAS export for MASC MCP agent control. Use x-mcp-operations for canonical MCP operation metadata and x-agent-sdk-tools for the current SDK-facing projections." );

--- a/lib/version.ml
+++ b/lib/version.ml
@@ -1,3 +1,0 @@
-(** Version auto-synced from dune-project via the runtime build owner. *)
-
-let version = Runtime_build_version.current

--- a/lib/version.mli
+++ b/lib/version.mli
@@ -1,5 +1,0 @@
-(** Version — auto-synced from dune-project via dune-build-info.
-
-    @since 0.1.0 *)
-
-val version : string

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -627,7 +627,7 @@ let test_shared_mcp_protocol_is_negotiated () =
        |> to_string);
     check string
       "MCP server version uses the canonical build owner"
-      Version.version
+      Runtime_build_version.current
       (dispatch.response
        |> Option.get
        |> member "result"

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -184,6 +184,7 @@ let test_missing_cli_is_not_reported_as_logout () =
       in
       Runtime_claude_code.probe_subscription
         ~mgr:(Eio.Stdenv.process_mgr env)
+        ~clock:(Eio.Stdenv.clock env)
         ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
         config)
   in

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -53,17 +53,23 @@ let rec drop count values =
 let fixture_script ?capture_path lines =
   let path = Filename.temp_file "masc-codex-app-server-" ".sh" in
   let output = open_out_bin path in
-  let read_request () =
-    output_string output "IFS= read -r ignored\n";
+  let read_request ?(expect_version = false) () =
+    output_string output "IFS= read -r request\n";
+    if expect_version
+    then
+      output_string output
+        (Printf.sprintf
+           "printf '%%s' \"$request\" | grep -F %s >/dev/null || exit 97\n"
+           (shell_quote (Printf.sprintf {|"version":"%s"|} Version.version)));
     Option.iter
       (fun capture_path ->
          output_string
            output
-           ("printf '%s\\n' \"$ignored\" >> " ^ shell_quote capture_path ^ "\n"))
+           ("printf '%s\\n' \"$request\" >> " ^ shell_quote capture_path ^ "\n"))
       capture_path
   in
   output_string output "#!/bin/sh\n";
-  read_request ();
+  read_request ~expect_version:true ();
   output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 0) ^ "\n");
   read_request ();
   read_request ();

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -60,7 +60,7 @@ let fixture_script ?capture_path lines =
       output_string output
         (Printf.sprintf
            "printf '%%s' \"$request\" | grep -F %s >/dev/null || exit 97\n"
-           (shell_quote (Printf.sprintf {|"version":"%s"|} Version.version)));
+           (shell_quote (Printf.sprintf {|"version":"%s"|} Runtime_build_version.current)));
     Option.iter
       (fun capture_path ->
          output_string
@@ -613,7 +613,7 @@ let test_protocol_uses_spawn_cwd_and_named_permissions () =
        let params = Yojson.Safe.Util.member "params" thread_start in
        check string
          "client version SSOT"
-         Version.version
+         Runtime_build_version.current
          (client_info |> Yojson.Safe.Util.member "version" |> Yojson.Safe.Util.to_string);
        check string
          "protocol cwd"

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -221,7 +221,7 @@ let test_subscription_probe_stops_before_thread () =
       let outcome =
         Eio_main.run (fun env ->
           let config =
-            { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+            { (Runtime_codex_app_server.default_config ()) with
               cli_path = path
             ; timeout_s = 2.0
             }

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -202,6 +202,37 @@ let test_chatgpt_subscription_turn () =
         check bool "new thread" false result.resumed)
 ;;
 
+let test_subscription_probe_stops_before_thread () =
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun path ->
+      let outcome =
+        Eio_main.run (fun env ->
+          let config =
+            { (Runtime_codex_app_server.default_config ~cwd:"/tmp") with
+              cli_path = path
+            ; timeout_s = 2.0
+            }
+          in
+          Runtime_codex_app_server.probe_subscription
+            ~mgr:(Eio.Stdenv.process_mgr env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+            config)
+      in
+      match outcome with
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok probe ->
+        check string "plan" "pro" probe.subscription.plan_type;
+        check (option string) "user agent" (Some "fixture/0.147.0") probe.user_agent)
+;;
+
 let test_thread_resume_skips_history_injection () =
   let history =
     [ { Runtime_codex_app_server.role = User; text = "already in official thread" } ]
@@ -1881,6 +1912,10 @@ let () =
   run "runtime codex app-server"
     [ ( "subscription boundary"
       , [ test_case "ChatGPT turn completes" `Quick test_chatgpt_subscription_turn
+        ; test_case
+            "probe stops before thread"
+            `Quick
+            test_subscription_probe_stops_before_thread
         ; test_case "declared cwd reaches spawn" `Quick test_declared_cwd_reaches_spawn
         ; test_case
             "protocol and spawn share cwd authority"

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -632,7 +632,7 @@ let test_rest_generate_openapi_document () =
   let open Yojson.Safe.Util in
   let doc = Transport.Rest.generate_openapi_document () in
   check string "openapi version" "3.1.0" (doc |> member "openapi" |> to_string);
-  check string "info.version matches repo version" Version.version
+  check string "info.version matches repo version" Runtime_build_version.current
     (doc |> member "info" |> member "version" |> to_string);
   check string "bearer security scheme type" "http"
     (doc |> member "components" |> member "securitySchemes"

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -632,7 +632,7 @@ let test_rest_generate_openapi_document () =
   let open Yojson.Safe.Util in
   let doc = Transport.Rest.generate_openapi_document () in
   check string "openapi version" "3.1.0" (doc |> member "openapi" |> to_string);
-  check string "info.version matches repo version" Masc.Version.version
+  check string "info.version matches repo version" Version.version
     (doc |> member "info" |> member "version" |> to_string);
   check string "bearer security scheme type" "http"
     (doc |> member "components" |> member "securitySchemes"


### PR DESCRIPTION
## Summary
- probe Codex App Server subscription state through initialize and account/read without creating a thread or model turn
- bound Claude Code auth status with the configured timeout
- use the same native cwd, process environment, and typed error boundary as official-client execution

## Contract
- subscription login evidence is distinct from model execution evidence
- initialize reports Version.version from the repository SSOT
- API-key transports and ambient credential fallbacks are not admitted
- cancellation propagates and timeout remains typed

## Verification
- OCaml format, parse, and diff checks pass at this head
- initialize fixtures require the exact Version.version wire value
- required CI now executes the Codex, Claude, Claude config, Keeper Claude runtime, and official-client session-store suites
- CI target audit: 158 declared targets, 701 unwired at the exact baseline
- focused local Dune execution is pending because the repository guard detected unrelated bare Dune processes; current GitHub CI is authoritative
