### PR TITLE
fix(tool-blobs): type truncated marker failures

### DIFF
--- a/lib/tool_blob_store/tool_output.ml
+++ b/lib/tool_blob_store/tool_output.ml
@@ -146,6 +146,7 @@ let decode_from_oas s =
            (fun sha256 bytes mime preview -> Ok (sha256, bytes, mime, preview))
        with
        | Scanf.Scan_failure msg -> Error msg
+       | End_of_file -> Error "unexpected end of artifact marker"
        | Failure msg -> Error msg
        | Invalid_argument msg -> Error msg)
     with


### PR DESCRIPTION
Closes #27943.

A truncated normalized artifact marker can make Scanf.sscanf raise End_of_file. Keep decode_from_oas on its typed Invalid_marker boundary so maintenance fails closed instead of crashing.

Validation:
- scripts/dune-local.sh build @test/runtest-test_tool_blob_store (37/37)
- ocamlformat --check lib/tool_blob_store/tool_output.ml
- ocamlc -stop-after parsing lib/tool_blob_store/tool_output.ml
- git diff --check