### PR TITLE
ci: run the Keeper owner and chat cutover suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1116,6 +1116,20 @@ jobs:
           opam exec -- dune build --root . \
             @test/runtest-test_keeper_keepalive_launch_order_ast
 
+      - name: Run Keeper owner and chat cutover suites
+        # #27962 put every Keeper mutation and chat turn behind one owner actor,
+        # and #27993 made an unarchived chat-queue.sqlite3 sidecar refuse Keeper
+        # Owner installation at boot. @check compiles both and runs neither, so
+        # one-running-turn, restart settlement, and the boot gate itself were
+        # assertions nothing executed. A gate that can hold a fleet out of ready
+        # has to run where a red result blocks the merge.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_keeper_owner \
+            @test/runtest-test_keeper_chat_operation_http \
+            @test/runtest-test_keeper_autoboot_single_owner \
+            @test/runtest-test_keeper_chat_cutover_preflight
+
       - name: Run memory journal suite
         # The journal is the only disk record of a librarian pass that produced
         # no snapshot. @check compiles this suite but does not run it, and an

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1123,11 +1123,15 @@ jobs:
         # one-running-turn, restart settlement, and the boot gate itself were
         # assertions nothing executed. A gate that can hold a fleet out of ready
         # has to run where a red result blocks the merge.
+        #
+        # test_keeper_autoboot_single_owner is deliberately absent here: it is
+        # already invoked from scripts/ci-run-focused-tests.sh, the second CI
+        # target source, and audit-ci-test-targets.sh rejects a target that two
+        # manifests run.
         run: |
           opam exec -- dune build --root . \
             @test/runtest-test_keeper_owner \
             @test/runtest-test_keeper_chat_operation_http \
-            @test/runtest-test_keeper_autoboot_single_owner \
             @test/runtest-test_keeper_chat_cutover_preflight
 
       - name: Run memory journal suite

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -111,7 +111,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=698
+UNWIRED_BASELINE=689
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
## Summary

- run the Keeper owner and chat cutover suites in CI instead of only compiling them
- lower `UNWIRED_BASELINE` so the gain cannot be given back silently

## Root cause

CI names every `@test/runtest-*` target explicitly across two manifests. The suites added by #27962 (owner actor) and #27993 (chat cutover boot gate) were never added, so `@check` compiled them and nothing executed them.

That gap is not theoretical. #27993 makes an unarchived `chat-queue.sqlite3` sidecar refuse Keeper Owner installation at boot. A live BasePath held eight such sidecars and eight stranded direct-delivery markers while `main` stayed green, because the suite asserting that gate never ran.

## Targets wired

| target | tests |
|---|---|
| `test_keeper_owner` | 33 |
| `test_keeper_chat_cutover_preflight` | 4 |
| `test_keeper_chat_operation_http` | 3 |

`test_keeper_autoboot_single_owner` is **not** wired here. `scripts/ci-run-focused-tests.sh` already runs it, and `audit-ci-test-targets.sh` fails when two manifests name the same target. The first push of this PR got that wrong and the audit caught it — a comment in the step now records why the target is absent.

## Ratchet

```
origin/main            164 CI targets   692 unwired
this branch            167 CI targets   689 unwired
UNWIRED_BASELINE   698 -> 689
```

The baseline sat six above the tree it guards, so earlier wiring work was not being held. Lowering it to the measured value is what `audit-ci-test-targets.sh` asks for in its own output ("lower UNWIRED_BASELINE ... to hold the gain").

## Verification

Suites executed against `origin/main` at `affa660327` before wiring, per the convention stated in this file ("Every suite here was executed against origin/main before being added"):

```
dune build --root . --force \
  @test/runtest-test_keeper_owner \
  @test/runtest-test_keeper_chat_operation_http \
  @test/runtest-test_keeper_autoboot_single_owner \
  @test/runtest-test_keeper_chat_cutover_preflight
EXIT=0   43 tests run, 0 failures
```

Guards run locally on the branch head:

- `scripts/audit-ci-test-targets.sh` — OK, 167 targets, 689 unwired at baseline
- `scripts/ci/check-ocaml-compile-authority.sh` — PASS
- `test/test_deploy_preflight.sh` — PASS
- `scripts/check-pr-hygiene.sh` — PASS
- `yaml.safe_load` on the edited `ci.yml` — OK

## Scope boundary

689 declared suites still do not run. Each has to be executed against `origin/main` before it is wired, and three guards in this family are known red today and are deliberately excluded by the existing "invariant and SSOT guard suites" step. Wiring them blind would turn a green step red for reasons unrelated to owner execution.

Note: `test_keeper_chat_cutover_preflight` pins a boot gate whose removal is under discussion. If that gate is retired, this line goes with it.

RFC-WAIVED: CI target declaration and an audit baseline only. No runtime, credential, identity, operator, sandbox, or hook surface is touched; no contract changes.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
