### PR TITLE
Pass USER to Claude subscription runtime

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -239,6 +239,7 @@ let optional_int stage name fields =
 let subscription_only_environment () =
   let inherited_names =
     [ "HOME"
+    ; "USER"
     ; "PATH"
     ; "TMPDIR"
     ; "XDG_CONFIG_HOME"

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -68,6 +68,7 @@ let fixture_script
     ; "MASC_CLAUDE_SECRET_CANARY"
     ];
   output_string output "[ -n \"${HOME-}\" ] || exit 91\n";
+  output_string output "[ -n \"${USER-}\" ] || exit 97\n";
   output_string output
     "[ \"${CLAUDE_CODE_ENTRYPOINT-}\" = masc ] || exit 92\n";
   output_string output


### PR DESCRIPTION
## What changed

- pass `USER` through the Claude Code subscription-only process environment
- require the Claude runtime fixture to observe a non-empty `USER`
- continue removing Anthropic API keys, OAuth token overrides, proxy endpoints, and cloud-provider auth switches

## Why

Claude Code 2.1.226 cannot resolve its macOS Keychain-backed `claude.ai` Max session when MASC launches it without `USER`. The same minimal environment reports `loggedIn=false`; adding only `USER` reports the current `claude.ai` subscription and allows non-interactive inference.

The production symptom is a Keeper `RUN_ERROR` from:

```text
Provider 'claude_code' unavailable: ... claude auth status --json
```

## Evidence

- `env -i ... claude auth status --json` with the current MASC environment: `loggedIn=false`
- the same environment plus only `USER`: `loggedIn=true`, `authMethod=claude.ai`, `subscriptionType=max`
- host subscription canary with API variables removed: `MASC_CLAUDE_OK` from `claude-sonnet-5`
- `git diff --check`: pass
- `ocamlformat --check lib/runtime/runtime_claude_code.ml test/test_runtime_claude_code.ml`: pass
- OCaml parse checks for both changed files: pass
- focused Dune target pending: repo wrapper correctly refused while another session runs bare `dune build --root . bin/deployment_preflight_helper.exe`

## Impact

MASC Claude Code Keepers can use the official macOS Keychain subscription session without admitting API-key or token environment fallbacks.
