### PR TITLE
refactor(dashboard): accumulate generation stats by rebinding the table entry

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -192,34 +192,48 @@ let compute_metrics_window
                  let generation_stats_row =
                    match Hashtbl.find_opt generation_stats generation with
                    | Some stats -> stats
-                   | None ->
-                       let stats = create_keeper_gen_window_stats () in
-                       Hashtbl.add generation_stats generation stats;
-                       stats
+                   | None -> create_keeper_gen_window_stats ()
                  in
-                 generation_stats_row.turns <-
-                   generation_stats_row.turns + 1;
-                 (match usage with
-                  | Some (input, output, total) ->
-                      generation_stats_row.usage_points <-
-                        generation_stats_row.usage_points + 1;
-                      generation_stats_row.input_tokens <-
-                        generation_stats_row.input_tokens + input;
-                      generation_stats_row.output_tokens <-
-                        generation_stats_row.output_tokens + output;
-                      generation_stats_row.total_tokens <-
-                        generation_stats_row.total_tokens + total
-                  | None -> ());
-                 if handoff_performed
-                 then
-                   generation_stats_row.handoffs <-
-                     generation_stats_row.handoffs + 1;
-                 if
-                   generation_stats_row.first_ts <= 0.0
-                   || ts_unix < generation_stats_row.first_ts
-                 then generation_stats_row.first_ts <- ts_unix;
-                 if ts_unix > generation_stats_row.last_ts
-                 then generation_stats_row.last_ts <- ts_unix;
+                 let usage_points, input_tokens, output_tokens, total_tokens =
+                   match usage with
+                   | Some (input, output, total) ->
+                       ( generation_stats_row.usage_points + 1,
+                         generation_stats_row.input_tokens + input,
+                         generation_stats_row.output_tokens + output,
+                         generation_stats_row.total_tokens + total )
+                   | None ->
+                       ( generation_stats_row.usage_points,
+                         generation_stats_row.input_tokens,
+                         generation_stats_row.output_tokens,
+                         generation_stats_row.total_tokens )
+                 in
+                 (* [Hashtbl.replace] inserts when the generation is new, so
+                    the row no longer has to be added before it is filled in.
+                    [tools] is the same table either way — the record update
+                    copies the handle, not the contents. *)
+                 Hashtbl.replace generation_stats generation
+                   {
+                     generation_stats_row with
+                     turns = generation_stats_row.turns + 1;
+                     usage_points;
+                     input_tokens;
+                     output_tokens;
+                     total_tokens;
+                     handoffs =
+                       (if handoff_performed
+                        then generation_stats_row.handoffs + 1
+                        else generation_stats_row.handoffs);
+                     first_ts =
+                       (if
+                          generation_stats_row.first_ts <= 0.0
+                          || ts_unix < generation_stats_row.first_ts
+                        then ts_unix
+                        else generation_stats_row.first_ts);
+                     last_ts =
+                       (if ts_unix > generation_stats_row.last_ts
+                        then ts_unix
+                        else generation_stats_row.last_ts);
+                   };
                  List.iter
                    (count_table_incr generation_stats_row.tools)
                    tools_used;

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -21,14 +21,14 @@ let normalize_model_name s =
   Runtime_provider_binding.normalize_runtime_name_for_bucket s
 
 type keeper_gen_window_stats = {
-  mutable turns: int;
-  mutable usage_points: int;
-  mutable input_tokens: int;
-  mutable output_tokens: int;
-  mutable total_tokens: int;
-  mutable handoffs: int;
-  mutable first_ts: float;
-  mutable last_ts: float;
+  turns: int;
+  usage_points: int;
+  input_tokens: int;
+  output_tokens: int;
+  total_tokens: int;
+  handoffs: int;
+  first_ts: float;
+  last_ts: float;
   tools: (string, int) Hashtbl.t;
 }
 

--- a/lib/dashboard/dashboard_http_keeper_metrics.mli
+++ b/lib/dashboard/dashboard_http_keeper_metrics.mli
@@ -21,14 +21,14 @@ val normalize_model_name : string -> string
 (** {1 Per-keeper window statistics (runtime-visible)} *)
 
 type keeper_gen_window_stats = {
-  mutable turns : int;
-  mutable usage_points : int;
-  mutable input_tokens : int;
-  mutable output_tokens : int;
-  mutable total_tokens : int;
-  mutable handoffs : int;
-  mutable first_ts : float;
-  mutable last_ts : float;
+  turns : int;
+  usage_points : int;
+  input_tokens : int;
+  output_tokens : int;
+  total_tokens : int;
+  handoffs : int;
+  first_ts : float;
+  last_ts : float;
   tools : (string, int) Hashtbl.t;
 }
 (** Per-keeper rolling-window statistics record.  All counters

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -256,6 +256,62 @@ let test_history_summary_decodes_content_blocks () =
             content
       | _ -> fail "expected non-empty conversation list")
 
+
+(* [generation_stats] rows are values held in a table: each turn rebinds the
+   entry rather than writing through a shared record. Two turns in the same
+   generation must still accumulate, a second generation must not inherit the
+   first one's totals, and the per-generation tool table must survive the
+   rebinding. *)
+let test_generation_equipment_accumulates_across_rebinds () =
+  let turn ~generation ~ts_unix tools =
+    match metric tools with
+    | `Assoc fields ->
+        `Assoc
+          (("generation", `Int generation)
+          :: ("ts_unix", `Float ts_unix)
+          :: List.filter
+               (fun (key, _) -> key <> "generation" && key <> "ts_unix")
+               fields)
+    | other -> other
+  in
+  let _, summary, _ =
+    Detail.compute_metrics_window
+      ~parsed_metrics:
+        [
+          turn ~generation:1 ~ts_unix:10.0 [ "tool_execute" ];
+          turn ~generation:1 ~ts_unix:30.0 [ "tool_execute" ];
+          turn ~generation:2 ~ts_unix:50.0 [ "tool_read" ];
+        ]
+      ~compact:false
+      ~series_points:80
+  in
+  let open Yojson.Safe.Util in
+  let equipment = summary |> member "generation_equipment" |> to_list in
+  check int "one entry per generation" 2 (List.length equipment);
+  let entry generation =
+    match
+      List.find_opt
+        (fun row -> row |> member "generation" |> to_int = generation)
+        equipment
+    with
+    | Some row -> row
+    | None -> fail (Printf.sprintf "generation %d missing" generation)
+  in
+  let first = entry 1 in
+  check int "same generation accumulates turns" 2 (first |> member "turns" |> to_int);
+  check (float 0.001) "earliest ts retained" 10.0
+    (first |> member "first_ts_unix" |> to_float);
+  check (float 0.001) "latest ts retained" 30.0
+    (first |> member "last_ts_unix" |> to_float);
+  check int "tool table survives the rebind" 2
+    (first |> member "top_tool" |> member "count" |> to_int);
+  let second = entry 2 in
+  check int "a new generation starts from zero" 1
+    (second |> member "turns" |> to_int);
+  check (float 0.001) "new generation keeps its own first ts" 50.0
+    (second |> member "first_ts_unix" |> to_float)
+;;
+
 let () =
   run "dashboard_keeper_metrics_10286"
     [
@@ -270,6 +326,8 @@ let () =
             test_metrics_window_does_not_classify_execute_as_pr_work;
           test_case "preserves current turn telemetry" `Quick
             test_metrics_series_preserves_current_turn_telemetry;
+          test_case "generation equipment accumulates across rebinds" `Quick
+            test_generation_equipment_accumulates_across_rebinds;
           test_case "omits retired model and handoff labels" `Quick
             test_metrics_window_omits_retired_model_and_handoff_labels;
         ] );


### PR DESCRIPTION
## 목표

`keeper_gen_window_stats`의 `mutable` 8개를 제거하고, 세대별 집계를 제자리 쓰기에서 테이블 재바인딩으로 바꾼다.

## 판정 근거

`turns`, `handoffs`, `first_ts` 같은 이름은 다른 레코드에도 있어 필드명 grep이 신뢰할 수 없다. `mutable`을 떼고 빌드해 컴파일러가 짚은 대입 지점만 셌고, 유일한 writer는 `dashboard_http_keeper_detail.ml`의 집계 루프였다.

## 변경

새 카운터를 먼저 계산한 뒤 `Hashtbl.replace`로 저장한다. `replace`는 키가 없으면 삽입하므로, 행을 채우기 전에 테이블에 미리 넣어둘 필요가 없어졌다.

`tools`는 `Hashtbl.t` 그대로다. 레코드 갱신은 핸들만 복사하므로 세대별 도구 카운트는 같은 테이블에 계속 쌓인다.

## 테스트

`generation_equipment` 집계에는 테스트가 없었다. 이 재작성이 깨뜨릴 수 있는 경로를 덮는 케이스를 추가했다:

- 같은 세대의 두 턴이 누적되는가 (`Hashtbl.replace` 누락 시 실패)
- 새 세대가 0에서 시작하는가 (세대 오염 시 실패)
- `first_ts` / `last_ts` 가 각각 최초·최신 스탬프를 유지하는가 (조건 뒤바뀜 시 실패)
- 도구 테이블이 재바인딩을 넘어 살아남는가 (핸들 분실 시 실패)

이 테스트는 수정 전 코드에서도 통과한다. 레코드가 `compute_metrics_window` 내부에만 있어 값 의미를 외부에서 관찰할 수 없기 때문이며, 따라서 불변성 고정이 아니라 **동작 보존** 테스트다. 이 점을 숨기지 않는다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `dune build --root . @test/runtest-test_dashboard_keeper_metrics_10286` → 6/6 통과

## 효과 (실측)

`lib/` 의 `mutable <name> :` 선언 수:

| | main | 이 PR 이후 |
|---|---|---|
| `lib/*.ml` | 227 | 219 |
| `lib/*.mli` | 71 | 63 |
| 합계 | 298 | 282 |

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
