### PR TITLE
refactor(ide): keep the ingest capacity beside the queue, not inside it

### DIFF
--- a/lib/ide/ide_ingest_queue.ml
+++ b/lib/ide/ide_ingest_queue.ml
@@ -11,14 +11,18 @@ type queue_state =
   { mu : Stdlib.Mutex.t
   ; cond : Eio.Condition.t
   ; items : job Queue.t
-  ; mutable capacity : int
   }
+
+(* Production never changes this — the only writer is [For_testing.reset].
+   Keeping it beside the queue rather than inside it leaves [queue_state]
+   with nothing but its lock, condition and item buffer, and the knob does
+   not need the queue lock to be read. *)
+let capacity = Atomic.make default_capacity
 
 let queue =
   { mu = Stdlib.Mutex.create ()
   ; cond = Eio.Condition.create ()
   ; items = Queue.create ()
-  ; capacity = default_capacity
   }
 
 let with_queue f =
@@ -44,7 +48,7 @@ let submit (job : job) : unit =
          intentionally a Stdlib.Mutex rather than Eio.Mutex because submit can
          be reached from pre-Eio/test contexts, and the protected work never
          performs I/O or suspends. *)
-      if Queue.length queue.items >= queue.capacity
+      if Queue.length queue.items >= Atomic.get capacity
       then (
         (* See [dropped]: eviction is intentional for the bounded newest-job queue. *)
         ignore (Queue.take_opt queue.items : job option);
@@ -86,8 +90,8 @@ let run_writer () =
 module For_testing = struct
   let reset ?(capacity_override = default_capacity) () =
     with_queue (fun () ->
-      queue.capacity <- capacity_override;
       Queue.clear queue.items);
+    Atomic.set capacity capacity_override;
     Atomic.set active false;
     Atomic.set dropped 0;
     Eio.Condition.broadcast queue.cond


### PR DESCRIPTION
## 관찰

`capacity` 는 `queue_state` 의 유일한 `mutable` 필드였고, **쓰는 곳은 `For_testing.reset` 하나뿐**이다. 프로덕션에서는 값이 바뀌지 않는다. 즉 이 필드는 테스트 노브를 큐의 런타임 상태에 실어 나르려고 존재했다.

## 변경

모듈 레벨 `int Atomic.t` 로 옮긴다. 같은 파일의 `active` / `dropped` 가 이미 그 형태다.

`queue_state` 에는 락·condition·아이템 버퍼만 남는다 — 전부 컨테이너다. 그리고 노브를 읽는 데 큐 락이 필요 없어진다.

## 검증

- `dune build --root . @default @check @install` (CI Build 단계와 동일) → exit 0
- `python3 scripts/check_test_coverage.py` → exit 0

용량 경로는 덮여 있다: `test_ide_bridge` 가 `~capacity_override:4` 로 리셋하고 6건 드롭을 단언한다. 리셋이 override 를 무시하게 바꾸면 `ingest_queue / drops oldest at capacity` 가 실패한다.

같은 스위트의 `rotation` 실패 2건은 `origin/main` 에서 동일하게 재현되는 기존 실패이고 이 변경과 무관하다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
