### PR TITLE
ci: run official-client host suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1567,7 +1567,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_runtime_codex_app_server @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code"
+          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_keeper_official_client_host @test/runtest-test_runtime_codex_app_server @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${official_client_targets}"
 
       - name: Run host FD pressure contract suite


### PR DESCRIPTION
## Summary

- run `test_keeper_official_client_host` with the required official-client CI group
- keep the declared-but-unwired suite count at its enforced baseline

## Verification

- `bash scripts/audit-ci-test-targets.sh`
- `scripts/dune-local.sh build @test/runtest-test_keeper_official_client_host`
- `git diff --check origin/main...HEAD`

## Evidence

Main CI run 31313728544 reported 702 unwired suites against baseline 701 after this suite was added.