### PR TITLE
feat(claude-code): 턴이 실제로 무엇을 보내는지 기록한다 — #28101 이 남긴 다른 official-client 경로

### DIFF
--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -370,6 +370,29 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             | Error detail -> Error detail))
       | Ambiguous | Fatal -> require_recovery detail
     in
+    (* Same gap #28101 closed for Codex, on the other official-client path. A
+       claude_code turn resumes a server-side session, so the accumulated
+       conversation is not held here and cannot be measured from this process.
+       What this process does send every turn - the prompt, the system prompt
+       and the tool declarations - is measurable, and a live refusal says that
+       part alone is the problem: analyst was told the request is ~2,226,104
+       tokens against a 1,000,000 limit while "this conversation is only
+       ~1,094,432 tokens - the rest is system prompt, tool definitions, and
+       attachment content" (#27427). Recording the half this process controls
+       is what lets that sentence be checked against a number rather than
+       believed. Sizes are bytes this process holds, not provider tokens. *)
+    Log.Keeper.info
+      ~keeper_name
+      "%s turn composition: mode=%s prompt_bytes=%d system_prompt_bytes=%d \
+       tools=%d tool_surface_bytes=%d"
+      runtime_label
+      (match session_mode with
+       | Runtime_claude_code.Start -> "start"
+       | Runtime_claude_code.Resume _ -> "resume")
+      (String.length prompt)
+      (Option.fold ~none:0 ~some:String.length client_config.Runtime_claude_code.system_prompt)
+      (List.length dynamic_tools)
+      (Runtime_claude_code.dynamic_tool_bytes dynamic_tools);
     let started_at = Time_compat.now () in
     let turn_result =
       try

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -80,6 +80,17 @@ type dynamic_tool =
   ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
   }
 
+let dynamic_tool_bytes tools =
+  List.fold_left
+    (fun acc tool ->
+       acc
+       + String.length tool.name
+       + String.length tool.description
+       + String.length (Yojson.Safe.to_string tool.input_schema))
+    0
+    tools
+;;
+
 type error =
   | Invalid_config of string
   | Spawn_failed of string

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -69,6 +69,10 @@ type dynamic_tool =
   ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
   }
 
+val dynamic_tool_bytes : dynamic_tool list -> int
+(** Bytes the tool declarations occupy in the request this process builds. Not
+    provider tokens: it bounds the request, it does not price it. *)
+
 type error =
   | Invalid_config of string
   | Spawn_failed of string

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -173,6 +173,29 @@ let test_subscription_turn_and_env_scrub () =
       check bool "no usage block yields none" true (Option.is_none turn.usage))
 ;;
 
+(* [dynamic_tool_bytes] measures what the tool declarations add to a request.
+   The request-side check #27427 needs is a comparison against a declared
+   window, and a size that silently ignores part of what it sends is what made
+   the old system_and_user_bytes report 6,971 bytes for a turn the provider
+   refused as full. Each field the request carries has to be in the sum. *)
+let test_dynamic_tool_bytes_counts_every_field () =
+  let tool =
+    { Runtime_claude_code.name = "ab"
+    ; description = "cde"
+    ; input_schema = `Assoc [ "f", `String "g" ]
+    ; call = (fun ~call_id:_ _ -> { Runtime_claude_code.success = true; content = "" })
+    }
+  in
+  let schema_bytes = String.length (Yojson.Safe.to_string tool.Runtime_claude_code.input_schema) in
+  check int "single tool sums name, description and schema"
+    (2 + 3 + schema_bytes)
+    (Runtime_claude_code.dynamic_tool_bytes [ tool ]);
+  check int "empty list is zero" 0 (Runtime_claude_code.dynamic_tool_bytes []);
+  check int "two tools sum"
+    (2 * (2 + 3 + schema_bytes))
+    (Runtime_claude_code.dynamic_tool_bytes [ tool; tool ])
+;;
+
 (* The keeper side of this runtime hardcoded [usage = None] while the
    antigravity runtime fills the same slot from its CLI stream, which is why
    official-client turns carry no input_tokens (#28023). Reading it here is what
@@ -877,6 +900,10 @@ let () =
         ; test_case "malformed JSON fails closed" `Quick test_malformed_json_fails_closed
         ; test_case "duplicate keys fail closed" `Quick test_duplicate_keys_fail_closed
         ; test_case "result usage is carried" `Quick test_result_usage_is_carried
+        ; test_case
+            "dynamic tool bytes counts every field"
+            `Quick
+            test_dynamic_tool_bytes_counts_every_field
         ; test_case
             "partial usage does not fail the turn"
             `Quick


### PR DESCRIPTION
## 무엇을

claude_code 턴의 구성을 dispatch 시점에 기록합니다 — `#28101` 이 Codex 에 넣은 것과 같은 형태입니다.

```
mode, prompt_bytes, system_prompt_bytes, tools, tool_surface_bytes
```

## 왜 — 그 문장이 지금은 검증 불가능합니다

`analyst` 가 받은 거부:

> the request is **~2,226,104 tokens** (limit 1,000,000) but this conversation is only ~1,094,432 tokens — **the rest is system prompt, tool definitions, and attachment content**

**"the rest" 가 1,131,672 토큰인데, 그 크기를 이 프로세스에서 재는 것이 아무것도 없습니다.** provider 의 말을 믿는 것 외에 확인할 방법이 없습니다.

claude_code 는 서버측 세션을 resume 하므로 누적 대화는 여기에 없고 잴 수 없습니다. **하지만 매 턴 보내는 자기 몫 — 프롬프트·system prompt·툴 선언 — 은 잴 수 있고, 거부 문장이 문제라고 지목한 것이 바로 그 몫입니다.**

## 환산 계수의 짝이 맞춰집니다

| | 구성 바이트 | 거부 시 토큰 수 |
|---|---|---|
| Codex | **있음** (`#28101`) | 없음 (문장만) |
| claude_code | 없음 → **이 PR** | **있음** (`~2226104 / limit 1000000`) |

한 런타임에서 양쪽이 다 기록되면 **거부 한 번으로 바이트당 토큰 비율이 나옵니다.** 추정이 아니라 그 런타임이 방금 보고한 값입니다.

## 검증

```
test_runtime_claude_code         Test Successful
test_keeper_claude_code_runtime  Test Successful
dune build @check                clean
ocamlformat --check              clean
```

## 범위

로그만 추가합니다. 판정도, 축소도 하지 않습니다 — `#27427` 의 1단계가 필요로 하는 **입력**을 만드는 것이 전부입니다.

크기는 이 프로세스가 들고 있는 바이트이지 provider 토큰이 아닙니다. 요청을 **bound** 하지 **price** 하지 않습니다 — `#28101` 이 같은 문장을 씁니다.

RFC-WAIVED: 로그 한 줄과 그 바이트 헬퍼만 추가합니다. 동작·설정·hook 을 바꾸지 않습니다.

Refs #27427, #28023

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
