### PR TITLE
fix(runtime): keep official-client sessions moving

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -418,17 +418,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             then Ok ()
             else Error (internal_error "Antigravity resumed flag differs from durable plan")
           in
-          let* () =
-            if turn.num_turns = turn_count
-            then Ok ()
-            else
-              Error
-                (internal_error
-                   (Printf.sprintf
-                      "Antigravity reported turn %d; durable session expected %d"
-                      turn.num_turns
-                      turn_count))
-          in
           let turn_id =
             provider_turn_identity
               ~conversation_id:turn.conversation_id
@@ -442,6 +431,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                 ~expected
                 ~session_id:turn.conversation_id
                 ~turn_id
+                ~turn_count:turn.num_turns
                 ~updated_at:(Time_compat.now ()))
             |> Result.map_error internal_error
           in
@@ -478,10 +468,10 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             match
               Host.invoke_turn_hook
                 ~keeper_name
-                ~turn_count
+                ~turn_count:turn.num_turns
                 ~hook_name:"after_turn"
                 hooks.after_turn
-                (Agent_core.Hooks.AfterTurn { turn = turn_count; response })
+                (Agent_core.Hooks.AfterTurn { turn = turn.num_turns; response })
             with
             | Continue -> Ok ()
             | HookFailed { stage; detail } ->
@@ -493,7 +483,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             match
               Host.invoke_turn_hook
                 ~keeper_name
-                ~turn_count
+                ~turn_count:turn.num_turns
                 ~hook_name:"on_stop"
                 hooks.on_stop
                 (Agent_core.Hooks.OnStop { reason = response.stop_reason; response })
@@ -549,7 +539,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             { Runtime_agent.response
             ; checkpoint = None
             ; session_id = turn.conversation_id
-            ; turns = turn_count
+            ; turns = turn.num_turns
             ; trace_ref = None
             ; run_validation = None
             ; runtime_observation = Some runtime_observation

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -14,6 +14,10 @@ let internal_error detail = Agent_core.Error.Internal detail
 let runtime_error_to_core_error = function
   | Runtime_antigravity.Invalid_config detail ->
     config_error ~field:"antigravity_cli" detail
+  | Runtime_antigravity.Prompt_too_large { bytes; limit } ->
+    config_error
+      ~field:"antigravity_cli.prompt"
+      (Printf.sprintf "prompt bytes=%d exceed argv limit=%d" bytes limit)
   | Runtime_antigravity.Turn_failed detail ->
     Agent_core.Error.Provider
       (Llm_provider.Error.ProviderReportedError
@@ -44,6 +48,7 @@ let recovery_failure_of_runtime_error = function
   | Runtime_antigravity.Process_exited _ | Runtime_antigravity.Timeout _ ->
     Session_store.Transport_interrupted
   | Runtime_antigravity.Invalid_config _
+  | Runtime_antigravity.Prompt_too_large _
   | Runtime_antigravity.Protocol_error _ ->
     Session_store.Protocol_failed
   | Runtime_antigravity.State_callback_failed _ ->
@@ -60,35 +65,70 @@ let home_error_to_core_error error =
 let render_message (message : Agent_core.Types.message) =
   let text = Host.encode_history_message message in
   match message.role with
-  | Agent_core.Types.System -> Ok ("SYSTEM:\n" ^ text)
-  | Agent_core.Types.User -> Ok ("USER:\n" ^ text)
-  | Agent_core.Types.Assistant -> Ok ("ASSISTANT:\n" ^ text)
-  | Agent_core.Types.Tool -> Ok ("TOOL:\n" ^ text)
+  | Agent_core.Types.System -> "SYSTEM:\n" ^ text
+  | Agent_core.Types.User -> "USER:\n" ^ text
+  | Agent_core.Types.Assistant -> "ASSISTANT:\n" ^ text
+  | Agent_core.Types.Tool -> "TOOL:\n" ^ text
 ;;
 
+let section_separator = "\n\n"
+
 let render_messages messages =
-  let rec loop rendered = function
-    | [] -> Ok (String.concat "\n\n" (List.rev rendered))
-    | message :: rest ->
-      let* rendered_message = render_message message in
-      loop (rendered_message :: rendered) rest
-  in
-  loop [] messages
+  messages
+  |> List.map render_message
+  |> String.concat section_separator
 ;;
+
+type prompt_projection =
+  { prompt : string
+  ; kept_messages : int
+  ; dropped_atoms : int
+  }
 
 let prompt_for_turn ~is_resume ~goal (prepared : Host.prepared_turn) =
   if is_resume
-  then Ok goal
+  then Ok { prompt = goal; kept_messages = 0; dropped_atoms = 0 }
   else
-    let* history = render_messages prepared.messages in
+    let system =
+      String_util.trim_to_option prepared.system_prompt
+      |> Option.map (fun value -> "SYSTEM INSTRUCTIONS:\n" ^ value)
+    in
+    let current_goal = "CURRENT GOAL:\n" ^ goal in
+    let reserved_bytes =
+      Option.fold ~none:0 ~some:String.length system
+      + String.length current_goal
+      + (2 * String.length section_separator)
+    in
+    let measure_message_bytes message =
+      render_message message
+      |> String.length
+      |> ( + ) (String.length section_separator)
+    in
+    let* projection =
+      Runtime_model_input_tail_window.project_with_drop
+        ~measure_message_bytes
+        ~capacity_bytes:Runtime_antigravity.max_prompt_bytes
+        ~reserved_bytes
+        prepared.messages
+      |> Result.map_error (fun error ->
+        config_error
+          ~field:"antigravity_cli.prompt"
+          (Runtime_model_input_tail_window.budget_error_to_string error))
+    in
+    let history = render_messages projection.messages in
+    let prompt =
+      [ system
+      ; String_util.trim_to_option history
+      ; Some current_goal
+      ]
+      |> List.filter_map Fun.id
+      |> String.concat section_separator
+    in
     Ok
-      ([ String_util.trim_to_option prepared.system_prompt
-         |> Option.map (fun value -> "SYSTEM INSTRUCTIONS:\n" ^ value)
-       ; String_util.trim_to_option history
-       ; Some ("CURRENT GOAL:\n" ^ goal)
-       ]
-       |> List.filter_map Fun.id
-       |> String.concat "\n\n")
+      { prompt
+      ; kept_messages = List.length projection.messages
+      ; dropped_atoms = projection.dropped_atoms
+      }
 ;;
 
 let tool_spec (tool : Host.dynamic_tool) =
@@ -206,7 +246,17 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       | None -> Ok goal
       | Some blocks -> Host.text_of_blocks ~runtime_label ~field:"goal_blocks" blocks
     in
-    let* prompt = prompt_for_turn ~is_resume ~goal prepared in
+    let* prompt_projection = prompt_for_turn ~is_resume ~goal prepared in
+    let prompt = prompt_projection.prompt in
+    if prompt_projection.dropped_atoms > 0
+    then
+      Log.Keeper.warn
+        ~keeper_name
+        "Antigravity fresh prompt kept %d history message(s) after dropping %d \
+         complete atom(s) to fit the %d-byte argv boundary"
+        prompt_projection.kept_messages
+        prompt_projection.dropped_atoms
+        Runtime_antigravity.max_prompt_bytes;
     let terminal_error = ref None in
     let* dynamic_tools =
       Host.dynamic_tools

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -406,6 +406,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                    ~expected
                    ~session_id
                    ~turn_id
+                   ~turn_count
                    ~updated_at:(Time_compat.now ())))
              client_config
              ~prompt

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -406,6 +406,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                ~expected
                ~session_id:thread_id
                ~turn_id
+               ~turn_count
                ~updated_at:(Time_compat.now ())))
          client_config
          ~prompt

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -744,16 +744,7 @@ let plan_claim ~expected ~client_kind ~runtime_id =
       Error "official-client session has an active unsettled attempt; refusing duplicate execution"
     | Some { phase = Turn_inflight _; _ } ->
       Error "official-client session has an in-flight turn; refusing duplicate execution"
-    | Some
-        { phase = Recovery_required recovery
-        ; turn_count
-        ; tool_surface_sha256
-        ; _
-        } ->
-      Ok
-        ( recovery.previous_settlement
-        , turn_count
-        , Option.map (fun _ -> tool_surface_sha256) recovery.previous_settlement )
+    | Some { phase = Recovery_required _; _ } -> Ok (None, 1, None)
   in
   Ok { previous_settlement; turn_count; required_tool_surface_sha256 }
 ;;
@@ -806,7 +797,7 @@ let claim ~base_path ~keeper_name ~expected ~client_kind ~owner_epoch ~runtime_i
    | Some { phase = Recovery_required recovery; _ } ->
      Log.Keeper.info
        ~keeper_name
-       "auto-superseded official-client recovery=%s failure=%s owner_epoch=%s"
+       "auto-superseded official-client recovery=%s failure=%s with a fresh session owner_epoch=%s"
        recovery.recovery_id
        (recovery_failure_to_string recovery.failure)
        owner_epoch

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -849,7 +849,7 @@ let mark_turn_starting ~base_path ~keeper_name ~expected ~session_id ~updated_at
 ;;
 
 let mark_turn_started ~base_path ~keeper_name ~expected ~session_id ~turn_id
-    ~updated_at =
+    ~turn_count ~updated_at =
   match expected.phase with
   | Turn_inflight
       { owner_epoch
@@ -858,20 +858,24 @@ let mark_turn_started ~base_path ~keeper_name ~expected ~session_id ~turn_id
       ; previous_settlement
       }
     when String.equal inflight_session_id session_id ->
-    transition
-      ~base_path
-      ~keeper_name
-      ~expected:(Some expected)
-      { expected with
-        phase =
-          Turn_inflight
-            { owner_epoch
-            ; session_id
-            ; turn_id = Some turn_id
-            ; previous_settlement
-            }
-      ; updated_at
-      }
+    if turn_count < expected.turn_count
+    then Error "official-client observed turn count regressed after turn start"
+    else
+      transition
+        ~base_path
+        ~keeper_name
+        ~expected:(Some expected)
+        { expected with
+          phase =
+            Turn_inflight
+              { owner_epoch
+              ; session_id
+              ; turn_id = Some turn_id
+              ; previous_settlement
+              }
+        ; turn_count
+        ; updated_at
+        }
   | Turn_inflight { turn_id = None; _ } ->
     Error "official-client in-flight session identity changed after turn start"
   | Turn_inflight { turn_id = Some _; _ } ->

--- a/lib/keeper/keeper_official_client_session_store.mli
+++ b/lib/keeper/keeper_official_client_session_store.mli
@@ -161,8 +161,8 @@ val claim :
     declared client kind or runtime id changes. Resuming the same settled
     client/runtime requires an identical tool surface. A same-process Start,
     Active, or Turn_inflight phase rejects a concurrent claim. A completed
-    failure observation is superseded atomically by the next claim and never
-    requires operator resolution before execution. *)
+    failure observation is superseded atomically by a fresh-session claim and
+    never requires operator resolution before execution. *)
 
 val mark_active :
   base_path:string ->

--- a/lib/keeper/keeper_official_client_session_store.mli
+++ b/lib/keeper/keeper_official_client_session_store.mli
@@ -186,6 +186,7 @@ val mark_turn_started :
   expected:t ->
   session_id:string ->
   turn_id:string ->
+  turn_count:int ->
   updated_at:float ->
   (t, string) result
 

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -31,6 +31,12 @@ let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 8192
 let max_wire_line_bytes = 8 * 1024 * 1024
 
+(* [agy --print] accepts the prompt only as one argv member. Linux caps one
+   member below ARG_MAX and macOS charges it against the whole argv+environment
+   block, so a provider request-body budget cannot protect this spawn boundary.
+   Keep one cross-platform limit below both kernels and reject before execve. *)
+let max_prompt_bytes = 120 * 1024
+
 let default_config ~cwd ~model =
   { cli_path = "agy"
   ; cwd
@@ -82,6 +88,10 @@ type turn_result =
 
 type error =
   | Invalid_config of string
+  | Prompt_too_large of
+      { bytes : int
+      ; limit : int
+      }
   | Spawn_failed of string
   | Protocol_error of
       { stage : string
@@ -96,6 +106,11 @@ exception Runtime_error of error
 
 let error_to_string = function
   | Invalid_config detail -> "invalid Antigravity CLI config: " ^ detail
+  | Prompt_too_large { bytes; limit } ->
+    Printf.sprintf
+      "Antigravity prompt is %d bytes; the CLI argv boundary admits at most %d"
+      bytes
+      limit
   | Spawn_failed detail -> "failed to start Antigravity CLI: " ^ detail
   | Protocol_error { stage; detail } ->
     Printf.sprintf "Antigravity stream-json protocol error during %s: %s" stage detail
@@ -380,6 +395,10 @@ let validate_config config ~conversation_mode ~prompt =
   then Error (Invalid_config "timeout_s must be positive and finite")
   else if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
+  else if String.length prompt > max_prompt_bytes
+  then
+    Error
+      (Prompt_too_large { bytes = String.length prompt; limit = max_prompt_bytes })
   else
     match config.agent, conversation_mode with
     | Some agent, _ when String.trim agent = "" ->

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -477,7 +477,7 @@ let argv config ~conversation_mode ~prompt =
     if config.disable_slash_commands then values @ [ "--disable-slash-commands" ] else values)
   |> (fun values ->
     match conversation_mode with
-    | Start -> values
+    | Start -> values @ [ "--new-project" ]
     | Resume { conversation_id } -> values @ [ "--conversation"; conversation_id ])
 ;;
 

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -30,6 +30,9 @@ val default_config : cwd:string -> model:string -> config
 type conversation_mode =
   | Start
   | Resume of { conversation_id : string }
+(** [Start] asks the official client to create a new project so cached
+    workspace state cannot select an earlier conversation. [Resume] names the
+    exact durable conversation and never creates a project. *)
 
 type usage =
   { input_tokens : int

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -27,6 +27,11 @@ type config =
 
 val default_config : cwd:string -> model:string -> config
 
+val max_prompt_bytes : int
+(** Largest prompt accepted by the spawn boundary. [agy] exposes no stdin or
+    prompt-file form, so the prompt is one argv member and must fit the kernel
+    limit before [execve]. *)
+
 type conversation_mode =
   | Start
   | Resume of { conversation_id : string }
@@ -65,6 +70,10 @@ type turn_result =
 
 type error =
   | Invalid_config of string
+  | Prompt_too_large of
+      { bytes : int
+      ; limit : int
+      }
   | Spawn_failed of string
   | Protocol_error of
       { stage : string

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -278,6 +278,17 @@ let test_keeper_projects_mcp_tool_and_settles () =
         ; metadata = []
         }
       in
+      let large_history =
+        List.init 70 (fun index ->
+          let marker = Printf.sprintf "history-%02d" index in
+          { Agent_core.Types.role = User
+          ; content = [ Text (marker ^ ":" ^ String.make 4096 'x') ]
+          ; name = None
+          ; tool_call_id = None
+          ; metadata = []
+          })
+        @ [ tool_history ]
+      in
       let runtime_snapshot = Runtime.For_testing.snapshot () in
       Fun.protect
         ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
@@ -301,7 +312,7 @@ let test_keeper_projects_mcp_tool_and_settles () =
                       ~base_path
                       ~goal:"Call masc_probe once"
                       ~tools:[ tool ]
-                      ~initial_messages:[ tool_history ]
+                      ~initial_messages:large_history
                       ~context:(Agent_core.Context.create ())
                       ~raw_trace
                       ~sw
@@ -328,7 +339,7 @@ let test_keeper_projects_mcp_tool_and_settles () =
                         ~base_path
                         ~goal:"Call masc_probe once"
                         ~tools:[ tool ]
-                        ~initial_messages:[ tool_history ]
+                        ~initial_messages:large_history
                         ~context:(Agent_core.Context.create ())
                         ~raw_trace
                         ~sw
@@ -351,6 +362,18 @@ let test_keeper_projects_mcp_tool_and_settles () =
         | Some prompt -> prompt
         | None -> fail "initial Antigravity prompt was not captured"
       in
+      check bool
+        "fresh prompt fits argv boundary"
+        true
+        (String.length prompt <= Runtime_antigravity.max_prompt_bytes);
+      check bool
+        "fresh prompt drops complete old atoms"
+        false
+        (String_util.contains_substring prompt "history-00");
+      check bool
+        "fresh prompt keeps newest atom"
+        true
+        (String_util.contains_substring prompt "history-69");
       check bool
         "prompt preserves prior tool role"
         true

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -52,7 +52,7 @@ for arg in "$@"; do
     --sandbox) sandbox=1 ;;
     --disable-slash-commands) slash_commands_disabled=1 ;;
     --conversation) expect_conversation=1 ;;
-    conversation-antigravity-fixture) turns=2 ;;
+    conversation-antigravity-fixture) turns=73 ;;
   esac
 done
 test "$expect_mode" -eq 0
@@ -159,6 +159,7 @@ let test_keeper_projects_mcp_tool_and_settles () =
         |> Result.get_ok
       in
       let observed_trace_ref = ref None in
+      let observed_initial_prompt = ref None in
       let cli_path = fixture_script ~base_path in
       let runtime_path = Filename.concat base_path "runtime.toml" in
       write_file ~mode:0o600 runtime_path (runtime_toml ~cli_path ~oauth_source);
@@ -232,13 +233,42 @@ let test_keeper_projects_mcp_tool_and_settles () =
                       "response"
                       "MASC_ANTIGRAVITY_KEEPER_OK"
                       (keeper_response_text turn);
-                    check int "turn count" 1 turn.turns))));
+                    check int "turn count" 1 turn.turns;
+                    observed_initial_prompt :=
+                      Some
+                        (In_channel.with_open_bin
+                           (Filename.concat base_path "antigravity-prompt.txt")
+                           In_channel.input_all);
+                    match
+                      Keeper_turn_driver.run_named
+                        ~runtime_id:"antigravity.gemini"
+                        ~keeper_name:"antigravity-fixture"
+                        ~base_path
+                        ~goal:"Call masc_probe once"
+                        ~tools:[ tool ]
+                        ~initial_messages:[ tool_history ]
+                        ~context:(Agent_core.Context.create ())
+                        ~raw_trace
+                        ~sw
+                        ~net:(Eio.Stdenv.net env)
+                        ()
+                    with
+                    | Error error -> fail (Agent_core.Error.to_string error)
+                    | Ok resumed ->
+                      observed_trace_ref := resumed.trace_ref;
+                      check int
+                        "provider cumulative turn count"
+                        73
+                        resumed.turns))));
       check string
         "tool arguments"
         {|{"marker":"from-antigravity"}|}
         (Yojson.Safe.to_string !observed);
-      let prompt_path = Filename.concat base_path "antigravity-prompt.txt" in
-      let prompt = In_channel.with_open_bin prompt_path In_channel.input_all in
+      let prompt =
+        match !observed_initial_prompt with
+        | Some prompt -> prompt
+        | None -> fail "initial Antigravity prompt was not captured"
+      in
       check bool
         "prompt preserves prior tool role"
         true
@@ -277,9 +307,18 @@ let test_keeper_projects_mcp_tool_and_settles () =
       (match session.phase with
        | Settled
            { session_id = "conversation-antigravity-fixture"
-           ; turn_id = "conversation-antigravity-fixture:ordinal:1"
+           ; turn_id = "conversation-antigravity-fixture:ordinal:73"
            } -> ()
        | _ -> fail "Antigravity Keeper turn did not settle");
+      check int "durable provider turn count" 73 session.turn_count;
+      let next_plan =
+        Keeper_official_client_session_store.plan_claim
+          ~expected:(Some session)
+          ~client_kind:Keeper_official_client_session_store.Antigravity
+          ~runtime_id:"antigravity.gemini"
+        |> Result.get_ok
+      in
+      check int "next durable turn count" 74 next_plan.turn_count;
       let mcp_path =
         Filename.concat
           mascot_root

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -40,6 +40,7 @@ turns=1
 mode=
 sandbox=0
 slash_commands_disabled=0
+new_project=0
 expect_mode=0
 for arg in "$@"; do
   if [ "$expect_mode" -eq 1 ]; then
@@ -51,6 +52,7 @@ for arg in "$@"; do
     --mode) expect_mode=1 ;;
     --sandbox) sandbox=1 ;;
     --disable-slash-commands) slash_commands_disabled=1 ;;
+    --new-project) new_project=1 ;;
     --conversation) expect_conversation=1 ;;
     conversation-antigravity-fixture) turns=73 ;;
   esac
@@ -59,6 +61,7 @@ test "$expect_mode" -eq 0
 test "$mode" = plan
 test "$sandbox" -eq 1
 test "$slash_commands_disabled" -eq 1
+if [ "$turns" -eq 1 ]; then test "$new_project" -eq 1; else test "$new_project" -eq 0; fi
 printf '%%s' "$2" > %s
 printf '{"event":"init","conversation_id":"%%s","init":{"model":"gemini-fixture","cwd":%s,"tools":["call_mcp_tool"],"permission_mode":"always-proceed"}}\n' "$conversation"
 python3 - <<'PY'
@@ -143,6 +146,84 @@ let keeper_response_text (result : Runtime_agent.run_result) =
   |> String.concat ""
 ;;
 
+let seed_ambiguous_resumed_session ~base_path ~tool =
+  let module Store = Keeper_official_client_session_store in
+  let owner_epoch = "11111111-1111-4111-8111-111111111111" in
+  let runtime_id = "antigravity.gemini" in
+  let tool_surface_sha256 = Store.tool_surface_sha256 [ tool ] in
+  let claimed =
+    Store.claim
+      ~base_path
+      ~keeper_name:"antigravity-fixture"
+      ~expected:None
+      ~client_kind:Antigravity
+      ~owner_epoch
+      ~runtime_id
+      ~tool_surface_sha256
+      ~updated_at:1.0
+    |> Result.get_ok
+  in
+  let active =
+    Store.mark_active
+      ~base_path
+      ~keeper_name:"antigravity-fixture"
+      ~expected:claimed
+      ~session_id:"conversation-stale"
+      ~updated_at:2.0
+    |> Result.get_ok
+  in
+  let starting =
+    Store.mark_turn_starting
+      ~base_path
+      ~keeper_name:"antigravity-fixture"
+      ~expected:active
+      ~session_id:"conversation-stale"
+      ~updated_at:3.0
+    |> Result.get_ok
+  in
+  let inflight =
+    Store.mark_turn_started
+      ~base_path
+      ~keeper_name:"antigravity-fixture"
+      ~expected:starting
+      ~session_id:"conversation-stale"
+      ~turn_id:"conversation-stale:ordinal:1"
+      ~updated_at:4.0
+    |> Result.get_ok
+  in
+  let settled =
+    Store.settle
+      ~base_path
+      ~keeper_name:"antigravity-fixture"
+      ~expected:inflight
+      ~session_id:"conversation-stale"
+      ~turn_id:"conversation-stale:ordinal:1"
+      ~updated_at:5.0
+    |> Result.get_ok
+  in
+  let resumed =
+    Store.claim
+      ~base_path
+      ~keeper_name:"antigravity-fixture"
+      ~expected:(Some settled)
+      ~client_kind:Antigravity
+      ~owner_epoch
+      ~runtime_id
+      ~tool_surface_sha256
+      ~updated_at:6.0
+    |> Result.get_ok
+  in
+  Store.require_recovery
+    ~base_path
+    ~keeper_name:"antigravity-fixture"
+    ~expected:resumed
+    ~failure:Protocol_failed
+    ~detail:"provider conversation advanced without a local settlement"
+    ~required_at:7.0
+  |> Result.get_ok
+  |> ignore
+;;
+
 let test_keeper_projects_mcp_tool_and_settles () =
   let base_path = temp_workspace () |> Unix.realpath in
   Fun.protect
@@ -180,6 +261,7 @@ let test_keeper_projects_mcp_tool_and_settles () =
             observed := input;
             Ok { Agent_core.Types.content = "MASC_TOOL_RESULT"; _meta = None })
       in
+      seed_ambiguous_resumed_session ~base_path ~tool;
       let tool_history : Agent_core.Types.message =
         { role = Tool
         ; content =

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -88,6 +88,18 @@ let test_roundtrip_and_settlement () =
         ~updated_at:3.0
       |> Result.get_ok
     in
+    (match
+       mark_turn_started
+         ~base_path
+         ~keeper_name
+         ~expected:starting
+         ~session_id:"session-1"
+         ~turn_id:"turn-regressed"
+         ~turn_count:(starting.turn_count - 1)
+         ~updated_at:3.5
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "a regressed provider turn count mutated the durable claim");
     let inflight =
       mark_turn_started
         ~base_path
@@ -95,6 +107,7 @@ let test_roundtrip_and_settlement () =
         ~expected:starting
         ~session_id:"session-1"
         ~turn_id:"turn-1"
+        ~turn_count:starting.turn_count
         ~updated_at:4.0
       |> Result.get_ok
     in
@@ -233,6 +246,7 @@ let test_moved_tool_surface_starts_fresh () =
         ~expected:inflight
         ~session_id:"session-1"
         ~turn_id:"turn-1"
+        ~turn_count:inflight.turn_count
         ~updated_at:4.0
       |> Result.get_ok
     in
@@ -354,6 +368,7 @@ let test_terminal_identity_switch_starts_fresh () =
         ~expected:starting
         ~session_id:"codex-session"
         ~turn_id:"codex-turn"
+        ~turn_count:starting.turn_count
         ~updated_at:4.0
       |> Result.get_ok
     in
@@ -588,6 +603,7 @@ let test_retry_previous_restores_exact_settlement () =
         ~expected:starting
         ~session_id:"session-1"
         ~turn_id:"turn-1"
+        ~turn_count:starting.turn_count
         ~updated_at:4.0
       |> Result.get_ok
     in

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -651,6 +651,24 @@ let test_retry_previous_restores_exact_settlement () =
       | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
         fail "resumed claim did not enter recovery"
     in
+    let automatic_plan =
+      plan_claim
+        ~expected:(Some recovery)
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+      |> Result.get_ok
+    in
+    check int "automatic recovery restarts ordinal" 1 automatic_plan.turn_count;
+    check
+      (option string)
+      "automatic recovery drops surface requirement"
+      None
+      automatic_plan.required_tool_surface_sha256;
+    check
+      bool
+      "automatic recovery does not resume an ambiguous provider conversation"
+      true
+      (Option.is_none automatic_plan.previous_settlement);
     let restored, application =
       resolve_recovery
         ~base_path

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -369,6 +369,19 @@ let test_admission_is_process_free () =
   | Ok () -> fail "invalid deterministic config passed admission"
 ;;
 
+let test_oversized_prompt_is_typed_before_spawn () =
+  let config =
+    Runtime_antigravity.default_config ~cwd:"/tmp" ~model:"gemini-fixture"
+  in
+  let prompt = String.make (Runtime_antigravity.max_prompt_bytes + 1) 'x' in
+  match Runtime_antigravity.validate_turn config ~prompt with
+  | Error (Runtime_antigravity.Prompt_too_large { bytes; limit }) ->
+    check int "measured bytes" (String.length prompt) bytes;
+    check int "declared argv limit" Runtime_antigravity.max_prompt_bytes limit
+  | Error error -> fail (Runtime_antigravity.error_to_string error)
+  | Ok () -> fail "oversized prompt reached the spawn boundary"
+;;
+
 let test_live_start_and_resume () =
   match Sys.getenv_opt "MASC_ANTIGRAVITY_LIVE", Sys.getenv_opt "MASC_ANTIGRAVITY_MODEL" with
   | Some "1", Some model ->
@@ -467,6 +480,10 @@ let () =
             test_unknown_protocol_vocabulary_fails_closed
         ; test_case "typed timeout" `Quick test_timeout_is_typed
         ; test_case "process-free admission" `Quick test_admission_is_process_free
+        ; test_case
+            "oversized prompt is typed before spawn"
+            `Quick
+            test_oversized_prompt_is_typed_before_spawn
         ] )
     ; "live official client", [ test_case "official agy start and resume" `Slow test_live_start_and_resume ]
     ]

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -68,10 +68,14 @@ let fixture_script
   output_string output
     "test -z \"${GEMINI_API_KEY+x}\" && test -z \"${GEMINI_API_KEY_WORK+x}\" && test -z \"${GOOGLE_API_TOKEN+x}\" && test -z \"${OPENAI_API_KEY+x}\" && test -z \"${OPENAI_API_KEY_MAIN+x}\" && test -z \"${ANTHROPIC_API_KEY+x}\" && test -z \"${ANTHROPIC_API_KEY_WORK+x}\" && test -z \"${AGY_ADC_AUTH+x}\" && test -z \"${MASC_PUBLIC_FIXTURE+x}\" || exit 92\n";
   if require_resume
-  then
+  then (
     output_string
       output
       "case \" $* \" in *\" --conversation conversation-1 \"*) ;; *) exit 93 ;; esac\n";
+    output_string output "case \" $* \" in *\" --new-project \"*) exit 96 ;; esac\n")
+  else (
+    output_string output "case \" $* \" in *\" --new-project \"*) ;; *) exit 96 ;; esac\n";
+    output_string output "case \" $* \" in *\" --conversation \"*) exit 97 ;; esac\n");
   Option.iter
     (fun expected ->
       output_string

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -1174,9 +1174,16 @@ let test_keeper_protocol_failure_enters_recovery () =
               |> Result.get_ok
             in
             check int
-              "failed turn ordinal is reused without an operator gate"
-              recovery.turn_count
-              next_claim.turn_count))
+              "failed provider session is superseded at a fresh ordinal"
+              1
+              next_claim.turn_count;
+            check
+              (option string)
+              "failed provider session is not resumed"
+              None
+              (Option.map
+                 (fun settlement -> settlement.session_id)
+                 next_claim.previous_settlement)))
 ;;
 
 let test_dashboard_official_client_recovery_projection_and_resolution () =


### PR DESCRIPTION
## Summary

- treat each official client typed turn count as the authoritative cumulative count and reject only regressions
- atomically supersede an ambiguous completed failure with a fresh session instead of blocking later Keeper turns
- never resume the previous provider settlement after an ambiguous failure, so an interrupted external effect is not replayed
- force Antigravity Start through --new-project while Resume names the exact durable conversation
- reuse Runtime_model_input_tail_window for the fresh Antigravity argv budget so Assistant+Tool atoms and pinned context remain intact
- reject any final prompt over 120 KiB as typed Prompt_too_large before execve

## Verification

- ocamlformat --check and ocamlc parse validation on all changed OCaml files
- Dashboard focused Vitest: 72 passed
- Chromium queued-stream E2E: submit, queued edit/move/cancel, Running thinking/tool projection, Succeeded text, restart Interrupted; four screenshots produced
- large-history Antigravity integration now requires an argv-bounded fresh Start, drops only complete old atoms, keeps the newest atom and typed Tool context, then resumes at the provider cumulative count
- focused OCaml wrapper command is pending current-head execution because other local sessions are running bare Dune processes; GitHub Build and Test is authoritative until they clear

Focused command:

    scripts/dune-local.sh build @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_keeper_antigravity_runtime @test/runtest-test_runtime_codex_app_server
