### PR TITLE
fix(keeper): make standalone authorities fail visible

### DIFF
--- a/dashboard/src/api/dashboard-verification-runs.test.ts
+++ b/dashboard/src/api/dashboard-verification-runs.test.ts
@@ -1,5 +1,3 @@
-// RFC-0361 D4 — completion-authority review registry decoding.
-//
 // The registry exists so a review that produced no verdict is visible. These
 // cases pin that the decoder never turns such a row into something healthier
 // than it is, and that each outcome's cause survives into the one column the
@@ -118,6 +116,35 @@ describe('parseVerificationRunsResponse', () => {
     expect(onlyRun(parsed).status).toBe('not_reviewed')
     expect(onlyRun(parsed).cause).toBe('no runtime')
     expect(onlyRun(parsed).gate).toBe('evaluator_unavailable')
+  })
+
+  it('keeps the typed infrastructure stage without inventing a verdict', () => {
+    const parsed = parseVerificationRunsResponse({
+      generated_at: '2026-08-05T00:00:00Z',
+      count: 1,
+      runs: [row({
+        status: 'infrastructure_unavailable',
+        stage: 'lookup_surface',
+        detail: 'producer metadata unavailable',
+      })],
+    })
+    expect(onlyRun(parsed)).toMatchObject({
+      status: 'infrastructure_unavailable',
+      infrastructureStage: 'lookup_surface',
+      cause: 'producer metadata unavailable',
+    })
+  })
+
+  it('rejects an unknown infrastructure stage', () => {
+    expect(() => parseVerificationRunsResponse({
+      generated_at: '2026-08-05T00:00:00Z',
+      count: 1,
+      runs: [row({
+        status: 'infrastructure_unavailable',
+        stage: 'probably_available',
+        detail: 'producer metadata unavailable',
+      })],
+    })).toThrow('runs[0].stage has unknown value')
   })
 
   it('rejects an unrecognized status as a protocol break', () => {

--- a/dashboard/src/api/dashboard-verification-runs.ts
+++ b/dashboard/src/api/dashboard-verification-runs.ts
@@ -17,7 +17,7 @@ export type VerificationRunStatusLabel =
   | 'running'
   | 'approved'
   | 'rejected'
-  | 'contract_rejected'
+  | 'infrastructure_unavailable'
   | 'not_reviewed'
   | 'commit_failed'
   | 'raised'
@@ -38,7 +38,7 @@ const BACKEND_STATUSES: readonly string[] = [
   'running',
   'approved',
   'rejected',
-  'contract_rejected',
+  'infrastructure_unavailable',
   'not_reviewed',
   'commit_failed',
   'raised',
@@ -63,6 +63,8 @@ export interface VerificationRunRecord {
   cause?: string
   /** Which gate declined to produce a verdict; `not_reviewed` rows only. */
   gate?: string
+  /** Which pre-review boundary was unavailable. */
+  infrastructureStage?: 'review_preparation' | 'lookup_surface'
   tools?: VerificationToolObservation[]
 }
 
@@ -180,7 +182,10 @@ function parseRun(raw: unknown, index: number): VerificationRunRecord {
       requiredOutcomeFields = ['elapsed_s', 'gate', 'detail', 'tools']
       optionalFields = ['evaluator_runtime']
       break
-    case 'contract_rejected':
+    case 'infrastructure_unavailable':
+      requiredOutcomeFields = ['elapsed_s', 'stage', 'detail', 'tools']
+      optionalFields = ['evaluator_runtime']
+      break
     case 'commit_failed':
     case 'raised':
       requiredOutcomeFields = ['elapsed_s', 'detail', 'tools']
@@ -213,12 +218,17 @@ function parseRun(raw: unknown, index: number): VerificationRunRecord {
     evaluatorRuntime: optionalNonEmptyString(raw.evaluator_runtime, `${context}.evaluator_runtime`),
     cause: status === 'rejected'
       ? nonEmptyString(raw.reason, `${context}.reason`)
-      : status === 'contract_rejected' || status === 'not_reviewed'
+      : status === 'infrastructure_unavailable' || status === 'not_reviewed'
         || status === 'commit_failed' || status === 'raised'
         ? nonEmptyString(raw.detail, `${context}.detail`)
         : undefined,
     gate: status === 'not_reviewed'
       ? nonEmptyString(raw.gate, `${context}.gate`)
+      : undefined,
+    infrastructureStage: status === 'infrastructure_unavailable'
+      ? raw.stage === 'review_preparation' || raw.stage === 'lookup_surface'
+        ? raw.stage
+        : protocolError(`${context}.stage has unknown value ${JSON.stringify(raw.stage)}`)
       : undefined,
     tools,
   }

--- a/dashboard/src/components/verification-runs-panel.ts
+++ b/dashboard/src/components/verification-runs-panel.ts
@@ -41,9 +41,8 @@ import { registerInternalAgentRefresh } from '../sse-store'
  *  `not_reviewed` / `commit_failed` / `raised`. Protocol breaks are rejected by
  *  the decoder before a row reaches this projection.
  *
- *  `contract_rejected` is `warn`: the Task was rejected without the configured
- *  LLM ever running, so repeated rows point upstream at malformed evidence
- *  rather than at judgment. */
+ *  `infrastructure_unavailable` is bad because no semantic verdict reached
+ *  the Task; the submitted obligation remains pending for retry. */
 export function verificationRunTone(status: VerificationRunStatusLabel): StatusBadgeTone {
   switch (status) {
     case 'running':
@@ -52,8 +51,8 @@ export function verificationRunTone(status: VerificationRunStatusLabel): StatusB
       return 'ok'
     case 'rejected':
       return 'info'
-    case 'contract_rejected':
-      return 'warn'
+    case 'infrastructure_unavailable':
+      return 'bad'
     case 'not_reviewed':
     case 'commit_failed':
     case 'raised':
@@ -71,8 +70,8 @@ export function verificationRunLabel(status: VerificationRunStatusLabel): string
       return '승인'
     case 'rejected':
       return '거부'
-    case 'contract_rejected':
-      return '증거 계약 무효'
+    case 'infrastructure_unavailable':
+      return '판정 기반시설 오류'
     case 'not_reviewed':
       return '판정 없음'
     case 'commit_failed':
@@ -122,6 +121,7 @@ function VerificationRunRow({ row }: { row: VerificationRunRecord }) {
       </td>
       <td class="py-2 text-[var(--color-fg-secondary)] break-words">
         ${row.gate ? html`<code class="mr-1">${row.gate}</code>` : null}
+        ${row.infrastructureStage ? html`<code class="mr-1">${row.infrastructureStage}</code>` : null}
         ${row.cause ?? ''}
       </td>
     </tr>

--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -16,6 +16,7 @@ type runtime =
   ; retry_scheduled : bool Atomic.t
   ; retry_interval_sec : float
   ; in_flight : review_key list Atomic.t
+  ; review_slots : Eio.Semaphore.t
   }
 
 and review_key =
@@ -161,9 +162,7 @@ let required_string_list_field ~context name fields =
 let completion_contract_of_request
       (request : Verification.verification_request)
   =
-  let completion_contract =
-    List.map (fun (Verification.Custom description) -> description) request.criteria
-  in
+  let completion_contract = request.criteria in
   let completion_contract =
     match completion_contract with
     | [] -> None
@@ -388,12 +387,10 @@ let observe_rejection_wakeup
 ;;
 
 (* Returns the control-flow outcome the scan loop acts on, paired with the
-   observation outcome recorded for this review (RFC-0361 D4). [on_commit] is
-   what the record should say when the durable commit succeeds — the caller
-   knows whether this verdict came from the configured LLM or from the agent's
-   own evidence-contract rejection, and a surface that cannot tell those apart
-   shows "rejected" without saying whether a judge ever ran. A failed commit is
-   its own outcome: the verdict was decided but never reached the Task. *)
+   observation outcome recorded for this review. [on_commit] is the exact
+   semantic verdict produced by the evaluator. Infrastructure failures never
+   call this function. A failed commit is its own outcome because the verdict
+   was decided but never reached the Task. *)
 let commit_verdict
       (runtime : runtime)
       (task : Masc_domain.task)
@@ -449,10 +446,8 @@ let process_task_once
   =
   let agent_run_id = Random_id.prefixed ~prefix:"system-llm-agent-" ~bytes:16 in
   let authority = Masc_domain.System_llm_agent { agent_run_id } in
-  (* RFC-0361 D4: register before any work so a review that raises or defers is
-     still visible. Every exit below records through [complete], including the
-     paths that produce no verdict — those were previously invisible, since only
-     a committed verdict emitted a durable event. *)
+  (* Register before any work. Every exit below records through [complete],
+     including paths that produce no semantic verdict. *)
   let registry = Verification_run_registry.global () in
   let started_at = Eio.Time.now runtime.clock in
   let tools = ref [] in
@@ -483,19 +478,10 @@ let process_task_once
       ();
     process_outcome
   in
-  let reject_contract ~reason ~detail =
+  let defer_unavailable ~stage ~detail =
     complete
-      (commit_verdict
-         runtime
-         task
-         ~assignee
-         ~verification_id
-         ~authority
-         ~verdict:(Masc_domain.Verdict_rejected { reason })
-         ~notes:reason
-         ~verdict_label:"rejected_contract"
-         ~on_commit:(Verification_run_registry.Contract_rejected { detail })
-         ~evaluator_runtime:None)
+      ( defer ~task_id:task.id ~verification_id ~authority ~reason:detail
+      , Verification_run_registry.Infrastructure_unavailable { stage; detail } )
   in
   try
     match
@@ -507,8 +493,9 @@ let process_task_once
         ~authority
     with
     | Error reason ->
-      let rejection_reason = "completion evidence contract invalid: " ^ reason in
-      reject_contract ~reason:rejection_reason ~detail:reason
+      defer_unavailable
+        ~stage:Verification_run_registry.Review_preparation
+        ~detail:reason
     | Ok prepared ->
       (match
          Verification_authority_tools.create
@@ -516,8 +503,9 @@ let process_task_once
            ~producer:assignee
        with
        | Error reason ->
-         let rejection_reason = "completion lookup contract invalid: " ^ reason in
-         reject_contract ~reason:rejection_reason ~detail:reason
+         defer_unavailable
+           ~stage:Verification_run_registry.Lookup_surface
+           ~detail:reason
        | Ok lookup_tools ->
          let lookup =
            Task.Anti_rationalization.Lookup_tools
@@ -637,7 +625,13 @@ let process_pending (runtime : runtime) =
          match task.task_status with
          | Masc_domain.AwaitingVerification { assignee; verification_id; _ } ->
            Eio.Fiber.fork ~sw:runtime.sw (fun () ->
-             process_task runtime task ~assignee ~verification_id)
+             Eio.Semaphore.acquire runtime.review_slots;
+             (* fun-protect-finally-ok: [Eio.Semaphore.release] is
+                non-suspending and must return the bounded review slot on
+                normal completion, exception, or cancellation. *)
+             Fun.protect
+               ~finally:(fun () -> Eio.Semaphore.release runtime.review_slots)
+               (fun () -> process_task runtime task ~assignee ~verification_id))
          | Masc_domain.Todo
          | Masc_domain.Claimed _
          | Masc_domain.InProgress _
@@ -689,6 +683,7 @@ let start ~sw ~clock ~(config : Workspace_utils_backend_setup.config) =
     ; retry_scheduled = Atomic.make false
     ; retry_interval_sec = Env_config.Timeouts.maintenance_pulse_interval_sec
     ; in_flight = Atomic.make []
+    ; review_slots = Eio.Semaphore.make 4
     }
   in
   let owner = Some runtime in

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -23,14 +23,13 @@ let clamp_limit limit =
   else if l > max_limit then max_limit
   else l
 
-(** Criteria carry the "completion_contract" in their Custom text. *)
+(** Criteria are the exact completion-contract statements. *)
 let completion_contract_of_criteria (criteria : V.criterion list) : string list =
-  List.map (fun (V.Custom text) -> text) criteria
+  criteria
 
 (** Read one required current-schema evidence list. Empty arrays are valid;
-    missing or malformed fields carry a public projection error. No legacy
-    field aliases are consulted and malformed arrays are never partially
-    projected. *)
+    missing or malformed fields carry a public projection error and malformed
+    arrays are never partially projected. *)
 let string_list_of_output field (output : Yojson.Safe.t)
   : string list * string option =
   let missing () =
@@ -154,19 +153,11 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
 
 (* ── Snapshot assembly ──────────────────────────────── *)
 
-(** Load the raw verification request list from the supplied MASC base_path.
-
-    Protected against filesystem errors — failures surface as an empty
-    list plus a log line, matching the tolerance
-    [Verification.list_requests] already offers on a missing dir. *)
+(** Load the raw verification request list from the supplied MASC base_path. *)
 let load_requests ~base_path () : V.verification_request list =
-  try V.list_requests base_path
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-      Log.Task.warn "[dashboard-verification] list_requests failed: %s"
-        (Printexc.to_string exn);
-      []
+  match V.list_requests base_path with
+  | Ok requests -> requests
+  | Error detail -> failwith detail
 
 (** Filter by task_id when the caller requested a specific task. Empty
     string is treated as "no filter" to match the HTTP contract. *)
@@ -215,13 +206,8 @@ let summary_json ~base_path () : Yojson.Safe.t =
      ]
      @ fd_pressure_fields ())
 
-(* Single-load companion for handlers that emit both projections
-   side-by-side ([/api/v1/dashboard/proof] is the live caller).
-
-   [summary_json] and [requests_json] each call [load_requests], so
-   the historic proof handler scanned the verification store twice
-   per refresh.  This helper performs one scan and folds the two
-   projections from the shared list. *)
+(* Single-load companion for handlers that emit both projections side by side.
+   One request-store scan feeds both projections. *)
 let proof_compose ~base_path ?limit () : Yojson.Safe.t * Yojson.Safe.t =
   let limit = clamp_limit limit in
   let all = load_requests ~base_path () in

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -374,6 +374,108 @@ let handle_read_file_with_outcome
          (error_json ~fields:[ "path", `String target ] msg))
 ;;
 
+let handle_owned_read_file_with_outcome
+      ~ownership_root
+      ~(args : Yojson.Safe.t)
+  =
+  let path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
+  let max_bytes = read_file_default_max_bytes in
+  let cwd = string_opt_nonempty "cwd" args in
+  let resolve_target () =
+    if String.equal path ""
+    then Error "path is required"
+    else
+      let cwd_abs =
+        match cwd with
+        | None -> ownership_root
+        | Some cwd ->
+          if Filename.is_relative cwd
+          then Filename.concat ownership_root cwd
+          else cwd
+      in
+      match Fs_compat.inspect_owned_directory_chain ~ownership_root cwd_abs with
+      | Error rejection ->
+        Error (Fs_compat.owned_directory_chain_rejection_to_string rejection)
+      | Ok Fs_compat.Owned_directory_missing ->
+        Error
+          (Printf.sprintf
+             "cwd_not_directory: %s (directory does not exist)"
+             cwd_abs)
+      | Ok (Fs_compat.Owned_directory _) ->
+        let target =
+          if Filename.is_relative path then Filename.concat cwd_abs path else path
+        in
+        Ok target
+  in
+  match read_line_window_of_args args, resolve_target () with
+  | Error window_error, _ -> Keeper_tool_execution.failure (error_json window_error)
+  | Ok _, Error detail -> Keeper_tool_execution.failure (error_json detail)
+  | Ok window, Ok target ->
+    let fetch_bytes = read_window_fetch_bytes ~max_bytes window in
+    (match
+       Fs_compat.load_owned_regular_file_prefix
+         ~ownership_root
+         ~max_bytes:fetch_bytes
+         target
+     with
+     | Error error ->
+       Keeper_tool_execution.failure
+         (error_json
+            ~fields:[ "path", `String target ]
+            (Fs_compat.owned_regular_file_read_error_to_string error))
+     | Ok None ->
+       Keeper_tool_execution.failure
+         (missing_file_error_json
+            ~cwd
+            ~raw_path:(Some path)
+            ~target
+            ~error:"owned file is missing")
+     | Ok (Some prefix) ->
+       (match
+          slice_read_window
+            ~window
+            ~max_bytes
+            ~scan_complete:(not prefix.truncated)
+            prefix.content
+        with
+        | Error `Offset_beyond_scan ->
+          Keeper_tool_execution.failure
+            (error_json
+               ~fields:
+                 [ "path", `String target
+                 ; "offset", `Int window.start_line
+                 ; "scanned_bytes", `Int (String.length prefix.content)
+                 ]
+               (Printf.sprintf
+                  "offset %d is beyond the scanned window (%d bytes)"
+                  window.start_line
+                  (String.length prefix.content)))
+        | Ok slice ->
+          let optional_fields =
+            List.concat
+              [ (match slice.next_offset with
+                 | Some next -> [ "next_offset", `Int next ]
+                 | None -> [])
+              ; (if slice.last_line_partial
+                 then [ "last_line_partial", `Bool true ]
+                 else [])
+              ]
+          in
+          Keeper_tool_execution.success
+            (Yojson.Safe.to_string
+               (`Assoc
+                   ([ "ok", `Bool true
+                    ; "path", `String target
+                    ; "bytes", `Int (String.length slice.window_content)
+                    ; "file_bytes", `Int prefix.file_size
+                    ; "truncated", `Bool slice.window_truncated
+                    ; "offset", `Int window.start_line
+                    ; "returned_lines", `Int slice.returned_lines
+                    ; "content", `String slice.window_content
+                    ]
+                    @ optional_fields)))))
+;;
+
 (* RFC-0006 Phase A.4: replace [old] with [new] in [text]. When
    [replace_all=false], requires exactly one occurrence so accidental
    multi-edits are rejected (mirrors Edit semantics). *)

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -42,6 +42,14 @@ val handle_read_file_with_outcome :
   args:Yojson.Safe.t ->
   Keeper_tool_execution.t
 
+val handle_owned_read_file_with_outcome :
+  ownership_root:string ->
+  args:Yojson.Safe.t ->
+  Keeper_tool_execution.t
+(** Read-only boundary for a Workspace producer that has no Keeper runtime
+    metadata. Relative paths are rooted at [ownership_root], and the opened
+    regular file plus every parent component is verified by [Fs_compat]. *)
+
 (** Rebuild the write arguments from a recorded Gate input, including the
     mode the approval carried. [Error] when the recorded effect is one this
     module cannot reproduce exactly, so a caller replays nothing instead of

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -6,45 +6,23 @@
 
     Design:
     - File-based storage under .masc/verifications/
-    - Criteria-based checking (schema, contains, custom)
+    - Exact operator-authored completion criteria
     - Cross-agent enforcement (worker cannot verify own output)
     - Integration with existing task lifecycle
 *)
 
 open Result.Syntax
 
-(** A verification criterion. One constructor, because one is what is
-    produced: [Verification_protocol.submit_request_spec] builds the list with
-    [List.map (fun s -> Custom s)] over the task's completion contract, and
-    [Completion_authority_agent.completion_contract_of_request] accepts only
-    [Custom].
+type criterion = string
+[@@deriving eq]
 
-    Three more used to sit here — [Schema_match], [Contains] and
-    [Not_contains]. Nothing ever constructed them; their only appearance
-    outside this module was the arm that rejected them with "criteria[i] is not
-    a persisted custom completion contract". Verifying a deliverable by testing
-    whether its text contains a substring was never wired, and the wire tag is
-    kept so the JSON shape does not change. *)
-type criterion = Custom of string  (** Natural-language criterion for a verifier *)
-[@@deriving show, eq]
-
-let criterion_to_yojson = function
-  | Custom s ->
-      `Assoc [("type", `String "custom"); ("description", `String s)]
+let criterion_to_yojson criterion = `String criterion
 
 let criterion_of_yojson = function
-  | `Assoc fields ->
-      (match List.assoc_opt "type" fields with
-       | Some (`String "custom") ->
-           let* description =
-             match List.assoc_opt "description" fields with
-             | Some (`String s) -> Ok s
-             | _ -> Error "custom requires 'description' string field"
-           in
-           Ok (Custom description)
-       | Some (`String t) -> Error (Printf.sprintf "unknown criterion type: %s" t)
-       | _ -> Error "criterion requires 'type' field")
-  | _ -> Error "criterion must be a JSON object"
+  | `String criterion when not (String.equal (String.trim criterion) "") ->
+    Ok criterion
+  | `String _ -> Error "criterion must be a non-empty string"
+  | _ -> Error "criterion must be a string"
 
 (** Verification request *)
 type verification_request = {
@@ -135,50 +113,33 @@ let verifications_dir = Workspace_verification_store.verifications_dir
 let request_path base_path req_id =
   Workspace_verification_store.request_path base_path req_id
 
-(* [list_requests] used to walk [verifications/*.json] on every dashboard
-   refresh: one [Safe_ops.list_dir_safe] for the directory followed by
-   [Safe_ops.read_json_eio] per file (the per-file [load_request] in the
-   filter_map below).  Dashboard layers — [Dashboard_verification.proof_compose],
-   [summary_json], [requests_json] — and verification HTTP routes all funnel
-   into this scan.  PR #19015 collapsed two scans into one within the proof
-   compose, but each cache miss still pays N+1 disk reads.
+type verification_directory =
+  | Missing_directory
+  | Present_directory
 
-   This storage-level cache keeps the most-recent parsed list addressed by
-   [(base_path, dir mtime)].  When the directory has not changed since the
-   last scan, the cache returns the previously-parsed list — a single
-   [Unix.stat] syscall — and skips the readdir + per-file open chain.
-
-   Single-entry [Atomic.t] is sufficient because production deployments run
-   a single [base_path] per MASC server instance.  Multi-tenant workloads
-   would alternate cache misses but never serve stale data — the mtime guard
-   detects directory churn from any source (file create/update/delete all
-   bump [st_mtime]).  Write paths below ([save_request]) additionally
-   invalidate the cache explicitly to close the sub-second mtime resolution
-   race on fast filesystems. *)
-type list_requests_cache_entry = {
-  cache_base_path : string;
-  dir_mtime : float;
-  results : verification_request list;
-}
-
-let list_requests_cache : list_requests_cache_entry option Atomic.t =
-  Atomic.make None
-
-let invalidate_list_requests_cache () =
-  Atomic.set list_requests_cache None
-
-let dir_mtime_opt dir =
-  try Some (Unix.stat dir).Unix.st_mtime with
-  | Unix.Unix_error _ | Sys_error _ -> None
+let verification_directory dir =
+  try
+    let (_ : Unix.stats) = Unix.stat dir in
+    Ok Present_directory
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok Missing_directory
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | exn ->
+    Keeper_fd_pressure.note_exception ~site:"verification.list_requests.stat" exn;
+    Error
+      (Printf.sprintf
+         "verification request directory unavailable at %s: %s"
+         dir
+         (Printexc.to_string exn))
 
 let save_request base_path req =
   try
+    let json = request_to_yojson req in
+    let* _validated = request_of_yojson json in
     let dir = verifications_dir base_path in
     Fs_compat.mkdir_p dir;
-    let json = request_to_yojson req in
     let path = request_path base_path req.id in
     let* () = Fs_compat.save_file_atomic path (Yojson.Safe.pretty_to_string json) in
-    invalidate_list_requests_cache ();
     Ok req.id
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -197,7 +158,6 @@ let delete_request base_path req_id =
   try
     let path = request_path base_path req_id in
     if Sys.file_exists path then Sys.remove path;
-    invalidate_list_requests_cache ();
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -231,59 +191,36 @@ let list_requests_uncached base_path =
       ~detail
   in
   let dir = verifications_dir base_path in
-  let dir_exists =
-    try Sys.file_exists dir with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      Keeper_fd_pressure.note_exception ~site:"verification.list_requests.exists" exn;
-      report_drop
-        ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error
-        ~path:dir
-        ~detail:(Printexc.to_string exn);
-      false
-  in
-  if not dir_exists then
-    []
-  else
-    match Safe_ops.list_dir_safe dir with
-    | Error detail ->
-      report_drop ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error ~path:dir ~detail;
-      []
-    | Ok files ->
-      files
-      |> List.filter (fun f -> Filename.check_suffix f ".json")
-      |> List.filter_map (fun f ->
-          let id = Filename.chop_suffix f ".json" in
-          Safe_ops.result_to_option_logged
-            ~on_drop:(fun () ->
-              observe_drop ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error)
-            ~surface
-            ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
-            ~path:(Filename.concat dir f)
-            (load_request base_path id))
+  match Safe_ops.list_dir_safe dir with
+  | Error detail ->
+    report_drop ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error ~path:dir ~detail;
+    Error (Printf.sprintf "verification request directory unreadable: %s" detail)
+  | Ok files ->
+    let files = List.filter (fun f -> Filename.check_suffix f ".json") files in
+    let rec load acc = function
+      | [] -> Ok (List.rev acc)
+      | file :: rest ->
+        let id = Filename.chop_suffix file ".json" in
+        (match load_request base_path id with
+         | Ok request -> load (request :: acc) rest
+         | Error detail ->
+           let path = Filename.concat dir file in
+           report_drop
+             ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+             ~path
+             ~detail;
+           Error (Printf.sprintf "verification request unreadable at %s: %s" path detail))
+    in
+    load [] files
 
-(* Public entry: check the mtime-keyed cache before the readdir + N+1 open
-   chain.  A cache hit returns the previously-parsed list after a single
-   [Unix.stat] syscall; cache miss falls through to [list_requests_uncached]
-   and refreshes the entry.  See [list_requests_cache] above for the design. *)
+(* Public entry: read the current directory and every current-schema request.
+   Content identity is not inferred from filesystem timestamps. *)
 let list_requests base_path =
   let dir = verifications_dir base_path in
-  match dir_mtime_opt dir with
-  | None ->
-      (* Directory missing or stat failed — defer to the uncached path so
-         the existing directory check and explicit error reporting run. *)
-      list_requests_uncached base_path
-  | Some mtime -> (
-      match Atomic.get list_requests_cache with
-      | Some entry
-        when String.equal entry.cache_base_path base_path
-             && Float.equal entry.dir_mtime mtime ->
-          entry.results
-      | _ ->
-          let results = list_requests_uncached base_path in
-          Atomic.set list_requests_cache
-            (Some { cache_base_path = base_path; dir_mtime = mtime; results });
-          results)
+  match verification_directory dir with
+  | Error detail -> Error detail
+  | Ok Missing_directory -> Ok []
+  | Ok Present_directory -> list_requests_uncached base_path
 
 (** High-level API *)
 

--- a/lib/verification.mli
+++ b/lib/verification.mli
@@ -5,12 +5,10 @@
 
 (** {1 Types} *)
 
-(** One constructor, because one is what is produced: request criteria are
-    built as [Custom] over the task's completion contract, and the completion
-    authority accepts only [Custom]. The wire tag stays ["custom"]. *)
-type criterion = Custom of string
+(** One non-empty completion-contract statement. There is one semantic value,
+    so the wire is the string itself rather than a tagged one-arm union. *)
+type criterion = string
 
-val show_criterion : criterion -> string
 val equal_criterion : criterion -> criterion -> bool
 val criterion_to_yojson : criterion -> Yojson.Safe.t
 val criterion_of_yojson : Yojson.Safe.t -> (criterion, string) result
@@ -40,7 +38,9 @@ val save_request : string -> verification_request -> (string, string) result
 val delete_request : string -> string -> (unit, string) result
 
 val load_request : string -> string -> (verification_request, string) result
-val list_requests : string -> verification_request list
+val list_requests : string -> (verification_request list, string) result
+(** Missing storage is an empty list. An unreadable directory or malformed
+    request is an [Error]; the caller never receives a partial list. *)
 
 (** {1 High-level API} *)
 

--- a/lib/verification_authority_tools.ml
+++ b/lib/verification_authority_tools.ml
@@ -7,22 +7,24 @@
 type tool =
   | Read_file
   | Search_files
-  | Execute
 
 let tool_name = function
   | Read_file -> "tool_read_file"
   | Search_files -> "tool_search_files"
-  | Execute -> "tool_execute"
 ;;
 
-let all_tools = [ Read_file; Search_files; Execute ]
+let all_tools = [ Read_file; Search_files ]
 
 type t =
   { ownership_root : string
   ; config : Workspace.config
-  ; producer_meta : Keeper_meta_contract.keeper_meta
+  ; producer_scope : producer_scope
   ; tools : (tool * Keeper_tool_descriptor.t) list
   }
+
+and producer_scope =
+  | Keeper_producer of Keeper_meta_contract.keeper_meta
+  | Workspace_producer
 
 let descriptor_of_tool tool =
   match Keeper_tool_descriptor.descriptors_for_internal (tool_name tool) with
@@ -51,27 +53,45 @@ let rec resolve_tools = function
 
 let create ~config ~producer =
   let open Result.Syntax in
-  let* tools = resolve_tools all_tools in
-  let* producer_meta =
+  let* producer_scope =
     match Keeper_meta_store.read_meta config producer with
     | Error message ->
       Error (Printf.sprintf "producer %s meta unreadable: %s" producer message)
-    | Ok None -> Error (Printf.sprintf "producer %s has no keeper meta" producer)
-    | Ok (Some producer_meta) -> Ok producer_meta
+    | Ok None -> Ok Workspace_producer
+    | Ok (Some producer_meta) -> Ok (Keeper_producer producer_meta)
   in
-  let project_root =
-    Workspace_verification_store.project_root_of_base_path config.base_path
+  let* tools =
+    resolve_tools
+      (match producer_scope with
+       | Keeper_producer _ -> all_tools
+       | Workspace_producer -> [ Read_file ])
+  in
+  let* ownership_root =
+    match producer_scope with
+    | Keeper_producer producer_meta ->
+      Ok (Keeper_sandbox.host_root_abs_of_meta ~config producer_meta)
+    | Workspace_producer ->
+      let project_root =
+        Workspace_verification_store.project_root_of_base_path config.base_path
+      in
+      (try
+         Ok
+           (Keeper_sandbox_config.host_root_abs_of_agent
+              ~base_path:project_root
+              ~agent_name:producer)
+       with
+       | Keeper_sandbox_config.Invalid_keeper_sandbox_config detail ->
+         Error
+           (Printf.sprintf
+              "producer %s sandbox configuration invalid: %s"
+              producer
+              detail))
   in
   let ownership_root =
-    Keeper_sandbox_config.host_root_abs_of_agent
-      ~base_path:project_root
-      ~agent_name:producer
-    |> Env_config_core.strip_trailing_slashes
+    Env_config_core.strip_trailing_slashes ownership_root
   in
-  Ok { ownership_root; config; producer_meta; tools }
+  Ok { ownership_root; config; producer_scope; tools }
 ;;
-
-let ownership_root t = t.ownership_root
 
 (* ================================================================ *)
 (* Schemas                                                          *)
@@ -142,29 +162,28 @@ let result_of_execution (execution : Keeper_tool_execution.t) =
    profile resolves no sandbox and the runtime returns its own error — the judge
    is told the tree is unreachable rather than silently inspecting the host. *)
 let run t tool ~args =
-  match tool with
-  | Read_file ->
+  match t.producer_scope, tool with
+  | Keeper_producer producer_meta, Read_file ->
     Keeper_tool_filesystem_runtime.handle_read_file_with_outcome
       ~turn_sandbox_factory:None
       ~config:t.config
-      ~meta:t.producer_meta
+      ~meta:producer_meta
       ~args
     |> result_of_execution
-  | Search_files ->
+  | Keeper_producer producer_meta, Search_files ->
     Keeper_workspace_ops.handle_tool_search_files_with_outcome
       ~turn_sandbox_factory:None
       ~config:t.config
-      ~meta:t.producer_meta
+      ~meta:producer_meta
       ~args
     |> result_of_execution
-  | Execute ->
-    Keeper_tool_execute_runtime.handle_tool_execute_with_outcome
-      ~turn_sandbox_factory:None
-      ~config:t.config
-      ~meta:t.producer_meta
+  | Workspace_producer, Read_file ->
+    Keeper_tool_filesystem_runtime.handle_owned_read_file_with_outcome
+      ~ownership_root:t.ownership_root
       ~args
-      ()
     |> result_of_execution
+  | Workspace_producer, Search_files ->
+    Error "workspace producers do not expose tool_search_files"
 ;;
 
 let dispatch t ~name ~args =
@@ -174,7 +193,7 @@ let dispatch t ~name ~args =
       Printf.sprintf
         "unknown tool %s; this review offers %s"
         name
-        (String.concat ", " (List.map tool_name all_tools))
+        (String.concat ", " (List.map (fun (tool, _) -> tool_name tool) t.tools))
     in
     log_call t ~name ~argument:"" ~outcome:Unknown_tool;
     Error detail

--- a/lib/verification_authority_tools.mli
+++ b/lib/verification_authority_tools.mli
@@ -1,14 +1,16 @@
-(** Completion-authority access to one producer's typed filesystem and command
-    descriptors. Descriptor registry drift and unreadable producer state reject
-    surface construction. Every dispatched call is validated and translated by
-    the same descriptor that was advertised. *)
+(** Completion-authority access to one producer's typed read-only filesystem
+    descriptors. A Keeper producer receives its metadata-bound Read and Grep;
+    a Workspace producer without Keeper runtime metadata receives an
+    ownership-root-bound Read. Descriptor registry drift and unreadable
+    producer state reject surface construction. Every dispatched call is
+    validated and translated by the same descriptor that was advertised.
+    Mutating execution is absent: a verifier has no turn continuation that
+    could resume an approved Gate effect. *)
 
 type t
 
 val create :
   config:Workspace.config -> producer:string -> (t, string) result
-
-val ownership_root : t -> string
 
 val schemas : t -> Types_core.tool_schema list
 

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -7,14 +7,10 @@
 
     @since Phase B+C *)
 
-(* Fail-closed by types: [~assignee] is passed directly by the caller,
-   which already destructures [AwaitingVerification { assignee; _ }]. Removes
-   the prior "unknown" fallback that violated Silent Failure 금지. Issue #7547.
-
-   Contract source rules (must stay aligned with [task_contract] in
+(* Contract source rules (must stay aligned with [task_contract] in
    types_core.ml):
    - [criteria]: the operator-facing "must be true" statements →
-     [task.contract.completion_contract] wrapped in [Verification.Custom].
+     [task.contract.completion_contract] as exact criterion strings.
    - [evidence_refs]: the artefact list the completion authority expects to see →
      [task.contract.verify_gate_evidence] plus required evidence refs,
      passed in by the caller at task-state lifecycle so this function does
@@ -28,18 +24,14 @@ type submit_request_spec =
   ; board_title : string
   ; board_content : string
   ; evidence_fields : (string * Yojson.Safe.t) list
-      (* task-1664: transient required/submitted role split for Board/SSE.
-         Request persistence replaces the raw [submitted_evidence] list with
-         its one typed submit-time snapshot SSOT. *)
+      (* Request persistence replaces [submitted_evidence] with its typed
+         submit-time snapshot SSOT. *)
   ; submitted_evidence : string list
   }
 
 let submit_request_spec ~(config : Workspace.config) ~(task : Masc_domain.task)
     ~assignee ~evidence_refs =
-  (* Every submission is an ordinary verification request. The
-     [conflict_triage] branch this replaced was selected by reading the
-     planning deliverable's prose for an English "completed" prefix, which
-     matched 0 of the 199 non-empty deliverables in the live store. *)
+  (* Every submission is an ordinary verification request. *)
   let request_kind = "normal" in
   let request_summary = "" in
   let next_action = "" in
@@ -49,13 +41,14 @@ let submit_request_spec ~(config : Workspace.config) ~(task : Masc_domain.task)
     Printf.sprintf "Verification requested for task %s (%s) by %s"
       task.id task.title assignee
   in
-  let criteria = List.map (fun s -> Verification.Custom s)
-    (match task.contract with
-     | Some c -> c.completion_contract
-     | None -> []) in
-  (* task-1664: derive the required/submitted role split from the task SSOT.
-     The submitted strings remain transient here; [create_submit_request]
-     replaces them with the typed persisted snapshot. *)
+  let criteria =
+    match task.contract with
+    | Some c -> c.completion_contract
+    | None -> []
+  in
+  (* Derive the required/submitted role split from the task SSOT. The strings
+     remain transient here; [create_submit_request] persists the typed
+     snapshot. *)
   let verification_evidence =
     Masc_task_handlers.Tool_task_completion_review.concrete_verification_evidence
       ~submitted_evidence_refs:evidence_refs

--- a/lib/verification_run_registry.ml
+++ b/lib/verification_run_registry.ml
@@ -1,7 +1,14 @@
+type infrastructure_stage =
+  | Review_preparation
+  | Lookup_surface
+
 type outcome =
   | Approved
   | Rejected of { reason : string }
-  | Contract_rejected of { detail : string }
+  | Infrastructure_unavailable of
+      { stage : infrastructure_stage
+      ; detail : string
+      }
   | Not_reviewed of
       { gate : string
       ; detail : string
@@ -41,13 +48,24 @@ type run =
 let outcome_label = function
   | Approved -> "approved"
   | Rejected _ -> "rejected"
-  | Contract_rejected _ -> "contract_rejected"
+  | Infrastructure_unavailable _ -> "infrastructure_unavailable"
   | Not_reviewed _ -> "not_reviewed"
   | Commit_failed _ -> "commit_failed"
   | Raised _ -> "raised"
 ;;
 
 module Payload = struct
+  let infrastructure_stage_to_string = function
+    | Review_preparation -> "review_preparation"
+    | Lookup_surface -> "lookup_surface"
+  ;;
+
+  let infrastructure_stage_of_string = function
+    | "review_preparation" -> Ok Review_preparation
+    | "lookup_surface" -> Ok Lookup_surface
+    | value -> Error (Printf.sprintf "unknown infrastructure stage %S" value)
+  ;;
+
   type registration =
     { task_id : string
     ; producer : string
@@ -98,8 +116,12 @@ module Payload = struct
   let outcome_fields = function
     | Approved -> []
     | Rejected { reason } -> [ "reason", `String reason ]
-    | Contract_rejected { detail } | Commit_failed { detail } | Raised { detail } ->
+    | Commit_failed { detail } | Raised { detail } ->
       [ "detail", `String detail ]
+    | Infrastructure_unavailable { stage; detail } ->
+      [ "stage", `String (infrastructure_stage_to_string stage)
+      ; "detail", `String detail
+      ]
     | Not_reviewed { gate; detail } ->
       [ "gate", `String gate; "detail", `String detail ]
   ;;
@@ -138,7 +160,8 @@ module Payload = struct
       match label with
       | "approved" -> Ok []
       | "rejected" -> Ok [ "reason" ]
-      | "contract_rejected" | "commit_failed" | "raised" -> Ok [ "detail" ]
+      | "infrastructure_unavailable" -> Ok [ "stage"; "detail" ]
+      | "commit_failed" | "raised" -> Ok [ "detail" ]
       | "not_reviewed" -> Ok [ "gate"; "detail" ]
       | other -> Error (Printf.sprintf "unknown verification outcome %S" other)
     in
@@ -218,9 +241,11 @@ module Payload = struct
       | "rejected" ->
         let* reason = Run_registry_core.Json.string_field "reason" fields in
         Ok (Rejected { reason })
-      | "contract_rejected" ->
+      | "infrastructure_unavailable" ->
+        let* stage = Run_registry_core.Json.string_field "stage" fields in
+        let* stage = infrastructure_stage_of_string stage in
         let* detail = Run_registry_core.Json.string_field "detail" fields in
-        Ok (Contract_rejected { detail })
+        Ok (Infrastructure_unavailable { stage; detail })
       | "not_reviewed" ->
         let* gate = Run_registry_core.Json.string_field "gate" fields in
         let* detail = Run_registry_core.Json.string_field "detail" fields in
@@ -339,8 +364,12 @@ let status_label = function
 let outcome_detail_fields = function
   | Approved -> []
   | Rejected { reason } -> [ "reason", `String reason ]
-  | Contract_rejected { detail } | Commit_failed { detail } | Raised { detail } ->
+  | Commit_failed { detail } | Raised { detail } ->
     [ "detail", `String detail ]
+  | Infrastructure_unavailable { stage; detail } ->
+    [ "stage", `String (Payload.infrastructure_stage_to_string stage)
+    ; "detail", `String detail
+    ]
   | Not_reviewed { gate; detail } ->
     [ "gate", `String gate; "detail", `String detail ]
 ;;

--- a/lib/verification_run_registry.mli
+++ b/lib/verification_run_registry.mli
@@ -1,9 +1,16 @@
 (** Bounded observation registry for completion-authority reviews. *)
 
+type infrastructure_stage =
+  | Review_preparation
+  | Lookup_surface
+
 type outcome =
   | Approved
   | Rejected of { reason : string }
-  | Contract_rejected of { detail : string }
+  | Infrastructure_unavailable of
+      { stage : infrastructure_stage
+      ; detail : string
+      }
   | Not_reviewed of
       { gate : string
       ; detail : string

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -891,13 +891,32 @@ let commit_verdict_r
            in
            let producer = decided.Workspace_task_lifecycle.producer in
            let verification_id = decided.Workspace_task_lifecycle.verification_id in
+           let rejection_handoff =
+             match verdict with
+             | Masc_domain.Verdict_approved -> None
+             | Masc_domain.Verdict_rejected { reason } ->
+               Some
+                 { Masc_domain.summary = reason
+                 ; reason = Some reason
+                 ; next_step = None
+                 ; failure_mode = None
+                 ; reclaim_policy = None
+                 ; evidence_refs = [ verification_id ]
+                 ; updated_at = Some now
+                 ; updated_by = Some authority_actor
+                 }
+           in
            let new_backlog =
              { backlog with
                tasks =
                  List.map
                    (fun (t : task) ->
                       if String.equal t.id task_id
-                      then { t with task_status = new_status }
+                      then
+                        { t with
+                          task_status = new_status
+                        ; handoff_context = rejection_handoff
+                        }
                       else t)
                    backlog.tasks
              }

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -228,9 +228,22 @@ let submitted_evidence_item_of_yojson = function
     in
     (match List.assoc_opt "kind" fields with
      | Some (`String "note") ->
+       let open Result.Syntax in
+       let* () =
+         Json_util.reject_unknown_fields
+           ~surface:"submitted evidence note"
+           ~allowed:[ "kind"; "content" ]
+           fields
+       in
        Result.map (fun note -> Evidence_note note) (string_field "content")
      | Some (`String "artifact") ->
        let open Result.Syntax in
+       let* () =
+         Json_util.reject_unknown_fields
+           ~surface:"submitted evidence artifact"
+           ~allowed:[ "kind"; "reference"; "content"; "bytes"; "truncated" ]
+           fields
+       in
        let* reference = string_field "reference" in
        let* content = string_field "content" in
        let* bytes =

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -537,7 +537,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # Exact current count. The audit's documented categories explain why every
 # reported entry is not mechanically removable; the ratchet still forbids
 # adding another dead public export.
-DEAD_EXPORT_BASELINE = 550
+DEAD_EXPORT_BASELINE = 549
 
 
 def run_ratchet(count: int) -> int:

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1548,7 +1548,7 @@ let test_dashboard_proof_http_json_surfaces_submission_index () =
        ~base_path:config.base_path
        ~task_id:"task-proof-route"
        ~output
-       ~criteria:[ V.Custom "proof route must expose verification evidence" ]
+       ~criteria:[ "proof route must expose verification evidence" ]
        ~worker:"keeper-proof"
        ()
    with

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -11,16 +11,9 @@ let () = Mirage_crypto_rng_unix.use_default ()
 
 module V = Masc.Verification
 module D = Dashboard_verification
-module CU = Workspace_utils
 module FD = Keeper_fd_pressure
 
 (* ── Fixture helpers ────────────────────────────────── *)
-
-let active_verifications_dir base_path =
-  Filename.concat (CU.masc_dir_from_base_path ~base_path) "verifications"
-
-let legacy_verifications_dir base_path =
-  Filename.concat base_path "verifications"
 
 let rec rm_rf path =
   if Sys.file_exists path then
@@ -150,7 +143,7 @@ let test_temp_base_path_overrides_and_restores_env_inputs () =
           (Some base_path) (Sys.getenv_opt "MASC_BASE_PATH_INPUT");
         let _ =
           create_pending_request ~base_path ~task_id:"task-env-override"
-            ~worker:"keeper-alpha" ~criteria:[V.Custom "env isolated"]
+            ~worker:"keeper-alpha" ~criteria:[ "env isolated" ]
             ~evidence:["ref-env"]
         in
         let j = D.requests_json ~base_path () in
@@ -173,8 +166,8 @@ let test_requests_json_shape () =
         ~task_id:"task-shape"
         ~worker:"keeper-alpha"
         ~criteria:[
-          V.Custom "Must reduce FD leak";
-          V.Custom "Must pass integration tests";
+          "Must reduce FD leak";
+          "Must pass integration tests";
         ]
         ~required_artifacts:[
           "artifact://required-report";
@@ -236,8 +229,6 @@ let test_requests_json_shape () =
            ["trace://submitted-runtime-proof"]
            (List.map Yojson.Safe.Util.to_string items)
      | _ -> Alcotest.fail "submitted_evidence should be list");
-    Alcotest.(check bool) "legacy required_evidence alias removed"
-      true (member "required_evidence" r = `Null);
     Alcotest.(check bool) "valid empty/non-empty evidence has no projection error"
       true (member "evidence_projection_error" r = `Null);
     (match member "submitted_by" r with
@@ -269,14 +260,14 @@ let test_requests_json_uses_explicit_base_path_not_env () =
         create_pending_request ~base_path:workspace_base
           ~task_id:"task-workspace"
           ~worker:"keeper-workspace"
-          ~criteria:[V.Custom "workspace criterion"]
+          ~criteria:[ "workspace criterion" ]
           ~evidence:["ref-workspace"]
       in
       let _ =
         create_pending_request ~base_path:env_base
           ~task_id:"task-env"
           ~worker:"keeper-env"
-          ~criteria:[V.Custom "env criterion"]
+          ~criteria:[ "env criterion" ]
           ~evidence:["ref-env"]
       in
       let j = D.requests_json ~base_path:workspace_base () in
@@ -298,13 +289,13 @@ let test_task_id_filter () =
   with_temp_base_path (fun base_path ->
     let _ = create_pending_request ~base_path
         ~task_id:"task-A" ~worker:"alpha"
-        ~criteria:[V.Custom "A criterion"] ~evidence:["ref-A"] in
+        ~criteria:[ "A criterion" ] ~evidence:["ref-A"] in
     let _ = create_pending_request ~base_path
         ~task_id:"task-A" ~worker:"alpha"
-        ~criteria:[V.Custom "A criterion 2"] ~evidence:["ref-A2"] in
+        ~criteria:[ "A criterion 2" ] ~evidence:["ref-A2"] in
     let _ = create_pending_request ~base_path
         ~task_id:"task-B" ~worker:"beta"
-        ~criteria:[V.Custom "B criterion"] ~evidence:["ref-B"] in
+        ~criteria:[ "B criterion" ] ~evidence:["ref-B"] in
 
     (* Unfiltered: all 3 requests *)
     let j_all = D.requests_json ~base_path () in
@@ -345,30 +336,6 @@ let test_task_id_filter () =
      | `List _ -> Alcotest.fail "expected empty list"
      | _ -> Alcotest.fail "requests not list"))
 
-let test_requests_json_ignores_legacy_root_entries () =
-  with_temp_base_path (fun base_path ->
-    let _ =
-      create_pending_request ~base_path ~task_id:"task-live" ~worker:"alpha"
-        ~criteria:[V.Custom "live criterion"] ~evidence:["ref-live"]
-    in
-    let legacy_dir = legacy_verifications_dir base_path in
-    Fs_compat.mkdir_p legacy_dir;
-    Fs_compat.save_file (Filename.concat legacy_dir "vrf-foreign.json")
-      {|{"id":"vrf-foreign","task_id":"task-legacy","evaluator":"oracle","overall_verdict":"approve"}|};
-    Alcotest.(check bool) "active store exists" true
-      (Sys.file_exists (active_verifications_dir base_path));
-    let j = D.requests_json ~base_path () in
-    (match member "total" j with
-     | `Int 1 -> ()
-     | `Int n -> Alcotest.fail (Printf.sprintf "expected 1 live row, got %d" n)
-     | _ -> Alcotest.fail "total not int");
-    match member "requests" j with
-    | `List [row] -> (
-        match member "task_id" row with
-        | `String "task-live" -> ()
-        | _ -> Alcotest.fail "legacy root row leaked into dashboard")
-    | _ -> Alcotest.fail "expected one dashboard row")
-
 let test_requests_json_surfaces_conflict_triage_fields () =
   with_temp_base_path (fun base_path ->
     let output =
@@ -385,7 +352,7 @@ let test_requests_json_surfaces_conflict_triage_fields () =
     in
     let req =
       match V.create_request ~base_path ~task_id:"task-conflict" ~output
-              ~criteria:[V.Custom "tests pass"] ~worker:"keeper-alpha" () with
+              ~criteria:[ "tests pass" ] ~worker:"keeper-alpha" () with
       | Ok req -> req
       | Error e -> Alcotest.fail (Printf.sprintf "create_request failed: %s" e)
     in
@@ -592,7 +559,7 @@ let test_requests_and_summary_remain_available_after_fd_observation () =
         ~base_path
         ~task_id:"task-fd-pressure"
         ~worker:"keeper-alpha"
-        ~criteria:[ V.Custom "verification remains visible under FD pressure" ]
+        ~criteria:[ "verification remains visible under FD pressure" ]
         ~evidence:[ "ref-fd" ]
     in
     FD.reset_for_tests ();
@@ -643,8 +610,6 @@ let () =
       Alcotest.test_case "uses explicit base_path, not env" `Quick
         test_requests_json_uses_explicit_base_path_not_env;
       Alcotest.test_case "task_id filter" `Quick test_task_id_filter;
-      Alcotest.test_case "ignores legacy root entries" `Quick
-        test_requests_json_ignores_legacy_root_entries;
       Alcotest.test_case "conflict triage fields" `Quick
         test_requests_json_surfaces_conflict_triage_fields;
       Alcotest.test_case "evidence projection errors" `Quick

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -23,9 +23,6 @@ let () = Mirage_crypto_rng_unix.use_default ()
 let active_verifications_dir base_path =
   Filename.concat (CU.masc_dir_from_base_path ~base_path) "verifications"
 
-let legacy_verifications_dir base_path =
-  Filename.concat base_path "verifications"
-
 (** Use a temporary directory for each test.
 
     Cleanup goes through [Masc_test_deps.cleanup_test_workspace], which stats
@@ -52,6 +49,12 @@ let with_eio_temp_dir_and_clock f =
   Fun.protect
     ~finally:Fs_compat.clear_fs
     (fun () -> with_temp_dir (f ~clock:(Eio.Stdenv.clock env)))
+
+let list_requests_exn base_path =
+  match V.list_requests base_path with
+  | Ok requests -> requests
+  | Error detail -> Alcotest.fail detail
+;;
 
 let ensure_keeper_meta config name =
   match
@@ -127,7 +130,7 @@ let test_rejected_verdict_event_preserves_wire_type () =
 (* --- Criterion tests --- *)
 
 let test_criterion_roundtrip () =
-  let criteria = [ V.Custom "output should be helpful"; V.Custom "" ] in
+  let criteria = [ "output should be helpful"; "artifact exists" ] in
   List.iter (fun c ->
     let json = V.criterion_to_yojson c in
     match V.criterion_of_yojson json with
@@ -139,17 +142,10 @@ let test_criterion_roundtrip () =
 
 let test_criterion_of_yojson_errors () =
   let bad_cases = [
-    (`String "not an object", "not object");
-    (`Assoc [], "missing type");
-    (`Assoc [("type", `String "banana")], "unknown type");
-    (* The three criteria that no producer ever built -- a substring check, its
-       negation and a schema match -- are gone. A persisted request naming one
-       is now rejected at the parse instead of loading and being refused by the
-       completion authority. *)
-    (`Assoc [("type", `String "contains"); ("value", `String "hello")], "contains");
-    (`Assoc [("type", `String "not_contains"); ("value", `String "err")], "not_contains");
-    (`Assoc [("type", `String "schema_match"); ("schema", `Assoc [])], "schema_match");
-    (`Assoc [("type", `String "custom")], "custom missing description");
+    (`String "", "blank");
+    (`String "  ", "whitespace");
+    (`Assoc [], "object");
+    (`Null, "null");
   ] in
   List.iter (fun (json, label) ->
     match V.criterion_of_yojson json with
@@ -162,7 +158,7 @@ let valid_request_json =
     [ "id", `String "vrf-1"
     ; "task_id", `String "task-1"
     ; "output", `Assoc [ "evidence_refs", `List [ `String "note:done" ] ]
-    ; "criteria", `List [ `Assoc [ "type", `String "custom"; "description", `String "done" ] ]
+    ; "criteria", `List [ `String "done" ]
     ; "worker", `String "worker-1"
     ; "created_at", `Float 1234.5
     ]
@@ -194,7 +190,7 @@ let test_request_of_yojson_is_strict () =
       [ "id", `String "vrf-1"
       ; "task_id", `String "task-1"
       ; "output", `Null
-      ; "criteria", `List [ `Assoc [ "type", `String "custom" ] ]
+      ; "criteria", `List [ `String "" ]
       ; "worker", `String "worker-1"
       ; "created_at", `Float 1234.5
       ]);
@@ -242,7 +238,7 @@ let test_system_llm_review_notes_are_metadata_only () =
     ; task_id = "task-metadata-only"
     ; output =
         `Assoc [ "secret_output", `String "must not be duplicated" ]
-    ; criteria = [ V.Custom "secret criterion should stay in the audit store" ]
+    ; criteria = [ "secret criterion should stay in the audit store" ]
     ; worker = "keeper-executor-agent"
     ; created_at = 1234.5
     }
@@ -739,7 +735,6 @@ let test_system_llm_agent_commits_without_a_keeper_verifier () =
           in
           let config = W.default_config base_path in
           ignore (W.init config ~agent_name:(Some "system-test-worker"));
-          ensure_keeper_meta config "system-test-worker";
           ignore
             (W.add_task
                config
@@ -803,28 +798,15 @@ let test_system_llm_agent_commits_without_a_keeper_verifier () =
           | tasks -> Alcotest.failf "expected one task, got %d" (List.length tasks)))
   )
 
-let test_system_llm_agent_rejects_invalid_contract_without_stalling () =
+let test_system_llm_agent_defers_invalid_contract_without_rejecting_task () =
   with_eio_temp_dir_and_clock (fun ~clock base_path ->
     Masc.Workspace_metric_hooks.install ();
-    let previous_notification =
-      Atomic.get Workspace_hooks.verification_notify_verdict_fn
-    in
     let previous_submitted = Atomic.get Workspace_hooks.verification_submitted_fn in
     Fun.protect
       ~finally:(fun () ->
-        Atomic.set Workspace_hooks.verification_notify_verdict_fn previous_notification;
         Atomic.set Workspace_hooks.verification_submitted_fn previous_submitted)
       (fun () ->
         Eio.Switch.run (fun sw ->
-          let verdict_committed, resolve_verdict_committed = Eio.Promise.create () in
-          Atomic.set Workspace_hooks.verification_notify_verdict_fn
-            (fun ~task_id ~authority ~verification_id ~decision ->
-               previous_notification
-                 ~task_id
-                 ~authority
-                 ~verification_id
-                 ~decision;
-               Eio.Promise.resolve resolve_verdict_committed ());
           let config = W.default_config base_path in
           ignore (W.init config ~agent_name:(Some "contract-retry-worker"));
           ignore
@@ -863,21 +845,51 @@ let test_system_llm_agent_rejects_invalid_contract_without_stalling () =
             ~task
             ~assignee:"contract-retry-worker"
             ~verification_id;
-          Eio.Time.with_timeout_exn clock 5.0 (fun () ->
-            Eio.Promise.await verdict_committed);
+          let outcome =
+            Eio.Time.with_timeout_exn clock 5.0 (fun () ->
+              let rec await () =
+                match
+                  Masc.Verification_run_registry.get
+                    (Masc.Verification_run_registry.global ())
+                    ~verification_id
+                with
+                | Some
+                    { status =
+                        Masc.Verification_run_registry.Completed { outcome; _ }
+                    ; _
+                    } -> outcome
+                | Some { status = Masc.Verification_run_registry.Running; _ }
+                | None ->
+                  Eio.Time.sleep clock 0.01;
+                  await ()
+              in
+              await ())
+          in
+          (match outcome with
+           | Masc.Verification_run_registry.Infrastructure_unavailable
+               { stage = Masc.Verification_run_registry.Review_preparation; _ } -> ()
+           | _ -> Alcotest.fail "missing request was not a preparation failure");
           match W.get_tasks_raw config with
-          | [ { task_status = Masc_domain.InProgress { assignee; started_at }; _ } ] ->
+          | [ { task_status =
+                  Masc_domain.AwaitingVerification
+                    { assignee; started_at; verification_id = observed_id; _ }
+              ; _
+              } ] ->
             Alcotest.(check string)
-              "rejection returns task to its producer"
+              "infrastructure failure keeps the submitted producer"
               "contract-retry-worker"
               assignee;
             Alcotest.(check string)
-              "rejection preserves original claim time"
+              "infrastructure failure preserves original claim time"
               original_started_at
-              started_at
+              started_at;
+            Alcotest.(check string)
+              "infrastructure failure keeps the verification obligation"
+              verification_id
+              observed_id
           | [ task ] ->
             Alcotest.failf
-              "invalid contract left task stranded: %s"
+              "infrastructure failure changed task authority: %s"
               (Masc_domain.task_status_to_string task.task_status)
           | tasks -> Alcotest.failf "expected one task, got %d" (List.length tasks)))
   )
@@ -1052,6 +1064,22 @@ let test_rejected_verdict_audit_preserves_reason () =
      with
      | Error error -> Alcotest.fail (Masc_domain.masc_error_to_string error)
      | Ok _ -> ());
+    (match W.get_tasks_raw config with
+     | [ { handoff_context = Some handoff; _ } ] ->
+       Alcotest.(check string)
+         "task keeps the exact rejection reason"
+         "required deployment evidence is missing"
+         handoff.summary;
+       Alcotest.(check (list string))
+         "task keeps the rejected verification identity"
+         [ "vrf-audit-rejected" ]
+         handoff.evidence_refs;
+       Alcotest.(check (option string))
+         "task keeps the rejecting authority"
+         (Some "system-audit-agent")
+         handoff.updated_by
+     | [ _ ] -> Alcotest.fail "rejected task lost its durable continuation"
+     | tasks -> Alcotest.failf "expected one task, got %d" (List.length tasks));
     let open Unix in
     let tm = gmtime (gettimeofday ()) in
     let month = Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) in
@@ -1226,7 +1254,7 @@ let test_raw_workspace_submission_notifies_once () =
 let test_create_and_load () =
   with_temp_dir (fun base_path ->
     match V.create_request ~base_path ~task_id:"task-1"
-        ~output:(`String "result") ~criteria:[V.Custom "result"]
+        ~output:(`String "result") ~criteria:[ "result" ]
         ~worker:"claude" () with
     | Error e -> Alcotest.fail e
     | Ok req ->
@@ -1241,13 +1269,31 @@ let test_create_and_load () =
             Alcotest.(check string) "task_id" "task-1" loaded.task_id;
             Alcotest.(check string) "worker" "claude" loaded.worker)
 
+let test_create_rejects_blank_criterion_before_write () =
+  with_temp_dir (fun base_path ->
+    match
+      V.create_request
+        ~base_path
+        ~task_id:"task-blank-criterion"
+        ~output:`Null
+        ~criteria:[ " " ]
+        ~worker:"worker"
+        ()
+    with
+    | Ok _ -> Alcotest.fail "blank completion criterion reached persistence"
+    | Error _ ->
+      Alcotest.(check int)
+        "no request was written"
+        0
+        (List.length (list_requests_exn base_path)))
+
 (* RFC-0221 §3.1: [delete_request] removes the record (compensation) and is
    idempotent — deleting a missing record is success, so a caller can compensate
    without first checking existence. *)
 let test_delete_request () =
   with_temp_dir (fun base_path ->
     match V.create_request ~base_path ~task_id:"task-1"
-        ~output:(`String "result") ~criteria:[V.Custom "result"]
+        ~output:(`String "result") ~criteria:[ "result" ]
         ~worker:"claude" () with
     | Error e -> Alcotest.fail e
     | Ok req ->
@@ -1272,7 +1318,7 @@ let test_list_requests () =
         ~output:`Null ~criteria:[] ~worker:"a" () in
     let _ = V.create_request ~base_path ~task_id:"t2"
         ~output:`Null ~criteria:[] ~worker:"b" () in
-    let reqs = V.list_requests base_path in
+    let reqs = list_requests_exn base_path in
     Alcotest.(check int) "two requests" 2 (List.length reqs))
 
 let test_list_requests_missing_dir_stays_quiet () =
@@ -1280,7 +1326,7 @@ let test_list_requests_missing_dir_stays_quiet () =
     let before =
       persistence_counter Safe_ops.persistence_read_drop_reason_list_dir_error
     in
-    let reqs = V.list_requests base_path in
+    let reqs = list_requests_exn base_path in
     Alcotest.(check int) "no requests" 0 (List.length reqs);
     Alcotest.(check (float 0.1)) "missing dir does not increment metric"
       before
@@ -1288,28 +1334,18 @@ let test_list_requests_missing_dir_stays_quiet () =
 
 let test_verifications_dir_resolves_active_store () =
   with_temp_dir (fun base_path ->
-    let legacy_dir = legacy_verifications_dir base_path in
-    Fs_compat.mkdir_p legacy_dir;
-    Fs_compat.save_file (Filename.concat legacy_dir "vrf-legacy.json")
-      {|{"id":"vrf-legacy","task_id":"task-legacy"}|};
     let active_dir = active_verifications_dir base_path in
     let resolved = VS.verifications_dir base_path in
-    Alcotest.(check string) "resolved active store" active_dir resolved;
-    Alcotest.(check bool) "resolved path is not legacy root" false
-      (String.equal legacy_dir resolved))
+    Alcotest.(check string) "resolved current store" active_dir resolved)
 
-let test_request_path_ignores_legacy_root_store () =
+let test_request_path_uses_current_store () =
   with_temp_dir (fun base_path ->
-    let req_id = "vrf-shadowed" in
-    let legacy_dir = legacy_verifications_dir base_path in
-    Fs_compat.mkdir_p legacy_dir;
-    Fs_compat.save_file (Filename.concat legacy_dir (req_id ^ ".json"))
-      {|{"id":"vrf-shadowed","task_id":"task-legacy"}|};
+    let req_id = "vrf-current" in
     Alcotest.(check string) "request path uses active store"
       (Filename.concat (active_verifications_dir base_path) (req_id ^ ".json"))
       (VS.request_path base_path req_id))
 
-let test_list_requests_skips_bad_entries_with_metric () =
+let test_list_requests_rejects_bad_entry_with_metric () =
   with_temp_dir (fun base_path ->
     let _ = V.create_request ~base_path ~task_id:"t1"
         ~output:`Null ~criteria:[] ~worker:"a" () in
@@ -1318,45 +1354,40 @@ let test_list_requests_skips_bad_entries_with_metric () =
     let before =
       persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
     in
-    let reqs = V.list_requests base_path in
-    Alcotest.(check int) "only valid request returned" 1 (List.length reqs);
+    (match V.list_requests base_path with
+     | Ok _ -> Alcotest.fail "malformed request yielded a partial list"
+     | Error detail ->
+       Alcotest.(check bool)
+         "malformed path is named"
+         true
+         (Astring.String.is_infix ~affix:"broken.json" detail));
     Alcotest.(check (float 0.1)) "broken file increments metric" 1.0
       (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
        -. before))
 
-let test_list_requests_ignores_legacy_only_stale_entries () =
+let test_list_requests_rereads_current_request_content () =
   with_temp_dir (fun base_path ->
-    let legacy_dir = legacy_verifications_dir base_path in
-    Fs_compat.mkdir_p legacy_dir;
-    Fs_compat.save_file (Filename.concat legacy_dir "broken.json") "{not-json";
-    Fs_compat.save_file (Filename.concat legacy_dir "vrf-foreign.json")
-      {|{"id":"vrf-foreign","task_id":"t-foreign","evaluator":"oracle","overall_verdict":"approve"}|};
-    let before =
-      persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+    let request =
+      match
+        V.create_request
+          ~base_path
+          ~task_id:"t1"
+          ~output:`Null
+          ~criteria:[]
+          ~worker:"a"
+          ()
+      with
+      | Ok request -> request
+      | Error detail -> Alcotest.fail detail
     in
-    let reqs = V.list_requests base_path in
-    Alcotest.(check int) "legacy-only store ignored" 0 (List.length reqs);
-    Alcotest.(check (float 0.1)) "legacy-only stale files stay silent"
-      before
-      (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error))
-
-let test_list_requests_ignores_legacy_root_entries () =
-  with_temp_dir (fun base_path ->
-    let _ = V.create_request ~base_path ~task_id:"t1"
-        ~output:`Null ~criteria:[] ~worker:"a" () in
-    let legacy_dir = legacy_verifications_dir base_path in
-    Fs_compat.mkdir_p legacy_dir;
-    Fs_compat.save_file (Filename.concat legacy_dir "broken.json") "{not-json";
-    Fs_compat.save_file (Filename.concat legacy_dir "vrf-foreign.json")
-      {|{"id":"vrf-foreign","task_id":"t-foreign","evaluator":"oracle","overall_verdict":"approve"}|};
-    let before =
-      persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
-    in
-    let reqs = V.list_requests base_path in
-    Alcotest.(check int) "legacy root ignored" 1 (List.length reqs);
-    Alcotest.(check (float 0.1)) "legacy root does not increment metric"
-      before
-      (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error))
+    Alcotest.(check int)
+      "initial request is readable"
+      1
+      (List.length (list_requests_exn base_path));
+    Fs_compat.save_file (VS.request_path base_path request.id) "{not-json";
+    match V.list_requests base_path with
+    | Ok _ -> Alcotest.fail "changed malformed request reused an earlier list"
+    | Error _ -> ())
 
 let create_evidence_request ~base_path ~request_id ~artifact_path =
   let profile_path =
@@ -1391,7 +1422,7 @@ let create_evidence_request ~base_path ~request_id ~artifact_path =
       ~output:
         (`Assoc
             [ "submitted_evidence", evidence_snapshot ])
-      ~criteria:[ V.Custom "inspect artifact" ]
+      ~criteria:[ "inspect artifact" ]
       ~worker:"keeper-executor-agent"
       ()
   with
@@ -1714,7 +1745,7 @@ let test_submit_snapshot_rejects_bare_and_absolute_references () =
            ~request_id
            ~task_id:"task-001"
            ~output:(`Assoc [ "submitted_evidence", snapshot ])
-           ~criteria:[ V.Custom "inspect explicit refs" ]
+           ~criteria:[ "inspect explicit refs" ]
            ~worker:"keeper-executor-agent"
            ()
        with
@@ -1765,12 +1796,7 @@ let test_submitted_evidence_inspection_rejects_cross_playground_path () =
       ()
     | _ -> Alcotest.fail "cross-playground artifact must remain unreadable")
 
-(* Records written before [content_sha256] was dropped still carry it: 58
-   evidence items in the live store are shaped this way. The artifact branch
-   must ignore the extra field rather than reject the record, and it must no
-   longer validate it — the hash below is deliberately wrong, so this decodes
-   only because the check is gone. *)
-let test_submitted_evidence_decodes_legacy_content_sha256 () =
+let test_submitted_evidence_rejects_unknown_artifact_field () =
   with_eio_temp_dir (fun base_path ->
     let profile_path =
       Keeper_sandbox_config.keeper_toml_path
@@ -1779,18 +1805,17 @@ let test_submitted_evidence_decodes_legacy_content_sha256 () =
     in
     Fs_compat.mkdir_p (Filename.dirname profile_path);
     Fs_compat.save_file profile_path "[keeper]\nsandbox_profile = \"docker\"\n";
-    let request_id = "vrf-legacy-content-sha256" in
-    let content = "legacy artifact body" in
-    let legacy_snapshot =
+    let request_id = "vrf-unknown-artifact-field" in
+    let content = "artifact body" in
+    let snapshot =
       `List
         [ `Assoc
             [ "kind", `String "artifact"
-            ; "reference", `String "artifact:artifacts/legacy.txt"
+            ; "reference", `String "artifact:artifacts/current.txt"
             ; "content", `String content
             ; "bytes", `Int (String.length content)
             ; "truncated", `Bool false
-            ; ( "content_sha256"
-              , `String (String.make 64 '0') )
+            ; "unexpected_field", `String "not part of the current contract"
             ]
         ; `Assoc [ "kind", `String "note"; "content", `String "executor summary" ]
         ]
@@ -1800,36 +1825,24 @@ let test_submitted_evidence_decodes_legacy_content_sha256 () =
          ~base_path
          ~request_id
          ~task_id:"task-001"
-         ~output:(`Assoc [ "submitted_evidence", legacy_snapshot ])
-         ~criteria:[ V.Custom "inspect artifact" ]
+         ~output:(`Assoc [ "submitted_evidence", snapshot ])
+         ~criteria:[ "inspect artifact" ]
          ~worker:"keeper-executor-agent"
          ()
      with
      | Ok _ -> ()
      | Error detail -> Alcotest.fail detail);
     match inspect_evidence ~base_path ~request_id () with
-    | VS.Evidence_available
-        { items =
-            VS.Evidence_artifact
-              { reference; content = decoded; truncated = false; _ }
-            :: VS.Evidence_note "executor summary"
-            :: []
-        ; _
-        } ->
-      Alcotest.(check string)
-        "legacy record keeps its artifact reference"
-        "artifact:artifacts/legacy.txt"
-        reference;
-      Alcotest.(check string)
-        "legacy record keeps its persisted content"
-        content
-        decoded
+    | VS.Evidence_unavailable { reason = VS.Evidence_snapshot_invalid detail; _ } ->
+      Alcotest.(check bool)
+        "unknown artifact field is named"
+        true
+        (Astring.String.is_infix ~affix:"unexpected_field" detail)
     | VS.Evidence_unavailable { reason; _ } ->
       Alcotest.failf
-        "legacy record was rejected: %s"
+        "wrong rejection: %s"
         (VS.evidence_access_failure_to_string ~request_id reason)
-    | VS.Evidence_available _ ->
-      Alcotest.fail "expected the legacy record to decode as artifact + note")
+    | VS.Evidence_available _ -> Alcotest.fail "unknown artifact field accepted")
 
 let test_submitted_evidence_inspection_is_bounded_and_utf8_safe () =
   with_eio_temp_dir (fun base_path ->
@@ -1984,7 +1997,7 @@ let test_submitted_evidence_requires_exact_task_assignment_identity () =
                       ~worker:"keeper-executor-agent"
                       [ "artifact:assignment.txt" ] )
                 ])
-          ~criteria:[ V.Custom "inspect artifact" ]
+          ~criteria:[ "inspect artifact" ]
           ~worker:"keeper-executor-agent"
           ()
       with
@@ -2215,8 +2228,8 @@ let () =
         test_system_llm_rejection_does_not_derive_unregistered_keeper;
       Alcotest.test_case "system LLM commits without Keeper verifier" `Quick
         test_system_llm_agent_commits_without_a_keeper_verifier;
-      Alcotest.test_case "system LLM invalid contract returns to producer" `Quick
-        test_system_llm_agent_rejects_invalid_contract_without_stalling;
+      Alcotest.test_case "system LLM invalid contract remains pending" `Quick
+        test_system_llm_agent_defers_invalid_contract_without_rejecting_task;
       Alcotest.test_case "system LLM uses persisted request contract" `Quick
         test_system_llm_agent_uses_persisted_request_contract_snapshot;
       Alcotest.test_case "rejected verdict audit keeps reason" `Quick
@@ -2240,20 +2253,20 @@ let () =
     ];
     "storage", [
       Alcotest.test_case "create and load" `Quick test_create_and_load;
+      Alcotest.test_case "create rejects blank criterion" `Quick
+        test_create_rejects_blank_criterion_before_write;
       Alcotest.test_case "delete request (idempotent)" `Quick test_delete_request;
       Alcotest.test_case "list requests" `Quick test_list_requests;
       Alcotest.test_case "list requests missing dir stays quiet" `Quick
         test_list_requests_missing_dir_stays_quiet;
       Alcotest.test_case "verifications dir resolves active store" `Quick
         test_verifications_dir_resolves_active_store;
-      Alcotest.test_case "request path ignores legacy root store" `Quick
-        test_request_path_ignores_legacy_root_store;
-      Alcotest.test_case "list requests skips bad entries with metric" `Quick
-        test_list_requests_skips_bad_entries_with_metric;
-      Alcotest.test_case "list requests ignores legacy-only stale entries" `Quick
-        test_list_requests_ignores_legacy_only_stale_entries;
-      Alcotest.test_case "list requests ignores legacy root entries" `Quick
-        test_list_requests_ignores_legacy_root_entries;
+      Alcotest.test_case "request path uses current store" `Quick
+        test_request_path_uses_current_store;
+      Alcotest.test_case "list requests rejects bad entry with metric" `Quick
+        test_list_requests_rejects_bad_entry_with_metric;
+      Alcotest.test_case "list requests rereads current content" `Quick
+        test_list_requests_rereads_current_request_content;
       Alcotest.test_case "submitted evidence authority-scoped and contained" `Quick
         test_submitted_evidence_inspection_is_authority_scoped_and_contained;
       Alcotest.test_case "submit snapshot resolves Docker relative refs" `Quick
@@ -2268,8 +2281,8 @@ let () =
         test_submitted_evidence_inspection_rejects_cross_playground_path;
       Alcotest.test_case "submitted evidence bounded UTF-8" `Quick
         test_submitted_evidence_inspection_is_bounded_and_utf8_safe;
-      Alcotest.test_case "submitted evidence decodes legacy content_sha256" `Quick
-        test_submitted_evidence_decodes_legacy_content_sha256;
+      Alcotest.test_case "submitted evidence rejects unknown artifact field" `Quick
+        test_submitted_evidence_rejects_unknown_artifact_field;
       Alcotest.test_case "submitted evidence rejects malformed UTF-8" `Quick
         test_submitted_evidence_rejects_malformed_utf8;
       Alcotest.test_case "submitted evidence rejects symlink and FIFO" `Quick

--- a/test/test_verification_authority_tools.ml
+++ b/test/test_verification_authority_tools.ml
@@ -30,10 +30,7 @@ let rec rm_rf path =
 
 (* [agent_name] is deliberately omitted: [meta_of_json_fixture] fills in the
    canonical [Keeper_identity.keeper_agent_name], so this fixture cannot drift
-   from the identity rule the meta parser enforces.
-
-   [always_allow] is the producer's Gate posture. These cases exercise the
-   immediate execution branch. *)
+   from the identity rule the meta parser enforces. *)
 let ensure_producer config name =
   match
     Result.bind
@@ -56,15 +53,6 @@ let with_surface f =
   Eio.Switch.on_release sw (fun () -> rm_rf dir);
   let config = Workspace_core.default_config dir in
   ignore (Workspace_core.init config ~agent_name:(Some "test"));
-  (* [tool_execute] submits through the external-effect Gate, which refuses to
-     run at all until its durable store exists. Without this the execute cases
-     would fail on missing infrastructure and prove nothing about the surface. *)
-  (match Masc.Keeper_approval_queue.install_persistence ~base_path:dir with
-   | Ok _ -> ()
-   | Error err ->
-     Alcotest.failf
-       "gate store install failed: %s"
-       (Masc.Keeper_approval_queue.install_error_to_string err));
   ensure_producer config producer;
   match VAT.create ~config ~producer with
   | Error reason -> Alcotest.failf "surface creation failed: %s" reason
@@ -72,12 +60,12 @@ let with_surface f =
 ;;
 
 (* Create the producer playground used to resolve relative tool paths. *)
-let producer_playground (config : Workspace_core.config) =
+let producer_playground (config : Workspace_core.config) producer_name =
   let path =
     Keeper_sandbox_config.host_root_abs_of_agent
       ~base_path:
         (Workspace_verification_store.project_root_of_base_path config.base_path)
-      ~agent_name:producer
+      ~agent_name:producer_name
   in
   let rec mkdir_p dir =
     if not (Sys.file_exists dir)
@@ -97,8 +85,8 @@ let test_schemas_are_the_descriptor_schemas () =
       List.map (fun (schema : Masc_domain.tool_schema) -> schema.name) offered
     in
     Alcotest.(check (list string))
-      "the surface is read, search, execute"
-      [ "tool_read_file"; "tool_search_files"; "tool_execute" ]
+      "the surface is read-only"
+      [ "tool_read_file"; "tool_search_files" ]
       names;
     List.iter
       (fun (schema : Masc_domain.tool_schema) ->
@@ -124,7 +112,7 @@ let test_schemas_are_the_descriptor_schemas () =
    a missing required argument must be rejected at the same boundary. *)
 let test_read_translates_the_advertised_argument_and_refuses_a_malformed_one () =
   with_surface (fun config surface ->
-    let playground = producer_playground config in
+    let playground = producer_playground config producer in
     let name = "advertised-argument-probe.txt" in
     let contents = "written by the probe" in
     (try
@@ -176,7 +164,7 @@ let test_read_translates_the_advertised_argument_and_refuses_a_malformed_one () 
 (* A search requires an explicit non-empty pattern. *)
 let test_search_refuses_a_call_without_its_required_pattern () =
   with_surface (fun config surface ->
-    ignore (producer_playground config);
+    ignore (producer_playground config producer);
     (match
        VAT.dispatch surface ~name:"tool_search_files" ~args:(`Assoc [])
      with
@@ -200,26 +188,6 @@ let test_search_refuses_a_call_without_its_required_pattern () =
       Alcotest.failf "a search carrying its pattern was refused: %s" detail)
 ;;
 
-(* [argv] is a process vector, never a shell-line string. *)
-let test_execute_refuses_argv_that_is_not_a_process_vector () =
-  with_surface (fun _config surface ->
-    match
-      VAT.dispatch
-        surface
-        ~name:"tool_execute"
-        ~args:(`Assoc [ "argv", `String "echo durable-marker" ])
-    with
-    | Ok output ->
-      Alcotest.failf
-        "argv as a bare string resolved instead of being refused: %s"
-        output
-    | Error detail ->
-      Alcotest.(check bool)
-        "the refusal names argv"
-        true
-        (Astring.String.is_infix ~affix:"argv" detail))
-;;
-
 (* A judge that calls a name this surface does not offer must be told so. A
    dropped call would read to the model as a tool that returned nothing. *)
 let test_unknown_tool_name_is_an_error () =
@@ -230,90 +198,13 @@ let test_unknown_tool_name_is_an_error () =
       Alcotest.(check bool)
         "names the offered tools"
         true
-        (Astring.String.is_infix ~affix:"tool_execute" detail))
+        (Astring.String.is_infix ~affix:"tool_search_files" detail))
 ;;
 
-(* Where the judge's process would run is the safety property this layer owns.
-   The keeper runtime resolves it and reports the resolution back, so the
-   assertion is on that resolution rather than on process output: whether the
-   effect then executes or defers is the Gate's decision, and standing the Gate
-   and its Auto Judge up belongs to an integration test, not here.
-
-   The judge borrows the producer's meta, so it borrows the producer's jail. A
-   [cwd] of "." must land in the producer's playground — not the host, not
-   another keeper's tree, and not the workspace root. *)
-let test_execute_resolves_inside_the_producer_playground () =
-  with_surface (fun _config surface ->
-    let root = VAT.ownership_root surface in
-    let report =
-      match
-        VAT.dispatch
-          surface
-          ~name:"tool_execute"
-          ~args:
-            (`Assoc
-               [ "argv", `List [ `String "echo"; `String "durable-marker" ]
-               ; "cwd", `String "."
-               ])
-      with
-      | Ok output | Error output -> output
-    in
-    Alcotest.(check bool)
-      "the resolved working directory is the producer playground"
-      true
-      (Astring.String.is_infix ~affix:root report);
-    Alcotest.(check bool)
-      "the resolution names the playground scope"
-      true
-      (Astring.String.is_infix ~affix:"playground_root" report))
-;;
-
-(* An escape must not resolve. A judge that can point [cwd] outside the
-   producer's jail reaches trees no one authorized it to touch, and with write
-   capability that is not a read of the wrong file but a change to it. *)
-let test_execute_cannot_escape_the_producer_playground () =
-  with_surface (fun _config surface ->
-    match
-      VAT.dispatch
-        surface
-        ~name:"tool_execute"
-        ~args:
-          (`Assoc
-             [ "argv", `List [ `String "echo"; `String "escaped" ]
-             ; "cwd", `String "../../.."
-             ])
-    with
-    | Ok output ->
-      Alcotest.failf "an escaping cwd must not resolve; got %s" output
-    | Error detail ->
-      Alcotest.(check bool)
-        "the rejection does not report a resolved playground scope"
-        false
-        (Astring.String.is_infix ~affix:"\"scope\":\"playground_root\"" detail))
-;;
-
-(* A failed process is a failed lookup result. *)
-let test_a_failed_run_is_an_error_not_empty_output () =
-  with_surface (fun _config surface ->
-    match
-      VAT.dispatch
-        surface
-        ~name:"tool_execute"
-        ~args:
-          (`Assoc
-             [ "argv", `List [ `String "false" ]
-             ; "cwd", `String "."
-             ])
-    with
-    | Ok output ->
-      Alcotest.failf "a non-zero exit must not resolve as success; got %s" output
-    | Error _ -> ())
-;;
-
-(* A producer with no keeper meta has no tree to point at. Handing back a
-   surface anyway would advertise three tools whose every call fails, which
-   reads to the model as a broken tree rather than as an absent one. *)
-let test_unknown_producer_yields_no_surface () =
+(* Workspace agents are valid verification producers even though they have no
+   Keeper runtime metadata. Their surface is rooted directly at the producer
+   playground and exposes only the owned regular-file reader. *)
+let test_workspace_producer_gets_owned_read_surface () =
   Eio_main.run
   @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -323,13 +214,44 @@ let test_unknown_producer_yields_no_surface () =
   Eio.Switch.on_release sw (fun () -> rm_rf dir);
   let config = Workspace_core.default_config dir in
   ignore (Workspace_core.init config ~agent_name:(Some "test"));
-  match VAT.create ~config ~producer:"no-such-producer" with
-  | Ok _ -> Alcotest.fail "a producer with no meta must not yield a surface"
-  | Error reason ->
-    Alcotest.(check bool)
-      "the reason names the producer"
-      true
-      (Astring.String.is_infix ~affix:"no-such-producer" reason)
+  let producer_name = "workspace-producer" in
+  let playground = producer_playground config producer_name in
+  let path = Filename.concat playground "evidence.txt" in
+  Out_channel.with_open_text path (fun channel ->
+    output_string channel "first line\nsecond line\n");
+  match VAT.create ~config ~producer:producer_name with
+  | Error reason -> Alcotest.failf "workspace surface creation failed: %s" reason
+  | Ok surface ->
+    Alcotest.(check (list string))
+      "workspace producer surface"
+      [ "tool_read_file" ]
+      (VAT.schemas surface
+       |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name));
+    (match
+       VAT.dispatch
+         surface
+         ~name:"tool_read_file"
+         ~args:
+           (`Assoc
+               [ "file_path", `String "evidence.txt"
+               ; "offset", `Int 2
+               ; "limit", `Int 1
+               ])
+     with
+     | Error detail -> Alcotest.failf "owned read failed: %s" detail
+     | Ok payload ->
+       let json = Yojson.Safe.from_string payload in
+       Alcotest.(check string)
+         "reads the requested line"
+         "second line\n"
+         Yojson.Safe.Util.(json |> member "content" |> to_string));
+    (match VAT.dispatch surface ~name:"tool_search_files" ~args:(`Assoc []) with
+     | Ok output -> Alcotest.failf "workspace search unexpectedly ran: %s" output
+     | Error detail ->
+       Alcotest.(check bool)
+         "error lists only the exact offered surface"
+         false
+         (Astring.String.is_infix ~affix:"this review offers tool_search_files" detail))
 ;;
 
 (* The prompt states the exact tools attached to the review request. *)
@@ -362,21 +284,17 @@ let test_prompt_states_the_available_surface () =
     Alcotest.(check bool)
       "toolless prompt does not advertise a tool"
       false
-      (Astring.String.is_infix ~affix:"tool_execute" without);
+      (Astring.String.is_infix ~affix:"tool_search_files" without);
     Alcotest.(check bool)
       "tool prompt names the tools"
       true
-      (Astring.String.is_infix ~affix:"tool_execute" with_tools);
+      (Astring.String.is_infix ~affix:"tool_search_files" with_tools);
     Alcotest.(check bool)
       "tool prompt does not deny having tools"
       false
       (Astring.String.is_infix
          ~affix:"You have no tool that opens anything else"
          with_tools);
-    Alcotest.(check bool)
-      "tool prompt does not promise the surface cannot change anything"
-      false
-      (Astring.String.is_infix ~affix:"cannot change anything" with_tools);
     Alcotest.(check bool)
       "tool prompt forbids repairing the work under review"
       true
@@ -396,22 +314,12 @@ let () =
             test_read_translates_the_advertised_argument_and_refuses_a_malformed_one
         ; Alcotest.test_case "search refuses a call without its required pattern"
             `Quick test_search_refuses_a_call_without_its_required_pattern
-        ; Alcotest.test_case "execute refuses argv that is not a process vector"
-            `Quick test_execute_refuses_argv_that_is_not_a_process_vector
-        ; Alcotest.test_case "unknown producer yields no surface" `Quick
-            test_unknown_producer_yields_no_surface
+        ; Alcotest.test_case "workspace producer gets owned read surface" `Quick
+            test_workspace_producer_gets_owned_read_surface
         ] )
     ; ( "dispatch"
       , [ Alcotest.test_case "unknown tool name is an error" `Quick
             test_unknown_tool_name_is_an_error
-        ] )
-    ; ( "execution"
-      , [ Alcotest.test_case "execute resolves inside the producer playground" `Quick
-            test_execute_resolves_inside_the_producer_playground
-        ; Alcotest.test_case "execute cannot escape the producer playground" `Quick
-            test_execute_cannot_escape_the_producer_playground
-        ; Alcotest.test_case "a failed run is an error, not empty output" `Quick
-            test_a_failed_run_is_an_error_not_empty_output
         ] )
     ; ( "prompt"
       , [ Alcotest.test_case "prompt states the available surface" `Quick

--- a/test/test_verification_run_registry.ml
+++ b/test/test_verification_run_registry.ml
@@ -1,11 +1,8 @@
-(* RFC-0361 D4 — completion-authority review observation record.
+(* Completion-authority review observation record.
 
-   The registry exists because a review that deferred, raised, or rejected on
-   the evidence contract previously left no durable trace: only the paths that
-   committed a verdict emitted a [task_completion_verdict] event. These cases
-   pin that every outcome constructor survives a write/replay round trip with
-   its detail intact, and that an outcome label this module did not write is an
-   [Error] rather than a permissive default.
+   These cases pin that every outcome constructor survives a write/replay
+   round trip with its detail intact, and that an outcome label this module did
+   not write is an [Error] rather than a permissive default.
 
    Isolated: each case gets its own temp path and the process-wide
    {!Verification_run_registry.global} is never touched. *)
@@ -75,7 +72,9 @@ let register t ~verification_id ~started_at =
 let all_outcomes : (string * E.outcome) list =
   [ "approved", E.Approved
   ; "rejected", E.Rejected { reason = "aria attributes are not committed" }
-  ; "contract_rejected", E.Contract_rejected { detail = "missing required artifact" }
+  ; ( "infrastructure_unavailable"
+    , E.Infrastructure_unavailable
+        { stage = E.Review_preparation; detail = "request store unavailable" } )
   ; "not_reviewed", E.Not_reviewed { gate = "evaluator_unavailable"; detail = "no runtime" }
   ; "commit_failed", E.Commit_failed { detail = "verification id mismatch" }
   ; "raised", E.Raised { detail = "Failure(\"boom\")" }


### PR DESCRIPTION
## Summary

- hard-cut Verification criteria to exact non-empty strings and reject unknown persisted fields
- restrict completion-authority lookup to ownership-bound read-only tools; Workspace producers receive only Read and Keeper producers receive Read plus Search
- persist rejected-verdict handoff context in the same backlog commit as the verdict transition
- distinguish infrastructure unavailability from semantic rejection in the durable run registry and Dashboard
- bound concurrent completion reviews to four fibers
- drop every Librarian research, Memory OS, Board provider-detail, obsolete-doc, and compatibility hunk from the superseded mixed commit

## Verification

- focused OCaml suites: Verification 45/45, verification authority tools 6/6, verification run registry 12/12, dashboard verification 11/11
- changed dashboard_http_core proof-route case PASS; unrelated pre-existing cases remain outside this diff
- Dashboard typecheck PASS
- Dashboard verification-runs Vitest 12/12 PASS
- ocamlformat check PASS
- dead-surface ratchet PASS at 549
- Board exact-flow boundary PASS
- diff check PASS

Live runtime state and credentials were not mutated by this PR.