### PR TITLE
fix(agent-core): exclude unresolvable targets instead of failing the snapshot

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -168,18 +168,28 @@ let exact_output_snapshot_error_to_string = function
       detail
   | Exact_output.Catalog_collision collision ->
     exact_output_collision_to_string collision
-  | Exact_output.Target_binding_missing { target_ref; component } ->
+;;
+
+let exact_output_exclusion_reason_to_string = function
+  | Exact_output.Excluded_binding_missing { component } ->
     Printf.sprintf
-      "target %S is missing its %s binding"
-      target_ref
+      "missing %s binding"
       (exact_output_binding_component_to_string component)
-  | Exact_output.Target_endpoint_invalid { target_ref; cause } ->
-    Printf.sprintf
-      "target %S endpoint is invalid: %s"
-      target_ref
-      (exact_output_endpoint_error_to_string cause)
-  | Exact_output.Environment_read_failed { environment_variable } ->
-    Printf.sprintf "failed to read environment variable %s" environment_variable
+  | Exact_output.Excluded_endpoint_invalid { cause } ->
+    Printf.sprintf "invalid endpoint: %s" (exact_output_endpoint_error_to_string cause)
+  | Exact_output.Excluded_environment_unreadable { environment_variable } ->
+    Printf.sprintf "environment variable %s is unreadable" environment_variable
+;;
+
+let warn_excluded_exact_output_targets resolver_snapshot =
+  List.iter
+    (fun (excluded : Exact_output.excluded_target) ->
+       Log.Server.warn
+         "exact_output: target %S excluded from the frozen catalog (%s); lanes \
+          referencing it reject that slot"
+         excluded.excluded_target_ref
+         (exact_output_exclusion_reason_to_string excluded.exclusion_reason))
+    (Exact_output.resolver_excluded_targets resolver_snapshot)
 ;;
 
 let read_exact_output_overlay path =
@@ -318,6 +328,7 @@ let configure_exact_output_registry ?config_root () =
          ("exact-output resolver snapshot: "
           ^ exact_output_snapshot_error_to_string error))
   | Ok resolver_snapshot ->
+    warn_excluded_exact_output_targets resolver_snapshot;
     (match
        Runtime.publish_exact_output_registry
          ~required_lane_ids:mandatory_exact_output_lane_ids

--- a/packages/agent_core/lib/llm_provider/exact_output.mli
+++ b/packages/agent_core/lib/llm_provider/exact_output.mli
@@ -110,15 +110,23 @@ type resolver_snapshot_error =
       ; detail : string
       }
   | Catalog_collision of resolver_collision
-  | Target_binding_missing of
-      { target_ref : string
-      ; component : resolver_binding_component
-      }
-  | Target_endpoint_invalid of
-      { target_ref : string
-      ; cause : resolver_endpoint_error
-      }
-  | Environment_read_failed of { environment_variable : string }
+
+(** A declared target that cannot become a routable frozen target is excluded
+    from the snapshot instead of failing the whole load. Excluded targets are
+    absent from the frozen catalog: [admit_target_ref] answers
+    [Target_not_in_catalog], lanes referencing them reject that slot, and
+    mandatory-lane enforcement still refuses to publish. Catalog-level
+    [resolver_snapshot_error] cases above stay fail-closed because no coherent
+    catalog exists to exclude from. *)
+type target_exclusion_reason =
+  | Excluded_binding_missing of { component : resolver_binding_component }
+  | Excluded_endpoint_invalid of { cause : resolver_endpoint_error }
+  | Excluded_environment_unreadable of { environment_variable : string }
+
+type excluded_target =
+  { excluded_target_ref : string
+  ; exclusion_reason : target_exclusion_reason
+  }
 
 type minimum_guarantee =
   | Json_syntax
@@ -367,6 +375,11 @@ val load_resolver_snapshot
 
 val resolver_catalog_generation : resolver_snapshot -> catalog_generation
 val resolver_catalog_evidence : resolver_snapshot -> catalog_evidence
+
+(** Declared targets excluded from the frozen catalog, in declaration order:
+    binding-missing exclusions first, then endpoint/environment exclusions. *)
+val resolver_excluded_targets : resolver_snapshot -> excluded_target list
+
 val catalog_generation_fingerprint : catalog_generation -> string
 val catalog_evidence_sha256 : catalog_evidence -> string
 val target_identity_fingerprint : target_identity -> string

--- a/packages/agent_core/lib/llm_provider/exact_output_resolver.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_resolver.ml
@@ -74,15 +74,24 @@ type resolver_snapshot_error =
       ; detail : string
       }
   | Catalog_collision of resolver_collision
-  | Target_binding_missing of
-      { target_ref : string
-      ; component : resolver_binding_component
-      }
-  | Target_endpoint_invalid of
-      { target_ref : string
-      ; cause : resolver_endpoint_error
-      }
-  | Environment_read_failed of { environment_variable : string }
+
+(* A declared target that cannot become a routable frozen target is excluded
+   from the snapshot instead of failing the whole load. Exclusion keeps the
+   target out of the frozen catalog, so admission answers Target_not_in_catalog,
+   lanes referencing it reject that slot, and mandatory-lane enforcement still
+   refuses to publish — while unrelated declarations (including operator
+   overlay rows nothing references) keep the process bootable. Catalog-level
+   failures above stay fail-closed because no coherent catalog exists to
+   exclude from. *)
+type target_exclusion_reason =
+  | Excluded_binding_missing of { component : resolver_binding_component }
+  | Excluded_endpoint_invalid of { cause : resolver_endpoint_error }
+  | Excluded_environment_unreadable of { environment_variable : string }
+
+type excluded_target =
+  { excluded_target_ref : string
+  ; exclusion_reason : target_exclusion_reason
+  }
 
 type target_declaration =
   { target_ref : target_ref
@@ -112,6 +121,7 @@ type frozen_target =
 
 type resolver_snapshot =
   { targets : frozen_target String_map.t
+  ; excluded_targets : excluded_target list
   ; generation : catalog_generation
   ; evidence : catalog_evidence
   }
@@ -194,6 +204,10 @@ let catalog_generation_fingerprint (Catalog_generation value) = value
 let catalog_evidence_sha256 (Catalog_evidence value) = value
 let resolver_catalog_generation (snapshot : resolver_snapshot) = snapshot.generation
 let resolver_catalog_evidence (snapshot : resolver_snapshot) = snapshot.evidence
+
+let resolver_excluded_targets (snapshot : resolver_snapshot) =
+  snapshot.excluded_targets
+;;
 let target_identity_fingerprint identity = identity.fingerprint
 let selected_target_identity (target : selected_target) = target.identity
 let selected_target_catalog_generation (target : selected_target) = target.generation
@@ -529,21 +543,18 @@ let%test "case-only target overlay shadow fails closed" =
   | None, _ | _, None -> false
 ;;
 
-let endpoint_result ~target_ref =
-  Result.map_error (fun cause ->
-    Target_endpoint_invalid { target_ref = target_ref_id target_ref; cause })
+let endpoint_result result =
+  Result.map_error (fun cause -> Excluded_endpoint_invalid { cause }) result
 ;;
 
-let validate_base_url ~target_ref value =
-  Binding.validate_base_url value |> endpoint_result ~target_ref
+let validate_base_url value = Binding.validate_base_url value |> endpoint_result
+
+let validate_request_path ~kind value =
+  Binding.validate_request_path ~kind value |> endpoint_result
 ;;
 
-let validate_request_path ~target_ref ~kind value =
-  Binding.validate_request_path ~kind value |> endpoint_result ~target_ref
-;;
-
-let validate_model_path ~target_ref kind model_id =
-  Binding.validate_model_path kind model_id |> endpoint_result ~target_ref
+let validate_model_path kind model_id =
+  Binding.validate_model_path kind model_id |> endpoint_result
 ;;
 
 let option_float = function
@@ -724,10 +735,16 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
         , merge_target_declarations ~base:base_targets ~overlay:overlay_targets )
   in
   let catalog, model_entries, target_declarations = catalog_models_and_targets in
-  let* structural =
+  let structural_rev, excluded_binding_rev =
     List.fold_left
-      (fun result (target : target_declaration) ->
-         let* bindings = result in
+      (fun (bindings, excluded) (target : target_declaration) ->
+         let exclude component =
+           ( bindings
+           , { excluded_target_ref = target_ref_id target.target_ref
+             ; exclusion_reason = Excluded_binding_missing { component }
+             }
+             :: excluded )
+         in
          match
            Binding.resolve_exact
              ~catalog
@@ -735,20 +752,13 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
              ~provider_ref:target.provider_ref
              ~model_id:target.model_id
          with
-         | Error Binding.Provider_missing ->
-           Error
-             (Target_binding_missing
-                { target_ref = target_ref_id target.target_ref
-                ; component = Target_provider
-                })
-         | Error Binding.Model_missing ->
-           Error
-             (Target_binding_missing
-                { target_ref = target_ref_id target.target_ref; component = Target_model })
-         | Ok (provider, model) -> Ok ((target, provider, model) :: bindings))
-      (Ok [])
+         | Error Binding.Provider_missing -> exclude Target_provider
+         | Error Binding.Model_missing -> exclude Target_model
+         | Ok (provider, model) -> (target, provider, model) :: bindings, excluded)
+      ([], [])
       target_declarations
   in
+  let structural = List.rev structural_rev in
   let environment_names =
     List.fold_left
       (fun names
@@ -775,38 +785,29 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
     | Ok value -> value
     | Error () -> None
   in
-  let* targets =
-    List.fold_left
-      (fun result
-        ( (target : target_declaration)
-        , (provider : Model_catalog.provider_entry)
-        , (model : Model_catalog.model_entry) ) ->
-         let* targets = result in
-         let capabilities = Binding.capabilities_of_catalog_binding provider model in
-         let anthropic_thinking_control =
-           Binding.anthropic_thinking_control_of_model model
-         in
-         let* () =
-           match provider.base_url_env with
-           | Some name when name <> "" ->
-             (match observed_environment name with
-              | Ok _ -> Ok ()
-              | Error () ->
-                Error (Environment_read_failed { environment_variable = name }))
-           | Some _ | None -> Ok ()
-         in
-         let base_url = Model_provider_catalog.resolved_base_url ~getenv provider in
-         let* () = validate_base_url ~target_ref:target.target_ref base_url in
-         let* () =
-           validate_request_path
-             ~target_ref:target.target_ref
-             ~kind:provider.kind
-             provider.request_path
-         in
-         let* () =
-           validate_model_path ~target_ref:target.target_ref provider.kind target.model_id
-         in
-         let projection_config =
+  let freeze_target
+        (target : target_declaration)
+        (provider : Model_catalog.provider_entry)
+        (model : Model_catalog.model_entry)
+    =
+    let capabilities = Binding.capabilities_of_catalog_binding provider model in
+    let anthropic_thinking_control =
+      Binding.anthropic_thinking_control_of_model model
+    in
+    let* () =
+      match provider.base_url_env with
+      | Some name when name <> "" ->
+        (match observed_environment name with
+         | Ok _ -> Ok ()
+         | Error () ->
+           Error (Excluded_environment_unreadable { environment_variable = name }))
+      | Some _ | None -> Ok ()
+    in
+    let base_url = Model_provider_catalog.resolved_base_url ~getenv provider in
+    let* () = validate_base_url base_url in
+    let* () = validate_request_path ~kind:provider.kind provider.request_path in
+    let* () = validate_model_path provider.kind target.model_id in
+    let projection_config =
            PC.make
              ~kind:provider.kind
              ~provider_id:provider.id
@@ -871,20 +872,35 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
                 | None -> Credential_missing provider.api_key_env)
              | Ok None -> Credential_missing provider.api_key_env)
          in
-         let target_id = target_ref_id target.target_ref in
-         Ok
-           (String_map.add
-              target_id
-              { config = projection_config
-              ; capabilities
-              ; anthropic_thinking_control
-              ; body_timeout_s = target.body_timeout_s
-              ; credential
-              ; identity
-              }
-              targets))
-      (Ok String_map.empty)
+    Ok
+      { config = projection_config
+      ; capabilities
+      ; anthropic_thinking_control
+      ; body_timeout_s = target.body_timeout_s
+      ; credential
+      ; identity
+      }
+  in
+  let targets, excluded_frozen_rev =
+    List.fold_left
+      (fun (targets, excluded)
+        ( (target : target_declaration)
+        , (provider : Model_catalog.provider_entry)
+        , (model : Model_catalog.model_entry) ) ->
+         match freeze_target target provider model with
+         | Ok frozen ->
+           String_map.add (target_ref_id target.target_ref) frozen targets, excluded
+         | Error exclusion_reason ->
+           ( targets
+           , { excluded_target_ref = target_ref_id target.target_ref
+             ; exclusion_reason
+             }
+             :: excluded ))
+      (String_map.empty, [])
       structural
+  in
+  let excluded_targets =
+    List.rev excluded_binding_rev @ List.rev excluded_frozen_rev
   in
   let generation =
     String_map.bindings targets
@@ -897,7 +913,7 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
     canonical_catalog_evidence catalog model_entries target_declarations
   in
   let evidence = Catalog_evidence (hash_parts evidence_material) in
-  Ok { targets; generation; evidence }
+  Ok { targets; excluded_targets; generation; evidence }
 ;;
 
 let admit_target_ref snapshot value =

--- a/packages/agent_core/lib/llm_provider/exact_output_resolver.mli
+++ b/packages/agent_core/lib/llm_provider/exact_output_resolver.mli
@@ -69,15 +69,23 @@ type resolver_snapshot_error =
       ; detail : string
       }
   | Catalog_collision of resolver_collision
-  | Target_binding_missing of
-      { target_ref : string
-      ; component : resolver_binding_component
-      }
-  | Target_endpoint_invalid of
-      { target_ref : string
-      ; cause : resolver_endpoint_error
-      }
-  | Environment_read_failed of { environment_variable : string }
+
+(** A declared target that cannot become a routable frozen target is excluded
+    from the snapshot instead of failing the whole load. Excluded targets are
+    absent from the frozen catalog: [admit_target_ref] answers
+    [Target_not_in_catalog], lanes referencing them reject that slot, and
+    mandatory-lane enforcement still refuses to publish. Catalog-level
+    [resolver_snapshot_error] cases above stay fail-closed because no coherent
+    catalog exists to exclude from. *)
+type target_exclusion_reason =
+  | Excluded_binding_missing of { component : resolver_binding_component }
+  | Excluded_endpoint_invalid of { cause : resolver_endpoint_error }
+  | Excluded_environment_unreadable of { environment_variable : string }
+
+type excluded_target =
+  { excluded_target_ref : string
+  ; exclusion_reason : target_exclusion_reason
+  }
 
 type selected_target = private
   { config : Provider_config.t
@@ -111,6 +119,10 @@ val catalog_generation_fingerprint : catalog_generation -> string
 val catalog_evidence_sha256 : catalog_evidence -> string
 val resolver_catalog_generation : resolver_snapshot -> catalog_generation
 val resolver_catalog_evidence : resolver_snapshot -> catalog_evidence
+
+(** Declared targets excluded from the frozen catalog, in declaration order:
+    binding-missing exclusions first, then endpoint/environment exclusions. *)
+val resolver_excluded_targets : resolver_snapshot -> excluded_target list
 val target_identity_fingerprint : target_identity -> string
 val admitted_target_identity : admitted_target -> target_identity
 val admitted_target_catalog_generation : admitted_target -> catalog_generation

--- a/packages/agent_core/test/test_exact_output_flow.ml
+++ b/packages/agent_core/test/test_exact_output_flow.ml
@@ -161,10 +161,19 @@ let with_catalog ?(getenv = fun _ -> Ok None) entries f =
     failf "outer-flow catalog rejected by the resolver: %s" detail
   | Error (EO.Catalog_parse_failed { detail; _ }) ->
     failf "outer-flow catalog did not parse: %s" detail
-  | Error (EO.Target_binding_missing { target_ref; _ }) ->
-    failf "outer-flow catalog target %s has an unbound component" target_ref
   | Error _ -> fail "outer-flow resolver snapshot should load"
-  | Ok snapshot -> f snapshot
+  | Ok snapshot ->
+    (match EO.resolver_excluded_targets snapshot with
+     | [] -> f snapshot
+     | excluded ->
+       failf
+         "outer-flow catalog excluded %d target(s): %s"
+         (List.length excluded)
+         (String.concat
+            ", "
+            (List.map
+               (fun (entry : EO.excluded_target) -> entry.excluded_target_ref)
+               excluded)))
 ;;
 
 let admitted_target snapshot selector =

--- a/packages/agent_core/test/test_exact_output_resolver_snapshot.ml
+++ b/packages/agent_core/test/test_exact_output_resolver_snapshot.ml
@@ -927,14 +927,24 @@ let test_old_and_new_whole_tuples_never_mix_across_domains_and_fibers () =
   check bool "A and B whole tuples differ" true (old_observation <> new_observation)
 ;;
 
-let expect_endpoint_error label expected_cause contents =
+let expect_endpoint_exclusion label expected_cause contents =
   let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
   let overlay : EO.catalog_document = { source = label; contents } in
   match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
-  | Error (EO.Target_endpoint_invalid { cause; _ }) ->
-    check bool (label ^ " exact typed cause") true (cause = expected_cause)
-  | Error _ -> fail (label ^ " returned the wrong resolver error class")
-  | Ok _ -> fail (label ^ " must fail closed")
+  | Error _ -> fail (label ^ " must load; an endpoint violation excludes the target")
+  | Ok snapshot ->
+    (match EO.resolver_excluded_targets snapshot with
+     | [ { excluded_target_ref
+         ; exclusion_reason = EO.Excluded_endpoint_invalid { cause }
+         } ] ->
+       check string (label ^ " excluded target ref") "snapshot-target" excluded_target_ref;
+       check bool (label ^ " exact typed cause") true (cause = expected_cause);
+       (match EO.admit_target_ref snapshot "snapshot-target" with
+        | Error (EO.Target_not_in_catalog _) -> ()
+        | Ok _ -> fail (label ^ " excluded target must not be admitted")
+        | Error _ -> fail (label ^ " admission failed for the wrong reason"))
+     | [] -> fail (label ^ " did not exclude the invalid target")
+     | _ -> fail (label ^ " exclusion list has an unexpected shape"))
 ;;
 
 let test_endpoint_error_cause_table () =
@@ -982,8 +992,48 @@ let test_endpoint_error_cause_table () =
     ]
   in
   List.iter
-    (fun (label, cause, contents) -> expect_endpoint_error label cause contents)
+    (fun (label, cause, contents) -> expect_endpoint_exclusion label cause contents)
     cases
+;;
+
+let test_unbound_declaration_is_excluded_not_fatal () =
+  (* Live incident 2026-08-10: an operator overlay carried a target row whose
+     model id was absent from the merged catalog, and no lane referenced it —
+     the snapshot load still failed the whole boot. The declaration must be
+     excluded while every other target stays admitted. *)
+  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  let valid = target_catalog () in
+  let unbound =
+    String.concat
+      "\n"
+      [ "[[targets]]"
+      ; {|id = "carried-over-target"|}
+      ; {|provider_ref = "snapshot-fixture"|}
+      ; {|model_id = "model-absent-from-catalog"|}
+      ]
+  in
+  let overlay : EO.catalog_document =
+    { source = "unbound declaration fixture"
+    ; contents = valid ^ "\n" ^ unbound
+    }
+  in
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
+  | Error _ -> fail "an unbound declaration must not fail the snapshot load"
+  | Ok snapshot ->
+    (match EO.resolver_excluded_targets snapshot with
+     | [ { excluded_target_ref
+         ; exclusion_reason =
+             EO.Excluded_binding_missing { component = EO.Target_model }
+         } ] ->
+       check string "excluded target ref" "carried-over-target" excluded_target_ref
+     | _ -> fail "expected exactly the unbound declaration to be excluded");
+    (match EO.admit_target_ref snapshot "snapshot-target" with
+     | Ok _ -> ()
+     | Error _ -> fail "the bound sibling target must stay admitted");
+    (match EO.admit_target_ref snapshot "carried-over-target" with
+     | Error (EO.Target_not_in_catalog _) -> ()
+     | Ok _ -> fail "the unbound declaration must not be admitted"
+     | Error _ -> fail "admission failed for the wrong reason")
 ;;
 
 let test_caller_headers_fail_closed () =
@@ -1091,6 +1141,10 @@ let () =
             `Quick
             test_old_and_new_whole_tuples_never_mix_across_domains_and_fibers
         ; test_case "endpoint exact-cause table" `Quick test_endpoint_error_cause_table
+        ; test_case
+            "unbound declaration is excluded not fatal"
+            `Quick
+            test_unbound_declaration_is_excluded_not_fatal
         ; test_case "caller headers rejected" `Quick test_caller_headers_fail_closed
         ; test_case
             "collision and input hardening"

--- a/packages/agent_core/test/test_exact_output_single_surface.ml
+++ b/packages/agent_core/test/test_exact_output_single_surface.ml
@@ -2070,11 +2070,20 @@ let test_gemini_nonempty_request_path_rejected_before_resolution () =
     }
   in
   match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
-  | Error
-      (EO.Target_endpoint_invalid
-         { target_ref; cause = EO.Unsupported_gemini_request_path }) ->
-    check string "rejected Gemini target" id target_ref
-  | Ok _ | Error _ -> fail "nonempty Gemini request_path must fail before resolution"
+  | Error _ ->
+    fail "nonempty Gemini request_path must exclude the target, not fail the load"
+  | Ok snapshot ->
+    (match EO.resolver_excluded_targets snapshot with
+     | [ { excluded_target_ref
+         ; exclusion_reason =
+             EO.Excluded_endpoint_invalid
+               { cause = EO.Unsupported_gemini_request_path }
+         } ] -> check string "rejected Gemini target" id excluded_target_ref
+     | _ -> fail "expected exactly the Gemini target to be excluded");
+    (match EO.admit_target_ref snapshot id with
+     | Error (EO.Target_not_in_catalog _) -> ()
+     | Ok _ -> fail "excluded Gemini target must not be admitted"
+     | Error _ -> fail "admission failed for the wrong reason")
 ;;
 
 let () =


### PR DESCRIPTION
## Summary

- exact-output resolver snapshot이 **선언만 되고 어디서도 참조되지 않는 target** 때문에 전체 부팅을 죽이던 회귀를 근본 수정합니다.
- unresolvable 선언(binding-missing / endpoint-invalid / environment-unreadable)은 이제 snapshot 로드 실패가 아니라 **typed `excluded_target`으로 frozen catalog에서 제외**됩니다.
- 제외된 target을 참조하는 lane 슬롯은 기존 #27961 기계(`Target_not_in_catalog` → rejected_slot)로 자연 강등되고, **mandatory lane 강제는 그대로 boot-fatal**입니다 (`required exact-output lane %S has no admitted target in the frozen catalog`).
- bootstrap은 제외 항목마다 WARN 1줄을 남깁니다 (`excluded from the frozen catalog (<reason>)`).
- 죽은 개념 척살: `Target_binding_missing` / `Target_endpoint_invalid` / `Environment_read_failed` snapshot error 변형과 bootstrap의 해당 formatter arm을 제거했습니다. catalog 레벨 오류(read/parse/invalid/collision)는 fail-closed 유지.

## Root cause (라이브 사고 2026-08-10)

main head(`b9359de911`) 바이너리로 운영 config 부팅 시:

```
[FATAL] Critical startup failed before readiness; refusing partial BasePath ownership:
Env_config_core.Config_error: exact-output resolver snapshot:
target "glm-coding.glm-4-7-coding" is missing its model binding
```

- 운영 overlay의 해당 행은 주석으로 **"runtime.toml does not reference these targets today, so they are preserved rather than relied on"**이라 명시된 carried-over 선언이며, `model_id = "glm-4.7"`이 병합 카탈로그에 없습니다.
- `load_resolver_snapshot`의 structural fold가 선언 전체를 fail-closed로 순회해, 참조 0건인 선언 하나가 전체 snapshot을 Error로 만들고 bootstrap이 Config_error로 승격 → boot-fatal.
- #27961이 만든 per-slot 국소화는 snapshot 이후 단계라 도달 불가. 같은 파일의 `credential_outcome`은 credential 실패를 이미 per-target으로 국소화하고 있습니다 — binding/endpoint/env만 전체 fatal이던 비대칭이 원인.
- CI는 저장소 밖 운영 config를 원리적으로 못 봅니다. 첫 부팅이 첫 테스트가 되는 클래스(#27763→#27959와 동형)의 세 번째 사례입니다.

## 설계 판단

- **정책 노브 없음**: `load_resolver_snapshot`의 프로덕션 호출자는 `server_runtime_bootstrap.ml` 1곳입니다 (나머지는 테스트/픽스처/probe). opt-in 노브는 보호할 두 번째 소비자가 없는 신규 게이트이고, 새 호출자가 기본값으로 같은 지뢰를 다시 밟게 합니다.
- **fold2(endpoint/env)까지 동일 파티션**: binding만 국소화하면 stale `base_url` 하나로 동일 사고가 재발합니다. 제외는 항상 "frozen catalog 부재"로 수렴하므로 invalid endpoint로는 어떤 트래픽도 나가지 않습니다 (기존 fail-closed보다 약하지 않은 통제 — admission이 `Target_not_in_catalog`로 거부).
- 제외 목록은 선언 순서 유지: binding-missing 먼저, endpoint/env 다음. `resolver_excluded_targets` 접근자로 관측 가능.

## Tests

- `test_exact_output_resolver_snapshot.ml`
  - `expect_endpoint_error`(fail-closed 단언) → `expect_endpoint_exclusion`: endpoint cause 테이블 전 케이스가 typed cause + 제외 ref + **admit 거부(Target_not_in_catalog)** 3중 단언으로 전환.
  - 신규 `unbound declaration is excluded not fatal`: 라이브 사고 재현 — 유효 target과 미바인딩 carried-over 선언 공존 시 로드 성공, 정확히 1건 제외(`Excluded_binding_missing{Target_model}`), 형제 target admit 유지, 제외 target admit 거부.
- `test_exact_output_single_surface.ml`: Gemini nonempty request_path 케이스를 제외+admit-거부 계약으로 전환.
- `test_exact_output_flow.ml`: `with_catalog`가 Ok 후 제외 목록 비어있음을 명시 단언 (픽스처 drift가 제외로 위장하는 것 방지).

## Known verification boundary

- masc측 `test_exact_output_catalog_precedence` 하네스(서버 상태 + env 의존)에는 케이스를 추가하지 않았습니다. resolver 계층 테스트 + 운영 config 사본 부팅 스모크(아래)로 커버합니다. 병렬 브랜치 `exact-output-unbound-target-degrade-20260810`가 같은 하네스 확장을 갖고 있어 수렴 시 그쪽 채택 권장.
- 운영 config 사본 부팅 스모크: pre-fix 바이너리 = 위 FATAL 재현, 이 브랜치 바이너리 = readiness 도달 + `glm-coding.glm-4-7-coding` 제외 WARN 1줄. (로컬 실측, PR 코멘트에 로그 첨부)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
