### PR TITLE
fix(dashboard): 라우트만 있고 링크가 없던 섹션 4개를 배선한다

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -33,6 +33,7 @@ const TARGET_FILES = [
   'src/components/mission.ts',
   'src/components/runtime-monitor.ts',
   'src/components/session-trace/session-trace-live-store.ts',
+  'src/components/common/section-nav.ts',
   'src/components/status.ts',
   'src/components/transport-health.ts',
   'src/dashboard-ws.ts',

--- a/dashboard/src/components/common/section-nav.ts
+++ b/dashboard/src/components/common/section-nav.ts
@@ -1,0 +1,58 @@
+// Section navigation strip.
+//
+// A surface dispatches its sections with `section === 'x' ? html\`...\`` and
+// nothing in that shape produces a link: adding a route draws the section once
+// you arrive, never a way to get there. #27547 counted 23 sections that were
+// routable with no rendered link anywhere in the app, because the nav that
+// used to draw section sublists ([SideRail]) was declared and never mounted.
+//
+// Monitor got a strip of its own first; this is that strip with the tab lifted
+// to a prop, so a surface mounts it instead of restating it. The section list
+// comes from the same registry the router validates against, so a section
+// cannot be routable and unlisted at the same time.
+import { html } from 'htm/preact'
+import {
+  DASHBOARD_SURFACES,
+  visibleSectionItemsForTab,
+} from '../../config/navigation'
+import type { TabId } from '../../types'
+import { RouteLink } from './route-link'
+
+function tabLabel(tab: TabId): string {
+  return DASHBOARD_SURFACES.find(surface => surface.tabs.includes(tab))?.label ?? tab
+}
+
+/**
+ * Links to every visible section of `tab`, marking `current` as the page.
+ *
+ * Renders nothing when the tab has fewer than two visible sections: the tab's
+ * own nav entry is then the only way in and already exists.
+ */
+export function SectionNav({ tab, current }: { tab: TabId, current: string }) {
+  const items = visibleSectionItemsForTab(tab)
+  if (items.length < 2) return null
+  return html`
+    <nav
+      class="flex flex-wrap items-center gap-1 border-b border-[var(--color-border-divider)] pb-2"
+      aria-label="${tabLabel(tab)} sections"
+      data-testid="section-nav-${tab}"
+    >
+      ${items.map(item => {
+        const active = item.params.section === current
+        return html`
+          <${RouteLink}
+            tab=${tab}
+            params=${item.params}
+            title=${item.description}
+            ariaCurrent=${active ? 'page' : undefined}
+            class="rounded-[var(--r-0)] border px-2 py-0.5 font-mono text-[var(--fs-10)] uppercase leading-5 tracking-[var(--track-sub)] cursor-pointer transition-[background-color,border-color,color] duration-[var(--t-med)] ${active
+              ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)]'
+              : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-primary)]'}"
+          >
+            ${item.label}
+          <//>
+        `
+      })}
+    </nav>
+  `
+}

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -5,6 +5,7 @@ import { HarnessHealth } from './harness-health'
 import { LabPerf } from './lab-perf'
 import { KeeperMemoryHealth } from './memory/keeper-memory-health'
 import { AuditIntegrity } from './memory/audit-integrity'
+import { SectionNav } from './common/section-nav'
 import { SurfaceHeader } from './common/surface-header'
 
 type LabSection =
@@ -32,6 +33,7 @@ export function Lab() {
 
   return html`
     <div class="v2-lab-surface ss-surface bg-surface-page flex flex-col gap-6" data-testid="lab-surface">
+      <${SectionNav} tab="lab" current=${section} />
       <${SurfaceHeader} />
       ${section === 'tools' ? html`
         <${Tools} />

--- a/dashboard/src/components/section-nav-reachability.test.ts
+++ b/dashboard/src/components/section-nav-reachability.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+//
+// Reachability, not shape. #27547 counted 23 routable sections with no
+// rendered link; the Monitor strip closed 19 of them and left 4, all on the
+// two other tabs that carry more than one visible section:
+//
+//   workspace/verification, lab/performance,
+//   lab/keeper-memory-health, lab/audit-integrity
+//
+// Every pure-function test over the section table passed the whole time. The
+// registry always knew those sections existed — what was missing was a
+// component that turned the registry into links, so these cases render the
+// surface a user actually lands on and ask whether they can click their way
+// in. Mounting the strip is the assertion; remove it from either surface and
+// these fail.
+import { cleanup, render, screen, within } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import { html } from 'htm/preact'
+import { route } from '../router'
+import { visibleSectionItemsForTab } from '../config/navigation'
+import type { TabId } from '../types'
+import { Lab } from './lab'
+import { Work } from './work'
+
+afterEach(cleanup)
+
+const SURFACES: Array<{ tab: TabId, name: string, landing: string, Surface: unknown }> = [
+  { tab: 'lab', name: 'Lab', landing: 'tools', Surface: Lab },
+  { tab: 'workspace', name: 'Work', landing: 'work', Surface: Work },
+]
+
+for (const { tab, name, landing, Surface } of SURFACES) {
+  describe(`${name} section navigation`, () => {
+    function renderAt(section: string) {
+      route.value = { tab, params: { section }, postId: null }
+      render(html`<${Surface} />`)
+      return screen.getByTestId(`section-nav-${tab}`)
+    }
+
+    it('renders a link to every visible section', () => {
+      const nav = renderAt(landing)
+      for (const item of visibleSectionItemsForTab(tab)) {
+        expect(within(nav).getByText(item.label)).toBeTruthy()
+      }
+    })
+
+    // The landing is where clicking the tab puts you. A strip that only
+    // rendered on the non-default sections would leave the one screen users
+    // arrive at with no way out — the exact shape of the original defect.
+    it('renders on the landing section, not only on the others', () => {
+      expect(renderAt(landing)).toBeTruthy()
+    })
+
+    it('marks the section being viewed as current', () => {
+      const items = visibleSectionItemsForTab(tab)
+      const target = items.find(item => item.params.section !== landing)
+      expect(target).toBeTruthy()
+      const section = target?.params.section as string
+      const nav = renderAt(section)
+      const active = within(nav).getByText(target?.label as string).closest('a')
+      expect(active?.getAttribute('aria-current')).toBe('page')
+    })
+  })
+}
+
+// Named rather than derived: the point is that these four specific sections
+// were unreachable, and a loop over the registry would keep passing if one of
+// them were quietly dropped from it.
+describe('sections that #27547 left unreachable', () => {
+  const ORPHANS: Array<[TabId, string, string, unknown]> = [
+    ['workspace', 'verification', 'work', Work],
+    ['lab', 'performance', 'tools', Lab],
+    ['lab', 'keeper-memory-health', 'tools', Lab],
+    ['lab', 'audit-integrity', 'tools', Lab],
+  ]
+
+  for (const [tab, section, landing, Surface] of ORPHANS) {
+    it(`links to ${tab}/${section} from the landing`, () => {
+      route.value = { tab, params: { section: landing }, postId: null }
+      render(html`<${Surface} />`)
+      const nav = screen.getByTestId(`section-nav-${tab}`)
+      const item = visibleSectionItemsForTab(tab)
+        .find(entry => entry.params.section === section)
+      expect(item).toBeTruthy()
+      const link = within(nav).getByText(item?.label as string).closest('a')
+      expect(link).toBeTruthy()
+      expect(link?.getAttribute('href')).toContain(`section=${section}`)
+    })
+  }
+})

--- a/dashboard/src/components/status-section-nav.test.ts
+++ b/dashboard/src/components/status-section-nav.test.ts
@@ -17,7 +17,7 @@ afterEach(cleanup)
 function renderAt(section: string) {
   route.value = { tab: 'monitoring', params: { section }, postId: null }
   render(html`<${Status} />`)
-  return screen.getByTestId('monitor-section-nav')
+  return screen.getByTestId('section-nav-monitoring')
 }
 
 describe('Monitor section navigation', () => {

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -5,9 +5,9 @@
 import { html } from 'htm/preact'
 import { lazy, Suspense } from 'preact/compat'
 import { route } from '../router'
-import { sectionItemsForTab, visibleSectionItemsForTab } from '../config/navigation'
+import { sectionItemsForTab } from '../config/navigation'
 import { LoadingState } from './common/feedback-state'
-import { RouteLink } from './common/route-link'
+import { SectionNav } from './common/section-nav'
 import { SurfaceHeader } from './common/surface-header'
 
 export type StatusSection =
@@ -97,44 +97,6 @@ function currentSection(): StatusSection {
   return normalizeStatusSection(route.value.params.section)
 }
 
-/* Every Monitor section except the 'agents' landing was routable but had no
-   rendered link anywhere in the app. The nav that used to draw section
-   sublists ([SideRail]) is never mounted — the live rail ([NavRailV2]) has no
-   section concept, and [SurfaceHeader] only renders the current section as a
-   breadcrumb label. So 'internal-agents', which carries librarian and judge
-   runs, could only be reached by typing #monitoring?section=internal-agents.
-   This strip is that missing link, and it renders on the landing too — the
-   'agents' branch below returns before [SurfaceHeader], so putting it there
-   would have left the one screen users actually arrive at without a way out. */
-function MonitorSectionNav({ current }: { current: StatusSection }) {
-  const items = visibleSectionItemsForTab('monitoring')
-  if (items.length < 2) return null
-  return html`
-    <nav
-      class="flex flex-wrap items-center gap-1 border-b border-[var(--color-border-divider)] pb-2"
-      aria-label="Monitor sections"
-      data-testid="monitor-section-nav"
-    >
-      ${items.map(item => {
-        const active = item.params.section === current
-        return html`
-          <${RouteLink}
-            tab="monitoring"
-            params=${item.params}
-            title=${item.description}
-            ariaCurrent=${active ? 'page' : undefined}
-            class="rounded-[var(--r-0)] border px-2 py-0.5 font-mono text-[var(--fs-10)] uppercase leading-5 tracking-[var(--track-sub)] cursor-pointer transition-[background-color,border-color,color] duration-[var(--t-med)] ${active
-              ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)]'
-              : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-primary)]'}"
-          >
-            ${item.label}
-          <//>
-        `
-      })}
-    </nav>
-  `
-}
-
 export function Status() {
   const section = currentSection()
 
@@ -146,7 +108,7 @@ export function Status() {
     // row above a min-h-0 flex child rather than an extra wrapper card.
     return html`
       <div class="v2-monitoring-surface flex h-full min-h-0 flex-col gap-3">
-        <${MonitorSectionNav} current=${section} />
+        <${SectionNav} tab="monitoring" current=${section} />
         <div class="min-h-0 flex-1">
           <${Suspense} fallback=${sectionFallback(sectionLabel('agents'))}>
             <${LazyAgentsUnified} />
@@ -158,7 +120,7 @@ export function Status() {
 
   return html`
     <div class="v2-monitoring-surface flex flex-col gap-5">
-      <${MonitorSectionNav} current=${section} />
+      <${SectionNav} tab="monitoring" current=${section} />
       <${SurfaceHeader} />
       <div class="transition-opacity duration-[var(--t-slow)]">
         <${Suspense} fallback=${sectionFallback(sectionLabel(section))}>

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -21,7 +21,12 @@ vi.mock('../api/mcp', () => ({
   callMcpTool: callMcpToolMock,
 }))
 
-vi.mock('../router', () => ({
+// Only the two entry points this file drives are replaced. The rest of the
+// module stays real because the surface renders RouteLink, which calls
+// hashForRoute: a mock listing just route and navigate left that undefined,
+// and every case here failed on the call once Work mounted its section nav.
+vi.mock('../router', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../router')>(),
   get route() { return routeSignal },
   navigate: navigateMock,
 }))

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -18,6 +18,7 @@ import { VerificationRequestsPanel } from './verification-requests-panel'
 import { VerificationRunsPanel } from './verification-runs-panel'
 import { ErrorBoundary } from './common/error-boundary'
 import { LoadingState } from './common/feedback-state'
+import { SectionNav } from './common/section-nav'
 import { VirtualList } from './common/virtual-list'
 import { KeeperBadge } from './keeper-badge'
 import { openTaskDetail } from './goals/task-detail-state'
@@ -1636,6 +1637,7 @@ export function Work() {
 
   return html`
     <div class="v2-workspace-surface flex min-w-0 flex-col gap-3">
+      <${SectionNav} tab="workspace" current=${current} />
       <${ErrorBoundary} label=${current}>
         ${current === 'work' ? html`<${WorkSurfaceV2} />`
           : current === 'board' ? html`<${BoardSurface} />`


### PR DESCRIPTION
Closes #27547

## 무엇이 문제였나

#27547 은 "라우트만 있고 렌더된 링크가 없는 섹션 23개"를 보고했습니다. 섹션 sublist 를 그리던 nav 가 선언만 되고 마운트되지 않은 상태였습니다.

이후 Monitor 전용 strip 이 추가되며 19개가 닫혔습니다. **남은 4개**는 visible 섹션이 2개 이상인 나머지 두 탭에 있습니다.

| tab | section |
|-----|---------|
| workspace | `verification` |
| lab | `performance` |
| lab | `keeper-memory-health` |
| lab | `audit-integrity` |

해시를 직접 타이핑해야만 도달할 수 있었습니다.

## 왜 생겼나

`lab.ts` · `work.ts` 는 섹션을 삼항 사슬로 디스패치합니다.

```ts
${section === 'keeper-memory-health' ? html`<${KeeperMemoryHealth} />` : null}
```

이 형태는 **"도착하면 그리는 코드"와 "가는 링크"를 구조적으로 분리**합니다. 라우트를 추가해도 링크가 생기지 않고, 섹션 테이블 위의 순수 함수 테스트는 전부 통과합니다 — 레지스트리는 그 섹션들의 존재를 처음부터 알고 있었으니까요. 없던 건 레지스트리를 링크로 바꾸는 컴포넌트입니다.

## 변경

Monitor strip 은 이미 `visibleSectionItemsForTab` 위에서 돌고 `items.length < 2` 면 `null` 을 반환하는 제네릭 컴포넌트였고, **탭만 하드코딩**돼 있었습니다. 탭을 prop 으로 올려 `common/section-nav.ts` 로 옮기고 Lab · Work 에 마운트했습니다.

visible 섹션이 1개인 탭(`command` · `connectors` · `code`)은 계속 아무것도 그리지 않습니다. 그 탭의 nav 항목 자체가 유일한 진입로이고 이미 존재합니다.

`data-testid` 는 `monitor-section-nav` → `section-nav-${tab}` 으로 바뀌었습니다. 탭별 특수 케이스를 만들지 않기 위해서고, 기존 테스트 1곳을 함께 고쳤습니다.

## 로컬 검증

### 1. 계측 — 대조군 2개

섹션 도달 경로는 두 가지고 한쪽만 grep 하면 과다 집계됩니다: **제네릭 nav**(섹션 문자열이 컴포넌트에 리터럴로 안 나타남) 와 **리터럴 링크**. 그래서 대조군을 걸었습니다.

| 대조군 | 기대 |
|--------|------|
| `internal-agents` — 이 계열 수정이 노출하려던 바로 그 섹션 | reachable |
| 존재하지 않는 섹션 id | unreachable |

```
BEFORE (origin/main b9359de911)
CONTROL reachable(internal-agents)=True  unreachable(...)=True
orphaned visible sections: 4
  workspace/verification · lab/performance · lab/keeper-memory-health · lab/audit-integrity
tabs with >=2 visible sections: ['lab','monitoring','workspace']
... missing a generic nav: ['lab','workspace']

AFTER
CONTROL reachable(internal-agents)=True  unreachable(...)=True
orphaned visible sections: 0
... missing a generic nav: []
```

이 대조군이 두 번 일을 했습니다. 처음 실행에서 `rg -o --no-heading` 이 경로 접두를 남겨 탭 이름이 깨졌을 때, 그리고 이 PR 이 탭을 prop 으로 바꾼 뒤 탐지 규칙이 낡아 "모든 탭에 nav 없음"으로 읽혔을 때. 둘 다 **보고 전에** 멈췄습니다.

### 2. 뮤테이션 — 마운트를 지우면 빨개지는가

```
$ # lab.ts / work.ts 의 <${SectionNav} ...> 두 줄 삭제
Tests  10 failed | 4 passed (14)
```

새 케이스 10개가 전부 실패하고, **Monitor 케이스 4개는 초록으로 남습니다**. 실패가 전역 파손이 아니라 지운 마운트에 특정된다는 걸 그 4개가 증명합니다. 복원하면 14/14 통과.

### 3. 전체 스위트

```
$ pnpm test
Test Files  639 passed (639)
     Tests  8870 passed (8870)

$ pnpm run typecheck      # tsc --noEmit, clean
$ pnpm exec eslint src/components/common/section-nav.ts    # clean
```

`work.test.ts` 60건이 처음엔 전부 깨졌습니다. 원인은 그 파일이 `'../router'` 를 `route`/`navigate` 만으로 목킹해 **`hashForRoute` 가 undefined** 였던 것 — Work 가 링크를 그리기 시작하자 드러났습니다. baseline(내 변경 stash 후)이 60/60 초록인 걸 먼저 확인하고, 목이 실제 모듈을 spread 하도록 고쳤습니다. 이제 목이 surface 가 호출하는 것으로부터 드리프트할 수 없습니다.

## 이 PR 이 건드리지 않는 것

- 숨김 섹션 6개 (`transport-health` · `feature-health` · `journey` · `board` · `sub-boards` · `moderation`) — `hidden: true` 는 의도된 상태이므로 그대로 둡니다.
- `scripts/dashboard-drift-check.sh` 는 이 브랜치에서 exit 2 인데 **origin/main 에서도 동일하게 exit 2** 입니다(`text-px-literal: 51 > baseline 12`, 51건 전부 기존 코드). 이 PR 은 그 수를 늘리지도 줄이지도 않습니다. CI 에서 이 게이트가 초록인 이유는 별건이며 #27965 로 분리했습니다.

RFC-WAIVED: dashboard 표면 네비게이션 배선. credential/identity/operator/sandbox/hooks 등 RFC 게이트 대상 subsystem 을 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
