### PR TITLE
refactor(execution): 버려지는 try_resolve 결과를 bool 로 고정한다 — #2611 이 남긴 5곳

### DIFF
--- a/packages/agent_core/lib/execution_lane_writer.ml
+++ b/packages/agent_core/lib/execution_lane_writer.ml
@@ -510,6 +510,7 @@ let publish_open_journal writer journal =
        reopen follows an open that a waiter had already observed. The promise
        carries the first outcome and later publishes are the same fact, so the
        flag has no consumer here. *)
+    (* fire-and-forget: [false] only means the promise already holds an outcome. *)
     ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ()) : bool))
 ;;
 
@@ -626,7 +627,9 @@ let complete_actor writer =
          promise may be resolved from an earlier ready publish or a concurrent
          closer, and both mean the waiter has its answer, so [false] is not a
          failure to report. *)
+      (* fire-and-forget: [false] only means the promise already holds an outcome. *)
       ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ()) : bool);
+      (* fire-and-forget: [false] only means the promise already holds an outcome. *)
       ignore (Eio.Promise.try_resolve writer.resolve_closed (Ok ()) : bool)))
 ;;
 
@@ -669,6 +672,7 @@ let fail_actor writer failure =
       (* A waiter that already holds a readiness outcome keeps it: the failure
          it would learn here reaches it through its own command settlement
          below, which is the path that carries the per-command error. *)
+      (* fire-and-forget: [false] only means the promise already holds an outcome. *)
       ignore (Eio.Promise.try_resolve writer.resolve_ready (Error failure) : bool);
       let rec settle_all count = function
         | [] -> count
@@ -681,6 +685,7 @@ let fail_actor writer failure =
       record_settled writer newly_settled;
       (* Same as the readiness promise above: closure is announced once, and a
          second announcement of the same failure is redundant rather than lost. *)
+      (* fire-and-forget: [false] only means the promise already holds an outcome. *)
       ignore (Eio.Promise.try_resolve writer.resolve_closed (Error failure) : bool))
 ;;
 

--- a/packages/agent_core/lib/execution_lane_writer.ml
+++ b/packages/agent_core/lib/execution_lane_writer.ml
@@ -506,6 +506,10 @@ let publish_open_journal writer journal =
       writer.journal_view <- Available journal;
       writer.pending_outcome <- None;
       writer.worker_phase <- Idle);
+    (* [false] means readiness was already published, which happens whenever a
+       reopen follows an open that a waiter had already observed. The promise
+       carries the first outcome and later publishes are the same fact, so the
+       flag has no consumer here. *)
     ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ()) : bool))
 ;;
 
@@ -618,6 +622,10 @@ let complete_actor writer =
     in
     if transitioned
     then (
+      (* [transitioned] already says this fiber performed the close. Either
+         promise may be resolved from an earlier ready publish or a concurrent
+         closer, and both mean the waiter has its answer, so [false] is not a
+         failure to report. *)
       ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ()) : bool);
       ignore (Eio.Promise.try_resolve writer.resolve_closed (Ok ()) : bool)))
 ;;
@@ -658,6 +666,9 @@ let fail_actor writer failure =
     match pending with
     | None -> ()
     | Some (failure, in_flight, queued) ->
+      (* A waiter that already holds a readiness outcome keeps it: the failure
+         it would learn here reaches it through its own command settlement
+         below, which is the path that carries the per-command error. *)
       ignore (Eio.Promise.try_resolve writer.resolve_ready (Error failure) : bool);
       let rec settle_all count = function
         | [] -> count
@@ -668,6 +679,8 @@ let fail_actor writer failure =
       in
       let newly_settled = settle_all (settle_all 0 in_flight) queued in
       record_settled writer newly_settled;
+      (* Same as the readiness promise above: closure is announced once, and a
+         second announcement of the same failure is redundant rather than lost. *)
       ignore (Eio.Promise.try_resolve writer.resolve_closed (Error failure) : bool))
 ;;
 

--- a/packages/agent_core/lib/execution_lane_writer.ml
+++ b/packages/agent_core/lib/execution_lane_writer.ml
@@ -506,7 +506,7 @@ let publish_open_journal writer journal =
       writer.journal_view <- Available journal;
       writer.pending_outcome <- None;
       writer.worker_phase <- Idle);
-    ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ())))
+    ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ()) : bool))
 ;;
 
 let reconcile_pending writer durable_writer journal pending =
@@ -618,8 +618,8 @@ let complete_actor writer =
     in
     if transitioned
     then (
-      ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ()));
-      ignore (Eio.Promise.try_resolve writer.resolve_closed (Ok ()))))
+      ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ()) : bool);
+      ignore (Eio.Promise.try_resolve writer.resolve_closed (Ok ()) : bool)))
 ;;
 
 let fail_actor writer failure =
@@ -658,7 +658,7 @@ let fail_actor writer failure =
     match pending with
     | None -> ()
     | Some (failure, in_flight, queued) ->
-      ignore (Eio.Promise.try_resolve writer.resolve_ready (Error failure));
+      ignore (Eio.Promise.try_resolve writer.resolve_ready (Error failure) : bool);
       let rec settle_all count = function
         | [] -> count
         | command :: rest ->
@@ -668,7 +668,7 @@ let fail_actor writer failure =
       in
       let newly_settled = settle_all (settle_all 0 in_flight) queued in
       record_settled writer newly_settled;
-      ignore (Eio.Promise.try_resolve writer.resolve_closed (Error failure)))
+      ignore (Eio.Promise.try_resolve writer.resolve_closed (Error failure) : bool))
 ;;
 
 let await_reconciliation_wake writer observed_wake =


### PR DESCRIPTION
## 무엇을

`execution_lane_writer.ml` 의 5곳이 `Eio.Promise.try_resolve` 결과를 **맨 `ignore`** 로 버립니다. `ignore` 는 어떤 타입이든 받으므로, 그 표현식이 내는 것이 바뀌어도 컴파일이 통과합니다.

```ocaml
- ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ()))
+ ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ()) : bool)
```

## 왜 — 저장소에 이미 관례가 있습니다

```ocaml
(* lib/server/server_routes_http_keeper_stream.ml:1031-1032 *)
ignore
  (Eio.Promise.try_resolve worker_completion_resolver completion : bool)
```

같은 호출에 대해 한쪽은 타입을 고정하고 lane writer 는 하지 않았습니다. `#2611` 이 store 쪽에 이 처리를 적용하고 lane writer 를 남긴 것이 `#27887` 이 기록한 N-of-M 입니다.

## 검증

```
test_execution_lane_writer   Test Successful
test_execution_event_store   Test Successful
dune build @check            clean
ocamlformat --check          clean
```

동작 변경은 없습니다 — 버려지는 값은 그대로 버려지고, **무엇을 버리는지가 타입으로 남습니다.**

## 범위 밖

`#27887` 의 나머지 둘은 다루지 않습니다: cancel-protect 회귀 테스트 부재(`store_writer` · `commit_mutation` 이 `test/` 에 0건)와 RATCHET-WAIVED 가 가리키는 RFC 의 실체 부재. 둘 다 이 diff 와 다른 작업입니다.

RFC-WAIVED: 타입 주석만 추가하며 동작·설정·hook 을 바꾸지 않습니다.

Refs #27887

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
