### PR TITLE
refactor(gate): rebind channel and binding metric rows instead of mutating

### DIFF
--- a/lib/gate/channel_gate_metrics.ml
+++ b/lib/gate/channel_gate_metrics.ml
@@ -89,41 +89,41 @@ type gate_event = {
 }
 
 type binding_acc = {
-  mutable msg_count : int;
-  mutable success_count : int;
-  mutable err_count : int;
-  mutable last_ts : float;
-  mutable last_success_ts : float;
-  mutable last_error_ts : float;
-  mutable keeper : string;
-  mutable last_error : string;
-  mutable last_error_kind : error_kind;
-  mutable last_outcome : string;
-  mutable total_dur_ms : int;
-  mutable timed_count : int;
-  mutable max_dur_ms : int;
+  msg_count : int;
+  success_count : int;
+  err_count : int;
+  last_ts : float;
+  last_success_ts : float;
+  last_error_ts : float;
+  keeper : string;
+  last_error : string;
+  last_error_kind : error_kind;
+  last_outcome : string;
+  total_dur_ms : int;
+  timed_count : int;
+  max_dur_ms : int;
 }
 
 type stats_acc = {
-  mutable msg_count : int;
-  mutable success_count : int;
-  mutable err_count : int;
-  mutable validation_error_count : int;
-  mutable keeper_error_count : int;
-  mutable dispatch_unavailable_count : int;
-  mutable internal_error_count : int;
-  mutable last_ts : float;
-  mutable last_success_ts : float;
-  mutable last_error_ts : float;
-  mutable last_keeper : string;
-  mutable last_workspace_id : string;
-  mutable last_error : string;
-  mutable last_error_kind : error_kind;
-  mutable last_outcome : string;
-  mutable total_dur_ms : int;
-  mutable timed_count : int;
-  mutable max_dur_ms : int;
-  mutable slow_count : int;
+  msg_count : int;
+  success_count : int;
+  err_count : int;
+  validation_error_count : int;
+  keeper_error_count : int;
+  dispatch_unavailable_count : int;
+  internal_error_count : int;
+  last_ts : float;
+  last_success_ts : float;
+  last_error_ts : float;
+  last_keeper : string;
+  last_workspace_id : string;
+  last_error : string;
+  last_error_kind : error_kind;
+  last_outcome : string;
+  total_dur_ms : int;
+  timed_count : int;
+  max_dur_ms : int;
+  slow_count : int;
   workspaces : (string, unit) Hashtbl.t;
   workspace_order : string Queue.t;
   bindings : (string, binding_acc) Hashtbl.t;
@@ -201,19 +201,25 @@ let outcome_name = function
   | Internal_error _ -> "internal_error"
 
 let update_error_fields acc ~now ~kind ~message =
-  acc.err_count <- acc.err_count + 1;
-  acc.last_error_ts <- now;
-  acc.last_error_kind <- kind;
-  acc.last_error <- message
+  { acc with
+    err_count = acc.err_count + 1
+  ; last_error_ts = now
+  ; last_error_kind = kind
+  ; last_error = message
+  }
 
 let update_binding_error_fields (acc : binding_acc) ~now ~kind ~message =
-  acc.err_count <- acc.err_count + 1;
-  acc.last_error_ts <- now;
-  acc.last_error_kind <- kind;
-  acc.last_error <- message
+  { acc with
+    err_count = acc.err_count + 1
+  ; last_error_ts = now
+  ; last_error_kind = kind
+  ; last_error = message
+  }
 
+(* The workspace set and its eviction queue are containers held by [acc];
+   they keep mutating in place. Only [last_workspace_id] is a field, so it
+   comes back on the returned record. *)
 let remember_workspace acc workspace_id =
-  acc.last_workspace_id <- workspace_id;
   if not (Hashtbl.mem acc.workspaces workspace_id) then begin
     if Hashtbl.length acc.workspaces >= max_tracked_workspaces
        && not (Queue.is_empty acc.workspace_order)
@@ -223,7 +229,8 @@ let remember_workspace acc workspace_id =
     end;
     Hashtbl.replace acc.workspaces workspace_id ();
      Queue.add workspace_id acc.workspace_order
-   end
+   end;
+  { acc with last_workspace_id = workspace_id }
 
 let get_or_create_binding acc workspace_id =
   match Hashtbl.find_opt acc.bindings workspace_id with
@@ -273,86 +280,117 @@ let record_attempt ~channel ~workspace_id ~keeper ~duration_ms outcome =
         if trimmed_channel = "" then "unknown"
         else String.lowercase_ascii trimmed_channel
       in
+      (* [acc] and [binding] are values now, so every step below rebinds them
+         and the two tables are written once at the end. The nested [bindings]
+         / [workspaces] tables are shared handles carried by [{ acc with ... }],
+         so their in-place updates land whichever copy is held. *)
       let acc = get_or_create_acc channel_key in
       let now = Unix.gettimeofday () in
       let trimmed_keeper = String.trim keeper in
-      acc.msg_count <- acc.msg_count + 1;
-      acc.last_ts <- now;
-      acc.last_outcome <- outcome_name outcome;
-      if trimmed_keeper <> "" then acc.last_keeper <- trimmed_keeper;
+      let acc =
+        { acc with
+          msg_count = acc.msg_count + 1
+        ; last_ts = now
+        ; last_outcome = outcome_name outcome
+        ; last_keeper =
+            (if trimmed_keeper <> "" then trimmed_keeper else acc.last_keeper)
+        }
+      in
       let trimmed_workspace = String.trim workspace_id in
-      let binding =
-        if trimmed_workspace = "" then None
+      let acc, binding =
+        if trimmed_workspace = "" then acc, None
         else begin
-          remember_workspace acc trimmed_workspace;
+          let acc = remember_workspace acc trimmed_workspace in
           let binding = get_or_create_binding acc trimmed_workspace in
-          binding.msg_count <- binding.msg_count + 1;
-          binding.last_ts <- now;
-          binding.last_outcome <- outcome_name outcome;
-          if trimmed_keeper <> "" then binding.keeper <- trimmed_keeper;
-          Some binding
+          let binding =
+            { binding with
+              msg_count = binding.msg_count + 1
+            ; last_ts = now
+            ; last_outcome = outcome_name outcome
+            ; keeper =
+                (if trimmed_keeper <> "" then trimmed_keeper else binding.keeper)
+            }
+          in
+          acc, Some binding
         end
       in
-      if duration_ms > 0 then begin
-        acc.total_dur_ms <- acc.total_dur_ms + duration_ms;
-        acc.timed_count <- acc.timed_count + 1;
-        acc.max_dur_ms <- max acc.max_dur_ms duration_ms;
-        if duration_ms >= slow_threshold_ms () then
-          acc.slow_count <- acc.slow_count + 1
-      end;
+      let acc =
+        if duration_ms > 0 then
+          { acc with
+            total_dur_ms = acc.total_dur_ms + duration_ms
+          ; timed_count = acc.timed_count + 1
+          ; max_dur_ms = max acc.max_dur_ms duration_ms
+          ; slow_count =
+              (if duration_ms >= slow_threshold_ms () then acc.slow_count + 1
+               else acc.slow_count)
+          }
+        else acc
+      in
+      let binding =
+        match binding with
+        | Some binding when duration_ms > 0 ->
+            Some
+              { binding with
+                total_dur_ms = binding.total_dur_ms + duration_ms
+              ; timed_count = binding.timed_count + 1
+              ; max_dur_ms = max binding.max_dur_ms duration_ms
+              }
+        | (Some _ | None) as binding -> binding
+      in
+      let error_outcome (acc : stats_acc) (binding : binding_acc option)
+          ~kind ~message =
+        ( update_error_fields acc ~now ~kind ~message,
+          Option.map
+            (fun (binding : binding_acc) ->
+              update_binding_error_fields binding ~now ~kind ~message)
+            binding )
+      in
+      let acc, binding =
+        match outcome with
+        | Success ->
+            ( { acc with
+                success_count = acc.success_count + 1
+              ; last_success_ts = now
+              },
+              Option.map
+                (fun (binding : binding_acc) ->
+                  { binding with
+                    success_count = binding.success_count + 1
+                  ; last_success_ts = now
+                  })
+                binding )
+        | Validation_error message ->
+            error_outcome
+              { acc with validation_error_count = acc.validation_error_count + 1 }
+              binding
+              ~kind:Ek_validation
+              ~message
+        | Keeper_error message ->
+            error_outcome
+              { acc with keeper_error_count = acc.keeper_error_count + 1 }
+              binding
+              ~kind:Ek_keeper
+              ~message
+        | Dispatch_unavailable ->
+            error_outcome
+              { acc with
+                dispatch_unavailable_count = acc.dispatch_unavailable_count + 1
+              }
+              binding
+              ~kind:Ek_dispatch_unavailable
+              ~message:"keeper dispatch unavailable"
+        | Internal_error message ->
+            error_outcome
+              { acc with internal_error_count = acc.internal_error_count + 1 }
+              binding
+              ~kind:Ek_internal
+              ~message
+      in
       (match binding with
-       | Some binding when duration_ms > 0 ->
-           binding.total_dur_ms <- binding.total_dur_ms + duration_ms;
-           binding.timed_count <- binding.timed_count + 1;
-           binding.max_dur_ms <- max binding.max_dur_ms duration_ms
+       | Some binding when trimmed_workspace <> "" ->
+           Hashtbl.replace acc.bindings trimmed_workspace binding
        | Some _ | None -> ());
-      (match outcome with
-      | Success ->
-          acc.success_count <- acc.success_count + 1;
-          acc.last_success_ts <- now;
-          (match binding with
-           | Some binding ->
-               binding.success_count <- binding.success_count + 1;
-               binding.last_success_ts <- now
-           | None -> ())
-      | Validation_error message ->
-          acc.validation_error_count <- acc.validation_error_count + 1;
-          update_error_fields acc ~now
-            ~kind:(Ek_validation) ~message;
-          (match binding with
-           | Some binding ->
-               update_binding_error_fields binding ~now
-                 ~kind:(Ek_validation) ~message
-           | None -> ())
-      | Keeper_error message ->
-          acc.keeper_error_count <- acc.keeper_error_count + 1;
-          update_error_fields acc ~now ~kind:(Ek_keeper)
-            ~message;
-          (match binding with
-           | Some binding ->
-               update_binding_error_fields binding ~now
-                 ~kind:(Ek_keeper) ~message
-           | None -> ())
-      | Dispatch_unavailable ->
-          acc.dispatch_unavailable_count <- acc.dispatch_unavailable_count + 1;
-          update_error_fields acc ~now
-            ~kind:(Ek_dispatch_unavailable)
-            ~message:"keeper dispatch unavailable";
-          (match binding with
-           | Some binding ->
-               update_binding_error_fields binding ~now
-                 ~kind:(Ek_dispatch_unavailable)
-                 ~message:"keeper dispatch unavailable"
-           | None -> ())
-      | Internal_error message ->
-          acc.internal_error_count <- acc.internal_error_count + 1;
-          update_error_fields acc ~now ~kind:(Ek_internal)
-            ~message;
-          (match binding with
-           | Some binding ->
-               update_binding_error_fields binding ~now
-                 ~kind:(Ek_internal) ~message
-           | None -> ()));
+      Hashtbl.replace table channel_key acc;
       append_event ~channel:channel_key ~workspace_id:trimmed_workspace ~keeper:trimmed_keeper
         ~duration_ms outcome ~timestamp:now)
 

--- a/test/test_channel_gate_metrics.ml
+++ b/test/test_channel_gate_metrics.ml
@@ -221,12 +221,51 @@ let test_workspace_tracking_is_bounded () =
       check int "workspace_count capped" 256 stats.workspace_count;
       check string "last_workspace_id still updates" "workspace-300" stats.last_workspace_id)
 
+
+(* The accumulators are values now, so each attempt rebinds the channel row
+   rather than writing through it. Two carry-forward rules have to survive
+   that: a blank keeper keeps the previous one, and [last_workspace_id]
+   tracks the newest non-blank workspace. Both used to be conditional writes
+   that simply skipped; as record updates they need an explicit else-branch,
+   which is the easiest thing to get wrong. *)
+let test_record_attempt_carries_previous_keeper_and_workspace () =
+  with_eio (fun () ->
+      let channel = unique_channel "carry-forward" in
+      Metrics.record_attempt ~channel ~workspace_id:"workspace-first"
+        ~keeper:"luna" ~duration_ms:5 Metrics.Success;
+      Metrics.record_attempt ~channel ~workspace_id:"workspace-second"
+        ~keeper:"   " ~duration_ms:0 Metrics.Success;
+      let stats =
+        Metrics.snapshot ()
+        |> List.find (fun (row : Metrics.channel_stats) ->
+               String.equal row.channel channel)
+      in
+      check int "both attempts counted" 2 stats.message_count;
+      check string "blank keeper keeps the previous one" "luna" stats.last_keeper;
+      check string "workspace advances to the newest" "workspace-second"
+        stats.last_workspace_id;
+      check int "both workspaces tracked" 2 stats.workspace_count;
+      Metrics.record_attempt ~channel ~workspace_id:"   " ~keeper:"sol"
+        ~duration_ms:0 Metrics.Success;
+      let stats =
+        Metrics.snapshot ()
+        |> List.find (fun (row : Metrics.channel_stats) ->
+               String.equal row.channel channel)
+      in
+      check string "non-blank keeper replaces it" "sol" stats.last_keeper;
+      check string "blank workspace leaves the previous one" "workspace-second"
+        stats.last_workspace_id;
+      check int "blank workspace is not tracked" 2 stats.workspace_count)
+;;
+
 let () =
   Alcotest.run "Channel_gate_metrics"
     [
       ( "metrics",
         [
           test_case "error kind round trip" `Quick test_error_kind_round_trip;
+  test_case "carries the previous keeper and workspace" `Quick
+    test_record_attempt_carries_previous_keeper_and_workspace;
           test_case "records connector diagnostics" `Quick
             test_record_attempt_tracks_connector_diagnostics;
           test_case "records internal exception diagnostics" `Quick


### PR DESCRIPTION
## 이 PR이 정정하는 것

`stats_acc`(19) + `binding_acc`(13) = **32개**로 `lib/` 최대 집중이고, 다음 모듈의 2.7배다. 앞선 라운드에서 못 봤다 — 순위를 `.mli` 노출 기준으로 매겼는데 이 타입들은 `.ml` 에만 선언돼 있다.

## 왜 전환 가능한가

두 레코드 모두 Hashtbl에 산다: `table`(채널 키), `acc.bindings`(workspace 키). 모든 쓰기가 `record_attempt` 안 `mu` 아래에 있으므로, 값으로 두고 마지막에 두 테이블을 한 번씩 재바인딩하면 된다.

`workspaces` / `workspace_order` / `bindings` 는 컨테이너 핸들이라 `{ acc with ... }` 가 그대로 복사한다. 제자리 갱신이 어느 사본을 들고 있든 반영된다.

## 타입 주석 3곳

`success_count`, `last_success_ts`, 에러 필드들이 **두 레코드에 모두 존재**해서 타입 지향 disambiguation이 람다 인자를 `stats_acc` 로 잡았다. `binding_acc` 로 명시했다.

## 검증 — 읽기가 아니라 변이 실험으로

`{ acc with ... }` 는 필드 누락을 컴파일러가 잡아주지 않는다. 그래서 기존 테스트가 실제로 이 재작성을 지키는지 변이로 확인했다:

| 변이 | 결과 |
|---|---|
| 채널 행 저장 제거 | 기존 8개 실패 |
| 바인딩 행 저장 제거 | 기존 3개 실패 |
| `slow_count` 증가 제거 | 기존 3개 실패 |

## 추가한 테스트

조건부 쓰기가 레코드 필드가 될 때 가장 잃기 쉬운 두 규칙에 커버리지가 없었다:

- 빈 keeper는 이전 값을 유지해야 한다
- 빈 workspace는 `last_workspace_id` 를 건드리지 않아야 한다

케이스를 추가했고, `last_keeper` 를 무조건 덮어쓰게 바꾸면 `blank keeper keeps the previous one` 에서 실패하는 것을 확인했다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `test_channel_gate_metrics` 10/10, `test_channel_gate` 13/13, `test_channel_gate_connector_routes` 12/12
- `python3 scripts/check_test_coverage.py` → exit 0

## 효과 (실측)

`lib/` 의 `mutable <name> :` 선언 수: **264 → 232**.

세션 시작 358 대비 누적 −126 (−35.2%).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
