### PR TITLE
feat(runtime): prepare isolated Antigravity home

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1559,7 +1559,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_keeper_official_client_host @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code @test/runtest-test_runtime_official_client_mcp_http"
+          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_keeper_official_client_host @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code @test/runtest-test_runtime_official_client_mcp_http @test/runtest-test_runtime_antigravity_home"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${official_client_targets}"
 
       - name: Run host FD pressure contract suite

--- a/lib/runtime/runtime_antigravity_home.ml
+++ b/lib/runtime/runtime_antigravity_home.ml
@@ -1,0 +1,323 @@
+type error =
+  | Invalid_runtime_root of string
+  | Invalid_owner_leaf of string
+  | Unsafe_directory of
+      { path : string
+      ; detail : string
+      }
+  | Invalid_oauth_source of
+      { path : string
+      ; detail : string
+      }
+  | Invalid_oauth_link of
+      { path : string
+      ; detail : string
+      }
+  | Settings_write_failed of
+      { path : string
+      ; detail : string
+      }
+
+type t =
+  { home_dir : string
+  ; workspace_dir : string
+  ; settings_path : string
+  ; mcp_config_path : string
+  ; oauth_link_path : string
+  }
+
+let error_to_string = function
+  | Invalid_runtime_root detail -> "invalid Antigravity runtime root: " ^ detail
+  | Invalid_owner_leaf owner_leaf ->
+    Printf.sprintf "invalid Antigravity owner leaf %S" owner_leaf
+  | Unsafe_directory { path; detail } ->
+    Printf.sprintf "unsafe Antigravity directory %s: %s" path detail
+  | Invalid_oauth_source { path; detail } ->
+    Printf.sprintf "invalid Antigravity OAuth source %s: %s" path detail
+  | Invalid_oauth_link { path; detail } ->
+    Printf.sprintf "invalid Antigravity OAuth link %s: %s" path detail
+  | Settings_write_failed { path; detail } ->
+    Printf.sprintf "failed to write Antigravity settings %s: %s" path detail
+;;
+
+let unix_error_detail error fn arg =
+  Printf.sprintf
+    "%s%s%s"
+    (Unix.error_message error)
+    (if String.equal fn "" then "" else ": " ^ fn)
+    (if String.equal arg "" then "" else " " ^ arg)
+;;
+
+let file_kind_name = function
+  | Unix.S_REG -> "regular_file"
+  | Unix.S_DIR -> "directory"
+  | Unix.S_CHR -> "character_device"
+  | Unix.S_BLK -> "block_device"
+  | Unix.S_LNK -> "symbolic_link"
+  | Unix.S_FIFO -> "fifo"
+  | Unix.S_SOCK -> "socket"
+;;
+
+let effective_uid = Unix.geteuid ()
+
+let verify_runtime_root path =
+  if Filename.is_relative path
+  then Error (Invalid_runtime_root "path must be absolute")
+  else
+    try
+      let stat = Unix.lstat path in
+      if stat.Unix.st_kind <> Unix.S_DIR
+      then
+        Error
+          (Invalid_runtime_root
+             (Printf.sprintf
+                "%s has kind %s"
+                path
+                (file_kind_name stat.Unix.st_kind)))
+      else if stat.Unix.st_uid <> effective_uid
+      then
+        Error
+          (Invalid_runtime_root
+             (Printf.sprintf
+                "%s is owned by uid %d, expected %d"
+                path
+                stat.Unix.st_uid
+                effective_uid))
+      else Ok ()
+    with
+    | Unix.Unix_error (error, fn, arg) ->
+      Error (Invalid_runtime_root (unix_error_detail error fn arg))
+;;
+
+let verify_private_directory path =
+  try
+    let stat = Unix.lstat path in
+    if stat.Unix.st_kind <> Unix.S_DIR
+    then
+      Error
+        (Unsafe_directory
+           { path
+           ; detail = "expected directory, found " ^ file_kind_name stat.Unix.st_kind
+           })
+    else if stat.Unix.st_uid <> effective_uid
+    then
+      Error
+        (Unsafe_directory
+           { path
+           ; detail =
+               Printf.sprintf
+                 "owned by uid %d, expected %d"
+                 stat.Unix.st_uid
+                 effective_uid
+           })
+    else
+      let mode = stat.Unix.st_perm land 0o7777 in
+      if mode <> 0o700
+      then
+        Error
+          (Unsafe_directory
+             { path
+             ; detail = Printf.sprintf "mode is %04o, expected 0700" mode
+             })
+      else Ok ()
+  with
+  | Unix.Unix_error (error, fn, arg) ->
+    Error (Unsafe_directory { path; detail = unix_error_detail error fn arg })
+;;
+
+let ensure_private_child parent leaf =
+  let path = Filename.concat parent leaf in
+  let created =
+    try
+      Unix.mkdir path 0o700;
+      Ok ()
+    with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> Ok ()
+    | Unix.Unix_error (error, fn, arg) ->
+      Error (Unsafe_directory { path; detail = unix_error_detail error fn arg })
+  in
+  match created with
+  | Error _ as error -> error
+  | Ok () -> Result.map (fun () -> path) (verify_private_directory path)
+;;
+
+let settings_json () =
+  `Assoc
+    [ ( "permissions"
+      , `Assoc
+          [ "allow", `List [ `String "mcp(masc/*)" ]
+          ; ( "deny"
+            , `List
+                (List.map
+                   (fun permission -> `String permission)
+                   [ "read_file(*)"
+                   ; "write_file(*)"
+                   ; "read_url(*)"
+                   ; "execute_url(*)"
+                   ; "command(*)"
+                   ; "unsandboxed(*)"
+                   ]) )
+          ] )
+    ; "toolPermission", `String "request-review"
+    ]
+;;
+
+let write_private_settings path =
+  let contents = settings_json () |> Yojson.Safe.pretty_to_string in
+  match Fs_compat.save_file_atomic_strict path contents with
+  | Error detail -> Error (Settings_write_failed { path; detail })
+  | Ok () ->
+    (try
+       Unix.chmod path 0o600;
+       let stat = Unix.lstat path in
+       let mode = stat.Unix.st_perm land 0o7777 in
+       if stat.Unix.st_kind <> Unix.S_REG
+       then
+         Error
+           (Settings_write_failed
+              { path
+              ; detail = "expected regular file, found " ^ file_kind_name stat.Unix.st_kind
+              })
+       else if stat.Unix.st_uid <> effective_uid || mode <> 0o600
+       then
+         Error
+           (Settings_write_failed
+              { path
+              ; detail =
+                  Printf.sprintf
+                    "owner/mode mismatch: uid=%d mode=%04o"
+                    stat.Unix.st_uid
+                    mode
+              })
+       else Ok ()
+     with
+     | Unix.Unix_error (error, fn, arg) ->
+       Error
+         (Settings_write_failed
+            { path; detail = unix_error_detail error fn arg }))
+;;
+
+let validate_oauth_source path =
+  if Filename.is_relative path
+  then Error (Invalid_oauth_source { path; detail = "path must be absolute" })
+  else
+    try
+      let lexical_stat = Unix.lstat path in
+      if lexical_stat.Unix.st_kind <> Unix.S_REG
+      then
+        Error
+          (Invalid_oauth_source
+             { path
+             ; detail =
+                 "expected regular file, found "
+                 ^ file_kind_name lexical_stat.Unix.st_kind
+             })
+      else
+        let canonical_path = Unix.realpath path in
+        let stat = Unix.lstat canonical_path in
+        if
+          stat.Unix.st_kind <> Unix.S_REG
+          || stat.Unix.st_dev <> lexical_stat.Unix.st_dev
+          || stat.Unix.st_ino <> lexical_stat.Unix.st_ino
+        then
+          Error
+            (Invalid_oauth_source
+               { path; detail = "file identity changed while resolving the source" })
+        else if stat.Unix.st_uid <> effective_uid
+      then
+        Error
+          (Invalid_oauth_source
+             { path
+             ; detail =
+                 Printf.sprintf
+                   "owned by uid %d, expected %d"
+                   stat.Unix.st_uid
+                   effective_uid
+             })
+      else
+        let mode = stat.Unix.st_perm land 0o7777 in
+        if mode <> 0o600
+        then
+          Error
+            (Invalid_oauth_source
+               { path
+               ; detail = Printf.sprintf "mode is %04o, expected 0600" mode
+               })
+        else Ok canonical_path
+    with
+    | Unix.Unix_error (error, fn, arg) ->
+      Error
+        (Invalid_oauth_source
+           { path; detail = unix_error_detail error fn arg })
+;;
+
+let ensure_oauth_link ~source path =
+  let verify () =
+    try
+      let stat = Unix.lstat path in
+      if stat.Unix.st_kind <> Unix.S_LNK
+      then
+        Error
+          (Invalid_oauth_link
+             { path
+             ; detail = "expected symbolic link, found " ^ file_kind_name stat.Unix.st_kind
+             })
+      else
+        let target = Unix.readlink path in
+        if String.equal target source
+        then Ok ()
+        else
+          Error
+            (Invalid_oauth_link
+               { path
+               ; detail = Printf.sprintf "target is %S, expected %S" target source
+               })
+    with
+    | Unix.Unix_error (error, fn, arg) ->
+      Error
+        (Invalid_oauth_link
+           { path; detail = unix_error_detail error fn arg })
+  in
+  try
+    match Unix.lstat path with
+    | _ -> verify ()
+    | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+      (try
+         Unix.symlink source path;
+         verify ()
+       with
+       | Unix.Unix_error (error, fn, arg) ->
+         Error
+           (Invalid_oauth_link
+              { path; detail = unix_error_detail error fn arg }))
+  with
+  | Unix.Unix_error (error, fn, arg) ->
+    Error
+      (Invalid_oauth_link
+         { path; detail = unix_error_detail error fn arg })
+;;
+
+let ( let* ) = Result.bind
+
+let prepare ~runtime_root ~owner_leaf ~oauth_source =
+  if not (Fs_compat.is_capability_leaf owner_leaf)
+  then Error (Invalid_owner_leaf owner_leaf)
+  else
+    let* () = verify_runtime_root runtime_root in
+    let* oauth_source = validate_oauth_source oauth_source in
+    let* official_clients = ensure_private_child runtime_root "official-clients" in
+    let* antigravity_root = ensure_private_child official_clients "antigravity" in
+    let* home_dir = ensure_private_child antigravity_root owner_leaf in
+    let* workspace_dir = ensure_private_child home_dir "workspace" in
+    let* gemini_dir = ensure_private_child home_dir ".gemini" in
+    let* cli_dir = ensure_private_child gemini_dir "antigravity-cli" in
+    let* config_dir = ensure_private_child gemini_dir "config" in
+    let settings_path = Filename.concat cli_dir "settings.json" in
+    let mcp_config_path = Filename.concat config_dir "mcp_config.json" in
+    let oauth_link_path = Filename.concat cli_dir "antigravity-oauth-token" in
+    let* () = write_private_settings settings_path in
+    let* () = ensure_oauth_link ~source:oauth_source oauth_link_path in
+    Ok { home_dir; workspace_dir; settings_path; mcp_config_path; oauth_link_path }
+;;
+
+let child_environment t = [ "HOME", t.home_dir ]

--- a/lib/runtime/runtime_antigravity_home.mli
+++ b/lib/runtime/runtime_antigravity_home.mli
@@ -1,0 +1,53 @@
+(** Persistent, operator-owned HOME layout for the official Antigravity CLI.
+
+    This module never reads or copies the OAuth token. It validates the
+    operator token file and installs only a symbolic link inside the isolated
+    HOME. Turn-scoped MCP configuration is deliberately owned by the caller. *)
+
+type error =
+  | Invalid_runtime_root of string
+  | Invalid_owner_leaf of string
+  | Unsafe_directory of
+      { path : string
+      ; detail : string
+      }
+  | Invalid_oauth_source of
+      { path : string
+      ; detail : string
+      }
+  | Invalid_oauth_link of
+      { path : string
+      ; detail : string
+      }
+  | Settings_write_failed of
+      { path : string
+      ; detail : string
+      }
+
+type t = private
+  { home_dir : string
+  ; workspace_dir : string
+  ; settings_path : string
+  ; mcp_config_path : string
+  ; oauth_link_path : string
+  }
+
+val error_to_string : error -> string
+
+val prepare
+  :  runtime_root:string
+  -> owner_leaf:string
+  -> oauth_source:string
+  -> (t, error) result
+(** Create or verify the private Antigravity HOME below
+    [<runtime_root>/official-clients/antigravity/<owner_leaf>]. Every managed
+    directory is an exact 0700 real directory owned by the effective user.
+    [oauth_source] must resolve to an effective-user-owned regular 0600 file.
+    An unexpected existing OAuth target is rejected without replacement. *)
+
+val child_environment : t -> (string * string) list
+(** Exact environment overrides for the child. No API key or OAuth token value
+    is included. *)
+
+val settings_json : unit -> Yojson.Safe.t
+(** Exact deny-by-default settings measured against Antigravity CLI 1.1.11. *)

--- a/test/dune
+++ b/test/dune
@@ -1942,6 +1942,7 @@
 (include stanzas/test_runtime_claude_code.inc)
 (include stanzas/test_runtime_antigravity.inc)
 (include stanzas/test_runtime_official_client_mcp_http.inc)
+(include stanzas/test_runtime_antigravity_home.inc)
 (include stanzas/test_official_client_session_store.inc)
 
 (include stanzas/test_runtime_provider_projection_boundary.inc)

--- a/test/stanzas/test_runtime_antigravity_home.inc
+++ b/test/stanzas/test_runtime_antigravity_home.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_antigravity_home)
+ (modules test_runtime_antigravity_home)
+ (libraries masc masc_test_deps))

--- a/test/test_runtime_antigravity_home.ml
+++ b/test/test_runtime_antigravity_home.ml
@@ -1,0 +1,184 @@
+open Alcotest
+
+let with_temp_root f =
+  let root = Filename.temp_dir "masc-antigravity-home-" "" in
+  Unix.chmod root 0o700;
+  Fun.protect ~finally:(fun () -> Fs_compat.remove_tree root) (fun () -> f root)
+;;
+
+let write_file ~mode path contents =
+  let channel = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr channel)
+    (fun () -> output_string channel contents);
+  Unix.chmod path mode
+;;
+
+let require_ok = function
+  | Ok value -> value
+  | Error error -> fail (Runtime_antigravity_home.error_to_string error)
+;;
+
+let permission path = (Unix.lstat path).Unix.st_perm land 0o7777
+
+let test_prepares_private_home_without_copying_oauth () =
+  with_temp_root
+  @@ fun runtime_root ->
+  let oauth_source = Filename.concat runtime_root "operator-oauth-token" in
+  write_file ~mode:0o600 oauth_source "operator-secret-canary";
+  let layout =
+    Runtime_antigravity_home.prepare
+      ~runtime_root
+      ~owner_leaf:"keeper-sangsu"
+      ~oauth_source
+    |> require_ok
+  in
+  let expected_home =
+    Filename.concat runtime_root "official-clients"
+    |> fun path -> Filename.concat path "antigravity"
+    |> fun path -> Filename.concat path "keeper-sangsu"
+  in
+  check string "isolated HOME" expected_home layout.home_dir;
+  check
+    (list (pair string string))
+    "child environment has no token"
+    [ "HOME", expected_home ]
+    (Runtime_antigravity_home.child_environment layout);
+  let managed_directories =
+    [ Filename.concat runtime_root "official-clients"
+    ; Filename.concat (Filename.concat runtime_root "official-clients") "antigravity"
+    ; layout.home_dir
+    ; layout.workspace_dir
+    ; Filename.concat layout.home_dir ".gemini"
+    ; Filename.dirname layout.settings_path
+    ; Filename.dirname layout.mcp_config_path
+    ]
+  in
+  List.iter
+    (fun path -> check int ("private directory " ^ path) 0o700 (permission path))
+    managed_directories;
+  check int "settings mode" 0o600 (permission layout.settings_path);
+  check
+    bool
+    "settings contract"
+    true
+    (Yojson.Safe.equal
+       (Runtime_antigravity_home.settings_json ())
+       (Yojson.Safe.from_file layout.settings_path));
+  check bool "oauth target is a symlink" true
+    ((Unix.lstat layout.oauth_link_path).Unix.st_kind = Unix.S_LNK);
+  check
+    string
+    "oauth link points to canonical source"
+    (Unix.realpath oauth_source)
+    (Unix.readlink layout.oauth_link_path);
+  check
+    string
+    "source bytes remain operator-owned"
+    "operator-secret-canary"
+    (Fs_compat.load_file oauth_source);
+  check bool "MCP capability is not persisted by HOME preparation" false
+    (Sys.file_exists layout.mcp_config_path)
+;;
+
+let test_rejects_non_private_or_indirect_oauth_source () =
+  with_temp_root
+  @@ fun runtime_root ->
+  let oauth_source = Filename.concat runtime_root "operator-oauth-token" in
+  write_file ~mode:0o644 oauth_source "secret";
+  (match
+     Runtime_antigravity_home.prepare
+       ~runtime_root
+       ~owner_leaf:"keeper-sangsu"
+       ~oauth_source
+   with
+   | Error (Runtime_antigravity_home.Invalid_oauth_source _) -> ()
+   | Error error -> fail (Runtime_antigravity_home.error_to_string error)
+   | Ok _ -> fail "0644 OAuth source was admitted");
+  check bool "invalid source caused no managed mutation" false
+    (Sys.file_exists (Filename.concat runtime_root "official-clients"));
+  Unix.chmod oauth_source 0o600;
+  let oauth_symlink = Filename.concat runtime_root "oauth-symlink" in
+  Unix.symlink oauth_source oauth_symlink;
+  match
+    Runtime_antigravity_home.prepare
+      ~runtime_root
+      ~owner_leaf:"keeper-sangsu"
+      ~oauth_source:oauth_symlink
+  with
+  | Error (Runtime_antigravity_home.Invalid_oauth_source _) -> ()
+  | Error error -> fail (Runtime_antigravity_home.error_to_string error)
+  | Ok _ -> fail "symbolic-link OAuth source was admitted"
+;;
+
+let test_refuses_unexpected_existing_oauth_target () =
+  with_temp_root
+  @@ fun runtime_root ->
+  let oauth_source = Filename.concat runtime_root "operator-oauth-token" in
+  write_file ~mode:0o600 oauth_source "operator-secret";
+  let layout =
+    Runtime_antigravity_home.prepare
+      ~runtime_root
+      ~owner_leaf:"keeper-sangsu"
+      ~oauth_source
+    |> require_ok
+  in
+  Unix.unlink layout.oauth_link_path;
+  write_file ~mode:0o600 layout.oauth_link_path "do-not-overwrite";
+  (match
+     Runtime_antigravity_home.prepare
+       ~runtime_root
+       ~owner_leaf:"keeper-sangsu"
+       ~oauth_source
+   with
+   | Error (Runtime_antigravity_home.Invalid_oauth_link _) -> ()
+   | Error error -> fail (Runtime_antigravity_home.error_to_string error)
+   | Ok _ -> fail "unexpected OAuth target was replaced");
+  check
+    string
+    "unexpected target preserved"
+    "do-not-overwrite"
+    (Fs_compat.load_file layout.oauth_link_path)
+;;
+
+let test_rejects_owner_path_escape_before_mutation () =
+  with_temp_root
+  @@ fun runtime_root ->
+  let oauth_source = Filename.concat runtime_root "operator-oauth-token" in
+  write_file ~mode:0o600 oauth_source "secret";
+  (match
+     Runtime_antigravity_home.prepare
+       ~runtime_root
+       ~owner_leaf:"../outside"
+       ~oauth_source
+   with
+   | Error (Runtime_antigravity_home.Invalid_owner_leaf "../outside") -> ()
+   | Error error -> fail (Runtime_antigravity_home.error_to_string error)
+   | Ok _ -> fail "owner path escape was admitted");
+  check bool "managed root not created" false
+    (Sys.file_exists (Filename.concat runtime_root "official-clients"))
+;;
+
+let () =
+  run
+    "runtime_antigravity_home"
+    [ ( "layout"
+      , [ test_case
+            "private HOME and OAuth link"
+            `Quick
+            test_prepares_private_home_without_copying_oauth
+        ; test_case
+            "private direct OAuth source"
+            `Quick
+            test_rejects_non_private_or_indirect_oauth_source
+        ; test_case
+            "unexpected OAuth target"
+            `Quick
+            test_refuses_unexpected_existing_oauth_target
+        ; test_case
+            "owner path containment"
+            `Quick
+            test_rejects_owner_path_escape_before_mutation
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- create a persistent Antigravity HOME under the effective MASC runtime root
- validate the operator OAuth source as an exact effective-user-owned 0600 regular file
- install only a symlink to the OAuth source; never read or copy token bytes
- write the measured deny-by-default Antigravity settings as a private 0600 file
- expose only `HOME` as a child environment override and reserve the exact MCP config path without writing a capability

## Measured layout

Antigravity CLI 1.1.11 reads:

- `~/.gemini/antigravity-cli/settings.json`
- `~/.gemini/antigravity-cli/antigravity-oauth-token`
- `~/.gemini/config/mcp_config.json`

The settings deny filesystem, URL, command, and unsandboxed tools; only `mcp(masc/*)` is allowed and `toolPermission` remains `request-review`.

## Safety boundary

- managed directories are exact 0700 real directories owned by the effective user
- owner names are validated as one capability leaf before mutation
- invalid, indirect, or group/world-readable OAuth sources fail closed before managed files are created
- an unexpected existing OAuth target is preserved and rejected
- no API key, OAuth token value, or turn-scoped MCP Bearer is persisted by this slice

## Verification

- parser-only OCaml checks passed
- ocamlformat check passed
- deterministic-boundary ratchet passed
- CI target audit passed at 158 targets / 701-suite baseline
- focused/full build delegated to CI per operator request

## Not included

This PR does not write the ephemeral MCP config or spawn `agy`; those remain the next turn-scoped adapter slice.
