### PR TITLE
fix(runtime): 실패한 Claude Code 턴에서 provider 사유를 버리지 않는다 — api_status=400 의 원인이 사라지고 있었다

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -667,15 +667,26 @@ let parse_result ~expected_session_id ~rate_limit fields =
     then Error (Quota_blocked { api_error_status; rate_limit })
     else if is_error
     then
+      (* [result] is the one field on this frame that says why the turn failed,
+         and it was parsed and dropped: a live keeper reported
+         "terminal subtype=success api_status=400" eleven times with no way to
+         tell a context overflow from anything else that returns 400 (#28071).
+         The 429 branch above already proves a status code can carry a typed
+         decision; until 400 gets the same treatment, the operator needs the
+         provider's own sentence. *)
       Error
         (Turn_failed
            (Printf.sprintf
-              "terminal subtype=%s api_status=%s"
+              "terminal subtype=%s api_status=%s%s"
               subtype
               (Option.fold
                  ~none:"unknown"
                  ~some:string_of_int
-                 api_error_status)))
+                 api_error_status)
+              (match result with
+               | Some detail when String.trim detail <> "" ->
+                 ": " ^ String.trim detail
+               | Some _ | None -> "")))
     else if subtype <> "success"
     then Error (Turn_failed (Printf.sprintf "terminal subtype=%s" subtype))
     else Ok (turn_id, result)

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -207,6 +207,34 @@ let quota_result_with_success_flag =
   {|{"type":"result","subtype":"success","is_error":false,"session_id":"__SESSION__","uuid":"turn-quota-flag-1","result":"must not settle","api_error_status":null}|}
 ;;
 
+let error_400_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-1","result":"prompt is too long: 250000 tokens > 200000 maximum","api_error_status":400}|}
+;;
+
+(* A live keeper reported "terminal subtype=success api_status=400" eleven times
+   in fifteen minutes with no way to tell a context overflow from anything else
+   that returns 400. The frame carried the reason in [result] and the error path
+   parsed it and dropped it (#28071). The expectation is a substring of the
+   provider's own sentence, not a re-render of the format string, so it fails if
+   the field stops being carried. *)
+let test_terminal_error_carries_the_provider_reason () =
+  with_fixture [ Emit error_400_result ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Turn_failed detail) ->
+      check
+        bool
+        "provider reason survives into the typed failure"
+        true
+        (Astring.String.is_infix ~affix:"prompt is too long" detail);
+      check
+        bool
+        "status code is still reported"
+        true
+        (Astring.String.is_infix ~affix:"api_status=400" detail)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "an is_error terminal was reported as completion")
+;;
+
 let test_quota_is_structurally_classified () =
   with_fixture [ Emit rate_limit_rejected; Emit quota_result ] (fun path ->
     match run_fixture path with
@@ -797,6 +825,10 @@ let () =
         ] )
     ; ( "terminal"
       , [ test_case
+            "terminal error carries the provider reason"
+            `Quick
+            test_terminal_error_carries_the_provider_reason
+        ; test_case
             "quota is structurally classified"
             `Quick
             test_quota_is_structurally_classified


### PR DESCRIPTION
## 무엇을

실패한 Claude Code 턴에서 **provider 가 보낸 사유**를 버리지 않고 에러에 실어 보냅니다.

## 왜 — 라이브에서 진단이 불가능합니다

`analyst` 가 15분간 11번 이렇게 실패했습니다:

```
Provider 'claude_code' reported an error (turn_failed):
  terminal subtype=success api_status=400
```

**왜 400 인지가 없습니다.** 컨텍스트 초과인지, 잘못된 요청인지, 다른 무엇인지 구별할 방법이 없습니다.

그런데 프레임은 사유를 싣고 있었습니다:

```ocaml
(* runtime_claude_code.ml:652-657 — 파싱은 한다 *)
let result =
  match List.assoc_opt "result" fields with
  | Some (`String value) -> Ok (Some value)
  | …

(* :668-678 — 에러 분기가 쓰지 않는다 *)
else if is_error
then Error (Turn_failed (Printf.sprintf
       "terminal subtype=%s api_status=%s" subtype …))
```

**파싱하고 버립니다.**

## 429 는 타입을 받는데 400 은 못 받습니다

바로 위 분기가 그 대비를 보여줍니다:

```ocaml
if structurally_quota_blocked                       (* api_error_status = 429 *)
then Error (Quota_blocked { api_error_status; rate_limit })   (* ← 타입 변형 *)
```

**상태 코드로 타입 분기하는 것이 이미 가능하고 실제로 하고 있습니다.** 400 은 아직 그 대우를 못 받고, 그때까지는 운영자에게 provider 의 문장이 필요합니다.

이 PR 은 400 을 타입으로 승격하지 **않습니다** — 무엇을 승격할지 정하려면 먼저 그 400 들이 무엇인지 봐야 하고, 지금은 볼 수가 없습니다.

## 변경

```ocaml
"terminal subtype=%s api_status=%s%s"
  subtype
  (… api_error_status)
  (match result with
   | Some detail when String.trim detail <> "" -> ": " ^ String.trim detail
   | Some _ | None -> "")
```

빈 문자열·공백만 있는 경우는 붙이지 않습니다.

## 검증

```
$ dune build --root . @test/runtest-test_runtime_claude_code
Test Successful in 7.428s. 19 tests run.
```

새 테스트는 **provider 문장의 부분 문자열**을 단언합니다 — 포맷 문자열을 다시 렌더해 비교하면 함수가 무엇을 만들든 통과하는 항등식이 됩니다.

**뮤테이션**: `result` 를 다시 버리면

```
> [FAIL]  terminal  0  terminal error carries the provider re...
ASSERT provider reason survives into the typed failure
1 failure! in 5.523s. 19 tests run.
```

**소비자 스위트**:

```
test_runtime_claude_code          19/19  Successful
test_runtime_claude_code_config          Successful
test_keeper_claude_code_runtime    8/8   Successful  (exit=0, failure 0건)
```

## 남는 것

`#28071` 은 같은 형태를 codex 어댑터에서도 기록합니다(`turn_error_message` 가 `error` 객체의 `message` 외 전부를 버림). 이 PR 은 claude_code 쪽만 다룹니다.

RFC-WAIVED: 에러 메시지에 이미 파싱된 필드를 포함. 분류·게이트·타입 변경 없음이며, 429 의 typed 경로는 그대로.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
