### PR TITLE
feat(ide): INTERJECT에 IDE surface context 동봉 — 인간 리뷰 루프의 끊긴 반쪽 연결

### DIFF
--- a/dashboard/src/components/ide/ide-interject-surface-context.test.ts
+++ b/dashboard/src/components/ide/ide-interject-surface-context.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { buildIdeInterjectSurfaceContext } from './ide-interject-surface-context'
+import type { IdeFileFocus } from './ide-state'
+
+function focusOn(path: string, workspace_identity: IdeFileFocus['workspace_identity'] = { kind: 'project' }): IdeFileFocus {
+  return {
+    path,
+    workspace_identity,
+    origin: 'operator',
+    availability: 'available',
+  }
+}
+
+describe('buildIdeInterjectSurfaceContext', () => {
+  it('returns undefined when the IDE holds no anchor', () => {
+    expect(buildIdeInterjectSurfaceContext({ focus: null, selection: null })).toBeUndefined()
+  })
+
+  it('returns undefined for a whitespace-only focus path', () => {
+    expect(
+      buildIdeInterjectSurfaceContext({ focus: focusOn('   '), selection: null }),
+    ).toBeUndefined()
+  })
+
+  it('carries the focused file with the board-shaped envelope', () => {
+    const context = buildIdeInterjectSurfaceContext({
+      focus: focusOn('lib/web_dashboard.ml'),
+      selection: null,
+    })
+    expect(context).toEqual({
+      label: 'IDE interject context',
+      route: '#code?section=ide-shell&file=lib%2Fweb_dashboard.ml',
+      scene: 'ide_interject',
+      fields: [
+        { k: 'surface', v: 'ide' },
+        { k: 'file', v: 'lib/web_dashboard.ml' },
+      ],
+    })
+  })
+
+  it('renders a single-line selection as one line marker', () => {
+    const context = buildIdeInterjectSurfaceContext({
+      focus: focusOn('lib/a.ml'),
+      selection: { filePath: 'lib/a.ml', lineStart: 42, lineEnd: 42 },
+    })
+    expect(context?.fields).toContainEqual({ k: 'lines', v: 'L42' })
+    expect(context?.route).toContain('line=42')
+  })
+
+  it('renders a range selection with both endpoints', () => {
+    const context = buildIdeInterjectSurfaceContext({
+      focus: focusOn('lib/a.ml'),
+      selection: { filePath: 'lib/a.ml', lineStart: 3, lineEnd: 9 },
+    })
+    expect(context?.fields).toContainEqual({ k: 'lines', v: 'L3-L9' })
+  })
+
+  it('prefers the selection file over a stale focused tab', () => {
+    const context = buildIdeInterjectSurfaceContext({
+      focus: focusOn('lib/stale.ml'),
+      selection: { filePath: 'lib/actual.ml', lineStart: 7, lineEnd: 8 },
+    })
+    expect(context?.fields).toContainEqual({ k: 'file', v: 'lib/actual.ml' })
+    expect(context?.fields).not.toContainEqual({ k: 'file', v: 'lib/stale.ml' })
+  })
+
+  it('carries a repository workspace identity as repo', () => {
+    const context = buildIdeInterjectSurfaceContext({
+      focus: focusOn('lib/a.ml', { kind: 'repository', repoId: 'masc' }),
+      selection: null,
+    })
+    expect(context?.fields).toContainEqual({ k: 'repo', v: 'masc' })
+  })
+
+  it('carries a keeper workspace identity as workspace_keeper', () => {
+    const context = buildIdeInterjectSurfaceContext({
+      focus: focusOn('lib/a.ml', { kind: 'keeper', keeper: 'nick0cave' }),
+      selection: null,
+    })
+    expect(context?.fields).toContainEqual({ k: 'workspace_keeper', v: 'nick0cave' })
+  })
+
+  it('sends a selection anchor even without a focused tab', () => {
+    const context = buildIdeInterjectSurfaceContext({
+      focus: null,
+      selection: { filePath: 'lib/only-selection.ml', lineStart: 1, lineEnd: 2 },
+    })
+    expect(context?.fields).toContainEqual({ k: 'file', v: 'lib/only-selection.ml' })
+    expect(context?.fields).toContainEqual({ k: 'lines', v: 'L1-L2' })
+  })
+})

--- a/dashboard/src/components/ide/ide-interject-surface-context.ts
+++ b/dashboard/src/components/ide/ide-interject-surface-context.ts
@@ -1,0 +1,63 @@
+// Builds the `surface_context` payload an IDE interject attaches to a keeper
+// chat message, so the keeper knows what the operator was looking at.
+//
+// Wire shape mirrors the board producer
+// (server_routes_http_routes_activity.ml, board_context_inference_surface_context):
+// `{label, route, scene, fields}` where `fields` is a `[{k, v}, ...]` list the
+// keeper prompt renders as `- k: v` lines
+// (keeper_turn.ml, surface_context_fields).
+import type { KeeperStreamSurfaceContext } from '../../api/keeper'
+import type { IdeFileFocus } from './ide-state'
+import type { IdeEditorSelection } from './ide-editor-selection'
+
+export interface IdeInterjectContextInputs {
+  readonly focus: IdeFileFocus | null
+  readonly selection: IdeEditorSelection | null
+}
+
+interface SurfaceContextField {
+  readonly k: string
+  readonly v: string
+}
+
+function selectionLinesLabel(selection: IdeEditorSelection): string {
+  return selection.lineStart === selection.lineEnd
+    ? `L${selection.lineStart}`
+    : `L${selection.lineStart}-L${selection.lineEnd}`
+}
+
+/** Returns `undefined` when the IDE holds no context worth sending — a bare
+ *  `surface: ide` marker alone would add prompt noise without an anchor. */
+export function buildIdeInterjectSurfaceContext(
+  inputs: IdeInterjectContextInputs,
+): KeeperStreamSurfaceContext | undefined {
+  const fields: SurfaceContextField[] = [{ k: 'surface', v: 'ide' }]
+  const focusPath = inputs.focus?.path.trim() || null
+  const selection = inputs.selection
+  const selectionPath = selection?.filePath.trim() || null
+  // The selection carries its own filePath; prefer it over the focused tab so
+  // lines always refer to the file they were selected in.
+  const file = selectionPath ?? focusPath
+  if (file) {
+    fields.push({ k: 'file', v: file })
+  }
+  if (selection && selectionPath) {
+    fields.push({ k: 'lines', v: selectionLinesLabel(selection) })
+  }
+  const identity = inputs.focus?.workspace_identity
+  if (identity?.kind === 'repository') {
+    fields.push({ k: 'repo', v: identity.repoId })
+  } else if (identity?.kind === 'keeper') {
+    fields.push({ k: 'workspace_keeper', v: identity.keeper })
+  }
+  if (fields.length === 1) return undefined
+  const routeParams = new URLSearchParams({ section: 'ide-shell' })
+  if (file) routeParams.set('file', file)
+  if (selection && selectionPath) routeParams.set('line', String(selection.lineStart))
+  return {
+    label: 'IDE interject context',
+    route: `#code?${routeParams.toString()}`,
+    scene: 'ide_interject',
+    fields,
+  }
+}

--- a/dashboard/src/components/ide/ide-interject.ts
+++ b/dashboard/src/components/ide/ide-interject.ts
@@ -16,6 +16,9 @@ import {
 } from './ide-context-lens'
 import { globalPresenceSnapshot, presenceEntries, type KeeperPresenceStatus } from './keeper-presence-store'
 import { cursorOverlaySignal, getKeeperColor, type KeeperCursor } from './keeper-cursor-overlay'
+import { activeIdeFocus } from './ide-state'
+import { ideEditorSelection } from './ide-editor-selection'
+import { buildIdeInterjectSurfaceContext } from './ide-interject-surface-context'
 
 // The input and button states flow through the same store/dispatch boundary
 // that live active-keeper wiring uses. Send remains disabled until a concrete
@@ -26,6 +29,10 @@ async function dispatchInterject(request: InterjectDispatchRequest): Promise<voi
     kind: request.kind,
     keeperName: request.keeper_id,
     message: request.message,
+    surfaceContext: buildIdeInterjectSurfaceContext({
+      focus: activeIdeFocus.value,
+      selection: ideEditorSelection.value,
+    }),
   })
 }
 

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -7,6 +7,7 @@ import {
   interruptKeeperTurn as apiInterruptKeeperTurn,
   streamKeeperMessage,
 } from './api/keeper'
+import type { KeeperStreamSurfaceContext } from './api/keeper'
 import { fetchKeeperToolCalls } from './api/dashboard'
 import {
   markToolCallOutputsHydrated,
@@ -97,6 +98,9 @@ interface KeeperInterjectCommand {
   readonly kind: KeeperInterjectActionKind
   readonly keeperName: string
   readonly message?: string
+  /** Wire shape of `surface_context` on /api/v1/keepers/chat/stream; rendered
+   *  into the keeper prompt by keeper_turn.surface_context_fields. */
+  readonly surfaceContext?: KeeperStreamSurfaceContext
 }
 
 async function refreshDashboardState(): Promise<void> {
@@ -227,7 +231,9 @@ export async function dispatchKeeperInterjectAction(command: KeeperInterjectComm
   if (command.kind === 'send') {
     const message = command.message?.trim() ?? ''
     if (!message) throw new Error('INTERJECT send requires a message.')
-    await sendKeeperThreadMessage(keeperName, message)
+    await sendKeeperThreadMessage(keeperName, message, {
+      surfaceContext: command.surfaceContext,
+    })
     return
   }
 
@@ -889,6 +895,7 @@ export async function sendKeeperThreadMessage(
     clientActionIds?: readonly string[]
     blocks?: ChatBlock[]
     userBlocks?: KeeperUserInputBlock[]
+    surfaceContext?: KeeperStreamSurfaceContext
   } = {},
 ): Promise<void> {
   const keeperName = name.trim()
@@ -957,6 +964,7 @@ export async function sendKeeperThreadMessage(
       signal: controller.signal,
       attachments,
       userBlocks,
+      surfaceContext: options.surfaceContext,
       onEvent: event => {
         markKeeperStreamSignal(keeperName)
         if (


### PR DESCRIPTION
## 무엇

IDE INTERJECT가 keeper 채팅 메시지에 `surface_context`(인간이 보고 있던 파일·선택 라인·워크스페이스 정체성)를 동봉합니다.

## 왜

orca 대조 감사(`reports/orca-vs-masc-adversarial-2026-08-11.html` G1)의 최상위 발견: 인간 리뷰 루프의 반쪽 부재. orca는 diff 코멘트+코드 컨텍스트를 에이전트에 회신하는 루프가 제품 중심인데, masc IDE의 유일한 인간→keeper 채널(INTERJECT)은 `{kind, keeperName, message}`만 보내 keeper가 인간이 무엇을 보는지 알 수 없었습니다.

전수 추적 결과 이 갭은 "가장 좁은 갭"이었습니다 — 파이프 전체가 이미 존재:

- wire 파서 allowlist에 `surface_context` 포함: `lib/server/server_routes_http_keeper_stream.ml:284`
- invocation contract optional 필드: `lib/keeper/keeper_invocation_contract.mli:32`
- 소비 경로 전달: `lib/keeper/keeper_tool_surface_ops.ml` `handle_keeper_msg`
- 프롬프트 렌더: `lib/keeper/keeper_turn.ml` `surface_context_fields` (`[{k,v}]` → `- k: v` 라인)
- API 조립부: `dashboard/src/api/keeper.ts:305-307` (이미 `surfaceContext` 옵션 수용)
- board 표면은 이 파이프를 실사용 중 (`server_routes_http_routes_activity.ml` `board_context_inference_surface_context`)

**IDE만 이 파이프에 아무것도 싣지 않았습니다.** 백엔드 변경 0으로 닫히는 문제입니다.

## 어떻게

- `ide-interject-surface-context.ts` (신규): board와 동일한 `{label, route, scene, fields}` envelope 조립. fields: `surface: ide`, `file`(선택의 filePath를 stale 탭보다 우선), `lines`(`L42` / `L3-L9`), `repo` 또는 `workspace_keeper`(IdeWorkspaceIdentity). 앵커가 하나도 없으면 `undefined` — 일반 채팅 무영향.
- `ide-interject.ts`: dispatch 시 `activeIdeFocus`/`ideEditorSelection` 스냅샷으로 조립해 전달.
- `keeper-actions.ts`: `KeeperInterjectCommand`·`sendKeeperThreadMessage` options에 `surfaceContext?` 추가, `streamKeeperMessage`로 전달.

## 검증

- 신규 테스트 9건 (`ide-interject-surface-context.test.ts`): 무앵커 undefined, 공백 경로, envelope 형태, 단일/범위 라인, stale 탭 대비 선택 파일 우선, repository/keeper identity, 선택-단독 앵커. 전부 green.
- 회귀: `keeper-actions.test.ts` + `ide-interject.test.ts` 49건 green.
- `tsc --noEmit` 0 에러.
- 미검증: 실 keeper 턴에서의 프롬프트 렌더 E2E (렌더러는 board 경로로 이미 운영 검증됨).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
