### PR TITLE
fix(keeper): recovery 대체 여부를 failure class 별 닫힌 매핑으로 — #28016 이 코드버그 신호까지 열었다

### DIFF
--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -40,6 +40,35 @@ let failure_disposition = function
   | Provider_rejected -> Fatal
 ;;
 
+(* The operator gate on [Recovery_required] did two things, and #28016 removed
+   both. It stopped the keeper -- costly, and the reason it went: 38 recoveries
+   blocked 1,233 turns on 2026-08-10, a 32:1 amplification that took fleet
+   completion from 97.7% to 73.6%. It also made a failure visible, which is how
+   three code bugs were found (RFC-0368 §problem: unknown-notification cap ->
+   #27954, empty-delta -> #27969, retry-cap -> #27990). Superseding every class
+   keeps the first fix and drops the second: the same bugs now emit one info
+   line per turn that nothing reads, while the fleet runs on a degraded path.
+
+   RFC-0368's design separates the two by failure class, and this is that
+   mapping. A class whose resolution carried no human judgement supersedes; the
+   two classes whose park revealed a code bug keep it. Deciding per class also
+   means a new [recovery_failure] constructor cannot silently inherit
+   auto-supersede -- the compiler asks. *)
+type recovery_policy =
+  | Supersede_at_claim
+  | Park_for_operator
+
+let recovery_policy_of_failure = function
+  | Transient_spawn_failed
+  | Owner_stopped_turn
+  | Transport_interrupted
+  | Host_hook_failed
+  | State_persistence_failed
+  | Process_restarted ->
+    Supersede_at_claim
+  | Protocol_failed | Provider_rejected -> Park_for_operator
+;;
+
 type recovery_required =
   { recovery_id : string
   ; previous_settlement : settlement option
@@ -750,10 +779,19 @@ let plan_claim ~expected ~client_kind ~runtime_id =
         ; tool_surface_sha256
         ; _
         } ->
-      Ok
-        ( recovery.previous_settlement
-        , turn_count
-        , Option.map (fun _ -> tool_surface_sha256) recovery.previous_settlement )
+      (match recovery_policy_of_failure recovery.failure with
+       | Supersede_at_claim ->
+         Ok
+           ( recovery.previous_settlement
+           , turn_count
+           , Option.map (fun _ -> tool_surface_sha256) recovery.previous_settlement )
+       | Park_for_operator ->
+         Error
+           (Printf.sprintf
+              "official-client session recovery %s (%s) must be resolved before \
+               another execution"
+              recovery.recovery_id
+              (recovery_failure_to_string recovery.failure)))
   in
   Ok { previous_settlement; turn_count; required_tool_surface_sha256 }
 ;;

--- a/lib/keeper/keeper_official_client_session_store.mli
+++ b/lib/keeper/keeper_official_client_session_store.mli
@@ -32,6 +32,18 @@ type failure_disposition =
 
 val failure_disposition : recovery_failure -> failure_disposition
 
+(** What the next claim does with a durable [Recovery_required] record.
+
+    [Supersede_at_claim] replaces the observation and proceeds; the failure
+    carried no decision an operator could make. [Park_for_operator] refuses,
+    keeping the failure visible -- the classes where a park has caught a code
+    bug rather than an environment fault (RFC-0368). *)
+type recovery_policy =
+  | Supersede_at_claim
+  | Park_for_operator
+
+val recovery_policy_of_failure : recovery_failure -> recovery_policy
+
 type recovery_required =
   { recovery_id : string
   ; previous_settlement : settlement option

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -461,6 +461,92 @@ let test_restart_recovery_and_transient_release () =
     | None -> fail "transient release evidence was not persisted")
 ;;
 
+(* #28016 let the next claim supersede a Recovery_required record for every
+   failure class. That removed a 32:1 amplification -- 38 recoveries blocked
+   1,233 turns on 2026-08-10 -- and with it the only surface that made a
+   protocol-level code bug visible: three were found because the fleet stopped
+   (RFC-0368 §problem). These two cases pin the split. They fail together if
+   recovery_policy_of_failure is bypassed, and the pair is the point: parking
+   everything reinstates the amplification, superseding everything hides the
+   bugs. *)
+let test_protocol_failure_parks_for_operator () =
+  with_workspace "masc-official-client-store-park-" (fun base_path ->
+    let keeper_name = "park" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Claude_code
+        ~runtime_id:"claude-code.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    let recovery =
+      require_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~failure:Protocol_failed
+        ~detail:"client sent a frame the protocol does not allow"
+        ~required_at:2.0
+      |> Result.get_ok
+    in
+    match
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some recovery)
+        ~client_kind:Claude_code
+        ~owner_epoch:"22222222-2222-4222-8222-222222222222"
+        ~runtime_id:"claude-code.default"
+        ~tool_surface_sha256:empty_surface
+        ~updated_at:3.0
+    with
+    | Ok _ -> fail "a protocol failure was superseded; the code-bug signal is gone"
+    | Error _ -> ())
+;;
+
+let test_transport_interruption_supersedes_at_claim () =
+  with_workspace "masc-official-client-store-supersede-" (fun base_path ->
+    let keeper_name = "supersede" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Claude_code
+        ~runtime_id:"claude-code.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    let recovery =
+      require_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~failure:Transport_interrupted
+        ~detail:"Timeout: Claude Code turn timed out after 300.000s"
+        ~required_at:2.0
+      |> Result.get_ok
+    in
+    match
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some recovery)
+        ~client_kind:Claude_code
+        ~owner_epoch:"22222222-2222-4222-8222-222222222222"
+        ~runtime_id:"claude-code.default"
+        ~tool_surface_sha256:empty_surface
+        ~updated_at:3.0
+    with
+    | Error message ->
+      fail
+        (Printf.sprintf
+           "a turn timeout still needs an operator; the amplification is back: %s"
+           message)
+    | Ok _ -> ())
+;;
+
 let test_exact_recovery_restart () =
   with_workspace "masc-official-client-store-resolution-" (fun base_path ->
     let keeper_name = "resolution" in
@@ -768,6 +854,14 @@ let () =
             "restart recovery and transient release"
             `Quick
             test_restart_recovery_and_transient_release
+        ; test_case
+            "protocol failure parks for operator"
+            `Quick
+            test_protocol_failure_parks_for_operator
+        ; test_case
+            "transport interruption supersedes at claim"
+            `Quick
+            test_transport_interruption_supersedes_at_claim
         ; test_case "exact recovery restart" `Quick test_exact_recovery_restart
         ; test_case
             "retry previous restores exact settlement"


### PR DESCRIPTION
## 무엇을

`Recovery_required` 를 다음 claim 이 대체할지 여부를 **failure class 별 닫힌 매핑**으로 결정합니다. RFC-0368 §설계 1이 명시한 그 매핑입니다.

## 왜 — #28016 이 두 기능 중 하나만 남겼습니다

#28016 은 `Recovery_required` 를 전 클래스 auto-supersede 로 바꿨습니다. **가용성 논거는 옳고, 실측도 지지합니다.**

```
2026-08-10 라이브
  receipt_failed 1,307건의 terminal_reason_code
    config_error           1,277   ← 전부 "recovery <uuid> must be resolved"
    api_error_network         18
    internal_error            14
    provider_error_parse       1

  recovery 38건 → 차단된 턴 1,233건 → 32:1
  완주율 73.6%  ·  증폭 제외 시 97.7%
  Recovery 를 안 쓰는 rondo·lane-smith: 99.5%
```

fleet 손실의 94%가 이 게이트에서 나왔습니다. 없애는 것이 맞습니다.

**그런데 게이트에는 두 번째 기능이 있었습니다.** RFC-0368 §문제 표 그대로:

| 원인 | 운영자 판단 | 결과 |
|---|---|---|
| unknown-notification cap (`protocol_failed`) | — | **#27954 로 코드버그 제거** |
| empty-delta 거부 (`protocol_failed`) | — | **#27969 로 코드버그 제거** |
| retry-cap (`provider_rejected`) | — | **#27990 으로 코드버그 제거** |
| 300s 타임아웃 (`transport_interrupted`) | **0** | 전건 기계 규칙 |
| epoch 변경 | **0** | 전건 기계 규칙 |

> 게이트가 가치 있었던 순간도 분명하다: `protocol_failed`를 멈춰 세운 것이 empty-delta·retry-cap 코드버그를 **드러냈다**. — RFC-0368

### 대체 통제가 없습니다

```ocaml
Log.Keeper.info ~keeper_name
  "auto-superseded official-client recovery=%s failure=%s owner_epoch=%s"
```

```
$ rg -c 'auto.superseded' --glob '!_build' .
lib/keeper/keeper_official_client_session_store.ml:1     ← 정의 자신뿐
```

`info` 레벨, **소비자 0개**. 같은 코드버그가 재발하면 fleet 은 계속 돌고 로그만 쌓입니다.

## 변경

```ocaml
type recovery_policy =
  | Supersede_at_claim
  | Park_for_operator

let recovery_policy_of_failure = function
  | Transient_spawn_failed | Owner_stopped_turn | Transport_interrupted
  | Host_hook_failed | State_persistence_failed | Process_restarted ->
    Supersede_at_claim
  | Protocol_failed | Provider_rejected -> Park_for_operator
```

`failure_disposition` 의 함수로 만들 수 없습니다 — `Transport_interrupted` 와 `Protocol_failed` 가 둘 다 `Ambiguous` 인데 정책은 반대입니다. 두 질문이 다르므로 닫힌 매핑을 하나 더 둡니다.

닫힌 매핑이라 **새 `recovery_failure` 변형이 auto-supersede 를 조용히 상속하지 못합니다** — 컴파일러가 정책을 묻습니다.

## 라이브 영향 범위

현재 세션 파일의 failure 분포:

```
transport_interrupted   다수  → Supersede (변화 없음, 여전히 안 막힘)
process_restarted       다수  → Supersede
protocol_failed          1건  → Park (되돌아감)
```

즉 1,233건의 차단은 대부분 `transport_interrupted` 에서 왔고 그대로 풀린 채 유지됩니다. park 로 돌아가는 것은 드문 클래스뿐입니다.

## 검증

```
$ dune build --root . @test/runtest-test_official_client_session_store
Test Successful in 0.043s. 12 tests run.     (기존 10 + 신규 2)
```

**뮤테이션** — `Protocol_failed | Provider_rejected -> Supersede_at_claim` 으로 되돌리면:

```
> [FAIL]  durable owner  6  protocol failure parks for operator.
  [OK]    durable owner  7  transport interruption supersedes at claim.
FAIL a protocol failure was superseded; the code-bug signal is gone
1 failure! in 0.615s. 12 tests run.
```

**대조군이 초록으로 남는 것**이 요점입니다 — 전부 park 으로 되돌리면 32:1 이 돌아오고, 전부 supersede 하면 버그가 숨습니다. 두 테스트가 그 사이를 고정합니다.

라이브 검증은 주장하지 않습니다 — 이 소스는 아직 빌드·배포되지 않았습니다.

배경: #28025 · RFC-0368

RFC-WAIVED: RFC-0368 §설계 1의 매핑을 그대로 구현. 새 정책을 도입하지 않으며, 해당 RFC 가 이미 이 결정을 서술함.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
