### PR TITLE
fix(runtime): make Antigravity stdin cleanup cancellation-safe

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -645,9 +645,11 @@ let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
     Eio.Flow.close stdout_w;
     Eio.Flow.close stderr_w;
     Eio.Fiber.fork ~sw (fun () ->
-      Fun.protect
-        ~finally:(fun () -> Eio.Flow.close stdin_w)
-        (fun () -> Eio.Flow.copy_string prompt stdin_w));
+      Eio.Flow.copy_string prompt stdin_w;
+      (* A successful prompt write must deliver EOF to the CLI. If the copy
+         raises, the failed fiber cancels [sw] and the pipe's switch-owned
+         release handler closes [stdin_w]. *)
+      Eio.Flow.close stdin_w);
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
     let process_settled = ref false in

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -350,17 +350,12 @@ let test_keeper_projects_mcp_tool_and_settles () =
                     with
                     | Error error -> fail (Agent_core.Error.to_string error)
                     | Ok resumed ->
-                      (* #28049 made run_named return named_run_result, which
-                         carries the turn's run_result plus the runtime that
-                         actually executed it. #28062 was written against the
-                         previous bare run_result and the two merged in that
-                         order, so these two reads have to go through the
-                         nested field. *)
-                      observed_trace_ref := resumed.run_result.trace_ref;
+                      let resumed = resumed.Keeper_turn_driver.run_result in
+                      observed_trace_ref := resumed.trace_ref;
                       check int
                         "provider cumulative turn count"
                         73
-                        resumed.run_result.turns))));
+                        resumed.turns))));
       check string
         "tool arguments"
         {|{"marker":"from-antigravity"}|}


### PR DESCRIPTION
## Summary

- close Antigravity stdin only after the prompt copy succeeds; switch-owned cleanup handles failed writer fibers
- keep the cumulative-turn assertion on the current named run-result contract
- remove historical merge-order narration from the focused runtime test

## Root cause

The stdin transport change put an Eio close operation inside a Fun.protect finalizer, which the blocking cancellation-safety lint rejects. The cumulative-turn test also read the wrapper result as though it were the nested runtime result; current main fixed that compile error but retained historical repair narration.

## Validation

- ocamlformat check: pass
- git diff check: pass
- Fun.protect finalizer guard and self-test: pass
- focused Antigravity Dune targets: pending because unrelated bare Dune processes are holding the machine-wide build boundary; the wrapper correctly exits 75 instead of bypassing it
