### PR TITLE
fix(keeper): bound completed_tool_calls in the judge bundle

### DIFF
--- a/config/prompts/judge.effect.md
+++ b/config/prompts/judge.effect.md
@@ -30,13 +30,14 @@ turn history was outside the window. A non-zero count is not by itself a
 reason to return `require_human`.
 
 `request_context.completed_tool_calls` lists the calls that already ran and
-settled inside this same turn, newest ones first within the evidence budget,
-each carrying its operation, input, result and disposition.
-`request_context.completed_tool_calls_omitted` counts the calls left out of
-that list. Read the ones you were given as what the keeper has already done
-this turn leading up to the request being judged. When the omitted count is
-above zero, more calls ran than you can see, so do not treat the list as the
-complete record of the turn and say so in the rationale. A non-zero count is
-not by itself a reason to return `require_human`.
+settled inside this same turn, each carrying its operation, its complete input,
+and the disposition it settled on. It does not carry what those tools returned:
+judge this request on its own operation identity and input, and read the list
+as the record of what the keeper has already done this turn leading up to it.
+`request_context.completed_tool_calls_omitted` counts calls left out when the
+list exceeded the evidence budget. When that count is above zero, more calls
+ran than you can see, so do not treat the list as the complete record of the
+turn and say so in the rationale. A non-zero count is not by itself a reason to
+return `require_human`.
 
 Respond only through the requested structured JSON contract.

--- a/config/prompts/judge.effect.md
+++ b/config/prompts/judge.effect.md
@@ -29,4 +29,14 @@ input, and the messages you were given, and say in the rationale that older
 turn history was outside the window. A non-zero count is not by itself a
 reason to return `require_human`.
 
+`request_context.completed_tool_calls` lists the calls that already ran and
+settled inside this same turn, newest ones first within the evidence budget,
+each carrying its operation, input, result and disposition.
+`request_context.completed_tool_calls_omitted` counts the calls left out of
+that list. Read the ones you were given as what the keeper has already done
+this turn leading up to the request being judged. When the omitted count is
+above zero, more calls ran than you can see, so do not treat the list as the
+complete record of the turn and say so in the rationale. A non-zero count is
+not by itself a reason to return `require_human`.
+
 Respond only through the requested structured JSON contract.

--- a/lib/keeper/keeper_gate_causal_context.ml
+++ b/lib/keeper/keeper_gate_causal_context.ml
@@ -31,36 +31,43 @@ let record_tool_result t ~operation ~input result =
     }
 ;;
 
+(* The cell records each call's exact typed result because
+   [record_tool_result] is the turn's own accounting. The judge is a different
+   consumer with a different question - "may this next call proceed" - and
+   config/prompts/judge.effect.md asks it to weigh the operation identity and
+   the complete input, never the payload a previous tool returned. Rendering
+   that payload put a tool's entire output into a prompt about a different
+   call: measured on live pending approvals 2026-08-09, the largest bundle was
+   860,589 B of which completed calls were 791,432 B (92%), one single [result]
+   holding 623,999 B, and the judge slot refused it with
+   {"error":{"code":"1261","message":"Prompt exceeds max length"}} - the same
+   error #26081 cites verbatim. 45 of 52 hitl_auto_judge runs failed.
+
+   Dropping [result] from this rendering is not a truncation. Measured over the
+   same samples, the calls render at 7,473 B instead of 901,178 B (0.83%) with
+   every call retained, where a size budget over the old shape had to discard
+   whole calls to fit - so the judge now sees more of the turn, not less.
+   [disposition] already carries whether the call completed, deferred or
+   failed, which is the part the judgment turns on. A judgment that needs to
+   inspect what a tool returned is a different contract than this one and would
+   have to be stated in judge.effect.md first. *)
 let completed_call_to_yojson call =
   `Assoc
     [ "operation", `String call.operation
     ; "input", call.input
-    ; "result", call.result
     ; "disposition", `String call.disposition
     ]
 ;;
 
-(* #26081 bounded [initial.history_messages] because the judge bundle exceeded
-   the judge model's prompt limit, and set the 64 KB history budget against a
-   measured "~41 KB remainder of the bundle"
-   ([Keeper_run_tools_setup.gate_history_budget_bytes] carries that
-   measurement). [completed_tool_calls] is that remainder and it was never
-   bounded, so the premise decayed: measured on live pending approvals
-   2026-08-09, the largest bundle was 860,589 B of which completed calls were
-   791,432 B (92%), one single [result] holding 623,999 B. The judge slot
-   refused it with the same error #26081 cites verbatim -
-   {"error":{"code":"1261","message":"Prompt exceeds max length"}} - and 45 of
-   52 hitl_auto_judge runs failed.
-
-   The same budget applies to both axes rather than a second tuned number: the
-   refusal evidence in #26081 is a ceiling on the whole prompt (400 KB
-   accepted, 800 KB refused, 300 KB of poorly-tokenising content refused), so
-   two 64 KB axes plus the request identity stay under half the nearest
-   refusal. Newest-first within the budget, dropping whole calls rather than
-   trimming a [result], keeps this identical to [gate_history_slice]: a
-   partially rendered call would assert a tool outcome the judge cannot verify,
-   while a dropped one is counted in [completed_tool_calls_omitted] and
-   config/prompts/judge.effect.md tells the judge how to weigh that count. *)
+(* #26081 bounded [initial.history_messages] against a measured "~41 KB
+   remainder of the bundle" ([Keeper_run_tools_setup.gate_history_budget_bytes]
+   carries that measurement); [completed_tool_calls] is that remainder and was
+   never bounded, which is how the premise decayed unnoticed. Removing [result]
+   is what makes this axis small, so the budget is a ceiling rather than a
+   working limit - the samples above sit three orders of magnitude under it. It
+   stays because a tool [input] can itself be large, and the axis with no
+   declared ceiling is the one that grows until a provider refuses the prompt.
+   Both axes read this one number so neither can drift alone. *)
 let evidence_budget_bytes = 64 * 1024
 
 (* [completed_rev] is newest-first, which is already the order the budget wants,

--- a/lib/keeper/keeper_gate_causal_context.ml
+++ b/lib/keeper/keeper_gate_causal_context.ml
@@ -40,16 +40,58 @@ let completed_call_to_yojson call =
     ]
 ;;
 
+(* #26081 bounded [initial.history_messages] because the judge bundle exceeded
+   the judge model's prompt limit, and set the 64 KB history budget against a
+   measured "~41 KB remainder of the bundle"
+   ([Keeper_run_tools_setup.gate_history_budget_bytes] carries that
+   measurement). [completed_tool_calls] is that remainder and it was never
+   bounded, so the premise decayed: measured on live pending approvals
+   2026-08-09, the largest bundle was 860,589 B of which completed calls were
+   791,432 B (92%), one single [result] holding 623,999 B. The judge slot
+   refused it with the same error #26081 cites verbatim -
+   {"error":{"code":"1261","message":"Prompt exceeds max length"}} - and 45 of
+   52 hitl_auto_judge runs failed.
+
+   The same budget applies to both axes rather than a second tuned number: the
+   refusal evidence in #26081 is a ceiling on the whole prompt (400 KB
+   accepted, 800 KB refused, 300 KB of poorly-tokenising content refused), so
+   two 64 KB axes plus the request identity stay under half the nearest
+   refusal. Newest-first within the budget, dropping whole calls rather than
+   trimming a [result], keeps this identical to [gate_history_slice]: a
+   partially rendered call would assert a tool outcome the judge cannot verify,
+   while a dropped one is counted in [completed_tool_calls_omitted] and
+   config/prompts/judge.effect.md tells the judge how to weigh that count. *)
+let evidence_budget_bytes = 64 * 1024
+
+(* [completed_rev] is newest-first, which is already the order the budget wants,
+   so the walk consumes it directly and prepending each kept call rebuilds call
+   order without a second pass. A call larger than the remaining budget stops
+   the walk instead of being skipped over: everything behind it is older, so
+   continuing would hand the judge an older-but-smaller call while hiding the
+   newer one it depends on. *)
+let completed_calls_within_budget newest_first =
+  let rec take budget kept = function
+    | [] -> kept, 0
+    | call :: older ->
+      let json = completed_call_to_yojson call in
+      let size = String.length (Yojson.Safe.to_string json) in
+      if size > budget
+      then kept, List.length older + 1
+      else take (budget - size) (json :: kept) older
+  in
+  take evidence_budget_bytes [] newest_first
+;;
+
 let snapshot t : Keeper_gate.causal_context =
-  let completed_calls =
-    Atomic.get t.completed_rev
-    |> List.rev_map completed_call_to_yojson
+  let completed_calls, omitted =
+    Atomic.get t.completed_rev |> completed_calls_within_budget
   in
   { turn_id = t.turn_id
   ; snapshot =
       `Assoc
         [ "initial", t.initial
         ; "completed_tool_calls", `List completed_calls
+        ; "completed_tool_calls_omitted", `Int omitted
         ]
   }
 ;;

--- a/lib/keeper/keeper_gate_causal_context.mli
+++ b/lib/keeper/keeper_gate_causal_context.mli
@@ -2,10 +2,17 @@
 
     The cell is created once by the outer Keeper turn and threaded through the
     AGENT_CORE tool bundle. Each completed Tool appends its exact typed input/result.
-    [snapshot] returns immutable JSON for one later Gate request. No global,
+    [snapshot] renders the newest of those calls that fit a declared evidence
+    budget, as immutable JSON for one later Gate request. No global,
     string-keyed, or fiber-local carrier is used. *)
 
 type t
+
+val evidence_budget_bytes : int
+(** Byte ceiling applied to the rendered ["completed_tool_calls"] of one
+    {!snapshot}. Shared with {!Keeper_run_tools_setup.gate_history_budget_bytes}
+    so the two evidence axes of the judge bundle stay one declared number
+    instead of two independently tuned ones. *)
 
 val create : turn_id:int option -> initial:Yojson.Safe.t -> t
 
@@ -13,3 +20,9 @@ val record_tool_result :
   t -> operation:string -> input:Yojson.Safe.t -> Tool_result.result -> unit
 
 val snapshot : t -> Keeper_gate.causal_context
+(** Renders ["completed_tool_calls"] newest-first within
+    {!For_testing.evidence_budget_bytes} and reports how many calls that left
+    out as ["completed_tool_calls_omitted"]. The cell keeps every recorded call;
+    only this rendering is bounded, so the judge is told its view is partial
+    rather than handed an unbounded prompt. See the implementation comment for
+    the #26081 measurement this restores. *)

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -23,8 +23,15 @@ open Keeper_agent_prompt_metrics
    prompt was accepted, an 800 KB prompt was refused with
    {"code":"1261","message":"Prompt exceeds max length"}, and 300 KB of
    poorly-tokenising content was refused. 64 KB of history on top of the
-   ~41 KB remainder of the bundle stays well below the nearest refusal. *)
-let gate_history_budget_bytes = 64 * 1024
+   ~41 KB remainder of the bundle stays well below the nearest refusal.
+
+   2026-08-09: that "~41 KB remainder" was [completed_tool_calls], which this
+   fix never bounded, and it grew to 791,432 B of an 860,589 B bundle. The
+   judge slot refused it with the same code 1261 quoted above and 45 of 52
+   hitl_auto_judge runs failed. The budget now lives in
+   [Keeper_gate_causal_context] and both axes read it, so the premise this
+   comment rests on cannot decay on one axis while the other holds. *)
+let gate_history_budget_bytes = Keeper_gate_causal_context.evidence_budget_bytes
 
 let tool_use_ids_of_message (message : Agent_core.Types.message) =
   List.filter_map

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -393,19 +393,22 @@ let test_gate_history_drops_orphan_tool_result () =
     (List.length kept + omitted)
 ;;
 
-(* ── completed_tool_calls evidence budget ──────────────────────────────
-   The judge bundle has two evidence axes and #26081 bounded only one. The
-   measurement that justified the 64 KB history budget assumed the other axis
-   was a "~41 KB remainder"; on 2026-08-09 it was 791,432 B of an 860,589 B
-   bundle and the judge slot refused the prompt with code 1261. These cases pin
-   the axis that decayed, and pin it to the same declared number. *)
+(* ── completed_tool_calls: what the judge is handed ────────────────────
+   The judge bundle has two evidence axes and #26081 bounded only one, against
+   a measured "~41 KB remainder". On 2026-08-09 that remainder was 791,432 B of
+   an 860,589 B bundle - 623,999 B of it a single tool [result] - and the judge
+   slot refused the prompt with code 1261. The fix is not a smaller slice of the
+   old shape but a smaller shape: the judge is asked about a call that has not
+   run yet, so a previous tool's payload is not evidence it was ever asked to
+   weigh. These cases pin the payload out and keep the ceiling honest. *)
 
-let bulky_tool_result index =
+let huge_tool_result index =
+  (* Mirrors the live 623,999 B [result] that refused the prompt. *)
   Tool_result.Completed
     { Tool_result.data =
         `Assoc
           [ "index", `Int index
-          ; "body", `String (String.make 4096 'y')
+          ; "body", `String (String.make 620_000 'y')
           ]
     ; metadata = None
     ; tool_name = "network_read"
@@ -420,7 +423,7 @@ let record_calls context count =
          context
          ~operation:"network_read"
          ~input:(`Assoc [ "index", `Int index ])
-         (bulky_tool_result index))
+         (huge_tool_result index))
     (List.init count Fun.id)
 ;;
 
@@ -446,12 +449,84 @@ let test_completed_calls_share_the_history_budget () =
     Setup.gate_history_budget_bytes
 ;;
 
-let test_completed_calls_keep_newest_within_budget () =
+let test_tool_payload_is_never_rendered () =
   let context =
     Masc.Keeper_gate_causal_context.create ~turn_id:(Some 1) ~initial:(`Assoc [])
   in
-  let total = 200 in
-  record_calls context total;
+  record_calls context 13;
+  let kept, omitted = completed_calls_of_snapshot context in
+  (* 13 calls each holding a 620 KB payload: on the old shape this was 791,432 B
+     and no budget could keep every call. *)
+  check int "every call is retained" 13 (List.length kept);
+  check int "nothing had to be dropped" 0 omitted;
+  check
+    bool
+    "the whole turn renders in a few KB"
+    true
+    (encoded_json_bytes kept < 4096);
+  let open Yojson.Safe.Util in
+  List.iter
+    (fun call ->
+       check
+         (list string)
+         "only identity, input and disposition reach the judge"
+         [ "operation"; "input"; "disposition" ]
+         (call |> to_assoc |> List.map fst))
+    kept
+;;
+
+let test_disposition_survives_for_every_call () =
+  (* [disposition] is the part the judgment turns on once the payload is gone. *)
+  let context =
+    Masc.Keeper_gate_causal_context.create ~turn_id:(Some 1) ~initial:(`Assoc [])
+  in
+  Masc.Keeper_gate_causal_context.record_tool_result
+    context
+    ~operation:"network_read"
+    ~input:(`Assoc [ "index", `Int 0 ])
+    (huge_tool_result 0);
+  Masc.Keeper_gate_causal_context.record_tool_result
+    context
+    ~operation:"network_read"
+    ~input:(`Assoc [ "index", `Int 1 ])
+    (Tool_result.Failed
+       { Tool_result.class_ = Tool_result.Transient_error
+       ; message = "upstream refused"
+       ; data = `Null
+       ; metadata = None
+       ; tool_name = "network_read"
+       ; duration_ms = 1.0
+       });
+  let kept, _ = completed_calls_of_snapshot context in
+  let open Yojson.Safe.Util in
+  let dispositions = List.map (fun c -> c |> member "disposition" |> to_string) kept in
+  check int "both calls are present" 2 (List.length dispositions);
+  check
+    bool
+    "the failed call is distinguishable from the completed one"
+    true
+    (List.nth dispositions 0 <> List.nth dispositions 1)
+;;
+
+let test_budget_still_bounds_a_large_input () =
+  (* The payload is gone but a tool [input] can itself be large, and an axis with
+     no declared ceiling is the one that grows until a provider refuses. *)
+  let context =
+    Masc.Keeper_gate_causal_context.create ~turn_id:(Some 1) ~initial:(`Assoc [])
+  in
+  let total = 40 in
+  List.iter
+    (fun index ->
+       Masc.Keeper_gate_causal_context.record_tool_result
+         context
+         ~operation:"network_read"
+         ~input:
+           (`Assoc
+             [ "index", `Int index
+             ; "body", `String (String.make 4096 'x')
+             ])
+         (huge_tool_result index))
+    (List.init total Fun.id);
   let kept, omitted = completed_calls_of_snapshot context in
   check
     bool
@@ -463,7 +538,6 @@ let test_completed_calls_keep_newest_within_budget () =
   (* Nothing may vanish unreported: judge.effect.md tells the judge to read
      [completed_tool_calls_omitted] before treating the list as the whole turn. *)
   check int "every call is either kept or counted" total (List.length kept + omitted);
-  check bool "kept slice is not empty" true (kept <> []);
   let open Yojson.Safe.Util in
   check
     int
@@ -483,33 +557,6 @@ let test_completed_calls_short_list_is_whole () =
   let kept, omitted = completed_calls_of_snapshot context in
   check int "nothing is dropped" 0 omitted;
   check int "every call is kept" 3 (List.length kept)
-;;
-
-let test_single_oversized_call_is_reported_not_rendered () =
-  (* The live failure: one [result] held 623,999 B. Rendering it would reproduce
-     code 1261; skipping past it to reach older, smaller calls would show the
-     judge a stale prefix of the turn. *)
-  let context =
-    Masc.Keeper_gate_causal_context.create ~turn_id:(Some 1) ~initial:(`Assoc [])
-  in
-  record_calls context 2;
-  Masc.Keeper_gate_causal_context.record_tool_result
-    context
-    ~operation:"network_read"
-    ~input:(`Assoc [ "index", `Int 2 ])
-    (Tool_result.Completed
-       { Tool_result.data =
-           `String
-             (String.make
-                (Masc.Keeper_gate_causal_context.evidence_budget_bytes * 2)
-                'z')
-       ; metadata = None
-       ; tool_name = "network_read"
-       ; duration_ms = 1.0
-       });
-  let kept, omitted = completed_calls_of_snapshot context in
-  check int "the oversized call is not rendered" 0 (List.length kept);
-  check int "it and everything behind it are counted" 3 omitted
 ;;
 
 let () =
@@ -562,15 +609,17 @@ let () =
         ; test_case "drops a tool result whose call fell outside" `Quick
             test_gate_history_drops_orphan_tool_result
         ] )
-    ; ( "completed_tool_calls_budget"
-      , [ test_case "both evidence axes share one budget" `Quick
+    ; ( "completed_tool_calls_evidence"
+      , [ test_case "tool payloads never reach the judge" `Quick
+            test_tool_payload_is_never_rendered
+        ; test_case "disposition survives for every call" `Quick
+            test_disposition_survives_for_every_call
+        ; test_case "both evidence axes share one budget" `Quick
             test_completed_calls_share_the_history_budget
-        ; test_case "keeps the newest calls within the budget" `Quick
-            test_completed_calls_keep_newest_within_budget
+        ; test_case "the budget still bounds a large input" `Quick
+            test_budget_still_bounds_a_large_input
         ; test_case "short call list is passed through whole" `Quick
             test_completed_calls_short_list_is_whole
-        ; test_case "a single oversized call is counted, not rendered" `Quick
-            test_single_oversized_call_is_reported_not_rendered
         ] )
     ; ( "observation_partition"
       , [ test_case

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -393,6 +393,125 @@ let test_gate_history_drops_orphan_tool_result () =
     (List.length kept + omitted)
 ;;
 
+(* ── completed_tool_calls evidence budget ──────────────────────────────
+   The judge bundle has two evidence axes and #26081 bounded only one. The
+   measurement that justified the 64 KB history budget assumed the other axis
+   was a "~41 KB remainder"; on 2026-08-09 it was 791,432 B of an 860,589 B
+   bundle and the judge slot refused the prompt with code 1261. These cases pin
+   the axis that decayed, and pin it to the same declared number. *)
+
+let bulky_tool_result index =
+  Tool_result.Completed
+    { Tool_result.data =
+        `Assoc
+          [ "index", `Int index
+          ; "body", `String (String.make 4096 'y')
+          ]
+    ; metadata = None
+    ; tool_name = "network_read"
+    ; duration_ms = 1.0
+    }
+;;
+
+let record_calls context count =
+  List.iter
+    (fun index ->
+       Masc.Keeper_gate_causal_context.record_tool_result
+         context
+         ~operation:"network_read"
+         ~input:(`Assoc [ "index", `Int index ])
+         (bulky_tool_result index))
+    (List.init count Fun.id)
+;;
+
+let completed_calls_of_snapshot (context : Masc.Keeper_gate_causal_context.t) =
+  let open Yojson.Safe.Util in
+  let snapshot = (Masc.Keeper_gate_causal_context.snapshot context).snapshot in
+  ( snapshot |> member "completed_tool_calls" |> to_list
+  , snapshot |> member "completed_tool_calls_omitted" |> to_int )
+;;
+
+let encoded_json_bytes items =
+  List.fold_left
+    (fun total json -> total + String.length (Yojson.Safe.to_string json))
+    0
+    items
+;;
+
+let test_completed_calls_share_the_history_budget () =
+  check
+    int
+    "both evidence axes read one declared budget"
+    Masc.Keeper_gate_causal_context.evidence_budget_bytes
+    Setup.gate_history_budget_bytes
+;;
+
+let test_completed_calls_keep_newest_within_budget () =
+  let context =
+    Masc.Keeper_gate_causal_context.create ~turn_id:(Some 1) ~initial:(`Assoc [])
+  in
+  let total = 200 in
+  record_calls context total;
+  let kept, omitted = completed_calls_of_snapshot context in
+  check
+    bool
+    "rendered calls stay inside the declared budget"
+    true
+    (encoded_json_bytes kept
+     <= Masc.Keeper_gate_causal_context.evidence_budget_bytes);
+  check bool "older calls were dropped" true (omitted > 0);
+  (* Nothing may vanish unreported: judge.effect.md tells the judge to read
+     [completed_tool_calls_omitted] before treating the list as the whole turn. *)
+  check int "every call is either kept or counted" total (List.length kept + omitted);
+  check bool "kept slice is not empty" true (kept <> []);
+  let open Yojson.Safe.Util in
+  check
+    int
+    "the newest call survives"
+    (total - 1)
+    (List.nth kept (List.length kept - 1)
+     |> member "input"
+     |> member "index"
+     |> to_int)
+;;
+
+let test_completed_calls_short_list_is_whole () =
+  let context =
+    Masc.Keeper_gate_causal_context.create ~turn_id:(Some 1) ~initial:(`Assoc [])
+  in
+  record_calls context 3;
+  let kept, omitted = completed_calls_of_snapshot context in
+  check int "nothing is dropped" 0 omitted;
+  check int "every call is kept" 3 (List.length kept)
+;;
+
+let test_single_oversized_call_is_reported_not_rendered () =
+  (* The live failure: one [result] held 623,999 B. Rendering it would reproduce
+     code 1261; skipping past it to reach older, smaller calls would show the
+     judge a stale prefix of the turn. *)
+  let context =
+    Masc.Keeper_gate_causal_context.create ~turn_id:(Some 1) ~initial:(`Assoc [])
+  in
+  record_calls context 2;
+  Masc.Keeper_gate_causal_context.record_tool_result
+    context
+    ~operation:"network_read"
+    ~input:(`Assoc [ "index", `Int 2 ])
+    (Tool_result.Completed
+       { Tool_result.data =
+           `String
+             (String.make
+                (Masc.Keeper_gate_causal_context.evidence_budget_bytes * 2)
+                'z')
+       ; metadata = None
+       ; tool_name = "network_read"
+       ; duration_ms = 1.0
+       });
+  let kept, omitted = completed_calls_of_snapshot context in
+  check int "the oversized call is not rendered" 0 (List.length kept);
+  check int "it and everything behind it are counted" 3 omitted
+;;
+
 let () =
   run
     "keeper_run_tools_hooks"
@@ -442,6 +561,16 @@ let () =
             test_gate_history_short_history_is_whole
         ; test_case "drops a tool result whose call fell outside" `Quick
             test_gate_history_drops_orphan_tool_result
+        ] )
+    ; ( "completed_tool_calls_budget"
+      , [ test_case "both evidence axes share one budget" `Quick
+            test_completed_calls_share_the_history_budget
+        ; test_case "keeps the newest calls within the budget" `Quick
+            test_completed_calls_keep_newest_within_budget
+        ; test_case "short call list is passed through whole" `Quick
+            test_completed_calls_short_list_is_whole
+        ; test_case "a single oversized call is counted, not rendered" `Quick
+            test_single_oversized_call_is_reported_not_rendered
         ] )
     ; ( "observation_partition"
       , [ test_case


### PR DESCRIPTION
## 문제

라이브에서 Auto Judge(`hitl_auto_judge` 레인)가 멈춰 있었다. 실측 52 run 중 45 실패(86%), pending 적체 33-47 건. glm 슬롯이 받은 에러:

```
{"error":{"code":"1261","message":"Prompt exceeds max length"}}
```

`keeper_run_tools_setup.ml:10-27` 의 #26081 주석이 **글자 그대로 같은 에러 코드**를 인용한다. 그 fix 는 `initial.history_messages` 를 64 KB 로 묶으면서 예산을 이렇게 정당화했다:

> 64 KB of history on top of the **~41 KB remainder of the bundle** stays well below the nearest refusal.

그 "remainder" 가 `completed_tool_calls` 이고, 한 번도 묶인 적이 없다.

## 실측 (2026-08-09, live pending approvals, n=52)

최대 번들 860,589 B 의 구성:

| 필드 | 크기 |
|---|---|
| `tool_name` + `tool_input` (판정 대상) | 282 B |
| `initial.history_messages` | 64 KB (예산 있음) |
| `completed_tool_calls` | **791 KB (92%)** — 13 건 중 한 건의 `result` 가 623,999 B |

## 이건 크기 문제가 아니라 경계 문제다

첫 번째 커밋은 이 축에 바이트 예산을 걸었다. 그건 여전히 잘라먹기였다 — 바이트의 99.99% 가 한 필드에 몰려 있어서, 크기 예산은 그 필드를 담기 위해 `operation`/`input`/`disposition` 까지 포함한 **호출 전체를** 버려야 했다.

판정자는 **아직 실행되지 않은 호출**에 대해 묻는 자리에 있고, `judge.effect.md` 는 operation identity 와 complete input 을 weigh 하라고 한다. 이전 도구가 **반환한 것**을 읽으라고 한 적이 없다. 그 payload 를 렌더한 것은 다른 호출에 대한 프롬프트에 어떤 도구의 출력 전문을 넣은 것이다.

## 변경

`completed_tool_calls` 는 이제 `operation`, `input`, `disposition` 만 렌더한다.

같은 live 표본에서 **901,178 B → 7,473 B (0.83%), 모든 호출 보존**. 예산 방식은 담기 위해 호출을 버려야 했으므로, 이 변경은 판정자에게 **더 많은** 증거를 준다:

| | 렌더 크기 | 판정자가 보는 호출 |
|---|---|---|
| 원래 (payload 포함) | 791,432 B | 프롬프트 거부 |
| 예산으로 자르기 (첫 커밋) | 64 KB 이하 | 13 건 중 일부 |
| **payload 제외 (현재)** | **1,806 B** | **13 건 전부** |

`disposition` 이 completed/deferred/failed 를 이미 담고 있고, 판정이 기대는 축이 그것이다. 도구 출력을 들여다봐야 하는 판정은 다른 계약이며 `judge.effect.md` 에 먼저 명시되어야 한다.

예산은 남겼다. 다만 작동하는 제한이 아니라 **천장**이다 — 도구 `input` 자체가 커질 수 있고, #26081 이 보여준 것은 "선언된 천장이 없는 축이 결국 provider 가 거부할 때까지 자란다" 이다. 두 축이 같은 상수를 읽으므로 한쪽만 표류할 수 없다.

`judge.effect.md` 는 `completed_tool_calls` 를 **한 번도 언급하지 않았다**. 이제 필드 구성과 payload 가 없다는 사실, non-zero omitted 처리법을 명시한다.

## 검증

`test/test_keeper_run_tools_hooks.ml` 에 `completed_tool_calls_evidence` 5 케이스.

**게이트가 결함을 실제로 잡는지 확인했다.** `result` 를 렌더링에 되돌린 트리에서:

```
> [FAIL] completed_tool_calls_evidence  0  tool payloads never reach the judge
  [FAIL] completed_tool_calls_evidence  1  disposition survives for every call
  [OK]   completed_tool_calls_evidence  2  both evidence axes share one budget
  [FAIL] completed_tool_calls_evidence  3  the budget still bounds a large input
  [FAIL] completed_tool_calls_evidence  4  short call list is passed through whole
5 failures! in 0.042s. 26 tests run.
```

통과한 2 번은 상수 비교라 렌더 형태와 무관하다. 수정 후:

```
[OK] completed_tool_calls_evidence  0..4   (5/5)
1 failure! in 0.036s. 26 tests run.
```

남은 1 건은 `observation_partition` 의 docker visible path 케이스로 이 diff 가 건드리지 않은 로직이다. 로컬 sandbox 경로 해석 차이(`Expected "lib/docker.ml"` vs `Received "/home/keeper/playground/tester/repos/masc/lib/docker.ml"`)이며 CI 에서 확인한다.

## 범위 밖 (배포 config, repo 변경 아님)

라이브 복구를 위해 `~/.masc/config/` 에서:
- `hitl_auto_judge` 1 번 슬롯을 `ollama.agentworld-35b-a3b`(로컬, 262K ctx, 쿼터 무관)로. 2-4 번 ollama_cloud 는 주간 쿼터 소진 상태였고 429/402 는 `Completion_failed` 로 접혀 레인을 종결시키므로 도달 자체가 불가능했다.
- `ea17e01c89` (#27945) 가 overlay 파일명을 `oas-models-overlay.toml` → `agent-core-models-overlay.toml` 로 바꾸면서 운영자 config 마이그레이션을 제공하지 않아, 18 KB 운영 overlay 가 무시되고 8.9 KB repo seed 로 대체돼 부팅이 fail-closed 로 막혔다. 운영 내용을 새 이름으로 이관하고 seed 고유 항목 3 개를 보존했다.

이 PR 이 머지되면 번들이 glm 200K 한계 안에 충분히 들어오므로 슬롯 순서를 되돌려 판정을 로컬(건당 300-800 s)에서 glm(실측 7 s)으로 되돌리는 것을 검토할 수 있다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
