### PR TITLE
docs(rfc): RFC-0368 이 빠진 생성 인덱스를 재생성한다 — #28113 의 enforce 실패는 이 빚이다

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -232,6 +232,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0364 | keeper 당 체크아웃 하나 (`repos/` 중간 디렉터리 폐기) | Draft | - |
 | 0365 | handoff_context must survive the ownership boundary | Draft | - |
 | 0366 | 운영자가 다음 턴의 컨텍스트에 한 문장을 넣는다 | Draft | - |
+| 0368 | 판단 없는 recovery는 keeper의 다음 claim이 스스로 해제한다 | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |


### PR DESCRIPTION
## 무엇을

`docs/rfc/README.md` 의 생성 인덱스 표를 재생성합니다. 1줄 추가입니다.

```
$ python3 scripts/rfc-generate-index.py --check
OK: RFC index table is up to date
```

## 왜 — 제 빚입니다

오늘 `RFC-0368-typed-recovery-auto-heal.md` 를 추가하면서 `scripts/rfc-generate-index.py --update` 를 돌리지 않았습니다. 표에 한 행이 빠지자 그 아래 전부가 한 칸씩 밀렸고, `rfc-enforcer` 가 이렇게 보고합니다:

```
line 191: '| RFC-0034d-stale-agent-sync | … |' != '| 0368 | 판단 없는 recovery는 … |'
line 192: '| RFC-async-log-sink-durable-append-offload | … |' != '| RFC-0034d-stale-agent-sync | … |'
…
```

## 왜 지금

이 검사는 **RFC 문서를 건드리는 다음 PR 에서** 터집니다. `#28113` 이 그 PR 이 됐고, 그 PR 은 원인이 아닙니다. 남의 PR 을 빨갛게 만들어 두는 것이 제 빚이므로 분리해서 냅니다.

## 관측

`--check` 가 `--update` 와 같은 생성기를 쓰므로 이 수정은 정의상 정확합니다. 다만 그 성질 때문에 **회귀를 잡는 테스트가 아니라 상태를 맞추는 변경**이며, 재발 방지는 이 PR 이 아니라 "RFC 를 추가할 때 인덱스를 같이 갱신한다" 는 절차에 있습니다. 그 절차가 문서화돼 있는지는 확인하지 않았습니다.

Refs #28113
