### PR TITLE
ci: drop the retired chat cutover preflight target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1110,13 +1110,16 @@ jobs:
           opam exec -- dune build --root . \
             @test/runtest-test_keeper_keepalive_launch_order_ast
 
-      - name: Run Keeper owner and chat cutover suites
-        # #27962 put every Keeper mutation and chat turn behind one owner actor,
-        # and #27993 made an unarchived chat-queue.sqlite3 sidecar refuse Keeper
-        # Owner installation at boot. @check compiles both and runs neither, so
-        # one-running-turn, restart settlement, and the boot gate itself were
-        # assertions nothing executed. A gate that can hold a fleet out of ready
-        # has to run where a red result blocks the merge.
+      - name: Run Keeper owner and chat operation suites
+        # #27962 put every Keeper mutation and chat turn behind one owner actor.
+        # @check compiles the suites and runs neither, so one-running-turn and
+        # restart settlement were assertions nothing executed. A gate that can
+        # hold a fleet out of ready has to run where a red result blocks the
+        # merge.
+        #
+        # The chat cutover preflight target left with the boot gate in #28007;
+        # dune hard-fails on an alias it cannot resolve, so the retired target
+        # cannot stay listed here.
         #
         # test_keeper_autoboot_single_owner is deliberately absent here: it is
         # already invoked from scripts/ci-run-focused-tests.sh, the second CI
@@ -1125,8 +1128,7 @@ jobs:
         run: |
           opam exec -- dune build --root . \
             @test/runtest-test_keeper_owner \
-            @test/runtest-test_keeper_chat_operation_http \
-            @test/runtest-test_keeper_chat_cutover_preflight
+            @test/runtest-test_keeper_chat_operation_http
 
       - name: Run memory journal suite
         # The journal is the only disk record of a librarian pass that produced


### PR DESCRIPTION
## 증상

`main` (`b95edbe43d`) 에서 CI 가 hard-fail 한다.

```
$ dune build --root . @test/runtest-test_keeper_chat_cutover_preflight
Error: Alias "runtest-test_keeper_chat_cutover_preflight" specified on the
command line is empty.
It is not defined in test or any of its descendants.
exit=1
```

`scripts/audit-ci-test-targets.sh` (ci.yml:455 에 배선됨) 도 같은 것을 잡는다:

```
[ci-test-targets] FAIL - CI names targets Dune does not declare
  - test_keeper_chat_cutover_preflight
Occurrences:
  .github/workflows/ci.yml:1139:            @test/runtest-test_keeper_chat_cutover_preflight
exit=2
```

## 라이브 확인

로컬 재현만이 아니라 `main` 의 실제 CI 런에서 확정됨:

- run `31390925981` (`b95edbe43d`, `main`) — job `Meta Guards` = `failure`
- 실패 스텝: **`Check CI test targets`** (= ci.yml:455, `scripts/audit-ci-test-targets.sh`)

## 원인

#28007 (`refactor(keeper): remove the chat cutover boot gate`) 이 `test/test_keeper_chat_cutover_preflight.ml` 과 `test/stanzas/test_keeper_chat_cutover_preflight.inc` 를 삭제하면서 CI 스텝의 타깃은 남겼다. dune 은 해석 불가한 alias 에 hard-fail 한다.

`audit-ci-test-targets.sh` 는 정확히 이 실패 유형을 위해 존재하고 CI 에도 배선돼 있는데 왜 막지 못했나 — #28007 직전 커밋(`0699398e76`)의 CI 런이 **cancelled** 였다. 취소된 체크는 검증이 아니다.

## 변경

스텝에서 은퇴한 타깃 한 줄을 제거하고 스텝 이름과 주석을 남은 두 스위트에 맞춘다. `test_keeper_owner` / `test_keeper_chat_operation_http` 는 그대로 실행된다.

## 검증

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 169 CI targets, all declared in Dune
[ci-test-targets] OK - 689 suites unwired, at baseline
exit=0

$ dune build --root . @test/runtest-test_keeper_owner @test/runtest-test_keeper_chat_operation_http
Test Successful in 0.001s. 3 tests run.
Test Successful in 0.500s. 32 tests run.
exit=0
```

## 범위 밖

`689 suites unwired, at baseline` — CI 가 실행하지 않는 스위트 689개는 이 PR 의 범위가 아니다. baseline 으로 인정돼 있고, 별건이다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
