### PR TITLE
feat(keeper): Codex 턴이 실제로 무엇을 보내는지 기록한다 — system_and_user_bytes 는 히스토리도 툴도 세지 않는다

### DIFF
--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -263,23 +263,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
        context" — the mode is recorded because the injection only happens on
        that branch. Sizes are the bytes this process holds, not provider
        tokens; they bound the request, they do not price it. *)
-    let history_bytes =
-      List.fold_left
-        (fun acc (message : Runtime_codex_app_server.history_message) ->
-          acc + String.length message.text)
-        0
-        history
-    in
-    let tool_surface_bytes =
-      List.fold_left
-        (fun acc (tool : Runtime_codex_app_server.dynamic_tool) ->
-          acc
-          + String.length tool.name
-          + String.length tool.description
-          + String.length (Yojson.Safe.to_string tool.input_schema))
-        0
-        dynamic_tools
-    in
     Log.Keeper.info
       ~keeper_name
       "%s turn composition: mode=%s prompt_bytes=%d developer_instructions_bytes=%d \
@@ -291,9 +274,9 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       (String.length prompt)
       (Option.fold ~none:0 ~some:String.length client_config.developer_instructions)
       (List.length history)
-      history_bytes
+      (Runtime_codex_app_server.history_bytes history)
       (List.length dynamic_tools)
-      tool_surface_bytes;
+      (Runtime_codex_app_server.dynamic_tool_bytes dynamic_tools);
     let* () =
       match
         Runtime_codex_app_server.validate_turn

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -252,6 +252,48 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~raw_trace_run:None
     in
     let dynamic_tools = List.map codex_dynamic_tool host_dynamic_tools in
+    (* The only size this tree reports for a turn is
+       [keeper_unified_turn.ml]'s [system_and_user_bytes], which sums
+       [system_prompt + world_state + user_message] and nothing else. The
+       history and the tool declarations reach the provider through
+       [thread/inject_items] and [thread/start]'s [dynamicTools], so a live
+       keeper can report 6,971 bytes used of a 128,000 budget while the server
+       answers that the context window is full (#28071). A [Start] also injects
+       the whole history into the new thread, so "fresh" does not mean "empty
+       context" — the mode is recorded because the injection only happens on
+       that branch. Sizes are the bytes this process holds, not provider
+       tokens; they bound the request, they do not price it. *)
+    let history_bytes =
+      List.fold_left
+        (fun acc (message : Runtime_codex_app_server.history_message) ->
+          acc + String.length message.text)
+        0
+        history
+    in
+    let tool_surface_bytes =
+      List.fold_left
+        (fun acc (tool : Runtime_codex_app_server.dynamic_tool) ->
+          acc
+          + String.length tool.name
+          + String.length tool.description
+          + String.length (Yojson.Safe.to_string tool.input_schema))
+        0
+        dynamic_tools
+    in
+    Log.Keeper.info
+      ~keeper_name
+      "%s turn composition: mode=%s prompt_bytes=%d developer_instructions_bytes=%d \
+       history_messages=%d history_bytes=%d tools=%d tool_surface_bytes=%d"
+      runtime_label
+      (match thread_mode with
+       | Runtime_codex_app_server.Start -> "start"
+       | Runtime_codex_app_server.Resume _ -> "resume")
+      (String.length prompt)
+      (Option.fold ~none:0 ~some:String.length client_config.developer_instructions)
+      (List.length history)
+      history_bytes
+      (List.length dynamic_tools)
+      tool_surface_bytes;
     let* () =
       match
         Runtime_codex_app_server.validate_turn

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -76,6 +76,21 @@ type history_message =
   ; text : string
   }
 
+let history_bytes messages =
+  List.fold_left (fun acc message -> acc + String.length message.text) 0 messages
+;;
+
+let dynamic_tool_bytes tools =
+  List.fold_left
+    (fun acc tool ->
+      acc
+      + String.length tool.name
+      + String.length tool.description
+      + String.length (Yojson.Safe.to_string tool.input_schema))
+    0
+    tools
+;;
+
 type error =
   | Invalid_config of string
   | Spawn_failed of string

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -60,6 +60,16 @@ type history_message =
   ; text : string
   }
 
+val history_bytes : history_message list -> int
+(** Bytes the history occupies on the wire. On a [Start] this is what
+    [thread/inject_items] carries into the new thread; on a [Resume] the thread
+    already holds it. Bytes this process sends, not provider tokens. *)
+
+val dynamic_tool_bytes : dynamic_tool list -> int
+(** Bytes the tool declarations occupy in [thread/start]'s [dynamicTools]. Sums
+    each name, description, and serialized input schema; the protocol wrapper
+    keys are excluded because they are fixed per tool. *)
+
 type error =
   | Invalid_config of string
   | Spawn_failed of string

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -481,6 +481,65 @@ let test_failed_turn_keeps_unnamed_error_scalars () =
       | Ok _ -> fail "failed turn incorrectly reported as completed")
 ;;
 
+(* These two sizes are the only report of what a turn actually sends: the
+   keeper log's [system_and_user_bytes] sums the prompt strings and omits both
+   the history and the tool declarations (#28071). The expectations are computed
+   literals, not a second call to the function under test — that would pass for
+   any implementation. *)
+let test_history_bytes_sums_text_only () =
+  let messages =
+    [ { Runtime_codex_app_server.role = Runtime_codex_app_server.User
+      ; text = "abcde"
+      }
+    ; { Runtime_codex_app_server.role = Runtime_codex_app_server.Assistant
+      ; text = "fghijklmno"
+      }
+    ]
+  in
+  check int "sum of both texts" 15 (Runtime_codex_app_server.history_bytes messages);
+  check int "empty history is zero" 0 (Runtime_codex_app_server.history_bytes []);
+  (* The role is not part of the payload size: two messages differing only in
+     role must measure the same, or the number would drift with the split
+     between user and assistant turns rather than with the bytes sent. *)
+  check
+    int
+    "role does not change the size"
+    (Runtime_codex_app_server.history_bytes
+       [ { Runtime_codex_app_server.role = Runtime_codex_app_server.User
+         ; text = "same"
+         }
+       ])
+    (Runtime_codex_app_server.history_bytes
+       [ { Runtime_codex_app_server.role = Runtime_codex_app_server.Assistant
+         ; text = "same"
+         }
+       ])
+;;
+
+let test_dynamic_tool_bytes_counts_name_description_and_schema () =
+  let tool name description schema =
+    { Runtime_codex_app_server.name
+    ; description
+    ; input_schema = schema
+    ; call = (fun ~call_id:_ _ -> { Runtime_codex_app_server.success = true; content = "" })
+    }
+  in
+  (* {"type":"object"} serializes to 17 bytes; name 2 + description 3 + 17 = 22. *)
+  let schema = `Assoc [ "type", `String "object" ] in
+  check
+    int
+    "one tool: name + description + serialized schema"
+    22
+    (Runtime_codex_app_server.dynamic_tool_bytes [ tool "ab" "cde" schema ]);
+  check int "no tools is zero" 0 (Runtime_codex_app_server.dynamic_tool_bytes []);
+  check
+    int
+    "two tools add up"
+    44
+    (Runtime_codex_app_server.dynamic_tool_bytes
+       [ tool "ab" "cde" schema; tool "xy" "zzz" schema ])
+;;
+
 let test_failed_turn_is_not_completion () =
   let failed =
     {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"fixture failure"}}}}|}
@@ -2235,6 +2294,10 @@ let () =
             test_failed_turn_keeps_typed_error_fields
         ; test_case "failed turn keeps unnamed error scalars" `Quick
             test_failed_turn_keeps_unnamed_error_scalars
+        ; test_case "history bytes sum text only" `Quick
+            test_history_bytes_sums_text_only
+        ; test_case "dynamic tool bytes count name, description, schema" `Quick
+            test_dynamic_tool_bytes_counts_name_description_and_schema
         ; test_case "failed turn stays failed" `Quick test_failed_turn_is_not_completion
         ; test_case
             "retry notifications are observational"


### PR DESCRIPTION
## 무엇을

Codex 턴이 provider 에게 보내는 구성을 바이트로 남깁니다.

```
Codex turn composition: mode=start prompt_bytes=6971 developer_instructions_bytes=4532
  history_messages=214 history_bytes=381204 tools=40 tool_surface_bytes=63031
```

`keeper_codex_runtime.ml` 에서 네 조각이 이미 스코프에 있는 자리(`:254`, `dynamic_tools` 바인딩 직후)에 한 줄입니다. 공유 타입 변경 없음, 파일 1개.

## 이건 fix 가 아닙니다

sangsu 의 완주 0% 를 고치지 않습니다. **텔레메트리이고 그 이상을 주장하지 않습니다.** 그런데도 필요한 이유는, 지금 있는 숫자가 없느니만 못하기 때문입니다.

`keeper_unified_turn.ml:926-941` 이 내는 유일한 크기:

```ocaml
(String.length system_prompt + String.length world_state + String.length user_message)
```

이 값이 `system_and_user_bytes` 로 찍히고 옆에 `context_budget=128000` 이 붙습니다. 운영자는 이 줄을 "얼마나 보냈고 얼마나 남았나" 로 읽습니다. 그런데 **히스토리도 툴 선언도 여기 없습니다** — 둘 다 별도 요청(`thread/inject_items`, `thread/start` 의 `dynamicTools`)으로 갑니다.

라이브 실측(2026-08-11, sangsu):

```
system_and_user_bytes=6971  context_budget=128000
→ Codex: "ran out of room in the model's context window"
```

masc 는 6.9 KB 를 썼다고 기록하고 제공자는 창이 꽉 찼다고 답합니다. **두 문장이 같은 로그 줄에 있습니다.**

## 왜 telemetry-as-fix 가 아닌가

CLAUDE.md 의 워크어라운드 시그니처 1번은 "silent failure 를 *visible* 로 만들지만 *fix* 하지 않는" PR 입니다. 그 판정 기준은 **fix 가 가능한데 계측으로 대체했는가** 입니다.

여기서는 fix 를 특정할 수 없고, 그 이유가 이 계측의 부재입니다. 오늘 #28071 에서 후보 7건을 실측으로 배제했는데(모델·창·툴표면·cwd·주입량·누적대화·프롬프트 크기) **전부 masc 밖에서 재현해야 했습니다** — masc 가 자기가 보낸 것을 안 남기기 때문입니다. 남은 후보는 "masc 의 요청 구성" 하나이고, 그걸 볼 유일한 방법이 이 줄입니다.

즉 이 PR 은 fix 를 대체하는 게 아니라 **fix 를 특정하기 위한 선행 조건**입니다.

## 값이 무엇을 뜻하는지 주석에 박았습니다

> Sizes are the bytes this process holds, not provider tokens; they bound the request, they do not price it.

`system_and_user_bytes` 가 이름이 무엇을 세는지 말하지 않아 오독을 만들었습니다. 같은 함정을 만들지 않기 위해서입니다.

`mode` 를 함께 찍는 이유도 같습니다 — `thread/inject_items` 주입은 **`Start` 에서만** 일어나므로(`runtime_codex_app_server.ml:763-773`), `Resume` 이면 같은 `history_bytes` 가 "이미 스레드에 있다" 를 뜻합니다. 모드 없이는 같은 숫자가 두 가지를 뜻합니다.

## 검증

```
dune build @check         → exit 0   (CI 의 타입 검사 단계와 동일)
ocamlformat --check       → exit 0
```

### 테스트에 대한 정정

첫 커밋에서 저는 테스트를 넣지 않고 "덧셈 수준이라 이 PR 이 답하려는 질문이 아니다" 라고 적었습니다. 커버리지 게이트가 거부했습니다:

```
Added 31 lines to covered code paths but no test files changed.
```

**게이트가 맞습니다.** 그 논거는 어떤 추가에도 쓸 수 있어서, 자유롭게 허용하면 게이트가 무의미해집니다.

대응은 skip 마커가 아니라 구조 변경입니다. 두 fold 를 **와이어 타입을 소유한 모듈**로 옮겼습니다:

```ocaml
(* runtime_codex_app_server.mli *)
val history_bytes : history_message list -> int
val dynamic_tool_bytes : dynamic_tool list -> int
```

`keeper_codex_runtime.mli` 는 `val run` 하나만 노출합니다. 테스트를 위해 거기를 열면 test backdoor 이므로, 크기를 그 모양을 정의한 모듈의 속성으로 두었습니다 — 그 모듈엔 이미 스위트가 있습니다.

기대값은 **계산된 리터럴**이며 함수를 다시 호출하지 않습니다(그러면 어떤 구현이든 통과합니다). 단언 하나는 **role 이 크기를 바꾸지 않음**을 고정합니다 — 바뀌면 이 숫자가 보낸 바이트가 아니라 user/assistant 비율에 따라 흔들립니다.

```
test_runtime_codex_app_server   Test Successful  37 tests  (이전 35)
python3 scripts/check_test_coverage.py   → passed
ocamlformat --check (4 파일)              → exit 0
```

## 범위 밖

antigravity 쪽(#28080 · #28097)도 같은 계측이 필요하지만 다른 런타임·다른 조립 지점이라 한 PR 로 묶지 않습니다. codex 쪽이 라이브에서 값을 확인한 뒤 같은 형태로 잇겠습니다.

Refs #28071, #28080, #28097
