### PR TITLE
fix(keeper): owner 가 멈춘 턴은 recovery 가 아니라 release 로 끝난다 (라이브 kidsnote 정지 원인)

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -557,9 +557,16 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             ; stop_reason = Completed
             }
       with
+      (* A stop the owner raised is not an ambiguity: it knows the turn did
+         not finish and why. Only an unexplained cancellation needs an
+         operator to adjudicate what the transport left behind (#28012). *)
       | Eio.Cancel.Cancelled _ as exn ->
         let backtrace = Printexc.get_raw_backtrace () in
-        recovery_failure := Session_store.Transport_interrupted;
+        recovery_failure
+          := (match exn with
+              | Eio.Cancel.Cancelled Keeper_owner_signals.Stop_active_child ->
+                Session_store.Owner_stopped_turn
+              | _ -> Session_store.Transport_interrupted);
         let detail = "Antigravity turn cancelled: " ^ Printexc.to_string exn in
         (match Eio.Cancel.protect (fun () -> settle_failed_claim detail) with
          | Ok () -> ()

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -560,9 +560,16 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
              ; stop_reason = Completed
              })
       with
+      (* A stop the owner raised is not an ambiguity: it knows the turn did
+         not finish and why. Only an unexplained cancellation needs an
+         operator to adjudicate what the transport left behind (#28012). *)
       | Eio.Cancel.Cancelled _ as exn ->
         let backtrace = Printexc.get_raw_backtrace () in
-        recovery_failure := Session_store.Transport_interrupted;
+        recovery_failure
+          := (match exn with
+              | Eio.Cancel.Cancelled Keeper_owner_signals.Stop_active_child ->
+                Session_store.Owner_stopped_turn
+              | _ -> Session_store.Transport_interrupted);
         let detail = "Claude Code turn cancelled: " ^ Printexc.to_string exn in
         (match Eio.Cancel.protect (fun () -> settle_failed_claim detail) with
          | Ok () -> ()

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -530,9 +530,16 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
          ; stop_reason = Completed
          })
       with
+      (* A stop the owner raised is not an ambiguity: it knows the turn did
+         not finish and why. Only an unexplained cancellation needs an
+         operator to adjudicate what the transport left behind (#28012). *)
       | Eio.Cancel.Cancelled _ as exn ->
         let backtrace = Printexc.get_raw_backtrace () in
-        recovery_failure := Keeper_official_client_session_store.Transport_interrupted;
+        recovery_failure
+          := (match exn with
+              | Eio.Cancel.Cancelled Keeper_owner_signals.Stop_active_child ->
+                Keeper_official_client_session_store.Owner_stopped_turn
+              | _ -> Keeper_official_client_session_store.Transport_interrupted);
         let detail = "Codex turn cancelled: " ^ Printexc.to_string exn in
         (match Eio.Cancel.protect (fun () -> settle_failed_claim detail) with
          | Ok () -> ()

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -10,6 +10,7 @@ type settlement =
 
 type recovery_failure =
   | Transient_spawn_failed
+  | Owner_stopped_turn
   | Transport_interrupted
   | Protocol_failed
   | Provider_rejected
@@ -22,8 +23,14 @@ type failure_disposition =
   | Ambiguous
   | Fatal
 
+(* [Owner_stopped_turn] is transient because it is not an ambiguity: the owner
+   raised the stop itself and already classifies the operation as
+   Turn_cancelled. Recovery exists to get an operator's judgement on what a
+   crash left behind; a stop we made with a known reason has nothing to
+   adjudicate, and routing it to Recovery_required blocked every later turn for
+   that keeper until someone resolved it by hand (#28012). *)
 let failure_disposition = function
-  | Transient_spawn_failed -> Transient
+  | Transient_spawn_failed | Owner_stopped_turn -> Transient
   | Transport_interrupted
   | Protocol_failed
   | Host_hook_failed
@@ -339,6 +346,7 @@ let settlement_opt_of_yojson = function
 
 let recovery_failure_to_string = function
   | Transient_spawn_failed -> "transient_spawn_failed"
+  | Owner_stopped_turn -> "owner_stopped_turn"
   | Transport_interrupted -> "transport_interrupted"
   | Protocol_failed -> "protocol_failed"
   | Provider_rejected -> "provider_rejected"
@@ -349,6 +357,7 @@ let recovery_failure_to_string = function
 
 let recovery_failure_of_string = function
   | "transient_spawn_failed" -> Ok Transient_spawn_failed
+  | "owner_stopped_turn" -> Ok Owner_stopped_turn
   | "transport_interrupted" -> Ok Transport_interrupted
   | "protocol_failed" -> Ok Protocol_failed
   | "provider_rejected" -> Ok Provider_rejected

--- a/lib/keeper/keeper_official_client_session_store.mli
+++ b/lib/keeper/keeper_official_client_session_store.mli
@@ -17,6 +17,7 @@ type settlement =
 
 type recovery_failure =
   | Transient_spawn_failed
+  | Owner_stopped_turn
   | Transport_interrupted
   | Protocol_failed
   | Provider_rejected

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -172,7 +172,9 @@ type _ command =
 type packed_command =
   | Command : 'response command * 'response Eio.Promise.u -> packed_command
 
-exception Stop_active_child
+(* Declared in Keeper_owner_signals so the runtime adapters can match it
+   without depending on this module; see #28012. *)
+exception Stop_active_child = Keeper_owner_signals.Stop_active_child
 
 type t =
   { keeper_name : string

--- a/lib/keeper/keeper_owner_signals.ml
+++ b/lib/keeper/keeper_owner_signals.ml
@@ -1,0 +1,18 @@
+(** Signals the Keeper owner raises into a turn, readable by the runtime
+    adapters that observe them.
+
+    [Keeper_owner] calls the adapters, so the adapters cannot reference it back.
+    That left them unable to tell a cancellation they caused from one they did
+    not: every [Eio.Cancel.Cancelled] was recorded as [Transport_interrupted],
+    which is [Ambiguous], which sends the official-client session to
+    [Recovery_required] -- and that blocks every later turn for the keeper until
+    an operator resolves it by hand (#28012).
+
+    An exception carries no dependencies, so a module holding only this one can
+    sit below both without inverting anything. The alternative was matching on
+    [Printexc.to_string], which is the classifier shape #26770 removed. *)
+
+(** The owner stopped a turn it had started. Not an ambiguity: the owner knows
+    the turn did not complete and knows why, and classifies it as
+    [Turn_cancelled] on the operation side. *)
+exception Stop_active_child

--- a/lib/keeper/keeper_owner_signals.mli
+++ b/lib/keeper/keeper_owner_signals.mli
@@ -1,0 +1,7 @@
+(** Signals the Keeper owner raises into a turn, readable by runtime adapters.
+
+    See the implementation for why this module exists separately from
+    [Keeper_owner]: the owner calls the adapters, so they cannot depend on it,
+    and an exception declaration depends on nothing. *)
+
+exception Stop_active_child

--- a/lib/server/server_dashboard_official_client_session.ml
+++ b/lib/server/server_dashboard_official_client_session.ml
@@ -23,6 +23,7 @@ let client_kind_to_string = function
 let failure_to_string = function
   | Keeper_official_client_session_store.Transient_spawn_failed ->
     "transient_spawn_failed"
+  | Owner_stopped_turn -> "owner_stopped_turn"
   | Transport_interrupted -> "transport_interrupted"
   | Protocol_failed -> "protocol_failed"
   | Provider_rejected -> "provider_rejected"

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -295,6 +295,28 @@ let test_moved_tool_surface_starts_fresh () =
     | Error detail -> fail ("claim after a moved surface must succeed: " ^ detail))
 ;;
 
+(* A stop the owner raised is not an ambiguity. Recovery exists to get an
+   operator's judgement on what a crash left behind; the owner knows the turn
+   did not finish and why, and already classifies the operation as
+   Turn_cancelled. Routing it to Recovery_required blocked every later turn for
+   that keeper until someone resolved it by hand -- kidsnote re-entered three
+   minutes after being cleared (#28012). *)
+let test_owner_stop_releases_without_recovery () =
+  check bool
+    "owner stop is transient"
+    true
+    (failure_disposition Owner_stopped_turn = Transient);
+  (* Control: an unexplained cancellation still needs an operator, so this
+     cannot pass by making every failure transient. *)
+  check bool
+    "unexplained transport interruption stays ambiguous"
+    true
+    (failure_disposition Transport_interrupted = Ambiguous);
+  (* The wire codec is not exported, so the round trip is covered where it is
+     reachable rather than asserted here. *)
+  ()
+;;
+
 let test_terminal_identity_switch_starts_fresh () =
   with_workspace "masc-official-client-store-switch-" (fun base_path ->
     let keeper_name = "switch" in
@@ -744,6 +766,10 @@ let () =
             "duplicate claim and CAS fail closed"
             `Quick
             test_duplicate_claim_and_cas_are_fail_closed
+        ; test_case
+            "owner stop releases without recovery"
+            `Quick
+            test_owner_stop_releases_without_recovery
         ; test_case
             "moved tool surface starts fresh"
             `Quick


### PR DESCRIPTION
Closes #28012

## 우리가 멈춘 턴이 운영자 개입을 요구했습니다

어댑터에 도달하는 **모든** `Eio.Cancel.Cancelled` 가 `Transport_interrupted` 로 기록되고, 그건 `Ambiguous` 이며, 세션을 `Recovery_required` 로 보냅니다. 그 상태는 **설계상 자동 해소되지 않습니다** — 크래시가 provider·tool 효과를 남겼을 수 있어 운영자만 판단할 수 있기 때문입니다.

그래서 그 키퍼의 이후 모든 턴이 `official_client_session.claim` 에서 실패합니다.

**`Stop_active_child` 는 그런 경우가 아닙니다.** owner 가 직접 올리고, 직접 잡고, 이미 operation 을 `Turn_cancelled` 로 분류합니다:

```ocaml
(* keeper_owner.ml:532 *)
| Stop_active_child ->
  Operation_failed { kind = Turn_cancelled
                   ; detail = "Keeper owner stopped the active turn" ; ... }
```

**판단할 모호성이 없습니다** — 턴이 안 끝났다는 것도, 그 이유도 우리가 압니다.

라이브 kidsnote 가 해소 **3분 만에** 이 사유로 재진입했고, 6시간 동안 세 키퍼가 서로 다른 recovery id **14개**를 쌓았습니다.

## 어댑터가 둘을 구별할 수 없었습니다

```
$ git grep -c "Keeper_owner" lib/keeper/keeper_{claude_code,codex,antigravity}_runtime.ml
(0건)
$ git grep -n "exception Stop_active_child" lib/
lib/keeper/keeper_owner.ml:175
```

owner 가 어댑터를 호출하므로 어댑터가 owner 를 참조하면 **역방향 의존**입니다. 그리고 `Printexc.to_string` 매칭은 **#26770 에서 걷어낸 분류기 형태**입니다.

**예외는 아무것에도 의존하지 않습니다.** `Keeper_owner_signals` 가 선언만 담고 양쪽 아래에 앉으므로 방향이 뒤집히지 않습니다. `Keeper_owner` 는 그것을 alias 해서 자기 raise·catch 지점은 그대로입니다:

```ocaml
exception Stop_active_child = Keeper_owner_signals.Stop_active_child
```

## Transient 로 분류합니다

`Owner_stopped_turn` 이 `recovery_failure` 에 합류하고 `Transient` 가 됩니다 → `release_transient`, 즉 **판단이 필요 없는 실패를 위해 이미 존재하는 경로**입니다.

컴파일러가 대시보드의 wire 코덱을 찾아냈습니다 — 이 어휘를 닫아둔 이유가 그것입니다.

## 검증

```
$ dune build @check                                              exit=0
$ dune build @test/runtest-test_official_client_session_store    10 tests, Successful
$ dune build @test/runtest-test_keeper_claude_code_runtime        1 test,  Successful
$ dune build @test/runtest-test_keeper_antigravity_runtime        7 tests, Successful
```

**뮤테이션** — `Owner_stopped_turn` 을 다시 `Ambiguous` 쪽에 두면 새 테스트가 `owner stop is transient` 에서 실패합니다.

**대조군** — *설명되지 않은* `Transport_interrupted` 는 여전히 `Ambiguous` 여야 한다는 단언을 같은 테스트에 넣었습니다. 이게 없으면 "모든 실패를 transient 로" 만들어도 통과합니다.

## 범위

`Recovery_required` 의 원래 취지 — **재시작 후 발견된 임차의 모호성** — 는 그대로입니다. 바뀌는 건 우리가 이유를 아는 중단 하나뿐입니다.

RFC-WAIVED: 취소 분류 1개 변형 추가 + 예외 선언 위치 이동. credential/identity/operator/sandbox/hooks 및 `lib/repo_manager/` 를 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
