### PR TITLE
feat(dashboard): operate official-client sessions

### DIFF
--- a/dashboard/dev-fixtures/official-client-session-fixture.html
+++ b/dashboard/dev-fixtures/official-client-session-fixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Official client session recovery</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/demo/official-client-session-fixture.ts"></script>
+  </body>
+</html>

--- a/dashboard/e2e/official-client-session.mjs
+++ b/dashboard/e2e/official-client-session.mjs
@@ -1,0 +1,96 @@
+import { chromium } from 'playwright'
+
+const fixtureUrl = process.env.OFFICIAL_CLIENT_SESSION_FIXTURE_URL
+if (!fixtureUrl) throw new Error('OFFICIAL_CLIENT_SESSION_FIXTURE_URL is required')
+
+const artifactDir = process.env.OFFICIAL_CLIENT_SESSION_ARTIFACT_DIR ?? '/tmp'
+const recoveryScreenshot = `${artifactDir}/official-client-session-recovery-required.png`
+const resolvedScreenshot = `${artifactDir}/official-client-session-recovery-resolved.png`
+const recoveryId = '018f3a4a-27f4-7c9a-8fd8-330c2a3845aa'
+let getRequests = 0
+let postedBody = null
+
+const recoveryPayload = {
+  schema: 'masc.dashboard.official-client-session.v1',
+  ok: true,
+  keeper_name: 'sangsu',
+  session: {
+    client_kind: 'antigravity',
+    runtime_id: 'antigravity.gemini',
+    phase: {
+      kind: 'recovery_required',
+      recovery_id: recoveryId,
+      failure: 'protocol_failed',
+      detail: 'malformed stream-json event after the durable conversation claim',
+      required_at: 1786230000,
+      owner_epoch: '018f3a4a-27f4-7c9a-8fd8-330c2a3845ab',
+      observed_session_id: 'conversation-observed',
+      observed_turn_id: null,
+      previous_settlement: null,
+    },
+    turn_count: 1,
+    tool_surface_sha256: 'a'.repeat(64),
+    last_recovery_resolution: null,
+    last_transient_release: null,
+    updated_at: 1786230000,
+  },
+}
+
+const resolvedPayload = {
+  ...recoveryPayload,
+  session: {
+    ...recoveryPayload.session,
+    phase: { kind: 'ready' },
+    last_recovery_resolution: {
+      recovery_id: recoveryId,
+      failure: 'protocol_failed',
+      resolution: { kind: 'restart_fresh' },
+      resolved_by: 'dashboard-admin',
+      resolved_at: 1786230060,
+    },
+    updated_at: 1786230060,
+  },
+}
+
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } })
+  await page.route('**/api/v1/dashboard/dev-token', route => route.fulfill({
+    json: { token: 'fixture-token', actor: 'dashboard-admin', role: 'admin' },
+  }))
+  await page.route('**/api/v1/runtime/sessions/official-client?**', route => {
+    getRequests += 1
+    return route.fulfill({ json: recoveryPayload })
+  })
+  await page.route('**/api/v1/runtime/sessions/official-client/resolve', async route => {
+    postedBody = route.request().postDataJSON()
+    await route.fulfill({ json: resolvedPayload })
+  })
+
+  await page.goto(fixtureUrl)
+  await page.getByTestId('official-client-session-phase').getByText('recovery_required', { exact: true }).waitFor()
+  const recovery = page.getByTestId('official-client-session-recovery-required')
+  await recovery.getByText('protocol_failed', { exact: true }).waitFor()
+  await recovery.getByText('conversation-observed', { exact: true }).waitFor()
+  await recovery.getByText(recoveryId, { exact: true }).waitFor()
+  if (getRequests !== 1) throw new Error(`expected one session GET, got ${getRequests}`)
+
+  await page.screenshot({ path: recoveryScreenshot, fullPage: true })
+  await page.getByTestId('official-client-session-restart-fresh').click()
+  await page.getByTestId('official-client-session-phase').getByText('ready', { exact: true }).waitFor()
+  await page.getByTestId('official-client-session-last-resolution').getByText(/dashboard-admin/).waitFor()
+
+  const expectedBody = {
+    keeper_name: 'sangsu',
+    recovery_id: recoveryId,
+    resolution: 'restart_fresh',
+  }
+  if (JSON.stringify(postedBody) !== JSON.stringify(expectedBody)) {
+    throw new Error(`unexpected recovery body: ${JSON.stringify(postedBody)}`)
+  }
+  await page.screenshot({ path: resolvedScreenshot, fullPage: true })
+  process.stdout.write(`official_client_recovery_required_screenshot=${recoveryScreenshot}\n`)
+  process.stdout.write(`official_client_recovery_resolved_screenshot=${resolvedScreenshot}\n`)
+} finally {
+  await browser.close()
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -18,6 +18,7 @@
     "test:serial": "pnpm test",
     "test:e2e:keeper-lane": "../scripts/harness_dashboard_keeper_lane_timeline_e2e.sh",
     "test:e2e:queued-stream": "../scripts/harness_dashboard_keeper_queued_stream_e2e.sh",
+    "test:e2e:official-client-session": "../scripts/harness_dashboard_official_client_session_e2e.sh",
     "test:watch": "vitest",
     "tokens:build": "tsx design-system/tokens/build.ts",
     "tokens:check": "node design-system/tokens/scripts/check-equivalence.mjs"

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -1037,6 +1037,188 @@ export interface RuntimeTomlConfig {
   issues?: unknown
 }
 
+export type DashboardOfficialClientRecoveryFailure =
+  | 'transient_spawn_failed'
+  | 'transport_interrupted'
+  | 'protocol_failed'
+  | 'provider_rejected'
+  | 'host_hook_failed'
+  | 'state_persistence_failed'
+  | 'process_restarted'
+
+export type DashboardOfficialClientKind = 'codex' | 'claude_code' | 'antigravity'
+
+export interface DashboardOfficialClientSettlement {
+  session_id: string
+  turn_id: string
+}
+
+export interface DashboardOfficialClientSessionPhase {
+  kind: 'ready' | 'start' | 'active' | 'turn_inflight' | 'recovery_required' | 'settled'
+  session_id?: string | null
+  turn_id?: string | null
+  previous_settlement?: DashboardOfficialClientSettlement | null
+  recovery_id?: string | null
+  failure?: DashboardOfficialClientRecoveryFailure | null
+  detail?: string | null
+  required_at?: number | null
+  observed_session_id?: string | null
+  observed_turn_id?: string | null
+  owner_epoch?: string | null
+}
+
+export interface DashboardOfficialClientRecoveryResolutionRecord {
+  recovery_id: string
+  failure: DashboardOfficialClientRecoveryFailure
+  resolution: { kind: 'retry_previous' | 'restart_fresh' }
+  resolved_by: string
+  resolved_at: number
+}
+
+export interface DashboardOfficialClientTransientReleaseRecord {
+  failure: 'transient_spawn_failed'
+  owner_epoch: string
+  released_at: number
+}
+
+export interface DashboardOfficialClientSession {
+  client_kind: DashboardOfficialClientKind
+  runtime_id: string
+  phase: DashboardOfficialClientSessionPhase
+  turn_count: number
+  tool_surface_sha256: string
+  last_recovery_resolution: DashboardOfficialClientRecoveryResolutionRecord | null
+  last_transient_release: DashboardOfficialClientTransientReleaseRecord | null
+  updated_at: number
+}
+
+export interface DashboardOfficialClientSessionResponse {
+  schema: 'masc.dashboard.official-client-session.v1'
+  ok: true
+  keeper_name: string
+  session: DashboardOfficialClientSession | null
+}
+
+export type DashboardOfficialClientRecoveryDecision =
+  | { resolution: 'retry_previous' }
+  | { resolution: 'restart_fresh' }
+
+const OFFICIAL_CLIENT_RECOVERY_FAILURES = new Set<DashboardOfficialClientRecoveryFailure>([
+  'transient_spawn_failed',
+  'transport_interrupted',
+  'protocol_failed',
+  'provider_rejected',
+  'host_hook_failed',
+  'state_persistence_failed',
+  'process_restarted',
+])
+
+const OFFICIAL_CLIENT_KINDS = new Set<DashboardOfficialClientKind>([
+  'codex',
+  'claude_code',
+  'antigravity',
+])
+
+function decodeOfficialClientSettlement(raw: unknown): DashboardOfficialClientSettlement | null {
+  if (!isRecord(raw)) return null
+  const session_id = asString(raw.session_id)
+  const turn_id = asString(raw.turn_id)
+  return session_id && turn_id ? { session_id, turn_id } : null
+}
+
+function decodeOfficialClientFailure(raw: unknown): DashboardOfficialClientRecoveryFailure | null {
+  return typeof raw === 'string' && OFFICIAL_CLIENT_RECOVERY_FAILURES.has(raw as DashboardOfficialClientRecoveryFailure)
+    ? raw as DashboardOfficialClientRecoveryFailure
+    : null
+}
+
+function decodeOfficialClientPhase(raw: unknown): DashboardOfficialClientSessionPhase | null {
+  if (!isRecord(raw)) return null
+  const kind = asString(raw.kind)
+  if (!kind || !['ready', 'start', 'active', 'turn_inflight', 'recovery_required', 'settled'].includes(kind)) return null
+  const phase: DashboardOfficialClientSessionPhase = {
+    kind: kind as DashboardOfficialClientSessionPhase['kind'],
+    session_id: asNullableString(raw.session_id),
+    turn_id: asNullableString(raw.turn_id),
+    previous_settlement: raw.previous_settlement == null
+      ? null
+      : decodeOfficialClientSettlement(raw.previous_settlement),
+    recovery_id: asNullableString(raw.recovery_id),
+    failure: raw.failure == null ? null : decodeOfficialClientFailure(raw.failure),
+    detail: asNullableString(raw.detail),
+    required_at: asNumber(raw.required_at),
+    observed_session_id: asNullableString(raw.observed_session_id),
+    observed_turn_id: asNullableString(raw.observed_turn_id),
+    owner_epoch: asNullableString(raw.owner_epoch),
+  }
+  if (phase.kind === 'recovery_required' && (!phase.recovery_id || !phase.failure || phase.required_at == null)) return null
+  if (['start', 'active', 'turn_inflight', 'recovery_required'].includes(phase.kind) && !phase.owner_epoch) return null
+  if ((phase.kind === 'active' || phase.kind === 'turn_inflight') && !phase.session_id) return null
+  if (phase.kind === 'settled' && (!phase.session_id || !phase.turn_id)) return null
+  return phase
+}
+
+function decodeOfficialClientResolutionRecord(raw: unknown): DashboardOfficialClientRecoveryResolutionRecord | null {
+  if (!isRecord(raw) || !isRecord(raw.resolution)) return null
+  const recovery_id = asString(raw.recovery_id)
+  const failure = decodeOfficialClientFailure(raw.failure)
+  const resolved_by = asString(raw.resolved_by)
+  const resolved_at = asNumber(raw.resolved_at)
+  const kind = asString(raw.resolution.kind)
+  if (!recovery_id || !failure || !resolved_by || resolved_at == null) return null
+  if (kind !== 'retry_previous' && kind !== 'restart_fresh') return null
+  return { recovery_id, failure, resolution: { kind }, resolved_by, resolved_at }
+}
+
+function decodeOfficialClientTransientRelease(raw: unknown): DashboardOfficialClientTransientReleaseRecord | null {
+  if (!isRecord(raw)) return null
+  const failure = asString(raw.failure)
+  const owner_epoch = asString(raw.owner_epoch)
+  const released_at = asNumber(raw.released_at)
+  if (failure !== 'transient_spawn_failed' || !owner_epoch || released_at == null) return null
+  return { failure, owner_epoch, released_at }
+}
+
+function decodeOfficialClientSessionResponse(raw: unknown): DashboardOfficialClientSessionResponse | null {
+  if (!isRecord(raw) || raw.schema !== 'masc.dashboard.official-client-session.v1' || raw.ok !== true) return null
+  const keeper_name = asString(raw.keeper_name)
+  if (!keeper_name) return null
+  if (raw.session === null) {
+    return { schema: 'masc.dashboard.official-client-session.v1', ok: true, keeper_name, session: null }
+  }
+  if (!isRecord(raw.session)) return null
+  const client_kind = asString(raw.session.client_kind)
+  const runtime_id = asString(raw.session.runtime_id)
+  const phase = decodeOfficialClientPhase(raw.session.phase)
+  const turn_count = asNumber(raw.session.turn_count)
+  const tool_surface_sha256 = asString(raw.session.tool_surface_sha256)
+  const updated_at = asNumber(raw.session.updated_at)
+  const last_recovery_resolution = raw.session.last_recovery_resolution == null
+    ? null
+    : decodeOfficialClientResolutionRecord(raw.session.last_recovery_resolution)
+  const last_transient_release = raw.session.last_transient_release == null
+    ? null
+    : decodeOfficialClientTransientRelease(raw.session.last_transient_release)
+  if (!client_kind || !OFFICIAL_CLIENT_KINDS.has(client_kind as DashboardOfficialClientKind) || !runtime_id || !phase || turn_count == null || !Number.isInteger(turn_count) || turn_count < 0 || !tool_surface_sha256 || updated_at == null) return null
+  if (raw.session.last_recovery_resolution != null && !last_recovery_resolution) return null
+  if (raw.session.last_transient_release != null && !last_transient_release) return null
+  return {
+    schema: 'masc.dashboard.official-client-session.v1',
+    ok: true,
+    keeper_name,
+    session: {
+      client_kind: client_kind as DashboardOfficialClientKind,
+      runtime_id,
+      phase,
+      turn_count,
+      tool_surface_sha256,
+      last_recovery_resolution,
+      last_transient_release,
+      updated_at,
+    },
+  }
+}
+
 function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
   const record = isRecord(raw) ? raw : {}
   return {
@@ -1054,6 +1236,34 @@ function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
 export async function fetchRuntimeTomlConfig(): Promise<RuntimeTomlConfig> {
   await ensureDevToken()
   return get<unknown>('/api/v1/runtime/config/raw').then(normalizeRuntimeTomlConfig)
+}
+
+export async function fetchOfficialClientSession(
+  keeperName: string,
+  opts?: AbortableRequestOptions,
+): Promise<DashboardOfficialClientSessionResponse> {
+  await ensureDevToken()
+  const query = new URLSearchParams({ keeper_name: keeperName })
+  const raw = await get<unknown>(`/api/v1/runtime/sessions/official-client?${query}`, { signal: opts?.signal })
+  const decoded = decodeOfficialClientSessionResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 official-client session payload')
+  return decoded
+}
+
+export async function resolveOfficialClientSession(
+  keeperName: string,
+  recoveryId: string,
+  decision: DashboardOfficialClientRecoveryDecision,
+): Promise<DashboardOfficialClientSessionResponse> {
+  await ensureDevToken()
+  const raw = await post<unknown>('/api/v1/runtime/sessions/official-client/resolve', {
+    keeper_name: keeperName,
+    recovery_id: recoveryId,
+    ...decision,
+  })
+  const decoded = decodeOfficialClientSessionResponse(raw)
+  if (!decoded) throw new Error('유효하지 않은 official-client recovery payload')
+  return decoded
 }
 
 // Structured, already-resolved runtime defaults / model routing (runtime.toml

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -178,6 +178,15 @@ export type {
   DashboardRuntimeModelMetricsResponse,
   RuntimeTomlConfig,
   RuntimeRoutingLane,
+  DashboardOfficialClientKind,
+  DashboardOfficialClientRecoveryDecision,
+  DashboardOfficialClientRecoveryFailure,
+  DashboardOfficialClientRecoveryResolutionRecord,
+  DashboardOfficialClientSession,
+  DashboardOfficialClientSessionPhase,
+  DashboardOfficialClientSessionResponse,
+  DashboardOfficialClientSettlement,
+  DashboardOfficialClientTransientReleaseRecord,
 } from './dashboard-runtime'
 export {
   fetchRuntimeProviders,
@@ -189,6 +198,8 @@ export {
   patchRuntimeAssignment,
   patchRuntimeMediaFailover,
   patchRuntimeRouting,
+  fetchOfficialClientSession,
+  resolveOfficialClientSession,
 } from './dashboard-runtime'
 
 export type {

--- a/dashboard/src/components/official-client-session-panel.test.ts
+++ b/dashboard/src/components/official-client-session-panel.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { fireEvent, render, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { keepers } from '../store'
+import { OfficialClientSessionPanel } from './official-client-session-panel'
+
+const apiMocks = vi.hoisted(() => ({
+  fetchOfficialClientSession: vi.fn(),
+  resolveOfficialClientSession: vi.fn(),
+}))
+
+vi.mock('../api/dashboard', () => apiMocks)
+
+const recoveryId = '018f3a4a-27f4-7c9a-8fd8-330c2a3845aa'
+const recoveryResponse = {
+  schema: 'masc.dashboard.official-client-session.v1' as const,
+  ok: true as const,
+  keeper_name: 'sangsu',
+  session: {
+    client_kind: 'antigravity' as const,
+    runtime_id: 'antigravity.gemini',
+    phase: {
+      kind: 'recovery_required' as const,
+      recovery_id: recoveryId,
+      failure: 'protocol_failed' as const,
+      detail: 'malformed stream-json event after conversation init',
+      required_at: 1_786_230_000,
+      owner_epoch: '018f3a4a-27f4-7c9a-8fd8-330c2a3845ab',
+      observed_session_id: 'conversation-observed',
+      observed_turn_id: null,
+      previous_settlement: null,
+    },
+    turn_count: 1,
+    tool_surface_sha256: 'a'.repeat(64),
+    last_recovery_resolution: null,
+    last_transient_release: null,
+    updated_at: 1_786_230_000,
+  },
+}
+
+const resolvedResponse = {
+  ...recoveryResponse,
+  session: {
+    ...recoveryResponse.session,
+    phase: { kind: 'ready' as const },
+    last_recovery_resolution: {
+      recovery_id: recoveryId,
+      failure: 'protocol_failed' as const,
+      resolution: { kind: 'restart_fresh' as const },
+      resolved_by: 'dashboard-admin',
+      resolved_at: 1_786_230_010,
+    },
+  },
+}
+
+describe('OfficialClientSessionPanel', () => {
+  beforeEach(() => {
+    keepers.value = [{ name: 'sangsu', status: 'idle', runtime_id: 'antigravity.gemini' }]
+    apiMocks.fetchOfficialClientSession.mockReset().mockResolvedValue(recoveryResponse)
+    apiMocks.resolveOfficialClientSession.mockReset().mockResolvedValue(resolvedResponse)
+  })
+
+  afterEach(() => {
+    keepers.value = []
+  })
+
+  it('shows measured Antigravity evidence and resolves the exact recovery fence', async () => {
+    const view = render(html`<${OfficialClientSessionPanel} />`)
+
+    await waitFor(() => {
+      expect(view.getByTestId('official-client-session-phase').textContent).toContain('recovery_required')
+    })
+    expect(view.getByTestId('official-client-session-evidence').textContent).toContain('antigravity.gemini')
+    expect(view.getByTestId('official-client-session-evidence').textContent).toContain('antigravity')
+    expect(view.getByTestId('official-client-session-recovery-required').textContent).toContain('protocol_failed')
+    expect(view.getByTestId('official-client-session-recovery-required').textContent).toContain('conversation-observed')
+
+    fireEvent.click(view.getByTestId('official-client-session-restart-fresh'))
+
+    await waitFor(() => {
+      expect(apiMocks.resolveOfficialClientSession).toHaveBeenCalledWith(
+        'sangsu',
+        recoveryId,
+        { resolution: 'restart_fresh' },
+      )
+      expect(view.getByTestId('official-client-session-phase').textContent).toContain('ready')
+      expect(view.getByTestId('official-client-session-last-resolution').textContent).toContain('dashboard-admin')
+    })
+  })
+
+  it('refreshes the selected Keeper without mutating recovery state', async () => {
+    const view = render(html`<${OfficialClientSessionPanel} />`)
+    await waitFor(() => expect(apiMocks.fetchOfficialClientSession).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(view.getByTestId('official-client-session-refresh'))
+
+    await waitFor(() => expect(apiMocks.fetchOfficialClientSession).toHaveBeenCalledTimes(2))
+    expect(apiMocks.resolveOfficialClientSession).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/components/official-client-session-panel.ts
+++ b/dashboard/src/components/official-client-session-panel.ts
@@ -1,0 +1,206 @@
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import {
+  fetchOfficialClientSession,
+  resolveOfficialClientSession,
+  type DashboardOfficialClientRecoveryDecision,
+  type DashboardOfficialClientSessionResponse,
+} from '../api/dashboard'
+import { keepers } from '../store'
+import { errorToString } from '../lib/format-string'
+import { ActionButton } from './common/button'
+import { SectionCard } from './common/card'
+import { EmptyState } from './common/feedback-state'
+import { Select } from './common/select'
+import { StatusChip } from './common/status-chip'
+
+function phaseTone(kind: string): 'ok' | 'warn' | 'bad' | 'info' | 'neutral' {
+  if (kind === 'settled' || kind === 'ready') return 'ok'
+  if (kind === 'recovery_required') return 'bad'
+  if (kind === 'active' || kind === 'turn_inflight') return 'info'
+  if (kind === 'start') return 'warn'
+  return 'neutral'
+}
+
+function timestampText(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '—'
+  return new Date(value * 1_000).toLocaleString()
+}
+
+function compactHash(value: string): string {
+  return value.length > 18 ? `${value.slice(0, 10)}…${value.slice(-8)}` : value
+}
+
+export function OfficialClientSessionPanel() {
+  const selectedKeeper = useSignal('')
+  const response = useSignal<DashboardOfficialClientSessionResponse | null>(null)
+  const loading = useSignal(false)
+  const resolving = useSignal(false)
+  const error = useSignal<string | null>(null)
+  const requestRevision = useSignal(0)
+
+  const keeperNames = keepers.value
+    .map(keeper => keeper.name)
+    .filter((name, index, names) => names.indexOf(name) === index)
+    .sort((left, right) => left.localeCompare(right))
+  const keeperKey = keeperNames.join('\u0000')
+
+  const load = async (keeperName: string) => {
+    if (!keeperName) {
+      response.value = null
+      return
+    }
+    const revision = requestRevision.value + 1
+    requestRevision.value = revision
+    loading.value = true
+    error.value = null
+    try {
+      const next = await fetchOfficialClientSession(keeperName)
+      if (requestRevision.value === revision) response.value = next
+    } catch (cause) {
+      if (requestRevision.value === revision) error.value = errorToString(cause)
+    } finally {
+      if (requestRevision.value === revision) loading.value = false
+    }
+  }
+
+  useEffect(() => {
+    const next = keeperNames.includes(selectedKeeper.value)
+      ? selectedKeeper.value
+      : (keeperNames[0] ?? '')
+    selectedKeeper.value = next
+    void load(next)
+  }, [keeperKey])
+
+  const resolve = async (decision: DashboardOfficialClientRecoveryDecision) => {
+    const keeperName = selectedKeeper.value
+    const recoveryId = response.value?.session?.phase.recovery_id
+    if (!keeperName || !recoveryId || resolving.value) return
+    resolving.value = true
+    error.value = null
+    try {
+      response.value = await resolveOfficialClientSession(keeperName, recoveryId, decision)
+    } catch (cause) {
+      error.value = errorToString(cause)
+      await load(keeperName)
+    } finally {
+      resolving.value = false
+    }
+  }
+
+  const session = response.value?.session ?? null
+  const phase = session?.phase ?? null
+  const recoveryRequired = phase?.kind === 'recovery_required'
+  const lastResolution = session?.last_recovery_resolution ?? null
+  const transientRelease = session?.last_transient_release ?? null
+
+  return html`
+    <${SectionCard}
+      label="공식 클라이언트 세션"
+      status=${phase?.kind ?? (session ? 'unknown' : '')}
+      testId="official-client-session-panel"
+    >
+      <div class="flex flex-wrap items-center gap-2 mb-3">
+        <${Select}
+          class="max-w-72"
+          ariaLabel="Keeper 선택"
+          testId="official-client-session-keeper"
+          value=${selectedKeeper.value}
+          disabled=${keeperNames.length === 0 || loading.value || resolving.value}
+          placeholder="Keeper 없음"
+          options=${keeperNames}
+          onInput=${(keeperName: string) => {
+            selectedKeeper.value = keeperName
+            void load(keeperName)
+          }}
+        />
+        <${ActionButton}
+          variant="ghost"
+          size="sm"
+          testId="official-client-session-refresh"
+          disabled=${!selectedKeeper.value || loading.value || resolving.value}
+          ariaBusy=${loading.value}
+          onClick=${() => void load(selectedKeeper.value)}
+        >새로고침<//>
+        ${phase
+          ? html`<${StatusChip} tone=${phaseTone(phase.kind)} uppercase=${false} testId="official-client-session-phase">${phase.kind}<//>`
+          : null}
+      </div>
+
+      ${error.value
+        ? html`<div class="mb-3 rounded-[var(--r-1)] border border-[var(--danger-20)] bg-[var(--danger-10)] px-3 py-2 text-xs text-[var(--color-status-err)]" role="alert" data-testid="official-client-session-error">${error.value}</div>`
+        : null}
+      ${loading.value && !session
+        ? html`<div class="text-xs text-[var(--color-fg-muted)]" role="status">공식 클라이언트 세션 불러오는 중…</div>`
+        : null}
+      ${keeperNames.length === 0
+        ? html`<${EmptyState} message="운영할 Keeper가 없습니다." compact />`
+        : null}
+      ${keeperNames.length > 0 && !loading.value && !session
+        ? html`<${EmptyState} message="이 Keeper는 아직 공식 클라이언트 세션을 시작하지 않았습니다." compact />`
+        : null}
+
+      ${session && phase
+        ? html`
+          <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2 text-xs" data-testid="official-client-session-evidence">
+            <div><span class="text-[var(--color-fg-muted)]">keeper</span> · <span class="mono">${response.value?.keeper_name}</span></div>
+            <div><span class="text-[var(--color-fg-muted)]">client</span> · <span class="mono">${session.client_kind}</span></div>
+            <div><span class="text-[var(--color-fg-muted)]">runtime</span> · <span class="mono">${session.runtime_id}</span></div>
+            <div><span class="text-[var(--color-fg-muted)]">completed turns</span> · ${session.turn_count}</div>
+            <div><span class="text-[var(--color-fg-muted)]">updated</span> · ${timestampText(session.updated_at)}</div>
+            <div title=${session.tool_surface_sha256}><span class="text-[var(--color-fg-muted)]">tool surface</span> · <span class="mono">${compactHash(session.tool_surface_sha256)}</span></div>
+            ${phase.owner_epoch ? html`<div title=${phase.owner_epoch}><span class="text-[var(--color-fg-muted)]">process epoch</span> · <span class="mono">${compactHash(phase.owner_epoch)}</span></div>` : null}
+            ${phase.session_id ? html`<div><span class="text-[var(--color-fg-muted)]">session</span> · <span class="mono">${phase.session_id}</span></div>` : null}
+            ${phase.turn_id ? html`<div><span class="text-[var(--color-fg-muted)]">turn</span> · <span class="mono">${phase.turn_id}</span></div>` : null}
+          </div>
+          ${recoveryRequired
+            ? html`
+              <div class="mt-4 rounded-[var(--r-1)] border border-[var(--danger-20)] bg-[var(--danger-10)] p-3" data-testid="official-client-session-recovery-required">
+                <div class="flex flex-wrap items-center gap-2 mb-2">
+                  <${StatusChip} tone="bad" uppercase=${false}>operator resolution required<//>
+                  <span class="mono text-2xs">${phase.recovery_id}</span>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs mb-3">
+                  <div>failure · <span class="mono">${phase.failure}</span></div>
+                  <div>required · ${timestampText(phase.required_at)}</div>
+                  <div>observed session · <span class="mono">${phase.observed_session_id ?? '—'}</span></div>
+                  <div>observed turn · <span class="mono">${phase.observed_turn_id ?? '—'}</span></div>
+                </div>
+                <div class="mb-3 whitespace-pre-wrap break-words text-xs text-[var(--color-fg-secondary)]">${phase.detail}</div>
+                <div class="flex flex-wrap gap-2">
+                  <${ActionButton}
+                    variant="warn"
+                    size="sm"
+                    testId="official-client-session-retry-previous"
+                    disabled=${resolving.value}
+                    ariaBusy=${resolving.value}
+                    onClick=${() => void resolve({ resolution: 'retry_previous' })}
+                  >이전 settlement에서 재시도<//>
+                  <${ActionButton}
+                    variant="danger"
+                    size="sm"
+                    testId="official-client-session-restart-fresh"
+                    disabled=${resolving.value}
+                    ariaBusy=${resolving.value}
+                    onClick=${() => void resolve({ resolution: 'restart_fresh' })}
+                  >새 session으로 재시작<//>
+                </div>
+              </div>
+            `
+            : null}
+          ${lastResolution
+            ? html`<div class="mt-3 text-2xs text-[var(--color-fg-muted)]" data-testid="official-client-session-last-resolution">
+                last resolution · ${lastResolution.resolution.kind} · ${lastResolution.resolved_by} · ${timestampText(lastResolution.resolved_at)}
+              </div>`
+            : null}
+          ${transientRelease
+            ? html`<div class="mt-1 text-2xs text-[var(--color-fg-muted)]" data-testid="official-client-session-transient-release">
+                last transient release · ${transientRelease.failure} · ${timestampText(transientRelease.released_at)}
+              </div>`
+            : null}
+        `
+        : null}
+    <//>
+  `
+}

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -34,6 +34,7 @@ import {
   runtimeCatalogRequestConfig as runtimeRequestConfigText,
   runtimeCatalogSnapshotFacts as runtimeSnapshotFactsText,
 } from '../lib/runtime-provider-summary'
+import { OfficialClientSessionPanel } from './official-client-session-panel'
 
 /**
  * Filters model metrics by case-insensitive substring match against
@@ -977,6 +978,8 @@ export function RuntimeMonitor() {
             : html`<${EmptyState} message="runtime snapshot이 없습니다." compact />`}
         </div>
       <//>
+
+      <${OfficialClientSessionPanel} />
 
       <${SectionCard} label="런타임 메트릭">
         <div class="grid grid-cols-3 gap-3 mb-4">

--- a/dashboard/src/demo/official-client-session-fixture.ts
+++ b/dashboard/src/demo/official-client-session-fixture.ts
@@ -1,0 +1,35 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { OfficialClientSessionPanel } from '../components/official-client-session-panel'
+import { keepers } from '../store'
+
+keepers.value = [
+  { name: 'sangsu', status: 'idle', runtime_id: 'antigravity.gemini' },
+]
+
+function OfficialClientSessionFixture() {
+  return html`
+    <main class="min-h-screen px-5 py-6" style="background: var(--color-bg-page);">
+      <section class="mx-auto max-w-[1180px]">
+        <header class="mb-5">
+          <div class="text-2xs uppercase tracking-[0.16em] text-[var(--color-accent-fg)]">
+            MASC Runtime Control
+          </div>
+          <h1 class="mt-1 text-xl font-semibold text-[var(--color-fg-primary)]">
+            공식 클라이언트 세션 운영
+          </h1>
+          <p class="mt-1 text-xs text-[var(--color-fg-muted)]">
+            실제 claim phase와 recovery fence를 확인한 뒤 명시적으로 해소합니다.
+          </p>
+        </header>
+        <${OfficialClientSessionPanel} />
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) render(html`<${OfficialClientSessionFixture} />`, root)

--- a/scripts/harness_dashboard_official_client_session_e2e.sh
+++ b/scripts/harness_dashboard_official_client_session_e2e.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5192}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/official-client-session-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-official-client-session-vite-${PORT}.log"
+ARTIFACT_DIR="${OFFICIAL_CLIENT_SESSION_ARTIFACT_DIR:-${TMPDIR:-/tmp}/masc-official-client-session-e2e}"
+
+mkdir -p "${ARTIFACT_DIR}"
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    sed -n '1,160p' "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+OFFICIAL_CLIENT_SESSION_FIXTURE_URL="${FIXTURE_URL}" \
+OFFICIAL_CLIENT_SESSION_ARTIFACT_DIR="${ARTIFACT_DIR}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec node e2e/official-client-session.mjs
+
+printf 'Official client session recovery Playwright E2E passed\n'


### PR DESCRIPTION
## Summary
- render exact official-client session, turn, recovery, and release evidence in Runtime Monitor
- allow only retry previous and restart fresh recovery actions
- update state from the exact admin API result without fabricated provider identities

## Stack
- base: replacement session API PR

## Verification
- focused Vitest interaction suite passed (2 tests)
- real Playwright recovery-to-restart interaction passed with screenshots
- full build is delegated to CI