### PR TITLE
fix(antigravity): admit the system_message step type

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -226,6 +226,7 @@ and step_type =
   | User_input
   | Internal
   | Checkpoint
+  | System_message
 
 and result_status =
   | Success
@@ -271,6 +272,7 @@ let parse_step_type stage value =
       | "user_input" -> Some User_input
       | "unknown" -> Some Internal
       | "checkpoint" -> Some Checkpoint
+      | "system_message" -> Some System_message
       | _ -> None)
     value
 ;;

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -115,6 +115,30 @@ let run_fixture ?conversation_mode ?home_dir ?on_conversation_ready ?(timeout_s 
       ~prompt:"Return the fixture marker")
 ;;
 
+(* The installed agy emits step_type="system_message" on turns that carry tool
+   work, and the closed parser rejected it, which fails the whole turn — a
+   progress label killing an answer that had already been produced. Measured
+   2026-08-10 on the live fleet: 66 consecutive taskmaster turns died on this
+   one value, with the same runtime answering a trivial prompt fine because
+   that path emits only agent_response / checkpoint / unknown / user_input.
+
+   The step list here is the one the failing turns carried. Asserting the turn
+   text is what makes this a coverage test rather than a parse test: the point
+   is that the answer survives the step, not merely that the step parses. *)
+let test_system_message_step_does_not_fail_the_turn () =
+  with_fixture
+    [ init ()
+    ; step ~index:0 ~step_type:"user_input" ()
+    ; step ~index:1 ~step_type:"system_message" ()
+    ; step ~index:2 ~step_type:"agent_response" ()
+    ; result ()
+    ]
+    (fun path ->
+       match run_fixture path with
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok turn -> check string "text" "MASC_ANTIGRAVITY_OK\n" turn.text)
+;;
+
 let test_successful_official_client_turn () =
   with_fixture
     [ init ()
@@ -424,6 +448,10 @@ let () =
             test_unknown_protocol_vocabulary_fails_closed
         ; test_case "typed timeout" `Quick test_timeout_is_typed
         ; test_case "process-free admission" `Quick test_admission_is_process_free
+        ; test_case
+            "a system_message step does not fail the turn"
+            `Quick
+            test_system_message_step_does_not_fail_the_turn
         ] )
     ; "live official client", [ test_case "official agy start and resume" `Slow test_live_start_and_resume ]
     ]


### PR DESCRIPTION
## 증상

`antigravity_subscription` 키퍼의 모든 턴이 실패한다. 2026-08-10 라이브(`~/me/.masc`), 재기동 후 30분 동안 `taskmaster` 66연속:

```
taskmaster: turn terminal (non-exhaustion error)
  — err=Parse error: step_update event: unsupported field "step_type" value "system_message"
taskmaster: keeper cycle FAILED runtime=antigravity_subscription.gemini-3-6-flash-high
  system_and_user_bytes=5576 latency=22607ms (server parse rejection, counts toward crash threshold)
```

`latency=22607ms` 가 핵심이다 — 모델은 22초 동안 답을 만들었고, **진행 상황 라벨 하나 때문에 그 답이 버려진다.**

## 원인

`parse_step_type` (`runtime_antigravity.ml:264-276`) 이 5개 값만 받는다: `agent_response` · `tool` · `user_input` · `unknown` · `checkpoint`. 설치된 `agy` 는 도구 작업이 있는 턴에서 `system_message` 를 함께 내보낸다.

사소한 프롬프트로는 재현되지 않는다 — 그 경로는 위 5개만 낸다:

```
$ agy --print "1+1은?" --output-format stream-json --model gemini-3.6-flash-high --mode plan ...
$ rg -o '"step_type":"[^"]*"' out.jsonl | sort | uniq -c
   2 "step_type":"agent_response"
   1 "step_type":"checkpoint"
   1 "step_type":"unknown"
   1 "step_type":"user_input"
```

`system_message` 는 agy 바이너리 문자열에 존재하고, 라이브 로그에 66회 나타난다.

## 변경

`step_type` variant 에 `System_message` 를 추가하고 매핑한다. 소비자는 한 곳(`is_tool = step_type = Tool`, 도구 카운터)뿐이라 `System_message` 는 도구가 아니며 다른 판정에 관여하지 않는다.

**catch-all 을 넣지 않았다.** `| _ -> None` 을 `| _ -> Some Internal` 로 바꾸는 것이 66개 턴을 즉시 살리지만, 그 순간 벤더가 무엇을 보내든 조용히 `Internal` 이 되고 다음 스키마 변경이 관측되지 않는다. 형제 어댑터(claude / codex)도 전부 닫힌 파싱 + `protocol_error` 이므로, 이 저장소의 일관된 자세를 깨는 것은 별건의 판단이다.

## 남는 문제 (이 PR 범위 밖)

`step_type` 은 **외부 벤더가 소유한 열린 enum** 인데 masc 는 닫힌 sum type 으로 모델링한다. 벤더가 값을 추가할 때마다 그 provider 의 전 키퍼가 멈춘다. 이번이 그 사례다.

`Known of step_type | Unrecognized of string` 처럼 "열려 있음"을 타입에 드러내는 편이 정직하지만, 이는 세 어댑터 전부의 파싱 자세를 바꾸는 결정이라 RFC 로 다뤄야 한다. 이 PR 은 관측된 값을 이름으로 추가하는 데 그친다 — 완결이 아니라는 것을 명시해 둔다.

## 검증

`test/test_runtime_antigravity.ml` 에 케이스 추가. 이미 CI 배선됨 (`scripts/ci-run-focused-tests.sh:81`). 15 tests run, 전부 통과.

파싱만 보지 않고 **턴 텍스트가 살아남는지**를 단언한다 — 요점은 스텝이 파싱되는 것이 아니라 이미 생성된 답이 버려지지 않는 것이다.

뮤테이션: `system_message` 매핑 제거 → 그 케이스만 FAIL, 실패 메시지가 라이브 로그와 동일 (`unsupported field "step_type" value "system_message"`).

RFC-WAIVED: 어댑터의 wire enum 에 관측된 값 하나를 추가한다. credential / identity / operator control / sandbox / hooks / workflow 문서에 닿지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
