### PR TITLE
refactor(http): return a new router from add_kind

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -463,8 +463,8 @@ module Router = struct
     delete: method_routes;
     options: method_routes;
     exact_paths: (string, unit) Hashtbl.t;
-    mutable routes: route list;
-    mutable route_count: int;
+    routes: route list;
+    route_count: int;
   }
 
   let create_prefix_node () =
@@ -558,9 +558,14 @@ module Router = struct
               | Some routes -> add_to_method_routes Prefix route routes
               | None -> ())
            methods);
-    router.routes <- route :: router.routes;
-    router.route_count <- router.route_count + 1;
-    router
+    (* [add_kind] already returns the router and every caller threads it
+       (`router |> get ... |> post ...`), so the two fields the router owns
+       can come back on a new record. The method index and the prefix trie
+       stay in-place containers carried by [{ router with ... }]. *)
+    { router with
+      routes = route :: router.routes
+    ; route_count = router.route_count + 1
+    }
 
   let add ~path ~methods ~handler router =
     add_kind Exact ~path ~methods ~handler:(Plain handler) router


### PR DESCRIPTION
## 이 PR이 정정하는 것

나는 앞서 `http_server_eio` 를 "정체성 있는 객체이고, 전환하려면 19개 모듈을 다 고쳐야 하는 RFC 규모" 로 분류했다. **등록 API 를 읽지 않고 내린 판단이었고 틀렸다.**

`add_kind` 는 이미 `router` 를 반환한다. 그리고 19개 `add_routes` 는 전부 이렇게 쓴다:

```ocaml
let add_routes router =
  router
  |> Http.Router.get "/api/v1/..." handler
  |> Http.Router.prefix_get "/api/v1/..." handler
```

반환값을 엮는 스타일이므로, 라우터가 소유한 두 필드를 새 레코드로 돌려줘도 **호출부는 한 줄도 바뀌지 않는다**. 컴파일러가 확인해 준다.

## 변경

`add_kind` 가 `{ router with routes = ...; route_count = ... }` 를 반환한다.

메서드 인덱스(`exact_by_path`, `exact_paths`)와 prefix 트라이(`prefix_node`)는 제자리 컨테이너로 남는다. `{ router with ... }` 가 핸들을 그대로 복사하므로 등록은 같은 테이블에 들어가고, `Hashtbl` 자식을 가진 트라이는 변이가 맞는 구조다. `method_routes.prefix_routes` 와 `prefix_node.routes` 도 같은 이유로 두었다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `test_http_server_eio` 31/31, `test_http_server_eio_coverage` 6/6
- `python3 scripts/check_test_coverage.py` → exit 0

load-bearing 확인: 새 레코드 대신 `router` 를 그대로 반환하면 `router / add GET route` 가 실패한다.

## 효과

`lib/` 의 `mutable <name> :` 선언 −2.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
