### PR TITLE
fix(runtime): reject lanes whose candidates disagree on checkpoint ownership

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -215,26 +215,95 @@ let media_failover_references (media_failover : string list) =
     media_failover
 ;;
 
+let checkpoint_owner_label = function
+  | Runtime_execution.Masc_agent_core -> "masc_agent_core"
+  | Runtime_execution.Official_client -> "official_client"
+;;
+
+(* A lane's candidates must agree on who owns the resumable execution state.
+   [Keeper_agent_run_finalize_response] derives [checkpoint_owner] from the
+   assignment (the lane id), while the checkpoint in hand comes from whichever
+   candidate actually ran. When those disagree the turn is rejected after the
+   answer was already produced, and the rejection names the assigned runtime
+   rather than the executor — so the operator-facing error describes something
+   that never ran.
+
+   The failure is also permanent rather than intermittent:
+   [Runtime_lane_preference.note_success] fires on the runtime attempt, which
+   succeeded, so the cross-owner candidate becomes the sticky head of the lane
+   and every later turn repeats the rejection.
+
+   Same-owner failover is unaffected: an Agent_core lane may rotate freely
+   across Agent_core candidates, which is what the failover lanes are for.
+
+   Pure so the decision is testable without a materialized runtime catalog;
+   [candidates] is [(candidate_id, owner)] in declared order. *)
+let lane_checkpoint_owner_conflict ~(lane_id : string)
+    (candidates : (string * Runtime_execution.checkpoint_owner) list)
+  : string option
+  =
+  match candidates with
+  | [] | [ _ ] -> None
+  | (head_id, head_owner) :: rest ->
+    (match
+       List.find_opt
+         (fun (_, owner) -> owner <> head_owner)
+         rest
+     with
+     | None -> None
+     | Some (other_id, other_owner) ->
+       Some
+         (Printf.sprintf
+            "[runtime.lanes.%s] mixes checkpoint owners: candidate %S owns %s \
+             but candidate %S owns %s. A turn that fails over across this \
+             boundary is rejected at checkpoint finalization, and the sticky \
+             lane preference makes the rejection permanent. Use candidates \
+             that share one owner."
+            lane_id
+            head_id
+            (checkpoint_owner_label head_owner)
+            other_id
+            (checkpoint_owner_label other_owner)))
+;;
+
 (* [runtime.lanes.<id>] candidate ids must resolve to configured runtimes.
    Empty candidate lists are rejected at parse time; here we reject unknown ids
-   as operator typos (mirrors [runtime].default validation). *)
+   as operator typos (mirrors [runtime].default validation), then reject
+   candidate sets that disagree on checkpoint ownership. *)
 let validate_lanes ~(config_path : string)
     ~(dropped_bindings : (string * string) list) (runtimes : t list)
     (lane_decls : Runtime_schema.lane_decl list)
   : (unit, string) result
   =
-  let runtime_exists id =
-    List.exists (fun (r : t) -> String.equal r.id id) runtimes
+  let runtime_by_id id =
+    List.find_opt (fun (r : t) -> String.equal r.id id) runtimes
   in
   let rec first_unknown = function
     | [] -> None
     | { Runtime_schema.id = lane_id; candidate_ids; _ } :: rest ->
-      (match List.find_opt (fun id -> not (runtime_exists id)) candidate_ids with
+      (match
+         List.find_opt (fun id -> Option.is_none (runtime_by_id id)) candidate_ids
+       with
        | Some id -> Some (lane_id, id)
        | None -> first_unknown rest)
   in
+  let rec first_owner_conflict = function
+    | [] -> None
+    | { Runtime_schema.id = lane_id; candidate_ids; _ } :: rest ->
+      let owners =
+        List.filter_map
+          (fun id ->
+            Option.map
+              (fun (r : t) ->
+                id, Runtime_execution.checkpoint_owner r.execution)
+              (runtime_by_id id))
+          candidate_ids
+      in
+      (match lane_checkpoint_owner_conflict ~lane_id owners with
+       | Some detail -> Some detail
+       | None -> first_owner_conflict rest)
+  in
   match first_unknown lane_decls with
-  | None -> Ok ()
   | Some (lane_id, id) ->
     Error
       (Printf.sprintf
@@ -244,6 +313,10 @@ let validate_lanes ~(config_path : string)
          id
          (unresolved_runtime_suffix ~dropped_bindings
             ~runtime_count:(List.length runtimes) id))
+  | None ->
+    (match first_owner_conflict lane_decls with
+     | None -> Ok ()
+     | Some detail -> Error (Printf.sprintf "%s: %s" config_path detail))
 ;;
 
 let lanes_of_decls ~(config_path : string)
@@ -1778,6 +1851,8 @@ module For_testing = struct
   let restore snapshot = Atomic.set loaded_state_ref snapshot
   (* TEL-OK: test-only alias of the pure reachability projection above. *)
   let keeper_dispatch_runtime_ids = keeper_dispatch_runtime_ids
+  (* TEL-OK: test-only alias of the pure lane-ownership decision above. *)
+  let lane_checkpoint_owner_conflict = lane_checkpoint_owner_conflict
 
   let save_config_text_with_sync_parent
       ?runtime_config_path

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -205,6 +205,15 @@ module For_testing : sig
     (unit, string) result
   (** Production-equivalent runtime config replacement with an injected
       parent-directory sync operation. *)
+
+  val lane_checkpoint_owner_conflict :
+    lane_id:string ->
+    (string * Runtime_execution.checkpoint_owner) list ->
+    string option
+  (** [None] when every candidate of the lane declares the same checkpoint
+      owner. [Some detail] names the first candidate pair that disagrees; the
+      loader turns it into a config error. Candidates are [(id, owner)] in
+      declared order. *)
 end
 
 val get_default_runtime : unit -> t option

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -116,6 +116,12 @@ max-concurrent = 1
 max-request-body-bytes = 65536
 |}
 
+(* Both lane candidates are official-client: [Runtime.validate_lanes] refuses a
+   lane whose candidates disagree on checkpoint ownership, because a turn that
+   fails over across that boundary is rejected at finalization after the answer
+   was produced. The tests below assert only on the codex attempt's manifest
+   rows, so the second candidate's owner was incidental — it is pinned here so
+   the fixture keeps loading and keeps meaning "failover lane". *)
 let runtime_toml_checkpoint_lane =
   {|
 [runtime]
@@ -123,7 +129,7 @@ default = "codex.codex"
 
 [runtime.lanes.checkpoint_lane]
 strategy = "ordered"
-candidates = [ "codex.codex", "primary.test_model" ]
+candidates = [ "codex.codex", "codex.codex_standby" ]
 
 [providers.codex]
 protocol = "codex-app-server"
@@ -134,7 +140,13 @@ is-non-interactive = true
 api-name = "gpt-fixture"
 max-context = 400000
 
+[models.codex_standby]
+api-name = "gpt-fixture-standby"
+max-context = 400000
+
 [codex.codex]
+
+[codex.codex_standby]
 
 [providers.primary]
 display-name = "Primary Provider"

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -857,6 +857,61 @@ let test_model_without_turn_timeout_leaves_it_unset () =
          (model.Runtime_schema.turn_timeout_s = None)
      | _ -> fail "exactly one model must parse")
 
+(* A lane whose candidates disagree on checkpoint ownership cannot execute: the
+   turn is finalized against the assignment's owner while the checkpoint in hand
+   comes from whichever candidate ran, so the answer is produced and then
+   discarded. Measured on a live deployment before this check existed: kidsnote
+   18/18 and taskmaster 16/17 turns executed on an Agent_core candidate under an
+   official-client lane and every one was rejected. Same-owner rotation is the
+   normal case and must keep loading. *)
+let test_lane_checkpoint_owner_conflict_arms () =
+  check
+    (option string)
+    "an empty lane has no conflict"
+    None
+    (Runtime.For_testing.lane_checkpoint_owner_conflict ~lane_id:"l" []);
+  check
+    (option string)
+    "a single candidate has no conflict"
+    None
+    (Runtime.For_testing.lane_checkpoint_owner_conflict
+       ~lane_id:"l"
+       [ "a", Runtime_execution.Official_client ]);
+  check
+    (option string)
+    "candidates that share an owner have no conflict"
+    None
+    (Runtime.For_testing.lane_checkpoint_owner_conflict
+       ~lane_id:"l"
+       (
+          [ "a", Runtime_execution.Masc_agent_core
+          ; "b", Runtime_execution.Masc_agent_core
+          ]));
+  match
+    Runtime.For_testing.lane_checkpoint_owner_conflict
+      ~lane_id:"claude_code.sonnet"
+      (
+         [ "claude_code.sonnet", Runtime_execution.Official_client
+         ; "glm.turbo", Runtime_execution.Masc_agent_core
+         ])
+  with
+  | None -> fail "a lane mixing checkpoint owners must be reported"
+  | Some detail ->
+    let contains needle =
+      let n = String.length needle in
+      let rec scan i =
+        i + n <= String.length detail
+        && (String.sub detail i n = needle || scan (i + 1))
+      in
+      scan 0
+    in
+    (* The operator has to know which two candidates disagree; a bare "lane is
+       invalid" would send them reading the whole candidate list. *)
+    check bool "names the lane" true (contains "claude_code.sonnet");
+    check bool "names the other candidate" true (contains "glm.turbo");
+    check bool "names the official-client owner" true (contains "official_client");
+    check bool "names the agent-core owner" true (contains "masc_agent_core")
+
 let test_exact_output_lane_config_is_ordered_and_rejects_duplicates () =
   let valid =
     "[runtime.exact_output_lanes.compaction_exact]\nslots = [\"slot-b\", \"slot-a\"]\n"
@@ -2772,6 +2827,84 @@ let test_runtime_toml_max_concurrent_flows_to_provider_config () =
 
 (* [runtime].cross_verifier resolves to a configured JSON-capable runtime,
    defaults to None, and rejects unknown or incapable targets. *)
+(* The pure decision above is only worth having if the loader consults it. This
+   drives [Runtime.load_list] end to end so a lane declared across the ownership
+   boundary is refused where the operator writes it, and a same-owner lane over
+   the same runtimes still loads. Without the second half a check that rejects
+   every lane would pass. *)
+let test_load_rejects_a_lane_that_mixes_checkpoint_owners () =
+  with_fake_runtime_model_catalog @@ fun () ->
+  let base =
+    "[providers.local]\n\
+     display-name = \"Local\"\n\
+     protocol = \"ollama-http\"\n\
+     endpoint = \"http://localhost:11434\"\n\
+     \n\
+     [providers.subscription]\n\
+     display-name = \"Claude Code Subscription\"\n\
+     protocol = \"claude-code\"\n\
+     command = \"/usr/bin/true\"\n\
+     is-non-interactive = true\n\
+     \n\
+     [models.chat]\n\
+     api-name = \"chat\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.other]\n\
+     api-name = \"other\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.sonnet]\n\
+     api-name = \"sonnet\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.chat]\n\
+     \n\
+     [local.other]\n\
+     \n\
+     [subscription.sonnet]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.chat\"\n"
+  in
+  with_temp_runtime_toml
+    (base
+     ^ "\n\
+        [runtime.lanes.\"subscription.sonnet\"]\n\
+        strategy = \"ordered\"\n\
+        candidates = [\"subscription.sonnet\", \"local.chat\"]\n")
+    (fun path ->
+      match Runtime.load_list ~config_path:path with
+      | Ok _ ->
+        fail
+          "a lane pairing an official-client candidate with an Agent_core one \
+           must be rejected at load"
+      | Error msg ->
+        let contains needle =
+          let n = String.length needle in
+          let rec scan i =
+            i + n <= String.length msg
+            && (String.sub msg i n = needle || scan (i + 1))
+          in
+          scan 0
+        in
+        check bool "the rejection names the lane" true
+          (contains "subscription.sonnet");
+        check bool "the rejection names checkpoint ownership" true
+          (contains "checkpoint owners"));
+  (* Control: the same runtimes, both Agent_core. This is the ordinary failover
+     lane and it must keep loading, or the check is just refusing lanes. *)
+  with_temp_runtime_toml
+    (base
+     ^ "\n\
+        [runtime.lanes.\"local.chat\"]\n\
+        strategy = \"ordered\"\n\
+        candidates = [\"local.chat\", \"local.other\"]\n")
+    (fun path ->
+      match Runtime.load_list ~config_path:path with
+      | Ok _ -> ()
+      | Error msg -> failf "a same-owner failover lane must load: %s" msg)
+
 let test_cross_verifier_runtime_routing () =
   with_fake_runtime_model_catalog @@ fun () ->
   let base =
@@ -3785,5 +3918,11 @@ let () =
         ; test_case
             "a model without turn-timeout-s leaves it unset"
             `Quick test_model_without_turn_timeout_leaves_it_unset
+        ; test_case
+            "lane checkpoint-owner conflict is reported per candidate pair"
+            `Quick test_lane_checkpoint_owner_conflict_arms
+        ; test_case
+            "load rejects a lane that mixes checkpoint owners"
+            `Quick test_load_rejects_a_lane_that_mixes_checkpoint_owners
         ] )
     ]


### PR DESCRIPTION
## 문제

lane 후보가 checkpoint 소유자를 공유하지 않아도 config 가 로드된다. 그런 lane 에서 turn 이 넘어가면:

1. official-client head 후보가 실패하고 lane 이 Agent_core 후보로 넘어간다
2. 그 후보가 turn 을 완주하고 규약대로 AGENT_CORE checkpoint 를 만든다
3. `Runtime_lane_preference.note_success` 는 **runtime attempt** 성공에 반응하므로 그 후보가 lane 의 sticky head 가 된다
4. `Keeper_agent_run_finalize_response` 는 소유권을 **배정(lane) id** 로 판정해 `Official_client, Some _` 갈래를 타고 그 checkpoint 를 거부한다
5. 이미 생성된 답이 폐기되고 turn 이 실패로 종결된다 — 이후 모든 turn 이 같은 경로를 반복한다

에러 문구는 `official-client runtime returned an AGENT_CORE checkpoint` 인데, 그 official-client runtime 은 **실행되지 않았다.**

## 실측

official-client lane 에 Agent_core 2번 후보를 둔 라이브 배포에서, 키퍼별 runtime manifest 의 `runtime_completed` 행(`runtime_id` = lane, `decision.runtime_id` = 실행 후보)으로 집계:

| keeper | lane | 실행 | 결과 |
|---|---|---|---|
| kidsnote | `claude_code.claude-sonnet-5` | `glm-coding.glm-5-turbo` ×18 | 18/18 폐기 |
| taskmaster | `antigravity_subscription.gemini-3-6-flash-high` | `glm` ×16 / antigravity ×1 | 16/17 폐기 |
| analyst | `claude_code.claude-opus-5-max` | `glm` ×1 | 1 폐기 |

**대조군 (통과해야 하는 것):** 같은 창에서 `rondo` 는 lane `glm-coding.glm-5-turbo` → 실행 `ollama_cloud.deepseek-v4-flash` 로 **111회** 갈아탔고 정상 완주했다. `sangsu` 는 codex lane 314회 전부 lane=실행 일치. 즉 불일치 자체가 아니라 **소유권 경계를 넘는 불일치**만 깨진다.

## 변경

`Runtime.validate_lanes` 는 이미 후보 id 를 materialize 된 runtime 에 대해 해석하므로 소유자가 그 자리에 있다. 순수 결정 `lane_checkpoint_owner_conflict` 를 추가하고 loader 에 배선했다. 거부는 operator 가 lane 을 쓴 자리에서 발생한다.

같은 소유자끼리의 rotation 은 그대로다 — failover lane 의 본래 용도.

## 검증

```
dune build @test/runtest-test_runtime_config_validity        74 tests, OK
dune build @test/runtest-test_keeper_turn_driver_failover    36 tests, OK
dune build @test/runtest-test_exact_output_catalog_precedence 9 tests, OK
```

배선 증명: `validate_lanes` 의 conflict 분기를 `None` 으로 단락시키면 `load rejects a lane that mixes checkpoint owners` 가 red 가 되고, 순수 arm 테스트는 green 을 유지한다 (helper 자체는 건드리지 않았으므로). 즉 end-to-end 테스트가 helper 가 아니라 배선을 검증한다.

## 기존 픽스처

`test_keeper_turn_driver_failover.ml` 의 `checkpoint_lane` 픽스처가 codex 후보와 HTTP 후보를 짝지어 놓았다. 두 테스트(`test_agent_core_checkpoint_...`, `test_text_official_client_history_stays_admissible`)는 codex attempt 의 manifest 행만 단언하고 2번 후보에 대해서는 **아무것도 단언하지 않는다** — 소유권 혼합은 의도가 아니라 우연이었다. 2번 후보를 두 번째 codex binding 으로 고정했고 두 테스트 모두 수정 없이 통과한다.

RFC-WAIVED: 변경 범위가 `lib/runtime/` config 로드 검증에 한정되며 credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 중 어느 것도 건드리지 않는다.

WORKAROUND-WAIVED: 증상 억제가 아니라 표현 불가능한 상태를 config 파스 시점에서 거부하는 변경이다. cap/cooldown/dedup/repair 없음, 문자열 분류기 없음, catch-all 추가 없음, 텔레메트리 추가 없음.

Co-Authored-By: Claude Opus 5 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrQctrmuNds4HVg9sHgicM
