### PR TITLE
feat(runtime): declare a per-model turn timeout for official-client runtimes

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -247,7 +247,13 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ; execution_mode = Plan
       ; sandbox = true
       ; disable_slash_commands = true
-      ; timeout_s = config.timeout_s
+      ; (* A per-model [turn-timeout-s] overrides the admission-time bound.
+           Absent, [config.timeout_s] stands, so a config that declares none
+           behaves exactly as before. *)
+        timeout_s =
+          Option.value
+            (Runtime_inference.resolve_turn_timeout_s ~runtime_id)
+            ~default:config.timeout_s
       }
     in
     let* () =

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -226,7 +226,13 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ; cwd = base_path
       ; model = config.model
       ; system_prompt
-      ; timeout_s = config.timeout_s
+      ; (* A per-model [turn-timeout-s] overrides the admission-time bound.
+           Absent, [config.timeout_s] stands, so a config that declares none
+           behaves exactly as before. *)
+        timeout_s =
+          Option.value
+            (Runtime_inference.resolve_turn_timeout_s ~runtime_id)
+            ~default:config.timeout_s
       }
     in
     let terminal_error = ref None in

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -234,7 +234,13 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       { Runtime_codex_app_server.cli_path = config.cli_path
       ; model = config.model
       ; developer_instructions
-      ; timeout_s = config.timeout_s
+      ; (* A per-model [turn-timeout-s] overrides the admission-time bound.
+           Absent, [config.timeout_s] stands, so a config that declares none
+           behaves exactly as before. *)
+        timeout_s =
+          Option.value
+            (Runtime_inference.resolve_turn_timeout_s ~runtime_id)
+            ~default:config.timeout_s
       }
     in
     let terminal_error = ref None in

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1323,6 +1323,12 @@ let reasoning_effort_of_runtime_id (id : string)
   | None -> None
 ;;
 
+let turn_timeout_s_of_runtime_id (id : string) : float option =
+  match get_runtime_by_id id with
+  | Some rt -> rt.model.turn_timeout_s
+  | None -> None
+;;
+
 let default_preserve_thinking_for_model (_rt : t) : bool option =
   (* AGENT_CORE owns provider/model capability truth and can preserve reasoning when
      the provider contract requires it. MASC must not turn "request-side

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -355,6 +355,13 @@ val reasoning_effort_of_runtime_id : string -> Llm_provider.Reasoning_effort.t o
     the runtime id is unknown. Consumed by
     {!Runtime_inference.resolve_reasoning_effort}. *)
 
+val turn_timeout_s_of_runtime_id : string -> float option
+(** Per-model [turn-timeout-s] from runtime.toml, or [None] when unset or the
+    runtime id is unknown. [None] means "keep whatever bound the caller already
+    has" — the antigravity provider [timeout-s] or the adapter default — so an
+    unknown id degrades to current behaviour rather than to an invented bound.
+    Consumed by {!Runtime_inference.resolve_turn_timeout_s}. *)
+
 val top_p_of_runtime_id : string -> float option
 (** Request [top_p] from the materialized AGENT_CORE provider config for runtime [id],
     or [None] when the runtime is not configured or no explicit value is

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -22,6 +22,8 @@ let resolve_temperature ~runtime_id ~fallback =
 let resolve_reasoning_effort ~runtime_id =
   Runtime.reasoning_effort_of_runtime_id runtime_id
 
+let resolve_turn_timeout_s ~runtime_id = Runtime.turn_timeout_s_of_runtime_id runtime_id
+
 (* masc#24067 / agent-core boundary: MASC must not synthesize a request [max_tokens]
    value. The former resolver invented one from either a model capability
    ceiling or a flat fallback. Callers now carry explicit intent as [int

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -4,6 +4,11 @@ val resolve_reasoning_effort :
     when the model leaves it unset. Official-client runtimes have no other
     declared reasoning control. *)
 
+val resolve_turn_timeout_s : runtime_id:string -> float option
+(** The per-model [turn-timeout-s] declared for [runtime_id], or [None] when
+    the model leaves it unset. Callers keep their existing bound on [None]:
+    this overrides a timeout, it does not supply one. *)
+
 val resolve_temperature :
   runtime_id:string -> fallback:(unit -> float) -> float
 (** Use the runtime.toml model override when present; evaluate [fallback] only

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -218,6 +218,16 @@ type model_spec =
         {!Runtime.reasoning_effort_of_runtime_id} →
         {!Runtime_inference.resolve_reasoning_effort}, symmetric to the
         [temperature] path. *)
+  ; turn_timeout_s : float option
+    (** [turn-timeout-s] — per-model wall-clock bound on one official-client
+        turn, in seconds. Reasoning effort is declared per model, and effort is
+        the dominant term in how long a turn runs; a timeout that can only be
+        set per provider therefore cannot bound a [max]-effort binding and a
+        [low]-effort one differently, and for claude-code / codex-app-server it
+        could not be set at all. [None] keeps the provider value where one
+        exists (antigravity [timeout-s]) and the adapter default otherwise.
+        Resolved via {!Runtime.turn_timeout_s_of_runtime_id} →
+        {!Runtime_inference.resolve_turn_timeout_s}. *)
   ; capabilities : model_capabilities option
   }
 [@@deriving show, eq]

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -143,6 +143,7 @@ type model_spec =
   ; min_p : float option
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
        [@equal fun a b -> a = b]
+  ; turn_timeout_s : float option
   ; capabilities : model_capabilities option
   }
 [@@deriving show, eq]

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -829,6 +829,19 @@ let reasoning_effort_opt_field ~(path : string) (tbl : Otoml.t)
          ])
 ;;
 
+(* Read the optional per-model [turn-timeout-s]. Named distinctly from the
+   antigravity provider key [timeout-s] because the two sit at different layers
+   and the model value wins: an operator reading a config with both should be
+   able to tell which one bounds the turn without consulting the resolver. *)
+let turn_timeout_opt_field ~(path : string) (tbl : Otoml.t)
+  : (float option, parse_error list) result
+  =
+  positive_finite_float_opt_field
+    ~path
+    ~key:"turn-timeout-s"
+    (strict_float_find path tbl "turn-timeout-s")
+;;
+
 (* Read the optional per-model [temperature]. A TOML integer (1) or float (1.0)
    both read as a float so an operator is not tripped by "1 vs 1.0". Absent →
    [Ok None] (caller keeps its fallback). Wrong type or out of
@@ -950,6 +963,7 @@ let parse_model (id : string) (tbl : Otoml.t)
     let top_k_result = positive_int_opt_field ~path ~key:"top-k" tbl in
     let min_p_result = probability_opt_field ~path ~key:"min-p" tbl in
     let reasoning_effort_result = reasoning_effort_opt_field ~path tbl in
+    let turn_timeout_result = turn_timeout_opt_field ~path tbl in
     let ( let* ) = Result.bind in
     let* max_context = max_context_result in
     let* capabilities = capabilities_result in
@@ -958,6 +972,7 @@ let parse_model (id : string) (tbl : Otoml.t)
     let* top_k = top_k_result in
     let* min_p = min_p_result in
     let* reasoning_effort = reasoning_effort_result in
+    let* turn_timeout_s = turn_timeout_result in
     match sampling_capability_errors ~path ~capabilities ~top_k ~min_p with
     | _ :: _ as errors -> Error errors
     | [] ->
@@ -975,6 +990,7 @@ let parse_model (id : string) (tbl : Otoml.t)
         ; top_k
         ; min_p
         ; reasoning_effort
+        ; turn_timeout_s
         ; capabilities        })
 ;;
 

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -796,6 +796,67 @@ let test_model_without_reasoning_effort_leaves_it_unset () =
          (model.Runtime_schema.reasoning_effort = None)
      | _ -> fail "exactly one model must parse")
 
+(* [turn-timeout-s] exists because reasoning effort is per model while the only
+   pre-existing bound was per provider (antigravity [timeout-s]) or absent
+   entirely (claude-code, codex-app-server, both fixed at 300s in the adapter).
+   A max-effort binding could therefore not be given more wall clock than a
+   low-effort one sharing its provider. Live evidence, 2026-08-10: keeper
+   analyst on claude_code.claude-opus-5-max failed every turn with "timed out
+   after 300.000s" at 5,884 bytes of system+user input.
+
+   The rejection case is the load-bearing one: a timeout that silently became
+   zero or infinity would either kill every turn or hang the keeper, and both
+   read as a provider fault rather than a config typo. *)
+let test_model_turn_timeout_parses_as_a_positive_float () =
+  let config = "[models.probe]\napi-name = \"probe\"\nturn-timeout-s = 900.0\n" in
+  match Runtime_toml.parse_string config with
+  | Error _ -> fail "a model declaring a positive turn-timeout-s must parse"
+  | Ok parsed ->
+    (match parsed.Runtime_schema.models with
+     | [ model ] ->
+       check
+         bool
+         "turn-timeout-s reaches the model spec"
+         true
+         (model.Runtime_schema.turn_timeout_s = Some 900.0)
+     | _ -> fail "exactly one model must parse")
+
+let test_model_turn_timeout_rejects_a_non_positive_value_at_load () =
+  let config = "[models.probe]\napi-name = \"probe\"\nturn-timeout-s = 0.0\n" in
+  match Runtime_toml.parse_string config with
+  | Ok _ -> fail "a non-positive turn-timeout-s must be rejected at load"
+  | Error errors ->
+    check
+      bool
+      "the rejection names the offending key"
+      true
+      (List.exists
+         (fun (e : Runtime_toml.parse_error) ->
+            let contains needle =
+              let n = String.length needle in
+              let rec scan i =
+                i + n <= String.length e.path
+                && (String.sub e.path i n = needle || scan (i + 1))
+              in
+              scan 0
+            in
+            contains "turn-timeout-s")
+         errors)
+
+let test_model_without_turn_timeout_leaves_it_unset () =
+  let config = "[models.probe]\napi-name = \"probe\"\n" in
+  match Runtime_toml.parse_string config with
+  | Error _ -> fail "a model without turn-timeout-s must still parse"
+  | Ok parsed ->
+    (match parsed.Runtime_schema.models with
+     | [ model ] ->
+       check
+         bool
+         "an undeclared turn-timeout-s stays None so the caller keeps its bound"
+         true
+         (model.Runtime_schema.turn_timeout_s = None)
+     | _ -> fail "exactly one model must parse")
+
 let test_exact_output_lane_config_is_ordered_and_rejects_duplicates () =
   let valid =
     "[runtime.exact_output_lanes.compaction_exact]\nslots = [\"slot-b\", \"slot-a\"]\n"
@@ -3607,5 +3668,14 @@ let () =
         ; test_case
             "a model without reasoning-effort leaves it unset"
             `Quick test_model_without_reasoning_effort_leaves_it_unset
+        ; test_case
+            "turn-timeout-s parses as a positive float"
+            `Quick test_model_turn_timeout_parses_as_a_positive_float
+        ; test_case
+            "turn-timeout-s rejects a non-positive value at load"
+            `Quick test_model_turn_timeout_rejects_a_non_positive_value_at_load
+        ; test_case
+            "a model without turn-timeout-s leaves it unset"
+            `Quick test_model_without_turn_timeout_leaves_it_unset
         ] )
     ]

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -57,6 +57,7 @@ let qwen_model =
   ; top_k = None
   ; min_p = None
   ; reasoning_effort = None
+  ; turn_timeout_s = None
   ; capabilities = None
   }
 


### PR DESCRIPTION
## 문제

reasoning effort 는 **모델별**로 선언되는데(#28011), 그 턴을 묶는 timeout 은 **프로바이더별**이거나 아예 설정할 수 없다.

| protocol | timeout 설정 경로 | 값 |
|---|---|---|
| `antigravity-cli` | `[providers.X] timeout-s` (프로바이더 단위) | 설정값, 기본 300 |
| `claude-code` | **없음** — `timeout-s` 는 `antigravity_cli_option_keys` 에만 유효 | 300 고정 (`runtime_claude_code.ml:15`) |
| `codex-app-server` | **없음** | 300 고정 (`runtime_codex_app_server.ml:24`) |

`runtime_toml.ml:463-478` 이 `Claude_code_runtime` / `Codex_app_server_runtime` 에서 `timeout-s` 를 "valid only for protocol antigravity-cli" 로 거부한다.

결과: 같은 프로바이더를 공유하는 `effort = max` 바인딩과 `effort = low` 바인딩에 서로 다른 시간을 줄 수 없다. effort 는 턴 길이의 지배항인데도.

## 라이브 증거 (2026-08-10, `~/me/.masc`)

```
analyst: turn terminal (non-exhaustion error)
  — err=Timeout: Claude Code turn timed out after 300.000s attempt=1
analyst: keeper cycle FAILED runtime=claude_code.claude-opus-5-max
  max_context=1000000 context_budget=1000000 system_and_user_bytes=5884
```

입력이 5,884 바이트인데 300 초를 넘긴다 — 컨텍스트가 아니라 effort 가 원인이다. `claude-opus-5-max` 는 `reasoning-effort = "max"` 로 선언된 바인딩이고, 이 키퍼는 이 실패로 턴을 하나도 완료하지 못한다.

같은 축의 두 번째 사례 (프로바이더 단위 값이 존재하지만 모델별로 못 나누는 경우):

```
taskmaster: turn terminal — err=Timeout: Antigravity turn timed out after 180.000s
  runtime=antigravity_subscription.gemini-3-6-flash-high   (consecutive=92)
```

`[providers.antigravity_subscription] timeout-s = 180.0` 이 `-high` / `-medium` / `-low` 세 레벨에 똑같이 적용된다. 참고 실측(사소한 프롬프트, `agy --print`): high 34.7s · medium 21.1s · low 10.8s.

## 왜 타임아웃 하나가 키퍼를 영구히 막는가 (RFC-0368 인접)

타임아웃은 턴 하나를 잃는 것으로 끝나지 않는다. `Runtime_claude_code.Timeout` 은 `recovery_failure_of_client_error` 에서 `Session_store.Transport_interrupted` 로 매핑되고, 그 disposition 은 `Ambiguous` 다 — 즉 **운영자가 resolve 를 호출할 때까지 그 키퍼의 모든 턴이 `official_client_session.claim` 에서 fail-closed** 된다.

2026-08-10 라이브에서 이 순환을 실측했다: resolve 5건 실행 → 세 키퍼가 각각 턴 1회 시도 → 타임아웃 → **다시 좌초**. resolve 가 사준 것은 턴 한 번뿐이었다.

RFC-0368 이 이 좌초를 다루고 있고, `Transport_interrupted` 를 transient 로 재분류하는 §설계 1 은 **철회**됐다 (#28017). 철회 근거가 옳다 — transport 가 끊겼다는 것은 반대편이 그 턴을 실행했는지 모른다는 뜻이고, 그것이 `Ambiguous` 의 정의다. 대체 설계는 관측으로 모호함을 붕괴시키는 것이다.

이 PR 은 그 축과 경쟁하지 않는다. **타임아웃이 발생하지 않게 하여 좌초가 형성되지 않게** 한다. RFC-0368 이 착지하면 남은 타임아웃도 자동 해제되고, 그 전까지는 이 PR 이 발생 빈도를 줄인다.

## 변경

`[models.X]` 에 `turn-timeout-s` 를 추가한다. `reasoning-effort` 와 정확히 같은 축·같은 경로다.

```
Runtime_toml.turn_timeout_opt_field
  → Runtime_schema.model_spec.turn_timeout_s
  → Runtime.turn_timeout_s_of_runtime_id
  → Runtime_inference.resolve_turn_timeout_s
  → keeper_{claude_code,codex,antigravity}_runtime.ml 의 client config
```

- `None` 이면 **호출자가 이미 가진 값을 유지**한다 — antigravity 프로바이더 값 또는 어댑터 기본값. 이 필드는 timeout 을 *덮어쓰지* 공급하지 않는다. 선언이 없는 설정의 동작은 이전과 바이트 동일하다.
- 키 이름을 프로바이더의 `timeout-s` 와 다르게 둔 것은 의도적이다. 둘이 다른 층에 있고 모델 값이 이기므로, 둘 다 있는 설정을 읽는 운영자가 resolver 를 열지 않고도 어느 쪽이 턴을 묶는지 알아야 한다.
- 0 이하 / 비유한 값은 **load 시점에 거부**한다. 조용히 0 이 되면 모든 턴이 죽고 무한대가 되면 키퍼가 멈추는데, 둘 다 화면에는 provider 장애로 보인다.

## 검증

`test/test_runtime_config_validity.ml` 에 3 케이스 추가 (이미 CI 배선된 스위트 — `@test/runtest-test_runtime_config_validity`, ci.yml:846). 69 tests run, 전부 통과.

뮤테이션:

| 뮤테이션 | 결과 |
|---|---|
| 값을 읽지 않음 (`Ok None` 고정) | 66 FAIL · 67 FAIL · 68 OK |
| 양수 가드 제거 | 67 FAIL · 66,68 OK |

`dune build --root .` clean.

## 미검증

세 개의 적용 지점(keeper client config 구성)은 **컴파일로만** 커버된다. 이 값이 실제로 턴을 늘리는지는 배포 후 라이브에서 확인한다: `analyst` 를 `turn-timeout-s = 900.0` 으로 두고 300 초 타임아웃이 사라지는지 본다. 결과는 이 PR 에 코멘트로 남긴다.

RFC-WAIVED: 변경 범위가 credential / identity / operator control / sandbox / hooks / workflow 문서 중 어디에도 닿지 않는다. runtime 설정 스키마에 모델별 필드 하나를 추가하는 것으로, #28011 (per-model reasoning effort) 이 만든 비대칭을 같은 축에서 닫는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
