### PR TITLE
test(agent_core): pin the Ollama native think-omission arm

### DIFF
--- a/packages/agent_core/test/test_thinking_control_dialects.ml
+++ b/packages/agent_core/test/test_thinking_control_dialects.ml
@@ -1061,6 +1061,19 @@ let test_ollama_qwen_uses_native_think_bool () =
   check_member_absent "reasoning_effort" json
 ;;
 
+(* Absence is a third request state, not a synonym for [think:false]: with no
+   [think] key Ollama applies the model's own default, and for a reasoning
+   model that default is thinking-on. A caller that leaves [enable_thinking]
+   unset therefore gets reasoning, so a target that wants a judgment rather
+   than a reasoning trace has to declare the boolean rather than rely on the
+   omission. [test_ollama_gemma4_disabled_uses_native_think_false] pins the
+   [Some false] arm; this pins the [None] arm it is contrasted with. *)
+let test_ollama_qwen_unset_omits_think () =
+  let config = ollama_config "qwen3:32b" in
+  let json = BOL.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  check_member_absent "think" json
+;;
+
 let test_ollama_cloud_glm_uses_native_think_not_zai_thinking () =
   let config = ollama_cloud_config ~enable_thinking:true "glm-5.2" in
   let json = BOL.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
@@ -1468,6 +1481,10 @@ let () =
               "qwen uses native think bool"
               `Quick
               test_ollama_qwen_uses_native_think_bool
+          ; test_case
+              "qwen unset omits think"
+              `Quick
+              test_ollama_qwen_unset_omits_think
           ; test_case
               "cloud GLM uses native think not ZAI thinking"
               `Quick


### PR DESCRIPTION
## 목표

`Backend_ollama.build_request` 의 thinking 제어 match 에서 `enable_thinking = None` (필드 생략) arm 을 테스트로 고정한다.

## 왜

```ocaml
match config.enable_thinking with
| Some enabled -> ("think", `Bool enabled) :: body
| None -> body
```

기존 ollama fixture 는 전부 `enable_thinking` 을 명시해서 `Some` arm 만 지난다. `| None -> body` 를 `("think", `Bool true) :: body` 로 변형해도 43개 케이스가 전부 green 이었다.

생략은 `think:false` 와 다른 요청이다. 필드가 없으면 Ollama 가 모델 기본값을 적용하고, reasoning 모델의 기본값은 thinking-on 이다.

## 실측

로컬 Ollama reasoning 모델(agentworld-35b-a3b), 기록된 HITL judge 번들, `num_predict` 2000 기준 12셀 매트릭스:

| 입력 | think | thinking chars | content chars | wall |
|---|---|---|---|---|
| 7,043 tok | 생략 | 6,567 | **0** | 67.2s |
| 40,501 tok | 생략 | 7,565 | **0** | 192.8s |
| 7,045 tok | false | 0 | 986 | 5.6s |
| 40,503 tok | false | 0 | 889 | 6.0s |

출력이 예산 상한 2,000 tok 에 정확히 걸리고 전량 reasoning 으로 소모된다. exact-output lane 관점에서는 `no_summary_produced` 형태로 관측된다.

## 변경

- `packages/agent_core/test/test_thinking_control_dialects.ml`: `test_ollama_qwen_unset_omits_think` 1건 추가 (17줄).

`Some false` arm 은 `test_ollama_gemma4_disabled_uses_native_think_false` 가 이미 고정하고 있다 — 변형 테스트로 확인했고, 그래서 중복 케이스는 넣지 않았다.

## 검증

```
dune build --root . packages/agent_core/test/test_thinking_control_dialects.exe
./_build/default/packages/agent_core/test/test_thinking_control_dialects.exe test
→ Test Successful. 44 tests run.
```

변형 테스트 (`| None -> ("think", `Bool true) :: body`):
```
> [FAIL] ollama 1  qwen unset omits think.
1 failure! 44 tests run.
```
44개 중 이 테스트만 잡는다.

## 미검증

- 라이브 wire body 는 직접 관측하지 못했다. 위 실측은 동일 모델에 대한 직접 HTTP 호출이고, MASC 경로는 코드 추적(`exact_output_plan` → `Complete_common.serialize_http_request_with_thinking_control` → `Provider_http_codec.Ollama_chat` → `Backend_ollama.build_request`)으로 확인했다.
- 테스트 전용 변경이라 소스 동작은 바뀌지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
