### PR TITLE
fix(keeper): protect the store-transition lock cleanup from cancellation

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -340,19 +340,25 @@ let with_store_transition_lock ~base_path ~request_id f =
         Store_transition_table.add store_transition_locks key lock;
         lock)
   in
-  (* fun-protect-finally-ok: the registry user-count cleanup acquires only the
-     cancellation-protected bookkeeping mutex; it awaits no external event and
-     cannot strand the protected exception behind cancellable cleanup. *)
+  (* fun-protect-finally-ok: the user-count decrement runs under
+     [Eio.Cancel.protect], so it completes even when [f] raised because this
+     fiber is being cancelled. [Eio.Mutex.use_rw ~protect:true] is not enough on
+     its own: Eio documents [protect] as covering the critical section, not the
+     wait for the lock, so a contended [mu] would abort the cleanup and leave
+     [lock.users] above zero — the entry keyed by request id would then never be
+     removed from [store_transition_locks]. [with_keeper_lane_lock] below already
+     protects its cleanup the same way. *)
   Fun.protect
     ~finally:(fun () ->
-      Eio.Mutex.use_rw ~protect:true mu (fun () ->
-        lock.users <- lock.users - 1;
-        if lock.users = 0
-        then
-          match Store_transition_table.find_opt store_transition_locks key with
-          | Some current when current == lock ->
-            Store_transition_table.remove store_transition_locks key
-          | Some _ | None -> ()))
+      Eio.Cancel.protect (fun () ->
+        Eio.Mutex.use_rw ~protect:true mu (fun () ->
+          lock.users <- lock.users - 1;
+          if lock.users = 0
+          then
+            match Store_transition_table.find_opt store_transition_locks key with
+            | Some current when current == lock ->
+              Store_transition_table.remove store_transition_locks key
+            | Some _ | None -> ())))
     (fun () -> Eio.Mutex.use_rw ~protect:true lock.mutex f)
 ;;
 


### PR DESCRIPTION
## 결함

`with_store_transition_lock`은 레지스트리 참조 카운트를 `Fun.protect ~finally` 안에서 감소시키면서 `Eio.Mutex.use_rw ~protect:true mu` 만으로 보호했다.

Eio 1.3 `eio_mutex.mli`의 `use_rw` 문서:

> `@param protect` If `[true]`, uses `Cancel.protect` to prevent the critical section from being cancelled. **Cancellation is not prevented while waiting to take the lock.**

즉 `~protect:true`는 임계구역만 덮고 **락 대기는 취소 가능**하다. `f`가 파이버 취소 때문에 예외를 던진 상태에서 `mu`가 경합 중이면, cleanup이 감소 전에 중단된다.

결과:

1. `lock.users`가 0으로 돌아가지 않아 `store_transition_locks`에서 항목이 제거되지 않는다. 키가 `{base_path; request_id}`이고 request id는 재사용되지 않으므로, 취소 경로를 따라 테이블이 무한히 자란다.
2. 남은 카운트 때문에, 같은 키를 다음에 잡는 쪽도 제거 조건(`users = 0`)에 도달하지 못한다.

기존 주석은 "acquires only the cancellation-protected bookkeeping mutex; it awaits no external event" 라고 적고 있었는데, 경합 시 `mu`를 기다리므로 사실과 다르다.

## 수정

cleanup을 `Eio.Cancel.protect`로 감싼다. 같은 파일의 두 번째 레지스트리인 `with_keeper_lane_lock`은 **이미 같은 방식으로 보호하고 있다** — 이 PR은 갈라진 한 벌을 맞추는 것이다.

## 같은 패턴의 다른 구현 (영향 없음)

`Keeper_fs.release_path_lock` 과 `Fusion_delivery_obligation.release_operation_lock` 도 동일한 refcount 패턴이지만 레지스트리에 `Stdlib.Mutex` 를 쓴다. Eio 취소 지점이 아니므로 이 결함이 없다. (같은 패턴이 3개 모듈에 4벌 복제돼 있다는 점은 별개 문제로 남긴다.)

## 테스트

회귀 테스트를 넣지 않았다. 이 창을 재현하려면 `mu` 경합 중에 취소가 도착해야 하고, 레지스트리를 관찰할 접근자가 없다. 접근자를 추가하는 것은 테스트 백도어이므로 하지 않았다.

`python3 scripts/check_test_coverage.py` 는 이 diff에서 통과한다 (exit 0). `# ci:skip-test-coverage` 는 게이트가 트립하지 않았으므로 넣지 않았다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `test_keeper_msg_async_durable_active_inventory` 4/4, `test_keeper_msg_async_path_traversal` 3/3 통과
- `test_keeper_msg_async_terminal_event` 의 `settlement carries BasePath identity` 실패는 `origin/main` 에서 동일하게 재현되는 기존 실패이고 이 변경과 무관하다. 해당 스위트는 CI 실행 목록에 없다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
