### PR TITLE
fix(keeper): reset the official-client ordinal on a fresh restart

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -4383,6 +4383,10 @@ describe('official-client session API', () => {
       session: {
         ...recoveryPayload.session,
         phase: { kind: 'ready' },
+        // restart_fresh abandons the conversation, so the server resets the
+        // completed-turn count with it. Spreading recoveryPayload's turn_count: 1
+        // would mock a response the server cannot emit.
+        turn_count: 0,
         last_recovery_resolution: {
           recovery_id: recoveryPayload.session.phase.recovery_id,
           failure: 'protocol_failed',

--- a/lib/keeper/keeper_official_client_session_store.ml
+++ b/lib/keeper/keeper_official_client_session_store.ml
@@ -1025,19 +1025,29 @@ let resolve_recovery ~base_path ~keeper_name ~expected ~recovery_id ~resolution
     | Some _ | None -> Error Recovery_not_required
   in
   let apply directory (current : t) (recovery : recovery_required) =
-    let completed_turn_count = current.turn_count - 1 in
-    let* phase =
+    let* phase, turn_count =
       match resolution with
       | Retry_previous ->
+        (* The conversation is kept, so only the turn that failed is dropped and
+           the next claim re-attempts the same ordinal against it. *)
         (match recovery.previous_settlement with
          | None -> Error Retry_previous_unavailable
-         | Some settlement -> Ok (Settled settlement))
-      | Restart_fresh -> Ok Ready
+         | Some settlement -> Ok (Settled settlement, current.turn_count - 1))
+      | Restart_fresh ->
+        (* Restart abandons the conversation, so the ordinal restarts with it and
+           the next claim asks for ordinal 1 -- what a fresh provider conversation
+           reports. This is the same reset the automatic supersede already does
+           ([plan_claim]'s [Recovery_required] arm). Carrying
+           [current.turn_count - 1] across the discard left the operator's
+           explicit restart counting from a conversation that no longer exists,
+           and since the observed provider count became authoritative it also
+           made the next turn fail [mark_turn_started]'s regression guard. *)
+        Ok (Ready, 0)
     in
     let resolved =
       { current with
         phase
-      ; turn_count = completed_turn_count
+      ; turn_count
       ; last_recovery_resolution =
           Some
             { recovery_id

--- a/lib/keeper/keeper_official_client_session_store.mli
+++ b/lib/keeper/keeper_official_client_session_store.mli
@@ -241,9 +241,12 @@ val resolve_recovery :
   resolved_at:float ->
   ((t * recovery_resolution_application), recovery_resolution_error) result
 (** Resolve one exact recovery claim with compare-and-swap authority.
-    [Retry_previous] restores the last settled session, [Restart_fresh] makes
-    the next claim start a new session. Repeating the same recovery id and
-    decision returns the already committed binding as [Replayed]; a different
-    decision for the same recovery id is a conflict. *)
+    [Retry_previous] restores the last settled session and drops only the turn
+    that failed, so the next claim re-attempts the same ordinal against it.
+    [Restart_fresh] abandons the conversation, so the ordinal restarts with it
+    and the next claim asks for ordinal 1 -- the same reset an automatic
+    supersede performs. Repeating the same recovery id and decision returns the
+    already committed binding as [Replayed]; a different decision for the same
+    recovery id is a conflict. *)
 (** Every phase change is a process-safe durable compare-and-swap followed by
     exact read-back. Any incomplete phase blocks a later automatic claim. *)

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -711,6 +711,159 @@ let test_retry_previous_restores_exact_settlement () =
       fail "restored settlement did not drive the next resume claim")
 ;;
 
+(* The sibling restart case starts at turn_count = 1, where [turn_count - 1] and
+   a true reset are the same number, so it cannot see the ordinal carry across a
+   discarded conversation. This one reaches turn_count = 2 first and then runs
+   the next turn far enough to reach [mark_turn_started], which is where the
+   carried ordinal becomes a failure: a restart opens a fresh provider
+   conversation, that conversation reports ordinal 1, and the regression guard
+   rejects any observed count below the durable one. *)
+let test_restart_fresh_lets_the_next_fresh_turn_start () =
+  with_workspace "masc-official-client-store-restart-ordinal-" (fun base_path ->
+    let keeper_name = "restart-ordinal" in
+    let claimed =
+      claim_new
+        ~base_path
+        ~keeper_name
+        ~client_kind:Codex
+        ~runtime_id:"codex.default"
+        ~owner_epoch
+        ~at:1.0
+    in
+    let settled =
+      mark_active
+        ~base_path
+        ~keeper_name
+        ~expected:claimed
+        ~session_id:"session-1"
+        ~updated_at:2.0
+      |> Result.get_ok
+      |> fun active ->
+      mark_turn_starting
+        ~base_path
+        ~keeper_name
+        ~expected:active
+        ~session_id:"session-1"
+        ~updated_at:3.0
+      |> Result.get_ok
+      |> fun starting ->
+      mark_turn_started
+        ~base_path
+        ~keeper_name
+        ~expected:starting
+        ~session_id:"session-1"
+        ~turn_id:"session-1:ordinal:1"
+        ~turn_count:1
+        ~updated_at:4.0
+      |> Result.get_ok
+      |> fun inflight ->
+      settle
+        ~base_path
+        ~keeper_name
+        ~expected:inflight
+        ~session_id:"session-1"
+        ~turn_id:"session-1:ordinal:1"
+        ~updated_at:5.0
+      |> Result.get_ok
+    in
+    let second_claim =
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some settled)
+        ~client_kind:Codex
+        ~owner_epoch
+        ~runtime_id:"codex.default"
+        ~tool_surface_sha256:empty_surface
+        ~updated_at:6.0
+      |> Result.get_ok
+    in
+    check int "second claim is ordinal two" 2 second_claim.turn_count;
+    let recovery =
+      require_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:second_claim
+        ~failure:Protocol_failed
+        ~detail:"second turn ended ambiguously"
+        ~required_at:7.0
+      |> Result.get_ok
+    in
+    let recovery_id =
+      match recovery.phase with
+      | Recovery_required required -> required.recovery_id
+      | Ready | Start _ | Active _ | Turn_inflight _ | Settled _ ->
+        fail "second turn did not enter recovery"
+    in
+    let restarted, application =
+      resolve_recovery
+        ~base_path
+        ~keeper_name
+        ~expected:recovery
+        ~recovery_id
+        ~resolution:Restart_fresh
+        ~resolved_by:"operator"
+        ~resolved_at:8.0
+      |> Result.get_ok
+    in
+    check bool "restart applied" true (application = Applied);
+    check int "restart resets the ordinal" 0 restarted.turn_count;
+    (match restarted.phase with
+     | Ready -> ()
+     | Settled _ | Start _ | Active _ | Turn_inflight _ | Recovery_required _ ->
+       fail "fresh restart did not return the binding to Ready");
+    let next_claim =
+      claim
+        ~base_path
+        ~keeper_name
+        ~expected:(Some restarted)
+        ~client_kind:Codex
+        ~owner_epoch
+        ~runtime_id:"codex.default"
+        ~tool_surface_sha256:empty_surface
+        ~updated_at:9.0
+      |> Result.get_ok
+    in
+    check int "claim after restart asks for ordinal one" 1 next_claim.turn_count;
+    (match next_claim.phase with
+     | Start { previous_settlement = None; _ } -> ()
+     | Start { previous_settlement = Some _; _ } ->
+       fail "restart carried a settlement into the next claim"
+     | Ready | Active _ | Turn_inflight _ | Recovery_required _ | Settled _ ->
+       fail "claim after restart did not open a turn");
+    let starting =
+      mark_active
+        ~base_path
+        ~keeper_name
+        ~expected:next_claim
+        ~session_id:"session-2"
+        ~updated_at:10.0
+      |> Result.get_ok
+      |> fun active ->
+      mark_turn_starting
+        ~base_path
+        ~keeper_name
+        ~expected:active
+        ~session_id:"session-2"
+        ~updated_at:11.0
+      |> Result.get_ok
+    in
+    match
+      mark_turn_started
+        ~base_path
+        ~keeper_name
+        ~expected:starting
+        ~session_id:"session-2"
+        ~turn_id:"session-2:ordinal:1"
+        ~turn_count:1
+        ~updated_at:12.0
+    with
+    | Ok inflight ->
+      check int "fresh conversation ordinal is accepted" 1 inflight.turn_count
+    | Error detail ->
+      fail ("a fresh conversation after restart was rejected: " ^ detail))
+;;
+
 let write_file path content =
   let output = open_out_bin path in
   Fun.protect
@@ -807,6 +960,10 @@ let () =
             "retry previous restores exact settlement"
             `Quick
             test_retry_previous_restores_exact_settlement
+        ; test_case
+            "restart fresh lets the next fresh turn start"
+            `Quick
+            test_restart_fresh_lets_the_next_fresh_turn_start
         ; test_case "ambiguous JSON rejected" `Quick test_ambiguous_json_is_rejected
         ; test_case
             "tool surface fingerprint canonical"


### PR DESCRIPTION
## 무엇이 남아 있는가

`resolve_recovery`의 `Restart_fresh`는 previous settlement을 버려 다음 claim이 provider에게 **새 대화**를 요구하게 만든다. 그런데 ordinal은 `turn_count - 1`로 유지한다. masc는 방금 버린 대화에서 계속 세고, provider의 ordinal은 1에서 다시 시작한다.

`reconcile_tool_surface`는 예전부터 같은 폐기를 하면서 ordinal을 1로 리셋했고, #28045가 `plan_claim`의 `Recovery_required` 분기도 `Ok (None, 1, None)`으로 리셋하게 만들었다. **운영자가 명시적으로 고른 경로만 리셋하지 않는다.**

### #28045 이후로는 틀린 숫자가 아니라 실패한 턴이다

#28045는 관측된 provider count를 권위로 삼고(`mark_turn_started ~turn_count:turn.num_turns`) 회귀 가드를 넣었다:

```ocaml
if turn_count < expected.turn_count
then Error "official-client observed turn count regressed after turn start"
```

두 변경이 만나면:

| 단계 | 값 |
|---|---|
| 운영자가 ordinal N에서 `restart_fresh` 해소 | Ready, `turn_count = N-1` |
| 다음 claim (Ready 분기 → +1) | `turn_count = N`, settlement 없음 → 새 대화 |
| provider가 새 대화 시작 → `num_turns` | **1** |
| `mark_turn_started ~turn_count:1` vs expected `N` | **거부** |

자동 supersede 경로가 그 다음 턴에 ordinal 1로 구제하므로 영구 정지는 아니다. **비용은 명시적 restart 1회당 버려지는 턴 1개와 가짜 recovery 1건**이고, 운영자가 의도적으로 고른 경로에서만 발생한다.

## 범위에서 뺀 것

이 브랜치는 원래 `num_turns` 정확 일치 검사 제거도 포함했다. **#28045가 이미 제거**했으므로 뺐다(#28056 닫음). 남은 것은 #28045가 건드리지 않은 `resolve_recovery` 뿐이다.

## 검증

### 대조군 — 수정 없이 실패해야 함

기존 restart 테스트는 `turn_count = 1`에서 시작한다. 거기서는 `turn_count - 1`과 진짜 리셋이 **둘 다 0**이라 결함이 보이지 않는다.

새 테스트는 `turn_count = 2`에 먼저 도달한 뒤, 다음 턴을 `mark_turn_started`까지 실제로 진행시킨다.

수정을 되돌리면 새 테스트만 실패한다:
```
[FAIL]  durable owner  8  restart fresh lets the next fresh turn start
FAIL restart resets the ordinal
```

첫 단언에서 멈추므로, **주장한 하류 결과를 실제로 관측하기 위해** 앞 두 단언의 기대값을 버그 값(`1`, `2`)으로 바꿔 끝까지 실행했다:
```
FAIL a fresh conversation after restart was rejected:
     official-client observed turn count regressed after turn start
```
추론이 아니라 실행 결과다. (이 완화는 관측용이며 커밋에 포함되지 않는다.)

### 수정 적용 후

```
test_official_client_session_store          11 tests  Test Successful
dashboard src/api/dashboard.test.ts        147 tests  1 file passed
```

`dashboard.test.ts`는 clean main에서도 통과함을 먼저 확인한 뒤 변경본을 돌렸다 — 이 변경은 결과를 바꾸지 않는다(stale mirror 정정이므로 의도한 대로다).

첫 push 때 `Build and Test`가 실패했는데, 원인은 이 PR이 아니라 base가 컴파일되지 않는 상태였던 것이다 — `test/test_keeper_antigravity_runtime.ml`이 `named_run_result`에서 `trace_ref`/`turns`를 직접 읽고 있었다. #28066이 main에서 고쳤고 이 브랜치는 그것을 merge했다. 이후:

```
dune build --root . @check                                EXIT=0
test_official_client_session_store                        11 tests  Test Successful
test_keeper_antigravity_runtime                            1 test   Test Successful
```

## 폐포

| 축 | 결과 |
|---|---|
| `resolve_recovery` / `Restart_fresh` 소비자 | `test_official_client_session_store.ml`과 `lib/server/server_dashboard_official_client_session.ml`(JSON 통과)뿐 |
| `turn_count = 0` 상태 | 신규 아님. validator가 `Ready`와 함께 허용하고 `release_transient`가 이미 생산한다 |
| dashboard TS decoder | `dashboard-runtime.ts`가 `turn_count === 0 && phase.kind !== 'ready'`만 거부 — 통과 |
| CI 배선 | `test_official_client_session_store`는 이미 `scripts/ci-run-focused-tests.sh:84`. **매니페스트 변경 없음** → 머지 순서 의존 없음 |

## 하지 않은 것

- **`validate`를 `Ready ⟹ turn_count = 0`으로 강화하지 않았다.** 라이브 durable 파일에 오늘 코드가 만든 `Ready`-at-N>0가 이미 있고 `of_yojson`이 매 load마다 `validate`를 돌리므로, 강화하면 fail-closed로 이 PR이 풀려는 바로 그 binding들을 좌초시킨다.
- **`Retry_previous`의 `turn_count - 1`은 그대로 뒀다.** 대화가 유지되므로 실패한 턴만 버리고 같은 ordinal을 재시도하는 것이 맞다.

RFC-WAIVED: 변경 범위가 `~/me/instructions/workflow-pr.md` §11의 RFC 필수 subsystem(credential/identity/auth, operator control plane, keeper sandbox, dashboard credential, hooks, workflow 문서) 중 어디에도 해당하지 않는다. 변경 파일: `lib/keeper/keeper_official_client_session_store.ml`, `.mli`, `test/test_official_client_session_store.ml`, `dashboard/src/api/dashboard.test.ts`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
