### PR TITLE
ci(keeper): 미배선 Gate·승인 스위트 5개를 실행한다 — 그중 하나는 이미 red 였다

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=686
+UNWIRED_BASELINE=681
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -46,6 +46,11 @@ normal_targets=(
   @test/runtest-test_keeper_approval_queue
   @test/runtest-test_keeper_hitl_resolution_prompt
   @test/runtest-test_keeper_approval_audit_timeline
+  @test/runtest-test_keeper_approval_queue_rules
+  @test/runtest-test_keeper_approval_queue_rules_types
+  @test/runtest-test_keeper_approval_resolved_history
+  @test/runtest-test_keeper_gate_effect_coverage
+  @test/runtest-test_keeper_gate_replay
   @test/runtest-test_verification
   @test/runtest-test_tool_schema_constraint_enforcement
   @test/runtest-test_keeper_artifact_read_request

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -170,10 +170,25 @@ let test_second_tool_snapshot_contains_first_tool_result () =
       "tool_read_file"
       Yojson.Safe.Util.(call |> member "operation" |> to_string);
     check yojson "first input" first_input Yojson.Safe.Util.(call |> member "input");
-    check yojson
-      "first result"
-      (Tool_result.data first_result)
-      Yojson.Safe.Util.(call |> member "result")
+    check
+      string
+      "first disposition"
+      (Tool_result.string_of_disposition first_result)
+      Yojson.Safe.Util.(call |> member "disposition" |> to_string);
+    (* [result] is deliberately absent from this rendering. The cell records the
+       typed result, but the judge is asked to weigh operation identity and
+       input, never the payload a previous tool returned; rendering it put whole
+       tool outputs into a prompt about a different call and the judge slot
+       refused them. [disposition] carries the part the judgment turns on.
+       Asserting absence rather than dropping the check keeps a re-added
+       [result] failing here instead of silently restoring that shape. *)
+    check
+      bool
+      "first result stays out of the judge rendering"
+      true
+      (match Yojson.Safe.Util.(call |> member "result") with
+       | `Null -> true
+       | _ -> false)
   | _ -> failf "expected one completed call, got %d" (List.length calls)
 ;;
 


### PR DESCRIPTION
## 무엇을

Gate·승인 스위트 **5개를 CI 에 배선**하고, 그중 하나가 붙잡고 있던 죽은 필드 단언을 고칩니다.

## 왜 — Gate 는 효과가 워크스페이스를 나가는 경계입니다

`#27297` 이 지적한 7개 스위트 중 CI 가 이름을 부르는 것은 2개뿐이었습니다.

```bash
$ rg -o 'runtest-test_keeper_(approval|gate)[a-z_]*' .github/workflows/*.yml scripts/ci-run-focused-tests.sh
scripts/ci-run-focused-tests.sh:runtest-test_keeper_approval_audit_timeline
scripts/ci-run-focused-tests.sh:runtest-test_keeper_approval_queue
```

나머지 5개는 컴파일만 됐고, **그중 하나는 이미 red 였습니다.** 아무도 보지 않았기 때문에 언제부터인지도 남아 있지 않습니다.

## 그 red 는 죽은 필드를 붙잡은 단언이었습니다

`test_keeper_gate_effect_coverage` 가 causal context 스냅샷의 완료된 호출에 `result` 가 실려 있다고 단언했습니다. 프로덕션은 그 필드를 **의도적으로 렌더링에서 뺐고**, 그 이유가 파일에 측정과 함께 적혀 있습니다:

> measured on live pending approvals 2026-08-09, the largest bundle was 860,589 B of which completed calls were 791,432 B (92%), one single `[result]` holding **623,999 B**, and the judge slot refused it with `{"error":{"code":"1261","message":"Prompt exceeds max length"}}` … **45 of 52** hitl_auto_judge runs failed.
>
> Dropping `[result]` … the calls render at **7,473 B instead of 901,178 B (0.83%)** with every call retained … so the judge now sees more of the turn, not less.

제거는 옳고 **단언이 안 따라간 것**입니다. judge 가 판단하는 축은 `disposition` 이며 그건 그대로 실립니다.

단언을 지우지 않고 **부재를 단언**으로 바꿨습니다. 지우기만 하면 누가 `result` 를 되살려도 잡히지 않습니다.

```ocaml
check bool "first result stays out of the judge rendering" true
  (match Yojson.Safe.Util.(call |> member "result") with
   | `Null -> true
   | _ -> false)
```

## 검증

**뮤테이션** — `completed_call_to_yojson` 에 `result` 를 되살리면:

```
FAIL first result stays out of the judge rendering
   Expected: `true'   Received: `false'
1 failure! in 0.051s. 8 tests run.
```

그 단언만 빨개집니다.

**배선한 5개 전부**

```
test_keeper_approval_queue_rules              Test Successful
test_keeper_approval_queue_rules_types        Test Successful  10 tests
test_keeper_approval_resolved_history         Test Successful
test_keeper_gate_effect_coverage              Test Successful   8 tests
test_keeper_gate_replay                       Test Successful
```

**래칫**

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 175 CI targets, all declared in Dune
[ci-test-targets] OK - 681 suites unwired, at baseline
```

`UNWIRED_BASELINE` 을 686 → 681 로 낮춰 되돌아가지 못하게 했습니다. 낮추지 않으면 스크립트가 "lower UNWIRED_BASELINE to hold the gain" 을 출력합니다.

## 범위 밖

`#27297` 의 7개 중 나머지 2개(`test_keeper_approval_audit_timeline`, `test_keeper_approval_queue`)는 이미 배선돼 있습니다. 이 PR 로 **7/7 이 됩니다.**

미배선 681개 전체는 다루지 않습니다 — `#26734`(허용목록이 opt-in) 가 그 기제를 추적합니다. 이 PR 은 Gate 라는 한 경계만 닫습니다.

RFC-WAIVED: CI 실행 목록과 그 래칫, 그리고 테스트 단언만 변경합니다. `lib/keeper/keeper_sandbox*` · credential · repo_manager · operator control · dashboard credential · hooks · workflow 문서 어느 것도 건드리지 않습니다.

Refs #27297

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
