### PR TITLE
feat(official-client): bound the start-turn seed with a declared byte ceiling

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -178,6 +178,8 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       Host.prepare_turn
         ~configured_reasoning_effort:
           (Runtime_inference.resolve_reasoning_effort ~runtime_id)
+        ~max_prompt_bytes:
+          (Runtime_inference.resolve_max_prompt_bytes ~runtime_id)
         ~runtime_label
         ~keeper_name
         ~turn_count

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -195,6 +195,8 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       Host.prepare_turn
         ~configured_reasoning_effort:
           (Runtime_inference.resolve_reasoning_effort ~runtime_id)
+        ~max_prompt_bytes:
+          (Runtime_inference.resolve_max_prompt_bytes ~runtime_id)
         ~runtime_label
         ~keeper_name
         ~turn_count

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -202,6 +202,8 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       Host.prepare_turn
         ~configured_reasoning_effort:
           (Runtime_inference.resolve_reasoning_effort ~runtime_id)
+        ~max_prompt_bytes:
+          (Runtime_inference.resolve_max_prompt_bytes ~runtime_id)
         ~runtime_label
         ~keeper_name
         ~turn_count

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -139,6 +139,7 @@ type prepared_turn =
   ; system_prompt : string
   ; tools : Agent_core.Tool.t list
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
+  ; seed_dropped_atoms : int
   }
 
 let resolve_reasoning_effort ~enable_thinking ~reasoning_effort =
@@ -151,8 +152,19 @@ let resolve_reasoning_effort ~enable_thinking ~reasoning_effort =
   | None -> Ok reasoning_effort
 ;;
 
+(* The canonical MASC message encoder, the same one the Agent_core budget path
+   measures with. It is not any adapter's own rendering: antigravity renders
+   "ROLE:\ntext" and the JSON form of that message is strictly larger, so the
+   measure is at or above what each adapter actually sends and the ceiling
+   cannot be exceeded by measuring here. *)
+let measure_message_bytes (message : Agent_core.Types.message) =
+  String.length
+    (Yojson.Safe.to_string (Keeper_context_core.message_to_json message))
+;;
+
 let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
-    ~initial_messages ~model_input_projection ~hooks ~configured_reasoning_effort =
+    ~initial_messages ~model_input_projection ~hooks ~configured_reasoning_effort
+    ~max_prompt_bytes =
   let hooks = match hooks with Some hooks -> hooks | None -> Agent_core.Hooks.empty in
   let before_turn =
     invoke_turn_hook
@@ -234,6 +246,56 @@ let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
   let system_prompt =
     Option.value turn_params.system_prompt_override ~default:system_prompt
   in
+  (* An official-client turn 1 seeds the vendor conversation with the whole
+     projected history; from turn 2 the client owns the transcript and the
+     adapters send only the goal. So an unbounded seed does not fail once — it
+     fails on turn 1, never reaches turn 2, and re-renders a larger history on
+     the next cycle. Recovery closes the loop rather than breaking it: a fresh
+     session resets the counter, which makes the next turn a start turn again.
+     Measured on the live fleet with three keepers pinned at turn_count = 1,
+     one of them auto-superseding to a fresh session 293 times in a single log.
+
+     The newest messages are kept, since the goal answers the most recent turn
+     and trimming the tail would drop exactly the context it refers to.
+     [dropped_atoms] is returned to the caller rather than logged here so the
+     loss lands on the keeper's own line; a silent window would read as "the
+     model saw everything".
+
+     Applied here rather than in each adapter because all three consume
+     [messages] for the same purpose and would otherwise carry three copies of
+     one rule. Resume paths ignore [messages] entirely, so windowing is a no-op
+     for them. *)
+  let* messages, seed_dropped_atoms =
+    match max_prompt_bytes with
+    | None -> Ok (messages, 0)
+    | Some capacity_bytes ->
+      let reserved_bytes = String.length system_prompt in
+      (match
+         Runtime_model_input_tail_window.project_with_drop
+           ~measure_message_bytes
+           ~capacity_bytes
+           ~reserved_bytes
+           messages
+       with
+       | Ok projection ->
+         let dropped = projection.Runtime_model_input_tail_window.dropped_atoms in
+         if dropped > 0
+         then
+           Log.Keeper.warn
+             "%s: %s start-turn seed dropped %d oldest message atom(s) to fit               the declared %d-byte prompt budget"
+             keeper_name
+             runtime_label
+             dropped
+             capacity_bytes;
+         Ok (projection.Runtime_model_input_tail_window.messages, dropped)
+       | Error error ->
+         Error
+           (config_error
+              ~field:"max_prompt_bytes"
+              (runtime_label
+               ^ " start-turn seed does not fit the declared prompt budget: "
+               ^ Runtime_model_input_tail_window.budget_error_to_string error)))
+  in
   let unsupported_parameter field value =
     match value with
     | None -> Ok ()
@@ -266,7 +328,13 @@ let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
               (Yojson.Safe.to_string
                  (Agent_core.Types.tool_choice_to_json choice))))
   in
-  Ok { messages; system_prompt; tools; reasoning_effort }
+  Ok
+    { messages
+    ; system_prompt
+    ; tools
+    ; reasoning_effort
+    ; seed_dropped_atoms
+    }
 ;;
 
 type dynamic_tool_result =

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -9,6 +9,7 @@ type prepared_turn =
   ; system_prompt : string
   ; tools : Agent_core.Tool.t list
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
+  ; seed_dropped_atoms : int
   }
 
 type dynamic_tool_result =
@@ -106,6 +107,11 @@ val invoke_turn_hook :
   Agent_core.Hooks.hook_event ->
   Agent_core.Hooks.hook_decision
 
+val measure_message_bytes : Agent_core.Types.message -> int
+(** Bytes one message contributes to the start-turn seed budget, in the
+    canonical MASC encoding. At or above what any adapter's own rendering
+    sends, so a budget checked with this cannot be exceeded downstream. *)
+
 val prepare_turn :
   runtime_label:string ->
   keeper_name:string ->
@@ -116,9 +122,15 @@ val prepare_turn :
   model_input_projection:Agent_core.Agent.model_input_projection option ->
   hooks:Agent_core.Hooks.hooks option ->
   configured_reasoning_effort:Llm_provider.Reasoning_effort.t option ->
+  max_prompt_bytes:int option ->
   (prepared_turn, Agent_core.Error.t) result
 (** [configured_reasoning_effort] seeds the turn params the
-    [before_turn_params] hook receives, so a hook can still override it. *)
+    [before_turn_params] hook receives, so a hook can still override it.
+
+    [max_prompt_bytes] bounds the history a start turn seeds its conversation
+    with, keeping the newest messages. [None] applies no ceiling, which is the
+    behaviour before this parameter existed. [seed_dropped_atoms] on the result
+    reports what was left out so the caller can say so on its own log line. *)
 
 val dynamic_tools :
   runtime_label:string ->

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1334,6 +1334,12 @@ let turn_timeout_s_of_runtime_id (id : string) : float option =
   | None -> None
 ;;
 
+let max_prompt_bytes_of_runtime_id (id : string) : int option =
+  match get_runtime_by_id id with
+  | Some rt -> rt.model.max_prompt_bytes
+  | None -> None
+;;
+
 let default_preserve_thinking_for_model (_rt : t) : bool option =
   (* AGENT_CORE owns provider/model capability truth and can preserve reasoning when
      the provider contract requires it. MASC must not turn "request-side

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -357,6 +357,10 @@ val reasoning_effort_of_runtime_id : string -> Llm_provider.Reasoning_effort.t o
     {!Runtime_inference.resolve_reasoning_effort}. *)
 
 val turn_timeout_s_of_runtime_id : string -> float option
+
+val max_prompt_bytes_of_runtime_id : string -> int option
+(** Declared [max-prompt-bytes] for the model bound to this runtime id, or
+    [None] when the model declares none. *)
 (** Per-model [turn-timeout-s] from runtime.toml, or [None] when unset or the
     runtime id is unknown. [None] means "keep whatever bound the caller already
     has" — the antigravity provider [timeout-s] or the adapter default — so an

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -24,6 +24,9 @@ let resolve_reasoning_effort ~runtime_id =
 
 let resolve_turn_timeout_s ~runtime_id = Runtime.turn_timeout_s_of_runtime_id runtime_id
 
+let resolve_max_prompt_bytes ~runtime_id =
+  Runtime.max_prompt_bytes_of_runtime_id runtime_id
+
 (* masc#24067 / agent-core boundary: MASC must not synthesize a request [max_tokens]
    value. The former resolver invented one from either a model capability
    ceiling or a flat fallback. Callers now carry explicit intent as [int

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -5,6 +5,10 @@ val resolve_reasoning_effort :
     declared reasoning control. *)
 
 val resolve_turn_timeout_s : runtime_id:string -> float option
+
+val resolve_max_prompt_bytes : runtime_id:string -> int option
+(** Per-model ceiling, in bytes, on the history an official-client start turn
+    seeds its conversation with. [None] applies no ceiling. *)
 (** The per-model [turn-timeout-s] declared for [runtime_id], or [None] when
     the model leaves it unset. Callers keep their existing bound on [None]:
     this overrides a timeout, it does not supply one. *)

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -231,6 +231,27 @@ type model_spec =
         exists (antigravity [timeout-s]) and the adapter default otherwise.
         Resolved via {!Runtime.turn_timeout_s_of_runtime_id} →
         {!Runtime_inference.resolve_turn_timeout_s}. *)
+  ; max_prompt_bytes : int option
+    (** [max-prompt-bytes] — per-model ceiling on the history an official-client
+        start turn seeds its conversation with, in bytes.
+
+        An official-client turn 1 sends the whole projected history; from turn 2
+        the client owns the transcript and MASC sends only the goal. So a keeper
+        whose history outgrows the model's window cannot fail once — it fails on
+        turn 1, never reaches turn 2, and re-sends a larger history next cycle.
+        Recovery does not break the loop: a fresh session resets the counter,
+        which makes the next turn a start turn again.
+
+        Declared in bytes rather than derived from [max-context] because MASC
+        has no tokenizer: converting a token budget would need a
+        bytes-per-token constant with nothing to justify it, and a wrong
+        constant either truncates silently or overflows silently. This mirrors
+        [max-request-body-bytes] on the Agent_core side, which is likewise an
+        operator-declared byte cap.
+
+        [None] applies no ceiling, which is the behaviour every deployment has
+        today. Resolved via {!Runtime.max_prompt_bytes_of_runtime_id} →
+        {!Runtime_inference.resolve_max_prompt_bytes}. *)
   ; capabilities : model_capabilities option
   }
 [@@deriving show, eq]

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -147,6 +147,7 @@ type model_spec =
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
        [@equal fun a b -> a = b]
   ; turn_timeout_s : float option
+  ; max_prompt_bytes : int option
   ; capabilities : model_capabilities option
   }
 [@@deriving show, eq]

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -969,6 +969,9 @@ let parse_model (id : string) (tbl : Otoml.t)
     let min_p_result = probability_opt_field ~path ~key:"min-p" tbl in
     let reasoning_effort_result = reasoning_effort_opt_field ~path tbl in
     let turn_timeout_result = turn_timeout_opt_field ~path tbl in
+    let max_prompt_bytes_result =
+      positive_int_opt_field ~path ~key:"max-prompt-bytes" tbl
+    in
     let ( let* ) = Result.bind in
     let* max_context = max_context_result in
     let* capabilities = capabilities_result in
@@ -978,6 +981,7 @@ let parse_model (id : string) (tbl : Otoml.t)
     let* min_p = min_p_result in
     let* reasoning_effort = reasoning_effort_result in
     let* turn_timeout_s = turn_timeout_result in
+    let* max_prompt_bytes = max_prompt_bytes_result in
     match sampling_capability_errors ~path ~capabilities ~top_k ~min_p with
     | _ :: _ as errors -> Error errors
     | [] ->
@@ -996,6 +1000,7 @@ let parse_model (id : string) (tbl : Otoml.t)
         ; min_p
         ; reasoning_effort
         ; turn_timeout_s
+        ; max_prompt_bytes
         ; capabilities        })
 ;;
 

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -272,6 +272,85 @@ let test_typed_blocks_are_preserved_as_canonical_json () =
     (encoded_message_json message |> Yojson.Safe.to_string)
 ;;
 
+
+let msg role text : Agent_core.Types.message =
+  { role; content = [ Agent_core.Types.Text text ]; name = None
+  ; tool_call_id = None; metadata = [] }
+;;
+
+let prepare ?max_prompt_bytes messages =
+  Host.prepare_turn
+    ~runtime_label:"Fixture"
+    ~keeper_name:"seed-fixture"
+    ~turn_count:1
+    ~system_prompt:"SYS"
+    ~tools:[]
+    ~initial_messages:messages
+    ~model_input_projection:None
+    ~hooks:None
+    ~configured_reasoning_effort:None
+    ~max_prompt_bytes
+;;
+
+let text_of (m : Agent_core.Types.message) =
+  m.content
+  |> List.filter_map (function Agent_core.Types.Text t -> Some t | _ -> None)
+  |> String.concat ""
+;;
+
+(* An official-client turn 1 seeds the vendor conversation with the whole
+   history, so an unbounded seed is what pins a keeper at turn_count = 1
+   forever: it overflows the model window, never reaches turn 2, and a fresh
+   session makes the next turn a start turn again. Measured on the live fleet
+   as claude_code ~2,227,119 tokens against a 1,000,000 limit and codex "ran
+   out of room in the model's context window".
+
+   The history is 240 messages because the cut is quantized to
+   [atoms_per_window] (60): a handful of messages has no cut position below
+   "keep everything", so a small fixture would exercise the refusal path
+   instead of the windowing path and prove nothing about either. Real keepers
+   carry thousands. *)
+let seed_history () =
+  List.init 240 (fun i ->
+    msg
+      (if i mod 2 = 0 then Agent_core.Types.User else Agent_core.Types.Assistant)
+      (Printf.sprintf "history message %03d" i))
+;;
+
+let test_seed_is_bounded_and_keeps_the_newest () =
+  let messages = seed_history () in
+  let total = List.fold_left (fun acc m -> acc + Host.measure_message_bytes m) 0 messages in
+  (* Controls first. Without them a bound that dropped everything, or one that
+     refused every turn, would still look correct below. *)
+  (match prepare messages with
+   | Error _ -> fail "an undeclared ceiling must not fail the turn"
+   | Ok prepared ->
+     check int "keeps every message" 240 (List.length prepared.messages);
+     check int "reports no drop" 0 prepared.seed_dropped_atoms);
+  (match prepare ~max_prompt_bytes:(total * 2) messages with
+   | Error _ -> fail "a generous ceiling must not fail the turn"
+   | Ok prepared ->
+     check int "keeps every message" 240 (List.length prepared.messages);
+     check int "reports no drop" 0 prepared.seed_dropped_atoms);
+  (* Half the history's worth of budget has to cut, and what survives must be
+     the newest: the goal answers the most recent turn, so trimming the tail
+     would drop exactly the context it refers to. *)
+  match prepare ~max_prompt_bytes:(total / 2) messages with
+  | Error e ->
+    fail ("a partial fit must window rather than fail: " ^ Agent_core.Error.to_string e)
+  | Ok prepared ->
+    check bool "drops something" true (prepared.seed_dropped_atoms > 0);
+    check bool "keeps fewer than all" true (List.length prepared.messages < 240);
+    let kept =
+      List.fold_left (fun acc m -> acc + Host.measure_message_bytes m) 0 prepared.messages
+    in
+    check bool "fits the declared budget" true (kept <= total / 2);
+    (match List.rev prepared.messages with
+     | last :: _ ->
+       check string "keeps the newest" "history message 239" (text_of last)
+     | [] -> fail "the window must not empty the history")
+;;
+
 let () =
   run
     "keeper official-client host"
@@ -318,6 +397,12 @@ let () =
             "typed blocks preserve canonical JSON"
             `Quick
             test_typed_blocks_are_preserved_as_canonical_json
+        ] )
+    ; ( "start-turn seed budget"
+      , [ test_case
+            "bounds the seed and keeps the newest messages"
+            `Quick
+            test_seed_is_bounded_and_keeps_the_newest
         ] )
     ]
 ;;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -59,6 +59,7 @@ let qwen_model =
   ; min_p = None
   ; reasoning_effort = None
   ; turn_timeout_s = None
+  ; max_prompt_bytes = None
   ; capabilities = None
   }
 


### PR DESCRIPTION
Refs #28111.

## 문제

official-client 턴 1 은 벤더 대화를 **투영된 히스토리 전량**으로 시드한다. 턴 2 부터는 클라이언트가 대화를 소유하므로 MASC 는 goal 만 보낸다. 그 시드에 상한이 없었다.

그래서 히스토리가 모델 창을 넘긴 키퍼는 **한 번 실패하고 마는 게 아니다**: 턴 1 에서 실패 → 턴 2 에 도달 못 함 → 다음 주기에 더 커진 히스토리를 다시 렌더 → 반복.

**복구가 루프를 닫는다.** fresh session 은 턴 카운터를 리셋하고, 리셋된 카운터는 다음 턴을 다시 start 턴으로 만든다. 라이브 실측: 키퍼 3기가 `turn_count = 1` 에 고정, 그중 하나는 로그 한 개 안에서 fresh session 으로 **293 회** 자동 승계.

## 3계열 전부, 단위만 다르다

| 계열 | 벤더가 보고한 것 |
|---|---|
| claude_code | `400 Prompt is too long · the request is ~2227119 tokens (limit 1000000)` |
| codex | `Codex ran out of room in the model's context window.` |
| antigravity | argv 바운드가 stdin 전환(#28062)으로 제거됨 — stdin 엔 `ARG_MAX` 가 없으니 **제거 자체는 옳다**. 다만 그 바운드가 부수적으로 제공하던 컨텍스트 상한을 대체한 것이 없다 |

배포 후 완주율에서 0% 두 칸이 정확히 이것이다:

| runtime id | 시도 | 완주 |
|---|---:|---:|
| claude_code.claude-sonnet-5 | 421 | **421** |
| claude_code.claude-opus-5-max | 456 | **0** |
| codex_subscription.gpt-5.3-codex-spark | 427 | **0** |

`claude-sonnet-5` 가 대조군이다 — **같은 provider, 같은 코드 경로, 다른 히스토리 크기.** 창 안에 있어서 턴 1 을 넘겼고(`turn_count=448 phase=settled`) resume 경로로 들어가 100% 를 낸다.

## 왜 응답 측이 아니라 요청 측인가

#28071 이 넓힌 형태 — `error` 객체의 `message` 외 **모든 스칼라**를 싣는 형태 — 가 배포된 상태에서 라이브 codex 실패를 다시 읽으면 **annotation 이 하나도 없다.** 그 함수는 `String`/`Int`/`Intlit`/`Bool`/`Float` 를 전부 받으므로, 빈 결과는 정확히 한 가지를 뜻한다: 서버가 `message` 외 스칼라를 보내지 않는다.

따라서 타입 있는 overflow 승격은 응답에서 읽을 키가 없다. 남는 응답 측 선택지는 문자열 분류기뿐이고 그건 거부 패턴이다. **요청 시점 계측만 남는다.**

## 설계 — 왜 선언형 바이트인가

`max-context` 에서 유도하지 않는다. MASC 에는 토크나이저가 없으므로 토큰 예산을 바이트로 바꾸려면 bytes-per-token 상수가 필요한데, 그 숫자를 정당화할 근거가 이 저장소에 없다 (`rg 'bytes_per_token|approx_tokens'` → 0건). 그리고 그 상수가 틀리면 **조용히 잘리거나 조용히 넘친다** — 둘 다 지금보다 진단이 어렵다.

선례는 Agent_core 쪽 `max-request-body-bytes` 다: 운영자가 선언하는 바이트 캡이고 토큰에서 계산하지 않는다. official-client 바인딩에 그 대응물이 없었을 뿐이다.

`None` = 상한 없음 = **오늘 모든 배포의 동작**이므로 이 PR 자체는 회귀를 만들지 않는다. 값 선언은 별도이며 실측으로 정한다.

## 구현 위치

`Keeper_official_client_host.prepare_turn` — 세 어댑터가 이미 전부 호출하는 공용 진입점이다. 여기 한 곳이면 규칙이 한 번만 존재하고, 각 어댑터는 해석된 값을 넘기기만 한다. 세 곳에 같은 로직을 복사하는 것은 CLAUDE.md 의 N-of-M 안티패턴이다.

윈도잉은 `Runtime_model_input_tail_window` 재사용 — Agent_core 경로가 이미 쓰는 모듈이다. **최신 메시지를 남긴다**: goal 은 가장 최근 턴에 답하므로 tail 을 자르면 goal 이 가리키는 문맥을 정확히 버린다.

드롭은 키퍼 자신의 로그 줄에 남기고 `seed_dropped_atoms` 로도 반환한다 — 조용한 윈도우는 "모델이 전부 봤다" 로 읽힌다.

`prepared.messages` 소비자는 세 어댑터의 히스토리 투영뿐이며(`rg 'prepared\.messages'` → 3건), resume 경로는 messages 를 읽지 않으므로 윈도잉이 no-op 이다.

## 검증

```
dune build @check                                            OK (트리 전체)
dune build @test/runtest-test_keeper_official_client_host    11 tests, OK
dune build @test/runtest-test_runtime_config_validity        73 tests, OK
scripts/ci/check-telemetry-coverage.sh                       TEL gate PASS
scripts/audit-ci-test-targets.sh                             176 targets OK
```

새 테스트 `bounds the seed and keeps the newest messages` 는 **대조군 두 개를 먼저** 통과해야 한다:

1. 상한 미선언 → 240 메시지 전부 유지, 드롭 0 (오늘의 동작)
2. 넉넉한 상한 → 전부 유지, 드롭 0
3. 절반 예산 → 드롭 > 0, 유지 < 240, 유지분이 예산 안에 들어감, **마지막이 가장 최신**

대조군이 없으면 "전부 드롭" 이나 "매번 거부" 도 통과한다.

배선 증명: `prepare_turn` 의 `max_prompt_bytes` 분기를 `None` 으로 단락시키면 이 테스트가 red 가 된다.

픽스처가 240 메시지인 이유도 실측이다 — 컷이 `atoms_per_window`(60) 로 양자화되므로 3 개짜리 히스토리는 컷 위치가 없어 **거부 경로**를 타고, 윈도잉을 전혀 증명하지 못한다. 처음에 3 개로 썼다가 `undroppable_bytes=302` 로 실패해서 알았다.

RFC-WAIVED: 변경 범위가 런타임 config 스키마의 선언 필드 하나와 official-client 공용 host 의 프롬프트 구성이다. credential / identity / repo_manager / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 어느 것도 건드리지 않는다.

WORKAROUND-WAIVED: 증상 억제가 아니라 **없던 바운드를 추가**하는 변경이다. 재시도/캡/쿨다운/dedup 으로 실패를 눌러 감추지 않고, 넘치면 타입 있는 config 에러로 fail-closed 한다. 문자열 분류기 없음, catch-all 추가 없음, 텔레메트리-as-fix 없음 — 드롭은 카운터가 아니라 운영자 로그 줄과 반환값으로 노출된다.

Co-Authored-By: Claude Opus 5 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrQctrmuNds4HVg9sHgicM
