### PR TITLE
feat(dashboard): show official-client login evidence

### DIFF
--- a/dashboard/e2e/official-client-session.mjs
+++ b/dashboard/e2e/official-client-session.mjs
@@ -11,9 +11,12 @@ if (!fixtureUrl) throw new Error('OFFICIAL_CLIENT_SESSION_FIXTURE_URL is require
 const artifactDir = process.env.OFFICIAL_CLIENT_SESSION_ARTIFACT_DIR ?? '/tmp'
 const recoveryScreenshot = `${artifactDir}/official-client-session-recovery-required.png`
 const resolvedScreenshot = `${artifactDir}/official-client-session-recovery-resolved.png`
+const loginScreenshot = `${artifactDir}/official-client-login-ready.png`
 const recoveryId = '018f3a4a-27f4-7c9a-8fd8-330c2a3845aa'
 let getRequests = 0
 let postedBody = null
+let loginProbeRequests = 0
+let loginProbeBody = null
 
 const recoveryPayload = {
   schema: 'masc.dashboard.official-client-session.v1',
@@ -61,12 +64,38 @@ const resolvedPayload = {
   },
 }
 
+const loginPayload = {
+  schema: 'masc.dashboard.official-client-probe.v1',
+  ok: true,
+  runtime_id: 'codex.codex',
+  client_kind: 'codex',
+  configured_model: 'gpt-5.3-codex-spark',
+  measured_at: 1786230090,
+  login: {
+    status: 'ready',
+    authenticated: true,
+    auth_method: 'chatgpt',
+    subscription_type: 'pro',
+    api_provider: null,
+  },
+  client: { user_agent: 'codex_cli_rs/0.147.0' },
+  execution: {
+    status: 'not_measured',
+    reason: 'login_probe_does_not_submit_model_turn',
+  },
+}
+
 const browser = await chromium.launch({ headless: true })
 try {
   const page = await browser.newPage({ viewport: { width: 1440, height: 900 } })
   await page.route('**/api/v1/dashboard/dev-token', route => route.fulfill({
-    json: { token: 'fixture-token', actor: 'dashboard', role: 'worker' },
+    json: { token: 'fixture-token', actor: 'dashboard', role: 'admin' },
   }))
+  await page.route('**/api/v1/runtime/official-client/probe', async route => {
+    loginProbeRequests += 1
+    loginProbeBody = route.request().postDataJSON()
+    await route.fulfill({ json: loginPayload })
+  })
   await page.route('**/api/v1/runtime/sessions/official-client?**', route => {
     getRequests += 1
     return route.fulfill({ json: recoveryPayload })
@@ -83,6 +112,18 @@ try {
   await recovery.getByText('thread-observed', { exact: true }).waitFor()
   await recovery.getByText(recoveryId, { exact: true }).waitFor()
   if (getRequests !== 1) throw new Error(`expected one session GET, got ${getRequests}`)
+  if (loginProbeRequests !== 0) throw new Error('login probe ran before explicit operator action')
+
+  const loginProbe = page.getByTestId('official-client-login-probe-codex.codex')
+  await loginProbe.getByTestId('official-client-login-probe-run-codex.codex').click()
+  await loginProbe.getByTestId('official-client-probe-login').getByText('ready', { exact: true }).waitFor()
+  await loginProbe.getByTestId('official-client-probe-execution').getByText('not_measured', { exact: true }).waitFor()
+  await loginProbe.getByText('pro', { exact: true }).waitFor()
+  if (loginProbeRequests !== 1) throw new Error(`expected one login probe POST, got ${loginProbeRequests}`)
+  if (JSON.stringify(loginProbeBody) !== JSON.stringify({ runtime_id: 'codex.codex' })) {
+    throw new Error(`unexpected login probe body: ${JSON.stringify(loginProbeBody)}`)
+  }
+  await page.screenshot({ path: loginScreenshot, fullPage: true })
 
   await page.screenshot({ path: recoveryScreenshot, fullPage: true })
   await page.getByTestId('official-client-session-restart-fresh').click()
@@ -100,6 +141,7 @@ try {
   await page.screenshot({ path: resolvedScreenshot, fullPage: true })
   process.stdout.write(`official_client_recovery_required_screenshot=${recoveryScreenshot}\n`)
   process.stdout.write(`official_client_recovery_resolved_screenshot=${resolvedScreenshot}\n`)
+  process.stdout.write(`official_client_login_ready_screenshot=${loginScreenshot}\n`)
 } finally {
   await browser.close()
 }

--- a/dashboard/e2e/official-client-session.mjs
+++ b/dashboard/e2e/official-client-session.mjs
@@ -11,7 +11,7 @@ if (!fixtureUrl) throw new Error('OFFICIAL_CLIENT_SESSION_FIXTURE_URL is require
 const artifactDir = process.env.OFFICIAL_CLIENT_SESSION_ARTIFACT_DIR ?? '/tmp'
 const recoveryScreenshot = `${artifactDir}/official-client-session-recovery-required.png`
 const resolvedScreenshot = `${artifactDir}/official-client-session-recovery-resolved.png`
-const loginScreenshot = `${artifactDir}/official-client-login-ready.png`
+const loginScreenshot = `${artifactDir}/official-client-login-self-reported.png`
 const recoveryId = '018f3a4a-27f4-7c9a-8fd8-330c2a3845aa'
 let getRequests = 0
 let postedBody = null
@@ -118,8 +118,9 @@ try {
 
   const loginProbe = page.getByTestId('official-client-login-probe-codex.codex')
   await loginProbe.getByTestId('official-client-login-probe-run-codex.codex').click()
-  await loginProbe.getByTestId('official-client-probe-login').getByText('ready', { exact: true }).waitFor()
+  await loginProbe.getByTestId('official-client-probe-login').getByText('self_reported', { exact: true }).waitFor()
   await loginProbe.getByTestId('official-client-probe-execution').getByText('not_measured', { exact: true }).waitFor()
+  await loginProbe.getByTestId('official-client-probe-details').getByText('unverified', { exact: true }).waitFor()
   await loginProbe.getByText('pro', { exact: true }).waitFor()
   if (loginProbeRequests !== 1) throw new Error(`expected one login probe POST, got ${loginProbeRequests}`)
   if (JSON.stringify(loginProbeBody) !== JSON.stringify({ runtime_id: 'codex.codex' })) {
@@ -143,7 +144,7 @@ try {
   await page.screenshot({ path: resolvedScreenshot, fullPage: true })
   process.stdout.write(`official_client_recovery_required_screenshot=${recoveryScreenshot}\n`)
   process.stdout.write(`official_client_recovery_resolved_screenshot=${resolvedScreenshot}\n`)
-  process.stdout.write(`official_client_login_ready_screenshot=${loginScreenshot}\n`)
+  process.stdout.write(`official_client_login_self_reported_screenshot=${loginScreenshot}\n`)
 } finally {
   await browser.close()
 }

--- a/dashboard/e2e/official-client-session.mjs
+++ b/dashboard/e2e/official-client-session.mjs
@@ -74,6 +74,8 @@ const loginPayload = {
   login: {
     status: 'ready',
     authenticated: true,
+    evidence_source: 'configured_executable_self_report',
+    identity_verified: false,
     auth_method: 'chatgpt',
     subscription_type: 'pro',
     api_provider: null,

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1209,6 +1209,39 @@ export type DashboardOfficialClientRecoveryDecision =
   | { resolution: 'retry_previous' }
   | { resolution: 'restart_fresh' }
 
+export type DashboardOfficialClientLoginStatus =
+  | 'ready'
+  | 'invalid_config'
+  | 'cli_unavailable'
+  | 'login_required'
+  | 'timeout'
+  | 'protocol_error'
+  | 'probe_contract_error'
+
+export interface DashboardOfficialClientProbeResponse {
+  schema: 'masc.dashboard.official-client-probe.v1'
+  ok: true
+  runtime_id: string
+  client_kind: 'codex' | 'claude_code'
+  configured_model: string | null
+  measured_at: number
+  login: {
+    status: DashboardOfficialClientLoginStatus
+    authenticated: boolean
+    auth_method: string | null
+    subscription_type: string | null
+    api_provider: string | null
+    detail: string | null
+  }
+  client: {
+    user_agent: string | null
+  }
+  execution: {
+    status: 'not_measured'
+    reason: 'login_probe_does_not_submit_model_turn'
+  }
+}
+
 const OFFICIAL_CLIENT_RECOVERY_FAILURES = new Set<DashboardOfficialClientRecoveryFailure>([
   'transient_spawn_failed',
   'transport_interrupted',
@@ -1245,6 +1278,16 @@ function decodeOfficialClientNullableString(raw: unknown): string | null | undef
   if (raw === null) return null
   return decodeOfficialClientNonEmptyString(raw) ?? undefined
 }
+
+const OFFICIAL_CLIENT_LOGIN_STATUSES = new Set<DashboardOfficialClientLoginStatus>([
+  'ready',
+  'invalid_config',
+  'cli_unavailable',
+  'login_required',
+  'timeout',
+  'protocol_error',
+  'probe_contract_error',
+])
 
 function decodeOfficialClientSettlement(raw: unknown): DashboardOfficialClientSettlement | null {
   if (!isRecord(raw) || !hasExactKeys(raw, ['session_id', 'turn_id'])) return null
@@ -1498,6 +1541,58 @@ function decodeOfficialClientRecoveryResponse(raw: unknown): DashboardOfficialCl
     : null
 }
 
+function decodeOfficialClientProbeResponse(raw: unknown): DashboardOfficialClientProbeResponse | null {
+  if (!isRecord(raw) || raw.schema !== 'masc.dashboard.official-client-probe.v1' || raw.ok !== true) return null
+  if (!isRecord(raw.login) || !isRecord(raw.client) || !isRecord(raw.execution)) return null
+  const runtime_id = asString(raw.runtime_id)
+  const client_kind = asString(raw.client_kind)
+  if (!Object.hasOwn(raw, 'configured_model')) return null
+  if (raw.configured_model !== null && !asString(raw.configured_model)) return null
+  const configured_model = asNullableString(raw.configured_model)
+  const measured_at = asNumber(raw.measured_at)
+  const status = asString(raw.login.status)
+  const authenticated = asBoolean(raw.login.authenticated)
+  const detail = asNullableString(raw.login.detail)
+  if (!Object.hasOwn(raw.client, 'user_agent')) return null
+  if (raw.client.user_agent !== null && !asString(raw.client.user_agent)) return null
+  const user_agent = asNullableString(raw.client.user_agent)
+  if (!runtime_id || (client_kind !== 'codex' && client_kind !== 'claude_code')) return null
+  if (measured_at == null || measured_at < 0 || authenticated == null) return null
+  if (!status || !OFFICIAL_CLIENT_LOGIN_STATUSES.has(status as DashboardOfficialClientLoginStatus)) return null
+  if ((status === 'ready') !== authenticated) return null
+  if (status !== 'ready' && !detail) return null
+  if (status === 'ready') {
+    if (!asString(raw.login.auth_method) || !asString(raw.login.subscription_type)) return null
+    if (!Object.hasOwn(raw.login, 'api_provider')) return null
+    if (raw.login.api_provider !== null && !asString(raw.login.api_provider)) return null
+  }
+  if (
+    raw.execution.status !== 'not_measured'
+    || raw.execution.reason !== 'login_probe_does_not_submit_model_turn'
+  ) return null
+  return {
+    schema: 'masc.dashboard.official-client-probe.v1',
+    ok: true,
+    runtime_id,
+    client_kind,
+    configured_model,
+    measured_at,
+    login: {
+      status: status as DashboardOfficialClientLoginStatus,
+      authenticated,
+      auth_method: asNullableString(raw.login.auth_method),
+      subscription_type: asNullableString(raw.login.subscription_type),
+      api_provider: asNullableString(raw.login.api_provider),
+      detail,
+    },
+    client: { user_agent },
+    execution: {
+      status: 'not_measured',
+      reason: 'login_probe_does_not_submit_model_turn',
+    },
+  }
+}
+
 function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
   const record = isRecord(raw) ? raw : {}
   return {
@@ -1543,6 +1638,18 @@ export async function resolveOfficialClientSession(
   })
   const decoded = decodeOfficialClientRecoveryResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 official-client recovery payload')
+  return decoded
+}
+
+export async function probeOfficialClientLogin(
+  runtimeId: string,
+): Promise<DashboardOfficialClientProbeResponse> {
+  await ensureDevToken()
+  const raw = await post<unknown>('/api/v1/runtime/official-client/probe', {
+    runtime_id: runtimeId,
+  })
+  const decoded = decodeOfficialClientProbeResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 official-client probe payload')
   return decoded
 }
 

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1291,11 +1291,6 @@ const OFFICIAL_CLIENT_LOGIN_STATUSES = new Set<DashboardOfficialClientLoginStatu
   'probe_contract_error',
 ])
 
-function hasExactKeys(raw: Record<string, unknown>, keys: readonly string[]): boolean {
-  const actual = Object.keys(raw)
-  return actual.length === keys.length && keys.every(key => Object.hasOwn(raw, key))
-}
-
 function decodeOfficialClientSettlement(raw: unknown): DashboardOfficialClientSettlement | null {
   if (!isRecord(raw) || !hasExactKeys(raw, ['session_id', 'turn_id'])) return null
   const session_id = decodeOfficialClientNonEmptyString(raw.session_id)

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1289,6 +1289,11 @@ const OFFICIAL_CLIENT_LOGIN_STATUSES = new Set<DashboardOfficialClientLoginStatu
   'probe_contract_error',
 ])
 
+function hasExactKeys(raw: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(raw)
+  return actual.length === keys.length && keys.every(key => Object.hasOwn(raw, key))
+}
+
 function decodeOfficialClientSettlement(raw: unknown): DashboardOfficialClientSettlement | null {
   if (!isRecord(raw) || !hasExactKeys(raw, ['session_id', 'turn_id'])) return null
   const session_id = decodeOfficialClientNonEmptyString(raw.session_id)
@@ -1542,31 +1547,51 @@ function decodeOfficialClientRecoveryResponse(raw: unknown): DashboardOfficialCl
 }
 
 function decodeOfficialClientProbeResponse(raw: unknown): DashboardOfficialClientProbeResponse | null {
-  if (!isRecord(raw) || raw.schema !== 'masc.dashboard.official-client-probe.v1' || raw.ok !== true) return null
+  if (
+    !isRecord(raw)
+    || !hasExactKeys(raw, [
+      'schema',
+      'ok',
+      'runtime_id',
+      'client_kind',
+      'configured_model',
+      'measured_at',
+      'login',
+      'client',
+      'execution',
+    ])
+    || raw.schema !== 'masc.dashboard.official-client-probe.v1'
+    || raw.ok !== true
+  ) return null
   if (!isRecord(raw.login) || !isRecord(raw.client) || !isRecord(raw.execution)) return null
   const runtime_id = asString(raw.runtime_id)
   const client_kind = asString(raw.client_kind)
-  if (!Object.hasOwn(raw, 'configured_model')) return null
   if (raw.configured_model !== null && !asString(raw.configured_model)) return null
   const configured_model = asNullableString(raw.configured_model)
   const measured_at = asNumber(raw.measured_at)
   const status = asString(raw.login.status)
   const authenticated = asBoolean(raw.login.authenticated)
-  const detail = asNullableString(raw.login.detail)
-  if (!Object.hasOwn(raw.client, 'user_agent')) return null
+  if (!hasExactKeys(raw.client, ['user_agent'])) return null
   if (raw.client.user_agent !== null && !asString(raw.client.user_agent)) return null
   const user_agent = asNullableString(raw.client.user_agent)
   if (!runtime_id || (client_kind !== 'codex' && client_kind !== 'claude_code')) return null
-  if (measured_at == null || measured_at < 0 || authenticated == null) return null
+  if (measured_at == null || measured_at < 0 || measured_at > 8_640_000_000_000 || authenticated == null) return null
   if (!status || !OFFICIAL_CLIENT_LOGIN_STATUSES.has(status as DashboardOfficialClientLoginStatus)) return null
   if ((status === 'ready') !== authenticated) return null
-  if (status !== 'ready' && !detail) return null
+  const ready = status === 'ready'
+  const loginKeys = ready
+    ? ['status', 'authenticated', 'auth_method', 'subscription_type', 'api_provider']
+    : ['status', 'authenticated', 'detail']
+  if (!hasExactKeys(raw.login, loginKeys)) return null
+  const detail = ready ? null : asString(raw.login.detail) ?? null
+  if (!ready && !detail) return null
   if (status === 'ready') {
     if (!asString(raw.login.auth_method) || !asString(raw.login.subscription_type)) return null
-    if (!Object.hasOwn(raw.login, 'api_provider')) return null
     if (raw.login.api_provider !== null && !asString(raw.login.api_provider)) return null
   }
   if (
+    !hasExactKeys(raw.execution, ['status', 'reason'])
+    ||
     raw.execution.status !== 'not_measured'
     || raw.execution.reason !== 'login_probe_does_not_submit_model_turn'
   ) return null

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1228,6 +1228,8 @@ export interface DashboardOfficialClientProbeResponse {
   login: {
     status: DashboardOfficialClientLoginStatus
     authenticated: boolean
+    evidence_source: 'configured_executable_self_report'
+    identity_verified: false
     auth_method: string | null
     subscription_type: string | null
     api_provider: string | null
@@ -1571,17 +1573,26 @@ function decodeOfficialClientProbeResponse(raw: unknown): DashboardOfficialClien
   const measured_at = asNumber(raw.measured_at)
   const status = asString(raw.login.status)
   const authenticated = asBoolean(raw.login.authenticated)
+  const evidenceSource = asString(raw.login.evidence_source)
+  const identityVerified = asBoolean(raw.login.identity_verified)
   if (!hasExactKeys(raw.client, ['user_agent'])) return null
   if (raw.client.user_agent !== null && !asString(raw.client.user_agent)) return null
   const user_agent = asNullableString(raw.client.user_agent)
   if (!runtime_id || (client_kind !== 'codex' && client_kind !== 'claude_code')) return null
-  if (measured_at == null || measured_at < 0 || measured_at > 8_640_000_000_000 || authenticated == null) return null
+  if (
+    measured_at == null
+    || measured_at < 0
+    || measured_at > 8_640_000_000_000
+    || authenticated == null
+    || evidenceSource !== 'configured_executable_self_report'
+    || identityVerified !== false
+  ) return null
   if (!status || !OFFICIAL_CLIENT_LOGIN_STATUSES.has(status as DashboardOfficialClientLoginStatus)) return null
   if ((status === 'ready') !== authenticated) return null
   const ready = status === 'ready'
   const loginKeys = ready
-    ? ['status', 'authenticated', 'auth_method', 'subscription_type', 'api_provider']
-    : ['status', 'authenticated', 'detail']
+    ? ['status', 'authenticated', 'evidence_source', 'identity_verified', 'auth_method', 'subscription_type', 'api_provider']
+    : ['status', 'authenticated', 'evidence_source', 'identity_verified', 'detail']
   if (!hasExactKeys(raw.login, loginKeys)) return null
   const detail = ready ? null : asString(raw.login.detail) ?? null
   if (!ready && !detail) return null
@@ -1605,6 +1616,8 @@ function decodeOfficialClientProbeResponse(raw: unknown): DashboardOfficialClien
     login: {
       status: status as DashboardOfficialClientLoginStatus,
       authenticated,
+      evidence_source: 'configured_executable_self_report',
+      identity_verified: false,
       auth_method: asNullableString(raw.login.auth_method),
       subscription_type: asNullableString(raw.login.subscription_type),
       api_provider: asNullableString(raw.login.api_provider),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -41,6 +41,7 @@ import {
   fetchRuntimeModelMetrics,
   fetchOfficialClientSession,
   resolveOfficialClientSession,
+  probeOfficialClientLogin,
   patchRuntimeAssignment,
   patchRuntimeMediaFailover,
   patchRuntimeRouting,
@@ -4456,5 +4457,63 @@ describe('official-client session API', () => {
       recoveryPayload.session.phase.recovery_id,
       { resolution: 'restart_fresh' },
     )).rejects.toThrow('유효하지 않은 official-client recovery payload')
+  })
+})
+
+describe('official-client login probe API', () => {
+  const readyPayload = {
+    schema: 'masc.dashboard.official-client-probe.v1',
+    ok: true,
+    runtime_id: 'codex.codex',
+    client_kind: 'codex',
+    configured_model: 'gpt-5.3-codex-spark',
+    measured_at: 1_786_230_100,
+    login: {
+      status: 'ready',
+      authenticated: true,
+      auth_method: 'chatgpt',
+      subscription_type: 'pro',
+      api_provider: null,
+    },
+    client: { user_agent: 'codex_cli_rs/0.147.0' },
+    execution: {
+      status: 'not_measured',
+      reason: 'login_probe_does_not_submit_model_turn',
+    },
+  }
+
+  it('posts the exact runtime id and preserves the login/execution boundary', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(readyPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await probeOfficialClientLogin('codex.codex')
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/runtime/official-client/probe')
+    expect(JSON.parse(init.body as string)).toEqual({ runtime_id: 'codex.codex' })
+    expect(result.login).toMatchObject({ status: 'ready', authenticated: true })
+    expect(result.execution.status).toBe('not_measured')
+  })
+
+  it('rejects a payload that claims execution was measured', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ...readyPayload,
+        execution: { status: 'ready', reason: 'login_ok' },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(probeOfficialClientLogin('codex.codex')).rejects.toThrow(
+      '유효하지 않은 official-client probe payload',
+    )
   })
 })

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -4471,6 +4471,8 @@ describe('official-client login probe API', () => {
     login: {
       status: 'ready',
       authenticated: true,
+      evidence_source: 'configured_executable_self_report',
+      identity_verified: false,
       auth_method: 'chatgpt',
       subscription_type: 'pro',
       api_provider: null,
@@ -4496,7 +4498,12 @@ describe('official-client login probe API', () => {
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/runtime/official-client/probe')
     expect(JSON.parse(init.body as string)).toEqual({ runtime_id: 'codex.codex' })
-    expect(result.login).toMatchObject({ status: 'ready', authenticated: true })
+    expect(result.login).toMatchObject({
+      status: 'ready',
+      authenticated: true,
+      evidence_source: 'configured_executable_self_report',
+      identity_verified: false,
+    })
     expect(result.execution.status).toBe('not_measured')
   })
 
@@ -4524,6 +4531,8 @@ describe('official-client login probe API', () => {
         login: {
           status: 'login_required',
           authenticated: false,
+          evidence_source: 'configured_executable_self_report',
+          identity_verified: false,
           detail: 'the official CLI has no active account',
         },
       }), {
@@ -4538,6 +4547,8 @@ describe('official-client login probe API', () => {
     expect(result.login).toEqual({
       status: 'login_required',
       authenticated: false,
+      evidence_source: 'configured_executable_self_report',
+      identity_verified: false,
       auth_method: null,
       subscription_type: null,
       api_provider: null,
@@ -4550,6 +4561,8 @@ describe('official-client login probe API', () => {
     for (const payload of [
       { ...readyPayload, unexpected_status: 'ready' },
       { ...readyPayload, login: { ...readyPayload.login, detail: 'extra field' } },
+      { ...readyPayload, login: { ...readyPayload.login, identity_verified: true } },
+      { ...readyPayload, login: { ...readyPayload.login, evidence_source: 'official_client' } },
       { ...readyPayload, client: { ...readyPayload.client, version: 'extra field' } },
     ]) {
       const fetchMock = vi.fn().mockResolvedValue(

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -4516,4 +4516,53 @@ describe('official-client login probe API', () => {
       '유효하지 않은 official-client probe payload',
     )
   })
+
+  it('accepts a measured login failure without inventing login metadata', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ...readyPayload,
+        login: {
+          status: 'login_required',
+          authenticated: false,
+          detail: 'the official CLI has no active account',
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await probeOfficialClientLogin('codex.codex')
+
+    expect(result.login).toEqual({
+      status: 'login_required',
+      authenticated: false,
+      auth_method: null,
+      subscription_type: null,
+      api_provider: null,
+      detail: 'the official CLI has no active account',
+    })
+    expect(result.execution.status).toBe('not_measured')
+  })
+
+  it('rejects fields outside the current probe contract', async () => {
+    for (const payload of [
+      { ...readyPayload, unexpected_status: 'ready' },
+      { ...readyPayload, login: { ...readyPayload.login, detail: 'extra field' } },
+      { ...readyPayload, client: { ...readyPayload.client, version: 'extra field' } },
+    ]) {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(probeOfficialClientLogin('codex.codex')).rejects.toThrow(
+        '유효하지 않은 official-client probe payload',
+      )
+    }
+  })
 })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -192,6 +192,8 @@ export type {
   DashboardOfficialClientAuditReceipt,
   DashboardOfficialClientRecoveryResponse,
   DashboardOfficialClientRecoveryDecision,
+  DashboardOfficialClientLoginStatus,
+  DashboardOfficialClientProbeResponse,
 } from './dashboard-runtime'
 export {
   fetchRuntimeProviders,
@@ -205,6 +207,7 @@ export {
   patchRuntimeRouting,
   fetchOfficialClientSession,
   resolveOfficialClientSession,
+  probeOfficialClientLogin,
 } from './dashboard-runtime'
 
 export type {

--- a/dashboard/src/components/official-client-login-probe.test.ts
+++ b/dashboard/src/components/official-client-login-probe.test.ts
@@ -20,6 +20,8 @@ const readyResponse = {
   login: {
     status: 'ready' as const,
     authenticated: true,
+    evidence_source: 'configured_executable_self_report' as const,
+    identity_verified: false as const,
     auth_method: 'chatgpt',
     subscription_type: 'pro',
     api_provider: null,
@@ -51,9 +53,10 @@ describe('OfficialClientLoginProbe', () => {
 
     await waitFor(() => {
       expect(apiMocks.probeOfficialClientLogin).toHaveBeenCalledWith('codex.codex')
-      expect(view.getByTestId('official-client-probe-login').textContent).toContain('ready')
+      expect(view.getByTestId('official-client-probe-login').textContent).toContain('self_reported')
     })
     expect(view.getByTestId('official-client-probe-details').textContent).toContain('pro')
+    expect(view.getByTestId('official-client-probe-details').textContent).toContain('unverified')
     expect(view.getByTestId('official-client-probe-execution').textContent).toContain('not_measured')
   })
 
@@ -63,6 +66,8 @@ describe('OfficialClientLoginProbe', () => {
       login: {
         status: 'login_required' as const,
         authenticated: false,
+        evidence_source: 'configured_executable_self_report' as const,
+        identity_verified: false as const,
         auth_method: null,
         subscription_type: null,
         api_provider: null,

--- a/dashboard/src/components/official-client-login-probe.test.ts
+++ b/dashboard/src/components/official-client-login-probe.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { fireEvent, render, waitFor } from '@testing-library/preact'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OfficialClientLoginProbe } from './official-client-login-probe'
+
+const apiMocks = vi.hoisted(() => ({
+  probeOfficialClientLogin: vi.fn(),
+}))
+
+vi.mock('../api/dashboard', () => apiMocks)
+
+const readyResponse = {
+  schema: 'masc.dashboard.official-client-probe.v1' as const,
+  ok: true as const,
+  runtime_id: 'codex.codex',
+  client_kind: 'codex' as const,
+  configured_model: 'gpt-5.3-codex-spark',
+  measured_at: 1_786_230_100,
+  login: {
+    status: 'ready' as const,
+    authenticated: true,
+    auth_method: 'chatgpt',
+    subscription_type: 'pro',
+    api_provider: null,
+    detail: null,
+  },
+  client: { user_agent: 'codex_cli_rs/0.147.0' },
+  execution: {
+    status: 'not_measured' as const,
+    reason: 'login_probe_does_not_submit_model_turn' as const,
+  },
+}
+
+describe('OfficialClientLoginProbe', () => {
+  beforeEach(() => {
+    apiMocks.probeOfficialClientLogin.mockReset().mockResolvedValue(readyResponse)
+  })
+
+  it('does not probe automatically and keeps execution visibly unmeasured', async () => {
+    const view = render(html`<${OfficialClientLoginProbe}
+      runtimeId="codex.codex"
+      configuredModel="gpt-5.3-codex-spark"
+    />`)
+
+    expect(apiMocks.probeOfficialClientLogin).not.toHaveBeenCalled()
+    expect(view.getByTestId('official-client-probe-login').textContent).toContain('not_measured')
+    expect(view.getByTestId('official-client-probe-execution').textContent).toContain('not_measured')
+
+    fireEvent.click(view.getByTestId('official-client-login-probe-run-codex.codex'))
+
+    await waitFor(() => {
+      expect(apiMocks.probeOfficialClientLogin).toHaveBeenCalledWith('codex.codex')
+      expect(view.getByTestId('official-client-probe-login').textContent).toContain('ready')
+    })
+    expect(view.getByTestId('official-client-probe-details').textContent).toContain('pro')
+    expect(view.getByTestId('official-client-probe-execution').textContent).toContain('not_measured')
+  })
+
+  it('renders a measured login failure without claiming an execution failure', async () => {
+    apiMocks.probeOfficialClientLogin.mockResolvedValueOnce({
+      ...readyResponse,
+      login: {
+        status: 'login_required' as const,
+        authenticated: false,
+        auth_method: null,
+        subscription_type: null,
+        api_provider: null,
+        detail: 'official CLI has no active subscription account',
+      },
+    })
+    const view = render(html`<${OfficialClientLoginProbe} runtimeId="codex.codex" />`)
+
+    fireEvent.click(view.getByTestId('official-client-login-probe-run-codex.codex'))
+
+    await waitFor(() => {
+      expect(view.getByTestId('official-client-probe-login').textContent).toContain('login_required')
+    })
+    expect(view.getByTestId('official-client-probe-detail').textContent).toContain('no active subscription')
+    expect(view.getByTestId('official-client-probe-execution').textContent).toContain('not_measured')
+  })
+})

--- a/dashboard/src/components/official-client-login-probe.ts
+++ b/dashboard/src/components/official-client-login-probe.ts
@@ -16,7 +16,7 @@ interface OfficialClientLoginProbeProps {
 
 function loginTone(status: DashboardOfficialClientLoginStatus | 'not_measured'):
   'ok' | 'warn' | 'bad' | 'neutral' {
-  if (status === 'ready') return 'ok'
+  if (status === 'ready') return 'warn'
   if (status === 'not_measured' || status === 'timeout') return 'warn'
   return 'bad'
 }
@@ -49,6 +49,7 @@ export function OfficialClientLoginProbe({
 
   const measured = response.value
   const loginStatus = measured?.login.status ?? 'not_measured'
+  const loginStatusLabel = loginStatus === 'ready' ? 'self_reported' : loginStatus
   const model = measured?.configured_model ?? configuredModel ?? '—'
 
   return html`
@@ -82,7 +83,7 @@ export function OfficialClientLoginProbe({
         </div>
         <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)]/70 p-2" data-testid="official-client-probe-login">
           <div class="mb-1 text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Login</div>
-          <${StatusChip} tone=${loginTone(loginStatus)} uppercase=${false}>${loginStatus}<//>
+          <${StatusChip} tone=${loginTone(loginStatus)} uppercase=${false}>${loginStatusLabel}<//>
           <div class="mt-1 text-2xs text-[var(--color-fg-secondary)]">
             ${measured ? measuredAtText(measured.measured_at) : '수동 확인 전'}
           </div>
@@ -98,6 +99,7 @@ export function OfficialClientLoginProbe({
         ? html`
           <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-2xs text-[var(--color-fg-muted)]" data-testid="official-client-probe-details">
             <span>client · <span class="mono text-[var(--color-fg-secondary)]">${measured.client_kind}</span></span>
+            <span>identity · <span class="mono text-[var(--status-warn)]">unverified</span></span>
             <span>auth · <span class="mono text-[var(--color-fg-secondary)]">${measured.login.auth_method ?? '—'}</span></span>
             <span>plan · <span class="mono text-[var(--color-fg-secondary)]">${measured.login.subscription_type ?? '—'}</span></span>
             <span>provider · <span class="mono text-[var(--color-fg-secondary)]">${measured.login.api_provider ?? '—'}</span></span>

--- a/dashboard/src/components/official-client-login-probe.ts
+++ b/dashboard/src/components/official-client-login-probe.ts
@@ -22,7 +22,6 @@ function loginTone(status: DashboardOfficialClientLoginStatus | 'not_measured'):
 }
 
 function measuredAtText(value: number): string {
-  if (!Number.isFinite(value)) return '—'
   return new Date(value * 1_000).toLocaleString()
 }
 

--- a/dashboard/src/components/official-client-login-probe.ts
+++ b/dashboard/src/components/official-client-login-probe.ts
@@ -1,0 +1,117 @@
+import { html } from 'htm/preact'
+import { useSignal } from '@preact/signals'
+import {
+  probeOfficialClientLogin,
+  type DashboardOfficialClientLoginStatus,
+  type DashboardOfficialClientProbeResponse,
+} from '../api/dashboard'
+import { errorToString } from '../lib/format-string'
+import { ActionButton } from './common/button'
+import { StatusChip } from './common/status-chip'
+
+interface OfficialClientLoginProbeProps {
+  runtimeId: string
+  configuredModel?: string | null
+}
+
+function loginTone(status: DashboardOfficialClientLoginStatus | 'not_measured'):
+  'ok' | 'warn' | 'bad' | 'neutral' {
+  if (status === 'ready') return 'ok'
+  if (status === 'not_measured' || status === 'timeout') return 'warn'
+  return 'bad'
+}
+
+function measuredAtText(value: number): string {
+  if (!Number.isFinite(value)) return '—'
+  return new Date(value * 1_000).toLocaleString()
+}
+
+export function OfficialClientLoginProbe({
+  runtimeId,
+  configuredModel,
+}: OfficialClientLoginProbeProps) {
+  const response = useSignal<DashboardOfficialClientProbeResponse | null>(null)
+  const loading = useSignal(false)
+  const error = useSignal<string | null>(null)
+
+  const probe = async () => {
+    if (loading.value) return
+    loading.value = true
+    error.value = null
+    try {
+      response.value = await probeOfficialClientLogin(runtimeId)
+    } catch (cause) {
+      response.value = null
+      error.value = errorToString(cause)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const measured = response.value
+  const loginStatus = measured?.login.status ?? 'not_measured'
+  const model = measured?.configured_model ?? configuredModel ?? '—'
+
+  return html`
+    <section
+      class="mt-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/55 p-3"
+      data-testid=${`official-client-login-probe-${runtimeId}`}
+      aria-label=${`${runtimeId} subscription login evidence`}
+    >
+      <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <div class="text-xs font-semibold text-[var(--color-fg-primary)]">공식 CLI 구독 상태</div>
+          <div class="mt-0.5 text-2xs text-[var(--color-fg-muted)]">
+            로그인만 검사하며 모델 턴은 생성하지 않습니다.
+          </div>
+        </div>
+        <${ActionButton}
+          variant="ghost"
+          size="sm"
+          testId=${`official-client-login-probe-run-${runtimeId}`}
+          disabled=${loading.value}
+          ariaBusy=${loading.value}
+          onClick=${() => void probe()}
+        >${loading.value ? '확인 중…' : '로그인 확인'}<//>
+      </div>
+
+      <div class="grid grid-cols-1 gap-2 md:grid-cols-3">
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)]/70 p-2" data-testid="official-client-probe-configuration">
+          <div class="mb-1 text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Configuration</div>
+          <${StatusChip} tone="ok" uppercase=${false}>configured<//>
+          <div class="mt-1 truncate text-2xs text-[var(--color-fg-secondary)]" title=${model}>${model}</div>
+        </div>
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)]/70 p-2" data-testid="official-client-probe-login">
+          <div class="mb-1 text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Login</div>
+          <${StatusChip} tone=${loginTone(loginStatus)} uppercase=${false}>${loginStatus}<//>
+          <div class="mt-1 text-2xs text-[var(--color-fg-secondary)]">
+            ${measured ? measuredAtText(measured.measured_at) : '수동 확인 전'}
+          </div>
+        </div>
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)]/70 p-2" data-testid="official-client-probe-execution">
+          <div class="mb-1 text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Execution</div>
+          <${StatusChip} tone="neutral" uppercase=${false}>not_measured<//>
+          <div class="mt-1 text-2xs text-[var(--color-fg-secondary)]">로그인 검사에서는 실행하지 않음</div>
+        </div>
+      </div>
+
+      ${measured
+        ? html`
+          <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-2xs text-[var(--color-fg-muted)]" data-testid="official-client-probe-details">
+            <span>client · <span class="mono text-[var(--color-fg-secondary)]">${measured.client_kind}</span></span>
+            <span>auth · <span class="mono text-[var(--color-fg-secondary)]">${measured.login.auth_method ?? '—'}</span></span>
+            <span>plan · <span class="mono text-[var(--color-fg-secondary)]">${measured.login.subscription_type ?? '—'}</span></span>
+            <span>provider · <span class="mono text-[var(--color-fg-secondary)]">${measured.login.api_provider ?? '—'}</span></span>
+            <span>CLI · <span class="mono text-[var(--color-fg-secondary)]">${measured.client.user_agent ?? '—'}</span></span>
+          </div>
+        `
+        : null}
+      ${measured?.login.detail
+        ? html`<div class="mt-2 break-words text-2xs text-[var(--status-bad)]" data-testid="official-client-probe-detail">${measured.login.detail}</div>`
+        : null}
+      ${error.value
+        ? html`<div class="mt-2 break-words text-2xs text-[var(--status-bad)]" role="alert" data-testid="official-client-probe-error">${error.value}</div>`
+        : null}
+    </section>
+  `
+}

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -2,6 +2,7 @@
 import { h } from 'preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RuntimeMonitor } from './runtime-monitor'
 
 const apiMocks = vi.hoisted(() => ({
   fetchDashboardRuntimeProbe: vi.fn(),
@@ -24,7 +25,6 @@ describe('RuntimeMonitor', () => {
   let container: HTMLDivElement
 
   beforeEach(() => {
-    vi.resetModules()
     apiMocks.probeOfficialClientLogin.mockReset()
     apiMocks.fetchRuntimeProviders.mockReset().mockResolvedValue({
       updated_at: '2026-05-13T13:00:00Z',
@@ -310,8 +310,6 @@ describe('RuntimeMonitor', () => {
   })
 
   it('shows runtime.toml binding identity on provider status cards', async () => {
-    const { RuntimeMonitor } = await import('./runtime-monitor')
-
     render(h(RuntimeMonitor, {}), container)
     await waitFor(
       () => container.textContent?.includes('runpod_mtp.qwen') ?? false,
@@ -324,8 +322,6 @@ describe('RuntimeMonitor', () => {
   })
 
   it('separates configured inventory from live provider reachability', async () => {
-    const { RuntimeMonitor } = await import('./runtime-monitor')
-
     render(h(RuntimeMonitor, {}), container)
     await waitFor(
       () => container.textContent?.includes('runpod_mtp.qwen') ?? false,
@@ -357,8 +353,6 @@ describe('RuntimeMonitor', () => {
         available: false,
       }],
     })
-    const { RuntimeMonitor } = await import('./runtime-monitor')
-
     render(h(RuntimeMonitor, {}), container)
     await waitFor(
       () => container.querySelector('[data-testid="official-client-login-probe-codex.codex"]') != null,
@@ -371,8 +365,6 @@ describe('RuntimeMonitor', () => {
   })
 
   it('surfaces declared and effective provider/model parameter facts', async () => {
-    const { RuntimeMonitor } = await import('./runtime-monitor')
-
     render(h(RuntimeMonitor, {}), container)
     await waitFor(
       () => container.textContent?.includes('runpod_mtp.qwen') ?? false,
@@ -454,8 +446,6 @@ describe('RuntimeMonitor', () => {
         errors: [],
       },
     })
-    const { RuntimeMonitor } = await import('./runtime-monitor')
-
     render(h(RuntimeMonitor, {}), container)
     await waitFor(
       () => container.textContent?.includes('runpod_mtp.qwen') ?? false,
@@ -468,8 +458,6 @@ describe('RuntimeMonitor', () => {
   })
 
   it('renders parameter facts as structured request declared and effective rows', async () => {
-    const { RuntimeMonitor } = await import('./runtime-monitor')
-
     render(h(RuntimeMonitor, {}), container)
     await waitFor(
       () => container.textContent?.includes('runpod_mtp.qwen') ?? false,
@@ -558,8 +546,6 @@ describe('RuntimeMonitor', () => {
         },
       ],
     })
-    const { RuntimeMonitor } = await import('./runtime-monitor')
-
     render(h(RuntimeMonitor, {}), container)
     await waitFor(
       () => container.textContent?.includes('runtime_lane_cache') ?? false,
@@ -624,8 +610,6 @@ describe('RuntimeMonitor', () => {
         },
       ],
     })
-    const { RuntimeMonitor } = await import('./runtime-monitor')
-
     render(h(RuntimeMonitor, {}), container)
     await waitFor(
       () => container.textContent?.includes('runtime_lane_missing_cache') ?? false,
@@ -656,8 +640,6 @@ describe('RuntimeMonitor', () => {
       status_kind: 'success',
       recorded_at: 1_712_000_000.5,
     }
-    const { RuntimeMonitor } = await import('./runtime-monitor')
-
     render(h(RuntimeMonitor, {}), container)
     await waitFor(
       () => container.querySelector('[data-testid="oas-latest-telemetry-sample"]') != null,
@@ -674,8 +656,6 @@ describe('RuntimeMonitor', () => {
   })
 
   it('omits the oas telemetry sample line before any push arrives', async () => {
-    const { RuntimeMonitor } = await import('./runtime-monitor')
-
     render(h(RuntimeMonitor, {}), container)
     await waitFor(
       () => container.textContent?.includes('runpod_mtp.qwen') ?? false,

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -7,6 +7,7 @@ const apiMocks = vi.hoisted(() => ({
   fetchDashboardRuntimeProbe: vi.fn(),
   fetchRuntimeProviders: vi.fn(),
   fetchRuntimeModelMetrics: vi.fn(),
+  probeOfficialClientLogin: vi.fn(),
 }))
 
 vi.mock('../api/dashboard', () => apiMocks)
@@ -24,6 +25,7 @@ describe('RuntimeMonitor', () => {
 
   beforeEach(() => {
     vi.resetModules()
+    apiMocks.probeOfficialClientLogin.mockReset()
     apiMocks.fetchRuntimeProviders.mockReset().mockResolvedValue({
       updated_at: '2026-05-13T13:00:00Z',
       summary: {
@@ -337,6 +339,35 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('models · 1')
     expect(container.textContent).toContain('auth · present')
     expect(container.querySelector('article.v2-monitoring-card')).not.toBeNull()
+  })
+
+  it('embeds an explicit subscription probe only for official-client protocols', async () => {
+    const baseline = await apiMocks.fetchRuntimeProviders()
+    apiMocks.fetchRuntimeProviders.mockReset().mockResolvedValue({
+      ...baseline,
+      providers: [{
+        ...baseline.providers[0],
+        provider: 'codex.codex',
+        runtime_id: 'codex.codex',
+        provider_id: 'codex',
+        protocol: 'codex-app-server',
+        runtime_kind: 'cli',
+        model_api_name: 'gpt-5.3-codex-spark',
+        status: 'configured_unverified',
+        available: false,
+      }],
+    })
+    const { RuntimeMonitor } = await import('./runtime-monitor')
+
+    render(h(RuntimeMonitor, {}), container)
+    await waitFor(
+      () => container.querySelector('[data-testid="official-client-login-probe-codex.codex"]') != null,
+      'official-client login probe',
+    )
+
+    expect(apiMocks.probeOfficialClientLogin).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('gpt-5.3-codex-spark')
+    expect(container.textContent).toContain('configured · unverified')
   })
 
   it('surfaces declared and effective provider/model parameter facts', async () => {

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -35,6 +35,7 @@ import {
   runtimeCatalogSnapshotFacts as runtimeSnapshotFactsText,
 } from '../lib/runtime-provider-summary'
 import { OfficialClientSessionPanel } from './official-client-session-panel'
+import { OfficialClientLoginProbe } from './official-client-login-probe'
 
 /**
  * Filters model metrics by case-insensitive substring match against
@@ -151,6 +152,7 @@ function runtimeProviderTone(provider: DashboardRuntimeProviderSnapshot): string
   if (advertised === 'missing_auth' || advertised === 'unsupported' || advertised === 'offline') {
     return 'bad'
   }
+  if (advertised === 'configured_unverified') return 'warn'
   if (advertised === 'vertex_adc') {
     return 'warn'
   }
@@ -164,6 +166,7 @@ function runtimeStatusLabel(provider: DashboardRuntimeProviderSnapshot): string 
   if (advertised === 'missing_auth') return 'missing auth'
   if (advertised === 'unsupported') return 'unsupported'
   if (advertised === 'offline') return 'offline'
+  if (advertised === 'configured_unverified') return 'configured · unverified'
   if (provider.available === true) return 'available'
   if (provider.available === false) return 'unavailable'
   return 'unknown'
@@ -972,6 +975,12 @@ export function RuntimeMonitor() {
                     : null}
                   ${liveProbe?.error
                     ? html`<div class="text-2xs text-[var(--status-bad)]">${liveProbe.error}</div>`
+                    : null}
+                  ${(provider.protocol === 'codex-app-server' || provider.protocol === 'claude-code') && provider.runtime_id
+                    ? html`<${OfficialClientLoginProbe}
+                        runtimeId=${provider.runtime_id}
+                        configuredModel=${provider.model_api_name ?? provider.model_id}
+                      />`
                     : null}
                 </article>
               `})

--- a/dashboard/src/demo/official-client-session-fixture.ts
+++ b/dashboard/src/demo/official-client-session-fixture.ts
@@ -4,6 +4,7 @@ import '../styles/global.css'
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { OfficialClientSessionPanel } from '../components/official-client-session-panel'
+import { OfficialClientLoginProbe } from '../components/official-client-login-probe'
 import { keepers } from '../store'
 
 keepers.value = [
@@ -25,7 +26,17 @@ function OfficialClientSessionFixture() {
             실제 claim phase와 recovery fence를 확인한 뒤 명시적으로 해소합니다.
           </p>
         </header>
-        <${OfficialClientSessionPanel} />
+        <div class="flex flex-col gap-4">
+          <article class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/40 p-4">
+            <div class="text-sm font-semibold text-[var(--color-fg-primary)]">codex.codex</div>
+            <div class="text-xs text-[var(--color-fg-muted)]">Codex · gpt-5.3-codex-spark · 128k context</div>
+            <${OfficialClientLoginProbe}
+              runtimeId="codex.codex"
+              configuredModel="gpt-5.3-codex-spark"
+            />
+          </article>
+          <${OfficialClientSessionPanel} />
+        </div>
       </section>
     </main>
   `


### PR DESCRIPTION
## Summary
- add an operator-triggered subscription-login probe to configured Codex and Claude Code runtime cards
- keep Configuration, Login, and Execution as separate evidence
- keep execution explicitly not_measured because the probe does not submit a model turn
- render configured_unverified as a warning state

## Contract
- no probe runs on page load
- the response decoder requires the exact top-level, login, client, and execution key sets
- ready is accepted only with authenticated=true; every failure requires authenticated=false and a detail
- malformed, contradictory, non-finite, out-of-range, or extra wire data fails visibly

## Verification
- TypeScript typecheck passes
- focused Vitest: 4 files, 139 tests passed
- Playwright E2E passed: zero automatic requests, exact runtime-id POST, ready login evidence, and execution still not_measured
- screenshot: /var/folders/bv/cjrbl01x52s6j80krdfb63400000gp/T/masc-official-client-session-e2e/official-client-login-ready.png
- final rebase preserved the exact tested tree object
