### PR TITLE
perf(ci): batch focused Dune suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
-    # ready_for_review must re-evaluate Draft-only dependency allowances on the
-    # exact same head; otherwise an ephemeral review ref could retain a green
-    # CI Gate after the PR becomes mergeable.
-    types: [opened, synchronize, reopened, ready_for_review]
+    # Readiness changes no code and no longer changes any CI allowance. The
+    # exact-head CI Gate from opened/synchronize/reopened therefore remains the
+    # merge authority without starting the same heavy graph a second time.
+    types: [opened, synchronize, reopened]
   workflow_dispatch: {}
 
 permissions:
@@ -26,9 +26,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event_name }}-${{
       github.event.pull_request.number || github.ref_name || github.run_id
     }}
-  # Pushes supersede older CI for the same branch. Code-changing and
-  # ready-for-review PR events likewise replace an outdated run for that PR.
-  cancel-in-progress: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action)) }}
+  # Pushes supersede older CI for the same branch. Code-changing PR events
+  # likewise replace an outdated run for that PR.
+  cancel-in-progress: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action)) }}
 
 jobs:
   pr-sync-check:
@@ -698,11 +698,15 @@ jobs:
           set -euo pipefail
           echo "Disk before cleanup:"
           df -h /
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /opt/ghc /usr/local/.ghcup || true
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
-          sudo docker image prune --all --force || true
+          cleanup_pids=()
+          sudo rm -rf /usr/local/lib/android & cleanup_pids+=("$!")
+          sudo rm -rf /usr/share/dotnet & cleanup_pids+=("$!")
+          sudo rm -rf /opt/ghc /usr/local/.ghcup & cleanup_pids+=("$!")
+          sudo rm -rf /opt/hostedtoolcache/CodeQL & cleanup_pids+=("$!")
+          sudo docker image prune --all --force & cleanup_pids+=("$!")
+          for cleanup_pid in "${cleanup_pids[@]}"; do
+            wait "${cleanup_pid}" || true
+          done
           echo "Disk after cleanup:"
           df -h /
 
@@ -747,11 +751,11 @@ jobs:
       - name: Build
         id: build_step
         env:
-          # Two workers use the hosted runner's available parallelism while
-          # bounding concurrent native links. Run 31319982424 had 110 GB free
-          # after cleanup, so the former fully-serial setting no longer bought
-          # disk safety and made the cold compile the 24-minute critical path.
-          DUNE_JOBS: "2"
+          # Public ubuntu-latest runners provide four CPUs and 16 GB RAM. Use
+          # all four for the compile-only graph; focused behavior suites below
+          # remain serial because some own fixed ports and shared fixtures.
+          # Disk pressure is handled by the cleanup step before checkout.
+          DUNE_JOBS: "4"
         # NO continue-on-error: dune build is deterministic and must hard-fail.
         # Focused test execution steps below are also required: any failing
         # suite fails the Build and Test job and blocks merge via the CI Gate.
@@ -1123,51 +1127,6 @@ jobs:
           opam exec -- dune build --root . \
             @test/runtest-test_enum_mirror_sync
 
-      - name: Run paused-work transfer and source-ACK suites
-        id: paused_work_transfer_and_operator_suites
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ALCOTEST_QUICK_TESTS: "1"
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_turn_outcome @test/runtest-test_keeper_paused_work_transfer_transaction @test/runtest-test_keeper_paused_work_source_terminal_transaction @test/runtest-test_keeper_paused_work_operator"
-
-      - name: Run keeper autonomous chat-activity suite
-        id: keeper_autonomous_chat_activity_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_autonomous_turn_source"
-
-      - name: Run keeper autoboot ownership suite
-        id: keeper_autoboot_ownership_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_autoboot_single_owner"
-
-      - name: Run keeper meta current-schema conformance suite
-        # This suite would have caught masc#27393 (fleet-wide autoboot 0/7:
-        # the persona hard-cut's schema change made every real, durable
-        # keeper meta JSON unloadable) before it reached production -- it
-        # was compiling under @check but never executing in CI.
-        id: keeper_meta_current_schema_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_meta_current_schema"
-
       # NOTE: the "Shell IR differential-safety harness gate" step was removed
       # here. #24332 (nonhierarchical Gate refactor) retired the entire
       # shell_ir risk/typed subsystem (Shell_ir_risk, Shell_ir_typed,
@@ -1187,463 +1146,16 @@ jobs:
           chmod +x dashboard/scripts/gen-sse-types.sh
           opam exec -- dashboard/scripts/gen-sse-types.sh --check
 
-      # The former catch-all `dune test` gate mixed executable behavior tests
-      # with source-text, log-wording, and TLA text-parity assertions. Those
-      # implementation-shape checks made main permanently red after legitimate
-      # refactors without identifying a runtime regression. `@check` above
-      # still compiles every test target; the authoritative runtime, operator,
-      # transport, SSE, and contract suites below remain executable gates.
-
-      - name: Run dashboard behavior contracts
-        id: dashboard_behavior_contracts
+      # Compile-only @check above and this focused runner form one authority:
+      # every listed behavior suite executes exactly once. The runner batches
+      # aliases by environment contract so Dune loads the already-built graph
+      # five times instead of once per suite.
+      - name: Run focused OCaml behavior suites
+        id: focused_ocaml_behavior_suites
         if: ${{ always() && steps.build_step.outcome == 'success' }}
         env:
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-dashboard-http-behavior-contracts"
-
-      - name: Run agent core behavior suite
-        id: agent_core_behavior_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' && needs.changes.outputs.agent_core == 'true' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          agent_core_targets="@test/runtest-test_keeper_hooks_oas_introspection @test/runtest-test_keeper_execution_join @test/runtest-test_hitl_summary_worker"
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @packages/agent_core/test/runtest ${agent_core_targets}"
-
-      - name: Run model inference metrics suite
-        id: model_inference_metrics_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_model_inference_metrics"
-
-      - name: Run channel-gate content-length knob suite
-        id: channel_gate_content_length_knob_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_channel_gate_content_length_knob"
-
-      - name: Run keeper decision-audit dated-store suite
-        id: decision_audit_dated_store_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_decision_audit_dated_store"
-
-      # Redaction is the last thing every observability payload passes through,
-      # so a defect here is not scoped to one field: a preview truncated inside
-      # a multibyte character makes the whole JSON response undecodable and the
-      # panel that reads it renders nothing. test_observability_redact carried a
-      # max-length case from the start and compiled on every run, but was never
-      # named here, so it never executed and the byte-indexed cut survived.
-      - name: Run observability redaction suite
-        id: observability_redaction_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_observability_redact"
-
-      # Approval persistence, typed terminal decisions, Keeper prompt
-      # projection, and audit vocabulary form one current Gate contract.
-      - name: Run approval Gate contract suites
-        id: approval_audit_vocabulary_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_approval_queue @test/runtest-test_keeper_hitl_resolution_prompt @test/runtest-test_keeper_approval_audit_timeline"
-
-      - name: Run verification behavior suite
-        id: verification_behavior_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_verification"
-
-      # Declared JSON-Schema bounds (minimum/maximum/exclusiveMinimum/
-      # exclusiveMaximum/minLength/maxLength/minItems/maxItems) are dropped
-      # by Tool_bridge.params_of_json_schema, so for a long time nothing
-      # read them: keeper_artifact_read answered max_bytes=565244 with a
-      # message naming sha256 (2026-08-05 20:06:36, keeper kidsnote). These
-      # suites assert the bounds are enforced pre-dispatch, that every
-      # declaration masc holds is reachable and readable by that
-      # enforcement, and that artifact-read rejections name the field that
-      # actually failed without changing which requests are served.
-      #
-      # test_tool_input_validation is the presence half of the same boundary:
-      # a missing required field is rejected, a tool with no registered schema
-      # is refused rather than dispatched, and declared types are coerced or
-      # rejected. It was declared in test/dune and named by no CI step, so
-      # those 86 assertions compiled and never ran.
-      - name: Run tool input constraint enforcement suite
-        id: tool_input_constraint_enforcement_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          constraint_targets="@test/runtest-test_tool_schema_constraint_enforcement @test/runtest-test_keeper_artifact_read_request @test/runtest-test_tool_input_validation @test/runtest-test_tool_schema_oas_boundary"
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${constraint_targets}"
-
-      # The tool-call quality benchmark scores keeper runs against selectors
-      # declared in benchmarks/data/tool_call_quality_cases.json. Those
-      # selectors name descriptors in the live keeper registry, so deleting or
-      # re-tagging a descriptor turns a stale case definition into a keeper
-      # quality score instead of an error (#26811). The suite existed in
-      # test/dune but was never listed here, so nothing it asserts has been
-      # running; the registry coherence gate it now carries only counts once
-      # this step does.
-      - name: Run tool-call quality benchmark suite
-        id: tool_call_quality_benchmark_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_tool_call_quality_benchmark"
-
-      # MCP identity is session-bound behavior: compile-only coverage cannot
-      # prove that the complete handshake -> start -> status -> transition
-      # path preserves one identity through the durable Task lifecycle. The
-      # Keeper prompt target separately proves caller-owned config projection.
-      - name: Run MCP session Task lifecycle and Keeper prompt config suites
-        id: mcp_session_task_lifecycle_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          identity_targets="@test/runtest-test_client_identity @test/runtest-test_mcp_session_task_lifecycle @test/runtest-test_keeper_sandbox_docker_cwd_response"
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${identity_targets}"
-
-      # Goal store durability: the suite drives a real workspace and asserts
-      # on-disk bytes, not source text — the read path stays lenient while a
-      # write over an undecodable store must be refused and must leave both
-      # goals.json and its .last-good mirror untouched. Compile-only under
-      # @check leaves that refusal ungated.
-      - name: Run goal store durability suite
-        id: goal_store_durability_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_goal_store"
-
-      # Goal phase projection: active_goal_ids records assignment and is never
-      # cleared when a goal reaches a terminal phase, so both prompt surfaces
-      # have to consult the store's phase. The suite seeds one goal per phase in
-      # a real workspace and asserts the rendered sets, which compile-only under
-      # @check does not exercise.
-      - name: Run keeper goal phase projection suite
-        id: keeper_goal_phase_projection_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_goal_phase_projection"
-
-      # Keeper tool descriptor registry: the suite pins each cluster tool's
-      # keeper_model_projection and asserts that Operator_only tools are absent
-      # from the autonomous Keeper bundle. Compile-only under @check leaves both
-      # ungated, so a projection change reaches Keepers without a failing check.
-      - name: Run keeper tool descriptor registry integrity suite
-        id: keeper_tool_descriptor_registry_integrity_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_tool_descriptor_registry_integrity"
-
-      # Schedule occurrence reclaim: an occurrence the consumer durably accepted
-      # is [Execution_dispatched] until a correlated completion path settles it,
-      # so nothing in the scheduler finishes it on its own. The suite drives a
-      # real workspace to that state and asserts the reclaim sweep settles it
-      # only on positive consumer evidence — a held occurrence and an unreadable
-      # consumer must both leave it untouched. Compile-only under @check leaves
-      # every one of those branches ungated, and no schedule suite ran here
-      # before (issue #26685).
-      - name: Run schedule runner suite
-        id: schedule_runner_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_schedule_runner @test/runtest-test_schedule_store @test/runtest-test_schedule_consumer_dispatch"
-
-      # Keeper registry hardening: identity resolution and goal-reconciliation
-      # routing are executable behavior — the suite drives a real workspace and
-      # asserts which Keeper a durable stimulus is addressed to, never source
-      # text. It is the only suite covering
-      # [Keeper_goal_reconciliation_wake], so that routing stays ungated under
-      # @check.
-      - name: Run keeper registry hardening suite
-        id: keeper_registry_hardening_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_registry_hardening"
-
-      # Keeper unified prompt surface: asserts what a Keeper is actually handed
-      # on a turn. The schedule wake row carries two ids with different
-      # meanings — occurrence_id is a one-way SHA-256 that no tool accepts, and
-      # schedule_id is the durable pointer resolved with masc_schedule_get — so
-      # a projection that drops the pointer is a silent capability loss with no
-      # compile-time signal. @check cannot see it: the wake type still compiles
-      # either way.
-      # Named for what it runs: the targets below are the unified verification
-      # surface and schedule tool wiring, not a prompt suite. The previous name
-      # ("keeper unified prompt surface suite") read as prompt coverage in the
-      # job log while no prompt assertion executed anywhere in CI.
-      - name: Run keeper unified verification surface and schedule wiring suites
-        id: keeper_unified_verification_surface_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_unified_verification_surface @test/runtest-test_schedule_tool_wiring"
-
-      # Every Keeper turn uses the assembled prompt. Pin its exact bytes,
-      # current content contract, and tool-schema projection.
-      - name: Run keeper prompt assembly suites
-        id: keeper_prompt_assembly_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          prompt_targets="@test/runtest-test_keeper_system_prompt_bytes @test/runtest-test_keeper_tool_schema_bytes @test/runtest-test_keeper_prompt_metrics @test/runtest-test_keeper_surface_presence_prompt"
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${prompt_targets}"
-
-      - name: Run board attention suite
-        id: board_attention_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          board_attention_targets="@test/runtest-test_keeper_board_attention_worker @test/runtest-test_keeper_board_attention_partition @test/runtest-test_keeper_board_attention_candidate @test/runtest-test_keeper_lifecycle_global_gate"
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${board_attention_targets}"
-
-      - name: Run tool blob retention suite
-        id: tool_blob_retention_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          tool_blob_targets="@test/runtest-test_tool_blob_store @test/runtest-test_keeper_tool_call_log @test/runtest-test_keeper_wire_capture"
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${tool_blob_targets}"
-
-      - name: Run runtime provider agent suite
-        id: runtime_provider_agent_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          official_client_targets="@test/runtest-test_runtime_provider_auth_headers @test/runtest-test_keeper_official_client_host @test/runtest-test_runtime_codex_app_server @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_runtime_claude_code @test/runtest-test_runtime_claude_code_config @test/runtest-test_keeper_claude_code_runtime"
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${official_client_targets}"
-
-      - name: Run host FD pressure contract suite
-        id: host_fd_pressure_contract_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          bash test/test_monitor_system_health_paths.sh
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_host_fd_pressure_poller"
-
-      - name: Run Keeper request-cap suite
-        id: keeper_request_cap_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          request_cap_targets="@test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_turn_driver_accept @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute @test/runtest-test_runtime_model_input_tail_window @test/runtest-test_keeper_context_overflow_shrink @test/runtest-test_keeper_provider_call_deadline @test/runtest-test_keeper_runtime_resolved_observability @test/runtest-test_runtime_toml_overrides"
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${request_cap_targets}"
-
-      - name: Run operator control suite
-        id: operator_control_suite
-        # Run regardless of earlier test failures, but only after a successful
-        # compile, so every suite gets a chance to report and the job fails if
-        # any suite fails.
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          ALCOTEST_QUICK_TESTS: "1"
-          CI_TEST_HEARTBEAT_SEC: 15
-          MASC_LOCAL_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
-          MASC_E2E_TESTS: "true"
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          operator_targets="@test/runtest-test_operator_control_snapshot_state @test/runtest-test_operator_control_snapshot @test/runtest-test_operator_control_snapshot_cache @test/runtest-test_model_map_of_keeper_rows"
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${operator_targets}"
-
-      - name: Run SSE unit and reconnect suites
-        id: sse_reconnect_e2e
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-          MASC_E2E_TESTS: "true"
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_sse_coverage @test/runtest-test_ag_ui_coverage @test/runtest-test_sse_storm_e2e"
-
-      # Keeper prompt and tool-bundle contracts exercise rendered text and the
-      # current metadata shape accepted by the production decoder.
-      - name: Run keeper prompt and tool-bundle contract suites
-        id: keeper_prompt_contract_suites
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_wake_turn_context @test/runtest-test_warn_root_causes"
-
-      # Workspace heartbeat and transport-vocabulary guards landed without a
-      # runtest target, so the ci-test-targets ratchet counted them as
-      # compile-only. Run them. The assertion-kind mirror already runs in the
-      # invariant and SSOT guard step above.
-      - name: Run mirror guard and workspace heartbeat suites
-        id: mirror_guard_suites
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_agent_api_query_params @test/runtest-test_h2_mode_vocabulary @test/runtest-test_agent_transport_vocabulary @test/runtest-test_keeper_catchup_digest @test/runtest-test_workspace_root_state_parity"
-
-      # Persona name, tool-result demotion, and tool type label landed on main
-      # without a runtest target. The verification-authority suite already
-      # runs in its dedicated completion-authority step above.
-      - name: Run persona, demotion, and tool-label suites
-        id: recent_unwired_suites
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_dashboard_keeper_name @test/runtest-test_dashboard_briefing @test/runtest-test_keeper_model_input_demotion @test/runtest-test_tool_type_label @test/runtest-test_telemetry_eio_pbt"
-
-      # Subprocess capture is bounded head+tail; without a runtest target the
-      # assertions that a 9MiB child gets truncated — and that a short one does
-      # not — would only ever be compiled. Unbounded capture is what retained
-      # 590MB in a single Execute call and stalled a keeper for 115 minutes, so
-      # this is the suite that has to actually run.
-      - name: Run subprocess capture bound suite
-        id: process_capture_suite
-        if: ${{ always() && steps.build_step.outcome == 'success' }}
-        env:
-          ME_ROOT: /tmp/me
-          CI_TEST_HEARTBEAT_SEC: 15
-          DUNE_JOBS: 1
-        run: |
-          mkdir -p /tmp/me
-          chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_process_eio_coverage @test/runtest-test_keeper_secret_redaction"
+          RUN_AGENT_CORE: ${{ needs.changes.outputs.agent_core }}
+        run: scripts/ci-run-focused-tests.sh
 
       - name: Run transport harness suite
         id: transport_harness_suite

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Fail when ci.yml names a test target that the Dune test declarations cannot build.
+# Fail when the CI execution manifests name a test target that the Dune test
+# declarations cannot build.
 #
 # CI runs a hand-maintained allowlist of @test/runtest-<name> targets. Deleting
 # the test behind one is a normal cleanup, and nothing in the deleting PR looks
-# at ci.yml, so the stale target survives and dune hard-fails on the next run —
+# at the CI manifests, so the stale target survives and dune hard-fails on the next run —
 # after the full build, on main, for everyone.
 #
 # It has happened twice. #24332 retired the shell_ir subsystem and left
@@ -18,11 +19,16 @@
 # coverage-test manifest declares it, or an explicit alias declares it.
 set -uo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+cd "$(git rev-parse --show-toplevel)" || exit
 
 declared="$(mktemp)"
 referenced="$(mktemp)"
 trap 'rm -f "$declared" "$referenced"' EXIT
+
+CI_TARGET_SOURCES=(
+  .github/workflows/ci.yml
+  scripts/ci-run-focused-tests.sh
+)
 
 # Test executables: every module listed in a (names ...) block or a (name X).
 # Field-wise, not one match per line: test/dune puts two names on a line in
@@ -63,19 +69,19 @@ for inc in test/stanzas/*.inc; do
 done
 sort -u -o "$declared" "$declared"
 
-grep -oE '@test/runtest-[a-z_0-9-]+' .github/workflows/ci.yml \
+grep -h -oE '@test/runtest-[a-z_0-9-]+' "${CI_TARGET_SOURCES[@]}" \
   | sed 's|@test/runtest-||' \
   | sort -u > "$referenced"
 
 duplicate_references="$(
-  grep -oE '@test/runtest-[a-z_0-9-]+' .github/workflows/ci.yml \
+  grep -h -oE '@test/runtest-[a-z_0-9-]+' "${CI_TARGET_SOURCES[@]}" \
     | sed 's|@test/runtest-||' \
     | sort \
     | uniq -d
 )"
 
 if [ -n "$duplicate_references" ]; then
-  echo "[ci-test-targets] FAIL - ci.yml executes the same Dune test target more than once"
+  echo "[ci-test-targets] FAIL - CI executes the same Dune test target more than once"
   echo
   printf '%s\n' "$duplicate_references" | sed 's/^/  - /'
   echo
@@ -87,7 +93,7 @@ fi
 missing="$(comm -23 "$referenced" "$declared")"
 
 if [ -n "$missing" ]; then
-  echo "[ci-test-targets] FAIL - ci.yml names targets Dune does not declare"
+  echo "[ci-test-targets] FAIL - CI names targets Dune does not declare"
   echo
   printf '%s\n' "$missing" | sed 's/^/  - /'
   echo
@@ -97,7 +103,7 @@ if [ -n "$missing" ]; then
   echo "Occurrences:"
   while IFS= read -r name; do
     [ -z "$name" ] && continue
-    grep -n "@test/runtest-${name}\b" .github/workflows/ci.yml | sed 's/^/  ci.yml:/'
+    grep -Hn "@test/runtest-${name}\b" "${CI_TARGET_SOURCES[@]}" | sed 's/^/  /'
   done <<< "$missing"
   exit 2
 fi
@@ -116,9 +122,9 @@ if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then
   echo "set is large, so diff it against main rather than reading it here:"
   echo "  comm -13 <(ci targets) <(Dune test names)"
   echo
-  echo "A suite outside ci.yml is compile-only: it never executes, so its"
+  echo "A suite outside the CI manifests is compile-only: it never executes, so its"
   echo "assertions can outlive the code they pin. Add a @test/runtest-<name>"
-  echo "target to .github/workflows/ci.yml."
+  echo "target to one of the declared CI target sources."
   exit 2
 fi
 

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# The two environment-specific groups intentionally use subshells so their
+# test knobs cannot leak into the following group.
+# shellcheck disable=SC2030,SC2031
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit
+
+# One Dune graph evaluation per environment contract. The previous workflow
+# launched one Dune process for nearly every focused suite, spending minutes
+# repeatedly loading the same already-built graph. DUNE_JOBS=1 preserves the
+# existing serial execution contract for fixed ports and shared test fixtures.
+export CI_TEST_HEARTBEAT_SEC="${CI_TEST_HEARTBEAT_SEC:-15}"
+export DUNE_JOBS="${DUNE_JOBS:-1}"
+export ME_ROOT="${ME_ROOT:-/tmp/me}"
+mkdir -p "${ME_ROOT}"
+
+run_group() {
+  local label="$1"
+  shift
+  local target_args=""
+  local status=0
+  printf -v target_args ' %q' "$@"
+  echo "::group::focused tests: ${label}"
+  scripts/ci-run-tests.sh "opam exec -- dune build --root .${target_args}" || status=$?
+  echo "::endgroup::"
+  return "${status}"
+}
+
+paused_targets=(
+  @test/runtest-test_keeper_turn_outcome
+  @test/runtest-test_keeper_paused_work_transfer_transaction
+  @test/runtest-test_keeper_paused_work_source_terminal_transaction
+  @test/runtest-test_keeper_paused_work_operator
+)
+
+normal_targets=(
+  @test/runtest-test_keeper_autonomous_turn_source
+  @test/runtest-test_keeper_autoboot_single_owner
+  @test/runtest-test_keeper_meta_current_schema
+  @test/runtest-dashboard-http-behavior-contracts
+  @test/runtest-test_model_inference_metrics
+  @test/runtest-test_channel_gate_content_length_knob
+  @test/runtest-test_keeper_decision_audit_dated_store
+  @test/runtest-test_observability_redact
+  @test/runtest-test_keeper_approval_queue
+  @test/runtest-test_keeper_hitl_resolution_prompt
+  @test/runtest-test_keeper_approval_audit_timeline
+  @test/runtest-test_verification
+  @test/runtest-test_tool_schema_constraint_enforcement
+  @test/runtest-test_keeper_artifact_read_request
+  @test/runtest-test_tool_input_validation
+  @test/runtest-test_tool_schema_oas_boundary
+  @test/runtest-test_tool_call_quality_benchmark
+  @test/runtest-test_client_identity
+  @test/runtest-test_mcp_session_task_lifecycle
+  @test/runtest-test_keeper_sandbox_docker_cwd_response
+  @test/runtest-test_goal_store
+  @test/runtest-test_keeper_goal_phase_projection
+  @test/runtest-test_keeper_tool_descriptor_registry_integrity
+  @test/runtest-test_schedule_runner
+  @test/runtest-test_schedule_store
+  @test/runtest-test_schedule_consumer_dispatch
+  @test/runtest-test_keeper_registry_hardening
+  @test/runtest-test_keeper_unified_verification_surface
+  @test/runtest-test_schedule_tool_wiring
+  @test/runtest-test_keeper_system_prompt_bytes
+  @test/runtest-test_keeper_tool_schema_bytes
+  @test/runtest-test_keeper_prompt_metrics
+  @test/runtest-test_keeper_surface_presence_prompt
+  @test/runtest-test_keeper_board_attention_worker
+  @test/runtest-test_keeper_board_attention_partition
+  @test/runtest-test_keeper_board_attention_candidate
+  @test/runtest-test_keeper_lifecycle_global_gate
+  @test/runtest-test_tool_blob_store
+  @test/runtest-test_keeper_tool_call_log
+  @test/runtest-test_keeper_wire_capture
+  @test/runtest-test_runtime_provider_auth_headers
+  @test/runtest-test_keeper_official_client_host
+  @test/runtest-test_runtime_codex_app_server
+  @test/runtest-test_runtime_antigravity
+  @test/runtest-test_official_client_session_store
+  @test/runtest-test_runtime_claude_code
+  @test/runtest-test_runtime_claude_code_config
+  @test/runtest-test_keeper_claude_code_runtime
+  @test/runtest-test_host_fd_pressure_poller
+  @test/runtest-test_keeper_turn_driver_failover
+  @test/runtest-test_keeper_turn_driver_accept
+  @test/runtest-test_keeper_vision_tool
+  @test/runtest-test_runtime_modality_reroute
+  @test/runtest-test_runtime_model_input_tail_window
+  @test/runtest-test_keeper_context_overflow_shrink
+  @test/runtest-test_keeper_provider_call_deadline
+  @test/runtest-test_keeper_runtime_resolved_observability
+  @test/runtest-test_runtime_toml_overrides
+  @test/runtest-test_keeper_wake_turn_context
+  @test/runtest-test_warn_root_causes
+  @test/runtest-test_workspace_heartbeat_outcome
+  @test/runtest-test_agent_api_query_params
+  @test/runtest-test_h2_mode_vocabulary
+  @test/runtest-test_agent_transport_vocabulary
+  @test/runtest-test_keeper_catchup_digest
+  @test/runtest-test_workspace_root_state_parity
+  @test/runtest-test_dashboard_keeper_name
+  @test/runtest-test_dashboard_briefing
+  @test/runtest-test_keeper_model_input_demotion
+  @test/runtest-test_tool_type_label
+  @test/runtest-test_telemetry_eio_pbt
+  @test/runtest-test_process_eio_coverage
+  @test/runtest-test_keeper_secret_redaction
+)
+
+agent_core_targets=(
+  @packages/agent_core/test/runtest
+  @test/runtest-test_keeper_hooks_oas_introspection
+  @test/runtest-test_keeper_execution_join
+  @test/runtest-test_hitl_summary_worker
+)
+
+operator_targets=(
+  @test/runtest-test_operator_control_snapshot_state
+  @test/runtest-test_operator_control_snapshot
+  @test/runtest-test_operator_control_snapshot_cache
+  @test/runtest-test_model_map_of_keeper_rows
+)
+
+sse_targets=(
+  @test/runtest-test_sse_coverage
+  @test/runtest-test_ag_ui_coverage
+  @test/runtest-test_sse_storm_e2e
+)
+
+overall_status=0
+
+(
+  export ALCOTEST_QUICK_TESTS=1
+  run_group paused-work "${paused_targets[@]}"
+) || overall_status=1
+
+echo "::group::focused tests: host-fd-health-paths"
+if ! bash test/test_monitor_system_health_paths.sh; then
+  overall_status=1
+fi
+echo "::endgroup::"
+
+run_group normal "${normal_targets[@]}" || overall_status=1
+
+if [[ "${RUN_AGENT_CORE:-false}" == "true" ]]; then
+  run_group agent-core "${agent_core_targets[@]}" || overall_status=1
+else
+  echo "::notice::focused tests: agent-core skipped by changed-surface scope"
+fi
+
+(
+  export ALCOTEST_QUICK_TESTS=1
+  export MASC_LOCAL_RUNTIMES_JSON='[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
+  export MASC_E2E_TESTS=true
+  run_group operator-control "${operator_targets[@]}"
+) || overall_status=1
+
+(
+  export MASC_E2E_TESTS=true
+  run_group sse "${sse_targets[@]}"
+) || overall_status=1
+
+exit "${overall_status}"


### PR DESCRIPTION
## Summary

- batch 88 focused OCaml aliases into five Dune graph invocations grouped by environment contract
- keep all 160 CI test targets and the host FD shell path contract; no test authority is removed
- use four public ubuntu-latest CPUs for the compile-only graph while behavior suites remain serial
- run explicit disk cleanup tasks concurrently
- remove the ready_for_review trigger after the draft-only OAS allowance and its check were deleted
- audit workflow plus runner as one duplicate-free CI target manifest

## Exact measurement

Baseline job 93293189334: 1,396s total, 763s cold Build, 78s cleanup.

Exact-head job 93300150810 at d511a716a9f4e1e8eaa520b654347ed8a8cc7d8c: 932s total, 582s cold Build, 57s cleanup, 102s batched focused suites.

Result: 464s faster, from 23m16s to 15m32s, a 33.2 percent reduction. The cold compile saved 181s and the focused test section saved 254s versus the former 356s aggregate.

## Verification

- actionlint workflow validation
- ShellCheck and bash syntax validation
- exact target set before and after is identical
- CI target audit: 160 declared targets, zero duplicates, unwired baseline 700
- compile authority PASS
- host FD shell path test PASS
- fake opam harness proves later groups still run after an earlier failure and final status remains nonzero
- exact GitHub CI Gate PASS

## Dependency

#27950 merged as 06a23d7311055d0e4da9b7b63bf4bbf60c65f0e2. This PR is rebased onto current main 5999baa696896a49f50dee0017c21f736222e202.