### PR TITLE
fix(wizard): 바인딩이 하나면 그것이 install-wizard 기본값 — 결정 없는 요구가 부팅되는 설정을 거부했다

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1041,11 +1041,17 @@ let runtime_wizard_binding_for_provider (cfg : Runtime_schema.config)
   | _ ->
       (match List.filter (fun (binding : Runtime_schema.binding) -> binding.wizard_default) bindings with
        | [ binding ] -> Ok binding
+       (* One enabled binding is the default by arithmetic: there is nothing
+          else the wizard could install, so requiring the operator to say so
+          rejects a config the server boots from (#27991, live glm-coding).
+          Two or more without a flag stays an error -- that one is a real
+          choice and guessing it would install a model nobody picked. *)
+       | [] when List.length bindings = 1 -> Ok (List.hd bindings)
        | [] ->
            Error
              (Printf.sprintf
-                "provider %s has no install wizard default binding; set wizard-default = true on exactly one [%s.<model>] binding"
-                provider.id provider.id)
+                "provider %s has %d enabled bindings and no install wizard default; set wizard-default = true on exactly one [%s.<model>] binding"
+                provider.id (List.length bindings) provider.id)
        | defaults ->
            Error
              (Printf.sprintf


### PR DESCRIPTION
## 무엇을

`runtime-wizard-catalog` 가 **바인딩이 하나뿐인 provider** 에 `wizard-default = true` 를 요구하던 것을 없앱니다. `#27991` 입니다.

## 왜

서버는 부팅하는데 명령은 실패했습니다. 이슈가 보고한 그대로:

```
$ main_eio.exe runtime-wizard-catalog --base-path /Users/dancer/me
runtime-wizard-catalog failed: provider glm-coding has no install wizard default
binding; set wizard-default = true on exactly one [glm-coding.<model>] binding
```

`[glm-coding.*]` 바인딩은 **정확히 하나**입니다. wizard 가 설치할 다른 후보가 없으므로 그 플래그는 **아무 결정도 담지 않습니다** — 동작하는 설정을 nonzero 종료로 바꾸는 일만 합니다.

## 남기는 것

바인딩이 **2개 이상인데 플래그가 없으면** 그대로 에러입니다. 그건 진짜 선택이고, 추측하면 아무도 고르지 않은 모델을 설치합니다. 메시지에 **경쟁 중인 바인딩 개수**를 넣었습니다(이전 문구엔 없었습니다).

## 라이브 검증 — 이슈의 그 명령으로

```
현행 : failed: provider glm-coding has no install wizard default binding
수정 : failed: provider ollama has 3 enabled bindings and no install wizard
       default; set wizard-default = true on exactly one [ollama.<model>]
```

**실패가 사라진 게 아니라 결정이 필요한 곳으로 옮겨갔습니다.** 그 설정은 여전히 nonzero 로 끝나고, 그게 옳습니다.

라이브 `runtime.toml` 을 세어보면:

| | 개수 |
|---|---|
| 바인딩 1개, 플래그 없음 | 2 (`glm-coding`, `local_llama_server`) |
| 바인딩 2개+, 플래그 없음 | 4 (`antigravity_subscription`, `kimi_coding`, `ollama`, `ollama_cloud`) |
| 플래그 있음 | **0** |

**어떤 provider 도 이 플래그를 설정하지 않았습니다.** 이 수정은 6건 중 2건을 없애고 4건은 운영자 판단으로 남깁니다. 부분적이라는 점을 분명히 해둡니다.

## 테스트가 없는 이유

`runtime_wizard_binding_for_provider` 와 형제 함수들(`runtime_wizard_endpoint`·`_credential_key`·`_provider_record` 등 `bin/main_eio.ml:997-1063`)이 **실행 파일 안에 있습니다.** 어떤 테스트도 이걸 링크하지 않고, 실행 파일을 다루는 스위트들은 프로세스로 spawn 합니다.

`runtime_wizard_*` 를 `lib/runtime/` 으로 추출하면 단위 테스트가 가능해지지만, **그 이동과 동작 변경을 한 PR 에 섞으면 둘 다 가려집니다.** 이슈에 후속으로 적었습니다.

그래서 증거는 위의 라이브 재현입니다 — 이슈가 보고한 정확한 명령을, 같은 설정에서, 수정 전후로 돌린 결과입니다.

RFC-WAIVED: 결정을 담지 않는 요구 제거. 모호한 경우(바인딩 2개+)의 거부는 유지되며 메시지에 개수를 추가함. 새 기본값·새 게이트 없음.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
