### PR TITLE
fix(claude-code): carry the client's reason on a failed turn

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -667,15 +667,23 @@ let parse_result ~expected_session_id ~rate_limit fields =
     then Error (Quota_blocked { api_error_status; rate_limit })
     else if is_error
     then
+      (* The terminal message's [result] is the client's own account of what
+         went wrong — for an api_status=400 it is the only place the provider's
+         reason appears. It was parsed and then dropped, so every failed turn
+         reached the operator as a status code with no cause and could not be
+         diagnosed without reproducing the run outside MASC. Carry it. *)
       Error
         (Turn_failed
            (Printf.sprintf
-              "terminal subtype=%s api_status=%s"
+              "terminal subtype=%s api_status=%s%s"
               subtype
               (Option.fold
                  ~none:"unknown"
                  ~some:string_of_int
-                 api_error_status)))
+                 api_error_status)
+              (match Option.map String.trim result with
+               | Some detail when detail <> "" -> ": " ^ detail
+               | Some _ | None -> "")))
     else if subtype <> "success"
     then Error (Turn_failed (Printf.sprintf "terminal subtype=%s" subtype))
     else Ok (turn_id, result)

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -354,6 +354,33 @@ let test_dynamic_tool_callback () =
 
    Emit_and_expect_request_id makes the fixture wait and exit 96 unless the
    response carries the id, so this now fails if the ack is dropped again. *)
+let result_api_error =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-api-error-1","result":"messages.0.content.1: unexpected tool_use_id","api_error_status":400}|}
+;;
+
+(* A failed turn used to reach the operator as "terminal subtype=success
+   api_status=400" and nothing else. The client's own account of the failure was
+   parsed off the terminal message and then dropped, so a 400 could not be
+   diagnosed without reproducing the run outside MASC — which is what it cost to
+   find this. The provider's reason is the whole value of the error. *)
+let test_turn_failure_carries_the_client_reason () =
+  with_fixture [ Emit result_api_error ] (fun path ->
+    match run_fixture path with
+    | Ok _ -> fail "a terminal is_error result must not settle as success"
+    | Error error ->
+      let text = Runtime_claude_code.error_to_string error in
+      let contains needle =
+        let n = String.length needle in
+        let rec scan i =
+          i + n <= String.length text && (String.sub text i n = needle || scan (i + 1))
+        in
+        scan 0
+      in
+      check bool "keeps the status code" true (contains "api_status=400");
+      check bool "carries the provider reason" true
+        (contains "unexpected tool_use_id"))
+;;
+
 let test_mcp_notification_is_acknowledged_on_the_control_channel () =
   with_fixture
     [ Emit_and_read mcp_initialize
@@ -825,6 +852,10 @@ let () =
             "shared protocol is negotiated"
             `Quick
             test_shared_mcp_protocol_is_negotiated
+        ; test_case
+            "turn failure carries the client reason"
+            `Quick
+            test_turn_failure_carries_the_client_reason
         ; test_case
             "notification is acknowledged on the control channel"
             `Quick


### PR DESCRIPTION
## 문제

실패한 `claude_code` 턴이 운영자에게 이렇게 도달한다:

```
Provider 'claude_code' reported an error (turn_failed): terminal subtype=success api_status=400
```

이게 전부다. terminal 메시지의 `result` — **클라이언트 자신이 무엇이 잘못됐는지 적은 필드이고, 400 에서는 provider 의 이유가 나타나는 유일한 자리** — 는 바로 윗줄에서 파싱돼 변수에 담긴 뒤 버려진다.

```ocaml
let* result = result in            (* ← 여기 있다 *)
...
else if is_error
then Error (Turn_failed (Printf.sprintf "terminal subtype=%s api_status=%s" subtype ...))
                                    (* ← result 를 쓰지 않는다 *)
```

## 비용

#28069 로 control 채널 교착이 풀리자 claude_code 키퍼가 provider 까지 도달해 **약 8초 만에 정확히 이 메시지로 실패**하기 시작했다. 그래서 400 을 진단하려면 키퍼 argv 를 MASC 밖에서 재현해야 했다 — 이유는 이미 손에 있었는데.

라이브 관측 (2026-08-11 02:13~02:14, `analyst` / `claude_code.claude-opus-5-max`):

```
turn terminal (non-exhaustion error) — err=Provider 'claude_code' reported an error
  (turn_failed): terminal subtype=success api_status=400 attempt=1
keeper cycle FAILED runtime=claude_code.claude-opus-5-max latency=7613ms
turn failure observed (consecutive=12)
```

12연속 실패가 전부 이 한 줄이다.

## 변경

`result` 가 있고 비어 있지 않으면 타입 있는 에러 뒤에 붙인다. 없거나 공백이면 메시지는 그대로다.

이건 계측 추가가 아니라 **이미 받은 정보를 버리지 않는 것**이다. `Prompt_too_large { bytes; limit }` 이 측정값과 예산을 함께 싣는 것과 같은 종류다 — 타입 있는 에러가 자기 원인을 들고 있게 한다.

## 검증

```
dune build @check                                   OK
dune build @test/runtest-test_runtime_claude_code   19 tests, OK
```

새 테스트 `turn failure carries the client reason`: `api_error_status: 400` + `result: "messages.0.content.1: unexpected tool_use_id"` 인 terminal 을 흘리고, 에러 문자열이 **상태 코드와 provider 이유를 둘 다** 담는지 확인한다. 상태 코드만 확인하면 회귀를 못 잡으므로 두 축을 다 본다.

RFC-WAIVED: claude_code 어댑터의 에러 구성 한 곳과 그 테스트다. credential / identity / repo_manager / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 어느 것도 건드리지 않는다.

WORKAROUND-WAIVED: 증상 억제가 아니다. 카운터를 추가하는 것도 아니고 — 파싱해놓고 버리던 값을 타입 있는 에러에 싣는 것이다. 재시도/캡/쿨다운/문자열 분류기 없음.

Co-Authored-By: Claude Opus 5 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrQctrmuNds4HVg9sHgicM
