### PR TITLE
perf(ci): remove duplicate guards and warm Dune cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -775,11 +775,11 @@ jobs:
       - name: Build
         id: build_step
         env:
-          # Group 1 links hundreds of native test executables against the full
-          # masc_test_deps graph. Serializing this build bounds concurrent
-          # native-link disk pressure without changing the test backend or
-          # dropping native Domain/C-stub coverage.
-          DUNE_JOBS: "1"
+          # Two workers use the hosted runner's available parallelism while
+          # bounding concurrent native links. Run 31319982424 had 110 GB free
+          # after cleanup, so the former fully-serial setting no longer bought
+          # disk safety and made the cold compile the 24-minute critical path.
+          DUNE_JOBS: "2"
         # NO continue-on-error: dune build is deterministic and must hard-fail.
         # Focused test execution steps below are also required: any failing
         # suite fails the Build and Test job and blocks merge via the CI Gate.
@@ -1752,6 +1752,14 @@ jobs:
         with:
           name: release-evidence-main
           path: .release-evidence/
+
+      - name: Trim Dune cache for main publication
+        if: ${{ always() && steps.build_step.outcome == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: |
+          set -euo pipefail
+          echo "Dune cache before trim: $(du -sh "${HOME}/.cache/dune" | cut -f1)"
+          opam exec -- dune cache trim --size=6GiB
+          echo "Dune cache after trim: $(du -sh "${HOME}/.cache/dune" | cut -f1)"
 
       - name: Config diagnostic drift report
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -69,7 +69,9 @@ jobs:
             "${{ github.event.pull_request.base.sha }}"
       - name: Run blocking lints (push)
         if: github.event_name != 'pull_request'
-        run: bash scripts/ci/run-lint-suite.sh blocking
+        run: >-
+          bash scripts/ci/run-lint-suite.sh blocking
+          "${{ github.event.before }}"
 
   lint-advisory:
     name: Lint Suite (advisory)

--- a/scripts/ci/run-lint-suite.sh
+++ b/scripts/ci/run-lint-suite.sh
@@ -9,7 +9,7 @@
 # preserving the old "see all failures at once" property.
 #
 # Modes:
-#   run-lint-suite.sh blocking            # every always-on blocking lint
+#   run-lint-suite.sh blocking [BASE]     # every always-on blocking lint
 #   run-lint-suite.sh blocking-pr BASE    # + PR-only diff guards vs BASE
 #   run-lint-suite.sh advisory            # non-blocking lints (job uses
 #                                         # continue-on-error)
@@ -36,19 +36,47 @@ run_lint() {
   fi
 }
 
+run_self_test_when_changed() {
+  local label="$1"
+  local script="$2"
+  shift 2
+
+  # A checker's synthetic fixtures validate the checker implementation, not
+  # every product change. Run them when the checker changes; the real checks
+  # remain owned by ci.yml's Meta Guards on every heavy CI run. If the base is
+  # unavailable (manual/initial push), fail safe by running the self-test.
+  if [[ -n "${base_sha}" && "${base_sha}" != "0000000000000000000000000000000000000000" ]] \
+    && git cat-file -e "${base_sha}^{commit}" 2>/dev/null \
+    && git diff --quiet "${base_sha}" HEAD -- "${script}"
+  then
+    echo "::notice::Skipping ${label}; ${script} is unchanged"
+    return
+  fi
+
+  run_lint "${label}" "$@"
+}
+
 blocking_lints() {
   run_lint "Hardcoded model prefix" bash scripts/lint/no-roadmap-stale-hardcoding.sh
   run_lint "Raw font-size px" bash scripts/lint/no-raw-font-size-px.sh
   run_lint "OCaml comment terminator trap" bash scripts/lint/no-ocaml-comment-terminator-trap.sh
   run_lint "Timeout env knob ceiling (RFC-0138)" bash scripts/lint/timeout-env-ceiling.sh
-  run_lint ".mli env knob exists self-test" bash scripts/lint/mli-env-knob-exists.sh --self-test
+  run_self_test_when_changed ".mli env knob exists self-test" \
+    scripts/lint/mli-env-knob-exists.sh \
+    bash scripts/lint/mli-env-knob-exists.sh --self-test
   run_lint ".mli env knob exists" bash scripts/lint/mli-env-knob-exists.sh --fail
-  run_lint "Guard scan targets exist self-test" bash scripts/lint/guard-scan-targets-exist.sh --self-test
+  run_self_test_when_changed "Guard scan targets exist self-test" \
+    scripts/lint/guard-scan-targets-exist.sh \
+    bash scripts/lint/guard-scan-targets-exist.sh --self-test
   run_lint "Guard scan targets exist" bash scripts/lint/guard-scan-targets-exist.sh --fail
-  run_lint "CI gate outcome vocabulary self-test" bash scripts/ci/check-gate-outcome-vocabulary.sh --self-test
+  run_self_test_when_changed "CI gate outcome vocabulary self-test" \
+    scripts/ci/check-gate-outcome-vocabulary.sh \
+    bash scripts/ci/check-gate-outcome-vocabulary.sh --self-test
   run_lint "CI gate outcome vocabulary" bash scripts/ci/check-gate-outcome-vocabulary.sh --fail
   run_lint "Opam cache freshness ratchet" bash scripts/ci/opam-cache-freshness.sh --check
-  run_lint "Opam cache freshness self-test" bash scripts/ci/opam-cache-freshness.sh --self-test
+  run_self_test_when_changed "Opam cache freshness self-test" \
+    scripts/ci/opam-cache-freshness.sh \
+    bash scripts/ci/opam-cache-freshness.sh --self-test
   run_lint "No actionable-signal bool context" bash scripts/lint/no-actionable-signal-bool-context.sh
   run_lint "Provider name hardcoding ratchet" bash scripts/lint/no-provider-name-hardcoding.sh --fail
   run_lint "Keeper behavior hardcoding" bash scripts/lint/no-keeper-behavior-hardcoding.sh
@@ -59,13 +87,16 @@ blocking_lints() {
   run_lint "Tool substrate adapter surface" bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail
   run_lint "Tool -> Keeper dependency-direction ratchet (RFC-0194)" bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail
   run_lint "MASC domain ownership ratchet" bash scripts/lint/masc-domain-boundary-ratchet.sh --fail
-  run_lint "Keeper turn content boundary self-test" bash scripts/check-keeper-turn-content-boundary.sh --self-test
-  run_lint "Keeper turn content boundary" bash scripts/check-keeper-turn-content-boundary.sh --check
-  run_lint "Compaction exact-flow boundary self-test" bash scripts/check-compaction-exact-flow-boundary.sh --self-test
-  run_lint "Compaction exact-flow boundary" bash scripts/check-compaction-exact-flow-boundary.sh
+  run_self_test_when_changed "Keeper turn content boundary self-test" \
+    scripts/check-keeper-turn-content-boundary.sh \
+    bash scripts/check-keeper-turn-content-boundary.sh --self-test
+  run_self_test_when_changed "Compaction exact-flow boundary self-test" \
+    scripts/check-compaction-exact-flow-boundary.sh \
+    bash scripts/check-compaction-exact-flow-boundary.sh --self-test
   run_lint "No Tool_result.error + Printexc (RFC-0148)" bash scripts/lint/no-tool-result-error-printexc.sh
-  run_lint "Board attention exact-flow boundary self-test" bash scripts/check-board-attention-exact-flow-boundary.sh --self-test
-  run_lint "Board attention exact-flow boundary" bash scripts/check-board-attention-exact-flow-boundary.sh --check
+  run_self_test_when_changed "Board attention exact-flow boundary self-test" \
+    scripts/check-board-attention-exact-flow-boundary.sh \
+    bash scripts/check-board-attention-exact-flow-boundary.sh --self-test
   run_lint "Boundary redaction SSOT (RFC-0132 PR-3)" bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail
   run_lint "No fabricated telemetry" bash scripts/lint/no-fabricated-telemetry.sh
   run_lint "No inline ok-envelope literals" bash scripts/lint/no-inline-ok-envelope.sh
@@ -76,7 +107,6 @@ blocking_lints() {
   run_lint "Board SLO extractor fixture" bash scripts/test-board-slo-extractor.sh
   run_lint "Branch protection fail-closed fixture" bash scripts/test-main-branch-protection-fail-closed.sh
   run_lint "Feedback-loop metrics fixture" bash scripts/test-feedback-loop-metrics.sh
-  run_lint "audit-path-ssot" bash scripts/audit-path-ssot.sh
 }
 
 blocking_pr_lints() {


### PR DESCRIPTION
## Summary

- hard-cut four exact-flow/path audits from `Fundamental Check` because `CI / Meta Guards` already owns and runs the same scripts
- run checker self-tests only when the checker itself changed; real repository checks still run on every heavy CI execution
- raise the cold compile from one to two bounded Dune workers
- trim the main Dune cache to 6 GiB before publication so it fits the repository cache budget and can actually warm later PRs

## Measured baseline

- successful PR CI run `31320014005`: `Build and Test` 33m17s, initial Dune build 22m00s
- successful main CI run `31319982424`: `Build and Test` 49m15s, initial Dune build 24m27s, Dune cache upload 12.6 GB / 2m47s
- successful Fundamental run `31322222427`: blocking lints 4m52s; 4m31s was the Board attention checker self-test
- repository cache API after that main run exposed no reusable main Dune cache

## Local verification

- `git diff --check`
- `bash -n scripts/ci/run-lint-suite.sh`
- `python3 scripts/ci/check-yaml-syntax.py` (38 files)
- `bash scripts/ci/run-lint-suite.sh blocking origin/main` (29/29, 21.6s vs 292s observed baseline)
- all four audits retained by Meta Guards pass directly:
  - keeper turn content boundary
  - compaction exact-flow boundary
  - Board attention exact-flow boundary
  - path SSOT

## Runtime proof still needed

The draft CI run must prove the two-worker native-link bound. The first post-merge main run must prove the trimmed Dune cache publishes under quota; the following PR run is the authoritative cache-hit/time measurement.
