### PR TITLE
feat(keeper): expose Librarian research, RAW, and memory joins

### DIFF
--- a/dashboard/src/api/dashboard-exact-lane-runs.test.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.test.ts
@@ -12,7 +12,7 @@ describe('parseExactLaneRunsResponse', () => {
         subject_id: 'trace-1',
         actor: 'keeper-a',
         started_at: 1,
-        input: { message_count: 4 },
+        input: { kind: 'exact', payload: { message_count: 4 } },
         status: 'succeeded',
         elapsed_s: 0.4,
         output: { fact_count: 3 },
@@ -21,7 +21,7 @@ describe('parseExactLaneRunsResponse', () => {
     expect(parsed.runs[0]).toMatchObject({
       lane: 'librarian_exact',
       status: 'succeeded',
-      input: { message_count: 4 },
+      input: { kind: 'exact', payload: { message_count: 4 } },
       output: { fact_count: 3 },
     })
   })
@@ -32,8 +32,33 @@ describe('parseExactLaneRunsResponse', () => {
       count: 1,
       runs: [{
         run_id: 'x', lane: 'mystery', subject_id: 's', actor: 'a',
-        started_at: 1, input: {}, status: 'running',
+        started_at: 1, input: { kind: 'exact', payload: {} }, status: 'running',
       }],
     })).toThrow('unknown value')
+  })
+
+  it('decodes a typed research trace join without guessing fields', () => {
+    const parsed = parseExactLaneRunsResponse({
+      generated_at: '2026-08-09T00:00:00Z',
+      count: 1,
+      runs: [{
+        run_id: 'librarian-research-1',
+        lane: 'librarian_exact',
+        subject_id: 'trace-1',
+        actor: 'keeper-a',
+        started_at: 1,
+        input: {
+          kind: 'research',
+          raw_trace_path: '/tmp/raw-traces/librarian-research-1.jsonl',
+          payload: { message_count: 4 },
+        },
+        status: 'running',
+      }],
+    })
+    expect(parsed.runs[0]?.input).toEqual({
+      kind: 'research',
+      rawTracePath: '/tmp/raw-traces/librarian-research-1.jsonl',
+      payload: { message_count: 4 },
+    })
   })
 })

--- a/dashboard/src/api/dashboard-exact-lane-runs.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.ts
@@ -9,13 +9,17 @@ export type ExactLane =
 
 export type ExactLaneRunStatus = 'running' | 'succeeded' | 'cancelled' | 'failed'
 
+export type ExactLaneRunInput =
+  | { kind: 'exact'; payload: unknown }
+  | { kind: 'research'; rawTracePath: string | null; payload: unknown }
+
 export interface ExactLaneRunRecord {
   runId: string
   lane: ExactLane
   subjectId: string
   actor: string
   startedAt: number
-  input: unknown
+  input: ExactLaneRunInput
   status: ExactLaneRunStatus
   elapsedSeconds?: number
   output?: unknown
@@ -67,6 +71,23 @@ function exactFields(
   }
 }
 
+function parseInput(raw: unknown, context: string): ExactLaneRunInput {
+  if (!isRecord(raw)) fail(`${context} must be an object`)
+  const kind = string(raw.kind, `${context}.kind`)
+  if (kind === 'exact') {
+    exactFields(raw, ['kind', 'payload'], [], context)
+    return { kind, payload: raw.payload }
+  }
+  if (kind === 'research') {
+    exactFields(raw, ['kind', 'raw_trace_path', 'payload'], [], context)
+    const rawTracePath = raw.raw_trace_path === null
+      ? null
+      : string(raw.raw_trace_path, `${context}.raw_trace_path`)
+    return { kind, rawTracePath, payload: raw.payload }
+  }
+  return fail(`${context}.kind has unknown value ${JSON.stringify(kind)}`)
+}
+
 function parseRun(raw: unknown, index: number): ExactLaneRunRecord {
   const context = `runs[${index}]`
   if (!isRecord(raw)) fail(`${context} must be an object`)
@@ -87,7 +108,7 @@ function parseRun(raw: unknown, index: number): ExactLaneRunRecord {
     subjectId: string(raw.subject_id, `${context}.subject_id`),
     actor: string(raw.actor, `${context}.actor`),
     startedAt: number(raw.started_at, `${context}.started_at`),
-    input: raw.input,
+    input: parseInput(raw.input, `${context}.input`),
     status: status as ExactLaneRunStatus,
     elapsedSeconds: status === 'running' ? undefined : number(raw.elapsed_s, `${context}.elapsed_s`),
     output: status === 'running' ? undefined : raw.output,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -66,6 +66,7 @@ export {
   type DashboardExactLaneRunsResponse,
   type ExactLane,
   type ExactLaneRunRecord,
+  type ExactLaneRunInput,
   type ExactLaneRunStatus,
 } from './dashboard-exact-lane-runs'
 

--- a/dashboard/src/components/internal-agents-monitor.test.ts
+++ b/dashboard/src/components/internal-agents-monitor.test.ts
@@ -22,6 +22,7 @@ vi.mock('../sse-store', () => ({
 
 import { InternalAgentsMonitor } from './internal-agents-monitor'
 import { keepers, shellRuntimeResolution } from '../store'
+import { ApiRequestError } from '../api/core'
 
 afterEach(() => {
   cleanup()
@@ -111,11 +112,11 @@ describe('InternalAgentsMonitor', () => {
         status: 'succeeded',
         elapsedSeconds: 2,
         output: {
-          before: { facts: [{ claim: '낡은 기억' }] },
+          before: { present: true, fact_count: 1 },
           after: {
             revision: 42,
-            facts: [{ claim: '새 기억' }],
-            change: { added: [{ claim: '새 기억' }], removed: [{ claim: '낡은 기억' }], retained: 0 },
+            fact_count: 1,
+            change: { added_count: 1, removed_count: 1, retained: 0 },
           },
         },
       }],
@@ -235,11 +236,11 @@ describe('InternalAgentsMonitor', () => {
         output: {
           research: {
             outcome: { kind: 'not_dispatched' },
-            raw_trace: { kind: 'unavailable', detail: 'sink create failed' },
+            raw_trace: { kind: 'unavailable', category: 'internal', retryable: false },
           },
         },
         code: 'librarian_failed',
-        detail: 'sink create failed',
+        detail: 'Librarian pass failed; inspect the operator raw trace and Memory journal',
       }],
     })
     memoryApi.fetchKeeperMemoryJournal.mockResolvedValue({
@@ -251,5 +252,22 @@ describe('InternalAgentsMonitor', () => {
 
     expect(await screen.findByText('RAW trace unavailable')).toBeTruthy()
     expect(rawApi.fetchKeeperRawTrace).not.toHaveBeenCalled()
+  })
+
+  it('states that exact lanes and RAW require an Admin bearer', async () => {
+    api.fetchExactLaneRuns.mockRejectedValue(new ApiRequestError({
+      method: 'GET',
+      path: '/api/v1/dashboard/exact-lane-runs',
+      status: 403,
+      statusText: 'Forbidden',
+    }))
+    api.fetchFusionRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchVerificationRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+
+    const { container } = render(html`<${InternalAgentsMonitor} />`)
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Exact lanes + RAW: Admin 권한 필요')
+    })
   })
 })

--- a/dashboard/src/components/internal-agents-monitor.test.ts
+++ b/dashboard/src/components/internal-agents-monitor.test.ts
@@ -88,8 +88,56 @@ describe('InternalAgentsMonitor', () => {
     expect(screen.getByText(/Completion verdict recorded: APPROVE/)).toBeTruthy()
 
     const filters = screen.getByRole('group', { name: 'Internal agent filters' })
-    fireEvent.click(within(filters).getByRole('button', { name: 'Judge 0' }))
+    fireEvent.click(within(filters).getByRole('button', { name: 'Auto Judge 0' }))
     expect(screen.queryByText('report_review_verdict')).toBeNull()
+  })
+
+  it('keeps Auto Judge and Board Attention as separate exact execution kinds', async () => {
+    api.fetchFusionRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchVerificationRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchExactLaneRuns.mockResolvedValue({
+      count: 2,
+      generatedAt: 'now',
+      runs: [
+        {
+          runId: 'auto-judge-1',
+          lane: 'hitl_auto_judge',
+          subjectId: 'approval-1',
+          actor: 'keeper-a',
+          startedAt: 1786000002,
+          input: { kind: 'exact', payload: { approval_id: 'approval-1' } },
+          status: 'succeeded',
+          elapsedSeconds: 0.4,
+          output: { decision: 'allow' },
+        },
+        {
+          runId: 'board-attention-1',
+          lane: 'board_attention_exact',
+          subjectId: 'board-post-1',
+          actor: 'keeper-a',
+          startedAt: 1786000001,
+          input: { kind: 'exact', payload: { post_id: 'board-post-1' } },
+          status: 'succeeded',
+          elapsedSeconds: 0.7,
+          output: { action: 'reply' },
+        },
+      ],
+    })
+
+    const { container } = render(html`<${InternalAgentsMonitor} />`)
+    const filters = await screen.findByRole('group', { name: 'Internal agent filters' })
+
+    expect(within(filters).getByRole('button', { name: 'Auto Judge 1' })).toBeTruthy()
+    expect(within(filters).getByRole('button', { name: 'Board Attention 1' })).toBeTruthy()
+    expect(container.textContent).not.toContain('Board Judge')
+
+    fireEvent.click(within(filters).getByRole('button', { name: 'Auto Judge 1' }))
+    expect(screen.getByRole('button', { name: /Auto Judge approval-1/i })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /Board Attention board-post-1/i })).toBeNull()
+
+    fireEvent.click(within(filters).getByRole('button', { name: 'Board Attention 1' }))
+    expect(screen.getByRole('button', { name: /Board Attention board-post-1/i })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /Auto Judge approval-1/i })).toBeNull()
   })
 
   it('joins a librarian run to the exact memory revision and shows changed claims', async () => {

--- a/dashboard/src/components/internal-agents-monitor.test.ts
+++ b/dashboard/src/components/internal-agents-monitor.test.ts
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/preact'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { html } from 'htm/preact'
 
 const api = vi.hoisted(() => ({
@@ -8,9 +8,14 @@ const api = vi.hoisted(() => ({
   fetchFusionRuns: vi.fn(),
 }))
 const memoryApi = vi.hoisted(() => ({ fetchKeeperMemoryJournal: vi.fn() }))
+const rawApi = vi.hoisted(() => ({
+  fetchKeeperRawTrace: vi.fn(),
+  fetchKeeperRawTraces: vi.fn(),
+}))
 
 vi.mock('../api/dashboard', () => api)
 vi.mock('../api/dashboard-memory-journal', () => memoryApi)
+vi.mock('../api/dashboard-keeper-prompt', () => rawApi)
 vi.mock('../sse-store', () => ({
   registerInternalAgentRefresh: vi.fn(() => vi.fn()),
 }))
@@ -26,6 +31,10 @@ afterEach(() => {
 })
 
 describe('InternalAgentsMonitor', () => {
+  beforeEach(() => {
+    rawApi.fetchKeeperRawTraces.mockResolvedValue([])
+  })
+
   it('keeps paused keepers with zero observed runs in the owner matrix', async () => {
     api.fetchExactLaneRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
     api.fetchFusionRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
@@ -94,11 +103,28 @@ describe('InternalAgentsMonitor', () => {
         subjectId: 'trace-1',
         actor: 'kidsnote',
         startedAt: 1786000000,
-        input: { current_fact_count: 1, message_count: 5 },
+        input: {
+          kind: 'research',
+          rawTracePath: '/tmp/raw-traces/librarian-research-1.jsonl',
+          payload: { current_fact_count: 1, message_count: 5 },
+        },
         status: 'succeeded',
         elapsedSeconds: 2,
-        output: { revision: 42, fact_count: 1, added_count: 1, removed_count: 1 },
+        output: {
+          before: { facts: [{ claim: '낡은 기억' }] },
+          after: {
+            revision: 42,
+            facts: [{ claim: '새 기억' }],
+            change: { added: [{ claim: '새 기억' }], removed: [{ claim: '낡은 기억' }], retained: 0 },
+          },
+        },
       }],
+    })
+    rawApi.fetchKeeperRawTrace.mockResolvedValue({
+      file: 'librarian-research-1.jsonl',
+      totalRecords: 1,
+      offset: 0,
+      records: [{ ok: true, raw: '{"type":"tool_result","value":"실제 RAW 값"}', record: { type: 'tool_result', value: '실제 RAW 값' } }],
     })
     memoryApi.fetchKeeperMemoryJournal.mockResolvedValue({
       keeper: 'kidsnote',
@@ -127,9 +153,15 @@ describe('InternalAgentsMonitor', () => {
     expect(container.textContent).toContain('새 기억')
     expect(container.textContent).toContain('낡은 기억')
     expect(container.textContent).toContain('새 근거로 대체됨')
-    expect(container.textContent).toContain('TRACE JOIN UNAVAILABLE')
-    expect(container.textContent).toContain('subject 문자열로 실행 레코드를 추정 연결하지 않습니다')
-    expect(screen.queryByRole('button', { name: /RAW 열기/ })).toBeNull()
+    expect(await screen.findByText('Retained RAW JSONL')).toBeTruthy()
+    expect(container.textContent).toContain('실제 RAW 값')
+    expect(container.textContent).toContain('Execution join')
+    expect(container.textContent).not.toContain('TRACE JOIN UNAVAILABLE')
+    expect(rawApi.fetchKeeperRawTrace).toHaveBeenCalledWith(
+      'kidsnote',
+      'librarian-research-1.jsonl',
+      expect.objectContaining({ signal: expect.any(AbortSignal), offset: 0, limit: 20 }),
+    )
     expect(memoryApi.fetchKeeperMemoryJournal).toHaveBeenCalledWith(
       'kidsnote',
       500,
@@ -149,7 +181,7 @@ describe('InternalAgentsMonitor', () => {
         subjectId: 'trace-shared',
         actor: 'full-cycle-probe',
         startedAt: 1786200000,
-        input: { current_fact_count: 2 },
+        input: { kind: 'research', rawTracePath: null, payload: { current_fact_count: 2 } },
         status: 'running',
       }],
     })
@@ -179,5 +211,45 @@ describe('InternalAgentsMonitor', () => {
     expect(container.textContent).toContain('explicit_write')
     expect(container.textContent).toContain('revision 617')
     expect(container.textContent).toContain('실제 도구 체인 성공')
+  })
+
+  it('does not fetch a pre-registered trace candidate when sink creation failed', async () => {
+    api.fetchFusionRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchVerificationRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchExactLaneRuns.mockResolvedValue({
+      count: 1,
+      generatedAt: 'now',
+      runs: [{
+        runId: 'librarian-research-unavailable',
+        lane: 'librarian_exact',
+        subjectId: 'trace-unavailable',
+        actor: 'rondo',
+        startedAt: 1786200000,
+        input: {
+          kind: 'research',
+          rawTracePath: '/tmp/raw-traces/candidate.jsonl',
+          payload: { message_count: 1 },
+        },
+        status: 'failed',
+        elapsedSeconds: 0.1,
+        output: {
+          research: {
+            outcome: { kind: 'not_dispatched' },
+            raw_trace: { kind: 'unavailable', detail: 'sink create failed' },
+          },
+        },
+        code: 'librarian_failed',
+        detail: 'sink create failed',
+      }],
+    })
+    memoryApi.fetchKeeperMemoryJournal.mockResolvedValue({
+      keeper: 'rondo', returned: 0, undecodableLines: 0, entries: [],
+    })
+
+    render(html`<${InternalAgentsMonitor} />`)
+    fireEvent.click(await screen.findByRole('button', { name: /Librarian trace-unavailable/i }))
+
+    expect(await screen.findByText('RAW trace unavailable')).toBeTruthy()
+    expect(rawApi.fetchKeeperRawTrace).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/components/internal-agents-monitor.ts
+++ b/dashboard/src/components/internal-agents-monitor.ts
@@ -13,6 +13,10 @@ import {
   type MemoryJournal,
   type MemoryJournalEntry,
 } from '../api/dashboard-memory-journal'
+import {
+  fetchKeeperRawTrace,
+  type RawTracePage,
+} from '../api/dashboard-keeper-prompt'
 import { KeeperTurnInspectorPanel } from './keeper-turn-inspector-panel'
 import { registerInternalAgentRefresh } from '../sse-store'
 import { Btn } from './btn'
@@ -120,8 +124,94 @@ function fusionHref(): string {
 
 function librarianRevision(value: unknown): number | undefined {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return undefined
-  const revision = (value as Record<string, unknown>).revision
+  const after = (value as Record<string, unknown>).after
+  if (after === null || typeof after !== 'object' || Array.isArray(after)) return undefined
+  const revision = (after as Record<string, unknown>).revision
   return typeof revision === 'number' && Number.isFinite(revision) ? revision : undefined
+}
+
+function librarianMemoryEvidence(value: unknown): { before: unknown; after: unknown } | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return null
+  const fields = value as Record<string, unknown>
+  if (!('before' in fields) || !('after' in fields)) return null
+  return { before: fields.before, after: fields.after }
+}
+
+function researchRawUnavailable(value: unknown): boolean {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+  const research = (value as Record<string, unknown>).research
+  if (research === null || typeof research !== 'object' || Array.isArray(research)) return false
+  const rawTrace = (research as Record<string, unknown>).raw_trace
+  if (rawTrace === null || typeof rawTrace !== 'object' || Array.isArray(rawTrace)) return false
+  return (rawTrace as Record<string, unknown>).kind === 'unavailable'
+}
+
+function rawTraceFile(path: string): string {
+  return path.split(/[\\/]/).at(-1) ?? path
+}
+
+function ResearchRawTrace({ keeper, path }: { keeper: string; path: string | null }) {
+  const [page, setPage] = useState<RawTracePage | null>(null)
+  const [offset, setOffset] = useState(0)
+  const [view, setView] = useState<'literal' | 'tree'>('literal')
+  const [error, setError] = useState<string | null>(null)
+  const file = path === null ? null : rawTraceFile(path)
+
+  useEffect(() => {
+    if (file === null) return
+    const controller = new AbortController()
+    setPage(null)
+    setError(null)
+    fetchKeeperRawTrace(keeper, file, { signal: controller.signal, offset, limit: 20 })
+      .then(setPage)
+      .catch((reason: unknown) => {
+        if (controller.signal.aborted) return
+        setError(reason instanceof Error ? reason.message : String(reason))
+      })
+    return () => controller.abort()
+  }, [file, keeper, offset])
+
+  if (path === null) {
+    return html`
+      <div class="rounded border border-[var(--color-danger)] p-3 text-xs">
+        <div class="flex items-center gap-2"><${EvidenceBadge} kind="raw" /><strong>RAW trace unavailable</strong></div>
+        <p class="mt-1 text-[var(--color-fg-muted)]">sink 생성 전에 실패해 연구 phase를 실행하지 않았습니다. typed registry preview와 RAW를 같은 것으로 표시하지 않습니다.</p>
+      </div>
+    `
+  }
+  if (error !== null) {
+    return html`<div class="rounded border border-[var(--color-danger)] p-3 text-xs text-[var(--color-danger)]">RAW trace를 읽지 못했습니다: ${error}</div>`
+  }
+  if (page === null) {
+    return html`<p class="text-xs text-[var(--color-fg-muted)]">RAW trace <code>${file}</code> 읽는 중…</p>`
+  }
+
+  return html`
+    <div class="grid gap-2 rounded border border-[var(--status-warn)] p-3" data-testid="research-raw-trace">
+      <div class="flex flex-wrap items-center gap-2 text-xs">
+        <${EvidenceBadge} kind="raw" />
+        <strong>Retained RAW JSONL</strong>
+        <code>${page.file}</code>
+        <span class="text-[var(--color-fg-muted)]">${page.offset + 1}–${page.offset + page.records.length} / ${page.totalRecords}</span>
+      </div>
+      <p class="text-3xs text-[var(--color-fg-muted)]">provider event를 보존한 JSONL의 실제 행입니다. 비밀값은 저장 시점에 redaction되며, registry의 1,024자 typed preview와는 별도 원본입니다.</p>
+      <div class="flex flex-wrap gap-1" role="group" aria-label="Librarian RAW 표시 방식">
+        <button type="button" class="rounded border px-2 py-1 text-3xs" aria-pressed=${view === 'literal'} onClick=${() => setView('literal')}>Literal RAW</button>
+        <button type="button" class="rounded border px-2 py-1 text-3xs" aria-pressed=${view === 'tree'} onClick=${() => setView('tree')}>Readable JSON</button>
+        <button type="button" class="ml-auto rounded border px-2 py-1 text-3xs" disabled=${page.offset === 0} onClick=${() => setOffset(Math.max(0, page.offset - 20))}>이전</button>
+        <button type="button" class="rounded border px-2 py-1 text-3xs" disabled=${page.offset + page.records.length >= page.totalRecords} onClick=${() => setOffset(page.offset + 20)}>다음</button>
+      </div>
+      ${page.records.map((record, index) => html`
+        <div key=${page.offset + index} class="grid gap-1">
+          <span class="text-3xs font-mono text-[var(--color-fg-muted)]">line ${page.offset + index + 1}</span>
+          ${view === 'literal' || !record.ok
+            ? html`<pre class="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--color-bg-page)] p-3 text-3xs">${record.raw}</pre>`
+            : html`<${JsonViewerCard} title=${`Provider record ${page.offset + index + 1}`} data=${record.record} />`}
+          ${record.ok ? null : html`<span class="text-3xs text-[var(--color-danger)]">${record.error}</span>`}
+        </div>
+      `)}
+    </div>
+  `
 }
 
 function LibrarianJournal({
@@ -191,7 +281,7 @@ function LibrarianJournal({
           ? html`<span class="text-[var(--color-danger)]"> · 읽지 못한 줄 ${journal.undecodableLines}</span>`
           : null}
       </div>
-      <p class="text-xs text-[var(--color-fg-muted)]">정규화된 commit journal입니다. Redaction된 retained 실행 레코드는 아래 Turn inspector에서 별도로 확인합니다.</p>
+      <p class="text-xs text-[var(--color-fg-muted)]">정규화된 commit journal입니다. retained RAW는 같은 execution join 또는 Turn inspector에서 별도 출처로 확인합니다.</p>
       ${related.length === 0
         ? html`<p class="rounded border border-[var(--color-border-default)] p-3 text-xs text-[var(--color-fg-muted)]">정확히 조인되는 journal 행이 없습니다. trace만 같거나 시간상 가까운 행을 추정해서 붙이지 않았습니다.</p>`
         : null}
@@ -304,6 +394,12 @@ function Details({ row }: { row: Row }) {
   }
   if (row.source === 'exact') {
     const output = row.run.output ?? { code: row.run.code, detail: row.run.detail }
+    const researchTracePath = row.run.input.kind === 'research'
+      ? researchRawUnavailable(row.run.output) ? null : row.run.input.rawTracePath
+      : undefined
+    const memoryEvidence = row.run.lane === 'librarian_exact'
+      ? librarianMemoryEvidence(row.run.output)
+      : null
     return html`
       <div class="grid gap-3 p-3 bg-[var(--color-bg-surface)] border-t border-[var(--color-border-default)]">
         <div class="flex flex-wrap items-center gap-2 text-xs">
@@ -313,13 +409,24 @@ function Details({ row }: { row: Row }) {
           <a class="ml-auto text-[var(--color-accent)] hover:underline" href=${keeperHref(row.run.actor)}>Keeper 전체 evidence 열기 →</a>
         </div>
         <div class="grid gap-3 lg:grid-cols-2">
-          <${JsonViewerCard} title="입력값 · typed preview" data=${row.run.input} />
+          <${JsonViewerCard} title="입력값 · typed preview" data=${row.run.input.payload} />
           <${JsonViewerCard} title="출력값 · typed preview" data=${output} />
         </div>
-        <p class="text-xs text-[var(--color-fg-muted)]">
-          <span class="mr-2 inline-flex rounded border border-[var(--color-danger)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wide text-[var(--color-danger)]">TRACE JOIN UNAVAILABLE</span>
-          이 registry는 retained trace run ref를 보존하지 않습니다. 시간이나 subject 문자열로 실행 레코드를 추정 연결하지 않습니다.
-        </p>
+        ${researchTracePath === undefined
+          ? html`<p class="text-xs text-[var(--color-fg-muted)]"><span class="mr-2 inline-flex rounded border border-[var(--color-danger)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wide text-[var(--color-danger)]">TRACE JOIN UNAVAILABLE</span>이 exact-only 실행에는 RAW run ref가 없습니다. 시간이나 subject 문자열로 추정 연결하지 않습니다.</p>`
+          : html`<div class="grid gap-2">
+              <p class="text-xs text-[var(--color-fg-muted)]"><strong class="text-[var(--color-fg-primary)]">Execution join</strong> · <code>${row.run.runId}</code> → research RAW → exact finalizer → memory revision</p>
+              <${ResearchRawTrace} keeper=${row.run.actor} path=${researchTracePath} />
+            </div>`}
+        ${memoryEvidence === null
+          ? null
+          : html`<div class="grid gap-2 border-t border-[var(--color-border-default)] pt-3">
+              <div class="flex items-center gap-2 text-xs"><${EvidenceBadge} kind="typed" /><strong>Memory before → after</strong><span class="text-[var(--color-fg-muted)]">exact run output가 보존한 동일 실행의 변화</span></div>
+              <div class="grid gap-3 lg:grid-cols-2">
+                <${JsonViewerCard} title="Before memory · typed preview" data=${memoryEvidence.before} />
+                <${JsonViewerCard} title="After memory + change · typed preview" data=${memoryEvidence.after} />
+              </div>
+            </div>`}
         ${row.run.lane === 'librarian_exact'
           ? html`<div class="border-t border-[var(--color-border-default)] pt-3">
               <${LibrarianJournal}
@@ -451,7 +558,7 @@ export function InternalAgentsMonitor() {
       </div>
 
       <div class="v2-monitoring-card flex flex-wrap gap-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3 text-xs">
-        <span class="flex items-center gap-2"><${EvidenceBadge} kind="raw" /> Redaction된 retained 실행 레코드</span>
+        <span class="flex items-center gap-2"><${EvidenceBadge} kind="raw" /> retained JSONL 실제 행 · 저장 시 secret redaction</span>
         <span class="flex items-center gap-2"><${EvidenceBadge} kind="typed" /> 정규화·redaction된 구조화 evidence</span>
         <span class="flex items-center gap-2"><${EvidenceBadge} kind="excerpt" /> 원문 전체가 아닌 제한된 출력</span>
       </div>

--- a/dashboard/src/components/internal-agents-monitor.ts
+++ b/dashboard/src/components/internal-agents-monitor.ts
@@ -18,6 +18,7 @@ import {
   type RawTracePage,
 } from '../api/dashboard-keeper-prompt'
 import { KeeperTurnInspectorPanel } from './keeper-turn-inspector-panel'
+import { ApiRequestError } from '../api/core'
 import { registerInternalAgentRefresh } from '../sse-store'
 import { Btn } from './btn'
 import { EmptyState, ErrorState } from './common/feedback-state'
@@ -34,6 +35,15 @@ type Row =
   | { source: 'fusion'; id: string; run: FusionRunRecord }
 type CommittedMemoryJournalEntry = Extract<MemoryJournalEntry, { ok: true; outcome: 'committed' }>
 type FailedMemoryJournalEntry = Extract<MemoryJournalEntry, { ok: true; outcome: 'failed' }>
+
+function isForbidden(reason: unknown): boolean {
+  return reason instanceof ApiRequestError
+    ? reason.status === 403
+    : typeof reason === 'object'
+      && reason !== null
+      && 'status' in reason
+      && reason.status === 403
+}
 
 const FILTERS: Array<{ id: Filter; label: string }> = [
   { id: 'all', label: 'All' },
@@ -166,7 +176,9 @@ function ResearchRawTrace({ keeper, path }: { keeper: string; path: string | nul
       .then(setPage)
       .catch((reason: unknown) => {
         if (controller.signal.aborted) return
-        setError(reason instanceof Error ? reason.message : String(reason))
+        setError(isForbidden(reason)
+          ? 'Admin 권한이 있어야 retained RAW blob을 읽을 수 있습니다.'
+          : reason instanceof Error ? reason.message : String(reason))
       })
     return () => controller.abort()
   }, [file, keeper, offset])
@@ -194,7 +206,7 @@ function ResearchRawTrace({ keeper, path }: { keeper: string; path: string | nul
         <code>${page.file}</code>
         <span class="text-[var(--color-fg-muted)]">${page.offset + 1}–${page.offset + page.records.length} / ${page.totalRecords}</span>
       </div>
-      <p class="text-3xs text-[var(--color-fg-muted)]">provider event를 보존한 JSONL의 실제 행입니다. 비밀값은 저장 시점에 redaction되며, registry의 1,024자 typed preview와는 별도 원본입니다.</p>
+      <p class="text-3xs text-[var(--color-fg-muted)]">provider event를 보존한 operator-only JSONL의 실제 행입니다. registry metadata와 달리 민감한 실제 값이 포함될 수 있습니다.</p>
       <div class="flex flex-wrap gap-1" role="group" aria-label="Librarian RAW 표시 방식">
         <button type="button" class="rounded border px-2 py-1 text-3xs" aria-pressed=${view === 'literal'} onClick=${() => setView('literal')}>Literal RAW</button>
         <button type="button" class="rounded border px-2 py-1 text-3xs" aria-pressed=${view === 'tree'} onClick=${() => setView('tree')}>Readable JSON</button>
@@ -232,7 +244,9 @@ function LibrarianJournal({
       .then(setJournal)
       .catch((reason: unknown) => {
         if (controller.signal.aborted) return
-        setError(reason instanceof Error ? reason.message : String(reason))
+        setError(isForbidden(reason)
+          ? 'Admin 권한이 있어야 Memory before/after journal을 읽을 수 있습니다.'
+          : reason instanceof Error ? reason.message : String(reason))
       })
     return () => controller.abort()
   }, [keeper])
@@ -404,13 +418,13 @@ function Details({ row }: { row: Row }) {
       <div class="grid gap-3 p-3 bg-[var(--color-bg-surface)] border-t border-[var(--color-border-default)]">
         <div class="flex flex-wrap items-center gap-2 text-xs">
           <${EvidenceBadge} kind="typed" />
-          <strong>Exact-output registry preview</strong>
-          <span class="text-[var(--color-fg-muted)]">민감값 redaction + 긴 문자열 1,024자 preview</span>
+          <strong>Exact-output registry metadata</strong>
+          <span class="text-[var(--color-fg-muted)]">secret-free 장기 보존 요약 · 실제 값은 operator RAW blob</span>
           <a class="ml-auto text-[var(--color-accent)] hover:underline" href=${keeperHref(row.run.actor)}>Keeper 전체 evidence 열기 →</a>
         </div>
         <div class="grid gap-3 lg:grid-cols-2">
-          <${JsonViewerCard} title="입력값 · typed preview" data=${row.run.input.payload} />
-          <${JsonViewerCard} title="출력값 · typed preview" data=${output} />
+          <${JsonViewerCard} title="입력 metadata · typed" data=${row.run.input.payload} />
+          <${JsonViewerCard} title="출력 metadata · typed" data=${output} />
         </div>
         ${researchTracePath === undefined
           ? html`<p class="text-xs text-[var(--color-fg-muted)]"><span class="mr-2 inline-flex rounded border border-[var(--color-danger)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wide text-[var(--color-danger)]">TRACE JOIN UNAVAILABLE</span>이 exact-only 실행에는 RAW run ref가 없습니다. 시간이나 subject 문자열로 추정 연결하지 않습니다.</p>`
@@ -421,7 +435,7 @@ function Details({ row }: { row: Row }) {
         ${memoryEvidence === null
           ? null
           : html`<div class="grid gap-2 border-t border-[var(--color-border-default)] pt-3">
-              <div class="flex items-center gap-2 text-xs"><${EvidenceBadge} kind="typed" /><strong>Memory before → after</strong><span class="text-[var(--color-fg-muted)]">exact run output가 보존한 동일 실행의 변화</span></div>
+              <div class="flex items-center gap-2 text-xs"><${EvidenceBadge} kind="typed" /><strong>Memory before → after</strong><span class="text-[var(--color-fg-muted)]">registry에는 count/revision만, 실제 추가·제거는 아래 journal</span></div>
               <div class="grid gap-3 lg:grid-cols-2">
                 <${JsonViewerCard} title="Before memory · typed preview" data=${memoryEvidence.before} />
                 <${JsonViewerCard} title="After memory + change · typed preview" data=${memoryEvidence.after} />
@@ -493,7 +507,9 @@ export function InternalAgentsMonitor() {
     const failures: string[] = []
     if (exact.status === 'fulfilled') {
       next.push(...exact.value.runs.map(run => ({ source: 'exact' as const, id: `exact:${run.runId}`, run })))
-    } else failures.push(`Exact lanes: ${String(exact.reason)}`)
+    } else failures.push(isForbidden(exact.reason)
+      ? 'Exact lanes + RAW: Admin 권한 필요 (Settings에서 Admin bearer token을 사용하세요).'
+      : `Exact lanes: ${String(exact.reason)}`)
     if (verification.status === 'fulfilled') {
       next.push(...verification.value.runs.map(run => ({ source: 'verification' as const, id: `verification:${run.verificationId}`, run })))
     } else failures.push(`Verification: ${String(verification.reason)}`)
@@ -558,8 +574,8 @@ export function InternalAgentsMonitor() {
       </div>
 
       <div class="v2-monitoring-card flex flex-wrap gap-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3 text-xs">
-        <span class="flex items-center gap-2"><${EvidenceBadge} kind="raw" /> retained JSONL 실제 행 · 저장 시 secret redaction</span>
-        <span class="flex items-center gap-2"><${EvidenceBadge} kind="typed" /> 정규화·redaction된 구조화 evidence</span>
+        <span class="flex items-center gap-2"><${EvidenceBadge} kind="raw" /> Admin 전용 retained JSONL 실제 행 · 민감값 포함 가능</span>
+        <span class="flex items-center gap-2"><${EvidenceBadge} kind="typed" /> secret-free 장기 보존 metadata</span>
         <span class="flex items-center gap-2"><${EvidenceBadge} kind="excerpt" /> 원문 전체가 아닌 제한된 출력</span>
       </div>
 
@@ -619,7 +635,7 @@ export function InternalAgentsMonitor() {
           >${item.label} ${item.id === 'all' ? rows.length : inventory.find(entry => entry.id === item.id)?.count ?? 0}</button>
         `)}
       </div>
-      ${errors.length > 0 ? html`<${ErrorState}>${errors.join(' · ')}<//>` : null}
+      ${errors.length > 0 ? html`<${ErrorState} message=${errors.join(' · ')} />` : null}
       <div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
         <${KeeperTurnInspectorPanel} keepers=${keepers} />
       </div>

--- a/dashboard/src/components/internal-agents-monitor.ts
+++ b/dashboard/src/components/internal-agents-monitor.ts
@@ -28,7 +28,14 @@ import { formatDateTimeKo, relativeTime } from '../lib/format-time'
 import { hashForRoute } from '../router'
 import { keepers as keeperRosterSignal, shellRuntimeResolution } from '../store'
 
-type Filter = 'all' | 'librarian' | 'judge' | 'compaction' | 'verification' | 'fusion'
+type Filter =
+  | 'all'
+  | 'librarian'
+  | 'auto-judge'
+  | 'board-attention'
+  | 'compaction'
+  | 'verification'
+  | 'fusion'
 type Row =
   | { source: 'exact'; id: string; run: ExactLaneRunRecord }
   | { source: 'verification'; id: string; run: VerificationRunRecord }
@@ -48,7 +55,8 @@ function isForbidden(reason: unknown): boolean {
 const FILTERS: Array<{ id: Filter; label: string }> = [
   { id: 'all', label: 'All' },
   { id: 'librarian', label: 'Librarian' },
-  { id: 'judge', label: 'Judge' },
+  { id: 'auto-judge', label: 'Auto Judge' },
+  { id: 'board-attention', label: 'Board Attention' },
   { id: 'compaction', label: 'Compaction' },
   { id: 'verification', label: 'Verification' },
   { id: 'fusion', label: 'Fusion' },
@@ -60,7 +68,7 @@ function laneLabel(row: Row): string {
   switch (row.run.lane) {
     case 'librarian_exact': return 'Librarian'
     case 'hitl_auto_judge': return 'Auto Judge'
-    case 'board_attention_exact': return 'Board Judge'
+    case 'board_attention_exact': return 'Board Attention'
     case 'compaction_exact': return 'Compaction'
   }
 }
@@ -110,9 +118,16 @@ function finishedAt(row: Row): number | undefined {
 function rowKind(row: Row): Exclude<Filter, 'all'> {
   if (row.source === 'verification') return 'verification'
   if (row.source === 'fusion') return 'fusion'
-  if (row.run.lane === 'librarian_exact') return 'librarian'
-  if (row.run.lane === 'compaction_exact') return 'compaction'
-  return 'judge'
+  switch (row.run.lane) {
+    case 'librarian_exact': return 'librarian'
+    case 'hitl_auto_judge': return 'auto-judge'
+    case 'board_attention_exact': return 'board-attention'
+    case 'compaction_exact': return 'compaction'
+    default: {
+      const unreachable: never = row.run.lane
+      return unreachable
+    }
+  }
 }
 
 function EvidenceBadge({ kind }: { kind: 'raw' | 'typed' | 'excerpt' }) {
@@ -466,12 +481,7 @@ function Details({ row }: { row: Row }) {
 
 function matches(row: Row, filter: Filter): boolean {
   if (filter === 'all') return true
-  if (filter === 'verification') return row.source === 'verification'
-  if (filter === 'fusion') return row.source === 'fusion'
-  if (filter === 'librarian') return row.source === 'exact' && row.run.lane === 'librarian_exact'
-  if (filter === 'compaction') return row.source === 'exact' && row.run.lane === 'compaction_exact'
-  return row.source === 'exact'
-    && (row.run.lane === 'hitl_auto_judge' || row.run.lane === 'board_attention_exact')
+  return rowKind(row) === filter
 }
 
 type KeeperIdentity = { name: string; agent_name?: string | null }
@@ -584,7 +594,7 @@ export function InternalAgentsMonitor() {
           <h3 id="internal-agent-inventory-title" class="text-sm font-semibold text-[var(--color-fg-primary)]">Observed run inventory</h3>
           <span class="text-3xs text-[var(--color-fg-muted)]">0건인 lane도 숨기지 않습니다.</span>
         </div>
-        <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+        <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-6">
           ${inventory.map(item => html`
             <button
               key=${item.id}

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -50,6 +50,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_shared_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_task_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_task_runtime.mli` - execution-dispatch
+- `lib/keeper/keeper_tool_terminal_boundary.ml` - execution-dispatch
+- `lib/keeper/keeper_tool_terminal_boundary.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_voice_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_voice_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_dispatch_runtime.ml` - execution-dispatch

--- a/lib/exact_lane_run_registry.ml
+++ b/lib/exact_lane_run_registry.ml
@@ -20,13 +20,20 @@ type run_status =
       ; output : Yojson.Safe.t
       }
 
+type run_input =
+  | Exact_input of Yojson.Safe.t
+  | Research_input of
+      { raw_trace_path : string option
+      ; payload : Yojson.Safe.t
+      }
+
 type run =
   { run_id : string
   ; lane : lane
   ; subject_id : string
   ; actor : string
   ; started_at : float
-  ; input : Yojson.Safe.t
+  ; input : run_input
   ; status : run_status
   }
 
@@ -51,12 +58,55 @@ let outcome_label = function
   | Failed _ -> "failed"
 ;;
 
+let input_to_yojson = function
+  | Exact_input payload -> `Assoc [ "kind", `String "exact"; "payload", payload ]
+  | Research_input { raw_trace_path; payload } ->
+    `Assoc
+      [ "kind", `String "research"
+      ; ( "raw_trace_path"
+        , Option.fold ~none:`Null ~some:(fun path -> `String path) raw_trace_path )
+      ; "payload", payload
+      ]
+;;
+
+let input_of_yojson json =
+  let ( let* ) = Result.bind in
+  let* fields = Run_registry_core.Json.object_fields json in
+  let* kind = Run_registry_core.Json.string_field "kind" fields in
+  match kind with
+  | "exact" ->
+    let* () = Run_registry_core.Json.exact_fields ~required:[ "kind"; "payload" ] fields in
+    let* payload =
+      List.assoc_opt "payload" fields |> Option.to_result ~none:"missing field payload"
+    in
+    Ok (Exact_input payload)
+  | "research" ->
+    let* () =
+      Run_registry_core.Json.exact_fields
+        ~required:[ "kind"; "raw_trace_path"; "payload" ]
+        fields
+    in
+    let* raw_trace_path =
+      match List.assoc_opt "raw_trace_path" fields with
+      | Some `Null -> Ok None
+      | Some (`String path) when not (String.equal (String.trim path) "") -> Some path |> Result.ok
+      | Some (`String _) -> Error "field raw_trace_path must not be blank"
+      | Some _ -> Error "field raw_trace_path must be a string or null"
+      | None -> Error "missing field raw_trace_path"
+    in
+    let* payload =
+      List.assoc_opt "payload" fields |> Option.to_result ~none:"missing field payload"
+    in
+    Ok (Research_input { raw_trace_path; payload })
+  | value -> Error (Printf.sprintf "unknown exact lane input kind %S" value)
+;;
+
 module Payload = struct
   type registration =
     { lane : lane
     ; subject_id : string
     ; actor : string
-    ; input : Yojson.Safe.t
+    ; input : run_input
     }
 
   type completion =
@@ -74,7 +124,7 @@ module Payload = struct
       [ "lane", `String (lane_key registration.lane)
       ; "subject_id", `String registration.subject_id
       ; "actor", `String registration.actor
-      ; "input", registration.input
+      ; "input", input_to_yojson registration.input
       ]
   ;;
 
@@ -92,7 +142,7 @@ module Payload = struct
     let* actor = Run_registry_core.Json.string_field "actor" fields in
     let* input =
       match List.assoc_opt "input" fields with
-      | Some value -> Ok value
+      | Some value -> input_of_yojson value
       | None -> Error "missing field input"
     in
     Ok { lane; subject_id; actor; input }
@@ -152,6 +202,8 @@ module Store = Run_registry_core.Make (Payload)
 
 type t = Store.t
 
+let storage_filename = "exact-lane-runs-v2.jsonl"
+
 let change_observer_fn : (unit -> unit) Atomic.t = Atomic.make (fun () -> ())
 
 let notify_changed () =
@@ -168,10 +220,21 @@ let replay = Store.replay
 let max_completed_retained = Store.max_completed_retained
 
 let register_running t ~run_id ~lane ~subject_id ~actor ~started_at ~input =
-  let input =
-    input
+  (match input with
+   | Research_input { raw_trace_path = Some path; _ }
+     when String.equal (String.trim path) "" ->
+     invalid_arg "exact lane research raw trace path must not be blank"
+   | Exact_input _ | Research_input _ -> ());
+  let preview payload =
+    payload
     |> Observability_redact.redact_json_value
     |> Observability_redact.preview_json_strings ~max_len:1024
+  in
+  let input =
+    match input with
+    | Exact_input payload -> Exact_input (preview payload)
+    | Research_input { raw_trace_path; payload } ->
+      Research_input { raw_trace_path; payload = preview payload }
   in
   Store.register
     t
@@ -229,7 +292,7 @@ let run_to_yojson run =
     ; "subject_id", `String run.subject_id
     ; "actor", `String run.actor
     ; "started_at", `Float run.started_at
-    ; "input", run.input
+    ; "input", input_to_yojson run.input
     ; "status", `String (status_label run.status)
     ]
   in
@@ -245,6 +308,18 @@ let run_to_yojson run =
       [ "elapsed_s", `Float elapsed_s; "output", output ] @ detail
   in
   `Assoc (base @ completion)
+;;
+
+let research_raw_trace_paths t ~actor =
+  list_runs t
+  |> List.filter_map (fun run ->
+    if not (String.equal run.actor actor)
+    then None
+    else
+      match run.input with
+      | Research_input { raw_trace_path = Some path; _ } -> Some path
+      | Exact_input _ | Research_input { raw_trace_path = None; _ } -> None)
+  |> List.sort_uniq String.compare
 ;;
 
 type global_install_error = Already_installed

--- a/lib/exact_lane_run_registry.mli
+++ b/lib/exact_lane_run_registry.mli
@@ -22,17 +22,29 @@ type run_status =
       ; output : Yojson.Safe.t
       }
 
+type run_input =
+  | Exact_input of Yojson.Safe.t
+  | Research_input of
+      { raw_trace_path : string option
+      ; payload : Yojson.Safe.t
+      }
+
 type run =
   { run_id : string
   ; lane : lane
   ; subject_id : string
   ; actor : string
   ; started_at : float
-  ; input : Yojson.Safe.t
+  ; input : run_input
   ; status : run_status
   }
 
 type t
+
+(** Current-only durable registry. The v2 file starts at the closed
+    [run_input] contract; the removed open-JSON rows are not replayed or
+    migrated into this store. *)
+val storage_filename : string
 
 val create : ?path:string -> unit -> t
 val replay : string -> t
@@ -44,7 +56,7 @@ val register_running
   -> subject_id:string
   -> actor:string
   -> started_at:float
-  -> input:Yojson.Safe.t
+  -> input:run_input
   -> unit
 
 val mark_completed
@@ -61,6 +73,10 @@ val lane_key : lane -> string
 val outcome_label : outcome -> string
 val status_label : run_status -> string
 val run_to_yojson : run -> Yojson.Safe.t
+
+(** Raw-trace paths retained by registered research/exact executions for one
+    Keeper actor. *)
+val research_raw_trace_paths : t -> actor:string -> string list
 
 (** Called after a registry mutation is durable/in-memory-visible. The server
     installs a WS invalidation broadcaster; tests and library-only users keep

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -1214,14 +1214,15 @@ let spawn_with
       ~actor:entry.keeper_name
       ~started_at
       ~input:
-        (`Assoc
+        (Exact_lane_run_registry.Exact_input
+           (`Assoc
            [ "tool_name", `String entry.tool_name
            ; "turn_id", Json_util.int_opt_to_json entry.turn_id
            ; "task_id", Json_util.string_opt_to_json entry.task_id
            ; "goal_id", Json_util.string_opt_to_json entry.goal_id
            ; "goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids)
            ; "partial_context", `Bool (Option.is_none entry.request_context)
-           ]);
+           ]));
     let complete outcome output =
       Exact_lane_run_registry.mark_completed
         registry

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -314,21 +314,7 @@ let turn_record_raw_trace_run_ref
       }
 ;;
 
-let terminal_effect_boundary_decision = function
-  | Keeper_tools_oas.Terminal_effect_open -> Ok Runtime_agent.Continue
-  | Keeper_tools_oas.Deferred_tool_result ->
-    Ok (Runtime_agent.Yield Runtime_agent.Durable_stimulus_waiting)
-  | Keeper_tools_oas.External_effect_deferred ->
-    Ok (Runtime_agent.Yield Runtime_agent.External_effect_deferred)
-  | Keeper_tools_oas.Terminal_effect_completed ->
-    Ok (Runtime_agent.Yield Runtime_agent.Terminal_tool_completed)
-  | Keeper_tools_oas.Terminal_effect_failed
-      { failure_class; effect_disposition; diagnostic } ->
-    Error
-      (Keeper_internal_error.sdk_error_of_masc_internal_error
-         (Keeper_internal_error.Terminal_effect_failed
-            { failure_class; effect_disposition; diagnostic }))
-;;
+let terminal_effect_boundary_decision = Keeper_tool_terminal_boundary.decision
 
 module For_testing = struct
   let sse_event_progress_kind = Turn_helpers.sse_event_progress_kind
@@ -1079,7 +1065,9 @@ let run_turn
                                  AfterTurn ordinal")
                          | Ok turn_outcome, Some final_oas_turn_ordinal ->
                            Keeper_agent_run_finalize_response.finalize
-                             ~config ~meta ~generation ~profile_defaults
+                             ~config ~meta ~publication_recovery
+                             ~ctx_snapshot:ctx_work
+                             ~generation ~profile_defaults
                              ~manifest_keeper_turn_id
                              ~session ~append_manifest ~model
                              ~acc
@@ -1096,6 +1084,7 @@ let run_turn
                              ~history_assistant_source
                              ~raw_response_text:response_text
                              ~turn_outcome
+                             ?continuation_channel
                              ?continuation_delivery_channel
                              ~capture_replay_response:
                                (fun ~response_text ->

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -12,6 +12,8 @@ open Keeper_agent_result
 let finalize
     ~config
     ~meta
+    ~publication_recovery
+    ~ctx_snapshot
     ~generation
     ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
     ~manifest_keeper_turn_id
@@ -35,6 +37,7 @@ let finalize
     ~raw_response_text
     ~turn_outcome
     ~capture_replay_response
+    ?continuation_channel
     ?continuation_delivery_channel
     () =
   let completion_contract_result = acc.receipt_completion_contract_result in
@@ -237,6 +240,10 @@ let finalize
     Keeper_agent_run_post_turn_memory.run
       ~config
       ~meta
+      ~publication_recovery
+      ~ctx_snapshot
+      ~runtime_id:runtime_id_string
+      ?continuation_channel
       ~generation
       ~turn:manifest_keeper_turn_id
       ~oas_turn_count:result.turns

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -6,6 +6,10 @@
 let run
   ~config
   ~(meta : Keeper_meta_contract.keeper_meta)
+  ~publication_recovery
+  ~ctx_snapshot
+  ~runtime_id
+  ?continuation_channel
   ~generation
   ~turn
   ~oas_turn_count
@@ -63,6 +67,14 @@ let run
             }
           in
           Keeper_librarian_runtime.run_best_effort
+            ~research_context:
+              { config
+              ; meta
+              ; publication_recovery
+              ; ctx_snapshot
+              ; runtime_id
+              ; continuation_channel
+              }
             ~keepers_dir
             ~keeper_id:meta.name
             ~expected_revision

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -11,6 +11,10 @@
 val run :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
+  publication_recovery:Keeper_publication_recovery_availability.turn_context ->
+  ctx_snapshot:Keeper_types.working_context ->
+  runtime_id:string ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   generation:int ->
   turn:int ->
   oas_turn_count:int ->

--- a/lib/keeper/keeper_board_attention_exact_flow.ml
+++ b/lib/keeper/keeper_board_attention_exact_flow.ml
@@ -367,7 +367,7 @@ let execute_current ?clock ~before_dispatch ~before_advance prepared =
     ~subject_id:prepared.candidate.candidate_id
     ~actor:prepared.candidate.keeper_name
     ~started_at
-    ~input:prepared.candidate.judgment_request;
+    ~input:(Exact_lane_run_registry.Exact_input prepared.candidate.judgment_request);
   let complete outcome output =
     Exact_lane_run_registry.mark_completed
       registry

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -902,11 +902,12 @@ let execute_prepared_lane_current
     ~actor:keeper_name
     ~started_at
     ~input:
-      (`Assoc
+      (Exact_lane_run_registry.Exact_input
+         (`Assoc
          [ "registry_generation", `Intlit (Int64.to_string prepared_lane.registry_generation)
          ; "slot_ids", `List (List.map (fun id -> `String id) prepared_lane.ordered_slot_ids)
          ; "source_unit_count", `Int (List.length prepared_lane.window.source_units)
-         ]);
+         ]));
   let complete outcome output =
     Exact_lane_run_registry.mark_completed
       registry

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1152,12 +1152,25 @@ let start_keepalive
            invokes it only after the child-owning switch and all children
            finish. *)
         let cleanup_tracking outcome =
-          let terminal_result =
-            try
-              terminalize_lane outcome;
-              Ok ()
+          let librarian_join_result =
+            match
+              Keeper_memory_lane.cancel_and_join_librarian
+                ~base_path:ctx.config.Workspace.base_path
+                ~keeper_name:live_meta.name
             with
-            | exn -> Error (Printexc.to_string exn)
+            | Keeper_memory_lane.No_librarian_work
+            | Keeper_memory_lane.Librarian_joined _ -> Ok ()
+            | Keeper_memory_lane.Librarian_join_failed detail -> Error detail
+          in
+          let terminal_result =
+            match librarian_join_result with
+            | Error _ as error -> error
+            | Ok () ->
+              (try
+                 terminalize_lane outcome;
+                 Ok ()
+               with
+               | exn -> Error (Printexc.to_string exn))
           in
           let tracking_result =
           try

--- a/lib/keeper/keeper_librarian_research.ml
+++ b/lib/keeper/keeper_librarian_research.ml
@@ -10,6 +10,68 @@ type raw_trace_sink_outcome =
   | Raw_trace_ready of Agent_sdk.Raw_trace.t
   | Raw_trace_degraded of Agent_sdk.Error.sdk_error
 
+type research_tool =
+  | Search_files
+  | Read_file
+  | Time_now
+  | Context_status
+  | Artifact_read
+  | Memory_search
+  | Library_search
+  | Library_read
+  | Surface_read
+  | Web_search
+  | Web_fetch
+  | Fusion_status
+  | Analyze_image
+
+let research_tools =
+  [ Search_files
+  ; Read_file
+  ; Time_now
+  ; Context_status
+  ; Artifact_read
+  ; Memory_search
+  ; Library_search
+  ; Library_read
+  ; Surface_read
+  ; Web_search
+  ; Web_fetch
+  ; Fusion_status
+  ; Analyze_image
+  ]
+;;
+
+let descriptor_owns_research_tool tool (descriptor : Keeper_tool_descriptor.t) =
+  match tool, descriptor.runtime_handler with
+  | Search_files, Tool_search_files
+  | Read_file, Tool_read_file
+  | Time_now, Tool_time_now
+  | Context_status, Tool_context_status
+  | Artifact_read, Tool_artifact_read
+  | Memory_search, Tool_memory_search
+  | Library_search, Tool_library_search
+  | Library_read, Tool_library_read
+  | Surface_read, Tool_surface_read
+  | Web_search, Tool_web_search
+  | Web_fetch, Tool_web_fetch
+  | Fusion_status, Tool_masc_fusion_status
+  | Analyze_image, Tool_analyze_image -> true
+  | _ -> false
+;;
+
+let research_descriptors () =
+  let visible = Keeper_tool_descriptor.model_visible_descriptors () in
+  List.map
+    (fun tool ->
+       match List.filter (descriptor_owns_research_tool tool) visible with
+       | [ descriptor ] -> descriptor
+       | [] -> failwith "Librarian research descriptor is not model-visible"
+       | _ :: _ :: _ ->
+         failwith "Librarian research tool has multiple model-visible descriptors")
+    research_tools
+;;
+
 let create_raw_trace_sink
       ~before_create
       ~(config : Workspace.config)
@@ -146,50 +208,35 @@ let tool_error_class_to_yojson = function
   | Some value -> `String (Agent_sdk.Types.show_tool_error_class value)
 ;;
 
-let tool_call_result_to_yojson = function
-  | Executed (Ok { content; _meta }) ->
-    let metadata =
-      match _meta with
-      | None -> `Null
-      | Some value -> value
-    in
+let registry_tool_call_result_to_yojson = function
+  | Executed (Ok _) ->
     `Assoc
       [ "kind", `String "executed"
       ; "outcome", `String "succeeded"
-      ; "content", `String content
-      ; "metadata", metadata
       ]
-  | Executed (Error { message; recoverable; error_class }) ->
+  | Executed (Error { recoverable; error_class; _ }) ->
     `Assoc
       [ "kind", `String "executed"
       ; "outcome", `String "failed"
-      ; "message", `String message
       ; "recoverable", `Bool recoverable
       ; "error_class", tool_error_class_to_yojson error_class
       ]
-  | Rejected_before_execution detail ->
-    `Assoc
-      [ "kind", `String "rejected_before_execution"
-      ; "detail", `String detail
-      ]
-  | Execution_failure_observed detail ->
-    `Assoc
-      [ "kind", `String "execution_failure_observed"
-      ; "detail", `String detail
-      ]
+  | Rejected_before_execution _ ->
+    `Assoc [ "kind", `String "rejected_before_execution" ]
+  | Execution_failure_observed _ ->
+    `Assoc [ "kind", `String "execution_failure_observed" ]
   | Terminal_observation_missing ->
     `Assoc [ "kind", `String "terminal_observation_missing" ]
 ;;
 
-let tool_call_to_yojson call =
+let registry_tool_call_to_yojson call =
   `Assoc
     [ "invocation", invocation_to_yojson call.invocation
     ; "tool_name", `String call.tool_name
-    ; "input", call.input
     ; "started_at", `Float call.started_at
     ; "finished_at", `Float call.finished_at
     ; "duration_ms", `Float call.duration_ms
-    ; "result", tool_call_result_to_yojson call.result
+    ; "result", registry_tool_call_result_to_yojson call.result
     ]
 ;;
 
@@ -263,6 +310,14 @@ let bounded_evidence_to_yojson evidence =
     ]
 ;;
 
+let registry_bounded_evidence_to_yojson evidence =
+  `Assoc
+    [ "original_bytes", `Int evidence.original_bytes
+    ; "retained_bytes", `Int evidence.retained_bytes
+    ; "truncated", `Bool evidence.truncated
+    ]
+;;
+
 let execution_outcome_to_yojson = function
   | Research_completed { evidence; session_id; turns; stop_reason } ->
     `Assoc
@@ -282,12 +337,31 @@ let execution_outcome_to_yojson = function
   | Research_cancelled -> `Assoc [ "kind", `String "cancelled" ]
 ;;
 
-let trace_ref_to_yojson = function
+let registry_execution_outcome_to_yojson = function
+  | Research_completed { evidence; session_id; turns; stop_reason } ->
+    `Assoc
+      [ "kind", `String "completed"
+      ; "evidence", registry_bounded_evidence_to_yojson evidence
+      ; "session_id", `String session_id
+      ; "turns", `Int turns
+      ; "stop_reason", runtime_stop_reason_to_yojson stop_reason
+      ]
+  | Research_failed error ->
+    `Assoc
+      [ "kind", `String "failed"
+      ; "category"
+      , `String
+          (Agent_sdk.Error.category_label (Agent_sdk.Error.category error))
+      ; "retryable", `Bool (Agent_sdk.Error.is_retryable error)
+      ]
+  | Research_cancelled -> `Assoc [ "kind", `String "cancelled" ]
+;;
+
+let registry_trace_ref_to_yojson = function
   | None -> `Null
   | Some (trace : Agent_sdk.Raw_trace.run_ref) ->
     `Assoc
       [ "worker_run_id", `String trace.worker_run_id
-      ; "path", `String trace.path
       ; "start_seq", `Int trace.start_seq
       ; "end_seq", `Int trace.end_seq
       ; "agent_name", `String trace.agent_name
@@ -296,23 +370,21 @@ let trace_ref_to_yojson = function
       ]
 ;;
 
-let receipt_to_yojson receipt =
+let registry_receipt_to_yojson receipt =
   `Assoc
     [ "owner", `String "librarian"
     ; "execution_id", `String (Execution_id.to_string receipt.execution_id)
     ; "runtime_id", `String receipt.runtime_id
-    ; "frozen_system_prompt", `String receipt.frozen_system_prompt
-    ; "frozen_prompt", `String receipt.frozen_prompt
-    ; "frozen_input", receipt.frozen_input
     ; "started_at", `Float receipt.started_at
     ; "finished_at", `Float receipt.finished_at
     ; "duration_ms", `Float receipt.duration_ms
     ; "tool_names", Json_util.json_string_list receipt.tool_names
-    ; "tool_calls", `List (List.map tool_call_to_yojson receipt.tool_calls)
+    ; "tool_calls"
+    , `List (List.map registry_tool_call_to_yojson receipt.tool_calls)
     ; "terminal_effect", terminal_effect_to_yojson receipt.terminal_effect
     ; "cleanup", cleanup_to_yojson receipt.cleanup
-    ; "outcome", execution_outcome_to_yojson receipt.outcome
-    ; "trace_ref", trace_ref_to_yojson receipt.trace_ref
+    ; "outcome", registry_execution_outcome_to_yojson receipt.outcome
+    ; "trace_ref", registry_trace_ref_to_yojson receipt.trace_ref
     ]
 ;;
 
@@ -508,7 +580,7 @@ let freeze_calls recorder =
         }))
 ;;
 
-let make_bundle (request : request) =
+let make_bundle_with_gate_context (request : request) =
   let gate_context =
     Keeper_gate_causal_context.create
       ~turn_id:None
@@ -517,18 +589,22 @@ let make_bundle (request : request) =
            [ "librarian_research_execution_id"
            , `String (Execution_id.to_string request.execution_id)
            ; "owner", `String "librarian"
-           ; "frozen_input", request.frozen_input
            ])
   in
-  Keeper_tools_oas_bundle.make_tool_bundle
-    ~config:request.config
-    ~meta:request.meta
-    ~publication_recovery:request.publication_recovery
-    ~ctx_snapshot:request.ctx_snapshot
-    ~clock:request.clock
-    ?continuation_channel:request.continuation_channel
-    ~gate_context
-    ()
+  ( Keeper_tools_oas_bundle.make_tool_bundle_for_descriptors
+      ~config:request.config
+      ~meta:request.meta
+      ~publication_recovery:request.publication_recovery
+      ~ctx_snapshot:request.ctx_snapshot
+      ~clock:request.clock
+      ?continuation_channel:request.continuation_channel
+      ~gate_context
+      ~descriptors:(research_descriptors ())
+      ()
+  , gate_context )
+;;
+
+let make_bundle request = make_bundle_with_gate_context request |> fst
 ;;
 
 let protect_with_cleanup ~cleanup ~on_cleanup body =
@@ -655,5 +731,33 @@ module For_testing = struct
     match !cleanup with
     | Some outcome -> names, outcome
     | None -> failwith "librarian research cleanup invariant violated"
+  ;;
+
+  let research_descriptor_contract () =
+    research_descriptors ()
+    |> List.map (fun (descriptor : Keeper_tool_descriptor.t) ->
+      ( descriptor.public_name
+      , descriptor.policy.readonly_hint
+      , Keeper_tool_descriptor.runtime_handler_to_string
+          descriptor.runtime_handler ))
+  ;;
+
+  let invalid_request_gate_callback_count request =
+    let bundle, gate_context = make_bundle_with_gate_context request in
+    protect_with_cleanup
+      ~cleanup:bundle.cleanup
+      ~on_cleanup:(fun _ -> ())
+      (fun () ->
+         List.iter
+           (fun (tool : Agent_sdk.Tool.t) ->
+              ignore (Agent_sdk.Tool.execute tool `Null : Agent_sdk.Types.tool_result))
+           bundle.tools;
+         let snapshot = Keeper_gate_causal_context.snapshot gate_context in
+         match snapshot.snapshot with
+         | `Assoc fields ->
+           (match List.assoc_opt "completed_tool_calls" fields with
+            | Some (`List calls) -> List.length calls
+            | Some _ | None -> failwith "missing completed Gate callback list")
+         | _ -> failwith "invalid Librarian Gate causal snapshot")
   ;;
 end

--- a/lib/keeper/keeper_librarian_research.ml
+++ b/lib/keeper/keeper_librarian_research.ml
@@ -148,11 +148,16 @@ let tool_error_class_to_yojson = function
 
 let tool_call_result_to_yojson = function
   | Executed (Ok { content; _meta }) ->
+    let metadata =
+      match _meta with
+      | None -> `Null
+      | Some value -> value
+    in
     `Assoc
       [ "kind", `String "executed"
       ; "outcome", `String "succeeded"
       ; "content", `String content
-      ; "metadata", Option.value ~default:`Null _meta
+      ; "metadata", metadata
       ]
   | Executed (Error { message; recoverable; error_class }) ->
     `Assoc

--- a/lib/keeper/keeper_librarian_research.ml
+++ b/lib/keeper/keeper_librarian_research.ml
@@ -750,7 +750,10 @@ module For_testing = struct
       (fun () ->
          List.iter
            (fun (tool : Agent_sdk.Tool.t) ->
-              ignore (Agent_sdk.Tool.execute tool `Null : Agent_sdk.Types.tool_result))
+              let _result : Agent_sdk.Types.tool_result =
+                Agent_sdk.Tool.execute tool `Null
+              in
+              ())
            bundle.tools;
          let snapshot = Keeper_gate_causal_context.snapshot gate_context in
          match snapshot.snapshot with

--- a/lib/keeper/keeper_librarian_research.ml
+++ b/lib/keeper/keeper_librarian_research.ml
@@ -1,0 +1,654 @@
+module Execution_id = struct
+  type t = string
+
+  let generate () = Random_id.prefixed ~prefix:"librarian-research-" ~bytes:16
+
+  let to_string value = value
+end
+
+type raw_trace_sink_outcome =
+  | Raw_trace_ready of Agent_sdk.Raw_trace.t
+  | Raw_trace_degraded of Agent_sdk.Error.sdk_error
+
+let create_raw_trace_sink
+      ~before_create
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~execution_id
+  =
+  let path_result =
+    try Ok (Keeper_types_support.keeper_raw_trace_turn_path config meta.name) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Agent_sdk.Error.Internal (Printexc.to_string exn))
+  in
+  match path_result with
+  | Error error -> Raw_trace_degraded error
+  | Ok path ->
+    before_create path;
+    (match
+       Agent_sdk.Raw_trace.create
+         ~session_id:(Execution_id.to_string execution_id)
+         ~path
+         ()
+     with
+     | Ok sink -> Raw_trace_ready sink
+     | Error error -> Raw_trace_degraded error)
+;;
+
+type request =
+  { execution_id : Execution_id.t
+  ; runtime_id : string
+  ; frozen_system_prompt : string
+  ; frozen_prompt : string
+  ; frozen_input : Yojson.Safe.t
+  ; evidence_budget_bytes : int
+  ; config : Workspace.config
+  ; meta : Keeper_meta_contract.keeper_meta
+  ; publication_recovery :
+      Keeper_publication_recovery_availability.turn_context
+  ; ctx_snapshot : Keeper_types.working_context
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t
+  ; net : Eio_context.eio_net
+  ; continuation_channel : Keeper_continuation_channel.t option
+  ; raw_trace : Agent_sdk.Raw_trace.t option
+  }
+
+type tool_call_result =
+  | Executed of Agent_sdk.Types.tool_result
+  | Rejected_before_execution of string
+  | Execution_failure_observed of string
+  | Terminal_observation_missing
+
+type tool_call =
+  { invocation : Agent_sdk.Tool_contract.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; started_at : float
+  ; finished_at : float
+  ; duration_ms : float
+  ; result : tool_call_result
+  }
+
+type bounded_evidence =
+  { text : string
+  ; original_bytes : int
+  ; retained_bytes : int
+  ; truncated : bool
+  }
+
+type execution_outcome =
+  | Research_completed of
+      { evidence : bounded_evidence
+      ; session_id : string
+      ; turns : int
+      ; stop_reason : Runtime_agent.stop_reason
+      }
+  | Research_failed of Agent_sdk.Error.sdk_error
+  | Research_cancelled
+
+type cleanup_outcome =
+  | Cleanup_succeeded
+  | Cleanup_failed of string
+  | Cleanup_cancelled
+
+type receipt =
+  { execution_id : Execution_id.t
+  ; runtime_id : string
+  ; frozen_system_prompt : string
+  ; frozen_prompt : string
+  ; frozen_input : Yojson.Safe.t
+  ; started_at : float
+  ; finished_at : float
+  ; duration_ms : float
+  ; tool_names : string list
+  ; tool_calls : tool_call list
+  ; terminal_effect : Keeper_tools_oas.terminal_effect_state
+  ; cleanup : cleanup_outcome
+  ; outcome : execution_outcome
+  ; trace_ref : Agent_sdk.Raw_trace.run_ref option
+  }
+
+let execution_mode_label = function
+  | Agent_sdk.Tool_contract.Concurrent -> "concurrent"
+  | Agent_sdk.Tool_contract.Serial -> "serial"
+;;
+
+let completion_to_yojson = function
+  | Agent_sdk.Tool_contract.Continue_after_success ->
+    `Assoc [ "kind", `String "continue_after_success" ]
+  | Agent_sdk.Tool_contract.Terminal_after_success disposition ->
+    `Assoc
+      [ "kind", `String "terminal_after_success"
+      ; ( "failure_effect_disposition"
+        , `String
+            (Agent_sdk.Tool_contract.show_failure_effect_disposition disposition) )
+      ]
+;;
+
+let invocation_to_yojson invocation =
+  let schedule = Agent_sdk.Tool_contract.Invocation.schedule invocation in
+  `Assoc
+    [ "tool_use_id"
+    , `String (Agent_sdk.Tool_contract.Invocation.tool_use_id invocation)
+    ; "turn", `Int (Agent_sdk.Tool_contract.Invocation.turn invocation)
+    ; "planned_index", `Int schedule.planned_index
+    ; "batch_index", `Int schedule.batch_index
+    ; "batch_size", `Int schedule.batch_size
+    ; "execution_mode", `String (execution_mode_label schedule.execution_mode)
+    ; ( "completion"
+      , completion_to_yojson
+          (Agent_sdk.Tool_contract.Invocation.completion invocation) )
+    ]
+;;
+
+let tool_error_class_to_yojson = function
+  | None -> `Null
+  | Some value -> `String (Agent_sdk.Types.show_tool_error_class value)
+;;
+
+let tool_call_result_to_yojson = function
+  | Executed (Ok { content; _meta }) ->
+    `Assoc
+      [ "kind", `String "executed"
+      ; "outcome", `String "succeeded"
+      ; "content", `String content
+      ; "metadata", Option.value ~default:`Null _meta
+      ]
+  | Executed (Error { message; recoverable; error_class }) ->
+    `Assoc
+      [ "kind", `String "executed"
+      ; "outcome", `String "failed"
+      ; "message", `String message
+      ; "recoverable", `Bool recoverable
+      ; "error_class", tool_error_class_to_yojson error_class
+      ]
+  | Rejected_before_execution detail ->
+    `Assoc
+      [ "kind", `String "rejected_before_execution"
+      ; "detail", `String detail
+      ]
+  | Execution_failure_observed detail ->
+    `Assoc
+      [ "kind", `String "execution_failure_observed"
+      ; "detail", `String detail
+      ]
+  | Terminal_observation_missing ->
+    `Assoc [ "kind", `String "terminal_observation_missing" ]
+;;
+
+let tool_call_to_yojson call =
+  `Assoc
+    [ "invocation", invocation_to_yojson call.invocation
+    ; "tool_name", `String call.tool_name
+    ; "input", call.input
+    ; "started_at", `Float call.started_at
+    ; "finished_at", `Float call.finished_at
+    ; "duration_ms", `Float call.duration_ms
+    ; "result", tool_call_result_to_yojson call.result
+    ]
+;;
+
+let runtime_stop_reason_to_yojson = function
+  | Runtime_agent.Completed -> `Assoc [ "kind", `String "completed" ]
+  | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
+    `Assoc
+      [ "kind", `String "yielded_to_chat_waiting"
+      ; "turns_used", `Int turns_used
+      ]
+  | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
+    `Assoc
+      [ "kind", `String "yielded_to_durable_stimulus"
+      ; "turns_used", `Int turns_used
+      ]
+  | Runtime_agent.Awaiting_external_effect { turns_used } ->
+    `Assoc
+      [ "kind", `String "awaiting_external_effect"
+      ; "turns_used", `Int turns_used
+      ]
+  | Runtime_agent.Yielded_after_repeated_tool_call
+      { turns_used; tool_name; repeated_count } ->
+    `Assoc
+      [ "kind", `String "yielded_after_repeated_tool_call"
+      ; "turns_used", `Int turns_used
+      ; "tool_name", `String tool_name
+      ; "repeated_count", `Int repeated_count
+      ]
+  | Runtime_agent.InputRequired { turns_used; request } ->
+    `Assoc
+      [ "kind", `String "input_required"
+      ; "turns_used", `Int turns_used
+      ; "request_id", `String request.request_id
+      ]
+;;
+
+let terminal_effect_to_yojson = function
+  | Keeper_tools_oas.Terminal_effect_open ->
+    `Assoc [ "kind", `String "open" ]
+  | Keeper_tools_oas.Deferred_tool_result ->
+    `Assoc [ "kind", `String "deferred_tool_result" ]
+  | Keeper_tools_oas.External_effect_deferred ->
+    `Assoc [ "kind", `String "external_effect_deferred" ]
+  | Keeper_tools_oas.Terminal_effect_completed ->
+    `Assoc [ "kind", `String "completed" ]
+  | Keeper_tools_oas.Terminal_effect_failed
+      { failure_class; effect_disposition; diagnostic } ->
+    `Assoc
+      [ "kind", `String "failed"
+      ; "failure_class", Tool_result.tool_failure_class_to_yojson failure_class
+      ; ( "effect_disposition"
+        , `String
+            (Tool_result.failure_effect_disposition_to_string effect_disposition) )
+      ; "diagnostic", `String diagnostic
+      ]
+;;
+
+let cleanup_to_yojson = function
+  | Cleanup_succeeded -> `Assoc [ "kind", `String "succeeded" ]
+  | Cleanup_failed detail ->
+    `Assoc [ "kind", `String "failed"; "detail", `String detail ]
+  | Cleanup_cancelled -> `Assoc [ "kind", `String "cancelled" ]
+;;
+
+let bounded_evidence_to_yojson evidence =
+  `Assoc
+    [ "text", `String evidence.text
+    ; "original_bytes", `Int evidence.original_bytes
+    ; "retained_bytes", `Int evidence.retained_bytes
+    ; "truncated", `Bool evidence.truncated
+    ]
+;;
+
+let execution_outcome_to_yojson = function
+  | Research_completed { evidence; session_id; turns; stop_reason } ->
+    `Assoc
+      [ "kind", `String "completed"
+      ; "evidence", bounded_evidence_to_yojson evidence
+      ; "session_id", `String session_id
+      ; "turns", `Int turns
+      ; "stop_reason", runtime_stop_reason_to_yojson stop_reason
+      ]
+  | Research_failed error ->
+    `Assoc
+      [ "kind", `String "failed"
+      ; "category", `String (Agent_sdk.Error.category_label (Agent_sdk.Error.category error))
+      ; "detail", `String (Agent_sdk.Error.to_string error)
+      ; "retryable", `Bool (Agent_sdk.Error.is_retryable error)
+      ]
+  | Research_cancelled -> `Assoc [ "kind", `String "cancelled" ]
+;;
+
+let trace_ref_to_yojson = function
+  | None -> `Null
+  | Some (trace : Agent_sdk.Raw_trace.run_ref) ->
+    `Assoc
+      [ "worker_run_id", `String trace.worker_run_id
+      ; "path", `String trace.path
+      ; "start_seq", `Int trace.start_seq
+      ; "end_seq", `Int trace.end_seq
+      ; "agent_name", `String trace.agent_name
+      ; ( "session_id"
+        , Option.fold ~none:`Null ~some:(fun value -> `String value) trace.session_id )
+      ]
+;;
+
+let receipt_to_yojson receipt =
+  `Assoc
+    [ "owner", `String "librarian"
+    ; "execution_id", `String (Execution_id.to_string receipt.execution_id)
+    ; "runtime_id", `String receipt.runtime_id
+    ; "frozen_system_prompt", `String receipt.frozen_system_prompt
+    ; "frozen_prompt", `String receipt.frozen_prompt
+    ; "frozen_input", receipt.frozen_input
+    ; "started_at", `Float receipt.started_at
+    ; "finished_at", `Float receipt.finished_at
+    ; "duration_ms", `Float receipt.duration_ms
+    ; "tool_names", Json_util.json_string_list receipt.tool_names
+    ; "tool_calls", `List (List.map tool_call_to_yojson receipt.tool_calls)
+    ; "terminal_effect", terminal_effect_to_yojson receipt.terminal_effect
+    ; "cleanup", cleanup_to_yojson receipt.cleanup
+    ; "outcome", execution_outcome_to_yojson receipt.outcome
+    ; "trace_ref", trace_ref_to_yojson receipt.trace_ref
+    ]
+;;
+
+let finalizer_evidence_to_yojson receipt =
+  let outcome =
+    match receipt.outcome with
+    | Research_completed { evidence; session_id = _; turns; stop_reason } ->
+      `Assoc
+        [ "kind", `String "completed"
+        ; "evidence", bounded_evidence_to_yojson evidence
+        ; "turns", `Int turns
+        ; "stop_reason", runtime_stop_reason_to_yojson stop_reason
+        ]
+    | Research_failed error -> execution_outcome_to_yojson (Research_failed error)
+    | Research_cancelled -> execution_outcome_to_yojson Research_cancelled
+  in
+  `Assoc
+    [ "owner", `String "librarian"
+    ; "execution_id", `String (Execution_id.to_string receipt.execution_id)
+    ; "runtime_id", `String receipt.runtime_id
+    ; "started_at", `Float receipt.started_at
+    ; "finished_at", `Float receipt.finished_at
+    ; "duration_ms", `Float receipt.duration_ms
+    ; "tool_calls"
+    , `List
+        (List.map
+           (fun call ->
+              `Assoc
+                [ "invocation", invocation_to_yojson call.invocation
+                ; "tool_name", `String call.tool_name
+                ; "started_at", `Float call.started_at
+                ; "finished_at", `Float call.finished_at
+                ])
+           receipt.tool_calls)
+    ; "terminal_effect", terminal_effect_to_yojson receipt.terminal_effect
+    ; "cleanup", cleanup_to_yojson receipt.cleanup
+    ; "outcome", outcome
+    ]
+;;
+
+type observed_call =
+  { ordinal : int
+  ; invocation : Agent_sdk.Tool_contract.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; started_at : float
+  ; mutable terminal : (float * float * tool_call_result) option
+  }
+
+type recorder =
+  { mutex : Eio.Mutex.t
+  ; mutable next_ordinal : int
+  ; mutable calls : observed_call list
+  ; by_tool_use_id : (string, observed_call) Hashtbl.t
+  }
+
+let create_recorder () =
+  { mutex = Eio.Mutex.create ()
+  ; next_ordinal = 0
+  ; calls = []
+  ; by_tool_use_id = Hashtbl.create 16
+  }
+;;
+
+let with_recorder recorder f = Eio_guard.with_mutex recorder.mutex f
+
+let observe_started recorder ~now ~invocation ~tool_name ~input =
+  with_recorder recorder (fun () ->
+    let ordinal = recorder.next_ordinal in
+    recorder.next_ordinal <- ordinal + 1;
+    let call =
+      { ordinal; invocation; tool_name; input; started_at = now; terminal = None }
+    in
+    recorder.calls <- call :: recorder.calls;
+    Hashtbl.replace
+      recorder.by_tool_use_id
+      (Agent_sdk.Tool_contract.Invocation.tool_use_id invocation)
+      call)
+;;
+
+let observe_terminal
+      recorder
+      ~now
+      ~invocation
+      ~tool_name
+      ~input
+      ~duration_ms
+      ~result
+  =
+  with_recorder recorder (fun () ->
+    let tool_use_id = Agent_sdk.Tool_contract.Invocation.tool_use_id invocation in
+    let call =
+      match Hashtbl.find_opt recorder.by_tool_use_id tool_use_id with
+      | Some call -> call
+      | None ->
+        let ordinal = recorder.next_ordinal in
+        recorder.next_ordinal <- ordinal + 1;
+        let call =
+          { ordinal
+          ; invocation
+          ; tool_name
+          ; input
+          ; started_at = now -. (duration_ms /. 1000.0)
+          ; terminal = None
+          }
+        in
+        recorder.calls <- call :: recorder.calls;
+        Hashtbl.replace recorder.by_tool_use_id tool_use_id call;
+        call
+    in
+    match call.terminal, result with
+    | None, _ -> call.terminal <- Some (now, duration_ms, result)
+    | Some (_, _, Execution_failure_observed _), Executed _ ->
+      (* [PostToolUse] is the authoritative handler result. The execution
+         failure hook is a compact secondary observation and may be delivered
+         first by a custom observer scheduler. *)
+      call.terminal <- Some (now, duration_ms, result)
+    | Some _, _ -> ())
+;;
+
+let recorder_hooks recorder =
+  let pre_tool_use = function
+    | Agent_sdk.Hooks.PreToolUse { invocation; tool_name; input; _ } ->
+      observe_started recorder ~now:(Time_compat.now ()) ~invocation ~tool_name ~input;
+      Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue
+  in
+  let post_tool_use = function
+    | Agent_sdk.Hooks.PostToolUse
+        { invocation; tool_name; input; output; duration_ms; _ } ->
+      observe_terminal
+        recorder
+        ~now:(Time_compat.now ())
+        ~invocation
+        ~tool_name
+        ~input
+        ~duration_ms
+        ~result:(Executed output);
+      Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue
+  in
+  let post_tool_use_failure = function
+    | Agent_sdk.Hooks.PostToolUseFailure
+        { invocation; tool_name; input; stage; duration_ms; error } ->
+      let result =
+        match stage with
+        | Agent_sdk.Hooks.Validation_before_execution ->
+          Rejected_before_execution error
+        | Agent_sdk.Hooks.Execution -> Execution_failure_observed error
+      in
+      observe_terminal
+        recorder
+        ~now:(Time_compat.now ())
+        ~invocation
+        ~tool_name
+        ~input
+        ~duration_ms
+        ~result;
+      Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue
+  in
+  { Agent_sdk.Hooks.empty with
+    pre_tool_use = Some pre_tool_use
+  ; post_tool_use = Some post_tool_use
+  ; post_tool_use_failure = Some post_tool_use_failure
+  }
+;;
+
+let freeze_calls recorder =
+  with_recorder recorder (fun () ->
+    recorder.calls
+    |> List.sort (fun left right -> Int.compare left.ordinal right.ordinal)
+    |> List.map (fun call ->
+      match call.terminal with
+      | Some (finished_at, duration_ms, result) ->
+        { invocation = call.invocation
+        ; tool_name = call.tool_name
+        ; input = call.input
+        ; started_at = call.started_at
+        ; finished_at
+        ; duration_ms
+        ; result
+        }
+      | None ->
+        let finished_at = Time_compat.now () in
+        { invocation = call.invocation
+        ; tool_name = call.tool_name
+        ; input = call.input
+        ; started_at = call.started_at
+        ; finished_at
+        ; duration_ms = (finished_at -. call.started_at) *. 1000.0
+        ; result = Terminal_observation_missing
+        }))
+;;
+
+let make_bundle (request : request) =
+  let gate_context =
+    Keeper_gate_causal_context.create
+      ~turn_id:None
+      ~initial:
+        (`Assoc
+           [ "librarian_research_execution_id"
+           , `String (Execution_id.to_string request.execution_id)
+           ; "owner", `String "librarian"
+           ; "frozen_input", request.frozen_input
+           ])
+  in
+  Keeper_tools_oas_bundle.make_tool_bundle
+    ~config:request.config
+    ~meta:request.meta
+    ~publication_recovery:request.publication_recovery
+    ~ctx_snapshot:request.ctx_snapshot
+    ~clock:request.clock
+    ?continuation_channel:request.continuation_channel
+    ~gate_context
+    ()
+;;
+
+let protect_with_cleanup ~cleanup ~on_cleanup body =
+  Eio_guard.protect
+    ~finally:(fun () ->
+      match cleanup () with
+      | () -> on_cleanup Cleanup_succeeded
+      | exception (Eio.Cancel.Cancelled _ as exn) ->
+        on_cleanup Cleanup_cancelled;
+        raise exn
+      | exception exn -> on_cleanup (Cleanup_failed (Printexc.to_string exn)))
+    body
+;;
+
+let bounded_evidence ~max_bytes text =
+  if max_bytes < 0
+  then invalid_arg "librarian research evidence budget must be non-negative";
+  let original_bytes = String.length text in
+  let text, truncated = Keeper_text_processing.truncate_utf8_prefix ~max_bytes text in
+  { text
+  ; original_bytes
+  ; retained_bytes = String.length text
+  ; truncated
+  }
+;;
+
+let run ~on_receipt (request : request) =
+  let started_at = Time_compat.now () in
+  let bundle = make_bundle request in
+  let recorder = create_recorder () in
+  let hooks = recorder_hooks recorder in
+  let tool_names =
+    List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) bundle.tools
+  in
+  let cleanup_outcome = ref None in
+  let execution =
+    try
+      `Returned
+        (protect_with_cleanup
+           ~cleanup:bundle.cleanup
+           ~on_cleanup:(fun outcome -> cleanup_outcome := Some outcome)
+           (fun () ->
+              try
+                Keeper_turn_driver.run_named
+                  ~runtime_id:request.runtime_id
+                  ~keeper_name:request.meta.name
+                  ~base_path:request.config.base_path
+                  ~goal:request.frozen_prompt
+                  ~system_prompt:request.frozen_system_prompt
+                  ~tools:bundle.tools
+                  ~hooks
+                  ?raw_trace:request.raw_trace
+                  ~cooperative_yield_probe:(fun _ ->
+                    Keeper_tool_terminal_boundary.decision
+                      (bundle.terminal_effect_state ()))
+                  ~net:request.net
+                  ()
+              with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
+              | exn -> Error (Agent_sdk.Error.Internal (Printexc.to_string exn))))
+    with
+    | Eio.Cancel.Cancelled _ as exn ->
+      `Cancelled (exn, Printexc.get_raw_backtrace ())
+  in
+  let cleanup =
+    match !cleanup_outcome with
+    | Some outcome -> outcome
+    | None -> failwith "librarian research cleanup invariant violated"
+  in
+  let outcome, trace_ref =
+    match execution with
+    | `Returned (Ok result) ->
+      let raw_evidence = Agent_sdk.Types.text_of_response result.response in
+      let evidence =
+        bounded_evidence ~max_bytes:request.evidence_budget_bytes raw_evidence
+      in
+      ( Research_completed
+          { evidence
+          ; session_id = result.session_id
+          ; turns = result.turns
+          ; stop_reason = result.stop_reason
+          }
+      , result.trace_ref )
+    | `Returned (Error error) -> Research_failed error, None
+    | `Cancelled _ -> Research_cancelled, None
+  in
+  let finished_at = Time_compat.now () in
+  let receipt =
+    { execution_id = request.execution_id
+  ; runtime_id = request.runtime_id
+  ; frozen_system_prompt = request.frozen_system_prompt
+  ; frozen_prompt = request.frozen_prompt
+  ; frozen_input = request.frozen_input
+  ; started_at
+  ; finished_at
+  ; duration_ms = max 0.0 ((finished_at -. started_at) *. 1000.0)
+  ; tool_names
+  ; tool_calls = freeze_calls recorder
+  ; terminal_effect = bundle.terminal_effect_state ()
+  ; cleanup
+  ; outcome
+  ; trace_ref
+    }
+  in
+  on_receipt receipt;
+  match execution with
+  | `Returned _ -> receipt
+  | `Cancelled (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
+;;
+
+module For_testing = struct
+  let protect_with_cleanup = protect_with_cleanup
+
+  let tool_names_for_request request =
+    let bundle = make_bundle request in
+    let names =
+      List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) bundle.tools
+    in
+    let cleanup = ref None in
+    protect_with_cleanup
+      ~cleanup:bundle.cleanup
+      ~on_cleanup:(fun outcome -> cleanup := Some outcome)
+      (fun () -> ());
+    match !cleanup with
+    | Some outcome -> names, outcome
+    | None -> failwith "librarian research cleanup invariant violated"
+  ;;
+end

--- a/lib/keeper/keeper_librarian_research.mli
+++ b/lib/keeper/keeper_librarian_research.mli
@@ -1,10 +1,10 @@
 (** Tool-capable research phase owned by the Librarian.
 
-    Research receives the complete Keeper model-visible tool bundle. Its typed
-    receipt is evidence for the existing tool-free exact Librarian finalizer;
-    it never replaces that finalization authority. This module deliberately
-    has no generic internal-role sum: a later role must prove and own its own
-    production context and failure policy. *)
+    Research receives the closed read/observation-only {!research_tool}
+    authority. Its typed receipt is evidence for the existing tool-free exact
+    Librarian finalizer; it never replaces that finalization authority. This
+    module deliberately has no generic internal-role sum: a later role must
+    prove and own its own production context and failure policy. *)
 
 module Execution_id : sig
   type t
@@ -16,6 +16,23 @@ end
 type raw_trace_sink_outcome =
   | Raw_trace_ready of Agent_sdk.Raw_trace.t
   | Raw_trace_degraded of Agent_sdk.Error.sdk_error
+
+type research_tool =
+  | Search_files
+  | Read_file
+  | Time_now
+  | Context_status
+  | Artifact_read
+  | Memory_search
+  | Library_search
+  | Library_read
+  | Surface_read
+  | Web_search
+  | Web_fetch
+  | Fusion_status
+  | Analyze_image
+(** Closed, read/observation-only authority granted to the detached Librarian
+    research phase. Operational/mutating Keeper tools are not representable. *)
 
 (** Create a fresh retained-trace candidate for one Librarian research phase.
     The caller registers [Agent_sdk.Raw_trace.file_path] as a durable reachability
@@ -106,9 +123,10 @@ val run : on_receipt:(receipt -> unit) -> request -> receipt
     and terminal observation freeze. Cancellation is re-raised only after the
     cancelled receipt has been delivered to this callback. *)
 
-(** Full receipt for durable/raw observation. Exact inputs and tool results are
-    retained here; the finalizer projection below is deliberately bounded. *)
-val receipt_to_yojson : receipt -> Yojson.Safe.t
+(** Secret-free long-lived registry projection. Frozen prompts/input, tool
+    input/output, evidence text, and trace paths remain only in the retained
+    raw-trace blob behind the operator route. *)
+val registry_receipt_to_yojson : receipt -> Yojson.Safe.t
 
 (** Bounded evidence projection consumed by the later exact-output phase. *)
 val finalizer_evidence_to_yojson : receipt -> Yojson.Safe.t
@@ -121,4 +139,11 @@ module For_testing : sig
     -> 'a
 
   val tool_names_for_request : request -> string list * cleanup_outcome
+
+  val research_descriptor_contract : unit -> (string * bool option * string) list
+
+  val invalid_request_gate_callback_count : request -> int
+  (** Dispatch one schema-invalid occurrence through every research tool. No
+      handler executes; each standard Keeper handler must still record exactly
+      one Gate/result callback. *)
 end

--- a/lib/keeper/keeper_librarian_research.mli
+++ b/lib/keeper/keeper_librarian_research.mli
@@ -1,0 +1,124 @@
+(** Tool-capable research phase owned by the Librarian.
+
+    Research receives the complete Keeper model-visible tool bundle. Its typed
+    receipt is evidence for the existing tool-free exact Librarian finalizer;
+    it never replaces that finalization authority. This module deliberately
+    has no generic internal-role sum: a later role must prove and own its own
+    production context and failure policy. *)
+
+module Execution_id : sig
+  type t
+
+  val generate : unit -> t
+  val to_string : t -> string
+end
+
+type raw_trace_sink_outcome =
+  | Raw_trace_ready of Agent_sdk.Raw_trace.t
+  | Raw_trace_degraded of Agent_sdk.Error.sdk_error
+
+(** Create a fresh retained-trace candidate for one Librarian research phase.
+    The caller registers [Agent_sdk.Raw_trace.file_path] as a durable reachability
+    root before dispatch. Sink failure prevents the research dispatch; the
+    caller records that observation and may continue the exact finalizer. *)
+val create_raw_trace_sink
+  :  before_create:(string -> unit)
+  -> config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> execution_id:Execution_id.t
+  -> raw_trace_sink_outcome
+
+type request =
+  { execution_id : Execution_id.t
+  ; runtime_id : string
+  ; frozen_system_prompt : string
+  ; frozen_prompt : string
+  ; frozen_input : Yojson.Safe.t
+  ; evidence_budget_bytes : int
+  ; config : Workspace.config
+  ; meta : Keeper_meta_contract.keeper_meta
+  ; publication_recovery :
+      Keeper_publication_recovery_availability.turn_context
+  ; ctx_snapshot : Keeper_types.working_context
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t
+  ; net : Eio_context.eio_net
+  ; continuation_channel : Keeper_continuation_channel.t option
+  ; raw_trace : Agent_sdk.Raw_trace.t option
+  }
+
+type tool_call_result =
+  | Executed of Agent_sdk.Types.tool_result
+  | Rejected_before_execution of string
+  | Execution_failure_observed of string
+  | Terminal_observation_missing
+
+type tool_call =
+  { invocation : Agent_sdk.Tool_contract.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; started_at : float
+  ; finished_at : float
+  ; duration_ms : float
+  ; result : tool_call_result
+  }
+
+type bounded_evidence =
+  { text : string
+  ; original_bytes : int
+  ; retained_bytes : int
+  ; truncated : bool
+  }
+
+type execution_outcome =
+  | Research_completed of
+      { evidence : bounded_evidence
+      ; session_id : string
+      ; turns : int
+      ; stop_reason : Runtime_agent.stop_reason
+      }
+  | Research_failed of Agent_sdk.Error.sdk_error
+  | Research_cancelled
+
+type cleanup_outcome =
+  | Cleanup_succeeded
+  | Cleanup_failed of string
+  | Cleanup_cancelled
+
+type receipt =
+  { execution_id : Execution_id.t
+  ; runtime_id : string
+  ; frozen_system_prompt : string
+  ; frozen_prompt : string
+  ; frozen_input : Yojson.Safe.t
+  ; started_at : float
+  ; finished_at : float
+  ; duration_ms : float
+  ; tool_names : string list
+  ; tool_calls : tool_call list
+  ; terminal_effect : Keeper_tools_oas.terminal_effect_state
+  ; cleanup : cleanup_outcome
+  ; outcome : execution_outcome
+  ; trace_ref : Agent_sdk.Raw_trace.run_ref option
+  }
+
+val run : on_receipt:(receipt -> unit) -> request -> receipt
+(** Run one research phase. [on_receipt] is called exactly once after cleanup
+    and terminal observation freeze. Cancellation is re-raised only after the
+    cancelled receipt has been delivered to this callback. *)
+
+(** Full receipt for durable/raw observation. Exact inputs and tool results are
+    retained here; the finalizer projection below is deliberately bounded. *)
+val receipt_to_yojson : receipt -> Yojson.Safe.t
+
+(** Bounded evidence projection consumed by the later exact-output phase. *)
+val finalizer_evidence_to_yojson : receipt -> Yojson.Safe.t
+
+module For_testing : sig
+  val protect_with_cleanup
+    :  cleanup:(unit -> unit)
+    -> on_cleanup:(cleanup_outcome -> unit)
+    -> (unit -> 'a)
+    -> 'a
+
+  val tool_names_for_request : request -> string list * cleanup_outcome
+end

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -396,7 +396,7 @@ type research_observation =
 
 let research_observation_to_yojson = function
   | Research_receipt receipt ->
-    Keeper_librarian_research.receipt_to_yojson receipt
+    Keeper_librarian_research.registry_receipt_to_yojson receipt
   | Raw_trace_unavailable error ->
     `Assoc
       [ "owner", `String "librarian"
@@ -408,7 +408,6 @@ let research_observation_to_yojson = function
             , `String
                 (Agent_sdk.Error.category_label
                    (Agent_sdk.Error.category error))
-            ; "detail", `String (Agent_sdk.Error.to_string error)
             ; "retryable", `Bool (Agent_sdk.Error.is_retryable error)
             ] )
       ]
@@ -519,14 +518,13 @@ let record_failure ~keepers_dir ~keeper_id ~trace_id ~kind ~detail ~cadence_defe
     ~cadence_deferred
 ;;
 
-let facts_to_yojson facts =
-  `List (List.map Keeper_memory_os_types.fact_to_json facts)
-;;
-
-let current_selection_to_yojson = function
-  | None -> `Null
+let current_selection_registry_summary = function
+  | None -> `Assoc [ "present", `Bool false; "fact_count", `Int 0 ]
   | Some (current : Keeper_librarian.current_selection) ->
-    `Assoc [ "facts", facts_to_yojson current.facts ]
+    `Assoc
+      [ "present", `Bool true
+      ; "fact_count", `Int (List.length current.facts)
+      ]
 ;;
 
 let completed_output
@@ -536,16 +534,16 @@ let completed_output
   =
   `Assoc
     [ "research", research_observation_to_yojson research
-    ; "before", current_selection_to_yojson inp.current
+    ; "before", current_selection_registry_summary inp.current
     ; ( "after"
       , `Assoc
           [ "revision", `Int snapshot.revision
           ; "updated_at", `Float snapshot.updated_at
-          ; "facts", facts_to_yojson snapshot.facts
+          ; "fact_count", `Int (List.length snapshot.facts)
           ; ( "change"
             , `Assoc
-                [ "added", facts_to_yojson snapshot.change.added
-                ; "removed", facts_to_yojson snapshot.change.removed
+                [ "added_count", `Int (List.length snapshot.change.added)
+                ; "removed_count", `Int (List.length snapshot.change.removed)
                 ; "retained", `Int snapshot.change.retained
                 ] )
           ] )
@@ -603,7 +601,6 @@ let run_best_effort
                       ; "message_count", `Int (List.length inp.messages)
                       ; "current_fact_count", `Int current_fact_count
                       ; "max_recall_fact_bytes", `Int inp.max_recall_fact_bytes
-                      ; "frozen_input", research_payload inp
                       ]
                  });
           registered := true
@@ -724,7 +721,10 @@ let run_best_effort
              let detail = extraction_error_to_string error in
              complete
                (Exact_lane_run_registry.Failed
-                  { code = "librarian_failed"; detail })
+                  { code = "librarian_failed"
+                  ; detail =
+                      "Librarian pass failed; inspect the operator raw trace and Memory journal"
+                  })
                (failed_output !research_observation);
              Otel_metric_store.inc_counter
                Keeper_metrics.(to_string MemoryOsLibrarianFailures)
@@ -778,7 +778,10 @@ let run_best_effort
          | exn ->
            complete
              (Exact_lane_run_registry.Failed
-                { code = "librarian_raised"; detail = Printexc.to_string exn })
+                { code = "librarian_raised"
+                ; detail =
+                    "Librarian raised; inspect the operator logs and Memory journal"
+                })
              (failed_output !research_observation);
            raise exn)
       (* Missing Eio context is a failed pass like any other: the keeper's

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -87,6 +87,16 @@ let message role text =
   Agent_sdk.Types.make_message ~role [ Agent_sdk.Types.Text text ]
 ;;
 
+type research_context =
+  { config : Workspace.config
+  ; meta : Keeper_meta_contract.keeper_meta
+  ; publication_recovery :
+      Keeper_publication_recovery_availability.turn_context
+  ; ctx_snapshot : Keeper_types.working_context
+  ; runtime_id : string
+  ; continuation_channel : Keeper_continuation_channel.t option
+  }
+
 type exact_setup_error =
   | Exact_registry_unavailable of Runtime_exact_output_registry.publication_error
   | Exact_lane_unavailable of Runtime_exact_output_registry.lane_resolution_error
@@ -188,7 +198,7 @@ let render_prompt key variables =
   | Error message -> Error (Printf.sprintf "%s: %s" key message)
 ;;
 
-let messages_and_input_for_librarian (inp : Keeper_librarian.input) =
+let prompt_and_input_for_librarian (inp : Keeper_librarian.input) =
   let input =
     { inp with
       messages =
@@ -201,12 +211,18 @@ let messages_and_input_for_librarian (inp : Keeper_librarian.input) =
   (* One asset, one message: the librarian's role statement lives at the top
      of the selection prompt it is rendered with, so there is no second file
      to keep in step. *)
-  let+ user =
+  let+ prompt =
     render_prompt
       Prompt_names.librarian
       (Keeper_librarian.prompt_variables input)
   in
-  input, [ message Agent_sdk.Types.User user ]
+  input, prompt
+;;
+
+let messages_and_input_for_librarian inp =
+  Result.map
+    (fun (input, prompt) -> input, [ message Agent_sdk.Types.User prompt ])
+    (prompt_and_input_for_librarian inp)
 ;;
 
 let messages_for_librarian inp =
@@ -310,87 +326,157 @@ let exact_execution_error error =
   { outward_effect; detail }
 ;;
 
-let extract_with_exact_output_classified
-      ?clock
+let execute_exact_output_classified
+      ~clock
       ~net
-      (inp : Keeper_librarian.input)
-  : (Keeper_librarian.selection, extraction_error) result
+      ~(selected_input : Keeper_librarian.input)
+      ~messages
   =
   let open Result.Syntax in
-  match clock with
-  | None -> Error Execution_clock_unavailable
-  | Some clock ->
-    let* selected_input, messages =
-      messages_and_input_for_librarian inp
-      |> Result.map_error (fun detail -> Prompt_render_failed detail)
+  let* attempt = prepare_attempt messages in
+  let validate flow_success =
+    let output = Exact_output.flow_success_output flow_success in
+    match
+      Keeper_librarian.selection_of_json_result
+        selected_input
+        output.output
+    with
+    | Ok selection -> Exact_output.Accept selection
+    | Error error -> Exact_output.Reject_and_advance error
+  in
+  match
+    Exact_output.execute_flow_once
+      ~net
+      ~clock
+      ~before_measurement_dispatch:(fun _ -> Ok ())
+      ~on_measurement_terminal:(fun _ -> Ok ())
+      ~before_dispatch:(fun _ -> Ok ())
+      ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
+      ~validate
+      attempt
+  with
+  | Ok success -> Ok success.accepted
+  | Error (Exact_output.Flow_execution_terminal { cause; _ }) ->
+    Error (Exact_execution_failed (exact_execution_error cause))
+  | Error
+      (Exact_output.Flow_semantic_candidates_exhausted
+         { rejections; _ }) ->
+    let rejection =
+      List.fold_left
+        (fun _ rejection -> rejection)
+        rejections.first
+        rejections.rest
     in
-    let* attempt = prepare_attempt messages in
-    let validate flow_success =
-      let output = Exact_output.flow_success_output flow_success in
-      match
-        Keeper_librarian.selection_of_json_result
-          selected_input
-          output.output
-      with
-      | Ok selection -> Exact_output.Accept selection
-      | Error error -> Exact_output.Reject_and_advance error
-    in
-    (match
-       Exact_output.execute_flow_once
-         ~net
-         ~clock
-         ~before_measurement_dispatch:(fun _ -> Ok ())
-         ~on_measurement_terminal:(fun _ -> Ok ())
-         ~before_dispatch:(fun _ -> Ok ())
-         ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
-         ~validate
-         attempt
-     with
-     | Ok success -> Ok success.accepted
-     | Error (Exact_output.Flow_execution_terminal { cause; _ }) ->
-       Error (Exact_execution_failed (exact_execution_error cause))
-     | Error
-         (Exact_output.Flow_semantic_candidates_exhausted
-            { rejections; _ }) ->
-       let rejection =
-         List.fold_left
-           (fun _ rejection -> rejection)
-           rejections.first
-           rejections.rest
-       in
-       Error
-         (Domain_output_invalid
-            (Keeper_librarian.parse_error_to_string rejection.rejection)))
+    Error
+      (Domain_output_invalid
+         (Keeper_librarian.parse_error_to_string rejection.rejection))
 ;;
 
-let extract_and_commit_with_exact_output_classified
-      ?clock
-      ~net
-      ~keepers_dir
-      ~keeper_id
-      ~expected_revision
-      inp
-  =
-  let open Result.Syntax in
-  let* selection =
-    extract_with_exact_output_classified ?clock ~net inp
+let research_system_prompt =
+  "You are the tool-capable research phase for the Keeper Librarian. Use the available tools only when they materially improve the evidence. Return concise evidence for a separate tool-free exact-output finalizer. Do not emit the final memory-selection JSON."
+;;
+
+let research_payload (inp : Keeper_librarian.input) =
+  `Assoc
+    [ "turn_ref", Ids.Turn_ref.to_yojson inp.turn_ref
+    ; "generation", `Int inp.generation
+    ; "keeper_instructions", `String inp.keeper_instructions
+    ; "max_recall_fact_bytes", `Int inp.max_recall_fact_bytes
+    ; ( "rendered_prompt_variables"
+      , `Assoc
+          (List.map
+             (fun (name, value) -> name, `String value)
+             (Keeper_librarian.prompt_variables inp)) )
+    ]
+;;
+
+type research_observation =
+  | Research_receipt of Keeper_librarian_research.receipt
+  | Raw_trace_unavailable of Agent_sdk.Error.sdk_error
+
+let research_observation_to_yojson = function
+  | Research_receipt receipt ->
+    Keeper_librarian_research.receipt_to_yojson receipt
+  | Raw_trace_unavailable error ->
+    `Assoc
+      [ "owner", `String "librarian"
+      ; "outcome", `Assoc [ "kind", `String "not_dispatched" ]
+      ; ( "raw_trace"
+        , `Assoc
+            [ "kind", `String "unavailable"
+            ; "category"
+            , `String
+                (Agent_sdk.Error.category_label
+                   (Agent_sdk.Error.category error))
+            ; "detail", `String (Agent_sdk.Error.to_string error)
+            ; "retryable", `Bool (Agent_sdk.Error.is_retryable error)
+            ] )
+      ]
+;;
+
+let research_finalizer_evidence_to_yojson = function
+  | Research_receipt receipt ->
+    Keeper_librarian_research.finalizer_evidence_to_yojson receipt
+  | Raw_trace_unavailable _ as observation ->
+    research_observation_to_yojson observation
+;;
+
+let research_evidence_message observation =
+  let evidence =
+    research_finalizer_evidence_to_yojson observation
+    |> Yojson.Safe.pretty_to_string
   in
-  Keeper_memory_os_current.replace
-    ?clock
-    ~dropped_statements:selection.dropped
-    ~keepers_dir
-    ~keeper_id
-    ~expected_revision
-    ~now:(Time_compat.now ())
-    ~source:
-      { kind = Keeper_memory_os_current.Librarian
-      ; trace_id = input_trace_id inp
-      ; generation = inp.generation
-      }
-    ~facts:selection.facts
-    ()
-  |> Result.map_error (fun detail ->
-    Memory_snapshot_write_failed detail)
+  message
+    Agent_sdk.Types.User
+    ("Tool-capable research observation follows. A failed or unavailable research phase means no research evidence was obtained; continue from the original Librarian input. Treat any completed research only as evidence and return the exact Librarian JSON schema requested above.\n\n"
+     ^ evidence)
+;;
+
+let research_degraded_detail = function
+  | Raw_trace_unavailable error -> Some (Agent_sdk.Error.to_string error)
+  | Research_receipt receipt ->
+    (match receipt.cleanup, receipt.outcome with
+     | Keeper_librarian_research.Cleanup_succeeded
+     , Keeper_librarian_research.Research_completed _ -> None
+     | Keeper_librarian_research.Cleanup_failed detail, _ ->
+       Some ("tool cleanup failed: " ^ detail)
+     | Keeper_librarian_research.Cleanup_cancelled, _ ->
+       Some "tool cleanup cancelled"
+     | Keeper_librarian_research.Cleanup_succeeded
+     , Keeper_librarian_research.Research_failed error ->
+       Some (Agent_sdk.Error.to_string error)
+     | Keeper_librarian_research.Cleanup_succeeded
+     , Keeper_librarian_research.Research_cancelled ->
+       Some "research cancelled")
+;;
+
+let run_research
+      ~(research_context : research_context)
+      ~clock
+      ~net
+      ~execution_id
+      ~raw_trace
+      ~on_receipt
+      ~(selected_input : Keeper_librarian.input)
+      ~prompt
+  =
+  Keeper_librarian_research.run
+    ~on_receipt
+    { execution_id
+    ; runtime_id = research_context.runtime_id
+    ; frozen_system_prompt = research_system_prompt
+    ; frozen_prompt = prompt
+    ; frozen_input = research_payload selected_input
+    ; evidence_budget_bytes = selected_input.max_recall_fact_bytes
+    ; config = research_context.config
+    ; meta = research_context.meta
+    ; publication_recovery = research_context.publication_recovery
+    ; ctx_snapshot = research_context.ctx_snapshot
+    ; clock
+    ; net
+    ; continuation_channel = research_context.continuation_channel
+    ; raw_trace
+    }
 ;;
 
 (* A failure while no current snapshot exists means the keeper is running
@@ -433,7 +519,51 @@ let record_failure ~keepers_dir ~keeper_id ~trace_id ~kind ~detail ~cadence_defe
     ~cadence_deferred
 ;;
 
+let facts_to_yojson facts =
+  `List (List.map Keeper_memory_os_types.fact_to_json facts)
+;;
+
+let current_selection_to_yojson = function
+  | None -> `Null
+  | Some (current : Keeper_librarian.current_selection) ->
+    `Assoc [ "facts", facts_to_yojson current.facts ]
+;;
+
+let completed_output
+      ~(inp : Keeper_librarian.input)
+      ~(research : research_observation)
+      (snapshot : Keeper_memory_os_current.t)
+  =
+  `Assoc
+    [ "research", research_observation_to_yojson research
+    ; "before", current_selection_to_yojson inp.current
+    ; ( "after"
+      , `Assoc
+          [ "revision", `Int snapshot.revision
+          ; "updated_at", `Float snapshot.updated_at
+          ; "facts", facts_to_yojson snapshot.facts
+          ; ( "change"
+            , `Assoc
+                [ "added", facts_to_yojson snapshot.change.added
+                ; "removed", facts_to_yojson snapshot.change.removed
+                ; "retained", `Int snapshot.change.retained
+                ] )
+          ] )
+    ]
+;;
+
+let failed_output research =
+  `Assoc
+    [ ( "research"
+      , Option.fold
+          ~none:`Null
+          ~some:research_observation_to_yojson
+          research )
+    ]
+;;
+
 let run_best_effort
+      ~(research_context : research_context)
       ~keepers_dir
       ~keeper_id
       ~expected_revision
@@ -446,54 +576,142 @@ let run_best_effort
       match Eio_context.get_net_opt (), Eio_context.get_clock_opt () with
       | Some net, Some clock ->
         let registry = Exact_lane_run_registry.global () in
-        let run_id = Random_id.prefixed ~prefix:"exact-librarian-" ~bytes:16 in
-        let started_at = Eio.Time.now clock in
+        let execution_id = Keeper_librarian_research.Execution_id.generate () in
+        let run_id = Keeper_librarian_research.Execution_id.to_string execution_id in
+        let started_at = Time_compat.now () in
+        let started_at_monotonic = Eio.Time.now clock in
         let current_fact_count =
           match inp.current with
           | None -> 0
           | Some current -> List.length current.facts
         in
-        Exact_lane_run_registry.register_running
-          registry
-          ~run_id
-          ~lane:Exact_lane_run_registry.Librarian
-          ~subject_id:trace_id
-          ~actor:keeper_id
-          ~started_at
-          ~input:
-            (`Assoc
-               [ "generation", `Int inp.generation
-               ; "message_count", `Int (List.length inp.messages)
-               ; "current_fact_count", `Int current_fact_count
-               ; "max_recall_fact_bytes", `Int inp.max_recall_fact_bytes
-               ]);
+        let registered = ref false in
+        let register raw_trace_path =
+          Exact_lane_run_registry.register_running
+            registry
+            ~run_id
+            ~lane:Exact_lane_run_registry.Librarian
+            ~subject_id:trace_id
+            ~actor:keeper_id
+            ~started_at
+            ~input:
+              (Exact_lane_run_registry.Research_input
+                 { raw_trace_path
+                 ; payload =
+                     `Assoc
+                      [ "generation", `Int inp.generation
+                      ; "message_count", `Int (List.length inp.messages)
+                      ; "current_fact_count", `Int current_fact_count
+                      ; "max_recall_fact_bytes", `Int inp.max_recall_fact_bytes
+                      ; "frozen_input", research_payload inp
+                      ]
+                 });
+          registered := true
+        in
+        let research_dispatch =
+          match
+            Keeper_librarian_research.create_raw_trace_sink
+              ~before_create:(fun path -> register (Some path))
+              ~config:research_context.config
+              ~meta:research_context.meta
+              ~execution_id
+          with
+          | Keeper_librarian_research.Raw_trace_ready sink ->
+            `Ready sink
+          | Keeper_librarian_research.Raw_trace_degraded error ->
+            if not !registered then register None;
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RawTraceSinkDegraded)
+              ~labels:[ "keeper", keeper_id ]
+              ();
+            Log.Keeper.warn
+              ~keeper_name:keeper_id
+              "librarian research raw-trace sink unavailable; research not dispatched: %s"
+              (Agent_sdk.Error.to_string error);
+            `Unavailable error
+        in
         let complete outcome output =
           Exact_lane_run_registry.mark_completed
             registry
             ~run_id
             ~outcome
-            ~elapsed_s:(Eio.Time.now clock -. started_at)
+            ~elapsed_s:(Eio.Time.now clock -. started_at_monotonic)
             ~output
         in
+        let research_observation =
+          ref
+            (match research_dispatch with
+             | `Ready _ -> None
+             | `Unavailable error -> Some (Raw_trace_unavailable error))
+        in
         (try
-           match
-             extract_and_commit_with_exact_output_classified
+           let result =
+             let open Result.Syntax in
+             let* selected_input, prompt =
+               prompt_and_input_for_librarian inp
+               |> Result.map_error (fun detail -> Prompt_render_failed detail)
+             in
+             let research =
+               match research_dispatch with
+               | `Unavailable error -> Raw_trace_unavailable error
+               | `Ready raw_trace ->
+                 let receipt =
+                   run_research
+                     ~research_context
+                     ~clock
+                     ~net
+                     ~execution_id
+                     ~raw_trace:(Some raw_trace)
+                     ~on_receipt:(fun receipt ->
+                       research_observation := Some (Research_receipt receipt))
+                     ~selected_input
+                     ~prompt
+                 in
+                 Research_receipt receipt
+             in
+             research_observation := Some research;
+             (match research_degraded_detail research with
+              | None -> ()
+              | Some detail ->
+                Log.Keeper.warn
+                  ~keeper_name:keeper_id
+                  "librarian research unavailable; exact finalizer continues from original input: %s"
+                  detail);
+             let* selection =
+               execute_exact_output_classified
+                 ~clock
+                 ~net
+                 ~selected_input
+                 ~messages:
+                   [ message Agent_sdk.Types.User prompt
+                   ; research_evidence_message research
+                   ]
+             in
+             let+ snapshot =
+               Keeper_memory_os_current.replace
                ~clock
-               ~net
+               ~dropped_statements:selection.dropped
                ~keepers_dir
                ~keeper_id
                ~expected_revision
-               inp
-           with
-           | Ok snapshot ->
+               ~now:(Time_compat.now ())
+               ~source:
+                 { kind = Keeper_memory_os_current.Librarian
+                 ; trace_id = input_trace_id inp
+                 ; generation = inp.generation
+                 }
+               ~facts:selection.facts
+               ()
+             |> Result.map_error (fun detail ->
+               Memory_snapshot_write_failed detail)
+             in
+             snapshot, research
+           in
+           match result with
+           | Ok (snapshot, research) ->
              complete
                Exact_lane_run_registry.Succeeded
-               (`Assoc
-                  [ "revision", `Int snapshot.revision
-                  ; "fact_count", `Int (List.length snapshot.facts)
-                  ; "added_count", `Int (List.length snapshot.change.added)
-                  ; "removed_count", `Int (List.length snapshot.change.removed)
-                  ]);
+               (completed_output ~inp ~research snapshot);
              cadence_record_success ~keeper_id ~trace_id;
              Log.Keeper.info
                ~keeper_name:keeper_id
@@ -507,7 +725,7 @@ let run_best_effort
              complete
                (Exact_lane_run_registry.Failed
                   { code = "librarian_failed"; detail })
-               `Null;
+               (failed_output !research_observation);
              Otel_metric_store.inc_counter
                Keeper_metrics.(to_string MemoryOsLibrarianFailures)
                ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
@@ -539,7 +757,9 @@ let run_best_effort
             cancelled in turn and record nothing, which is the failure it
             exists to close. *)
          | Eio.Cancel.Cancelled _ as exn ->
-           complete Exact_lane_run_registry.Cancelled `Null;
+           complete
+             Exact_lane_run_registry.Cancelled
+             (failed_output !research_observation);
            Eio.Cancel.protect (fun () ->
              record_failure
                ~keepers_dir
@@ -559,7 +779,7 @@ let run_best_effort
            complete
              (Exact_lane_run_registry.Failed
                 { code = "librarian_raised"; detail = Printexc.to_string exn })
-             `Null;
+             (failed_output !research_observation);
            raise exn)
       (* Missing Eio context is a failed pass like any other: the keeper's
          memory does not advance. It was previously a bare WARN with no record,

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -1,8 +1,11 @@
 (** Runtime adapter for LLM-owned current Memory OS selection.
 
-    One OAS exact-output call selects the complete current memory. After domain
-    validation, one atomic current-snapshot replacement is the only MASC-side
-    effect. There is no secondary journal or episode/facts fan-out. *)
+    A Librarian-owned research phase receives the complete Keeper model-visible
+    tool bundle and records exact tool lifecycle evidence. The existing
+    tool-free exact-output flow remains the sole selection authority and one
+    atomic current-snapshot replacement remains the sole Memory OS mutation.
+    If research or its RAW trace is unavailable, the exact flow continues from
+    the original immutable Librarian input and records that degradation. *)
 
 val cadence_step : cadence:int -> counter:int -> int * bool
 val cadence_step_keyed
@@ -17,6 +20,16 @@ val messages_for_librarian
   :  Keeper_librarian.input
   -> (Agent_sdk.Types.message list, string) result
 
+type research_context =
+  { config : Workspace.config
+  ; meta : Keeper_meta_contract.keeper_meta
+  ; publication_recovery :
+      Keeper_publication_recovery_availability.turn_context
+  ; ctx_snapshot : Keeper_types.working_context
+  ; runtime_id : string
+  ; continuation_channel : Keeper_continuation_channel.t option
+  }
+
 type extraction_error
 
 (** Which failure kind this error records in the memory journal. The vocabulary
@@ -25,7 +38,8 @@ type extraction_error
     happens, so adding an [extraction_error] case fails to compile until it
     names its journal kind. *)
 val run_best_effort
-  :  keepers_dir:string
+  :  research_context:research_context
+  -> keepers_dir:string
   -> keeper_id:string
   -> expected_revision:int option
   -> Keeper_librarian.input

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -29,6 +29,7 @@ type librarian_drain =
   { mutable latest : (unit -> unit) option
   ; mutable in_flight : bool
   ; mutable switch_hook : Eio.Switch.hook option
+  ; owner_lane : Keeper_lane.t
   }
 
 type entry =
@@ -80,10 +81,12 @@ let init ~sw =
 
 let current_sw () = Stdlib.Mutex.protect registry_mu (fun () -> !executor_sw)
 
+let entry_key ~base_path ~keeper_name ~lane =
+  Keeper_registry_types.registry_key ~base_path keeper_name ^ "#" ^ lane_label lane
+;;
+
 let entry_for ~base_path ~keeper_name ~lane =
-  let key =
-    Keeper_registry_types.registry_key ~base_path keeper_name ^ "#" ^ lane_label lane
-  in
+  let key = entry_key ~base_path ~keeper_name ~lane in
   Stdlib.Mutex.protect registry_mu (fun () ->
     match Hashtbl.find_opt entries key with
     | Some e -> e
@@ -280,7 +283,13 @@ let librarian_reserve entry f =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
     match entry.librarian_drain with
     | None ->
-      let drain = { latest = None; in_flight = false; switch_hook = None } in
+      let drain =
+        { latest = None
+        ; in_flight = false
+        ; switch_hook = None
+        ; owner_lane = Keeper_lane.create ()
+        }
+      in
       entry.librarian_drain <- Some drain;
       entry.pending <- 1;
       Start_drain drain
@@ -413,28 +422,19 @@ let librarian_finish_current ~keeper_name entry drain =
 let rec run_librarian_drain ~keeper_name entry drain sw current =
   if librarian_begin_current ~keeper_name entry drain
   then (
-    let cancelled =
-      try
-        Eio_context.with_turn_switch sw current;
-        false
-      with
-      | Eio.Cancel.Cancelled _ -> true
-      | exn ->
-        record_counter ~keeper_name ~lane:Librarian MemoryLaneUnitFailures;
-        Log.Keeper.warn ~keeper_name
-          "memory lane unit failed: %s"
-          (Printexc.to_string exn);
-        false
-    in
-    if cancelled
-    then cleanup_librarian_drain ~keeper_name ~remove_hook:true entry drain
-    else (
-      match librarian_finish_current ~keeper_name entry drain with
-      | Drain_stopped -> ()
-      | Drain_done hook ->
-        Option.iter (fun h -> ignore (Eio.Switch.try_remove_hook h)) hook
-      | Drain_next latest ->
-        run_librarian_drain ~keeper_name entry drain sw latest))
+    (try Eio_context.with_turn_switch sw current with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       record_counter ~keeper_name ~lane:Librarian MemoryLaneUnitFailures;
+       Log.Keeper.warn ~keeper_name
+         "memory lane unit failed: %s"
+         (Printexc.to_string exn));
+    match librarian_finish_current ~keeper_name entry drain with
+    | Drain_stopped -> ()
+    | Drain_done hook ->
+      Option.iter (fun h -> ignore (Eio.Switch.try_remove_hook h)) hook
+    | Drain_next latest ->
+      run_librarian_drain ~keeper_name entry drain sw latest)
 ;;
 
 let submit_librarian ~keeper_name entry sw f =
@@ -463,9 +463,28 @@ let submit_librarian ~keeper_name entry sw f =
       Dropped)
     else (
       try
-        Eio.Fiber.fork ~sw (fun () ->
-          run_librarian_drain ~keeper_name entry drain sw f);
-        Submitted
+        (match
+           Keeper_lane.fork
+             ~sw
+             drain.owner_lane
+             ~run:(fun lane_sw ->
+               run_librarian_drain ~keeper_name entry drain lane_sw f)
+             ~cleanup:(fun _outcome ->
+               cleanup_librarian_drain
+                 ~keeper_name
+                 ~remove_hook:true
+                 entry
+                 drain;
+               Ok ())
+         with
+         | Ok () -> Submitted
+         | Error error ->
+           cleanup_librarian_drain ~keeper_name ~remove_hook:true entry drain;
+           record_counter ~keeper_name ~lane:Librarian MemoryLaneUnitFailures;
+           Log.Keeper.warn ~keeper_name
+             "memory lane fork failed: %s"
+             (Keeper_lane.start_error_to_string error);
+           Dropped)
       with
       | Eio.Cancel.Cancelled _ as e ->
         cleanup_librarian_drain ~keeper_name ~remove_hook:true entry drain;
@@ -549,6 +568,43 @@ let submit ~base_path ~keeper_name ~lane f =
      | Deterministic -> submit_bounded ~keeper_name ~lane entry sw f)
 ;;
 
+type librarian_join_outcome =
+  | No_librarian_work
+  | Librarian_joined of Keeper_lane.outcome
+  | Librarian_join_failed of string
+
+let cancel_and_join_librarian ~base_path ~keeper_name =
+  let entry =
+    let key = entry_key ~base_path ~keeper_name ~lane:Librarian in
+    Stdlib.Mutex.protect registry_mu (fun () -> Hashtbl.find_opt entries key)
+  in
+  match entry with
+  | None -> No_librarian_work
+  | Some entry ->
+    let owner_lane =
+      Stdlib.Mutex.protect entry.state_mu (fun () ->
+        Option.map (fun drain -> drain.owner_lane) entry.librarian_drain)
+    in
+    (match owner_lane with
+     | None -> No_librarian_work
+     | Some owner_lane ->
+    (match Keeper_lane.request_cancel owner_lane with
+     | Keeper_lane.Cancel_wrong_domain ->
+       Librarian_join_failed
+         "librarian cancellation requested from a non-owning domain"
+     | Keeper_lane.Cancel_not_committed exn ->
+       Librarian_join_failed
+         ("librarian cancellation was not committed: " ^ Printexc.to_string exn)
+     | Keeper_lane.Cancel_committed_with_failure _
+     | Keeper_lane.Cancel_requested
+     | Keeper_lane.Cancel_already_requested
+     | Keeper_lane.Cancel_already_exiting ->
+       let exit = Keeper_lane.await_exit owner_lane in
+       (match exit.cleanup_error with
+        | Some detail -> Librarian_join_failed detail
+        | None -> Librarian_joined exit.outcome)))
+;;
+
 module For_testing = struct
   let reset () =
     Stdlib.Mutex.protect registry_mu (fun () ->
@@ -557,9 +613,7 @@ module For_testing = struct
   ;;
 
   let pending ~base_path ~keeper_name ~lane =
-    let key =
-      Keeper_registry_types.registry_key ~base_path keeper_name ^ "#" ^ lane_label lane
-    in
+    let key = entry_key ~base_path ~keeper_name ~lane in
     Stdlib.Mutex.protect registry_mu (fun () -> Hashtbl.find_opt entries key)
     |> Option.map (fun e -> Stdlib.Mutex.protect e.state_mu (fun () -> e.pending))
   ;;

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -75,6 +75,19 @@ val submit
     counted rather than escaping. Outcomes and per-keeper state are exported as
     metrics. *)
 
+type librarian_join_outcome =
+  | No_librarian_work
+  | Librarian_joined of Keeper_lane.outcome
+  | Librarian_join_failed of string
+
+val cancel_and_join_librarian
+  :  base_path:string
+  -> keeper_name:string
+  -> librarian_join_outcome
+(** Cancel the exact detached Librarian drain owned by [keeper_name] and wait
+    until its provider/tool scope and cleanup have joined. A Keeper lifecycle
+    boundary must call this before publishing its own terminal state. *)
+
 module For_testing : sig
   val reset : unit -> unit
   (** Clear the lane registry and the executor switch. *)

--- a/lib/keeper/keeper_raw_trace_retention.ml
+++ b/lib/keeper/keeper_raw_trace_retention.ml
@@ -27,6 +27,7 @@ type error =
       ; actual : string
       }
   | Invalid_raw_trace_reference of string
+  | Invalid_exact_lane_raw_trace_reference of string
   | Raw_trace_directory_unreadable of string
 
 let error_to_string = function
@@ -43,6 +44,10 @@ let error_to_string = function
     Printf.sprintf "TurnRecord keeper mismatch: expected=%s actual=%s" expected actual
   | Invalid_raw_trace_reference path ->
     Printf.sprintf "TurnRecord raw-trace reference is outside the keeper store: %s" path
+  | Invalid_exact_lane_raw_trace_reference path ->
+    Printf.sprintf
+      "exact-lane raw-trace reference is outside the keeper store: %s"
+      path
   | Raw_trace_directory_unreadable detail ->
     Printf.sprintf "cannot read keeper raw-trace directory: %s" detail
 ;;
@@ -76,7 +81,18 @@ let protected_references ~config ~keeper_name ~dir =
            then collect (String_set.add run_ref.path protected) rest
            else Error (Invalid_raw_trace_reference run_ref.path))
     in
-    collect String_set.empty entries
+    let open Result.Syntax in
+    let* turn_references = collect String_set.empty entries in
+    Exact_lane_run_registry.research_raw_trace_paths
+      (Exact_lane_run_registry.global ())
+      ~actor:keeper_name
+    |> List.fold_left
+         (fun references path ->
+            let* references = references in
+            if path_is_in_store ~dir path
+            then Ok (String_set.add path references)
+            else Error (Invalid_exact_lane_raw_trace_reference path))
+         (Ok turn_references)
 ;;
 
 let regular_trace_files dir =

--- a/lib/keeper/keeper_raw_trace_retention.mli
+++ b/lib/keeper/keeper_raw_trace_retention.mli
@@ -34,6 +34,7 @@ type error =
       ; actual : string
       }
   | Invalid_raw_trace_reference of string
+  | Invalid_exact_lane_raw_trace_reference of string
   | Raw_trace_directory_unreadable of string
 
 val error_to_string : error -> string

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -406,11 +406,50 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
            | Keeper_lane.Shutdown_cancel_failed _
            | Keeper_lane.Cancelled_by_parent _
            | Keeper_lane.Failed _ -> ());
+          let memory_join_error =
+            match
+              Keeper_memory_lane.cancel_and_join_librarian
+                ~base_path:config.Workspace.base_path
+                ~keeper_name:current.name
+            with
+            | Keeper_memory_lane.No_librarian_work
+            | Keeper_memory_lane.Librarian_joined _ -> None
+            | Keeper_memory_lane.Librarian_join_failed detail -> Some detail
+          in
+          let cleanup_error =
+            match lane_exit.cleanup_error, memory_join_error with
+            | None, None -> None
+            | Some detail, None | None, Some detail -> Some detail
+            | Some lane_detail, Some memory_detail ->
+              Some
+                (Printf.sprintf
+                   "lane cleanup failed: %s; Librarian join failed: %s"
+                   lane_detail
+                   memory_detail)
+          in
+          (match cleanup_error with
+           | Some detail ->
+             let blocked =
+               { operation with
+                 revision = operation.revision + 1
+               ; phase = Blocked { stage = Lane_join; detail }
+               ; updated_at = Masc_domain.now_iso ()
+               }
+             in
+             (match
+                Keeper_shutdown_store.replace
+                  ~config
+                  ~expected_revision:operation.revision
+                  blocked
+              with
+              | Ok () -> Error (Join_failed blocked)
+              | Error error -> Error (Join_record_update_failed error))
+           | None ->
           let terminal_result = Eio.Promise.await current.done_p in
           let evidence =
             { lane_outcome = lane_outcome lane_exit.outcome
             ; terminal = terminal terminal_result
-            ; cleanup_error = lane_exit.cleanup_error
+            ; cleanup_error = None
             }
           in
           (* [operation.turn_disposition] is an admission-time snapshot: it
@@ -446,31 +485,14 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
             ; updated_at = Masc_domain.now_iso ()
             }
           in
-          (match lane_exit.cleanup_error with
-           | Some detail ->
-             let blocked =
-               { joined with
-                 phase = Blocked { stage = Lane_join; detail }
-               ; updated_at = Masc_domain.now_iso ()
-               }
-             in
-             (match
-                Keeper_shutdown_store.replace
-                  ~config
-                  ~expected_revision:operation.revision
-                  blocked
-              with
-              | Ok () -> Error (Join_failed blocked)
-              | Error error -> Error (Join_record_update_failed error))
-           | None ->
-             (match
-                Keeper_shutdown_store.replace
-                  ~config
-                  ~expected_revision:operation.revision
-                  joined
-              with
-              | Ok () -> Ok joined
-              | Error error -> Error (Join_record_update_failed error)))))
+          (match
+             Keeper_shutdown_store.replace
+               ~config
+               ~expected_revision:operation.revision
+               joined
+           with
+           | Ok () -> Ok joined
+           | Error error -> Error (Join_record_update_failed error)))))
 ;;
 
 let run ~config ~entry ~request =

--- a/lib/keeper/keeper_tool_terminal_boundary.ml
+++ b/lib/keeper/keeper_tool_terminal_boundary.ml
@@ -1,0 +1,15 @@
+let decision = function
+  | Keeper_tools_oas.Terminal_effect_open -> Ok Runtime_agent.Continue
+  | Keeper_tools_oas.Deferred_tool_result ->
+    Ok (Runtime_agent.Yield Runtime_agent.Durable_stimulus_waiting)
+  | Keeper_tools_oas.External_effect_deferred ->
+    Ok (Runtime_agent.Yield Runtime_agent.External_effect_deferred)
+  | Keeper_tools_oas.Terminal_effect_completed ->
+    Ok (Runtime_agent.Yield Runtime_agent.Terminal_tool_completed)
+  | Keeper_tools_oas.Terminal_effect_failed
+      { failure_class; effect_disposition; diagnostic } ->
+    Error
+      (Keeper_internal_error.sdk_error_of_masc_internal_error
+         (Keeper_internal_error.Terminal_effect_failed
+            { failure_class; effect_disposition; diagnostic }))
+;;

--- a/lib/keeper/keeper_tool_terminal_boundary.mli
+++ b/lib/keeper/keeper_tool_terminal_boundary.mli
@@ -1,0 +1,6 @@
+(** Typed projection from a Keeper tool bundle's terminal-effect state to the
+    Agent Core cooperative-yield boundary. *)
+
+val decision
+  :  Keeper_tools_oas.terminal_effect_state
+  -> (Runtime_agent.cooperative_yield_decision, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -39,7 +39,7 @@ let terminal_externalization_failure
     None
 ;;
 
-let make_tool_bundle
+let make_tool_bundle_for_descriptors
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
@@ -49,6 +49,7 @@ let make_tool_bundle
       ?continuation_channel
       ?gate_context
       ?hitl_resolution
+      ~(descriptors : Keeper_tool_descriptor.t list)
       ()
   : tool_bundle
   =
@@ -136,9 +137,10 @@ let make_tool_bundle
            result)
       gate_context
   in
-  (* Every descriptor-declared model tool is materialized. The turn hook sends
-     this exact list to OAS without per-Keeper or per-turn reduction. *)
-  let model_visible_descriptors = Keeper_tool_descriptor.model_visible_descriptors () in
+  (* Every descriptor authorized by this caller is materialized through the
+     canonical Keeper handler. [make_tool_bundle] supplies the full
+     model-visible set; bounded internal roles supply their own closed typed
+     subset. *)
   (* The bundle lives for exactly one Agent run. Its typed tool-boundary
      state is request-scoped and observed by the OAS tool-boundary probe only
      after the whole tool batch and checkpoint sink have completed. A generic
@@ -277,7 +279,7 @@ let make_tool_bundle
                    ?oas_invocation:
                      (Agent_sdk.Tool.Execution_env.invocation execution_env)
                    input)))
-      model_visible_descriptors
+      descriptors
   in
   { tools = descriptor_tools
   ; cleanup =
@@ -286,6 +288,31 @@ let make_tool_bundle
   ; terminal_effect_state = (fun () -> Atomic.get terminal_effect_state)
   ; gate_replay_delivery
   }
+;;
+
+let make_tool_bundle
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~(publication_recovery :
+          Keeper_publication_recovery_availability.turn_context)
+      ~(ctx_snapshot : Keeper_types.working_context)
+      ?clock
+      ?continuation_channel
+      ?gate_context
+      ?hitl_resolution
+      ()
+  =
+  make_tool_bundle_for_descriptors
+    ~config
+    ~meta
+    ~publication_recovery
+    ~ctx_snapshot
+    ?clock
+    ?continuation_channel
+    ?gate_context
+    ?hitl_resolution
+    ~descriptors:(Keeper_tool_descriptor.model_visible_descriptors ())
+    ()
 ;;
 
 let make_tools

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -1,5 +1,22 @@
 (** Tool bundle assembly for keeper OAS execution. *)
 
+val make_tool_bundle_for_descriptors
+  :  config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> publication_recovery:
+       Keeper_publication_recovery_availability.turn_context
+  -> ctx_snapshot:Keeper_types.working_context
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?continuation_channel:Keeper_continuation_channel.t
+  -> ?gate_context:Keeper_gate_causal_context.t
+  -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
+  -> descriptors:Keeper_tool_descriptor.t list
+  -> unit
+  -> Keeper_tools_oas.tool_bundle
+(** Materialize an already-authorized typed descriptor set through the same
+    validation, Gate, dispatch, receipt, and cleanup path as a Keeper turn.
+    The caller owns the closed authority policy that selected [descriptors]. *)
+
 (** Build the keeper's full [tool_bundle]: internal tools +
     alias-registered (public name) tools that translate input to
     internal payloads. The cleanup thunk releases per-turn sandbox

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -16,6 +16,7 @@ let keeper_suffix_directive = "/directive"
 let keeper_suffix_paused_work = "/paused-work"
 let keeper_suffix_raw_traces = "/raw-traces"
 let keeper_suffix_raw_trace = "/raw-trace"
+let keeper_suffix_memory_journal = "/memory-journal"
 let keeper_suffix_catchup_judge = "/catchup-judge"
 let keeper_suffix_operator_note = "/operator-note"
 
@@ -200,7 +201,8 @@ let keeper_get_permission req_path =
   else if
     keeper_path_ends_with req_path keeper_suffix_raw_traces
     || keeper_path_ends_with req_path keeper_suffix_raw_trace
-  then Some Masc_domain.CanReadState
+    || keeper_path_ends_with req_path keeper_suffix_memory_journal
+  then Some Masc_domain.CanAdmin
   else None
 
 let trim_to_opt = String_util.trim_to_option

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -106,9 +106,9 @@ val is_keeper_paused_work_get_path : string -> bool
 
 val keeper_get_permission : string -> Masc_domain.permission option
 (** Mandatory token-bound permission for sensitive keeper GET sub-routes.
-    Raw retained traces require [CanReadState]; checkpoint and paused-work
-    operator state require [CanAdmin]. [None] leaves the route on its existing
-    public-read policy. *)
+    Raw retained traces, Memory OS change journals, checkpoint state, and
+    paused-work operator state all require [CanAdmin]. [None] leaves the route
+    on its existing public-read policy. *)
 
 (** {1 Trajectory preview helpers} *)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -19,6 +19,7 @@ let config_cache_ttl_s = Server_dashboard_http_core_cache.config_cache_ttl_s
 let standard_cache_ttl_s = Server_dashboard_http_core_cache.standard_cache_ttl_s
 let live_cache_ttl_s = Server_dashboard_http_core_cache.live_cache_ttl_s
 let feature_health_cache_ttl_s = Server_dashboard_http_core_cache.feature_health_cache_ttl_s
+let exact_lane_run_permission = Masc_domain.CanAdmin
 
 let dashboard_actor_cache_segment state req =
   dashboard_actor_for_request
@@ -418,6 +419,7 @@ module For_testing = struct
     | Recovery_not_requested
 
   let gate_mode_change_json = gate_mode_change_json
+  let exact_lane_run_permission = exact_lane_run_permission
 end
 
 let handle_gate_mode_body state operator_name request reqd body_str =
@@ -685,7 +687,8 @@ let add_routes ~sw ~clock router =
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/exact-lane-runs" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
+       with_token_permission_auth ~permission:exact_lane_run_permission
+         (fun _state _agent_name req reqd ->
          let runs =
            Exact_lane_run_registry.list_runs (Exact_lane_run_registry.global ())
          in

--- a/lib/server/server_routes_http_routes_dashboard.mli
+++ b/lib/server/server_routes_http_routes_dashboard.mli
@@ -11,6 +11,8 @@ val add_routes :
   Http_server_eio.Router.t -> Http_server_eio.Router.t
 
 module For_testing : sig
+  val exact_lane_run_permission : Masc_domain.permission
+
   type gate_mode_recovery =
     | Recovery_completed of Keeper_gate.operator_recovery_report
     | Recovery_failed of string

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -761,7 +761,7 @@ let initialize_owner_state_blocking
        (Owner_initialization_failed
           (Run_registry_already_installed `Verification)));
   let exact_lane_registry =
-    Filename.concat masc_dir "exact-lane-runs.jsonl"
+    Filename.concat masc_dir Exact_lane_run_registry.storage_filename
     |> Exact_lane_run_registry.replay
   in
   (match Exact_lane_run_registry.install_global exact_lane_registry with

--- a/packages/agent_core/lib/agent/agent_tools.ml
+++ b/packages/agent_core/lib/agent/agent_tools.ml
@@ -309,7 +309,7 @@ let find_and_execute_tool_with_index
               { failure_kind = Validation_error; error_class = Some Types.Deterministic }
         }
       in
-      let emit_post_tool_use_failure ~input message =
+      let emit_post_tool_use_failure ~input ~stage ~duration_ms message =
         invoke_post_hook
           ?on_hook_invoked
           ~tracer
@@ -319,11 +319,18 @@ let find_and_execute_tool_with_index
           ~tool_name:name
           hooks.post_tool_use_failure
           (Hooks.PostToolUseFailure
-             { invocation; tool_name = name; input; error = message })
+             { invocation
+             ; tool_name = name
+             ; input
+             ; stage
+             ; duration_ms
+             ; error = message
+             })
       in
       (* Tool inputs cross this boundary unchanged. The schema either accepts
            the exact JSON value or produces a typed validation failure for the
            model to correct in a later native ToolUse block. *)
+      let validation_started_at = Unix.gettimeofday () in
       let validated_input =
         match Tool_input_validation.validate tool.schema input with
         | Tool_input_validation.Valid exact_input -> Ok exact_input
@@ -331,8 +338,15 @@ let find_and_execute_tool_with_index
           let message =
             Tool_input_validation.format_errors_inline ~tool_name:name ~args:input errors
           in
+          let duration_ms =
+            max 0.0 ((Unix.gettimeofday () -. validation_started_at) *. 1000.0)
+          in
           defer_observer (fun () ->
-            emit_post_tool_use_failure ~input message
+            emit_post_tool_use_failure
+              ~input
+              ~stage:Hooks.Validation_before_execution
+              ~duration_ms
+              message
             |> Option.iter record_deferred_failure);
           Error message
       in
@@ -382,7 +396,13 @@ let find_and_execute_tool_with_index
                 ~tool_name:name
                 hooks.post_tool_use_failure
                 (Hooks.PostToolUseFailure
-                   { invocation; tool_name = name; input = exact_input; error = message })
+                   { invocation
+                   ; tool_name = name
+                   ; input = exact_input
+                   ; stage = Hooks.Execution
+                   ; duration_ms
+                   ; error = message
+                   })
               |> Option.iter record_deferred_failure);
             (* [OnToolError] is the compact error projection. The exact
                invocation remains shared with the richer failure hook. *)

--- a/packages/agent_core/lib/base/hooks.ml
+++ b/packages/agent_core/lib/base/hooks.ml
@@ -45,6 +45,10 @@ let empty_reasoning_summary =
   { thinking_blocks = []; has_uncertainty = false; tool_rationale = None }
 ;;
 
+type tool_failure_stage =
+  | Validation_before_execution
+  | Execution
+
 (** Extract structured reasoning summary from message list.
     This only preserves provider-emitted Thinking blocks; it does not infer
     uncertainty or tool rationale from prose. *)
@@ -106,6 +110,8 @@ type hook_event =
       { invocation : Tool_contract.Invocation.t
       ; tool_name : string
       ; input : Yojson.Safe.t
+      ; stage : tool_failure_stage
+      ; duration_ms : float
       ; error : string
       }
   | OnStop of

--- a/packages/agent_core/lib/base/hooks.mli
+++ b/packages/agent_core/lib/base/hooks.mli
@@ -30,6 +30,11 @@ type reasoning_summary =
 val empty_reasoning_summary : reasoning_summary
 val extract_reasoning : Types.message list -> reasoning_summary
 
+(** Exact stage owned by the tool dispatcher when a failure hook is emitted. *)
+type tool_failure_stage =
+  | Validation_before_execution
+  | Execution
+
 (** Events emitted during agent execution *)
 type hook_event =
   | BeforeTurn of
@@ -70,6 +75,8 @@ type hook_event =
             @since 0.216.0 *)
       ; tool_name : string
       ; input : Yojson.Safe.t
+      ; stage : tool_failure_stage
+      ; duration_ms : float
       ; error : string
       }
   | OnStop of

--- a/packages/agent_core/test/test_hooks.ml
+++ b/packages/agent_core/test/test_hooks.ml
@@ -108,6 +108,8 @@ let test_post_tool_use_failure_event () =
          { invocation = invocation ~tool_use_id:"tu-echo" ()
          ; tool_name = "echo"
          ; input = `Null
+         ; stage = Hooks.Execution
+         ; duration_ms = 4.0
          ; error = "boom"
          })
   in
@@ -182,6 +184,8 @@ let dummy_post_tool_use_failure =
     { invocation = invocation ~tool_use_id:"tu-1" ~turn:1 ()
     ; tool_name = "t"
     ; input = `Null
+    ; stage = Hooks.Validation_before_execution
+    ; duration_ms = 2.0
     ; error = "err"
     }
 ;;

--- a/packages/agent_core/test/test_tool_execution.ml
+++ b/packages/agent_core/test/test_tool_execution.ml
@@ -1074,6 +1074,7 @@ let test_lifecycle_surfaces_share_exact_tool_invocation () =
   let pre_invocations = ref [] in
   let post_invocations = ref [] in
   let failure_invocations = ref [] in
+  let failure_stages = ref [] in
   let handler_invocations = ref [] in
   let started_invocations = ref [] in
   let finished_invocations = ref [] in
@@ -1097,8 +1098,9 @@ let test_lifecycle_surfaces_share_exact_tool_invocation () =
     ; post_tool_use_failure =
         Some
           (function
-            | Hooks.PostToolUseFailure { invocation; _ } ->
+            | Hooks.PostToolUseFailure { invocation; stage; duration_ms; _ } ->
               capture failure_invocations invocation;
+              failure_stages := (stage, duration_ms) :: !failure_stages;
               Hooks.Continue
             | _ -> fail "expected PostToolUseFailure")
     }
@@ -1172,6 +1174,10 @@ let test_lifecycle_surfaces_share_exact_tool_invocation () =
     "PostToolUseFailure exact occurrences"
     expected_failure
     !failure_invocations;
+  (match !failure_stages with
+   | [ Hooks.Execution, duration_ms ] ->
+     check bool "execution failure duration is measured" true (duration_ms >= 0.0)
+   | _ -> fail "handler failure did not carry the exact execution stage");
   check_occurrences "ToolCalled exact occurrences" expected_all called_invocations;
   check_occurrences "ToolCompleted exact occurrences" expected_all completed_invocations;
   check_occurrences "handler exact occurrences" expected_all !handler_invocations;
@@ -1409,6 +1415,18 @@ let test_invalid_terminal_input_remains_correction_capable () =
   Eio_main.run
   @@ fun env ->
   let handler_count = ref 0 in
+  let failure_observation = ref None in
+  let hooks =
+    { Hooks.empty with
+      post_tool_use_failure =
+        Some
+          (function
+            | Hooks.PostToolUseFailure { stage; duration_ms; _ } ->
+              failure_observation := Some (stage, duration_ms);
+              Hooks.Continue
+            | _ -> fail "expected PostToolUseFailure")
+    }
+  in
   let tool =
     Tool.create
       ~descriptor:(Tool.terminal_descriptor Tool_contract.Effect_outcome_unknown)
@@ -1429,7 +1447,7 @@ let test_invalid_terminal_input_remains_correction_capable () =
     execute_result_with_tools_in_env
       env
       ~tools:[ tool ]
-      ~hooks:Hooks.empty
+      ~hooks
       [ ToolUse
           { id = "terminal-invalid"
           ; name = "finish"
@@ -1440,6 +1458,10 @@ let test_invalid_terminal_input_remains_correction_capable () =
   | Error _ -> fail "invalid terminal input must remain a model-visible result"
   | Ok report ->
     check int "terminal handler did not run" 0 !handler_count;
+    (match !failure_observation with
+     | Some (Hooks.Validation_before_execution, duration_ms) ->
+       check bool "validation duration is measured" true (duration_ms >= 0.0)
+     | _ -> fail "validation failure did not carry the pre-execution stage");
     (match report.completed_results with
      | [ { outcome = Tool_failed { failure_kind = Validation_error; _ }; _ } ] -> ()
      | _ -> fail "invalid terminal input was not a typed Validation_error");

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -181,14 +181,21 @@ let test_keeper_sensitive_get_permissions_are_exact () =
     (fun suffix ->
        let path = "/api/v1/keepers/idealist/" ^ suffix in
        check bool (suffix ^ " permission") true
-         (permission path = Some Masc_domain.CanReadState);
+         (permission path = Some Masc_domain.CanAdmin);
        check bool (suffix ^ " trailing segment") true
          (permission (path ^ "/extra") = None))
-    [ "raw-traces"; "raw-trace" ];
+    [ "raw-traces"; "raw-trace"; "memory-journal" ];
   check bool "checkpoint permission" true
     (permission "/api/v1/keepers/idealist/checkpoints" = Some Masc_domain.CanAdmin);
   check bool "ordinary keeper read stays public" true
     (permission "/api/v1/keepers/idealist/trajectory" = None)
+
+let test_internal_exact_lane_registry_is_admin_only () =
+  check bool
+    "exact lane registry requires Admin"
+    true
+    (Server_routes_http_routes_dashboard.For_testing.exact_lane_run_permission
+     = Masc_domain.CanAdmin)
 
 let test_keeper_chat_receipt_route_and_json () =
   let receipt_id =
@@ -3551,6 +3558,8 @@ let () =
             test_keeper_paused_work_route_is_admin_exact;
           test_case "keeper sensitive GET permissions are exact" `Quick
             test_keeper_sensitive_get_permissions_are_exact;
+          test_case "internal exact lane registry is Admin-only" `Quick
+            test_internal_exact_lane_registry_is_admin_only;
           test_case "keeper chat receipt route is typed" `Quick
             test_keeper_chat_receipt_route_and_json;
           test_case "keeper chat recovery route is exact" `Quick

--- a/test/test_exact_lane_run_registry.ml
+++ b/test/test_exact_lane_run_registry.ml
@@ -6,6 +6,11 @@ let remove_if_exists path =
   | Sys_error _ -> ()
 ;;
 
+let write_file path content =
+  let channel = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out_noerr channel) (fun () -> output_string channel content)
+;;
+
 let test_round_trip_preserves_exact_evidence () =
   let path = Filename.temp_file "exact-lane-runs-" ".jsonl" in
   remove_if_exists path;
@@ -17,7 +22,7 @@ let test_round_trip_preserves_exact_evidence () =
     ~subject_id:"trace-1"
     ~actor:"keeper-a"
     ~started_at:10.0
-    ~input:(`Assoc [ "message_count", `Int 4 ]);
+    ~input:(R.Exact_input (`Assoc [ "message_count", `Int 4 ]));
   R.mark_completed
     registry
     ~run_id:"run-1"
@@ -40,7 +45,7 @@ let test_running_shape_has_no_invented_completion () =
     ~subject_id:"candidate-1"
     ~actor:"keeper-a"
     ~started_at:20.0
-    ~input:`Null;
+    ~input:(R.Exact_input `Null);
   let run = R.get registry ~run_id:"run-live" |> Option.get in
   check string "status" "running" (R.status_label run.status);
   match R.run_to_yojson run with
@@ -50,11 +55,73 @@ let test_running_shape_has_no_invented_completion () =
   | _ -> fail "run serializer must emit an object"
 ;;
 
+let test_research_trace_path_is_typed_by_registry_envelope () =
+  let registry = R.create () in
+  let input =
+    R.Research_input
+      { raw_trace_path = Some "/tmp/keeper/raw-traces/research.jsonl"
+      ; payload = `Assoc [ "message_count", `Int 4 ]
+      }
+  in
+  R.register_running
+    registry
+    ~run_id:"research-1"
+    ~lane:R.Librarian
+    ~subject_id:"trace-1"
+    ~actor:"keeper-a"
+    ~started_at:20.0
+    ~input;
+  check
+    (list string)
+    "registered research path"
+    [ "/tmp/keeper/raw-traces/research.jsonl" ]
+    (R.research_raw_trace_paths registry ~actor:"keeper-a");
+  check
+    (list string)
+    "other actor cannot retain the path"
+    []
+    (R.research_raw_trace_paths registry ~actor:"keeper-b")
+;;
+
+let test_open_json_input_is_not_replayed_into_current_store () =
+  let path = Filename.temp_file "exact-lane-runs-v1-" ".jsonl" in
+  write_file
+    path
+    {|{"event":"register","id":"old-run","started_at":1.0,"registration":{"lane":"librarian_exact","subject_id":"trace-old","actor":"keeper-a","input":{"message_count":4}}}
+|};
+  let replayed = R.replay path in
+  check int "old open input is absent" 0 (List.length (R.list_runs replayed));
+  check string "current-only store file" "exact-lane-runs-v2.jsonl" R.storage_filename;
+  remove_if_exists path
+;;
+
+let test_blank_research_trace_path_is_rejected_before_persistence () =
+  let registry = R.create () in
+  check_raises
+    "blank trace path"
+    (Invalid_argument "exact lane research raw trace path must not be blank")
+    (fun () ->
+       R.register_running
+         registry
+         ~run_id:"research-blank"
+         ~lane:R.Librarian
+         ~subject_id:"trace-blank"
+         ~actor:"keeper-a"
+         ~started_at:20.0
+         ~input:(R.Research_input { raw_trace_path = Some "  "; payload = `Null }))
+;;
+
 let () =
   run
     "exact_lane_run_registry"
     [ ( "registry"
       , [ test_case "durable exact evidence" `Quick test_round_trip_preserves_exact_evidence
         ; test_case "running shape" `Quick test_running_shape_has_no_invented_completion
+        ; test_case "research trace reachability envelope" `Quick
+            test_research_trace_path_is_typed_by_registry_envelope
+        ; test_case "open JSON input is not replayed" `Quick
+            test_open_json_input_is_not_replayed_into_current_store
+        ; test_case "blank research trace path is rejected" `Quick
+            test_blank_research_trace_path_is_rejected_before_persistence
         ] )
     ]

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -25,6 +25,7 @@ module Keeper_lifecycle_admission = Masc.Keeper_lifecycle_admission
 module WO = Masc.Keeper_world_observation
 module Health = Masc.Health
 module Lane = Masc.Keeper_lane
+module Memory_lane = Masc.Keeper_memory_lane
 module Shutdown_types = Masc.Keeper_shutdown_types
 module Shutdown_store = Masc.Keeper_shutdown_store
 module Shutdown_prepare_join = Masc.Keeper_shutdown_prepare_join
@@ -2246,6 +2247,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
     ~finally:(fun () ->
       Masc.Keeper_chat_queue.For_testing.reset ();
       Masc.Keeper_turn_admission.For_testing.reset ();
+      Memory_lane.For_testing.reset ();
       R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->
@@ -2259,6 +2261,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
        | Ok () -> ()
        | Error detail -> fail detail);
       let entry = R.For_testing.register ~base_path:config.base_path name meta in
+      Memory_lane.init ~sw:parent_sw;
       let never_p, _never_r = Eio.Promise.create () in
       (match
          Lane.fork
@@ -2280,6 +2283,26 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
        | Ok () -> ()
        | Error error -> fail (Lane.start_error_to_string error));
       Eio.Fiber.yield ();
+      let librarian_started, resolve_librarian_started = Eio.Promise.create () in
+      let librarian_never, _resolve_librarian_never = Eio.Promise.create () in
+      let librarian_cancelled = ref false in
+      (match
+         Memory_lane.submit
+           ~base_path:config.base_path
+           ~keeper_name:name
+           ~lane:Memory_lane.Librarian
+           (fun () ->
+              Eio.Promise.resolve resolve_librarian_started ();
+              try Eio.Promise.await librarian_never with
+              | Eio.Cancel.Cancelled _ as exn ->
+                librarian_cancelled := true;
+                raise exn)
+       with
+       | Memory_lane.Submitted -> ()
+       | Memory_lane.Coalesced
+       | Memory_lane.Ran_inline
+       | Memory_lane.Dropped -> fail "shutdown Librarian was not submitted");
+      Eio.Promise.await librarian_started;
       let operation =
         match
           Shutdown_prepare_join.run
@@ -2306,6 +2329,18 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
         "shutdown operation records lane join evidence"
         true
         (Option.is_some operation.join_evidence);
+      check bool
+        "shutdown cancelled the detached Librarian before returning"
+        true
+        !librarian_cancelled;
+      check
+        (option int)
+        "shutdown joined the detached Librarian"
+        (Some 0)
+        (Memory_lane.For_testing.pending
+           ~base_path:config.base_path
+           ~keeper_name:name
+           ~lane:Memory_lane.Librarian);
       (match
          Masc.Keeper_turn_admission.run_if_free
            ~base_path:config.base_path

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -40,10 +40,20 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
   | Error detail -> Alcotest.failf "keeper meta fixture failed: %s" detail
 ;;
 
-let run_post_turn ~config ~meta ~turn =
+let run_post_turn ~config ~(meta : Masc.Keeper_meta_contract.keeper_meta) ~turn =
+  let publication_recovery =
+    Masc.Keeper_publication_recovery_availability.
+      { provider = Masc_test_deps.non_runtime_publication_recovery_provider
+      ; keeper_name = meta.name
+      }
+  in
   Post_turn_memory.run
     ~config
     ~meta
+    ~publication_recovery
+    ~ctx_snapshot:
+      (Masc.Keeper_context_runtime.create ~eio:false ~system_prompt:"test")
+    ~runtime_id:"test-runtime"
     ~generation:turn
     ~turn
     ~oas_turn_count:1

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -5,6 +5,7 @@
     leak-safe on a raising unit. *)
 
 module Lane = Masc.Keeper_memory_lane
+module Keeper_lane = Masc.Keeper_lane
 module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Memory_current = Masc.Keeper_memory_os_current
 module Post_turn_memory = Masc.Keeper_agent_run_post_turn_memory
@@ -366,6 +367,51 @@ let test_releases_on_cancel () =
   | None -> Alcotest.fail "keeper entry missing after cancel"
 ;;
 
+let test_keeper_shutdown_cancels_and_joins_librarian () =
+  Lane.For_testing.reset ();
+  let cancelled = ref false in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let started, set_started = Eio.Promise.create () in
+      let never, _set_never = Eio.Promise.create () in
+      let submitted =
+        Lane.submit
+          ~base_path
+          ~keeper_name:"shutdown-owner"
+          ~lane:Lane.Librarian
+          (fun () ->
+             Eio.Promise.resolve set_started ();
+             try Eio.Promise.await never with
+             | Eio.Cancel.Cancelled _ as exn ->
+               cancelled := true;
+               raise exn)
+      in
+      (match submitted with
+       | Lane.Submitted -> ()
+       | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped ->
+         Alcotest.fail "shutdown Librarian was not submitted");
+      Eio.Promise.await started;
+      (match
+         Lane.cancel_and_join_librarian
+           ~base_path
+           ~keeper_name:"shutdown-owner"
+       with
+       | Lane.Librarian_joined Keeper_lane.Shutdown_requested -> ()
+       | Lane.Librarian_joined _ ->
+         Alcotest.fail "shutdown Librarian joined with a non-shutdown outcome"
+       | Lane.No_librarian_work -> Alcotest.fail "shutdown missed active Librarian"
+       | Lane.Librarian_join_failed detail -> Alcotest.fail detail);
+      Alcotest.(check bool) "provider scope observed cancellation" true !cancelled;
+      Alcotest.(check (option int))
+        "terminal join drained all Librarian work"
+        (Some 0)
+        (Lane.For_testing.pending
+           ~base_path
+           ~keeper_name:"shutdown-owner"
+           ~lane:Lane.Librarian)))
+;;
+
 (* Submitting against a finished executor switch must not leak the pending
    reservation. Eio.Fiber.fork does not raise to the caller for an off switch, so
    the lane needs its own executor-switch release fallback. *)
@@ -546,6 +592,10 @@ let () =
             test_lanes_have_independent_budgets
         ; Alcotest.test_case "releases on raise" `Quick test_releases_on_raise
         ; Alcotest.test_case "releases on cancel" `Quick test_releases_on_cancel
+        ; Alcotest.test_case
+            "Keeper shutdown cancels and joins Librarian"
+            `Quick
+            test_keeper_shutdown_cancels_and_joins_librarian
         ; Alcotest.test_case
             "finished switch drops without leak"
             `Quick

--- a/test/test_keeper_raw_trace_reader.ml
+++ b/test/test_keeper_raw_trace_reader.ml
@@ -242,7 +242,7 @@ let test_raw_trace_read_permission_requires_a_token () =
     let authorize request =
       Server_auth.authorize_token_bound_permission_request
         ~base_path:config.base_path
-        ~permission:Masc_domain.CanReadState
+        ~permission:Masc_domain.CanAdmin
         request
     in
     let anonymous = Httpun.Request.create `GET "/api/v1/keepers/test-keeper/raw-traces" in
@@ -251,10 +251,11 @@ let test_raw_trace_read_permission_requires_a_token () =
        Alcotest.(check bool) "anonymous is unauthorized" true
          (Server_auth.http_status_of_auth_error error = `Unauthorized)
      | Ok actor -> Alcotest.failf "anonymous resolved actor %s" actor);
-    Alcotest.(check (result string string)) "Worker can read"
-      (Ok "worker")
-      (authorize (bearer_request worker)
-       |> Result.map_error Masc_domain.masc_error_to_string);
+    (match authorize (bearer_request worker) with
+     | Error error ->
+       Alcotest.(check bool) "Worker is forbidden" true
+         (Server_auth.http_status_of_auth_error error = `Forbidden)
+     | Ok actor -> Alcotest.failf "Worker unexpectedly resolved actor %s" actor);
     Alcotest.(check (result string string)) "Admin can read"
       (Ok "admin")
       (authorize (bearer_request admin)
@@ -377,7 +378,7 @@ let () =
             test_invalid_keeper_name_is_refused
         ; Alcotest.test_case "symlink traces are rejected" `Quick
             test_symlink_trace_is_rejected_for_listing_and_read
-        ; Alcotest.test_case "raw trace read requires Worker or Admin token" `Quick
+        ; Alcotest.test_case "raw trace read requires Admin token" `Quick
             test_raw_trace_read_permission_requires_a_token
         ] )
     ; ( "listing"

--- a/test/test_keeper_raw_trace_sink.ml
+++ b/test/test_keeper_raw_trace_sink.ml
@@ -221,6 +221,36 @@ let test_sink_creates_keeper_runtime_dir () =
   Alcotest.(check bool) "raw-trace store dir created" true
     (Sys.file_exists raw_trace_dir && Sys.is_directory raw_trace_dir)
 
+let test_librarian_research_sink_registers_path_before_file_creation () =
+  with_workspace @@ fun config ->
+  let meta = make_test_meta () in
+  let execution_id = Keeper_librarian_research.Execution_id.generate () in
+  let registered_path = ref None in
+  let sink =
+    match
+      Keeper_librarian_research.create_raw_trace_sink
+        ~before_create:(fun path ->
+          Alcotest.(check bool) "trace file not created before registration" false
+            (Sys.file_exists path);
+          registered_path := Some path)
+        ~config
+        ~meta
+        ~execution_id
+    with
+    | Keeper_librarian_research.Raw_trace_ready sink -> sink
+    | Keeper_librarian_research.Raw_trace_degraded error ->
+      Alcotest.failf
+        "librarian research trace sink degraded: %s"
+        (Agent_sdk.Error.to_string error)
+  in
+  Alcotest.(check (option string)) "registered path is the sink path"
+    (Some (Agent_sdk.Raw_trace.file_path sink))
+    !registered_path;
+  Alcotest.(check (option string)) "execution id is the trace session join"
+    (Some (Keeper_librarian_research.Execution_id.to_string execution_id))
+    (Agent_sdk.Raw_trace.session_id sink)
+;;
+
 (* Each turn is its own file: turn N+1 never appends to (or scans) turn
    N's file, so per-turn sink creation cost is independent of lifetime
    trace volume. *)
@@ -477,6 +507,35 @@ let test_post_commit_cleanup_prunes_orphan_and_preserves_reference () =
   Alcotest.(check int) "only reference plus current sink remain" 2
     (List.length (jsonl_files dir))
 
+(* Librarian research traces are not named by the parent Keeper TurnRecord.
+   Their durable exact-lane registration is the independent reachability root,
+   including while the research phase is still running. *)
+let test_prune_preserves_registered_librarian_research_trace () =
+  with_workspace @@ fun config ->
+  let dir = Keeper_types_support.keeper_raw_trace_dir config keeper_name in
+  Fs_compat.mkdir_p dir;
+  let research = Filename.concat dir "turn-librarian-research.jsonl" in
+  let orphan = Filename.concat dir "turn-unreferenced.jsonl" in
+  write_file research "{}\n";
+  write_file orphan "{}\n";
+  Exact_lane_run_registry.register_running
+    (Exact_lane_run_registry.global ())
+    ~run_id:"librarian-research-retention"
+    ~lane:Exact_lane_run_registry.Librarian
+    ~subject_id:"trace-internal"
+    ~actor:keeper_name
+    ~started_at:1.0
+    ~input:
+      (Exact_lane_run_registry.Research_input
+         { raw_trace_path = Some research; payload = `Null });
+  let summary = prune_or_fail config in
+  Alcotest.(check int) "unreferenced trace removed" 1 summary.removed;
+  Alcotest.(check int) "research trace retained" 1 summary.retained_references;
+  Alcotest.(check bool) "registered research trace survives" true
+    (Sys.file_exists research);
+  Alcotest.(check bool) "unreferenced trace is removed" false
+    (Sys.file_exists orphan)
+
 let response ?(content = []) ?(stop_reason = Agent_sdk.Types.EndTurn) () =
   {
     Agent_sdk.Types.id = "resp-test";
@@ -630,6 +689,8 @@ let () =
             test_sink_path_and_session_identity;
           Alcotest.test_case "sink creates keeper runtime dir" `Quick
             test_sink_creates_keeper_runtime_dir;
+          Alcotest.test_case "librarian research path registers before create" `Quick
+            test_librarian_research_sink_registers_path_before_file_creation;
           Alcotest.test_case "per-turn files isolate turns" `Quick
             test_per_turn_files_isolate_turns;
           Alcotest.test_case "corrupt history does not block sink" `Quick
@@ -644,6 +705,8 @@ let () =
             test_prune_uses_shared_turn_record_window;
           Alcotest.test_case "post-commit cleanup is reference-aware" `Quick
             test_post_commit_cleanup_prunes_orphan_and_preserves_reference;
+          Alcotest.test_case "retention preserves registered librarian research" `Quick
+            test_prune_preserves_registered_librarian_research_trace;
           Alcotest.test_case "traced turn yields result-level fields" `Quick
             test_traced_turn_yields_result_level_fields;
           Alcotest.test_case "dispatch passes ?raw_trace" `Quick

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -205,7 +205,7 @@ let test_bundle_exactly_matches_model_visible_descriptors () =
           check int "bundle contains no duplicate model names" (List.length actual_names)
             (List.length bundle.tools)))
 
-let test_librarian_research_bundle_exactly_matches_model_visible_descriptors () =
+let test_librarian_research_bundle_is_closed_and_read_only () =
   ignore (init_registry ());
   let dir =
     Filename.concat
@@ -258,20 +258,53 @@ let test_librarian_research_bundle_exactly_matches_model_visible_descriptors () 
        let actual_names, cleanup =
          Keeper_librarian_research.For_testing.tool_names_for_request request
        in
+       let descriptor_contract =
+         Keeper_librarian_research.For_testing.research_descriptor_contract ()
+       in
        let expected_names =
-         Keeper_tool_descriptor.model_visible_descriptors ()
-         |> List.concat_map Keeper_tool_descriptor.keeper_model_names
+         descriptor_contract
+         |> List.map (fun (name, _, _) -> name)
          |> List.sort_uniq String.compare
        in
        check
          (list string)
-         "research runner receives the complete descriptor projection"
+         "research runner receives only its closed descriptor projection"
          expected_names
          (List.sort_uniq String.compare actual_names);
        check int
          "research runner bundle contains no duplicates"
          (List.length expected_names)
          (List.length actual_names);
+       List.iter
+         (fun (name, readonly_hint, route) ->
+            check
+              (option bool)
+              (Printf.sprintf "%s is statically read-only" name)
+              (Some true)
+              readonly_hint;
+            check bool
+              (Printf.sprintf "%s retains a typed runtime route" name)
+              true
+              (String.starts_with ~prefix:"tool_" route))
+         descriptor_contract;
+       List.iter
+         (fun name ->
+            check bool
+              (Printf.sprintf "%s is not representable in Librarian research" name)
+              false
+              (List.mem name actual_names))
+         [ "Execute"
+         ; "Edit"
+         ; "Write"
+         ; "keeper_memory_write"
+         ; "keeper_surface_post"
+         ; "masc_fusion"
+         ];
+       check int
+         "each research callback traverses the standard Gate/result boundary once"
+         (List.length actual_names)
+         (Keeper_librarian_research.For_testing.invalid_request_gate_callback_count
+            request);
        match cleanup with
        | Keeper_librarian_research.Cleanup_succeeded -> ()
        | Cleanup_failed detail -> failf "research bundle cleanup failed: %s" detail
@@ -348,6 +381,53 @@ let test_librarian_research_cleanup_contract () =
       true
       (string_contains detail "cleanup failed")
   | _ -> fail "cleanup failure outcome was not recorded"
+;;
+
+let test_librarian_registry_receipt_excludes_raw_payloads () =
+  let execution_id = Keeper_librarian_research.Execution_id.generate () in
+  let receipt : Keeper_librarian_research.receipt =
+    { execution_id
+    ; runtime_id = "runtime-safe"
+    ; frozen_system_prompt = "SECRET_SYSTEM_SENTINEL"
+    ; frozen_prompt = "SECRET_PROMPT_SENTINEL"
+    ; frozen_input = `Assoc [ "opaque", `String "SECRET_INPUT_SENTINEL" ]
+    ; started_at = 1.0
+    ; finished_at = 2.0
+    ; duration_ms = 1000.0
+    ; tool_names = [ "keeper_time_now" ]
+    ; tool_calls = []
+    ; terminal_effect = Keeper_tools_oas.Terminal_effect_open
+    ; cleanup = Keeper_librarian_research.Cleanup_succeeded
+    ; outcome =
+        Keeper_librarian_research.Research_completed
+          { evidence =
+              { text = "SECRET_EVIDENCE_SENTINEL"
+              ; original_bytes = 24
+              ; retained_bytes = 24
+              ; truncated = false
+              }
+          ; session_id = "session-safe"
+          ; turns = 1
+          ; stop_reason = Runtime_agent.Completed
+          }
+    ; trace_ref = None
+    }
+  in
+  let projected =
+    Keeper_librarian_research.registry_receipt_to_yojson receipt
+    |> Yojson.Safe.to_string
+  in
+  List.iter
+    (fun sentinel ->
+       check bool
+         (sentinel ^ " absent from long-lived projection")
+         false
+         (string_contains projected sentinel))
+    [ "SECRET_SYSTEM_SENTINEL"
+    ; "SECRET_PROMPT_SENTINEL"
+    ; "SECRET_INPUT_SENTINEL"
+    ; "SECRET_EVIDENCE_SENTINEL"
+    ]
 ;;
 
 let test_missing_current_task_reconciled_before_transition_hint () =
@@ -581,10 +661,12 @@ let () =
             test_fusion_default_descriptor_is_bundle_visible;
           test_case "bundle exactly matches model-visible descriptors" `Quick
             test_bundle_exactly_matches_model_visible_descriptors;
-          test_case "librarian research bundle matches model-visible descriptors" `Quick
-            test_librarian_research_bundle_exactly_matches_model_visible_descriptors;
+          test_case "librarian research bundle is closed and read-only" `Quick
+            test_librarian_research_bundle_is_closed_and_read_only;
           test_case "librarian research cleanup covers success error cancellation" `Quick
             test_librarian_research_cleanup_contract;
+          test_case "librarian registry receipt excludes raw payloads" `Quick
+            test_librarian_registry_receipt_excludes_raw_payloads;
           test_case "missing current task reconciles before transition hint" `Quick
             test_missing_current_task_reconciled_before_transition_hint;
           test_case "bundle assembly does not emit assignment" `Quick

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -205,6 +205,151 @@ let test_bundle_exactly_matches_model_visible_descriptors () =
           check int "bundle contains no duplicate model names" (List.length actual_names)
             (List.length bundle.tools)))
 
+let test_librarian_research_bundle_exactly_matches_model_visible_descriptors () =
+  ignore (init_registry ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_test_librarian_research_bundle_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      try Unix.rmdir dir with
+      | _ -> ())
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Eio.Switch.run
+       @@ fun sw ->
+       let config = Workspace.default_config dir in
+       let meta = make_meta ~name:"test-librarian-research-bundle" () in
+       let ctx_snapshot =
+         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
+       in
+       Masc_test_deps.with_publication_recovery_registry
+         ~sw
+         ~fs:(Eio.Stdenv.fs env)
+         ~registry_root:dir
+       @@ fun publication_recovery_registry ->
+       let publication_recovery =
+         publication_recovery_turn_context
+           ~registry:publication_recovery_registry
+           ~keeper_name:meta.name
+       in
+       let request : Keeper_librarian_research.request =
+         { execution_id = Keeper_librarian_research.Execution_id.generate ()
+         ; runtime_id = "test-runtime"
+         ; frozen_system_prompt = "test"
+         ; frozen_prompt = "test"
+         ; frozen_input = `Assoc [ "test", `Bool true ]
+         ; evidence_budget_bytes = 1024
+         ; config
+         ; meta
+         ; publication_recovery
+         ; ctx_snapshot
+         ; clock = Eio.Stdenv.clock env
+         ; net = Eio.Stdenv.net env
+         ; continuation_channel = None
+         ; raw_trace = None
+         }
+       in
+       let actual_names, cleanup =
+         Keeper_librarian_research.For_testing.tool_names_for_request request
+       in
+       let expected_names =
+         Keeper_tool_descriptor.model_visible_descriptors ()
+         |> List.concat_map Keeper_tool_descriptor.keeper_model_names
+         |> List.sort_uniq String.compare
+       in
+       check
+         (list string)
+         "research runner receives the complete descriptor projection"
+         expected_names
+         (List.sort_uniq String.compare actual_names);
+       check int
+         "research runner bundle contains no duplicates"
+         (List.length expected_names)
+         (List.length actual_names);
+       match cleanup with
+       | Keeper_librarian_research.Cleanup_succeeded -> ()
+       | Cleanup_failed detail -> failf "research bundle cleanup failed: %s" detail
+       | Cleanup_cancelled -> fail "research bundle cleanup was cancelled")
+;;
+
+let test_librarian_research_cleanup_contract () =
+  let first_execution_id =
+    Keeper_librarian_research.Execution_id.generate ()
+    |> Keeper_librarian_research.Execution_id.to_string
+  in
+  let second_execution_id =
+    Keeper_librarian_research.Execution_id.generate ()
+    |> Keeper_librarian_research.Execution_id.to_string
+  in
+  check bool
+    "generated research execution id names its phase"
+    true
+    (String.starts_with ~prefix:"librarian-research-" first_execution_id);
+  check bool
+    "generated research execution ids are distinct"
+    false
+    (String.equal first_execution_id second_execution_id);
+  let cleanup_count = ref 0 in
+  let observed = ref None in
+  let value =
+    Keeper_librarian_research.For_testing.protect_with_cleanup
+      ~cleanup:(fun () -> incr cleanup_count)
+      ~on_cleanup:(fun outcome -> observed := Some outcome)
+      (fun () -> 42)
+  in
+  check int "success body result" 42 value;
+  check int "success cleanup exactly once" 1 !cleanup_count;
+  (match !observed with
+   | Some Keeper_librarian_research.Cleanup_succeeded -> ()
+   | _ -> fail "successful cleanup outcome was not recorded");
+  let raised = ref false in
+  (try
+     ignore
+       (Keeper_librarian_research.For_testing.protect_with_cleanup
+          ~cleanup:(fun () -> incr cleanup_count)
+          ~on_cleanup:(fun outcome -> observed := Some outcome)
+          (fun () -> raise (Failure "research failed"))
+        : unit)
+   with
+   | Failure detail when String.equal detail "research failed" -> raised := true
+   | _ -> ());
+  check bool "body failure propagated" true !raised;
+  check int "failure cleanup exactly once" 2 !cleanup_count;
+  let cancelled = ref false in
+  (try
+     ignore
+       (Keeper_librarian_research.For_testing.protect_with_cleanup
+          ~cleanup:(fun () -> incr cleanup_count)
+          ~on_cleanup:(fun outcome -> observed := Some outcome)
+          (fun () -> raise (Eio.Cancel.Cancelled (Failure "cancel research")))
+        : unit)
+   with
+   | Eio.Cancel.Cancelled _ -> cancelled := true);
+  check bool "cancellation propagated" true !cancelled;
+  check int "cancellation cleanup exactly once" 3 !cleanup_count;
+  let cleanup_failure = ref None in
+  let value =
+    Keeper_librarian_research.For_testing.protect_with_cleanup
+      ~cleanup:(fun () -> raise (Failure "cleanup failed"))
+      ~on_cleanup:(fun outcome -> cleanup_failure := Some outcome)
+      (fun () -> 7)
+  in
+  check int "cleanup failure does not replace body result" 7 value;
+  match !cleanup_failure with
+  | Some (Keeper_librarian_research.Cleanup_failed detail) ->
+    check bool
+      "cleanup failure detail retained"
+      true
+      (string_contains detail "cleanup failed")
+  | _ -> fail "cleanup failure outcome was not recorded"
+;;
+
 let test_missing_current_task_reconciled_before_transition_hint () =
   ignore (init_registry ());
   let dir =
@@ -436,6 +581,10 @@ let () =
             test_fusion_default_descriptor_is_bundle_visible;
           test_case "bundle exactly matches model-visible descriptors" `Quick
             test_bundle_exactly_matches_model_visible_descriptors;
+          test_case "librarian research bundle matches model-visible descriptors" `Quick
+            test_librarian_research_bundle_exactly_matches_model_visible_descriptors;
+          test_case "librarian research cleanup covers success error cancellation" `Quick
+            test_librarian_research_cleanup_contract;
           test_case "missing current task reconciles before transition hint" `Quick
             test_missing_current_task_reconciled_before_transition_hint;
           test_case "bundle assembly does not emit assignment" `Quick


### PR DESCRIPTION
## Summary

- add a Librarian-owned research phase with exact lifecycle receipts and a separate tool-free exact-output finalizer
- hard-cut Librarian authority to a closed 13-variant read/observation tool sum projected through canonical Keeper descriptors and the standard Gate boundary
- make detached Librarian work per-Keeper owned: Keeper shutdown cancels and joins the exact research lane before publishing the Keeper terminal state
- keep the durable exact registry secret-free (counts, ids, timings, outcomes, revisions); retain full provider rows only in the existing RAW JSONL store
- require Admin for exact internal-lane registry, Keeper RAW traces, and Memory journal; Worker access is forbidden
- expose typed input/output metadata, Admin RAW literal/readable JSON, exact execution joins, and Memory revision/journal evidence in Internal Agents

## Authority boundary

The Librarian receives exactly:

`Grep`, `Read`, `keeper_time_now`, `keeper_context_status`, `keeper_artifact_read`, `keeper_memory_search`, `keeper_library_search`, `keeper_library_read`, `keeper_surface_read`, `WebSearch`, `WebFetch`, `masc_fusion_status`, `analyze_image`.

Operational/mutating Keeper descriptors are unrepresentable in the closed research tool sum. Focused coverage projects every descriptor and sends an invalid request through every callback, proving one standard Gate causal completion per tool.

## Verification

- focused OCaml build: `bin/main_eio.exe`, `test_keeper_memory_lane.exe`, `test_warn_root_causes.exe`, `test_keeper_raw_trace_reader.exe`, `test_dashboard_http_core.exe`, `test_exact_lane_run_registry.exe`, `test_heartbeat_integration.exe`
- focused OCaml tests passed:
  - Memory lane: 12/12
  - Librarian authority/registry/Gate contracts: 12/12
  - RAW trace reader and Admin permission: 13/13
  - exact lane registry: 5/5
  - dashboard sensitive route permissions: 2/2 (cases 45-46)
  - shutdown-during-Librarian integration: 1/1 (direct_keepalive case 13)
- Dashboard: `npx tsc --noEmit --pretty`; focused Vitest 9/9; production `vite build` passed
- parsing and whitespace: `ocamlc -stop-after parsing` and `git diff --check` passed

The full `test_heartbeat_integration.exe` invocation also ran: the touched shutdown case passed, while cases 9 and 20 failed from cross-test global state. The full `test_dashboard_http_core.exe` invocation similarly showed three cache/config-order failures; the two touched permission cases pass in isolation. These are not reported as green.

## Live evidence

Measured from this worktree binary at head `fd7339e6d76c9ae34d7fb63a9f5494965e16b551` against isolated root `/tmp/masc-librarian-live-20260809-7WmgVH` on port 18946. Discord/Slack tokens were unset for the probe. The operating server on 8935 and `/Users/dancer/me/.masc` were not restarted or mutated.

### Shutdown while provider work is live

- Keeper: `lane-smith`
- exact run: `librarian-research-fc74673f469f1afceb8509d38b1e1e55`
- provider research was observed `running`; shutdown was then submitted
- in the same second, logs recorded `memory os librarian cancelled` → Keeper `draining` → `stopped` → shutdown operation finalized
- HTTP shutdown response: 25 ms
- postcondition: exact run `cancelled`; running Keeper fiber count `0`

### Successful evidence join

- Keeper: `analyst`
- exact run: `librarian-research-df7115cad1097c37507c3e43c8479311`
- research duration: 58.712 s
- model-visible tools: 13; model-selected tool calls: 0
- retained RAW JSONL: 7 actual provider rows
- Memory: before 4 facts → revision 1544 / after 4 facts; added 0, removed 0, retained 4
- exact registry v2 register/complete rows contain no system/user prompt, frozen input, tool-result payload, or fact payload
- live permissions: Admin exact/RAW/journal = 200; Worker exact/RAW/journal = 403

### Real Playwright

Admin session interaction: Librarian filter → expand successful `analyst` run → switch RAW to `Readable JSON`.

- input/output metadata, all 13 tool names, RAW `1–7 / 7`, and Memory revision 1544 were visible
- evidence API responses were 200
- console errors: 0; page errors: 0; failed requests: 0
- screenshot: `/tmp/librarian-internal-agents-p0-live.png`

Fixes #27801.
