### PR TITLE
fix(keeper): record Librarian prompt window as actual input

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -83,6 +83,15 @@ let select_recent_messages ~max_messages messages =
   drop drop_count messages
 ;;
 
+let prompt_input_for_librarian (inp : Keeper_librarian.input) =
+  { inp with
+    messages =
+      select_recent_messages
+        ~max_messages:(prompt_max_messages ())
+        inp.messages
+  }
+;;
+
 let message role text =
   Agent_core.Types.make_message ~role [ Agent_core.Types.Text text ]
 ;;
@@ -188,23 +197,20 @@ let render_prompt key variables =
   | Error message -> Error (Printf.sprintf "%s: %s" key message)
 ;;
 
+let render_librarian_prompt input =
+  render_prompt
+    Prompt_names.librarian
+    (Keeper_librarian.prompt_variables input)
+;;
+
 let prompt_and_input_for_librarian (inp : Keeper_librarian.input) =
-  let input =
-    { inp with
-      messages =
-        select_recent_messages
-          ~max_messages:(prompt_max_messages ())
-          inp.messages
-    }
-  in
+  let input = prompt_input_for_librarian inp in
   let open Result.Syntax in
   (* One asset, one message: the librarian's role statement lives at the top
      of the selection prompt it is rendered with, so there is no second file
      to keep in step. *)
   let+ prompt =
-    render_prompt
-      Prompt_names.librarian
-      (Keeper_librarian.prompt_variables input)
+    render_librarian_prompt input
   in
   input, prompt
 ;;
@@ -472,6 +478,7 @@ let run_best_effort
           | None -> 0
           | Some current -> List.length current.facts
         in
+        let prompt_input = prompt_input_for_librarian inp in
         Exact_lane_run_registry.register_running
           registry
           ~run_id
@@ -482,11 +489,12 @@ let run_best_effort
           ~input:
             (Exact_lane_run_registry.Exact_input
                (`Assoc
-                  [ "actual_input", exact_input_payload inp
-                  ; "generation", `Int inp.generation
-                  ; "message_count", `Int (List.length inp.messages)
+                  [ "actual_input", exact_input_payload prompt_input
+                  ; "generation", `Int prompt_input.generation
+                  ; "message_count", `Int (List.length prompt_input.messages)
                   ; "current_fact_count", `Int current_fact_count
-                  ; "max_recall_fact_bytes", `Int inp.max_recall_fact_bytes
+                  ; ( "max_recall_fact_bytes"
+                    , `Int prompt_input.max_recall_fact_bytes )
                   ]));
         let complete outcome output =
           Exact_lane_run_registry.mark_completed
@@ -499,15 +507,15 @@ let run_best_effort
         (try
            let result =
              let open Result.Syntax in
-             let* selected_input, prompt =
-               prompt_and_input_for_librarian inp
+             let* prompt =
+               render_librarian_prompt prompt_input
                |> Result.map_error (fun detail -> Prompt_render_failed detail)
              in
              let* selection, exact_output =
                execute_exact_output_classified
                  ~clock
                  ~net
-                 ~selected_input
+                 ~selected_input:prompt_input
                  ~messages:[ message Agent_core.Types.User prompt ]
              in
              let+ snapshot =

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -14,6 +14,15 @@ val cadence_step_keyed
 val cadence_counter_entries : unit -> int
 
 val max_messages : unit -> int
+val prompt_max_messages : unit -> int
+
+(** The immutable input projected into the Librarian prompt. The exact-run
+    registry records this value as the actual input, so observability and
+    provider dispatch share the same history window. *)
+val prompt_input_for_librarian
+  :  Keeper_librarian.input
+  -> Keeper_librarian.input
+
 val messages_for_librarian
   :  Keeper_librarian.input
   -> (Agent_core.Types.message list, string) result

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -404,6 +404,54 @@ let user_text_of_messages messages =
   |> String.concat "\n"
 ;;
 
+let test_prompt_input_and_rendered_prompt_share_the_same_window () =
+  let max_messages = Runtime.prompt_max_messages () in
+  check bool "configured prompt window is positive" true (max_messages > 0);
+  let total = max_messages + 3 in
+  let messages =
+    List.init total (fun index ->
+      Agent_core.Types.make_message
+        ~role:Agent_core.Types.User
+        [ Agent_core.Types.Text (Printf.sprintf "history-%04d" index) ])
+  in
+  let original = { (input ()) with messages } in
+  let projected = Runtime.prompt_input_for_librarian original in
+  check int
+    "registry/provider input uses configured history window"
+    max_messages
+    (List.length projected.messages);
+  let projected_text = user_text_of_messages projected.messages in
+  check bool
+    "discarded head is absent from projected input"
+    false
+    (String_util.contains_substring projected_text "history-0000");
+  check bool
+    "first retained message is present in projected input"
+    true
+    (String_util.contains_substring projected_text "history-0003");
+  let last = Printf.sprintf "history-%04d" (total - 1) in
+  check bool
+    "latest message is present in projected input"
+    true
+    (String_util.contains_substring projected_text last);
+  match Runtime.messages_for_librarian original with
+  | Error detail -> failf "librarian render failed: %s" detail
+  | Ok rendered_messages ->
+    let rendered = user_text_of_messages rendered_messages in
+    check bool
+      "rendered prompt omits the same discarded head"
+      false
+      (String_util.contains_substring rendered "history-0000");
+    check bool
+      "rendered prompt carries the same first retained message"
+      true
+      (String_util.contains_substring rendered "history-0003");
+    check bool
+      "rendered prompt carries the latest message"
+      true
+      (String_util.contains_substring rendered last)
+;;
+
 let test_prompt_carries_recall_fact_byte_budget () =
   let constrained = { (input ()) with max_recall_fact_bytes = 12_345 } in
   check string "budget variable is exact"
@@ -629,6 +677,10 @@ let () =
             test_prompt_carries_recall_fact_byte_budget
         ; test_case "prompt omits tool payload and stays single-message" `Quick
             test_prompt_omits_tool_result_payload_and_has_one_message
+        ; test_case
+            "prompt input and rendered prompt share history window"
+            `Quick
+            test_prompt_input_and_rendered_prompt_share_the_same_window
         ; test_case "repo template renders Keeper instructions" `Quick
             test_repo_template_renders_keeper_instructions
         ; test_case "constraint category excludes self-imposed scope" `Quick


### PR DESCRIPTION
## Summary
- make Librarian prompt projection the single input used by provider dispatch and exact-run observability
- record the windowed message count and rendered prompt variables instead of the pre-window full history
- pin that the projected input and rendered prompt retain the same tail window

## Live evidence
- deployed main `64f10a94bc` sent a bounded Librarian prompt but recorded the full pre-window history as `actual_input`
- recent lane-smith rows reported 4,025 messages / ~1.23 MB per registration
- `exact-lane-runs-v3.jsonl` reached 22 MB after 46 Librarian registrations
- Dashboard labels this payload as `실제 입력 · typed`, so this was an observability SSOT error, not only storage overhead

## Verification
- `git diff --check` passed
- local build/tests intentionally not run per operator; GitHub CI is the build/test authority