### PR TITLE
fix(keeper): fence Codex overflow retry after tools

### DIFF
--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -98,9 +98,17 @@ let codex_error_to_core_error = function
     config_error ~field:"codex_app_server" detail
   | Runtime_codex_app_server.Subscription_required detail ->
     config_error ~field:"codex_subscription" detail
-  | Runtime_codex_app_server.Context_window_exceeded { message } ->
+  | Runtime_codex_app_server.Context_window_exceeded
+      { message; tool_effect_attempted = false } ->
     Agent_core.Error.Api
       (Llm_provider.Retry.ContextOverflow { message; limit = None })
+  | Runtime_codex_app_server.Context_window_exceeded _ as error ->
+    Agent_core.Error.Provider
+      (Llm_provider.Error.ProviderReportedError
+         { provider = "codex_app_server"
+         ; error_type = Some "context_window_exceeded_after_tool_effect"
+         ; detail = Runtime_codex_app_server.error_to_string error
+         })
   | error -> Agent_core.Error.Internal (Runtime_codex_app_server.error_to_string error)
 ;;
 

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -105,7 +105,10 @@ type error =
       }
   | Subscription_required of string
   | Unsupported_server_request of string
-  | Context_window_exceeded of { message : string }
+  | Context_window_exceeded of
+      { message : string
+      ; tool_effect_attempted : bool
+      }
   | Turn_failed of string
   | Turn_interrupted
   | Process_exited of string
@@ -123,8 +126,11 @@ let error_to_string = function
     "Codex ChatGPT subscription login required: " ^ detail
   | Unsupported_server_request method_ ->
     "Codex app-server requested unsupported host action: " ^ method_
-  | Context_window_exceeded { message } ->
-    "Codex app-server context window exceeded: " ^ message
+  | Context_window_exceeded { message; tool_effect_attempted } ->
+    Printf.sprintf
+      "Codex app-server context window exceeded (tool_effect_attempted=%b): %s"
+      tool_effect_attempted
+      message
   | Turn_failed detail -> "Codex app-server turn failed: " ^ detail
   | Turn_interrupted -> "Codex app-server turn was interrupted"
   | Process_exited detail -> "Codex app-server exited before completion: " ^ detail
@@ -518,14 +524,14 @@ let turn_error_detail ~message error_fields =
   | annotations -> message ^ " (" ^ String.concat " " annotations ^ ")"
 ;;
 
-let turn_error_of_fields ~message error_fields =
+let turn_error_of_fields ~tool_effect_attempted ~message error_fields =
   match List.assoc_opt "codexErrorInfo" error_fields with
   | Some (`String "contextWindowExceeded") ->
-    Context_window_exceeded { message }
+    Context_window_exceeded { message; tool_effect_attempted }
   | Some _ | None -> Turn_failed (turn_error_detail ~message error_fields)
 ;;
 
-let turn_error fields =
+let turn_error ~tool_effect_attempted fields =
   match List.assoc_opt "error" fields with
   | Some (`Assoc error_fields) ->
     let message =
@@ -534,11 +540,12 @@ let turn_error fields =
         String.trim message
       | _ -> "turn failed without a typed error message"
     in
-    turn_error_of_fields ~message error_fields
+    turn_error_of_fields ~tool_effect_attempted ~message error_fields
   | Some _ | None -> Turn_failed "turn failed without an error object"
 ;;
 
-let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
+let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback
+    ~tool_effect_attempted params =
   let stage = "turn/completed" in
   let* fields = assoc_at stage params in
   let* terminal_thread_id = required_string stage "threadId" fields in
@@ -553,7 +560,7 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params =
     else
       let* status = required_string stage "status" turn_fields in
       match status with
-      | "failed" -> Error (turn_error turn_fields)
+      | "failed" -> Error (turn_error ~tool_effect_attempted turn_fields)
       | "interrupted" -> Error Turn_interrupted
       | "inProgress" -> protocol_error stage "terminal notification carried inProgress status"
       | "completed" ->
@@ -694,9 +701,19 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       let* error_json = required_member stage "error" fields in
       let* error_fields = assoc_at stage error_json in
       let* message = required_string stage "message" error_fields in
-      Error (turn_error_of_fields ~message error_fields)
+      Error
+        (turn_error_of_fields
+           ~tool_effect_attempted:(!tool_call_count > 0)
+           ~message
+           error_fields)
   | Notification { method_ = "turn/completed"; params } ->
-    terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback params
+    terminal_result
+      ~thread_id
+      ~turn_id
+      ~seen_final
+      ~seen_fallback
+      ~tool_effect_attempted:(!tool_call_count > 0)
+      params
   (* App-server progress and account notifications are observational. Protocol
      evolution must not turn them into a computation failure; the enclosing
      turn timeout remains the liveness boundary. *)

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -84,7 +84,10 @@ type error =
       }
   | Subscription_required of string
   | Unsupported_server_request of string
-  | Context_window_exceeded of { message : string }
+  | Context_window_exceeded of
+      { message : string
+      ; tool_effect_attempted : bool
+      }
   | Turn_failed of string
   | Turn_interrupted
   | Process_exited of string

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -170,6 +170,37 @@ let test_dynamic_tool_callback () =
            (Yojson.Safe.to_string !arguments))
 ;;
 
+let test_context_error_records_prior_tool_effect () =
+  let tool : Runtime_codex_app_server.dynamic_tool =
+    { name = "masc_probe"
+    ; description = "Record one deterministic tool effect"
+    ; input_schema = `Assoc [ "type", `String "object" ]
+    ; call =
+        (fun ~call_id:_ _ ->
+          { Runtime_codex_app_server.success = true; content = "effect applied" })
+    }
+  in
+  let failed =
+    {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"context is full","codexErrorInfo":"contextWindowExceeded"}}}}|}
+  in
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; tool_call_request
+    ; failed
+    ]
+    (fun path ->
+       match run_fixture ~dynamic_tools:[ tool ] path with
+       | Error
+           (Runtime_codex_app_server.Context_window_exceeded
+              { message = "context is full"; tool_effect_attempted = true }) ->
+         ()
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok _ -> fail "context overflow after a tool effect was not reported")
+;;
+
 let test_history_is_injected_before_turn () =
   let injected = {|{"id":4,"result":{}}|} in
   let turn_after_injection = {|{"id":5,"result":{"turn":{"id":"turn-1"}}}|} in
@@ -440,7 +471,8 @@ let test_failed_turn_uses_official_context_error_enum () =
     (fun path ->
       match run_fixture path with
       | Error
-          (Runtime_codex_app_server.Context_window_exceeded { message }) ->
+          (Runtime_codex_app_server.Context_window_exceeded
+             { message; tool_effect_attempted = false }) ->
         check
           string
           "provider message"
@@ -609,7 +641,7 @@ let test_terminal_error_notification_uses_official_context_error_enum () =
        match run_fixture path with
        | Error
            (Runtime_codex_app_server.Context_window_exceeded
-              { message = "context is full" }) ->
+              { message = "context is full"; tool_effect_attempted = false }) ->
          ()
        | Error error -> fail (Runtime_codex_app_server.error_to_string error)
        | Ok _ -> fail "typed terminal context overflow did not fail the turn")
@@ -1107,6 +1139,44 @@ let test_keeper_maps_official_context_error_to_typed_core_error () =
          ()
        | Error error -> fail (Agent_core.Error.to_string error)
        | Ok _ -> fail "Keeper erased the typed Codex context overflow")
+;;
+
+let test_keeper_does_not_retry_context_error_after_tool_effect () =
+  let tool =
+    fixture_tool
+      ~name:"masc_probe"
+      ~description:"Record one deterministic tool effect"
+      ()
+  in
+  let failed =
+    {|{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"status":"failed","error":{"message":"context is full","codexErrorInfo":"contextWindowExceeded"}}}}|}
+  in
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; tool_call_request
+    ; failed
+    ]
+    (fun cli_path ->
+       match
+         run_keeper_turn
+           ~tools:[ tool ]
+           ~cli_path
+           ~model:"gpt-fixture"
+           ()
+       with
+       | Error
+           (Agent_core.Error.Provider
+              (Llm_provider.Error.ProviderReportedError
+                 { provider = "codex_app_server"
+                 ; error_type = Some "context_window_exceeded_after_tool_effect"
+                 ; _
+                 })) ->
+         ()
+       | Error error -> fail (Agent_core.Error.to_string error)
+       | Ok _ -> fail "Keeper retried a context overflow after a tool effect")
 ;;
 
 let test_keeper_dispatches_codex_turn_runtime () =
@@ -2378,6 +2448,10 @@ let () =
             `Quick
             test_dispatch_validation_is_process_free
         ; test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
+        ; test_case
+            "context error records prior tool effect"
+            `Quick
+            test_context_error_records_prior_tool_effect
         ; test_case "history injects before turn" `Quick test_history_is_injected_before_turn
         ; test_case
             "thread resume skips history injection"
@@ -2399,6 +2473,10 @@ let () =
             "Keeper maps official context error to typed core error"
             `Quick
             test_keeper_maps_official_context_error_to_typed_core_error
+        ; test_case
+            "Keeper does not retry context error after tool effect"
+            `Quick
+            test_keeper_does_not_retry_context_error_after_tool_effect
         ; test_case
             "Keeper preserves typed history on Codex wire"
             `Quick


### PR DESCRIPTION
## Summary

- record whether a Codex `contextWindowExceeded` terminal arrived after a dynamic tool effect
- expose retryable `Agent_core.Error.Api (ContextOverflow ...)` only when no tool effect was attempted
- preserve the exact context-overflow observation after a tool effect as a non-retryable provider error
- cover both protocol projection and the Keeper bridge

## Why

PR #28114 restored Codex app-server typed context overflow. The ordinary typed overflow path is eligible for same-runtime shrink and lane retry. A context overflow can also arrive after Codex has already invoked a dynamic tool; retrying that turn could duplicate an external effect. This follow-up makes the retry authority explicit instead of inferring safety from the error class alone.

No string matching, compatibility decoder, or fallback path is added.

## Verification

- `git diff --check`
- local build/tests intentionally not run per operator instruction; GitHub CI is the build and test authority

Refs #27427
Follow-up to #28114