### PR TITLE
fix(keeper): preserve Codex context overflow type

### DIFF
--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -98,6 +98,9 @@ let codex_error_to_core_error = function
     config_error ~field:"codex_app_server" detail
   | Runtime_codex_app_server.Subscription_required detail ->
     config_error ~field:"codex_subscription" detail
+  | Runtime_codex_app_server.Context_window_exceeded { message } ->
+    Agent_core.Error.Api
+      (Llm_provider.Retry.ContextOverflow { message; limit = None })
   | error -> Agent_core.Error.Internal (Runtime_codex_app_server.error_to_string error)
 ;;
 
@@ -114,6 +117,7 @@ let recovery_failure_of_client_error = function
   | Runtime_codex_app_server.Unsupported_server_request _ ->
     Keeper_official_client_session_store.Protocol_failed
   | Runtime_codex_app_server.Subscription_required _
+  | Runtime_codex_app_server.Context_window_exceeded _
   | Runtime_codex_app_server.Turn_failed _ ->
     Keeper_official_client_session_store.Provider_rejected
 ;;

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -105,6 +105,7 @@ type error =
       }
   | Subscription_required of string
   | Unsupported_server_request of string
+  | Context_window_exceeded of { message : string }
   | Turn_failed of string
   | Turn_interrupted
   | Process_exited of string
@@ -122,6 +123,8 @@ let error_to_string = function
     "Codex ChatGPT subscription login required: " ^ detail
   | Unsupported_server_request method_ ->
     "Codex app-server requested unsupported host action: " ^ method_
+  | Context_window_exceeded { message } ->
+    "Codex app-server context window exceeded: " ^ message
   | Turn_failed detail -> "Codex app-server turn failed: " ^ detail
   | Turn_interrupted -> "Codex app-server turn was interrupted"
   | Process_exited detail -> "Codex app-server exited before completion: " ^ detail
@@ -136,6 +139,7 @@ let error_kind = function
   | Rpc_error _ -> "rpc_error"
   | Subscription_required _ -> "subscription_required"
   | Unsupported_server_request _ -> "unsupported_server_request"
+  | Context_window_exceeded _ -> "context_window_exceeded"
   | Turn_failed _ -> "turn_failed"
   | Turn_interrupted -> "turn_interrupted"
   | Process_exited _ -> "process_exited"
@@ -492,16 +496,36 @@ let messages_of_items ~stage = function
   | _ -> protocol_error stage "turn items must be an array"
 ;;
 
-(* Only [message] used to survive this function, so a live keeper failing every
-   turn on "Codex ran out of room in the model's context window" carried no
-   machine-readable trace of what kind of failure that was (#28071). Whatever
-   else the server put on the error object is kept here as well: a later change
-   that wants to route context overflow to the shrink retry needs a typed field
-   to key on, and it cannot recover one that was discarded at parse time.
+(* [CodexErrorInfo] is part of Codex app-server's generated protocol schema.
+   The exact [contextWindowExceeded] enum is the provider-owned classification;
+   human prose and ad-hoc scalar fields remain observational detail only. *)
+let turn_error_detail ~message error_fields =
+  let annotation (name, value) =
+    if String.equal name "message"
+    then None
+    else (
+      match value with
+      | `String value when String.trim value <> "" ->
+        Some (name ^ "=" ^ String.trim value)
+      | `Int value -> Some (name ^ "=" ^ string_of_int value)
+      | `Intlit value -> Some (name ^ "=" ^ value)
+      | `Bool value -> Some (name ^ "=" ^ string_of_bool value)
+      | `Float value -> Some (name ^ "=" ^ Printf.sprintf "%g" value)
+      | `String _ | `Null | `Assoc _ | `List _ | `Tuple _ | `Variant _ -> None)
+  in
+  match List.filter_map annotation error_fields with
+  | [] -> message
+  | annotations -> message ^ " (" ^ String.concat " " annotations ^ ")"
+;;
 
-   This does not classify anything. It stops throwing away the input a
-   classification would need. *)
-let turn_error_message fields =
+let turn_error_of_fields ~message error_fields =
+  match List.assoc_opt "codexErrorInfo" error_fields with
+  | Some (`String "contextWindowExceeded") ->
+    Context_window_exceeded { message }
+  | Some _ | None -> Turn_failed (turn_error_detail ~message error_fields)
+;;
+
+let turn_error fields =
   match List.assoc_opt "error" fields with
   | Some (`Assoc error_fields) ->
     let message =
@@ -510,35 +534,8 @@ let turn_error_message fields =
         String.trim message
       | _ -> "turn failed without a typed error message"
     in
-    (* Carrying only [code] and [type] cannot answer what the server sends,
-       because a name that is absent and a name that was never looked for
-       produce the same empty annotation. Measured 2026-08-11 on live sangsu
-       (codex_subscription.gpt-5.3-codex-spark): the deployed narrow form
-       printed the overflow sentence with no annotation, which left "the error
-       object carries no scalar" and "the scalar is called something else"
-       indistinguishable. Every scalar except [message] is carried, so the
-       empty case now means exactly one thing.
-
-       Nested objects and arrays are skipped: this string is read by an
-       operator and joined into one line, and the fields a classification
-       would key on are scalars. *)
-    let annotation (name, value) =
-      if String.equal name "message"
-      then None
-      else (
-        match value with
-        | `String value when String.trim value <> "" ->
-          Some (name ^ "=" ^ String.trim value)
-        | `Int value -> Some (name ^ "=" ^ string_of_int value)
-        | `Intlit value -> Some (name ^ "=" ^ value)
-        | `Bool value -> Some (name ^ "=" ^ string_of_bool value)
-        | `Float value -> Some (name ^ "=" ^ Printf.sprintf "%g" value)
-        | `String _ | `Null | `Assoc _ | `List _ | `Tuple _ | `Variant _ -> None)
-    in
-    (match List.filter_map annotation error_fields with
-     | [] -> message
-     | annotations -> message ^ " (" ^ String.concat " " annotations ^ ")")
-  | _ -> "turn failed without an error object"
+    turn_error_of_fields ~message error_fields
+  | Some _ | None -> Turn_failed "turn failed without an error object"
 ;;
 
 let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
@@ -556,7 +553,7 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
     else
       let* status = required_string stage "status" turn_fields in
       match status with
-      | "failed" -> Error (Turn_failed (turn_error_message turn_fields))
+      | "failed" -> Error (turn_error turn_fields)
       | "interrupted" -> Error Turn_interrupted
       | "inProgress" -> protocol_error stage "terminal notification carried inProgress status"
       | "completed" ->
@@ -697,7 +694,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       let* error_json = required_member stage "error" fields in
       let* error_fields = assoc_at stage error_json in
       let* message = required_string stage "message" error_fields in
-      Error (Turn_failed message)
+      Error (turn_error_of_fields ~message error_fields)
   | Notification { method_ = "turn/completed"; params } ->
     terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params
   (* App-server progress and account notifications are observational. Protocol

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -84,6 +84,7 @@ type error =
       }
   | Subscription_required of string
   | Unsupported_server_request of string
+  | Context_window_exceeded of { message : string }
   | Turn_failed of string
   | Turn_interrupted
   | Process_exited of string

--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -78,7 +78,8 @@ let codex_failure_status = function
   | Timeout _ -> "timeout"
   | Protocol_error _ | Rpc_error _ | Unsupported_server_request _ ->
     "protocol_error"
-  | Turn_failed _ | Turn_interrupted -> "probe_contract_error"
+  | Context_window_exceeded _ | Turn_failed _ | Turn_interrupted ->
+    "probe_contract_error"
 ;;
 
 let claude_failure_status = function

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -431,6 +431,25 @@ let test_failed_turn_keeps_typed_error_fields () =
       | Ok _ -> fail "failed turn incorrectly reported as completed")
 ;;
 
+let test_failed_turn_uses_official_context_error_enum () =
+  let failed =
+    {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"ran out of room in the model's context window","codexErrorInfo":"contextWindowExceeded"}}}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; failed ]
+    (fun path ->
+      match run_fixture path with
+      | Error
+          (Runtime_codex_app_server.Context_window_exceeded { message }) ->
+        check
+          string
+          "provider message"
+          "ran out of room in the model's context window"
+          message
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "typed context overflow incorrectly reported as completed")
+;;
+
 (* The named-field form could not distinguish "the server sent no scalar" from
    "the scalar is called something else": both printed the sentence with no
    annotation. That is what live sangsu produced on 2026-08-11 after the narrow
@@ -578,6 +597,22 @@ let test_retry_notifications_are_observational () =
        | Error (Runtime_codex_app_server.Turn_failed "provider gave up") -> ()
        | Error error -> fail (Runtime_codex_app_server.error_to_string error)
        | Ok _ -> fail "terminal error notification did not fail the turn")
+;;
+
+let test_terminal_error_notification_uses_official_context_error_enum () =
+  let terminal =
+    {|{"method":"error","params":{"threadId":"thread-1","turnId":"turn-1","willRetry":false,"error":{"message":"context is full","codexErrorInfo":"contextWindowExceeded"}}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; terminal ]
+    (fun path ->
+       match run_fixture path with
+       | Error
+           (Runtime_codex_app_server.Context_window_exceeded
+              { message = "context is full" }) ->
+         ()
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok _ -> fail "typed terminal context overflow did not fail the turn")
 ;;
 
 let test_nonterminal_notifications_do_not_preempt_completion () =
@@ -1055,6 +1090,23 @@ let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projecti
                       ()
                     |> Result.map (fun selected ->
                       selected.Keeper_turn_driver.run_result))))))
+;;
+
+let test_keeper_maps_official_context_error_to_typed_core_error () =
+  let failed =
+    {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"context is full","codexErrorInfo":"contextWindowExceeded"}}}}|}
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; failed ]
+    (fun cli_path ->
+       match run_keeper_turn ~cli_path ~model:"gpt-fixture" () with
+       | Error
+           (Agent_core.Error.Api
+              (Agent_core.Retry.ContextOverflow
+                 { message = "context is full"; limit = None })) ->
+         ()
+       | Error error -> fail (Agent_core.Error.to_string error)
+       | Ok _ -> fail "Keeper erased the typed Codex context overflow")
 ;;
 
 let test_keeper_dispatches_codex_turn_runtime () =
@@ -2292,6 +2344,8 @@ let () =
         ; test_case "server request fails closed" `Quick test_server_request_fails_closed
         ; test_case "failed turn keeps typed error fields" `Quick
             test_failed_turn_keeps_typed_error_fields
+        ; test_case "failed turn uses official context error enum" `Quick
+            test_failed_turn_uses_official_context_error_enum
         ; test_case "failed turn keeps unnamed error scalars" `Quick
             test_failed_turn_keeps_unnamed_error_scalars
         ; test_case "history bytes sum text only" `Quick
@@ -2303,6 +2357,10 @@ let () =
             "retry notifications are observational"
             `Quick
             test_retry_notifications_are_observational
+        ; test_case
+            "terminal error notification uses official context error enum"
+            `Quick
+            test_terminal_error_notification_uses_official_context_error_enum
          ; test_case
              "nonterminal notifications do not preempt completion"
              `Quick
@@ -2337,6 +2395,10 @@ let () =
             "Keeper dispatches Codex runtime"
             `Quick
             test_keeper_dispatches_codex_turn_runtime
+        ; test_case
+            "Keeper maps official context error to typed core error"
+            `Quick
+            test_keeper_maps_official_context_error_to_typed_core_error
         ; test_case
             "Keeper preserves typed history on Codex wire"
             `Quick


### PR DESCRIPTION
## Summary

- decode the official Codex app-server `codexErrorInfo=contextWindowExceeded` enum into a typed runtime error
- bridge that error to `Agent_core.Error.Api (ContextOverflow ...)`
- keep prose and ad-hoc scalar error fields observational; no string matching or heuristic classification
- cover both `turn/completed` and terminal `error` notifications plus the Keeper bridge

## Why

Live Codex Keepers repeatedly entered recovery with a generic internal error even though Codex app-server 0.147.0 exposes an exact typed context-window signal. The adapter preserved the message but erased `codexErrorInfo`, so the existing typed overflow routing and shrink machinery could not observe it.

This PR restores the protocol fact. Wiring same-runtime adaptive windowing for official-client execution remains follow-up scope; this change does not claim that repeated overflows are fully resolved.

## Verification

- `git diff --check`
- local build/tests intentionally not run per operator instruction; GitHub CI is the build and test authority

## Evidence

- `codex --version`: `codex-cli 0.147.0`
- `codex app-server generate-json-schema --experimental`: generated `CodexErrorInfo` includes exact enum `contextWindowExceeded`
- live build `4b0139e0e7` recorded repeated generic Codex context-full failures because the nested typed field was not decoded

Refs #27427