### PR TITLE
fix(keeper): finish the typed operation failure vocabulary at the stream sites

### DIFF
--- a/lib/keeper_chat_operations/keeper_chat_operation.ml
+++ b/lib/keeper_chat_operations/keeper_chat_operation.ml
@@ -37,6 +37,7 @@ type failure_kind =
   | No_queued_operation
   | Invalid_input
   | Turn_invariant
+  | Delivery_failed
 
 let all_failure_kinds =
   [ Interrupted_by_restart
@@ -46,6 +47,7 @@ let all_failure_kinds =
   ; No_queued_operation
   ; Invalid_input
   ; Turn_invariant
+  ; Delivery_failed
   ]
 ;;
 
@@ -57,6 +59,7 @@ let failure_kind_to_string = function
   | No_queued_operation -> "No_queued_operation"
   | Invalid_input -> "Invalid_input"
   | Turn_invariant -> "Turn_invariant"
+  | Delivery_failed -> "Delivery_failed"
 ;;
 
 let failure_kind_of_string = function
@@ -67,6 +70,7 @@ let failure_kind_of_string = function
   | "No_queued_operation" -> Ok No_queued_operation
   | "Invalid_input" -> Ok Invalid_input
   | "Turn_invariant" -> Ok Turn_invariant
+  | "Delivery_failed" -> Ok Delivery_failed
   | value -> Error (Printf.sprintf "unknown Keeper chat operation failure kind %S" value)
 ;;
 

--- a/lib/keeper_chat_operations/keeper_chat_operation.mli
+++ b/lib/keeper_chat_operations/keeper_chat_operation.mli
@@ -21,6 +21,7 @@ type failure_kind =
   | No_queued_operation
   | Invalid_input
   | Turn_invariant
+  | Delivery_failed
 
 val all_failure_kinds : failure_kind list
 val failure_kind_to_string : failure_kind -> string

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -931,6 +931,15 @@ let queued_turn_failure_kind_to_string = function
   | Transcript_persist_failed -> "transcript_persist_failed"
   | Stream_projection_failed -> "stream_projection_failed"
 
+(* Total mapping into the closed operation-ledger vocabulary; the queued kind's
+   full name still travels in the failure detail. *)
+let chat_operation_failure_kind_of_queued = function
+  | Turn_failed -> Keeper_chat_operation.Turn_exception
+  | Turn_cancelled -> Keeper_chat_operation.Turn_cancelled
+  | No_visible_reply | Missing_turn_ref -> Keeper_chat_operation.Turn_invariant
+  | Transcript_persist_failed | Stream_projection_failed ->
+    Keeper_chat_operation.Delivery_failed
+
 let queued_delivery_outcome_of_turn_ref = function
   | Some turn_ref ->
       Delivered { outcome_ref = Ids.Turn_ref.to_string turn_ref }
@@ -2003,9 +2012,11 @@ let operation_executor ~state ~clock : Keeper_owner.operation_executor =
              | Some (Delivered { outcome_ref }), Ok () ->
                Keeper_owner.Operation_succeeded { outcome_ref }
              | Some (Delivered { outcome_ref }), Error detail ->
-               failed ~outcome_ref "Delivery_failed" detail
+               failed ~outcome_ref Keeper_chat_operation.Delivery_failed detail
              | Some (Failed { kind; detail }), _ ->
-               failed (queued_turn_failure_kind_to_string kind) detail
+               failed
+                 (chat_operation_failure_kind_of_queued kind)
+                 (queued_turn_failure_kind_to_string kind ^ ": " ^ detail)
              | None, _ ->
                failed
                  Keeper_chat_operation.Turn_invariant


### PR DESCRIPTION
main은 #27985 이후에도 컴파일되지 않습니다 — `server_routes_http_keeper_stream.ml`의 두 사이트가 여전히 string kind를 넘깁니다 (`"Delivery_failed"` 상수, `queued_turn_failure_kind_to_string`). 로컬 재현: `dune build .` → `This constant has type string but an expression was expected of type Keeper_owner.Chat_operation.failure_kind`.

수리:

- 어휘에 `Delivery_failed` 추가 — 해당 사이트가 이미 string으로 요구하던 이름 (turn 출력의 persist/delivery 실패)
- queued 6종을 catch-all 없이 total 매핑: `Turn_failed→Turn_exception`, `Turn_cancelled→동일`, `No_visible_reply`·`Missing_turn_ref→Turn_invariant`, `Transcript_persist_failed`·`Stream_projection_failed→Delivery_failed`
- queued kind 원명은 failure detail 접두로 보존해 세부 분류가 ledger row까지 도달
- store의 SQLite CHECK 목록은 `all_failure_kinds`에서 생성되므로 신규 DB에 자동 반영. 배포된 chat-operations DB는 아직 없어(컷오버 미출하) 좁은 CHECK를 가진 라이브 DB도 존재하지 않습니다.

검증: `bin/main_eio.exe` + `test/test_keeper_owner.exe` 빌드 green (현 main 베이스로 ff 후), keeper_owner 32/32 통과.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
