### PR TITLE
feat(keeper): add single-owner inbox ledger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1296,6 +1296,21 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_decision_audit_dated_store"
 
+      # The operation ledger is a new durability boundary. @check compiles its
+      # executable but does not run the blob, FIFO, replay, terminal
+      # immutability, startup-audit, symlink-containment, and mailbox cases.
+      - name: Run Keeper operation ledger suite
+        id: keeper_operation_ledger_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_operation_ledger"
+
       # Redaction is the last thing every observability payload passes through,
       # so a defect here is not scoped to one field: a preview truncated inside
       # a multibyte character makes the whole JSON response undecodable and the

--- a/docs/design/keeper-single-owner-inbox-ledger-v1.md
+++ b/docs/design/keeper-single-owner-inbox-ledger-v1.md
@@ -1,0 +1,347 @@
+# Keeper Single-Owner Inbox Ledger v1
+
+## Contract
+
+The operation ledger is a Keeper's durable inbox and execution history. It is
+not a workflow engine.
+
+- Message and Stimulus ingress stores immutable input before accepting an
+  operation.
+- One Keeper owner is the only writer of that Keeper's ledger and conversation
+  state.
+- At most one operation per Keeper is Running with conversation-state
+  authority.
+- A Running operation is never automatically executed again after a crash.
+- Terminal operations and terminal delivery attempts are immutable.
+- A stale child completion cannot settle a different operation or a replacement
+  owner.
+- Interrupted operations, failed outcomes, and Ambiguous deliveries remain
+  visible context. They do not block later work.
+- Keeper-to-Keeper messages are ordinary inbox messages. They create no wait,
+  join, callback, dependency, or reply obligation.
+
+The system does not promise exactly-once external effects, fleet-wide resource
+isolation, or arbitrary orchestration liveness.
+
+## Authorities
+
+| Concern | Authority |
+| --- | --- |
+| Keeper existence and profile | resolved active config |
+| Acceptance, FIFO, and execution history | per-Keeper operation ledger |
+| Conversation | successful `next_state_ref` values and ledger projection |
+| Connector attempts | delivery ledger |
+| Async jobs | the producer-owned Fusion, HITL, or Gate store |
+| Pause | `keeper_control` |
+| Routine health reads | immutable owner projection |
+
+## Identity and canonical requests
+
+The Keeper identity is the canonical BasePath and Keeper name. Recreating the
+same name at the same BasePath resumes the same ledger. A new identity requires
+a new name or BasePath.
+
+Identifiers use positive v1 parsers:
+
+```text
+operation_id = kop1:<64 lowercase hexadecimal characters>
+delivery_id  = kdel1:<64 lowercase hexadecimal characters>
+blob_ref     = sha256:<64 lowercase hexadecimal characters>
+```
+
+No other identifier is accepted or reinterpreted.
+
+An ingress-specific constructor uses cryptographic randomness or a
+domain-separated deterministic digest. Event and continuation constructors are
+deterministic. Operator and connector constructors may be random.
+
+The request digest is the SHA-256 of canonical v1 envelope bytes, not an
+unframed concatenation:
+
+```json
+{"schema":"masc.keeper_operation.request.v1","kind":...,"source_ref":...,"submitter_ref":...,"input":...}
+```
+
+The typed encoder fixes field order, value representation, and UTF-8 bytes.
+Duplicate fields, unknown fields, malformed UTF-8, and non-finite numbers are
+rejected before encoding. The authenticated submitter is injected by the host.
+
+The same operation ID and digest is a replay. The same ID and a different
+digest is an identity conflict.
+
+## Runtime layout
+
+```text
+<base>/.masc/keepers/<keeper>/operations.sqlite3
+<base>/.masc/keepers/<keeper>/operation-blobs/sha256/<prefix>/<digest>
+```
+
+Each owner holds one persistent SQLite connection. Exact operation reads and
+all writes use the same serialized store lane. Routine reads use the immutable
+owner projection.
+
+SQLite configuration is:
+
+```text
+PRAGMA journal_mode=DELETE
+PRAGMA synchronous=FULL
+PRAGMA foreign_keys=ON
+```
+
+The schema activates only when exact `application_id`, `user_version`, and
+schema objects match v1.
+
+### operations
+
+```text
+queue_seq       INTEGER PRIMARY KEY
+operation_id    TEXT UNIQUE NOT NULL
+kind            Message | Stimulus | Autonomous
+source_ref      canonical typed bytes NOT NULL
+submitter_ref   canonical typed bytes NOT NULL
+state           Queued | Running | Settled | Cancelled | Interrupted
+request_digest  lowercase SHA-256 NOT NULL
+input_ref       typed immutable blob ref NOT NULL
+base_state_ref  typed immutable blob ref NULL
+outcome_ref     typed immutable blob ref NULL
+next_state_ref  typed immutable blob ref NULL
+created_at      REAL NOT NULL
+started_at      REAL NULL
+finished_at     REAL NULL
+```
+
+SQL checks enforce the legal field shapes for each state. A partial FIFO index
+selects Queued rows, and a partial unique index permits at most one Running row.
+
+Legal transitions are:
+
+```text
+Queued  -> Running -> Settled
+Queued  -> Cancelled
+Running -> Interrupted
+```
+
+Success, failure, tool failure, input required, and continuation-unrepresentable
+are typed outcome variants inside `outcome_ref`; they are not operation states.
+
+### deliveries
+
+```text
+delivery_seq          INTEGER PRIMARY KEY
+delivery_id           TEXT UNIQUE NOT NULL
+operation_id          TEXT NOT NULL REFERENCES operations(operation_id)
+destination_ref       canonical typed bytes NOT NULL
+state                 Pending | Attempting | Delivered | Failed | Ambiguous
+payload_ref           typed immutable blob ref NOT NULL
+connector_message_id  TEXT NULL
+evidence_ref           typed immutable blob ref NULL
+created_at             REAL NOT NULL
+started_at             REAL NULL
+finished_at            REAL NULL
+```
+
+One row is one connector attempt. A partial FIFO index selects Pending rows.
+There is no attempt sub-record and no retry mutation. A new explicit request may
+create a new delivery row.
+
+### keeper_control
+
+```text
+singleton  INTEGER PRIMARY KEY CHECK (singleton = 1)
+paused     INTEGER NOT NULL CHECK (paused IN (0, 1))
+```
+
+Pause blocks new computation and autonomous generation. It does not block
+message acceptance or delivery.
+
+## Immutable blobs
+
+The operation blob store is independent from tool blobs. The wire reference is
+only the SHA-256 content address. Distinct OCaml ref types and the canonical
+blob envelope carry the expected kind; read-back verifies the descriptor byte
+length, exact bytes, envelope kind, and digest. Input, outcome, state, delivery
+payload, and delivery evidence cannot be mixed without an explicit parse.
+
+Publication order is:
+
+1. produce canonical redacted bytes;
+2. write a temporary file;
+3. fsync the file;
+4. atomically rename it;
+5. fsync the parent directory;
+6. read it back and verify exact bytes and digest;
+7. only then commit a SQLite reference.
+
+An orphan blob is harmless. A committed reference to an absent or mismatched
+blob is a store integrity failure. v1 never deletes operation blobs.
+
+Raw authorization, secrets, and inline attachment bytes are removed before
+admission. Attachments become immutable media references.
+
+## Owner
+
+The directory maps `(canonical BasePath, Keeper name)` to a stable owner object.
+The object enters the map with `accepting = false`, performs its strict startup
+audit outside the directory mutex, and remains mapped while stopping. It is
+removed only after its child switches have ended and pointer identity still
+matches the map entry.
+
+The owner has:
+
+- a bounded 128-command external mailbox;
+- a serialized store lane;
+- one computation completion slot;
+- one delivery completion slot;
+- coalesced shutdown and wake slots;
+- at most one computation child and one delivery child;
+- an immutable Atomic read projection.
+
+Mailbox capacity is not acceptance. `202 Accepted` is returned only after the
+input blob and Queued transaction are durable. A full mailbox rejects before
+blob or row creation. The durable FIFO has no artificial row-count limit.
+
+The actor never joins a child while draining commands. Provider, tool, connector,
+filesystem, and SQLite work runs outside the actor fiber. The store lane returns
+typed completions in request order. Child exceptions and cancellation become
+typed completions and never escape to the server root switch.
+
+A computation completion settles only when both are true:
+
+```text
+completion.owner == owner
+completion.operation_id == owner.running_operation_id
+```
+
+An Admin interrupt requests child cancellation without joining it. The operation
+becomes Interrupted only after the matching child reports typed cancellation, or
+during startup audit after a process crash. The interrupt request has no durable
+journal of its own.
+
+## Scheduling and settlement
+
+When unpaused and no operation is Running, the owner starts the smallest
+`queue_seq` Queued row. The Running transaction captures the latest successful
+`next_state_ref` as `base_state_ref`. The executor receives an already-Running,
+immutable operation and does not repeat admission or lifecycle checks.
+
+The child creates immutable outcome, next-state, and delivery-payload blobs.
+One terminal SQLite transaction performs all of the following that apply:
+
+- Running to Settled;
+- outcome and next-state refs;
+- the complete deterministic Pending delivery set;
+- one deterministic FIFO-tail successor for cooperative continuation.
+
+If a commit response is uncertain, success requires an exact read-back of the
+prior state, target terminal payload, and complete delivery/successor set.
+Anything else stops acceptance and scheduling for that owner until restart and
+strict audit.
+
+Startup changes every remaining Running row to Interrupted and continues with
+later Queued rows. It never recreates or reruns the interrupted computation.
+
+## Context and continuation
+
+The current conversation state is the newest Settled operation with a non-null
+`next_state_ref`. The next execution combines that state with the deterministic
+ledger tail and current immutable input. The tail includes later Settled,
+Interrupted, and Cancelled facts plus terminal delivery facts.
+
+Cooperative yield creates a provider-neutral continuation delta. The parent
+terminal transaction inserts one ordinary Stimulus successor at the FIFO tail.
+Its deterministic identity is derived from the parent operation ID and exact
+delta ref. The successor sees the latest conversation state at execution time
+and the delta as additional typed context. It has no priority, dependency edge,
+or hidden callback. If executor state cannot be represented as that delta, the
+parent settles with `Continuation_unrepresentable` and creates no successor.
+
+Autonomous wake is a coalesced hint. An Autonomous operation is created only
+when unpaused, with no Running row, no Queued row, and no existing autonomous
+candidate. Once accepted it is ordinary FIFO work.
+
+## Keeper messaging
+
+`masc_keeper_send` submits each requested message independently and immediately
+returns an operation ID or typed rejection for each item. There is no batch
+transaction or target-wide preflight. A busy target may accept while it is
+Running if its mailbox has capacity. A self-message is queued behind the current
+operation.
+
+`masc_keeper_read` returns exact state and a typed outcome summary only when the
+authenticated calling Keeper is the recorded submitter. Admin REST reads use a
+separate permission boundary.
+
+Peer content is provenance-bearing user-role data, never target system
+instruction. Replies are independent messages.
+
+## Event, async, and Gate handoff
+
+Event Queue remains a durable transport buffer:
+
+```text
+durable Event -> Accepted or Replayed operation -> Event ACK
+```
+
+An Event is not acknowledged on mailbox, blob, or ledger failure.
+
+Each async producer owns its job and terminal handoff in its existing durable
+store. Its terminal transaction records a self-contained completion input,
+deterministic Event/operation identity, and whether handoff is pending. Its
+reconciler retries the same Event identity until the Event transport accepts or
+replays it.
+
+Gate is one such producer. Approval makes the exact immutable effect payload
+eligible for one automatic attempt:
+
+```text
+Pending -> Approved -> Attempting -> Applied | Failed | Ambiguous
+```
+
+The Gate-owned executor durably enters Attempting before dispatching the exact
+bytes. A crash, timeout, or lost response from Attempting becomes Ambiguous and
+is not dispatched again. This is at-most-one automatic attempt, not exactly-once
+external effect. Gate terminal state and its pending completion handoff are
+committed together.
+
+## Storage failure and backup
+
+There is no percentage-based capacity formula, reservation ledger, or automatic
+blob deletion. A concrete pre-acceptance storage exhaustion maps to a typed 507
+response; other store unavailability maps to 503. A failure after acceptance is
+settled when possible, otherwise startup turns a remaining Running row into
+Interrupted. Storage health is observable but does not become a fleet scheduler
+gate.
+
+Backup is quiesced maintenance: stop owner intake and children, close the sole
+SQLite connection, copy the database and referenced immutable blobs, then verify
+hashes and run the same strict startup audit against the restore.
+
+## Hard cut
+
+Production has one call graph:
+
+```text
+Ingress -> Keeper_owner -> Operation_store -> Operation_executor
+```
+
+OAS never imports MASC types; a MASC adapter converts OAS results to typed
+outcome and continuation delta values. Every production ingress reaches the
+single call graph above directly.
+
+Cutover is offline. It verifies no active old work, stops the process, archives
+old mutable state outside runtime discovery, creates fresh ledger/control/blob
+stores from resolved config, and runs verify-and-exit. Old data is never decoded
+or converted. Archive rollback is permitted only before the first v1 operation
+is accepted.
+
+## Acceptance invariants
+
+- No execution before durable Queued acceptance.
+- At most one state-authorized Running operation per Keeper.
+- Terminal operation and delivery rows never reopen.
+- A stale completion never settles current work.
+- A Running crash never causes automatic computation replay.
+- An Ambiguous delivery or Gate attempt never causes automatic resend.
+- Failed, Interrupted, and Ambiguous facts do not fence unrelated future work.
+- Keeper messaging creates no wait graph.
+- Every production ingress has one direct owner admission path.

--- a/lib/keeper_operation/dune
+++ b/lib/keeper_operation/dune
@@ -11,9 +11,9 @@
   keeper_operation_blob_store
   keeper_operation_store)
  (flags
-  (:standard -w +4 -w +33 -w +37))
+ (:standard -w +4 -w +33 -w +37))
  (libraries
- digestif
+  digestif
   eio
   masc.fs_compat
   masc.masc_random_id

--- a/lib/keeper_operation/dune
+++ b/lib/keeper_operation/dune
@@ -7,14 +7,17 @@
  (modules
   keeper_operation_id
   keeper_operation_request
+  keeper_operation_mailbox
   keeper_operation_blob_store
   keeper_operation_store)
  (flags
   (:standard -w +4 -w +33 -w +37))
  (libraries
-  digestif
+ digestif
+  eio
   masc.fs_compat
   masc.masc_random_id
   sqlite3
+  threads
   unix
   yojson))

--- a/lib/keeper_operation/dune
+++ b/lib/keeper_operation/dune
@@ -1,0 +1,20 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_operation)
+ (public_name masc.keeper_operation)
+ (wrapped false)
+ (modules
+  keeper_operation_id
+  keeper_operation_request
+  keeper_operation_blob_store
+  keeper_operation_store)
+ (flags
+  (:standard -w +4 -w +33 -w +37))
+ (libraries
+  digestif
+  masc.fs_compat
+  masc.masc_random_id
+  sqlite3
+  unix
+  yojson))

--- a/lib/keeper_operation/keeper_operation_blob_store.ml
+++ b/lib/keeper_operation/keeper_operation_blob_store.ml
@@ -1,0 +1,282 @@
+type t =
+  { root : string
+  ; base_path : string
+  }
+
+let ref_prefix = "sha256:"
+
+let validate_ref value =
+  let prefix_length = String.length ref_prefix in
+  let expected_length = prefix_length + 64 in
+  if String.length value <> expected_length
+  then Error (Printf.sprintf "blob ref must be exactly %d bytes" expected_length)
+  else if not (String.equal (String.sub value 0 prefix_length) ref_prefix)
+  then Error "blob ref must begin with sha256:"
+  else
+    let rec loop index =
+      if index = expected_length
+      then Ok value
+      else
+        match String.unsafe_get value index with
+        | '0' .. '9' | 'a' .. 'f' -> loop (index + 1)
+        | found ->
+          Error
+            (Printf.sprintf
+               "blob ref has non-lowercase-hex byte %C at index %d"
+               found
+               index)
+    in
+    loop prefix_length
+;;
+
+module Input_ref = struct
+  type t = string
+  let of_string = validate_ref
+  let to_string value = value
+  let equal = String.equal
+end
+
+module Outcome_ref = struct
+  type t = string
+  let of_string = validate_ref
+  let to_string value = value
+  let equal = String.equal
+end
+
+module State_ref = struct
+  type t = string
+  let of_string = validate_ref
+  let to_string value = value
+  let equal = String.equal
+end
+
+module Delivery_payload_ref = struct
+  type t = string
+  let of_string = validate_ref
+  let to_string value = value
+  let equal = String.equal
+end
+
+module Delivery_evidence_ref = struct
+  type t = string
+  let of_string = validate_ref
+  let to_string value = value
+  let equal = String.equal
+end
+
+type error =
+  | Invalid_ref of string
+  | Filesystem_error of string
+  | Read_error of string
+  | Integrity_error of string
+  | Kind_mismatch of
+      { expected : string
+      ; actual : string
+      }
+
+let error_to_string = function
+  | Invalid_ref detail -> "invalid operation blob ref: " ^ detail
+  | Filesystem_error detail -> "operation blob write failed: " ^ detail
+  | Read_error detail -> "operation blob read failed: " ^ detail
+  | Integrity_error detail -> "operation blob integrity failure: " ^ detail
+  | Kind_mismatch { expected; actual } ->
+    Printf.sprintf
+      "operation blob kind mismatch: expected=%s actual=%s"
+      expected
+      actual
+;;
+
+let create ~base_path ~keeper_runtime_dir =
+  { root = Filename.concat keeper_runtime_dir "operation-blobs/sha256"
+  ; base_path
+  }
+;;
+
+let root_dir t = t.root
+
+let digest_of_ref value =
+  String.sub value (String.length ref_prefix) 64
+;;
+
+let path_of_ref t value =
+  let digest = digest_of_ref value in
+  Filename.concat (Filename.concat t.root (String.sub digest 0 2)) digest
+;;
+
+let canonical_envelope ~kind payload =
+  Keeper_operation_request.Canonical_json.of_yojson
+    (`Assoc
+       [ "schema", `String "masc.keeper_operation.blob.v1"
+       ; "kind", `String kind
+       ; ( "payload"
+         , Keeper_operation_request.Canonical_json.to_yojson payload )
+       ])
+  |> Result.map_error Keeper_operation_request.Canonical_json.error_to_string
+;;
+
+let owned_read_error_to_string error =
+  Fs_compat.owned_regular_file_read_error_to_string error
+;;
+
+let read_exact t path =
+  match Fs_compat.load_owned_regular_file ~ownership_root:t.base_path path with
+  | Error error -> Error (Read_error (owned_read_error_to_string error))
+  | Ok value -> Ok value
+;;
+
+let ensure_shard t path =
+  let shard = Filename.dirname path in
+  try
+    Fs_compat.mkdir_p shard;
+    match Fs_compat.inspect_owned_directory_chain ~ownership_root:t.base_path shard with
+    | Ok (Fs_compat.Owned_directory _) -> Ok ()
+    | Ok Fs_compat.Owned_directory_missing ->
+      Error (Filesystem_error ("blob shard was not created: " ^ shard))
+    | Error rejection ->
+      Error
+        (Filesystem_error
+           (Fs_compat.owned_directory_chain_rejection_to_string rejection))
+  with
+  | Sys_error detail -> Error (Filesystem_error detail)
+  | Unix.Unix_error (code, operation, argument) ->
+    Error
+      (Filesystem_error
+         (Printf.sprintf
+            "%s(%s): %s"
+            operation
+            argument
+            (Unix.error_message code)))
+;;
+
+let put_common t ~kind payload =
+  match canonical_envelope ~kind payload with
+  | Error detail -> Error (Integrity_error detail)
+  | Ok envelope ->
+    let bytes = Keeper_operation_request.Canonical_json.to_bytes envelope in
+    let digest = Digestif.SHA256.(digest_string bytes |> to_hex) in
+    let reference = ref_prefix ^ digest in
+    let path = path_of_ref t reference in
+    (match ensure_shard t path with
+     | Error _ as error -> error
+     | Ok () ->
+       (match Fs_compat.save_file_atomic_strict path bytes with
+        | Error detail -> Error (Filesystem_error detail)
+        | Ok () ->
+          (match read_exact t path with
+           | Error _ as error -> error
+           | Ok None ->
+             Error
+               (Integrity_error
+                  "durably published blob disappeared before read-back")
+           | Ok (Some observed) ->
+             let observed_digest =
+               Digestif.SHA256.(digest_string observed |> to_hex)
+             in
+             if not (String.equal bytes observed)
+             then Error (Integrity_error "blob read-back bytes differ")
+             else if not (String.equal digest observed_digest)
+             then
+               Error
+                 (Integrity_error
+                    (Printf.sprintf
+                       "blob digest mismatch expected=%s actual=%s"
+                       digest
+                       observed_digest))
+             else Ok reference)))
+;;
+
+let exact_assoc_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Integrity_error (Printf.sprintf "blob is missing field %S" name))
+;;
+
+let decode_envelope ~expected_kind bytes =
+  match Keeper_operation_request.Canonical_json.of_string bytes with
+  | Error error ->
+    Error
+      (Integrity_error
+         (Keeper_operation_request.Canonical_json.error_to_string error))
+  | Ok canonical ->
+    if
+      not
+        (String.equal
+           bytes
+           (Keeper_operation_request.Canonical_json.to_bytes canonical))
+    then Error (Integrity_error "blob bytes are not canonical JSON")
+    else
+      match Keeper_operation_request.Canonical_json.to_yojson canonical with
+      | `Assoc fields when List.length fields = 3 ->
+        (match exact_assoc_field "schema" fields with
+         | Error _ as error -> error
+         | Ok (`String "masc.keeper_operation.blob.v1") ->
+           (match exact_assoc_field "kind" fields with
+            | Error _ as error -> error
+            | Ok (`String actual_kind) when String.equal actual_kind expected_kind ->
+              (match exact_assoc_field "payload" fields with
+               | Error _ as error -> error
+               | Ok payload ->
+                 Keeper_operation_request.Canonical_json.of_yojson payload
+                 |> Result.map_error (fun error ->
+                   Integrity_error
+                     (Keeper_operation_request.Canonical_json.error_to_string error)))
+            | Ok (`String actual) ->
+              Error (Kind_mismatch { expected = expected_kind; actual })
+            | Ok _ -> Error (Integrity_error "blob kind must be a string"))
+         | Ok (`String actual) ->
+           Error (Integrity_error ("unsupported blob schema: " ^ actual))
+         | Ok _ -> Error (Integrity_error "blob schema must be a string"))
+      | `Assoc _ -> Error (Integrity_error "blob must contain exactly three fields")
+      | _ -> Error (Integrity_error "blob envelope must be an object")
+;;
+
+let fetch_common t ~kind reference =
+  match validate_ref reference with
+  | Error detail -> Error (Invalid_ref detail)
+  | Ok reference ->
+    let expected_digest = digest_of_ref reference in
+    let path = path_of_ref t reference in
+    (match read_exact t path with
+     | Error _ as error -> error
+     | Ok None -> Ok None
+     | Ok (Some bytes) ->
+       let actual_digest = Digestif.SHA256.(digest_string bytes |> to_hex) in
+       if not (String.equal expected_digest actual_digest)
+       then
+         Error
+           (Integrity_error
+              (Printf.sprintf
+                 "blob digest mismatch expected=%s actual=%s"
+                 expected_digest
+                 actual_digest))
+       else decode_envelope ~expected_kind:kind bytes |> Result.map Option.some)
+;;
+
+let put_input t payload = put_common t ~kind:"input" payload
+let put_outcome t payload = put_common t ~kind:"outcome" payload
+let put_state t payload = put_common t ~kind:"state" payload
+let put_delivery_payload t payload = put_common t ~kind:"delivery_payload" payload
+let put_delivery_evidence t payload = put_common t ~kind:"delivery_evidence" payload
+
+let fetch_input t reference =
+  fetch_common t ~kind:"input" (Input_ref.to_string reference)
+;;
+
+let fetch_outcome t reference =
+  fetch_common t ~kind:"outcome" (Outcome_ref.to_string reference)
+;;
+
+let fetch_state t reference =
+  fetch_common t ~kind:"state" (State_ref.to_string reference)
+;;
+
+let fetch_delivery_payload t reference =
+  fetch_common t ~kind:"delivery_payload" (Delivery_payload_ref.to_string reference)
+;;
+
+let fetch_delivery_evidence t reference =
+  fetch_common
+    t
+    ~kind:"delivery_evidence"
+    (Delivery_evidence_ref.to_string reference)
+;;

--- a/lib/keeper_operation/keeper_operation_blob_store.ml
+++ b/lib/keeper_operation/keeper_operation_blob_store.ml
@@ -50,20 +50,6 @@ module State_ref = struct
   let equal = String.equal
 end
 
-module Delivery_payload_ref = struct
-  type t = string
-  let of_string = validate_ref
-  let to_string value = value
-  let equal = String.equal
-end
-
-module Delivery_evidence_ref = struct
-  type t = string
-  let of_string = validate_ref
-  let to_string value = value
-  let equal = String.equal
-end
-
 type error =
   | Invalid_ref of string
   | Filesystem_error of string
@@ -255,8 +241,6 @@ let fetch_common t ~kind reference =
 let put_input t payload = put_common t ~kind:"input" payload
 let put_outcome t payload = put_common t ~kind:"outcome" payload
 let put_state t payload = put_common t ~kind:"state" payload
-let put_delivery_payload t payload = put_common t ~kind:"delivery_payload" payload
-let put_delivery_evidence t payload = put_common t ~kind:"delivery_evidence" payload
 
 let fetch_input t reference =
   fetch_common t ~kind:"input" (Input_ref.to_string reference)
@@ -268,15 +252,4 @@ let fetch_outcome t reference =
 
 let fetch_state t reference =
   fetch_common t ~kind:"state" (State_ref.to_string reference)
-;;
-
-let fetch_delivery_payload t reference =
-  fetch_common t ~kind:"delivery_payload" (Delivery_payload_ref.to_string reference)
-;;
-
-let fetch_delivery_evidence t reference =
-  fetch_common
-    t
-    ~kind:"delivery_evidence"
-    (Delivery_evidence_ref.to_string reference)
 ;;

--- a/lib/keeper_operation/keeper_operation_blob_store.ml
+++ b/lib/keeper_operation/keeper_operation_blob_store.ml
@@ -112,16 +112,25 @@ let read_exact t path =
 
 let ensure_shard t path =
   let shard = Filename.dirname path in
+  let inspect () =
+    Fs_compat.inspect_owned_directory_chain ~ownership_root:t.base_path shard
+  in
+  let rejection error =
+    Error
+      (Filesystem_error
+         (Fs_compat.owned_directory_chain_rejection_to_string error))
+  in
   try
-    Fs_compat.mkdir_p shard;
-    match Fs_compat.inspect_owned_directory_chain ~ownership_root:t.base_path shard with
+    match inspect () with
+    | Error error -> rejection error
     | Ok (Fs_compat.Owned_directory _) -> Ok ()
     | Ok Fs_compat.Owned_directory_missing ->
-      Error (Filesystem_error ("blob shard was not created: " ^ shard))
-    | Error rejection ->
-      Error
-        (Filesystem_error
-           (Fs_compat.owned_directory_chain_rejection_to_string rejection))
+      Fs_compat.mkdir_p shard;
+      (match inspect () with
+       | Error error -> rejection error
+       | Ok (Fs_compat.Owned_directory _) -> Ok ()
+       | Ok Fs_compat.Owned_directory_missing ->
+         Error (Filesystem_error ("blob shard was not created: " ^ shard)))
   with
   | Sys_error detail -> Error (Filesystem_error detail)
   | Unix.Unix_error (code, operation, argument) ->

--- a/lib/keeper_operation/keeper_operation_blob_store.mli
+++ b/lib/keeper_operation/keeper_operation_blob_store.mli
@@ -1,0 +1,101 @@
+type t
+
+module Input_ref : sig
+  type t
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end
+
+module Outcome_ref : sig
+  type t
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end
+
+module State_ref : sig
+  type t
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end
+
+module Delivery_payload_ref : sig
+  type t
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end
+
+module Delivery_evidence_ref : sig
+  type t
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end
+
+type error =
+  | Invalid_ref of string
+  | Filesystem_error of string
+  | Read_error of string
+  | Integrity_error of string
+  | Kind_mismatch of
+      { expected : string
+      ; actual : string
+      }
+
+val error_to_string : error -> string
+
+val create : base_path:string -> keeper_runtime_dir:string -> t
+val root_dir : t -> string
+
+val put_input
+  :  t
+  -> Keeper_operation_request.Canonical_json.t
+  -> (Input_ref.t, error) result
+
+val put_outcome
+  :  t
+  -> Keeper_operation_request.Canonical_json.t
+  -> (Outcome_ref.t, error) result
+
+val put_state
+  :  t
+  -> Keeper_operation_request.Canonical_json.t
+  -> (State_ref.t, error) result
+
+val put_delivery_payload
+  :  t
+  -> Keeper_operation_request.Canonical_json.t
+  -> (Delivery_payload_ref.t, error) result
+
+val put_delivery_evidence
+  :  t
+  -> Keeper_operation_request.Canonical_json.t
+  -> (Delivery_evidence_ref.t, error) result
+
+val fetch_input
+  :  t
+  -> Input_ref.t
+  -> (Keeper_operation_request.Canonical_json.t option, error) result
+
+val fetch_outcome
+  :  t
+  -> Outcome_ref.t
+  -> (Keeper_operation_request.Canonical_json.t option, error) result
+
+val fetch_state
+  :  t
+  -> State_ref.t
+  -> (Keeper_operation_request.Canonical_json.t option, error) result
+
+val fetch_delivery_payload
+  :  t
+  -> Delivery_payload_ref.t
+  -> (Keeper_operation_request.Canonical_json.t option, error) result
+
+val fetch_delivery_evidence
+  :  t
+  -> Delivery_evidence_ref.t
+  -> (Keeper_operation_request.Canonical_json.t option, error) result

--- a/lib/keeper_operation/keeper_operation_blob_store.mli
+++ b/lib/keeper_operation/keeper_operation_blob_store.mli
@@ -21,20 +21,6 @@ module State_ref : sig
   val equal : t -> t -> bool
 end
 
-module Delivery_payload_ref : sig
-  type t
-  val of_string : string -> (t, string) result
-  val to_string : t -> string
-  val equal : t -> t -> bool
-end
-
-module Delivery_evidence_ref : sig
-  type t
-  val of_string : string -> (t, string) result
-  val to_string : t -> string
-  val equal : t -> t -> bool
-end
-
 type error =
   | Invalid_ref of string
   | Filesystem_error of string
@@ -65,16 +51,6 @@ val put_state
   -> Keeper_operation_request.Canonical_json.t
   -> (State_ref.t, error) result
 
-val put_delivery_payload
-  :  t
-  -> Keeper_operation_request.Canonical_json.t
-  -> (Delivery_payload_ref.t, error) result
-
-val put_delivery_evidence
-  :  t
-  -> Keeper_operation_request.Canonical_json.t
-  -> (Delivery_evidence_ref.t, error) result
-
 val fetch_input
   :  t
   -> Input_ref.t
@@ -88,14 +64,4 @@ val fetch_outcome
 val fetch_state
   :  t
   -> State_ref.t
-  -> (Keeper_operation_request.Canonical_json.t option, error) result
-
-val fetch_delivery_payload
-  :  t
-  -> Delivery_payload_ref.t
-  -> (Keeper_operation_request.Canonical_json.t option, error) result
-
-val fetch_delivery_evidence
-  :  t
-  -> Delivery_evidence_ref.t
   -> (Keeper_operation_request.Canonical_json.t option, error) result

--- a/lib/keeper_operation/keeper_operation_id.ml
+++ b/lib/keeper_operation/keeper_operation_id.ml
@@ -1,0 +1,96 @@
+let lowercase_hex_length = 64
+
+let validate_prefixed ~prefix value =
+  let prefix_length = String.length prefix in
+  let expected = prefix_length + lowercase_hex_length in
+  if String.length value <> expected
+  then
+    Error
+      (Printf.sprintf
+         "%s identifier must be exactly %d bytes"
+         prefix
+         expected)
+  else if not (String.equal (String.sub value 0 prefix_length) prefix)
+  then Error (Printf.sprintf "identifier must begin with %s" prefix)
+  else
+    let rec loop index =
+      if index = expected
+      then Ok value
+      else
+        match String.unsafe_get value index with
+        | '0' .. '9' | 'a' .. 'f' -> loop (index + 1)
+        | found ->
+          Error
+            (Printf.sprintf
+               "identifier has non-lowercase-hex byte %C at index %d"
+               found
+               index)
+    in
+    loop prefix_length
+;;
+
+let add_framed buffer value =
+  Buffer.add_string buffer (string_of_int (String.length value));
+  Buffer.add_char buffer ':';
+  Buffer.add_string buffer value
+;;
+
+let derive_hex ~domain parts =
+  let buffer = Buffer.create 256 in
+  add_framed buffer "masc.keeper.identity.v1";
+  add_framed buffer domain;
+  List.iter (add_framed buffer) parts;
+  Digestif.SHA256.(digest_string (Buffer.contents buffer) |> to_hex)
+;;
+
+module Operation_id = struct
+  type t = string
+
+  let prefix = "kop1:"
+  let generate () = prefix ^ Random_id.hex ~bytes:32
+  let of_string value = validate_prefixed ~prefix value
+  let to_string value = value
+  let equal = String.equal
+
+  let derived ~domain parts = prefix ^ derive_hex ~domain parts
+
+  let for_event ~keeper_key ~event_identity =
+    derived ~domain:"event" [ keeper_key; event_identity ]
+  ;;
+
+  let for_continuation ~parent ~continuation_ref =
+    derived ~domain:"continuation" [ to_string parent; continuation_ref ]
+  ;;
+
+  let for_keeper_message ~causing_operation ~ordinal ~target_keeper =
+    if ordinal < 0 then invalid_arg "Keeper message ordinal must be non-negative";
+    derived
+      ~domain:"keeper-message"
+      [ to_string causing_operation; string_of_int ordinal; target_keeper ]
+  ;;
+
+  let for_autonomous ~keeper_key ~candidate_identity =
+    derived ~domain:"autonomous" [ keeper_key; candidate_identity ]
+  ;;
+end
+
+module Delivery_id = struct
+  type t = string
+
+  let prefix = "kdel1:"
+  let of_string value = validate_prefixed ~prefix value
+  let to_string value = value
+  let equal = String.equal
+
+  let derive ~operation_id ~ordinal ~destination_ref ~payload_ref =
+    if ordinal < 0 then invalid_arg "Delivery ordinal must be non-negative";
+    prefix
+    ^ derive_hex
+        ~domain:"delivery"
+        [ Operation_id.to_string operation_id
+        ; string_of_int ordinal
+        ; destination_ref
+        ; payload_ref
+        ]
+  ;;
+end

--- a/lib/keeper_operation/keeper_operation_id.ml
+++ b/lib/keeper_operation/keeper_operation_id.ml
@@ -62,11 +62,13 @@ module Operation_id = struct
     derived ~domain:"continuation" [ to_string parent; continuation_ref ]
   ;;
 
-  let for_keeper_message ~causing_operation ~ordinal ~target_keeper =
+  let for_keeper_message ~causing_operation ~tool_call_id ~ordinal ~target_keeper =
+    if String.length tool_call_id = 0
+    then invalid_arg "Keeper message tool_call_id must not be empty";
     if ordinal < 0 then invalid_arg "Keeper message ordinal must be non-negative";
     derived
       ~domain:"keeper-message"
-      [ to_string causing_operation; string_of_int ordinal; target_keeper ]
+      [ to_string causing_operation; tool_call_id; string_of_int ordinal; target_keeper ]
   ;;
 
   let for_autonomous ~keeper_key ~candidate_identity =

--- a/lib/keeper_operation/keeper_operation_id.mli
+++ b/lib/keeper_operation/keeper_operation_id.mli
@@ -1,0 +1,38 @@
+module Operation_id : sig
+  type t
+
+  val generate : unit -> t
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+
+  val for_event : keeper_key:string -> event_identity:string -> t
+
+  val for_continuation
+    :  parent:t
+    -> continuation_ref:string
+    -> t
+
+  val for_keeper_message
+    :  causing_operation:t
+    -> ordinal:int
+    -> target_keeper:string
+    -> t
+
+  val for_autonomous : keeper_key:string -> candidate_identity:string -> t
+end
+
+module Delivery_id : sig
+  type t
+
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+
+  val derive
+    :  operation_id:Operation_id.t
+    -> ordinal:int
+    -> destination_ref:string
+    -> payload_ref:string
+    -> t
+end

--- a/lib/keeper_operation/keeper_operation_id.mli
+++ b/lib/keeper_operation/keeper_operation_id.mli
@@ -15,6 +15,7 @@ module Operation_id : sig
 
   val for_keeper_message
     :  causing_operation:t
+    -> tool_call_id:string
     -> ordinal:int
     -> target_keeper:string
     -> t

--- a/lib/keeper_operation/keeper_operation_mailbox.ml
+++ b/lib/keeper_operation/keeper_operation_mailbox.ml
@@ -1,0 +1,73 @@
+type 'a t =
+  { mutex : Stdlib.Mutex.t
+  ; condition : Eio.Condition.t
+  ; items : 'a Queue.t
+  ; capacity : int
+  ; mutable closed : bool
+  }
+
+type add_result =
+  | Added
+  | Full
+  | Closed
+
+let create ~capacity =
+  if capacity <= 0
+  then Error "mailbox capacity must be positive"
+  else
+    Ok
+      { mutex = Stdlib.Mutex.create ()
+      ; condition = Eio.Condition.create ()
+      ; items = Queue.create ()
+      ; capacity
+      ; closed = false
+      }
+;;
+
+let with_lock t f =
+  Stdlib.Mutex.lock t.mutex;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock t.mutex) f
+;;
+
+let try_add t item =
+  let result =
+    with_lock t (fun () ->
+      if t.closed
+      then Closed
+      else if Queue.length t.items >= t.capacity
+      then Full
+      else (
+        Queue.add item t.items;
+        Added))
+  in
+  (match result with
+   | Added -> Eio.Condition.broadcast t.condition
+   | Full | Closed -> ());
+  result
+;;
+
+let take_nonblocking t =
+  with_lock t (fun () ->
+    match Queue.take_opt t.items with
+    | Some item -> Some (Some item)
+    | None when t.closed -> Some None
+    | None -> None)
+;;
+
+let take t = Eio.Condition.loop_no_mutex t.condition (fun () -> take_nonblocking t)
+
+let close t =
+  let changed =
+    with_lock t (fun () ->
+      if t.closed
+      then false
+      else (
+        t.closed <- true;
+        true))
+  in
+  if changed then Eio.Condition.broadcast t.condition
+;;
+
+let length t = with_lock t (fun () -> Queue.length t.items)
+let capacity t = t.capacity
+let is_closed t = with_lock t (fun () -> t.closed)

--- a/lib/keeper_operation/keeper_operation_mailbox.mli
+++ b/lib/keeper_operation/keeper_operation_mailbox.mli
@@ -1,0 +1,19 @@
+(** Bounded non-blocking admission mailbox.
+
+    Producers never wait for capacity. The consumer may suspend until an item
+    arrives or the mailbox closes. *)
+
+type 'a t
+
+type add_result =
+  | Added
+  | Full
+  | Closed
+
+val create : capacity:int -> ('a t, string) result
+val try_add : 'a t -> 'a -> add_result
+val take : 'a t -> 'a option
+val close : 'a t -> unit
+val length : 'a t -> int
+val capacity : 'a t -> int
+val is_closed : 'a t -> bool

--- a/lib/keeper_operation/keeper_operation_request.ml
+++ b/lib/keeper_operation/keeper_operation_request.ml
@@ -1,0 +1,314 @@
+module Canonical_json = struct
+  type t = Yojson.Safe.t
+
+  type error =
+    | Duplicate_field of string
+    | Invalid_utf8 of string
+    | Non_finite_number
+    | Unsupported_json_shape
+    | Malformed_json of string
+
+  let error_to_string = function
+    | Duplicate_field field -> Printf.sprintf "duplicate JSON field %S" field
+    | Invalid_utf8 path -> path ^ " contains malformed UTF-8"
+    | Non_finite_number -> "JSON contains a non-finite number"
+    | Unsupported_json_shape -> "JSON contains a non-standard tuple or variant"
+    | Malformed_json detail -> "malformed JSON: " ^ detail
+  ;;
+
+  let valid_integer_literal value =
+    let length = String.length value in
+    let first_digit =
+      if length > 0 && Char.equal value.[0] '-' then 1 else 0
+    in
+    if first_digit = length
+    then false
+    else if Char.equal value.[first_digit] '0'
+    then first_digit + 1 = length
+    else
+      match value.[first_digit] with
+      | '1' .. '9' ->
+        let rec loop index =
+          if index = length
+          then true
+          else
+            match value.[index] with
+            | '0' .. '9' -> loop (index + 1)
+            | _ -> false
+        in
+        loop (first_digit + 1)
+      | _ -> false
+  ;;
+
+  let rec normalize ~path = function
+    | `Null as value -> Ok value
+    | `Bool _ as value -> Ok value
+    | `Int _ as value -> Ok value
+    | `Intlit value as json ->
+      if not (String.is_valid_utf_8 value)
+      then Error (Invalid_utf8 path)
+      else if valid_integer_literal value
+      then Ok json
+      else Error (Malformed_json (path ^ " contains an invalid integer literal"))
+    | `Float value as json ->
+      if Float.is_finite value then Ok json else Error Non_finite_number
+    | `String value as json ->
+      if String.is_valid_utf_8 value then Ok json else Error (Invalid_utf8 path)
+    | `List values ->
+      let rec loop index acc = function
+        | [] -> Ok (`List (List.rev acc))
+        | value :: rest ->
+          (match normalize ~path:(Printf.sprintf "%s[%d]" path index) value with
+           | Error _ as error -> error
+           | Ok value -> loop (index + 1) (value :: acc) rest)
+      in
+      loop 0 [] values
+    | `Assoc fields ->
+      let sorted = List.sort (fun (left, _) (right, _) -> String.compare left right) fields in
+      let rec loop previous acc = function
+        | [] -> Ok (`Assoc (List.rev acc))
+        | (field, value) :: rest ->
+          if not (String.is_valid_utf_8 field)
+          then Error (Invalid_utf8 (path ^ ".<field>"))
+          else if Option.exists (String.equal field) previous
+          then Error (Duplicate_field field)
+          else
+            (match normalize ~path:(path ^ "." ^ field) value with
+             | Error _ as error -> error
+             | Ok value -> loop (Some field) ((field, value) :: acc) rest)
+      in
+      loop None [] sorted
+    | `Tuple _ | `Variant _ -> Error Unsupported_json_shape
+  ;;
+
+  let of_yojson json = normalize ~path:"$" json
+
+  let of_string bytes =
+    if not (String.is_valid_utf_8 bytes)
+    then Error (Invalid_utf8 "JSON bytes")
+    else
+      try of_yojson (Yojson.Safe.from_string bytes) with
+      | Yojson.Json_error detail -> Error (Malformed_json detail)
+  ;;
+
+  let to_yojson value = value
+  let to_bytes value = Yojson.Safe.to_string value
+end
+
+type kind =
+  | Message
+  | Stimulus
+  | Autonomous
+
+let ( let* ) = Result.bind
+
+let kind_to_string = function
+  | Message -> "message"
+  | Stimulus -> "stimulus"
+  | Autonomous -> "autonomous"
+;;
+
+let valid_identity ~field value =
+  if String.equal value ""
+  then Error (field ^ " must not be empty")
+  else if not (String.is_valid_utf_8 value)
+  then Error (field ^ " contains malformed UTF-8")
+  else Ok value
+;;
+
+module Source_ref = struct
+  type connector =
+    | Dashboard
+    | Discord
+    | Slack
+
+  type t =
+    | Operator_message of { request_id : string }
+    | Connector_message of
+        { connector : connector
+        ; message_id : string
+        }
+    | Keeper_message of
+        { keeper_name : string
+        ; causing_operation_id : Keeper_operation_id.Operation_id.t
+        ; ordinal : int
+        }
+    | Event of { event_id : string }
+    | Continuation of
+        { causal_parent_operation_id : Keeper_operation_id.Operation_id.t
+        ; delta_ref : string
+        }
+    | Autonomous_candidate of { candidate_id : string }
+
+  let connector_to_string = function
+    | Dashboard -> "dashboard"
+    | Discord -> "discord"
+    | Slack -> "slack"
+  ;;
+
+  let to_canonical_json source =
+    let open Result in
+    let json =
+      match source with
+      | Operator_message { request_id } ->
+        let* request_id = valid_identity ~field:"operator request_id" request_id in
+        Ok
+          (`Assoc
+             [ "kind", `String "operator_message"
+             ; "request_id", `String request_id
+             ])
+      | Connector_message { connector; message_id } ->
+        let* message_id = valid_identity ~field:"connector message_id" message_id in
+        Ok
+          (`Assoc
+             [ "kind", `String "connector_message"
+             ; "connector", `String (connector_to_string connector)
+             ; "message_id", `String message_id
+             ])
+      | Keeper_message { keeper_name; causing_operation_id; ordinal } ->
+        let* keeper_name = valid_identity ~field:"source Keeper name" keeper_name in
+        if ordinal < 0
+        then Error "source Keeper message ordinal must be non-negative"
+        else
+          Ok
+            (`Assoc
+               [ "kind", `String "keeper_message"
+               ; "keeper_name", `String keeper_name
+               ; ( "causing_operation_id"
+                 , `String
+                     (Keeper_operation_id.Operation_id.to_string causing_operation_id) )
+               ; "ordinal", `Int ordinal
+               ])
+      | Event { event_id } ->
+        let* event_id = valid_identity ~field:"Event id" event_id in
+        Ok (`Assoc [ "kind", `String "event"; "event_id", `String event_id ])
+      | Continuation { causal_parent_operation_id; delta_ref } ->
+        let* delta_ref = valid_identity ~field:"continuation delta_ref" delta_ref in
+        Ok
+          (`Assoc
+             [ "kind", `String "continuation"
+             ; ( "causal_parent_operation_id"
+               , `String
+                   (Keeper_operation_id.Operation_id.to_string
+                      causal_parent_operation_id) )
+             ; "delta_ref", `String delta_ref
+             ])
+      | Autonomous_candidate { candidate_id } ->
+        let* candidate_id = valid_identity ~field:"autonomous candidate_id" candidate_id in
+        Ok
+          (`Assoc
+             [ "kind", `String "autonomous_candidate"
+             ; "candidate_id", `String candidate_id
+             ])
+    in
+    let* json = json in
+    Canonical_json.of_yojson json |> map_error Canonical_json.error_to_string
+  ;;
+end
+
+module Submitter_ref = struct
+  type t =
+    | Operator of { principal_id : string }
+    | Connector of { authenticated_identity : string }
+    | Keeper of { keeper_name : string }
+    | System
+
+  let to_canonical_json submitter =
+    let open Result in
+    let json =
+      match submitter with
+      | Operator { principal_id } ->
+        let* principal_id = valid_identity ~field:"operator principal_id" principal_id in
+        Ok
+          (`Assoc
+             [ "kind", `String "operator"
+             ; "principal_id", `String principal_id
+             ])
+      | Connector { authenticated_identity } ->
+        let* authenticated_identity =
+          valid_identity
+            ~field:"connector authenticated_identity"
+            authenticated_identity
+        in
+        Ok
+          (`Assoc
+             [ "kind", `String "connector"
+             ; "authenticated_identity", `String authenticated_identity
+             ])
+      | Keeper { keeper_name } ->
+        let* keeper_name = valid_identity ~field:"submitter Keeper name" keeper_name in
+        Ok
+          (`Assoc
+             [ "kind", `String "keeper"
+             ; "keeper_name", `String keeper_name
+             ])
+      | System -> Ok (`Assoc [ "kind", `String "system" ])
+    in
+    let* json = json in
+    Canonical_json.of_yojson json |> map_error Canonical_json.error_to_string
+  ;;
+end
+
+type t =
+  { operation_id : Keeper_operation_id.Operation_id.t
+  ; kind : kind
+  ; source_ref : Source_ref.t
+  ; submitter_ref : Submitter_ref.t
+  ; input : Canonical_json.t
+  ; canonical_bytes : string
+  ; request_digest : string
+  }
+
+let source_matches_kind kind source =
+  match kind, source with
+  | Message, (Source_ref.Operator_message _ | Connector_message _ | Keeper_message _) ->
+    true
+  | Stimulus, (Source_ref.Event _ | Continuation _) -> true
+  | Autonomous, Source_ref.Autonomous_candidate _ -> true
+  | Message, (Event _ | Continuation _ | Autonomous_candidate _)
+  | Stimulus, (Operator_message _ | Connector_message _ | Keeper_message _ | Autonomous_candidate _)
+  | Autonomous, (Operator_message _ | Connector_message _ | Keeper_message _ | Event _ | Continuation _) ->
+    false
+;;
+
+let make ~operation_id ~kind ~source_ref ~submitter_ref ~input =
+  let open Result in
+  if not (source_matches_kind kind source_ref)
+  then Error "operation kind does not match its typed source"
+  else
+    let* source_json = Source_ref.to_canonical_json source_ref in
+    let* submitter_json = Submitter_ref.to_canonical_json submitter_ref in
+    let envelope =
+      `Assoc
+        [ "schema", `String "masc.keeper_operation.request.v1"
+        ; "kind", `String (kind_to_string kind)
+        ; "source_ref", Canonical_json.to_yojson source_json
+        ; "submitter_ref", Canonical_json.to_yojson submitter_json
+        ; "input", Canonical_json.to_yojson input
+        ]
+    in
+    let* envelope =
+      Canonical_json.of_yojson envelope |> map_error Canonical_json.error_to_string
+    in
+    let canonical_bytes = Canonical_json.to_bytes envelope in
+    let request_digest =
+      Digestif.SHA256.(digest_string canonical_bytes |> to_hex)
+    in
+    Ok
+      { operation_id
+      ; kind
+      ; source_ref
+      ; submitter_ref
+      ; input
+      ; canonical_bytes
+      ; request_digest
+      }
+;;
+
+let operation_id t = t.operation_id
+let kind t = t.kind
+let source_ref t = t.source_ref
+let submitter_ref t = t.submitter_ref
+let input t = t.input
+let canonical_bytes t = t.canonical_bytes
+let request_digest t = t.request_digest

--- a/lib/keeper_operation/keeper_operation_request.ml
+++ b/lib/keeper_operation/keeper_operation_request.ml
@@ -116,6 +116,40 @@ let valid_identity ~field value =
   else Ok value
 ;;
 
+let assoc_fields ~surface canonical =
+  match Canonical_json.to_yojson canonical with
+  | `Assoc fields -> Ok fields
+  | _ -> Error (surface ^ " must be an object")
+;;
+
+let reject_unknown_fields ~surface ~allowed fields =
+  match List.find_opt (fun (field, _) -> not (List.mem field allowed)) fields with
+  | None -> Ok ()
+  | Some (field, _) ->
+    Error (Printf.sprintf "%s contains unsupported field %s" surface field)
+;;
+
+let required_string ~surface field fields =
+  match List.assoc_opt field fields with
+  | Some (`String value) -> valid_identity ~field:(surface ^ "." ^ field) value
+  | Some _ -> Error (surface ^ "." ^ field ^ " must be a string")
+  | None -> Error (surface ^ "." ^ field ^ " is required")
+;;
+
+let required_nonnegative_int ~surface field fields =
+  match List.assoc_opt field fields with
+  | Some (`Int value) when value >= 0 -> Ok value
+  | Some (`Int _) -> Error (surface ^ "." ^ field ^ " must be non-negative")
+  | Some _ -> Error (surface ^ "." ^ field ^ " must be an integer")
+  | None -> Error (surface ^ "." ^ field ^ " is required")
+;;
+
+let required_operation_id ~surface field fields =
+  let* value = required_string ~surface field fields in
+  Keeper_operation_id.Operation_id.of_string value
+  |> Result.map_error (fun detail -> surface ^ "." ^ field ^ ": " ^ detail)
+;;
+
 module Source_ref = struct
   type t =
     | Operator_message of { request_id : string }
@@ -217,6 +251,88 @@ module Source_ref = struct
     let* json = json in
     Canonical_json.of_yojson json |> map_error Canonical_json.error_to_string
   ;;
+
+  let of_canonical_json canonical =
+    let surface = "keeper_operation.source_ref" in
+    let* fields = assoc_fields ~surface canonical in
+    let* kind = required_string ~surface "kind" fields in
+    match kind with
+    | "operator_message" ->
+      let* () =
+        reject_unknown_fields ~surface ~allowed:[ "kind"; "request_id" ] fields
+      in
+      let* request_id = required_string ~surface "request_id" fields in
+      Ok (Operator_message { request_id })
+    | "discord_message" ->
+      let* () =
+        reject_unknown_fields
+          ~surface
+          ~allowed:[ "kind"; "guild_id"; "channel_id"; "message_id" ]
+          fields
+      in
+      let* guild_id = required_string ~surface "guild_id" fields in
+      let* channel_id = required_string ~surface "channel_id" fields in
+      let* message_id = required_string ~surface "message_id" fields in
+      Ok (Discord_message { guild_id; channel_id; message_id })
+    | "slack_message" ->
+      let* () =
+        reject_unknown_fields
+          ~surface
+          ~allowed:[ "kind"; "team_id"; "channel_id"; "message_ts" ]
+          fields
+      in
+      let* team_id = required_string ~surface "team_id" fields in
+      let* channel_id = required_string ~surface "channel_id" fields in
+      let* message_ts = required_string ~surface "message_ts" fields in
+      Ok (Slack_message { team_id; channel_id; message_ts })
+    | "keeper_message" ->
+      let* () =
+        reject_unknown_fields
+          ~surface
+          ~allowed:
+            [ "kind"
+            ; "keeper_name"
+            ; "causing_operation_id"
+            ; "tool_call_id"
+            ; "ordinal"
+            ]
+          fields
+      in
+      let* keeper_name = required_string ~surface "keeper_name" fields in
+      let* causing_operation_id =
+        required_operation_id ~surface "causing_operation_id" fields
+      in
+      let* tool_call_id = required_string ~surface "tool_call_id" fields in
+      let* ordinal = required_nonnegative_int ~surface "ordinal" fields in
+      Ok
+        (Keeper_message
+           { keeper_name; causing_operation_id; tool_call_id; ordinal })
+    | "event" ->
+      let* () =
+        reject_unknown_fields ~surface ~allowed:[ "kind"; "event_id" ] fields
+      in
+      let* event_id = required_string ~surface "event_id" fields in
+      Ok (Event { event_id })
+    | "continuation" ->
+      let* () =
+        reject_unknown_fields
+          ~surface
+          ~allowed:[ "kind"; "causal_parent_operation_id"; "delta_ref" ]
+          fields
+      in
+      let* causal_parent_operation_id =
+        required_operation_id ~surface "causal_parent_operation_id" fields
+      in
+      let* delta_ref = required_string ~surface "delta_ref" fields in
+      Ok (Continuation { causal_parent_operation_id; delta_ref })
+    | "autonomous_candidate" ->
+      let* () =
+        reject_unknown_fields ~surface ~allowed:[ "kind"; "candidate_id" ] fields
+      in
+      let* candidate_id = required_string ~surface "candidate_id" fields in
+      Ok (Autonomous_candidate { candidate_id })
+    | other -> Error (Printf.sprintf "%s.kind %S is unknown" surface other)
+  ;;
 end
 
 module Submitter_ref = struct
@@ -260,6 +376,40 @@ module Submitter_ref = struct
     let* json = json in
     Canonical_json.of_yojson json |> map_error Canonical_json.error_to_string
   ;;
+
+  let of_canonical_json canonical =
+    let surface = "keeper_operation.submitter_ref" in
+    let* fields = assoc_fields ~surface canonical in
+    let* kind = required_string ~surface "kind" fields in
+    match kind with
+    | "operator" ->
+      let* () =
+        reject_unknown_fields ~surface ~allowed:[ "kind"; "principal_id" ] fields
+      in
+      let* principal_id = required_string ~surface "principal_id" fields in
+      Ok (Operator { principal_id })
+    | "connector" ->
+      let* () =
+        reject_unknown_fields
+          ~surface
+          ~allowed:[ "kind"; "authenticated_identity" ]
+          fields
+      in
+      let* authenticated_identity =
+        required_string ~surface "authenticated_identity" fields
+      in
+      Ok (Connector { authenticated_identity })
+    | "keeper" ->
+      let* () =
+        reject_unknown_fields ~surface ~allowed:[ "kind"; "keeper_name" ] fields
+      in
+      let* keeper_name = required_string ~surface "keeper_name" fields in
+      Ok (Keeper { keeper_name })
+    | "system" ->
+      let* () = reject_unknown_fields ~surface ~allowed:[ "kind" ] fields in
+      Ok System
+    | other -> Error (Printf.sprintf "%s.kind %S is unknown" surface other)
+  ;;
 end
 
 type t =
@@ -284,11 +434,38 @@ let source_matches_kind kind source =
     false
 ;;
 
-let make ~operation_id ~kind ~source_ref ~submitter_ref ~input =
-  let open Result in
+let validate_persisted_identity ~kind ~source_ref ~submitter_ref =
   if not (source_matches_kind kind source_ref)
   then Error "operation kind does not match its typed source"
   else
+    let mismatch () =
+      Error "operation source and authenticated submitter do not match"
+    in
+    match source_ref with
+    | Source_ref.Operator_message _ ->
+      (match submitter_ref with
+       | Submitter_ref.Operator _ -> Ok ()
+       | Connector _ | Keeper _ | System -> mismatch ())
+    | Discord_message _ | Slack_message _ ->
+      (match submitter_ref with
+       | Submitter_ref.Connector _ -> Ok ()
+       | Operator _ | Keeper _ | System -> mismatch ())
+    | Keeper_message { keeper_name = source_keeper; _ } ->
+      (match submitter_ref with
+       | Submitter_ref.Keeper { keeper_name = submitter_keeper }
+         when String.equal source_keeper submitter_keeper -> Ok ()
+       | Keeper _ | Operator _ | Connector _ | System -> mismatch ())
+    | Event _ | Continuation _ | Autonomous_candidate _ ->
+      (match submitter_ref with
+       | Submitter_ref.System -> Ok ()
+       | Operator _ | Connector _ | Keeper _ -> mismatch ())
+;;
+
+let make ~operation_id ~kind ~source_ref ~submitter_ref ~input =
+  let open Result in
+  match validate_persisted_identity ~kind ~source_ref ~submitter_ref with
+  | Error _ as error -> error
+  | Ok () ->
     let* source_json = Source_ref.to_canonical_json source_ref in
     let* submitter_json = Submitter_ref.to_canonical_json submitter_ref in
     let envelope =

--- a/lib/keeper_operation/keeper_operation_request.ml
+++ b/lib/keeper_operation/keeper_operation_request.ml
@@ -117,20 +117,22 @@ let valid_identity ~field value =
 ;;
 
 module Source_ref = struct
-  type connector =
-    | Dashboard
-    | Discord
-    | Slack
-
   type t =
     | Operator_message of { request_id : string }
-    | Connector_message of
-        { connector : connector
+    | Discord_message of
+        { guild_id : string
+        ; channel_id : string
         ; message_id : string
+        }
+    | Slack_message of
+        { team_id : string
+        ; channel_id : string
+        ; message_ts : string
         }
     | Keeper_message of
         { keeper_name : string
         ; causing_operation_id : Keeper_operation_id.Operation_id.t
+        ; tool_call_id : string
         ; ordinal : int
         }
     | Event of { event_id : string }
@@ -139,12 +141,6 @@ module Source_ref = struct
         ; delta_ref : string
         }
     | Autonomous_candidate of { candidate_id : string }
-
-  let connector_to_string = function
-    | Dashboard -> "dashboard"
-    | Discord -> "discord"
-    | Slack -> "slack"
-  ;;
 
   let to_canonical_json source =
     let open Result in
@@ -157,16 +153,32 @@ module Source_ref = struct
              [ "kind", `String "operator_message"
              ; "request_id", `String request_id
              ])
-      | Connector_message { connector; message_id } ->
+      | Discord_message { guild_id; channel_id; message_id } ->
+        let* guild_id = valid_identity ~field:"Discord guild_id" guild_id in
+        let* channel_id = valid_identity ~field:"Discord channel_id" channel_id in
         let* message_id = valid_identity ~field:"connector message_id" message_id in
         Ok
           (`Assoc
-             [ "kind", `String "connector_message"
-             ; "connector", `String (connector_to_string connector)
+             [ "kind", `String "discord_message"
+             ; "guild_id", `String guild_id
+             ; "channel_id", `String channel_id
              ; "message_id", `String message_id
              ])
-      | Keeper_message { keeper_name; causing_operation_id; ordinal } ->
+      | Slack_message { team_id; channel_id; message_ts } ->
+        let* team_id = valid_identity ~field:"Slack team_id" team_id in
+        let* channel_id = valid_identity ~field:"Slack channel_id" channel_id in
+        let* message_ts = valid_identity ~field:"Slack message_ts" message_ts in
+        Ok
+          (`Assoc
+             [ "kind", `String "slack_message"
+             ; "team_id", `String team_id
+             ; "channel_id", `String channel_id
+             ; "message_ts", `String message_ts
+             ])
+      | Keeper_message
+          { keeper_name; causing_operation_id; tool_call_id; ordinal } ->
         let* keeper_name = valid_identity ~field:"source Keeper name" keeper_name in
+        let* tool_call_id = valid_identity ~field:"host tool_call_id" tool_call_id in
         if ordinal < 0
         then Error "source Keeper message ordinal must be non-negative"
         else
@@ -177,6 +189,7 @@ module Source_ref = struct
                ; ( "causing_operation_id"
                  , `String
                      (Keeper_operation_id.Operation_id.to_string causing_operation_id) )
+               ; "tool_call_id", `String tool_call_id
                ; "ordinal", `Int ordinal
                ])
       | Event { event_id } ->
@@ -261,13 +274,13 @@ type t =
 
 let source_matches_kind kind source =
   match kind, source with
-  | Message, (Source_ref.Operator_message _ | Connector_message _ | Keeper_message _) ->
+  | Message, (Source_ref.Operator_message _ | Discord_message _ | Slack_message _ | Keeper_message _) ->
     true
   | Stimulus, (Source_ref.Event _ | Continuation _) -> true
   | Autonomous, Source_ref.Autonomous_candidate _ -> true
   | Message, (Event _ | Continuation _ | Autonomous_candidate _)
-  | Stimulus, (Operator_message _ | Connector_message _ | Keeper_message _ | Autonomous_candidate _)
-  | Autonomous, (Operator_message _ | Connector_message _ | Keeper_message _ | Event _ | Continuation _) ->
+  | Stimulus, (Operator_message _ | Discord_message _ | Slack_message _ | Keeper_message _ | Autonomous_candidate _)
+  | Autonomous, (Operator_message _ | Discord_message _ | Slack_message _ | Keeper_message _ | Event _ | Continuation _) ->
     false
 ;;
 

--- a/lib/keeper_operation/keeper_operation_request.mli
+++ b/lib/keeper_operation/keeper_operation_request.mli
@@ -21,20 +21,22 @@ type kind =
   | Autonomous
 
 module Source_ref : sig
-  type connector =
-    | Dashboard
-    | Discord
-    | Slack
-
   type t =
     | Operator_message of { request_id : string }
-    | Connector_message of
-        { connector : connector
+    | Discord_message of
+        { guild_id : string
+        ; channel_id : string
         ; message_id : string
+        }
+    | Slack_message of
+        { team_id : string
+        ; channel_id : string
+        ; message_ts : string
         }
     | Keeper_message of
         { keeper_name : string
         ; causing_operation_id : Keeper_operation_id.Operation_id.t
+        ; tool_call_id : string
         ; ordinal : int
         }
     | Event of { event_id : string }

--- a/lib/keeper_operation/keeper_operation_request.mli
+++ b/lib/keeper_operation/keeper_operation_request.mli
@@ -1,0 +1,77 @@
+module Canonical_json : sig
+  type t
+
+  type error =
+    | Duplicate_field of string
+    | Invalid_utf8 of string
+    | Non_finite_number
+    | Unsupported_json_shape
+    | Malformed_json of string
+
+  val of_yojson : Yojson.Safe.t -> (t, error) result
+  val of_string : string -> (t, error) result
+  val to_yojson : t -> Yojson.Safe.t
+  val to_bytes : t -> string
+  val error_to_string : error -> string
+end
+
+type kind =
+  | Message
+  | Stimulus
+  | Autonomous
+
+module Source_ref : sig
+  type connector =
+    | Dashboard
+    | Discord
+    | Slack
+
+  type t =
+    | Operator_message of { request_id : string }
+    | Connector_message of
+        { connector : connector
+        ; message_id : string
+        }
+    | Keeper_message of
+        { keeper_name : string
+        ; causing_operation_id : Keeper_operation_id.Operation_id.t
+        ; ordinal : int
+        }
+    | Event of { event_id : string }
+    | Continuation of
+        { causal_parent_operation_id : Keeper_operation_id.Operation_id.t
+        ; delta_ref : string
+        }
+    | Autonomous_candidate of { candidate_id : string }
+
+  val to_canonical_json : t -> (Canonical_json.t, string) result
+end
+
+module Submitter_ref : sig
+  type t =
+    | Operator of { principal_id : string }
+    | Connector of { authenticated_identity : string }
+    | Keeper of { keeper_name : string }
+    | System
+
+  val to_canonical_json : t -> (Canonical_json.t, string) result
+end
+
+type t
+
+val make
+  :  operation_id:Keeper_operation_id.Operation_id.t
+  -> kind:kind
+  -> source_ref:Source_ref.t
+  -> submitter_ref:Submitter_ref.t
+  -> input:Canonical_json.t
+  -> (t, string) result
+
+val operation_id : t -> Keeper_operation_id.Operation_id.t
+val kind : t -> kind
+val source_ref : t -> Source_ref.t
+val submitter_ref : t -> Submitter_ref.t
+val input : t -> Canonical_json.t
+val canonical_bytes : t -> string
+val request_digest : t -> string
+val kind_to_string : kind -> string

--- a/lib/keeper_operation/keeper_operation_request.mli
+++ b/lib/keeper_operation/keeper_operation_request.mli
@@ -47,6 +47,7 @@ module Source_ref : sig
     | Autonomous_candidate of { candidate_id : string }
 
   val to_canonical_json : t -> (Canonical_json.t, string) result
+  val of_canonical_json : Canonical_json.t -> (t, string) result
 end
 
 module Submitter_ref : sig
@@ -57,7 +58,14 @@ module Submitter_ref : sig
     | System
 
   val to_canonical_json : t -> (Canonical_json.t, string) result
+  val of_canonical_json : Canonical_json.t -> (t, string) result
 end
+
+val validate_persisted_identity
+  :  kind:kind
+  -> source_ref:Source_ref.t
+  -> submitter_ref:Submitter_ref.t
+  -> (unit, string) result
 
 type t
 

--- a/lib/keeper_operation/keeper_operation_store.ml
+++ b/lib/keeper_operation/keeper_operation_store.ml
@@ -34,7 +34,10 @@ type error =
 
 type t =
   { db : Sqlite3.db
+  ; blobs : Keeper_operation_blob_store.t
+  ; lock : Stdlib.Mutex.t
   ; mutable closed : bool
+  ; mutable write_blocked : string option
   }
 
 let ( let* ) = Result.bind
@@ -75,6 +78,11 @@ let error_to_string = function
       (state_to_string state)
   | Store_error detail -> "Keeper operation store failure: " ^ detail
   | Integrity_error detail -> "Keeper operation store integrity failure: " ^ detail
+;;
+
+let blob_error stage error =
+  Integrity_error
+    (stage ^ ": " ^ Keeper_operation_blob_store.error_to_string error)
 ;;
 
 let sqlite_error db operation rc =
@@ -169,7 +177,7 @@ let database_user_version = 1L
 let database_file = "operations.sqlite3"
 
 let operations_table_sql =
-  "CREATE TABLE operations (queue_seq INTEGER PRIMARY KEY, operation_id TEXT UNIQUE NOT NULL CHECK (length(operation_id) = 69 AND substr(operation_id, 1, 5) = 'kop1:' AND substr(operation_id, 6) NOT GLOB '*[^0-9a-f]*'), kind TEXT NOT NULL CHECK (kind IN ('message', 'stimulus', 'autonomous')), source_ref TEXT NOT NULL CHECK (length(source_ref) > 0), submitter_ref TEXT NOT NULL CHECK (length(submitter_ref) > 0), state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'settled', 'cancelled', 'interrupted')), request_digest TEXT NOT NULL CHECK (length(request_digest) = 64 AND request_digest NOT GLOB '*[^0-9a-f]*'), input_ref TEXT NOT NULL CHECK (length(input_ref) = 71 AND substr(input_ref, 1, 7) = 'sha256:' AND substr(input_ref, 8) NOT GLOB '*[^0-9a-f]*'), base_state_ref TEXT, outcome_ref TEXT, next_state_ref TEXT, created_at REAL NOT NULL CHECK (created_at >= 0), started_at REAL, finished_at REAL, CHECK (base_state_ref IS NULL OR (length(base_state_ref) = 71 AND substr(base_state_ref, 1, 7) = 'sha256:' AND substr(base_state_ref, 8) NOT GLOB '*[^0-9a-f]*')), CHECK (outcome_ref IS NULL OR (length(outcome_ref) = 71 AND substr(outcome_ref, 1, 7) = 'sha256:' AND substr(outcome_ref, 8) NOT GLOB '*[^0-9a-f]*')), CHECK (next_state_ref IS NULL OR (length(next_state_ref) = 71 AND substr(next_state_ref, 1, 7) = 'sha256:' AND substr(next_state_ref, 8) NOT GLOB '*[^0-9a-f]*')), CHECK ((state = 'queued' AND started_at IS NULL AND finished_at IS NULL AND base_state_ref IS NULL AND outcome_ref IS NULL AND next_state_ref IS NULL) OR (state = 'running' AND started_at IS NOT NULL AND finished_at IS NULL AND outcome_ref IS NULL AND next_state_ref IS NULL) OR (state = 'settled' AND started_at IS NOT NULL AND finished_at IS NOT NULL AND outcome_ref IS NOT NULL) OR (state = 'cancelled' AND started_at IS NULL AND finished_at IS NOT NULL AND base_state_ref IS NULL AND outcome_ref IS NULL AND next_state_ref IS NULL) OR (state = 'interrupted' AND started_at IS NOT NULL AND finished_at IS NOT NULL AND outcome_ref IS NOT NULL AND next_state_ref IS NULL))) STRICT"
+  "CREATE TABLE operations (queue_seq INTEGER PRIMARY KEY, operation_id TEXT UNIQUE NOT NULL CHECK (length(operation_id) = 69 AND substr(operation_id, 1, 5) = 'kop1:' AND substr(operation_id, 6) NOT GLOB '*[^0-9a-f]*'), kind TEXT NOT NULL CHECK (kind IN ('message', 'stimulus', 'autonomous')), source_ref TEXT NOT NULL CHECK (length(source_ref) > 0), submitter_ref TEXT NOT NULL CHECK (length(submitter_ref) > 0), state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'settled', 'cancelled', 'interrupted')), request_digest TEXT NOT NULL CHECK (length(request_digest) = 64 AND request_digest NOT GLOB '*[^0-9a-f]*'), input_ref TEXT NOT NULL CHECK (length(input_ref) = 71 AND substr(input_ref, 1, 7) = 'sha256:' AND substr(input_ref, 8) NOT GLOB '*[^0-9a-f]*'), base_state_ref TEXT, outcome_ref TEXT, next_state_ref TEXT, created_at REAL NOT NULL CHECK (created_at >= 0), started_at REAL, finished_at REAL, CHECK (base_state_ref IS NULL OR (length(base_state_ref) = 71 AND substr(base_state_ref, 1, 7) = 'sha256:' AND substr(base_state_ref, 8) NOT GLOB '*[^0-9a-f]*')), CHECK (outcome_ref IS NULL OR (length(outcome_ref) = 71 AND substr(outcome_ref, 1, 7) = 'sha256:' AND substr(outcome_ref, 8) NOT GLOB '*[^0-9a-f]*')), CHECK (next_state_ref IS NULL OR (length(next_state_ref) = 71 AND substr(next_state_ref, 1, 7) = 'sha256:' AND substr(next_state_ref, 8) NOT GLOB '*[^0-9a-f]*')), CHECK ((state = 'queued' AND started_at IS NULL AND finished_at IS NULL AND base_state_ref IS NULL AND outcome_ref IS NULL AND next_state_ref IS NULL) OR (state = 'running' AND started_at IS NOT NULL AND finished_at IS NULL AND outcome_ref IS NULL AND next_state_ref IS NULL) OR (state = 'settled' AND started_at IS NOT NULL AND finished_at IS NOT NULL AND outcome_ref IS NOT NULL) OR (state = 'cancelled' AND started_at IS NULL AND finished_at IS NOT NULL AND base_state_ref IS NULL AND outcome_ref IS NOT NULL AND next_state_ref IS NULL) OR (state = 'interrupted' AND started_at IS NOT NULL AND finished_at IS NOT NULL AND outcome_ref IS NOT NULL AND next_state_ref IS NULL))) STRICT"
 ;;
 
 let deliveries_table_sql =
@@ -327,6 +335,7 @@ let initialize_database db path =
   in
   match body with
   | Error error ->
+    (* See the returned schema error; rollback is cleanup and cannot replace it. *)
     ignore (exec db ~operation:"rollback schema transaction" "ROLLBACK");
     Error error
   | Ok () ->
@@ -367,7 +376,139 @@ let read_schema_objects db =
        loop [])
 ;;
 
-let validate_database db =
+let canonical_of_persisted_bytes field bytes =
+  match Keeper_operation_request.Canonical_json.of_string bytes with
+  | Ok value
+    when String.equal
+           bytes
+           (Keeper_operation_request.Canonical_json.to_bytes value) -> Ok value
+  | Ok _ -> Error (Integrity_error (field ^ " is not canonical JSON"))
+  | Error error ->
+    Error
+      (Integrity_error
+         (field
+          ^ ": "
+          ^ Keeper_operation_request.Canonical_json.error_to_string error))
+;;
+
+let required_blob stage fetch reference =
+  match fetch reference with
+  | Error error -> Error (blob_error stage error)
+  | Ok None -> Error (Integrity_error (stage ^ " does not resolve to a blob"))
+  | Ok (Some payload) -> Ok payload
+;;
+
+let validate_optional_blob stage decode fetch value =
+  if String.equal value ""
+  then Ok ()
+  else
+    let* reference =
+      decode value
+      |> Result.map_error (fun detail -> Integrity_error (stage ^ ": " ^ detail))
+    in
+    let* _ = required_blob stage fetch reference in
+    Ok ()
+;;
+
+let validate_operation_row blobs stmt =
+  let* operation_id =
+    Keeper_operation_id.Operation_id.of_string (Sqlite3.column_text stmt 0)
+    |> Result.map_error (fun detail -> Integrity_error ("operation_id: " ^ detail))
+  in
+  let* kind = kind_of_string (Sqlite3.column_text stmt 1) in
+  let* source_json =
+    canonical_of_persisted_bytes "source_ref" (Sqlite3.column_text stmt 2)
+  in
+  let* source_ref =
+    Keeper_operation_request.Source_ref.of_canonical_json source_json
+    |> Result.map_error (fun detail -> Integrity_error detail)
+  in
+  let* submitter_json =
+    canonical_of_persisted_bytes "submitter_ref" (Sqlite3.column_text stmt 3)
+  in
+  let* submitter_ref =
+    Keeper_operation_request.Submitter_ref.of_canonical_json submitter_json
+    |> Result.map_error (fun detail -> Integrity_error detail)
+  in
+  let* () =
+    Keeper_operation_request.validate_persisted_identity
+      ~kind
+      ~source_ref
+      ~submitter_ref
+    |> Result.map_error (fun detail -> Integrity_error detail)
+  in
+  let request_digest = Sqlite3.column_text stmt 4 in
+  let* input_ref =
+    Keeper_operation_blob_store.Input_ref.of_string (Sqlite3.column_text stmt 5)
+    |> Result.map_error (fun detail -> Integrity_error ("input_ref: " ^ detail))
+  in
+  let* input =
+    required_blob
+      "input_ref"
+      (Keeper_operation_blob_store.fetch_input blobs)
+      input_ref
+  in
+  let* request =
+    Keeper_operation_request.make
+      ~operation_id
+      ~kind
+      ~source_ref
+      ~submitter_ref
+      ~input
+    |> Result.map_error (fun detail -> Integrity_error detail)
+  in
+  let* () =
+    if
+      String.equal
+        request_digest
+        (Keeper_operation_request.request_digest request)
+    then Ok ()
+    else Error (Integrity_error "request_digest does not match persisted request")
+  in
+  let optional_text index =
+    if Sqlite3.column_is_null stmt index then "" else Sqlite3.column_text stmt index
+  in
+  let* () =
+    validate_optional_blob
+      "base_state_ref"
+      Keeper_operation_blob_store.State_ref.of_string
+      (Keeper_operation_blob_store.fetch_state blobs)
+      (optional_text 6)
+  in
+  let* () =
+    validate_optional_blob
+      "outcome_ref"
+      Keeper_operation_blob_store.Outcome_ref.of_string
+      (Keeper_operation_blob_store.fetch_outcome blobs)
+      (optional_text 7)
+  in
+  validate_optional_blob
+    "next_state_ref"
+    Keeper_operation_blob_store.State_ref.of_string
+    (Keeper_operation_blob_store.fetch_state blobs)
+    (optional_text 8)
+;;
+
+let validate_operation_rows db blobs =
+  with_statement
+    db
+    ~operation:"validate operation rows"
+    "SELECT operation_id, kind, source_ref, submitter_ref, request_digest, input_ref, base_state_ref, outcome_ref, next_state_ref FROM operations ORDER BY queue_seq"
+    (fun stmt ->
+       let rec loop () =
+         let rc = Sqlite3.step stmt in
+         if rc = Sqlite3.Rc.DONE
+         then Ok ()
+         else if rc = Sqlite3.Rc.ROW
+         then (
+           let* () = validate_operation_row blobs stmt in
+           loop ())
+         else Error (Store_error (sqlite_error db "validate operation rows" rc))
+       in
+       loop ())
+;;
+
+let validate_database db blobs =
   let* application_id =
     single_int64 db ~operation:"read application id" "PRAGMA application_id"
   in
@@ -401,9 +542,9 @@ let validate_database db =
         let* integrity =
         single_text db ~operation:"run integrity check" "PRAGMA integrity_check"
         in
-        if String.equal integrity "ok"
-        then Ok ()
-        else Error (Integrity_error ("SQLite integrity_check: " ^ integrity))
+        if not (String.equal integrity "ok")
+        then Error (Integrity_error ("SQLite integrity_check: " ^ integrity))
+        else validate_operation_rows db blobs
 ;;
 
 let inspect_database_path path =
@@ -431,38 +572,54 @@ let close_db db =
 
 let open_or_create ~base_path ~keeper_runtime_dir =
   let path = Filename.concat keeper_runtime_dir database_file in
+  let inspect_runtime_dir () =
+    Fs_compat.inspect_owned_directory_chain
+      ~ownership_root:base_path
+      keeper_runtime_dir
+    |> Result.map_error (fun rejection ->
+      Integrity_error
+        (Fs_compat.owned_directory_chain_rejection_to_string rejection))
+  in
   try
-    Fs_compat.mkdir_p keeper_runtime_dir;
-    let* ownership =
-      Fs_compat.inspect_owned_directory_chain
-        ~ownership_root:base_path
-        keeper_runtime_dir
-      |> Result.map_error (fun rejection ->
-        Integrity_error
-          (Fs_compat.owned_directory_chain_rejection_to_string rejection))
-    in
+    let* ownership = inspect_runtime_dir () in
     let* () =
       match ownership with
       | Fs_compat.Owned_directory _ -> Ok ()
       | Fs_compat.Owned_directory_missing ->
-        Error (Store_error "Keeper runtime directory was not created")
+        Fs_compat.mkdir_p keeper_runtime_dir;
+        (match inspect_runtime_dir () with
+         | Ok (Fs_compat.Owned_directory _) -> Ok ()
+         | Ok Fs_compat.Owned_directory_missing ->
+           Error (Store_error "Keeper runtime directory was not created")
+         | Error _ as error -> error)
     in
     let* existed = inspect_database_path path in
+    let blobs =
+      Keeper_operation_blob_store.create ~base_path ~keeper_runtime_dir
+    in
     let db = Sqlite3.db_open ~mutex:`FULL path in
     let opened =
       if existed
       then
-        let* () = validate_database db in
+        let* () = validate_database db blobs in
         let* () = configure_connection db in
-        validate_database db
+        validate_database db blobs
       else
         let* () = configure_connection db in
         let* () = initialize_database db path in
-        validate_database db
+        validate_database db blobs
     in
     (match opened with
-     | Ok () -> Ok { db; closed = false }
+     | Ok () ->
+       Ok
+         { db
+         ; blobs
+         ; lock = Stdlib.Mutex.create ()
+         ; closed = false
+         ; write_blocked = None
+         }
      | Error error ->
+       (* See the returned validation error; close is cleanup for the rejected handle. *)
        ignore (close_db db);
        Error error)
   with
@@ -478,12 +635,30 @@ let ensure_open t =
   if t.closed then Error (Store_error "operation store is closed") else Ok ()
 ;;
 
+let ensure_writable t =
+  let* () = ensure_open t in
+  match t.write_blocked with
+  | None -> Ok ()
+  | Some detail ->
+    Error
+      (Store_error
+         ("operation store writes are blocked after uncertain durable state: "
+          ^ detail))
+;;
+
+let block_writes t error =
+  t.write_blocked <- Some (error_to_string error)
+;;
+
+let with_store_lock t f = Stdlib.Mutex.protect t.lock f
+
 let close t =
-  if t.closed
-  then Ok ()
-  else (
-    t.closed <- true;
-    close_db t.db)
+  with_store_lock t (fun () ->
+    if t.closed
+    then Ok ()
+    else (
+      t.closed <- true;
+      close_db t.db))
 ;;
 
 let nullable_text stmt index =
@@ -495,17 +670,7 @@ let nullable_float stmt index =
 ;;
 
 let parse_canonical field bytes =
-  match Keeper_operation_request.Canonical_json.of_string bytes with
-  | Ok value
-    when String.equal bytes (Keeper_operation_request.Canonical_json.to_bytes value) ->
-    Ok value
-  | Ok _ -> Error (Integrity_error (field ^ " is not canonical JSON"))
-  | Error error ->
-    Error
-      (Integrity_error
-         (field
-          ^ ": "
-          ^ Keeper_operation_request.Canonical_json.error_to_string error))
+  canonical_of_persisted_bytes field bytes
 ;;
 
 let parse_ref field decode = function
@@ -524,6 +689,21 @@ let operation_of_row stmt =
   let* kind = kind_of_string (Sqlite3.column_text stmt 2) in
   let* source_ref = parse_canonical "source_ref" (Sqlite3.column_text stmt 3) in
   let* submitter_ref = parse_canonical "submitter_ref" (Sqlite3.column_text stmt 4) in
+  let* typed_source =
+    Keeper_operation_request.Source_ref.of_canonical_json source_ref
+    |> Result.map_error (fun detail -> Integrity_error detail)
+  in
+  let* typed_submitter =
+    Keeper_operation_request.Submitter_ref.of_canonical_json submitter_ref
+    |> Result.map_error (fun detail -> Integrity_error detail)
+  in
+  let* () =
+    Keeper_operation_request.validate_persisted_identity
+      ~kind
+      ~source_ref:typed_source
+      ~submitter_ref:typed_submitter
+    |> Result.map_error (fun detail -> Integrity_error detail)
+  in
   let* state = state_of_string (Sqlite3.column_text stmt 5) in
   let* input_ref =
     Keeper_operation_blob_store.Input_ref.of_string (Sqlite3.column_text stmt 7)
@@ -569,7 +749,7 @@ let select_columns =
   "queue_seq, operation_id, kind, source_ref, submitter_ref, state, request_digest, input_ref, base_state_ref, outcome_ref, next_state_ref, created_at, started_at, finished_at"
 ;;
 
-let find t operation_id =
+let find_unlocked t operation_id =
   let* () = ensure_open t in
   with_statement
     t.db
@@ -597,6 +777,10 @@ let find t operation_id =
        else Error (Store_error (sqlite_error t.db "find operation" rc)))
 ;;
 
+let find t operation_id =
+  with_store_lock t (fun () -> find_unlocked t operation_id)
+;;
+
 let begin_immediate t = exec t.db ~operation:"begin operation transaction" "BEGIN IMMEDIATE"
 let rollback t = exec t.db ~operation:"rollback operation transaction" "ROLLBACK"
 let commit t = exec t.db ~operation:"commit operation transaction" "COMMIT"
@@ -605,10 +789,26 @@ type admission =
   | Accepted of operation
   | Replayed of operation
 
-let exact_request_row request input_ref row =
-  String.equal row.request_digest (Keeper_operation_request.request_digest request)
-  && Keeper_operation_blob_store.Input_ref.equal row.input_ref input_ref
-  && row.kind = Keeper_operation_request.kind request
+let canonical_equal left right =
+  String.equal
+    (Keeper_operation_request.Canonical_json.to_bytes left)
+    (Keeper_operation_request.Canonical_json.to_bytes right)
+;;
+
+let exact_request_row t request row =
+  if
+    not
+      (String.equal
+         row.request_digest
+         (Keeper_operation_request.request_digest request))
+    || row.kind <> Keeper_operation_request.kind request
+  then Ok false
+  else
+    match Keeper_operation_blob_store.fetch_input t.blobs row.input_ref with
+    | Error error -> Error (blob_error "input_ref" error)
+    | Ok None -> Error (Integrity_error "input_ref does not resolve to a blob")
+    | Ok (Some input) ->
+      Ok (canonical_equal input (Keeper_operation_request.input request))
 ;;
 
 let insert_queued t ~now ~request ~input_ref =
@@ -652,38 +852,63 @@ let insert_queued t ~now ~request ~input_ref =
        bind_all 1 values)
 ;;
 
-let admit t ~now ~request ~input_ref =
-  let* () = ensure_open t in
+let admit_unlocked t ~now ~request =
+  let* () = ensure_writable t in
   let* () = validate_time "created_at" now in
   let operation_id = Keeper_operation_request.operation_id request in
-  let* () = begin_immediate t in
-  match find t operation_id with
-  | Error error ->
-    ignore (rollback t);
-    Error error
+  match find_unlocked t operation_id with
+  | Error _ as error -> error
   | Ok (Some existing) ->
-    ignore (rollback t);
-    if exact_request_row request input_ref existing
-    then Ok (Replayed existing)
-    else Error (Identity_conflict operation_id)
+    let* exact = exact_request_row t request existing in
+    if exact then Ok (Replayed existing) else Error (Identity_conflict operation_id)
   | Ok None ->
-    (match insert_queued t ~now ~request ~input_ref with
+    let* input_ref =
+      Keeper_operation_blob_store.put_input
+        t.blobs
+        (Keeper_operation_request.input request)
+      |> Result.map_error (blob_error "publish input blob")
+    in
+    let* () = begin_immediate t in
+    (match find_unlocked t operation_id with
      | Error error ->
+       (* See the returned read error; rollback only abandons this admission attempt. *)
        ignore (rollback t);
        Error error
-     | Ok () ->
-       (match commit t with
-        | Error commit_error ->
+     | Ok (Some existing) ->
+       (* See exact replay handling below; rollback closes the unused transaction. *)
+       ignore (rollback t);
+       let* exact = exact_request_row t request existing in
+       if exact then Ok (Replayed existing) else Error (Identity_conflict operation_id)
+     | Ok None ->
+       (match insert_queued t ~now ~request ~input_ref with
+        | Error error ->
+          (* See the returned insert error; rollback only abandons this admission attempt. *)
           ignore (rollback t);
-          (match find t operation_id with
-           | Ok (Some row) when exact_request_row request input_ref row ->
-             Ok (Accepted row)
-           | Ok _ | Error _ -> Error commit_error)
+          Error error
         | Ok () ->
-          (match find t operation_id with
-           | Ok (Some row) -> Ok (Accepted row)
-           | Ok None -> Error (Integrity_error "accepted operation disappeared")
-           | Error _ as error -> error)))
+          (match commit t with
+           | Error commit_error ->
+             (* See exact read-back below; commit outcome, not rollback status, is authoritative. *)
+             ignore (rollback t);
+             (match find_unlocked t operation_id with
+              | Ok (Some row) ->
+                (match exact_request_row t request row with
+                 | Ok true -> Ok (Accepted row)
+                 | Ok false | Error _ ->
+                   block_writes t commit_error;
+                   Error commit_error)
+              | Ok None | Error _ ->
+                block_writes t commit_error;
+                Error commit_error)
+           | Ok () ->
+             (match find_unlocked t operation_id with
+              | Ok (Some row) -> Ok (Accepted row)
+              | Ok None -> Error (Integrity_error "accepted operation disappeared")
+              | Error _ as error -> error))))
+;;
+
+let admit t ~now ~request =
+  with_store_lock t (fun () -> admit_unlocked t ~now ~request)
 ;;
 
 let running_count t =
@@ -719,9 +944,33 @@ let first_queued_id t =
        else Error (Store_error (sqlite_error t.db "select queued operation" rc)))
 ;;
 
-let start_next t ~now ~base_state_ref =
-  let* () = ensure_open t in
+let publish_optional_state t ~stage = function
+  | None -> Ok None
+  | Some state ->
+    Keeper_operation_blob_store.put_state t.blobs state
+    |> Result.map Option.some
+    |> Result.map_error (blob_error stage)
+;;
+
+let same_optional_state_ref left right =
+  match left, right with
+  | None, None -> true
+  | Some left, Some right -> Keeper_operation_blob_store.State_ref.equal left right
+  | None, Some _ | Some _, None -> false
+;;
+
+let exact_running_row ~now ~base_state_ref row =
+  row.state = Running
+  && Option.exists (Float.equal now) row.started_at
+  && same_optional_state_ref base_state_ref row.base_state_ref
+;;
+
+let start_next_unlocked t ~now ~base_state =
+  let* () = ensure_writable t in
   let* () = validate_time "started_at" now in
+  let* base_state_ref =
+    publish_optional_state t ~stage:"publish base state blob" base_state
+  in
   let* () = begin_immediate t in
   let body =
     let* running = running_count t in
@@ -764,14 +1013,32 @@ let start_next t ~now ~base_state_ref =
   in
   match body with
   | Error error ->
+    (* See the returned transition error; rollback only abandons this start attempt. *)
     ignore (rollback t);
     Error error
   | Ok None ->
-    let* () = commit t in
-    Ok None
+    (match commit t with
+     | Ok () -> Ok None
+     | Error error ->
+       (* See the returned commit error; no operation row was selected to read back. *)
+       ignore (rollback t);
+       Error error)
   | Ok (Some operation_id) ->
-    let* () = commit t in
-    find t operation_id
+    (match commit t with
+     | Ok () -> find_unlocked t operation_id
+     | Error commit_error ->
+       (* See exact Running read-back below; durable row state is authoritative. *)
+       ignore (rollback t);
+       (match find_unlocked t operation_id with
+        | Ok (Some row) when exact_running_row ~now ~base_state_ref row ->
+          Ok (Some row)
+        | Ok _ | Error _ ->
+          block_writes t commit_error;
+          Error commit_error))
+;;
+
+let start_next t ~now ~base_state =
+  with_store_lock t (fun () -> start_next_unlocked t ~now ~base_state)
 ;;
 
 let update_terminal t ~operation_id ~from_state ~to_state ~now ~outcome_ref ~next_state_ref =
@@ -838,14 +1105,41 @@ let update_terminal t ~operation_id ~from_state ~to_state ~now ~outcome_ref ~nex
        else Error (Integrity_error "terminal operation compare-and-update failed"))
 ;;
 
-let cancel_queued t ~now operation_id =
-  let* () = ensure_open t in
+let cancellation_evidence operation_id =
+  Keeper_operation_request.Canonical_json.of_yojson
+    (`Assoc
+       [ "kind", `String "cancelled"
+       ; ( "operation_id"
+         , `String
+             (Keeper_operation_id.Operation_id.to_string operation_id) )
+       ])
+  |> Result.map_error (fun error ->
+    Integrity_error
+      (Keeper_operation_request.Canonical_json.error_to_string error))
+;;
+
+let exact_terminal_row ~target_state ~now ~outcome_ref ~next_state_ref row =
+  row.state = target_state
+  && Option.exists
+       (Keeper_operation_blob_store.Outcome_ref.equal outcome_ref)
+       row.outcome_ref
+  && same_optional_state_ref next_state_ref row.next_state_ref
+  && Option.exists (Float.equal now) row.finished_at
+;;
+
+let cancel_queued_unlocked t ~now operation_id =
+  let* () = ensure_writable t in
   let* () = validate_time "finished_at" now in
-  let* existing = find t operation_id in
+  let* existing = find_unlocked t operation_id in
   match existing with
   | None -> Error (Invalid_input "operation does not exist")
   | Some ({ state = Cancelled; _ } as operation) -> Ok operation
   | Some { state = Queued; _ } ->
+    let* evidence = cancellation_evidence operation_id in
+    let* outcome_ref =
+      Keeper_operation_blob_store.put_outcome t.blobs evidence
+      |> Result.map_error (blob_error "publish cancellation evidence")
+    in
     let* () = begin_immediate t in
     (match
        update_terminal
@@ -854,49 +1148,89 @@ let cancel_queued t ~now operation_id =
          ~from_state:Queued
          ~to_state:Cancelled
          ~now
-         ~outcome_ref:None
+         ~outcome_ref:(Some outcome_ref)
          ~next_state_ref:None
      with
      | Error error ->
+       (* See the returned transition error; rollback only abandons this cancellation. *)
        ignore (rollback t);
        Error error
      | Ok () ->
-       let* () = commit t in
-       (match find t operation_id with
-        | Ok (Some operation) -> Ok operation
-        | Ok None -> Error (Integrity_error "cancelled operation disappeared")
-        | Error _ as error -> error))
+       (match commit t with
+        | Ok () ->
+          (match find_unlocked t operation_id with
+           | Ok (Some operation) -> Ok operation
+           | Ok None -> Error (Integrity_error "cancelled operation disappeared")
+           | Error _ as error -> error)
+        | Error commit_error ->
+          (* See exact Cancelled read-back below; durable row state is authoritative. *)
+          ignore (rollback t);
+          (match find_unlocked t operation_id with
+           | Ok (Some row)
+             when exact_terminal_row
+                    ~target_state:Cancelled
+                    ~now
+                    ~outcome_ref
+                    ~next_state_ref:None
+                    row -> Ok row
+           | Ok _ | Error _ ->
+             block_writes t commit_error;
+             Error commit_error)))
   | Some ({ state = (Running | Settled | Interrupted); _ } as operation) ->
     Error (State_conflict { operation_id; state = operation.state })
 ;;
 
-let finish_running t ~now ~operation_id ~target_state ~outcome_ref ~next_state_ref =
-  let* () = ensure_open t in
+let cancel_queued t ~now operation_id =
+  with_store_lock t (fun () -> cancel_queued_unlocked t ~now operation_id)
+;;
+
+let stored_terminal_payload_matches t ~outcome ~next_state operation =
+  match operation.outcome_ref with
+  | None -> Error (Integrity_error "terminal operation has no outcome_ref")
+  | Some outcome_ref ->
+    let* stored_outcome =
+      match Keeper_operation_blob_store.fetch_outcome t.blobs outcome_ref with
+      | Error error -> Error (blob_error "outcome_ref" error)
+      | Ok None -> Error (Integrity_error "outcome_ref does not resolve to a blob")
+      | Ok (Some payload) -> Ok payload
+    in
+    if not (canonical_equal stored_outcome outcome)
+    then Ok false
+    else
+      match next_state, operation.next_state_ref with
+      | None, None -> Ok true
+      | Some expected, Some state_ref ->
+        (match Keeper_operation_blob_store.fetch_state t.blobs state_ref with
+         | Error error -> Error (blob_error "next_state_ref" error)
+         | Ok None ->
+           Error (Integrity_error "next_state_ref does not resolve to a blob")
+         | Ok (Some actual) -> Ok (canonical_equal expected actual))
+      | None, Some _ | Some _, None -> Ok false
+;;
+
+let finish_running_unlocked t ~now ~operation_id ~target_state ~outcome ~next_state =
+  let* () = ensure_writable t in
   let* () = validate_time "finished_at" now in
-  let* existing = find t operation_id in
+  let* existing = find_unlocked t operation_id in
   match existing with
   | None -> Error (Invalid_input "operation does not exist")
   | Some operation ->
     if operation.state = target_state
-    then
-      let same_outcome =
-        Option.exists
-          (Keeper_operation_blob_store.Outcome_ref.equal outcome_ref)
-          operation.outcome_ref
+    then (
+      let* exact =
+        stored_terminal_payload_matches t ~outcome ~next_state operation
       in
-      let same_next =
-        match next_state_ref, operation.next_state_ref with
-        | None, None -> true
-        | Some left, Some right ->
-          Keeper_operation_blob_store.State_ref.equal left right
-        | None, Some _ | Some _, None -> false
-      in
-      if same_outcome && same_next
-      then Ok operation
-      else Error (State_conflict { operation_id; state = operation.state })
+      if exact then Ok operation else Error (State_conflict { operation_id; state = operation.state }))
     else
       match operation.state with
       | Running ->
+        let* outcome_ref =
+          Keeper_operation_blob_store.put_outcome t.blobs outcome
+          |> Result.map_error (blob_error "publish terminal outcome")
+        in
+        let* next_state_ref =
+          publish_optional_state t ~stage:"publish next state blob" next_state
+        in
         let* () = begin_immediate t in
         (match
            update_terminal
@@ -909,40 +1243,58 @@ let finish_running t ~now ~operation_id ~target_state ~outcome_ref ~next_state_r
              ~next_state_ref
          with
          | Error error ->
+           (* See the returned transition error; rollback only abandons this settlement. *)
            ignore (rollback t);
            Error error
          | Ok () ->
-           let* () = commit t in
-           (match find t operation_id with
-            | Ok (Some terminal) -> Ok terminal
-            | Ok None -> Error (Integrity_error "terminal operation disappeared")
-            | Error _ as error -> error))
+           (match commit t with
+            | Ok () ->
+              (match find_unlocked t operation_id with
+               | Ok (Some terminal) -> Ok terminal
+               | Ok None -> Error (Integrity_error "terminal operation disappeared")
+               | Error _ as error -> error)
+            | Error commit_error ->
+              (* See exact terminal read-back below; durable row state is authoritative. *)
+              ignore (rollback t);
+              (match find_unlocked t operation_id with
+               | Ok (Some row)
+                 when exact_terminal_row
+                        ~target_state
+                        ~now
+                        ~outcome_ref
+                        ~next_state_ref
+                        row -> Ok row
+               | Ok _ | Error _ ->
+                 block_writes t commit_error;
+                 Error commit_error)))
       | Queued | Settled | Cancelled | Interrupted ->
         Error (State_conflict { operation_id; state = operation.state })
 ;;
 
-let interrupt_running t ~now ~operation_id ~evidence_ref =
-  finish_running
-    t
-    ~now
-    ~operation_id
-    ~target_state:Interrupted
-    ~outcome_ref:evidence_ref
-    ~next_state_ref:None
+let interrupt_running t ~now ~operation_id ~evidence =
+  with_store_lock t (fun () ->
+    finish_running_unlocked
+      t
+      ~now
+      ~operation_id
+      ~target_state:Interrupted
+      ~outcome:evidence
+      ~next_state:None)
 ;;
 
-let settle t ~now ~operation_id ~outcome_ref ~next_state_ref =
-  finish_running
-    t
-    ~now
-    ~operation_id
-    ~target_state:Settled
-    ~outcome_ref
-    ~next_state_ref
+let settle t ~now ~operation_id ~outcome ~next_state =
+  with_store_lock t (fun () ->
+    finish_running_unlocked
+      t
+      ~now
+      ~operation_id
+      ~target_state:Settled
+      ~outcome
+      ~next_state)
 ;;
 
-let set_paused t value =
-  let* () = ensure_open t in
+let set_paused_unlocked t value =
+  let* () = ensure_writable t in
   let* () =
     with_statement
       t.db
@@ -964,7 +1316,11 @@ let set_paused t value =
   else Error (Integrity_error "keeper_control contains an invalid row count")
 ;;
 
-let paused t =
+let set_paused t value =
+  with_store_lock t (fun () -> set_paused_unlocked t value)
+;;
+
+let paused_unlocked t =
   let* () = ensure_open t in
   let* value =
     single_int64
@@ -979,7 +1335,13 @@ let paused t =
   else Error (Integrity_error "keeper_control.paused is outside its domain")
 ;;
 
-let count_operations t =
+let paused t = with_store_lock t (fun () -> paused_unlocked t)
+
+let count_operations_unlocked t =
   let* () = ensure_open t in
   single_int64 t.db ~operation:"count operations" "SELECT COUNT(*) FROM operations"
+;;
+
+let count_operations t =
+  with_store_lock t (fun () -> count_operations_unlocked t)
 ;;

--- a/lib/keeper_operation/keeper_operation_store.ml
+++ b/lib/keeper_operation/keeper_operation_store.ml
@@ -1,0 +1,933 @@
+type operation_state =
+  | Queued
+  | Running
+  | Settled
+  | Cancelled
+  | Interrupted
+
+type operation =
+  { queue_seq : int64
+  ; operation_id : Keeper_operation_id.Operation_id.t
+  ; kind : Keeper_operation_request.kind
+  ; source_ref : Keeper_operation_request.Canonical_json.t
+  ; submitter_ref : Keeper_operation_request.Canonical_json.t
+  ; state : operation_state
+  ; request_digest : string
+  ; input_ref : Keeper_operation_blob_store.Input_ref.t
+  ; base_state_ref : Keeper_operation_blob_store.State_ref.t option
+  ; outcome_ref : Keeper_operation_blob_store.Outcome_ref.t option
+  ; next_state_ref : Keeper_operation_blob_store.State_ref.t option
+  ; created_at : float
+  ; started_at : float option
+  ; finished_at : float option
+  }
+
+type error =
+  | Invalid_input of string
+  | Identity_conflict of Keeper_operation_id.Operation_id.t
+  | State_conflict of
+      { operation_id : Keeper_operation_id.Operation_id.t
+      ; state : operation_state
+      }
+  | Store_error of string
+  | Integrity_error of string
+
+type t =
+  { db : Sqlite3.db
+  ; mutable closed : bool
+  }
+
+let ( let* ) = Result.bind
+
+let state_to_string = function
+  | Queued -> "queued"
+  | Running -> "running"
+  | Settled -> "settled"
+  | Cancelled -> "cancelled"
+  | Interrupted -> "interrupted"
+;;
+
+let state_of_string = function
+  | "queued" -> Ok Queued
+  | "running" -> Ok Running
+  | "settled" -> Ok Settled
+  | "cancelled" -> Ok Cancelled
+  | "interrupted" -> Ok Interrupted
+  | value -> Error (Integrity_error ("unknown operation state: " ^ value))
+;;
+
+let kind_of_string = function
+  | "message" -> Ok Keeper_operation_request.Message
+  | "stimulus" -> Ok Keeper_operation_request.Stimulus
+  | "autonomous" -> Ok Keeper_operation_request.Autonomous
+  | value -> Error (Integrity_error ("unknown operation kind: " ^ value))
+;;
+
+let error_to_string = function
+  | Invalid_input detail -> "invalid Keeper operation input: " ^ detail
+  | Identity_conflict operation_id ->
+    "Keeper operation identity conflict: "
+    ^ Keeper_operation_id.Operation_id.to_string operation_id
+  | State_conflict { operation_id; state } ->
+    Printf.sprintf
+      "Keeper operation state conflict: operation_id=%s state=%s"
+      (Keeper_operation_id.Operation_id.to_string operation_id)
+      (state_to_string state)
+  | Store_error detail -> "Keeper operation store failure: " ^ detail
+  | Integrity_error detail -> "Keeper operation store integrity failure: " ^ detail
+;;
+
+let sqlite_error db operation rc =
+  Printf.sprintf
+    "%s: rc=%s detail=%s"
+    operation
+    (Sqlite3.Rc.to_string rc)
+    (Sqlite3.errmsg db)
+;;
+
+let exec db ~operation sql =
+  let rc = Sqlite3.exec db sql in
+  if Sqlite3.Rc.is_success rc
+  then Ok ()
+  else Error (Store_error (sqlite_error db operation rc))
+;;
+
+let prepare db ~operation sql =
+  try Ok (Sqlite3.prepare db sql) with
+  | Sqlite3.Error detail -> Error (Store_error (operation ^ ": " ^ detail))
+;;
+
+let finalize db stmt result =
+  let finalize_result =
+    try
+      let rc = Sqlite3.finalize stmt in
+      if Sqlite3.Rc.is_success rc
+      then Ok ()
+      else Error (Store_error (sqlite_error db "finalize statement" rc))
+    with
+    | Sqlite3.Error detail -> Error (Store_error ("finalize statement: " ^ detail))
+  in
+  match result, finalize_result with
+  | Ok value, Ok () -> Ok value
+  | Error _ as error, Ok () -> error
+  | Ok _, (Error _ as error) -> error
+  | Error first, Error second ->
+    Error (Store_error (error_to_string first ^ "; " ^ error_to_string second))
+;;
+
+let with_statement db ~operation sql f =
+  let* stmt = prepare db ~operation sql in
+  let result =
+    try f stmt with
+    | Sqlite3.Error detail -> Error (Store_error (operation ^ ": " ^ detail))
+  in
+  finalize db stmt result
+;;
+
+let bind db stmt ~operation index data =
+  let rc = Sqlite3.bind stmt index data in
+  if Sqlite3.Rc.is_success rc
+  then Ok ()
+  else Error (Store_error (sqlite_error db operation rc))
+;;
+
+let expect_done db stmt ~operation =
+  let rc = Sqlite3.step stmt in
+  if rc = Sqlite3.Rc.DONE
+  then Ok ()
+  else Error (Store_error (sqlite_error db operation rc))
+;;
+
+let single_int64 db ~operation sql =
+  with_statement db ~operation sql (fun stmt ->
+    let rc = Sqlite3.step stmt in
+    if rc = Sqlite3.Rc.ROW
+    then (
+      let value = Sqlite3.column_int64 stmt 0 in
+      let terminal_rc = Sqlite3.step stmt in
+      if terminal_rc = Sqlite3.Rc.DONE
+      then Ok value
+      else Error (Store_error (sqlite_error db operation terminal_rc)))
+    else Error (Store_error (sqlite_error db operation rc)))
+;;
+
+let single_text db ~operation sql =
+  with_statement db ~operation sql (fun stmt ->
+    let rc = Sqlite3.step stmt in
+    if rc = Sqlite3.Rc.ROW
+    then (
+      let value = Sqlite3.column_text stmt 0 in
+      let terminal_rc = Sqlite3.step stmt in
+      if terminal_rc = Sqlite3.Rc.DONE
+      then Ok value
+      else Error (Store_error (sqlite_error db operation terminal_rc)))
+    else Error (Store_error (sqlite_error db operation rc)))
+;;
+
+let database_application_id = 0x4d4b4f50L
+let database_user_version = 1L
+let database_file = "operations.sqlite3"
+
+let operations_table_sql =
+  "CREATE TABLE operations (queue_seq INTEGER PRIMARY KEY, operation_id TEXT UNIQUE NOT NULL CHECK (length(operation_id) = 69 AND substr(operation_id, 1, 5) = 'kop1:' AND substr(operation_id, 6) NOT GLOB '*[^0-9a-f]*'), kind TEXT NOT NULL CHECK (kind IN ('message', 'stimulus', 'autonomous')), source_ref TEXT NOT NULL CHECK (length(source_ref) > 0), submitter_ref TEXT NOT NULL CHECK (length(submitter_ref) > 0), state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'settled', 'cancelled', 'interrupted')), request_digest TEXT NOT NULL CHECK (length(request_digest) = 64 AND request_digest NOT GLOB '*[^0-9a-f]*'), input_ref TEXT NOT NULL CHECK (length(input_ref) = 71 AND substr(input_ref, 1, 7) = 'sha256:' AND substr(input_ref, 8) NOT GLOB '*[^0-9a-f]*'), base_state_ref TEXT, outcome_ref TEXT, next_state_ref TEXT, created_at REAL NOT NULL CHECK (created_at >= 0), started_at REAL, finished_at REAL, CHECK (base_state_ref IS NULL OR (length(base_state_ref) = 71 AND substr(base_state_ref, 1, 7) = 'sha256:' AND substr(base_state_ref, 8) NOT GLOB '*[^0-9a-f]*')), CHECK (outcome_ref IS NULL OR (length(outcome_ref) = 71 AND substr(outcome_ref, 1, 7) = 'sha256:' AND substr(outcome_ref, 8) NOT GLOB '*[^0-9a-f]*')), CHECK (next_state_ref IS NULL OR (length(next_state_ref) = 71 AND substr(next_state_ref, 1, 7) = 'sha256:' AND substr(next_state_ref, 8) NOT GLOB '*[^0-9a-f]*')), CHECK ((state = 'queued' AND started_at IS NULL AND finished_at IS NULL AND base_state_ref IS NULL AND outcome_ref IS NULL AND next_state_ref IS NULL) OR (state = 'running' AND started_at IS NOT NULL AND finished_at IS NULL AND outcome_ref IS NULL AND next_state_ref IS NULL) OR (state = 'settled' AND started_at IS NOT NULL AND finished_at IS NOT NULL AND outcome_ref IS NOT NULL) OR (state = 'cancelled' AND started_at IS NULL AND finished_at IS NOT NULL AND base_state_ref IS NULL AND outcome_ref IS NULL AND next_state_ref IS NULL) OR (state = 'interrupted' AND started_at IS NOT NULL AND finished_at IS NOT NULL AND outcome_ref IS NOT NULL AND next_state_ref IS NULL))) STRICT"
+;;
+
+let deliveries_table_sql =
+  "CREATE TABLE deliveries (delivery_seq INTEGER PRIMARY KEY, delivery_id TEXT UNIQUE NOT NULL CHECK (length(delivery_id) = 70 AND substr(delivery_id, 1, 6) = 'kdel1:' AND substr(delivery_id, 7) NOT GLOB '*[^0-9a-f]*'), operation_id TEXT NOT NULL REFERENCES operations(operation_id), destination_ref TEXT NOT NULL CHECK (length(destination_ref) > 0), state TEXT NOT NULL CHECK (state IN ('pending', 'attempting', 'delivered', 'failed', 'ambiguous')), payload_ref TEXT NOT NULL CHECK (length(payload_ref) = 71 AND substr(payload_ref, 1, 7) = 'sha256:' AND substr(payload_ref, 8) NOT GLOB '*[^0-9a-f]*'), connector_message_id TEXT, evidence_ref TEXT, created_at REAL NOT NULL CHECK (created_at >= 0), started_at REAL, finished_at REAL, CHECK (evidence_ref IS NULL OR (length(evidence_ref) = 71 AND substr(evidence_ref, 1, 7) = 'sha256:' AND substr(evidence_ref, 8) NOT GLOB '*[^0-9a-f]*')), CHECK ((state = 'pending' AND started_at IS NULL AND finished_at IS NULL AND connector_message_id IS NULL AND evidence_ref IS NULL) OR (state = 'attempting' AND started_at IS NOT NULL AND finished_at IS NULL AND connector_message_id IS NULL AND evidence_ref IS NULL) OR (state IN ('delivered', 'failed', 'ambiguous') AND started_at IS NOT NULL AND finished_at IS NOT NULL AND evidence_ref IS NOT NULL))) STRICT"
+;;
+
+let keeper_control_table_sql =
+  "CREATE TABLE keeper_control (singleton INTEGER PRIMARY KEY CHECK (singleton = 1), paused INTEGER NOT NULL CHECK (paused IN (0, 1))) STRICT"
+;;
+
+let queued_index_sql =
+  "CREATE INDEX operations_queued_fifo ON operations(queue_seq) WHERE state = 'queued'"
+;;
+
+let running_index_sql =
+  "CREATE UNIQUE INDEX operations_single_running ON operations(state) WHERE state = 'running'"
+;;
+
+let pending_delivery_index_sql =
+  "CREATE INDEX deliveries_pending_fifo ON deliveries(delivery_seq) WHERE state = 'pending'"
+;;
+
+let expected_schema_objects =
+  [ "index", "deliveries_pending_fifo", pending_delivery_index_sql
+  ; "index", "operations_queued_fifo", queued_index_sql
+  ; "index", "operations_single_running", running_index_sql
+  ; "table", "deliveries", deliveries_table_sql
+  ; "table", "keeper_control", keeper_control_table_sql
+  ; "table", "operations", operations_table_sql
+  ]
+;;
+
+let validate_time field value =
+  if Float.is_finite value && value >= 0.
+  then Ok ()
+  else Error (Invalid_input (field ^ " must be a finite non-negative timestamp"))
+;;
+
+let configure_connection db =
+  let* mode =
+    single_text db ~operation:"set DELETE journal mode" "PRAGMA journal_mode=DELETE"
+  in
+  let* () =
+    if String.equal mode "delete"
+    then Ok ()
+    else Error (Store_error ("SQLite refused DELETE journal mode: " ^ mode))
+  in
+  let* () = exec db ~operation:"set FULL synchronous" "PRAGMA synchronous=FULL" in
+  let* () = exec db ~operation:"enable foreign keys" "PRAGMA foreign_keys=ON" in
+  let* synchronous =
+    single_int64 db ~operation:"read synchronous mode" "PRAGMA synchronous"
+  in
+  let* foreign_keys =
+    single_int64 db ~operation:"read foreign key mode" "PRAGMA foreign_keys"
+  in
+  if not (Int64.equal synchronous 2L)
+  then Error (Store_error "SQLite synchronous mode is not FULL")
+  else if not (Int64.equal foreign_keys 1L)
+  then Error (Store_error "SQLite foreign key enforcement is disabled")
+  else Ok ()
+;;
+
+let fsync_directory path =
+  let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
+  match Unix.fsync fd with
+  | () -> Unix.close fd
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    (try Unix.close fd with _ -> ());
+    Printexc.raise_with_backtrace exn backtrace
+;;
+
+let initialize_database db path =
+  let* () = exec db ~operation:"begin schema transaction" "BEGIN EXCLUSIVE" in
+  let body =
+    let* () = exec db ~operation:"create operations" operations_table_sql in
+    let* () = exec db ~operation:"create deliveries" deliveries_table_sql in
+    let* () = exec db ~operation:"create keeper control" keeper_control_table_sql in
+    let* () = exec db ~operation:"create queued index" queued_index_sql in
+    let* () = exec db ~operation:"create running index" running_index_sql in
+    let* () =
+      exec db ~operation:"create pending delivery index" pending_delivery_index_sql
+    in
+    let* () =
+      exec
+        db
+        ~operation:"initialize keeper control"
+        "INSERT INTO keeper_control(singleton, paused) VALUES (1, 0)"
+    in
+    let* () =
+      exec
+        db
+        ~operation:"set application id"
+        (Printf.sprintf "PRAGMA application_id=%Ld" database_application_id)
+    in
+    let* () =
+      exec
+        db
+        ~operation:"set user version"
+        (Printf.sprintf "PRAGMA user_version=%Ld" database_user_version)
+    in
+    exec db ~operation:"commit schema transaction" "COMMIT"
+  in
+  match body with
+  | Error error ->
+    ignore (exec db ~operation:"rollback schema transaction" "ROLLBACK");
+    Error error
+  | Ok () ->
+    (try
+       fsync_directory (Filename.dirname path);
+       Ok ()
+     with
+     | Sys_error detail -> Error (Store_error detail)
+     | Unix.Unix_error (code, operation, argument) ->
+       Error
+         (Store_error
+            (Printf.sprintf
+               "%s(%s): %s"
+               operation
+               argument
+               (Unix.error_message code))))
+;;
+
+let read_schema_objects db =
+  with_statement
+    db
+    ~operation:"read schema objects"
+    "SELECT type, name, sql FROM sqlite_schema WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' ORDER BY type, name"
+    (fun stmt ->
+       let rec loop acc =
+         let rc = Sqlite3.step stmt in
+         if rc = Sqlite3.Rc.DONE
+         then Ok (List.rev acc)
+         else if rc = Sqlite3.Rc.ROW
+         then
+           loop
+             (( Sqlite3.column_text stmt 0
+              , Sqlite3.column_text stmt 1
+              , Sqlite3.column_text stmt 2 )
+              :: acc)
+         else Error (Store_error (sqlite_error db "read schema objects" rc))
+       in
+       loop [])
+;;
+
+let validate_database db =
+  let* application_id =
+    single_int64 db ~operation:"read application id" "PRAGMA application_id"
+  in
+  let* user_version =
+    single_int64 db ~operation:"read user version" "PRAGMA user_version"
+  in
+  if not (Int64.equal application_id database_application_id)
+  then
+    Error
+      (Integrity_error
+         (Printf.sprintf "unsupported application_id=%Ld" application_id))
+  else if not (Int64.equal user_version database_user_version)
+  then
+    Error
+      (Integrity_error
+         (Printf.sprintf "unsupported user_version=%Ld" user_version))
+  else
+    let* objects = read_schema_objects db in
+    if objects <> expected_schema_objects
+    then Error (Integrity_error "database schema does not exactly match v1")
+    else
+      let* control_rows =
+        single_int64
+          db
+          ~operation:"count keeper control rows"
+          "SELECT COUNT(*) FROM keeper_control"
+      in
+      if not (Int64.equal control_rows 1L)
+      then Error (Integrity_error "keeper_control must contain exactly one row")
+      else
+        let* integrity =
+        single_text db ~operation:"run integrity check" "PRAGMA integrity_check"
+        in
+        if String.equal integrity "ok"
+        then Ok ()
+        else Error (Integrity_error ("SQLite integrity_check: " ^ integrity))
+;;
+
+let inspect_database_path path =
+  try
+    let stat = Unix.lstat path in
+    if stat.Unix.st_kind = Unix.S_REG
+    then Ok true
+    else Error (Integrity_error "operation database path is not a regular file")
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
+  | Unix.Unix_error (code, operation, argument) ->
+    Error
+      (Store_error
+         (Printf.sprintf "%s(%s): %s" operation argument (Unix.error_message code)))
+;;
+
+let close_db db =
+  try
+    if Sqlite3.db_close db
+    then Ok ()
+    else Error (Store_error "SQLite close reported a busy handle")
+  with
+  | Sqlite3.Error detail -> Error (Store_error ("SQLite close: " ^ detail))
+;;
+
+let open_or_create ~base_path ~keeper_runtime_dir =
+  let path = Filename.concat keeper_runtime_dir database_file in
+  try
+    Fs_compat.mkdir_p keeper_runtime_dir;
+    let* ownership =
+      Fs_compat.inspect_owned_directory_chain
+        ~ownership_root:base_path
+        keeper_runtime_dir
+      |> Result.map_error (fun rejection ->
+        Integrity_error
+          (Fs_compat.owned_directory_chain_rejection_to_string rejection))
+    in
+    let* () =
+      match ownership with
+      | Fs_compat.Owned_directory _ -> Ok ()
+      | Fs_compat.Owned_directory_missing ->
+        Error (Store_error "Keeper runtime directory was not created")
+    in
+    let* existed = inspect_database_path path in
+    let db = Sqlite3.db_open ~mutex:`FULL path in
+    let opened =
+      if existed
+      then
+        let* () = validate_database db in
+        let* () = configure_connection db in
+        validate_database db
+      else
+        let* () = configure_connection db in
+        let* () = initialize_database db path in
+        validate_database db
+    in
+    (match opened with
+     | Ok () -> Ok { db; closed = false }
+     | Error error ->
+       ignore (close_db db);
+       Error error)
+  with
+  | Sys_error detail -> Error (Store_error detail)
+  | Sqlite3.Error detail -> Error (Store_error ("SQLite open: " ^ detail))
+  | Unix.Unix_error (code, operation, argument) ->
+    Error
+      (Store_error
+         (Printf.sprintf "%s(%s): %s" operation argument (Unix.error_message code)))
+;;
+
+let ensure_open t =
+  if t.closed then Error (Store_error "operation store is closed") else Ok ()
+;;
+
+let close t =
+  if t.closed
+  then Ok ()
+  else (
+    t.closed <- true;
+    close_db t.db)
+;;
+
+let nullable_text stmt index =
+  if Sqlite3.column_is_null stmt index then None else Some (Sqlite3.column_text stmt index)
+;;
+
+let nullable_float stmt index =
+  if Sqlite3.column_is_null stmt index then None else Some (Sqlite3.column_double stmt index)
+;;
+
+let parse_canonical field bytes =
+  match Keeper_operation_request.Canonical_json.of_string bytes with
+  | Ok value
+    when String.equal bytes (Keeper_operation_request.Canonical_json.to_bytes value) ->
+    Ok value
+  | Ok _ -> Error (Integrity_error (field ^ " is not canonical JSON"))
+  | Error error ->
+    Error
+      (Integrity_error
+         (field
+          ^ ": "
+          ^ Keeper_operation_request.Canonical_json.error_to_string error))
+;;
+
+let parse_ref field decode = function
+  | None -> Ok None
+  | Some value ->
+    decode value
+    |> Result.map Option.some
+    |> Result.map_error (fun detail -> Integrity_error (field ^ ": " ^ detail))
+;;
+
+let operation_of_row stmt =
+  let* operation_id =
+    Keeper_operation_id.Operation_id.of_string (Sqlite3.column_text stmt 1)
+    |> Result.map_error (fun detail -> Integrity_error detail)
+  in
+  let* kind = kind_of_string (Sqlite3.column_text stmt 2) in
+  let* source_ref = parse_canonical "source_ref" (Sqlite3.column_text stmt 3) in
+  let* submitter_ref = parse_canonical "submitter_ref" (Sqlite3.column_text stmt 4) in
+  let* state = state_of_string (Sqlite3.column_text stmt 5) in
+  let* input_ref =
+    Keeper_operation_blob_store.Input_ref.of_string (Sqlite3.column_text stmt 7)
+    |> Result.map_error (fun detail -> Integrity_error ("input_ref: " ^ detail))
+  in
+  let* base_state_ref =
+    parse_ref
+      "base_state_ref"
+      Keeper_operation_blob_store.State_ref.of_string
+      (nullable_text stmt 8)
+  in
+  let* outcome_ref =
+    parse_ref
+      "outcome_ref"
+      Keeper_operation_blob_store.Outcome_ref.of_string
+      (nullable_text stmt 9)
+  in
+  let* next_state_ref =
+    parse_ref
+      "next_state_ref"
+      Keeper_operation_blob_store.State_ref.of_string
+      (nullable_text stmt 10)
+  in
+  Ok
+    { queue_seq = Sqlite3.column_int64 stmt 0
+    ; operation_id
+    ; kind
+    ; source_ref
+    ; submitter_ref
+    ; state
+    ; request_digest = Sqlite3.column_text stmt 6
+    ; input_ref
+    ; base_state_ref
+    ; outcome_ref
+    ; next_state_ref
+    ; created_at = Sqlite3.column_double stmt 11
+    ; started_at = nullable_float stmt 12
+    ; finished_at = nullable_float stmt 13
+    }
+;;
+
+let select_columns =
+  "queue_seq, operation_id, kind, source_ref, submitter_ref, state, request_digest, input_ref, base_state_ref, outcome_ref, next_state_ref, created_at, started_at, finished_at"
+;;
+
+let find t operation_id =
+  let* () = ensure_open t in
+  with_statement
+    t.db
+    ~operation:"find operation"
+    ("SELECT " ^ select_columns ^ " FROM operations WHERE operation_id = ?")
+    (fun stmt ->
+       let* () =
+         bind
+           t.db
+           stmt
+           ~operation:"bind operation id"
+           1
+           (Sqlite3.Data.TEXT (Keeper_operation_id.Operation_id.to_string operation_id))
+       in
+       let rc = Sqlite3.step stmt in
+       if rc = Sqlite3.Rc.DONE
+       then Ok None
+       else if rc = Sqlite3.Rc.ROW
+       then
+         let* operation = operation_of_row stmt in
+         let terminal_rc = Sqlite3.step stmt in
+         if terminal_rc = Sqlite3.Rc.DONE
+         then Ok (Some operation)
+         else Error (Store_error (sqlite_error t.db "find operation" terminal_rc))
+       else Error (Store_error (sqlite_error t.db "find operation" rc)))
+;;
+
+let begin_immediate t = exec t.db ~operation:"begin operation transaction" "BEGIN IMMEDIATE"
+let rollback t = exec t.db ~operation:"rollback operation transaction" "ROLLBACK"
+let commit t = exec t.db ~operation:"commit operation transaction" "COMMIT"
+
+type admission =
+  | Accepted of operation
+  | Replayed of operation
+
+let exact_request_row request input_ref row =
+  String.equal row.request_digest (Keeper_operation_request.request_digest request)
+  && Keeper_operation_blob_store.Input_ref.equal row.input_ref input_ref
+  && row.kind = Keeper_operation_request.kind request
+;;
+
+let insert_queued t ~now ~request ~input_ref =
+  let* source_ref =
+    Keeper_operation_request.Source_ref.to_canonical_json
+      (Keeper_operation_request.source_ref request)
+    |> Result.map_error (fun detail -> Invalid_input detail)
+  in
+  let* submitter_ref =
+    Keeper_operation_request.Submitter_ref.to_canonical_json
+      (Keeper_operation_request.submitter_ref request)
+    |> Result.map_error (fun detail -> Invalid_input detail)
+  in
+  with_statement
+    t.db
+    ~operation:"insert queued operation"
+    "INSERT INTO operations(operation_id, kind, source_ref, submitter_ref, state, request_digest, input_ref, created_at) VALUES (?, ?, ?, ?, 'queued', ?, ?, ?)"
+    (fun stmt ->
+       let values =
+         [ Sqlite3.Data.TEXT
+             (Keeper_operation_id.Operation_id.to_string
+                (Keeper_operation_request.operation_id request))
+         ; Sqlite3.Data.TEXT
+             (Keeper_operation_request.kind_to_string
+                (Keeper_operation_request.kind request))
+         ; Sqlite3.Data.TEXT
+             (Keeper_operation_request.Canonical_json.to_bytes source_ref)
+         ; Sqlite3.Data.TEXT
+             (Keeper_operation_request.Canonical_json.to_bytes submitter_ref)
+         ; Sqlite3.Data.TEXT (Keeper_operation_request.request_digest request)
+         ; Sqlite3.Data.TEXT (Keeper_operation_blob_store.Input_ref.to_string input_ref)
+         ; Sqlite3.Data.FLOAT now
+         ]
+       in
+       let rec bind_all index = function
+         | [] -> expect_done t.db stmt ~operation:"insert queued operation"
+         | value :: rest ->
+           let* () = bind t.db stmt ~operation:"bind queued operation" index value in
+           bind_all (index + 1) rest
+       in
+       bind_all 1 values)
+;;
+
+let admit t ~now ~request ~input_ref =
+  let* () = ensure_open t in
+  let* () = validate_time "created_at" now in
+  let operation_id = Keeper_operation_request.operation_id request in
+  let* () = begin_immediate t in
+  match find t operation_id with
+  | Error error ->
+    ignore (rollback t);
+    Error error
+  | Ok (Some existing) ->
+    ignore (rollback t);
+    if exact_request_row request input_ref existing
+    then Ok (Replayed existing)
+    else Error (Identity_conflict operation_id)
+  | Ok None ->
+    (match insert_queued t ~now ~request ~input_ref with
+     | Error error ->
+       ignore (rollback t);
+       Error error
+     | Ok () ->
+       (match commit t with
+        | Error commit_error ->
+          ignore (rollback t);
+          (match find t operation_id with
+           | Ok (Some row) when exact_request_row request input_ref row ->
+             Ok (Accepted row)
+           | Ok _ | Error _ -> Error commit_error)
+        | Ok () ->
+          (match find t operation_id with
+           | Ok (Some row) -> Ok (Accepted row)
+           | Ok None -> Error (Integrity_error "accepted operation disappeared")
+           | Error _ as error -> error)))
+;;
+
+let running_count t =
+  single_int64
+    t.db
+    ~operation:"count running operations"
+    "SELECT COUNT(*) FROM operations WHERE state = 'running'"
+;;
+
+let first_queued_id t =
+  with_statement
+    t.db
+    ~operation:"select FIFO queued operation"
+    "SELECT operation_id FROM operations WHERE state = 'queued' ORDER BY queue_seq LIMIT 1"
+    (fun stmt ->
+       let rc = Sqlite3.step stmt in
+       if rc = Sqlite3.Rc.DONE
+       then Ok None
+       else if rc = Sqlite3.Rc.ROW
+       then
+         let value = Sqlite3.column_text stmt 0 in
+         let* operation_id =
+           Keeper_operation_id.Operation_id.of_string value
+           |> Result.map_error (fun detail -> Integrity_error detail)
+         in
+         let terminal_rc = Sqlite3.step stmt in
+         if terminal_rc = Sqlite3.Rc.DONE
+         then Ok (Some operation_id)
+         else
+           Error
+             (Store_error
+                (sqlite_error t.db "select queued operation" terminal_rc))
+       else Error (Store_error (sqlite_error t.db "select queued operation" rc)))
+;;
+
+let start_next t ~now ~base_state_ref =
+  let* () = ensure_open t in
+  let* () = validate_time "started_at" now in
+  let* () = begin_immediate t in
+  let body =
+    let* running = running_count t in
+    if not (Int64.equal running 0L)
+    then Ok None
+    else
+      let* next = first_queued_id t in
+      match next with
+      | None -> Ok None
+      | Some operation_id ->
+        with_statement
+          t.db
+          ~operation:"start queued operation"
+          "UPDATE operations SET state = 'running', base_state_ref = ?, started_at = ? WHERE operation_id = ? AND state = 'queued'"
+          (fun stmt ->
+             let base =
+               match base_state_ref with
+               | None -> Sqlite3.Data.NULL
+               | Some reference ->
+                 Sqlite3.Data.TEXT
+                   (Keeper_operation_blob_store.State_ref.to_string reference)
+             in
+             let* () = bind t.db stmt ~operation:"bind base state" 1 base in
+             let* () =
+               bind t.db stmt ~operation:"bind started_at" 2 (Sqlite3.Data.FLOAT now)
+             in
+             let* () =
+               bind
+                 t.db
+                 stmt
+                 ~operation:"bind operation id"
+                 3
+                 (Sqlite3.Data.TEXT
+                    (Keeper_operation_id.Operation_id.to_string operation_id))
+             in
+             let* () = expect_done t.db stmt ~operation:"start queued operation" in
+             if Sqlite3.changes t.db = 1
+             then Ok (Some operation_id)
+             else Error (Integrity_error "FIFO queued operation changed before start"))
+  in
+  match body with
+  | Error error ->
+    ignore (rollback t);
+    Error error
+  | Ok None ->
+    let* () = commit t in
+    Ok None
+  | Ok (Some operation_id) ->
+    let* () = commit t in
+    find t operation_id
+;;
+
+let update_terminal t ~operation_id ~from_state ~to_state ~now ~outcome_ref ~next_state_ref =
+  with_statement
+    t.db
+    ~operation:"update terminal operation"
+    "UPDATE operations SET state = ?, outcome_ref = ?, next_state_ref = ?, finished_at = ? WHERE operation_id = ? AND state = ?"
+    (fun stmt ->
+       let* () =
+         bind
+           t.db
+           stmt
+           ~operation:"bind terminal state"
+           1
+           (Sqlite3.Data.TEXT (state_to_string to_state))
+       in
+       let* () =
+         bind
+           t.db
+           stmt
+           ~operation:"bind outcome ref"
+           2
+           (match outcome_ref with
+            | None -> Sqlite3.Data.NULL
+            | Some reference ->
+              Sqlite3.Data.TEXT
+                (Keeper_operation_blob_store.Outcome_ref.to_string reference))
+       in
+       let* () =
+         bind
+           t.db
+           stmt
+           ~operation:"bind next state ref"
+           3
+           (match next_state_ref with
+            | None -> Sqlite3.Data.NULL
+            | Some reference ->
+              Sqlite3.Data.TEXT
+                (Keeper_operation_blob_store.State_ref.to_string reference))
+       in
+       let* () =
+         bind t.db stmt ~operation:"bind finished_at" 4 (Sqlite3.Data.FLOAT now)
+       in
+       let* () =
+         bind
+           t.db
+           stmt
+           ~operation:"bind operation id"
+           5
+           (Sqlite3.Data.TEXT
+              (Keeper_operation_id.Operation_id.to_string operation_id))
+       in
+       let* () =
+         bind
+           t.db
+           stmt
+           ~operation:"bind prior state"
+           6
+           (Sqlite3.Data.TEXT (state_to_string from_state))
+       in
+       let* () = expect_done t.db stmt ~operation:"update terminal operation" in
+       if Sqlite3.changes t.db = 1
+       then Ok ()
+       else Error (Integrity_error "terminal operation compare-and-update failed"))
+;;
+
+let cancel_queued t ~now operation_id =
+  let* () = ensure_open t in
+  let* () = validate_time "finished_at" now in
+  let* existing = find t operation_id in
+  match existing with
+  | None -> Error (Invalid_input "operation does not exist")
+  | Some ({ state = Cancelled; _ } as operation) -> Ok operation
+  | Some { state = Queued; _ } ->
+    let* () = begin_immediate t in
+    (match
+       update_terminal
+         t
+         ~operation_id
+         ~from_state:Queued
+         ~to_state:Cancelled
+         ~now
+         ~outcome_ref:None
+         ~next_state_ref:None
+     with
+     | Error error ->
+       ignore (rollback t);
+       Error error
+     | Ok () ->
+       let* () = commit t in
+       (match find t operation_id with
+        | Ok (Some operation) -> Ok operation
+        | Ok None -> Error (Integrity_error "cancelled operation disappeared")
+        | Error _ as error -> error))
+  | Some ({ state = (Running | Settled | Interrupted); _ } as operation) ->
+    Error (State_conflict { operation_id; state = operation.state })
+;;
+
+let finish_running t ~now ~operation_id ~target_state ~outcome_ref ~next_state_ref =
+  let* () = ensure_open t in
+  let* () = validate_time "finished_at" now in
+  let* existing = find t operation_id in
+  match existing with
+  | None -> Error (Invalid_input "operation does not exist")
+  | Some operation ->
+    if operation.state = target_state
+    then
+      let same_outcome =
+        Option.exists
+          (Keeper_operation_blob_store.Outcome_ref.equal outcome_ref)
+          operation.outcome_ref
+      in
+      let same_next =
+        match next_state_ref, operation.next_state_ref with
+        | None, None -> true
+        | Some left, Some right ->
+          Keeper_operation_blob_store.State_ref.equal left right
+        | None, Some _ | Some _, None -> false
+      in
+      if same_outcome && same_next
+      then Ok operation
+      else Error (State_conflict { operation_id; state = operation.state })
+    else
+      match operation.state with
+      | Running ->
+        let* () = begin_immediate t in
+        (match
+           update_terminal
+             t
+             ~operation_id
+             ~from_state:Running
+             ~to_state:target_state
+             ~now
+             ~outcome_ref:(Some outcome_ref)
+             ~next_state_ref
+         with
+         | Error error ->
+           ignore (rollback t);
+           Error error
+         | Ok () ->
+           let* () = commit t in
+           (match find t operation_id with
+            | Ok (Some terminal) -> Ok terminal
+            | Ok None -> Error (Integrity_error "terminal operation disappeared")
+            | Error _ as error -> error))
+      | Queued | Settled | Cancelled | Interrupted ->
+        Error (State_conflict { operation_id; state = operation.state })
+;;
+
+let interrupt_running t ~now ~operation_id ~evidence_ref =
+  finish_running
+    t
+    ~now
+    ~operation_id
+    ~target_state:Interrupted
+    ~outcome_ref:evidence_ref
+    ~next_state_ref:None
+;;
+
+let settle t ~now ~operation_id ~outcome_ref ~next_state_ref =
+  finish_running
+    t
+    ~now
+    ~operation_id
+    ~target_state:Settled
+    ~outcome_ref
+    ~next_state_ref
+;;
+
+let set_paused t value =
+  let* () = ensure_open t in
+  let* () =
+    with_statement
+      t.db
+      ~operation:"set paused"
+      "UPDATE keeper_control SET paused = ? WHERE singleton = 1"
+      (fun stmt ->
+         let* () =
+           bind
+             t.db
+             stmt
+             ~operation:"bind paused"
+             1
+             (Sqlite3.Data.INT (if value then 1L else 0L))
+         in
+         expect_done t.db stmt ~operation:"set paused")
+  in
+  if Sqlite3.changes t.db = 1 || Sqlite3.changes t.db = 0
+  then Ok ()
+  else Error (Integrity_error "keeper_control contains an invalid row count")
+;;
+
+let paused t =
+  let* () = ensure_open t in
+  let* value =
+    single_int64
+      t.db
+      ~operation:"read paused"
+      "SELECT paused FROM keeper_control WHERE singleton = 1"
+  in
+  if Int64.equal value 0L
+  then Ok false
+  else if Int64.equal value 1L
+  then Ok true
+  else Error (Integrity_error "keeper_control.paused is outside its domain")
+;;
+
+let count_operations t =
+  let* () = ensure_open t in
+  single_int64 t.db ~operation:"count operations" "SELECT COUNT(*) FROM operations"
+;;

--- a/lib/keeper_operation/keeper_operation_store.ml
+++ b/lib/keeper_operation/keeper_operation_store.ml
@@ -192,6 +192,22 @@ let pending_delivery_index_sql =
   "CREATE INDEX deliveries_pending_fifo ON deliveries(delivery_seq) WHERE state = 'pending'"
 ;;
 
+let operations_terminal_update_trigger_sql =
+  "CREATE TRIGGER operations_terminal_update_immutable BEFORE UPDATE ON operations WHEN OLD.state IN ('settled', 'cancelled', 'interrupted') BEGIN SELECT RAISE(ABORT, 'terminal operation is immutable'); END"
+;;
+
+let operations_terminal_delete_trigger_sql =
+  "CREATE TRIGGER operations_terminal_delete_immutable BEFORE DELETE ON operations WHEN OLD.state IN ('settled', 'cancelled', 'interrupted') BEGIN SELECT RAISE(ABORT, 'terminal operation is immutable'); END"
+;;
+
+let deliveries_terminal_update_trigger_sql =
+  "CREATE TRIGGER deliveries_terminal_update_immutable BEFORE UPDATE ON deliveries WHEN OLD.state IN ('delivered', 'failed', 'ambiguous') BEGIN SELECT RAISE(ABORT, 'terminal delivery is immutable'); END"
+;;
+
+let deliveries_terminal_delete_trigger_sql =
+  "CREATE TRIGGER deliveries_terminal_delete_immutable BEFORE DELETE ON deliveries WHEN OLD.state IN ('delivered', 'failed', 'ambiguous') BEGIN SELECT RAISE(ABORT, 'terminal delivery is immutable'); END"
+;;
+
 let expected_schema_objects =
   [ "index", "deliveries_pending_fifo", pending_delivery_index_sql
   ; "index", "operations_queued_fifo", queued_index_sql
@@ -199,6 +215,18 @@ let expected_schema_objects =
   ; "table", "deliveries", deliveries_table_sql
   ; "table", "keeper_control", keeper_control_table_sql
   ; "table", "operations", operations_table_sql
+  ; ( "trigger"
+    , "deliveries_terminal_delete_immutable"
+    , deliveries_terminal_delete_trigger_sql )
+  ; ( "trigger"
+    , "deliveries_terminal_update_immutable"
+    , deliveries_terminal_update_trigger_sql )
+  ; ( "trigger"
+    , "operations_terminal_delete_immutable"
+    , operations_terminal_delete_trigger_sql )
+  ; ( "trigger"
+    , "operations_terminal_update_immutable"
+    , operations_terminal_update_trigger_sql )
   ]
 ;;
 
@@ -252,6 +280,30 @@ let initialize_database db path =
     let* () = exec db ~operation:"create running index" running_index_sql in
     let* () =
       exec db ~operation:"create pending delivery index" pending_delivery_index_sql
+    in
+    let* () =
+      exec
+        db
+        ~operation:"create terminal operation update trigger"
+        operations_terminal_update_trigger_sql
+    in
+    let* () =
+      exec
+        db
+        ~operation:"create terminal operation delete trigger"
+        operations_terminal_delete_trigger_sql
+    in
+    let* () =
+      exec
+        db
+        ~operation:"create terminal delivery update trigger"
+        deliveries_terminal_update_trigger_sql
+    in
+    let* () =
+      exec
+        db
+        ~operation:"create terminal delivery delete trigger"
+        deliveries_terminal_delete_trigger_sql
     in
     let* () =
       exec

--- a/lib/keeper_operation/keeper_operation_store.mli
+++ b/lib/keeper_operation/keeper_operation_store.mli
@@ -51,7 +51,6 @@ val admit
   :  t
   -> now:float
   -> request:Keeper_operation_request.t
-  -> input_ref:Keeper_operation_blob_store.Input_ref.t
   -> (admission, error) result
 
 val find
@@ -62,7 +61,7 @@ val find
 val start_next
   :  t
   -> now:float
-  -> base_state_ref:Keeper_operation_blob_store.State_ref.t option
+  -> base_state:Keeper_operation_request.Canonical_json.t option
   -> (operation option, error) result
 
 val cancel_queued
@@ -75,15 +74,15 @@ val interrupt_running
   :  t
   -> now:float
   -> operation_id:Keeper_operation_id.Operation_id.t
-  -> evidence_ref:Keeper_operation_blob_store.Outcome_ref.t
+  -> evidence:Keeper_operation_request.Canonical_json.t
   -> (operation, error) result
 
 val settle
   :  t
   -> now:float
   -> operation_id:Keeper_operation_id.Operation_id.t
-  -> outcome_ref:Keeper_operation_blob_store.Outcome_ref.t
-  -> next_state_ref:Keeper_operation_blob_store.State_ref.t option
+  -> outcome:Keeper_operation_request.Canonical_json.t
+  -> next_state:Keeper_operation_request.Canonical_json.t option
   -> (operation, error) result
 
 val set_paused : t -> bool -> (unit, error) result

--- a/lib/keeper_operation/keeper_operation_store.mli
+++ b/lib/keeper_operation/keeper_operation_store.mli
@@ -1,0 +1,91 @@
+type t
+
+type operation_state =
+  | Queued
+  | Running
+  | Settled
+  | Cancelled
+  | Interrupted
+
+type operation =
+  { queue_seq : int64
+  ; operation_id : Keeper_operation_id.Operation_id.t
+  ; kind : Keeper_operation_request.kind
+  ; source_ref : Keeper_operation_request.Canonical_json.t
+  ; submitter_ref : Keeper_operation_request.Canonical_json.t
+  ; state : operation_state
+  ; request_digest : string
+  ; input_ref : Keeper_operation_blob_store.Input_ref.t
+  ; base_state_ref : Keeper_operation_blob_store.State_ref.t option
+  ; outcome_ref : Keeper_operation_blob_store.Outcome_ref.t option
+  ; next_state_ref : Keeper_operation_blob_store.State_ref.t option
+  ; created_at : float
+  ; started_at : float option
+  ; finished_at : float option
+  }
+
+type error =
+  | Invalid_input of string
+  | Identity_conflict of Keeper_operation_id.Operation_id.t
+  | State_conflict of
+      { operation_id : Keeper_operation_id.Operation_id.t
+      ; state : operation_state
+      }
+  | Store_error of string
+  | Integrity_error of string
+
+val error_to_string : error -> string
+
+val open_or_create
+  :  base_path:string
+  -> keeper_runtime_dir:string
+  -> (t, error) result
+
+val close : t -> (unit, error) result
+
+type admission =
+  | Accepted of operation
+  | Replayed of operation
+
+val admit
+  :  t
+  -> now:float
+  -> request:Keeper_operation_request.t
+  -> input_ref:Keeper_operation_blob_store.Input_ref.t
+  -> (admission, error) result
+
+val find
+  :  t
+  -> Keeper_operation_id.Operation_id.t
+  -> (operation option, error) result
+
+val start_next
+  :  t
+  -> now:float
+  -> base_state_ref:Keeper_operation_blob_store.State_ref.t option
+  -> (operation option, error) result
+
+val cancel_queued
+  :  t
+  -> now:float
+  -> Keeper_operation_id.Operation_id.t
+  -> (operation, error) result
+
+val interrupt_running
+  :  t
+  -> now:float
+  -> operation_id:Keeper_operation_id.Operation_id.t
+  -> evidence_ref:Keeper_operation_blob_store.Outcome_ref.t
+  -> (operation, error) result
+
+val settle
+  :  t
+  -> now:float
+  -> operation_id:Keeper_operation_id.Operation_id.t
+  -> outcome_ref:Keeper_operation_blob_store.Outcome_ref.t
+  -> next_state_ref:Keeper_operation_blob_store.State_ref.t option
+  -> (operation, error) result
+
+val set_paused : t -> bool -> (unit, error) result
+val paused : t -> (bool, error) result
+val count_operations : t -> (int64, error) result

--- a/test/dune
+++ b/test/dune
@@ -2515,3 +2515,4 @@
 (include stanzas/test_keeper_operator_note.inc)
 
 (include stanzas/test_keeper_memory_journal_projection.inc)
+(include stanzas/test_keeper_operation_ledger.inc)

--- a/test/stanzas/test_keeper_operation_ledger.inc
+++ b/test/stanzas/test_keeper_operation_ledger.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_operation_ledger)
+ (modules test_keeper_operation_ledger)
+ (libraries alcotest masc.keeper_operation unix))

--- a/test/stanzas/test_keeper_operation_ledger.inc
+++ b/test/stanzas/test_keeper_operation_ledger.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_operation_ledger)
  (modules test_keeper_operation_ledger)
- (libraries alcotest eio eio_main masc.keeper_operation sqlite3 unix))
+ (libraries alcotest eio eio_main masc.fs_compat masc.keeper_operation sqlite3 unix))

--- a/test/stanzas/test_keeper_operation_ledger.inc
+++ b/test/stanzas/test_keeper_operation_ledger.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_operation_ledger)
  (modules test_keeper_operation_ledger)
- (libraries alcotest masc.keeper_operation unix))
+ (libraries alcotest eio eio_main masc.keeper_operation unix))

--- a/test/stanzas/test_keeper_operation_ledger.inc
+++ b/test/stanzas/test_keeper_operation_ledger.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_operation_ledger)
  (modules test_keeper_operation_ledger)
- (libraries alcotest eio eio_main masc.keeper_operation unix))
+ (libraries alcotest eio eio_main masc.keeper_operation sqlite3 unix))

--- a/test/test_keeper_operation_ledger.ml
+++ b/test/test_keeper_operation_ledger.ml
@@ -1,0 +1,323 @@
+open Alcotest
+
+module Id = Keeper_operation_id
+module Request = Keeper_operation_request
+module Blob = Keeper_operation_blob_store
+module Store = Keeper_operation_store
+
+let result_exn to_string = function
+  | Ok value -> value
+  | Error error -> fail (to_string error)
+;;
+
+let json_exn json =
+  result_exn Request.Canonical_json.error_to_string
+    (Request.Canonical_json.of_yojson json)
+;;
+
+let operation_id char =
+  result_exn Fun.id (Id.Operation_id.of_string ("kop1:" ^ String.make 64 char))
+;;
+
+let request_exn ~operation_id ~request_id content =
+  result_exn Fun.id
+    (Request.make
+       ~operation_id
+       ~kind:Request.Message
+       ~source_ref:(Request.Source_ref.Operator_message { request_id })
+       ~submitter_ref:(Request.Submitter_ref.Operator { principal_id = "operator-1" })
+       ~input:
+         (json_exn
+            (`Assoc
+               [ "schema", `String "masc.keeper_operation.message_input.v1"
+               ; "content", `String content
+               ])))
+;;
+
+let rec remove_tree path =
+  match Unix.lstat path with
+  | { Unix.st_kind = Unix.S_DIR; _ } ->
+    Sys.readdir path
+    |> Array.iter (fun entry -> remove_tree (Filename.concat path entry));
+    Unix.rmdir path
+  | _ -> Unix.unlink path
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+;;
+
+let with_temp_dir f =
+  let base_path = Filename.temp_dir "keeper-operation-ledger-" "" in
+  Fun.protect ~finally:(fun () -> remove_tree base_path) (fun () -> f base_path)
+;;
+
+let test_strict_identifiers () =
+  let valid = "kop1:" ^ String.make 64 'a' in
+  check bool "valid operation id" true (Result.is_ok (Id.Operation_id.of_string valid));
+  check bool
+    "old operation id rejected"
+    true
+    (Result.is_error (Id.Operation_id.of_string ("kmsg1-" ^ String.make 64 'a')));
+  check bool
+    "uppercase digest rejected"
+    true
+    (Result.is_error
+       (Id.Operation_id.of_string ("kop1:" ^ String.make 64 'A')));
+  let parent = operation_id 'b' in
+  let left =
+    Id.Operation_id.for_keeper_message
+      ~causing_operation:parent
+      ~ordinal:1
+      ~target_keeper:"ab"
+  in
+  let right =
+    Id.Operation_id.for_keeper_message
+      ~causing_operation:parent
+      ~ordinal:11
+      ~target_keeper:"b"
+  in
+  check bool
+    "framed identity derivation"
+    false
+    (Id.Operation_id.equal left right)
+;;
+
+let test_canonical_json_rejections () =
+  check bool
+    "duplicate fields rejected"
+    true
+    (Result.is_error
+       (Request.Canonical_json.of_yojson
+          (`Assoc [ "a", `Int 1; "a", `Int 2 ])));
+  check bool
+    "non-finite rejected"
+    true
+    (Result.is_error (Request.Canonical_json.of_yojson (`Float Float.nan)));
+  check bool
+    "invalid integer literal rejected"
+    true
+    (Result.is_error (Request.Canonical_json.of_yojson (`Intlit "01")));
+  check bool
+    "invalid UTF-8 rejected"
+    true
+    (Result.is_error
+       (Request.Canonical_json.of_yojson (`String (String.make 1 '\xff'))));
+  let first =
+    json_exn (`Assoc [ "z", `Int 1; "a", `Assoc [ "b", `Int 2; "a", `Int 3 ] ])
+  in
+  let second =
+    json_exn (`Assoc [ "a", `Assoc [ "a", `Int 3; "b", `Int 2 ]; "z", `Int 1 ])
+  in
+  check string
+    "object fields canonicalized"
+    (Request.Canonical_json.to_bytes first)
+    (Request.Canonical_json.to_bytes second)
+;;
+
+let test_blob_store_kind_and_readback () =
+  with_temp_dir @@ fun base_path ->
+  let keeper_runtime_dir =
+    Filename.concat base_path ".masc/keepers/sangsu"
+  in
+  let store = Blob.create ~base_path ~keeper_runtime_dir in
+  let payload = json_exn (`Assoc [ "content", `String "hello" ]) in
+  let input_ref = result_exn Blob.error_to_string (Blob.put_input store payload) in
+  let fetched = result_exn Blob.error_to_string (Blob.fetch_input store input_ref) in
+  let fetched = Option.get fetched in
+  check string
+    "exact blob payload"
+    (Request.Canonical_json.to_bytes payload)
+    (Request.Canonical_json.to_bytes fetched);
+  let state_ref =
+    result_exn Fun.id
+      (Blob.State_ref.of_string (Blob.Input_ref.to_string input_ref))
+  in
+  match Blob.fetch_state store state_ref with
+  | Error (Blob.Kind_mismatch { expected = "state"; actual = "input" }) -> ()
+  | Error error -> fail (Blob.error_to_string error)
+  | Ok _ -> fail "typed blob kind mismatch was accepted"
+;;
+
+let with_store base_path f =
+  let keeper_runtime_dir =
+    Filename.concat base_path ".masc/keepers/sangsu"
+  in
+  let blobs = Blob.create ~base_path ~keeper_runtime_dir in
+  let store =
+    result_exn Store.error_to_string
+      (Store.open_or_create ~base_path ~keeper_runtime_dir)
+  in
+  Fun.protect
+    ~finally:(fun () -> ignore (Store.close store))
+    (fun () -> f blobs store)
+;;
+
+let put_input blobs request =
+  result_exn Blob.error_to_string (Blob.put_input blobs (Request.input request))
+;;
+
+let put_outcome blobs label =
+  result_exn Blob.error_to_string
+    (Blob.put_outcome blobs (json_exn (`Assoc [ "kind", `String label ])))
+;;
+
+let put_state blobs content =
+  result_exn Blob.error_to_string
+    (Blob.put_state blobs (json_exn (`Assoc [ "conversation", `String content ])))
+;;
+
+let admitted_operation = function
+  | Store.Accepted operation | Store.Replayed operation -> operation
+;;
+
+let test_ledger_replay_fifo_and_terminal_immutability () =
+  with_temp_dir @@ fun base_path ->
+  with_store base_path @@ fun blobs store ->
+  let first_id = operation_id '1' in
+  let first = request_exn ~operation_id:first_id ~request_id:"req-1" "first" in
+  let first_input = put_input blobs first in
+  let accepted =
+    result_exn Store.error_to_string
+      (Store.admit store ~now:1. ~request:first ~input_ref:first_input)
+  in
+  (match accepted with
+   | Store.Accepted operation -> check int64 "first sequence" 1L operation.queue_seq
+   | Store.Replayed _ -> fail "new operation was reported as replay");
+  (match
+     result_exn Store.error_to_string
+       (Store.admit store ~now:2. ~request:first ~input_ref:first_input)
+   with
+   | Store.Replayed _ -> ()
+   | Store.Accepted _ -> fail "exact request replay inserted a second row");
+  let conflicting = request_exn ~operation_id:first_id ~request_id:"req-1" "changed" in
+  let conflicting_input = put_input blobs conflicting in
+  (match Store.admit store ~now:3. ~request:conflicting ~input_ref:conflicting_input with
+   | Error (Store.Identity_conflict operation_id) ->
+     check string
+       "conflicting id"
+       (Id.Operation_id.to_string first_id)
+       (Id.Operation_id.to_string operation_id)
+   | Error error -> fail (Store.error_to_string error)
+   | Ok _ -> fail "same id with different request digest was accepted");
+  let second_id = operation_id '2' in
+  let second = request_exn ~operation_id:second_id ~request_id:"req-2" "second" in
+  let second_input = put_input blobs second in
+  ignore
+    (result_exn Store.error_to_string
+       (Store.admit store ~now:4. ~request:second ~input_ref:second_input));
+  let running =
+    result_exn Store.error_to_string
+      (Store.start_next store ~now:5. ~base_state_ref:None)
+    |> Option.get
+  in
+  check string
+    "FIFO starts first"
+    (Id.Operation_id.to_string first_id)
+    (Id.Operation_id.to_string running.operation_id);
+  check bool
+    "second start suppressed while Running"
+    true
+    (Option.is_none
+       (result_exn Store.error_to_string
+          (Store.start_next store ~now:6. ~base_state_ref:None)));
+  let outcome = put_outcome blobs "succeeded" in
+  let next_state = put_state blobs "first absorbed" in
+  let settled =
+    result_exn Store.error_to_string
+      (Store.settle
+         store
+         ~now:7.
+         ~operation_id:first_id
+         ~outcome_ref:outcome
+         ~next_state_ref:(Some next_state))
+  in
+  (match settled.state with
+   | Store.Settled -> ()
+   | _ -> fail "Running operation did not settle");
+  let conflicting_outcome = put_outcome blobs "different" in
+  (match
+     Store.settle
+       store
+       ~now:8.
+       ~operation_id:first_id
+       ~outcome_ref:conflicting_outcome
+       ~next_state_ref:(Some next_state)
+   with
+   | Error (Store.State_conflict _) -> ()
+   | Error error -> fail (Store.error_to_string error)
+   | Ok _ -> fail "terminal operation was reopened or overwritten");
+  let second_running =
+    result_exn Store.error_to_string
+      (Store.start_next store ~now:9. ~base_state_ref:(Some next_state))
+    |> Option.get
+  in
+  check string
+    "second starts after settlement"
+    (Id.Operation_id.to_string second_id)
+    (Id.Operation_id.to_string second_running.operation_id);
+  let interrupted = put_outcome blobs "process_crash" in
+  let terminal =
+    result_exn Store.error_to_string
+      (Store.interrupt_running
+         store
+         ~now:10.
+         ~operation_id:second_id
+         ~evidence_ref:interrupted)
+  in
+  (match terminal.state with
+   | Store.Interrupted -> ()
+   | _ -> fail "Running operation did not become Interrupted");
+  check int64
+    "dedupe rows retained"
+    2L
+    (result_exn Store.error_to_string (Store.count_operations store))
+;;
+
+let test_cancel_and_pause () =
+  with_temp_dir @@ fun base_path ->
+  with_store base_path @@ fun blobs store ->
+  check bool "fresh unpaused" false (result_exn Store.error_to_string (Store.paused store));
+  result_exn Store.error_to_string (Store.set_paused store true);
+  check bool "paused persisted" true (result_exn Store.error_to_string (Store.paused store));
+  let operation_id = operation_id '3' in
+  let request = request_exn ~operation_id ~request_id:"req-3" "cancel me" in
+  let input_ref = put_input blobs request in
+  ignore
+    (admitted_operation
+       (result_exn Store.error_to_string
+          (Store.admit store ~now:1. ~request ~input_ref)));
+  let cancelled =
+    result_exn Store.error_to_string (Store.cancel_queued store ~now:2. operation_id)
+  in
+  (match cancelled.state with
+   | Store.Cancelled -> ()
+   | _ -> fail "Queued operation did not cancel");
+  let replay =
+    result_exn Store.error_to_string (Store.cancel_queued store ~now:3. operation_id)
+  in
+  check int64 "cancel replay same row" cancelled.queue_seq replay.queue_seq
+;;
+
+let () =
+  run
+    "keeper operation ledger"
+    [ ( "identity"
+      , [ test_case "strict identifiers" `Quick test_strict_identifiers
+        ; test_case
+            "canonical JSON rejection"
+            `Quick
+            test_canonical_json_rejections
+        ] )
+    ; ( "blob"
+      , [ test_case
+            "typed durable blob read-back"
+            `Quick
+            test_blob_store_kind_and_readback
+        ] )
+    ; ( "ledger"
+      , [ test_case
+            "replay FIFO terminal immutability"
+            `Quick
+            test_ledger_replay_fifo_and_terminal_immutability
+        ; test_case "cancel and pause" `Quick test_cancel_and_pause
+        ] )
+    ]
+;;

--- a/test/test_keeper_operation_ledger.ml
+++ b/test/test_keeper_operation_ledger.ml
@@ -174,18 +174,49 @@ let with_store base_path f =
     (fun () -> f blobs store)
 ;;
 
-let put_input blobs request =
-  result_exn Blob.error_to_string (Blob.put_input blobs (Request.input request))
+let insert_raw_queued
+      ~database_path
+      ~operation_id
+      ~kind
+      ~source_ref
+      ~submitter_ref
+      ~request_digest
+      ~input_ref
+  =
+  let db = Sqlite3.db_open database_path in
+  let stmt =
+    Sqlite3.prepare
+      db
+      "INSERT INTO operations(operation_id, kind, source_ref, submitter_ref, state, request_digest, input_ref, created_at) VALUES (?, ?, ?, ?, 'queued', ?, ?, 1.0)"
+  in
+  let values =
+    [ operation_id; kind; source_ref; submitter_ref; request_digest; input_ref ]
+  in
+  List.iteri
+    (fun index value ->
+       let rc = Sqlite3.bind stmt (index + 1) (Sqlite3.Data.TEXT value) in
+       check bool "raw row bind" true (Sqlite3.Rc.is_success rc))
+    values;
+  check bool "raw row inserted" true (Sqlite3.step stmt = Sqlite3.Rc.DONE);
+  check bool
+    "raw statement finalized"
+    true
+    (Sqlite3.Rc.is_success (Sqlite3.finalize stmt));
+  check bool "raw database closed" true (Sqlite3.db_close db)
 ;;
 
-let put_outcome blobs label =
-  result_exn Blob.error_to_string
-    (Blob.put_outcome blobs (json_exn (`Assoc [ "kind", `String label ])))
+let expect_integrity_rejection = function
+  | Error (Store.Integrity_error _) -> ()
+  | Error error -> fail (Store.error_to_string error)
+  | Ok store ->
+    ignore (Store.close store);
+    fail "invalid persisted operation reopened successfully"
 ;;
 
-let put_state blobs content =
-  result_exn Blob.error_to_string
-    (Blob.put_state blobs (json_exn (`Assoc [ "conversation", `String content ])))
+let outcome_payload label = json_exn (`Assoc [ "kind", `String label ])
+
+let state_payload content =
+  json_exn (`Assoc [ "conversation", `String content ])
 ;;
 
 let admitted_operation = function
@@ -194,26 +225,24 @@ let admitted_operation = function
 
 let test_ledger_replay_fifo_and_terminal_immutability () =
   with_temp_dir @@ fun base_path ->
-  with_store base_path @@ fun blobs store ->
+  with_store base_path @@ fun _blobs store ->
   let first_id = operation_id '1' in
   let first = request_exn ~operation_id:first_id ~request_id:"req-1" "first" in
-  let first_input = put_input blobs first in
   let accepted =
     result_exn Store.error_to_string
-      (Store.admit store ~now:1. ~request:first ~input_ref:first_input)
+      (Store.admit store ~now:1. ~request:first)
   in
   (match accepted with
    | Store.Accepted operation -> check int64 "first sequence" 1L operation.queue_seq
    | Store.Replayed _ -> fail "new operation was reported as replay");
   (match
      result_exn Store.error_to_string
-       (Store.admit store ~now:2. ~request:first ~input_ref:first_input)
+       (Store.admit store ~now:2. ~request:first)
    with
    | Store.Replayed _ -> ()
-   | Store.Accepted _ -> fail "exact request replay inserted a second row");
+  | Store.Accepted _ -> fail "exact request replay inserted a second row");
   let conflicting = request_exn ~operation_id:first_id ~request_id:"req-1" "changed" in
-  let conflicting_input = put_input blobs conflicting in
-  (match Store.admit store ~now:3. ~request:conflicting ~input_ref:conflicting_input with
+  (match Store.admit store ~now:3. ~request:conflicting with
    | Error (Store.Identity_conflict operation_id) ->
      check string
        "conflicting id"
@@ -223,13 +252,12 @@ let test_ledger_replay_fifo_and_terminal_immutability () =
    | Ok _ -> fail "same id with different request digest was accepted");
   let second_id = operation_id '2' in
   let second = request_exn ~operation_id:second_id ~request_id:"req-2" "second" in
-  let second_input = put_input blobs second in
   ignore
     (result_exn Store.error_to_string
-       (Store.admit store ~now:4. ~request:second ~input_ref:second_input));
+       (Store.admit store ~now:4. ~request:second));
   let running =
     result_exn Store.error_to_string
-      (Store.start_next store ~now:5. ~base_state_ref:None)
+      (Store.start_next store ~now:5. ~base_state:None)
     |> Option.get
   in
   check string
@@ -241,17 +269,17 @@ let test_ledger_replay_fifo_and_terminal_immutability () =
     true
     (Option.is_none
        (result_exn Store.error_to_string
-          (Store.start_next store ~now:6. ~base_state_ref:None)));
-  let outcome = put_outcome blobs "succeeded" in
-  let next_state = put_state blobs "first absorbed" in
+          (Store.start_next store ~now:6. ~base_state:None)));
+  let outcome = outcome_payload "succeeded" in
+  let next_state = state_payload "first absorbed" in
   let settled =
     result_exn Store.error_to_string
       (Store.settle
          store
          ~now:7.
          ~operation_id:first_id
-         ~outcome_ref:outcome
-         ~next_state_ref:(Some next_state))
+         ~outcome
+         ~next_state:(Some next_state))
   in
   (match settled.state with
    | Store.Settled -> ()
@@ -267,35 +295,35 @@ let test_ledger_replay_fifo_and_terminal_immutability () =
   in
   ignore (Sqlite3.db_close raw_db : bool);
   check bool "SQL trigger protects terminal row" true (direct_update <> Sqlite3.Rc.OK);
-  let conflicting_outcome = put_outcome blobs "different" in
+  let conflicting_outcome = outcome_payload "different" in
   (match
      Store.settle
        store
        ~now:8.
        ~operation_id:first_id
-       ~outcome_ref:conflicting_outcome
-       ~next_state_ref:(Some next_state)
+       ~outcome:conflicting_outcome
+       ~next_state:(Some next_state)
    with
    | Error (Store.State_conflict _) -> ()
    | Error error -> fail (Store.error_to_string error)
    | Ok _ -> fail "terminal operation was reopened or overwritten");
   let second_running =
     result_exn Store.error_to_string
-      (Store.start_next store ~now:9. ~base_state_ref:(Some next_state))
+      (Store.start_next store ~now:9. ~base_state:(Some next_state))
     |> Option.get
   in
   check string
     "second starts after settlement"
     (Id.Operation_id.to_string second_id)
     (Id.Operation_id.to_string second_running.operation_id);
-  let interrupted = put_outcome blobs "process_crash" in
+  let interrupted = outcome_payload "process_crash" in
   let terminal =
     result_exn Store.error_to_string
       (Store.interrupt_running
          store
          ~now:10.
          ~operation_id:second_id
-         ~evidence_ref:interrupted)
+         ~evidence:interrupted)
   in
   (match terminal.state with
    | Store.Interrupted -> ()
@@ -308,27 +336,127 @@ let test_ledger_replay_fifo_and_terminal_immutability () =
 
 let test_cancel_and_pause () =
   with_temp_dir @@ fun base_path ->
-  with_store base_path @@ fun blobs store ->
+  with_store base_path @@ fun _blobs store ->
   check bool "fresh unpaused" false (result_exn Store.error_to_string (Store.paused store));
   result_exn Store.error_to_string (Store.set_paused store true);
   check bool "paused persisted" true (result_exn Store.error_to_string (Store.paused store));
   let operation_id = operation_id '3' in
   let request = request_exn ~operation_id ~request_id:"req-3" "cancel me" in
-  let input_ref = put_input blobs request in
   ignore
     (admitted_operation
        (result_exn Store.error_to_string
-          (Store.admit store ~now:1. ~request ~input_ref)));
+          (Store.admit store ~now:1. ~request)));
   let cancelled =
     result_exn Store.error_to_string (Store.cancel_queued store ~now:2. operation_id)
   in
   (match cancelled.state with
    | Store.Cancelled -> ()
    | _ -> fail "Queued operation did not cancel");
+  check bool
+    "cancelled operation has durable evidence"
+    true
+    (Option.is_some cancelled.outcome_ref);
   let replay =
     result_exn Store.error_to_string (Store.cancel_queued store ~now:3. operation_id)
   in
   check int64 "cancel replay same row" cancelled.queue_seq replay.queue_seq
+;;
+
+let test_startup_rejects_missing_input_blob () =
+  with_temp_dir @@ fun base_path ->
+  let keeper_runtime_dir =
+    Filename.concat base_path ".masc/keepers/sangsu"
+  in
+  let store =
+    result_exn Store.error_to_string
+      (Store.open_or_create ~base_path ~keeper_runtime_dir)
+  in
+  result_exn Store.error_to_string (Store.close store);
+  let operation_id = operation_id '4' in
+  let request = request_exn ~operation_id ~request_id:"req-4" "missing" in
+  let source_ref =
+    result_exn Fun.id
+      (Request.Source_ref.to_canonical_json (Request.source_ref request))
+    |> Request.Canonical_json.to_bytes
+  in
+  let submitter_ref =
+    result_exn Fun.id
+      (Request.Submitter_ref.to_canonical_json (Request.submitter_ref request))
+    |> Request.Canonical_json.to_bytes
+  in
+  insert_raw_queued
+    ~database_path:(Filename.concat keeper_runtime_dir "operations.sqlite3")
+    ~operation_id:(Id.Operation_id.to_string operation_id)
+    ~kind:(Request.kind_to_string (Request.kind request))
+    ~source_ref
+    ~submitter_ref
+    ~request_digest:(Request.request_digest request)
+    ~input_ref:("sha256:" ^ String.make 64 'a');
+  expect_integrity_rejection
+    (Store.open_or_create ~base_path ~keeper_runtime_dir)
+;;
+
+let test_startup_rejects_untyped_source () =
+  with_temp_dir @@ fun base_path ->
+  let keeper_runtime_dir =
+    Filename.concat base_path ".masc/keepers/sangsu"
+  in
+  let blobs = Blob.create ~base_path ~keeper_runtime_dir in
+  let store =
+    result_exn Store.error_to_string
+      (Store.open_or_create ~base_path ~keeper_runtime_dir)
+  in
+  result_exn Store.error_to_string (Store.close store);
+  let operation_id = operation_id '5' in
+  let request = request_exn ~operation_id ~request_id:"req-5" "untyped" in
+  let input_ref =
+    result_exn Blob.error_to_string (Blob.put_input blobs (Request.input request))
+  in
+  let submitter_ref =
+    result_exn Fun.id
+      (Request.Submitter_ref.to_canonical_json (Request.submitter_ref request))
+    |> Request.Canonical_json.to_bytes
+  in
+  insert_raw_queued
+    ~database_path:(Filename.concat keeper_runtime_dir "operations.sqlite3")
+    ~operation_id:(Id.Operation_id.to_string operation_id)
+    ~kind:(Request.kind_to_string (Request.kind request))
+    ~source_ref:"{}"
+    ~submitter_ref
+    ~request_digest:(Request.request_digest request)
+    ~input_ref:(Blob.Input_ref.to_string input_ref);
+  expect_integrity_rejection
+    (Store.open_or_create ~base_path ~keeper_runtime_dir)
+;;
+
+let test_symlink_escape_rejected_before_mutation () =
+  with_temp_dir @@ fun base_path ->
+  with_temp_dir @@ fun external_path ->
+  let keepers_dir = Filename.concat base_path ".masc/keepers" in
+  Fs_compat.mkdir_p keepers_dir;
+  let keeper_runtime_dir = Filename.concat keepers_dir "sangsu" in
+  Unix.symlink external_path keeper_runtime_dir;
+  check bool
+    "symlink runtime rejected"
+    true
+    (Result.is_error (Store.open_or_create ~base_path ~keeper_runtime_dir));
+  check bool
+    "database not created through symlink"
+    false
+    (Sys.file_exists (Filename.concat external_path "operations.sqlite3"));
+  Unix.unlink keeper_runtime_dir;
+  Fs_compat.mkdir_p keeper_runtime_dir;
+  let operation_blob_dir = Filename.concat keeper_runtime_dir "operation-blobs" in
+  Fs_compat.mkdir_p operation_blob_dir;
+  let sha_root = Filename.concat operation_blob_dir "sha256" in
+  Unix.symlink external_path sha_root;
+  let blobs = Blob.create ~base_path ~keeper_runtime_dir in
+  let payload = json_exn (`Assoc [ "content", `String "no escape" ]) in
+  check bool
+    "symlink blob root rejected"
+    true
+    (Result.is_error (Blob.put_input blobs payload));
+  check int "external directory untouched" 0 (Array.length (Sys.readdir external_path))
 ;;
 
 let test_bounded_mailbox () =
@@ -374,6 +502,18 @@ let () =
             `Quick
             test_ledger_replay_fifo_and_terminal_immutability
         ; test_case "cancel and pause" `Quick test_cancel_and_pause
+        ; test_case
+            "startup rejects missing input blob"
+            `Quick
+            test_startup_rejects_missing_input_blob
+        ; test_case
+            "startup rejects untyped source"
+            `Quick
+            test_startup_rejects_untyped_source
+        ; test_case
+            "symlink escape rejected before mutation"
+            `Quick
+            test_symlink_escape_rejected_before_mutation
         ] )
     ; ( "mailbox"
       , [ test_case "bounded non-blocking admission" `Quick test_bounded_mailbox ] )

--- a/test/test_keeper_operation_ledger.ml
+++ b/test/test_keeper_operation_ledger.ml
@@ -3,6 +3,7 @@ open Alcotest
 module Id = Keeper_operation_id
 module Request = Keeper_operation_request
 module Blob = Keeper_operation_blob_store
+module Mailbox = Keeper_operation_mailbox
 module Store = Keeper_operation_store
 
 let result_exn to_string = function
@@ -308,6 +309,27 @@ let test_cancel_and_pause () =
   check int64 "cancel replay same row" cancelled.queue_seq replay.queue_seq
 ;;
 
+let test_bounded_mailbox () =
+  let mailbox = result_exn Fun.id (Mailbox.create ~capacity:2) in
+  check int "capacity" 2 (Mailbox.capacity mailbox);
+  check bool "open" false (Mailbox.is_closed mailbox);
+  check bool "first added" true (Mailbox.try_add mailbox 1 = Mailbox.Added);
+  check bool "second added" true (Mailbox.try_add mailbox 2 = Mailbox.Added);
+  check int "full depth" 2 (Mailbox.length mailbox);
+  check bool "full is immediate" true (Mailbox.try_add mailbox 3 = Mailbox.Full);
+  Eio_main.run @@ fun _env ->
+  check (option int) "FIFO first" (Some 1) (Mailbox.take mailbox);
+  check (option int) "FIFO second" (Some 2) (Mailbox.take mailbox);
+  Eio.Switch.run @@ fun sw ->
+  let result, resolve = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () -> Eio.Promise.resolve resolve (Mailbox.take mailbox));
+  Eio.Fiber.yield ();
+  Mailbox.close mailbox;
+  check (option int) "close wakes empty consumer" None (Eio.Promise.await result);
+  check bool "closed" true (Mailbox.is_closed mailbox);
+  check bool "closed rejects" true (Mailbox.try_add mailbox 4 = Mailbox.Closed)
+;;
+
 let () =
   run
     "keeper operation ledger"
@@ -331,5 +353,7 @@ let () =
             test_ledger_replay_fifo_and_terminal_immutability
         ; test_case "cancel and pause" `Quick test_cancel_and_pause
         ] )
+    ; ( "mailbox"
+      , [ test_case "bounded non-blocking admission" `Quick test_bounded_mailbox ] )
     ]
 ;;

--- a/test/test_keeper_operation_ledger.ml
+++ b/test/test_keeper_operation_ledger.ml
@@ -66,12 +66,14 @@ let test_strict_identifiers () =
   let left =
     Id.Operation_id.for_keeper_message
       ~causing_operation:parent
+      ~tool_call_id:"call-1"
       ~ordinal:1
       ~target_keeper:"ab"
   in
   let right =
     Id.Operation_id.for_keeper_message
       ~causing_operation:parent
+      ~tool_call_id:"call-1"
       ~ordinal:11
       ~target_keeper:"b"
   in
@@ -79,6 +81,15 @@ let test_strict_identifiers () =
     "framed identity derivation"
     false
     (Id.Operation_id.equal left right)
+  ;
+  let another_call =
+    Id.Operation_id.for_keeper_message
+      ~causing_operation:parent
+      ~tool_call_id:"call-2"
+      ~ordinal:1
+      ~target_keeper:"ab"
+  in
+  check bool "tool call identity participates in dedupe" false (Id.Operation_id.equal left another_call)
 ;;
 
 let test_canonical_json_rejections () =
@@ -245,6 +256,17 @@ let test_ledger_replay_fifo_and_terminal_immutability () =
   (match settled.state with
    | Store.Settled -> ()
    | _ -> fail "Running operation did not settle");
+  let raw_db =
+    Sqlite3.db_open
+      (Filename.concat base_path ".masc/keepers/sangsu/operations.sqlite3")
+  in
+  let direct_update =
+    Sqlite3.exec
+      raw_db
+      "UPDATE operations SET request_digest = lower(hex(randomblob(32))) WHERE state = 'settled'"
+  in
+  ignore (Sqlite3.db_close raw_db : bool);
+  check bool "SQL trigger protects terminal row" true (direct_update <> Sqlite3.Rc.OK);
   let conflicting_outcome = put_outcome blobs "different" in
   (match
      Store.settle

--- a/test/test_keeper_operation_ledger.ml
+++ b/test/test_keeper_operation_ledger.ml
@@ -126,6 +126,18 @@ let test_blob_store_kind_and_readback () =
     "exact blob payload"
     (Request.Canonical_json.to_bytes payload)
     (Request.Canonical_json.to_bytes fetched);
+  let outcome = json_exn (`Assoc [ "kind", `String "accepted" ]) in
+  let outcome_ref =
+    result_exn Blob.error_to_string (Blob.put_outcome store outcome)
+  in
+  let fetched_outcome =
+    result_exn Blob.error_to_string (Blob.fetch_outcome store outcome_ref)
+    |> Option.get
+  in
+  check string
+    "exact outcome payload"
+    (Request.Canonical_json.to_bytes outcome)
+    (Request.Canonical_json.to_bytes fetched_outcome);
   let state_ref =
     result_exn Fun.id
       (Blob.State_ref.of_string (Blob.Input_ref.to_string input_ref))


### PR DESCRIPTION
## What

- Adds a typed, per-Keeper SQLite inbox ledger and bounded admission mailbox.
- Stores input, outcome, and state evidence as content-addressed blobs owned by the ledger.
- Keeps operation identity, FIFO state transitions, terminal immutability, and pause control in one storage authority.

## Current invariants

- Strict `kop1:` operation IDs and `sha256:` evidence references.
- Typed source and authenticated submitter decoding on every persisted-row audit.
- Blob-first admission and settlement with digest, kind, canonical-byte, and existence verification.
- One serialized store lane with a database constraint allowing at most one Running operation.
- Exact durable read-back after uncertain commits; writes stop when the durable result cannot be proven.
- Terminal operation and delivery rows reject direct SQL update or delete.
- Pre-mutation owned-path inspection rejects pre-existing symlink escapes.

## Verification

- `scripts/dune-local.sh build test/test_keeper_operation_ledger.exe`
- `scripts/dune-local.sh exec test/test_keeper_operation_ledger.exe` — 9/9 pass
- `python3 scripts/audit-dead-surface.py --exports --ratchet` — 551/551
- `python3 scripts/check_test_coverage.py` — pass
- `bash scripts/audit-ci-test-targets.sh` — pass
- `bash scripts/lint-ignore-without-comment.sh --strict --target lib/keeper_operation/keeper_operation_store.ml` — pass
- `bash scripts/lint/yaml-syntax.sh` — 20 workflows pass

## Draft boundary

This tranche is not wired to production Keeper dispatch yet. Production wiring and closed typed input codecs for Message, Stimulus, and Autonomous requests remain required before merge.
