### PR TITLE
refactor(server): drop record fields that are never mutated

### DIFF
--- a/lib/server/lsp_process_manager.ml
+++ b/lib/server/lsp_process_manager.ml
@@ -12,7 +12,6 @@ type lsp_process =
   ; stdin_w : [ Eio.Flow.sink_ty | Eio.Resource.close_ty ] Eio.Std.r
   ; stdout_r : [ Eio.Flow.source_ty | Eio.Resource.close_ty ] Eio.Std.r
   ; stderr_r : [ Eio.Flow.source_ty | Eio.Resource.close_ty ] Eio.Std.r
-  ; mutable next_id : int
   }
 
 type spawn_error =
@@ -199,7 +198,7 @@ let spawn ~sw ~lang_id ~workspace_root (proc_mgr : Eio_unix.Process.mgr_ty Eio.R
               "LSP %s stderr reader ended: %s"
               lang_id
               (Printexc.to_string exn));
-        Ok { lang_id; proc; stdin_w; stdout_r; stderr_r; next_id = 1 }
+        Ok { lang_id; proc; stdin_w; stdout_r; stderr_r }
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn -> Error (Process_error (Printexc.to_string exn)))

--- a/lib/server/lsp_process_manager.mli
+++ b/lib/server/lsp_process_manager.mli
@@ -10,7 +10,6 @@ type lsp_process = {
   stdin_w : [ Eio.Flow.sink_ty | Eio.Resource.close_ty ] Eio.Std.r;
   stdout_r : [ Eio.Flow.source_ty | Eio.Resource.close_ty ] Eio.Std.r;
   stderr_r : [ Eio.Flow.source_ty | Eio.Resource.close_ty ] Eio.Std.r;
-  mutable next_id : int;
 }
 
 type spawn_error =

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -30,8 +30,8 @@ type runtime_manifest_scan =
   ; mutable latest_provider_lane_decision : Yojson.Safe.t option
   ; mutable latest_provider_lane_row : Keeper_runtime_manifest.t option
   ; mutable latest_pre_dispatch_blocked_row : Keeper_runtime_manifest.t option
-  ; mutable payload_role_counts : (string, int) Hashtbl.t
-  ; mutable source_clock_counts : (string, int) Hashtbl.t
+  ; payload_role_counts : (string, int) Hashtbl.t
+  ; source_clock_counts : (string, int) Hashtbl.t
   ; mutable context_injected_count : int
   ; mutable context_compacted_event_count : int
   ; mutable provider_started_count : int

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
@@ -28,8 +28,8 @@ type runtime_manifest_scan =
   ; mutable latest_provider_lane_decision : Yojson.Safe.t option
   ; mutable latest_provider_lane_row : Keeper_runtime_manifest.t option
   ; mutable latest_pre_dispatch_blocked_row : Keeper_runtime_manifest.t option
-  ; mutable payload_role_counts : (string, int) Hashtbl.t
-  ; mutable source_clock_counts : (string, int) Hashtbl.t
+  ; payload_role_counts : (string, int) Hashtbl.t
+  ; source_clock_counts : (string, int) Hashtbl.t
   ; mutable context_injected_count : int
   ; mutable context_compacted_event_count : int
   ; mutable provider_started_count : int

--- a/test/test_lsp_process_manager.ml
+++ b/test/test_lsp_process_manager.ml
@@ -193,7 +193,6 @@ let test_shutdown_signals_child_and_closes_held_pipes () =
     ; stdin_w
     ; stdout_r
     ; stderr_r
-    ; next_id = 1
     }
   in
   Lsp_process_manager.shutdown lsp_proc;


### PR DESCRIPTION
## 목표

`mutable`로 선언됐지만 어디서도 대입되지 않는 레코드 필드를 제거한다. OCaml warning 69의 "never mutated"와 동일한 판정을 전수 계산해서 나온 결과다.

## 판정 방법

`lib/` 전체에서 `mutable <name> :` 형태로 선언된 필드명 203개를 뽑고, `lib bin test` 전체에서 `<-` 대입 대상이 되는 필드명 238개를 뽑아 차집합을 구했다. 줄바꿈된 대입(`acc.f\n  <- v`)을 놓치는 줄 단위 정규식 때문에 1차 결과 11개 중 4개(`evict_failure_count_total`, `prompt_blocks`, `tool_surface`, `trace_completed`)가 오탐이었고, multiline 재검사로 제외했다. 남은 것 중 실제 선언이 존재하는 3개 필드가 이 PR의 범위다.

레코드 필드 변이 문법은 `<-` 하나뿐이므로, 필드명이 대입 대상으로 한 번도 등장하지 않으면 그 필드는 확실히 변이되지 않는다.

## 변경

### 1. `lsp_process_manager`: 죽은 필드 `next_id` 제거

`mutable next_id : int`는 생성 시 `1`이 들어가고 그 뒤로 읽기 0건, 증가 0건이다. `lib/`와 `test/` 전체에서 `next_id` 등장 지점은 선언 2곳(`.ml`/`.mli`)과 생성 2곳(`lsp_process_manager.ml:202`, `test_lsp_process_manager.ml:196`) 뿐이다.

JSON-RPC 요청 id 할당기의 형태를 하고 있으나 할당기로 쓰이지 않는다. 공개 `.mli`에 남아 있으면 이후 작업자가 증가 없이 읽어 쓸 수 있다.

### 2. `server_dashboard_http_keeper_runtime_manifest_scan`: 불필요한 `mutable` 2개 제거

`payload_role_counts` / `source_clock_counts`는 `(string, int) Hashtbl.t`다. 테이블 내용은 `Hashtbl.replace`로 바뀌지만 필드 자체는 재대입되지 않는다. `mutable`을 떼면 컴파일러가 재대입을 금지한다.

이 레코드의 29개 mutable 필드에 대한 `<-` 쓰기 27건은 전부 소유 모듈 내부이고 외부 쓰기는 0건이다. 나머지 필드는 실제로 재대입되므로 건드리지 않았다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일한 명령)

## 범위 밖

`.mli`에 노출된 mutable 필드는 저장소 전체에 225개(전체 549개 선언 중 41%)다. 이 PR은 그중 "변이되지 않는" 것만 다룬다. 노출 자체를 줄이려면 타입 추상화가 필요하고 소비자 8개 모듈이 필드를 읽으므로 별도 RFC 범위다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
