### PR TITLE
docs(rfc): RFC-0369 keeper credential-surface observability (Draft)

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -233,6 +233,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0365 | handoff_context must survive the ownership boundary | Draft | - |
 | 0366 | 운영자가 다음 턴의 컨텍스트에 한 문장을 넣는다 | Draft | - |
 | 0368 | 판단 없는 recovery는 keeper의 다음 claim이 스스로 해제한다 | Draft | - |
+| 0369 | Keeper credential-surface observability for repo-hosting CLIs | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |

--- a/docs/rfc/RFC-0369-keeper-credential-surface-observability.md
+++ b/docs/rfc/RFC-0369-keeper-credential-surface-observability.md
@@ -1,0 +1,99 @@
+---
+rfc: "0369"
+title: "Keeper credential-surface observability for repo-hosting CLIs"
+status: Draft
+created: 2026-08-11
+updated: 2026-08-11
+author: vincent + claude
+supersedes: []
+superseded_by: null
+related: ["0312", "0343"]
+implementation_prs: []
+---
+
+# RFC-0369: Keeper credential-surface observability for repo-hosting CLIs
+
+## 1. Problem
+
+A keeper that opens PRs authenticates to GitHub through whatever its execution
+environment resolves: the host `gh` keyring, a projected `GH_TOKEN` secret, or
+nothing. No surface can answer "is this keeper able to push right now?":
+
+- `Keeper_secret_projection.dashboard_status_json` exposes `env_names`
+  presence only — it cannot say whether a projected token is valid, expired,
+  or missing a scope, and it knows nothing about host-keyring credentials the
+  Local profile inherits through `HOME`.
+- `scripts/lib/gh-preflight.sh` checks `gh auth status` but only inside the
+  PR scripts' own run, invisible to the operator.
+- A keeper whose push fails on credentials burns its turn on a terminal error
+  the dashboard renders as a generic tool failure.
+
+The 2026-08-11 orca comparison audit (G3) measured the contrast: orca surfaces
+a three-state connection card with account, scopes, token source, and the
+env-token-shadowing footgun; masc surfaces nothing.
+
+One constraint shapes the whole design. RFC-0309 (typed gh capability gating)
+was withdrawn by #24332 because generic execution and Gate layers must not
+know a particular CLI, credential scheme, or verb family
+(`docs/spec/05-keeper-agent.md#inv-keeper-008-non-hierarchical-effect-gate`).
+Any credential-surface feature that reintroduces product knowledge into
+exec/Gate repeats the withdrawn design.
+
+## 2. Decision
+
+Add a product-specific **observation** module, structurally parallel to the
+connector modules that already know Discord or Slack, and keep it entirely
+outside exec/Gate:
+
+- New `lib/credential_observation/`: runs `gh auth status` and parses the
+  stable field labels (host, account, token source `keyring | env`, scopes),
+  using the same non-interactive env discipline as `Repo_git`
+  (`GIT_TERMINAL_PROMPT=0`, empty askpass). Unknown or unparseable output is
+  a typed `Unknown` verdict, never a permissive default.
+- Probes evaluate **per keeper profile**, not per host: the probe runs under
+  the keeper's projected environment (`local_env_for_keeper`; the Docker
+  profile probes with the projected `--env-file`), so the verdict reflects
+  what that keeper's shell would actually resolve — including the case where
+  a host-keyring credential is shadowed by a projected `GH_TOKEN`, the
+  documented `gh` footgun where `gh auth refresh` silently no-ops.
+- Read surface: `GET /api/v1/keepers/:name/credential-surface` returning
+  `{schema, host, status: authenticated | unauthenticated | shadowed |
+  unknown, account?, token_source?, scopes?, probed_at, next_action}` — never
+  a token value, and the store stays write-only as today.
+- Dashboard: a credential card on the keeper detail panel rendering exactly
+  those fields, with a manual re-probe action.
+- Probe budget: results are cached with a TTL (default 10 minutes) and a
+  manual refresh; probes serialize through a single in-process slot so a
+  fleet of N keepers cannot multiply `gh` API calls (the fleet shares one
+  personal rate limit — audit G4).
+
+## 3. Non-goals
+
+- No gh awareness in exec, Gate, or policy layers (INV-KEEPER-008 stands).
+- No credential values in any response, log, or trace.
+- No automatic remediation: the surface reports `next_action` text
+  (for example `gh auth login`), it never runs it.
+- No new credential storage or rotation semantics; `Keeper_secret_projection`
+  remains the only carrier.
+
+## 4. Consequences
+
+Positive: credential failures move from silent turn-burn to a first-class
+keeper-detail verdict; the Local-profile asymmetry (env boundary without a
+file boundary) becomes visible because the probe reports which source
+resolved.
+
+Negative: a probe consumes the operator's own `gh` API budget (bounded by the
+TTL and the single-slot serialization); parser follows `gh auth status` text,
+which is stable-labeled but not a formal API and needs a compatibility test
+against the pinned gh version.
+
+## 5. Verification
+
+- Unit: parser fixtures for keyring/env/shadowed/GHES-host outputs, including
+  future-unknown labels mapping to `Unknown`.
+- Integration: probe under a projected fake `GH_TOKEN` reports `env` source;
+  probe with an empty projection on a logged-in host reports `keyring`.
+- E2E completion bar (per the audit's production-use standard): the verdict
+  visible on a live instance's keeper detail card, wrong-credential keeper
+  showing `unauthenticated` before its next push attempt fails.


### PR DESCRIPTION
orca 대조 감사 G3 후속. keeper별 repo-hosting CLI 자격증명 상태(authenticated/unauthenticated/shadowed/unknown)를 관측하는 RFC 초안입니다.

핵심 설계 제약: RFC-0309 철회 사유(product-blind exec/Gate, INV-KEEPER-008)를 존중해 **exec/Gate 밖의 connector류 관측 전용 모듈**로 위치. keeper의 projected env로 프로브해 env-token shadowing까지 판정. 값 무노출, TTL 캐시 + 단일 슬롯 직렬화로 fleet의 gh API 소모 상한(G4 연계).

- 발단: `reports/orca-vs-masc-adversarial-2026-08-11.html` G3 (orca `auth-diagnose.ts` 대조)
- 구현 전 설계 리뷰용 Draft입니다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>