### PR TITLE
fix(runtime): admit dotted model ids, reject only path components

### DIFF
--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -225,16 +225,32 @@ let obsolete_top_level_namespaces = [ "system"; "routes"; "profiles" ]
 let reserved_namespaces = active_top_level_namespaces @ obsolete_top_level_namespaces
 let is_reserved name = List.mem name reserved_namespaces
 
+(* Model and provider ids routinely carry a dotted version segment:
+   [gpt-5.3-codex-spark], [mimo-v2.5-pro], [claude-3.5-sonnet]. runtime.toml
+   writes them as quoted keys — [\[models."gpt-5.3-codex-spark"\]] — so the dot
+   is unambiguous to the TOML parser and never nests a table.
+
+   Excluding it made a live config unbootable on 2026-08-09 (#27957): the
+   workspace had been serving those three ids, and startup then refused the
+   same file with "model id must match [A-Za-z0-9_-]+", stopping all eight
+   keepers before readiness.
+
+   ["."] and [".."] stay rejected, and so does a leading dot: an id reaches
+   path construction elsewhere in the runtime, and those are the traversal
+   forms. A dot inside the identifier is not one. *)
 let valid_runtime_id_component value =
   let length = String.length value in
   length > 0
+  && (not (String.equal value "."))
+  && (not (String.equal value ".."))
+  && value.[0] <> '.'
   &&
   let rec loop index =
     if index = length
     then true
     else (
       match value.[index] with
-      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> loop (index + 1)
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' | '.' -> loop (index + 1)
       | _ -> false)
   in
   loop 0
@@ -246,7 +262,10 @@ let validate_runtime_id_component ~kind ~path value =
     Error
       (error
          path
-         (Printf.sprintf "%s id must match [A-Za-z0-9_-]+" kind))
+         (Printf.sprintf
+            "%s id must match [A-Za-z0-9_.-]+ and must not be a path component \
+             (., .., or a leading dot)"
+            kind))
   else if is_reserved value
   then
     Error

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -772,6 +772,43 @@ let test_exact_output_lane_rejects_unknown_key () =
          errors)
   | Ok _ -> fail "unknown exact-output lane key must fail config parsing"
 
+(* Live regression (#27957): the workspace config declares
+   [\[models."gpt-5.3-codex-spark"\]] and two mimo ids with the same shape. A
+   character class without '.' rejected all three, and startup refused the file
+   it had been serving — every keeper stopped before readiness. The key is
+   quoted, so the dot never nests a table. *)
+let test_dotted_model_id_parses () =
+  let config =
+    "[models.\"gpt-5.3-codex-spark\"]\n\
+     api-name = \"gpt-5.3-codex-spark\"\n\
+     max-context = 131072\n"
+  in
+  match Runtime_toml.parse_string config with
+  | Ok _ -> ()
+  | Error errors ->
+    failf
+      "dotted model id must parse; got: %s"
+      (String.concat "; "
+         (List.map
+            (fun (error : Runtime_toml.parse_error) ->
+               error.path ^ ": " ^ error.message)
+            errors))
+
+(* A dot inside an identifier is not a path component. These two forms are, and
+   the id reaches path construction elsewhere in the runtime. *)
+let test_path_traversal_model_ids_are_rejected () =
+  List.iter
+    (fun id ->
+       let config =
+         Printf.sprintf
+           "[models.%S]\napi-name = \"sample\"\nmax-context = 1024\n"
+           id
+       in
+       match Runtime_toml.parse_string config with
+       | Ok _ -> failf "model id %S must fail config parsing" id
+       | Error _ -> ())
+    [ "."; ".."; ".hidden" ]
+
 let test_retired_native_streaming_capability_is_rejected () =
   let config =
     "[models.sample]\n\
@@ -3373,6 +3410,10 @@ let () =
             test_exact_output_lane_rejects_unknown_key;
           test_case "retired native-streaming capability is rejected" `Quick
             test_retired_native_streaming_capability_is_rejected;
+          test_case "dotted model id parses" `Quick
+            test_dotted_model_id_parses;
+          test_case "path-traversal model ids are rejected" `Quick
+            test_path_traversal_model_ids_are_rejected;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
           test_case


### PR DESCRIPTION
Closes #27957.

## 라이브 장애

2026-08-09 23:46:30Z, 부팅이 readiness 전에 죽고 포트 8935 가 닫힌 채로 남았다. keeper 8대가 같은 분에 전부 멈췄다.

```
[FATAL] Critical startup failed before readiness; refusing partial BasePath ownership:
Runtime.init_default_degraded failed: runtime config parse failed
(/Users/dancer/me/.masc/config/runtime.toml): 3 error(s):
  - models.gpt-5.3-codex-spark: model id must match [A-Za-z0-9_-]+
  - models.mimo-v2.5-pro:       model id must match [A-Za-z0-9_-]+
  - models.mimo-v2.5:           model id must match [A-Za-z0-9_-]+
```

## 원인

`validate_runtime_id_component` 의 문자 집합 `[A-Za-z0-9_-]` 이 점을 배제한다. 모델 id 에는 버전 구간이 점으로 들어가는 게 보통이고(`gpt-5.3-codex-spark`, `mimo-v2.5-pro`, `claude-3.5-sonnet`), runtime.toml 은 이를 **따옴표 키**로 쓴다:

```toml
[models."gpt-5.3-codex-spark"]
api-name = "gpt-5.3-codex-spark"
```

따옴표 안의 점은 한 키 안의 문자이지 테이블 중첩이 아니다. 파서는 이미 `gpt-5.3-codex-spark` 를 단일 id 로 넘겼고 — 오류 경로가 `models.gpt-5.3-codex-spark` 인 것이 그 증거다 — 검증기만 거부했다.

## 변경

점을 허용하고, **경로 성분 형태만** 계속 거부한다: `"."`, `".."`, 선행 점. id 가 런타임 다른 곳에서 경로 구성에 도달하므로 이 셋은 막아야 하지만, 식별자 내부의 점은 경로 성분이 아니다. reserved-namespace 검사는 그대로다.

오류 문구도 실제 규칙을 말하도록 고쳤다 (`[A-Za-z0-9_.-]+ and must not be a path component`).

## 검증 — 실파일로 확인했다

```ocaml
Runtime_toml.parse_file "~/me/.masc/config/runtime.toml"  →  Ok
```

**파일 부재 분기를 실패로 뒤집은 상태에서 실행**했다. 즉 "파일이 없어서 조용히 통과" 가 통과로 위장할 수 없는 조건에서 파싱에 성공했다.

수정 전 같은 파일은 3 error 로 거부된다 (위 FATAL 로그).

## 테스트

`test_runtime_config_validity` 에 2건 추가. 이 스위트는 **CI 가 이름으로 지정해 실행하는** 몇 안 되는 것 중 하나라(`@test/runtest-test_runtime_config_validity`, ci.yml:858) 컴파일만 되고 마는 상태가 아니다.

| 테스트 | 입력 | 기대 |
|---|---|---|
| `dotted model id parses` | `[models."gpt-5.3-codex-spark"]` | Ok |
| `path-traversal model ids are rejected` | `"."`, `".."`, `".hidden"` | Error |

전체: **64/64 통과**.

## 부수 관찰 (이 PR 범위 밖)

**1. 같은 부팅이 같은 파일을 두 번, 다른 규칙으로 읽는다.** FATAL 직전에 이미 성공 로그가 있다:

```
INFO  runtime.toml: applied 3 override(s)                 ← server_runtime_bootstrap.ml:495 수용
INFO  keeper stream idle timeout resolved: 120.0s (source: toml)
ERROR [FATAL] Runtime.init_default_degraded failed        ← server_runtime_bootstrap.ml:869 거부
```

이 PR 은 문자 집합을 고칠 뿐 두 경로의 규칙 불일치는 남긴다. 다음 검증 항목이 추가될 때 같은 형태가 재발할 수 있다. #27957 에 기록했다.

**2. 라이브 설정에 따옴표 없는 점 키가 있다.**

```toml
[models.qwen3.6-35b-uncensored.capabilities]
```

이건 TOML 이 `models → qwen3 → 6-35b-uncensored → capabilities` 로 중첩한다. 즉 `qwen3.6-35b-uncensored` 라는 모델을 의도했다면 지금 그렇게 읽히지 않는다. 별개의 설정 결함이며 이 PR 이 다루지 않는다.

RFC-WAIVED: 변경 범위가 `lib/runtime/runtime_toml.ml` 의 식별자 문자 집합 한 곳과 그 테스트로, credential/identity/operator control/keeper sandbox/hooks/workflow 문서 어디에도 해당하지 않음.
