### PR TITLE
fix(metrics): type provider failure reasons

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -7,18 +7,6 @@ let provider_cache_mu = Stdlib.Mutex.create ()
 let with_provider_cache_lock f = Stdlib.Mutex.protect provider_cache_mu f
 ;;
 
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0 then true
-  else
-    let rec loop i =
-      i + needle_len <= haystack_len
-      && (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
-    in
-    loop 0
-;;
-
 let note_provider ~model_id ~provider =
   if (not (String.equal model_id "")) && not (String.equal provider "") then
     with_provider_cache_lock (fun () ->
@@ -232,20 +220,8 @@ let emit_request_start ~model_id =
     ~labels:(model_labels ~model_id)
 ;;
 
-let error_reason error =
-  let error = String.lowercase_ascii error in
-  if contains_substring error "429" || contains_substring error "rate limit"
-  then "rate_limit"
-  else if
-    contains_substring error "timeout"
-    || contains_substring error "timed out"
-    || contains_substring error "deadline"
-  then "timeout"
-  else "unknown"
-;;
-
-let emit_error ~model_id ~error =
-  let reason = error_reason error in
+let emit_error ~model_id ~message ~reason =
+  let reason = Metrics.error_reason_to_string reason in
   let provider = genai_provider_for_model ~model_id in
   inc_counter
     Otel_metric_store.metric_llm_provider_errors
@@ -254,7 +230,7 @@ let emit_error ~model_id ~error =
     Otel_metric_store.metric_llm_provider_errors_by_reason
     ~labels:[ ("model", model_id); ("error_reason", reason) ];
   Otel_spans.record_error
-    ~message:error
+    ~message
     ~error_type:reason
     ~attrs:
       [ Otel_genai.Attr_key.gen_ai_operation_name, `String genai_operation_name

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -18,7 +18,11 @@ val emit_request_latency
   -> unit
 
 val emit_cache_hit : model_id:string -> unit
-val emit_error : model_id:string -> error:string -> unit
+val emit_error
+  :  model_id:string
+  -> message:string
+  -> reason:Llm_provider.Metrics.error_reason
+  -> unit
 val emit_token_usage
   :  provider:string
   -> model_id:string

--- a/lib/runtime/runtime_observation.ml
+++ b/lib/runtime/runtime_observation.ml
@@ -381,9 +381,9 @@ let runtime_metrics_for_candidates ~candidate_count:(_ : int) () =
         record_attempt_start capture ~model_id);
       on_request_end = (fun ~model_id ~latency_ms ->
         ensure_terminal_attempt capture ~model_id ~latency_ms ~error:None);
-      on_error = (fun ~model_id ~error ->
+      on_error = (fun ~model_id ~message ~reason:_ ->
         ensure_terminal_attempt capture ~model_id ~latency_ms:None
-          ~error:(Some error));
+          ~error:(Some message));
       on_capability_drop = (fun ~model_id:_ ~field:_ -> ());
       on_http_status = (fun ~provider:_ ~model_id:_ ~status:_ -> ());
       on_circuit_state =

--- a/packages/agent_core/lib/llm_provider/complete.ml
+++ b/packages/agent_core/lib/llm_provider/complete.ml
@@ -244,6 +244,16 @@ let complete_prepared_sync
            | _, _ -> ());
           Ok resp
         | Error err ->
+          let metric_error_reason =
+            match err with
+            | Http_client.HttpError { code = 429; _ } -> Metrics.Rate_limit
+            | Http_client.TimeoutError _ -> Metrics.Timeout
+            | Http_client.HttpError _
+            | Http_client.AcceptRejected _
+            | Http_client.NetworkError _
+            | Http_client.ProviderTerminal _
+            | Http_client.ProviderFailure _ -> Metrics.Unknown
+          in
           let err_str =
             match err with
             | Http_client.HttpError { code; _ } -> Printf.sprintf "HTTP %d" code
@@ -254,7 +264,7 @@ let complete_prepared_sync
             | Http_client.ProviderFailure { kind; message } ->
               Http_client.provider_failure_to_string ~kind ~message
           in
-          m.on_error ~model_id ~error:err_str;
+          m.on_error ~model_id ~message:err_str ~reason:metric_error_reason;
           Error err))
 ;;
 

--- a/packages/agent_core/lib/llm_provider/metrics.ml
+++ b/packages/agent_core/lib/llm_provider/metrics.ml
@@ -17,12 +17,23 @@ let circuit_state_to_string = function
   | Circuit_half_open -> "half_open"
 ;;
 
+type error_reason =
+  | Rate_limit
+  | Timeout
+  | Unknown
+
+let error_reason_to_string = function
+  | Rate_limit -> "rate_limit"
+  | Timeout -> "timeout"
+  | Unknown -> "unknown"
+;;
+
 type t =
   { on_cache_hit : model_id:string -> unit
   ; on_cache_miss : model_id:string -> unit
   ; on_request_start : model_id:string -> unit
   ; on_request_end : model_id:string -> latency_ms:int option -> unit
-  ; on_error : model_id:string -> error:string -> unit
+  ; on_error : model_id:string -> message:string -> reason:error_reason -> unit
   ; on_http_status : provider:string -> model_id:string -> status:int -> unit
   ; on_circuit_state :
       provider:string
@@ -60,7 +71,7 @@ let noop =
   ; on_cache_miss = (fun ~model_id:_ -> ())
   ; on_request_start = (fun ~model_id:_ -> ())
   ; on_request_end = (fun ~model_id:_ ~latency_ms:_ -> ())
-  ; on_error = (fun ~model_id:_ ~error:_ -> ())
+  ; on_error = (fun ~model_id:_ ~message:_ ~reason:_ -> ())
   ; on_http_status = (fun ~provider:_ ~model_id:_ ~status:_ -> ())
   ; on_circuit_state = (fun ~provider:_ ~model_id:_ ~provider_key:_ ~state:_ -> ())
   ; on_capability_drop = (fun ~model_id:_ ~field:_ -> ())
@@ -303,8 +314,8 @@ module Aggregating = struct
               s.latency_ms_count <- s.latency_ms_count + 1)
           | None -> ())
     ; on_error =
-        (fun ~model_id ~error ->
-          agg.hooks.on_error ~model_id ~error;
+        (fun ~model_id ~message ~reason ->
+          agg.hooks.on_error ~model_id ~message ~reason;
           with_state agg ("unknown/" ^ model_id) (fun s ->
             s.error_total <- s.error_total + 1))
     ; on_http_status =

--- a/packages/agent_core/lib/llm_provider/metrics.mli
+++ b/packages/agent_core/lib/llm_provider/metrics.mli
@@ -19,6 +19,15 @@ type circuit_state =
 val circuit_state_to_int : circuit_state -> int
 val circuit_state_to_string : circuit_state -> string
 
+(** Bounded failure classification supplied by the typed transport boundary.
+    Metric consumers must not infer this value from the diagnostic message. *)
+type error_reason =
+  | Rate_limit
+  | Timeout
+  | Unknown
+
+val error_reason_to_string : error_reason -> string
+
 (** Metrics callback interface. All callbacks are optional — provide [noop]
     as a default that does nothing.
 
@@ -33,7 +42,9 @@ type t =
   ; on_cache_miss : model_id:string -> unit
   ; on_request_start : model_id:string -> unit
   ; on_request_end : model_id:string -> latency_ms:int option -> unit
-  ; on_error : model_id:string -> error:string -> unit
+  ; on_error : model_id:string -> message:string -> reason:error_reason -> unit
+    (** Fired for a failed request. [message] is diagnostic text only; control
+        flow and metric labels must use [reason]. *)
   ; on_http_status : provider:string -> model_id:string -> status:int -> unit
   ; on_circuit_state :
       provider:string

--- a/packages/agent_core/test/test_complete_ext.ml
+++ b/packages/agent_core/test/test_complete_ext.ml
@@ -91,7 +91,9 @@ let metrics_of_probe probe =
   ; on_cache_miss = (fun ~model_id:_ -> probe.cache_misses <- probe.cache_misses + 1)
   ; on_request_start = (fun ~model_id:_ -> probe.starts <- probe.starts + 1)
   ; on_request_end = (fun ~model_id:_ ~latency_ms:_ -> probe.ends <- probe.ends + 1)
-  ; on_error = (fun ~model_id:_ ~error -> probe.errors <- error :: probe.errors)
+  ; on_error =
+      (fun ~model_id:_ ~message ~reason:_ ->
+        probe.errors <- message :: probe.errors)
   ; on_http_status =
       (fun ~provider:_ ~model_id:_ ~status -> probe.statuses <- status :: probe.statuses)
   ; on_token_usage =

--- a/packages/agent_core/test/test_complete_http.ml
+++ b/packages/agent_core/test/test_complete_http.ml
@@ -972,7 +972,7 @@ let test_complete_metrics () =
       ; on_cache_miss = (fun ~model_id:_ -> incr miss_count)
       ; on_request_start = (fun ~model_id:_ -> incr start_count)
       ; on_request_end = (fun ~model_id:_ ~latency_ms:_ -> incr end_count)
-      ; on_error = (fun ~model_id:_ ~error:_ -> ())
+      ; on_error = (fun ~model_id:_ ~message:_ ~reason:_ -> ())
       ; on_http_status =
           (fun ~provider ~model_id ~status ->
             status_calls := (provider, model_id, status) :: !status_calls)
@@ -1074,7 +1074,7 @@ let test_complete_error_metrics () =
       ; on_cache_miss = (fun ~model_id:_ -> ())
       ; on_request_start = (fun ~model_id:_ -> ())
       ; on_request_end = (fun ~model_id:_ ~latency_ms:_ -> ())
-      ; on_error = (fun ~model_id:_ ~error:_ -> incr error_count)
+      ; on_error = (fun ~model_id:_ ~message:_ ~reason:_ -> incr error_count)
       ; on_http_status =
           (fun ~provider ~model_id ~status ->
             status_calls := (provider, model_id, status) :: !status_calls)

--- a/packages/agent_core/test/test_metrics_aggregating.ml
+++ b/packages/agent_core/test/test_metrics_aggregating.ml
@@ -94,7 +94,7 @@ let test_aggregating_on_circuit_state () =
 let test_aggregating_on_error () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
-  hooks.on_error ~model_id:"bad-model" ~error:"timeout";
+  hooks.on_error ~model_id:"bad-model" ~message:"timeout" ~reason:M.Timeout;
   let snap = Agg.snapshot agg in
   let entry = List.hd snap in
   check int "error_total" 1 entry.M.error_total
@@ -153,7 +153,7 @@ let test_aggregating_reset () =
   let agg = Agg.create () in
   let hooks = Agg.to_hooks agg in
   hooks.on_request_start ~model_id:"x";
-  hooks.on_error ~model_id:"x" ~error:"err";
+  hooks.on_error ~model_id:"x" ~message:"err" ~reason:M.Unknown;
   Agg.reset agg;
   let snap = Agg.snapshot agg in
   check int "empty after reset" 0 (List.length snap)

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -157,7 +157,10 @@ let test_sink_records_agent_core_callbacks () =
   sink.on_cache_hit ~model_id;
   sink.on_cache_miss ~model_id;
   sink.on_request_start ~model_id;
-  sink.on_error ~model_id ~error:"ignored-freeform-error";
+  sink.on_error
+    ~model_id
+    ~message:"ignored-freeform-error"
+    ~reason:Llm_provider.Metrics.Unknown;
   sink.on_retry ~provider ~model_id ~attempt:2;
   sink.on_circuit_state ~provider ~model_id ~provider_key
     ~state:Llm_provider.Metrics.Circuit_open;
@@ -584,7 +587,11 @@ let test_error_records_genai_exception_span_signal () =
     ~emit_event:(fun ~name ~attrs -> events := (name, attrs) :: !events)
     ~emit_attrs:(fun ~attrs -> span_attrs := attrs @ !span_attrs)
     ~set_status:(fun status -> span_status := Some status)
-    (fun () -> Bridge.emit_error ~model_id ~error:"deadline exceeded after 30s");
+    (fun () ->
+      Bridge.emit_error
+        ~model_id
+        ~message:"deadline exceeded after 30s"
+        ~reason:Llm_provider.Metrics.Timeout);
   (match !span_status with
    | Some { Opentelemetry.Span_status.message; code } ->
      Alcotest.(check string)
@@ -735,7 +742,7 @@ let test_request_latency_uses_provider_seen_from_status () =
     ~before
     ~delta:1.0
 
-let test_error_reason_labels_are_bounded () =
+let test_error_reason_labels_use_typed_reason () =
   let model_id =
     Printf.sprintf "bridge-error-reason-%d" (Unix.getpid ())
   in
@@ -750,8 +757,18 @@ let test_error_reason_labels_are_bounded () =
     metric Metrics.metric_llm_provider_errors_by_reason
       ~labels:(reason_labels "rate_limit")
   in
-  Bridge.emit_error ~model_id ~error:"deadline exceeded after 30s";
-  Bridge.emit_error ~model_id ~error:"HTTP 429 rate limit exceeded";
+  Bridge.emit_error
+    ~model_id
+    ~message:"deadline exceeded after 30s"
+    ~reason:Llm_provider.Metrics.Timeout;
+  Bridge.emit_error
+    ~model_id
+    ~message:"HTTP 429 rate limit exceeded"
+    ~reason:Llm_provider.Metrics.Rate_limit;
+  Bridge.emit_error
+    ~model_id
+    ~message:"request completed latency_ms=3429"
+    ~reason:Llm_provider.Metrics.Unknown;
   check_metric_delta "timeout reason +1"
     Metrics.metric_llm_provider_errors_by_reason
     ~labels:(reason_labels "timeout") ~before:before_timeout ~delta:1.0;
@@ -810,7 +827,7 @@ let () =
             test_request_latency_positive_ms_does_not_clamp;
           Alcotest.test_case "request latency uses provider seen from status" `Quick
             test_request_latency_uses_provider_seen_from_status;
-          Alcotest.test_case "error reason labels are bounded" `Quick
-            test_error_reason_labels_are_bounded;
+          Alcotest.test_case "error reason labels use typed reason" `Quick
+            test_error_reason_labels_use_typed_reason;
         ] );
     ]


### PR DESCRIPTION
## Summary
- replace diagnostic-string parsing with a bounded typed metric failure reason
- classify HTTP 429 and transport timeouts at the typed producer boundary
- keep diagnostic messages data-only and cover latency_ms=3429 against false rate-limit attribution

## Validation
- Not run locally (not requested)
- CI pending