### PR TITLE
fix(antigravity): bound the start-turn prompt to what a single argv entry admits

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -37,6 +37,13 @@ let runtime_error_to_core_error = function
       (Llm_provider.Error.ParseError
          { detail = Printf.sprintf "%s: %s" stage detail })
   | Runtime_antigravity.State_callback_failed detail -> internal_error detail
+  (* Not a provider fault and not retryable: the prompt never reached the CLI.
+     With the start-turn history windowed to the argv budget this only fires
+     when the system prompt and goal alone overflow, which is an operator-side
+     condition, so it surfaces as an invalid input on the prompt field rather
+     than as provider capacity (which implies a retry_after). *)
+  | Runtime_antigravity.Prompt_too_large _ as error ->
+    config_error ~field:"prompt" (Runtime_antigravity.error_to_string error)
 ;;
 
 let recovery_failure_of_runtime_error = function
@@ -49,6 +56,13 @@ let recovery_failure_of_runtime_error = function
   | Runtime_antigravity.State_callback_failed _ ->
     Session_store.State_persistence_failed
   | Runtime_antigravity.Turn_failed _ -> Session_store.Provider_rejected
+  (* The rejection happens before spawn, so the vendor never admitted this turn
+     and the claim can be released without recovery — which is what
+     [Transient_spawn_failed] means on the store's axis. It says nothing about
+     whether a retry of the same input would succeed; that is the lane
+     classifier's question, and [runtime_error_to_core_error] answers it with a
+     non-retryable config error. *)
+  | Runtime_antigravity.Prompt_too_large _ -> Session_store.Transient_spawn_failed
 ;;
 
 let home_error_to_core_error error =
@@ -66,9 +80,9 @@ let render_message (message : Agent_core.Types.message) =
   | Agent_core.Types.Tool -> Ok ("TOOL:\n" ^ text)
 ;;
 
-let render_messages messages =
+let render_message_list messages =
   let rec loop rendered = function
-    | [] -> Ok (String.concat "\n\n" (List.rev rendered))
+    | [] -> Ok (List.rev rendered)
     | message :: rest ->
       let* rendered_message = render_message message in
       loop (rendered_message :: rendered) rest
@@ -76,19 +90,65 @@ let render_messages messages =
   loop [] messages
 ;;
 
-let prompt_for_turn ~is_resume ~goal (prepared : Host.prepared_turn) =
+let history_separator = "\n\n"
+
+(* "SYSTEM INSTRUCTIONS:\n", "CURRENT GOAL:\n", and the two blank-line joins
+   between the three sections. Charged against the argv budget so the history
+   window does not have to be told about the frame it sits in. *)
+let fixed_prompt_label_bytes =
+  String.length "SYSTEM INSTRUCTIONS:\n"
+  + String.length "CURRENT GOAL:\n"
+  + (2 * String.length history_separator)
+;;
+
+type history_window =
+  { history : string
+  ; admitted : int
+  ; dropped : int
+  }
+
+(* The start-turn prompt seeds a fresh vendor conversation; from turn two on the
+   CLI owns the transcript and [prompt_for_turn] sends only the goal. That seed
+   travels as one argv entry, so it is bounded by the exec boundary rather than
+   by the model's context window, and an unbounded seed does not fail once: it
+   re-renders and re-fails on every later turn while the history only grows.
+
+   Keep the most recent messages, since a truncated tail would drop the turn the
+   goal responds to. [admitted]/[dropped] are returned rather than logged here so
+   the caller can put the loss on the keeper's own log line — a silent window
+   would read as "the model saw everything". *)
+let window_history_to_budget ~budget messages =
+  let rec take acc used admitted = function
+    | [] -> { history = String.concat history_separator acc; admitted; dropped = 0 }
+    | (rendered : string) :: older ->
+      let separator = if admitted = 0 then 0 else String.length history_separator in
+      let next = used + separator + String.length rendered in
+      if next > budget
+      then
+        { history = String.concat history_separator acc
+        ; admitted
+        ; dropped = List.length older + 1
+        }
+      else take (rendered :: acc) next (admitted + 1) older
+  in
+  take [] 0 0 (List.rev messages)
+;;
+
+let prompt_for_turn ~is_resume ~goal ~history_budget_bytes (prepared : Host.prepared_turn) =
   if is_resume
-  then Ok goal
+  then Ok (goal, None)
   else
-    let* history = render_messages prepared.messages in
+    let* rendered = render_message_list prepared.messages in
+    let window = window_history_to_budget ~budget:history_budget_bytes rendered in
     Ok
-      ([ String_util.trim_to_option prepared.system_prompt
-         |> Option.map (fun value -> "SYSTEM INSTRUCTIONS:\n" ^ value)
-       ; String_util.trim_to_option history
-       ; Some ("CURRENT GOAL:\n" ^ goal)
-       ]
-       |> List.filter_map Fun.id
-       |> String.concat "\n\n")
+      ( [ String_util.trim_to_option prepared.system_prompt
+          |> Option.map (fun value -> "SYSTEM INSTRUCTIONS:\n" ^ value)
+        ; String_util.trim_to_option window.history
+        ; Some ("CURRENT GOAL:\n" ^ goal)
+        ]
+        |> List.filter_map Fun.id
+        |> String.concat "\n\n"
+      , if window.dropped = 0 then None else Some window )
 ;;
 
 let tool_spec (tool : Host.dynamic_tool) =
@@ -206,7 +266,31 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       | None -> Ok goal
       | Some blocks -> Host.text_of_blocks ~runtime_label ~field:"goal_blocks" blocks
     in
-    let* prompt = prompt_for_turn ~is_resume ~goal prepared in
+    (* What is left for history after the fixed parts of the prompt. Negative or
+       tiny budgets are not special-cased here: the window then admits nothing,
+       and [Runtime_antigravity.validate_turn] still rejects with
+       [Prompt_too_large] if the system prompt and goal alone overflow, which is
+       the honest answer — there is nothing to shorten from this side. *)
+    let history_budget_bytes =
+      Runtime_antigravity.max_prompt_argv_bytes
+      - String.length prepared.system_prompt
+      - String.length goal
+      - fixed_prompt_label_bytes
+    in
+    let* prompt, windowed = prompt_for_turn ~is_resume ~goal ~history_budget_bytes prepared in
+    Option.iter
+      (fun window ->
+        Log.Keeper.warn
+          "%s: official-client runtime %s seeded its start turn with the most \
+           recent %d of %d history message(s); %d dropped to fit the %d-byte \
+           argv budget"
+          keeper_name
+          runtime_id
+          window.admitted
+          (window.admitted + window.dropped)
+          window.dropped
+          Runtime_antigravity.max_prompt_argv_bytes)
+      windowed;
     let terminal_error = ref None in
     let* dynamic_tools =
       Host.dynamic_tools
@@ -621,3 +705,15 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       ~raw_trace
       ~config)
 ;;
+
+module For_testing = struct
+  type nonrec history_window = history_window =
+    { history : string
+    ; admitted : int
+    ; dropped : int
+    }
+
+  (* TEL-OK: pure aliases of the windowing decision above; no effect. *)
+  let window_history_to_budget = window_history_to_budget
+  let fixed_prompt_label_bytes = fixed_prompt_label_bytes
+end

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -17,3 +17,21 @@ val run :
   raw_trace:Agent_core.Raw_trace.t option ->
   config:Runtime_execution.antigravity_cli ->
   (Runtime_agent.run_result, Agent_core.Error.t) result
+
+module For_testing : sig
+  type history_window =
+    { history : string
+    ; admitted : int
+    ; dropped : int
+    }
+
+  val window_history_to_budget : budget:int -> string list -> history_window
+  (** Keeps the most recent rendered messages that fit [budget] bytes including
+      the separators between them, and reports how many older ones were left
+      out. The start-turn prompt travels as one argv entry, so this bound is the
+      exec boundary rather than the model's context window. *)
+
+  val fixed_prompt_label_bytes : int
+  (** Bytes the prompt frame costs before any content, charged against the argv
+      budget by the caller. *)
+end

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -91,6 +91,11 @@ type error =
   | Turn_failed of string
   | Process_exited of string
   | Timeout of float
+  | Prompt_too_large of
+      { bytes : int
+      ; limit : int
+      ; detail : string
+      }
 
 exception Runtime_error of error
 
@@ -103,6 +108,12 @@ let error_to_string = function
   | Turn_failed detail -> "Antigravity turn failed: " ^ detail
   | Process_exited detail -> "Antigravity CLI exited before completion: " ^ detail
   | Timeout seconds -> Printf.sprintf "Antigravity turn timed out after %.3fs" seconds
+  | Prompt_too_large { bytes; limit; detail } ->
+    Printf.sprintf
+      "Antigravity prompt is %d bytes; the exec boundary admits %d (%s)"
+      bytes
+      limit
+      detail
 ;;
 
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
@@ -369,6 +380,31 @@ let execution_mode_to_string = function
   | Accept_edits -> "accept-edits"
 ;;
 
+(* The Antigravity CLI takes the whole prompt as one argv entry (`--print
+   <prompt>`); `agy --help` documents no stdin prompt mode, and piping a prompt
+   with `--print` unset makes the CLI read the following flag as the prompt
+   instead. So the prompt is bounded by the exec boundary, not by the wire.
+
+   Linux caps a *single* argv entry at MAX_ARG_STRLEN = 32 pages = 131072 bytes
+   regardless of the larger ARG_MAX total; macOS has no per-entry cap but bounds
+   argv + envp together at ARG_MAX (1048576 on darwin 25). The per-entry Linux
+   cap is the smaller of the two, so it is the portable bound. The margin below
+   covers the fixed flags, the cwd path, and the environment, none of which the
+   prompt controls.
+
+   A keeper whose prompt exceeds this does not fail once: on a start turn the
+   prompt carries the rendered history, so it re-renders and re-fails on every
+   later turn while the history only grows. Measured on a live deployment: a
+   keeper with 3255 canonical messages rendered 1064246 bytes and every turn
+   died with Failure("execve: Argument list too long") — an untyped exception
+   from Unix, escaping as "Provider 'antigravity_cli' unavailable". *)
+let max_prompt_argv_bytes = 131072 - 8192
+
+let prompt_argv_overflow ~prompt =
+  let bytes = String.length prompt in
+  if bytes <= max_prompt_argv_bytes then None else Some (bytes, max_prompt_argv_bytes)
+;;
+
 let validate_config config ~conversation_mode ~prompt =
   if String.trim config.cli_path = ""
   then Error (Invalid_config "cli_path must not be empty")
@@ -381,6 +417,12 @@ let validate_config config ~conversation_mode ~prompt =
   else if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
   else
+    match prompt_argv_overflow ~prompt with
+    | Some (bytes, limit) ->
+      Error
+        (Prompt_too_large
+           { bytes; limit; detail = "antigravity CLI takes the prompt as one argv entry" })
+    | None ->
     match config.agent, conversation_mode with
     | Some agent, _ when String.trim agent = "" ->
       Error (Invalid_config "agent must not be empty when present")

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -71,8 +71,23 @@ type error =
   | Turn_failed of string
   | Process_exited of string
   | Timeout of float
+  | Prompt_too_large of
+      { bytes : int
+      ; limit : int
+      ; detail : string
+      }
+      (** The rendered prompt exceeds what a single argv entry admits. The CLI
+          has no stdin prompt mode, so the caller must shorten the prompt rather
+          than retry it. *)
 
 val error_to_string : error -> string
+
+val max_prompt_argv_bytes : int
+(** Largest prompt, in bytes, that {!run_turn} will pass to the CLI. Bounded by
+    Linux MAX_ARG_STRLEN (32 pages) less a margin for the fixed flags, the cwd
+    path, and the environment. Callers that render history into the prompt
+    should window it to this budget; {!validate_turn} rejects anything larger
+    with {!Prompt_too_large} instead of letting [execve] raise. *)
 
 val validate_turn :
   ?conversation_mode:conversation_mode ->

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -288,6 +288,46 @@ let test_keeper_projects_mcp_tool_and_settles () =
       check bool "turn capability cleared" false (Sys.file_exists mcp_path))
 ;;
 
+(* A start turn seeds a fresh vendor conversation with the rendered history in
+   one argv entry, so the seed is bounded by the exec boundary. The window keeps
+   the newest messages: the goal answers the most recent turn, so trimming from
+   the tail would drop exactly the context the goal refers to. *)
+let test_history_window_keeps_the_newest_messages_within_budget () =
+  let module W = Keeper_antigravity_runtime.For_testing in
+  let messages = [ "oldest"; "middle"; "newest" ] in
+  (* Every message fits: nothing is dropped and the order is preserved. *)
+  let full = W.window_history_to_budget ~budget:1000 messages in
+  check int "admits every message" 3 full.admitted;
+  check int "drops nothing" 0 full.dropped;
+  check string "keeps declared order" "oldest\n\nmiddle\n\nnewest" full.history;
+  (* "middle\n\nnewest" is 14 bytes; "oldest" plus a separator would need 22. *)
+  let windowed = W.window_history_to_budget ~budget:14 messages in
+  check int "admits what fits" 2 windowed.admitted;
+  check int "reports what it left out" 1 windowed.dropped;
+  check string "keeps the newest, in order" "middle\n\nnewest" windowed.history;
+  (* A budget under the newest message alone admits nothing rather than
+     emitting a half message: the caller then hits the typed argv rejection,
+     which names the boundary, instead of sending a truncated turn. *)
+  let none = W.window_history_to_budget ~budget:3 messages in
+  check int "admits nothing" 0 none.admitted;
+  check int "reports the whole history as dropped" 3 none.dropped;
+  check string "produces no history" "" none.history
+;;
+
+let test_history_window_budget_accounts_for_the_prompt_frame () =
+  let module W = Keeper_antigravity_runtime.For_testing in
+  (* The caller subtracts this from the argv budget, so it has to be the real
+     cost of the frame rather than a guess. *)
+  check
+    int
+    "frame cost is the two labels plus the two section joins"
+    (String.length "SYSTEM INSTRUCTIONS:\n"
+     + String.length "CURRENT GOAL:\n"
+     + String.length "\n\n"
+     + String.length "\n\n")
+    W.fixed_prompt_label_bytes
+;;
+
 let () =
   run
     "keeper_antigravity_runtime"
@@ -296,6 +336,16 @@ let () =
             "projects MCP tool and settles"
             `Quick
             test_keeper_projects_mcp_tool_and_settles
+        ] )
+    ; ( "start-turn history window"
+      , [ test_case
+            "keeps the newest messages within the argv budget"
+            `Quick
+            test_history_window_keeps_the_newest_messages_within_budget
+        ; test_case
+            "the budget accounts for the prompt frame"
+            `Quick
+            test_history_window_budget_accounts_for_the_prompt_frame
         ] )
     ]
 ;;

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -365,6 +365,35 @@ let test_admission_is_process_free () =
   | Ok () -> fail "invalid deterministic config passed admission"
 ;;
 
+(* The CLI takes the prompt as one argv entry and documents no stdin mode, so a
+   prompt larger than a single argv entry admits is rejected here rather than
+   surfacing as Failure("execve: Argument list too long") from Unix. Measured on
+   a live deployment before this bound existed: a keeper rendered 1064246 bytes
+   of history into the start turn and every turn died with that untyped
+   exception, reported to the operator as "Provider 'antigravity_cli'
+   unavailable". *)
+let test_prompt_over_the_argv_budget_is_rejected_before_spawn () =
+  let config =
+    Runtime_antigravity.default_config ~cwd:"/tmp" ~model:"gemini-fixture"
+  in
+  let at_limit = String.make Runtime_antigravity.max_prompt_argv_bytes 'x' in
+  (match Runtime_antigravity.validate_turn config ~prompt:at_limit with
+   | Ok () -> ()
+   | Error error ->
+     failf "a prompt exactly at the budget must be admitted: %s"
+       (Runtime_antigravity.error_to_string error));
+  let over = at_limit ^ "x" in
+  match Runtime_antigravity.validate_turn config ~prompt:over with
+  | Ok () -> fail "a prompt over the argv budget must be rejected"
+  | Error (Runtime_antigravity.Prompt_too_large { bytes; limit; _ }) ->
+    (* The operator has to see both numbers to know how much to shed. *)
+    check int "reports the measured prompt size" (String.length over) bytes;
+    check int "reports the budget" Runtime_antigravity.max_prompt_argv_bytes limit
+  | Error error ->
+    failf "the rejection must be typed as Prompt_too_large: %s"
+      (Runtime_antigravity.error_to_string error)
+;;
+
 let test_live_start_and_resume () =
   match Sys.getenv_opt "MASC_ANTIGRAVITY_LIVE", Sys.getenv_opt "MASC_ANTIGRAVITY_MODEL" with
   | Some "1", Some model ->
@@ -463,6 +492,10 @@ let () =
             test_unknown_protocol_vocabulary_fails_closed
         ; test_case "typed timeout" `Quick test_timeout_is_typed
         ; test_case "process-free admission" `Quick test_admission_is_process_free
+        ; test_case
+            "a prompt over the argv budget is rejected before spawn"
+            `Quick
+            test_prompt_over_the_argv_budget_is_rejected_before_spawn
         ] )
     ; "live official client", [ test_case "official agy start and resume" `Slow test_live_start_and_resume ]
     ]


### PR DESCRIPTION
## 문제

Antigravity CLI 는 프롬프트 전체를 **argv 한 항목**으로 받는다 (`--print <prompt>`).

- `agy --help` 에 stdin 프롬프트 모드가 없다.
- `--print` 를 값 없이 두고 프롬프트를 파이프하면 CLI 가 **다음 플래그를 프롬프트로 읽는다** (실측: `printf '...' | agy --print --output-format text --model ...` → 모델이 `--output-format` 플래그를 설명하는 답을 반환).

즉 경계는 argv 뿐이다.

start 턴은 투영된 히스토리 전체를 그 프롬프트에 렌더한다. 키퍼 히스토리가 argv 한 항목을 넘으면 턴이 **한 번 실패하고 마는 게 아니다** — start 턴마다 프롬프트를 다시 렌더하고 히스토리는 계속 자라므로 그 런타임은 그 키퍼에게 영구히 사용 불가가 된다.

실패는 `Failure("execve: Argument list too long")` — Unix 에서 올라온 **비타입 예외**로, 운영자에게는 `Provider 'antigravity_cli' unavailable` 로 보인다. 프롬프트도, 크기도 이름에 없다.

## 실측

라이브 배포의 `taskmaster`:

| 항목 | 값 |
|---|---|
| canonical 메시지 | 3,255 |
| 렌더 바이트 | 1,064,246 |
| darwin `ARG_MAX` | 1,048,576 |
| 초과 | 15,670 (1.5%) |
| 연속 실패 턴 | 36 |

세션이 `turn_count=0 / phase=ready` 로 초기화돼 있어 **모든 턴이 start 턴**이고, 따라서 매번 같은 자리에서 죽는다.

## 변경

각 지식이 있는 자리에 하나씩.

**`Runtime_antigravity`** — exec 경계를 소유하므로 예산을 선언한다. `max_prompt_argv_bytes` 는 Linux `MAX_ARG_STRLEN`(32 페이지 = 131,072 바이트, 두 플랫폼 제한 중 작은 쪽) 에서 고정 플래그·cwd·환경 몫을 뺀 값이다. macOS 는 항목별 제한이 없고 argv+envp 합계를 `ARG_MAX` 로 묶으므로 Linux 쪽이 이식 가능한 경계다. `validate_turn` 이 초과 프롬프트를 `Prompt_too_large { bytes; limit; detail }` 로 거부한다 — 측정값과 예산이 둘 다 실려야 운영자가 얼마를 덜어낼지 안다.

**`Keeper_antigravity_runtime`** — 프롬프트를 소유하므로 히스토리를 남은 예산에 맞춰 윈도잉한다. **최신 메시지를 남긴다**: goal 은 가장 최근 턴에 답하는 것이므로 tail 을 자르면 goal 이 가리키는 문맥을 정확히 버리게 된다. 드롭은 키퍼 자신의 로그 줄에 admitted/total 로 남긴다 — 조용한 윈도우는 "모델이 전부 봤다" 로 읽힌다.

윈도우가 들어간 뒤 `Prompt_too_large` 는 **system prompt + goal 만으로 초과할 때**만 발화한다. 그건 운영자측 조건이므로 provider capacity(= `retry_after` 함의) 가 아니라 prompt 필드의 재시도 불가 config 에러로 매핑한다. 세션 스토어 축에서는 `Transient_spawn_failed` — 거부가 spawn 앞에서 일어나므로 벤더는 이 턴을 admit 한 적이 없고 claim 은 recovery 없이 해제되면 된다.

## 검증

```
dune build @check                                          OK
dune build @test/runtest-test_runtime_antigravity          16 tests, OK
dune build @test/runtest-test_keeper_antigravity_runtime    3 tests, OK
scripts/ci/check-telemetry-coverage.sh                     TEL gate PASS
scripts/audit-ci-test-targets.sh                           170 targets OK
```

새 테스트:

- `a prompt over the argv budget is rejected before spawn` — 예산 **정확히** 에서는 통과하고 +1 바이트에서 `Prompt_too_large` 로 거부되며, 보고된 `bytes`/`limit` 가 실제 값과 일치하는지 확인. 경계 양쪽을 다 잡으므로 "무조건 거부" 로는 통과할 수 없다.
- `keeps the newest messages within the argv budget` — 전부 들어가는 경우(드롭 0, 순서 유지), 일부만 들어가는 경우(최신 2개 유지, 드롭 1 보고), 최신 하나도 안 들어가는 경우(0개 admit, 잘린 반쪽 메시지 대신 아무것도 안 보냄 → 타입 있는 argv 거부로 넘어감).
- `the budget accounts for the prompt frame` — 호출자가 argv 예산에서 빼는 프레임 비용이 실제 라벨+구분자 길이와 같은지.

두 스위트 모두 `scripts/ci-run-focused-tests.sh` 를 통해 이미 CI 에서 실행된다 (81, 87 행).

## 남는 것

이 PR 은 exec 경계만 다룬다. 히스토리가 런타임 선언 컨텍스트 창(`max-context = 128000` 토큰)의 두 배 넘게 자란 것 자체는 별개 문제이며, 이 바운드는 그 상류 결함을 대체하지 않는다.

RFC-WAIVED: 변경 범위가 antigravity official-client 어댑터의 프롬프트 구성과 exec 경계 검증에 한정된다. credential / identity / repo_manager / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 어느 것도 건드리지 않는다.

WORKAROUND-WAIVED: 증상 억제가 아니라 **없던 바운드를 추가**하는 변경이다. 하드 물리 제약(`execve` 가 받는 단일 argv 항목 크기)에 입력을 맞추는 것이며, cap/cooldown/dedup/repair 로 재시도를 눌러 감추는 종류가 아니다. 드롭은 카운터가 아니라 키퍼 로그 줄로 노출되고, 바운드로도 못 맞추면 타입 있는 에러로 fail-closed 한다.

Co-Authored-By: Claude Opus 5 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrQctrmuNds4HVg9sHgicM
