### PR TITLE
feat(dashboard): expose official-client session evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1567,7 +1567,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_keeper_antigravity_runtime"
+          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_keeper_antigravity_runtime @test/runtest-test_dashboard_official_client_session"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${official_client_targets}"
 
       - name: Run host FD pressure contract suite

--- a/lib/server/server_dashboard_official_client_session.ml
+++ b/lib/server/server_dashboard_official_client_session.ml
@@ -1,0 +1,274 @@
+module Session = Keeper_official_client_session_store
+
+type error_kind =
+  | Bad_request
+  | Conflict
+  | Service_unavailable
+
+type error =
+  { kind : error_kind
+  ; code : string
+  ; message : string
+  }
+
+let ( let* ) = Result.bind
+let schema = "masc.dashboard.official-client-session.v1"
+let error kind code message = Error { kind; code; message }
+
+let client_kind_to_string = function
+  | Session.Codex -> "codex"
+  | Claude_code -> "claude_code"
+  | Antigravity -> "antigravity"
+;;
+
+let failure_to_string = function
+  | Session.Transient_spawn_failed -> "transient_spawn_failed"
+  | Transport_interrupted -> "transport_interrupted"
+  | Protocol_failed -> "protocol_failed"
+  | Provider_rejected -> "provider_rejected"
+  | Host_hook_failed -> "host_hook_failed"
+  | State_persistence_failed -> "state_persistence_failed"
+  | Process_restarted -> "process_restarted"
+;;
+
+let settlement_json (settlement : Session.settlement) =
+  `Assoc
+    [ "session_id", `String settlement.session_id
+    ; "turn_id", `String settlement.turn_id
+    ]
+;;
+
+let settlement_opt_json = function
+  | None -> `Null
+  | Some settlement -> settlement_json settlement
+;;
+
+let string_opt_json = function
+  | None -> `Null
+  | Some value -> `String value
+;;
+
+let resolution_json = function
+  | Session.Retry_previous -> `Assoc [ "kind", `String "retry_previous" ]
+  | Restart_fresh -> `Assoc [ "kind", `String "restart_fresh" ]
+;;
+
+let resolution_record_json (record : Session.recovery_resolution_record) =
+  `Assoc
+    [ "failure", `String (failure_to_string record.failure)
+    ; "recovery_id", `String record.recovery_id
+    ; "resolution", resolution_json record.resolution
+    ; "resolved_at", `Float record.resolved_at
+    ; "resolved_by", `String record.resolved_by
+    ]
+;;
+
+let transient_release_record_json (record : Session.transient_release_record) =
+  `Assoc
+    [ "failure", `String (failure_to_string record.failure)
+    ; "owner_epoch", `String record.owner_epoch
+    ; "released_at", `Float record.released_at
+    ]
+;;
+
+let phase_json = function
+  | Session.Ready -> `Assoc [ "kind", `String "ready" ]
+  | Start { owner_epoch; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "start"
+      ; "owner_epoch", `String owner_epoch
+      ; "previous_settlement", settlement_opt_json previous_settlement
+      ]
+  | Active { owner_epoch; session_id; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "active"
+      ; "owner_epoch", `String owner_epoch
+      ; "session_id", `String session_id
+      ; "previous_settlement", settlement_opt_json previous_settlement
+      ]
+  | Turn_inflight { owner_epoch; session_id; turn_id; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "turn_inflight"
+      ; "owner_epoch", `String owner_epoch
+      ; "session_id", `String session_id
+      ; "turn_id", string_opt_json turn_id
+      ; "previous_settlement", settlement_opt_json previous_settlement
+      ]
+  | Recovery_required recovery ->
+    `Assoc
+      [ "kind", `String "recovery_required"
+      ; "recovery_id", `String recovery.recovery_id
+      ; "failure", `String (failure_to_string recovery.failure)
+      ; "detail", `String recovery.detail
+      ; "required_at", `Float recovery.required_at
+      ; "owner_epoch", `String recovery.owner_epoch
+      ; "observed_session_id", string_opt_json recovery.observed_session_id
+      ; "observed_turn_id", string_opt_json recovery.observed_turn_id
+      ; "previous_settlement", settlement_opt_json recovery.previous_settlement
+      ]
+  | Settled settlement ->
+    `Assoc
+      [ "kind", `String "settled"
+      ; "session_id", `String settlement.session_id
+      ; "turn_id", `String settlement.turn_id
+      ]
+;;
+
+let binding_json (binding : Session.t) =
+  `Assoc
+    [ "client_kind", `String (client_kind_to_string binding.client_kind)
+    ; "runtime_id", `String binding.runtime_id
+    ; "phase", phase_json binding.phase
+    ; "turn_count", `Int binding.turn_count
+    ; "tool_surface_sha256", `String binding.tool_surface_sha256
+    ; ( "last_recovery_resolution"
+      , Option.fold
+          ~none:`Null
+          ~some:resolution_record_json
+          binding.last_recovery_resolution )
+    ; ( "last_transient_release"
+      , Option.fold
+          ~none:`Null
+          ~some:transient_release_record_json
+          binding.last_transient_release )
+    ; "updated_at", `Float binding.updated_at
+    ]
+;;
+
+let response_json ~keeper_name session =
+  `Assoc
+    [ "schema", `String schema
+    ; "ok", `Bool true
+    ; "keeper_name", `String keeper_name
+    ; "session", Option.fold ~none:`Null ~some:binding_json session
+    ]
+;;
+
+let validate_keeper_name keeper_name =
+  let keeper_name = String.trim keeper_name in
+  if keeper_name = ""
+  then error Bad_request "keeper_name_required" "keeper_name is required"
+  else if not (Keeper_config.validate_name keeper_name)
+  then
+    error
+      Bad_request
+      "keeper_name_invalid"
+      (Printf.sprintf "invalid keeper_name %S" keeper_name)
+  else Ok keeper_name
+;;
+
+let load ~base_path ~keeper_name =
+  match Session.load ~base_path ~keeper_name with
+  | Ok session -> Ok session
+  | Error message ->
+    error
+      Service_unavailable
+      "official_client_session_load_failed"
+      message
+;;
+
+let snapshot ~base_path ~keeper_name =
+  let* keeper_name = validate_keeper_name keeper_name in
+  let* session = load ~base_path ~keeper_name in
+  Ok (response_json ~keeper_name session)
+;;
+
+type request =
+  { keeper_name : string
+  ; recovery_id : string
+  ; resolution : Session.recovery_resolution
+  }
+
+let non_empty field value =
+  let value = String.trim value in
+  if value = ""
+  then error Bad_request (field ^ "_required") (field ^ " is required")
+  else Ok value
+;;
+
+let parse_body body =
+  let* json =
+    try Ok (Yojson.Safe.from_string body) with
+    | Yojson.Json_error message ->
+      error Bad_request "invalid_json" ("invalid JSON: " ^ message)
+  in
+  match json with
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "keeper_name", `String keeper_name
+       ; "recovery_id", `String recovery_id
+       ; "resolution", `String ("retry_previous" as resolution) ]
+     | [ "keeper_name", `String keeper_name
+       ; "recovery_id", `String recovery_id
+       ; "resolution", `String ("restart_fresh" as resolution) ] ->
+       let* keeper_name = validate_keeper_name keeper_name in
+       let* recovery_id = non_empty "recovery_id" recovery_id in
+       let resolution =
+         if String.equal resolution "retry_previous"
+         then Session.Retry_previous
+         else Restart_fresh
+       in
+       Ok { keeper_name; recovery_id; resolution }
+     | _ ->
+       error
+         Bad_request
+         "request_fields_invalid"
+         "expected exact keeper_name, recovery_id, and retry_previous or restart_fresh resolution fields")
+  | _ -> error Bad_request "request_not_object" "request body must be a JSON object"
+;;
+
+let conflict code message = error Conflict code message
+
+let resolve_body ~base_path ~actor ~body =
+  let* request = parse_body body in
+  let* actor = non_empty "actor" actor in
+  let* current = load ~base_path ~keeper_name:request.keeper_name in
+  let* current =
+    match current with
+    | None ->
+      conflict
+        "official_client_session_missing"
+        "Keeper has no durable official-client session"
+    | Some current -> Ok current
+  in
+  let* () =
+    match current.phase with
+    | Session.Recovery_required recovery
+      when String.equal recovery.recovery_id request.recovery_id ->
+      Ok ()
+    | Recovery_required _ ->
+      conflict
+        "recovery_id_changed"
+        "official-client recovery identity changed before resolution"
+    | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+      conflict
+        "recovery_not_required"
+        "official-client session is not awaiting recovery"
+  in
+  match
+    Session.resolve_recovery
+      ~base_path
+      ~keeper_name:request.keeper_name
+      ~expected:current
+      ~recovery_id:request.recovery_id
+      ~resolution:request.resolution
+      ~resolved_by:actor
+      ~resolved_at:(Time_compat.now ())
+  with
+  | Ok resolved -> Ok (response_json ~keeper_name:request.keeper_name (Some resolved))
+  | Error message ->
+    (match load ~base_path ~keeper_name:request.keeper_name with
+     | Ok (Some observed) when observed <> current ->
+       conflict
+         "official_client_session_changed"
+         "official-client session changed before recovery resolution"
+     | Ok None ->
+       conflict
+         "official_client_session_disappeared"
+         "official-client session disappeared before recovery resolution"
+     | Ok (Some _) | Error _ ->
+       error
+         Service_unavailable
+         "official_client_session_resolution_failed"
+         message)
+;;

--- a/lib/server/server_dashboard_official_client_session.mli
+++ b/lib/server/server_dashboard_official_client_session.mli
@@ -1,0 +1,24 @@
+(** Authenticated Dashboard projection and operator resolution for the durable
+    per-Keeper official-client session owner. *)
+
+type error_kind =
+  | Bad_request
+  | Conflict
+  | Service_unavailable
+
+type error =
+  { kind : error_kind
+  ; code : string
+  ; message : string
+  }
+
+val snapshot :
+  base_path:string ->
+  keeper_name:string ->
+  (Yojson.Safe.t, error) result
+
+val resolve_body :
+  base_path:string ->
+  actor:string ->
+  body:string ->
+  (Yojson.Safe.t, error) result

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -14,6 +14,7 @@ include Server_routes_http_routes_dashboard_setup
 module Keeper_chat_pending = Server_dashboard_http_keeper_chat_pending
 module Keeper_event_queue_operator =
   Server_dashboard_http_keeper_event_queue_operator
+module Official_client_session = Server_dashboard_official_client_session
 
 let config_cache_ttl_s = Server_dashboard_http_core_cache.config_cache_ttl_s
 let standard_cache_ttl_s = Server_dashboard_http_core_cache.standard_cache_ttl_s
@@ -44,6 +45,27 @@ let respond_dashboard_ok ?request reqd =
   Http.Response.json_value ?request ~compress:true
     (`Assoc [ ("ok", `Bool true) ])
     reqd
+
+let respond_official_client_session_result request reqd = function
+  | Ok json -> Http.Response.json_value ~compress:true ~request json reqd
+  | Error ({ Official_client_session.kind; code; message } : Official_client_session.error) ->
+    let status =
+      match kind with
+      | Bad_request -> `Bad_request
+      | Conflict -> `Conflict
+      | Service_unavailable -> `Service_unavailable
+    in
+    Http.Response.json_value
+      ~status
+      ~request
+      (`Assoc
+        [ "schema", `String "masc.dashboard.official-client-session.error.v1"
+        ; "ok", `Bool false
+        ; "error_code", `String code
+        ; "error", `String message
+        ])
+      reqd
+;;
 
 let execute_output_heartbeat_s = 15.0
 
@@ -783,6 +805,31 @@ let add_routes ~sw ~clock router =
              ~config:(Mcp_server.workspace_config state)
          in
          Http.Response.json_value ~compress:true ~request:req json reqd)
+         request reqd)
+  |> Http.Router.get "/api/v1/runtime/sessions/official-client" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state _agent_name req reqd ->
+           let keeper_name =
+             Server_utils.string_query_param req "keeper_name" ~default:""
+           in
+           let base_path = (Mcp_server.workspace_config state).base_path in
+           respond_official_client_session_result
+             req
+             reqd
+             (Official_client_session.snapshot ~base_path ~keeper_name))
+         request reqd)
+  |> Http.Router.post "/api/v1/runtime/sessions/official-client/resolve" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body ->
+             let base_path = (Mcp_server.workspace_config state).base_path in
+             respond_official_client_session_result
+               req
+               reqd
+               (Official_client_session.resolve_body
+                  ~base_path
+                  ~actor:agent_name
+                  ~body)))
          request reqd)
   |> Http.Router.get "/api/v1/runtime/config/raw" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin

--- a/test/dune
+++ b/test/dune
@@ -1945,6 +1945,7 @@
 (include stanzas/test_runtime_antigravity.inc)
 (include stanzas/test_official_client_session_store.inc)
 (include stanzas/test_keeper_antigravity_runtime.inc)
+(include stanzas/test_dashboard_official_client_session.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)
 

--- a/test/stanzas/test_dashboard_official_client_session.inc
+++ b/test/stanzas/test_dashboard_official_client_session.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_dashboard_official_client_session)
+ (modules test_dashboard_official_client_session)
+ (libraries masc masc_test_deps))

--- a/test/test_dashboard_official_client_session.ml
+++ b/test/test_dashboard_official_client_session.ml
@@ -1,0 +1,231 @@
+open Alcotest
+open Masc
+open Keeper_official_client_session_store
+open Yojson.Safe.Util
+
+let temp_workspace prefix =
+  let path = Filename.temp_file prefix "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  Unix.realpath path
+;;
+
+let cleanup_tree root =
+  let rec remove path =
+    if Sys.file_exists path
+    then if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try remove root with
+  | _ -> ()
+;;
+
+let ok = function
+  | Ok value -> value
+  | Error detail -> fail detail
+;;
+
+let claim ~base_path ~keeper_name =
+  Keeper_official_client_session_store.claim
+    ~base_path
+    ~keeper_name
+    ~expected:None
+    ~client_kind:Antigravity
+    ~owner_epoch:(Keeper_official_client_session_store.process_epoch ())
+    ~runtime_id:"antigravity.gemini"
+    ~tool_surface_sha256:
+      (Keeper_official_client_session_store.tool_surface_sha256 [])
+    ~updated_at:1.0
+  |> ok
+;;
+
+let settled_binding ~base_path ~keeper_name =
+  let claimed = claim ~base_path ~keeper_name in
+  let active =
+    mark_active
+      ~base_path
+      ~keeper_name
+      ~expected:claimed
+      ~session_id:"conversation-1"
+      ~updated_at:2.0
+    |> ok
+  in
+  let inflight =
+    mark_turn_starting
+      ~base_path
+      ~keeper_name
+      ~expected:active
+      ~session_id:"conversation-1"
+      ~updated_at:3.0
+    |> ok
+  in
+  let identified =
+    mark_turn_started
+      ~base_path
+      ~keeper_name
+      ~expected:inflight
+      ~session_id:"conversation-1"
+      ~turn_id:"conversation-1:ordinal:1"
+      ~updated_at:4.0
+    |> ok
+  in
+  settle
+    ~base_path
+    ~keeper_name
+    ~expected:identified
+    ~session_id:"conversation-1"
+    ~turn_id:"conversation-1:ordinal:1"
+    ~updated_at:5.0
+  |> ok
+;;
+
+let recovery_binding ~base_path ~keeper_name =
+  let claimed = claim ~base_path ~keeper_name in
+  let active =
+    mark_active
+      ~base_path
+      ~keeper_name
+      ~expected:claimed
+      ~session_id:"conversation-recovery"
+      ~updated_at:2.0
+    |> ok
+  in
+  let inflight =
+    mark_turn_starting
+      ~base_path
+      ~keeper_name
+      ~expected:active
+      ~session_id:"conversation-recovery"
+      ~updated_at:3.0
+    |> ok
+  in
+  require_recovery
+    ~base_path
+    ~keeper_name
+    ~expected:inflight
+    ~failure:Transport_interrupted
+    ~detail:"fixture transport interrupted after init"
+    ~required_at:4.0
+  |> ok
+;;
+
+let test_snapshot_projects_antigravity_evidence () =
+  let base_path = temp_workspace "masc-dashboard-official-session-" in
+  let keeper_name = "agydashboard" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       ignore (settled_binding ~base_path ~keeper_name);
+       let json =
+         match
+           Server_dashboard_official_client_session.snapshot
+             ~base_path
+             ~keeper_name
+         with
+         | Ok json -> json
+         | Error error -> fail error.message
+       in
+       check string
+         "schema"
+         "masc.dashboard.official-client-session.v1"
+         (json |> member "schema" |> to_string);
+       let session = json |> member "session" in
+       check string "client" "antigravity" (session |> member "client_kind" |> to_string);
+       check string
+         "logical runtime"
+         "antigravity.gemini"
+         (session |> member "runtime_id" |> to_string);
+       check int "turn count" 1 (session |> member "turn_count" |> to_int);
+       let phase = session |> member "phase" in
+       check string "phase" "settled" (phase |> member "kind" |> to_string);
+       check string
+         "conversation"
+         "conversation-1"
+         (phase |> member "session_id" |> to_string);
+       check string
+         "provider ordinal"
+         "conversation-1:ordinal:1"
+         (phase |> member "turn_id" |> to_string))
+;;
+
+let test_recovery_resolution_is_exact_and_audited () =
+  let base_path = temp_workspace "masc-dashboard-official-recovery-" in
+  let keeper_name = "agyrecovery" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       let recovery = recovery_binding ~base_path ~keeper_name in
+       let recovery_id =
+         match recovery.phase with
+         | Recovery_required value -> value.recovery_id
+         | _ -> fail "fixture did not enter recovery"
+       in
+       let body =
+         `Assoc
+           [ "keeper_name", `String keeper_name
+           ; "recovery_id", `String recovery_id
+           ; "resolution", `String "restart_fresh"
+           ]
+         |> Yojson.Safe.to_string
+       in
+       let json =
+         match
+           Server_dashboard_official_client_session.resolve_body
+             ~base_path
+             ~actor:"dashboard-admin"
+             ~body
+         with
+         | Ok json -> json
+         | Error error -> fail error.message
+       in
+       let session = json |> member "session" in
+       check string
+         "resolved phase"
+         "ready"
+         (session |> member "phase" |> member "kind" |> to_string);
+       let resolution = session |> member "last_recovery_resolution" in
+       check string
+         "actor"
+         "dashboard-admin"
+         (resolution |> member "resolved_by" |> to_string);
+       check string
+         "decision"
+         "restart_fresh"
+         (resolution |> member "resolution" |> member "kind" |> to_string))
+;;
+
+let test_resolution_rejects_extra_fields () =
+  match
+    Server_dashboard_official_client_session.resolve_body
+      ~base_path:"/tmp"
+      ~actor:"dashboard-admin"
+      ~body:
+        {|{"keeper_name":"agydashboard","recovery_id":"recovery","resolution":"restart_fresh","session_id":"unverified"}|}
+  with
+  | Error { kind = Bad_request; code = "request_fields_invalid"; _ } -> ()
+  | Error error -> failf "unexpected error %s" error.code
+  | Ok _ -> fail "extra recovery fields were admitted"
+;;
+
+let () =
+  run
+    "Dashboard official-client session"
+    [ ( "session evidence"
+      , [ test_case
+            "projects Antigravity evidence"
+            `Quick
+            test_snapshot_projects_antigravity_evidence
+        ; test_case
+            "resolves exact recovery"
+            `Quick
+            test_recovery_resolution_is_exact_and_audited
+        ; test_case
+            "rejects extra resolution fields"
+            `Quick
+            test_resolution_rejects_extra_fields
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- expose exact durable official-client session and recovery evidence to Dashboard admins
- support only typed retry_previous and restart_fresh CAS resolutions
- hard-cut manual session adoption and provider identity injection

## Stack
- base: #27787

## Verification
- OCaml formatting and parser checks passed
- focused endpoint tests are wired into CI
- full build is delegated to CI