### PR TITLE
fix(dashboard): 백엔드가 내보내는 health 토큰 3종에 한국어 라벨 — default 가 영어 원문을 노출하고 있었다

### DIFF
--- a/dashboard/src/lib/status-label.test.ts
+++ b/dashboard/src/lib/status-label.test.ts
@@ -12,6 +12,16 @@ describe('statusLabel', () => {
     expect(statusLabel('running')).toBe('진행 중')
   })
   it('maps paused', () => { expect(statusLabel('paused')).toBe('일시정지') })
+  // These three reach the surface from types/health_status.ml and
+  // keeper/keeper_status_runtime.ml. The default arm returns the wire token
+  // unchanged, so a missing case is not a missing label — it is the English
+  // token printed inside a Korean surface (#27165). The expectations are
+  // literals: comparing against statusLabel's own output would pass either way.
+  it('maps health tokens the backend emits', () => {
+    expect(statusLabel('warming')).toBe('예열 중')
+    expect(statusLabel('snapshot_not_ready')).toBe('스냅샷 준비 안 됨')
+    expect(statusLabel('zombie')).toBe('좀비')
+  })
   it('maps error variants', () => {
     expect(statusLabel('error')).toBe('오류')
     expect(statusLabel('failed')).toBe('오류')

--- a/dashboard/src/lib/status-label.ts
+++ b/dashboard/src/lib/status-label.ts
@@ -100,6 +100,16 @@ export function statusLabel(value?: string | null): string {
       return '미리보기'
     case 'captured':
       return '기록됨'
+    // Emitted by types/health_status.ml (to_string) and
+    // keeper/keeper_status_runtime.ml (keeper_health_to_string). Without a case
+    // the default below returns the wire token, so a Korean surface rendered
+    // "warming" and "zombie" verbatim (#27165).
+    case 'warming':
+      return '예열 중'
+    case 'snapshot_not_ready':
+      return '스냅샷 준비 안 됨'
+    case 'zombie':
+      return '좀비'
     case 'unknown':
     case '':
       return UNKNOWN_STATUS_LABEL


### PR DESCRIPTION
## 무엇을

백엔드가 내보내는 health 토큰 3종에 한국어 라벨을 붙입니다. `#27165` 의 "의도된 `default` 뒤의 미번역" 부류 중 확인된 것들입니다.

## 왜 — `default` 는 원문을 그대로 돌려줍니다

```ts
// dashboard/src/lib/status-label.ts
default:
  return value?.trim() || UNKNOWN_STATUS_LABEL
```

case 가 없으면 "알 수 없음"으로 표시되는 게 아니라 **wire 토큰이 그대로 화면에 나옵니다.** 한국어 UI 안에 영어가 박힙니다.

확인한 3종:

| 토큰 | 출처 | case |
|---|---|---|
| `warming` | `lib/types/health_status.ml:30` | **0건** |
| `snapshot_not_ready` | `lib/types/health_status.ml:31` | **0건** |
| `zombie` | `lib/keeper/keeper_status_runtime.ml` | **0건** |

## `timeout` 은 손대지 않았습니다

이슈가 함께 지목했지만 **백엔드가 그것을 status 로 내보내는지 확인하지 못했습니다** — 에러 종류일 수 있습니다. 도착하지 않을 값에 라벨을 추측해 넣으면 아무도 실행하지 않는 줄이 하나 늘어납니다.

## 검증

```
$ npx vitest run src/lib/status-label.test.ts
Test Files  1 passed (1)
     Tests  17 passed (17)
```

기대값을 **리터럴**로 썼습니다 — `statusLabel` 을 양쪽에 쓰면 함수가 무엇을 반환하든 통과하는 항등식이 됩니다.

**뮤테이션**: `'warming'` case 를 제거하면

```
AssertionError: expected 'warming' to be '예열 중'
Tests  1 failed | 16 passed (17)
```

**이슈가 보고한 증상(영어 토큰이 그대로 노출)이 실패 메시지로 재현됩니다.**

## 이슈의 나머지 부분

`#27165` 는 15쌍의 미커버 중 이 부류를 다루고, 논리 결함 1건은 `#27163` 으로 분리돼 있습니다. 이 PR 은 확인된 3종만 닫으므로 이슈 전체를 닫지 않습니다.

RFC-WAIVED: 대시보드 라벨 3개 추가. 동작·게이트·기본값 변경 없으며 `default` 분기는 그대로 유지.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
