### PR TITLE
fix(runtime): negotiate official-client MCP protocol

### DIFF
--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -17,6 +17,7 @@
   masc.agent_core
   masc.agent_core.base
   masc.agent_core.llm_provider
+  masc.agent_core.mcp_protocol_bundle
   masc.masc_core
   masc.masc_types
   uri

--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -17,7 +17,7 @@
   masc.agent_core
   masc.agent_core.base
   masc.agent_core.llm_provider
-  masc.agent_core.mcp_protocol_bundle
+  masc.mcp_transport_protocol
   masc.masc_core
   masc.masc_types
   uri

--- a/lib/runtime/runtime_build_version.ml
+++ b/lib/runtime/runtime_build_version.ml
@@ -1,0 +1,7 @@
+(** Build version owner shared by runtime adapters and protocol servers. *)
+
+let current =
+  match Build_info.V1.version () with
+  | None -> "dev"
+  | Some version -> Build_info.V1.Version.to_string version
+;;

--- a/lib/runtime/runtime_build_version.mli
+++ b/lib/runtime/runtime_build_version.mli
@@ -1,0 +1,3 @@
+(** Build version projected from the linked dune-build-info metadata. *)
+
+val current : string

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -373,7 +373,7 @@ let handle_control_request io ~tools ~tool_call_count fields =
           ~tool_specs
           ~call_tool
           (Yojson.Safe.to_string message)
-        |> Result.map_error (fun { Runtime_official_client_mcp.stage; detail } ->
+        |> Result.map_error (fun { Runtime_official_client_mcp.stage; detail; _ } ->
           Protocol_error { stage; detail })
       in
       if dispatch.tool_called then incr tool_call_count;

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -372,8 +372,8 @@ let handle_control_request io ~tools ~tool_call_count fields =
           ~server_name:mcp_server_name
           ~tool_specs
           ~call_tool
-          (Yojson.Safe.to_string message)
-        |> Result.map_error (fun { Runtime_official_client_mcp.stage; detail; _ } ->
+          message
+        |> Result.map_error (fun { Runtime_official_client_mcp.stage; detail } ->
           Protocol_error { stage; detail })
       in
       if dispatch.tool_called then incr tool_call_count;

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -331,7 +331,7 @@ let send_control_error io ~request_id detail =
        ])
 ;;
 
-let handle_control_request io ~tools ~tool_call_count fields =
+let handle_control_request io ~mcp_session ~tools ~tool_call_count fields =
   let stage = "control request" in
   let* request_id = required_string stage "request_id" fields in
   let* request = required_member stage "request" fields in
@@ -369,6 +369,7 @@ let handle_control_request io ~tools ~tool_call_count fields =
       in
       let* dispatch =
         Runtime_official_client_mcp.handle_message
+          ~session:mcp_session
           ~server_name:mcp_server_name
           ~tool_specs
           ~call_tool
@@ -435,17 +436,25 @@ let parse_control_response ~expected_request_id fields =
       protocol_error stage (Printf.sprintf "unknown response subtype %S" other)
 ;;
 
-let rec await_initialize io ~tools ~tool_call_count ~request_id ~ignored =
+let rec await_initialize io ~mcp_session ~tools ~tool_call_count ~request_id ~ignored =
   let* json = io.receive () in
   let* type_, fields = wire_fields json in
   match type_ with
   | "control_response" ->
     parse_control_response ~expected_request_id:request_id fields
   | "control_request" ->
-    let* () = handle_control_request io ~tools ~tool_call_count fields in
-    await_initialize io ~tools ~tool_call_count ~request_id ~ignored
+    let* () =
+      handle_control_request io ~mcp_session ~tools ~tool_call_count fields
+    in
+    await_initialize io ~mcp_session ~tools ~tool_call_count ~request_id ~ignored
   | ("system" | "rate_limit_event") when ignored < 32 ->
-    await_initialize io ~tools ~tool_call_count ~request_id ~ignored:(ignored + 1)
+    await_initialize
+      io
+      ~mcp_session
+      ~tools
+      ~tool_call_count
+      ~request_id
+      ~ignored:(ignored + 1)
   | other ->
     protocol_error
       "initialize"
@@ -585,30 +594,32 @@ let parse_result ~expected_session_id ~rate_limit fields =
 
 let max_ignored_messages = 256
 
-let rec await_terminal io ~tools ~tool_call_count ~expected_session_id
+let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session_id
     ~subscription ~resumed ~rate_limit ~assistant_model ~assistant_texts
     ~on_turn_started ~ignored =
   let* json = io.receive () in
   let* type_, fields = wire_fields json in
   match type_ with
   | "control_request" ->
-    let* () = handle_control_request io ~tools ~tool_call_count fields in
+    let* () =
+      handle_control_request io ~mcp_session ~tools ~tool_call_count fields
+    in
     await_terminal
-      io ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
+      io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit ~assistant_model ~assistant_texts ~on_turn_started ~ignored
   | "control_response" ->
     protocol_error "turn" "received an unsolicited control response"
   | "assistant" ->
     let* _uuid, model, texts = parse_assistant ~expected_session_id fields in
     await_terminal
-      io ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
+      io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit ~assistant_model:(Some model)
       ~assistant_texts:(assistant_texts @ texts)
       ~on_turn_started ~ignored
   | "rate_limit_event" ->
     let* rate_limit = parse_rate_limit ~expected_session_id fields in
     await_terminal
-      io ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
+      io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit:(Some rate_limit) ~assistant_model ~assistant_texts
       ~on_turn_started ~ignored
   | "result" ->
@@ -650,7 +661,7 @@ let rec await_terminal io ~tools ~tool_call_count ~expected_session_id
       }
   | ("system" | "user") when ignored < max_ignored_messages ->
     await_terminal
-      io ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
+      io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit ~assistant_model ~assistant_texts ~on_turn_started
       ~ignored:(ignored + 1)
   | other ->
@@ -788,11 +799,13 @@ let terminate_spawned_process ~clock proc stdin_w =
 let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
     ~prompt ~on_session_ready ~on_turn_starting ~on_turn_started =
   let tool_call_count = ref 0 in
+  let mcp_session = Runtime_official_client_mcp.create_session () in
   let initialize_id = Random_id.prefixed ~prefix:"masc-init-" ~bytes:12 in
   io.send (initialize_request initialize_id);
   let* () =
     await_initialize
       io
+      ~mcp_session
       ~tools:dynamic_tools
       ~tool_call_count
       ~request_id:initialize_id
@@ -809,6 +822,7 @@ let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
   io.send (user_message prompt);
   await_terminal
     io
+    ~mcp_session
     ~tools:dynamic_tools
     ~tool_call_count
     ~expected_session_id:session_id

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -25,11 +25,7 @@ let approval_policy = "never"
 let permissions_profile = ":read-only"
 let thread_is_ephemeral = false
 
-let client_version =
-  match Build_info.V1.version () with
-  | None -> "dev"
-  | Some version -> Build_info.V1.Version.to_string version
-;;
+let client_version = Runtime_build_version.current
 
 let default_config () =
   { cli_path = "codex"

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -59,6 +59,8 @@ let reject_unknown_fields ~stage ~allowed fields =
 let parse_message stage raw_message =
   try Ok (Yojson.Safe.from_string raw_message) with
   | Yojson.Json_error detail -> error stage ("invalid JSON: " ^ detail)
+  | Stack_overflow -> error stage "JSON nesting exceeds parser limits"
+  | Failure detail -> error stage ("invalid JSON: " ^ detail)
 ;;
 
 let assoc_at stage = function
@@ -106,18 +108,32 @@ let params_object stage fields =
   | Some _ -> error stage "field \"params\" must be an object"
 ;;
 
-let initialize ~server_name ~id =
-  response
-    ~id
-    (`Assoc
-       [ "protocolVersion", `String "2024-11-05"
-       ; "capabilities", `Assoc [ "tools", `Assoc [] ]
-       ; ( "serverInfo"
-         , `Assoc
-             [ "name", `String server_name
-             ; "version", `String "1.0.0"
-             ] )
-       ])
+let protocol_version params =
+  let supported = [ "2025-11-25"; "2025-06-18"; "2025-03-26"; "2024-11-05" ] in
+  match params with
+  | `Assoc fields ->
+    (match List.assoc_opt "protocolVersion" fields with
+     | Some (`String requested) when List.mem requested supported -> Ok requested
+     | Some (`String _) -> Ok "2025-11-25"
+     | None -> Ok "2024-11-05"
+     | Some _ -> error "MCP initialize" "field \"protocolVersion\" must be a string")
+  | _ -> error "MCP initialize" "params must be an object"
+;;
+
+let initialize ~server_name ~id ~params =
+  let* protocol_version = protocol_version params in
+  Ok
+    (response
+       ~id
+       (`Assoc
+          [ "protocolVersion", `String protocol_version
+          ; "capabilities", `Assoc [ "tools", `Assoc [] ]
+          ; ( "serverInfo"
+            , `Assoc
+                [ "name", `String server_name
+                ; "version", `String "1.0.0"
+                ] )
+          ]))
 ;;
 
 let tool_result_json ~id (result : tool_result) =
@@ -182,8 +198,9 @@ let handle_message ~server_name ~tool_specs ~call_tool raw_message =
     let* request = request_id_opt stage fields in
     match method_, request with
     | "initialize", Some id ->
+      let* initialize_response = initialize ~server_name ~id ~params in
       Ok
-        { response = Some (initialize ~server_name ~id)
+        { response = Some initialize_response
         ; tool_called = false
         }
     | "tools/list", Some id ->

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -173,7 +173,7 @@ let initialize ~server_name ~id ~params =
           ; ( "serverInfo"
             , `Assoc
                 [ "name", `String server_name
-                ; "version", `String Version.version
+                ; "version", `String Runtime_build_version.current
                 ] )
           ]))
 ;;

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -13,6 +13,15 @@ type dispatch =
   ; tool_called : bool
   }
 
+type phase =
+  | Awaiting_initialize
+  | Awaiting_initialized
+  | Ready
+
+type session =
+  { phase : phase Atomic.t
+  }
+
 type message =
   { method_name : string
   ; request_id : Mcp_transport_protocol.request_id option
@@ -21,6 +30,40 @@ type message =
 
 let ( let* ) = Result.bind
 let error stage detail = Error { stage; detail }
+
+let create_session () = { phase = Atomic.make Awaiting_initialize }
+
+let phase_to_string = function
+  | Awaiting_initialize -> "awaiting_initialize"
+  | Awaiting_initialized -> "awaiting_initialized"
+  | Ready -> "ready"
+;;
+
+let require_phase session ~stage expected =
+  let actual = Atomic.get session.phase in
+  if actual = expected
+  then Ok ()
+  else
+    error
+      stage
+      (Printf.sprintf
+         "MCP session phase is %s; expected %s"
+         (phase_to_string actual)
+         (phase_to_string expected))
+;;
+
+let transition_phase session ~stage ~expected ~next =
+  if Atomic.compare_and_set session.phase expected next
+  then Ok ()
+  else
+    let actual = Atomic.get session.phase in
+    error
+      stage
+      (Printf.sprintf
+         "MCP session phase changed to %s; expected %s"
+         (phase_to_string actual)
+         (phase_to_string expected))
+;;
 
 let rec validate_message_value ~stage ~path = function
   | `Assoc fields ->
@@ -197,16 +240,25 @@ let decode_message message =
     Ok { method_name; request_id; params }
 ;;
 
-let dispatch_message ~server_name ~tool_specs ~call_tool message =
+let dispatch_message ~session ~server_name ~tool_specs ~call_tool message =
   match message.method_name, message.request_id with
     | "initialize", Some request_id ->
+      let* () = require_phase session ~stage:"MCP initialize" Awaiting_initialize in
       let id = Mcp_transport_protocol.request_id_to_yojson request_id in
       let* initialize_response = initialize ~server_name ~id ~params:message.params in
+      let* () =
+        transition_phase
+          session
+          ~stage:"MCP initialize"
+          ~expected:Awaiting_initialize
+          ~next:Awaiting_initialized
+      in
       Ok
         { response = Some initialize_response
         ; tool_called = false
         }
     | "tools/list", Some request_id ->
+      let* () = require_phase session ~stage:"MCP tools/list" Ready in
       let id = Mcp_transport_protocol.request_id_to_yojson request_id in
       Ok
         { response =
@@ -217,11 +269,19 @@ let dispatch_message ~server_name ~tool_specs ~call_tool message =
         ; tool_called = false
         }
     | "tools/call", Some request_id ->
+      let* () = require_phase session ~stage:"MCP tools/call" Ready in
       tools_call
         ~id:(Mcp_transport_protocol.request_id_to_yojson request_id)
         ~params:message.params
         ~call_tool
     | "notifications/initialized", None ->
+      let* () =
+        transition_phase
+          session
+          ~stage:"MCP notifications/initialized"
+          ~expected:Awaiting_initialized
+          ~next:Ready
+      in
       Ok { response = None; tool_called = false }
     | _, None ->
       error
@@ -240,7 +300,7 @@ let dispatch_message ~server_name ~tool_specs ~call_tool message =
         }
 ;;
 
-let handle_message ~server_name ~tool_specs ~call_tool message_json =
+let handle_message ~session ~server_name ~tool_specs ~call_tool message_json =
   let* message = decode_message message_json in
-  dispatch_message ~server_name ~tool_specs ~call_tool message
+  dispatch_message ~session ~server_name ~tool_specs ~call_tool message
 ;;

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -1,5 +1,10 @@
+type error_kind =
+  | Json_parse
+  | Protocol
+
 type error =
-  { stage : string
+  { kind : error_kind
+  ; stage : string
   ; detail : string
   }
 
@@ -20,7 +25,8 @@ type message =
   }
 
 let ( let* ) = Result.bind
-let error stage detail = Error { stage; detail }
+let error stage detail = Error { kind = Protocol; stage; detail }
+let json_parse_error stage detail = Error { kind = Json_parse; stage; detail }
 
 let rec validate_message_value ~stage ~path = function
   | `Assoc fields ->
@@ -64,9 +70,9 @@ let reject_unknown_fields ~stage ~allowed fields =
 
 let parse_message stage raw_message =
   try Ok (Yojson.Safe.from_string raw_message) with
-  | Yojson.Json_error detail -> error stage ("invalid JSON: " ^ detail)
-  | Stack_overflow -> error stage "JSON nesting exceeds parser limits"
-  | Failure detail -> error stage ("invalid JSON: " ^ detail)
+  | Yojson.Json_error detail -> json_parse_error stage ("invalid JSON: " ^ detail)
+  | Stack_overflow -> json_parse_error stage "JSON nesting exceeds parser limits"
+  | Failure detail -> json_parse_error stage ("invalid JSON: " ^ detail)
 ;;
 
 let assoc_at stage = function

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -13,6 +13,12 @@ type dispatch =
   ; tool_called : bool
   }
 
+type message =
+  { method_name : string
+  ; request_id : Yojson.Safe.t option
+  ; params : Yojson.Safe.t
+  }
+
 let ( let* ) = Result.bind
 let error stage detail = Error { stage; detail }
 
@@ -176,9 +182,12 @@ let tools_call ~id ~params ~call_tool =
     Ok { response = Some (tool_result_json ~id result); tool_called = true }
 ;;
 
+let message_method message = message.method_name
+let message_request_id message = message.request_id
+
 (* TEL-OK: pure fail-closed protocol decoder; the runtime caller owns terminal
    error telemetry and control-response delivery. *)
-let handle_message ~server_name ~tool_specs ~call_tool raw_message =
+let decode_message raw_message =
   let stage = "MCP message" in
   let* message = parse_message stage raw_message in
   let* () = validate_message_value ~stage ~path:"$" message in
@@ -193,12 +202,16 @@ let handle_message ~server_name ~tool_specs ~call_tool raw_message =
   if jsonrpc <> "2.0"
   then error stage (Printf.sprintf "unsupported jsonrpc %S" jsonrpc)
   else
-    let* method_ = required_string stage "method" fields in
+    let* method_name = required_string stage "method" fields in
     let* params = params_object stage fields in
-    let* request = request_id_opt stage fields in
-    match method_, request with
+    let* request_id = request_id_opt stage fields in
+    Ok { method_name; request_id; params }
+;;
+
+let dispatch_message ~server_name ~tool_specs ~call_tool message =
+  match message.method_name, message.request_id with
     | "initialize", Some id ->
-      let* initialize_response = initialize ~server_name ~id ~params in
+      let* initialize_response = initialize ~server_name ~id ~params:message.params in
       Ok
         { response = Some initialize_response
         ; tool_called = false
@@ -209,13 +222,13 @@ let handle_message ~server_name ~tool_specs ~call_tool raw_message =
             Some (response ~id (`Assoc [ "tools", `List (tool_specs ()) ]))
         ; tool_called = false
         }
-    | "tools/call", Some id -> tools_call ~id ~params ~call_tool
+    | "tools/call", Some id -> tools_call ~id ~params:message.params ~call_tool
     | "notifications/initialized", None ->
       Ok { response = None; tool_called = false }
     | _, None ->
       error
-        stage
-        (Printf.sprintf "MCP notification %S is not supported" method_)
+        "MCP message"
+        (Printf.sprintf "MCP notification %S is not supported" message.method_name)
     | _, Some id ->
       Ok
         { response =
@@ -223,7 +236,12 @@ let handle_message ~server_name ~tool_specs ~call_tool raw_message =
               (error_response
                  ~id
                  ~code:(-32601)
-                 (Printf.sprintf "MCP method %S is not supported" method_))
+                 (Printf.sprintf "MCP method %S is not supported" message.method_name))
         ; tool_called = false
         }
+;;
+
+let handle_message ~server_name ~tool_specs ~call_tool raw_message =
+  let* message = decode_message raw_message in
+  dispatch_message ~server_name ~tool_specs ~call_tool message
 ;;

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -1,10 +1,5 @@
-type error_kind =
-  | Json_parse
-  | Protocol
-
 type error =
-  { kind : error_kind
-  ; stage : string
+  { stage : string
   ; detail : string
   }
 
@@ -20,13 +15,12 @@ type dispatch =
 
 type message =
   { method_name : string
-  ; request_id : Yojson.Safe.t option
+  ; request_id : Mcp_transport_protocol.request_id option
   ; params : Yojson.Safe.t
   }
 
 let ( let* ) = Result.bind
-let error stage detail = Error { kind = Protocol; stage; detail }
-let json_parse_error stage detail = Error { kind = Json_parse; stage; detail }
+let error stage detail = Error { stage; detail }
 
 let rec validate_message_value ~stage ~path = function
   | `Assoc fields ->
@@ -68,13 +62,6 @@ let reject_unknown_fields ~stage ~allowed fields =
   | Some (name, _) -> error stage (Printf.sprintf "unknown field %S" name)
 ;;
 
-let parse_message stage raw_message =
-  try Ok (Yojson.Safe.from_string raw_message) with
-  | Yojson.Json_error detail -> json_parse_error stage ("invalid JSON: " ^ detail)
-  | Stack_overflow -> json_parse_error stage "JSON nesting exceeds parser limits"
-  | Failure detail -> json_parse_error stage ("invalid JSON: " ^ detail)
-;;
-
 let assoc_at stage = function
   | `Assoc fields -> Ok fields
   | _ -> error stage "expected an object"
@@ -87,30 +74,29 @@ let required_string stage name fields =
   | None -> error stage (Printf.sprintf "missing field %S" name)
 ;;
 
-let response ~id result =
-  `Assoc [ "jsonrpc", `String "2.0"; "id", id; "result", result ]
-;;
-
-let error_response ~id ~code message =
-  `Assoc
-    [ "jsonrpc", `String "2.0"
-    ; "id", id
-    ; "error", `Assoc [ "code", `Int code; "message", `String message ]
-    ]
-;;
-
 let request_id stage = function
-  | `String id when String.trim id <> "" -> Ok (`String id, id)
-  | `Int id -> Ok (`Int id, string_of_int id)
-  | _ -> error stage "request id must be a non-empty string or integer"
+  | id ->
+    (match Mcp_transport_protocol.request_id_of_yojson id with
+     | Error request_id_error ->
+       error
+         stage
+         (Mcp_transport_protocol.request_id_error_to_string request_id_error)
+     | Ok request_id ->
+       let json = Mcp_transport_protocol.request_id_to_yojson request_id in
+       let* call_id =
+         match json with
+         | `String value | `Intlit value -> Ok value
+         | _ -> error stage "typed request id projected to an invalid JSON value"
+       in
+       Ok (request_id, json, call_id))
 ;;
 
 let request_id_opt stage fields =
   match List.assoc_opt "id" fields with
   | None -> Ok None
   | Some id ->
-    let* id, _call_id = request_id stage id in
-    Ok (Some id)
+    let* request_id, _json, _call_id = request_id stage id in
+    Ok (Some request_id)
 ;;
 
 let params_object stage fields =
@@ -121,21 +107,22 @@ let params_object stage fields =
 ;;
 
 let protocol_version params =
-  let supported = [ "2025-11-25"; "2025-06-18"; "2025-03-26"; "2024-11-05" ] in
-  match params with
-  | `Assoc fields ->
-    (match List.assoc_opt "protocolVersion" fields with
-     | Some (`String requested) when List.mem requested supported -> Ok requested
-     | Some (`String _) -> Ok "2025-11-25"
-     | None -> Ok "2024-11-05"
-     | Some _ -> error "MCP initialize" "field \"protocolVersion\" must be a string")
-  | _ -> error "MCP initialize" "params must be an object"
+  let stage = "MCP initialize" in
+  let* () =
+    Mcp_transport_protocol.validate_initialize_params (Some params)
+    |> Result.map_error (fun detail -> { stage; detail })
+  in
+  match Mcp_transport_protocol.get_field "protocolVersion" params with
+  | Some (`String requested) ->
+    Mcp_transport_protocol.validate_protocol_version requested
+    |> Result.map_error (fun detail -> { stage; detail })
+  | None | Some _ -> error stage "invalid protocolVersion"
 ;;
 
 let initialize ~server_name ~id ~params =
   let* protocol_version = protocol_version params in
   Ok
-    (response
+    (Mcp_transport_protocol.make_response
        ~id
        (`Assoc
           [ "protocolVersion", `String protocol_version
@@ -143,13 +130,13 @@ let initialize ~server_name ~id ~params =
           ; ( "serverInfo"
             , `Assoc
                 [ "name", `String server_name
-                ; "version", `String "1.0.0"
+                ; "version", `String Version.version
                 ] )
           ]))
 ;;
 
 let tool_result_json ~id (result : tool_result) =
-  response
+  Mcp_transport_protocol.make_response
     ~id
     (`Assoc
        ([ ( "content"
@@ -164,7 +151,7 @@ let tool_result_json ~id (result : tool_result) =
 
 let tools_call ~id ~params ~call_tool =
   let stage = "MCP tools/call" in
-  let* id, call_id = request_id stage id in
+  let* _request_id, id, call_id = request_id stage id in
   let* fields = assoc_at stage params in
   let* name = required_string stage "name" fields in
   let* arguments =
@@ -178,9 +165,9 @@ let tools_call ~id ~params ~call_tool =
     Ok
       { response =
           Some
-            (error_response
+            (Mcp_transport_protocol.make_error
                ~id
-               ~code:(-32602)
+               (-32602)
                (Printf.sprintf "unknown official-client tool %S" name))
       ; tool_called = false
       }
@@ -188,14 +175,10 @@ let tools_call ~id ~params ~call_tool =
     Ok { response = Some (tool_result_json ~id result); tool_called = true }
 ;;
 
-let message_method message = message.method_name
-let message_request_id message = message.request_id
-
 (* TEL-OK: pure fail-closed protocol decoder; the runtime caller owns terminal
    error telemetry and control-response delivery. *)
-let decode_message raw_message =
+let decode_message message =
   let stage = "MCP message" in
-  let* message = parse_message stage raw_message in
   let* () = validate_message_value ~stage ~path:"$" message in
   let* fields = assoc_at stage message in
   let* () =
@@ -216,38 +199,48 @@ let decode_message raw_message =
 
 let dispatch_message ~server_name ~tool_specs ~call_tool message =
   match message.method_name, message.request_id with
-    | "initialize", Some id ->
+    | "initialize", Some request_id ->
+      let id = Mcp_transport_protocol.request_id_to_yojson request_id in
       let* initialize_response = initialize ~server_name ~id ~params:message.params in
       Ok
         { response = Some initialize_response
         ; tool_called = false
         }
-    | "tools/list", Some id ->
+    | "tools/list", Some request_id ->
+      let id = Mcp_transport_protocol.request_id_to_yojson request_id in
       Ok
         { response =
-            Some (response ~id (`Assoc [ "tools", `List (tool_specs ()) ]))
+            Some
+              (Mcp_transport_protocol.make_response
+                 ~id
+                 (`Assoc [ "tools", `List (tool_specs ()) ]))
         ; tool_called = false
         }
-    | "tools/call", Some id -> tools_call ~id ~params:message.params ~call_tool
+    | "tools/call", Some request_id ->
+      tools_call
+        ~id:(Mcp_transport_protocol.request_id_to_yojson request_id)
+        ~params:message.params
+        ~call_tool
     | "notifications/initialized", None ->
       Ok { response = None; tool_called = false }
     | _, None ->
       error
         "MCP message"
         (Printf.sprintf "MCP notification %S is not supported" message.method_name)
-    | _, Some id ->
+    | _, Some request_id ->
+      let id = Mcp_transport_protocol.request_id_to_yojson request_id in
       Ok
         { response =
             Some
-              (error_response
+              (Mcp_transport_protocol.make_error
                  ~id
-                 ~code:(-32601)
+                 (-32601)
                  (Printf.sprintf "MCP method %S is not supported" message.method_name))
         ; tool_called = false
         }
 ;;
 
-let handle_message ~server_name ~tool_specs ~call_tool raw_message =
-  let* message = decode_message raw_message in
+let handle_message ~server_name ~tool_specs ~call_tool message_json =
+  let* message = decode_message message_json in
   dispatch_message ~server_name ~tool_specs ~call_tool message
 ;;

--- a/lib/runtime/runtime_official_client_mcp.mli
+++ b/lib/runtime/runtime_official_client_mcp.mli
@@ -5,8 +5,13 @@
     tools/list, tools/call, notification no-response semantics, and typed
     protocol failures. *)
 
+type error_kind =
+  | Json_parse
+  | Protocol
+
 type error =
-  { stage : string
+  { kind : error_kind
+  ; stage : string
   ; detail : string
   }
 

--- a/lib/runtime/runtime_official_client_mcp.mli
+++ b/lib/runtime/runtime_official_client_mcp.mli
@@ -1,17 +1,12 @@
 (** Exact JSON-RPC/MCP bridge shared by official subscription clients.
 
     Client adapters own their transport and tool representation. This module's
-    raw-text entrypoint owns JSON parsing and the protocol state: initialize,
-    tools/list, tools/call, notification no-response semantics, and typed
-    protocol failures. *)
-
-type error_kind =
-  | Json_parse
-  | Protocol
+    parsed-message entrypoint owns protocol validation and dispatch:
+    initialize, tools/list, tools/call, and notification no-response
+    semantics. Each client adapter owns its raw transport parsing. *)
 
 type error =
-  { kind : error_kind
-  ; stage : string
+  { stage : string
   ; detail : string
   }
 
@@ -25,23 +20,6 @@ type dispatch =
   ; tool_called : bool
   }
 
-type message
-
-val decode_message : string -> (message, error) result
-val message_method : message -> string
-val message_request_id : message -> Yojson.Safe.t option
-
-val dispatch_message :
-  server_name:string ->
-  tool_specs:(unit -> Yojson.Safe.t list) ->
-  call_tool:
-    (name:string ->
-     call_id:string ->
-     arguments:Yojson.Safe.t ->
-     tool_result option) ->
-  message ->
-  (dispatch, error) result
-
 val handle_message :
   server_name:string ->
   tool_specs:(unit -> Yojson.Safe.t list) ->
@@ -50,5 +28,5 @@ val handle_message :
      call_id:string ->
      arguments:Yojson.Safe.t ->
      tool_result option) ->
-  string ->
+  Yojson.Safe.t ->
   (dispatch, error) result

--- a/lib/runtime/runtime_official_client_mcp.mli
+++ b/lib/runtime/runtime_official_client_mcp.mli
@@ -20,7 +20,13 @@ type dispatch =
   ; tool_called : bool
   }
 
+type session
+
+val create_session : unit -> session
+(** Fresh closed lifecycle: initialize, initialized notification, then Ready. *)
+
 val handle_message :
+  session:session ->
   server_name:string ->
   tool_specs:(unit -> Yojson.Safe.t list) ->
   call_tool:

--- a/lib/runtime/runtime_official_client_mcp.mli
+++ b/lib/runtime/runtime_official_client_mcp.mli
@@ -20,6 +20,23 @@ type dispatch =
   ; tool_called : bool
   }
 
+type message
+
+val decode_message : string -> (message, error) result
+val message_method : message -> string
+val message_request_id : message -> Yojson.Safe.t option
+
+val dispatch_message :
+  server_name:string ->
+  tool_specs:(unit -> Yojson.Safe.t list) ->
+  call_tool:
+    (name:string ->
+     call_id:string ->
+     arguments:Yojson.Safe.t ->
+     tool_result option) ->
+  message ->
+  (dispatch, error) result
+
 val handle_message :
   server_name:string ->
   tool_specs:(unit -> Yojson.Safe.t list) ->

--- a/lib/version.ml
+++ b/lib/version.ml
@@ -1,6 +1,3 @@
-(** Version auto-synced from dune-project via dune-build-info *)
+(** Version auto-synced from dune-project via the runtime build owner. *)
 
-let version =
-  match Build_info.V1.version () with
-  | None -> "dev"
-  | Some v -> Build_info.V1.Version.to_string v
+let version = Runtime_build_version.current

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -272,11 +272,19 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
     else failf "unexpected tool dispatch reached the callback: %s" name
   in
   let dispatch json =
-    Runtime_official_client_mcp.handle_message
+    let message =
+      Runtime_official_client_mcp.decode_message (Yojson.Safe.to_string json)
+      |> Result.get_ok
+    in
+    check string
+      "decoded method"
+      (json |> Yojson.Safe.Util.member "method" |> Yojson.Safe.Util.to_string)
+      (Runtime_official_client_mcp.message_method message);
+    Runtime_official_client_mcp.dispatch_message
       ~server_name:"masc"
       ~tool_specs
       ~call_tool
-      (Yojson.Safe.to_string json)
+      message
     |> Result.get_ok
   in
   let list =
@@ -289,6 +297,17 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
          ])
   in
   check bool "list has response" true (Option.is_some list.response);
+  let decoded_list =
+    Runtime_official_client_mcp.decode_message
+      {|{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}|}
+    |> Result.get_ok
+  in
+  check
+    (option string)
+    "decoded request id"
+    (Some "1")
+    (Runtime_official_client_mcp.message_request_id decoded_list
+     |> Option.map Yojson.Safe.to_string);
   check bool "list did not call a tool" false list.tool_called;
   let notification =
     dispatch

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -379,6 +379,32 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
   rejects_raw "malformed JSON" {|{"jsonrpc":"2.0","id":7|}
 ;;
 
+let test_shared_mcp_protocol_is_negotiated () =
+  let tool_specs () = [] in
+  let call_tool ~name:_ ~call_id:_ ~arguments:_ = None in
+  let initialize =
+    {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}|}
+  in
+  let open Yojson.Safe.Util in
+  match
+    Runtime_official_client_mcp.handle_message
+      ~server_name:"masc"
+      ~tool_specs
+      ~call_tool
+      initialize
+  with
+  | Error error -> fail (error.stage ^ ": " ^ error.detail)
+  | Ok dispatch ->
+    check string
+      "measured Antigravity protocol"
+      "2025-11-25"
+      (dispatch.response
+       |> Option.get
+       |> member "result"
+       |> member "protocolVersion"
+       |> to_string)
+;;
+
 let test_malformed_json_fails_closed () =
   with_fixture [ Emit "not-json" ] (fun path ->
     match run_fixture path with
@@ -503,6 +529,10 @@ let () =
             "shared bridge owns exact dispatch"
             `Quick
             test_shared_mcp_bridge_owns_exact_dispatch
+        ; test_case
+            "shared protocol is negotiated"
+            `Quick
+            test_shared_mcp_protocol_is_negotiated
         ; test_case
             "notification has no response"
             `Quick

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -226,6 +226,7 @@ let test_dynamic_tool_callback () =
   in
   with_fixture
     [ Emit_and_read mcp_initialize
+    ; Emit mcp_initialized_notification
     ; Emit_and_read mcp_list
     ; Emit_and_read mcp_call
     ; Emit assistant
@@ -245,7 +246,8 @@ let test_dynamic_tool_callback () =
 
 let test_mcp_notification_has_no_response () =
   with_fixture
-    [ Emit mcp_initialized_notification
+    [ Emit_and_read mcp_initialize
+    ; Emit mcp_initialized_notification
     ; Emit_and_expect_request_id
         (mcp_list_after_notification, "mcp-list-after-notification")
     ; Emit assistant
@@ -271,14 +273,122 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
     then None
     else failf "unexpected tool dispatch reached the callback: %s" name
   in
+  let session = Runtime_official_client_mcp.create_session () in
   let dispatch json =
     Runtime_official_client_mcp.handle_message
+      ~session
       ~server_name:"masc"
       ~tool_specs
       ~call_tool
       json
     |> Result.get_ok
   in
+  let callback_count = ref 0 in
+  let guarded_call_tool ~name:_ ~call_id:_ ~arguments:_ =
+    incr callback_count;
+    Some { Runtime_official_client_mcp.success = true; content = "unexpected" }
+  in
+  let fresh_session = Runtime_official_client_mcp.create_session () in
+  let rejects_phase label message =
+    match
+      Runtime_official_client_mcp.handle_message
+        ~session:fresh_session
+        ~server_name:"masc"
+        ~tool_specs
+        ~call_tool:guarded_call_tool
+        message
+    with
+    | Error { stage; _ } when String.starts_with ~prefix:"MCP " stage -> ()
+    | Error _ -> failf "%s had the wrong lifecycle error stage" label
+    | Ok _ -> failf "%s bypassed the MCP lifecycle" label
+  in
+  rejects_phase
+    "list before initialize"
+    (`Assoc
+       [ "jsonrpc", `String "2.0"
+       ; "id", `Int 90
+       ; "method", `String "tools/list"
+       ; "params", `Assoc []
+       ]);
+  rejects_phase
+    "call before initialize"
+    (`Assoc
+       [ "jsonrpc", `String "2.0"
+       ; "id", `Int 91
+       ; "method", `String "tools/call"
+       ; ( "params"
+         , `Assoc
+             [ "name", `String "masc_probe"
+             ; "arguments", `Assoc []
+             ] )
+       ]);
+  check int "pre-initialize callback count" 0 !callback_count;
+  let initialized =
+    Runtime_official_client_mcp.handle_message
+      ~session:fresh_session
+      ~server_name:"masc"
+      ~tool_specs
+      ~call_tool:guarded_call_tool
+      (`Assoc
+         [ "jsonrpc", `String "2.0"
+         ; "id", `Int 92
+         ; "method", `String "initialize"
+         ; ( "params"
+           , `Assoc
+               [ "protocolVersion", `String "2025-11-25"
+               ; "capabilities", `Assoc []
+               ; ( "clientInfo"
+                 , `Assoc
+                     [ "name", `String "official-client-test"
+                     ; "version", `String "1"
+                     ] )
+               ] )
+         ])
+    |> Result.get_ok
+  in
+  check bool "initialize has response" true (Option.is_some initialized.response);
+  rejects_phase
+    "call before initialized notification"
+    (`Assoc
+       [ "jsonrpc", `String "2.0"
+       ; "id", `Int 93
+       ; "method", `String "tools/call"
+       ; ( "params"
+         , `Assoc
+             [ "name", `String "masc_probe"
+             ; "arguments", `Assoc []
+             ] )
+       ]);
+  check int "pre-ready callback count" 0 !callback_count;
+  let initialize =
+    dispatch
+      (`Assoc
+         [ "jsonrpc", `String "2.0"
+         ; "id", `Int 0
+         ; "method", `String "initialize"
+         ; ( "params"
+           , `Assoc
+               [ "protocolVersion", `String "2025-11-25"
+               ; "capabilities", `Assoc []
+               ; ( "clientInfo"
+                 , `Assoc
+                     [ "name", `String "official-client-test"
+                     ; "version", `String "1"
+                     ] )
+               ] )
+         ])
+  in
+  check bool "initialize has response" true (Option.is_some initialize.response);
+  let notification =
+    dispatch
+      (`Assoc
+         [ "jsonrpc", `String "2.0"
+         ; "method", `String "notifications/initialized"
+         ; "params", `Assoc []
+         ])
+  in
+  check (option string) "notification has no response" None
+    (Option.map Yojson.Safe.to_string notification.response);
   let list =
     dispatch
       (`Assoc
@@ -290,16 +400,6 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
   in
   check bool "list has response" true (Option.is_some list.response);
   check bool "list did not call a tool" false list.tool_called;
-  let notification =
-    dispatch
-      (`Assoc
-         [ "jsonrpc", `String "2.0"
-         ; "method", `String "notifications/initialized"
-         ; "params", `Assoc []
-         ])
-  in
-  check (option string) "notification has no response" None
-    (Option.map Yojson.Safe.to_string notification.response);
   let unknown =
     dispatch
       (`Assoc
@@ -321,6 +421,7 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
     (unknown.response |> Option.get |> member "error" |> member "code" |> to_int);
   (match
      Runtime_official_client_mcp.handle_message
+       ~session
        ~server_name:"masc"
        ~tool_specs
        ~call_tool
@@ -336,6 +437,7 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
   let rejects label message =
     match
       Runtime_official_client_mcp.handle_message
+        ~session
         ~server_name:"masc"
         ~tool_specs
         ~call_tool
@@ -405,12 +507,16 @@ let test_shared_mcp_protocol_is_negotiated () =
       ]
   in
   let open Yojson.Safe.Util in
-  match
+  let handle message =
     Runtime_official_client_mcp.handle_message
+      ~session:(Runtime_official_client_mcp.create_session ())
       ~server_name:"masc"
       ~tool_specs
       ~call_tool
-      (initialize "2025-11-25")
+      message
+  in
+  match
+    handle (initialize "2025-11-25")
   with
   | Error error -> fail (error.stage ^ ": " ^ error.detail)
   | Ok dispatch ->
@@ -423,20 +529,13 @@ let test_shared_mcp_protocol_is_negotiated () =
        |> member "protocolVersion"
        |> to_string);
     (match
-       Runtime_official_client_mcp.handle_message
-         ~server_name:"masc"
-         ~tool_specs
-         ~call_tool
-         (initialize "2099-01-01")
+       handle (initialize "2099-01-01")
      with
      | Error { stage = "MCP initialize"; _ } -> ()
      | Error _ -> fail "unsupported protocol version had the wrong stage"
      | Ok _ -> fail "unsupported protocol version was silently normalized");
     (match
-       Runtime_official_client_mcp.handle_message
-         ~server_name:"masc"
-         ~tool_specs
-         ~call_tool
+       handle
          (`Assoc
             [ "jsonrpc", `String "2.0"
             ; "id", `Int 2

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -528,6 +528,15 @@ let test_shared_mcp_protocol_is_negotiated () =
        |> member "result"
        |> member "protocolVersion"
        |> to_string);
+    check string
+      "MCP server version uses the canonical build owner"
+      Version.version
+      (dispatch.response
+       |> Option.get
+       |> member "result"
+       |> member "serverInfo"
+       |> member "version"
+       |> to_string);
     (match
        handle (initialize "2099-01-01")
      with

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -187,7 +187,7 @@ let test_quota_is_structurally_classified () =
 ;;
 
 let mcp_initialize =
-  {|{"type":"control_request","request_id":"mcp-init-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}}}|}
+  {|{"type":"control_request","request_id":"mcp-init-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"claude-code-fixture","version":"1"}}}}}|}
 ;;
 
 let mcp_list =
@@ -272,19 +272,11 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
     else failf "unexpected tool dispatch reached the callback: %s" name
   in
   let dispatch json =
-    let message =
-      Runtime_official_client_mcp.decode_message (Yojson.Safe.to_string json)
-      |> Result.get_ok
-    in
-    check string
-      "decoded method"
-      (json |> Yojson.Safe.Util.member "method" |> Yojson.Safe.Util.to_string)
-      (Runtime_official_client_mcp.message_method message);
-    Runtime_official_client_mcp.dispatch_message
+    Runtime_official_client_mcp.handle_message
       ~server_name:"masc"
       ~tool_specs
       ~call_tool
-      message
+      json
     |> Result.get_ok
   in
   let list =
@@ -297,17 +289,6 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
          ])
   in
   check bool "list has response" true (Option.is_some list.response);
-  let decoded_list =
-    Runtime_official_client_mcp.decode_message
-      {|{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}|}
-    |> Result.get_ok
-  in
-  check
-    (option string)
-    "decoded request id"
-    (Some "1")
-    (Runtime_official_client_mcp.message_request_id decoded_list
-     |> Option.map Yojson.Safe.to_string);
   check bool "list did not call a tool" false list.tool_called;
   let notification =
     dispatch
@@ -343,24 +324,30 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
        ~server_name:"masc"
        ~tool_specs
        ~call_tool
-       {|{"jsonrpc":"2.0","id":true,"method":"tools/list"}|}
+       (`Assoc
+          [ "jsonrpc", `String "2.0"
+          ; "id", `Bool true
+          ; "method", `String "tools/list"
+          ])
    with
    | Error { stage = "MCP message"; _ } -> ()
    | Error _ -> fail "invalid request id had the wrong error stage"
    | Ok _ -> fail "boolean JSON-RPC request id was admitted");
-  let rejects_raw label raw_message =
+  let rejects label message =
     match
       Runtime_official_client_mcp.handle_message
         ~server_name:"masc"
         ~tool_specs
         ~call_tool
-        raw_message
+        message
     with
     | Error { stage = "MCP message"; _ } -> ()
     | Error _ -> failf "%s had the wrong error stage" label
     | Ok _ -> failf "%s was admitted" label
   in
-  let rejects label json = rejects_raw label (Yojson.Safe.to_string json) in
+  let rejects_raw label raw_message =
+    rejects label (Yojson.Safe.from_string raw_message)
+  in
   rejects
     "explicit null notification id"
     (`Assoc
@@ -394,15 +381,28 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
        ]);
   rejects_raw
     "non-finite nested value"
-    {|{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"missing","arguments":{"score":NaN}}}|};
-  rejects_raw "malformed JSON" {|{"jsonrpc":"2.0","id":7|}
+    {|{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"missing","arguments":{"score":NaN}}}|}
 ;;
 
 let test_shared_mcp_protocol_is_negotiated () =
   let tool_specs () = [] in
   let call_tool ~name:_ ~call_id:_ ~arguments:_ = None in
-  let initialize =
-    {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}|}
+  let initialize protocol_version =
+    `Assoc
+      [ "jsonrpc", `String "2.0"
+      ; "id", `Int 1
+      ; "method", `String "initialize"
+      ; ( "params"
+        , `Assoc
+            [ "protocolVersion", `String protocol_version
+            ; "capabilities", `Assoc []
+            ; ( "clientInfo"
+              , `Assoc
+                  [ "name", `String "official-client-test"
+                  ; "version", `String "1"
+                  ] )
+            ] )
+      ]
   in
   let open Yojson.Safe.Util in
   match
@@ -410,7 +410,7 @@ let test_shared_mcp_protocol_is_negotiated () =
       ~server_name:"masc"
       ~tool_specs
       ~call_tool
-      initialize
+      (initialize "2025-11-25")
   with
   | Error error -> fail (error.stage ^ ": " ^ error.detail)
   | Ok dispatch ->
@@ -421,7 +421,40 @@ let test_shared_mcp_protocol_is_negotiated () =
        |> Option.get
        |> member "result"
        |> member "protocolVersion"
-       |> to_string)
+       |> to_string);
+    (match
+       Runtime_official_client_mcp.handle_message
+         ~server_name:"masc"
+         ~tool_specs
+         ~call_tool
+         (initialize "2099-01-01")
+     with
+     | Error { stage = "MCP initialize"; _ } -> ()
+     | Error _ -> fail "unsupported protocol version had the wrong stage"
+     | Ok _ -> fail "unsupported protocol version was silently normalized");
+    (match
+       Runtime_official_client_mcp.handle_message
+         ~server_name:"masc"
+         ~tool_specs
+         ~call_tool
+         (`Assoc
+            [ "jsonrpc", `String "2.0"
+            ; "id", `Int 2
+            ; "method", `String "initialize"
+            ; ( "params"
+              , `Assoc
+                  [ "capabilities", `Assoc []
+                  ; ( "clientInfo"
+                    , `Assoc
+                        [ "name", `String "official-client-test"
+                        ; "version", `String "1"
+                        ] )
+                  ] )
+            ])
+     with
+     | Error { stage = "MCP initialize"; _ } -> ()
+     | Error _ -> fail "missing protocol version had the wrong stage"
+     | Ok _ -> fail "missing protocol version inherited a hidden default")
 ;;
 
 let test_malformed_json_fails_closed () =


### PR DESCRIPTION
## Summary

- negotiate only canonical typed MCP protocol versions and echo the admitted version
- reject missing, malformed, and unsupported initialize contracts without fallback
- own a per-session `Awaiting_initialize -> Awaiting_initialized -> Ready` phase machine
- permit `tools/list` and `tools/call` only in `Ready`; pre-ready calls cannot reach the tool callback
- keep raw stream parsing at each official-client transport boundary while this shared bridge owns strict parsed-message validation and dispatch

## Evidence

- measured Antigravity CLI 1.1.11 requesting MCP `2025-11-25`
- adversarial tests cover missing/unknown version rejection, malformed ids/params, duplicate/nested-invalid values, notification no-response semantics, and callback count 0 before Ready
- parser, ocamlformat, and diff checks passed locally; focused/full build is delegated to GitHub CI per operator request

## Boundary

This foundational PR does not start a listener or select Claude Code for a Keeper turn. The linked turn-scoped transport/adapter stack owns raw-wire listener lifetime, isolated official-client home/config, and production Keeper routing. Until that stack lands, the Claude Code runtime is intentionally not advertised as available.