### PR TITLE
fix(eio): 마지막 wildcard catch 3곳에 cancel 가드를 넣고 린트를 배선한다

### DIFF
--- a/lib/auth/auth.ml
+++ b/lib/auth/auth.ml
@@ -132,7 +132,9 @@ let verify_workspace_secret config ~cached_hash secret : bool =
        if Sys.file_exists file
        then constant_time_string_equal hash (String.trim (In_channel.with_open_text file In_channel.input_all))
        else false
-     with _ -> false)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | _ -> false)
 ;;
 
 let check_permission config ~agent_name ~token ~permission : (unit, masc_error) result =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1481,7 +1481,7 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
                 | Some _ -> Some `Null
                 | None -> None)
             | _ -> None
-            | exception _ -> None
+            | exception _ -> None (* cancel-guard-ok: the scrutinee is a decoded JSON value and the arms only pattern-match on it, so no fiber work runs under this handler *)
           in
           let send_overloaded_response rejection =
             Log.Server.debug

--- a/lib/server/session_lifecycle_event.ml
+++ b/lib/server/session_lifecycle_event.ml
@@ -215,8 +215,9 @@ let _installed : bool Atomic.t = Atomic.make false
 
 let publish evt =
   let p = Atomic.get _publisher in
-  try p evt
-  with exn ->
+  try p evt with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     (* Swallow + log: a failing observer must not break the eviction
        path. The whole point of PR-3 is that transport teardown
        remains predictable regardless of subscriber state. *)

--- a/scripts/ci/run-lint-suite.sh
+++ b/scripts/ci/run-lint-suite.sh
@@ -119,6 +119,12 @@ blocking_pr_lints() {
     python3 scripts/ci/test_check_stale_base_revert.py
   run_lint "Stale-base revert guard (RFC-0235)" \
     python3 scripts/ci/check-stale-base-revert.py --base "${base}" --head HEAD
+  # A wildcard catch that swallows Eio.Cancel.Cancelled is the bug this repo
+  # modelled in TLA+ (CancelledAbsorbed / CancelledNeverAbsorbed) and hit at
+  # runtime as an Assert_failure. The lint existed but no workflow ran it, so
+  # the count drifted to 32 and back to 0 without anyone seeing either move.
+  # Blocking at 0 keeps the next one from landing unnoticed.
+  run_lint "Cancel guard on wildcard catches" bash scripts/lint-cancel-guard.sh
 }
 
 advisory_lints() {


### PR DESCRIPTION
## 무엇을

`scripts/lint-cancel-guard.sh` 가 잡는 3곳을 처리하고, 그 린트를 `blocking_lints` 에 넣습니다.

## 왜 — TLA+ 로 모델링까지 한 버그 클래스가 무방비였습니다

이 린트는 `Eio.Cancel.Cancelled` 를 삼킬 수 있는 wildcard catch 를 찾습니다. 이 저장소가 `CancelledAbsorbed` 액션 + `CancelledNeverAbsorbed` invariant 로 TLA+ 모델링을 했고, 런타임에서는 `keeper_registry` 의 `Assert_failure` 로 드러난 바로 그 버그입니다.

**어느 워크플로도 이 린트를 돌리지 않았습니다.** `#27521` 접수 시 32건이었고 지금 3건입니다 — **양쪽 이동을 아무도 보지 못했습니다.**

## 세 지점

**1. `lib/auth/auth.ml:135`** — workspace secret 을 읽는 `try … with _ -> false`. 취소된 fiber 가 unwind 하는 대신 **"인증 실패"로 답합니다.**

**2. `lib/server/session_lifecycle_event.ml:219`** — observer 실패를 일부러 삼킵니다. 주석이 이유를 적어뒀습니다(*"a failing observer must not break the eviction path"*). 그 논리는 옳지만 **취소에는 적용되지 않습니다.**

둘 다 catch-all 앞에 re-raise 를 넣습니다:

```ocaml
| Eio.Cancel.Cancelled _ as e -> raise e
```

**3. `lib/server/server_runtime_bootstrap.ml:1484`** — 디코드된 JSON 값에 대한 match 이고 그 핸들러 아래에서 fiber 작업이 돌지 않습니다. **발화할 수 없는 가드를 넣는 대신** 인라인 `cancel-guard-ok` 마커에 그 이유를 적었습니다.

## 배선

0건이므로 `blocking_lints` 에 넣습니다. 다음 한 건이 드리프트가 아니라 **PR 실패**가 됩니다.

## 검증

```
scripts/lint-cancel-guard.sh   exit 0, no violations   (수정 전 3건)
test_auth                      Test Successful
dune build @check              clean
ocamlformat --check            clean
```

**대조군**: `test_server_runtime_bootstrap` 은 이 변경 전후 모두 11건 실패입니다(`#27250`, 무관한 기존 red).

RFC-WAIVED: 예외 핸들러 3곳과 린트 배선만 변경합니다. credential 로직·hooks·workflow 문서를 건드리지 않습니다.

Refs #27521

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
