### PR TITLE
feat(runtime): materialize Antigravity CLI config

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -283,7 +283,8 @@ let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with
   | Some runtime ->
     (match runtime.Runtime.execution with
-     | Runtime_execution.Codex_app_server _ -> Ok runtime
+     | Runtime_execution.Codex_app_server _
+     | Runtime_execution.Antigravity_cli _ -> Ok runtime
      | Runtime_execution.Agent_core provider_config ->
        let* _request_body_cap =
          validate_provider_request_cap
@@ -739,6 +740,16 @@ let run_named
              on_runtime_observation
          | Error _ -> ());
         codex_result, None
+      | Runtime_execution.Antigravity_cli _ ->
+        Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
+        ( Error
+            (Agent_sdk.Error.Config
+               (Agent_sdk.Error.InvalidConfig
+                  { field = "runtime_execution"
+                  ; detail =
+                      "antigravity-cli is configured but Keeper dispatch is not admitted"
+                  }))
+        , None )
       | Runtime_execution.Agent_core runtime_provider_config ->
        (match
           match provider_config_transform with

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -87,7 +87,8 @@ let vision_runtime_candidates ()
   from_failover @ rest
   |> List.filter_map (fun (rt : Runtime.t) ->
        match rt.Runtime.execution with
-       | Runtime_execution.Codex_app_server _ -> None
+       | Runtime_execution.Codex_app_server _
+       | Runtime_execution.Antigravity_cli _ -> None
        | Runtime_execution.Agent_core provider_config ->
          let caps = Runtime_agent.input_capabilities_of_runtime rt in
          if Runtime_agent.caps_admit_required_modalities caps [ "image" ]

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -448,7 +448,7 @@ let capabilities_for_runtime (rt : t) =
   match rt.execution with
   | Runtime_execution.Agent_core provider_config ->
     Llm_provider.Provider_config.capabilities_for_config_model provider_config
-  | Runtime_execution.Codex_app_server _ -> None
+  | Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _ -> None
 ;;
 
 type max_context_source =
@@ -604,7 +604,8 @@ let validate_keeper_dispatch_request_caps
          | None -> None
          | Some runtime ->
            (match runtime.execution with
-            | Runtime_execution.Codex_app_server _ -> None
+            | Runtime_execution.Codex_app_server _
+            | Runtime_execution.Antigravity_cli _ -> None
             | Runtime_execution.Agent_core provider_config ->
               (match
                  validate_request_body_cap
@@ -641,7 +642,8 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
     List.filter_map
       (fun (r : t) ->
          match r.execution, capabilities_for_runtime r with
-         | Runtime_execution.Codex_app_server _, _ -> None
+         | (Runtime_execution.Codex_app_server _ | Runtime_execution.Antigravity_cli _), _ ->
+           None
          | Runtime_execution.Agent_core _, Some _ -> None
          | Runtime_execution.Agent_core provider_config, None ->
            let provider_label =

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -203,12 +203,13 @@ let messages_api_compatible_provider_kind = function
 let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.provider)
     : (Llm_provider.Provider_config.provider_kind, string) result =
   match provider.api_format with
-  | Codex_app_server_runtime ->
+  | Codex_app_server_runtime | Antigravity_cli_runtime ->
     Error
       (Printf.sprintf
-         "provider %S uses codex-app-server and cannot be materialized as an \
+         "provider %S uses official CLI protocol %s and cannot be materialized as an \
           HTTP provider"
-         provider.id)
+         provider.id
+         provider.protocol)
   | Ollama_api -> Ok Llm_provider.Provider_config.Ollama
   | Chat_completions_api ->
     (* Chat-completions keeps the historical OpenAI-compatible fallback when
@@ -491,6 +492,65 @@ let codex_app_server_execution (provider : Runtime_schema.provider)
             { cli_path = command; model = Some spec.api_name; timeout_s = 300.0 }))
 ;;
 
+let runtime_antigravity_effort = function
+  | Runtime_schema.Antigravity_low -> Runtime_antigravity.Low
+  | Runtime_schema.Antigravity_medium -> Runtime_antigravity.Medium
+  | Runtime_schema.Antigravity_high -> Runtime_antigravity.High
+;;
+
+let runtime_antigravity_execution_mode = function
+  | Runtime_schema.Antigravity_plan -> Runtime_antigravity.Plan
+  | Runtime_schema.Antigravity_accept_edits -> Runtime_antigravity.Accept_edits
+;;
+
+let antigravity_cli_execution (provider : Runtime_schema.provider)
+    (spec : Runtime_schema.model_spec) : (Runtime_execution.t, string) result =
+  match provider.transport with
+  | Http _ ->
+    Error
+      (Printf.sprintf
+         "provider %S uses protocol antigravity-cli but declares an HTTP endpoint; \
+          an official Antigravity CLI command is required"
+         provider.id)
+  | Cli command when String.trim command = "" ->
+    Error
+      (Printf.sprintf
+         "provider %S declares an empty Antigravity CLI command"
+         provider.id)
+  | Cli command ->
+    (match provider.credentials, provider.antigravity_cli with
+     | Some _, _ ->
+       Error
+         (Printf.sprintf
+            "provider %S uses antigravity-cli and must not declare credentials; \
+             the official Antigravity client owns login state"
+            provider.id)
+     | None, _ when not provider.is_non_interactive ->
+       Error
+         (Printf.sprintf
+            "provider %S uses antigravity-cli and must declare \
+             is-non-interactive = true"
+            provider.id)
+     | None, None ->
+       Error
+         (Printf.sprintf
+            "provider %S uses antigravity-cli without typed Antigravity options"
+            provider.id)
+     | None, Some options ->
+       Ok
+         (Runtime_execution.Antigravity_cli
+            { cli_path = command
+            ; model = spec.api_name
+            ; agent = options.agent
+            ; effort = Option.map runtime_antigravity_effort options.effort
+            ; execution_mode =
+                runtime_antigravity_execution_mode options.execution_mode
+            ; sandbox = options.sandbox
+            ; disable_slash_commands = options.disable_slash_commands
+            ; timeout_s = options.timeout_s
+            }))
+;;
+
 let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema.binding)
     : (Runtime_execution.t, string) result =
   match Runtime_schema.model_of_id cfg binding.model_id with
@@ -502,6 +562,8 @@ let binding_to_execution (cfg : Runtime_schema.config) (binding : Runtime_schema
        (match provider.api_format with
         | Runtime_schema.Codex_app_server_runtime ->
           codex_app_server_execution provider spec
+        | Runtime_schema.Antigravity_cli_runtime ->
+          antigravity_cli_execution provider spec
         | Messages_api | Chat_completions_api | Ollama_api ->
           Result.map
             (fun provider_config -> Runtime_execution.Agent_core provider_config)

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -37,4 +37,5 @@ val binding_to_execution
 (** Materialize the owner of a complete turn. HTTP model APIs become
     {!Runtime_execution.Agent_core}. The exact [codex-app-server] protocol over
     a credential-free CLI transport becomes
-    {!Runtime_execution.Codex_app_server}. Other CLI protocols remain rejected. *)
+    {!Runtime_execution.Codex_app_server}; [antigravity-cli] becomes a typed
+    {!Runtime_execution.Antigravity_cli}. Other CLI protocols remain rejected. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -683,7 +683,8 @@ let input_capabilities_of_runtime (rt : Runtime.t) =
     match rt.Runtime.execution with
     | Runtime_execution.Agent_core provider_config ->
       provider_caps_of_config provider_config
-    | Runtime_execution.Codex_app_server _ ->
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Antigravity_cli _ ->
       Llm_provider.Capabilities.default_capabilities
   in
   apply_runtime_model_input_capabilities

--- a/lib/runtime/runtime_execution.ml
+++ b/lib/runtime/runtime_execution.ml
@@ -4,9 +4,21 @@ type codex_app_server =
   ; timeout_s : float
   }
 
+type antigravity_cli =
+  { cli_path : string
+  ; model : string
+  ; agent : string option
+  ; effort : Runtime_antigravity.effort option
+  ; execution_mode : Runtime_antigravity.execution_mode
+  ; sandbox : bool
+  ; disable_slash_commands : bool
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
+  | Antigravity_cli of antigravity_cli
 
 type checkpoint_owner =
   | Masc_oas
@@ -14,20 +26,22 @@ type checkpoint_owner =
 
 let agent_core_provider_config = function
   | Agent_core config -> Some config
-  | Codex_app_server _ -> None
+  | Codex_app_server _ | Antigravity_cli _ -> None
 ;;
 
 let model_id = function
   | Agent_core config -> Some config.Llm_provider.Provider_config.model_id
   | Codex_app_server config -> config.model
+  | Antigravity_cli config -> Some config.model
 ;;
 
 let label = function
   | Agent_core _ -> "agent_core"
   | Codex_app_server _ -> "codex_app_server"
+  | Antigravity_cli _ -> "antigravity_cli"
 ;;
 
 let checkpoint_owner = function
   | Agent_core _ -> Masc_oas
-  | Codex_app_server _ -> Official_client
+  | Codex_app_server _ | Antigravity_cli _ -> Official_client
 ;;

--- a/lib/runtime/runtime_execution.mli
+++ b/lib/runtime/runtime_execution.mli
@@ -2,7 +2,9 @@
 
     [Agent_core] means MASC/OAS owns the model/tool/checkpoint loop.
     [Codex_app_server] means the official Codex client owns the whole turn;
-    MASC owns admission, process lifetime, and result projection. *)
+    [Antigravity_cli] means the official Antigravity client owns its model and
+    built-in tool loop. MASC owns admission, process lifetime, durable session
+    identity, and result projection. *)
 
 type codex_app_server =
   { cli_path : string
@@ -10,9 +12,21 @@ type codex_app_server =
   ; timeout_s : float
   }
 
+type antigravity_cli =
+  { cli_path : string
+  ; model : string
+  ; agent : string option
+  ; effort : Runtime_antigravity.effort option
+  ; execution_mode : Runtime_antigravity.execution_mode
+  ; sandbox : bool
+  ; disable_slash_commands : bool
+  ; timeout_s : float
+  }
+
 type t =
   | Agent_core of Llm_provider.Provider_config.t
   | Codex_app_server of codex_app_server
+  | Antigravity_cli of antigravity_cli
 
 type checkpoint_owner =
   | Masc_oas

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -88,6 +88,11 @@ let resolve_runtime_providers ~runtime_id () =
         (Printf.sprintf
            "runtime %S is owned by codex-app-server, not the OAS agent_core"
            rt.Runtime.id)
+    | Runtime_execution.Antigravity_cli _ ->
+      Error
+        (Printf.sprintf
+           "runtime %S is owned by antigravity-cli, not the OAS agent_core"
+           rt.Runtime.id)
   in
   if String.equal runtime_id "" then
     match Runtime.get_default_runtime () with

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -14,6 +14,7 @@ type api_format =
   | Chat_completions_api
   | Ollama_api
   | Codex_app_server_runtime
+  | Antigravity_cli_runtime
 [@@deriving show, eq]
 
 type transport =
@@ -45,6 +46,27 @@ type capabilities =
     per-provider HTTP header injection. *)
 let connect_timeout_s_key = "connect-timeout-s"
 
+type antigravity_effort =
+  | Antigravity_low
+  | Antigravity_medium
+  | Antigravity_high
+[@@deriving show, eq]
+
+type antigravity_execution_mode =
+  | Antigravity_plan
+  | Antigravity_accept_edits
+[@@deriving show, eq]
+
+type antigravity_cli_options =
+  { agent : string option
+  ; effort : antigravity_effort option
+  ; execution_mode : antigravity_execution_mode
+  ; sandbox : bool
+  ; disable_slash_commands : bool
+  ; timeout_s : float
+  }
+[@@deriving show, eq]
+
 type provider =
   { id : string
   ; display_name : string
@@ -63,6 +85,9 @@ type provider =
       on the provider, not the model, because it is a transport property.
       oas#2163, RFC-OAS-026 I2: MASC declares the budget; OAS owns enforcement
       and phase=Http_operation attribution. *)
+  ; antigravity_cli : antigravity_cli_options option
+    (** Typed [antigravity-cli] process options. Present exactly for providers
+        using that protocol; absent for every other transport. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -12,6 +12,7 @@ type api_format =
   | Chat_completions_api
   | Ollama_api
   | Codex_app_server_runtime
+  | Antigravity_cli_runtime
 [@@deriving show, eq]
 
 type transport =
@@ -36,6 +37,27 @@ type capabilities =
 
 val connect_timeout_s_key : string
 
+type antigravity_effort =
+  | Antigravity_low
+  | Antigravity_medium
+  | Antigravity_high
+[@@deriving show, eq]
+
+type antigravity_execution_mode =
+  | Antigravity_plan
+  | Antigravity_accept_edits
+[@@deriving show, eq]
+
+type antigravity_cli_options =
+  { agent : string option
+  ; effort : antigravity_effort option
+  ; execution_mode : antigravity_execution_mode
+  ; sandbox : bool
+  ; disable_slash_commands : bool
+  ; timeout_s : float
+  }
+[@@deriving show, eq]
+
 type provider =
   { id : string
   ; display_name : string
@@ -54,6 +76,8 @@ type provider =
       on the provider, not the model, because it is a transport property.
       oas#2163, RFC-OAS-026 I2: MASC declares the budget; OAS owns enforcement
       and phase=Http_operation attribution. *)
+  ; antigravity_cli : antigravity_cli_options option
+    (** Present exactly when [protocol = "antigravity-cli"]. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -106,7 +106,8 @@ let partition_results
 
 let canonical_protocol_of_protocol = function
   | "messages-cli" | "messages-http" | "openai-compatible-cli"
-  | "openai-compatible-http" | "ollama-http" | "codex-app-server" as protocol ->
+  | "openai-compatible-http" | "ollama-http" | "codex-app-server"
+  | "antigravity-cli" as protocol ->
     Some protocol
   | _ -> None
 ;;
@@ -115,7 +116,7 @@ let unknown_protocol_error s =
   Printf.sprintf
     "unknown protocol %S: expected one of messages-cli, messages-http, \
      openai-compatible-cli, openai-compatible-http, ollama-http, \
-     codex-app-server"
+     codex-app-server, antigravity-cli"
     s
 ;;
 
@@ -128,6 +129,7 @@ let api_format_of_protocol (s : string)
     Ok Runtime_schema.Chat_completions_api
   | "ollama-http" -> Ok Runtime_schema.Ollama_api
   | "codex-app-server" -> Ok Runtime_schema.Codex_app_server_runtime
+  | "antigravity-cli" -> Ok Runtime_schema.Antigravity_cli_runtime
   | _ -> Error (unknown_protocol_error s)
 ;;
 
@@ -267,6 +269,120 @@ let parse_headers (tbl : Otoml.t) (path : string) : (string * string) list =
     List.sort (fun (a, _) (b, _) -> String.compare a b) pairs
 ;;
 
+let antigravity_cli_option_keys =
+  [ "agent"
+  ; "effort"
+  ; "execution-mode"
+  ; "sandbox"
+  ; "disable-slash-commands"
+  ; "timeout-s"
+  ]
+;;
+
+let antigravity_optional_string ~(path : string) (tbl : Otoml.t) key =
+  match typed_find "a string" path tbl key Otoml.get_string with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some value) when String.trim value = "" ->
+    Error (error (path ^ "." ^ key) (key ^ " must be non-empty when present"))
+  | Ok (Some value) when not (String.equal value (String.trim value)) ->
+    Error
+      (error
+         (path ^ "." ^ key)
+         (key ^ " must not have leading or trailing whitespace"))
+  | Ok (Some value) -> Ok (Some value)
+;;
+
+let antigravity_cli_options ~(path : string) (tbl : Otoml.t)
+    (api_format : Runtime_schema.api_format)
+  : (Runtime_schema.antigravity_cli_options option, parse_error list) result
+  =
+  match api_format with
+  | Antigravity_cli_runtime ->
+    let agent_result = antigravity_optional_string ~path tbl "agent" in
+    let effort_result = antigravity_optional_string ~path tbl "effort" in
+    let execution_mode_result =
+      antigravity_optional_string ~path tbl "execution-mode"
+    in
+    let sandbox_result = typed_find "a boolean" path tbl "sandbox" Otoml.get_boolean in
+    let disable_slash_commands_result =
+      typed_find "a boolean" path tbl "disable-slash-commands" Otoml.get_boolean
+    in
+    let timeout_result =
+      strict_float_find path tbl "timeout-s"
+      |> positive_finite_float_opt_field ~path ~key:"timeout-s"
+    in
+    (match
+       agent_result,
+       effort_result,
+       execution_mode_result,
+       sandbox_result,
+       disable_slash_commands_result,
+       timeout_result
+     with
+     | Error errors, _, _, _, _, _
+     | _, Error errors, _, _, _, _
+     | _, _, Error errors, _, _, _
+     | _, _, _, Error errors, _, _
+     | _, _, _, _, Error errors, _
+     | _, _, _, _, _, Error errors -> Error errors
+     | ( Ok agent
+       , Ok effort
+       , Ok execution_mode
+       , Ok sandbox
+       , Ok disable_slash_commands
+       , Ok timeout_s ) ->
+       let effort_result =
+         match effort with
+         | None -> Ok None
+         | Some "low" -> Ok (Some Runtime_schema.Antigravity_low)
+         | Some "medium" -> Ok (Some Runtime_schema.Antigravity_medium)
+         | Some "high" -> Ok (Some Runtime_schema.Antigravity_high)
+         | Some value ->
+           Error
+             (error
+                (path ^ ".effort")
+                (Printf.sprintf "effort must be low, medium, or high; got %S" value))
+       in
+       let execution_mode_result =
+         match execution_mode with
+         | None | Some "plan" -> Ok Runtime_schema.Antigravity_plan
+         | Some "accept-edits" -> Ok Runtime_schema.Antigravity_accept_edits
+         | Some value ->
+           Error
+             (error
+                (path ^ ".execution-mode")
+                (Printf.sprintf
+                   "execution-mode must be plan or accept-edits; got %S"
+                   value))
+       in
+       (match effort_result, execution_mode_result with
+        | Error errors, _ | _, Error errors -> Error errors
+        | Ok effort, Ok execution_mode ->
+          Ok
+            (Some
+               { Runtime_schema.agent
+               ; effort
+               ; execution_mode
+               ; sandbox = Option.value ~default:false sandbox
+               ; disable_slash_commands =
+                   Option.value ~default:true disable_slash_commands
+               ; timeout_s = Option.value ~default:300.0 timeout_s
+               })))
+  | Messages_api | Chat_completions_api | Ollama_api | Codex_app_server_runtime ->
+    (match
+       List.find_opt
+         (fun key -> Option.is_some (Otoml.find_opt tbl Fun.id [ key ]))
+         antigravity_cli_option_keys
+     with
+     | None -> Ok None
+     | Some key ->
+       Error
+         (error
+            (path ^ "." ^ key)
+            (Printf.sprintf "%s is valid only for protocol antigravity-cli" key)))
+;;
+
 let parse_provider (id : string) (tbl : Otoml.t)
   : (Runtime_schema.provider, parse_error list) result
   =
@@ -304,9 +420,10 @@ let parse_provider (id : string) (tbl : Otoml.t)
         Result.map Option.some (parse_credential cred_tbl (path ^ ".credentials"))
       | None -> Ok None
     in
-    (match credentials_result with
-     | Error errs -> Error errs
-     | Ok credentials ->
+    let antigravity_cli_result = antigravity_cli_options ~path tbl api_format in
+    (match credentials_result, antigravity_cli_result with
+     | Error errs, _ | _, Error errs -> Error errs
+     | Ok credentials, Ok antigravity_cli ->
        let capabilities =
          Otoml.find_opt tbl Fun.id [ "capabilities" ]
          |> Option.map (parse_capabilities ~path)
@@ -358,6 +475,7 @@ let parse_provider (id : string) (tbl : Otoml.t)
             ; healthcheck_path
             ; headers
             ; connect_timeout_s
+            ; antigravity_cli
             }))
 ;;
 

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -774,7 +774,8 @@ let dashboard_runtime_append_probe_path base ~suffix =
 
 let dashboard_runtime_probe_url ~(api_format : Runtime_schema.api_format) base_url =
   match api_format with
-  | Runtime_schema.Codex_app_server_runtime -> None
+  | Runtime_schema.Codex_app_server_runtime
+  | Runtime_schema.Antigravity_cli_runtime -> None
   | Runtime_schema.Ollama_api ->
     let base = dashboard_runtime_trim_trailing_slashes base_url in
     Some
@@ -884,7 +885,8 @@ let dashboard_runtime_model_count_of_body ~(api_format : Runtime_schema.api_form
   try
     let json = Yojson.Safe.from_string body in
     match api_format with
-    | Runtime_schema.Codex_app_server_runtime -> None
+    | Runtime_schema.Codex_app_server_runtime
+    | Runtime_schema.Antigravity_cli_runtime -> None
     | Runtime_schema.Ollama_api -> dashboard_runtime_list_member_len "models" json
     | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
       (match dashboard_runtime_list_member_len "data" json with
@@ -1546,6 +1548,30 @@ let runtime_request_config_json (rt : Runtime.t) =
       ; "timeout_s", `Float config.timeout_s
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Antigravity_cli config ->
+    `Assoc
+      [ "source", `String "official-client-runtime"
+      ; "execution", `String "antigravity_cli"
+      ; "model", `String config.model
+      ; "agent", Json_util.string_opt_to_json config.agent
+      ; ( "effort"
+        , Json_util.string_opt_to_json
+            (Option.map
+               (function
+                 | Runtime_antigravity.Low -> "low"
+                 | Runtime_antigravity.Medium -> "medium"
+                 | Runtime_antigravity.High -> "high")
+               config.effort) )
+      ; ( "execution_mode"
+        , `String
+            (match config.execution_mode with
+             | Runtime_antigravity.Plan -> "plan"
+             | Runtime_antigravity.Accept_edits -> "accept-edits") )
+      ; "sandbox", `Bool config.sandbox
+      ; "disable_slash_commands", `Bool config.disable_slash_commands
+      ; "timeout_s", `Float config.timeout_s
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core cfg ->
     `Assoc
     [ "source", `String "oas-provider-config"
@@ -1591,6 +1617,7 @@ let runtime_api_format_wire : Runtime_schema.api_format -> string = function
   | Runtime_schema.Chat_completions_api -> "chat-completions"
   | Runtime_schema.Ollama_api -> "ollama"
   | Runtime_schema.Codex_app_server_runtime -> "codex-app-server"
+  | Runtime_schema.Antigravity_cli_runtime -> "antigravity-cli"
 ;;
 
 let runtime_provider_behavior_capabilities_json
@@ -1700,6 +1727,12 @@ let effective_capabilities_json (rt : Runtime.t) =
       ; "execution", `String "codex_app_server"
       ; "verified", `Bool false
       ]
+  | Runtime_execution.Antigravity_cli _ ->
+    `Assoc
+      [ "source", `String "unverified"
+      ; "execution", `String "antigravity_cli"
+      ; "verified", `Bool false
+      ]
   | Runtime_execution.Agent_core provider_config ->
    (match Llm_provider.Provider_config.capabilities_for_config_model provider_config with
   | None -> `Null
@@ -1780,6 +1813,11 @@ let runtime_parameter_policy_json (rt : Runtime.t) =
       [ "source", `String "official-client-owned"
       ; "execution", `String "codex_app_server"
       ]
+  | Runtime_execution.Antigravity_cli _ ->
+    `Assoc
+      [ "source", `String "official-client-owned"
+      ; "execution", `String "antigravity_cli"
+      ]
   | Runtime_execution.Agent_core provider_config ->
     let dialect = RD.for_provider_config provider_config in
     let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
@@ -1807,7 +1845,8 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
   let runtime_kind = runtime_kind_of_transport rt.provider.transport in
   let is_official_client_runtime =
     match rt.execution with
-    | Runtime_execution.Codex_app_server _ -> true
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Antigravity_cli _ -> true
     | Runtime_execution.Agent_core _ -> false
   in
   let runtime_status =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -96,6 +96,12 @@ let validate_requested_model (runtime : Runtime.t) requested_model =
          "runtime %S is owned by codex-app-server; local_runtime_bench only \
           measures OAS agent_core providers"
          runtime.id)
+  | Runtime_execution.Antigravity_cli _ ->
+    Error
+      (Printf.sprintf
+         "runtime %S is owned by antigravity-cli; local_runtime_bench only \
+          measures OAS agent_core providers"
+         runtime.id)
   | Runtime_execution.Agent_core provider_config ->
     (match requested_model with
      | None -> Ok (runtime, provider_config)

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -13,7 +13,8 @@ let parse_or_fail content =
 let agent_core_provider_config (runtime : Runtime.t) =
   match runtime.execution with
   | Runtime_execution.Agent_core provider_config -> provider_config
-  | Runtime_execution.Codex_app_server _ ->
+  | Runtime_execution.Codex_app_server _
+  | Runtime_execution.Antigravity_cli _ ->
     failf "runtime %s is not an agent_core provider" runtime.id
 ;;
 
@@ -3158,13 +3159,14 @@ let test_runtime_assignment_default_rider_resolves_to_default_runtime () =
              "local.good"
              (Runtime.get_default_runtime_id ())))
 
-let codex_app_server_runtime_toml ?credential () =
+let codex_app_server_runtime_toml ?credential ?(options = "") () =
   let credential = Option.value credential ~default:"" in
   Printf.sprintf
     "[providers.codex]\n\
      protocol = \"codex-app-server\"\n\
      command = \"codex\"\n\
      is-non-interactive = true\n\
+     %s\n\
      %s\n\
      [models.codex]\n\
      api-name = \"gpt-5.6-sol\"\n\
@@ -3174,6 +3176,7 @@ let codex_app_server_runtime_toml ?credential () =
      \n\
      [runtime]\n\
      default = \"codex.codex\"\n"
+    options
     credential
 ;;
 
@@ -3189,7 +3192,117 @@ let test_codex_app_server_materializes_as_turn_runtime () =
          fail "codex-app-server was incorrectly materialized as agent_core"
        | Runtime_execution.Codex_app_server config ->
          check string "cli path" "codex" config.cli_path;
-         check (option string) "model" (Some "gpt-5.6-sol") config.model))
+         check (option string) "model" (Some "gpt-5.6-sol") config.model
+       | Runtime_execution.Antigravity_cli _ ->
+         fail "codex-app-server was incorrectly materialized as antigravity-cli"))
+;;
+
+let antigravity_cli_runtime_toml ?credential ?(options = "") () =
+  let credential = Option.value credential ~default:"" in
+  Printf.sprintf
+    "[providers.antigravity]\n\
+     protocol = \"antigravity-cli\"\n\
+     command = \"agy\"\n\
+     is-non-interactive = true\n\
+     %s\n\
+     %s\n\
+     [models.gemini]\n\
+     api-name = \"gemini-3.6-flash-high\"\n\
+     max-context = 128000\n\
+     \n\
+     [antigravity.gemini]\n\
+     \n\
+     [runtime]\n\
+     default = \"antigravity.gemini\"\n"
+    options
+    credential
+;;
+
+let test_antigravity_cli_materializes_typed_process_options () =
+  let options =
+    "agent = \"fixture-agent\"\n\
+     effort = \"high\"\n\
+     execution-mode = \"accept-edits\"\n\
+     sandbox = true\n\
+     disable-slash-commands = false\n\
+     timeout-s = 45.0"
+  in
+  with_temp_runtime_toml
+    (antigravity_cli_runtime_toml ~options ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Error error -> failf "antigravity-cli runtime should load: %s" error
+       | Ok (runtimes, default, _, _, _, _) ->
+         check int "one runtime" 1 (List.length runtimes);
+         check string "default id" "antigravity.gemini" default.id;
+         (match default.execution with
+          | Runtime_execution.Antigravity_cli config ->
+            check string "cli path" "agy" config.cli_path;
+            check string "model" "gemini-3.6-flash-high" config.model;
+            check (option string) "agent" (Some "fixture-agent") config.agent;
+            check bool
+              "effort"
+              true
+              (config.effort = Some Runtime_antigravity.High);
+            check bool
+              "execution mode"
+              true
+              (config.execution_mode = Runtime_antigravity.Accept_edits);
+            check bool "sandbox" true config.sandbox;
+            check bool "slash commands" false config.disable_slash_commands;
+            check (float 0.0) "timeout" 45.0 config.timeout_s
+          | Runtime_execution.Agent_core _ | Runtime_execution.Codex_app_server _ ->
+            fail "antigravity-cli was materialized through the wrong execution owner"))
+;;
+
+let test_antigravity_cli_defaults_are_explicit () =
+  with_temp_runtime_toml (antigravity_cli_runtime_toml ()) (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error error -> failf "antigravity-cli runtime should load: %s" error
+    | Ok (_, default, _, _, _, _) ->
+      (match default.execution with
+       | Runtime_execution.Antigravity_cli config ->
+         check (option string) "agent" None config.agent;
+         check bool "effort" true (config.effort = None);
+         check bool "plan" true (config.execution_mode = Runtime_antigravity.Plan);
+         check bool "sandbox opt-in" false config.sandbox;
+         check bool "slash expansion disabled" true config.disable_slash_commands;
+         check (float 0.0) "timeout" 300.0 config.timeout_s
+       | Runtime_execution.Agent_core _ | Runtime_execution.Codex_app_server _ ->
+         fail "antigravity-cli was materialized through the wrong execution owner"))
+;;
+
+let test_antigravity_cli_rejects_declared_credentials () =
+  let credential =
+    "[providers.antigravity.credentials]\n\
+     type = \"env\"\n\
+     key = \"GEMINI_API_KEY\""
+  in
+  with_temp_runtime_toml
+    (antigravity_cli_runtime_toml ~credential ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> fail "antigravity-cli incorrectly admitted declared credentials"
+       | Error error ->
+         check bool "diagnostic names official login ownership" true
+           (String_util.contains_substring
+              error
+              "official Antigravity client owns login state"))
+;;
+
+let test_antigravity_options_are_protocol_scoped () =
+  with_temp_runtime_toml
+    (codex_app_server_runtime_toml
+       ~options:"execution-mode = \"accept-edits\""
+       ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> fail "codex-app-server silently admitted an Antigravity option"
+       | Error error ->
+         check bool "diagnostic names scoped option" true
+           (String_util.contains_substring
+              error
+              "execution-mode is valid only for protocol antigravity-cli"))
 ;;
 
 let test_codex_app_server_rejects_declared_credentials () =
@@ -3219,6 +3332,14 @@ let () =
             test_codex_app_server_materializes_as_turn_runtime;
           test_case "codex app-server rejects declared credentials" `Quick
             test_codex_app_server_rejects_declared_credentials;
+          test_case "antigravity CLI options materialize" `Quick
+            test_antigravity_cli_materializes_typed_process_options;
+          test_case "antigravity CLI defaults are explicit" `Quick
+            test_antigravity_cli_defaults_are_explicit;
+          test_case "antigravity CLI rejects declared credentials" `Quick
+            test_antigravity_cli_rejects_declared_credentials;
+          test_case "antigravity options are protocol-scoped" `Quick
+            test_antigravity_options_are_protocol_scoped;
           test_case "deployment OAS catalog covers live RunPod MTP runtime" `Quick
             test_deployment_oas_model_catalog_covers_live_runpod_mtp;
           test_case

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -40,6 +40,7 @@ let runpod_provider =
   ; healthcheck_path = None
   ; headers = None
   ; connect_timeout_s = None
+  ; antigravity_cli = None
   }
 
 let qwen_model =


### PR DESCRIPTION
## Summary

- add exact antigravity-cli protocol parsing and typed execution ownership
- expose agent, effort, execution-mode, sandbox, slash expansion, and timeout settings
- default to plan, sandbox opt-in, slash expansion disabled, and a 300 second timeout
- reject provider credentials and reject Antigravity-only fields on other protocols
- keep Antigravity outside OAS provider and checkpoint paths
- project configured options to Dashboard runtime inventory without claiming login or execution readiness

## Verification

- focused compile: test/test_runtime_config_validity.exe
- runtime config validity: 62 passed in 0.429s

## Stack

- depends on #27782
- Keeper dispatch intentionally remains fail-closed until the next stacked PR