### PR TITLE
harness: transport boot-path config 를 히어독에서 파일로 뺀다 — 히어독은 게이트에 안 보인다

### DIFF
--- a/scripts/fixtures/transport-harness/agent-core-models-overlay.toml
+++ b/scripts/fixtures/transport-harness/agent-core-models-overlay.toml
@@ -1,0 +1,24 @@
+[[providers]]
+id = "deepseek"
+kind = "openai_compat"
+base_url = "http://127.0.0.1:9/v1"
+request_path = "/chat/completions"
+api_key_env = ""
+capabilities_base = "openai_chat"
+
+[[models]]
+id_prefix = "transport-harness-smoke"
+provider_name = "deepseek"
+base = "openai_chat"
+max_context_tokens = 32768
+max_output_tokens = 1024
+supports_tools = true
+supports_tool_choice = true
+supports_response_format_json = false
+supports_structured_output = false
+supports_native_streaming = true
+
+[[targets]]
+id = "deepseek.smoke"
+provider_ref = "deepseek"
+model_id = "transport-harness-smoke"

--- a/scripts/fixtures/transport-harness/runtime.toml
+++ b/scripts/fixtures/transport-harness/runtime.toml
@@ -1,0 +1,29 @@
+[runtime]
+default = "deepseek.smoke"
+
+[runtime.exact_output_lanes.hitl_auto_judge]
+slots = ["deepseek.smoke"]
+
+[runtime.exact_output_lanes.board_attention_exact]
+slots = ["deepseek.smoke"]
+
+[providers.deepseek]
+display-name = "Transport Harness Smoke"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:9/v1"
+
+[models.smoke]
+# Harness-local opaque runtime alias. The adjacent typed capability block is
+# the sole declaration used when no exact AGENT_CORE catalog row exists.
+api-name = "transport-harness-smoke"
+max-context = 32768
+tools-support = true
+streaming = true
+
+[models.smoke.capabilities]
+supports-tool-choice = true
+
+[deepseek.smoke]
+is-default = true
+max-concurrent = 1
+max-request-body-bytes = 65536

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -118,73 +118,34 @@ harness_seed_server_config() {
   local config_dir="${base_path%/}/.masc/config"
   local seeded_runtime=0
 
+  # The boot-path config lives in files rather than heredocs so
+  # [test_runtime_config_validity] discovers it and checks the lane ids against
+  # [Server_runtime_bootstrap.mandatory_exact_output_lane_ids]. A heredoc is
+  # invisible to that test, which is how a harness fixture can name a lane the
+  # server no longer accepts and only fail when the harness runs (#25726,
+  # #25727). Missing fixtures fail here rather than seeding an empty config.
+  local TRANSPORT_HARNESS_FIXTURE_DIR="$repo_root/scripts/fixtures/transport-harness"
+  local fixture
+  for fixture in runtime.toml agent-core-models-overlay.toml; do
+    if [[ ! -f "$TRANSPORT_HARNESS_FIXTURE_DIR/$fixture" ]]; then
+      echo "harness: fixture missing: scripts/fixtures/transport-harness/$fixture" >&2
+      return 1
+    fi
+  done
+
   mkdir -p \
     "$config_dir" \
     "$config_dir/keepers" \
     "$config_dir/prompts"
 
   if [[ ! -f "$config_dir/runtime.toml" ]]; then
-    cat >"$config_dir/runtime.toml" <<'EOF'
-[runtime]
-default = "deepseek.smoke"
-
-[runtime.exact_output_lanes.hitl_auto_judge]
-slots = ["deepseek.smoke"]
-
-[runtime.exact_output_lanes.board_attention_exact]
-slots = ["deepseek.smoke"]
-
-[providers.deepseek]
-display-name = "Transport Harness Smoke"
-protocol = "openai-compatible-http"
-endpoint = "http://127.0.0.1:9/v1"
-
-[models.smoke]
-# Harness-local opaque runtime alias. The adjacent typed capability block is
-# the sole declaration used when no exact AGENT_CORE catalog row exists.
-api-name = "transport-harness-smoke"
-max-context = 32768
-tools-support = true
-streaming = true
-
-[models.smoke.capabilities]
-supports-tool-choice = true
-
-[deepseek.smoke]
-is-default = true
-max-concurrent = 1
-max-request-body-bytes = 65536
-EOF
+    cp "$TRANSPORT_HARNESS_FIXTURE_DIR/runtime.toml" "$config_dir/runtime.toml"
     seeded_runtime=1
   fi
 
   if [[ "$seeded_runtime" == "1" && ! -f "$config_dir/agent-core-models-overlay.toml" ]]; then
-    cat >"$config_dir/agent-core-models-overlay.toml" <<'EOF'
-[[providers]]
-id = "deepseek"
-kind = "openai_compat"
-base_url = "http://127.0.0.1:9/v1"
-request_path = "/chat/completions"
-api_key_env = ""
-capabilities_base = "openai_chat"
-
-[[models]]
-id_prefix = "transport-harness-smoke"
-provider_name = "deepseek"
-base = "openai_chat"
-max_context_tokens = 32768
-max_output_tokens = 1024
-supports_tools = true
-supports_tool_choice = true
-supports_response_format_json = false
-supports_structured_output = false
-supports_native_streaming = true
-
-[[targets]]
-id = "deepseek.smoke"
-provider_ref = "deepseek"
-model_id = "transport-harness-smoke"
-EOF
+    cp "$TRANSPORT_HARNESS_FIXTURE_DIR/agent-core-models-overlay.toml" \
+      "$config_dir/agent-core-models-overlay.toml"
   fi
 }
 


### PR DESCRIPTION
## 무엇을

transport harness 의 boot-path config 두 개를 히어독에서 파일로 빼냅니다 — `#25727` 의 1번 항목입니다.

```
scripts/harness/lib/server_bootstrap.sh  히어독 2개
  → scripts/fixtures/transport-harness/{runtime.toml,agent-core-models-overlay.toml}
```

## 왜 — 히어독은 게이트에 보이지 않습니다

`test_runtime_config_validity` 는 **발견형**입니다:

```ocaml
(* Discovered, not enumerated: any scripts/fixtures/<name>/runtime.toml is a
   boot-path fixture ... *)
```

발견된 fixture 의 레인 id 를 `Server_runtime_bootstrap.mandatory_exact_output_lane_ids` 와 대조합니다. **히어독은 그 발견에 걸리지 않으므로**, harness fixture 가 서버가 더 이상 받지 않는 레인을 이름으로 대고 있어도 **harness 를 돌릴 때에야** 드러납니다.

## 검증 — 추출이 실제로 커버리지를 삽니다

레인 id 하나를 바꿔봤습니다:

```
[runtime.exact_output_lanes.hitl_auto_judge]  →  [runtime.exact_output_lanes.not_a_real_lane]
```

```
[FAIL]  runtime TOML gate  64  every discovered boot-path fixture ...
[OK]    runtime TOML gate  65  release-evidence smoke lanes ...
```

**그 단언만 빨개집니다.** 히어독이었을 때는 같은 변경이 아무 데도 안 걸렸습니다.

## 내용 동일성

둘 다 quoted heredoc(`<<'EOF'`) 이라 보간이 없고, 원본과 **바이트 단위로 동일**합니다:

```bash
$ git show HEAD:scripts/harness/lib/server_bootstrap.sh \
    | sed -n '/cat >"\$config_dir\/runtime.toml"/,/^EOF$/p' | sed '1d;$d' \
    | diff - scripts/fixtures/transport-harness/runtime.toml
(차이 없음)
```

"파일이 없을 때만 시드" 조건은 그대로 두었고, **fixture 가 없으면 조용히 빈 config 를 만드는 대신 실패**합니다 — `scripts/release-evidence.sh` 가 `#25726` 에서 쓴 형태와 같습니다.

## 검증

```
test_runtime_config_validity   Test Successful  73 tests
bash -n server_bootstrap.sh    clean
원본 히어독과 diff             동일
```

## 범위 밖

`scripts/harness/perf/keeper_load_gate.sh` 는 여전히 `runtime.toml` 히어독을 씁니다. **보간이 있는 케이스**라 `#25727` 이 "그대로 복사 불가" 로 분류한 쪽이고, 별도 판단이 필요합니다. 이 PR 이후 `rg "cat >.*runtime\.toml" scripts/` 는 그 한 건만 남습니다.

RFC-WAIVED: harness fixture 를 파일로 옮기고 복사로 바꿉니다. 내용은 동일하며 프로덕션 코드·credential·hook 을 건드리지 않습니다.

Refs #25727

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
