### PR TITLE
fix(dashboard): fold a run of autonomous turns behind one header

### DIFF
--- a/dashboard/src/components/chat/autonomous-turn-group.test.ts
+++ b/dashboard/src/components/chat/autonomous-turn-group.test.ts
@@ -5,7 +5,7 @@
 // collapsed group, so adjacent wakes remain distinguishable in the transcript.
 import { describe, expect, it } from 'vitest'
 import type { KeeperConversationEntry } from '../../types'
-import { buildChatRenderUnits } from './primitives'
+import { buildChatRenderUnits, foldAutonomousRuns } from './primitives'
 import { chatHistoryEntriesFromRest, isDefaultVisibleConversationEntry } from '../../keeper-state'
 
 const entry = (
@@ -51,6 +51,16 @@ describe('buildChatRenderUnits — autonomous turns', () => {
     ).toEqual(['a1', 'a2', 'a3'])
   })
 
+  it('leaves folding to foldAutonomousRuns', () => {
+    // The two stages are separate because only the caller knows which units it
+    // still has to anchor a divider on.
+    const units = buildChatRenderUnits(
+      [autonomous('a1'), autonomous('a2'), autonomous('a3'), autonomous('a4')],
+      true,
+    )
+    expect(units.every((unit) => unit.kind === 'autonomousGroup')).toBe(true)
+  })
+
   it('keeps separate runs separate so conversation between them stays in place', () => {
     const units = buildChatRenderUnits(
       [autonomous('a1'), user('u1'), autonomous('a2')],
@@ -76,6 +86,119 @@ describe('buildChatRenderUnits — autonomous turns', () => {
   it('leaves a transcript without autonomous turns unchanged', () => {
     const units = buildChatRenderUnits([user('u1'), entry('m1')], true)
     expect(units.map((unit) => unit.kind)).toEqual(['entry', 'entry'])
+  })
+})
+
+describe('foldAutonomousRuns', () => {
+  const fold = (
+    entries: KeeperConversationEntry[],
+    opts: Partial<Parameters<typeof foldAutonomousRuns>[1]> = {},
+  ) =>
+    foldAutonomousRuns(buildChatRenderUnits(entries, true), {
+      startsNewRun: () => false,
+      runBoundaryKey: () => null,
+      ...opts,
+    })
+
+  it('leaves a run shorter than the fold threshold inline', () => {
+    // One or two wakes read as part of the conversation around them; a header
+    // over them would only add a click.
+    const units = fold([user('u1'), autonomous('a1'), autonomous('a2'), user('u2')])
+    expect(units.map((unit) => unit.kind)).toEqual([
+      'entry',
+      'autonomousGroup',
+      'autonomousGroup',
+      'entry',
+    ])
+  })
+
+  it('folds a longer run while keeping every turn its own row', () => {
+    const units = fold([
+      user('u1'),
+      autonomous('a1'),
+      autonomous('a2'),
+      autonomous('a3'),
+      user('u2'),
+    ])
+    expect(units.map((unit) => unit.kind)).toEqual(['entry', 'autonomousRun', 'entry'])
+    const run = units[1]
+    if (run?.kind !== 'autonomousRun') throw new Error('expected an autonomousRun')
+    expect(run.entries.map((entry) => entry.id)).toEqual(['a1', 'a2', 'a3'])
+  })
+
+  it('gives the run the first turn s unit id so anchors computed before folding still resolve', () => {
+    const ungrouped = buildChatRenderUnits([autonomous('a1'), autonomous('a2'), autonomous('a3')], true)
+    const firstId = ungrouped[0]?.kind === 'autonomousGroup' ? ungrouped[0].id : null
+    const folded = foldAutonomousRuns(ungrouped, {
+      startsNewRun: () => false,
+      runBoundaryKey: () => null,
+    })
+    expect(folded[0]?.kind === 'autonomousRun' ? folded[0].id : null).toBe(firstId)
+  })
+
+  it('does not fold across a message that interrupts the run', () => {
+    // Two runs of two, not one run of four: the conversation between them is
+    // what the transcript is about.
+    const units = fold([
+      autonomous('a1'),
+      autonomous('a2'),
+      user('u1'),
+      autonomous('a3'),
+      autonomous('a4'),
+    ])
+    expect(units.map((unit) => unit.kind)).toEqual([
+      'autonomousGroup',
+      'autonomousGroup',
+      'entry',
+      'autonomousGroup',
+      'autonomousGroup',
+    ])
+  })
+
+  it('cuts the run before a unit the caller still needs at top level', () => {
+    const units = fold(
+      [
+        autonomous('a1'),
+        autonomous('a2'),
+        autonomous('a3'),
+        autonomous('a4'),
+        autonomous('a5'),
+        autonomous('a6'),
+      ],
+      { startsNewRun: (unit) => unit.kind === 'autonomousGroup' && unit.entry.id === 'a4' },
+    )
+    expect(units.map((unit) => unit.kind)).toEqual(['autonomousRun', 'autonomousRun'])
+    const second = units[1]
+    if (second?.kind !== 'autonomousRun') throw new Error('expected an autonomousRun')
+    expect(second.entries.map((entry) => entry.id)).toEqual(['a4', 'a5', 'a6'])
+  })
+
+  it('cuts the run when the boundary key changes', () => {
+    const units = fold(
+      [
+        autonomous('a1'),
+        autonomous('a2'),
+        autonomous('a3'),
+        autonomous('b1'),
+        autonomous('b2'),
+        autonomous('b3'),
+      ],
+      { runBoundaryKey: (unit) => (unit.kind === 'autonomousGroup' ? unit.entry.id[0] ?? null : null) },
+    )
+    expect(units.map((unit) => unit.kind)).toEqual(['autonomousRun', 'autonomousRun'])
+  })
+
+  it('treats a null boundary key as carrying no boundary', () => {
+    // A turn with no timestamp must not cut the run, and must not erase the
+    // last key that would have.
+    const units = fold(
+      [autonomous('a1'), autonomous('a2'), autonomous('a3'), autonomous('a4')],
+      {
+        runBoundaryKey: (unit) =>
+          unit.kind === 'autonomousGroup' && unit.entry.id === 'a3' ? null : 'day-1',
+      },
+    )
+    expect(units.map((unit) => unit.kind)).toEqual(['autonomousRun'])
   })
 })
 

--- a/dashboard/src/components/chat/autonomous-turn-run.test.ts
+++ b/dashboard/src/components/chat/autonomous-turn-run.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+//
+// Rendering of a folded run of autonomous turns. The unit-level contract lives
+// in autonomous-turn-group.test.ts; what is asserted here is what the fold does
+// to the transcript around it, which is only observable after a render: the
+// run must replace N identical rows with one header, must still hold N rows
+// inside, and must not swallow a divider the transcript still has to draw.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { html } from 'htm/preact'
+import type { KeeperConversationEntry } from '../../types'
+import { ChatTranscript } from './primitives'
+
+const wake = (id: string, timestamp: string): KeeperConversationEntry =>
+  ({
+    id,
+    role: 'assistant',
+    source: 'autonomous_turn',
+    label: 'keeper',
+    text: '',
+    delivery: 'history',
+    timestamp,
+  }) as KeeperConversationEntry
+
+const said = (id: string, timestamp: string): KeeperConversationEntry =>
+  ({
+    id,
+    role: 'user',
+    source: 'direct_user',
+    label: 'vincent',
+    text: '상태 알려줘',
+    delivery: 'history',
+    timestamp,
+  }) as KeeperConversationEntry
+
+// A keeper wakes on the order of once a minute. Two days chosen 48h apart so
+// they land on different calendar days in every timezone the suite might run in.
+const DAY_ONE = '2026-08-10T12:00:00.000Z'
+const DAY_THREE = '2026-08-12T12:00:00.000Z'
+
+const minutesAfter = (iso: string, minutes: number): string =>
+  new Date(Date.parse(iso) + minutes * 60_000).toISOString()
+
+const secondsOf = (iso: string): number => Math.floor(Date.parse(iso) / 1000)
+
+const wakesFrom = (prefix: string, start: string, count: number): KeeperConversationEntry[] =>
+  Array.from({ length: count }, (_, i) => wake(`${prefix}${i + 1}`, minutesAfter(start, i)))
+
+describe('ChatTranscript — folded autonomous runs', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  const draw = (
+    entries: KeeperConversationEntry[],
+    opts: { unreadAfterTs?: number | null; showDayDividers?: boolean } = {},
+  ) => {
+    render(
+      html`<${ChatTranscript}
+        entries=${entries}
+        emptyText="대화 없음"
+        showDayDividers=${opts.showDayDividers ?? true}
+        groupToolCalls=${true}
+        unreadAfterTs=${opts.unreadAfterTs ?? null}
+      />`,
+      container,
+    )
+  }
+
+  const headerCounts = (): (string | null)[] =>
+    [...container.querySelectorAll('.chat-block-trace-count')].map((node) => node.textContent)
+
+  const runHeaders = (): HTMLElement[] =>
+    [...container.querySelectorAll('.chat-auto-run > .chat-block-trace-hd')] as HTMLElement[]
+
+  it('replaces a wall of identical rows with one header carrying the count', () => {
+    draw([said('u1', DAY_ONE), ...wakesFrom('a', minutesAfter(DAY_ONE, 1), 6)])
+    // One chip, not six reading "1개".
+    expect(headerCounts()).toEqual(['6개'])
+  })
+
+  it('holds every turn as its own row inside, so the run is a container and not a merge', () => {
+    draw(wakesFrom('a', DAY_ONE, 6))
+    act(() => {
+      runHeaders()[0]?.click()
+    })
+    const nested = container.querySelectorAll('.chat-auto-run-turns > .chat-block-trace')
+    expect(nested.length).toBe(6)
+    // Each nested turn is still closed and still counts one turn.
+    expect([...nested].map((node) => node.querySelector('.chat-block-trace-count')?.textContent))
+      .toEqual(['1개', '1개', '1개', '1개', '1개', '1개'])
+  })
+
+  it('leaves a short run of wakes inline', () => {
+    draw([said('u1', DAY_ONE), ...wakesFrom('a', minutesAfter(DAY_ONE, 1), 2)])
+    expect(container.querySelectorAll('.chat-auto-run').length).toBe(0)
+    expect(headerCounts()).toEqual(['1개', '1개'])
+  })
+
+  it('still draws a day divider for every day the run covers', () => {
+    // A run that folded across midnight would take the second day's divider
+    // with it, and the transcript would claim those turns happened on day one.
+    draw([...wakesFrom('a', DAY_ONE, 4), ...wakesFrom('b', DAY_THREE, 4)])
+    expect(container.querySelectorAll('.kw-daydiv:not(.kw-unreaddiv)').length).toBe(2)
+    expect(container.querySelectorAll('.chat-auto-run').length).toBe(2)
+  })
+
+  it('still draws the unread line when the cursor falls inside a run', () => {
+    // The anchor is computed before folding. Folding the anchored turn into a
+    // run that starts earlier would leave the line with nothing to attach to.
+    const wakes = wakesFrom('a', DAY_ONE, 8)
+    const cutoff = secondsOf(minutesAfter(DAY_ONE, 3)) + 1
+    draw(wakes, { unreadAfterTs: cutoff })
+    expect(container.querySelectorAll('.kw-unreaddiv').length).toBe(1)
+    expect(container.querySelectorAll('.chat-auto-run').length).toBe(2)
+  })
+
+  it('keeps the unread line above the first unseen turn', () => {
+    const wakes = wakesFrom('a', DAY_ONE, 8)
+    const cutoff = secondsOf(minutesAfter(DAY_ONE, 3)) + 1
+    draw(wakes, { unreadAfterTs: cutoff })
+    const divider = container.querySelector('.kw-unreaddiv')
+    const runs = [...container.querySelectorAll('.chat-auto-run')]
+    expect(divider).not.toBeNull()
+    expect(runs.length).toBe(2)
+    // The second run begins at the first unseen turn, so the line sits
+    // immediately before it rather than after the whole block.
+    expect(divider?.nextElementSibling).toBe(runs[1])
+  })
+})

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3721,6 +3721,66 @@ function AutonomousTurnGroup({
   `
 }
 
+/** A run of consecutive autonomous turns behind one header. Starts closed for
+ *  the same reason each turn does: the transcript's subject is the conversation
+ *  these wakes sit between. Expanding renders the run's turns as the same rows
+ *  they would be at top level, each still closed and each still its own turn. */
+function AutonomousTurnRun({
+  entries,
+  showMetadata,
+  variant,
+  showSourceBadge,
+  toolOutputsCoveredSinceMs,
+  toolOutputsCoveredThroughMs,
+  toolOutputHydrationContract,
+  action,
+}: {
+  entries: KeeperConversationEntry[]
+  showMetadata?: boolean
+  variant: ChatTranscriptVariant
+  showSourceBadge: boolean
+  toolOutputsCoveredSinceMs: number | null
+  toolOutputsCoveredThroughMs: number | null
+  toolOutputHydrationContract: ToolCallOutputHydrationContract | null
+  action?: ChatTranscriptAction
+}) {
+  const [open, setOpen] = useState(false)
+  const first = timeLabel(entries[0]?.timestamp)
+  const last = timeLabel(entries[entries.length - 1]?.timestamp)
+  // Both ends or neither: a half range would read as a single point in time.
+  const range = first && last ? (first === last ? first : `${first} ~ ${last}`) : null
+  return html`
+    <div class="chat-block-trace chat-auto-run ${open ? 'open' : ''}">
+      <button
+        type="button"
+        class="chat-block-trace-hd"
+        onClick=${() => setOpen((o) => !o)}
+        aria-expanded=${open}
+      >
+        <span class="chat-block-trace-chev">${open ? '▾' : '▸'}</span>
+        <span class="chat-block-trace-label">자율턴</span>
+        <span class="chat-block-trace-count">${entries.length}개</span>
+        ${range ? html`<span class="chat-block-trace-meta">${range}</span>` : null}
+      </button>
+      ${open
+        ? html`<div class="chat-auto-run-turns">
+            ${entries.map((entry) => html`<${AutonomousTurnGroup}
+              key=${entry.id}
+              entry=${entry}
+              showMetadata=${showMetadata}
+              variant=${variant}
+              showSourceBadge=${showSourceBadge}
+              toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
+              toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+              toolOutputHydrationContract=${toolOutputHydrationContract}
+              action=${action}
+            />`)}
+          </div>`
+        : null}
+    </div>
+  `
+}
+
 type ChatRenderUnit =
   | { kind: 'entry'; entry: KeeperConversationEntry }
   | { kind: 'toolGroup'; id: string; entries: KeeperConversationEntry[] }
@@ -3731,6 +3791,15 @@ type ChatRenderUnit =
   // bury the conversation it sits between. The exact turn remains the group
   // boundary; adjacent autonomous turns must never merge into one giant run.
   | { kind: 'autonomousGroup'; id: string; entry: KeeperConversationEntry }
+  // Consecutive autonomous turns behind one header. Collapsing each turn
+  // individually bounds how tall one wake renders but not how many wakes do:
+  // an hour with nobody watching still puts dozens of identical rows between
+  // two human messages, which buries the conversation the same way expanding
+  // them would. This is a container, not a merge — every turn keeps its own
+  // row and its own open/closed state inside, so the exact turn is still the
+  // group boundary. Runs are cut at any boundary the transcript itself has to
+  // draw; see foldAutonomousRuns.
+  | { kind: 'autonomousRun'; id: string; entries: KeeperConversationEntry[] }
 
 function entryTurnRef(entry: KeeperConversationEntry): string | null {
   const value = entry.turnRef?.trim()
@@ -3836,11 +3905,76 @@ export function buildChatRenderUnits(
   return units
 }
 
+// Below this many consecutive autonomous turns, folding costs more than it
+// saves: one or two stray wakes read as part of the surrounding conversation,
+// and hiding them behind a header only adds a click. At or above it the rows
+// stop being incidental and start being the wall this fold exists to remove.
+const AUTONOMOUS_RUN_FOLD_THRESHOLD = 3
+
+/** Fold consecutive `autonomousGroup` units behind one `autonomousRun`.
+ *
+ *  Runs shorter than the threshold are returned untouched, so a transcript with
+ *  the occasional wake renders exactly as before.
+ *
+ *  A folded run is not allowed to swallow a row the transcript still has to
+ *  anchor something on: the caller draws day dividers and the unread line
+ *  against top-level units, and a unit absorbed into a run stops being one.
+ *  `startsNewRun` cuts before such a row, and `runBoundaryKey` cuts whenever the
+ *  key changes inside an open run — both leave the row at top level as the
+ *  start of the next run. */
+export function foldAutonomousRuns(
+  units: ChatRenderUnit[],
+  opts: {
+    startsNewRun: (unit: ChatRenderUnit) => boolean
+    runBoundaryKey: (unit: ChatRenderUnit) => string | null
+  },
+): ChatRenderUnit[] {
+  const out: ChatRenderUnit[] = []
+  let run: Extract<ChatRenderUnit, { kind: 'autonomousGroup' }>[] = []
+  let boundary: string | null = null
+  const flush = () => {
+    const first = run[0]
+    if (first && run.length >= AUTONOMOUS_RUN_FOLD_THRESHOLD) {
+      // The run reuses the first group's id so its key and timestamp are the
+      // ones the caller already computed anchors from: a divider that would
+      // have landed on that group lands on the run instead of vanishing.
+      out.push({ kind: 'autonomousRun', id: first.id, entries: run.map((unit) => unit.entry) })
+    } else {
+      out.push(...run)
+    }
+    run = []
+    boundary = null
+  }
+  for (const unit of units) {
+    if (unit.kind !== 'autonomousGroup') {
+      flush()
+      out.push(unit)
+      continue
+    }
+    const key = opts.runBoundaryKey(unit)
+    // A null key carries no boundary information, so it neither cuts the run
+    // nor overwrites the last key that did.
+    if (opts.startsNewRun(unit) || (key !== null && boundary !== null && key !== boundary)) {
+      flush()
+    }
+    if (key !== null) boundary = key
+    run.push(unit)
+  }
+  flush()
+  return out
+}
+
 function unitTimestamp(unit: ChatRenderUnit): string | null {
-  const ts = unit.kind === 'entry' || unit.kind === 'autonomousGroup'
-    ? unit.entry.timestamp
-    : unit.entries[0]?.timestamp ?? (unit.kind === 'turnBundle' ? unit.entry.timestamp : null)
-  return ts ?? null
+  switch (unit.kind) {
+    case 'entry':
+    case 'autonomousGroup':
+      return unit.entry.timestamp ?? null
+    case 'toolGroup':
+    case 'autonomousRun':
+      return unit.entries[0]?.timestamp ?? null
+    case 'turnBundle':
+      return unit.entries[0]?.timestamp ?? unit.entry.timestamp ?? null
+  }
 }
 
 function unitTimestampMs(unit: ChatRenderUnit): number | null {
@@ -3870,11 +4004,21 @@ function renderChatTranscriptBody(opts: {
   action?: ChatTranscriptAction
 }): VNode[] {
   const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, toolOutputHydrationContract, unreadAfterTs, action } = opts
-  const units = buildChatRenderUnits(entries, groupToolCalls)
+  const ungroupedUnits = buildChatRenderUnits(entries, groupToolCalls)
+  // Anchored on the unfolded list: folding must not move the unread line, only
+  // avoid hiding it. foldAutonomousRuns cuts a run open at this key so the unit
+  // it names is still top level below.
   const unreadAnchorKey = unreadDividerAnchorKey(
-    units.map(unit => ({ key: unitKey(unit), tsMs: unitTimestampMs(unit) })),
+    ungroupedUnits.map(unit => ({ key: unitKey(unit), tsMs: unitTimestampMs(unit) })),
     unreadAfterTs,
   )
+  const units = foldAutonomousRuns(ungroupedUnits, {
+    startsNewRun: (unit) => unreadAnchorKey !== null && unitKey(unit) === unreadAnchorKey,
+    // Day dividers are emitted per unit below, so a run that spanned midnight
+    // would show only its first day. Cutting on the day key keeps every day
+    // that has turns in it addressable by a divider.
+    runBoundaryKey: (unit) => (showDayDividers ? dayKey(unitTimestamp(unit)) : null),
+  })
   const out: VNode[] = []
   // Track the last NON-NULL calendar day rather than only the immediately
   // previous entry, so a null-timestamp entry (live placeholder, checkpoint) in
@@ -3895,7 +4039,19 @@ function renderChatTranscriptBody(opts: {
     if (unreadAnchorKey !== null && unitKey(unit) === unreadAnchorKey) {
       out.push(html`<div class="kw-daydiv kw-unreaddiv" key="unread-divider">${UNREAD_DIVIDER_LABEL}</div>`)
     }
-    if (unit.kind === 'autonomousGroup') {
+    if (unit.kind === 'autonomousRun') {
+      out.push(html`<${AutonomousTurnRun}
+        key=${unit.id}
+        entries=${unit.entries}
+        showMetadata=${showMetadata}
+        variant=${variant}
+        showSourceBadge=${showSourceBadge}
+        toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
+        toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+        toolOutputHydrationContract=${toolOutputHydrationContract}
+        action=${action}
+      />`)
+    } else if (unit.kind === 'autonomousGroup') {
       out.push(html`<${AutonomousTurnGroup}
         key=${unit.id}
         entry=${unit.entry}

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -68,6 +68,20 @@
   border-top-left-radius: var(--r-0);
 }
 
+/* A run of autonomous turns. The nested turns are indented and separated so
+   the run header reads as their parent rather than as a sibling row. */
+.chat-auto-run-turns {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 8px 8px 20px;
+  border-top: 1px solid var(--color-border-default);
+}
+
+.chat-auto-run-turns .chat-block-trace {
+  background: var(--color-bg-surface);
+}
+
 .chat-block-trace-hd {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 무엇을

연속된 자율턴을 헤더 하나 뒤로 접는다. 턴 자체는 합치지 않는다.

## 왜

`#keepers?keeper=sangsu` 의 transcript 에서 `자율턴 1개` 행이 **99개** 연속으로 나열돼 있었다. 확인하는 동안에도 40~50초마다 하나씩 늘어났다.

턴 단위 collapse 는 **한 번의 wake 가 얼마나 높게 그려지는지**는 막지만 **몇 번 그려지는지**는 막지 않는다. 기존 주석이 밝힌 이 collapse 의 목적은 이것이었다:

> a keeper wakes on the order of once a minute, so rendering each turn expanded would bury the conversation it sits between

접힌 행 99개도 그 사이의 대화를 똑같이 묻는다. 접기가 문제를 절반만 해결한 상태다.

계층으로 보면 한 단이 없다:

```
전:  ▸ 자율턴 1개  22:42:53      ← 99행이 평면
     ▸ 자율턴 1개  22:43:42
     ... × 97

후:  ▸ 자율턴 99개  22:42:08 ~ 01:17:34
         ▸ 자율턴 1개  22:42:53   ← 펼쳤을 때, 각 턴은 여전히 자기 행
         ▸ 자율턴 1개  22:43:42
```

## 어떻게

`ChatRenderUnit` 에 `autonomousRun` 을 추가한다. **container 이지 merge 가 아니다** — 각 턴은 자기 행과 자기 open/closed 상태를 그대로 갖고, 정확한 턴이 여전히 그룹 경계다. 기존 주석의 불변식(`adjacent autonomous turns must never merge into one giant run`)은 유지된다.

3개 미만의 run 은 접지 않고 그대로 둔다. 한두 번의 wake 는 주변 대화의 일부로 읽히고, 거기에 헤더를 씌우면 클릭만 하나 늘어난다.

**접기를 grouping 과 별도 pass 로 뒀다.** 어떤 unit 에 무엇을 앵커해야 하는지는 호출자만 안다:

- `buildChatRenderUnits` 는 그대로 턴당 unit 하나를 낸다.
- `renderChatTranscriptBody` 가 그 **접히지 않은** 목록에서 unread 앵커를 먼저 계산하고,
- `foldAutonomousRuns` 로 접되 **앵커 지점**과 **날짜 변경 지점**에서 run 을 끊는다.

끊지 않으면 구분선이 사라진다. run 이 삼킨 unit 은 더 이상 top-level 이 아니고, 날짜를 넘긴 run 은 첫날 divider 만 그려서 이틀치 턴을 하루에 일어난 것처럼 보이게 한다. run 은 첫 턴의 unit id 를 그대로 쓰므로, 접기 전에 계산된 앵커가 접은 뒤에도 그대로 해결된다.

## 검증

`pnpm lint` exit 0, `pnpm exec tsc --noEmit` exit 0.
`src/components/chat/` + `src/styles/chat-blocks-v2.test.ts` — 15 파일 273 tests 통과.

**새 테스트가 실제로 결함을 잡는지 두 번 확인했다.**

1. 구현 파일만 부모 커밋으로 되돌리고 `autonomous-turn-run.test.ts` 실행 → **6건 중 5건 FAIL**. 통과한 1건은 `leaves a short run of wakes inline` 로, 동작이 의도적으로 변하지 않는 대조군이다.

2. 수정을 되돌린 뒤 fold 만 남기고 경계 분할을 무력화(`startsNewRun: () => false`, `runBoundaryKey: () => null`) → **3건 FAIL**:
   - `still draws a day divider for every day the run covers`
   - `still draws the unread line when the cursor falls inside a run`
   - `keeps the unread line above the first unseen turn`

   즉 이 3건은 "접기"가 아니라 "구분선을 삼키지 않는 분할"을 지킨다.

`autonomous-turn-group.test.ts` 의 `foldAutonomousRuns` 단위 테스트 7건은 새 export 를 호출하므로 수정 전 트리에서 컴파일되지 않는다. 결함 탐지를 증명하지 못하고 새 계약의 회귀 방지 역할만 한다.

## 남는 것

`primitives.ts` 는 이 PR 이후 3,800줄이다. `autonomous-turn-group.test.ts` 는 있는데 구현 파일 `autonomous-turn-group.ts` 는 없다 — 자율턴 렌더를 그 파일로 분리하는 것은 이 PR 범위 밖이며 별도로 다뤄야 한다.

fusion 결과 카드가 턴 그룹 안에 어떻게 중첩되는지는 이 PR 에서 판정하지 않았다. 확인한 transcript 에 fusion 실행 이력이 없어 카드가 렌더되지 않았다.

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
