### PR TITLE
fix(test): drop the duplicate test_env_keeper_scrub modules entry

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -613,7 +613,6 @@
   test_blocker_class_exhaustiveness
   test_workspace_goal_index
   test_log_severity_outcome_level
-  test_env_keeper_scrub
   test_relation_materializer
   test_keeper_wire_capture
   test_board_rest_routes


### PR DESCRIPTION
## 무엇을

`test/dune` 의 같은 `(modules)` 목록에 두 번 들어간 `test_env_keeper_scrub` 항목 하나를 지웁니다. 1줄 삭제입니다.

## 왜 — 같은 stanza 안의 중복입니다

이슈가 지목한 줄 번호(333, 625)는 드리프트했고 현재는 330·616 입니다. 지우기 전에 **세 등장이 같은 stanza 소속인지** 괄호 깊이로 확인했습니다.

```
line 316: stanza starts line 28 -> '(tests'     ← (names 안. 정당한 선언
line 330: stanza starts line 28 -> '(tests'     ← (modules 안
line 616: stanza starts line 28 -> '(tests'     ← (modules 안. 중복
```

`(names)` 1회 + `(modules)` 1회는 정상 형태이고, `(modules)` 안의 두 번째 등장만 잉여입니다. 만약 616 이 다른 stanza 의 `(modules)` 였다면 삭제가 그 stanza 를 깼을 텐데, 깊이 분석상 line 28 의 한 stanza 가 616 을 포함합니다.

## 이것 하나뿐입니다

이슈가 지목한 항목만 고치면 같은 변환을 다른 사이트에 남기는 형태가 되므로, 전체를 셌습니다.

```
모든 (names) / (modules) 블록 중복 스캔 → 남은 중복 총계: 0
```

다른 중복이 없으므로 이 PR 이 결함 전체입니다.

## 검증

```
dune build test/test_env_keeper_scrub.exe   clean
test_env_keeper_scrub                       7 tests, Test Successful
```

중복 자체는 dune 이 에러로 잡지 않아 빌드는 전에도 통과했습니다. 이 변경은 동작을 바꾸지 않고 선언을 정리합니다 — 그 이상을 주장하지 않겠습니다.

RFC-WAIVED: 빌드 설정 파일에서 잉여 항목 1줄을 삭제합니다. RFC 게이트 대상 subsystem 이 아니고 동작·durable 스키마를 바꾸지 않습니다.

Closes #26658

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
