### PR TITLE
fix(keeper): Read 가 cwd 를 거부할 때 통했을 cwd 를 이름으로 댄다

### DIFF
--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -193,6 +193,42 @@ let string_opt_nonempty name json =
     if trimmed = "" then None else Some trimmed
 ;;
 
+(* The rejection names the cwds that would have worked.
+   A keeper that guesses the host layout ("workspace/<org>/<repo>") gets the
+   same "directory does not exist" as one that asked for a repo nobody
+   materialized, and the two need opposite responses: retry with the right
+   prefix, or stop asking. Live taskmaster hit the first and kept retrying
+   (#23442). The vocabulary is "repos/<repo>" -- see the projection note in
+   [resolve_read_file_cwd] -- so the accepted set is exactly what sits under
+   the keeper's playground [repos/]. An empty set is reported as empty rather
+   than omitted, because "no repository is materialized" is the answer to a
+   different question than "you named the wrong one". *)
+let materialized_repo_cwds ~config ~meta =
+  let repos_root = Filename.concat (keeper_playground_root ~config ~meta) "repos" in
+  if not (safe_is_dir repos_root)
+  then []
+  else (
+    match Sys.readdir repos_root with
+    | exception Sys_error _ -> []
+    | entries ->
+      Array.to_list entries
+      |> List.filter (fun name ->
+           (not (String.length name > 0 && name.[0] = '.'))
+           && safe_is_dir (Filename.concat repos_root name))
+      |> List.sort String.compare)
+;;
+
+let available_cwd_hint ~config ~meta =
+  match materialized_repo_cwds ~config ~meta with
+  | [] ->
+    " no repository is materialized under repos/ for this keeper, so no \
+     repos/<repo> cwd exists yet"
+  | repos ->
+    Printf.sprintf
+      " available repo cwds: %s"
+      (String.concat ", " (List.map (fun name -> "repos/" ^ name) repos))
+;;
+
 let resolve_read_file_cwd ~(config : Workspace.config) ~(meta : keeper_meta) ~cwd =
   match cwd with
   | None -> Ok (keeper_default_read_root ~config ~meta)
@@ -210,8 +246,10 @@ let resolve_read_file_cwd ~(config : Workspace.config) ~(meta : keeper_meta) ~cw
     else
       Error
         (Printf.sprintf
-           "cwd_not_directory: %s (directory does not exist; Read will not create cwd)"
-           cwd)
+           "cwd_not_directory: %s (directory does not exist; Read will not create \
+            cwd);%s"
+           cwd
+           (available_cwd_hint ~config ~meta))
 ;;
 
 let resolve_read_file_target

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -385,6 +385,105 @@ let test_repo_prefixed_missing_read_preserves_exact_input () =
     (Json.member "available_repos" json = `Null)
 ;;
 
+(* A keeper that guesses the host layout and one whose repos were never
+   materialized both got "directory does not exist", and the two need opposite
+   responses. Live taskmaster asked for
+   [workspace/yousleepwhen/masc] and retried (#23442).
+
+   The hint enumerates the playground's own [repos/]; it does not infer which
+   repo was meant. The last case pins that distinction: the file-path failure
+   keeps refusing to volunteer a repository list, which is a separate decision
+   this change does not touch. *)
+let test_cwd_rejection_names_the_materialized_repos () =
+  setup
+  @@ fun ~config ~meta ~playground ~publication_recovery:_ ->
+  allow_repo ~config ~meta "masc";
+  write_file (Filename.concat playground "repos/masc/README.md") "readme\n";
+  let raw =
+    handle_read_file
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+            [ "cwd", `String "workspace/yousleepwhen/masc"
+            ; "path", `String "README.md"
+            ; "max_bytes", `Int 4096
+            ])
+  in
+  if parse_ok raw then Alcotest.failf "expected Read to fail, got ok: %s" raw;
+  let error = Option.value (parse_string "error" raw) ~default:raw in
+  let contains needle = String_util.contains_substring error needle in
+  Alcotest.(check bool) "names the cwd vocabulary" true (contains "repos/masc");
+  Alcotest.(check bool) "still says why it failed" true
+    (contains "cwd_not_directory")
+;;
+
+let test_cwd_rejection_says_when_nothing_is_materialized () =
+  setup
+  @@ fun ~config ~meta ~playground:_ ~publication_recovery:_ ->
+  allow_repo ~config ~meta "masc";
+  let raw =
+    handle_read_file
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+            [ "cwd", `String "repos/masc"
+            ; "path", `String "README.md"
+            ; "max_bytes", `Int 4096
+            ])
+  in
+  if parse_ok raw then Alcotest.failf "expected Read to fail, got ok: %s" raw;
+  let error = Option.value (parse_string "error" raw) ~default:raw in
+  Alcotest.(check bool) "distinguishes empty from wrong" true
+    (String_util.contains_substring error "no repository is materialized")
+;;
+
+let test_valid_repo_cwd_carries_no_hint () =
+  setup
+  @@ fun ~config ~meta ~playground ~publication_recovery:_ ->
+  allow_repo ~config ~meta "masc";
+  write_file (Filename.concat playground "repos/masc/README.md") "readme\n";
+  let raw =
+    handle_read_file
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+            [ "cwd", `String "repos/masc"
+            ; "path", `String "README.md"
+            ; "max_bytes", `Int 4096
+            ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected Read ok, got: %s" raw;
+  Alcotest.(check bool) "success carries no cwd advice" false
+    (String_util.contains_substring raw "available repo cwds")
+;;
+
+let test_missing_file_still_volunteers_no_repository_list () =
+  setup
+  @@ fun ~config ~meta ~playground ~publication_recovery:_ ->
+  allow_repo ~config ~meta "masc";
+  write_file (Filename.concat playground "repos/masc/README.md") "readme\n";
+  let raw =
+    handle_read_file
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+            [ "path", `String "repos/masc/does_not_exist_xyz.ml"
+            ; "max_bytes", `Int 4096
+            ])
+  in
+  if parse_ok raw then Alcotest.failf "expected Read to fail, got ok: %s" raw;
+  Alcotest.(check bool) "no inferred repository list" true
+    (Json.member "available_repos" (parse raw) = `Null)
+;;
+
 let test_write_visible_scratch_path () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker ~always_allow:true
   @@ fun ~config ~meta ~playground ~publication_recovery ->
@@ -447,6 +546,22 @@ let () =
             "repo-prefixed missing read surfaces playground hint"
             `Quick
             test_repo_prefixed_missing_read_preserves_exact_input
+        ; Alcotest.test_case
+            "cwd rejection names the materialized repos"
+            `Quick
+            test_cwd_rejection_names_the_materialized_repos
+        ; Alcotest.test_case
+            "cwd rejection says when nothing is materialized"
+            `Quick
+            test_cwd_rejection_says_when_nothing_is_materialized
+        ; Alcotest.test_case
+            "valid repo cwd carries no hint"
+            `Quick
+            test_valid_repo_cwd_carries_no_hint
+        ; Alcotest.test_case
+            "missing file still volunteers no repository list"
+            `Quick
+            test_missing_file_still_volunteers_no_repository_list
         ] )
     ; ( "repository_checkouts"
       , [ Alcotest.test_case


### PR DESCRIPTION
Refs #23442

## 라이브에서 지금 일어나는 일

```
{"event":"tool_exec","keeper_name":"taskmaster","tool":"tool_read_file","disposition":"failed",
 "error_preview":"{\"error\":\"cwd_not_directory: /Users/dancer/me/.masc/playground/taskmaster/
   workspace/yousleepwhen/masc (directory does not exist; Read will not create cwd)\"}"}
```

taskmaster 가 `workspace/yousleepwhen/masc` 를 cwd 로 요청했습니다. **호스트 체크아웃의 레이아웃**이지 playground 의 것이 아닙니다. 보존된 decision log 에 7건, 가장 최근 것이 24분 전입니다.

정작 에러 네 줄 위의 주석이 어휘를 적어뒀습니다:

```ocaml
(* File tools keep the logical projection for cwd: a keeper-visible
   relative cwd ("repos/<repo>") composed with a relative file_path is
   established Read vocabulary (test_keeper_visible_path_projection). *)
```

**키퍼는 그 주석을 읽을 수 없습니다.** 거부는 "없다"만 말하고 "무엇이 있는지"는 말하지 않습니다.

## 두 실패가 같은 문장으로 나옵니다

| 상황 | 올바른 대응 |
|------|-------------|
| 접두사를 잘못 씀 (`workspace/...`) | 올바른 접두사로 재시도 |
| 그 키퍼에게 materialize 된 repo 가 없음 | 재시도 중단 |

지금은 둘 다 `directory does not exist` 입니다. taskmaster 는 첫 번째였고 계속 재시도했습니다.

**이 fleet 에서 둘 다 실재합니다.** `keeper_repo_mappings.toml` 에서 `masc` 로 매핑된 키퍼들의 playground `repos/` 실측:

| keeper | repos/ |
|--------|--------|
| sangsu | masc, masc-wtask-188, masc-wtask-195, … (6) |
| rondo | masc, kidsnote_web_service, masc-wtask-205 (3) |
| kidsnote | 9 |
| lane-smith | 7 |
| **taskmaster** | **0** |
| **verifier** | **0** |

대조군: 중앙 클론 `.masc/repos/masc` 는 정상입니다(56 엔트리, `.git` 존재, 08-10 08:42 갱신). 즉 클론 자체가 깨진 게 아닙니다.

## 변경

거부 시 그 키퍼의 playground `repos/` 를 열거해 이름을 댑니다.

```
cwd_not_directory: <path> (directory does not exist; Read will not create cwd);
  available repo cwds: repos/masc
```

비어 있으면 **비어 있다고** 말합니다 — 생략하지 않습니다.

```
cwd_not_directory: <path> (directory does not exist; Read will not create cwd);
  no repository is materialized under repos/ for this keeper, so no repos/<repo> cwd exists yet
```

## 추론이 아니라 열거입니다

`test_repo_prefixed_missing_read_preserves_exact_input` 과 `test_keeper_tool_dispatch_runtime` 이 **missing file** 경로에서 `available_repos = Null` · `path_resolution = Null` 을 단언합니다 — 어느 repo 를 의도했는지 *추측하지 않는다*는 기존 결정입니다.

이 변경은 그 결정을 건드리지 않습니다. 다른 실패(파일이 아니라 **cwd**)에서, 디스크에 실제로 있는 것을 열거할 뿐입니다. 그 구분을 테스트로 고정했습니다.

## 검증

```
$ dune build @check                                              exit=0
$ dune build @test/runtest-test_keeper_visible_path_projection
Test Successful in 0.839s. 14 tests run.
```

새 케이스 4개 중 2개는 동작, 2개는 **대조군**입니다:

| 케이스 | 역할 |
|--------|------|
| cwd rejection names the materialized repos | 동작 |
| cwd rejection says when nothing is materialized | 동작 |
| valid repo cwd carries no hint | 대조군 — 성공에는 조언이 붙지 않는다 |
| missing file still volunteers no repository list | 대조군 — 기존 결정 불변 |

**뮤테이션**: `lib/` 만 `origin/main` 으로 되돌리면

```
[FAIL]  file_tools  4   cwd rejection names the mat...
[FAIL]  file_tools  5   cwd rejection says when not...
[OK]    file_tools  6   valid repo cwd carries no h...
[OK]    file_tools  7   missing file still voluntee...
2 failures! in 0.629s. 14 tests run.
```

정확히 새 케이스 2개만 빨개지고 대조군 2개와 기존 4개는 초록입니다.

## 이 PR 이 하지 않는 것

**taskmaster·verifier 의 `repos/` 를 채우지 않습니다.** provisioning 은 `lib/repo_manager/` 소관이고 그쪽은 RFC 게이트 대상이라, RFC 없이 PR 을 열지 않습니다. sangsu 의 체크아웃은 브랜치가 `sangsu/task-217-service-repo-access` 인 **자체 클론**이라 — 키퍼가 일하다 직접 만든 것이지 provisioning 산출물이 아닙니다. 그 축은 #23442 에 남깁니다.

이 PR 은 그 사이에 키퍼가 **재시도로 턴을 태우는 것**을 멈춥니다.

RFC-WAIVED: `lib/keeper/keeper_tool_filesystem_runtime.ml` 의 오류 메시지 한 곳. credential/identity/operator/sandbox/hooks 및 `lib/repo_manager/` 를 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
