### PR TITLE
fix(claude-code): result 메시지가 보고하는 usage 를 싣는다 — 형제 런타임은 이미 채우는 슬롯이다

### DIFF
--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -451,7 +451,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                       { input_tokens = usage.input_tokens
                       ; output_tokens = usage.output_tokens
                       ; cache_creation_input_tokens = 0
-                      ; cache_read_input_tokens = usage.cache_read_tokens
+                      ; cache_read_input_tokens = 0
                       ; cost_usd = None
                       })
                    turn.usage

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -444,7 +444,17 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
              ; model = turn.model
              ; stop_reason = EndTurn
              ; content = [ Text turn.text ]
-             ; usage = None
+             ; usage =
+                 Option.map
+                   (fun (usage : Runtime_claude_code.turn_usage) :
+                        Agent_core.Types.api_usage ->
+                      { input_tokens = usage.input_tokens
+                      ; output_tokens = usage.output_tokens
+                      ; cache_creation_input_tokens = 0
+                      ; cache_read_input_tokens = usage.cache_read_tokens
+                      ; cost_usd = None
+                      })
+                   turn.usage
              ; telemetry =
                  Some
                    { Agent_core.Types.default_inference_telemetry with

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -51,6 +51,12 @@ type rate_limit =
   ; overage_disabled_reason : string option
   }
 
+type turn_usage =
+  { input_tokens : int
+  ; output_tokens : int
+  ; cache_read_tokens : int
+  }
+
 type turn_result =
   { session_id : string
   ; turn_id : string
@@ -60,6 +66,7 @@ type turn_result =
   ; subscription : subscription
   ; rate_limit : rate_limit option
   ; resumed : bool
+  ; usage : turn_usage option
   }
 
 type dynamic_tool_result =
@@ -657,6 +664,33 @@ let parse_result ~expected_session_id ~rate_limit fields =
       | Some _ -> protocol_error stage "field \"result\" must be a string or null"
     in
     let* result = result in
+    (* The keeper side of this runtime hardcoded [usage = None] while the
+       antigravity runtime fills the same slot from its CLI stream, which is why
+       official-client turns carry no input_tokens (#28023) and why a turn that
+       exceeds the window is only discoverable from the provider's prose
+       (#27427). Read leniently: a turn must not fail because its usage block is
+       absent or shaped differently than expected, and an absent value after
+       this lands means the CLI does not send one. *)
+    let usage =
+      match List.assoc_opt "usage" fields with
+      | None | Some `Null -> None
+      | Some (`Assoc usage_fields) ->
+        let int_field name =
+          match List.assoc_opt name usage_fields with
+          | Some (`Int value) when value >= 0 -> Some value
+          | _ -> None
+        in
+        (match int_field "input_tokens", int_field "output_tokens" with
+         | Some input_tokens, Some output_tokens ->
+           Some
+             { input_tokens
+             ; output_tokens
+             ; cache_read_tokens =
+                 Option.value (int_field "cache_read_input_tokens") ~default:0
+             }
+         | Some _, None | None, Some _ | None, None -> None)
+      | Some _ -> None
+    in
     let structurally_quota_blocked =
       Option.equal Int.equal api_error_status (Some 429)
       || Option.exists
@@ -689,7 +723,7 @@ let parse_result ~expected_session_id ~rate_limit fields =
                | Some _ | None -> "")))
     else if subtype <> "success"
     then Error (Turn_failed (Printf.sprintf "terminal subtype=%s" subtype))
-    else Ok (turn_id, result)
+    else Ok (turn_id, result, usage)
 ;;
 
 let max_ignored_messages = 256
@@ -729,7 +763,7 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
       ~rate_limit:(Some rate_limit) ~assistant_model ~assistant_texts
       ~on_turn_started ~ignored
   | "result" ->
-    let* turn_id, result =
+    let* turn_id, result, usage =
       parse_result ~expected_session_id ~rate_limit fields
     in
     let* () =
@@ -764,6 +798,7 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
       ; subscription
       ; rate_limit
       ; resumed
+      ; usage
       }
   | ("system" | "user") when ignored < max_ignored_messages ->
     await_terminal

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -54,7 +54,6 @@ type rate_limit =
 type turn_usage =
   { input_tokens : int
   ; output_tokens : int
-  ; cache_read_tokens : int
   }
 
 type turn_result =
@@ -680,14 +679,11 @@ let parse_result ~expected_session_id ~rate_limit fields =
           | Some (`Int value) when value >= 0 -> Some value
           | _ -> None
         in
+        (* Only the two counts this reads are carried. A cache-read field would
+           need a value when the block omits it, and defaulting a count nobody
+           reported to zero states something the stream did not say. *)
         (match int_field "input_tokens", int_field "output_tokens" with
-         | Some input_tokens, Some output_tokens ->
-           Some
-             { input_tokens
-             ; output_tokens
-             ; cache_read_tokens =
-                 Option.value (int_field "cache_read_input_tokens") ~default:0
-             }
+         | Some input_tokens, Some output_tokens -> Some { input_tokens; output_tokens }
          | Some _, None | None, Some _ | None, None -> None)
       | Some _ -> None
     in

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -40,6 +40,12 @@ type rate_limit =
   ; overage_disabled_reason : string option
   }
 
+type turn_usage =
+  { input_tokens : int
+  ; output_tokens : int
+  ; cache_read_tokens : int
+  }
+
 type turn_result =
   { session_id : string
   ; turn_id : string
@@ -49,6 +55,7 @@ type turn_result =
   ; subscription : subscription
   ; rate_limit : rate_limit option
   ; resumed : bool
+  ; usage : turn_usage option
   }
 
 type dynamic_tool_result =

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -43,7 +43,6 @@ type rate_limit =
 type turn_usage =
   { input_tokens : int
   ; output_tokens : int
-  ; cache_read_tokens : int
   }
 
 type turn_result =

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -17,6 +17,14 @@ let result =
   {|{"type":"result","subtype":"success","is_error":false,"session_id":"__SESSION__","uuid":"turn-fixture-1","result":"MASC_CLAUDE_OK","api_error_status":null}|}
 ;;
 
+let result_with_usage =
+  {|{"type":"result","subtype":"success","is_error":false,"session_id":"__SESSION__","uuid":"turn-usage-1","result":"MASC_CLAUDE_OK","api_error_status":null,"usage":{"input_tokens":123456,"output_tokens":789,"cache_read_input_tokens":42}}|}
+;;
+
+let result_with_partial_usage =
+  {|{"type":"result","subtype":"success","is_error":false,"session_id":"__SESSION__","uuid":"turn-usage-2","result":"MASC_CLAUDE_OK","api_error_status":null,"usage":{"output_tokens":789}}|}
+;;
+
 type fixture_step =
   | Emit of string
   | Emit_and_read of string
@@ -161,7 +169,38 @@ let test_subscription_turn_and_env_scrub () =
       check string "turn" "turn-fixture-1" turn.turn_id;
       check string "model" "claude-fixture" turn.model;
       check string "subscription" "team" turn.subscription.subscription_type;
-      check bool "new session" false turn.resumed)
+      check bool "new session" false turn.resumed;
+      check bool "no usage block yields none" true (Option.is_none turn.usage))
+;;
+
+(* The keeper side of this runtime hardcoded [usage = None] while the
+   antigravity runtime fills the same slot from its CLI stream, which is why
+   official-client turns carry no input_tokens (#28023). Reading it here is what
+   lets a turn record the size it actually sent. *)
+let test_result_usage_is_carried () =
+  with_fixture [ Emit assistant; Emit result_with_usage ] (fun path ->
+    match run_fixture path with
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok turn ->
+      (match turn.usage with
+       | None -> fail "usage block was dropped"
+       | Some usage ->
+         check int "input tokens" 123456 usage.input_tokens;
+         check int "output tokens" 789 usage.output_tokens;
+         check int "cache read tokens" 42 usage.cache_read_tokens))
+;;
+
+(* A usage block the CLI shapes differently must not fail the turn: the text is
+   the turn's product and the counts are an observation of it. An absent value
+   after this lands means the CLI sent nothing usable, which is the measurement
+   #27427 needs. *)
+let test_partial_result_usage_does_not_fail_the_turn () =
+  with_fixture [ Emit assistant; Emit result_with_partial_usage ] (fun path ->
+    match run_fixture path with
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok turn ->
+      check string "text survives" "MASC_CLAUDE_OK" turn.text;
+      check bool "partial usage yields none" true (Option.is_none turn.usage))
 ;;
 
 let test_non_subscription_auth_is_rejected () =
@@ -838,6 +877,11 @@ let () =
             test_rejected_rate_limit_overrides_success_flag
         ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
         ; test_case "duplicate keys fail closed" `Quick test_duplicate_keys_fail_closed
+        ; test_case "result usage is carried" `Quick test_result_usage_is_carried
+        ; test_case
+            "partial usage does not fail the turn"
+            `Quick
+            test_partial_result_usage_does_not_fail_the_turn
         ] )
     ; ( "mcp"
       , [ test_case "dynamic tool callback" `Quick test_dynamic_tool_callback

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -186,8 +186,7 @@ let test_result_usage_is_carried () =
        | None -> fail "usage block was dropped"
        | Some usage ->
          check int "input tokens" 123456 usage.input_tokens;
-         check int "output tokens" 789 usage.output_tokens;
-         check int "cache read tokens" 42 usage.cache_read_tokens))
+         check int "output tokens" 789 usage.output_tokens))
 ;;
 
 (* A usage block the CLI shapes differently must not fail the turn: the text is


### PR DESCRIPTION
## 무엇을

`runtime_claude_code` 가 result 메시지의 `usage` 블록을 읽고, `keeper_claude_code_runtime` 이 그것을 응답에 싣습니다. 지금은 `usage = None` 이 하드코딩돼 있습니다.

## 왜 — 같은 슬롯을 형제 런타임은 채우고 있습니다

```
lib/keeper/keeper_claude_code_runtime.ml:447   usage = None          ← 하드코딩
lib/keeper/keeper_codex_runtime.ml:444         usage = None          ← 하드코딩
lib/keeper/keeper_antigravity_runtime.ml:445   usage = Some usage    ← CLI 스트림에서
```

셋 다 구독 CLI 를 spawn 합니다. **전송 방식의 차이가 아닙니다** — 한 런타임은 스트림이 싣는 값을 읽고, 둘은 본 적이 없습니다.

파싱 여부도 그대로 갈립니다:

```
runtime_antigravity          usage=19  input_tokens=5
runtime_claude_code          usage=0   input_tokens=0
runtime_codex_app_server     usage=0   input_tokens=0
```

## 무엇이 걸려 있나

**`#28023`** — official-client 턴이 `input_tokens` 를 기록하지 않는 이유가 이 `None` 입니다. `taskmaster`(antigravity) 의 turn-record 에는 실제로 남아 있고, 그 값이 `#28051`(execve E2BIG) 진단의 근거였습니다.

**`#27427`** — 창을 넘는 턴이 provider 의 산문으로만 발견되는 이유입니다. masc 는 자기가 렌더한 프롬프트를 갖고 있지만, **provider 가 그것을 몇 토큰으로 세는지는 한 번도 가진 적이 없습니다.** 그래서 요청 시점 판정이 불가능했습니다.

라이브에서 그 대가가 관측됩니다 — `analyst` 는 `~2226104 tokens (limit 1000000)` 로 271턴 연속 실패했고, 매번 같은 크기를 보냈습니다.

## 읽기는 관대합니다 — 의도적입니다

`usage` 가 없거나, 모양이 다르거나, `input_tokens` 가 빠져 있으면 **`None` 을 내고 턴은 성공합니다.**

```ocaml
| None | Some `Null -> None
| Some (`Assoc usage_fields) ->
  (match int_field "input_tokens", int_field "output_tokens" with
   | Some input_tokens, Some output_tokens -> Some { … }
   | Some _, None | None, Some _ | None, None -> None)
| Some _ -> None
```

턴의 산물은 텍스트이고 카운트는 그것에 대한 관측입니다. **관측 때문에 산물을 잃으면 안 됩니다.**

동시에 이 관대함이 답을 만듭니다 — 이 변경 이후 `usage` 가 비어 있으면 그건 **CLI 가 보내지 않는다**는 뜻 하나입니다. `#28083` 이 Codex error 객체에 대해 쓴 것과 같은 방식입니다(그때 결과: 스칼라 0개, 126건 실측).

## 검증

```
test_runtime_claude_code         Test Successful  21 tests
test_keeper_claude_code_runtime  Test Successful
test_runtime_claude_code_config  Test Successful
```

**뮤테이션** — `input_tokens` 읽기를 막으면:

```
[FAIL]  terminal 5  result usage is carried
[OK]    terminal 6  partial usage does not fail the turn
```

그 단언만 빨개지고, partial-usage 케이스는 양쪽에서 초록입니다. **후자가 "턴이 이 값에 의존하지 않는다" 를 말합니다.**

새 fixture 2종은 실제 스트림 모양을 따릅니다 — 완전한 usage 블록 하나, `input_tokens` 가 빠진 것 하나.

## 범위 밖

`runtime_codex_app_server` 는 같은 형태로 남아 있습니다. Codex 스트림이 usage 를 싣는지 확인되지 않았고, 한 런타임씩 배포해 관측하는 편이 답을 분리해서 얻습니다.

요청 시점 판정 자체(`#27427` 의 1단계)도 이 PR 이 하지 않습니다. 이건 그 판정에 필요한 **입력을 복원**할 뿐입니다.

RFC-WAIVED: 런타임 스트림 파싱과 그 회귀 테스트만 변경합니다. credential · repo_manager · operator control · keeper sandbox · dashboard credential · hooks · workflow 문서 어느 것도 건드리지 않습니다.

Refs #28023, #27427

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
