### PR TITLE
fix(test): qualify reaction ledger module

### DIFF
--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1,6 +1,7 @@
 module Queue = Keeper_event_queue
 module State = Keeper_event_queue_state
 module Persistence = Keeper_event_queue_persistence
+module Keeper_reaction_ledger = Masc.Keeper_reaction_ledger
 
 let require_ok label = function
   | Ok value -> value


### PR DESCRIPTION
## Summary
- expose the main Masc.Keeper_reaction_ledger module to the focused event queue state test through a local module alias
- repair the post-merge compile failure from #27996 without changing production behavior

## Evidence
- failing main run: https://github.com/jeong-sik/masc/actions/runs/31378696223
- failure: test/test_keeper_event_queue_state_v2.ml:750 Unbound module Keeper_reaction_ledger
- git diff --check: passed
- local Dune build intentionally not run; validation is delegated to PR CI per operator direction