### PR TITLE
fix: fail closed on missing runtime tool schemas

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -1,7 +1,7 @@
 # Keeper Tool Boundary Matrix
 
 Status: P0 ratchet source for keeper agent tool boundaries.
-Last updated: 2026-07-12.
+Last updated: 2026-08-09.
 
 This matrix freezes the owner map for keeper modules that participate in the
 agent tool path. A new file in scope must be added here with exactly one owner
@@ -136,6 +136,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_descriptor.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_descriptor_resolution.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_descriptor_resolution.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_runtime_schemas.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_runtime_schemas.mli` - tool-surface-policy
 - `lib/keeper_tool_name/keeper_tool_name.ml` - tool-surface-policy
 - `lib/keeper_tool_name/keeper_tool_name.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_diversity.ml` - tool-surface-policy

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -2,42 +2,8 @@
 
 module StringSet = Set_util.StringSet
 
-(* Keep the internal runtime schemas for descriptor-backed shard tools.  Their
-   public Keeper descriptors may deliberately expose a different shape that is
-   validated before translation (for example, Edit.file_path becomes the
-   runtime tool_edit_file.path).  Only project a descriptor-owned schema when
-   no shard runtime schema exists for that internal name.
-
-   Do NOT trim "keeper-only" tools out of this projection to keep them off the
-   operator MCP surface.  [raw_all_tool_schemas] feeds both the keeper universe
-   and the public MCP surface, and the operator-surface
-   exclusion is enforced separately and downstream by [Tool_catalog.is_public_mcp]
-   / [public_mcp_surface_tools] (contract stated in tool_schemas_misc.mli).
-   The Keeper model surface itself comes directly from descriptors. *)
-let keeper_runtime_tool_schemas = Tool_shard.all_keeper_tool_schemas
-
-let keeper_runtime_tool_names =
-  keeper_runtime_tool_schemas
-  |> List.fold_left
-       (fun names (schema : Masc_domain.tool_schema) ->
-          StringSet.add schema.name names)
-       StringSet.empty
-
-let descriptor_only_internal_tool_schemas : Masc_domain.tool_schema list =
-  Keeper_tool_descriptor.public_descriptors
-  |> List.filter_map (fun (descriptor : Keeper_tool_descriptor.t) ->
-    if StringSet.mem descriptor.internal_name keeper_runtime_tool_names
-    then None
-    else
-      Some
-        { Masc_domain.name = descriptor.internal_name
-        ; description = descriptor.description
-        ; input_schema = descriptor.input_schema
-        })
-
 let raw_all_tool_schemas : Masc_domain.tool_schema list =
-  keeper_runtime_tool_schemas
-  @ descriptor_only_internal_tool_schemas
+  Tool_shard.all_keeper_tool_schemas
   @ Tools.raw_schemas
   @ Tool_schemas_misc.schemas
   @ Board_tool.tools

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -4,6 +4,8 @@ module StringSet = Set_util.StringSet
 
 let raw_all_tool_schemas : Masc_domain.tool_schema list =
   Tool_shard.all_keeper_tool_schemas
+  @ Keeper_tool_runtime_schemas.schemas
+  @ Tool_schemas_misc.web_schemas
   @ Tools.raw_schemas
   @ Tool_schemas_misc.schemas
   @ Board_tool.tools

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -384,73 +384,6 @@ let search_files_schema =
     ]
 ;;
 
-let search_web_schema =
-  object_schema
-    ~required:[ "query" ]
-    [ property "query" "string" "Plain-text search query. Example: \"OCaml 5.2 release date\"."
-    ; property "limit" "integer" "Maximum number of results to return (1-10, default 5)."
-    ; property
-        "includeContent"
-        "boolean"
-        "When true, also fetch each result page and add raw page_content plus a human-readable content_text summary. Recommended for research."
-    ; ( "contentMaxChars",
-        `Assoc
-          [ "type", `String "integer"
-          ; "description",
-            `String "Maximum raw page_content characters per result."
-          ; "minimum", `Int 100
-          ; "maximum", `Int 20000
-          ; "default", `Int 4000
-          ] )
-    ; ( "contentTimeout",
-        `Assoc
-          [ "type", `String "integer"
-          ; "description", `String "Per-result content fetch timeout in seconds."
-          ; "minimum", `Int 1
-          ; "maximum", `Int 60
-          ; "default", `Int 15
-          ] )
-    ]
-;;
-
-let fetch_web_schema =
-  `Assoc
-    [ "type", `String "object"
-    ; ( "properties",
-        `Assoc
-          [ property "url" "string" "Full URL to fetch. Example: \"https://ocaml.org/news\"."
-          ; ( "timeout",
-              `Assoc
-                [ "type", `String "integer"
-                ; "description", `String "Request timeout in seconds."
-                ; "minimum", `Int 1
-                ; "maximum", `Int 60
-                ; "default", `Int 15
-                ] )
-          ; ( "extractMode",
-              `Assoc
-                [ "type", `String "string"
-                ; "enum", `List [ `String "markdown"; `String "text" ]
-                ; "description",
-                  `String
-                    "Output extraction mode. markdown (default) preserves headings/lists/links; \
-                     text returns flattened plain text."
-                ; "default", `String "markdown"
-                ] )
-          ; ( "maxChars",
-              `Assoc
-                [ "type", `String "integer"
-                ; "description", `String "Maximum extracted content characters to return."
-                ; "minimum", `Int 1
-                ; "maximum", `Int 100000
-                ; "default", `Int 50000
-                ] )
-          ] )
-    ; "required", `List [ `String "url" ]
-    ; "additionalProperties", `Bool false
-    ]
-;;
-
 (* [offset]/[limit] pass through as LINE coordinates — the runtime owns the
    line-window contract (keeper_tool_filesystem_runtime.slice_read_window).
    [limit] used to be renamed to [max_bytes] here, which silently turned "200
@@ -781,17 +714,12 @@ let public_descriptors =
   ; descriptor
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Preferred_public_name
-      ~input_schema_source:Descriptor_owned
+      ~input_schema_source:Canonical_registry
       ~id:"agent.search_web"
       ~public_name:"WebSearch"
-      ~internal_name:"masc_web_search"
-      ~description:
-        "Search the public web. Use exact tool name WebSearch. Example input: \
-         {\"query\":\"OCaml 5.2 release date\",\"limit\":5,\"includeContent\":true}. \
-         Returns result.results with title, url, snippet. With includeContent:true \
-         each result also has page_content and the response has a human-readable \
-         content_text summary. Do not use snake_case names like web_search."
-      ~input_schema:search_web_schema
+      ~internal_name:Tool_schemas_misc.web_search_schema.name
+      ~description:Tool_schemas_misc.web_search_schema.description
+      ~input_schema:Tool_schemas_misc.web_search_schema.input_schema
       ~policy:
         (policy
            ~readonly:true
@@ -806,17 +734,12 @@ let public_descriptors =
   ; descriptor
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Preferred_public_name
-      ~input_schema_source:Descriptor_owned
+      ~input_schema_source:Canonical_registry
       ~id:"agent.fetch_web"
       ~public_name:"WebFetch"
-      ~internal_name:"masc_web_fetch"
-      ~description:
-        "Fetch one web page for deeper reading. Use exact tool name WebFetch. \
-         Example input: {\"url\":\"https://ocaml.org/news\",\"extractMode\":\"markdown\",\"maxChars\":5000}. \
-         Returns text, title, final_url, http_status, truncated. Use after WebSearch \
-         when you need a citation or full article text. Do not use snake_case names \
-         like web_fetch."
-      ~input_schema:fetch_web_schema
+      ~internal_name:Tool_schemas_misc.web_fetch_schema.name
+      ~description:Tool_schemas_misc.web_fetch_schema.description
+      ~input_schema:Tool_schemas_misc.web_fetch_schema.input_schema
       ~policy:
         (policy
            ~readonly:true
@@ -928,41 +851,6 @@ let base_schema_input name =
     Canonical_registry, schema.input_schema
   | None -> invalid_arg ("missing base tool schema for " ^ name)
 
-let artifact_read_schema =
-  `Assoc
-    [ "type", `String "object"
-    ; ( "properties"
-      , `Assoc
-          [ ( "sha256"
-            , `Assoc
-                [ "type", `String "string"
-                ; ( "description"
-                  , `String "Exact sha256 from a [masc:blob ...] ToolResult." )
-                ] )
-          ; ( "offset"
-            , `Assoc
-                [ "type", `String "integer"
-                ; "minimum", `Int 0
-                ; "default", `Int 0
-                ; "description", `String "Byte offset to read from."
-                ] )
-          ; ( "max_bytes"
-            , `Assoc
-                [ "type", `String "integer"
-                ; "minimum", `Int Keeper_artifact_read.minimum_max_bytes
-                ; "maximum", `Int Keeper_artifact_read.maximum_max_bytes
-                ; "default", `Int Keeper_artifact_read.default_max_bytes
-                ; ( "description"
-                  , `String
-                      "Maximum source bytes to expose in this model-visible \
-                       page." )
-                ] )
-          ] )
-    ; "required", `List [ `String "sha256" ]
-    ; "additionalProperties", `Bool false
-    ]
-;;
-
 let library_search_schema =
   object_schema
     [ property
@@ -1073,82 +961,6 @@ let memory_write_schema_source, memory_write_schema =
 
 let ide_annotate_schema_source, ide_annotate_schema =
   base_schema_input "keeper_ide_annotate"
-;;
-
-let masc_fusion_schema =
-  object_schema
-    ~required:[ "prompt" ]
-    [ property
-        "prompt"
-        "string"
-        "Question or task to deliberate. A panel of models answers \
-         independently, then a judge synthesises consensus, contradictions, \
-         partial coverage, unique insights, and blind spots. Out-of-band: the \
-         synthesis arrives asynchronously on this keeper's chat lane, not \
-         inline in this turn."
-    ; property
-        "preset"
-        "string"
-        "Panel preset name from runtime.toml [fusion.presets]. Omitted uses \
-         the configured default_preset."
-    ; property
-        "web_tools"
-        "boolean"
-        "When true, the panel and judge agents are given web_search / \
-         web_fetch tools to ground their answers. Defaults to false; the \
-         selected preset may also enable web tools on its own (the effective \
-         setting is this flag OR the preset's)."
-    ; property
-        "topology"
-        "string"
-        "How to reduce the panel answers. \"simple\" (default): panel -> one \
-         judge -> result. \"refine\": panel -> judge -> a second judge that \
-         critically reviews and improves the first synthesis against the panel \
-         evidence -> result (deeper, two judge passes). \"conditional\": like \
-         simple, but escalates to a second (refine) judge only when the first \
-         judge could not decide (verdict insufficient); otherwise returns the \
-         first synthesis. \"judge_of_judges\": several distinct judges each \
-         synthesise the panel independently and a meta-judge reconciles them \
-         (requires the preset to configure >= 2 judges). \
-         \"staged_judge_of_judges\": first judges are grouped by \
-         [fusion].staged_judge_group_size, each group is reconciled by a \
-         stage meta-judge, then a final meta-judge reconciles the stage \
-         results (requires at least two exact groups; ragged counts are \
-         rejected). Unknown values are rejected."
-    ]
-;;
-
-let masc_fusion_status_schema =
-  object_schema
-    [ property
-        "run_id"
-        "string"
-        "Optional fusion run id (the run_id returned by masc_fusion). When \
-         given, returns that single run's status; when omitted, lists every \
-         tracked run (in-progress and recently completed)."
-    ]
-;;
-
-let analyze_image_schema =
-  object_schema
-    ~required:[ "artifact"; "query" ]
-    [ property
-        "artifact"
-        "string"
-        "Handle of a stored image artifact (the content-addressed id returned \
-         when the image was stored). The raw image is read in a vision sub-call \
-         and never enters this conversation."
-    ; property
-        "query"
-        "string"
-        "What to ask about the image, e.g. \"describe the chart\" or \
-         \"transcribe the text\"."
-    ; string_enum_property
-        "media_type"
-        Keeper_vision_tool.supported_image_media_types
-        "Optional image MIME type override (e.g. image/png, image/jpeg). \
-         Sniffed from the bytes when omitted."
-    ]
 ;;
 
 let read_only_in_process_policy ?(polling_read = false) () =
@@ -1586,19 +1398,18 @@ let internal_descriptors : t list =
       ~input_schema:empty_object_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_context_status
-  ; in_process_descriptor
+  ; (in_process_descriptor_with_schema_source
+      ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Internal_name
+      ~input_schema_source:Canonical_registry
       ~id:"keeper.artifact.read"
-      ~name:"keeper_artifact_read"
-      ~description:
-        "Read an explicit byte range from a [masc:blob ...] ToolResult. Use \
-         the marker's sha256, then continue with the returned next_offset. \
-         Text pages use UTF-8; arbitrary bytes use base64. The full artifact \
-         is never restored into model history."
-      ~input_schema:artifact_read_schema
+      ~name:Keeper_tool_runtime_schemas.artifact_read.name
+      ~description:Keeper_tool_runtime_schemas.artifact_read.description
+      ~input_schema:Keeper_tool_runtime_schemas.artifact_read.input_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_artifact_read
-    |> with_model_output_projection Tool_output.bounded_inline_model_projection
+      ()
+    |> with_model_output_projection Tool_output.bounded_inline_model_projection)
   ; in_process_descriptor_with_schema_source
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Internal_name
@@ -1687,64 +1498,44 @@ let internal_descriptors : t list =
       ~handler:Tool_ide_annotate
       ()
     (* ── fusion deliberation (RFC-0252) ───────────────────────── *)
-  ; in_process_descriptor
+  ; in_process_descriptor_with_schema_source
+      ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Internal_name
+      ~input_schema_source:Canonical_registry
       ~id:"masc.fusion.deliberate"
-      ~name:"masc_fusion"
-      ~description:
-        "Run an out-of-band panel+judge deliberation. A panel of models from \
-         the configured preset answers the prompt independently; a judge model \
-         synthesises consensus, contradictions, partial coverage, unique \
-         insights, and blind spots. Advisory only: this keeper turn continues \
-         immediately; when the deliberation completes you are WOKEN with the \
-         result, and the conclusion (or the failure reason) is appended to \
-         your chat lane (also visible in the dashboard) — do not poll \
-         masc_fusion_status while waiting. Returns a status with a run_id. \
-         Panels answer from their own knowledge only: they cannot see your \
-         files, tasks, or conversation, so phrase the prompt \
-         self-contained. Set web_tools=true to let the panel and judge ground \
-         their answers with web_search / web_fetch. Gated by runtime.toml \
-         [fusion] (disabled by default)."
-      ~input_schema:masc_fusion_schema
+      ~name:Keeper_tool_runtime_schemas.fusion.name
+      ~description:Keeper_tool_runtime_schemas.fusion.description
+      ~input_schema:Keeper_tool_runtime_schemas.fusion.input_schema
       (* The explicit [Internal_name] projection makes Fusion available. *)
       ~policy:(write_in_process_policy ())
       ~handler:Tool_masc_fusion_dispatch
+      ()
     (* ── fusion status (RFC-0266 §7 Phase 3) ──────────────────── *)
-  ; in_process_descriptor
+  ; in_process_descriptor_with_schema_source
+      ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Internal_name
+      ~input_schema_source:Canonical_registry
       ~id:"masc.fusion.status"
-      ~name:"masc_fusion_status"
-      ~description:
-        "Read the status of out-of-band fusion deliberations started by \
-         masc_fusion. With no argument, lists tracked runs (in-progress and \
-         recently completed); with a run_id, returns that single run. Each run \
-         reports keeper, preset, started_at (unix seconds), and status \
-         (running | completed | failed); failed runs also carry error and \
-         failure_code. Prefer waiting for the completion wake over polling \
-         this tool — the result reaches you without it. Read-only — does not \
-         start a deliberation. In-memory and server-lifetime: runs do not \
-         survive a restart."
-      ~input_schema:masc_fusion_status_schema
+      ~name:Keeper_tool_runtime_schemas.fusion_status.name
+      ~description:Keeper_tool_runtime_schemas.fusion_status.description
+      ~input_schema:Keeper_tool_runtime_schemas.fusion_status.input_schema
       (* [Internal_name] is the model exposure authority. *)
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_masc_fusion_status
+      ()
     (* ── vision delegation (RFC-keeper-vision-delegation-tool §2.6) ─ *)
-  ; in_process_descriptor
+  ; in_process_descriptor_with_schema_source
+      ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Internal_name
+      ~input_schema_source:Canonical_registry
       ~id:"keeper.vision.analyze_image"
-      ~name:"analyze_image"
-      ~description:
-         "Read a stored image artifact and return a text description or answer. \
-         Delegates to a vision model in a sub-call; the image is never added to \
-         this conversation. Returns the extracted text, or a typed error \
-         (invalid_args | eio_context_unavailable | artifact_load_failed | \
-         invalid_timeout | image_too_large | invalid_media_type | \
-         invalid_request | no_capable_runtime | empty_extraction | \
-         truncated_extraction | timeout | provider_error)."
-      ~input_schema:analyze_image_schema
+      ~name:Keeper_tool_runtime_schemas.analyze_image.name
+      ~description:Keeper_tool_runtime_schemas.analyze_image.description
+      ~input_schema:Keeper_tool_runtime_schemas.analyze_image.input_schema
       (* [Internal_name] keeps the read-only vision sub-call model-visible. *)
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_analyze_image
+      ()
     (* ── voice cluster (RFC-0179 PR-3, 6 tools) ───────────────── *)
   ; voice_descriptor
       "keeper_voice_speak"

--- a/lib/keeper/keeper_tool_runtime_schemas.ml
+++ b/lib/keeper/keeper_tool_runtime_schemas.ml
@@ -1,0 +1,172 @@
+open Masc_domain
+
+let property name kind description =
+  name, `Assoc [ "type", `String kind; "description", `String description ]
+;;
+
+let object_schema ?(required = []) properties =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc properties
+    ; "required", `List (List.map (fun name -> `String name) required)
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let string_enum_property name values description =
+  ( name
+  , `Assoc
+      [ "type", `String "string"
+      ; "enum", `List (List.map (fun value -> `String value) values)
+      ; "description", `String description
+      ] )
+;;
+
+let artifact_read =
+  { name = "keeper_artifact_read"
+  ; description =
+      "Read an explicit byte range from a [masc:blob ...] ToolResult. Use \
+       the marker's sha256, then continue with the returned next_offset. \
+       Text pages use UTF-8; arbitrary bytes use base64. The full artifact \
+       is never restored into model history."
+  ; input_schema =
+      object_schema
+        ~required:[ "sha256" ]
+        [ property "sha256" "string" "Exact sha256 from a [masc:blob ...] ToolResult."
+        ; ( "offset"
+          , `Assoc
+              [ "type", `String "integer"
+              ; "minimum", `Int 0
+              ; "default", `Int 0
+              ; "description", `String "Byte offset to read from."
+              ] )
+        ; ( "max_bytes"
+          , `Assoc
+              [ "type", `String "integer"
+              ; "minimum", `Int Keeper_artifact_read.minimum_max_bytes
+              ; "maximum", `Int Keeper_artifact_read.maximum_max_bytes
+              ; "default", `Int Keeper_artifact_read.default_max_bytes
+              ; "description", `String "Maximum source bytes to expose in this model-visible page."
+              ] )
+        ]
+  }
+;;
+
+let fusion =
+  { name = "masc_fusion"
+  ; description =
+      "Run an out-of-band panel+judge deliberation. A panel of models from \
+       the configured preset answers the prompt independently; a judge model \
+       synthesises consensus, contradictions, partial coverage, unique \
+       insights, and blind spots. Advisory only: this keeper turn continues \
+       immediately; when the deliberation completes you are WOKEN with the \
+       result, and the conclusion (or the failure reason) is appended to \
+       your chat lane (also visible in the dashboard) — do not poll \
+       masc_fusion_status while waiting. Returns a status with a run_id. \
+       Panels answer from their own knowledge only: they cannot see your \
+       files, tasks, or conversation, so phrase the prompt \
+       self-contained. Set web_tools=true to let the panel and judge ground \
+       their answers with web_search / web_fetch. Gated by runtime.toml \
+       [fusion] (disabled by default)."
+  ; input_schema =
+      object_schema
+        ~required:[ "prompt" ]
+        [ property
+            "prompt"
+            "string"
+            "Question or task to deliberate. A panel of models answers \
+             independently, then a judge synthesises consensus, contradictions, \
+             partial coverage, unique insights, and blind spots. Out-of-band: the \
+             synthesis arrives asynchronously on this keeper's chat lane, not \
+             inline in this turn."
+        ; property
+            "preset"
+            "string"
+            "Panel preset name from runtime.toml [fusion.presets]. Omitted uses \
+             the configured default_preset."
+        ; property
+            "web_tools"
+            "boolean"
+            "When true, the panel and judge agents are given web_search / \
+             web_fetch tools to ground their answers. Defaults to false; the \
+             selected preset may also enable web tools on its own (the effective \
+             setting is this flag OR the preset's)."
+        ; property
+            "topology"
+            "string"
+            "How to reduce the panel answers. \"simple\" (default): panel -> one \
+             judge -> result. \"refine\": panel -> judge -> a second judge that \
+             critically reviews and improves the first synthesis against the panel \
+             evidence -> result (deeper, two judge passes). \"conditional\": like \
+             simple, but escalates to a second (refine) judge only when the first \
+             judge could not decide (verdict insufficient); otherwise returns the \
+             first synthesis. \"judge_of_judges\": several distinct judges each \
+             synthesise the panel independently and a meta-judge reconciles them \
+             (requires the preset to configure >= 2 judges). \
+             \"staged_judge_of_judges\": first judges are grouped by \
+             [fusion].staged_judge_group_size, each group is reconciled by a \
+             stage meta-judge, then a final meta-judge reconciles the stage \
+             results (requires at least two exact groups; ragged counts are \
+             rejected). Unknown values are rejected."
+        ]
+  }
+;;
+
+let fusion_status =
+  { name = "masc_fusion_status"
+  ; description =
+      "Read the status of out-of-band fusion deliberations started by \
+       masc_fusion. With no argument, lists tracked runs (in-progress and \
+       recently completed); with a run_id, returns that single run. Each run \
+       reports keeper, preset, started_at (unix seconds), and status \
+       (running | completed | failed); failed runs also carry error and \
+       failure_code. Prefer waiting for the completion wake over polling \
+       this tool — the result reaches you without it. Read-only — does not \
+       start a deliberation. In-memory and server-lifetime: runs do not \
+       survive a restart."
+  ; input_schema =
+      object_schema
+        [ property
+            "run_id"
+            "string"
+            "Optional fusion run id (the run_id returned by masc_fusion). When \
+             given, returns that single run's status; when omitted, lists every \
+             tracked run (in-progress and recently completed)."
+        ]
+  }
+;;
+
+let analyze_image =
+  { name = "analyze_image"
+  ; description =
+      "Read a stored image artifact and return a text description or answer. \
+       Delegates to a vision model in a sub-call; the image is never added to \
+       this conversation. Returns the extracted text, or a typed error \
+       (invalid_args | eio_context_unavailable | artifact_load_failed | \
+       invalid_timeout | image_too_large | invalid_media_type | \
+       invalid_request | no_capable_runtime | empty_extraction | \
+       truncated_extraction | timeout | provider_error)."
+  ; input_schema =
+      object_schema
+        ~required:[ "artifact"; "query" ]
+        [ property
+            "artifact"
+            "string"
+            "Handle of a stored image artifact (the content-addressed id returned \
+             when the image was stored). The raw image is read in a vision sub-call \
+             and never enters this conversation."
+        ; property
+            "query"
+            "string"
+            "What to ask about the image, e.g. \"describe the chart\" or \
+             \"transcribe the text\"."
+        ; string_enum_property
+            "media_type"
+            Keeper_vision_tool.supported_image_media_types
+            "Optional image MIME type override (e.g. image/png, image/jpeg). \
+             Sniffed from the bytes when omitted."
+        ]
+  }
+;;
+
+let schemas = [ artifact_read; fusion; fusion_status; analyze_image ]

--- a/lib/keeper/keeper_tool_runtime_schemas.mli
+++ b/lib/keeper/keeper_tool_runtime_schemas.mli
@@ -1,0 +1,11 @@
+(** Canonical input schemas for Keeper handlers implemented in the main
+    runtime library. Descriptor projection and dispatch registration consume
+    these same values. *)
+
+val artifact_read : Masc_domain.tool_schema
+val fusion : Masc_domain.tool_schema
+val fusion_status : Masc_domain.tool_schema
+val analyze_image : Masc_domain.tool_schema
+
+val schemas : Masc_domain.tool_schema list
+(** Complete stable-order runtime schema inventory owned by this module. *)

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -23,13 +23,117 @@ let control_schema = function
 
 let control_schemas = List.map control_schema control_operations
 
-(* [schemas] is the generated public misc schema set. Operator control schemas
-   use the dedicated typed projection above so they remain registered without
-   entering Config's public/front-door inventory. Descriptor-owned web backend
-   names (masc_web_search / masc_web_fetch) are intentionally not generated
-   here; [Config.raw_all_tool_schemas] projects them from
-   [Keeper_tool_descriptor.public_descriptors] so the keeper universe still
-   knows they exist without duplicating their schema ownership. *)
+let web_search_schema : tool_schema =
+  { name = "masc_web_search"
+  ; description =
+      "Search the public web. Use exact tool name WebSearch. Example input: \
+       {\"query\":\"OCaml 5.2 release date\",\"limit\":5,\"includeContent\":true}. \
+       Returns result.results with title, url, snippet. With includeContent:true \
+       each result also has page_content and the response has a human-readable \
+       content_text summary. Do not use snake_case names like web_search."
+  ; input_schema =
+      `Assoc
+        [ "type", `String "object"
+        ; ( "properties"
+          , `Assoc
+              [ ( "query"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "description"
+                      , `String
+                          "Plain-text search query. Example: \"OCaml 5.2 release date\"." )
+                    ] )
+              ; ( "limit"
+                , `Assoc
+                    [ "type", `String "integer"
+                    ; ( "description"
+                      , `String "Maximum number of results to return (1-10, default 5)." )
+                    ] )
+              ; ( "includeContent"
+                , `Assoc
+                    [ "type", `String "boolean"
+                    ; ( "description"
+                      , `String
+                          "When true, also fetch each result page and add raw page_content plus a human-readable content_text summary. Recommended for research." )
+                    ] )
+              ; ( "contentMaxChars"
+                , `Assoc
+                    [ "type", `String "integer"
+                    ; "description", `String "Maximum raw page_content characters per result."
+                    ; "minimum", `Int 100
+                    ; "maximum", `Int 20000
+                    ; "default", `Int 4000
+                    ] )
+              ; ( "contentTimeout"
+                , `Assoc
+                    [ "type", `String "integer"
+                    ; "description", `String "Per-result content fetch timeout in seconds."
+                    ; "minimum", `Int 1
+                    ; "maximum", `Int 60
+                    ; "default", `Int 15
+                    ] )
+              ] )
+        ; "required", `List [ `String "query" ]
+        ; "additionalProperties", `Bool false
+        ]
+  }
+;;
+
+let web_fetch_schema : tool_schema =
+  { name = "masc_web_fetch"
+  ; description =
+      "Fetch one web page for deeper reading. Use exact tool name WebFetch. \
+       Example input: {\"url\":\"https://ocaml.org/news\",\"extractMode\":\"markdown\",\"maxChars\":5000}. \
+       Returns text, title, final_url, http_status, truncated. Use after WebSearch \
+       when you need a citation or full article text. Do not use snake_case names \
+       like web_fetch."
+  ; input_schema =
+      `Assoc
+        [ "type", `String "object"
+        ; ( "properties"
+          , `Assoc
+              [ ( "url"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "description"
+                      , `String "Full URL to fetch. Example: \"https://ocaml.org/news\"." )
+                    ] )
+              ; ( "timeout"
+                , `Assoc
+                    [ "type", `String "integer"
+                    ; "description", `String "Request timeout in seconds."
+                    ; "minimum", `Int 1
+                    ; "maximum", `Int 60
+                    ; "default", `Int 15
+                    ] )
+              ; ( "extractMode"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; "enum", `List [ `String "markdown"; `String "text" ]
+                    ; ( "description"
+                      , `String
+                          "Output extraction mode. markdown (default) preserves headings/lists/links; text returns flattened plain text." )
+                    ; "default", `String "markdown"
+                    ] )
+              ; ( "maxChars"
+                , `Assoc
+                    [ "type", `String "integer"
+                    ; "description", `String "Maximum extracted content characters to return."
+                    ; "minimum", `Int 1
+                    ; "maximum", `Int 100000
+                    ; "default", `Int 50000
+                    ] )
+              ] )
+        ; "required", `List [ `String "url" ]
+        ; "additionalProperties", `Bool false
+        ]
+  }
+;;
+
+let web_schemas = [ web_search_schema; web_fetch_schema ]
+
+(* [schemas] is the generated public misc schema set. Operator control and web
+   runtime schemas use the dedicated projections above. *)
 let schemas : tool_schema list = Tool_descriptors_gen.schemas
 
 type mcp_runtime_operation =

--- a/lib/tool_schemas/tool_schemas_misc.mli
+++ b/lib/tool_schemas/tool_schemas_misc.mli
@@ -33,19 +33,18 @@ val control_schema : control_operation -> Masc_domain.tool_schema
 (** Canonical generated schema for a control operation. *)
 
 val control_schemas : Masc_domain.tool_schema list
-(** Canonical control schemas used by registration. These schemas are
-    intentionally excluded from {!schemas} and the Config front-door inventory. *)
+(** Canonical control schemas used by registration. *)
+
+val web_search_schema : Masc_domain.tool_schema
+val web_fetch_schema : Masc_domain.tool_schema
+val web_schemas : Masc_domain.tool_schema list
+(** Canonical input schemas owned by the Tool_misc web handlers. *)
 
 val schemas : Masc_domain.tool_schema list
 (** [schemas] is the generated [Masc_domain.tool_schema list] for misc tools.
-    Operator controls are intentionally available only through
-    {!control_schemas}; they do not enter the Config front-door inventory.
-    Descriptor-owned web backend names ([masc_web_search] / [masc_web_fetch])
-    are intentionally projected into {!Config.raw_all_tool_schemas} from
-    [Keeper_tool_descriptor.public_descriptors] instead of duplicated here.
-    Public-surface exclusion is enforced downstream by
-    {!Tool_catalog.is_public_mcp} / [public_mcp_surface_tools], not by trimming
-    the raw inventory. The schema [enum] fields derive from
+    Operator controls are available through {!control_schemas}. Public-surface
+    exclusion is enforced downstream by {!Tool_catalog.is_public_mcp} and
+    [public_mcp_surface_tools]. The schema [enum] fields derive from
     [Tool_schemas_specs_types.config_category_enum_strings] so
     adding a value updates the schema automatically.
 

--- a/lib/unified_tool_registry.ml
+++ b/lib/unified_tool_registry.ml
@@ -52,6 +52,14 @@ let inline_runtime_tool_names =
 
 let is_inline_runtime_tool_name name = List.mem name inline_runtime_tool_names
 
+let control_tool_names =
+  List.map
+    (fun (schema : Masc_domain.tool_schema) -> schema.name)
+    Tool_schemas_misc.control_schemas
+;;
+
+let is_control_tool_name name = List.mem name control_tool_names
+
 (** Exact dispatch tag for one typed descriptor handler. *)
 let tag_of_runtime_handler
       (handler : Keeper_tool_descriptor.runtime_handler)
@@ -101,6 +109,7 @@ let tag_of_name name : TD.module_tag option =
   if is_workspace_state_tool_name name then Some TD.Mod_state
   else if is_keeper_task_tool_name name then Some TD.Mod_keeper_task
   else if is_inline_runtime_tool_name name then Some TD.Mod_inline
+  else if is_control_tool_name name then Some TD.Mod_control
   else
     match Keeper_tool_descriptor.descriptors_for_internal name with
     | [ descriptor ] -> Some (tag_of_runtime_handler descriptor.runtime_handler)
@@ -132,19 +141,34 @@ let register_visible_raw_schemas () =
            invalid_arg
              ("visible tool schema has no exact dispatch owner: " ^ schema.name))
 
+(** Resolve a descriptor's validation schema from its runtime owner. Control
+    schemas stay outside the Config front-door inventory and are registered by
+    [Tool_control]; every other descriptor handler resolves through the raw
+    runtime inventory. *)
+let runtime_schema_for_descriptor
+      (descriptor : Keeper_tool_descriptor.t)
+  : Masc_domain.tool_schema option
+  =
+  let inventory =
+    match descriptor.runtime_handler with
+    | Keeper_tool_descriptor.Tool_masc_control_dispatch ->
+      Tool_schemas_misc.control_schemas
+    | _ -> Config.raw_all_tool_schemas
+  in
+  List.find_opt
+    (fun (schema : Masc_domain.tool_schema) ->
+       String.equal schema.name descriptor.internal_name)
+    inventory
+;;
+
 (** 2. Register each descriptor's internal handler name with its exact runtime
-    schema.  [Config.raw_all_tool_schemas] owns translated runtime shapes;
-    descriptor schemas remain the model-facing, pre-translation contract. *)
+    schema. Descriptor schemas remain the model-facing, pre-translation
+    contract. *)
 let register_descriptor_handlers () =
   Keeper_tool_descriptor.all_descriptors ()
   |> List.iter (fun (descriptor : Keeper_tool_descriptor.t) ->
          let schema =
-           match
-             List.find_opt
-               (fun (schema : Masc_domain.tool_schema) ->
-                  String.equal schema.name descriptor.internal_name)
-               Config.raw_all_tool_schemas
-           with
+           match runtime_schema_for_descriptor descriptor with
            | Some schema -> schema
            | None ->
              invalid_arg

--- a/lib/unified_tool_registry.ml
+++ b/lib/unified_tool_registry.ml
@@ -147,10 +147,9 @@ let register_descriptor_handlers () =
            with
            | Some schema -> schema
            | None ->
-             { Masc_domain.name = descriptor.internal_name
-             ; description = descriptor.description
-             ; input_schema = descriptor.input_schema
-             }
+             invalid_arg
+               ("descriptor internal handler has no exact runtime schema: "
+                ^ descriptor.internal_name)
          in
          register_canonical_schema
            schema

--- a/lib/unified_tool_registry.mli
+++ b/lib/unified_tool_registry.mli
@@ -6,13 +6,13 @@
     The flow is invoked once at startup by the MCP composition root; it is
     idempotent and preserves tags already registered via [Tool_spec]. *)
 
+(** Exact lookup from canonical schema membership or a typed descriptor. *)
 val tag_of_name : string -> Tool_dispatch.module_tag option
 
 val runtime_schema_for_descriptor :
   Keeper_tool_descriptor.t -> Masc_domain.tool_schema option
 (** Resolve the exact validation schema from the descriptor handler's runtime
     owner. *)
-(** Exact lookup from canonical schema membership or a typed descriptor. *)
 
 val tag_of_runtime_handler :
   Keeper_tool_descriptor.runtime_handler -> Tool_dispatch.module_tag

--- a/lib/unified_tool_registry.mli
+++ b/lib/unified_tool_registry.mli
@@ -7,6 +7,11 @@
     idempotent and preserves tags already registered via [Tool_spec]. *)
 
 val tag_of_name : string -> Tool_dispatch.module_tag option
+
+val runtime_schema_for_descriptor :
+  Keeper_tool_descriptor.t -> Masc_domain.tool_schema option
+(** Resolve the exact validation schema from the descriptor handler's runtime
+    owner. *)
 (** Exact lookup from canonical schema membership or a typed descriptor. *)
 
 val tag_of_runtime_handler :

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -1,13 +1,4 @@
-(** RFC-0057 Phase 2 regression test.
-
-    Guards [bin/gen_tool_descriptors.ml] output against the
-    effective schema exposed by [Tool_schemas_misc] for generated
-    misc/infra tools such as [masc_config] and [masc_tool_help].
-
-    Phase 2 lifted spec types into [lib/tool_schemas_specs/] and added
-    additional generated tools. Hand-written entries for these tools
-    were removed from [Tool_schemas_misc]; generated schemas are the
-    SSOT. The test pins generated vs effective field-for-field. *)
+(** Pins generated misc schemas to their effective runtime projections. *)
 
 open Masc_domain
 
@@ -64,17 +55,6 @@ let test_config_category_ssot () =
     "SSOT enum matches Env_config_snapshot.valid_config_category_strings"
     Env_config_snapshot.valid_config_category_strings
     Tool_schemas_specs_types.config_category_enum_strings
-;;
-
-let test_masc_spawn_is_not_generated () =
-  Alcotest.(check bool)
-    "masc_spawn absent from generated schemas"
-    false
-    (has_schema "masc_spawn" Tool_descriptors_gen.schemas);
-  Alcotest.(check bool)
-    "masc_spawn absent from effective misc schemas"
-    false
-    (has_schema "masc_spawn" Tool_schemas_misc.schemas)
 ;;
 
 let test_control_schemas_use_dedicated_typed_projection () =
@@ -255,11 +235,9 @@ let descriptor_internal_schema name : tool_schema =
   | None -> Alcotest.failf "descriptor for internal tool %S not found" name
 ;;
 
-(* Regression guard for PR #19864 -> keeper web alias pruning spam.
-   Web tools are descriptor-backed keeper tools: they MUST be
-   present in the raw substrate inventory, but their schema owner is
-   [Keeper_tool_descriptor.public_descriptors], not [Tool_descriptors_gen]. *)
-let test_web_tools_owned_by_keeper_descriptors () =
+(* Web handler schemas are owned by [Tool_schemas_misc.web_schemas]. Keeper
+   descriptors project the same exact schema into the model surface. *)
+let test_web_tools_use_runtime_schema_owner () =
   List.iter
     (fun name ->
       let descriptor = descriptor_internal_schema name in
@@ -271,16 +249,22 @@ let test_web_tools_owned_by_keeper_descriptors () =
         (name ^ " absent from Tool_schemas_misc.schemas")
         false
         (has_schema name Tool_schemas_misc.schemas);
+      let runtime = find_by_name name Tool_schemas_misc.web_schemas in
       let raw = find_by_name name Masc.Config.raw_all_tool_schemas in
       Alcotest.(check string)
-        (name ^ " raw description matches descriptor")
-        descriptor.description
+        (name ^ " raw description matches runtime owner")
+        runtime.description
         raw.description;
       Alcotest.check
         yojson_testable
-        (name ^ " raw input_schema matches descriptor")
-        descriptor.input_schema
+        (name ^ " raw input_schema matches runtime owner")
+        runtime.input_schema
         raw.input_schema;
+      Alcotest.check
+        yojson_testable
+        (name ^ " descriptor input_schema matches runtime owner")
+        runtime.input_schema
+        descriptor.input_schema;
       Alcotest.(check bool)
         (name ^ " present in Config.raw_all_tool_schemas")
         true
@@ -318,9 +302,6 @@ let () =
     ; ( "config category SSOT"
       , [ Alcotest.test_case "enum matches producer" `Quick test_config_category_ssot ]
       )
-    ; ( "retired tool exclusion"
-      , [ Alcotest.test_case "masc_spawn removed" `Quick test_masc_spawn_is_not_generated
-        ] )
     ; ( "control schema SSOT"
       , [ Alcotest.test_case
             "control tools use a dedicated typed projection"
@@ -362,11 +343,11 @@ let () =
         ; Alcotest.test_case "description" `Quick test_masc_gc_description_matches
         ; Alcotest.test_case "input_schema" `Quick test_masc_gc_input_schema_matches
         ] )
-    ; ( "descriptor-backed web tools"
+    ; ( "runtime-owned web tools"
       , [ Alcotest.test_case
-            "owned by keeper descriptors"
+            "projected through keeper descriptors"
             `Quick
-            test_web_tools_owned_by_keeper_descriptors
+            test_web_tools_use_runtime_schema_owner
         ; Alcotest.test_case
             "remain in complete model surface after substrate injection"
             `Quick

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -57,6 +57,17 @@ let test_config_category_ssot () =
     Tool_schemas_specs_types.config_category_enum_strings
 ;;
 
+let test_masc_spawn_is_not_generated () =
+  Alcotest.(check bool)
+    "masc_spawn absent from generated schemas"
+    false
+    (has_schema "masc_spawn" Tool_descriptors_gen.schemas);
+  Alcotest.(check bool)
+    "masc_spawn absent from effective misc schemas"
+    false
+    (has_schema "masc_spawn" Tool_schemas_misc.schemas)
+;;
+
 let test_control_schemas_use_dedicated_typed_projection () =
   let properties schema =
     match schema.input_schema with
@@ -302,6 +313,9 @@ let () =
     ; ( "config category SSOT"
       , [ Alcotest.test_case "enum matches producer" `Quick test_config_category_ssot ]
       )
+    ; ( "retired tool exclusion"
+      , [ Alcotest.test_case "masc_spawn removed" `Quick test_masc_spawn_is_not_generated
+        ] )
     ; ( "control schema SSOT"
       , [ Alcotest.test_case
             "control tools use a dedicated typed projection"

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -99,6 +99,22 @@ let test_schema_inventory_matches_dispatch_validation_registry () =
     Config.raw_all_tool_schemas
 ;;
 
+let test_every_descriptor_has_exact_runtime_schema () =
+  let inventory_names = schema_inventory_names () in
+  let missing =
+    Keeper_tool_descriptor.all_descriptors ()
+    |> List.filter_map (fun (descriptor : Keeper_tool_descriptor.t) ->
+      if List.mem descriptor.internal_name inventory_names
+      then None
+      else Some descriptor.internal_name)
+    |> sorted_set
+  in
+  Alcotest.(check (list string))
+    "every descriptor internal handler has an exact runtime schema"
+    []
+    missing
+;;
+
 let schema_property_names schema =
   match Json_util.assoc_member_opt "properties" schema with
   | Some (`Assoc properties) -> List.map fst properties
@@ -298,6 +314,10 @@ let () =
             "schema inventory matches dispatch validation registry"
             `Quick
             test_schema_inventory_matches_dispatch_validation_registry
+        ; test_case
+            "every descriptor has an exact runtime schema"
+            `Quick
+            test_every_descriptor_has_exact_runtime_schema
         ; test_case
             "translated descriptors keep distinct runtime schemas"
             `Quick

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -98,13 +98,12 @@ let test_schema_inventory_matches_dispatch_validation_registry () =
 ;;
 
 let test_every_descriptor_has_exact_runtime_schema () =
-  let inventory_names = schema_inventory_names () in
   let missing =
     Keeper_tool_descriptor.all_descriptors ()
     |> List.filter_map (fun (descriptor : Keeper_tool_descriptor.t) ->
-      if List.mem descriptor.internal_name inventory_names
-      then None
-      else Some descriptor.internal_name)
+      match Unified_tool_registry.runtime_schema_for_descriptor descriptor with
+      | Some _ -> None
+      | None -> Some descriptor.internal_name)
     |> sorted_set
   in
   Alcotest.(check (list string))

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -5,12 +5,10 @@ open Masc
     Asserts that:
     1. The runtime schema-registry key set equals the tag-registry key set.
     2. Mandatory (core-always) tools are present in the tag/schema registries.
-    3. Retired tool names are absent from the tag/schema/handler registries.
 
     These invariants are foundational for the MASC/Keeper/OAS overhaul:
     every tool that can be dispatched must have both a tag (for token
-    validation) and a schema (for input validation), and retired surfaces
-    must not leak back into the runtime registry. *)
+    validation) and a schema (for input validation). *)
 
 let init () = Masc_test_deps.init_unified_tool_registry ()
 


### PR DESCRIPTION
## Summary
- remove the descriptor-schema fallback from internal runtime registration
- fail startup when a descriptor internal handler has no exact runtime schema owner
- pin complete descriptor-to-runtime-schema coverage in the existing registry consistency suite

## Contract
Public/model descriptor schemas and translated internal runtime schemas remain distinct. Internal dispatch registration now consumes only `Config.raw_all_tool_schemas`; it does not silently substitute a model-facing descriptor schema when runtime ownership drifts.

No compatibility alias, dual-shape admission, heuristic, or fallback is introduced.

## Prompt and docs
No prompt behavior or user-facing tool contract changes. The existing source comments describe the public/runtime split, so no competing prompt or documentation copy was added.

## Verification
- Local tests not run, per current workflow
- Exact-head CI is authoritative
