### PR TITLE
feat(fusion): run panelists on official-client runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,6 +857,16 @@ jobs:
           opam exec -- dune exec --root . test/test_workspace_coverage.exe -- test revision
           opam exec -- dune exec --root . test/test_workspace_coverage.exe -- test claim_next
 
+      - name: Run fusion official-client panel routing suite
+        # @check compiles this suite but never runs it, and its whole point is
+        # a wiring assertion: the execution case spawns a stub client and fails
+        # if the panelist never reached it. Compiled-but-unrun, it would keep
+        # passing with the split deleted from fusion_panel.ml — which is the
+        # regression it exists to catch.
+        # See: test/test_fusion_official_client_panel.ml.
+        run: |
+          opam exec -- dune build --root . @test/runtest-test_fusion_official_client_panel
+
       - name: Run MCP authentication contract suites
         # @check compiles these suites but never runs them. Exercise both the
         # dual-auth admission path and the typed HTTP/JSON-RPC auth envelope so

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -149,8 +149,10 @@ let print_judge_arm ~(tag : string)
       , u.Fusion_types.input_tokens
       , u.Fusion_types.output_tokens )
 
-let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.preset)
-    ~(prompt : string) ~(config_path : string) : unit =
+let run_harness ~sw ~net ~(base_path : string) ~(policy : Fusion_policy.t)
+    ~(preset : Fusion_policy.preset) ~(prompt : string) ~(config_path : string)
+  : unit
+  =
   let models_all = Fusion_policy.preset_models preset in
   let n = List.length models_all in
   (* 하네스는 동질 arm 비교 도구다(RFC-0252 §11). 이종 preset이면 첫 그룹의 plumbing
@@ -174,6 +176,7 @@ let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.pr
   let run_panel ~models =
     let groups = [ { g0 with Fusion_policy.models } ] in
     Masc.Fusion_panel.run
+      ~base_dir:base_path
       ~sw
       ~net
       ~groups
@@ -417,4 +420,4 @@ let () =
        (* RFC-0280: find_preset가 검증된 preset을 돌려준다. 하네스는 raw preset으로
           coerce해 arm을 구성한다(read-only). *)
        let preset = Fusion_policy.Validated_preset.preset vp in
-       run_harness ~sw ~net ~policy ~preset ~prompt ~config_path)
+       run_harness ~sw ~net ~base_path ~policy ~preset ~prompt ~config_path)

--- a/lib/fusion/fusion_official_client.ml
+++ b/lib/fusion/fusion_official_client.ml
@@ -1,0 +1,129 @@
+(* Execution path for fusion panelists on official-client runtimes. See the
+   .mli for why this exists. *)
+
+let runtime_execution ~runtime_id =
+  match Runtime.get_runtime_by_id runtime_id with
+  | None -> None
+  | Some runtime -> Some runtime.Runtime.execution
+;;
+
+let is_official_client ~runtime_id =
+  match runtime_execution ~runtime_id with
+  | None -> false
+  | Some execution ->
+    (match Runtime_execution.checkpoint_owner execution with
+     | Runtime_execution.Official_client -> true
+     | Runtime_execution.Masc_agent_core -> false)
+;;
+
+(* Attribution matters here: a panel outcome carries the failure back to the
+   operator, and "provider error" without a runtime sends them to the wrong
+   place. Every message names the runtime it came from. *)
+let provider_error ~runtime_id detail : Fusion_types.panel_failure =
+  Fusion_types.Provider_error (Printf.sprintf "%s: %s" runtime_id detail)
+;;
+
+let eio_context ~runtime_id =
+  match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
+  | Some env, Some clock -> Ok (env, clock)
+  | None, _ | _, None ->
+    Error
+      (provider_error
+         ~runtime_id
+         "official-client panelist requires the initialized Eio runtime")
+;;
+
+(* [Runtime_execution.*] carries admission-time config; each adapter has its own
+   config record. The conversions below mirror the keeper path exactly
+   (keeper_claude_code_runtime.ml:224, keeper_antigravity_runtime.ml:241) so a
+   panelist runs the same client the keeper would, minus the parts a panelist
+   has no business using. *)
+
+let claude_config ~base_dir ~system_prompt (execution : Runtime_execution.claude_code)
+  : Runtime_claude_code.config
+  =
+  { cli_path = execution.cli_path
+  ; cwd = base_dir
+  ; model = execution.model
+  ; system_prompt
+  ; timeout_s = execution.timeout_s
+  }
+;;
+
+let codex_config ~system_prompt (execution : Runtime_execution.codex_app_server)
+  : Runtime_codex_app_server.config
+  =
+  { cli_path = execution.cli_path
+  ; model = execution.model
+  ; developer_instructions = system_prompt
+  ; timeout_s = execution.timeout_s
+  }
+;;
+
+let antigravity_config ~base_dir (execution : Runtime_execution.antigravity_cli)
+  : Runtime_antigravity.config
+  =
+  { cli_path = execution.cli_path
+  ; cwd = base_dir
+  ; model = execution.model
+  ; agent = execution.agent
+  ; effort = execution.effort
+  ; (* A panelist answers a question; it does not edit the workspace. Plan mode
+       plus the sandbox is the same pair the keeper path uses, and it is the
+       correct pair here for a stronger reason: nothing downstream of a panel
+       answer expects files to have changed. *)
+    execution_mode = Runtime_antigravity.Plan
+  ; sandbox = true
+  ; disable_slash_commands = true
+  ; timeout_s = execution.timeout_s
+  }
+;;
+
+let run_panelist ~base_dir ~runtime_id ~system_prompt ~prompt =
+  let ( let* ) = Result.bind in
+  (* Both adapters take the system prompt as an option and treat [None] as
+     "client default". An empty group prompt is not an instruction, so it
+     becomes [None] rather than an empty instruction the client must obey. *)
+  let system_prompt =
+    match String.trim system_prompt with "" -> None | text -> Some text
+  in
+  let* execution =
+    match runtime_execution ~runtime_id with
+    | Some execution -> Ok execution
+    | None -> Error (provider_error ~runtime_id "runtime is not configured")
+  in
+  let* env, clock = eio_context ~runtime_id in
+  let mgr = Eio.Stdenv.process_mgr env in
+  let cwd = Eio.Path.(Eio.Stdenv.fs env / base_dir) in
+  match execution with
+  | Runtime_execution.Agent_core _ ->
+    (* Callers route Agent_core panelists through Fusion_agent_core. Reaching
+       here means the split in Fusion_panel disagreed with [is_official_client],
+       which is a bug in this module's callers rather than a provider failure. *)
+    Error
+      (provider_error
+         ~runtime_id
+         "runtime is Agent_core-owned; it belongs on the Async_agent path")
+  | Runtime_execution.Claude_code execution ->
+    let config = claude_config ~base_dir ~system_prompt execution in
+    (match Runtime_claude_code.run_turn ~mgr ~clock ~cwd config ~prompt with
+     | Ok (result : Runtime_claude_code.turn_result) -> Ok result.text
+     | Error error ->
+       Error (provider_error ~runtime_id (Runtime_claude_code.error_to_string error)))
+  | Runtime_execution.Codex_app_server execution ->
+    let config = codex_config ~system_prompt execution in
+    (match Runtime_codex_app_server.run_turn ~mgr ~clock ~cwd config ~prompt with
+     | Ok (result : Runtime_codex_app_server.turn_result) -> Ok result.text
+     | Error error ->
+       Error
+         (provider_error ~runtime_id (Runtime_codex_app_server.error_to_string error)))
+  | Runtime_execution.Antigravity_cli execution ->
+    let config = antigravity_config ~base_dir execution in
+    (* [home_dir] is left unset so the client uses the inherited HOME, which is
+       where its OAuth token already lives. The keeper path overrides it for
+       per-keeper isolation; a panelist has no durable state to isolate. *)
+    (match Runtime_antigravity.run_turn ~mgr ~clock ~cwd config ~prompt with
+     | Ok (result : Runtime_antigravity.turn_result) -> Ok result.text
+     | Error error ->
+       Error (provider_error ~runtime_id (Runtime_antigravity.error_to_string error)))
+;;

--- a/lib/fusion/fusion_official_client.mli
+++ b/lib/fusion/fusion_official_client.mli
@@ -1,0 +1,36 @@
+(** Run one fusion panelist on an official-client runtime.
+
+    Fusion panels are fanned out through {!Agent_core.Async_agent.all}, which
+    can only drive [Runtime_execution.Agent_core] runtimes. A panelist naming a
+    Claude Code / Codex / Antigravity runtime therefore never produced an answer:
+    a panel made only of them ended in [Panels_unavailable], and a mixed panel
+    completed on quorum while those panelists silently contributed nothing.
+
+    This module is the missing execution path. It runs a panelist as a
+    stateless one-shot turn — no session resume, no dynamic tools — because a
+    panelist answers a question and does not act. *)
+
+val is_official_client : runtime_id:string -> bool
+(** Whether [runtime_id] resolves to an official-client runtime, i.e. one that
+    {!Fusion_agent_core.build_agent} cannot build an agent for. [false] for an
+    unknown id: an id that resolves to nothing is not this module's failure to
+    report, and the Agent_core path already names it precisely. *)
+
+val run_panelist
+  :  base_dir:string
+  -> runtime_id:string
+  -> system_prompt:string
+  -> prompt:string
+  -> (string, Fusion_types.panel_failure) result
+(** Execute [prompt] as a single turn on [runtime_id] and return the answer text.
+
+    [base_dir] is the directory the official client is spawned in. There is no
+    global accessor for the MASC base path, so callers thread it down from
+    {!Fusion_tool.handle}, which already receives it.
+
+    Requires the initialized Eio runtime: the process manager and clock come
+    from {!Eio_context}, the same way the official-client login probe obtains
+    them, so no fusion signature has to thread them through.
+
+    Timeouts stay owned by each adapter's own configuration; this module adds no
+    second deadline, so a panel-level timeout still bounds the whole fan-out. *)

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -5,7 +5,7 @@ type compute_outcome =
   | Compute_denied of Fusion_types.deny_reason
   | Computed of Fusion_types.deliberation_evidence
 
-let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
+let compute ~base_dir ~sw ~net ~policy ~topology ~request () : compute_outcome =
   match Fusion_policy.decide ~policy request with
   | Fusion_types.Deny reason ->
     Fusion_metrics.record_invocation ~topology `Denied;
@@ -27,7 +27,7 @@ let compute ~sw ~net ~policy ~topology ~request () : compute_outcome =
               groups
           in
           let panel =
-            Fusion_panel.run ~sw ~net
+            Fusion_panel.run ~base_dir ~sw ~net
               ~groups:effective_groups ~prompt:req.Fusion_types.prompt ()
           in
           let judge_web_tools =

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -15,7 +15,8 @@ type compute_outcome =
     projection. The caller can durably claim the semantic terminal before
     passing a [Computed] value to {!project}. *)
 val compute
-  :  sw:Eio.Switch.t
+  :  base_dir:string
+  -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> policy:Fusion_policy.t
   -> topology:Fusion_types.fusion_topology

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -66,34 +66,46 @@ let bridge_failure_of_error (error : Agent_core.Error.t) : Fusion_types.panel_fa
   | Agent_core.Error.Provider (Llm_provider.Error.Timeout _) -> Fusion_types.Timeout
   | _ -> Fusion_types.Bridge_error (Agent_core.Error.to_string error)
 
-let run ~sw ~net ~groups ~prompt ()
+let run ~base_dir ~sw ~net ~groups ~prompt ()
   : Fusion_types.panel_outcome list
   =
   (* 1. 각 그룹의 모델을 그 그룹 설정(system_prompt/tools/timeout)으로
         에이전트 빌드. 빌드 실패는 격리. 그룹순 × 그룹내 모델순으로 평탄화 —
         순서 보존(단일 그룹이면 원 모델 순서 = 오늘과 동일). *)
-  let built, build_failures =
+  let built, official, build_failures =
     List.fold_left
       (fun acc (g : Fusion_policy.panel_group) ->
         let tools = if g.web_tools then Fusion_agent_core.web_tool_bundle () else [] in
         List.fold_left
-          (fun (oks, fails) model ->
+          (fun (oks, officials, fails) model ->
             (* 정체성은 그룹 라벨 + model로 derive. 카드명(=정체성)으로 빌드하되 provider
                라우팅은 build_agent 내부에서 원 model로 한다 (RFC-0278). *)
             let panelist = Fusion_policy.panelist_id ~label:g.label ~model in
-            match
-              Fusion_agent_core.build_agent ~sw ~net ~system_prompt:g.system_prompt ~tools
-                ?max_tokens:g.max_output_tokens
-                ~name:panelist model
-            with
-            | Ok agent -> ((agent, panelist, model) :: oks, fails)
-            | Error reason ->
-              (oks, Fusion_types.Failed { failed_model = panelist; reason } :: fails))
+            (* official-client 런타임은 spawn 프로세스라 Agent_core agent 가 될 수
+               없다. [build_agent] 는 이들에서 provider 해석 단계에 실패하므로,
+               이전에는 패널리스트가 답을 낼 기회 자체가 없었다 — 전원이 그쪽이면
+               [Panels_unavailable], 섞이면 정족수로 완료되면서 그 자리는 조용히
+               비었다. 여기서 갈라 별도 실행 경로로 보낸다. *)
+            if Fusion_official_client.is_official_client ~runtime_id:model
+            then (oks, (panelist, model, g.system_prompt) :: officials, fails)
+            else (
+              match
+                Fusion_agent_core.build_agent ~sw ~net ~system_prompt:g.system_prompt
+                  ~tools
+                  ?max_tokens:g.max_output_tokens
+                  ~name:panelist model
+              with
+              | Ok agent -> ((agent, panelist, model) :: oks, officials, fails)
+              | Error reason ->
+                ( oks
+                , officials
+                , Fusion_types.Failed { failed_model = panelist; reason } :: fails )))
           acc g.models)
-      ([], [])
+      ([], [], [])
       groups
   in
   let built = List.rev built in
+  let official = List.rev official in
   let build_failures = List.rev build_failures in
   (* 2. 모든 그룹을 하나의 Async_agent.all에 union으로 던진다 — 이종 설정은 이미 각
         agent에 baked되어 있으므로 단일 fan-out으로 충분. [run_safe]는 예외/취소
@@ -123,7 +135,36 @@ let run ~sw ~net ~groups ~prompt ()
           Fusion_types.Failed { failed_model = panelist; reason })
         built
   in
-  build_failures @ answered
+  (* official-client 패널리스트는 Agent_core fan-out 과 동시에 돈다. 각 어댑터가
+     자기 timeout 을 소유하므로 여기서 두 번째 데드라인을 걸지 않는다 —
+     [Async_agent.all] 쪽과 같은 규약이다.
+
+     usage 는 [zero_usage] 다. 공식 클라이언트는 토큰 회계를 돌려주지 않으므로,
+     추정치를 지어내는 대신 "측정하지 않음" 을 0 으로 남긴다. *)
+  let official_answered =
+    Eio.Fiber.List.map
+      (fun (panelist, model, system_prompt) ->
+        match
+          Fusion_official_client.run_panelist ~base_dir ~runtime_id:model ~system_prompt
+            ~prompt
+        with
+        | Error reason -> Fusion_types.Failed { failed_model = panelist; reason }
+        | Ok text ->
+          let answer = String.trim text in
+          if String.length answer = 0
+          then
+            Fusion_types.Failed
+              { failed_model = panelist
+              ; reason =
+                  Fusion_types.Empty_response
+                    (model ^ ": official client returned no text")
+              }
+          else
+            Fusion_types.Answered
+              { model = panelist; answer; usage = Fusion_types.zero_usage })
+      official
+  in
+  build_failures @ answered @ official_answered
 
 module For_testing = struct
   let outcome_of_result = outcome_of_result

--- a/lib/fusion/fusion_panel.mli
+++ b/lib/fusion/fusion_panel.mli
@@ -26,7 +26,8 @@
     - 빌드 실패·실행 실패·빈 응답은 [Failed]로 격리되어 다른 패널을 죽이지 않는다.
     - 반환 순서: 빌드 실패분 먼저, 그 다음 실행 결과(그룹순 × 그룹내 모델순). *)
 val run
-  :  sw:Eio.Switch.t
+  :  base_dir:string
+  -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> groups:Fusion_policy.panel_group list
   -> prompt:string

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -150,7 +150,11 @@ let handle_with_compute_result ~compute ~sw ~net ~base_dir ~keeper ~now_unix
 
 let handle_result ~sw ~net ~base_dir ~keeper ~now_unix ~policy ?continuation_channel
       ~args () =
-  handle_with_compute_result ~compute:Fusion_orchestrator.compute ~sw ~net ~base_dir
+  (* base_dir 를 여기서 부분 적용한다. [compute_runner] 계약을 넓히지 않으면서
+     official-client 패널리스트가 spawn 될 디렉터리를 orchestrator 아래로
+     내려보내는 유일한 지점이다 — MASC base path 에는 전역 접근자가 없다. *)
+  handle_with_compute_result ~compute:(Fusion_orchestrator.compute ~base_dir) ~sw
+    ~net ~base_dir
     ~keeper ~now_unix ~policy ?continuation_channel ~args ()
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -798,6 +798,20 @@
  (modules test_fusion_judge_usage)
  (libraries masc_test_deps masc.fusion_core))
 
+; Panel routing for official-client runtimes. Needs the full masc library
+; (not just fusion_core) because the predicate reads Runtime/Runtime_execution.
+
+(test
+ (name test_fusion_official_client_panel)
+ (modules test_fusion_official_client_panel)
+ (libraries
+  masc_test_deps
+  masc
+  masc.runtime
+  masc.fusion_core
+  masc.masc_eio_context
+  eio_main))
+
 ; RFC-0284 — Fusion deliberation OTel metrics: label wiring + counter emission.
 
 (test

--- a/test/test_fusion_official_client_panel.ml
+++ b/test/test_fusion_official_client_panel.ml
@@ -1,0 +1,183 @@
+open Alcotest
+
+(* The panel split in Fusion_panel keys entirely on [is_official_client]: a true
+   sends the panelist to the spawn path, a false sends it to build_agent. Before
+   this existed, official-client panelists reached build_agent, failed provider
+   resolution, and never answered — a panel made only of them ended in
+   Panels_unavailable, and a mixed panel completed on quorum with those seats
+   silently empty.
+
+   Pinning the predicate alone would not notice the split being dropped from
+   fusion_panel.ml, so the last test drives Fusion_panel.run for real and judges
+   by whether the client process was spawned, not by what the error said.
+
+   The repo seed has its claude_code provider commented out, so the fixture
+   declares its own rather than asserting against a config that happens not to
+   have one today. *)
+
+let fixture ~claude_cli =
+  Printf.sprintf
+    {|
+[runtime]
+default = "stub-http.stub-model"
+
+[providers.stub-http]
+display-name = "Stub HTTP"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:9/v1"
+
+[providers.claude_code]
+display-name = "Claude Code Max Subscription"
+protocol = "claude-code"
+command = "%s"
+is-non-interactive = true
+
+[models.stub-model]
+api-name = "gpt-5.4"
+max-context = 200000
+tools-support = true
+streaming = true
+
+[stub-http.stub-model]
+
+[models."claude-sonnet-5"]
+api-name = "claude-sonnet-5"
+max-context = 1000000
+tools-support = true
+streaming = true
+
+[claude_code."claude-sonnet-5"]
+|}
+    claude_cli
+;;
+
+let official_client_runtime = "claude_code.claude-sonnet-5"
+let agent_core_runtime = "stub-http.stub-model"
+
+let write_file ~path ~perm contents =
+  let channel = open_out_gen [ Open_creat; Open_trunc; Open_wronly ] perm path in
+  Fun.protect
+    ~finally:(fun () -> close_out channel)
+    (fun () -> output_string channel contents)
+;;
+
+(* A stand-in for the Claude Code CLI that records the fact of its own execution
+   and nothing else. The marker path is baked into the script because the claude
+   adapter runs the client under a restricted environment allowlist, so a value
+   passed through the environment would not survive to the child. *)
+let stub_cli_script ~marker = Printf.sprintf "#!/bin/sh\n: > '%s'\nexit 0\n" marker
+
+let with_initialized_runtime ~claude_cli f =
+  let path = Filename.temp_file "fusion-official-client" ".toml" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+       write_file ~path ~perm:0o600 (fixture ~claude_cli);
+       match Runtime.init_default ~config_path:path with
+       | Error detail -> failf "fixture runtime must initialize: %s" detail
+       | Ok () -> f ())
+;;
+
+(* /usr/bin/true is enough for the tests that only read the runtime table: they
+   classify a runtime without executing it. *)
+let with_classification_runtime f = with_initialized_runtime ~claude_cli:"/usr/bin/true" f
+
+let test_official_client_runtime_is_routed_to_the_spawn_path () =
+  with_classification_runtime (fun () ->
+    check
+      bool
+      "a claude-code binding is an official-client panelist"
+      true
+      (Masc.Fusion_official_client.is_official_client ~runtime_id:official_client_runtime))
+;;
+
+let test_agent_core_runtime_stays_on_the_async_agent_path () =
+  with_classification_runtime (fun () ->
+    check
+      bool
+      "an HTTP binding is not an official-client panelist"
+      false
+      (Masc.Fusion_official_client.is_official_client ~runtime_id:agent_core_runtime))
+;;
+
+(* An unknown id must not be claimed by this path. The Agent_core path already
+   reports it precisely ("no provider config"); routing it here would replace
+   that message with a spawn-side one that names the wrong subsystem. *)
+let test_unknown_runtime_is_not_claimed_by_the_spawn_path () =
+  with_classification_runtime (fun () ->
+    check
+      bool
+      "an unconfigured id is left to the Agent_core path to report"
+      false
+      (Masc.Fusion_official_client.is_official_client ~runtime_id:"nope.not-configured"))
+;;
+
+let panel_group models : Fusion_policy.panel_group =
+  { models
+  ; label = ""
+  ; system_prompt = "Answer in one word."
+  ; web_tools = false
+  ; max_output_tokens = None
+  }
+;;
+
+(* Judged by the marker, not by the error text. The stub CLI emits no result
+   event, so this panelist fails either way — what separates "routed to the
+   spawn path" from "routed to build_agent" is whether the client ran at all.
+   Delete the official branch in fusion_panel.ml and the marker stops
+   appearing. *)
+let test_official_client_panelist_reaches_its_client () =
+  let base_dir = Filename.temp_dir "fusion-official-client-run" "" in
+  let marker = Filename.concat base_dir "spawned" in
+  let claude_cli = Filename.concat base_dir "stub-claude" in
+  write_file ~path:claude_cli ~perm:0o700 (stub_cli_script ~marker);
+  with_initialized_runtime ~claude_cli (fun () ->
+    let outcomes =
+      Eio_main.run (fun env ->
+        Eio_context.set_env env;
+        Eio.Switch.run (fun sw ->
+          Eio_context.with_test_env
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~mono_clock:(Eio.Stdenv.mono_clock env)
+            ~sw
+            (fun () ->
+               Masc.Fusion_panel.run
+                 ~base_dir
+                 ~sw
+                 ~net:(Eio.Stdenv.net env)
+                 ~groups:[ panel_group [ official_client_runtime ] ]
+                 ~prompt:"ping"
+                 ())))
+    in
+    check bool "the official client was executed" true (Sys.file_exists marker);
+    (* One declared panelist stays one reported outcome. A panelist dropped
+       rather than run is the failure mode that survives a quorum. *)
+    check int "the panelist is accounted for in the outcomes" 1 (List.length outcomes))
+;;
+
+let () =
+  run
+    "fusion official-client panel"
+    [ ( "panelist routing"
+      , [ test_case
+            "official-client runtime is routed to the spawn path"
+            `Quick
+            test_official_client_runtime_is_routed_to_the_spawn_path
+        ; test_case
+            "Agent_core runtime stays on the Async_agent path"
+            `Quick
+            test_agent_core_runtime_stays_on_the_async_agent_path
+        ; test_case
+            "unknown runtime is not claimed by the spawn path"
+            `Quick
+            test_unknown_runtime_is_not_claimed_by_the_spawn_path
+        ] )
+    ; ( "panel execution"
+      , [ test_case
+            "official-client panelist reaches its client"
+            `Quick
+            test_official_client_panelist_reaches_its_client
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 무엇

Fusion 패널리스트가 official-client 런타임(`claude-code` / `codex-app-server` / `antigravity-cli`)에서 실행되도록 실행 경로를 추가한다.

## 왜

`lib/fusion/fusion_panel.ml` 은 패널 전체를 `Agent_core.Async_agent.all` 로만 실행했다. official-client 런타임은 `Runtime_execution.Official_client` 소유의 spawn 프로세스라 `Agent_core` agent 가 될 수 없고, 따라서 패널리스트로 지명해도 **답을 내지 못했다**. 설정 문제가 아니라 실행 경로의 부재다.

2026-08-10 라이브 실측 (`~/me/.masc`, main `25ebf46946`, 런타임 43개. keeper `rondo` 가 `masc_fusion` 호출, `/api/v1/dashboard/fusion-runs` 기록):

| preset | 패널 구성 | 결과 |
|---|---|---|
| `trio` | Agent_core ×3 | `completed` |
| `subscription_trio` | official-client ×3 | **`failed`** · `panels_unavailable` · `none of 3 panels returned an answer` |
| `mixed_estate` | Agent_core 2 + official-client 2 | `completed` — 4명 중 2명만 답했고 run 레코드에 그 흔적이 없다 |

두 증상 중 위험한 쪽은 실패가 아니라 성공이다. 전멸은 `panels_unavailable` 로 시끄럽게 죽지만, 혼합 패널은 정족수(`min_answered`, 기본 1)로 살아나면서 **4명 선언 → 2명 심의**가 된다. `/api/v1/dashboard/fusion-runs` 레코드에는 패널 구성이 남지 않아 운영자 화면에서 이 축소가 보이지 않는다.

서로 다른 학습 분포에서 나온 이견이 심의의 값어치인데, 현재 패널은 `ollama_cloud` 안에서만 구성 가능했다. 구독 런타임 22종(claude 4 · codex 7 · antigravity 11)은 CLI 턴 실측을 통과했고 키퍼 배정에서도 돌고 있다.

## 어떻게

- `lib/fusion/fusion_official_client.{ml,mli}` (신규): `is_official_client` 로 분류하고, 어댑터별 config 변환 후 `run_turn` 을 stateless one-shot 으로 호출한다. 세션 재개 없음, 동적 도구 없음 — 패널리스트는 답만 낸다. 변환은 keeper 경로(`keeper_claude_code_runtime.ml:224`, `keeper_antigravity_runtime.ml:241`)를 그대로 따른다.
- `lib/fusion/fusion_panel.ml`: 빌드 fold 가 패널리스트를 두 갈래로 나눈다. `Agent_core` 는 기존 `Async_agent.all`, official-client 는 `Eio.Fiber.List.map` 으로 동시 실행. 반환 순서 계약(빌드 실패분 → 실행 결과)은 유지.
- `mgr`/`clock` 은 fusion 시그니처에 꿰지 않고 `Eio_context.get_env_opt()` / `get_clock_opt()` 에서 가져온다 — `Server_dashboard_official_client_probe` 가 같은 문제를 푸는 방식.
- `base_dir` 만 `Fusion_tool.handle` → `Fusion_orchestrator.compute` → `Fusion_panel.run` 으로 내려간다 (MASC base path 전역 접근자가 없음).
- official-client 는 토큰 회계를 반환하지 않으므로 usage 는 `Fusion_types.zero_usage`.

## 검증

`test/test_fusion_official_client_panel.ml` — 4 케이스, CI 배선 완료(`@test/runtest-test_fusion_official_client_panel`).

실행 케이스는 **에러 문자열이 아니라 클라이언트가 실제로 스폰됐는지**로 판정한다. 스텁 CLI 가 마커 파일을 만들고, `Fusion_panel.run` 진입점에서 호출한다.

뮤테이션 3종으로 각 단언이 무엇을 잡는지 확인:

| 뮤테이션 | 결과 |
|---|---|
| `checkpoint_owner` 판정 뒤집기 | routing 0,1 FAIL · 2 OK |
| unknown id 를 이 경로가 주장 (`None -> true`) | routing 2 FAIL · 0,1 OK |
| **`fusion_panel.ml` 의 분기 자체 무효화** | **execution FAIL · routing 3개 전부 OK** |

세 번째가 이 테스트 구성의 이유다. predicate 만 고정했다면 배선이 통째로 사라져도 초록이었다.

로컬: `dune build --root .` clean. 형제 스위트 `test_fusion_metrics`(3) / `test_fusion_sink_meta`(18) 회귀 없음.

## 범위 밖

- **judge 축은 Agent_core 유지.** judge 는 구조적 JSON 을 요구하므로, official-client judge 를 허용하려면 그 출력 계약을 어떻게 강제할지 별도 판단이 필요하다.
- **preset 적격성 검증 미포함.** 적격 패널 수가 `min_answered` 미만인 preset 을 load 시점에 거부하는 것(`validate_lane_candidates_capability` 와 같은 패턴)은 별건이다. 이 PR 이후 `subscription_trio` 의 적격 수는 0 → 3 이 되므로 급하지 않다.
- **run 레코드의 패널 구성 노출 미포함.** 그건 보이게 만들 뿐 고치지 않는다.

## 미검증

배포 후 `subscription_trio` 라이브 fusion 실행은 아직 하지 않았다. 이 PR 머지 후 `~/me/.masc` 런타임에서 실측하고 결과를 리포트에 반영한다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
