### PR TITLE
refactor(server): make the runtime manifest scan an immutable fold

### DIFF
--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -16,38 +16,38 @@ type runtime_manifest_scan =
   ; returned_rows : Keeper_runtime_manifest.t Queue.t
   ; provider_attempt_rows : Keeper_runtime_manifest.t Queue.t
   ; event_counts : (string, int) Hashtbl.t
-  ; mutable total_rows : int
-  ; mutable has_terminal : bool
-  ; mutable terminal_keeper_turn_ids : int list
-  ; mutable max_agent_core_turn_count : int option
-  ; mutable keeper_turn_ids : int list
-  ; mutable event_bus_count : int
-  ; mutable event_bus_correlation_ids : string list
-  ; mutable event_bus_run_ids : string list
-  ; mutable context_compact_started_count : int
-  ; mutable context_compacted_count : int
-  ; mutable last_compaction : Yojson.Safe.t option
-  ; mutable latest_provider_lane_decision : Yojson.Safe.t option
-  ; mutable latest_provider_lane_row : Keeper_runtime_manifest.t option
-  ; mutable latest_pre_dispatch_blocked_row : Keeper_runtime_manifest.t option
+  ; total_rows : int
+  ; has_terminal : bool
+  ; terminal_keeper_turn_ids : int list
+  ; max_agent_core_turn_count : int option
+  ; keeper_turn_ids : int list
+  ; event_bus_count : int
+  ; event_bus_correlation_ids : string list
+  ; event_bus_run_ids : string list
+  ; context_compact_started_count : int
+  ; context_compacted_count : int
+  ; last_compaction : Yojson.Safe.t option
+  ; latest_provider_lane_decision : Yojson.Safe.t option
+  ; latest_provider_lane_row : Keeper_runtime_manifest.t option
+  ; latest_pre_dispatch_blocked_row : Keeper_runtime_manifest.t option
   ; payload_role_counts : (string, int) Hashtbl.t
   ; source_clock_counts : (string, int) Hashtbl.t
-  ; mutable context_injected_count : int
-  ; mutable context_compacted_event_count : int
-  ; mutable provider_started_count : int
-  ; mutable provider_finished_count : int
-  ; mutable provider_terminal_row : Keeper_runtime_manifest.t option
-  ; mutable latest_context_injected_row : Keeper_runtime_manifest.t option
-  ; mutable latest_context_compacted_row : Keeper_runtime_manifest.t option
-  ; mutable dag_edges : (string * string) list
-  ; mutable scanned_lines : int
+  ; context_injected_count : int
+  ; context_compacted_event_count : int
+  ; provider_started_count : int
+  ; provider_finished_count : int
+  ; provider_terminal_row : Keeper_runtime_manifest.t option
+  ; latest_context_injected_row : Keeper_runtime_manifest.t option
+  ; latest_context_compacted_row : Keeper_runtime_manifest.t option
+  ; dag_edges : (string * string) list
+  ; scanned_lines : int
   ; scan_line_limit : int
   ; scan_scope : string
   ; unsupported_event_counts : (string, int) Hashtbl.t
-  ; mutable unsupported_event_count : int
-  ; mutable unsupported_event_unattributed_count : int
-  ; mutable invalid_manifest_row_count : int
-  ; mutable invalid_json_row_count : int
+  ; unsupported_event_count : int
+  ; unsupported_event_unattributed_count : int
+  ; invalid_manifest_row_count : int
+  ; invalid_json_row_count : int
   ; diagnostic_samples : manifest_scan_diagnostic Queue.t
   }
 
@@ -126,17 +126,32 @@ let increment_bounded_count table ~capacity key =
 ;;
 
 let record_manifest_scan_diagnostic scan diagnostic =
-  (match diagnostic with
-   | Unsupported_event_row event ->
-     scan.unsupported_event_count <- scan.unsupported_event_count + 1;
-     if not (increment_bounded_count scan.unsupported_event_counts ~capacity:scan.limit event)
-     then
-       scan.unsupported_event_unattributed_count <-
-         scan.unsupported_event_unattributed_count + 1
-   | Invalid_manifest_row _ ->
-     scan.invalid_manifest_row_count <- scan.invalid_manifest_row_count + 1
-   | Invalid_json_row _ -> scan.invalid_json_row_count <- scan.invalid_json_row_count + 1);
-  push_bounded scan.diagnostic_samples scan.limit diagnostic
+  let scan =
+    match diagnostic with
+    | Unsupported_event_row event ->
+      (* [increment_bounded_count] mutates the shared [unsupported_event_counts]
+         table and reports whether the event fit under the capacity bound; the
+         unattributed counter absorbs the ones that did not. *)
+      let attributed =
+        increment_bounded_count
+          scan.unsupported_event_counts
+          ~capacity:scan.limit
+          event
+      in
+      { scan with
+        unsupported_event_count = scan.unsupported_event_count + 1
+      ; unsupported_event_unattributed_count =
+          (if attributed
+           then scan.unsupported_event_unattributed_count
+           else scan.unsupported_event_unattributed_count + 1)
+      }
+    | Invalid_manifest_row _ ->
+      { scan with invalid_manifest_row_count = scan.invalid_manifest_row_count + 1 }
+    | Invalid_json_row _ ->
+      { scan with invalid_json_row_count = scan.invalid_json_row_count + 1 }
+  in
+  push_bounded scan.diagnostic_samples scan.limit diagnostic;
+  scan
 ;;
 
 let sorted_count_rows table key_to_string =
@@ -195,23 +210,25 @@ let max_int_opt current value =
   | Some existing -> Some (max existing value)
 
 let update_runtime_manifest_scan scan (row : Keeper_runtime_manifest.t) =
-  scan.total_rows <- scan.total_rows + 1;
   push_bounded scan.returned_rows scan.limit row;
   increment_event_count scan row.Keeper_runtime_manifest.event;
-  (match
-     let decision = row.Keeper_runtime_manifest.decision in
-     let clock_refs = Json_util.assoc_member_opt "clock_refs" decision in
-     match clock_refs with
-     | Some (`Assoc _ as refs) ->
-       let event_id = Json_util.get_string refs "event_id" in
-       let parent_event_id = Json_util.get_string refs "parent_event_id" in
-       (match event_id, parent_event_id with
-        | Some eid, Some peid -> Some (peid, eid)
-        | _ -> None)
-     | None | Some _ -> None
-   with
-   | Some edge -> scan.dag_edges <- edge :: scan.dag_edges
-   | None -> ());
+  let scan = { scan with total_rows = scan.total_rows + 1 } in
+  let scan =
+    match
+       let decision = row.Keeper_runtime_manifest.decision in
+       let clock_refs = Json_util.assoc_member_opt "clock_refs" decision in
+       match clock_refs with
+       | Some (`Assoc _ as refs) ->
+         let event_id = Json_util.get_string refs "event_id" in
+         let parent_event_id = Json_util.get_string refs "parent_event_id" in
+         (match event_id, parent_event_id with
+          | Some eid, Some peid -> Some (peid, eid)
+          | _ -> None)
+      | None | Some _ -> None
+    with
+    | Some edge -> { scan with dag_edges = edge :: scan.dag_edges }
+    | None -> scan
+  in
   (match
      Json_util.assoc_member_opt "payload_role" row.Keeper_runtime_manifest.decision
    with
@@ -248,59 +265,90 @@ let update_runtime_manifest_scan scan (row : Keeper_runtime_manifest.t) =
     | None -> 0
   in
   Hashtbl.replace scan.source_clock_counts source_clock (current + 1);
-  (match row.Keeper_runtime_manifest.keeper_turn_id with
-   | Some value -> scan.keeper_turn_ids <- value :: scan.keeper_turn_ids
-   | None -> ());
-  (match row.Keeper_runtime_manifest.agent_core_turn_count with
-   | Some value -> scan.max_agent_core_turn_count <- max_int_opt scan.max_agent_core_turn_count value
-   | None -> ());
-  (match row.Keeper_runtime_manifest.event with
-   | Keeper_runtime_manifest.Turn_finished ->
-     scan.has_terminal <- true;
-     (match row.Keeper_runtime_manifest.keeper_turn_id with
+  let scan =
+    match row.Keeper_runtime_manifest.keeper_turn_id with
+    | Some value -> { scan with keeper_turn_ids = value :: scan.keeper_turn_ids }
+    | None -> scan
+  in
+  let scan =
+    match row.Keeper_runtime_manifest.agent_core_turn_count with
+    | Some value ->
+      { scan with
+        max_agent_core_turn_count =
+          max_int_opt scan.max_agent_core_turn_count value
+      }
+    | None -> scan
+  in
+  match row.Keeper_runtime_manifest.event with
+  | Keeper_runtime_manifest.Turn_finished ->
+    let scan = { scan with has_terminal = true } in
+    (match row.Keeper_runtime_manifest.keeper_turn_id with
+     | Some value ->
+       { scan with
+         terminal_keeper_turn_ids = value :: scan.terminal_keeper_turn_ids
+       }
+     | None -> scan)
+  | Keeper_runtime_manifest.Provider_lane_resolved ->
+    { scan with
+      latest_provider_lane_decision = Some row.Keeper_runtime_manifest.decision
+    ; latest_provider_lane_row = Some row
+    }
+  | Keeper_runtime_manifest.Pre_dispatch_blocked ->
+    { scan with latest_pre_dispatch_blocked_row = Some row }
+  | Keeper_runtime_manifest.Context_injected ->
+    { scan with
+      context_injected_count = scan.context_injected_count + 1
+    ; latest_context_injected_row = Some row
+    }
+  | Keeper_runtime_manifest.Context_compacted ->
+    { scan with
+      context_compacted_event_count = scan.context_compacted_event_count + 1
+    ; latest_context_compacted_row = Some row
+    }
+  | Keeper_runtime_manifest.Event_bus_correlated ->
+    let decision = row.Keeper_runtime_manifest.decision in
+    let scan =
+      { scan with
+        event_bus_count = scan.event_bus_count + 1
+      ; context_compact_started_count =
+          scan.context_compact_started_count
+          + Option.value
+              (Json_util.get_int decision "context_compact_started_count")
+              ~default:0
+      ; context_compacted_count =
+          scan.context_compacted_count
+          + Option.value
+              (Json_util.get_int decision "context_compacted_count")
+              ~default:0
+      }
+    in
+    let scan =
+      match Json_util.get_string decision "correlation_id" with
       | Some value ->
-        scan.terminal_keeper_turn_ids <- value :: scan.terminal_keeper_turn_ids
-      | None -> ())
-   | Keeper_runtime_manifest.Provider_lane_resolved ->
-     scan.latest_provider_lane_decision <- Some row.Keeper_runtime_manifest.decision;
-     scan.latest_provider_lane_row <- Some row
-   | Keeper_runtime_manifest.Pre_dispatch_blocked ->
-     scan.latest_pre_dispatch_blocked_row <- Some row
-   | Keeper_runtime_manifest.Context_injected ->
-     scan.context_injected_count <- scan.context_injected_count + 1;
-     scan.latest_context_injected_row <- Some row
-   | Keeper_runtime_manifest.Context_compacted ->
-     scan.context_compacted_event_count <- scan.context_compacted_event_count + 1;
-     scan.latest_context_compacted_row <- Some row
-   | Keeper_runtime_manifest.Event_bus_correlated ->
-     let decision = row.Keeper_runtime_manifest.decision in
-     scan.event_bus_count <- scan.event_bus_count + 1;
-     (match Json_util.get_string decision "correlation_id" with
-      | Some value -> scan.event_bus_correlation_ids <- value :: scan.event_bus_correlation_ids
-      | None -> ());
-     (match Json_util.get_string decision "run_id" with
-      | Some value -> scan.event_bus_run_ids <- value :: scan.event_bus_run_ids
-      | None -> ());
-     scan.context_compact_started_count <-
-       scan.context_compact_started_count
-       + Option.value
-           (Json_util.get_int decision "context_compact_started_count")
-           ~default:0;
-     scan.context_compacted_count <-
-       scan.context_compacted_count
-       + Option.value (Json_util.get_int decision "context_compacted_count")
-           ~default:0;
-     (match Json_util.assoc_member_opt "last_compaction" decision with
-      | Some (`Assoc _ as obj) -> scan.last_compaction <- Some obj
-      | _ -> ())
-   | Keeper_runtime_manifest.Provider_attempt_started ->
-     scan.provider_started_count <- scan.provider_started_count + 1;
-     push_bounded scan.provider_attempt_rows scan.limit row
-   | Keeper_runtime_manifest.Provider_attempt_finished ->
-     scan.provider_finished_count <- scan.provider_finished_count + 1;
-     scan.provider_terminal_row <- Some row;
-     push_bounded scan.provider_attempt_rows scan.limit row
-   | _ -> ())
+        { scan with
+          event_bus_correlation_ids = value :: scan.event_bus_correlation_ids
+        }
+      | None -> scan
+    in
+    let scan =
+      match Json_util.get_string decision "run_id" with
+      | Some value ->
+        { scan with event_bus_run_ids = value :: scan.event_bus_run_ids }
+      | None -> scan
+    in
+    (match Json_util.assoc_member_opt "last_compaction" decision with
+     | Some (`Assoc _ as obj) -> { scan with last_compaction = Some obj }
+     | _ -> scan)
+  | Keeper_runtime_manifest.Provider_attempt_started ->
+    push_bounded scan.provider_attempt_rows scan.limit row;
+    { scan with provider_started_count = scan.provider_started_count + 1 }
+  | Keeper_runtime_manifest.Provider_attempt_finished ->
+    push_bounded scan.provider_attempt_rows scan.limit row;
+    { scan with
+      provider_finished_count = scan.provider_finished_count + 1
+    ; provider_terminal_row = Some row
+    }
+  | _ -> scan
 
 let manifest_identity_matches ?turn_id keeper_name trace_id
     (identity : Keeper_runtime_manifest.row_identity) =
@@ -325,9 +373,9 @@ let read_runtime_manifest_scan ~config ~keeper_name ~trace_id ?turn_id ~limit ()
       ~scan_scope:"tail"
   in
   Dated_jsonl.load_tail_lines path ~max_lines:scan_line_limit
-  |> List.iter
-       (fun line ->
-          scan.scanned_lines <- scan.scanned_lines + 1;
+  |> List.fold_left
+       (fun scan line ->
+          let scan = { scan with scanned_lines = scan.scanned_lines + 1 } in
           try
             let json = Yojson.Safe.from_string line in
             match Keeper_runtime_manifest.decode_persisted_row json with
@@ -337,10 +385,10 @@ let read_runtime_manifest_scan ~config ~keeper_name ~trace_id ?turn_id ~limit ()
             | Ok (Keeper_runtime_manifest.Unsupported_row (identity, unsupported))
               when manifest_identity_matches ?turn_id keeper_name trace_id identity ->
               record_manifest_scan_diagnostic scan (Unsupported_event_row unsupported)
-            | Ok _ -> ()
+            | Ok _ -> scan
             | Error detail ->
               record_manifest_scan_diagnostic scan (Invalid_manifest_row detail)
           with
           | Yojson.Json_error msg | Yojson.Safe.Util.Type_error (msg, _) ->
-            record_manifest_scan_diagnostic scan (Invalid_json_row msg));
-  scan
+            record_manifest_scan_diagnostic scan (Invalid_json_row msg))
+       scan

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
@@ -14,38 +14,38 @@ type runtime_manifest_scan =
   ; returned_rows : Keeper_runtime_manifest.t Queue.t
   ; provider_attempt_rows : Keeper_runtime_manifest.t Queue.t
   ; event_counts : (string, int) Hashtbl.t
-  ; mutable total_rows : int
-  ; mutable has_terminal : bool
-  ; mutable terminal_keeper_turn_ids : int list
-  ; mutable max_agent_core_turn_count : int option
-  ; mutable keeper_turn_ids : int list
-  ; mutable event_bus_count : int
-  ; mutable event_bus_correlation_ids : string list
-  ; mutable event_bus_run_ids : string list
-  ; mutable context_compact_started_count : int
-  ; mutable context_compacted_count : int
-  ; mutable last_compaction : Yojson.Safe.t option
-  ; mutable latest_provider_lane_decision : Yojson.Safe.t option
-  ; mutable latest_provider_lane_row : Keeper_runtime_manifest.t option
-  ; mutable latest_pre_dispatch_blocked_row : Keeper_runtime_manifest.t option
+  ; total_rows : int
+  ; has_terminal : bool
+  ; terminal_keeper_turn_ids : int list
+  ; max_agent_core_turn_count : int option
+  ; keeper_turn_ids : int list
+  ; event_bus_count : int
+  ; event_bus_correlation_ids : string list
+  ; event_bus_run_ids : string list
+  ; context_compact_started_count : int
+  ; context_compacted_count : int
+  ; last_compaction : Yojson.Safe.t option
+  ; latest_provider_lane_decision : Yojson.Safe.t option
+  ; latest_provider_lane_row : Keeper_runtime_manifest.t option
+  ; latest_pre_dispatch_blocked_row : Keeper_runtime_manifest.t option
   ; payload_role_counts : (string, int) Hashtbl.t
   ; source_clock_counts : (string, int) Hashtbl.t
-  ; mutable context_injected_count : int
-  ; mutable context_compacted_event_count : int
-  ; mutable provider_started_count : int
-  ; mutable provider_finished_count : int
-  ; mutable provider_terminal_row : Keeper_runtime_manifest.t option
-  ; mutable latest_context_injected_row : Keeper_runtime_manifest.t option
-  ; mutable latest_context_compacted_row : Keeper_runtime_manifest.t option
-  ; mutable dag_edges : (string * string) list
-  ; mutable scanned_lines : int
+  ; context_injected_count : int
+  ; context_compacted_event_count : int
+  ; provider_started_count : int
+  ; provider_finished_count : int
+  ; provider_terminal_row : Keeper_runtime_manifest.t option
+  ; latest_context_injected_row : Keeper_runtime_manifest.t option
+  ; latest_context_compacted_row : Keeper_runtime_manifest.t option
+  ; dag_edges : (string * string) list
+  ; scanned_lines : int
   ; scan_line_limit : int
   ; scan_scope : string
   ; unsupported_event_counts : (string, int) Hashtbl.t
-  ; mutable unsupported_event_count : int
-  ; mutable unsupported_event_unattributed_count : int
-  ; mutable invalid_manifest_row_count : int
-  ; mutable invalid_json_row_count : int
+  ; unsupported_event_count : int
+  ; unsupported_event_unattributed_count : int
+  ; invalid_manifest_row_count : int
+  ; invalid_json_row_count : int
   ; diagnostic_samples : manifest_scan_diagnostic Queue.t
   }
 
@@ -65,7 +65,12 @@ val runtime_manifest_scan_event_count :
   runtime_manifest_scan -> Keeper_runtime_manifest.event_kind -> int
 
 val max_int_opt : int option -> int -> int option
-val update_runtime_manifest_scan : runtime_manifest_scan -> Keeper_runtime_manifest.t -> unit
+
+(** Fold one manifest row into the scan. Returns the updated scan; the
+    [Queue.t] and [Hashtbl.t] fields are shared with the argument and are
+    still mutated in place. *)
+val update_runtime_manifest_scan :
+  runtime_manifest_scan -> Keeper_runtime_manifest.t -> runtime_manifest_scan
 
 val read_runtime_manifest_scan :
   config:Workspace.config ->

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -244,6 +244,45 @@ let runtime_manifest_json_without_field row_json field =
   | _ -> fail "runtime manifest row must encode as an object"
 ;;
 
+(* The scan record carries no mutable field, so folding a row must leave the
+   argument at its previous value and report the advance through the return.
+   This pins the property the fold buys: a caller can hold on to an earlier
+   scan without it drifting under them. It does not compile against the
+   in-place shape, where [update_runtime_manifest_scan] returned [unit]. *)
+let test_runtime_manifest_scan_fold_leaves_input_untouched () =
+  let scan =
+    Runtime_lens_scan.make_runtime_manifest_scan
+      ~path:"/tmp/immutable-runtime-manifest.jsonl"
+      ~limit:4
+      ~scan_line_limit:16
+      ~scan_scope:"test"
+  in
+  let row =
+    Keeper_runtime_manifest.make
+      ~keeper_name:"immutable-scan-keeper"
+      ~trace_id:"trace-immutable-scan"
+      ~keeper_turn_id:7
+      ~event:Keeper_runtime_manifest.Turn_finished
+      ~status:"finished"
+      ()
+  in
+  let advanced = Runtime_lens_scan.update_runtime_manifest_scan scan row in
+  check int "argument keeps its row count" 0 scan.total_rows;
+  check bool "argument keeps its terminal flag" false scan.has_terminal;
+  check
+    (list int)
+    "argument keeps its terminal turn ids"
+    []
+    scan.terminal_keeper_turn_ids;
+  check int "result counts the row" 1 advanced.total_rows;
+  check bool "result observes the terminal event" true advanced.has_terminal;
+  check
+    (list int)
+    "result records the terminal turn id"
+    [ 7 ]
+    advanced.terminal_keeper_turn_ids
+;;
+
 let test_runtime_manifest_scan_surfaces_diagnostics_without_repeat_warnings () =
   with_temp_dir @@ fun dir ->
   let config = Workspace.default_config dir in
@@ -699,6 +738,10 @@ let () =
             "surfaces unsupported rows without repeated warnings"
             `Quick
             test_runtime_manifest_scan_surfaces_diagnostics_without_repeat_warnings
+        ; test_case
+            "folding a row leaves the argument scan untouched"
+            `Quick
+            test_runtime_manifest_scan_fold_leaves_input_untouched
         ] )
     ; ( "checkpoint_inventory"
       , [ test_case


### PR DESCRIPTION
## 목표

`runtime_manifest_scan`은 `lib/` 전체 mutable 필드 선언 358개 중 29개(8.1%)를 혼자 들고 있는 최대 집중 지점이다. 이 레코드를 불변으로 바꾸고 스캔을 in-place 변이에서 fold로 전환한다.

## 왜 이 레코드인가

- 29개 필드에 대한 `<-` 쓰기 27건이 **전부 소유 모듈 내부**이고 외부 쓰기 0건이다.
- 변이 API의 외부 호출자도 0건이다: `update_runtime_manifest_scan` 0, `increment_event_count` 0, `push_bounded` 0, `max_int_opt` 0. (`Server_dashboard_http_keeper_api_post`가 `include` 로 재노출하므로 무자격 참조까지 세었다.)
- 소비자 8개 모듈은 필드를 **읽기만** 한다. 읽기는 불변 레코드에서 동일하게 컴파일된다.

즉 mutable이 주는 권한을 아무도 쓰지 않는데 타입은 그 권한을 계속 광고하고 있었다.

## 변경

- `runtime_manifest_scan`의 `mutable` 27개 제거 (`.ml` + `.mli`).
- `update_runtime_manifest_scan : t -> row -> unit` → `t -> row -> t`.
- `record_manifest_scan_diagnostic`도 새 스캔을 반환.
- `read_runtime_manifest_scan`의 `List.iter` → `List.fold_left`.

`Queue.t` / `Hashtbl.t` 필드(`returned_rows`, `event_counts`, `payload_role_counts`, `source_clock_counts`, `unsupported_event_counts`, `diagnostic_samples`)는 그대로 제자리 변이한다. 컨테이너 핸들은 재대입되지 않으므로 필드 자체는 불변이면 충분하고, `.mli`에 그 점을 명시했다.

## 성능

행마다 39필드 레코드를 새로 만든다. 스캔 상한은 `runtime_manifest_tail_scan_max_lines = 6000`이므로 최대 6000 × 39 워드 ≈ 1.9 MB minor 할당이다. 같은 6000행을 `Yojson.Safe.from_string`으로 파싱하는 비용에 비해 무시할 수준이다.

## 동작 차이 (의도적, 1건)

한 행 처리 도중 `Yojson.Safe.Util.Type_error`가 나면, 기존에는 그 시점까지의 부분 변이(`total_rows` 증가 등)가 남았고 지금은 남지 않는다. 행 단위 갱신이 원자적이 된다. 진단 기록(`Invalid_json_row`)은 양쪽 모두 남는다. `event_counts` / `returned_rows` 같은 공유 컨테이너 갱신은 예외 이전에 일어나므로 양쪽 동일하다.

부분 집계에 의존하는 소비자는 없다.

## 테스트

`update_runtime_manifest_scan`이 인자를 변이하지 않고 결과로만 전진을 알린다는 것을 단언하는 케이스를 추가했다. 이 단언은 양방향으로 유효하다: 이전 in-place 형태에서는 반환이 `unit`이라 컴파일되지 않고, 필드를 다시 `mutable`로 되돌리면 인자와 결과가 같은 물리 레코드가 되어 앞 세 단언이 깨진다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `dune build --root . @test/runtest-test_server_dashboard_http_keeper_api_trace` → 16/16 통과. 기존 `runtime_manifest_scan` 케이스가 스캔·진단 경로를 실제로 실행하고, 새 케이스가 fold의 값 의미를 고정한다.

## 효과 (실측)

`lib/` 의 `mutable <name> :` 선언 수:

| | main (#28074 이후) | 이 PR 이후 |
|---|---|---|
| `lib/*.ml` | 254 | 227 |
| `lib/*.mli` | 98 | 71 |
| 합계 | 352 | 298 |

이 PR 단독 −54. #28074(−6)와 합쳐 358 → 298, −60 (16.8%).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

#28079는 스택 base 브랜치가 #28074 병합과 함께 삭제되면서 자동으로 닫혔다. 같은 작업을 `main` 기준으로 다시 올린 것이다.
