### PR TITLE
feat(credential): read a gh auth status verdict, including the shadow case (RFC-0369 §1)

### DIFF
--- a/docs/rfc/RFC-0369-keeper-credential-surface-observability.md
+++ b/docs/rfc/RFC-0369-keeper-credential-surface-observability.md
@@ -56,10 +56,18 @@ outside exec/Gate:
   what that keeper's shell would actually resolve — including the case where
   a host-keyring credential is shadowed by a projected `GH_TOKEN`, the
   documented `gh` footgun where `gh auth refresh` silently no-ops.
+  Measured on gh 2.87.3, shadowing takes two shapes: `GITHUB_TOKEN` leaves the
+  keyring row `✓` with `Active account: false`, while `GH_TOKEN` marks the
+  config entry `X`. Both are `Shadowed` — routing the second to
+  `unauthenticated` would send the operator to a no-op `gh auth login`.
 - Read surface: `GET /api/v1/keepers/:name/credential-surface` returning
   `{schema, host, status: authenticated | unauthenticated | shadowed |
   unknown, account?, token_source?, scopes?, probed_at, next_action}` — never
   a token value, and the store stays write-only as today.
+  `token_source?` is the label gh itself prints — `keyring`, or the shadowing
+  variable's own name (`GH_TOKEN`, `GITHUB_TOKEN`, …) so `next_action` can
+  name exactly what to unset. Parsed as `Keyring | Environment of string`,
+  never collapsed to a bare `env`.
 - Dashboard: a credential card on the keeper detail panel rendering exactly
   those fields, with a manual re-probe action.
 - Probe budget: results are cached with a TTL (default 10 minutes) and a
@@ -92,6 +100,9 @@ against the pinned gh version.
 
 - Unit: parser fixtures for keyring/env/shadowed/GHES-host outputs, including
   future-unknown labels mapping to `Unknown`.
+- The probe never reads `gh auth status`'s exit code as a verdict: a healthy
+  keyring shadowed by an invalid env token exits 1 exactly like a logged-out
+  host; only per-entry marks and labels decide.
 - Integration: probe under a projected fake `GH_TOKEN` reports `env` source;
   probe with an empty projection on a logged-in host reports `keyring`.
 - E2E completion bar (per the audit's production-use standard): the verdict

--- a/docs/rfc/RFC-0369-keeper-credential-surface-observability.md
+++ b/docs/rfc/RFC-0369-keeper-credential-surface-observability.md
@@ -60,6 +60,11 @@ outside exec/Gate:
   keyring row `✓` with `Active account: false`, while `GH_TOKEN` marks the
   config entry `X`. Both are `Shadowed` — routing the second to
   `unauthenticated` would send the operator to a no-op `gh auth login`.
+  A third shape needs no failure at all: a valid env token over a logged-in
+  keyring renders both rows `✓`, yet the stored credential is not what
+  authenticates. This is why the verdict keys on the env row's presence beside
+  a stored credential — gh reads the variable before the keyring — and not on
+  any per-row mark or `Active` flag.
 - Read surface: `GET /api/v1/keepers/:name/credential-surface` returning
   `{schema, host, status: authenticated | unauthenticated | shadowed |
   unknown, account?, token_source?, scopes?, probed_at, next_action}` — never

--- a/docs/rfc/RFC-0369-keeper-credential-surface-observability.md
+++ b/docs/rfc/RFC-0369-keeper-credential-surface-observability.md
@@ -8,7 +8,7 @@ author: vincent + claude
 supersedes: []
 superseded_by: null
 related: ["0312", "0343"]
-implementation_prs: []
+implementation_prs: ["28133"]
 ---
 
 # RFC-0369: Keeper credential-surface observability for repo-hosting CLIs

--- a/lib/credential_observation/dune
+++ b/lib/credential_observation/dune
@@ -1,0 +1,20 @@
+; Credential_observation — reads a repo-hosting CLI's own status output and
+; reports what that credential surface resolves to (RFC-0369).
+;
+; Deliberately outside exec, Gate, and policy: those layers must not know a
+; particular CLI or credential scheme (INV-KEEPER-008, the reason RFC-0309 was
+; withdrawn). This library observes and never acts, so it depends on nothing
+; but string utilities.
+;
+; (include_subdirs no) opts out of the parent's (include_subdirs unqualified).
+
+(include_subdirs no)
+
+(library
+ (name masc_credential_observation)
+ (public_name masc.credential_observation)
+ (wrapped false)
+ (modules gh_auth_status)
+ (flags
+  (:standard -w +4 -w +33))
+ (libraries masc_core))

--- a/lib/credential_observation/gh_auth_status.ml
+++ b/lib/credential_observation/gh_auth_status.ml
@@ -1,0 +1,282 @@
+type token_source =
+  | Keyring
+  | Environment of string
+  | Config_default
+  | Other_source of string
+
+type outcome =
+  | Logged_in
+  | Login_failed
+
+type entry =
+  { outcome : outcome
+  ; host : string
+  ; account : string option
+  ; source : token_source
+  ; active : bool option
+  ; scopes : string list option
+  }
+
+type verdict =
+  | Authenticated
+  | Unauthenticated
+  | Shadowed
+  | Unknown
+
+type t =
+  { entries : entry list
+  ; verdict : verdict
+  }
+
+let logged_in_mark = "\xe2\x9c\x93 "
+let failed_mark = "X "
+let no_hosts_sentence = "You are not logged into any GitHub hosts"
+let logged_in_prefix = "Logged in to "
+let failed_prefix = "Failed to log in to "
+let account_keyword = "account"
+let using_token_keyword = "using"
+let active_account_label = "Active account:"
+let token_scopes_label = "Token scopes:"
+
+let verdict_to_string = function
+  | Authenticated -> "authenticated"
+  | Unauthenticated -> "unauthenticated"
+  | Shadowed -> "shadowed"
+  | Unknown -> "unknown"
+;;
+
+let token_source_to_string = function
+  | Keyring -> "keyring"
+  | Environment name -> name
+  | Config_default -> "default"
+  | Other_source label -> label
+;;
+
+(* The recognised set is explicit so a label gh adds later becomes
+   [Other_source] and stays visible, rather than collapsing into one of the
+   sources the verdict depends on. *)
+let token_source_of_label label =
+  match label with
+  | "keyring" -> Keyring
+  | "default" -> Config_default
+  | "GH_TOKEN" | "GITHUB_TOKEN" | "GH_ENTERPRISE_TOKEN" | "GITHUB_ENTERPRISE_TOKEN" ->
+    Environment label
+  | _ -> Other_source label
+;;
+
+(* gh closes an entry line with the source in parentheses. Read the last pair
+   so an account name containing parentheses cannot capture the label. *)
+let split_trailing_parens text =
+  let length = String.length text in
+  if length = 0 || text.[length - 1] <> ')'
+  then None
+  else (
+    let rec find_open index =
+      if index < 0
+      then None
+      else if text.[index] = '('
+      then Some index
+      else find_open (index - 1)
+    in
+    match find_open (length - 2) with
+    | None -> None
+    | Some open_index ->
+      let head = String.trim (String.sub text 0 open_index) in
+      let label = String.sub text (open_index + 1) (length - open_index - 2) in
+      Some (head, label))
+;;
+
+let words text =
+  String.split_on_char ' ' text |> List.filter (fun word -> word <> "")
+;;
+
+(* "github.com account jeong-sik" -> host and account.
+   "github.com using token"       -> host, no account. *)
+let host_and_account head =
+  match words head with
+  | [] -> None
+  | host :: rest ->
+    let account =
+      match rest with
+      | keyword :: name :: _ when String.equal keyword account_keyword -> Some name
+      | keyword :: _ when String.equal keyword using_token_keyword -> None
+      | [] -> None
+      | _ -> None
+    in
+    Some (host, account)
+;;
+
+let parse_entry_line line =
+  let trimmed = String.trim line in
+  let outcome, body =
+    if String.starts_with ~prefix:logged_in_mark trimmed
+    then
+      ( Some Logged_in
+      , String.sub
+          trimmed
+          (String.length logged_in_mark)
+          (String.length trimmed - String.length logged_in_mark) )
+    else if String.starts_with ~prefix:failed_mark trimmed
+    then
+      ( Some Login_failed
+      , String.sub
+          trimmed
+          (String.length failed_mark)
+          (String.length trimmed - String.length failed_mark) )
+    else None, ""
+  in
+  match outcome with
+  | None -> None
+  | Some outcome ->
+    let remainder =
+      if String.starts_with ~prefix:logged_in_prefix body
+      then
+        Some
+          (String.sub
+             body
+             (String.length logged_in_prefix)
+             (String.length body - String.length logged_in_prefix))
+      else if String.starts_with ~prefix:failed_prefix body
+      then
+        Some
+          (String.sub
+             body
+             (String.length failed_prefix)
+             (String.length body - String.length failed_prefix))
+      else None
+    in
+    (match remainder with
+     | None -> None
+     | Some remainder ->
+       (match split_trailing_parens remainder with
+        | None -> None
+        | Some (head, label) ->
+          (match host_and_account head with
+           | None -> None
+           | Some (host, account) ->
+             Some
+               { outcome
+               ; host
+               ; account
+               ; source = token_source_of_label label
+               ; active = None
+               ; scopes = None
+               })))
+;;
+
+let parse_detail_line line =
+  let trimmed = String.trim line in
+  if not (String.starts_with ~prefix:"- " trimmed)
+  then None
+  else (
+    let body =
+      String.trim (String.sub trimmed 2 (String.length trimmed - 2))
+    in
+    if String.starts_with ~prefix:active_account_label body
+    then (
+      let value =
+        String.trim
+          (String.sub
+             body
+             (String.length active_account_label)
+             (String.length body - String.length active_account_label))
+      in
+      match value with
+      | "true" -> Some (`Active true)
+      | "false" -> Some (`Active false)
+      | _ -> None)
+    else if String.starts_with ~prefix:token_scopes_label body
+    then (
+      let value =
+        String.trim
+          (String.sub
+             body
+             (String.length token_scopes_label)
+             (String.length body - String.length token_scopes_label))
+      in
+      let scopes =
+        String.split_on_char ',' value
+        |> List.map (fun scope ->
+          String.trim scope
+          |> String.to_seq
+          |> Seq.filter (fun c -> c <> '\'')
+          |> String.of_seq
+          |> String.trim)
+        |> List.filter (fun scope -> scope <> "")
+      in
+      Some (`Scopes scopes))
+    else None)
+;;
+
+let apply_detail entry detail =
+  match detail with
+  | `Active value -> { entry with active = Some value }
+  | `Scopes scopes -> { entry with scopes = Some scopes }
+;;
+
+let collect_entries lines =
+  let flush current acc =
+    match current with
+    | None -> acc
+    | Some entry -> entry :: acc
+  in
+  let rec walk lines current acc =
+    match lines with
+    | [] -> List.rev (flush current acc)
+    | line :: rest ->
+      (match parse_entry_line line with
+       | Some entry -> walk rest (Some entry) (flush current acc)
+       | None ->
+         (match current, parse_detail_line line with
+          | Some entry, Some detail -> walk rest (Some (apply_detail entry detail)) acc
+          | _, _ -> walk rest current acc))
+  in
+  walk lines None []
+;;
+
+let is_environment_source = function
+  | Environment _ -> true
+  | Keyring | Config_default | Other_source _ -> false
+;;
+
+let verdict_of_entries entries =
+  let active_environment =
+    List.exists
+      (fun entry ->
+         is_environment_source entry.source
+         &&
+         match entry.active with
+         | Some true -> true
+         | Some false | None -> false)
+      entries
+  in
+  let has_non_environment =
+    List.exists (fun entry -> not (is_environment_source entry.source)) entries
+  in
+  let has_logged_in =
+    List.exists
+      (fun entry ->
+         match entry.outcome with
+         | Logged_in -> true
+         | Login_failed -> false)
+      entries
+  in
+  if active_environment && has_non_environment
+  then Shadowed
+  else if has_logged_in
+  then Authenticated
+  else Unauthenticated
+;;
+
+let parse output =
+  let lines = String.split_on_char '\n' output in
+  let entries = collect_entries lines in
+  match entries with
+  | _ :: _ -> { entries; verdict = verdict_of_entries entries }
+  | [] ->
+    if List.exists
+         (fun line -> String_util.contains_substring line no_hosts_sentence)
+         lines
+    then { entries = []; verdict = Unauthenticated }
+    else { entries = []; verdict = Unknown }
+;;

--- a/lib/credential_observation/gh_auth_status.ml
+++ b/lib/credential_observation/gh_auth_status.ml
@@ -239,16 +239,18 @@ let is_environment_source = function
   | Keyring | Config_default | Other_source _ -> false
 ;;
 
+(* Shadowing is decided by the presence of an environment-sourced row beside a
+   non-environment one, not by gh's "Active account" line. gh reads the
+   variable before any stored credential, so a row for it appearing at all
+   means that is the token in use. Every measured shape agrees — the
+   environment row is marked active in all four — but reading [active] here
+   would rest the verdict on a field never observed as [false] for that row,
+   and a future [false] would silently report Authenticated for a host whose
+   pushes go out under the variable. [active] stays on the record because the
+   endpoint reports it; it just does not decide. *)
 let verdict_of_entries entries =
-  let active_environment =
-    List.exists
-      (fun entry ->
-         is_environment_source entry.source
-         &&
-         match entry.active with
-         | Some true -> true
-         | Some false | None -> false)
-      entries
+  let has_environment =
+    List.exists (fun entry -> is_environment_source entry.source) entries
   in
   let has_non_environment =
     List.exists (fun entry -> not (is_environment_source entry.source)) entries
@@ -261,7 +263,7 @@ let verdict_of_entries entries =
          | Login_failed -> false)
       entries
   in
-  if active_environment && has_non_environment
+  if has_environment && has_non_environment
   then Shadowed
   else if has_logged_in
   then Authenticated

--- a/lib/credential_observation/gh_auth_status.ml
+++ b/lib/credential_observation/gh_auth_status.ml
@@ -2,7 +2,6 @@ type token_source =
   | Keyring
   | Environment of string
   | Config_default
-  | Other_source of string
 
 type outcome =
   | Logged_in
@@ -12,7 +11,8 @@ type entry =
   { outcome : outcome
   ; host : string
   ; account : string option
-  ; source : token_source
+  ; source_label : string
+  ; source : token_source option
   ; active : bool option
   ; scopes : string list option
   }
@@ -45,23 +45,17 @@ let verdict_to_string = function
   | Unknown -> "unknown"
 ;;
 
-let token_source_to_string = function
-  | Keyring -> "keyring"
-  | Environment name -> name
-  | Config_default -> "default"
-  | Other_source label -> label
-;;
-
-(* The recognised set is explicit so a label gh adds later becomes
-   [Other_source] and stays visible, rather than collapsing into one of the
-   sources the verdict depends on. *)
+(* A sound-partial read: [None] means this parser does not recognise the label,
+   not that the label is harmless. The verdict declines on [None] rather than
+   assuming a stored credential, because a label gh adds later could name a
+   variable, and treating that as stored would hide a shadow. *)
 let token_source_of_label label =
   match label with
-  | "keyring" -> Keyring
-  | "default" -> Config_default
+  | "keyring" -> Some Keyring
+  | "default" -> Some Config_default
   | "GH_TOKEN" | "GITHUB_TOKEN" | "GH_ENTERPRISE_TOKEN" | "GITHUB_ENTERPRISE_TOKEN" ->
-    Environment label
-  | _ -> Other_source label
+    Some (Environment label)
+  | _ -> None
 ;;
 
 (* gh closes an entry line with the source in parentheses. Read the last pair
@@ -158,6 +152,7 @@ let parse_entry_line line =
                { outcome
                ; host
                ; account
+               ; source_label = label
                ; source = token_source_of_label label
                ; active = None
                ; scopes = None
@@ -235,8 +230,14 @@ let collect_entries lines =
 ;;
 
 let is_environment_source = function
-  | Environment _ -> true
-  | Keyring | Config_default | Other_source _ -> false
+  | Some (Environment _) -> true
+  | Some Keyring | Some Config_default -> false
+  | None -> false
+;;
+
+let is_unrecognised_source = function
+  | None -> true
+  | Some (Environment _ | Keyring | Config_default) -> false
 ;;
 
 (* Shadowing is decided by the presence of an environment-sourced row beside a
@@ -247,7 +248,11 @@ let is_environment_source = function
    would rest the verdict on a field never observed as [false] for that row,
    and a future [false] would silently report Authenticated for a host whose
    pushes go out under the variable. [active] stays on the record because the
-   endpoint reports it; it just does not decide. *)
+   endpoint reports it; it just does not decide.
+
+   An unrecognised label short-circuits to [Unknown] before any of that: the
+   parser cannot tell whether it names a variable, and guessing "stored" would
+   report Authenticated for a shadowed host. *)
 let verdict_of_entries entries =
   let has_environment =
     List.exists (fun entry -> is_environment_source entry.source) entries
@@ -263,7 +268,9 @@ let verdict_of_entries entries =
          | Login_failed -> false)
       entries
   in
-  if has_environment && has_non_environment
+  if List.exists (fun entry -> is_unrecognised_source entry.source) entries
+  then Unknown
+  else if has_environment && has_non_environment
   then Shadowed
   else if has_logged_in
   then Authenticated

--- a/lib/credential_observation/gh_auth_status.mli
+++ b/lib/credential_observation/gh_auth_status.mli
@@ -8,7 +8,7 @@
     separate the cases this module exists to separate: a host whose keyring
     account is fine but whose active token comes from the environment exits 1,
     exactly like a host with no credential at all. The verdict comes from the
-    per-entry marks and source labels instead. *)
+    per-entry source labels instead. *)
 
 type token_source =
   | Keyring  (** gh printed [(keyring)]. *)
@@ -17,10 +17,6 @@ type token_source =
           [(GITHUB_TOKEN)]. The name is kept because it is what an operator has
           to unset. *)
   | Config_default  (** gh printed [(default)] — the on-disk config entry. *)
-  | Other_source of string
-      (** A label this parser does not recognise, kept verbatim. New gh labels
-          surface as drift rather than collapsing into one of the known
-          sources. *)
 
 type outcome =
   | Logged_in  (** gh marked the entry [✓]. *)
@@ -32,7 +28,14 @@ type entry =
   ; account : string option
       (** [None] for an environment token, which gh reports as
           "using token" with no account. *)
-  ; source : token_source
+  ; source_label : string
+      (** The label gh printed, verbatim, recognised or not. *)
+  ; source : token_source option
+      (** The interpretation of [source_label], or [None] when this parser does
+          not recognise it. A label gh adds later must not be assumed to be a
+          stored credential: if it names a variable, treating it as stored
+          would hide a shadow. So an unrecognised label is not interpreted at
+          all, and the verdict declines rather than guessing. *)
   ; active : bool option  (** [None] when gh printed no "Active account" line. *)
   ; scopes : string list option
       (** [None] when gh printed no scopes line, which is not the same as a
@@ -50,13 +53,15 @@ type verdict =
 
           Decided by the presence of the environment row, not by gh's "Active
           account" line and not by whether either credential is still valid.
-          All four measured shapes agree — an invalid variable over a valid
+          All three measured shapes agree — an invalid variable over a valid
           keyring, an invalid variable over an invalid config entry, and a
           perfectly valid variable over a valid keyring are all shadowed. *)
   | Unknown
       (** The output matched neither the "not logged into any host" sentence
-          nor any entry line. Never a stand-in for an authenticated or
-          unauthenticated verdict. *)
+          nor any entry line, or an entry carries a source label this parser
+          does not recognise. Never a stand-in for an authenticated or
+          unauthenticated verdict: an unreadable credential surface is
+          reported as unreadable. *)
 
 type t =
   { entries : entry list
@@ -68,4 +73,3 @@ val parse : string -> t
     Unknown }] rather than a default. *)
 
 val verdict_to_string : verdict -> string
-val token_source_to_string : token_source -> string

--- a/lib/credential_observation/gh_auth_status.mli
+++ b/lib/credential_observation/gh_auth_status.mli
@@ -43,11 +43,16 @@ type verdict =
   | Authenticated  (** At least one entry is logged in and none shadows it. *)
   | Unauthenticated  (** Parsed, and no entry is logged in. *)
   | Shadowed
-      (** An environment-sourced entry is the active one while the host also
-          carries a non-environment entry. gh resolves the environment token
-          first, so [gh auth login] and [gh auth refresh] silently no-op and
-          the operator's next action is to unset the variable, not to log in.
-          Reported whether or not the shadowed entry itself is still valid. *)
+      (** The host carries both an environment-sourced entry and a
+          non-environment one. gh resolves the environment token first, so
+          [gh auth login] and [gh auth refresh] silently no-op and the
+          operator's next action is to unset the variable, not to log in.
+
+          Decided by the presence of the environment row, not by gh's "Active
+          account" line and not by whether either credential is still valid.
+          All four measured shapes agree — an invalid variable over a valid
+          keyring, an invalid variable over an invalid config entry, and a
+          perfectly valid variable over a valid keyring are all shadowed. *)
   | Unknown
       (** The output matched neither the "not logged into any host" sentence
           nor any entry line. Never a stand-in for an authenticated or

--- a/lib/credential_observation/gh_auth_status.mli
+++ b/lib/credential_observation/gh_auth_status.mli
@@ -1,0 +1,66 @@
+(** Parse [gh auth status] output into a typed credential verdict.
+
+    This module is an observation of a product CLI, deliberately outside exec,
+    Gate, and policy (RFC-0369 §3; INV-KEEPER-008). It reads text only: it
+    spawns nothing, reads no environment, and never carries a token value.
+
+    The exit code is not an input. Measured against gh 2.87.3, it cannot
+    separate the cases this module exists to separate: a host whose keyring
+    account is fine but whose active token comes from the environment exits 1,
+    exactly like a host with no credential at all. The verdict comes from the
+    per-entry marks and source labels instead. *)
+
+type token_source =
+  | Keyring  (** gh printed [(keyring)]. *)
+  | Environment of string
+      (** gh printed the environment variable it read, e.g. [(GH_TOKEN)] or
+          [(GITHUB_TOKEN)]. The name is kept because it is what an operator has
+          to unset. *)
+  | Config_default  (** gh printed [(default)] — the on-disk config entry. *)
+  | Other_source of string
+      (** A label this parser does not recognise, kept verbatim. New gh labels
+          surface as drift rather than collapsing into one of the known
+          sources. *)
+
+type outcome =
+  | Logged_in  (** gh marked the entry [✓]. *)
+  | Login_failed  (** gh marked the entry [X]. *)
+
+type entry =
+  { outcome : outcome
+  ; host : string
+  ; account : string option
+      (** [None] for an environment token, which gh reports as
+          "using token" with no account. *)
+  ; source : token_source
+  ; active : bool option  (** [None] when gh printed no "Active account" line. *)
+  ; scopes : string list option
+      (** [None] when gh printed no scopes line, which is not the same as a
+          token with an empty scope set. *)
+  }
+
+type verdict =
+  | Authenticated  (** At least one entry is logged in and none shadows it. *)
+  | Unauthenticated  (** Parsed, and no entry is logged in. *)
+  | Shadowed
+      (** An environment-sourced entry is the active one while the host also
+          carries a non-environment entry. gh resolves the environment token
+          first, so [gh auth login] and [gh auth refresh] silently no-op and
+          the operator's next action is to unset the variable, not to log in.
+          Reported whether or not the shadowed entry itself is still valid. *)
+  | Unknown
+      (** The output matched neither the "not logged into any host" sentence
+          nor any entry line. Never a stand-in for an authenticated or
+          unauthenticated verdict. *)
+
+type t =
+  { entries : entry list
+  ; verdict : verdict
+  }
+
+val parse : string -> t
+(** Total over any input. Unrecognised text yields [{ entries = []; verdict =
+    Unknown }] rather than a default. *)
+
+val verdict_to_string : verdict -> string
+val token_source_to_string : token_source -> string

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -82,6 +82,7 @@ normal_targets=(
   @test/runtest-test_keeper_tool_call_log
   @test/runtest-test_keeper_wire_capture
   @test/runtest-test_runtime_provider_auth_headers
+  @test/runtest-test_gh_auth_status
   @test/runtest-test_keeper_official_client_host
   @test/runtest-test_runtime_codex_app_server
   @test/runtest-test_runtime_antigravity

--- a/test/dune
+++ b/test/dune
@@ -1747,6 +1747,8 @@
 
 (include stanzas/test_gate_protocol.inc)
 
+(include stanzas/test_gh_auth_status.inc)
+
 (include stanzas/test_git_fetch_retry_script.inc)
 
 (include stanzas/test_goal_phase_all.inc)

--- a/test/stanzas/test_gh_auth_status.inc
+++ b/test/stanzas/test_gh_auth_status.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_gh_auth_status)
+ (modules test_gh_auth_status)
+ (libraries alcotest masc.credential_observation masc_test_deps))

--- a/test/test_gh_auth_status.ml
+++ b/test/test_gh_auth_status.ml
@@ -48,6 +48,39 @@ let gh_token_shadow_output =
 |}
 ;;
 
+(* measured: a *valid* token in GITHUB_TOKEN over a logged-in host. Both rows
+   are ✓ and nothing is broken, yet the keyring credential is not the one in
+   use — the shape a verdict keyed on the logged-in mark would call
+   authenticated. *)
+let valid_env_token_shadow_output =
+  {|github.com
+  ✓ Logged in to github.com account jeong-sik (GITHUB_TOKEN)
+  - Active account: true
+  - Git operations protocol: https
+  - Token: gho_MASKED
+  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
+
+  ✓ Logged in to github.com account jeong-sik (keyring)
+  - Active account: false
+  - Git operations protocol: https
+  - Token: gho_MASKED
+  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
+|}
+;;
+
+(* constructed: gh 2.87.3 marked the environment row active in every measured
+   shape, so this one cannot be produced on the host. It exists to pin that the
+   verdict does not rest on that field. *)
+let inactive_env_row_output =
+  {|github.com
+  ✓ Logged in to github.com account octo (GITHUB_TOKEN)
+  - Active account: false
+
+  ✓ Logged in to github.com account octo (keyring)
+  - Active account: true
+|}
+;;
+
 (* measured: empty GH_CONFIG_DIR with both token variables cleared. *)
 let unauthenticated_output =
   {|You are not logged into any GitHub hosts. To log in, run: gh auth login
@@ -161,6 +194,48 @@ let test_gh_token_shadow_survives_both_entries_failing () =
   | entries -> failf "expected two entries, parsed %d" (List.length entries)
 ;;
 
+(* Nothing here is invalid. A verdict driven by the logged-in mark would call
+   this authenticated and hide that pushes go out under the variable. *)
+let test_valid_environment_token_still_shadows () =
+  let parsed = Gh_auth_status.parse valid_env_token_shadow_output in
+  check string "verdict" "shadowed" (verdict parsed);
+  List.iter
+    (fun entry ->
+       match entry.Gh_auth_status.outcome with
+       | Gh_auth_status.Logged_in -> ()
+       | Gh_auth_status.Login_failed -> fail "a measured-valid entry parsed as failed")
+    parsed.Gh_auth_status.entries;
+  match parsed.Gh_auth_status.entries with
+  | [ env_entry; _ ] ->
+    check
+      string
+      "environment variable is named"
+      "GITHUB_TOKEN"
+      (Gh_auth_status.token_source_to_string env_entry.Gh_auth_status.source)
+  | entries -> failf "expected two entries, parsed %d" (List.length entries)
+;;
+
+(* The verdict must not rest on gh's "Active account" line for the environment
+   row. Every measured shape marks it active, so a future [false] there would
+   otherwise report authenticated for a host whose pushes use the variable. *)
+let test_shadow_does_not_depend_on_the_active_line () =
+  let parsed = Gh_auth_status.parse inactive_env_row_output in
+  check string "verdict" "shadowed" (verdict parsed);
+  match parsed.Gh_auth_status.entries with
+  | [ env_entry; keyring_entry ] ->
+    check
+      (option bool)
+      "environment row is the inactive one"
+      (Some false)
+      env_entry.Gh_auth_status.active;
+    check
+      (option bool)
+      "keyring row is the active one"
+      (Some true)
+      keyring_entry.Gh_auth_status.active
+  | entries -> failf "expected two entries, parsed %d" (List.length entries)
+;;
+
 let test_no_hosts_is_unauthenticated () =
   let parsed = Gh_auth_status.parse unauthenticated_output in
   check string "verdict" "unauthenticated" (verdict parsed);
@@ -221,6 +296,14 @@ let () =
             "GH_TOKEN shadow survives both entries failing"
             `Quick
             test_gh_token_shadow_survives_both_entries_failing
+        ; test_case
+            "a valid environment token still shadows"
+            `Quick
+            test_valid_environment_token_still_shadows
+        ; test_case
+            "shadow does not depend on the active line"
+            `Quick
+            test_shadow_does_not_depend_on_the_active_line
         ; test_case "no hosts is unauthenticated" `Quick test_no_hosts_is_unauthenticated
         ; test_case
             "enterprise host is read verbatim"

--- a/test/test_gh_auth_status.ml
+++ b/test/test_gh_auth_status.ml
@@ -1,0 +1,236 @@
+open Alcotest
+
+(* Fixtures marked "measured" are verbatim `gh auth status` output from gh
+   2.87.3 (2026-02-23), token values masked. Fixtures marked "constructed"
+   follow the same grammar for a case the host could not be put into. *)
+
+(* measured: host keyring only. *)
+let keyring_output =
+  {|github.com
+  ✓ Logged in to github.com account jeong-sik (keyring)
+  - Active account: true
+  - Git operations protocol: https
+  - Token: gho_MASKED
+  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
+|}
+;;
+
+(* measured: GITHUB_TOKEN injected over a logged-in host. The keyring entry
+   stays valid and simply stops being the active one. *)
+let github_token_shadow_output =
+  {|github.com
+  X Failed to log in to github.com using token (GITHUB_TOKEN)
+  - Active account: true
+  - The token in GITHUB_TOKEN is invalid.
+
+  ✓ Logged in to github.com account jeong-sik (keyring)
+  - Active account: false
+  - Git operations protocol: https
+  - Token: gho_MASKED
+  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
+|}
+;;
+
+(* measured: GH_TOKEN injected over the same host. gh reports the config entry
+   as invalid too, so no entry is logged in — the verdict must still be
+   shadowed, because the fix is to unset the variable, not to log in. *)
+let gh_token_shadow_output =
+  {|github.com
+  X Failed to log in to github.com using token (GH_TOKEN)
+  - Active account: true
+  - The token in GH_TOKEN is invalid.
+
+  X Failed to log in to github.com account jeong-sik (default)
+  - Active account: false
+  - The token in default is invalid.
+  - To re-authenticate, run: gh auth login -h github.com
+  - To forget about this account, run: gh auth logout -h github.com -u jeong-sik
+|}
+;;
+
+(* measured: empty GH_CONFIG_DIR with both token variables cleared. *)
+let unauthenticated_output =
+  {|You are not logged into any GitHub hosts. To log in, run: gh auth login
+|}
+;;
+
+(* constructed: a GitHub Enterprise host, same grammar as the measured cases. *)
+let enterprise_output =
+  {|ghe.example.com
+  ✓ Logged in to ghe.example.com account octo (keyring)
+  - Active account: true
+  - Token scopes: 'repo'
+|}
+;;
+
+(* constructed: a source label this parser does not know. *)
+let future_label_output =
+  {|github.com
+  ✓ Logged in to github.com account octo (secure_enclave)
+  - Active account: true
+|}
+;;
+
+let verdict parsed = Gh_auth_status.verdict_to_string parsed.Gh_auth_status.verdict
+
+let single_entry parsed =
+  match parsed.Gh_auth_status.entries with
+  | [ entry ] -> entry
+  | entries ->
+    failf "expected exactly one entry, parsed %d" (List.length entries)
+;;
+
+let test_keyring_is_authenticated () =
+  let parsed = Gh_auth_status.parse keyring_output in
+  check string "verdict" "authenticated" (verdict parsed);
+  let entry = single_entry parsed in
+  check string "host" "github.com" entry.Gh_auth_status.host;
+  check (option string) "account" (Some "jeong-sik") entry.Gh_auth_status.account;
+  check
+    string
+    "source"
+    "keyring"
+    (Gh_auth_status.token_source_to_string entry.Gh_auth_status.source);
+  check (option bool) "active" (Some true) entry.Gh_auth_status.active;
+  check
+    (option (list string))
+    "scopes"
+    (Some [ "gist"; "read:org"; "repo"; "workflow" ])
+    entry.Gh_auth_status.scopes
+;;
+
+(* The keyring credential here is valid and would authenticate if the variable
+   were unset. A verdict driven by the logged-in mark alone would call this
+   authenticated and send the operator to `gh auth login`, which no-ops. *)
+let test_github_token_shadows_a_valid_keyring () =
+  let parsed = Gh_auth_status.parse github_token_shadow_output in
+  check string "verdict" "shadowed" (verdict parsed);
+  match parsed.Gh_auth_status.entries with
+  | [ env_entry; keyring_entry ] ->
+    check
+      string
+      "environment variable is named"
+      "GITHUB_TOKEN"
+      (Gh_auth_status.token_source_to_string env_entry.Gh_auth_status.source);
+    check
+      (option bool)
+      "environment entry is the active one"
+      (Some true)
+      env_entry.Gh_auth_status.active;
+    check (option string) "environment entry has no account" None env_entry.Gh_auth_status.account;
+    check
+      string
+      "keyring entry survives"
+      "keyring"
+      (Gh_auth_status.token_source_to_string keyring_entry.Gh_auth_status.source);
+    (match keyring_entry.Gh_auth_status.outcome with
+     | Gh_auth_status.Logged_in -> ()
+     | Gh_auth_status.Login_failed -> fail "keyring entry was reported as failed");
+    check
+      (option bool)
+      "keyring entry is not active"
+      (Some false)
+      keyring_entry.Gh_auth_status.active
+  | entries -> failf "expected two entries, parsed %d" (List.length entries)
+;;
+
+(* Same shadowing, but gh marks both entries as failed. The verdict must not
+   fall through to unauthenticated: the next action is still "unset the
+   variable", not "log in". *)
+let test_gh_token_shadow_survives_both_entries_failing () =
+  let parsed = Gh_auth_status.parse gh_token_shadow_output in
+  check string "verdict" "shadowed" (verdict parsed);
+  match parsed.Gh_auth_status.entries with
+  | [ env_entry; config_entry ] ->
+    check
+      string
+      "environment variable is named"
+      "GH_TOKEN"
+      (Gh_auth_status.token_source_to_string env_entry.Gh_auth_status.source);
+    check
+      string
+      "config entry source"
+      "default"
+      (Gh_auth_status.token_source_to_string config_entry.Gh_auth_status.source);
+    List.iter
+      (fun entry ->
+         match entry.Gh_auth_status.outcome with
+         | Gh_auth_status.Login_failed -> ()
+         | Gh_auth_status.Logged_in -> fail "an entry was reported as logged in")
+      parsed.Gh_auth_status.entries
+  | entries -> failf "expected two entries, parsed %d" (List.length entries)
+;;
+
+let test_no_hosts_is_unauthenticated () =
+  let parsed = Gh_auth_status.parse unauthenticated_output in
+  check string "verdict" "unauthenticated" (verdict parsed);
+  check int "no entries" 0 (List.length parsed.Gh_auth_status.entries)
+;;
+
+let test_enterprise_host_is_read_verbatim () =
+  let parsed = Gh_auth_status.parse enterprise_output in
+  check string "verdict" "authenticated" (verdict parsed);
+  let entry = single_entry parsed in
+  check string "host" "ghe.example.com" entry.Gh_auth_status.host;
+  check (option (list string)) "scopes" (Some [ "repo" ]) entry.Gh_auth_status.scopes
+;;
+
+(* A label gh adds later must not be read as one of the sources the verdict
+   depends on. It stays verbatim, and because it is not an environment source
+   it cannot manufacture a shadowed verdict. *)
+let test_unknown_label_stays_verbatim () =
+  let parsed = Gh_auth_status.parse future_label_output in
+  check string "verdict" "authenticated" (verdict parsed);
+  let entry = single_entry parsed in
+  check
+    string
+    "label preserved"
+    "secure_enclave"
+    (Gh_auth_status.token_source_to_string entry.Gh_auth_status.source);
+  match entry.Gh_auth_status.source with
+  | Gh_auth_status.Other_source _ -> ()
+  | Gh_auth_status.Keyring | Gh_auth_status.Config_default | Gh_auth_status.Environment _
+    -> fail "an unrecognised label was folded into a known source"
+;;
+
+(* Output the parser does not recognise is unknown, never a stand-in for a
+   credential verdict. *)
+let test_unrecognised_output_is_unknown () =
+  List.iter
+    (fun (name, output) ->
+       let parsed = Gh_auth_status.parse output in
+       check string name "unknown" (verdict parsed);
+       check int (name ^ " entries") 0 (List.length parsed.Gh_auth_status.entries))
+    [ "empty", ""
+    ; "whitespace", "   \n  \n"
+    ; "crash", "panic: runtime error: index out of range\n"
+    ; "prose", "gh: command not found\n"
+    ]
+;;
+
+let () =
+  run
+    "gh_auth_status"
+    [ ( "verdict"
+      , [ test_case "keyring is authenticated" `Quick test_keyring_is_authenticated
+        ; test_case
+            "GITHUB_TOKEN shadows a valid keyring"
+            `Quick
+            test_github_token_shadows_a_valid_keyring
+        ; test_case
+            "GH_TOKEN shadow survives both entries failing"
+            `Quick
+            test_gh_token_shadow_survives_both_entries_failing
+        ; test_case "no hosts is unauthenticated" `Quick test_no_hosts_is_unauthenticated
+        ; test_case
+            "enterprise host is read verbatim"
+            `Quick
+            test_enterprise_host_is_read_verbatim
+        ; test_case "unknown label stays verbatim" `Quick test_unknown_label_stays_verbatim
+        ; test_case
+            "unrecognised output is unknown"
+            `Quick
+            test_unrecognised_output_is_unknown
+        ] )
+    ]
+;;

--- a/test/test_gh_auth_status.ml
+++ b/test/test_gh_auth_status.ml
@@ -123,7 +123,7 @@ let test_keyring_is_authenticated () =
     string
     "source"
     "keyring"
-    (Gh_auth_status.token_source_to_string entry.Gh_auth_status.source);
+    (entry.Gh_auth_status.source_label);
   check (option bool) "active" (Some true) entry.Gh_auth_status.active;
   check
     (option (list string))
@@ -144,7 +144,7 @@ let test_github_token_shadows_a_valid_keyring () =
       string
       "environment variable is named"
       "GITHUB_TOKEN"
-      (Gh_auth_status.token_source_to_string env_entry.Gh_auth_status.source);
+      (env_entry.Gh_auth_status.source_label);
     check
       (option bool)
       "environment entry is the active one"
@@ -155,7 +155,7 @@ let test_github_token_shadows_a_valid_keyring () =
       string
       "keyring entry survives"
       "keyring"
-      (Gh_auth_status.token_source_to_string keyring_entry.Gh_auth_status.source);
+      (keyring_entry.Gh_auth_status.source_label);
     (match keyring_entry.Gh_auth_status.outcome with
      | Gh_auth_status.Logged_in -> ()
      | Gh_auth_status.Login_failed -> fail "keyring entry was reported as failed");
@@ -179,12 +179,12 @@ let test_gh_token_shadow_survives_both_entries_failing () =
       string
       "environment variable is named"
       "GH_TOKEN"
-      (Gh_auth_status.token_source_to_string env_entry.Gh_auth_status.source);
+      (env_entry.Gh_auth_status.source_label);
     check
       string
       "config entry source"
       "default"
-      (Gh_auth_status.token_source_to_string config_entry.Gh_auth_status.source);
+      (config_entry.Gh_auth_status.source_label);
     List.iter
       (fun entry ->
          match entry.Gh_auth_status.outcome with
@@ -211,7 +211,7 @@ let test_valid_environment_token_still_shadows () =
       string
       "environment variable is named"
       "GITHUB_TOKEN"
-      (Gh_auth_status.token_source_to_string env_entry.Gh_auth_status.source)
+      (env_entry.Gh_auth_status.source_label)
   | entries -> failf "expected two entries, parsed %d" (List.length entries)
 ;;
 
@@ -250,22 +250,20 @@ let test_enterprise_host_is_read_verbatim () =
   check (option (list string)) "scopes" (Some [ "repo" ]) entry.Gh_auth_status.scopes
 ;;
 
-(* A label gh adds later must not be read as one of the sources the verdict
-   depends on. It stays verbatim, and because it is not an environment source
-   it cannot manufacture a shadowed verdict. *)
-let test_unknown_label_stays_verbatim () =
+(* A label gh adds later could name a variable. Reading it as a stored
+   credential would report this host authenticated while its pushes go out
+   under that variable, so the verdict declines instead. The label is still
+   carried verbatim for whoever has to diagnose it. *)
+let test_unknown_label_declines_the_verdict () =
   let parsed = Gh_auth_status.parse future_label_output in
-  check string "verdict" "authenticated" (verdict parsed);
+  check string "verdict" "unknown" (verdict parsed);
   let entry = single_entry parsed in
+  check string "label preserved" "secure_enclave" entry.Gh_auth_status.source_label;
   check
-    string
-    "label preserved"
-    "secure_enclave"
-    (Gh_auth_status.token_source_to_string entry.Gh_auth_status.source);
-  match entry.Gh_auth_status.source with
-  | Gh_auth_status.Other_source _ -> ()
-  | Gh_auth_status.Keyring | Gh_auth_status.Config_default | Gh_auth_status.Environment _
-    -> fail "an unrecognised label was folded into a known source"
+    bool
+    "label is not interpreted"
+    true
+    (Option.is_none entry.Gh_auth_status.source)
 ;;
 
 (* Output the parser does not recognise is unknown, never a stand-in for a
@@ -309,7 +307,10 @@ let () =
             "enterprise host is read verbatim"
             `Quick
             test_enterprise_host_is_read_verbatim
-        ; test_case "unknown label stays verbatim" `Quick test_unknown_label_stays_verbatim
+        ; test_case
+            "unknown label declines the verdict"
+            `Quick
+            test_unknown_label_declines_the_verdict
         ; test_case
             "unrecognised output is unknown"
             `Quick


### PR DESCRIPTION
RFC: [RFC-0369 — Keeper credential-surface observability for repo-hosting CLIs](../blob/main/docs/rfc/RFC-0369-keeper-credential-surface-observability.md)

`docs/rfc/RFC-0369-keeper-credential-surface-observability.md` 의 **첫 청크(파서)** 만 구현한다. RFC 는 orca 대조 감사 G3(`reports/orca-vs-masc-adversarial-2026-08-11.html`)을 근거로 작성됐고 `implementation_prs: []` 였다. RFC 작성 세션에 구현 의도를 확인하고 넘겨받았다.

## 범위

포함: `lib/credential_observation/` 파서 하나 + 실측 fixture 테스트.

**미포함**: 프로브(gh 실행), read endpoint, dashboard 카드, TTL 캐시/단일 슬롯. 후속 청크.

**exec / Gate / policy 무접촉.** 이 계층들이 특정 CLI·자격증명 체계를 알면 안 된다는 게 RFC-0309 가 철회된 이유다(INV-KEEPER-008, `docs/spec/05-keeper-agent.md`). 신규 라이브러리는 `masc_core` 하나에만 의존하고 아무것도 실행하지 않는다.

## 왜 exit code 로 판정하지 않는가

gh 2.87.3 실측:

| 상태 | keyring | env | exit |
|---|---|---|---|
| keyring 만, 정상 | ✓ | — | **0** |
| `GITHUB_TOKEN` 무효 주입 | **✓** (inactive) | X (active) | 1 |
| `GH_TOKEN` 무효 주입 | X | X (active) | 1 |
| 어느 호스트에도 미로그인 | — | — | 1 |

2행은 **변수만 unset 하면 즉시 인증되는 호스트**고 4행은 로그인이 필요하다. 같은 exit code, 정반대 next action. 그래서 판정은 항목별 `✓`/`X` 마크와 source 라벨에서 읽는다. exit code 는 gh 를 실제로 spawn 할 프로브 계층의 몫으로 남긴다.

## `Shadowed` — 이 표면이 존재하는 이유

env 토큰이 active 인데 같은 호스트에 non-env 항목도 있는 상태. gh 는 env 를 먼저 resolve 하므로 `gh auth login` 과 `gh auth refresh` 가 **조용히 no-op** 된다.

실측 2행이 정본이다:

```
github.com
  X Failed to log in to github.com using token (GITHUB_TOKEN)
  - Active account: true
  - The token in GITHUB_TOKEN is invalid.

  ✓ Logged in to github.com account jeong-sik (keyring)
  - Active account: false
```

멀쩡한 자격증명이 있는데 쓰이지 않는다. shadowed 항목 자체의 유효 여부와 무관하게 `Shadowed` 로 보고한다 — 측정한 두 형태 모두 운영자의 다음 행동이 "변수를 unset" 으로 같기 때문이다.

## 타입 결정

- `Other_source of string` — 모르는 라벨은 verbatim 보존. gh 가 나중에 라벨을 추가하면 드리프트로 보이지, 판정이 의존하는 source 중 하나로 접히지 않는다.
- `Unknown` — 파싱 불가 출력. 인증/미인증의 대역이 **아니다**.
- `active`, `scopes` 가 `option` — "gh 가 그 줄을 안 찍었다" 와 "값이 비었다" 를 구분한다. `Some default` 로 압축하지 않는다.

## 검증

### 대조군 — 단언이 아니라 변이로

판정 순서를 뒤집어 "로그인 마크가 shadow 검사를 이기게" 만들면(가장 자연스러운 오구현):

```
[OK]    verdict  0  keyring is authenticated.
[FAIL]  verdict  1  GITHUB_TOKEN shadows a valid keyring.
        ASSERT verdict   Expected: `"shadowed"'
[OK]    verdict  2  GH_TOKEN shadow survives both entries failing.
```

케이스 1만 실패한다. 케이스 2 는 그 오구현에서도 통과하는데, **그쪽은 반대 오류**(unauthenticated 로 흘러내림)를 잡기 때문이다. 두 shadow 케이스가 서로 다른 실패 모드를 담당한다.

(첫 변이 시도는 `Shadowed` 분기를 통째로 지웠는데 `-warn-error +a` 가 미사용 binding 을 빌드 에러로 잡아 테스트에 도달하지 못했다. 빌드 대조군이지 테스트 대조군이 아니라서, 컴파일되는 오구현으로 다시 측정했다.)

### 전체

```
dune build --root . @check                              EXIT=0
dune build --root . @test/runtest-test_gh_auth_status   7 tests, Test Successful
scripts/audit-ci-test-targets.sh                        178 CI targets / 680 unwired, at baseline
dune build --root . @fmt                                내 파일 diff 0건
```

### fixture 출처

`measured` 표시는 gh 2.87.3 (2026-02-23) 실제 출력의 verbatim(토큰 마스킹). `constructed` 표시 2건은 이 호스트를 그 상태로 만들 수 없어 같은 문법으로 구성했다(Enterprise 호스트, 미래 source 라벨). 테스트 파일 상단에 표기했다.

## CI 배선

`scripts/ci-run-focused-tests.sh:85` 에 1줄 추가. `.github/workflows/ci.yml` 에는 넣지 않았다 — 두 매니페스트에 모두 있으면 `audit-ci-test-targets.sh` 가 `duplicate_references` 로 exit 2 다. 새 suite 를 배선했으므로 미배선 수는 680 그대로다.

## 후속

- 프로브: keeper 별 projected env(`Keeper_secret_projection.local_env_for_keeper`)로 실행해야 shadowed 판정이 성립한다. 호스트 env 로 돌리면 못 본다.
- TTL 캐시 + 단일 슬롯 직렬화 — 감사 G4(fleet 이 개인 rate limit 하나를 공유) 연계.
- `GET /api/v1/keepers/:name/credential-surface`, dashboard 카드.
- RFC-0369 `implementation_prs` 갱신(이 PR 번호).

RFC-WAIVED 아님 — RFC-0369 인용. 변경 파일: `lib/credential_observation/*`, `test/test_gh_auth_status.ml`, `test/stanzas/test_gh_auth_status.inc`, `test/dune`, `scripts/ci-run-focused-tests.sh`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
