### PR TITLE
docs(rfc): RFC-0312의 죽은 RFC-0309 인용을 후계 규범으로 교체

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -232,6 +232,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0364 | keeper 당 체크아웃 하나 (`repos/` 중간 디렉터리 폐기) | Draft | - |
 | 0365 | handoff_context must survive the ownership boundary | Draft | - |
 | 0366 | 운영자가 다음 턴의 컨텍스트에 한 문장을 넣는다 | Draft | - |
+| 0368 | 판단 없는 recovery는 keeper의 다음 claim이 스스로 해제한다 | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |

--- a/docs/rfc/RFC-0312-keeper-repo-mapping-advisory-scope.md
+++ b/docs/rfc/RFC-0312-keeper-repo-mapping-advisory-scope.md
@@ -3,11 +3,11 @@ rfc: "0312"
 title: "Keeper repo mappings are advisory default scope, not access caps"
 status: Accepted
 created: 2026-07-07
-updated: 2026-07-07
+updated: 2026-08-11
 author: vincent + codex
 supersedes: []
 superseded_by: null
-related: ["0104", "0219", "0305", "0309"]
+related: ["0104", "0219", "0305"]
 implementation_prs:
   - "#23359"
 ---
@@ -61,8 +61,10 @@ policy layers:
   is a known repository.
 - Destructive filesystem and shell operations remain gated by the existing
   execution policy.
-- GitHub mutation capability is governed by the typed capability-policy axis in
-  RFC-0309, not by keeper repo mappings.
+- Repo-hosting CLI mutations (for example `gh`) are not governed by keeper
+  repo mappings. Like every external effect, they are judged per operation by
+  the non-hierarchical effect Gate
+  (`docs/spec/05-keeper-agent.md#inv-keeper-008-non-hierarchical-effect-gate`).
 
 Mutable checkout metadata, including a playground clone's `.git/config` remote
 URLs, must not authorize repository identity. It can inform diagnostics, but it


### PR DESCRIPTION
## 무엇

RFC-0312 §3의 GitHub mutation 거버넌스 불릿이 존재하지 않는 RFC-0309를 인용합니다. 후계 규범 anchor로 교체하고 frontmatter `related`에서 0309를 제거했습니다.

## 왜

RFC-0309(typed gh capability gating)의 생애를 추적한 결과:

- #23378 초안 + G-0 baseline harness
- #23618 구현 (`lib/exec/gh_capability_policy.ml` 817줄, `approval_policy.ml` 475줄)
- #24332 **의도적 철회** + 구현 전체 제거. Withdrawn 스텁에 `superseded_by: docs/spec/05-keeper-agent.md#inv-keeper-008-non-hierarchical-effect-gate` 명시. 철회 사유는 product-blind 원칙("Gate 레이어는 특정 CLI·verb·credential scheme을 알면 안 된다").
- #27624 Withdrawn 스텁 자체 삭제 (죽은 개념 척살 원칙)

RFC-0312(#23359)는 철회 이전에 작성되어, 이 인용만 두 번의 숙청에서 살아남아 죽은 권위를 가리키고 있었습니다.

교체 문안의 근거:

- `docs/spec/05-keeper-agent.md:465` — INV-KEEPER-008(non-hierarchical effect Gate) 실존 확인
- `lib/keeper/keeper_tool_execute_runtime.ml:57-63` — keeper 셸 실행이 `masc.keeper_gate.request.v1`로 Gate에 제출됨 (repo-hosting CLI mutation이 실제로 이 축의 판정을 받음)

## 검증

- 문서 전용 변경 (코드 없음). `rg -n '0309' docs/rfc/RFC-0312-keeper-repo-mapping-advisory-scope.md` → 0건.
- 발단: `reports/orca-vs-masc-adversarial-2026-08-11.html` G2 (orca 대조 감사 v2.1 — 해당 리포트의 v2 판정 "규범 공백"은 이 추적으로 자기정정됨).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
