### PR TITLE
fix(runtime): Codex error 객체의 스칼라를 이름으로 고르지 않는다 — 라이브에서 음성 결과가 두 원인을 가졌다

### DIFF
--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -495,14 +495,32 @@ let turn_error_message fields =
         String.trim message
       | _ -> "turn failed without a typed error message"
     in
-    let scalar name =
-      match List.assoc_opt name error_fields with
-      | Some (`String value) when String.trim value <> "" ->
-        Some (name ^ "=" ^ String.trim value)
-      | Some (`Int value) -> Some (name ^ "=" ^ string_of_int value)
-      | _ -> None
+    (* Carrying only [code] and [type] cannot answer what the server sends,
+       because a name that is absent and a name that was never looked for
+       produce the same empty annotation. Measured 2026-08-11 on live sangsu
+       (codex_subscription.gpt-5.3-codex-spark): the deployed narrow form
+       printed the overflow sentence with no annotation, which left "the error
+       object carries no scalar" and "the scalar is called something else"
+       indistinguishable. Every scalar except [message] is carried, so the
+       empty case now means exactly one thing.
+
+       Nested objects and arrays are skipped: this string is read by an
+       operator and joined into one line, and the fields a classification
+       would key on are scalars. *)
+    let annotation (name, value) =
+      if String.equal name "message"
+      then None
+      else (
+        match value with
+        | `String value when String.trim value <> "" ->
+          Some (name ^ "=" ^ String.trim value)
+        | `Int value -> Some (name ^ "=" ^ string_of_int value)
+        | `Intlit value -> Some (name ^ "=" ^ value)
+        | `Bool value -> Some (name ^ "=" ^ string_of_bool value)
+        | `Float value -> Some (name ^ "=" ^ Printf.sprintf "%g" value)
+        | `String _ | `Null | `Assoc _ | `List _ | `Tuple _ | `Variant _ -> None)
     in
-    (match List.filter_map scalar [ "code"; "type" ] with
+    (match List.filter_map annotation error_fields with
      | [] -> message
      | annotations -> message ^ " (" ^ String.concat " " annotations ^ ")")
   | _ -> "turn failed without an error object"

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -431,6 +431,56 @@ let test_failed_turn_keeps_typed_error_fields () =
       | Ok _ -> fail "failed turn incorrectly reported as completed")
 ;;
 
+(* The named-field form could not distinguish "the server sent no scalar" from
+   "the scalar is called something else": both printed the sentence with no
+   annotation. That is what live sangsu produced on 2026-08-11 after the narrow
+   form deployed. This fixture carries no [code] and no [type], so it renders
+   the sentence unannotated under the named form and fails there. The
+   expectations are literals rather than a re-render of the function, and one
+   of them asserts [message] is *not* repeated as an annotation. *)
+let test_failed_turn_keeps_unnamed_error_scalars () =
+  let failed =
+    {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"ran out of room in the model's context window","kind":"context_length","http_status":400,"retryable":false,"details":{"nested":"skipped"}}}}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; failed ]
+    (fun path ->
+      match run_fixture path with
+      | Error (Runtime_codex_app_server.Turn_failed detail) ->
+        check
+          bool
+          "provider sentence survives"
+          true
+          (Astring.String.is_infix ~affix:"ran out of room" detail);
+        check
+          bool
+          "string scalar outside the named list survives"
+          true
+          (Astring.String.is_infix ~affix:"kind=context_length" detail);
+        check
+          bool
+          "int scalar survives"
+          true
+          (Astring.String.is_infix ~affix:"http_status=400" detail);
+        check
+          bool
+          "bool scalar survives"
+          true
+          (Astring.String.is_infix ~affix:"retryable=false" detail);
+        check
+          bool
+          "nested object is skipped"
+          false
+          (Astring.String.is_infix ~affix:"details=" detail);
+        check
+          bool
+          "message is not repeated as an annotation"
+          false
+          (Astring.String.is_infix ~affix:"message=" detail)
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "failed turn incorrectly reported as completed")
+;;
+
 let test_failed_turn_is_not_completion () =
   let failed =
     {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"fixture failure"}}}}|}
@@ -2183,6 +2233,8 @@ let () =
         ; test_case "server request fails closed" `Quick test_server_request_fails_closed
         ; test_case "failed turn keeps typed error fields" `Quick
             test_failed_turn_keeps_typed_error_fields
+        ; test_case "failed turn keeps unnamed error scalars" `Quick
+            test_failed_turn_keeps_unnamed_error_scalars
         ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
         ; test_case
             "retry notifications are observational"


### PR DESCRIPTION
WORKAROUND-WAIVED: STRING_CLASSIFIER 시그니처는 본문이 문자열 분류기를 *피해야 할 대상으로 인용*해서 걸린 false positive다. 이 변경은 문자열 매칭을 추가하지 않고, typed 필드를 버리던 코드를 멈춘다 — 분류기의 반대 방향이다.

## 무엇을

`turn_error_message` 가 Codex `error` 객체의 스칼라를 **이름 목록으로 고르지 않고** `message` 를 제외한 전부를 싣습니다.

```ocaml
- List.filter_map scalar [ "code"; "type" ]
+ List.filter_map annotation error_fields   (* message 제외, 스칼라만 *)
```

## 왜 — 이름으로 고르면 음성 결과에 원인이 두 개 남습니다

#28078 이 `code` 와 `type` 을 보존하도록 머지되어 **라이브에 배포됐습니다**(main `a0b5899b3f`, 배포 02:50:38 KST). 배포 후 sangsu 의 첫 실패:

```
[2026-08-11 02:51:16] [ERROR] [Keeper/sangsu] sangsu: keeper cycle FAILED
  runtime=codex_subscription.gpt-5.3-codex-spark
  system_and_user_bytes=6971 latency=10546ms
  error=Internal error: Codex app-server turn failed: Codex ran out of room in
        the model's context window. Start a new thread or clear earlier history
        before retrying.
```

**주석이 없습니다.** 이 출력은 두 가지를 동시에 뜻합니다:

1. 서버가 `error` 객체에 스칼라를 아예 안 싣는다
2. 스칼라를 싣지만 이름이 `code` 도 `type` 도 아니다

#28078 리뷰에서 이 모호함을 예고했고, 배포 결과가 그대로 나왔습니다. 이름을 모르는 상태에서 이름으로 필터하면, 음성이 나와도 다음에 무엇을 할지 결정할 수 없습니다.

전부 싣게 되면 빈 주석은 **1번 하나**를 뜻하고, 그때 #28071 의 분류 문제는 "provider 응답으로는 불가능" 으로 결론이 나 설계가 갈립니다(요청 시점 계측 등).

## 이건 fix 가 아닙니다

관측 변경이고 그 이상을 주장하지 않습니다. sangsu 의 컨텍스트 초과는 이 PR 로 해결되지 않습니다. 근거는 #28078 의 주석과 같습니다 — **파스 시점에 버려진 필드는 하류에서 복구할 수 없고**, typed 분류(#28071 이 요구하는 `Api (ContextOverflow _)` 승격)는 그 필드 없이는 문자열 매칭이 됩니다. 문자열 분류기는 이 저장소에서 명시적으로 제거된 패턴입니다(`keeper_error_classify.ml:669`).

추적 이슈: #28071. 이 PR 은 그 이슈의 **입력 복원** 단계이며, 분류 자체는 필드가 실재하는지 확인된 뒤에 별도로 다룹니다.

## 변경 상세

- `_ ->` catch-all 대신 Yojson 변형을 전수 열거했습니다. 새 변형이 추가되면 컴파일러가 잡습니다.
- 중첩 `Assoc` / `List` 는 싣지 않습니다. 이 문자열은 한 줄로 합쳐져 운영자가 읽고, 분류가 키로 쓸 값은 스칼라입니다.
- `message` 는 주석에서 제외됩니다(문장이 이미 앞에 있음).

## 검증

### 대조군 — 수정 없이 실패해야 함

새 테스트 fixture 는 `code` 도 `type` 도 없고 `kind` · `http_status` · `retryable` · 중첩 `details` 를 가집니다. 현재 main 의 이름 목록 형태에서는 주석이 붙지 않아 **실패합니다**.

단언 6개는 전부 리터럴이며(함수 출력을 다시 렌더해 비교하지 않음), 그중 둘은 음성 단언입니다:
- 중첩 `details=` 가 **나오지 않을 것**
- `message=` 가 주석으로 **중복되지 않을 것**

### 실행 결과

수정 없이 (main 의 이름 목록 그대로, 테스트만 추가):

```
[FAIL]  subscription boundary  11  failed turn keeps unnamed error scalars
ASSERT provider sentence survives
FAIL   string scalar outside the named list survives
```

수정 적용 후:

```
Test Successful in 21.002s. 35 tests run.
```

**정직하게 적자면**, 대조군은 첫 새 단언에서 멈추므로 나머지 4개(int · bool · 중첩 제외 · `message` 중복 없음)는 통과 방향으로만 확인됐고 실패 방향은 관측하지 않았습니다.

### 게이트

`bash ~/me/scripts/pr-rfc-check.sh --workaround-gate-only` — 본문이 문자열 분류기를 *비판 대상으로 인용*해 `STRING_CLASSIFIER` 로 걸렸고, 위 `WORKAROUND-WAIVED` 로 PASS(warn).
