### PR TITLE
fix(ci): 감사 스크립트가 테스트 실행 파일만 세도록 — 지원 모듈이 미배선 baseline 에 섞여 있었다

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -36,9 +36,22 @@ CI_TARGET_SOURCES=(
 # is how this check came to report test_task_cache_invariant_13397 as missing
 # while (names ...) declared it. The trailing `)` closing a (names ...) list is
 # stripped so the last entry in each block still counts.
-awk '/^[[:space:]]+test_[a-z_0-9]+/ {
-       for (i = 1; i <= NF; i++) {
-         name = $i
+# Field-aware: only (names ...) entries are test executables with a
+# runtest-<name> alias. (modules ...) lists the support modules compiled into
+# them, which have none — `dune build @test/runtest-<module>` answers "Alias ...
+# is empty". Counting both inflated the unwired baseline with six such modules
+# (test_operator_control_support, test_keeper_tool_matrix_cases, and four
+# siblings; the first two verified against dune directly), and let the
+# referenced-subset-declared check above pass for a name dune cannot build —
+# the exact breakage that check exists to catch.
+awk '/^[[:space:]]*\(names/ { field = "names"; line = substr($0, index($0, "(names") + 6) }
+     /^[[:space:]]*\(modules/ { field = "modules"; line = substr($0, index($0, "(modules") + 8) }
+     /^[[:space:]]*\((libraries|preprocess|deps|flags|action|alias)/ { field = ""; line = "" }
+     !/^[[:space:]]*\(/ { line = $0 }
+     field == "names" {
+       n = split(line, parts, /[[:space:]]+/)
+       for (i = 1; i <= n; i++) {
+         name = parts[i]
          sub(/\)+$/, "", name)
          if (name ~ /^test_[a-z_0-9]+$/) print name
        }
@@ -111,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=689
+UNWIRED_BASELINE=686
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
## 무엇을

`audit-ci-test-targets.sh` 가 **테스트 실행 파일**만 세도록 고칩니다. 지금은 그 실행 파일에 컴파일되는 **지원 모듈**까지 함께 셉니다.

## 문제

`declared` 집합을 만드는 awk 가 `test/dune` 의 들여쓰인 `test_*` 토큰을 **필드 구분 없이** 모읍니다:

```awk
awk '/^[[:space:]]+test_[a-z_0-9]+/ { … print name … }' test/dune > "$declared"
```

`(names ...)` 는 실행 파일이고 각각 `runtest-<name>` alias 를 갖습니다. `(modules ...)` 는 그 실행 파일들에 들어가는 지원 모듈이고 alias 가 **없습니다**:

```
$ dune build --root . @test/runtest-test_operator_control_support
Error: Alias "runtest-test_operator_control_support" ... is empty.
       It is not defined in test or any of its descendants.

$ dune build --root . @test/runtest-test_keeper_tool_matrix_cases
(동일)
```

`test/dune:382` 를 보면 그 이름이 `(modules ...)` 블록(325행 시작) 안에 있습니다. `(names ...)` 는 29행입니다.

## 결과 두 가지

**1. baseline 이 비-테스트를 셉니다.** `UNWIRED_BASELINE=689` 에 지원 모듈 3개가 섞여 있습니다.

**2. 잠복 구멍.** 위쪽의 `referenced ⊆ declared` 검사가 **지원 모듈을 이름으로 쓴 CI 타깃을 통과**시킵니다. dune 은 그걸 hard-fail 하므로 `#28022` 와 같은 파손이 됩니다 — 이 검사가 막으려는 바로 그 실패입니다.

현재 CI 타깃 중 그런 이름은 **없습니다**(확인함). 즉 실현된 위험이 아니라 잠복입니다.

## 변경

awk 를 필드 인식으로 바꿉니다. `(names` / `(modules` 를 만나면 상태를 바꾸고, `(libraries` · `(preprocess` · `(deps` · `(flags` · `(action` · `(alias` 에서 해제합니다. `(names ...)` 안의 토큰만 수집합니다.

`(name X)` 단수형·coverage manifest·include 스탠자는 전부 실행 파일이므로 그대로 둡니다.

## 검증

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 170 CI targets, all declared in Dune
[ci-test-targets] OK - 686 suites unwired, at baseline
```

baseline 689 → **686**. 이 수치는 스크립트가 스스로 요구한 것입니다:

```
[ci-test-targets] OK - 686 suites unwired, 689 baseline —
  lower UNWIRED_BASELINE in scripts/audit-ci-test-targets.sh to hold the gain
```

**뮤테이션**: `field == "names"` 를 `field == "names" || field == "modules"` 로 되돌리면

```
뮤테이션 exit=2   (FAIL, unwired 가 baseline 초과)
복원     exit=0
```

즉 ratchet 이 이 변경을 실제로 지킵니다.

## 배경

`#26150` 이 지적한 결함 중 *"executable-only / disabled 스탠자를 runnable 로 센다"* 가 현재 스크립트에도 남아 있던 형태입니다. 그 이슈의 원래 대상(`audit-test-gate-candidates.py`)은 `#26151` 로 은퇴했지만, 같은 혼동이 이 스크립트에 있었습니다.

`#28031` 의 미배선 스위트 실측에서 `test_operator_control_support` 가 "alias 없음"으로 나온 것이 단서였습니다.

RFC-WAIVED: CI 감사 스크립트의 집계 정확도 수정. 게이트 판정 기준·정책 변경 없음이며, `referenced ⊆ declared` 검사의 의미는 좁아지기만 함(비-테스트 이름을 더 이상 통과시키지 않음).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
