### PR TITLE
refactor(keeper): drop the resume check that cannot be false

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -413,11 +413,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         | Error error -> Error error
         | Ok turn ->
           recovery_failure := Session_store.Protocol_failed;
-          let* () =
-            if Bool.equal is_resume turn.resumed
-            then Ok ()
-            else Error (internal_error "Antigravity resumed flag differs from durable plan")
-          in
           let turn_id =
             provider_turn_identity
               ~conversation_id:turn.conversation_id


### PR DESCRIPTION
## 무엇을

항등식이라 절대 false 가 될 수 없는 resume 검사를 지웁니다 — 5줄 삭제, 0줄 추가.

```ocaml
(* 삭제 *)
let* () =
  if Bool.equal is_resume turn.resumed
  then Ok ()
  else Error (internal_error "Antigravity resumed flag differs from durable plan")
in
```

## 왜 — 양변이 같은 값에서 나옵니다

```
keeper_antigravity_runtime.ml:169   conversation_mode  ←  claim_plan.previous_settlement
keeper_antigravity_runtime.ml:175   is_resume          ←  claim_plan.previous_settlement
runtime_antigravity.ml:750          resumed            ←  conversation_mode
```

`turn.resumed` 는 provider 응답에서 파싱되지 않습니다. `runtime_antigravity` 가 masc 가 넘긴 `conversation_mode` 로 다시 계산하고, 그 파라미터는 `run_turn` 을 지나는 동안 재바인딩되지 않습니다(`rg 'conversation_mode' lib/runtime/runtime_antigravity.ml` 15곳 전부 파라미터 전달·판독).

따라서 `is_resume = turn.resumed` 는 구성상 항상 참이고, 그 `internal_error` 는 도달 불가능합니다.

## 등가 통제 — 지우는 게 아니라 이미 더 강한 게 있습니다

이 게이트가 지키는 것처럼 보였던 불변식은 **provider 가 실제로 보고하는 값**에 대해 다른 곳에서 강제됩니다.

```ocaml
(* runtime_antigravity.ml:566 — init 이벤트의 conversation_id 와 비교 *)
verify_identity ~expected:(expected_conversation_id conversation_mode) conversation_id
```

이쪽이 더 강합니다. 지워지는 게이트는 "start 를 계획했는데 resume 했나"만 보지만, 이 검사는 **다른 대화를 resume 했나**까지 거부합니다.

## 뮤테이션 — 살아남는 통제가 배선돼 있는지 증명

삭제 PR 이라 뮤테이션 방향이 반대입니다. 새 테스트가 빨개지는 걸 보이는 대신, **남는 통제를 깨뜨려** 그게 진짜인지 봤습니다.

`verify_identity` 의 mismatch 분기를 `false &&` 로 막았을 때:

```
[FAIL]  stream-json  3  resume mismatch.
```

되돌리면:

```
Test Successful in 3.309s. 16 tests run.
```

`test_resume_identity_mismatch_fails_closed` 는 `Ok _` 를 `"resume admitted a different conversation"` 으로 실패시킵니다 — 통과를 성공 조건으로 삼지 않습니다.

## 검증

```
dune build @check                        clean
test_runtime_antigravity                 16 tests, Test Successful
test_keeper_antigravity_runtime          Test Successful
ocamlformat --check (변경 파일)          clean
```

`dune build @fmt` 는 exit 1 이지만 **main 에서도 동일**하고(대조군 실행 확인), 그 diff 는 `test/dune` 의 include stanza 간격이며 제 변경 파일과 무관합니다.

RFC-WAIVED: 도달 불가능한 분기 하나를 삭제합니다. `keeper_antigravity_runtime.ml` 은 RFC 게이트 대상(credential / repo_manager / operator_control / sandbox / hooks) 어디에도 속하지 않고, 동작·설정·durable 스키마를 바꾸지 않습니다.

Closes #28057

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
