### PR TITLE
fix(runtime): 읽지 않는 provider 필드 3자리의 제약 제거 — 같은 모양이 이번 주 키퍼 둘을 세웠다

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -303,7 +303,9 @@ let parse_step_update fields =
   let* step_json = required_member stage "step_update" fields in
   let* step_fields = assoc_at stage step_json in
   let* conversation_id = required_string stage "conversation_id" step_fields in
-  let* _step_index = required_nonnegative_int stage "step_index" step_fields in
+  (* [step_index] is not read; [state] and [step_type] are what this event
+     contributes. Requiring a non-negative int on an unread ordinal made a
+     step update fail on a value nothing consumes (#28010). *)
   let* state_string = required_string stage "state" step_fields in
   let* state = parse_step_state stage state_string in
   let* step_type_string = required_string stage "step_type" step_fields in

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -385,7 +385,9 @@ let parse_initialize result =
 let parse_subscription result =
   let stage = "account/read" in
   let* fields = assoc_at stage result in
-  let* _requires_auth = required_bool stage "requiresOpenaiAuth" fields in
+  (* [requiresOpenaiAuth] is in the response and is not read: the decision
+     below is account.type = "chatgpt". Requiring it to be a bool made the
+     subscription probe depend on a field this tree ignores (#28010). *)
   let* account = required_member stage "account" fields in
   match account with
   | `Null -> Error (Subscription_required "the official CLI has no active account")
@@ -532,7 +534,12 @@ let validate_item_delta_notification ~method_ ~thread_id ~turn_id params =
   let* fields = assoc_at method_ params in
   let* notification_thread_id = required_string method_ "threadId" fields in
   let* notification_turn_id = required_string method_ "turnId" fields in
-  let* _item_id = required_string method_ "itemId" fields in
+  (* [delta] stays required: its presence is what makes this frame an item
+     delta, and the identity check below is only meaningful on one. Its
+     *content* is not checked -- #27967 rejected empty chunks a provider
+     legitimately sends. [itemId] carries neither role. Nothing here reads it,
+     so a frame that omits it or sends it empty changes nothing this function
+     decides, while requiring it adds one more way to end a turn (#28010). *)
   let* _delta = required_string_any method_ "delta" fields in
   if notification_thread_id <> thread_id || notification_turn_id <> turn_id
   then protocol_error method_ "item delta identity does not match the active turn"

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -521,6 +521,32 @@ let test_empty_output_delta_does_not_end_the_turn () =
     ; "whitespace delta", {|"   "|}
     ; "newline delta", {|"\n"|}
     ];
+  (* itemId is not read here, so its content cannot change what this frame
+     decides. It used to be required non-empty and a keeper died on the frames
+     that carried it empty; the identity check that does matter -- threadId and
+     turnId -- is asserted unchanged in the rejection list below. *)
+  List.iter
+    (fun (label, notification) ->
+      with_fixture
+        [ init_result
+        ; account_chatgpt
+        ; thread_result
+        ; turn_result
+        ; notification
+        ; item_completed
+        ; turn_completed
+        ]
+        (fun path ->
+          match run_fixture path with
+          | Ok result -> check string label "MASC_SUBSCRIPTION_OK" result.text
+          | Error error -> fail (Runtime_codex_app_server.error_to_string error)))
+    [ ( "empty itemId"
+      , {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"","delta":"chunk"}}|}
+      )
+    ; ( "absent itemId"
+      , {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"turn-1","delta":"chunk"}}|}
+      )
+    ];
   List.iter
     (fun (label, notification) ->
       with_fixture
@@ -533,9 +559,6 @@ let test_empty_output_delta_does_not_end_the_turn () =
     [ ( "a non-string delta was admitted", delta "42" )
     ; ( "a delta that is not present was admitted"
       , {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"command-1"}}|}
-      )
-    ; ( "an empty itemId was admitted"
-      , {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"","delta":"chunk"}}|}
       )
     ; ( "an empty turnId was admitted"
       , {|{"method":"item/commandExecution/outputDelta","params":{"threadId":"thread-1","turnId":"","itemId":"command-1","delta":"chunk"}}|}


### PR DESCRIPTION
## 무엇을

읽지 않는 provider 필드에 걸린 제약 3자리를 제거합니다. `#28010` 을 닫습니다.

## 문제 — 판단에 쓰지 않는 값이 턴을 죽입니다

| 파일 | 필드 | 제약 | 소비 |
|---|---|---|---|
| `runtime_codex_app_server.ml:535` | `itemId` | 빈 문자열 거부 | `_item_id` — 폐기 |
| `runtime_codex_app_server.ml:388` | `requiresOpenaiAuth` | bool 요구 | `_requires_auth` — 폐기 |
| `runtime_antigravity.ml:306` | `step_index` | 음이 아닌 int 요구 | `_step_index` — 폐기 |

바인딩이 `_` 로 시작하므로 **컴파일러가 이미 "아무도 안 읽는다"고 알고 있습니다.** 읽지 않는 값에 걸린 제약이 할 수 있는 일은 거부뿐이고, 거부는 턴을 terminal 로 만들고, terminal 턴은 세션을 `Recovery_required` 로 보냅니다.

이 형태가 이번 주에 키퍼 둘을 세웠습니다:

| # | 필드 | 결과 |
|---|---|---|
| #27967 | `delta` non-empty 요구, `_delta` 로 폐기 | 오염 3건 → 턴 3,236건 거부 |
| #28008 | `permission_mode` 멤버 1개, `match` 없음 | taskmaster 1시간 110턴 0% |

둘 다 **키퍼가 멈춘 뒤에** 발견됐습니다.

## `delta` 는 왜 남기나

```ocaml
(* delta 는 이 프레임이 item delta 라는 표시이고,
   뒤따르는 identity 검사는 그런 프레임에서만 의미가 있다.
   itemId 는 두 역할 중 어느 것도 하지 않는다. *)
let* _delta = required_string_any method_ "delta" fields in
```

`delta` 는 **존재**가 프레임 종류를 가리킵니다(내용은 #27969 이후 검사하지 않음). `itemId` 는 식별자일 뿐이고 이 함수는 `threadId`/`turnId` 로만 판단합니다. 그 두 거부는 **그대로 유지**되고 테스트도 그대로입니다.

## 검증

```
$ dune build --root . @test/runtest-test_runtime_codex_app_server
Test Successful in 27.812s. 32 tests run.
```

`empty itemId` 케이스를 **거부 목록에서 허용 목록으로 옮겼습니다** — 같은 픽스처, 반대 판정. 디코더를 넓힌다는 것이 그런 뜻입니다. `absent itemId` 도 함께 추가했습니다.

**뮤테이션** — `required_string ... "itemId"` 를 되돌리면:

```
> [FAIL]  subscription boundary  14  an empty output delta does...
ASSERT Codex app-server protocol error during item/commandExecution/outputDelta:
       field "itemId" must be a non-empty string
1 failure! in 19.815s. 32 tests run.
```

프로덕션 에러 문구 그대로 실패합니다.

## 등가 통제

제거되는 것은 **거부 경로**이므로, 남아 있어야 할 거부를 명시합니다:

| 그대로 유지 | 확인 |
|---|---|
| `threadId` 불일치 거부 | 기존 테스트 유지 |
| `turnId` 빈 문자열 거부 | 기존 테스트 유지 |
| `delta` 부재 거부 | 기존 테스트 유지 |
| `delta` 비문자열 거부 | 기존 테스트 유지 |
| `account.type = "chatgpt"` 판정 | `parse_subscription` 의 실제 결정, 무변경 |
| `state` · `step_type` 파싱 | `parse_step_update` 의 실제 산출, 무변경 |

RFC-WAIVED: 읽지 않는 필드의 제약 제거. 새 동작·새 게이트·새 기본값 없음이며, 유지되는 거부 6종을 위에 열거함.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
