### PR TITLE
fix(runtime): harden official-client MCP admission

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -372,7 +372,7 @@ let handle_control_request io ~tools ~tool_call_count fields =
           ~server_name:mcp_server_name
           ~tool_specs
           ~call_tool
-          message
+          (Yojson.Safe.to_string message)
         |> Result.map_error (fun { Runtime_official_client_mcp.stage; detail } ->
           Protocol_error { stage; detail })
       in

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -29,8 +29,6 @@ type rate_limit_status =
   | Allowed_warning
   | Rejected
 
-val rate_limit_status_to_string : rate_limit_status -> string
-
 type rate_limit =
   { status : rate_limit_status
   ; rate_limit_type : string option

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -16,6 +16,46 @@ type dispatch =
 let ( let* ) = Result.bind
 let error stage detail = Error { stage; detail }
 
+let rec validate_message_value ~stage ~path = function
+  | `Assoc fields ->
+    let seen = Hashtbl.create (min 32 (List.length fields)) in
+    let rec loop = function
+      | [] -> Ok ()
+      | (name, value) :: rest ->
+        if Hashtbl.mem seen name
+        then error stage (Printf.sprintf "duplicate object key %S at %s" name path)
+        else (
+          Hashtbl.add seen name ();
+          let* () =
+            validate_message_value ~stage ~path:(path ^ "." ^ name) value
+          in
+          loop rest)
+    in
+    loop fields
+  | `List values ->
+    let rec loop index = function
+      | [] -> Ok ()
+      | value :: rest ->
+        let* () =
+          validate_message_value
+            ~stage
+            ~path:(Printf.sprintf "%s[%d]" path index)
+            value
+        in
+        loop (index + 1) rest
+    in
+    loop 0 values
+  | `Float value when not (Float.is_finite value) ->
+    error stage (Printf.sprintf "non-finite number at %s" path)
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
+;;
+
+let reject_unknown_fields ~stage ~allowed fields =
+  match List.find_opt (fun (name, _) -> not (List.mem name allowed)) fields with
+  | None -> Ok ()
+  | Some (name, _) -> error stage (Printf.sprintf "unknown field %S" name)
+;;
+
 let assoc_at stage = function
   | `Assoc fields -> Ok fields
   | _ -> error stage "expected an object"
@@ -44,6 +84,21 @@ let request_id stage = function
   | `String id when String.trim id <> "" -> Ok (`String id, id)
   | `Int id -> Ok (`Int id, string_of_int id)
   | _ -> error stage "request id must be a non-empty string or integer"
+;;
+
+let request_id_opt stage fields =
+  match List.assoc_opt "id" fields with
+  | None -> Ok None
+  | Some id ->
+    let* id, _call_id = request_id stage id in
+    Ok (Some id)
+;;
+
+let params_object stage fields =
+  match List.assoc_opt "params" fields with
+  | None -> Ok (`Assoc [])
+  | Some (`Assoc _ as params) -> Ok params
+  | Some _ -> error stage "field \"params\" must be an object"
 ;;
 
 let initialize ~server_name ~id =
@@ -102,21 +157,21 @@ let tools_call ~id ~params ~call_tool =
 
 let handle_message ~server_name ~tool_specs ~call_tool message =
   let stage = "MCP message" in
+  let* () = validate_message_value ~stage ~path:"$" message in
   let* fields = assoc_at stage message in
+  let* () =
+    reject_unknown_fields
+      ~stage
+      ~allowed:[ "jsonrpc"; "id"; "method"; "params" ]
+      fields
+  in
   let* jsonrpc = required_string stage "jsonrpc" fields in
   if jsonrpc <> "2.0"
   then error stage (Printf.sprintf "unsupported jsonrpc %S" jsonrpc)
   else
     let* method_ = required_string stage "method" fields in
-    let id = Option.value (List.assoc_opt "id" fields) ~default:`Null in
-    let params = Option.value (List.assoc_opt "params" fields) ~default:(`Assoc []) in
-    let* request =
-      if id = `Null
-      then Ok None
-      else
-        let* id, _call_id = request_id stage id in
-        Ok (Some id)
-    in
+    let* params = params_object stage fields in
+    let* request = request_id_opt stage fields in
     match method_, request with
     | "initialize", Some id ->
       Ok

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -56,6 +56,11 @@ let reject_unknown_fields ~stage ~allowed fields =
   | Some (name, _) -> error stage (Printf.sprintf "unknown field %S" name)
 ;;
 
+let parse_message stage raw_message =
+  try Ok (Yojson.Safe.from_string raw_message) with
+  | Yojson.Json_error detail -> error stage ("invalid JSON: " ^ detail)
+;;
+
 let assoc_at stage = function
   | `Assoc fields -> Ok fields
   | _ -> error stage "expected an object"
@@ -155,8 +160,9 @@ let tools_call ~id ~params ~call_tool =
     Ok { response = Some (tool_result_json ~id result); tool_called = true }
 ;;
 
-let handle_message ~server_name ~tool_specs ~call_tool message =
+let handle_message ~server_name ~tool_specs ~call_tool raw_message =
   let stage = "MCP message" in
+  let* message = parse_message stage raw_message in
   let* () = validate_message_value ~stage ~path:"$" message in
   let* fields = assoc_at stage message in
   let* () =

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -160,6 +160,8 @@ let tools_call ~id ~params ~call_tool =
     Ok { response = Some (tool_result_json ~id result); tool_called = true }
 ;;
 
+(* TEL-OK: pure fail-closed protocol decoder; the runtime caller owns terminal
+   error telemetry and control-response delivery. *)
 let handle_message ~server_name ~tool_specs ~call_tool raw_message =
   let stage = "MCP message" in
   let* message = parse_message stage raw_message in

--- a/lib/runtime/runtime_official_client_mcp.mli
+++ b/lib/runtime/runtime_official_client_mcp.mli
@@ -27,5 +27,5 @@ val handle_message :
      call_id:string ->
      arguments:Yojson.Safe.t ->
      tool_result option) ->
-  Yojson.Safe.t ->
+  string ->
   (dispatch, error) result

--- a/lib/runtime/runtime_official_client_mcp.mli
+++ b/lib/runtime/runtime_official_client_mcp.mli
@@ -1,8 +1,9 @@
 (** Exact JSON-RPC/MCP bridge shared by official subscription clients.
 
-    Client adapters own their transport and tool representation. This module
-    owns the protocol state: initialize, tools/list, tools/call, notification
-    no-response semantics, and typed protocol failures. *)
+    Client adapters own their transport and tool representation. This module's
+    raw-text entrypoint owns JSON parsing and the protocol state: initialize,
+    tools/list, tools/call, notification no-response semantics, and typed
+    protocol failures. *)
 
 type error =
   { stage : string

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -276,7 +276,7 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
       ~server_name:"masc"
       ~tool_specs
       ~call_tool
-      json
+      (Yojson.Safe.to_string json)
     |> Result.get_ok
   in
   let list =
@@ -324,27 +324,24 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
        ~server_name:"masc"
        ~tool_specs
        ~call_tool
-       (`Assoc
-          [ "jsonrpc", `String "2.0"
-          ; "id", `Bool true
-          ; "method", `String "tools/list"
-          ])
+       {|{"jsonrpc":"2.0","id":true,"method":"tools/list"}|}
    with
    | Error { stage = "MCP message"; _ } -> ()
    | Error _ -> fail "invalid request id had the wrong error stage"
    | Ok _ -> fail "boolean JSON-RPC request id was admitted");
-  let rejects label json =
+  let rejects_raw label raw_message =
     match
       Runtime_official_client_mcp.handle_message
         ~server_name:"masc"
         ~tool_specs
         ~call_tool
-        json
+        raw_message
     with
     | Error { stage = "MCP message"; _ } -> ()
     | Error _ -> failf "%s had the wrong error stage" label
     | Ok _ -> failf "%s was admitted" label
   in
+  let rejects label json = rejects_raw label (Yojson.Safe.to_string json) in
   rejects
     "explicit null notification id"
     (`Assoc
@@ -361,20 +358,17 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
        ; "method", `String "tools/list"
        ; "params", `Null
        ]);
-  rejects
+  rejects_raw
     "duplicate method"
-    (`Assoc
-       [ "jsonrpc", `String "2.0"
-       ; "id", `Int 3
-       ; "method", `String "tools/list"
-       ; "method", `String "tools/call"
-       ; "params", `Assoc []
-       ]);
+    {|{"jsonrpc":"2.0","id":3,"method":"tools/list","method":"tools/call","params":{}}|};
+  rejects_raw
+    "nested duplicate argument"
+    {|{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"missing","arguments":{"score":1,"score":2}}}|};
   rejects
     "unknown top-level field"
     (`Assoc
        [ "jsonrpc", `String "2.0"
-       ; "id", `Int 4
+       ; "id", `Int 5
        ; "method", `String "tools/list"
        ; "params", `Assoc []
        ; "fallback", `Bool true
@@ -383,7 +377,7 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
     "non-finite nested value"
     (`Assoc
        [ "jsonrpc", `String "2.0"
-       ; "id", `Int 5
+       ; "id", `Int 6
        ; "method", `String "tools/call"
        ; ( "params"
          , `Assoc
@@ -391,6 +385,8 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
              ; "arguments", `Assoc [ "score", `Float Float.nan ]
              ] )
        ])
+  ;
+  rejects_raw "malformed JSON" {|{"jsonrpc":"2.0","id":7|}
 ;;
 
 let test_malformed_json_fails_closed () =

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -266,8 +266,10 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
         ]
     ]
   in
-  let call_tool ~name:_ ~call_id:_ ~arguments:_ =
-    fail "unknown tool dispatch reached the callback"
+  let call_tool ~name ~call_id:_ ~arguments:_ =
+    if String.equal name "missing"
+    then None
+    else failf "unexpected tool dispatch reached the callback: %s" name
   in
   let dispatch json =
     Runtime_official_client_mcp.handle_message
@@ -330,7 +332,65 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
    with
    | Error { stage = "MCP message"; _ } -> ()
    | Error _ -> fail "invalid request id had the wrong error stage"
-   | Ok _ -> fail "boolean JSON-RPC request id was admitted")
+   | Ok _ -> fail "boolean JSON-RPC request id was admitted");
+  let rejects label json =
+    match
+      Runtime_official_client_mcp.handle_message
+        ~server_name:"masc"
+        ~tool_specs
+        ~call_tool
+        json
+    with
+    | Error { stage = "MCP message"; _ } -> ()
+    | Error _ -> failf "%s had the wrong error stage" label
+    | Ok _ -> failf "%s was admitted" label
+  in
+  rejects
+    "explicit null notification id"
+    (`Assoc
+       [ "jsonrpc", `String "2.0"
+       ; "id", `Null
+       ; "method", `String "notifications/initialized"
+       ; "params", `Assoc []
+       ]);
+  rejects
+    "scalar params"
+    (`Assoc
+       [ "jsonrpc", `String "2.0"
+       ; "id", `Int 2
+       ; "method", `String "tools/list"
+       ; "params", `Null
+       ]);
+  rejects
+    "duplicate method"
+    (`Assoc
+       [ "jsonrpc", `String "2.0"
+       ; "id", `Int 3
+       ; "method", `String "tools/list"
+       ; "method", `String "tools/call"
+       ; "params", `Assoc []
+       ]);
+  rejects
+    "unknown top-level field"
+    (`Assoc
+       [ "jsonrpc", `String "2.0"
+       ; "id", `Int 4
+       ; "method", `String "tools/list"
+       ; "params", `Assoc []
+       ; "fallback", `Bool true
+       ]);
+  rejects
+    "non-finite nested value"
+    (`Assoc
+       [ "jsonrpc", `String "2.0"
+       ; "id", `Int 5
+       ; "method", `String "tools/call"
+       ; ( "params"
+         , `Assoc
+             [ "name", `String "missing"
+             ; "arguments", `Assoc [ "score", `Float Float.nan ]
+             ] )
+       ])
 ;;
 
 let test_malformed_json_fails_closed () =

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -373,19 +373,9 @@ let test_shared_mcp_bridge_owns_exact_dispatch () =
        ; "params", `Assoc []
        ; "fallback", `Bool true
        ]);
-  rejects
+  rejects_raw
     "non-finite nested value"
-    (`Assoc
-       [ "jsonrpc", `String "2.0"
-       ; "id", `Int 6
-       ; "method", `String "tools/call"
-       ; ( "params"
-         , `Assoc
-             [ "name", `String "missing"
-             ; "arguments", `Assoc [ "score", `Float Float.nan ]
-             ] )
-       ])
-  ;
+    {|{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"missing","arguments":{"score":NaN}}}|};
   rejects_raw "malformed JSON" {|{"jsonrpc":"2.0","id":7|}
 ;;
 


### PR DESCRIPTION
## Summary

- make the official-client MCP public boundary accept raw JSON text and own parse, duplicate-key, non-finite-number, typed decode, and dispatch
- reject unknown top-level fields, explicit null request IDs, and present non-object params
- keep absent notification IDs distinct from invalid explicit IDs
- keep the Claude rate-limit formatter private so the dead-surface ratchet remains exact

Closes #27805.

## Verification

Current exact head:

- `scripts/dune-local.sh build test/test_runtime_claude_code.exe`
- `scripts/dune-local.sh exec test/test_runtime_claude_code.exe` (12 pass, 1 live skip)
- `ocamlc -stop-after parsing` for changed OCaml implementations/tests
- `ocamlformat --check ...`
- `git diff --check origin/main...HEAD`
- `python3 scripts/audit-dead-surface.py --exports --ratchet` (551/551)
- `bash scripts/ocaml-structure-ratchet.sh`
- `bash scripts/audit-ci-test-targets.sh`
- `bash scripts/ci/check-telemetry-coverage.sh`