### PR TITLE
fix(keeper): isolate fresh Codex history

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -686,7 +686,7 @@ let run_named
       in
       match runtime.Runtime.execution with
       | Runtime_execution.Codex_app_server config ->
-        let run_codex () =
+        let run_codex ~initial_messages () =
           Keeper_codex_runtime.run
             ~runtime_id:attempt_runtime_id
             ~keeper_name
@@ -727,8 +727,8 @@ let run_named
                   ; ("routing_reason", `String "official_client_owns_session_state")
                   ])
               Keeper_runtime_manifest.Runtime_routed;
-            run_codex ()
-          | None, None -> run_codex ()
+            run_codex ~initial_messages:[] ()
+          | None, None -> run_codex ~initial_messages ()
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let codex_result =

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -119,7 +119,7 @@ max-request-body-bytes = 65536
 let runtime_toml_checkpoint_lane =
   {|
 [runtime]
-default = "checkpoint_lane"
+default = "codex.codex"
 
 [runtime.lanes.checkpoint_lane]
 strategy = "ordered"
@@ -765,13 +765,34 @@ let test_oas_checkpoint_starts_fresh_official_client_session () =
       ; manifest_keeper_turn_id = Some 1
       }
     in
-    let checkpoint = checkpoint_with_session_id "oas-session" in
+    let history_messages =
+      [ message
+          [ Agent_sdk.Types.Thinking
+              { content = "prior provider reasoning"; signature = None }
+          ; Agent_sdk.Types.ToolUse
+              { id = "prior-tool-call"
+              ; name = "prior_tool"
+              ; input = `Assoc []
+              }
+          ]
+      ; Agent_sdk.Types.tool_result_msg
+          ~tool_use_id:"prior-tool-call"
+          ~content:"prior tool result"
+          ()
+      ]
+    in
+    let checkpoint =
+      { (checkpoint_with_session_id "oas-session") with
+        messages = history_messages
+      }
+    in
     match
       Driver.run_named
         ~runtime_id:"checkpoint_lane"
         ~keeper_name:"checkpoint-runtime-compat-keeper"
         ~base_path:(Filename.get_temp_dir_name ())
         ~goal:"continue the OAS turn"
+        ~initial_messages:history_messages
         ~oas_checkpoint:checkpoint
         ~runtime_manifest_context:context
         ~runtime_manifest_append:(fun manifest -> manifests := manifest :: !manifests)
@@ -785,6 +806,11 @@ let test_oas_checkpoint_starts_fresh_official_client_session () =
         (Agent_sdk.Error.Config
            (Agent_sdk.Error.InvalidConfig { field = "oas_checkpoint"; _ })) ->
       Alcotest.fail "the official-client runtime must start without OAS resume"
+    | Error
+        (Agent_sdk.Error.Config
+           (Agent_sdk.Error.InvalidConfig { field = "initial_messages"; _ })) ->
+      Alcotest.fail
+        "a fresh official-client session must not import OAS history"
     | Error _ ->
       let fresh_session =
         List.find_opt


### PR DESCRIPTION
## What changed

- start an official-client turn with an empty history seed when an OAS checkpoint is present
- keep ordinary no-checkpoint Codex turns on their existing `initial_messages` path
- exercise the checkpoint transition with real `Thinking`, `ToolUse`, and `ToolResult` history
- fix the regression fixture so its default points to a concrete runtime and reaches the behavior under test

## Root cause

#27807 stopped passing the OAS checkpoint into the Codex runtime, but still passed `initial_messages` materialized from that same checkpoint. The official-client adapter rejects those OAS-only blocks before provider dispatch, leaving affected Keepers in a repeated `Invalid config 'initial_messages'` failure loop.

The fresh-session branch now follows its declared contract: it does not import provider-specific OAS history. It does not silently filter individual blocks or invent a partial history projection.

## Impact

Keepers switching from an OAS checkpoint to a Codex official-client runtime can make forward progress. Existing Codex turns without an OAS checkpoint are unchanged.

## Validation

- `scripts/dune-local.sh build test/test_keeper_turn_driver_failover.exe`
- `_build/default/test/test_keeper_turn_driver_failover.exe` — 35 tests passed
- `git diff --check origin/main...HEAD`
