### PR TITLE
docs(dashboard_api_types): 제거된 shared-compile SSOT 서사를 걷어낸다

### DIFF
--- a/lib/dashboard_api_types/README.md
+++ b/lib/dashboard_api_types/README.md
@@ -5,8 +5,12 @@ the Bonsai client island (`dashboard_bonsai/`).
 
 ## Purpose
 
-This library is the **single source of truth** for the shape of every JSON
-response the Bonsai island consumes. Two consumers:
+This library is the **single source of truth for the encoder** of the routes
+listed under [Modules](#modules): the server serializes those responses from
+records defined here. It is not a shared-compile SSOT, and it does not cover
+every Bonsai route — the client does not link this library, so nothing here
+constrains how the client reads the bytes, and routes not listed below have
+their types elsewhere. Two consumers:
 
 - **Server** — `lib/dashboard/dashboard_http_*.ml` serialize via
   `<Module>.response_to_yojson` instead of hand-rolling
@@ -41,12 +45,16 @@ once it stabilizes).
 
 ## ppx strategy
 
-Server uses `ppx_deriving_yojson` (the same ppx already in `lib/types/`).
-For the client, Bonsai's `ppx_yojson_conv` can re-parse the same record by
-copying the module file or by generating a mirror with compatible field
-attributes. Phase 1 uses the simplest path: server emits the JSON, client
-parses with a small hand-written `of_yojson` in `dashboard_bonsai/src/`.
-Full ppx sharing is Phase 2.
+Server uses `ppx_deriving_yojson` and derives the encoder only. There is no
+decoder here: #26992 removed the generated `*_of_yojson` API, and the client
+reads each field with `Yojson.Safe.Util.member` in `dashboard_bonsai/src/`
+rather than calling into this library at all — `dashboard_bonsai/src/dune`
+does not depend on it.
+
+This section used to describe that split as "Phase 1" with full ppx sharing
+as "Phase 2". Sharing the ppx is not planned: it would require the client to
+link this library, which is what the module boundary above exists to prevent.
+The hand-written mirror is the arrangement, not a step toward another one.
 
 ## Guarantees we do **not** make
 


### PR DESCRIPTION
Closes #27000

## 무엇이 문제였나

README 가 **세 줄 간격으로 자기 자신과 모순**됐습니다.

```md
This library is the **single source of truth** for the shape of every JSON
response the Bonsai island consumes.
...
Only the encoder is derived (`to_yojson`). A schema change is therefore two
edits — this library, then the client mirror — and no compiler checks that
the second one happened.
```

앞은 SSOT 라고 하고, 뒤는 클라이언트가 손으로 복제하며 컴파일러가 검증하지 않는다고 합니다. **둘 다 참일 수 없고, 참인 쪽은 뒤입니다.**

## 실측 — `origin/main` `326b3fdae8`

| 확인 | 결과 |
|------|------|
| `dashboard_bonsai/src/dune` 가 이 라이브러리를 의존 | **0** |
| `lib/dashboard_api_types/` 의 `*_of_yojson` | **0** |
| `to_yojson` 파생 (대조군) | **존재** |
| 클라이언트 파서 형태 | `Yojson.Safe.Util.member` 수동 |

`#26992` 가 생성 디코더를 지웠고, 클라이언트는 이 라이브러리를 **링크조차 하지 않습니다.**

## 두 주장을 성립 범위로 좁혔습니다

**1. SSOT 범위** — "every JSON response" 가 아니라 Modules 표에 있는 라우트의 **인코더**입니다. 표 자신이 logs 는 `dashboard_bonsai/src/` 안의 별도 `Logs_types` 를 쓴다고 적어뒀으므로, `#26992` 이전에도 "every" 는 틀렸습니다.

**2. ppx 서사** — 이슈가 `:40-47` 로 지목한 부분입니다. 수동 미러를 "Phase 1", 완전한 ppx 공유를 "Phase 2" 로 서술했습니다. ppx 를 공유하려면 **클라이언트가 이 라이브러리를 링크해야 하는데, 그건 파일의 나머지가 정당화하는 경계 그 자체입니다.** 수동 미러는 다른 상태로 가는 단계가 아니라 **현재의 배치**입니다.

## 왜 문서가 값어치가 있나

이 저장소는 에이전트가 소스를 읽는 것을 전제로 합니다. "Phase 2 에서 ppx 를 공유한다"는 문장은 다음 작업자에게 **아직 안 한 일**로 읽히고, 실제로 하려 들면 경계를 깨는 방향으로 갑니다. 계획이 아니라 결정을 적어야 그 일이 안 일어납니다.

작성 중 제 초안이 "every JSON response ... serialized from a record defined here" 라고 과장했다가, Modules 표를 다시 읽고 좁혔습니다 — 원문이 틀린 것과 같은 종류의 과장이었습니다.

문서 전용, 코드 변경 없음.

RFC-WAIVED: README 2개 단락. credential/identity/operator/sandbox/hooks 를 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
