### PR TITLE
test(runtime): align fresh-start fixtures

### DIFF
--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -188,6 +188,7 @@ let seed_ambiguous_resumed_session ~base_path ~tool =
       ~expected:starting
       ~session_id:"conversation-stale"
       ~turn_id:"conversation-stale:ordinal:1"
+      ~turn_count:1
       ~updated_at:4.0
     |> Result.get_ok
   in

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -189,6 +189,7 @@ let test_resume_requires_exact_identity_and_argv () =
 
 let test_resume_identity_mismatch_fails_closed () =
   with_fixture
+    ~require_resume:true
     [ init ~conversation_id:"different" (); result ~conversation_id:"different" () ]
     (fun path ->
        match

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -1182,7 +1182,8 @@ let test_keeper_protocol_failure_enters_recovery () =
               "failed provider session is not resumed"
               None
               (Option.map
-                 (fun settlement -> settlement.session_id)
+                 (fun (settlement : Keeper_official_client_session_store.settlement) ->
+                    settlement.session_id)
                  next_claim.previous_settlement)))
 ;;
 


### PR DESCRIPTION
## Summary

- align the Antigravity stale-session seed with the durable provider turn count
- make the resume-mismatch fixture exercise the Resume argv contract after `--new-project` became Start-only
- annotate the settlement type at the fresh-recovery assertion so the record field remains unambiguous

This is the focused test forward-fix for merged #28045. It adds no compatibility path or runtime behavior.

## Verification

- `ocamlformat --check test/test_keeper_antigravity_runtime.ml test/test_runtime_antigravity.ml test/test_runtime_codex_app_server.ml`
- `scripts/dune-local.sh build @test/runtest-test_runtime_antigravity @test/runtest-test_official_client_session_store @test/runtest-test_keeper_antigravity_runtime @test/runtest-test_runtime_codex_app_server`
  - 60 focused tests passed
  - 8 credential-gated live tests skipped by design
