### PR TITLE
fix(test): read the run result through named_run_result (main is red)

### DIFF
--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -350,11 +350,17 @@ let test_keeper_projects_mcp_tool_and_settles () =
                     with
                     | Error error -> fail (Agent_core.Error.to_string error)
                     | Ok resumed ->
-                      observed_trace_ref := resumed.trace_ref;
+                      (* #28049 made run_named return named_run_result, which
+                         carries the turn's run_result plus the runtime that
+                         actually executed it. #28062 was written against the
+                         previous bare run_result and the two merged in that
+                         order, so these two reads have to go through the
+                         nested field. *)
+                      observed_trace_ref := resumed.run_result.trace_ref;
                       check int
                         "provider cumulative turn count"
                         73
-                        resumed.turns))));
+                        resumed.run_result.turns))));
       check string
         "tool arguments"
         {|{"marker":"from-antigravity"}|}


### PR DESCRIPTION
## main 이 컴파일되지 않는다

`origin/main` (9d14a38b99) 에서 `dune build @check` 가 트리 전체를 실패시킨다:

```
File "test/test_keeper_antigravity_runtime.ml", line 353, characters 52-61:
353 |     observed_trace_ref := resumed.trace_ref;
                                        ^^^^^^^^^
Error: This expression has type Keeper_turn_driver.named_run_result
       There is no field trace_ref within type Keeper_turn_driver.named_run_result
```

로컬 편집 전 pristine `origin/main` 에서 재현했다.

## 원인 — 머지 순서

- **#28049** 가 `Keeper_turn_driver.run_named` 의 반환을 `Runtime_agent.run_result` 에서 `named_run_result` 로 바꿨다 (turn 의 run_result + **실제로 실행한 런타임**: `selected_runtime_id` / `selected_max_context` / `checkpoint_owner`).
- **#28062** 는 그 이전의 bare `run_result` 기준으로 작성됐다.

둘 다 개별로는 옳고, **이 순서로 머지될 때만** 깨진다. 어느 쪽 diff 에도 상대가 보이지 않는다.

## 변경

`resumed.trace_ref` / `resumed.turns` → `resumed.run_result.trace_ref` / `resumed.run_result.turns`. 왜 중첩 필드를 지나야 하는지 주석으로 남겼다.

단언 자체는 그대로다 — 이 테스트가 재는 것(트레이스 참조 전달, 벤더 누적 턴 73)은 바뀌지 않았고 필드 경로만 바뀌었다.

## 검증

```
dune build @check                                             OK (트리 전체)
dune build @test/runtest-test_keeper_antigravity_runtime      1 test, OK
```

RFC-WAIVED: 테스트 한 파일의 필드 접근 경로 수정이다. credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 어느 것도 건드리지 않는다.

WORKAROUND-WAIVED: 증상 억제가 아니라 타입이 요구하는 정확한 경로로 읽는 수정이다. 단언을 약화하거나 우회하지 않았다.

Co-Authored-By: Claude Opus 5 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrQctrmuNds4HVg9sHgicM
