### PR TITLE
fix(runtime): admit dots in model ids

### DIFF
--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -225,7 +225,12 @@ let obsolete_top_level_namespaces = [ "system"; "routes"; "profiles" ]
 let reserved_namespaces = active_top_level_namespaces @ obsolete_top_level_namespaces
 let is_reserved name = List.mem name reserved_namespaces
 
-let valid_runtime_id_component value =
+(* Provider ids stay dot-free: a Runtime id is the literal string
+   "<provider>.<model>", so a dot inside the provider id would make that
+   compound ambiguous. Model ids admit '.' because they carry upstream API
+   model names verbatim (gpt-5.3-codex-spark, mimo-v2.5), written as quoted
+   TOML keys that Otoml already parses. *)
+let valid_runtime_id_component ~allow_dot value =
   let length = String.length value in
   length > 0
   &&
@@ -235,18 +240,23 @@ let valid_runtime_id_component value =
     else (
       match value.[index] with
       | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> loop (index + 1)
+      | '.' when allow_dot -> loop (index + 1)
       | _ -> false)
   in
   loop 0
 ;;
 
-let validate_runtime_id_component ~kind ~path value =
-  if not (valid_runtime_id_component value)
+let runtime_id_charset ~allow_dot =
+  if allow_dot then "[A-Za-z0-9._-]+" else "[A-Za-z0-9_-]+"
+;;
+
+let validate_runtime_id_component ~allow_dot ~kind ~path value =
+  if not (valid_runtime_id_component ~allow_dot value)
   then
     Error
       (error
          path
-         (Printf.sprintf "%s id must match [A-Za-z0-9_-]+" kind))
+         (Printf.sprintf "%s id must match %s" kind (runtime_id_charset ~allow_dot)))
   else if is_reserved value
   then
     Error
@@ -609,6 +619,7 @@ let parse_providers (toml : Otoml.t)
          (fun (id, tbl) ->
             match
               validate_runtime_id_component
+                ~allow_dot:false
                 ~kind:"provider"
                 ~path:("providers." ^ id)
                 id
@@ -985,6 +996,7 @@ let parse_models (toml : Otoml.t)
          (fun (id, tbl) ->
             match
               validate_runtime_id_component
+                ~allow_dot:true
                 ~kind:"model"
                 ~path:("models." ^ id)
                 id

--- a/test/test_runtime_model_temperature_toml.ml
+++ b/test/test_runtime_model_temperature_toml.ml
@@ -193,6 +193,36 @@ let test_sampling_fields_conflicting_declared_capabilities_fail_closed () =
     content
 ;;
 
+(* The [models] table keys carry upstream API model names verbatim, and those
+   names contain dots (gpt-5.3-codex-spark, mimo-v2.5). Provider ids stay
+   dot-free so the "<provider>.<model>" Runtime id remains unambiguous. *)
+let test_dotted_model_id_parses () =
+  let cfg =
+    parse_string_or_fail "[models.\"gpt-5.3-codex-spark\"]\nmax-context = 200000\n"
+  in
+  check
+    (option (float 0.0001))
+    "dotted model id parses"
+    None
+    (model_temperature cfg "gpt-5.3-codex-spark")
+;;
+
+let test_dotted_provider_id_fails_closed () =
+  parse_string_expect_error_entry
+    "provider id with a dot is rejected"
+    ~path:"providers.bad.provider"
+    ~message:"provider id must match [A-Za-z0-9_-]+"
+    "[providers.\"bad.provider\"]\nendpoint = \"http://127.0.0.1:1\"\n"
+;;
+
+let test_model_id_rejection_names_dotted_charset () =
+  parse_string_expect_error_entry
+    "model id outside the charset names the dotted accepted set"
+    ~path:"models.bad model"
+    ~message:"model id must match [A-Za-z0-9._-]+"
+    "[models.\"bad model\"]\nmax-context = 200000\n"
+;;
+
 let () =
   run "runtime_model_temperature_toml"
     [ ( "valid values"
@@ -222,6 +252,13 @@ let () =
             test_top_k_invalid_values_fail_closed
         ; test_case "sampling fields conflict with declared capabilities" `Quick
             test_sampling_fields_conflicting_declared_capabilities_fail_closed
+        ] )
+    ; ( "id charset"
+      , [ test_case "dotted model id parses" `Quick test_dotted_model_id_parses
+        ; test_case "dotted provider id fails closed" `Quick
+            test_dotted_provider_id_fails_closed
+        ; test_case "model id rejection names dotted charset" `Quick
+            test_model_id_rejection_names_dotted_charset
         ] )
     ]
 ;;


### PR DESCRIPTION
## 라이브 장애 (boot-fatal)

2026-08-10 08:46 KST, main head(`2b6d7e01c7` 이후) 바이너리로 재기동하자 서버가 운영 `runtime.toml`을 거부하고 boot에서 종료했다:

```
- models.gpt-5.3-codex-spark: model id must match [A-Za-z0-9_-]+
- models.mimo-v2.5-pro: model id must match [A-Za-z0-9_-]+
- models.mimo-v2.5: model id must match [A-Za-z0-9_-]+
```

운영 config는 이 키들을 quoted TOML 키로 이미 사용 중이고(`[models."gpt-5.3-codex-spark"]`), 직전 라이브 바이너리(#27823, `d44b699f5e`)는 같은 config로 정상 부팅했다. 검증기는 #27763(`011fb99a3d`)에서 테스트 0건으로 도입됐다 — 도입 근거는 dashboard 편집기의 라인 파서 가정(`runtime-toml-config.ts:725`)인데, 편집기 도구의 한계가 백엔드 boot-fatal 법칙으로 승격된 방향 오류다.

## 수정

- model id 문자셋에 `.` 허용 (`~allow_dot:true`) — 모델 id는 업스트림 API 모델명을 그대로 담는다
- provider id는 dot-free 유지 (`~allow_dot:false`) — Runtime id `"<provider>.<model>"` 문자열의 비모호성 보존
- 거부 메시지가 kind별 실제 accepted set을 명시 (`[A-Za-z0-9._-]+` vs `[A-Za-z0-9_-]+`)

## 검증 (mutation 프로토콜)

- 테스트 선작성 → 미수정 lib에서 실행: `dotted model id parses` **FAIL** (라이브 boot 에러와 동일 메시지 재현), `model id rejection names dotted charset` **FAIL** → lib 수정 후 **17/17 OK**
- `dotted provider id fails closed`는 수정 전후 모두 OK (provider 불변식 고정)
- hotfix 바이너리로 라이브 서버 복구 완료 (같은 config, boot 통과)

## 후속

- dashboard 편집기는 quoted TOML 키(`[models."a.b"]`)를 파싱/기록하지 못한다 — 편집기 한계는 별도 이슈로 추적, 백엔드가 validity SSOT(superset)이고 편집기는 표현 불가 항목을 보존해야 한다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
