### PR TITLE
fix(antigravity): fit a fresh session's history to the CLI prompt budget

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -14,6 +14,14 @@ let internal_error detail = Agent_core.Error.Internal detail
 let runtime_error_to_core_error = function
   | Runtime_antigravity.Invalid_config detail ->
     config_error ~field:"antigravity_cli" detail
+  | Runtime_antigravity.Prompt_too_large { bytes; limit } ->
+    (* The prompt is assembled here, so a prompt this runtime cannot spawn is
+       this layer's own construction error, not the provider's. *)
+    internal_error
+      (Printf.sprintf
+         "Antigravity prompt was %d bytes against a %d byte command-line budget"
+         bytes
+         limit)
   | Runtime_antigravity.Turn_failed detail ->
     Agent_core.Error.Provider
       (Llm_provider.Error.ProviderReportedError
@@ -46,6 +54,10 @@ let recovery_failure_of_runtime_error = function
   | Runtime_antigravity.Invalid_config _
   | Runtime_antigravity.Protocol_error _ ->
     Session_store.Protocol_failed
+  | Runtime_antigravity.Prompt_too_large _ ->
+    (* Retrying the same claim rebuilds the same oversized prompt, so this is a
+       persistence-class stop for an operator, not a transient release. *)
+    Session_store.State_persistence_failed
   | Runtime_antigravity.State_callback_failed _ ->
     Session_store.State_persistence_failed
   | Runtime_antigravity.Turn_failed _ -> Session_store.Provider_rejected
@@ -66,29 +78,85 @@ let render_message (message : Agent_core.Types.message) =
   | Agent_core.Types.Tool -> Ok ("TOOL:\n" ^ text)
 ;;
 
-let render_messages messages =
-  let rec loop rendered = function
-    | [] -> Ok (String.concat "\n\n" (List.rev rendered))
-    | message :: rest ->
-      let* rendered_message = render_message message in
-      loop (rendered_message :: rendered) rest
+type prompt_projection =
+  { prompt : string
+  ; history_kept_messages : int
+  ; history_dropped_messages : int
+  }
+
+let section_separator = "\n\n"
+
+(* A resumed turn sends only the goal because the CLI still holds the
+   conversation. A fresh one has to re-seed it, and that seed is the whole
+   rendered history -- which the CLI takes as one command-line argument. Past
+   the kernel's cap the spawn fails outright, so a Keeper whose history had
+   grown could not start a fresh session at all (#28051, live 2026-08-10).
+
+   The system prompt and the current goal are what the turn is; they are never
+   dropped, and if they alone do not fit the turn is refused rather than
+   silently reshaped. History is the part that can be partial, so it is fitted
+   newest-first into whatever budget remains and the caller is told how many
+   messages did not fit. *)
+let fit_history_to_budget ~budget messages =
+  let rec loop kept kept_bytes = function
+    | [] -> kept, kept_bytes, 0
+    | message :: older ->
+      (match render_message message with
+       | Error _ -> kept, kept_bytes, List.length (message :: older)
+       | Ok rendered ->
+         let separator = if kept = [] then 0 else String.length section_separator in
+         let next_bytes = kept_bytes + separator + String.length rendered in
+         if next_bytes > budget
+         then kept, kept_bytes, List.length (message :: older)
+         else loop (rendered :: kept) next_bytes older)
   in
-  loop [] messages
+  let kept, _, dropped = loop [] 0 (List.rev messages) in
+  String.concat section_separator kept, List.length kept, dropped
 ;;
 
 let prompt_for_turn ~is_resume ~goal (prepared : Host.prepared_turn) =
   if is_resume
-  then Ok goal
+  then
+    Ok { prompt = goal; history_kept_messages = 0; history_dropped_messages = 0 }
   else
-    let* history = render_messages prepared.messages in
-    Ok
-      ([ String_util.trim_to_option prepared.system_prompt
-         |> Option.map (fun value -> "SYSTEM INSTRUCTIONS:\n" ^ value)
-       ; String_util.trim_to_option history
-       ; Some ("CURRENT GOAL:\n" ^ goal)
-       ]
-       |> List.filter_map Fun.id
-       |> String.concat "\n\n")
+    let framed_system =
+      String_util.trim_to_option prepared.system_prompt
+      |> Option.map (fun value -> "SYSTEM INSTRUCTIONS:\n" ^ value)
+    in
+    let framed_goal = "CURRENT GOAL:\n" ^ goal in
+    let required =
+      [ framed_system; Some framed_goal ]
+      |> List.filter_map Fun.id
+      |> String.concat section_separator
+    in
+    let required_bytes = String.length required in
+    if required_bytes >= Runtime_antigravity.max_prompt_bytes
+    then
+      Error
+        (internal_error
+           (Printf.sprintf
+              "Antigravity fresh-session prompt needs %d bytes for the system \
+               prompt and goal alone; the CLI accepts at most %d"
+              required_bytes
+              Runtime_antigravity.max_prompt_bytes))
+    else
+      let budget =
+        Runtime_antigravity.max_prompt_bytes
+        - required_bytes
+        - String.length section_separator
+      in
+      let history, history_kept_messages, history_dropped_messages =
+        fit_history_to_budget ~budget prepared.messages
+      in
+      let prompt =
+        [ framed_system
+        ; String_util.trim_to_option history
+        ; Some framed_goal
+        ]
+        |> List.filter_map Fun.id
+        |> String.concat section_separator
+      in
+      Ok { prompt; history_kept_messages; history_dropped_messages }
 ;;
 
 let tool_spec (tool : Host.dynamic_tool) =
@@ -206,7 +274,19 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       | None -> Ok goal
       | Some blocks -> Host.text_of_blocks ~runtime_label ~field:"goal_blocks" blocks
     in
-    let* prompt = prompt_for_turn ~is_resume ~goal prepared in
+    let* projected_prompt = prompt_for_turn ~is_resume ~goal prepared in
+    let prompt = projected_prompt.prompt in
+    if projected_prompt.history_dropped_messages > 0
+    then
+      Log.Keeper.warn
+        ~keeper_name
+        "Antigravity fresh session seeded with %d of %d history message(s); %d \
+         did not fit the CLI's command-line prompt budget of %d bytes"
+        projected_prompt.history_kept_messages
+        (projected_prompt.history_kept_messages
+         + projected_prompt.history_dropped_messages)
+        projected_prompt.history_dropped_messages
+        Runtime_antigravity.max_prompt_bytes;
     let terminal_error = ref None in
     let* dynamic_tools =
       Host.dynamic_tools
@@ -621,3 +701,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       ~raw_trace
       ~config)
 ;;
+
+module For_testing = struct
+  let fit_history_to_budget = fit_history_to_budget
+end

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -17,3 +17,12 @@ val run :
   raw_trace:Agent_core.Raw_trace.t option ->
   config:Runtime_execution.antigravity_cli ->
   (Runtime_agent.run_result, Agent_core.Error.t) result
+
+module For_testing : sig
+  val fit_history_to_budget :
+    budget:int -> Agent_core.Types.message list -> string * int * int
+  (** Fit rendered history newest-first into [budget] bytes, returning the
+      rendered text, how many messages were kept, and how many were left out.
+      Exposed because the CLI prompt budget is a kernel limit rather than a
+      provider one, so the fitting rule is worth pinning directly. *)
+end

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -31,6 +31,21 @@ let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 8192
 let max_wire_line_bytes = 8 * 1024 * 1024
 
+(* The CLI takes the prompt as a command-line argument (`--print <prompt>`; it
+   has no stdin or file form), so an oversized prompt fails the spawn itself
+   with an opaque Unix error instead of anything a caller can act on. Live
+   2026-08-10: every fresh-session turn for one Keeper died on
+   Failure("execve: Argument list too long"), because a fresh prompt carries
+   the rendered history while a resumed one carries only the goal (#28051).
+
+   The binding constraint is per-argument, not total: Linux caps one argument
+   at MAX_ARG_STRLEN = 32 pages = 131072 bytes regardless of how large ARG_MAX
+   is, and macOS counts the prompt against a 1 MiB ARG_MAX shared with the
+   environment. The bound below stays under the smaller of the two so the same
+   prompt is accepted or refused identically on both, and it is checked here
+   rather than assumed by callers. *)
+let max_prompt_bytes = 120 * 1024
+
 let default_config ~cwd ~model =
   { cli_path = "agy"
   ; cwd
@@ -82,6 +97,10 @@ type turn_result =
 
 type error =
   | Invalid_config of string
+  | Prompt_too_large of
+      { bytes : int
+      ; limit : int
+      }
   | Spawn_failed of string
   | Protocol_error of
       { stage : string
@@ -96,6 +115,12 @@ exception Runtime_error of error
 
 let error_to_string = function
   | Invalid_config detail -> "invalid Antigravity CLI config: " ^ detail
+  | Prompt_too_large { bytes; limit } ->
+    Printf.sprintf
+      "Antigravity prompt is %d bytes; the CLI takes it as one command-line \
+       argument, which the kernel caps at %d bytes"
+      bytes
+      limit
   | Spawn_failed detail -> "failed to start Antigravity CLI: " ^ detail
   | Protocol_error { stage; detail } ->
     Printf.sprintf "Antigravity stream-json protocol error during %s: %s" stage detail
@@ -380,6 +405,10 @@ let validate_config config ~conversation_mode ~prompt =
   then Error (Invalid_config "timeout_s must be positive and finite")
   else if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
+  else if String.length prompt > max_prompt_bytes
+  then
+    Error
+      (Prompt_too_large { bytes = String.length prompt; limit = max_prompt_bytes })
   else
     match config.agent, conversation_mode with
     | Some agent, _ when String.trim agent = "" ->

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -27,6 +27,13 @@ type config =
 
 val default_config : cwd:string -> model:string -> config
 
+val max_prompt_bytes : int
+(** Largest prompt this runtime can spawn. The CLI has no stdin or file form
+    for the prompt, so it travels as one command-line argument and is bounded
+    by the kernel rather than by the provider. Callers that assemble a prompt
+    from unbounded material must fit it to this budget and account for what
+    they left out; [validate_turn] refuses anything larger. *)
+
 type conversation_mode =
   | Start
   | Resume of { conversation_id : string }
@@ -62,6 +69,14 @@ type turn_result =
 
 type error =
   | Invalid_config of string
+  | Prompt_too_large of
+      { bytes : int
+      ; limit : int
+      }
+      (** The CLI takes the prompt as one command-line argument, so a prompt
+          past the kernel's per-argument cap cannot be spawned at all. Refused
+          here so the caller sees the size instead of an opaque
+          [execve: Argument list too long] from the spawn. *)
   | Spawn_failed of string
   | Protocol_error of
       { stage : string

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -288,6 +288,50 @@ let test_keeper_projects_mcp_tool_and_settles () =
       check bool "turn capability cleared" false (Sys.file_exists mcp_path))
 ;;
 
+let user_message text =
+  { Agent_core.Types.role = Agent_core.Types.User
+  ; content = [ Agent_core.Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+(* Live 2026-08-10 (#28051): a fresh Antigravity session re-seeds the CLI with
+   the rendered history, and the CLI takes the prompt as one command-line
+   argument, so an unbounded history made the spawn fail outright. History is
+   now fitted newest-first and the shortfall is counted rather than silently
+   cut. *)
+let test_history_is_fitted_newest_first_with_a_count () =
+  let messages =
+    [ user_message (String.make 400 'o')
+    ; user_message (String.make 400 'm')
+    ; user_message (String.make 400 'n')
+    ]
+  in
+  let rendered, kept, dropped =
+    Keeper_antigravity_runtime.For_testing.fit_history_to_budget ~budget:900 messages
+  in
+  check int "kept" 2 kept;
+  check int "dropped" 1 dropped;
+  check bool "newest message survives" true (String_util.contains_substring rendered "n");
+  check
+    bool
+    "oldest message is the one left out"
+    false
+    (String_util.contains_substring rendered (String.make 400 'o'));
+  check bool "kept text fits the budget" true (String.length rendered <= 900);
+  (* Control: a budget that fits everything drops nothing, so this cannot pass
+     by always dropping. *)
+  let _, kept_all, dropped_none =
+    Keeper_antigravity_runtime.For_testing.fit_history_to_budget
+      ~budget:100_000
+      messages
+  in
+  check int "all kept when the budget allows" 3 kept_all;
+  check int "none dropped when the budget allows" 0 dropped_none
+;;
+
 let () =
   run
     "keeper_antigravity_runtime"
@@ -296,6 +340,10 @@ let () =
             "projects MCP tool and settles"
             `Quick
             test_keeper_projects_mcp_tool_and_settles
+        ; test_case
+            "history fitted newest-first with a count"
+            `Quick
+            test_history_is_fitted_newest_first_with_a_count
         ] )
     ]
 ;;

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -365,6 +365,28 @@ let test_admission_is_process_free () =
   | Ok () -> fail "invalid deterministic config passed admission"
 ;;
 
+(* Live 2026-08-10 (#28051): a fresh session carries the rendered history in the
+   prompt, and the CLI takes the prompt as one command-line argument, so an
+   oversized one killed the spawn with Failure("execve: Argument list too
+   long") -- a Unix string no caller could act on. Admission now names the two
+   numbers that decide it. *)
+let test_oversized_prompt_is_refused_before_spawn () =
+  let config = Runtime_antigravity.default_config ~cwd:"/tmp" ~model:"gemini-fixture" in
+  let oversized = String.make (Runtime_antigravity.max_prompt_bytes + 1) 'x' in
+  (match Runtime_antigravity.validate_turn config ~prompt:oversized with
+   | Error (Runtime_antigravity.Prompt_too_large { bytes; limit }) ->
+     check int "reported prompt size" (Runtime_antigravity.max_prompt_bytes + 1) bytes;
+     check int "reported limit" Runtime_antigravity.max_prompt_bytes limit
+   | Error error -> fail (Runtime_antigravity.error_to_string error)
+   | Ok () -> fail "an unspawnable prompt passed admission");
+  (* Control: the bound admits what fits, so this cannot pass by refusing
+     everything. *)
+  let largest_admissible = String.make Runtime_antigravity.max_prompt_bytes 'x' in
+  match Runtime_antigravity.validate_turn config ~prompt:largest_admissible with
+  | Ok () -> ()
+  | Error error -> fail (Runtime_antigravity.error_to_string error)
+;;
+
 let test_live_start_and_resume () =
   match Sys.getenv_opt "MASC_ANTIGRAVITY_LIVE", Sys.getenv_opt "MASC_ANTIGRAVITY_MODEL" with
   | Some "1", Some model ->
@@ -463,6 +485,10 @@ let () =
             test_unknown_protocol_vocabulary_fails_closed
         ; test_case "typed timeout" `Quick test_timeout_is_typed
         ; test_case "process-free admission" `Quick test_admission_is_process_free
+        ; test_case
+            "oversized prompt refused before spawn"
+            `Quick
+            test_oversized_prompt_is_refused_before_spawn
         ] )
     ; "live official client", [ test_case "official agy start and resume" `Slow test_live_start_and_resume ]
     ]


### PR DESCRIPTION
#28051 을 닫습니다. 라이브 taskmaster 가 **CLI 를 띄우지도 못하던** 상태의 근본 수정입니다.

## 무엇이 문제였나

`agy` 는 프롬프트를 **커맨드라인 인자 하나**로 받습니다 (`--print <prompt>`; stdin·파일 형태 없음 — 실측 확인). 그래서 프롬프트 크기는 provider 가 아니라 **커널**이 정합니다.

재개 턴은 goal 만 보내지만(작음), **fresh 턴은 CLI 를 새 대화로 다시 씨앗 넣기 위해 렌더된 history 전문을 프롬프트에 접습니다**. history 는 줄어들 이유가 없으므로, 한 번 상한을 넘으면 그 keeper 는 **매 턴 spawn 단계에서 죽고 스스로 회복하지 못합니다**:

```
Provider 'antigravity_cli' unavailable: Failure("execve: Argument list too long")
```

라이브 2026-08-10: 10분에 16건, fresh 를 강제한 시점부터 시작. 그리고 이건 **곧 상시 경로가 됩니다** — #28045 가 모든 자동 recovery 를 fresh 로 돌립니다.

## 수정

**turn 이 무엇인가(system prompt + current goal)는 절대 버리지 않습니다.** 그 둘만으로 예산을 넘으면 두 숫자를 담아 거부합니다 — 조용히 모양을 바꾸지 않습니다.

**history 는 부분이어도 되는 부분**이므로 남은 예산에 **newest-first 로 맞춰 넣고, 못 들어간 개수를 셉니다**:

```
Antigravity fresh session seeded with 12 of 47 history message(s); 35 did not fit
the CLI's command-line prompt budget of 122880 bytes
```

런타임 계층은 초과 프롬프트를 **typed `Prompt_too_large { bytes; limit }`** 로 거부합니다 — spawn 에서 Unix 문자열로 새는 대신 크기와 상한을 스스로 말합니다. recovery class 는 `State_persistence_failed`: 같은 claim 을 재시도하면 같은 프롬프트를 다시 만들므로 transient 해제 대상이 아니라 운영자 stop 입니다.

## 상한 근거 (매직 넘버 아님)

120 KiB. **Linux 는 ARG_MAX 와 무관하게 인자 하나를 MAX_ARG_STRLEN = 128 KiB 로 자릅니다**; macOS 는 환경과 공유하는 1 MiB ARG_MAX 에 프롬프트를 함께 셉니다. 둘 중 작은 쪽 아래에 두어 **같은 프롬프트가 두 플랫폼에서 동일하게 수용/거부**되게 했습니다.

## 검증

- `test_runtime_antigravity.exe` 16/16 — 신규 `oversized prompt refused before spawn` 은 typed 거부의 두 숫자를 단언하고, **대조군**으로 상한 정확히까지는 통과함을 확인 (전부 거부해서 통과할 수 없음)
- `test_keeper_antigravity_runtime.exe` 2/2 — 신규 `history fitted newest-first with a count` 는 kept/dropped 수, 최신 메시지 생존, 최고령 메시지 탈락, 예산 준수를 단언하고, **대조군**으로 넉넉한 예산에서는 0건 드랍
- **뮤테이션 검증**: `fit_history_to_budget` 의 예산 비교를 무력화(수정 이전 동작 재현)하면 새 테스트가 정확히 실패(`FAIL kept`), 복원하면 통과 — 이 테스트가 실제로 이 결함을 잡습니다
- `bin/main_eio.exe` 빌드 green

## 남는 것

fresh 재시작이 **전체 history 재주입을 요구하는지** 자체는 이 PR 이 답하지 않습니다 — 지금은 "요구한다"를 전제로 예산에 맞춰 넣고 손실을 셉니다. 그 전제를 바꾸는 건 official-client 계약 설계라 별도 논의가 맞다고 봅니다.

Closes #28051

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
