### PR TITLE
docs(types): Gemini 서명이 어디 있는지 정의 지점에 적는다

### DIFF
--- a/packages/agent_core/lib/llm_provider/types.ml
+++ b/packages/agent_core/lib/llm_provider/types.ml
@@ -918,12 +918,21 @@ type content_block =
       { content : string
       ; signature : string option
         (** [Some s]: Anthropic cryptographic signature, replayed byte-exact on
-            tool turns (never sanitized or re-encoded). [None]: provider
-            reasoning that carries no verification signature
-            (OpenAI-compatible / Gemini / GLM / Ollama). Replaces the former
-            [thinking_type : string], which conflated this signature with a
-            free-form provider label ("reasoning" / "thinking" /
-            "reasoning_summary") that no consumer read. *)
+            tool turns (never sanitized or re-encoded). Only the Anthropic wire
+            parse populates it; every other backend constructs [None].
+
+            [None] says this block carries no signature, not that the provider
+            has none. Gemini signs too, and its [thoughtSignature] rides in a
+            {!RedactedThinking} carrier instead — see
+            [Backend_gemini.gemini_thought_signature_carrier] — which is why
+            {!Reasoning_dialect} gives Gemini a replay policy that keeps signed
+            parts attached to their exact response part. Reading [None] here as
+            "Gemini is signature-less" contradicts that policy and is the
+            misreading this paragraph exists to prevent.
+
+            Replaces the former [thinking_type : string], which conflated this
+            signature with a free-form provider label ("reasoning" /
+            "thinking" / "reasoning_summary") that no consumer read. *)
       }
   | ReasoningDetails of
       { reasoning_content : string option


### PR DESCRIPTION
Closes #27873

## 무엇이 문제였나

`Thinking.signature` 의 문서 주석이 Gemini 를 **무서명 그룹**에 나열합니다.

```ocaml
(** [Some s]: Anthropic cryptographic signature ...
    [None]: provider reasoning that carries no verification signature
    (OpenAI-compatible / Gemini / GLM / Ollama). *)
```

**이 필드에 관한 서술로는 맞습니다.** 실측 (`packages/agent_core/lib/llm_provider/`):

| 생산자 | `Thinking.signature` |
|--------|----------------------|
| Anthropic wire parse (`api_common.ml`) | `Some s` |
| `backend_gemini.ml` · `backend_glm.ml` · `backend_openai*.ml` · `backend_ollama.ml` | `signature = None` |

## 그런데 Gemini 에 관한 서술로 읽으면 틀립니다

Gemini 도 서명합니다. `thoughtSignature` 가 **다른 블록**에 실립니다:

```ocaml
(* backend_gemini.ml:191 *)
let gemini_thought_signature_carrier ~tool_use_id ~thought_signature =
  RedactedThinking (gemini_thought_signature_payload ~tool_use_id ~thought_signature)
```

그래서 `reasoning_dialect.ml:550` 의 Gemini arm 이 이렇게 말합니다:

```ocaml
| Gemini ->
  { default with
    toggle_wire = Gemini_thinking_config
  ; (* GenerateContent is stateless. Signed parts must remain attached to the
       exact model response part and be returned unchanged. *)
    replay_policy = All_assistant_messages
```

두 주석은 **모순이 아닙니다** — 서로 다른 캐리어를 말합니다. 하지만 정의 지점에 그 사실이 없었습니다.

## 실제로 오독됐습니다

#27873 이 이 문장을 "`reasoning_dialect` 와 모순된다"며 P1 로 제기했습니다. 작성자는 두 주석만 읽고 합리적으로 추론했고, 정의 지점이 캐리어를 말해주지 않아 확인할 방법이 없었습니다.

이슈 본문은 Gemini arm 의 정책을 `Preserve_always` 라고 적었는데 현재는 `All_assistant_messages` 입니다. 변형 이름만 바뀌었고 요구는 같아 판정에 영향이 없습니다.

## 변경

`[None]` 이 **"이 블록에 서명이 없다"**이지 **"그 provider 에 서명이 없다"**가 아님을 명시하고, Gemini 의 서명이 어디 있는지 이름으로 가리킵니다.

## 왜 문서 수정이 값어치가 있나

이 저장소는 사람뿐 아니라 **에이전트가 소스를 읽는 것을 전제**로 합니다 (#26654 가 같은 근거로 죽은 심볼 나열을 문제 삼았습니다). "Gemini 는 서명이 없다"로 읽히는 필드 주석은 틀린 문장 하나로 끝나지 않고 **틀린 replay 결정**이 됩니다 — 서명을 버려도 된다고 판단하는 코드가 이 주석을 근거로 인용할 수 있습니다.

## 왜 masc 인가 — oas 는 어제 archived 됐습니다

이 이슈는 oas 경로(`lib/llm_provider/types.ml`)를 인용해 "타 저장소 귀속"으로 분류돼 있었습니다. 그 판정이 더 이상 성립하지 않습니다.

| | |
|---|---|
| oas archived | **2026-08-09T16:15:36Z** (마지막 push 08-07) |
| 같은 코드의 현재 위치 | `packages/agent_core/lib/llm_provider/types.ml` |

oas 는 read-only 라 **거기서는 아무것도 고칠 수 없습니다**(push 시 `403 This repository was archived`). 실제로 oas 브랜치에 같은 수정을 만들었다가 push 가 거부돼 masc 로 옮겼습니다.

이건 이 이슈 하나의 문제가 아닙니다. oas 귀속으로 분류된 open 이슈 **57건 중 53건**이 인용 경로가 지금 `packages/agent_core/` 아래 존재합니다 — 즉 masc 에서 수정 가능합니다. 별도로 정리하겠습니다.

## 검증

```
$ dune build @check     exit=0
```

용어 변경 없음, 문서 전용입니다.

RFC-WAIVED: 문서 주석 한 곳 수정. credential/identity/operator/sandbox/hooks 등 RFC 게이트 대상 subsystem 을 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
