### PR TITLE
refactor(runtime): own official-client MCP bridge

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -305,127 +305,6 @@ type io =
   ; receive : unit -> (Yojson.Safe.t, error) result
   }
 
-let jsonrpc_response ~id result =
-  `Assoc [ "jsonrpc", `String "2.0"; "id", id; "result", result ]
-;;
-
-let jsonrpc_error ~id ~code message =
-  `Assoc
-    [ "jsonrpc", `String "2.0"
-    ; "id", id
-    ; "error", `Assoc [ "code", `Int code; "message", `String message ]
-    ]
-;;
-
-let jsonrpc_id_to_call_id = function
-  | `String id when String.trim id <> "" -> Ok id
-  | `Int id -> Ok (string_of_int id)
-  | _ -> protocol_error "MCP tools/call" "request id must be a string or integer"
-;;
-
-let mcp_initialize ~id =
-  jsonrpc_response
-    ~id
-    (`Assoc
-       [ "protocolVersion", `String "2024-11-05"
-       ; "capabilities", `Assoc [ "tools", `Assoc [] ]
-       ; ( "serverInfo"
-         , `Assoc
-             [ "name", `String mcp_server_name
-             ; "version", `String "1.0.0"
-             ] )
-       ])
-;;
-
-let mcp_tools_list ~id tools =
-  jsonrpc_response
-    ~id
-    (`Assoc [ "tools", `List (List.map dynamic_tool_spec tools) ])
-;;
-
-let mcp_tool_result ~id (result : dynamic_tool_result) =
-  jsonrpc_response
-    ~id
-    (`Assoc
-       ([ ( "content"
-          , `List
-              [ `Assoc
-                  [ "type", `String "text"
-                  ; "text", `String result.content
-                  ] ] )
-        ]
-        @ if result.success then [] else [ "isError", `Bool true ]))
-;;
-
-let mcp_tools_call ~id ~params ~tools ~tool_call_count =
-  let stage = "MCP tools/call" in
-  let* call_id = jsonrpc_id_to_call_id id in
-  let* fields = assoc_at stage params in
-  let* name = required_string stage "name" fields in
-  let arguments =
-    match List.assoc_opt "arguments" fields with
-    | None -> Ok (`Assoc [])
-    | Some (`Assoc _ as arguments) -> Ok arguments
-    | Some _ -> protocol_error stage "field \"arguments\" must be an object"
-  in
-  let* arguments = arguments in
-  match find_dynamic_tool tools name with
-  | None ->
-    Ok
-      (jsonrpc_error
-         ~id
-         ~code:(-32602)
-         (Printf.sprintf "unknown MASC tool %S" name))
-  | Some tool ->
-    let result =
-      try tool.call ~call_id arguments with
-      | Eio.Cancel.Cancelled _ as exn -> raise exn
-      | exn ->
-        Log.Runtime_agent.warn
-          "Claude Code MCP tool handler raised (tool=%s error=%s)"
-          name
-          (Printexc.to_string exn);
-        { success = false; content = "MASC tool handler raised" }
-    in
-    incr tool_call_count;
-    Ok (mcp_tool_result ~id result)
-;;
-
-type mcp_dispatch =
-  | Mcp_response of Yojson.Safe.t
-  | Mcp_notification
-
-let handle_mcp_message ~tools ~tool_call_count message =
-  let stage = "MCP message" in
-  let* fields = assoc_at stage message in
-  let* jsonrpc = required_string stage "jsonrpc" fields in
-  if jsonrpc <> "2.0"
-  then protocol_error stage (Printf.sprintf "unsupported jsonrpc %S" jsonrpc)
-  else
-    let* method_ = required_string stage "method" fields in
-    let id = Option.value (List.assoc_opt "id" fields) ~default:`Null in
-    let params = Option.value (List.assoc_opt "params" fields) ~default:(`Assoc []) in
-    match method_ with
-    | "initialize" when id <> `Null -> Ok (Mcp_response (mcp_initialize ~id))
-    | "tools/list" when id <> `Null -> Ok (Mcp_response (mcp_tools_list ~id tools))
-    | "tools/call" when id <> `Null ->
-      let* response = mcp_tools_call ~id ~params ~tools ~tool_call_count in
-      Ok (Mcp_response response)
-    | "notifications/initialized" when id = `Null ->
-      Ok Mcp_notification
-    | _ when id = `Null ->
-      protocol_error
-        stage
-        (Printf.sprintf "MCP notification %S is not supported" method_)
-    | _ ->
-      Ok
-        (Mcp_response
-           (jsonrpc_error
-              ~id
-              ~code:(-32601)
-              (Printf.sprintf "MCP method %S is not supported" method_)))
-;;
-
 let send_control_success io ~request_id response =
   io.send
     (`Assoc
@@ -468,10 +347,39 @@ let handle_control_request io ~tools ~tool_call_count fields =
       Error (Unsupported_control_request subtype)
     else
       let* message = required_member stage "message" request_fields in
-      let* dispatch = handle_mcp_message ~tools ~tool_call_count message in
-      (match dispatch with
-       | Mcp_notification -> Ok ()
-       | Mcp_response mcp_response ->
+      let tool_specs () = List.map dynamic_tool_spec tools in
+      let call_tool ~name ~call_id ~arguments =
+        match find_dynamic_tool tools name with
+        | None -> None
+        | Some tool ->
+          let result =
+            try tool.call ~call_id arguments with
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+              Log.Runtime_agent.warn
+                "Claude Code MCP tool handler raised (tool=%s error=%s)"
+                name
+                (Printexc.to_string exn);
+              { success = false; content = "MASC tool handler raised" }
+          in
+          Some
+            { Runtime_official_client_mcp.success = result.success
+            ; content = result.content
+            }
+      in
+      let* dispatch =
+        Runtime_official_client_mcp.handle_message
+          ~server_name:mcp_server_name
+          ~tool_specs
+          ~call_tool
+          message
+        |> Result.map_error (fun { Runtime_official_client_mcp.stage; detail } ->
+          Protocol_error { stage; detail })
+      in
+      if dispatch.tool_called then incr tool_call_count;
+      (match dispatch.response with
+       | None -> Ok ()
+       | Some mcp_response ->
          send_control_success
            io
            ~request_id

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -1,0 +1,149 @@
+type error =
+  { stage : string
+  ; detail : string
+  }
+
+type tool_result =
+  { success : bool
+  ; content : string
+  }
+
+type dispatch =
+  { response : Yojson.Safe.t option
+  ; tool_called : bool
+  }
+
+let ( let* ) = Result.bind
+let error stage detail = Error { stage; detail }
+
+let assoc_at stage = function
+  | `Assoc fields -> Ok fields
+  | _ -> error stage "expected an object"
+;;
+
+let required_string stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> error stage (Printf.sprintf "field %S must be a string" name)
+  | None -> error stage (Printf.sprintf "missing field %S" name)
+;;
+
+let response ~id result =
+  `Assoc [ "jsonrpc", `String "2.0"; "id", id; "result", result ]
+;;
+
+let error_response ~id ~code message =
+  `Assoc
+    [ "jsonrpc", `String "2.0"
+    ; "id", id
+    ; "error", `Assoc [ "code", `Int code; "message", `String message ]
+    ]
+;;
+
+let request_id stage = function
+  | `String id when String.trim id <> "" -> Ok (`String id, id)
+  | `Int id -> Ok (`Int id, string_of_int id)
+  | _ -> error stage "request id must be a non-empty string or integer"
+;;
+
+let initialize ~server_name ~id =
+  response
+    ~id
+    (`Assoc
+       [ "protocolVersion", `String "2024-11-05"
+       ; "capabilities", `Assoc [ "tools", `Assoc [] ]
+       ; ( "serverInfo"
+         , `Assoc
+             [ "name", `String server_name
+             ; "version", `String "1.0.0"
+             ] )
+       ])
+;;
+
+let tool_result_json ~id (result : tool_result) =
+  response
+    ~id
+    (`Assoc
+       ([ ( "content"
+          , `List
+              [ `Assoc
+                  [ "type", `String "text"
+                  ; "text", `String result.content
+                  ] ] )
+        ]
+        @ if result.success then [] else [ "isError", `Bool true ]))
+;;
+
+let tools_call ~id ~params ~call_tool =
+  let stage = "MCP tools/call" in
+  let* id, call_id = request_id stage id in
+  let* fields = assoc_at stage params in
+  let* name = required_string stage "name" fields in
+  let* arguments =
+    match List.assoc_opt "arguments" fields with
+    | None -> Ok (`Assoc [])
+    | Some (`Assoc _ as arguments) -> Ok arguments
+    | Some _ -> error stage "field \"arguments\" must be an object"
+  in
+  match call_tool ~name ~call_id ~arguments with
+  | None ->
+    Ok
+      { response =
+          Some
+            (error_response
+               ~id
+               ~code:(-32602)
+               (Printf.sprintf "unknown official-client tool %S" name))
+      ; tool_called = false
+      }
+  | Some result ->
+    Ok { response = Some (tool_result_json ~id result); tool_called = true }
+;;
+
+let handle_message ~server_name ~tool_specs ~call_tool message =
+  let stage = "MCP message" in
+  let* fields = assoc_at stage message in
+  let* jsonrpc = required_string stage "jsonrpc" fields in
+  if jsonrpc <> "2.0"
+  then error stage (Printf.sprintf "unsupported jsonrpc %S" jsonrpc)
+  else
+    let* method_ = required_string stage "method" fields in
+    let id = Option.value (List.assoc_opt "id" fields) ~default:`Null in
+    let params = Option.value (List.assoc_opt "params" fields) ~default:(`Assoc []) in
+    let* request =
+      if id = `Null
+      then Ok None
+      else
+        let* id, _call_id = request_id stage id in
+        Ok (Some id)
+    in
+    match method_, request with
+    | "initialize", Some id ->
+      Ok
+        { response = Some (initialize ~server_name ~id)
+        ; tool_called = false
+        }
+    | "tools/list", Some id ->
+      Ok
+        { response =
+            Some (response ~id (`Assoc [ "tools", `List (tool_specs ()) ]))
+        ; tool_called = false
+        }
+    | "tools/call", Some id -> tools_call ~id ~params ~call_tool
+    | "notifications/initialized", None ->
+      Ok { response = None; tool_called = false }
+    | _, None ->
+      error
+        stage
+        (Printf.sprintf "MCP notification %S is not supported" method_)
+    | _, Some id ->
+      Ok
+        { response =
+            Some
+              (error_response
+                 ~id
+                 ~code:(-32601)
+                 (Printf.sprintf "MCP method %S is not supported" method_))
+        ; tool_called = false
+        }
+;;

--- a/lib/runtime/runtime_official_client_mcp.mli
+++ b/lib/runtime/runtime_official_client_mcp.mli
@@ -1,0 +1,31 @@
+(** Exact JSON-RPC/MCP bridge shared by official subscription clients.
+
+    Client adapters own their transport and tool representation. This module
+    owns the protocol state: initialize, tools/list, tools/call, notification
+    no-response semantics, and typed protocol failures. *)
+
+type error =
+  { stage : string
+  ; detail : string
+  }
+
+type tool_result =
+  { success : bool
+  ; content : string
+  }
+
+type dispatch =
+  { response : Yojson.Safe.t option
+  ; tool_called : bool
+  }
+
+val handle_message :
+  server_name:string ->
+  tool_specs:(unit -> Yojson.Safe.t list) ->
+  call_tool:
+    (name:string ->
+     call_id:string ->
+     arguments:Yojson.Safe.t ->
+     tool_result option) ->
+  Yojson.Safe.t ->
+  (dispatch, error) result

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -257,6 +257,82 @@ let test_mcp_notification_has_no_response () =
       | Ok turn -> check string "text" "MASC_CLAUDE_OK" turn.text)
 ;;
 
+let test_shared_mcp_bridge_owns_exact_dispatch () =
+  let tool_specs () =
+    [ `Assoc
+        [ "name", `String "masc_probe"
+        ; "description", `String "fixture"
+        ; "inputSchema", `Assoc [ "type", `String "object" ]
+        ]
+    ]
+  in
+  let call_tool ~name:_ ~call_id:_ ~arguments:_ =
+    fail "unknown tool dispatch reached the callback"
+  in
+  let dispatch json =
+    Runtime_official_client_mcp.handle_message
+      ~server_name:"masc"
+      ~tool_specs
+      ~call_tool
+      json
+    |> Result.get_ok
+  in
+  let list =
+    dispatch
+      (`Assoc
+         [ "jsonrpc", `String "2.0"
+         ; "id", `Int 1
+         ; "method", `String "tools/list"
+         ; "params", `Assoc []
+         ])
+  in
+  check bool "list has response" true (Option.is_some list.response);
+  check bool "list did not call a tool" false list.tool_called;
+  let notification =
+    dispatch
+      (`Assoc
+         [ "jsonrpc", `String "2.0"
+         ; "method", `String "notifications/initialized"
+         ; "params", `Assoc []
+         ])
+  in
+  check (option string) "notification has no response" None
+    (Option.map Yojson.Safe.to_string notification.response);
+  let unknown =
+    dispatch
+      (`Assoc
+         [ "jsonrpc", `String "2.0"
+         ; "id", `String "call-unknown"
+         ; "method", `String "tools/call"
+         ; ( "params"
+           , `Assoc
+               [ "name", `String "missing"
+               ; "arguments", `Assoc []
+               ] )
+         ])
+  in
+  check bool "unknown tool did not execute" false unknown.tool_called;
+  let open Yojson.Safe.Util in
+  check int
+    "unknown tool JSON-RPC code"
+    (-32602)
+    (unknown.response |> Option.get |> member "error" |> member "code" |> to_int);
+  (match
+     Runtime_official_client_mcp.handle_message
+       ~server_name:"masc"
+       ~tool_specs
+       ~call_tool
+       (`Assoc
+          [ "jsonrpc", `String "2.0"
+          ; "id", `Bool true
+          ; "method", `String "tools/list"
+          ])
+   with
+   | Error { stage = "MCP message"; _ } -> ()
+   | Error _ -> fail "invalid request id had the wrong error stage"
+   | Ok _ -> fail "boolean JSON-RPC request id was admitted")
+;;
+
 let test_malformed_json_fails_closed () =
   with_fixture [ Emit "not-json" ] (fun path ->
     match run_fixture path with
@@ -377,6 +453,10 @@ let () =
         ] )
     ; ( "mcp"
       , [ test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
+        ; test_case
+            "shared bridge owns exact dispatch"
+            `Quick
+            test_shared_mcp_bridge_owns_exact_dispatch
         ; test_case
             "notification has no response"
             `Quick


### PR DESCRIPTION
## Summary

- move exact JSON-RPC/MCP dispatch out of the Claude-specific transport into one provider-neutral runtime owner
- keep Claude Code as a production caller through a narrow tool-spec/tool-call adapter
- preserve notification no-response and unknown-tool fail-closed behavior while rejecting non-string/non-integer request IDs

## Why

Official subscription clients need one MASC-owned MCP boundary before another CLI transport can be added safely. This slice does not add Antigravity execution or claim subscription readiness; it removes the protocol duplication point that a later turn-scoped Antigravity bridge can reuse.

## Verification

- `ocamlformat` applied to changed OCaml files
- parser-only `ocamlc -stop-after parsing` passed for changed implementation/interface/test files
- focused/full build delegated to CI per operator request
