### PR TITLE
fix(runtime): keep Codex progress notifications observational

### DIFF
--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -508,7 +508,6 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
 ;;
 
 let max_retry_notifications = 3
-let max_unknown_notifications = 128
 
 let validate_item_delta_notification ~method_ ~thread_id ~turn_id params =
   let* fields = assoc_at method_ params in
@@ -522,7 +521,7 @@ let validate_item_delta_notification ~method_ ~thread_id ~turn_id params =
 ;;
 
 let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen_final
-    ~seen_fallback ~retry_notifications ~unknown_notifications =
+    ~seen_fallback ~retry_notifications =
   let* message = io.receive () in
   match message with
   | Response _ | Response_error _ ->
@@ -547,7 +546,6 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~seen_final
       ~seen_fallback
       ~retry_notifications
-      ~unknown_notifications
   | Server_request { id; method_; _ } ->
     reject_server_request io id;
     Error (Unsupported_server_request method_)
@@ -571,7 +569,6 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~seen_final
       ~seen_fallback
       ~retry_notifications
-      ~unknown_notifications
   | Notification { method_ = "item/completed"; params } ->
     let stage = "item/completed" in
     let* fields = assoc_at stage params in
@@ -597,7 +594,6 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~seen_final
         ~seen_fallback
         ~retry_notifications
-        ~unknown_notifications
   | Notification { method_ = "error"; params } ->
     let stage = "error notification" in
     let* fields = assoc_at stage params in
@@ -613,7 +609,6 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~seen_final
         ~seen_fallback
         ~retry_notifications:(retry_notifications + 1)
-        ~unknown_notifications
     else if will_retry
     then Error (Turn_failed "app-server retry notification limit exceeded")
     else
@@ -623,7 +618,10 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       Error (Turn_failed message)
   | Notification { method_ = "turn/completed"; params } ->
     terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params
-  | Notification _ when unknown_notifications < max_unknown_notifications ->
+  (* App-server progress and account notifications are observational. Protocol
+     evolution must not turn them into a computation failure; the enclosing
+     turn timeout remains the liveness boundary. *)
+  | Notification _ ->
     await_turn_terminal
       io
       ~tools
@@ -633,13 +631,6 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~seen_final
       ~seen_fallback
       ~retry_notifications
-      ~unknown_notifications:(unknown_notifications + 1)
-  | Notification { method_; _ } ->
-    protocol_error
-      "turn"
-      (Printf.sprintf
-         "unknown notification limit exceeded (last method %S)"
-         method_)
 ;;
 
 let optional_field name = function
@@ -791,7 +782,6 @@ let run_protocol io (config : config) ~protocol_cwd ~dynamic_tools ~reasoning_ef
       ~seen_final:None
       ~seen_fallback:None
       ~retry_notifications:0
-      ~unknown_notifications:0
   in
   Ok
     { thread_id

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -435,17 +435,21 @@ let test_retry_notifications_are_bounded () =
        | Ok _ -> fail "retry notifications were unbounded")
 ;;
 
-let test_unknown_notifications_are_bounded () =
-  let unknown = {|{"method":"fixture/unknown","params":{}}|} in
+let test_nonterminal_notifications_do_not_preempt_completion () =
+  let progress =
+    {|{"method":"account/rateLimits/updated","params":{"rateLimits":{}}}|}
+  in
   let lines =
     [ init_result; account_chatgpt; thread_result; turn_result ]
-    @ List.init 129 (fun _ -> unknown)
+    @ List.init 256 (fun _ -> progress)
+    @ [ item_completed; turn_completed ]
   in
   with_fixture lines (fun path ->
     match run_fixture path with
-    | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+    | Ok turn ->
+      check string "completed after progress" "MASC_SUBSCRIPTION_OK" turn.text
     | Error error -> fail (Runtime_codex_app_server.error_to_string error)
-      | Ok _ -> fail "unknown notifications were unbounded")
+    )
 ;;
 
 let test_item_output_deltas_are_typed_and_unbounded () =
@@ -1948,9 +1952,9 @@ let () =
             `Quick
             test_retry_notifications_are_bounded
          ; test_case
-             "unknown notifications are bounded"
+             "nonterminal notifications do not preempt completion"
              `Quick
-             test_unknown_notifications_are_bounded
+             test_nonterminal_notifications_do_not_preempt_completion
          ; test_case
              "item output deltas are typed and unbounded"
              `Quick


### PR DESCRIPTION
## Summary

- keep nonterminal Codex app-server notifications observational instead of counting them toward a turn-fatal budget
- retain typed handling for terminal/error/item events, malformed wire data, unsolicited responses, and server requests
- cover 256 official `account/rateLimits/updated` notifications followed by normal completion

## Root cause

A live Keeper turn received valid additive Codex app-server notifications. MASC counted notifications outside its partial semantic projection and converted the 129th into `Protocol_error`. That durable failure then moved the official-client session into `recovery_required`, so every later claim was correctly rejected until explicit recovery.

Nonterminal notifications do not authorize settlement or tool dispatch. They therefore should not be an additional computation-failure gate. The existing finite turn timeout remains the liveness boundary.

## Preserved boundaries

- malformed/duplicate JSON and invalid typed deltas still fail closed
- explicit app-server error notifications and failed turns still fail
- unsupported server requests and unsolicited responses still fail
- terminal settlement still requires typed `turn/completed`

## External comparison

- Hermes Agent `244d296646909aca1dd16c9759491da0ef4cd163`: wire transport queues notifications while the semantic projector materializes completion events
- OpenClaw `34b8a6515d780e07866b437dfc1a6f12d1fc7f18`: app-server notifications fan out to typed handlers; request deadlines remain a separate liveness authority
- Orca `34f2a62cdaf58dc5924a3b01f560f91b53a5c277` was inspected, but its finite terminal/cursor lifecycle is not this wire-notification boundary and was not copied

## Validation

- `ocamlformat --check lib/runtime/runtime_codex_app_server.ml test/test_runtime_codex_app_server.ml`
- `scripts/dune-local.sh build @test/runtest-test_runtime_codex_app_server`
- `_build/default/test/test_runtime_codex_app_server.exe test --quick-tests --color=never`: 31 passed, 7 opt-in live tests skipped
- official Codex app-server live canary reached transport/auth/provider dispatch, but the provider rejected the turn because the subscription quota was exhausted; successful live terminal completion remains unproven

## Live follow-up

After deployment, the existing Sangsu `recovery_required` session still requires an explicit operator recovery decision. This patch prevents the valid-notification overflow from recurring; it does not mutate durable live recovery state.
