### PR TITLE
feat(keeper): run durable Antigravity CLI turns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1567,7 +1567,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store"
+          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_keeper_antigravity_runtime"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${official_client_targets}"
 
       - name: Run host FD pressure contract suite

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -172,7 +172,11 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
              ~field:"enable_thinking"
              "agy has no no-thinking flag; configure Antigravity effort in runtime.toml instead")
     in
-    let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
+    let hooks =
+      match hooks with
+      | Some hooks -> hooks
+      | None -> Agent_sdk.Hooks.empty
+    in
     let owner_epoch = Session.process_epoch () in
     let* stored_session =
       match Session.load ~base_path ~keeper_name with

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -1,0 +1,562 @@
+open Result.Syntax
+
+module Host = Keeper_official_client_host
+module Session = Keeper_official_client_session_store
+
+let runtime_label = "Antigravity"
+
+let config_error ~field detail =
+  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })
+;;
+
+let internal_error detail = Agent_sdk.Error.Internal detail
+
+let runtime_error_to_sdk_error = function
+  | Runtime_antigravity.Invalid_config detail ->
+    config_error ~field:"antigravity_cli" detail
+  | error -> Agent_sdk.Error.Internal (Runtime_antigravity.error_to_string error)
+;;
+
+let recovery_failure_of_runtime_error = function
+  | Runtime_antigravity.Spawn_failed _ -> Session.Transient_spawn_failed
+  | Runtime_antigravity.Process_exited _ | Runtime_antigravity.Timeout _ ->
+    Session.Transport_interrupted
+  | Runtime_antigravity.Invalid_config _
+  | Runtime_antigravity.Protocol_error _ ->
+    Session.Protocol_failed
+  | Runtime_antigravity.State_callback_failed _ -> Session.State_persistence_failed
+  | Runtime_antigravity.Turn_failed _ -> Session.Provider_rejected
+;;
+
+let user_message text : Agent_sdk.Types.message =
+  { role = User
+  ; content = [ Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let render_message (message : Agent_sdk.Types.message) =
+  let* text =
+    Host.text_of_blocks
+      ~runtime_label
+      ~field:"initial_messages"
+      message.content
+  in
+  match message.role with
+  | Tool ->
+    Error
+      (config_error
+         ~field:"initial_messages"
+         "antigravity-cli history projection does not admit OAS tool messages")
+  | System -> Ok ("SYSTEM:\n" ^ text)
+  | User -> Ok ("USER:\n" ^ text)
+  | Assistant -> Ok ("ASSISTANT:\n" ^ text)
+;;
+
+let render_messages messages =
+  let rec loop rendered = function
+    | [] -> Ok (String.concat "\n\n" (List.rev rendered))
+    | message :: rest ->
+      let* text = render_message message in
+      loop (text :: rendered) rest
+  in
+  loop [] messages
+;;
+
+let reject_unprojected_tool_contracts ~tools ~hooks ~context_injector =
+  if tools <> []
+  then
+    Error
+      (config_error
+         ~field:"tools"
+         "agy --print does not expose a custom-tool transport; MASC tools cannot be projected into the Antigravity built-in tool loop")
+  else if Option.is_some context_injector
+  then
+    Error
+      (config_error
+         ~field:"context_injector"
+         "Antigravity built-in tool results are not available to the MASC context injector")
+  else
+    match hooks with
+    | Some
+        { Agent_sdk.Hooks.pre_tool_use = Some _
+        ; _
+        }
+    | Some { post_tool_use = Some _; _ }
+    | Some { post_tool_use_failure = Some _; _ }
+    | Some { on_tool_error = Some _; _ } ->
+      Error
+        (config_error
+           ~field:"hooks"
+           "Antigravity built-in tool calls cannot run MASC tool lifecycle hooks")
+    | None | Some _ -> Ok ()
+;;
+
+let prepare_prompt ~keeper_name ~turn_count ~is_resume ~goal ~system_prompt
+    ~initial_messages ~model_input_projection ~hooks =
+  let messages =
+    (if is_resume then [] else initial_messages) @ [ user_message goal ]
+  in
+  let* prepared =
+    Host.prepare_turn
+      ~runtime_label
+      ~keeper_name
+      ~turn_count
+      ~system_prompt
+      ~tools:[]
+      ~initial_messages:messages
+      ~model_input_projection
+      ~hooks
+      ~enable_thinking:None
+  in
+  let* () =
+    match prepared.reasoning_effort with
+    | None -> Ok ()
+    | Some _ ->
+      Error
+        (config_error
+           ~field:"reasoning_effort"
+           "Antigravity effort is owned by runtime.toml and cannot be replaced by an OAS turn hook")
+  in
+  let* rendered = render_messages prepared.messages in
+  let sections =
+    [ Option.map (fun text -> "SYSTEM INSTRUCTIONS:\n" ^ text)
+        (String_util.trim_to_option prepared.system_prompt)
+    ; String_util.trim_to_option rendered
+    ]
+    |> List.filter_map Fun.id
+  in
+  Ok (String.concat "\n\n" sections)
+;;
+
+let effort_label = function
+  | None -> "default"
+  | Some Runtime_antigravity.Low -> "low"
+  | Some Runtime_antigravity.Medium -> "medium"
+  | Some Runtime_antigravity.High -> "high"
+;;
+
+let execution_mode_label = function
+  | Runtime_antigravity.Plan -> "plan"
+  | Runtime_antigravity.Accept_edits -> "accept-edits"
+;;
+
+let runtime_binding_id runtime_id (config : Runtime_execution.antigravity_cli) =
+  let canonical =
+    `Assoc
+      [ "agent", Option.fold ~none:`Null ~some:(fun value -> `String value) config.agent
+      ; "disable_slash_commands", `Bool config.disable_slash_commands
+      ; "effort", `String (effort_label config.effort)
+      ; "execution_mode", `String (execution_mode_label config.execution_mode)
+      ; "model", `String config.model
+      ; "sandbox", `Bool config.sandbox
+      ]
+    |> Yojson.Safe.to_string
+  in
+  let digest = Digestif.SHA256.(digest_string canonical |> to_hex) in
+  runtime_id ^ "#" ^ digest
+;;
+
+let provider_turn_identity ~conversation_id ~num_turns =
+  Printf.sprintf "%s:ordinal:%d" conversation_id num_turns
+;;
+
+let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
+    ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
+    ~enable_thinking ~(config : Runtime_execution.antigravity_cli) =
+  match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
+  | None, _ ->
+    Error
+      (config_error
+         ~field:"eio_env"
+         "Antigravity CLI runtime requires the initialized Eio standard environment")
+  | _, None ->
+    Error
+      (config_error
+         ~field:"eio_clock"
+         "Antigravity CLI runtime requires the initialized Eio clock")
+  | Some env, Some clock ->
+    let* () = reject_unprojected_tool_contracts ~tools ~hooks ~context_injector in
+    let* () =
+      match enable_thinking with
+      | None | Some true -> Ok ()
+      | Some false ->
+        Error
+          (config_error
+             ~field:"enable_thinking"
+             "agy has no no-thinking flag; configure Antigravity effort in runtime.toml instead")
+    in
+    let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
+    let owner_epoch = Session.process_epoch () in
+    let binding_runtime_id = runtime_binding_id runtime_id config in
+    let* stored_session =
+      match Session.load ~base_path ~keeper_name with
+      | Ok session -> Ok session
+      | Error detail ->
+        Error (internal_error ("Antigravity session binding load failed: " ^ detail))
+    in
+    let* stored_session =
+      match stored_session with
+      | Some ({ Session.phase = (Start _ | Active _ | Turn_inflight _); _ } as expected) ->
+        (match
+           Session.reconcile_process_restart
+             ~base_path
+             ~keeper_name
+             ~expected
+             ~current_owner_epoch:owner_epoch
+             ~required_at:(Time_compat.now ())
+         with
+         | Ok reconciled -> Ok (Some reconciled)
+         | Error detail ->
+           Error (config_error ~field:"official_client_session.phase" detail))
+      | None | Some { phase = (Ready | Recovery_required _ | Settled _); _ } ->
+        Ok stored_session
+    in
+    let* claim_plan =
+      match
+        Session.plan_claim
+          ~expected:stored_session
+          ~client_kind:Antigravity
+          ~runtime_id:binding_runtime_id
+      with
+      | Ok plan -> Ok plan
+      | Error detail ->
+        Error (config_error ~field:"official_client_session.claim" detail)
+    in
+    let conversation_mode =
+      match claim_plan.previous_settlement with
+      | None -> Runtime_antigravity.Start
+      | Some { session_id; _ } -> Runtime_antigravity.Resume { conversation_id = session_id }
+    in
+    let is_resume = Option.is_some claim_plan.previous_settlement in
+    let turn_count = claim_plan.turn_count in
+    let* goal =
+      match goal_blocks with
+      | None -> Ok goal
+      | Some blocks -> Host.text_of_blocks ~runtime_label ~field:"goal_blocks" blocks
+    in
+    let* prompt =
+      prepare_prompt
+        ~keeper_name
+        ~turn_count
+        ~is_resume
+        ~goal
+        ~system_prompt
+        ~initial_messages
+        ~model_input_projection
+        ~hooks:(Some hooks)
+    in
+    let tool_surface_sha256 = Session.tool_surface_sha256 [] in
+    let* () =
+      match claim_plan.required_tool_surface_sha256 with
+      | None -> Ok ()
+      | Some stored when String.equal stored tool_surface_sha256 -> Ok ()
+      | Some _ ->
+        Error
+          (config_error
+             ~field:"official_client_session.tool_surface_sha256"
+             "stored Antigravity session has a different projected MASC tool surface")
+    in
+    let client_config : Runtime_antigravity.config =
+      { cli_path = config.cli_path
+      ; cwd = base_path
+      ; model = config.model
+      ; agent = config.agent
+      ; effort = config.effort
+      ; execution_mode = config.execution_mode
+      ; sandbox = config.sandbox
+      ; disable_slash_commands = config.disable_slash_commands
+      ; timeout_s = config.timeout_s
+      }
+    in
+    let* () =
+      match
+        Runtime_antigravity.validate_turn
+          ~conversation_mode
+          client_config
+          ~prompt
+      with
+      | Ok () -> Ok ()
+      | Error error -> Error (runtime_error_to_sdk_error error)
+    in
+    let* claimed =
+      match
+        Session.claim
+          ~base_path
+          ~keeper_name
+          ~expected:stored_session
+          ~client_kind:Antigravity
+          ~owner_epoch
+          ~runtime_id:binding_runtime_id
+          ~tool_surface_sha256
+          ~updated_at:(Time_compat.now ())
+      with
+      | Ok session -> Ok session
+      | Error detail -> Error (internal_error ("Antigravity session claim failed: " ^ detail))
+    in
+    let session_state = ref claimed in
+    let recovery_failure = ref Session.Transport_interrupted in
+    let update_session label transition =
+      match transition !session_state with
+      | Ok next ->
+        session_state := next;
+        Ok ()
+      | Error detail ->
+        recovery_failure := Session.State_persistence_failed;
+        Error (Printf.sprintf "Antigravity session %s failed: %s" label detail)
+    in
+    let require_recovery detail =
+      match !session_state with
+      | { Session.phase = (Ready | Settled _ | Recovery_required _); _ } -> Ok ()
+      | expected ->
+        (match
+           Session.require_recovery
+             ~base_path
+             ~keeper_name
+             ~expected
+             ~failure:!recovery_failure
+             ~detail
+             ~required_at:(Time_compat.now ())
+         with
+         | Ok recovery ->
+           session_state := recovery;
+           Ok ()
+         | Error recovery_detail -> Error recovery_detail)
+    in
+    let settle_failed_claim detail =
+      match Session.failure_disposition !recovery_failure with
+      | Transient ->
+        (match !session_state with
+         | { phase = (Ready | Settled _ | Recovery_required _); _ } -> Ok ()
+         | expected ->
+           (match
+              Session.release_transient
+                ~base_path
+                ~keeper_name
+                ~expected
+                ~failure:!recovery_failure
+                ~released_at:(Time_compat.now ())
+            with
+            | Ok released ->
+              session_state := released;
+              Ok ()
+            | Error recovery_detail -> Error recovery_detail))
+      | Ambiguous | Fatal -> require_recovery detail
+    in
+    let started_at = Time_compat.now () in
+    let turn_result =
+      try
+        (match
+           Runtime_antigravity.run_turn
+             ~conversation_mode
+             ~mgr:(Eio.Stdenv.process_mgr env)
+             ~clock
+             ~cwd:Eio.Path.(Eio.Stdenv.fs env / base_path)
+             ~on_conversation_ready:(fun ~conversation_id ->
+               let* () =
+                 update_session "active transition" (fun expected ->
+                   Session.mark_active
+                     ~base_path
+                     ~keeper_name
+                     ~expected
+                     ~session_id:conversation_id
+                     ~updated_at:(Time_compat.now ()))
+               in
+               update_session "turn-starting transition" (fun expected ->
+                 Session.mark_turn_starting
+                   ~base_path
+                   ~keeper_name
+                   ~expected
+                   ~session_id:conversation_id
+                   ~updated_at:(Time_compat.now ())))
+             client_config
+             ~prompt
+         with
+         | Error error ->
+           recovery_failure := recovery_failure_of_runtime_error error;
+           Error (runtime_error_to_sdk_error error)
+         | Ok turn ->
+           recovery_failure := Session.Protocol_failed;
+           let* () =
+             if Bool.equal is_resume turn.resumed
+             then Ok ()
+             else
+               Error
+                 (internal_error
+                    "Antigravity reported a conversation mode different from the durable claim")
+           in
+           let* () =
+             if turn.num_turns = turn_count
+             then Ok ()
+             else
+               Error
+                 (internal_error
+                    (Printf.sprintf
+                       "Antigravity reported conversation ordinal %d but durable session expected %d"
+                       turn.num_turns
+                       turn_count))
+           in
+           let turn_id =
+             provider_turn_identity
+               ~conversation_id:turn.conversation_id
+               ~num_turns:turn.num_turns
+           in
+           recovery_failure := Session.State_persistence_failed;
+           let* () =
+             update_session "turn identity transition" (fun expected ->
+               Session.mark_turn_started
+                 ~base_path
+                 ~keeper_name
+                 ~expected
+                 ~session_id:turn.conversation_id
+                 ~turn_id
+                 ~updated_at:(Time_compat.now ()))
+           in
+           let latency_ms = Int.of_float ((Time_compat.now () -. started_at) *. 1000.0) in
+           let usage : Agent_sdk.Types.api_usage =
+             { input_tokens = turn.usage.input_tokens
+             ; output_tokens = turn.usage.output_tokens
+             ; cache_creation_input_tokens = 0
+             ; cache_read_input_tokens = turn.usage.cache_read_tokens
+             ; cost_usd = None
+             }
+           in
+           let response =
+             { Agent_sdk.Types.id = turn_id
+             ; model = turn.model
+             ; stop_reason = EndTurn
+             ; content = [ Text turn.text ]
+             ; usage = Some usage
+             ; telemetry =
+                 Some
+                   { Agent_sdk.Types.default_inference_telemetry with
+                     request_latency_ms = Some latency_ms
+                   ; canonical_model_id = Some turn.model
+                   }
+             }
+           in
+           recovery_failure := Session.Host_hook_failed;
+           let* () =
+             match
+               Host.invoke_turn_hook
+                 ~keeper_name
+                 ~turn_count
+                 ~hook_name:"after_turn"
+                 hooks.after_turn
+                 (Agent_sdk.Hooks.AfterTurn { turn = turn_count; response })
+             with
+             | Continue -> Ok ()
+             | HookFailed { stage; detail } ->
+               Error (Host.hook_error ~runtime_label ~hook_name:"after_turn" ~stage detail)
+             | decision ->
+               Error (Host.illegal_hook_decision ~runtime_label ~hook_name:"after_turn" decision)
+           in
+           let* () =
+             match
+               Host.invoke_turn_hook
+                 ~keeper_name
+                 ~turn_count
+                 ~hook_name:"on_stop"
+                 hooks.on_stop
+                 (Agent_sdk.Hooks.OnStop { reason = response.stop_reason; response })
+             with
+             | Continue -> Ok ()
+             | HookFailed { stage; detail } ->
+               Error (Host.hook_error ~runtime_label ~hook_name:"on_stop" ~stage detail)
+             | decision ->
+               Error (Host.illegal_hook_decision ~runtime_label ~hook_name:"on_stop" decision)
+           in
+           recovery_failure := Session.State_persistence_failed;
+           let* () =
+             match
+               Session.settle
+                 ~base_path
+                 ~keeper_name
+                 ~expected:!session_state
+                 ~session_id:turn.conversation_id
+                 ~turn_id
+                 ~updated_at:(Time_compat.now ())
+             with
+             | Ok settled ->
+               session_state := settled;
+               Ok ()
+             | Error detail ->
+               Error (internal_error ("Antigravity session settlement failed: " ^ detail))
+           in
+           let capture, _metrics =
+             Runtime_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
+           in
+           Runtime_observation.record_attempt_terminal
+             capture
+             ~model_id:turn.model
+             ~latency_ms:(Some latency_ms)
+             ~error:None;
+           let runtime_observation =
+             Runtime_observation.runtime_observation_with_metrics
+               ~runtime_id
+               ~strategy:"official_client_runtime"
+               ~configured_labels:
+                 [ "antigravity_cli"
+                 ; "tool_owner=official_client"
+                 ; "masc_tool_surface=not_projected"
+                 ; "provider_turn_identity=conversation_ordinal"
+                 ; Printf.sprintf "execution_mode=%s" (execution_mode_label config.execution_mode)
+                 ; Printf.sprintf "sandbox=%b" config.sandbox
+                 ; Printf.sprintf "permission_mode=%s" turn.permission_mode
+                 ; Printf.sprintf "tool_steps=%d" turn.tool_steps
+                 ; Printf.sprintf "tool_errors=%d" turn.tool_errors
+                 ; Printf.sprintf "resumed=%b" turn.resumed
+                 ; Printf.sprintf "turn_count=%d" turn_count
+                 ; Printf.sprintf "input_tokens=%d" turn.usage.input_tokens
+                 ; Printf.sprintf "output_tokens=%d" turn.usage.output_tokens
+                 ; Printf.sprintf "thinking_tokens=%d" turn.usage.thinking_tokens
+                 ; Printf.sprintf "cache_read_tokens=%d" turn.usage.cache_read_tokens
+                 ; Printf.sprintf "total_tokens=%d" turn.usage.total_tokens
+                 ]
+               ~candidate_count:1
+               ~selected_model_raw:(Some turn.model)
+               ~capture
+               ~attempt_details_source:"antigravity_cli"
+               ~oas_internal_runtime_allowed:false
+               ()
+           in
+           Ok
+             { Runtime_agent.response
+             ; checkpoint = None
+             ; session_id = turn.conversation_id
+             ; turns = turn_count
+             ; trace_ref = None
+             ; run_validation = None
+             ; runtime_observation = Some runtime_observation
+             ; stop_reason = Completed
+             })
+      with
+      | Eio.Cancel.Cancelled _ as exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        recovery_failure := Session.Transport_interrupted;
+        let detail = "Antigravity turn cancelled: " ^ Printexc.to_string exn in
+        (match Eio.Cancel.protect (fun () -> settle_failed_claim detail) with
+         | Ok () -> ()
+         | Error recovery_detail ->
+           Log.Keeper.error
+             ~keeper_name
+             "Antigravity cancellation recovery persistence failed: %s"
+             recovery_detail);
+        Printexc.raise_with_backtrace exn backtrace
+    in
+    (match turn_result with
+     | Ok _ -> turn_result
+     | Error original_error ->
+       let original_detail = Agent_sdk.Error.to_string original_error in
+       (match Eio.Cancel.protect (fun () -> settle_failed_claim original_detail) with
+        | Ok () -> turn_result
+        | Error recovery_detail ->
+          Error
+            (internal_error
+               (Printf.sprintf
+                  "Antigravity turn failed and recovery state persistence also failed: original=%s recovery=%s"
+                  original_detail
+                  recovery_detail))))
+;;

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -143,22 +143,6 @@ let execution_mode_label = function
   | Runtime_antigravity.Accept_edits -> "accept-edits"
 ;;
 
-let runtime_binding_id runtime_id (config : Runtime_execution.antigravity_cli) =
-  let canonical =
-    `Assoc
-      [ "agent", Option.fold ~none:`Null ~some:(fun value -> `String value) config.agent
-      ; "disable_slash_commands", `Bool config.disable_slash_commands
-      ; "effort", `String (effort_label config.effort)
-      ; "execution_mode", `String (execution_mode_label config.execution_mode)
-      ; "model", `String config.model
-      ; "sandbox", `Bool config.sandbox
-      ]
-    |> Yojson.Safe.to_string
-  in
-  let digest = Digestif.SHA256.(digest_string canonical |> to_hex) in
-  runtime_id ^ "#" ^ digest
-;;
-
 let provider_turn_identity ~conversation_id ~num_turns =
   Printf.sprintf "%s:ordinal:%d" conversation_id num_turns
 ;;
@@ -190,7 +174,6 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     in
     let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
     let owner_epoch = Session.process_epoch () in
-    let binding_runtime_id = runtime_binding_id runtime_id config in
     let* stored_session =
       match Session.load ~base_path ~keeper_name with
       | Ok session -> Ok session
@@ -219,7 +202,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
         Session.plan_claim
           ~expected:stored_session
           ~client_kind:Antigravity
-          ~runtime_id:binding_runtime_id
+          ~runtime_id
       with
       | Ok plan -> Ok plan
       | Error detail ->
@@ -289,7 +272,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
           ~expected:stored_session
           ~client_kind:Antigravity
           ~owner_epoch
-          ~runtime_id:binding_runtime_id
+          ~runtime_id
           ~tool_surface_sha256
           ~updated_at:(Time_compat.now ())
       with

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -1,0 +1,21 @@
+(** Keeper projection for one official Antigravity CLI turn. *)
+
+val run :
+  runtime_id:string ->
+  keeper_name:string ->
+  base_path:string ->
+  goal:string ->
+  goal_blocks:Agent_sdk.Types.content_block list option ->
+  system_prompt:string ->
+  tools:Agent_sdk.Tool.t list ->
+  initial_messages:Agent_sdk.Types.message list ->
+  model_input_projection:Agent_sdk.Agent.model_input_projection option ->
+  hooks:Agent_sdk.Hooks.hooks option ->
+  context_injector:Agent_sdk.Hooks.context_injector option ->
+  enable_thinking:bool option ->
+  config:Runtime_execution.antigravity_cli ->
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
+
+(** Antigravity owns its built-in tool loop and does not expose a custom-tool
+    transport in [agy --print]. Consequently this boundary rejects MASC tools,
+    tool hooks, and context injection instead of silently dropping them. *)

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -104,6 +104,8 @@ let schema = "masc.keeper.official-client-session.v1"
 let filename = "session.json"
 let state_dirname = "official-client-runtime"
 let lock_filename = "session.lock"
+(* NDT-OK: recovery and process epochs are opaque UUID fences. Randomness is
+   confined to identity generation and never controls a semantic branch. *)
 let recovery_rng = Random.State.make_self_init ()
 let recovery_rng_mutex = Stdlib.Mutex.create ()
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -740,16 +740,56 @@ let run_named
              on_runtime_observation
          | Error _ -> ());
         codex_result, None
-      | Runtime_execution.Antigravity_cli _ ->
+      | Runtime_execution.Antigravity_cli config ->
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
-        ( Error
-            (Agent_sdk.Error.Config
-               (Agent_sdk.Error.InvalidConfig
-                  { field = "runtime_execution"
-                  ; detail =
-                      "antigravity-cli is configured but Keeper dispatch is not admitted"
-                  }))
-        , None )
+        let antigravity_result =
+          match provider_config_transform, oas_checkpoint with
+          | Some _, _ ->
+            Error
+              (Agent_sdk.Error.Config
+                 (Agent_sdk.Error.InvalidConfig
+                    { field = "provider_config_transform"
+                    ; detail =
+                        "provider config transforms cannot target an antigravity-cli runtime"
+                    }))
+          | None, Some _ ->
+            Error
+              (Agent_sdk.Error.Config
+                 (Agent_sdk.Error.InvalidConfig
+                    { field = "oas_checkpoint"
+                    ; detail =
+                        "an OAS agent_core checkpoint cannot resume through an antigravity-cli runtime"
+                    }))
+          | None, None ->
+            Keeper_antigravity_runtime.run
+              ~runtime_id:attempt_runtime_id
+              ~keeper_name
+              ~base_path
+              ~goal
+              ~goal_blocks
+              ~system_prompt
+              ~tools
+              ~initial_messages
+              ~model_input_projection
+              ~hooks
+              ~context_injector
+              ~enable_thinking:inference_policy.attempt_enable_thinking
+              ~config
+        in
+        let antigravity_result =
+          Result.bind antigravity_result (fun run_result ->
+            Keeper_turn_driver_try_provider.apply_accept
+              ~runtime_id:attempt_runtime_id
+              ~accept
+              run_result)
+        in
+        (match antigravity_result with
+         | Ok run_result ->
+           Option.iter
+             (fun observe -> Option.iter observe run_result.Runtime_agent.runtime_observation)
+             on_runtime_observation
+         | Error _ -> ());
+        antigravity_result, None
       | Runtime_execution.Agent_core runtime_provider_config ->
        (match
           match provider_config_transform with

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -618,7 +618,11 @@ let run_turn ?(conversation_mode = Start) ~mgr ~clock ~cwd
       }
   | _, Some _, Some (result_status, _, error, _, _)
     when not (String.equal result_status "SUCCESS") ->
-    let detail = Option.value ~default:("status=" ^ result_status) error in
+    let detail =
+      match error with
+      | Some detail -> detail
+      | None -> "status=" ^ result_status
+    in
     Error (Turn_failed detail)
   | `Exited 0, _, None ->
     Error (Protocol_error { stage = "process completion"; detail = "missing result event" })

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -359,15 +359,29 @@ let antigravity_cli_options ~(path : string) (tbl : Otoml.t)
        (match effort_result, execution_mode_result with
         | Error errors, _ | _, Error errors -> Error errors
         | Ok effort, Ok execution_mode ->
+          let sandbox =
+            match sandbox with
+            | Some value -> value
+            | None -> false
+          in
+          let disable_slash_commands =
+            match disable_slash_commands with
+            | Some value -> value
+            | None -> true
+          in
+          let timeout_s =
+            match timeout_s with
+            | Some value -> value
+            | None -> 300.0
+          in
           Ok
             (Some
                { Runtime_schema.agent
                ; effort
                ; execution_mode
-               ; sandbox = Option.value ~default:false sandbox
-               ; disable_slash_commands =
-                   Option.value ~default:true disable_slash_commands
-               ; timeout_s = Option.value ~default:300.0 timeout_s
+               ; sandbox
+               ; disable_slash_commands
+               ; timeout_s
                })))
   | Messages_api | Chat_completions_api | Ollama_api | Codex_app_server_runtime ->
     (match

--- a/test/dune
+++ b/test/dune
@@ -1944,6 +1944,7 @@
 (include stanzas/test_runtime_codex_app_server.inc)
 (include stanzas/test_runtime_antigravity.inc)
 (include stanzas/test_official_client_session_store.inc)
+(include stanzas/test_keeper_antigravity_runtime.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)
 

--- a/test/stanzas/test_keeper_antigravity_runtime.inc
+++ b/test/stanzas/test_keeper_antigravity_runtime.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_antigravity_runtime)
+ (modules test_keeper_antigravity_runtime)
+ (libraries masc masc_test_deps))

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -1,0 +1,244 @@
+open Alcotest
+open Masc
+open Keeper_official_client_session_store
+
+let conversation_id = "conversation-fixture-1"
+
+let shell_quote value =
+  "'" ^ String.concat "'\"'\"'" (String.split_on_char '\'' value) ^ "'"
+;;
+
+let temp_workspace prefix =
+  let path = Filename.temp_file prefix "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  Unix.realpath path
+;;
+
+let cleanup_tree root =
+  let rec remove path =
+    if Sys.file_exists path
+    then if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try remove root with
+  | _ -> ()
+;;
+
+let fixture_script ~workspace ?(malformed = false) () =
+  let path = Filename.temp_file "masc-agy-keeper-" ".sh" in
+  let output = open_out_bin path in
+  output_string output "#!/bin/sh\n";
+  output_string output ("test \"$PWD\" = " ^ shell_quote workspace ^ " || exit 71\n");
+  output_string output
+    "test -z \"${GEMINI_API_KEY+x}\" && test -z \"${GOOGLE_API_TOKEN+x}\" && test -z \"${ANTHROPIC_API_KEY+x}\" || exit 72\n";
+  output_string output
+    "case \" $* \" in *\" --model gemini-fixture \"*) ;; *) exit 73 ;; esac\n";
+  output_string output
+    "case \" $* \" in *\" --mode plan \"*) ;; *) exit 74 ;; esac\n";
+  output_string output
+    "case \" $* \" in *\" --disable-slash-commands \"*) ;; *) exit 75 ;; esac\n";
+  output_string output ("conversation=" ^ shell_quote conversation_id ^ "\n");
+  output_string output "turns=1\nresponse=MASC_AGY_KEEPER_START\n";
+  output_string output
+    "while test \"$#\" -gt 0; do case \"$1\" in --conversation) shift; conversation=\"$1\"; turns=2; response=MASC_AGY_KEEPER_RESUME ;; esac; shift; done\n";
+  if malformed
+  then output_string output "printf '%s\\n' 'not-json'\n"
+  else (
+    output_string output
+      "printf '%s\\n' \"{\\\"event\\\":\\\"init\\\",\\\"conversation_id\\\":\\\"$conversation\\\",\\\"init\\\":{\\\"model\\\":\\\"gemini-fixture\\\",\\\"cwd\\\":\\\"$PWD\\\",\\\"tools\\\":[\\\"run_command\\\"],\\\"permission_mode\\\":\\\"always-proceed\\\"}}\"\n";
+    output_string output
+      "printf '%s\\n' \"{\\\"event\\\":\\\"step_update\\\",\\\"step_update\\\":{\\\"conversation_id\\\":\\\"$conversation\\\",\\\"step_index\\\":1,\\\"state\\\":\\\"ACTIVE\\\",\\\"step_type\\\":\\\"tool\\\"}}\"\n";
+    output_string output
+      "printf '%s\\n' \"{\\\"event\\\":\\\"result\\\",\\\"result\\\":{\\\"conversation_id\\\":\\\"$conversation\\\",\\\"status\\\":\\\"SUCCESS\\\",\\\"response\\\":\\\"$response\\\",\\\"num_turns\\\":$turns,\\\"usage\\\":{\\\"input_tokens\\\":21,\\\"output_tokens\\\":4,\\\"thinking_tokens\\\":2,\\\"cache_read_tokens\\\":7,\\\"total_tokens\\\":25}}}\"\n");
+  close_out output;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let runtime_toml ~cli_path =
+  Printf.sprintf
+    "[providers.antigravity]\n\
+     protocol = \"antigravity-cli\"\n\
+     command = %S\n\
+     is-non-interactive = true\n\
+     \n\
+     [models.gemini-fixture]\n\
+     api-name = \"gemini-fixture\"\n\
+     max-context = 128000\n\
+     \n\
+     [antigravity.gemini-fixture]\n\
+     \n\
+     [runtime]\n\
+     default = \"antigravity.gemini-fixture\"\n"
+    cli_path
+;;
+
+let with_runtime_config ~cli_path f =
+  let path = Filename.temp_file "masc-agy-keeper-runtime-" ".toml" in
+  let output = open_out_bin path in
+  output_string output (runtime_toml ~cli_path);
+  close_out output;
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let response_text (result : Runtime_agent.run_result) =
+  result.response.content
+  |> List.filter_map (function
+    | Agent_sdk.Types.Text text -> Some text
+    | _ -> None)
+  |> String.concat ""
+;;
+
+let run_turn ?(tools = []) ~base_path ~cli_path ~goal () =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       with_runtime_config ~cli_path (fun runtime_path ->
+         Eio_main.run (fun env ->
+           Eio.Switch.run (fun sw ->
+             Eio_context.set_env env;
+             Eio_context.with_test_env
+               ~net:(Eio.Stdenv.net env)
+               ~clock:(Eio.Stdenv.clock env)
+               ~mono_clock:(Eio.Stdenv.mono_clock env)
+               ~sw
+               (fun () ->
+                  match Runtime.init_default ~config_path:runtime_path with
+                  | Error error -> fail error
+                  | Ok () ->
+                    Keeper_turn_driver.run_named
+                      ~runtime_id:"antigravity.gemini-fixture"
+                      ~keeper_name:"agy-fixture"
+                      ~base_path
+                      ~goal
+                      ~tools
+                      ~initial_messages:[]
+                      ~sw
+                      ~net:(Eio.Stdenv.net env)
+                      ())))))
+;;
+
+let fixture_tool () =
+  Agent_sdk.Tool.create
+    ~name:"masc_fixture"
+    ~description:"A MASC-only fixture tool"
+    ~parameters:[]
+    (fun _ -> Ok { Agent_sdk.Types.content = "fixture"; _meta = None })
+;;
+
+let test_start_resume_and_durable_ordinal () =
+  let base_path = temp_workspace "masc-agy-keeper-" in
+  let cli_path = fixture_script ~workspace:base_path () in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove cli_path; cleanup_tree base_path)
+    (fun () ->
+       let first =
+         match run_turn ~base_path ~cli_path ~goal:"fixture start" () with
+         | Ok result -> result
+         | Error error -> fail (Agent_sdk.Error.to_string error)
+       in
+       check string "first response" "MASC_AGY_KEEPER_START" (response_text first);
+       check int "first turn" 1 first.turns;
+       check string "conversation" conversation_id first.session_id;
+       (match first.response.usage with
+        | None -> fail "provider usage was dropped"
+        | Some usage ->
+          check int "input tokens" 21 usage.input_tokens;
+          check int "output tokens" 4 usage.output_tokens;
+          check int "cache tokens" 7 usage.cache_read_input_tokens);
+       let resumed =
+         match run_turn ~base_path ~cli_path ~goal:"fixture resume" () with
+         | Ok result -> result
+         | Error error -> fail (Agent_sdk.Error.to_string error)
+       in
+       check string "resumed response" "MASC_AGY_KEEPER_RESUME" (response_text resumed);
+       check int "resumed turn" 2 resumed.turns;
+       match
+         Keeper_official_client_session_store.load
+           ~base_path
+           ~keeper_name:"agy-fixture"
+       with
+       | Error detail -> fail detail
+       | Ok None -> fail "settled Antigravity session disappeared"
+       | Ok (Some binding) ->
+         check bool
+           "client kind"
+           true
+           (binding.client_kind = Antigravity);
+         (match binding.phase with
+          | Settled { session_id; turn_id } ->
+            check string "stored conversation" conversation_id session_id;
+            check string
+              "provider-observed ordinal"
+              (conversation_id ^ ":ordinal:2")
+              turn_id
+          | Ready | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+            fail "successful Antigravity turn was not settled"))
+;;
+
+let test_protocol_failure_requires_recovery () =
+  let base_path = temp_workspace "masc-agy-recovery-" in
+  let cli_path = fixture_script ~workspace:base_path ~malformed:true () in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove cli_path; cleanup_tree base_path)
+    (fun () ->
+       (match run_turn ~base_path ~cli_path ~goal:"malformed" () with
+        | Error _ -> ()
+        | Ok _ -> fail "malformed Antigravity stream completed");
+       match
+         Keeper_official_client_session_store.load
+           ~base_path
+           ~keeper_name:"agy-fixture"
+       with
+       | Error detail -> fail detail
+       | Ok None -> fail "failed turn left no recovery record"
+       | Ok (Some { phase = Recovery_required recovery; _ }) ->
+         check bool "protocol failure" true (recovery.failure = Protocol_failed)
+       | Ok (Some _) -> fail "failed turn did not require recovery")
+;;
+
+let test_masc_tools_fail_before_claim () =
+  let base_path = temp_workspace "masc-agy-tools-" in
+  let cli_path = fixture_script ~workspace:base_path () in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove cli_path; cleanup_tree base_path)
+    (fun () ->
+       match
+         run_turn
+           ~tools:[ fixture_tool () ]
+           ~base_path
+           ~cli_path
+           ~goal:"must reject unprojected tools"
+           ()
+       with
+       | Error
+         (Agent_sdk.Error.Config
+             (Agent_sdk.Error.InvalidConfig { field; _ })) ->
+         check string "rejection field" "tools" field;
+         (match
+            Keeper_official_client_session_store.load
+              ~base_path
+              ~keeper_name:"agy-fixture"
+          with
+          | Ok None -> ()
+          | Ok (Some _) -> fail "tool rejection left a durable claim"
+          | Error detail -> fail detail)
+       | Error error -> fail (Agent_sdk.Error.to_string error)
+       | Ok _ -> fail "MASC tools were silently dropped")
+;;
+
+let () =
+  run
+    "Keeper Antigravity official-client runtime"
+    [ ( "durable execution"
+      , [ test_case "start resume and durable ordinal" `Quick test_start_resume_and_durable_ordinal
+        ; test_case "protocol failure requires recovery" `Quick test_protocol_failure_requires_recovery
+        ; test_case "MASC tools fail before claim" `Quick test_masc_tools_fail_before_claim
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- dispatch typed `antigravity-cli` runtimes through Keeper without OAS checkpoints or API credentials
- persist conversation identity before tool execution, retain ambiguous failures as recovery-required, and settle successful turns with the provider-reported conversation ordinal
- project measured usage, wall latency, permission mode, tool steps/errors, resume state, and runtime configuration into runtime observations
- reject MASC tools/tool hooks/context injection before claim because `agy --print` exposes no custom-tool transport

## Stack
- base: #27785
- prerequisite: #27782

## Verification
- `ocamlformat` completed for new OCaml sources
- `ocamlc -stop-after parsing` passed for the new implementation, interface, and test
- focused Keeper Antigravity target is wired into the official-client CI job
- full build and focused executable are intentionally delegated to CI