### PR TITLE
chore(runtime): remove dead external providers

### DIFF
--- a/config/agent-core-models-overlay.toml
+++ b/config/agent-core-models-overlay.toml
@@ -73,34 +73,6 @@ supports_response_format_json = false
 supports_structured_output = false
 supports_native_streaming = true
 
-# Kimi Code coding-plan gateway under [providers.kimi_code].
-[[models]]
-id_prefix = "kimi-for-coding"
-provider_name = "kimi_code"
-base = "kimi"
-max_context_tokens = 256000
-ignored_sampling_parameters = ["temperature", "top_p"]
-input_per_million = 0.0
-output_per_million = 0.0
-
-# Deployment transport alias for the vllm-qwen3-mtp serving contract.
-[[models]]
-id_prefix = "qwen36-35b-a3b-mtp"
-provider_name = "runpod_mtp"
-base = "openai_chat"
-max_context_tokens = 131072
-supports_tools = true
-supports_tool_choice = true
-supports_parallel_tool_calls = true
-supports_reasoning = true
-supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "chat_template_kwargs"
-preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
-reasoning_streaming_format = "delta:reasoning_content"
-reasoning_replay = "drop_without_tool_preserve_with_tool"
-supports_native_streaming = true
-
 # Local Ollama Gemma 4 QAT build, probed on 2026-06-12.
 [[models]]
 id_prefix = "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
@@ -212,8 +184,7 @@ supports_structured_output = false
 
 # Same agent-core boundary /v1-truth remediation as the three rows above — this lane was
 # missed by the 2026-07-20 audit (it covered deepseek-v4-pro but analyst is
-# bound to deepseek-v4-flash via the deepseek-direct substitute,
-# runtime.toml:492) and surfaced live as Enable_not_encodable on the first
+# bound to deepseek-v4-flash and surfaced live as Enable_not_encodable on the first
 # post-bump turn. Mirrors agent_core models.toml @476.
 [[models]]
 id_prefix = "deepseek-v4-flash"
@@ -273,8 +244,3 @@ model_id = "GLM-5-Turbo"
 id = "glm-coding.glm-4-7-coding"
 provider_ref = "glm-coding-sb-exact"
 model_id = "glm-4.7"
-
-[[targets]]
-id = "deepseek.deepseek-v4-pro"
-provider_ref = "deepseek"
-model_id = "deepseek-v4-pro"

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -12,17 +12,17 @@
 [runtime]
 default = "ollama_cloud.deepseek-v4-flash"
 # Anti-rationalization/cross-verifier work uses a typed verdict tool call.
-# Keep normal keeper turns on the fleet default flash runtime; reserve Pro for
-# this explicit smart lane.
-cross_verifier = "deepseek.deepseek-v4-pro"
+# Keep normal keeper turns on the fleet default flash runtime; use the typed
+# GLM coding runtime for this explicit smart lane.
+cross_verifier = "glm-coding.glm-5-turbo"
 
 # Existing workspaces are not overwritten by this seed. Copy the required lane
 # declarations into the live runtime.toml before enabling their consumers.
 [runtime.exact_output_lanes.librarian_exact]
-slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
+slots = ["glm-coding.glm-5-turbo", "glm-coding.glm-4-7-coding"]
 
 [runtime.exact_output_lanes.compaction_exact]
-slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
+slots = ["glm-coding.glm-5-turbo", "glm-coding.glm-4-7-coding"]
 
 [runtime.exact_output_lanes.hitl_auto_judge]
 slots = ["glm-coding.glm-5-turbo", "glm-coding.glm-4-7-coding"]
@@ -67,18 +67,6 @@ path = "/api/tags"
 type = "env"
 key = "OLLAMA_CLOUD_API_KEY"
 
-[providers.deepseek]
-display-name = "DeepSeek API"
-protocol = "openai-compatible-http"
-endpoint = "https://api.deepseek.com"
-
-[providers.deepseek.healthcheck]
-path = "/models"
-
-[providers.deepseek.credentials]
-type = "env"
-key = "DEEPSEEK_API_KEY"
-
 [providers.glm-coding]
 display-name = "GLM Coding Plan"
 protocol = "openai-compatible-http"
@@ -114,22 +102,6 @@ path = "/api/tags"
 # max-context = 200000
 #
 # [claude_code.claude-code-sonnet]
-
-[models.deepseek-v4-pro]
-api-name = "deepseek-v4-pro"
-max-context = 1000000
-tools-support = true
-thinking-support = true
-streaming = true
-
-[models.deepseek-v4-pro.capabilities]
-max-output-tokens = 384000
-supports-tool-choice = true
-supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
-supports-response-format-json = true
-supports-structured-output = false
 
 [models.deepseek-v4-flash]
 api-name = "deepseek-v4-flash"
@@ -218,13 +190,6 @@ wizard-default = true
 # remain bounded so durable canonical history cannot become an n,n+1,... wire
 # replay. AGENT_CORE rejects an oversized serialized body locally before POST; the
 # Keeper turn policy owns any subsequent recovery decision.
-max-request-body-bytes = 524288
-
-[deepseek.deepseek-v4-pro]
-max-request-body-bytes = 524288
-
-[deepseek.deepseek-v4-flash]
-wizard-default = true
 max-request-body-bytes = 524288
 
 [glm-coding.glm-4-7-coding]
@@ -396,11 +361,9 @@ max-request-body-bytes = 524288
 # deepseek4.context_length 1048576 with capabilities [completion tools thinking].
 #
 # It gets its own entry instead of retagging an existing block because
-# [models.deepseek-v4-flash] is bound to BOTH providers
-# ([ollama_cloud.deepseek-v4-flash] and [deepseek.deepseek-v4-flash]) and the
-# `:0731` suffix is an Ollama tag convention — api.deepseek.com/models serves
-# only `deepseek-v4-flash` and `deepseek-v4-pro`, so an in-place retag would
-# 404 the direct lane.
+# [models.deepseek-v4-flash] is bound to the untagged Ollama Cloud runtime and
+# the `:0731` suffix selects a distinct Ollama tag, so an in-place retag would
+# silently change the selected model.
 [models.ollama-cloud-deepseek-v4-flash-0731]
 api-name = "deepseek-v4-flash:0731"
 max-context = 1048576
@@ -990,7 +953,7 @@ max-concurrent = 1
 strategy = "ordered"
 candidates = [
   "ollama_cloud.deepseek-v4-flash",
-  "deepseek.deepseek-v4-pro",
+  "glm-coding.glm-5-turbo",
 ]
 
 # ── Keeper assignments ──────────────────────────────────────────────
@@ -1011,7 +974,7 @@ candidates = [
 # on collision).
 [runtime.assignments]
 # example: pin a test keeper to an explicit runtime
-# canary = "deepseek.deepseek-v4-pro"
+# canary = "glm-coding.glm-5-turbo"
 
 # ── Discord ──────────────────────────────────────────────────────────
 # Trigger policy controls which inbound Discord events the bot responds to.

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -361,69 +361,35 @@ let with_deployment_agent_core_model_catalog f =
          | None -> fail "embedded plus deployment overlay catalog should load"
          | Some catalog -> f catalog)
 
-let test_deployment_agent_core_model_catalog_covers_live_runpod_mtp () =
-  with_deployment_agent_core_model_catalog @@ fun catalog ->
-  let runpod_model_id = "qwen36-35b-a3b-mtp" in
-  let provider_labels = [ "runpod_mtp"; "vllm-qwen3-mtp" ] in
-  let expect_provider_lookup provider_name =
-    match
-      Llm_provider.Model_catalog.lookup_for_provider
-        catalog
-        ~provider_name
-        ~model_id:runpod_model_id
-    with
-    | None ->
-      failf
-        "expected deployment AGENT_CORE catalog row for provider=%s model=%s"
-        provider_name
-        runpod_model_id
-    | Some entry ->
-      check (option string) (provider_name ^ " base") (Some "openai_chat")
-        entry.base_label;
-      check (option int) (provider_name ^ " context") (Some 131072)
-        entry.max_context_tokens
+let test_retired_runtime_providers_are_absent_from_deployment_config () =
+  let assert_source_absent path needles =
+    let source = Fs_compat.load_file path in
+    List.iter
+      (fun needle ->
+         check bool (Filename.basename path ^ " excludes " ^ needle) false
+           (String_util.contains_substring source needle))
+      needles
   in
-  let expect_runpod_caps
-        name
-      (caps : Llm_provider.Capabilities.capabilities)
-    =
-    check bool (name ^ " tools") true caps.supports_tools;
-    check bool (name ^ " tool choice") true caps.supports_tool_choice;
-    check bool (name ^ " extended thinking") true
-      caps.supports_extended_thinking;
-    check bool (name ^ " chat-template thinking") true
-      (Llm_provider.Capabilities.(
-         caps.thinking_control_format = Chat_template_kwargs))
-  in
-  List.iter expect_provider_lookup provider_labels;
-  List.iter
-    (fun provider_label ->
-       match
-         Llm_provider.Capabilities.for_provider_model_id
-           ~allow_bare_fallback:false
-           ~provider_label
-           ~model_id:runpod_model_id
-       with
-       | None ->
-         failf "expected RunPod qwen3.6 capability lookup for %s" provider_label
-       | Some caps -> expect_runpod_caps provider_label caps)
-    provider_labels;
-  (* Verify both the deployment transport alias and the upstream serving
-     contract without bare fallback. *)
-  List.iter
-    (fun provider_label ->
-       let name = "RunPod qwen3.6 gate " ^ provider_label in
-       match
-         Llm_provider.Capabilities.for_provider_model_id
-           ~allow_bare_fallback:false
-           ~provider_label
-           ~model_id:runpod_model_id
-       with
-       | None ->
-         failf "RunPod qwen3.6 must resolve via gate path (%s)"
-           provider_label
-       | Some gate_caps -> expect_runpod_caps name gate_caps)
-    provider_labels
+  let root = repo_root () in
+  assert_source_absent
+    (Filename.concat root "config/runtime.toml")
+    [ "[providers.deepseek]"
+    ; "[deepseek."
+    ; "kimi_code"
+    ; "kimi-for-coding"
+    ; "runpod"
+    ; "qwen36-35b-a3b-mtp"
+    ; "mimo-v2.5"
+    ; "gemma4-coder-fable5"
+    ];
+  assert_source_absent
+    (Filename.concat root "config/agent-core-models-overlay.toml")
+    [ "provider_name = \"kimi_code\""
+    ; "provider_name = \"runpod_mtp\""
+    ; "provider_ref = \"deepseek\""
+    ; "qwen36-35b-a3b-mtp"
+    ; "gemma4-coder-fable5"
+    ]
 
 let test_deployment_agent_core_model_catalog_covers_glm_streaming_reasoning () =
   with_deployment_agent_core_model_catalog @@ fun _catalog ->
@@ -449,45 +415,6 @@ let test_deployment_agent_core_model_catalog_covers_glm_streaming_reasoning () =
               caps.reasoning_streaming_format
               = Delta_reasoning_field "reasoning_content")))
     [ "glm-coding"; "glm-coding-sb-exact" ]
-
-let test_deployment_agent_core_model_catalog_covers_live_runpod_rtxa6000_gemma () =
-  with_deployment_agent_core_model_catalog @@ fun catalog ->
-  let model_id = "gemma4-coder-fable5-q4km" in
-  let provider_name = "runpod_rtxa6000" in
-  (match
-     Llm_provider.Model_catalog.lookup_for_provider catalog ~provider_name ~model_id
-   with
-   | None ->
-     failf
-       "expected deployment AGENT_CORE catalog row for provider=%s model=%s"
-       provider_name
-       model_id
-   | Some entry ->
-     check (option string) (provider_name ^ " base") (Some "openai_chat")
-       entry.base_label;
-     check (option int) (provider_name ^ " context") (Some 262144)
-       entry.max_context_tokens);
-  match
-    Llm_provider.Capabilities.for_provider_model_id
-      ~allow_bare_fallback:false
-      ~provider_label:"runpod_rtxa6000"
-      ~model_id
-  with
-  | None ->
-    failf
-      "live RunPod RTX A6000 Gemma runtime must resolve via raw \
-       deployment provider gate path"
-  | Some caps ->
-    check bool "RunPod RTX A6000 Gemma tools" true caps.supports_tools;
-    check bool "RunPod RTX A6000 Gemma tool choice" true
-      caps.supports_tool_choice;
-    check bool "RunPod RTX A6000 Gemma extended thinking" true
-      caps.supports_extended_thinking;
-    check bool "RunPod RTX A6000 Gemma top_k" true caps.supports_top_k;
-    check bool "RunPod RTX A6000 Gemma seed" true caps.supports_seed;
-    check bool "RunPod RTX A6000 Gemma chat-template token thinking" true
-      (Llm_provider.Capabilities.(
-         caps.thinking_control_format = Chat_template_token "<|think|>"))
 
 let test_deployment_agent_core_model_catalog_covers_local_gemma4_e2b_qat () =
   with_deployment_agent_core_model_catalog @@ fun catalog ->
@@ -563,27 +490,6 @@ let test_deployment_agent_core_model_catalog_preserve_axes_resolve () =
       check (option string) (provider_name ^ " " ^ field_name) (Some expected)
         (get entry)
   in
-  let expect_request_side_preserve ~provider_name ~model_id =
-    expect_provider_catalog_field
-      ~field_name:"preserve_thinking_control_format"
-      ~get:(fun entry -> entry.preserve_thinking_control_format)
-      ~provider_name
-      ~model_id
-      "chat_template_kwargs_preserve_thinking";
-    match
-      Llm_provider.Capabilities.for_provider_model_id
-        ~allow_bare_fallback:false
-        ~provider_label:provider_name
-        ~model_id
-    with
-    | None ->
-      failf "expected AGENT_CORE capabilities for provider=%s model=%s" provider_name model_id
-    | Some caps ->
-      check bool (provider_name ^ " request-side preserve capability") true
-        (Llm_provider.Capabilities.(
-           caps.preserve_thinking_control_format
-           = Chat_template_kwargs_preserve_thinking))
-  in
   let expect_preserve_always_replay ~provider_name ~model_id =
     expect_provider_catalog_field
       ~field_name:"reasoning_replay"
@@ -632,9 +538,6 @@ let test_deployment_agent_core_model_catalog_preserve_axes_resolve () =
         (Llm_provider.Capabilities.(
            caps.reasoning_replay_override = Force_preserve_always))
   in
-  expect_request_side_preserve
-    ~provider_name:"runpod_mtp"
-    ~model_id:"qwen36-35b-a3b-mtp";
   expect_preserve_always_replay
     ~provider_name:"ollama_cloud"
     ~model_id:"kimi-k2.7-code";
@@ -910,35 +813,10 @@ List.iter
           check bool "GLM Coding Plan extended thinking" true
             caps.supports_extended_thinking
         | None -> fail "expected GLM Coding Plan capabilities"));
-    (match
-       List.find_opt
-         (fun (runtime : Runtime.t) ->
-            String.equal runtime.id "deepseek.deepseek-v4-pro")
-         runtimes
-     with
-     | None -> fail "expected DeepSeek Pro runtime in seed"
-     | Some runtime ->
-       check (option (float 0.0)) "DeepSeek keeps AGENT_CORE connect timeout default"
-         None
-         (agent_core_provider_config runtime).connect_timeout_s;
-       (match runtime.model.capabilities with
-        | Some caps ->
-          check bool "DeepSeek Pro structured output disabled" false
-            caps.supports_structured_output
-        | None -> fail "expected DeepSeek Pro capabilities"));
-    (match
-       List.find_opt
-         (fun (runtime : Runtime.t) ->
-            String.equal runtime.id "deepseek.deepseek-v4-flash")
-         runtimes
-     with
-     | None -> fail "expected DeepSeek Flash runtime in seed"
-     | Some runtime ->
-       (match runtime.model.capabilities with
-        | Some caps ->
-          check bool "DeepSeek Flash structured output disabled" false
-            caps.supports_structured_output
-        | None -> fail "expected DeepSeek Flash capabilities"));
+    check bool "direct DeepSeek runtimes are absent" false
+      (List.exists
+         (fun (runtime : Runtime.t) -> has_prefix ~prefix:"deepseek." runtime.id)
+         runtimes);
     (match
        List.find_opt
          (fun (runtime : Runtime.t) ->
@@ -3361,15 +3239,12 @@ let () =
             test_antigravity_cli_rejects_declared_credentials;
           test_case "antigravity options are protocol-scoped" `Quick
             test_antigravity_options_are_protocol_scoped;
-          test_case "deployment AGENT_CORE catalog covers live RunPod MTP runtime" `Quick
-            test_deployment_agent_core_model_catalog_covers_live_runpod_mtp;
+          test_case "retired runtime providers are absent from deployment config" `Quick
+            test_retired_runtime_providers_are_absent_from_deployment_config;
           test_case
             "deployment AGENT_CORE catalog covers GLM typed streaming reasoning"
             `Quick
             test_deployment_agent_core_model_catalog_covers_glm_streaming_reasoning;
-          test_case
-            "deployment AGENT_CORE catalog covers live RunPod RTX A6000 Gemma runtime"
-            `Quick test_deployment_agent_core_model_catalog_covers_live_runpod_rtxa6000_gemma;
           test_case
             "deployment AGENT_CORE catalog covers local Gemma4 E2B QAT runtime"
             `Quick test_deployment_agent_core_model_catalog_covers_local_gemma4_e2b_qat;


### PR DESCRIPTION
## Summary

- remove the direct DeepSeek provider, bindings, target, and routing references from the public runtime seed
- remove Kimi Code and RunPod deployment catalog rows
- route the seed cross-verifier, exact-output fallback, and default lane fallback through working GLM bindings
- replace positive tests for retired providers with a hard-cut absence invariant

Ollama Cloud models whose model names contain deepseek or kimi remain intentionally; they are served by the active ollama_cloud provider, not the removed direct providers.

## Validation

- TOML parse: repo runtime.toml and agent-core-models-overlay.toml pass Python tomllib
- ocamlformat --check test/test_runtime_config_validity.ml: pass
- git diff --check: pass
- live runtime on :8935 after config reload: startup ready, catalog degradation 0, dead materialized runtime/lane IDs 0
- isolated server on :18935 loading the cleaned runtime.toml plus cleaned agent-core-models-overlay.toml: ready, catalog degradation 0, 19 runtimes, 7 lanes, dead IDs 0, graceful shutdown
- focused local Dune compile was attempted but correctly refused because three unrelated bare Dune processes were bypassing the shared lock; CI is the remaining compile authority

## Operational config

The active /Users/dancer/me/.masc config was hard-cut in parallel and backed up outside the active config root under /Users/dancer/me/.tmp/runtime-provider-hardcut-20260810/.