### PR TITLE
fix(keeper): complete official-client recovery operation

### DIFF
--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -966,11 +966,11 @@ let resolve_recovery ~base_path ~keeper_name ~expected ~recovery_id ~resolution
   let* phase, turn_count =
     match resolution with
     | Retry_previous ->
-      Ok
-        ( (match recovery.previous_settlement with
-           | None -> Ready
-           | Some settlement -> Settled settlement)
-        , completed_turn_count )
+      (match recovery.previous_settlement with
+       | None ->
+         Error
+           "retry_previous requires an exact previous official-client settlement"
+       | Some settlement -> Ok (Settled settlement, completed_turn_count))
     | Restart_fresh -> Ok (Ready, completed_turn_count)
   in
   let* resolved =

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -68,6 +68,21 @@ type recovery_resolution =
   | Retry_previous
   | Restart_fresh
 
+type recovery_resolution_application =
+  | Applied
+  | Replayed
+
+type recovery_resolution_error =
+  | Invalid_resolved_by
+  | Invalid_resolved_at
+  | Session_missing
+  | Session_changed
+  | Recovery_id_changed
+  | Recovery_not_required
+  | Retry_previous_unavailable
+  | Resolution_conflict
+  | Store_unavailable of string
+
 type recovery_resolution_record =
   { recovery_id : string
   ; failure : recovery_failure
@@ -951,36 +966,37 @@ let reconcile_process_restart ~base_path ~keeper_name ~expected
 
 let resolve_recovery ~base_path ~keeper_name ~expected ~recovery_id ~resolution
     ~resolved_by ~resolved_at =
-  let* () = non_empty "resolved_by" resolved_by in
-  let* recovery =
-    match expected.phase with
-    | Recovery_required recovery
-      when String.equal recovery.recovery_id recovery_id ->
-      Ok recovery
-    | Recovery_required _ ->
-      Error "official-client recovery identity changed before resolution"
-    | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
-      Error "official-client session is not awaiting recovery"
+  let ( let* ) = Result.bind in
+  let* () =
+    match non_empty "resolved_by" resolved_by with
+    | Ok () -> Ok ()
+    | Error _ -> Error Invalid_resolved_by
   in
-  let completed_turn_count = max 0 (expected.turn_count - 1) in
-  let* phase, turn_count =
-    match resolution with
-    | Retry_previous ->
-      (match recovery.previous_settlement with
-       | None ->
-         Error
-           "retry_previous requires an exact previous official-client settlement"
-       | Some settlement -> Ok (Settled settlement, completed_turn_count))
-    | Restart_fresh -> Ok (Ready, completed_turn_count)
+  let* () =
+    if Float.is_finite resolved_at then Ok () else Error Invalid_resolved_at
   in
-  let* resolved =
-    transition
-      ~base_path
-      ~keeper_name
-      ~expected:(Some expected)
-      { expected with
+  let replay (current : t) =
+    match current.last_recovery_resolution with
+    | Some record when String.equal record.recovery_id recovery_id ->
+      if record.resolution = resolution
+      then Ok (current, Replayed)
+      else Error Resolution_conflict
+    | Some _ | None -> Error Recovery_not_required
+  in
+  let apply directory (current : t) (recovery : recovery_required) =
+    let completed_turn_count = current.turn_count - 1 in
+    let* phase =
+      match resolution with
+      | Retry_previous ->
+        (match recovery.previous_settlement with
+         | None -> Error Retry_previous_unavailable
+         | Some settlement -> Ok (Settled settlement))
+      | Restart_fresh -> Ok Ready
+    in
+    let resolved =
+      { current with
         phase
-      ; turn_count
+      ; turn_count = completed_turn_count
       ; last_recovery_resolution =
           Some
             { recovery_id
@@ -991,14 +1007,52 @@ let resolve_recovery ~base_path ~keeper_name ~expected ~recovery_id ~resolution
             }
       ; updated_at = resolved_at
       }
+    in
+    let* () =
+      match save_path ~state_dir:directory resolved with
+      | Ok () -> Ok ()
+      | Error detail -> Error (Store_unavailable detail)
+    in
+    Log.Keeper.info
+      ~keeper_name
+      "resolved official-client session recovery=%s actor=%s decision=%s"
+      recovery_id
+      resolved_by
+      (match resolution with
+       | Retry_previous -> "retry_previous"
+       | Restart_fresh -> "restart_fresh");
+    Ok (resolved, Applied)
   in
-  Log.Keeper.info
-    ~keeper_name
-    "resolved official-client session recovery=%s actor=%s decision=%s"
-    recovery_id
-    resolved_by
-    (match resolution with
-     | Retry_previous -> "retry_previous"
-     | Restart_fresh -> "restart_fresh");
-  Ok resolved
+  match prepare_state_dir ~base_path ~keeper_name with
+  | Error detail -> Error (Store_unavailable detail)
+  | Ok directory ->
+    (match
+       File_lock_eio.with_durable_lock
+         ~lock_path:(Filename.concat directory lock_filename)
+         (fun () ->
+      let* current =
+        match load_path (Filename.concat directory filename) with
+        | Ok current -> Ok current
+        | Error detail -> Error (Store_unavailable detail)
+      in
+      match current with
+      | None -> Error Session_missing
+      | Some current when not (equal current expected) ->
+        (match replay current with
+         | Ok replayed -> Ok replayed
+         | Error Recovery_not_required -> Error Session_changed
+         | Error error -> Error error)
+      | Some current ->
+        (match current.phase with
+         | Recovery_required recovery
+           when String.equal recovery.recovery_id recovery_id ->
+           apply directory current recovery
+         | Recovery_required _ -> Error Recovery_id_changed
+         | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ -> replay current))
+     with
+     | Ok result -> result
+     | Error detail ->
+       Error
+         (Store_unavailable
+            (File_lock_eio.durable_lock_error_to_string detail)))
 ;;

--- a/lib/keeper/keeper_official_client_session_store.mli
+++ b/lib/keeper/keeper_official_client_session_store.mli
@@ -66,6 +66,21 @@ type recovery_resolution =
   | Retry_previous
   | Restart_fresh
 
+type recovery_resolution_application =
+  | Applied
+  | Replayed
+
+type recovery_resolution_error =
+  | Invalid_resolved_by
+  | Invalid_resolved_at
+  | Session_missing
+  | Session_changed
+  | Recovery_id_changed
+  | Recovery_not_required
+  | Retry_previous_unavailable
+  | Resolution_conflict
+  | Store_unavailable of string
+
 type recovery_resolution_record =
   { recovery_id : string
   ; failure : recovery_failure
@@ -209,9 +224,11 @@ val resolve_recovery :
   resolution:recovery_resolution ->
   resolved_by:string ->
   resolved_at:float ->
-  (t, string) result
+  ((t * recovery_resolution_application), recovery_resolution_error) result
 (** Resolve one exact recovery claim with compare-and-swap authority.
     [Retry_previous] restores the last settled session, [Restart_fresh] makes
-    the next claim start a new session. *)
+    the next claim start a new session. Repeating the same recovery id and
+    decision returns the already committed binding as [Replayed]; a different
+    decision for the same recovery id is a conflict. *)
 (** Every phase change is a process-safe durable compare-and-swap followed by
     exact read-back. Any incomplete phase blocks a later automatic claim. *)

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -481,6 +481,17 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
 let max_retry_notifications = 3
 let max_unknown_notifications = 128
 
+let validate_item_delta_notification ~method_ ~thread_id ~turn_id params =
+  let* fields = assoc_at method_ params in
+  let* notification_thread_id = required_string method_ "threadId" fields in
+  let* notification_turn_id = required_string method_ "turnId" fields in
+  let* _item_id = required_string method_ "itemId" fields in
+  let* _delta = required_string method_ "delta" fields in
+  if notification_thread_id <> thread_id || notification_turn_id <> turn_id
+  then protocol_error method_ "item delta identity does not match the active turn"
+  else Ok ()
+;;
+
 let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen_final
     ~seen_fallback ~retry_notifications ~unknown_notifications =
   let* message = io.receive () in
@@ -511,6 +522,27 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
   | Server_request { id; method_; _ } ->
     reject_server_request io id;
     Error (Unsupported_server_request method_)
+  | Notification
+      { method_ =
+          (( "item/agentMessage/delta"
+           | "item/commandExecution/outputDelta"
+           | "item/fileChange/outputDelta"
+           | "item/plan/delta" ) as method_)
+      ; params
+      } ->
+    let* () =
+      validate_item_delta_notification ~method_ ~thread_id ~turn_id params
+    in
+    await_turn_terminal
+      io
+      ~tools
+      ~tool_call_count
+      ~thread_id
+      ~turn_id
+      ~seen_final
+      ~seen_fallback
+      ~retry_notifications
+      ~unknown_notifications
   | Notification { method_ = "item/completed"; params } ->
     let stage = "item/completed" in
     let* fields = assoc_at stage params in

--- a/lib/server/server_dashboard_official_client_session.ml
+++ b/lib/server/server_dashboard_official_client_session.ml
@@ -1,0 +1,279 @@
+type error_kind =
+  | Bad_request
+  | Conflict
+  | Service_unavailable
+
+type error =
+  { kind : error_kind
+  ; code : string
+  ; message : string
+  }
+
+let ( let* ) = Result.bind
+let schema = "masc.dashboard.official-client-session.v1"
+
+let error kind code message = Error { kind; code; message }
+
+let client_kind_to_string = function
+  | Keeper_official_client_session_store.Codex -> "codex"
+  | Claude_code -> "claude_code"
+  | Antigravity -> "antigravity"
+;;
+
+let failure_to_string = function
+  | Keeper_official_client_session_store.Transient_spawn_failed ->
+    "transient_spawn_failed"
+  | Transport_interrupted -> "transport_interrupted"
+  | Protocol_failed -> "protocol_failed"
+  | Provider_rejected -> "provider_rejected"
+  | Host_hook_failed -> "host_hook_failed"
+  | State_persistence_failed -> "state_persistence_failed"
+  | Process_restarted -> "process_restarted"
+;;
+
+let settlement_json (settlement : Keeper_official_client_session_store.settlement) =
+  `Assoc
+    [ "session_id", `String settlement.session_id
+    ; "turn_id", `String settlement.turn_id
+    ]
+;;
+
+let settlement_opt_json = function
+  | None -> `Null
+  | Some settlement -> settlement_json settlement
+;;
+
+let string_opt_json = function
+  | None -> `Null
+  | Some value -> `String value
+;;
+
+let resolution_json = function
+  | Keeper_official_client_session_store.Retry_previous ->
+    `Assoc [ "kind", `String "retry_previous" ]
+  | Restart_fresh -> `Assoc [ "kind", `String "restart_fresh" ]
+;;
+
+let resolution_record_json
+    (record : Keeper_official_client_session_store.recovery_resolution_record) =
+  `Assoc
+    [ "failure", `String (failure_to_string record.failure)
+    ; "recovery_id", `String record.recovery_id
+    ; "resolution", resolution_json record.resolution
+    ; "resolved_at", `Float record.resolved_at
+    ; "resolved_by", `String record.resolved_by
+    ]
+;;
+
+let transient_release_record_json
+    (record : Keeper_official_client_session_store.transient_release_record) =
+  `Assoc
+    [ "failure", `String (failure_to_string record.failure)
+    ; "owner_epoch", `String record.owner_epoch
+    ; "released_at", `Float record.released_at
+    ]
+;;
+
+let phase_json = function
+  | Keeper_official_client_session_store.Ready -> `Assoc [ "kind", `String "ready" ]
+  | Start { owner_epoch; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "start"
+      ; "owner_epoch", `String owner_epoch
+      ; "previous_settlement", settlement_opt_json previous_settlement
+      ]
+  | Active { owner_epoch; session_id; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "active"
+      ; "owner_epoch", `String owner_epoch
+      ; "session_id", `String session_id
+      ; "previous_settlement", settlement_opt_json previous_settlement
+      ]
+  | Turn_inflight { owner_epoch; session_id; turn_id; previous_settlement } ->
+    `Assoc
+      [ "kind", `String "turn_inflight"
+      ; "owner_epoch", `String owner_epoch
+      ; "session_id", `String session_id
+      ; "turn_id", string_opt_json turn_id
+      ; "previous_settlement", settlement_opt_json previous_settlement
+      ]
+  | Recovery_required recovery ->
+    `Assoc
+      [ "kind", `String "recovery_required"
+      ; "recovery_id", `String recovery.recovery_id
+      ; "failure", `String (failure_to_string recovery.failure)
+      ; "detail", `String recovery.detail
+      ; "required_at", `Float recovery.required_at
+      ; "owner_epoch", `String recovery.owner_epoch
+      ; "observed_session_id", string_opt_json recovery.observed_session_id
+      ; "observed_turn_id", string_opt_json recovery.observed_turn_id
+      ; ( "previous_settlement"
+        , settlement_opt_json recovery.previous_settlement )
+      ]
+  | Settled settlement ->
+    `Assoc
+      [ "kind", `String "settled"
+      ; "session_id", `String settlement.session_id
+      ; "turn_id", `String settlement.turn_id
+      ]
+;;
+
+let binding_json (binding : Keeper_official_client_session_store.t) =
+  `Assoc
+    [ "client_kind", `String (client_kind_to_string binding.client_kind)
+    ; "runtime_id", `String binding.runtime_id
+    ; "phase", phase_json binding.phase
+    ; "turn_count", `Int binding.turn_count
+    ; "tool_surface_sha256", `String binding.tool_surface_sha256
+    ; ( "last_recovery_resolution"
+      , Option.fold
+          ~none:`Null
+          ~some:resolution_record_json
+          binding.last_recovery_resolution )
+    ; ( "last_transient_release"
+      , Option.fold
+          ~none:`Null
+          ~some:transient_release_record_json
+          binding.last_transient_release )
+    ; "updated_at", `Float binding.updated_at
+    ]
+;;
+
+let response_json ~keeper_name session =
+  `Assoc
+    [ "schema", `String schema
+    ; "ok", `Bool true
+    ; "keeper_name", `String keeper_name
+    ; "session", Option.fold ~none:`Null ~some:binding_json session
+    ]
+;;
+
+let validate_keeper_name keeper_name =
+  let keeper_name = String.trim keeper_name in
+  if keeper_name = ""
+  then error Bad_request "keeper_name_required" "keeper_name is required"
+  else if not (Keeper_config.validate_name keeper_name)
+  then
+    error
+      Bad_request
+      "keeper_name_invalid"
+      (Printf.sprintf "invalid keeper_name %S" keeper_name)
+  else Ok keeper_name
+;;
+
+let load ~base_path ~keeper_name =
+  match Keeper_official_client_session_store.load ~base_path ~keeper_name with
+  | Ok session -> Ok session
+  | Error message ->
+    error
+      Service_unavailable
+      "official_client_session_load_failed"
+      message
+;;
+
+let snapshot ~base_path ~keeper_name =
+  let* keeper_name = validate_keeper_name keeper_name in
+  let* session = load ~base_path ~keeper_name in
+  Ok (response_json ~keeper_name session)
+;;
+
+type request =
+  { keeper_name : string
+  ; recovery_id : string
+  ; resolution : Keeper_official_client_session_store.recovery_resolution
+  }
+
+let non_empty field value =
+  let value = String.trim value in
+  if value = ""
+  then error Bad_request (field ^ "_required") (field ^ " is required")
+  else Ok value
+;;
+
+let parse_body body =
+  let* json =
+    try Ok (Yojson.Safe.from_string body) with
+    | Yojson.Json_error message ->
+      error Bad_request "invalid_json" ("invalid JSON: " ^ message)
+  in
+  match json with
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "keeper_name", `String keeper_name
+       ; "recovery_id", `String recovery_id
+       ; "resolution", `String ("retry_previous" as resolution) ]
+     | [ "keeper_name", `String keeper_name
+       ; "recovery_id", `String recovery_id
+       ; "resolution", `String ("restart_fresh" as resolution) ] ->
+       let* keeper_name = validate_keeper_name keeper_name in
+       let* recovery_id = non_empty "recovery_id" recovery_id in
+       let resolution =
+         if String.equal resolution "retry_previous"
+         then Keeper_official_client_session_store.Retry_previous
+         else Restart_fresh
+       in
+       Ok { keeper_name; recovery_id; resolution }
+     | _ ->
+       error
+         Bad_request
+         "request_fields_invalid"
+         "expected exact keeper_name, recovery_id, resolution fields")
+  | _ -> error Bad_request "request_not_object" "request body must be a JSON object"
+;;
+
+let conflict code message = error Conflict code message
+
+let resolve_body ~base_path ~actor ~body =
+  let* request = parse_body body in
+  let* actor = non_empty "actor" actor in
+  let* current = load ~base_path ~keeper_name:request.keeper_name in
+  let* current =
+    match current with
+    | None ->
+      conflict
+        "official_client_session_missing"
+        "Keeper has no durable official-client session"
+    | Some current -> Ok current
+  in
+  let* () =
+    match current.phase with
+    | Keeper_official_client_session_store.Recovery_required recovery
+      when String.equal recovery.recovery_id request.recovery_id ->
+      Ok ()
+    | Recovery_required _ ->
+      conflict
+        "recovery_id_changed"
+        "official-client recovery identity changed before resolution"
+    | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+      conflict
+        "recovery_not_required"
+        "official-client session is not awaiting recovery"
+  in
+  match
+    Keeper_official_client_session_store.resolve_recovery
+      ~base_path
+      ~keeper_name:request.keeper_name
+      ~expected:current
+      ~recovery_id:request.recovery_id
+      ~resolution:request.resolution
+      ~resolved_by:actor
+      ~resolved_at:(Time_compat.now ())
+  with
+  | Ok resolved ->
+    Ok (response_json ~keeper_name:request.keeper_name (Some resolved))
+  | Error message ->
+    (match load ~base_path ~keeper_name:request.keeper_name with
+     | Ok (Some observed) when observed <> current ->
+       conflict
+         "official_client_session_changed"
+         "official-client session changed before recovery resolution"
+     | Ok None ->
+       conflict
+         "official_client_session_disappeared"
+         "official-client session disappeared before recovery resolution"
+     | Ok (Some _) | Error _ ->
+       error
+         Service_unavailable
+         "official_client_session_resolution_failed"
+         message)
+;;

--- a/lib/server/server_dashboard_official_client_session.ml
+++ b/lib/server/server_dashboard_official_client_session.ml
@@ -148,6 +148,11 @@ let response_json ~keeper_name session =
     ]
 ;;
 
+let resolution_application_json = function
+  | Keeper_official_client_session_store.Applied -> `String "applied"
+  | Replayed -> `String "replayed"
+;;
+
 let validate_keeper_name keeper_name =
   let keeper_name = String.trim keeper_name in
   if keeper_name = ""
@@ -223,9 +228,86 @@ let parse_body body =
 
 let conflict code message = error Conflict code message
 
-let resolve_body ~base_path ~actor ~body =
+let audit_resolution config ~actor request ~application ~outcome =
+  try
+    Audit_log.log_action
+      config
+      ~agent_id:actor
+      ~action:(Audit_log.Custom "official_client_session_recovery_resolve")
+      ~details:
+        (`Assoc
+          [ "keeper_name", `String request.keeper_name
+          ; "recovery_id", `String request.recovery_id
+          ; "resolution", resolution_json request.resolution
+          ; ( "application"
+            , match application with
+              | None -> `Null
+              | Some application -> resolution_application_json application )
+          ])
+      ~outcome
+      ();
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let resolution_response_json ~keeper_name ~session ~application ~audit =
+  match response_json ~keeper_name (Some session) with
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       @ [ "resolution_application", resolution_application_json application
+         ; "audit", Audit_log.write_result_to_json audit
+         ])
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _) as
+    impossible ->
+    impossible
+;;
+
+let store_resolution_error = function
+  | Keeper_official_client_session_store.Invalid_resolved_by ->
+    error Bad_request "actor_required" "actor is required"
+  | Invalid_resolved_at ->
+    error
+      Service_unavailable
+      "official_client_session_clock_invalid"
+      "official-client recovery resolution clock was invalid"
+  | Session_missing ->
+    conflict
+      "official_client_session_missing"
+      "Keeper has no durable official-client session"
+  | Session_changed ->
+    conflict
+      "official_client_session_changed"
+      "official-client session changed before recovery resolution"
+  | Recovery_id_changed ->
+    conflict
+      "recovery_id_changed"
+      "official-client recovery identity changed before resolution"
+  | Recovery_not_required ->
+    conflict
+      "recovery_not_required"
+      "official-client session is not awaiting recovery"
+  | Retry_previous_unavailable ->
+    conflict
+      "retry_previous_unavailable"
+      "official-client recovery has no exact previous settlement to retry"
+  | Resolution_conflict ->
+    conflict
+      "recovery_resolution_conflict"
+      "official-client recovery was already resolved with a different decision"
+  | Store_unavailable message ->
+    error
+      Service_unavailable
+      "official_client_session_resolution_failed"
+      message
+;;
+
+let resolve_body ~config ~actor ~body =
   let* request = parse_body body in
   let* actor = non_empty "actor" actor in
+  let base_path = config.Workspace.base_path in
   let* current = load ~base_path ~keeper_name:request.keeper_name in
   let* current =
     match current with
@@ -234,28 +316,6 @@ let resolve_body ~base_path ~actor ~body =
         "official_client_session_missing"
         "Keeper has no durable official-client session"
     | Some current -> Ok current
-  in
-  let* recovery =
-    match current.phase with
-    | Keeper_official_client_session_store.Recovery_required recovery
-      when String.equal recovery.recovery_id request.recovery_id ->
-      Ok recovery
-    | Recovery_required _ ->
-      conflict
-        "recovery_id_changed"
-        "official-client recovery identity changed before resolution"
-    | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
-      conflict
-        "recovery_not_required"
-        "official-client session is not awaiting recovery"
-  in
-  let* () =
-    match request.resolution, recovery.previous_settlement with
-    | Keeper_official_client_session_store.Retry_previous, None ->
-      conflict
-        "retry_previous_unavailable"
-        "official-client recovery has no exact previous settlement to retry"
-    | Retry_previous, Some _ | Restart_fresh, _ -> Ok ()
   in
   match
     Keeper_official_client_session_store.resolve_recovery
@@ -267,21 +327,34 @@ let resolve_body ~base_path ~actor ~body =
       ~resolved_by:actor
       ~resolved_at:(Time_compat.now ())
   with
-  | Ok resolved ->
-    Ok (response_json ~keeper_name:request.keeper_name (Some resolved))
-  | Error message ->
-    (match load ~base_path ~keeper_name:request.keeper_name with
-     | Ok (Some observed) when observed <> current ->
-       conflict
-         "official_client_session_changed"
-         "official-client session changed before recovery resolution"
-     | Ok None ->
-       conflict
-         "official_client_session_disappeared"
-         "official-client session disappeared before recovery resolution"
-     | Ok (Some _) | Error _ ->
-       error
-         Service_unavailable
-         "official_client_session_resolution_failed"
-         message)
+  | Ok (resolved, application) ->
+    let audit =
+      audit_resolution
+        config
+        ~actor
+        request
+        ~application:(Some application)
+        ~outcome:Audit_log.Success
+    in
+    Ok
+      (resolution_response_json
+         ~keeper_name:request.keeper_name
+         ~session:resolved
+         ~application
+         ~audit)
+  | Error store_error ->
+    let mapped = store_resolution_error store_error in
+    let detail =
+      match mapped with
+      | Error { code; message; _ } -> code ^ ": " ^ message
+      | Ok _ -> "official-client recovery resolution failed"
+    in
+    ignore
+      (audit_resolution
+         config
+         ~actor
+         request
+         ~application:None
+         ~outcome:(Audit_log.Failure detail));
+    mapped
 ;;

--- a/lib/server/server_dashboard_official_client_session.ml
+++ b/lib/server/server_dashboard_official_client_session.ml
@@ -235,11 +235,11 @@ let resolve_body ~base_path ~actor ~body =
         "Keeper has no durable official-client session"
     | Some current -> Ok current
   in
-  let* () =
+  let* recovery =
     match current.phase with
     | Keeper_official_client_session_store.Recovery_required recovery
       when String.equal recovery.recovery_id request.recovery_id ->
-      Ok ()
+      Ok recovery
     | Recovery_required _ ->
       conflict
         "recovery_id_changed"
@@ -248,6 +248,14 @@ let resolve_body ~base_path ~actor ~body =
       conflict
         "recovery_not_required"
         "official-client session is not awaiting recovery"
+  in
+  let* () =
+    match request.resolution, recovery.previous_settlement with
+    | Keeper_official_client_session_store.Retry_previous, None ->
+      conflict
+        "retry_previous_unavailable"
+        "official-client recovery has no exact previous settlement to retry"
+    | Retry_previous, Some _ | Restart_fresh, _ -> Ok ()
   in
   match
     Keeper_official_client_session_store.resolve_recovery

--- a/lib/server/server_dashboard_official_client_session.mli
+++ b/lib/server/server_dashboard_official_client_session.mli
@@ -1,0 +1,24 @@
+(** Authenticated dashboard projection and operator resolution for the durable
+    per-Keeper official-client session owner. *)
+
+type error_kind =
+  | Bad_request
+  | Conflict
+  | Service_unavailable
+
+type error =
+  { kind : error_kind
+  ; code : string
+  ; message : string
+  }
+
+val snapshot :
+  base_path:string ->
+  keeper_name:string ->
+  (Yojson.Safe.t, error) result
+
+val resolve_body :
+  base_path:string ->
+  actor:string ->
+  body:string ->
+  (Yojson.Safe.t, error) result

--- a/lib/server/server_dashboard_official_client_session.mli
+++ b/lib/server/server_dashboard_official_client_session.mli
@@ -18,7 +18,7 @@ val snapshot :
   (Yojson.Safe.t, error) result
 
 val resolve_body :
-  base_path:string ->
+  config:Workspace.config ->
   actor:string ->
   body:string ->
   (Yojson.Safe.t, error) result

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -14,6 +14,7 @@ include Server_routes_http_routes_dashboard_setup
 module Keeper_chat_pending = Server_dashboard_http_keeper_chat_pending
 module Keeper_event_queue_operator =
   Server_dashboard_http_keeper_event_queue_operator
+module Official_client_session = Server_dashboard_official_client_session
 
 let config_cache_ttl_s = Server_dashboard_http_core_cache.config_cache_ttl_s
 let standard_cache_ttl_s = Server_dashboard_http_core_cache.standard_cache_ttl_s
@@ -45,6 +46,28 @@ let respond_dashboard_ok ?request reqd =
   Http.Response.json_value ?request ~compress:true
     (`Assoc [ ("ok", `Bool true) ])
     reqd
+
+let respond_official_client_session_result request reqd = function
+  | Ok json -> Http.Response.json_value ~compress:true ~request json reqd
+  | Error
+      ({ Official_client_session.kind; code; message } :
+        Official_client_session.error) ->
+    let status =
+      match kind with
+      | Bad_request -> `Bad_request
+      | Conflict -> `Conflict
+      | Service_unavailable -> `Service_unavailable
+    in
+    Http.Response.json_value
+      ~status
+      ~request
+      (`Assoc
+        [ "schema", `String "masc.dashboard.official-client-session.error.v1"
+        ; "ok", `Bool false
+        ; "error_code", `String code
+        ; "error", `String message
+        ])
+      reqd
 
 let execute_output_heartbeat_s = 15.0
 
@@ -786,6 +809,33 @@ let add_routes ~sw ~clock router =
              ~config:(Mcp_server.workspace_config state)
          in
          Http.Response.json_value ~compress:true ~request:req json reqd)
+         request reqd)
+  |> Http.Router.get "/api/v1/runtime/sessions/official-client" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state _agent_name req reqd ->
+           let keeper_name =
+             Option.value
+               (Server_utils.query_param req "keeper_name")
+               ~default:""
+           in
+           let base_path = (Mcp_server.workspace_config state).base_path in
+           respond_official_client_session_result
+             req
+             reqd
+             (Official_client_session.snapshot ~base_path ~keeper_name))
+         request reqd)
+  |> Http.Router.post "/api/v1/runtime/sessions/official-client/resolve" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body ->
+             let base_path = (Mcp_server.workspace_config state).base_path in
+             respond_official_client_session_result
+               req
+               reqd
+               (Official_client_session.resolve_body
+                  ~base_path
+                  ~actor:agent_name
+                  ~body)))
          request reqd)
   |> Http.Router.get "/api/v1/runtime/config/raw" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -828,12 +828,11 @@ let add_routes ~sw ~clock router =
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun state agent_name req reqd ->
            Http.Request.read_body_async reqd (fun body ->
-             let base_path = (Mcp_server.workspace_config state).base_path in
              respond_official_client_session_result
                req
                reqd
                (Official_client_session.resolve_body
-                  ~base_path
+                  ~config:(Mcp_server.workspace_config state)
                   ~actor:agent_name
                   ~body)))
          request reqd)

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -317,7 +317,7 @@ let test_restart_recovery_and_transient_release () =
       | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
         fail "old process claim did not enter recovery"
     in
-    let ready =
+    let ready, application =
       resolve_recovery
         ~base_path
         ~keeper_name
@@ -328,6 +328,7 @@ let test_restart_recovery_and_transient_release () =
         ~resolved_at:4.0
       |> Result.get_ok
     in
+    check bool "recovery applied" true (application = Applied);
     let reclaimed =
       claim
         ~base_path
@@ -401,7 +402,7 @@ let test_exact_recovery_restart () =
      with
      | Error _ -> ()
      | Ok _ -> fail "wrong recovery fence was accepted");
-    let restarted =
+    let restarted, application =
       resolve_recovery
         ~base_path
         ~keeper_name
@@ -412,16 +413,169 @@ let test_exact_recovery_restart () =
         ~resolved_at:4.0
       |> Result.get_ok
     in
+    check bool "recovery applied" true (application = Applied);
     check int "restart drops incomplete turn" 0 restarted.turn_count;
     (match restarted.phase with
      | Ready -> ()
      | Settled _ | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
        fail "fresh restart did not return the binding to Ready");
+    let replayed, replay_application =
+      resolve_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:recovery
+        ~recovery_id
+        ~resolution:Restart_fresh
+        ~resolved_by:"operator-retry"
+        ~resolved_at:5.0
+      |> Result.get_ok
+    in
+    check bool "recovery replayed" true (replay_application = Replayed);
+    check bool "replay returns committed binding" true (restarted = replayed);
+    (match
+       resolve_recovery
+         ~base_path
+         ~keeper_name
+         ~expected:recovery
+         ~recovery_id
+         ~resolution:Retry_previous
+         ~resolved_by:"operator"
+         ~resolved_at:6.0
+     with
+     | Error Resolution_conflict -> ()
+     | Error _ -> fail "different replay decision returned the wrong conflict"
+     | Ok _ -> fail "different replay decision replaced committed recovery");
     match restarted.last_recovery_resolution with
     | Some record ->
       check string "durable actor" "operator" record.resolved_by;
       check string "recovery fence" recovery_id record.recovery_id
     | None -> fail "recovery resolution evidence was not persisted")
+;;
+
+let test_retry_previous_restores_exact_settlement () =
+  with_workspace "masc-official-client-store-retry-" (fun base_path ->
+    let keeper_name = "retry" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    let active =
+      mark_active
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~session_id:"session-1"
+        ~updated_at:2.0
+      |> Result.get_ok
+    in
+    let starting =
+      mark_turn_starting
+        ~base_path
+        ~keeper_name
+        ~expected:active
+        ~session_id:"session-1"
+        ~updated_at:3.0
+      |> Result.get_ok
+    in
+    let inflight =
+      mark_turn_started
+        ~base_path
+        ~keeper_name
+        ~expected:starting
+        ~session_id:"session-1"
+        ~turn_id:"turn-1"
+        ~updated_at:4.0
+      |> Result.get_ok
+    in
+    let settled =
+      settle
+        ~base_path
+        ~keeper_name
+        ~expected:inflight
+        ~session_id:"session-1"
+        ~turn_id:"turn-1"
+        ~updated_at:5.0
+      |> Result.get_ok
+    in
+    let resumed_claim =
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some settled)
+        ~client_kind:Codex
+        ~owner_epoch
+        ~runtime_id:"codex.default"
+        ~tool_surface_sha256:empty_surface
+        ~updated_at:6.0
+      |> Result.get_ok
+    in
+    let recovery =
+      require_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:resumed_claim
+        ~failure:Protocol_failed
+        ~detail:"resume transport ended before the next turn started"
+        ~required_at:7.0
+      |> Result.get_ok
+    in
+    let recovery_id =
+      match recovery.phase with
+      | Recovery_required required ->
+        check bool
+          "retry retains exact previous settlement"
+          true
+          (required.previous_settlement
+           = Some { session_id = "session-1"; turn_id = "turn-1" });
+        required.recovery_id
+      | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+        fail "resumed claim did not enter recovery"
+    in
+    let restored, application =
+      resolve_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:recovery
+        ~recovery_id
+        ~resolution:Retry_previous
+        ~resolved_by:"operator"
+        ~resolved_at:8.0
+      |> Result.get_ok
+    in
+    check bool "retry decision applied" true (application = Applied);
+    check int "failed retry does not count" 1 restored.turn_count;
+    (match restored.phase with
+     | Settled { session_id; turn_id } ->
+       check string "restored session" "session-1" session_id;
+       check string "restored turn" "turn-1" turn_id
+     | Ready | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+       fail "retry_previous did not restore the exact settlement");
+    let next_claim =
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some restored)
+        ~client_kind:Codex
+        ~owner_epoch
+        ~runtime_id:"codex.default"
+        ~tool_surface_sha256:empty_surface
+        ~updated_at:9.0
+      |> Result.get_ok
+    in
+    match next_claim.phase with
+    | Start { previous_settlement; _ } ->
+      check bool
+        "next claim resumes restored session"
+        true
+        (previous_settlement
+         = Some { session_id = "session-1"; turn_id = "turn-1" })
+    | Ready | Active _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+      fail "restored settlement did not drive the next resume claim")
 ;;
 
 let write_file path content =
@@ -508,6 +662,10 @@ let () =
             `Quick
             test_restart_recovery_and_transient_release
         ; test_case "exact recovery restart" `Quick test_exact_recovery_restart
+        ; test_case
+            "retry previous restores exact settlement"
+            `Quick
+            test_retry_previous_restores_exact_settlement
         ; test_case "ambiguous JSON rejected" `Quick test_ambiguous_json_is_rejected
         ; test_case
             "tool surface fingerprint canonical"

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -811,6 +811,134 @@ let test_keeper_protocol_failure_enters_recovery () =
              | Ok _ -> fail "unresolved Codex recovery admitted a duplicate turn")))
 ;;
 
+let test_dashboard_official_client_recovery_projection_and_resolution () =
+  let base_path = temp_workspace "masc-official-client-dashboard-recovery-" in
+  let keeper_name = "codex-fixture" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ "not-json"
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            match run_keeper_turn ~base_path ~cli_path ~model:"gpt-fixture" () with
+            | Error _ -> ()
+            | Ok _ -> fail "malformed official-client response completed the Keeper turn");
+       let recovery =
+         match Keeper_official_client_session_store.load ~base_path ~keeper_name with
+         | Error detail -> fail detail
+         | Ok None -> fail "real Keeper failure left no recovery state"
+         | Ok (Some recovery) -> recovery
+       in
+       let recovery_id =
+         match recovery.phase with
+         | Recovery_required required -> required.recovery_id
+         | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+           fail "dashboard recovery fixture was not recovery-required"
+       in
+       let snapshot =
+         Server_dashboard_official_client_session.snapshot ~base_path ~keeper_name
+         |> Result.get_ok
+       in
+       let open Yojson.Safe.Util in
+       check string
+         "dashboard schema"
+         "masc.dashboard.official-client-session.v1"
+         (snapshot |> member "schema" |> to_string);
+       check string
+         "dashboard client kind"
+         "codex"
+         (snapshot |> member "session" |> member "client_kind" |> to_string);
+       check string
+         "dashboard recovery phase"
+         "recovery_required"
+         (snapshot |> member "session" |> member "phase" |> member "kind" |> to_string);
+       check string
+         "dashboard recovery fence"
+         recovery_id
+         (snapshot
+          |> member "session"
+          |> member "phase"
+          |> member "recovery_id"
+          |> to_string);
+       let body =
+         `Assoc
+           [ "keeper_name", `String keeper_name
+           ; "recovery_id", `String recovery_id
+           ; "resolution", `String "restart_fresh"
+           ]
+         |> Yojson.Safe.to_string
+       in
+       let resolved =
+         Server_dashboard_official_client_session.resolve_body
+           ~base_path
+           ~actor:"dashboard-admin"
+           ~body
+         |> Result.get_ok
+       in
+       check string
+         "dashboard resolved phase"
+         "ready"
+         (resolved |> member "session" |> member "phase" |> member "kind" |> to_string);
+       check string
+         "dashboard resolution actor"
+         "dashboard-admin"
+         (resolved
+          |> member "session"
+          |> member "last_recovery_resolution"
+          |> member "resolved_by"
+          |> to_string);
+       with_fixture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            match run_keeper_turn ~base_path ~cli_path ~model:"gpt-fixture" () with
+            | Error error -> fail (Agent_sdk.Error.to_string error)
+            | Ok result ->
+              check string
+                "post-resolution Keeper response"
+                "MASC_SUBSCRIPTION_OK"
+                (keeper_response_text result));
+       let settled =
+         match Keeper_official_client_session_store.load ~base_path ~keeper_name with
+         | Error detail -> fail detail
+         | Ok None -> fail "post-resolution Keeper turn lost its durable state"
+         | Ok (Some settled) -> settled
+       in
+       (match settled.phase with
+        | Settled { session_id; turn_id } ->
+          check string "post-resolution session" "thread-1" session_id;
+          check string "post-resolution turn" "turn-1" turn_id
+        | Ready | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+          fail "post-resolution Keeper turn did not settle");
+       let duplicate_body =
+         Printf.sprintf
+           {|{"keeper_name":%S,"keeper_name":%S,"recovery_id":%S,"resolution":"restart_fresh"}|}
+           keeper_name
+           keeper_name
+           recovery_id
+       in
+       match
+         Server_dashboard_official_client_session.resolve_body
+           ~base_path
+           ~actor:"dashboard-admin"
+           ~body:duplicate_body
+       with
+       | Error { kind = Bad_request; _ } -> ()
+       | Error _ -> fail "duplicate dashboard request had the wrong error class"
+       | Ok _ -> fail "duplicate dashboard request fields were admitted")
+;;
+
 let test_keeper_resumes_persisted_codex_thread () =
   let base_path = temp_workspace "masc-codex-resume-" in
   Fun.protect
@@ -1459,6 +1587,10 @@ let () =
             "Keeper protocol failure enters recovery"
             `Quick
             test_keeper_protocol_failure_enters_recovery
+        ; test_case
+            "dashboard official-client recovery projection and resolution"
+            `Quick
+            test_dashboard_official_client_recovery_projection_and_resolution
         ; test_case
             "Keeper resumes persisted Codex thread"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -817,10 +817,55 @@ let test_keeper_protocol_failure_enters_recovery () =
 
 let test_dashboard_official_client_recovery_projection_and_resolution () =
   let base_path = temp_workspace "masc-official-client-dashboard-recovery-" in
+  let config = Workspace.default_config base_path in
   let keeper_name = "codex-fixture" in
+  let success_capture = Filename.temp_file "masc-codex-recovery-retry-" ".jsonl" in
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+           [ "name", `String keeper_name
+           ; "agent_name", `String (Keeper_identity.keeper_agent_name keeper_name)
+           ; "trace_id", `String "trace-official-client-recovery"
+           ; "allowed_paths", `List [ `String base_path ]
+           ])
+    with
+    | Ok meta -> meta
+    | Error detail -> fail detail
+  in
+  ignore (Keeper_registry.For_testing.register ~base_path keeper_name meta);
   Fun.protect
-    ~finally:(fun () -> cleanup_tree base_path)
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.unregister ~base_path keeper_name;
+      cleanup_tree base_path;
+      Sys.remove success_capture)
     (fun () ->
+       let stimulus : Keeper_event_queue.stimulus =
+         { post_id = "official-client-recovery-stimulus"
+         ; urgency = Keeper_event_queue.Normal
+         ; arrived_at = 1.0
+         ; payload = Keeper_event_queue.Bootstrap
+         }
+       in
+       (match
+          Keeper_registry_event_queue.enqueue_durable_result
+            ~base_path
+            keeper_name
+            stimulus
+        with
+        | Ok () -> ()
+        | Error detail -> fail detail);
+       let selection =
+         match
+           Keeper_registry_event_queue.select_when_result
+             ~base_path
+             keeper_name
+             ~ready:(fun _ -> true)
+         with
+         | Ok (Some selection) -> selection
+         | Ok None -> fail "durable recovery stimulus was not selected"
+         | Error detail -> fail detail
+       in
        with_fixture
          [ init_result
          ; account_chatgpt
@@ -832,6 +877,14 @@ let test_dashboard_official_client_recovery_projection_and_resolution () =
             match run_keeper_turn ~base_path ~cli_path ~model:"gpt-fixture" () with
             | Error _ -> ()
             | Ok _ -> fail "provider-rejected official-client turn completed");
+       (match
+          Keeper_registry_event_queue.validate_pending_selection_result
+            ~base_path
+            keeper_name
+            ~selection
+        with
+        | Ok () -> ()
+        | Error detail -> fail detail);
        let recovery =
          match Keeper_official_client_session_store.load ~base_path ~keeper_name with
          | Error detail -> fail detail
@@ -892,7 +945,7 @@ let test_dashboard_official_client_recovery_projection_and_resolution () =
        in
        (match
           Server_dashboard_official_client_session.resolve_body
-            ~base_path
+            ~config
             ~actor:"dashboard-admin"
             ~body:retry_body
         with
@@ -914,7 +967,7 @@ let test_dashboard_official_client_recovery_projection_and_resolution () =
        in
        let resolved =
          Server_dashboard_official_client_session.resolve_body
-           ~base_path
+           ~config
            ~actor:"dashboard-admin"
            ~body
          |> Result.get_ok
@@ -929,9 +982,52 @@ let test_dashboard_official_client_recovery_projection_and_resolution () =
          (resolved
           |> member "session"
           |> member "last_recovery_resolution"
+         |> member "resolved_by"
+         |> to_string);
+       check string
+         "dashboard resolution applied"
+         "applied"
+         (resolved |> member "resolution_application" |> to_string);
+       check bool
+         "dashboard resolution audit recorded"
+         true
+         (resolved |> member "audit" |> member "recorded" |> to_bool);
+       let replayed =
+         Server_dashboard_official_client_session.resolve_body
+           ~config
+           ~actor:"dashboard-admin-retry"
+           ~body
+         |> Result.get_ok
+       in
+       check string
+         "dashboard response loss replays committed resolution"
+         "replayed"
+         (replayed |> member "resolution_application" |> to_string);
+       check string
+         "replayed resolution preserves original actor"
+         "dashboard-admin"
+         (replayed
+          |> member "session"
+          |> member "last_recovery_resolution"
           |> member "resolved_by"
           |> to_string);
+       let selected_after_resolution =
+         match
+           Keeper_registry_event_queue.select_when_result
+             ~base_path
+             keeper_name
+             ~ready:(fun _ -> true)
+         with
+         | Ok (Some selection) -> selection
+         | Ok None -> fail "resolution lost the retained durable stimulus"
+         | Error detail -> fail detail
+       in
+       check bool
+         "resolution reuses the exact durable stimulus"
+         true
+         (selected_after_resolution = selection);
        with_fixture
+         ~capture_path:success_capture
          [ init_result
          ; account_chatgpt
          ; thread_result
@@ -947,6 +1043,34 @@ let test_dashboard_official_client_recovery_projection_and_resolution () =
                 "post-resolution Keeper response"
                 "MASC_SUBSCRIPTION_OK"
                 (keeper_response_text result));
+       let success_requests =
+         In_channel.with_open_bin success_capture (fun input ->
+           In_channel.input_lines input |> List.map Yojson.Safe.from_string)
+       in
+       check int
+         "resolution admits exactly one provider turn"
+         1
+         (success_requests
+          |> List.filter (fun json ->
+            Yojson.Safe.Util.member "method" json = `String "turn/start")
+          |> List.length);
+       (match
+          Keeper_registry_event_queue.ack_pending_result
+            ~base_path
+            keeper_name
+            ~selection:selected_after_resolution
+        with
+        | Ok () -> ()
+        | Error detail -> fail detail);
+       let queue_after_success =
+         match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+         | Ok queue -> queue
+         | Error detail -> fail detail
+       in
+       check int
+         "successful retry acknowledges the durable stimulus"
+         0
+         (Keeper_event_queue.length queue_after_success);
        let settled =
          match Keeper_official_client_session_store.load ~base_path ~keeper_name with
          | Error detail -> fail detail
@@ -968,7 +1092,7 @@ let test_dashboard_official_client_recovery_projection_and_resolution () =
        in
        match
          Server_dashboard_official_client_session.resolve_body
-           ~base_path
+           ~config
            ~actor:"dashboard-admin"
            ~body:duplicate_body
        with

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -23,6 +23,10 @@ let turn_completed =
   {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[{"type":"agentMessage","id":"message-1","text":"MASC_SUBSCRIPTION_OK","phase":"final_answer"}],"status":"completed"}}}|}
 ;;
 
+let turn_failed =
+  {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"fixture provider rejection"}}}}|}
+;;
+
 let resumed_turn_result = {|{"id":4,"result":{"turn":{"id":"turn-2"}}}|}
 
 let resumed_item_completed =
@@ -818,17 +822,16 @@ let test_dashboard_official_client_recovery_projection_and_resolution () =
     ~finally:(fun () -> cleanup_tree base_path)
     (fun () ->
        with_fixture
-         [ "not-json"
+         [ init_result
          ; account_chatgpt
          ; thread_result
          ; turn_result
-         ; item_completed
-         ; turn_completed
+         ; turn_failed
          ]
          (fun cli_path ->
             match run_keeper_turn ~base_path ~cli_path ~model:"gpt-fixture" () with
             | Error _ -> ()
-            | Ok _ -> fail "malformed official-client response completed the Keeper turn");
+            | Ok _ -> fail "provider-rejected official-client turn completed");
        let recovery =
          match Keeper_official_client_session_store.load ~base_path ~keeper_name with
          | Error detail -> fail detail
@@ -837,7 +840,20 @@ let test_dashboard_official_client_recovery_projection_and_resolution () =
        in
        let recovery_id =
          match recovery.phase with
-         | Recovery_required required -> required.recovery_id
+         | Recovery_required required ->
+           check bool
+             "recovery follows provider rejection"
+             true
+             (required.failure = Provider_rejected);
+           check (option string)
+             "recovery observed exact session"
+             (Some "thread-1")
+             required.observed_session_id;
+           check (option string)
+             "recovery observed exact turn"
+             (Some "turn-1")
+             required.observed_turn_id;
+           required.recovery_id
          | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
            fail "dashboard recovery fixture was not recovery-required"
        in
@@ -866,6 +882,28 @@ let test_dashboard_official_client_recovery_projection_and_resolution () =
           |> member "phase"
           |> member "recovery_id"
           |> to_string);
+       let retry_body =
+         `Assoc
+           [ "keeper_name", `String keeper_name
+           ; "recovery_id", `String recovery_id
+           ; "resolution", `String "retry_previous"
+           ]
+         |> Yojson.Safe.to_string
+       in
+       (match
+          Server_dashboard_official_client_session.resolve_body
+            ~base_path
+            ~actor:"dashboard-admin"
+            ~body:retry_body
+        with
+        | Error { kind = Conflict; code = "retry_previous_unavailable"; _ } -> ()
+        | Error error ->
+          fail
+            (Printf.sprintf
+               "retry_previous had wrong rejection: %s: %s"
+               error.code
+               error.message)
+        | Ok _ -> fail "retry_previous silently restarted a fresh session");
        let body =
          `Assoc
            [ "keeper_name", `String keeper_name

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -408,7 +408,34 @@ let test_unknown_notifications_are_bounded () =
     match run_fixture path with
     | Error (Runtime_codex_app_server.Protocol_error _) -> ()
     | Error error -> fail (Runtime_codex_app_server.error_to_string error)
-    | Ok _ -> fail "unknown notifications were unbounded")
+      | Ok _ -> fail "unknown notifications were unbounded")
+;;
+
+let test_item_output_deltas_are_typed_and_unbounded () =
+  let delta index =
+    Printf.sprintf
+      {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"command-1","delta":"chunk-%d"}}|}
+      index
+  in
+  with_fixture
+    ([ init_result; account_chatgpt; thread_result; turn_result ]
+     @ List.init 129 delta
+     @ [ item_completed; turn_completed ])
+    (fun path ->
+      match run_fixture path with
+      | Ok result ->
+        check string "terminal text" "MASC_SUBSCRIPTION_OK" result.text
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error));
+  let wrong_identity =
+    {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-other","turnId":"turn-1","itemId":"command-1","delta":"chunk"}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; wrong_identity ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "item output delta with the wrong identity was admitted")
 ;;
 
 let codex_runtime_toml ~model cli_path =
@@ -1719,10 +1746,14 @@ let () =
             "retry notifications are bounded"
             `Quick
             test_retry_notifications_are_bounded
-        ; test_case
-            "unknown notifications are bounded"
-            `Quick
-            test_unknown_notifications_are_bounded
+         ; test_case
+             "unknown notifications are bounded"
+             `Quick
+             test_unknown_notifications_are_bounded
+         ; test_case
+             "item output deltas are typed and unbounded"
+             `Quick
+             test_item_output_deltas_are_typed_and_unbounded
         ; test_case
             "turn admission validation is process-free"
             `Quick


### PR DESCRIPTION
## Summary
- expose authenticated official-client session inspection and exact CAS recovery resolution
- make resolution durable, audited, and idempotent while rejecting conflicting decisions
- retain the exact durable Keeper stimulus until the post-resolution provider turn succeeds
- reject `retry_previous` when no exact previous settlement exists
- accept current Codex app-server item delta notifications without consuming the unknown-notification budget
- validate exact `threadId`, `turnId`, `itemId`, and `delta` types while keeping truly unknown notifications bounded

## Validation
- `dune exec --root . ./test/test_official_client_session_store.exe` (8 passed)
- `dune exec --root . ./test/test_runtime_codex_app_server.exe` (29 passed, 7 opt-in live cases skipped)
- `dune build --root . bin/main_eio.exe`
- live runtime commit `4c1ec11ad2` serving on port 8935
- resolved exact kidsnote recoveries `c7226677-edad-4bad-86c7-ff41e2c5fdd1` and `559485cd-d682-4c8b-85d5-6e6a06177d04` via authenticated operator API
- live Codex Keeper returned `LIVE_CODEX_KEEPER_OK` and terminal `done/ok=true`
- durable official-client state settled at session `019fe6dd-cc70-7c12-85d0-3443e11c0352`, turn `019fe6dd-cd9d-7d90-a443-651768c95f0d`
