### PR TITLE
feat(runtime): support disabling providers and bindings

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -236,6 +236,12 @@ instructions = """
 
 Keeper → runtime 할당은 `runtime.toml`에서 합니다 (keeper toml은 model/runtime을 직접 갖지 않습니다):
 
+Provider와 binding 테이블은 `enabled = false`를 지원합니다.
+`[providers.<id>]`를 비활성화하면 해당 provider의 모든 binding이 실행
+inventory에서 빠지고, `[<provider>.<model>]`을 비활성화하면 해당
+runtime만 빠집니다. 비활성 runtime ID를 `[runtime].default`, lane, assignment,
+failover list가 계속 참조하면 설정 오류로 거부합니다.
+
 ```toml
 [runtime.assignments]
 albini = "<provider>.<model>"   # config/runtime.toml에 정의된 id로 교체

--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ instructions = """
 
 Keeper → runtime assignment is done in `runtime.toml` (the keeper toml does not hold model/runtime directly):
 
+Provider and binding tables accept `enabled = false`. Disabling a
+`[providers.<id>]` table excludes all of its bindings; disabling a
+`[<provider>.<model>]` table excludes only that runtime. Disabled runtime IDs
+must not remain selected by `[runtime].default`, lanes, assignments, or
+failover lists.
+
 ```toml
 [runtime.assignments]
 albini = "<provider>.<model>"   # replace with an id from config/runtime.toml

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1033,7 +1033,7 @@ let runtime_wizard_binding_for_provider (cfg : Runtime_schema.config)
   let bindings =
     List.filter
       (fun (binding : Runtime_schema.binding) ->
-         String.equal binding.provider_id provider.id)
+         binding.enabled && String.equal binding.provider_id provider.id)
       cfg.bindings
   in
   match bindings with
@@ -1106,7 +1106,10 @@ let runtime_wizard_catalog_records (cfg : Runtime_schema.config) =
          | Error _ as err -> err
          | Ok record -> provider_records (record :: acc) rest)
   in
-  match provider_records [] cfg.providers with
+  let enabled_providers =
+    List.filter (fun (provider : Runtime_schema.provider) -> provider.enabled) cfg.providers
+  in
+  match provider_records [] enabled_providers with
   | Error _ as err -> err
   | Ok records ->
       (match runtime_wizard_default_record cfg with

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -18,6 +18,10 @@ cross_verifier = "deepseek.deepseek-v4-pro"
 
 # Existing workspaces are not overwritten by this seed. Copy the required lane
 # declarations into the live runtime.toml before enabling their consumers.
+# Providers and individual provider.model bindings default to `enabled = true`.
+# Set `enabled = false` in either table to keep the catalog example while
+# excluding it from the executable runtime inventory. A disabled runtime cannot
+# remain referenced by [runtime].default, lanes, assignments, or failover lists.
 [runtime.exact_output_lanes.librarian_exact]
 slots = ["glm-coding.glm-5-turbo", "deepseek.deepseek-v4-pro"]
 

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -20,6 +20,7 @@ import {
 import {
   isReservedRuntimeTomlId,
   isValidRuntimeTomlIdFormat,
+  enabledRuntimeIds,
   parseRuntimeTomlEnvironment,
   type RuntimeTomlCredentialType,
   type RuntimeTomlEnvironment,
@@ -38,7 +39,7 @@ export type RuntimeStructuredSection =
   | 'bindings'
   | 'assignments'
 
-export type RuntimeBindingEditableField = 'max-concurrent' | 'keep-alive' | 'num-ctx'
+export type RuntimeBindingEditableField = 'enabled' | 'max-concurrent' | 'keep-alive' | 'num-ctx'
 export type RuntimeProviderTransportEditableField = 'endpoint' | 'command'
 
 // Basic-field-only payloads (RFC-0273 §3.2 reuse boundary). Per-model
@@ -85,7 +86,7 @@ interface RuntimeEnvironmentEditorProps {
   onBindingFieldChange: (
     runtimeId: string,
     field: RuntimeBindingEditableField,
-    value: string | number | null,
+    value: string | number | boolean | null,
   ) => void
   onAddProvider: (input: NewRuntimeProviderInput) => void
   onAddModel: (input: NewRuntimeModelInput) => void
@@ -96,6 +97,7 @@ interface RuntimeEnvironmentEditorProps {
     field: RuntimeProviderTransportEditableField,
     value: string,
   ) => void
+  onProviderEnabledChange: (providerId: string, enabled: boolean) => void
   onProviderCredentialChange: (
     providerId: string,
     credentialType: RuntimeTomlCredentialType,
@@ -103,12 +105,8 @@ interface RuntimeEnvironmentEditorProps {
   ) => void
 }
 
-function firstId<T extends { id: string }>(items: T[]): string {
-  return items[0]?.id ?? ''
-}
-
 function runtimeOptions(environment: RuntimeTomlEnvironment): string[] {
-  return environment.bindings.map(binding => binding.id)
+  return enabledRuntimeIds(environment)
 }
 
 function credentialValue(provider: RuntimeTomlProvider): string {
@@ -290,6 +288,7 @@ export function RuntimeEnvironmentEditor({
   onAddBinding,
   onDeleteProvider,
   onProviderTransportChange,
+  onProviderEnabledChange,
   onProviderCredentialChange,
 }: RuntimeEnvironmentEditorProps) {
   const defaultProviderProtocol = providerProtocols[0]
@@ -622,7 +621,7 @@ export function RuntimeEnvironmentEditor({
           'default',
           '기본 런타임',
           '[runtime].default — 배정 없는 keeper가 사용',
-          environment.defaultRuntimeId || firstId(environment.bindings),
+          environment.defaultRuntimeId || runtimeIds[0] || '',
           updateDefault,
         )}
         ${laneRow(
@@ -658,6 +657,22 @@ export function RuntimeEnvironmentEditor({
                 <span class="rt-card-id mono">${provider.id}</span>
                 <span class="rt-card-name">${provider.displayName}</span>
                 <span class="rt-proto mono">${provider.protocol || '—'}</span>
+                <label class="rt-mini">
+                  <span>enabled</span>
+                  <input
+                    type="checkbox"
+                    checked=${provider.enabled}
+                    disabled=${isDisabled}
+                    aria-label=${`${provider.id} provider enabled`}
+                    data-testid=${`runtime-provider-${provider.id}-enabled`}
+                    onChange=${(event: Event) => {
+                      onProviderEnabledChange(
+                        provider.id,
+                        (event.currentTarget as HTMLInputElement).checked,
+                      )
+                    }}
+                  />
+                </label>
                 ${officialClient ? html`<span class="rt-assign-tag pin mono">구독 CLI</span>` : null}
                 <button
                   type="button"
@@ -1070,6 +1085,10 @@ export function RuntimeEnvironmentEditor({
           ${environment.bindings.map(binding => {
             const isDefault = binding.id === environment.defaultRuntimeId || binding.isDefault
             const model = environment.models.find(m => m.id === binding.modelId) ?? null
+            const providerEnabled = environment.providers.find(
+              provider => provider.id === binding.providerId,
+            )?.enabled === true
+            const effectiveEnabled = binding.enabled && providerEnabled
             return html`
               <div key=${binding.id} class="rt-bind ${isDefault ? 'is-default' : ''}">
                 <button
@@ -1084,6 +1103,7 @@ export function RuntimeEnvironmentEditor({
                 <div class="rt-bind-main">
                   <div class="rt-bind-key mono">
                     ${binding.id}${isDefault ? html`<span class="rt-default-tag">default</span>` : null}
+                    ${effectiveEnabled ? null : html`<span class="rt-default-tag">disabled</span>`}
                   </div>
                   <div class="rt-bind-sub mono">
                     ${protoContext(model?.maxContext ?? null)}${binding.priceInput != null
@@ -1093,6 +1113,23 @@ export function RuntimeEnvironmentEditor({
                   <${RuntimeBindingCatalogSpec} runtimeId=${binding.id} />
                 </div>
                 <div class="rt-bind-fields">
+                  <label class="rt-mini">
+                    <span>enabled</span>
+                    <input
+                      type="checkbox"
+                      checked=${binding.enabled}
+                      disabled=${isDisabled}
+                      aria-label=${`${binding.id} enabled`}
+                      data-testid=${`runtime-binding-${binding.id}-enabled`}
+                      onChange=${(event: Event) => {
+                        onBindingFieldChange(
+                          binding.id,
+                          'enabled',
+                          (event.currentTarget as HTMLInputElement).checked,
+                        )
+                      }}
+                    />
+                  </label>
                   <label class="rt-mini">
                     <span>max-conc</span>
                     <input

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -657,7 +657,7 @@ export function RuntimeEnvironmentEditor({
                 <span class="rt-card-id mono">${provider.id}</span>
                 <span class="rt-card-name">${provider.displayName}</span>
                 <span class="rt-proto mono">${provider.protocol || '—'}</span>
-                <label class="rt-mini">
+                <label class="rt-mini v2-mobile-operator-target">
                   <span>enabled</span>
                   <input
                     type="checkbox"
@@ -1113,7 +1113,7 @@ export function RuntimeEnvironmentEditor({
                   <${RuntimeBindingCatalogSpec} runtimeId=${binding.id} />
                 </div>
                 <div class="rt-bind-fields">
-                  <label class="rt-mini">
+                  <label class="rt-mini v2-mobile-operator-target">
                     <span>enabled</span>
                     <input
                       type="checkbox"

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -307,6 +307,37 @@ describe('RuntimeTomlEditor', () => {
     expect(apiMocks.patchRuntimeAssignment).not.toHaveBeenCalled()
   })
 
+  it('disables providers and individual bindings through typed draft controls', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-providers"]')).not.toBeNull()
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-providers"]') as HTMLButtonElement)
+    fireEvent.click(
+      container.querySelector('[data-testid="runtime-provider-runpod_mtp-enabled"]') as HTMLInputElement,
+    )
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-bindings"]') as HTMLButtonElement)
+    fireEvent.click(
+      container.querySelector('[data-testid="runtime-binding-runpod_mtp.qwen-enabled"]') as HTMLInputElement,
+    )
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source.match(/^enabled = false$/gm)).toHaveLength(2)
+      expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const savedSource = apiMocks.saveRuntimeTomlConfig.mock.calls[0]?.[0] as string
+      expect(savedSource.match(/^enabled = false$/gm)).toHaveLength(2)
+    })
+  })
+
   it('edits binding runtime knobs as a draft and applies them through the existing save path', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -13,6 +13,7 @@ import { errorToString } from '../lib/format-string'
 import {
   cascadeDeleteProvider,
   createRuntimeTomlBinding,
+  enabledRuntimeIds,
   parseRuntimeTomlEnvironment,
   runtimeTomlImpactSummary,
   setRuntimeTomlBindingField,
@@ -291,7 +292,7 @@ export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps =
   function handleBindingFieldChange(
     runtimeId: string,
     field: RuntimeBindingEditableField,
-    value: string | number | null,
+    value: string | number | boolean | null,
   ) {
     if (saving || loadState !== 'loaded') return
     setDraft(current => setRuntimeTomlBindingField(current, runtimeId, field, value))
@@ -360,6 +361,13 @@ export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps =
   ) {
     if (saving || loadState !== 'loaded') return
     setDraft(current => setRuntimeTomlProviderField(current, providerId, field, value))
+    setNotice(null)
+    setError(null)
+  }
+
+  function handleProviderEnabledChange(providerId: string, enabled: boolean) {
+    if (saving || loadState !== 'loaded') return
+    setDraft(current => setRuntimeTomlProviderField(current, providerId, 'enabled', enabled))
     setNotice(null)
     setError(null)
   }
@@ -457,7 +465,7 @@ export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps =
     [config, dirty, draft],
   )
   const environment = useMemo(() => parseRuntimeTomlEnvironment(draft), [draft])
-  const runtimeCount = environment.bindings.length
+  const runtimeCount = enabledRuntimeIds(environment).length
   const providerCount = environment.providers.length
 
   // Structured sections (routing/providers/models/bindings/assignments) all map
@@ -642,8 +650,9 @@ export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps =
                 onAddModel=${handleAddModel}
                 onAddBinding=${handleAddBinding}
                 onDeleteProvider=${handleDeleteProvider}
-                onProviderTransportChange=${handleProviderTransportChange}
-                onProviderCredentialChange=${handleProviderCredentialChange}
+              onProviderTransportChange=${handleProviderTransportChange}
+              onProviderEnabledChange=${handleProviderEnabledChange}
+              onProviderCredentialChange=${handleProviderCredentialChange}
               />` : null}
             </div>
 

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   createRuntimeTomlBinding,
   deleteRuntimeTomlKey,
+  enabledRuntimeIds,
   getRuntimeTomlKey,
   isReservedRuntimeTomlId,
   isValidRuntimeTomlIdFormat,
@@ -51,6 +52,7 @@ describe('runtime TOML dashboard editing helpers', () => {
     expect(environment.assignments).toEqual({})
     expect(environment.providers[0]).toMatchObject({
       id: 'runpod_mtp',
+      enabled: true,
       displayName: 'RunPod',
       protocol: 'openai-http',
       transportKind: 'endpoint',
@@ -69,9 +71,21 @@ describe('runtime TOML dashboard editing helpers', () => {
     })
     expect(environment.bindings[0]).toMatchObject({
       id: 'runpod_mtp.qwen',
+      enabled: true,
       maxConcurrent: 4,
       keepAlive: '10m',
     })
+  })
+
+  it('parses and edits explicit provider and binding disable state', () => {
+    let next = setRuntimeTomlProviderField(sourceText, 'runpod_mtp', 'enabled', false)
+    next = setRuntimeTomlBindingField(next, 'runpod_mtp.qwen', 'enabled', false)
+
+    const environment = parseRuntimeTomlEnvironment(next)
+    expect(environment.providers[0]?.enabled).toBe(false)
+    expect(environment.bindings[0]?.enabled).toBe(false)
+    expect(enabledRuntimeIds(environment)).toEqual([])
+    expect(next.match(/^enabled = false$/gm)).toHaveLength(2)
   })
 
   it('projects the Codex official-client subscription boundary without credentials', () => {

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -3,6 +3,7 @@ export type RuntimeTomlCredentialType = 'env' | 'file' | 'inline' | 'none'
 
 export interface RuntimeTomlProvider {
   id: string
+  enabled: boolean
   displayName: string
   protocol: string
   transportKind: RuntimeTomlTransportKind
@@ -36,6 +37,7 @@ export interface RuntimeTomlBinding {
   id: string
   providerId: string
   modelId: string
+  enabled: boolean
   isDefault: boolean
   maxConcurrent: number | null
   keepAlive: string
@@ -279,6 +281,7 @@ function providerFromDocument(document: TomlDocument, id: string): RuntimeTomlPr
   const credentialType = asString(credentials.type) as RuntimeTomlCredentialType
   return {
     id,
+    enabled: asBoolean(values.enabled, true),
     displayName: asString(values['display-name'], asString(values['provider-name'], id)),
     protocol: asString(values.protocol),
     transportKind: endpoint ? 'endpoint' : command ? 'command' : 'missing',
@@ -340,6 +343,7 @@ function bindingFromDocument(
     id: `${entry.providerId}.${entry.modelId}`,
     providerId: entry.providerId,
     modelId: entry.modelId,
+    enabled: asBoolean(values.enabled, true),
     isDefault: asBoolean(values['is-default']),
     maxConcurrent: asNumber(values['max-concurrent']),
     keepAlive: asString(values['keep-alive']),
@@ -380,6 +384,15 @@ export function parseRuntimeTomlEnvironment(sourceText: string): RuntimeTomlEnvi
     bindings,
     warnings,
   }
+}
+
+export function enabledRuntimeIds(environment: RuntimeTomlEnvironment): string[] {
+  const enabledProviderIds = new Set(
+    environment.providers.filter(provider => provider.enabled).map(provider => provider.id),
+  )
+  return environment.bindings
+    .filter(binding => binding.enabled && enabledProviderIds.has(binding.providerId))
+    .map(binding => binding.id)
 }
 
 function sourceLineCount(sourceText: string): number {
@@ -641,7 +654,7 @@ export function setRuntimeTomlDefault(sourceText: string, runtimeId: string): st
 export function setRuntimeTomlProviderField(
   sourceText: string,
   providerId: string,
-  field: 'display-name' | 'protocol' | 'endpoint' | 'command' | 'is-non-interactive',
+  field: 'enabled' | 'display-name' | 'protocol' | 'endpoint' | 'command' | 'is-non-interactive',
   value: string | boolean,
 ): string {
   const section = `providers.${providerId}`
@@ -706,7 +719,7 @@ export function setRuntimeTomlModelField(
 export function setRuntimeTomlBindingField(
   sourceText: string,
   runtimeId: string,
-  field: 'is-default' | 'max-concurrent' | 'keep-alive' | 'num-ctx',
+  field: 'enabled' | 'is-default' | 'max-concurrent' | 'keep-alive' | 'num-ctx',
   value: string | number | boolean | null,
 ): string {
   if (value === null) return deleteRuntimeTomlKey(sourceText, runtimeId, field)

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -34,12 +34,17 @@ let id_of_binding (b : binding) : string = binding_key b
     task-route / lane 검증이 "not found" 대신 근본 원인을 표면화하는 데 쓰인다
     (Unknown→silent-drop 안티패턴 차단). *)
 let of_binding_result (cfg : config) (b : binding) : (t, string) result =
-  match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
+  if not b.enabled
+  then Error "binding is disabled by runtime.toml"
+  else match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
   | Some provider, Some model ->
-    (match Runtime_adapter.binding_to_execution cfg b with
-     | Ok execution ->
-       Ok { id = id_of_binding b; provider; model; binding = b; execution }
-     | Error reason -> Error reason)
+    if not provider.enabled
+    then Error (Printf.sprintf "provider %S is disabled by runtime.toml" provider.id)
+    else
+      (match Runtime_adapter.binding_to_execution cfg b with
+       | Ok execution ->
+         Ok { id = id_of_binding b; provider; model; binding = b; execution }
+       | Error reason -> Error reason)
   | None, _ -> Error (Printf.sprintf "provider not found: %s" b.provider_id)
   | Some _, None -> Error (Printf.sprintf "model not found: %s" b.model_id)
 ;;

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -62,6 +62,9 @@ type antigravity_cli_options =
 
 type provider =
   { id : string
+  ; enabled : bool
+    (** Whether bindings owned by this provider may be materialized. Omitted
+        [enabled] in TOML defaults to [true]. *)
   ; display_name : string
   ; protocol : string
   ; api_format : api_format
@@ -237,6 +240,9 @@ type model_spec =
 type binding =
   { provider_id : string
   ; model_id : string
+  ; enabled : bool
+    (** Whether this provider x model binding may be materialized. Omitted
+        [enabled] in TOML defaults to [true]. *)
   ; is_default : bool
   ; wizard_default : bool
   ; max_concurrent : int option

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -53,6 +53,9 @@ type antigravity_cli_options =
 
 type provider =
   { id : string
+  ; enabled : bool
+    (** Whether bindings owned by this provider may be materialized. Omitted
+        [enabled] in TOML defaults to [true]. *)
   ; display_name : string
   ; protocol : string
   ; api_format : api_format
@@ -153,6 +156,9 @@ type model_spec =
 type binding =
   { provider_id : string
   ; model_id : string
+  ; enabled : bool
+    (** Whether this provider x model binding may be materialized. Omitted
+        [enabled] in TOML defaults to [true]. *)
   ; is_default : bool
   ; wizard_default : bool
   ; max_concurrent : int option

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -561,7 +561,7 @@ let parse_provider (id : string) (tbl : Otoml.t)
        (match enabled_result, healthcheck_result, connect_timeout_result with
         | Error errs, _, _ | _, Error errs, _ | _, _, Error errs -> Error errs
         | Ok enabled_opt, Ok healthcheck_path, Ok connect_timeout_s ->
-          let enabled = Option.value enabled_opt ~default:true in
+          let enabled = match enabled_opt with Some value -> value | None -> true in
           Ok
             { Runtime_schema.id
             ; enabled
@@ -1116,7 +1116,7 @@ let parse_binding_fields (provider_id : string) (model_id : string) (tbl : Otoml
   let num_ctx_result = typed_find "an integer" path tbl "num-ctx" Otoml.get_integer in
   let ( let* ) = Result.bind in
   let* enabled_opt = enabled_result in
-  let enabled = Option.value enabled_opt ~default:true in
+  let enabled = match enabled_opt with Some value -> value | None -> true in
   let* is_default_opt = is_default_result in
   let is_default = Option.value is_default_opt ~default:false (* DET-OK: fallback to false if omitted *) in
   let* wizard_default_opt = wizard_default_result in

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -482,6 +482,9 @@ let parse_provider (id : string) (tbl : Otoml.t)
   : (Runtime_schema.provider, parse_error list) result
   =
   let path = Printf.sprintf "providers.%s" id in
+  let enabled_result =
+    typed_find "a boolean" path tbl "enabled" Otoml.get_boolean
+  in
   let display_name =
     match Otoml.find_opt tbl Otoml.get_string [ "display-name" ] with
     | Some n -> n
@@ -555,11 +558,13 @@ let parse_provider (id : string) (tbl : Otoml.t)
          strict_float_find path tbl connect_timeout_key
          |> positive_finite_float_opt_field ~path ~key:connect_timeout_key
        in
-       (match healthcheck_result, connect_timeout_result with
-        | Error errs, _ | _, Error errs -> Error errs
-        | Ok healthcheck_path, Ok connect_timeout_s ->
+       (match enabled_result, healthcheck_result, connect_timeout_result with
+        | Error errs, _, _ | _, Error errs, _ | _, _, Error errs -> Error errs
+        | Ok enabled_opt, Ok healthcheck_path, Ok connect_timeout_s ->
+          let enabled = Option.value enabled_opt ~default:true in
           Ok
             { Runtime_schema.id
+            ; enabled
             ; display_name
             ; protocol
             ; api_format
@@ -1067,6 +1072,7 @@ let parse_binding_fields (provider_id : string) (model_id : string) (tbl : Otoml
      An explicit non-positive value is a configuration error: 0 was historically
      used as an omission sentinel, and negative values are meaningless. Reject
      them at load time rather than silently downgrading to "no cap". *)
+  let enabled_result = typed_find "a boolean" path tbl "enabled" Otoml.get_boolean in
   let is_default_result = typed_find "a boolean" path tbl "is-default" Otoml.get_boolean in
   let wizard_default_result =
     typed_find "a boolean" path tbl "wizard-default" Otoml.get_boolean
@@ -1109,6 +1115,8 @@ let parse_binding_fields (provider_id : string) (model_id : string) (tbl : Otoml
   let keep_alive_result = typed_find "a string" path tbl "keep-alive" Otoml.get_string in
   let num_ctx_result = typed_find "an integer" path tbl "num-ctx" Otoml.get_integer in
   let ( let* ) = Result.bind in
+  let* enabled_opt = enabled_result in
+  let enabled = Option.value enabled_opt ~default:true in
   let* is_default_opt = is_default_result in
   let is_default = Option.value is_default_opt ~default:false (* DET-OK: fallback to false if omitted *) in
   let* wizard_default_opt = wizard_default_result in
@@ -1125,6 +1133,7 @@ let parse_binding_fields (provider_id : string) (model_id : string) (tbl : Otoml
   Ok
     { Runtime_schema.provider_id
     ; model_id
+    ; enabled
     ; is_default
     ; wizard_default
     ; max_concurrent

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -2187,39 +2187,142 @@ let test_runtime_capability_gate_uses_provider_qualified_catalog () =
          check (option bool) "provider-qualified preserve policy" None
            (Runtime.preserve_thinking_of_runtime_id "ollama_cloud.shared")))
 
-let test_runtime_assignment_rejects_commented_disabled_binding () =
+let test_runtime_toml_enabled_defaults_true () =
+  let runtime_toml =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.sample]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.sample\"\n"
+  in
+  match Runtime_toml.parse_string runtime_toml with
+  | Error errors ->
+    failf "enabled defaults should parse: %s"
+      (errors
+       |> List.map (fun (error : Runtime_toml.parse_error) -> error.message)
+       |> String.concat "; ")
+  | Ok cfg ->
+    (match cfg.Runtime_schema.providers, cfg.Runtime_schema.bindings with
+     | [ provider ], [ binding ] ->
+       check bool "provider enabled by default" true provider.enabled;
+       check bool "binding enabled by default" true binding.enabled
+     | providers, bindings ->
+       failf
+         "expected one provider and one binding, got %d and %d"
+         (List.length providers)
+         (List.length bindings))
+;;
+
+let test_runtime_provider_disable_excludes_its_bindings () =
+  let runtime_toml =
+    "[providers.active]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [providers.dormant]\n\
+     enabled = false\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:2/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [active.sample]\n\
+     [dormant.sample]\n\
+     \n\
+     [runtime]\n\
+     default = \"active.sample\"\n"
+  in
+  with_temp_runtime_toml runtime_toml (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error msg -> failf "disabled provider should not block active runtime: %s" msg
+    | Ok (runtimes, _, _, _, _, _) ->
+      check (list string) "materialized runtime ids" [ "active.sample" ]
+        (List.map (fun (runtime : Runtime.t) -> runtime.id) runtimes))
+;;
+
+let test_runtime_binding_disable_excludes_only_that_binding () =
   let runtime_toml =
     "[providers.local]\n\
      protocol = \"openai-compatible-http\"\n\
      endpoint = \"http://127.0.0.1:1/v1\"\n\
      \n\
      [models.good]\n\
-     api-name = \"chat\"\n\
+     api-name = \"good\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.disabled]\n\
+     api-name = \"disabled\"\n\
      max-context = 1024\n\
      \n\
      [local.good]\n\
-     \n\
-     # Disabled runtime binding. An assignment to it must fail closed rather\n\
-     # than inheriting [runtime].default.\n\
-     # [models.disabled]\n\
-     # api-name = \"disabled\"\n\
-     # max-context = 1024\n\
-     # [local.disabled]\n\
+     [local.disabled]\n\
+     enabled = false\n\
      \n\
      [runtime]\n\
-     default = \"local.good\"\n\
-     \n\
-     [runtime.assignments]\n\
-     keeper_a = \"local.disabled\"\n"
+     default = \"local.good\"\n"
   in
   with_temp_runtime_toml runtime_toml (fun path ->
     match Runtime.load_list ~config_path:path with
-    | Ok _ -> failf "assignment to commented/disabled runtime should be rejected"
+    | Error msg -> failf "disabled binding should not block active runtime: %s" msg
+    | Ok (runtimes, _, _, _, _, _) ->
+      check (list string) "materialized runtime ids" [ "local.good" ]
+        (List.map (fun (runtime : Runtime.t) -> runtime.id) runtimes));
+  let referenced_runtime_toml =
+    runtime_toml
+    ^ "\n[runtime.assignments]\nkeeper_a = \"local.disabled\"\n"
+  in
+  with_temp_runtime_toml referenced_runtime_toml (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Ok _ -> failf "assignment to explicitly disabled runtime should be rejected"
     | Error msg ->
       check bool "error mentions assignment table" true
         (String_util.contains_substring msg "[runtime.assignments].keeper_a");
       check bool "error mentions disabled runtime id" true
-        (String_util.contains_substring msg "local.disabled"))
+        (String_util.contains_substring msg "local.disabled");
+      check bool "error identifies configured disable" true
+        (String_util.contains_substring msg "disabled by runtime.toml"))
+;;
+
+let test_runtime_toml_rejects_non_boolean_enabled () =
+  let runtime_toml =
+    "[providers.local]\n\
+     enabled = \"no\"\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.sample]\n\
+     enabled = 0\n\
+     \n\
+     [runtime]\n\
+     default = \"local.sample\"\n"
+  in
+  match Runtime_toml.parse_string runtime_toml with
+  | Ok _ -> failf "non-boolean enabled fields should be rejected"
+  | Error errors ->
+    let rendered =
+      errors
+      |> List.map (fun (error : Runtime_toml.parse_error) ->
+        Printf.sprintf "%s: %s" error.path error.message)
+      |> String.concat "\n"
+    in
+    check bool "provider enabled path" true
+      (String_util.contains_substring rendered "providers.local.enabled");
+    check bool "binding enabled path" true
+      (String_util.contains_substring rendered "local.sample.enabled")
+;;
 
 (* One validator now decides every [runtime] field that names a routing target
    (keeper assignments, the route ids, media_failover entries), so the properties
@@ -3590,9 +3693,14 @@ let () =
           test_case
             "server degraded init rejects uncatalogued default"
             `Quick test_server_degraded_init_rejects_uncatalogued_default;
-          test_case
-            "runtime assignment rejects commented disabled binding"
-            `Quick test_runtime_assignment_rejects_commented_disabled_binding;
+          test_case "runtime enabled defaults true" `Quick
+            test_runtime_toml_enabled_defaults_true;
+          test_case "disabled provider excludes all of its bindings" `Quick
+            test_runtime_provider_disable_excludes_its_bindings;
+          test_case "disabled binding is excluded and rejected when referenced" `Quick
+            test_runtime_binding_disable_excludes_only_that_binding;
+          test_case "runtime enabled fields require booleans" `Quick
+            test_runtime_toml_rejects_non_boolean_enabled;
           test_case
             "every routing field names itself in its diagnostic"
             `Quick test_every_routing_field_names_itself_in_its_diagnostic;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -30,6 +30,7 @@ let with_env key value f =
 
 let runpod_provider =
   { Runtime_schema.id = "runpod_mtp"
+  ; enabled = true
   ; display_name = "RunPod"
   ; protocol = "openai-compatible-http"
   ; api_format = Chat_completions_api
@@ -64,6 +65,7 @@ let qwen_model =
 let runpod_binding =
   { Runtime_schema.provider_id = "runpod_mtp"
   ; model_id = "qwen"
+  ; enabled = true
   ; is_default = true
   ; wizard_default = false
   ; max_concurrent = None


### PR DESCRIPTION
## Summary

- add typed `enabled` flags to provider and binding TOML schemas, defaulting to `true`
- exclude disabled providers and bindings from runtime materialization and the install wizard
- expose provider/binding enablement in the Dashboard structured editor
- document local disablement while keeping the provider catalog and examples intact

## Why

Local deployments need to retain useful provider examples while preventing unavailable runtimes from entering executable inventory. Previously, deleting declarations was the only reliable option and `enabled = false` was not a typed runtime contract.

## Behavior

- `[providers.<id>] enabled = false` disables every binding owned by that provider.
- A binding-level `enabled = false` disables only that binding.
- Disabled route references fail clearly instead of silently selecting a fallback.
- Existing configurations remain enabled by default.

## Validation

- `scripts/dune-local.sh build test/test_runtime_config_validity.exe test/test_runtime_provider_auth_headers.exe bin/main_eio.exe`
- `test_runtime_config_validity.exe`: 69/69 passed
- `test_runtime_provider_auth_headers.exe`: 49/49 passed
- Dashboard TypeScript: `tsc --noEmit` passed
- focused Dashboard Vitest: 95/95 passed
- `git diff --check` passed
