### PR TITLE
refactor(server): fold clock groups by rebinding the table entry

### DIFF
--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_groups.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_groups.ml
@@ -29,18 +29,18 @@ let option_int_string = function
 type clock_group_acc =
   { group_type : string
   ; group_id : string
-  ; mutable edge_count : int
-  ; mutable edge_ids : string list
-  ; mutable lanes : string list
-  ; mutable events : string list
-  ; mutable statuses : string list
-  ; mutable first_observed_at : string option
-  ; mutable last_observed_at : string option
-  ; mutable terminal_events : string list
-  ; mutable parent_event_ids : string list
-  ; mutable caused_by : string list
-  ; mutable event_bus_event_count : int
-  ; mutable event_bus_payload_kinds : string list
+  ; edge_count : int
+  ; edge_ids : string list
+  ; lanes : string list
+  ; events : string list
+  ; statuses : string list
+  ; first_observed_at : string option
+  ; last_observed_at : string option
+  ; terminal_events : string list
+  ; parent_event_ids : string list
+  ; caused_by : string list
+  ; event_bus_event_count : int
+  ; event_bus_payload_kinds : string list
   }
 
 let clock_group_terminal_event group_type event =
@@ -61,7 +61,7 @@ let runtime_lens_clock_groups_json scan =
   let ensure_group group_type group_id =
     let key = clock_group_key group_type group_id in
     match Hashtbl.find_opt groups key with
-    | Some group -> group
+    | Some group -> key, group
     | None ->
       let group =
         { group_type
@@ -82,44 +82,63 @@ let runtime_lens_clock_groups_json scan =
       in
       Hashtbl.replace groups key group;
       ordered_keys := !ordered_keys @ [ key ];
-      group
+      key, group
   in
+  (* The table owns the group, so an edge folds in by rebinding the entry.
+     Every field reads [group] from before this edge, matching what the
+     in-place writes observed. *)
   let update_group group_type group_id edge =
-    let group = ensure_group group_type group_id in
+    let key, group = ensure_group group_type group_id in
     let event = option_string_default "unknown_event" (edge_string "event" edge) in
-    group.edge_count <- group.edge_count + 1;
-    (match edge_string "edge_id" edge with
-     | Some value -> group.edge_ids <- add_unique_non_empty value group.edge_ids
-     | None -> ());
-    (match edge_string "lane" edge with
-     | Some value -> group.lanes <- add_unique_non_empty value group.lanes
-     | None -> ());
-    group.events <- add_unique_non_empty event group.events;
-    (match edge_string "status" edge with
-     | Some value -> group.statuses <- add_unique_non_empty value group.statuses
-     | None -> ());
-    (match edge_string "observed_at" edge with
-     | Some value ->
-       if group.first_observed_at = None then group.first_observed_at <- Some value;
-       group.last_observed_at <- Some value
-     | None -> ());
-    if clock_group_terminal_event group_type event then
-      group.terminal_events <- add_unique_non_empty event group.terminal_events;
-    (match edge_string "parent_event_id" edge with
-     | Some value ->
-       group.parent_event_ids <- add_unique_non_empty value group.parent_event_ids
-     | None -> ());
-    (match edge_string "caused_by" edge with
-     | Some value -> group.caused_by <- add_unique_non_empty value group.caused_by
-     | None -> ());
-    (match edge_int "event_bus_event_count" edge with
-     | Some count -> group.event_bus_event_count <- group.event_bus_event_count + count
-     | None -> ());
-    group.event_bus_payload_kinds <-
-      List.fold_left
-        (fun acc value -> add_unique_non_empty value acc)
-        group.event_bus_payload_kinds
-        (edge_string_list "event_bus_payload_kinds" edge)
+    let observed_at = edge_string "observed_at" edge in
+    let updated =
+      { group with
+        edge_count = group.edge_count + 1
+      ; edge_ids =
+          (match edge_string "edge_id" edge with
+           | Some value -> add_unique_non_empty value group.edge_ids
+           | None -> group.edge_ids)
+      ; lanes =
+          (match edge_string "lane" edge with
+           | Some value -> add_unique_non_empty value group.lanes
+           | None -> group.lanes)
+      ; events = add_unique_non_empty event group.events
+      ; statuses =
+          (match edge_string "status" edge with
+           | Some value -> add_unique_non_empty value group.statuses
+           | None -> group.statuses)
+      ; first_observed_at =
+          (match observed_at, group.first_observed_at with
+           | Some value, None -> Some value
+           | (Some _ | None), existing -> existing)
+      ; last_observed_at =
+          (match observed_at with
+           | Some value -> Some value
+           | None -> group.last_observed_at)
+      ; terminal_events =
+          (if clock_group_terminal_event group_type event
+           then add_unique_non_empty event group.terminal_events
+           else group.terminal_events)
+      ; parent_event_ids =
+          (match edge_string "parent_event_id" edge with
+           | Some value -> add_unique_non_empty value group.parent_event_ids
+           | None -> group.parent_event_ids)
+      ; caused_by =
+          (match edge_string "caused_by" edge with
+           | Some value -> add_unique_non_empty value group.caused_by
+           | None -> group.caused_by)
+      ; event_bus_event_count =
+          (match edge_int "event_bus_event_count" edge with
+           | Some count -> group.event_bus_event_count + count
+           | None -> group.event_bus_event_count)
+      ; event_bus_payload_kinds =
+          List.fold_left
+            (fun acc value -> add_unique_non_empty value acc)
+            group.event_bus_payload_kinds
+            (edge_string_list "event_bus_payload_kinds" edge)
+      }
+    in
+    Hashtbl.replace groups key updated
   in
   let add_if_present edge group_type field =
     match edge_string field edge with

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -696,6 +696,72 @@ let test_compaction_snapshots_cache_returns_warming_then_ready () =
       Yojson.Safe.Util.(ready |> member "count" |> to_int))
 ;;
 
+
+(* Clock groups fold the edge stream into a table of per-group accumulators.
+   The records are immutable, so each edge rebinds its entry; two edges in the
+   same turn must still land in one group with the count advanced and the
+   observed-at window spanning both. *)
+let test_clock_groups_accumulate_edges_per_turn () =
+  with_temp_dir @@ fun dir ->
+  let config = Workspace.default_config dir in
+  let keeper_name = "clock-group-keeper" in
+  let trace_id = "trace-clock-groups" in
+  let row event =
+    Keeper_runtime_manifest.make
+      ~keeper_name
+      ~trace_id
+      ~keeper_turn_id:7
+      ~event
+      ~status:"observed"
+      ()
+    |> Keeper_runtime_manifest.to_json
+  in
+  let path = Keeper_runtime_manifest.path_for_trace config ~keeper_name ~trace_id in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  let channel = open_out path in
+  List.iter
+    (fun json -> Printf.fprintf channel "%s\n" (Yojson.Safe.to_string json))
+    [ row Keeper_runtime_manifest.Turn_started
+    ; row Keeper_runtime_manifest.Turn_finished
+    ];
+  close_out channel;
+  let scan =
+    Runtime_lens_scan.read_runtime_manifest_scan
+      ~config
+      ~keeper_name
+      ~trace_id
+      ~limit:8
+      ()
+  in
+  check int "both rows decoded" 2 scan.total_rows;
+  let open Yojson.Safe.Util in
+  let groups =
+    match
+      Server_dashboard_http_keeper_runtime_lens_clock_groups
+      .runtime_lens_clock_groups_json
+        scan
+    with
+    | `List groups -> groups
+    | _ -> fail "clock groups projection must be a list"
+  in
+  let turn_groups =
+    List.filter (fun g -> g |> member "group_type" |> to_string = "turn") groups
+  in
+  check int "one turn group" 1 (List.length turn_groups);
+  match turn_groups with
+  | [ group ] ->
+    check int "both edges folded into it" 2 (group |> member "edge_count" |> to_int);
+    check bool
+      "the terminal event closes the group"
+      true
+      (group |> member "closed" |> to_bool);
+    check bool
+      "distinct events are kept"
+      true
+      (List.length (group |> member "events" |> to_list) >= 2)
+  | _ -> fail "expected exactly one turn group"
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -742,6 +808,10 @@ let () =
             "folding a row leaves the argument scan untouched"
             `Quick
             test_runtime_manifest_scan_fold_leaves_input_untouched
+        ; test_case
+            "clock groups accumulate edges per turn"
+            `Quick
+            test_clock_groups_accumulate_edges_per_turn
         ] )
     ; ( "checkpoint_inventory"
       , [ test_case


### PR DESCRIPTION
## 목표

`clock_group_acc`의 `mutable` 12개를 제거하고, 클록 그룹 집계를 제자리 쓰기에서 테이블 재바인딩으로 바꾼다. `runtime_manifest_scan`(#28081), `activity_graph_reducer`(#28084), `keeper_gen_window_stats`(#28085)와 같은 부류의 네 번째이자, 이 부류의 마지막이다.

## 판정 근거

`edge_count`, `lanes`, `statuses` 같은 이름은 다른 레코드에도 있어 필드명 grep이 신뢰할 수 없다. `mutable`을 떼고 빌드해 컴파일러가 짚은 대입 지점만 셌다. 결과:

- 테이블(`groups`)은 `runtime_lens_clock_groups_json` 안에서 생성된다
- 레코드 타입은 `.mli`에 노출돼 있지 않다
- 모든 쓰기가 이 모듈 안에 있다

## 변경

갱신된 그룹을 만들어 `Hashtbl.replace`로 저장한다. 갱신식의 모든 조건은 `group`(이 엣지 이전 값)을 읽으므로 제자리 형태가 관찰하던 값과 같다. `observed_at`은 `first_observed_at` / `last_observed_at` 각각에서 두 번 조회하던 것을 한 번 바인딩한다.

## 테스트

이 프로젝션에는 테스트가 없었다. 같은 keeper turn의 매니페스트 행 2개를 써서, 하나의 그룹에 모이고 카운트가 전진하며 종료 이벤트가 그룹을 닫는지 단언하는 케이스를 추가했다.

**load-bearing 확인**: `Hashtbl.replace groups key updated` 를 `ignore updated` 로 바꾸면 `both edges folded into it` 에서 FAIL 한다. 즉 이 재작성의 핵심 실패 모드(갱신 유실)를 실제로 잡는다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `dune build --root . @test/runtest-test_server_dashboard_http_keeper_api_trace` → 17/17 통과
- `python3 scripts/check_test_coverage.py` → exit 0

## 효과 (실측)

`lib/` 의 `mutable <name> :` 선언 수: **264 → 252**.

세션 시작 시점 358 대비 누적 −106 (−29.6%). 앞선 병합: #28074, #28081, #28084, #28085.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
