### PR TITLE
test(keeper): unwrap Antigravity named run result

### DIFF
--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -349,7 +349,8 @@ let test_keeper_projects_mcp_tool_and_settles () =
                         ()
                     with
                     | Error error -> fail (Agent_core.Error.to_string error)
-                    | Ok resumed ->
+                    | Ok selected ->
+                      let resumed = selected.Keeper_turn_driver.run_result in
                       observed_trace_ref := resumed.trace_ref;
                       check int
                         "provider cumulative turn count"


### PR DESCRIPTION
## Problem

Main CI after #28049 failed while compiling test_keeper_antigravity_runtime.ml. The second Antigravity resume call still treated Keeper_turn_driver.run_named as Runtime_agent.run_result even though the API now returns named_run_result.

## Change

Unwrap selected.run_result before reading trace_ref and turns, matching the first invocation in the same fixture and the other direct run_named callers.

## Verification

- git diff --check
- audited every direct Keeper_turn_driver.run_named and Driver.run_named OCaml call site
- local build and tests intentionally not run per operator request; GitHub CI is the build and test authority

## Evidence

Main CI run 31409800491, Build and Test job 93525077039: test/test_keeper_antigravity_runtime.ml:353 attempted resumed.trace_ref on Keeper_turn_driver.named_run_result.