### PR TITLE
Auto-supersede failed official client sessions

### DIFF
--- a/dashboard/src/components/official-client-session-panel.ts
+++ b/dashboard/src/components/official-client-session-panel.ts
@@ -169,7 +169,7 @@ export function OfficialClientSessionPanel() {
             ? html`
               <div class="mt-4 rounded-[var(--r-1)] border border-[var(--danger-20)] bg-[var(--danger-10)] p-3" data-testid="official-client-session-recovery-required">
                 <div class="flex flex-wrap items-center gap-2 mb-2">
-                  <${StatusChip} tone="bad" uppercase=${false}>operator resolution required<//>
+                  <${StatusChip} tone="warn" uppercase=${false}>next turn auto-recovers<//>
                   <span class="mono text-2xs">${recovery.recovery_id}</span>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs mb-3">

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -715,6 +715,10 @@ let plan_claim ~expected ~client_kind ~runtime_id =
       when binding.client_kind <> client_kind
            || not (String.equal binding.runtime_id runtime_id) ->
       Ok (None, 1, None)
+    | Some ({ phase = Recovery_required _; _ } as binding)
+      when binding.client_kind <> client_kind
+           || not (String.equal binding.runtime_id runtime_id) ->
+      Ok (None, 1, None)
     | Some
         { phase = Settled settlement
         ; turn_count
@@ -731,11 +735,16 @@ let plan_claim ~expected ~client_kind ~runtime_id =
       Error "official-client session has an active unsettled attempt; refusing duplicate execution"
     | Some { phase = Turn_inflight _; _ } ->
       Error "official-client session has an in-flight turn; refusing duplicate execution"
-    | Some { phase = Recovery_required recovery; _ } ->
-      Error
-        (Printf.sprintf
-           "official-client session recovery %s must be resolved before another execution"
-           recovery.recovery_id)
+    | Some
+        { phase = Recovery_required recovery
+        ; turn_count
+        ; tool_surface_sha256
+        ; _
+        } ->
+      Ok
+        ( recovery.previous_settlement
+        , turn_count
+        , Option.map (fun _ -> tool_surface_sha256) recovery.previous_settlement )
   in
   Ok { previous_settlement; turn_count; required_tool_surface_sha256 }
 ;;
@@ -753,19 +762,31 @@ let claim ~base_path ~keeper_name ~expected ~client_kind ~owner_epoch ~runtime_i
   let last_recovery_resolution =
     Option.bind expected (fun binding -> binding.last_recovery_resolution)
   in
-  transition
-    ~base_path
-    ~keeper_name
-    ~expected
-    { client_kind
-    ; runtime_id
-    ; phase = Start { owner_epoch; previous_settlement = plan.previous_settlement }
-    ; turn_count = plan.turn_count
-    ; tool_surface_sha256
-    ; last_recovery_resolution
-    ; last_transient_release = Option.bind expected (fun binding -> binding.last_transient_release)
-    ; updated_at
-    }
+  let* claimed =
+    transition
+      ~base_path
+      ~keeper_name
+      ~expected
+      { client_kind
+      ; runtime_id
+      ; phase = Start { owner_epoch; previous_settlement = plan.previous_settlement }
+      ; turn_count = plan.turn_count
+      ; tool_surface_sha256
+      ; last_recovery_resolution
+      ; last_transient_release = Option.bind expected (fun binding -> binding.last_transient_release)
+      ; updated_at
+      }
+  in
+  (match expected with
+   | Some { phase = Recovery_required recovery; _ } ->
+     Log.Keeper.info
+       ~keeper_name
+       "auto-superseded official-client recovery=%s failure=%s owner_epoch=%s"
+       recovery.recovery_id
+       (recovery_failure_to_string recovery.failure)
+       owner_epoch
+   | Some _ | None -> ());
+  Ok claimed
 ;;
 
 let mark_active ~base_path ~keeper_name ~expected ~session_id ~updated_at =

--- a/lib/keeper/keeper_official_client_session_store.mli
+++ b/lib/keeper/keeper_official_client_session_store.mli
@@ -148,8 +148,10 @@ val claim :
   (t, string) result
 (** Claim the next exact turn. A terminal binding may start fresh when its
     declared client kind or runtime id changes. Resuming the same settled
-    client/runtime requires an identical tool surface. Incomplete and recovery
-    phases always reject another claim regardless of configuration changes. *)
+    client/runtime requires an identical tool surface. A same-process Start,
+    Active, or Turn_inflight phase rejects a concurrent claim. A completed
+    failure observation is superseded atomically by the next claim and never
+    requires operator resolution before execution. *)
 
 val mark_active :
   base_path:string ->
@@ -193,8 +195,9 @@ val require_recovery :
   detail:string ->
   required_at:float ->
   (t, string) result
-(** Convert the exact incomplete claim into an explicit operator-visible
-    recovery state. This never retries or clears a possibly executed turn. *)
+(** Convert the exact incomplete claim into an operator-visible failure
+    observation. The next claim may supersede it atomically; an operator may
+    still resolve it first to choose the previous settlement or a fresh start. *)
 
 val release_transient :
   base_path:string ->

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -307,47 +307,33 @@ let test_restart_recovery_and_transient_release () =
         ~required_at:3.0
       |> Result.get_ok
     in
-    let recovery_id =
-      match recovery.phase with
-      | Recovery_required required ->
-        check bool "restart class" true (required.failure = Process_restarted);
-        check bool "ambiguous" true (failure_disposition required.failure = Ambiguous);
-        check string "claim epoch" owner_epoch required.owner_epoch;
-        required.recovery_id
-      | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
-        fail "old process claim did not enter recovery"
-    in
-    let ready, application =
-      resolve_recovery
-        ~base_path
-        ~keeper_name
-        ~expected:recovery
-        ~recovery_id
-        ~resolution:Restart_fresh
-        ~resolved_by:"operator"
-        ~resolved_at:4.0
-      |> Result.get_ok
-    in
-    check bool "recovery applied" true (application = Applied);
+    (match recovery.phase with
+     | Recovery_required required ->
+       check bool "restart class" true (required.failure = Process_restarted);
+       check bool "ambiguous" true (failure_disposition required.failure = Ambiguous);
+       check string "claim epoch" owner_epoch required.owner_epoch
+     | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+       fail "old process claim did not enter recovery");
     let reclaimed =
       claim
         ~base_path
         ~keeper_name
-        ~expected:(Some ready)
+        ~expected:(Some recovery)
         ~client_kind:Antigravity
         ~owner_epoch:next_owner_epoch
         ~runtime_id:"antigravity.gemini"
         ~tool_surface_sha256:empty_surface
-        ~updated_at:5.0
+        ~updated_at:4.0
       |> Result.get_ok
     in
+    check int "recovery claim reuses failed turn ordinal" 1 reclaimed.turn_count;
     let released =
       release_transient
         ~base_path
         ~keeper_name
         ~expected:reclaimed
         ~failure:Transient_spawn_failed
-        ~released_at:6.0
+        ~released_at:5.0
       |> Result.get_ok
     in
     check int "transient does not count" 0 released.turn_count;

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -1052,19 +1052,17 @@ let test_keeper_protocol_failure_enters_recovery () =
                check (option string) "no observed session" None required.observed_session_id
              | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
                fail "failed Codex runtime claim was not converted to recovery-required");
-            (match
-               run_keeper_turn
-                 ~base_path
-                 ~cli_path
-                 ~model:"gpt-fixture"
-                 ()
-             with
-             | Error
-                 (Agent_core.Error.Config
-                   (Agent_core.Error.InvalidConfig { field; _ })) ->
-               check string "recovery gate field" "official_client_session.claim" field
-             | Error error -> fail (Agent_core.Error.to_string error)
-             | Ok _ -> fail "unresolved Codex recovery admitted a duplicate turn")))
+            let next_claim =
+              Keeper_official_client_session_store.plan_claim
+                ~expected:(Some recovery)
+                ~client_kind:Codex
+                ~runtime_id:recovery.runtime_id
+              |> Result.get_ok
+            in
+            check int
+              "failed turn ordinal is reused without an operator gate"
+              recovery.turn_count
+              next_claim.turn_count))
 ;;
 
 let test_dashboard_official_client_recovery_projection_and_resolution () =


### PR DESCRIPTION
## Summary

- allow the next official-client claim to atomically supersede a completed `Recovery_required` observation
- reuse the failed turn ordinal and resume the previous settled session when one exists
- start fresh when the runtime/client identity changed or no previous settlement exists
- keep `Start`, `Active`, and `Turn_inflight` as the only duplicate-execution conflicts
- update the session-store contract, Codex/store regression fixtures, and Dashboard wording

## Root cause

`plan_claim` treated every durable `Recovery_required` record as an operator gate. An ordinary protocol, transport, provider, hook, persistence, or process-restart failure therefore blocked every later Keeper turn until a human selected `retry_previous` or `restart_fresh`.

The failed runtime invocation has already returned before the next serialized Keeper turn. The durable failure observation is not proof of a concurrent execution, so requiring manual settlement made recovery availability depend on an unrelated operator action.

## Behavior

The next claim uses the existing filesystem lock and exact expected-state CAS to replace the recovery observation with its new `Start` owner. It preserves a previous settled session when available and otherwise starts fresh. Manual recovery resolution remains an optional immediate operator action, not an execution prerequisite.

No timeout, threshold, admission rule, provider fallback, or new gate is added.

## Measured evidence

- `test_official_client_session_store.exe`: 8/8 passed
- `test_runtime_codex_app_server.exe`: 32/32 passed, 7 explicit live-subscription fixtures skipped by their existing opt-in contract
- `official-client-session-panel.test.ts`: 2/2 passed

Live runtime validation is not claimed because this source has not been built and deployed to the running MASC process.
