### PR TITLE
fix(dashboard): runtime_liveness must require a recent turn, not a lifetime counter

### DIFF
--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -157,16 +157,48 @@ let meta_counter_feature
     ~next_action
     eligible_snapshots
 
-let runtime_liveness_feature snapshots =
+let timestamp_within_window ?window_hours ~now ts =
+  (* Reject zero/negative timestamps (marker/unset) and future timestamps
+     (clock skew or corrupted logs). Without the [ts <= now] guard, any
+     future timestamp would satisfy the recency check because [now -. ts]
+     would be negative and trivially [<= hours *. 3600.0]. *)
+  ts > 0.0
+  && ts <= now
+  &&
+  match window_hours with
+  | None -> true
+  | Some hours when hours <= 0.0 ->
+    (* Non-positive window is treated as "no recency check": flipping it
+       to a hard reject would silently disqualify all past evidence. The
+       top-level [json] helper clamps callers' inputs to a sane domain;
+       this keeps internal logic robust if a caller bypasses the boundary. *)
+    true
+  | Some hours -> now -. ts <= hours *. Masc_time_constants.hour
+
+let runtime_liveness_feature ~now snapshots =
   meta_counter_feature snapshots
     ~id:"runtime_liveness"
     ~label:"Persisted keeper runtime turns"
     ~eligible:(fun _snapshot -> true)
-    ~predicate:(fun meta -> meta.runtime.usage.total_turns > 0)
-    ~summary_label:"keepers have persisted runtime turns"
+    ~predicate:(fun meta ->
+       (* A lifetime counter latches: once [total_turns] passes zero it stays
+          positive for the rest of the keeper's life, so a counter-only
+          predicate reports a stopped keeper as live forever. This feature is
+          named liveness, so it also requires the last persisted turn to be
+          recent, using the same window as [persistent_24h_turn_exchange]. *)
+       meta.runtime.usage.total_turns > 0
+       && timestamp_within_window
+            ~window_hours:Decision.recent_turn_max_age_hours
+            ~now
+            meta.runtime.usage.last_turn_ts)
+    ~summary_label:
+      (Printf.sprintf
+         "keepers have persisted runtime turns with a latest turn <= %.1fh old"
+         Decision.recent_turn_max_age_hours)
     ~evidence_refs:[keeper_meta_evidence; route_evidence "/api/v1/dashboard/execution"]
     ~next_action:
-      "Resume or repair keepers without persisted turns before claiming fleet-wide autonomy."
+      "Resume or repair keepers without recent persisted turns before claiming \
+       fleet-wide autonomy."
 
 let persistent_turn_exchange_feature ~config ~now snapshots =
   let stats =
@@ -265,24 +297,6 @@ let board_reactive_feature snapshots =
     ~evidence_refs:[keeper_meta_evidence; route_evidence "/api/v1/dashboard/board"]
     ~next_action:
       "Post board events and confirm every active keeper records board-reactive turns."
-
-let timestamp_within_window ?window_hours ~now ts =
-  (* Reject zero/negative timestamps (marker/unset) and future timestamps
-     (clock skew or corrupted logs). Without the [ts <= now] guard, any
-     future timestamp would satisfy the recency check because [now -. ts]
-     would be negative and trivially [<= hours *. 3600.0]. *)
-  ts > 0.0
-  && ts <= now
-  &&
-  match window_hours with
-  | None -> true
-  | Some hours when hours <= 0.0 ->
-    (* Non-positive window is treated as "no recency check": flipping it
-       to a hard reject would silently disqualify all past evidence. The
-       top-level [json] helper clamps callers' inputs to a sane domain;
-       this keeps internal logic robust if a caller bypasses the boundary. *)
-    true
-  | Some hours -> now -. ts <= hours *. Masc_time_constants.hour
 
 let scheduled_proactive_feature ~config ?window_hours ~now snapshots =
   let decision_stats =
@@ -439,7 +453,7 @@ let json ~config ?window_hours ?now () =
   let snapshots = load_keeper_snapshots config in
   let features =
     [
-      runtime_liveness_feature snapshots;
+      runtime_liveness_feature ~now snapshots;
       persistent_turn_exchange_feature ~config ~now snapshots;
       autonomous_tool_feature snapshots;
       board_reactive_feature snapshots;

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -90,6 +90,7 @@ normal_targets=(
   @test/runtest-test_official_client_session_store
   @test/runtest-test_runtime_claude_code
   @test/runtest-test_runtime_claude_code_config
+  @test/runtest-test_dashboard_keeper_feature_proof
   @test/runtest-test_keeper_antigravity_runtime
   @test/runtest-test_keeper_claude_code_runtime
   @test/runtest-test_server_dashboard_official_client_probe

--- a/test/dune
+++ b/test/dune
@@ -1966,6 +1966,7 @@
 (include stanzas/test_runtime_antigravity_home.inc)
 (include stanzas/test_runtime_official_client_mcp_http.inc)
 (include stanzas/test_runtime_claude_code_config.inc)
+(include stanzas/test_dashboard_keeper_feature_proof.inc)
 (include stanzas/test_keeper_antigravity_runtime.inc)
 (include stanzas/test_keeper_claude_code_runtime.inc)
 (include stanzas/test_server_dashboard_official_client_probe.inc)

--- a/test/stanzas/test_dashboard_keeper_feature_proof.inc
+++ b/test/stanzas/test_dashboard_keeper_feature_proof.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_dashboard_keeper_feature_proof)
+ (modules test_dashboard_keeper_feature_proof)
+ (libraries masc masc_dashboard masc_test_deps))

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -1,0 +1,185 @@
+(* Feature-proof gates read persisted keeper counters. [total_turns] is a
+   lifetime counter, so a counter-only predicate latches: once a keeper takes
+   its first turn the gate reports it forever, including after the keeper
+   stops. These tests pin the recency requirement that separates a keeper
+   taking turns now from one that took turns once. *)
+
+open Alcotest
+module U = Yojson.Safe.Util
+module Keeper_meta_contract = Masc.Keeper_meta_contract
+module Keeper_meta_store = Masc.Keeper_meta_store
+module Keeper_owner_registry = Masc.Keeper_owner_registry
+module Feature_proof = Dashboard_keeper_feature_proof
+
+let () = ignore Operator_tool.force_link
+
+(* Matches Dashboard_keeper_decision_log_proof.recent_turn_max_age_hours. The
+   test states the boundary it exercises rather than importing it, so a silent
+   widening of the production window fails here instead of following along. *)
+let recent_window_hours = 24.0
+let hour_seconds = 3600.0
+let now = 1_800_000_000.0
+
+let temp_dir () =
+  let path = Filename.temp_file "dashboard_feature_proof_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path
+    then
+      if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path)
+      else Sys.remove path
+  in
+  match rm dir with
+  | () -> ()
+  | exception Sys_error msg -> fail ("rm_rf failed: " ^ msg)
+;;
+
+let with_workspace f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  let config = Workspace_core.default_config dir in
+  ignore (Workspace_core.init config ~agent_name:(Some "test"));
+  (match Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+   | Ok _ -> ()
+   | Error error ->
+     fail
+       ("owner inventory install failed: "
+        ^ Keeper_owner_registry.install_error_to_string error));
+  f config
+;;
+
+(* Both keepers have taken turns, so [total_turns > 0] holds for both. They
+   differ only in when the last turn landed. *)
+let seed_keeper config ~name ~last_turn_ts =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
+      ; "trace_id", `String ("trace-" ^ name)
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Error err -> failf "meta fixture failed for %s: %s" name err
+  | Ok meta ->
+    let meta =
+      Keeper_meta_contract.map_usage
+        (fun usage -> { usage with total_turns = 5; last_turn_ts })
+        meta
+    in
+    (match Keeper_meta_store.replace_snapshot config meta with
+     | Ok () -> ()
+     | Error err -> failf "replace_snapshot failed for %s: %s" name err)
+;;
+
+let feature_by_id payload id =
+  payload
+  |> U.member "features"
+  |> U.to_list
+  |> List.find_opt (fun feature -> U.member "id" feature |> U.to_string = id)
+  |> function
+  | Some feature -> feature
+  | None -> failf "feature %s absent from payload" id
+;;
+
+let keeper_names feature key =
+  feature
+  |> U.member "keeper_evidence"
+  |> U.member key
+  |> U.to_list
+  |> List.map U.to_string
+  |> List.sort compare
+;;
+
+let test_stale_keeper_fails_runtime_liveness () =
+  with_workspace
+  @@ fun config ->
+  seed_keeper config ~name:"fresh" ~last_turn_ts:(now -. hour_seconds);
+  seed_keeper
+    config
+    ~name:"stale"
+    ~last_turn_ts:(now -. ((recent_window_hours +. 2.0) *. hour_seconds));
+  let payload = Feature_proof.json ~config ~now () in
+  let feature = feature_by_id payload "runtime_liveness" in
+  check
+    (list string)
+    "only the recently active keeper is observed"
+    [ "fresh" ]
+    (keeper_names feature "observed_keepers");
+  check
+    (list string)
+    "the stopped keeper is reported missing"
+    [ "stale" ]
+    (keeper_names feature "missing_keepers");
+  check
+    string
+    "a partially live fleet does not pass"
+    "warn"
+    (U.member "status" feature |> U.to_string)
+;;
+
+(* Guards the boundary from the other side: without this, a predicate that
+   rejected every keeper would also satisfy the test above. *)
+let test_recent_keeper_passes_runtime_liveness () =
+  with_workspace
+  @@ fun config ->
+  seed_keeper config ~name:"fresh" ~last_turn_ts:(now -. hour_seconds);
+  let payload = Feature_proof.json ~config ~now () in
+  let feature = feature_by_id payload "runtime_liveness" in
+  check
+    (list string)
+    "the recently active keeper is observed"
+    [ "fresh" ]
+    (keeper_names feature "observed_keepers");
+  check
+    string
+    "a fully live fleet passes"
+    "pass"
+    (U.member "status" feature |> U.to_string)
+;;
+
+(* A keeper that never took a turn has no timestamp to be recent about. It must
+   fail on the counter, not be admitted by a permissive timestamp branch. *)
+let test_keeper_without_turns_fails_runtime_liveness () =
+  with_workspace
+  @@ fun config ->
+  seed_keeper config ~name:"idle" ~last_turn_ts:0.0;
+  let payload = Feature_proof.json ~config ~now () in
+  let feature = feature_by_id payload "runtime_liveness" in
+  check
+    (list string)
+    "a keeper with no turns is not observed"
+    []
+    (keeper_names feature "observed_keepers");
+  check
+    string
+    "a fleet with no live keeper fails"
+    "fail"
+    (U.member "status" feature |> U.to_string)
+;;
+
+let () =
+  run
+    "dashboard_keeper_feature_proof"
+    [ ( "runtime_liveness"
+      , [ test_case "stale keeper fails" `Quick test_stale_keeper_fails_runtime_liveness
+        ; test_case "recent keeper passes" `Quick test_recent_keeper_passes_runtime_liveness
+        ; test_case
+            "keeper without turns fails"
+            `Quick
+            test_keeper_without_turns_fails_runtime_liveness
+        ] )
+    ]
+;;

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -27,21 +27,6 @@ let temp_dir () =
   path
 ;;
 
-let rm_rf dir =
-  let rec rm path =
-    if Sys.file_exists path
-    then
-      if Sys.is_directory path
-      then (
-        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
-        Unix.rmdir path)
-      else Sys.remove path
-  in
-  match rm dir with
-  | () -> ()
-  | exception Sys_error msg -> fail ("rm_rf failed: " ^ msg)
-;;
-
 let with_workspace f =
   Eio_main.run
   @@ fun env ->
@@ -49,7 +34,12 @@ let with_workspace f =
   let dir = temp_dir () in
   Eio.Switch.run
   @@ fun sw ->
-  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  (* Masc_test_deps.cleanup_test_workspace, not a local rm_rf: it stats with
+     Unix.lstat, so a symlink is unlinked rather than followed. A local rm_rf
+     built on Sys.file_exists reads a dangling link as absent, skips it, and
+     leaves the parent non-empty for rmdir (#26648, fixed for the shared
+     helper by #26652). *)
+  Eio.Switch.on_release sw (fun () -> Masc_test_deps.cleanup_test_workspace dir);
   let config = Workspace_core.default_config dir in
   ignore (Workspace_core.init config ~agent_name:(Some "test"));
   (match Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with


### PR DESCRIPTION
## 무엇을

`runtime_liveness` 가 생애 누적 카운터만 보던 것을 **최근 턴**까지 요구하도록 바꾸고, 이 모듈의 **첫 테스트**를 붙입니다.

```ocaml
(* 전 *)
~predicate:(fun meta -> meta.runtime.usage.total_turns > 0)

(* 후 *)
~predicate:(fun meta ->
   meta.runtime.usage.total_turns > 0
   && timestamp_within_window
        ~window_hours:Decision.recent_turn_max_age_hours
        ~now
        meta.runtime.usage.last_turn_ts)
```

## 왜 — 래치되는 술어는 정지를 못 봅니다

`total_turns` 는 생애 누적입니다. keeper 가 **첫 턴을 넘기는 순간 참이 되고 그 뒤로 영원히 참**입니다. 그래서 이 술어는 *지금 턴을 돌리는 keeper* 와 *한 번 돌리고 멈춘 keeper* 를 원리적으로 구별할 수 없습니다. #27947 이 기록한 실측은 26시간 정지한 keeper 가 이름이 liveness 인 게이트를 통과한 것입니다.

창은 새로 만들지 않고 `Decision.recent_turn_max_age_hours` 를 씁니다 — `persistent_24h_turn_exchange` 가 이미 쓰는 값이라 두 recency 기능이 "최근"의 정의를 공유합니다. 매직 넘버가 늘지 않습니다.

`timestamp_within_window` 는 기존 헬퍼를 재사용합니다. unset(0)·미래 timestamp 를 통과시키지 않는 가드가 이미 그 안에 있습니다.

## 이 모듈엔 테스트가 0개였습니다

`.mli` 는 `?now` 를 **"deterministic tests 용"** 이라고 노출해 놓았는데, 그 이음매를 쓰는 테스트가 하나도 없었습니다. 첫 테스트를 붙입니다.

| 케이스 | 입력 | 기대 |
|---|---|---|
| stale keeper fails | 마지막 턴 26h 전, `total_turns=5` | missing, `warn` |
| **recent keeper passes** | 마지막 턴 1h 전 | observed, `pass` |
| keeper without turns fails | `last_turn_ts=0` | missing, `fail` |

두 번째가 **대조군**입니다. 모든 keeper 를 거부하는 술어도 첫 번째 케이스는 만족시키므로, 이게 없으면 테스트가 방향을 못 잡습니다.

## 뮤테이션

술어를 원래(카운터 전용)로 되돌렸을 때:

```
[FAIL]  stale keeper fails
[OK]    recent keeper passes      ← 대조군 유지
[FAIL]  keeper without turns fails
```

되돌리면 3/3 green.

## CI 배선

이 저장소는 새 스위트가 **안 도는 상태로 태어나는** 경향이 있어(`audit-ci-test-targets.sh` 의 `UNWIRED_BASELINE=680`), `scripts/ci-run-focused-tests.sh` 에 등록했습니다.

```
[ci-test-targets] OK - 177 CI targets, all declared in Dune
[ci-test-targets] OK - 680 suites unwired, at baseline
```

배선하지 않았다면 681 이 되어 이 검사가 FAIL 합니다.

## 범위 — 나머지 두 게이트는 건드리지 않았습니다

#27947 은 `autonomous_tool_use` 와 `board_reactive_autonomy` 도 같은 카운터 술어라고 지적합니다. 사실입니다. 다만 그 둘은 이름이 liveness 를 주장하지 않고, "이 keeper 가 자율 도구 사용을 **보인 적이 있는가**"라는 능력 증명으로 읽는 게 타당할 수 있습니다. 의미를 조용히 바꾸는 대신 이름과 의미가 명백히 어긋나는 `runtime_liveness` 만 고쳤습니다. 나머지 판단은 이슈에 남깁니다 — 그래서 `Closes` 가 아니라 `Refs` 입니다.

## 검증

```
dune build @check                     clean (exit 0)
test_dashboard_keeper_feature_proof   3 tests, Test Successful
audit-ci-test-targets.sh              OK, 680 unwired, at baseline
ocamlformat --check                   변경된 두 OCaml 파일 clean
```

RFC-WAIVED: dashboard read-model 술어 하나를 좁히고 테스트를 추가합니다. RFC 게이트 대상(credential / repo_manager / operator_control / keeper sandbox / dashboard credential component / hooks) 어디에도 속하지 않고, durable 스키마나 설정을 바꾸지 않습니다.

Refs #27947

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
