### PR TITLE
Remove dead Memory lane legacy

### DIFF
--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -201,7 +201,7 @@ stateDiagram-v2
 | compaction | `keeper_post_turn.ml` | 현재 trace checkpoint | post-turn single-writer |
 | handoff rollover | `keeper_post_turn.ml` + `keeper_rollover.ml` | 새 trace checkpoint + keeper meta generation/trace | keeper FSM `Handoff_*` events |
 | typed checkpoint metadata | `keeper_post_turn.ml` | keeper meta | keeper post-turn contract |
-| Memory OS facts/episodes | `keeper_librarian_runtime.ml` | `.masc/config/keepers/<name>.facts.jsonl` + `episodes/` | librarian 계약 (RFC-0247/0272) |
+| Memory OS current snapshot | `keeper_memory_os_current.ml` + `keeper_librarian.ml` | `.masc/keepers/<name>.memory-current.json` | revision-CAS librarian contract |
 | collaboration activity signal | `workspace_task.ml` + `workspace.ml` | `.masc/activity-events/YYYY-MM/YYYY-MM-DD.jsonl` | task lifecycle + activity graph event contract |
 
 ### 4.2 Keeper Supervisor Lifecycle

--- a/docs/spec/12-memory-systems.md
+++ b/docs/spec/12-memory-systems.md
@@ -51,10 +51,12 @@ health, and dashboard surfaces report the read failure explicitly.
 
 ## Recall Contract
 
-Recall reads the same current snapshot projected by the dashboard and injects
-every claim in stored order; it does not rank, trim, or apply a count/byte
-budget. A malformed snapshot is reported as recall unavailable rather than
-silently treated as empty memory.
+Recall reads the same current snapshot projected by the dashboard and renders
+every claim in stored order. It does not rank or trim individual claims. If the
+complete rendered block exceeds the current 64 KiB byte budget, recall is
+reported unavailable for that turn rather than injecting a partial block. A
+malformed snapshot is likewise reported as unavailable rather than silently
+treated as empty memory.
 
 Explicit Memory OS search filters exact query substrings and preserves snapshot
 order. It does not emit a relevance score or reorder facts by timestamp.
@@ -69,11 +71,12 @@ agent core reduces active context through its checkpoint/context APIs. MASC may
 request a configured strategy and observe the outcome, but must not rewrite
 the transcript through domain-specific text parsing.
 
-The librarian LLM returns retained current memory IDs and new claims. Omission
-removes a current claim. Deterministic code validates the exact schema and
-claim identities, then atomically replaces the snapshot only if its observed
-revision still matches. No threshold, priority score, recency rule, or
-capacity heuristic decides which memories survive.
+The librarian LLM returns exactly one retain/drop disposition for every current
+memory ID plus any new claims. Missing or duplicate dispositions invalidate the
+result. Deterministic code validates the exact schema and claim identities,
+then atomically replaces the snapshot only if its observed revision still
+matches. No threshold, priority score, recency rule, or capacity heuristic
+decides which memories survive.
 
 ## Generation and Handoff
 

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -80,7 +80,6 @@ let run
         Keeper_memory_lane.submit
           ~base_path:config.Workspace.base_path
           ~keeper_name:meta.name
-          ~lane:Keeper_memory_lane.Librarian
           librarian_series
       in
       ()

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -1,29 +1,6 @@
-(** Per-keeper memory execution lane. See keeper_memory_lane.mli (RFC-0257). *)
+(** Per-keeper Librarian execution lane. See keeper_memory_lane.mli (RFC-0257). *)
 
-(* Post-turn memory work splits into two kinds that write different stores
-   under their own locks (delegation-request persistence vs the atomic
-   [Keeper_memory_os_current] snapshot), so they
-   never needed to serialize against each other. Sharing one lane made them
-   compete for one reservation budget anyway, and the librarian holds its
-   mutex across a provider round trip (seconds) while the deterministic write
-   is a local append. A turn submits one of each, so a librarian still in
-   flight from the previous turn left room for only one of them — and the
-   deterministic write is one-shot with no retry, while the librarian unit is
-   re-tried by its own cadence. Measured live on 2026-07-20: 220 drops against
-   375 librarian writes, keeper `analyst` at 144 drops / 136 writes, 52 of
-   those turns losing both units.
-
-   Each kind therefore gets its own entry: its own mutex (so a provider round
-   trip cannot block a local append) and its own reservation budget (so neither
-   kind can evict the other). Serialization *within* a kind is preserved. *)
-type lane =
-  | Deterministic
-  | Librarian
-
-let lane_label = function
-  | Deterministic -> "deterministic"
-  | Librarian -> "librarian"
-;;
+let lane_label = "librarian"
 
 type librarian_drain =
   { mutable latest : (unit -> unit) option
@@ -33,10 +10,7 @@ type librarian_drain =
   }
 
 type entry =
-  { mem_mu : Eio.Mutex.t
-    (* Serializes deterministic work. Librarian work has one drain fiber, so its
-       [librarian_drain] state is the serialization boundary. *)
-  ; state_mu : Stdlib.Mutex.t
+  { state_mu : Stdlib.Mutex.t
     (* Guards [pending] and [librarian_drain]. Critical sections never yield. *)
   ; mutable pending : int
   ; mutable librarian_drain : librarian_drain option
@@ -47,23 +21,6 @@ type outcome =
   | Coalesced
   | Ran_inline
   | Dropped
-
-type reservation =
-  { release_mu : Stdlib.Mutex.t
-  ; mutable released : bool
-  ; mutable switch_hook : Eio.Switch.hook option
-  }
-
-(* Per-keeper reservation bound: 1 in-flight (holding [mem_mu]) plus 1 queued.
-   A third concurrent post-turn unit for the same keeper means turns outpace
-   extraction; the excess is best-effort and dropped rather than piling up
-   fibers. Tunable via environment for fleet-wide capacity experiments. *)
-let max_pending () =
-  Env_config_memory.get_int_logged
-    "MASC_KEEPER_MEMORY_LANE_MAX_PENDING"
-    ~default:2
-  |> max 1
-;;
 
 let entries : (string, entry) Hashtbl.t = Hashtbl.create 16
 
@@ -81,22 +38,18 @@ let init ~sw =
 
 let current_sw () = Stdlib.Mutex.protect registry_mu (fun () -> !executor_sw)
 
-let entry_key ~base_path ~keeper_name ~lane =
-  Keeper_registry_types.registry_key ~base_path keeper_name ^ "#" ^ lane_label lane
+let entry_key ~base_path ~keeper_name =
+  Keeper_registry_types.registry_key ~base_path keeper_name ^ "#" ^ lane_label
 ;;
 
-let entry_for ~base_path ~keeper_name ~lane =
-  let key = entry_key ~base_path ~keeper_name ~lane in
+let entry_for ~base_path ~keeper_name =
+  let key = entry_key ~base_path ~keeper_name in
   Stdlib.Mutex.protect registry_mu (fun () ->
     match Hashtbl.find_opt entries key with
     | Some e -> e
     | None ->
       let e =
-        { mem_mu = Eio.Mutex.create ()
-        ; state_mu = Stdlib.Mutex.create ()
-        ; pending = 0
-        ; librarian_drain = None
-        }
+        { state_mu = Stdlib.Mutex.create (); pending = 0; librarian_drain = None }
       in
       Hashtbl.add entries key e;
       e)
@@ -104,169 +57,63 @@ let entry_for ~base_path ~keeper_name ~lane =
 
 let metric_name m = Keeper_metrics.(to_string m)
 
-let record_counter ~keeper_name ~lane metric =
+let record_counter ~keeper_name metric =
   Otel_metric_store.inc_counter
     (metric_name metric)
-    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label ]
     ()
 ;;
 
-let inc_pending ~keeper_name ~lane () =
+let inc_pending ~keeper_name () =
   Otel_metric_store.inc_gauge
     (metric_name MemoryLanePending)
-    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label ]
     ()
 ;;
 
-let dec_pending ~keeper_name ~lane () =
+let dec_pending ~keeper_name () =
   Otel_metric_store.dec_gauge
     (metric_name MemoryLanePending)
-    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label ]
     ()
 ;;
 
-let inc_in_flight ~keeper_name ~lane () =
+let inc_in_flight ~keeper_name () =
   Otel_metric_store.inc_gauge
     (metric_name MemoryLaneInFlight)
-    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label ]
     ()
 ;;
 
-let dec_in_flight ~keeper_name ~lane () =
+let dec_in_flight ~keeper_name () =
   Otel_metric_store.dec_gauge
     (metric_name MemoryLaneInFlight)
-    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label ]
     ()
 ;;
 
-let inc_latest_pending ~keeper_name ~lane () =
+let inc_latest_pending ~keeper_name () =
   Otel_metric_store.inc_gauge
     (metric_name MemoryLaneLatestPending)
-    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label ]
     ()
 ;;
 
-let dec_latest_pending ~keeper_name ~lane () =
+let dec_latest_pending ~keeper_name () =
   Otel_metric_store.dec_gauge
     (metric_name MemoryLaneLatestPending)
-    ~labels:[ "keeper", keeper_name; "lane", lane_label lane ]
+    ~labels:[ "keeper", keeper_name; "lane", lane_label ]
     ()
 ;;
 
-let try_reserve ~keeper_name ~lane entry =
-  Stdlib.Mutex.protect entry.state_mu (fun () ->
-    let bound = max_pending () in
-    if entry.pending >= bound
-    then None
-    else (
-      entry.pending <- entry.pending + 1;
-      inc_pending ~keeper_name ~lane ();
-      Some bound))
-;;
-
-let release_reservation ~keeper_name ~lane entry =
-  Stdlib.Mutex.protect entry.state_mu (fun () ->
-    entry.pending <- entry.pending - 1;
-    dec_pending ~keeper_name ~lane ())
-;;
-
-let make_reservation () =
-  { release_mu = Stdlib.Mutex.create (); released = false; switch_hook = None }
-;;
-
-let reservation_released reservation =
-  Stdlib.Mutex.protect reservation.release_mu (fun () -> reservation.released)
-;;
-
-let release_reservation_once ~keeper_name ~lane entry reservation =
-  let should_release =
-    Stdlib.Mutex.protect reservation.release_mu (fun () ->
-      if reservation.released
-      then false
-      else (
-        reservation.released <- true;
-        true))
-  in
-  if should_release then release_reservation ~keeper_name ~lane entry
-;;
-
-let disarm_switch_hook reservation =
-  let hook =
-    Stdlib.Mutex.protect reservation.release_mu (fun () ->
-      let hook = reservation.switch_hook in
-      reservation.switch_hook <- None;
-      hook)
-  in
-  Option.iter (fun hook -> ignore (Eio.Switch.try_remove_hook hook)) hook
-;;
-
-let protect_cleanup ~keeper_name ~lane label f =
+let protect_cleanup ~keeper_name label f =
   try f () with
   | exn ->
-    record_counter ~keeper_name ~lane MemoryLaneUnitFailures;
+    record_counter ~keeper_name MemoryLaneUnitFailures;
     Log.Keeper.warn ~keeper_name
       "memory lane cleanup failed (%s): %s"
       label
       (Printexc.to_string exn)
-;;
-
-let release_after_run ~keeper_name ~lane entry reservation ~acquired ~in_flight =
-  if !in_flight
-  then
-    protect_cleanup ~keeper_name ~lane "dec_in_flight" (fun () ->
-      dec_in_flight ~keeper_name ~lane ());
-  if !acquired
-  then
-    protect_cleanup ~keeper_name ~lane "unlock" (fun () -> Eio.Mutex.unlock entry.mem_mu);
-  protect_cleanup ~keeper_name ~lane "release_reservation" (fun () ->
-    release_reservation_once ~keeper_name ~lane entry reservation)
-;;
-
-let arm_switch_release ~keeper_name ~lane entry reservation sw =
-  let release_from_switch () =
-    protect_cleanup ~keeper_name ~lane "executor_switch_release" (fun () ->
-      release_reservation_once ~keeper_name ~lane entry reservation)
-  in
-  try
-    let hook = Eio.Switch.on_release_cancellable sw release_from_switch in
-    Stdlib.Mutex.protect reservation.release_mu (fun () ->
-      if reservation.released
-      then ignore (Eio.Switch.try_remove_hook hook)
-      else reservation.switch_hook <- Some hook)
-  with
-  | _exn ->
-    (* Finished switches can raise while running the release callback; any hook
-       registration failure means the executor cannot own this reservation. *)
-    release_from_switch ()
-;;
-
-(* Runs on a forked fiber owned by the executor switch. Holds [mem_mu] across
-   the unit. Releases the mutex (only if acquired) and the reservation on every
-   exit, including cancellation at shutdown. No exception escapes: a best-effort
-   unit must never propagate into the executor switch — that would cancel the
-   fleet. *)
-let run_unit ~keeper_name ~lane entry reservation sw f =
-  let acquired = ref false in
-  let in_flight = ref false in
-  Eio.Switch.run (fun cleanup_sw ->
-    Eio.Switch.on_release cleanup_sw (fun () ->
-      release_after_run ~keeper_name ~lane entry reservation ~acquired ~in_flight);
-      disarm_switch_hook reservation;
-      try
-        Eio.Mutex.lock entry.mem_mu;
-        (* No suspension point between [lock] returning and this assignment, so
-           cancellation cannot strand a held mutex with [acquired = false]. *)
-        acquired := true;
-        inc_in_flight ~keeper_name ~lane ();
-        in_flight := true;
-        Eio_context.with_turn_switch sw f
-      with
-      | Eio.Cancel.Cancelled _ -> () (* shutdown: silent, cleanup runs above *)
-      | exn ->
-        record_counter ~keeper_name ~lane MemoryLaneUnitFailures;
-        Log.Keeper.warn ~keeper_name
-          "memory lane unit failed: %s"
-          (Printexc.to_string exn))
 ;;
 
 type librarian_submission =
@@ -313,17 +160,17 @@ let librarian_drain_is_active entry drain =
 
 let emit_librarian_cleanup ~keeper_name ~pending ~in_flight ~latest_pending =
   for _ = 1 to pending do
-    protect_cleanup ~keeper_name ~lane:Librarian "dec_pending" (fun () ->
-      dec_pending ~keeper_name ~lane:Librarian ())
+    protect_cleanup ~keeper_name "dec_pending" (fun () ->
+      dec_pending ~keeper_name ())
   done;
   if in_flight
   then
-    protect_cleanup ~keeper_name ~lane:Librarian "dec_in_flight" (fun () ->
-      dec_in_flight ~keeper_name ~lane:Librarian ());
+    protect_cleanup ~keeper_name "dec_in_flight" (fun () ->
+      dec_in_flight ~keeper_name ());
   if latest_pending
   then
-    protect_cleanup ~keeper_name ~lane:Librarian "dec_latest_pending" (fun () ->
-      dec_latest_pending ~keeper_name ~lane:Librarian ())
+    protect_cleanup ~keeper_name "dec_latest_pending" (fun () ->
+      dec_latest_pending ~keeper_name ())
 ;;
 
 let detach_librarian_drain entry drain =
@@ -354,7 +201,7 @@ let cleanup_librarian_drain ~keeper_name ~remove_hook entry drain =
 
 let arm_librarian_switch_release ~keeper_name entry drain sw =
   let release_from_switch () =
-    protect_cleanup ~keeper_name ~lane:Librarian
+    protect_cleanup ~keeper_name
       "librarian_executor_switch_release"
       (fun () ->
         cleanup_librarian_drain ~keeper_name ~remove_hook:false entry drain)
@@ -386,7 +233,7 @@ let librarian_begin_current ~keeper_name entry drain =
         true
       | Some _ | None -> false)
   in
-  if started then inc_in_flight ~keeper_name ~lane:Librarian ();
+  if started then inc_in_flight ~keeper_name ();
   started
 ;;
 
@@ -410,12 +257,12 @@ let librarian_finish_current ~keeper_name entry drain =
       | Some _ | None -> false, false, Drain_stopped)
   in
   if in_flight
-  then dec_in_flight ~keeper_name ~lane:Librarian ();
+  then dec_in_flight ~keeper_name ();
   (match step with
    | Drain_stopped -> ()
    | Drain_done _ | Drain_next _ ->
-     dec_pending ~keeper_name ~lane:Librarian ());
-  if took_latest then dec_latest_pending ~keeper_name ~lane:Librarian ();
+     dec_pending ~keeper_name ());
+  if took_latest then dec_latest_pending ~keeper_name ();
   step
 ;;
 
@@ -425,7 +272,7 @@ let rec run_librarian_drain ~keeper_name entry drain sw current =
     (try Eio_context.with_turn_switch sw current with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
-       record_counter ~keeper_name ~lane:Librarian MemoryLaneUnitFailures;
+       record_counter ~keeper_name MemoryLaneUnitFailures;
        Log.Keeper.warn ~keeper_name
          "memory lane unit failed: %s"
          (Printexc.to_string exn));
@@ -440,23 +287,23 @@ let rec run_librarian_drain ~keeper_name entry drain sw current =
 let submit_librarian ~keeper_name entry sw f =
   match librarian_reserve entry f with
   | Queue_latest ->
-    inc_pending ~keeper_name ~lane:Librarian ();
-    inc_latest_pending ~keeper_name ~lane:Librarian ();
-    record_counter ~keeper_name ~lane:Librarian MemoryLaneSubmitted;
+    inc_pending ~keeper_name ();
+    inc_latest_pending ~keeper_name ();
+    record_counter ~keeper_name MemoryLaneSubmitted;
     Submitted
   | Replace_latest ->
-    record_counter ~keeper_name ~lane:Librarian MemoryLaneCoalesced;
+    record_counter ~keeper_name MemoryLaneCoalesced;
     Log.Keeper.warn ~keeper_name
       "memory lane coalesced latest snapshot (lane=librarian pending=2): replacing \
        superseded post-turn memory unit";
     Coalesced
   | Start_drain drain ->
-    inc_pending ~keeper_name ~lane:Librarian ();
-    record_counter ~keeper_name ~lane:Librarian MemoryLaneSubmitted;
+    inc_pending ~keeper_name ();
+    record_counter ~keeper_name MemoryLaneSubmitted;
     arm_librarian_switch_release ~keeper_name entry drain sw;
     if not (librarian_drain_is_active entry drain)
     then (
-      record_counter ~keeper_name ~lane:Librarian MemoryLaneDropped;
+      record_counter ~keeper_name MemoryLaneDropped;
       Log.Keeper.warn ~keeper_name
         "memory lane executor switch unavailable (lane=librarian): dropping post-turn \
          memory unit";
@@ -480,7 +327,7 @@ let submit_librarian ~keeper_name entry sw f =
          | Ok () -> Submitted
          | Error error ->
            cleanup_librarian_drain ~keeper_name ~remove_hook:true entry drain;
-           record_counter ~keeper_name ~lane:Librarian MemoryLaneUnitFailures;
+           record_counter ~keeper_name MemoryLaneUnitFailures;
            Log.Keeper.warn ~keeper_name
              "memory lane fork failed: %s"
              (Keeper_lane.start_error_to_string error);
@@ -491,62 +338,14 @@ let submit_librarian ~keeper_name entry sw f =
         raise e
       | exn ->
         cleanup_librarian_drain ~keeper_name ~remove_hook:true entry drain;
-        record_counter ~keeper_name ~lane:Librarian MemoryLaneUnitFailures;
+        record_counter ~keeper_name MemoryLaneUnitFailures;
         Log.Keeper.warn ~keeper_name
           "memory lane fork failed: %s"
           (Printexc.to_string exn);
         Dropped)
 ;;
 
-let submit_bounded ~keeper_name ~lane entry sw f =
-  match try_reserve ~keeper_name ~lane entry with
-  | None ->
-    record_counter ~keeper_name ~lane MemoryLaneDropped;
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string DispatchEventFailures)
-      ~labels:
-        [ "keeper", keeper_name
-        ; "site", "memory_lane_saturated"
-        ; "lane", lane_label lane
-        ]
-      ();
-    Log.Keeper.warn ~keeper_name
-      "memory lane saturated (lane=%s pending>=%d): dropping post-turn memory unit"
-      (lane_label lane)
-      (max_pending ());
-    Dropped
-  | Some _bound ->
-    let reservation = make_reservation () in
-    arm_switch_release ~keeper_name ~lane entry reservation sw;
-    if reservation_released reservation
-    then (
-      record_counter ~keeper_name ~lane MemoryLaneDropped;
-      Log.Keeper.warn ~keeper_name
-        "memory lane executor switch unavailable (lane=%s): dropping post-turn memory unit"
-        (lane_label lane);
-      Dropped)
-    else (
-      try
-        record_counter ~keeper_name ~lane MemoryLaneSubmitted;
-        Eio.Fiber.fork ~sw (fun () ->
-          run_unit ~keeper_name ~lane entry reservation sw f);
-        Submitted
-      with
-      | Eio.Cancel.Cancelled _ as e ->
-        protect_cleanup ~keeper_name ~lane "fork_cancel_release" (fun () ->
-          release_reservation_once ~keeper_name ~lane entry reservation);
-        raise e
-      | exn ->
-        protect_cleanup ~keeper_name ~lane "fork_failure_release" (fun () ->
-          release_reservation_once ~keeper_name ~lane entry reservation);
-        record_counter ~keeper_name ~lane MemoryLaneUnitFailures;
-        Log.Keeper.warn ~keeper_name
-          "memory lane fork failed: %s"
-          (Printexc.to_string exn);
-        Dropped)
-;;
-
-let submit ~base_path ~keeper_name ~lane f =
+let submit ~base_path ~keeper_name f =
   match current_sw () with
   | None ->
     (* Not initialized: run inline. The caller is still inside the per-keeper
@@ -555,17 +354,15 @@ let submit ~base_path ~keeper_name ~lane f =
     (try f () with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->
-       record_counter ~keeper_name ~lane MemoryLaneUnitFailures;
+       record_counter ~keeper_name MemoryLaneUnitFailures;
        Log.Keeper.warn ~keeper_name
          "memory lane unit failed (inline): %s"
          (Printexc.to_string exn));
-    record_counter ~keeper_name ~lane MemoryLaneRanInline;
+    record_counter ~keeper_name MemoryLaneRanInline;
     Ran_inline
   | Some sw ->
-    let entry = entry_for ~base_path ~keeper_name ~lane in
-    (match lane with
-     | Librarian -> submit_librarian ~keeper_name entry sw f
-     | Deterministic -> submit_bounded ~keeper_name ~lane entry sw f)
+    let entry = entry_for ~base_path ~keeper_name in
+    submit_librarian ~keeper_name entry sw f
 ;;
 
 type librarian_join_outcome =
@@ -575,7 +372,7 @@ type librarian_join_outcome =
 
 let cancel_and_join_librarian ~base_path ~keeper_name =
   let entry =
-    let key = entry_key ~base_path ~keeper_name ~lane:Librarian in
+    let key = entry_key ~base_path ~keeper_name in
     Stdlib.Mutex.protect registry_mu (fun () -> Hashtbl.find_opt entries key)
   in
   match entry with
@@ -612,8 +409,8 @@ module For_testing = struct
       executor_sw := None)
   ;;
 
-  let pending ~base_path ~keeper_name ~lane =
-    let key = entry_key ~base_path ~keeper_name ~lane in
+  let pending ~base_path ~keeper_name =
+    let key = entry_key ~base_path ~keeper_name in
     Stdlib.Mutex.protect registry_mu (fun () -> Hashtbl.find_opt entries key)
     |> Option.map (fun e -> Stdlib.Mutex.protect e.state_mu (fun () -> e.pending))
   ;;

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -1,9 +1,9 @@
-(** Per-keeper memory execution lane (RFC-0257).
+(** Per-keeper Librarian execution lane (RFC-0257).
 
-    Detaches post-turn memory work (deterministic write, librarian extraction,
-    compaction) from the keeper turn lane. Each keeper has its own mutex, so
-    memory work is serialized within a keeper and runs independently across
-    keepers. This replaces the process-global [Eio.Semaphore.make 1] in
+    Detaches post-turn Librarian extraction from the keeper turn lane. Each
+    keeper owns one latest-wins drain, so work is serialized within a keeper
+    and runs independently across keepers. This replaces the process-global
+    [Eio.Semaphore.make 1] in
     [Keeper_librarian_runtime] that previously serialized every keeper's
     librarian work fleet-wide — the opposite of the lane-per-keeper model
     (RFC-0225).
@@ -17,45 +17,25 @@
     (e.g. [Keeper_meta_contract.keeper_meta], [Workspace.config]) and never over
     mutable turn-local references.
 
-    Work is split into two independent lanes per keeper ({!lane}). They write
-    different stores under their own locks, so serializing them against each
-    other bought nothing while making them share one reservation budget: a
-    librarian unit holding its mutex across a provider round trip left room for
-    only one of the next turn's two units, and the deterministic write has no
-    retry. Each lane now has its own mutex and its own budget; ordering within a
-    lane is unchanged.
-
-    The deterministic per-keeper reservation bound is controlled by
-    [MASC_KEEPER_MEMORY_LANE_MAX_PENDING] (default [2]). Librarian work instead
-    has a fixed process-local bound of one running unit plus one overwriteable
-    latest snapshot. Submission outcomes are counted under
+    Librarian work has a fixed process-local bound of one running unit plus one
+    overwriteable latest snapshot. Submission outcomes are counted under
     [masc_keeper_memory_lane_*]; per-keeper pending, in-flight, and
-    latest-pending gauges are exported, all labelled by [lane]. *)
-
-type lane =
-  | Deterministic
-      (** Local append to the keeper memory bank. One-shot: a drop here is
-          permanent, so it must not queue behind provider-backed work. *)
-  | Librarian
-      (** Provider-backed current-memory selection. Holds its lane across the
-          round trip. Saturated submissions replace the queued latest snapshot,
-          so cleanup remains reliably eventual without blocking the Keeper turn. *)
+    latest-pending gauges are exported with the [librarian] lane label. *)
 
 type outcome =
   | Submitted
       (** Accepted as the running unit or the queued latest snapshot. *)
   | Coalesced
-      (** The Librarian lane already had one running and one latest unit. The
+      (** The lane already had one running and one latest unit. The
           prior latest snapshot was replaced atomically by this newer immutable
-          snapshot. Deterministic submissions never return this outcome. *)
+          snapshot. *)
   | Ran_inline
       (** Executor switch not initialized; the unit ran synchronously in the
           caller so no work is lost (tests, or startup before {!init}). A
           raising unit is contained and emits a metric instead of escaping. *)
   | Dropped
-      (** The executor switch could not own the unit, or the deterministic lane
-          was saturated. Librarian saturation returns {!Coalesced}, not
-          [Dropped]. The drop is counted, never silent. *)
+      (** The executor switch could not own the unit. Saturation returns
+          {!Coalesced}, not [Dropped]. The drop is counted, never silent. *)
 
 val init : sw:Eio.Switch.t -> unit
 (** Record the long-lived switch that owns detached memory fibers. Call once at
@@ -64,12 +44,10 @@ val init : sw:Eio.Switch.t -> unit
 val submit
   :  base_path:string
   -> keeper_name:string
-  -> lane:lane
   -> (unit -> unit)
   -> outcome
-(** [submit ~base_path ~keeper_name ~lane f] runs [f] on [keeper_name]'s [lane].
-    With an executor switch, deterministic work retains the bounded serialized
-    submission policy. Librarian work uses a non-blocking latest-wins drain:
+(** [submit ~base_path ~keeper_name f] runs [f] on [keeper_name]'s Librarian lane.
+    With an executor switch, work uses a non-blocking latest-wins drain:
     one running unit plus one overwriteable latest snapshot. When the executor
     is not initialized, [f] runs inline and any exception is contained and
     counted rather than escaping. Outcomes and per-keeper state are exported as
@@ -92,6 +70,6 @@ module For_testing : sig
   val reset : unit -> unit
   (** Clear the lane registry and the executor switch. *)
 
-  val pending : base_path:string -> keeper_name:string -> lane:lane -> int option
-  (** Current pending count for a keeper's [lane] ([None] if it has no entry). *)
+  val pending : base_path:string -> keeper_name:string -> int option
+  (** Current pending count for a keeper ([None] if it has no entry). *)
 end

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2419,7 +2419,6 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
          Memory_lane.submit
            ~base_path:config.base_path
            ~keeper_name:name
-           ~lane:Memory_lane.Librarian
            (fun () ->
               Eio.Promise.resolve resolve_librarian_started ();
               try Eio.Promise.await librarian_never with
@@ -2468,8 +2467,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
         (Some 0)
         (Memory_lane.For_testing.pending
            ~base_path:config.base_path
-           ~keeper_name:name
-           ~lane:Memory_lane.Librarian);
+           ~keeper_name:name);
       (match
          owner_shutdown_operation_id_exn
            ~base_path:config.base_path

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -60,7 +60,7 @@ let test_inline_when_uninitialized () =
   Lane.For_testing.reset ();
   let ran = ref false in
   let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ran := true)
+    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ran := true)
   in
   Alcotest.(check bool) "unit ran inline" true !ran;
   match outcome with
@@ -74,7 +74,7 @@ let test_inline_when_uninitialized () =
 let test_inline_contains_raise () =
   Lane.For_testing.reset ();
   let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> raise Test_boom)
+    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
   in
   match outcome with
   | Lane.Ran_inline -> ()
@@ -95,7 +95,7 @@ let test_serializes_within_keeper () =
       let p_started, set_started = Eio.Promise.create () in
       let p_release, set_release = Eio.Promise.create () in
       let oa =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
           add "a-start";
           Eio.Promise.resolve set_started ();
           Eio.Promise.await p_release;
@@ -103,7 +103,7 @@ let test_serializes_within_keeper () =
       in
       Eio.Promise.await p_started;
       let ob =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> add "b")
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () -> add "b")
       in
       (* Let B attempt (and fail) to acquire the keeper mutex held by A. *)
       Eio.Fiber.yield ();
@@ -132,14 +132,14 @@ let test_independent_across_keepers () =
       let p_started, set_started = Eio.Promise.create () in
       let p_release, set_release = Eio.Promise.create () in
       let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
           Eio.Promise.resolve set_started ();
           Eio.Promise.await p_release;
           add "k1")
       in
       Eio.Promise.await p_started;
       let _ =
-        Lane.submit ~base_path ~keeper_name:"k2" ~lane:Lane.Librarian (fun () -> add "k2")
+        Lane.submit ~base_path ~keeper_name:"k2" (fun () -> add "k2")
       in
       (* k2 runs to completion while k1 is still holding its own lane. *)
       Eio.Fiber.yield ();
@@ -147,37 +147,6 @@ let test_independent_across_keepers () =
       Alcotest.(check bool) "k2 ran while k1 blocked" true (List.mem "k2" !order);
       Eio.Promise.resolve set_release ()));
   Alcotest.(check (list string)) "k2 before k1" [ "k2"; "k1" ] (List.rev !order)
-;;
-
-(* The deterministic lane retains its existing bounded-drop policy. *)
-let test_deterministic_saturation_drops () =
-  Lane.For_testing.reset ();
-  Eio_main.run (fun _env ->
-    Eio.Switch.run (fun sw ->
-      Lane.init ~sw;
-      let p_release, set_release = Eio.Promise.create () in
-      let o1 =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Deterministic (fun () ->
-          Eio.Promise.await p_release)
-      in
-      let o2 =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Deterministic (fun () -> ())
-      in
-      let o3 =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Deterministic (fun () -> ())
-      in
-      (match o1 with
-       | Lane.Submitted -> ()
-       | _ -> Alcotest.fail "o1 not submitted");
-      (match o2 with
-       | Lane.Submitted -> ()
-       | _ -> Alcotest.fail "o2 not submitted");
-      (match o3 with
-       | Lane.Dropped -> ()
-       | Lane.Submitted -> Alcotest.fail "o3 should be Dropped, got Submitted"
-       | Lane.Coalesced -> Alcotest.fail "deterministic lane must not coalesce"
-       | Lane.Ran_inline -> Alcotest.fail "o3 should be Dropped, got Ran_inline");
-      Eio.Promise.resolve set_release ()))
 ;;
 
 (* Librarian saturation keeps one running unit and one overwriteable latest
@@ -192,7 +161,7 @@ let test_librarian_saturation_coalesces_latest () =
       let started, set_started = Eio.Promise.create () in
       let release, set_release = Eio.Promise.create () in
       let running =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
           Eio.Promise.resolve set_started ();
           Eio.Promise.await release;
           evaluated := "running" :: !evaluated)
@@ -204,21 +173,21 @@ let test_librarian_saturation_coalesces_latest () =
           :: !evaluated
       in
       let stale =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian
+        Lane.submit ~base_path ~keeper_name:"k1"
           (snapshot "trace-stale" 1 [ "stale" ])
       in
       let newer =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian
+        Lane.submit ~base_path ~keeper_name:"k1"
           (snapshot "trace-newer" 2 [ "newer" ])
       in
       let newest =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian
+        Lane.submit ~base_path ~keeper_name:"k1"
           (snapshot "trace-newest" 3 [ "newest-a"; "newest-b" ])
       in
       (match running, stale, newer, newest with
        | Lane.Submitted, Lane.Submitted, Lane.Coalesced, Lane.Coalesced -> ()
        | _ -> Alcotest.fail "unexpected Librarian coalescing outcomes");
-      (match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
+      (match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
        | Some 2 -> ()
        | Some n -> Alcotest.failf "running+latest bound should be 2, got %d" n
        | None -> Alcotest.fail "missing Librarian lane entry");
@@ -227,62 +196,10 @@ let test_librarian_saturation_coalesces_latest () =
     "only running and newest snapshot evaluate"
     [ "running"; "trace-newest:3:newest-a,newest-b" ]
     (List.rev !evaluated);
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
+  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
   | Some 0 -> ()
   | Some n -> Alcotest.failf "pending leaked after coalesced drain: %d" n
   | None -> Alcotest.fail "Librarian lane entry missing"
-;;
-
-(* The regression this split exists for: a saturated librarian lane must not
-   consume the deterministic lane's budget. A librarian unit parked in a
-   provider round trip plus one queued behind it fills the librarian lane, and
-   the deterministic write — one-shot, no retry — must still be admitted and
-   must run while the librarian is still blocked. Before the split both kinds
-   shared one budget, so this deterministic unit was dropped: measured live on
-   2026-07-20 at 220 drops fleet-wide, keeper `analyst` losing 144 of 280. *)
-let test_lanes_have_independent_budgets () =
-  Lane.For_testing.reset ();
-  let det_ran = ref false in
-  Eio_main.run (fun _env ->
-    Eio.Switch.run (fun sw ->
-      Lane.init ~sw;
-      let p_release, set_release = Eio.Promise.create () in
-      let lib1 =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
-          Eio.Promise.await p_release)
-      in
-      let lib2 =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ())
-      in
-      let lib3 =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> ())
-      in
-      let det =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Deterministic (fun () ->
-          det_ran := true)
-      in
-      (match lib1, lib2 with
-       | Lane.Submitted, Lane.Submitted -> ()
-       | _ -> Alcotest.fail "librarian lane should admit two units");
-      (match lib3 with
-       | Lane.Coalesced -> ()
-       | _ -> Alcotest.fail "librarian lane should coalesce at the bound");
-      (match det with
-       | Lane.Submitted -> ()
-       | Lane.Coalesced ->
-         Alcotest.fail "deterministic unit must not use Librarian coalescing"
-       | Lane.Dropped ->
-         Alcotest.fail "deterministic unit dropped by a saturated librarian lane"
-       | Lane.Ran_inline -> Alcotest.fail "deterministic unit ran inline");
-      (* Still blocked on the librarian round trip; the deterministic write must
-         not be waiting behind it. *)
-      Eio.Fiber.yield ();
-      Eio.Fiber.yield ();
-      Alcotest.(check bool)
-        "deterministic write ran while librarian was in flight"
-        true
-        !det_ran;
-      Eio.Promise.resolve set_release ()))
 ;;
 
 (* A unit that raises releases the mutex and the pending slot, so the lane
@@ -296,14 +213,14 @@ let test_releases_on_raise () =
       let started, set_started = Eio.Promise.create () in
       let release, set_release = Eio.Promise.create () in
       let first =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
           Eio.Promise.resolve set_started ();
           Eio.Promise.await release;
           raise Test_boom)
       in
       Eio.Promise.await started;
       let latest =
-        Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
           latest_ran := true)
       in
       (match first, latest with
@@ -311,7 +228,7 @@ let test_releases_on_raise () =
        | _ -> Alcotest.fail "raise fixture submissions were not accepted");
       Eio.Promise.resolve set_release ()));
   Alcotest.(check bool) "latest runs after raising unit" true !latest_ran;
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
+  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
   | Some 0 -> ()
   | Some n -> Alcotest.failf "pending leaked: %d" n
   | None -> Alcotest.fail "keeper entry missing"
@@ -328,12 +245,12 @@ let test_releases_on_cancel () =
          let started, set_started = Eio.Promise.create () in
          let never, _set_never = Eio.Promise.create () in
          let outcome =
-           Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+           Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
              Eio.Promise.resolve set_started ();
              Eio.Promise.await never)
          in
          let latest =
-           Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () ->
+           Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
              latest_ran := true)
          in
          (match outcome with
@@ -351,7 +268,7 @@ let test_releases_on_cancel () =
    with
    | Cancel_lane_test -> ());
   Alcotest.(check bool) "latest did not run after switch cancel" false !latest_ran;
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
+  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
   | Some 0 -> ()
   | Some n -> Alcotest.failf "pending leaked after cancel: %d" n
   | None -> Alcotest.fail "keeper entry missing after cancel"
@@ -369,7 +286,6 @@ let test_keeper_shutdown_cancels_and_joins_librarian () =
         Lane.submit
           ~base_path
           ~keeper_name:"shutdown-owner"
-          ~lane:Lane.Librarian
           (fun () ->
              Eio.Promise.resolve set_started ();
              try Eio.Promise.await never with
@@ -399,7 +315,7 @@ let test_keeper_shutdown_cancels_and_joins_librarian () =
         (Lane.For_testing.pending
            ~base_path
            ~keeper_name:"shutdown-owner"
-           ~lane:Lane.Librarian)))
+)))
 ;;
 
 (* Submitting against a finished executor switch must not leak the pending
@@ -419,14 +335,14 @@ let test_finished_switch_drops_without_leak () =
   in
   Lane.init ~sw;
   let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian (fun () -> raise Test_boom)
+    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
   in
   (match outcome with
    | Lane.Dropped -> ()
    | Lane.Submitted -> Alcotest.fail "expected Dropped, got Submitted"
    | Lane.Coalesced -> Alcotest.fail "expected Dropped, got Coalesced"
    | Lane.Ran_inline -> Alcotest.fail "expected Dropped, got Ran_inline");
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" ~lane:Lane.Librarian with
+  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
   | Some 0 -> ()
   | Some n -> Alcotest.failf "pending leaked after finished switch submit: %d" n
   | None -> Alcotest.fail "keeper entry missing after finished switch submit"
@@ -473,7 +389,6 @@ let test_post_turn_librarian_live_config_boundaries () =
           Lane.For_testing.pending
             ~base_path:config.base_path
             ~keeper_name
-            ~lane:Lane.Librarian
         with
         | None -> ()
         | Some pending ->
@@ -507,7 +422,6 @@ let test_post_turn_librarian_live_config_boundaries () =
           Lane.submit
             ~base_path:config.base_path
             ~keeper_name
-            ~lane:Lane.Librarian
             (fun () ->
                Eio.Promise.resolve set_started ();
                Eio.Promise.await release)
@@ -524,7 +438,7 @@ let test_post_turn_librarian_live_config_boundaries () =
           (Lane.For_testing.pending
              ~base_path:config.base_path
              ~keeper_name
-             ~lane:Lane.Librarian);
+);
         Unix.putenv env_key terminal_value;
         Eio.Promise.resolve set_release ()
       in
@@ -569,17 +483,9 @@ let () =
             `Quick
             test_independent_across_keepers
         ; Alcotest.test_case
-            "deterministic saturation drops"
-            `Quick
-            test_deterministic_saturation_drops
-        ; Alcotest.test_case
             "librarian saturation coalesces latest"
             `Quick
             test_librarian_saturation_coalesces_latest
-        ; Alcotest.test_case
-            "lanes have independent budgets"
-            `Quick
-            test_lanes_have_independent_budgets
         ; Alcotest.test_case "releases on raise" `Quick test_releases_on_raise
         ; Alcotest.test_case "releases on cancel" `Quick test_releases_on_cancel
         ; Alcotest.test_case


### PR DESCRIPTION
## Summary

- remove the unused `Keeper_memory_lane.Deterministic` variant and its bounded-queue implementation
- make the memory lane API Librarian-only and update production/test callers
- delete deterministic-lane fixtures that only pinned the retired memory-bank path
- correct Memory OS specs to name the current snapshot SSOT, 64 KiB recall behavior, and retain/drop totality

## Why

The deterministic lane belonged to the removed legacy memory-bank writer and has no production caller. Keeping its lane selector, queue policy, environment knob, comments, and tests made the current Librarian-only runtime look like a two-lane system.

This is a hard cleanup only. It does not add a gate, admission rule, provider fallback, or new Memory policy.

## Impact

Post-turn Librarian submission, latest-wins coalescing, metrics, and shutdown join behavior remain in place. Callers no longer select a dead lane.

## Checks

Not run. This publication pass intentionally leaves build and focused tests to CI.
