### PR TITLE
fix(dashboard): tool-host 장애를 문자열이 아니라 던져진 값으로 판정한다

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -14,15 +14,34 @@ const {
   isRemoteAccess,
   setStoredToken,
 } = vi.hoisted(() => ({
+  // Carries timeout/timeoutMs like the real one in ./core. The double used to
+  // drop them, so every case that "tested a timeout" actually threw an error
+  // with no timeout field and a hand-written message -- which is why a
+  // message-substring classifier looked correct here.
   ApiRequestError: class ApiRequestError extends Error {
     status?: number
     authErrorCode?: string
+    timeout?: boolean
+    timeoutMs?: number
 
-    constructor(opts: { status?: number; detail?: string; authErrorCode?: string }) {
-      super(opts.detail ?? 'API request failed')
+    constructor(opts: {
+      status?: number
+      detail?: string
+      authErrorCode?: string
+      timeout?: boolean
+      timeoutMs?: number
+      method?: string
+      path?: string
+    }) {
+      super(
+        opts.timeout === true
+          ? `${opts.method ?? 'POST'} ${opts.path ?? '/mcp'}: timeout after ${opts.timeoutMs ?? 0}ms`
+          : opts.detail ?? 'API request failed')
       this.name = 'ApiRequestError'
       this.status = opts.status
       this.authErrorCode = opts.authErrorCode
+      this.timeout = opts.timeout
+      this.timeoutMs = opts.timeoutMs
     }
   },
   apiRequestErrorFromResponse: vi.fn(async (method: string, path: string, res: Response) =>
@@ -226,7 +245,8 @@ describe('MCP 2026-07-28 dashboard client', () => {
   })
 
   it('reports transport failures without legacy session telemetry', async () => {
-    fetchWithTimeout.mockRejectedValueOnce(new Error('POST /mcp: timeout after 30000ms'))
+    fetchWithTimeout.mockRejectedValueOnce(
+      new ApiRequestError({ method: 'POST', path: '/mcp', timeout: true, timeoutMs: 30000 }))
 
     const { callMcpTool } = await import('./mcp')
     await expect(callMcpTool('masc_keeper_msg', { message: 'ping' }))
@@ -240,6 +260,42 @@ describe('MCP 2026-07-28 dashboard client', () => {
       timeout_ms: 30000,
     }))
     expect(reportToolHostFailure.mock.calls[0]![0].session_id).toBeUndefined()
+  })
+
+  // The transport says whether a request reached a tool. These cases pin that
+  // the decision reads the thrown value, not its prose.
+  it('reports a fetch that never reached the host', async () => {
+    fetchWithTimeout.mockRejectedValueOnce(new TypeError('Load failed'))
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_keeper_msg', { message: 'ping' })).rejects.toThrow()
+
+    expect(reportToolHostFailure).toHaveBeenCalledWith(expect.objectContaining({
+      tool_name: 'masc_keeper_msg',
+      phase: 'tools/call',
+    }))
+  })
+
+  it('does not report a non-timeout ApiRequestError', async () => {
+    fetchWithTimeout.mockRejectedValueOnce(
+      new ApiRequestError({ status: 500, detail: 'internal error' }))
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_keeper_msg', { message: 'ping' })).rejects.toThrow()
+
+    expect(reportToolHostFailure).not.toHaveBeenCalled()
+  })
+
+  // The regression the typed check removes: a tool error whose own text
+  // contains transport wording was reported as a host failure.
+  it('does not report a tool error whose message reads like a transport failure', async () => {
+    fetchWithTimeout.mockRejectedValueOnce(
+      new Error('tool refused: load failed while parsing the uploaded fixture'))
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_keeper_msg', { message: 'ping' })).rejects.toThrow()
+
+    expect(reportToolHostFailure).not.toHaveBeenCalled()
   })
 
   it('fails closed after a 403 until client state is reset', async () => {

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -55,16 +55,25 @@ async function bestEffortReportToolHostFailure(payload: {
   }
 }
 
-function shouldReportToolHostFailure(message: string): boolean {
-  const normalized = message.toLowerCase()
-  return (
-    normalized.includes('timeout after')
-    || normalized.includes('timed out awaiting tools/call')
-    || normalized.includes('failed to fetch')
-    || normalized.includes('networkerror')
-    || normalized.includes('load failed')
-    || normalized.includes('error decoding response body')
-  )
+/* A tool-host failure means the request never reached a tool, so the transport
+   already knows: fetchWithTimeout converts an abort into ApiRequestError with
+   timeout set, and a fetch that cannot reach the host rejects with TypeError.
+   Both are answers this function can read off the thrown value.
+
+   It used to lowercase the message and look for six substrings, which decided
+   transport health from prose the transport does not own. That misclassifies
+   a normal MCP error whose tool message happens to contain "load failed", and
+   misses a network failure worded differently by another browser or locale.
+   Two of the six arms could never fire: "timed out awaiting tools/call" exists
+   only in an OCaml fixture describing the payload this file *sends*, and
+   "error decoding response body" appears nowhere in the tree at all. A string
+   classifier has no exhaustiveness, so nothing said so. */
+function shouldReportToolHostFailure(err: unknown): boolean {
+  if (err instanceof ApiRequestError) return err.timeout === true
+  // Browser fetch rejects with TypeError when the host is unreachable
+  // (connection refused, DNS failure, CORS preflight failure). The wording
+  // varies by engine; the class does not.
+  return err instanceof TypeError
 }
 
 function explicitToolActor(args: Record<string, unknown>): string | null {
@@ -308,7 +317,7 @@ async function callMcpToolInternal(
       return callMcpToolInternal(toolName, args, false)
     }
     const message = errorToString(err)
-    if (shouldReportToolHostFailure(message)) {
+    if (shouldReportToolHostFailure(err)) {
       await bestEffortReportToolHostFailure({
         toolName,
         message,


### PR DESCRIPTION
Closes #26770

## 무엇이 문제였나

`shouldReportToolHostFailure` 가 오류 메시지를 소문자로 바꿔 **substring 6개**와 비교해 tool-host 장애 여부를 정했습니다.

```ts
function shouldReportToolHostFailure(message: string): boolean {
  const normalized = message.toLowerCase()
  return normalized.includes('timeout after')
    || normalized.includes('timed out awaiting tools/call')
    || normalized.includes('failed to fetch')
    || normalized.includes('networkerror')
    || normalized.includes('load failed')
    || normalized.includes('error decoding response body')
}
```

**전송 계층이 이미 답을 압니다.** `fetchWithTimeout` 은 abort 를 `ApiRequestError({ timeout: true })` 로 바꾸고, 호스트에 닿지 못한 fetch 는 `TypeError` 로 reject 합니다. 둘 다 던져진 **값**에서 읽을 수 있고, 그 값은 호출 지점 스코프에 있었는데 문자열로 눌러 담은 뒤 되물었습니다.

## 양방향으로 틀립니다

| 방향 | 사례 |
|------|------|
| 과다 | tool 메시지에 `load failed` 가 들어간 **정상 MCP 오류**를 host 장애로 보고 |
| 과소 | 다른 엔진·locale 이 다르게 표현한 네트워크 오류를 놓침 |

## arm 2개는 발화 불가능이었습니다

| substring | 저장소 내 생산자 |
|-----------|------------------|
| `timed out awaiting tools/call` | **없음** — `test/test_dashboard_tool_host_events.ml` 픽스처에만 존재하며, 그건 이 파일이 *보내는* 페이로드입니다 |
| `error decoding response body` | **없음** — 분류기 자신 외에 트리 어디에도 없습니다 (reqwest 문구로 보입니다) |

문자열 분류기에는 exhaustiveness 가 없어서, 발화한 적 없는 arm 이 그대로 남아 있어도 아무도 말해주지 않습니다.

## 변경

```ts
function shouldReportToolHostFailure(err: unknown): boolean {
  if (err instanceof ApiRequestError) return err.timeout === true
  return err instanceof TypeError
}
```

메시지는 **보고 페이로드**로만 남고 판정에는 쓰이지 않습니다.

## 테스트 픽스처가 결함을 가리고 있었습니다

`ApiRequestError` 테스트 더블이 **`timeout`·`timeoutMs` 를 버리고** 있었습니다. 그래서 *"reports transport failures"* 케이스가 손으로 쓴 `'POST /mcp: timeout after 30000ms'` 를 담은 **평범한 `Error`** 를 던졌습니다 — substring 경로만 지나갔고, 올바른 이유로 실패할 수 없는 테스트였습니다.

더블이 두 필드를 갖도록 고치고, 그 케이스가 `fetchWithTimeout` 이 실제로 던지는 것을 던지게 했습니다.

## 검증

```
$ pnpm exec vitest run src/api/mcp.test.ts     Tests  17 passed (17)
$ pnpm exec vitest run src/api/core.test.ts    Tests  38 passed (38)
$ pnpm run typecheck                            tsc --noEmit, clean
```

**뮤테이션** — `mcp.ts` 만 되돌리면 `Tests 1 failed | 16 passed`.

신규 3건 중 **판별력을 가진 건 1건**입니다:

| 케이스 | 뮤테이션에서 |
|--------|--------------|
| tool 오류 `"load failed while parsing the uploaded fixture"` 를 보고하지 않는다 | **실패** — 이슈가 지목한 오분류 |
| 호스트에 닿지 못한 fetch(`TypeError`)를 보고한다 | 통과 (구현 무관) |
| timeout 아닌 `ApiRequestError` 를 보고하지 않는다 | 통과 (구현 무관) |

뒤의 둘은 회귀 증명이 아니라 **동작 고정**입니다. 그렇게 적어둡니다 — 3건 전부가 회귀를 잡는다고 말하면 과장입니다.

## 범위

`core.ts:729` 의 `/timeout after \d+ms/i` 는 **건드리지 않았습니다.** 그건 `ApiRequestError` 가 아닌 오류에 대한 폴백이고(같은 함수가 `ApiRequestError` 는 이미 `err.timeout` 으로 타입 판정합니다), 별도 판단이 필요합니다. 이 PR 은 `#26770` 이 지목한 한 함수만 봅니다.

RFC-WAIVED: 대시보드 전송 오류 분류 1개 함수. credential/identity/operator/sandbox/hooks 를 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
