### PR TITLE
fix(runtime): Codex error 객체의 typed 필드를 버리지 않는다 — 초과 분류에 쓸 입력이 파스 시점에 사라졌다

### DIFF
--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -477,12 +477,34 @@ let messages_of_items ~stage = function
   | _ -> protocol_error stage "turn items must be an array"
 ;;
 
+(* Only [message] used to survive this function, so a live keeper failing every
+   turn on "Codex ran out of room in the model's context window" carried no
+   machine-readable trace of what kind of failure that was (#28071). Whatever
+   else the server put on the error object is kept here as well: a later change
+   that wants to route context overflow to the shrink retry needs a typed field
+   to key on, and it cannot recover one that was discarded at parse time.
+
+   This does not classify anything. It stops throwing away the input a
+   classification would need. *)
 let turn_error_message fields =
   match List.assoc_opt "error" fields with
   | Some (`Assoc error_fields) ->
-    (match List.assoc_opt "message" error_fields with
-     | Some (`String message) when String.trim message <> "" -> message
-     | _ -> "turn failed without a typed error message")
+    let message =
+      match List.assoc_opt "message" error_fields with
+      | Some (`String message) when String.trim message <> "" ->
+        String.trim message
+      | _ -> "turn failed without a typed error message"
+    in
+    let scalar name =
+      match List.assoc_opt name error_fields with
+      | Some (`String value) when String.trim value <> "" ->
+        Some (name ^ "=" ^ String.trim value)
+      | Some (`Int value) -> Some (name ^ "=" ^ string_of_int value)
+      | _ -> None
+    in
+    (match List.filter_map scalar [ "code"; "type" ] with
+     | [] -> message
+     | annotations -> message ^ " (" ^ String.concat " " annotations ^ ")")
   | _ -> "turn failed without an error object"
 ;;
 

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -401,6 +401,36 @@ let test_server_request_fails_closed () =
       | Ok _ -> fail "unsupported server request incorrectly admitted")
 ;;
 
+(* A live keeper failed every turn on a context overflow the server reported,
+   and the receipt carried only the sentence: nothing downstream could tell that
+   failure class from any other Turn_failed (#28071). The server's own error
+   object is the only place a typed field could come from, and this function was
+   dropping everything but [message]. The expectation names the annotation
+   literally rather than re-rendering the function, so it fails if the field
+   stops being carried. *)
+let test_failed_turn_keeps_typed_error_fields () =
+  let failed =
+    {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"ran out of room in the model's context window","code":"context_length_exceeded"}}}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; failed ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Turn_failed detail) ->
+        check
+          bool
+          "provider sentence survives"
+          true
+          (Astring.String.is_infix ~affix:"ran out of room" detail);
+        check
+          bool
+          "typed code survives"
+          true
+          (Astring.String.is_infix ~affix:"code=context_length_exceeded" detail)
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "failed turn incorrectly reported as completed")
+;;
+
 let test_failed_turn_is_not_completion () =
   let failed =
     {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"fixture failure"}}}}|}
@@ -2151,6 +2181,8 @@ let () =
             `Quick
             test_notification_without_params_fails_closed
         ; test_case "server request fails closed" `Quick test_server_request_fails_closed
+        ; test_case "failed turn keeps typed error fields" `Quick
+            test_failed_turn_keeps_typed_error_fields
         ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
         ; test_case
             "retry notifications are observational"


### PR DESCRIPTION
## 무엇을

Codex 서버가 보낸 `error` 객체에서 **`message` 외 필드를 버리지 않습니다.** `#28071` 의 codex 절반입니다.

## 왜 — 분류에 쓸 입력이 파스 시점에 사라집니다

```ocaml
(* 이전 *)
let turn_error_message fields =
  match List.assoc_opt "error" fields with
  | Some (`Assoc error_fields) ->
    (match List.assoc_opt "message" error_fields with
     | Some (`String message) when String.trim message <> "" -> message
     | _ -> "turn failed without a typed error message")
```

라이브에서 `sangsu` 가 매 턴 이렇게 실패합니다:

```
Internal error: Codex app-server turn failed:
  Codex ran out of room in the model's context window. Start a new thread…
```

**컨텍스트 초과인데 그 사실이 문자열로만 남습니다.**

## 왜 문자열 매칭이 답이 아닌가

이 저장소에는 초과 시 요청을 절반씩 줄여 재시도하는 기계가 있습니다(#27320). 트리거는 전수 열거된 `Api (ContextOverflow _)` 하나이고, codex 의 초과는 `Turn_failed` → `Provider_rejected` → `internal_error` 로 가서 **닿지 않습니다.**

`"ran out of room"` 을 매칭해 승격하고 싶어지지만, 그 패턴은 명시적으로 제거된 선례가 있습니다:

> classifying an `[Error.Agent _]` as a context overflow here is **a string classifier standing in for a typed provider signal** — `keeper_error_classify.ml:669`

typed 필드가 대안이고, **파스 시점에 버려진 것은 복구할 수 없습니다.**

## 변경

서버가 `code` · `type` 을 보내면 유지합니다:

```
message (code=context_length_exceeded)
```

**아무것도 분류하지 않습니다.** 분류가 필요로 할 입력을 버리지 않을 뿐입니다. 실제로 승격할지, 어떤 code 를 승격할지는 그 필드가 라이브에서 무엇으로 오는지 본 뒤에 정할 문제입니다.

## 검증

```
$ dune build --root . @test/runtest-test_runtime_codex_app_server
exit=0   Test Successful in 20.772s. 34 tests run.
```

새 테스트는 주석 문자열을 **리터럴로** 단언합니다 — 함수를 다시 호출해 비교하면 무엇을 만들든 통과하는 항등식이 됩니다.

**뮤테이션**: 필드 목록을 비우면

```
exit=1
ASSERT typed code survives
1 failure! in 12.396s. 34 tests run.
```

**소비자 스위트**: `test_runtime_codex_app_server` · `test_keeper_official_client_host` 둘 다 exit=0.

## 짝 PR

`#28075` 가 같은 형태를 claude_code 쪽에서 고칩니다(터미널 프레임의 `result` 를 버리던 것). 두 어댑터가 서로 다른 필드를 버리고 있었고, 증상은 같습니다 — 실패의 종류를 알 수 없음.

RFC-WAIVED: 이미 파싱한 필드를 에러 메시지에 보존. 분류·게이트·타입 변경 없음.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

WORKAROUND-WAIVED: 본문이 "string classifier" 를 언급하는 것은 그 패턴을 **도입하지 않는 근거**로서다. 이 변경은 문자열 매칭을 추가하지 않고, 이미 파싱된 typed 필드(`code`·`type`)를 버리지 않을 뿐이다. 분류 로직은 이 PR 에 없다.
