### PR TITLE
feat(runtime): serve turn-scoped official-client MCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1559,7 +1559,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_keeper_official_client_host @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code"
+          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_keeper_official_client_host @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code @test/runtest-test_runtime_official_client_mcp_http"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${official_client_targets}"
 
       - name: Run host FD pressure contract suite

--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -14,6 +14,9 @@
   unix
   logs
   eio
+  cohttp
+  cohttp-eio
+  eqaf
   masc.agent_core
   masc.agent_core.base
   masc.agent_core.llm_provider

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -18,8 +18,18 @@ type phase =
   | Awaiting_initialized
   | Ready
 
+type session_snapshot =
+  { phase : phase
+  ; negotiated_protocol_version : string option
+  }
+
+type lifecycle =
+  | Needs_initialize
+  | Needs_initialized of string
+  | Session_ready of string
+
 type session =
-  { phase : phase Atomic.t
+  { lifecycle : lifecycle Atomic.t
   }
 
 type message =
@@ -31,7 +41,25 @@ type message =
 let ( let* ) = Result.bind
 let error stage detail = Error { stage; detail }
 
-let create_session () = { phase = Atomic.make Awaiting_initialize }
+let create_session () = { lifecycle = Atomic.make Needs_initialize }
+
+let phase_of_lifecycle = function
+  | Needs_initialize -> Awaiting_initialize
+  | Needs_initialized _ -> Awaiting_initialized
+  | Session_ready _ -> Ready
+;;
+
+let protocol_version_of_lifecycle = function
+  | Needs_initialize -> None
+  | Needs_initialized version | Session_ready version -> Some version
+;;
+
+let snapshot_session session =
+  let lifecycle = Atomic.get session.lifecycle in
+  { phase = phase_of_lifecycle lifecycle
+  ; negotiated_protocol_version = protocol_version_of_lifecycle lifecycle
+  }
+;;
 
 let phase_to_string = function
   | Awaiting_initialize -> "awaiting_initialize"
@@ -40,7 +68,7 @@ let phase_to_string = function
 ;;
 
 let require_phase session ~stage expected =
-  let actual = Atomic.get session.phase in
+  let actual = Atomic.get session.lifecycle |> phase_of_lifecycle in
   if actual = expected
   then Ok ()
   else
@@ -52,17 +80,56 @@ let require_phase session ~stage expected =
          (phase_to_string expected))
 ;;
 
-let transition_phase session ~stage ~expected ~next =
-  if Atomic.compare_and_set session.phase expected next
-  then Ok ()
-  else
-    let actual = Atomic.get session.phase in
+let transition_initialize session ~stage protocol_version =
+  let current = Atomic.get session.lifecycle in
+  match current with
+  | Needs_initialize ->
+    if Atomic.compare_and_set
+         session.lifecycle
+         current
+         (Needs_initialized protocol_version)
+    then Ok ()
+    else
+      let actual = Atomic.get session.lifecycle |> phase_of_lifecycle in
+      error
+        stage
+        (Printf.sprintf
+           "MCP session phase changed to %s; expected %s"
+           (phase_to_string actual)
+           (phase_to_string Awaiting_initialize))
+  | Needs_initialized _ | Session_ready _ ->
     error
       stage
       (Printf.sprintf
-         "MCP session phase changed to %s; expected %s"
-         (phase_to_string actual)
-         (phase_to_string expected))
+         "MCP session phase is %s; expected %s"
+         (phase_to_string (phase_of_lifecycle current))
+         (phase_to_string Awaiting_initialize))
+;;
+
+let transition_initialized session ~stage =
+  let current = Atomic.get session.lifecycle in
+  match current with
+  | Needs_initialized protocol_version ->
+    if Atomic.compare_and_set
+         session.lifecycle
+         current
+         (Session_ready protocol_version)
+    then Ok ()
+    else
+      let actual = Atomic.get session.lifecycle |> phase_of_lifecycle in
+      error
+        stage
+        (Printf.sprintf
+           "MCP session phase changed to %s; expected %s"
+           (phase_to_string actual)
+           (phase_to_string Awaiting_initialized))
+  | Needs_initialize | Session_ready _ ->
+    error
+      stage
+      (Printf.sprintf
+         "MCP session phase is %s; expected %s"
+         (phase_to_string (phase_of_lifecycle current))
+         (phase_to_string Awaiting_initialized))
 ;;
 
 let rec validate_message_value ~stage ~path = function
@@ -165,17 +232,18 @@ let protocol_version params =
 let initialize ~server_name ~id ~params =
   let* protocol_version = protocol_version params in
   Ok
-    (Mcp_transport_protocol.make_response
-       ~id
-       (`Assoc
-          [ "protocolVersion", `String protocol_version
-          ; "capabilities", `Assoc [ "tools", `Assoc [] ]
-          ; ( "serverInfo"
-            , `Assoc
-                [ "name", `String server_name
-                ; "version", `String Runtime_build_version.current
-                ] )
-          ]))
+    ( protocol_version
+    , Mcp_transport_protocol.make_response
+        ~id
+        (`Assoc
+           [ "protocolVersion", `String protocol_version
+           ; "capabilities", `Assoc [ "tools", `Assoc [] ]
+           ; ( "serverInfo"
+             , `Assoc
+                 [ "name", `String server_name
+                 ; "version", `String Runtime_build_version.current
+                 ] )
+           ]) )
 ;;
 
 let tool_result_json ~id (result : tool_result) =
@@ -245,13 +313,11 @@ let dispatch_message ~session ~server_name ~tool_specs ~call_tool message =
     | "initialize", Some request_id ->
       let* () = require_phase session ~stage:"MCP initialize" Awaiting_initialize in
       let id = Mcp_transport_protocol.request_id_to_yojson request_id in
-      let* initialize_response = initialize ~server_name ~id ~params:message.params in
+      let* protocol_version, initialize_response =
+        initialize ~server_name ~id ~params:message.params
+      in
       let* () =
-        transition_phase
-          session
-          ~stage:"MCP initialize"
-          ~expected:Awaiting_initialize
-          ~next:Awaiting_initialized
+        transition_initialize session ~stage:"MCP initialize" protocol_version
       in
       Ok
         { response = Some initialize_response
@@ -275,13 +341,7 @@ let dispatch_message ~session ~server_name ~tool_specs ~call_tool message =
         ~params:message.params
         ~call_tool
     | "notifications/initialized", None ->
-      let* () =
-        transition_phase
-          session
-          ~stage:"MCP notifications/initialized"
-          ~expected:Awaiting_initialized
-          ~next:Ready
-      in
+      let* () = transition_initialized session ~stage:"MCP notifications/initialized" in
       Ok { response = None; tool_called = false }
     | _, None ->
       error

--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -13,6 +13,18 @@ type dispatch =
   ; tool_called : bool
   }
 
+type tool_call =
+  { id : Yojson.Safe.t
+  ; name : string
+  ; call_id : string
+  ; arguments : Yojson.Safe.t
+  }
+
+type prepared =
+  | Prepared_response of dispatch
+  | Prepared_tools_list of { id : Yojson.Safe.t }
+  | Prepared_tool_call of tool_call
+
 type phase =
   | Awaiting_initialize
   | Awaiting_initialized
@@ -260,7 +272,7 @@ let tool_result_json ~id (result : tool_result) =
         @ if result.success then [] else [ "isError", `Bool true ]))
 ;;
 
-let tools_call ~id ~params ~call_tool =
+let prepare_tools_call ~id ~params =
   let stage = "MCP tools/call" in
   let* _request_id, id, call_id = request_id stage id in
   let* fields = assoc_at stage params in
@@ -271,19 +283,33 @@ let tools_call ~id ~params ~call_tool =
     | Some (`Assoc _ as arguments) -> Ok arguments
     | Some _ -> error stage "field \"arguments\" must be an object"
   in
-  match call_tool ~name ~call_id ~arguments with
+  Ok (Prepared_tool_call { id; name; call_id; arguments })
+;;
+
+let complete_tools_list ~id tools =
+  { response =
+      Some
+        (Mcp_transport_protocol.make_response
+           ~id
+           (`Assoc [ "tools", `List tools ]))
+  ; tool_called = false
+  }
+;;
+
+let complete_tool_call request = function
   | None ->
-    Ok
-      { response =
-          Some
-            (Mcp_transport_protocol.make_error
-               ~id
-               (-32602)
-               (Printf.sprintf "unknown official-client tool %S" name))
-      ; tool_called = false
-      }
+    { response =
+        Some
+          (Mcp_transport_protocol.make_error
+             ~id:request.id
+             (-32602)
+             (Printf.sprintf "unknown official-client tool %S" request.name))
+    ; tool_called = false
+    }
   | Some result ->
-    Ok { response = Some (tool_result_json ~id result); tool_called = true }
+    { response = Some (tool_result_json ~id:request.id result)
+    ; tool_called = true
+    }
 ;;
 
 (* TEL-OK: pure fail-closed protocol decoder; the runtime caller owns terminal
@@ -308,7 +334,7 @@ let decode_message message =
     Ok { method_name; request_id; params }
 ;;
 
-let dispatch_message ~session ~server_name ~tool_specs ~call_tool message =
+let dispatch_message ~session ~server_name message =
   match message.method_name, message.request_id with
     | "initialize", Some request_id ->
       let* () = require_phase session ~stage:"MCP initialize" Awaiting_initialize in
@@ -320,29 +346,22 @@ let dispatch_message ~session ~server_name ~tool_specs ~call_tool message =
         transition_initialize session ~stage:"MCP initialize" protocol_version
       in
       Ok
-        { response = Some initialize_response
-        ; tool_called = false
-        }
+        (Prepared_response
+           { response = Some initialize_response
+           ; tool_called = false
+           })
     | "tools/list", Some request_id ->
       let* () = require_phase session ~stage:"MCP tools/list" Ready in
       let id = Mcp_transport_protocol.request_id_to_yojson request_id in
-      Ok
-        { response =
-            Some
-              (Mcp_transport_protocol.make_response
-                 ~id
-                 (`Assoc [ "tools", `List (tool_specs ()) ]))
-        ; tool_called = false
-        }
+      Ok (Prepared_tools_list { id })
     | "tools/call", Some request_id ->
       let* () = require_phase session ~stage:"MCP tools/call" Ready in
-      tools_call
+      prepare_tools_call
         ~id:(Mcp_transport_protocol.request_id_to_yojson request_id)
         ~params:message.params
-        ~call_tool
     | "notifications/initialized", None ->
       let* () = transition_initialized session ~stage:"MCP notifications/initialized" in
-      Ok { response = None; tool_called = false }
+      Ok (Prepared_response { response = None; tool_called = false })
     | _, None ->
       error
         "MCP message"
@@ -350,17 +369,36 @@ let dispatch_message ~session ~server_name ~tool_specs ~call_tool message =
     | _, Some request_id ->
       let id = Mcp_transport_protocol.request_id_to_yojson request_id in
       Ok
-        { response =
-            Some
-              (Mcp_transport_protocol.make_error
-                 ~id
-                 (-32601)
-                 (Printf.sprintf "MCP method %S is not supported" message.method_name))
-        ; tool_called = false
-        }
+        (Prepared_response
+           { response =
+               Some
+                 (Mcp_transport_protocol.make_error
+                    ~id
+                    (-32601)
+                    (Printf.sprintf "MCP method %S is not supported" message.method_name))
+           ; tool_called = false
+           })
+;;
+
+let prepare_message ~session ~server_name message_json =
+  try
+    let* message = decode_message message_json in
+    dispatch_message ~session ~server_name message
+  with
+  | Stack_overflow -> error "MCP message" "JSON nesting exceeds validation limits"
 ;;
 
 let handle_message ~session ~server_name ~tool_specs ~call_tool message_json =
-  let* message = decode_message message_json in
-  dispatch_message ~session ~server_name ~tool_specs ~call_tool message
+  let* prepared = prepare_message ~session ~server_name message_json in
+  match prepared with
+  | Prepared_response dispatch -> Ok dispatch
+  | Prepared_tools_list { id } -> Ok (complete_tools_list ~id (tool_specs ()))
+  | Prepared_tool_call request ->
+    Ok
+      (complete_tool_call
+         request
+         (call_tool
+            ~name:request.name
+            ~call_id:request.call_id
+            ~arguments:request.arguments))
 ;;

--- a/lib/runtime/runtime_official_client_mcp.mli
+++ b/lib/runtime/runtime_official_client_mcp.mli
@@ -20,10 +20,23 @@ type dispatch =
   ; tool_called : bool
   }
 
+type phase =
+  | Awaiting_initialize
+  | Awaiting_initialized
+  | Ready
+
+type session_snapshot =
+  { phase : phase
+  ; negotiated_protocol_version : string option
+  }
+
 type session
 
 val create_session : unit -> session
 (** Fresh closed lifecycle: initialize, initialized notification, then Ready. *)
+
+val snapshot_session : session -> session_snapshot
+(** One immutable observation of lifecycle phase and negotiated protocol. *)
 
 val handle_message :
   session:session ->

--- a/lib/runtime/runtime_official_client_mcp.mli
+++ b/lib/runtime/runtime_official_client_mcp.mli
@@ -20,6 +20,18 @@ type dispatch =
   ; tool_called : bool
   }
 
+type tool_call = private
+  { id : Yojson.Safe.t
+  ; name : string
+  ; call_id : string
+  ; arguments : Yojson.Safe.t
+  }
+
+type prepared =
+  | Prepared_response of dispatch
+  | Prepared_tools_list of { id : Yojson.Safe.t }
+  | Prepared_tool_call of tool_call
+
 type phase =
   | Awaiting_initialize
   | Awaiting_initialized
@@ -37,6 +49,18 @@ val create_session : unit -> session
 
 val snapshot_session : session -> session_snapshot
 (** One immutable observation of lifecycle phase and negotiated protocol. *)
+
+val prepare_message :
+  session:session ->
+  server_name:string ->
+  Yojson.Safe.t ->
+  (prepared, error) result
+(** Validate one message and commit only its protocol-state transition. Tool
+    inventory and tool effects are returned as typed work for the transport
+    owner to execute outside any protocol-state critical section. *)
+
+val complete_tools_list : id:Yojson.Safe.t -> Yojson.Safe.t list -> dispatch
+val complete_tool_call : tool_call -> tool_result option -> dispatch
 
 val handle_message :
   session:session ->

--- a/lib/runtime/runtime_official_client_mcp_http.ml
+++ b/lib/runtime/runtime_official_client_mcp_http.ml
@@ -30,12 +30,12 @@ type t =
 
 let max_body_bytes = 1024 * 1024
 
-let hex_of_bytes bytes =
+let hex_of_cstruct bytes =
   let alphabet = "0123456789abcdef" in
-  let length = Bytes.length bytes in
+  let length = Cstruct.length bytes in
   let result = Bytes.create (length * 2) in
   for index = 0 to length - 1 do
-    let value = Char.code (Bytes.get bytes index) in
+    let value = Cstruct.get_uint8 bytes index in
     Bytes.set result (index * 2) alphabet.[value lsr 4];
     Bytes.set result ((index * 2) + 1) alphabet.[value land 0x0f]
   done;
@@ -43,10 +43,10 @@ let hex_of_bytes bytes =
 ;;
 
 let fresh_capabilities secure_random =
-  let entropy = Bytes.create 48 in
+  let entropy = Cstruct.create 48 in
   Eio.Flow.read_exact secure_random entropy;
-  let path_id = Bytes.sub entropy 0 16 |> hex_of_bytes in
-  let token = Bytes.sub entropy 16 32 |> hex_of_bytes in
+  let path_id = Cstruct.sub entropy 0 16 |> hex_of_cstruct in
+  let token = Cstruct.sub entropy 16 32 |> hex_of_cstruct in
   path_id, token
 ;;
 

--- a/lib/runtime/runtime_official_client_mcp_http.ml
+++ b/lib/runtime/runtime_official_client_mcp_http.ml
@@ -120,6 +120,34 @@ let protocol_error_response id code message =
     ]
 ;;
 
+let protocol_version_header t request =
+  let values =
+    Cohttp.Header.get_multi
+      (Cohttp.Request.headers request)
+      "mcp-protocol-version"
+  in
+  let session = Runtime_official_client_mcp.snapshot_session t.session in
+  match session.phase, session.negotiated_protocol_version, values with
+  | Awaiting_initialize, None, [] -> Ok ()
+  | Awaiting_initialize, None, [ value ] ->
+    Mcp_transport_protocol.validate_protocol_version value
+    |> Result.map (fun _ -> ())
+  | (Awaiting_initialized | Ready), Some expected, [ value ]
+    when String.equal expected value -> Ok ()
+  | (Awaiting_initialized | Ready), Some _, [] ->
+    Error "missing MCP-Protocol-Version header"
+  | (Awaiting_initialized | Ready), Some expected, [ value ] ->
+    Error
+      (Printf.sprintf
+         "MCP-Protocol-Version mismatch: expected %S, got %S"
+         expected
+         value)
+  | _, _, _ :: _ :: _ -> Error "duplicate MCP-Protocol-Version header"
+  | Awaiting_initialize, Some _, _
+  | (Awaiting_initialized | Ready), None, _ ->
+    Error "MCP session has no negotiated protocol version"
+;;
+
 type dispatch_error =
   | Protocol_error of Runtime_official_client_mcp.error
   | Protocol_header_error of string
@@ -231,34 +259,6 @@ let content_type_is_json request =
   | [ value ] ->
     Mcp_transport_protocol.Http_negotiation.is_json_content_type (Some value)
   | [] | _ :: _ :: _ -> false
-;;
-
-let protocol_version_header t request =
-  let values =
-    Cohttp.Header.get_multi
-      (Cohttp.Request.headers request)
-      "mcp-protocol-version"
-  in
-  let session = Runtime_official_client_mcp.snapshot_session t.session in
-  match session.phase, session.negotiated_protocol_version, values with
-  | Awaiting_initialize, None, [] -> Ok ()
-  | Awaiting_initialize, None, [ value ] ->
-    Mcp_transport_protocol.validate_protocol_version value
-    |> Result.map (fun _ -> ())
-  | (Awaiting_initialized | Ready), Some expected, [ value ]
-    when String.equal expected value -> Ok ()
-  | (Awaiting_initialized | Ready), Some _, [] ->
-    Error "missing MCP-Protocol-Version header"
-  | (Awaiting_initialized | Ready), Some expected, [ value ] ->
-    Error
-      (Printf.sprintf
-         "MCP-Protocol-Version mismatch: expected %S, got %S"
-         expected
-         value)
-  | _, _, _ :: _ :: _ -> Error "duplicate MCP-Protocol-Version header"
-  | Awaiting_initialize, Some _, _
-  | (Awaiting_initialized | Ready), None, _ ->
-    Error "MCP session has no negotiated protocol version"
 ;;
 
 let content_length request =

--- a/lib/runtime/runtime_official_client_mcp_http.ml
+++ b/lib/runtime/runtime_official_client_mcp_http.ml
@@ -256,7 +256,7 @@ let handle_post t ~tool_specs ~call_tool request body =
          respond `Bad_request detail
        | Ok (Some length) when length > max_body_bytes ->
          reject t;
-         respond `Payload_too_large "MCP request body exceeds 1048576 bytes"
+         respond `Request_entity_too_large "MCP request body exceeds 1048576 bytes"
        | Ok _ ->
          (try
             let body =
@@ -267,7 +267,7 @@ let handle_post t ~tool_specs ~call_tool request body =
           | Eio.Cancel.Cancelled _ as exn -> raise exn
           | Eio.Buf_read.Buffer_limit_exceeded ->
             reject t;
-            respond `Payload_too_large "MCP request body exceeds 1048576 bytes"
+            respond `Request_entity_too_large "MCP request body exceeds 1048576 bytes"
           | _ ->
             reject t;
             respond `Bad_request "failed to read MCP request body"))

--- a/lib/runtime/runtime_official_client_mcp_http.ml
+++ b/lib/runtime/runtime_official_client_mcp_http.ml
@@ -1,4 +1,4 @@
-type phase =
+type phase = Runtime_official_client_mcp.phase =
   | Awaiting_initialize
   | Awaiting_initialized
   | Ready
@@ -12,17 +12,16 @@ type snapshot =
   }
 
 type mutable_state =
-  { mutable phase : phase
-  ; mutable authenticated_requests : int
+  { mutable authenticated_requests : int
   ; mutable rejected_requests : int
   ; mutable tool_calls : int
-  ; mutable negotiated_protocol_version : string option
   }
 
 type t =
   { endpoint : string
   ; server_name : string
   ; authorization : string
+  ; session : Runtime_official_client_mcp.session
   ; state : mutable_state
   ; state_mutex : Eio.Mutex.t
   ; dispatch_mutex : Eio.Mutex.t
@@ -51,13 +50,15 @@ let fresh_capabilities secure_random =
 ;;
 
 let snapshot t =
-  Eio.Mutex.use_ro t.state_mutex (fun () ->
-    { phase = t.state.phase
-    ; authenticated_requests = t.state.authenticated_requests
-    ; rejected_requests = t.state.rejected_requests
-    ; tool_calls = t.state.tool_calls
-    ; negotiated_protocol_version = t.state.negotiated_protocol_version
-    })
+  Eio.Mutex.use_ro t.dispatch_mutex (fun () ->
+    let session = Runtime_official_client_mcp.snapshot_session t.session in
+    Eio.Mutex.use_ro t.state_mutex (fun () ->
+      { phase = session.phase
+      ; authenticated_requests = t.state.authenticated_requests
+      ; rejected_requests = t.state.rejected_requests
+      ; tool_calls = t.state.tool_calls
+      ; negotiated_protocol_version = session.negotiated_protocol_version
+      }))
 ;;
 
 let endpoint t = t.endpoint
@@ -110,77 +111,23 @@ let protocol_error_response id code message =
     ]
 ;;
 
-let initialize_protocol_version = function
-  | Some (`Assoc fields) ->
-    (match List.assoc_opt "result" fields with
-     | Some (`Assoc result_fields) ->
-       (match List.assoc_opt "protocolVersion" result_fields with
-        | Some (`String value) -> Some value
-        | _ -> None)
-     | _ -> None)
-  | _ -> None
-;;
-
-let phase_error phase method_ =
-  let expected =
-    match phase with
-    | Awaiting_initialize -> "initialize"
-    | Awaiting_initialized -> "notifications/initialized"
-    | Ready -> "tools/list or tools/call"
-  in
-  Printf.sprintf "MCP method %S is not valid before %s" method_ expected
-;;
-
-let phase_admits phase method_ request_id =
-  match method_ with
-  | "server/discover" | "initialize" ->
-    phase = Awaiting_initialize && Option.is_some request_id
-  | "notifications/initialized" ->
-    phase = Awaiting_initialized && Option.is_none request_id
-  | "tools/list" | "tools/call" -> phase = Ready && Option.is_some request_id
-  | _ -> true
-;;
-
-let request_id_json = function
-  | Some id -> id
-  | None -> `Null
-;;
-
-let dispatch t ~tool_specs ~call_tool raw_message =
+let dispatch t ~tool_specs ~call_tool message =
   Eio.Mutex.use_rw ~protect:true t.dispatch_mutex (fun () ->
-    match Runtime_official_client_mcp.decode_message raw_message with
-    | Error error -> Error (`Dispatch error)
-    | Ok message ->
-      let method_ = Runtime_official_client_mcp.message_method message in
-      let request_id = Runtime_official_client_mcp.message_request_id message in
-      let phase = Eio.Mutex.use_ro t.state_mutex (fun () -> t.state.phase) in
-      if not (phase_admits phase method_ request_id)
+    match
+      Runtime_official_client_mcp.handle_message
+        ~session:t.session
+        ~server_name:t.server_name
+        ~tool_specs
+        ~call_tool
+        message
+    with
+    | Error error -> Error error
+    | Ok result ->
+      if result.tool_called
       then
-        Error
-          (`Protocol
-            (request_id_json request_id, phase_error phase method_))
-      else
-        (match
-           Runtime_official_client_mcp.dispatch_message
-             ~server_name:t.server_name
-             ~tool_specs
-             ~call_tool
-             message
-         with
-         | Error error -> Error (`Dispatch error)
-         | Ok result ->
-           Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () ->
-             (match t.state.phase, method_, result.response with
-              | Awaiting_initialize, "initialize", Some _ ->
-                t.state.phase <- Awaiting_initialized;
-                t.state.negotiated_protocol_version <-
-                  initialize_protocol_version result.response
-              | Awaiting_initialized, "notifications/initialized", None ->
-                t.state.phase <- Ready
-              | _ -> ());
-             if result.tool_called
-             then t.state.tool_calls <- t.state.tool_calls + 1);
-           Ok result))
+        Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () ->
+          t.state.tool_calls <- t.state.tool_calls + 1);
+      Ok result)
 ;;
 
 let update_state t f =
@@ -202,16 +149,53 @@ let authorization_matches t request =
   | [] | _ :: _ :: _ -> false
 ;;
 
+let origin_is_admitted request =
+  match Cohttp.Header.get_multi (Cohttp.Request.headers request) "origin" with
+  | [] -> true
+  | _ :: _ -> false
+;;
+
+let accepts_streamable_mcp request =
+  match Cohttp.Header.get_multi (Cohttp.Request.headers request) "accept" with
+  | [] -> false
+  | values ->
+    Mcp_transport_protocol.Http_negotiation.accepts_streamable_mcp
+      (Some (String.concat "," values))
+;;
+
 let content_type_is_json request =
   match Cohttp.Header.get_multi (Cohttp.Request.headers request) "content-type" with
   | [ value ] ->
-    let media_type =
-      match String.index_opt value ';' with
-      | None -> value
-      | Some index -> String.sub value 0 index
-    in
-    String.equal (String.trim media_type |> String.lowercase_ascii) "application/json"
+    Mcp_transport_protocol.Http_negotiation.is_json_content_type (Some value)
   | [] | _ :: _ :: _ -> false
+;;
+
+let protocol_version_header t request =
+  let values =
+    Cohttp.Header.get_multi
+      (Cohttp.Request.headers request)
+      "mcp-protocol-version"
+  in
+  let session = Runtime_official_client_mcp.snapshot_session t.session in
+  match session.phase, session.negotiated_protocol_version, values with
+  | Awaiting_initialize, None, [] -> Ok ()
+  | Awaiting_initialize, None, [ value ] ->
+    Mcp_transport_protocol.validate_protocol_version value
+    |> Result.map (fun _ -> ())
+  | (Awaiting_initialized | Ready), Some expected, [ value ]
+    when String.equal expected value -> Ok ()
+  | (Awaiting_initialized | Ready), Some _, [] ->
+    Error "missing MCP-Protocol-Version header"
+  | (Awaiting_initialized | Ready), Some expected, [ value ] ->
+    Error
+      (Printf.sprintf
+         "MCP-Protocol-Version mismatch: expected %S, got %S"
+         expected
+         value)
+  | _, _, _ :: _ :: _ -> Error "duplicate MCP-Protocol-Version header"
+  | Awaiting_initialize, Some _, _
+  | (Awaiting_initialized | Ready), None, _ ->
+    Error "MCP session has no negotiated protocol version"
 ;;
 
 let content_length request =
@@ -225,58 +209,77 @@ let content_length request =
 ;;
 
 let handle_message t ~tool_specs ~call_tool body =
-  match dispatch t ~tool_specs ~call_tool body with
-  | Error (`Protocol (id, detail)) ->
+  match
+    try Ok (Yojson.Safe.from_string body) with
+    | Yojson.Json_error detail -> Error detail
+    | Stack_overflow -> Error "JSON nesting exceeds parser limits"
+    | Failure detail -> Error detail
+  with
+  | Error detail ->
     reject t;
-    respond_json `Conflict (protocol_error_response id (-32002) detail)
-  | Error (`Dispatch { kind; stage; detail }) ->
-    reject t;
-    let code =
-      match kind with
-      | Runtime_official_client_mcp.Json_parse -> -32700
-      | Runtime_official_client_mcp.Protocol -> -32600
-    in
     respond_json
       `Bad_request
-      (protocol_error_response `Null code (stage ^ ": " ^ detail))
-  | Ok { response = None; _ } -> respond `Accepted ""
-  | Ok { response = Some response; _ } ->
-    let protocol_version = (snapshot t).negotiated_protocol_version in
-    respond_json ?protocol_version `OK response
+      (protocol_error_response `Null (-32700) ("MCP message: " ^ detail))
+  | Ok message ->
+    (match dispatch t ~tool_specs ~call_tool message with
+     | Error { stage; detail } ->
+       reject t;
+       respond_json
+         `Bad_request
+         (protocol_error_response `Null (-32600) (stage ^ ": " ^ detail))
+     | Ok { response = None; _ } -> respond `Accepted ""
+     | Ok { response = Some response; _ } ->
+       let protocol_version = (snapshot t).negotiated_protocol_version in
+       respond_json ?protocol_version `OK response)
 ;;
 
 let handle_post t ~tool_specs ~call_tool request body =
-  if not (content_type_is_json request)
+  if not (accepts_streamable_mcp request)
+  then (
+    reject t;
+    respond
+      `Not_acceptable
+      "Accept must include application/json and text/event-stream")
+  else if not (content_type_is_json request)
   then (
     reject t;
     respond `Unsupported_media_type "Content-Type must be application/json")
   else
-    match content_length request with
+    match protocol_version_header t request with
     | Error detail ->
       reject t;
       respond `Bad_request detail
-    | Ok (Some length) when length > max_body_bytes ->
-      reject t;
-      respond `Payload_too_large "MCP request body exceeds 1048576 bytes"
-    | Ok _ ->
-      (try
-         let body =
-           Eio.Buf_read.(of_flow ~max_size:max_body_bytes body |> take_all)
-         in
-         handle_message t ~tool_specs ~call_tool body
-       with
-       | Eio.Cancel.Cancelled _ as exn -> raise exn
-       | Eio.Buf_read.Buffer_limit_exceeded ->
+    | Ok () ->
+      (match content_length request with
+       | Error detail ->
+         reject t;
+         respond `Bad_request detail
+       | Ok (Some length) when length > max_body_bytes ->
          reject t;
          respond `Payload_too_large "MCP request body exceeds 1048576 bytes"
-       | _ ->
-         reject t;
-         respond `Bad_request "failed to read MCP request body")
+       | Ok _ ->
+         (try
+            let body =
+              Eio.Buf_read.(of_flow ~max_size:max_body_bytes body |> take_all)
+            in
+            handle_message t ~tool_specs ~call_tool body
+          with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | Eio.Buf_read.Buffer_limit_exceeded ->
+            reject t;
+            respond `Payload_too_large "MCP request body exceeds 1048576 bytes"
+          | _ ->
+            reject t;
+            respond `Bad_request "failed to read MCP request body"))
 ;;
 
 let request_handler t ~path ~tool_specs ~call_tool _client_addr request body =
   if not (String.equal (Uri.path (Cohttp.Request.uri request)) path)
   then respond `Not_found "Not found"
+  else if not (origin_is_admitted request)
+  then (
+    reject t;
+    respond `Forbidden "Origin is not admitted on the native-client endpoint")
   else if not (authorization_matches t request)
   then (
     reject t;
@@ -289,9 +292,15 @@ let request_handler t ~path ~tool_specs ~call_tool _client_addr request body =
     record_authenticated_request t;
     match Cohttp.Request.meth request with
     | `POST -> handle_post t ~tool_specs ~call_tool request body
-    | `GET -> respond `Method_not_allowed "SSE is not enabled for this endpoint"
-    | `DELETE -> respond `No_content ""
-    | _ -> respond `Method_not_allowed "Method not allowed")
+    | `GET ->
+      reject t;
+      respond `Method_not_allowed "SSE is not enabled for this endpoint"
+    | `DELETE ->
+      reject t;
+      respond `Method_not_allowed "Session deletion is not enabled"
+    | _ ->
+      reject t;
+      respond `Method_not_allowed "Method not allowed")
 ;;
 
 let start ~sw ~net ~secure_random ~server_name ~tool_specs ~call_tool () =
@@ -311,17 +320,16 @@ let start ~sw ~net ~secure_random ~server_name ~tool_specs ~call_tool () =
     | `Unix _ -> assert false
   in
   let state =
-    { phase = Awaiting_initialize
-    ; authenticated_requests = 0
+    { authenticated_requests = 0
     ; rejected_requests = 0
     ; tool_calls = 0
-    ; negotiated_protocol_version = None
     }
   in
   let t =
     { endpoint = Printf.sprintf "http://127.0.0.1:%d%s" port path
     ; server_name
     ; authorization
+    ; session = Runtime_official_client_mcp.create_session ()
     ; state
     ; state_mutex = Eio.Mutex.create ()
     ; dispatch_mutex = Eio.Mutex.create ()

--- a/lib/runtime/runtime_official_client_mcp_http.ml
+++ b/lib/runtime/runtime_official_client_mcp_http.ml
@@ -1,0 +1,345 @@
+type phase =
+  | Awaiting_initialize
+  | Awaiting_initialized
+  | Ready
+
+type snapshot =
+  { phase : phase
+  ; authenticated_requests : int
+  ; rejected_requests : int
+  ; tool_calls : int
+  ; negotiated_protocol_version : string option
+  }
+
+type mutable_state =
+  { mutable phase : phase
+  ; mutable authenticated_requests : int
+  ; mutable rejected_requests : int
+  ; mutable tool_calls : int
+  ; mutable negotiated_protocol_version : string option
+  }
+
+type t =
+  { endpoint : string
+  ; server_name : string
+  ; authorization : string
+  ; state : mutable_state
+  ; state_mutex : Eio.Mutex.t
+  ; dispatch_mutex : Eio.Mutex.t
+  }
+
+let max_body_bytes = 1024 * 1024
+
+let hex_of_bytes bytes =
+  let alphabet = "0123456789abcdef" in
+  let length = Bytes.length bytes in
+  let result = Bytes.create (length * 2) in
+  for index = 0 to length - 1 do
+    let value = Char.code (Bytes.get bytes index) in
+    Bytes.set result (index * 2) alphabet.[value lsr 4];
+    Bytes.set result ((index * 2) + 1) alphabet.[value land 0x0f]
+  done;
+  Bytes.unsafe_to_string result
+;;
+
+let fresh_capabilities secure_random =
+  let entropy = Bytes.create 48 in
+  Eio.Flow.read_exact secure_random entropy;
+  let path_id = Bytes.sub entropy 0 16 |> hex_of_bytes in
+  let token = Bytes.sub entropy 16 32 |> hex_of_bytes in
+  path_id, token
+;;
+
+let snapshot t =
+  Eio.Mutex.use_ro t.state_mutex (fun () ->
+    { phase = t.state.phase
+    ; authenticated_requests = t.state.authenticated_requests
+    ; rejected_requests = t.state.rejected_requests
+    ; tool_calls = t.state.tool_calls
+    ; negotiated_protocol_version = t.state.negotiated_protocol_version
+    })
+;;
+
+let endpoint t = t.endpoint
+
+let mcp_config_json t =
+  `Assoc
+    [ ( "mcpServers"
+      , `Assoc
+          [ ( t.server_name
+            , `Assoc
+                [ "url", `String t.endpoint
+                ; ( "headers"
+                  , `Assoc
+                      [ "Authorization", `String ("Bearer " ^ t.authorization) ] )
+                ] )
+          ] )
+    ]
+;;
+
+let headers ?protocol_version content_type =
+  Cohttp.Header.of_list
+    ([ "content-type", content_type; "cache-control", "no-store" ]
+     @ Option.fold
+         ~none:[]
+         ~some:(fun version -> [ "mcp-protocol-version", version ])
+         protocol_version)
+;;
+
+let respond ?protocol_version ?(content_type = "text/plain") status body =
+  Cohttp_eio.Server.respond_string
+    ~headers:(headers ?protocol_version content_type)
+    ~status
+    ~body
+    ()
+;;
+
+let respond_json ?protocol_version status json =
+  respond
+    ?protocol_version
+    ~content_type:"application/json"
+    status
+    (Yojson.Safe.to_string json)
+;;
+
+let protocol_error_response id code message =
+  `Assoc
+    [ "jsonrpc", `String "2.0"
+    ; "id", id
+    ; "error", `Assoc [ "code", `Int code; "message", `String message ]
+    ]
+;;
+
+let request_method_and_id = function
+  | `Assoc fields ->
+    let method_ =
+      match List.assoc_opt "method" fields with
+      | Some (`String value) -> Some value
+      | _ -> None
+    in
+    method_, Option.value (List.assoc_opt "id" fields) ~default:`Null
+  | _ -> None, `Null
+;;
+
+let initialize_protocol_version = function
+  | Some (`Assoc fields) ->
+    (match List.assoc_opt "result" fields with
+     | Some (`Assoc result_fields) ->
+       (match List.assoc_opt "protocolVersion" result_fields with
+        | Some (`String value) -> Some value
+        | _ -> None)
+     | _ -> None)
+  | _ -> None
+;;
+
+let phase_error phase method_ =
+  let expected =
+    match phase with
+    | Awaiting_initialize -> "initialize"
+    | Awaiting_initialized -> "notifications/initialized"
+    | Ready -> "tools/list or tools/call"
+  in
+  Printf.sprintf "MCP method %S is not valid before %s" method_ expected
+;;
+
+let phase_admits phase method_ id =
+  match method_ with
+  | Some ("server/discover" | "initialize") ->
+    phase = Awaiting_initialize && id <> `Null
+  | Some "notifications/initialized" ->
+    phase = Awaiting_initialized && id = `Null
+  | Some ("tools/list" | "tools/call") -> phase = Ready && id <> `Null
+  | None | Some _ -> true
+;;
+
+let dispatch t ~tool_specs ~call_tool message =
+  Eio.Mutex.use_rw ~protect:true t.dispatch_mutex (fun () ->
+    let method_, id = request_method_and_id message in
+    let phase = Eio.Mutex.use_ro t.state_mutex (fun () -> t.state.phase) in
+    if not (phase_admits phase method_ id)
+    then
+      let method_ = Option.value method_ ~default:"<missing>" in
+      Error (`Protocol (id, phase_error phase method_))
+    else
+      match
+        Runtime_official_client_mcp.handle_message
+          ~server_name:t.server_name
+          ~tool_specs
+          ~call_tool
+          message
+      with
+      | Error error -> Error (`Dispatch error)
+      | Ok result ->
+        Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () ->
+          (match t.state.phase, method_, result.response with
+           | Awaiting_initialize, Some "initialize", Some _ ->
+             t.state.phase <- Awaiting_initialized;
+             t.state.negotiated_protocol_version <-
+               initialize_protocol_version result.response
+           | Awaiting_initialized, Some "notifications/initialized", None ->
+             t.state.phase <- Ready
+           | _ -> ());
+          if result.tool_called
+          then t.state.tool_calls <- t.state.tool_calls + 1);
+        Ok result)
+;;
+
+let update_state t f =
+  Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () -> f t.state)
+;;
+
+let reject t =
+  update_state t (fun state -> state.rejected_requests <- state.rejected_requests + 1)
+;;
+
+let record_authenticated_request t =
+  update_state t (fun state ->
+    state.authenticated_requests <- state.authenticated_requests + 1)
+;;
+
+let authorization_matches t request =
+  match Cohttp.Header.get_multi (Cohttp.Request.headers request) "authorization" with
+  | [ value ] -> Eqaf.equal value ("Bearer " ^ t.authorization)
+  | [] | _ :: _ :: _ -> false
+;;
+
+let content_type_is_json request =
+  match Cohttp.Header.get_multi (Cohttp.Request.headers request) "content-type" with
+  | [ value ] ->
+    let media_type =
+      match String.index_opt value ';' with
+      | None -> value
+      | Some index -> String.sub value 0 index
+    in
+    String.equal (String.trim media_type |> String.lowercase_ascii) "application/json"
+  | [] | _ :: _ :: _ -> false
+;;
+
+let content_length request =
+  match Cohttp.Header.get_multi (Cohttp.Request.headers request) "content-length" with
+  | [] -> Ok None
+  | [ value ] ->
+    (match int_of_string_opt (String.trim value) with
+     | Some length when length >= 0 -> Ok (Some length)
+     | _ -> Error "invalid Content-Length")
+  | _ :: _ :: _ -> Error "duplicate Content-Length"
+;;
+
+let handle_message t ~tool_specs ~call_tool body =
+  match Runtime_official_client_mcp.parse_message body with
+  | Error { stage; detail } ->
+    reject t;
+    respond_json
+      `Bad_request
+      (protocol_error_response `Null (-32700) (stage ^ ": " ^ detail))
+  | Ok message ->
+    (match dispatch t ~tool_specs ~call_tool message with
+     | Error (`Protocol (id, detail)) ->
+       reject t;
+       respond_json `Conflict (protocol_error_response id (-32002) detail)
+     | Error (`Dispatch { stage; detail }) ->
+       reject t;
+       respond_json
+         `Bad_request
+         (protocol_error_response `Null (-32600) (stage ^ ": " ^ detail))
+     | Ok { response = None; _ } -> respond `Accepted ""
+     | Ok { response = Some response; _ } ->
+       let protocol_version = (snapshot t).negotiated_protocol_version in
+       respond_json ?protocol_version `OK response)
+;;
+
+let handle_post t ~tool_specs ~call_tool request body =
+  if not (content_type_is_json request)
+  then (
+    reject t;
+    respond `Unsupported_media_type "Content-Type must be application/json")
+  else
+    match content_length request with
+    | Error detail ->
+      reject t;
+      respond `Bad_request detail
+    | Ok (Some length) when length > max_body_bytes ->
+      reject t;
+      respond `Payload_too_large "MCP request body exceeds 1048576 bytes"
+    | Ok _ ->
+      (try
+         let body =
+           Eio.Buf_read.(of_flow ~max_size:max_body_bytes body |> take_all)
+         in
+         handle_message t ~tool_specs ~call_tool body
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | Eio.Buf_read.Buffer_limit_exceeded ->
+         reject t;
+         respond `Payload_too_large "MCP request body exceeds 1048576 bytes"
+       | _ ->
+         reject t;
+         respond `Bad_request "failed to read MCP request body")
+;;
+
+let request_handler t ~path ~tool_specs ~call_tool _client_addr request body =
+  if not (String.equal (Uri.path (Cohttp.Request.uri request)) path)
+  then respond `Not_found "Not found"
+  else if not (authorization_matches t request)
+  then (
+    reject t;
+    Cohttp_eio.Server.respond_string
+      ~headers:(Cohttp.Header.of_list [ "www-authenticate", "Bearer" ])
+      ~status:`Unauthorized
+      ~body:"Unauthorized"
+      ())
+  else (
+    record_authenticated_request t;
+    match Cohttp.Request.meth request with
+    | `POST -> handle_post t ~tool_specs ~call_tool request body
+    | `GET -> respond `Method_not_allowed "SSE is not enabled for this endpoint"
+    | `DELETE -> respond `No_content ""
+    | _ -> respond `Method_not_allowed "Method not allowed")
+;;
+
+let start ~sw ~net ~secure_random ~server_name ~tool_specs ~call_tool () =
+  let path_id, authorization = fresh_capabilities secure_random in
+  let path = "/mcp/" ^ path_id in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~reuse_addr:false
+      ~backlog:8
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, 0))
+  in
+  let port =
+    match Eio.Net.listening_addr socket with
+    | `Tcp (_, port) -> port
+    | `Unix _ -> assert false
+  in
+  let state =
+    { phase = Awaiting_initialize
+    ; authenticated_requests = 0
+    ; rejected_requests = 0
+    ; tool_calls = 0
+    ; negotiated_protocol_version = None
+    }
+  in
+  let t =
+    { endpoint = Printf.sprintf "http://127.0.0.1:%d%s" port path
+    ; server_name
+    ; authorization
+    ; state
+    ; state_mutex = Eio.Mutex.create ()
+    ; dispatch_mutex = Eio.Mutex.create ()
+    }
+  in
+  let server =
+    Cohttp_eio.Server.make
+      ~callback:(request_handler t ~path ~tool_specs ~call_tool)
+      ()
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    Cohttp_eio.Server.run
+      socket
+      server
+      ~on_error:(fun _ ->
+        Log.Runtime_agent.warn "official-client MCP HTTP connection failed"));
+  t
+;;

--- a/lib/runtime/runtime_official_client_mcp_http.ml
+++ b/lib/runtime/runtime_official_client_mcp_http.ml
@@ -8,6 +8,9 @@ type snapshot =
   ; authenticated_requests : int
   ; rejected_requests : int
   ; tool_calls : int
+  ; connection_failures : int
+  ; last_connection_error : string option
+  ; listener_failure : string option
   ; negotiated_protocol_version : string option
   }
 
@@ -15,6 +18,9 @@ type mutable_state =
   { mutable authenticated_requests : int
   ; mutable rejected_requests : int
   ; mutable tool_calls : int
+  ; mutable connection_failures : int
+  ; mutable last_connection_error : string option
+  ; mutable listener_failure : string option
   }
 
 type t =
@@ -57,6 +63,9 @@ let snapshot t =
       ; authenticated_requests = t.state.authenticated_requests
       ; rejected_requests = t.state.rejected_requests
       ; tool_calls = t.state.tool_calls
+      ; connection_failures = t.state.connection_failures
+      ; last_connection_error = t.state.last_connection_error
+      ; listener_failure = t.state.listener_failure
       ; negotiated_protocol_version = session.negotiated_protocol_version
       }))
 ;;
@@ -111,23 +120,63 @@ let protocol_error_response id code message =
     ]
 ;;
 
-let dispatch t ~tool_specs ~call_tool message =
-  Eio.Mutex.use_rw ~protect:true t.dispatch_mutex (fun () ->
-    match
-      Runtime_official_client_mcp.handle_message
-        ~session:t.session
-        ~server_name:t.server_name
-        ~tool_specs
-        ~call_tool
-        message
-    with
-    | Error error -> Error error
-    | Ok result ->
-      if result.tool_called
-      then
-        Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () ->
-          t.state.tool_calls <- t.state.tool_calls + 1);
-      Ok result)
+type dispatch_error =
+  | Protocol_error of Runtime_official_client_mcp.error
+  | Protocol_header_error of string
+  | Tool_inventory_failed of exn
+  | Tool_outcome_unknown of
+      { id : Yojson.Safe.t
+      ; name : string
+      ; call_id : string
+      ; cause : exn
+      }
+
+let dispatch t ~request ~tool_specs ~call_tool message =
+  match
+    Eio.Mutex.use_rw ~protect:true t.dispatch_mutex (fun () ->
+      match protocol_version_header t request with
+      | Error detail -> Error (Protocol_header_error detail)
+      | Ok () ->
+        Runtime_official_client_mcp.prepare_message
+          ~session:t.session
+          ~server_name:t.server_name
+          message
+        |> Result.map_error (fun error -> Protocol_error error))
+  with
+  | Error error -> Error error
+  | Ok (Prepared_response result) -> Ok result
+  | Ok (Prepared_tools_list { id }) ->
+    (try
+       Ok (Runtime_official_client_mcp.complete_tools_list ~id (tool_specs ()))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Tool_inventory_failed exn))
+  | Ok (Prepared_tool_call request) ->
+    (try
+       let result =
+         call_tool
+           ~name:request.name
+           ~call_id:request.call_id
+           ~arguments:request.arguments
+       in
+       let dispatch =
+         Runtime_official_client_mcp.complete_tool_call request result
+       in
+       if dispatch.tool_called
+       then
+         Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () ->
+           t.state.tool_calls <- t.state.tool_calls + 1);
+       Ok dispatch
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Tool_outcome_unknown
+            { id = request.id
+            ; name = request.name
+            ; call_id = request.call_id
+            ; cause = exn
+            }))
 ;;
 
 let update_state t f =
@@ -141,6 +190,20 @@ let reject t =
 let record_authenticated_request t =
   update_state t (fun state ->
     state.authenticated_requests <- state.authenticated_requests + 1)
+;;
+
+let record_connection_failure t exn =
+  let detail = Printexc.to_string exn in
+  update_state t (fun state ->
+    state.connection_failures <- state.connection_failures + 1;
+    state.last_connection_error <- Some detail);
+  Log.Runtime_agent.warn "official-client MCP HTTP connection failed: %s" detail
+;;
+
+let record_listener_failure t exn =
+  let detail = Printexc.to_string exn in
+  update_state t (fun state -> state.listener_failure <- Some detail);
+  Log.Runtime_agent.error "official-client MCP HTTP listener failed: %s" detail
 ;;
 
 let authorization_matches t request =
@@ -208,7 +271,7 @@ let content_length request =
   | _ :: _ :: _ -> Error "duplicate Content-Length"
 ;;
 
-let handle_message t ~tool_specs ~call_tool body =
+let handle_message t ~request ~tool_specs ~call_tool body =
   match
     try Ok (Yojson.Safe.from_string body) with
     | Yojson.Json_error detail -> Error detail
@@ -221,12 +284,36 @@ let handle_message t ~tool_specs ~call_tool body =
       `Bad_request
       (protocol_error_response `Null (-32700) ("MCP message: " ^ detail))
   | Ok message ->
-    (match dispatch t ~tool_specs ~call_tool message with
-     | Error { stage; detail } ->
+    (match dispatch t ~request ~tool_specs ~call_tool message with
+     | Error (Protocol_error { stage; detail }) ->
        reject t;
        respond_json
          `Bad_request
          (protocol_error_response `Null (-32600) (stage ^ ": " ^ detail))
+     | Error (Protocol_header_error detail) ->
+       reject t;
+       respond `Bad_request detail
+     | Error (Tool_inventory_failed exn) ->
+       reject t;
+       Log.Runtime_agent.error
+         "official-client MCP tool inventory failed: %s"
+         (Printexc.to_string exn);
+       respond_json
+         `Internal_server_error
+         (protocol_error_response `Null (-32603) "MCP tool inventory unavailable")
+     | Error (Tool_outcome_unknown { id; name; call_id; cause }) ->
+       reject t;
+       Log.Runtime_agent.error
+         "official-client MCP tool outcome unknown (tool=%s call_id=%s error=%s)"
+         name
+         call_id
+         (Printexc.to_string cause);
+       respond_json
+         `Internal_server_error
+         (protocol_error_response
+            id
+            (-32603)
+            "MCP tool outcome is unknown; do not retry this call id")
      | Ok { response = None; _ } -> respond `Accepted ""
      | Ok { response = Some response; _ } ->
        let protocol_version = (snapshot t).negotiated_protocol_version in
@@ -245,32 +332,32 @@ let handle_post t ~tool_specs ~call_tool request body =
     reject t;
     respond `Unsupported_media_type "Content-Type must be application/json")
   else
-    match protocol_version_header t request with
+    match content_length request with
     | Error detail ->
       reject t;
       respond `Bad_request detail
-    | Ok () ->
-      (match content_length request with
-       | Error detail ->
-         reject t;
-         respond `Bad_request detail
-       | Ok (Some length) when length > max_body_bytes ->
+    | Ok (Some length) when length > max_body_bytes ->
+      reject t;
+      respond `Request_entity_too_large "MCP request body exceeds 1048576 bytes"
+    | Ok _ ->
+      (match
+         try
+           Ok Eio.Buf_read.(of_flow ~max_size:max_body_bytes body |> take_all)
+         with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | Eio.Buf_read.Buffer_limit_exceeded -> Error `Too_large
+         | exn -> Error (`Read_failed exn)
+       with
+       | Error `Too_large ->
          reject t;
          respond `Request_entity_too_large "MCP request body exceeds 1048576 bytes"
-       | Ok _ ->
-         (try
-            let body =
-              Eio.Buf_read.(of_flow ~max_size:max_body_bytes body |> take_all)
-            in
-            handle_message t ~tool_specs ~call_tool body
-          with
-          | Eio.Cancel.Cancelled _ as exn -> raise exn
-          | Eio.Buf_read.Buffer_limit_exceeded ->
-            reject t;
-            respond `Request_entity_too_large "MCP request body exceeds 1048576 bytes"
-          | _ ->
-            reject t;
-            respond `Bad_request "failed to read MCP request body"))
+       | Error (`Read_failed exn) ->
+         reject t;
+         Log.Runtime_agent.warn
+           "official-client MCP request body read failed: %s"
+           (Printexc.to_string exn);
+         respond `Bad_request "failed to read MCP request body"
+       | Ok body -> handle_message t ~request ~tool_specs ~call_tool body)
 ;;
 
 let request_handler t ~path ~tool_specs ~call_tool _client_addr request body =
@@ -323,6 +410,9 @@ let start ~sw ~net ~secure_random ~server_name ~tool_specs ~call_tool () =
     { authenticated_requests = 0
     ; rejected_requests = 0
     ; tool_calls = 0
+    ; connection_failures = 0
+    ; last_connection_error = None
+    ; listener_failure = None
     }
   in
   let t =
@@ -341,10 +431,10 @@ let start ~sw ~net ~secure_random ~server_name ~tool_specs ~call_tool () =
       ()
   in
   Eio.Fiber.fork ~sw (fun () ->
-    Cohttp_eio.Server.run
-      socket
-      server
-      ~on_error:(fun _ ->
-        Log.Runtime_agent.warn "official-client MCP HTTP connection failed"));
+    try
+      Cohttp_eio.Server.run socket server ~on_error:(record_connection_failure t)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> record_listener_failure t exn);
   t
 ;;

--- a/lib/runtime/runtime_official_client_mcp_http.ml
+++ b/lib/runtime/runtime_official_client_mcp_http.ml
@@ -29,51 +29,6 @@ type t =
   }
 
 let max_body_bytes = 1024 * 1024
-let ( let* ) = Result.bind
-
-let protocol_error stage detail =
-  Error ({ Runtime_official_client_mcp.stage; detail } : Runtime_official_client_mcp.error)
-;;
-
-let rec validate_unique_object_keys ~path = function
-  | `Assoc fields ->
-    let seen = Hashtbl.create (min 64 (List.length fields)) in
-    let rec loop = function
-      | [] -> Ok ()
-      | (name, value) :: rest ->
-        if Hashtbl.mem seen name
-        then protocol_error "MCP message" (Printf.sprintf "duplicate object key %S at %s" name path)
-        else
-          let () = Hashtbl.add seen name () in
-          let* () = validate_unique_object_keys ~path:(path ^ "." ^ name) value in
-          loop rest
-    in
-    loop fields
-  | `List values ->
-    let rec loop index = function
-      | [] -> Ok ()
-      | value :: rest ->
-        let* () =
-          validate_unique_object_keys ~path:(Printf.sprintf "%s[%d]" path index) value
-        in
-        loop (index + 1) rest
-    in
-    loop 0 values
-  | `Float value when not (Float.is_finite value) ->
-    protocol_error "MCP message" (Printf.sprintf "non-finite number at %s" path)
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
-;;
-
-let parse_message text =
-  let* message =
-    try Ok (Yojson.Safe.from_string text) with
-    | Yojson.Json_error detail -> protocol_error "MCP message" ("invalid JSON: " ^ detail)
-    | Stack_overflow -> protocol_error "MCP message" "JSON nesting exceeds parser limits"
-    | Failure detail -> protocol_error "MCP message" ("invalid JSON: " ^ detail)
-  in
-  let* () = validate_unique_object_keys ~path:"$" message in
-  Ok message
-;;
 
 let hex_of_bytes bytes =
   let alphabet = "0123456789abcdef" in
@@ -155,22 +110,6 @@ let protocol_error_response id code message =
     ]
 ;;
 
-let request_method_and_id = function
-  | `Assoc fields ->
-    let method_ =
-      match List.assoc_opt "method" fields with
-      | Some (`String value) -> Some value
-      | _ -> None
-    in
-    let id =
-      match List.assoc_opt "id" fields with
-      | Some id -> id
-      | None -> `Null
-    in
-    method_, id
-  | _ -> None, `Null
-;;
-
 let initialize_protocol_version = function
   | Some (`Assoc fields) ->
     (match List.assoc_opt "result" fields with
@@ -192,50 +131,56 @@ let phase_error phase method_ =
   Printf.sprintf "MCP method %S is not valid before %s" method_ expected
 ;;
 
-let phase_admits phase method_ id =
+let phase_admits phase method_ request_id =
   match method_ with
-  | Some ("server/discover" | "initialize") ->
-    phase = Awaiting_initialize && id <> `Null
-  | Some "notifications/initialized" ->
-    phase = Awaiting_initialized && id = `Null
-  | Some ("tools/list" | "tools/call") -> phase = Ready && id <> `Null
-  | None | Some _ -> true
+  | "server/discover" | "initialize" ->
+    phase = Awaiting_initialize && Option.is_some request_id
+  | "notifications/initialized" ->
+    phase = Awaiting_initialized && Option.is_none request_id
+  | "tools/list" | "tools/call" -> phase = Ready && Option.is_some request_id
+  | _ -> true
 ;;
 
-let dispatch t ~tool_specs ~call_tool message =
+let request_id_json = function
+  | Some id -> id
+  | None -> `Null
+;;
+
+let dispatch t ~tool_specs ~call_tool raw_message =
   Eio.Mutex.use_rw ~protect:true t.dispatch_mutex (fun () ->
-    let method_, id = request_method_and_id message in
-    let phase = Eio.Mutex.use_ro t.state_mutex (fun () -> t.state.phase) in
-    if not (phase_admits phase method_ id)
-    then
-      let method_ =
-        match method_ with
-        | Some method_ -> method_
-        | None -> "<missing>"
-      in
-      Error (`Protocol (id, phase_error phase method_))
-    else
-      match
-        Runtime_official_client_mcp.handle_message
-          ~server_name:t.server_name
-          ~tool_specs
-          ~call_tool
-          message
-      with
-      | Error error -> Error (`Dispatch error)
-      | Ok result ->
-        Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () ->
-          (match t.state.phase, method_, result.response with
-           | Awaiting_initialize, Some "initialize", Some _ ->
-             t.state.phase <- Awaiting_initialized;
-             t.state.negotiated_protocol_version <-
-               initialize_protocol_version result.response
-           | Awaiting_initialized, Some "notifications/initialized", None ->
-             t.state.phase <- Ready
-           | _ -> ());
-          if result.tool_called
-          then t.state.tool_calls <- t.state.tool_calls + 1);
-        Ok result)
+    match Runtime_official_client_mcp.decode_message raw_message with
+    | Error error -> Error (`Dispatch error)
+    | Ok message ->
+      let method_ = Runtime_official_client_mcp.message_method message in
+      let request_id = Runtime_official_client_mcp.message_request_id message in
+      let phase = Eio.Mutex.use_ro t.state_mutex (fun () -> t.state.phase) in
+      if not (phase_admits phase method_ request_id)
+      then
+        Error
+          (`Protocol
+            (request_id_json request_id, phase_error phase method_))
+      else
+        (match
+           Runtime_official_client_mcp.dispatch_message
+             ~server_name:t.server_name
+             ~tool_specs
+             ~call_tool
+             message
+         with
+         | Error error -> Error (`Dispatch error)
+         | Ok result ->
+           Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () ->
+             (match t.state.phase, method_, result.response with
+              | Awaiting_initialize, "initialize", Some _ ->
+                t.state.phase <- Awaiting_initialized;
+                t.state.negotiated_protocol_version <-
+                  initialize_protocol_version result.response
+              | Awaiting_initialized, "notifications/initialized", None ->
+                t.state.phase <- Ready
+              | _ -> ());
+             if result.tool_called
+             then t.state.tool_calls <- t.state.tool_calls + 1);
+           Ok result))
 ;;
 
 let update_state t f =
@@ -280,26 +225,24 @@ let content_length request =
 ;;
 
 let handle_message t ~tool_specs ~call_tool body =
-  match parse_message body with
-  | Error { stage; detail } ->
+  match dispatch t ~tool_specs ~call_tool body with
+  | Error (`Protocol (id, detail)) ->
     reject t;
+    respond_json `Conflict (protocol_error_response id (-32002) detail)
+  | Error (`Dispatch { kind; stage; detail }) ->
+    reject t;
+    let code =
+      match kind with
+      | Runtime_official_client_mcp.Json_parse -> -32700
+      | Runtime_official_client_mcp.Protocol -> -32600
+    in
     respond_json
       `Bad_request
-      (protocol_error_response `Null (-32700) (stage ^ ": " ^ detail))
-  | Ok message ->
-    (match dispatch t ~tool_specs ~call_tool message with
-     | Error (`Protocol (id, detail)) ->
-       reject t;
-       respond_json `Conflict (protocol_error_response id (-32002) detail)
-     | Error (`Dispatch { stage; detail }) ->
-       reject t;
-       respond_json
-         `Bad_request
-         (protocol_error_response `Null (-32600) (stage ^ ": " ^ detail))
-     | Ok { response = None; _ } -> respond `Accepted ""
-     | Ok { response = Some response; _ } ->
-       let protocol_version = (snapshot t).negotiated_protocol_version in
-       respond_json ?protocol_version `OK response)
+      (protocol_error_response `Null code (stage ^ ": " ^ detail))
+  | Ok { response = None; _ } -> respond `Accepted ""
+  | Ok { response = Some response; _ } ->
+    let protocol_version = (snapshot t).negotiated_protocol_version in
+    respond_json ?protocol_version `OK response
 ;;
 
 let handle_post t ~tool_specs ~call_tool request body =

--- a/lib/runtime/runtime_official_client_mcp_http.ml
+++ b/lib/runtime/runtime_official_client_mcp_http.ml
@@ -29,6 +29,51 @@ type t =
   }
 
 let max_body_bytes = 1024 * 1024
+let ( let* ) = Result.bind
+
+let protocol_error stage detail =
+  Error ({ Runtime_official_client_mcp.stage; detail } : Runtime_official_client_mcp.error)
+;;
+
+let rec validate_unique_object_keys ~path = function
+  | `Assoc fields ->
+    let seen = Hashtbl.create (min 64 (List.length fields)) in
+    let rec loop = function
+      | [] -> Ok ()
+      | (name, value) :: rest ->
+        if Hashtbl.mem seen name
+        then protocol_error "MCP message" (Printf.sprintf "duplicate object key %S at %s" name path)
+        else
+          let () = Hashtbl.add seen name () in
+          let* () = validate_unique_object_keys ~path:(path ^ "." ^ name) value in
+          loop rest
+    in
+    loop fields
+  | `List values ->
+    let rec loop index = function
+      | [] -> Ok ()
+      | value :: rest ->
+        let* () =
+          validate_unique_object_keys ~path:(Printf.sprintf "%s[%d]" path index) value
+        in
+        loop (index + 1) rest
+    in
+    loop 0 values
+  | `Float value when not (Float.is_finite value) ->
+    protocol_error "MCP message" (Printf.sprintf "non-finite number at %s" path)
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
+;;
+
+let parse_message text =
+  let* message =
+    try Ok (Yojson.Safe.from_string text) with
+    | Yojson.Json_error detail -> protocol_error "MCP message" ("invalid JSON: " ^ detail)
+    | Stack_overflow -> protocol_error "MCP message" "JSON nesting exceeds parser limits"
+    | Failure detail -> protocol_error "MCP message" ("invalid JSON: " ^ detail)
+  in
+  let* () = validate_unique_object_keys ~path:"$" message in
+  Ok message
+;;
 
 let hex_of_bytes bytes =
   let alphabet = "0123456789abcdef" in
@@ -117,7 +162,12 @@ let request_method_and_id = function
       | Some (`String value) -> Some value
       | _ -> None
     in
-    method_, Option.value (List.assoc_opt "id" fields) ~default:`Null
+    let id =
+      match List.assoc_opt "id" fields with
+      | Some id -> id
+      | None -> `Null
+    in
+    method_, id
   | _ -> None, `Null
 ;;
 
@@ -158,7 +208,11 @@ let dispatch t ~tool_specs ~call_tool message =
     let phase = Eio.Mutex.use_ro t.state_mutex (fun () -> t.state.phase) in
     if not (phase_admits phase method_ id)
     then
-      let method_ = Option.value method_ ~default:"<missing>" in
+      let method_ =
+        match method_ with
+        | Some method_ -> method_
+        | None -> "<missing>"
+      in
       Error (`Protocol (id, phase_error phase method_))
     else
       match
@@ -226,7 +280,7 @@ let content_length request =
 ;;
 
 let handle_message t ~tool_specs ~call_tool body =
-  match Runtime_official_client_mcp.parse_message body with
+  match parse_message body with
   | Error { stage; detail } ->
     reject t;
     respond_json

--- a/lib/runtime/runtime_official_client_mcp_http.mli
+++ b/lib/runtime/runtime_official_client_mcp_http.mli
@@ -5,7 +5,7 @@
     Eio switch. Closing the turn switch closes the listener and all accepted
     connections. *)
 
-type phase =
+type phase = Runtime_official_client_mcp.phase =
   | Awaiting_initialize
   | Awaiting_initialized
   | Ready

--- a/lib/runtime/runtime_official_client_mcp_http.mli
+++ b/lib/runtime/runtime_official_client_mcp_http.mli
@@ -15,6 +15,9 @@ type snapshot =
   ; authenticated_requests : int
   ; rejected_requests : int
   ; tool_calls : int
+  ; connection_failures : int
+  ; last_connection_error : string option
+  ; listener_failure : string option
   ; negotiated_protocol_version : string option
   }
 

--- a/lib/runtime/runtime_official_client_mcp_http.mli
+++ b/lib/runtime/runtime_official_client_mcp_http.mli
@@ -1,0 +1,43 @@
+(** Turn-scoped loopback MCP transport for official subscription clients.
+
+    The listener binds only to IPv4 loopback on an ephemeral port, requires an
+    independently generated Bearer capability, and is owned by the caller's
+    Eio switch. Closing the turn switch closes the listener and all accepted
+    connections. *)
+
+type phase =
+  | Awaiting_initialize
+  | Awaiting_initialized
+  | Ready
+
+type snapshot =
+  { phase : phase
+  ; authenticated_requests : int
+  ; rejected_requests : int
+  ; tool_calls : int
+  ; negotiated_protocol_version : string option
+  }
+
+type t
+
+val start :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  secure_random:Eio.Flow.source_ty Eio.Resource.t ->
+  server_name:string ->
+  tool_specs:(unit -> Yojson.Safe.t list) ->
+  call_tool:
+    (name:string ->
+     call_id:string ->
+     arguments:Yojson.Safe.t ->
+     Runtime_official_client_mcp.tool_result option) ->
+  unit ->
+  t
+
+(** Exact remote-MCP configuration measured against Antigravity CLI 1.1.11.
+    The returned JSON contains the ephemeral capability and must not be logged
+    or persisted after the turn. *)
+val mcp_config_json : t -> Yojson.Safe.t
+
+val endpoint : t -> string
+val snapshot : t -> snapshot

--- a/test/dune
+++ b/test/dune
@@ -1941,6 +1941,7 @@
 (include stanzas/test_runtime_codex_app_server.inc)
 (include stanzas/test_runtime_claude_code.inc)
 (include stanzas/test_runtime_antigravity.inc)
+(include stanzas/test_runtime_official_client_mcp_http.inc)
 (include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/stanzas/test_runtime_official_client_mcp_http.inc
+++ b/test/stanzas/test_runtime_official_client_mcp_http.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_official_client_mcp_http)
+ (modules test_runtime_official_client_mcp_http)
+ (libraries masc masc_test_deps))

--- a/test/test_runtime_official_client_mcp_http.ml
+++ b/test/test_runtime_official_client_mcp_http.ml
@@ -102,6 +102,36 @@ let json_request id method_ params =
 
 let member name json = Yojson.Safe.Util.member name json
 
+let initialize_session ~sw ~net ~endpoint ~authorization =
+  let protocol_version = "2025-11-25" in
+  let initialize =
+    json_request
+      1
+      "initialize"
+      (`Assoc
+         [ "protocolVersion", `String protocol_version
+         ; ( "clientInfo"
+           , `Assoc [ "name", `String "test-client"; "version", `String "1" ] )
+         ; "capabilities", `Assoc []
+         ])
+  in
+  let initialized =
+    request ~sw ~net ~endpoint ~authorization initialize
+  in
+  check int "initialize" 200 initialized.status;
+  let notified =
+    request
+      ~protocol_version
+      ~sw
+      ~net
+      ~endpoint
+      ~authorization
+      {|{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}|}
+  in
+  check int "initialized notification" 202 notified.status;
+  protocol_version
+;;
+
 let test_turn_scoped_capability_and_protocol () =
   Eio_main.run
   @@ fun env ->
@@ -334,6 +364,85 @@ let test_turn_scoped_capability_and_protocol () =
     snapshot.negotiated_protocol_version
 ;;
 
+let test_callback_failures_do_not_poison_protocol_state () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let effects = ref 0 in
+  let inventory_fails = ref false in
+  let tool_specs () =
+    if !inventory_fails
+    then failwith "inventory exploded"
+    else [ `Assoc [ "name", `String "masc_effect" ] ]
+  in
+  let call_tool ~name:_ ~call_id:_ ~arguments:_ =
+    incr effects;
+    failwith "effect applied before callback failure"
+  in
+  let bridge =
+    Runtime_official_client_mcp_http.start
+      ~sw
+      ~net:env#net
+      ~secure_random:env#secure_random
+      ~server_name:"masc"
+      ~tool_specs
+      ~call_tool
+      ()
+  in
+  let endpoint, authorization = config_fields bridge in
+  let protocol_version =
+    initialize_session ~sw ~net:env#net ~endpoint ~authorization
+  in
+  let call =
+    request
+      ~protocol_version
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request
+         2
+         "tools/call"
+         (`Assoc [ "name", `String "masc_effect"; "arguments", `Assoc [] ]))
+  in
+  check int "unknown tool outcome is a server failure" 500 call.status;
+  check int
+    "typed internal JSON-RPC error"
+    (-32603)
+    (Yojson.Safe.from_string call.body
+     |> member "error"
+     |> member "code"
+     |> Yojson.Safe.Util.to_int);
+  check int "effect ran exactly once" 1 !effects;
+  inventory_fails := true;
+  let unavailable =
+    request
+      ~protocol_version
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 3 "tools/list" (`Assoc []))
+  in
+  check int "inventory failure is a server failure" 500 unavailable.status;
+  inventory_fails := false;
+  let recovered =
+    request
+      ~protocol_version
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 4 "tools/list" (`Assoc []))
+  in
+  check int "callback failure did not poison protocol mutex" 200 recovered.status;
+  let snapshot = Runtime_official_client_mcp_http.snapshot bridge in
+  check bool "session remains ready" true (snapshot.phase = Ready);
+  check int "failed effect is not counted as completed" 0 snapshot.tool_calls;
+  check int "callback failures are observable rejections" 2 snapshot.rejected_requests
+;;
+
 let () =
   run
     "runtime_official_client_mcp_http"
@@ -342,6 +451,12 @@ let () =
             "capability, protocol, phase, and tool callback"
             `Quick
             test_turn_scoped_capability_and_protocol
+        ] )
+    ; ( "effect boundary"
+      , [ test_case
+            "callback failures remain typed and do not poison lifecycle"
+            `Quick
+            test_callback_failures_do_not_poison_protocol_state
         ] )
     ]
 ;;

--- a/test/test_runtime_official_client_mcp_http.ml
+++ b/test/test_runtime_official_client_mcp_http.ml
@@ -1,0 +1,261 @@
+open Alcotest
+
+type response =
+  { status : int
+  ; body : string
+  }
+
+let config_fields bridge =
+  let open Yojson.Safe.Util in
+  let config = Runtime_official_client_mcp_http.mcp_config_json bridge in
+  let server = config |> member "mcpServers" |> member "masc" in
+  let endpoint = server |> member "url" |> to_string in
+  let authorization =
+    server |> member "headers" |> member "Authorization" |> to_string
+  in
+  endpoint, authorization
+;;
+
+let rec read_headers reader content_length =
+  let line = Eio.Buf_read.line reader in
+  if String.equal line "\r" || String.equal line ""
+  then content_length
+  else
+    let content_length =
+      match String.index_opt line ':' with
+      | None -> content_length
+      | Some index ->
+        let name =
+          String.sub line 0 index |> String.trim |> String.lowercase_ascii
+        in
+        if not (String.equal name "content-length")
+        then content_length
+        else
+          String.sub line (index + 1) (String.length line - index - 1)
+          |> String.trim
+          |> int_of_string
+    in
+    read_headers reader content_length
+;;
+
+let request ~sw ~net ~endpoint ~authorization body =
+  let uri = Uri.of_string endpoint in
+  let port = Uri.port uri |> Option.get in
+  let path = Uri.path uri in
+  let flow =
+    Eio.Net.connect ~sw net (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  Eio.Flow.copy_string
+    (Printf.sprintf
+       "POST %s HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nAuthorization: %s\r\nContent-Type: application/json\r\nAccept: application/json, text/event-stream\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"
+       path
+       port
+       authorization
+       (String.length body)
+       body)
+    flow;
+  let reader = Eio.Buf_read.of_flow ~max_size:(2 * 1024 * 1024) flow in
+  let status_line = Eio.Buf_read.line reader in
+  let status =
+    match String.split_on_char ' ' status_line with
+    | _version :: code :: _ -> int_of_string code
+    | _ -> failf "invalid HTTP status line: %S" status_line
+  in
+  let content_length = read_headers reader 0 in
+  { status; body = Eio.Buf_read.take content_length reader }
+;;
+
+let json_request id method_ params =
+  `Assoc
+    [ "jsonrpc", `String "2.0"
+    ; "id", `Int id
+    ; "method", `String method_
+    ; "params", params
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let member name json = Yojson.Safe.Util.member name json
+
+let test_turn_scoped_capability_and_protocol () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let calls = ref [] in
+  let tool_specs () =
+    [ `Assoc
+        [ "name", `String "masc_probe"
+        ; "description", `String "Return a marker"
+        ; "inputSchema", `Assoc [ "type", `String "object" ]
+        ]
+    ]
+  in
+  let call_tool ~name ~call_id ~arguments =
+    calls := (name, call_id, arguments) :: !calls;
+    Some
+      { Runtime_official_client_mcp.success = true
+      ; content = "MASC_TOOL_OK"
+      }
+  in
+  let bridge =
+    Runtime_official_client_mcp_http.start
+      ~sw
+      ~net:env#net
+      ~secure_random:env#secure_random
+      ~server_name:"masc"
+      ~tool_specs
+      ~call_tool
+      ()
+  in
+  let endpoint, authorization = config_fields bridge in
+  let initialize =
+    json_request
+      2
+      "initialize"
+      (`Assoc
+         [ "protocolVersion", `String "2025-11-25"
+         ; ( "clientInfo"
+           , `Assoc
+               [ "name", `String "antigravity-client"
+               ; "version", `String "v1.0.0"
+               ] )
+         ; "capabilities", `Assoc []
+         ])
+  in
+  let unauthorized =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization:"Bearer wrong"
+      initialize
+  in
+  check int "wrong capability" 401 unauthorized.status;
+  let discover =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 1 "server/discover" (`Assoc []))
+  in
+  check int "discovery extension is an exact JSON-RPC miss" 200 discover.status;
+  check int
+    "discovery error"
+    (-32601)
+    (Yojson.Safe.from_string discover.body
+     |> member "error"
+     |> member "code"
+     |> Yojson.Safe.Util.to_int);
+  let initialized =
+    request ~sw ~net:env#net ~endpoint ~authorization initialize
+  in
+  check int "initialize" 200 initialized.status;
+  check string
+    "negotiated measured protocol"
+    "2025-11-25"
+    (Yojson.Safe.from_string initialized.body
+     |> member "result"
+     |> member "protocolVersion"
+     |> Yojson.Safe.Util.to_string);
+  let call_params =
+    `Assoc
+      [ "name", `String "masc_probe"
+      ; "arguments", `Assoc [ "marker", `String "measured" ]
+      ]
+  in
+  let premature =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 3 "tools/call" call_params)
+  in
+  check int "tool call before initialized notification" 409 premature.status;
+  check int "premature call not executed" 0 (List.length !calls);
+  let notification =
+    {|{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}|}
+  in
+  let notified =
+    request ~sw ~net:env#net ~endpoint ~authorization notification
+  in
+  check int "initialized notification" 202 notified.status;
+  let listed =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 4 "tools/list" (`Assoc []))
+  in
+  check int "tools/list" 200 listed.status;
+  check string
+    "turn tool"
+    "masc_probe"
+    (Yojson.Safe.from_string listed.body
+     |> member "result"
+     |> member "tools"
+     |> Yojson.Safe.Util.to_list
+     |> List.hd
+     |> member "name"
+     |> Yojson.Safe.Util.to_string);
+  let called =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 5 "tools/call" call_params)
+  in
+  check int "tools/call" 200 called.status;
+  check string
+    "tool result"
+    "MASC_TOOL_OK"
+    (Yojson.Safe.from_string called.body
+     |> member "result"
+     |> member "content"
+     |> Yojson.Safe.Util.to_list
+     |> List.hd
+     |> member "text"
+     |> Yojson.Safe.Util.to_string);
+  let duplicate_key =
+    {|{"jsonrpc":"2.0","id":6,"method":"tools/call","method":"tools/call","params":{"name":"masc_probe"}}|}
+  in
+  let duplicate =
+    request
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      duplicate_key
+  in
+  check int "duplicate JSON key" 400 duplicate.status;
+  check int "only admitted call executed" 1 (List.length !calls);
+  let snapshot = Runtime_official_client_mcp_http.snapshot bridge in
+  check bool
+    "ready"
+    true
+    (snapshot.phase = Runtime_official_client_mcp_http.Ready);
+  check int "authenticated requests" 7 snapshot.authenticated_requests;
+  check int "rejected requests" 3 snapshot.rejected_requests;
+  check int "measured tool calls" 1 snapshot.tool_calls;
+  check
+    (option string)
+    "protocol evidence"
+    (Some "2025-11-25")
+    snapshot.negotiated_protocol_version
+;;
+
+let () =
+  run
+    "runtime_official_client_mcp_http"
+    [ ( "turn-scoped transport"
+      , [ test_case
+            "capability, protocol, phase, and tool callback"
+            `Quick
+            test_turn_scoped_capability_and_protocol
+        ] )
+    ]
+;;

--- a/test/test_runtime_official_client_mcp_http.ml
+++ b/test/test_runtime_official_client_mcp_http.ml
@@ -38,20 +38,45 @@ let rec read_headers reader content_length =
     read_headers reader content_length
 ;;
 
-let request ~sw ~net ~endpoint ~authorization body =
+let request
+      ?(method_ = "POST")
+      ?(accept = Some "application/json, text/event-stream")
+      ?origin
+      ?protocol_version
+      ~sw
+      ~net
+      ~endpoint
+      ~authorization
+      body
+  =
   let uri = Uri.of_string endpoint in
   let port = Uri.port uri |> Option.get in
   let path = Uri.path uri in
   let flow =
     Eio.Net.connect ~sw net (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
   in
+  let optional_header name = function
+    | None -> []
+    | Some value -> [ Printf.sprintf "%s: %s" name value ]
+  in
+  let headers =
+    [ Printf.sprintf "Host: 127.0.0.1:%d" port
+    ; "Authorization: " ^ authorization
+    ; "Content-Type: application/json"
+    ]
+    @ optional_header "Accept" accept
+    @ optional_header "Origin" origin
+    @ optional_header "MCP-Protocol-Version" protocol_version
+    @ [ Printf.sprintf "Content-Length: %d" (String.length body)
+      ; "Connection: close"
+      ]
+  in
   Eio.Flow.copy_string
     (Printf.sprintf
-       "POST %s HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nAuthorization: %s\r\nContent-Type: application/json\r\nAccept: application/json, text/event-stream\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"
+       "%s %s HTTP/1.1\r\n%s\r\n\r\n%s"
+       method_
        path
-       port
-       authorization
-       (String.length body)
+       (String.concat "\r\n" headers)
        body)
     flow;
   let reader = Eio.Buf_read.of_flow ~max_size:(2 * 1024 * 1024) flow in
@@ -109,12 +134,13 @@ let test_turn_scoped_capability_and_protocol () =
       ()
   in
   let endpoint, authorization = config_fields bridge in
+  let protocol_version = "2025-11-25" in
   let initialize =
     json_request
       2
       "initialize"
       (`Assoc
-         [ "protocolVersion", `String "2025-11-25"
+         [ "protocolVersion", `String protocol_version
          ; ( "clientInfo"
            , `Assoc
                [ "name", `String "antigravity-client"
@@ -132,6 +158,26 @@ let test_turn_scoped_capability_and_protocol () =
       initialize
   in
   check int "wrong capability" 401 unauthorized.status;
+  let cross_origin =
+    request
+      ~origin:"https://attacker.example"
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      initialize
+  in
+  check int "explicit browser origin" 403 cross_origin.status;
+  let missing_accept =
+    request
+      ~accept:None
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      initialize
+  in
+  check int "streamable Accept is required" 406 missing_accept.status;
   let discover =
     request
       ~sw
@@ -154,7 +200,7 @@ let test_turn_scoped_capability_and_protocol () =
   check int "initialize" 200 initialized.status;
   check string
     "negotiated measured protocol"
-    "2025-11-25"
+    protocol_version
     (Yojson.Safe.from_string initialized.body
      |> member "result"
      |> member "protocolVersion"
@@ -165,7 +211,7 @@ let test_turn_scoped_capability_and_protocol () =
       ; "arguments", `Assoc [ "marker", `String "measured" ]
       ]
   in
-  let premature =
+  let missing_protocol_header =
     request
       ~sw
       ~net:env#net
@@ -173,17 +219,44 @@ let test_turn_scoped_capability_and_protocol () =
       ~authorization
       (json_request 3 "tools/call" call_params)
   in
-  check int "tool call before initialized notification" 409 premature.status;
+  check int "subsequent protocol header is required" 400 missing_protocol_header.status;
+  let mismatched_protocol_header =
+    request
+      ~protocol_version:"2024-11-05"
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 3 "tools/call" call_params)
+  in
+  check int "mismatched protocol header" 400 mismatched_protocol_header.status;
+  let premature =
+    request
+      ~protocol_version
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 3 "tools/call" call_params)
+  in
+  check int "tool call before initialized notification" 400 premature.status;
   check int "premature call not executed" 0 (List.length !calls);
   let notification =
     {|{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}|}
   in
   let notified =
-    request ~sw ~net:env#net ~endpoint ~authorization notification
+    request
+      ~protocol_version
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      notification
   in
   check int "initialized notification" 202 notified.status;
   let listed =
     request
+      ~protocol_version
       ~sw
       ~net:env#net
       ~endpoint
@@ -203,6 +276,7 @@ let test_turn_scoped_capability_and_protocol () =
      |> Yojson.Safe.Util.to_string);
   let called =
     request
+      ~protocol_version
       ~sw
       ~net:env#net
       ~endpoint
@@ -225,6 +299,7 @@ let test_turn_scoped_capability_and_protocol () =
   in
   let duplicate =
     request
+      ~protocol_version
       ~sw
       ~net:env#net
       ~endpoint
@@ -232,14 +307,25 @@ let test_turn_scoped_capability_and_protocol () =
       duplicate_key
   in
   check int "duplicate JSON key" 400 duplicate.status;
+  let deletion =
+    request
+      ~method_:"DELETE"
+      ~protocol_version
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      ""
+  in
+  check int "unsupported session deletion" 405 deletion.status;
   check int "only admitted call executed" 1 (List.length !calls);
   let snapshot = Runtime_official_client_mcp_http.snapshot bridge in
   check bool
     "ready"
     true
     (snapshot.phase = Runtime_official_client_mcp_http.Ready);
-  check int "authenticated requests" 7 snapshot.authenticated_requests;
-  check int "rejected requests" 3 snapshot.rejected_requests;
+  check int "authenticated requests" 11 snapshot.authenticated_requests;
+  check int "rejected requests" 8 snapshot.rejected_requests;
   check int "measured tool calls" 1 snapshot.tool_calls;
   check
     (option string)


### PR DESCRIPTION
## Summary

- bind a per-turn MCP endpoint to IPv4 loopback on an ephemeral port
- require independent random path and Bearer capabilities
- enforce initialize -> initialized -> tools lifecycle before MASC callbacks
- expose exact request, rejection, negotiated-protocol, and tool-call evidence
- emit the remote-MCP JSON shape measured against Antigravity CLI 1.1.11

## Measured wire

Antigravity 1.1.11 sent `server/discover`, MCP `initialize` with protocol `2025-11-25`, `notifications/initialized`, `tools/list`, and `tools/call`. The client tolerated the exact `-32601` discovery-extension response and a `405` GET response, then completed the MASC tool call over authenticated POST.

## Safety boundary

- listener exists only under the caller turn switch
- no public bind and no global MASC tool inventory
- 1 MiB raw body cap and strict duplicate-key rejection
- wrong capability and out-of-phase calls cannot execute callbacks
- generated MCP config contains an ephemeral secret and is explicitly non-persistent

## Verification

- parser-only OCaml checks passed
- CI target audit passed at the 701-suite baseline
- `git diff --check` passed
- focused/full build delegated to CI per operator request

## Not included

This PR does not yet create the isolated Antigravity HOME or spawn `agy`; that stays in the next small client-adapter slice.

Supersedes closed stacked PR #27803 after its parent was merged and GitHub declined reopening it.
