### PR TITLE
fix(runtime): keep an unseen Antigravity step_type from ending the turn

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -226,6 +226,7 @@ and step_type =
   | User_input
   | Internal
   | Checkpoint
+  | Unrecognized of string
 
 and result_status =
   | Success
@@ -261,18 +262,26 @@ let parse_step_state stage value =
     value
 ;;
 
-let parse_step_type stage value =
-  closed_string
-    stage
-    "step_type"
-    (function
-      | "agent_response" -> Some Agent_response
-      | "tool" -> Some Tool
-      | "user_input" -> Some User_input
-      | "unknown" -> Some Internal
-      | "checkpoint" -> Some Checkpoint
-      | _ -> None)
-    value
+(* [step_type] decides one thing: whether this step is a tool step, for the two
+   tool counters. Every non-[Tool] value is behaviourally identical, so an
+   upstream value we have not seen carries no decision we could get wrong — but
+   rejecting it ended the turn and parked the session, which blocked every later
+   turn for that Keeper until an operator resolved it by hand. Live 2026-08-10:
+   Antigravity started emitting "system_message" and taskmaster stopped
+   (#28027). The value is kept in [Unrecognized] so the wire vocabulary drift is
+   still visible rather than silently normalised away.
+
+   [state], [permission_mode] and [status] stay closed: each of those does
+   decide something. *)
+let parse_step_type _stage value =
+  Ok
+    (match value with
+     | "agent_response" -> Agent_response
+     | "tool" -> Tool
+     | "user_input" -> User_input
+     | "unknown" -> Internal
+     | "checkpoint" -> Checkpoint
+     | other -> Unrecognized other)
 ;;
 
 let parse_result_status stage value =

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -143,6 +143,36 @@ let test_successful_official_client_turn () =
          check bool "measured wall duration" true (turn.wall_duration_s >= 0.0))
 ;;
 
+(* Live 2026-08-10 (#28027): Antigravity started emitting step_type
+   "system_message" and every taskmaster turn died on it, parking the session
+   until an operator resolved it. step_type only decides whether a step counts
+   as a tool step, so an unseen value carries no decision — but the tool
+   counters must still be exact for the values that do. *)
+let test_unknown_step_type_does_not_end_the_turn () =
+  with_fixture
+    [ init ()
+    ; step ~index:0 ~step_type:"system_message" ()
+    ; step ~index:1 ~state:"ACTIVE" ~step_type:"tool" ()
+    ; step ~index:2 ~state:"DONE" ~step_type:"tool" ()
+    ; step ~index:3 ~step_type:"agent_response" ()
+    ; result ()
+    ]
+    (fun path ->
+       match run_fixture path with
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok turn ->
+         check string "text" "MASC_ANTIGRAVITY_OK\n" turn.text;
+         check int "unknown step is not counted as a tool" 1 turn.tool_steps);
+  (* Control: a value that does decide something stays closed. *)
+  with_fixture
+    [ init (); step ~index:0 ~state:"SIDEWAYS" (); result () ]
+    (fun path ->
+       match run_fixture path with
+       | Error (Runtime_antigravity.Protocol_error _) -> ()
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok _ -> fail "an unknown step state was admitted")
+;;
+
 let test_child_environment_is_allowlisted () =
   Unix.putenv "MASC_PUBLIC_FIXTURE" "must-not-leak";
   with_fixture [ init (); result () ] (fun path ->
@@ -290,10 +320,13 @@ let test_unknown_protocol_vocabulary_fails_closed () =
   let unknown_permission =
     {|{"event":"init","conversation_id":"conversation-1","init":{"model":"gemini-fixture","cwd":"/tmp","permission_mode":"unreviewed"}}|}
   in
+  (* step_type left this list in #28027: it is the one vocabulary here that
+     decides nothing (see [test_unknown_step_type_does_not_end_the_turn]).
+     permission_mode, step state and result status each still decide something,
+     so an unseen value there is a real ambiguity and stays closed. *)
   let cases =
     [ "permission mode", [ unknown_permission; result () ]
     ; "step state", [ init (); step ~state:"PAUSED" (); result () ]
-    ; "step type", [ init (); step ~step_type:"shell" (); result () ]
     ; "result status", [ init (); result ~status:"PARTIAL" () ]
     ]
   in
@@ -412,6 +445,10 @@ let () =
             `Quick
             test_conversation_callback_failure_is_typed
         ; test_case "tool measurements" `Quick test_tool_steps_and_errors_are_measured
+        ; test_case
+            "unknown step type does not end the turn"
+            `Quick
+            test_unknown_step_type_does_not_end_the_turn
         ; test_case "error result" `Quick test_result_error_is_not_success
         ; test_case "duplicate keys" `Quick test_duplicate_keys_fail_closed
         ; test_case


### PR DESCRIPTION
라이브 taskmaster(antigravity)가 반복 파킹되던 원인입니다 — 2026-08-10 실측:

```
Parse error: step_update event: unsupported field "step_type" value "system_message"
```

Antigravity 가 `system_message` 를 내보내기 시작했는데 `parse_step_type` 의 닫힌 목록에 없어 **턴이 죽고 세션이 `Recovery_required` 로 파킹** → 그 keeper 의 이후 모든 턴이 claim 에서 fail closed. 오늘 `#27954`(unknown notification cap) · `#27969`(empty delta) · `#27990`(retry cap) 과 같은 클래스입니다.

## 왜 이 값만 여는가

`step_type` 의 소비처는 **하나**입니다 (`runtime_antigravity.ml` 의 상태 폴드):

```ocaml
let is_tool = step_type = Tool in
... tool_steps + if is_tool && step_state = Active then 1 else 0
... tool_errors + if is_tool && step_state = Step_error then 1 else 0
```

`Tool` 이 아닌 값은 전부 동작이 동일하므로, 못 본 값이 있어도 **우리가 틀릴 수 있는 판단이 없습니다**. 반면 같은 파일의 `permission_mode`(권한) · `state`(카운터 조건) · `status`(성공/실패)는 각각 실제로 무언가를 결정하므로 **닫힌 채로 둡니다**.

미지 값은 `Unrecognized of string` 으로 디코드해 wire 어휘 드리프트가 파싱 결과에 **보이게** 남깁니다 — 조용히 정규화하지 않습니다.

## 테스트

- 신규 `unknown step type does not end the turn`: `system_message` 가 섞인 스트림이 완주하고 **tool 카운터가 정확히 1** (미지 스텝이 tool 로 세어지지 않음) + **대조군**으로 미지 `state`("SIDEWAYS")는 여전히 `Protocol_error`
- 기존 `unknown protocol vocabulary fails closed` 에서 `step type` 케이스를 제거하고 **왜 제거하는지 주석으로 명시** — 나머지 3종(permission_mode/state/status)은 그대로 유지. 정책 변경을 우회가 아니라 명시적 변경으로 반영했습니다.
- 로컬: `test_runtime_antigravity.exe` 15/15 통과, `bin/main_eio.exe` 빌드 green.

## 참고

같은 로그 창에서 `permission_mode "request-review"` 거부도 보였는데 그건 **이미 main 에 있고**(라이브 바이너리가 낡았던 것) 방금 배포로 해소됐습니다. 이 PR 은 아직 남아 있는 `step_type` 축만 닫습니다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
