### PR TITLE
feat(runtime): declare per-model reasoning effort for official-client turns

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -185,6 +185,8 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     let turn_count = claim_plan.turn_count in
     let* prepared =
       Host.prepare_turn
+        ~configured_reasoning_effort:
+          (Runtime_inference.resolve_reasoning_effort ~runtime_id)
         ~runtime_label
         ~keeper_name
         ~turn_count

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -193,6 +193,8 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     let turn_count = claim_plan.turn_count in
     let* prepared =
       Host.prepare_turn
+        ~configured_reasoning_effort:
+          (Runtime_inference.resolve_reasoning_effort ~runtime_id)
         ~runtime_label
         ~keeper_name
         ~turn_count

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -206,6 +206,8 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     let turn_count = claim_plan.turn_count in
     let* prepared =
       Host.prepare_turn
+        ~configured_reasoning_effort:
+          (Runtime_inference.resolve_reasoning_effort ~runtime_id)
         ~runtime_label
         ~keeper_name
         ~turn_count

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -179,7 +179,7 @@ let resolve_reasoning_effort ~enable_thinking ~reasoning_effort =
 ;;
 
 let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
-    ~initial_messages ~model_input_projection ~hooks =
+    ~initial_messages ~model_input_projection ~hooks ~configured_reasoning_effort =
   let hooks = match hooks with Some hooks -> hooks | None -> Agent_core.Hooks.empty in
   let before_turn =
     invoke_turn_hook
@@ -198,7 +198,17 @@ let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
     | decision ->
       Error (illegal_hook_decision ~runtime_label ~hook_name:"before_turn" decision)
   in
-  let current_params = Agent_core.Hooks.default_turn_params in
+  (* Seed the params the hook sees rather than overwriting its answer: an
+     operator declaration is a default for the turn, not an override of a
+     hook that deliberately chose a different effort. *)
+  let current_params =
+    match configured_reasoning_effort with
+    | None -> Agent_core.Hooks.default_turn_params
+    | Some _ ->
+      { Agent_core.Hooks.default_turn_params with
+        reasoning_effort = configured_reasoning_effort
+      }
+  in
   let before_turn_params =
     invoke_turn_hook
       ~keeper_name

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -126,7 +126,10 @@ val prepare_turn :
   initial_messages:Agent_core.Types.message list ->
   model_input_projection:Agent_core.Agent.model_input_projection option ->
   hooks:Agent_core.Hooks.hooks option ->
+  configured_reasoning_effort:Llm_provider.Reasoning_effort.t option ->
   (prepared_turn, Agent_core.Error.t) result
+(** [configured_reasoning_effort] seeds the turn params the
+    [before_turn_params] hook receives, so a hook can still override it. *)
 
 val dynamic_tools :
   runtime_label:string ->

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1312,6 +1312,17 @@ let top_p_of_runtime_id (id : string) : float option =
   | None -> None
 ;;
 
+(* The per-model [reasoning-effort] declared in runtime.toml
+   ([models.<id>.reasoning-effort]), or [None] when the runtime is unknown
+   or the model leaves it unset. Mirrors [temperature_of_runtime_id]. *)
+let reasoning_effort_of_runtime_id (id : string)
+  : Llm_provider.Reasoning_effort.t option
+  =
+  match get_runtime_by_id id with
+  | Some rt -> rt.model.reasoning_effort
+  | None -> None
+;;
+
 let default_preserve_thinking_for_model (_rt : t) : bool option =
   (* AGENT_CORE owns provider/model capability truth and can preserve reasoning when
      the provider contract requires it. MASC must not turn "request-side

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -350,6 +350,11 @@ val temperature_of_runtime_id : string -> float option
     set and its caller fallback ([MASC_KEEPER_UNIFIED_TEMP]) otherwise.  Required
     for models that reject the default temperature (Kimi K2.7 accepts only 1.0). *)
 
+val reasoning_effort_of_runtime_id : string -> Llm_provider.Reasoning_effort.t option
+(** Per-model [reasoning-effort] from runtime.toml, or [None] when unset or
+    the runtime id is unknown. Consumed by
+    {!Runtime_inference.resolve_reasoning_effort}. *)
+
 val top_p_of_runtime_id : string -> float option
 (** Request [top_p] from the materialized AGENT_CORE provider config for runtime [id],
     or [None] when the runtime is not configured or no explicit value is

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -14,6 +14,14 @@ let resolve_temperature ~runtime_id ~fallback =
   | Some temperature -> temperature
   | None -> fallback ()
 
+(* Per-runtime reasoning effort. Official-client runtimes reject
+   [enable_thinking] and take effort instead, so without this the effort a
+   Claude Code / Codex / Antigravity turn runs at is whatever the CLI
+   defaults to and no operator declaration reaches it. [None] leaves the
+   caller's own value in place. *)
+let resolve_reasoning_effort ~runtime_id =
+  Runtime.reasoning_effort_of_runtime_id runtime_id
+
 (* masc#24067 / agent-core boundary: MASC must not synthesize a request [max_tokens]
    value. The former resolver invented one from either a model capability
    ceiling or a flat fallback. Callers now carry explicit intent as [int

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -1,3 +1,9 @@
+val resolve_reasoning_effort :
+  runtime_id:string -> Llm_provider.Reasoning_effort.t option
+(** The per-model [reasoning-effort] declared for [runtime_id], or [None]
+    when the model leaves it unset. Official-client runtimes have no other
+    declared reasoning control. *)
+
 val resolve_temperature :
   runtime_id:string -> fallback:(unit -> float) -> float
 (** Use the runtime.toml model override when present; evaluate [fallback] only

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -203,6 +203,21 @@ type model_spec =
     (** [min_p] — per-model minimum probability sampling value forwarded through
         the materialized AGENT_CORE [Provider_config]. [None] leaves the caller/AGENT_CORE
         profile unchanged. *)
+  ; reasoning_effort : Llm_provider.Reasoning_effort.t option
+       [@equal fun a b -> a = b]
+    (* Reasoning_effort.t is a plain variant with no derived [equal];
+       structural equality is exactly right for it, and declaring it here
+       keeps the comparison inside masc rather than widening the AGENT_CORE
+       module's interface for one consumer. *)
+    (** [reasoning-effort] — per-model reasoning depth. Official-client
+        runtimes take no [enable_thinking]
+        ({!Keeper_official_client_host.resolve_reasoning_effort} rejects it
+        outright), so this is the only declared control over how much a
+        Claude Code / Codex / Antigravity turn reasons. [None] leaves the
+        turn at the caller default. Resolved via
+        {!Runtime.reasoning_effort_of_runtime_id} →
+        {!Runtime_inference.resolve_reasoning_effort}, symmetric to the
+        [temperature] path. *)
   ; capabilities : model_capabilities option
   }
 [@@deriving show, eq]

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -141,6 +141,8 @@ type model_spec =
   ; top_p : float option
   ; top_k : int option
   ; min_p : float option
+  ; reasoning_effort : Llm_provider.Reasoning_effort.t option
+       [@equal fun a b -> a = b]
   ; capabilities : model_capabilities option
   }
 [@@deriving show, eq]

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -805,6 +805,30 @@ let bounded_number_opt_field
             value))
 ;;
 
+(* Read the optional per-model [reasoning-effort]. Parsed into the typed
+   effort at load time rather than carried as a string: an unknown value is
+   an operator typo, and rejecting it here means no later consumer has to
+   decide what an unparseable effort means. *)
+let reasoning_effort_opt_field ~(path : string) (tbl : Otoml.t)
+  : (Llm_provider.Reasoning_effort.t option, parse_error list) result
+  =
+  match Otoml.find_opt tbl Otoml.get_string [ "reasoning-effort" ] with
+  | None -> Ok None
+  | Some raw ->
+    (match Llm_provider.Reasoning_effort.of_string raw with
+     | Some effort -> Ok (Some effort)
+     | None ->
+       Error
+         [ { path
+           ; message =
+               Printf.sprintf
+                 "reasoning-effort %S is not a known effort; expected one of %s"
+                 raw
+                 Llm_provider.Reasoning_effort.values_for_log
+           }
+         ])
+;;
+
 (* Read the optional per-model [temperature]. A TOML integer (1) or float (1.0)
    both read as a float so an operator is not tripped by "1 vs 1.0". Absent →
    [Ok None] (caller keeps its fallback). Wrong type or out of
@@ -925,6 +949,7 @@ let parse_model (id : string) (tbl : Otoml.t)
     let top_p_result = probability_opt_field ~path ~key:"top-p" tbl in
     let top_k_result = positive_int_opt_field ~path ~key:"top-k" tbl in
     let min_p_result = probability_opt_field ~path ~key:"min-p" tbl in
+    let reasoning_effort_result = reasoning_effort_opt_field ~path tbl in
     let ( let* ) = Result.bind in
     let* max_context = max_context_result in
     let* capabilities = capabilities_result in
@@ -932,6 +957,7 @@ let parse_model (id : string) (tbl : Otoml.t)
     let* top_p = top_p_result in
     let* top_k = top_k_result in
     let* min_p = min_p_result in
+    let* reasoning_effort = reasoning_effort_result in
     match sampling_capability_errors ~path ~capabilities ~top_k ~min_p with
     | _ :: _ as errors -> Error errors
     | [] ->
@@ -948,6 +974,7 @@ let parse_model (id : string) (tbl : Otoml.t)
         ; top_p
         ; top_k
         ; min_p
+        ; reasoning_effort
         ; capabilities        })
 ;;
 

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -736,6 +736,66 @@ let test_deployment_agent_core_model_catalog_modality_priorities_resolve () =
               (caps.modality_priority = expected)))
     rows
 
+(* [reasoning-effort] is the only declared reasoning control official-client
+   runtimes have: Keeper_official_client_host.resolve_reasoning_effort rejects
+   enable_thinking outright. Asserting the parsed variant rather than "parsing
+   succeeded" is what separates a declaration that reached the model spec from
+   one that was accepted and dropped. *)
+let test_model_reasoning_effort_parses_into_the_typed_variant () =
+  let config =
+    "[models.probe]\napi-name = \"probe\"\nreasoning-effort = \"xhigh\"\n"
+  in
+  match Runtime_toml.parse_string config with
+  | Error _ -> fail "a model declaring a known reasoning-effort must parse"
+  | Ok parsed ->
+    (match parsed.Runtime_schema.models with
+     | [ model ] ->
+       check
+         bool
+         "reasoning-effort xhigh reaches the model spec as XHigh"
+         true
+         (model.Runtime_schema.reasoning_effort
+          = Some Llm_provider.Reasoning_effort.XHigh)
+     | _ -> fail "exactly one model must parse")
+
+let test_model_reasoning_effort_rejects_unknown_value_at_load () =
+  let config =
+    "[models.probe]\napi-name = \"probe\"\nreasoning-effort = \"turbo\"\n"
+  in
+  match Runtime_toml.parse_string config with
+  | Ok _ -> fail "an unknown reasoning-effort must be rejected at load"
+  | Error errors ->
+    check
+      bool
+      "the rejection names the offending value"
+      true
+      (List.exists
+         (fun (e : Runtime_toml.parse_error) ->
+            let contains needle =
+              let n = String.length needle in
+              let rec scan i =
+                i + n <= String.length e.message
+                && (String.sub e.message i n = needle || scan (i + 1))
+              in
+              scan 0
+            in
+            contains "turbo")
+         errors)
+
+let test_model_without_reasoning_effort_leaves_it_unset () =
+  let config = "[models.probe]\napi-name = \"probe\"\n" in
+  match Runtime_toml.parse_string config with
+  | Error _ -> fail "a model without reasoning-effort must still parse"
+  | Ok parsed ->
+    (match parsed.Runtime_schema.models with
+     | [ model ] ->
+       check
+         bool
+         "an undeclared reasoning-effort stays None rather than defaulting"
+         true
+         (model.Runtime_schema.reasoning_effort = None)
+     | _ -> fail "exactly one model must parse")
+
 let test_exact_output_lane_config_is_ordered_and_rejects_duplicates () =
   let valid =
     "[runtime.exact_output_lanes.compaction_exact]\nslots = [\"slot-b\", \"slot-a\"]\n"
@@ -3538,5 +3598,14 @@ let () =
           test_case
             "release-evidence smoke lanes resolve with no credential present"
             `Quick test_release_evidence_fixture_lanes_resolve_without_credentials
+        ; test_case
+            "reasoning-effort parses into the typed variant"
+            `Quick test_model_reasoning_effort_parses_into_the_typed_variant
+        ; test_case
+            "reasoning-effort rejects an unknown value at load"
+            `Quick test_model_reasoning_effort_rejects_unknown_value_at_load
+        ; test_case
+            "a model without reasoning-effort leaves it unset"
+            `Quick test_model_without_reasoning_effort_leaves_it_unset
         ] )
     ]

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -56,6 +56,7 @@ let qwen_model =
   ; top_p = None
   ; top_k = None
   ; min_p = None
+  ; reasoning_effort = None
   ; capabilities = None
   }
 


### PR DESCRIPTION
## 문제

세 official-client 어댑터는 전부 `reasoning_effort` 를 받는다.

- `runtime_claude_code.ml:788` → `--effort`
- `runtime_codex_app_server.ml:785` → `effort`
- `runtime_antigravity.ml:427` → `--effort`

`keeper_official_client_host.ml:171-178` 은 한 발 더 나아가 이것이 **유일한** 제어축이라고 못박는다.

```ocaml
"official-client runtimes do not project enable_thinking; use reasoning_effort for explicit control"
```

그런데 `lib/` 전체에서 `reasoning_effort` 에 값을 넣는 코드가 **0곳**이다.

- `Runtime_schema.model_spec` 에 필드가 없다 — `temperature` / `top_p` / `top_k` / `min_p` 는 있다.
- `keeper_context_core_accessors.ml:66` 이 `reasoning_effort = None` 으로 고정한다.
- `turn_params` 는 `Agent_core.Hooks.default_turn_params` 에서 시작하며 그 기본값도 `None` 이다.

결과: Claude Code / Codex 턴이 어느 effort 로 도는지는 CLI 기본값이 정하고, 운영자가 선언할 방법이 없다. Antigravity 만 우연히 예외인데, 그건 masc 가 제어해서가 아니라 레벨이 모델 id 에 박혀 있어서다 (`gemini-3.6-flash-high` vs `-low`).

관측: 2026-08-10 실측에서 `gemini-3.6-flash` 3단계의 턴 벽시계가 34.7 / 21.1 / 10.8 초로 단조 감소했다. 레벨은 실제로 동작한다 — 선언 경로만 없다.

## 변경

`temperature` 가 이미 깔아둔 대칭 경로를 그대로 따른다.

```
runtime.toml [models.<id>].reasoning-effort
  → Runtime_toml.reasoning_effort_opt_field   (로드 시점에 타입으로 파싱)
  → Runtime_schema.model_spec.reasoning_effort
  → Runtime.reasoning_effort_of_runtime_id
  → Runtime_inference.resolve_reasoning_effort
  → Keeper_official_client_host.prepare_turn ~configured_reasoning_effort
  → turn_params.reasoning_effort → 세 어댑터
```

설계 선택 두 가지.

1. **로드 시점에 타입으로 파싱한다.** `model_spec` 이 문자열이 아니라 `Llm_provider.Reasoning_effort.t option` 을 든다. 모르는 값은 허용 집합을 나열하며 로드에서 거부하므로, 이후 어떤 소비자도 "파싱 안 되는 effort" 를 어떻게 처리할지 결정할 필요가 없다.

2. **훅이 보는 파라미터를 seed 한다** (훅의 답을 덮어쓰지 않는다). 운영자 선언은 그 턴의 기본값이지, 일부러 다른 effort 를 고른 훅에 대한 override 가 아니다.

`Reasoning_effort.t` 에는 derived `equal` 이 없어서 `model_spec` 의 `[@@deriving eq]` 가 깨진다. 소비자 한 명 때문에 AGENT_CORE 모듈 인터페이스를 넓히는 대신 필드 단위 `[@equal fun a b -> a = b]` 로 masc 안에 가뒀다 — 평범한 variant 라 구조적 동등성이 정확히 맞다.

## 검증

`test/test_runtime_config_validity.ml` 에 3 케이스.

- `reasoning-effort parses into the typed variant` — 파싱 성공 여부가 아니라 **파싱된 variant**(`XHigh`)를 단언한다. 성공 여부만 보면 값이 받아들여진 뒤 버려진 경우도 통과한다.
- `reasoning-effort rejects an unknown value at load` — 거부 메시지가 문제의 값을 실제로 지목하는지까지 본다.
- `a model without reasoning-effort leaves it unset` — 미선언이 조용히 어떤 값으로 defaulting 되지 않음을 고정한다.

```
$ dune build --root .
$ ./_build/default/test/test_runtime_config_validity.exe
  [OK]  runtime TOML gate  63  reasoning-effort parses into t...
  [OK]  runtime TOML gate  64  reasoning-effort rejects an un...
  [OK]  runtime TOML gate  65  a model without reasoning-effo...
Test Successful in 0.350s. 66 tests run.
```

뮤테이션 — 파서를 `Ok None` 으로 무력화하면 앞의 두 케이스가 빨개진다. 세 번째는 통과하는 것이 맞다 (미선언은 여전히 `None`).

```
> [FAIL]  runtime TOML gate  63  reasoning-effort parses into t...
  [FAIL]  runtime TOML gate  64  reasoning-effort rejects an un...
FAIL reasoning-effort xhigh reaches the model spec as XHigh
2 failures! in 0.282s. 66 tests run.
```

## 미검증

- **라이브 턴에서 effort 가 실제로 CLI 에 도달하는지 실측하지 않았다.** 배선은 컴파일 타임에 닫혀 있고 (`prepare_turn` 이 인자를 요구하므로 세 호출자 모두 전달할 수밖에 없다) 세 어댑터가 값을 argv/wire 로 옮기는 코드는 이미 존재하지만, `runtime.toml` 에 `reasoning-effort` 를 선언한 키퍼 턴을 돌려 확인하지는 않았다. 후속으로 실측한다.
- 기존 `runtime.toml` 에 `reasoning-effort` 를 선언한 모델이 없으므로 이 PR 은 현재 라이브 동작을 바꾸지 않는다 (`None` → 기존과 동일 경로).

RFC-WAIVED: credential/identity/operator/sandbox/dashboard credential/hooks/workflow 중 어느 subsystem 도 건드리지 않는다. 변경은 런타임 설정 스키마와 official-client 턴 파라미터 배선뿐이다.
