### PR TITLE
fix(ci): qualify tool blob test registration

### DIFF
--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -1130,7 +1130,7 @@ let () =
             "maintenance malformed reference fails closed"
             `Quick
             test_maintenance_malformed_reference_fails_closed;
-          test_case
+          Alcotest.test_case
             "maintenance ignores prose blob placeholder"
             `Quick
             test_maintenance_ignores_prose_blob_placeholder;


### PR DESCRIPTION
## What changed

- qualify the newly added tool-blob maintenance test registration as `Alcotest.test_case`

## Why

Current `main` fails the authoritative Dune `@check` graph because the bare `test_case` name is not in scope. This blocks every remaining PR build independently of its own changes.

## Impact

This is a test-only compile repair. Production behavior is unchanged.

## Verification

- `git diff --check`
- `ocamlformat --check test/test_tool_blob_store.ml`
- focused Dune build requested; repo-wide shared Dune lock was occupied, so GitHub CI is the current compile authority

Closes #27939
