### PR TITLE
refactor(board): vote 반환값을 담고 있는 것의 이름으로 — delta 가 총점을 가리키고 있었다

### DIFF
--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -113,9 +113,14 @@ let persisted_vote_row_of_yojson = function
        | _ -> None)
   | _ -> None
 
-(* [vote_outcome] carries the information needed to run post-lock vote hooks. *)
+(* [vote_outcome] carries the information needed to run post-lock vote hooks.
+
+   [total_score] is the post's score after this vote, not the change this vote
+   made. It was called [delta] and read as a change by every caller name around
+   it; the file's other [delta] (karma_score_for_direction) really is a change,
+   so one word meant both. *)
 type vote_outcome = {
-  delta : int;
+  total_score : int;
   vote_target : string;
   vote_voter : string;
   vote_direction : vote_direction;
@@ -181,7 +186,7 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
                   Hashtbl.replace store.vote_log vote_key (direction, now);
                   mark_dirty_post store (Post_id.to_string pid);
                   invalidate_post_caches store;
-                  Ok { delta = flipped.votes_up - flipped.votes_down;
+                  Ok { total_score = flipped.votes_up - flipped.votes_down;
                        vote_target = vote_key;
                        vote_voter = voter;
                        vote_direction = direction;
@@ -196,7 +201,7 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
                   Hashtbl.replace store.vote_log vote_key (direction, now);
                   mark_dirty_post store (Post_id.to_string pid);
                   invalidate_post_caches store;
-                  Ok { delta = updated.votes_up - updated.votes_down;
+                  Ok { total_score = updated.votes_up - updated.votes_down;
                        vote_target = vote_key;
                        vote_voter = voter;
                        vote_direction = direction;
@@ -208,9 +213,9 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
          so holding [store.mutex] across their I/O would be gratuitous
          contention with every other reader/writer. *)
       (match board_result with
-       | Ok ({ delta; _ } as outcome) ->
+       | Ok ({ total_score; _ } as outcome) ->
            record_vote_side_effect store outcome;
-           Ok delta
+           Ok total_score
        | Error _ as e -> e)
 
 let current_vote_for_comment store ~voter ~comment_id
@@ -266,7 +271,7 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) Result
                 mark_dirty_comment store (Comment_id.to_string cid);
                 invalidate_comment_caches store;
                 Ok {
-                  delta = flipped.votes_up - flipped.votes_down;
+                  total_score = flipped.votes_up - flipped.votes_down;
                   vote_target = vote_key;
                   vote_voter = voter;
                   vote_direction = direction;
@@ -282,7 +287,7 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) Result
                 mark_dirty_comment store (Comment_id.to_string cid);
                 invalidate_comment_caches store;
                 Ok {
-                  delta = updated.votes_up - updated.votes_down;
+                  total_score = updated.votes_up - updated.votes_down;
                   vote_target = vote_key;
                   vote_voter = voter;
                   vote_direction = direction;
@@ -291,7 +296,7 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) Result
       )
       |> Result.map (fun outcome ->
              record_vote_side_effect store outcome;
-             outcome.delta)
+             outcome.total_score)
 
 (** {1 Stats} *)
 

--- a/lib/board/board_votes.mli
+++ b/lib/board/board_votes.mli
@@ -22,8 +22,8 @@
     - {b Vote log persistence}: [append_vote_log],
       [save_vote_log_jsonl].
     - {b Internal vote outcome}: the [vote_outcome] record
-      carries the score delta and post-lock vote log / feedback
-      side effects.
+      carries the post-vote total score and post-lock vote log /
+      feedback side effects.
     - {b Persistence loaders}: [load_persisted_posts],
       [load_persisted_comments], [load_persisted_votes],
       [recalculate_reply_counts].
@@ -83,10 +83,10 @@ val vote :
   direction:vote_direction ->
   (int, board_error) Result.t
 (** Casts a vote on the post identified by [post_id].
-    Returns [Ok delta] where [delta] is the new
-    [(votes_up - votes_down)] score.  Validates [voter] +
-    [post_id] before taking the lock; rejects duplicate
-    votes in the same direction with [Already_voted].
+    Returns [Ok total_score] — the post's [(votes_up - votes_down)]
+    score {b after} this vote, not the amount this vote changed it.
+    Validates [voter] + [post_id] before taking the lock; rejects
+    duplicate votes in the same direction with [Already_voted].
 
     Vote flips swap up↔down without re-counting (and
     {b without} earning credits, to prevent down/up

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -628,6 +628,31 @@ let test_dashboard_projection_does_not_produce_attention_candidate () =
          (Atomic.get entry.fiber_wakeup))
 ;;
 
+(* [vote] returns the post's score after the vote, not the amount this vote
+   changed it. The two are equal for the first voter, which is why the field
+   could sit under the name [delta] and read correctly everywhere it was tried
+   (#27675). A second voter separates them: the total is 2, a change is 1. *)
+let test_vote_returns_total_score_not_change () =
+  let post =
+    match
+      Board_dispatch.create_post ~author:"score-author"
+        ~content:"two voters separate a total from a change" ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  let vote_exn ~voter =
+    match Board_dispatch.vote ~voter ~post_id ~direction:Board.Up with
+    | Ok score -> score
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let first = vote_exn ~voter:"score-voter-a" in
+  let second = vote_exn ~voter:"score-voter-b" in
+  Alcotest.(check int) "first vote: total and change agree" 1 first;
+  Alcotest.(check int) "second vote returns the total, not the change" 2 second
+;;
+
 let test_recent_sort_bypasses_hot_cutoff () =
   let create_post_exn ~author ~content =
     match
@@ -2195,6 +2220,8 @@ let () =
         (with_eio test_reaction_rejects_unsupported_emoji);
     ];
     "misc", [
+      Alcotest.test_case "vote returns total score, not change" `Quick
+        (with_eio test_vote_returns_total_score_not_change);
       Alcotest.test_case "stats" `Quick (with_eio test_stats);
       Alcotest.test_case "search" `Quick (with_eio test_search);
       Alcotest.test_case "hearths" `Quick (with_eio test_hearths);


### PR DESCRIPTION
## 무엇을

`Board_votes.vote` 의 반환값이 실제로 담고 있는 것에 맞게 이름을 고칩니다. `#27675` 을 닫습니다.

## 문제

`.mli` 문장이 자기 주어와 모순됩니다:

```
Returns [Ok delta] where [delta] is the new (votes_up - votes_down) score.
        ^^^^^ 변동량                          ^^^^^^^^^^^^^^^^^^^^^ 총점
```

그리고 **같은 파일에 진짜 delta 가 따로 있습니다**:

```ocaml
(* :835 *)
(** Scoring contract: returns the karma delta for a vote direction.
    Upvotes earn +1 karma; downvotes do not deduct karma (delta = 0). *)
```

한 단어가 두 개념을 나릅니다. 첫 투표자에서는 총점과 변동량이 **둘 다 1** 이라 구별되지 않고, 두 번째 투표자부터 어긋납니다.

## 변경

파일 로컬 `vote_outcome.delta` → `total_score`. 타입은 export 되지 않고 **wire 는 건드리지 않습니다.**

`#27675` 이 인용한 `.mli:231` 은 확인해 보니 `karma_event_to_yojson` 의 것이고, 그 `delta` 는 **진짜 karma 변동량(+1/0)** 이라 이름이 옳습니다. 대시보드 소비자도 그쪽입니다:

```ts
// dashboard/src/api/board.ts:872 — karma_event
delta: asNumber(raw.delta, 0),
```

그래서 이번 변경의 폭발 반경은 `board_votes.ml` 내부 + `.mli` 주석뿐입니다.

## 이슈가 인용한 심볼은 이미 개명돼 있었습니다

| #27675 표기 | 현재 |
|---|---|
| `vote_post_with_direction` | `Board_votes.vote` |
| `vote_comment_with_direction` | `Board_votes.vote_comment` |

개명은 됐지만 **의미 혼선은 이월**됐습니다. 이 PR 이 그쪽을 닫습니다.

## 검증

```
$ dune build --root . @test/runtest-test_board_dispatch
  [OK]  misc  0  vote returns total score, not change.
```

새 테스트는 두 개념을 **분리해서** 고정합니다 — 투표자 한 명으로는 총점과 변동량을 구별할 수 없으므로 두 명을 씁니다:

```ocaml
let first  = vote_exn ~voter:"score-voter-a" in   (* 총점 1 = 변동량 1 *)
let second = vote_exn ~voter:"score-voter-b" in   (* 총점 2 ≠ 변동량 1 *)
Alcotest.(check int) "second vote returns the total, not the change" 2 second
```

`board_vote_persistence` 도 6/6 통과.

## 이 PR 과 무관한 기존 실패 4건 (별도 보고)

`test_board_dispatch` 는 이 브랜치에서 **81 tests / 4 failures** 인데, `origin/main` 을 그대로 체크아웃해 돌려도 **80 tests / 같은 4 failures** 입니다:

```
[FAIL] posts       12  dedup hit does not fan out post_created
[FAIL] posts       19  first observation starts at current head
[FAIL] posts       20  dashboard projection does not produce ...
[FAIL] validation   3  malformed target fails closed
```

제 변경으로 생긴 것이 아니며, 이 스위트는 CI 에 배선돼 있지 않습니다:

```
$ rg -c 'runtest-test_board_dispatch' .github/workflows/ci.yml scripts/ci-run-focused-tests.sh
(0건)
```

별도 이슈로 올립니다 — 이 PR 에서 고치면 범위를 넘습니다.

RFC-WAIVED: 파일 로컬 필드 개명 + 문서 정정. wire·durable 포맷 무변경, export 표면 무변경, 동작 무변경.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
