### PR TITLE
ci: test_masc_test_runtime 를 선언만 하지 말고 실행한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -923,6 +923,7 @@ jobs:
             @test/runtest-test_keepers_runtime_dir_ssot \
             @test/runtest-test_mcp_h1_h2_admission_parity \
             @test/runtest-test_masc_dirname_ssot \
+            @test/runtest-test_masc_test_runtime \
             @test/runtest-test_nickname_words_ssot \
             @test/runtest-test_agent_core_message_constructor_contract \
             @test/runtest-test_otel_port_ssot \

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -111,7 +111,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=699
+UNWIRED_BASELINE=698
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
Closes #26779

## 이슈의 재현 명령 그대로

```
$ rg -n "test_masc_test_runtime" .github/workflows/ci.yml test/stanzas test/dune
test/dune:908: (name test_masc_test_runtime)
test/dune:909: (modules test_masc_test_runtime)
```

`test/dune` 은 선언하는데 **ci.yml 에는 없습니다.** `@check` 가 컴파일만 합니다.

## 무엇이 안 지켜지고 있었나

이 스위트가 고정하는 건 바이너리 해석 계약입니다.

```
[OK]  binary resolution  0  requires explicit root.
[OK]  binary resolution  1  does not escape parent checkout.
[OK]  binary resolution  2  uses exact bound binary.
[OK]  binary resolution  3  invalid override does not fall back.
```

이 중 하나가 회귀하면 **운영자가 지정하지 않은 checkout 을 상대로 테스트가 돌 수 있습니다.** 이슈가 지적했듯 SSE E2E 는 `MASC_MAIN_EIO_EXE` 가 **올바르게 주입된** 경로만 검증합니다 — 잘못된 경로는 아무도 안 봅니다.

## 지금 통과합니다 — 그게 배선할 때라는 뜻입니다

```
$ dune build @test/runtest-test_masc_test_runtime
Test Successful in 0.004s. 4 tests run.
```

빨간 스위트를 배선하면 모두의 main 이 깨집니다. 초록일 때 넣습니다.

## 래칫도 같이

배선만 하면 되돌리기가 공짜입니다. 감사 스크립트가 자기 출력으로 후속을 지시하므로 같은 커밋에서 `699 → 698`.

| | CI targets | unwired |
|---|---|---|
| before | 162 | 699 |
| after | **163** | **698** (at baseline) |

## 검증

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 163 CI targets, all declared in Dune
[ci-test-targets] OK - 698 suites unwired, at baseline
exit=0

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
yaml OK, jobs: 12
```

**뮤테이션** — 새 ci.yml 한 줄을 지우면:

```
[ci-test-targets] FAIL - 699 suites are declared but never run in CI (baseline 698)
exit=2
```

래칫이 실제로 이득을 고정합니다.

## 범위

남은 698건은 건드리지 않습니다 — 선언 대비 실행 격차 자체는 #27297 의 주제입니다. 이 PR 은 **실패 모드가 구체적으로 서술된 한 건**만 배선합니다. 직전 선례: #27973 (`test_keeper_transition_audit`, 700 → 699).

RFC-WAIVED: CI 실행 목록에 기존 스위트 1건 추가 + 래칫 1 감소.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
