### PR TITLE
fix(keeper): advance reaction ledger generation

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -24,7 +24,7 @@ module Event_id_set = Set.Make (String)
 
 (* The storage namespace and row schema advance together. Readers inspect
    exactly this namespace, keeping exact evidence under one authority. *)
-let storage_generation = "v5"
+let storage_generation = "v6"
 let schema = "keeper.reaction_ledger." ^ storage_generation
 
 let stimulus_kind_to_string = function

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -2,7 +2,7 @@
 
     Queue-visible stimuli and queue transition reactions are
     written to a replayable JSONL store under
-    [.masc/keepers/<keeper>/reaction-ledger/v5/YYYY-MM/DD.jsonl].  The
+    [.masc/keepers/<keeper>/reaction-ledger/v6/YYYY-MM/DD.jsonl].  The
     generation namespace is a hard boundary: older stores are neither read nor
     written by this module. *)
 

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -118,7 +118,7 @@ let reaction_ledger_dir ~base_path ~keeper_name =
           (Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers")
           keeper_name)
        "reaction-ledger")
-    "v5"
+    "v6"
 ;;
 
 let reaction_ledger_store ~base_path ~keeper_name =
@@ -186,7 +186,7 @@ let test_event_queue_stimulus_and_turn_reaction () =
   in
   check int "two rows persisted" 2 (List.length rows);
   let stimulus_row = List.nth rows 0 in
-  check_member_string "stimulus schema" "keeper.reaction_ledger.v5" "schema" stimulus_row;
+  check_member_string "stimulus schema" "keeper.reaction_ledger.v6" "schema" stimulus_row;
   check_member_string "stimulus record kind" "stimulus" "record_kind" stimulus_row;
   check_member_string "board stimulus id" "board:post-42" "stimulus_id" stimulus_row;
   check_member_string
@@ -264,7 +264,7 @@ let test_unknown_record_kind_is_quarantined_not_fatal () =
   Dated_jsonl.append
     (reaction_ledger_store ~base_path ~keeper_name)
     (`Assoc
-        [ "schema", `String "keeper.reaction_ledger.v5"
+        [ "schema", `String "keeper.reaction_ledger.v6"
         ; "record_kind", `String "unexpected"
         ; "event_id", `String "krl:unknown-record-kind-fixture"
         ; "keeper_name", `String keeper_name
@@ -647,7 +647,7 @@ let test_unknown_reaction_is_quarantined_without_clearing_pending () =
   Dated_jsonl.append
     (reaction_ledger_store ~base_path ~keeper_name)
     (`Assoc
-        [ "schema", `String "keeper.reaction_ledger.v5"
+        [ "schema", `String "keeper.reaction_ledger.v6"
         ; "record_kind", `String "reaction"
         ; "event_id", `String (stimulus_id ^ ":reaction:turn_started")
         ; "keeper_name", `String keeper_name
@@ -977,7 +977,7 @@ let test_missing_identity_does_not_claim_an_occurrence_identity () =
   Dated_jsonl.append
     (reaction_ledger_store ~base_path ~keeper_name)
     (`Assoc
-        [ "schema", `String "keeper.reaction_ledger.v5"
+        [ "schema", `String "keeper.reaction_ledger.v6"
         ; "record_kind", `String "stimulus"
         ; "event_id", `String "unattributed-event"
         ; "keeper_name", `String keeper_name

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -68,7 +68,7 @@ let reaction_ledger_dir ~base_path ~keeper_name =
           (Common.keepers_runtime_dir_of_base ~base_path)
           keeper_name)
        "reaction-ledger")
-    "v5"
+    "v6"
 ;;
 
 let write_malformed_reaction_ledger_row ~base_path ~keeper_name =
@@ -1739,7 +1739,7 @@ let test_dashboard_projects_quarantined_and_unreadable_reaction_evidence () =
        ~base_dir:(reaction_ledger_dir ~base_path ~keeper_name)
        ())
     (`Assoc
-        [ "schema", `String "keeper.reaction_ledger.v5"
+        [ "schema", `String "keeper.reaction_ledger.v6"
         ; "record_kind", `String "reaction"
         ; "event_id", `String (stimulus_id ^ ":reaction:turn_started")
         ; "keeper_name", `String keeper_name


### PR DESCRIPTION
## Problem

The current reaction-ledger decoder accepts only `stimulus` and `reaction`, but storage still uses the historical `v5` namespace that contains removed `cursor_ack` rows. Health therefore quarantines valid historical rows as `unknown_record_kind`.

## Change

- advance the current reaction-ledger namespace and schema to `v6`
- update the public storage contract documentation
- update reaction-ledger and schedule-consumer contract fixtures
- do not restore a legacy `cursor_ack` decoder or migrate old rows

## Runtime effect

Current writes/readbacks use a clean generation. Existing v5 artifacts remain untouched but no longer degrade current health.

## Validation

Not run locally; draft CI is authoritative.