### PR TITLE
fix(keeper): canonicalize chat cutover archive path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -799,6 +799,12 @@ jobs:
           MASC_DEPLOYMENT_PREFLIGHT_HELPER: ${{ github.workspace }}/_build/default/bin/deployment_preflight_helper.exe
         run: scripts/check-runtime-deployment-preflight.sh --self-test
 
+      - name: Run Keeper chat cutover archive self-test
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          MASC_DEPLOYMENT_PREFLIGHT_HELPER: ${{ github.workspace }}/_build/default/bin/deployment_preflight_helper.exe
+        run: test/test_keeper_chat_cutover_archive.sh
+
       - name: Check keeper event queue projection boundary
         # This parser uses compiler-libs directly, so keep it beside the sole
         # OCaml toolchain instead of bootstrapping another toolchain in Lint.

--- a/scripts/archive-keeper-chat-cutover-v1.sh
+++ b/scripts/archive-keeper-chat-cutover-v1.sh
@@ -74,6 +74,18 @@ owner_pid="${MASC_DEPLOYMENT_LEASE_OWNER_PID:-}"
   >/dev/null \
   || fail "BasePath lease proof is invalid"
 
+requested_base_path="$(cd "$BASE_PATH" && pwd -L)"
+requested_archive_parent="$(dirname "$ARCHIVE_DIR")"
+archive_name="$(basename "$ARCHIVE_DIR")"
+[[ -n "$archive_name" && "$archive_name" != "." && "$archive_name" != ".." ]] \
+  || fail "archive destination has an invalid final component"
+requested_archive_parent_name="$(basename "$requested_archive_parent")"
+[[ "$requested_archive_parent_name" == "archive" ]] \
+  || fail "archive destination must be below the BasePath archive directory"
+requested_archive_runtime_root="$(dirname "$requested_archive_parent")"
+[[ -d "$requested_archive_runtime_root" && ! -L "$requested_archive_runtime_root" ]] \
+  || fail "archive runtime root is not an exact directory: $requested_archive_runtime_root"
+requested_archive_parent="$(cd "$requested_archive_runtime_root" && pwd -L)/archive"
 BASE_PATH="$(cd "$BASE_PATH" && pwd -P)"
 runtime_root="$BASE_PATH/.masc"
 keepers_root="$runtime_root/keepers"
@@ -81,13 +93,13 @@ archive_parent="$runtime_root/archive"
 
 [[ -d "$runtime_root" && ! -L "$runtime_root" ]] \
   || fail "runtime root is not an exact directory: $runtime_root"
+if [[ "$requested_archive_parent" != "$requested_base_path/.masc/archive" \
+      && "$requested_archive_parent" != "$archive_parent" ]]; then
+  fail "archive destination must be an immediate child of $archive_parent"
+fi
+ARCHIVE_DIR="$archive_parent/$archive_name"
 [[ ! -e "$ARCHIVE_DIR" && ! -L "$ARCHIVE_DIR" ]] \
   || fail "archive destination already exists: $ARCHIVE_DIR"
-[[ "$(dirname "$ARCHIVE_DIR")" == "$archive_parent" ]] \
-  || fail "archive destination must be an immediate child of $archive_parent"
-archive_name="$(basename "$ARCHIVE_DIR")"
-[[ -n "$archive_name" && "$archive_name" != "." && "$archive_name" != ".." ]] \
-  || fail "archive destination has an invalid final component"
 if [[ -e "$archive_parent" || -L "$archive_parent" ]]; then
   [[ -d "$archive_parent" && ! -L "$archive_parent" ]] \
     || fail "archive parent is not an exact directory: $archive_parent"

--- a/test/test_keeper_chat_cutover_archive.sh
+++ b/test/test_keeper_chat_cutover_archive.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="${MASC_DEPLOYMENT_PREFLIGHT_HELPER:-$REPO_ROOT/_build/default/bin/deployment_preflight_helper.exe}"
+ARCHIVE_SCRIPT="$REPO_ROOT/scripts/archive-keeper-chat-cutover-v1.sh"
+
+[[ -x "$HELPER" ]] || {
+  printf '[keeper-chat-cutover-archive-test] helper is not executable: %s\n' "$HELPER" >&2
+  exit 1
+}
+
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/keeper-chat-cutover-archive.XXXXXX")"
+trap 'rm -rf "$fixture_root"' EXIT
+
+success_base="$fixture_root/success"
+requested_archive="$success_base/.masc/archive/smoke"
+mkdir -p "$success_base/.masc/keepers/demo/.chat-direct-active-v1"
+MASC_DEPLOYMENT_PREFLIGHT_HELPER="$HELPER" \
+  "$HELPER" lease-run \
+    --base-path "$success_base" \
+    -- \
+    "$ARCHIVE_SCRIPT" \
+      --base-path "$success_base" \
+      --archive-dir "$requested_archive" \
+    >/dev/null
+
+canonical_base="$(cd "$success_base" && pwd -P)"
+canonical_archive="$canonical_base/.masc/archive/smoke"
+[[ -d "$canonical_archive/keepers/demo/.chat-direct-active-v1" ]]
+[[ -f "$canonical_archive/SHA256SUMS" ]]
+"$HELPER" inspect-keeper-chat-cutover --base-path "$success_base" \
+  | jq -e '.artifact_count == 0 and .stranded_work_count == 0' \
+  >/dev/null
+
+blocked_base="$fixture_root/blocked"
+blocked_archive="$blocked_base/.masc/archive/smoke"
+mkdir -p "$blocked_base/.masc/keepers/demo/.chat-direct-active-v1"
+touch "$blocked_base/.masc/keepers/demo/.chat-direct-active-v1/kmsg-active"
+if MASC_DEPLOYMENT_PREFLIGHT_HELPER="$HELPER" \
+  "$HELPER" lease-run \
+    --base-path "$blocked_base" \
+    -- \
+    "$ARCHIVE_SCRIPT" \
+      --base-path "$blocked_base" \
+      --archive-dir "$blocked_archive" \
+    >/dev/null 2>&1; then
+  printf '[keeper-chat-cutover-archive-test] active marker was archived\n' >&2
+  exit 1
+fi
+[[ -f "$blocked_base/.masc/keepers/demo/.chat-direct-active-v1/kmsg-active" ]]
+[[ ! -e "$blocked_base/.masc/archive" ]]
+
+escape_base="$fixture_root/escape"
+escape_archive="$escape_base/.masc/archive/../outside"
+mkdir -p "$escape_base/.masc/keepers/demo/.chat-direct-active-v1"
+if MASC_DEPLOYMENT_PREFLIGHT_HELPER="$HELPER" \
+  "$HELPER" lease-run \
+    --base-path "$escape_base" \
+    -- \
+    "$ARCHIVE_SCRIPT" \
+      --base-path "$escape_base" \
+      --archive-dir "$escape_archive" \
+    >/dev/null 2>&1; then
+  printf '[keeper-chat-cutover-archive-test] escaping archive path was accepted\n' >&2
+  exit 1
+fi
+[[ -d "$escape_base/.masc/keepers/demo/.chat-direct-active-v1" ]]
+[[ ! -e "$escape_base/.masc/outside" ]]
+
+printf '[keeper-chat-cutover-archive-test] OK\n'


### PR DESCRIPTION
## Summary
- canonicalize the logical BasePath and archive parent before the immediate-child check
- preserve the canonical runtime-root destination while accepting macOS /tmp and /var path aliases
- add an executable regression self-test for alias success, active-marker refusal, and path-escape refusal
- run the archive regression immediately after the typed helper build in CI

## Verification
- bash syntax check passed
- archive regression self-test passed with the merged typed helper
- merged main affa660327d5 full CI passed, including Build and Test, deployment preflight self-test, and Dashboard

## Cause
The first post-merge temp smoke correctly exposed that macOS canonicalizes /tmp through /private paths. The archive command compared the requested logical path against the physical BasePath string and rejected a valid immediate child.