### PR TITLE
feat(runtime): add native Antigravity CLI boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1567,7 +1567,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_keeper_official_client_host @test/runtest-test_runtime_codex_app_server @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code"
+          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_keeper_official_client_host @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${official_client_targets}"
 
       - name: Run host FD pressure contract suite

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -283,7 +283,8 @@ let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with
   | Some runtime ->
     (match runtime.Runtime.execution with
-     | Runtime_execution.Codex_app_server _ -> Ok runtime
+     | Runtime_execution.Codex_app_server _
+     | Runtime_execution.Antigravity_cli _ -> Ok runtime
      | Runtime_execution.Agent_core provider_config ->
        let* _request_body_cap =
          validate_provider_request_cap
@@ -744,6 +745,16 @@ let run_named
              on_runtime_observation
          | Error _ -> ());
         codex_result, None
+      | Runtime_execution.Antigravity_cli _ ->
+        Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
+        ( Error
+            (Agent_sdk.Error.Config
+               (Agent_sdk.Error.InvalidConfig
+                  { field = "runtime_execution"
+                  ; detail =
+                      "antigravity-cli is configured but Keeper dispatch is not admitted"
+                  }))
+        , None )
       | Runtime_execution.Agent_core runtime_provider_config ->
        (match
           match provider_config_transform with

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -87,7 +87,8 @@ let vision_runtime_candidates ()
   from_failover @ rest
   |> List.filter_map (fun (rt : Runtime.t) ->
        match rt.Runtime.execution with
-       | Runtime_execution.Codex_app_server _ -> None
+       | Runtime_execution.Codex_app_server _
+       | Runtime_execution.Antigravity_cli _ -> None
        | Runtime_execution.Agent_core provider_config ->
          let caps = Runtime_agent.input_capabilities_of_runtime rt in
          if Runtime_agent.caps_admit_required_modalities caps [ "image" ]

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -448,7 +448,7 @@ let capabilities_for_runtime (rt : t) =
   match rt.execution with
   | Runtime_execution.Agent_core provider_config ->
     Llm_provider.Provider_config.capabilities_for_config_model provider_config
-  | Runtime_execution.Codex_app_server _ -> None
+  | Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _ -> None
 ;;
 
 type max_context_source =
@@ -604,7 +604,8 @@ let validate_keeper_dispatch_request_caps
          | None -> None
          | Some runtime ->
            (match runtime.execution with
-            | Runtime_execution.Codex_app_server _ -> None
+            | Runtime_execution.Codex_app_server _
+            | Runtime_execution.Antigravity_cli _ -> None
             | Runtime_execution.Agent_core provider_config ->
               (match
                  validate_request_body_cap
@@ -641,7 +642,8 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
     List.filter_map
       (fun (r : t) ->
          match r.execution, capabilities_for_runtime r with
-         | Runtime_execution.Codex_app_server _, _ -> None
+         | (Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _), _ ->
+           None
          | Runtime_execution.Agent_core _, Some _ -> None
          | Runtime_execution.Agent_core provider_config, None ->
            let provider_label =

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -203,12 +203,13 @@ let messages_api_compatible_provider_kind = function
 let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.provider)
     : (Llm_provider.Provider_config.provider_kind, string) result =
   match provider.api_format with
-  | Codex_app_server_runtime ->
+  | Codex_app_server_runtime | Antigravity_cli_runtime ->
     Error
       (Printf.sprintf
-         "provider %S uses codex-app-server and cannot be materialized as an \
+         "provider %S uses official CLI protocol %s and cannot be materialized as an \
           HTTP provider"
-         provider.id)
+         provider.id
+         provider.protocol)
   | Ollama_api -> Ok Llm_provider.Provider_config.Ollama
   | Chat_completions_api ->
     (* Chat-completions keeps the historical OpenAI-compatible fallback when
@@ -491,6 +492,65 @@ let codex_app_server_execution (provider : Runtime_schema.provider)
             { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
 ;;
 
+let runtime_antigravity_effort = function
+  | Runtime_schema.Antigravity_low -> Runtime_antigravity.Low
+  | Runtime_schema.Antigravity_medium -> Runtime_antigravity.Medium
+  | Runtime_schema.Antigravity_high -> Runtime_antigravity.High
+;;
+
+let runtime_antigravity_execution_mode = function
+  | Runtime_schema.Antigravity_plan -> Runtime_antigravity.Plan
+  | Runtime_schema.Antigravity_accept_edits -> Runtime_antigravity.Accept_edits
+;;
+
+let antigravity_cli_execution (provider : Runtime_schema.provider)
+    (spec : Runtime_schema.model_spec) : (Runtime_execution.t, string) result =
+  match provider.transport with
+  | Http _ ->
+    Error
+      (Printf.sprintf
+         "provider %S uses protocol antigravity-cli but declares an HTTP endpoint; \
+          an official Antigravity CLI command is required"
+         provider.id)
+  | Cli command when String.trim command = "" ->
+    Error
+      (Printf.sprintf
+         "provider %S declares an empty Antigravity CLI command"
+         provider.id)
+  | Cli command ->
+    (match provider.credentials, provider.antigravity_cli with
+     | Some _, _ ->
+       Error
+         (Printf.sprintf
+            "provider %S uses antigravity-cli and must not declare credentials; \
+             the official Antigravity client owns login state"
+            provider.id)
+     | None, _ when not provider.is_non_interactive ->
+       Error
+         (Printf.sprintf
+            "provider %S uses antigravity-cli and must declare \
+             is-non-interactive = true"
+            provider.id)
+     | None, None ->
+       Error
+         (Printf.sprintf
+            "provider %S uses antigravity-cli without typed Antigravity options"
+            provider.id)
+     | None, Some options ->
+       Ok
+         (Runtime_execution.Antigravity_cli
+            { cli_path = command
+            ; model = spec.api_name
+            ; agent = options.agent
+            ; effort = Option.map runtime_antigravity_effort options.effort
+            ; execution_mode =
+                runtime_antigravity_execution_mode options.execution_mode
+            ; sandbox = options.sandbox
+            ; disable_slash_commands = options.disable_slash_commands
+            ; timeout_s = options.timeout_s
+            }))
+;;
+
 let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema.binding)
     : (Runtime_execution.t, string) result =
   match Runtime_schema.model_of_id cfg binding.model_id with
@@ -502,6 +562,8 @@ let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema
        (match provider.api_format with
         | Runtime_schema.Codex_app_server_runtime ->
           codex_app_server_execution provider spec
+        | Runtime_schema.Antigravity_cli_runtime ->
+          antigravity_cli_execution provider spec
         | Messages_api | Chat_completions_api | Ollama_api ->
           Result.map
             (fun provider_config -> Runtime_execution.Agent_core provider_config)

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -37,4 +37,5 @@ val binding_to_execution
 (** Materialize the owner of a complete turn. HTTP model APIs become
     {!Runtime_execution.Agent_core}. The exact [codex-app-server] protocol over
     a credential-free CLI transport becomes
-    {!Runtime_execution.Codex_app_server}. Other CLI protocols remain rejected. *)
+    {!Runtime_execution.Codex_app_server}; [antigravity-cli] becomes a typed
+    {!Runtime_execution.Antigravity_cli}. Other CLI protocols remain rejected. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -683,7 +683,8 @@ let input_capabilities_of_runtime (rt : Runtime.t) =
     match rt.Runtime.execution with
     | Runtime_execution.Agent_core provider_config ->
       provider_caps_of_config provider_config
-    | Runtime_execution.Codex_app_server _ ->
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Antigravity_cli _ ->
       Llm_provider.Capabilities.default_capabilities
   in
   apply_runtime_model_input_capabilities

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -600,6 +600,14 @@ let run_spawned ~mgr ~clock ~cwd config ~conversation_mode ~prompt ~on_conversat
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
     let process_status = ref None in
+    let abort_with_runtime_error error =
+      (* SIL-OK: the typed protocol error remains authoritative; the finalizer
+         retries termination and awaits the child if this immediate kill races. *)
+      (try Eio.Process.signal proc Sys.sigkill with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | _ -> ());
+      raise (Runtime_error error)
+    in
     Fun.protect
       ~finally:(fun () ->
         match !process_status with
@@ -611,7 +619,7 @@ let run_spawned ~mgr ~clock ~cwd config ~conversation_mode ~prompt ~on_conversat
            while true do
              let line = Eio.Buf_read.line reader in
              match parse_wire_line line with
-             | Error error -> raise (Runtime_error error)
+             | Error error -> abort_with_runtime_error error
              | Ok event ->
                (match
                   apply_event
@@ -621,7 +629,7 @@ let run_spawned ~mgr ~clock ~cwd config ~conversation_mode ~prompt ~on_conversat
                     !state
                     event
                 with
-                | Error error -> raise (Runtime_error error)
+                | Error error -> abort_with_runtime_error error
                 | Ok next -> state := next)
            done
          with
@@ -681,7 +689,7 @@ let run_turn ?(conversation_mode = Start) ~mgr ~clock ~cwd
       ; wall_duration_s
       }
   | _, Some _, Some (Result_error, _, error, _, _) ->
-    let detail = Option.value ~default:"status=ERROR" error in
+    let detail = match error with Some detail -> detail | None -> "status=ERROR" in
     Error (Turn_failed detail)
   | `Exited 0, _, None ->
     Error (Protocol_error { stage = "process completion"; detail = "missing result event" })

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -483,8 +483,8 @@ let terminate_spawned_process ~clock proc stdin_w =
 ;;
 
 type protocol_state =
-  { init : (string * string * string) option
-  ; result : (string * string * string option * int * usage) option
+  { init : (string * string * permission_mode) option
+  ; result : (result_status * string * string option * int * usage) option
   ; tool_steps : int
   ; tool_errors : int
   }

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -1,0 +1,630 @@
+(** Official Antigravity CLI single-turn execution.
+
+    The [agy] process owns its OAuth session, model turn, and built-in agent
+    tools. MASC owns argv construction, environment admission, process
+    lifetime, strict stream-json decoding, and durable conversation identity. *)
+
+type effort =
+  | Low
+  | Medium
+  | High
+
+type execution_mode =
+  | Plan
+  | Accept_edits
+
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string
+  ; agent : string option
+  ; effort : effort option
+  ; execution_mode : execution_mode
+  ; sandbox : bool
+  ; disable_slash_commands : bool
+  ; timeout_s : float
+  }
+
+let default_timeout_s = 300.0
+let process_termination_grace_s = 2.0
+let stderr_chunk_bytes = 4096
+let stderr_tail_bytes = 8192
+let max_wire_line_bytes = 8 * 1024 * 1024
+
+let default_config ~cwd ~model =
+  { cli_path = "agy"
+  ; cwd
+  ; model
+  ; agent = None
+  ; effort = None
+  ; execution_mode = Plan
+  ; sandbox = false
+  ; disable_slash_commands = true
+  ; timeout_s = default_timeout_s
+  }
+;;
+
+type conversation_mode =
+  | Start
+  | Resume of { conversation_id : string }
+
+type usage =
+  { input_tokens : int
+  ; output_tokens : int
+  ; thinking_tokens : int
+  ; cache_read_tokens : int
+  ; total_tokens : int
+  }
+
+type turn_result =
+  { conversation_id : string
+  ; model : string
+  ; text : string
+  ; num_turns : int
+  ; usage : usage
+  ; permission_mode : string
+  ; tool_steps : int
+  ; tool_errors : int
+  ; resumed : bool
+  ; wall_duration_s : float
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | State_callback_failed of string
+  | Turn_failed of string
+  | Process_exited of string
+  | Timeout of float
+
+exception Runtime_error of error
+
+let error_to_string = function
+  | Invalid_config detail -> "invalid Antigravity CLI config: " ^ detail
+  | Spawn_failed detail -> "failed to start Antigravity CLI: " ^ detail
+  | Protocol_error { stage; detail } ->
+    Printf.sprintf "Antigravity stream-json protocol error during %s: %s" stage detail
+  | State_callback_failed detail -> "Antigravity conversation state callback failed: " ^ detail
+  | Turn_failed detail -> "Antigravity turn failed: " ^ detail
+  | Process_exited detail -> "Antigravity CLI exited before completion: " ^ detail
+  | Timeout seconds -> Printf.sprintf "Antigravity turn timed out after %.3fs" seconds
+;;
+
+let protocol_error stage detail = Error (Protocol_error { stage; detail })
+let ( let* ) result f = Result.bind result f
+
+let rec validate_unique_object_keys ~stage ~path = function
+  | `Assoc fields ->
+    let rec loop seen = function
+      | [] -> Ok ()
+      | (name, value) :: rest ->
+        if List.mem name seen
+        then protocol_error stage (Printf.sprintf "duplicate object key %S at %s" name path)
+        else
+          let* () =
+            validate_unique_object_keys ~stage ~path:(path ^ "." ^ name) value
+          in
+          loop (name :: seen) rest
+    in
+    loop [] fields
+  | `List values ->
+    let rec loop index = function
+      | [] -> Ok ()
+      | value :: rest ->
+        let* () =
+          validate_unique_object_keys
+            ~stage
+            ~path:(Printf.sprintf "%s[%d]" path index)
+            value
+        in
+        loop (index + 1) rest
+    in
+    loop 0 values
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
+;;
+
+let assoc_at stage = function
+  | `Assoc fields -> Ok fields
+  | _ -> protocol_error stage "expected a JSON object"
+;;
+
+let required_member stage name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let required_string ?(nonempty = true) stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) when (not nonempty) || String.trim value <> "" -> Ok value
+  | Some (`String _) ->
+    protocol_error stage (Printf.sprintf "field %S must not be empty" name)
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let optional_string stage name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
+;;
+
+let required_nonnegative_int stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) when value >= 0 -> Ok value
+  | Some (`Int _) ->
+    protocol_error stage (Printf.sprintf "field %S must be non-negative" name)
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be an integer" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let parse_usage stage fields =
+  let* usage_json = required_member stage "usage" fields in
+  let* usage_fields = assoc_at stage usage_json in
+  let* input_tokens = required_nonnegative_int stage "input_tokens" usage_fields in
+  let* output_tokens = required_nonnegative_int stage "output_tokens" usage_fields in
+  let* thinking_tokens = required_nonnegative_int stage "thinking_tokens" usage_fields in
+  let* cache_read_tokens = required_nonnegative_int stage "cache_read_tokens" usage_fields in
+  let* total_tokens = required_nonnegative_int stage "total_tokens" usage_fields in
+  if total_tokens <> input_tokens + output_tokens
+  then
+    protocol_error
+      stage
+      "usage.total_tokens must equal input_tokens + output_tokens"
+  else Ok { input_tokens; output_tokens; thinking_tokens; cache_read_tokens; total_tokens }
+;;
+
+type wire_event =
+  | Init of
+      { conversation_id : string
+      ; model : string
+      ; cwd : string
+      ; permission_mode : string
+      }
+  | Step_update of
+      { conversation_id : string
+      ; state : string
+      ; step_type : string
+      }
+  | Result of
+      { conversation_id : string
+      ; status : string
+      ; response : string
+      ; error : string option
+      ; num_turns : int
+      ; usage : usage
+      }
+
+let parse_init fields =
+  let stage = "init event" in
+  let* conversation_id = required_string stage "conversation_id" fields in
+  let* init_json = required_member stage "init" fields in
+  let* init_fields = assoc_at stage init_json in
+  let* model = required_string stage "model" init_fields in
+  let* cwd = required_string stage "cwd" init_fields in
+  let* permission_mode = required_string stage "permission_mode" init_fields in
+  Ok (Init { conversation_id; model; cwd; permission_mode })
+;;
+
+let parse_step_update fields =
+  let stage = "step_update event" in
+  let* step_json = required_member stage "step_update" fields in
+  let* step_fields = assoc_at stage step_json in
+  let* conversation_id = required_string stage "conversation_id" step_fields in
+  let* _step_index = required_nonnegative_int stage "step_index" step_fields in
+  let* state = required_string stage "state" step_fields in
+  let* step_type = required_string stage "step_type" step_fields in
+  Ok (Step_update { conversation_id; state; step_type })
+;;
+
+let parse_result fields =
+  let stage = "result event" in
+  let* result_json = required_member stage "result" fields in
+  let* result_fields = assoc_at stage result_json in
+  let* conversation_id = required_string stage "conversation_id" result_fields in
+  let* status = required_string stage "status" result_fields in
+  let* response = required_string ~nonempty:false stage "response" result_fields in
+  let* error = optional_string stage "error" result_fields in
+  let* num_turns = required_nonnegative_int stage "num_turns" result_fields in
+  let* usage = parse_usage stage result_fields in
+  Ok (Result { conversation_id; status; response; error; num_turns; usage })
+;;
+
+let parse_wire_line line =
+  let stage = "stream-json message" in
+  let json_result =
+    try Ok (Yojson.Safe.from_string line) with
+    | Yojson.Json_error detail -> protocol_error stage ("invalid JSON: " ^ detail)
+  in
+  let* json = json_result in
+  let* () = validate_unique_object_keys ~stage ~path:"$" json in
+  let* fields = assoc_at stage json in
+  let* event = required_string stage "event" fields in
+  match event with
+  | "init" -> parse_init fields
+  | "step_update" -> parse_step_update fields
+  | "result" -> parse_result fields
+  | other -> protocol_error stage (Printf.sprintf "unsupported event %S" other)
+;;
+
+let effort_to_string = function
+  | Low -> "low"
+  | Medium -> "medium"
+  | High -> "high"
+;;
+
+let execution_mode_to_string = function
+  | Plan -> "plan"
+  | Accept_edits -> "accept-edits"
+;;
+
+let validate_config config ~conversation_mode ~prompt =
+  if String.trim config.cli_path = ""
+  then Error (Invalid_config "cli_path must not be empty")
+  else if String.trim config.cwd = "" || Filename.is_relative config.cwd
+  then Error (Invalid_config "cwd must be an absolute path")
+  else if String.trim config.model = ""
+  then Error (Invalid_config "model must not be empty")
+  else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
+  then Error (Invalid_config "timeout_s must be positive and finite")
+  else if String.trim prompt = ""
+  then Error (Invalid_config "prompt must not be empty")
+  else
+    match config.agent, conversation_mode with
+    | Some agent, _ when String.trim agent = "" ->
+      Error (Invalid_config "agent must not be empty when present")
+    | _, Resume { conversation_id } when String.trim conversation_id = "" ->
+      Error (Invalid_config "resume conversation_id must not be empty")
+    | (None | Some _), (Start | Resume _) -> Ok ()
+;;
+
+let validate_turn ?(conversation_mode = Start) config ~prompt =
+  validate_config config ~conversation_mode ~prompt
+;;
+
+let env_key entry =
+  match String.index_opt entry '=' with
+  | Some index -> String.sub entry 0 index
+  | None -> entry
+;;
+
+let contains_substring value needle =
+  let value_length = String.length value in
+  let needle_length = String.length needle in
+  let rec loop offset =
+    if offset + needle_length > value_length
+    then false
+    else if String.equal (String.sub value offset needle_length) needle
+    then true
+    else loop (offset + 1)
+  in
+  needle_length = 0 || loop 0
+;;
+
+let forbidden_environment_key key =
+  contains_substring key "API_KEY"
+  || contains_substring key "API_TOKEN"
+  || List.mem
+       key
+       [ "GOOGLE_APPLICATION_CREDENTIALS"
+       ; "GOOGLE_GENAI_USE_VERTEXAI"
+       ; "GOOGLE_CLOUD_PROJECT"
+       ; "GOOGLE_CLOUD_LOCATION"
+       ; "GOOGLE_CREDENTIALS"
+       ; "GOOGLE_OAUTH_ACCESS_TOKEN"
+       ; "GOOGLE_ACCESS_TOKEN"
+       ; "CLOUDSDK_AUTH_ACCESS_TOKEN"
+       ; "VERTEX_AI_PROJECT"
+       ; "VERTEX_AI_LOCATION"
+       ; "AGY_ADC_AUTH"
+       ]
+;;
+
+let official_client_environment () =
+  Unix.environment ()
+  |> Array.to_list
+  |> List.filter (fun entry -> not (forbidden_environment_key (env_key entry)))
+  |> Array.of_list
+;;
+
+let duration_argument seconds = Printf.sprintf "%.3fs" seconds
+
+let cli_timeout_s timeout_s = max 0.001 (timeout_s *. 0.95)
+
+let argv config ~conversation_mode ~prompt =
+  let base =
+    [ config.cli_path
+    ; "--print"
+    ; prompt
+    ; "--output-format"
+    ; "stream-json"
+    ; "--model"
+    ; config.model
+    ; "--mode"
+    ; execution_mode_to_string config.execution_mode
+    ; "--add-dir"
+    ; config.cwd
+    ; "--print-timeout"
+    ; duration_argument (cli_timeout_s config.timeout_s)
+    ]
+  in
+  let with_optional flag value values =
+    match value with
+    | None -> values
+    | Some value -> values @ [ flag; value ]
+  in
+  base
+  |> with_optional "--agent" config.agent
+  |> with_optional "--effort" (Option.map effort_to_string config.effort)
+  |> (fun values -> if config.sandbox then values @ [ "--sandbox" ] else values)
+  |> (fun values ->
+    if config.disable_slash_commands then values @ [ "--disable-slash-commands" ] else values)
+  |> (fun values ->
+    match conversation_mode with
+    | Start -> values
+    | Resume { conversation_id } -> values @ [ "--conversation"; conversation_id ])
+;;
+
+let bounded_tail ~limit current addition =
+  let combined = current ^ addition in
+  let length = String.length combined in
+  if length <= limit then combined else String.sub combined (length - limit) limit
+;;
+
+let drain_stderr flow tail =
+  let chunk = Cstruct.create stderr_chunk_bytes in
+  try
+    while true do
+      let count = Eio.Flow.single_read flow chunk in
+      tail :=
+        bounded_tail
+          ~limit:stderr_tail_bytes
+          !tail
+          (Cstruct.to_string (Cstruct.sub chunk 0 count))
+    done
+  with
+  | End_of_file -> ()
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Runtime_agent.debug
+      "Antigravity CLI stderr drain failed: %s"
+      (Printexc.to_string exn)
+;;
+
+let terminate_spawned_process ~clock proc stdin_w =
+  let owning_switch_cancelled = Eio.Fiber.is_cancelled () in
+  Eio.Cancel.protect (fun () ->
+    (try Eio.Flow.close stdin_w with
+     | _ -> ());
+    (try Eio.Process.signal proc Sys.sigterm with
+     | _ -> ());
+    if not owning_switch_cancelled
+    then
+      try
+        Eio.Time.with_timeout_exn clock process_termination_grace_s (fun () ->
+          Eio.Process.await proc |> ignore)
+      with
+      | Eio.Time.Timeout ->
+        (try
+           Eio.Process.signal proc Sys.sigkill;
+           Eio.Process.await proc |> ignore
+         with
+         | _ -> ())
+      | _ -> ())
+;;
+
+type protocol_state =
+  { init : (string * string * string) option
+  ; result : (string * string * string option * int * usage) option
+  ; tool_steps : int
+  ; tool_errors : int
+  }
+
+let initial_protocol_state =
+  { init = None; result = None; tool_steps = 0; tool_errors = 0 }
+;;
+
+let expected_conversation_id = function
+  | Start -> None
+  | Resume { conversation_id } -> Some conversation_id
+;;
+
+let verify_identity ~stage ~expected actual =
+  match expected with
+  | Some value when not (String.equal value actual) ->
+    protocol_error
+      stage
+      (Printf.sprintf "conversation identity mismatch: expected %S, got %S" value actual)
+  | None | Some _ -> Ok ()
+;;
+
+let apply_event (config : config) ~conversation_mode ~on_conversation_ready state = function
+  | Init { conversation_id; model; cwd; permission_mode } ->
+    let stage = "init event" in
+    if Option.is_some state.init
+    then protocol_error stage "received more than one init event"
+    else if Option.is_some state.result
+    then protocol_error stage "received init after result"
+    else
+      let* () =
+        verify_identity
+          ~stage
+          ~expected:(expected_conversation_id conversation_mode)
+          conversation_id
+      in
+      if not (String.equal model config.model)
+      then
+        protocol_error
+          stage
+          (Printf.sprintf "model mismatch: expected %S, got %S" config.model model)
+      else if not (String.equal cwd config.cwd)
+      then
+        protocol_error
+          stage
+          (Printf.sprintf "cwd mismatch: expected %S, got %S" config.cwd cwd)
+      else
+        let callback_result =
+          try on_conversation_ready ~conversation_id with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn -> Error (Printexc.to_string exn)
+        in
+        (match callback_result with
+         | Error detail -> Error (State_callback_failed detail)
+         | Ok () ->
+           Ok { state with init = Some (conversation_id, model, permission_mode) })
+  | Step_update { conversation_id; state = step_state; step_type } ->
+    let stage = "step_update event" in
+    (match state.init with
+     | None -> protocol_error stage "received step_update before init"
+     | Some (expected, _, _) ->
+       let* () = verify_identity ~stage ~expected:(Some expected) conversation_id in
+       if Option.is_some state.result
+       then protocol_error stage "received step_update after result"
+       else
+         let is_tool = String.equal step_type "tool" in
+         Ok
+           { state with
+             tool_steps =
+               state.tool_steps
+               + if is_tool && String.equal step_state "ACTIVE" then 1 else 0
+           ; tool_errors =
+               state.tool_errors
+               + if is_tool && String.equal step_state "ERROR" then 1 else 0
+           })
+  | Result { conversation_id; status; response; error; num_turns; usage } ->
+    let stage = "result event" in
+    (match state.init with
+     | None -> protocol_error stage "received result before init"
+     | Some (expected, _, _) ->
+       let* () = verify_identity ~stage ~expected:(Some expected) conversation_id in
+       if Option.is_some state.result
+       then protocol_error stage "received more than one result event"
+       else Ok { state with result = Some (status, response, error, num_turns, usage) })
+;;
+
+let status_to_string = function
+  | `Exited code -> Printf.sprintf "exit code %d" code
+  | `Signaled signal -> Printf.sprintf "signal %d" signal
+;;
+
+let run_spawned ~mgr ~clock ~cwd config ~conversation_mode ~prompt ~on_conversation_ready =
+  Eio.Switch.run (fun sw ->
+    let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
+    let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
+    let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
+    let stderr_tail = ref "" in
+    let proc =
+      Eio.Process.spawn
+        ~sw
+        mgr
+        ~cwd
+        ~env:(official_client_environment ())
+        ~stdin:stdin_r
+        ~stdout:stdout_w
+        ~stderr:stderr_w
+        (argv config ~conversation_mode ~prompt)
+    in
+    Eio.Flow.close stdin_r;
+    Eio.Flow.close stdin_w;
+    Eio.Flow.close stdout_w;
+    Eio.Flow.close stderr_w;
+    Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
+    let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
+    let process_status = ref None in
+    Fun.protect
+      ~finally:(fun () ->
+        match !process_status with
+        | Some _ -> ()
+        | None -> terminate_spawned_process ~clock proc stdin_w)
+      (fun () ->
+        let state = ref initial_protocol_state in
+        (try
+           while true do
+             let line = Eio.Buf_read.line reader in
+             match parse_wire_line line with
+             | Error error -> raise (Runtime_error error)
+             | Ok event ->
+               (match
+                  apply_event
+                    config
+                    ~conversation_mode
+                    ~on_conversation_ready
+                    !state
+                    event
+                with
+                | Error error -> raise (Runtime_error error)
+                | Ok next -> state := next)
+           done
+         with
+         | End_of_file -> ()
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | Runtime_error _ as exn -> raise exn
+         | exn ->
+           raise
+             (Runtime_error
+                (Protocol_error
+                   { stage = "stdout read"; detail = Printexc.to_string exn })));
+        let status = Eio.Process.await proc in
+        process_status := Some status;
+        status, !state, String.trim !stderr_tail))
+;;
+
+let run_turn ?(conversation_mode = Start) ~mgr ~clock ~cwd
+    ?(on_conversation_ready = fun ~conversation_id:_ -> Ok ()) config ~prompt =
+  let* () = validate_config config ~conversation_mode ~prompt in
+  let started_at = Eio.Time.now clock in
+  let run_result =
+    try
+      Ok
+        (Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+           run_spawned
+             ~mgr
+             ~clock
+             ~cwd
+             config
+             ~conversation_mode
+             ~prompt
+             ~on_conversation_ready))
+    with
+    | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Runtime_error error -> Error error
+    | exn -> Error (Spawn_failed (Printexc.to_string exn))
+  in
+  let* status, state, stderr = run_result in
+  let wall_duration_s = max 0.0 (Eio.Time.now clock -. started_at) in
+  match status, state.init, state.result with
+  | `Exited 0, Some (conversation_id, model, permission_mode),
+    Some ("SUCCESS", text, _, num_turns, usage) ->
+    Ok
+      { conversation_id
+      ; model
+      ; text
+      ; num_turns
+      ; usage
+      ; permission_mode
+      ; tool_steps = state.tool_steps
+      ; tool_errors = state.tool_errors
+      ; resumed =
+          (match conversation_mode with
+           | Start -> false
+           | Resume _ -> true)
+      ; wall_duration_s
+      }
+  | _, Some _, Some (result_status, _, error, _, _)
+    when not (String.equal result_status "SUCCESS") ->
+    let detail = Option.value ~default:("status=" ^ result_status) error in
+    Error (Turn_failed detail)
+  | `Exited 0, _, None ->
+    Error (Protocol_error { stage = "process completion"; detail = "missing result event" })
+  | `Exited 0, None, Some _ ->
+    Error (Protocol_error { stage = "process completion"; detail = "missing init event" })
+  | (`Exited _ | `Signaled _), _, _ ->
+    let exit = status_to_string status in
+    Error (Process_exited (if stderr = "" then exit else exit ^ ": " ^ stderr))
+;;

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -56,13 +56,15 @@ type usage =
   ; total_tokens : int
   }
 
+type permission_mode = Always_proceed
+
 type turn_result =
   { conversation_id : string
   ; model : string
   ; text : string
   ; num_turns : int
   ; usage : usage
-  ; permission_mode : string
+  ; permission_mode : permission_mode
   ; tool_steps : int
   ; tool_errors : int
   ; resumed : bool
@@ -184,21 +186,85 @@ type wire_event =
       { conversation_id : string
       ; model : string
       ; cwd : string
-      ; permission_mode : string
+      ; permission_mode : permission_mode
       }
   | Step_update of
       { conversation_id : string
-      ; state : string
-      ; step_type : string
+      ; state : step_state
+      ; step_type : step_type
       }
   | Result of
       { conversation_id : string
-      ; status : string
+      ; status : result_status
       ; response : string
       ; error : string option
       ; num_turns : int
       ; usage : usage
       }
+
+and step_state =
+  | Active
+  | Done
+  | Step_error
+
+and step_type =
+  | Agent_response
+  | Tool
+
+and result_status =
+  | Success
+  | Result_error
+
+let closed_string stage name parse value =
+  match parse value with
+  | Some value -> Ok value
+  | None ->
+    protocol_error stage (Printf.sprintf "unsupported field %S value %S" name value)
+;;
+
+let parse_permission_mode stage value =
+  closed_string
+    stage
+    "permission_mode"
+    (function
+      | "always-proceed" -> Some Always_proceed
+      | _ -> None)
+    value
+;;
+
+let parse_step_state stage value =
+  closed_string
+    stage
+    "state"
+    (function
+      | "ACTIVE" -> Some Active
+      | "DONE" -> Some Done
+      | "ERROR" -> Some Step_error
+      | _ -> None)
+    value
+;;
+
+let parse_step_type stage value =
+  closed_string
+    stage
+    "step_type"
+    (function
+      | "agent_response" -> Some Agent_response
+      | "tool" -> Some Tool
+      | _ -> None)
+    value
+;;
+
+let parse_result_status stage value =
+  closed_string
+    stage
+    "status"
+    (function
+      | "SUCCESS" -> Some Success
+      | "ERROR" -> Some Result_error
+      | _ -> None)
+    value
+;;
 
 let parse_init fields =
   let stage = "init event" in
@@ -207,7 +273,8 @@ let parse_init fields =
   let* init_fields = assoc_at stage init_json in
   let* model = required_string stage "model" init_fields in
   let* cwd = required_string stage "cwd" init_fields in
-  let* permission_mode = required_string stage "permission_mode" init_fields in
+  let* permission_mode_string = required_string stage "permission_mode" init_fields in
+  let* permission_mode = parse_permission_mode stage permission_mode_string in
   Ok (Init { conversation_id; model; cwd; permission_mode })
 ;;
 
@@ -217,8 +284,10 @@ let parse_step_update fields =
   let* step_fields = assoc_at stage step_json in
   let* conversation_id = required_string stage "conversation_id" step_fields in
   let* _step_index = required_nonnegative_int stage "step_index" step_fields in
-  let* state = required_string stage "state" step_fields in
-  let* step_type = required_string stage "step_type" step_fields in
+  let* state_string = required_string stage "state" step_fields in
+  let* state = parse_step_state stage state_string in
+  let* step_type_string = required_string stage "step_type" step_fields in
+  let* step_type = parse_step_type stage step_type_string in
   Ok (Step_update { conversation_id; state; step_type })
 ;;
 
@@ -227,7 +296,8 @@ let parse_result fields =
   let* result_json = required_member stage "result" fields in
   let* result_fields = assoc_at stage result_json in
   let* conversation_id = required_string stage "conversation_id" result_fields in
-  let* status = required_string stage "status" result_fields in
+  let* status_string = required_string stage "status" result_fields in
+  let* status = parse_result_status stage status_string in
   let* response = required_string ~nonempty:false stage "response" result_fields in
   let* error = optional_string stage "error" result_fields in
   let* num_turns = required_nonnegative_int stage "num_turns" result_fields in
@@ -293,42 +363,36 @@ let env_key entry =
   | None -> entry
 ;;
 
-let contains_substring value needle =
-  let value_length = String.length value in
-  let needle_length = String.length needle in
-  let rec loop offset =
-    if offset + needle_length > value_length
-    then false
-    else if String.equal (String.sub value offset needle_length) needle
-    then true
-    else loop (offset + 1)
-  in
-  needle_length = 0 || loop 0
-;;
-
-let forbidden_environment_key key =
-  contains_substring key "API_KEY"
-  || contains_substring key "API_TOKEN"
-  || List.mem
-       key
-       [ "GOOGLE_APPLICATION_CREDENTIALS"
-       ; "GOOGLE_GENAI_USE_VERTEXAI"
-       ; "GOOGLE_CLOUD_PROJECT"
-       ; "GOOGLE_CLOUD_LOCATION"
-       ; "GOOGLE_CREDENTIALS"
-       ; "GOOGLE_OAUTH_ACCESS_TOKEN"
-       ; "GOOGLE_ACCESS_TOKEN"
-       ; "CLOUDSDK_AUTH_ACCESS_TOKEN"
-       ; "VERTEX_AI_PROJECT"
-       ; "VERTEX_AI_LOCATION"
-       ; "AGY_ADC_AUTH"
-       ]
+let allowed_environment_key key =
+  List.mem
+    key
+    [ "COLORTERM"
+    ; "HOME"
+    ; "LANG"
+    ; "LC_ALL"
+    ; "LC_CTYPE"
+    ; "LOGNAME"
+    ; "PATH"
+    ; "SHELL"
+    ; "SSL_CERT_DIR"
+    ; "SSL_CERT_FILE"
+    ; "TEMP"
+    ; "TERM"
+    ; "TMP"
+    ; "TMPDIR"
+    ; "TZ"
+    ; "USER"
+    ; "XDG_CACHE_HOME"
+    ; "XDG_CONFIG_HOME"
+    ; "XDG_DATA_HOME"
+    ; "XDG_RUNTIME_DIR"
+    ]
 ;;
 
 let official_client_environment () =
   Unix.environment ()
   |> Array.to_list
-  |> List.filter (fun entry -> not (forbidden_environment_key (env_key entry)))
+  |> List.filter (fun entry -> allowed_environment_key (env_key entry))
   |> Array.of_list
 ;;
 
@@ -486,15 +550,15 @@ let apply_event (config : config) ~conversation_mode ~on_conversation_ready stat
        if Option.is_some state.result
        then protocol_error stage "received step_update after result"
        else
-         let is_tool = String.equal step_type "tool" in
+         let is_tool = step_type = Tool in
          Ok
            { state with
              tool_steps =
                state.tool_steps
-               + if is_tool && String.equal step_state "ACTIVE" then 1 else 0
+               + if is_tool && step_state = Active then 1 else 0
            ; tool_errors =
                state.tool_errors
-               + if is_tool && String.equal step_state "ERROR" then 1 else 0
+               + if is_tool && step_state = Step_error then 1 else 0
            })
   | Result { conversation_id; status; response; error; num_turns; usage } ->
     let stage = "result event" in
@@ -600,7 +664,7 @@ let run_turn ?(conversation_mode = Start) ~mgr ~clock ~cwd
   let wall_duration_s = max 0.0 (Eio.Time.now clock -. started_at) in
   match status, state.init, state.result with
   | `Exited 0, Some (conversation_id, model, permission_mode),
-    Some ("SUCCESS", text, _, num_turns, usage) ->
+    Some (Success, text, _, num_turns, usage) ->
     Ok
       { conversation_id
       ; model
@@ -616,9 +680,8 @@ let run_turn ?(conversation_mode = Start) ~mgr ~clock ~cwd
            | Resume _ -> true)
       ; wall_duration_s
       }
-  | _, Some _, Some (result_status, _, error, _, _)
-    when not (String.equal result_status "SUCCESS") ->
-    let detail = Option.value ~default:("status=" ^ result_status) error in
+  | _, Some _, Some (Result_error, _, error, _, _) ->
+    let detail = Option.value ~default:"status=ERROR" error in
     Error (Turn_failed detail)
   | `Exited 0, _, None ->
     Error (Protocol_error { stage = "process completion"; detail = "missing result event" })

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -39,13 +39,15 @@ type usage =
   ; total_tokens : int
   }
 
+type permission_mode = Always_proceed
+
 type turn_result =
   { conversation_id : string
   ; model : string
   ; text : string
   ; num_turns : int
   ; usage : usage
-  ; permission_mode : string
+  ; permission_mode : permission_mode
   ; tool_steps : int
   ; tool_errors : int
   ; resumed : bool

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -1,0 +1,83 @@
+(** A single-turn Antigravity CLI client.
+
+    This is an official-client runtime boundary, not an
+    {!Llm_provider.Llm_transport}. Antigravity owns its OAuth session, model
+    turn, and built-in tools. *)
+
+type effort =
+  | Low
+  | Medium
+  | High
+
+type execution_mode =
+  | Plan
+  | Accept_edits
+
+type config =
+  { cli_path : string
+  ; cwd : string
+  ; model : string
+  ; agent : string option
+  ; effort : effort option
+  ; execution_mode : execution_mode
+  ; sandbox : bool
+  ; disable_slash_commands : bool
+  ; timeout_s : float
+  }
+
+val default_config : cwd:string -> model:string -> config
+
+type conversation_mode =
+  | Start
+  | Resume of { conversation_id : string }
+
+type usage =
+  { input_tokens : int
+  ; output_tokens : int
+  ; thinking_tokens : int
+  ; cache_read_tokens : int
+  ; total_tokens : int
+  }
+
+type turn_result =
+  { conversation_id : string
+  ; model : string
+  ; text : string
+  ; num_turns : int
+  ; usage : usage
+  ; permission_mode : string
+  ; tool_steps : int
+  ; tool_errors : int
+  ; resumed : bool
+  ; wall_duration_s : float
+  }
+
+type error =
+  | Invalid_config of string
+  | Spawn_failed of string
+  | Protocol_error of
+      { stage : string
+      ; detail : string
+      }
+  | State_callback_failed of string
+  | Turn_failed of string
+  | Process_exited of string
+  | Timeout of float
+
+val error_to_string : error -> string
+
+val validate_turn :
+  ?conversation_mode:conversation_mode ->
+  config ->
+  prompt:string ->
+  (unit, error) result
+
+val run_turn :
+  ?conversation_mode:conversation_mode ->
+  mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  cwd:Eio.Fs.dir_ty Eio.Path.t ->
+  ?on_conversation_ready:(conversation_id:string -> (unit, string) result) ->
+  config ->
+  prompt:string ->
+  (turn_result, error) result

--- a/lib/runtime/runtime_execution.ml
+++ b/lib/runtime/runtime_execution.ml
@@ -4,9 +4,21 @@ type codex_app_server =
   ; timeout_s : float
   }
 
+type antigravity_cli =
+  { cli_path : string
+  ; model : string
+  ; agent : string option
+  ; effort : Runtime_antigravity.effort option
+  ; execution_mode : Runtime_antigravity.execution_mode
+  ; sandbox : bool
+  ; disable_slash_commands : bool
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
+  | Antigravity_cli of antigravity_cli
 
 type checkpoint_owner =
   | Masc_oas
@@ -14,20 +26,22 @@ type checkpoint_owner =
 
 let agent_core_provider_config = function
   | Agent_core config -> Some config
-  | Codex_app_server _ -> None
+  | Codex_app_server _ | Antigravity_cli _ -> None
 ;;
 
 let model_id = function
   | Agent_core config -> Some config.Llm_provider.Provider_config.model_id
   | Codex_app_server config -> config.model
+  | Antigravity_cli config -> Some config.model
 ;;
 
 let label = function
   | Agent_core _ -> "agent_core"
   | Codex_app_server _ -> "codex_app_server"
+  | Antigravity_cli _ -> "antigravity_cli"
 ;;
 
 let checkpoint_owner = function
   | Agent_core _ -> Masc_oas
-  | Codex_app_server _ -> Official_client
+  | Codex_app_server _ | Antigravity_cli _ -> Official_client
 ;;

--- a/lib/runtime/runtime_execution.mli
+++ b/lib/runtime/runtime_execution.mli
@@ -2,7 +2,9 @@
 
     [Agent_core] means MASC/OAS owns the model/tool/checkpoint loop.
     [Codex_app_server] means the official Codex client owns the whole turn;
-    MASC owns admission, process lifetime, and result projection. *)
+    [Antigravity_cli] means the official Antigravity client owns its model and
+    built-in tool loop. MASC owns admission, process lifetime, durable session
+    identity, and result projection. *)
 
 type codex_app_server =
   { cli_path : string
@@ -10,9 +12,21 @@ type codex_app_server =
   ; timeout_s : float
   }
 
+type antigravity_cli =
+  { cli_path : string
+  ; model : string
+  ; agent : string option
+  ; effort : Runtime_antigravity.effort option
+  ; execution_mode : Runtime_antigravity.execution_mode
+  ; sandbox : bool
+  ; disable_slash_commands : bool
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
+  | Antigravity_cli of antigravity_cli
 
 type checkpoint_owner =
   | Masc_oas

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -88,6 +88,11 @@ let resolve_runtime_providers ~runtime_id () =
         (Printf.sprintf
            "runtime %S is owned by codex-app-server, not the OAS agent_core"
            rt.Runtime.id)
+    | Runtime_execution.Antigravity_cli _ ->
+      Error
+        (Printf.sprintf
+           "runtime %S is owned by antigravity-cli, not the OAS agent_core"
+           rt.Runtime.id)
   in
   if String.equal runtime_id "" then
     match Runtime.get_default_runtime () with

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -14,6 +14,7 @@ type api_format =
   | Chat_completions_api
   | Ollama_api
   | Codex_app_server_runtime
+  | Antigravity_cli_runtime
 [@@deriving show, eq]
 
 type transport =
@@ -45,6 +46,27 @@ type capabilities =
     per-provider HTTP header injection. *)
 let connect_timeout_s_key = "connect-timeout-s"
 
+type antigravity_effort =
+  | Antigravity_low
+  | Antigravity_medium
+  | Antigravity_high
+[@@deriving show, eq]
+
+type antigravity_execution_mode =
+  | Antigravity_plan
+  | Antigravity_accept_edits
+[@@deriving show, eq]
+
+type antigravity_cli_options =
+  { agent : string option
+  ; effort : antigravity_effort option
+  ; execution_mode : antigravity_execution_mode
+  ; sandbox : bool
+  ; disable_slash_commands : bool
+  ; timeout_s : float
+  }
+[@@deriving show, eq]
+
 type provider =
   { id : string
   ; display_name : string
@@ -63,6 +85,9 @@ type provider =
       on the provider, not the model, because it is a transport property.
       oas#2163, RFC-OAS-026 I2: MASC declares the budget; OAS owns enforcement
       and phase=Http_operation attribution. *)
+  ; antigravity_cli : antigravity_cli_options option
+    (** Typed [antigravity-cli] process options. Present exactly for providers
+        using that protocol; absent for every other transport. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -12,6 +12,7 @@ type api_format =
   | Chat_completions_api
   | Ollama_api
   | Codex_app_server_runtime
+  | Antigravity_cli_runtime
 [@@deriving show, eq]
 
 type transport =
@@ -36,6 +37,27 @@ type capabilities =
 
 val connect_timeout_s_key : string
 
+type antigravity_effort =
+  | Antigravity_low
+  | Antigravity_medium
+  | Antigravity_high
+[@@deriving show, eq]
+
+type antigravity_execution_mode =
+  | Antigravity_plan
+  | Antigravity_accept_edits
+[@@deriving show, eq]
+
+type antigravity_cli_options =
+  { agent : string option
+  ; effort : antigravity_effort option
+  ; execution_mode : antigravity_execution_mode
+  ; sandbox : bool
+  ; disable_slash_commands : bool
+  ; timeout_s : float
+  }
+[@@deriving show, eq]
+
 type provider =
   { id : string
   ; display_name : string
@@ -54,6 +76,8 @@ type provider =
       on the provider, not the model, because it is a transport property.
       oas#2163, RFC-OAS-026 I2: MASC declares the budget; OAS owns enforcement
       and phase=Http_operation attribution. *)
+  ; antigravity_cli : antigravity_cli_options option
+    (** Present exactly when [protocol = "antigravity-cli"]. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -106,7 +106,8 @@ let partition_results
 
 let canonical_protocol_of_protocol = function
   | "messages-cli" | "messages-http" | "openai-compatible-cli"
-  | "openai-compatible-http" | "ollama-http" | "codex-app-server" as protocol ->
+  | "openai-compatible-http" | "ollama-http" | "codex-app-server"
+  | "antigravity-cli" as protocol ->
     Some protocol
   | _ -> None
 ;;
@@ -115,7 +116,7 @@ let unknown_protocol_error s =
   Printf.sprintf
     "unknown protocol %S: expected one of messages-cli, messages-http, \
      openai-compatible-cli, openai-compatible-http, ollama-http, \
-     codex-app-server"
+     codex-app-server, antigravity-cli"
     s
 ;;
 
@@ -128,6 +129,7 @@ let api_format_of_protocol (s : string)
     Ok Runtime_schema.Chat_completions_api
   | "ollama-http" -> Ok Runtime_schema.Ollama_api
   | "codex-app-server" -> Ok Runtime_schema.Codex_app_server_runtime
+  | "antigravity-cli" -> Ok Runtime_schema.Antigravity_cli_runtime
   | _ -> Error (unknown_protocol_error s)
 ;;
 
@@ -267,6 +269,120 @@ let parse_headers (tbl : Otoml.t) (path : string) : (string * string) list =
     List.sort (fun (a, _) (b, _) -> String.compare a b) pairs
 ;;
 
+let antigravity_cli_option_keys =
+  [ "agent"
+  ; "effort"
+  ; "execution-mode"
+  ; "sandbox"
+  ; "disable-slash-commands"
+  ; "timeout-s"
+  ]
+;;
+
+let antigravity_optional_string ~(path : string) (tbl : Otoml.t) key =
+  match typed_find "a string" path tbl key Otoml.get_string with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some value) when String.trim value = "" ->
+    Error (error (path ^ "." ^ key) (key ^ " must be non-empty when present"))
+  | Ok (Some value) when not (String.equal value (String.trim value)) ->
+    Error
+      (error
+         (path ^ "." ^ key)
+         (key ^ " must not have leading or trailing whitespace"))
+  | Ok (Some value) -> Ok (Some value)
+;;
+
+let antigravity_cli_options ~(path : string) (tbl : Otoml.t)
+    (api_format : Runtime_schema.api_format)
+  : (Runtime_schema.antigravity_cli_options option, parse_error list) result
+  =
+  match api_format with
+  | Antigravity_cli_runtime ->
+    let agent_result = antigravity_optional_string ~path tbl "agent" in
+    let effort_result = antigravity_optional_string ~path tbl "effort" in
+    let execution_mode_result =
+      antigravity_optional_string ~path tbl "execution-mode"
+    in
+    let sandbox_result = typed_find "a boolean" path tbl "sandbox" Otoml.get_boolean in
+    let disable_slash_commands_result =
+      typed_find "a boolean" path tbl "disable-slash-commands" Otoml.get_boolean
+    in
+    let timeout_result =
+      strict_float_find path tbl "timeout-s"
+      |> positive_finite_float_opt_field ~path ~key:"timeout-s"
+    in
+    (match
+       agent_result,
+       effort_result,
+       execution_mode_result,
+       sandbox_result,
+       disable_slash_commands_result,
+       timeout_result
+     with
+     | Error errors, _, _, _, _, _
+     | _, Error errors, _, _, _, _
+     | _, _, Error errors, _, _, _
+     | _, _, _, Error errors, _, _
+     | _, _, _, _, Error errors, _
+     | _, _, _, _, _, Error errors -> Error errors
+     | ( Ok agent
+       , Ok effort
+       , Ok execution_mode
+       , Ok sandbox
+       , Ok disable_slash_commands
+       , Ok timeout_s ) ->
+       let effort_result =
+         match effort with
+         | None -> Ok None
+         | Some "low" -> Ok (Some Runtime_schema.Antigravity_low)
+         | Some "medium" -> Ok (Some Runtime_schema.Antigravity_medium)
+         | Some "high" -> Ok (Some Runtime_schema.Antigravity_high)
+         | Some value ->
+           Error
+             (error
+                (path ^ ".effort")
+                (Printf.sprintf "effort must be low, medium, or high; got %S" value))
+       in
+       let execution_mode_result =
+         match execution_mode with
+         | None | Some "plan" -> Ok Runtime_schema.Antigravity_plan
+         | Some "accept-edits" -> Ok Runtime_schema.Antigravity_accept_edits
+         | Some value ->
+           Error
+             (error
+                (path ^ ".execution-mode")
+                (Printf.sprintf
+                   "execution-mode must be plan or accept-edits; got %S"
+                   value))
+       in
+       (match effort_result, execution_mode_result with
+        | Error errors, _ | _, Error errors -> Error errors
+        | Ok effort, Ok execution_mode ->
+          Ok
+            (Some
+               { Runtime_schema.agent
+               ; effort
+               ; execution_mode
+               ; sandbox = Option.value ~default:false sandbox
+               ; disable_slash_commands =
+                   Option.value ~default:true disable_slash_commands
+               ; timeout_s = Option.value ~default:300.0 timeout_s
+               })))
+  | Messages_api | Chat_completions_api | Ollama_api | Codex_app_server_runtime ->
+    (match
+       List.find_opt
+         (fun key -> Option.is_some (Otoml.find_opt tbl Fun.id [ key ]))
+         antigravity_cli_option_keys
+     with
+     | None -> Ok None
+     | Some key ->
+       Error
+         (error
+            (path ^ "." ^ key)
+            (Printf.sprintf "%s is valid only for protocol antigravity-cli" key)))
+;;
+
 let parse_provider (id : string) (tbl : Otoml.t)
   : (Runtime_schema.provider, parse_error list) result
   =
@@ -304,9 +420,10 @@ let parse_provider (id : string) (tbl : Otoml.t)
         Result.map Option.some (parse_credential cred_tbl (path ^ ".credentials"))
       | None -> Ok None
     in
-    (match credentials_result with
-     | Error errs -> Error errs
-     | Ok credentials ->
+    let antigravity_cli_result = antigravity_cli_options ~path tbl api_format in
+    (match credentials_result, antigravity_cli_result with
+     | Error errs, _ | _, Error errs -> Error errs
+     | Ok credentials, Ok antigravity_cli ->
        let capabilities =
          Otoml.find_opt tbl Fun.id [ "capabilities" ]
          |> Option.map (parse_capabilities ~path)
@@ -358,6 +475,7 @@ let parse_provider (id : string) (tbl : Otoml.t)
             ; healthcheck_path
             ; headers
             ; connect_timeout_s
+            ; antigravity_cli
             }))
 ;;
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -359,15 +359,19 @@ let antigravity_cli_options ~(path : string) (tbl : Otoml.t)
        (match effort_result, execution_mode_result with
         | Error errors, _ | _, Error errors -> Error errors
         | Ok effort, Ok execution_mode ->
+          let sandbox = match sandbox with Some value -> value | None -> false in
+          let disable_slash_commands =
+            match disable_slash_commands with Some value -> value | None -> true
+          in
+          let timeout_s = match timeout_s with Some value -> value | None -> 300.0 in
           Ok
             (Some
                { Runtime_schema.agent
                ; effort
                ; execution_mode
-               ; sandbox = Option.value ~default:false sandbox
-               ; disable_slash_commands =
-                   Option.value ~default:true disable_slash_commands
-               ; timeout_s = Option.value ~default:300.0 timeout_s
+               ; sandbox
+               ; disable_slash_commands
+               ; timeout_s
                })))
   | Messages_api | Chat_completions_api | Ollama_api | Codex_app_server_runtime ->
     (match

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -774,7 +774,8 @@ let dashboard_runtime_append_probe_path base ~suffix =
 
 let dashboard_runtime_probe_url ~(api_format : Runtime_schema.api_format) base_url =
   match api_format with
-  | Runtime_schema.Codex_app_server_runtime -> None
+  | Runtime_schema.Codex_app_server_runtime
+  | Runtime_schema.Antigravity_cli_runtime -> None
   | Runtime_schema.Ollama_api ->
     let base = dashboard_runtime_trim_trailing_slashes base_url in
     Some
@@ -884,7 +885,8 @@ let dashboard_runtime_model_count_of_body ~(api_format : Runtime_schema.api_form
   try
     let json = Yojson.Safe.from_string body in
     match api_format with
-    | Runtime_schema.Codex_app_server_runtime -> None
+    | Runtime_schema.Codex_app_server_runtime
+    | Runtime_schema.Antigravity_cli_runtime -> None
     | Runtime_schema.Ollama_api -> dashboard_runtime_list_member_len "models" json
     | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
       (match dashboard_runtime_list_member_len "data" json with
@@ -1546,6 +1548,30 @@ let runtime_request_config_json (rt : Runtime.t) =
       ; "timeout_s", `Float config.timeout_s
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Antigravity_cli config ->
+    `Assoc
+      [ "source", `String "official-client-runtime"
+      ; "execution", `String "antigravity_cli"
+      ; "model", `String config.model
+      ; "agent", Json_util.string_opt_to_json config.agent
+      ; ( "effort"
+        , Json_util.string_opt_to_json
+            (Option.map
+               (function
+                 | Runtime_antigravity.Low -> "low"
+                 | Runtime_antigravity.Medium -> "medium"
+                 | Runtime_antigravity.High -> "high")
+               config.effort) )
+      ; ( "execution_mode"
+        , `String
+            (match config.execution_mode with
+             | Runtime_antigravity.Plan -> "plan"
+             | Runtime_antigravity.Accept_edits -> "accept-edits") )
+      ; "sandbox", `Bool config.sandbox
+      ; "disable_slash_commands", `Bool config.disable_slash_commands
+      ; "timeout_s", `Float config.timeout_s
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core cfg ->
     `Assoc
     [ "source", `String "oas-provider-config"
@@ -1591,6 +1617,7 @@ let runtime_api_format_wire : Runtime_schema.api_format -> string = function
   | Runtime_schema.Chat_completions_api -> "chat-completions"
   | Runtime_schema.Ollama_api -> "ollama"
   | Runtime_schema.Codex_app_server_runtime -> "codex-app-server"
+  | Runtime_schema.Antigravity_cli_runtime -> "antigravity-cli"
 ;;
 
 let runtime_provider_behavior_capabilities_json
@@ -1700,6 +1727,12 @@ let effective_capabilities_json (rt : Runtime.t) =
       ; "execution", `String "codex_app_server"
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Antigravity_cli _ ->
+    `Assoc
+      [ "source", `String "unverified"
+      ; "execution", `String "antigravity_cli"
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core provider_config ->
    (match Llm_provider.Provider_config.capabilities_for_config_model provider_config with
   | None -> `Null
@@ -1780,6 +1813,11 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
       [ "source", `String "official-client-owned"
       ; "execution", `String "codex_app_server"
       ]
+  | Runtime_execution.Antigravity_cli _ ->
+    `Assoc
+      [ "source", `String "official-client-owned"
+      ; "execution", `String "antigravity_cli"
+      ]
   | Runtime_execution.Agent_core provider_config ->
     let dialect = RD.for_provider_config provider_config in
     let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
@@ -1807,7 +1845,8 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
   let runtime_kind = runtime_kind_of_transport rt.provider.transport in
   let is_official_client_runtime =
     match rt.execution with
-    | Runtime_execution.Codex_app_server _ -> true
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Antigravity_cli _ -> true
     | Runtime_execution.Agent_core _ -> false
   in
   let runtime_status =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -96,6 +96,12 @@ let validate_requested_model (runtime : Runtime.t) requested_model =
          "runtime %S is owned by codex-app-server; local_runtime_bench only \
           measures OAS agent_core providers"
          runtime.id)
+  | Runtime_execution.Antigravity_cli _ ->
+    Error
+      (Printf.sprintf
+         "runtime %S is owned by antigravity-cli; local_runtime_bench only \
+          measures OAS agent_core providers"
+         runtime.id)
   | Runtime_execution.Agent_core provider_config ->
     (match requested_model with
      | None -> Ok (runtime, provider_config)

--- a/test/dune
+++ b/test/dune
@@ -1940,6 +1940,7 @@
 (include stanzas/test_keeper_official_client_host.inc)
 (include stanzas/test_runtime_codex_app_server.inc)
 (include stanzas/test_runtime_claude_code.inc)
+(include stanzas/test_runtime_antigravity.inc)
 (include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/stanzas/test_runtime_antigravity.inc
+++ b/test/stanzas/test_runtime_antigravity.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_antigravity)
+ (modules test_runtime_antigravity)
+ (libraries masc masc_test_deps))

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -577,7 +577,8 @@ let test_provider_for_vision_uses_runtime_temperature () =
        | None -> failwith "selected vision runtime should resolve"
        | Some runtime ->
          (match runtime.Runtime.execution with
-          | Runtime_execution.Codex_app_server _ ->
+          | Runtime_execution.Codex_app_server _
+          | Runtime_execution.Antigravity_cli _ ->
             failwith "selected vision runtime should be agent_core"
           | Runtime_execution.Agent_core provider_config ->
             let configured = Vt.provider_for_vision provider_config in

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -54,7 +54,7 @@ let fixture_script ?(require_resume = false) ?(sleep_s = 0.0) ?(exit_code = 0) l
   let output = open_out_bin path in
   output_string output "#!/bin/sh\n";
   output_string output
-    "test -z \"${GEMINI_API_KEY+x}\" && test -z \"${GEMINI_API_KEY_WORK+x}\" && test -z \"${GOOGLE_API_TOKEN+x}\" && test -z \"${OPENAI_API_KEY+x}\" && test -z \"${OPENAI_API_KEY_MAIN+x}\" && test -z \"${ANTHROPIC_API_KEY+x}\" && test -z \"${ANTHROPIC_API_KEY_WORK+x}\" && test -z \"${AGY_ADC_AUTH+x}\" || exit 92\n";
+    "test -z \"${GEMINI_API_KEY+x}\" && test -z \"${GEMINI_API_KEY_WORK+x}\" && test -z \"${GOOGLE_API_TOKEN+x}\" && test -z \"${OPENAI_API_KEY+x}\" && test -z \"${OPENAI_API_KEY_MAIN+x}\" && test -z \"${ANTHROPIC_API_KEY+x}\" && test -z \"${ANTHROPIC_API_KEY_WORK+x}\" && test -z \"${AGY_ADC_AUTH+x}\" && test -z \"${MASC_PUBLIC_FIXTURE+x}\" || exit 92\n";
   if require_resume
   then
     output_string
@@ -106,9 +106,21 @@ let test_successful_official_client_turn () =
          check int "turn count" 1 turn.num_turns;
          check int "input tokens" 100 turn.usage.input_tokens;
          check int "total tokens" 107 turn.usage.total_tokens;
-         check string "permission mode" "always-proceed" turn.permission_mode;
+         check
+           bool
+           "permission mode"
+           true
+           (turn.permission_mode = Runtime_antigravity.Always_proceed);
          check bool "new conversation" false turn.resumed;
          check bool "measured wall duration" true (turn.wall_duration_s >= 0.0))
+;;
+
+let test_child_environment_is_allowlisted () =
+  Unix.putenv "MASC_PUBLIC_FIXTURE" "must-not-leak";
+  with_fixture [ init (); result () ] (fun path ->
+    match run_fixture path with
+    | Error error -> fail (Runtime_antigravity.error_to_string error)
+    | Ok _ -> ())
 ;;
 
 let test_resume_requires_exact_identity_and_argv () =
@@ -212,6 +224,27 @@ let test_duplicate_keys_fail_closed () =
        | Ok _ -> fail "duplicate key was admitted")
 ;;
 
+let test_unknown_protocol_vocabulary_fails_closed () =
+  let unknown_permission =
+    {|{"event":"init","conversation_id":"conversation-1","init":{"model":"gemini-fixture","cwd":"/tmp","permission_mode":"unreviewed"}}|}
+  in
+  let cases =
+    [ "permission mode", [ unknown_permission; result () ]
+    ; "step state", [ init (); step ~state:"PAUSED" (); result () ]
+    ; "step type", [ init (); step ~step_type:"shell" (); result () ]
+    ; "result status", [ init (); result ~status:"PARTIAL" () ]
+    ]
+  in
+  List.iter
+    (fun (name, lines) ->
+      with_fixture lines (fun path ->
+        match run_fixture path with
+        | Error (Runtime_antigravity.Protocol_error _) -> ()
+        | Error error -> fail (name ^ ": " ^ Runtime_antigravity.error_to_string error)
+        | Ok _ -> fail (name ^ " was admitted")))
+    cases
+;;
+
 let test_timeout_is_typed () =
   with_fixture
     ~sleep_s:1.0
@@ -301,6 +334,10 @@ let () =
             `Quick
             test_resume_identity_mismatch_fails_closed
         ; test_case
+            "child environment allowlist"
+            `Quick
+            test_child_environment_is_allowlisted
+        ; test_case
             "conversation callback"
             `Quick
             test_conversation_callback_precedes_terminal_result
@@ -311,6 +348,10 @@ let () =
         ; test_case "tool measurements" `Quick test_tool_steps_and_errors_are_measured
         ; test_case "error result" `Quick test_result_error_is_not_success
         ; test_case "duplicate keys" `Quick test_duplicate_keys_fail_closed
+        ; test_case
+            "unknown protocol vocabulary"
+            `Quick
+            test_unknown_protocol_vocabulary_fails_closed
         ; test_case "typed timeout" `Quick test_timeout_is_typed
         ; test_case "process-free admission" `Quick test_admission_is_process_free
         ] )

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -1,0 +1,319 @@
+open Alcotest
+open Masc
+
+let init ?(conversation_id = "conversation-1") ?(model = "gemini-fixture") () =
+  Printf.sprintf
+    {|{"event":"init","conversation_id":%S,"init":{"model":%S,"cwd":"/tmp","tools":["view_file"],"permission_mode":"always-proceed"}}|}
+    conversation_id
+    model
+;;
+
+let step
+    ?(conversation_id = "conversation-1")
+    ?(index = 1)
+    ?(state = "DONE")
+    ?(step_type = "agent_response")
+    ()
+  =
+  Printf.sprintf
+    {|{"event":"step_update","step_update":{"conversation_id":%S,"step_index":%d,"state":%S,"step_type":%S}}|}
+    conversation_id
+    index
+    state
+    step_type
+;;
+
+let result
+    ?(conversation_id = "conversation-1")
+    ?(status = "SUCCESS")
+    ?(response = "MASC_ANTIGRAVITY_OK\n")
+    ?error
+    ?(num_turns = 1)
+    ()
+  =
+  let error_field =
+    match error with
+    | None -> ""
+    | Some value -> Printf.sprintf ",\"error\":%S" value
+  in
+  Printf.sprintf
+    {|{"event":"result","result":{"conversation_id":%S,"status":%S,"response":%S%s,"duration_seconds":5.5,"num_turns":%d,"usage":{"input_tokens":100,"output_tokens":7,"thinking_tokens":3,"cache_read_tokens":50,"total_tokens":107}}}|}
+    conversation_id
+    status
+    response
+    error_field
+    num_turns
+;;
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let fixture_script ?(require_resume = false) ?(sleep_s = 0.0) ?(exit_code = 0) lines =
+  let path = Filename.temp_file "masc-antigravity-" ".sh" in
+  let output = open_out_bin path in
+  output_string output "#!/bin/sh\n";
+  output_string output
+    "test -z \"${GEMINI_API_KEY+x}\" && test -z \"${GEMINI_API_KEY_WORK+x}\" && test -z \"${GOOGLE_API_TOKEN+x}\" && test -z \"${OPENAI_API_KEY+x}\" && test -z \"${OPENAI_API_KEY_MAIN+x}\" && test -z \"${ANTHROPIC_API_KEY+x}\" && test -z \"${ANTHROPIC_API_KEY_WORK+x}\" && test -z \"${AGY_ADC_AUTH+x}\" || exit 92\n";
+  if require_resume
+  then
+    output_string
+      output
+      "case \" $* \" in *\" --conversation conversation-1 \"*) ;; *) exit 93 ;; esac\n";
+  if sleep_s > 0.0 then output_string output (Printf.sprintf "sleep %.3f\n" sleep_s);
+  List.iter
+    (fun line -> output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
+    lines;
+  output_string output (Printf.sprintf "exit %d\n" exit_code);
+  close_out output;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let with_fixture ?require_resume ?sleep_s ?exit_code lines f =
+  let path = fixture_script ?require_resume ?sleep_s ?exit_code lines in
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let run_fixture ?conversation_mode ?on_conversation_ready ?(timeout_s = 2.0) path =
+  Eio_main.run (fun env ->
+    let config =
+      { (Runtime_antigravity.default_config ~cwd:"/tmp" ~model:"gemini-fixture") with
+        cli_path = path
+      ; timeout_s
+      }
+    in
+    Runtime_antigravity.run_turn
+      ?conversation_mode
+      ?on_conversation_ready
+      ~mgr:(Eio.Stdenv.process_mgr env)
+      ~clock:(Eio.Stdenv.clock env)
+      ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+      config
+      ~prompt:"Return the fixture marker")
+;;
+
+let test_successful_official_client_turn () =
+  with_fixture
+    [ init (); step (); result () ]
+    (fun path ->
+       match run_fixture path with
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok turn ->
+         check string "conversation" "conversation-1" turn.conversation_id;
+         check string "model" "gemini-fixture" turn.model;
+         check string "text" "MASC_ANTIGRAVITY_OK\n" turn.text;
+         check int "turn count" 1 turn.num_turns;
+         check int "input tokens" 100 turn.usage.input_tokens;
+         check int "total tokens" 107 turn.usage.total_tokens;
+         check string "permission mode" "always-proceed" turn.permission_mode;
+         check bool "new conversation" false turn.resumed;
+         check bool "measured wall duration" true (turn.wall_duration_s >= 0.0))
+;;
+
+let test_resume_requires_exact_identity_and_argv () =
+  with_fixture
+    ~require_resume:true
+    [ init (); step ~index:4 (); result ~num_turns:2 () ]
+    (fun path ->
+       match
+         run_fixture
+           ~conversation_mode:
+             (Runtime_antigravity.Resume { conversation_id = "conversation-1" })
+           path
+       with
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok turn ->
+         check bool "resumed" true turn.resumed;
+         check int "cumulative turn count" 2 turn.num_turns)
+;;
+
+let test_resume_identity_mismatch_fails_closed () =
+  with_fixture
+    [ init ~conversation_id:"different" (); result ~conversation_id:"different" () ]
+    (fun path ->
+       match
+         run_fixture
+           ~conversation_mode:
+             (Runtime_antigravity.Resume { conversation_id = "conversation-1" })
+           path
+       with
+       | Error (Runtime_antigravity.Protocol_error _) -> ()
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok _ -> fail "resume admitted a different conversation")
+;;
+
+let test_conversation_callback_precedes_terminal_result () =
+  let observed = ref None in
+  with_fixture
+    [ init (); result () ]
+    (fun path ->
+       match
+         run_fixture
+           ~on_conversation_ready:(fun ~conversation_id ->
+             observed := Some conversation_id;
+             Ok ())
+           path
+       with
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok _ -> check (option string) "callback identity" (Some "conversation-1") !observed)
+;;
+
+let test_conversation_callback_failure_is_typed () =
+  with_fixture [ init (); result () ] (fun path ->
+    match
+      run_fixture
+        ~on_conversation_ready:(fun ~conversation_id:_ -> failwith "fixture callback")
+        path
+    with
+    | Error (Runtime_antigravity.State_callback_failed _) -> ()
+    | Error error -> fail (Runtime_antigravity.error_to_string error)
+    | Ok _ -> fail "callback exception was admitted as a successful turn")
+;;
+
+let test_tool_steps_and_errors_are_measured () =
+  with_fixture
+    [ init ()
+    ; step ~index:1 ~state:"ACTIVE" ~step_type:"tool" ()
+    ; step ~index:1 ~state:"ERROR" ~step_type:"tool" ()
+    ; step ~index:2 ~state:"ACTIVE" ~step_type:"tool" ()
+    ; step ~index:2 ~state:"DONE" ~step_type:"tool" ()
+    ; result ()
+    ]
+    (fun path ->
+       match run_fixture path with
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok turn ->
+         check int "tool starts" 2 turn.tool_steps;
+         check int "tool errors" 1 turn.tool_errors)
+;;
+
+let test_result_error_is_not_success () =
+  with_fixture
+    ~exit_code:1
+    [ init (); result ~status:"ERROR" ~response:"" ~error:"timeout waiting for response" () ]
+    (fun path ->
+       match run_fixture path with
+       | Error (Runtime_antigravity.Turn_failed "timeout waiting for response") -> ()
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok _ -> fail "ERROR result was admitted as success")
+;;
+
+let test_duplicate_keys_fail_closed () =
+  let duplicate =
+    {|{"event":"init","event":"init","conversation_id":"conversation-1","init":{"model":"gemini-fixture","cwd":"/tmp","permission_mode":"always-proceed"}}|}
+  in
+  with_fixture
+    [ duplicate; result () ]
+    (fun path ->
+       match run_fixture path with
+       | Error (Runtime_antigravity.Protocol_error _) -> ()
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok _ -> fail "duplicate key was admitted")
+;;
+
+let test_timeout_is_typed () =
+  with_fixture
+    ~sleep_s:1.0
+    [ init (); result () ]
+    (fun path ->
+       match run_fixture ~timeout_s:0.05 path with
+       | Error (Runtime_antigravity.Timeout _) -> ()
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok _ -> fail "slow CLI ignored the runtime timeout")
+;;
+
+let test_admission_is_process_free () =
+  let config =
+    { (Runtime_antigravity.default_config ~cwd:"relative" ~model:"gemini-fixture") with
+      cli_path = ""
+    }
+  in
+  match Runtime_antigravity.validate_turn config ~prompt:"fixture" with
+  | Error (Runtime_antigravity.Invalid_config "cli_path must not be empty") -> ()
+  | Error error -> fail (Runtime_antigravity.error_to_string error)
+  | Ok () -> fail "invalid deterministic config passed admission"
+;;
+
+let test_live_start_and_resume () =
+  match Sys.getenv_opt "MASC_ANTIGRAVITY_LIVE", Sys.getenv_opt "MASC_ANTIGRAVITY_MODEL" with
+  | Some "1", Some model ->
+    let cwd = Sys.getcwd () in
+    let cli_path = Option.value ~default:"agy" (Sys.getenv_opt "MASC_ANTIGRAVITY_CLI") in
+    let first, second =
+      Eio_main.run (fun env ->
+        let config =
+          { (Runtime_antigravity.default_config ~cwd ~model) with
+            cli_path
+          ; timeout_s = 60.0
+          }
+        in
+        let run ?conversation_mode prompt =
+          Runtime_antigravity.run_turn
+            ?conversation_mode
+            ~mgr:(Eio.Stdenv.process_mgr env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~cwd:Eio.Path.(Eio.Stdenv.fs env / cwd)
+            config
+            ~prompt
+        in
+        let first = run "Reply with exactly: MASC_ANTIGRAVITY_LIVE_OK" in
+        let second =
+          match first with
+          | Error _ as error -> error
+          | Ok turn ->
+            run
+              ~conversation_mode:
+                (Runtime_antigravity.Resume
+                   { conversation_id = turn.conversation_id })
+              "Reply with exactly: MASC_ANTIGRAVITY_LIVE_RESUMED"
+        in
+        first, second)
+    in
+    (match first, second with
+     | Ok first, Ok second ->
+       check string "first live response" "MASC_ANTIGRAVITY_LIVE_OK\n" first.text;
+       check string
+         "resumed live response"
+         "MASC_ANTIGRAVITY_LIVE_RESUMED\n"
+         second.text;
+       check string "same conversation" first.conversation_id second.conversation_id;
+       check bool "cumulative turns" true (second.num_turns >= 2)
+     | Error error, _ | _, Error error ->
+       fail (Runtime_antigravity.error_to_string error))
+  | _ -> Alcotest.skip ()
+;;
+
+let () =
+  run
+    "runtime_antigravity"
+    [ ( "stream-json"
+      , [ test_case
+            "successful official-client turn"
+            `Quick
+            test_successful_official_client_turn
+        ; test_case
+            "resume identity and argv"
+            `Quick
+            test_resume_requires_exact_identity_and_argv
+        ; test_case
+            "resume mismatch"
+            `Quick
+            test_resume_identity_mismatch_fails_closed
+        ; test_case
+            "conversation callback"
+            `Quick
+            test_conversation_callback_precedes_terminal_result
+        ; test_case
+            "conversation callback failure"
+            `Quick
+            test_conversation_callback_failure_is_typed
+        ; test_case "tool measurements" `Quick test_tool_steps_and_errors_are_measured
+        ; test_case "error result" `Quick test_result_error_is_not_success
+        ; test_case "duplicate keys" `Quick test_duplicate_keys_fail_closed
+        ; test_case "typed timeout" `Quick test_timeout_is_typed
+        ; test_case "process-free admission" `Quick test_admission_is_process_free
+        ] )
+    ; "live official client", [ test_case "official agy start and resume" `Slow test_live_start_and_resume ]
+    ]
+;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -13,7 +13,8 @@ let parse_or_fail content =
 let agent_core_provider_config (runtime : Runtime.t) =
   match runtime.execution with
   | Runtime_execution.Agent_core provider_config -> provider_config
-  | Runtime_execution.Codex_app_server _ ->
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Antigravity_cli _ ->
     failf "runtime %s is not an agent_core provider" runtime.id
 ;;
 
@@ -3158,13 +3159,14 @@ let test_runtime_assignment_default_rider_resolves_to_default_runtime () =
              "local.good"
              (Runtime.get_default_runtime_id ())))
 
-let codex_app_server_runtime_toml ?credential () =
+let codex_app_server_runtime_toml ?credential ?(options = "") () =
   let credential = Option.value credential ~default:"" in
   Printf.sprintf
     "[providers.codex]\n\
      protocol = \"codex-app-server\"\n\
      command = \"codex\"\n\
      is-non-interactive = true\n\
+     %s\n\
      %s\n\
      [models.codex]\n\
      api-name = \"gpt-5.6-sol\"\n\
@@ -3174,6 +3176,7 @@ let codex_app_server_runtime_toml ?credential () =
      \n\
      [runtime]\n\
      default = \"codex.codex\"\n"
+    options
     credential
 ;;
 
@@ -3189,7 +3192,117 @@ let test_codex_app_server_materializes_as_turn_runtime () =
          fail "codex-app-server was incorrectly materialized as agent_core"
        | Runtime_execution.Codex_app_server config ->
          check string "cli path" "codex" config.cli_path;
-         check (option string) "model" (Some "gpt-5.6-sol") config.model))
+         check (option string) "model" (Some "gpt-5.6-sol") config.model
+       | Runtime_execution.Antigravity_cli _ ->
+         fail "codex-app-server was incorrectly materialized as antigravity-cli"))
+;;
+
+let antigravity_cli_runtime_toml ?credential ?(options = "") () =
+  let credential = Option.value credential ~default:"" in
+  Printf.sprintf
+    "[providers.antigravity]\n\
+     protocol = \"antigravity-cli\"\n\
+     command = \"agy\"\n\
+     is-non-interactive = true\n\
+     %s\n\
+     %s\n\
+     [models.gemini]\n\
+     api-name = \"gemini-3.6-flash-high\"\n\
+     max-context = 128000\n\
+     \n\
+     [antigravity.gemini]\n\
+     \n\
+     [runtime]\n\
+     default = \"antigravity.gemini\"\n"
+    options
+    credential
+;;
+
+let test_antigravity_cli_materializes_typed_process_options () =
+  let options =
+    "agent = \"fixture-agent\"\n\
+     effort = \"high\"\n\
+     execution-mode = \"accept-edits\"\n\
+     sandbox = true\n\
+     disable-slash-commands = false\n\
+     timeout-s = 45.0"
+  in
+  with_temp_runtime_toml
+    (antigravity_cli_runtime_toml ~options ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Error error -> failf "antigravity-cli runtime should load: %s" error
+       | Ok (runtimes, default, _, _, _, _) ->
+         check int "one runtime" 1 (List.length runtimes);
+         check string "default id" "antigravity.gemini" default.id;
+         (match default.execution with
+          | Runtime_execution.Antigravity_cli config ->
+            check string "cli path" "agy" config.cli_path;
+            check string "model" "gemini-3.6-flash-high" config.model;
+            check (option string) "agent" (Some "fixture-agent") config.agent;
+            check bool
+              "effort"
+              true
+              (config.effort = Some Runtime_antigravity.High);
+            check bool
+              "execution mode"
+              true
+              (config.execution_mode = Runtime_antigravity.Accept_edits);
+            check bool "sandbox" true config.sandbox;
+            check bool "slash commands" false config.disable_slash_commands;
+            check (float 0.0) "timeout" 45.0 config.timeout_s
+          | Runtime_execution.Agent_core _ | Runtime_execution.Codex_app_server _ ->
+            fail "antigravity-cli was materialized through the wrong execution owner"))
+;;
+
+let test_antigravity_cli_defaults_are_explicit () =
+  with_temp_runtime_toml (antigravity_cli_runtime_toml ()) (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error error -> failf "antigravity-cli runtime should load: %s" error
+    | Ok (_, default, _, _, _, _) ->
+      (match default.execution with
+       | Runtime_execution.Antigravity_cli config ->
+         check (option string) "agent" None config.agent;
+         check bool "effort" true (config.effort = None);
+         check bool "plan" true (config.execution_mode = Runtime_antigravity.Plan);
+         check bool "sandbox opt-in" false config.sandbox;
+         check bool "slash expansion disabled" true config.disable_slash_commands;
+         check (float 0.0) "timeout" 300.0 config.timeout_s
+       | Runtime_execution.Agent_core _ | Runtime_execution.Codex_app_server _ ->
+         fail "antigravity-cli was materialized through the wrong execution owner"))
+;;
+
+let test_antigravity_cli_rejects_declared_credentials () =
+  let credential =
+    "[providers.antigravity.credentials]\n\
+     type = \"env\"\n\
+     key = \"GEMINI_API_KEY\""
+  in
+  with_temp_runtime_toml
+    (antigravity_cli_runtime_toml ~credential ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> fail "antigravity-cli incorrectly admitted declared credentials"
+       | Error error ->
+         check bool "diagnostic names official login ownership" true
+           (String_util.contains_substring
+              error
+              "official Antigravity client owns login state"))
+;;
+
+let test_antigravity_options_are_protocol_scoped () =
+  with_temp_runtime_toml
+    (codex_app_server_runtime_toml
+       ~options:"execution-mode = \"accept-edits\""
+       ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> fail "codex-app-server silently admitted an Antigravity option"
+       | Error error ->
+         check bool "diagnostic names scoped option" true
+           (String_util.contains_substring
+              error
+              "execution-mode is valid only for protocol antigravity-cli"))
 ;;
 
 let test_codex_app_server_rejects_declared_credentials () =
@@ -3219,6 +3332,14 @@ let () =
             test_codex_app_server_materializes_as_turn_runtime;
           test_case "codex app-server rejects declared credentials" `Quick
             test_codex_app_server_rejects_declared_credentials;
+          test_case "antigravity CLI options materialize" `Quick
+            test_antigravity_cli_materializes_typed_process_options;
+          test_case "antigravity CLI defaults are explicit" `Quick
+            test_antigravity_cli_defaults_are_explicit;
+          test_case "antigravity CLI rejects declared credentials" `Quick
+            test_antigravity_cli_rejects_declared_credentials;
+          test_case "antigravity options are protocol-scoped" `Quick
+            test_antigravity_options_are_protocol_scoped;
           test_case "deployment OAS catalog covers live RunPod MTP runtime" `Quick
             test_deployment_oas_model_catalog_covers_live_runpod_mtp;
           test_case

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -40,6 +40,7 @@ let runpod_provider =
   ; healthcheck_path = None
   ; headers = None
   ; connect_timeout_s = None
+  ; antigravity_cli = None
   }
 
 let qwen_model =

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -362,7 +362,8 @@ max-concurrent = 1
             && String.equal err.message
                  "unknown protocol \"openai-http\": expected one of \
                   messages-cli, messages-http, openai-compatible-cli, \
-                  openai-compatible-http, ollama-http, codex-app-server")
+                  openai-compatible-http, ollama-http, codex-app-server, \
+                  antigravity-cli")
          errors)
 
 let test_runtime_toml_accepts_messages_caching_capability () =


### PR DESCRIPTION
## Summary

- add an argv-only official Antigravity CLI runtime over agy stream-json
- preserve and verify conversation identity across start and resume
- project measured usage, permission mode, tool starts, tool failures, and MASC wall duration
- remove provider API keys, API tokens, Vertex selectors, service-account credentials, and AGY_ADC_AUTH from the child environment
- expose typed plan or accept-edits and optional sandbox settings without using dangerously-skip-permissions
- run the focused runtime suite in CI

## Verification

- focused build: test/test_runtime_antigravity.exe
- fixture suite: 10 passed, live skipped by default
- official agy 1.1.11 live start plus resume: 1 passed in 23.779s with gemini-3.6-flash-high
- CI target audit: 156 targets declared, 701 unwired at baseline

## Stack

- depends on #27770
- runtime.toml, Keeper settlement, and Dashboard evidence remain separate follow-up PRs