### PR TITLE
refactor(keeper): close operation failure vocabulary

### DIFF
--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -78,7 +78,7 @@ type error =
 type operation_execution =
   | Operation_succeeded of { outcome_ref : string }
   | Operation_failed of
-      { kind : string
+      { kind : Chat_operation.failure_kind
       ; detail : string
       ; outcome_ref : string option
       }
@@ -523,7 +523,7 @@ let start
                   if (Atomic.get t.projection).Keeper_owner_reducer.stopping
                   then
                     Operation_failed
-                      { kind = "Turn_cancelled"
+                      { kind = Chat_operation.Turn_cancelled
                       ; detail = "Keeper owner is stopping"
                       ; outcome_ref = None
                       }
@@ -531,19 +531,19 @@ let start
               with
               | Stop_active_child ->
                 Operation_failed
-                  { kind = "Turn_cancelled"
+                  { kind = Chat_operation.Turn_cancelled
                   ; detail = "Keeper owner stopped the active turn"
                   ; outcome_ref = None
                   }
               | Eio.Cancel.Cancelled cause ->
                 Operation_failed
-                  { kind = "Turn_cancelled"
+                  { kind = Chat_operation.Turn_cancelled
                   ; detail = Printexc.to_string cause
                   ; outcome_ref = None
                   }
               | exn ->
                 Operation_failed
-                  { kind = "Turn_exception"
+                  { kind = Chat_operation.Turn_exception
                   ; detail = Printexc.to_string exn
                   ; outcome_ref = None
                   }

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -84,7 +84,7 @@ type error =
 type operation_execution =
   | Operation_succeeded of { outcome_ref : string }
   | Operation_failed of
-      { kind : string
+      { kind : Chat_operation.failure_kind
       ; detail : string
       ; outcome_ref : string option
       }
@@ -220,7 +220,7 @@ val succeed_running_operation
 val fail_running_operation
   :  t
   -> operation_id:Chat_operation.Operation_id.t
-  -> kind:string
+  -> kind:Chat_operation.failure_kind
   -> detail:string
   -> outcome_ref:string option
   -> (Chat_operation.t, error) result

--- a/lib/keeper_chat_operations/keeper_chat_operation.ml
+++ b/lib/keeper_chat_operations/keeper_chat_operation.ml
@@ -29,8 +29,49 @@ module Operation_id = struct
   let equal = String.equal
 end
 
+type failure_kind =
+  | Interrupted_by_restart
+  | Turn_cancelled
+  | Turn_exception
+  | Store_unavailable
+  | No_queued_operation
+  | Invalid_input
+  | Turn_invariant
+
+let all_failure_kinds =
+  [ Interrupted_by_restart
+  ; Turn_cancelled
+  ; Turn_exception
+  ; Store_unavailable
+  ; No_queued_operation
+  ; Invalid_input
+  ; Turn_invariant
+  ]
+;;
+
+let failure_kind_to_string = function
+  | Interrupted_by_restart -> "Interrupted_by_restart"
+  | Turn_cancelled -> "Turn_cancelled"
+  | Turn_exception -> "Turn_exception"
+  | Store_unavailable -> "Store_unavailable"
+  | No_queued_operation -> "No_queued_operation"
+  | Invalid_input -> "Invalid_input"
+  | Turn_invariant -> "Turn_invariant"
+;;
+
+let failure_kind_of_string = function
+  | "Interrupted_by_restart" -> Ok Interrupted_by_restart
+  | "Turn_cancelled" -> Ok Turn_cancelled
+  | "Turn_exception" -> Ok Turn_exception
+  | "Store_unavailable" -> Ok Store_unavailable
+  | "No_queued_operation" -> Ok No_queued_operation
+  | "Invalid_input" -> Ok Invalid_input
+  | "Turn_invariant" -> Ok Turn_invariant
+  | value -> Error (Printf.sprintf "unknown Keeper chat operation failure kind %S" value)
+;;
+
 type failure =
-  { kind : string
+  { kind : failure_kind
   ; detail : string
   ; outcome_ref : string option
   }
@@ -86,7 +127,7 @@ let to_json operation =
     | Failed { completed_at; failure = { kind; detail; outcome_ref } } ->
       [ "state", `String "Failed"
       ; "completed_at", `Float completed_at
-      ; "failure_kind", `String kind
+      ; "failure_kind", `String (failure_kind_to_string kind)
       ; "failure_detail", `String detail
       ; ( "outcome_ref"
         , match outcome_ref with

--- a/lib/keeper_chat_operations/keeper_chat_operation.mli
+++ b/lib/keeper_chat_operations/keeper_chat_operation.mli
@@ -13,8 +13,21 @@ module Operation_id : sig
   val equal : t -> t -> bool
 end
 
+type failure_kind =
+  | Interrupted_by_restart
+  | Turn_cancelled
+  | Turn_exception
+  | Store_unavailable
+  | No_queued_operation
+  | Invalid_input
+  | Turn_invariant
+
+val all_failure_kinds : failure_kind list
+val failure_kind_to_string : failure_kind -> string
+val failure_kind_of_string : string -> (failure_kind, string) result
+
 type failure =
-  { kind : string
+  { kind : failure_kind
   ; detail : string
   ; outcome_ref : string option
   }

--- a/lib/keeper_chat_operations/keeper_chat_operation_reducer.ml
+++ b/lib/keeper_chat_operations/keeper_chat_operation_reducer.ml
@@ -109,13 +109,12 @@ let apply (operation : Operation.t) command =
   | Fail_running { completed_at; failure }, Running _ ->
     (match
        validate_terminal_time completed_at,
-       Operation.validate_nonblank ~field:"failure.kind" failure.kind,
        Operation.validate_nonblank ~field:"failure.detail" failure.detail
      with
-     | Error error, _, _ -> Error error
-     | _, Error detail, _ | _, _, Error detail -> Error (Invalid_input detail)
-     | Ok (), Ok kind, Ok detail ->
-       let failure = { failure with kind; detail } in
+     | Error error, _ -> Error error
+     | _, Error detail -> Error (Invalid_input detail)
+     | Ok (), Ok detail ->
+       let failure = { failure with detail } in
        Ok
          (transition
             { operation with

--- a/lib/keeper_chat_operations/keeper_chat_operation_store.ml
+++ b/lib/keeper_chat_operations/keeper_chat_operation_store.ml
@@ -37,8 +37,16 @@ let metadata_table_sql =
   "CREATE TABLE metadata (singleton INTEGER PRIMARY KEY CHECK (singleton = 1), schema TEXT NOT NULL CHECK (schema = 'masc.keeper_chat_operations.v1'), next_sequence INTEGER NOT NULL CHECK (next_sequence >= 0)) STRICT"
 ;;
 
+let failure_kind_database_values =
+  Operation.all_failure_kinds
+  |> List.map (fun kind -> "'" ^ Operation.failure_kind_to_string kind ^ "'")
+  |> String.concat ", "
+;;
+
 let operations_table_sql =
-  "CREATE TABLE operations (operation_id TEXT PRIMARY KEY, admission_digest TEXT NOT NULL CHECK (length(admission_digest) = 64), execution_digest TEXT NOT NULL CHECK (length(execution_digest) = 64), sequence INTEGER NOT NULL UNIQUE CHECK (sequence >= 0), source_json TEXT NOT NULL, input_json TEXT, state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')), created_at REAL NOT NULL CHECK (created_at >= 0), started_at REAL, completed_at REAL, outcome_ref TEXT, failure_kind TEXT, failure_detail TEXT, CHECK ((state = 'queued' AND input_json IS NOT NULL AND started_at IS NULL AND completed_at IS NULL AND outcome_ref IS NULL AND failure_kind IS NULL AND failure_detail IS NULL) OR (state = 'running' AND input_json IS NOT NULL AND started_at IS NOT NULL AND completed_at IS NULL AND outcome_ref IS NULL AND failure_kind IS NULL AND failure_detail IS NULL) OR (state = 'succeeded' AND input_json IS NULL AND started_at IS NOT NULL AND completed_at IS NOT NULL AND outcome_ref IS NOT NULL AND failure_kind IS NULL AND failure_detail IS NULL) OR (state = 'failed' AND input_json IS NULL AND started_at IS NOT NULL AND completed_at IS NOT NULL AND failure_kind IS NOT NULL AND failure_detail IS NOT NULL) OR (state = 'cancelled' AND input_json IS NULL AND started_at IS NULL AND completed_at IS NOT NULL AND outcome_ref IS NULL AND failure_kind IS NULL AND failure_detail IS NULL))) STRICT"
+  Printf.sprintf
+    "CREATE TABLE operations (operation_id TEXT PRIMARY KEY, admission_digest TEXT NOT NULL CHECK (length(admission_digest) = 64), execution_digest TEXT NOT NULL CHECK (length(execution_digest) = 64), sequence INTEGER NOT NULL UNIQUE CHECK (sequence >= 0), source_json TEXT NOT NULL, input_json TEXT, state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')), created_at REAL NOT NULL CHECK (created_at >= 0), started_at REAL, completed_at REAL, outcome_ref TEXT, failure_kind TEXT CHECK (failure_kind IS NULL OR failure_kind IN (%s)), failure_detail TEXT, CHECK ((state = 'queued' AND input_json IS NOT NULL AND started_at IS NULL AND completed_at IS NULL AND outcome_ref IS NULL AND failure_kind IS NULL AND failure_detail IS NULL) OR (state = 'running' AND input_json IS NOT NULL AND started_at IS NOT NULL AND completed_at IS NULL AND outcome_ref IS NULL AND failure_kind IS NULL AND failure_detail IS NULL) OR (state = 'succeeded' AND input_json IS NULL AND started_at IS NOT NULL AND completed_at IS NOT NULL AND outcome_ref IS NOT NULL AND failure_kind IS NULL AND failure_detail IS NULL) OR (state = 'failed' AND input_json IS NULL AND started_at IS NOT NULL AND completed_at IS NOT NULL AND failure_kind IS NOT NULL AND failure_detail IS NOT NULL) OR (state = 'cancelled' AND input_json IS NULL AND started_at IS NULL AND completed_at IS NOT NULL AND outcome_ref IS NULL AND failure_kind IS NULL AND failure_detail IS NULL))) STRICT"
+    failure_kind_database_values
 ;;
 
 let operations_state_sequence_index_sql =
@@ -322,6 +330,10 @@ let decode_operation stmt =
       | "failed" ->
         let* completed_at = required_option "completed_at" completed_at in
         let* kind = required_option "failure_kind" failure_kind in
+        let* kind =
+          Operation.failure_kind_of_string kind
+          |> Result.map_error (fun detail -> Integrity_error detail)
+        in
         let* detail = required_option "failure_detail" failure_detail in
         Ok
           (Operation.Failed
@@ -967,7 +979,14 @@ let fail_running store ~now ~operation_id ~kind ~detail ~outcome_ref =
     (fun stmt ->
        let* () = bind_float store.db stmt ~operation:"bind failure time" 1 now in
        let* () = bind_optional_text store.db stmt ~operation:"bind failure outcome" 2 outcome_ref in
-       let* () = bind_text store.db stmt ~operation:"bind failure kind" 3 kind in
+       let* () =
+         bind_text
+           store.db
+           stmt
+           ~operation:"bind failure kind"
+           3
+           (Operation.failure_kind_to_string kind)
+       in
        let* () = bind_text store.db stmt ~operation:"bind failure detail" 4 detail in
        bind_text store.db stmt ~operation:"bind failed operation" 5 (Id.to_string operation_id))
 ;;
@@ -982,9 +1001,17 @@ let settle_running_after_restart store ~now =
     with_statement
       store.db
       ~operation:"settle interrupted operations"
-      "UPDATE operations SET state = 'failed', input_json = NULL, completed_at = ?, failure_kind = 'Interrupted_by_restart', failure_detail = 'process restarted before terminal operation commit' WHERE state = 'running'"
+      "UPDATE operations SET state = 'failed', input_json = NULL, completed_at = ?, failure_kind = ?, failure_detail = 'process restarted before terminal operation commit' WHERE state = 'running'"
       (fun stmt ->
          let* () = bind_float store.db stmt ~operation:"bind restart settlement time" 1 now in
+         let* () =
+           bind_text
+             store.db
+             stmt
+             ~operation:"bind restart failure kind"
+             2
+             (Operation.failure_kind_to_string Operation.Interrupted_by_restart)
+         in
          let* () = expect_done store.db stmt ~operation:"settle interrupted operations" in
          Ok (Sqlite3.changes store.db)))
 ;;

--- a/lib/keeper_chat_operations/keeper_chat_operation_store.mli
+++ b/lib/keeper_chat_operations/keeper_chat_operation_store.mli
@@ -76,7 +76,7 @@ val fail_running
   :  t
   -> now:float
   -> operation_id:Operation.Operation_id.t
-  -> kind:string
+  -> kind:Operation.failure_kind
   -> detail:string
   -> outcome_ref:string option
   -> (Operation.t, error) result

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1836,13 +1836,17 @@ let operation_executor ~state ~clock : Keeper_owner.operation_executor =
   let execute_admitted admission_token =
     match claim () with
     | Error error ->
-      failed "Store_unavailable" (Keeper_owner.error_to_string error)
+      failed Keeper_chat_operation.Store_unavailable (Keeper_owner.error_to_string error)
     | Ok None ->
-      failed "No_queued_operation" "Owner FIFO head disappeared before claim"
+      failed
+        Keeper_chat_operation.No_queued_operation
+        "Owner FIFO head disappeared before claim"
     | Ok (Some operation) ->
       (match operation.input with
        | None ->
-         failed "Invalid_input" "Running Keeper chat operation has no execution input"
+         failed
+           Keeper_chat_operation.Invalid_input
+           "Running Keeper chat operation has no execution input"
        | Some input ->
          (match
             operation_payload_of_json
@@ -1851,7 +1855,7 @@ let operation_executor ~state ~clock : Keeper_owner.operation_executor =
               ~source:operation.source
               ~input
           with
-          | Error detail -> failed "Invalid_input" detail
+          | Error detail -> failed Keeper_chat_operation.Invalid_input detail
           | Ok operation_payload ->
             let payload = operation_payload.payload in
             let operation_id =
@@ -2003,7 +2007,9 @@ let operation_executor ~state ~clock : Keeper_owner.operation_executor =
              | Some (Failed { kind; detail }), _ ->
                failed (queued_turn_failure_kind_to_string kind) detail
              | None, _ ->
-               failed "Turn_invariant" "Owner operation returned no terminal turn outcome")))
+               failed
+                 Keeper_chat_operation.Turn_invariant
+                 "Owner operation returned no terminal turn outcome")))
   in
   match
     Keeper_turn_dispatch_authority.run execute_admitted

--- a/test/keeper_chat_operations/test_keeper_chat_operation_store.ml
+++ b/test/keeper_chat_operations/test_keeper_chat_operation_store.ml
@@ -218,7 +218,8 @@ let test_restart_interrupts_running_once_and_preserves_queued () =
          (store_ok (Store.settle_running_after_restart reopened ~now:5.0));
        let interrupted = get_exn reopened running_id in
        (match interrupted.state with
-        | Operation.Failed { failure = { kind = "Interrupted_by_restart"; _ }; _ } -> ()
+        | Operation.Failed
+            { failure = { kind = Operation.Interrupted_by_restart; _ }; _ } -> ()
         | _ -> fail "running operation was not interrupted");
        check bool "interrupted input scrubbed" true (Option.is_none interrupted.input);
        let queued = get_exn reopened queued_id in

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -735,7 +735,10 @@ let test_stopping_cancels_and_joins_active_child () =
   let operation = Option.get (owner_ok (Owner.exact_operation owner operation_id)) in
   match operation.state with
   | Chat_operation.Failed { failure = { kind; _ }; _ } ->
-    check string "stopped active child is terminal" "Turn_cancelled" kind
+    check string
+      "stopped active child is terminal"
+      "Turn_cancelled"
+      (Chat_operation.failure_kind_to_string kind)
   | state ->
     fail
       ("stopping returned before terminal persistence: "
@@ -868,13 +871,16 @@ let test_operation_executor_claims_latest_input_and_drains_fifo () =
     match claim () with
     | Error error ->
       Owner.Operation_failed
-        { kind = "Claim_failed"
+        { kind = Chat_operation.Store_unavailable
         ; detail = Owner.error_to_string error
         ; outcome_ref = None
         }
     | Ok None ->
       Owner.Operation_failed
-        { kind = "No_operation"; detail = "missing FIFO head"; outcome_ref = None }
+        { kind = Chat_operation.No_queued_operation
+        ; detail = "missing FIFO head"
+        ; outcome_ref = None
+        }
     | Ok (Some (operation : Chat_operation.t)) ->
       seen_inputs := operation.input :: !seen_inputs;
       Owner.Operation_succeeded
@@ -937,7 +943,7 @@ let test_operation_executor_exception_is_terminal_and_next_runs () =
     match claim () with
     | Error error ->
       Owner.Operation_failed
-        { kind = "Claim_failed"
+        { kind = Chat_operation.Store_unavailable
         ; detail = Owner.error_to_string error
         ; outcome_ref = None
         }
@@ -980,7 +986,10 @@ let test_operation_executor_exception_is_terminal_and_next_runs () =
   let second = await_terminal owner second_id 1_000 in
   (match first.state with
    | Chat_operation.Failed { failure = { kind; detail; _ }; _ } ->
-     check string "exception failure kind" "Turn_exception" kind;
+     check string
+       "exception failure kind"
+       "Turn_exception"
+       (Chat_operation.failure_kind_to_string kind);
      check bool "exception detail is retained" true (String.length detail > 0)
    | _ -> fail "child exception did not fail the first operation");
   (match second.state with
@@ -1029,7 +1038,10 @@ let test_startup_interrupts_running_without_requeue () =
        let settled = Option.get (owner_ok (Owner.exact_operation owner operation_id)) in
        (match settled.state with
         | Chat_operation.Failed { failure = { kind; _ }; _ } ->
-          check string "restart failure kind" "Interrupted_by_restart" kind
+          check string
+            "restart failure kind"
+            "Interrupted_by_restart"
+            (Chat_operation.failure_kind_to_string kind)
         | state -> fail ("restart did not interrupt Running: " ^ Chat_operation.state_to_string state));
        check bool "interrupted input is scrubbed" true (Option.is_none settled.input);
        check bool


### PR DESCRIPTION
## Summary

- replace Keeper chat operation failure `kind:string` with one closed OCaml variant
- derive JSON and SQLite failure values from the same typed codec
- reject unknown persisted failure kinds during strict decode
- update owner execution, restart settlement, HTTP execution, and focused tests to use typed constructors

## Context

Follow-up to #27962. The operation state machine was closed, but its failure sub-state remained an open string and restart inventory depended on an exact magic string. This hard-cuts that remaining vocabulary drift without adding compatibility aliases or fallback decoding.

## Verification

- Not run locally in this editing pass. GitHub CI is authoritative for this Draft PR.
