### PR TITLE
fix(runtime): type Antigravity system messages

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -56,17 +56,6 @@ type usage =
   ; total_tokens : int
   }
 
-(* The modes the CLI has been observed to announce. [Request_review] arrived
-   from a live init event and was not modelled, so the parse failed, the turn
-   ended as a protocol error, and the official-client session went to
-   Recovery_required -- which blocked every later turn for that keeper until an
-   operator resolved it (taskmaster, 110 turns in one hour).
-
-   Nothing in this tree branches on the value: it is parsed, carried through
-   [state.init] into [turn_result], and never matched. A closed vocabulary over
-   a field the provider owns and we do not read costs a session each time the
-   provider adds a member. Kept closed for now because guessing members is
-   worse than failing loudly, but see #28008. *)
 type permission_mode =
   | Always_proceed
   | Request_review
@@ -222,11 +211,11 @@ and step_state =
 
 and step_type =
   | Agent_response
+  | System_message
   | Tool
   | User_input
   | Internal
   | Checkpoint
-  | Unrecognized of string
 
 and result_status =
   | Success
@@ -262,26 +251,19 @@ let parse_step_state stage value =
     value
 ;;
 
-(* [step_type] decides one thing: whether this step is a tool step, for the two
-   tool counters. Every non-[Tool] value is behaviourally identical, so an
-   upstream value we have not seen carries no decision we could get wrong — but
-   rejecting it ended the turn and parked the session, which blocked every later
-   turn for that Keeper until an operator resolved it by hand. Live 2026-08-10:
-   Antigravity started emitting "system_message" and taskmaster stopped
-   (#28027). The value is kept in [Unrecognized] so the wire vocabulary drift is
-   still visible rather than silently normalised away.
-
-   [state], [permission_mode] and [status] stay closed: each of those does
-   decide something. *)
-let parse_step_type _stage value =
-  Ok
-    (match value with
-     | "agent_response" -> Agent_response
-     | "tool" -> Tool
-     | "user_input" -> User_input
-     | "unknown" -> Internal
-     | "checkpoint" -> Checkpoint
-     | other -> Unrecognized other)
+let parse_step_type stage value =
+  closed_string
+    stage
+    "step_type"
+    (function
+      | "agent_response" -> Some Agent_response
+      | "system_message" -> Some System_message
+      | "tool" -> Some Tool
+      | "user_input" -> Some User_input
+      | "unknown" -> Some Internal
+      | "checkpoint" -> Some Checkpoint
+      | _ -> None)
+    value
 ;;
 
 let parse_result_status stage value =

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -95,6 +95,7 @@ assert [tool["name"] for tool in tools["result"]["tools"]] == ["masc_probe"]
 called = post({"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"masc_probe","arguments":{"marker":"from-antigravity"}}}, version)
 assert called["result"]["content"][0]["text"] == "MASC_TOOL_RESULT"
 PY
+printf '{"event":"step_update","step_update":{"conversation_id":"%%s","step_index":0,"state":"DONE","step_type":"system_message"}}\n' "$conversation"
 printf '{"event":"step_update","step_update":{"conversation_id":"%%s","step_index":1,"state":"DONE","step_type":"tool"}}\n' "$conversation"
 printf '{"event":"result","result":{"conversation_id":"%%s","status":"SUCCESS","response":"MASC_ANTIGRAVITY_KEEPER_OK","error":null,"num_turns":%%d,"usage":{"input_tokens":12,"output_tokens":4,"thinking_tokens":1,"cache_read_tokens":0,"total_tokens":16}}}\n' "$conversation" "$turns"
 |}

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -121,7 +121,8 @@ let test_successful_official_client_turn () =
     ; step ~index:0 ~step_type:"user_input" ()
     ; step ~index:1 ~step_type:"unknown" ()
     ; step ~index:2 ~step_type:"agent_response" ()
-    ; step ~index:3 ~step_type:"checkpoint" ()
+    ; step ~index:3 ~step_type:"system_message" ()
+    ; step ~index:4 ~step_type:"checkpoint" ()
     ; result ()
     ]
     (fun path ->
@@ -141,36 +142,6 @@ let test_successful_official_client_turn () =
            (turn.permission_mode = Runtime_antigravity.Always_proceed);
          check bool "new conversation" false turn.resumed;
          check bool "measured wall duration" true (turn.wall_duration_s >= 0.0))
-;;
-
-(* Live 2026-08-10 (#28027): Antigravity started emitting step_type
-   "system_message" and every taskmaster turn died on it, parking the session
-   until an operator resolved it. step_type only decides whether a step counts
-   as a tool step, so an unseen value carries no decision — but the tool
-   counters must still be exact for the values that do. *)
-let test_unknown_step_type_does_not_end_the_turn () =
-  with_fixture
-    [ init ()
-    ; step ~index:0 ~step_type:"system_message" ()
-    ; step ~index:1 ~state:"ACTIVE" ~step_type:"tool" ()
-    ; step ~index:2 ~state:"DONE" ~step_type:"tool" ()
-    ; step ~index:3 ~step_type:"agent_response" ()
-    ; result ()
-    ]
-    (fun path ->
-       match run_fixture path with
-       | Error error -> fail (Runtime_antigravity.error_to_string error)
-       | Ok turn ->
-         check string "text" "MASC_ANTIGRAVITY_OK\n" turn.text;
-         check int "unknown step is not counted as a tool" 1 turn.tool_steps);
-  (* Control: a value that does decide something stays closed. *)
-  with_fixture
-    [ init (); step ~index:0 ~state:"SIDEWAYS" (); result () ]
-    (fun path ->
-       match run_fixture path with
-       | Error (Runtime_antigravity.Protocol_error _) -> ()
-       | Error error -> fail (Runtime_antigravity.error_to_string error)
-       | Ok _ -> fail "an unknown step state was admitted")
 ;;
 
 let test_child_environment_is_allowlisted () =
@@ -296,12 +267,6 @@ let test_duplicate_keys_fail_closed () =
        | Ok _ -> fail "duplicate key was admitted")
 ;;
 
-(* A live init event announced request-review. It was not modelled, the parse
-   failed, and the resulting protocol error put the official-client session in
-   Recovery_required -- which blocked every later turn for that keeper until an
-   operator resolved it (taskmaster, 110 turns in one hour). Nothing in this
-   tree branches on the value; the vocabulary is closed only to fail loudly on
-   a member we have not seen. *)
 let test_observed_permission_modes_are_admitted () =
   List.iter
     (fun (wire, expected) ->
@@ -320,13 +285,10 @@ let test_unknown_protocol_vocabulary_fails_closed () =
   let unknown_permission =
     {|{"event":"init","conversation_id":"conversation-1","init":{"model":"gemini-fixture","cwd":"/tmp","permission_mode":"unreviewed"}}|}
   in
-  (* step_type left this list in #28027: it is the one vocabulary here that
-     decides nothing (see [test_unknown_step_type_does_not_end_the_turn]).
-     permission_mode, step state and result status each still decide something,
-     so an unseen value there is a real ambiguity and stays closed. *)
   let cases =
     [ "permission mode", [ unknown_permission; result () ]
     ; "step state", [ init (); step ~state:"PAUSED" (); result () ]
+    ; "step type", [ init (); step ~step_type:"shell" (); result () ]
     ; "result status", [ init (); result ~status:"PARTIAL" () ]
     ]
   in
@@ -445,10 +407,6 @@ let () =
             `Quick
             test_conversation_callback_failure_is_typed
         ; test_case "tool measurements" `Quick test_tool_steps_and_errors_are_measured
-        ; test_case
-            "unknown step type does not end the turn"
-            `Quick
-            test_unknown_step_type_does_not_end_the_turn
         ; test_case "error result" `Quick test_result_error_is_not_success
         ; test_case "duplicate keys" `Quick test_duplicate_keys_fail_closed
         ; test_case


### PR DESCRIPTION
## Summary

- represent Antigravity `system_message` steps with a closed typed constructor
- keep unsupported step types fail-closed instead of accepting arbitrary strings
- exercise the current wire value in both the parser fixture and the full Keeper MCP/session-settlement fixture
- remove incident narration from the active source and focused tests

## Contract

`step_type` remains a closed wire vocabulary. `system_message` is a non-tool step, while only `tool` contributes to tool-step and tool-error counters.

## Validation

- `git diff --check`
- `ocamlformat --check lib/runtime/runtime_antigravity.ml test/test_runtime_antigravity.ml test/test_keeper_antigravity_runtime.ml`
- `ocamlc -stop-after parsing` for all three changed OCaml files
- focused Dune target attempted through `scripts/dune-local.sh`; the machine-wide guard returned exit 75 because unrelated bare Dune processes were active, so behavioral authority is delegated to PR CI
