### PR TITLE
feat(health): dashboard_surface를 /health 1급 필드로 — 꺼진 관측 표면의 가시화

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -289,6 +289,7 @@ let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
       ("schedule_runner", schedule_runner_status_json ());
       ("runtime_startup_degradation",
        Runtime.startup_degradation_to_yojson (Runtime.startup_degradation ()));
+      ("dashboard_surface", Web_dashboard.surface_status_json ());
       ("subsystems", Subsystem_health.to_yojson ());
       ("logs", Log.Ring.summary_json ());
       ("gc", quick_gc_json ());
@@ -643,6 +644,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref
     ("sse_clients", `Int (Sse.client_count ()));
     ("startup", Server_startup_state.to_yojson ());
     ("runtime_startup_degradation", runtime_startup_degradation_json);
+    ("dashboard_surface", Web_dashboard.surface_status_json ());
     ("subsystems", Subsystem_health.to_yojson ());
     (* Server log visibility belongs on the first health probe too.  Keep the
        payload cheap and redacted: only ring counters, latest metadata, and

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -100,6 +100,48 @@ let log_bundle_freshness_warning () =
       (iso8601_of_unix_seconds stamp_mtime)
       (iso8601_of_unix_seconds binary_mtime)
 
+let rebuild_next_action = "cd dashboard && pnpm run build"
+
+(** Health projection of the dashboard surface. The boot-time WARN from
+    {!log_bundle_freshness_warning} scrolls away with the log ring; this JSON
+    keeps the same verdict visible on every [/health] probe, so an operator
+    (or an audit) can see a dark dashboard surface without replaying startup
+    logs. [status] is ["ok"], ["stale"], or ["missing"]; a present build-stamp
+    with no [index.html] still reports ["missing"] because the index is what
+    actually serves. *)
+let surface_status_json () =
+  let index = index_path () in
+  let index_present = Sys.file_exists index in
+  let freshness_status, freshness_fields =
+    match bundle_freshness () with
+    | Missing_stamp -> ("missing", [])
+    | Stale { stamp_mtime; binary_mtime } ->
+      ( "stale"
+      , [ ("build_stamp_at", `String (iso8601_of_unix_seconds stamp_mtime))
+        ; ("binary_built_at", `String (iso8601_of_unix_seconds binary_mtime))
+        ] )
+    | Fresh ->
+      let stamp_field =
+        match mtime_of (build_stamp_path ()) with
+        | Some stamp_mtime ->
+          [ ("build_stamp_at", `String (iso8601_of_unix_seconds stamp_mtime)) ]
+        | None -> []
+      in
+      ("ok", stamp_field)
+  in
+  (* A missing index.html trumps freshness: the index is what actually
+     serves, so a stale-or-fresh stamp without it is still a dark surface. *)
+  let status = if index_present then freshness_status else "missing" in
+  let next_action = if status = "ok" then "none" else rebuild_next_action in
+  `Assoc
+    ([ ("schema", `String "masc.dashboard_surface.v1")
+     ; ("status", `String status)
+     ; ("index_present", `Bool index_present)
+     ; ("assets_root", `String (assets_root ()))
+     ; ("next_action", `String next_action)
+     ]
+     @ freshness_fields)
+
 let html () =
   try
     Fs_compat.load_file (index_path ())

--- a/lib/web_dashboard.mli
+++ b/lib/web_dashboard.mli
@@ -27,6 +27,13 @@ val bundle_freshness : unit -> bundle_freshness
     server startup. *)
 val log_bundle_freshness_warning : unit -> unit
 
+(** Health projection of the dashboard surface for [/health]. [status] is
+    ["ok"], ["stale"] (bundle predates the running binary), or ["missing"]
+    (no build-stamp, unreadable stamp, or a stamp without [index.html]).
+    Carries [assets_root], [index_present], [next_action], and RFC3339
+    freshness timestamps when known. *)
+val surface_status_json : unit -> Yojson.Safe.t
+
 (** Generate the dashboard HTML page *)
 val html : unit -> string
 

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -361,6 +361,70 @@ let test_log_bundle_freshness_warning_does_not_raise_on_fresh () =
     Web_dashboard.log_bundle_freshness_warning ())
 
 (* ============================================================
+   surface_status_json: /health projection of the dashboard surface
+   ============================================================ *)
+
+let assoc_field name = function
+  | `Assoc kvs -> List.assoc_opt name kvs
+  | _ -> None
+
+let status_of json =
+  match assoc_field "status" json with
+  | Some (`String s) -> s
+  | _ -> "<no-status>"
+
+let index_present_of json =
+  match assoc_field "index_present" json with
+  | Some (`Bool b) -> b
+  | _ -> fail "index_present field missing"
+
+let next_action_of json =
+  match assoc_field "next_action" json with
+  | Some (`String s) -> s
+  | _ -> "<no-next-action>"
+
+let test_surface_status_ok_when_fresh_and_index_present () =
+  let far_future = Unix.gettimeofday () +. (365.0 *. 24.0 *. 3600.0) in
+  with_temp_dashboard_root ~stamp_mtime:far_future (fun () ->
+    let json = Web_dashboard.surface_status_json () in
+    check string "status" "ok" (status_of json);
+    check bool "index_present" true (index_present_of json);
+    check string "next_action" "none" (next_action_of json);
+    check bool "build_stamp_at present" true
+      (assoc_field "build_stamp_at" json <> None))
+
+let test_surface_status_stale_when_stamp_predates_binary () =
+  with_temp_dashboard_root ~stamp_mtime:long_ago (fun () ->
+    let json = Web_dashboard.surface_status_json () in
+    check string "status" "stale" (status_of json);
+    check bool "binary_built_at present" true
+      (assoc_field "binary_built_at" json <> None);
+    check string "next_action names the rebuild" "cd dashboard && pnpm run build"
+      (next_action_of json))
+
+let test_surface_status_missing_without_stamp () =
+  with_temp_dashboard_root (fun () ->
+    let json = Web_dashboard.surface_status_json () in
+    check string "status" "missing" (status_of json);
+    check bool "index_present stays true" true (index_present_of json);
+    check string "next_action names the rebuild" "cd dashboard && pnpm run build"
+      (next_action_of json))
+
+let test_surface_status_missing_when_index_absent_despite_fresh_stamp () =
+  let far_future = Unix.gettimeofday () +. (365.0 *. 24.0 *. 3600.0) in
+  with_temp_dashboard_root ~stamp_mtime:far_future (fun () ->
+    (* Partially-deployed tree: the stamp survived, index.html did not. *)
+    let index =
+      Filename.concat
+        (Filename.concat (Web_dashboard.assets_root ()) "dashboard")
+        "index.html"
+    in
+    if Sys.file_exists index then Sys.remove index;
+    let json = Web_dashboard.surface_status_json () in
+    check string "status" "missing" (status_of json);
+    check bool "index_present" false (index_present_of json))
+
+(* ============================================================
    Test Runners
    ============================================================ *)
 
@@ -403,5 +467,11 @@ let () =
       test_case "warn does not raise on missing stamp" `Quick test_log_bundle_freshness_warning_does_not_raise_on_missing_stamp;
       test_case "warn does not raise on stale" `Quick test_log_bundle_freshness_warning_does_not_raise_on_stale;
       test_case "warn does not raise on fresh" `Quick test_log_bundle_freshness_warning_does_not_raise_on_fresh;
+    ];
+    "surface_status", [
+      test_case "ok when fresh and index present" `Quick test_surface_status_ok_when_fresh_and_index_present;
+      test_case "stale when stamp predates binary" `Quick test_surface_status_stale_when_stamp_predates_binary;
+      test_case "missing without stamp" `Quick test_surface_status_missing_without_stamp;
+      test_case "missing when index absent despite fresh stamp" `Quick test_surface_status_missing_when_index_absent_despite_fresh_stamp;
     ];
   ]


### PR DESCRIPTION
## 무엇

`/health`(probe·full 양쪽)에 `dashboard_surface` 필드를 추가합니다 — 대시보드 번들의 서빙 가능 상태(`ok | stale | missing`)를 typed로 투영합니다.

```json
"dashboard_surface": {
  "schema": "masc.dashboard_surface.v1",
  "status": "missing",
  "index_present": false,
  "assets_root": "/private/tmp/masc-live-main-20260810-v6/assets",
  "next_action": "cd dashboard && pnpm run build"
}
```

## 왜

orca 대조 감사(`reports/orca-vs-masc-adversarial-2026-08-11.html` G0)의 실측: 라이브 인스턴스가 두 번 연속 **대시보드 미빌드 상태로 배포**돼 있었습니다 (`GET /dashboard` → 264B "Dashboard build not found"). IDE observation plane 전체(컴포넌트 59개)가 물리적으로 도달 불가였는데, 이를 알 수 있는 신호는 부팅 시 1회 WARN(`log_bundle_freshness_warning`, 로그 링에서 밀려남)뿐이었습니다.

원인 사슬도 확인했습니다: 배포 트리가 `/private/tmp/masc-live-main-*`로 매번 새로 만들어지는데, `scripts/build-dashboard-if-needed.sh`는 pnpm/corepack이 없으면 **조용히 exit 0** 합니다. 즉 "표면이 꺼진 채 서버만 도는" 상태가 구조적으로 재발 가능하고, 지금까지는 관측 불가였습니다.

판정 소스는 기존 `bundle_freshness()`(#24332 이후 존재)를 그대로 쓰고, health projection 한 곳만 추가합니다. `index.html` 부재는 스탬프 신선도와 무관하게 `missing`이 우선합니다(실제로 서빙되는 것은 index이므로 — 부분 배포 트리 케이스).

기동 거부 gate는 의도적으로 추가하지 않았습니다: 대시보드 없이 서버만 띄우는 것은 개발에서 정당한 용례이고, masc의 gate 추가 기준(압도적 이득 없는 gate 금지)에 부합하지 않습니다. 관측(1급 노출)이 올바른 수위입니다.

## 검증

- 신규 Alcotest `surface_status` 4건: fresh+index→`ok`, stale→`stale`(+RFC3339 타임스탬프), 무스탬프→`missing`, fresh 스탬프+index 부재→`missing`. 기존 `bundle_freshness`·fallback 스위트 포함 32건 green (`test_web_dashboard_coverage`, `test/dune:1489`→`stanzas/coverage_tests.inc` 배선 확인).
- `dune build --root . lib/server/` green (양쪽 health 조립부 컴파일).
- 미검증: 라이브 인스턴스 실측 (머지·배포 후 `/health`에서 `dashboard_surface.status` 확인 예정 — 이 필드의 완료 기준은 코드 머지가 아니라 운영 인스턴스에서의 실측입니다).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
