### PR TITLE
fix(ci): DET 게이트가 재들여쓰기를 새 부채로 오탐하지 않는다

### DIFF
--- a/scripts/ci/check-determinism-contract.sh
+++ b/scripts/ci/check-determinism-contract.sh
@@ -70,6 +70,19 @@ is_det_ndt_pattern() {
   return 1
 }
 
+# A line that only changed indentation is the same line. Wrapping an
+# expression in a new scope re-indents everything inside it, and this
+# comparison was whitespace-exact, so such a refactor reported every wrapped
+# line as new deterministic-boundary debt (#26583, observed on #26573).
+# Both sides are compared with outer whitespace stripped: what the patterns
+# above match is the expression, not the column it sits in.
+strip_outer_space() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
 collect_moved_det_ndt_lines() {
   local current_path=""
   local raw=""
@@ -88,7 +101,7 @@ collect_moved_det_ndt_lines() {
         if [[ "$raw" != "---"* && "$current_path" == lib/*.ml ]]; then
           text="${raw:1}"
           if is_det_ndt_pattern "$text"; then
-            printf '%s\n' "$text" >> "$moved_det_ndt_lines_file"
+            printf '%s\n' "$(strip_outer_space "$text")" >> "$moved_det_ndt_lines_file"
           fi
         fi
         ;;
@@ -97,7 +110,8 @@ collect_moved_det_ndt_lines() {
 }
 
 is_moved_det_ndt_line() {
-  local text="$1"
+  local text
+  text="$(strip_outer_space "$1")"
   [ -s "$moved_det_ndt_lines_file" ] || return 1
   grep -Fxq -- "$text" "$moved_det_ndt_lines_file"
 }


### PR DESCRIPTION
Closes #26583

## 무엇이 오탐이었나

```bash
is_moved_det_ndt_line() {
  local text="$1"
  grep -Fxq -- "$text" "$moved_det_ndt_lines_file"   # 선행 공백까지 완전일치
}
```

표현식을 새 스코프로 감싸면 그 안의 모든 줄이 **들여쓰기만** 바뀝니다. 문자는 하나도 안 바뀌었는데 제거된 줄과 추가된 줄이 다른 문자열이 되고, DET/NDT 패턴에 걸리는 줄마다 *"new deterministic-boundary debt"* 로 보고됐습니다. #26573 이 그 사례입니다.

이 게이트가 매칭하는 패턴들 — `Unix.gettimeofday`, `Option.value ~default:`, `| _ -> Some` — 은 **표현식**에 관한 것이지 그것이 놓인 열에 관한 게 아닙니다.

## 변경

양쪽을 바깥 공백을 벗기고 비교합니다.

```bash
strip_outer_space() {
  local s="$1"
  s="${s#"${s%%[![:space:]]*}"}"
  s="${s%"${s##*[![:space:]]}"}"
  printf '%s' "$s"
}
```

수집 시점과 비교 시점 **양쪽 모두** 통과시켜, 한쪽만 정규화해서 생기는 비대칭을 만들지 않습니다.

## 재현과 검증

`lib/activity_graph/activity_graph.ml:595` 의 DET/NDT 줄에 **공백 2칸만** 더한 커밋으로 재현했습니다.

```
let prev = StringMap.find_opt e.kind acc |> Option.value ~default:0 in
```

| 시나리오 | 수정 전 | 수정 후 |
|----------|---------|---------|
| **들여쓰기만 변경** | `DET/NDT gate: FAIL` exit=1 | **`PASS` exit=0** |
| **진짜 새 DET/NDT 줄 추가** | FAIL | **FAIL** exit=1 |

두 번째가 대조군입니다. 비교를 넓히는 변경은 **다른 것을 새로 놓치지 않을 때만** 옳습니다. 새 부채 케이스에서 게이트가 여전히 줄을 지목합니다:

```
origin/main...HEAD: lib/activity_graph/activity_graph.ml:596:
  let _fresh_debt = Option.value ~default:0 (Some 1) in
=== DET/NDT gate: FAIL ===
```

```
$ bash -n scripts/ci/check-determinism-contract.sh    syntax OK
$ bash scripts/ci/check-determinism-contract.sh       DET/NDT gate: PASS (clean tree)
```

이 스크립트는 이미 `ci.yml:564` 에서 돕니다 — 새 배선 없음.

RFC-WAIVED: CI 게이트 스크립트의 문자열 비교 정규화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
