### PR TITLE
feat(catalog): add rows for subscription models that resolve to none or a shorter prefix

### DIFF
--- a/packages/agent_core/models.toml
+++ b/packages/agent_core/models.toml
@@ -34,6 +34,23 @@ max_context_tokens = 1000000
 max_output_tokens = 128000
 
 [[models]]
+# Claude Opus 5. Limits and effort ladder from the Claude Platform model
+# overview (checked 2026-08-10); pricing matches the Opus 4.8 tier it replaces.
+# thinking control: thinking is on by default and `disabled` is accepted only at
+# effort high or below. The vocab has no variant for that effort-gated form
+# (capability_vocab.ml:119-123), so this declares the nearest true value —
+# adaptive_only, i.e. `disabled` is accepted — and the effort gate stays
+# enforced by the API rather than by this row.
+id_prefix = "claude-opus-5"
+base = "anthropic"
+anthropic_thinking_control = "adaptive_only"
+accepted_reasoning_efforts = ["low", "medium", "high", "xhigh", "max"]
+max_context_tokens = 1000000
+max_output_tokens = 128000
+input_per_million = 5.0
+output_per_million = 25.0
+
+[[models]]
 id_prefix = "claude-opus-4-8"
 base = "anthropic"
 anthropic_thinking_control = "adaptive_only"
@@ -159,6 +176,19 @@ cache_read_multiplier = 0.1
 # OpenAI Responses API reasoning.effort reference, checked 2026-06-29:
 # gpt-5.1+ rows may declare none/minimal/low/medium/high/xhigh; the bare
 # gpt-5 row predates gpt-5.1 and therefore omits none/xhigh here.
+[[models]]
+# gpt-5.6-{sol,terra,luna}, served through the Codex ChatGPT subscription.
+# Without this row they prefix-match the generic "gpt-5" row, whose
+# accepted_reasoning_efforts omits both "none" and "xhigh". Values mirror the
+# declared gpt-5.5 sibling; no per-token rate is published for subscription
+# serving, so pricing is omitted as on gpt-5.3-codex-spark.
+id_prefix = "gpt-5.6"
+base = "openai_chat_extended"
+max_context_tokens = 1050000
+max_output_tokens = 128000
+supports_computer_use = true
+accepted_reasoning_efforts = ["none", "minimal", "low", "medium", "high", "xhigh"]
+
 [[models]]
 id_prefix = "gpt-5.5"
 base = "openai_chat_extended"
@@ -1208,6 +1238,23 @@ supports_image_input = false
 supports_native_streaming = true
 
 [[models]]
+# gpt-oss-120b-medium, served through the Antigravity Google subscription. The
+# existing rows use the Ollama tag form ("gpt-oss:120b"), which does not prefix
+# the hyphenated subscription id, so that id resolves to no row at all.
+id_prefix = "gpt-oss-120b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "ollama_think"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
 id_prefix = "gpt-oss:120b"
 base = "ollama_cloud"
 max_context_tokens = 131072
@@ -1423,6 +1470,18 @@ base = "gemini"
 max_context_tokens = 1000000
 supports_reasoning_budget = true
 accepted_reasoning_efforts = []
+
+[[models]]
+# gemini-3.6-flash-{high,medium,low}, served through the Antigravity Google
+# subscription. Without this row they prefix-match the generic "gemini-3" row,
+# which declares no accepted_reasoning_efforts at all — so no effort level is
+# admitted. Values mirror the declared gemini-3.5-flash sibling.
+id_prefix = "gemini-3.6-flash"
+base = "gemini"
+max_context_tokens = 1000000
+max_output_tokens = 64000
+supports_reasoning_budget = false
+accepted_reasoning_efforts = ["minimal", "low", "medium", "high"]
 
 [[models]]
 id_prefix = "gemini-3.5-flash"

--- a/packages/agent_core/test/test_model_catalog_default.ml
+++ b/packages/agent_core/test/test_model_catalog_default.ml
@@ -15,6 +15,83 @@ let with_clean_model_catalog_override f =
   Fun.protect ~finally:Model_catalog.clear_global f
 ;;
 
+(* Model ids masc declares in runtime.toml for the Claude Code, Codex and
+   Antigravity subscriptions. [Model_catalog.lookup] is a longest-prefix match,
+   so a missing row fails in one of two silent ways: an id that no row prefixes
+   resolves to [None] and [Runtime] disables that runtime at boot, while an id
+   that only a *shorter* row prefixes inherits that row's capabilities with no
+   error. Asserting the resolved [id_prefix] — rather than merely that the
+   lookup succeeded — is what separates "gpt-5.6-sol found its own row" from
+   "gpt-5.6-sol silently landed on gpt-5". *)
+let subscription_model_rows =
+  [ "claude-opus-5", "claude-opus-5"
+  ; "claude-fable-5", "claude-fable-5"
+  ; "claude-sonnet-5", "claude-sonnet-5"
+  ; "claude-haiku-4-5-20251001", "claude-haiku-4-5"
+  ; "gpt-5.6-sol", "gpt-5.6"
+  ; "gpt-5.6-terra", "gpt-5.6"
+  ; "gpt-5.6-luna", "gpt-5.6"
+  ; "gpt-5.3-codex-spark", "gpt-5.3-codex-spark"
+  ; "gemini-3.6-flash-high", "gemini-3.6-flash"
+  ; "gemini-3.6-flash-medium", "gemini-3.6-flash"
+  ; "gemini-3.6-flash-low", "gemini-3.6-flash"
+  ; "gemini-3.5-flash-high", "gemini-3.5-flash"
+  ; "gemini-3.1-pro-high", "gemini-3.1-pro"
+  ; "claude-sonnet-4-6", "claude-sonnet-4-6"
+  ; "claude-opus-4-6-thinking", "claude-opus-4-6"
+  ; "gpt-oss-120b-medium", "gpt-oss-120b"
+  ]
+;;
+
+let test_subscription_models_resolve_their_own_rows () =
+  let catalog =
+    Model_catalog_test_support.load_repo_model_catalog ~suite:"subscription model rows"
+  in
+  List.iter
+    (fun (model_id, expected_prefix) ->
+       match Model_catalog.lookup catalog model_id with
+       | None ->
+         failf
+           "%s resolves to no catalog row; Runtime disables uncatalogued runtimes at boot"
+           model_id
+       | Some (entry : Model_catalog.model_entry) ->
+         check
+           string
+           (Printf.sprintf "%s resolves to its own row" model_id)
+           expected_prefix
+           entry.id_prefix)
+    subscription_model_rows
+;;
+
+(* The effort ladders are written out as literals rather than read back from the
+   row under test: a comparison that sources both sides from the catalog passes
+   whatever the catalog happens to say, including a row that admits nothing. *)
+let subscription_model_efforts =
+  [ "claude-opus-5", [ "low"; "medium"; "high"; "xhigh"; "max" ]
+  ; "gpt-5.6-sol", [ "none"; "minimal"; "low"; "medium"; "high"; "xhigh" ]
+  ; "gpt-5.3-codex-spark", [ "none"; "minimal"; "low"; "medium"; "high"; "xhigh" ]
+  ; "gemini-3.6-flash-high", [ "minimal"; "low"; "medium"; "high" ]
+  ]
+;;
+
+let test_subscription_models_admit_their_reasoning_efforts () =
+  let catalog =
+    Model_catalog_test_support.load_repo_model_catalog
+      ~suite:"subscription model efforts"
+  in
+  List.iter
+    (fun (model_id, expected) ->
+       match Model_catalog.lookup catalog model_id with
+       | None -> failf "%s resolves to no catalog row" model_id
+       | Some (entry : Model_catalog.model_entry) ->
+         check
+           (option (list string))
+           (Printf.sprintf "%s admits its declared reasoning efforts" model_id)
+           (Some expected)
+           entry.accepted_reasoning_efforts)
+    subscription_model_efforts
+;;
+
 let test_load_default_catalog () =
   let expected =
     Model_catalog_test_support.load_repo_model_catalog ~suite:"model catalog default"
@@ -284,6 +361,14 @@ let () =
             "partial serving evidence fails closed"
             `Quick
             test_serving_constraint_partial_group_fails_closed
+        ; test_case
+            "subscription models resolve their own rows"
+            `Quick
+            test_subscription_models_resolve_their_own_rows
+        ; test_case
+            "subscription models admit their reasoning efforts"
+            `Quick
+            test_subscription_models_admit_their_reasoning_efforts
         ] )
     ]
 ;;


### PR DESCRIPTION
## 정정 (2026-08-10, 최초 본문 철회)

최초 본문은 이 행들이 없으면 `Runtime` 이 해당 런타임을 **부팅 시 disable** 한다고 썼다. **틀렸다.** 대조 실험으로 확인했다.

`missing_runtime_model_capabilities` (`runtime.ml:644-650`) 는 official-client 실행을 명시적으로 면제한다.

```ocaml
| ( Runtime_execution.Codex_app_server _
  | Runtime_execution.Claude_code _
  | Runtime_execution.Antigravity_cli _ ), _ -> None
```

이 PR 이 다루는 4개 모델군은 전부 official-client 로 서빙된다. 그래서 카탈로그 행이 있든 없든 부팅 결과가 같다 — 동일한 `runtime.toml` 을 두 바이너리로 부팅해 비교했다.

| 바이너리 | resolve 된 런타임 | `missing_catalog_model_count` | `disabled_runtime_ids` |
|---|---:|---:|---|
| 이 브랜치 (행 있음) | 34 | 0 | `[]` |
| `origin/main` (행 없음) | 34 | 0 | `[]` |

`claude_code` 4종, `codex_subscription` 7종, `antigravity_subscription` 11종이 양쪽 모두 동일하게 나왔다.

## 그래서 이 PR 은 무엇인가

**현재 라이브 동작 변화가 없는 데이터 정정 + 회귀 고정**이다. 그 이상으로 주장하지 않는다.

행이 없을 때 실제로 일어나는 일은 `Model_catalog.lookup` 의 longest-prefix 매칭이 더 짧은 행으로 흡수하는 것이다.

| model id | 흡수되는 행 | 그 행이 선언하는 effort |
|---|---|---|
| `gpt-5.6-{sol,terra,luna}` | `gpt-5` | `minimal, low, medium, high` — 형제 `gpt-5.5` 의 `none` 과 `xhigh` 가 빠진다 |
| `gemini-3.6-flash-{high,medium,low}` | `gemini-3` | `accepted_reasoning_efforts` 를 **선언하지 않는다** |
| `claude-opus-5` | (매칭 없음) | — |
| `gpt-oss-120b-medium` | (매칭 없음, 기존 행은 태그형 `gpt-oss:120b`) | — |

`accepted_reasoning_efforts` 의 소비자는 AGENT_CORE HTTP 백엔드(`backend_openai.ml`, `backend_gemini.ml`, `provider_config.ml`)와 `server_dashboard_http_runtime_info.ml:1757` 이다. official-client 경로는 어느 쪽도 지나지 않는다. 따라서 지금 이 값이 틀려도 턴 동작은 바뀌지 않는다.

값이 살아나는 경우는 두 가지다.

1. 같은 모델 id 가 OpenAI/Gemini 호환 provider 로도 서빙될 때 (지금은 없다).
2. 대시보드 런타임 정보가 이 모델들의 effort 사다리를 보고할 때 — 코드 경로상 그렇게 되지만 **이 PR 에서 실측하지 않았다**.

## 변경

`packages/agent_core/models.toml` 에 4개 행. 값은 각 모델의 가장 가까운 선언된 형제에서 복사했고, 공표 요율을 확인하지 못한 곳은 가격을 생략했다 (같은 파일 `gpt-5.3-codex-spark`, `gemini-3.5-flash` 선례).

- `claude-opus-5` — 1M ctx / 128K out / effort `low`~`max` / $5·$25 (Claude Platform model overview, 2026-08-10 확인)
- `gpt-5.6` — `gpt-5.5` 미러, 가격 생략
- `gemini-3.6-flash` — `gemini-3.5-flash` 미러
- `gpt-oss-120b` — 기존 `gpt-oss:120b` 미러 (하이픈형 id 용)

## 알려진 한계

`claude-opus-5` 는 thinking 이 기본 on 이고 `disabled` 는 effort `high` 이하에서만 허용된다. `Capability_vocab.anthropic_thinking_control` 에 이 effort-gated 형태를 표현할 variant 가 없어 (`capability_vocab.ml:119-123`) 가장 가까운 참값 `adaptive_only`(= `disabled` 가 허용됨)로 선언했다. effort 게이트는 API 가 계속 강제한다. vocab 확장은 소비자 전수를 건드리므로 이 PR 범위 밖이다.

## 검증

`test_model_catalog_default.ml` 에 2개 케이스.

- `subscription models resolve their own rows` — 16개 구독 model id 가 각각 어느 `id_prefix` 로 resolve 되는지 단언한다. lookup 성공만 보면 `gpt-5.6-sol` 이 `gpt-5` 로 흡수된 상태도 통과하므로, 해소된 `id_prefix` 를 비교한다.
- `subscription models admit their reasoning efforts` — effort 사다리를 **리터럴로** 적어 비교한다. 양변을 카탈로그에서 읽으면 아무것도 허용하지 않는 행도 통과한다.

```
$ ./_build/default/packages/agent_core/test/test_model_catalog_default.exe
Test Successful in 0.188s. 11 tests run.
```

뮤테이션 — `models.toml` 만 되돌리면 두 케이스가 빨개진다.

```
> [FAIL]  embedded catalog  9   subscription models resolve the...
  [FAIL]  embedded catalog  10  subscription models admit their...
2 failures! in 0.309s. 11 tests run.
```

## 미검증

- 대시보드 런타임 정보에서 effort 사다리 표시가 실제로 바뀌는지 실측하지 않았다.
- `gpt-5.6` / `gemini-3.6-flash` 의 실제 서빙 컨텍스트 상한은 공표 문서를 찾지 못해 형제 행 값을 그대로 썼다. 실측 근거가 나오면 정정 대상.
- 라이브 동작 변화가 없으므로, 리뷰어가 "지금 값어치가 없다" 고 판단하면 닫는 것도 타당한 결론이다.

RFC-WAIVED: credential/identity/operator/sandbox/dashboard/hooks/workflow 중 어느 subsystem 도 건드리지 않는다. 변경 범위는 AGENT_CORE 능력 카탈로그 데이터 행과 그 테스트뿐이다.
