### PR TITLE
fix(keeper): main red — #27981 이 떨어뜨린 failure kind 를 복원하고 두 철자를 읽는다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -911,6 +911,7 @@ jobs:
             @test/runtest-test_fs_compat_home_guard \
             @test/runtest-test_guarded_dispatch_telemetry \
             @test/runtest-test_keeper_checkpoint_stale_guard \
+            @test/runtest-test_keeper_chat_operation_failure_kind \
             @test/runtest-test_keeper_contract_classifier_pure \
             @test/runtest-test_keeper_conditions_wire_parity \
             @test/runtest-test_keeper_fsm_guard_actions \

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -141,7 +141,7 @@ type _ command =
       -> (Chat_operation.t, error) result command
   | Fail_running_operation :
       { operation_id : Operation_id.t
-      ; kind : string
+      ; kind : Chat_operation.failure_kind
       ; detail : string
       ; outcome_ref : string option
       }

--- a/lib/keeper_chat_operations/keeper_chat_operation.ml
+++ b/lib/keeper_chat_operations/keeper_chat_operation.ml
@@ -29,6 +29,13 @@ module Operation_id = struct
   let equal = String.equal
 end
 
+(* Every kind a producer actually writes. #27981 closed this vocabulary to
+   seven and left six out, which broke two ways at once: three call sites
+   stopped compiling, and [failure_kind_of_string] began rejecting kinds that
+   are already on disk -- 77 failed receipts in the live queues carry
+   turn_failed (52), no_visible_reply (15), cancelled (9) and
+   transcript_persist_failed (1). A decoder that refuses its own history is
+   the #27393 shape (see #27401): the record is not wrong, it is unreadable. *)
 type failure_kind =
   | Interrupted_by_restart
   | Turn_cancelled
@@ -37,6 +44,12 @@ type failure_kind =
   | No_queued_operation
   | Invalid_input
   | Turn_invariant
+  | Turn_failed
+  | No_visible_reply
+  | Missing_turn_ref
+  | Transcript_persist_failed
+  | Stream_projection_failed
+  | Delivery_failed
 
 let all_failure_kinds =
   [ Interrupted_by_restart
@@ -46,6 +59,12 @@ let all_failure_kinds =
   ; No_queued_operation
   ; Invalid_input
   ; Turn_invariant
+  ; Turn_failed
+  ; No_visible_reply
+  ; Missing_turn_ref
+  ; Transcript_persist_failed
+  ; Stream_projection_failed
+  ; Delivery_failed
   ]
 ;;
 
@@ -57,6 +76,12 @@ let failure_kind_to_string = function
   | No_queued_operation -> "No_queued_operation"
   | Invalid_input -> "Invalid_input"
   | Turn_invariant -> "Turn_invariant"
+  | Turn_failed -> "Turn_failed"
+  | No_visible_reply -> "No_visible_reply"
+  | Missing_turn_ref -> "Missing_turn_ref"
+  | Transcript_persist_failed -> "Transcript_persist_failed"
+  | Stream_projection_failed -> "Stream_projection_failed"
+  | Delivery_failed -> "Delivery_failed"
 ;;
 
 let failure_kind_of_string = function
@@ -67,6 +92,21 @@ let failure_kind_of_string = function
   | "No_queued_operation" -> Ok No_queued_operation
   | "Invalid_input" -> Ok Invalid_input
   | "Turn_invariant" -> Ok Turn_invariant
+  | "Turn_failed" -> Ok Turn_failed
+  | "No_visible_reply" -> Ok No_visible_reply
+  | "Missing_turn_ref" -> Ok Missing_turn_ref
+  | "Transcript_persist_failed" -> Ok Transcript_persist_failed
+  | "Stream_projection_failed" -> Ok Stream_projection_failed
+  | "Delivery_failed" -> Ok Delivery_failed
+  (* The queued-turn writer spells these lowercase, and receipts on disk carry
+     that spelling. Reading is where history arrives, so both are accepted;
+     [failure_kind_to_string] still emits one form. *)
+  | "turn_failed" -> Ok Turn_failed
+  | "turn_cancelled" | "cancelled" -> Ok Turn_cancelled
+  | "no_visible_reply" -> Ok No_visible_reply
+  | "missing_turn_ref" -> Ok Missing_turn_ref
+  | "transcript_persist_failed" -> Ok Transcript_persist_failed
+  | "stream_projection_failed" -> Ok Stream_projection_failed
   | value -> Error (Printf.sprintf "unknown Keeper chat operation failure kind %S" value)
 ;;
 

--- a/lib/keeper_chat_operations/keeper_chat_operation.mli
+++ b/lib/keeper_chat_operations/keeper_chat_operation.mli
@@ -21,6 +21,12 @@ type failure_kind =
   | No_queued_operation
   | Invalid_input
   | Turn_invariant
+  | Turn_failed
+  | No_visible_reply
+  | Missing_turn_ref
+  | Transcript_persist_failed
+  | Stream_projection_failed
+  | Delivery_failed
 
 val all_failure_kinds : failure_kind list
 val failure_kind_to_string : failure_kind -> string

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -931,6 +931,19 @@ let queued_turn_failure_kind_to_string = function
   | Transcript_persist_failed -> "transcript_persist_failed"
   | Stream_projection_failed -> "stream_projection_failed"
 
+(* One arm per queued kind rather than a hop through the string form above: a
+   kind added on either side becomes a compile error here instead of a value
+   the operation vocabulary refuses to parse later. *)
+let operation_failure_kind_of_queued_turn_failure_kind
+  : queued_turn_failure_kind -> Keeper_owner.Chat_operation.failure_kind
+  = function
+  | Turn_failed -> Keeper_owner.Chat_operation.Turn_failed
+  | Turn_cancelled -> Keeper_owner.Chat_operation.Turn_cancelled
+  | No_visible_reply -> Keeper_owner.Chat_operation.No_visible_reply
+  | Missing_turn_ref -> Keeper_owner.Chat_operation.Missing_turn_ref
+  | Transcript_persist_failed -> Keeper_owner.Chat_operation.Transcript_persist_failed
+  | Stream_projection_failed -> Keeper_owner.Chat_operation.Stream_projection_failed
+
 let queued_delivery_outcome_of_turn_ref = function
   | Some turn_ref ->
       Delivered { outcome_ref = Ids.Turn_ref.to_string turn_ref }
@@ -1836,16 +1849,16 @@ let operation_executor ~state ~clock : Keeper_owner.operation_executor =
   let execute_admitted admission_token =
     match claim () with
     | Error error ->
-      failed Keeper_chat_operation.Store_unavailable (Keeper_owner.error_to_string error)
+      failed Keeper_owner.Chat_operation.Store_unavailable (Keeper_owner.error_to_string error)
     | Ok None ->
       failed
-        Keeper_chat_operation.No_queued_operation
+        Keeper_owner.Chat_operation.No_queued_operation
         "Owner FIFO head disappeared before claim"
     | Ok (Some operation) ->
       (match operation.input with
        | None ->
          failed
-           Keeper_chat_operation.Invalid_input
+           Keeper_owner.Chat_operation.Invalid_input
            "Running Keeper chat operation has no execution input"
        | Some input ->
          (match
@@ -1855,7 +1868,7 @@ let operation_executor ~state ~clock : Keeper_owner.operation_executor =
               ~source:operation.source
               ~input
           with
-          | Error detail -> failed Keeper_chat_operation.Invalid_input detail
+          | Error detail -> failed Keeper_owner.Chat_operation.Invalid_input detail
           | Ok operation_payload ->
             let payload = operation_payload.payload in
             let operation_id =
@@ -2003,12 +2016,12 @@ let operation_executor ~state ~clock : Keeper_owner.operation_executor =
              | Some (Delivered { outcome_ref }), Ok () ->
                Keeper_owner.Operation_succeeded { outcome_ref }
              | Some (Delivered { outcome_ref }), Error detail ->
-               failed ~outcome_ref "Delivery_failed" detail
+               failed ~outcome_ref Keeper_owner.Chat_operation.Delivery_failed detail
              | Some (Failed { kind; detail }), _ ->
-               failed (queued_turn_failure_kind_to_string kind) detail
+               failed (operation_failure_kind_of_queued_turn_failure_kind kind) detail
              | None, _ ->
                failed
-                 Keeper_chat_operation.Turn_invariant
+                 Keeper_owner.Chat_operation.Turn_invariant
                  "Owner operation returned no terminal turn outcome")))
   in
   match

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -111,7 +111,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=698
+UNWIRED_BASELINE=691
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/dune
+++ b/test/dune
@@ -698,6 +698,17 @@
  (libraries masc_test_deps)
  (deps ../dashboard/src/api/schemas/keeper-composite.ts))
 
+; Focused CI gate: the operation failure vocabulary must still read what the
+; writing side has already written. #27981 closed it to seven constructors and
+; left six out, so failure_kind_of_string began rejecting kinds already in the
+; live receipts (turn_failed 52, no_visible_reply 15, cancelled 9,
+; transcript_persist_failed 1).
+
+(test
+ (name test_keeper_chat_operation_failure_kind)
+ (modules test_keeper_chat_operation_failure_kind)
+ (libraries masc_test_deps))
+
 ; Focused CI gate for runtime TOML validity.
 
 (test

--- a/test/test_keeper_chat_operation_failure_kind.ml
+++ b/test/test_keeper_chat_operation_failure_kind.ml
@@ -1,0 +1,98 @@
+(** Pin the operation failure vocabulary against what is already on disk.
+
+    #27981 closed [Keeper_chat_operation.failure_kind] to seven constructors.
+    Three call sites stopped compiling, which CI caught. What it did not catch
+    is that [failure_kind_of_string] returns [Error] for anything outside the
+    set, and the live queues hold failed receipts naming kinds that were left
+    out: turn_failed (52), no_visible_reply (15), cancelled (9),
+    transcript_persist_failed (1) across the eight chat-queue databases.
+
+    A decoder that refuses its own history is the shape of #27393, where a
+    field removal made every durable file with that field unloadable and took
+    autoboot to 0/7. #27401 filed the general form. These cases keep the
+    reading side able to read what the writing side has already written.
+
+    The producer-side coverage is enforced by the compiler instead: the
+    mapping from [queued_turn_failure_kind] lives in one exhaustive match in
+    server_routes_http_keeper_stream.ml, so a kind added on either side is a
+    build error rather than a value that fails to parse at read time. *)
+
+open Masc
+module Op = Keeper_chat_operation
+
+let fail_if condition message =
+  if condition
+  then (
+    prerr_endline ("test_keeper_chat_operation_failure_kind: " ^ message);
+    exit 1)
+;;
+
+let decodes what value =
+  match Op.failure_kind_of_string value with
+  | Ok _ -> ()
+  | Error detail ->
+    fail_if true (Printf.sprintf "%s %S must decode, got: %s" what value detail)
+;;
+
+let () =
+  (* Every constructor round-trips through its own rendering. This is what
+     stops a constructor being added to the type and forgotten in one of the
+     two string functions. *)
+  List.iter
+    (fun kind ->
+      let rendered = Op.failure_kind_to_string kind in
+      match Op.failure_kind_of_string rendered with
+      | Ok decoded ->
+        fail_if
+          (decoded <> kind)
+          (Printf.sprintf "round trip changed %s" rendered)
+      | Error detail ->
+        fail_if true (Printf.sprintf "%s did not round trip: %s" rendered detail))
+    Op.all_failure_kinds;
+
+  (* all_failure_kinds must actually list them all. A constructor missing here
+     would make the loop above vacuous for that constructor. *)
+  fail_if
+    (List.length Op.all_failure_kinds < 13)
+    (Printf.sprintf
+       "all_failure_kinds has %d entries; the type declares more"
+       (List.length Op.all_failure_kinds));
+
+  (* The spellings observed in live receipt_json. The writer that produced
+     them uses lowercase snake case; failure_kind_to_string emits PascalCase.
+     Reading is where history arrives, so both are accepted. *)
+  List.iter
+    (decodes "live receipt spelling")
+    [ "turn_failed"
+    ; "no_visible_reply"
+    ; "cancelled"
+    ; "transcript_persist_failed"
+    ; "turn_cancelled"
+    ; "missing_turn_ref"
+    ; "stream_projection_failed"
+    ];
+
+  (* And the kinds #27981 left out, in the rendering this module emits. *)
+  List.iter
+    (decodes "kind restored after #27981")
+    [ "Turn_failed"
+    ; "No_visible_reply"
+    ; "Missing_turn_ref"
+    ; "Transcript_persist_failed"
+    ; "Stream_projection_failed"
+    ; "Delivery_failed"
+    ];
+
+  (* Widening the decoder is only correct if it still refuses what is not a
+     kind: without this, accepting everything would pass every case above. *)
+  (match Op.failure_kind_of_string "not_a_failure_kind_at_all" with
+   | Error _ -> ()
+   | Ok _ ->
+     fail_if true "decoder accepted a value that is not a failure kind");
+
+  print_endline
+    (Printf.sprintf
+       "test_keeper_chat_operation_failure_kind: OK - %d kinds round trip, live \
+        spellings decode"
+       (List.length Op.all_failure_kinds))
+;;


### PR DESCRIPTION
Closes #27987

## main 이 컴파일되지 않습니다

`a3ea1806b4` (PR #27981, *close operation failure vocabulary*) 가 `failure_kind` 를 7개로 좁히면서 호출부 3곳을 남겼습니다.

| 위치 | 증상 |
|------|------|
| `keeper_owner.ml:144` | `Fail_running_operation` 페이로드가 `kind : string` — **`.mli` 는 이미 `failure_kind` 로 약속**했는데 내부 GADT 만 안 바뀜 |
| `..._keeper_stream.ml` | bare `Keeper_chat_operation.` 5곳 — 이 파일은 `Keeper_owner.Chat_operation` 경로로 접근합니다 |
| `..._keeper_stream.ml:2006` | `failed ~outcome_ref "Delivery_failed" detail` |

## 세 번째가 진짜 문제입니다

`Delivery_failed` 는 **닫힌 집합에 아예 없습니다.** queued-turn writer 가 만드는 6종 중 5종(`Turn_failed` · `No_visible_reply` · `Missing_turn_ref` · `Transcript_persist_failed` · `Stream_projection_failed`)도 없습니다.

즉 변환을 놓친 게 아니라 **프로덕션이 쓰는 종류를 떨어뜨렸습니다.**

### 이미 디스크에 있습니다

라이브 `chat-queue.sqlite3` 8개의 `state_kind='failed'` 영수증 **77건**:

```
turn_failed                  52
no_visible_reply             15
cancelled                     9
transcript_persist_failed     1
```

`failure_kind_of_string` 은 이 전부에 대해 `Error` 를 냅니다.

**디코더가 자기 이력을 거부하는 상태**입니다 — #27393 의 모양이고(그때는 필드 제거로 durable 파일이 로드 불가가 되어 autoboot 0/7), #27401 이 "다음에 어디서 날 수 있는가"로 예고한 형태입니다.

## 변경

1. **어휘를 생산자가 쓰는 전부로 복원** — 빠진 6종 추가. `Turn_exception` 으로 접었으면 컴파일은 됐겠지만, 어휘를 닫는 목적인 **구별**을 잃습니다.
2. **읽기가 두 철자를 모두 받습니다** — 영수증은 소문자 스네이크, 이 모듈은 PascalCase 를 냅니다. **이력이 도착하는 곳은 읽기**이므로 읽기만 넓히고 인코더는 한 형태를 유지합니다.
3. **queued 종류 변환이 문자열을 경유하지 않습니다** — exhaustive match 하나라, 어느 쪽에 종류가 추가돼도 **빌드 에러**로 드러납니다.

## 검증

```
$ dune build @check                                          exit=0   (main 은 실패)
$ dune build @test/runtest-test_keeper_chat_operation_failure_kind
test_keeper_chat_operation_failure_kind: OK - 13 kinds round trip, live spellings decode
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 165 CI targets, all declared in Dune
[ci-test-targets] OK - 691 suites unwired, at baseline
```

**뮤테이션** — 소문자 arm 만 지우면:

```
must decode, got: unknown Keeper chat operation failure kind "turn_failed"
```

테스트가 네 가지를 봅니다: 모든 생성자의 라운드트립, `all_failure_kinds` 가 실제로 전부인지, **라이브 영수증 철자**, 그리고 **비-종류는 여전히 거부**되는지. 마지막이 대조군입니다 — 넓히는 변경이 "전부 수락"으로 통과하는 걸 막습니다.

## 래칫

새 스위트를 추가하며 같은 커밋에서 ci.yml 에 명명하므로 순증 0입니다. baseline 은 `698 → 691` 로 내렸는데, 그건 이 PR 이 아니라 **다른 머지들이 만든 이득을 고정**하는 것입니다(감사 스크립트가 출력으로 지시).

RFC-WAIVED: 닫힌 variant 복원 + 읽기 경로 철자 수용 + 호출부 3곳. credential/identity/operator/sandbox/hooks 를 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
