### PR TITLE
fix(keeper): preserve official-client history across OAS checkpoints

### DIFF
--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -19,6 +19,57 @@ let text_of_blocks ~runtime_label ~field blocks =
   loop [] blocks
 ;;
 
+type history_projection =
+  { messages : Agent_sdk.Types.message list
+  ; dropped_tool_messages : int
+  ; dropped_messages : int
+  ; dropped_blocks : int
+  }
+
+(* The official-client wire admits text-only user/assistant history
+   ([text_of_blocks] rejects every other block, and Tool-role messages are not
+   representable at all). Project the representable subset instead of erasing
+   the whole history, and account for every dropped part so the caller can
+   surface the loss (masc#27812). *)
+let project_official_history messages =
+  let project
+      (kept, dropped_tool, dropped_msgs, dropped_blocks)
+      (message : Agent_sdk.Types.message) =
+    match message.role with
+    | Tool -> kept, dropped_tool + 1, dropped_msgs, dropped_blocks
+    | System | User | Assistant ->
+      let text_blocks, other_blocks =
+        List.partition
+          (function
+            | Agent_sdk.Types.Text _ -> true
+            | _ -> false)
+          message.content
+      in
+      let dropped_blocks = dropped_blocks + List.length other_blocks in
+      (match text_blocks, message.content with
+       | [], _ :: _ -> kept, dropped_tool, dropped_msgs + 1, dropped_blocks
+       | _, _ ->
+         ( { message with content = text_blocks } :: kept
+         , dropped_tool
+         , dropped_msgs
+         , dropped_blocks ))
+  in
+  let kept, dropped_tool_messages, dropped_messages, dropped_blocks =
+    List.fold_left project ([], 0, 0, 0) messages
+  in
+  { messages = List.rev kept
+  ; dropped_tool_messages
+  ; dropped_messages
+  ; dropped_blocks
+  }
+;;
+
+let history_projection_lossless projection =
+  projection.dropped_tool_messages = 0
+  && projection.dropped_messages = 0
+  && projection.dropped_blocks = 0
+;;
+
 let user_message text : Agent_sdk.Types.message =
   { role = User
   ; content = [ Text text ]

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -54,6 +54,24 @@ val text_of_blocks :
   Agent_sdk.Types.content_block list ->
   (string, Agent_sdk.Error.sdk_error) result
 
+type history_projection =
+  { messages : Agent_sdk.Types.message list
+  ; dropped_tool_messages : int
+  ; dropped_messages : int
+  ; dropped_blocks : int
+  }
+
+(** Project canonical history onto the official-client wire, which admits
+    text-only user/assistant items. Tool-role messages are dropped whole,
+    non-text blocks are stripped from kept messages, and a message left
+    without any text is dropped; every drop is counted. The representable
+    remainder keeps its original order (masc#27812). *)
+val project_official_history :
+  Agent_sdk.Types.message list -> history_projection
+
+(** [true] when the projection dropped nothing. *)
+val history_projection_lossless : history_projection -> bool
+
 val hook_error :
   runtime_label:string ->
   hook_name:string ->

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -385,6 +385,8 @@ let decision_public_allowlist =
     ; "routing_action"; "routing_reason"; "degraded_runtime_id"
     ; "runtime_execution_built"
     ; "media_dropped_total"; "media_dropped_counts"
+    ; "history_kept_messages"; "history_dropped_tool_messages"
+    ; "history_dropped_messages"; "history_dropped_blocks"
     ; "payload_role"; "trigger"; "trigger_detail"
     ; "ratio"; "threshold"; "count"
     ; "source_requeued"; compaction_outcome_key

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -715,20 +715,70 @@ let run_named
                         "provider config transforms cannot target a \
                          codex-app-server runtime"
                     }))
-          | None, Some _ ->
-            Log.Keeper.info
-              "%s: starting official-client runtime %s as a fresh session; OAS checkpoint is not resumed"
-              keeper_name attempt_runtime_id;
-            emit_runtime_manifest
-              ~status:"fresh_session"
-              ~decision:
-                (`Assoc
-                  [ ("routing_action", `String "official_client_fresh_session")
-                  ; ("routing_reason", `String "official_client_owns_session_state")
-                  ])
-              Keeper_runtime_manifest.Runtime_routed;
-            run_codex ~initial_messages:[] ()
-          | None, None -> run_codex ~initial_messages ()
+          | None, checkpoint ->
+            (* The official-client session store is the start-or-resume
+               authority ([Keeper_codex_runtime] reads the durable
+               [previous_settlement]); the OAS checkpoint payload is never
+               replayed on this lane, but the representable canonical history
+               is preserved instead of being erased with it (masc#27812). *)
+            (match checkpoint with
+             | Some _ ->
+               Log.Keeper.info
+                 "%s: official-client runtime %s resolves start-or-resume from \
+                  its durable session store; the OAS checkpoint payload is not \
+                  replayed"
+                 keeper_name attempt_runtime_id;
+               emit_runtime_manifest
+                 ~status:"checkpoint_not_replayed"
+                 ~decision:
+                   (`Assoc
+                     [ ( "routing_action"
+                       , `String "official_client_checkpoint_not_replayed" )
+                     ; ( "routing_reason"
+                       , `String "official_client_session_store_owns_resume" )
+                     ])
+                 Keeper_runtime_manifest.Runtime_routed
+             | None -> ());
+            let ({ Keeper_official_client_host.messages = projected_history
+                 ; dropped_tool_messages
+                 ; dropped_messages
+                 ; dropped_blocks
+                 } as projection)
+              =
+              Keeper_official_client_host.project_official_history
+                initial_messages
+            in
+            if
+              not
+                (Keeper_official_client_host.history_projection_lossless
+                   projection)
+            then (
+              Log.Keeper.warn
+                "%s: official-client runtime %s history projection dropped %d \
+                 tool message(s), %d unrepresentable message(s), %d non-text \
+                 block(s); the text-only remainder is preserved"
+                keeper_name
+                attempt_runtime_id
+                dropped_tool_messages
+                dropped_messages
+                dropped_blocks;
+              emit_runtime_manifest
+                ~status:"degraded"
+                ~decision:
+                  (`Assoc
+                    [ ( "routing_action"
+                      , `String "official_client_history_projected" )
+                    ; ( "routing_reason"
+                      , `String "official_client_wire_admits_text_only_history"
+                      )
+                    ; ( "history_kept_messages"
+                      , `Int (List.length projected_history) )
+                    ; ("history_dropped_tool_messages", `Int dropped_tool_messages)
+                    ; ("history_dropped_messages", `Int dropped_messages)
+                    ; ("history_dropped_blocks", `Int dropped_blocks)
+                    ])
+                Keeper_runtime_manifest.Runtime_routed);
+            run_codex ~initial_messages:projected_history ()
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let codex_result =

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -218,6 +218,108 @@ let test_cancellation_records_terminal_raw_observation () =
     check int "one tool finish" 1 (count Agent_sdk.Raw_trace.Tool_execution_finished))
 ;;
 
+let msg role content : Agent_sdk.Types.message =
+  { role; content; name = None; tool_call_id = None; metadata = [] }
+;;
+
+let text value = Agent_sdk.Types.Text value
+
+let projection_counts
+    { Host.messages = _; dropped_tool_messages; dropped_messages; dropped_blocks } =
+  dropped_tool_messages, dropped_messages, dropped_blocks
+;;
+
+(* Feeding the projected output back through the strict [text_of_blocks] both
+   extracts the kept text and proves the projection satisfies the runtime's
+   admission invariant. Expected values below stay literal. *)
+let projected_texts (projection : Host.history_projection) =
+  List.map
+    (fun (message : Agent_sdk.Types.message) ->
+      match
+        Host.text_of_blocks
+          ~runtime_label:"Test"
+          ~field:"projection"
+          message.content
+      with
+      | Ok value -> value
+      | Error _ -> fail "projected message still holds non-text blocks")
+    projection.Host.messages
+;;
+
+let test_lossless_history_is_preserved_verbatim () =
+  let projection =
+    Host.project_official_history
+      [ msg Agent_sdk.Types.User [ text "prior user turn" ]
+      ; msg Agent_sdk.Types.Assistant [ text "prior assistant reply" ]
+      ]
+  in
+  check
+    (list string)
+    "kept texts"
+    [ "prior user turn"; "prior assistant reply" ]
+    (projected_texts projection);
+  check (triple int int int) "no drops" (0, 0, 0) (projection_counts projection);
+  check bool "lossless" true (Host.history_projection_lossless projection)
+;;
+
+let test_tool_messages_are_dropped_and_counted () =
+  let projection =
+    Host.project_official_history
+      [ msg Agent_sdk.Types.User [ text "prior user turn" ]
+      ; Agent_sdk.Types.tool_result_msg
+          ~tool_use_id:"call-1"
+          ~content:"tool output"
+          ()
+      ]
+  in
+  check (list string) "kept texts" [ "prior user turn" ] (projected_texts projection);
+  check
+    (triple int int int)
+    "tool message dropped"
+    (1, 0, 0)
+    (projection_counts projection);
+  check bool "lossy" false (Host.history_projection_lossless projection)
+;;
+
+let test_non_text_blocks_are_stripped_from_kept_messages () =
+  let projection =
+    Host.project_official_history
+      [ msg
+          Agent_sdk.Types.Assistant
+          [ Agent_sdk.Types.Thinking
+              { content = "hidden reasoning"; signature = None }
+          ; text "visible reply"
+          ; Agent_sdk.Types.ToolUse
+              { id = "call-1"; name = "prior_tool"; input = `Assoc [] }
+          ]
+      ]
+  in
+  check (list string) "kept texts" [ "visible reply" ] (projected_texts projection);
+  check
+    (triple int int int)
+    "blocks stripped"
+    (0, 0, 2)
+    (projection_counts projection)
+;;
+
+let test_fully_unrepresentable_message_is_dropped () =
+  let projection =
+    Host.project_official_history
+      [ msg
+          Agent_sdk.Types.Assistant
+          [ Agent_sdk.Types.ToolUse
+              { id = "call-1"; name = "prior_tool"; input = `Assoc [] }
+          ]
+      ]
+  in
+  check (list string) "no kept texts" [] (projected_texts projection);
+  check
+    (triple int int int)
+    "message dropped"
+    (0, 1, 1)
+    (projection_counts projection)
+;;
+
 let () =
   run
     "keeper official-client host"
@@ -250,6 +352,24 @@ let () =
             "cancellation records terminal RAW observation"
             `Quick
             test_cancellation_records_terminal_raw_observation
+        ] )
+    ; ( "history projection"
+      , [ test_case
+            "lossless history is preserved verbatim"
+            `Quick
+            test_lossless_history_is_preserved_verbatim
+        ; test_case
+            "tool messages are dropped and counted"
+            `Quick
+            test_tool_messages_are_dropped_and_counted
+        ; test_case
+            "non-text blocks are stripped from kept messages"
+            `Quick
+            test_non_text_blocks_are_stripped_from_kept_messages
+        ; test_case
+            "fully unrepresentable message is dropped"
+            `Quick
+            test_fully_unrepresentable_message_is_dropped
         ] )
     ]
 ;;

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -749,7 +749,30 @@ let test_run_named_media_degrade_emits_typed_manifest () =
         "primary.test_model"
         (string_member "degraded_runtime_id" decision))
 
-let test_oas_checkpoint_starts_fresh_official_client_session () =
+let int_member key json =
+  match assoc_member key json with
+  | Some (`Int value) -> value
+  | _ ->
+    Alcotest.failf "expected int member %S in %s" key (Yojson.Safe.to_string json)
+
+let routed_rows_with_status status manifests =
+  List.filter
+    (fun (manifest : Runtime_manifest.t) ->
+       manifest.event = Runtime_manifest.Runtime_routed
+       && String.equal manifest.status status)
+    manifests
+
+let history_projection_rows manifests =
+  routed_rows_with_status "degraded" manifests
+  |> List.filter (fun (manifest : Runtime_manifest.t) ->
+    let decision =
+      Runtime_manifest.public_projection_of_decision manifest.decision
+    in
+    match assoc_member "routing_action" decision with
+    | Some (`String "official_client_history_projected") -> true
+    | _ -> false)
+
+let run_checkpoint_lane_turn ~history_messages ~on_manifests =
   with_runtime_config runtime_toml_checkpoint_lane (fun () ->
     Eio_main.run
     @@ fun env ->
@@ -764,22 +787,6 @@ let test_oas_checkpoint_starts_fresh_official_client_session () =
       ; manifest_generation = Some 1
       ; manifest_keeper_turn_id = Some 1
       }
-    in
-    let history_messages =
-      [ message
-          [ Agent_sdk.Types.Thinking
-              { content = "prior provider reasoning"; signature = None }
-          ; Agent_sdk.Types.ToolUse
-              { id = "prior-tool-call"
-              ; name = "prior_tool"
-              ; input = `Assoc []
-              }
-          ]
-      ; Agent_sdk.Types.tool_result_msg
-          ~tool_use_id:"prior-tool-call"
-          ~content:"prior tool result"
-          ()
-      ]
     in
     let checkpoint =
       { (checkpoint_with_session_id "oas-session") with
@@ -810,29 +817,102 @@ let test_oas_checkpoint_starts_fresh_official_client_session () =
         (Agent_sdk.Error.Config
            (Agent_sdk.Error.InvalidConfig { field = "initial_messages"; _ })) ->
       Alcotest.fail
-        "a fresh official-client session must not import OAS history"
-    | Error _ ->
-      let fresh_session =
-        List.find_opt
-          (fun (manifest : Runtime_manifest.t) ->
-             manifest.event = Runtime_manifest.Runtime_routed
-             && String.equal manifest.status "fresh_session")
-          !manifests
+        "projected official-client history must stay representable"
+    | Error _ -> on_manifests !manifests)
+
+let test_oas_checkpoint_preserves_official_client_history () =
+  let history_messages =
+    [ message
+        ~role:Agent_sdk.Types.User
+        [ Agent_sdk.Types.Text "prior user turn" ]
+    ; message
+        [ Agent_sdk.Types.Thinking
+            { content = "prior provider reasoning"; signature = None }
+        ; Agent_sdk.Types.ToolUse
+            { id = "prior-tool-call"
+            ; name = "prior_tool"
+            ; input = `Assoc []
+            }
+        ]
+    ; Agent_sdk.Types.tool_result_msg
+        ~tool_use_id:"prior-tool-call"
+        ~content:"prior tool result"
+        ()
+    ]
+  in
+  run_checkpoint_lane_turn ~history_messages ~on_manifests:(fun manifests ->
+    (match routed_rows_with_status "fresh_session" manifests with
+     | [] -> ()
+     | _ :: _ ->
+       Alcotest.fail "the retired fresh_session manifest row must not reappear");
+    (match routed_rows_with_status "checkpoint_not_replayed" manifests with
+     | [ manifest ] ->
+       let decision =
+         Runtime_manifest.public_projection_of_decision manifest.decision
+       in
+       Alcotest.(check string)
+         "checkpoint routing action"
+         "official_client_checkpoint_not_replayed"
+         (string_member "routing_action" decision);
+       Alcotest.(check string)
+         "checkpoint routing reason"
+         "official_client_session_store_owns_resume"
+         (string_member "routing_reason" decision)
+     | [] ->
+       Alcotest.fail "checkpoint_not_replayed manifest row was not observable"
+     | _ :: _ :: _ ->
+       Alcotest.fail "expected exactly one checkpoint_not_replayed row");
+    match history_projection_rows manifests with
+    | [ manifest ] ->
+      let decision =
+        Runtime_manifest.public_projection_of_decision manifest.decision
       in
-      (match fresh_session with
-       | None -> Alcotest.fail "fresh official-client session was not observable"
-       | Some manifest ->
-         let decision =
-           Runtime_manifest.public_projection_of_decision manifest.decision
-         in
-         Alcotest.(check string)
-           "fresh-session routing action"
-           "official_client_fresh_session"
-           (string_member "routing_action" decision);
-         Alcotest.(check string)
-           "fresh-session routing reason"
-           "official_client_owns_session_state"
-           (string_member "routing_reason" decision)))
+      Alcotest.(check string)
+        "projection routing reason"
+        "official_client_wire_admits_text_only_history"
+        (string_member "routing_reason" decision);
+      Alcotest.(check int)
+        "kept messages"
+        1
+        (int_member "history_kept_messages" decision);
+      Alcotest.(check int)
+        "dropped tool messages"
+        1
+        (int_member "history_dropped_tool_messages" decision);
+      Alcotest.(check int)
+        "dropped messages"
+        1
+        (int_member "history_dropped_messages" decision);
+      Alcotest.(check int)
+        "dropped blocks"
+        2
+        (int_member "history_dropped_blocks" decision)
+    | [] ->
+      Alcotest.fail "official-client history projection row was not observable"
+    | _ :: _ :: _ -> Alcotest.fail "expected exactly one history projection row")
+
+let test_lossless_official_client_history_emits_no_projection_row () =
+  let history_messages =
+    [ message
+        ~role:Agent_sdk.Types.User
+        [ Agent_sdk.Types.Text "prior user turn" ]
+    ; message [ Agent_sdk.Types.Text "prior assistant reply" ]
+    ]
+  in
+  run_checkpoint_lane_turn ~history_messages ~on_manifests:(fun manifests ->
+    (match routed_rows_with_status "fresh_session" manifests with
+     | [] -> ()
+     | _ :: _ ->
+       Alcotest.fail "the retired fresh_session manifest row must not reappear");
+    (match routed_rows_with_status "checkpoint_not_replayed" manifests with
+     | [ _ ] -> ()
+     | [] ->
+       Alcotest.fail "checkpoint_not_replayed manifest row was not observable"
+     | _ :: _ :: _ ->
+       Alcotest.fail "expected exactly one checkpoint_not_replayed row");
+    match history_projection_rows manifests with
+    | [] -> ()
+    | _ :: _ -> Alcotest.fail "lossless history must not emit a projection row")
 
 let test_lane_media_reroute_stays_within_lane () =
   with_runtime_config runtime_toml_media_lane_with_global_outside (fun () ->
@@ -1644,9 +1724,13 @@ let () =
             `Quick
             test_run_named_media_degrade_emits_typed_manifest;
           Alcotest.test_case
-            "OAS checkpoint starts fresh official-client session"
+            "OAS checkpoint preserves official-client history"
             `Quick
-            test_oas_checkpoint_starts_fresh_official_client_session;
+            test_oas_checkpoint_preserves_official_client_history;
+          Alcotest.test_case
+            "lossless official-client history emits no projection row"
+            `Quick
+            test_lossless_official_client_history_emits_no_projection_row;
           Alcotest.test_case
             "lane media reroute stays within lane"
             `Quick


### PR DESCRIPTION
## Summary

- stop erasing canonical history on the codex-app-server lane: the `oas_checkpoint`-keyed `initial_messages:[]` override in `Keeper_turn_driver` used checkpoint presence as a fresh-session signal, while the actual start-or-resume authority is the durable official-client session store (`claim_plan.previous_settlement` in `Keeper_codex_runtime`). Mixing the two states erased prior user/assistant context on every lane entry (#27812).
- project canonical history onto the official-client wire instead of dropping it: new `Keeper_official_client_host.project_official_history` keeps text-only user/assistant/system messages in order, and counts every dropped part — Tool-role messages, non-text blocks, and messages left without any text.
- surface lossy projections loudly, never silently: WARN log plus a `Runtime_routed` manifest row (`routing_action=official_client_history_projected`) carrying `history_kept_messages` / `history_dropped_tool_messages` / `history_dropped_messages` / `history_dropped_blocks`. This follows the in-file RFC-0265 media-degrade precedent; the four count keys are added to the manifest public-projection allowlist.
- replace the `fresh_session` manifest row — it claimed a fresh session even when the runtime actually resumed — with `checkpoint_not_replayed` + `official_client_session_store_owns_resume`, which is true in both modes at the driver level.
- keep the runtime-side strict admission (`project_messages` rejecting tool messages, `text_of_blocks` rejecting non-text blocks) unchanged as the invariant guard; the driver-level projection guarantees canonical history can no longer trip it.

## Behavior change

- Start turns on the codex lane now inject prior representable history through `thread/inject_items` instead of running goal-only.
- Resume turns are unaffected (the wire ignores history on resume). The projection also unblocks turns for keepers whose canonical history contains tool blocks but no OAS checkpoint — previously a typed `initial_messages` error on every attempt, which permanently starved the lane.

## Verification

- `test_keeper_official_client_host`: four new projection unit tests (lossless passthrough / tool-message drop / non-text block strip / empty-message drop). Projected output is re-fed through the strict `text_of_blocks`, proving wire admissibility; expected values are literals.
- `test_keeper_turn_driver_failover`: `test_oas_checkpoint_starts_fresh_official_client_session` — whose success condition was the history loss itself — is replaced by `test_oas_checkpoint_preserves_official_client_history` (checkpoint row + projection row with exact counts) and `test_lossless_official_client_history_emits_no_projection_row`. Both assert the retired `fresh_session` row does not reappear.
- Both suites already run in required CI (`request_cap_targets` includes `runtest-test_keeper_turn_driver_failover`; `official_client_targets` includes the host suite).
- Local: focused `dune build` + both test executables + `ocamlformat --check` on changed files (results in PR checks; CI Gate is authoritative).

## Notes for in-flight branches

- #27777 (Claude Code lane) copies the removed driver arm verbatim; after this lands, that branch should call `project_official_history` at the same site and flip its `"checkpoint history is not imported"` regression, which currently pins the loss as a success condition.
- #27782 (Antigravity) must not re-copy the old arm.

Fixes #27812.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
