### PR TITLE
fix(keeper): keep OAS thinking seed out of official clients

### DIFF
--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -49,7 +49,17 @@ let seed_of_thinking_support ?(preserve_thinking = None) (thinking_support : boo
 ;;
 
 let for_runtime ~name =
-  seed_of_thinking_support
-    ~preserve_thinking:(Runtime.preserve_thinking_of_runtime_id name)
-    (Runtime.thinking_support_of_runtime_id name)
+  match Runtime.get_runtime_by_id name with
+  | Some runtime ->
+    (match Runtime_execution.checkpoint_owner runtime.Runtime.execution with
+     | Runtime_execution.Official_client ->
+       seed_of_thinking_support None
+     | Runtime_execution.Masc_oas ->
+       seed_of_thinking_support
+         ~preserve_thinking:(Runtime.preserve_thinking_of_runtime_id name)
+         (Runtime.thinking_support_of_runtime_id name))
+  | None ->
+    seed_of_thinking_support
+      ~preserve_thinking:(Runtime.preserve_thinking_of_runtime_id name)
+      (Runtime.thinking_support_of_runtime_id name)
 ;;

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -18,7 +18,8 @@ val seed_of_thinking_support
     [Some true] actively enables thinking for that model binding. *)
 
 val for_runtime : name:string -> seed
-(** Per-model thinking seed for runtime [name], resolved from the runtime.toml
-    [thinking-support], explicit [preserve-thinking], and OAS typed
-    preserve-thinking capability of the bound model.  See
-    {!seed_of_thinking_support} for the gate semantics. *)
+(** Per-model thinking seed for runtime [name]. [Masc_oas] executions resolve
+    runtime.toml [thinking-support] and explicit [preserve-thinking].
+    [Official_client] executions return an empty seed because their typed
+    effort is owned by the client boundary, not the OAS boolean controls.
+    Unknown runtimes preserve the existing all-absent result. *)

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -559,8 +559,25 @@ let test_codex_runtime_cannot_enter_oas_runner () =
     | Error detail ->
       Alcotest.(check bool)
         "typed ownership diagnostic"
-        true
-        (string_contains detail "not the OAS agent_core"))
+          true
+          (string_contains detail "not the OAS agent_core"))
+;;
+
+let test_codex_runtime_has_no_oas_thinking_seed () =
+  with_codex_runtime_initialized (fun () ->
+    let seed = Runtime_inference.for_runtime ~name:"codex.codex" in
+    Alcotest.(check (option int))
+      "thinking budget"
+      None
+      seed.Runtime_inference.thinking_budget;
+    Alcotest.(check (option bool))
+      "thinking enabled"
+      None
+      seed.Runtime_inference.thinking_enabled;
+    Alcotest.(check (option bool))
+      "preserve thinking"
+      None
+      seed.Runtime_inference.preserve_thinking)
 ;;
 
 let test_runtime_inventory_surfaces_declared_model_capabilities () =
@@ -1973,6 +1990,10 @@ let () =
             "Codex official-client runtime cannot enter OAS runner"
             `Quick
             test_codex_runtime_cannot_enter_oas_runner
+        ; Alcotest.test_case
+            "Codex official-client runtime has no OAS thinking seed"
+            `Quick
+            test_codex_runtime_has_no_oas_thinking_seed
         ] )
     ; ( "per-model thinking gate"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- gate runtime thinking seeds by the typed execution owner
- keep OAS `thinking_enabled` and `preserve_thinking` controls out of official-client hooks
- retain the official-client fail-closed guard for hook-injected generic toggles
- add a Codex runtime seed regression and remove a malformed diagnostic artifact

## Why
PR #27815 removed the generic toggle at the Codex consumer, but the shared hook producer still reconstructed `Some false` from runtime model metadata. That would replace the original provider 400 with a pre-dispatch configuration failure. This change removes the value at its typed producer boundary.

## Validation
- Not run locally; CI pending.
