### PR TITLE
fix(runtime): stream Antigravity prompts over stdin

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -14,10 +14,6 @@ let internal_error detail = Agent_core.Error.Internal detail
 let runtime_error_to_core_error = function
   | Runtime_antigravity.Invalid_config detail ->
     config_error ~field:"antigravity_cli" detail
-  | Runtime_antigravity.Prompt_too_large { bytes; limit } ->
-    config_error
-      ~field:"antigravity_cli.prompt"
-      (Printf.sprintf "prompt bytes=%d exceed argv limit=%d" bytes limit)
   | Runtime_antigravity.Turn_failed detail ->
     Agent_core.Error.Provider
       (Llm_provider.Error.ProviderReportedError
@@ -48,7 +44,6 @@ let recovery_failure_of_runtime_error = function
   | Runtime_antigravity.Process_exited _ | Runtime_antigravity.Timeout _ ->
     Session_store.Transport_interrupted
   | Runtime_antigravity.Invalid_config _
-  | Runtime_antigravity.Prompt_too_large _
   | Runtime_antigravity.Protocol_error _ ->
     Session_store.Protocol_failed
   | Runtime_antigravity.State_callback_failed _ ->
@@ -65,70 +60,35 @@ let home_error_to_core_error error =
 let render_message (message : Agent_core.Types.message) =
   let text = Host.encode_history_message message in
   match message.role with
-  | Agent_core.Types.System -> "SYSTEM:\n" ^ text
-  | Agent_core.Types.User -> "USER:\n" ^ text
-  | Agent_core.Types.Assistant -> "ASSISTANT:\n" ^ text
-  | Agent_core.Types.Tool -> "TOOL:\n" ^ text
+  | Agent_core.Types.System -> Ok ("SYSTEM:\n" ^ text)
+  | Agent_core.Types.User -> Ok ("USER:\n" ^ text)
+  | Agent_core.Types.Assistant -> Ok ("ASSISTANT:\n" ^ text)
+  | Agent_core.Types.Tool -> Ok ("TOOL:\n" ^ text)
 ;;
-
-let section_separator = "\n\n"
 
 let render_messages messages =
-  messages
-  |> List.map render_message
-  |> String.concat section_separator
+  let rec loop rendered = function
+    | [] -> Ok (String.concat "\n\n" (List.rev rendered))
+    | message :: rest ->
+      let* rendered_message = render_message message in
+      loop (rendered_message :: rendered) rest
+  in
+  loop [] messages
 ;;
-
-type prompt_projection =
-  { prompt : string
-  ; kept_messages : int
-  ; dropped_atoms : int
-  }
 
 let prompt_for_turn ~is_resume ~goal (prepared : Host.prepared_turn) =
   if is_resume
-  then Ok { prompt = goal; kept_messages = 0; dropped_atoms = 0 }
+  then Ok goal
   else
-    let system =
-      String_util.trim_to_option prepared.system_prompt
-      |> Option.map (fun value -> "SYSTEM INSTRUCTIONS:\n" ^ value)
-    in
-    let current_goal = "CURRENT GOAL:\n" ^ goal in
-    let reserved_bytes =
-      Option.fold ~none:0 ~some:String.length system
-      + String.length current_goal
-      + (2 * String.length section_separator)
-    in
-    let measure_message_bytes message =
-      render_message message
-      |> String.length
-      |> ( + ) (String.length section_separator)
-    in
-    let* projection =
-      Runtime_model_input_tail_window.project_with_drop
-        ~measure_message_bytes
-        ~capacity_bytes:Runtime_antigravity.max_prompt_bytes
-        ~reserved_bytes
-        prepared.messages
-      |> Result.map_error (fun error ->
-        config_error
-          ~field:"antigravity_cli.prompt"
-          (Runtime_model_input_tail_window.budget_error_to_string error))
-    in
-    let history = render_messages projection.messages in
-    let prompt =
-      [ system
+    let* history = render_messages prepared.messages in
+    Ok
+      ([ String_util.trim_to_option prepared.system_prompt
+         |> Option.map (fun value -> "SYSTEM INSTRUCTIONS:\n" ^ value)
       ; String_util.trim_to_option history
-      ; Some current_goal
+      ; Some ("CURRENT GOAL:\n" ^ goal)
       ]
       |> List.filter_map Fun.id
-      |> String.concat section_separator
-    in
-    Ok
-      { prompt
-      ; kept_messages = List.length projection.messages
-      ; dropped_atoms = projection.dropped_atoms
-      }
+      |> String.concat "\n\n")
 ;;
 
 let tool_spec (tool : Host.dynamic_tool) =
@@ -246,17 +206,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       | None -> Ok goal
       | Some blocks -> Host.text_of_blocks ~runtime_label ~field:"goal_blocks" blocks
     in
-    let* prompt_projection = prompt_for_turn ~is_resume ~goal prepared in
-    let prompt = prompt_projection.prompt in
-    if prompt_projection.dropped_atoms > 0
-    then
-      Log.Keeper.warn
-        ~keeper_name
-        "Antigravity fresh prompt kept %d history message(s) after dropping %d \
-         complete atom(s) to fit the %d-byte argv boundary"
-        prompt_projection.kept_messages
-        prompt_projection.dropped_atoms
-        Runtime_antigravity.max_prompt_bytes;
+    let* prompt = prompt_for_turn ~is_resume ~goal prepared in
     let terminal_error = ref None in
     let* dynamic_tools =
       Host.dynamic_tools

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -31,12 +31,6 @@ let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 8192
 let max_wire_line_bytes = 8 * 1024 * 1024
 
-(* [agy --print] accepts the prompt only as one argv member. Linux caps one
-   member below ARG_MAX and macOS charges it against the whole argv+environment
-   block, so a provider request-body budget cannot protect this spawn boundary.
-   Keep one cross-platform limit below both kernels and reject before execve. *)
-let max_prompt_bytes = 120 * 1024
-
 let default_config ~cwd ~model =
   { cli_path = "agy"
   ; cwd
@@ -88,10 +82,6 @@ type turn_result =
 
 type error =
   | Invalid_config of string
-  | Prompt_too_large of
-      { bytes : int
-      ; limit : int
-      }
   | Spawn_failed of string
   | Protocol_error of
       { stage : string
@@ -106,11 +96,6 @@ exception Runtime_error of error
 
 let error_to_string = function
   | Invalid_config detail -> "invalid Antigravity CLI config: " ^ detail
-  | Prompt_too_large { bytes; limit } ->
-    Printf.sprintf
-      "Antigravity prompt is %d bytes; the CLI argv boundary admits at most %d"
-      bytes
-      limit
   | Spawn_failed detail -> "failed to start Antigravity CLI: " ^ detail
   | Protocol_error { stage; detail } ->
     Printf.sprintf "Antigravity stream-json protocol error during %s: %s" stage detail
@@ -395,10 +380,6 @@ let validate_config config ~conversation_mode ~prompt =
   then Error (Invalid_config "timeout_s must be positive and finite")
   else if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
-  else if String.length prompt > max_prompt_bytes
-  then
-    Error
-      (Prompt_too_large { bytes = String.length prompt; limit = max_prompt_bytes })
   else
     match config.agent, conversation_mode with
     | Some agent, _ when String.trim agent = "" ->
@@ -466,11 +447,9 @@ let duration_argument seconds = Printf.sprintf "%.3fs" seconds
 
 let cli_timeout_s timeout_s = max 0.001 (timeout_s *. 0.95)
 
-let argv config ~conversation_mode ~prompt =
+let argv config ~conversation_mode =
   let base =
     [ config.cli_path
-    ; "--print"
-    ; prompt
     ; "--output-format"
     ; "stream-json"
     ; "--model"
@@ -660,12 +639,15 @@ let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
         ~stdin:stdin_r
         ~stdout:stdout_w
         ~stderr:stderr_w
-        (argv config ~conversation_mode ~prompt)
+        (argv config ~conversation_mode)
     in
     Eio.Flow.close stdin_r;
-    Eio.Flow.close stdin_w;
     Eio.Flow.close stdout_w;
     Eio.Flow.close stderr_w;
+    Eio.Fiber.fork ~sw (fun () ->
+      Fun.protect
+        ~finally:(fun () -> Eio.Flow.close stdin_w)
+        (fun () -> Eio.Flow.copy_string prompt stdin_w));
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
     let process_settled = ref false in

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -27,11 +27,6 @@ type config =
 
 val default_config : cwd:string -> model:string -> config
 
-val max_prompt_bytes : int
-(** Largest prompt accepted by the spawn boundary. [agy] exposes no stdin or
-    prompt-file form, so the prompt is one argv member and must fit the kernel
-    limit before [execve]. *)
-
 type conversation_mode =
   | Start
   | Resume of { conversation_id : string }
@@ -70,10 +65,6 @@ type turn_result =
 
 type error =
   | Invalid_config of string
-  | Prompt_too_large of
-      { bytes : int
-      ; limit : int
-      }
   | Spawn_failed of string
   | Protocol_error of
       { stage : string

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -62,7 +62,7 @@ test "$mode" = plan
 test "$sandbox" -eq 1
 test "$slash_commands_disabled" -eq 1
 if [ "$turns" -eq 1 ]; then test "$new_project" -eq 1; else test "$new_project" -eq 0; fi
-printf '%%s' "$2" > %s
+cat > %s
 printf '{"event":"init","conversation_id":"%%s","init":{"model":"gemini-fixture","cwd":%s,"tools":["call_mcp_tool"],"permission_mode":"always-proceed"}}\n' "$conversation"
 python3 - <<'PY'
 import json
@@ -365,12 +365,8 @@ let test_keeper_projects_mcp_tool_and_settles () =
         | None -> fail "initial Antigravity prompt was not captured"
       in
       check bool
-        "fresh prompt fits argv boundary"
+        "fresh prompt preserves oldest atom"
         true
-        (String.length prompt <= Runtime_antigravity.max_prompt_bytes);
-      check bool
-        "fresh prompt drops complete old atoms"
-        false
         (String_util.contains_substring prompt "history-00");
       check bool
         "fresh prompt keeps newest atom"

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -67,6 +67,7 @@ let fixture_script
   output_string output "#!/bin/sh\n";
   output_string output
     "test -z \"${GEMINI_API_KEY+x}\" && test -z \"${GEMINI_API_KEY_WORK+x}\" && test -z \"${GOOGLE_API_TOKEN+x}\" && test -z \"${OPENAI_API_KEY+x}\" && test -z \"${OPENAI_API_KEY_MAIN+x}\" && test -z \"${ANTHROPIC_API_KEY+x}\" && test -z \"${ANTHROPIC_API_KEY_WORK+x}\" && test -z \"${AGY_ADC_AUTH+x}\" && test -z \"${MASC_PUBLIC_FIXTURE+x}\" || exit 92\n";
+  output_string output "case \" $* \" in *\" --print \"*) exit 98 ;; esac\n";
   if require_resume
   then (
     output_string
@@ -85,6 +86,7 @@ let fixture_script
         output
         "test -z \"${XDG_CACHE_HOME+x}\" && test -z \"${XDG_CONFIG_HOME+x}\" && test -z \"${XDG_DATA_HOME+x}\" || exit 95\n")
     required_home;
+  output_string output "cat >/dev/null\n";
   if sleep_s > 0.0 then output_string output (Printf.sprintf "sleep %.3f\n" sleep_s);
   List.iter
     (fun line -> output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
@@ -100,7 +102,14 @@ let with_fixture ?require_resume ?required_home ?sleep_s ?exit_code lines f =
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
-let run_fixture ?conversation_mode ?home_dir ?on_conversation_ready ?(timeout_s = 2.0) path =
+let run_fixture
+    ?conversation_mode
+    ?home_dir
+    ?on_conversation_ready
+    ?(timeout_s = 2.0)
+    ?(prompt = "Return the fixture marker")
+    path
+  =
   Eio_main.run (fun env ->
     let config =
       { (Runtime_antigravity.default_config ~cwd:"/tmp" ~model:"gemini-fixture") with
@@ -116,7 +125,7 @@ let run_fixture ?conversation_mode ?home_dir ?on_conversation_ready ?(timeout_s 
       ~clock:(Eio.Stdenv.clock env)
       ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
       config
-      ~prompt:"Return the fixture marker")
+      ~prompt)
 ;;
 
 let test_successful_official_client_turn () =
@@ -146,6 +155,16 @@ let test_successful_official_client_turn () =
            (turn.permission_mode = Runtime_antigravity.Always_proceed);
          check bool "new conversation" false turn.resumed;
          check bool "measured wall duration" true (turn.wall_duration_s >= 0.0))
+;;
+
+let test_large_prompt_streams_over_stdin () =
+  let prompt = String.make 1_100_000 'x' in
+  with_fixture [ init (); result () ] (fun path ->
+    match run_fixture ~prompt path with
+    | Error error -> fail (Runtime_antigravity.error_to_string error)
+    | Ok turn ->
+      check string "response" "MASC_ANTIGRAVITY_OK\n" turn.text;
+      check int "turn count" 1 turn.num_turns)
 ;;
 
 let test_child_environment_is_allowlisted () =
@@ -370,19 +389,6 @@ let test_admission_is_process_free () =
   | Ok () -> fail "invalid deterministic config passed admission"
 ;;
 
-let test_oversized_prompt_is_typed_before_spawn () =
-  let config =
-    Runtime_antigravity.default_config ~cwd:"/tmp" ~model:"gemini-fixture"
-  in
-  let prompt = String.make (Runtime_antigravity.max_prompt_bytes + 1) 'x' in
-  match Runtime_antigravity.validate_turn config ~prompt with
-  | Error (Runtime_antigravity.Prompt_too_large { bytes; limit }) ->
-    check int "measured bytes" (String.length prompt) bytes;
-    check int "declared argv limit" Runtime_antigravity.max_prompt_bytes limit
-  | Error error -> fail (Runtime_antigravity.error_to_string error)
-  | Ok () -> fail "oversized prompt reached the spawn boundary"
-;;
-
 let test_live_start_and_resume () =
   match Sys.getenv_opt "MASC_ANTIGRAVITY_LIVE", Sys.getenv_opt "MASC_ANTIGRAVITY_MODEL" with
   | Some "1", Some model ->
@@ -445,6 +451,10 @@ let () =
             `Quick
             test_resume_requires_exact_identity_and_argv
         ; test_case
+            "large prompt uses stdin"
+            `Quick
+            test_large_prompt_streams_over_stdin
+        ; test_case
             "resume mismatch"
             `Quick
             test_resume_identity_mismatch_fails_closed
@@ -481,10 +491,6 @@ let () =
             test_unknown_protocol_vocabulary_fails_closed
         ; test_case "typed timeout" `Quick test_timeout_is_typed
         ; test_case "process-free admission" `Quick test_admission_is_process_free
-        ; test_case
-            "oversized prompt is typed before spawn"
-            `Quick
-            test_oversized_prompt_is_typed_before_spawn
         ] )
     ; "live official client", [ test_case "official agy start and resume" `Slow test_live_start_and_resume ]
     ]


### PR DESCRIPTION
## Summary

- stream the complete Antigravity turn prompt over stdin with bounded argv
- preserve every prepared history atom for fresh official-client sessions
- pin the installed CLI pipe contract and a 1.1 MB runtime regression

## Validation

- ocamlformat check: pass
- git diff check: pass
- installed agy piped-prompt sentinel: MASC_STDIN_OK
- focused Dune rerun: pending the shared machine lock