### PR TITLE
fix(keeper): restore typed operation failure build

### DIFF
--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -141,7 +141,7 @@ type _ command =
       -> (Chat_operation.t, error) result command
   | Fail_running_operation :
       { operation_id : Operation_id.t
-      ; kind : string
+      ; kind : Chat_operation.failure_kind
       ; detail : string
       ; outcome_ref : string option
       }

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -25,6 +25,7 @@
   ;; #20929: server bootstrap converges <base>/.masc/config/prompts onto the
   ;; binary-embedded config/ tree so merged prompt edits ship on restart.
   masc.embedded_config
+  masc.keeper_chat_operations
   ;; server_dashboard_http_keeper_api reads the manifest decision payload
   ;; through Keeper_compaction_evidence.exact_evidence_key; dune does not
   ;; re-export it through the masc dep, so masc_server lists it explicitly.


### PR DESCRIPTION
## Summary
- align the Owner command payload with the typed chat operation failure vocabulary
- declare the server direct dependency on the chat operation library
- do not add compatibility decoding or string conversion

## Evidence
The Build and Test job for PR #27984 failed on current main with:
- Keeper_owner Fail_running_operation carrying string where Chat_operation.failure_kind is required
- server_routes_http_keeper_stream naming Keeper_chat_operation without the direct Dune dependency

## Verification
- git diff --check: pass
- focused scripts/dune-local.sh build attempt: blocked by existing bare Dune processes in the shared workspace, so local compile is not claimed
- exact-head GitHub CI: pending

Closes the current-main compile regression exposed by Actions run 31354620702.