### PR TITLE
fix(dashboard): split internal exact judge lanes

### DIFF
--- a/dashboard/src/components/internal-agents-monitor.test.ts
+++ b/dashboard/src/components/internal-agents-monitor.test.ts
@@ -88,8 +88,56 @@ describe('InternalAgentsMonitor', () => {
     expect(screen.getByText(/Completion verdict recorded: APPROVE/)).toBeTruthy()
 
     const filters = screen.getByRole('group', { name: 'Internal agent filters' })
-    fireEvent.click(within(filters).getByRole('button', { name: 'Judge 0' }))
+    fireEvent.click(within(filters).getByRole('button', { name: 'Auto Judge 0' }))
     expect(screen.queryByText('report_review_verdict')).toBeNull()
+  })
+
+  it('keeps Auto Judge and Board Attention as separate exact execution kinds', async () => {
+    api.fetchFusionRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchVerificationRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchExactLaneRuns.mockResolvedValue({
+      count: 2,
+      generatedAt: 'now',
+      runs: [
+        {
+          runId: 'auto-judge-1',
+          lane: 'hitl_auto_judge',
+          subjectId: 'approval-1',
+          actor: 'keeper-a',
+          startedAt: 1786000002,
+          input: { kind: 'exact', payload: { approval_id: 'approval-1' } },
+          status: 'succeeded',
+          elapsedSeconds: 0.4,
+          output: { decision: 'allow' },
+        },
+        {
+          runId: 'board-attention-1',
+          lane: 'board_attention_exact',
+          subjectId: 'board-post-1',
+          actor: 'keeper-a',
+          startedAt: 1786000001,
+          input: { kind: 'exact', payload: { post_id: 'board-post-1' } },
+          status: 'succeeded',
+          elapsedSeconds: 0.7,
+          output: { action: 'reply' },
+        },
+      ],
+    })
+
+    const { container } = render(html`<${InternalAgentsMonitor} />`)
+    const filters = await screen.findByRole('group', { name: 'Internal agent filters' })
+
+    expect(within(filters).getByRole('button', { name: 'Auto Judge 1' })).toBeTruthy()
+    expect(within(filters).getByRole('button', { name: 'Board Attention 1' })).toBeTruthy()
+    expect(container.textContent).not.toContain('Board Judge')
+
+    fireEvent.click(within(filters).getByRole('button', { name: 'Auto Judge 1' }))
+    expect(screen.getByRole('button', { name: /Auto Judge approval-1/i })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /Board Attention board-post-1/i })).toBeNull()
+
+    fireEvent.click(within(filters).getByRole('button', { name: 'Board Attention 1' }))
+    expect(screen.getByRole('button', { name: /Board Attention board-post-1/i })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /Auto Judge approval-1/i })).toBeNull()
   })
 
   it('joins a librarian run to the exact memory revision and shows changed claims', async () => {

--- a/dashboard/src/components/internal-agents-monitor.ts
+++ b/dashboard/src/components/internal-agents-monitor.ts
@@ -28,7 +28,14 @@ import { formatDateTimeKo, relativeTime } from '../lib/format-time'
 import { hashForRoute } from '../router'
 import { keepers as keeperRosterSignal, shellRuntimeResolution } from '../store'
 
-type Filter = 'all' | 'librarian' | 'judge' | 'compaction' | 'verification' | 'fusion'
+type Filter =
+  | 'all'
+  | 'librarian'
+  | 'auto-judge'
+  | 'board-attention'
+  | 'compaction'
+  | 'verification'
+  | 'fusion'
 type Row =
   | { source: 'exact'; id: string; run: ExactLaneRunRecord }
   | { source: 'verification'; id: string; run: VerificationRunRecord }
@@ -48,7 +55,8 @@ function isForbidden(reason: unknown): boolean {
 const FILTERS: Array<{ id: Filter; label: string }> = [
   { id: 'all', label: 'All' },
   { id: 'librarian', label: 'Librarian' },
-  { id: 'judge', label: 'Judge' },
+  { id: 'auto-judge', label: 'Auto Judge' },
+  { id: 'board-attention', label: 'Board Attention' },
   { id: 'compaction', label: 'Compaction' },
   { id: 'verification', label: 'Verification' },
   { id: 'fusion', label: 'Fusion' },
@@ -60,7 +68,7 @@ function laneLabel(row: Row): string {
   switch (row.run.lane) {
     case 'librarian_exact': return 'Librarian'
     case 'hitl_auto_judge': return 'Auto Judge'
-    case 'board_attention_exact': return 'Board Judge'
+    case 'board_attention_exact': return 'Board Attention'
     case 'compaction_exact': return 'Compaction'
   }
 }
@@ -110,9 +118,16 @@ function finishedAt(row: Row): number | undefined {
 function rowKind(row: Row): Exclude<Filter, 'all'> {
   if (row.source === 'verification') return 'verification'
   if (row.source === 'fusion') return 'fusion'
-  if (row.run.lane === 'librarian_exact') return 'librarian'
-  if (row.run.lane === 'compaction_exact') return 'compaction'
-  return 'judge'
+  switch (row.run.lane) {
+    case 'librarian_exact': return 'librarian'
+    case 'hitl_auto_judge': return 'auto-judge'
+    case 'board_attention_exact': return 'board-attention'
+    case 'compaction_exact': return 'compaction'
+    default: {
+      const unreachable: never = row.run.lane
+      return unreachable
+    }
+  }
 }
 
 function EvidenceBadge({ kind }: { kind: 'raw' | 'typed' | 'excerpt' }) {
@@ -466,12 +481,7 @@ function Details({ row }: { row: Row }) {
 
 function matches(row: Row, filter: Filter): boolean {
   if (filter === 'all') return true
-  if (filter === 'verification') return row.source === 'verification'
-  if (filter === 'fusion') return row.source === 'fusion'
-  if (filter === 'librarian') return row.source === 'exact' && row.run.lane === 'librarian_exact'
-  if (filter === 'compaction') return row.source === 'exact' && row.run.lane === 'compaction_exact'
-  return row.source === 'exact'
-    && (row.run.lane === 'hitl_auto_judge' || row.run.lane === 'board_attention_exact')
+  return rowKind(row) === filter
 }
 
 type KeeperIdentity = { name: string; agent_name?: string | null }
@@ -584,7 +594,7 @@ export function InternalAgentsMonitor() {
           <h3 id="internal-agent-inventory-title" class="text-sm font-semibold text-[var(--color-fg-primary)]">Observed run inventory</h3>
           <span class="text-3xs text-[var(--color-fg-muted)]">0건인 lane도 숨기지 않습니다.</span>
         </div>
-        <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+        <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-6">
           ${inventory.map(item => html`
             <button
               key=${item.id}


### PR DESCRIPTION
## Summary

- split the collapsed `Judge` dashboard kind into the exact `hitl_auto_judge` and `board_attention_exact` identities
- expose separate Auto Judge and Board Attention inventory cards, filters, owner-matrix columns, and timeline labels
- make exact-lane classification exhaustive so a future lane addition fails TypeScript validation instead of falling into a generic bucket

## Verification

- `npx tsc --noEmit --pretty`
- `npx vitest run src/components/internal-agents-monitor.test.ts` — 7/7
- `npm run build`
- `git diff --check`

## Live Playwright evidence

Measured from exact head `a2f9d58755de437aba9edf93993f5a70b1995c4c` using the branch server binary on isolated port 18947. The data root was a disposable copy of the earlier isolated Keeper measurement, so the browser consumed actual persisted `hitl_auto_judge` and `board_attention_exact` registry rows. The operating server on 8935 and `/Users/dancer/me/.masc` were not restarted or mutated.

- manual Admin session verified as `@local-admin · admin`
- exact registry response: 200
- Auto Judge filter: 6 actual rows, no Board Attention row leaked
- Board Attention filter: 1 actual row, no Auto Judge row leaked
- owner matrix exposed separate Auto Judge and Board Attention columns
- console errors: 0; page errors: 0; failed requests: 0
- screenshots: `/tmp/internal-agent-role-split-all-live.png`, `/tmp/internal-agent-role-split-board-live.png`

Stacked on #27804; keep Draft until the parent lands and this branch is rebased onto `main`.
