### PR TITLE
fix(keeper): persist successful event reaction ACKs

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -666,21 +666,15 @@ let run_keepalive_unified_turn
           Cycle.meta cycle_outcome)
         else meta_after_triage
       in
-      let terminalize_failed_selection ~selection ~detail =
-        match
-          Keeper_registry_event_queue.terminalize_pending_turn_attempt_result
-            ~base_path:ctx.config.base_path
-            meta_after_triage.name
-            ~current_owner_nonce:meta_after_triage.runtime.nonce
-            ~applied_at:(Time_compat.now ())
-            ~selection
-            ~detail
-        with
-        | Error message -> record_event_queue_failure message
+      let record_terminal_selection_result ~label = function
+        | Error message ->
+          record_event_queue_failure message;
+          false
         | Ok
             ( Keeper_registry_event_queue.Acked _
             | Keeper_registry_event_queue.Already_acked _ ) ->
-          selection_acked := true
+          selection_acked := true;
+          true
         | Ok
             (Keeper_registry_event_queue.Ack_committed_followup_failed
                { stage; detail = followup_detail; _ }) ->
@@ -693,10 +687,32 @@ let run_keepalive_unified_turn
           in
           record_event_queue_failure
             (Printf.sprintf
-               "turn-attempt terminal receipt committed but %s follow-up \
+               "%s receipt committed but %s follow-up \
                 failed: %s"
+               label
                stage
-               followup_detail)
+               followup_detail);
+          true
+      in
+      let terminalize_failed_selection ~selection ~detail =
+        Keeper_registry_event_queue.terminalize_pending_turn_attempt_result
+          ~base_path:ctx.config.base_path
+          meta_after_triage.name
+          ~current_owner_nonce:meta_after_triage.runtime.nonce
+          ~applied_at:(Time_compat.now ())
+          ~selection
+          ~detail
+        |> record_terminal_selection_result ~label:"turn-attempt terminal"
+        |> ignore
+      in
+      let terminalize_completed_selection ~selection =
+        Keeper_registry_event_queue.terminalize_pending_turn_completed_result
+          ~base_path:ctx.config.base_path
+          meta_after_triage.name
+          ~current_owner_nonce:meta_after_triage.runtime.nonce
+          ~applied_at:(Time_compat.now ())
+          ~selection
+        |> record_terminal_selection_result ~label:"turn completion"
       in
       let persist_transcript_corruption_pause ~detail =
         let pause_result =
@@ -766,19 +782,12 @@ let run_keepalive_unified_turn
        | None -> ()
        | Some selection ->
            let remove_completed_selection () =
-             match
-               Keeper_registry_event_queue.ack_pending_result
-                 ~base_path:ctx.config.base_path
-                 meta_after_triage.name
-                 ~selection
-             with
-             | Ok () ->
-               selection_acked := true;
+             if terminalize_completed_selection ~selection
+             then
                mark_connector_attention_ignored_after_turn
                  ~base_path:ctx.config.base_path
                  ~keeper_name:meta_after_triage.name
                  (connector_attention_event_ids_of_stimuli !consumed_stimuli)
-             | Error message -> record_event_queue_failure message
            in
            match !cycle_outcome_ref with
            | Some

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -149,6 +149,7 @@ let transfer_owner_to_yojson transfer =
 let source_terminal_receipt_kind = function
   | Keeper_event_queue_state.Fusion_terminal _ -> "fusion_terminal"
   | Keeper_event_queue_state.Hitl_terminal _ -> "hitl_terminal"
+  | Keeper_event_queue_state.Turn_completed -> "turn_completed"
   | Keeper_event_queue_state.Turn_attempt_terminal _ ->
     "turn_attempt_terminal"
 ;;

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -38,6 +38,7 @@ type accepted_transfer = Keeper_event_queue_persistence.accepted_transfer =
 type source_terminal_receipt = Keeper_event_queue_persistence.source_terminal_receipt =
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_completed
   | Turn_attempt_terminal of { detail : string }
 
 type accepted_source_terminal = Keeper_event_queue_persistence.accepted_source_terminal =
@@ -751,6 +752,28 @@ let terminalize_pending_turn_attempt_result
     ~applied_at
     ~selection
     ~detail
+    ~after_commit:(publish_pending ~base_path name)
+    ()
+  |> Result.map (function
+    | Transition_applied receipt -> Acked receipt
+    | Transition_already_applied receipt -> Already_acked receipt
+    | Transition_committed_followup_failed { receipt; stage; detail } ->
+      Ack_committed_followup_failed { receipt; stage; detail })
+;;
+
+let terminalize_pending_turn_completed_result
+      ~base_path
+      name
+      ~current_owner_nonce
+      ~applied_at
+      ~selection
+  =
+  Keeper_event_queue_persistence.terminalize_pending_turn_completed_result
+    ~base_path
+    ~keeper_name:name
+    ~current_owner_nonce
+    ~applied_at
+    ~selection
     ~after_commit:(publish_pending ~base_path name)
     ()
   |> Result.map (function

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -28,6 +28,7 @@ type accepted_transfer = Keeper_event_queue_persistence.accepted_transfer =
 type source_terminal_receipt = Keeper_event_queue_persistence.source_terminal_receipt =
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_completed
   | Turn_attempt_terminal of { detail : string }
 
 type accepted_source_terminal = Keeper_event_queue_persistence.accepted_source_terminal =
@@ -140,6 +141,16 @@ val terminalize_pending_turn_attempt_result :
   (source_ack_result, string) result
 (** Commit a source-bearing terminal receipt for one failed admitted turn and
     publish the post-commit pending projection. *)
+
+val terminalize_pending_turn_completed_result :
+  base_path:string ->
+  string ->
+  current_owner_nonce:int ->
+  applied_at:float ->
+  selection:Keeper_event_queue_state.pending_selection ->
+  (source_ack_result, string) result
+(** Commit a source-bearing completion receipt for one successful admitted turn
+    and publish the post-commit pending projection. *)
 
 (** Enqueue a stimulus on the keeper's event queue. An owner not registered yet
     may receive durable work so a later lane can replay it. A finalized

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -46,6 +46,7 @@ type accepted_transfer = State.accepted_transfer =
 type source_terminal_receipt = State.source_terminal_receipt =
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_completed
   | Turn_attempt_terminal of { detail : string }
 
 type accepted_source_terminal = State.accepted_source_terminal =
@@ -1088,14 +1089,11 @@ let ack_pending_source_terminal_result
             (Printexc.to_string exn)))
 ;;
 
-let terminalize_pending_turn_attempt_result
+let terminalize_pending_turn_result
       ?(after_commit = fun _ -> ())
       ~base_path
       ~keeper_name
-      ~current_owner_nonce
-      ~applied_at
-      ~selection
-      ~detail
+      ~transition
       ()
   =
   match resolve_owner ~base_path ~keeper_name with
@@ -1109,11 +1107,7 @@ let terminalize_pending_turn_attempt_result
            commit_transition_unlocked
              owner
              ~after_commit
-             (State.terminalize_pending_turn_attempt
-                ~current_owner_nonce
-                ~applied_at
-                ~selection
-                ~detail)
+             transition
              state
            |> Result.map fst)
      with
@@ -1121,9 +1115,53 @@ let terminalize_pending_turn_attempt_result
      | exn ->
        Error
          (Printf.sprintf
-            "event queue pending turn-attempt terminalization raised keeper=%s: %s"
+            "event queue pending turn terminalization raised keeper=%s: %s"
             (keeper_name_of_owner owner)
             (Printexc.to_string exn)))
+;;
+
+let terminalize_pending_turn_attempt_result
+      ?after_commit
+      ~base_path
+      ~keeper_name
+      ~current_owner_nonce
+      ~applied_at
+      ~selection
+      ~detail
+      ()
+  =
+  terminalize_pending_turn_result
+    ?after_commit
+    ~base_path
+    ~keeper_name
+    ~transition:
+      (State.terminalize_pending_turn_attempt
+         ~current_owner_nonce
+         ~applied_at
+         ~selection
+         ~detail)
+    ()
+;;
+
+let terminalize_pending_turn_completed_result
+      ?after_commit
+      ~base_path
+      ~keeper_name
+      ~current_owner_nonce
+      ~applied_at
+      ~selection
+      ()
+  =
+  terminalize_pending_turn_result
+    ?after_commit
+    ~base_path
+    ~keeper_name
+    ~transition:
+      (State.terminalize_pending_turn_completed
+         ~current_owner_nonce
+         ~applied_at
+         ~selection)
+    ()
 ;;
 
 let mark_transition_projected_result state ~transition_id =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -60,6 +60,7 @@ type accepted_transfer = Keeper_event_queue_state.accepted_transfer =
 type source_terminal_receipt = Keeper_event_queue_state.source_terminal_receipt =
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_completed
   | Turn_attempt_terminal of { detail : string }
 
 type accepted_source_terminal = Keeper_event_queue_state.accepted_source_terminal =
@@ -235,6 +236,18 @@ val terminalize_pending_turn_attempt_result :
 (** Atomically construct and commit a source-bearing terminal receipt for one
     failed admitted turn. The selection carries the exact source incarnation;
     no caller-provided prose or counter controls admission. *)
+
+val terminalize_pending_turn_completed_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  current_owner_nonce:int ->
+  applied_at:float ->
+  selection:Keeper_event_queue_state.pending_selection ->
+  unit ->
+  (transition_result, string) result
+(** Atomically construct and commit a source-bearing completion receipt for one
+    successful admitted turn. *)
 
 val project_transition_outbox_result :
   append_before_retire:(outbox_entry -> (unit, string) result) ->

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -20,6 +20,7 @@ type accepted_transfer =
 type source_terminal_receipt =
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_completed
   | Turn_attempt_terminal of { detail : string }
 
 type accepted_source_terminal =
@@ -417,7 +418,7 @@ let validate_accepted_source_terminal
   then Error "source-terminal ACK operation id must not be empty"
   else (
     match source_terminal.source_receipt with
-    | Turn_attempt_terminal _ -> Ok ()
+    | Turn_completed | Turn_attempt_terminal _ -> Ok ()
     | (Fusion_terminal _ | Hitl_terminal _) as expected ->
       let* receipt = source_terminal_receipt_of_stimulus source_terminal.source in
       if receipt = expected
@@ -731,11 +732,23 @@ let ack_pending_source_terminal
        state)
 ;;
 
-let terminalize_pending_turn_attempt
+let turn_terminal_receipt_matches_replay left right =
+  match left, right with
+  | Turn_completed, Turn_completed
+  | Turn_attempt_terminal _, Turn_attempt_terminal _ ->
+    true
+  | Fusion_terminal _, _
+  | Hitl_terminal _, _
+  | Turn_completed, _
+  | Turn_attempt_terminal _, _ ->
+    false
+;;
+
+let terminalize_pending_turn
       ~current_owner_nonce
       ~applied_at
       ~selection
-      ~detail
+      ~source_receipt
       state
   =
   let { source; admitted_revision } = selection in
@@ -751,13 +764,16 @@ let terminalize_pending_turn_attempt
            Ack_source_terminal
              { source = prior_source
              ; owner_nonce
-             ; source_receipt = Turn_attempt_terminal _
+             ; source_receipt = prior_source_receipt
              ; _
              }
        ; _
        } as receipt)
     when Int.equal owner_nonce current_owner_nonce
-         && prior_source = source ->
+         && prior_source = source
+         && turn_terminal_receipt_matches_replay
+              prior_source_receipt
+              source_receipt ->
     Ok (state, Transition_already_applied receipt)
   | Some _ ->
     Error
@@ -771,7 +787,7 @@ let terminalize_pending_turn_attempt
       ; source_incarnation = admitted_revision
       ; owner_nonce = current_owner_nonce
       ; operator_operation_id
-      ; source_receipt = Turn_attempt_terminal { detail }
+      ; source_receipt
       }
     in
     ack_pending_source_terminal
@@ -779,6 +795,35 @@ let terminalize_pending_turn_attempt
       ~applied_at
       ~source_terminal
       state
+;;
+
+let terminalize_pending_turn_attempt
+      ~current_owner_nonce
+      ~applied_at
+      ~selection
+      ~detail
+      state
+  =
+  terminalize_pending_turn
+    ~current_owner_nonce
+    ~applied_at
+    ~selection
+    ~source_receipt:(Turn_attempt_terminal { detail })
+    state
+;;
+
+let terminalize_pending_turn_completed
+      ~current_owner_nonce
+      ~applied_at
+      ~selection
+      state
+  =
+  terminalize_pending_turn
+    ~current_owner_nonce
+    ~applied_at
+    ~selection
+    ~source_receipt:Turn_completed
+    state
 ;;
 
 let restore_pending_transition entry state apply =
@@ -971,6 +1016,8 @@ let transition_to_yojson = function
         [ "source_receipt_kind", `String "fusion_terminal" ]
       | Hitl_terminal _ ->
         [ "source_receipt_kind", `String "hitl_terminal" ]
+      | Turn_completed ->
+        [ "source_receipt_kind", `String "turn_completed" ]
       | Turn_attempt_terminal { detail } ->
         [ "source_receipt_kind", `String "turn_attempt_terminal"
         ; "detail", `String detail
@@ -1079,6 +1126,9 @@ let transition_of_yojson json =
     in
     let* source_receipt =
       match source_receipt_kind with
+      | "turn_completed" ->
+        let* () = exact_fields ~context ~expected:common_fields fields in
+        Ok Turn_completed
       | "turn_attempt_terminal" ->
         let* () =
           exact_fields
@@ -1095,6 +1145,7 @@ let transition_of_yojson json =
           match source_receipt with
           | Fusion_terminal _ -> Ok "fusion_terminal"
           | Hitl_terminal _ -> Ok "hitl_terminal"
+          | Turn_completed
           | Turn_attempt_terminal _ ->
             Error "source payload produced a non-intrinsic terminal receipt"
         in

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -33,10 +33,12 @@ type accepted_transfer =
 type source_terminal_receipt =
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_completed
   | Turn_attempt_terminal of { detail : string }
-(** Closed terminal source evidence. The first three families are intrinsically
-    represented by their durable event payload. [Turn_attempt_terminal] records
-    that one admitted turn ended without durable compaction progress; the exact
+(** Closed terminal source evidence. Fusion and HITL completion are intrinsically
+    represented by their durable event payload. [Turn_completed] records a
+    successful admitted turn; [Turn_attempt_terminal] records that one admitted
+    turn ended without durable compaction progress. In both cases the exact
     source remains in the transition receipt instead of being discarded by a
     raw ACK. [detail] is diagnostic only and carries no transition authority. *)
 
@@ -197,6 +199,17 @@ val terminalize_pending_turn_attempt :
     Repeating the same request after WAL projection returns its original
     receipt, while a later selection of the same source is a new attempt;
     diagnostic [detail] never participates in admission or idempotency. *)
+
+val terminalize_pending_turn_completed :
+  current_owner_nonce:int ->
+  applied_at:float ->
+  selection:pending_selection ->
+  t ->
+  (t * transition_result, string) result
+(** Commit typed completion evidence for one admitted turn. Completion and
+    failure share one deterministic per-attempt operation identity, so a stale
+    contradictory settlement fails closed instead of replacing the first
+    durable outcome. *)
 
 val accepted_pending_cancellation_replay :
   accepted_cancellation ->

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -646,7 +646,8 @@ let occurrence_source_and_disposition
       | Keeper_event_queue_state.Turn_attempt_terminal { detail } ->
         Terminally_failed (detail, terminal_evidence)
       | Keeper_event_queue_state.Fusion_terminal _
-      | Keeper_event_queue_state.Hitl_terminal _ ->
+      | Keeper_event_queue_state.Hitl_terminal _
+      | Keeper_event_queue_state.Turn_completed ->
         Terminally_completed terminal_evidence
     in
     ( terminal.source

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -232,6 +232,64 @@ let test_turn_attempt_terminal_receipt_preserves_exact_source () =
   |> ignore
 ;;
 
+let test_turn_completed_receipt_is_terminal_and_conflict_fenced () =
+  let source = stimulus "completed-turn-source" 1.0 in
+  let initial = State.with_pending (queue [ source ]) State.empty in
+  let selection = select initial in
+  let staged, receipt =
+    match
+      State.terminalize_pending_turn_completed
+        ~current_owner_nonce:7
+        ~applied_at:2.0
+        ~selection
+        initial
+      |> require_ok "terminalize completed turn source"
+    with
+    | state, State.Transition_applied receipt -> state, receipt
+    | _, State.Transition_already_applied _ ->
+      Alcotest.fail "first completed-turn terminalization was replayed"
+  in
+  Alcotest.(check (list string))
+    "completed source leaves runnable pending"
+    []
+    (post_ids (State.pending staged));
+  (match receipt.transition with
+   | State.Ack_source_terminal { source_receipt = State.Turn_completed; _ } -> ()
+   | State.Cancel_accepted _
+   | State.Transfer_accepted _
+   | State.Ack_source_terminal _ ->
+     Alcotest.fail "completed turn did not commit Turn_completed evidence");
+  let projected =
+    State.mark_transition_projected ~transition_id:receipt.transition_id staged
+    |> require_ok "project completed turn receipt"
+  in
+  (match
+     State.terminalize_pending_turn_completed
+       ~current_owner_nonce:7
+       ~applied_at:3.0
+       ~selection
+       projected
+     |> require_ok "replay completed turn receipt"
+   with
+   | _, State.Transition_already_applied replayed ->
+     Alcotest.(check string)
+       "completion replay keeps transition identity"
+       receipt.transition_id
+       replayed.transition_id
+   | _, State.Transition_applied _ ->
+     Alcotest.fail "completed turn was applied twice");
+  (match
+     State.terminalize_pending_turn_attempt
+       ~current_owner_nonce:7
+       ~applied_at:4.0
+       ~selection
+       ~detail:"late contradictory failure"
+       projected
+   with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "failure replaced an already-completed turn")
+;;
+
 let test_projected_disposition_ledger_replays_older_operation () =
   let cancelled_source = stimulus "cancelled-source" 1.0 in
   let transferred_source = stimulus "transferred-source" 2.0 in
@@ -685,6 +743,78 @@ let test_durable_inflight_selection_rejects_reinserted_source () =
       (post_ids pending))
 ;;
 
+let test_durable_completed_turn_projects_reaction_ack () =
+  with_temp_dir "keeper-completed-turn-terminal" (fun base_path ->
+    let keeper_name = "completed-turn-keeper" in
+    let source = stimulus "completed" 1.0 in
+    Keeper_reaction_ledger.record_event_queue_stimulus
+      ~base_path
+      ~keeper_name
+      source;
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending source)
+    |> require_ok "seed completed turn pending";
+    let selection =
+      Persistence.select_when_result
+        ~base_path
+        ~keeper_name
+        ~ready:(fun _ -> true)
+      |> require_ok "select completed turn source"
+      |> require_some "completed turn selection"
+    in
+    let receipt =
+      match
+        Persistence.terminalize_pending_turn_completed_result
+          ~base_path
+          ~keeper_name
+          ~current_owner_nonce:7
+          ~applied_at:3.0
+          ~selection
+          ()
+        |> require_ok "commit completed turn receipt"
+      with
+      | Persistence.Transition_applied receipt
+      | Persistence.Transition_already_applied receipt ->
+        receipt
+      | Persistence.Transition_committed_followup_failed { detail; _ } ->
+        Alcotest.fail detail
+    in
+    Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+      ~base_path
+      ~keeper_name
+      ~expected_transition_id:receipt.transition_id
+    |> require_ok "project completed turn reaction";
+    let restarted =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "restart completed turn state"
+    in
+    Alcotest.(check int)
+      "completed source stays removed after restart"
+      0
+      (Queue.length (State.pending restarted));
+    Alcotest.(check int)
+      "completed reaction retires outbox"
+      0
+      (List.length (State.transition_outbox restarted));
+    let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue source in
+    match
+      Keeper_reaction_ledger.event_queue_reaction_evidence_result
+        ~base_path
+        ~keeper_name
+        ~stimulus_id
+    with
+    | Ok (Keeper_reaction_ledger.Evidence_complete evidence) ->
+      Alcotest.(check bool)
+        "completed turn has durable ACK evidence"
+        true
+        evidence.event_queue_ack_seen
+    | Ok (Keeper_reaction_ledger.Evidence_quarantined _) ->
+      Alcotest.fail "completed turn evidence was quarantined"
+    | Error error ->
+      Alcotest.fail
+        (Keeper_reaction_ledger.event_queue_reaction_evidence_error_to_string error))
+;;
+
 let () =
   Alcotest.run
     "keeper pending queue current schema"
@@ -709,6 +839,10 @@ let () =
             `Quick
             test_turn_attempt_terminal_receipt_preserves_exact_source
         ; Alcotest.test_case
+            "turn completion is terminal and conflict fenced"
+            `Quick
+            test_turn_completed_receipt_is_terminal_and_conflict_fenced
+        ; Alcotest.test_case
             "older projected disposition replays"
             `Quick
             test_projected_disposition_ledger_replays_older_operation
@@ -727,6 +861,10 @@ let () =
             "durable failed turn receipt restart"
             `Quick
             test_durable_turn_attempt_terminal_restart
+        ; Alcotest.test_case
+            "durable completed turn projects reaction ACK"
+            `Quick
+            test_durable_completed_turn_projects_reaction_ack
         ; Alcotest.test_case
             "durable in-flight selection rejects reinserted source"
             `Quick

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -289,6 +289,7 @@ let test_source_ack_identity_survives_checkpoint_reload () =
       | State.Hitl_terminal resolution ->
         { resolution with approval_id = "approval-terminal-2" }
       | State.Fusion_terminal _
+      | State.Turn_completed
       | State.Turn_attempt_terminal _ ->
         Alcotest.fail "fixture must carry a HITL terminal receipt"
     in
@@ -601,6 +602,7 @@ let test_projected_wal_recovery_allows_next_source_ack () =
       | State.Hitl_terminal resolution ->
         { resolution with approval_id = "approval-terminal-after-projection" }
       | State.Fusion_terminal _
+      | State.Turn_completed
       | State.Turn_attempt_terminal _ ->
         Alcotest.fail "fixture must carry a HITL terminal receipt"
     in


### PR DESCRIPTION
## Summary

- replace the successful heartbeat raw queue ACK with one typed `Turn_completed` source-terminal receipt
- commit the exact source-bearing transition before removal and project it through the existing Reaction Ledger outbox
- fence late contradictory success/failure settlement under one deterministic per-attempt operation identity
- keep schedule occurrence projection typed as terminal completion

## Why

A completed Keeper turn removed its event source with `ack_pending_result`, while failed turns already used the durable source-terminal transition. The successful path therefore bypassed the only producer for Reaction Ledger `event_queue_ack` evidence. Live queues could remove a source while the ledger retained only `stimulus` and `turn_started`, breaking causal observability and later diagnosis.

## Tests

- `ocamlformat --check` on all 11 changed OCaml files
- `ocamlc -stop-after parsing` on all changed `.ml` and `.mli` files
- `git diff --check`
- pending locally: focused Dune tests are queued behind unrelated live Dune processes; this PR remains draft until they pass

## Scope

No migration, compatibility decoder, string heuristic, new schema version, or generic receipt graph. The separate raw ACK for an already-consumed HITL grant is intentionally not folded into this turn-completion receipt.