### PR TITLE
ci: test_keeper_transition_audit 를 컴파일만 하지 말고 실행한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -918,6 +918,7 @@ jobs:
             @test/runtest-test_keeper_path_ssot \
             @test/runtest-test_keeper_phase_drift_contract \
             @test/runtest-test_keeper_tool_error_text_bounded \
+            @test/runtest-test_keeper_transition_audit \
             @test/runtest-test_keeper_turn_fsm_tla_parity \
             @test/runtest-test_keepers_runtime_dir_ssot \
             @test/runtest-test_mcp_h1_h2_admission_parity \

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -111,7 +111,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=700
+UNWIRED_BASELINE=699
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
Closes #26104

## 무엇이 문제였나

`test/test_keeper_transition_audit.ml` 이 **실행 가능한 CI 게이트 어디에도 없었습니다.** `@check` 가 컴파일만 했습니다.

```
$ rg -c 'runtest-test_keeper_transition_audit' .github/workflows/ci.yml
0
```

이슈는 그 틈 뒤에 **이미 실패가 잠복 중**이라고 보고했습니다:

```
[FAIL] transition_observation 1  runtime trust timeline carries transition observation
  meta_of_json failed: invalid current keeper meta:
  fields outside the current schema: runtime_id; runtime reset required
```

## 지금은 통과합니다 — 그게 배선할 이유입니다

```
$ dune build @test/runtest-test_keeper_transition_audit
Test Successful in 0.190s. 18 tests run.
```

빨개졌다가 초록으로 돌아오는 동안 **어느 게이트도 두 전이를 보지 않았습니다.** 이 스위트가 담은 단언 — transition observation, append-failure 경로, cancel 재-raise — 도 같은 방식으로 낡을 수 있습니다.

통과하니까 닫자가 아니라, **통과하는 지금이 배선하기 좋은 시점**입니다. 빨간 상태로 배선하면 main 을 깨뜨리니까요.

## 래칫도 같이 내립니다

배선만 하면 되돌리기가 공짜입니다. 감사 스크립트가 **자기 출력으로 후속을 지시**합니다:

```
[ci-test-targets] OK - 699 suites unwired, 700 baseline
  — lower UNWIRED_BASELINE in scripts/audit-ci-test-targets.sh to hold the gain
```

같은 커밋에서 `700 → 699` 로 내렸습니다.

| | CI targets | unwired |
|---|---|---|
| before | 161 | 700 |
| after | **162** | **699** (at baseline) |

## 검증

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 162 CI targets, all declared in Dune
[ci-test-targets] OK - 699 suites unwired, at baseline
exit=0

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
yaml OK, jobs: 12
```

**뮤테이션** — 새로 넣은 ci.yml 한 줄을 지우면:

```
[ci-test-targets] OK - 161 CI targets, all declared in Dune
[ci-test-targets] FAIL - 700 suites are declared but never run in CI (baseline 699)
exit=2
```

래칫이 실제로 이득을 고정합니다. 이 확인 없이 baseline 만 내렸으면 숫자만 바꾼 셈이 됩니다.

## 범위

**남은 699건은 건드리지 않습니다.** 선언 대비 실행 격차 자체는 #27297 의 주제이고, 이 PR 은 *실패 이력이 실증된 한 건*만 배선합니다. 나머지를 일괄로 켜면 어느 것이 빨간지 모르는 채 main 을 깨뜨립니다.

RFC-WAIVED: CI 실행 목록에 기존 스위트 1건 추가 + 래칫 1 감소. credential/identity/operator/sandbox/hooks 를 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
