### PR TITLE
fix(runtime): admit empty Codex content delta chunks

### DIFF
--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -191,6 +191,18 @@ let optional_string stage name fields =
   | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
 ;;
 
+(* Streamed content chunks: the wire type must be a string, but emptiness is a
+   value-level non-issue — command output legitimately streams ""- and
+   whitespace-only chunks (String.trim would reject a lone "\n"), and the
+   observational delta consumers discard the value. Identity fields keep
+   [required_string]. *)
+let required_content_string stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
 let required_bool stage name fields =
   match List.assoc_opt name fields with
   | Some (`Bool value) -> Ok value
@@ -514,7 +526,7 @@ let validate_item_delta_notification ~method_ ~thread_id ~turn_id params =
   let* notification_thread_id = required_string method_ "threadId" fields in
   let* notification_turn_id = required_string method_ "turnId" fields in
   let* _item_id = required_string method_ "itemId" fields in
-  let* _delta = required_string method_ "delta" fields in
+  let* _delta = required_content_string method_ "delta" fields in
   if notification_thread_id <> thread_id || notification_turn_id <> turn_id
   then protocol_error method_ "item delta identity does not match the active turn"
   else Ok ()

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -467,6 +467,36 @@ let test_item_output_deltas_are_typed_and_unbounded () =
       | Ok result ->
         check string "terminal text" "MASC_SUBSCRIPTION_OK" result.text
       | Error error -> fail (Runtime_codex_app_server.error_to_string error));
+  (* Live incident 2026-08-10 (masc#27953): command output legitimately streams
+     empty and whitespace-only chunks; a lone "\n" trims to "" and killed the
+     turn as a protocol error. Content chunks are typed string, not
+     non-empty-after-trim. *)
+  let content_delta value =
+    Printf.sprintf
+      {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"command-1","delta":%s}}|}
+      value
+  in
+  with_fixture
+    ([ init_result; account_chatgpt; thread_result; turn_result ]
+     @ [ content_delta {|""|}; content_delta {|"\n"|}; content_delta {|"   "|} ]
+     @ [ item_completed; turn_completed ])
+    (fun path ->
+      match run_fixture path with
+      | Ok result ->
+        check string "empty and whitespace deltas admitted" "MASC_SUBSCRIPTION_OK" result.text
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error));
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; content_delta "7"
+    ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "non-string delta was admitted");
   let wrong_identity =
     {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-other","turnId":"turn-1","itemId":"command-1","delta":"chunk"}}|}
   in


### PR DESCRIPTION
## Summary

- 관측용 item delta 알림(`item/agentMessage/delta`, `item/commandExecution/outputDelta`, `item/fileChange/outputDelta`, `item/plan/delta`)의 `delta` 필드를 `required_string`(trim 후 비어있으면 protocol error)으로 디코드하던 것을, 새 `required_content_string`(string 타입만 강제, 공백/빈 값 허용)으로 교체합니다.
- 신원 필드(`threadId`/`turnId`/`itemId`)는 기존 non-empty 강제를 유지합니다. non-string delta는 여전히 protocol error입니다.

## Root cause (라이브 사고 2026-08-10 10:16 KST, #27953)

`b9359de911` 라이브에서 sangsu의 restart_fresh 첫 턴이 즉사:

```
Internal error: Codex app-server protocol error during item/commandExecution/outputDelta:
field "delta" must be a non-empty string
```

- `validate_item_delta_notification`은 delta 값을 `_delta`로 **버립니다** — 소비자가 없는 관측용 필드입니다.
- 그런데 `required_string`은 `String.trim value <> ""`를 요구하므로, 명령 출력 스트리밍에서 흔한 **빈 청크와 개행-단독 청크(`"\n"` → trim 후 `""`)**가 protocol error → 턴 사망 → `recovery_required`가 됩니다.
- #27954("keep Codex progress notifications observational")와 같은 계열의 잔존물: 관측용 알림의 값-레벨 엄격성이 turn-fatal로 승격돼 있던 마지막 지점입니다.

## Tests

`test_runtime_codex_app_server.ml`의 기존 wired 케이스 `item output deltas are typed and unbounded` 확장:

- `""`, `"\n"`, `"   "` delta가 섞인 스트림이 턴을 완주 (수정 전에는 protocol error — red 측 증거는 위 라이브 사고 그 자체)
- 숫자(non-string) delta는 여전히 `Protocol_error`로 거부
- 신원 불일치 거부 케이스는 기존 그대로 유지

## Known verification boundary

- 라이브 재현 조건(실제 codex CLI가 empty delta를 보내는 시점)은 확률적입니다. 배포 후 sangsu recovery 해제 → 턴 settle 관측으로 라이브 검증 예정.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
