### PR TITLE
fix(runtime): keep Codex willRetry error notifications observational

### DIFF
--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -517,8 +517,6 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
       | other -> protocol_error stage (Printf.sprintf "unknown turn status %S" other)
 ;;
 
-let max_retry_notifications = 3
-
 (* What this decides is identity: does this delta belong to the turn we are
    awaiting. threadId, turnId and itemId are identifiers, so emptiness in one
    of them is malformed and stays rejected.
@@ -542,7 +540,7 @@ let validate_item_delta_notification ~method_ ~thread_id ~turn_id params =
 ;;
 
 let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen_final
-    ~seen_fallback ~retry_notifications =
+    ~seen_fallback =
   let* message = io.receive () in
   match message with
   | Response _ | Response_error _ ->
@@ -566,7 +564,6 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~turn_id
       ~seen_final
       ~seen_fallback
-      ~retry_notifications
   | Server_request { id; method_; _ } ->
     reject_server_request io id;
     Error (Unsupported_server_request method_)
@@ -589,7 +586,6 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~turn_id
       ~seen_final
       ~seen_fallback
-      ~retry_notifications
   | Notification { method_ = "item/completed"; params } ->
     let stage = "item/completed" in
     let* fields = assoc_at stage params in
@@ -614,12 +610,18 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~turn_id
         ~seen_final
         ~seen_fallback
-        ~retry_notifications
   | Notification { method_ = "error"; params } ->
+    (* willRetry:true is a progress signal — the app-server itself is retrying
+       upstream, so the turn is alive. Counting these and failing the turn at a
+       cap preempted the declared liveness boundary below and, under one
+       upstream degradation window, drove three keepers into
+       Recovery_required twice in two hours. The enclosing turn timeout
+       remains the only liveness boundary; willRetry:false still carries the
+       provider's terminal error. *)
     let stage = "error notification" in
     let* fields = assoc_at stage params in
     let* will_retry = required_bool stage "willRetry" fields in
-    if will_retry && retry_notifications < max_retry_notifications
+    if will_retry
     then
       await_turn_terminal
         io
@@ -629,9 +631,6 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~turn_id
         ~seen_final
         ~seen_fallback
-        ~retry_notifications:(retry_notifications + 1)
-    else if will_retry
-    then Error (Turn_failed "app-server retry notification limit exceeded")
     else
       let* error_json = required_member stage "error" fields in
       let* error_fields = assoc_at stage error_json in
@@ -651,7 +650,6 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~turn_id
       ~seen_final
       ~seen_fallback
-      ~retry_notifications
 ;;
 
 let optional_field name = function
@@ -802,7 +800,6 @@ let run_protocol io (config : config) ~protocol_cwd ~dynamic_tools ~reasoning_ef
       ~turn_id
       ~seen_final:None
       ~seen_fallback:None
-      ~retry_notifications:0
   in
   Ok
     { thread_id

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -414,25 +414,31 @@ let test_failed_turn_is_not_completion () =
       | Ok _ -> fail "failed turn incorrectly reported as completed")
 ;;
 
-let test_retry_notifications_are_bounded () =
+let test_retry_notifications_are_observational () =
+  (* Live incident 2026-08-10 (masc#27953): one upstream degradation window
+     drove three keepers into Recovery_required twice in two hours because the
+     turn died at the fourth willRetry:true. The app-server retrying upstream
+     is progress, not failure; the turn deadline is the liveness boundary. *)
   let retry = {|{"method":"error","params":{"willRetry":true}}|} in
   with_fixture
-    [ init_result
-    ; account_chatgpt
-    ; thread_result
-    ; turn_result
-    ; retry
-    ; retry
-    ; retry
-    ; retry
-    ]
+    ([ init_result; account_chatgpt; thread_result; turn_result ]
+     @ List.init 10 (fun _ -> retry)
+     @ [ item_completed; turn_completed ])
     (fun path ->
        match run_fixture path with
-       | Error
-           (Runtime_codex_app_server.Turn_failed
-             "app-server retry notification limit exceeded") -> ()
+       | Ok turn ->
+         check string "completed after retries" "MASC_SUBSCRIPTION_OK" turn.text
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error));
+  let terminal =
+    {|{"method":"error","params":{"willRetry":false,"error":{"message":"provider gave up"}}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; terminal ]
+    (fun path ->
+       match run_fixture path with
+       | Error (Runtime_codex_app_server.Turn_failed "provider gave up") -> ()
        | Error error -> fail (Runtime_codex_app_server.error_to_string error)
-       | Ok _ -> fail "retry notifications were unbounded")
+       | Ok _ -> fail "terminal error notification did not fail the turn")
 ;;
 
 let test_nonterminal_notifications_do_not_preempt_completion () =
@@ -2006,9 +2012,9 @@ let () =
         ; test_case "server request fails closed" `Quick test_server_request_fails_closed
         ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
         ; test_case
-            "retry notifications are bounded"
+            "retry notifications are observational"
             `Quick
-            test_retry_notifications_are_bounded
+            test_retry_notifications_are_observational
          ; test_case
              "nonterminal notifications do not preempt completion"
              `Quick


### PR DESCRIPTION
`willRetry:true` 오류 알림은 app-server가 스스로 upstream을 재시도 중이라는 **진행 신호**입니다. 이를 세어 4번째에 턴을 죽이는 `max_retry_notifications = 3` cap은, 같은 파일이 선언한 계약("관측 알림은 계산 실패로 승격 금지, 턴 타임아웃이 liveness 경계")을 더 좁고 비문서화된 경계로 선점하고 있었습니다.

라이브 실증 (#27953 코멘트, 2026-08-10): 한 upstream 저하 창이 2시간 내 두 차례 fleet-wide recovery를 만들었습니다 — kidsnote는 `retry notification limit exceeded`로, sangsu/taskmaster는 300s 타임아웃으로, 매 라운드 운영자 수동 해제 필요.

수리 (#27954와 동일 계약):

- `retry_notifications` 카운터·cap 전면 제거 — `willRetry:true`는 terminal 대기 계속
- `willRetry:false`는 기존대로 provider 메시지로 `Turn_failed`
- 턴 타임아웃이 유일한 liveness 경계로 남음 (폭주는 여전히 상한됨)

테스트: `retry notifications are bounded`(cap을 사양으로 고정) → `retry notifications are observational`로 교체 — willRetry 10연발 후 정상 완주 + `willRetry:false` terminal 오류 유지 단언.

검증: `bin/main_eio.exe` + 테스트 exe 빌드 green, 신규 케이스 양 런 통과. 참고: 로컬 스위트에서 무관한 2.000s-데드라인 케이스 2종이 머신 과부하(병렬 dune 3파이프라인) 하에 번갈아 플레이크 — 각 런에서 다른 케이스가 실패해 내 변경과 무상관임을 교차 확인했습니다(단일 테넌트 CI가 판정자).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
