### PR TITLE
fix(test): read the resumed turn through its run_result (main does not compile)

### DIFF
--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -350,6 +350,7 @@ let test_keeper_projects_mcp_tool_and_settles () =
                     with
                     | Error error -> fail (Agent_core.Error.to_string error)
                     | Ok resumed ->
+                      let resumed = resumed.Keeper_turn_driver.run_result in
                       observed_trace_ref := resumed.trace_ref;
                       check int
                         "provider cumulative turn count"


### PR DESCRIPTION
## main 이 컴파일되지 않는다

```
$ dune build --root . @check
File "test/test_keeper_antigravity_runtime.ml", line 353, characters 52-61:
353 |   observed_trace_ref := resumed.trace_ref;
                                      ^^^^^^^^^
Error: This expression has type Keeper_turn_driver.named_run_result
       There is no field trace_ref within type Keeper_turn_driver.named_run_result
```

`Keeper_turn_driver.run_named` 은 `named_run_result` 를 돌려준다. 이건 `Runtime_agent.run_result` 를 **감싼** 레코드지 그 자체가 아니다:

```ocaml
type named_run_result =
  { run_result : Runtime_agent.run_result
  ; selected_runtime_id : string
  ; selected_max_context : int
  ; checkpoint_owner : Runtime_execution.checkpoint_owner
  }
```

resume 분기가 `resumed.trace_ref` 와 `resumed.turns` 를 래퍼에서 바로 읽는다. 두 필드 모두 `run_result` 에 있다.

15줄 위 fresh-turn 분기는 이미 올바르게 푼다:

```ocaml
| Ok selected ->
  let turn = selected.Keeper_turn_driver.run_result in
  observed_trace_ref := turn.trace_ref;
```

이 PR 은 resume 분기를 같은 형태로 맞춘다. 한 줄 추가.

## 왜 아무도 못 봤나

`mark_turn_started` 가 `~turn_count` 를 받게 된 #28045 이후 **완료된 컴파일이 main 에서 한 번도 돌지 않았다.**

| commit | Build and Test |
|---|---|
| #28045 `6d2a0f8dee` | 테스트 픽스처 2개가 깨진 채 머지 |
| #28061 `6f175778b4` | **cancelled** |
| #28062 `9d14a38b99` | 미완 |

`6f175778b4` 의 체크런 전수를 보면 green 은 전부 lint/meta 잡(`Lint`, `Meta Guards`, `ocamlformat-check`, `TLA+`, `Shell IR Consumption Ratchet`, `OCaml Structure Ratchet`, `Health`, `Detect Changed Surfaces`)이고 `Build and Test` 와 `Dashboard` 는 `cancelled` 다. 부분 rollup 이 green 으로 보였다.

## 검증

```
dune build --root . @check                                  EXIT=0   (이 한 줄이 유일한 컴파일 에러였다)
dune build --root . --force @test/runtest-test_keeper_antigravity_runtime
  [OK]  lifecycle  0  projects MCP tool and settles.
  Test Successful in 2.619s. 1 test run.
```

resume 분기는 그 단일 테스트 안에 중첩돼 있으므로 통과가 곧 이 경로의 실행 증명이다.

RFC-WAIVED: 테스트 파일 한 줄 수정. `workflow-pr.md` §11 의 RFC 필수 subsystem 에 해당하지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
