### PR TITLE
fix(antigravity): reject blank successful turns before settlement

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -736,6 +736,12 @@ let run_turn ?(conversation_mode = Start) ?home_dir ~mgr ~clock ~cwd
   let* status, state, stderr = run_result in
   let wall_duration_s = max 0.0 (Eio.Time.now clock -. started_at) in
   match status, state.init, state.result with
+  | `Exited 0, Some _, Some (Success, text, _, _, _)
+    when not
+           (Agent_core.Response_shape.has_deliverable_content
+              (Agent_core.Response_shape.summarize_blocks
+                 [ Agent_core.Types.Text text ])) ->
+    Error (Turn_failed "successful result response has no deliverable content")
   | `Exited 0, Some (conversation_id, model, permission_mode),
     Some (Success, text, _, num_turns, usage) ->
     Ok

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -115,6 +115,42 @@ printf '{"event":"result","result":{"conversation_id":"%%s","status":"SUCCESS","
   path
 ;;
 
+let blank_then_success_fixture_script ~base_path =
+  let path = Filename.concat base_path "agy-blank-then-success.sh" in
+  let invocation_path = Filename.concat base_path "antigravity-invocation" in
+  let script =
+    Printf.sprintf
+      {|#!/bin/sh
+set -eu
+test "$HOME" = %s
+case " $* " in *" --new-project "*) ;; *) exit 96 ;; esac
+case " $* " in *" --conversation "*) exit 97 ;; esac
+cat >/dev/null
+if [ -e %s ]; then
+  conversation=conversation-recovered
+  response=MASC_ANTIGRAVITY_RECOVERED
+else
+  : > %s
+  conversation=conversation-blank
+  response='   '
+fi
+printf '{"event":"init","conversation_id":"%%s","init":{"model":"gemini-fixture","cwd":%s,"tools":[],"permission_mode":"always-proceed"}}\n' "$conversation"
+printf '{"event":"result","result":{"conversation_id":"%%s","status":"SUCCESS","response":"%%s","error":null,"num_turns":1,"usage":{"input_tokens":12,"output_tokens":4,"thinking_tokens":1,"cache_read_tokens":0,"total_tokens":16}}}\n' "$conversation" "$response"
+|}
+      (shell_quote
+         (Filename.concat
+            (Filename.concat
+               (Filename.concat base_path ".masc")
+               "official-clients")
+            "antigravity/antigravity-fixture"))
+      (shell_quote invocation_path)
+      (shell_quote invocation_path)
+      (Yojson.Safe.to_string (`String base_path))
+  in
+  write_file ~mode:0o700 path script;
+  path
+;;
+
 let runtime_toml ~cli_path ~oauth_source =
   Printf.sprintf
     {|[providers.antigravity]
@@ -431,14 +467,104 @@ let test_keeper_projects_mcp_tool_and_settles () =
       check bool "turn capability cleared" false (Sys.file_exists mcp_path))
 ;;
 
+let test_blank_success_requires_fresh_conversation () =
+  let base_path = temp_workspace () |> Unix.realpath in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+      Unix.mkdir (Filename.concat base_path ".masc") 0o700;
+      let oauth_source = Filename.concat base_path "operator-oauth-token" in
+      write_file ~mode:0o600 oauth_source "operator-oauth-fixture";
+      let cli_path = blank_then_success_fixture_script ~base_path in
+      let runtime_path = Filename.concat base_path "runtime.toml" in
+      write_file ~mode:0o600 runtime_path (runtime_toml ~cli_path ~oauth_source);
+      let runtime_snapshot = Runtime.For_testing.snapshot () in
+      Fun.protect
+        ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+        (fun () ->
+          Eio_main.run (fun env ->
+            Eio.Switch.run (fun sw ->
+              Eio_context.set_env env;
+              Eio_context.with_test_env
+                ~net:(Eio.Stdenv.net env)
+                ~clock:(Eio.Stdenv.clock env)
+                ~mono_clock:(Eio.Stdenv.mono_clock env)
+                ~sw
+                (fun () ->
+                  Runtime.init_default ~config_path:runtime_path |> Result.get_ok;
+                  let run () =
+                    Keeper_turn_driver.run_named
+                      ~runtime_id:"antigravity.gemini"
+                      ~keeper_name:"antigravity-fixture"
+                      ~base_path
+                      ~goal:"Return a non-empty completion"
+                      ~context:(Agent_core.Context.create ())
+                      ~sw
+                      ~net:(Eio.Stdenv.net env)
+                      ()
+                  in
+                  (match run () with
+                   | Error
+                       (Agent_core.Error.Provider
+                          (Llm_provider.Error.ProviderReportedError
+                             { provider = "antigravity_cli"
+                             ; error_type = Some "turn_failed"
+                             ; detail =
+                                 "successful result response has no deliverable content"
+                             })) ->
+                     ()
+                   | Error error -> fail (Agent_core.Error.to_string error)
+                   | Ok _ -> fail "blank Antigravity result settled as success");
+                  let failed_session =
+                    Keeper_official_client_session_store.load
+                      ~base_path
+                      ~keeper_name:"antigravity-fixture"
+                    |> Result.get_ok
+                    |> Option.get
+                  in
+                  (match failed_session.phase with
+                   | Recovery_required { failure = Provider_rejected; _ } -> ()
+                   | _ -> fail "blank Antigravity result did not require a fresh session");
+                  match run () with
+                  | Error error -> fail (Agent_core.Error.to_string error)
+                  | Ok selected ->
+                    let result = selected.Keeper_turn_driver.run_result in
+                    check string
+                      "recovered response"
+                      "MASC_ANTIGRAVITY_RECOVERED"
+                      (keeper_response_text result);
+                    check string
+                      "fresh conversation"
+                      "conversation-recovered"
+                      result.session_id))));
+      let session =
+        Keeper_official_client_session_store.load
+          ~base_path
+          ~keeper_name:"antigravity-fixture"
+        |> Result.get_ok
+        |> Option.get
+      in
+      match session.phase with
+      | Settled
+          { session_id = "conversation-recovered"
+          ; turn_id = "conversation-recovered:ordinal:1"
+          } ->
+        ()
+      | _ -> fail "fresh Antigravity conversation did not settle")
+;;
+
 let () =
   run
     "keeper_antigravity_runtime"
     [ ( "lifecycle"
-      , [ test_case
+        , [ test_case
             "projects MCP tool and settles"
             `Quick
             test_keeper_projects_mcp_tool_and_settles
+          ; test_case
+              "blank result starts fresh next turn"
+              `Quick
+              test_blank_success_requires_fresh_conversation
         ] )
     ]
 ;;

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -278,6 +278,19 @@ let test_result_error_is_not_success () =
        | Ok _ -> fail "ERROR result was admitted as success")
 ;;
 
+let test_success_with_blank_response_is_not_success () =
+  with_fixture
+    [ init (); result ~response:" \n\t" () ]
+    (fun path ->
+       match run_fixture path with
+       | Error
+           (Runtime_antigravity.Turn_failed
+              "successful result response has no deliverable content") ->
+         ()
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok _ -> fail "blank SUCCESS result was admitted as a completed turn")
+;;
+
 let test_duplicate_keys_fail_closed () =
   let duplicate =
     {|{"event":"init","event":"init","conversation_id":"conversation-1","init":{"model":"gemini-fixture","cwd":"/tmp","permission_mode":"always-proceed"}}|}
@@ -476,6 +489,10 @@ let () =
             test_conversation_callback_failure_is_typed
         ; test_case "tool measurements" `Quick test_tool_steps_and_errors_are_measured
         ; test_case "error result" `Quick test_result_error_is_not_success
+        ; test_case
+            "blank success"
+            `Quick
+            test_success_with_blank_response_is_not_success
         ; test_case "duplicate keys" `Quick test_duplicate_keys_fail_closed
         ; test_case
             "observed permission modes are admitted"


### PR DESCRIPTION
## Invariant

An Antigravity result may settle its official-client session only when the response has canonical deliverable content.

## Change

- validate successful Antigravity result content at the runtime boundary with Agent Core Response_shape
- return a typed turn_failed provider rejection before Keeper turn hooks and session settlement
- require the following Keeper invocation to start a fresh conversation after Recovery_required

## Verification

- scripts/dune-local.sh build @test/runtest-test_runtime_antigravity @test/runtest-test_keeper_antigravity_runtime
- ocamlformat --check lib/runtime/runtime_antigravity.ml test/test_runtime_antigravity.ml test/test_keeper_antigravity_runtime.ml

Live deployment verification remains pending after merge and server rebuild.