### PR TITLE
feat(dashboard): expose official-client login evidence

### DIFF
--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -88,11 +88,10 @@ let claude_failure_status = function
   | Turn_failed _ | Quota_blocked _ -> "probe_contract_error"
 ;;
 
-let probe_codex ~mgr ~clock ~cwd ~process_cwd ~runtime_id ~model
+let probe_codex ~mgr ~clock ~process_cwd ~runtime_id ~model
     (config : Runtime_execution.codex_app_server) =
   let probe_config : Runtime_codex_app_server.config =
     { cli_path = config.cli_path
-    ; cwd
     ; model = config.model
     ; developer_instructions = None
     ; timeout_s = Float.min max_probe_timeout_s config.timeout_s
@@ -205,7 +204,6 @@ let probe_body ~base_path ~body =
       (probe_codex
          ~mgr
          ~clock
-         ~cwd:base_path
          ~process_cwd
          ~runtime_id
          ~model

--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -63,6 +63,8 @@ let failed_login_json ~status ~detail =
   `Assoc
     [ "status", `String status
     ; "authenticated", `Bool false
+    ; "evidence_source", `String "configured_executable_self_report"
+    ; "identity_verified", `Bool false
     ; "detail", `String detail
     ]
 ;;
@@ -113,6 +115,8 @@ let probe_codex ~mgr ~clock ~process_cwd ~runtime_id ~model
         (`Assoc
            [ "status", `String "ready"
            ; "authenticated", `Bool true
+           ; "evidence_source", `String "configured_executable_self_report"
+           ; "identity_verified", `Bool false
            ; "auth_method", `String "chatgpt"
            ; "subscription_type", `String measured.subscription.plan_type
            ; "api_provider", `Null
@@ -158,6 +162,8 @@ let probe_claude ~mgr ~clock ~cwd ~process_cwd ~runtime_id ~model
         (`Assoc
            [ "status", `String "ready"
            ; "authenticated", `Bool true
+           ; "evidence_source", `String "configured_executable_self_report"
+           ; "identity_verified", `Bool false
            ; "auth_method", `String measured.auth_method
            ; "subscription_type", `String measured.subscription_type
            ; "api_provider", `String measured.api_provider

--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -87,7 +87,8 @@ let claude_failure_status = function
   | Subscription_required _ -> "login_required"
   | Timeout _ -> "timeout"
   | Protocol_error _ | Unsupported_control_request _ -> "protocol_error"
-  | Turn_failed _ | Quota_blocked _ -> "probe_contract_error"
+  | Turn_transport_interrupted _ | Turn_failed _ | Quota_blocked _ ->
+    "probe_contract_error"
 ;;
 
 let probe_codex ~mgr ~clock ~process_cwd ~runtime_id ~model
@@ -224,6 +225,13 @@ let probe_body ~base_path ~body =
          ~runtime_id
          ~model
          config)
+  | Runtime_execution.Antigravity_cli _ ->
+    error
+      Bad_request
+      "login_probe_unsupported"
+      (Printf.sprintf
+         "official-client runtime %S does not expose a login probe"
+         runtime_id)
   | Runtime_execution.Agent_core _ ->
     error
       Bad_request

--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -1,0 +1,228 @@
+type error_kind =
+  | Bad_request
+  | Not_found
+  | Service_unavailable
+
+type error =
+  { kind : error_kind
+  ; code : string
+  ; message : string
+  }
+
+let ( let* ) = Result.bind
+let schema = "masc.dashboard.official-client-probe.v1"
+let max_probe_timeout_s = 10.0
+
+let error kind code message = Error { kind; code; message }
+
+let non_empty field value =
+  let value = String.trim value in
+  if value = ""
+  then error Bad_request (field ^ "_required") (field ^ " is required")
+  else Ok value
+;;
+
+let parse_body body =
+  let* json =
+    try Ok (Yojson.Safe.from_string body) with
+    | Yojson.Json_error message ->
+      error Bad_request "invalid_json" ("invalid JSON: " ^ message)
+  in
+  match json with
+  | `Assoc [ "runtime_id", `String runtime_id ] -> non_empty "runtime_id" runtime_id
+  | `Assoc _ ->
+    error
+      Bad_request
+      "request_fields_invalid"
+      "expected the exact runtime_id field"
+  | _ -> error Bad_request "request_not_object" "request body must be a JSON object"
+;;
+
+let execution_not_measured_json =
+  `Assoc
+    [ "status", `String "not_measured"
+    ; "reason", `String "login_probe_does_not_submit_model_turn"
+    ]
+;;
+
+let response_json ~runtime_id ~client_kind ~model ~login ~client =
+  `Assoc
+    [ "schema", `String schema
+    ; "ok", `Bool true
+    ; "runtime_id", `String runtime_id
+    ; "client_kind", `String client_kind
+    ; "configured_model", Json_util.string_opt_to_json model
+    ; "measured_at", `Float (Time_compat.now ())
+    ; "login", login
+    ; "client", client
+    ; "execution", execution_not_measured_json
+    ]
+;;
+
+let failed_login_json ~status ~detail =
+  `Assoc
+    [ "status", `String status
+    ; "authenticated", `Bool false
+    ; "detail", `String detail
+    ]
+;;
+
+let empty_client_json = `Assoc [ "user_agent", `Null ]
+
+let codex_failure_status = function
+  | Runtime_codex_app_server.Invalid_config _ -> "invalid_config"
+  | Spawn_failed _ | Process_exited _ -> "cli_unavailable"
+  | Subscription_required _ -> "login_required"
+  | Timeout _ -> "timeout"
+  | Protocol_error _ | Rpc_error _ | Unsupported_server_request _ ->
+    "protocol_error"
+  | Turn_failed _ | Turn_interrupted -> "probe_contract_error"
+;;
+
+let claude_failure_status = function
+  | Runtime_claude_code.Invalid_config _ -> "invalid_config"
+  | Spawn_failed _ | Process_exited _ -> "cli_unavailable"
+  | Subscription_required _ -> "login_required"
+  | Timeout _ -> "timeout"
+  | Protocol_error _ | Unsupported_control_request _ -> "protocol_error"
+  | Turn_failed _ | Quota_blocked _ -> "probe_contract_error"
+;;
+
+let probe_codex ~mgr ~clock ~cwd ~process_cwd ~runtime_id ~model
+    (config : Runtime_execution.codex_app_server) =
+  let probe_config : Runtime_codex_app_server.config =
+    { cli_path = config.cli_path
+    ; cwd
+    ; model = config.model
+    ; developer_instructions = None
+    ; timeout_s = Float.min max_probe_timeout_s config.timeout_s
+    }
+  in
+  match
+    Runtime_codex_app_server.probe_subscription
+      ~mgr
+      ~clock
+      ~cwd:process_cwd
+      probe_config
+  with
+  | Ok measured ->
+    response_json
+      ~runtime_id
+      ~client_kind:"codex"
+      ~model
+      ~login:
+        (`Assoc
+           [ "status", `String "ready"
+           ; "authenticated", `Bool true
+           ; "auth_method", `String "chatgpt"
+           ; "subscription_type", `String measured.subscription.plan_type
+           ; "api_provider", `Null
+           ])
+      ~client:
+        (`Assoc
+           [ "user_agent", Json_util.string_opt_to_json measured.user_agent ])
+  | Error probe_error ->
+    response_json
+      ~runtime_id
+      ~client_kind:"codex"
+      ~model
+      ~login:
+        (failed_login_json
+           ~status:(codex_failure_status probe_error)
+           ~detail:(Runtime_codex_app_server.error_to_string probe_error))
+      ~client:empty_client_json
+;;
+
+let probe_claude ~mgr ~clock ~cwd ~process_cwd ~runtime_id ~model
+    (config : Runtime_execution.claude_code) =
+  let probe_config : Runtime_claude_code.config =
+    { cli_path = config.cli_path
+    ; cwd
+    ; model = config.model
+    ; system_prompt = None
+    ; timeout_s = Float.min max_probe_timeout_s config.timeout_s
+    }
+  in
+  match
+    Runtime_claude_code.probe_subscription
+      ~mgr
+      ~clock
+      ~cwd:process_cwd
+      probe_config
+  with
+  | Ok measured ->
+    response_json
+      ~runtime_id
+      ~client_kind:"claude_code"
+      ~model
+      ~login:
+        (`Assoc
+           [ "status", `String "ready"
+           ; "authenticated", `Bool true
+           ; "auth_method", `String measured.auth_method
+           ; "subscription_type", `String measured.subscription_type
+           ; "api_provider", `String measured.api_provider
+           ])
+      ~client:empty_client_json
+  | Error probe_error ->
+    response_json
+      ~runtime_id
+      ~client_kind:"claude_code"
+      ~model
+      ~login:
+        (failed_login_json
+           ~status:(claude_failure_status probe_error)
+           ~detail:(Runtime_claude_code.error_to_string probe_error))
+      ~client:empty_client_json
+;;
+
+let probe_body ~base_path ~body =
+  let* runtime_id = parse_body body in
+  let* runtime =
+    match Runtime.get_runtime_by_id runtime_id with
+    | Some runtime -> Ok runtime
+    | None ->
+      error
+        Not_found
+        "runtime_not_found"
+        (Printf.sprintf "runtime %S is not configured" runtime_id)
+  in
+  let* env, clock =
+    match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
+    | Some env, Some clock -> Ok (env, clock)
+    | None, _ | _, None ->
+      error
+        Service_unavailable
+        "eio_context_unavailable"
+        "official-client probe requires the initialized Eio runtime"
+  in
+  let mgr = Eio.Stdenv.process_mgr env in
+  let process_cwd = Eio.Path.(Eio.Stdenv.fs env / base_path) in
+  let model = Runtime_execution.model_id runtime.execution in
+  match runtime.execution with
+  | Runtime_execution.Codex_app_server config ->
+    Ok
+      (probe_codex
+         ~mgr
+         ~clock
+         ~cwd:base_path
+         ~process_cwd
+         ~runtime_id
+         ~model
+         config)
+  | Runtime_execution.Claude_code config ->
+    Ok
+      (probe_claude
+         ~mgr
+         ~clock
+         ~cwd:base_path
+         ~process_cwd
+         ~runtime_id
+         ~model
+         config)
+  | Runtime_execution.Agent_core _ ->
+    error
+      Bad_request
+      "runtime_not_official_client"
+      (Printf.sprintf "runtime %S is not an official-client runtime" runtime_id)
+;;

--- a/lib/server/server_dashboard_official_client_probe.mli
+++ b/lib/server/server_dashboard_official_client_probe.mli
@@ -1,6 +1,7 @@
 (** Explicit, no-model-call login probes for configured official-client
     runtimes. Operational negative results are returned as measured payloads;
-    malformed or non-official runtime requests are typed request errors. *)
+    malformed requests, non-official runtimes, and official clients without a
+    typed login probe are distinct request errors. *)
 
 type error_kind =
   | Bad_request

--- a/lib/server/server_dashboard_official_client_probe.mli
+++ b/lib/server/server_dashboard_official_client_probe.mli
@@ -1,0 +1,19 @@
+(** Explicit, no-model-call login probes for configured official-client
+    runtimes. Operational negative results are returned as measured payloads;
+    malformed or non-official runtime requests are typed request errors. *)
+
+type error_kind =
+  | Bad_request
+  | Not_found
+  | Service_unavailable
+
+type error =
+  { kind : error_kind
+  ; code : string
+  ; message : string
+  }
+
+val probe_body :
+  base_path:string ->
+  body:string ->
+  (Yojson.Safe.t, error) result

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -15,6 +15,7 @@ module Keeper_chat_pending = Server_dashboard_http_keeper_chat_pending
 module Keeper_event_queue_operator =
   Server_dashboard_http_keeper_event_queue_operator
 module Official_client_session = Server_dashboard_official_client_session
+module Official_client_probe = Server_dashboard_official_client_probe
 
 let config_cache_ttl_s = Server_dashboard_http_core_cache.config_cache_ttl_s
 let standard_cache_ttl_s = Server_dashboard_http_core_cache.standard_cache_ttl_s
@@ -63,6 +64,27 @@ let respond_official_client_session_result request reqd = function
       ~request
       (`Assoc
         [ "schema", `String "masc.dashboard.official-client-session.error.v1"
+        ; "ok", `Bool false
+        ; "error_code", `String code
+        ; "error", `String message
+        ])
+      reqd
+
+let respond_official_client_probe_result request reqd = function
+  | Ok json -> Http.Response.json_value ~compress:true ~request json reqd
+  | Error
+      ({ Official_client_probe.kind; code; message } : Official_client_probe.error) ->
+    let status =
+      match kind with
+      | Bad_request -> `Bad_request
+      | Not_found -> `Not_found
+      | Service_unavailable -> `Service_unavailable
+    in
+    Http.Response.json_value
+      ~status
+      ~request
+      (`Assoc
+        [ "schema", `String "masc.dashboard.official-client-probe.error.v1"
         ; "ok", `Bool false
         ; "error_code", `String code
         ; "error", `String message
@@ -850,6 +872,16 @@ let add_routes ~sw ~clock router =
              req
              reqd
              (Official_client_session.snapshot ~base_path ~keeper_name))
+         request reqd)
+  |> Http.Router.post "/api/v1/runtime/official-client/probe" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state _agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body ->
+             let base_path = (Mcp_server.workspace_config state).base_path in
+             respond_official_client_probe_result
+               req
+               reqd
+               (Official_client_probe.probe_body ~base_path ~body)))
          request reqd)
   |> Http.Router.post "/api/v1/runtime/sessions/official-client/resolve" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -83,6 +83,7 @@ normal_targets=(
   @test/runtest-test_runtime_claude_code
   @test/runtest-test_runtime_claude_code_config
   @test/runtest-test_keeper_claude_code_runtime
+  @test/runtest-test_server_dashboard_official_client_probe
   @test/runtest-test_host_fd_pressure_poller
   @test/runtest-test_keeper_turn_driver_failover
   @test/runtest-test_keeper_turn_driver_accept

--- a/test/dune
+++ b/test/dune
@@ -1953,6 +1953,7 @@
 (include stanzas/test_runtime_antigravity.inc)
 (include stanzas/test_runtime_claude_code_config.inc)
 (include stanzas/test_keeper_claude_code_runtime.inc)
+(include stanzas/test_server_dashboard_official_client_probe.inc)
 (include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/stanzas/test_server_dashboard_official_client_probe.inc
+++ b/test/stanzas/test_server_dashboard_official_client_probe.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_server_dashboard_official_client_probe)
+ (modules test_server_dashboard_official_client_probe)
+ (libraries masc masc_test_deps))

--- a/test/test_server_dashboard_official_client_probe.ml
+++ b/test/test_server_dashboard_official_client_probe.ml
@@ -141,6 +141,14 @@ let test_codex_and_claude_login_are_measured_separately () =
     check string "codex status" "ready" (json_string [ "login"; "status" ] codex);
     check bool "codex authenticated" true (json_bool [ "login"; "authenticated" ] codex);
     check string
+      "codex evidence source"
+      "configured_executable_self_report"
+      (json_string [ "login"; "evidence_source" ] codex);
+    check bool
+      "codex identity remains unverified"
+      false
+      (json_bool [ "login"; "identity_verified" ] codex);
+    check string
       "codex plan"
       "pro"
       (json_string [ "login"; "subscription_type" ] codex);
@@ -165,6 +173,10 @@ let test_codex_and_claude_login_are_measured_separately () =
       "claude status"
       "ready"
       (json_string [ "login"; "status" ] claude);
+    check bool
+      "claude identity remains unverified"
+      false
+      (json_bool [ "login"; "identity_verified" ] claude);
     check string
       "claude auth"
       "claude.ai"
@@ -197,6 +209,10 @@ let test_cli_unavailable_is_measured_login_evidence () =
       "not authenticated"
       false
       (json_bool [ "login"; "authenticated" ] response);
+    check bool
+      "missing executable identity remains unverified"
+      false
+      (json_bool [ "login"; "identity_verified" ] response);
     check string
       "execution remains unknown"
       "not_measured"

--- a/test/test_server_dashboard_official_client_probe.ml
+++ b/test/test_server_dashboard_official_client_probe.ml
@@ -1,0 +1,221 @@
+open Alcotest
+open Masc
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let write_executable prefix body =
+  let path = Filename.temp_file prefix ".sh" in
+  let output = open_out_bin path in
+  output_string output body;
+  close_out output;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let codex_fixture () =
+  let initialize =
+    {|{"id":1,"result":{"userAgent":"fixture/0.147.0","codexHome":"/tmp/codex","platformFamily":"unix","platformOs":"linux"}}|}
+  in
+  let account =
+    {|{"id":2,"result":{"account":{"type":"chatgpt","email":"not-projected@example.test","planType":"pro"},"requiresOpenaiAuth":true}}|}
+  in
+  write_executable
+    "masc-dashboard-codex-probe-"
+    ("#!/bin/sh\nset -eu\n"
+     ^ "IFS= read -r initialize\n"
+     ^ "printf '%s\\n' "
+     ^ shell_quote initialize
+     ^ "\nIFS= read -r initialized\nIFS= read -r account\n"
+     ^ "printf '%s\\n' "
+     ^ shell_quote account
+     ^ "\nwhile IFS= read -r ignored; do :; done\n")
+;;
+
+let claude_fixture () =
+  let auth =
+    {|{"loggedIn":true,"authMethod":"claude.ai","subscriptionType":"team","apiProvider":"firstParty"}|}
+  in
+  write_executable
+    "masc-dashboard-claude-probe-"
+    ("#!/bin/sh\nset -eu\n"
+     ^ "[ \"${1-}\" = auth ] || exit 91\n"
+     ^ "printf '%s\\n' "
+     ^ shell_quote auth
+     ^ "\n")
+;;
+
+let runtime_toml ~codex_cli ~claude_cli =
+  Printf.sprintf
+    "[providers.codex]\n\
+     protocol = \"codex-app-server\"\n\
+     command = %S\n\
+     is-non-interactive = true\n\
+     \n\
+     [providers.claude]\n\
+     protocol = \"claude-code\"\n\
+     command = %S\n\
+     is-non-interactive = true\n\
+     \n\
+     [providers.missing]\n\
+     protocol = \"claude-code\"\n\
+     command = \"/definitely/missing/claude\"\n\
+     is-non-interactive = true\n\
+     \n\
+     [models.codex]\n\
+     api-name = \"gpt-fixture\"\n\
+     max-context = 128000\n\
+     \n\
+     [models.claude]\n\
+     api-name = \"claude-fixture\"\n\
+     max-context = 200000\n\
+     \n\
+     [models.missing]\n\
+     api-name = \"claude-missing\"\n\
+     max-context = 200000\n\
+     \n\
+     [codex.codex]\n\
+     [claude.claude]\n\
+     [missing.missing]\n\
+     \n\
+     [runtime]\n\
+     default = \"codex.codex\"\n"
+    codex_cli
+    claude_cli
+;;
+
+let json_string path json =
+  List.fold_left (fun current field -> Yojson.Safe.Util.member field current) json path
+  |> Yojson.Safe.Util.to_string
+;;
+
+let json_bool path json =
+  List.fold_left (fun current field -> Yojson.Safe.Util.member field current) json path
+  |> Yojson.Safe.Util.to_bool
+;;
+
+let probe runtime_id =
+  match
+    Server_dashboard_official_client_probe.probe_body
+      ~base_path:"/tmp"
+      ~body:(Printf.sprintf {|{"runtime_id":%S}|} runtime_id)
+  with
+  | Ok json -> json
+  | Error error -> fail error.message
+;;
+
+let with_probe_runtime f =
+  let codex_cli = codex_fixture () in
+  let claude_cli = claude_fixture () in
+  let config_path = Filename.temp_file "masc-dashboard-official-probe-" ".toml" in
+  let output = open_out_bin config_path in
+  output_string output (runtime_toml ~codex_cli ~claude_cli);
+  close_out output;
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore snapshot;
+      List.iter
+        (fun path -> if Sys.file_exists path then Sys.remove path)
+        [ codex_cli; claude_cli; config_path ])
+    (fun () ->
+      match Runtime.init_default ~config_path with
+      | Error detail -> fail detail
+      | Ok () ->
+        Eio_main.run (fun env ->
+          Eio.Switch.run (fun sw ->
+            Eio_context.set_env env;
+            Eio_context.with_test_env
+              ~net:(Eio.Stdenv.net env)
+              ~clock:(Eio.Stdenv.clock env)
+              ~mono_clock:(Eio.Stdenv.mono_clock env)
+              ~sw
+              f)))
+;;
+
+let test_codex_and_claude_login_are_measured_separately () =
+  with_probe_runtime (fun () ->
+    let codex = probe "codex.codex" in
+    check string "codex kind" "codex" (json_string [ "client_kind" ] codex);
+    check string "codex status" "ready" (json_string [ "login"; "status" ] codex);
+    check bool "codex authenticated" true (json_bool [ "login"; "authenticated" ] codex);
+    check string
+      "codex plan"
+      "pro"
+      (json_string [ "login"; "subscription_type" ] codex);
+    check string
+      "codex user agent"
+      "fixture/0.147.0"
+      (json_string [ "client"; "user_agent" ] codex);
+    check string
+      "codex execution remains unknown"
+      "not_measured"
+      (json_string [ "execution"; "status" ] codex);
+    check bool
+      "email is redacted"
+      false
+      (String_util.contains_substring (Yojson.Safe.to_string codex) "example.test");
+    let claude = probe "claude.claude" in
+    check string
+      "claude kind"
+      "claude_code"
+      (json_string [ "client_kind" ] claude);
+    check string
+      "claude status"
+      "ready"
+      (json_string [ "login"; "status" ] claude);
+    check string
+      "claude auth"
+      "claude.ai"
+      (json_string [ "login"; "auth_method" ] claude);
+    check string
+      "claude plan"
+      "team"
+      (json_string [ "login"; "subscription_type" ] claude))
+;;
+
+let test_request_shape_is_exact () =
+  match
+    Server_dashboard_official_client_probe.probe_body
+      ~base_path:"/tmp"
+      ~body:{|{"runtime_id":"codex.codex","extra":true}|}
+  with
+  | Error { code = "request_fields_invalid"; _ } -> ()
+  | Error error -> fail error.message
+  | Ok _ -> fail "extra official-client probe fields were admitted"
+;;
+
+let test_cli_unavailable_is_measured_login_evidence () =
+  with_probe_runtime (fun () ->
+    let response = probe "missing.missing" in
+    check string
+      "login status"
+      "cli_unavailable"
+      (json_string [ "login"; "status" ] response);
+    check bool
+      "not authenticated"
+      false
+      (json_bool [ "login"; "authenticated" ] response);
+    check string
+      "execution remains unknown"
+      "not_measured"
+      (json_string [ "execution"; "status" ] response))
+;;
+
+let () =
+  run
+    "server_dashboard_official_client_probe"
+    [ ( "probe"
+      , [ test_case
+            "Codex and Claude login evidence"
+            `Quick
+            test_codex_and_claude_login_are_measured_separately
+        ; test_case "request shape is exact" `Quick test_request_shape_is_exact
+        ; test_case
+            "CLI unavailable is measured"
+            `Quick
+            test_cli_unavailable_is_measured_login_evidence
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add an Admin-only official-client login probe endpoint for configured Codex and Claude Code runtimes
- return measured login evidence without submitting a model turn
- omit account email and keep execution explicitly not_measured

## Endpoint
- POST /api/v1/runtime/official-client/probe
- exact body: { "runtime_id": "provider.model" }
- response schema: masc.dashboard.official-client-probe.v1

## Verification
- request shape, Codex login, Claude login, unavailable CLI, email omission, and not_measured execution are covered by test_server_dashboard_official_client_probe
- the endpoint suite is a required CI target in the runtime provider step
- OCaml format, parse, diff, and CI-target ratchet checks pass
- CI target audit: 159 declared targets, 701 unwired at the exact baseline
- focused local Dune execution is pending because the repository guard detected unrelated bare Dune processes; current GitHub CI is authoritative
