### PR TITLE
fix(keeper): antigravity ordinal contract — reset on restart, stop failing on mismatch

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -418,17 +418,16 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             then Ok ()
             else Error (internal_error "Antigravity resumed flag differs from durable plan")
           in
-          let* () =
-            if turn.num_turns = turn_count
-            then Ok ()
-            else
-              Error
-                (internal_error
-                   (Printf.sprintf
-                      "Antigravity reported turn %d; durable session expected %d"
-                      turn.num_turns
-                      turn_count))
-          in
+          (* [turn_count] and [turn.num_turns] count different things and are
+             allowed to disagree. [turn_count] is masc's claim ordinal for this
+             durable binding; [turn.num_turns] is the provider's ordinal inside
+             the CLI conversation, which masc does not own -- it survives removal
+             of the session file and advances on the provider's terms. Turn
+             identity below is built from the provider's own pair
+             (conversation_id, num_turns), so it stays unique without the two
+             counters agreeing. Asserting equality here turned every divergence
+             into a failed turn, and a failed turn does not realign the counters,
+             so the keeper stayed down until the binding was rebuilt by hand. *)
           let turn_id =
             provider_turn_identity
               ~conversation_id:turn.conversation_id

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -1030,19 +1030,26 @@ let resolve_recovery ~base_path ~keeper_name ~expected ~recovery_id ~resolution
     | Some _ | None -> Error Recovery_not_required
   in
   let apply directory (current : t) (recovery : recovery_required) =
-    let completed_turn_count = current.turn_count - 1 in
-    let* phase =
+    let* phase, turn_count =
       match resolution with
       | Retry_previous ->
+        (* The conversation is kept, so only the turn that failed is dropped and
+           the next claim re-attempts the same ordinal. *)
         (match recovery.previous_settlement with
          | None -> Error Retry_previous_unavailable
-         | Some settlement -> Ok (Settled settlement))
-      | Restart_fresh -> Ok Ready
+         | Some settlement -> Ok (Settled settlement, current.turn_count - 1))
+      | Restart_fresh ->
+        (* Restart abandons the conversation, the same discard [reconcile_tool_surface]
+           performs, so the ordinal restarts with it: the next claim carries no
+           previous settlement and asks the provider for a fresh conversation whose
+           own ordinal begins at 1. Carrying [current.turn_count - 1] across the
+           discard left masc counting from a conversation that no longer exists. *)
+        Ok (Ready, 0)
     in
     let resolved =
       { current with
         phase
-      ; turn_count = completed_turn_count
+      ; turn_count
       ; last_recovery_resolution =
           Some
             { recovery_id

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -677,6 +677,126 @@ let test_retry_previous_restores_exact_settlement () =
       fail "restored settlement did not drive the next resume claim")
 ;;
 
+(* The sibling restart test starts at turn_count = 1, where the old
+   [current.turn_count - 1] and a true reset are the same number. This one
+   reaches turn_count = 2 first, so the two differ, and it asserts the ordinal
+   the next claim actually hands the provider: a restart discards the
+   conversation, so that claim must ask for ordinal 1, matching the fresh
+   conversation the provider will open. *)
+let test_restart_fresh_resets_ordinal_after_second_turn () =
+  with_workspace "masc-official-client-store-restart-ordinal-" (fun base_path ->
+    let keeper_name = "restart-ordinal" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    let settled =
+      mark_active
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~session_id:"session-1"
+        ~updated_at:2.0
+      |> Result.get_ok
+      |> fun active ->
+      mark_turn_starting
+        ~base_path
+        ~keeper_name
+        ~expected:active
+        ~session_id:"session-1"
+        ~updated_at:3.0
+      |> Result.get_ok
+      |> fun starting ->
+      mark_turn_started
+        ~base_path
+        ~keeper_name
+        ~expected:starting
+        ~session_id:"session-1"
+        ~turn_id:"turn-1"
+        ~updated_at:4.0
+      |> Result.get_ok
+      |> fun inflight ->
+      settle
+        ~base_path
+        ~keeper_name
+        ~expected:inflight
+        ~session_id:"session-1"
+        ~turn_id:"turn-1"
+        ~updated_at:5.0
+      |> Result.get_ok
+    in
+    let second_claim =
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some settled)
+        ~client_kind:Codex
+        ~owner_epoch
+        ~runtime_id:"codex.default"
+        ~tool_surface_sha256:empty_surface
+        ~updated_at:6.0
+      |> Result.get_ok
+    in
+    check int "second claim is ordinal two" 2 second_claim.turn_count;
+    let recovery =
+      require_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:second_claim
+        ~failure:Protocol_failed
+        ~detail:"second turn ended ambiguously"
+        ~required_at:7.0
+      |> Result.get_ok
+    in
+    let recovery_id =
+      match recovery.phase with
+      | Recovery_required required -> required.recovery_id
+      | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+        fail "second turn did not enter recovery"
+    in
+    let restarted, application =
+      resolve_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:recovery
+        ~recovery_id
+        ~resolution:Restart_fresh
+        ~resolved_by:"operator"
+        ~resolved_at:8.0
+      |> Result.get_ok
+    in
+    check bool "restart applied" true (application = Applied);
+    check int "restart resets the ordinal" 0 restarted.turn_count;
+    (match restarted.phase with
+     | Ready -> ()
+     | Settled _ | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+       fail "fresh restart did not return the binding to Ready");
+    let next_claim =
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some restarted)
+        ~client_kind:Codex
+        ~owner_epoch
+        ~runtime_id:"codex.default"
+        ~tool_surface_sha256:empty_surface
+        ~updated_at:9.0
+      |> Result.get_ok
+    in
+    check int "claim after restart asks for ordinal one" 1 next_claim.turn_count;
+    match next_claim.phase with
+    | Start { previous_settlement = None; _ } -> ()
+    | Start { previous_settlement = Some _; _ } ->
+      fail "restart carried a settlement into the next claim"
+    | Ready | Active _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+      fail "claim after restart did not open a turn")
+;;
+
 let write_file path content =
   let output = open_out_bin path in
   Fun.protect
@@ -773,6 +893,10 @@ let () =
             "retry previous restores exact settlement"
             `Quick
             test_retry_previous_restores_exact_settlement
+        ; test_case
+            "restart fresh resets ordinal after second turn"
+            `Quick
+            test_restart_fresh_resets_ordinal_after_second_turn
         ; test_case "ambiguous JSON rejected" `Quick test_ambiguous_json_is_rejected
         ; test_case
             "tool surface fingerprint canonical"


### PR DESCRIPTION
## 무엇이 고장났는가

`taskmaster`가 매 턴 다음으로 실패했다:

```
Internal error: Antigravity reported turn 82; durable session expected 2
```

`keeper_antigravity_runtime.ml`은 턴이 끝날 때마다 provider가 보고한 `num_turns`가 masc의 durable `turn_count`와 **정확히 같은지** 단언하고, 다르면 그 턴을 실패시켰다. 두 카운터는 서로 다른 것을 센다.

| | 소유자 | 수명 |
|---|---|---|
| `turn_count` | masc | durable binding. session 파일과 함께 산다 |
| `num_turns` | provider (`agy` CLI) | conversation. masc가 통제하지 않으며 session 파일 삭제를 살아남는다 |

### 실패가 스스로를 악화시킨다

불일치는 턴의 잘못이 아닌데, 턴을 실패시키면 상황이 나빠진다:

1. 실패 → `Protocol_failed` → binding이 `Recovery_required`로 간다
2. `plan_claim`은 `Recovery_required`를 받아들이고 **같은 ordinal로** 재claim한다 (증가 없음)
3. 같은 conversation을 resume하므로 **provider의 카운터만 1 오른다**
4. 간극이 매 시도마다 1씩 벌어진다 — 닫힐 수 없다

시도당 provider 턴 1개를 태우면서 영구히 실패한다. `82 vs 2`는 약 80회 재시도의 결과다.

## 두 개의 수정

### 1. `Restart_fresh`가 ordinal을 리셋하지 않았다 (`bf13332cae`)

`Restart_fresh`는 previous settlement을 버리므로 다음 claim은 provider에게 **새 conversation**을 요구한다. 그런데 `turn_count - 1`을 유지해서, masc는 방금 버린 conversation에서 계속 세고 provider의 ordinal은 1에서 다시 시작했다.

`reconcile_tool_surface`는 동일한 폐기를 수행하면서 이미 ordinal을 1로 리셋한다. 이 수정은 recovery 경로를 그것과 일치시킨다.

`Restart_fresh`는 `previous_settlement = None`이면서 `turn_count > 1`인 상태를 만드는 **유일한 생산자**였다. 다른 모든 reset 분기(identity switch, tool-surface move, 파일 없음)는 이미 1을 반환한다.

### 2. 정확 일치 검사 제거 (`71b999b97e`)

masc의 장부와 provider의 장부가 일치할 것을 요구하는 단언을 제거했다. 이 검사는 불일치를 **조정하지 않았고**, 실패로 변환하기만 했다.

## 제거되는 제약이 무엇을 지키고 있었나

제약 제거 PR이므로 등가 통제를 명시한다.

| 위험 | 이 검사가 막았나 | 무엇이 지금 막나 |
|---|---|---|
| provider가 다른 conversation에서 답함 | 아니오 | `verify_identity` — provider가 알린 `conversation_id`를 masc가 resume 요청한 것과 대조. init 이벤트에서(상태 저장 **전**), 그리고 모든 step_update에서 재확인. `runtime_antigravity.ml:527-534, 545-549, 575` |
| turn identity 충돌 | 아니오 | `provider_turn_identity`는 provider 자신의 `(conversation_id, num_turns)` 쌍으로 만들어진다. 두 카운터가 일치하지 않아도 유일하다 |
| 무한 재시도 / 이중 과금 | 아니오 — **오히려 유발했다** | 검사는 `run_client ()` 반환 **후**에 실행된다. CLI 프로세스는 이미 종료했고 MCP tool 호출도 이미 실행된 뒤다. 모든 side effect와 토큰이 이미 소비된 시점 |

**실제로 잃는 것**: durable ordinal이 provider가 보고하는 어떤 값과도 대조되지 않는다. 다만 이전에도 유용하게 대조된 적은 없다 — 검사는 divergence를 해소하지 않고 실패로 바꾸기만 했다.

`keeper_codex_runtime.ml`에는 대응하는 단언이 애초에 없다. 이 검사는 antigravity에만 있던 비대칭 제약이었다.

## 검증

### 대조군 (버그 있는 코드에서 실패해야 함)

기존 restart 테스트는 `turn_count = 1`에서 시작한다. 거기서는 `turn_count - 1`과 진짜 리셋이 **둘 다 0**이라 결함이 보이지 않는다. 스위트 전체가 결함을 통과시키고 있었다.

새 테스트는 먼저 `turn_count = 2`에 도달한 뒤, **다음 claim이 provider에게 건네는 ordinal**을 단언한다.

수정을 되돌리고 실행:

```
CONTROL_EXIT=1
[FAIL]  durable owner  8  restart fresh resets ordinal after...
FAIL restart resets the ordinal
```

나머지 10개는 전부 통과 — 이 결함이 스위트 전체에 보이지 않았다는 증거.

### 수정 적용 후

```
test_official_client_session_store   11 tests  Test Successful
test_keeper_antigravity_runtime       1 test   Test Successful
test_runtime_antigravity             14 tests  Test Successful
dune build --root . @check            EXIT=0
scripts/audit-ci-test-targets.sh      170 CI targets / 689 unwired, at baseline
```

`@check` 통과가 곧 edit 2의 폐포 증명이다: root `dune`이 `-w +32 -warn-error +a`를 걸어서 미사용 binding이 **빌드 에러**이므로, `turn_count`가 여전히 7곳에서 쓰인다는 뜻이다.

### CI 배선

세 스위트 모두 이미 `scripts/ci-run-focused-tests.sh:81,84,87`에 있고 `.github/workflows/ci.yml`에는 없다. **매니페스트 변경이 없으므로 머지 순서 의존이 없다** (#28022 재발 방지).

## 폐포 스윕

| 축 | 결과 |
|---|---|
| 삭제된 에러 문자열 (`reported turn`, `durable session expected`) | 트리 전체 0건 (삭제 대상 라인 제외) |
| `.mli` 문서 | `keeper_antigravity_runtime.mli`는 19줄, ordinal 계약 서술 없음 |
| `docs/`, `docs/rfc/` | antigravity 언급 0건 |
| drift-guard 스크립트 | 이 코드 형태를 grep하는 스크립트 없음 |
| `turn_count = 0` 상태 | 신규 상태 아님. validator(`store:305-318`)와 dashboard decoder(`dashboard-runtime.ts:1481-1488`)가 이미 `(0, Ready)`를 허용하고, `release_transient`가 이미 생산한다 |

## 하지 않은 것

- **`validate`를 `Ready ⟹ turn_count = 0`으로 강화하지 않았다.** 라이브 durable 파일에 오늘 코드가 만든 `Ready`-at-N>0가 이미 들어 있고 `of_yojson`이 매 load마다 `validate`를 돌리므로, 강화하면 fail-closed로 이 PR이 풀려는 바로 그 keeper들을 좌초시킨다.
- **`turn.resumed` 검사는 건드리지 않았다.** 검증 중 이 검사가 **항등식**임을 발견했다 — `turn.resumed`는 provider 필드가 아니라 masc가 넘긴 `conversation_mode`에서 재계산되고(`runtime_antigravity.ml:724-727`), `is_resume`와 같은 `claim_plan.previous_settlement`에서 12줄 간격으로 파생된다(`keeper_antigravity_runtime.ml:169-175`). `Bool.equal is_resume turn.resumed`는 false가 될 수 없다. 이 PR 범위 밖이라 #28057 로 기록했다.

RFC-WAIVED: 변경 범위가 `~/me/instructions/workflow-pr.md` §11의 RFC 필수 subsystem(credential/identity/auth, operator control plane, keeper sandbox, dashboard credential, hooks, workflow 문서) 중 어디에도 해당하지 않는다. 변경 파일은 `lib/keeper/keeper_official_client_session_store.ml`, `lib/keeper/keeper_antigravity_runtime.ml`, `test/test_official_client_session_store.ml`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
