### PR TITLE
fix(keeper): omit synthetic Codex reasoning none

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -98,6 +98,11 @@ sangsu = "codex_subscription.gpt-5.3-codex-spark"
 
 The fallback candidate must already be a valid binding in the same file.
 There is intentionally no `[providers.codex_subscription.credentials]` table.
+An unspecified reasoning effort is omitted from the app-server request so the
+official client can choose a value supported by the selected model. MASC does
+not translate the provider-neutral `enable_thinking = false` toggle into a
+synthetic `reasoning.effort = "none"`; an explicitly supplied effort remains
+explicit and is validated against the toggle before dispatch.
 
 ## Creation and update
 

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -92,6 +92,29 @@ type prepared_turn =
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
   }
 
+let resolve_reasoning_effort ~enable_thinking ~reasoning_effort =
+  match enable_thinking, reasoning_effort with
+  | Some false, None ->
+    (* A provider-neutral boolean is not an official-client effort value.
+       Omitting the field lets the client select a value admitted by the
+       chosen model; synthesizing [None_] sent an unsupported "none" to
+       Codex models whose minimum effort is [Low]. *)
+    Ok None
+  | Some false, Some Llm_provider.Reasoning_effort.None_ ->
+    Ok (Some Llm_provider.Reasoning_effort.None_)
+  | Some false, Some _ ->
+    Error
+      (config_error
+         ~field:"reasoning_effort"
+         "enable_thinking=false conflicts with a non-none reasoning effort")
+  | Some true, Some Llm_provider.Reasoning_effort.None_ ->
+    Error
+      (config_error
+         ~field:"reasoning_effort"
+         "enable_thinking=true conflicts with reasoning effort none")
+  | (Some true | None), reasoning_effort -> Ok reasoning_effort
+;;
+
 let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
     ~initial_messages ~model_input_projection ~hooks ~enable_thinking =
   let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
@@ -181,20 +204,9 @@ let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
   let* () = unsupported_parameter "thinking_budget" turn_params.thinking_budget in
   let* () = unsupported_parameter "preserve_thinking" turn_params.preserve_thinking in
   let* reasoning_effort =
-    match turn_params.enable_thinking, turn_params.reasoning_effort with
-    | Some false, Some Llm_provider.Reasoning_effort.None_
-    | Some false, None -> Ok (Some Llm_provider.Reasoning_effort.None_)
-    | Some false, Some _ ->
-      Error
-        (config_error
-           ~field:"reasoning_effort"
-           "enable_thinking=false conflicts with a non-none reasoning effort")
-    | Some true, Some Llm_provider.Reasoning_effort.None_ ->
-      Error
-        (config_error
-           ~field:"reasoning_effort"
-           "enable_thinking=true conflicts with reasoning effort none")
-    | (Some true | None), reasoning_effort -> Ok reasoning_effort
+    resolve_reasoning_effort
+      ~enable_thinking:turn_params.enable_thinking
+      ~reasoning_effort:turn_params.reasoning_effort
   in
   let* tools =
     match turn_params.tool_choice with

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -23,6 +23,14 @@ type dynamic_tool =
   ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
   }
 
+val resolve_reasoning_effort :
+  enable_thinking:bool option ->
+  reasoning_effort:Llm_provider.Reasoning_effort.t option ->
+  (Llm_provider.Reasoning_effort.t option, Agent_sdk.Error.sdk_error) result
+(** Reconcile provider-neutral thinking control with an explicit
+    official-client effort. An absent effort remains absent; this function
+    never fabricates a model-specific effort from the boolean toggle. *)
+
 val text_of_blocks :
   runtime_label:string ->
   field:string ->

--- a/test/dune
+++ b/test/dune
@@ -1941,6 +1941,7 @@
 
 (include stanzas/test_runtime_agent_close_cancel_source.inc)
 
+(include stanzas/test_keeper_official_client_host.inc)
 (include stanzas/test_runtime_codex_app_server.inc)
 (include stanzas/test_runtime_claude_code.inc)
 (include stanzas/test_official_client_session_store.inc)

--- a/test/stanzas/test_keeper_official_client_host.inc
+++ b/test/stanzas/test_keeper_official_client_host.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_official_client_host)
+ (modules test_keeper_official_client_host)
+ (libraries alcotest masc masc_test_deps))

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -1,0 +1,72 @@
+open Alcotest
+open Masc
+
+module Effort = Llm_provider.Reasoning_effort
+module Host = Keeper_official_client_host
+
+let effort_string = Option.map Effort.to_string
+
+let expect_effort label expected result =
+  match result with
+  | Ok actual -> check (option string) label (effort_string expected) (effort_string actual)
+  | Error _ -> fail (label ^ ": unexpected configuration error")
+;;
+
+let test_disabled_without_effort_is_omitted () =
+  Host.resolve_reasoning_effort
+    ~enable_thinking:(Some false)
+    ~reasoning_effort:None
+  |> expect_effort "no synthesized none" None
+;;
+
+let test_explicit_efforts_are_preserved () =
+  Host.resolve_reasoning_effort
+    ~enable_thinking:(Some true)
+    ~reasoning_effort:(Some Effort.Medium)
+  |> expect_effort "medium" (Some Effort.Medium);
+  Host.resolve_reasoning_effort
+    ~enable_thinking:None
+    ~reasoning_effort:(Some Effort.Low)
+  |> expect_effort "low" (Some Effort.Low);
+  Host.resolve_reasoning_effort
+    ~enable_thinking:(Some false)
+    ~reasoning_effort:(Some Effort.None_)
+  |> expect_effort "explicit none" (Some Effort.None_)
+;;
+
+let test_conflicting_controls_fail_closed () =
+  (match
+     Host.resolve_reasoning_effort
+       ~enable_thinking:(Some false)
+       ~reasoning_effort:(Some Effort.High)
+   with
+   | Error _ -> ()
+   | Ok _ -> fail "disabled thinking admitted a non-none effort");
+  match
+    Host.resolve_reasoning_effort
+      ~enable_thinking:(Some true)
+      ~reasoning_effort:(Some Effort.None_)
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "enabled thinking admitted an explicit none effort"
+;;
+
+let () =
+  run
+    "keeper official-client host"
+    [ ( "reasoning effort"
+      , [ test_case
+            "disabled without effort is omitted"
+            `Quick
+            test_disabled_without_effort_is_omitted
+        ; test_case
+            "explicit efforts are preserved"
+            `Quick
+            test_explicit_efforts_are_preserved
+        ; test_case
+            "conflicting controls fail closed"
+            `Quick
+            test_conflicting_controls_fail_closed
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- stop translating generic `enable_thinking=false` into Codex `reasoning.effort="none"`
- preserve explicitly supplied reasoning efforts and existing conflict validation
- add a focused host contract test and document default ownership

## Runtime evidence
`gpt-5.3-codex-spark` rejects `none` and accepts `low|medium|high|xhigh`. The failing turns had no requested effort; MASC synthesized the rejected value.

## Validation
- Not run locally; CI pending.
