### PR TITLE
fix(runtime): localize unknown exact-output slots

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1080,8 +1080,13 @@ let init_default ~config_path =
   set_loaded ~config_path loaded;
   Ok ()
 
-let publish_exact_output_registry ~lanes resolver_snapshot =
-  match Runtime_exact_output_registry.publish ~lanes resolver_snapshot with
+let publish_exact_output_registry ?required_lane_ids ~lanes resolver_snapshot =
+  match
+    Runtime_exact_output_registry.publish
+      ?required_lane_ids
+      ~lanes
+      resolver_snapshot
+  with
   | Ok registry -> Ok registry
   | Error error ->
     Error (Runtime_exact_output_registry.publication_error_to_string error)

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -152,12 +152,13 @@ val init_default : config_path:string -> (unit, string) result
     with arbitrary-model runtime fixtures. *)
 
 val publish_exact_output_registry :
+  ?required_lane_ids:string list ->
   lanes:Runtime_schema.exact_output_lane_decl list ->
   Agent_core.Exact_output.resolver_snapshot ->
   (Runtime_exact_output_registry.t, string) result
 (** Publish one immutable AGENT_CORE resolver-and-lane snapshot and return that exact
-    publication. Startup callers validate mandatory lanes against this value,
-    so validation cannot observe a later global generation. *)
+    publication. [required_lane_ids] must each retain an admitted slot; that
+    validation happens before the global publication changes. *)
 
 val init_default_strict : config_path:string -> (unit, string) result
 (** Fail-closed startup entry point: {!init_default} PLUS the AGENT_CORE

--- a/lib/runtime/runtime_exact_output_registry.ml
+++ b/lib/runtime/runtime_exact_output_registry.ml
@@ -12,9 +12,19 @@ type admitted_lane =
   ; slots : admitted_slot list
   }
 
+type rejected_slot =
+  { lane_id : string
+  ; position : int
+  ; slot_id : string
+  ; target_ref : string
+  }
+
 type t =
   { resolver_snapshot : Exact_output.resolver_snapshot
+  ; declared_lanes : Runtime_schema.exact_output_lane_decl list
   ; exact_output_lanes : admitted_lane list
+  ; rejected_slots : rejected_slot list
+  ; required_lane_ids : string list
   ; generation : int64
   }
 
@@ -47,12 +57,7 @@ type publication_error =
       ; slot_id : string
       ; cause : Exact_output.target_ref_error
       }
-  | Unknown_lane_slot of
-      { lane_id : string
-      ; position : int
-      ; slot_id : string
-      ; target_ref : string
-      }
+  | Required_lane_unavailable of { lane_id : string }
  
 type selected_slot =
   { slot_id : string
@@ -90,8 +95,9 @@ let ( let* ) = Result.bind
 
 let admit_lane_slots resolver_snapshot admitted_by_id
     (lane : Runtime_schema.exact_output_lane_decl) =
-  let rec loop position seen admitted_by_id admitted_slots = function
-    | [] -> Ok (List.rev admitted_slots, admitted_by_id)
+  let rec loop position seen admitted_by_id admitted_slots rejected_slots = function
+    | [] ->
+      Ok (List.rev admitted_slots, admitted_by_id, List.rev rejected_slots)
     | slot_id :: rest ->
       if String.equal (String.trim slot_id) ""
       then Error (Blank_lane_slot { lane_id = lane.id; position })
@@ -99,46 +105,54 @@ let admit_lane_slots resolver_snapshot admitted_by_id
       then Error (Duplicate_lane_slot { lane_id = lane.id; position; slot_id })
       else
         let admitted = String_map.find_opt slot_id admitted_by_id in
-        let* admitted_target, admitted_by_id =
-          match admitted with
-          | Some admitted_target -> Ok (admitted_target, admitted_by_id)
-          | None ->
-            (match Exact_output.admit_target_ref resolver_snapshot slot_id with
-             | Error (Exact_output.Target_ref_rejected cause) ->
-               Error
-                 (Invalid_lane_slot
-                    { lane_id = lane.id; position; slot_id; cause })
-             | Error (Exact_output.Target_not_in_catalog target_ref) ->
-               Error
-                 (Unknown_lane_slot
-                    { lane_id = lane.id; position; slot_id; target_ref })
-             | Ok admitted_target ->
-               Ok
-                 ( admitted_target
-                 , String_map.add slot_id admitted_target admitted_by_id ))
-        in
-        loop
-          (position + 1)
-          (String_set.add slot_id seen)
-          admitted_by_id
-          (({ slot_id; admitted_target } : admitted_slot) :: admitted_slots)
-          rest
+        (match admitted with
+         | Some admitted_target ->
+           loop
+             (position + 1)
+             (String_set.add slot_id seen)
+             admitted_by_id
+             (({ slot_id; admitted_target } : admitted_slot) :: admitted_slots)
+             rejected_slots
+             rest
+         | None ->
+           (match Exact_output.admit_target_ref resolver_snapshot slot_id with
+            | Error (Exact_output.Target_ref_rejected cause) ->
+              Error
+                (Invalid_lane_slot
+                   { lane_id = lane.id; position; slot_id; cause })
+            | Error (Exact_output.Target_not_in_catalog target_ref) ->
+              loop
+                (position + 1)
+                (String_set.add slot_id seen)
+                admitted_by_id
+                admitted_slots
+                ({ lane_id = lane.id; position; slot_id; target_ref }
+                 :: rejected_slots)
+                rest
+            | Ok admitted_target ->
+              loop
+                (position + 1)
+                (String_set.add slot_id seen)
+                (String_map.add slot_id admitted_target admitted_by_id)
+                (({ slot_id; admitted_target } : admitted_slot) :: admitted_slots)
+                rejected_slots
+                rest))
   in
   match lane.slot_ids with
   | [] -> Error (Empty_lane { lane_id = lane.id })
-  | slot_ids -> loop 1 String_set.empty admitted_by_id [] slot_ids
+  | slot_ids -> loop 1 String_set.empty admitted_by_id [] [] slot_ids
 ;;
 
 let admit_lanes ~admitted_by_id resolver_snapshot lanes =
-  let rec loop position seen admitted_by_id admitted_lanes = function
-    | [] -> Ok (List.rev admitted_lanes)
+  let rec loop position seen admitted_by_id admitted_lanes rejected_slots = function
+    | [] -> Ok (List.rev admitted_lanes, List.rev rejected_slots)
     | (lane : Runtime_schema.exact_output_lane_decl) :: rest ->
       if String.equal (String.trim lane.id) ""
       then Error (Blank_lane_id { position })
       else if String_set.mem lane.id seen
       then Error (Duplicate_lane_id { position; lane_id = lane.id })
       else
-        let* slots, admitted_by_id =
+        let* slots, admitted_by_id, lane_rejected_slots =
           admit_lane_slots resolver_snapshot admitted_by_id lane
         in
         loop
@@ -146,28 +160,44 @@ let admit_lanes ~admitted_by_id resolver_snapshot lanes =
           (String_set.add lane.id seen)
           admitted_by_id
           ({ id = lane.id; slots } :: admitted_lanes)
+          (List.rev_append lane_rejected_slots rejected_slots)
           rest
   in
-  loop 1 String_set.empty admitted_by_id [] lanes
+  loop 1 String_set.empty admitted_by_id [] [] lanes
 ;;
 
-let rec same_slot_ids (admitted_slots : admitted_slot list) declared_slot_ids =
-  match admitted_slots, declared_slot_ids with
+let rec same_slot_ids left_slot_ids right_slot_ids =
+  match left_slot_ids, right_slot_ids with
   | [], [] -> true
-  | admitted :: admitted_rest, declared :: declared_rest ->
-    String.equal admitted.slot_id declared
-    && same_slot_ids admitted_rest declared_rest
+  | left :: left_rest, right :: right_rest ->
+    String.equal left right && same_slot_ids left_rest right_rest
   | [], _ :: _ | _ :: _, [] -> false
 ;;
 
-let rec same_lane_declarations admitted_lanes declared_lanes =
-  match admitted_lanes, declared_lanes with
+let rec same_lane_declarations left_lanes right_lanes =
+  match left_lanes, right_lanes with
   | [], [] -> true
-  | admitted :: admitted_rest, declared :: declared_rest ->
-    String.equal admitted.id declared.Runtime_schema.id
-    && same_slot_ids admitted.slots declared.slot_ids
-    && same_lane_declarations admitted_rest declared_rest
+  | left :: left_rest, right :: right_rest ->
+    String.equal left.Runtime_schema.id right.Runtime_schema.id
+    && same_slot_ids left.slot_ids right.slot_ids
+    && same_lane_declarations left_rest right_rest
   | [], _ :: _ | _ :: _, [] -> false
+;;
+
+let validate_required_lanes required_lane_ids admitted_lanes =
+  let rec loop = function
+    | [] -> Ok ()
+    | lane_id :: rest ->
+      (match
+         List.find_opt
+           (fun (lane : admitted_lane) -> String.equal lane.id lane_id)
+           admitted_lanes
+       with
+       | Some { slots = _ :: _; _ } -> loop rest
+       | Some { slots = []; _ } | None ->
+         Error (Required_lane_unavailable { lane_id }))
+  in
+  loop required_lane_ids
 ;;
 
 let admitted_by_id admitted_lanes =
@@ -195,18 +225,27 @@ let next_generation = function
     else Ok (Int64.succ registry.generation)
 ;;
 
-let publish ~lanes resolver_snapshot =
+let publish ?(required_lane_ids = []) ~lanes resolver_snapshot =
   with_publication_lock
   @@ fun () ->
   match !active_reservation with
   | Some _ -> Error Publication_busy
   | None ->
     let previous = Atomic.get published in
-    let* exact_output_lanes =
+    let* exact_output_lanes, rejected_slots =
       admit_lanes ~admitted_by_id:String_map.empty resolver_snapshot lanes
     in
+    let* () = validate_required_lanes required_lane_ids exact_output_lanes in
     let* generation = next_generation previous in
-    let registry = { resolver_snapshot; exact_output_lanes; generation } in
+    let registry =
+      { resolver_snapshot
+      ; declared_lanes = lanes
+      ; exact_output_lanes
+      ; rejected_slots
+      ; required_lane_ids
+      ; generation
+      }
+    in
     Atomic.set published (Some registry);
     Ok registry
 ;;
@@ -234,14 +273,17 @@ let prepare_replacement ~lanes =
   | None, [] -> Ok { base; candidate = None }
   | None, _ :: _ -> Error Registry_not_published
   | Some previous, _ ->
-    if same_lane_declarations previous.exact_output_lanes lanes
+    if same_lane_declarations previous.declared_lanes lanes
     then Ok { base; candidate = Some previous }
     else (
-      let* exact_output_lanes =
+      let* exact_output_lanes, rejected_slots =
         admit_lanes
           ~admitted_by_id:(admitted_by_id previous.exact_output_lanes)
           previous.resolver_snapshot
           lanes
+      in
+      let* () =
+        validate_required_lanes previous.required_lane_ids exact_output_lanes
       in
       let* generation = next_generation (Some previous) in
       Ok
@@ -249,7 +291,10 @@ let prepare_replacement ~lanes =
         ; candidate =
             Some
               { resolver_snapshot = previous.resolver_snapshot
+              ; declared_lanes = lanes
               ; exact_output_lanes
+              ; rejected_slots
+              ; required_lane_ids = previous.required_lane_ids
               ; generation
               }
         })
@@ -335,6 +380,7 @@ let abort_replacement reservation =
   | Some _ | None -> Error Reservation_inactive
 ;;
 let generation registry = registry.generation
+let rejected_slots registry = registry.rejected_slots
 
 let resolve_lane registry ~lane_id =
   match
@@ -397,13 +443,10 @@ let publication_error_to_string = function
       position
       slot_id
       detail
-  | Unknown_lane_slot { lane_id; position; slot_id; target_ref } ->
+  | Required_lane_unavailable { lane_id } ->
     Printf.sprintf
-      "exact-output lane %S slot %d (%S): target %S is not in the frozen catalog"
+      "required exact-output lane %S has no admitted target in the frozen catalog"
       lane_id
-      position
-      slot_id
-      target_ref
 ;;
 
 let lane_resolution_error_to_string = function

--- a/lib/runtime/runtime_exact_output_registry.mli
+++ b/lib/runtime/runtime_exact_output_registry.mli
@@ -30,12 +30,14 @@ type publication_error =
       ; slot_id : string
       ; cause : Agent_core.Exact_output.target_ref_error
       }
-  | Unknown_lane_slot of
-      { lane_id : string
-      ; position : int
-      ; slot_id : string
-      ; target_ref : string
-      }
+  | Required_lane_unavailable of { lane_id : string }
+
+type rejected_slot =
+  { lane_id : string
+  ; position : int
+  ; slot_id : string
+  ; target_ref : string
+  }
 
 type prepared_replacement
 
@@ -56,7 +58,8 @@ type lane_resolution_error =
   | No_admitted_lane_slots of { lane_id : string }
 
 val publish
-  :  lanes:Runtime_schema.exact_output_lane_decl list
+  :  ?required_lane_ids:string list
+  -> lanes:Runtime_schema.exact_output_lane_decl list
   -> Agent_core.Exact_output.resolver_snapshot
   -> (t, publication_error) result
 (** Validate and atomically publish one complete resolver-and-lane registry.
@@ -64,11 +67,13 @@ val publish
     monotonically. Invalid declarations are rejected before the Atomic is
     changed.
 
-    Every declaration string is converted to an immutable AGENT_CORE admitted-target
-    handle before publication. Credential presence is deliberately excluded
-    from publication admission. Config-level errors — blank or duplicate ids,
-    malformed or unknown target refs — remain fatal at publish. Returns
-    [Publication_busy] while a replacement reservation is active. *)
+    Every declaration string present in the frozen catalog is converted to an
+    immutable AGENT_CORE admitted-target handle before publication. Credential
+    presence is deliberately excluded from publication admission. Unknown
+    catalog targets are retained as typed [rejected_slot] observations and do
+    not suppress admitted siblings. Blank or duplicate ids and malformed target
+    refs remain fatal. A required lane must retain at least one admitted slot.
+    Returns [Publication_busy] while a replacement reservation is active. *)
 
 val prepare_replacement
   :  lanes:Runtime_schema.exact_output_lane_decl list
@@ -97,6 +102,7 @@ val current : unit -> (t, publication_error) result
     [Registry_not_published] before bootstrap has published one. *)
 
 val generation : t -> int64
+val rejected_slots : t -> rejected_slot list
 
 val resolve_lane : t -> lane_id:string -> (resolved_lane, lane_resolution_error) result
 (** Acquire one lane exclusively from the immutable admitted handles retained

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -255,34 +255,32 @@ let require_explicit_mandatory_exact_output_lanes ~config_path lanes =
     mandatory_exact_output_lane_ids
 ;;
 
-let require_usable_mandatory_exact_output_lanes ~config_path registry =
+let warn_rejected_exact_output_slots registry =
   List.iter
-    (fun lane_id ->
-       match Runtime_exact_output_registry.resolve_lane registry ~lane_id with
-       | Ok { selected_slots = _ :: _; _ } -> ()
-       | Ok { selected_slots = []; _ } ->
-         raise
-           (Env_config_core.Config_error
-              (Printf.sprintf
-                 "exact-output registry: mandatory lane %S in %s resolved \
-                  without a usable admitted slot; make at least one configured \
-                  target credential available and restart; no runtime, \
-                  environment, or migration fallback is applied"
-                 lane_id
-                 config_path))
-       | Error error ->
-         raise
-           (Env_config_core.Config_error
-              (Printf.sprintf
-                 "exact-output registry: mandatory lane %S in %s has no \
-                  credential-usable admitted slot: %s; make at least one \
-                  configured target credential available and restart; no \
-                  runtime, environment, or migration fallback is applied"
-                 lane_id
-                 config_path
-                 (Runtime_exact_output_registry.lane_resolution_error_to_string
-                    error))))
-    mandatory_exact_output_lane_ids
+    (fun (slot : Runtime_exact_output_registry.rejected_slot) ->
+       Log.Server.warn
+         "exact_output: lane %S slot %d (%S) ignored because target %S is absent from the frozen catalog; remaining admitted slots stay active"
+         slot.lane_id
+         slot.position
+         slot.slot_id
+         slot.target_ref)
+    (Runtime_exact_output_registry.rejected_slots registry)
+;;
+
+let warn_optional_exact_output_lane registry ~lane_id ~feature =
+  match Runtime_exact_output_registry.resolve_lane registry ~lane_id with
+  | Ok { selected_slots = _ :: _; _ } -> ()
+  | Ok { selected_slots = []; _ }
+  | Error (Runtime_exact_output_registry.No_admitted_lane_slots _) ->
+    Log.Server.warn
+      "exact_output: %s is degraded because lane %S has no admitted target in the frozen catalog"
+      feature
+      lane_id
+  | Error (Runtime_exact_output_registry.Exact_lane_unconfigured _) ->
+    Log.Server.warn
+      "exact_output: %s is degraded until [runtime.exact_output_lanes.%s] is configured with AGENT_CORE target refs"
+      feature
+      lane_id
 ;;
 
 let configure_exact_output_registry ?config_root () =
@@ -320,39 +318,31 @@ let configure_exact_output_registry ?config_root () =
          ("exact-output resolver snapshot: "
           ^ exact_output_snapshot_error_to_string error))
   | Ok resolver_snapshot ->
-    (match Runtime.publish_exact_output_registry ~lanes resolver_snapshot with
+    (match
+       Runtime.publish_exact_output_registry
+         ~required_lane_ids:mandatory_exact_output_lane_ids
+         ~lanes
+         resolver_snapshot
+     with
      | Error detail ->
        raise
          (Env_config_core.Config_error
             ("exact-output resolver-and-lane registry: " ^ detail))
      | Ok registry ->
-       (* [resolve_lane] is the exact credential-availability path used by
-          execution. Validate the immutable value returned by atomic publication
-          before Keeper persistence recovery or any worker can be produced. *)
-       require_usable_mandatory_exact_output_lanes ~config_path registry;
+       warn_rejected_exact_output_slots registry;
        let generation = Runtime_exact_output_registry.generation registry in
        Log.Misc.info
          "exact_output: immutable resolver-and-lane registry generation %Ld published%s"
          generation
          catalog_description;
-       if
-         not
-           (List.exists
-              (fun (lane : Runtime_schema.exact_output_lane_decl) ->
-                 String.equal lane.id "compaction_exact")
-              lanes)
-       then
-         Log.Server.warn
-           "exact_output: compaction is degraded until [runtime.exact_output_lanes.compaction_exact] is configured with AGENT_CORE target refs";
-       if
-         not
-           (List.exists
-              (fun (lane : Runtime_schema.exact_output_lane_decl) ->
-                 String.equal lane.id "librarian_exact")
-              lanes)
-       then
-         Log.Server.warn
-           "exact_output: librarian is degraded until [runtime.exact_output_lanes.librarian_exact] is configured with AGENT_CORE target refs")
+       warn_optional_exact_output_lane
+         registry
+         ~lane_id:"compaction_exact"
+         ~feature:"compaction";
+       warn_optional_exact_output_lane
+         registry
+         ~lane_id:"librarian_exact"
+         ~feature:"librarian")
 ;;
 
 let install_domain_pool_references domain_pool =

--- a/test/test_exact_output_catalog_precedence.ml
+++ b/test/test_exact_output_catalog_precedence.ml
@@ -414,6 +414,83 @@ let test_registry_preserves_admitted_slots_without_resolving_credentials () =
     registry
 ;;
 
+let test_unknown_slots_degrade_locally_and_preserve_required_lane_atomicity () =
+  let snapshot =
+    load_control_snapshot
+      (Exact_output.Full_replacement
+         { source = "unknown-slot-local-degradation"
+         ; contents = replacement_catalog
+         })
+  in
+  let optional_lane = "optional-exact" in
+  let unknown_target = "not-in-frozen-catalog" in
+  let optional_registry =
+    match
+      Registry.publish
+        ~lanes:[ { id = optional_lane; slot_ids = [ unknown_target ] } ]
+        snapshot
+    with
+    | Ok registry -> registry
+    | Error error ->
+      Alcotest.failf
+        "unknown optional slot must not block publication: %s"
+        (Registry.publication_error_to_string error)
+  in
+  (match Registry.resolve_lane optional_registry ~lane_id:optional_lane with
+   | Error (Registry.No_admitted_lane_slots { lane_id }) ->
+     Alcotest.(check string) "degraded optional lane" optional_lane lane_id
+   | Error error ->
+     Alcotest.failf
+       "unknown optional slot returned the wrong typed result: %s"
+       (Registry.lane_resolution_error_to_string error)
+   | Ok _ -> Alcotest.fail "unknown optional lane must have no selected slots");
+  (match Registry.rejected_slots optional_registry with
+   | [ rejected ] ->
+     Alcotest.(check string) "rejected optional slot" unknown_target rejected.slot_id
+   | rejected ->
+     Alcotest.failf
+       "expected one rejected optional slot, got %d"
+       (List.length rejected));
+  let required_lane = "required-exact" in
+  let stable_registry =
+    match
+      Registry.publish
+        ~required_lane_ids:[ required_lane ]
+        ~lanes:[ { id = required_lane; slot_ids = [ replacement_target ] } ]
+        snapshot
+    with
+    | Ok registry -> registry
+    | Error error ->
+      Alcotest.failf
+        "required lane fixture failed to publish: %s"
+        (Registry.publication_error_to_string error)
+  in
+  let stable_generation = Registry.generation stable_registry in
+  (match
+     Registry.publish
+       ~required_lane_ids:[ required_lane ]
+       ~lanes:[ { id = required_lane; slot_ids = [ unknown_target ] } ]
+       snapshot
+   with
+   | Error (Registry.Required_lane_unavailable { lane_id }) ->
+     Alcotest.(check string) "unavailable required lane" required_lane lane_id
+   | Error error ->
+     Alcotest.failf
+       "unknown required slot returned the wrong typed error: %s"
+       (Registry.publication_error_to_string error)
+   | Ok _ -> Alcotest.fail "unknown required slot must block publication");
+  match Registry.current () with
+  | Ok current ->
+    Alcotest.(check int64)
+      "failed required publication preserves the prior generation"
+      stable_generation
+      (Registry.generation current)
+  | Error error ->
+    Alcotest.failf
+      "failed required publication lost the prior registry: %s"
+      (Registry.publication_error_to_string error)
+;;
+
 let test_hitl_auto_judge_lane_bootstrap ~clock ~mono_clock ~net ~proc_mgr ~fs () =
   with_temp_dir "exact-output-hitl-lane-bootstrap" @@ fun root ->
   let config_root = Filename.concat root "config" in
@@ -484,12 +561,39 @@ let test_hitl_auto_judge_lane_bootstrap ~clock ~mono_clock ~net ~proc_mgr ~fs ()
    | Ok _ -> Alcotest.fail "missing HITL exact lane was synthesized");
   write_file runtime_path (runtime_toml replacement_target);
   create_server_state ();
-let default_registry = current_registry "default HITL lane bootstrap" in
-require_lane_slots
-  "explicit default HITL lane keeps its configured slot"
+  let default_registry = current_registry "default HITL lane bootstrap" in
+  require_lane_slots
+    "explicit default HITL lane keeps its configured slot"
     ~lane_id:"hitl_auto_judge"
-~expected:[ replacement_target ]
-default_registry;
+    ~expected:[ replacement_target ]
+    default_registry;
+  write_file
+    runtime_path
+    (runtime_toml
+       ~compaction_slots:[ overlay_target; replacement_target ]
+       replacement_target);
+  create_server_state ();
+  let degraded_optional_registry =
+    current_registry "unknown optional exact-output slot bootstrap"
+  in
+  require_lane_slots
+    "unknown optional slot is excluded while admitted fallback remains"
+    ~lane_id:"compaction_exact"
+    ~expected:[ replacement_target ]
+    degraded_optional_registry;
+  (match Registry.rejected_slots degraded_optional_registry with
+   | [ rejected ] ->
+     Alcotest.(check string)
+       "rejected lane"
+       "compaction_exact"
+       rejected.lane_id;
+     Alcotest.(check int) "rejected position" 1 rejected.position;
+     Alcotest.(check string) "rejected slot" overlay_target rejected.slot_id;
+     Alcotest.(check string) "rejected target" overlay_target rejected.target_ref
+   | rejected ->
+     Alcotest.failf
+       "expected one typed rejected slot, got %d"
+       (List.length rejected));
   let runtime_lane_candidates =
     [ replacement_runtime_target
     ; replacement_secondary_runtime_target
@@ -694,6 +798,10 @@ let () =
             "registry preserves admitted slots without resolving credentials"
             `Quick
             test_registry_preserves_admitted_slots_without_resolving_credentials
+        ; Alcotest.test_case
+            "unknown slots degrade locally while required lanes stay atomic"
+            `Quick
+            test_unknown_slots_degrade_locally_and_preserve_required_lane_atomicity
         ; Alcotest.test_case
             "closed registry transaction publishes final generation and lane"
             `Quick

--- a/test/test_exact_output_catalog_precedence_fixture.ml
+++ b/test/test_exact_output_catalog_precedence_fixture.ml
@@ -122,6 +122,7 @@ let replacement_catalog =
 
 let runtime_toml
       ?hitl_slots
+      ?compaction_slots
       ?runtime_lane_candidates
       ?(include_board_attention = true)
       ?(include_hitl_auto_judge = true)
@@ -154,6 +155,7 @@ let runtime_toml
     else ""
   in
   let base =
+    let compaction_slots = Option.value ~default:[ lane_target ] compaction_slots in
     (Printf.sprintf
        {|[providers.replacement_provider]
 protocol = "openai-compatible-http"
@@ -186,10 +188,10 @@ default = "replacement_provider.replacement"
 %s
 
 [runtime.exact_output_lanes.compaction_exact]
-slots = [%S]
+slots = [%s]
 |}
        runtime_route
-       lane_target)
+       (compaction_slots |> List.map (Printf.sprintf "%S") |> String.concat ", "))
     ^ board_attention_lane
     ^ runtime_lane
     ^ hitl_auto_judge_lane


### PR DESCRIPTION
## Summary

- treat an exact-output target absent from the frozen catalog as a typed rejected slot instead of rejecting the whole registry
- preserve declared slot order for admitted siblings and expose rejected slot identity for startup warnings
- keep HITL and Board attention mandatory: publication fails atomically when a required lane has no admitted target
- degrade optional compaction and librarian lanes with warnings when no usable slot remains

## Product impact

A stale or temporarily mismatched optional exact-output slot no longer prevents MASC from becoming ready. Valid siblings remain available. Malformed declarations and unavailable mandatory lanes still fail before registry publication.

## Evidence

- reproduced the reported boundary with an unknown first compaction slot and an admitted second slot
- `scripts/dune-local.sh build test/test_exact_output_catalog_precedence.exe`
- `./_build/default/test/test_exact_output_catalog_precedence.exe` — 9/9 passed
- `git diff --check`

## Direct evidence

schema_version: 1
direct_ratio: 3/3
provenance: direct

- direct source inspection of registry admission and server bootstrap
- direct focused build and Alcotest execution at commit `e0401881e5`
- direct read-only comparison of live `runtime.toml` and `agent-core-models-overlay.toml`

## Review evidence

Self-review checked the failure boundary, atomic publication ordering, replacement behavior, and typed observability. No compatibility path, fallback target synthesis, or string-matched recovery was added.

## Linked issue

None — fixes the live startup failure reported directly during runtime operation.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/exact-output-unknown-slot-degrade-20260810` → `main` · 1 commit(s) · synced 2026-08-10T00:27:31Z

| sha | subject | date |
|---|---|---|
| `e0401881e` | fix(runtime): localize unknown exact-output slots | 2026-08-10 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->