### PR TITLE
P0: official-client 의 AGENT_CORE checkpoint 는 턴 실패가 아니다 — keeper 3기 완주 0% 복구

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -203,18 +203,27 @@ let finalize
            ~keeper_name:meta.name
            ~detail:"missing AGENT_CORE checkpoint after run")
   in
-  let unexpected_agent_core_checkpoint () =
-    Log.Keeper.error ~keeper_name:meta.name
-      "runtime=%s official-client runtime returned an AGENT_CORE checkpoint"
+  (* An official-client runtime does return an AGENT_CORE checkpoint, and the
+     rest of the system already treats that as ordinary. keeper_turn_driver
+     meets the same combination on the way in and logs
+     official_client_checkpoint_not_replayed because the durable session store
+     owns resume (:726, :805, :875); #27945, which added the branch below, says
+     in its own PR body that it "preserved" that contract. On disk, taskmaster
+     and kidsnote each hold 12 agent-core snapshots -- the same count as the
+     agent_core keepers rondo and lane-smith.
+
+     Ending the turn over it stopped three keepers at 0% completion for half an
+     hour (#28050). The payload is dropped here for the same reason the driver
+     drops it on the way in, so this path now matches the [None] case below:
+     the session store, not this checkpoint, is what resumes an official
+     client. *)
+  let official_client_checkpoint_not_persisted () =
+    Log.Keeper.info ~keeper_name:meta.name
+      "runtime=%s official-client runtime returned an AGENT_CORE checkpoint; \
+       the payload is not persisted here because the durable session store owns \
+       resume"
       (Keeper_meta_contract.runtime_id_of_meta meta);
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string CheckpointFailures)
-      ~labels:[ "keeper", meta.name; "site", "owner_mismatch" ]
-      ();
-    Error
-      (checkpoint_persistence_error
-         ~keeper_name:meta.name
-         ~detail:"official-client runtime returned an AGENT_CORE checkpoint")
+    Ok None
   in
   let saved_checkpoint_result =
     match checkpoint_owner_result, result.checkpoint with
@@ -223,7 +232,7 @@ let finalize
       save_agent_core_checkpoint result_checkpoint
     | Ok Runtime_execution.Masc_agent_core, None -> missing_agent_core_checkpoint ()
     | Ok Runtime_execution.Official_client, Some _ ->
-      unexpected_agent_core_checkpoint ()
+      official_client_checkpoint_not_persisted ()
     | Ok Runtime_execution.Official_client, None -> Ok None
   in
   match saved_checkpoint_result with


### PR DESCRIPTION
## 라이브 P0 — keeper 3기가 완주 0%

재기동 이후 16분, receipt 136건 기준. 실패 46건이 **전부 하나**입니다.

| keeper | done | failed | 완주율 |
|---|---|---|---|
| rondo · lane-smith · sangsu · code-reviewer | 90 | 0 | **100%** |
| **taskmaster · kidsnote · analyst** | **0** | 46 | **0%** |

```
keeper_checkpoint_persist_failed: keeper=taskmaster
  detail=official-client runtime returned an AGENT_CORE checkpoint
```

첫 발생 `2026-08-10T15:11:14Z`, 그 이전 0건(08-09·08-10 receipt 전수).

## 게이트가 주장하는 상태는 이 시스템의 정상 상태입니다

| 컴포넌트 | official-client + AGENT_CORE checkpoint 를 |
|---|---|
| `keeper_turn_driver.ml:726,805,875` | **정상** — `official_client_checkpoint_not_replayed`, 세션 스토어가 resume 소유 |
| `keeper_run_context.ml:96` | **필요** — owner 분기 없이 매 턴 로드해 컨텍스트 조립 |
| 라이브 파일시스템 | **존재** — 아래 표 |
| `keeper_agent_run_finalize_response.ml:206` | **불가능** — 턴을 죽임 |

각 keeper 의 마지막 turn-record `trace_id` 로 `~/me/.masc/traces/<trace_id>/agent-core-snapshot-*.json` 을 셌습니다:

| keeper | 종류 | 스냅샷 | 최신 |
|---|---|---|---|
| taskmaster | **official-client** | **12** | 10.7분 전 |
| kidsnote | **official-client** | **12** | 10.3분 전 |
| rondo | agent-core | 12 | 0.6분 전 |
| lane-smith | agent-core | 12 | 0.2분 전 |

**네 keeper 모두 정확히 12개.** 소유자와 무관하게 같은 메커니즘이 돕니다. 차이는 최신 시각뿐이고, 실패 중인 둘은 턴이 죽으면서 쓰기도 멈췄습니다.

## #27945 자신이 이 계약을 보존했다고 말합니다

이 브랜치를 추가한 `#27945` 의 PR 본문:

> The latest `main` Claude Code subscription runtime and **`checkpoint_not_replayed` manifest contract are preserved**

`checkpoint_not_replayed` 는 official-client + AGENT_CORE checkpoint 를 정상으로 처리하는 바로 그 계약입니다. 추가된 브랜치가 그 문장과 모순됩니다.

## 변경

```ocaml
| Ok Runtime_execution.Official_client, Some _ ->
  official_client_checkpoint_not_persisted ()   (* Ok None + info 로그 *)
| Ok Runtime_execution.Official_client, None -> Ok None
```

드라이버가 입력에서 버리는 것과 같은 이유로 출력에서도 버립니다. 하류는 변화 없습니다 — `saved_checkpoint = None` 은 이미 `librarian_messages` 를 `assistant_msg` 로 보냅니다(`:236-240`), 그게 `None` 분기의 기존 동작입니다.

`error` 로그와 `CheckpointFailures{site=owner_mismatch}` 카운터는 제거했습니다. 실패가 아닌 것을 세고 있었습니다.

## 테스트 — 없고, 그게 원인입니다

이 브랜치를 도는 테스트가 **없습니다.** 그래서 세 컴포넌트와 모순되는 게이트가 배포됐습니다.

- `test_warn_root_causes` 는 로그 사이트를 **소스 텍스트**로 단언하는데, 이 문자열은 고정하지 않습니다(확인함, 9/9 통과 유지).
- `test_keeper_antigravity_runtime` 은 **finalize 까지 가지 않습니다.** 갔다면 이 게이트에서 빨개졌을 텐데 fleet 이 멈춘 동안에도 초록이었습니다.

커버링 테스트는 `Keeper_agent_run_finalize_response` 를 official-client owner 로 도달시키는 keeper run 이 필요하고, **오늘 그런 하네스가 없습니다.** 새로 만드는 것은 이 수정보다 큰 작업이라 함께 넣지 않았습니다.

그래서 증거는 위의 라이브 데이터와 4-컴포넌트 대조입니다. 인접 스위트는 통과합니다:

```
test_warn_root_causes             9 tests  Successful
test_keeper_antigravity_runtime            Successful
test_keeper_claude_code_runtime            Successful
```

## 남는 위험

`#27945` 가 이 불변식으로 막으려던 것이 따로 있다면 이 변경이 그것도 풉니다. PR 본문에는 그런 서술이 없고 오히려 반대 계약을 보존했다고 적혀 있습니다. **다만 현재 상태(3기 완주 0%)가 그 미확인 위험보다 확실히 나쁩니다** — 그 판단으로 보냅니다.

Closes #28050

RFC-WAIVED: 세 컴포넌트가 이미 정상으로 처리하는 상태에 대한 거부를 제거. 새 저장 경로·새 기본값 없으며, 하류 동작은 기존 `None` 분기와 동일.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
