### PR TITLE
fix(runtime): 빈 스트림 청크로 Codex 턴을 끝내지 않는다 (거부된 턴 3,236건)

### DIFF
--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -191,6 +191,16 @@ let optional_string stage name fields =
   | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
 ;;
 
+(* Present and a string, with no constraint on its contents. For payload
+   fields whose value this decoder does not read: an emptiness rule there
+   ends the turn over a byte nobody looks at. *)
+let required_string_any stage name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string" name)
+  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+;;
+
 let required_bool stage name fields =
   match List.assoc_opt name fields with
   | Some (`Bool value) -> Ok value
@@ -509,12 +519,23 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
 
 let max_retry_notifications = 3
 
+(* What this decides is identity: does this delta belong to the turn we are
+   awaiting. threadId, turnId and itemId are identifiers, so emptiness in one
+   of them is malformed and stays rejected.
+
+   delta carries stream payload this function never reads, and an empty or
+   whitespace chunk is ordinary in a streaming protocol. Requiring it to be
+   non-empty turned such a chunk into a terminal protocol error, which put the
+   official-client session into Recovery_required and made every later turn for
+   that keeper fail closed on `official_client_session.claim` until an operator
+   resolved it by hand. Three such chunks accounted for 3,236 rejected turns
+   across sangsu, kidsnote and taskmaster in one retained log window (#27967). *)
 let validate_item_delta_notification ~method_ ~thread_id ~turn_id params =
   let* fields = assoc_at method_ params in
   let* notification_thread_id = required_string method_ "threadId" fields in
   let* notification_turn_id = required_string method_ "turnId" fields in
   let* _item_id = required_string method_ "itemId" fields in
-  let* _delta = required_string method_ "delta" fields in
+  let* _delta = required_string_any method_ "delta" fields in
   if notification_thread_id <> thread_id || notification_turn_id <> turn_id
   then protocol_error method_ "item delta identity does not match the active turn"
   else Ok ()

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -479,6 +479,64 @@ let test_item_output_deltas_are_typed_and_unbounded () =
       | Ok _ -> fail "item output delta with the wrong identity was admitted")
 ;;
 
+(* An empty or whitespace stream chunk is ordinary in a streaming protocol and
+   this decoder never reads the payload. It used to reject both, which ended
+   the turn, put the official-client session into Recovery_required, and made
+   every later turn for that keeper fail closed until an operator resolved it
+   by hand: three such chunks accounted for 3,236 rejected turns across sangsu,
+   kidsnote and taskmaster in one retained log window (#27967).
+
+   The rejections that must survive are in the same test, because widening a
+   decoder is only correct if it stops accepting nothing else: an empty
+   identifier, a delta that is not a string, an absent delta, and a chunk
+   belonging to another turn. *)
+let test_empty_output_delta_does_not_end_the_turn () =
+  let delta payload =
+    Printf.sprintf
+      {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"command-1","delta":%s}}|}
+      payload
+  in
+  List.iter
+    (fun (label, payload) ->
+      with_fixture
+        [ init_result
+        ; account_chatgpt
+        ; thread_result
+        ; turn_result
+        ; delta payload
+        ; item_completed
+        ; turn_completed
+        ]
+        (fun path ->
+          match run_fixture path with
+          | Ok result -> check string label "MASC_SUBSCRIPTION_OK" result.text
+          | Error error -> fail (Runtime_codex_app_server.error_to_string error)))
+    [ "empty delta", {|""|}
+    ; "whitespace delta", {|"   "|}
+    ; "newline delta", {|"\n"|}
+    ];
+  List.iter
+    (fun (label, notification) ->
+      with_fixture
+        [ init_result; account_chatgpt; thread_result; turn_result; notification ]
+        (fun path ->
+          match run_fixture path with
+          | Error (Runtime_codex_app_server.Protocol_error _) -> ()
+          | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+          | Ok _ -> fail label))
+    [ ( "a non-string delta was admitted", delta "42" )
+    ; ( "a delta that is not present was admitted"
+      , {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"command-1"}}|}
+      )
+    ; ( "an empty itemId was admitted"
+      , {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"","delta":"chunk"}}|}
+      )
+    ; ( "an empty turnId was admitted"
+      , {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"","itemId":"command-1","delta":"chunk"}}|}
+      )
+    ]
+;;
+
 let codex_runtime_toml ~model cli_path =
   Printf.sprintf
     "[providers.codex]\n\
@@ -1959,6 +2017,10 @@ let () =
              "item output deltas are typed and unbounded"
              `Quick
              test_item_output_deltas_are_typed_and_unbounded
+         ; test_case
+             "an empty output delta does not end the turn"
+             `Quick
+             test_empty_output_delta_does_not_end_the_turn
         ; test_case
             "turn admission validation is process-free"
             `Quick


### PR DESCRIPTION
Closes #27967

## 무엇이 문제였나

`validate_item_delta_notification` 이 판정하는 건 **동일성 하나**입니다 — 이 델타가 지금 기다리는 턴의 것인가. 비교 대상은 `threadId`/`turnId` 입니다.

그런데 `delta` 는 `_delta` 로 **버려지면서** non-empty 를 요구했고, `String.trim` 때문에 공백만 있는 청크도 거부했습니다.

```ocaml
let* _item_id = required_string method_ "itemId" fields in
let* _delta   = required_string method_ "delta"  fields in   (* 값을 안 읽는데 비어 있으면 거부 *)
if notification_thread_id <> thread_id || notification_turn_id <> turn_id
then protocol_error method_ "item delta identity does not match the active turn"
```

빈/공백 청크는 스트리밍에서 정상입니다. 여기서는 **터미널 protocol error** 가 됩니다.

## 폭발 반경 — 실측

터미널 에러 → 세션이 `Recovery_required` 로 오염 → 그 키퍼의 **이후 모든 턴이** `official_client_session.claim` 에서 fail closed. 운영자가 손으로 해소할 때까지.

decision log 27,446 턴 스캔:

| 신호 | 건수 |
|------|------|
| 오염 이벤트 | **3** |
| 그로 인해 거부된 턴 | **3,236** |

| keeper | 거부된 턴 | 구간 |
|--------|-----------|------|
| sangsu | 1,272 | 12.8h |
| kidsnote | 1,136 | 11.7h |
| taskmaster | 828 | 7.7h |

## 재기동으로 안 났었다

부모 커밋(`b9359de911`)으로 재기동한 뒤 42분 실측:

| keeper | 재기동 전 6h | 재기동 후 42m |
|--------|--------------|---------------|
| analyst · code-reviewer · rondo | 100% | 100% |
| lane-smith | 100.0% (575) | 98.0% (51) |
| kidsnote | 5.0% (643) | 100.0% (28) |
| **sangsu** | **0.0% (653)** | **0.0% (60)** |
| taskmaster | 0.2% (650) | 5.1% (59) |
| fleet | 55.2% (4,270) | 67.2% (357) |

sangsu 의 recovery_id 가 재기동을 넘어 `e8cd611e…` → `36acb595…` 로 **새로 생겼습니다**. 상태 잔재가 아니라 재생산입니다.

집계만 보면 55.2% → 67.2% 로 "개선"이지만, 쪼개면 **정상 4대는 처음부터 100% 였고 고장 3대 중 1대만 나았습니다.** 집계가 이걸 감췄습니다.

라이브 sangsu 의 recovery 를 `restart_fresh` 로 해소한 뒤 6.8분:

```
sangsu       turns=4    {'success': 4}
taskmaster   turns=8    {'success': 6, 'error': 2}
kidsnote     turns=6    {'success': 6}
```

## 변경

`delta` 는 **존재 + string 타입**만 요구하고 내용에는 제약을 두지 않습니다. 식별자(`threadId`·`turnId`·`itemId`)는 emptiness 규칙을 유지합니다 — 빈 식별자는 정상이 아니라 malformed 이기 때문입니다.

```ocaml
(* Present and a string, with no constraint on its contents. For payload
   fields whose value this decoder does not read: an emptiness rule there
   ends the turn over a byte nobody looks at. *)
let required_string_any stage name fields = ...
```

## 로컬 검증

디코더를 넓히는 변경은 **다른 것을 새로 받아들이지 않을 때만** 옳습니다. 그래서 같은 테스트 케이스 안에 허용 3종과 **살아남아야 할 거부 4종**을 함께 넣었습니다.

| 입력 | 기대 |
|------|------|
| `"delta": ""` | 턴 완료 |
| `"delta": "   "` | 턴 완료 |
| `"delta": "\n"` | 턴 완료 |
| `"delta": 42` | protocol error |
| `delta` 필드 없음 | protocol error |
| `"itemId": ""` | protocol error |
| `"turnId": ""` | protocol error |

```
$ dune build --force @test/runtest-test_runtime_codex_app_server
Test Successful in 9.849s. 32 tests run     ← 3회 반복, 모두 동일
```

**뮤테이션**: `lib/` 만 부모 커밋으로 되돌리고 새 테스트를 그대로 두면

```
[FAIL]  subscription boundary  14   an empty output delta does...
ASSERT  Codex app-server protocol error during item/commandExecution/outputDelta:
        field "delta" must be a non-empty string
1 failure! in 12.608s. 32 tests run
```

프로덕션 에러 문자열과 **정확히 일치**하고, 나머지 31건은 초록으로 남습니다.

부모 커밋 baseline: `Test Successful in 13.921s. 31 tests run`.

**참고**: 첫 실행에서 `declared cwd reaches spawn` 이 2초 타임아웃으로 실패했는데, 강제 재실행 3회 모두 초록이었습니다. 부하 기인 flaky 이며 이 변경과 무관합니다(그 테스트는 spawn cwd 를 봅니다).

## 이 PR 이 하지 않는 것

- `_item_id` 도 버려지지만 `required_string` 을 유지했습니다. 같은 *모양*이지만 같은 *결함*은 아닙니다 — 빈 델타는 프로토콜상 정상이고, 빈 식별자는 아닙니다. 관측된 실패도 없습니다.
- 이미 `Recovery_required` 에 빠진 세션을 자동 해소하지 않습니다. 이 PR 은 새로 빠지는 것을 막습니다.

RFC-WAIVED: Codex app-server 프로토콜 디코더의 필드 제약 수정. credential/identity/operator/sandbox/hooks 등 RFC 게이트 대상 subsystem 을 건드리지 않음.

관련: #27953 · #27954 (같은 계열 — app-server 디코더 과잉 엄격성이 세션을 교착시킴)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
