### PR TITLE
fix(board): unify feed and expose full detail

### DIFF
--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -92,16 +92,7 @@ export const boardComposerDraft = signal('')
 
 // ── Pagination ─────────────────────────────────────────────────────
 export const PAGE_SIZE = 20
-export const visibleLimit = signal(PAGE_SIZE)
-export const automationVisibleLimit = signal(PAGE_SIZE)
-export const systemVisibleLimit = signal(PAGE_SIZE)
-/** Per-category pagination limits */
-export const categoryVisibleLimits = signal<Record<string, number>>({
-  article: PAGE_SIZE,
-  review: PAGE_SIZE,
-  notice: PAGE_SIZE,
-  system: PAGE_SIZE,
-})
+export const feedVisibleLimit = signal(PAGE_SIZE)
 
 // ── Selection / bulk delete ────────────────────────────────────────
 export const deletingPostId = signal<string | null>(null)

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -14,7 +14,7 @@ import { route } from '../../router'
 import { createPost } from '../../api'
 import { requestBoardContextInference } from '../../api/board'
 import { dispatchOperatorAction, operatorSnapshot } from '../../operator-store'
-import { PAGE_SIZE, boardFlairs, boardFlairsError, boardHearths, boardHearthsError, categoryVisibleLimits, contentCategory, selectedBoardPostId, boardFilterMode, boardComposerMode } from './board-state'
+import { PAGE_SIZE, feedVisibleLimit, boardFlairs, boardFlairsError, boardHearths, boardHearthsError, contentCategory, selectedBoardPostId, boardFilterMode, boardComposerMode } from './board-state'
 import { resetBoardLatencyMetrics } from '../../board-metrics'
 import type { BoardPost, OperatorSnapshot } from '../../types'
 
@@ -209,6 +209,7 @@ describe('BoardSurface Component', () => {
     await Promise.resolve()
     vi.unstubAllGlobals()
     resetBoardLatencyMetrics()
+    feedVisibleLimit.value = PAGE_SIZE
     clearLocalStorage()
   })
 
@@ -248,12 +249,6 @@ describe('BoardSurface Component', () => {
     ]
     boardFlairsError.value = false
     resetBoardLatencyMetrics()
-    categoryVisibleLimits.value = {
-      article: PAGE_SIZE,
-      review: PAGE_SIZE,
-      notice: PAGE_SIZE,
-      system: PAGE_SIZE,
-    }
     selectedBoardPostId.value = null
     boardFilterMode.value = 'all'
     boardComposerMode.value = 'post'
@@ -396,21 +391,18 @@ describe('BoardSurface Component', () => {
     expect(screen.queryByTestId('bd-mention-detail')).toBeNull()
   })
 
-  it('keeps v2 workspace panels for category cards', () => {
+  it('renders one unified feed in server order instead of fixed category sections', () => {
     boardPosts.value = [
-      makePost({ id: 'post-1', title: '기술 탐색: test topic', body: 'content', author: 'keeper' }),
+      makePost({ id: 'notice-first', title: '먼저 온 알림', author: 'keeper', post_kind: 'automation' }),
+      makePost({ id: 'article-second', title: '나중에 온 글', author: 'keeper', post_kind: 'direct' }),
     ]
-    const { container } = render(h(BoardSurface, null))
-    expect(container.querySelectorAll('.v2-workspace-panel').length).toBeGreaterThanOrEqual(1)
-  })
 
-  it('applies StyleSeed surface/card classes', () => {
-    boardPosts.value = [
-      makePost({ id: 'post-1', title: '기술 탐색: test topic', body: 'content', author: 'keeper' }),
-    ]
-    const { container } = render(h(BoardSurface, null))
-    expect(container.querySelector('.v2-board-surface.ss-surface.bg-surface-page.text-text-primary')).not.toBeNull()
-    expect(container.querySelectorAll('.v2-workspace-panel.ss-card').length).toBeGreaterThanOrEqual(1)
+    render(h(BoardSurface, null))
+
+    const feed = screen.getByTestId('bd-unified-feed')
+    const titles = Array.from(feed.querySelectorAll('.bd-post-title')).map(node => node.textContent)
+    expect(titles).toEqual(['먼저 온 알림', '나중에 온 글'])
+    expect(screen.queryByRole('navigation', { name: '글/분석 게시글 페이지' })).not.toBeInTheDocument()
   })
 
   it('applies the v2 board summary class on focus surfaces', () => {
@@ -656,7 +648,6 @@ describe('BoardSurface Component', () => {
     fireEvent.change(sort, { target: { value: 'discussed' } })
 
     expect(boardSortMode.value).toBe('discussed')
-    expect(categoryVisibleLimits.value.article).toBe(PAGE_SIZE)
   })
 
   it('renders permalink, trackback, context inference, and X share actions for a post', () => {
@@ -958,44 +949,37 @@ describe('BoardSurface Component', () => {
     expect(screen.queryByText('System Post')).not.toBeInTheDocument()
   })
 
-  it('uses shared cursor pagination for category expansion', () => {
+  it('uses one shared cursor pagination for the unified feed', () => {
     boardPosts.value = Array.from({ length: PAGE_SIZE + 1 }, (_, index) => makePost({
       id: `post-${index}`,
-      title: `기술 탐색: topic ${index}`,
-      body: 'exploration content here',
+      title: `post ${index}`,
+      body: 'content',
       author: 'keeper',
-      post_kind: 'direct',
+      post_kind: index % 2 === 0 ? 'direct' : 'automation',
     }))
 
     render(h(BoardSurface, null))
 
-    const nav = screen.getByRole('navigation', { name: '글/분석 게시글 페이지' })
-    expect(nav).toBeInTheDocument()
-    expect(nav.textContent).toContain('표시')
+    expect(screen.getByRole('navigation', { name: '전체 게시글 페이지' }).textContent)
+      .toContain(`${PAGE_SIZE} / ${PAGE_SIZE + 1}`)
     fireEvent.click(screen.getByRole('button', { name: /더 보기/ }))
-
-    expect(categoryVisibleLimits.value.article).toBe(PAGE_SIZE * 2)
+    expect(feedVisibleLimit.value).toBe(PAGE_SIZE * 2)
   })
 
-  it('lets category pagination collapse an expanded category', () => {
-    categoryVisibleLimits.value = {
-      article: PAGE_SIZE * 2,
-      review: PAGE_SIZE,
-      notice: PAGE_SIZE,
-      system: PAGE_SIZE,
-    }
+  it('lets unified feed pagination collapse after expansion', () => {
+    feedVisibleLimit.value = PAGE_SIZE * 2
     boardPosts.value = Array.from({ length: PAGE_SIZE * 2 + 1 }, (_, index) => makePost({
       id: `post-${index}`,
-      title: `기술 탐색: topic ${index}`,
-      body: 'exploration content here',
+      title: `post ${index}`,
+      body: 'content',
       author: 'keeper',
       post_kind: 'direct',
     }))
 
     render(h(BoardSurface, null))
-    fireEvent.click(screen.getByRole('button', { name: '줄이기' }))
 
-    expect(categoryVisibleLimits.value.article).toBe(PAGE_SIZE)
+    fireEvent.click(screen.getByRole('button', { name: '줄이기' }))
+    expect(feedVisibleLimit.value).toBe(PAGE_SIZE)
   })
 
   it('renders the operator author sigil with the "OP" glyph and .op modifier', () => {

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -2,7 +2,6 @@ import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback, useMemo, useState } from 'preact/hooks'
 import { AtSign, Mic, Paperclip, Sparkles, Square, Trophy, X } from 'lucide-preact'
 import { ActionButton } from '../common/button'
-import { SectionCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { showToast } from '../common/toast'
 import { requestConfirm } from '../common/confirm-dialog'
@@ -66,12 +65,14 @@ import {
   boardLoading,
   boardLoadingMore,
   boardHasMore,
+  boardTotal,
+  boardHiddenCategories,
   lastBoardRefreshAt,
   refreshBoard,
   loadMoreBoardPosts,
   PAGE_SIZE,
+  feedVisibleLimit,
   CONTENT_CATEGORIES,
-  categoryVisibleLimits,
   detailPost,
   detailLoading,
   detailPostId,
@@ -81,6 +82,7 @@ import {
   loadPostDetail,
   togglePostSelection,
   splitVisiblePosts,
+  contentCategory,
   categoryLabel,
   refreshBoardHearths,
   refreshBoardFlairs,
@@ -90,7 +92,7 @@ import {
   boardComposerMode,
   SORT_MODES,
 } from './board-state'
-import type { BoardPost, BoardSortMode, ContentCategory } from './board-state'
+import type { BoardPost, BoardSortMode } from './board-state'
 
 export const BOARD_DETAIL_WIDTH_STORAGE_KEY = 'dashboard:board-detail-width'
 export const BOARD_DETAIL_WIDTH_DEFAULT = 360
@@ -174,108 +176,6 @@ function ScrollMarker({ onVisible }: { onVisible: () => void }) {
     return () => obs.disconnect()
   }, [cb])
   return html`<div ref=${ref} class="h-1" />`
-}
-
-// ── Render section (paginated group by category) ──────────────────
-/** Expand the visible slice for this category by PAGE_SIZE.
- *  If the category has run out of locally-loaded posts AND the server
- *  still has more, also trigger a server-side page fetch. */
-function expandCategory(
-  category: ContentCategory,
-  limits: Record<string, number>,
-  currentLimit: number,
-  localPostCount: number,
-) {
-  const nextLimit = currentLimit + PAGE_SIZE
-  categoryVisibleLimits.value = { ...limits, [category]: nextLimit }
-  // Exhausted the locally-loaded slice for this category — ask the server
-  // for more. loadMoreBoardPosts is a noop if already loading or has_more=false.
-  if (nextLimit >= localPostCount && boardHasMore.value) {
-    void loadMoreBoardPosts()
-  }
-}
-
-function collapseCategory(
-  category: ContentCategory,
-  limits: Record<string, number>,
-  currentLimit: number,
-) {
-  const nextLimit = Math.max(PAGE_SIZE, currentLimit - PAGE_SIZE)
-  categoryVisibleLimits.value = { ...limits, [category]: nextLimit }
-}
-
-function renderCategorySection(
-  category: ContentCategory,
-  posts: BoardPost[],
-  total: number,
-  hidden: number,
-) {
-  const meta = CONTENT_CATEGORIES.find(c => c.id === category)
-  const label = meta ? `${meta.icon} ${meta.label}` : category
-  const limits = categoryVisibleLimits.value
-  const limit = limits[category] ?? PAGE_SIZE
-  // "has more" considers both the locally-loaded posts and the server's
-  // signal. Without boardHasMore, once the category's slice catches up to
-  // the loaded window the button disappears and the next server page is
-  // never requested — that was the #7118 regression.
-  const hasMoreLocal = posts.length > limit
-  const hasMoreRemote = boardHasMore.value
-  const hasMore = hasMoreLocal || hasMoreRemote
-  const loadingMore = boardLoadingMore.value
-  const remainingLabel = hasMoreLocal
-    ? `${posts.length - limit}개 남음`
-    : '다음 페이지 불러오기'
-  const visibleCount = Math.min(limit, posts.length)
-  const cursorLabel = hasMoreRemote && !hasMoreLocal
-    ? `${visibleCount} / ${total}+`
-    : `${visibleCount} / ${total}`
-
-  if (posts.length === 0 && hidden === 0) return null
-  if (posts.length === 0 && hidden > 0) {
-    return html`
-      <div class="v2-workspace-panel mb-3 px-3 py-2 rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] text-xs text-[var(--color-fg-muted)]">
-        ${label} — ${hidden}건 숨김
-      </div>
-    `
-  }
-
-  return html`
-    <${SectionCard} label=${`${label} (${total})`} class="mb-4 v2-workspace-panel ss-card" variant="standard">
-      <div class="flex flex-col gap-2">
-        ${posts.slice(0, limit).map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
-      </div>
-      ${hasMore ? html`
-        <${ScrollMarker} onVisible=${() => {
-          if (loadingMore) return
-          expandCategory(category, limits, limit, posts.length)
-        }} />
-        <div class="flex justify-center py-3">
-          <${CursorPagination}
-            class="bd-category-pagination"
-            cursor=${cursorLabel}
-            cursorLabel="표시"
-            hasPrevious=${limit > PAGE_SIZE}
-            hasNext=${hasMore}
-            previousLabel="줄이기"
-            nextLabel=${loadingMore ? '불러오는 중...' : `더 보기 (${remainingLabel})`}
-            ariaLabel=${`${categoryLabel(category)} 게시글 페이지`}
-            disabled=${loadingMore}
-            testId=${`board-category-pagination-${category}`}
-            onPrevious=${() => {
-              collapseCategory(category, limits, limit)
-            }}
-            onNext=${() => {
-              expandCategory(category, limits, limit, posts.length)
-            }}
-          />
-        </div>
-      ` : null}
-    <//>
-  `
-}
-
-function CategorySection({ group }: { group: { category: ContentCategory; posts: BoardPost[]; total: number; hidden: number } }) {
-  return renderCategorySection(group.category, group.posts, group.total, group.hidden)
 }
 
 // ── Board summary stats (compact inline) ─────────────────────────
@@ -368,6 +268,8 @@ function PostCard({ post }: { post: BoardPost }) {
   const voteScoreAria = post.vote_blind ? '점수 투표 후 공개' : `점수 ${post.votes ?? 0}`
   const isMod = post.moderation_status && post.moderation_status !== 'none' && post.moderation_status !== 'approved'
   const selected = selectedBoardPostId.value === post.id
+  const category = contentCategory(post)
+  const categoryMeta = CONTENT_CATEGORIES.find(item => item.id === category)
 
   const handleVote = async (dir: 'up' | 'down', event: Event) => {
     event.stopPropagation()
@@ -447,6 +349,7 @@ function PostCard({ post }: { post: BoardPost }) {
         >${authorLabel}</a>
         ${post.pinned ? html`<span class="bd-badge pin" title="고정된 게시글">고정</span>` : null}
         ${isMod ? html`<span class="bd-badge mod">모더레이션 대기</span>` : null}
+        <span class="bd-badge" title="게시글 분류">${categoryMeta?.icon ?? ''} ${categoryLabel(category)}</span>
         ${post.flair ? html`<span class="bd-badge">flair:${post.flair}</span>` : null}
         ${boardHearthFilter.value === '' && post.hearth ? html`<span class="bd-badge">${post.hearth}</span>` : null}
         <span class="ts"><${TimeAgo} timestamp=${post.created_at} /></span>
@@ -541,7 +444,8 @@ function BdRail({ activeSub, onSub, onMentions }: {
   onMentions: () => void
 }) {
   const hearths = boardHearths.value
-  const allCount = boardPosts.value.length
+  const allCount = boardTotal.value ?? boardPosts.value.length
+  const allCountLabel = boardTotal.value === null && boardHasMore.value ? `${allCount}+` : String(allCount)
   const modCount = useMemo(() => boardPosts.value.filter(p => p.moderation_status && p.moderation_status !== 'none' && p.moderation_status !== 'approved').length, [boardPosts.value])
   const mentionCount = useMemo(() => countMentionMessages(), [messages.value])
 
@@ -557,7 +461,10 @@ function BdRail({ activeSub, onSub, onMentions }: {
         >
           <span class="glyph">${SUB_BOARD_GLYPHS.all}</span>
           <span style=${{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>전체</span>
-          <span class="n">${allCount}</span>
+          <span
+            class="n"
+            title=${boardTotal.value === null && boardHasMore.value ? `${allCount}개 이상 · 현재 불러온 게시글 기준` : `전체 ${allCount}개`}
+          >${allCountLabel}</span>
         </button>
         ${hearths.map(hearth => html`
           <button
@@ -591,10 +498,10 @@ function BdRail({ activeSub, onSub, onMentions }: {
   `
 }
 
-function BdFeedHead({ activeFilter, onFilter, count, contentQuery, onContentQuery, sortMode, onSort }: {
+function BdFeedHead({ activeFilter, onFilter, countLabel, contentQuery, onContentQuery, sortMode, onSort }: {
   activeFilter: 'all' | 'mod'
   onFilter: (filter: 'all' | 'mod') => void
-  count: number
+  countLabel: string
   contentQuery: string
   onContentQuery: (value: string) => void
   sortMode: BoardSortMode
@@ -612,7 +519,7 @@ function BdFeedHead({ activeFilter, onFilter, count, contentQuery, onContentQuer
   return html`
     <div class="bd-feed-head">
       <h2>${title}</h2>
-      <span class="ns">${count}개 포스트</span>
+      <span class="ns">${countLabel}</span>
       <${TextInput}
         type="search"
         value=${contentQuery}
@@ -737,7 +644,17 @@ function BdThreadDetail({
             <div class="bd-th-hd"><span class="who">${authorLabel}</span><span class="ts mono"><${TimeAgo} timestamp=${post.created_at} /></span></div>
             <div class="bd-th-body">
               <div class="text-sm font-semibold mb-1">${stripInlineMarkdown(post.title)}</div>
-              <div class="mb-2"><${PostShareActions} post=${post} /></div>
+              <div class="mb-2 flex flex-wrap items-center gap-2">
+                <${ActionButton}
+                  variant="ghost"
+                  size="sm"
+                  class="v2-workspace-action"
+                  onClick=${() => navigateBoard({ post: post.id })}
+                  ariaLabel=${`전체 상세 보기: ${post.id}`}
+                  testId=${`bd-open-full-detail-${post.id}`}
+                >전체 상세 보기<//>
+                <${PostShareActions} post=${post} />
+              </div>
               <${RichContent} text=${post.body} previewLimit=${4} />
               <${FusionBoardEvidence} post=${evidencePost} class="mt-3" />
             </div>
@@ -1317,47 +1234,112 @@ function BdMobileQueues({
   `
 }
 
+function UnifiedBoardFeed({
+  posts,
+  visibleLimit,
+  onVisibleLimitChange,
+}: {
+  posts: BoardPost[]
+  visibleLimit: number
+  onVisibleLimitChange: (limit: number) => void
+}) {
+  const hasMoreLocal = posts.length > visibleLimit
+  const hasMoreRemote = boardHasMore.value
+  const hasMore = hasMoreLocal || hasMoreRemote
+  const loadingMore = boardLoadingMore.value
+  const visibleCount = Math.min(visibleLimit, posts.length)
+  const remainingLabel = hasMoreLocal
+    ? `${posts.length - visibleLimit}개 남음`
+    : '다음 페이지 불러오기'
+  const cursorLabel = hasMoreRemote && !hasMoreLocal
+    ? `${visibleCount} / ${posts.length}+`
+    : `${visibleCount} / ${posts.length}`
+
+  const expand = () => {
+    if (loadingMore) return
+    const nextLimit = visibleLimit + PAGE_SIZE
+    onVisibleLimitChange(nextLimit)
+    if (nextLimit >= posts.length && boardHasMore.value) void loadMoreBoardPosts()
+  }
+
+  return html`
+    <div class="flex flex-col gap-2" data-testid="bd-unified-feed">
+      ${posts.slice(0, visibleLimit).map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
+    </div>
+    ${hasMore ? html`
+      <${ScrollMarker} onVisible=${expand} />
+      <div class="flex justify-center py-3">
+        <${CursorPagination}
+          class="bd-feed-pagination"
+          cursor=${cursorLabel}
+          cursorLabel="표시"
+          hasPrevious=${visibleLimit > PAGE_SIZE}
+          hasNext=${hasMore}
+          previousLabel="줄이기"
+          nextLabel=${loadingMore ? '불러오는 중...' : `더 보기 (${remainingLabel})`}
+          ariaLabel="전체 게시글 페이지"
+          disabled=${loadingMore}
+          testId="board-feed-pagination"
+          onPrevious=${() => onVisibleLimitChange(Math.max(PAGE_SIZE, visibleLimit - PAGE_SIZE))}
+          onNext=${expand}
+        />
+      </div>
+    ` : null}
+  `
+}
+
 function BdFeed({ posts, onMentions }: { posts: BoardPost[]; onMentions: () => void }) {
   const [contentQuery, setContentQuery] = useState('')
+  const visibleLimit = feedVisibleLimit.value
   const filteredPosts = useMemo(
     () => filterBoardPosts(posts, contentQuery),
     [posts, contentQuery],
   )
   const isFiltering = contentQuery.trim() !== ''
-  const visibleGroups = useMemo(() => splitVisiblePosts(filteredPosts), [filteredPosts])
+  const visiblePosts = useMemo(
+    () => filteredPosts.filter(post => !boardHiddenCategories.value.has(contentCategory(post))),
+    [filteredPosts, boardHiddenCategories.value],
+  )
   const mentionCount = useMemo(() => countMentionMessages(), [messages.value])
   const modCount = useMemo(
     () => posts.filter(post => post.moderation_status && post.moderation_status !== 'none' && post.moderation_status !== 'approved').length,
     [posts],
   )
 
-  const modeFilteredGroups = useMemo(() => visibleGroups.groups.map(g => ({
-    ...g,
-    posts: g.posts.filter(post => {
+  const filteredByMode = useMemo(
+    () => visiblePosts.filter(post => {
       if (boardFilterMode.value === 'mod') return post.moderation_status && post.moderation_status !== 'none' && post.moderation_status !== 'approved'
       return true
     }),
-  })), [visibleGroups, boardFilterMode.value])
-  const filteredByMode = useMemo(() => modeFilteredGroups.flatMap(g => g.posts), [modeFilteredGroups])
+    [visiblePosts, boardFilterMode.value],
+  )
+  const countLabel = isFiltering || boardFilterMode.value === 'mod'
+    ? `${filteredByMode.length}개 표시`
+    : boardTotal.value !== null
+      ? `전체 ${boardTotal.value}개`
+      : boardHasMore.value
+        ? `현재 ${filteredByMode.length}개 불러옴 · 더 있음`
+        : `전체 ${filteredByMode.length}개`
 
   return html`
     <section class="bd-feed">
       <${BdFeedHead}
         activeFilter=${boardFilterMode.value}
-        onFilter=${(filter: 'all' | 'mod') => { boardFilterMode.value = filter }}
-        count=${filteredByMode.length}
+        onFilter=${(filter: 'all' | 'mod') => {
+          boardFilterMode.value = filter
+          feedVisibleLimit.value = PAGE_SIZE
+        }}
+        countLabel=${countLabel}
         contentQuery=${contentQuery}
-        onContentQuery=${setContentQuery}
+        onContentQuery=${(query: string) => {
+          setContentQuery(query)
+          feedVisibleLimit.value = PAGE_SIZE
+        }}
         sortMode=${boardSortMode.value}
         onSort=${(sortMode: BoardSortMode) => {
           if (boardSortMode.value === sortMode) return
           boardSortMode.value = sortMode
-          categoryVisibleLimits.value = {
-            article: PAGE_SIZE,
-            review: PAGE_SIZE,
-            notice: PAGE_SIZE,
-            system: PAGE_SIZE,
-          }
+          feedVisibleLimit.value = PAGE_SIZE
           selectedBoardPostId.value = null
           refreshBoard()
         }}
@@ -1376,11 +1358,11 @@ function BdFeed({ posts, onMentions }: { posts: BoardPost[]; onMentions: () => v
             ? html`<${LoadingState} title="게시판 불러오는 중…" />`
             : filteredByMode.length === 0
               ? html`<${EmptyState} title="아직 게시글이 없습니다" hint="에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
-              : modeFilteredGroups.map(g =>
-                  g.posts.length > 0
-                    ? html`<${CategorySection} key=${g.category} group=${{ category: g.category, posts: g.posts, total: g.total, hidden: g.hidden }} />`
-                    : null,
-                )}
+              : html`<${UnifiedBoardFeed}
+                  posts=${filteredByMode}
+                  visibleLimit=${visibleLimit}
+                  onVisibleLimitChange=${(limit: number) => { feedVisibleLimit.value = limit }}
+                />`}
       </div>
       <${BdComposer} />
     </section>


### PR DESCRIPTION
## Summary

- render the Board "전체" view as one server-ordered feed instead of fixed content-category sections
- show category metadata on each post card and use one feed-level pagination cursor
- distinguish loaded counts from authoritative totals while more pages remain
- add an explicit "전체 상세 보기" action that opens the existing `#board?post=<id>` route
- remove obsolete per-category pagination signals and update the Board UI contract tests

## Root cause

The all-posts surface split the server-sorted response into insertion-ordered category buckets before rendering, so cross-category chronology was lost. The rail also displayed the currently loaded array length as if it were the complete total. Post selection only changed a local signal, while the existing full-detail route had no visible navigation affordance.

## Impact

Operators now see one chronological/sorted Board feed, can tell when more posts remain, and can intentionally navigate from the side rail to a stable full-detail URL.

## Validation

- `pnpm vitest run src/components/board/board-surface.test.ts --reporter=dot`
- 57 tests passed