### PR TITLE
fix(runtime): preserve Antigravity OAuth refreshes

### DIFF
--- a/lib/runtime/runtime_antigravity_home.ml
+++ b/lib/runtime/runtime_antigravity_home.ml
@@ -9,7 +9,7 @@ type error =
       { path : string
       ; detail : string
       }
-  | Invalid_oauth_copy of
+  | Invalid_managed_oauth of
       { path : string
       ; detail : string
       }
@@ -41,8 +41,8 @@ let error_to_string = function
     Printf.sprintf "unsafe Antigravity directory %s: %s" path detail
   | Invalid_oauth_source { path; detail } ->
     Printf.sprintf "invalid Antigravity OAuth source %s: %s" path detail
-  | Invalid_oauth_copy { path; detail } ->
-    Printf.sprintf "invalid Antigravity OAuth copy %s: %s" path detail
+  | Invalid_managed_oauth { path; detail } ->
+    Printf.sprintf "invalid managed Antigravity OAuth file %s: %s" path detail
   | Settings_write_failed { path; detail } ->
     Printf.sprintf "failed to write Antigravity settings %s: %s" path detail
   | Mcp_config_write_failed { path; detail } ->
@@ -218,33 +218,49 @@ let write_private_settings path =
     (settings_json () |> Yojson.Safe.pretty_to_string)
 ;;
 
-let read_oauth_source path =
+let load_private_oauth_file ~make_error path =
+  match
+    Fs_compat.load_owned_regular_file_with_snapshot
+      ~ownership_root:(Filename.dirname path)
+      path
+  with
+  | Ok (Some contents)
+    when contents.snapshot.owner_uid <> effective_uid
+         || contents.snapshot.permissions <> 0o600 ->
+    Error
+      (make_error
+         path
+         (Printf.sprintf
+            "owner/mode mismatch: uid=%d mode=%04o"
+            contents.snapshot.owner_uid
+            contents.snapshot.permissions))
+  | Ok contents -> Ok contents
+  | Error error ->
+    Error
+      (make_error path (Fs_compat.owned_regular_file_read_error_to_string error))
+;;
+
+let read_oauth_seed path =
   if Filename.is_relative path
   then Error (Invalid_oauth_source { path; detail = "path must be absolute" })
   else
     match
-      Fs_compat.load_owned_regular_file_with_snapshot
-        ~ownership_root:(Filename.dirname path)
+      load_private_oauth_file
+        ~make_error:(fun path detail -> Invalid_oauth_source { path; detail })
         path
     with
-    | Ok (Some contents)
-      when contents.snapshot.owner_uid <> effective_uid
-           || contents.snapshot.permissions <> 0o600 ->
-      Error
-        (Invalid_oauth_source
-           { path
-           ; detail =
-               Printf.sprintf
-                 "owner/mode mismatch: uid=%d mode=%04o"
-                 contents.snapshot.owner_uid
-                 contents.snapshot.permissions
-           })
     | Ok (Some contents) -> Ok contents.content
     | Ok None -> Error (Invalid_oauth_source { path; detail = "file is missing" })
-    | Error error ->
-      Error
-        (Invalid_oauth_source
-           { path; detail = Fs_compat.owned_regular_file_read_error_to_string error })
+    | Error _ as error -> error
+;;
+
+let inspect_managed_oauth path =
+  load_private_oauth_file
+    ~make_error:(fun path detail -> Invalid_managed_oauth { path; detail })
+    path
+  |> Result.map (function
+    | Some _ -> `Present
+    | None -> `Missing)
 ;;
 
 let ( let* ) = Result.bind
@@ -254,7 +270,7 @@ let prepare ~runtime_root ~owner_leaf ~oauth_source =
   then Error (Invalid_owner_leaf owner_leaf)
   else
     let* () = verify_runtime_root runtime_root in
-    let* oauth_contents = read_oauth_source oauth_source in
+    let* oauth_seed = read_oauth_seed oauth_source in
     let* official_clients = ensure_private_child runtime_root "official-clients" in
     let* antigravity_root = ensure_private_child official_clients "antigravity" in
     let* home_dir = ensure_private_child antigravity_root owner_leaf in
@@ -265,10 +281,14 @@ let prepare ~runtime_root ~owner_leaf ~oauth_source =
     let mcp_config_path = Filename.concat config_dir "mcp_config.json" in
     let oauth_path = Filename.concat cli_dir "antigravity-oauth-token" in
     let* () =
-      write_private_file
-        ~make_error:(fun path detail -> Invalid_oauth_copy { path; detail })
-        oauth_path
-        oauth_contents
+      match inspect_managed_oauth oauth_path with
+      | Error _ as error -> error
+      | Ok `Present -> Ok ()
+      | Ok `Missing ->
+        write_private_file
+          ~make_error:(fun path detail -> Invalid_managed_oauth { path; detail })
+          oauth_path
+          oauth_seed
     in
     let* () = write_private_settings settings_path in
     Ok { home_dir; settings_path; mcp_config_path; oauth_path }

--- a/lib/runtime/runtime_antigravity_home.mli
+++ b/lib/runtime/runtime_antigravity_home.mli
@@ -1,8 +1,9 @@
 (** Persistent, operator-owned HOME layout for the official Antigravity CLI.
 
-    The operator credential is read through the owned-file boundary and copied
-    into the isolated HOME as an exact 0600 snapshot. Turn-scoped MCP
-    configuration is deliberately owned by the caller. *)
+    The operator credential seeds the isolated HOME once. The resulting 0600
+    regular file is then persistent runtime state so an OAuth refresh written by
+    the CLI survives later turns. Turn-scoped MCP configuration is deliberately
+    owned by the caller. *)
 
 type error =
   | Invalid_runtime_root of string
@@ -15,7 +16,7 @@ type error =
       { path : string
       ; detail : string
       }
-  | Invalid_oauth_copy of
+  | Invalid_managed_oauth of
       { path : string
       ; detail : string
       }
@@ -45,7 +46,9 @@ val prepare
     [<runtime_root>/official-clients/antigravity/<owner_leaf>]. Every managed
     directory is an exact 0700 real directory owned by the effective user.
     [oauth_source] must be an effective-user-owned regular 0600 file reached
-    without symbolic links. *)
+    without symbolic links. It is copied only when the managed OAuth file does
+    not exist; an existing managed file must itself be an effective-user-owned
+    regular 0600 file and is never overwritten by preparation. *)
 
 val home_dir : t -> string
 

--- a/test/test_runtime_antigravity_home.ml
+++ b/test/test_runtime_antigravity_home.ml
@@ -21,7 +21,7 @@ let require_ok = function
 
 let permission path = (Unix.lstat path).Unix.st_perm land 0o7777
 
-let test_prepares_private_home_with_pinned_oauth_snapshot () =
+let test_prepares_private_home_with_oauth_seed () =
   with_temp_root
   @@ fun runtime_root ->
   let oauth_source = Filename.concat runtime_root "operator-oauth-token" in
@@ -63,10 +63,10 @@ let test_prepares_private_home_with_pinned_oauth_snapshot () =
        (Yojson.Safe.from_file paths.settings_path));
   check bool "oauth target is a regular file" true
     ((Unix.lstat paths.oauth_path).Unix.st_kind = Unix.S_REG);
-  check int "oauth snapshot mode" 0o600 (permission paths.oauth_path);
+  check int "managed oauth mode" 0o600 (permission paths.oauth_path);
   check
     string
-    "oauth snapshot bytes"
+    "managed oauth seed bytes"
     "operator-secret-canary"
     (Fs_compat.load_file paths.oauth_path);
   check
@@ -108,7 +108,7 @@ let test_rejects_non_private_or_indirect_oauth_source () =
   | Ok _ -> fail "symbolic-link OAuth source was admitted"
 ;;
 
-let test_refreshes_oauth_snapshot_from_current_source () =
+let test_preserves_runtime_managed_oauth_after_initial_seed () =
   with_temp_root
   @@ fun runtime_root ->
   let oauth_source = Filename.concat runtime_root "operator-oauth-token" in
@@ -120,7 +120,9 @@ let test_refreshes_oauth_snapshot_from_current_source () =
       ~oauth_source
     |> require_ok
   in
-  write_file ~mode:0o600 oauth_source "rotated-operator-secret";
+  let layout_paths = Runtime_antigravity_home.For_testing.paths layout in
+  write_file ~mode:0o600 layout_paths.oauth_path "refreshed-runtime-secret";
+  write_file ~mode:0o600 oauth_source "stale-operator-secret";
   let refreshed =
     Runtime_antigravity_home.prepare
       ~runtime_root
@@ -128,17 +130,46 @@ let test_refreshes_oauth_snapshot_from_current_source () =
       ~oauth_source
     |> require_ok
   in
-  let layout_paths = Runtime_antigravity_home.For_testing.paths layout in
   let refreshed_paths = Runtime_antigravity_home.For_testing.paths refreshed in
   check
     string
-    "current source replaces snapshot"
-    "rotated-operator-secret"
+    "runtime refresh survives later preparation"
+    "refreshed-runtime-secret"
     (Fs_compat.load_file refreshed_paths.oauth_path);
+  check
+    string
+    "bootstrap source remains external"
+    "stale-operator-secret"
+    (Fs_compat.load_file oauth_source);
   check string
     "stable isolated path"
     layout_paths.oauth_path
     refreshed_paths.oauth_path
+;;
+
+let test_rejects_unsafe_existing_runtime_oauth () =
+  with_temp_root
+  @@ fun runtime_root ->
+  let oauth_source = Filename.concat runtime_root "operator-oauth-token" in
+  write_file ~mode:0o600 oauth_source "operator-secret";
+  let layout =
+    Runtime_antigravity_home.prepare
+      ~runtime_root
+      ~owner_leaf:"keeper-sangsu"
+      ~oauth_source
+    |> require_ok
+  in
+  let oauth_path = (Runtime_antigravity_home.For_testing.paths layout).oauth_path in
+  Unix.chmod oauth_path 0o644;
+  match
+    Runtime_antigravity_home.prepare
+      ~runtime_root
+      ~owner_leaf:"keeper-sangsu"
+      ~oauth_source
+  with
+  | Error (Runtime_antigravity_home.Invalid_managed_oauth _) -> ()
+  | Error error -> fail (Runtime_antigravity_home.error_to_string error)
+  | Ok _ -> fail "unsafe existing runtime OAuth file was silently replaced"
 ;;
 
 let test_mcp_capability_is_turn_scoped () =
@@ -194,17 +225,21 @@ let () =
     "runtime_antigravity_home"
     [ ( "layout"
       , [ test_case
-            "private HOME and OAuth snapshot"
+            "private HOME and OAuth seed"
             `Quick
-            test_prepares_private_home_with_pinned_oauth_snapshot
+            test_prepares_private_home_with_oauth_seed
         ; test_case
             "private direct OAuth source"
             `Quick
             test_rejects_non_private_or_indirect_oauth_source
         ; test_case
-            "OAuth snapshot refresh"
+            "runtime OAuth refresh survives preparation"
             `Quick
-            test_refreshes_oauth_snapshot_from_current_source
+            test_preserves_runtime_managed_oauth_after_initial_seed
+        ; test_case
+            "unsafe existing runtime OAuth"
+            `Quick
+            test_rejects_unsafe_existing_runtime_oauth
         ; test_case
             "turn-scoped MCP capability"
             `Quick


### PR DESCRIPTION
## Summary

- seed each isolated Antigravity HOME from the configured OAuth file only when its managed credential is absent
- preserve later OAuth refreshes written by `agy` instead of replacing them before every Keeper turn
- fail closed when an existing managed credential is not an owned regular 0600 file
- remove the obsolete OAuth-copy error concept in favor of the managed credential owner

## Root cause

`Runtime_antigravity_home.prepare` rewrote the isolated OAuth file from the configured source before every turn. Live `agy 1.1.11` refreshed an expired credential, timed out while saving it to Keychain, and persisted the fresh token to the isolated file. The next preparation immediately replaced that fresh token with the expired source, forcing another Keychain read and refresh loop.

## Product impact

Antigravity Keeper turns retain the credential refresh owned by their persistent isolated HOME. Preparation still validates both the configured seed and any existing managed credential through the owned regular-file boundary; it does not silently repair unsafe state.

## Validation

- `scripts/dune-local.sh build @test/runtest-test_runtime_antigravity_home` — 6/6 pass (`W68YI5BF`), latest-main rebuild exit 0
- `scripts/dune-local.sh build @test/runtest-test_keeper_antigravity_runtime` — 1/1 pass on latest main (`7ZW7NB2S`)
- `ocamlformat --check` on all three changed OCaml files
- `git diff --check`

## Scope

The Antigravity `step_type` protocol drift is already merged separately in #28029. This PR changes only OAuth ownership and persistence.
