### PR TITLE
feat(runtime): probe Antigravity login evidence

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -30,6 +30,7 @@ let process_termination_grace_s = 2.0
 let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 8192
 let max_wire_line_bytes = 8 * 1024 * 1024
+let max_probe_output_bytes = 256 * 1024
 
 let default_config ~cwd ~model =
   { cli_path = "agy"
@@ -67,6 +68,16 @@ type turn_result =
   ; tool_errors : int
   ; resumed : bool
   ; wall_duration_s : float
+  }
+
+type available_model =
+  { id : string
+  ; display_name : string
+  }
+
+type login_probe =
+  { client_version : string
+  ; available_models : available_model list
   }
 
 type error =
@@ -263,15 +274,20 @@ let execution_mode_to_string = function
   | Accept_edits -> "accept-edits"
 ;;
 
-let validate_config config ~conversation_mode ~prompt =
+let validate_process_config config =
   if String.trim config.cli_path = ""
   then Error (Invalid_config "cli_path must not be empty")
   else if String.trim config.cwd = "" || Filename.is_relative config.cwd
   then Error (Invalid_config "cwd must be an absolute path")
-  else if String.trim config.model = ""
-  then Error (Invalid_config "model must not be empty")
   else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
   then Error (Invalid_config "timeout_s must be positive and finite")
+  else Ok ()
+;;
+
+let validate_config config ~conversation_mode ~prompt =
+  let* () = validate_process_config config in
+  if String.trim config.model = ""
+  then Error (Invalid_config "model must not be empty")
   else if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
   else
@@ -572,6 +588,136 @@ let run_spawned ~mgr ~clock ~cwd config ~conversation_mode ~prompt ~on_conversat
         let status = Eio.Process.await proc in
         process_status := Some status;
         status, !state, String.trim !stderr_tail))
+;;
+
+let run_probe_process ~mgr ~clock ~cwd config arguments =
+  Eio.Switch.run (fun sw ->
+    let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
+    let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
+    let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
+    let stderr_tail = ref "" in
+    let proc =
+      Eio.Process.spawn
+        ~sw
+        mgr
+        ~cwd
+        ~env:(official_client_environment ())
+        ~stdin:stdin_r
+        ~stdout:stdout_w
+        ~stderr:stderr_w
+        (config.cli_path :: arguments)
+    in
+    Eio.Flow.close stdin_r;
+    Eio.Flow.close stdin_w;
+    Eio.Flow.close stdout_w;
+    Eio.Flow.close stderr_w;
+    Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
+    let process_status = ref None in
+    Fun.protect
+      ~finally:(fun () ->
+        match !process_status with
+        | Some _ -> ()
+        | None -> terminate_spawned_process ~clock proc stdin_w)
+      (fun () ->
+        let stdout =
+          try
+            Eio.Buf_read.of_flow ~max_size:max_probe_output_bytes stdout_r
+            |> Eio.Buf_read.take_all
+          with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
+            raise
+              (Runtime_error
+                 (Protocol_error
+                    { stage = "login probe stdout"; detail = Printexc.to_string exn }))
+        in
+        let status = Eio.Process.await proc in
+        process_status := Some status;
+        status, String.trim stdout, String.trim !stderr_tail))
+;;
+
+let probe_process_error command status stderr =
+  let exit = status_to_string status in
+  let detail = if stderr = "" then exit else exit ^ ": " ^ stderr in
+  Process_exited (Printf.sprintf "%s failed: %s" command detail)
+;;
+
+let parse_available_models output =
+  let lines =
+    output
+    |> String.split_on_char '\n'
+    |> List.map String.trim
+    |> List.filter (fun line -> line <> "")
+  in
+  let rec loop seen models = function
+    | [] ->
+      if models = []
+      then protocol_error "models probe" "agy models returned no models"
+      else Ok (List.rev models)
+    | line :: rest ->
+      (match String.index_opt line '\t' with
+       | None ->
+         protocol_error
+           "models probe"
+           "expected each model line to contain id and display name separated by a tab"
+       | Some separator ->
+         let id = String.sub line 0 separator |> String.trim in
+         let display_name =
+           String.sub line (separator + 1) (String.length line - separator - 1)
+           |> String.trim
+         in
+         if id = "" || display_name = ""
+         then protocol_error "models probe" "model id and display name must not be empty"
+         else if List.mem id seen
+         then
+           protocol_error
+             "models probe"
+             (Printf.sprintf "duplicate model id %S" id)
+         else loop (id :: seen) ({ id; display_name } :: models) rest)
+  in
+  loop [] [] lines
+;;
+
+let parse_client_version output =
+  match
+    output
+    |> String.split_on_char '\n'
+    |> List.map String.trim
+    |> List.filter (fun line -> line <> "")
+  with
+  | [ version ] -> Ok version
+  | [] -> protocol_error "version probe" "agy --version returned no version"
+  | _ -> protocol_error "version probe" "agy --version returned more than one line"
+;;
+
+let probe_login ~mgr ~clock ~cwd config =
+  let* () = validate_process_config config in
+  try
+    Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+      let models_status, models_stdout, models_stderr =
+        run_probe_process ~mgr ~clock ~cwd config [ "models" ]
+      in
+      let* available_models =
+        match models_status with
+        | `Exited 0 -> parse_available_models models_stdout
+        | (`Exited _ | `Signaled _) as status ->
+          Error (probe_process_error "agy models" status models_stderr)
+      in
+      let version_status, version_stdout, version_stderr =
+        run_probe_process ~mgr ~clock ~cwd config [ "--version" ]
+      in
+      let* client_version =
+        match version_status with
+        | `Exited 0 -> parse_client_version version_stdout
+        | (`Exited _ | `Signaled _) as status ->
+          Error (probe_process_error "agy --version" status version_stderr)
+      in
+      Ok { client_version; available_models })
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+  | Runtime_error error -> Error error
+  | exn -> Error (Spawn_failed (Printexc.to_string exn))
 ;;
 
 let run_turn ?(conversation_mode = Start) ~mgr ~clock ~cwd

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -52,6 +52,16 @@ type turn_result =
   ; wall_duration_s : float
   }
 
+type available_model =
+  { id : string
+  ; display_name : string
+  }
+
+type login_probe =
+  { client_version : string
+  ; available_models : available_model list
+  }
+
 type error =
   | Invalid_config of string
   | Spawn_failed of string
@@ -71,6 +81,16 @@ val validate_turn :
   config ->
   prompt:string ->
   (unit, error) result
+
+(** Execute the authenticated, no-model-turn [agy models] probe and read the
+    exact client version. API credential environment variables are removed in
+    the same way as for model turns. *)
+val probe_login :
+  mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  cwd:Eio.Fs.dir_ty Eio.Path.t ->
+  config ->
+  (login_probe, error) result
 
 val run_turn :
   ?conversation_mode:conversation_mode ->

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -75,6 +75,65 @@ let with_fixture ?require_resume ?sleep_s ?exit_code lines f =
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
+let probe_fixture_script
+    ?(models_output = [ "gemini-3.1-pro-high\tGemini 3.1 Pro (High)" ])
+    ?(models_stderr = "Fetching available models...")
+    ?(models_exit_code = 0)
+    ?(version_output = "1.1.11")
+    ()
+  =
+  let path = Filename.temp_file "masc-antigravity-probe-" ".sh" in
+  let output = open_out_bin path in
+  output_string output "#!/bin/sh\n";
+  output_string output
+    "test -z \"${GEMINI_API_KEY+x}\" && test -z \"${GOOGLE_API_TOKEN+x}\" && test -z \"${OPENAI_API_KEY+x}\" && test -z \"${ANTHROPIC_API_KEY+x}\" && test -z \"${AGY_ADC_AUTH+x}\" || exit 92\n";
+  output_string output "case \"$1\" in\n";
+  output_string output "  models)\n";
+  output_string
+    output
+    ("    printf '%s\\n' " ^ shell_quote models_stderr ^ " >&2\n");
+  List.iter
+    (fun line -> output_string output ("    printf '%s\\n' " ^ shell_quote line ^ "\n"))
+    models_output;
+  output_string output (Printf.sprintf "    exit %d\n" models_exit_code);
+  output_string output "    ;;\n";
+  output_string output "  --version)\n";
+  output_string output ("    printf '%s\\n' " ^ shell_quote version_output ^ "\n");
+  output_string output "    ;;\n";
+  output_string output "  *) exit 94 ;;\n";
+  output_string output "esac\n";
+  close_out output;
+  Unix.chmod path 0o700;
+  path
+;;
+
+let with_probe_fixture ?models_output ?models_stderr ?models_exit_code ?version_output f =
+  let path =
+    probe_fixture_script
+      ?models_output
+      ?models_stderr
+      ?models_exit_code
+      ?version_output
+      ()
+  in
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let run_probe_fixture ?(timeout_s = 2.0) path =
+  Eio_main.run (fun env ->
+    let config =
+      { (Runtime_antigravity.default_config ~cwd:"/tmp" ~model:"gemini-fixture") with
+        cli_path = path
+      ; timeout_s
+      }
+    in
+    Runtime_antigravity.probe_login
+      ~mgr:(Eio.Stdenv.process_mgr env)
+      ~clock:(Eio.Stdenv.clock env)
+      ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+      config)
+;;
+
 let run_fixture ?conversation_mode ?on_conversation_ready ?(timeout_s = 2.0) path =
   Eio_main.run (fun env ->
     let config =
@@ -235,6 +294,44 @@ let test_admission_is_process_free () =
   | Ok () -> fail "invalid deterministic config passed admission"
 ;;
 
+let test_login_probe_measures_models_and_version_without_turn () =
+  with_probe_fixture
+    ~models_output:
+      [ "gemini-3.1-pro-high\tGemini 3.1 Pro (High)"
+      ; "claude-sonnet-4-6\tClaude Sonnet 4.6 (Thinking)"
+      ]
+    (fun path ->
+       match run_probe_fixture path with
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok probe ->
+         check string "client version" "1.1.11" probe.client_version;
+         check int "measured model count" 2 (List.length probe.available_models);
+         let first = List.hd probe.available_models in
+         check string "first model id" "gemini-3.1-pro-high" first.id;
+         check string "first display name" "Gemini 3.1 Pro (High)" first.display_name)
+;;
+
+let test_login_probe_rejects_untyped_model_output () =
+  with_probe_fixture ~models_output:[ "not-tab-separated" ] (fun path ->
+    match run_probe_fixture path with
+    | Error (Runtime_antigravity.Protocol_error { stage = "models probe"; _ }) -> ()
+    | Error error -> fail (Runtime_antigravity.error_to_string error)
+    | Ok _ -> fail "malformed model inventory was admitted")
+;;
+
+let test_login_probe_preserves_process_failure () =
+  with_probe_fixture
+    ~models_output:[]
+    ~models_stderr:"Please sign in to view available models."
+    ~models_exit_code:1
+    (fun path ->
+       match run_probe_fixture path with
+       | Error (Runtime_antigravity.Process_exited detail) ->
+         check bool "command retained" true (String.starts_with ~prefix:"agy models failed:" detail)
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok _ -> fail "failed login probe was admitted")
+;;
+
 let test_live_start_and_resume () =
   match Sys.getenv_opt "MASC_ANTIGRAVITY_LIVE", Sys.getenv_opt "MASC_ANTIGRAVITY_MODEL" with
   | Some "1", Some model ->
@@ -313,6 +410,20 @@ let () =
         ; test_case "duplicate keys" `Quick test_duplicate_keys_fail_closed
         ; test_case "typed timeout" `Quick test_timeout_is_typed
         ; test_case "process-free admission" `Quick test_admission_is_process_free
+        ] )
+    ; ( "login probe"
+      , [ test_case
+            "measures models and version without a turn"
+            `Quick
+            test_login_probe_measures_models_and_version_without_turn
+        ; test_case
+            "rejects untyped model output"
+            `Quick
+            test_login_probe_rejects_untyped_model_output
+        ; test_case
+            "preserves process failure"
+            `Quick
+            test_login_probe_preserves_process_failure
         ] )
     ; "live official client", [ test_case "official agy start and resume" `Slow test_live_start_and_resume ]
     ]


### PR DESCRIPTION
## Summary
- probe authenticated Antigravity CLI state with the no-model-turn `agy models` command
- return the exact measured model IDs/display names and `agy --version`
- reuse the official-client credential-scrubbed environment, bounded output, timeout, and process termination boundary
- preserve nonzero process failures without guessing login/network causes from stderr text

## Stack
- base: #27791

## Measured contract
- local `agy models` emitted a tab-separated model inventory on stdout and its progress line on stderr
- a fresh HOME returned a sign-in-required process failure
- no prompt or model turn is submitted by this probe

## Verification
- `ocamlformat --check` passed
- OCaml parser checks passed for implementation, interface, and tests
- deterministic-boundary ratchet passed
- full build and focused runtime test are delegated to CI