### PR TITLE
refactor(pulse): make the alive flag an Atomic

### DIFF
--- a/lib/pulse/pulse.ml
+++ b/lib/pulse/pulse.ml
@@ -63,7 +63,10 @@ type t = {
   (* engine state *)
   mutable seq         : int;
   mutable last_beat_v : beat option;
-  mutable alive       : bool;
+  (* Written by the loop and by the daemon's release handler, read by
+     [nudge] from arbitrary fibers. [Atomic] states that crossing and keeps
+     the flag correct if the engine ever runs off the main domain. *)
+  alive       : bool Atomic.t;
   mutable total_nudges: int;
   mutable start_ts    : float;
 }
@@ -221,7 +224,7 @@ let loop t =
   done;
   (* Final beat: shutdown demand *)
   let _shutdown_beat = tick t Demand in
-  t.alive <- false;
+  Atomic.set t.alive false;
   Log.Pulse.info "stopped after %d beats" t.seq
 
 (* ── Public API ──────────────────────────────────────────────── *)
@@ -240,13 +243,13 @@ let create ~clock ~rhythm ~lifecycle ~consumers =
     shutdown_r;
     seq         = 0;
     last_beat_v = None;
-    alive       = false;
+    alive       = Atomic.make false;
     total_nudges= 0;
     start_ts    = now ac;
   }
 
 let run ~sw t =
-  t.alive    <- true;
+  Atomic.set t.alive true;
   t.start_ts <- now t.clock;
   match t.lifecycle with
   | Always_on ->
@@ -254,19 +257,19 @@ let run ~sw t =
       (* Safe: finally is mutable field write — no I/O, no exception risk *)
       Fun.protect
         (fun () -> loop t; `Stop_daemon)
-        ~finally:(fun () -> t.alive <- false)
+        ~finally:(fun () -> Atomic.set t.alive false)
     )
   | Bounded _ ->
     Eio.Fiber.fork ~sw (fun () ->
       (* Safe: finally is mutable field write — no I/O, no exception risk *)
       Fun.protect
         (fun () -> loop t)
-        ~finally:(fun () -> t.alive <- false)
+        ~finally:(fun () -> Atomic.set t.alive false)
     )
 
 let nudge t ~reason =
   Eio.Mutex.use_rw ~protect:true t.nudge_mutex (fun () ->
-    if t.alive && Eio.Stream.is_empty t.nudge_stream then
+    if Atomic.get t.alive && Eio.Stream.is_empty t.nudge_stream then
       (* Capacity-1 mailbox: buffer one nudge. If already pending, coalesce
          (skip the new one — the loop will fire a Nudge beat soon anyway).
          The is_empty guard avoids blocking on a full stream.
@@ -299,7 +302,7 @@ let stats t =
   }
 
 let last_beat t = t.last_beat_v
-let is_alive t  = t.alive
+let is_alive t  = Atomic.get t.alive
 
 let add_consumer t consumer =
   t.consumers <- t.consumers @ [consumer]


### PR DESCRIPTION
## 왜 `alive` 하나인가

앞선 PR들에서 나는 `pulse` 를 "writer 경로 6개라 유지" 로 판정했다. 그 판정은 **레코드 전체를 하나의 불변 셀로 묶는 것**에 대한 것이었고 지금도 유효하다. 하지만 필드별로 보면 하나는 다르다.

`alive` 는 파이버를 넘나든다:

| | |
|---|---|
| 쓰기 | loop 종료 경로, `run` (fork 이전), 데몬의 `Fun.protect ~finally` (2곳) |
| 읽기 | `nudge` (임의 파이버가 호출), `is_alive` (공개 API) |

`mutable bool` 은 이 교차를 타입으로 말하지 않는다. `Atomic` 은 말한다. 엔진이 나중에 메인 도메인 밖에서 돌더라도 플래그가 깨지지 않는다.

## 나머지 6개는 그대로 둔다

`rhythm` / `consumers` 는 등록 API 가, `seq` / `last_beat_v` / `total_nudges` / `start_ts` 는 loop 가 쓴다. 서로 다른 관심사에 서로 다른 writer 다. 하나의 셀로 묶으면 독립적이던 쓰기가 공유 레코드에 대한 read-modify-write 가 되어, 남의 갱신 이전 값을 들고 있던 writer 가 그것을 덮는다. 지금 없는 위험을 새로 만드는 셈이다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `dune build --root . @test/runtest-test_pulse` → 통과
- `python3 scripts/check_test_coverage.py` → exit 0

테스트가 이 필드를 실제로 지킨다: `is_alive` 를 상수로 바꾸면 `assert (not (Pulse.is_alive t))` 4곳에서 실패한다.

## 효과

`lib/` 의 `mutable <name> :` 선언 수: **218 → 217**.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
