### PR TITLE
perf(ci): remove ineffective Dune cache

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -6,16 +6,8 @@ inputs:
     description: OCaml compiler version (MASC supports exactly 5.5.0)
     required: false
     default: "5.5.0"
-  dune-cache:
-    description: Whether to enable dune cache
-    required: false
-    default: "true"
-  dune-cache-save:
-    description: Whether this job is the authoritative main-branch Dune cache writer
-    required: false
-    default: "false"
   cache-prefix:
-    description: Prefix for the dune cache key
+    description: Prefix for the OCaml toolchain cache key
     required: false
     default: oas-otel-02
 
@@ -37,7 +29,6 @@ runs:
       uses: ocaml/setup-ocaml@v3.6.0
       with:
         ocaml-compiler: ${{ inputs.ocaml-compiler }}
-        dune-cache: ${{ inputs.dune-cache }}
 
     - name: Cache OCaml toolchain (Linux)
       id: opam-toolchain-cache
@@ -50,60 +41,6 @@ runs:
         key: opam-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ hashFiles('*.opam', 'dune-project', 'scripts/opam-pin-external-deps.sh') }}-v2
         restore-keys: |
           opam-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
-
-    # The opam cache above only restores the toolchain/switch; every dune
-    # build of masc itself still started cold (~50 min Build and Test).
-    # Cache dune's content-addressed artifact store so an unchanged module
-    # graph rebuilds incrementally. Pull requests and non-authoritative jobs are
-    # restore-only: PR caches are ref-scoped and cannot warm other PRs, while
-    # partial Health/Lint artifacts must not race the full Build cache. Exactly
-    # one authoritative job per cache-prefix opts into the main-branch writer.
-    # The run id gives each main publication an immutable key; restore picks the
-    # newest cache in that trusted lineage.
-    - name: Restore dune build artifacts (Linux)
-      if: runner.os == 'Linux' && inputs.dune-cache == 'true' && (inputs.dune-cache-save != 'true' || github.event_name != 'push' || github.ref != 'refs/heads/main')
-      uses: actions/cache/restore@v5
-      with:
-        path: ~/.cache/dune
-        key: dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ github.run_id }}
-        restore-keys: |
-          dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
-
-    - name: Cache dune build artifacts (Linux authoritative main writer)
-      if: runner.os == 'Linux' && inputs.dune-cache == 'true' && inputs.dune-cache-save == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/dune
-        key: dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ github.run_id }}
-        restore-keys: |
-          dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
-
-    # Storage mode is hardlink, not copy. `copy` keeps every artifact twice:
-    # once in _build and once in ~/.cache/dune. On ubuntu-latest that
-    # duplication exhausted the runner disk and the Build and Test job of run
-    # 29090394322 (main, the #23996 merge) died while linking a test
-    # executable, with zero free space reported by the runner. Both paths live
-    # on `/`, so dune can hardlink cache entries into _build and keep a single
-    # copy on disk.
-    #
-    # This explanation stays a YAML comment on purpose. GitHub echoes the whole
-    # `run:` script into the job log, so a shell comment quoting the linker and
-    # disk-space messages would plant those exact strings in every job log —
-    # scripts/ci-run-tests.sh preserves them in failure diagnostics.
-    - name: Enable dune cache (Linux)
-      if: runner.os == 'Linux' && inputs.dune-cache == 'true'
-      shell: bash
-      run: |
-        # hardlink, NOT copy: copy mode duplicates every artifact into
-        # ~/.cache/dune, roughly doubling disk while the cache populates.
-        # The first cache-cold Build and Test after #23996 died at link time
-        # with "/usr/bin/ld: final link failed: No space left on device"
-        # (run 29091172837). ~/.cache/dune and the workspace share one
-        # filesystem on GitHub runners, so hardlinks add no meaningful space.
-        {
-          echo "DUNE_CACHE=enabled"
-          echo "DUNE_CACHE_STORAGE_MODE=hardlink"
-        } >> "$GITHUB_ENV"
 
     - name: Bootstrap local opam switch (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,8 +731,6 @@ jobs:
 
       - name: Setup OCaml toolchain
         uses: ./.github/actions/setup-ocaml-toolchain
-        with:
-          dune-cache-save: "true"
 
       - name: Pin external OCaml dependencies
         uses: ./.github/actions/pin-ocaml-deps
@@ -1746,14 +1744,6 @@ jobs:
         with:
           name: release-evidence-main
           path: .release-evidence/
-
-      - name: Trim Dune cache for main publication
-        if: ${{ always() && steps.build_step.outcome == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: |
-          set -euo pipefail
-          echo "Dune cache before trim: $(du -sh "${HOME}/.cache/dune" | cut -f1)"
-          opam exec -- dune cache trim --size=6GiB
-          echo "Dune cache after trim: $(du -sh "${HOME}/.cache/dune" | cut -f1)"
 
       - name: Config diagnostic drift report
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -12,9 +12,8 @@ on:
   # restore caches created on its own ref or on the default branch. Without a
   # main-scoped entry every PR cold-misses, rebuilds the opam switch, and saves
   # a duplicate into its own PR scope — on 2026-07-16 that was 42 duplicate
-  # v3-setup-ocaml entries (5.48 GB of the repo's 10 GB quota) whose LRU
-  # pressure evicted the Build and Test dune cache (dune-linux-oas-otel-02
-  # had zero live entries), forcing every build cold.
+  # v3-setup-ocaml entries (5.48 GB of the repo's 10 GB quota). Seed one
+  # reusable formatter toolchain on main instead of spending quota per PR.
   push:
     branches: [main]
     paths:

--- a/.github/workflows/webrtc-live-interop.yml
+++ b/.github/workflows/webrtc-live-interop.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup OCaml
         uses: ./.github/actions/setup-ocaml-toolchain
-        with:
-          dune-cache: true
 
       - name: Setup Node
         uses: actions/setup-node@v7


### PR DESCRIPTION
## Summary

- remove Dune cache restore/save from the shared OCaml toolchain action
- remove the now-dead Dune cache inputs and main trim step
- keep the effective opam toolchain cache unchanged

## Evidence

The cache was not warming CI:

- pre-change main cache upload from run `31319982424`: 12,615,351,067 bytes, then evicted
- after the attempted 6 GiB logical trim, runs `31322754233` and `31322745097` still uploaded 12,615,833,107 and 12,616,098,056 byte archives
- repository cache usage then returned to zero Dune entries
- each upload consumed about 3m13s in the successful #27837 main run without producing a durable restorable cache

The cold compile no longer needs this facade for acceptable latency: #27837's exact main run compiled with two bounded workers in 13m32s versus the previous 24m27s serial baseline, and all focused suites passed.

## Verification

- `git diff --check`
- `python3 scripts/ci/check-yaml-syntax.py` (38 files)
- `bash scripts/lint/yaml-syntax.sh` (20 workflow files)
- `bash scripts/ci/opam-cache-freshness.sh --check`
- repository-wide `.github` search: no remaining Dune cache inputs, cache keys, or paths
