### PR TITLE
fix(claude-code): answer every control_request, including MCP notifications

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -439,19 +439,29 @@ let handle_control_request
           Protocol_error { stage; detail })
       in
       if dispatch.tool_called then incr tool_call_count;
-      (match dispatch.response with
-       | None -> Ok ()
-       | Some mcp_response ->
-         send_control_response
-           io
-           ~control_phase
-           ~stage:"control success response"
-           ~tool_effect_attempted:dispatch.tool_called
-           (fun () ->
-             send_control_success
-               io
-               ~request_id
-               (`Assoc [ "mcp_response", mcp_response ])))
+      (* The control channel and the MCP payload have different reply rules and
+         the two must not be conflated. An MCP notification carries no id and so
+         produces no JSON-RPC response, but the client wraps *every* MCP message
+         in a control_request that carries a [request_id] and blocks until that
+         id is answered. Returning without sending anything therefore parks the
+         client forever: it waits for the control_response, MASC waits for the
+         next message, and the turn ends only when the turn timeout fires.
+
+         Measured against the real client (2.1.226): with the notification
+         unanswered the turn stops after `notifications/initialized` and never
+         reaches a result; answering it with an empty payload lets the same turn
+         run tools/list -> init -> result in 5.2s. Every other variable held. *)
+      let control_payload =
+        match dispatch.response with
+        | Some mcp_response -> `Assoc [ "mcp_response", mcp_response ]
+        | None -> `Assoc []
+      in
+      send_control_response
+        io
+        ~control_phase
+        ~stage:"control success response"
+        ~tool_effect_attempted:dispatch.tool_called
+        (fun () -> send_control_success io ~request_id control_payload)
   | unsupported ->
     let* () =
       send_control_response

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -350,11 +350,17 @@ let test_keeper_projects_mcp_tool_and_settles () =
                     with
                     | Error error -> fail (Agent_core.Error.to_string error)
                     | Ok resumed ->
-                      observed_trace_ref := resumed.trace_ref;
+                      (* #28049 made run_named return named_run_result, which
+                         carries the turn's run_result plus the runtime that
+                         actually executed it. #28062 was written against the
+                         previous bare run_result and the two merged in that
+                         order, so these two reads have to go through the
+                         nested field. *)
+                      observed_trace_ref := resumed.run_result.trace_ref;
                       check int
                         "provider cumulative turn count"
                         73
-                        resumed.turns))));
+                        resumed.run_result.turns))));
       check string
         "tool arguments"
         {|{"marker":"from-antigravity"}|}

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -336,10 +336,28 @@ let test_dynamic_tool_callback () =
           (Yojson.Safe.to_string !observed_input))
 ;;
 
-let test_mcp_notification_has_no_response () =
+(* This test used to assert the opposite: that an MCP notification draws no
+   control_response, on the reasoning that a JSON-RPC notification carries no id
+   and so needs no reply. That conflates two layers. The reply rule that binds
+   here belongs to the control channel, not to the MCP payload: the client wraps
+   every MCP message in a control_request carrying a [request_id] and blocks
+   until that id comes back.
+
+   The old fixture could not see the difference because it moved on without
+   waiting — a fake client that never blocks cannot observe that the real one
+   does. Measured against Claude Code 2.1.226 with every other variable held:
+   with the notification unanswered the turn stops after
+   notifications/initialized and never reaches a result (90s, 4 events); with it
+   answered the same turn runs tools/list -> init -> result in 5.2s. On the live
+   fleet that stall was every claude_code keeper turn — 458 attempts, 0
+   completions over 8 days (#28060).
+
+   Emit_and_expect_request_id makes the fixture wait and exit 96 unless the
+   response carries the id, so this now fails if the ack is dropped again. *)
+let test_mcp_notification_is_acknowledged_on_the_control_channel () =
   with_fixture
     [ Emit_and_read mcp_initialize
-    ; Emit mcp_initialized_notification
+    ; Emit_and_expect_request_id (mcp_initialized_notification, "mcp-notify-1")
     ; Emit_and_expect_request_id
         (mcp_list_after_notification, "mcp-list-after-notification")
     ; Emit assistant
@@ -808,9 +826,9 @@ let () =
             `Quick
             test_shared_mcp_protocol_is_negotiated
         ; test_case
-            "notification has no response"
+            "notification is acknowledged on the control channel"
             `Quick
-            test_mcp_notification_has_no_response
+            test_mcp_notification_is_acknowledged_on_the_control_channel
         ; test_case
             "unsupported control request fails closed"
             `Quick


### PR DESCRIPTION
Closes #28060.

## 문제

`claude_code` 구독 런타임으로 **키퍼 턴이 완주한 적이 없다.** 8일 관측 창에서 458회 시도, 완주 **0회**.

| provider | attempt | completed | 완주율 |
|---|---:|---:|---:|
| ollama_cloud | 979 | 957 | 97.8% |
| glm-coding | 6,153 | 5,686 | 92.4% |
| codex_subscription | 4,052 | 1,313 | 32.4% |
| **claude_code** | **458** | **0** | **0%** |

턴은 출력을 전혀 내지 않고 프로세스는 CPU 1.2% (7.18s / 576s) 로 앉아 있다가 턴 타임아웃에 죽었다. "느린 모델" 로 보였지 정지로 보이지 않았다. `analyst` 는 `turn-timeout-s = 900` 에서도 900.000s 로 똑같이 죽으므로 시간 문제가 아니다.

## 원인 — 두 계층의 응답 규칙을 섞었다

`handle_control_request` 의 `| None -> Ok ()`:

- **MCP 페이로드 규칙**: notification 은 id 가 없으므로 JSON-RPC 응답이 없다. 맞다.
- **control 채널 규칙**: 클라이언트는 *모든* MCP 메시지를 `request_id` 가 붙은 `control_request` 로 감싸고 **그 id 가 돌아올 때까지 블록한다.**

`notifications/initialized` 이후 양쪽이 대기한다 — 클라이언트는 control_response 를, MASC 는 다음 메시지를. 턴 타임아웃 말고는 이 교착을 끊는 것이 없다.

## 실측

키퍼가 실제로 쓰는 argv 를 프로세스에서 그대로 뜨고, 환경은 `runtime_claude_code.ml` 의 `subscription_only_environment` 허용 목록을 썼다. 변수는 **알림 control_request 에 응답하는가** 하나만 바꿨다.

| 셀 | 결과 |
|---|---|
| 알림 **미응답** (오늘의 MASC) | result 도달 못 함, 4 이벤트, 90s 예산 소진 — `notifications/initialized` 에서 정지 |
| 알림 **응답** (대조군) | `tools/list` → `system/init` → assistant → **`result/success` 5.2s** |

먼저 세운 컨텍스트 크기 가설은 **반증됐다**: 같은 클라이언트가 700 KB 프롬프트를 18.6s 에 답한다. `-p` 32바이트 대조군은 14.1s.

## 왜 기존 테스트가 못 잡았나

`test_runtime_claude_code.ml` 에 `test_mcp_notification_has_no_response` 가 있었고 **정반대를 단언**했다. 픽스처가 응답을 기다리지 않고 그냥 다음으로 넘어가기 때문에 통과했다 — **블록하지 않는 가짜 클라이언트는 진짜 클라이언트가 블록한다는 사실을 볼 수 없다.**

테스트를 뒤집어 `Emit_and_expect_request_id` 로 응답을 요구하게 했다. 이제:

```
수정 있음:  18 tests, Test Successful
수정 없음:  [FAIL] mcp 5 notification is acknowledged on the control channel
            FAIL Claude Code turn timed out after 2.000s
```

실패 문구가 라이브와 같다 — 픽스처가 프로덕션 교착을 2초에 재현한다.

## 검증

```
dune build @check                                   OK (트리 전체)
dune build @test/runtest-test_runtime_claude_code   18 tests, OK
```

## 머지 순서

이 PR 은 **#28066 의 커밋(`fix(test): read the run result through named_run_result`)을 포함한다.** `origin/main` (9d14a38b99) 이 지금 컴파일되지 않아서, 그것 없이는 이 PR 의 CI 도 초록이 될 수 없다.

두 PR 은 **순서에 무관하다**: #28066 이 먼저 머지되면 이 브랜치는 리베이스로 그 커밋을 떨군다. 이 PR 이 먼저 머지되면 #28066 이 no-op 이 되어 닫힌다. 어느 쪽이든 손해가 없다.

RFC-WAIVED: 변경 범위가 claude_code official-client 어댑터의 control 채널 응답 한 곳과 그 테스트다. credential / identity / repo_manager / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 어느 것도 건드리지 않는다.

WORKAROUND-WAIVED: 증상 억제가 아니라 프로토콜 계약을 지키는 수정이다. cap/cooldown/dedup/repair 없음, 문자열 분류기 없음, catch-all 추가 없음, 텔레메트리 추가 없음. 재시도를 늘리거나 타임아웃을 키우는 방향이 아니라 교착 자체를 없앤다.

Co-Authored-By: Claude Opus 5 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrQctrmuNds4HVg9sHgicM
