### PR TITLE
fix(board): align hearth counts with feed filters

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -772,11 +772,17 @@ describe('fetchBoardHearths', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(fetchBoardHearths()).resolves.toEqual([
+    await expect(fetchBoardHearths({
+      excludeSystem: true,
+      excludeAutomation: true,
+    })).resolves.toEqual([
       { name: 'ops', count: 3 },
       { name: 'research', count: 0 },
     ])
-    expect(fetchMock).toHaveBeenCalledWith('/api/v1/board/hearths', expect.any(Object))
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/board/hearths?exclude_system=true&exclude_automation=true',
+      expect.any(Object),
+    )
   })
 })
 

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1011,9 +1011,16 @@ export async function fetchBoard(
   }))
 }
 
-export async function fetchBoardHearths(): Promise<BoardHearth[]> {
+export async function fetchBoardHearths(options: {
+  excludeSystem?: boolean
+  excludeAutomation?: boolean
+} = {}): Promise<BoardHearth[]> {
   return withRetries('fetchBoardHearths', async () => {
-    const raw = await get<{ hearths?: unknown[] }>('/api/v1/board/hearths')
+    const params = new URLSearchParams()
+    if (options.excludeSystem) params.set('exclude_system', 'true')
+    if (options.excludeAutomation) params.set('exclude_automation', 'true')
+    const qs = params.toString()
+    const raw = await get<{ hearths?: unknown[] }>(`/api/v1/board/hearths${qs ? `?${qs}` : ''}`)
     return Array.isArray(raw.hearths)
       ? raw.hearths.map(normalizeBoardHearth).filter((row): row is BoardHearth => row !== null)
       : []

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -117,7 +117,10 @@ export async function refreshBoardHearths(): Promise<void> {
   const requestId = ++boardHearthsRequestId
   boardHearthsLoading.value = true
   try {
-    const hearths = await fetchBoardHearths()
+    const hearths = await fetchBoardHearths({
+      excludeSystem: boardExcludeSystem.value,
+      excludeAutomation: boardExcludeAutomation.value,
+    })
     if (requestId !== boardHearthsRequestId) return
     boardHearths.value = hearths
     boardHearthsError.value = false

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -691,9 +691,9 @@ let list_comments ?(limit = 1000) () =
   match backend () with
   | Jsonl store -> Board.list_comments store ~limit ()
 
-let list_hearths () =
+let list_hearths ?(exclude_system = false) ?(exclude_automation = false) () =
   match backend () with
-  | Jsonl store -> Board.list_hearths store
+  | Jsonl store -> Board.list_hearths store ~exclude_system ~exclude_automation ()
 
 let set_thread_id ~post_id ~thread_id =
   match backend () with

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -338,7 +338,13 @@ val get_agent_karma : agent_name:string -> int
 
 (** {1 Aggregates} *)
 
-val list_hearths : unit -> (string * int) list
+val list_hearths
+  :  ?exclude_system:bool
+  -> ?exclude_automation:bool
+  -> unit
+  -> (string * int) list
+(** Aggregates hearth counts over the same typed post-kind filter axis used by
+    [list_posts]. Omitted filters preserve the complete Board aggregate. *)
 
 val stats : unit -> Yojson.Safe.t
 (** Board snapshot ([post_count] / [comment_count] / per-author /

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -493,16 +493,20 @@ let load_persisted_sub_boards store =
 
 (** {1 Hearth (topic) operations} *)
 
-(** List active hearths with post counts *)
-let list_hearths store : (string * int) list =
+(** List active hearths with post counts for the requested post-kind axis. *)
+let list_hearths store ?(exclude_system = false) ?(exclude_automation = false) ()
+    : (string * int) list =
   with_lock store (fun () ->
     let counts = Hashtbl.create 16 in
     Hashtbl.iter (fun _ (p : post) ->
-      match p.hearth with
-      | Some h ->
-          let c = Hashtbl.find_opt counts h |> Option.value ~default:0 in
-          Hashtbl.replace counts h (c + 1)
-      | None -> ()
+      if Board_core_classify.post_matches_filters
+           ~exclude_system ~exclude_automation p
+      then
+        match p.hearth with
+        | Some h ->
+            let c = Hashtbl.find_opt counts h |> Option.value ~default:0 in
+            Hashtbl.replace counts h (c + 1)
+        | None -> ()
     ) store.posts;
     Hashtbl.fold (fun k v acc -> (k, v) :: acc) counts []
     |> List.sort (fun (_, a) (_, b) -> compare b a)

--- a/lib/board/board_votes.mli
+++ b/lib/board/board_votes.mli
@@ -136,9 +136,15 @@ val comment_of_yojson : Yojson.Safe.t -> comment option
 
 (** {1 Hearth aggregation} *)
 
-val list_hearths : store -> (string * int) list
+val list_hearths
+  :  store
+  -> ?exclude_system:bool
+  -> ?exclude_automation:bool
+  -> unit
+  -> (string * int) list
 (** Returns [(hearth, post_count)] pairs sorted by count
-    descending.  Posts with no [hearth] are skipped. *)
+    descending. Posts with no [hearth] are skipped. Optional post-kind filters
+    use the same classification contract as Board post listing. *)
 
 (** {1 Mutation helpers} *)
 

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -119,7 +119,15 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
       true
 
   | `GET, "/api/v1/board/hearths" ->
-      let hearths = Board_dispatch.list_hearths () in
+      let exclude_system =
+        bool_query_param httpun_request "exclude_system" ~default:false
+      in
+      let exclude_automation =
+        bool_query_param httpun_request "exclude_automation" ~default:false
+      in
+      let hearths =
+        Board_dispatch.list_hearths ~exclude_system ~exclude_automation ()
+      in
       let json = `Assoc [
         ("hearths", `List (List.map (fun (name, count) ->
           `Assoc [("name", `String name); ("count", `Int count)]

--- a/lib/server/server_h2_gateway_routes_extra.mli
+++ b/lib/server/server_h2_gateway_routes_extra.mli
@@ -30,7 +30,9 @@ val dispatch :
       (clamped to [0..5000]).  Author filter routes through
       {!Server_utils.board_actor_author_for_write} so keeper
       aliases resolve to canonical names.
-    - [GET /api/v1/board/hearths] — hearth name+count list.
+    - [GET /api/v1/board/hearths] — hearth name+count list. Optional
+      [exclude_system] / [exclude_automation] booleans use the same post-kind
+      filter axis as the Board listing.
     - [GET /api/v1/board/flairs] — available flair list.
     - [GET /api/v1/board/curation] — latest AI curation snapshot
       ([{snapshot: null}] when no snapshot has been submitted yet).

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -694,11 +694,17 @@ let add_routes ~sw ~clock router =
          reqd)
 
   |> Http.Router.get "/api/v1/board/hearths" (fun request reqd ->
-       with_public_read (fun state _req reqd ->
+       with_public_read (fun state req reqd ->
          let config = Mcp_server.workspace_config state in
+         let exclude_system = bool_query_param req "exclude_system" ~default:false in
+         let exclude_automation =
+           bool_query_param req "exclude_automation" ~default:false
+         in
          let cache_key =
-           Printf.sprintf "board:hearths:%s"
+           Printf.sprintf "board:hearths:%s:exclude-system=%b:exclude-automation=%b"
              (Keeper_api_types.cache_key_string_segment config.base_path)
+             exclude_system
+             exclude_automation
          in
          let json =
            Dashboard_cache.get_or_compute
@@ -706,7 +712,10 @@ let add_routes ~sw ~clock router =
              ~ttl:Server_dashboard_http_core_cache.standard_cache_ttl_s
              (fun () ->
                 Domain_pool_ref.submit_io_or_inline (fun () ->
-                  let hearths = Board_dispatch.list_hearths () in
+                  let hearths =
+                    Board_dispatch.list_hearths
+                      ~exclude_system ~exclude_automation ()
+                  in
                   `Assoc [
                     ("hearths", `List (List.map (fun (name, count) ->
                       `Assoc [("name", `String name); ("count", `Int count)]

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -1610,8 +1610,23 @@ let test_search () =
 let test_hearths () =
   ignore (Board_dispatch.create_post ~author:"hearth-test" ~content:"fire topic"
     ~hearth:"test-hearth" ~post_kind:Board.Human_post ());
+  ignore (Board_dispatch.create_post ~author:"hearth-system" ~content:"system topic"
+    ~hearth:"system-hearth" ~post_kind:Board.System_post ());
+  ignore (Board_dispatch.create_post ~author:"hearth-automation" ~content:"automation topic"
+    ~hearth:"automation-hearth" ~post_kind:Board.Automation_post ());
   let hearths = Board_dispatch.list_hearths () in
-  Alcotest.(check bool) "has hearths" true (List.length hearths >= 1)
+  let count name rows = List.assoc_opt name rows |> Option.value ~default:0 in
+  Alcotest.(check bool) "has hearths" true (List.length hearths >= 3);
+  Alcotest.(check int) "unfiltered system count" 1 (count "system-hearth" hearths);
+  Alcotest.(check int) "unfiltered automation count" 1 (count "automation-hearth" hearths);
+  let without_system = Board_dispatch.list_hearths ~exclude_system:true () in
+  Alcotest.(check int) "system excluded" 0 (count "system-hearth" without_system);
+  Alcotest.(check int) "automation retained" 1 (count "automation-hearth" without_system);
+  let direct_only =
+    Board_dispatch.list_hearths ~exclude_system:true ~exclude_automation:true ()
+  in
+  Alcotest.(check int) "automation excluded" 0 (count "automation-hearth" direct_only);
+  Alcotest.(check int) "human retained" 1 (count "test-hearth" direct_only)
 
 let test_set_thread_id () =
   match


### PR DESCRIPTION
## What changed

- add typed `exclude_system` and `exclude_automation` options to Board hearth aggregation
- pass the same filters through both HTTP transports
- request hearth counts with the Dashboard Board feed's active filters
- include the filter tuple in the HTTP/1 hearth cache key
- cover the API query and filtered aggregation contracts

## Why

The Board feed excluded system posts while `/api/v1/board/hearths` counted every post. This made values such as `전체 306` appear alongside a larger, incomparable hearth count such as `verification 435`.

Hearth counts now use the same post-kind population as the visible feed. Existing tool and activity callers retain unfiltered behavior because both options default to `false`.

## Validation

- `pnpm vitest run src/api/board.test.ts src/components/board/board-state.test.ts --reporter=dot`: 101 passed
- `dune exec test/test_board_dispatch.exe`: new `misc / hearths` filtered aggregation assertions passed
- the full OCaml executable still reports 4 pre-existing failures in earlier unrelated post/validation cases
