### PR TITLE
fix(runtime): bound distinct unknown notification methods, not repeats

### DIFF
--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -508,7 +508,24 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
 ;;
 
 let max_retry_notifications = 3
-let max_unknown_notifications = 128
+
+(* The cap answers "is the peer speaking a protocol we do not model?", and that
+   is a function of how many DISTINCT methods we fail to recognise, not of how
+   often one of them arrives. JSON-RPC notifications are fire-and-forget, so a
+   method we do not model is not an error on its own.
+
+   Counting repeats made a routine informational notification fatal. Codex
+   emits [account/rateLimits/updated] throughout a turn; on 2026-08-09 that one
+   unmodelled method exhausted a 128-occurrence budget on long turns, ended the
+   turn with a protocol error, and left the official-client session in
+   [Recovery_required] — after which every later execution was rejected with
+   [official_client_session.claim]. Three keepers accumulated 1,375 rejected
+   turns; [sangsu] completed 0 of 546 turns in six hours. Resolving the session
+   did not hold, because the next long turn reproduced it.
+
+   Distinct-method counting keeps the original detection intent: a peer sending
+   many different unrecognised methods still trips the cap. *)
+let max_unknown_notification_methods = 32
 
 let validate_item_delta_notification ~method_ ~thread_id ~turn_id params =
   let* fields = assoc_at method_ params in
@@ -522,7 +539,7 @@ let validate_item_delta_notification ~method_ ~thread_id ~turn_id params =
 ;;
 
 let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen_final
-    ~seen_fallback ~retry_notifications ~unknown_notifications =
+    ~seen_fallback ~retry_notifications ~unknown_methods =
   let* message = io.receive () in
   match message with
   | Response _ | Response_error _ ->
@@ -547,7 +564,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~seen_final
       ~seen_fallback
       ~retry_notifications
-      ~unknown_notifications
+      ~unknown_methods
   | Server_request { id; method_; _ } ->
     reject_server_request io id;
     Error (Unsupported_server_request method_)
@@ -571,7 +588,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~seen_final
       ~seen_fallback
       ~retry_notifications
-      ~unknown_notifications
+      ~unknown_methods
   | Notification { method_ = "item/completed"; params } ->
     let stage = "item/completed" in
     let* fields = assoc_at stage params in
@@ -597,7 +614,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~seen_final
         ~seen_fallback
         ~retry_notifications
-        ~unknown_notifications
+        ~unknown_methods
   | Notification { method_ = "error"; params } ->
     let stage = "error notification" in
     let* fields = assoc_at stage params in
@@ -613,7 +630,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~seen_final
         ~seen_fallback
         ~retry_notifications:(retry_notifications + 1)
-        ~unknown_notifications
+        ~unknown_methods
     else if will_retry
     then Error (Turn_failed "app-server retry notification limit exceeded")
     else
@@ -623,7 +640,9 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       Error (Turn_failed message)
   | Notification { method_ = "turn/completed"; params } ->
     terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params
-  | Notification _ when unknown_notifications < max_unknown_notifications ->
+  | Notification { method_; _ }
+    when List.mem method_ unknown_methods
+         || List.length unknown_methods < max_unknown_notification_methods ->
     await_turn_terminal
       io
       ~tools
@@ -633,12 +652,16 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~seen_final
       ~seen_fallback
       ~retry_notifications
-      ~unknown_notifications:(unknown_notifications + 1)
+      ~unknown_methods:
+        (if List.mem method_ unknown_methods
+         then unknown_methods
+         else method_ :: unknown_methods)
   | Notification { method_; _ } ->
     protocol_error
       "turn"
       (Printf.sprintf
-         "unknown notification limit exceeded (last method %S)"
+         "unknown notification method limit exceeded (%d distinct, last method %S)"
+         (List.length unknown_methods)
          method_)
 ;;
 
@@ -791,7 +814,7 @@ let run_protocol io (config : config) ~protocol_cwd ~dynamic_tools ~reasoning_ef
       ~seen_final:None
       ~seen_fallback:None
       ~retry_notifications:0
-      ~unknown_notifications:0
+      ~unknown_methods:[]
   in
   Ok
     { thread_id

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -435,17 +435,46 @@ let test_retry_notifications_are_bounded () =
        | Ok _ -> fail "retry notifications were unbounded")
 ;;
 
-let test_unknown_notifications_are_bounded () =
-  let unknown = {|{"method":"fixture/unknown","params":{}}|} in
+(* The cap detects a peer speaking an unmodelled protocol, so it counts
+   DISTINCT unrecognised methods. This fixture sends enough different ones to
+   trip it; the sibling test below sends one method many times and must not
+   trip it. *)
+let test_unknown_notification_methods_are_bounded () =
+  let unknown index =
+    Printf.sprintf {|{"method":"fixture/unknown-%d","params":{}}|} index
+  in
   let lines =
     [ init_result; account_chatgpt; thread_result; turn_result ]
-    @ List.init 129 (fun _ -> unknown)
+    @ List.init 33 unknown
   in
   with_fixture lines (fun path ->
     match run_fixture path with
     | Error (Runtime_codex_app_server.Protocol_error _) -> ()
     | Error error -> fail (Runtime_codex_app_server.error_to_string error)
-      | Ok _ -> fail "unknown notifications were unbounded")
+    | Ok _ -> fail "distinct unknown notification methods were unbounded")
+;;
+
+(* Live regression (2026-08-09): Codex emits [account/rateLimits/updated]
+   throughout a turn. Counting repeats exhausted the budget on long turns and
+   ended them with a protocol error, which put the official-client session into
+   Recovery_required and rejected every later execution — [sangsu] completed 0
+   of 546 turns in six hours. One unmodelled method is one gap, however often
+   it arrives. *)
+let test_repeated_unknown_notification_method_is_tolerated () =
+  let rate_limits =
+    {|{"method":"account/rateLimits/updated","params":{"primary":{"usedPercent":12}}}|}
+  in
+  let lines =
+    [ init_result; account_chatgpt; thread_result; turn_result ]
+    @ List.init 512 (fun _ -> rate_limits)
+    @ [ item_completed; turn_completed ]
+  in
+  with_fixture lines (fun path ->
+    match run_fixture path with
+    | Ok result ->
+      check string "turn still completes" "MASC_SUBSCRIPTION_OK"
+        (String.trim result.Runtime_codex_app_server.text)
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error))
 ;;
 
 let test_item_output_deltas_are_typed_and_unbounded () =
@@ -1948,9 +1977,13 @@ let () =
             `Quick
             test_retry_notifications_are_bounded
          ; test_case
-             "unknown notifications are bounded"
+             "distinct unknown notification methods are bounded"
              `Quick
-             test_unknown_notifications_are_bounded
+             test_unknown_notification_methods_are_bounded
+         ; test_case
+             "a repeated unknown notification method is tolerated"
+             `Quick
+             test_repeated_unknown_notification_method_is_tolerated
          ; test_case
              "item output deltas are typed and unbounded"
              `Quick


### PR DESCRIPTION
Closes #27953.

## 라이브 장애

Codex app-server 를 쓰는 keeper 3대가 세션 `recovery_required` 에 빠져 이후 모든 턴이 즉시 거부됐다 (latency 266–384ms, 하드 거부).

| keeper | 거부된 턴 | 미해소 세션 id 누적 | 최근 6h 완주 |
|---|---:|---:|---:|
| `sangsu` | 614 | 7 | **0 / 546** |
| `kidsnote` | 581 | 7 | 20 / 534 |
| `taskmaster` | 180 | 1 | 144 / 511 |

`paused=false`, `latched_reason=null`, `last_blocker=null` — 관측 표면에는 정상으로 보인다.

## 원인

`session.json` 의 `phase.detail`:

```
sangsu·taskmaster : unknown notification limit exceeded
                    (last method "account/rateLimits/updated")
kidsnote          : field "delta" must be a non-empty string
```

이 클라이언트가 아는 notification method 는 네 개뿐이다:

```
$ rg -o 'method_ = "[a-zA-Z/._]+"' lib/runtime/runtime_codex_app_server.ml | sort -u
"error"  "item/completed"  "item/tool/call"  "turn/completed"

$ rg -n 'rateLimits|rate_limits' lib/ packages/ --glob '*.ml'
(0건)
```

`account/rateLimits/updated` 는 Codex 가 턴 내내 반복 전송하는 정보성 알림이다. 128 **회** 예산을 쓰는 구조라 충분히 긴 턴은 결정론적으로 죽는다.

사슬: 정상 알림 반복 → unknown 카운터 → 128 초과 → `protocol_error` → 세션 `Recovery_required` → 이후 전 실행이 `official_client_session.claim` 로 거부.

**해소로는 안 잡힌다.** `sangsu` 는 운영자가 `restart_fresh` 로 해소했고 한 시간 안에 다시 `Recovery_required` 가 됐다 (`last_recovery_resolution.resolved_at = 1786293462`). 세션 id 가 7개 쌓인 것이 그 반복이다.

## 변경

cap 이 세는 대상을 **반복 횟수 → 서로 다른 method 수**로 바꾼다.

```ocaml
let max_unknown_notification_methods = 32

| Notification { method_; _ }
  when List.mem method_ unknown_methods
       || List.length unknown_methods < max_unknown_notification_methods -> ...
```

cap 의 목적은 "상대가 우리가 모르는 프로토콜을 말한다" 탐지이고, 그건 서로 다른 method 의 수의 함수이지 반복 횟수의 함수가 아니다. JSON-RPC 에서 notification 은 fire-and-forget 이므로 모르는 method 자체는 오류가 아니다. 서로 다른 미인식 method 를 다수 보내는 peer 는 여전히 32 에서 걸린다.

`account/rateLimits/updated` 를 알려진 목록에 추가하는 방식은 택하지 않았다. Codex 가 새 알림을 추가할 때마다 같은 사고가 재발하는 whack-a-mole 이 된다.

## 테스트 — 기존 단언을 바꿨다

`test_unknown_notifications_are_bounded` 는 **같은 method 를 129번** 보내고 protocol error 를 기대했다. 즉 이 결함을 사양으로 고정하고 있었다. 두 개로 갈랐다:

| 테스트 | 입력 | 기대 |
|---|---|---|
| `distinct unknown notification methods are bounded` | 서로 다른 method 33종 | protocol error (탐지 의도 유지) |
| `a repeated unknown notification method is tolerated` | `account/rateLimits/updated` 512회 | **턴 완주** |

뮤테이션 검증 — 반복 계수로 되돌리면:

```
> [FAIL]  subscription boundary  13  a repeated unknown notific...
```

새 관용 테스트 1건만 실패하고 distinct 상한 테스트는 통과한다. 즉 두 테스트가 서로 다른 것을 잡는다.

전체: `@test/runtest-test_runtime_codex_app_server` → **32/32 통과**.

## 범위 밖

- `kidsnote` 의 `field "delta" must be a non-empty string` 은 별개 경로(빈 delta 엄격 파싱)다. 같은 fail-closed 성향이며 #27953 에 함께 기록했다.
- 이미 `Recovery_required` 에 빠진 기존 세션은 이 PR 이 풀지 않는다. 재발을 막을 뿐이고, 해소는 운영 작업이다.
- 결정론적 실패가 무한 재시도되는 상위 문제(연속실패 카운터에 임계 소비자 없음)는 #27323.

RFC-WAIVED: 변경 범위가 `lib/runtime/runtime_codex_app_server.ml` 의 notification 예산 한 곳과 그 테스트로, credential/identity/operator control/keeper sandbox/hooks/workflow 문서 어디에도 해당하지 않음.
