### PR TITLE
refactor(dashboard): swap a whole cache snapshot instead of eight fields

### DIFF
--- a/lib/server/server_dashboard_http_cache.ml
+++ b/lib/server/server_dashboard_http_cache.ml
@@ -1,26 +1,33 @@
 (** Server_dashboard_http_cache — cached_surface type and cache lifecycle. *)
 
-type cached_surface = {
-  mutable json : Yojson.Safe.t;
-  mutable last_success_at : string option;
-  mutable last_success_unix : float option;
-  mutable last_attempt_at : string option;
-  mutable last_attempt_unix : float option;
-  mutable last_error : string option;
-  mutable last_error_at : string option;
-  mutable last_error_unix : float option;
+type surface_snapshot = {
+  json : Yojson.Safe.t;
+  last_success_at : string option;
+  last_success_unix : float option;
+  last_attempt_at : string option;
+  last_attempt_unix : float option;
+  last_error : string option;
+  last_error_at : string option;
+  last_error_unix : float option;
 }
+
+type cached_surface = { mutable current : surface_snapshot }
+
+let snapshot surface = surface.current
 
 let create_cached_surface json =
   {
-    json;
-    last_success_at = None;
-    last_success_unix = None;
-    last_attempt_at = None;
-    last_attempt_unix = None;
-    last_error = None;
-    last_error_at = None;
-    last_error_unix = None;
+    current =
+      {
+        json;
+        last_success_at = None;
+        last_success_unix = None;
+        last_attempt_at = None;
+        last_attempt_unix = None;
+        last_error = None;
+        last_error_at = None;
+        last_error_unix = None;
+      };
   }
 
 let now_cache_stamp () =
@@ -28,34 +35,47 @@ let now_cache_stamp () =
   (ts, Masc_domain.now_iso ())
 
 
+(* Each mutator swaps a whole snapshot in one write. The previous form wrote
+   the fields one at a time and was only free of torn reads because nothing
+   between the writes could yield; a log call or a move onto a worker domain
+   would have broken that silently. *)
 let mark_cached_surface_attempt surface =
   let ts, iso = now_cache_stamp () in
-  surface.last_attempt_unix <- Some ts;
-  surface.last_attempt_at <- Some iso
+  surface.current <-
+    { surface.current with last_attempt_unix = Some ts; last_attempt_at = Some iso }
 
 let mark_cached_surface_success surface json =
   let ts, iso = now_cache_stamp () in
-  surface.json <- json;
-  surface.last_success_unix <- Some ts;
-  surface.last_success_at <- Some iso;
-  surface.last_error <- None;
-  surface.last_error_at <- None;
-  surface.last_error_unix <- None
+  surface.current <-
+    { surface.current with
+      json
+    ; last_success_unix = Some ts
+    ; last_success_at = Some iso
+    ; last_error = None
+    ; last_error_at = None
+    ; last_error_unix = None
+    }
 
 let mark_cached_surface_error surface exn =
   let ts, iso = now_cache_stamp () in
-  surface.last_error <- Some (Printexc.to_string exn);
-  surface.last_error_at <- Some iso;
-  surface.last_error_unix <- Some ts
+  surface.current <-
+    { surface.current with
+      last_error = Some (Printexc.to_string exn)
+    ; last_error_at = Some iso
+    ; last_error_unix = Some ts
+    }
 
 let invalidate_cached_surface surface =
-  surface.last_success_at <- None;
-  surface.last_success_unix <- None;
-  surface.last_attempt_at <- None;
-  surface.last_attempt_unix <- None;
-  surface.last_error <- None;
-  surface.last_error_at <- None;
-  surface.last_error_unix <- None
+  surface.current <-
+    { surface.current with
+      last_success_at = None
+    ; last_success_unix = None
+    ; last_attempt_at = None
+    ; last_attempt_unix = None
+    ; last_error = None
+    ; last_error_at = None
+    ; last_error_unix = None
+    }
 
 let upsert_assoc_field key value fields =
   (key, value) :: List.remove_assoc key fields
@@ -89,7 +109,9 @@ let extend_projection_diagnostics json extra_fields =
            (List.remove_assoc "projection_diagnostics" fields))
   | other -> other
 
-let cached_surface_json surface =
+let cached_surface_json cache =
+  (* One read of the cell, so every field below comes from the same view. *)
+  let surface = snapshot cache in
   let now_ts = Unix.gettimeofday () in
   let cache_state, stale_reason, stale_age_ms =
     match surface.last_success_unix, surface.last_error_unix with
@@ -110,8 +132,8 @@ let cached_surface_json surface =
       ( "stale_age_ms", Json_util.int_opt_to_json stale_age_ms );
     ]
 
-let cached_surface_has_success surface =
-  Option.is_some surface.last_success_unix
+let cached_surface_has_success cache =
+  Option.is_some (snapshot cache).last_success_unix
 
 let cached_surface_or_first_success_json surface ~cache_key ~ttl ~clock
     ~timeout_sec compute =

--- a/lib/server/server_dashboard_http_cache.mli
+++ b/lib/server/server_dashboard_http_cache.mli
@@ -16,21 +16,29 @@
     cache-key/TTL machinery with the per-surface attempt/success/
     error tracking. *)
 
-type cached_surface = {
-  mutable json : Yojson.Safe.t;
-  mutable last_success_at : string option;
-  mutable last_success_unix : float option;
-  mutable last_attempt_at : string option;
-  mutable last_attempt_unix : float option;
-  mutable last_error : string option;
-  mutable last_error_at : string option;
-  mutable last_error_unix : float option;
+type surface_snapshot = {
+  json : Yojson.Safe.t;
+  last_success_at : string option;
+  last_success_unix : float option;
+  last_attempt_at : string option;
+  last_attempt_unix : float option;
+  last_error : string option;
+  last_error_at : string option;
+  last_error_unix : float option;
 }
-(** Concrete record because dashboard tests mutate it directly
-    ({!Test_dashboard_namespace_truth}, {!Test_dashboard_execution})
-    via {!mark_cached_surface_success} / {!invalidate_cached_surface}.
-    The three timestamp triples are paired (ISO + Unix) so callers
-    do not have to re-format on every render. *)
+(** One consistent view of a surface. The three timestamp triples are paired
+    (ISO + Unix) so callers do not have to re-format on every render. *)
+
+type cached_surface = { mutable current : surface_snapshot }
+(** The cell that holds the current {!surface_snapshot}. Concrete because
+    dashboard tests construct and read surfaces directly
+    ({!Test_dashboard_namespace_truth}, {!Test_dashboard_http_core}).
+    Every mutator replaces the whole snapshot in one write, so a reader can
+    never observe a half-applied update. *)
+
+val snapshot : cached_surface -> surface_snapshot
+(** [snapshot s] reads the current view. Bind it once and read fields off the
+    result rather than re-reading [s] per field. *)
 
 val create_cached_surface : Yojson.Safe.t -> cached_surface
 (** [create_cached_surface json] returns a fresh surface seeded

--- a/lib/server/server_dashboard_http_core_operator.ml
+++ b/lib/server/server_dashboard_http_core_operator.ml
@@ -96,7 +96,10 @@ let operator_snapshot_publication_ref =
 
 let install_operator_snapshot_invalidation generation =
   invalidate_cached_surface operator_snapshot_cache;
-  operator_snapshot_cache.json <- invalidated_operator_snapshot_json ();
+  operator_snapshot_cache.current <-
+    { (snapshot operator_snapshot_cache) with
+      json = invalidated_operator_snapshot_json ()
+    };
   let publication =
     make_operator_snapshot_publication
       ~generation
@@ -250,9 +253,12 @@ let mark_operator_snapshot_error_if_current ~compute exn =
            && compute.sequence > publication.terminal_sequence
         then (
           mark_cached_surface_error operator_snapshot_cache exn;
-          operator_snapshot_cache.json <- unavailable_operator_snapshot_json ();
-          operator_snapshot_cache.last_success_at <- None;
-          operator_snapshot_cache.last_success_unix <- None;
+          operator_snapshot_cache.current <-
+            { (snapshot operator_snapshot_cache) with
+              json = unavailable_operator_snapshot_json ()
+            ; last_success_at = None
+            ; last_success_unix = None
+            };
           let terminal =
             make_operator_snapshot_publication
               ~generation:compute.generation

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -181,7 +181,8 @@ let clear_execution_default_light_http_body () =
 ;;
 
 let execution_surface_has_fresh_success () =
-  match execution_cache.last_success_unix, execution_cache.last_error_unix with
+  let execution_snapshot = Server_dashboard_http_cache.snapshot execution_cache in
+  match execution_snapshot.last_success_unix, execution_snapshot.last_error_unix with
   | Some success_ts, Some error_ts when error_ts > success_ts -> false
   | Some _, _ -> true
   | None, _ -> false
@@ -788,7 +789,7 @@ let patch_surface_json_for_running_keepers (config : Workspace.config) = functio
 
 let patchexecution_cache_for_keeper ~keeper_name ~event ~keepalive_running =
   clear_execution_default_light_http_body ();
-  match execution_cache.json with
+  match (Server_dashboard_http_cache.snapshot execution_cache).json with
   | `Assoc fields ->
     (match List.assoc_opt "keepers" fields with
      | Some (`List rows) ->
@@ -797,13 +798,16 @@ let patchexecution_cache_for_keeper ~keeper_name ~event ~keepalive_running =
        in
        if keeper_rows <> rows
        then
-         execution_cache.json
-         <- `Assoc
-              (replace_keeper_rows_and_rebuild_briefs
-                 ~now_ts:(Time_compat.now ())
-                 ~keeper_rows
-                 ~keepers_json:(`List keeper_rows)
-                 fields)
+         execution_cache.Server_dashboard_http_cache.current
+         <- { (Server_dashboard_http_cache.snapshot execution_cache) with
+              json =
+                `Assoc
+                  (replace_keeper_rows_and_rebuild_briefs
+                     ~now_ts:(Time_compat.now ())
+                     ~keeper_rows
+                     ~keepers_json:(`List keeper_rows)
+                     fields)
+            }
      | Some _ -> ()
      | None -> ())
   | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> ()

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -110,12 +110,18 @@ let dashboard_namespace_truth_http_json ~state ~sw ~clock _request =
   let proactive_first_cycle_pending =
     not (cached_surface_has_success Execution_surfaces.execution_cache)
     &&
-    match Execution_surfaces.execution_cache.last_attempt_unix with
+    match
+      (Server_dashboard_http_cache.snapshot Execution_surfaces.execution_cache)
+        .last_attempt_unix
+    with
     | None -> true
     | Some attempt_ts ->
         let elapsed = Time_compat.now () -. attempt_ts in
         elapsed < warm_escape_s
-        && Option.is_none Execution_surfaces.execution_cache.last_error_unix
+        && Option.is_none
+             (Server_dashboard_http_cache.snapshot
+                Execution_surfaces.execution_cache)
+               .last_error_unix
   in
   if proactive_first_cycle_pending then
     Namespace_truth_support.compose_namespace_truth_initializing ~config
@@ -254,7 +260,9 @@ let namespace_truth_snapshot_from_caches (state : Mcp_server.server_state) :
          composed snapshot. The HTTP path
          ([dashboard_namespace_truth_http_json]) keeps [cached_surface_json]
          where clients render cache_state/stale_age_ms. *)
-      Server_dashboard_http_execution_surfaces.execution_cache.json
+      (Server_dashboard_http_cache.snapshot
+         Server_dashboard_http_execution_surfaces.execution_cache)
+        .json
     in
     Some
       (Namespace_truth_support.compose_namespace_truth_snapshot ~config

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -90,37 +90,11 @@ let with_cached_surface_success
       json
       f
   =
-  let saved =
-    ( surface.json
-    , surface.last_success_at
-    , surface.last_success_unix
-    , surface.last_attempt_at
-    , surface.last_attempt_unix
-    , surface.last_error
-    , surface.last_error_at
-    , surface.last_error_unix )
-  in
+  (* One snapshot is the whole saved state now — the eight-field save and
+     restore this used to carry collapsed with the record. *)
+  let saved = Server_dashboard_http_cache.snapshot surface in
   Fun.protect
-    ~finally:(fun () ->
-      let ( json
-          , last_success_at
-          , last_success_unix
-          , last_attempt_at
-          , last_attempt_unix
-          , last_error
-          , last_error_at
-          , last_error_unix )
-        =
-        saved
-      in
-      surface.json <- json;
-      surface.last_success_at <- last_success_at;
-      surface.last_success_unix <- last_success_unix;
-      surface.last_attempt_at <- last_attempt_at;
-      surface.last_attempt_unix <- last_attempt_unix;
-      surface.last_error <- last_error;
-      surface.last_error_at <- last_error_at;
-      surface.last_error_unix <- last_error_unix)
+    ~finally:(fun () -> surface.Server_dashboard_http_cache.current <- saved)
     (fun () ->
       Server_dashboard_http_cache.mark_cached_surface_success surface json;
       f ())
@@ -3355,6 +3329,37 @@ let test_keepers_dashboard_json_fiber_batch_collects_all_keepers () =
         (List.length names)
         (json |> member "total" |> to_int))
 
+
+(* The `.mli` calls the error clear on success a deliberate contract, and
+   nothing tested it. It is also exactly what a snapshot swap could drop,
+   since the fields now have to be named in the record update rather than
+   simply assigned. *)
+let test_cached_surface_success_clears_the_previous_error () =
+  let module Cache = Server_dashboard_http_cache in
+  let surface = Cache.create_cached_surface (`Assoc [ "seed", `Bool true ]) in
+  Cache.mark_cached_surface_error surface (Failure "compute blew up");
+  let errored = Cache.snapshot surface in
+  check bool "the error is recorded" true (Option.is_some errored.Cache.last_error);
+  check bool "the error is stamped" true (Option.is_some errored.Cache.last_error_at);
+  check bool "the error has a unix stamp" true
+    (Option.is_some errored.Cache.last_error_unix);
+  Cache.mark_cached_surface_success surface (`Assoc [ "fresh", `Bool true ]);
+  let succeeded = Cache.snapshot surface in
+  check bool "success clears the error" true
+    (Option.is_none succeeded.Cache.last_error);
+  check bool "success clears the error stamp" true
+    (Option.is_none succeeded.Cache.last_error_at);
+  check bool "success clears the error unix stamp" true
+    (Option.is_none succeeded.Cache.last_error_unix);
+  check bool "success records its own stamp" true
+    (Option.is_some succeeded.Cache.last_success_unix);
+  check
+    string
+    "success installs the new payload"
+    (Yojson.Safe.to_string (`Assoc [ "fresh", `Bool true ]))
+    (Yojson.Safe.to_string succeeded.Cache.json)
+;;
+
 let () =
   run "dashboard_http_core"
     [
@@ -3510,7 +3515,9 @@ let () =
             test_running_keeper_reconciliation_rebuilds_continuity_brief;
         ] );
       ( "context-window shrink guard (#25062/#25268)",
-        [ test_case "shrink of max_context_override is detected" `Quick
+        [ test_case "success clears the previous error" `Quick
+            test_cached_surface_success_clears_the_previous_error;
+          test_case "shrink of max_context_override is detected" `Quick
             test_context_shrink_detection;
           test_case "config POST atomically restarts runtime" `Quick
             test_config_post_restarts_from_atomic_toml;

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -124,8 +124,11 @@ let expire_execution_warmup () =
   let surface = Server_dashboard_http.execution_cache in
   Server_dashboard_http_cache.invalidate_cached_surface surface;
   let stale_attempt_ts = Unix.gettimeofday () -. 120.0 in
-  surface.last_attempt_unix <- Some stale_attempt_ts;
-  surface.last_attempt_at <- Some "stale_attempt_for_test"
+  surface.Server_dashboard_http_cache.current <-
+    { (Server_dashboard_http_cache.snapshot surface) with
+      last_attempt_unix = Some stale_attempt_ts
+    ; last_attempt_at = Some "stale_attempt_for_test"
+    }
 
 let create_keeper env sw state name =
   let workspace_scope = Lib.Mcp_server.workspace_scope state in


### PR DESCRIPTION
## 결함이 아니라 우발적 성질을 구조로 바꾸는 변경

`cached_surface` 는 `mutable` 필드 8개를 갖고, 각 mutator 가 그중 여럿을 순차로 썼다.

앞선 조사에서 나는 "찢어진 읽기는 없다"고 확인했다. 그 근거는: `Proactive_refresh.start` 가 `Eio.Fiber.fork`(같은 도메인)이고, `now_cache_stamp ()` 가 쓰기 시퀀스 **위로** 올라가 있으며 `Unix.gettimeofday` 를 쓰므로 Eio effect 가 아니다. 즉 쓰기 사이에 양보 지점이 없다.

문제는 그 성질이 **우발적**이라는 것이다. 로그 한 줄이 들어가거나 refresh 가 워커 도메인으로 옮겨가면, 독자가 새 `json` 옆에 낡은 `last_error` 를 보는 상태가 조용히 생긴다.

## 변경

- `surface_snapshot` — 값 8개를 담는 불변 레코드
- `cached_surface = { mutable current : surface_snapshot }` — 현재 뷰를 담는 셀
- `val snapshot : cached_surface -> surface_snapshot`

모든 mutator 가 셀을 한 번만 쓴다. 반쯤 적용된 상태는 관찰 불가능해진다. `cached_surface_json` / `cached_surface_has_success` 는 필드마다 다시 읽는 대신 한 번 바인딩한다.

## 호출부

타입을 `.mli` 에서 abstract 로 만들어 컴파일러가 짚게 했다. 필드 접근은 **5곳**뿐이었다 — `lib/server` 3, 테스트 2.

`test_dashboard_http_core` 의 save/restore 헬퍼는 8필드 튜플에서 스냅샷 하나로 줄었다. 이 변경의 축소판이다.

## 테스트

`.mli` 는 "성공 시 에러 클리어" 를 의도적 계약이라고 적어두었는데 테스트가 없었다. 스냅샷 교체로 바꿀 때 가장 잃기 쉬운 절이기도 하다 — 단순 대입이 아니라 레코드 갱신에서 필드를 **명시해야** 하기 때문이다.

- 클리어를 제거해도 스위트는 평소의 실패 4건 그대로였다 (미커버 확인)
- 케이스 추가 후 같은 변이를 넣으면 5건이 된다 (load-bearing 확인)

## 기존 실패에 대해

`test_dashboard_http_core` 와 `test_dashboard_namespace_truth` 는 `origin/main` 에서도 실패한다. **테스트 이름 기준으로 대조**했고 집합이 동일하다 (개수만 센 것이 아니다). 이 브랜치가 추가한 실패는 없다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `python3 scripts/check_test_coverage.py` → exit 0

## 효과 (실측)

`lib/` 의 `mutable <name> :` 선언 수: **244 → 236** (8 → 1).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
