### PR TITLE
fix(fusion): publish the Eio context the harness's panelists read

### DIFF
--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -391,6 +391,15 @@ let () =
   (* Capture the Eio handles used by Fusion runtime dependencies and elapsed
      telemetry. This does not install a Fusion-owned execution deadline. *)
   Masc.Masc_eio_env.init ~sw ~net ~clock:(Eio.Stdenv.clock env) ();
+  (* Official-client panelists spawn a CLI, so they read the process manager and
+     the clock off Eio_context. Masc_eio_env above is a different store
+     (Domain.DLS) and does not feed it. The server publishes both from
+     server_runtime_bootstrap; this harness is the other entry point into the
+     same panel code and has to publish them too, or every official-client
+     panelist in a preset fails while the same preset answers under the
+     server. *)
+  Eio_context.set_env env;
+  Eio_context.set_clock (Eio.Stdenv.clock env);
   let config_path = Masc.Fusion_config_loader.runtime_toml_path ~base_path in
   (match Runtime.init_default_strict ~config_path with
    | Error msg ->

--- a/lib/fusion/fusion_official_client.ml
+++ b/lib/fusion/fusion_official_client.ml
@@ -24,13 +24,29 @@ let provider_error ~runtime_id detail : Fusion_types.panel_failure =
 ;;
 
 let eio_context ~runtime_id =
+  (* Naming the absent handle is the point: both are published together by the
+     server but separately by other entry points, so "the Eio runtime is not
+     initialized" sends the reader to look at the wrong one. *)
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | Some env, Some clock -> Ok (env, clock)
-  | None, _ | _, None ->
+  | None, None ->
     Error
       (provider_error
          ~runtime_id
-         "official-client panelist requires the initialized Eio runtime")
+         "official-client panelist requires Eio_context env and clock; neither \
+          is published")
+  | None, Some _ ->
+    Error
+      (provider_error
+         ~runtime_id
+         "official-client panelist requires Eio_context env (process manager \
+          and fs); it is not published")
+  | Some _, None ->
+    Error
+      (provider_error
+         ~runtime_id
+         "official-client panelist requires Eio_context clock; it is not \
+          published")
 ;;
 
 (* [Runtime_execution.*] carries admission-time config; each adapter has its own


### PR DESCRIPTION
## 증상

#28020 이 official-client 패널 경로를 열었는데, `bin/fusion_run` 하네스로 돌리면 패널리스트 전원이 실패한다.

```
$ fusion_run.exe --base /Users/dancer/me --preset subscription_trio -- "..."
[fusion] claude_code.claude-opus-5  FAILED: provider_error: ... requires the initialized Eio runtime
[fusion] codex_subscription.gpt-5.6-sol  FAILED: ... 동일
[fusion] antigravity_subscription.gemini-3-6-flash-high  FAILED: ... 동일
```

서버 경로는 정상이다 — `server_runtime_bootstrap.ml:483` 이 `Eio_context.set_env` 를 호출한다. 하네스만 호출하지 않는다.

## 원인

패널 경로는 spawn 을 위해 `Eio_context` 에서 **env(process manager · fs)와 clock 둘 다** 읽는다. `fusion_run.ml` 은 `Masc_eio_env.init ~sw ~net ~clock` 을 부르는데, 그건 `Domain.DLS` 기반의 **별개 저장소**라 `Eio_context` 를 채우지 않는다.

이름이 비슷한 두 저장소가 있고 하나만 채워져 있었다.

## 변경

1. `bin/fusion_run.ml` — `Eio_context.set_env` 와 `set_clock` 을 함께 발행한다. dune 의존은 이미 `masc_eio_context` 를 포함하고 있었다.
2. `lib/fusion/fusion_official_client.ml` — 실패 메시지가 **어느 핸들이 없는지** 말하게 한다. 원래 메시지("requires the initialized Eio runtime")는 env 를 채운 뒤에도 그대로여서, clock 이 문제라는 것을 알아내는 데 빌드 사이클 하나가 더 들었다. 세 갈래(env 없음 / clock 없음 / 둘 다 없음)로 분리.

## 검증 — 라이브 종단

masc `8780909741` + 이 변경으로 빌드, 라이브 설정(`~/me/.masc`, 런타임 43)에서 `subscription_trio` 실행:

```
[fusion] claude_code.claude-opus-5                        (tokens in/out: 0/0)
[fusion] codex_subscription.gpt-5.6-sol                   (tokens in/out: 0/0)
[fusion] antigravity_subscription.gemini-3-6-flash-high   (tokens in/out: 0/0)
[fusion] decision: Answer
```

세 패널리스트 전원 답변, judge 합성 완주. 직전(2026-08-10, #28020 이전)에 같은 preset 은 `failed` · `panels_unavailable` · `none of 3 panels returned an answer` 였다.

`tokens 0/0` 은 예상된 값이다 — official client 는 토큰 회계를 반환하지 않아 `Fusion_types.zero_usage` 를 쓴다 (#28020).

judge 축은 별개다: 이 preset 의 judge 가 `claude_code.claude-haiku-4-5` 였는데 official-client 는 judge 가 될 수 없어(`owned by an official client, not Agent Core`) 심의 전체가 죽었다. **설정 쪽에서** Agent_core 런타임으로 옮겼고, 코드 변경은 없다 — #28020 이 판단대로 judge 축은 구조적 JSON 계약 때문에 Agent_core 로 남아 있다.

## 미검증

하네스 전용 경로라 새 테스트를 추가하지 않았다. 회귀 신호는 `subscription_trio` 실행 자체이고, 위 실행이 그 증거다. 서버 경로는 `test/test_fusion_official_client_panel.ml` (#28020) 이 스텁 CLI spawn 으로 이미 덮는다.

RFC-WAIVED: 디버그 하네스 진입점 하나에 이미 존재하는 전역 컨텍스트를 발행하는 변경과 에러 메시지 분기다. credential / identity / operator control / sandbox / hooks / workflow 문서에 닿지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
