### PR TITLE
test(fusion): pin that each absent Eio handle is named

### DIFF
--- a/lib/fusion/fusion_official_client.ml
+++ b/lib/fusion/fusion_official_client.ml
@@ -27,7 +27,12 @@ let provider_error ~runtime_id detail : Fusion_types.panel_failure =
    other entry points publish them separately, so "the Eio runtime is not
    initialized" sends the reader to look at the wrong one. Split out as a pure
    function because Eio_context has no reset, so a test that drove the real
-   globals could only reach these arms in one fragile order. *)
+   globals could only reach these arms in one fragile order.
+
+   Its result is already carried to the caller as a typed
+   [Fusion_types.panel_failure] and lands in the fusion run record. *)
+(* TEL-OK: pure string selection, no effect; the failure it names is already
+   observable through the panel outcome. *)
 let missing_handle_detail ~env_present ~clock_present =
   match env_present, clock_present with
   | true, true -> None
@@ -160,5 +165,8 @@ let run_panelist ~base_dir ~runtime_id ~system_prompt ~prompt =
 ;;
 
 module For_testing = struct
+  (* Re-exported so a test can reach every arm without driving the
+     process-global Eio context, which has no reset. *)
+  (* TEL-OK: alias of a pure function; no behaviour of its own. *)
   let missing_handle_detail = missing_handle_detail
 end

--- a/lib/fusion/fusion_official_client.ml
+++ b/lib/fusion/fusion_official_client.ml
@@ -23,30 +23,45 @@ let provider_error ~runtime_id detail : Fusion_types.panel_failure =
   Fusion_types.Provider_error (Printf.sprintf "%s: %s" runtime_id detail)
 ;;
 
+(* Naming the absent handle is the point: the server publishes both together but
+   other entry points publish them separately, so "the Eio runtime is not
+   initialized" sends the reader to look at the wrong one. Split out as a pure
+   function because Eio_context has no reset, so a test that drove the real
+   globals could only reach these arms in one fragile order. *)
+let missing_handle_detail ~env_present ~clock_present =
+  match env_present, clock_present with
+  | true, true -> None
+  | false, false ->
+    Some
+      "official-client panelist requires Eio_context env and clock; neither is \
+       published"
+  | false, true ->
+    Some
+      "official-client panelist requires Eio_context env (process manager and \
+       fs); it is not published"
+  | true, false ->
+    Some "official-client panelist requires Eio_context clock; it is not published"
+;;
+
 let eio_context ~runtime_id =
-  (* Naming the absent handle is the point: both are published together by the
-     server but separately by other entry points, so "the Eio runtime is not
-     initialized" sends the reader to look at the wrong one. *)
-  match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
+  let env = Eio_context.get_env_opt () in
+  let clock = Eio_context.get_clock_opt () in
+  match env, clock with
   | Some env, Some clock -> Ok (env, clock)
-  | None, None ->
-    Error
-      (provider_error
-         ~runtime_id
-         "official-client panelist requires Eio_context env and clock; neither \
-          is published")
-  | None, Some _ ->
-    Error
-      (provider_error
-         ~runtime_id
-         "official-client panelist requires Eio_context env (process manager \
-          and fs); it is not published")
-  | Some _, None ->
-    Error
-      (provider_error
-         ~runtime_id
-         "official-client panelist requires Eio_context clock; it is not \
-          published")
+  | _ ->
+    let detail =
+      match
+        missing_handle_detail
+          ~env_present:(Option.is_some env)
+          ~clock_present:(Option.is_some clock)
+      with
+      | Some detail -> detail
+      (* Unreachable: the Some/Some pair is matched above. Kept as a total
+         function rather than an assert so a future edit to either match cannot
+         raise on a live panel. *)
+      | None -> "official-client panelist could not resolve the Eio context"
+    in
+    Error (provider_error ~runtime_id detail)
 ;;
 
 (* [Runtime_execution.*] carries admission-time config; each adapter has its own
@@ -143,3 +158,7 @@ let run_panelist ~base_dir ~runtime_id ~system_prompt ~prompt =
      | Error error ->
        Error (provider_error ~runtime_id (Runtime_antigravity.error_to_string error)))
 ;;
+
+module For_testing = struct
+  let missing_handle_detail = missing_handle_detail
+end

--- a/lib/fusion/fusion_official_client.mli
+++ b/lib/fusion/fusion_official_client.mli
@@ -16,6 +16,13 @@ val is_official_client : runtime_id:string -> bool
     unknown id: an id that resolves to nothing is not this module's failure to
     report, and the Agent_core path already names it precisely. *)
 
+module For_testing : sig
+  val missing_handle_detail : env_present:bool -> clock_present:bool -> string option
+  (** The failure detail for an unresolvable Eio context, or [None] when both
+      handles are present. Exposed because {!Eio_context} has no reset, so a
+      test driving the real globals could reach these arms in only one order. *)
+end
+
 val run_panelist
   :  base_dir:string
   -> runtime_id:string

--- a/test/test_fusion_official_client_panel.ml
+++ b/test/test_fusion_official_client_panel.ml
@@ -156,6 +156,52 @@ let test_official_client_panelist_reaches_its_client () =
     check int "the panelist is accounted for in the outcomes" 1 (List.length outcomes))
 ;;
 
+(* The message has to name which handle is absent. It did not, and that cost a
+   build cycle: publishing Eio_context.set_env in bin/fusion_run left the text
+   identical, so the clock being the other half was invisible until the code was
+   read. Each arm is asserted separately — a single "some message came back"
+   check would pass with all three arms collapsed into one string. *)
+let detail_for ~env ~clock =
+  match
+    Masc.Fusion_official_client.For_testing.missing_handle_detail
+      ~env_present:env
+      ~clock_present:clock
+  with
+  | Some detail -> detail
+  | None -> "<none>"
+;;
+
+let test_both_handles_present_has_no_complaint () =
+  check
+    (option string)
+    "a resolvable context produces no failure detail"
+    None
+    (Masc.Fusion_official_client.For_testing.missing_handle_detail
+       ~env_present:true
+       ~clock_present:true)
+;;
+
+let test_each_absent_handle_is_named () =
+  let neither = detail_for ~env:false ~clock:false in
+  let env_missing = detail_for ~env:false ~clock:true in
+  let clock_missing = detail_for ~env:true ~clock:false in
+  check bool "the three arms are distinct" true
+    (neither <> env_missing && env_missing <> clock_missing && neither <> clock_missing);
+  let mentions haystack needle =
+    let n = String.length needle in
+    let rec scan i =
+      i + n <= String.length haystack
+      && (String.sub haystack i n = needle || scan (i + 1))
+    in
+    scan 0
+  in
+  check bool "a missing env names env" true (mentions env_missing "env");
+  check bool "a missing env does not blame the clock" false (mentions env_missing "clock");
+  check bool "a missing clock names clock" true (mentions clock_missing "clock");
+  check bool "both absent names both" true
+    (mentions neither "env" && mentions neither "clock")
+;;
+
 let () =
   run
     "fusion official-client panel"
@@ -172,6 +218,16 @@ let () =
             "unknown runtime is not claimed by the spawn path"
             `Quick
             test_unknown_runtime_is_not_claimed_by_the_spawn_path
+        ] )
+    ; ( "eio context diagnostics"
+      , [ test_case
+            "both handles present produces no complaint"
+            `Quick
+            test_both_handles_present_has_no_complaint
+        ; test_case
+            "each absent handle is named"
+            `Quick
+            test_each_absent_handle_is_named
         ] )
     ; ( "panel execution"
       , [ test_case


### PR DESCRIPTION
## 왜 별도 PR 인가

#28032 가 Test Coverage Check 실패 상태로 머지됐고(`Added 15 lines to covered code paths but no test files changed`), 내가 그 브랜치에 테스트를 push 했지만 **squash merge 뒤의 커밋은 main 에 도달하지 않는다**. 확인:

```
$ git show origin/main:lib/fusion/fusion_official_client.mli | rg -c 'For_testing'
0
```

그래서 같은 변경을 현재 main 위에 다시 올린다.

## 무엇을 고정하는가

#28032 는 Eio 컨텍스트 해석 실패를 세 갈래로 나눴다 — env 없음 / clock 없음 / 둘 다 없음. 그 분기가 왜 필요했는지는 실제로 지불한 비용이 말해준다: `bin/fusion_run` 에 `Eio_context.set_env` 를 발행한 뒤에도 메시지가 **글자 그대로 동일**해서, clock 이 나머지 절반이라는 것을 코드를 읽기 전까지 알 수 없었다. 빌드 사이클 하나.

## 어떻게

`Eio_context` 에는 reset 이 없다. 실제 전역을 조작하는 테스트는 세 조합을 **한 가지 취약한 순서로만** 도달할 수 있다(한 번 set 하면 되돌릴 수단이 없어, 마지막 조합은 도달 불가). 그래서 분기 선택을 순수 함수로 빼고 `For_testing` 으로 노출한다.

각 갈래를 **따로** 단언한다 — "메시지가 뭔가 돌아왔다" 한 줄이면 세 갈래가 하나로 합쳐져도 통과한다.

## 검증

6 tests run, 전부 통과.

뮤테이션: 세 갈래를 한 메시지로 합침 → `each absent handle is named` 만 FAIL (`ASSERT the three arms are distinct`), 나머지 5개는 OK. 즉 이 단언이 잡는 것이 정확히 "갈래가 구분된다" 이다.

RFC-WAIVED: 테스트 추가와 그 테스트를 가능하게 하는 순수 함수 추출이다. credential / identity / operator control / sandbox / hooks / workflow 문서에 닿지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
