### PR TITLE
fix(runtime): isolate unbound exact-output targets

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -267,6 +267,16 @@ let warn_rejected_exact_output_slots registry =
     (Runtime_exact_output_registry.rejected_slots registry)
 ;;
 
+let warn_rejected_exact_output_bindings resolver_snapshot =
+  List.iter
+    (fun (binding : Exact_output.rejected_target_binding) ->
+       Log.Server.warn
+         "exact_output: target %S excluded from the frozen resolver because its %s binding is missing; lane admission will decide whether required targets remain"
+         binding.target_ref
+         (exact_output_binding_component_to_string binding.component))
+    (Exact_output.resolver_rejected_target_bindings resolver_snapshot)
+;;
+
 let warn_optional_exact_output_lane registry ~lane_id ~feature =
   match Runtime_exact_output_registry.resolve_lane registry ~lane_id with
   | Ok { selected_slots = _ :: _; _ } -> ()
@@ -311,13 +321,20 @@ let configure_exact_output_registry ?config_root () =
           | Sys_error _ | Invalid_argument _ -> Error ())
     }
   in
-  match Exact_output.load_resolver_snapshot ~io ~catalog () with
+  match
+    Exact_output.load_resolver_snapshot
+      ~io
+      ~target_binding_policy:Exact_output.Exclude_unbound_targets
+      ~catalog
+      ()
+  with
   | Error error ->
     raise
       (Env_config_core.Config_error
          ("exact-output resolver snapshot: "
           ^ exact_output_snapshot_error_to_string error))
   | Ok resolver_snapshot ->
+    warn_rejected_exact_output_bindings resolver_snapshot;
     (match
        Runtime.publish_exact_output_registry
          ~required_lane_ids:mandatory_exact_output_lane_ids

--- a/packages/agent_core/lib/llm_provider/exact_output.mli
+++ b/packages/agent_core/lib/llm_provider/exact_output.mli
@@ -87,6 +87,15 @@ type resolver_binding_component =
   | Target_provider
   | Target_model
 
+type target_binding_policy =
+  | Require_all_target_bindings
+  | Exclude_unbound_targets
+
+type rejected_target_binding =
+  { target_ref : string
+  ; component : resolver_binding_component
+  }
+
 type resolver_endpoint_error =
   | Malformed_base_url
   | Base_url_userinfo_not_allowed
@@ -354,19 +363,27 @@ val snapshot_flow
     suppresses every embedded and overlay row; the input type provides no way
     to combine a full replacement with an overlay.
     [io.getenv] is observed exactly once per referenced environment name during
-    this call and is never retained. Invalid paths, syntax, bindings,
-    collisions, base-URL environment reads, and endpoint declarations fail
-    closed; missing, invalid, or read-failed credentials are instead frozen as
-    per-target outcomes for [resolve_target]. No source falls back to the
-    embedded catalog. *)
+    this call and is never retained. Invalid paths, syntax, collisions,
+    base-URL environment reads, and endpoint declarations fail closed.
+    [Require_all_target_bindings] also rejects the snapshot when any target has
+    no exact provider/model join. [Exclude_unbound_targets] instead records and
+    excludes only those targets; callers must inspect
+    [resolver_rejected_target_bindings] and decide whether their required target
+    set remains available. Missing, invalid, or read-failed credentials are
+    frozen as per-target outcomes for [resolve_target]. No source falls back to
+    the embedded catalog. *)
 val load_resolver_snapshot
   :  io:resolver_io
+  -> ?target_binding_policy:target_binding_policy
   -> ?catalog:resolver_catalog_input
   -> unit
   -> (resolver_snapshot, resolver_snapshot_error) result
 
 val resolver_catalog_generation : resolver_snapshot -> catalog_generation
 val resolver_catalog_evidence : resolver_snapshot -> catalog_evidence
+val resolver_rejected_target_bindings
+  :  resolver_snapshot
+  -> rejected_target_binding list
 val catalog_generation_fingerprint : catalog_generation -> string
 val catalog_evidence_sha256 : catalog_evidence -> string
 val target_identity_fingerprint : target_identity -> string

--- a/packages/agent_core/lib/llm_provider/exact_output_resolver.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_resolver.ml
@@ -51,6 +51,15 @@ type resolver_binding_component =
   | Target_provider
   | Target_model
 
+type target_binding_policy =
+  | Require_all_target_bindings
+  | Exclude_unbound_targets
+
+type rejected_target_binding =
+  { target_ref : string
+  ; component : resolver_binding_component
+  }
+
 type resolver_endpoint_error = Binding.endpoint_error =
   | Malformed_base_url
   | Base_url_userinfo_not_allowed
@@ -114,6 +123,7 @@ type resolver_snapshot =
   { targets : frozen_target String_map.t
   ; generation : catalog_generation
   ; evidence : catalog_evidence
+  ; rejected_target_bindings : rejected_target_binding list
   }
 
 type admitted_target =
@@ -194,6 +204,7 @@ let catalog_generation_fingerprint (Catalog_generation value) = value
 let catalog_evidence_sha256 (Catalog_evidence value) = value
 let resolver_catalog_generation (snapshot : resolver_snapshot) = snapshot.generation
 let resolver_catalog_evidence (snapshot : resolver_snapshot) = snapshot.evidence
+let resolver_rejected_target_bindings snapshot = snapshot.rejected_target_bindings
 let target_identity_fingerprint identity = identity.fingerprint
 let selected_target_identity (target : selected_target) = target.identity
 let selected_target_catalog_generation (target : selected_target) = target.generation
@@ -666,7 +677,12 @@ let read_full_replacement_file path =
       Error (Catalog_read_failed { path; detail = Printexc.to_string exn }))
 ;;
 
-let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
+let load_resolver_snapshot
+      ~io
+      ?(target_binding_policy = Require_all_target_bindings)
+      ?(catalog = Embedded_default)
+      ()
+  =
   let parse_model_catalog ~source ~parser_source contents =
     match Model_catalog.of_toml_string ~source:parser_source contents with
     | Ok catalog -> Ok catalog
@@ -724,10 +740,21 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
         , merge_target_declarations ~base:base_targets ~overlay:overlay_targets )
   in
   let catalog, model_entries, target_declarations = catalog_models_and_targets in
-  let* structural =
+  let* structural, rejected_target_bindings =
     List.fold_left
       (fun result (target : target_declaration) ->
-         let* bindings = result in
+         let* bindings, rejected = result in
+         let reject component =
+           let rejection =
+             { target_ref = target_ref_id target.target_ref; component }
+           in
+           match target_binding_policy with
+           | Require_all_target_bindings ->
+             Error
+               (Target_binding_missing
+                  { target_ref = rejection.target_ref; component })
+           | Exclude_unbound_targets -> Ok (bindings, rejection :: rejected)
+         in
          match
            Binding.resolve_exact
              ~catalog
@@ -735,20 +762,14 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
              ~provider_ref:target.provider_ref
              ~model_id:target.model_id
          with
-         | Error Binding.Provider_missing ->
-           Error
-             (Target_binding_missing
-                { target_ref = target_ref_id target.target_ref
-                ; component = Target_provider
-                })
-         | Error Binding.Model_missing ->
-           Error
-             (Target_binding_missing
-                { target_ref = target_ref_id target.target_ref; component = Target_model })
-         | Ok (provider, model) -> Ok ((target, provider, model) :: bindings))
-      (Ok [])
+         | Error Binding.Provider_missing -> reject Target_provider
+         | Error Binding.Model_missing -> reject Target_model
+         | Ok (provider, model) ->
+           Ok ((target, provider, model) :: bindings, rejected))
+      (Ok ([], []))
       target_declarations
   in
+  let rejected_target_bindings = List.rev rejected_target_bindings in
   let environment_names =
     List.fold_left
       (fun names
@@ -897,7 +918,7 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
     canonical_catalog_evidence catalog model_entries target_declarations
   in
   let evidence = Catalog_evidence (hash_parts evidence_material) in
-  Ok { targets; generation; evidence }
+  Ok { targets; generation; evidence; rejected_target_bindings }
 ;;
 
 let admit_target_ref snapshot value =

--- a/packages/agent_core/lib/llm_provider/exact_output_resolver.mli
+++ b/packages/agent_core/lib/llm_provider/exact_output_resolver.mli
@@ -46,6 +46,15 @@ type resolver_binding_component =
   | Target_provider
   | Target_model
 
+type target_binding_policy =
+  | Require_all_target_bindings
+  | Exclude_unbound_targets
+
+type rejected_target_binding =
+  { target_ref : string
+  ; component : resolver_binding_component
+  }
+
 type resolver_endpoint_error =
   | Malformed_base_url
   | Base_url_userinfo_not_allowed
@@ -124,9 +133,14 @@ val option_float : float option -> string
 
 val load_resolver_snapshot
   :  io:resolver_io
+  -> ?target_binding_policy:target_binding_policy
   -> ?catalog:resolver_catalog_input
   -> unit
   -> (resolver_snapshot, resolver_snapshot_error) result
+
+val resolver_rejected_target_bindings
+  :  resolver_snapshot
+  -> rejected_target_binding list
 
 val admit_target_ref
   :  resolver_snapshot

--- a/packages/agent_core/test/test_exact_output_resolver_snapshot.ml
+++ b/packages/agent_core/test/test_exact_output_resolver_snapshot.ml
@@ -4,6 +4,7 @@ module EO = Agent_core.Exact_output
 
 let _load_resolver_snapshot_contract
   :  io:EO.resolver_io
+  -> ?target_binding_policy:EO.target_binding_policy
   -> ?catalog:EO.resolver_catalog_input
   -> unit
   -> (EO.resolver_snapshot, EO.resolver_snapshot_error) result
@@ -680,6 +681,50 @@ let test_invalid_full_replacement_inputs_fail_without_fallback () =
   | Ok _ | Error _ -> fail "missing replacement file must fail without fallback"
 ;;
 
+let test_unbound_target_policy_is_explicit_and_observable () =
+  let valid_target = "bound-target" in
+  let unbound_target = "unbound-target" in
+  let contents =
+    target_catalog ~target:valid_target ()
+    ^ Printf.sprintf
+        "\n[[targets]]\nid = %S\nprovider_ref = \"missing-provider\"\nmodel_id = \"missing-model\"\n"
+        unbound_target
+  in
+  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  let catalog : EO.resolver_catalog_input =
+    EO.Embedded_with_overlay
+      { source = "unbound target policy fixture"; contents }
+  in
+  (match EO.load_resolver_snapshot ~io ~catalog () with
+   | Error
+       (EO.Target_binding_missing
+          { target_ref; component = EO.Target_provider }) ->
+     check string "strict target identity" unbound_target target_ref
+   | Error _ -> fail "strict mode returned the wrong target binding failure"
+   | Ok _ -> fail "strict mode must reject an unbound target");
+  let degraded =
+    match
+      EO.load_resolver_snapshot
+        ~io
+        ~target_binding_policy:EO.Exclude_unbound_targets
+        ~catalog
+        ()
+    with
+    | Ok snapshot -> snapshot
+    | Error _ -> fail "explicit exclusion mode must preserve bound targets"
+  in
+  ignore (admit degraded valid_target);
+  (match EO.admit_target_ref degraded unbound_target with
+   | Error (EO.Target_not_in_catalog target_ref) ->
+     check string "excluded target is absent" unbound_target target_ref
+   | Error _ -> fail "excluded target returned the wrong admission error"
+   | Ok _ -> fail "unbound target must not be admitted");
+  match EO.resolver_rejected_target_bindings degraded with
+  | [ { target_ref; component = EO.Target_provider } ] ->
+    check string "typed rejected target" unbound_target target_ref
+  | _ -> fail "degraded snapshot must retain one typed binding rejection"
+;;
+
 let test_credential_rotation_is_not_functional_identity () =
   let contents = target_catalog ~api_key_env:"ROTATING_FIXTURE_KEY" () in
   let load credential =
@@ -1062,6 +1107,10 @@ let () =
             "invalid full replacement has no fallback"
             `Quick
             test_invalid_full_replacement_inputs_fail_without_fallback
+        ; test_case
+            "unbound target policy is explicit and observable"
+            `Quick
+            test_unbound_target_policy_is_explicit_and_observable
         ; test_case
             "credential rotation is nonfunctional"
             `Quick

--- a/test/test_exact_output_catalog_precedence.ml
+++ b/test/test_exact_output_catalog_precedence.ml
@@ -594,6 +594,52 @@ let test_hitl_auto_judge_lane_bootstrap ~clock ~mono_clock ~net ~proc_mgr ~fs ()
      Alcotest.failf
        "expected one typed rejected slot, got %d"
        (List.length rejected));
+  write_file replacement_path replacement_catalog_with_unbound_target;
+  write_file
+    runtime_path
+    (runtime_toml
+       ~compaction_slots:[ unbound_target; replacement_target ]
+       replacement_target);
+  create_server_state ();
+  let unbound_optional_registry =
+    current_registry "unbound optional exact-output target bootstrap"
+  in
+  require_lane_slots
+    "unbound optional target is excluded while admitted fallback remains"
+    ~lane_id:"compaction_exact"
+    ~expected:[ replacement_target ]
+    unbound_optional_registry;
+  (match Registry.rejected_slots unbound_optional_registry with
+   | [ rejected ] ->
+     Alcotest.(check string) "unbound rejected slot" unbound_target rejected.slot_id
+   | rejected ->
+     Alcotest.failf
+       "expected one unbound rejected slot, got %d"
+       (List.length rejected));
+  let stable_generation = Registry.generation unbound_optional_registry in
+  write_file
+    runtime_path
+    (runtime_toml
+       ~hitl_slots:[ unbound_target ]
+       replacement_target);
+  (match create_server_state () with
+   | exception Env_config_core.Config_error _ -> ()
+   | () -> Alcotest.fail "an entirely unbound mandatory lane must block startup"
+   | exception exn ->
+     Alcotest.failf
+       "unbound mandatory lane returned the wrong exception: %s"
+       (Printexc.to_string exn));
+  (match Registry.current () with
+   | Ok registry ->
+     Alcotest.(check int64)
+       "failed mandatory admission preserves the published registry"
+       stable_generation
+       (Registry.generation registry)
+   | Error error ->
+     Alcotest.failf
+       "failed mandatory admission lost the published registry: %s"
+       (Registry.publication_error_to_string error));
+  write_file replacement_path replacement_catalog;
   let runtime_lane_candidates =
     [ replacement_runtime_target
     ; replacement_secondary_runtime_target

--- a/test/test_exact_output_catalog_precedence_fixture.ml
+++ b/test/test_exact_output_catalog_precedence_fixture.ml
@@ -41,6 +41,7 @@ let replacement_target = "replacement-only-target"
 let replacement_runtime_target = "replacement_provider.replacement"
 let replacement_secondary_runtime_target = "replacement_provider.secondary"
 let replacement_secondary_target = "replacement-secondary-target"
+let unbound_target = "unbound-target"
 
 let catalog_toml
       ?(api_key_env = "")
@@ -118,6 +119,13 @@ let replacement_catalog =
     ~model_id:"replacement-model"
     ~target_id:replacement_target
     ()
+;;
+
+let replacement_catalog_with_unbound_target =
+  replacement_catalog
+  ^ Printf.sprintf
+      "\n[[targets]]\nid = %S\nprovider_ref = \"replacement_provider\"\nmodel_id = \"missing-model\"\n"
+      unbound_target
 ;;
 
 let runtime_toml

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -2830,6 +2830,14 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
       String.equal lane_id actual_lane_id
     | Error _ | Ok _ -> false
   in
+  let lane_has_no_admitted_slots ~lane_id registry =
+    match Runtime_exact_output_registry.resolve_lane registry ~lane_id with
+    | Error
+        (Runtime_exact_output_registry.No_admitted_lane_slots
+           { lane_id = actual_lane_id }) ->
+      String.equal lane_id actual_lane_id
+    | Error _ | Ok _ -> false
+  in
   let baseline = content ~default:"local.chat" "slot-a" in
   with_temp_runtime_toml baseline (fun path ->
     (match Runtime.save_config_text ~runtime_config_path:path baseline with
@@ -2839,24 +2847,27 @@ let test_save_config_text_commits_exact_registry_with_runtime_state () =
     let stable_generation =
       Runtime_exact_output_registry.generation stable_registry
     in
-    let stable_file = Fs_compat.load_file path in
-    let invalid = content ~default:"local.libr" "missing-slot" in
-    (match Runtime.save_config_text ~runtime_config_path:path invalid with
-     | Ok () -> fail "unknown exact target must reject raw save"
+    let degraded = content ~default:"local.libr" "missing-slot" in
+    (match Runtime.save_config_text ~runtime_config_path:path degraded with
      | Error detail ->
-       check bool "error identifies frozen catalog rejection" true
-         (String_util.contains_substring detail "frozen catalog"));
-    check string "invalid save preserves file" stable_file (Fs_compat.load_file path);
-    check string "invalid save preserves runtime cache" "local.chat"
+       failf "optional unbound exact target must not reject raw save: %s" detail
+     | Ok () -> ());
+    check string "degraded save commits file" degraded (Fs_compat.load_file path);
+    check string "degraded save commits runtime cache" "local.libr"
       (Runtime.get_default_runtime_id ());
-    let after_invalid = registry_exn () in
-    check int64 "invalid save preserves registry generation" stable_generation
-      (Runtime_exact_output_registry.generation after_invalid);
-    check (list string) "invalid save preserves registry slots" [ "slot-a" ]
-      (slots_exn ~lane_id:"compaction_exact" after_invalid);
-check bool "invalid save does not synthesize HITL lane" true
-  (lane_is_unconfigured ~lane_id:"hitl_auto_judge" after_invalid);
-    let replacement = content ~default:"local.libr" "slot-b" in
+    let after_degraded = registry_exn () in
+    let degraded_generation =
+      Runtime_exact_output_registry.generation after_degraded
+    in
+    check bool "degraded save advances registry generation" true
+      (Int64.compare degraded_generation stable_generation > 0);
+    check bool "degraded save leaves optional lane without admitted slots" true
+      (lane_has_no_admitted_slots
+         ~lane_id:"compaction_exact"
+         after_degraded);
+    check bool "degraded save does not synthesize HITL lane" true
+      (lane_is_unconfigured ~lane_id:"hitl_auto_judge" after_degraded);
+    let replacement = content ~default:"local.chat" "slot-b" in
     let failed_path = path ^ ".directory" in
     Unix.mkdir failed_path 0o755;
     Fun.protect
@@ -2867,31 +2878,35 @@ check bool "invalid save does not synthesize HITL lane" true
           | Error detail ->
             check bool "write failure is surfaced" true
               (String_util.contains_substring detail "save_file_atomic"));
-         check string "write failure preserves runtime cache" "local.chat"
+         check string "write failure preserves runtime cache" "local.libr"
            (Runtime.get_default_runtime_id ());
          let after_write_failure = registry_exn () in
-         check int64 "write failure preserves registry generation" stable_generation
+         check int64 "write failure preserves registry generation" degraded_generation
            (Runtime_exact_output_registry.generation after_write_failure);
-         check (list string) "write failure preserves registry slots" [ "slot-a" ]
-           (slots_exn ~lane_id:"compaction_exact" after_write_failure);
-check bool "write failure does not synthesize HITL lane" true
-  (lane_is_unconfigured ~lane_id:"hitl_auto_judge" after_write_failure));
+         check bool "write failure preserves no-admitted lane" true
+           (lane_has_no_admitted_slots
+              ~lane_id:"compaction_exact"
+              after_write_failure);
+         check bool "write failure does not synthesize HITL lane" true
+           (lane_is_unconfigured
+              ~lane_id:"hitl_auto_judge"
+              after_write_failure));
     (match Runtime.save_config_text ~runtime_config_path:path replacement with
      | Error detail -> failf "valid exact replacement failed: %s" detail
      | Ok () -> ());
     check string "valid save commits file" replacement (Fs_compat.load_file path);
-    check string "valid save commits runtime cache" "local.libr"
+    check string "valid save commits runtime cache" "local.chat"
       (Runtime.get_default_runtime_id ());
     let replaced = registry_exn () in
     check bool "valid save advances registry generation" true
       (Int64.compare
          (Runtime_exact_output_registry.generation replaced)
-         stable_generation
+         degraded_generation
        > 0);
     check (list string) "valid save commits registry slots" [ "slot-b" ]
       (slots_exn ~lane_id:"compaction_exact" replaced);
-check bool "valid save does not synthesize HITL lane" true
-  (lane_is_unconfigured ~lane_id:"hitl_auto_judge" replaced))
+    check bool "valid save does not synthesize HITL lane" true
+      (lane_is_unconfigured ~lane_id:"hitl_auto_judge" replaced))
 
 let test_deprecated_capability_notice_warns_once_per_process () =
   (* runtime.toml is re-parsed on every keeper boot; a per-parse deprecation


### PR DESCRIPTION
## Summary

- keep AGENT_CORE resolver snapshots strict by default
- let MASC explicitly exclude target declarations whose provider/model binding is absent
- preserve typed rejection evidence so startup warnings and lane admission remain observable
- continue to fail startup when a mandatory exact-output lane has no admitted target
- update raw runtime-save coverage for optional no-admitted lanes

## Product impact

- User-visible change: one stale exact-output target no longer prevents all Keepers and connectors from starting when the affected lane is optional or still has another admitted target. No replacement target or fallback is synthesized.

## Evidence

- Failure: `exact-output resolver snapshot: target "glm-coding.glm-4-7-coding" is missing its model binding`
- `scripts/dune-local.sh build packages/agent_core/test/test_exact_output_resolver_snapshot.exe test/test_exact_output_catalog_precedence.exe test/test_runtime_config_validity.exe bin/main_eio.exe`
- resolver snapshot tests: 16/16 passed
- exact-output bootstrap tests: 9/9 passed
- runtime config validity tests: 62/62 passed
- `ocamlformat --check` passed on all touched OCaml files
- `bash scripts/check-variants.sh` passed
- `git diff --check` passed
- `scripts/dune-local.sh fmt` remains red on unrelated pre-existing Dune stanza formatting drift; no generated Dune changes are included here.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

## GOAL LOOP ACT checklist

- [x] Observe — fatal startup log identifies one target-local missing model binding
- [x] Orient — resolver aborted before lane admission could distinguish optional from mandatory impact
- [x] Decide — preserve strict AGENT_CORE default and opt MASC into typed target exclusion only
- [x] Act — add one explicit policy, typed rejection evidence, MASC warnings, and bounded regression coverage
- [x] Verify — focused tests pass; mandatory no-admitted lane still fails and preserves the prior registry generation
- [x] Loop — no known follow-up; CI and review remain PR gates

## Review evidence

- Author self-review complete at `079d62d7eb`; external review pending.

## Linked issue

- Closes: none
- Relates: startup fatal reported from the live runtime on 2026-08-10

## Variant addition checklist

- [x] **OCaml** — policy and typed rejection variants are declared in `.ml`/`.mli`; all matches are exhaustive
- [x] **TypeScript** — N/A: no wire or dashboard union changed
- [x] **TLA+ spec** — N/A: no state-machine domain changed
- [x] **Event / JSON schema** — N/A: no event or JSON enum changed
- [x] **`make check-variants` passes** — `bash scripts/check-variants.sh` passed locally

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/exact-output-unbound-target-degrade-20260810` → `main` · 1 commit(s) · synced 2026-08-10T01:12:01Z

| sha | subject | date |
|---|---|---|
| `079d62d7e` | fix(runtime): isolate unbound exact-output targets | 2026-08-10 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->