### PR TITLE
fix(dashboard): measure keeper turn span across rotated decision logs

### DIFF
--- a/lib/dashboard/dashboard_keeper_decision_log_proof.ml
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.ml
@@ -5,10 +5,28 @@ type scheduled_stat = {
   failure_count : int;
 }
 
+(* Where [first_ts] came from. The 24h persistence gate asks for the EARLIEST
+   turn row in durable history, and a bounded tail read can never witness a
+   minimum: the tail is by construction the newest slice. The origin is
+   therefore recorded rather than assumed, so a reader can tell "no turn rows
+   exist" apart from "turn rows exist but were not reached". *)
+type first_ts_origin =
+  | History_head of int option
+      (** Earliest turn row located in the head of the oldest surviving
+          decision-log segment. Carries that segment's rotation index;
+          [None] denotes the unrotated current segment. *)
+  | No_turn_row_in_history
+      (** No turn-exchange row inside the scanned head of any segment. *)
+
 type turn_span_stat = {
-  interaction_count : int;
+  recent_interaction_count : int;
+      (** Turn rows inside the recent tail window only. This is a liveness
+          signal, not a history total; [first_ts] deliberately comes from a
+          different (oldest) segment. *)
   first_ts : float option;
   latest_ts : float option;
+  first_ts_origin : first_ts_origin;
+  segments_observed : int;
 }
 
 let seconds_per_hour = Masc_time_constants.hour
@@ -17,11 +35,21 @@ let recent_turn_max_age_hours = 24.0
 let decision_tail_max_bytes = 512 * 1024
 let decision_tail_max_lines = 5000
 
+(* Head budget for locating the earliest turn row in one segment. Measured
+   2026-08-09 over the 8-keeper fleet: the first turn row sat within 7.6 KB of
+   every segment head (worst case [sangsu], row 4), so this clears the observed
+   worst case by ~67x while keeping the read O(1) in file size. *)
+let decision_head_max_bytes = 512 * 1024
+
 let empty_scheduled_stat =
   { decision_count = 0; latest_ts = None; latest_ts_unix = None; failure_count = 0 }
 
-let empty_turn_span_stat =
-  { interaction_count = 0; first_ts = None; latest_ts = None }
+(* Tail-window accumulator. Kept separate from [turn_span_stat] because the
+   tail can only answer "how recent" — "how far back" is answered by the head
+   scan below. *)
+type tail_scan = { count : int; latest : float option }
+
+let empty_tail_scan = { count = 0; latest = None }
 
 let fold_keeper_decision_log ~config keeper_name ~init ~f =
   let path = Keeper_types_support.keeper_decision_log_path config keeper_name in
@@ -101,29 +129,94 @@ let is_turn_exchange_channel = function
   | Some s -> Option.is_some (Keeper_world_observation.channel_of_string s)
   | None -> false
 
-let update_turn_span stat ts =
+let update_tail_scan scan ts =
   {
-    interaction_count = stat.interaction_count + 1;
-    first_ts =
+    count = scan.count + 1;
+    latest =
       Some
-        (match stat.first_ts with
-         | Some first -> min first ts
-         | None -> ts);
-    latest_ts =
-      Some
-        (match stat.latest_ts with
+        (match scan.latest with
          | Some latest -> max latest ts
          | None -> ts);
   }
 
+(** Every decision-log segment for [keeper_name], oldest first. Rotation is a
+    typed concept owned by {!Keeper_runtime_root_entry}; enumerating through
+    that catalog keeps this reader in step with the writer instead of
+    re-deriving a filename convention that only the writer knows. *)
+let decision_log_segments ~config keeper_name =
+  let current = Keeper_types_support.keeper_decision_log_path config keeper_name in
+  let dir = Filename.dirname current in
+  if not (Fs_compat.file_exists dir) then []
+  else
+    Fs_compat.read_dir dir
+    |> List.filter_map (fun base ->
+      Keeper_runtime_root_entry.classify_basename base
+      |> List.find_map (function
+        | Keeper_runtime_root_entry.Keeper
+            { keeper_name = name
+            ; artifact = Keeper_runtime_root_entry.Decision_log
+            ; rotation
+            }
+          when String.equal name keeper_name ->
+          Some (rotation, Filename.concat dir base)
+        | _ -> None))
+    |> List.sort (fun (left, _) (right, _) ->
+      (* Oldest first: a higher rotation index is an older segment, and the
+         unrotated current segment is the newest of all. *)
+      match left, right with
+      | Some left, Some right -> Int.compare right left
+      | Some _, None -> -1
+      | None, Some _ -> 1
+      | None, None -> 0)
+
+(** Earliest turn row inside the head budget of one segment. A head slice can
+    end mid-row; unparseable lines are skipped exactly as on the tail path, so
+    a truncated final line cannot fabricate a timestamp. *)
+let earliest_turn_ts_in_segment path =
+  let slice = Fs_compat.read_slice ~path ~from:0 ~len:decision_head_max_bytes in
+  if String.equal slice "" then None
+  else
+    String.split_on_char '\n' slice
+    |> List.find_map (fun line ->
+      let line = String.trim line in
+      if String.equal line "" then None
+      else
+        match Yojson.Safe.from_string line with
+        | exception Yojson.Json_error _ -> None
+        | json ->
+          if is_turn_exchange_channel (Safe_ops.json_string_opt "channel" json)
+          then decision_ts_unix json
+          else None)
+
+let earliest_turn_ts segments =
+  let rec scan = function
+    | [] -> None, No_turn_row_in_history
+    | (rotation, path) :: rest ->
+      (match earliest_turn_ts_in_segment path with
+       | Some ts -> Some ts, History_head rotation
+       | None -> scan rest)
+  in
+  scan segments
+
 let turn_span_stats ~config keeper_name =
-  fold_keeper_decision_log ~config keeper_name ~init:empty_turn_span_stat
-    ~f:(fun stat json ->
-      if is_turn_exchange_channel (Safe_ops.json_string_opt "channel" json) then
-        match decision_ts_unix json with
-        | Some ts -> update_turn_span stat ts
-        | None -> stat
-      else stat)
+  let tail =
+    fold_keeper_decision_log ~config keeper_name ~init:empty_tail_scan
+      ~f:(fun scan json ->
+        if is_turn_exchange_channel (Safe_ops.json_string_opt "channel" json) then
+          match decision_ts_unix json with
+          | Some ts -> update_tail_scan scan ts
+          | None -> scan
+        else scan)
+  in
+  let segments = decision_log_segments ~config keeper_name in
+  let first_ts, first_ts_origin = earliest_turn_ts segments in
+  {
+    recent_interaction_count = tail.count;
+    first_ts;
+    latest_ts = tail.latest;
+    first_ts_origin;
+    segments_observed = List.length segments;
+  }
 
 let hours_between first latest =
   max 0.0 (latest -. first) /. seconds_per_hour
@@ -145,13 +238,21 @@ let turn_span_hours_json stat =
   | Some first, Some latest -> `Float (hours_between first latest)
   | _ -> `Null
 
+let first_ts_origin_json = function
+  | History_head None ->
+    `Assoc [ ("segment", `String "current"); ("rotation", `Null) ]
+  | History_head (Some rotation) ->
+    `Assoc [ ("segment", `String "rotated"); ("rotation", `Int rotation) ]
+  | No_turn_row_in_history ->
+    `Assoc [ ("segment", `String "none"); ("rotation", `Null) ]
+
 let latest_age_hours_json ~now stat =
   match stat.latest_ts with
   | Some latest -> `Float (latest_age_hours ~now latest)
   | None -> `Null
 
 let has_persistent_turn_span ~now stat =
-  stat.interaction_count >= 2
+  stat.recent_interaction_count >= 2
   &&
   match stat.first_ts, stat.latest_ts with
   | Some first, Some latest ->
@@ -162,7 +263,9 @@ let has_persistent_turn_span ~now stat =
 let turn_span_evidence_json ~now keeper_name stat =
   `Assoc [
     ("keeper", `String keeper_name);
-    ("interaction_count", `Int stat.interaction_count);
+    ("recent_interaction_count", `Int stat.recent_interaction_count);
+    ("first_ts_origin", first_ts_origin_json stat.first_ts_origin);
+    ("segments_observed", `Int stat.segments_observed);
     ("first_ts_unix", unix_opt_to_json stat.first_ts);
     ("first_ts_iso", unix_opt_to_iso_json stat.first_ts);
     ("latest_ts_unix", unix_opt_to_json stat.latest_ts);

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.ml
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.ml
@@ -15,8 +15,11 @@ type first_ts_origin =
       (** Earliest turn row located in the head of the oldest surviving
           decision-log segment. Carries that segment's rotation index;
           [None] denotes the unrotated current segment. *)
+  | History_scan_exhausted of int option
+      (** The segment head budget ended before a turn row was found. Carries
+          the segment whose unscanned suffix may contain the earliest row. *)
   | No_turn_row_in_history
-      (** No turn-exchange row inside the scanned head of any segment. *)
+      (** Every surviving segment was scanned to EOF without a turn row. *)
 
 type turn_span_stat = {
   recent_interaction_count : int;
@@ -172,10 +175,14 @@ let decision_log_segments ~config keeper_name =
 (** Earliest turn row inside the head budget of one segment. A head slice can
     end mid-row; unparseable lines are skipped exactly as on the tail path, so
     a truncated final line cannot fabricate a timestamp. *)
+type segment_head_scan =
+  | Turn_found of float
+  | Complete_without_turn
+  | Scan_exhausted
+
 let earliest_turn_ts_in_segment path =
   let slice = Fs_compat.read_slice ~path ~from:0 ~len:decision_head_max_bytes in
-  if String.equal slice "" then None
-  else
+  let turn =
     String.split_on_char '\n' slice
     |> List.find_map (fun line ->
       let line = String.trim line in
@@ -187,14 +194,22 @@ let earliest_turn_ts_in_segment path =
           if is_turn_exchange_channel (Safe_ops.json_string_opt "channel" json)
           then decision_ts_unix json
           else None)
+  in
+  match turn with
+  | Some ts -> Turn_found ts
+  | None ->
+    (match Fs_compat.file_size path with
+     | Some size when size <= String.length slice -> Complete_without_turn
+     | Some _ | None -> Scan_exhausted)
 
 let earliest_turn_ts segments =
   let rec scan = function
     | [] -> None, No_turn_row_in_history
     | (rotation, path) :: rest ->
       (match earliest_turn_ts_in_segment path with
-       | Some ts -> Some ts, History_head rotation
-       | None -> scan rest)
+       | Turn_found ts -> Some ts, History_head rotation
+       | Complete_without_turn -> scan rest
+       | Scan_exhausted -> None, History_scan_exhausted rotation)
   in
   scan segments
 
@@ -243,6 +258,12 @@ let first_ts_origin_json = function
     `Assoc [ ("segment", `String "current"); ("rotation", `Null) ]
   | History_head (Some rotation) ->
     `Assoc [ ("segment", `String "rotated"); ("rotation", `Int rotation) ]
+  | History_scan_exhausted rotation ->
+    `Assoc
+      [ ("segment", `String "scan_exhausted")
+      ; ( "rotation"
+        , Option.fold ~none:`Null ~some:(fun value -> `Int value) rotation )
+      ]
   | No_turn_row_in_history ->
     `Assoc [ ("segment", `String "none"); ("rotation", `Null) ]
 

--- a/test/dune
+++ b/test/dune
@@ -1220,6 +1220,15 @@
   (action
    (setenv MASC_MAIN_EIO_EXE %{dep:../bin/main_eio.exe} (run %{test}))))
 
+; The 24h persistence gate shipped with no test, which is how a window that
+; could not hold 24h of rows survived as a permanent FAIL. Declared here and
+; attached to the alias below so it executes inside an existing CI step
+; instead of being added and never run.
+(test
+ (name test_keeper_persistence_span_history)
+ (modules test_keeper_persistence_span_history)
+ (libraries masc_test_deps masc.dashboard))
+
 ; Stable dashboard behavior contracts only. The HTTP core executable also
 ; contains source-shape assertions, so CI selects its behavior suite; the
 ; briefing executable is behavior-only and runs in full.
@@ -1228,7 +1237,8 @@
  (action
   (progn
    (run %{exe:test_dashboard_http_core.exe} test "dashboard behavior contracts")
-   (run %{exe:test_dashboard_briefing.exe}))))
+   (run %{exe:test_dashboard_briefing.exe})
+   (run %{exe:test_keeper_persistence_span_history.exe}))))
 
 (test
  (name test_voice_config)

--- a/test/test_keeper_persistence_span_history.ml
+++ b/test/test_keeper_persistence_span_history.ml
@@ -72,6 +72,13 @@ let turn_row ts = `Assoc [ ("channel", `String "turn"); ("ts_unix", `Float ts) ]
 let heartbeat_row ts =
   `Assoc [ ("channel", `String "heartbeat"); ("ts_unix", `Float ts) ]
 
+let oversized_heartbeat_row ts =
+  `Assoc
+    [ ("channel", `String "heartbeat")
+    ; ("ts_unix", `Float ts)
+    ; ("detail", `String (String.make (600 * 1024) 'x'))
+    ]
+
 let evidence ~now ~base ~keeper =
   let config = Workspace.default_config base in
   let stat = Proof.turn_span_stats ~config keeper in
@@ -185,6 +192,30 @@ let no_turn_rows_is_explicit () =
         (Proof.has_persistent_turn_span ~now stat);
       check string "absence is named, not defaulted" "none" (origin_segment json))
 
+(* A bounded head read is allowed, but exhausting that budget is not evidence
+   that history contains no turn rows. Keep the unknown suffix visible so the
+   proof fails closed without fabricating absence. *)
+let head_budget_exhaustion_is_explicit () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"bounded" ~rotation:None
+        [ oversized_heartbeat_row (now -. (48.0 *. hour))
+        ; turn_row (now -. (30.0 *. hour))
+        ; turn_row (now -. 60.0)
+        ];
+      let stat, json = evidence ~now ~base ~keeper:"bounded" in
+      check bool "an unscanned suffix cannot satisfy the gate" false
+        (Proof.has_persistent_turn_span ~now stat);
+      check string "budget exhaustion is not collapsed into absence"
+        "scan_exhausted" (origin_segment json);
+      check (option int) "recent turns remain visible" (Some 2)
+        (match json_field "recent_interaction_count" json with
+         | Some (`Int n) -> Some n
+         | _ -> None))
+
 let () =
   run "keeper persistence span history"
     [ ( "turn span"
@@ -192,5 +223,7 @@ let () =
         ; test_case "control: single segment" `Quick single_segment_control
         ; test_case "stale latest turn fails" `Quick stale_latest_turn_fails
         ; test_case "no turn rows is explicit" `Quick no_turn_rows_is_explicit
+        ; test_case "head budget exhaustion is explicit" `Quick
+            head_budget_exhaustion_is_explicit
         ] )
     ]

--- a/test/test_keeper_persistence_span_history.ml
+++ b/test/test_keeper_persistence_span_history.ml
@@ -1,0 +1,196 @@
+(** The 24h persistence gate asks for the EARLIEST turn row in durable
+    history. History is append-only and rotates, so the earliest row routinely
+    sits in a rotated segment that a bounded tail read cannot reach.
+
+    Live evidence, 2026-08-09 fleet: every one of the 8 keepers had its first
+    turn row in [<keeper>.decisions.jsonl.1], and the tail-only reader reported
+    spans of 0.92h-3.07h against true spans of 36h-153h. The gate read 0/8 and
+    could not have read otherwise: 24h of rows did not fit in the 512 KB
+    window.
+
+    Case [rotated_segment_reached] fails against a tail-only reader; case
+    [single_segment_control] passes against either, and exists so a harness
+    that reads nothing at all cannot be mistaken for a passing gate. *)
+
+open Masc
+module Proof = Dashboard_keeper_decision_log_proof
+open Alcotest
+
+let hour = 3600.0
+
+(* ── Fixture helpers ─────────────────────────────── *)
+
+let test_dir () =
+  let tmp = Filename.temp_file "masc_persistence_span" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  tmp
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path |> Array.iter (fun f -> rm_rf (Filename.concat path f));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let rec mkdir_p dir =
+  if not (Sys.file_exists dir) then begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
+let keepers_dir base =
+  let dir = Filename.concat base ".masc/keepers" in
+  mkdir_p dir;
+  dir
+
+(** [write_segment base ~keeper ~rotation rows] writes one decision-log
+    segment. [rotation = None] is the current unrotated segment. *)
+let write_segment base ~keeper ~rotation rows =
+  let dir = keepers_dir base in
+  let basename =
+    Keeper_runtime_root_entry.basename
+      (Keeper_runtime_root_entry.Keeper
+         { keeper_name = keeper
+         ; artifact = Keeper_runtime_root_entry.Decision_log
+         ; rotation
+         })
+  in
+  let oc = open_out (Filename.concat dir basename) in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () ->
+      List.iter
+        (fun row ->
+          output_string oc (Yojson.Safe.to_string row);
+          output_char oc '\n')
+        rows)
+
+let turn_row ts = `Assoc [ ("channel", `String "turn"); ("ts_unix", `Float ts) ]
+
+let heartbeat_row ts =
+  `Assoc [ ("channel", `String "heartbeat"); ("ts_unix", `Float ts) ]
+
+let evidence ~now ~base ~keeper =
+  let config = Workspace.default_config base in
+  let stat = Proof.turn_span_stats ~config keeper in
+  (stat, Proof.turn_span_evidence_json ~now keeper stat)
+
+let json_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let float_field name json =
+  match json_field name json with
+  | Some (`Float f) -> Some f
+  | Some (`Int i) -> Some (float_of_int i)
+  | _ -> None
+
+let origin_segment json =
+  match json_field "first_ts_origin" json with
+  | Some origin -> (
+    match json_field "segment" origin with
+    | Some (`String s) -> s
+    | _ -> "«absent»")
+  | None -> "«absent»"
+
+(* ── Cases ───────────────────────────────────────── *)
+
+(* The earliest turn row exists only in the rotated segment; the current
+   segment covers barely an hour. A tail-only reader sees ~1h and fails the
+   gate on a keeper that has been exchanging turns for two days. *)
+let rotated_segment_reached () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"rotor" ~rotation:(Some 1)
+        [ turn_row (now -. (48.0 *. hour))
+        ; turn_row (now -. (40.0 *. hour))
+        ; turn_row (now -. (2.0 *. hour))
+        ];
+      write_segment base ~keeper:"rotor" ~rotation:None
+        [ turn_row (now -. (1.0 *. hour))
+        ; turn_row (now -. (0.5 *. hour))
+        ; turn_row (now -. 60.0)
+        ];
+      let stat, json = evidence ~now ~base ~keeper:"rotor" in
+      check bool "gate passes on two days of durable turn exchange" true
+        (Proof.has_persistent_turn_span ~now stat);
+      (* 48.0 is asserted as a literal: deriving it from the reader under test
+         would make the assertion an identity. *)
+      let span = float_field "span_hours" json in
+      check bool "span spans the rotated segment, not the tail window" true
+        (match span with Some s -> s >= 47.9 && s <= 48.1 | None -> false);
+      check string "first_ts is attributed to the rotated segment" "rotated"
+        (origin_segment json);
+      check (option int) "both segments observed" (Some 2)
+        (match json_field "segments_observed" json with
+         | Some (`Int n) -> Some n
+         | _ -> None))
+
+(* Control: one unrotated segment already spanning 48h. This passes with or
+   without rotation support, so a reader that silently returns nothing cannot
+   masquerade as a working gate. *)
+let single_segment_control () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"solo" ~rotation:None
+        [ turn_row (now -. (48.0 *. hour))
+        ; turn_row (now -. (10.0 *. hour))
+        ; turn_row (now -. 30.0)
+        ];
+      let stat, json = evidence ~now ~base ~keeper:"solo" in
+      check bool "control: single-segment history passes" true
+        (Proof.has_persistent_turn_span ~now stat);
+      check string "control: first_ts comes from the current segment" "current"
+        (origin_segment json))
+
+(* Recency is a separate requirement from span: a long history whose last turn
+   is a day stale must still fail, or a stopped keeper reads as healthy. *)
+let stale_latest_turn_fails () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"stalled" ~rotation:(Some 1)
+        [ turn_row (now -. (100.0 *. hour)); turn_row (now -. (90.0 *. hour)) ];
+      write_segment base ~keeper:"stalled" ~rotation:None
+        [ turn_row (now -. (31.0 *. hour)); turn_row (now -. (30.0 *. hour)) ];
+      let stat, json = evidence ~now ~base ~keeper:"stalled" in
+      check bool "long span does not excuse a 30h-old latest turn" false
+        (Proof.has_persistent_turn_span ~now stat);
+      check bool "span itself is still reported from history" true
+        (match float_field "span_hours" json with
+         | Some s -> s >= 69.9
+         | None -> false))
+
+(* Absence of turn rows is reported as absence, not as a zero-length span. *)
+let no_turn_rows_is_explicit () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"quiet" ~rotation:None
+        [ heartbeat_row (now -. (48.0 *. hour)); heartbeat_row (now -. 60.0) ];
+      let stat, json = evidence ~now ~base ~keeper:"quiet" in
+      check bool "no turn rows cannot satisfy the gate" false
+        (Proof.has_persistent_turn_span ~now stat);
+      check string "absence is named, not defaulted" "none" (origin_segment json))
+
+let () =
+  run "keeper persistence span history"
+    [ ( "turn span"
+      , [ test_case "rotated segment is reached" `Quick rotated_segment_reached
+        ; test_case "control: single segment" `Quick single_segment_control
+        ; test_case "stale latest turn fails" `Quick stale_latest_turn_fails
+        ; test_case "no turn rows is explicit" `Quick no_turn_rows_is_explicit
+        ] )
+    ]


### PR DESCRIPTION
## 문제

`persistent_24h_turn_exchange` 게이트가 **구조적으로 통과 불가능**한 상태였다.

`dashboard_keeper_decision_log_proof.ml` 은 `first_ts`(역사상 최초 turn) 를 **꼬리 512KB 창**에서 구했다. 꼬리는 정의상 최소값을 목격할 수 없고, 24시간치 turn row 는 512KB 에 들어가지 않는다(관측 엔트리 ≈6.1KB, 24h ≈1,630행 ≈10MB).

## 실측 (2026-08-09, 라이브 8-keeper fleet, 동일 시점)

| keeper | 수정 전 span | 수정 후 span | 독립 검증(Python) |
|---|---:|---:|---:|
| analyst | 1.24h | 54.42h | 54.33h |
| code-reviewer | 0.92h | 44.85h | 44.75h |
| full-cycle-probe | 122.58h | 153.18h | 153.18h |
| kidsnote | 3.07h | 43.17h | 43.06h |
| lane-smith | 1.01h | 36.66h | 36.56h |
| rondo | 1.03h | 53.94h | 53.84h |
| sangsu | 2.96h | 78.53h | 78.42h |
| taskmaster | 0.96h | 45.82h | 45.72h |

`meets_24h_persistence`: **0/8 → 7/8**. 잔여 편차(≤0.11h)는 두 측정 실행 사이 실제 경과시간이며, 유일하게 정지한 keeper(`full-cycle-probe`)만 편차 0 으로 나와 두 모델이 같은 데이터를 읽음이 확인된다.

8번째 keeper 는 `paused=true`(운영자 정지), 마지막 turn 26시간 전이라 recency 요건에서 자기 사유로 실패한다. 즉 **망가진 게이트가 전부를 FAIL 처리하며 정지 keeper 1대를 가리고 있었다.**

## 변경

- `first_ts`: 가장 오래된 생존 세그먼트의 **head** 에서 취득. 세그먼트 열거는 `Keeper_runtime_root_entry` 의 타입화된 rotation 카탈로그를 사용(파일명 규칙 재유도 금지 — 기존 코드는 `rotation = None` 경로만 만들었다).
- `latest_ts`: 기존대로 현재 세그먼트 tail. recency 와 history depth 는 다른 질문이므로 출처가 다른 것이 정상.
- `first_ts_origin` / `segments_observed` 를 evidence JSON 에 추가. "turn row 가 없다" 와 "turn row 에 도달하지 못했다" 를 구분(Silent Failure 방지).
- `interaction_count` → `recent_interaction_count` 로 개명. 전 저장소 스윕 결과 소비자는 이 파일 하나뿐(대시보드 TS/zod/테스트 0건)이라 파급 없음.

head 예산은 512KB. 2026-08-09 fleet 실측에서 첫 turn row 가 모든 세그먼트 head 로부터 **7.6KB 이내**(최악 `sangsu`, 4번째 행)였으므로 관측 최악 대비 ~67배 여유이며 파일 크기에 대해 O(1) 을 유지한다.

## 테스트

이 모듈은 **테스트가 0건**이었고, 그래서 상시 FAIL 게이트가 살아남았다. 4건 추가:

| 케이스 | 패치 적용 | 수정 되돌린 뮤테이션 |
|---|---|---|
| rotated segment is reached | OK | **FAIL** |
| control: single segment | OK | OK |
| stale latest turn fails | OK | **FAIL** |
| no turn rows is explicit | OK | OK |

뮤테이션은 `decision_log_segments` 를 현재 세그먼트만 반환하도록 되돌려 수행했다. 대조군 2건이 양쪽에서 통과하므로, 아무것도 읽지 않는 리더가 통과 게이트로 위장할 수 없다.

기대값은 리터럴로 단언한다(검사 대상 함수를 기대값 쪽에 쓰지 않음).

CI 배선: 신규 테스트를 기존 `runtest-dashboard-http-behavior-contracts` alias 에 붙여 이미 실행 중인 CI 스텝에서 돌게 했다. 추가만 하고 실행되지 않는 테스트를 만들지 않기 위함.

## 검증

- `dune build --root . @test/runtest-dashboard-http-behavior-contracts` → 기존 13건 + 신규 4건 전부 통과
- 패치된 `bin/keeper_feature_proof_report.exe` 를 라이브 `.masc/keepers` 에 대해 실행하여 위 표 산출
- ocamlformat: `.ocamlformat` 에 `disable = true`(RFC-0010) 이므로 해당 게이트는 no-op

## 범위 밖 (별도 이슈로 제기)

게이트가 `paused=true` keeper 를 구별하지 않아 운영자 정지 1대 때문에 fleet 판정이 영구 WARN 이 된다. `keeper_meta` 에 `latched_reason` 타입 동반 필드가 이미 있으므로 배선 가능하나, 이 PR 은 관측 창 결함에 한정한다.

RFC-WAIVED: 변경 범위가 `lib/dashboard/` 관측 리더 + 테스트로, credential/identity/operator control/keeper sandbox/hooks/workflow 문서 어디에도 해당하지 않음.

## 이 작업 중 발견해 별도로 제기한 것

- **#27947** — 나머지 3개 feature (`runtime_liveness`, `autonomous_tool_use`, `board_reactive_autonomy`) 는 생애 누적 카운터 `> 0` 술어라 정지한 keeper 를 구별할 수 없다. 26시간 정지한 `full-cycle-probe` 가 전부 PASS 한다. 즉 교정 이전 하네스는 **통과 불가 게이트 1개 + 실패 불가 게이트 3개** 였다. 의미론 변경이 필요해 이 PR 에 넣지 않았다.
- **#27944** — `sangsu` 가 scheduled 자율성만 24.5시간 침묵. 이 PR 로 관측 창을 고쳐야 `--window-hours 24` 하에서 드러난다.

## 하네스와 무관한 대조 실측 (정정 포함)

게이트 통과만으로는 fleet 가동을 확인할 수 없어 decision log 에서 턴을 직접 셌다. 처음에는 turn **행** 만 세어 "717 turns/hour, 정상" 이라고 적었는데, `outcome` 을 함께 세자 뒤집혔다:

**fleet 완주율 50.5%** (32,141 turn 행 중 16,234 success).

| keeper | turn 행 | 완주 | 최근 6h 완주 |
|---|---:|---:|---:|
| taskmaster | 3,958 | 3,135 (79%) | 144 / 511 |
| code-reviewer | 3,960 | 2,384 (60%) | 194 / 508 |
| analyst | 4,846 | 2,185 (45%) | 126 / 471 |
| kidsnote | 3,861 | 1,751 (45%) | **20 / 534** |
| rondo | 4,712 | 1,885 (40%) | 181 / 498 |
| lane-smith | 3,246 | 1,126 (35%) | 192 / 361 |
| sangsu | 4,768 | 1,497 (31%) | **0 / 546** |

이 PR 은 필요하지만 충분하지 않다. **교정된 게이트도 turn 행만 세고 `outcome` 을 보지 않는다** — sangsu 는 최근 6시간 546턴 시도 · 0턴 완주인데 `persistent_24h_turn_exchange` 를 PASS 한다 (span 78h, 마지막 턴 0분 전). 완주 기준으로 세는 것은 게이트 의미론 변경이라 #27947 에서 함께 다룬다.

라이브 실패 두 종을 기존 이슈에 실측과 함께 첨부했다:
- #27835 (official-client 세션 recovery 교착) — sangsu 488 · kidsnote 456 턴 거부, 미해소 세션 id 가 keeper 당 7개까지 누적, 마지막 거부 0.01h 전
- #27427 (`Prompt exceeds max length`) — 종결로 기록됐으나 전수 11,088건, 7대 전부, 최근 2.1h 전
