### PR TITLE
fix(runtime): 아무것도 결정하지 않는 permission_mode 때문에 Antigravity 턴이 끝나지 않게

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -63,13 +63,20 @@ type usage =
    operator resolved it (taskmaster, 110 turns in one hour).
 
    Nothing in this tree branches on the value: it is parsed, carried through
-   [state.init] into [turn_result], and never matched. A closed vocabulary over
-   a field the provider owns and we do not read costs a session each time the
-   provider adds a member. Kept closed for now because guessing members is
-   worse than failing loudly, but see #28008. *)
+   [state.init] into [turn_result], and never matched -- the only read of the
+   field is its own parse site. A closed vocabulary over a field the provider
+   owns and we do not read costs a session each time the provider adds a
+   member.
+
+   "Failing loudly" was the stated reason to keep it closed, but the failure
+   here is not loud: it ends the turn, parks the session, and stops the keeper
+   until an operator acts. [step_type] resolved the same trade-off the other
+   way three definitions down -- carry the unseen value in a constructor so the
+   drift stays visible, without ending a turn over a value no arm reads. *)
 type permission_mode =
   | Always_proceed
   | Request_review
+  | Unrecognized_permission_mode of string
 
 type turn_result =
   { conversation_id : string
@@ -239,15 +246,12 @@ let closed_string stage name parse value =
     protocol_error stage (Printf.sprintf "unsupported field %S value %S" name value)
 ;;
 
-let parse_permission_mode stage value =
-  closed_string
-    stage
-    "permission_mode"
-    (function
-      | "always-proceed" -> Some Always_proceed
-      | "request-review" -> Some Request_review
-      | _ -> None)
-    value
+let parse_permission_mode _stage value =
+  Ok
+    (match value with
+     | "always-proceed" -> Always_proceed
+     | "request-review" -> Request_review
+     | other -> Unrecognized_permission_mode other)
 ;;
 
 let parse_step_state stage value =
@@ -271,8 +275,8 @@ let parse_step_state stage value =
    (#28027). The value is kept in [Unrecognized] so the wire vocabulary drift is
    still visible rather than silently normalised away.
 
-   [state], [permission_mode] and [status] stay closed: each of those does
-   decide something. *)
+   [state] and [status] stay closed: each of those does decide something.
+   [permission_mode] does not, and is open for the same reason as this one. *)
 let parse_step_type _stage value =
   Ok
     (match value with

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -42,6 +42,10 @@ type usage =
 type permission_mode =
   | Always_proceed
   | Request_review
+  | Unrecognized_permission_mode of string
+      (** A mode the CLI announced that this tree does not model. Nothing
+          branches on [permission_mode], so an unseen member is carried rather
+          than rejected: rejecting it ended the turn and parked the session. *)
 
 type turn_result =
   { conversation_id : string

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -299,9 +299,13 @@ let test_duplicate_keys_fail_closed () =
 (* A live init event announced request-review. It was not modelled, the parse
    failed, and the resulting protocol error put the official-client session in
    Recovery_required -- which blocked every later turn for that keeper until an
-   operator resolved it (taskmaster, 110 turns in one hour). Nothing in this
-   tree branches on the value; the vocabulary is closed only to fail loudly on
-   a member we have not seen. *)
+   operator resolved it (taskmaster, 110 turns in one hour).
+
+   Nothing in this tree branches on [permission_mode]: the only read of the
+   field is its own parse site. Adding the one member that stalled a keeper
+   leaves the next one to stall it again, so an unseen mode is carried in
+   [Unrecognized_permission_mode] rather than rejected -- the drift stays
+   visible without ending a turn. *)
 let test_observed_permission_modes_are_admitted () =
   List.iter
     (fun (wire, expected) ->
@@ -313,20 +317,22 @@ let test_observed_permission_modes_are_admitted () =
           fail (wire ^ " was rejected: " ^ Runtime_antigravity.error_to_string error)))
     [ "always-proceed", Runtime_antigravity.Always_proceed
     ; "request-review", Runtime_antigravity.Request_review
+    ; ( "supervised-2027"
+      , Runtime_antigravity.Unrecognized_permission_mode "supervised-2027" )
     ]
 ;;
 
 let test_unknown_protocol_vocabulary_fails_closed () =
-  let unknown_permission =
-    {|{"event":"init","conversation_id":"conversation-1","init":{"model":"gemini-fixture","cwd":"/tmp","permission_mode":"unreviewed"}}|}
-  in
-  (* step_type left this list in #28027: it is the one vocabulary here that
-     decides nothing (see [test_unknown_step_type_does_not_end_the_turn]).
-     permission_mode, step state and result status each still decide something,
-     so an unseen value there is a real ambiguity and stays closed. *)
+  (* step_type left this list in #28027 and permission_mode followed: both are
+     vocabularies nothing branches on, so an unseen value carries no ambiguity
+     to fail closed over (see [test_observed_permission_modes_are_admitted] and
+     [test_unknown_step_type_does_not_end_the_turn]).
+
+     step state and result status stay: [Done] vs [Step_error] and [Success] vs
+     [Result_error] each select a different terminal outcome, so a value we
+     cannot place is a real ambiguity. *)
   let cases =
-    [ "permission mode", [ unknown_permission; result () ]
-    ; "step state", [ init (); step ~state:"PAUSED" (); result () ]
+    [ "step state", [ init (); step ~state:"PAUSED" (); result () ]
     ; "result status", [ init (); result ~status:"PARTIAL" () ]
     ]
   in


### PR DESCRIPTION
## 무엇을

`parse_permission_mode` 의 닫힌 어휘를 엽니다. `step_type` 이 `#28027` 에서 한 것과 같은 방식입니다.

## 왜 — 같은 형태가 오늘 네 번 나왔습니다

| # | 필드 | 결과 |
|---|---|---|
| #27967 | `delta` non-empty | 턴 3,236건 거부 |
| #28008 | `permission_mode` 멤버 1개 | taskmaster 1시간 110턴 0% |
| #28010 | 읽지 않는 필드 3자리 | (선제 제거) |
| #28027 | `step_type` | taskmaster, 라이브 47분 46건 |

전부 **provider 가 고르는 값에 걸린 닫힌 어휘**입니다. 파스 실패 → 턴 terminal → 세션 `Recovery_required` → 그 키퍼의 모든 턴 정지.

## 이 필드는 아무것도 결정하지 않습니다

```
$ rg '\| Always_proceed|\| Request_review|Always_proceed ->' lib/ test/ packages/
lib/runtime/runtime_antigravity.ml:71:  | Always_proceed      ← 타입 정의
lib/runtime/runtime_antigravity.ml:72:  | Request_review      ← 타입 정의

$ rg '\.permission_mode|permission_mode =' lib/
lib/runtime/runtime_antigravity.ml:306:  let* permission_mode = parse_permission_mode ...   ← 자기 파싱 지점
```

**분기가 0개입니다.** `lib/`·`test/`·`packages/` 전체에서 생성자는 타입 정의에만 나옵니다.

## 주석 둘이 서로 모순이었습니다

```ocaml
(* :59-69 — 타입 주석 *)
   Nothing in this tree branches on the value: it is parsed, carried through
   [state.init] into [turn_result], and never matched.

(* :274 — parse_step_type 주석 *)
   [state], [permission_mode] and [status] stay closed: each of those does
   decide something.
```

앞의 것이 코드가 하는 일이고, 뒤의 것을 이 PR 이 정정합니다.

타입 주석은 닫아둔 근거로 *"guessing members is worse than failing loudly"* 를 들었습니다. 그런데 **여기서 실패는 loud 하지 않습니다** — 턴을 끝내고 세션을 park 하고 운영자가 올 때까지 키퍼를 세웁니다. `#28008` 이 멤버 하나를 추가했지만, 다음 멤버가 같은 일을 반복합니다.

## 닫힌 채로 두는 것

`state` 와 `status` 는 그대로입니다. `Done` vs `Step_error`, `Success` vs `Result_error` 는 **서로 다른 종료 결과를 선택**하므로 알 수 없는 값은 진짜 모호성입니다. 두 케이스 모두 fails-closed 테스트를 유지합니다.

## 검증

```
$ dune build --root . @test/runtest-test_runtime_antigravity
Test Successful in 5.524s. 15 tests run.
```

`test_unknown_protocol_vocabulary_fails_closed` 에서 `permission mode` 케이스를 빼고, `test_observed_permission_modes_are_admitted` 에 `supervised-2027 → Unrecognized_permission_mode "supervised-2027"` 을 넣었습니다 — **거부 목록에서 허용 목록으로 이동**.

**뮤테이션**: 알 수 없는 모드를 `Always_proceed` 로 **조용히 정규화**하도록 바꾸면

```
> [FAIL]  stream-json  11  observed permission modes a...
FAIL permission mode supervised-2027
1 failure! in 5.074s. 15 tests run.
```

새 케이스만 실패하고 나머지 14건은 초록입니다. 즉 테스트가 고정한 것은 "죽지 않는다"가 아니라 **"값이 보이게 실린다"** 입니다.

**소비자 스위트**도 돌렸습니다 — `test_runtime_antigravity_home`, `test_keeper_antigravity_runtime` 둘 다 통과. (직전 PR 에서 store 스위트만 돌리고 소비자를 빠뜨려 계약을 놓친 적이 있어 이번엔 함께 확인했습니다.)

## 어떻게 찾았나

runtime 계층의 리터럴 어휘 디코더 13개를 훑어 열림/닫힘을 분류했습니다(열림 12, 닫힘 1 — 닫힌 하나는 `runtime_toml.ml` 의 MASC 자체 config 파싱이라 옳음). 그 뒤 `closed_string` 호출 3자리를 개별 확인해 이 건을 찾았습니다.

RFC-WAIVED: 읽지 않는 필드의 어휘 개방. 새 게이트·새 기본값 없음이며, 결정에 쓰이는 `state`·`status` 의 fails-closed 는 유지·테스트로 고정됨.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
