### PR TITLE
refactor(activity-graph): rebind node and edge entries instead of writing through

### DIFF
--- a/lib/activity_graph/activity_graph_reducer.ml
+++ b/lib/activity_graph/activity_graph_reducer.ml
@@ -5,11 +5,11 @@ open Activity_graph_types
 type node_acc = {
   node_id : string;
   node_kind : string;
-  mutable label : string;
-  mutable status : node_status;
-  mutable weight : int;
-  mutable last_event_at : string;
-  mutable meta : Yojson.Safe.t;
+  label : string;
+  status : node_status;
+  weight : int;
+  last_event_at : string;
+  meta : Yojson.Safe.t;
 }
 
 type edge_acc = {
@@ -17,10 +17,10 @@ type edge_acc = {
   source : string;
   target : string;
   edge_kind : string;
-  mutable weight : int;
-  mutable active : bool;
-  mutable last_event_at : string;
-  mutable meta : Yojson.Safe.t;
+  weight : int;
+  active : bool;
+  last_event_at : string;
+  meta : Yojson.Safe.t;
 }
 
 let entity_node_id (value : entity_ref) = value.kind ^ ":" ^ value.id
@@ -41,14 +41,25 @@ let ensure_node (nodes : (string, node_acc) Hashtbl.t) ~(id : string)
     ~(status : node_status) ~(ts_iso : string) ~(meta : Yojson.Safe.t) =
   match Hashtbl.find_opt nodes id with
   | Some node ->
-      node.weight <- node.weight + 1;
-      node.last_event_at <- ts_iso;
-      if node.label = id || node.label = "" then node.label <- label;
-      if status <> Unset
-         && (not (is_generic_status status) || is_generic_status node.status)
-      then
-        node.status <- status;
-      if meta <> default_meta then node.meta <- meta
+      (* The table owns the node, so an update is a rebind rather than an
+         in-place write. Every field below reads [node] from before this
+         event, which is what the in-place form observed too. *)
+      Hashtbl.replace nodes id
+        {
+          node with
+          weight = node.weight + 1;
+          last_event_at = ts_iso;
+          label =
+            (if node.label = id || node.label = "" then label else node.label);
+          status =
+            (if
+               status <> Unset
+               && (not (is_generic_status status)
+                  || is_generic_status node.status)
+             then status
+             else node.status);
+          meta = (if meta <> default_meta then meta else node.meta);
+        }
   | None ->
       Hashtbl.add nodes id
         {
@@ -78,10 +89,14 @@ let ensure_edge (edges : (string, edge_acc) Hashtbl.t) ~source ~target ~kind
   let edge_id = source ^ "|" ^ kind ^ "|" ^ target in
   match Hashtbl.find_opt edges edge_id with
   | Some edge ->
-      edge.weight <- edge.weight + 1;
-      edge.active <- active;
-      edge.last_event_at <- ts_iso;
-      if meta <> default_meta then edge.meta <- meta
+      Hashtbl.replace edges edge_id
+        {
+          edge with
+          weight = edge.weight + 1;
+          active;
+          last_event_at = ts_iso;
+          meta = (if meta <> default_meta then meta else edge.meta);
+        }
   | None ->
       Hashtbl.add edges edge_id
         {
@@ -127,7 +142,7 @@ let reduce_event ~nodes ~edges (value : event) =
     match subject_id with
     | Some id -> (
         match Hashtbl.find_opt nodes id with
-        | Some node -> node.status <- status
+        | Some node -> Hashtbl.replace nodes id { node with status }
         | None -> ())
     | None -> ()
   in
@@ -135,7 +150,7 @@ let reduce_event ~nodes ~edges (value : event) =
     match actor_id with
     | Some id -> (
         match Hashtbl.find_opt nodes id with
-        | Some node -> node.status <- status
+        | Some node -> Hashtbl.replace nodes id { node with status }
         | None -> ())
     | None -> ()
   in

--- a/lib/activity_graph/activity_graph_reducer.mli
+++ b/lib/activity_graph/activity_graph_reducer.mli
@@ -1,5 +1,5 @@
 (** Activity_graph_reducer — graph reducer that folds {!event}s
-    into mutable node / edge accumulators.
+    into node / edge accumulators held by the caller's tables.
 
     The reducer is the single seam between the append-only event
     log and the live graph view.  {!Activity_graph} consumes
@@ -15,30 +15,32 @@
 type node_acc = {
   node_id : string;
   node_kind : string;
-  mutable label : string;
-  mutable status : Activity_graph_types.node_status;
-  mutable weight : int;
-  mutable last_event_at : string;
-  mutable meta : Yojson.Safe.t;
+  label : string;
+  status : Activity_graph_types.node_status;
+  weight : int;
+  last_event_at : string;
+  meta : Yojson.Safe.t;
 }
-(** Per-node accumulator.  Mutable fields for in-place update —
-    each event hit on the same [node_id] increments [weight] and
-    refreshes [last_event_at] / [meta] in place. *)
+(** Per-node accumulator.  Immutable: each event hit on the same
+    [node_id] rebinds the table entry to a record with [weight]
+    incremented and [last_event_at] / [meta] refreshed.  A record read
+    out of the table before a later event keeps the values it was read
+    with. *)
 
 type edge_acc = {
   edge_id : string;
   source : string;
   target : string;
   edge_kind : string;
-  mutable weight : int;
-  mutable active : bool;
-  mutable last_event_at : string;
-  mutable meta : Yojson.Safe.t;
+  weight : int;
+  active : bool;
+  last_event_at : string;
+  meta : Yojson.Safe.t;
 }
-(** Per-edge accumulator.  Mutable fields for in-place update —
-    each event hit on the same [(source, kind, target)] tuple
-    increments [weight] and updates [active] / [last_event_at] /
-    [meta] in place.
+(** Per-edge accumulator.  Immutable, like {!node_acc}: each event hit
+    on the same [(source, kind, target)] tuple rebinds the table entry
+    with [weight] incremented and [active] / [last_event_at] / [meta]
+    refreshed.
 
     [edge_id] format pinned: ["<source>|<kind>|<target>"]. *)
 
@@ -50,7 +52,8 @@ val reduce_event :
   Activity_graph_types.event ->
   unit
 (** [reduce_event ~nodes ~edges value] folds [value] into the
-    accumulators in place.  Effects (in order):
+    accumulator tables.  The tables are mutated; the records they hold
+    are replaced, not written through.  Effects (in order):
 
     + Ensure a [workspace:<workspace_id>] node exists with status [Workspace]
       and the event's [ts_iso].

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -734,6 +734,50 @@ let test_span_status_of_string_opt_returns_none_for_unknown () =
     (Activity_graph.span_status_of_string_opt "open"
      |> Option.map Activity_graph.span_status_to_string)
 
+
+(* Node accumulators are values, not cells. A record read out of the table
+   before a later event keeps what it was read with, while the table itself
+   advances. Against the previous in-place form both checks on [first] would
+   fail, because [first] and the table entry were the same physical record. *)
+let test_reducer_replaces_node_entries_instead_of_writing_through () =
+  let nodes = Hashtbl.create 8 in
+  let edges = Hashtbl.create 8 in
+  let event seq ts_iso : Activity_graph_types.event =
+    {
+      seq;
+      ts_ms = seq * 1000;
+      ts_iso;
+      workspace_id = "ws-immutable-reducer";
+      kind = "task.assigned";
+      actor = Some { kind = "agent"; id = "a1" };
+      subject = Some { kind = "task"; id = "t1" };
+      payload = `Assoc [];
+      tags = [];
+    }
+  in
+  Activity_graph_reducer.reduce_event ~nodes ~edges
+    (event 1 "2026-01-01T00:00:00Z");
+  let first : Activity_graph_reducer.node_acc =
+    match Hashtbl.find_opt nodes "agent:a1" with
+    | Some node -> node
+    | None -> fail "actor node missing after the first event"
+  in
+  check int "first read sees one hit" 1 first.weight;
+  Activity_graph_reducer.reduce_event ~nodes ~edges
+    (event 2 "2026-01-02T00:00:00Z");
+  check int "the earlier record keeps its weight" 1 first.weight;
+  check string "the earlier record keeps its timestamp" "2026-01-01T00:00:00Z"
+    first.last_event_at;
+  let second : Activity_graph_reducer.node_acc =
+    match Hashtbl.find_opt nodes "agent:a1" with
+    | Some node -> node
+    | None -> fail "actor node missing after the second event"
+  in
+  check int "the table advances the weight" 2 second.weight;
+  check string "the table advances the timestamp" "2026-01-02T00:00:00Z"
+    second.last_event_at
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -783,5 +827,10 @@ let () =
             test_current_day_cache_rescans_from_zero_on_truncation;
           test_case "past-day cache evicts entries for deleted files" `Quick
             test_past_day_cache_evicts_entries_for_deleted_files;
+        ] );
+      ( "reducer",
+        [
+          test_case "a later event replaces the node entry rather than writing through"
+            `Quick test_reducer_replaces_node_entries_instead_of_writing_through;
         ] );
     ]


### PR DESCRIPTION
## 목표

`activity_graph_reducer`의 `node_acc` / `edge_acc`가 들고 있던 `mutable` 9개를 제거하고, 그래프 누산기 갱신을 제자리 쓰기에서 테이블 재바인딩으로 바꾼다.

## 판정 근거 — grep이 아니라 컴파일러

이 레코드는 `label`, `status`, `weight`, `active`, `meta`, `last_event_at` 처럼 흔한 필드명을 쓴다. 필드명으로 `<-` 대입을 세면 외부 writer가 13건 나오지만, 전부 **다른 레코드의 동명 필드**였다:

| 오탐 지점 | 실제 수신자 |
|---|---|
| `fs_compat/fd_cache.ml:73` `w.active <-` | fd 워커 카운터 |
| `workspace/heartbeat.ml:46` `hb.active <-` | 하트비트 상태 |
| `inference_inflight_observation.ml:37` `global.active <-` | in-flight 카운터 |
| `voice/voice_session_manager.ml:276` `session.status <-` | 보이스 세션 |
| `gate/connector_ingress_lane.ml:101` `state.active <-` | 게이트 레인 |
| `keeper/keeper_turn_dispatch_authority.ml:8` `token.active <-` | 디스패치 토큰 |
| `keeper/keeper_run_tools_hooks.ml:217` `acc.meta <-` | 훅 누산기 |

그래서 필드명 매칭 대신 `mutable`을 떼고 빌드해 컴파일러가 짚는 대입 지점만 남겼다. 결과: 진짜 쓰기는 전부 `activity_graph_reducer.ml` 안(`ensure_node`, `ensure_edge`, `set_subject_status`, `set_actor_status`)이다.

## 왜 재바인딩이 동치인가

- 레코드는 호출자의 Hashtbl에 산다. 유일한 호출자 `activity_graph.ml:637`이 테이블을 만들고 `List.iter (reduce_event ~nodes ~edges) events` 후 `Hashtbl.fold`로 꺼낸다. 이벤트 사이에 레코드 참조를 붙들고 있는 곳이 없다.
- `Hashtbl.add`는 `find_opt`가 `None`일 때만 호출되므로 키당 바인딩이 하나다. 따라서 `Hashtbl.replace`는 그 하나를 교체하는 것과 같다.
- 갱신식의 모든 조건은 `node` / `edge`(이벤트 이전 값)를 읽는다. 제자리 형태가 관찰하던 값과 동일하다.

## 문서

`.mli`의 두 doc 주석이 "Mutable fields for in-place update"라고 적혀 있었다. 이제 재바인딩을 기술한다. `reduce_event` 주석의 "folds in place"도 고쳤다.

## 테스트

테이블에서 꺼낸 레코드가 이후 이벤트에 흔들리지 않는다는 것을 단언하는 케이스를 추가했다.

이 테스트는 수정 전 트리에서 실제로 실패하는 것을 확인했다. `lib/activity_graph/activity_graph_reducer.{ml,mli}`만 `origin/main` 버전으로 되돌리고 돌리면 `the earlier record keeps its weight`에서 FAIL 한다 (제자리 형태에서는 꺼낸 레코드와 테이블 항목이 같은 물리 레코드이기 때문).

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `dune build --root . @test/runtest-test_activity_graph` → 21/21 통과

## 효과 (실측)

`lib/` 의 `mutable <name> :` 선언 수:

| | main | 이 PR 이후 |
|---|---|---|
| `lib/*.ml` | 254 | 245 |
| `lib/*.mli` | 98 | 89 |
| 합계 | 352 | 334 |

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
