### PR TITLE
fix(keeper): clarify official-client effort diagnostic

### DIFF
--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -98,7 +98,7 @@ let resolve_reasoning_effort ~enable_thinking ~reasoning_effort =
     Error
       (config_error
          ~field:"enable_thinking"
-         "official-client runtimes require an explicit reasoning_effort; +          enable_thinking is not projected")
+         "official-client runtimes do not project enable_thinking; use reasoning_effort for explicit control")
   | None -> Ok reasoning_effort
 ;;
 


### PR DESCRIPTION
## Summary
- remove a malformed diagnostic artifact
- clarify that official-client runtimes reject the generic `enable_thinking` toggle
- state that typed `reasoning_effort` is needed only for explicit control
- preserve the valid omitted-effort path and all dispatch behavior

## Validation
- Diagnostic-only change; local tests not run.
