### PR TITLE
fix(docs): .mli private 노트의 대괄호 이름도 검사하고, 걸린 2건을 지운다

### DIFF
--- a/lib/keeper/keeper_status_detail.mli
+++ b/lib/keeper/keeper_status_detail.mli
@@ -5,8 +5,7 @@
     detail view.
 
     Selective .mli — internal helpers ([latest_metrics_json],
-    [model_observability_json], the
-    [resolve_status_target] dispatch helpers, etc.) stay private. *)
+    [model_observability_json], dispatch helpers, etc.) stay private. *)
 
 type tool_result = Keeper_types_profile.tool_result
 

--- a/lib/task/planning_eio.mli
+++ b/lib/task/planning_eio.mli
@@ -14,8 +14,8 @@
 
 
 
-    Internal: filesystem helpers ([ensure_dir],
-    [read_file_content], [write_file_content]), text helpers
+    Internal: filesystem helpers ([read_file_content],
+    [write_file_content]), text helpers
     ([find_substring_from], [normalize_placeholder],
     [extract_markdown_section]), markdown parser
     ([parsed_full_context] type + [parse_full_context_markdown]),

--- a/scripts/audit-odoc-refs.py
+++ b/scripts/audit-odoc-refs.py
@@ -109,6 +109,26 @@ TYPE_NAME_RE = re.compile(r"^\s*type\s+([a-z_][A-Za-z0-9_']*)", re.M)
 DOC_RE = re.compile(r"\(\*\*(.*?)\*\)", re.S)
 ODOC_REF_RE = re.compile(r"\{!([A-Za-z_][A-Za-z0-9_'.]*)\}")
 
+# `[foo]` is odoc code formatting, not a reference, so odoc never resolves it
+# and neither does the sweep above. One shape of it still makes a checkable
+# claim: "these helpers stay private" asserts the listed names exist AND are
+# unexported, which is a statement about the paired .ml and nothing else. When
+# such a name is absent the note describes a private layer that was never
+# there -- the wrong thing to hand a reader who cannot see the .ml. #26634
+# found eight; two outlived the {!...} sweep by being written in brackets.
+#
+# Scoped three ways, because brackets are used for far more than symbols:
+#   - only the line carrying the private-note phrase, not the whole comment,
+#     so neighbouring prose about tools and modules is out
+#   - resolved against the paired .ml alone, since "private here" is a claim
+#     about this module and a tree-wide symbol set would answer a different
+#     question
+#   - leading-underscore names skipped: `[_eio]`, `[_list]` are name fragments
+#     the prose is spelling out, not bindings
+PRIVATE_NOTE_RE = re.compile(
+    r"(?:Internal:|(?:stay|remain)s? private|Selective \.mli)", re.I)
+BRACKET_NAME_RE = re.compile(r"\[([a-z][a-z0-9_']*)\]")
+
 DERIVED_SUFFIXES = ("_to_yojson", "_of_yojson")
 DERIVED_PREFIXES = ("show_", "pp_", "equal_", "compare_")
 
@@ -165,6 +185,18 @@ def absent_references(known: set[str]) -> list[tuple[Path, str]]:
                     continue
                 if last not in known:
                     hits.append((path, ref))
+        ml_path = path.with_suffix(".ml")
+        if ml_path.exists():
+            try:
+                ml_text = ml_path.read_text(errors="ignore")
+            except OSError:
+                ml_text = ""
+            for line in text.splitlines():
+                if not PRIVATE_NOTE_RE.search(line):
+                    continue
+                for name in BRACKET_NAME_RE.findall(line):
+                    if not re.search(r"\b%s\b" % re.escape(name), ml_text):
+                        hits.append((path, "[%s]" % name))
     return hits
 
 
@@ -181,12 +213,13 @@ def main() -> int:
     hits = absent_references(known_symbols(files))
 
     if not hits:
-        print(f"[odoc-refs] OK - every {{!...}} in lib/**/*.mli resolves ({len(files)} files scanned)")
+        print(f"[odoc-refs] OK - every {{!...}} and every private-note [name] in lib/**/*.mli resolves ({len(files)} files scanned)")
         return 0
 
     print(f"[odoc-refs] {len(hits)} reference(s) name a symbol this tree does not define:\n")
     for path, ref in hits:
-        print(f"  {path.relative_to(REPO_ROOT)}: {{!{ref}}}")
+        rendered = ref if ref.startswith("[") else "{!%s}" % ref
+        print(f"  {path.relative_to(REPO_ROOT)}: {rendered}")
     print(
         "\nEither the symbol was renamed or removed and the doc did not follow,"
         "\nor it lives outside lib/ and its module prefix belongs in"


### PR DESCRIPTION
Closes #26634

## 무엇이 검사되지 않았나

`scripts/audit-odoc-refs.py` 는 `{!foo}` 를 해석하고 거기서 멈춥니다. 그런데 이 저장소의 산문은 심볼을 **`[foo]`** 로 부릅니다 — odoc 에서 `[foo]` 는 참조가 아니라 **코드 서식**이라 아무도 해석하지 않습니다.

그래서 *"these helpers stay private"* 노트가 **존재한 적 없는 이름**을 나열해도 어떤 게이트도 말하지 않았습니다. #26634 가 8건을 셌고, 그중 2건이 `{!...}` 스윕을 살아남은 이유가 정확히 이것입니다.

```
lib/task/planning_eio.mli            [ensure_dir]
lib/keeper/keeper_status_detail.mli  [resolve_status_target]
```

둘 다 짝 `.ml` 에 **어떤 형태로도** 없습니다.

## 왜 이게 단순 오타보다 나쁜가

`stay private` 는 **"존재하고, export 만 안 된다"** 는 뜻입니다. `.ml` 을 볼 수 없는 독자 — 인터페이스만 훑는 사람, `.mli` 만 로드한 에이전트 — 에게 **없는 계층이 있다고** 말합니다. 이슈 본문이 그 위험을 그대로 적었습니다:

> "private 로 남아있다" 는 곧 "존재한다" 는 뜻이라, 다음 사람(그리고 다음 AI 에이전트)이 없는 계층을 있다고 믿어용

## 범위를 세 겹으로 좁혔습니다

대괄호는 심볼 말고도 도구명·모듈 파일명·접미사 조각을 담습니다. 좁히지 않으면 신호가 묻힙니다.

| 좁힌 축 | 이유 |
|---------|------|
| 노트 문구가 있는 **줄**만 읽음 (주석 블록 전체 아님) | 옆 문장의 도구·모듈 이름 제외 |
| **짝 `.ml` 기준**으로만 해석 | "여기서 private" 는 한 모듈에 대한 주장 — 트리 전역 심볼 집합은 다른 질문에 답함 |
| 선행 밑줄 이름 제외 | `[_eio]`·`[_list]` 는 산문이 풀어쓴 **이름 조각**이지 바인딩이 아님 |

**좁히지 않았을 때 106건**이 나왔고 대부분 `[masc_board_post]` 형태의 도구명이었습니다. 좁히니 위 2건이고, 독립적으로 돌린 셸 스캔과 일치합니다.

## 검증

```
$ python3 scripts/audit-odoc-refs.py     # 수정 전
[odoc-refs] 2 reference(s) name a symbol this tree does not define:
  lib/keeper/keeper_status_detail.mli: [resolve_status_target]
  lib/task/planning_eio.mli: [ensure_dir]
exit=1

$ python3 scripts/audit-odoc-refs.py     # 수정 후
[odoc-refs] OK - every {!...} and every private-note [name] in lib/**/*.mli resolves (3466 files scanned)
exit=0

$ dune build @check
exit=0
```

**뮤테이션** — `[ensure_dir]` 를 다시 넣으면:

```
[odoc-refs] 1 reference(s) name a symbol this tree does not define:
  lib/task/planning_eio.mli: [ensure_dir]
exit=1
```

되돌리면 다시 0. 검사가 실제로 이 형태를 잡습니다.

## CI 배선은 필요 없습니다

`audit-odoc-refs.py` 는 이미 **"Check odoc references"** 스텝으로 돕니다. 새 스크립트를 만들어 배선을 또 놓치는 대신(이 저장소에 미배선 스위트가 699건 있습니다) 이미 도는 검사를 넓혔습니다.

## 노트에서 지운 것은 이름 하나씩입니다

두 노트 모두 나머지 이름은 실재합니다 — `planning_eio` 는 11개 중 `ensure_dir` 만, `keeper_status_detail` 은 3개 중 `resolve_status_target` 만 유령이었습니다. 노트를 통째로 지우지 않고 그 이름만 뺐습니다.

RFC-WAIVED: `.mli` 주석 2줄 + 기존 감사 스크립트 확장. credential/identity/operator/sandbox/hooks 를 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
