### PR TITLE
test(keeper): align replay projection with artifact refs

### DIFF
--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -2483,10 +2483,31 @@ let test_approved_web_search_replays_without_model_resubmission () =
              ~base_path:config.base_path
              model_message
          in
+         let projected_evidence =
+           projected_message
+           |> String.split_on_char '\n'
+           |> List.rev
+           |> List.find (fun line -> not (String.equal (String.trim line) ""))
+           |> Yojson.Safe.from_string
+         in
          check bool
-           "durable replay output reaches the provider-only projection"
-           true
+           "durable replay output stays outside the provider-only projection"
+           false
            (contains_substring projected_message "Replayed result");
+         (match
+            projected_evidence
+            |> Yojson.Safe.Util.member "untrusted_tool_output_ref"
+            |> Tool_output.normalized_artifact_ref_of_json
+          with
+          | Tool_output.Decoded_normalized_artifact_ref decoded ->
+            check string
+              "provider-only projection keeps the durable replay identity"
+              output_ref.sha256
+              decoded.sha256
+          | Tool_output.Not_normalized_artifact_ref ->
+            fail "provider replay evidence lost its artifact reference"
+          | Tool_output.Invalid_normalized_artifact_ref { detail } ->
+            fail detail);
          check bool
            "model is forbidden to request the consumed operation again"
            true


### PR DESCRIPTION
## Summary

- Align the focused WebSearch durable-replay runtime test with the canonical reference-only provider contract.
- Assert that raw replay bytes stay outside provider input while the normalized artifact SHA remains exact.
- Leave production replay behavior unchanged.

## Product impact

- User-visible change: none. The regression test no longer requires unsafe reinflation of durable tool output into provider input.

## Evidence

- Baseline on exact main `6e9882be5ffe882e3e687303290643a07587b9e9`: case 22 FAIL, because it expected `Replayed result` in provider-only projection.
- `scripts/dune-local.sh build test/test_keeper_tool_dispatch_runtime.exe`: PASS.
- `_build/default/test/test_keeper_tool_dispatch_runtime.exe test execute_keeper_tool_call_with_outcome 19-26`: 8 PASS.
- `scripts/dune-local.sh build test/test_keeper_gate_replay.exe`: PASS.
- `_build/default/test/test_keeper_gate_replay.exe`: 22 PASS.
- `opam exec -- ocamlformat --check test/test_keeper_tool_dispatch_runtime.ml`: PASS.
- `git diff --check`: PASS.
- `bash scripts/check-variants.sh`: PASS.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 7/7
provenance: direct
stages:
  - baseline_case_22_reproduction
  - focused_runtime_build
  - runtime_replay_cases_19_26
  - canonical_replay_build
  - canonical_replay_suite
  - ocamlformat_check
  - variant_guard
```

## GOAL LOOP ACT checklist

- [x] Observe — exact case 22 baseline failure reproduced on current main
- [x] Orient — mapped to issue #27816 and the reference-only replay projection contract
- [x] Decide — test-only correction; production behavior already matches its typed contract
- [x] Act — changed one assertion block in one test file
- [x] Verify — 30 focused tests plus format and variant guards pass
- [x] Loop — no remaining follow-up in this scope

## Review evidence

- Exact-diff source review: production code unchanged; test now matches `Keeper_gate_replay.project_model_input` and its interface contract.
- External reviewer: pending.

## Linked issue

- Closes #27816

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant change
- [ ] **TypeScript** — N/A: no TypeScript change
- [ ] **TLA+ spec** — N/A: no TLA+ change
- [ ] **Event / JSON schema** — N/A: no schema change
- [x] **`make check-variants` passes** — `bash scripts/check-variants.sh` PASS
