### PR TITLE
fix(runtime): request-review permission mode 를 받아들인다 (라이브 키퍼 1대 정지 중)

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -56,7 +56,20 @@ type usage =
   ; total_tokens : int
   }
 
-type permission_mode = Always_proceed
+(* The modes the CLI has been observed to announce. [Request_review] arrived
+   from a live init event and was not modelled, so the parse failed, the turn
+   ended as a protocol error, and the official-client session went to
+   Recovery_required -- which blocked every later turn for that keeper until an
+   operator resolved it (taskmaster, 110 turns in one hour).
+
+   Nothing in this tree branches on the value: it is parsed, carried through
+   [state.init] into [turn_result], and never matched. A closed vocabulary over
+   a field the provider owns and we do not read costs a session each time the
+   provider adds a member. Kept closed for now because guessing members is
+   worse than failing loudly, but see #28008. *)
+type permission_mode =
+  | Always_proceed
+  | Request_review
 
 type turn_result =
   { conversation_id : string
@@ -231,6 +244,7 @@ let parse_permission_mode stage value =
     "permission_mode"
     (function
       | "always-proceed" -> Some Always_proceed
+      | "request-review" -> Some Request_review
       | _ -> None)
     value
 ;;

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -39,7 +39,9 @@ type usage =
   ; total_tokens : int
   }
 
-type permission_mode = Always_proceed
+type permission_mode =
+  | Always_proceed
+  | Request_review
 
 type turn_result =
   { conversation_id : string

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -1,11 +1,17 @@
 open Alcotest
 open Masc
 
-let init ?(conversation_id = "conversation-1") ?(model = "gemini-fixture") () =
+let init
+    ?(conversation_id = "conversation-1")
+    ?(model = "gemini-fixture")
+    ?(permission_mode = "always-proceed")
+    ()
+  =
   Printf.sprintf
-    {|{"event":"init","conversation_id":%S,"init":{"model":%S,"cwd":"/tmp","tools":["view_file"],"permission_mode":"always-proceed"}}|}
+    {|{"event":"init","conversation_id":%S,"init":{"model":%S,"cwd":"/tmp","tools":["view_file"],"permission_mode":%S}}|}
     conversation_id
     model
+    permission_mode
 ;;
 
 let step
@@ -260,6 +266,26 @@ let test_duplicate_keys_fail_closed () =
        | Ok _ -> fail "duplicate key was admitted")
 ;;
 
+(* A live init event announced request-review. It was not modelled, the parse
+   failed, and the resulting protocol error put the official-client session in
+   Recovery_required -- which blocked every later turn for that keeper until an
+   operator resolved it (taskmaster, 110 turns in one hour). Nothing in this
+   tree branches on the value; the vocabulary is closed only to fail loudly on
+   a member we have not seen. *)
+let test_observed_permission_modes_are_admitted () =
+  List.iter
+    (fun (wire, expected) ->
+      with_fixture [ init ~permission_mode:wire (); result () ] (fun path ->
+        match run_fixture path with
+        | Ok turn ->
+          check bool ("permission mode " ^ wire) true (turn.permission_mode = expected)
+        | Error error ->
+          fail (wire ^ " was rejected: " ^ Runtime_antigravity.error_to_string error)))
+    [ "always-proceed", Runtime_antigravity.Always_proceed
+    ; "request-review", Runtime_antigravity.Request_review
+    ]
+;;
+
 let test_unknown_protocol_vocabulary_fails_closed () =
   let unknown_permission =
     {|{"event":"init","conversation_id":"conversation-1","init":{"model":"gemini-fixture","cwd":"/tmp","permission_mode":"unreviewed"}}|}
@@ -389,7 +415,11 @@ let () =
         ; test_case "error result" `Quick test_result_error_is_not_success
         ; test_case "duplicate keys" `Quick test_duplicate_keys_fail_closed
         ; test_case
-            "unknown protocol vocabulary"
+            "observed permission modes are admitted"
+            `Quick
+            test_observed_permission_modes_are_admitted
+        ; test_case
+            "unknown protocol vocabulary fails closed"
             `Quick
             test_unknown_protocol_vocabulary_fails_closed
         ; test_case "typed timeout" `Quick test_timeout_is_typed


### PR DESCRIPTION
Refs #28008

## 지금 라이브에서 키퍼 하나가 죽어 있습니다

```
taskmaster  phase=recovery_required  failure=protocol_failed
detail: Parse error: init event: unsupported field "permission_mode" value "request-review"
```

최근 1시간: taskmaster **0.0% (110턴)**, sangsu 0.0% (111), kidsnote 2.0% (99) → fleet **52.7% (673)**. 비-성공 318건 중 **317건이 이 파스 에러가 밀어넣은 `Recovery_required`** 에서 막힌 것입니다.

## 원인

```ocaml
type permission_mode = Always_proceed          (* 멤버 1개 *)

let parse_permission_mode stage value =
  closed_string stage "permission_mode"
    (function "always-proceed" -> Some Always_proceed | _ -> None) value
```

CLI 가 `request-review` 를 보내면 → `protocol_error` → 턴 terminal → 세션 오염 → 그 키퍼 정지.

## 아무도 읽지 않는 값입니다

`permission_mode` 는 `state.init` 을 거쳐 `turn_result` 까지 흐르지만 **`match` 되는 곳이 없습니다.** `lib/` 의 모든 등장이 타입 선언·파서·필드 대입입니다.

**읽지 않는 값의 닫힌 어휘가 provider 의 멤버 추가마다 세션을 하나씩 죽입니다** — #27967(빈 `delta` 에 non-empty 요구, 값은 `_delta` 로 폐기)과 같은 형태입니다.

## 이 PR 의 범위

관측된 멤버만 추가하고 **어휘는 닫힌 채로 둡니다.** 보지 못한 멤버를 추측하는 것보다 크게 실패하는 편이 낫습니다.

**다음 멤버에서 또 납니다.** "읽지도 않는 provider 소유 필드에 닫힌 어휘를 두는 게 맞는가"는 #28008 에 적었고, 어댑터 소유자 판단이라 여기서 정하지 않았습니다.

## 검증

```
$ dune build @check                                    exit=0
$ dune build @test/runtest-test_runtime_antigravity
Test Successful in 5.576s. 14 tests run.
```

새 케이스는 **관측된 두 값이 모두 통과**하는지 봅니다(`always-proceed`, `request-review`). 기존 `unknown protocol vocabulary fails closed` 는 그대로 남아 `unreviewed` 같은 미관측 값이 여전히 거부되는지 지킵니다 — 넓히는 변경의 대조군입니다.

**뮤테이션** — 새 arm 을 지우면:

```
was rejected: Antigravity stream-json protocol error during init event:
              unsupported field "permission_mode" value "request-review"
```

라이브 문자열과 동일합니다.

RFC-WAIVED: Antigravity stream-json 파서의 관측된 열거값 1개 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
