### PR TITLE
fix(keeper): gate Librarian memory writes

### DIFF
--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -166,6 +166,9 @@ let network_read_operation = Keeper_tool_in_process_runtime.network_read_gate_op
 let connector_post_operation =
   Keeper_tool_in_process_runtime.connector_post_gate_operation
 ;;
+let memory_write_operation =
+  Keeper_tool_memory_runtime.memory_write_gate_operation
+;;
 
 (* The producer owns both the argument schema and the effect encoding, so it
    owns the inversion; replay only decides whether to spend the grant. *)
@@ -184,6 +187,9 @@ let network_read_of_gate_input =
 let connector_post_of_gate_input =
   Keeper_tool_in_process_runtime.connector_post_replay_of_gate_input
 ;;
+let memory_write_args_of_gate_input =
+  Keeper_tool_memory_runtime.replay_memory_write_args_of_gate_input
+;;
 
 (* Which approved operations this module can spend without the Keeper
    re-emitting the call. Separated from the replay body so the set is
@@ -194,6 +200,7 @@ type replayable =
   | Replay_execute
   | Replay_network_read
   | Replay_connector_post
+  | Replay_memory_write
 
 let replayable_of_operation operation =
   if String.equal operation write_operation
@@ -204,6 +211,8 @@ let replayable_of_operation operation =
   then Some Replay_network_read
   else if String.equal operation connector_post_operation
   then Some Replay_connector_post
+  else if String.equal operation memory_write_operation
+  then Some Replay_memory_write
   else None
 ;;
 
@@ -914,7 +923,17 @@ let replay_approved_effect
               ?continuation_channel
               ?gate_context
               ~gate_grant:grant
-              connector_post))
+              connector_post)
+     | Some Replay_memory_write ->
+       replay memory_write_operation memory_write_args_of_gate_input (fun args ->
+         Keeper_tool_in_process_runtime.handle_memory_write_with_outcome
+           ~config
+           ~meta
+           ?continuation_channel
+           ?gate_context
+           ~gate_grant:grant
+           ~args
+           ()))
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_gate_replay.mli
+++ b/lib/keeper/keeper_gate_replay.mli
@@ -137,6 +137,7 @@ type replayable =
   | Replay_execute
   | Replay_network_read
   | Replay_connector_post
+  | Replay_memory_write
 
 val replayable_of_operation : string -> replayable option
 (** Which approved operations can be spent without the Keeper re-emitting the
@@ -147,8 +148,8 @@ val replayable_of_operation : string -> replayable option
 
     Covers operations whose approvals a Keeper must otherwise re-earn by
     re-emitting a byte-identical call: [filesystem_write], [tool_execute], and
-    producer-typed [network_read] (WebSearch/WebFetch), and exact
-    [connector_post] continuations. Any other operation is
+    producer-typed [network_read] (WebSearch/WebFetch), exact
+    [connector_post] continuations, and exact [memory_write] mutations. Any other operation is
     {!Not_applicable}; its existing model-issued path remains authoritative.
 
     [gate_context] is the same causal-context provider the model-issued write

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -312,6 +312,33 @@ let handle_memory_search ~config ~(meta : keeper_meta) ~ctx_work ~args =
   Keeper_tool_memory_runtime.keeper_memory_search_json ~config ~meta ~ctx_work ~args
 ;;
 
+let handle_memory_write_with_outcome
+      ~config
+      ~(meta : keeper_meta)
+      ?continuation_channel
+      ?gate_context
+      ?gate_grant
+      ~args
+      ()
+  =
+  let authorize_external_effect ~operation ~input continue =
+    with_external_gate_execution
+      ~config
+      ~meta
+      ?continuation_channel
+      ?gate_context
+      ?gate_grant
+      ~operation
+      ~input
+      continue
+  in
+  Keeper_tool_memory_runtime.keeper_memory_write_with_outcome
+    ~config
+    ~meta
+    ~authorize_external_effect
+    ~args
+;;
+
 let handle_library_search_with_outcome ~(meta : keeper_meta) ~args =
   Keeper_tool_execution.of_tool_result
     (Tool_library.handle_search

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -92,6 +92,18 @@ val handle_memory_search
   -> args:Yojson.Safe.t
   -> string
 
+val handle_memory_write_with_outcome
+  :  config:Workspace.config
+  -> meta:keeper_meta
+  -> ?continuation_channel:Keeper_continuation_channel.t
+  -> ?gate_context:(unit -> Keeper_gate.causal_context)
+  -> ?gate_grant:Keeper_gate.cycle_grant
+  -> args:Yojson.Safe.t
+  -> unit
+  -> Keeper_tool_execution.t
+(** Validate [args], consume the external-effect Gate for the exact Memory OS
+    mutation, and only then invoke the memory producer. *)
+
 val handle_library_search_with_outcome
   : meta:keeper_meta -> args:Yojson.Safe.t -> Keeper_tool_execution.t
 val handle_library_read_with_outcome

--- a/lib/keeper/keeper_tool_memory_runtime.ml
+++ b/lib/keeper/keeper_tool_memory_runtime.ml
@@ -417,6 +417,61 @@ let validate_memory_write_args (args : Yojson.Safe.t) : memory_write_validation 
     else Memory_write_ok { body }
 ;;
 
+let memory_write_gate_operation = "memory_write"
+
+let replay_memory_write_args_of_gate_input = function
+  | `Assoc fields as args ->
+    let open Result.Syntax in
+    let unknown_fields =
+      fields
+      |> List.filter_map (fun (name, _) ->
+        if String.equal name "title" || String.equal name "content"
+        then None
+        else Some name)
+      |> List.sort_uniq String.compare
+    in
+    let* () =
+      match unknown_fields with
+      | [] -> Ok ()
+      | names ->
+        Error
+          (Printf.sprintf
+             "approved memory_write input has unknown field(s): %s"
+             (String.concat ", " names))
+    in
+    let unique_field name =
+      match
+        fields
+        |> List.filter_map (fun (candidate, value) ->
+          if String.equal candidate name then Some value else None)
+      with
+      | [] -> Ok None
+      | [ value ] -> Ok (Some value)
+      | _ -> Error (Printf.sprintf "approved memory_write input repeats %S" name)
+    in
+    let* title = unique_field "title" in
+    let* content = unique_field "content" in
+    let* () =
+      match title with
+      | None | Some (`String _) -> Ok ()
+      | Some _ -> Error "approved memory_write title must be a string"
+    in
+    let* () =
+      match content with
+      | None -> Error "approved memory_write input has no content"
+      | Some (`String _) -> Ok ()
+      | Some _ -> Error "approved memory_write content must be a string"
+    in
+    (match validate_memory_write_args args with
+     | Memory_write_ok _ -> Ok args
+     | Memory_write_invalid { error_kind; _ } ->
+       Error
+         (Printf.sprintf
+            "approved memory_write input is invalid: %s"
+            (memory_write_error_kind_to_string error_kind)))
+  | _ -> Error "approved memory_write input must be an object"
+;;
+
 (* An explicit write is a claim a later turn reads back; the current Memory OS
    snapshot is the only store it reaches.
 
@@ -462,6 +517,7 @@ let upsert_explicit_fact
 let keeper_memory_write_with_outcome
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
+      ~authorize_external_effect
       ~(args : Yojson.Safe.t)
   : Keeper_tool_execution.t
   =
@@ -479,6 +535,10 @@ let keeper_memory_write_with_outcome
   | Memory_write_invalid { error_kind; extras } ->
     respond ~ok:false ~error_kind extras
   | Memory_write_ok { body } ->
+    authorize_external_effect
+      ~operation:memory_write_gate_operation
+      ~input:args
+    @@ fun () ->
     let keepers_dir =
       Config_dir_resolver.keepers_dir_for_base_path
         ~base_path:config.Workspace.base_path

--- a/lib/keeper/keeper_tool_memory_runtime.mli
+++ b/lib/keeper/keeper_tool_memory_runtime.mli
@@ -49,8 +49,22 @@ val keeper_context_status_json
 val keeper_memory_write_with_outcome
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> authorize_external_effect:
+       (operation:string ->
+        input:Yojson.Safe.t ->
+        (unit -> Keeper_tool_execution.t) ->
+        Keeper_tool_execution.t)
   -> args:Yojson.Safe.t
   -> Keeper_tool_execution.t
+
+val memory_write_gate_operation : string
+
+val replay_memory_write_args_of_gate_input
+  :  Yojson.Safe.t
+  -> (Yojson.Safe.t, string) result
+(** Validate and retain the exact producer-owned Gate input for host replay.
+    Replay rejects duplicate, unknown, missing, and invalid fields rather than
+    reconstructing or defaulting an approved request. *)
 
 (** Title length cap exposed for sync regression tests. *)
 (** Upper bound on the composed [**title** content] body. *)

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -190,10 +190,14 @@ let handle_in_process ctx descriptor args =
          ~args)
   | Tool_memory_write ->
     Some
-      (Keeper_tool_memory_runtime.keeper_memory_write_with_outcome
+      (Keeper_tool_in_process_runtime.handle_memory_write_with_outcome
          ~config:ctx.config
          ~meta:ctx.meta
-         ~args)
+         ?continuation_channel:ctx.continuation_channel
+         ?gate_context:ctx.gate_context
+         ?gate_grant:ctx.gate_grant
+         ~args
+         ())
   | Tool_library_search ->
     Some
       (Keeper_tool_in_process_runtime.handle_library_search_with_outcome

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -644,7 +644,49 @@ let test_dispatch_covers_all_replayable_operations () =
     Alcotest.bool
     "an approved connector_post is host-replayed"
     true
-    (replayable_of_operation "connector_post" = Some Replay_connector_post)
+    (replayable_of_operation "connector_post" = Some Replay_connector_post);
+  Alcotest.check
+    Alcotest.bool
+    "an approved memory_write is host-replayed"
+    true
+    (replayable_of_operation "memory_write" = Some Replay_memory_write)
+;;
+
+let test_memory_write_replay_preserves_exact_input () =
+  let input =
+    `Assoc
+      [ "title", `String "approved title"
+      ; "content", `String "approved content"
+      ]
+  in
+  Alcotest.check
+    result_json
+    "approved memory write arguments stay exact"
+    (Ok input)
+    (Masc.Keeper_tool_memory_runtime.replay_memory_write_args_of_gate_input
+       input)
+;;
+
+let test_memory_write_replay_rejects_invalid_input () =
+  List.iter
+    (fun input ->
+       match
+         Masc.Keeper_tool_memory_runtime.replay_memory_write_args_of_gate_input
+           input
+       with
+       | Error _ -> ()
+       | Ok _ -> Alcotest.fail "invalid memory write became replayable")
+    [ `Assoc [ "title", `String "missing content" ]
+    ; `Assoc
+        [ "content", `String "exact"
+        ; "content", `String "duplicate"
+        ]
+    ; `Assoc
+        [ "content", `String "exact"
+        ; "unknown", `String "widened"
+        ]
+    ; `String "not an object"
+    ]
 ;;
 
 let test_dispatch_refuses_unknown_operations () =
@@ -819,6 +861,14 @@ let () =
             "connector decoder rejects heuristic input"
             `Quick
             test_connector_post_rejects_heuristic_or_truncated_input
+        ; Alcotest.test_case
+            "memory write replay keeps exact input"
+            `Quick
+            test_memory_write_replay_preserves_exact_input
+        ; Alcotest.test_case
+            "memory write replay rejects invalid input"
+            `Quick
+            test_memory_write_replay_rejects_invalid_input
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -10,6 +10,15 @@ let make_args ~title ~content =
 ;;
 
 let error_label = Runtime.memory_write_error_kind_to_string
+let json = Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal
+
+let authorize_for_persistence_test ~operation ~input:_ continue =
+  Alcotest.(check string)
+    "memory write Gate operation"
+    Runtime.memory_write_gate_operation
+    operation;
+  continue ()
+;;
 
 let assert_invalid ~expected = function
   | Runtime.Memory_write_invalid { error_kind; _ } ->
@@ -162,6 +171,7 @@ let test_write_comes_back_through_recall () =
     Runtime.keeper_memory_write_with_outcome
       ~config
       ~meta
+      ~authorize_external_effect:authorize_for_persistence_test
       ~args:
         (make_args
            ~title:""
@@ -268,6 +278,7 @@ let test_tools_isolate_workspace_base_path_from_ambient_decoy () =
       Runtime.keeper_memory_write_with_outcome
         ~config
         ~meta
+        ~authorize_external_effect:authorize_for_persistence_test
         ~args:(make_args ~title:"" ~content:"workspace A only")
       |> fun result -> result.Masc.Keeper_tool_execution.raw_output
       |> Yojson.Safe.from_string
@@ -324,6 +335,44 @@ let test_tools_isolate_workspace_base_path_from_ambient_decoy () =
       (int_field "memory_facts_total" status))
 ;;
 
+let test_authorization_block_prevents_persistence () =
+  with_temp_dir
+  @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "authorization-blocked" in
+  let keepers_dir =
+    Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.base_path
+  in
+  let args = make_args ~title:"blocked" ~content:"must not persist" in
+  let authorization_calls = ref 0 in
+  let result =
+    Runtime.keeper_memory_write_with_outcome
+      ~config
+      ~meta
+      ~authorize_external_effect:(fun ~operation ~input continue:_ ->
+        incr authorization_calls;
+        Alcotest.(check string)
+          "exact operation reaches authority"
+          Runtime.memory_write_gate_operation
+          operation;
+        Alcotest.check json "exact input reaches authority" args input;
+        Masc.Keeper_tool_execution.failure
+          ~class_:Tool_result.Workflow_rejection
+          ~effect_disposition:Tool_result.Proven_pre_effect
+          "blocked by test authority")
+      ~args
+  in
+  Alcotest.(check int) "authority called once" 1 !authorization_calls;
+  Alcotest.(check string)
+    "authority result returned"
+    "blocked by test authority"
+    result.raw_output;
+  Alcotest.(check int)
+    "blocked write persisted nothing"
+    0
+    (List.length (current_facts ~keepers_dir ~keeper_id:meta.name))
+;;
+
 (* The source parser sits behind Safe_ops.json_string, which returns its
    default for both an absent key and a key holding a non-string. Before the
    fix {"source": ["memory"]} reached Memory while {"source": "memry"} was
@@ -373,6 +422,10 @@ let () =
             "tools isolate config BasePath from ambient decoy"
             `Quick
             test_tools_isolate_workspace_base_path_from_ambient_decoy
+        ; Alcotest.test_case
+            "authorization block prevents persistence"
+            `Quick
+            test_authorization_block_prevents_persistence
         ; Alcotest.test_case
             "search filters exact substring without ranking"
             `Quick

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -932,6 +932,51 @@ let test_manual_gate_defers_publication_writes_before_recovery () =
          (read_file path))
 ;;
 
+let test_manual_gate_defers_memory_write_before_persistence () =
+  with_exec_fixture
+    "keeper_tool_dispatch_manual_memory_write_gate"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       (match
+          Masc.Keeper_gate_mode.set
+            config
+            ~actor:"test"
+            Masc.Keeper_gate_mode.Manual
+        with
+        | Ok _ -> ()
+        | Error detail -> fail ("failed to select Manual Gate mode: " ^ detail));
+       let keepers_dir =
+         Config_dir_resolver.keepers_dir_for_base_path
+           ~base_path:config.base_path
+       in
+       let memory_path =
+         Masc.Keeper_memory_os_current.path_for_keepers_dir
+           ~keepers_dir
+           ~keeper_id:meta.name
+       in
+       let result =
+         KET.execute_keeper_tool_call_with_outcome
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_work
+           ~name:"keeper_memory_write"
+           ~input:
+             (`Assoc
+                [ "title", `String "must wait for approval"
+                ; "content", `String "must not persist before Gate approval"
+                ])
+           ()
+       in
+       check string
+         "Manual Gate memory write outcome"
+         "deferred"
+         (outcome_label result.KTE.disposition);
+       check bool
+         "Manual Gate memory write created no snapshot"
+         false
+         (Sys.file_exists memory_path))
+;;
+
 let test_manual_gate_deferral_stays_deferred_through_oas_bridge () =
   with_exec_fixture
     "keeper_tool_dispatch_manual_gate_oas_bridge"
@@ -2538,6 +2583,115 @@ let test_approved_web_search_replays_without_model_resubmission () =
           "consumed WebSearch did not reuse its durable outcome: %s"
           (Masc.Keeper_gate_replay.outcome_to_string outcome))
 
+let test_approved_memory_write_replays_without_model_resubmission () =
+  with_exec_fixture "keeper_tool_dispatch_replayed_memory_write"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       (match
+          Masc.Keeper_gate_mode.set
+            config
+            ~actor:"test"
+            Masc.Keeper_gate_mode.Manual
+        with
+        | Ok _ -> ()
+        | Error detail -> fail ("failed to select Manual Gate mode: " ^ detail));
+       let input =
+         `Assoc
+           [ "title", `String "approved memory"
+           ; "content", `String "host replay persisted this exact claim"
+           ]
+       in
+       let deferred =
+         KET.execute_keeper_tool_call_with_outcome
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_work
+           ~name:"keeper_memory_write"
+           ~input
+           ()
+       in
+       (match deferred.disposition with
+        | Tool_result.Deferred () -> ()
+        | Tool_result.Completed () | Tool_result.Failed _ ->
+          fail "approval-gated memory write did not defer before replay");
+       let approval_id =
+         match
+           Masc.Keeper_approval_queue.list_pending_entries_for_workspace
+             ~base_path:config.base_path
+         with
+         | Ok [ entry ] -> entry.id
+         | Ok entries ->
+           failf
+             "expected one pending memory approval, got %d"
+             (List.length entries)
+         | Error error ->
+           fail (Masc.Keeper_approval_queue.storage_error_to_string error)
+       in
+       (match
+          Masc.Keeper_approval_queue.resolve_with_policy
+            ~base_path:config.base_path
+            ~id:approval_id
+            ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+            ~source:Keeper_approval_queue_rules_types.Auto_judge
+            ()
+        with
+        | Ok _ -> ()
+        | Error error ->
+          fail (Masc.Keeper_approval_queue.resolve_error_to_string error));
+       let resolution : Keeper_event_queue.hitl_resolution =
+         { approval_id
+         ; decision = Keeper_event_queue.Hitl_approved
+         ; channel =
+             Keeper_continuation_channel.unrouted
+               "replayed memory write test"
+         }
+       in
+       let grant =
+         match Masc.Keeper_gate.cycle_grant_of_resolution resolution with
+         | Some grant -> grant
+         | None -> fail "approved memory resolution did not create a grant"
+       in
+       (match
+          Masc.Keeper_gate_replay.replay_approved_effect
+            ~config
+            ~meta
+            ~publication_recovery
+            ~turn_sandbox_factory:None
+            ~grant
+            ~approval_id
+            ()
+        with
+        | Masc.Keeper_gate_replay.Applied
+            { operation = "memory_write"
+            ; journal = Masc.Keeper_gate_replay.Replay_journal_recorded
+            ; _
+            } ->
+          ()
+        | outcome ->
+          failf
+            "approved memory write was not host-replayed: %s"
+            (Masc.Keeper_gate_replay.outcome_to_string outcome));
+       let keepers_dir =
+         Config_dir_resolver.keepers_dir_for_base_path
+           ~base_path:config.base_path
+       in
+       match
+         Masc.Keeper_memory_os_current.read_for_keepers_dir
+           ~keepers_dir
+           ~keeper_id:meta.name
+       with
+       | Ok (Some { facts = [ fact ]; _ }) ->
+         check string
+           "host replay persisted the approved exact claim"
+           "**approved memory** host replay persisted this exact claim"
+           fact.claim
+       | Ok (Some snapshot) ->
+         failf
+           "host replay persisted %d memory facts instead of one"
+           (List.length snapshot.facts)
+       | Ok None -> fail "host replay persisted no memory snapshot"
+       | Error detail -> fail detail)
+
 let approved_web_search_resolution
       ~config
       ~meta
@@ -4134,6 +4288,8 @@ let () =
         test_initializing_recovery_isolates_only_publication_writes;
       test_case "Manual Gate defers writes before recovery acquisition" `Quick
         test_manual_gate_defers_publication_writes_before_recovery;
+      test_case "Manual Gate defers memory write before persistence" `Quick
+        test_manual_gate_defers_memory_write_before_persistence;
       test_case "Manual Gate deferral stays deferred through OAS bridge" `Quick
         test_manual_gate_deferral_stays_deferred_through_oas_bridge;
       test_case "initialization crash is redacted from tool output" `Quick
@@ -4168,6 +4324,8 @@ let () =
         test_approved_web_search_grant_executes_exact_request;
       test_case "approved WebSearch replays without model resubmission" `Quick
         test_approved_web_search_replays_without_model_resubmission;
+      test_case "approved memory write replays without model resubmission" `Quick
+        test_approved_memory_write_replays_without_model_resubmission;
       test_case "blob failure repairs journal without second effect" `Quick
         test_blob_failure_repairs_journal_without_second_effect;
       test_case "journal failure retries only persistence" `Quick


### PR DESCRIPTION
## Summary

- keep `keeper_memory_write` in the complete Librarian tool surface
- route every valid durable memory mutation through the external-effect Gate
- host-replay the exact approved input without model resubmission
- reject malformed, duplicate, unknown, or widened approval inputs instead of reconstructing them

## Why

The merged dashboard/internal-agent work in #27823 made the Librarian complete tool surface visible. A strict post-merge pass found that `keeper_memory_write` was the only durable mutation in that surface that bypassed `gate_context` and `gate_grant`. An untrusted research result could therefore poison durable Memory OS state without an approval boundary.

This is a P0 follow-up. The tool remains available; only the side effect is gated.

## Verification

- exact head: `7f3edca379048c3db1e4d62fa4d1ed1ea7788124`
- rebased onto current main `6d076300f708f9a2715112d495a6b7e158a95edb`
- focused build includes memory, Gate replay, complete surface, dispatch, app-server, and `main_eio`
- `test_keeper_memory_write.exe`: 9/9 pass
- `test_keeper_gate_replay.exe`: 24/24 pass
- `test_warn_root_causes.exe`: 15/15 pass, including complete Librarian tool surface
- focused dispatch boundaries: 2/2 pass (`Deferred` creates no snapshot; approved host replay persists exactly one fact)
- app-server subscription boundary: 30/30 pass
- real Keeper: `MASC_CODEX_APP_SERVER_LIVE=1 ... test live subscription 4` passes in 9.67s with `gpt-5.6-sol`, typed tool call/output, final response, and RAW tool/final evidence assertions
- `scripts/ci/check-determinism-contract.sh`: PASS

The full dispatch executable has unrelated current-main red baselines already tracked in #26008 and #26171. The two memory Gate cases pass independently.

## Follow-ups

- #27824 tracks the separate P1 bounded/paginated exact-evidence ledger and fail-visible replay corruption contract.
- Related merged UI work: #27823.