### PR TITLE
refactor(rate-limit): store the refilled bucket instead of mutating it

### DIFF
--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -14,8 +14,8 @@ module StringMap = Set_util.StringMap
 (** {1 Token Bucket Algorithm} *)
 
 type bucket = {
-  mutable tokens: float;
-  mutable last_update: float;
+  tokens: float;
+  last_update: float;
 }
 
 type t = {
@@ -68,23 +68,20 @@ let with_lock limiter f =
 let check limiter ~key =
   with_lock limiter (fun () ->
     let now = Time_compat.now () in
+    (* The map already rebinds on every write, so the bucket is stored once
+       with its post-refill state instead of being inserted and then mutated. *)
     let bucket = match StringMap.find_opt key !(limiter.buckets) with
       | Some b -> b
-      | None ->
-          let b = { tokens = float_of_int limiter.burst; last_update = now } in
-          limiter.buckets := StringMap.add key b !(limiter.buckets);
-          b
+      | None -> { tokens = float_of_int limiter.burst; last_update = now }
     in
     let elapsed = now -. bucket.last_update in
     let new_tokens = bucket.tokens +. (elapsed *. limiter.rate) in
-    bucket.tokens <- min (float_of_int limiter.burst) new_tokens;
-    bucket.last_update <- now;
-
-    if bucket.tokens >= 1.0 then begin
-      bucket.tokens <- bucket.tokens -. 1.0;
-      true
-    end else
-      false
+    let refilled = min (float_of_int limiter.burst) new_tokens in
+    let granted = refilled >= 1.0 in
+    let tokens = if granted then refilled -. 1.0 else refilled in
+    limiter.buckets :=
+      StringMap.add key { tokens; last_update = now } !(limiter.buckets);
+    granted
   )
 
 let remaining limiter ~key =


### PR DESCRIPTION
## 이 PR이 정정하는 것

앞선 PR들에서 나는 `rate_limit.tokens` 를 "셀이라 전환은 이동일 뿐"이라고 분류했다. **틀렸다.** 필드 이름만 보고 소유 구조를 확인하지 않은 결과다.

실제 구조: `buckets : bucket StringMap.t ref` — 이미 불변 맵을 ref에 담아 매 쓰기마다 재바인딩한다. mutable인 것은 버킷 레코드뿐이고, `type t` 는 `.mli` 에서 abstract 이며, 모든 쓰기는 `check` 안 `with_lock` 아래에 있다. 즉 내가 4번 전환한 **테이블 소유 누산기와 같은 부류**이지 셀이 아니다.

## 변경

기존 `check` 는 콜드 경로에서 새 버킷을 맵에 넣은 뒤 **같은 물리 레코드를 변이**했다. 맵이 갱신된 값을 갖게 되는 것이 aliasing의 부작용이었다.

리필과 허용 판정을 먼저 계산하고 결과를 한 번 저장한다. 콜드 경로의 중복 삽입이 사라진다.

`min` 은 `Float.min` 으로 바꾸지 않았다 — NaN 처리가 달라지기 때문이다. `remaining` / `cleanup` 은 읽기만 하므로 그대로다.

## 테스트

새 테스트를 넣지 않았다. `test_rate_limit_coverage` 가 이 경로를 53개 케이스로 이미 덮고 있고, **load-bearing 임을 확인했다**: 저장을 `ignore` 로 바꾸면 5개가 실패한다 (`exceeds burst`, `remaining after check`, `remaining multiple`, `cleanup removes old`, `check_agent_global`).

`python3 scripts/check_test_coverage.py` → exit 0. 게이트가 트립하지 않았으므로 skip 마커도 넣지 않았다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `dune build --root . @test/runtest-test_rate_limit_coverage` → 53/53

## 효과

`lib/` 의 `mutable <name> :` 선언 −2. 세션 시작 358 대비, 병합된 것들과 열린 #28089 를 합치면 250.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
