### PR TITLE
fix(keeper): close Librarian review authority gaps

### DIFF
--- a/lib/keeper/keeper_librarian_research.ml
+++ b/lib/keeper/keeper_librarian_research.ml
@@ -23,7 +23,6 @@ type research_tool =
   | Web_search
   | Web_fetch
   | Fusion_status
-  | Analyze_image
 
 let research_tools =
   [ Search_files
@@ -38,7 +37,6 @@ let research_tools =
   ; Web_search
   ; Web_fetch
   ; Fusion_status
-  ; Analyze_image
   ]
 ;;
 
@@ -55,9 +53,13 @@ let descriptor_owns_research_tool tool (descriptor : Keeper_tool_descriptor.t) =
   | Surface_read, Tool_surface_read
   | Web_search, Tool_web_search
   | Web_fetch, Tool_web_fetch
-  | Fusion_status, Tool_masc_fusion_status
-  | Analyze_image, Tool_analyze_image -> true
+  | Fusion_status, Tool_masc_fusion_status -> true
   | _ -> false
+;;
+
+let internal_error_of_exception exn =
+  Llm_provider.Reserved_exn.reraise_if_reserved exn;
+  Agent_sdk.Error.Internal (Printexc.to_string exn)
 ;;
 
 let research_descriptors () =
@@ -80,8 +82,7 @@ let create_raw_trace_sink
   =
   let path_result =
     try Ok (Keeper_types_support.keeper_raw_trace_turn_path config meta.name) with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Agent_sdk.Error.Internal (Printexc.to_string exn))
+    | exn -> Error (internal_error_of_exception exn)
   in
   match path_result with
   | Error error -> Raw_trace_degraded error
@@ -608,15 +609,39 @@ let make_bundle request = make_bundle_with_gate_context request |> fst
 ;;
 
 let protect_with_cleanup ~cleanup ~on_cleanup body =
+  let body_outcome = ref None in
+  let cleanup_reserved = ref None in
   Eio_guard.protect
     ~finally:(fun () ->
       match cleanup () with
       | () -> on_cleanup Cleanup_succeeded
       | exception (Eio.Cancel.Cancelled _ as exn) ->
+        let backtrace = Printexc.get_raw_backtrace () in
         on_cleanup Cleanup_cancelled;
-        raise exn
-      | exception exn -> on_cleanup (Cleanup_failed (Printexc.to_string exn)))
-    body
+        cleanup_reserved := Some (exn, backtrace)
+      | exception exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        let reserved =
+          try
+            Llm_provider.Reserved_exn.reraise_if_reserved exn;
+            None
+          with
+          | reserved -> Some reserved
+        in
+        (match reserved with
+         | Some reserved -> cleanup_reserved := Some (reserved, backtrace)
+         | None -> on_cleanup (Cleanup_failed (Printexc.to_string exn))))
+    (fun () ->
+      body_outcome :=
+        Some
+          (try Ok (body ()) with
+           | exn -> Error (exn, Printexc.get_raw_backtrace ())));
+  match !cleanup_reserved, !body_outcome with
+  | Some (exn, backtrace), _
+  | None, Some (Error (exn, backtrace)) ->
+    Printexc.raise_with_backtrace exn backtrace
+  | None, Some (Ok value) -> value
+  | None, None -> failwith "librarian research body outcome missing"
 ;;
 
 let bounded_evidence ~max_bytes text =
@@ -663,8 +688,7 @@ let run ~on_receipt (request : request) =
                   ~net:request.net
                   ()
               with
-              | Eio.Cancel.Cancelled _ as exn -> raise exn
-              | exn -> Error (Agent_sdk.Error.Internal (Printexc.to_string exn))))
+              | exn -> Error (internal_error_of_exception exn)))
     with
     | Eio.Cancel.Cancelled _ as exn ->
       `Cancelled (exn, Printexc.get_raw_backtrace ())
@@ -742,7 +766,7 @@ module For_testing = struct
           descriptor.runtime_handler ))
   ;;
 
-  let invalid_request_gate_callback_count request =
+  let invalid_request_result_callback_count request =
     let bundle, gate_context = make_bundle_with_gate_context request in
     protect_with_cleanup
       ~cleanup:bundle.cleanup
@@ -760,7 +784,9 @@ module For_testing = struct
          | `Assoc fields ->
            (match List.assoc_opt "completed_tool_calls" fields with
             | Some (`List calls) -> List.length calls
-            | Some _ | None -> failwith "missing completed Gate callback list")
-         | _ -> failwith "invalid Librarian Gate causal snapshot")
+            | Some _ | None -> failwith "missing causal result callback list")
+         | _ -> failwith "invalid Librarian causal snapshot")
   ;;
+
+  let internal_error_of_exception = internal_error_of_exception
 end

--- a/lib/keeper/keeper_librarian_research.mli
+++ b/lib/keeper/keeper_librarian_research.mli
@@ -30,9 +30,9 @@ type research_tool =
   | Web_search
   | Web_fetch
   | Fusion_status
-  | Analyze_image
 (** Closed, read/observation-only authority granted to the detached Librarian
-    research phase. Operational/mutating Keeper tools are not representable. *)
+    research phase. Operational/mutating tools and ungated provider subcalls
+    are not representable. *)
 
 (** Create a fresh retained-trace candidate for one Librarian research phase.
     The caller registers [Agent_sdk.Raw_trace.file_path] as a durable reachability
@@ -142,8 +142,12 @@ module For_testing : sig
 
   val research_descriptor_contract : unit -> (string * bool option * string) list
 
-  val invalid_request_gate_callback_count : request -> int
+  val invalid_request_result_callback_count : request -> int
   (** Dispatch one schema-invalid occurrence through every research tool. No
-      handler executes; each standard Keeper handler must still record exactly
-      one Gate/result callback. *)
+      handler or authorization Gate executes; each standard Keeper handler must
+      still record exactly one causal result callback. *)
+
+  val internal_error_of_exception : exn -> Agent_sdk.Error.sdk_error
+  (** Re-raise reserved runtime exceptions and translate only ordinary failures
+      to the research degradation error. *)
 end

--- a/lib/server/server_routes_http_routes_artifacts.ml
+++ b/lib/server/server_routes_http_routes_artifacts.ml
@@ -24,6 +24,8 @@ module Http = Http_server_eio
 
 let is_valid_sha256 value = Result.is_ok (Tool_blob_store.validate_sha256 value)
 
+let artifact_read_permission = Masc_domain.CanAdmin
+
 let blob_response ~base_path ~sha256 =
   let store = Tool_blob_store.create ~base_path in
   match Tool_blob_store.fetch store ~sha256 with
@@ -57,18 +59,18 @@ let blob_response ~base_path ~sha256 =
 let add_routes router =
   router
   |> Http.Router.prefix_get "/api/v1/artifacts/" (fun request reqd ->
-       with_public_read
-         (fun state _req reqd ->
+       with_token_permission_auth ~permission:artifact_read_permission
+         (fun state _agent_name _req reqd ->
            let base_path = (Mcp_server.workspace_config state).base_path in
            let path = Http.Request.path request in
            match extract_path_param ~prefix:"/api/v1/artifacts/" path with
            | None ->
-               respond_public_read_json_value ~status:`Bad_request request reqd
+               respond_json_value_with_cors ~status:`Bad_request request reqd
                  (`Assoc [ ("error", `String "sha256 path parameter required") ])
            | Some raw ->
                (match Tool_blob_store.validate_sha256 raw with
                 | Error invalid ->
-                    respond_public_read_json_value
+                    respond_json_value_with_cors
                       ~status:`Bad_request
                       request
                       reqd
@@ -83,5 +85,5 @@ let add_routes router =
                     let json, status =
                       blob_response ~base_path ~sha256:raw
                     in
-                    respond_public_read_json_value ~status request reqd json))
+                    respond_json_value_with_cors ~status request reqd json))
          request reqd)

--- a/lib/server/server_routes_http_routes_artifacts.mli
+++ b/lib/server/server_routes_http_routes_artifacts.mli
@@ -36,11 +36,13 @@ val blob_response :
     Store inspection, read, and integrity failures return
     [`Service_unavailable]. Cancellation propagates. *)
 
+val artifact_read_permission : Masc_domain.permission
+(** Operator-only authority required to dereference exact tool-output bytes. *)
+
 val add_routes :
   Http_server_eio.Router.t ->
   Http_server_eio.Router.t
 (** Register the [GET /api/v1/artifacts/<sha256>] route on
-    [router] using {!Server_auth.with_public_read}. Non-strict deployments keep
-    the dashboard read surface public; strict HTTP auth routes it through the
-    ordinary read authorization boundary because a content digest is not an
-    authorization capability. Returns the augmented router. *)
+    [router]. Exact bytes require a token-bound operator credential even when
+    general HTTP auth is non-strict; a content digest is not an authorization
+    capability. Returns the augmented router. *)

--- a/test/test_artifacts_endpoint.ml
+++ b/test/test_artifacts_endpoint.ml
@@ -48,10 +48,10 @@ let test_valid_sha256 () =
        "ghi1234567890123456789012345678901234567890123456789012345678901");
   Alcotest.(check bool) "empty" false (A.is_valid_sha256 "")
 
-let test_strict_auth_requires_read_auth () =
+let test_artifact_bytes_require_operator_auth () =
   let sha256 = String.make 64 'a' in
   Alcotest.(check bool)
-    "artifact route is not public in strict auth mode"
+    "artifact route is not public"
     false
     (Server_auth.is_public_read_path
        ("/api/v1/artifacts/" ^ sha256));
@@ -59,7 +59,19 @@ let test_strict_auth_requires_read_auth () =
     "prefix-confusable route is not public"
     false
     (Server_auth.is_public_read_path
-       ("/api/v1/artifacts-evil/" ^ sha256))
+       ("/api/v1/artifacts-evil/" ^ sha256));
+  Alcotest.(check bool)
+    "route authority is CanAdmin"
+    true
+    (A.artifact_read_permission = Masc_domain.CanAdmin);
+  Alcotest.(check bool)
+    "worker cannot dereference exact bytes"
+    false
+    (Masc_domain.has_permission Masc_domain.Worker A.artifact_read_permission);
+  Alcotest.(check bool)
+    "admin can dereference exact bytes"
+    true
+    (Masc_domain.has_permission Masc_domain.Admin A.artifact_read_permission)
 
 (* --- blob_response shape --- *)
 
@@ -100,8 +112,8 @@ let () =
     [
       ( "sha256 validation",
         [ Alcotest.test_case "valid + invalid forms" `Quick test_valid_sha256
-        ; Alcotest.test_case "strict auth requires read auth" `Quick
-            test_strict_auth_requires_read_auth
+        ; Alcotest.test_case "exact bytes require operator auth" `Quick
+            test_artifact_bytes_require_operator_auth
         ] );
       ( "blob_response",
         [

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -299,11 +299,12 @@ let test_librarian_research_bundle_is_closed_and_read_only () =
          ; "keeper_memory_write"
          ; "keeper_surface_post"
          ; "masc_fusion"
+         ; "AnalyzeImage"
          ];
        check int
-         "each research callback traverses the standard Gate/result boundary once"
+         "each rejected research call records one causal result"
          (List.length actual_names)
-         (Keeper_librarian_research.For_testing.invalid_request_gate_callback_count
+         (Keeper_librarian_research.For_testing.invalid_request_result_callback_count
             request);
        match cleanup with
        | Keeper_librarian_research.Cleanup_succeeded -> ()
@@ -374,13 +375,58 @@ let test_librarian_research_cleanup_contract () =
       (fun () -> 7)
   in
   check int "cleanup failure does not replace body result" 7 value;
-  match !cleanup_failure with
-  | Some (Keeper_librarian_research.Cleanup_failed detail) ->
-    check bool
-      "cleanup failure detail retained"
-      true
-      (string_contains detail "cleanup failed")
-  | _ -> fail "cleanup failure outcome was not recorded"
+  (match !cleanup_failure with
+   | Some (Keeper_librarian_research.Cleanup_failed detail) ->
+     check bool
+       "cleanup failure detail retained"
+       true
+       (string_contains detail "cleanup failed")
+   | _ -> fail "cleanup failure outcome was not recorded");
+  let cleanup_reserved_propagated =
+    try
+      ignore
+        (Keeper_librarian_research.For_testing.protect_with_cleanup
+           ~cleanup:(fun () -> raise Stack_overflow)
+           ~on_cleanup:(fun _ -> fail "reserved cleanup became an outcome")
+           (fun () -> 9));
+      false
+    with
+    | Stack_overflow -> true
+    | _ -> false
+  in
+  check bool
+    "reserved cleanup failure propagates"
+    true
+    cleanup_reserved_propagated
+;;
+
+let test_librarian_research_reserved_exceptions_propagate () =
+  let assert_reserved name exception_ matches =
+    let propagated =
+      try
+        ignore
+          (Keeper_librarian_research.For_testing.internal_error_of_exception
+             exception_);
+        false
+      with
+      | caught -> matches caught
+    in
+    check bool name true propagated
+  in
+  assert_reserved "out of memory propagates" Out_of_memory
+    (function Out_of_memory -> true | _ -> false);
+  assert_reserved "stack overflow propagates" Stack_overflow
+    (function Stack_overflow -> true | _ -> false);
+  assert_reserved "break propagates" Sys.Break
+    (function Sys.Break -> true | _ -> false);
+  match
+    Keeper_librarian_research.For_testing.internal_error_of_exception
+      (Failure "ordinary research failure")
+  with
+  | Agent_sdk.Error.Internal detail ->
+    check bool "ordinary failure is translated" true
+      (string_contains detail "ordinary research failure")
+  | _ -> fail "ordinary research failure used the wrong SDK error"
 ;;
 
 let test_librarian_registry_receipt_excludes_raw_payloads () =
@@ -665,6 +711,8 @@ let () =
             test_librarian_research_bundle_is_closed_and_read_only;
           test_case "librarian research cleanup covers success error cancellation" `Quick
             test_librarian_research_cleanup_contract;
+          test_case "librarian research preserves reserved exceptions" `Quick
+            test_librarian_research_reserved_exceptions_propagate;
           test_case "librarian registry receipt excludes raw payloads" `Quick
             test_librarian_registry_receipt_excludes_raw_payloads;
           test_case "missing current task reconciles before transition hint" `Quick


### PR DESCRIPTION
## Summary

- hard-cut `AnalyzeImage` from the detached Librarian research authority so the bundle cannot initiate an ungated vision-provider subcall
- require token-bound `CanAdmin` authority to dereference exact tool-output artifact bytes
- preserve `Out_of_memory`, `Stack_overflow`, `Sys.Break`, and cancellation across research execution and cleanup boundaries
- rename the schema-rejection callback test so it no longer claims to prove authorization Gate execution

Follow-up to #27804.

## Product impact

- User-visible change: only Admin operators can expand exact stored tool-output bytes; non-admin dashboard readers receive the typed authorization failure.
- Librarian research no longer receives image-analysis authority. Existing gated WebSearch/WebFetch research remains available.

## Evidence

- `scripts/dune-local.sh build test/test_warn_root_causes.exe test/test_artifacts_endpoint.exe test/test_keeper_tool_dispatch_runtime.exe`
- `_build/default/test/test_warn_root_causes.exe` — 13 passed
- `_build/default/test/test_artifacts_endpoint.exe` — 4 passed
- `_build/default/test/test_keeper_tool_dispatch_runtime.exe test execute_keeper_tool_call_with_outcome 17-21` — 5 passed, including WebSearch/WebFetch dispatch, pre-network Manual Gate deferral, and approved execution
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- `bash scripts/check-variants.sh` — PASS

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 6/6
provenance: direct
stages:
  - stage: focused_build
    result: pass
  - stage: librarian_contract_tests
    result: 13_passed
  - stage: artifact_auth_tests
    result: 4_passed
  - stage: web_gate_tests
    result: 5_passed
  - stage: ocamlformat_and_diff
    result: pass
  - stage: variant_sync
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — exact-head review of #27804 identified the ungated vision route, non-admin blob dereference, and reserved-exception catch boundaries
- [x] Orient — mapped to the remaining P0 authority/evidence findings and P1 error-path finding
- [x] Decide — removed the new vision authority instead of adding another Gate; narrowed exact-byte reads to the existing operator role
- [x] Act — six files changed; rollback is the single follow-up commit
- [x] Verify — focused build plus 22 passing contract/Gate tests
- [x] Loop — unrelated replay projection failure recorded as #27816

## Review evidence

- Fresh-context Codex flow, architecture, and adversarial reviewers independently inspected exact #27804 head `ba3e8406793ba489f18ed3a5d606249c38f44668`.
- Flow review passed the lifecycle ownership path. Architecture and adversarial reviews independently found the ungated `AnalyzeImage` provider call; adversarial review additionally found reserved exceptions being translated.
- No provider fallback was used.

## Linked issue

- Relates #27804
- Relates #27816

## Variant addition checklist

- [x] **OCaml** — removed `Analyze_image` from both `.ml` and `.mli`; its exhaustive owner match was updated
- [x] **TypeScript** — N/A: the research authority sum is not a dashboard wire union
- [x] **TLA+ spec** — N/A: the research authority sum is not a modeled TLA+ domain
- [x] **Event / JSON schema** — N/A: no event or JSON enum changed
- [x] **`make check-variants` passes** — `bash scripts/check-variants.sh` PASS

## Out-of-scope discovery

- #27816 records the independently reproducible existing failure in WebSearch durable replay provider projection case 22.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/librarian-review-followup-20260809` → `main` · 1 commit(s) · synced 2026-08-09T12:53:27Z

| sha | subject | date |
|---|---|---|
| `fc263b840` | fix(keeper): close librarian review authority gaps | 2026-08-09 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->