### PR TITLE
fix(dashboard): source Root keeper counts from the fleet projection

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -30,7 +30,7 @@ import type {
   TelemetryEntry,
   TelemetrySourceSummary,
 } from '../../api/dashboard'
-import { keepers, boardPosts, boardTotal, lastBoardRefreshAt } from '../../store'
+import { keepers, boardPosts, boardTotal, lastBoardRefreshAt, shellRuntimeResolution } from '../../store'
 import type { Goal } from '../../types/core'
 
 const overviewMocks = vi.hoisted(() => ({
@@ -626,7 +626,6 @@ describe('pickAttentionKeepers', () => {
 describe('computeOverviewStats', () => {
   it('returns zeroed stats when empty', () => {
     expect(computeOverviewStats([], [])).toEqual({
-      run: 0,
       att: 0,
       hot: 0,
       avgCtx: null,
@@ -636,16 +635,18 @@ describe('computeOverviewStats', () => {
     })
   })
 
-  it('counts running keepers and context pressure', () => {
+  it('counts roster totals and context pressure without a running count', () => {
     const keepers = [
       makeKeeper({ name: 'a', status: 'active', context_ratio: 0.9, total_turns: 10 }),
       makeKeeper({ name: 'b', status: 'offline', context_ratio: 0.5, total_turns: 5 }),
     ]
     const stats = computeOverviewStats(keepers, [])
-    expect(stats.run).toBe(1)
     expect(stats.total).toBe(2)
     expect(stats.hot).toBe(1)
     expect(stats.traces).toBe(15)
+    // Execution counts are not derivable from roster rows; they come from the
+    // runtime-health fleet projection instead.
+    expect('run' in stats).toBe(false)
   })
 
   it('counts tasks assigned to keepers', () => {
@@ -1021,6 +1022,74 @@ describe('Overview prototype surface', () => {
       '예약 HITL',
       '진행 심의',
     ])
+  })
+
+  it('shows keeper execution counts from the runtime-health fleet projection', () => {
+    keepers.value = [
+      makeKeeper({ name: 'a', status: 'active' }),
+      makeKeeper({ name: 'b', status: 'active' }),
+    ]
+    shellRuntimeResolution.value = {
+      fleet_safety: {
+        paused_keepers_health: { count: 1 },
+        keeper_fleet_safety: {
+          running_keeper_fiber_count: 4,
+          recovering_keeper_fiber_count: 3,
+          executable_keeper_fiber_count: 7,
+        },
+      },
+    } as never
+
+    const { container } = render(h(Overview, null))
+    // The roster holds 2 active-looking rows; the projection reports 4 running.
+    // The projection wins.
+    expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('4 / 2')
+    expect(container.querySelector('[data-testid="fleet-stat-running"] .v')?.textContent).toBe('4')
+    expect(container.querySelector('[data-testid="fleet-stat-recovering"] .v')?.textContent).toBe('3')
+    expect(container.querySelector('[data-testid="fleet-stat-paused"] .v')?.textContent).toBe('1')
+
+    keepers.value = []
+    shellRuntimeResolution.value = null
+  })
+
+  it('shows no keeper execution count when the fleet projection is missing', () => {
+    // Three rows that the roster heuristic would have counted as running. With
+    // no fleet projection the surface must say it does not know, not print an
+    // estimate derived from these status strings.
+    keepers.value = [
+      makeKeeper({ name: 'a', status: 'active' }),
+      makeKeeper({ name: 'b', status: 'busy' }),
+      makeKeeper({ name: 'c', status: 'idle' }),
+    ]
+    shellRuntimeResolution.value = null
+
+    const { container } = render(h(Overview, null))
+    expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('— / 3')
+    expect(container.querySelector('[data-testid="fleet-stat-running"] .v')?.textContent).toBe('—')
+    expect(container.querySelector('[data-testid="fleet-stat-recovering"] .v')?.textContent).toBe('—')
+    expect(container.querySelector('[data-testid="fleet-stat-paused"] .v')?.textContent).toBe('—')
+
+    keepers.value = []
+  })
+
+  it('renders a projection-reported zero as zero, not as unknown', () => {
+    keepers.value = [makeKeeper({ name: 'a', status: 'active' })]
+    shellRuntimeResolution.value = {
+      fleet_safety: {
+        keeper_fleet_safety: {
+          running_keeper_fiber_count: 0,
+          recovering_keeper_fiber_count: 0,
+          paused_keeper_count: 0,
+        },
+      },
+    } as never
+
+    const { container } = render(h(Overview, null))
+    expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('0 / 1')
+    expect(container.querySelector('[data-testid="fleet-stat-running"] .v')?.textContent).toBe('0')
+
+    keepers.value = []
+    shellRuntimeResolution.value = null
   })
 
   it('marks deep-link KPI cells as buttons', () => {

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -19,7 +19,7 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import { AgentAvatar } from './agent-avatar'
 import { SCHED_TERMINAL_SET } from '../v2/schedule-constants'
-import { tasks, keepers, boardPosts, boardTotal, lastBoardRefreshAt, goals, fusionRuns } from '../../store'
+import { tasks, keepers, boardPosts, boardTotal, lastBoardRefreshAt, goals, fusionRuns, shellRuntimeResolution } from '../../store'
 import type { Agent, Task, Keeper, Message, BoardPost, Goal, KeeperRuntimeBlockerClass } from '../../types/core'
 import type {
   DashboardScheduledAutomation,
@@ -41,7 +41,11 @@ import {
   type KeeperPhaseToken,
 } from '../../lib/fleet-tone'
 import { UNKNOWN_STATUS_LABEL } from '../../lib/format-string'
-import { keeperRowLooksRunning } from '../../runtime-counts'
+import {
+  keeperRowLooksRunning,
+  resolveKeeperFleetExecutionCounts,
+  type KeeperFleetExecutionCounts,
+} from '../../runtime-counts'
 import { createAsyncResource, type AsyncResource, type AsyncState } from '../../lib/async-state'
 import { navigate } from '../../router'
 import { gateData } from '../gate-signals'
@@ -127,8 +131,12 @@ export function pickAttentionKeepers(keeperList: readonly Keeper[]): Keeper[] {
 
 // ─── KPI stats ───────────────────────────────────────────────────────────────
 
+/** Roster-derived counts. Keeper *execution* counts deliberately live outside
+ *  this type: they come from the runtime-health fleet projection via
+ *  {!resolveKeeperFleetExecutionCounts}, because a roster row's status string
+ *  describes what the row last recorded, not whether a keeper fiber is running
+ *  right now. */
 export interface OverviewStats {
-  run: number
   att: number
   hot: number
   avgCtx: number | null
@@ -147,7 +155,6 @@ export function keeperRuntimeLabel(keeper: Keeper): string {
 
 export function computeOverviewStats(keeperList: readonly Keeper[], taskList: readonly Task[]): OverviewStats {
   const total = keeperList.length
-  const run = keeperList.filter(keeperRowLooksRunning).length
   const att = pickAttentionKeepers(keeperList).length
   const hot = keeperList.filter(k => (k.context_ratio ?? 0) >= 0.85).length
   const traces = keeperList.reduce((sum, k) => sum + keeperTraceCount(k), 0)
@@ -155,12 +162,22 @@ export function computeOverviewStats(keeperList: readonly Keeper[], taskList: re
   const keeperNames = new Set(keeperList.map(k => k.name.toLowerCase()))
   const tasks = taskList.filter(t => t.assignee && keeperNames.has(t.assignee.toLowerCase())).length
 
+  // Still roster-scoped: context_ratio is only carried on roster rows, and the
+  // fleet projection reports running keepers as a count without the per-keeper
+  // ratios needed to average them.
   const liveCtx = keeperList.filter(k => keeperRowLooksRunning(k) && typeof k.context_ratio === 'number')
   const avgCtx = liveCtx.length
     ? Math.round(liveCtx.reduce((sum, k) => sum + (k.context_ratio ?? 0), 0) / liveCtx.length * 100)
     : null
 
-  return { run, att, hot, avgCtx, tasks, traces, total }
+  return { att, hot, avgCtx, tasks, traces, total }
+}
+
+/** Renders a fleet execution count. `—` means the runtime-health fleet
+ *  projection did not report the number; a rendered `0` always means the
+ *  projection reported zero. */
+export function fleetCountText(value: number | null | undefined): string {
+  return typeof value === 'number' ? String(value) : '—'
 }
 
 // ─── Cross-surface digest (overview.jsx:71-92) ───────────────────────────────
@@ -1016,16 +1033,18 @@ function OverviewKpi({
 // its surface. Labels and `sub` separators are copied verbatim from the prototype.
 function OverviewKpiStrip({
   stats,
+  fleet,
   digest,
   approvalQueueState,
 }: {
   stats: OverviewStats
+  fleet: KeeperFleetExecutionCounts | null
   digest: OverviewDigest
   approvalQueueState: NonNullable<typeof gateData.value>['approval_queue_state'] | undefined
 }) {
   return html`
     <section class="ov-kpis v2-overview-kpis" aria-label="Cross-surface KPIs" data-testid="overview-kpis">
-      <${OverviewKpi} label="실행 중 keeper" value=${String(stats.run)} sub=${` / ${stats.total}`} tone="ok" testId="kpi-run" onClick=${() => navigate('monitoring')} />
+      <${OverviewKpi} label="실행 중 keeper" value=${fleetCountText(fleet?.running)} sub=${` / ${stats.total}`} tone=${fleet?.running != null ? 'ok' : undefined} testId="kpi-run" onClick=${() => navigate('monitoring')} />
       <${OverviewKpi} label="주의 필요" value=${String(stats.att)} tone=${stats.att > 0 ? 'bad' : undefined} testId="kpi-att" onClick=${() => navigate('monitoring')} />
       ${approvalQueueState && approvalQueueState.state !== 'ready'
         ? html`<${OverviewKpi}
@@ -1225,10 +1244,12 @@ function DomainCard({
 
 function OverviewDomainSection({
   stats,
+  fleet,
   digest,
   approvalQueueState,
 }: {
   stats: OverviewStats
+  fleet: KeeperFleetExecutionCounts | null
   digest: OverviewDigest
   approvalQueueState: NonNullable<typeof gateData.value>['approval_queue_state'] | undefined
 }) {
@@ -1436,7 +1457,9 @@ function OverviewDomainSection({
       <!-- FLEET summary · overview.jsx:252-260 -->
       <${DomainCard} title="Fleet 요약" linkLabel="Monitor" nav=${{ tab: 'monitoring' }} testId="domain-fleet">
         <div class="ov-fleet-sum">
-          <div class="ov-fleet-stat"><span class="v ok">${stats.run}</span><span class="k">실행</span></div>
+          <div class="ov-fleet-stat" data-testid="fleet-stat-running"><span class="v ok">${fleetCountText(fleet?.running)}</span><span class="k">실행</span></div>
+          <div class="ov-fleet-stat" data-testid="fleet-stat-recovering"><span class=${`v ${(fleet?.recovering ?? 0) > 0 ? 'warn' : ''}`}>${fleetCountText(fleet?.recovering)}</span><span class="k">복구</span></div>
+          <div class="ov-fleet-stat" data-testid="fleet-stat-paused"><span class="v">${fleetCountText(fleet?.paused)}</span><span class="k">일시정지</span></div>
           <div class="ov-fleet-stat"><span class="v warn">${stats.att}</span><span class="k">주의</span></div>
           <div class="ov-fleet-stat"><span class=${`v ${stats.hot > 0 ? 'bad' : ''}`}>${stats.hot}</span><span class="k">압박</span></div>
           <div class="ov-fleet-stat"><span class="v">${stats.total}</span><span class="k">전체</span></div>
@@ -1474,6 +1497,11 @@ export function Overview() {
     overviewFullHealthResource.state.value.status === 'loaded'
       ? overviewFullHealthResource.state.value.data.schedule_runner ?? null
       : null
+  // Keeper execution counts come from the runtime-health fleet projection the
+  // shell already holds — the same `keeper_fleet_safety_health_json` payload
+  // `/health?full=1` embeds, so reading it here adds no request.
+  const fleetSafety = shellRuntimeResolution.value?.fleet_safety ?? null
+  const fleet = useMemo(() => resolveKeeperFleetExecutionCounts(fleetSafety), [fleetSafety])
   const stats = useMemo(() => computeOverviewStats(keeperList, taskList), [keeperList, taskList])
   const digest = useMemo(
     () => computeOverviewDigest(openGateRequests, goalList, fusionList, scheduledAutomation, scheduleRunnerStatus),
@@ -1487,6 +1515,7 @@ export function Overview() {
         <${OverviewHeader} />
         <${OverviewKpiStrip}
           stats=${stats}
+          fleet=${fleet}
           digest=${digest}
           approvalQueueState=${approvalQueueState}
         />
@@ -1496,6 +1525,7 @@ export function Overview() {
         </div>
         <${OverviewDomainSection}
           stats=${stats}
+          fleet=${fleet}
           digest=${digest}
           approvalQueueState=${approvalQueueState}
         />

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -13,6 +13,7 @@ import {
   keeperDetailRows,
   runtimeHealthIsFresh,
   resolveRuntimeFleetSafetyCounts,
+  resolveKeeperFleetExecutionCounts,
   resolveRuntimeCounts,
   runtimeDetailRows,
   runtimeCountSourceLabel,
@@ -244,6 +245,51 @@ describe('resolveRuntimeCounts', () => {
       configured: { keepers: 13, totalRuntimes: 13, source: 'shell' },
       source: 'runtime-health',
     })
+  })
+
+  it('reports each keeper execution phase separately', () => {
+    const runtimeFleetSafety = {
+      keeper_fibers: 4,
+      paused_keepers: 9,
+      paused_keepers_health: { count: 1 },
+      keeper_fleet_safety: {
+        running_keeper_fiber_count: 4,
+        recovering_keeper_fiber_count: 3,
+        executable_keeper_fiber_count: 7,
+        paused_keeper_count: 5,
+      },
+    } as any
+
+    expect(resolveKeeperFleetExecutionCounts(runtimeFleetSafety)).toEqual({
+      running: 4,
+      recovering: 3,
+      executable: 7,
+      paused: 1,
+    })
+  })
+
+  it('keeps a reported zero distinct from an unreported count', () => {
+    const runtimeFleetSafety = {
+      keeper_fleet_safety: {
+        running_keeper_fiber_count: 0,
+        executable_keeper_fiber_count: 2,
+      },
+    } as any
+
+    expect(resolveKeeperFleetExecutionCounts(runtimeFleetSafety)).toEqual({
+      running: 0,
+      recovering: null,
+      executable: 2,
+      paused: null,
+    })
+  })
+
+  it('returns null when no fleet projection is available', () => {
+    expect(resolveKeeperFleetExecutionCounts(null)).toBeNull()
+    expect(resolveKeeperFleetExecutionCounts(undefined)).toBeNull()
+    // keeper_fibers alone is a fiber gauge, not a per-phase projection: it must
+    // not be promoted into a running count.
+    expect(resolveKeeperFleetExecutionCounts({ keeper_fibers: 9 } as any)).toBeNull()
   })
 
   it('does not fall back to keeper_fibers when executable capacity is absent', () => {

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -156,6 +156,48 @@ export function resolveRuntimeFleetSafetyCounts(
   }
 }
 
+/** Keeper execution counts exactly as the runtime-health fleet projection
+ *  reports them. One producer backs every field here:
+ *  `keeper_fleet_safety_health_json` (server_routes_http_runtime_fleet_scan.ml),
+ *  which both `/health?full=1` and the shell `runtime_resolution` embed
+ *  verbatim.
+ *
+ *  A field is null when the server did not report it. Callers must render that
+ *  as unknown — collapsing it to 0 would present "we could not read the fleet"
+ *  as "the fleet is empty", which is the roster-estimate failure this type
+ *  exists to prevent. */
+export interface KeeperFleetExecutionCounts {
+  readonly running: number | null
+  readonly recovering: number | null
+  readonly executable: number | null
+  readonly paused: number | null
+}
+
+/** Returns null when no fleet projection is available at all — distinct from a
+ *  projection that reports zero, which is a fact the operator needs to see.
+ *
+ *  Unlike {!resolveRuntimeFleetSafetyCounts} this selector never substitutes a
+ *  count it did not receive, because its consumer (the Root surface) displays
+ *  the numbers directly instead of feeding a count-reconciliation chain. */
+export function resolveKeeperFleetExecutionCounts(
+  fleetSafety: DashboardFleetSafetyHealth | null | undefined,
+): KeeperFleetExecutionCounts | null {
+  if (!fleetSafety) return null
+  const fleet = fleetSafety.keeper_fleet_safety
+  const running = firstFiniteCount(fleet?.running_keeper_fiber_count)
+  const recovering = firstFiniteCount(fleet?.recovering_keeper_fiber_count)
+  const executable = firstFiniteCount(fleet?.executable_keeper_fiber_count)
+  const paused = firstFiniteCount(
+    fleetSafety.paused_keepers_health?.count,
+    fleet?.paused_keeper_count,
+    fleetSafety.paused_keepers,
+  )
+  if (running === null && recovering === null && executable === null && paused === null) {
+    return null
+  }
+  return { running, recovering, executable, paused }
+}
+
 export function runtimeHealthIsFresh(
   generatedAt: string | null | undefined,
   nowMs = Date.now(),

--- a/dashboard/src/styles/surfaces-v2.css
+++ b/dashboard/src/styles/surfaces-v2.css
@@ -991,10 +991,13 @@
   margin-top: 4px;
 }
 
-/* FLEET domain — summary tiles — surfaces.css:207-211 */
+/* FLEET domain — summary tiles — surfaces.css:207-211
+ * Six tiles (실행/복구/일시정지/주의/압박/전체) over three columns fill two rows
+ * exactly. An empty trailing track would expose the container --border-soft as
+ * a solid band through the 1px gap, the same failure documented on .ov-kpis. */
 .ov-fleet-sum {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 1px;
   background: var(--border-soft);
   border: 1px solid var(--border-main);


### PR DESCRIPTION
## 목표

Root(운영 홈)의 keeper 실행 숫자를 roster 상태 문자열 추정에서 runtime-health fleet projection으로 옮긴다.

## 결함

수정 전 `computeOverviewStats`는 `keeperRowLooksRunning`으로 roster row의 `status` / `phase` / `pipeline_stage` 문자열을 매칭해 "실행 중 keeper"를 셌다 (`overview.ts:150`). 두 가지 문제가 있다.

1. roster row가 마지막으로 기록한 값이지, keeper fiber가 지금 실행 중인지가 아니다.
2. 데이터가 없을 때 filter가 0을 반환하므로 "읽지 못했다"와 "실행 중인 keeper가 0이다"가 화면에서 똑같이 `0`으로 보인다. 화면에 미보고를 표현할 방법이 없었다.

## 호출 경로 감사

수정 전:

```
Overview()  (dashboard/src/components/overview/overview.ts)
  -> computeOverviewStats(keepers.value, tasks.value)
  -> keeperRowLooksRunning        (runtime-counts.ts:94)   <- roster status 문자열
  -> keepers signal               <- execution 응답
```

수정 후:

```
entrypoint : Overview()                       dashboard/src/components/overview/overview.ts
owner      : shellRuntimeResolution signal    dashboard/src/store.ts:86
             <- refreshShell -> GET /api/v1/dashboard/shell   api/dashboard-hot.ts:14
             <- normalizeDashboardRuntimeResolution           store-normalizers.ts:433
SSOT       : keeper_fleet_safety_health_json
             lib/server/server_routes_http_runtime_fleet_scan.ml:1495
consumers  : Root KPI `kpi-run`, Fleet 요약 카드 (실행 / 복구 / 일시정지)
```

같은 값을 읽는 기존 consumer (이번 PR에서 변경 없음):

- `components/v2/top-bar-v2.ts:139` — Header, executable 기준
- `components/dashboard-shell.ts:461`
- `components/fleet-health-panel.ts:244,445`

새 요청도 새 파싱도 없다. shell 응답은 Root 진입 시 이미 로드되고 (`app.ts:174`), fleet safety는 이미 파싱되어 store에 있다.

## 계획 문서와 다른 점

계획서는 "Keeper 숫자는 full health만 사용한다"로 지정했다. 실측 결과 `/health?full=1`의 `keeper_fleet_safety`와 shell `runtime_resolution`의 `keeper_fleet_safety`는 **같은 `keeper_fleet_safety_health_json` 산출물**이다 — `server_routes_http_runtime_health_fleet.ml:296-334`가 두 경로 공통의 base fields를 만든다.

full health 경로를 쓰려면 프론트에 두 번째 파싱 경로를 새로 만들어야 한다. 현재 `DashboardFullHealthResponse`는 `health_detail` / `schedule_runner`만 파싱하고 서버가 주는 `keeper_fleet_safety`를 버린다. 이미 파싱된 shell 경로를 쓰는 쪽이 파싱 중복 없이 같은 값에 도달한다. 값의 출처는 계획서 의도와 동일하다.

## 변경

- `runtime-counts.ts` — `resolveKeeperFleetExecutionCounts` 추가. 모든 필드가 `number | null`이고, projection 자체가 없으면 `null`을 반환한다. 보고되지 않은 값을 0으로 대체하지 않는다. 기존 `resolveRuntimeFleetSafetyCounts`는 count-reconciliation 체인에 답하므로 그대로 두었다 (질문이 다른 두 리더, 파서는 하나).
- `overview.ts` — `OverviewStats.run` 제거. 실행 상태는 roster row에서 파생할 수 없다. KPI `실행 중 keeper`와 Fleet 카드가 projection을 읽는다. `—`는 미보고, 숫자는 projection이 실제로 보고한 값이다.
- Fleet 요약 카드 — 4타일에서 6타일로 (실행 / 복구 / 일시정지 / 주의 / 압박 / 전체).
- `surfaces-v2.css` — `.ov-fleet-sum` 4열에서 3열로. 6타일이 2행을 정확히 채워 빈 트랙이 container border를 1px gap 사이로 밴드처럼 노출하는 것을 막는다. `.ov-kpis`에 이미 기록된 동일한 실패다.

## 로컬 검증

- `npx tsc --noEmit` — clean
- `npm run lint` (eslint src) — clean
- `npm test` — 638 test files / 8743 tests pass, exit 0
- 게이트 유효성 — 신규 테스트를 수정 전 소스에 대해 실행해 8건 실패를 확인했다. `shows no keeper execution count when the fleet projection is missing`은 수정 전 roster 추정값 `3 / 3`을 내고 `— / 3` 기대와 어긋난다. 통과가 아니라 실패로 검증했다.

테스트 fixture: `running=4, recovering=3, executable=7, paused=1`, 그리고 projection이 보고한 `0`이 `—`가 아니라 `0`으로 렌더되는지 별도 검증.

## 이번 PR에서 하지 않은 것

- `avgCtx`는 roster 기준으로 남았다. projection이 running keeper를 count로만 보고하고 per-keeper `context_ratio`를 주지 않아 평균을 낼 수 없다. 코드에 주석으로 명시했다.
- Header(`top-bar-v2.ts:125`)와 `dashboard-shell.ts:450`의 `fallbackRunningKeepers` roster fallback은 그대로다. 별도 결함이라 범위를 분리했다.
- `executable`은 selector가 노출하지만 Root는 표시하지 않는다. Header가 이미 executable을 쓴다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
