### PR TITLE
ci: chat cutover 게이트 제거 때 남은 고아 테스트 타깃 제거 — 모든 PR 이 Meta Guards 에서 실패 중

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1125,8 +1125,7 @@ jobs:
         run: |
           opam exec -- dune build --root . \
             @test/runtest-test_keeper_owner \
-            @test/runtest-test_keeper_chat_operation_http \
-            @test/runtest-test_keeper_chat_cutover_preflight
+            @test/runtest-test_keeper_chat_operation_http
 
       - name: Run memory journal suite
         # The journal is the only disk record of a librarian pass that produced


### PR DESCRIPTION
## 증상 — 모든 PR 이 Meta Guards 에서 빨갛습니다

문서만 넣은 PR(#28019)에서도 실패합니다:

```
[ci-test-targets] FAIL - CI names targets Dune does not declare
  - test_keeper_chat_cutover_preflight
Occurrences:
  .github/workflows/ci.yml:1129
```

`dune` 은 해결 못 하는 타깃에 hard-fail 하므로, 이 상태에서는 변경 내용과 무관하게 게이트가 떨어집니다.

## 사슬

| 시각 | PR | 한 일 |
|---|---|---|
| — | #27993 | chat cutover boot gate + `test/test_keeper_chat_cutover_preflight.ml` 추가 |
| 21:57:44 | #27997 | 그 테스트를 CI 에 배선 |
| 21:58:31 | #28007 | 게이트 제거 — 테스트는 지우고 **CI 라인은 남김** |

**47초 간격입니다.**

## 두 PR 다 잘못이 없습니다

```
$ gh pr view 28007 --json baseRefOid   → 8cc693d2a
$ git show 8cc693d2a:.github/workflows/ci.yml | rg -c cutover_preflight
0
```

#28007 의 base 에는 그 문자열이 **0건**이었습니다. 그 PR 의 체크는 고아 타깃을 **볼 수 없었습니다.** 파손은 두 변경의 *조합*에만 존재합니다 — per-PR CI 가 원리적으로 못 보는 종류입니다.

## 수정

고아 라인 한 줄 제거. 게이트가 사라졌으므로 테스트가 없는 것이 옳고, 남은 건 배선뿐입니다.

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 169 CI targets, all declared in Dune
[ci-test-targets] OK - 689 suites unwired, at baseline
```

대조군: 같은 명령이 이 커밋 전에는 위 FAIL 을 냅니다.

## 남는 구조적 질문 (이 PR 범위 밖)

merge 직전 base 최신화를 요구하지 않으면 이 형태는 반복됩니다. 개념 제거는 심볼·테스트·**CI 배선**을 함께 닫아야 하는데, 마지막 축은 삭제하는 PR 의 diff 에 나타나지 않습니다.

Refs #27993, #27997, #28007

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
