### PR TITLE
test: install Keeper owner inventory in integration fixtures

### DIFF
--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -3146,7 +3146,7 @@ let test_context_shrink_detection () =
     (shrink (with_max_override base (Some 1000)) [ ("name", `String "shrink-fixture") ])
 ;;
 
-let prepare_config_sync_keeper config name =
+let prepare_config_sync_keeper ~sw config name =
   let runtime_path = Filename.concat config.Workspace.base_path "runtime.toml" in
   write_file runtime_path config_sync_runtime_toml;
   (match Runtime.init_default ~config_path:runtime_path with
@@ -3176,9 +3176,13 @@ let prepare_config_sync_keeper config name =
       ; instructions = name ^ " config-sync fixture instructions"
       }
   in
-  match Masc.Keeper_meta_store.replace_snapshot config meta with
-  | Ok () -> ()
-  | Error error -> fail ("write meta: " ^ error)
+  (match Masc.Keeper_meta_store.replace_snapshot config meta with
+   | Ok () -> ()
+   | Error error -> fail ("write meta: " ^ error));
+  match Masc.Keeper_owner_registry.install_from_store ~sw config with
+  | Ok _ -> ()
+  | Error error ->
+    fail (Masc.Keeper_owner_registry.install_error_to_string error)
 
 let write_config_sync_toml config name =
   let dir =
@@ -3298,7 +3302,7 @@ let test_catchup_judge_prompt_failure_is_server_error () =
 let test_config_post_restarts_from_atomic_toml () =
   with_test_env @@ fun ~env ~sw ~config ->
   let name = "config-sync-success" in
-  prepare_config_sync_keeper config name;
+  prepare_config_sync_keeper ~sw config name;
   let path = write_config_sync_toml config name in
   ignore
     (post_config ~sw ~clock:(Eio.Stdenv.clock env)
@@ -3321,7 +3325,7 @@ let test_config_post_restarts_from_atomic_toml () =
 let test_config_post_materializes_missing_toml () =
   with_test_env @@ fun ~env ~sw ~config ->
   let name = "config-sync-no-toml" in
-  prepare_config_sync_keeper config name;
+  prepare_config_sync_keeper ~sw config name;
   Fun.protect
     ~finally:(fun () ->
       ignore
@@ -3358,7 +3362,7 @@ let test_config_post_materializes_missing_toml () =
 let test_config_post_reports_runtime_sync_failure () =
   with_test_env @@ fun ~env ~sw ~config ->
   let name = "config-sync-partial" in
-  prepare_config_sync_keeper config name;
+  prepare_config_sync_keeper ~sw config name;
   let toml_path = write_config_sync_toml config name in
   Sys.remove (Filename.concat config.base_path "runtime.toml");
   let raw, json =
@@ -3386,7 +3390,7 @@ let test_config_post_reports_runtime_sync_failure () =
 let test_config_post_prevalidates_mixed_request () =
   with_test_env @@ fun ~env ~sw ~config ->
   let name = "config-sync-invalid-mixed" in
-  prepare_config_sync_keeper config name;
+  prepare_config_sync_keeper ~sw config name;
   let toml_path = write_config_sync_toml config name in
   let raw, _ =
     post_config ~sw ~clock:(Eio.Stdenv.clock env)

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -284,6 +284,10 @@ let test_snapshot_keeps_context_unobserved_and_usage_separate () =
       init_runtime_default_for_snapshot base_dir;
       ignore (Workspace.init config ~agent_name:(Some "owner"));
       ignore (Workspace.bind_session config ~agent_name:"owner" ~capabilities:[] ());
+      (match Keeper_owner_registry.install_from_store ~sw config with
+       | Ok _ -> ()
+       | Error error ->
+         Alcotest.fail (Keeper_owner_registry.install_error_to_string error));
       let keeper_ctx : _ Keeper_tool_surface.context =
         {
           config;
@@ -336,9 +340,16 @@ let test_snapshot_keeps_context_unobserved_and_usage_separate () =
             };
         }
       in
-      (match Keeper_meta_store.replace_snapshot config updated_meta with
-      | Ok () -> ()
-      | Error err -> Alcotest.fail err);
+      (match
+         Keeper_owner_registry.commit_turn_runtime
+           ~base_path:config.base_path
+           ~keeper_name
+           ~before:meta
+           ~after:updated_meta
+       with
+       | Ok _ -> ()
+       | Error error ->
+         Alcotest.fail (Keeper_owner_registry.command_error_to_string error));
       Operator_control.invalidate_snapshot_cache ();
       let json =
         Operator_control.snapshot_json ~view:"summary"


### PR DESCRIPTION
## Summary

- install the per-BasePath Keeper owner inventory in Dashboard config-sync fixtures after seeding their durable metadata
- install an empty owner inventory before the Operator keeper-up fixture
- route the fixture usage update through Keeper_owner_registry.commit_turn_runtime instead of direct snapshot replacement

## Why

Main CI for squash merge 77ddc7cc0f2dd4b3afcec3375b53beeb1ac13f5d compiled successfully but exposed two stale test bootstraps in run 31317329307. Both invoked owner-authorized mutations without installing the required inventory. This repairs only the fixtures; it adds no production fallback or compatibility path.

## Verification

- scripts/dune-local.sh build @test/runtest-dashboard-http-behavior-contracts @test/runtest-test_operator_control_snapshot
- scripts/dune-local.sh build @test/runtest-test_operator_control_snapshot_state @test/runtest-test_operator_control_snapshot @test/runtest-test_operator_control_snapshot_cache @test/runtest-test_model_map_of_keeper_rows
- git diff --check

Local result: Dashboard behavior 10/10, Dashboard briefing 13/13, Operator snapshot 10/10, Operator state/cache/model projection 9/9.