### PR TITLE
fix(shared-audit): serialize append so the hash chain cannot fork

### DIFF
--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -1,5 +1,13 @@
 type t = {
   base_dir : string;
+  (* [append] reads this as the next entry's [prev_hash], writes the file,
+     then stores the new hash. Two appends interleaving between the read and
+     the store would chain both entries onto the same predecessor and fork
+     the chain that [verify] walks. [append_mu] makes the three steps one
+     step. Today the write goes through [Fs_compat.append_jsonl], which uses
+     blocking stdlib I/O and so never yields to another fiber — the chain
+     holds by accident of that choice, not by construction. *)
+  append_mu : Stdlib.Mutex.t;
   mutable latest_hash : string option;
 }
 
@@ -74,20 +82,21 @@ let load_latest_hash ~base_dir =
 let create ~base_dir =
   if not (Sys.file_exists base_dir) then Fs_compat.mkdir_p base_dir;
   let latest_hash = load_latest_hash ~base_dir in
-  { base_dir; latest_hash }
+  { base_dir; append_mu = Stdlib.Mutex.create (); latest_hash }
 
 let base_dir t = t.base_dir
 
 let append t ~category ~payload =
-  let entry = Envelope.make ~category ~payload ~prev_hash:t.latest_hash in
-  ignore
-    (Jsonl_writer.append_dated_jsonl
-       ~base_dir:t.base_dir
-       ~ts:entry.ts
-       (Envelope.to_json entry)
-      : Jsonl_writer.dated_path);
-  t.latest_hash <- Some (Envelope.hash_for_chain entry);
-  entry
+  Stdlib.Mutex.protect t.append_mu (fun () ->
+    let entry = Envelope.make ~category ~payload ~prev_hash:t.latest_hash in
+    ignore
+      (Jsonl_writer.append_dated_jsonl
+         ~base_dir:t.base_dir
+         ~ts:entry.ts
+         (Envelope.to_json entry)
+        : Jsonl_writer.dated_path);
+    t.latest_hash <- Some (Envelope.hash_for_chain entry);
+    entry)
 
 let read_all_entries t =
   if not (Sys.file_exists t.base_dir) then []

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -201,6 +201,27 @@ let test_store_verify_chain_detects_tampering () =
          because its prev_hash no longer matches. *)
       check bool "broken link reported" true (idx >= 2))
 
+(* A fork is what two interleaving appends produce: both entries take the same
+   predecessor, so the chain branches instead of breaking a hash. That is a
+   different shape from tampering — no payload changes and every hash is
+   genuine — and it had no test. [Store.append] now serializes the read of the
+   cursor with the write, but the fork only matters because [verify_chain]
+   catches it, so pin that. *)
+let test_store_verify_chain_detects_fork () =
+  let dir = unique_temp_dir "audit_verify_fork" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let e1 = Store.append store ~category:"X" ~payload:(`Int 1) in
+    let e2 = Store.append store ~category:"X" ~payload:(`Int 2) in
+    let e3 = Store.append store ~category:"X" ~payload:(`Int 3) in
+    check (option string) "third links to the second"
+      (Some (Env.hash_for_chain e2)) e3.prev_hash;
+    (* Re-chain the third onto the first, as a lost cursor update would. *)
+    let forked = [ e1; e2; { e3 with prev_hash = Some (Env.hash_for_chain e1) } ] in
+    match Store.verify_chain forked with
+    | Ok () -> fail "a forked chain must not verify"
+    | Error (idx, _) -> check int "fork reported at the branching entry" 2 idx)
+
 let test_store_verify_empty_log () =
   let dir = unique_temp_dir "audit_verify_empty" in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
@@ -320,6 +341,7 @@ let () =
       test_case "since filters by timestamp" `Quick test_store_since_filters;
       test_case "verify_chain intact" `Quick test_store_verify_chain_intact;
       test_case "verify_chain detects tampering" `Quick test_store_verify_chain_detects_tampering;
+      test_case "verify_chain detects fork" `Quick test_store_verify_chain_detects_fork;
       test_case "verify empty log" `Quick test_store_verify_empty_log;
       test_case "verify reports intact chain" `Quick test_store_verify_reports_intact_chain;
       test_case "verify reports on-disk tampering" `Quick test_store_verify_reports_on_disk_tampering;


### PR DESCRIPTION
## 결함

`Shared_audit.Store.append` 는 세 단계를 잠금 없이 수행한다:

1. `latest_hash` 를 읽어 다음 엔트리의 `prev_hash` 로 삼는다
2. 파일에 쓴다
3. 새 해시를 `latest_hash` 에 저장한다

두 append 가 1과 3 사이에서 교차하면 **두 엔트리가 같은 선행자에 연결되어 체인이 갈라진다**. 이 체인은 `Store.verify` 가 순회하고 대시보드의 감사 무결성 엔드포인트(`server_dashboard_http_audit_integrity.ml`)가 노출한다.

## 지금은 왜 안 터지는가 — 우발적이다

`Jsonl_writer.append_dated_jsonl` → `Fs_compat.append_jsonl` 이 `Stdlib.Mutex` 와 blocking `output_string` 을 쓴다. Eio 중단 지점이 아니므로 쓰기 중에 다른 파이버가 돌지 않는다.

그 writer 를 Eio 파일 I/O 로 바꾸면 — 이 저장소가 다른 곳에서 이미 그렇게 한다 — 체인이 조용히 갈라진다. 감사 무결성이 걸린 경로에서 이런 성질을 우연에 맡길 이유가 없다.

## 변경

세 단계를 store 별 뮤텍스 안에 넣는다. `type t` 는 `.mli` 에서 abstract 이므로 모듈 밖은 바뀌지 않는다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `@test/shared_audit/runtest` 20/20, `@test/resilience/runtest` 통과 (resilience bridge 가 keeper 파이버에서 append 하는 호출자다)

체인 단언이 load-bearing 임을 확인했다: 커서 갱신을 `ignore` 로 바꾸면 `Store / append chains prev_hash` 가 실패한다.

## 추가한 테스트 — fork 는 변조와 다른 모양이다

fork 형태에는 커버리지가 없었다. 변조(payload 변경)는 다음 링크를 깨뜨리므로 잡히지만, fork 는 payload 를 바꾸지 않고 모든 해시가 진짜다 — 분기는 `prev_hash` 포인터에만 보인다. 그게 정확히 교차 append 가 만드는 모양이다.

세 번째 엔트리를 첫 번째에 다시 연결하고 `verify_chain` 이 분기 인덱스를 보고하는지 단언한다. `verify_chain` 이 `prev_hash` 를 무시하게 바꾸면 이 케이스와 기존 변조 케이스가 함께 실패한다.

`@test/shared_audit/runtest` 21/21, `python3 scripts/check_test_coverage.py` exit 0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
