### PR TITLE
fix(keeper): preserve typed official-client context

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -58,21 +58,12 @@ let home_error_to_core_error error =
 ;;
 
 let render_message (message : Agent_core.Types.message) =
-  let* text =
-    Host.text_of_blocks
-      ~runtime_label
-      ~field:"initial_messages"
-      message.content
-  in
+  let text = Host.encode_history_message message in
   match message.role with
   | Agent_core.Types.System -> Ok ("SYSTEM:\n" ^ text)
   | Agent_core.Types.User -> Ok ("USER:\n" ^ text)
   | Agent_core.Types.Assistant -> Ok ("ASSISTANT:\n" ^ text)
-  | Agent_core.Types.Tool ->
-    Error
-      (config_error
-         ~field:"initial_messages"
-         "Antigravity history projection does not admit tool-role messages")
+  | Agent_core.Types.Tool -> Ok ("TOOL:\n" ^ text)
 ;;
 
 let render_messages messages =

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -60,12 +60,7 @@ let project_messages messages =
   let rec loop developer history = function
     | [] -> Ok (List.rev developer, List.rev history)
     | (message : Agent_core.Types.message) :: rest ->
-      let* text =
-        Host.text_of_blocks
-          ~runtime_label
-          ~field:"initial_messages"
-          message.content
-      in
+      let text = Host.encode_history_message message in
       (match message.role with
        | Agent_core.Types.System -> loop (text :: developer) history rest
        | Agent_core.Types.User ->
@@ -77,10 +72,9 @@ let project_messages messages =
            ({ Runtime_codex_app_server.role = Assistant; text } :: history)
            rest
        | Agent_core.Types.Tool ->
-         Error
-           (config_error
-              ~field:"initial_messages"
-              "codex-app-server history injection does not admit AGENT_CORE tool messages"))
+         loop developer
+           ({ Runtime_codex_app_server.role = User; text } :: history)
+           rest)
   in
   loop [] [] messages
 ;;

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -19,55 +19,28 @@ let text_of_blocks ~runtime_label ~field blocks =
   loop [] blocks
 ;;
 
-type history_projection =
-  { messages : Agent_core.Types.message list
-  ; dropped_tool_messages : int
-  ; dropped_messages : int
-  ; dropped_blocks : int
-  }
-
-(* The official-client wire admits text-only user/assistant history
-   ([text_of_blocks] rejects every other block, and Tool-role messages are not
-   representable at all). Project the representable subset instead of erasing
-   the whole history, and account for every dropped part so the caller can
-   surface the loss (masc#27812). *)
-let project_official_history messages =
-  let project
-      (kept, dropped_tool, dropped_msgs, dropped_blocks)
-      (message : Agent_core.Types.message) =
-    match message.role with
-    | Tool -> kept, dropped_tool + 1, dropped_msgs, dropped_blocks
-    | System | User | Assistant ->
-      let text_blocks, other_blocks =
-        List.partition
-          (function
-            | Agent_core.Types.Text _ -> true
-            | _ -> false)
-          message.content
-      in
-      let dropped_blocks = dropped_blocks + List.length other_blocks in
-      (match text_blocks, message.content with
-       | [], _ :: _ -> kept, dropped_tool, dropped_msgs + 1, dropped_blocks
-       | _, _ ->
-         ( { message with content = text_blocks } :: kept
-         , dropped_tool
-         , dropped_msgs
-         , dropped_blocks ))
+let encode_history_message (message : Agent_core.Types.message) =
+  let text_only =
+    message.role <> Tool
+    && List.for_all
+         (function
+           | Agent_core.Types.Text _ -> true
+           | _ -> false)
+         message.content
   in
-  let kept, dropped_tool_messages, dropped_messages, dropped_blocks =
-    List.fold_left project ([], 0, 0, 0) messages
-  in
-  { messages = List.rev kept
-  ; dropped_tool_messages
-  ; dropped_messages
-  ; dropped_blocks
-  }
-;;
-
-let history_projection_lossless projection =
-  projection.dropped_tool_messages = 0
-  && projection.dropped_messages = 0
-  && projection.dropped_blocks = 0
+  if text_only
+  then
+    message.content
+    |> List.filter_map (function
+      | Agent_core.Types.Text text -> Some text
+      | _ -> None)
+    |> String.concat "\n"
+  else
+    `Assoc
+      [ "schema", `String "masc.official-client-context-message.v1"
+      ; "message", Keeper_context_core.message_to_json message
+      ]
+    |> Yojson.Safe.to_string
 ;;
 
 let user_message text : Agent_core.Types.message =

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -78,23 +78,12 @@ val text_of_blocks :
   Agent_core.Types.content_block list ->
   (string, Agent_core.Error.t) result
 
-type history_projection =
-  { messages : Agent_core.Types.message list
-  ; dropped_tool_messages : int
-  ; dropped_messages : int
-  ; dropped_blocks : int
-  }
-
-(** Project canonical history onto the official-client wire, which admits
-    text-only user/assistant items. Tool-role messages are dropped whole,
-    non-text blocks are stripped from kept messages, and a message left
-    without any text is dropped; every drop is counted. The representable
-    remainder keeps its original order (masc#27812). *)
-val project_official_history :
-  Agent_core.Types.message list -> history_projection
-
-(** [true] when the projection dropped nothing. *)
-val history_projection_lossless : history_projection -> bool
+val encode_history_message : Agent_core.Types.message -> string
+(** Preserve one canonical message on a text-only official-client wire.
+    Text-only non-tool messages remain plain text. Tool-role messages and any
+    message containing typed blocks are encoded as the canonical message JSON
+    inside a versioned envelope, so role, block payloads, tool identities, and
+    metadata remain visible instead of being discarded. *)
 
 val hook_error :
   runtime_label:string ->

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -385,8 +385,6 @@ let decision_public_allowlist =
     ; "routing_action"; "routing_reason"; "degraded_runtime_id"
     ; "runtime_execution_built"
     ; "media_dropped_total"; "media_dropped_counts"
-    ; "history_kept_messages"; "history_dropped_tool_messages"
-    ; "history_dropped_messages"; "history_dropped_blocks"
     ; "payload_role"; "trigger"; "trigger_detail"
     ; "ratio"; "threshold"; "count"
     ; "source_requeued"; compaction_outcome_key

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -741,46 +741,7 @@ let run_named
                      ])
                  Keeper_runtime_manifest.Runtime_routed
              | None -> ());
-            let ({ Keeper_official_client_host.messages = projected_history
-                 ; dropped_tool_messages
-                 ; dropped_messages
-                 ; dropped_blocks
-                 } as projection)
-              =
-              Keeper_official_client_host.project_official_history
-                initial_messages
-            in
-            if
-              not
-                (Keeper_official_client_host.history_projection_lossless
-                   projection)
-            then (
-              Log.Keeper.warn
-                "%s: official-client runtime %s history projection dropped %d \
-                 tool message(s), %d unrepresentable message(s), %d non-text \
-                 block(s); the text-only remainder is preserved"
-                keeper_name
-                attempt_runtime_id
-                dropped_tool_messages
-                dropped_messages
-                dropped_blocks;
-              emit_runtime_manifest
-                ~status:"degraded"
-                ~decision:
-                  (`Assoc
-                    [ ( "routing_action"
-                      , `String "official_client_history_projected" )
-                    ; ( "routing_reason"
-                      , `String "official_client_wire_admits_text_only_history"
-                      )
-                    ; ( "history_kept_messages"
-                      , `Int (List.length projected_history) )
-                    ; ("history_dropped_tool_messages", `Int dropped_tool_messages)
-                    ; ("history_dropped_messages", `Int dropped_messages)
-                    ; ("history_dropped_blocks", `Int dropped_blocks)
-                    ])
-                Keeper_runtime_manifest.Runtime_routed);
-            run_codex ~initial_messages:projected_history ()
+            run_codex ~initial_messages ()
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let codex_result =
@@ -816,43 +777,8 @@ let run_named
             ~raw_trace
             ~config
         in
-        let run_projected_antigravity () =
-          let ({ Keeper_official_client_host.messages = projected_history
-               ; dropped_tool_messages
-               ; dropped_messages
-               ; dropped_blocks
-               } as projection)
-            =
-            Keeper_official_client_host.project_official_history initial_messages
-          in
-          if
-            not
-              (Keeper_official_client_host.history_projection_lossless projection)
-          then (
-            Log.Keeper.warn
-              "%s: official-client runtime %s history projection dropped %d \
-               tool message(s), %d unrepresentable message(s), %d non-text \
-               block(s); the text-only remainder is preserved"
-              keeper_name
-              attempt_runtime_id
-              dropped_tool_messages
-              dropped_messages
-              dropped_blocks;
-            emit_runtime_manifest
-              ~status:"degraded"
-              ~decision:
-                (`Assoc
-                  [ ( "routing_action"
-                    , `String "official_client_history_projected" )
-                  ; ( "routing_reason"
-                    , `String "official_client_wire_admits_text_only_history" )
-                  ; "history_kept_messages", `Int (List.length projected_history)
-                  ; "history_dropped_tool_messages", `Int dropped_tool_messages
-                  ; "history_dropped_messages", `Int dropped_messages
-                  ; "history_dropped_blocks", `Int dropped_blocks
-                  ])
-              Keeper_runtime_manifest.Runtime_routed);
-          run_antigravity ~initial_messages:projected_history ()
+        let run_antigravity_with_history () =
+          run_antigravity ~initial_messages ()
         in
         let antigravity_result =
           match provider_config_transform, agent_core_checkpoint with
@@ -881,8 +807,8 @@ let run_named
                     , `String "official_client_session_store_owns_resume" )
                   ])
               Keeper_runtime_manifest.Runtime_routed;
-            run_projected_antigravity ()
-          | None, None -> run_projected_antigravity ()
+            run_antigravity_with_history ()
+          | None, None -> run_antigravity_with_history ()
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let antigravity_result =

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -27,6 +27,7 @@ let write_file ~mode path contents =
 
 let fixture_script ~base_path =
   let path = Filename.concat base_path "agy-fixture.sh" in
+  let prompt_path = Filename.concat base_path "antigravity-prompt.txt" in
   let script =
     Printf.sprintf
       {|#!/bin/sh
@@ -58,6 +59,7 @@ test "$expect_mode" -eq 0
 test "$mode" = plan
 test "$sandbox" -eq 1
 test "$slash_commands_disabled" -eq 1
+printf '%%s' "$2" > %s
 printf '{"event":"init","conversation_id":"%%s","init":{"model":"gemini-fixture","cwd":%s,"tools":["call_mcp_tool"],"permission_mode":"always-proceed"}}\n' "$conversation"
 python3 - <<'PY'
 import json
@@ -102,6 +104,7 @@ printf '{"event":"result","result":{"conversation_id":"%%s","status":"SUCCESS","
                (Filename.concat base_path ".masc")
                "official-clients")
             "antigravity/antigravity-fixture"))
+      (shell_quote prompt_path)
       (Yojson.Safe.to_string (`String base_path))
   in
   write_file ~mode:0o700 path script;
@@ -233,6 +236,16 @@ let test_keeper_projects_mcp_tool_and_settles () =
         "tool arguments"
         {|{"marker":"from-antigravity"}|}
         (Yojson.Safe.to_string !observed);
+      let prompt_path = Filename.concat base_path "antigravity-prompt.txt" in
+      let prompt = In_channel.with_open_bin prompt_path In_channel.input_all in
+      check bool
+        "prompt preserves prior tool role"
+        true
+        (String_util.contains_substring prompt {|"role":"tool"|});
+      check bool
+        "prompt preserves prior tool output"
+        true
+        (String_util.contains_substring prompt "prior tool output");
       let trace_ref =
         match !observed_trace_ref with
         | Some trace_ref -> trace_ref

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -224,100 +224,52 @@ let msg role content : Agent_core.Types.message =
 
 let text value = Agent_core.Types.Text value
 
-let projection_counts
-    { Host.messages = _; dropped_tool_messages; dropped_messages; dropped_blocks } =
-  dropped_tool_messages, dropped_messages, dropped_blocks
+let encoded_message_json message =
+  let encoded = Host.encode_history_message message |> Yojson.Safe.from_string in
+  let open Yojson.Safe.Util in
+  check string
+    "envelope schema"
+    "masc.official-client-context-message.v1"
+    (encoded |> member "schema" |> to_string);
+  encoded |> member "message"
 ;;
 
-(* Feeding the projected output back through the strict [text_of_blocks] both
-   extracts the kept text and proves the projection satisfies the runtime's
-   admission invariant. Expected values below stay literal. *)
-let projected_texts (projection : Host.history_projection) =
-  List.map
-    (fun (message : Agent_core.Types.message) ->
-      match
-        Host.text_of_blocks
-          ~runtime_label:"Test"
-          ~field:"projection"
-          message.content
-      with
-      | Ok value -> value
-      | Error _ -> fail "projected message still holds non-text blocks")
-    projection.Host.messages
+let test_text_history_is_preserved_verbatim () =
+  let message = msg Agent_core.Types.User [ text "first"; text "second" ] in
+  check string "plain text" "first\nsecond" (Host.encode_history_message message)
 ;;
 
-let test_lossless_history_is_preserved_verbatim () =
-  let projection =
-    Host.project_official_history
-      [ msg Agent_core.Types.User [ text "prior user turn" ]
-      ; msg Agent_core.Types.Assistant [ text "prior assistant reply" ]
+let test_tool_message_is_preserved_as_canonical_json () =
+  let message =
+    Agent_core.Types.tool_result_msg
+      ~tool_use_id:"call-1"
+      ~content:"tool output"
+      ()
+  in
+  check string
+    "canonical tool message"
+    (Keeper_context_core.message_to_json message |> Yojson.Safe.to_string)
+    (encoded_message_json message |> Yojson.Safe.to_string)
+;;
+
+let test_typed_blocks_are_preserved_as_canonical_json () =
+  let message =
+    msg
+      Agent_core.Types.Assistant
+      [ Agent_core.Types.Thinking
+          { content = "prior provider reasoning"; signature = None }
+      ; text "visible reply"
+      ; Agent_core.Types.ToolUse
+          { id = "call-1"
+          ; name = "prior_tool"
+          ; input = `Assoc [ "path", `String "README.md" ]
+          }
       ]
   in
-  check
-    (list string)
-    "kept texts"
-    [ "prior user turn"; "prior assistant reply" ]
-    (projected_texts projection);
-  check (triple int int int) "no drops" (0, 0, 0) (projection_counts projection);
-  check bool "lossless" true (Host.history_projection_lossless projection)
-;;
-
-let test_tool_messages_are_dropped_and_counted () =
-  let projection =
-    Host.project_official_history
-      [ msg Agent_core.Types.User [ text "prior user turn" ]
-      ; Agent_core.Types.tool_result_msg
-          ~tool_use_id:"call-1"
-          ~content:"tool output"
-          ()
-      ]
-  in
-  check (list string) "kept texts" [ "prior user turn" ] (projected_texts projection);
-  check
-    (triple int int int)
-    "tool message dropped"
-    (1, 0, 0)
-    (projection_counts projection);
-  check bool "lossy" false (Host.history_projection_lossless projection)
-;;
-
-let test_non_text_blocks_are_stripped_from_kept_messages () =
-  let projection =
-    Host.project_official_history
-      [ msg
-          Agent_core.Types.Assistant
-          [ Agent_core.Types.Thinking
-              { content = "hidden reasoning"; signature = None }
-          ; text "visible reply"
-          ; Agent_core.Types.ToolUse
-              { id = "call-1"; name = "prior_tool"; input = `Assoc [] }
-          ]
-      ]
-  in
-  check (list string) "kept texts" [ "visible reply" ] (projected_texts projection);
-  check
-    (triple int int int)
-    "blocks stripped"
-    (0, 0, 2)
-    (projection_counts projection)
-;;
-
-let test_fully_unrepresentable_message_is_dropped () =
-  let projection =
-    Host.project_official_history
-      [ msg
-          Agent_core.Types.Assistant
-          [ Agent_core.Types.ToolUse
-              { id = "call-1"; name = "prior_tool"; input = `Assoc [] }
-          ]
-      ]
-  in
-  check (list string) "no kept texts" [] (projected_texts projection);
-  check
-    (triple int int int)
-    "message dropped"
-    (0, 1, 1)
-    (projection_counts projection)
+  check string
+    "canonical typed message"
+    (Keeper_context_core.message_to_json message |> Yojson.Safe.to_string)
+    (encoded_message_json message |> Yojson.Safe.to_string)
 ;;
 
 let () =
@@ -353,23 +305,19 @@ let () =
             `Quick
             test_cancellation_records_terminal_raw_observation
         ] )
-    ; ( "history projection"
+    ; ( "history encoding"
       , [ test_case
-            "lossless history is preserved verbatim"
+            "text history is preserved verbatim"
             `Quick
-            test_lossless_history_is_preserved_verbatim
+            test_text_history_is_preserved_verbatim
         ; test_case
-            "tool messages are dropped and counted"
+            "tool messages preserve canonical JSON"
             `Quick
-            test_tool_messages_are_dropped_and_counted
+            test_tool_message_is_preserved_as_canonical_json
         ; test_case
-            "non-text blocks are stripped from kept messages"
+            "typed blocks preserve canonical JSON"
             `Quick
-            test_non_text_blocks_are_stripped_from_kept_messages
-        ; test_case
-            "fully unrepresentable message is dropped"
-            `Quick
-            test_fully_unrepresentable_message_is_dropped
+            test_typed_blocks_are_preserved_as_canonical_json
         ] )
     ]
 ;;

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -749,28 +749,12 @@ let test_run_named_media_degrade_emits_typed_manifest () =
         "primary.test_model"
         (string_member "degraded_runtime_id" decision))
 
-let int_member key json =
-  match assoc_member key json with
-  | Some (`Int value) -> value
-  | _ ->
-    Alcotest.failf "expected int member %S in %s" key (Yojson.Safe.to_string json)
-
 let routed_rows_with_status status manifests =
   List.filter
     (fun (manifest : Runtime_manifest.t) ->
        manifest.event = Runtime_manifest.Runtime_routed
        && String.equal manifest.status status)
     manifests
-
-let history_projection_rows manifests =
-  routed_rows_with_status "degraded" manifests
-  |> List.filter (fun (manifest : Runtime_manifest.t) ->
-    let decision =
-      Runtime_manifest.public_projection_of_decision manifest.decision
-    in
-    match assoc_member "routing_action" decision with
-    | Some (`String "official_client_history_projected") -> true
-    | _ -> false)
 
 let run_checkpoint_lane_turn ~history_messages ~on_manifests =
   with_runtime_config runtime_toml_checkpoint_lane (fun () ->
@@ -817,7 +801,7 @@ let run_checkpoint_lane_turn ~history_messages ~on_manifests =
         (Agent_core.Error.Config
            (Agent_core.Error.InvalidConfig { field = "initial_messages"; _ })) ->
       Alcotest.fail
-        "projected official-client history must stay representable"
+        "canonical official-client history must stay representable"
     | Error _ -> on_manifests !manifests)
 
 let test_agent_core_checkpoint_preserves_official_client_history () =
@@ -862,36 +846,9 @@ let test_agent_core_checkpoint_preserves_official_client_history () =
        Alcotest.fail "checkpoint_not_replayed manifest row was not observable"
      | _ :: _ :: _ ->
        Alcotest.fail "expected exactly one checkpoint_not_replayed row");
-    match history_projection_rows manifests with
-    | [ manifest ] ->
-      let decision =
-        Runtime_manifest.public_projection_of_decision manifest.decision
-      in
-      Alcotest.(check string)
-        "projection routing reason"
-        "official_client_wire_admits_text_only_history"
-        (string_member "routing_reason" decision);
-      Alcotest.(check int)
-        "kept messages"
-        1
-        (int_member "history_kept_messages" decision);
-      Alcotest.(check int)
-        "dropped tool messages"
-        1
-        (int_member "history_dropped_tool_messages" decision);
-      Alcotest.(check int)
-        "dropped messages"
-        1
-        (int_member "history_dropped_messages" decision);
-      Alcotest.(check int)
-        "dropped blocks"
-        2
-        (int_member "history_dropped_blocks" decision)
-    | [] ->
-      Alcotest.fail "official-client history projection row was not observable"
-    | _ :: _ :: _ -> Alcotest.fail "expected exactly one history projection row")
+    ())
 
-let test_lossless_official_client_history_emits_no_projection_row () =
+let test_text_official_client_history_stays_admissible () =
   let history_messages =
     [ message
         ~role:Agent_core.Types.User
@@ -910,9 +867,7 @@ let test_lossless_official_client_history_emits_no_projection_row () =
        Alcotest.fail "checkpoint_not_replayed manifest row was not observable"
      | _ :: _ :: _ ->
        Alcotest.fail "expected exactly one checkpoint_not_replayed row");
-    match history_projection_rows manifests with
-    | [] -> ()
-    | _ :: _ -> Alcotest.fail "lossless history must not emit a projection row")
+    ())
 
 let test_lane_media_reroute_stays_within_lane () =
   with_runtime_config runtime_toml_media_lane_with_global_outside (fun () ->
@@ -1728,9 +1683,9 @@ let () =
             `Quick
             test_agent_core_checkpoint_preserves_official_client_history;
           Alcotest.test_case
-            "lossless official-client history emits no projection row"
+            "text official-client history stays admissible"
             `Quick
-            test_lossless_official_client_history_emits_no_projection_row;
+            test_text_official_client_history_stays_admissible;
           Alcotest.test_case
             "lane media reroute stays within lane"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -832,7 +832,7 @@ let run_production_keeper_turn ~base_path ~trace_id ~user_message ~cli_path ~mod
 ;;
 
 let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projection
-    ?base_path ?raw_trace_path
+    ?(initial_messages = []) ?base_path ?raw_trace_path
     ?(goal = "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.") ~cli_path
     ~model () =
   let owns_base_path = Option.is_none base_path in
@@ -882,7 +882,7 @@ let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projecti
                       ~base_path
                       ~goal
                       ~tools
-                      ~initial_messages:[]
+                      ~initial_messages
                       ?model_input_projection
                       ?hooks
                       ?context_injector
@@ -902,6 +902,97 @@ let test_keeper_dispatches_codex_turn_runtime () =
        | Ok result ->
          check string "Keeper response" "MASC_SUBSCRIPTION_OK" (keeper_response_text result);
          check bool "measured observation" true (Option.is_some result.runtime_observation))
+;;
+
+let test_keeper_preserves_typed_history_on_codex_wire () =
+  let capture_path = Filename.temp_file "masc-codex-typed-history-" ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove capture_path)
+    (fun () ->
+       let assistant_message : Agent_core.Types.message =
+         { role = Assistant
+         ; content =
+             [ ToolUse
+                 { id = "prior-call"
+                 ; name = "prior_tool"
+                 ; input = `Assoc [ "path", `String "README.md" ]
+                 }
+             ]
+         ; name = None
+         ; tool_call_id = None
+         ; metadata = []
+         }
+       in
+       let tool_message =
+         Agent_core.Types.tool_result_msg
+           ~tool_use_id:"prior-call"
+           ~content:"prior tool output"
+           ()
+       in
+       let injected = {|{"id":4,"result":{}}|} in
+       let turn_after_injection =
+         {|{"id":5,"result":{"turn":{"id":"turn-1"}}}|}
+       in
+       with_fixture
+         ~capture_path
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; injected
+         ; turn_after_injection
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~initial_messages:[ assistant_message; tool_message ]
+                ~cli_path
+                ~model:"gpt-fixture"
+                ()
+            with
+            | Error error -> fail (Agent_core.Error.to_string error)
+            | Ok _ -> ());
+       let requests =
+         In_channel.with_open_bin capture_path (fun input ->
+           In_channel.input_lines input |> List.map Yojson.Safe.from_string)
+       in
+       let items =
+         requests
+         |> List.find (fun json -> Yojson.Safe.Util.member "id" json = `Int 4)
+         |> Yojson.Safe.Util.member "params"
+         |> Yojson.Safe.Util.member "items"
+         |> Yojson.Safe.Util.to_list
+       in
+       check int "typed history item count" 2 (List.length items);
+       check
+         (list string)
+         "wire roles"
+         [ "assistant"; "user" ]
+         (List.map
+            (fun item ->
+               item
+               |> Yojson.Safe.Util.member "role"
+               |> Yojson.Safe.Util.to_string)
+            items);
+       List.iter2
+         (fun expected item ->
+            let encoded =
+              item
+              |> Yojson.Safe.Util.member "content"
+              |> Yojson.Safe.Util.to_list
+              |> List.hd
+              |> Yojson.Safe.Util.member "text"
+              |> Yojson.Safe.Util.to_string
+              |> Yojson.Safe.from_string
+              |> Yojson.Safe.Util.member "message"
+            in
+            check string
+              "canonical history message"
+              (Keeper_context_core.message_to_json expected |> Yojson.Safe.to_string)
+              (Yojson.Safe.to_string encoded))
+         [ assistant_message; tool_message ]
+         items)
 ;;
 
 let test_keeper_codex_raw_trace_contains_actual_tool_and_response () =
@@ -2066,6 +2157,10 @@ let () =
             "Keeper dispatches Codex runtime"
             `Quick
             test_keeper_dispatches_codex_turn_runtime
+        ; test_case
+            "Keeper preserves typed history on Codex wire"
+            `Quick
+            test_keeper_preserves_typed_history_on_codex_wire
         ; test_case
             "Keeper Codex RAW contains tool and response"
             `Quick


### PR DESCRIPTION
## Summary

- remove the lossy Codex/Antigravity history projection that dropped Tool-role messages and typed content blocks
- preserve plain text verbatim and encode typed canonical messages in `masc.official-client-context-message.v1`
- pass the original canonical history into both official-client adapters and delete the retired drop-count manifest surface
- add wire-level Codex and Antigravity regressions for ToolUse/ToolResult context

## Product impact

Keeper continuity no longer depends on whether the selected official client happens to expose a native Tool-role history item. Codex and Antigravity receive the role, typed blocks, tool identity, payload, and metadata as canonical JSON instead of receiving only the text remainder. This repairs the product-owned context-delivery boundary; it does not attempt to improve provider model quality.

## Evidence

- Live build `25ebf46946` repeatedly reported lossy projections. One sangsu turn dropped 388 tool messages, 379 otherwise unrepresentable messages, and 903 non-text blocks; code-reviewer dropped 64, 36, and 1,673 respectively.
- `Keeper_official_client_host.encode_history_message` preserves text-only non-tool messages verbatim and serializes every typed message through the existing canonical `Keeper_context_core.message_to_json` SSOT.
- Codex fixture inspection verifies two typed canonical messages reach `thread/inject_items`, with the Tool result demoted to the wire's user role while retaining canonical role=`tool` in its envelope.
- Antigravity fixture inspection verifies the generated prompt contains the canonical Tool role and exact prior tool output.
- Local Dune/build was intentionally not run at operator request. Required build and focused suites are delegated to this PR's CI.

## Direct evidence

schema_version: 1
direct_ratio: 4/4
provenance: direct

1. Direct live structured-log observation of official-client history drop counts.
2. Direct source trace from Keeper history assembly through Codex `thread/inject_items` and Antigravity `--print` prompt construction.
3. Direct static zero-result audit for the removed projection symbols and drop-count fields.
4. Direct fixture assertions on the outgoing official-client wire payloads.

## Review evidence

- `git diff --check`: pass
- OCaml pre-flight risk-pattern scan on changed production files: no new mutex, lazy, blocking-I/O, broad exception, or stub pattern
- PR CI: pending and authoritative for build, formatting, and focused behavior suites

## Linked issue

- Follow-up hard cut to #27812: the original repair preserved only the representable text remainder; this change preserves typed canonical context instead of documenting its loss.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/preserve-official-context-20260810` → `main` · 1 commit(s) · synced 2026-08-10T14:23:39Z

| sha | subject | date |
|---|---|---|
| `2a6693074` | fix(keeper): preserve typed official-client context | 2026-08-10 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->