### PR TITLE
refactor(keeper): purge generic thinking from official clients

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -100,9 +100,9 @@ The fallback candidate must already be a valid binding in the same file.
 There is intentionally no `[providers.codex_subscription.credentials]` table.
 An unspecified reasoning effort is omitted from the app-server request so the
 official client can choose a value supported by the selected model. MASC does
-not translate the provider-neutral `enable_thinking = false` toggle into a
-synthetic `reasoning.effort = "none"`; an explicitly supplied effort remains
-explicit and is validated against the toggle before dispatch.
+not project the provider-neutral `enable_thinking` toggle into official
+clients. A hook that needs control must supply a typed `reasoning_effort`;
+supplying `enable_thinking` at that boundary fails before dispatch.
 
 ## Creation and update
 

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -80,7 +80,7 @@ let recovery_failure_of_client_error = function
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
-    ~context_injector ~context ~event_bus ~enable_thinking
+    ~context_injector ~context ~event_bus
     ~(config : Runtime_execution.codex_app_server) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
@@ -154,7 +154,6 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~initial_messages
         ~model_input_projection
         ~hooks:(Some hooks)
-        ~enable_thinking
     in
     let tool_surface_sha256 =
       Keeper_official_client_session_store.tool_surface_sha256 prepared.tools

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -14,6 +14,5 @@ val run :
   context_injector:Agent_sdk.Hooks.context_injector option ->
   context:Agent_sdk.Context.t option ->
   event_bus:Agent_sdk.Event_bus.t option ->
-  enable_thinking:bool option ->
   config:Runtime_execution.codex_app_server ->
   (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -93,30 +93,17 @@ type prepared_turn =
   }
 
 let resolve_reasoning_effort ~enable_thinking ~reasoning_effort =
-  match enable_thinking, reasoning_effort with
-  | Some false, None ->
-    (* A provider-neutral boolean is not an official-client effort value.
-       Omitting the field lets the client select a value admitted by the
-       chosen model; synthesizing [None_] sent an unsupported "none" to
-       Codex models whose minimum effort is [Low]. *)
-    Ok None
-  | Some false, Some Llm_provider.Reasoning_effort.None_ ->
-    Ok (Some Llm_provider.Reasoning_effort.None_)
-  | Some false, Some _ ->
+  match enable_thinking with
+  | Some _ ->
     Error
       (config_error
-         ~field:"reasoning_effort"
-         "enable_thinking=false conflicts with a non-none reasoning effort")
-  | Some true, Some Llm_provider.Reasoning_effort.None_ ->
-    Error
-      (config_error
-         ~field:"reasoning_effort"
-         "enable_thinking=true conflicts with reasoning effort none")
-  | (Some true | None), reasoning_effort -> Ok reasoning_effort
+         ~field:"enable_thinking"
+         "official-client runtimes require an explicit reasoning_effort; +          enable_thinking is not projected")
+  | None -> Ok reasoning_effort
 ;;
 
 let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
-    ~initial_messages ~model_input_projection ~hooks ~enable_thinking =
+    ~initial_messages ~model_input_projection ~hooks =
   let hooks = Option.value hooks ~default:Agent_sdk.Hooks.empty in
   let before_turn =
     invoke_turn_hook
@@ -135,9 +122,7 @@ let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
     | decision ->
       Error (illegal_hook_decision ~runtime_label ~hook_name:"before_turn" decision)
   in
-  let current_params =
-    { Agent_sdk.Hooks.default_turn_params with enable_thinking }
-  in
+  let current_params = Agent_sdk.Hooks.default_turn_params in
   let before_turn_params =
     invoke_turn_hook
       ~keeper_name

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -28,8 +28,8 @@ val resolve_reasoning_effort :
   reasoning_effort:Llm_provider.Reasoning_effort.t option ->
   (Llm_provider.Reasoning_effort.t option, Agent_sdk.Error.sdk_error) result
 (** Reconcile provider-neutral thinking control with an explicit
-    official-client effort. An absent effort remains absent; this function
-    never fabricates a model-specific effort from the boolean toggle. *)
+    official-client effort. An absent effort remains absent. A generic
+    [enable_thinking] value is rejected rather than translated. *)
 
 val text_of_blocks :
   runtime_label:string ->
@@ -67,7 +67,6 @@ val prepare_turn :
   initial_messages:Agent_sdk.Types.message list ->
   model_input_projection:Agent_sdk.Agent.model_input_projection option ->
   hooks:Agent_sdk.Hooks.hooks option ->
-  enable_thinking:bool option ->
   (prepared_turn, Agent_sdk.Error.sdk_error) result
 
 val dynamic_tools :

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -701,7 +701,6 @@ let run_named
             ~context_injector
             ~context
             ~event_bus
-            ~enable_thinking:inference_policy.attempt_enable_thinking
             ~config
         in
         let codex_result =

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -12,16 +12,16 @@ let expect_effort label expected result =
   | Error _ -> fail (label ^ ": unexpected configuration error")
 ;;
 
-let test_disabled_without_effort_is_omitted () =
+let test_absent_controls_are_omitted () =
   Host.resolve_reasoning_effort
-    ~enable_thinking:(Some false)
+    ~enable_thinking:None
     ~reasoning_effort:None
-  |> expect_effort "no synthesized none" None
+  |> expect_effort "absent" None
 ;;
 
 let test_explicit_efforts_are_preserved () =
   Host.resolve_reasoning_effort
-    ~enable_thinking:(Some true)
+    ~enable_thinking:None
     ~reasoning_effort:(Some Effort.Medium)
   |> expect_effort "medium" (Some Effort.Medium);
   Host.resolve_reasoning_effort
@@ -29,26 +29,26 @@ let test_explicit_efforts_are_preserved () =
     ~reasoning_effort:(Some Effort.Low)
   |> expect_effort "low" (Some Effort.Low);
   Host.resolve_reasoning_effort
-    ~enable_thinking:(Some false)
+    ~enable_thinking:None
     ~reasoning_effort:(Some Effort.None_)
   |> expect_effort "explicit none" (Some Effort.None_)
 ;;
 
-let test_conflicting_controls_fail_closed () =
+let test_generic_toggle_is_rejected () =
   (match
      Host.resolve_reasoning_effort
        ~enable_thinking:(Some false)
-       ~reasoning_effort:(Some Effort.High)
+       ~reasoning_effort:None
    with
    | Error _ -> ()
-   | Ok _ -> fail "disabled thinking admitted a non-none effort");
+   | Ok _ -> fail "disabled generic toggle was admitted");
   match
     Host.resolve_reasoning_effort
       ~enable_thinking:(Some true)
-      ~reasoning_effort:(Some Effort.None_)
+      ~reasoning_effort:(Some Effort.Medium)
   with
   | Error _ -> ()
-  | Ok _ -> fail "enabled thinking admitted an explicit none effort"
+  | Ok _ -> fail "enabled generic toggle was admitted"
 ;;
 
 let () =
@@ -56,17 +56,17 @@ let () =
     "keeper official-client host"
     [ ( "reasoning effort"
       , [ test_case
-            "disabled without effort is omitted"
+            "absent controls are omitted"
             `Quick
-            test_disabled_without_effort_is_omitted
+            test_absent_controls_are_omitted
         ; test_case
             "explicit efforts are preserved"
             `Quick
             test_explicit_efforts_are_preserved
         ; test_case
-            "conflicting controls fail closed"
+            "generic toggle is rejected"
             `Quick
-            test_conflicting_controls_fail_closed
+            test_generic_toggle_is_rejected
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- remove the generic `enable_thinking` argument from the Codex official-client execution path
- admit only typed `reasoning_effort` at the official-client host boundary
- reject hook-injected generic toggles before dispatch
- update the focused contract test and runtime documentation

## Why
PR #27814 stopped synthesizing `reasoning.effort="none"`. This follow-up removes the obsolete boolean projection itself so the invalid dual-control path cannot return.

## Validation
- Not run locally; CI pending.
