### PR TITLE
Keeper single-owner hard cut v2

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -41,9 +41,6 @@ type tool_surface_metrics =
 let owned_active_task_id_for_meta =
   Keeper_current_task_reconcile.owned_active_task_id_for_meta
 
-let merge_current_task_id =
-  Keeper_current_task_reconcile.merge_current_task_id
-
 let sync_current_task_id_from_backlog =
   Keeper_current_task_reconcile.sync_current_task_id_from_backlog
 

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -33,12 +33,6 @@ val owned_active_task_id_for_meta :
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_id.Task_id.t option
 
-(** Field-level merge for [write_meta_with_merge]. *)
-val merge_current_task_id :
-  latest:Keeper_meta_contract.keeper_meta ->
-  caller:Keeper_meta_contract.keeper_meta ->
-  Keeper_meta_contract.keeper_meta
-
 (** Reconcile [meta.current_task_id] with the backlog. *)
 val sync_current_task_id_from_backlog :
   config:Workspace.config ->

--- a/lib/keeper/keeper_chat_operation_store.ml
+++ b/lib/keeper/keeper_chat_operation_store.ml
@@ -1,0 +1,1386 @@
+type source =
+  | Dashboard of { thread_id : string }
+  | Discord of
+      { channel_id : string
+      ; user_id : string
+      }
+  | Slack of
+      { channel_id : string
+      ; user_id : string
+      ; user_name : string
+      ; team_id : string option
+      ; thread_ts : string option
+      }
+
+type input =
+  { content : string
+  ; user_blocks : Keeper_multimodal_input.user_input_block list
+  ; attachments : Keeper_chat_store.attachment list
+  ; submitted_at : float
+  ; source : source
+  ; user_row_origin : Keeper_chat_store.user_row_origin
+  }
+
+type edit_input =
+  { content : string
+  ; user_blocks : Keeper_multimodal_input.user_input_block list
+  ; attachments : Keeper_chat_store.attachment list
+  }
+
+type failure_kind =
+  | Interrupted_by_restart
+  | Turn_failed
+  | No_visible_reply
+  | Transcript_persist_failed
+  | Connector_unavailable
+  | Delivery_failed
+  | Terminal_effect_failed
+  | Internal_error
+
+type state =
+  | Queued
+  | Running of { started_at : float }
+  | Succeeded of
+      { completed_at : float
+      ; outcome_ref : string
+      }
+  | Failed of
+      { completed_at : float
+      ; kind : failure_kind
+      ; detail : string
+      ; outcome_ref : string option
+      }
+  | Cancelled of { completed_at : float }
+
+type operation =
+  { operation_id : string
+  ; admission_digest : string
+  ; execution_digest : string
+  ; sequence : int64
+  ; input : input option
+  ; state : state
+  }
+
+type error =
+  | Unknown_operation of string
+  | Not_queued of
+      { operation_id : string
+      ; state : state
+      }
+  | Idempotency_conflict of string
+  | Invalid_input of string
+  | Store_unavailable of string
+
+type submit_result =
+  | Accepted of operation
+  | Existing of operation
+
+type t =
+  { db : Sqlite3.db
+  ; path : string
+  ; ownership_root : string
+  ; mutable closed : bool
+  }
+
+let ( let* ) = Result.bind
+
+let database_schema = "masc.keeper_chat_operations.v1"
+let database_user_version = 1L
+let database_application_id = 0x4d434f50L
+let database_file = "chat-operations.sqlite3"
+
+type commit_fault =
+  | Before_commit
+  | After_commit
+
+let commit_fault_for_testing : commit_fault option Atomic.t = Atomic.make None
+
+let failure_kind_to_string = function
+  | Interrupted_by_restart -> "interrupted_by_restart"
+  | Turn_failed -> "turn_failed"
+  | No_visible_reply -> "no_visible_reply"
+  | Transcript_persist_failed -> "transcript_persist_failed"
+  | Connector_unavailable -> "connector_unavailable"
+  | Delivery_failed -> "delivery_failed"
+  | Terminal_effect_failed -> "terminal_effect_failed"
+  | Internal_error -> "internal_error"
+;;
+
+let failure_kind_of_string = function
+  | "interrupted_by_restart" -> Ok Interrupted_by_restart
+  | "turn_failed" -> Ok Turn_failed
+  | "no_visible_reply" -> Ok No_visible_reply
+  | "transcript_persist_failed" -> Ok Transcript_persist_failed
+  | "connector_unavailable" -> Ok Connector_unavailable
+  | "delivery_failed" -> Ok Delivery_failed
+  | "terminal_effect_failed" -> Ok Terminal_effect_failed
+  | "internal_error" -> Ok Internal_error
+  | value -> Error ("unknown operation failure kind: " ^ value)
+;;
+
+let error_to_string = function
+  | Unknown_operation operation_id -> "unknown operation: " ^ operation_id
+  | Not_queued { operation_id; _ } -> "operation is not queued: " ^ operation_id
+  | Idempotency_conflict operation_id ->
+    "operation id was already submitted with different input: " ^ operation_id
+  | Invalid_input detail -> "invalid operation input: " ^ detail
+  | Store_unavailable detail -> "chat operation store unavailable: " ^ detail
+;;
+
+let store_error detail = Error (Store_unavailable detail)
+
+let valid_nonempty value =
+  let value = String.trim value in
+  value <> "" && String.is_valid_utf_8 value && not (String.contains value '\000')
+;;
+
+let validate_optional label = function
+  | None -> Ok ()
+  | Some value when valid_nonempty value -> Ok ()
+  | Some _ -> Error (Invalid_input (label ^ " must be non-empty UTF-8 when present"))
+;;
+
+let validate_source = function
+  | Dashboard { thread_id } ->
+    if valid_nonempty thread_id
+    then Ok ()
+    else Error (Invalid_input "dashboard thread_id must be non-empty UTF-8")
+  | Discord { channel_id; user_id } ->
+    if not (valid_nonempty channel_id)
+    then Error (Invalid_input "discord channel_id must be non-empty UTF-8")
+    else if not (valid_nonempty user_id)
+    then Error (Invalid_input "discord user_id must be non-empty UTF-8")
+    else Ok ()
+  | Slack { channel_id; user_id; user_name; team_id; thread_ts } ->
+    if not (valid_nonempty channel_id)
+    then Error (Invalid_input "slack channel_id must be non-empty UTF-8")
+    else if not (valid_nonempty user_id)
+    then Error (Invalid_input "slack user_id must be non-empty UTF-8")
+    else if not (valid_nonempty user_name)
+    then Error (Invalid_input "slack user_name must be non-empty UTF-8")
+    else
+      let* () = validate_optional "slack team_id" team_id in
+      validate_optional "slack thread_ts" thread_ts
+;;
+
+let validate_body ~content ~user_blocks ~attachments =
+  if not (String.is_valid_utf_8 content) || String.contains content '\000'
+  then Error (Invalid_input "content must be UTF-8 without NUL")
+  else if String.trim content = "" && user_blocks = [] && attachments = []
+  then Error (Invalid_input "operation input has no content or media")
+  else Ok ()
+;;
+
+let validate_input (input : input) =
+  if not (Float.is_finite input.submitted_at)
+  then Error (Invalid_input "submitted_at must be finite")
+  else
+    let* () = validate_source input.source in
+    validate_body
+      ~content:input.content
+      ~user_blocks:input.user_blocks
+      ~attachments:input.attachments
+;;
+
+let validate_edit input =
+  validate_body
+    ~content:input.content
+    ~user_blocks:input.user_blocks
+    ~attachments:input.attachments
+;;
+
+let validate_operation_id operation_id =
+  if not (valid_nonempty operation_id)
+  then Error (Invalid_input "operation_id must be non-empty UTF-8")
+  else if String.length operation_id > 256
+  then Error (Invalid_input "operation_id exceeds 256 bytes")
+  else Ok ()
+;;
+
+let validate_timestamp label value =
+  if Float.is_finite value
+  then Ok ()
+  else Error (Invalid_input (label ^ " must be finite"))
+;;
+
+let source_to_yojson = function
+  | Dashboard { thread_id } ->
+    `Assoc [ "kind", `String "dashboard"; "thread_id", `String thread_id ]
+  | Discord { channel_id; user_id } ->
+    `Assoc
+      [ "kind", `String "discord"
+      ; "channel_id", `String channel_id
+      ; "user_id", `String user_id
+      ]
+  | Slack { channel_id; user_id; user_name; team_id; thread_ts } ->
+    `Assoc
+      [ "kind", `String "slack"
+      ; "channel_id", `String channel_id
+      ; "user_id", `String user_id
+      ; "user_name", `String user_name
+      ; ("team_id", Option.fold ~none:`Null ~some:(fun value -> `String value) team_id)
+      ; ( "thread_ts"
+        , Option.fold ~none:`Null ~some:(fun value -> `String value) thread_ts )
+      ]
+;;
+
+let user_row_origin_to_yojson = function
+  | Keeper_chat_store.Needs_append -> `Assoc [ "kind", `String "needs_append" ]
+  | Keeper_chat_store.Already_persisted { row_id } ->
+    `Assoc [ "kind", `String "already_persisted"; "row_id", `String row_id ]
+  | Keeper_chat_store.Already_persisted_upstream ->
+    `Assoc [ "kind", `String "already_persisted_upstream" ]
+;;
+
+let input_body_to_yojson (input : input) =
+  `Assoc
+    [ "content", `String input.content
+    ; "user_blocks", Keeper_multimodal_input.user_blocks_to_yojson input.user_blocks
+    ; "attachments", Keeper_multimodal_input.attachments_to_yojson input.attachments
+    ; "submitted_at", `Float input.submitted_at
+    ; "user_row_origin", user_row_origin_to_yojson input.user_row_origin
+    ]
+;;
+
+let canonical_input (input : input) =
+  `Assoc
+    [ "source", source_to_yojson input.source
+    ; "input", input_body_to_yojson input
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let input_digest (input : input) =
+  Digestif.SHA256.(canonical_input input |> digest_string |> to_hex)
+;;
+
+let exact_object_keys ~context expected = function
+  | `Assoc fields ->
+    let actual = List.map fst fields |> List.sort_uniq String.compare in
+    let expected = List.sort String.compare expected in
+    if actual = expected
+    then Ok fields
+    else
+      Error
+        (Printf.sprintf
+           "%s JSON keys differ: expected=[%s] actual=[%s]"
+           context
+           (String.concat "," expected)
+           (String.concat "," actual))
+  | _ -> Error (context ^ " must be a JSON object")
+;;
+
+let member fields key =
+  match List.assoc_opt key fields with
+  | Some value -> Ok value
+  | None -> Error ("missing JSON field: " ^ key)
+;;
+
+let string_member fields key =
+  match member fields key with
+  | Ok (`String value) -> Ok value
+  | Ok _ -> Error ("JSON field must be string: " ^ key)
+  | Error _ as error -> error
+;;
+
+let optional_string_member fields key =
+  match member fields key with
+  | Ok `Null -> Ok None
+  | Ok (`String value) -> Ok (Some value)
+  | Ok _ -> Error ("JSON field must be string or null: " ^ key)
+  | Error _ as error -> error
+;;
+
+let source_of_yojson json =
+  let* outer =
+    match json with
+    | `Assoc fields -> Ok fields
+    | _ -> Error "operation source must be a JSON object"
+  in
+  match List.assoc_opt "kind" outer with
+  | Some (`String "dashboard") ->
+    let* fields =
+      exact_object_keys ~context:"dashboard operation source" [ "kind"; "thread_id" ] json
+    in
+    let* thread_id = string_member fields "thread_id" in
+    let source = Dashboard { thread_id } in
+    let* () = validate_source source |> Result.map_error error_to_string in
+    Ok source
+  | Some (`String "discord") ->
+    let* fields =
+      exact_object_keys
+        ~context:"discord operation source"
+        [ "channel_id"; "kind"; "user_id" ]
+        json
+    in
+    let* channel_id = string_member fields "channel_id" in
+    let* user_id = string_member fields "user_id" in
+    let source = Discord { channel_id; user_id } in
+    let* () = validate_source source |> Result.map_error error_to_string in
+    Ok source
+  | Some (`String "slack") ->
+    let* fields =
+      exact_object_keys
+        ~context:"slack operation source"
+        [ "channel_id"; "kind"; "team_id"; "thread_ts"; "user_id"; "user_name" ]
+        json
+    in
+    let* channel_id = string_member fields "channel_id" in
+    let* user_id = string_member fields "user_id" in
+    let* user_name = string_member fields "user_name" in
+    let* team_id = optional_string_member fields "team_id" in
+    let* thread_ts = optional_string_member fields "thread_ts" in
+    let source = Slack { channel_id; user_id; user_name; team_id; thread_ts } in
+    let* () = validate_source source |> Result.map_error error_to_string in
+    Ok source
+  | Some (`String kind) -> Error ("unknown operation source kind: " ^ kind)
+  | Some _ -> Error "operation source kind must be a string"
+  | None -> Error "operation source kind is missing"
+;;
+
+let attachment_of_yojson json =
+  let* fields =
+    exact_object_keys
+      ~context:"operation attachment"
+      [ "data"; "id"; "mime_type"; "name"; "size"; "type" ]
+      json
+  in
+  let* id = string_member fields "id" in
+  let* att_type = string_member fields "type" in
+  let* name = string_member fields "name" in
+  let* mime_type = string_member fields "mime_type" in
+  let* data = string_member fields "data" in
+  let* size =
+    match member fields "size" with
+    | Ok (`Int value) when value >= 0 -> Ok value
+    | Ok _ -> Error "operation attachment size must be a non-negative integer"
+    | Error _ as error -> error
+  in
+  if not (valid_nonempty id) || data = ""
+  then Error "operation attachment requires non-empty id and data"
+  else Ok { Keeper_chat_store.id; att_type; name; size; mime_type; data }
+;;
+
+let attachments_of_yojson = function
+  | `List values ->
+    List.fold_left
+      (fun result json ->
+         let* acc = result in
+         let* attachment = attachment_of_yojson json in
+         Ok (attachment :: acc))
+      (Ok [])
+      values
+    |> Result.map List.rev
+  | _ -> Error "operation attachments must be an array"
+;;
+
+let user_row_origin_of_yojson json =
+  match json with
+  | `Assoc [ "kind", `String "needs_append" ] -> Ok Keeper_chat_store.Needs_append
+  | `Assoc [ "kind", `String "already_persisted_upstream" ] ->
+    Ok Keeper_chat_store.Already_persisted_upstream
+  | _ ->
+    let* fields =
+      exact_object_keys
+        ~context:"operation user_row_origin"
+        [ "kind"; "row_id" ]
+        json
+    in
+    let* kind = string_member fields "kind" in
+    if not (String.equal kind "already_persisted")
+    then Error ("unknown operation user_row_origin kind: " ^ kind)
+    else
+      let* row_id = string_member fields "row_id" in
+      if valid_nonempty row_id
+      then Ok (Keeper_chat_store.Already_persisted { row_id })
+      else Error "operation persisted row id must be non-empty UTF-8"
+;;
+
+let input_body_of_yojson ~source json =
+  let* fields =
+    exact_object_keys
+      ~context:"operation input"
+      [ "attachments"; "content"; "submitted_at"; "user_blocks"; "user_row_origin" ]
+      json
+  in
+  let* content = string_member fields "content" in
+  let* submitted_at =
+    match member fields "submitted_at" with
+    | Ok (`Float value) when Float.is_finite value -> Ok value
+    | Ok (`Int value) -> Ok (Float.of_int value)
+    | Ok _ -> Error "operation submitted_at must be finite numeric JSON"
+    | Error _ as error -> error
+  in
+  let* attachments_json = member fields "attachments" in
+  let* attachments = attachments_of_yojson attachments_json in
+  let* user_row_origin_json = member fields "user_row_origin" in
+  let* user_row_origin = user_row_origin_of_yojson user_row_origin_json in
+  let* user_blocks =
+    match Keeper_multimodal_input.parse_user_blocks json with
+    | Ok blocks -> Ok blocks
+    | Error detail -> Error detail
+  in
+  let input = { content; user_blocks; attachments; submitted_at; source; user_row_origin } in
+  let* () = validate_input input |> Result.map_error error_to_string in
+  Ok input
+;;
+
+let metadata_table_sql =
+  "CREATE TABLE metadata (singleton INTEGER PRIMARY KEY CHECK (singleton = 1), schema TEXT NOT NULL, next_sequence INTEGER NOT NULL CHECK (next_sequence >= 0)) STRICT"
+;;
+
+let operations_table_sql =
+  "CREATE TABLE operations (operation_id TEXT PRIMARY KEY NOT NULL, admission_digest TEXT NOT NULL CHECK (length(admission_digest) = 64), execution_digest TEXT NOT NULL CHECK (length(execution_digest) = 64), fifo_sequence INTEGER NOT NULL UNIQUE CHECK (fifo_sequence >= 0), source_json TEXT, input_json TEXT, state_kind TEXT NOT NULL CHECK (state_kind IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')), submitted_at REAL NOT NULL, started_at REAL, completed_at REAL, outcome_ref TEXT, failure_kind TEXT, failure_detail TEXT, CHECK ((state_kind = 'queued' AND source_json IS NOT NULL AND input_json IS NOT NULL AND started_at IS NULL AND completed_at IS NULL AND outcome_ref IS NULL AND failure_kind IS NULL AND failure_detail IS NULL) OR (state_kind = 'running' AND source_json IS NOT NULL AND input_json IS NOT NULL AND started_at IS NOT NULL AND completed_at IS NULL AND outcome_ref IS NULL AND failure_kind IS NULL AND failure_detail IS NULL) OR (state_kind = 'succeeded' AND source_json IS NULL AND input_json IS NULL AND started_at IS NOT NULL AND completed_at IS NOT NULL AND outcome_ref IS NOT NULL AND length(outcome_ref) > 0 AND failure_kind IS NULL AND failure_detail IS NULL) OR (state_kind = 'failed' AND source_json IS NULL AND input_json IS NULL AND started_at IS NOT NULL AND completed_at IS NOT NULL AND failure_kind IS NOT NULL AND failure_detail IS NOT NULL) OR (state_kind = 'cancelled' AND source_json IS NULL AND input_json IS NULL AND started_at IS NULL AND completed_at IS NOT NULL AND outcome_ref IS NULL AND failure_kind IS NULL AND failure_detail IS NULL))) STRICT, WITHOUT ROWID"
+;;
+
+let state_sequence_index_sql =
+  "CREATE INDEX operations_state_sequence ON operations (state_kind, fifo_sequence)"
+;;
+
+let single_running_index_sql =
+  "CREATE UNIQUE INDEX operations_single_running ON operations ((CASE WHEN state_kind = 'running' THEN 1 END))"
+;;
+
+let expected_schema_objects =
+  [ "index", "operations_single_running", single_running_index_sql
+  ; "index", "operations_state_sequence", state_sequence_index_sql
+  ; "index", "sqlite_autoindex_operations_2", ""
+  ; "table", "metadata", metadata_table_sql
+  ; "table", "operations", operations_table_sql
+  ]
+;;
+
+let exec db ~operation sql =
+  Keeper_chat_queue_storage.exec db ~operation sql
+  |> Result.map_error (fun detail -> Store_unavailable detail)
+;;
+
+let with_statement db sql body =
+  match
+    try Ok (Sqlite3.prepare db sql) with
+    | exn -> store_error ("SQLite statement prepare failed: " ^ Printexc.to_string exn)
+  with
+  | Error _ as error -> error
+  | Ok stmt ->
+    let body_result =
+      try body stmt with
+      | Eio.Cancel.Cancelled _ as exn ->
+        (match Keeper_chat_queue_storage.finalize db stmt with
+         | Ok () -> ()
+         | Error detail ->
+           Log.Keeper.error
+             "chat operation statement finalize failed during cancellation: %s"
+             detail);
+        raise exn
+      | exn ->
+        store_error ("SQLite statement body raised: " ^ Printexc.to_string exn)
+    in
+    let cleanup =
+      Keeper_chat_queue_storage.finalize db stmt
+      |> Result.map_error (fun detail -> Store_unavailable detail)
+    in
+    (match body_result, cleanup with
+     | Ok value, Ok () -> Ok value
+     | Error error, Ok () | Ok _, Error error -> Error error
+     | Error first, Error second ->
+       store_error (error_to_string first ^ "; " ^ error_to_string second))
+;;
+
+let configure_connection db =
+  let* mode =
+    Keeper_chat_queue_storage.single_text
+      db
+      ~operation:"set chat operation DELETE journal mode"
+      "PRAGMA journal_mode=DELETE"
+    |> Result.map_error (fun detail -> Store_unavailable detail)
+  in
+  if not (String.equal mode "delete")
+  then store_error ("SQLite refused DELETE journal mode: " ^ mode)
+  else
+    let* () = exec db ~operation:"set chat operation FULL synchronous" "PRAGMA synchronous=FULL" in
+    let* () = exec db ~operation:"enable chat operation foreign keys" "PRAGMA foreign_keys=ON" in
+    let* synchronous =
+      Keeper_chat_queue_storage.single_int64
+        db
+        ~operation:"read chat operation synchronous mode"
+        "PRAGMA synchronous"
+      |> Result.map_error (fun detail -> Store_unavailable detail)
+    in
+    let* foreign_keys =
+      Keeper_chat_queue_storage.single_int64
+        db
+        ~operation:"read chat operation foreign key mode"
+        "PRAGMA foreign_keys"
+      |> Result.map_error (fun detail -> Store_unavailable detail)
+    in
+    if not (Int64.equal synchronous 2L)
+    then store_error (Printf.sprintf "SQLite synchronous mode is %Ld, expected FULL(2)" synchronous)
+    else if not (Int64.equal foreign_keys 1L)
+    then store_error "SQLite foreign key enforcement could not be enabled"
+    else Ok ()
+;;
+
+let rollback db primary =
+  match exec db ~operation:"rollback chat operation transaction" "ROLLBACK" with
+  | Ok () -> Error primary
+  | Error rollback_error ->
+    store_error (error_to_string primary ^ "; rollback failed: " ^ error_to_string rollback_error)
+;;
+
+let initialize_database db path =
+  let* () = exec db ~operation:"begin chat operation schema transaction" "BEGIN EXCLUSIVE" in
+  let body =
+    let* () = exec db ~operation:"create chat operation metadata" metadata_table_sql in
+    let* () = exec db ~operation:"create chat operations" operations_table_sql in
+    let* () =
+      exec db ~operation:"create chat operation single-running index" single_running_index_sql
+    in
+    let* () = exec db ~operation:"create chat operation state index" state_sequence_index_sql in
+    let* () =
+      with_statement
+        db
+        "INSERT INTO metadata(singleton, schema, next_sequence) VALUES (1, ?, 0)"
+        (fun stmt ->
+           let* () =
+             Keeper_chat_queue_storage.bind_text
+               db
+               stmt
+               ~operation:"bind chat operation schema"
+               1
+               database_schema
+             |> Result.map_error (fun detail -> Store_unavailable detail)
+           in
+           Keeper_chat_queue_storage.expect_done
+             db
+             stmt
+             ~operation:"insert chat operation metadata"
+           |> Result.map_error (fun detail -> Store_unavailable detail))
+    in
+    let* () =
+      exec
+        db
+        ~operation:"set chat operation application id"
+        (Printf.sprintf "PRAGMA application_id=%Ld" database_application_id)
+    in
+    let* () =
+      exec
+        db
+        ~operation:"set chat operation user version"
+        (Printf.sprintf "PRAGMA user_version=%Ld" database_user_version)
+    in
+    exec db ~operation:"commit chat operation schema transaction" "COMMIT"
+  in
+  match body with
+  | Error error -> rollback db error
+  | Ok () ->
+    (try
+       Keeper_fs_durable_directory.fsync_directory (Filename.dirname path);
+       Ok ()
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       store_error
+         ("failed to durably publish chat operation database: " ^ Printexc.to_string exn))
+;;
+
+let read_schema_objects db =
+  with_statement
+    db
+    "SELECT type, name, COALESCE(sql, '') FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' OR name = 'sqlite_autoindex_operations_2' ORDER BY type, name"
+    (fun stmt ->
+       let rec loop acc =
+         match Sqlite3.step stmt with
+         | Sqlite3.Rc.DONE -> Ok (List.rev acc)
+         | Sqlite3.Rc.ROW ->
+           loop
+             (( Sqlite3.column_text stmt 0
+              , Sqlite3.column_text stmt 1
+              , Sqlite3.column_text stmt 2 )
+              :: acc)
+         | rc ->
+           store_error
+             (Keeper_chat_queue_storage.error
+                ~operation:"read chat operation schema objects"
+                db
+                rc)
+       in
+       loop [])
+;;
+
+let validate_database db =
+  let* application_id =
+    Keeper_chat_queue_storage.single_int64
+      db
+      ~operation:"read chat operation application id"
+      "PRAGMA application_id"
+    |> Result.map_error (fun detail -> Store_unavailable detail)
+  in
+  let* user_version =
+    Keeper_chat_queue_storage.single_int64
+      db
+      ~operation:"read chat operation user version"
+      "PRAGMA user_version"
+    |> Result.map_error (fun detail -> Store_unavailable detail)
+  in
+  let* schema =
+    Keeper_chat_queue_storage.single_text
+      db
+      ~operation:"read chat operation schema"
+      "SELECT schema FROM metadata WHERE singleton = 1"
+    |> Result.map_error (fun detail -> Store_unavailable detail)
+  in
+  let* metadata_count =
+    Keeper_chat_queue_storage.single_int64
+      db
+      ~operation:"count chat operation metadata"
+      "SELECT COUNT(*) FROM metadata"
+    |> Result.map_error (fun detail -> Store_unavailable detail)
+  in
+  if not (Int64.equal application_id database_application_id)
+  then store_error (Printf.sprintf "unsupported operation application_id=%Ld" application_id)
+  else if not (Int64.equal user_version database_user_version)
+  then store_error (Printf.sprintf "unsupported operation user_version=%Ld" user_version)
+  else if not (String.equal schema database_schema)
+  then store_error ("unsupported operation schema: " ^ schema)
+  else if not (Int64.equal metadata_count 1L)
+  then store_error "operation database must contain exactly one metadata row"
+  else
+    let* objects = read_schema_objects db in
+    if objects = expected_schema_objects
+    then Ok ()
+    else store_error "operation database schema does not exactly match masc.keeper_chat_operations.v1"
+;;
+
+let database_path ~base_path ~keeper_name =
+  match Config_dir_resolver.canonical_base_path base_path with
+  | Error error ->
+    Error
+      (Invalid_input
+         (Config_dir_resolver.canonical_base_path_error_to_string error))
+  | Ok base_path ->
+    if not (Safe_identifier.is_portable_name keeper_name)
+    then Error (Invalid_input ("invalid Keeper name: " ^ keeper_name))
+    else
+      Ok
+        (Filename.concat
+           (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+           database_file)
+;;
+
+let close_db db =
+  try
+    if Sqlite3.db_close db
+    then Ok ()
+    else store_error "SQLite operation database close reported a busy handle"
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> store_error ("SQLite operation database close failed: " ^ Printexc.to_string exn)
+;;
+
+let open_ ~base_path ~keeper_name =
+  let* path = database_path ~base_path ~keeper_name in
+  let* ownership_root =
+    match Config_dir_resolver.canonical_base_path base_path with
+    | Ok value -> Ok value
+    | Error error ->
+      Error
+        (Invalid_input
+           (Config_dir_resolver.canonical_base_path_error_to_string error))
+  in
+  let* () =
+    Keeper_chat_queue_storage.prepare_database_parent
+      ~ownership_root
+      ~path
+      ~create_if_missing:true
+    |> Result.map_error (fun detail -> Store_unavailable detail)
+  in
+  let* observed =
+    Keeper_chat_queue_storage.validate_database_paths ~ownership_root path
+    |> Result.map_error (fun detail -> Store_unavailable detail)
+  in
+  let missing = observed = Keeper_chat_queue_storage.Path_absent in
+  let db =
+    try
+      Ok
+        (if missing
+         then Sqlite3.db_open ~mutex:`FULL path
+         else Sqlite3.db_open ~mode:`NO_CREATE ~mutex:`FULL path)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> store_error ("SQLite operation database open failed: " ^ Printexc.to_string exn)
+  in
+  let* db = db in
+  let prepared =
+    let* () = configure_connection db in
+    if missing then initialize_database db path else validate_database db
+  in
+  (match prepared with
+   | Ok () -> Ok { db; path; ownership_root; closed = false }
+   | Error error ->
+     let close_result = close_db db in
+     (match close_result with
+      | Ok () -> Error error
+      | Error close_error ->
+        store_error (error_to_string error ^ "; " ^ error_to_string close_error)))
+;;
+
+let ensure_open t =
+  if t.closed then Error (Store_unavailable "operation store is closed") else Ok ()
+;;
+
+let close t =
+  if t.closed
+  then Ok ()
+  else (
+    t.closed <- true;
+    let result = close_db t.db in
+    ignore (Sys.opaque_identity t.db);
+    let identity =
+      Keeper_chat_queue_storage.validate_owned_parent
+        ~ownership_root:t.ownership_root
+        t.path
+      |> Result.map_error (fun detail -> Store_unavailable detail)
+    in
+    match result, identity with
+    | Ok (), Ok () -> Ok ()
+    | Error error, Ok () | Ok (), Error error -> Error error
+    | Error first, Error second ->
+      store_error (error_to_string first ^ "; " ^ error_to_string second))
+;;
+
+let state_of_columns stmt =
+  let kind = Sqlite3.column_text stmt 5 in
+  let nullable_text column =
+    if Sqlite3.column_is_null stmt column then None else Some (Sqlite3.column_text stmt column)
+  in
+  let nullable_float column =
+    if Sqlite3.column_is_null stmt column then None else Some (Sqlite3.column_double stmt column)
+  in
+  match kind with
+  | "queued" -> Ok Queued
+  | "running" ->
+    (match nullable_float 7 with
+     | Some started_at when Float.is_finite started_at -> Ok (Running { started_at })
+     | Some _ | None -> store_error "running operation has invalid started_at")
+  | "succeeded" ->
+    (match nullable_float 8, nullable_text 9 with
+     | Some completed_at, Some outcome_ref
+       when Float.is_finite completed_at && valid_nonempty outcome_ref ->
+       Ok (Succeeded { completed_at; outcome_ref })
+     | _ -> store_error "succeeded operation has invalid terminal columns")
+  | "failed" ->
+    (match nullable_float 8, nullable_text 10, nullable_text 11 with
+     | Some completed_at, Some kind, Some detail when Float.is_finite completed_at ->
+       let* kind = failure_kind_of_string kind |> Result.map_error (fun detail -> Store_unavailable detail) in
+       Ok (Failed { completed_at; kind; detail; outcome_ref = nullable_text 9 })
+     | _ -> store_error "failed operation has invalid terminal columns")
+  | "cancelled" ->
+    (match nullable_float 8 with
+     | Some completed_at when Float.is_finite completed_at -> Ok (Cancelled { completed_at })
+     | Some _ | None -> store_error "cancelled operation has invalid completed_at")
+  | value -> store_error ("unknown persisted operation state: " ^ value)
+;;
+
+let operation_of_row stmt =
+  let operation_id = Sqlite3.column_text stmt 0 in
+  let admission_digest = Sqlite3.column_text stmt 1 in
+  let execution_digest = Sqlite3.column_text stmt 2 in
+  let sequence = Sqlite3.column_int64 stmt 3 in
+  let source_json =
+    if Sqlite3.column_is_null stmt 4 then None else Some (Sqlite3.column_text stmt 4)
+  in
+  let input_json =
+    if Sqlite3.column_is_null stmt 6 then None else Some (Sqlite3.column_text stmt 6)
+  in
+  let* state = state_of_columns stmt in
+  let* input =
+    match state, source_json, input_json with
+    | (Queued | Running _), Some source_json, Some input_json ->
+      (match Yojson.Safe.from_string source_json, Yojson.Safe.from_string input_json with
+       | source_json, input_json ->
+         let* source = source_of_yojson source_json |> Result.map_error (fun detail -> Store_unavailable detail) in
+         input_body_of_yojson ~source input_json
+         |> Result.map_error (fun detail -> Store_unavailable detail)
+       | exception exn ->
+         store_error ("operation input JSON parse failed: " ^ Printexc.to_string exn))
+      |> Result.map Option.some
+    | (Succeeded _ | Failed _ | Cancelled _), None, None -> Ok None
+    | _ -> store_error "operation input retention invariant is violated"
+  in
+  Ok { operation_id; admission_digest; execution_digest; sequence; input; state }
+;;
+
+let select_columns =
+  "operation_id, admission_digest, execution_digest, fifo_sequence, source_json, state_kind, input_json, started_at, completed_at, outcome_ref, failure_kind, failure_detail"
+;;
+
+let lookup_optional t ~operation_id =
+  let* () = ensure_open t in
+  with_statement
+    t.db
+    ("SELECT " ^ select_columns ^ " FROM operations WHERE operation_id = ?")
+    (fun stmt ->
+       let* () =
+         Keeper_chat_queue_storage.bind_text
+           t.db stmt ~operation:"bind operation lookup id" 1 operation_id
+         |> Result.map_error (fun detail -> Store_unavailable detail)
+       in
+       match Sqlite3.step stmt with
+       | Sqlite3.Rc.DONE -> Ok None
+       | Sqlite3.Rc.ROW ->
+         let* operation = operation_of_row stmt in
+         (match Sqlite3.step stmt with
+          | Sqlite3.Rc.DONE -> Ok (Some operation)
+          | rc ->
+            store_error
+              (Keeper_chat_queue_storage.error
+                 ~operation:"finish operation lookup"
+                 t.db
+                 rc))
+       | rc ->
+         store_error
+           (Keeper_chat_queue_storage.error ~operation:"lookup operation" t.db rc))
+;;
+
+let lookup t ~operation_id =
+  let* () = validate_operation_id operation_id in
+  let* operation = lookup_optional t ~operation_id in
+  match operation with
+  | Some operation -> Ok operation
+  | None -> Error (Unknown_operation operation_id)
+;;
+
+let operation_equal left right = left = right
+
+let durable_readback t ~operation_id =
+  let* db =
+    try Ok (Sqlite3.db_open ~mode:`READONLY ~mutex:`FULL t.path) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      store_error
+        ("SQLite durable read-back open failed: " ^ Printexc.to_string exn)
+  in
+  let readback =
+    let reader = { t with db; closed = false } in
+    lookup_optional reader ~operation_id
+  in
+  let closed = close_db db in
+  match readback, closed with
+  | Ok value, Ok () -> Ok value
+  | Error error, Ok () | Ok _, Error error -> Error error
+  | Error first, Error second ->
+    store_error (error_to_string first ^ "; " ^ error_to_string second)
+;;
+
+let rollback_after_uncertain_commit t =
+  match exec t.db ~operation:"rollback uncertain chat operation commit" "ROLLBACK" with
+  | Ok () | Error _ -> ()
+;;
+
+let commit_transaction t ~operation =
+  match Atomic.exchange commit_fault_for_testing None with
+  | None -> exec t.db ~operation "COMMIT"
+  | Some Before_commit ->
+    store_error "injected chat operation failure before COMMIT"
+  | Some After_commit ->
+    (match exec t.db ~operation "COMMIT" with
+     | Error _ as error -> error
+     | Ok () -> store_error "injected uncertain chat operation COMMIT result")
+;;
+
+let commit_operation t expected =
+  match commit_transaction t ~operation:"commit chat operation transaction" with
+  | Ok () -> Ok expected
+  | Error commit_error ->
+    (match durable_readback t ~operation_id:expected.operation_id with
+     | Ok (Some observed) when operation_equal observed expected -> Ok observed
+     | Ok _ | Error _ ->
+       rollback_after_uncertain_commit t;
+       store_error
+         ("chat operation commit could not be confirmed: " ^ error_to_string commit_error))
+;;
+
+let read_next_sequence t =
+  Keeper_chat_queue_storage.single_int64
+    t.db
+    ~operation:"read next chat operation sequence"
+    "SELECT next_sequence FROM metadata WHERE singleton = 1"
+  |> Result.map_error (fun detail -> Store_unavailable detail)
+;;
+
+let allocate_sequence t =
+  let* sequence = read_next_sequence t in
+  if Int64.equal sequence Int64.max_int
+  then Error (Invalid_input "chat operation sequence exhausted")
+  else
+    let* () =
+      with_statement
+        t.db
+        "UPDATE metadata SET next_sequence = ? WHERE singleton = 1"
+        (fun stmt ->
+           let* () =
+             Keeper_chat_queue_storage.bind_int64
+               t.db
+               stmt
+               ~operation:"bind next chat operation sequence"
+               1
+               (Int64.succ sequence)
+             |> Result.map_error (fun detail -> Store_unavailable detail)
+           in
+           Keeper_chat_queue_storage.expect_done
+             t.db
+             stmt
+             ~operation:"advance chat operation sequence"
+           |> Result.map_error (fun detail -> Store_unavailable detail))
+    in
+    Ok sequence
+;;
+
+let submit t ~operation_id input =
+  let* () = ensure_open t in
+  let* () = validate_operation_id operation_id in
+  let* () = validate_input input in
+  let digest = input_digest input in
+  let* existing = lookup_optional t ~operation_id in
+  match existing with
+  | Some operation when String.equal operation.admission_digest digest ->
+    Ok (Existing operation)
+  | Some _ -> Error (Idempotency_conflict operation_id)
+  | None ->
+    let* () = exec t.db ~operation:"begin chat operation submit" "BEGIN IMMEDIATE" in
+    let body =
+      let* sequence = allocate_sequence t in
+      let source_json = source_to_yojson input.source |> Yojson.Safe.to_string in
+      let input_json = input_body_to_yojson input |> Yojson.Safe.to_string in
+      let* () =
+        with_statement
+          t.db
+          "INSERT INTO operations(operation_id, admission_digest, execution_digest, fifo_sequence, source_json, input_json, state_kind, submitted_at) VALUES (?, ?, ?, ?, ?, ?, 'queued', ?)"
+          (fun stmt ->
+             let bind_text index value operation =
+               Keeper_chat_queue_storage.bind_text t.db stmt ~operation index value
+               |> Result.map_error (fun detail -> Store_unavailable detail)
+             in
+             let* () = bind_text 1 operation_id "bind submitted operation id" in
+             let* () = bind_text 2 digest "bind submitted admission digest" in
+             let* () = bind_text 3 digest "bind submitted execution digest" in
+             let* () =
+               Keeper_chat_queue_storage.bind_int64
+                 t.db stmt ~operation:"bind submitted operation sequence" 4 sequence
+               |> Result.map_error (fun detail -> Store_unavailable detail)
+             in
+             let* () = bind_text 5 source_json "bind submitted operation source" in
+             let* () = bind_text 6 input_json "bind submitted operation input" in
+             let* () =
+               Keeper_chat_queue_storage.bind
+                 t.db stmt ~operation:"bind submitted operation timestamp" 7
+                 (Sqlite3.Data.FLOAT input.submitted_at)
+               |> Result.map_error (fun detail -> Store_unavailable detail)
+             in
+             Keeper_chat_queue_storage.expect_done
+               t.db stmt ~operation:"insert submitted chat operation"
+             |> Result.map_error (fun detail -> Store_unavailable detail))
+      in
+      Ok
+        { operation_id
+        ; admission_digest = digest
+        ; execution_digest = digest
+        ; sequence
+        ; input = Some input
+        ; state = Queued
+        }
+    in
+    (match body with
+     | Error error -> rollback t.db error
+     | Ok operation -> commit_operation t operation |> Result.map (fun value -> Accepted value))
+;;
+
+let list_queued t ~after_sequence ~limit =
+  let* () = ensure_open t in
+  if limit <= 0 || limit > 1000
+  then Error (Invalid_input "queued operation limit must be between 1 and 1000")
+  else
+    let after_sequence = Option.value ~default:(-1L) after_sequence in
+    if Int64.compare after_sequence (-1L) < 0
+    then Error (Invalid_input "after_sequence must be non-negative when present")
+    else
+      with_statement
+        t.db
+        ("SELECT " ^ select_columns
+         ^ " FROM operations WHERE state_kind = 'queued' AND fifo_sequence > ? ORDER BY fifo_sequence LIMIT ?")
+        (fun stmt ->
+           let* () =
+             Keeper_chat_queue_storage.bind_int64
+               t.db stmt ~operation:"bind queued after sequence" 1 after_sequence
+             |> Result.map_error (fun detail -> Store_unavailable detail)
+           in
+           let* () =
+             Keeper_chat_queue_storage.bind_int64
+               t.db stmt ~operation:"bind queued operation limit" 2 (Int64.of_int limit)
+             |> Result.map_error (fun detail -> Store_unavailable detail)
+           in
+           let rec loop acc =
+             match Sqlite3.step stmt with
+             | Sqlite3.Rc.DONE -> Ok (List.rev acc)
+             | Sqlite3.Rc.ROW ->
+               let* operation = operation_of_row stmt in
+               loop (operation :: acc)
+             | rc ->
+               store_error
+                 (Keeper_chat_queue_storage.error
+                    ~operation:"list queued chat operations"
+                    t.db
+                    rc)
+           in
+           loop [])
+;;
+
+let update_and_read t ~operation_id ~sql ~bind =
+  let* () = exec t.db ~operation:"begin chat operation mutation" "BEGIN IMMEDIATE" in
+  let body =
+    let* () =
+      with_statement t.db sql (fun stmt ->
+          let* () = bind stmt in
+          Keeper_chat_queue_storage.expect_done
+            t.db stmt ~operation:"mutate chat operation"
+          |> Result.map_error (fun detail -> Store_unavailable detail))
+    in
+    if Sqlite3.changes t.db <> 1
+    then store_error "chat operation mutation changed an unexpected row count"
+    else
+      let* operation = lookup_optional t ~operation_id in
+      match operation with
+      | Some operation -> Ok operation
+      | None -> Error (Unknown_operation operation_id)
+  in
+  match body with
+  | Error error -> rollback t.db error
+  | Ok operation -> commit_operation t operation
+;;
+
+let start_next t ~started_at =
+  let* () = ensure_open t in
+  let* () = validate_timestamp "started_at" started_at in
+  let* () = exec t.db ~operation:"begin start next chat operation" "BEGIN IMMEDIATE" in
+  let body =
+    let* head =
+      with_statement
+        t.db
+        "SELECT operation_id FROM operations WHERE state_kind = 'queued' ORDER BY fifo_sequence LIMIT 1"
+        (fun stmt ->
+           match Sqlite3.step stmt with
+           | Sqlite3.Rc.DONE -> Ok None
+           | Sqlite3.Rc.ROW -> Ok (Some (Sqlite3.column_text stmt 0))
+           | rc ->
+             store_error
+               (Keeper_chat_queue_storage.error
+                  ~operation:"select queued chat operation head"
+                  t.db
+                  rc))
+    in
+    match head with
+    | None -> Ok None
+    | Some operation_id ->
+      let* () =
+        with_statement
+          t.db
+          "UPDATE operations SET state_kind = 'running', started_at = ? WHERE operation_id = ? AND state_kind = 'queued'"
+          (fun stmt ->
+             let* () =
+               Keeper_chat_queue_storage.bind
+                 t.db stmt ~operation:"bind operation started_at" 1
+                 (Sqlite3.Data.FLOAT started_at)
+               |> Result.map_error (fun detail -> Store_unavailable detail)
+             in
+             let* () =
+               Keeper_chat_queue_storage.bind_text
+                 t.db stmt ~operation:"bind operation start id" 2 operation_id
+               |> Result.map_error (fun detail -> Store_unavailable detail)
+             in
+             Keeper_chat_queue_storage.expect_done
+               t.db stmt ~operation:"start queued chat operation"
+             |> Result.map_error (fun detail -> Store_unavailable detail))
+      in
+      if Sqlite3.changes t.db <> 1
+      then store_error "queued operation head changed before start"
+      else
+        let* operation = lookup_optional t ~operation_id in
+        (match operation with
+         | Some operation -> Ok (Some operation)
+         | None -> store_error "started operation disappeared")
+  in
+  match body with
+  | Error error -> rollback t.db error
+  | Ok None ->
+    let* () = exec t.db ~operation:"commit empty chat operation start" "COMMIT" in
+    Ok None
+  | Ok (Some operation) -> commit_operation t operation |> Result.map Option.some
+;;
+
+let require_queued t operation_id =
+  let* operation = lookup t ~operation_id in
+  match operation.state with
+  | Queued -> Ok operation
+  | state -> Error (Not_queued { operation_id; state })
+;;
+
+let edit t ~operation_id edit =
+  let* () = ensure_open t in
+  let* () = validate_operation_id operation_id in
+  let* () = validate_edit edit in
+  let* current = require_queued t operation_id in
+  match current.input with
+  | None -> store_error "queued operation has no retained input"
+  | Some current_input ->
+    let input =
+      { current_input with
+        content = edit.content
+      ; user_blocks = edit.user_blocks
+      ; attachments = edit.attachments
+      }
+    in
+    let digest = input_digest input in
+    let input_json = input_body_to_yojson input |> Yojson.Safe.to_string in
+    update_and_read
+      t
+      ~operation_id
+      ~sql:
+        "UPDATE operations SET execution_digest = ?, input_json = ? WHERE operation_id = ? AND state_kind = 'queued'"
+      ~bind:(fun stmt ->
+        let bind index value operation =
+          Keeper_chat_queue_storage.bind_text t.db stmt ~operation index value
+          |> Result.map_error (fun detail -> Store_unavailable detail)
+        in
+        let* () = bind 1 digest "bind edited operation digest" in
+        let* () = bind 2 input_json "bind edited operation input" in
+        bind 3 operation_id "bind edited operation id")
+;;
+
+let move_to_end t ~operation_id =
+  let* () = ensure_open t in
+  let* () = validate_operation_id operation_id in
+  let* _ = require_queued t operation_id in
+  let* () = exec t.db ~operation:"begin move chat operation" "BEGIN IMMEDIATE" in
+  let body =
+    let* sequence = allocate_sequence t in
+    let* () =
+      with_statement
+        t.db
+        "UPDATE operations SET fifo_sequence = ? WHERE operation_id = ? AND state_kind = 'queued'"
+        (fun stmt ->
+           let* () =
+             Keeper_chat_queue_storage.bind_int64
+               t.db stmt ~operation:"bind moved operation sequence" 1 sequence
+             |> Result.map_error (fun detail -> Store_unavailable detail)
+           in
+           let* () =
+             Keeper_chat_queue_storage.bind_text
+               t.db stmt ~operation:"bind moved operation id" 2 operation_id
+             |> Result.map_error (fun detail -> Store_unavailable detail)
+           in
+           Keeper_chat_queue_storage.expect_done
+             t.db stmt ~operation:"move queued chat operation"
+           |> Result.map_error (fun detail -> Store_unavailable detail))
+    in
+    if Sqlite3.changes t.db <> 1
+    then store_error "queued operation changed before move-to-end"
+    else
+      let* operation = lookup_optional t ~operation_id in
+      match operation with
+      | Some operation -> Ok operation
+      | None -> store_error "moved operation disappeared"
+  in
+  match body with
+  | Error error -> rollback t.db error
+  | Ok operation -> commit_operation t operation
+;;
+
+let bind_terminal_common t ~operation_id ~completed_at stmt =
+  let* () =
+    Keeper_chat_queue_storage.bind
+      t.db stmt ~operation:"bind operation completed_at" 1
+      (Sqlite3.Data.FLOAT completed_at)
+    |> Result.map_error (fun detail -> Store_unavailable detail)
+  in
+  Keeper_chat_queue_storage.bind_text
+    t.db stmt ~operation:"bind terminal operation id" 2 operation_id
+  |> Result.map_error (fun detail -> Store_unavailable detail)
+;;
+
+let cancel t ~operation_id ~completed_at =
+  let* () = ensure_open t in
+  let* () = validate_operation_id operation_id in
+  let* () = validate_timestamp "completed_at" completed_at in
+  let* _ = require_queued t operation_id in
+  update_and_read
+    t
+    ~operation_id
+    ~sql:
+      "UPDATE operations SET state_kind = 'cancelled', source_json = NULL, input_json = NULL, completed_at = ? WHERE operation_id = ? AND state_kind = 'queued'"
+    ~bind:(bind_terminal_common t ~operation_id ~completed_at)
+;;
+
+let require_running t operation_id =
+  let* operation = lookup t ~operation_id in
+  match operation.state with
+  | Running _ -> Ok operation
+  | state -> Error (Not_queued { operation_id; state })
+;;
+
+let succeed t ~operation_id ~completed_at ~outcome_ref =
+  let* () = ensure_open t in
+  let* () = validate_operation_id operation_id in
+  let* () = validate_timestamp "completed_at" completed_at in
+  if not (valid_nonempty outcome_ref)
+  then Error (Invalid_input "outcome_ref must be non-empty UTF-8")
+  else
+    let* _ = require_running t operation_id in
+    update_and_read
+      t
+      ~operation_id
+      ~sql:
+        "UPDATE operations SET state_kind = 'succeeded', source_json = NULL, input_json = NULL, completed_at = ?, outcome_ref = ? WHERE operation_id = ? AND state_kind = 'running'"
+      ~bind:(fun stmt ->
+        let* () =
+          Keeper_chat_queue_storage.bind
+            t.db stmt ~operation:"bind successful operation completed_at" 1
+            (Sqlite3.Data.FLOAT completed_at)
+          |> Result.map_error (fun detail -> Store_unavailable detail)
+        in
+        let* () =
+          Keeper_chat_queue_storage.bind_text
+            t.db stmt ~operation:"bind successful operation outcome" 2 outcome_ref
+          |> Result.map_error (fun detail -> Store_unavailable detail)
+        in
+        Keeper_chat_queue_storage.bind_text
+          t.db stmt ~operation:"bind successful operation id" 3 operation_id
+        |> Result.map_error (fun detail -> Store_unavailable detail))
+;;
+
+let fail t ~operation_id ~completed_at ~kind ~detail ~outcome_ref =
+  let* () = ensure_open t in
+  let* () = validate_operation_id operation_id in
+  let* () = validate_timestamp "completed_at" completed_at in
+  if not (String.is_valid_utf_8 detail) || String.contains detail '\000'
+  then Error (Invalid_input "failure detail must be UTF-8 without NUL")
+  else
+    let* () = validate_optional "failure outcome_ref" outcome_ref in
+    let* _ = require_running t operation_id in
+    update_and_read
+      t
+      ~operation_id
+      ~sql:
+        "UPDATE operations SET state_kind = 'failed', source_json = NULL, input_json = NULL, completed_at = ?, failure_kind = ?, failure_detail = ?, outcome_ref = ? WHERE operation_id = ? AND state_kind = 'running'"
+      ~bind:(fun stmt ->
+        let* () =
+          Keeper_chat_queue_storage.bind
+            t.db stmt ~operation:"bind failed operation completed_at" 1
+            (Sqlite3.Data.FLOAT completed_at)
+          |> Result.map_error (fun detail -> Store_unavailable detail)
+        in
+        let bind_text index value operation =
+          Keeper_chat_queue_storage.bind_text t.db stmt ~operation index value
+          |> Result.map_error (fun detail -> Store_unavailable detail)
+        in
+        let* () = bind_text 2 (failure_kind_to_string kind) "bind operation failure kind" in
+        let* () = bind_text 3 detail "bind operation failure detail" in
+        let* () =
+          Keeper_chat_queue_storage.bind
+            t.db stmt ~operation:"bind failed operation outcome" 4
+            (Option.fold
+               ~none:Sqlite3.Data.NULL
+               ~some:(fun value -> Sqlite3.Data.TEXT value)
+               outcome_ref)
+          |> Result.map_error (fun detail -> Store_unavailable detail)
+        in
+        bind_text 5 operation_id "bind failed operation id")
+;;
+
+let settle_interrupted t ~completed_at =
+  let* () = ensure_open t in
+  let* () = validate_timestamp "completed_at" completed_at in
+  let* () = exec t.db ~operation:"begin interrupted operation settlement" "BEGIN IMMEDIATE" in
+  let body =
+    let* running_ids =
+      with_statement
+        t.db
+        "SELECT operation_id FROM operations WHERE state_kind = 'running' ORDER BY fifo_sequence"
+        (fun stmt ->
+           let rec loop acc =
+             match Sqlite3.step stmt with
+             | Sqlite3.Rc.DONE -> Ok (List.rev acc)
+             | Sqlite3.Rc.ROW -> loop (Sqlite3.column_text stmt 0 :: acc)
+             | rc ->
+               store_error
+                 (Keeper_chat_queue_storage.error
+                    ~operation:"list running operations for restart settlement"
+                    t.db
+                    rc)
+           in
+           loop [])
+    in
+    let* () =
+      with_statement
+        t.db
+        "UPDATE operations SET state_kind = 'failed', source_json = NULL, input_json = NULL, completed_at = ?, failure_kind = 'interrupted_by_restart', failure_detail = 'operation interrupted by process restart' WHERE state_kind = 'running'"
+        (fun stmt ->
+           let* () =
+             Keeper_chat_queue_storage.bind
+               t.db stmt ~operation:"bind interrupted settlement timestamp" 1
+               (Sqlite3.Data.FLOAT completed_at)
+             |> Result.map_error (fun detail -> Store_unavailable detail)
+           in
+           Keeper_chat_queue_storage.expect_done
+             t.db stmt ~operation:"settle interrupted chat operations"
+           |> Result.map_error (fun detail -> Store_unavailable detail))
+    in
+    Ok running_ids
+  in
+  match body with
+  | Error error -> rollback t.db error
+  | Ok running_ids ->
+    (match
+       commit_transaction t ~operation:"commit interrupted operation settlement"
+     with
+     | Ok () -> Ok (List.length running_ids)
+     | Error error ->
+       if running_ids = []
+       then (
+         rollback_after_uncertain_commit t;
+         Ok 0)
+       else
+       let durable =
+         List.for_all
+           (fun operation_id ->
+              match durable_readback t ~operation_id with
+              | Ok
+                  (Some
+                    { state =
+                        Failed
+                          { completed_at = observed_at
+                          ; kind = Interrupted_by_restart
+                          ; _
+                          }
+                    ; _
+                    }) ->
+                Float.equal observed_at completed_at
+              | Ok (Some _ | None) | Error _ -> false)
+           running_ids
+       in
+         if durable
+         then Ok (List.length running_ids)
+         else (
+           rollback_after_uncertain_commit t;
+           store_error
+             ("interrupted operation settlement commit was uncertain: "
+              ^ error_to_string error)))
+;;
+
+module For_testing = struct
+  type nonrec commit_fault = commit_fault =
+    | Before_commit
+    | After_commit
+
+  let database_path = database_path
+  let fail_next_commit fault = Atomic.set commit_fault_for_testing (Some fault)
+end

--- a/lib/keeper/keeper_chat_operation_store.mli
+++ b/lib/keeper/keeper_chat_operation_store.mli
@@ -1,0 +1,138 @@
+(** Strict durable operation log for one Keeper's chat lane.
+
+    A Keeper owner creates one store, owns its SQLite connection, and is the
+    only writer. The store has no lease, receipt, recovery, or revision
+    vocabulary. *)
+
+type source =
+  | Dashboard of { thread_id : string }
+  | Discord of
+      { channel_id : string
+      ; user_id : string
+      }
+  | Slack of
+      { channel_id : string
+      ; user_id : string
+      ; user_name : string
+      ; team_id : string option
+      ; thread_ts : string option
+      }
+
+type input =
+  { content : string
+  ; user_blocks : Keeper_multimodal_input.user_input_block list
+  ; attachments : Keeper_chat_store.attachment list
+  ; submitted_at : float
+  ; source : source
+  ; user_row_origin : Keeper_chat_store.user_row_origin
+  }
+
+type edit_input =
+  { content : string
+  ; user_blocks : Keeper_multimodal_input.user_input_block list
+  ; attachments : Keeper_chat_store.attachment list
+  }
+
+type failure_kind =
+  | Interrupted_by_restart
+  | Turn_failed
+  | No_visible_reply
+  | Transcript_persist_failed
+  | Connector_unavailable
+  | Delivery_failed
+  | Terminal_effect_failed
+  | Internal_error
+
+type state =
+  | Queued
+  | Running of { started_at : float }
+  | Succeeded of
+      { completed_at : float
+      ; outcome_ref : string
+      }
+  | Failed of
+      { completed_at : float
+      ; kind : failure_kind
+      ; detail : string
+      ; outcome_ref : string option
+      }
+  | Cancelled of { completed_at : float }
+
+type operation =
+  { operation_id : string
+  ; admission_digest : string
+  ; execution_digest : string
+  ; sequence : int64
+  ; input : input option
+  ; state : state
+  }
+
+type error =
+  | Unknown_operation of string
+  | Not_queued of
+      { operation_id : string
+      ; state : state
+      }
+  | Idempotency_conflict of string
+  | Invalid_input of string
+  | Store_unavailable of string
+
+type submit_result =
+  | Accepted of operation
+  | Existing of operation
+
+type t
+
+val open_ : base_path:string -> keeper_name:string -> (t, error) result
+(** Open or create [chat-operations.sqlite3] and strictly validate its schema.
+    No older database is recognized or migrated. *)
+
+val close : t -> (unit, error) result
+
+val submit : t -> operation_id:string -> input -> (submit_result, error) result
+(** Durably insert before returning [Accepted]. Reusing an ID returns the
+    existing operation only when the canonical input digest is identical. *)
+
+val lookup : t -> operation_id:string -> (operation, error) result
+
+val list_queued :
+  t -> after_sequence:int64 option -> limit:int -> (operation list, error) result
+
+val start_next : t -> started_at:float -> (operation option, error) result
+(** Atomically transition the FIFO head from [Queued] to [Running]. *)
+
+val edit : t -> operation_id:string -> edit_input -> (operation, error) result
+val move_to_end : t -> operation_id:string -> (operation, error) result
+val cancel : t -> operation_id:string -> completed_at:float -> (operation, error) result
+
+val succeed :
+  t ->
+  operation_id:string ->
+  completed_at:float ->
+  outcome_ref:string ->
+  (operation, error) result
+
+val fail :
+  t ->
+  operation_id:string ->
+  completed_at:float ->
+  kind:failure_kind ->
+  detail:string ->
+  outcome_ref:string option ->
+  (operation, error) result
+
+val settle_interrupted : t -> completed_at:float -> (int, error) result
+(** In one transaction, close every persisted [Running] operation as
+    [Failed Interrupted_by_restart]. Queued and terminal rows are unchanged. *)
+
+val failure_kind_to_string : failure_kind -> string
+val error_to_string : error -> string
+
+module For_testing : sig
+  type commit_fault =
+    | Before_commit
+    | After_commit
+
+  val database_path : base_path:string -> keeper_name:string -> (string, error) result
+  val fail_next_commit : commit_fault -> unit
+end

--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -138,14 +138,6 @@ let owned_active_task_id_for_meta ~(config : Workspace.config)
   | Ok task_id -> task_id
   | Error _ -> None
 
-let merge_current_task_id ~(latest : Keeper_meta_contract.keeper_meta)
-    ~(caller : Keeper_meta_contract.keeper_meta) =
-  {
-    latest with
-    current_task_id = caller.current_task_id;
-    updated_at = caller.updated_at;
-  }
-
 let sync_current_task_id_from_backlog ~(config : Workspace.config)
     (meta : Keeper_meta_contract.keeper_meta) =
   match owned_active_task_id_result_for_meta ~config ~meta with
@@ -163,42 +155,43 @@ let sync_current_task_id_from_backlog ~(config : Workspace.config)
     in
     if equal then meta
     else
-      let updated_meta =
-        { meta with current_task_id = desired; updated_at = Masc_domain.now_iso () }
-      in
-      Keeper_registry.update_meta ~base_path:config.base_path meta.name updated_meta;
       (match
-         Keeper_meta_store.write_meta_with_merge
-           ~merge:merge_current_task_id config updated_meta
+         Keeper_owner_registry.apply_meta
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           (Keeper_owner_reducer.Set_current_task
+              { task_id = desired; updated_at = Masc_domain.now_iso () })
        with
-       | Ok () -> ()
-       | Error msg ->
+       | Ok (Some updated_meta) ->
+         Log.Keeper.debug
+           ~keeper_name:meta.name
+           "reconciled current_task_id=%s from backlog ownership"
+           (match desired with
+            | Some task_id -> Keeper_id.Task_id.to_string task_id
+            | None -> "(cleared)");
+         updated_meta
+       | Ok None ->
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string WriteMetaFailures)
-           ~labels:[("keeper", meta.name); ("phase", "reconcile_task_id")]
+           ~labels:[ "keeper", meta.name; "phase", "reconcile_task_id" ]
            ();
-         Log.Keeper.warn ~keeper_name:meta.name
+         Log.Keeper.warn
+           ~keeper_name:meta.name
+           "owner removed metadata while reconciling current_task_id";
+         meta
+       | Error error ->
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string WriteMetaFailures)
+           ~labels:[ "keeper", meta.name; "phase", "reconcile_task_id" ]
+           ();
+         Log.Keeper.warn
+           ~keeper_name:meta.name
            "failed to persist reconciled current_task_id=%s: %s"
            (match desired with
             | Some task_id -> Keeper_id.Task_id.to_string task_id
             | None -> "(cleared)")
-           (Keeper_meta_store.write_meta_error_to_string msg));
-      (* RFC-0142 / audit 2026-05-21 §10.2: this is the success path of a
-         routine drift correction, firing on every observed delta between
-         keeper_meta.current_task_id and backlog ownership.  Live measurement
-         on 5/21 captured 1,183 events/day across the fleet — none of them
-         individually actionable (the WARN branch above + the
-         [metric_keeper_write_meta_failures] counter already cover the
-         failure case).  Demoted to DEBUG so the high-volume verbose path
-         no longer drowns the INFO stream; raise back to INFO only if a
-         per-keeper thrash investigation needs structured timing without
-         a debug-level subscription. *)
-      Log.Keeper.debug ~keeper_name:meta.name
-        "reconciled current_task_id=%s from backlog ownership"
-        (match desired with
-         | Some task_id -> Keeper_id.Task_id.to_string task_id
-         | None -> "(cleared)");
-      updated_meta
+           (Keeper_owner_registry.command_error_to_string error);
+         meta)
 
 let sync_current_task_id_for_agent_name ~(config : Workspace.config) ~agent_name =
   match

--- a/lib/keeper/keeper_current_task_reconcile.mli
+++ b/lib/keeper/keeper_current_task_reconcile.mli
@@ -45,12 +45,6 @@ val owned_active_task_id_for_meta :
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_id.Task_id.t option
 
-(** Field-level merge for [Keeper_meta_store.write_meta_with_merge]. *)
-val merge_current_task_id :
-  latest:Keeper_meta_contract.keeper_meta ->
-  caller:Keeper_meta_contract.keeper_meta ->
-  Keeper_meta_contract.keeper_meta
-
 (** Persist [meta.current_task_id] after comparing it with backlog ownership. *)
 val sync_current_task_id_from_backlog :
   config:Workspace.config ->

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -8,7 +8,6 @@
 
 open Keeper_types
 open Keeper_meta_contract
-open Keeper_meta_store
 open Keeper_types_profile
 open Keeper_memory
 open Keeper_execution
@@ -106,55 +105,51 @@ let repair_identity_drift_for_keepalive ?lifecycle_token ~(ctx : _ context) (met
         ();
       None
     | Ok new_trace_id ->
-      let base_dir = session_base_dir ctx.config in
-      let _session =
-        Keeper_context_runtime.create_session ~session_id:new_trace_id_raw ~base_dir
-      in
-      let repaired =
-        { meta with
-          agent_name = expected_agent_name
-        ; updated_at = now_iso ()
-        ; runtime =
-            { meta.runtime with
-              trace_id = new_trace_id
-            ; trace_history =
-                Json_util.dedupe_keep_order
-                  (previous_trace_id :: meta.runtime.trace_history)
-            ; nonce = meta.runtime.nonce + 1
-            }
-        }
-      in
       (match
-         match lifecycle_token with
-         | None ->
-           write_meta_with_merge
-             ~merge:Keeper_meta_merge.monotonic_usage_counters
-             ctx.config
-             repaired
-           |> Result.map_error Keeper_meta_store.write_meta_error_to_string
-         | Some token ->
-           write_meta_with_merge_for_lifecycle
-             token
-             ~merge:Keeper_meta_merge.monotonic_usage_counters
-             ctx.config
-             repaired
+         Keeper_owner_registry.apply_meta
+           ~base_path:ctx.config.base_path
+           ~keeper_name:meta.name
+           (Keeper_owner_reducer.Handoff_identity
+              { keeper_id = meta.keeper_id
+              ; agent_name = expected_agent_name
+              ; trace_id = new_trace_id
+              ; trace_history =
+                  Json_util.dedupe_keep_order
+                    (previous_trace_id :: meta.runtime.trace_history)
+              ; generation = meta.runtime.nonce + 1
+              ; updated_at = now_iso ()
+              })
        with
-       | Ok () ->
+       | Ok (Some repaired) ->
+         let base_dir = session_base_dir ctx.config in
+         ignore
+           (Keeper_context_runtime.create_session
+              ~session_id:new_trace_id_raw
+              ~base_dir);
          Log.Keeper.warn
            "keepalive repaired identity drift for %s: %s -> %s"
            meta.name
            meta.agent_name
            expected_agent_name;
          Some repaired
-       | Error err ->
+       | Ok None ->
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string WriteMetaFailures)
            ~labels:[ "keeper", meta.name; "phase", "identity_repair" ]
            ();
          Log.Keeper.error
-           "keepalive identity repair failed for %s: write_meta failed: %s"
+           "keepalive identity repair failed for %s: owner removed metadata"
+           meta.name;
+         None
+       | Error error ->
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string WriteMetaFailures)
+           ~labels:[ "keeper", meta.name; "phase", "identity_repair" ]
+           ();
+         Log.Keeper.error
+           "keepalive identity repair failed for %s: owner command failed: %s"
            meta.name
-           err;
+           (Keeper_owner_registry.command_error_to_string error);
          None))
 ;;
 

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -208,21 +208,7 @@ let sync_keeper_presence
       ~labels:[ "keeper", meta_current.name ]
       ();
     note_turn_failures_preserved_after_heartbeat ~ctx ~meta:meta_current;
-    match
-      write_meta_with_merge
-        ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-        ctx.config
-        synced
-    with
-    | Ok () -> synced
-    | Error e ->
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string WriteMetaFailures)
-        ~labels:[ "keeper", synced.name; "phase", "heartbeat" ]
-        ();
-      Log.Keeper.warn "write_meta failed (heartbeat): %s"
-        (Keeper_meta_store.write_meta_error_to_string e);
-      synced
+    synced
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -541,35 +541,9 @@ let bootstrap_live_keeper_meta ?lifecycle_token ~(ctx : _ context) (m : keeper_m
           }
       }
     in
-    (match lifecycle_token with
-     | Some _ ->
-       (* The revival coordinator already committed the durable candidate.
-          Keep this fresh presence timestamp in the new registry lane; the
-          heartbeat persists it after the transaction releases ownership. *)
-       ()
-     | None ->
-       (match
-          write_meta_with_merge
-            ~merge:Keeper_meta_merge.monotonic_usage_counters
-            ctx.config
-            synced
-        with
-        | Ok () -> ()
-        | Error e ->
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string WriteMetaFailures)
-            ~labels:[ "keeper", synced.name; "phase", "bootstrap" ]
-            ();
-          Log.Keeper.emit
-            Log.Warn
-            ~category:Log.Heartbeat
-            ~details:
-              (`Assoc
-                 [ "keeper", `String synced.name
-                 ; "error", `String (Keeper_meta_store.write_meta_error_to_string e)
-                 ])
-            (Printf.sprintf "write_meta failed (bootstrap): %s"
-                 (Keeper_meta_store.write_meta_error_to_string e))));
+    (* Bootstrap freshness is process presence, not a durable semantic change.
+       The registry lane receives [synced]; only typed owner commands replace
+       the metadata snapshot. *)
     synced
   with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -11,17 +11,35 @@ type error =
   | Owner_closed
 
 type turn_start =
-  | Started
+  | Started of turn_handle
   | Busy of { running_operation_id : string }
+
+and turn_terminal =
+  | Turn_succeeded
+  | Turn_failed of string
+  | Turn_cancelled
+
+and turn_handle =
+  { operation_id : string
+  ; terminal : turn_terminal Eio.Promise.t
+  }
+
+type completion =
+  { handle : turn_handle
+  ; resolve : turn_terminal Eio.Promise.u
+  ; settled : bool Atomic.t
+  }
 
 type turn_request =
   { operation_id : string
   ; run : Eio.Switch.t -> unit
+  ; completion : completion
   }
 
 type child_outcome =
   | Child_succeeded
   | Child_failed of string
+  | Child_cancelled
 
 type _ command =
   | Exact_projection :
@@ -44,6 +62,8 @@ type t =
   { mailbox : packed_command Eio.Stream.t
   ; projection : Keeper_owner_reducer.projection Atomic.t
   ; closed : bool Atomic.t
+  ; closed_p : unit Eio.Promise.t
+  ; active_completion : completion option Atomic.t
   }
 
 let error_to_string = function
@@ -59,8 +79,36 @@ let request t command =
   then Error Owner_closed
   else (
     let response, resolve = Eio.Promise.create () in
-    Eio.Stream.add t.mailbox (Command (command, resolve));
-    Eio.Promise.await response)
+    match
+      Eio.Fiber.first
+        (fun () ->
+           Eio.Stream.add t.mailbox (Command (command, resolve));
+           `Enqueued)
+        (fun () ->
+           Eio.Promise.await t.closed_p;
+           `Closed)
+    with
+    | `Closed -> Error Owner_closed
+    | `Enqueued ->
+      Eio.Fiber.first
+        (fun () -> Eio.Promise.await response)
+        (fun () ->
+           Eio.Promise.await t.closed_p;
+           Error Owner_closed))
+;;
+
+let settle completion terminal =
+  if Atomic.compare_and_set completion.settled false true
+  then Eio.Promise.resolve completion.resolve terminal
+;;
+
+let settle_active t operation_id terminal =
+  let current = Atomic.get t.active_completion in
+  match current with
+  | Some completion when String.equal completion.handle.operation_id operation_id ->
+    if Atomic.compare_and_set t.active_completion current None
+    then settle completion terminal
+  | Some _ | None -> ()
 ;;
 
 let commit store transition =
@@ -110,7 +158,7 @@ let run_child t request =
   let outcome =
     match Eio.Switch.run (fun turn_sw -> request.run turn_sw) with
     | () -> Child_succeeded
-    | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+    | exception Eio.Cancel.Cancelled _ -> Child_cancelled
     | exception exn -> Child_failed (Printexc.to_string exn)
   in
   notify_child_finished t ~operation_id:request.operation_id outcome
@@ -118,6 +166,8 @@ let run_child t request =
 
 let log_child_failure operation_id = function
   | Child_succeeded -> ()
+  | Child_cancelled ->
+    Log.Keeper.info "keeper_owner: child turn cancelled operation_id=%s" operation_id
   | Child_failed detail ->
     Log.Keeper.error
       "keeper_owner: child turn failed operation_id=%s error=%s"
@@ -125,16 +175,24 @@ let log_child_failure operation_id = function
       detail
 ;;
 
-let start ~sw ~store ~initial_meta =
-  let initial_state = Keeper_owner_reducer.create initial_meta in
+let start ~sw ~store ~keeper_name ~initial_meta =
+  match Keeper_owner_reducer.create ~keeper_name initial_meta with
+  | Error error -> Error (Reducer_rejected error)
+  | Ok initial_state ->
+  let closed_p, resolve_closed = Eio.Promise.create () in
   let t =
     { mailbox = Eio.Stream.create mailbox_capacity
     ; projection = Atomic.make (Keeper_owner_reducer.projection initial_state)
     ; closed = Atomic.make false
+    ; closed_p
+    ; active_completion = Atomic.make None
     }
   in
   Eio.Switch.on_release sw (fun () ->
     Atomic.set t.closed true;
+    Eio.Promise.resolve resolve_closed ();
+    Option.iter (fun completion -> settle completion Turn_cancelled)
+      (Atomic.exchange t.active_completion None);
     let projection = Atomic.get t.projection in
     Atomic.set t.projection { projection with stopping = true });
   Eio.Fiber.fork_daemon ~sw (fun () ->
@@ -173,7 +231,8 @@ let start ~sw ~store ~initial_meta =
                 Eio.Promise.resolve resolve (Error error);
                 loop state
               | Ok state ->
-                Eio.Promise.resolve resolve (Ok Started);
+                Atomic.set t.active_completion (Some request.completion);
+                Eio.Promise.resolve resolve (Ok (Started request.completion.handle));
                 if transition_starts_child transition request.operation_id
                 then Eio.Fiber.fork ~sw:child_sw (fun () -> run_child t request);
                 loop state))
@@ -181,10 +240,12 @@ let start ~sw ~store ~initial_meta =
           log_child_failure operation_id outcome;
           (match Keeper_owner_reducer.finish_turn state ~operation_id with
            | Error error ->
+             let detail = Keeper_owner_reducer.error_to_string error in
              Log.Keeper.error
                "keeper_owner: rejected child completion operation_id=%s error=%s"
                operation_id
-               (Keeper_owner_reducer.error_to_string error);
+               detail;
+             settle_active t operation_id (Turn_failed detail);
              Eio.Promise.resolve resolve (Ok ());
              loop state
            | Ok transition ->
@@ -197,6 +258,13 @@ let start ~sw ~store ~initial_meta =
                 Eio.Promise.resolve resolve (Ok ());
                 loop state
               | Ok state ->
+                let terminal =
+                  match outcome with
+                  | Child_succeeded -> Turn_succeeded
+                  | Child_failed detail -> Turn_failed detail
+                  | Child_cancelled -> Turn_cancelled
+                in
+                settle_active t operation_id terminal;
                 Eio.Promise.resolve resolve (Ok ());
                 loop state))
         | Command (Begin_stopping, resolve) ->
@@ -210,12 +278,20 @@ let start ~sw ~store ~initial_meta =
              loop state)
       in
       loop initial_state));
-  t
+  Ok t
 ;;
 
 let exact_projection t = request t Exact_projection
 let apply_meta t command = request t (Apply_meta command)
-let start_turn t ~operation_id ~run = request t (Start_turn { operation_id; run })
+let start_turn t ~operation_id ~run =
+  let terminal, resolve = Eio.Promise.create () in
+  let handle = { operation_id; terminal } in
+  let completion = { handle; resolve; settled = Atomic.make false } in
+  request t (Start_turn { operation_id; run; completion })
+;;
+
+let await_turn handle = Eio.Promise.await handle.terminal
+let turn_handle_operation_id (handle : turn_handle) = handle.operation_id
 let begin_stopping t = request t Begin_stopping
 
 module For_testing = struct

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -2,7 +2,7 @@ let mailbox_capacity = 128
 
 type store =
   { replace : Keeper_meta_contract.keeper_meta -> (unit, string) result
-  ; remove : unit -> (unit, string) result
+  ; remove : Keeper_meta_contract.keeper_meta -> (unit, string) result
   }
 
 type error =
@@ -70,8 +70,8 @@ let commit store transition =
     (match store.replace meta with
      | Ok () -> Ok transition.state
      | Error detail -> Error (Store_unavailable detail))
-  | Remove_snapshot ->
-    (match store.remove () with
+  | Remove_snapshot meta ->
+    (match store.remove meta with
      | Ok () -> Ok transition.state
      | Error detail -> Error (Store_unavailable detail))
 ;;

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -1,0 +1,223 @@
+let mailbox_capacity = 128
+
+type store =
+  { replace : Keeper_meta_contract.keeper_meta -> (unit, string) result
+  ; remove : unit -> (unit, string) result
+  }
+
+type error =
+  | Reducer_rejected of Keeper_owner_reducer.error
+  | Store_unavailable of string
+  | Owner_closed
+
+type turn_start =
+  | Started
+  | Busy of { running_operation_id : string }
+
+type turn_request =
+  { operation_id : string
+  ; run : Eio.Switch.t -> unit
+  }
+
+type child_outcome =
+  | Child_succeeded
+  | Child_failed of string
+
+type _ command =
+  | Exact_projection :
+      (Keeper_owner_reducer.projection, error) result command
+  | Apply_meta :
+      Keeper_owner_reducer.meta_command
+      -> (Keeper_meta_contract.keeper_meta option, error) result command
+  | Start_turn : turn_request -> (turn_start, error) result command
+  | Child_finished :
+      { operation_id : string
+      ; outcome : child_outcome
+      }
+      -> (unit, error) result command
+  | Begin_stopping : (unit, error) result command
+
+type packed_command =
+  | Command : 'response command * 'response Eio.Promise.u -> packed_command
+
+type t =
+  { mailbox : packed_command Eio.Stream.t
+  ; projection : Keeper_owner_reducer.projection Atomic.t
+  ; closed : bool Atomic.t
+  }
+
+let error_to_string = function
+  | Reducer_rejected error -> Keeper_owner_reducer.error_to_string error
+  | Store_unavailable detail -> "keeper owner store unavailable: " ^ detail
+  | Owner_closed -> "keeper owner is closed"
+;;
+
+let projection t = Atomic.get t.projection
+
+let request t command =
+  if Atomic.get t.closed
+  then Error Owner_closed
+  else (
+    let response, resolve = Eio.Promise.create () in
+    Eio.Stream.add t.mailbox (Command (command, resolve));
+    Eio.Promise.await response)
+;;
+
+let commit store transition =
+  match transition.Keeper_owner_reducer.persistence with
+  | Keeper_owner_reducer.No_persistence -> Ok transition.state
+  | Replace_snapshot meta ->
+    (match store.replace meta with
+     | Ok () -> Ok transition.state
+     | Error detail -> Error (Store_unavailable detail))
+  | Remove_snapshot ->
+    (match store.remove () with
+     | Ok () -> Ok transition.state
+     | Error detail -> Error (Store_unavailable detail))
+;;
+
+let publish_effect t = function
+  | Keeper_owner_reducer.Publish_projection projection ->
+    Atomic.set t.projection projection
+  | Start_turn_child _ -> ()
+;;
+
+let apply_transition t store old_state transition =
+  match commit store transition with
+  | Error error -> Error (old_state, error)
+  | Ok state ->
+    List.iter (publish_effect t) transition.effects;
+    Ok state
+;;
+
+let transition_starts_child transition operation_id =
+  List.exists
+    (function
+      | Keeper_owner_reducer.Start_turn_child { operation_id = effect_operation_id } ->
+        String.equal effect_operation_id operation_id
+      | Publish_projection _ -> false)
+    transition.Keeper_owner_reducer.effects
+;;
+
+let notify_child_finished t ~operation_id outcome =
+  match request t (Child_finished { operation_id; outcome }) with
+  | Ok () -> ()
+  | Error Owner_closed -> ()
+  | Error (Reducer_rejected _ | Store_unavailable _) -> ()
+;;
+
+let run_child t request =
+  let outcome =
+    match Eio.Switch.run (fun turn_sw -> request.run turn_sw) with
+    | () -> Child_succeeded
+    | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+    | exception exn -> Child_failed (Printexc.to_string exn)
+  in
+  notify_child_finished t ~operation_id:request.operation_id outcome
+;;
+
+let log_child_failure operation_id = function
+  | Child_succeeded -> ()
+  | Child_failed detail ->
+    Log.Keeper.error
+      "keeper_owner: child turn failed operation_id=%s error=%s"
+      operation_id
+      detail
+;;
+
+let start ~sw ~store ~initial_meta =
+  let initial_state = Keeper_owner_reducer.create initial_meta in
+  let t =
+    { mailbox = Eio.Stream.create mailbox_capacity
+    ; projection = Atomic.make (Keeper_owner_reducer.projection initial_state)
+    ; closed = Atomic.make false
+    }
+  in
+  Eio.Switch.on_release sw (fun () ->
+    Atomic.set t.closed true;
+    let projection = Atomic.get t.projection in
+    Atomic.set t.projection { projection with stopping = true });
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    Eio.Switch.run (fun child_sw ->
+      let rec loop state =
+        match Eio.Stream.take t.mailbox with
+        | Command (Exact_projection, resolve) ->
+          Eio.Promise.resolve resolve (Ok (Keeper_owner_reducer.projection state));
+          loop state
+        | Command (Apply_meta command, resolve) ->
+          (match Keeper_owner_reducer.apply_meta state command with
+           | Error error ->
+             Eio.Promise.resolve resolve (Error (Reducer_rejected error));
+             loop state
+           | Ok transition ->
+             (match apply_transition t store state transition with
+              | Error (state, error) ->
+                Eio.Promise.resolve resolve (Error error);
+                loop state
+              | Ok state ->
+                Eio.Promise.resolve
+                  resolve
+                  (Ok (Keeper_owner_reducer.projection state).meta);
+                loop state))
+        | Command (Start_turn request, resolve) ->
+          (match Keeper_owner_reducer.begin_turn state ~operation_id:request.operation_id with
+           | Error (Turn_already_running running_operation_id) ->
+             Eio.Promise.resolve resolve (Ok (Busy { running_operation_id }));
+             loop state
+           | Error error ->
+             Eio.Promise.resolve resolve (Error (Reducer_rejected error));
+             loop state
+           | Ok transition ->
+             (match apply_transition t store state transition with
+              | Error (state, error) ->
+                Eio.Promise.resolve resolve (Error error);
+                loop state
+              | Ok state ->
+                Eio.Promise.resolve resolve (Ok Started);
+                if transition_starts_child transition request.operation_id
+                then Eio.Fiber.fork ~sw:child_sw (fun () -> run_child t request);
+                loop state))
+        | Command (Child_finished { operation_id; outcome }, resolve) ->
+          log_child_failure operation_id outcome;
+          (match Keeper_owner_reducer.finish_turn state ~operation_id with
+           | Error error ->
+             Log.Keeper.error
+               "keeper_owner: rejected child completion operation_id=%s error=%s"
+               operation_id
+               (Keeper_owner_reducer.error_to_string error);
+             Eio.Promise.resolve resolve (Ok ());
+             loop state
+           | Ok transition ->
+             (match apply_transition t store state transition with
+              | Error (state, error) ->
+                Log.Keeper.error
+                  "keeper_owner: child completion projection failed operation_id=%s error=%s"
+                  operation_id
+                  (error_to_string error);
+                Eio.Promise.resolve resolve (Ok ());
+                loop state
+              | Ok state ->
+                Eio.Promise.resolve resolve (Ok ());
+                loop state))
+        | Command (Begin_stopping, resolve) ->
+          let transition = Keeper_owner_reducer.begin_stopping state in
+          (match apply_transition t store state transition with
+           | Error (state, error) ->
+             Eio.Promise.resolve resolve (Error error);
+             loop state
+           | Ok state ->
+             Eio.Promise.resolve resolve (Ok ());
+             loop state)
+      in
+      loop initial_state));
+  t
+;;
+
+let exact_projection t = request t Exact_projection
+let apply_meta t command = request t (Apply_meta command)
+let start_turn t ~operation_id ~run = request t (Start_turn { operation_id; run })
+let begin_stopping t = request t Begin_stopping
+
+module For_testing = struct
+  let mailbox_depth t = Eio.Stream.length t.mailbox
+end

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -18,16 +18,24 @@ type error =
   | Owner_closed
 
 type turn_start =
-  | Started
+  | Started of turn_handle
   | Busy of { running_operation_id : string }
+
+and turn_terminal =
+  | Turn_succeeded
+  | Turn_failed of string
+  | Turn_cancelled
+
+and turn_handle
 
 type t
 
 val start
   :  sw:Eio.Switch.t
   -> store:store
+  -> keeper_name:string
   -> initial_meta:Keeper_meta_contract.keeper_meta option
-  -> t
+  -> (t, error) result
 
 val projection : t -> Keeper_owner_reducer.projection
 (** Lock-free immutable snapshot. *)
@@ -50,6 +58,9 @@ val start_turn
 (** Admit one child turn and return after actor admission, without waiting for
     the child.  A child exception is contained by the owner and releases the
     running slot. *)
+
+val await_turn : turn_handle -> turn_terminal
+val turn_handle_operation_id : turn_handle -> string
 
 val begin_stopping : t -> (unit, error) result
 (** Reject future external commands.  The root switch remains the structured

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -1,0 +1,62 @@
+(** Single-fiber owner for one Keeper.
+
+    Producers communicate through a bounded mailbox.  [apply_meta],
+    [exact_projection], and [start_turn] apply backpressure when the mailbox is
+    full; commands are never dropped or coalesced.  Routine reads use
+    {!projection} and do not enter the mailbox. *)
+
+val mailbox_capacity : int
+
+type store =
+  { replace : Keeper_meta_contract.keeper_meta -> (unit, string) result
+  ; remove : unit -> (unit, string) result
+  }
+
+type error =
+  | Reducer_rejected of Keeper_owner_reducer.error
+  | Store_unavailable of string
+  | Owner_closed
+
+type turn_start =
+  | Started
+  | Busy of { running_operation_id : string }
+
+type t
+
+val start
+  :  sw:Eio.Switch.t
+  -> store:store
+  -> initial_meta:Keeper_meta_contract.keeper_meta option
+  -> t
+
+val projection : t -> Keeper_owner_reducer.projection
+(** Lock-free immutable snapshot. *)
+
+val exact_projection
+  :  t
+  -> (Keeper_owner_reducer.projection, error) result
+(** Mailbox-linearized projection for mutation and exact-operation paths. *)
+
+val apply_meta
+  :  t
+  -> Keeper_owner_reducer.meta_command
+  -> (Keeper_meta_contract.keeper_meta option, error) result
+
+val start_turn
+  :  t
+  -> operation_id:string
+  -> run:(Eio.Switch.t -> unit)
+  -> (turn_start, error) result
+(** Admit one child turn and return after actor admission, without waiting for
+    the child.  A child exception is contained by the owner and releases the
+    running slot. *)
+
+val begin_stopping : t -> (unit, error) result
+(** Reject future external commands.  The root switch remains the structured
+    cancellation and join authority for the actor and its current child. *)
+
+val error_to_string : error -> string
+
+module For_testing : sig
+  val mailbox_depth : t -> int
+end

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -9,7 +9,7 @@ val mailbox_capacity : int
 
 type store =
   { replace : Keeper_meta_contract.keeper_meta -> (unit, string) result
-  ; remove : unit -> (unit, string) result
+  ; remove : Keeper_meta_contract.keeper_meta -> (unit, string) result
   }
 
 type error =

--- a/lib/keeper/keeper_owner_reducer.ml
+++ b/lib/keeper/keeper_owner_reducer.ml
@@ -31,6 +31,22 @@ type compaction_result =
   ; updated_at : string
   }
 
+type profile_update =
+  { instructions : string
+  ; sandbox_profile : Keeper_types_profile.sandbox_profile
+  ; network_mode : Keeper_types_profile.network_mode
+  ; allowed_paths : string list
+  ; mention_targets : string list
+  ; proactive_enabled : bool
+  ; max_context_override : int option
+  ; active_goal_ids : string list
+  ; autoboot_enabled : bool
+  ; telemetry_feedback_enabled : bool option
+  ; telemetry_feedback_window_hours : int option
+  ; always_allow : bool option
+  ; updated_at : string
+  }
+
 type meta_command =
   | Create of Keeper_meta_contract.keeper_meta
   | Pause of
@@ -43,6 +59,7 @@ type meta_command =
       { enabled : bool
       ; updated_at : string
       }
+  | Update_profile of profile_update
   | Handoff_identity of identity_handoff
   | Repair_trace_generation of
       { trace_id : Keeper_id.Trace_id.t
@@ -248,6 +265,25 @@ let apply_existing (state : state) meta command =
          { meta with paused = false; latched_reason = None; runtime; updated_at })
   | Set_autoboot { enabled; updated_at } ->
     Ok (with_meta state { meta with autoboot_enabled = enabled; updated_at })
+  | Update_profile update ->
+    Ok
+      (with_meta
+         state
+         { meta with
+           instructions = update.instructions
+         ; sandbox_profile = update.sandbox_profile
+         ; network_mode = update.network_mode
+         ; allowed_paths = update.allowed_paths
+         ; mention_targets = update.mention_targets
+         ; proactive = { enabled = update.proactive_enabled }
+         ; max_context_override = update.max_context_override
+         ; active_goal_ids = update.active_goal_ids
+         ; autoboot_enabled = update.autoboot_enabled
+         ; telemetry_feedback_enabled = update.telemetry_feedback_enabled
+         ; telemetry_feedback_window_hours = update.telemetry_feedback_window_hours
+         ; always_allow = update.always_allow
+         ; updated_at = update.updated_at
+         })
   | Handoff_identity handoff ->
     let runtime =
       { meta.runtime with

--- a/lib/keeper/keeper_owner_reducer.ml
+++ b/lib/keeper/keeper_owner_reducer.ml
@@ -77,7 +77,8 @@ type meta_command =
       }
 
 type state =
-  { meta : Keeper_meta_contract.keeper_meta option
+  { keeper_name : string
+  ; meta : Keeper_meta_contract.keeper_meta option
   ; running_operation_id : string option
   ; stopping : bool
   }
@@ -114,8 +115,19 @@ type error =
       ; actual : string
       }
   | Invalid_delta of string
+  | Keeper_identity_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Delete_while_running of string
 
-let create meta : state = { meta; running_operation_id = None; stopping = false }
+let create ~keeper_name meta =
+  match meta with
+  | Some meta when not (String.equal keeper_name meta.Keeper_meta_contract.name) ->
+    Error (Keeper_identity_mismatch { expected = keeper_name; actual = meta.name })
+  | Some _ | None ->
+    Ok { keeper_name; meta; running_operation_id = None; stopping = false }
+;;
 
 let projection (state : state) : projection =
   { meta = state.meta
@@ -218,6 +230,8 @@ let update_usage meta usage =
 let apply_existing (state : state) meta command =
   match command with
   | Create _ -> Error Meta_already_exists
+  | Delete when Option.is_some state.running_operation_id ->
+    Error (Delete_while_running (Option.get state.running_operation_id))
   | Delete ->
     let state = { state with meta = None } in
     Ok (publish_transition state (Remove_snapshot meta) [])
@@ -286,6 +300,14 @@ let apply_existing (state : state) meta command =
   | Record_compaction result ->
     if result.count_delta < 0
     then Error (Invalid_delta "compaction count_delta must be non-negative")
+    else if result.before_tokens < 0
+    then Error (Invalid_delta "compaction before_tokens must be non-negative")
+    else if result.after_tokens < 0
+    then Error (Invalid_delta "compaction after_tokens must be non-negative")
+    else if not (Float.is_finite result.at)
+    then Error (Invalid_delta "compaction at must be finite")
+    else if not (Float.is_finite result.checked_at)
+    then Error (Invalid_delta "compaction checked_at must be finite")
     else
       let previous = meta.runtime.compaction_rt in
       (match checked_add "compaction count" previous.count result.count_delta with
@@ -312,7 +334,12 @@ let apply_meta (state : state) command =
   then Error Owner_stopping
   else
     match state.meta, command with
-    | None, Create meta -> Ok (with_meta state meta)
+    | None, Create meta when String.equal state.keeper_name meta.name ->
+      Ok (with_meta state meta)
+    | None, Create meta ->
+      Error
+        (Keeper_identity_mismatch
+           { expected = state.keeper_name; actual = meta.name })
     | None, _ -> Error Meta_missing
     | Some meta, command -> apply_existing state meta command
 ;;
@@ -321,9 +348,10 @@ let begin_turn (state : state) ~operation_id =
   if state.stopping
   then Error Owner_stopping
   else
-    match state.running_operation_id with
-    | Some running -> Error (Turn_already_running running)
-    | None ->
+    match state.meta, state.running_operation_id with
+    | None, _ -> Error Meta_missing
+    | Some _, Some running -> Error (Turn_already_running running)
+    | Some _, None ->
       let state = { state with running_operation_id = Some operation_id } in
       Ok
         (publish_transition
@@ -357,4 +385,8 @@ let error_to_string = function
   | Turn_identity_mismatch { expected; actual } ->
     Printf.sprintf "turn identity mismatch: expected=%s actual=%s" expected actual
   | Invalid_delta detail -> "invalid additive delta: " ^ detail
+  | Keeper_identity_mismatch { expected; actual } ->
+    Printf.sprintf "Keeper identity mismatch: expected=%s actual=%s" expected actual
+  | Delete_while_running operation_id ->
+    Printf.sprintf "cannot delete Keeper while turn %s is running" operation_id
 ;;

--- a/lib/keeper/keeper_owner_reducer.ml
+++ b/lib/keeper/keeper_owner_reducer.ml
@@ -34,6 +34,7 @@ type compaction_result =
 type profile_update =
   { instructions : string
   ; sandbox_profile : Keeper_types_profile.sandbox_profile
+  ; sandbox_image : string option
   ; network_mode : Keeper_types_profile.network_mode
   ; allowed_paths : string list
   ; mention_targets : string list
@@ -44,6 +45,7 @@ type profile_update =
   ; telemetry_feedback_enabled : bool option
   ; telemetry_feedback_window_hours : int option
   ; always_allow : bool option
+  ; oas_env : (string * string) list
   ; updated_at : string
   }
 
@@ -272,6 +274,7 @@ let apply_existing (state : state) meta command =
          { meta with
            instructions = update.instructions
          ; sandbox_profile = update.sandbox_profile
+         ; sandbox_image = update.sandbox_image
          ; network_mode = update.network_mode
          ; allowed_paths = update.allowed_paths
          ; mention_targets = update.mention_targets
@@ -282,6 +285,7 @@ let apply_existing (state : state) meta command =
          ; telemetry_feedback_enabled = update.telemetry_feedback_enabled
          ; telemetry_feedback_window_hours = update.telemetry_feedback_window_hours
          ; always_allow = update.always_allow
+         ; oas_env = update.oas_env
          ; updated_at = update.updated_at
          })
   | Handoff_identity handoff ->

--- a/lib/keeper/keeper_owner_reducer.ml
+++ b/lib/keeper/keeper_owner_reducer.ml
@@ -1,0 +1,360 @@
+type usage_delta =
+  { turns : int
+  ; input_tokens : int
+  ; output_tokens : int
+  ; total_tokens : int
+  ; cost_usd : float
+  ; last_turn_ts : float
+  ; last_input_tokens : int
+  ; last_output_tokens : int
+  ; last_total_tokens : int
+  ; last_usage_reported_at : float option
+  ; last_latency_ms : int
+  }
+
+type identity_handoff =
+  { keeper_id : Keeper_id.Uid.t option
+  ; agent_name : string
+  ; trace_id : Keeper_id.Trace_id.t
+  ; trace_history : string list
+  ; generation : int
+  ; updated_at : string
+  }
+
+type compaction_result =
+  { count_delta : int
+  ; at : float
+  ; before_tokens : int
+  ; after_tokens : int
+  ; checked_at : float
+  ; decision : Keeper_meta_contract.compaction_runtime_decision
+  ; updated_at : string
+  }
+
+type meta_command =
+  | Create of Keeper_meta_contract.keeper_meta
+  | Pause of
+      { reason : Keeper_latched_reason.t
+      ; updated_at : string
+      }
+  | Resume of { updated_at : string }
+  | Reset_latch of { updated_at : string }
+  | Set_autoboot of
+      { enabled : bool
+      ; updated_at : string
+      }
+  | Handoff_identity of identity_handoff
+  | Repair_trace_generation of
+      { trace_id : Keeper_id.Trace_id.t
+      ; trace_history : string list
+      ; generation : int
+      ; updated_at : string
+      }
+  | Delete
+  | Turn_started_projection of { updated_at : string }
+  | Turn_succeeded of
+      { usage : usage_delta
+      ; updated_at : string
+      }
+  | Turn_failed of
+      { blocker : Keeper_meta_contract.blocker_info
+      ; usage : usage_delta option
+      ; updated_at : string
+      }
+  | Add_usage of usage_delta
+  | Set_current_task of
+      { task_id : Keeper_id.Task_id.t option
+      ; updated_at : string
+      }
+  | Set_blocker of
+      { blocker : Keeper_meta_contract.blocker_info option
+      ; updated_at : string
+      }
+  | Record_compaction of compaction_result
+  | Ack_message_scope of
+      { message_id : string option
+      ; updated_at : string
+      }
+
+type state =
+  { meta : Keeper_meta_contract.keeper_meta option
+  ; running_operation_id : string option
+  ; stopping : bool
+  }
+
+type projection =
+  { meta : Keeper_meta_contract.keeper_meta option
+  ; running_operation_id : string option
+  ; stopping : bool
+  }
+
+type persistence_intent =
+  | No_persistence
+  | Replace_snapshot of Keeper_meta_contract.keeper_meta
+  | Remove_snapshot
+
+type post_commit_effect =
+  | Publish_projection of projection
+  | Start_turn_child of { operation_id : string }
+
+type transition =
+  { state : state
+  ; persistence : persistence_intent
+  ; effects : post_commit_effect list
+  }
+
+type error =
+  | Meta_missing
+  | Meta_already_exists
+  | Owner_stopping
+  | Turn_already_running of string
+  | Turn_not_running
+  | Turn_identity_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Invalid_delta of string
+
+let create meta : state = { meta; running_operation_id = None; stopping = false }
+
+let projection (state : state) : projection =
+  { meta = state.meta
+  ; running_operation_id = state.running_operation_id
+  ; stopping = state.stopping
+  }
+;;
+
+let publish_transition (state : state) persistence extra_effects =
+  let projection = projection state in
+  { state
+  ; persistence
+  ; effects = Publish_projection projection :: extra_effects
+  }
+;;
+
+let with_meta (state : state) meta =
+  let state = { state with meta = Some meta } in
+  publish_transition state (Replace_snapshot meta) []
+;;
+
+let validate_delta delta =
+  if delta.turns < 0
+  then Error (Invalid_delta "turns must be non-negative")
+  else if delta.input_tokens < 0
+  then Error (Invalid_delta "input_tokens must be non-negative")
+  else if delta.output_tokens < 0
+  then Error (Invalid_delta "output_tokens must be non-negative")
+  else if delta.total_tokens < 0
+  then Error (Invalid_delta "total_tokens must be non-negative")
+  else if delta.cost_usd < 0.0 || not (Float.is_finite delta.cost_usd)
+  then Error (Invalid_delta "cost_usd must be finite and non-negative")
+  else if not (Float.is_finite delta.last_turn_ts)
+  then Error (Invalid_delta "last_turn_ts must be finite")
+  else if delta.last_input_tokens < 0
+  then Error (Invalid_delta "last_input_tokens must be non-negative")
+  else if delta.last_output_tokens < 0
+  then Error (Invalid_delta "last_output_tokens must be non-negative")
+  else if delta.last_total_tokens < 0
+  then Error (Invalid_delta "last_total_tokens must be non-negative")
+  else if delta.last_latency_ms < 0
+  then Error (Invalid_delta "last_latency_ms must be non-negative")
+  else if
+    Option.fold
+      ~none:false
+      ~some:(fun observed_at -> not (Float.is_finite observed_at))
+      delta.last_usage_reported_at
+  then Error (Invalid_delta "last_usage_reported_at must be finite")
+  else Ok ()
+;;
+
+let checked_add field current delta =
+  if current > max_int - delta
+  then Error (Invalid_delta (field ^ " overflow"))
+  else Ok (current + delta)
+;;
+
+let ( let* ) result f = Result.bind result f
+
+let add_usage meta delta =
+  match validate_delta delta with
+  | Error _ as error -> error
+  | Ok () ->
+    let usage = meta.Keeper_meta_contract.runtime.usage in
+    let total_cost_usd = usage.total_cost_usd +. delta.cost_usd in
+    if not (Float.is_finite total_cost_usd)
+    then Error (Invalid_delta "total_cost_usd overflow")
+    else
+      let* total_turns = checked_add "total_turns" usage.total_turns delta.turns in
+      let* total_input_tokens =
+        checked_add "total_input_tokens" usage.total_input_tokens delta.input_tokens
+      in
+      let* total_output_tokens =
+        checked_add "total_output_tokens" usage.total_output_tokens delta.output_tokens
+      in
+      let* total_tokens = checked_add "total_tokens" usage.total_tokens delta.total_tokens in
+      let usage : Keeper_meta_contract.usage_metrics =
+        { total_turns
+        ; total_input_tokens
+        ; total_output_tokens
+        ; total_tokens
+        ; total_cost_usd
+        ; last_turn_ts = delta.last_turn_ts
+        ; last_input_tokens = delta.last_input_tokens
+        ; last_output_tokens = delta.last_output_tokens
+        ; last_total_tokens = delta.last_total_tokens
+        ; last_usage_reported_at = delta.last_usage_reported_at
+        ; last_latency_ms = delta.last_latency_ms
+        }
+      in
+      Ok (Keeper_meta_contract.map_usage (fun _ -> usage) meta)
+;;
+
+let update_usage meta usage =
+  match usage with
+  | None -> Ok meta
+  | Some delta -> add_usage meta delta
+;;
+
+let apply_existing (state : state) meta command =
+  match command with
+  | Create _ -> Error Meta_already_exists
+  | Delete ->
+    let state = { state with meta = None } in
+    Ok (publish_transition state Remove_snapshot [])
+  | Pause { reason; updated_at } ->
+    Ok (with_meta state { meta with paused = true; latched_reason = Some reason; updated_at })
+  | Resume { updated_at } ->
+    let resumed = Keeper_meta_contract.mark_resumed meta in
+    Ok (with_meta state { resumed with updated_at })
+  | Reset_latch { updated_at } ->
+    let runtime = { meta.runtime with last_blocker = None } in
+    Ok
+      (with_meta
+         state
+         { meta with paused = false; latched_reason = None; runtime; updated_at })
+  | Set_autoboot { enabled; updated_at } ->
+    Ok (with_meta state { meta with autoboot_enabled = enabled; updated_at })
+  | Handoff_identity handoff ->
+    let runtime =
+      { meta.runtime with
+        trace_id = handoff.trace_id
+      ; trace_history = handoff.trace_history
+      ; nonce = handoff.generation
+      }
+    in
+    Ok
+      (with_meta
+         state
+         { meta with
+           keeper_id = handoff.keeper_id
+         ; agent_name = handoff.agent_name
+         ; runtime
+         ; updated_at = handoff.updated_at
+         })
+  | Repair_trace_generation repair ->
+    let runtime =
+      { meta.runtime with
+        trace_id = repair.trace_id
+      ; trace_history = repair.trace_history
+      ; nonce = repair.generation
+      }
+    in
+    Ok (with_meta state { meta with runtime; updated_at = repair.updated_at })
+  | Turn_started_projection { updated_at } ->
+    Ok (with_meta state { meta with updated_at })
+  | Turn_succeeded { usage; updated_at } ->
+    (match add_usage meta usage with
+     | Error _ as error -> error
+     | Ok meta ->
+       let runtime = { meta.runtime with last_blocker = None } in
+       Ok (with_meta state { meta with runtime; updated_at }))
+  | Turn_failed { blocker; usage; updated_at } ->
+    (match update_usage meta usage with
+     | Error _ as error -> error
+     | Ok meta ->
+       let runtime = { meta.runtime with last_blocker = Some blocker } in
+       Ok (with_meta state { meta with runtime; updated_at }))
+  | Add_usage delta ->
+    (match add_usage meta delta with
+     | Error _ as error -> error
+     | Ok meta -> Ok (with_meta state meta))
+  | Set_current_task { task_id; updated_at } ->
+    Ok (with_meta state { meta with current_task_id = task_id; updated_at })
+  | Set_blocker { blocker; updated_at } ->
+    let runtime = { meta.runtime with last_blocker = blocker } in
+    Ok (with_meta state { meta with runtime; updated_at })
+  | Record_compaction result ->
+    if result.count_delta < 0
+    then Error (Invalid_delta "compaction count_delta must be non-negative")
+    else
+      let previous = meta.runtime.compaction_rt in
+      (match checked_add "compaction count" previous.count result.count_delta with
+       | Error _ as error -> error
+       | Ok count ->
+         let compaction_rt =
+           { Keeper_meta_contract.count
+           ; last_ts = result.at
+           ; last_before_tokens = result.before_tokens
+           ; last_after_tokens = result.after_tokens
+           ; last_check_ts = result.checked_at
+           ; last_decision = result.decision
+           }
+         in
+         let meta = Keeper_meta_contract.map_compaction_rt (fun _ -> compaction_rt) meta in
+         Ok (with_meta state { meta with updated_at = result.updated_at }))
+  | Ack_message_scope { message_id; updated_at } ->
+    let runtime = { meta.runtime with message_scope_ack_id = message_id } in
+    Ok (with_meta state { meta with runtime; updated_at })
+;;
+
+let apply_meta (state : state) command =
+  if state.stopping
+  then Error Owner_stopping
+  else
+    match state.meta, command with
+    | None, Create meta -> Ok (with_meta state meta)
+    | None, _ -> Error Meta_missing
+    | Some meta, command -> apply_existing state meta command
+;;
+
+let begin_turn (state : state) ~operation_id =
+  if state.stopping
+  then Error Owner_stopping
+  else
+    match state.running_operation_id with
+    | Some running -> Error (Turn_already_running running)
+    | None ->
+      let state = { state with running_operation_id = Some operation_id } in
+      Ok
+        (publish_transition
+           state
+           No_persistence
+           [ Start_turn_child { operation_id } ])
+;;
+
+let finish_turn (state : state) ~operation_id =
+  match state.running_operation_id with
+  | None -> Error Turn_not_running
+  | Some actual when String.equal actual operation_id ->
+    let state = { state with running_operation_id = None } in
+    Ok (publish_transition state No_persistence [])
+  | Some actual ->
+    Error (Turn_identity_mismatch { expected = operation_id; actual })
+;;
+
+let begin_stopping (state : state) =
+  let state = { state with stopping = true } in
+  publish_transition state No_persistence []
+;;
+
+let error_to_string = function
+  | Meta_missing -> "keeper metadata does not exist"
+  | Meta_already_exists -> "keeper metadata already exists"
+  | Owner_stopping -> "keeper owner is stopping"
+  | Turn_already_running operation_id ->
+    Printf.sprintf "keeper turn %s is already running" operation_id
+  | Turn_not_running -> "keeper has no running turn"
+  | Turn_identity_mismatch { expected; actual } ->
+    Printf.sprintf "turn identity mismatch: expected=%s actual=%s" expected actual
+  | Invalid_delta detail -> "invalid additive delta: " ^ detail
+;;

--- a/lib/keeper/keeper_owner_reducer.ml
+++ b/lib/keeper/keeper_owner_reducer.ml
@@ -91,7 +91,7 @@ type projection =
 type persistence_intent =
   | No_persistence
   | Replace_snapshot of Keeper_meta_contract.keeper_meta
-  | Remove_snapshot
+  | Remove_snapshot of Keeper_meta_contract.keeper_meta
 
 type post_commit_effect =
   | Publish_projection of projection
@@ -220,7 +220,7 @@ let apply_existing (state : state) meta command =
   | Create _ -> Error Meta_already_exists
   | Delete ->
     let state = { state with meta = None } in
-    Ok (publish_transition state Remove_snapshot [])
+    Ok (publish_transition state (Remove_snapshot meta) [])
   | Pause { reason; updated_at } ->
     Ok (with_meta state { meta with paused = true; latched_reason = Some reason; updated_at })
   | Resume { updated_at } ->

--- a/lib/keeper/keeper_owner_reducer.ml
+++ b/lib/keeper/keeper_owner_reducer.ml
@@ -249,11 +249,12 @@ let update_usage meta usage =
 let apply_existing (state : state) meta command =
   match command with
   | Create _ -> Error Meta_already_exists
-  | Delete when Option.is_some state.running_operation_id ->
-    Error (Delete_while_running (Option.get state.running_operation_id))
   | Delete ->
-    let state = { state with meta = None } in
-    Ok (publish_transition state (Remove_snapshot meta) [])
+    (match state.running_operation_id with
+     | Some operation_id -> Error (Delete_while_running operation_id)
+     | None ->
+       let state = { state with meta = None } in
+       Ok (publish_transition state (Remove_snapshot meta) []))
   | Pause { reason; updated_at } ->
     Ok (with_meta state { meta with paused = true; latched_reason = Some reason; updated_at })
   | Resume { updated_at } ->

--- a/lib/keeper/keeper_owner_reducer.mli
+++ b/lib/keeper/keeper_owner_reducer.mli
@@ -1,0 +1,135 @@
+(** Pure state transition core for one Keeper owner.
+
+    This module contains no locks, fibers, persistence calls, clocks, or
+    callbacks.  Metadata changes are a closed command set: callers cannot
+    submit an arbitrary [keeper_meta -> keeper_meta] function. *)
+
+type usage_delta =
+  { turns : int
+  ; input_tokens : int
+  ; output_tokens : int
+  ; total_tokens : int
+  ; cost_usd : float
+  ; last_turn_ts : float
+  ; last_input_tokens : int
+  ; last_output_tokens : int
+  ; last_total_tokens : int
+  ; last_usage_reported_at : float option
+  ; last_latency_ms : int
+  }
+
+type identity_handoff =
+  { keeper_id : Keeper_id.Uid.t option
+  ; agent_name : string
+  ; trace_id : Keeper_id.Trace_id.t
+  ; trace_history : string list
+  ; generation : int
+  ; updated_at : string
+  }
+
+type compaction_result =
+  { count_delta : int
+  ; at : float
+  ; before_tokens : int
+  ; after_tokens : int
+  ; checked_at : float
+  ; decision : Keeper_meta_contract.compaction_runtime_decision
+  ; updated_at : string
+  }
+
+type meta_command =
+  | Create of Keeper_meta_contract.keeper_meta
+  | Pause of
+      { reason : Keeper_latched_reason.t
+      ; updated_at : string
+      }
+  | Resume of { updated_at : string }
+  | Reset_latch of { updated_at : string }
+  | Set_autoboot of
+      { enabled : bool
+      ; updated_at : string
+      }
+  | Handoff_identity of identity_handoff
+  | Repair_trace_generation of
+      { trace_id : Keeper_id.Trace_id.t
+      ; trace_history : string list
+      ; generation : int
+      ; updated_at : string
+      }
+  | Delete
+  | Turn_started_projection of { updated_at : string }
+  | Turn_succeeded of
+      { usage : usage_delta
+      ; updated_at : string
+      }
+  | Turn_failed of
+      { blocker : Keeper_meta_contract.blocker_info
+      ; usage : usage_delta option
+      ; updated_at : string
+      }
+  | Add_usage of usage_delta
+  | Set_current_task of
+      { task_id : Keeper_id.Task_id.t option
+      ; updated_at : string
+      }
+  | Set_blocker of
+      { blocker : Keeper_meta_contract.blocker_info option
+      ; updated_at : string
+      }
+  | Record_compaction of compaction_result
+  | Ack_message_scope of
+      { message_id : string option
+      ; updated_at : string
+      }
+
+type state
+
+type projection =
+  { meta : Keeper_meta_contract.keeper_meta option
+  ; running_operation_id : string option
+  ; stopping : bool
+  }
+
+type persistence_intent =
+  | No_persistence
+  | Replace_snapshot of Keeper_meta_contract.keeper_meta
+  | Remove_snapshot
+
+type post_commit_effect =
+  | Publish_projection of projection
+  | Start_turn_child of { operation_id : string }
+
+type transition =
+  { state : state
+  ; persistence : persistence_intent
+  ; effects : post_commit_effect list
+  }
+
+type error =
+  | Meta_missing
+  | Meta_already_exists
+  | Owner_stopping
+  | Turn_already_running of string
+  | Turn_not_running
+  | Turn_identity_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Invalid_delta of string
+
+val create : Keeper_meta_contract.keeper_meta option -> state
+val projection : state -> projection
+val apply_meta : state -> meta_command -> (transition, error) result
+
+val begin_turn
+  :  state
+  -> operation_id:string
+  -> (transition, error) result
+
+val finish_turn
+  :  state
+  -> operation_id:string
+  -> (transition, error) result
+
+val begin_stopping : state -> transition
+val error_to_string : error -> string

--- a/lib/keeper/keeper_owner_reducer.mli
+++ b/lib/keeper/keeper_owner_reducer.mli
@@ -116,8 +116,16 @@ type error =
       ; actual : string
       }
   | Invalid_delta of string
+  | Keeper_identity_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Delete_while_running of string
 
-val create : Keeper_meta_contract.keeper_meta option -> state
+val create
+  :  keeper_name:string
+  -> Keeper_meta_contract.keeper_meta option
+  -> (state, error) result
 val projection : state -> projection
 val apply_meta : state -> meta_command -> (transition, error) result
 

--- a/lib/keeper/keeper_owner_reducer.mli
+++ b/lib/keeper/keeper_owner_reducer.mli
@@ -93,7 +93,7 @@ type projection =
 type persistence_intent =
   | No_persistence
   | Replace_snapshot of Keeper_meta_contract.keeper_meta
-  | Remove_snapshot
+  | Remove_snapshot of Keeper_meta_contract.keeper_meta
 
 type post_commit_effect =
   | Publish_projection of projection

--- a/lib/keeper/keeper_owner_reducer.mli
+++ b/lib/keeper/keeper_owner_reducer.mli
@@ -37,6 +37,22 @@ type compaction_result =
   ; updated_at : string
   }
 
+type profile_update =
+  { instructions : string
+  ; sandbox_profile : Keeper_types_profile.sandbox_profile
+  ; network_mode : Keeper_types_profile.network_mode
+  ; allowed_paths : string list
+  ; mention_targets : string list
+  ; proactive_enabled : bool
+  ; max_context_override : int option
+  ; active_goal_ids : string list
+  ; autoboot_enabled : bool
+  ; telemetry_feedback_enabled : bool option
+  ; telemetry_feedback_window_hours : int option
+  ; always_allow : bool option
+  ; updated_at : string
+  }
+
 type meta_command =
   | Create of Keeper_meta_contract.keeper_meta
   | Pause of
@@ -49,6 +65,7 @@ type meta_command =
       { enabled : bool
       ; updated_at : string
       }
+  | Update_profile of profile_update
   | Handoff_identity of identity_handoff
   | Repair_trace_generation of
       { trace_id : Keeper_id.Trace_id.t

--- a/lib/keeper/keeper_owner_reducer.mli
+++ b/lib/keeper/keeper_owner_reducer.mli
@@ -40,6 +40,7 @@ type compaction_result =
 type profile_update =
   { instructions : string
   ; sandbox_profile : Keeper_types_profile.sandbox_profile
+  ; sandbox_image : string option
   ; network_mode : Keeper_types_profile.network_mode
   ; allowed_paths : string list
   ; mention_targets : string list
@@ -50,6 +51,7 @@ type profile_update =
   ; telemetry_feedback_enabled : bool option
   ; telemetry_feedback_window_hours : int option
   ; always_allow : bool option
+  ; oas_env : (string * string) list
   ; updated_at : string
   }
 

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -8,6 +8,7 @@ type install_error =
 type lookup_error =
   | Inventory_not_installed of string
   | Owner_not_found of string
+  | Owner_initialization_failed of Keeper_owner.error
   | Inventory_stopping
 
 type command_error =
@@ -49,6 +50,8 @@ let lookup_error_to_string = function
     Printf.sprintf "Keeper owner inventory is not installed for BasePath %s" base_path
   | Owner_not_found keeper_name ->
     Printf.sprintf "Keeper owner not found: %s" keeper_name
+  | Owner_initialization_failed error ->
+    "Keeper owner initialization failed: " ^ Keeper_owner.error_to_string error
   | Inventory_stopping -> "Keeper owner inventory is stopping"
 ;;
 
@@ -136,15 +139,18 @@ let ensure_in_pool pool meta =
       match Hashtbl.find_opt pool.owners meta.Keeper_meta_contract.name with
       | Some owner -> Ok owner
       | None ->
-        let owner =
+        (match
           Keeper_owner.start
             ~sw:pool.sw
             ~store:(store_for pool meta.name)
+            ~keeper_name:meta.name
             ~initial_meta:(Some meta)
-        in
-        Hashtbl.add pool.owners meta.name owner;
-        refresh_owner_handles pool;
-        Ok owner)
+         with
+         | Error error -> Error (Owner_initialization_failed error)
+         | Ok owner ->
+           Hashtbl.add pool.owners meta.name owner;
+           refresh_owner_handles pool;
+           Ok owner))
 ;;
 
 let install_from_store ~sw config =
@@ -189,7 +195,9 @@ let install_from_store ~sw config =
                   { keeper_name = Some meta.name
                   ; detail = "root switch stopped during owner installation"
                   })
-           | Error (Inventory_not_installed _ | Owner_not_found _) ->
+           | Error
+               (Inventory_not_installed _ | Owner_not_found _
+               | Owner_initialization_failed _) ->
              Error
                (Inventory_load_failed
                   { keeper_name = Some meta.name

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -13,6 +13,7 @@ type lookup_error =
 
 type command_error =
   | Command_lookup_failed of lookup_error
+  | Command_lifecycle_reserved of Keeper_lifecycle_reservation.snapshot
   | Command_rejected of Keeper_owner.error
 
 exception Install_failed of install_error
@@ -57,6 +58,9 @@ let lookup_error_to_string = function
 
 let command_error_to_string = function
   | Command_lookup_failed error -> lookup_error_to_string error
+  | Command_lifecycle_reserved owner ->
+    "Keeper owner command rejected by lifecycle reservation: "
+    ^ Keeper_lifecycle_reservation.snapshot_to_string owner
   | Command_rejected error -> Keeper_owner.error_to_string error
 ;;
 
@@ -232,16 +236,37 @@ let get ~base_path ~keeper_name =
       | None -> Error (Owner_not_found keeper_name))
 ;;
 
-let apply_meta ~base_path ~keeper_name command =
+let apply_meta ?lifecycle_token ~base_path ~keeper_name command =
   match get ~base_path ~keeper_name with
   | Error error -> Error (Command_lookup_failed error)
   | Ok owner ->
-    (match Keeper_owner.apply_meta owner command with
-     | Error error -> Error (Command_rejected error)
+    let result =
+      Keeper_lifecycle_reservation.with_key_lock
+        ~base_path
+        ~keeper_name
+        (fun () ->
+           match
+             Keeper_lifecycle_reservation.authorize
+               ?token:lifecycle_token
+               ~base_path
+               ~keeper_name
+               ()
+           with
+           | Error reservation -> Error (Command_lifecycle_reserved reservation)
+           | Ok () ->
+             (match Keeper_owner.apply_meta owner command with
+              | Error error -> Error (Command_rejected error)
+              | Ok meta -> Ok meta))
+    in
+    (match result with
      | Ok (Some meta) ->
+       (* This derived registry projection owns no state and intentionally runs
+          after the lifecycle lock is released: its update path takes that
+          same lock.  The owner Atomic remains the routine read authority. *)
        Keeper_registry.update_meta_from_persisted ~base_path keeper_name meta;
        Ok (Some meta)
-     | Ok None -> Ok None)
+     | Ok None -> Ok None
+     | Error _ as error -> error)
 ;;
 
 let all_projections ~base_path =

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -10,6 +10,10 @@ type lookup_error =
   | Owner_not_found of string
   | Inventory_stopping
 
+type command_error =
+  | Command_lookup_failed of lookup_error
+  | Command_rejected of Keeper_owner.error
+
 exception Install_failed of install_error
 
 type pool =
@@ -46,6 +50,11 @@ let lookup_error_to_string = function
   | Owner_not_found keeper_name ->
     Printf.sprintf "Keeper owner not found: %s" keeper_name
   | Inventory_stopping -> "Keeper owner inventory is stopping"
+;;
+
+let command_error_to_string = function
+  | Command_lookup_failed error -> lookup_error_to_string error
+  | Command_rejected error -> Keeper_owner.error_to_string error
 ;;
 
 let () =
@@ -213,6 +222,18 @@ let get ~base_path ~keeper_name =
       match Hashtbl.find_opt pool.owners keeper_name with
       | Some owner -> Ok owner
       | None -> Error (Owner_not_found keeper_name))
+;;
+
+let apply_meta ~base_path ~keeper_name command =
+  match get ~base_path ~keeper_name with
+  | Error error -> Error (Command_lookup_failed error)
+  | Ok owner ->
+    (match Keeper_owner.apply_meta owner command with
+     | Error error -> Error (Command_rejected error)
+     | Ok (Some meta) ->
+       Keeper_registry.update_meta_from_persisted ~base_path keeper_name meta;
+       Ok (Some meta)
+     | Ok None -> Ok None)
 ;;
 
 let all_projections ~base_path =

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -1,0 +1,231 @@
+type install_error =
+  | Inventory_already_installed of string
+  | Inventory_load_failed of
+      { keeper_name : string option
+      ; detail : string
+      }
+
+type lookup_error =
+  | Inventory_not_installed of string
+  | Owner_not_found of string
+  | Inventory_stopping
+
+exception Install_failed of install_error
+
+type pool =
+  { config : Workspace.config
+  ; sw : Eio.Switch.t
+  ; owners : (string, Keeper_owner.t) Hashtbl.t
+  ; owners_mu : Eio.Mutex.t
+  ; owner_handles : Keeper_owner.t list Atomic.t
+  ; stopping : bool Atomic.t
+  }
+
+let pools : (string, pool) Hashtbl.t = Hashtbl.create 4
+let pools_mu = Stdlib.Mutex.create ()
+
+let canonical_base_path base_path =
+  Keeper_registry_types.canonical_base_path_exn base_path
+;;
+
+let pool_key base_path = canonical_base_path base_path
+
+let install_error_to_string = function
+  | Inventory_already_installed base_path ->
+    Printf.sprintf "Keeper owner inventory already installed for BasePath %s" base_path
+  | Inventory_load_failed { keeper_name; detail } ->
+    (match keeper_name with
+     | None -> "failed to load Keeper owner inventory: " ^ detail
+     | Some keeper_name ->
+       Printf.sprintf "failed to load Keeper owner %s: %s" keeper_name detail)
+;;
+
+let lookup_error_to_string = function
+  | Inventory_not_installed base_path ->
+    Printf.sprintf "Keeper owner inventory is not installed for BasePath %s" base_path
+  | Owner_not_found keeper_name ->
+    Printf.sprintf "Keeper owner not found: %s" keeper_name
+  | Inventory_stopping -> "Keeper owner inventory is stopping"
+;;
+
+let () =
+  Printexc.register_printer (function
+    | Install_failed error -> Some (install_error_to_string error)
+    | _ -> None)
+;;
+
+let load_all config =
+  match Keeper_meta_store.keeper_names_result config with
+  | Error detail -> Error (Inventory_load_failed { keeper_name = None; detail })
+  | Ok names ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | keeper_name :: rest ->
+        (match Keeper_meta_store.read_meta config keeper_name with
+         | Error detail ->
+           Error (Inventory_load_failed { keeper_name = Some keeper_name; detail })
+         | Ok None ->
+           Error
+             (Inventory_load_failed
+                { keeper_name = Some keeper_name
+                ; detail = "metadata disappeared during strict owner inventory load"
+                })
+         | Ok (Some meta) -> loop (meta :: acc) rest)
+    in
+    loop [] names
+;;
+
+let remove_error_to_string error =
+  Keeper_meta_store.identity_remove_error_to_string error
+;;
+
+let store_for pool keeper_name : Keeper_owner.store =
+  { replace =
+      (fun meta ->
+         if not (String.equal meta.Keeper_meta_contract.name keeper_name)
+         then
+           Error
+             (Printf.sprintf
+                "owner snapshot identity mismatch: expected=%s actual=%s"
+                keeper_name
+                meta.name)
+         else Keeper_meta_store.persist_meta pool.config keeper_name meta)
+  ; remove =
+      (fun meta ->
+         match
+           Keeper_meta_store.remove_meta_if_identity
+             pool.config
+             ~name:keeper_name
+             ~trace_id:meta.runtime.trace_id
+             ~generation:meta.runtime.nonce
+         with
+         | Ok () -> Ok ()
+         | Error error -> Error (remove_error_to_string error))
+  }
+;;
+
+let refresh_owner_handles pool =
+  let owner_handles =
+    Hashtbl.to_seq_values pool.owners
+    |> List.of_seq
+    |> List.sort (fun left right ->
+      let name owner =
+        match (Keeper_owner.projection owner).Keeper_owner_reducer.meta with
+        | Some meta -> meta.name
+        | None -> ""
+      in
+      String.compare (name left) (name right))
+  in
+  Atomic.set pool.owner_handles owner_handles
+;;
+
+let ensure_in_pool pool meta =
+  if Atomic.get pool.stopping
+  then Error Inventory_stopping
+  else
+    Eio.Mutex.use_rw ~protect:true pool.owners_mu (fun () ->
+      match Hashtbl.find_opt pool.owners meta.Keeper_meta_contract.name with
+      | Some owner -> Ok owner
+      | None ->
+        let owner =
+          Keeper_owner.start
+            ~sw:pool.sw
+            ~store:(store_for pool meta.name)
+            ~initial_meta:(Some meta)
+        in
+        Hashtbl.add pool.owners meta.name owner;
+        refresh_owner_handles pool;
+        Ok owner)
+;;
+
+let install_from_store ~sw config =
+  let base_path = pool_key config.Workspace.base_path in
+  match load_all config with
+  | Error _ as error -> error
+  | Ok metas ->
+    let pool =
+      { config
+      ; sw
+      ; owners = Hashtbl.create (max 16 (List.length metas))
+      ; owners_mu = Eio.Mutex.create ()
+      ; owner_handles = Atomic.make []
+      ; stopping = Atomic.make false
+      }
+    in
+    let installed =
+      Stdlib.Mutex.protect pools_mu (fun () ->
+        if Hashtbl.mem pools base_path
+        then false
+        else (
+          Hashtbl.add pools base_path pool;
+          true))
+    in
+    if not installed
+    then Error (Inventory_already_installed base_path)
+    else (
+      Eio.Switch.on_release sw (fun () ->
+        Atomic.set pool.stopping true;
+        Stdlib.Mutex.protect pools_mu (fun () ->
+          match Hashtbl.find_opt pools base_path with
+          | Some current when current == pool -> Hashtbl.remove pools base_path
+          | Some _ | None -> ()));
+      let rec start_all count = function
+        | [] -> Ok count
+        | meta :: rest ->
+          (match ensure_in_pool pool meta with
+           | Ok _ -> start_all (count + 1) rest
+           | Error Inventory_stopping ->
+             Error
+               (Inventory_load_failed
+                  { keeper_name = Some meta.name
+                  ; detail = "root switch stopped during owner installation"
+                  })
+           | Error (Inventory_not_installed _ | Owner_not_found _) ->
+             Error
+               (Inventory_load_failed
+                  { keeper_name = Some meta.name
+                  ; detail = "owner inventory installation invariant failed"
+                  }))
+      in
+      start_all 0 metas)
+;;
+
+let find_pool base_path =
+  let base_path = pool_key base_path in
+  Stdlib.Mutex.protect pools_mu (fun () ->
+    match Hashtbl.find_opt pools base_path with
+    | None -> Error (Inventory_not_installed base_path)
+    | Some pool when Atomic.get pool.stopping -> Error Inventory_stopping
+    | Some pool -> Ok pool)
+;;
+
+let ensure ~base_path meta =
+  match find_pool base_path with
+  | Error _ as error -> error
+  | Ok pool -> ensure_in_pool pool meta
+;;
+
+let get ~base_path ~keeper_name =
+  match find_pool base_path with
+  | Error _ as error -> error
+  | Ok pool ->
+    Eio.Mutex.use_ro pool.owners_mu (fun () ->
+      match Hashtbl.find_opt pool.owners keeper_name with
+      | Some owner -> Ok owner
+      | None -> Error (Owner_not_found keeper_name))
+;;
+
+let all_projections ~base_path =
+  match find_pool base_path with
+  | Error _ as error -> error
+  | Ok pool ->
+    Ok (List.map Keeper_owner.projection (Atomic.get pool.owner_handles))
+;;
+
+module For_testing = struct
+  let installed_owner_count ~base_path =
+    match find_pool base_path with
+    | Error _ -> 0
+    | Ok pool -> Eio.Mutex.use_ro pool.owners_mu (fun () -> Hashtbl.length pool.owners)
+  ;;
+end

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -157,6 +157,28 @@ let ensure_in_pool pool meta =
            Ok owner))
 ;;
 
+let ensure_empty_in_pool pool keeper_name =
+  if Atomic.get pool.stopping
+  then Error Inventory_stopping
+  else
+    Eio.Mutex.use_rw ~protect:true pool.owners_mu (fun () ->
+      match Hashtbl.find_opt pool.owners keeper_name with
+      | Some owner -> Ok owner
+      | None ->
+        (match
+           Keeper_owner.start
+             ~sw:pool.sw
+             ~store:(store_for pool keeper_name)
+             ~keeper_name
+             ~initial_meta:None
+         with
+         | Error error -> Error (Owner_initialization_failed error)
+         | Ok owner ->
+           Hashtbl.add pool.owners keeper_name owner;
+           refresh_owner_handles pool;
+           Ok owner))
+;;
+
 let install_from_store ~sw config =
   let base_path = pool_key config.Workspace.base_path in
   match load_all config with
@@ -220,12 +242,6 @@ let find_pool base_path =
     | Some pool -> Ok pool)
 ;;
 
-let ensure ~base_path meta =
-  match find_pool base_path with
-  | Error _ as error -> error
-  | Ok pool -> ensure_in_pool pool meta
-;;
-
 let get ~base_path ~keeper_name =
   match find_pool base_path with
   | Error _ as error -> error
@@ -263,10 +279,20 @@ let apply_meta ?lifecycle_token ~base_path ~keeper_name command =
        (* This derived registry projection owns no state and intentionally runs
           after the lifecycle lock is released: its update path takes that
           same lock.  The owner Atomic remains the routine read authority. *)
-       Keeper_registry.update_meta_from_persisted ~base_path keeper_name meta;
+       if Option.is_some (Keeper_registry.get ~base_path keeper_name)
+       then Keeper_registry.update_meta_from_persisted ~base_path keeper_name meta;
        Ok (Some meta)
      | Ok None -> Ok None
      | Error _ as error -> error)
+;;
+
+let create_meta ~base_path meta =
+  match find_pool base_path with
+  | Error error -> Error (Command_lookup_failed error)
+  | Ok pool ->
+    (match ensure_empty_in_pool pool meta.Keeper_meta_contract.name with
+     | Error error -> Error (Command_lookup_failed error)
+     | Ok _ -> apply_meta ~base_path ~keeper_name:meta.name (Keeper_owner_reducer.Create meta))
 ;;
 
 let all_projections ~base_path =

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -253,46 +253,61 @@ let get ~base_path ~keeper_name =
 ;;
 
 let apply_meta ?lifecycle_token ~base_path ~keeper_name command =
-  match get ~base_path ~keeper_name with
-  | Error error -> Error (Command_lookup_failed error)
-  | Ok owner ->
-    let result =
-      Keeper_lifecycle_reservation.with_key_lock
-        ~base_path
-        ~keeper_name
-        (fun () ->
-           match
-             Keeper_lifecycle_reservation.authorize
-               ?token:lifecycle_token
-               ~base_path
-               ~keeper_name
-               ()
-           with
-           | Error reservation -> Error (Command_lifecycle_reserved reservation)
-           | Ok () ->
-             (match Keeper_owner.apply_meta owner command with
-              | Error error -> Error (Command_rejected error)
-              | Ok meta -> Ok meta))
-    in
-    (match result with
-     | Ok (Some meta) ->
-       (* This derived registry projection owns no state and intentionally runs
-          after the lifecycle lock is released: its update path takes that
-          same lock.  The owner Atomic remains the routine read authority. *)
-       if Option.is_some (Keeper_registry.get ~base_path keeper_name)
-       then Keeper_registry.update_meta_from_persisted ~base_path keeper_name meta;
-       Ok (Some meta)
-     | Ok None -> Ok None
-     | Error _ as error -> error)
+  let result =
+    Keeper_lifecycle_reservation.with_key_lock
+      ~base_path
+      ~keeper_name
+      (fun () ->
+         match get ~base_path ~keeper_name with
+         | Error error -> Error (Command_lookup_failed error)
+         | Ok owner ->
+           (match
+              Keeper_lifecycle_reservation.authorize
+                ?token:lifecycle_token
+                ~base_path
+                ~keeper_name
+                ()
+            with
+            | Error reservation -> Error (Command_lifecycle_reserved reservation)
+            | Ok () ->
+              (match Keeper_owner.apply_meta owner command with
+               | Error error -> Error (Command_rejected error)
+               | Ok meta -> Ok meta)))
+  in
+  (match result with
+   | Ok (Some meta) ->
+     (* This derived registry projection owns no state and intentionally runs
+        after the lifecycle lock is released: its update path takes that
+        same lock.  The owner Atomic remains the routine read authority. *)
+     if Option.is_some (Keeper_registry.get ~base_path keeper_name)
+     then Keeper_registry.update_meta_from_persisted ~base_path keeper_name meta;
+     Ok (Some meta)
+   | Ok None -> Ok None
+   | Error _ as error -> error)
 ;;
 
 let create_meta ~base_path meta =
   match find_pool base_path with
   | Error error -> Error (Command_lookup_failed error)
   | Ok pool ->
-    (match ensure_empty_in_pool pool meta.Keeper_meta_contract.name with
-     | Error error -> Error (Command_lookup_failed error)
-     | Ok _ -> apply_meta ~base_path ~keeper_name:meta.name (Keeper_owner_reducer.Create meta))
+    Keeper_lifecycle_reservation.with_key_lock
+      ~base_path
+      ~keeper_name:meta.Keeper_meta_contract.name
+      (fun () ->
+         match
+           Keeper_lifecycle_reservation.authorize
+             ~base_path
+             ~keeper_name:meta.name
+             ()
+         with
+         | Error reservation -> Error (Command_lifecycle_reserved reservation)
+         | Ok () ->
+           (match ensure_empty_in_pool pool meta.name with
+            | Error error -> Error (Command_lookup_failed error)
+            | Ok owner ->
+              (match Keeper_owner.apply_meta owner (Keeper_owner_reducer.Create meta) with
+               | Error error -> Error (Command_rejected error)
+               | Ok committed -> Ok committed)))
 ;;
 
 let all_projections ~base_path =

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -105,7 +105,11 @@ let store_for pool keeper_name : Keeper_owner.store =
                 "owner snapshot identity mismatch: expected=%s actual=%s"
                 keeper_name
                 meta.name)
-         else Keeper_meta_store.persist_meta pool.config keeper_name meta)
+         else
+           Keeper_meta_store.persist_meta
+             pool.config
+             (Keeper_types_profile.keeper_meta_path pool.config keeper_name)
+             meta)
   ; remove =
       (fun meta ->
          match

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -15,6 +15,10 @@ type lookup_error =
   | Owner_not_found of string
   | Inventory_stopping
 
+type command_error =
+  | Command_lookup_failed of lookup_error
+  | Command_rejected of Keeper_owner.error
+
 exception Install_failed of install_error
 
 val install_from_store
@@ -36,6 +40,14 @@ val get
   -> keeper_name:string
   -> (Keeper_owner.t, lookup_error) result
 
+val apply_meta
+  :  base_path:string
+  -> keeper_name:string
+  -> Keeper_owner_reducer.meta_command
+  -> (Keeper_meta_contract.keeper_meta option, command_error) result
+(** Mailbox-linearized metadata mutation.  Registry metadata is refreshed only
+    from the committed owner projection. *)
+
 val all_projections
   :  base_path:string
   -> (Keeper_owner_reducer.projection list, lookup_error) result
@@ -43,6 +55,7 @@ val all_projections
 
 val install_error_to_string : install_error -> string
 val lookup_error_to_string : lookup_error -> string
+val command_error_to_string : command_error -> string
 
 module For_testing : sig
   val installed_owner_count : base_path:string -> int

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -18,6 +18,7 @@ type lookup_error =
 
 type command_error =
   | Command_lookup_failed of lookup_error
+  | Command_lifecycle_reserved of Keeper_lifecycle_reservation.snapshot
   | Command_rejected of Keeper_owner.error
 
 exception Install_failed of install_error
@@ -42,12 +43,14 @@ val get
   -> (Keeper_owner.t, lookup_error) result
 
 val apply_meta
-  :  base_path:string
+  :  ?lifecycle_token:Keeper_lifecycle_reservation.token
+  -> base_path:string
   -> keeper_name:string
   -> Keeper_owner_reducer.meta_command
   -> (Keeper_meta_contract.keeper_meta option, command_error) result
 (** Mailbox-linearized metadata mutation.  Registry metadata is refreshed only
-    from the committed owner projection. *)
+    from the committed owner projection.  The existing lifecycle reservation
+    remains the admission authority through the owner commit. *)
 
 val all_projections
   :  base_path:string

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -30,13 +30,6 @@ val install_from_store
 (** Strictly load every persisted Keeper and start exactly one owner actor for
     each under [sw].  Returns the installed owner count. *)
 
-val ensure
-  :  base_path:string
-  -> Keeper_meta_contract.keeper_meta
-  -> (Keeper_owner.t, lookup_error) result
-(** Start the owner for a newly created Keeper, or return the existing owner.
-    Name collisions never replace an existing actor. *)
-
 val get
   :  base_path:string
   -> keeper_name:string
@@ -51,6 +44,14 @@ val apply_meta
 (** Mailbox-linearized metadata mutation.  Registry metadata is refreshed only
     from the committed owner projection.  The existing lifecycle reservation
     remains the admission authority through the owner commit. *)
+
+val create_meta
+  :  base_path:string
+  -> Keeper_meta_contract.keeper_meta
+  -> (Keeper_meta_contract.keeper_meta option, command_error) result
+(** Install an empty actor for a new Keeper, then commit its first snapshot via
+    the closed [Create] command.  A failed commit leaves the empty actor in
+    place so same-name retries remain mailbox-linearized. *)
 
 val all_projections
   :  base_path:string

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -1,0 +1,49 @@
+(** Process-local inventory of per-Keeper owners.
+
+    The existing BasePath process lease remains the authority.  This module
+    adds no process lease, worker epoch, or persistent ownership record. *)
+
+type install_error =
+  | Inventory_already_installed of string
+  | Inventory_load_failed of
+      { keeper_name : string option
+      ; detail : string
+      }
+
+type lookup_error =
+  | Inventory_not_installed of string
+  | Owner_not_found of string
+  | Inventory_stopping
+
+exception Install_failed of install_error
+
+val install_from_store
+  :  sw:Eio.Switch.t
+  -> Workspace.config
+  -> (int, install_error) result
+(** Strictly load every persisted Keeper and start exactly one owner actor for
+    each under [sw].  Returns the installed owner count. *)
+
+val ensure
+  :  base_path:string
+  -> Keeper_meta_contract.keeper_meta
+  -> (Keeper_owner.t, lookup_error) result
+(** Start the owner for a newly created Keeper, or return the existing owner.
+    Name collisions never replace an existing actor. *)
+
+val get
+  :  base_path:string
+  -> keeper_name:string
+  -> (Keeper_owner.t, lookup_error) result
+
+val all_projections
+  :  base_path:string
+  -> (Keeper_owner_reducer.projection list, lookup_error) result
+(** Lock-free fleet projection. *)
+
+val install_error_to_string : install_error -> string
+val lookup_error_to_string : lookup_error -> string
+
+module For_testing : sig
+  val installed_owner_count : base_path:string -> int
+end

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -13,6 +13,7 @@ type install_error =
 type lookup_error =
   | Inventory_not_installed of string
   | Owner_not_found of string
+  | Owner_initialization_failed of Keeper_owner.error
   | Inventory_stopping
 
 type command_error =

--- a/lib/keeper/keeper_paused_work_resume_transaction.ml
+++ b/lib/keeper/keeper_paused_work_resume_transaction.ml
@@ -142,8 +142,21 @@ let receipt_matches_request ~keeper_name request receipt =
 ;;
 
 let read_meta config keeper_name =
-  Keeper_meta_store.read_meta config keeper_name
-  |> Result.map_error (fun detail -> Durable_meta_read_failed detail)
+  match
+    Keeper_owner_registry.get
+      ~base_path:config.Workspace.base_path
+      ~keeper_name
+  with
+  | Error error ->
+    Error
+      (Durable_meta_read_failed
+         (Keeper_owner_registry.lookup_error_to_string error))
+  | Ok owner ->
+    (match Keeper_owner.exact_projection owner with
+     | Ok projection -> Ok projection.meta
+     | Error error ->
+       Error
+         (Durable_meta_read_failed (Keeper_owner.error_to_string error)))
 ;;
 
 let validate_identity (receipt : Keeper_paused_work_disposition_receipt.t)
@@ -248,34 +261,34 @@ let project_receipt token config (receipt : Keeper_paused_work_disposition_recei
   let* committed =
     if current.paused
     then
-      let* paused = paused_meta receipt current in
-      let candidate =
-        { (Keeper_meta_contract.mark_resumed paused) with
-          updated_at = Keeper_meta_contract.now_iso ()
-        }
+      let* _paused = paused_meta receipt current in
+      let* committed =
+        match
+          Keeper_owner_registry.apply_meta
+            ~lifecycle_token:token
+            ~base_path:config.base_path
+            ~keeper_name:receipt.keeper_name
+            (Keeper_owner_reducer.Resume
+               { updated_at = Keeper_meta_contract.now_iso () })
+        with
+        | Ok (Some committed) -> Ok committed
+        | Ok None -> Error Durable_meta_missing
+        | Error error ->
+          Error
+            (Projection_failed
+               { stage = Durable_meta
+               ; detail = Keeper_owner_registry.command_error_to_string error
+               })
       in
-      let* () =
-        Keeper_meta_store.write_meta_with_merge_for_lifecycle
-          token
-          ~merge:Keeper_meta_merge.monotonic_usage_counters
-          config
-          candidate
-        |> Result.map_error (fun detail ->
-          Projection_failed { stage = Durable_meta; detail })
-      in
-      (match read_meta config receipt.keeper_name with
-       | Error _ as error -> error
-       | Ok None -> Error Durable_meta_missing
-       | Ok (Some committed) ->
-         let* () = validate_identity receipt committed in
-         if committed.paused
-         then
-           Error
-             (Projection_failed
-                { stage = Durable_meta
-                ; detail = "durable pause bit remained set after commit"
-                })
-         else Ok committed)
+      let* () = validate_identity receipt committed in
+      if committed.paused
+      then
+        Error
+          (Projection_failed
+             { stage = Durable_meta
+             ; detail = "durable pause bit remained set after commit"
+             })
+      else Ok committed
     else Ok current
   in
   match entry with

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -430,15 +430,46 @@ let ensure_keeper_meta_with_cause config name =
              | None -> target_active_goal_ids)
         }
       in
-      match write_meta_deferred_runtime_sync config persisted_updated with
-      | Ok () -> Ok { effective_updated with meta_version = effective_updated.meta_version + 1 }
-      | Error e ->
+      match
+        Keeper_owner_registry.apply_meta
+          ~base_path:config.base_path
+          ~keeper_name:persisted_updated.name
+          (Keeper_owner_reducer.Update_profile
+             { instructions = persisted_updated.instructions
+             ; sandbox_profile = persisted_updated.sandbox_profile
+             ; sandbox_image = persisted_updated.sandbox_image
+             ; network_mode = persisted_updated.network_mode
+             ; allowed_paths = persisted_updated.allowed_paths
+             ; mention_targets = persisted_updated.mention_targets
+             ; proactive_enabled = persisted_updated.proactive.enabled
+             ; max_context_override = persisted_updated.max_context_override
+             ; active_goal_ids = persisted_updated.active_goal_ids
+             ; autoboot_enabled = persisted_updated.autoboot_enabled
+             ; telemetry_feedback_enabled = persisted_updated.telemetry_feedback_enabled
+             ; telemetry_feedback_window_hours =
+                 persisted_updated.telemetry_feedback_window_hours
+             ; always_allow = persisted_updated.always_allow
+             ; oas_env = persisted_updated.oas_env
+             ; updated_at = persisted_updated.updated_at
+             })
+      with
+      | Ok (Some committed) ->
+        Ok { committed with active_goal_ids = target_active_goal_ids }
+      | Ok None ->
+        Error
+          (boot_meta_error
+             Meta_read_error
+             (Printf.sprintf
+                "ensure_keeper_meta: owner metadata disappeared for %s"
+                effective_updated.name))
+      | Error error ->
+        let detail = Keeper_owner_registry.command_error_to_string error in
         Otel_metric_store.inc_counter
           Keeper_metrics.(to_string WriteMetaFailures)
           ~labels:[("keeper", effective_updated.name); ("phase", "ensure_meta_resync")]
           ();
-        Log.Keeper.warn "ensure_keeper_meta: write_meta re-sync failed: %s" e;
-        Ok overlayed
+        Log.Keeper.warn "ensure_keeper_meta: owner re-sync failed: %s" detail;
+        Error (boot_meta_error Meta_read_error detail)
     end
     else Ok overlayed))
   | Ok None ->

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -465,44 +465,40 @@ let launch_supervised_fiber_body
 	                  ~base_path
                   meta.name
                   (Some (Keeper_registry.Fiber_unresolved Unexpected));
-                (* Keeper meta runtime [last_blocker] can remain null after an
-                 unresolved fiber. The diagnosis would otherwise stay buried in the
-                 crash registry but invisible on the per-keeper meta surface
-                 dashboards read.  Stamp the same cohort onto runtime so
-                 operators (and the dashboard "차단된 키퍼" card) see why a
-                 keeper is silent.  Best-effort: write_meta failure does not
-                 abort cleanup. *)
-                (match Keeper_registry.get ~base_path meta.name with
-                 | Some entry ->
-                   let stamped_meta =
-                     { entry.meta with
-                       runtime =
-                         { entry.meta.runtime with
-                           last_blocker =
-                             Some
-                               (blocker_info_of_class
-                                  ~detail:"fiber_unresolved"
-                                  Fiber_unresolved)
-                         }
-                     }
-                   in
-                   (match
-                      write_meta_with_merge
-                        ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-                        ctx.config
-                        stamped_meta
-                    with
-                    | Ok () -> ()
-                    | Error err ->
-                      Otel_metric_store.inc_counter
-                        Keeper_metrics.(to_string WriteMetaFailures)
-                        ~labels:[ "keeper", meta.name; "phase", "fiber_unresolved_stamp" ]
-                        ();
-                      Log.Keeper.warn
-                        "%s: fiber_unresolved meta stamp failed: %s"
-                        meta.name
-                        (Keeper_meta_store.write_meta_error_to_string err))
-                 | None -> ());
+                (* Stamp the durable blocker through the Keeper owner. Failure
+                   remains best-effort for supervisor cleanup, but no snapshot
+                   assembled by this fiber can overwrite owner state. *)
+                (match
+                   Keeper_owner_registry.apply_meta
+                     ~base_path
+                     ~keeper_name:meta.name
+                     (Keeper_owner_reducer.Set_blocker
+                        { blocker =
+                            Some
+                              (blocker_info_of_class
+                                 ~detail:"fiber_unresolved"
+                                 Fiber_unresolved)
+                        ; updated_at = Keeper_meta_contract.now_iso ()
+                        })
+                 with
+                 | Ok (Some _) -> ()
+                 | Ok None ->
+                   Otel_metric_store.inc_counter
+                     Keeper_metrics.(to_string WriteMetaFailures)
+                     ~labels:[ "keeper", meta.name; "phase", "fiber_unresolved_stamp" ]
+                     ();
+                   Log.Keeper.warn
+                     "%s: fiber_unresolved owner metadata missing"
+                     meta.name
+                 | Error error ->
+                   Otel_metric_store.inc_counter
+                     Keeper_metrics.(to_string WriteMetaFailures)
+                     ~labels:[ "keeper", meta.name; "phase", "fiber_unresolved_stamp" ]
+                     ();
+                   Log.Keeper.warn
+                     "%s: fiber_unresolved owner command failed: %s"
+                     meta.name
+                     (Keeper_owner_registry.command_error_to_string error));
                 let ts = Time_compat.now () in
                 Keeper_registry.record_crash ~base_path meta.name ts reason;
                 let rc =

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -192,16 +192,27 @@ let keeper_reset_body ~(config : Workspace.config) args : tool_result =
   match resolve_keeper_meta_config ~config args with
   | Error err -> tool_result_error err
   | Ok meta ->
-    let reset_meta = Keeper_meta_contract.reset_runtime_state meta in
-    (match Keeper_meta_store.write_meta config reset_meta with
-     | Ok () ->
+    (match
+       Keeper_owner_registry.apply_meta
+         ~base_path:config.base_path
+         ~keeper_name:meta.name
+         (Keeper_owner_reducer.Reset_latch
+            { updated_at = Keeper_meta_contract.now_iso () })
+     with
+     | Ok (Some _) ->
        tool_result_ok
          (Printf.sprintf
-            "Reset runtime state for %s: usage counters zeroed, last_model_used cleared."
+            "Reset lifecycle latch for %s: pause and blocker state cleared."
             meta.name)
-     | Error err ->
+     | Ok None ->
        tool_result_error
-         (Printf.sprintf "Failed to write reset meta for %s: %s" meta.name err))
+         (Printf.sprintf "Failed to reset %s: owner metadata missing" meta.name)
+     | Error error ->
+       tool_result_error
+         (Printf.sprintf
+            "Failed to reset %s: %s"
+            meta.name
+            (Keeper_owner_registry.command_error_to_string error)))
 
 let handle_keeper_reset ctx args : tool_result =
   keeper_reset_body ~config:ctx.config args

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -154,32 +154,40 @@ let maybe_reseed_keeper_identity_config ~(config : Workspace.config) (meta : kee
             "failed to reseed keeper identity for %s: invalid trace_id %s (%s)"
             meta.name new_trace_id_raw err)
     in
+    let* updated_meta =
+      match
+        Keeper_owner_registry.apply_meta
+          ~base_path:config.base_path
+          ~keeper_name:meta.name
+          (Keeper_owner_reducer.Handoff_identity
+             { keeper_id = meta.keeper_id
+             ; agent_name = expected_agent_name
+             ; trace_id = new_trace_id
+             ; trace_history =
+                 Json_util.dedupe_keep_order
+                   (previous_trace_id :: meta.runtime.trace_history)
+             ; generation = meta.runtime.nonce + 1
+             ; updated_at = Keeper_meta_contract.now_iso ()
+             })
+      with
+      | Ok (Some updated_meta) -> Ok updated_meta
+      | Ok None ->
+        Error
+          (Printf.sprintf
+             "failed to reseed keeper identity for %s: owner metadata missing"
+             meta.name)
+      | Error error ->
+        Error
+          (Printf.sprintf
+             "failed to persist reseeded keeper identity for %s: %s"
+             meta.name
+             (Keeper_owner_registry.command_error_to_string error))
+    in
     let base_dir = Keeper_types_profile.session_base_dir config in
-    let _session =
-      Keeper_context_runtime.create_session ~session_id:new_trace_id_raw ~base_dir
-    in
-    let updated_meta =
-      { meta with
-        agent_name = expected_agent_name;
-        updated_at = Keeper_meta_contract.now_iso ();
-        runtime =
-          { meta.runtime with
-            trace_id = new_trace_id;
-            trace_history =
-              Json_util.dedupe_keep_order (previous_trace_id :: meta.runtime.trace_history);
-            nonce = meta.runtime.nonce + 1;
-          };
-      }
-    in
-    let* () =
-      Keeper_meta_store.write_meta_with_merge
-        ~merge:Keeper_meta_merge.monotonic_usage_counters config updated_meta
-      |> Result.map_error Keeper_meta_store.write_meta_error_to_string
-      |> Result.map_error (fun err ->
-          Printf.sprintf
-            "failed to persist reseeded keeper identity for %s: %s"
-            meta.name err)
-    in
+    ignore
+      (Keeper_context_runtime.create_session
+         ~session_id:new_trace_id_raw
+         ~base_dir);
     Ok
       ( updated_meta,
         Some

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -222,14 +222,6 @@ let find_task_goal_id config task_id =
   | Some [] | None -> None
 ;;
 
-let merge_current_task_id ~(latest : keeper_meta) ~(caller : keeper_meta) =
-  {
-    latest with
-    current_task_id = caller.current_task_id;
-    updated_at = caller.updated_at;
-  }
-;;
-
 let sync_keeper_meta_current_task
     ~(config : Workspace.config)
     ~(meta : keeper_meta)
@@ -241,22 +233,33 @@ let sync_keeper_meta_current_task
       "could not sync claimed task %s into current_task_id: %s"
       task_id msg
   | Ok current_task_id ->
-    let updated_meta =
-      { meta with current_task_id = Some current_task_id; updated_at = now_iso () }
-    in
-    Keeper_registry.update_meta ~base_path:config.base_path meta.name updated_meta;
     (match
-       Keeper_meta_store.write_meta_with_merge ~merge:merge_current_task_id config updated_meta
+       Keeper_owner_registry.apply_meta
+         ~base_path:config.base_path
+         ~keeper_name:meta.name
+         (Keeper_owner_reducer.Set_current_task
+            { task_id = Some current_task_id; updated_at = now_iso () })
      with
-     | Ok () -> ()
-     | Error msg ->
+     | Ok (Some _) -> ()
+     | Ok None ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string WriteMetaFailures)
-         ~labels:[("keeper", meta.name); ("phase", "claim_task_id")]
+         ~labels:[ "keeper", meta.name; "phase", "claim_task_id" ]
          ();
-       Log.Keeper.warn ~keeper_name:meta.name
+       Log.Keeper.warn
+         ~keeper_name:meta.name
+         "owner removed metadata while syncing claimed current_task_id=%s"
+         task_id
+     | Error error ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string WriteMetaFailures)
+         ~labels:[ "keeper", meta.name; "phase", "claim_task_id" ]
+         ();
+       Log.Keeper.warn
+         ~keeper_name:meta.name
          "failed to persist claimed current_task_id=%s: %s"
-         task_id (Keeper_meta_store.write_meta_error_to_string msg))
+         task_id
+         (Keeper_owner_registry.command_error_to_string error))
 ;;
 
 (* Cluster sub-dispatch via closed sum type — string [name] is converted

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -13,14 +13,11 @@ open Keeper_execution
 open Keeper_turn_up_args
 
 
-(* #9749: bootstrap can race a heartbeat/supervisor meta write after
-   crash recovery. Retry on CAS conflict while keeping heartbeat-owned
-   cursors from disk. *)
 let write_initial_meta config meta =
-  write_meta_with_merge
-    ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-    config meta
-  |> Result.map_error Keeper_meta_store.write_meta_error_to_string
+  match Keeper_owner_registry.create_meta ~base_path:config.Workspace.base_path meta with
+  | Ok (Some _) -> Ok ()
+  | Ok None -> Error "Keeper owner removed metadata during create"
+  | Error error -> Error (Keeper_owner_registry.command_error_to_string error)
 
 let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   Log.Keeper.info "create_keeper: starting for name=%s" p.name;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -34,13 +34,25 @@ let resume_operator_pause
          ("explicit keeper up could not resume operator pause: "
           ^ Keeper_paused_work_resume_transaction.error_to_string error)
      | Ok _ ->
-       (match Keeper_meta_store.read_meta ctx.config old.name with
-        | Error detail ->
-          Error ("resumed keeper metadata read failed: " ^ detail)
-        | Ok None -> Error "resumed keeper metadata disappeared"
-        | Ok (Some resumed) when resumed.paused ->
-          Error "explicit keeper up committed but pause remained set"
-        | Ok (Some resumed) -> Ok resumed))
+       (match
+          Keeper_owner_registry.get
+            ~base_path:ctx.config.base_path
+            ~keeper_name:old.name
+        with
+        | Error error ->
+          Error
+            ("resumed Keeper owner lookup failed: "
+             ^ Keeper_owner_registry.lookup_error_to_string error)
+        | Ok owner ->
+          (match Keeper_owner.exact_projection owner with
+           | Error error ->
+             Error
+               ("resumed Keeper owner projection failed: "
+                ^ Keeper_owner.error_to_string error)
+           | Ok { meta = None; _ } -> Error "resumed Keeper metadata disappeared"
+           | Ok { meta = Some resumed; _ } when resumed.paused ->
+             Error "explicit keeper up committed but pause remained set"
+           | Ok { meta = Some resumed; _ } -> Ok resumed)))
   | false, _
   | true, Some
       ( Keeper_latched_reason.Dead_tombstone
@@ -345,26 +357,37 @@ let update_keeper ?(preserve_prompt_defaults = false)
               in
               ()
             in
-            (* CAS-merge instead of a force write: a dashboard/turn-up edit
-               builds [updated] from a meta snapshot ([old]), so a concurrent
-               keeper turn that bumped cumulative usage counters between the
-               read and this write would otherwise be silently rewound
-               (total_turns 385->370, 2026-06-10). This operator lifecycle edit
-               preserves the observed pause disposition while taking cumulative
-               counters as [max latest caller]. *)
             (match
-               write_meta_with_merge
-                 ~merge:Keeper_meta_merge.monotonic_usage_counters
-                 ctx.config
-                 updated
+               Keeper_owner_registry.apply_meta
+                 ~base_path:ctx.config.base_path
+                 ~keeper_name:updated.name
+                 (Keeper_owner_reducer.Update_profile
+                    { instructions = updated.instructions
+                    ; sandbox_profile = updated.sandbox_profile
+                    ; network_mode = updated.network_mode
+                    ; allowed_paths = updated.allowed_paths
+                    ; mention_targets = updated.mention_targets
+                    ; proactive_enabled = updated.proactive.enabled
+                    ; max_context_override = updated.max_context_override
+                    ; active_goal_ids = updated.active_goal_ids
+                    ; autoboot_enabled = updated.autoboot_enabled
+                    ; telemetry_feedback_enabled = updated.telemetry_feedback_enabled
+                    ; telemetry_feedback_window_hours =
+                        updated.telemetry_feedback_window_hours
+                    ; always_allow = updated.always_allow
+                    ; updated_at = updated.updated_at
+                    })
              with
-             | Error e ->
+             | Error error ->
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string WriteMetaFailures)
                  ~labels:[("keeper", updated.name); ("phase", "update_keeper")]
                  ();
-               tool_result_error (Keeper_meta_store.write_meta_error_to_string e)
-             | Ok () ->
+               tool_result_error
+                 (Keeper_owner_registry.command_error_to_string error)
+             | Ok None ->
+               tool_result_error "Keeper owner metadata disappeared during update"
+             | Ok (Some updated) ->
                (match
                   Keeper_shutdown_supersession.commit_after_metadata_update
                     ~config:ctx.config

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -364,6 +364,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
                  (Keeper_owner_reducer.Update_profile
                     { instructions = updated.instructions
                     ; sandbox_profile = updated.sandbox_profile
+                    ; sandbox_image = updated.sandbox_image
                     ; network_mode = updated.network_mode
                     ; allowed_paths = updated.allowed_paths
                     ; mention_targets = updated.mention_targets
@@ -375,6 +376,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
                     ; telemetry_feedback_window_hours =
                         updated.telemetry_feedback_window_hours
                     ; always_allow = updated.always_allow
+                    ; oas_env = updated.oas_env
                     ; updated_at = updated.updated_at
                     })
              with

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1037,6 +1037,14 @@ let start_keeper_loops_owned
       f
   in
   let config = workspace_scope.Mcp_server.config in
+  let keeper_owner_count =
+    match Keeper_owner_registry.install_from_store ~sw config with
+    | Ok count -> count
+    | Error error -> raise (Keeper_owner_registry.Install_failed error)
+  in
+  Log.Keeper.info
+    "keeper_owner: installed %d single-owner actor(s) under server root switch"
+    keeper_owner_count;
   (* [claimed_persistence] can only be constructed by the typed one-shot claim
      boundary before readiness publication. No late exception can turn an
      already-visible HTTP state into a degraded bootstrap. *)

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -119,32 +119,28 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
     let workspace_scope = Mcp_server.workspace_scope state in
     let config = workspace_scope.config in
     let persist_keeper_pause () =
-      match Keeper_meta_store.read_meta config name with
-      | Ok (Some meta) when meta.paused -> true
-      | Ok (Some meta) ->
-           let updated_meta =
-             { meta with
-               paused = true
-             ; updated_at = Keeper_meta_contract.now_iso ()
-             }
-           in
-           (match
-              Keeper_meta_store.write_meta_with_merge
-                ~merge:Keeper_meta_merge.caller_wins config updated_meta
-            with
-            | Ok () -> true
-            | Error err ->
-              Log.Keeper.warn
-                "keeper %s pause: write_meta failed: %s"
-                name
-                (Keeper_meta_store.write_meta_error_to_string err);
-              false)
-      (* Issue #8391 HIGH #1: split [Ok None] (meta vanished) from
-         [Error _] (IO/parse failure) so lifecycle pause persistence after
-         clear/shutdown cannot silently disappear. *)
-      | Ok None ->
+      match Keeper_owner_registry.get ~base_path:config.base_path ~keeper_name:name with
+      | Ok owner
+        when Option.exists
+               (fun (meta : Keeper_meta_contract.keeper_meta) -> meta.paused)
+               (Keeper_owner.projection owner).meta ->
+        true
+      | Ok _ ->
+        (match
+           Keeper_owner_registry.apply_meta
+             ~base_path:config.base_path
+             ~keeper_name:name
+             (Keeper_owner_reducer.Pause
+                { reason =
+                    Keeper_latched_reason.Operator_paused
+                      { operator_actor = Keeper_latched_reason.Keeper_down }
+                ; updated_at = Keeper_meta_contract.now_iso ()
+                })
+         with
+         | Ok (Some _) -> true
+         | Ok None ->
           Log.Keeper.warn
-            "keeper %s pause: meta missing — skipping paused-state persist"
+            "keeper %s pause: owner metadata missing — skipping paused-state persist"
             name;
           Otel_metric_store.inc_counter
             Keeper_metrics.(to_string PausedStatePersistErrors)
@@ -152,15 +148,29 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
                      ("reason", "meta_missing")]
             ();
           false
-      | Error err ->
+         | Error error ->
+           Log.Keeper.error
+             "keeper %s pause: owner command failed: %s"
+             name
+             (Keeper_owner_registry.command_error_to_string error);
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string PausedStatePersistErrors)
+             ~labels:
+               [ ( "phase"
+                 , Keeper_paused_state_persist_phase.(to_label Lifecycle_pause_persist) )
+               ; "reason", "owner_command_error"
+               ]
+             ();
+           false)
+      | Error lookup_error ->
           Log.Keeper.error
-            "keeper %s pause: read_meta failed: %s"
+            "keeper %s pause: owner lookup failed: %s"
             name
-            err;
+            (Keeper_owner_registry.lookup_error_to_string lookup_error);
           Otel_metric_store.inc_counter
             Keeper_metrics.(to_string PausedStatePersistErrors)
             ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Lifecycle_pause_persist));
-                     ("reason", "read_meta_error")]
+                     ("reason", "owner_lookup_error")]
             ();
           false
     in

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -1289,38 +1289,35 @@ let resume_result_json ~name
 let run_resume_owner config ~name request =
   Keeper_paused_work_resume_transaction.resume config ~keeper_name:name request
 
-let persist_directive_pause ~config ~name
-    (meta : Keeper_meta_contract.keeper_meta) =
-  let updated_meta =
-    { meta with
-      paused = true
-    ; runtime = { meta.runtime with last_blocker = None }
-    ; updated_at = Keeper_meta_contract.now_iso ()
-    }
-  in
-  (* Pause toggle via CAS merge: do not rewind a concurrent turn's cumulative
-     usage counters. Resume is owned exclusively by the receipt transaction. *)
+let persist_directive_pause ~config ~name =
   match
-       Keeper_meta_store.write_meta_with_merge
-         ~merge:Keeper_meta_merge.monotonic_usage_counters
-         config
-         updated_meta
+    Keeper_owner_registry.apply_meta
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:name
+      (Keeper_owner_reducer.Pause
+         { reason =
+             Keeper_latched_reason.Operator_paused
+               { operator_actor = Keeper_latched_reason.Grpc_directive }
+         ; updated_at = Keeper_meta_contract.now_iso ()
+         })
   with
-  | Ok () -> Ok ()
-  | Error err ->
+  | Ok (Some _) -> Ok ()
+  | Ok None -> Error "owner removed Keeper metadata during pause"
+  | Error error ->
+    let detail = Keeper_owner_registry.command_error_to_string error in
     Log.Keeper.warn
-      "directive pause: write_meta failed for %s: %s"
+      "directive pause: owner command failed for %s: %s"
       name
-      (Keeper_meta_store.write_meta_error_to_string err);
+      detail;
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string PausedStatePersistErrors)
       ~labels:
         [ ( "phase"
           , Keeper_paused_state_persist_phase.(to_label Directive) )
-        ; "reason", "write_meta_error"
+        ; "reason", "owner_command_error"
         ]
       ();
-    Error err
+    Error detail
 
 let handle_keeper_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_str =
   let req_path = Http.Request.path req in
@@ -1396,8 +1393,7 @@ let handle_keeper_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_
       let proceed meta_opt =
         let persist_result =
           match plain_directive, meta_opt with
-          | Plain_pause, Some meta ->
-            persist_directive_pause ~config ~name meta
+          | Plain_pause, Some _ -> persist_directive_pause ~config ~name
           | Plain_pause, None | Plain_wakeup, _ -> Ok ()
         in
         match persist_result with
@@ -1410,14 +1406,15 @@ let handle_keeper_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_
                ; "action", `String action_str
                ; "name", `String name
                ; ( "error"
-                 , `String (Keeper_meta_store.write_meta_error_to_string error) )
+                 , `String error )
                ])
             reqd
         | Ok () ->
           let resolved_agent_name =
             match Keeper_registry_lookup.find_by_name name, meta_opt with
             | Some entry, _ -> entry.meta.agent_name
-            | None, Some meta -> meta.agent_name
+            | None, Some (meta : Keeper_meta_contract.keeper_meta) ->
+              meta.agent_name
             | None, None -> Keeper_identity.keeper_agent_name name
           in
           Keeper_keepalive.process_directive
@@ -1557,8 +1554,7 @@ let handle_keeper_bulk_directive_post ~sw:_ ~clock:_ state _agent_name req reqd 
               in
               let persist_result =
                 match plain_directive, meta_opt with
-                | Plain_pause, Some meta ->
-                  persist_directive_pause ~config ~name meta
+                | Plain_pause, Some _ -> persist_directive_pause ~config ~name
                 | Plain_pause, None | Plain_wakeup, _ -> Ok ()
               in
               (match persist_result with
@@ -1567,13 +1563,14 @@ let handle_keeper_bulk_directive_post ~sw:_ ~clock:_ state _agent_name req reqd 
                    [ "name", `String name
                    ; "ok", `Bool false
                    ; ( "error"
-                     , `String (Keeper_meta_store.write_meta_error_to_string error) )
+                     , `String error )
                    ]
                | Ok () ->
                  let resolved_agent_name =
                    match Keeper_registry_lookup.find_by_name name, meta_opt with
                    | Some entry, _ -> entry.meta.agent_name
-                   | None, Some meta -> meta.agent_name
+                   | None, Some (meta : Keeper_meta_contract.keeper_meta) ->
+                     meta.agent_name
                    | None, None -> Keeper_identity.keeper_agent_name name
                  in
                  Keeper_keepalive.process_directive

--- a/test/dune
+++ b/test/dune
@@ -1821,6 +1821,7 @@
 
 (include stanzas/test_keeper_turn_admission.inc)
 (include stanzas/test_keeper_owner.inc)
+(include stanzas/test_keeper_chat_operation_store.inc)
 
 
 

--- a/test/dune
+++ b/test/dune
@@ -1820,6 +1820,7 @@
 (include stanzas/test_keeper_chat_coalescing.inc)
 
 (include stanzas/test_keeper_turn_admission.inc)
+(include stanzas/test_keeper_owner.inc)
 
 
 

--- a/test/stanzas/test_keeper_chat_operation_store.inc
+++ b/test/stanzas/test_keeper_chat_operation_store.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_chat_operation_store)
+ (modules test_keeper_chat_operation_store)
+ (libraries masc_test_deps))

--- a/test/stanzas/test_keeper_owner.inc
+++ b/test/stanzas/test_keeper_owner.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_owner)
+ (modules test_keeper_owner)
+ (libraries masc_test_deps))

--- a/test/test_keeper_chat_operation_store.ml
+++ b/test/test_keeper_chat_operation_store.ml
@@ -1,0 +1,276 @@
+open Alcotest
+
+module Store = Masc.Keeper_chat_operation_store
+
+let store_ok = function
+  | Ok value -> value
+  | Error error -> fail (Store.error_to_string error)
+;;
+
+let temp_dir () =
+  let path = Filename.temp_file "keeper-chat-operation-" "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+    then (
+      Array.iter
+        (fun child -> remove_tree (Filename.concat path child))
+        (Sys.readdir path);
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
+let dashboard_input ?(content = "hello") ?(submitted_at = 100.0) () : Store.input =
+  { content
+  ; user_blocks = []
+  ; attachments = []
+  ; submitted_at
+  ; source = Dashboard { thread_id = "thread-1" }
+  ; user_row_origin = Masc.Keeper_chat_store.Needs_append
+  }
+;;
+
+let with_store f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_path)
+    (fun () ->
+       let store = store_ok (Store.open_ ~base_path ~keeper_name:"sangsu") in
+       Fun.protect
+         ~finally:(fun () -> ignore (Store.close store))
+         (fun () -> f ~base_path store))
+;;
+
+let accepted = function
+  | Store.Accepted operation -> operation
+  | Existing _ -> fail "fresh operation returned Existing"
+;;
+
+let existing = function
+  | Store.Existing operation -> operation
+  | Accepted _ -> fail "duplicate operation returned Accepted"
+;;
+
+let check_state label expected operation =
+  let actual =
+    match operation.Store.state with
+    | Queued -> "queued"
+    | Running _ -> "running"
+    | Succeeded _ -> "succeeded"
+    | Failed { kind; _ } -> "failed:" ^ Store.failure_kind_to_string kind
+    | Cancelled _ -> "cancelled"
+  in
+  check string label expected actual
+;;
+
+let test_submit_is_durable_and_idempotent () =
+  with_store @@ fun ~base_path store ->
+  let input = dashboard_input () in
+  let first = store_ok (Store.submit store ~operation_id:"kmsg-1" input) |> accepted in
+  check_state "accepted queued" "queued" first;
+  let duplicate =
+    store_ok (Store.submit store ~operation_id:"kmsg-1" input) |> existing
+  in
+  check int64 "same durable sequence" first.sequence duplicate.sequence;
+  (match Store.submit store ~operation_id:"kmsg-1" (dashboard_input ~content:"other" ()) with
+   | Error (Idempotency_conflict "kmsg-1") -> ()
+   | Error error -> fail ("wrong conflict: " ^ Store.error_to_string error)
+   | Ok _ -> fail "same operation id accepted different input");
+  store_ok (Store.close store);
+  let reopened = store_ok (Store.open_ ~base_path ~keeper_name:"sangsu") in
+  Fun.protect
+    ~finally:(fun () -> ignore (Store.close reopened))
+    (fun () ->
+       let loaded = store_ok (Store.lookup reopened ~operation_id:"kmsg-1") in
+       check_state "reopened queued" "queued" loaded;
+       check bool "queued body retained" true (Option.is_some loaded.input))
+;;
+
+let test_fifo_edit_move_cancel_and_terminal_scrub () =
+  with_store @@ fun ~base_path:_ store ->
+  let op1 =
+    store_ok (Store.submit store ~operation_id:"kmsg-1" (dashboard_input ()))
+    |> accepted
+  in
+  let op2 =
+    store_ok
+      (Store.submit
+         store
+         ~operation_id:"kmsg-2"
+         (dashboard_input ~content:"second" ~submitted_at:101.0 ()))
+    |> accepted
+  in
+  let edited =
+    store_ok
+      (Store.edit
+         store
+         ~operation_id:"kmsg-1"
+         { content = "edited"; user_blocks = []; attachments = [] })
+  in
+  (match edited.input with
+   | Some input -> check string "edited content" "edited" input.content
+   | None -> fail "edit scrubbed queued input");
+  check bool
+    "edit changes execution digest only"
+    true
+    (not (String.equal edited.admission_digest edited.execution_digest));
+  let original_retry =
+    store_ok
+      (Store.submit store ~operation_id:"kmsg-1" (dashboard_input ()))
+    |> existing
+  in
+  (match original_retry.input with
+   | Some input ->
+     check string
+       "original retry dedupes to edited current input"
+       "edited"
+       input.content
+   | None -> fail "original retry lost queued input");
+  (match
+     Store.submit
+       store
+       ~operation_id:"kmsg-1"
+       (dashboard_input ~content:"edited" ())
+   with
+   | Error (Idempotency_conflict "kmsg-1") -> ()
+   | Error error -> fail ("wrong edited retry conflict: " ^ Store.error_to_string error)
+   | Ok _ -> fail "edited payload replaced immutable admission identity");
+  let moved = store_ok (Store.move_to_end store ~operation_id:"kmsg-1") in
+  check bool "move allocates new tail sequence" true (Int64.compare moved.sequence op2.sequence > 0);
+  let running =
+    store_ok (Store.start_next store ~started_at:110.0)
+    |> Option.get
+  in
+  check string "FIFO head after move" "kmsg-2" running.operation_id;
+  let succeeded =
+    store_ok
+      (Store.succeed
+         store
+         ~operation_id:"kmsg-2"
+         ~completed_at:120.0
+         ~outcome_ref:"chat-row-2")
+  in
+  check_state "terminal success" "succeeded" succeeded;
+  check bool "success scrubs input" true (Option.is_none succeeded.input);
+  let terminal_duplicate =
+    store_ok
+      (Store.submit
+         store
+         ~operation_id:"kmsg-2"
+         (dashboard_input ~content:"second" ~submitted_at:101.0 ()))
+    |> existing
+  in
+  check_state "terminal id dedupes forever" "succeeded" terminal_duplicate;
+  (match
+     Store.fail
+       store
+       ~operation_id:"kmsg-2"
+       ~completed_at:122.0
+       ~kind:Turn_failed
+       ~detail:"must not rewrite terminal"
+       ~outcome_ref:None
+   with
+   | Error (Not_queued _) -> ()
+   | Error error -> fail ("wrong terminal immutability error: " ^ Store.error_to_string error)
+   | Ok _ -> fail "terminal operation was rewritten");
+  check_state
+    "terminal remains succeeded"
+    "succeeded"
+    (store_ok (Store.lookup store ~operation_id:"kmsg-2"));
+  let cancelled =
+    store_ok (Store.cancel store ~operation_id:"kmsg-1" ~completed_at:121.0)
+  in
+  check_state "queued cancel" "cancelled" cancelled;
+  check bool "cancel scrubs input" true (Option.is_none cancelled.input);
+  let queued = store_ok (Store.list_queued store ~after_sequence:None ~limit:10) in
+  check int "no queued rows remain" 0 (List.length queued);
+  ignore op1
+;;
+
+let test_restart_interrupts_running_once_and_preserves_queued () =
+  with_store @@ fun ~base_path store ->
+  ignore
+    (store_ok (Store.submit store ~operation_id:"run" (dashboard_input ()))
+     |> accepted);
+  ignore
+    (store_ok
+       (Store.submit
+          store
+          ~operation_id:"wait"
+          (dashboard_input ~content:"wait" ~submitted_at:101.0 ()))
+     |> accepted);
+  ignore (store_ok (Store.start_next store ~started_at:110.0));
+  store_ok (Store.close store);
+  let reopened = store_ok (Store.open_ ~base_path ~keeper_name:"sangsu") in
+  Fun.protect
+    ~finally:(fun () -> ignore (Store.close reopened))
+    (fun () ->
+       check int "one interrupted row" 1
+         (store_ok (Store.settle_interrupted reopened ~completed_at:120.0));
+       check int "settlement is idempotent" 0
+         (store_ok (Store.settle_interrupted reopened ~completed_at:121.0));
+       let interrupted = store_ok (Store.lookup reopened ~operation_id:"run") in
+       check_state
+         "running becomes interrupted failure"
+         "failed:interrupted_by_restart"
+         interrupted;
+       check bool "interrupted body scrubbed" true (Option.is_none interrupted.input);
+       let queued = store_ok (Store.lookup reopened ~operation_id:"wait") in
+       check_state "queued survives restart" "queued" queued;
+       check bool "queued body survives" true (Option.is_some queued.input))
+;;
+
+let test_commit_failure_readback_is_durable_only () =
+  with_store @@ fun ~base_path:_ store ->
+  Store.For_testing.fail_next_commit Before_commit;
+  (match
+     Store.submit store ~operation_id:"pre-commit" (dashboard_input ())
+   with
+   | Error (Store_unavailable _) -> ()
+   | Error error -> fail ("wrong pre-commit failure: " ^ Store.error_to_string error)
+   | Ok _ -> fail "pre-commit failure returned success");
+  (match Store.lookup store ~operation_id:"pre-commit" with
+   | Error (Unknown_operation "pre-commit") -> ()
+   | Error error -> fail ("wrong pre-commit readback: " ^ Store.error_to_string error)
+   | Ok _ -> fail "pre-commit failure changed durable state");
+  Store.For_testing.fail_next_commit After_commit;
+  let committed =
+    store_ok
+      (Store.submit store ~operation_id:"uncertain" (dashboard_input ()))
+    |> accepted
+  in
+  check_state "durable read-back confirms applied commit" "queued" committed;
+  let observed = store_ok (Store.lookup store ~operation_id:"uncertain") in
+  check int64 "read-back identity" committed.sequence observed.sequence
+;;
+
+let () =
+  run
+    "keeper_chat_operation_store"
+    [ ( "store"
+      , [ test_case
+            "durable submit and permanent idempotency"
+            `Quick
+            test_submit_is_durable_and_idempotent
+        ; test_case
+            "FIFO edit move cancel and terminal scrub"
+            `Quick
+            test_fifo_edit_move_cancel_and_terminal_scrub
+        ; test_case
+            "restart interruption settlement"
+            `Quick
+            test_restart_interrupts_running_once_and_preserves_queued
+        ; test_case
+            "commit failure uses independent durable readback"
+            `Quick
+            test_commit_failure_readback_is_durable_only
+        ] )
+    ]
+;;

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -112,6 +112,7 @@ let test_profile_update_preserves_owner_runtime_state () =
   let update : Reducer.profile_update =
     { instructions = "updated instructions"
     ; sandbox_profile = current.sandbox_profile
+    ; sandbox_image = current.sandbox_image
     ; network_mode = current.network_mode
     ; allowed_paths = [ "/tmp/profile" ]
     ; mention_targets = [ "profile-target" ]
@@ -122,6 +123,7 @@ let test_profile_update_preserves_owner_runtime_state () =
     ; telemetry_feedback_enabled = Some true
     ; telemetry_feedback_window_hours = Some 24
     ; always_allow = Some false
+    ; oas_env = [ "PROFILE_TEST", "1" ]
     ; updated_at = "profile-updated"
     }
   in

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -3,6 +3,7 @@ open Masc
 
 module Reducer = Keeper_owner_reducer
 module Owner = Keeper_owner
+module Owner_registry = Keeper_owner_registry
 
 let make_meta name =
   match
@@ -76,7 +77,7 @@ let test_actor_concurrent_commands_are_exact () =
   let owner =
     Owner.start
       ~sw
-      ~store:{ replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) }
+      ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
       ~initial_meta:(Some (make_meta "concurrent"))
   in
   let commands =
@@ -116,7 +117,7 @@ let test_mailbox_backpressures_without_drop () =
              Eio.Promise.resolve resolve_replace_entered ();
              Eio.Promise.await release_replace);
            Ok ())
-    ; remove = (fun () -> Ok ())
+    ; remove = (fun _ -> Ok ())
     }
   in
   let owner = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "mailbox")) in
@@ -170,7 +171,7 @@ let rec await_idle clock owner remaining =
 let test_child_isolation_and_per_keeper_parallelism () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
-  let store = { Owner.replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) } in
+  let store = { Owner.replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) } in
   let owner_a = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "a")) in
   let owner_b = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "b")) in
   let child_a_started, resolve_child_a_started = Eio.Promise.create () in
@@ -231,7 +232,7 @@ let test_store_failure_is_precommit () =
       ~sw
       ~store:
         { replace = (fun _ -> Error "disk unavailable")
-        ; remove = (fun () -> Error "disk unavailable")
+        ; remove = (fun _ -> Error "disk unavailable")
         }
       ~initial_meta:(Some (make_meta "store-failure"))
   in
@@ -255,7 +256,7 @@ let test_stopping_rejects_new_commands () =
   let owner =
     Owner.start
       ~sw
-      ~store:{ replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) }
+      ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
       ~initial_meta:(Some (make_meta "stopping"))
   in
   ignore (owner_ok (Owner.begin_stopping owner));
@@ -267,6 +268,67 @@ let test_stopping_rejects_new_commands () =
    | Error (Owner.Reducer_rejected Reducer.Owner_stopping) -> ()
    | Error error -> fail ("wrong stopping error: " ^ Owner.error_to_string error)
    | Ok _ -> fail "stopping owner accepted metadata mutation")
+;;
+
+let temp_dir () =
+  let path = Filename.temp_file "keeper-owner-registry-" "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+    then (
+      Array.iter
+        (fun child -> remove_tree (Filename.concat path child))
+        (Sys.readdir path);
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
+let test_root_inventory_loads_and_extends_exactly_once () =
+  Eio_main.run @@ fun env ->
+  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_path)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       let config = Workspace.default_config base_path in
+       ignore (Workspace.init config ~agent_name:(Some "owner-test"));
+       let first = make_meta "inventory-first" in
+       (match Keeper_meta_store.persist_meta config first.name first with
+        | Ok () -> ()
+        | Error detail -> fail ("failed to seed owner meta: " ^ detail));
+       (match Owner_registry.install_from_store ~sw config with
+        | Ok count -> check int "strict startup owner count" 1 count
+        | Error error -> fail (Owner_registry.install_error_to_string error));
+       let loaded =
+         match Owner_registry.get ~base_path ~keeper_name:first.name with
+         | Ok owner -> owner
+         | Error error -> fail (Owner_registry.lookup_error_to_string error)
+       in
+       let ensured =
+         match Owner_registry.ensure ~base_path (make_meta "inventory-second") with
+         | Ok owner -> owner
+         | Error error -> fail (Owner_registry.lookup_error_to_string error)
+       in
+       let loaded_again =
+         match Owner_registry.ensure ~base_path first with
+         | Ok owner -> owner
+         | Error error -> fail (Owner_registry.lookup_error_to_string error)
+       in
+       check bool "ensure preserves the existing actor" true (loaded == loaded_again);
+       check bool "different keeper receives a different actor" false (loaded == ensured);
+       check int
+         "dynamic owner extends inventory once"
+         2
+         (Owner_registry.For_testing.installed_owner_count ~base_path);
+       (match Owner_registry.all_projections ~base_path with
+        | Ok projections -> check int "fleet projection count" 2 (List.length projections)
+        | Error error -> fail (Owner_registry.lookup_error_to_string error)))
 ;;
 
 let () =
@@ -296,6 +358,10 @@ let () =
             "stopping rejects new commands"
             `Quick
             test_stopping_rejects_new_commands
+        ; test_case
+            "root inventory loads and extends exactly once"
+            `Quick
+            test_root_inventory_loads_and_extends_exactly_once
         ] )
     ]
 ;;

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -5,6 +5,8 @@ module Reducer = Keeper_owner_reducer
 module Owner = Keeper_owner
 module Owner_registry = Keeper_owner_registry
 
+exception Synthetic_child_cancel
+
 let make_meta name =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -44,7 +46,12 @@ let owner_ok = function
 ;;
 
 let test_pure_reducer_adds_deltas_and_preserves_pause () =
-  let state = ref (Reducer.create (Some (make_meta "pure"))) in
+  let state =
+    ref
+      (match Reducer.create ~keeper_name:"pure" (Some (make_meta "pure")) with
+       | Ok state -> state
+       | Error error -> fail (Reducer.error_to_string error))
+  in
   for index = 1 to 1_000 do
     state := reducer_ok (Reducer.apply_meta !state (Add_usage (usage_delta ())));
     if index = 500
@@ -71,14 +78,39 @@ let test_pure_reducer_adds_deltas_and_preserves_pause () =
   check bool "pause latch retained" true (Option.is_some meta.latched_reason)
 ;;
 
+let test_reducer_rejects_invalid_compaction_numbers () =
+  let state =
+    match Reducer.create ~keeper_name:"numbers" (Some (make_meta "numbers")) with
+    | Ok state -> state
+    | Error error -> fail (Reducer.error_to_string error)
+  in
+  let command =
+    Reducer.Record_compaction
+      { count_delta = 1
+      ; at = Float.nan
+      ; before_tokens = -1
+      ; after_tokens = 0
+      ; checked_at = 42.0
+      ; decision = Keeper_meta_contract.Compaction_runtime_decision "test"
+      ; updated_at = "invalid"
+      }
+  in
+  match Reducer.apply_meta state command with
+  | Error (Reducer.Invalid_delta _) -> ()
+  | Error error -> fail ("wrong numeric error: " ^ Reducer.error_to_string error)
+  | Ok _ -> fail "invalid compaction numbers were accepted"
+;;
+
 let test_actor_concurrent_commands_are_exact () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
   let owner =
-    Owner.start
+    owner_ok
+      (Owner.start
       ~sw
       ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
-      ~initial_meta:(Some (make_meta "concurrent"))
+      ~keeper_name:"concurrent"
+      ~initial_meta:(Some (make_meta "concurrent")))
   in
   let commands =
     List.init 1_000 (fun _ () ->
@@ -120,7 +152,14 @@ let test_mailbox_backpressures_without_drop () =
     ; remove = (fun _ -> Ok ())
     }
   in
-  let owner = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "mailbox")) in
+  let owner =
+    owner_ok
+      (Owner.start
+         ~sw
+         ~store
+         ~keeper_name:"mailbox"
+         ~initial_meta:(Some (make_meta "mailbox")))
+  in
   let completed = Atomic.make 0 in
   let all_completed, resolve_all_completed = Eio.Promise.create () in
   let mark_completed () =
@@ -172,8 +211,14 @@ let test_child_isolation_and_per_keeper_parallelism () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let store = { Owner.replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) } in
-  let owner_a = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "a")) in
-  let owner_b = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "b")) in
+  let owner_a =
+    owner_ok
+      (Owner.start ~sw ~store ~keeper_name:"a" ~initial_meta:(Some (make_meta "a")))
+  in
+  let owner_b =
+    owner_ok
+      (Owner.start ~sw ~store ~keeper_name:"b" ~initial_meta:(Some (make_meta "b")))
+  in
   let child_a_started, resolve_child_a_started = Eio.Promise.create () in
   let release_child_a, resolve_release_child_a = Eio.Promise.create () in
   (match
@@ -182,7 +227,7 @@ let test_child_isolation_and_per_keeper_parallelism () =
           Eio.Promise.resolve resolve_child_a_started ();
           Eio.Promise.await release_child_a))
    with
-   | Owner.Started -> ()
+   | Owner.Started _ -> ()
    | Busy _ -> fail "owner a unexpectedly busy");
   Eio.Promise.await child_a_started;
   (match
@@ -191,14 +236,14 @@ let test_child_isolation_and_per_keeper_parallelism () =
    with
    | Busy { running_operation_id } ->
      check string "busy identifies current operation" "op-a" running_operation_id
-   | Started -> fail "second turn started concurrently on owner a");
+   | Started _ -> fail "second turn started concurrently on owner a");
   let child_b_ran = Atomic.make false in
   (match
      owner_ok
        (Owner.start_turn owner_b ~operation_id:"op-b" ~run:(fun _ ->
           Atomic.set child_b_ran true))
    with
-   | Started -> ()
+   | Started _ -> ()
    | Busy _ -> fail "independent owner b was blocked by owner a");
   await_idle (Eio.Stdenv.clock env) owner_b 1_000;
   check bool "independent keeper ran concurrently" true (Atomic.get child_b_ran);
@@ -213,13 +258,22 @@ let test_child_isolation_and_per_keeper_parallelism () =
     (Option.get (Owner.projection owner_a).meta).autoboot_enabled;
   Eio.Promise.resolve resolve_release_child_a ();
   await_idle (Eio.Stdenv.clock env) owner_a 1_000;
-  (match
+  let failed_handle =
+    match
      owner_ok
        (Owner.start_turn owner_a ~operation_id:"op-exn" ~run:(fun _ ->
           raise (Failure "synthetic child failure")))
-   with
-   | Started -> ()
-   | Busy _ -> fail "owner remained busy after first child");
+    with
+    | Started handle -> handle
+    | Busy _ -> fail "owner remained busy after first child"
+  in
+  (match Owner.await_turn failed_handle with
+   | Owner.Turn_failed detail ->
+     check bool
+       "typed terminal includes child failure"
+       true
+       (String.length detail > 0)
+   | Turn_succeeded | Turn_cancelled -> fail "child exception lost typed failure");
   await_idle (Eio.Stdenv.clock env) owner_a 1_000;
   ignore (owner_ok (Owner.exact_projection owner_a))
 ;;
@@ -228,13 +282,15 @@ let test_store_failure_is_precommit () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
   let owner =
-    Owner.start
+    owner_ok
+      (Owner.start
       ~sw
       ~store:
         { replace = (fun _ -> Error "disk unavailable")
         ; remove = (fun _ -> Error "disk unavailable")
         }
-      ~initial_meta:(Some (make_meta "store-failure"))
+      ~keeper_name:"store-failure"
+      ~initial_meta:(Some (make_meta "store-failure")))
   in
   (match
      Owner.apply_meta
@@ -250,14 +306,152 @@ let test_store_failure_is_precommit () =
     (Option.get (Owner.projection owner).meta).autoboot_enabled
 ;;
 
+let test_identity_and_running_lifecycle_guards () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let store = { Owner.replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) } in
+  let empty =
+    owner_ok (Owner.start ~sw ~store ~keeper_name:"empty" ~initial_meta:None)
+  in
+  (match Owner.start_turn empty ~operation_id:"missing" ~run:(fun _ -> ()) with
+   | Error (Owner.Reducer_rejected Reducer.Meta_missing) -> ()
+   | Error error -> fail ("wrong missing-meta error: " ^ Owner.error_to_string error)
+   | Ok _ -> fail "metadata-free owner admitted a turn");
+  (match Owner.apply_meta empty (Create (make_meta "other")) with
+   | Error (Owner.Reducer_rejected (Reducer.Keeper_identity_mismatch _)) -> ()
+   | Error error -> fail ("wrong identity error: " ^ Owner.error_to_string error)
+   | Ok _ -> fail "owner accepted metadata for another Keeper");
+  ignore (owner_ok (Owner.apply_meta empty (Create (make_meta "empty"))));
+  let started, resolve_started = Eio.Promise.create () in
+  let release, resolve_release = Eio.Promise.create () in
+  let handle =
+    match
+      owner_ok
+        (Owner.start_turn empty ~operation_id:"running" ~run:(fun _ ->
+           Eio.Promise.resolve resolve_started ();
+           Eio.Promise.await release))
+    with
+    | Started handle -> handle
+    | Busy _ -> fail "newly created owner was busy"
+  in
+  Eio.Promise.await started;
+  (match Owner.apply_meta empty Delete with
+   | Error (Owner.Reducer_rejected (Reducer.Delete_while_running "running")) -> ()
+   | Error error -> fail ("wrong delete guard error: " ^ Owner.error_to_string error)
+   | Ok _ -> fail "running owner allowed metadata deletion");
+  Eio.Promise.resolve resolve_release ();
+  (match Owner.await_turn handle with
+   | Owner.Turn_succeeded -> ()
+   | Turn_failed _ | Turn_cancelled -> fail "successful child did not settle successfully");
+  ignore (owner_ok (Owner.apply_meta empty Delete));
+  check bool "delete clears metadata" true (Option.is_none (Owner.projection empty).meta)
+;;
+
+let test_child_cancellation_releases_slot () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let owner =
+    owner_ok
+      (Owner.start
+         ~sw
+         ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
+         ~keeper_name:"cancel"
+         ~initial_meta:(Some (make_meta "cancel")))
+  in
+  let handle =
+    match
+      owner_ok
+        (Owner.start_turn owner ~operation_id:"cancelled" ~run:(fun turn_sw ->
+           Eio.Switch.fail turn_sw Synthetic_child_cancel))
+    with
+    | Started handle -> handle
+    | Busy _ -> fail "cancellation test owner was busy"
+  in
+  (match Owner.await_turn handle with
+   | Owner.Turn_cancelled -> ()
+   | Turn_succeeded | Turn_failed _ -> fail "child cancellation lost typed terminal");
+  await_idle (Eio.Stdenv.clock env) owner 1_000;
+  match
+    owner_ok
+      (Owner.start_turn owner ~operation_id:"after-cancel" ~run:(fun _ -> ()))
+  with
+  | Started handle ->
+    (match Owner.await_turn handle with
+     | Turn_succeeded -> ()
+     | Turn_failed _ | Turn_cancelled -> fail "owner did not recover after cancellation")
+  | Busy _ -> fail "child cancellation leaked the running slot"
+;;
+
+let test_shutdown_releases_full_mailbox_requests () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun test_sw ->
+  let owner_ready, resolve_owner_ready = Eio.Promise.create () in
+  let close_owner_scope, resolve_close_owner_scope = Eio.Promise.create () in
+  let owner_scope_done, resolve_owner_scope_done = Eio.Promise.create () in
+  let replace_entered, resolve_replace_entered = Eio.Promise.create () in
+  let never_release, _resolve_never_release = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw:test_sw (fun () ->
+    Eio.Switch.run (fun owner_sw ->
+      let owner =
+        owner_ok
+          (Owner.start
+             ~sw:owner_sw
+             ~store:
+               { replace =
+                   (fun _ ->
+                      Eio.Promise.resolve resolve_replace_entered ();
+                      Eio.Promise.await never_release;
+                      Ok ())
+               ; remove = (fun _ -> Ok ())
+               }
+             ~keeper_name:"shutdown-race"
+             ~initial_meta:(Some (make_meta "shutdown-race")))
+      in
+      Eio.Promise.resolve resolve_owner_ready owner;
+      Eio.Promise.await close_owner_scope);
+    Eio.Promise.resolve resolve_owner_scope_done ());
+  let owner = Eio.Promise.await owner_ready in
+  let results = Eio.Stream.create max_int in
+  let submit index () =
+    let result =
+      Owner.apply_meta
+        owner
+        (Set_autoboot { enabled = true; updated_at = string_of_int index })
+    in
+    Eio.Stream.add results result
+  in
+  Eio.Fiber.fork ~sw:test_sw (submit 0);
+  Eio.Promise.await replace_entered;
+  for index = 1 to 129 do
+    Eio.Fiber.fork ~sw:test_sw (submit index)
+  done;
+  for _ = 1 to 10 do
+    Eio.Fiber.yield ()
+  done;
+  check int
+    "mailbox is full before shutdown"
+    Owner.mailbox_capacity
+    (Owner.For_testing.mailbox_depth owner);
+  Eio.Promise.resolve resolve_close_owner_scope ();
+  for _ = 1 to 130 do
+    match Eio.Stream.take results with
+    | Error Owner.Owner_closed -> ()
+    | Error error -> fail ("wrong shutdown error: " ^ Owner.error_to_string error)
+    | Ok _ -> fail "shutdown race reported an uncommitted command as successful"
+  done;
+  Eio.Promise.await owner_scope_done
+;;
+
 let test_stopping_rejects_new_commands () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
   let owner =
-    Owner.start
+    owner_ok
+      (Owner.start
       ~sw
       ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
-      ~initial_meta:(Some (make_meta "stopping"))
+      ~keeper_name:"stopping"
+      ~initial_meta:(Some (make_meta "stopping")))
   in
   ignore (owner_ok (Owner.begin_stopping owner));
   (match
@@ -339,6 +533,10 @@ let () =
             "additive usage and pause are exact"
             `Quick
             test_pure_reducer_adds_deltas_and_preserves_pause
+        ; test_case
+            "invalid compaction numbers are rejected"
+            `Quick
+            test_reducer_rejects_invalid_compaction_numbers
         ] )
     ; ( "actor"
       , [ test_case
@@ -354,6 +552,18 @@ let () =
             `Quick
             test_mailbox_backpressures_without_drop
         ; test_case "store failure is precommit" `Quick test_store_failure_is_precommit
+        ; test_case
+            "identity and running lifecycle guards"
+            `Quick
+            test_identity_and_running_lifecycle_guards
+        ; test_case
+            "child cancellation releases slot"
+            `Quick
+            test_child_cancellation_releases_slot
+        ; test_case
+            "shutdown releases full mailbox requests"
+            `Quick
+            test_shutdown_releases_full_mailbox_requests
         ; test_case
             "stopping rejects new commands"
             `Quick

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -401,8 +401,8 @@ let test_child_cancellation_releases_slot () =
   let handle =
     match
       owner_ok
-        (Owner.start_turn owner ~operation_id:"cancelled" ~run:(fun turn_sw ->
-           Eio.Switch.fail turn_sw Synthetic_child_cancel))
+        (Owner.start_turn owner ~operation_id:"cancelled" ~run:(fun _ ->
+           raise (Eio.Cancel.Cancelled Synthetic_child_cancel)))
     with
     | Started handle -> handle
     | Busy _ -> fail "cancellation test owner was busy"
@@ -524,7 +524,7 @@ let rec remove_tree path =
 
 let test_root_inventory_loads_and_extends_exactly_once () =
   Eio_main.run @@ fun env ->
-  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> remove_tree base_path)
@@ -533,7 +533,7 @@ let test_root_inventory_loads_and_extends_exactly_once () =
        let config = Workspace.default_config base_path in
        ignore (Workspace.init config ~agent_name:(Some "owner-test"));
        let first = make_meta "inventory-first" in
-       (match Keeper_meta_store.persist_meta config first.name first with
+       (match Keeper_meta_store.write_meta config first with
         | Ok () -> ()
         | Error detail -> fail ("failed to seed owner meta: " ^ detail));
        (match Owner_registry.install_from_store ~sw config with
@@ -579,7 +579,7 @@ let test_root_inventory_loads_and_extends_exactly_once () =
 
 let test_lifecycle_reservation_remains_owner_admission_authority () =
   Eio_main.run @@ fun env ->
-  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> remove_tree base_path)
@@ -588,7 +588,7 @@ let test_lifecycle_reservation_remains_owner_admission_authority () =
        let config = Workspace.default_config base_path in
        ignore (Workspace.init config ~agent_name:(Some "owner-reservation-test"));
        let meta = make_meta "inventory-reserved" in
-       (match Keeper_meta_store.persist_meta config meta.name meta with
+       (match Keeper_meta_store.write_meta config meta with
         | Ok () -> ()
         | Error detail -> fail ("failed to seed reserved owner meta: " ^ detail));
        (match Owner_registry.install_from_store ~sw config with
@@ -635,7 +635,7 @@ let test_lifecycle_reservation_remains_owner_admission_authority () =
 
 let test_create_waits_for_lifecycle_admission_before_installing_owner () =
   Eio_main.run @@ fun env ->
-  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> remove_tree base_path)

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -633,6 +633,55 @@ let test_lifecycle_reservation_remains_owner_admission_authority () =
             ^ Keeper_lifecycle_reservation.release_outcome_to_string outcome))
 ;;
 
+let test_create_waits_for_lifecycle_admission_before_installing_owner () =
+  Eio_main.run @@ fun env ->
+  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_path)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       let config = Workspace.default_config base_path in
+       ignore (Workspace.init config ~agent_name:(Some "owner-create-reservation-test"));
+       (match Owner_registry.install_from_store ~sw config with
+        | Ok count -> check int "empty owner inventory" 0 count
+        | Error error -> fail (Owner_registry.install_error_to_string error));
+       let meta = make_meta "create-reserved" in
+       let token =
+         match
+           Keeper_lifecycle_reservation.acquire
+             ~base_path
+             ~keeper_name:meta.name
+             ~expected_generation:0
+             ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
+         with
+         | Ok token -> token
+         | Error _ -> fail "failed to reserve create identity"
+       in
+       (match Owner_registry.create_meta ~base_path meta with
+        | Error (Owner_registry.Command_lifecycle_reserved _) -> ()
+        | Error error -> fail (Owner_registry.command_error_to_string error)
+        | Ok _ -> fail "create crossed lifecycle reservation");
+       check int
+         "rejected create installs no empty owner"
+         0
+         (Owner_registry.For_testing.installed_owner_count ~base_path);
+       (match Keeper_lifecycle_reservation.release token with
+        | Keeper_lifecycle_reservation.Released -> ()
+        | outcome ->
+          fail
+            ("failed to release create reservation: "
+             ^ Keeper_lifecycle_reservation.release_outcome_to_string outcome));
+       (match Owner_registry.create_meta ~base_path meta with
+        | Ok (Some committed) -> check string "admitted create" meta.name committed.name
+        | Ok None -> fail "admitted create removed metadata"
+        | Error error -> fail (Owner_registry.command_error_to_string error));
+       check int
+         "admitted create installs one owner"
+         1
+         (Owner_registry.For_testing.installed_owner_count ~base_path))
+;;
+
 let () =
   run
     "keeper owner"
@@ -688,6 +737,10 @@ let () =
             "lifecycle reservation gates owner commands"
             `Quick
             test_lifecycle_reservation_remains_owner_admission_authority
+        ; test_case
+            "create authorizes before owner installation"
+            `Quick
+            test_create_waits_for_lifecycle_admission_before_installing_owner
         ] )
     ]
 ;;

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -1,0 +1,301 @@
+open Alcotest
+open Masc
+
+module Reducer = Keeper_owner_reducer
+module Owner = Keeper_owner
+
+let make_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name
+        ; "trace_id", `String ("trace-" ^ name)
+        ; "autoboot_enabled", `Bool false
+        ])
+  with
+  | Ok meta -> meta
+  | Error detail -> fail ("meta fixture failed: " ^ detail)
+;;
+
+let usage_delta ?(turns = 1) () : Reducer.usage_delta =
+  { turns
+  ; input_tokens = 2
+  ; output_tokens = 3
+  ; total_tokens = 5
+  ; cost_usd = 0.25
+  ; last_turn_ts = 42.0
+  ; last_input_tokens = 2
+  ; last_output_tokens = 3
+  ; last_total_tokens = 5
+  ; last_usage_reported_at = Some 42.0
+  ; last_latency_ms = 7
+  }
+;;
+
+let reducer_ok = function
+  | Ok transition -> transition.Reducer.state
+  | Error error -> fail (Reducer.error_to_string error)
+;;
+
+let owner_ok = function
+  | Ok value -> value
+  | Error error -> fail (Owner.error_to_string error)
+;;
+
+let test_pure_reducer_adds_deltas_and_preserves_pause () =
+  let state = ref (Reducer.create (Some (make_meta "pure"))) in
+  for index = 1 to 1_000 do
+    state := reducer_ok (Reducer.apply_meta !state (Add_usage (usage_delta ())));
+    if index = 500
+    then
+      state :=
+        reducer_ok
+          (Reducer.apply_meta
+             !state
+             (Pause
+                { reason =
+                    Keeper_latched_reason.Operator_paused
+                      { operator_actor = Keeper_latched_reason.Grpc_directive }
+                ; updated_at = "paused-at-500"
+                }))
+  done;
+  let projection = Reducer.projection !state in
+  let meta = Option.get projection.meta in
+  check int "all turn deltas retained" 1_000 meta.runtime.usage.total_turns;
+  check int "all input deltas retained" 2_000 meta.runtime.usage.total_input_tokens;
+  check int "all output deltas retained" 3_000 meta.runtime.usage.total_output_tokens;
+  check int "all total deltas retained" 5_000 meta.runtime.usage.total_tokens;
+  check (float 0.000_001) "all cost deltas retained" 250.0 meta.runtime.usage.total_cost_usd;
+  check bool "pause bit retained" true meta.paused;
+  check bool "pause latch retained" true (Option.is_some meta.latched_reason)
+;;
+
+let test_actor_concurrent_commands_are_exact () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let owner =
+    Owner.start
+      ~sw
+      ~store:{ replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) }
+      ~initial_meta:(Some (make_meta "concurrent"))
+  in
+  let commands =
+    List.init 1_000 (fun _ () ->
+      ignore (owner_ok (Owner.apply_meta owner (Add_usage (usage_delta ())))))
+  in
+  let pause () =
+    ignore
+      (owner_ok
+         (Owner.apply_meta
+            owner
+            (Pause
+               { reason =
+                   Keeper_latched_reason.Operator_paused
+                     { operator_actor = Keeper_latched_reason.Keeper_down }
+               ; updated_at = "concurrent-pause"
+               })))
+  in
+  Eio.Fiber.all (pause :: commands);
+  let projection = owner_ok (Owner.exact_projection owner) in
+  let meta = Option.get projection.meta in
+  check int "concurrent deltas are exact" 1_000 meta.runtime.usage.total_turns;
+  check bool "concurrent pause is preserved" true meta.paused
+;;
+
+let test_mailbox_backpressures_without_drop () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let replace_entered, resolve_replace_entered = Eio.Promise.create () in
+  let release_replace, resolve_release_replace = Eio.Promise.create () in
+  let first_replace = Atomic.make true in
+  let store =
+    { Owner.replace =
+        (fun _ ->
+           if Atomic.compare_and_set first_replace true false
+           then (
+             Eio.Promise.resolve resolve_replace_entered ();
+             Eio.Promise.await release_replace);
+           Ok ())
+    ; remove = (fun () -> Ok ())
+    }
+  in
+  let owner = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "mailbox")) in
+  let completed = Atomic.make 0 in
+  let all_completed, resolve_all_completed = Eio.Promise.create () in
+  let mark_completed () =
+    if Atomic.fetch_and_add completed 1 = 129
+    then Eio.Promise.resolve resolve_all_completed ()
+  in
+  let submit index () =
+    ignore
+      (owner_ok
+         (Owner.apply_meta
+            owner
+            (Set_autoboot
+               { enabled = index mod 2 = 0
+               ; updated_at = string_of_int index
+               })));
+    mark_completed ()
+  in
+  Eio.Fiber.fork ~sw (submit 0);
+  Eio.Promise.await replace_entered;
+  for index = 1 to 129 do
+    Eio.Fiber.fork ~sw (submit index)
+  done;
+  for _ = 1 to 10 do
+    Eio.Fiber.yield ()
+  done;
+  check int
+    "bounded mailbox reaches its exact capacity"
+    Owner.mailbox_capacity
+    (Owner.For_testing.mailbox_depth owner);
+  check int "no blocked command was dropped" 0 (Atomic.get completed);
+  Eio.Promise.resolve resolve_release_replace ();
+  Eio.Promise.await all_completed;
+  check int "all producers completed after capacity released" 130 (Atomic.get completed);
+  check int "mailbox drained" 0 (Owner.For_testing.mailbox_depth owner)
+;;
+
+let rec await_idle clock owner remaining =
+  if remaining = 0
+  then fail "owner did not return to idle"
+  else
+    match (Owner.projection owner).running_operation_id with
+    | None -> ()
+    | Some _ ->
+      Eio.Time.sleep clock 0.001;
+      await_idle clock owner (remaining - 1)
+;;
+
+let test_child_isolation_and_per_keeper_parallelism () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let store = { Owner.replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) } in
+  let owner_a = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "a")) in
+  let owner_b = Owner.start ~sw ~store ~initial_meta:(Some (make_meta "b")) in
+  let child_a_started, resolve_child_a_started = Eio.Promise.create () in
+  let release_child_a, resolve_release_child_a = Eio.Promise.create () in
+  (match
+     owner_ok
+       (Owner.start_turn owner_a ~operation_id:"op-a" ~run:(fun _turn_sw ->
+          Eio.Promise.resolve resolve_child_a_started ();
+          Eio.Promise.await release_child_a))
+   with
+   | Owner.Started -> ()
+   | Busy _ -> fail "owner a unexpectedly busy");
+  Eio.Promise.await child_a_started;
+  (match
+     owner_ok
+       (Owner.start_turn owner_a ~operation_id:"op-a-2" ~run:(fun _ -> ()))
+   with
+   | Busy { running_operation_id } ->
+     check string "busy identifies current operation" "op-a" running_operation_id
+   | Started -> fail "second turn started concurrently on owner a");
+  let child_b_ran = Atomic.make false in
+  (match
+     owner_ok
+       (Owner.start_turn owner_b ~operation_id:"op-b" ~run:(fun _ ->
+          Atomic.set child_b_ran true))
+   with
+   | Started -> ()
+   | Busy _ -> fail "independent owner b was blocked by owner a");
+  await_idle (Eio.Stdenv.clock env) owner_b 1_000;
+  check bool "independent keeper ran concurrently" true (Atomic.get child_b_ran);
+  ignore
+    (owner_ok
+       (Owner.apply_meta
+          owner_a
+          (Set_autoboot { enabled = true; updated_at = "while-running" })));
+  check bool
+    "actor processed metadata while child was running"
+    true
+    (Option.get (Owner.projection owner_a).meta).autoboot_enabled;
+  Eio.Promise.resolve resolve_release_child_a ();
+  await_idle (Eio.Stdenv.clock env) owner_a 1_000;
+  (match
+     owner_ok
+       (Owner.start_turn owner_a ~operation_id:"op-exn" ~run:(fun _ ->
+          raise (Failure "synthetic child failure")))
+   with
+   | Started -> ()
+   | Busy _ -> fail "owner remained busy after first child");
+  await_idle (Eio.Stdenv.clock env) owner_a 1_000;
+  ignore (owner_ok (Owner.exact_projection owner_a))
+;;
+
+let test_store_failure_is_precommit () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let owner =
+    Owner.start
+      ~sw
+      ~store:
+        { replace = (fun _ -> Error "disk unavailable")
+        ; remove = (fun () -> Error "disk unavailable")
+        }
+      ~initial_meta:(Some (make_meta "store-failure"))
+  in
+  (match
+     Owner.apply_meta
+       owner
+       (Set_autoboot { enabled = true; updated_at = "must-not-publish" })
+   with
+   | Error (Owner.Store_unavailable "disk unavailable") -> ()
+   | Error error -> fail ("wrong store error: " ^ Owner.error_to_string error)
+   | Ok _ -> fail "store failure was reported as success");
+  check bool
+    "failed persistence leaves projection unchanged"
+    false
+    (Option.get (Owner.projection owner).meta).autoboot_enabled
+;;
+
+let test_stopping_rejects_new_commands () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let owner =
+    Owner.start
+      ~sw
+      ~store:{ replace = (fun _ -> Ok ()); remove = (fun () -> Ok ()) }
+      ~initial_meta:(Some (make_meta "stopping"))
+  in
+  ignore (owner_ok (Owner.begin_stopping owner));
+  (match
+     Owner.apply_meta
+       owner
+       (Set_autoboot { enabled = true; updated_at = "rejected" })
+   with
+   | Error (Owner.Reducer_rejected Reducer.Owner_stopping) -> ()
+   | Error error -> fail ("wrong stopping error: " ^ Owner.error_to_string error)
+   | Ok _ -> fail "stopping owner accepted metadata mutation")
+;;
+
+let () =
+  run
+    "keeper owner"
+    [ ( "reducer"
+      , [ test_case
+            "additive usage and pause are exact"
+            `Quick
+            test_pure_reducer_adds_deltas_and_preserves_pause
+        ] )
+    ; ( "actor"
+      , [ test_case
+            "concurrent commands are exact"
+            `Quick
+            test_actor_concurrent_commands_are_exact
+        ; test_case
+            "child isolation and per-keeper parallelism"
+            `Quick
+            test_child_isolation_and_per_keeper_parallelism
+        ; test_case
+            "mailbox backpressures without drop"
+            `Quick
+            test_mailbox_backpressures_without_drop
+        ; test_case "store failure is precommit" `Quick test_store_failure_is_precommit
+        ; test_case
+            "stopping rejects new commands"
+            `Quick
+            test_stopping_rejects_new_commands
+        ] )
+    ]
+;;

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -525,6 +525,62 @@ let test_root_inventory_loads_and_extends_exactly_once () =
         | Error error -> fail (Owner_registry.lookup_error_to_string error)))
 ;;
 
+let test_lifecycle_reservation_remains_owner_admission_authority () =
+  Eio_main.run @@ fun env ->
+  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_path)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       let config = Workspace.default_config base_path in
+       ignore (Workspace.init config ~agent_name:(Some "owner-reservation-test"));
+       let meta = make_meta "inventory-reserved" in
+       (match Keeper_meta_store.persist_meta config meta.name meta with
+        | Ok () -> ()
+        | Error detail -> fail ("failed to seed reserved owner meta: " ^ detail));
+       (match Owner_registry.install_from_store ~sw config with
+        | Ok count -> check int "reserved owner count" 1 count
+        | Error error -> fail (Owner_registry.install_error_to_string error));
+       let token =
+         match
+           Keeper_lifecycle_reservation.acquire
+             ~base_path
+             ~keeper_name:meta.name
+             ~expected_generation:meta.runtime.nonce
+             ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
+         with
+         | Ok token -> token
+         | Error _ -> fail "failed to acquire lifecycle reservation"
+       in
+       let command =
+         Reducer.Set_autoboot { enabled = true; updated_at = "reserved-command" }
+       in
+       (match Owner_registry.apply_meta ~base_path ~keeper_name:meta.name command with
+        | Error (Owner_registry.Command_lifecycle_reserved _) -> ()
+        | Error error ->
+          fail
+            ("wrong reservation rejection: "
+             ^ Owner_registry.command_error_to_string error)
+        | Ok _ -> fail "unowned command crossed lifecycle reservation");
+       (match
+          Owner_registry.apply_meta
+            ~lifecycle_token:token
+            ~base_path
+            ~keeper_name:meta.name
+            command
+        with
+        | Ok (Some updated) -> check bool "reservation owner committed" true updated.autoboot_enabled
+        | Ok None -> fail "reservation owner removed metadata"
+        | Error error -> fail (Owner_registry.command_error_to_string error));
+       match Keeper_lifecycle_reservation.release token with
+       | Keeper_lifecycle_reservation.Released -> ()
+       | outcome ->
+         fail
+           ("failed to release lifecycle reservation: "
+            ^ Keeper_lifecycle_reservation.release_outcome_to_string outcome))
+;;
+
 let () =
   run
     "keeper owner"
@@ -572,6 +628,10 @@ let () =
             "root inventory loads and extends exactly once"
             `Quick
             test_root_inventory_loads_and_extends_exactly_once
+        ; test_case
+            "lifecycle reservation gates owner commands"
+            `Quick
+            test_lifecycle_reservation_remains_owner_admission_authority
         ] )
     ]
 ;;

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -504,18 +504,30 @@ let test_root_inventory_loads_and_extends_exactly_once () =
          | Ok owner -> owner
          | Error error -> fail (Owner_registry.lookup_error_to_string error)
        in
+       let second = make_meta "inventory-second" in
+       (match Owner_registry.create_meta ~base_path second with
+        | Ok (Some committed) -> check string "dynamic owner identity" second.name committed.name
+        | Ok None -> fail "dynamic owner create removed metadata"
+        | Error error -> fail (Owner_registry.command_error_to_string error));
        let ensured =
-         match Owner_registry.ensure ~base_path (make_meta "inventory-second") with
+         match Owner_registry.get ~base_path ~keeper_name:second.name with
          | Ok owner -> owner
          | Error error -> fail (Owner_registry.lookup_error_to_string error)
        in
        let loaded_again =
-         match Owner_registry.ensure ~base_path first with
+         match Owner_registry.get ~base_path ~keeper_name:first.name with
          | Ok owner -> owner
          | Error error -> fail (Owner_registry.lookup_error_to_string error)
        in
-       check bool "ensure preserves the existing actor" true (loaded == loaded_again);
+       check bool "lookup preserves the existing actor" true (loaded == loaded_again);
        check bool "different keeper receives a different actor" false (loaded == ensured);
+       (match Owner_registry.create_meta ~base_path first with
+        | Error
+            (Owner_registry.Command_rejected
+              (Owner.Reducer_rejected Reducer.Meta_already_exists)) ->
+          ()
+        | Error error -> fail ("wrong duplicate create error: " ^ Owner_registry.command_error_to_string error)
+        | Ok _ -> fail "duplicate create replaced existing owner metadata");
        check int
          "dynamic owner extends inventory once"
          2

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -101,6 +101,44 @@ let test_reducer_rejects_invalid_compaction_numbers () =
   | Ok _ -> fail "invalid compaction numbers were accepted"
 ;;
 
+let test_profile_update_preserves_owner_runtime_state () =
+  let original = make_meta "profile" in
+  let state =
+    match Reducer.create ~keeper_name:original.name (Some original) with
+    | Ok state -> reducer_ok (Reducer.apply_meta state (Add_usage (usage_delta ())))
+    | Error error -> fail (Reducer.error_to_string error)
+  in
+  let current = Option.get (Reducer.projection state).meta in
+  let update : Reducer.profile_update =
+    { instructions = "updated instructions"
+    ; sandbox_profile = current.sandbox_profile
+    ; network_mode = current.network_mode
+    ; allowed_paths = [ "/tmp/profile" ]
+    ; mention_targets = [ "profile-target" ]
+    ; proactive_enabled = true
+    ; max_context_override = Some 32_000
+    ; active_goal_ids = [ "goal-profile" ]
+    ; autoboot_enabled = true
+    ; telemetry_feedback_enabled = Some true
+    ; telemetry_feedback_window_hours = Some 24
+    ; always_allow = Some false
+    ; updated_at = "profile-updated"
+    }
+  in
+  let state = reducer_ok (Reducer.apply_meta state (Update_profile update)) in
+  let committed = Option.get (Reducer.projection state).meta in
+  check string "profile instructions updated" update.instructions committed.instructions;
+  check int
+    "profile update preserves additive turns"
+    current.runtime.usage.total_turns
+    committed.runtime.usage.total_turns;
+  check int
+    "profile update preserves generation"
+    current.runtime.nonce
+    committed.runtime.nonce;
+  check bool "profile update changes autoboot" true committed.autoboot_enabled
+;;
+
 let test_actor_concurrent_commands_are_exact () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
@@ -605,6 +643,10 @@ let () =
             "invalid compaction numbers are rejected"
             `Quick
             test_reducer_rejects_invalid_compaction_numbers
+        ; test_case
+            "profile update preserves runtime state"
+            `Quick
+            test_profile_update_preserves_owner_runtime_state
         ] )
     ; ( "actor"
       , [ test_case

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -34,6 +34,9 @@ let with_seeded_owner ?(registered = true) ?latched_reason ~paused ~generation f
       Keeper_registry.For_testing.clear ();
       remove_tree base_path)
     (fun () ->
+       Eio_main.run @@ fun env ->
+       if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Eio.Switch.run @@ fun sw ->
        let config = Workspace.default_config base_path in
        ignore (Workspace.init config ~agent_name:(Some "operator"));
        let keeper_name = "paused-cancel-owner" in
@@ -60,6 +63,11 @@ let with_seeded_owner ?(registered = true) ?latched_reason ~paused ~generation f
          |> require_ok "read persisted Keeper metadata"
          |> require_some "persisted Keeper metadata"
        in
+       (match Keeper_owner_registry.install_from_store ~sw config with
+        | Ok count -> Alcotest.(check int) "installed owner count" 1 count
+        | Error error ->
+          Alcotest.fail
+            (Keeper_owner_registry.install_error_to_string error));
        let source : Queue.stimulus =
          { post_id = "accepted-source"
          ; urgency = Queue.Normal


### PR DESCRIPTION
## Summary

Current-only continuation of the Keeper single-owner hard cut after closing #27767. This PR is stacked on #27758 exact head 5c5bef8838 until that prerequisite lands.

Implemented so far:
- one bounded owner actor per Keeper under the server root
- immutable reducer, typed metadata commands, atomic projections, isolated single child turn
- lifecycle, identity, task, profile, create, pause/resume/reset writers routed through owner commands
- strict chat-operations.sqlite3 store with permanent operation identity, FIFO Queued/Running/terminal states, edit/move/cancel, terminal input scrubbing, restart interruption settlement, and independent durable commit read-back
- immutable admission digest plus mutable execution digest so queued edits do not break original request idempotency

No legacy facade, migration, dual-write, or feature flag is introduced.

## Remaining hard-cut scope

- move production turn authority and terminal metadata commits fully into the Owner
- attach the operation connection and all writes to the Owner actor with blocking SQLite offload
- replace Dashboard, Gate, Discord, Slack, Tools/Async Tools and SSE identity with operation_id
- remove receipt/lease/recovery/revision queue paths and meta_version/CAS merge paths
- add final Playwright, TLA+, dashboard and operational acceptance coverage

## Focused verification

- test/test_keeper_owner.exe: 14/14 passed
- test/test_keeper_chat_operation_store.exe: 4/4 passed
- scripts/dune-local.sh build test/test_keeper_owner.exe
- scripts/dune-local.sh build test/test_keeper_chat_operation_store.exe

Status remains Draft and do-not-merge until the hard cut is complete and exact-head CI is green.