### PR TITLE
fix(dashboard): tools/list 를 페이지 예산이 아니라 진행성으로 끝낸다

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -193,6 +193,56 @@ describe('MCP 2026-07-28 dashboard client', () => {
     expect(body.params.arguments).toEqual({})
   })
 
+  // Pagination stops on absence of a cursor, and the guard is progress rather
+  // than a page budget: #26771 capped at 50 pages, which refused a server with
+  // 51 legitimate pages and let a non-progressing one run 50 round trips first.
+  it('rejects a server that repeats a cursor instead of advancing', async () => {
+    const page = () => new Response(JSON.stringify({
+      result: { tools: [{ name: 'one', description: '', inputSchema: {} }], nextCursor: 'same' },
+    }), { status: 200 })
+    fetchWithTimeout.mockResolvedValueOnce(page()).mockResolvedValueOnce(page())
+
+    const { listAllMcpTools } = await import('./mcp')
+    await expect(listAllMcpTools()).rejects.toThrow(/repeated cursor same/)
+    // Two round trips, not fifty: the second page is where non-progress shows.
+    expect(callsByMethod('tools/list')).toHaveLength(2)
+  })
+
+  it('follows more pages than the retired fixed cap allowed', async () => {
+    const PAGES = 60
+    for (let i = 0; i < PAGES; i++) {
+      const last = i === PAGES - 1
+      fetchWithTimeout.mockResolvedValueOnce(new Response(JSON.stringify({
+        result: {
+          tools: [{ name: `tool-${i}`, description: '', inputSchema: {} }],
+          ...(last ? {} : { nextCursor: `cursor-${i}` }),
+        },
+      }), { status: 200 }))
+    }
+
+    const { listAllMcpTools } = await import('./mcp')
+    await expect(listAllMcpTools()).resolves.toHaveLength(PAGES)
+  })
+
+  it('gives every tools/list page a distinct request id', async () => {
+    fetchWithTimeout
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        result: { tools: [{ name: 'one', description: '', inputSchema: {} }], nextCursor: 'next' },
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        result: { tools: [{ name: 'two', description: '', inputSchema: {} }] },
+      }), { status: 200 }))
+
+    const { listAllMcpTools } = await import('./mcp')
+    await listAllMcpTools()
+
+    const ids = callsByMethod('tools/list')
+      .map(([, init]) => JSON.parse(init.body as string).id)
+    expect(new Set(ids).size).toBe(ids.length)
+    // A wall-clock id is a number; these are uuids.
+    for (const id of ids) expect(typeof id).toBe('string')
+  })
+
   it('uses current metadata on every tools/list page', async () => {
     fetchWithTimeout
       .mockResolvedValueOnce(new Response(JSON.stringify({

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -367,7 +367,11 @@ async function listMcpTools(cursor?: string): Promise<McpToolsListResult> {
     jsonrpc: '2.0',
     method: 'tools/list',
     params: cursor ? { cursor } : {},
-    id: Date.now(),
+    // A uuid, like every other request in this file. `Date.now()` gave two
+    // calls in the same millisecond the same JSON-RPC id, and repeated the
+    // whole value space roughly every 16m40s once it was taken modulo a
+    // million.
+    id: randomUuid(),
   }, binding)
   const parsed = parseMcpListResponse(text)
   if (parsed.error) {
@@ -380,10 +384,19 @@ async function listMcpTools(cursor?: string): Promise<McpToolsListResult> {
   return parsed.result
 }
 
-const MAX_TOOL_LIST_PAGES = 50
+/* Pagination ends when the server stops handing back a cursor. The failure
+   worth guarding is a server that never stops -- one that returns the same
+   cursor forever, or cycles through a set of them -- and the answer to that is
+   progress, not a page budget.
 
+   A fixed cap answered a different question. It refused a server that
+   legitimately had more pages than the number someone picked, and it let a
+   non-progressing server run for that many round trips before saying anything.
+   Seen cursors decide it directly: a cursor that repeats means the server has
+   not advanced, and that is the error. */
 export async function listAllMcpTools(): Promise<McpToolsListResult['tools']> {
   const all: McpToolsListResult['tools'] = []
+  const seenCursors = new Set<string>()
   let cursor: string | undefined
   let pages = 0
   do {
@@ -391,10 +404,13 @@ export async function listAllMcpTools(): Promise<McpToolsListResult['tools']> {
     all.push(...page.tools)
     cursor = page.nextCursor
     pages++
-    if (pages >= MAX_TOOL_LIST_PAGES && cursor) {
-      throw new Error(
-        `tools/list: reached maximum pagination limit of ${MAX_TOOL_LIST_PAGES} pages while server indicated more pages (pagesFetched=${pages}, toolsCollected=${all.length}, lastCursor=${cursor})`
-      )
+    if (cursor !== undefined) {
+      if (seenCursors.has(cursor)) {
+        throw new Error(
+          `tools/list: server repeated cursor ${cursor} after ${pages} page(s), so pagination is not advancing (toolsCollected=${all.length})`
+        )
+      }
+      seenCursors.add(cursor)
     }
   } while (cursor)
   return all


### PR DESCRIPTION
Closes #26771

## 두 결함 모두 "질문에 숫자로 답한" 형태입니다

### 1. `id: Date.now()`

```ts
async function listMcpTools(cursor?: string) {
  const text = await mcpPost({ jsonrpc: '2.0', method: 'tools/list', ..., id: Date.now() }, binding)
```

같은 밀리초의 두 호출이 **같은 JSON-RPC id** 를 갖습니다. 이 파일의 다른 요청은 이미 `randomUuid()` 를 씁니다(`:284`) — 이 하나만 아니었습니다.

### 2. `MAX_TOOL_LIST_PAGES = 50`

**진행성 검사 자리에 페이지 예산**이 놓여 있었습니다. 양방향으로 틀립니다.

| 방향 | 결과 |
|------|------|
| 정당한 51페이지 서버 | `nextCursor` 가 계속 오는데 **클라이언트가 먼저 실패** — tool surface 가 잘린 채 로드 |
| 같은 cursor 를 영구 반복하는 서버 | **50 왕복을 돌고 나서야** 말하고, 그것도 "한도 초과"라고 보고 (원인이 아니라) |

이슈가 정확히 이 대비를 지적했습니다.

## 변경 — 본 cursor 로 직접 판정

```ts
const seenCursors = new Set<string>()
...
if (cursor !== undefined) {
  if (seenCursors.has(cursor)) {
    throw new Error(`tools/list: server repeated cursor ${cursor} after ${pages} page(s), so pagination is not advancing (...)`)
  }
  seenCursors.add(cursor)
}
```

cursor 가 반복되면 **서버가 전진하지 않은 것**이고 그게 에러입니다. 50번째가 아니라 **2번째 페이지**에서 잡힙니다. cursor 부재는 여전히 루프를 끝내므로 페이지 수가 몇이든 끝까지 따라갑니다.

`id` 는 `randomUuid()` 로.

## 검증

```
$ pnpm exec vitest run src/api/mcp.test.ts     Tests 20 passed (20)
$ pnpm run typecheck                            tsc --noEmit, clean
```

**뮤테이션** — `mcp.ts` 만 되돌리면:

```
× rejects a server that repeats a cursor instead of advancing
× follows more pages than the retired fixed cap allowed
× gives every tools/list page a distinct request id
Tests  3 failed | 17 passed (20)
```

**신규 3건 전부 판별력이 있습니다.** 기존 17건은 양쪽에서 통과합니다.

세 케이스가 각각 다른 것을 봅니다: 반복 cursor 거부(그리고 **2왕복만에**), 60페이지 완주, id 가 uuid 문자열인지.

RFC-WAIVED: 대시보드 MCP 클라이언트의 페이지네이션 종료 조건과 요청 id 생성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
