### PR TITLE
refactor(client-identity): rebind the registry entry on touch

### DIFF
--- a/lib/client_identity.ml
+++ b/lib/client_identity.ml
@@ -137,7 +137,7 @@ type t = {
   user_id : string option;        (** User ID from channel (e.g., telegram user id) *)
   capabilities : string list;     (** Declared agent capabilities *)
   registered_at : float;          (** Unix timestamp *)
-  mutable last_seen : float;      (** Last activity timestamp *)
+  last_seen : float;              (** Last activity timestamp *)
   metadata : (string * string) list;  (** Additional metadata *)
 }
 [@@deriving to_yojson]
@@ -262,7 +262,13 @@ module Registry = struct
     with_lock reg (fun () ->
       match StringMap.find_opt session_key !(reg.identities) with
       | Some identity ->
-          identity.last_seen <- Time_compat.now ()
+          (* The map owns the identity, so a touch rebinds the entry. Only
+             [identities] holds the record — [by_agent_name] maps a name to a
+             session key — so one rebind is the whole update. *)
+          reg.identities :=
+            StringMap.add session_key
+              { identity with last_seen = Time_compat.now () }
+              !(reg.identities)
       | None -> ()
     )
 

--- a/lib/client_identity.mli
+++ b/lib/client_identity.mli
@@ -30,7 +30,7 @@ type t = {
   user_id : string option;
   capabilities : string list;
   registered_at : float;
-  mutable last_seen : float;
+  last_seen : float;
   metadata : (string * string) list;
 }
 


### PR DESCRIPTION
## 마지막 남은 "맵이 소유한 값"

전수 census 에서 "외부 writer 없음 + 모듈 내 writer 경로 1개" 로 걸러진 9개 모듈을 필드 단위로 다시 확인했다. 8개는 셀이었다 — `exec_buffer` 는 링 버퍼, `http_server_eio` 는 라우터, `failure_observation` / `keeper_context_overflow_shrink_state` 는 불변 맵을 담은 단일 셀(전자는 `.mli` 에 그 설계가 명시돼 있다), `shared_audit/store` · `keeper_chat_operation_store` · `ide_ingest_queue` 는 상태 플래그/설정.

`client_identity.last_seen` 하나만 달랐다. 이 레코드는 `identities : t StringMap.t ref` 가 소유하는 **값**이고, 그 맵은 다른 모든 쓰기에서 이미 재바인딩된다. `touch` 만 제자리 변이를 하고 있었다.

## 변경

`touch` 가 갱신된 identity 를 맵에 다시 넣는다. `identities` 만 레코드를 들고 있고 `by_agent_name` 은 이름→세션키 매핑이므로, 한 번의 재바인딩이 갱신 전부다.

`.mli` 는 이미 `last_seen` 이 관찰 데이터이지 생명주기 권위가 아니라고 적어두었다. 따라서 앞서 반환받은 레코드를 통해 변화를 보는 호출자는 없다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `dune build --root . @test/runtest-test_client_identity` → 20/20
- `python3 scripts/check_test_coverage.py` → exit 0

load-bearing 확인: 재바인딩을 `ignore` 로 바꾸면 `registry / touch` 가 실패한다.

## 효과

`lib/` 의 `mutable <name> :` 선언 수: **210 → 208**.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
