### PR TITLE
ci: run the compaction exact-output conformance suite

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=680
+UNWIRED_BASELINE=679
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -93,6 +93,7 @@ normal_targets=(
   @test/runtest-test_keeper_antigravity_runtime
   @test/runtest-test_keeper_claude_code_runtime
   @test/runtest-test_server_dashboard_official_client_probe
+  @test/runtest-test_compaction_exact_output_conformance
   @test/runtest-test_host_fd_pressure_poller
   @test/runtest-test_keeper_turn_driver_failover
   @test/runtest-test_keeper_turn_driver_accept


### PR DESCRIPTION
## 무엇을

`test_compaction_exact_output_conformance` 를 CI 실행 대상에 넣고, `UNWIRED_BASELINE` 을 680 → 679 로 내립니다.

## 왜 — 컴파일만 되고 실행되지 않던 스위트입니다

`#25994` (런타임 3건 실패) 와 `#26013` (컴파일 실패) 이 이 스위트를 가리킵니다. 두 증상 모두 지금은 없습니다.

```
dune build test/test_compaction_exact_output_conformance.exe   exit 0
dune exec  test/test_compaction_exact_output_conformance.exe   13 tests, Test Successful
```

`#26013` 이 인용한 `"heartbeat guard binds before POST"` test_case 는 현재 파일에 없습니다(제거됨).

그런데 **어떤 CI 타깃도 이 스위트를 실행하지 않았습니다.** `audit-ci-test-targets.sh` 가 그 상태를 이렇게 부릅니다.

> A suite outside the CI manifests is compile-only: it never executes, so its assertions can outlive the code they pin.

증상이 사라진 것과 재발이 잡히는 것은 다릅니다. 배선하지 않고 두 이슈를 닫으면, 다음에 같은 실패가 생겨도 이번과 똑같이 아무도 모릅니다.

## 지금 배선이 안전한 이유

**초록일 때만 배선합니다.** 빨간 스위트를 CI 에 넣으면 main 이 빨개집니다. 이 스위트는 이 커밋 기준 13/13 통과이고, CI 가 실제로 실행할 형태(별칭)로 확인했습니다.

```
$ dune build @test/runtest-test_compaction_exact_output_conformance
Test Successful in 3.066s. 13 tests run.
alias exit=0
```

`.exe` 직접 실행이 아니라 `@test/runtest-<name>` 별칭으로 확인한 것이 요점입니다 — 배선이 가리키는 것이 그 별칭입니다.

## baseline 을 내리는 이유

배선만 하고 baseline 을 그대로 두면 다음 스위트가 배선 해제돼도 679 → 680 이 baseline 이하라 통과합니다. 즉 **이득이 고정되지 않습니다.** 스크립트가 그 지시를 직접 출력합니다.

```
[ci-test-targets] OK - 679 suites unwired, 680 baseline — lower UNWIRED_BASELINE in scripts/audit-ci-test-targets.sh to hold the gain
```

내린 뒤:

```
[ci-test-targets] OK - 679 suites unwired, at baseline
```

## 뮤테이션

배선 줄을 지우면 ratchet 이 잡습니다.

```
exit 2
FAIL - 680 suites are declared but never run in CI (baseline 679)
```

복원하면 `exit 0`. 처음에 `... | tail -3` 뒤의 `$?` 로 재서 `exit=0` 을 봤는데 그건 `tail` 의 종료코드였습니다 — 파이프 없이 다시 재서 `exit 2` 를 확인했습니다.

## 검증

```
dune build @test/runtest-test_compaction_exact_output_conformance   13 tests, Test Successful
audit-ci-test-targets.sh                                            OK, 679 at baseline
audit-ci-test-targets.sh (배선 제거 시)                              exit 2, FAIL
```

RFC-WAIVED: 이미 초록인 테스트 스위트를 CI 실행 목록에 추가하고 ratchet baseline 을 1 내립니다. 프로덕션 코드·durable 스키마·설정을 바꾸지 않고, RFC 게이트 대상 subsystem 이 아닙니다.

Closes #25994
Closes #26013

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
