### PR TITLE
fix(chat-store): make the closed flag an Atomic so only one caller closes

### DIFF
--- a/lib/keeper_chat_operations/keeper_chat_operation_store.ml
+++ b/lib/keeper_chat_operations/keeper_chat_operation_store.ml
@@ -5,7 +5,11 @@ module Id = Operation.Operation_id
 type t =
   { db : Sqlite3.db
   ; path : string
-  ; mutable closed : bool
+  (* [close] used to test this and then set it. Two closers could both see
+     [false] and both call [Sqlite3.db_close] on the same handle. As an
+     [Atomic] the test and the set are one step, so exactly one caller
+     reaches the close. *)
+  ; closed : bool Atomic.t
   }
 
 type error =
@@ -209,7 +213,9 @@ let single_text db ~operation sql =
 ;;
 
 let ensure_open store =
-  if store.closed then Error (Store_unavailable "database handle is closed") else Ok ()
+  if Atomic.get store.closed
+  then Error (Store_unavailable "database handle is closed")
+  else Ok ()
 ;;
 
 let rollback db = ignore (Sqlite3.exec db "ROLLBACK" : Sqlite3.Rc.t)
@@ -558,22 +564,21 @@ let open_or_create ~path =
               | Error error -> rollback db; fail error
               | Ok () ->
                 (match validate_schema db with
-                 | Ok () -> Ok { db; path; closed = false }
+                 | Ok () -> Ok { db; path; closed = Atomic.make false }
                  | Error error -> fail error))))
      | Ok _ ->
        (match validate_schema db with
-        | Ok () -> Ok { db; path; closed = false }
+        | Ok () -> Ok { db; path; closed = Atomic.make false }
         | Error error -> fail error))
 ;;
 
 let close store =
-  if store.closed
-  then Ok ()
-  else (
-    store.closed <- true;
+  if Atomic.compare_and_set store.closed false true
+  then
     if Sqlite3.db_close store.db
     then Ok ()
-    else Error (Store_unavailable "failed to close SQLite database"))
+    else Error (Store_unavailable "failed to close SQLite database")
+  else Ok ()
 ;;
 
 let next_sequence db =

--- a/test/keeper_chat_operations/test_keeper_chat_operation_store.ml
+++ b/test/keeper_chat_operations/test_keeper_chat_operation_store.ml
@@ -320,11 +320,38 @@ let test_terminal_row_is_sql_immutable () =
        check bool "terminal update rejected" false (Sqlite3.Rc.is_success rc))
 ;;
 
+
+(* [closed] is an [Atomic] so that the test-and-set in [close] is one step and
+   exactly one caller reaches [Sqlite3.db_close]. Two things have to hold and
+   neither was covered: a second close is a no-op that still reports success,
+   and every operation after a close is refused rather than reaching the freed
+   handle. *)
+let test_close_is_idempotent_and_refuses_later_operations () =
+  let directory = Filename.temp_dir "keeper-chat-operations-close" "" in
+  let path = Filename.concat directory Store.For_testing.database_file in
+  let store = store_ok (Store.open_or_create ~path) in
+  store_ok (Store.close store);
+  store_ok (Store.close store);
+  let operation_id =
+    match Operation.Operation_id.of_string "op-after-close" with
+    | Ok id -> id
+    | Error detail -> fail ("operation id fixture rejected: " ^ detail)
+  in
+  (match Store.get store operation_id with
+   | Ok _ -> fail "get after close must be refused"
+   | Error _ -> ());
+  match Store.close store with
+  | Ok () -> ()
+  | Error _ -> fail "a repeated close must stay successful"
+;;
+
 let () =
   run
     "keeper-chat-operation-store"
     [ ( "store"
       , [ test_case "schema identity and budget" `Quick test_schema_identity_and_budget
+        ; test_case "close is idempotent and refuses later operations" `Quick
+            test_close_is_idempotent_and_refuses_later_operations
         ; test_case "exact idempotency and terminal dedupe" `Quick
             test_exact_idempotency_and_terminal_dedupe
         ; test_case "FIFO edit move cancel" `Quick test_fifo_edit_move_cancel


### PR DESCRIPTION
## 결함

```ocaml
let close store =
  if store.closed then Ok ()
  else (store.closed <- true; if Sqlite3.db_close store.db then ... )
```

test-then-set 이다. 두 호출자가 모두 `false` 를 보고 **둘 다 `Sqlite3.db_close` 를 같은 핸들에 부른다**.

## 변경

`closed : bool Atomic.t` 로 바꾸고 `close` 를 `Atomic.compare_and_set store.closed false true` 로 한다. 테스트와 설정이 한 단계가 되어 정확히 한 호출자만 close 에 도달하고 나머지는 `Ok ()` 를 받는다. `ensure_open` 은 `Atomic.get` 으로 읽는다.

## 테스트

멱등성 계약에 테스트가 없었다. 추가했다: 두 번째 `close` 는 성공을 유지하고, close 이후의 연산은 거부된다.

CAS 를 빼서 매 호출이 `db_close` 에 도달하게 하면 새 케이스와 기존 3건(`schema identity and budget`, `restart interruption`, `terminal SQL immutability`)이 함께 실패한다.

**한 가지 정직하게 적어둔다**: 새 테스트는 *계약*을 고정하지 *가드*를 고정하지 않는다. `ensure_open` 이 무조건 `Ok` 를 반환하게 바꿔도 통과한다 — SQLite 가 닫힌 핸들을 스스로 거부하기 때문이다. 가드의 값은 그것을 드라이버 오류 대신 타입이 있는 `Store_unavailable` 로 만드는 데 있고, 모듈의 나머지 오류 표면이 그것을 기대한다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `@test/keeper_chat_operations/runtest` 8/8
- `python3 scripts/check_test_coverage.py` → exit 0

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
