### PR TITLE
feat(runtime): serve turn-scoped official-client MCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1567,7 +1567,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_runtime_codex_app_server @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code"
+          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_runtime_codex_app_server @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code @test/runtest-test_runtime_official_client_mcp_http"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${official_client_targets}"
 
       - name: Run host FD pressure contract suite

--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -14,6 +14,9 @@
   unix
   logs
   eio
+  cohttp
+  cohttp-eio
+  eqaf
   masc.agent_core
   masc.agent_core.base
   masc.agent_core.llm_provider

--- a/lib/runtime/runtime_official_client_mcp_http.ml
+++ b/lib/runtime/runtime_official_client_mcp_http.ml
@@ -1,0 +1,345 @@
+type phase =
+  | Awaiting_initialize
+  | Awaiting_initialized
+  | Ready
+
+type snapshot =
+  { phase : phase
+  ; authenticated_requests : int
+  ; rejected_requests : int
+  ; tool_calls : int
+  ; negotiated_protocol_version : string option
+  }
+
+type mutable_state =
+  { mutable phase : phase
+  ; mutable authenticated_requests : int
+  ; mutable rejected_requests : int
+  ; mutable tool_calls : int
+  ; mutable negotiated_protocol_version : string option
+  }
+
+type t =
+  { endpoint : string
+  ; server_name : string
+  ; authorization : string
+  ; state : mutable_state
+  ; state_mutex : Eio.Mutex.t
+  ; dispatch_mutex : Eio.Mutex.t
+  }
+
+let max_body_bytes = 1024 * 1024
+
+let hex_of_bytes bytes =
+  let alphabet = "0123456789abcdef" in
+  let length = Bytes.length bytes in
+  let result = Bytes.create (length * 2) in
+  for index = 0 to length - 1 do
+    let value = Char.code (Bytes.get bytes index) in
+    Bytes.set result (index * 2) alphabet.[value lsr 4];
+    Bytes.set result ((index * 2) + 1) alphabet.[value land 0x0f]
+  done;
+  Bytes.unsafe_to_string result
+;;
+
+let fresh_capabilities secure_random =
+  let entropy = Bytes.create 48 in
+  Eio.Flow.read_exact secure_random entropy;
+  let path_id = Bytes.sub entropy 0 16 |> hex_of_bytes in
+  let token = Bytes.sub entropy 16 32 |> hex_of_bytes in
+  path_id, token
+;;
+
+let snapshot t =
+  Eio.Mutex.use_ro t.state_mutex (fun () ->
+    { phase = t.state.phase
+    ; authenticated_requests = t.state.authenticated_requests
+    ; rejected_requests = t.state.rejected_requests
+    ; tool_calls = t.state.tool_calls
+    ; negotiated_protocol_version = t.state.negotiated_protocol_version
+    })
+;;
+
+let endpoint t = t.endpoint
+
+let mcp_config_json t =
+  `Assoc
+    [ ( "mcpServers"
+      , `Assoc
+          [ ( t.server_name
+            , `Assoc
+                [ "url", `String t.endpoint
+                ; ( "headers"
+                  , `Assoc
+                      [ "Authorization", `String ("Bearer " ^ t.authorization) ] )
+                ] )
+          ] )
+    ]
+;;
+
+let headers ?protocol_version content_type =
+  Cohttp.Header.of_list
+    ([ "content-type", content_type; "cache-control", "no-store" ]
+     @ Option.fold
+         ~none:[]
+         ~some:(fun version -> [ "mcp-protocol-version", version ])
+         protocol_version)
+;;
+
+let respond ?protocol_version ?(content_type = "text/plain") status body =
+  Cohttp_eio.Server.respond_string
+    ~headers:(headers ?protocol_version content_type)
+    ~status
+    ~body
+    ()
+;;
+
+let respond_json ?protocol_version status json =
+  respond
+    ?protocol_version
+    ~content_type:"application/json"
+    status
+    (Yojson.Safe.to_string json)
+;;
+
+let protocol_error_response id code message =
+  `Assoc
+    [ "jsonrpc", `String "2.0"
+    ; "id", id
+    ; "error", `Assoc [ "code", `Int code; "message", `String message ]
+    ]
+;;
+
+let request_method_and_id = function
+  | `Assoc fields ->
+    let method_ =
+      match List.assoc_opt "method" fields with
+      | Some (`String value) -> Some value
+      | _ -> None
+    in
+    method_, Option.value (List.assoc_opt "id" fields) ~default:`Null
+  | _ -> None, `Null
+;;
+
+let initialize_protocol_version = function
+  | Some (`Assoc fields) ->
+    (match List.assoc_opt "result" fields with
+     | Some (`Assoc result_fields) ->
+       (match List.assoc_opt "protocolVersion" result_fields with
+        | Some (`String value) -> Some value
+        | _ -> None)
+     | _ -> None)
+  | _ -> None
+;;
+
+let phase_error phase method_ =
+  let expected =
+    match phase with
+    | Awaiting_initialize -> "initialize"
+    | Awaiting_initialized -> "notifications/initialized"
+    | Ready -> "tools/list or tools/call"
+  in
+  Printf.sprintf "MCP method %S is not valid before %s" method_ expected
+;;
+
+let phase_admits phase method_ id =
+  match method_ with
+  | Some ("server/discover" | "initialize") ->
+    phase = Awaiting_initialize && id <> `Null
+  | Some "notifications/initialized" ->
+    phase = Awaiting_initialized && id = `Null
+  | Some ("tools/list" | "tools/call") -> phase = Ready && id <> `Null
+  | None | Some _ -> true
+;;
+
+let dispatch t ~tool_specs ~call_tool message =
+  Eio.Mutex.use_rw ~protect:true t.dispatch_mutex (fun () ->
+    let method_, id = request_method_and_id message in
+    let phase = Eio.Mutex.use_ro t.state_mutex (fun () -> t.state.phase) in
+    if not (phase_admits phase method_ id)
+    then
+      let method_ = Option.value method_ ~default:"<missing>" in
+      Error (`Protocol (id, phase_error phase method_))
+    else
+      match
+        Runtime_official_client_mcp.handle_message
+          ~server_name:t.server_name
+          ~tool_specs
+          ~call_tool
+          message
+      with
+      | Error error -> Error (`Dispatch error)
+      | Ok result ->
+        Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () ->
+          (match t.state.phase, method_, result.response with
+           | Awaiting_initialize, Some "initialize", Some _ ->
+             t.state.phase <- Awaiting_initialized;
+             t.state.negotiated_protocol_version <-
+               initialize_protocol_version result.response
+           | Awaiting_initialized, Some "notifications/initialized", None ->
+             t.state.phase <- Ready
+           | _ -> ());
+          if result.tool_called
+          then t.state.tool_calls <- t.state.tool_calls + 1);
+        Ok result)
+;;
+
+let update_state t f =
+  Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () -> f t.state)
+;;
+
+let reject t =
+  update_state t (fun state -> state.rejected_requests <- state.rejected_requests + 1)
+;;
+
+let record_authenticated_request t =
+  update_state t (fun state ->
+    state.authenticated_requests <- state.authenticated_requests + 1)
+;;
+
+let authorization_matches t request =
+  match Cohttp.Header.get_multi (Cohttp.Request.headers request) "authorization" with
+  | [ value ] -> Eqaf.equal value ("Bearer " ^ t.authorization)
+  | [] | _ :: _ :: _ -> false
+;;
+
+let content_type_is_json request =
+  match Cohttp.Header.get_multi (Cohttp.Request.headers request) "content-type" with
+  | [ value ] ->
+    let media_type =
+      match String.index_opt value ';' with
+      | None -> value
+      | Some index -> String.sub value 0 index
+    in
+    String.equal (String.trim media_type |> String.lowercase_ascii) "application/json"
+  | [] | _ :: _ :: _ -> false
+;;
+
+let content_length request =
+  match Cohttp.Header.get_multi (Cohttp.Request.headers request) "content-length" with
+  | [] -> Ok None
+  | [ value ] ->
+    (match int_of_string_opt (String.trim value) with
+     | Some length when length >= 0 -> Ok (Some length)
+     | _ -> Error "invalid Content-Length")
+  | _ :: _ :: _ -> Error "duplicate Content-Length"
+;;
+
+let handle_message t ~tool_specs ~call_tool body =
+  match Runtime_official_client_mcp.parse_message body with
+  | Error { stage; detail } ->
+    reject t;
+    respond_json
+      `Bad_request
+      (protocol_error_response `Null (-32700) (stage ^ ": " ^ detail))
+  | Ok message ->
+    (match dispatch t ~tool_specs ~call_tool message with
+     | Error (`Protocol (id, detail)) ->
+       reject t;
+       respond_json `Conflict (protocol_error_response id (-32002) detail)
+     | Error (`Dispatch { stage; detail }) ->
+       reject t;
+       respond_json
+         `Bad_request
+         (protocol_error_response `Null (-32600) (stage ^ ": " ^ detail))
+     | Ok { response = None; _ } -> respond `Accepted ""
+     | Ok { response = Some response; _ } ->
+       let protocol_version = (snapshot t).negotiated_protocol_version in
+       respond_json ?protocol_version `OK response)
+;;
+
+let handle_post t ~tool_specs ~call_tool request body =
+  if not (content_type_is_json request)
+  then (
+    reject t;
+    respond `Unsupported_media_type "Content-Type must be application/json")
+  else
+    match content_length request with
+    | Error detail ->
+      reject t;
+      respond `Bad_request detail
+    | Ok (Some length) when length > max_body_bytes ->
+      reject t;
+      respond `Payload_too_large "MCP request body exceeds 1048576 bytes"
+    | Ok _ ->
+      (try
+         let body =
+           Eio.Buf_read.(of_flow ~max_size:max_body_bytes body |> take_all)
+         in
+         handle_message t ~tool_specs ~call_tool body
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | Eio.Buf_read.Buffer_limit_exceeded ->
+         reject t;
+         respond `Payload_too_large "MCP request body exceeds 1048576 bytes"
+       | _ ->
+         reject t;
+         respond `Bad_request "failed to read MCP request body")
+;;
+
+let request_handler t ~path ~tool_specs ~call_tool _client_addr request body =
+  if not (String.equal (Uri.path (Cohttp.Request.uri request)) path)
+  then respond `Not_found "Not found"
+  else if not (authorization_matches t request)
+  then (
+    reject t;
+    Cohttp_eio.Server.respond_string
+      ~headers:(Cohttp.Header.of_list [ "www-authenticate", "Bearer" ])
+      ~status:`Unauthorized
+      ~body:"Unauthorized"
+      ())
+  else (
+    record_authenticated_request t;
+    match Cohttp.Request.meth request with
+    | `POST -> handle_post t ~tool_specs ~call_tool request body
+    | `GET -> respond `Method_not_allowed "SSE is not enabled for this endpoint"
+    | `DELETE -> respond `No_content ""
+    | _ -> respond `Method_not_allowed "Method not allowed")
+;;
+
+let start ~sw ~net ~secure_random ~server_name ~tool_specs ~call_tool () =
+  let path_id, authorization = fresh_capabilities secure_random in
+  let path = "/mcp/" ^ path_id in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~reuse_addr:false
+      ~backlog:8
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, 0))
+  in
+  let port =
+    match Eio.Net.listening_addr socket with
+    | `Tcp (_, port) -> port
+    | `Unix _ -> assert false
+  in
+  let state =
+    { phase = Awaiting_initialize
+    ; authenticated_requests = 0
+    ; rejected_requests = 0
+    ; tool_calls = 0
+    ; negotiated_protocol_version = None
+    }
+  in
+  let t =
+    { endpoint = Printf.sprintf "http://127.0.0.1:%d%s" port path
+    ; server_name
+    ; authorization
+    ; state
+    ; state_mutex = Eio.Mutex.create ()
+    ; dispatch_mutex = Eio.Mutex.create ()
+    }
+  in
+  let server =
+    Cohttp_eio.Server.make
+      ~callback:(request_handler t ~path ~tool_specs ~call_tool)
+      ()
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    Cohttp_eio.Server.run
+      socket
+      server
+      ~on_error:(fun _ ->
+        Log.Runtime_agent.warn "official-client MCP HTTP connection failed"));
+  t
+;;

--- a/lib/runtime/runtime_official_client_mcp_http.mli
+++ b/lib/runtime/runtime_official_client_mcp_http.mli
@@ -1,0 +1,43 @@
+(** Turn-scoped loopback MCP transport for official subscription clients.
+
+    The listener binds only to IPv4 loopback on an ephemeral port, requires an
+    independently generated Bearer capability, and is owned by the caller's
+    Eio switch. Closing the turn switch closes the listener and all accepted
+    connections. *)
+
+type phase =
+  | Awaiting_initialize
+  | Awaiting_initialized
+  | Ready
+
+type snapshot =
+  { phase : phase
+  ; authenticated_requests : int
+  ; rejected_requests : int
+  ; tool_calls : int
+  ; negotiated_protocol_version : string option
+  }
+
+type t
+
+val start :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  secure_random:Eio.Flow.source_ty Eio.Resource.t ->
+  server_name:string ->
+  tool_specs:(unit -> Yojson.Safe.t list) ->
+  call_tool:
+    (name:string ->
+     call_id:string ->
+     arguments:Yojson.Safe.t ->
+     Runtime_official_client_mcp.tool_result option) ->
+  unit ->
+  t
+
+(** Exact remote-MCP configuration measured against Antigravity CLI 1.1.11.
+    The returned JSON contains the ephemeral capability and must not be logged
+    or persisted after the turn. *)
+val mcp_config_json : t -> Yojson.Safe.t
+
+val endpoint : t -> string
+val snapshot : t -> snapshot

--- a/test/dune
+++ b/test/dune
@@ -1943,6 +1943,7 @@
 
 (include stanzas/test_runtime_codex_app_server.inc)
 (include stanzas/test_runtime_claude_code.inc)
+(include stanzas/test_runtime_official_client_mcp_http.inc)
 (include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/stanzas/test_runtime_official_client_mcp_http.inc
+++ b/test/stanzas/test_runtime_official_client_mcp_http.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_official_client_mcp_http)
+ (modules test_runtime_official_client_mcp_http)
+ (libraries masc masc_test_deps))

--- a/test/test_runtime_official_client_mcp_http.ml
+++ b/test/test_runtime_official_client_mcp_http.ml
@@ -1,0 +1,261 @@
+open Alcotest
+
+type response =
+  { status : int
+  ; body : string
+  }
+
+let config_fields bridge =
+  let open Yojson.Safe.Util in
+  let config = Runtime_official_client_mcp_http.mcp_config_json bridge in
+  let server = config |> member "mcpServers" |> member "masc" in
+  let endpoint = server |> member "url" |> to_string in
+  let authorization =
+    server |> member "headers" |> member "Authorization" |> to_string
+  in
+  endpoint, authorization
+;;
+
+let rec read_headers reader content_length =
+  let line = Eio.Buf_read.line reader in
+  if String.equal line "\r" || String.equal line ""
+  then content_length
+  else
+    let content_length =
+      match String.index_opt line ':' with
+      | None -> content_length
+      | Some index ->
+        let name =
+          String.sub line 0 index |> String.trim |> String.lowercase_ascii
+        in
+        if not (String.equal name "content-length")
+        then content_length
+        else
+          String.sub line (index + 1) (String.length line - index - 1)
+          |> String.trim
+          |> int_of_string
+    in
+    read_headers reader content_length
+;;
+
+let request ~sw ~net ~endpoint ~authorization body =
+  let uri = Uri.of_string endpoint in
+  let port = Uri.port uri |> Option.get in
+  let path = Uri.path uri in
+  let flow =
+    Eio.Net.connect ~sw net (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  Eio.Flow.copy_string
+    (Printf.sprintf
+       "POST %s HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nAuthorization: %s\r\nContent-Type: application/json\r\nAccept: application/json, text/event-stream\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"
+       path
+       port
+       authorization
+       (String.length body)
+       body)
+    flow;
+  let reader = Eio.Buf_read.of_flow ~max_size:(2 * 1024 * 1024) flow in
+  let status_line = Eio.Buf_read.line reader in
+  let status =
+    match String.split_on_char ' ' status_line with
+    | _version :: code :: _ -> int_of_string code
+    | _ -> failf "invalid HTTP status line: %S" status_line
+  in
+  let content_length = read_headers reader 0 in
+  { status; body = Eio.Buf_read.take content_length reader }
+;;
+
+let json_request id method_ params =
+  `Assoc
+    [ "jsonrpc", `String "2.0"
+    ; "id", `Int id
+    ; "method", `String method_
+    ; "params", params
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let member name json = Yojson.Safe.Util.member name json
+
+let test_turn_scoped_capability_and_protocol () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let calls = ref [] in
+  let tool_specs () =
+    [ `Assoc
+        [ "name", `String "masc_probe"
+        ; "description", `String "Return a marker"
+        ; "inputSchema", `Assoc [ "type", `String "object" ]
+        ]
+    ]
+  in
+  let call_tool ~name ~call_id ~arguments =
+    calls := (name, call_id, arguments) :: !calls;
+    Some
+      { Runtime_official_client_mcp.success = true
+      ; content = "MASC_TOOL_OK"
+      }
+  in
+  let bridge =
+    Runtime_official_client_mcp_http.start
+      ~sw
+      ~net:env#net
+      ~secure_random:env#secure_random
+      ~server_name:"masc"
+      ~tool_specs
+      ~call_tool
+      ()
+  in
+  let endpoint, authorization = config_fields bridge in
+  let initialize =
+    json_request
+      2
+      "initialize"
+      (`Assoc
+         [ "protocolVersion", `String "2025-11-25"
+         ; ( "clientInfo"
+           , `Assoc
+               [ "name", `String "antigravity-client"
+               ; "version", `String "v1.0.0"
+               ] )
+         ; "capabilities", `Assoc []
+         ])
+  in
+  let unauthorized =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization:"Bearer wrong"
+      initialize
+  in
+  check int "wrong capability" 401 unauthorized.status;
+  let discover =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 1 "server/discover" (`Assoc []))
+  in
+  check int "discovery extension is an exact JSON-RPC miss" 200 discover.status;
+  check int
+    "discovery error"
+    (-32601)
+    (Yojson.Safe.from_string discover.body
+     |> member "error"
+     |> member "code"
+     |> Yojson.Safe.Util.to_int);
+  let initialized =
+    request ~sw ~net:env#net ~endpoint ~authorization initialize
+  in
+  check int "initialize" 200 initialized.status;
+  check string
+    "negotiated measured protocol"
+    "2025-11-25"
+    (Yojson.Safe.from_string initialized.body
+     |> member "result"
+     |> member "protocolVersion"
+     |> Yojson.Safe.Util.to_string);
+  let call_params =
+    `Assoc
+      [ "name", `String "masc_probe"
+      ; "arguments", `Assoc [ "marker", `String "measured" ]
+      ]
+  in
+  let premature =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 3 "tools/call" call_params)
+  in
+  check int "tool call before initialized notification" 409 premature.status;
+  check int "premature call not executed" 0 (List.length !calls);
+  let notification =
+    {|{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}|}
+  in
+  let notified =
+    request ~sw ~net:env#net ~endpoint ~authorization notification
+  in
+  check int "initialized notification" 202 notified.status;
+  let listed =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 4 "tools/list" (`Assoc []))
+  in
+  check int "tools/list" 200 listed.status;
+  check string
+    "turn tool"
+    "masc_probe"
+    (Yojson.Safe.from_string listed.body
+     |> member "result"
+     |> member "tools"
+     |> Yojson.Safe.Util.to_list
+     |> List.hd
+     |> member "name"
+     |> Yojson.Safe.Util.to_string);
+  let called =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 5 "tools/call" call_params)
+  in
+  check int "tools/call" 200 called.status;
+  check string
+    "tool result"
+    "MASC_TOOL_OK"
+    (Yojson.Safe.from_string called.body
+     |> member "result"
+     |> member "content"
+     |> Yojson.Safe.Util.to_list
+     |> List.hd
+     |> member "text"
+     |> Yojson.Safe.Util.to_string);
+  let duplicate_key =
+    {|{"jsonrpc":"2.0","id":6,"method":"tools/call","method":"tools/call","params":{"name":"masc_probe"}}|}
+  in
+  let duplicate =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      duplicate_key
+  in
+  check int "duplicate JSON key" 400 duplicate.status;
+  check int "only admitted call executed" 1 (List.length !calls);
+  let snapshot = Runtime_official_client_mcp_http.snapshot bridge in
+  check bool
+    "ready"
+    true
+    (snapshot.phase = Runtime_official_client_mcp_http.Ready);
+  check int "authenticated requests" 7 snapshot.authenticated_requests;
+  check int "rejected requests" 3 snapshot.rejected_requests;
+  check int "measured tool calls" 1 snapshot.tool_calls;
+  check
+    (option string)
+    "protocol evidence"
+    (Some "2025-11-25")
+    snapshot.negotiated_protocol_version
+;;
+
+let () =
+  run
+    "runtime_official_client_mcp_http"
+    [ ( "turn-scoped transport"
+      , [ test_case
+            "capability, protocol, phase, and tool callback"
+            `Quick
+            test_turn_scoped_capability_and_protocol
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- bind a per-turn MCP endpoint to IPv4 loopback on an ephemeral port
- require independent random path and Bearer capabilities
- enforce initialize -> initialized -> tools lifecycle before MASC callbacks
- expose exact request, rejection, negotiated-protocol, and tool-call evidence
- emit the remote-MCP JSON shape measured against Antigravity CLI 1.1.11

## Measured wire

Antigravity 1.1.11 sent `server/discover`, MCP `initialize` with protocol `2025-11-25`, `notifications/initialized`, `tools/list`, and `tools/call`. The client tolerated the exact `-32601` discovery-extension response and a `405` GET response, then completed the MASC tool call over authenticated POST.

## Safety boundary

- listener exists only under the caller turn switch
- no public bind and no global MASC tool inventory
- 1 MiB raw body cap and strict duplicate-key rejection
- wrong capability and out-of-phase calls cannot execute callbacks
- generated MCP config contains an ephemeral secret and is explicitly non-persistent

## Verification

- parser-only OCaml checks passed
- CI target audit passed at the 701-suite baseline
- `git diff --check` passed
- focused/full build delegated to CI per operator request

## Not included

This PR does not yet create the isolated Antigravity HOME or spawn `agy`; that stays in the next small client-adapter slice.