### PR TITLE
fix(keeper): keep queued chat alive and stream Codex events

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -523,6 +523,11 @@ describe('sendKeeperThreadMessage operation stream', () => {
       })
       opts.onEvent({ type: 'TOOL_CALL_START', toolCallId: 'tool-1', toolCallName: 'lookup' })
       opts.onEvent({ type: 'TOOL_CALL_END', toolCallId: 'tool-1' })
+      opts.onEvent({
+        type: 'CUSTOM',
+        name: 'KEEPER_TOOL_RESULT_READY',
+        value: { tool_call_id: 'tool-1' },
+      })
       opts.onEvent({ type: 'TEXT_MESSAGE_CONTENT', delta: 'done' })
       opts.onEvent({ type: 'RUN_FINISHED' })
       return { terminal: true }

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -997,6 +997,8 @@ export async function sendKeeperThreadMessage(
         persistTrackedOperationAssistantDraft(keeperName, requestId, assistantId)
         if (event.type === 'TOOL_CALL_END') {
           toolCallEnded = true
+        }
+        if (event.type === 'CUSTOM' && event.name === 'KEEPER_TOOL_RESULT_READY') {
           void hydrateKeeperToolOutputs(keeperName)
         }
       },

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -227,6 +227,28 @@ describe('applyKeeperStreamEvent tool calls', () => {
     ])
   })
 
+  it('keeps a ready tool delivered when the provider end arrives later', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_START',
+      toolCallId: 'tc-ready-first',
+      toolCallName: 'masc_status',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_TOOL_RESULT_READY',
+      value: { tool_call_id: 'tc-ready-first' },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_END',
+      toolCallId: 'tc-ready-first',
+    })
+
+    const finished = keeperThreads.value.sangsu?.find(entry => entry.id === 'tool-tc-ready-first')
+    expect(finished?.delivery).toBe('delivered')
+    expect(finished?.streamState).toBeNull()
+  })
+
   it('replaces tool-call args when Agent Core emits argument snapshots', () => {
     assistantEntry()
     applyKeeperStreamEvent('sangsu', 'reply-1', {

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -176,6 +176,14 @@ describe('applyKeeperStreamEvent tool calls', () => {
     ])
 
     applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TOOL_CALL_END', toolCallId: 'tc-1' })
+    const argsFinished = keeperThreads.value.sangsu?.find(entry => entry.id === 'tool-tc-1')
+    expect(argsFinished?.delivery).toBe('streaming')
+    expect(argsFinished?.streamState).toBe('streaming')
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_TOOL_RESULT_READY',
+      value: { tool_call_id: 'tc-1' },
+    })
     const finished = keeperThreads.value.sangsu?.find(entry => entry.id === 'tool-tc-1')
     expect(finished?.delivery).toBe('delivered')
     expect(finished?.streamState).toBeNull()
@@ -197,6 +205,11 @@ describe('applyKeeperStreamEvent tool calls', () => {
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TOOL_CALL_END',
       toolCallId,
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_TOOL_RESULT_READY',
+      value: { tool_call_id: toolCallId },
     })
 
     const thread = keeperThreads.value.sangsu ?? []
@@ -271,6 +284,11 @@ describe('applyKeeperStreamEvent tool calls', () => {
     })
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
+      name: 'KEEPER_TOOL_RESULT_READY',
+      value: { tool_call_id: 'tc-ordered' },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
       name: 'KEEPER_THINKING_DELTA',
       value: { delta: 'think B' },
     })
@@ -317,6 +335,11 @@ describe('applyKeeperStreamEvent tool calls', () => {
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TOOL_CALL_END',
       toolCallId: 'tc-progress',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_TOOL_RESULT_READY',
+      value: { tool_call_id: 'tc-progress' },
     })
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TEXT_MESSAGE_CONTENT',
@@ -413,6 +436,11 @@ describe('applyKeeperStreamEvent tool calls', () => {
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TOOL_CALL_END',
       toolCallId: 'tc-agentCore',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_TOOL_RESULT_READY',
+      value: { tool_call_id: 'tc-agentCore' },
     })
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
@@ -541,6 +569,11 @@ describe('applyKeeperStreamEvent tool calls', () => {
     })
     applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TOOL_CALL_ARGS', toolCallId: 'tc-repeat', delta: '{"post_id":"p-1"}' })
     applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TOOL_CALL_END', toolCallId: 'tc-repeat' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_TOOL_RESULT_READY',
+      value: { tool_call_id: 'tc-repeat' },
+    })
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TOOL_CALL_START',
       toolCallId: 'tc-repeat',

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -582,12 +582,15 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (toolCallId) {
-        updateThreadEntry(keeperName, toolEntryIdFromCallId(toolCallId), entry => ({
-          ...entry,
-          delivery: 'streaming',
-          streamState: 'streaming',
-          streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
-        }))
+        updateThreadEntry(keeperName, toolEntryIdFromCallId(toolCallId), entry => {
+          if (entry.delivery === 'delivered') return entry
+          return {
+            ...entry,
+            delivery: 'streaming',
+            streamState: 'streaming',
+            streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
+          }
+        })
       }
       return null
     }

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -582,11 +582,10 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (toolCallId) {
-        markAssistantToolTraceEnded(keeperName, assistantEntryId, toolCallId)
         updateThreadEntry(keeperName, toolEntryIdFromCallId(toolCallId), entry => ({
           ...entry,
-          delivery: 'delivered',
-          streamState: null,
+          delivery: 'streaming',
+          streamState: 'streaming',
           streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
         }))
       }
@@ -594,6 +593,22 @@ export function applyKeeperStreamEvent(
     }
     case 'CUSTOM': {
       const customEventName: string = event.name
+      if (event.name === 'KEEPER_TOOL_RESULT_READY') {
+        const toolCallId = nonBlankToolCallId(event.value.tool_call_id)
+        if (!toolCallId) return 'KEEPER_TOOL_RESULT_READY missing tool_call_id'
+        markAssistantToolTraceEnded(keeperName, assistantEntryId, toolCallId)
+        updateThreadEntry(keeperName, toolEntryIdFromCallId(toolCallId), entry => ({
+          ...entry,
+          delivery: 'delivered',
+          streamState: null,
+          streamContract: keeperClientObservedSseStreamContract(
+            'sse_event',
+            'backend_stream_event',
+            { eventName: 'KEEPER_TOOL_RESULT_READY' },
+          ),
+        }))
+        return null
+      }
       if (event.name === 'KEEPER_CHAT_OPERATION_ACCEPTED') {
         const operationId = event.value.operation_id.trim()
         if (!operationId) return 'Keeper operation acceptance is missing operation_id.'

--- a/dashboard/src/lib/keeper-chat-stream-contract.ts
+++ b/dashboard/src/lib/keeper-chat-stream-contract.ts
@@ -14,6 +14,7 @@ export const KEEPER_CHAT_CUSTOM_EVENT_NAMES = [
   'KEEPER_CONTINUATION_CHECKPOINT',
   'KEEPER_EXTERNAL_EFFECT_COMPLETED',
   'KEEPER_REPLY_DETAILS',
+  'KEEPER_TOOL_RESULT_READY',
 ] as const
 
 export type KeeperChatCustomEventName = typeof KEEPER_CHAT_CUSTOM_EVENT_NAMES[number]
@@ -80,6 +81,11 @@ type KeeperChatCustomEvent =
     }
   | { type: 'CUSTOM'; name: 'KEEPER_STREAM_MESSAGE_STOP'; value: null }
   | { type: 'CUSTOM'; name: 'KEEPER_STREAM_PING'; value: null }
+  | {
+      type: 'CUSTOM'
+      name: 'KEEPER_TOOL_RESULT_READY'
+      value: { tool_call_id: string }
+    }
   | {
       type: 'CUSTOM'
       name: 'KEEPER_CONTENT_BLOCK_START'

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -249,6 +249,23 @@ describe('SSEMessageSchema', () => {
     expect(r.success).toBe(true)
   })
 
+  it('accepts exact durable tool-result readiness identity', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'keeper_chat_operation_event',
+      name: 'sangsu',
+      operation_id: 'kmsg-operation-1',
+      ag_ui_event: {
+        type: 'CUSTOM',
+        threadId: 'keeper-consumer:sangsu',
+        runId: 'run-1',
+        name: 'KEEPER_TOOL_RESULT_READY',
+        value: { tool_call_id: 'tool-use-7' },
+        timestamp: 1_712_000_000,
+      },
+    })
+    expect(r.success).toBe(true)
+  })
+
   it('accepts an operator-visible projection error for an operation', () => {
     const r = SSEMessageSchema.safeParse({
       type: 'keeper_chat_operation_event',

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -344,6 +344,7 @@ function validateKeeperCustomPayload(name: string, payload: unknown): SafeParseR
     KEEPER_STREAM_PROTOCOL_ERROR: ['kind', 'index', 'tool_call_id', 'event_type', 'reason', 'raw_bytes'],
     KEEPER_CONTINUATION_CHECKPOINT: ['message', 'request_id'],
     KEEPER_REPLY_DETAILS: ['reply', 'turn_outcome', 'turn_ref'],
+    KEEPER_TOOL_RESULT_READY: ['tool_call_id'],
   }
   const object = exactCustomObject(payload, name, allowedFields[name] ?? [])
   if (!object.success) return object
@@ -372,6 +373,8 @@ function validateKeeperCustomPayload(name: string, payload: unknown): SafeParseR
     }
     case 'KEEPER_CONTENT_BLOCK_STOP':
       return requiredInteger(value, 'index')
+    case 'KEEPER_TOOL_RESULT_READY':
+      return requiredString(value, 'tool_call_id')
     case 'KEEPER_THINKING_DELTA': {
       const index = requiredInteger(value, 'index')
       return index.success ? requiredString(value, 'delta') : index

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -607,7 +607,10 @@ function handleEvent(event: SSEEvent): void {
         operationId,
         event: event.ag_ui_event as unknown as KeeperChatStreamEvent,
       })
-      if (event.ag_ui_event.type === 'TOOL_CALL_END') {
+      if (
+        event.ag_ui_event.type === 'CUSTOM'
+        && event.ag_ui_event.name === 'KEEPER_TOOL_RESULT_READY'
+      ) {
         void import('./keeper-runtime')
           .then(mod => mod.hydrateKeeperToolOutputs(keeperName))
           .catch(err => {

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -383,6 +383,7 @@ let run_turn
       ?(history_assistant_source = "direct_assistant")
       ?temperature
       ?on_event
+      ?on_tool_result_ready
       ?(trajectory_acc : Trajectory.accumulator option)
       ?(degraded_retry_applied = false)
       ?degraded_retry_runtime
@@ -602,6 +603,7 @@ let run_turn
       ~meta
       ~publication_recovery
       ?continuation_channel
+      ?on_tool_result_ready
       ?hitl_resolution
       ~turn_ctx_cell
       ~ctx_work

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -189,6 +189,7 @@ val run_turn
   -> ?history_assistant_source:string
   -> ?temperature:float
   -> ?on_event:(Agent_core.Types.sse_event -> unit)
+  -> ?on_tool_result_ready:(tool_call_id:string -> unit)
   -> ?trajectory_acc:Trajectory.accumulator
   -> ?degraded_retry_applied:bool
   -> ?degraded_retry_runtime:string

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -309,7 +309,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ; execution_mode = Plan
       ; sandbox = true
       ; disable_slash_commands = true
-      ; (* A per-model [turn-timeout-s] overrides the admission-time bound.
+      ; (* A per-model [turn-timeout-s] overrides the stream-idle bound.
            Absent, [config.timeout_s] stands, so a config that declares none
            behaves exactly as before. *)
         timeout_s =

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -113,9 +113,78 @@ let provider_turn_identity ~conversation_id ~num_turns =
   Printf.sprintf "%s:ordinal:%d" conversation_id num_turns
 ;;
 
+type stream_projection =
+  { on_runtime_event : Runtime_antigravity.stream_event -> unit
+  ; on_tool_started :
+      call_id:string -> tool_name:string -> arguments:Yojson.Safe.t -> unit
+  ; on_tool_finished : call_id:string -> unit
+  }
+
+let stream_projection ~turn_count on_event =
+  match on_event with
+  | None ->
+    { on_runtime_event = ignore
+    ; on_tool_started = (fun ~call_id:_ ~tool_name:_ ~arguments:_ -> ())
+    ; on_tool_finished = (fun ~call_id:_ -> ())
+    }
+  | Some emit ->
+    let next_tool_index = ref 1 in
+    let tool_indexes = Hashtbl.create 8 in
+    let emit event =
+      try emit event with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        Log.Runtime_agent.warn
+          "Antigravity Keeper stream callback raised (error=%s)"
+          (Printexc.to_string exn)
+    in
+    { on_runtime_event =
+        (function
+          | Runtime_antigravity.Turn_started { conversation_id; model } ->
+            emit
+              (Agent_core.Types.MessageStart
+                 { id = provider_turn_identity ~conversation_id ~num_turns:turn_count
+                 ; model
+                 ; usage = None
+                 })
+          | Runtime_antigravity.Text_delta text ->
+            emit
+              (Agent_core.Types.ContentBlockDelta
+                 { index = 0; delta = Agent_core.Types.TextDelta text })
+          | Runtime_antigravity.Turn_finished { text = _ } ->
+            emit Agent_core.Types.MessageStop)
+    ; on_tool_started =
+        (fun ~call_id ~tool_name ~arguments ->
+          let index = !next_tool_index in
+          incr next_tool_index;
+          Hashtbl.replace tool_indexes call_id index;
+          emit
+            (Agent_core.Types.ContentBlockStart
+               { index
+               ; content_type = "tool_use"
+               ; tool_id = Some call_id
+               ; tool_name = Some tool_name
+               });
+          emit
+            (Agent_core.Types.ContentBlockDelta
+               { index
+               ; delta =
+                   Agent_core.Types.InputJsonSnapshot
+                     (Yojson.Safe.to_string arguments)
+               }))
+    ; on_tool_finished =
+        (fun ~call_id ->
+          Option.iter
+            (fun index ->
+               Hashtbl.remove tool_indexes call_id;
+               emit (Agent_core.Types.ContentBlockStop { index }))
+            (Hashtbl.find_opt tool_indexes call_id))
+    }
+;;
+
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
-    ~context_injector ~context ~event_bus ~raw_trace
+    ~context_injector ~context ~event_bus ~raw_trace ~on_event
     ~(config : Runtime_execution.antigravity_cli) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
@@ -345,6 +414,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     let process_mgr = Eio.Stdenv.process_mgr env in
     let process_cwd = Eio.Path.(Eio.Stdenv.fs env / base_path) in
     let started_at = Time_compat.now () in
+    let stream = stream_projection ~turn_count on_event in
     let run_client () =
       let cleanup_error = ref None in
       let turn_result =
@@ -363,7 +433,10 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
               ~call_tool:(fun ~name ~call_id ~arguments ->
                 find_tool dynamic_tools name
                 |> Option.map (fun (tool : Host.dynamic_tool) ->
-                  tool.call ~call_id arguments |> tool_result))
+                  stream.on_tool_started ~call_id ~tool_name:name ~arguments;
+                  Fun.protect
+                    ~finally:(fun () -> stream.on_tool_finished ~call_id)
+                    (fun () -> tool.call ~call_id arguments |> tool_result)))
               ()
           in
           let* () =
@@ -397,6 +470,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                   ~expected
                   ~session_id:conversation_id
                   ~updated_at:(Time_compat.now ())))
+            ~on_stream_event:stream.on_runtime_event
             client_config
             ~prompt
           |> Result.map_error (fun error ->
@@ -589,7 +663,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~raw_trace ~config =
+    ~context ~event_bus ~raw_trace ~on_event ~config =
   Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
     run_without_lifecycle
       ~runtime_id
@@ -606,5 +680,6 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       ~context
       ~event_bus
       ~raw_trace
+      ~on_event
       ~config)
 ;;

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -15,5 +15,6 @@ val run :
   context:Agent_core.Context.t option ->
   event_bus:Agent_core.Event_bus.t option ->
   raw_trace:Agent_core.Raw_trace.t option ->
+  on_event:(Agent_core.Types.sse_event -> unit) option ->
   config:Runtime_execution.antigravity_cli ->
   (Runtime_agent.run_result, Agent_core.Error.t) result

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -409,6 +409,7 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
     | Tool_call_args _
     | Tool_call_args_snapshot _
     | Tool_call_end _
+    | Tool_result_ready _
     | Tool_context_block _ -> continue ()
     | Link_block { url; title; description; image } ->
         send_link_block ?clock ~token ~channel_id ~url ~title ~description ~image ();

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -85,6 +85,7 @@ type keeper_chat_event =
   | Tool_call_args of { tool_call_id : string; delta : string }
   | Tool_call_args_snapshot of { tool_call_id : string; snapshot : string }
   | Tool_call_end of { tool_call_id : string }
+  | Tool_result_ready of { tool_call_id : string }
   | Link_block of
       { url : string
       ; title : string

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -96,6 +96,9 @@ type keeper_chat_event =
   | Tool_call_args of { tool_call_id : string; delta : string }
   | Tool_call_args_snapshot of { tool_call_id : string; snapshot : string }
   | Tool_call_end of { tool_call_id : string }
+      (** Provider argument streaming ended. This is not execution completion. *)
+  | Tool_result_ready of { tool_call_id : string }
+      (** The exact tool result is durably readable from the tool-call store. *)
   | Link_block of
       { url : string
       ; title : string

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -403,6 +403,39 @@ let edit_message_with_blocks ?clock
      | Yojson.Json_error message ->
        Error (Other ("Slack chat.update JSON parse error: " ^ message)))
 
+let delete_message ?clock
+    ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
+    ~token ~channel ~message_id () =
+  let body =
+    `Assoc [ "channel", `String channel; "ts", `String message_id ]
+    |> Yojson.Safe.to_string
+  in
+  match
+    Masc_http_client.post_sync ?clock ~timeout_sec
+      ~url:"https://slack.com/api/chat.delete"
+      ~headers:
+        [ "Authorization", "Bearer " ^ token
+        ; "Content-Type", "application/json"
+        ]
+      ~body ()
+  with
+  | Error error -> Error (Network error)
+  | Ok (code, response_body) when code < 200 || code >= 300 ->
+    Error (Http_status { code; body = response_body })
+  | Ok (_, response_body) ->
+    (try
+       let json = Yojson.Safe.from_string response_body in
+       match Json_util.get_bool json "ok" with
+       | Some true -> Ok ()
+       | Some false ->
+         (match Json_util.get_string json "error" with
+          | Some error -> Error (Slack_api { error })
+          | None -> Error (Other "Slack chat.delete returned ok=false"))
+       | None -> Error (Other "Slack chat.delete response is missing ok")
+     with
+     | Yojson.Json_error message ->
+       Error (Other ("Slack chat.delete JSON parse error: " ^ message)))
+
 (* ── Adapter loop ────────────────────────────────────────────────── *)
 
 let add_block acc block = block :: acc
@@ -412,8 +445,10 @@ let adapter_loop_with_transport
     ?post_stream
     ?edit_stream
     ?edit_blocks
+    ?delete_stream
     (* NDT-OK: wall time only paces external Slack edits; tests inject [now]. *)
     ?(now = Unix.gettimeofday)
+    ?(sleep = fun _ -> ())
     ~(send_plain : content:string -> (unit, error) result)
     ~(send_blocks :
        content:string -> blocks:Yojson.Safe.t list -> (unit, error) result)
@@ -421,6 +456,7 @@ let adapter_loop_with_transport
     ?base_url
     ?(on_send_result = fun _ -> ()) () =
   let external_effect_completed = ref false in
+  let external_effect_cleanup_result = ref (Ok ()) in
   let activity_error_logged = ref false in
   let last_activity_status = ref None in
   let update_activity status =
@@ -441,10 +477,15 @@ let adapter_loop_with_transport
   in
   let clear_activity () = update_activity "" in
   let streaming_transport =
-    match post_stream, edit_stream, edit_blocks with
-    | Some post, Some edit, Some edit_final -> Some (post, edit, edit_final)
-    | None, None, None -> None
+    match post_stream, edit_stream, edit_blocks, delete_stream with
+    | Some post, Some edit, Some edit_final, Some delete ->
+      Some (post, edit, edit_final, delete)
+    | None, None, None, None -> None
     | _ -> invalid_arg "Slack streaming transport must be supplied as one closed set"
+  in
+  let pace_edit last_edit_time =
+    let remaining = min_edit_interval_s -. (now () -. last_edit_time) in
+    if remaining > 0.0 then sleep remaining
   in
   let rec loop ~acc_text ~acc_blocks ~run_id_opt ~message_id
       ~last_edit_time ~last_edited_text =
@@ -463,7 +504,7 @@ let adapter_loop_with_transport
          | None, _ -> continue ~acc_text ()
          | Some _, None when patch_content = "" ->
            continue ~acc_text ()
-         | Some (post, _, _), None ->
+         | Some (post, _, _, _), None ->
            (match post ~content:patch_content with
             | Ok created_id ->
               continue ~acc_text ~message_id:(Some created_id)
@@ -473,7 +514,7 @@ let adapter_loop_with_transport
                 "keeper_chat_slack: streaming POST failed: %s"
                 (Format.asprintf "%a" pp_error error);
               continue ~acc_text ())
-         | Some (_, edit, _), Some message_id ->
+         | Some (_, edit, _, _), Some message_id ->
            let elapsed = now () -. last_edit_time in
            if patch_content = last_edited_text || elapsed < min_edit_interval_s
            then continue ~acc_text ()
@@ -491,8 +532,9 @@ let adapter_loop_with_transport
     | Text_message_end ->
         let final_content = final_stream_content acc_text in
         (match streaming_transport, message_id with
-         | Some (_, edit, _), Some message_id
+         | Some (_, edit, _, _), Some message_id
            when final_content <> last_edited_text ->
+           pace_edit last_edit_time;
            (match edit ~message_id ~content:final_content with
             | Ok () ->
               continue ~last_edit_time:(now ())
@@ -506,7 +548,7 @@ let adapter_loop_with_transport
          | _ -> continue ())
     | Run_finished { run_id = _ } ->
         if !external_effect_completed
-        then on_send_result (Ok ())
+        then on_send_result !external_effect_cleanup_result
         else begin
           let blocks =
             final_message_blocks ~content:acc_text
@@ -516,8 +558,14 @@ let adapter_loop_with_transport
           then
             let result =
               match streaming_transport, message_id with
-              | Some (_, _, edit_final), Some message_id ->
-                edit_final ~message_id ~content:acc_text ~blocks
+              | Some (_, _, edit_final, _), Some message_id ->
+                let final_content = final_stream_content acc_text in
+                if final_content = last_edited_text && blocks = []
+                then Ok ()
+                else begin
+                  pace_edit last_edit_time;
+                  edit_final ~message_id ~content:acc_text ~blocks
+                end
               | _ -> send_blocks ~content:acc_text ~blocks
             in
             on_send_result result
@@ -529,12 +577,17 @@ let adapter_loop_with_transport
         ()
     | External_effect_completed ->
         external_effect_completed := true;
+        (match streaming_transport, message_id with
+         | Some (_, _, _, delete), Some message_id ->
+           external_effect_cleanup_result := delete ~message_id
+         | _ -> ());
         continue ()
     | Event_error { message } ->
         let content = "Keeper error: " ^ message in
         let result =
           match streaming_transport, message_id with
-          | Some (_, edit, _), Some message_id ->
+          | Some (_, edit, _, _), Some message_id ->
+            pace_edit last_edit_time;
             edit ~message_id ~content:(final_stream_content content)
           | _ -> send_plain ~content
         in
@@ -625,6 +678,9 @@ let adapter_loop ~clock ~token ~channel ?thread_ts ~events ?base_url
     ~edit_blocks:(fun ~message_id ~content ~blocks ->
       edit_message_with_blocks ~clock ~token ~channel ~message_id ~content
         ~blocks ())
+    ~delete_stream:(fun ~message_id ->
+      delete_message ~clock ~token ~channel ~message_id ())
+    ~sleep:(Eio.Time.sleep clock)
     ~send_plain:(fun ~content ->
       send_message ~clock ?thread_ts ~token ~channel ~content ())
     ~send_blocks:(fun ~content ~blocks ->

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -412,6 +412,7 @@ let adapter_loop_with_transport
     ?post_stream
     ?edit_stream
     ?edit_blocks
+    (* NDT-OK: wall time only paces external Slack edits; tests inject [now]. *)
     ?(now = Unix.gettimeofday)
     ~(send_plain : content:string -> (unit, error) result)
     ~(send_blocks :
@@ -641,7 +642,6 @@ module For_testing = struct
   let content_blocks_of_text = content_blocks_of_text
   let final_message_blocks = final_message_blocks
   let build_message_body = build_message_body
-  let build_update_message_body = build_update_message_body
   let build_thread_status_body = build_thread_status_body
 
   let adapter_loop = adapter_loop_with_transport

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -17,6 +17,7 @@ let pp_error fmt = function
 let slack_message_limit = 4000
 let slack_max_blocks = 50
 let slack_block_text_limit = 3000
+let min_edit_interval_s = Slack_rest_client.streaming_update_min_interval_sec
 
 let redact content = Observability_redact.redact_text content
 
@@ -38,6 +39,20 @@ let split_at_codepoint s ~limit =
 
 let truncate_to_limit s limit = fst (split_at_codepoint s ~limit)
 
+let is_ascii_space = function
+  | ' ' | '\n' | '\r' | '\t' -> true
+  | _ -> false
+
+let stable_stream_prefix content =
+  let len = String.length content in
+  let rec find index =
+    if index < 0 then 0
+    else if is_ascii_space content.[index] then index + 1
+    else find (index - 1)
+  in
+  let stable_len = find (len - 1) in
+  if stable_len = 0 then "" else String.sub content 0 stable_len
+
 let escape_mrkdwn_text s =
   let buf = Buffer.create (String.length s) in
   String.iter
@@ -48,6 +63,19 @@ let escape_mrkdwn_text s =
       | c -> Buffer.add_char buf c)
     s;
   Buffer.contents buf
+
+let stream_content content =
+  content
+  |> stable_stream_prefix
+  |> redact
+  |> escape_mrkdwn_text
+  |> fun value -> truncate_to_limit value slack_message_limit
+
+let final_stream_content content =
+  content
+  |> redact
+  |> escape_mrkdwn_text
+  |> fun value -> truncate_to_limit value slack_message_limit
 
 let truncate_block_text s = truncate_to_limit s slack_block_text_limit
 
@@ -235,6 +263,20 @@ let build_message_body ~channel ~content ~blocks ?thread_ts () =
   in
   `Assoc fields |> Yojson.Safe.to_string
 
+let build_update_message_body ~channel ~message_id ~content ~blocks =
+  let fields =
+    [ "channel", `String channel
+    ; "ts", `String message_id
+    ; "text", `String content
+    ]
+  in
+  let fields =
+    match blocks with
+    | [] -> fields
+    | _ -> fields @ [ "blocks", `List blocks ]
+  in
+  `Assoc fields |> Yojson.Safe.to_string
+
 let build_thread_status_body ~channel ~thread_ts ~status =
   `Assoc
     [ "channel_id", `String channel
@@ -323,12 +365,54 @@ let send_message ?clock ?timeout_sec ?thread_ts ~token ~channel ~content () =
   send_message_with_blocks ?clock ?timeout_sec ?thread_ts
     ~token ~channel ~content ~blocks:[] ()
 
+let error_of_slack_rest = function
+  | Slack_rest_client.Network message -> Network message
+  | Slack_rest_client.Http_status { code; body } -> Http_status { code; body }
+  | Slack_rest_client.Slack_api { error } -> Slack_api { error }
+  | Slack_rest_client.Other message -> Other message
+
+let edit_message_with_blocks ?clock
+    ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
+    ~token ~channel ~message_id ~content ~blocks () =
+  let content = final_stream_content content in
+  let blocks = limit_blocks_for_slack blocks in
+  let body = build_update_message_body ~channel ~message_id ~content ~blocks in
+  match
+    Masc_http_client.post_sync ?clock ~timeout_sec
+      ~url:"https://slack.com/api/chat.update"
+      ~headers:
+        [ "Authorization", "Bearer " ^ token
+        ; "Content-Type", "application/json"
+        ]
+      ~body ()
+  with
+  | Error error -> Error (Network error)
+  | Ok (code, response_body) when code < 200 || code >= 300 ->
+    Error (Http_status { code; body = response_body })
+  | Ok (_, response_body) ->
+    (try
+       let json = Yojson.Safe.from_string response_body in
+       match Json_util.get_bool json "ok" with
+       | Some true -> Ok ()
+       | Some false ->
+         (match Json_util.get_string json "error" with
+          | Some error -> Error (Slack_api { error })
+          | None -> Error (Other "Slack chat.update returned ok=false"))
+       | None -> Error (Other "Slack chat.update response is missing ok")
+     with
+     | Yojson.Json_error message ->
+       Error (Other ("Slack chat.update JSON parse error: " ^ message)))
+
 (* ── Adapter loop ────────────────────────────────────────────────── *)
 
 let add_block acc block = block :: acc
 
 let adapter_loop_with_transport
     ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t)
+    ?post_stream
+    ?edit_stream
+    ?edit_blocks
+    ?(now = Unix.gettimeofday)
     ~(send_plain : content:string -> (unit, error) result)
     ~(send_blocks :
        content:string -> blocks:Yojson.Safe.t list -> (unit, error) result)
@@ -355,12 +439,70 @@ let adapter_loop_with_transport
     end
   in
   let clear_activity () = update_activity "" in
-  let rec loop ~acc_text ~acc_blocks ~run_id_opt =
+  let streaming_transport =
+    match post_stream, edit_stream, edit_blocks with
+    | Some post, Some edit, Some edit_final -> Some (post, edit, edit_final)
+    | None, None, None -> None
+    | _ -> invalid_arg "Slack streaming transport must be supplied as one closed set"
+  in
+  let rec loop ~acc_text ~acc_blocks ~run_id_opt ~message_id
+      ~last_edit_time ~last_edited_text =
+    let continue ?(acc_text = acc_text) ?(acc_blocks = acc_blocks)
+        ?(run_id_opt = run_id_opt) ?(message_id = message_id)
+        ?(last_edit_time = last_edit_time)
+        ?(last_edited_text = last_edited_text) () =
+      loop ~acc_text ~acc_blocks ~run_id_opt ~message_id ~last_edit_time
+        ~last_edited_text
+    in
     match Keeper_chat_events.subscribe events with
     | Text_delta text ->
-        loop ~acc_text:(acc_text ^ text) ~acc_blocks ~run_id_opt
+        let acc_text = acc_text ^ text in
+        let patch_content = stream_content acc_text in
+        (match streaming_transport, message_id with
+         | None, _ -> continue ~acc_text ()
+         | Some _, None when patch_content = "" ->
+           continue ~acc_text ()
+         | Some (post, _, _), None ->
+           (match post ~content:patch_content with
+            | Ok created_id ->
+              continue ~acc_text ~message_id:(Some created_id)
+                ~last_edit_time:(now ()) ~last_edited_text:patch_content ()
+            | Error error ->
+              Log.Keeper.warn
+                "keeper_chat_slack: streaming POST failed: %s"
+                (Format.asprintf "%a" pp_error error);
+              continue ~acc_text ())
+         | Some (_, edit, _), Some message_id ->
+           let elapsed = now () -. last_edit_time in
+           if patch_content = last_edited_text || elapsed < min_edit_interval_s
+           then continue ~acc_text ()
+           else
+             (match edit ~message_id ~content:patch_content with
+              | Ok () ->
+                continue ~acc_text ~last_edit_time:(now ())
+                  ~last_edited_text:patch_content ()
+              | Error error ->
+                Log.Keeper.warn
+                  "keeper_chat_slack: streaming PATCH failed (message_id=%s): %s"
+                  message_id
+                  (Format.asprintf "%a" pp_error error);
+                continue ~acc_text ()))
     | Text_message_end ->
-        loop ~acc_text ~acc_blocks ~run_id_opt
+        let final_content = final_stream_content acc_text in
+        (match streaming_transport, message_id with
+         | Some (_, edit, _), Some message_id
+           when final_content <> last_edited_text ->
+           (match edit ~message_id ~content:final_content with
+            | Ok () ->
+              continue ~last_edit_time:(now ())
+                ~last_edited_text:final_content ()
+            | Error error ->
+              Log.Keeper.warn
+                "keeper_chat_slack: text-end PATCH failed (message_id=%s): %s"
+                message_id
+                (Format.asprintf "%a" pp_error error);
+              continue ())
+         | _ -> continue ())
     | Run_finished { run_id = _ } ->
         if !external_effect_completed
         then on_send_result (Ok ())
@@ -370,7 +512,14 @@ let adapter_loop_with_transport
               ~event_blocks:(List.rev acc_blocks)
           in
           if String.length acc_text > 0 || List.length blocks > 0
-          then on_send_result (send_blocks ~content:acc_text ~blocks)
+          then
+            let result =
+              match streaming_transport, message_id with
+              | Some (_, _, edit_final), Some message_id ->
+                edit_final ~message_id ~content:acc_text ~blocks
+              | _ -> send_blocks ~content:acc_text ~blocks
+            in
+            on_send_result result
           else
             on_send_result
               (Error (Other "Slack terminal reply contained no text or blocks"))
@@ -379,16 +528,24 @@ let adapter_loop_with_transport
         ()
     | External_effect_completed ->
         external_effect_completed := true;
-        loop ~acc_text ~acc_blocks ~run_id_opt
+        continue ()
     | Event_error { message } ->
-        on_send_result (send_plain ~content:("Keeper error: " ^ message));
+        let content = "Keeper error: " ^ message in
+        let result =
+          match streaming_transport, message_id with
+          | Some (_, edit, _), Some message_id ->
+            edit ~message_id ~content:(final_stream_content content)
+          | _ -> send_plain ~content
+        in
+        on_send_result result;
         clear_activity ();
         ()
     | Run_started { run_id; thread_id = _ } ->
         update_activity "답변을 준비하고 있어요…";
         loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:(Some run_id)
+          ~message_id:None ~last_edit_time:0.0 ~last_edited_text:""
     | Text_message_start { message_id = _; role = _ } ->
-        loop ~acc_text ~acc_blocks ~run_id_opt
+        continue ()
     | Reply_details _
     | Continuation_checkpoint _
     | Agent_core_stream_connected
@@ -401,7 +558,7 @@ let adapter_loop_with_transport
     | Agent_core_thinking_delta _
     | Agent_core_thinking_signature_delta _
     | Agent_core_media_delta _ ->
-        loop ~acc_text ~acc_blocks ~run_id_opt
+        continue ()
     | Agent_core_stream_protocol_error error ->
         (* This is an interim diagnostic, not the terminal queued-message
            delivery receipt. Reporting it through [on_send_result] could let a
@@ -417,28 +574,29 @@ let adapter_loop_with_transport
            Log.Keeper.warn
              "keeper_chat_slack: protocol diagnostic delivery failed: %s"
              (Format.asprintf "%a" pp_error error));
-        loop ~acc_text ~acc_blocks ~run_id_opt
+        continue ()
     | Tool_call_start _ ->
         update_activity "필요한 작업을 진행하고 있어요…";
-        loop ~acc_text ~acc_blocks ~run_id_opt
+        continue ()
     | Tool_call_args _ | Tool_call_args_snapshot _ | Tool_call_end _ ->
-        loop ~acc_text ~acc_blocks ~run_id_opt
+        continue ()
     | Link_block { url; title; description; image = _ } ->
         let block = link_block_json ~url ~title ~description in
-        loop ~acc_text ~acc_blocks:(add_block acc_blocks block) ~run_id_opt
+        continue ~acc_blocks:(add_block acc_blocks block) ()
     | Image_block { url; caption } ->
         let block = image_block_json ~url ~caption in
-        loop ~acc_text ~acc_blocks:(add_block acc_blocks block) ~run_id_opt
+        continue ~acc_blocks:(add_block acc_blocks block) ()
     | Status_block status ->
         let block = status_block_json status in
-        loop ~acc_text:"" ~acc_blocks:(add_block acc_blocks block) ~run_id_opt
+        continue ~acc_text:"" ~acc_blocks:(add_block acc_blocks block) ()
     | Audio_block { token; mime = _; message_text; duration_sec = _ } ->
         let block = audio_block_json ~base_url ~token ~message_text in
-        loop ~acc_text ~acc_blocks:(add_block acc_blocks block) ~run_id_opt
+        continue ~acc_blocks:(add_block acc_blocks block) ()
     | Tool_context_block _ ->
-        loop ~acc_text ~acc_blocks ~run_id_opt
+        continue ()
   in
-  loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:None
+  loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:None ~message_id:None
+    ~last_edit_time:0.0 ~last_edited_text:""
 
 let adapter_loop ~clock ~token ~channel ?thread_ts ~events ?base_url
     ?on_send_result () =
@@ -454,6 +612,17 @@ let adapter_loop ~clock ~token ~channel ?thread_ts ~events ?base_url
         None
   in
   adapter_loop_with_transport
+    ~post_stream:(fun ~content ->
+      Slack_rest_client.send_message ~clock ~token ~channel_id:channel
+        ~text:content ?thread_ts ()
+      |> Result.map_error error_of_slack_rest)
+    ~edit_stream:(fun ~message_id ~content ->
+      Slack_rest_client.edit_message ~clock ~token ~channel_id:channel
+        ~ts:message_id ~text:content ()
+      |> Result.map_error error_of_slack_rest)
+    ~edit_blocks:(fun ~message_id ~content ~blocks ->
+      edit_message_with_blocks ~clock ~token ~channel ~message_id ~content
+        ~blocks ())
     ~send_plain:(fun ~content ->
       send_message ~clock ?thread_ts ~token ~channel ~content ())
     ~send_blocks:(fun ~content ~blocks ->
@@ -471,6 +640,7 @@ module For_testing = struct
   let content_blocks_of_text = content_blocks_of_text
   let final_message_blocks = final_message_blocks
   let build_message_body = build_message_body
+  let build_update_message_body = build_update_message_body
   let build_thread_status_body = build_thread_status_body
 
   let adapter_loop = adapter_loop_with_transport

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -578,7 +578,8 @@ let adapter_loop_with_transport
     | Tool_call_start _ ->
         update_activity "필요한 작업을 진행하고 있어요…";
         continue ()
-    | Tool_call_args _ | Tool_call_args_snapshot _ | Tool_call_end _ ->
+    | Tool_call_args _ | Tool_call_args_snapshot _ | Tool_call_end _
+    | Tool_result_ready _ ->
         continue ()
     | Link_block { url; title; description; image = _ } ->
         let block = link_block_json ~url ~title ~description in

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -1,8 +1,8 @@
 (** Keeper_chat_slack — Slack delivery adapter for keeper chat events.
 
     Subscribes to a [Keeper_chat_events] stream, accumulates assistant
-    text deltas and rich Block Kit blocks, and sends the final reply to
-    a Slack channel via the Web API when the run finishes. When the reply
+    text deltas and rich Block Kit blocks, and incrementally edits one Slack
+    reply before committing the final content when the run finishes. When the reply
     belongs to a thread, the production adapter projects active work through
     Slack's native assistant thread status.
 
@@ -70,8 +70,10 @@ val adapter_loop :
   unit ->
   unit
 (** [adapter_loop ~token ~channel ~events ?base_url ?on_send_result ()]
-    blocks on the event stream until [Run_finished] or [Error], then sends
-    the accumulated text (or error message) to the given Slack channel.
+    blocks on the event stream until [Run_finished] or [Error]. Stable text
+    creates one Slack message and updates that same message no more frequently
+    than Slack's documented streaming interval; terminal delivery commits the
+    complete text and rich blocks to the same message.
 
     Rich events ([Link_block], [Image_block], [Status_block], [Audio_block])
     are rendered as Slack Block Kit sections and included alongside the final
@@ -134,6 +136,14 @@ module For_testing : sig
 
   val adapter_loop :
     events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
+    ?post_stream:(content:string -> (string, error) result) ->
+    ?edit_stream:(message_id:string -> content:string -> (unit, error) result) ->
+    ?edit_blocks:
+      (message_id:string ->
+       content:string ->
+       blocks:Yojson.Safe.t list ->
+       (unit, error) result) ->
+    ?now:(unit -> float) ->
     send_plain:(content:string -> (unit, error) result) ->
     send_blocks:(content:string -> blocks:Yojson.Safe.t list -> (unit, error) result) ->
     ?set_activity_status:(status:string -> (unit, error) result) ->
@@ -141,7 +151,7 @@ module For_testing : sig
     ?on_send_result:((unit, error) result -> unit) ->
     unit ->
     unit
-  (** Test seam for the outbound transport. It runs the production terminal
-      settlement state machine with injected Slack sends and native activity
-      status updates. Activity failures never settle terminal delivery. *)
+  (** Test seam for the outbound transport. [post_stream], [edit_stream], and
+      [edit_blocks] are supplied together to exercise incremental delivery.
+      Activity failures never settle terminal delivery. *)
 end

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -143,7 +143,9 @@ module For_testing : sig
        content:string ->
        blocks:Yojson.Safe.t list ->
        (unit, error) result) ->
+    ?delete_stream:(message_id:string -> (unit, error) result) ->
     ?now:(unit -> float) ->
+    ?sleep:(float -> unit) ->
     send_plain:(content:string -> (unit, error) result) ->
     send_blocks:(content:string -> blocks:Yojson.Safe.t list -> (unit, error) result) ->
     ?set_activity_status:(status:string -> (unit, error) result) ->
@@ -151,7 +153,8 @@ module For_testing : sig
     ?on_send_result:((unit, error) result -> unit) ->
     unit ->
     unit
-  (** Test seam for the outbound transport. [post_stream], [edit_stream], and
-      [edit_blocks] are supplied together to exercise incremental delivery.
+  (** Test seam for the outbound transport. [post_stream], [edit_stream],
+      [edit_blocks], and [delete_stream] are supplied together to exercise
+      incremental delivery. [now] and [sleep] make update pacing deterministic.
       Activity failures never settle terminal delivery. *)
 end

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -57,6 +57,65 @@ let claude_dynamic_tool (tool : Host.dynamic_tool) : Runtime_claude_code.dynamic
   }
 ;;
 
+let claude_stream_callback on_event =
+  match on_event with
+  | None -> None
+  | Some emit ->
+    let next_tool_index = ref 1 in
+    let tool_indexes = Hashtbl.create 8 in
+    let streamed_text = Buffer.create 256 in
+    let turn_identity = ref None in
+    Some
+      (function
+        | Runtime_claude_code.Turn_started { turn_id; model } ->
+          turn_identity := Some (turn_id, model);
+          emit (Agent_core.Types.MessageStart { id = turn_id; model; usage = None })
+        | Runtime_claude_code.Text_delta text ->
+          Buffer.add_string streamed_text text;
+          emit
+            (Agent_core.Types.ContentBlockDelta
+               { index = 0; delta = Agent_core.Types.TextDelta text })
+        | Runtime_claude_code.Dynamic_tool_started
+            { call_id; tool_name; arguments } ->
+          let index = !next_tool_index in
+          incr next_tool_index;
+          Hashtbl.replace tool_indexes call_id index;
+          emit
+            (Agent_core.Types.ContentBlockStart
+               { index
+               ; content_type = "tool_use"
+               ; tool_id = Some call_id
+               ; tool_name = Some tool_name
+               });
+          emit
+            (Agent_core.Types.ContentBlockDelta
+               { index
+               ; delta =
+                   Agent_core.Types.InputJsonSnapshot
+                     (Yojson.Safe.to_string arguments)
+               })
+        | Runtime_claude_code.Dynamic_tool_finished { call_id } ->
+          Option.iter
+            (fun index ->
+               Hashtbl.remove tool_indexes call_id;
+               emit (Agent_core.Types.ContentBlockStop { index }))
+            (Hashtbl.find_opt tool_indexes call_id)
+        | Runtime_claude_code.Turn_finished { text } ->
+          emit Agent_core.Types.MessageStop;
+          if not (String.equal (Buffer.contents streamed_text) text)
+          then
+            Option.iter
+              (fun (turn_id, model) ->
+                 emit
+                   (Agent_core.Types.MessageStart
+                      { id = turn_id ^ "-terminal"
+                      ; model
+                      ; usage = None
+                      });
+                 emit Agent_core.Types.MessageStop)
+              !turn_identity)
+;;
+
 let retry_after_of_rate_limit = function
   | None -> None
   | Some ({ resets_at = None; _ } : Runtime_claude_code.rate_limit) -> None
@@ -126,7 +185,7 @@ let recovery_failure_of_client_error = function
 
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~raw_trace
+    ~context ~event_bus ~raw_trace ~on_event
     ~(config : Runtime_execution.claude_code) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
@@ -397,6 +456,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       (Runtime_claude_code.dynamic_tool_bytes dynamic_tools);
     let started_at = Time_compat.now () in
     let turn_result =
+      let on_stream_event = claude_stream_callback on_event in
       try
         (match
            Runtime_claude_code.run_turn
@@ -433,6 +493,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                    ~turn_id
                    ~turn_count
                    ~updated_at:(Time_compat.now ())))
+             ?on_stream_event
              client_config
              ~prompt
          with
@@ -650,7 +711,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~raw_trace ~config =
+    ~context ~event_bus ~raw_trace ~on_event ~config =
   Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
     run_without_lifecycle
       ~runtime_id
@@ -667,5 +728,6 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       ~context
       ~event_bus
       ~raw_trace
+      ~on_event
       ~config)
 ;;

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -64,11 +64,9 @@ let claude_stream_callback on_event =
     let next_tool_index = ref 1 in
     let tool_indexes = Hashtbl.create 8 in
     let streamed_text = Buffer.create 256 in
-    let turn_identity = ref None in
     Some
       (function
         | Runtime_claude_code.Turn_started { turn_id; model } ->
-          turn_identity := Some (turn_id, model);
           emit (Agent_core.Types.MessageStart { id = turn_id; model; usage = None })
         | Runtime_claude_code.Text_delta text ->
           Buffer.add_string streamed_text text;
@@ -101,19 +99,21 @@ let claude_stream_callback on_event =
                emit (Agent_core.Types.ContentBlockStop { index }))
             (Hashtbl.find_opt tool_indexes call_id)
         | Runtime_claude_code.Turn_finished { text } ->
-          emit Agent_core.Types.MessageStop;
-          if not (String.equal (Buffer.contents streamed_text) text)
-          then
-            Option.iter
-              (fun (turn_id, model) ->
-                 emit
-                   (Agent_core.Types.MessageStart
-                      { id = turn_id ^ "-terminal"
-                      ; model
-                      ; usage = None
-                      });
-                 emit Agent_core.Types.MessageStop)
-              !turn_identity)
+          let streamed = Buffer.contents streamed_text in
+          if String.starts_with ~prefix:streamed text
+          then begin
+            let suffix_length = String.length text - String.length streamed in
+            if suffix_length > 0
+            then
+              emit
+                (Agent_core.Types.ContentBlockDelta
+                   { index = 0
+                   ; delta =
+                       Agent_core.Types.TextDelta
+                         (String.sub text (String.length streamed) suffix_length)
+                   })
+          end;
+          emit Agent_core.Types.MessageStop
 ;;
 
 let retry_after_of_rate_limit = function

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -287,7 +287,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ; cwd = base_path
       ; model = config.model
       ; system_prompt
-      ; (* A per-model [turn-timeout-s] overrides the admission-time bound.
+      ; (* A per-model [turn-timeout-s] overrides the stream-idle bound.
            Absent, [config.timeout_s] stands, so a config that declares none
            behaves exactly as before. *)
         timeout_s =

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -15,5 +15,6 @@ val run :
   context:Agent_core.Context.t option ->
   event_bus:Agent_core.Event_bus.t option ->
   raw_trace:Agent_core.Raw_trace.t option ->
+  on_event:(Agent_core.Types.sse_event -> unit) option ->
   config:Runtime_execution.claude_code ->
   (Runtime_agent.run_result, Agent_core.Error.t) result

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -152,11 +152,9 @@ let codex_stream_callback on_event =
     let next_tool_index = ref 1 in
     let tool_indexes = Hashtbl.create 8 in
     let streamed_text = Buffer.create 256 in
-    let turn_identity = ref None in
     Some
       (function
         | Runtime_codex_app_server.Turn_started { turn_id; model } ->
-          turn_identity := Some (turn_id, model);
           emit (Agent_core.Types.MessageStart { id = turn_id; model; usage = None })
         | Runtime_codex_app_server.Text_delta text ->
           Buffer.add_string streamed_text text;
@@ -189,19 +187,21 @@ let codex_stream_callback on_event =
                emit (Agent_core.Types.ContentBlockStop { index }))
             (Hashtbl.find_opt tool_indexes call_id)
         | Runtime_codex_app_server.Turn_finished { text } ->
-          emit Agent_core.Types.MessageStop;
-          if not (String.equal (Buffer.contents streamed_text) text)
-          then
-            Option.iter
-              (fun (turn_id, model) ->
-                 emit
-                   (Agent_core.Types.MessageStart
-                      { id = turn_id ^ "-terminal"
-                      ; model
-                      ; usage = None
-                      });
-                 emit Agent_core.Types.MessageStop)
-              !turn_identity)
+          let streamed = Buffer.contents streamed_text in
+          if String.starts_with ~prefix:streamed text
+          then begin
+            let suffix_length = String.length text - String.length streamed in
+            if suffix_length > 0
+            then
+              emit
+                (Agent_core.Types.ContentBlockDelta
+                   { index = 0
+                   ; delta =
+                       Agent_core.Types.TextDelta
+                         (String.sub text (String.length streamed) suffix_length)
+                   })
+          end;
+          emit Agent_core.Types.MessageStop
 ;;
 
 let codex_error_to_core_error = function

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -353,7 +353,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       { Runtime_codex_app_server.cli_path = config.cli_path
       ; model = config.model
       ; developer_instructions
-      ; (* A per-model [turn-timeout-s] overrides the admission-time bound.
+      ; (* A per-model [turn-timeout-s] overrides the stream-idle bound.
            Absent, [config.timeout_s] stands, so a config that declares none
            behaves exactly as before. *)
         timeout_s =

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -145,6 +145,65 @@ let codex_dynamic_tool (tool : Host.dynamic_tool) :
   }
 ;;
 
+let codex_stream_callback on_event =
+  match on_event with
+  | None -> None
+  | Some emit ->
+    let next_tool_index = ref 1 in
+    let tool_indexes = Hashtbl.create 8 in
+    let streamed_text = Buffer.create 256 in
+    let turn_identity = ref None in
+    Some
+      (function
+        | Runtime_codex_app_server.Turn_started { turn_id; model } ->
+          turn_identity := Some (turn_id, model);
+          emit (Agent_core.Types.MessageStart { id = turn_id; model; usage = None })
+        | Runtime_codex_app_server.Text_delta text ->
+          Buffer.add_string streamed_text text;
+          emit
+            (Agent_core.Types.ContentBlockDelta
+               { index = 0; delta = Agent_core.Types.TextDelta text })
+        | Runtime_codex_app_server.Dynamic_tool_started
+            { call_id; tool_name; arguments } ->
+          let index = !next_tool_index in
+          incr next_tool_index;
+          Hashtbl.replace tool_indexes call_id index;
+          emit
+            (Agent_core.Types.ContentBlockStart
+               { index
+               ; content_type = "tool_use"
+               ; tool_id = Some call_id
+               ; tool_name = Some tool_name
+               });
+          emit
+            (Agent_core.Types.ContentBlockDelta
+               { index
+               ; delta =
+                   Agent_core.Types.InputJsonSnapshot
+                     (Yojson.Safe.to_string arguments)
+               })
+        | Runtime_codex_app_server.Dynamic_tool_finished { call_id } ->
+          Option.iter
+            (fun index ->
+               Hashtbl.remove tool_indexes call_id;
+               emit (Agent_core.Types.ContentBlockStop { index }))
+            (Hashtbl.find_opt tool_indexes call_id)
+        | Runtime_codex_app_server.Turn_finished { text } ->
+          emit Agent_core.Types.MessageStop;
+          if not (String.equal (Buffer.contents streamed_text) text)
+          then
+            Option.iter
+              (fun (turn_id, model) ->
+                 emit
+                   (Agent_core.Types.MessageStart
+                      { id = turn_id ^ "-terminal"
+                      ; model
+                      ; usage = None
+                      });
+                 emit Agent_core.Types.MessageStop)
+              !turn_identity)
+;;
+
 let codex_error_to_core_error = function
   | Runtime_codex_app_server.Invalid_config detail ->
     config_error ~field:"codex_app_server" detail
@@ -184,7 +243,7 @@ let recovery_failure_of_client_error = function
 
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
-    ~context_injector ~context ~event_bus ~raw_trace
+    ~context_injector ~context ~event_bus ~raw_trace ~on_event
     ~(config : Runtime_execution.codex_app_server) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
@@ -464,6 +523,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     let started_at = Time_compat.now () in
     let turn_result =
       try
+        let on_stream_event = codex_stream_callback on_event in
         (match
        Runtime_codex_app_server.run_turn
          ~mgr:(Eio.Stdenv.process_mgr env)
@@ -473,6 +533,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
          ?reasoning_effort:prepared.reasoning_effort
          ~thread_mode
          ~history
+         ?on_stream_event
          ~on_thread_ready:(fun ~thread_id ->
            update_session "active transition" (fun expected ->
              Keeper_official_client_session_store.mark_active
@@ -673,7 +734,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
-    ~context_injector ~context ~event_bus ~raw_trace ~config =
+    ~context_injector ~context ~event_bus ~raw_trace ~on_event ~config =
   let observed_full_bytes = ref None in
   let observed_history_atoms = ref None in
   let starting_capacity_bytes =
@@ -735,6 +796,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
           ~context
           ~event_bus
           ~raw_trace
+          ~on_event
           ~config)
       ())
 ;;

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -15,5 +15,6 @@ val run :
   context:Agent_core.Context.t option ->
   event_bus:Agent_core.Event_bus.t option ->
   raw_trace:Agent_core.Raw_trace.t option ->
+  on_event:(Agent_core.Types.sse_event -> unit) option ->
   config:Runtime_execution.codex_app_server ->
   (Runtime_agent.run_result, Agent_core.Error.t) result

--- a/lib/keeper/keeper_external_resource_lease.ml
+++ b/lib/keeper/keeper_external_resource_lease.ml
@@ -1,0 +1,17 @@
+type t =
+  | File_path of string
+  | Host_cwd of string
+
+let key = function
+  | File_path path -> "file\000" ^ path
+  | Host_cwd path -> "host-cwd\000" ^ path
+;;
+
+let with_lease resource f =
+  let key = key resource in
+  let lock = Keeper_fs.acquire_path_lock key in
+  Fun.protect
+    ~finally:(fun () -> Keeper_fs.release_path_lock key lock)
+    (fun () ->
+       Eio.Mutex.use_rw ~protect:true (Keeper_fs.path_lock_mutex lock) f)
+;;

--- a/lib/keeper/keeper_external_resource_lease.mli
+++ b/lib/keeper/keeper_external_resource_lease.mli
@@ -1,0 +1,14 @@
+(** Process-local exclusion for concrete external resources.
+
+    Keeper Owners remain independent. Only operations carrying the same
+    resolved resource key wait for one another; unrelated paths and working
+    directories continue concurrently. *)
+
+type t =
+  | File_path of string
+  | Host_cwd of string
+
+val with_lease : t -> (unit -> 'a) -> 'a
+(** Run [f] while exclusively owning the exact resource. Waiting applies
+    backpressure. Cancellation and exceptions always release the registry
+    reference and the mutex. *)

--- a/lib/keeper/keeper_hooks_agent_core.ml
+++ b/lib/keeper/keeper_hooks_agent_core.ml
@@ -139,6 +139,7 @@ let make_hooks
         success:bool -> duration_ms:float -> provider:string ->
         typed_outcome:Keeper_tool_outcome.t option -> unit =
         fun ~tool_name:_ ~input:_ ~output_text:_ ~success:_ ~duration_ms:_ ~provider:_ ~typed_outcome:_ -> ())
+    ?on_tool_result_ready
     ?(trajectory_acc : Trajectory.accumulator option)
     ()
   : Agent_core.Hooks.hooks =
@@ -515,7 +516,12 @@ let make_hooks
              ?allowed_paths:tctx.allowed_paths
              ?network_mode:tctx.network_mode
              ?runtime_profile:tctx.runtime_profile
-             ~result_bytes ?truncated_to ()
+             ~result_bytes ?truncated_to
+             ?on_committed:
+               (Option.map
+                  (fun notify () -> notify ~tool_call_id:tool_use_id)
+                  on_tool_result_ready)
+             ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
@@ -530,7 +536,8 @@ let make_hooks
                ();
              Log.Keeper.warn ~keeper_name:(!meta_ref).name
                "tool=%s log_call write failed: %s"
-               tool_name (Printexc.to_string exn));
+               tool_name (Printexc.to_string exn);
+             if Option.is_some on_tool_result_ready then raise exn);
         (match trajectory_acc with
          | None -> ()
          | Some acc ->

--- a/lib/keeper/keeper_hooks_agent_core.mli
+++ b/lib/keeper/keeper_hooks_agent_core.mli
@@ -167,11 +167,13 @@ val make_hooks :
                      success:bool ->
                      duration_ms:float -> provider:string ->
                      typed_outcome:Keeper_tool_outcome.t option -> unit) ->
+  ?on_tool_result_ready:(tool_call_id:string -> unit) ->
   ?trajectory_acc:Trajectory.accumulator ->
   unit -> Agent_core.Hooks.hooks
 (** Build the [Agent_core.Hooks.hooks] record used by the keeper turn loop:
     passive pre-tool timing, post-tool accounting, idle detection, and
-    trajectory hooks wired together. Cost remains part of post-turn
+    trajectory hooks wired together. [on_tool_result_ready] runs only after
+    the exact tool-call log row is synchronously committed. Cost remains part of post-turn
     observation. *)
 
 val hook_introspection_json : unit -> Yojson.Safe.t

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -712,6 +712,16 @@ let start_keepalive_outcome_to_string = function
   | Keepalive_lane_ownership_lost -> "lane ownership lost before fiber fork"
   | Keepalive_fork_rejected error -> Keeper_lane.start_error_to_string error
 
+let wake_queued_owner_operations ~base_path keeper_name =
+  match Keeper_owner_registry.wake_operation_drain ~base_path ~keeper_name with
+  | Ok () -> ()
+  | Error error ->
+    Log.Keeper.warn
+      "start_keepalive: owner operation drain wake rejected keeper=%s error=%s"
+      keeper_name
+      (Keeper_owner_registry.command_error_to_string error)
+;;
+
 let record_lifecycle_start_denial
       (meta : keeper_meta)
       (denial : Keeper_lifecycle_admission.autonomous_denial)
@@ -850,6 +860,9 @@ let start_keepalive
      | _ -> ());
     match Keeper_registry.get ~base_path:ctx.config.base_path m.name with
     | Some registered ->
+      wake_queued_owner_operations
+        ~base_path:ctx.config.base_path
+        m.name;
       Log.Keeper.emit
         Log.Info
         ~category:Log.Heartbeat
@@ -993,6 +1006,9 @@ let start_keepalive
               (Keeper_lane.start_error_to_string error));
           Keepalive_lane_ownership_lost)
         else (
+        wake_queued_owner_operations
+          ~base_path:ctx.config.base_path
+          live_meta.name;
         (* Telemetry feedback refresh loop removed in #6814:
          behavioral_stats no longer consumed by build_prompt. *)
         let current_failure_reason () =

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -89,6 +89,11 @@ type operation_executor =
   claim:(unit -> (Chat_operation.t option, error) result) ->
   operation_execution
 
+type operation_runner =
+  { ready : keeper_name:string -> bool
+  ; execute : operation_executor
+  }
+
 type 'a autonomous_response =
   | Autonomous_ran of 'a
   | Autonomous_busy of autonomous_block
@@ -146,6 +151,7 @@ type _ command =
       ; outcome_ref : string option
       }
       -> (Chat_operation.t, error) result command
+  | Wake_operation_drain : (unit, error) result command
   | Run_if_idle :
       { lane : turn_lane
       ; run : unit -> 'a
@@ -406,7 +412,7 @@ let start
       ~store
       ~operation_store_path
       ~now
-      ~operation_executor
+      ~operation_runner
       ~keeper_name
       ~initial_meta
   =
@@ -493,13 +499,14 @@ let start
         |> Result.map (fun _ -> ())
     in
     let rec start_child_if_needed state shutdown_operation_id =
-      match operation_executor with
+      match operation_runner with
       | None -> ()
       | Some _ when !(t.child_active) -> ()
       | Some _ when Option.is_some shutdown_operation_id -> ()
       | Some _ when (Keeper_owner_reducer.projection state).stopping -> ()
       | Some _ when Option.is_some !(t.store_error) -> ()
-      | Some executor ->
+      | Some runner when not (runner.ready ~keeper_name:t.keeper_name) -> ()
+      | Some runner ->
         let inventory = Atomic.get t.operation_projection in
         if inventory.queued_count > 0 && Option.is_none inventory.running_operation_id
         then (
@@ -529,7 +536,7 @@ let start
                       ; detail = "Keeper owner is stopping"
                       ; outcome_ref = None
                       }
-                  else executor ~sw:child_sw ~keeper_name ~claim)
+                  else runner.execute ~sw:child_sw ~keeper_name ~claim)
               with
               | Stop_active_child ->
                 Operation_failed
@@ -702,6 +709,10 @@ let start
           in
           Eio.Promise.resolve resolve response;
           loop state shutdown_operation_id
+        | Command (Wake_operation_drain, resolve) ->
+          Eio.Promise.resolve resolve (Ok ());
+          start_child_if_needed state shutdown_operation_id;
+          loop state shutdown_operation_id
         | Command (Begin_shutdown { operation_id }, resolve) ->
           (match shutdown_operation_id with
            | None ->
@@ -868,6 +879,7 @@ let start
 let exact_projection t = request t Exact_projection
 let apply_meta t command = request t (Apply_meta command)
 let exact_operation t operation_id = request t (Exact_operation operation_id)
+let wake_operation_drain t = request t Wake_operation_drain
 
 let submit_operation t ~operation_id ~source ~input =
   request t (Submit_operation { operation_id; source; input })

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -98,6 +98,15 @@ type operation_executor =
     body before [claim]: [claim] is the mailbox-linearized Queued-to-Running
     boundary and returns the latest edited input. *)
 
+type operation_runner =
+  { ready : keeper_name:string -> bool
+  ; execute : operation_executor
+  }
+(** Typed admission for the durable operation drain. [ready] must be a
+    non-yielding in-memory read. When it returns [false], the FIFO head remains
+    Queued and no child is started. The producer that makes the dependency
+    ready must call {!wake_operation_drain}; the Owner never polls. *)
+
 type t
 
 val start
@@ -105,7 +114,7 @@ val start
   -> store:store
   -> operation_store_path:string
   -> now:(unit -> float)
-  -> operation_executor:operation_executor option
+  -> operation_runner:operation_runner option
   -> keeper_name:string
   -> initial_meta:Keeper_meta_contract.keeper_meta option
   -> (t, error) result
@@ -115,6 +124,10 @@ val projection : t -> Keeper_owner_reducer.projection
 
 val operation_projection : t -> operation_projection
 (** Lock-free immutable operation inventory. *)
+
+val wake_operation_drain : t -> (unit, error) result
+(** Reconsider existing Queued rows after the operation runner's dependency
+    becomes ready. This command never changes sequence or state itself. *)
 
 val turn_in_flight : t -> turn_in_flight option
 (** Lock-free immutable projection of the single Owner-owned child turn. *)

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -27,7 +27,7 @@ type pool =
   ; owners_mu : Eio.Mutex.t
   ; owner_handles : Keeper_owner.t list Atomic.t
   ; stopping : bool Atomic.t
-  ; operation_executor : Keeper_owner.operation_executor option
+  ; operation_runner : Keeper_owner.operation_runner option
   }
 
 let pools : (string, pool) Hashtbl.t = Hashtbl.create 4
@@ -165,7 +165,7 @@ let start_owner pool ~keeper_name ~initial_meta =
       ~operation_store_path
       (* NDT-OK: wall time is injected once at the Owner persistence boundary. *)
       ~now:Unix.gettimeofday
-      ~operation_executor:pool.operation_executor
+      ~operation_runner:pool.operation_runner
       ~keeper_name
       ~initial_meta
 ;;
@@ -241,7 +241,7 @@ let ensure_empty_in_pool pool keeper_name =
               Ok owner)))
 ;;
 
-let install_from_store ~sw ~operation_executor config =
+let install_from_store ~sw ~operation_runner config =
   let base_path = pool_key config.Workspace.base_path in
   match load_all config with
   | Error _ as error -> error
@@ -254,7 +254,7 @@ let install_from_store ~sw ~operation_executor config =
       ; owners_mu = Eio.Mutex.create ()
       ; owner_handles = Atomic.make []
       ; stopping = Atomic.make false
-      ; operation_executor
+      ; operation_runner
       }
     in
     let installed =
@@ -330,6 +330,14 @@ let operation_projection ~base_path ~keeper_name =
   match get ~base_path ~keeper_name with
   | Error error -> Error error
   | Ok owner -> Ok (Keeper_owner.operation_projection owner)
+;;
+
+let wake_operation_drain ~base_path ~keeper_name =
+  match get ~base_path ~keeper_name with
+  | Error error -> Error (Command_lookup_failed error)
+  | Ok owner ->
+    Keeper_owner.wake_operation_drain owner
+    |> Result.map_error (fun error -> Command_rejected error)
 ;;
 
 let shutdown_operation_id ~base_path ~keeper_name =

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -26,7 +26,7 @@ exception Install_failed of install_error
 
 val install_from_store
   :  sw:Eio.Switch.t
-  -> operation_executor:Keeper_owner.operation_executor option
+  -> operation_runner:Keeper_owner.operation_runner option
   -> Workspace.config
   -> (int, install_error) result
 (** Load each valid persisted Keeper independently and start exactly one owner
@@ -47,6 +47,12 @@ val operation_projection
   -> keeper_name:string
   -> (Keeper_owner.operation_projection, lookup_error) result
 (** Lock-free immutable operation inventory for routine read models. *)
+
+val wake_operation_drain
+  :  base_path:string
+  -> keeper_name:string
+  -> (unit, command_error) result
+(** Notify one Owner that its operation runner dependency is ready. *)
 
 val run_autonomous_if_idle
   :  base_path:string

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -94,6 +94,7 @@ val prepare_agent_setup
   -> ?runtime_manifest_context:Keeper_runtime_manifest.turn_context
   -> ?runtime_manifest_append:(Keeper_runtime_manifest.t -> unit)
   -> ?continuation_channel:Keeper_continuation_channel.t
+  -> ?on_tool_result_ready:(tool_call_id:string -> unit)
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
   -> unit
   -> (agent_setup, Agent_core.Error.t) result

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -51,6 +51,7 @@ type ctx =
   ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref
   ; receipt_runtime_observation_ref : Runtime_observation.runtime_observation option ref
   ; receipt_response_text_present_ref : bool ref
+  ; on_tool_result_ready : (tool_call_id:string -> unit) option
   ; tools : Agent_core.Tool.t list
   }
 
@@ -196,6 +197,7 @@ let assemble_hooks
         ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
         ~keeper_turn_id
         ~on_after_turn_ordinal:(fun turn -> final_agent_core_turn_ordinal_ref := Some turn)
+        ?on_tool_result_ready:ctx.on_tool_result_ready
         ?trajectory_acc
         ~on_tool_executed:
           (fun

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -123,6 +123,7 @@ let prepare_agent_setup
       ?runtime_manifest_context
       ?runtime_manifest_append
       ?continuation_channel
+      ?on_tool_result_ready
       ?hitl_resolution
       ()
   : (Keeper_run_tools_hooks.agent_setup, Agent_core.Error.t) result
@@ -395,6 +396,7 @@ let prepare_agent_setup
     ; receipt_stop_reason_ref
     ; receipt_runtime_observation_ref
     ; receipt_response_text_present_ref
+    ; on_tool_result_ready
     ; tools
     }
   in

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -426,7 +426,7 @@ let handle_tool_execute_typed
                   meta.name
                   (Printexc.to_string exn))
           in
-          let dispatch_result =
+          let dispatch () =
             Keeper_tooling.Execute_shell_ir.dispatch
               ~workdir:cwd
               ~sandbox:dispatch_sandbox
@@ -434,6 +434,14 @@ let handle_tool_execute_typed
               ?base_host_env
               ~on_output_chunk
               ir
+          in
+          let dispatch_result =
+            match dispatch_sandbox with
+            | Masc_exec.Sandbox_target.Host ->
+              Keeper_external_resource_lease.with_lease
+                (Keeper_external_resource_lease.Host_cwd cwd)
+                dispatch
+            | Docker _ -> dispatch ()
           in
           match dispatch_result with
           | Error (Keeper_tooling.Execute_shell_ir.Gate_reject diagnostic) ->

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -2423,7 +2423,11 @@ let handle_file_write_with_outcome
                 |> Result.map_error (fun error ->
                   Content_write_capability { error; created_parents })))
       in
-      (match run () with
+      (match
+         Keeper_external_resource_lease.with_lease
+           (Keeper_external_resource_lease.File_path target)
+           run
+       with
        | Ok attempt -> file_write_attempt_to_execution attempt
        | Error msg ->
          Keeper_tool_execution.failure
@@ -2546,7 +2550,11 @@ let handle_file_write_with_outcome
                             file
                             content))))
       in
-      (match run () with
+      (match
+         Keeper_external_resource_lease.with_lease
+           (Keeper_external_resource_lease.File_path target)
+           run
+       with
        | Ok attempt -> file_write_attempt_to_execution attempt
        | Error msg ->
          Keeper_tool_execution.failure
@@ -2816,7 +2824,11 @@ let handle_file_write_with_outcome
                                  Content_write_capability
                                    { error; created_parents = [] }))))
               in
-              (match run () with
+              (match
+                 Keeper_external_resource_lease.with_lease
+                   (Keeper_external_resource_lease.File_path target)
+                   run
+               with
                | Ok attempt -> file_write_attempt_to_execution attempt
                | Error msg ->
                  Keeper_tool_execution.failure

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -523,6 +523,7 @@ let dispatch_keeper_msg_stream_admitted
       ~admission_token
       ?on_text_delta
       ?on_event
+      ?on_tool_result_ready
       ?continuation_channel
       ctx
       ~message
@@ -536,6 +537,7 @@ let dispatch_keeper_msg_stream_admitted
           ~admission_token
           ?on_text_delta
           ?on_event
+          ?on_tool_result_ready
           ?continuation_channel
           ctx
           message))

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -45,6 +45,7 @@ val dispatch_keeper_msg_stream_admitted :
   admission_token:Keeper_turn_dispatch_authority.token ->
   ?on_text_delta:(string -> unit) ->
   ?on_event:(Agent_core.Types.sse_event -> unit) ->
+  ?on_tool_result_ready:(tool_call_id:string -> unit) ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   _ context ->
   message:Keeper_invocation_contract.direct_message ->

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -842,6 +842,7 @@ let handle_keeper_msg_stream_admitted
       ~admission_token
       ?on_text_delta
       ?on_event
+      ?on_tool_result_ready
       ?continuation_channel
       ctx
       message
@@ -860,6 +861,7 @@ let handle_keeper_msg_stream_admitted
       ~admission_token
       ?on_text_delta
       ?on_event
+      ?on_tool_result_ready
       ?event_bus
       ?continuation_channel
       ctx

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -387,6 +387,7 @@ let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
 let run_keeper_invocation_turn_admitted_inner
       ?on_text_delta
       ?on_event
+      ?on_tool_result_ready
       ?event_bus
       ?continuation_channel
       ~surface
@@ -746,6 +747,7 @@ let run_keeper_invocation_turn_admitted_inner
 			                                ~world_observation
 		                                ~generation:meta.runtime.nonce
 		                                ?on_event
+		                                ?on_tool_result_ready
 		                                ~trajectory_acc
 		                                ?degraded_retry_runtime
 		                                ?fallback_reason
@@ -926,6 +928,7 @@ let run_keeper_invocation_turn_admitted_inner
 let run_keeper_invocation_turn_admitted
       ?on_text_delta
       ?on_event
+      ?on_tool_result_ready
       ?event_bus
       ?continuation_channel
       ~surface
@@ -950,6 +953,7 @@ let run_keeper_invocation_turn_admitted
     run_keeper_invocation_turn_admitted_inner
       ?on_text_delta
       ?on_event
+      ?on_tool_result_ready
       ?event_bus
       ?continuation_channel
       ~surface
@@ -969,6 +973,7 @@ let handle_keeper_msg_admitted
       ~admission_token:_
       ?on_text_delta
       ?on_event
+      ?on_tool_result_ready
       ?event_bus
       ?continuation_channel
       ctx
@@ -980,6 +985,7 @@ let handle_keeper_msg_admitted
   run_keeper_invocation_turn_admitted
     ?on_text_delta
     ?on_event
+    ?on_tool_result_ready
     ?event_bus
     ?continuation_channel
     ~surface:Direct_message

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -129,6 +129,7 @@ val handle_keeper_msg_admitted :
   admission_token:Keeper_turn_dispatch_authority.token ->
   ?on_text_delta:(string -> unit) ->
   ?on_event:(Agent_core.Types.sse_event -> unit) ->
+  ?on_tool_result_ready:(tool_call_id:string -> unit) ->
   ?event_bus:Agent_core.Event_bus.t ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   _ Keeper_types_profile.context ->

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -722,6 +722,7 @@ let run_named
             ~context
             ~event_bus
             ~raw_trace
+            ~on_event
             ~config
         in
         let codex_result =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -794,6 +794,7 @@ let run_named
             ~context
             ~event_bus
             ~raw_trace
+            ~on_event
             ~config
         in
         let run_antigravity_with_history () =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -863,6 +863,7 @@ let run_named
             ~context
             ~event_bus
             ~raw_trace
+            ~on_event
             ~config
         in
         let claude_result =

--- a/lib/keeper_chat_operations/keeper_chat_operation_store.ml
+++ b/lib/keeper_chat_operations/keeper_chat_operation_store.ml
@@ -118,6 +118,14 @@ let exec db ~operation sql =
   else Error (Store_unavailable (sqlite_error db operation rc))
 ;;
 
+let close_db db =
+  let closed = Sqlite3.db_close db in
+  (* [caml_sqlite3_close] has the same runtime-release/null-after-return
+     lifetime window as statement finalization. *)
+  ignore (Sys.opaque_identity db);
+  closed
+;;
+
 let prepare db ~operation sql =
   try Ok (Sqlite3.prepare db sql) with
   | Sqlite3.Error detail -> Error (Store_unavailable (operation ^ ": " ^ detail))
@@ -134,6 +142,13 @@ let finalize db stmt result =
     | Sqlite3.Error detail ->
       Error (Store_unavailable ("finalize statement: " ^ detail))
   in
+  (* sqlite3-ocaml 5.4.1 releases the OCaml runtime while
+     [sqlite3_finalize] runs, then clears the statement pointer only after it
+     reacquires the runtime.  Without a use after [Sqlite3.finalize], another
+     domain can collect the wrapper in that window and its GC finalizer calls
+     [sqlite3_finalize] on the same pointer.  Keep the wrapper reachable until
+     the explicit finalize has fully returned. *)
+  ignore (Sys.opaque_identity stmt);
   match result, cleanup with
   | Ok value, Ok () -> Ok value
   | Error _ as error, Ok () -> error
@@ -543,7 +558,7 @@ let open_or_create ~path =
   let db = Sqlite3.db_open path in
   let fail error =
     (* See open failure contract: preserve the typed store error; close is best-effort. *)
-    ignore (Sqlite3.db_close db : bool);
+    ignore (close_db db : bool);
     Error error
   in
   match configure db with
@@ -575,7 +590,7 @@ let open_or_create ~path =
 let close store =
   if Atomic.compare_and_set store.closed false true
   then
-    if Sqlite3.db_close store.db
+    if close_db store.db
     then Ok ()
     else Error (Store_unavailable "failed to close SQLite database")
   else Ok ()

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -256,7 +256,8 @@ let append_to_store_result (entry : append_entry) =
 ;;
 
 let append_to_store entry =
-  ignore (append_to_store_result entry : (unit, exn) result)
+  match append_to_store_result entry with
+  | Ok () | Error _ -> ()
 ;;
 
 let take_queued_append () =

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -176,6 +176,8 @@ let current_log_path () =
 let configured_masc_root () =
   Option.map fst (Atomic.get store_state).configured
 
+exception Commit_required_but_store_unavailable
+
 let record_append_coverage_gap ~store ~keeper_name ~tool_name ?trace_id exn =
   let durable_store = Dated_jsonl.base_dir store in
   let masc_root = Filename.dirname durable_store in
@@ -229,8 +231,11 @@ let record_unavailable_coverage_gap ~keeper_name ~tool_name ?trace_id () =
          (Printexc.to_string gap_exn))
 ;;
 
-let append_to_store (entry : append_entry) =
-  try Dated_jsonl.append entry.store entry.json with
+let append_to_store_result (entry : append_entry) =
+  try
+    Dated_jsonl.append entry.store entry.json;
+    Ok ()
+  with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     let trace_id = entry.trace_id in
@@ -246,7 +251,12 @@ let append_to_store (entry : append_entry) =
       ~keeper_name:entry.keeper_name
       ~tool_name:entry.tool_name
       ?trace_id
-      exn
+      exn;
+    Error exn
+;;
+
+let append_to_store entry =
+  ignore (append_to_store_result entry : (unit, exn) result)
 ;;
 
 let take_queued_append () =
@@ -393,10 +403,15 @@ let log_call
       ?runtime_profile
       ?result_bytes
       ?truncated_to
+      ?on_committed
       ()
   =
   match (Atomic.get store_state).store with
-    | None -> record_unavailable_coverage_gap ~keeper_name ~tool_name ?trace_id ()
+    | None ->
+      record_unavailable_coverage_gap ~keeper_name ~tool_name ?trace_id ();
+      (match on_committed with
+       | None -> ()
+       | Some _ -> raise Commit_required_but_store_unavailable)
     | Some store ->
       (* RFC-0225 §3.3: no ambient turn-context fallback. Both production
          callers (keeper_hooks_agent_core, mcp_server_eio_call_tool) pass their
@@ -594,7 +609,13 @@ let log_call
          captures) that would corrupt the JSONL file and cause downstream
          readers — including the dashboard — to silently skip entire rows. *)
       let safe_json = Inference_utils.sanitize_json_utf8 json in
-      append_or_enqueue { store; keeper_name; tool_name; trace_id; json = safe_json }
+      let entry = { store; keeper_name; tool_name; trace_id; json = safe_json } in
+      (match on_committed with
+       | None -> append_or_enqueue entry
+       | Some notify ->
+         (match append_to_store_result entry with
+          | Ok () -> notify ()
+          | Error exn -> raise exn))
 ;;
 
 (* Scan multiplier applied before the keeper filter: [read_recent] reads

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -160,6 +160,7 @@ val log_call :
   ?runtime_profile:string ->
   ?result_bytes:int ->
   ?truncated_to:int ->
+  ?on_committed:(unit -> unit) ->
   unit ->
   unit
 (** [log_call ...] persists a single tool call record with full I/O.
@@ -170,7 +171,10 @@ val log_call :
     agent_core:tool_called/agent_core:tool_completed event rows also carry. Blank and
     repeated provider ids remain meaningful when scoped by [turn] and
     [planned_index], so they are persisted unchanged.
-    Output is truncated to 4000 bytes. [model] is a compatibility input only;
+    [on_committed], when supplied, forces this row through the synchronous
+    append boundary and runs only after that append succeeds. It is intended
+    for exact completion notifications whose readers must not race the
+    asynchronous log queue. Output is truncated to 4000 bytes. [model] is a compatibility input only;
     non-empty values are redacted to the neutral runtime lane. [runtime_profile]
     is persisted separately as the operator-facing runtime selector. Turn-policy fields ([lane], [tool_choice],
     [thinking_enabled], [thinking_budget]) capture the effective tool
@@ -227,4 +231,3 @@ val reset_for_testing : unit -> unit
 
 val queued_count_for_testing : unit -> int
 (** Number of queued asynchronous append records. For unit tests only. *)
-

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -358,9 +358,9 @@ val reasoning_effort_of_runtime_id : string -> Llm_provider.Reasoning_effort.t o
 
 val turn_timeout_s_of_runtime_id : string -> float option
 (** Per-model [turn-timeout-s] from runtime.toml, or [None] when unset or the
-    runtime id is unknown. Codex and Claude interpret it as the maximum silence
-    between protocol messages, not total turn duration. [None] means "keep
-    whatever bound the caller already has". Consumed by
+    runtime id is unknown. Official-client adapters interpret it as the maximum
+    silence between protocol messages, not total turn duration. [None] means
+    "keep whatever bound the caller already has". Consumed by
     {!Runtime_inference.resolve_turn_timeout_s}. *)
 
 val max_prompt_bytes_of_runtime_id : string -> int option

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -357,15 +357,15 @@ val reasoning_effort_of_runtime_id : string -> Llm_provider.Reasoning_effort.t o
     {!Runtime_inference.resolve_reasoning_effort}. *)
 
 val turn_timeout_s_of_runtime_id : string -> float option
+(** Per-model [turn-timeout-s] from runtime.toml, or [None] when unset or the
+    runtime id is unknown. Codex and Claude interpret it as the maximum silence
+    between protocol messages, not total turn duration. [None] means "keep
+    whatever bound the caller already has". Consumed by
+    {!Runtime_inference.resolve_turn_timeout_s}. *)
 
 val max_prompt_bytes_of_runtime_id : string -> int option
 (** Declared [max-prompt-bytes] for the model bound to this runtime id, or
     [None] when the model declares none. *)
-(** Per-model [turn-timeout-s] from runtime.toml, or [None] when unset or the
-    runtime id is unknown. [None] means "keep whatever bound the caller already
-    has" — the antigravity provider [timeout-s] or the adapter default — so an
-    unknown id degrades to current behaviour rather than to an invented bound.
-    Consumed by {!Runtime_inference.resolve_turn_timeout_s}. *)
 
 val top_p_of_runtime_id : string -> float option
 (** Request [top_p] from the materialized AGENT_CORE provider config for runtime [id],

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -80,6 +80,26 @@ type turn_result =
   ; wall_duration_s : float
   }
 
+type stream_event =
+  | Turn_started of
+      { conversation_id : string
+      ; model : string
+      }
+  | Text_delta of string
+  | Turn_finished of { text : string }
+
+let emit_stream_event on_stream_event event =
+  match on_stream_event with
+  | None -> ()
+  | Some emit ->
+    (try emit event with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Runtime_agent.warn
+         "Antigravity stream callback raised (error=%s)"
+         (Printexc.to_string exn))
+;;
+
 type error =
   | Invalid_config of string
   | Spawn_failed of string
@@ -554,7 +574,8 @@ let verify_identity ~stage ~expected actual =
   | None | Some _ -> Ok ()
 ;;
 
-let apply_event (config : config) ~conversation_mode ~on_conversation_ready state = function
+let apply_event (config : config) ~conversation_mode ~on_conversation_ready
+    ~on_stream_event state = function
   | Init { conversation_id; model; cwd; permission_mode } ->
     let stage = "init event" in
     if Option.is_some state.init
@@ -587,6 +608,9 @@ let apply_event (config : config) ~conversation_mode ~on_conversation_ready stat
         (match callback_result with
          | Error detail -> Error (State_callback_failed detail)
          | Ok () ->
+           emit_stream_event
+             on_stream_event
+             (Turn_started { conversation_id; model });
            Ok { state with init = Some (conversation_id, model, permission_mode) })
   | Step_update { conversation_id; state = step_state; step_type } ->
     let stage = "step_update event" in
@@ -615,7 +639,11 @@ let apply_event (config : config) ~conversation_mode ~on_conversation_ready stat
        let* () = verify_identity ~stage ~expected:(Some expected) conversation_id in
        if Option.is_some state.result
        then protocol_error stage "received more than one result event"
-       else Ok { state with result = Some (status, response, error, num_turns, usage) })
+       else (
+         (match status with
+          | Success -> emit_stream_event on_stream_event (Text_delta response)
+          | Result_error -> ());
+         Ok { state with result = Some (status, response, error, num_turns, usage) }))
 ;;
 
 let status_to_string = function
@@ -624,7 +652,7 @@ let status_to_string = function
 ;;
 
 let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
-    ~on_conversation_ready =
+    ~on_conversation_ready ~on_stream_event =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -681,6 +709,7 @@ let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
                 config
                 ~conversation_mode
                 ~on_conversation_ready
+                ~on_stream_event
                 !state
                 event
             with
@@ -704,7 +733,8 @@ let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
 ;;
 
 let run_turn ?(conversation_mode = Start) ?home_dir ~mgr ~clock ~cwd
-    ?(on_conversation_ready = fun ~conversation_id:_ -> Ok ()) config ~prompt =
+    ?(on_conversation_ready = fun ~conversation_id:_ -> Ok ()) ?on_stream_event
+    config ~prompt =
   let* () =
     match home_dir with
     | None -> Ok ()
@@ -726,7 +756,8 @@ let run_turn ?(conversation_mode = Start) ?home_dir ~mgr ~clock ~cwd
              config
              ~conversation_mode
              ~prompt
-             ~on_conversation_ready))
+             ~on_conversation_ready
+             ~on_stream_event))
     with
     | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -744,6 +775,7 @@ let run_turn ?(conversation_mode = Start) ?home_dir ~mgr ~clock ~cwd
     Error (Turn_failed "successful result response has no deliverable content")
   | `Exited 0, Some (conversation_id, model, permission_mode),
     Some (Success, text, _, num_turns, usage) ->
+    emit_stream_event on_stream_event (Turn_finished { text });
     Ok
       { conversation_id
       ; model

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -31,6 +31,15 @@ let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 8192
 let max_wire_line_bytes = 8 * 1024 * 1024
 
+(* [--print-timeout] is a wall-clock deadline owned by agy, not an idle
+   deadline. It ended a live turn after 9.45s despite an agent response, a
+   completed 4.25s tool, and a checkpoint inside a 10s window (agy 1.1.12,
+   2026-08-11). MASC owns liveness below by timing each JSONL read, so the CLI
+   deadline must be non-authoritative. This is Go's maximum time.Duration,
+   accepted by the installed CLI; it is finite and therefore keeps argv strict
+   without imposing a practical wall-clock ceiling. *)
+let cli_non_authoritative_timeout = "2562047h47m16.854775807s"
+
 let default_config ~cwd ~model =
   { cli_path = "agy"
   ; cwd
@@ -122,7 +131,7 @@ let error_to_string = function
   | State_callback_failed detail -> "Antigravity conversation state callback failed: " ^ detail
   | Turn_failed detail -> "Antigravity turn failed: " ^ detail
   | Process_exited detail -> "Antigravity CLI exited before completion: " ^ detail
-  | Timeout seconds -> Printf.sprintf "Antigravity turn timed out after %.3fs" seconds
+  | Timeout seconds -> Printf.sprintf "Antigravity stream was idle for %.3fs" seconds
 ;;
 
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
@@ -463,10 +472,6 @@ let official_client_environment ?home_dir () =
   | Some home_dir -> Array.of_list (("HOME=" ^ home_dir) :: inherited)
 ;;
 
-let duration_argument seconds = Printf.sprintf "%.3fs" seconds
-
-let cli_timeout_s timeout_s = max 0.001 (timeout_s *. 0.95)
-
 let argv config ~conversation_mode =
   let base =
     [ config.cli_path
@@ -479,7 +484,7 @@ let argv config ~conversation_mode =
     ; "--add-dir"
     ; config.cwd
     ; "--print-timeout"
-    ; duration_argument (cli_timeout_s config.timeout_s)
+    ; cli_non_authoritative_timeout
     ]
   in
   let with_optional flag value values =
@@ -700,7 +705,10 @@ let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
     let state = ref initial_protocol_state in
     (try
        while true do
-         let line = Eio.Buf_read.line reader in
+         let line =
+           Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+             Eio.Buf_read.line reader)
+         in
          match parse_wire_line line with
          | Error error -> abort_with_runtime_error error
          | Ok event ->
@@ -722,6 +730,7 @@ let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
        signal_spawned_process proc stdin_w;
        process_settled := true;
        raise exn
+     | Eio.Time.Timeout -> abort_with_runtime_error (Timeout config.timeout_s)
      | Runtime_error _ as exn -> raise exn
      | exn ->
        abort_with_runtime_error
@@ -747,17 +756,16 @@ let run_turn ?(conversation_mode = Start) ?home_dir ~mgr ~clock ~cwd
   let run_result =
     try
       Ok
-        (Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
-           run_spawned
-             ?home_dir
-             ~mgr
-             ~clock
-             ~cwd
-             config
-             ~conversation_mode
-             ~prompt
-             ~on_conversation_ready
-             ~on_stream_event))
+        (run_spawned
+           ?home_dir
+           ~mgr
+           ~clock
+           ~cwd
+           config
+           ~conversation_mode
+           ~prompt
+           ~on_conversation_ready
+           ~on_stream_event)
     with
     | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
     | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -63,6 +63,14 @@ type turn_result =
   ; wall_duration_s : float
   }
 
+type stream_event =
+  | Turn_started of
+      { conversation_id : string
+      ; model : string
+      }
+  | Text_delta of string
+  | Turn_finished of { text : string }
+
 type error =
   | Invalid_config of string
   | Spawn_failed of string
@@ -90,6 +98,7 @@ val run_turn :
   clock:_ Eio.Time.clock ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   ?on_conversation_ready:(conversation_id:string -> (unit, string) result) ->
+  ?on_stream_event:(stream_event -> unit) ->
   config ->
   prompt:string ->
   (turn_result, error) result

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -23,6 +23,8 @@ type config =
   ; sandbox : bool
   ; disable_slash_commands : bool
   ; timeout_s : float
+    (** Maximum silence between valid stream-json messages. It is not a total
+        turn-duration bound. *)
   }
 
 val default_config : cwd:string -> model:string -> config

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -80,6 +80,32 @@ type dynamic_tool =
   ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
   }
 
+type stream_event =
+  | Turn_started of
+      { turn_id : string
+      ; model : string
+      }
+  | Text_delta of string
+  | Dynamic_tool_started of
+      { call_id : string
+      ; tool_name : string
+      ; arguments : Yojson.Safe.t
+      }
+  | Dynamic_tool_finished of { call_id : string }
+  | Turn_finished of { text : string }
+
+let emit_stream_event on_stream_event event =
+  match on_stream_event with
+  | None -> ()
+  | Some emit ->
+    (try emit event with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Runtime_agent.warn
+         "Claude Code stream callback raised (error=%s)"
+         (Printexc.to_string exn))
+;;
+
 let dynamic_tool_bytes tools =
   List.fold_left
     (fun acc tool ->
@@ -396,6 +422,7 @@ let handle_control_request
       ~mcp_session
       ~tools
       ~tool_call_count
+      ~on_stream_event
       fields
   =
   let stage = "control request" in
@@ -425,6 +452,9 @@ let handle_control_request
         match find_dynamic_tool tools name with
         | None -> None
         | Some tool ->
+          emit_stream_event
+            on_stream_event
+            (Dynamic_tool_started { call_id; tool_name = name; arguments });
           let result =
             try tool.call ~call_id arguments with
             | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -435,6 +465,7 @@ let handle_control_request
                 (Printexc.to_string exn);
               { success = false; content = "MASC tool handler raised" }
           in
+          emit_stream_event on_stream_event (Dynamic_tool_finished { call_id });
           Some
             { Runtime_official_client_mcp.success = result.success
             ; content = result.content
@@ -537,7 +568,8 @@ let parse_control_response ~expected_request_id fields =
       protocol_error stage (Printf.sprintf "unknown response subtype %S" other)
 ;;
 
-let rec await_initialize io ~mcp_session ~tools ~tool_call_count ~request_id ~ignored =
+let rec await_initialize io ~mcp_session ~tools ~tool_call_count ~request_id
+    ~on_stream_event ~ignored =
   let* json = io.receive () in
   let* type_, fields = wire_fields json in
   match type_ with
@@ -551,9 +583,11 @@ let rec await_initialize io ~mcp_session ~tools ~tool_call_count ~request_id ~ig
         ~mcp_session
         ~tools
         ~tool_call_count
+        ~on_stream_event
         fields
     in
-    await_initialize io ~mcp_session ~tools ~tool_call_count ~request_id ~ignored
+    await_initialize
+      io ~mcp_session ~tools ~tool_call_count ~request_id ~on_stream_event ~ignored
   | ("system" | "rate_limit_event") when ignored < 32 ->
     await_initialize
       io
@@ -561,6 +595,7 @@ let rec await_initialize io ~mcp_session ~tools ~tool_call_count ~request_id ~ig
       ~tools
       ~tool_call_count
       ~request_id
+      ~on_stream_event
       ~ignored:(ignored + 1)
   | other ->
     protocol_error
@@ -737,7 +772,7 @@ let max_ignored_messages = 256
 
 let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session_id
     ~subscription ~resumed ~rate_limit ~assistant_model ~assistant_texts
-    ~on_turn_started ~ignored =
+    ~on_turn_started ~on_stream_event ~stream_started ~ignored =
   let* json = io.receive () in
   let* type_, fields = wire_fields json in
   match type_ with
@@ -749,26 +784,35 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
         ~mcp_session
         ~tools
         ~tool_call_count
+        ~on_stream_event
         fields
     in
     await_terminal
       io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit ~assistant_model ~assistant_texts ~on_turn_started ~ignored
+      ~on_stream_event ~stream_started
   | "control_response" ->
     protocol_error "turn" "received an unsolicited control response"
   | "assistant" ->
-    let* _uuid, model, texts = parse_assistant ~expected_session_id fields in
+    let* uuid, model, texts = parse_assistant ~expected_session_id fields in
+    if not !stream_started
+    then (
+      stream_started := true;
+      emit_stream_event on_stream_event (Turn_started { turn_id = uuid; model }));
+    List.iter
+      (fun text -> emit_stream_event on_stream_event (Text_delta text))
+      texts;
     await_terminal
       io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit ~assistant_model:(Some model)
       ~assistant_texts:(assistant_texts @ texts)
-      ~on_turn_started ~ignored
+      ~on_turn_started ~on_stream_event ~stream_started ~ignored
   | "rate_limit_event" ->
     let* rate_limit = parse_rate_limit ~expected_session_id fields in
     await_terminal
       io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit:(Some rate_limit) ~assistant_model ~assistant_texts
-      ~on_turn_started ~ignored
+      ~on_turn_started ~on_stream_event ~stream_started ~ignored
   | "result" ->
     let* turn_id, result, usage =
       parse_result ~expected_session_id ~rate_limit fields
@@ -796,6 +840,7 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
       | Some text -> Ok text
       | None -> protocol_error "result message" "successful turn has no text"
     in
+    emit_stream_event on_stream_event (Turn_finished { text });
     Ok
       { session_id = expected_session_id
       ; turn_id
@@ -811,6 +856,7 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
     await_terminal
       io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit ~assistant_model ~assistant_texts ~on_turn_started
+      ~on_stream_event ~stream_started
       ~ignored:(ignored + 1)
   | other ->
     protocol_error
@@ -945,7 +991,8 @@ let terminate_spawned_process ~clock proc stdin_w =
 ;;
 
 let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
-    ~prompt ~on_session_ready ~on_turn_starting ~on_turn_started =
+    ~prompt ~on_session_ready ~on_turn_starting ~on_turn_started
+    ~on_stream_event =
   let tool_call_count = ref 0 in
   let mcp_session = Runtime_official_client_mcp.create_session () in
   let initialize_id = Random_id.prefixed ~prefix:"masc-init-" ~bytes:12 in
@@ -957,6 +1004,7 @@ let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
       ~tools:dynamic_tools
       ~tool_call_count
       ~request_id:initialize_id
+      ~on_stream_event
       ~ignored:0
   in
   let* () =
@@ -996,12 +1044,14 @@ let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
     ~assistant_model:None
     ~assistant_texts:[]
     ~on_turn_started
+    ~on_stream_event
+    ~stream_started:(ref false)
     ~ignored:0
 ;;
 
 let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
     ~session_mode ~session_id ~subscription ~prompt ~on_session_ready
-    ~on_turn_starting ~on_turn_started =
+    ~on_turn_starting ~on_turn_started ~on_stream_event =
   let* argv =
     command config ~dynamic_tools ~reasoning_effort ~session_mode ~session_id
   in
@@ -1051,7 +1101,8 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
             ~prompt
             ~on_session_ready
             ~on_turn_starting
-            ~on_turn_started)))
+            ~on_turn_started
+            ~on_stream_event)))
 ;;
 
 let validate_process_config config =
@@ -1121,7 +1172,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
     ?admitted_subscription
     ~mgr ~clock ~cwd ?(on_session_ready = fun ~session_id:_ -> Ok ())
     ?(on_turn_starting = fun ~session_id:_ -> Ok ())
-    ?(on_turn_started = fun ~session_id:_ ~turn_id:_ -> Ok ()) config
+    ?(on_turn_started = fun ~session_id:_ ~turn_id:_ -> Ok ()) ?on_stream_event config
     ~prompt =
   let result =
     let* () = validate_turn ~dynamic_tools ~session_mode config ~prompt in
@@ -1154,6 +1205,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
         ~on_session_ready
         ~on_turn_starting
         ~on_turn_started
+        ~on_stream_event
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Eio.Time.Timeout -> Error (Timeout config.timeout_s)

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -1077,8 +1077,9 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
     let send json =
-      Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
-      Eio.Flow.copy_string "\n" stdin_w
+      Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+        Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
+        Eio.Flow.copy_string "\n" stdin_w)
     in
     let receive () =
       try

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -172,7 +172,7 @@ let error_to_string = function
   | Process_exited detail ->
     "Claude Code exited before terminal result: " ^ detail
   | Timeout seconds ->
-    Printf.sprintf "Claude Code turn timed out after %.3fs" seconds
+    Printf.sprintf "Claude Code stream was idle for %.3fs" seconds
 ;;
 
 let error_kind = function
@@ -493,7 +493,7 @@ let handle_control_request
          in a control_request that carries a [request_id] and blocks until that
          id is answered. Returning without sending anything therefore parks the
          client forever: it waits for the control_response, MASC waits for the
-         next message, and the turn ends only when the turn timeout fires.
+         next message, and the stream-idle timeout eventually fires.
 
          Measured against the real client (2.1.226): with the notification
          unanswered the turn stops after `notifications/initialized` and never
@@ -1081,28 +1081,32 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
       Eio.Flow.copy_string "\n" stdin_w
     in
     let receive () =
-      try parse_wire_line (Eio.Buf_read.line reader) with
+      try
+        Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+          Eio.Buf_read.line reader)
+        |> parse_wire_line
+      with
       | End_of_file ->
         let detail = String.trim !stderr_tail in
         Error (Process_exited (if detail = "" then "stdout closed" else detail))
+      | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> protocol_error "stdout read" (Printexc.to_string exn)
     in
     Fun.protect
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
-        Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
-          run_protocol
-            { send; receive }
-            ~dynamic_tools
-            ~subscription
-            ~session_mode
-            ~session_id
-            ~prompt
-            ~on_session_ready
-            ~on_turn_starting
-            ~on_turn_started
-            ~on_stream_event)))
+        run_protocol
+          { send; receive }
+          ~dynamic_tools
+          ~subscription
+          ~session_mode
+          ~session_id
+          ~prompt
+          ~on_session_ready
+          ~on_turn_starting
+          ~on_turn_started
+          ~on_stream_event))
 ;;
 
 let validate_process_config config =

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -16,6 +16,8 @@ type config =
   ; model : string option
   ; system_prompt : string option
   ; timeout_s : float
+    (** Maximum silence between CLI stream messages. Each received message
+        resets the deadline; a progressing turn has no wall limit. *)
   }
 
 val default_timeout_s : float

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -69,6 +69,20 @@ type dynamic_tool =
   ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
   }
 
+type stream_event =
+  | Turn_started of
+      { turn_id : string
+      ; model : string
+      }
+  | Text_delta of string
+  | Dynamic_tool_started of
+      { call_id : string
+      ; tool_name : string
+      ; arguments : Yojson.Safe.t
+      }
+  | Dynamic_tool_finished of { call_id : string }
+  | Turn_finished of { text : string }
+
 val dynamic_tool_bytes : dynamic_tool list -> int
 (** Bytes the tool declarations occupy in the request this process builds. Not
     provider tokens: it bounds the request, it does not price it. *)
@@ -124,6 +138,7 @@ val run_turn :
   ?on_session_ready:(session_id:string -> (unit, string) result) ->
   ?on_turn_starting:(session_id:string -> (unit, string) result) ->
   ?on_turn_started:(session_id:string -> turn_id:string -> (unit, string) result) ->
+  ?on_stream_event:(stream_event -> unit) ->
   config ->
   prompt:string ->
   (turn_result, error) result

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -67,6 +67,31 @@ type dynamic_tool =
   ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
   }
 
+type stream_event =
+  | Turn_started of
+      { turn_id : string
+      ; model : string
+      }
+  | Text_delta of string
+  | Dynamic_tool_started of
+      { call_id : string
+      ; tool_name : string
+      ; arguments : Yojson.Safe.t
+      }
+  | Dynamic_tool_finished of { call_id : string }
+  | Turn_finished of { text : string }
+
+let emit_stream_event on_stream_event event =
+  match on_stream_event with
+  | None -> ()
+  | Some callback ->
+    (try callback event with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Runtime_agent.warn
+         "Codex app-server stream callback raised: %s"
+         (Printexc.to_string exn))
+
 type history_role =
   | User
   | Assistant
@@ -351,7 +376,8 @@ let send_dynamic_tool_response io ~id (result : dynamic_tool_result) =
        ])
 ;;
 
-let handle_dynamic_tool_call io ~tools ~thread_id ~turn_id ~tool_call_count ~id params =
+let handle_dynamic_tool_call io ~tools ~thread_id ~turn_id ~tool_call_count
+    ~on_stream_event ~id params =
   let stage = "item/tool/call" in
   let* fields = assoc_at stage params in
   let* request_thread_id = required_string stage "threadId" fields in
@@ -368,6 +394,9 @@ let handle_dynamic_tool_call io ~tools ~thread_id ~turn_id ~tool_call_count ~id 
     match find_dynamic_tool tools tool_name with
     | None -> protocol_error stage (Printf.sprintf "unknown dynamic tool %S" tool_name)
     | Some tool ->
+      emit_stream_event
+        on_stream_event
+        (Dynamic_tool_started { call_id; tool_name; arguments });
       let result =
         try tool.call ~call_id arguments with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -379,6 +408,7 @@ let handle_dynamic_tool_call io ~tools ~thread_id ~turn_id ~tool_call_count ~id 
           { success = false; content = "dynamic tool handler raised" }
       in
       incr tool_call_count;
+      emit_stream_event on_stream_event (Dynamic_tool_finished { call_id });
       send_dynamic_tool_response io ~id result;
       Ok ()
 ;;
@@ -582,31 +612,31 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback
    awaiting. threadId, turnId and itemId are identifiers, so emptiness in one
    of them is malformed and stays rejected.
 
-   delta carries stream payload this function never reads, and an empty or
-   whitespace chunk is ordinary in a streaming protocol. Requiring it to be
+   delta carries stream payload forwarded to the turn's typed stream callback,
+   and an empty or whitespace chunk is ordinary in a streaming protocol. Requiring it to be
    non-empty turned such a chunk into a terminal protocol error, which put the
    official-client session into Recovery_required and made every later turn for
    that keeper fail closed on `official_client_session.claim` until an operator
    resolved it by hand. Three such chunks accounted for 3,236 rejected turns
    across sangsu, kidsnote and taskmaster in one retained log window (#27967). *)
-let validate_item_delta_notification ~method_ ~thread_id ~turn_id params =
+let item_delta_notification ~method_ ~thread_id ~turn_id params =
   let* fields = assoc_at method_ params in
   let* notification_thread_id = required_string method_ "threadId" fields in
   let* notification_turn_id = required_string method_ "turnId" fields in
   (* [delta] stays required: its presence is what makes this frame an item
      delta, and the identity check below is only meaningful on one. Its
-     *content* is not checked -- #27967 rejected empty chunks a provider
+     *content* is forwarded without non-empty validation -- #27967 rejected empty chunks a provider
      legitimately sends. [itemId] carries neither role. Nothing here reads it,
      so a frame that omits it or sends it empty changes nothing this function
      decides, while requiring it adds one more way to end a turn (#28010). *)
-  let* _delta = required_string_any method_ "delta" fields in
+  let* delta = required_string_any method_ "delta" fields in
   if notification_thread_id <> thread_id || notification_turn_id <> turn_id
   then protocol_error method_ "item delta identity does not match the active turn"
-  else Ok ()
+  else Ok delta
 ;;
 
 let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen_final
-    ~seen_fallback =
+    ~seen_fallback ~on_stream_event =
   let* message = io.receive () in
   match message with
   | Response _ | Response_error _ ->
@@ -619,6 +649,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~thread_id
         ~turn_id
         ~tool_call_count
+        ~on_stream_event
         ~id
         params
     in
@@ -630,6 +661,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~turn_id
       ~seen_final
       ~seen_fallback
+      ~on_stream_event
   | Server_request { id; method_; _ } ->
     reject_server_request io id;
     Error (Unsupported_server_request method_)
@@ -641,9 +673,10 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
            | "item/plan/delta" ) as method_)
       ; params
       } ->
-    let* () =
-      validate_item_delta_notification ~method_ ~thread_id ~turn_id params
+    let* delta = item_delta_notification ~method_ ~thread_id ~turn_id params
     in
+    if String.equal method_ "item/agentMessage/delta"
+    then emit_stream_event on_stream_event (Text_delta delta);
     await_turn_terminal
       io
       ~tools
@@ -652,6 +685,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~turn_id
       ~seen_final
       ~seen_fallback
+      ~on_stream_event
   | Notification { method_ = "item/completed"; params } ->
     let stage = "item/completed" in
     let* fields = assoc_at stage params in
@@ -676,6 +710,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~turn_id
         ~seen_final
         ~seen_fallback
+        ~on_stream_event
   | Notification { method_ = "error"; params } ->
     (* willRetry:true is a progress signal — the app-server itself is retrying
        upstream, so the turn is alive. Counting these and failing the turn at a
@@ -697,6 +732,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
         ~turn_id
         ~seen_final
         ~seen_fallback
+        ~on_stream_event
     else
       let* error_json = required_member stage "error" fields in
       let* error_fields = assoc_at stage error_json in
@@ -726,6 +762,7 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~turn_id
       ~seen_final
       ~seen_fallback
+      ~on_stream_event
 ;;
 
 let optional_field name = function
@@ -762,8 +799,9 @@ let invoke_state_callback ~stage callback =
   | exn -> protocol_error stage (Printexc.to_string exn)
 ;;
 
-let run_protocol io (config : config) ~protocol_cwd ~dynamic_tools ~reasoning_effort ~thread_mode
-    ~history ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_started =
+let run_protocol io (config : config) ~protocol_cwd ~dynamic_tools ~reasoning_effort
+    ~thread_mode ~history ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_started
+    ~on_stream_event =
   send_request io ~id:1 ~method_:"initialize"
     ~params:
       (`Assoc
@@ -866,6 +904,7 @@ let run_protocol io (config : config) ~protocol_cwd ~dynamic_tools ~reasoning_ef
     invoke_state_callback ~stage:"turn started callback" (fun () ->
       on_turn_started ~thread_id ~turn_id)
   in
+  emit_stream_event on_stream_event (Turn_started { turn_id; model });
   let tool_call_count = ref 0 in
   let* text =
     await_turn_terminal
@@ -876,7 +915,9 @@ let run_protocol io (config : config) ~protocol_cwd ~dynamic_tools ~reasoning_ef
       ~turn_id
       ~seen_final:None
       ~seen_fallback:None
+      ~on_stream_event
   in
+  emit_stream_event on_stream_event (Turn_finished { text });
   Ok
     { thread_id
     ; turn_id
@@ -1019,7 +1060,7 @@ let with_spawned_client ~mgr ~clock ~cwd config run =
 
 let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
     ~reasoning_effort ~thread_mode ~history ~prompt ~on_thread_ready
-    ~on_turn_starting ~on_turn_started =
+    ~on_turn_starting ~on_turn_started ~on_stream_event =
   with_spawned_client ~mgr ~clock ~cwd config (fun io ->
     run_protocol
       io
@@ -1032,7 +1073,8 @@ let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
       ~prompt
       ~on_thread_ready
       ~on_turn_starting
-      ~on_turn_started)
+      ~on_turn_started
+      ~on_stream_event)
 ;;
 
 let native_cwd cwd =
@@ -1117,7 +1159,8 @@ let probe_subscription ~mgr ~clock ~cwd config =
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr ~clock ~cwd
     ?(history = []) ?(on_thread_ready = fun ~thread_id:_ -> Ok ())
     ?(on_turn_starting = fun ~thread_id:_ -> Ok ())
-    ?(on_turn_started = fun ~thread_id:_ ~turn_id:_ -> Ok ()) config ~prompt =
+    ?(on_turn_started = fun ~thread_id:_ ~turn_id:_ -> Ok ()) ?on_stream_event
+    config ~prompt =
   let result =
     match validate_turn_input ~dynamic_tools ~thread_mode ~cwd config ~prompt with
     | Error _ as error -> error
@@ -1138,6 +1181,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr
            ~on_thread_ready
            ~on_turn_starting
            ~on_turn_started
+           ~on_stream_event
        with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | Eio.Time.Timeout -> Error (Timeout config.timeout_s)

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -160,7 +160,7 @@ let error_to_string = function
   | Turn_interrupted -> "Codex app-server turn was interrupted"
   | Process_exited detail -> "Codex app-server exited before completion: " ^ detail
   | Timeout seconds ->
-    Printf.sprintf "Codex app-server turn timed out after %.3fs" seconds
+    Printf.sprintf "Codex app-server stream was idle for %.3fs" seconds
 ;;
 
 let error_kind = function
@@ -716,9 +716,9 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
        upstream, so the turn is alive. Counting these and failing the turn at a
        cap preempted the declared liveness boundary below and, under one
        upstream degradation window, drove three keepers into
-       Recovery_required twice in two hours. The enclosing turn timeout
-       remains the only liveness boundary; willRetry:false still carries the
-       provider's terminal error. *)
+       Recovery_required twice in two hours. The per-message stream idle
+       timeout remains the only liveness boundary; willRetry:false still
+       carries the provider's terminal error. *)
     let stage = "error notification" in
     let* fields = assoc_at stage params in
     let* will_retry = required_bool stage "willRetry" fields in
@@ -751,8 +751,8 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       ~tool_effect_attempted:(!tool_call_count > 0)
       params
   (* App-server progress and account notifications are observational. Protocol
-     evolution must not turn them into a computation failure; the enclosing
-     turn timeout remains the liveness boundary. *)
+     evolution must not turn them into a computation failure; each valid wire
+     message resets the stream-idle liveness boundary. *)
   | Notification _ ->
     await_turn_terminal
       io
@@ -1040,10 +1040,15 @@ let with_spawned_client ~mgr ~clock ~cwd config run =
       Eio.Flow.copy_string "\n" stdin_w
     in
     let receive () =
-      try parse_wire_line (Eio.Buf_read.line reader) with
+      try
+        Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+          Eio.Buf_read.line reader)
+        |> parse_wire_line
+      with
       | End_of_file ->
         let detail = String.trim !stderr_tail in
         Error (Process_exited (if detail = "" then "stdout closed" else detail))
+      | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> protocol_error "stdout read" (Printexc.to_string exn)
     in
@@ -1053,9 +1058,7 @@ let with_spawned_client ~mgr ~clock ~cwd config run =
        preserves cleanup across fiber cancellation. *)
     Fun.protect
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
-      (fun () ->
-        Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
-          run { send; receive })))
+      (fun () -> run { send; receive }))
 ;;
 
 let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -1036,8 +1036,9 @@ let with_spawned_client ~mgr ~clock ~cwd config run =
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
     let send json =
-      Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
-      Eio.Flow.copy_string "\n" stdin_w
+      Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+        Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
+        Eio.Flow.copy_string "\n" stdin_w)
     in
     let receive () =
       try

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -19,6 +19,8 @@ type config =
   ; model : string option
   ; developer_instructions : string option
   ; timeout_s : float
+    (** Maximum silence between app-server protocol messages. Each received
+        message resets the deadline; a progressing turn has no wall limit. *)
   }
 
 val default_timeout_s : float

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -51,6 +51,20 @@ type dynamic_tool =
   ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
   }
 
+type stream_event =
+  | Turn_started of
+      { turn_id : string
+      ; model : string
+      }
+  | Text_delta of string
+  | Dynamic_tool_started of
+      { call_id : string
+      ; tool_name : string
+      ; arguments : Yojson.Safe.t
+      }
+  | Dynamic_tool_finished of { call_id : string }
+  | Turn_finished of { text : string }
+
 type history_role =
   | User
   | Assistant
@@ -126,6 +140,7 @@ val run_turn :
   ?on_thread_ready:(thread_id:string -> (unit, string) result) ->
   ?on_turn_starting:(thread_id:string -> (unit, string) result) ->
   ?on_turn_started:(thread_id:string -> turn_id:string -> (unit, string) result) ->
+  ?on_stream_event:(stream_event -> unit) ->
   config ->
   prompt:string ->
   (turn_result, error) result

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -5,13 +5,13 @@ val resolve_reasoning_effort :
     declared reasoning control. *)
 
 val resolve_turn_timeout_s : runtime_id:string -> float option
+(** The per-model [turn-timeout-s] declared for [runtime_id], or [None] when
+    the model leaves it unset. Streaming official-client adapters use it as
+    their protocol-idle liveness window. *)
 
 val resolve_max_prompt_bytes : runtime_id:string -> int option
 (** Per-model ceiling, in bytes, on the history an official-client start turn
     seeds its conversation with. [None] applies no ceiling. *)
-(** The per-model [turn-timeout-s] declared for [runtime_id], or [None] when
-    the model leaves it unset. Callers keep their existing bound on [None]:
-    this overrides a timeout, it does not supply one. *)
 
 val resolve_temperature :
   runtime_id:string -> fallback:(unit -> float) -> float

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -222,13 +222,11 @@ type model_spec =
         {!Runtime_inference.resolve_reasoning_effort}, symmetric to the
         [temperature] path. *)
   ; turn_timeout_s : float option
-    (** [turn-timeout-s] — per-model wall-clock bound on one official-client
-        turn, in seconds. Reasoning effort is declared per model, and effort is
-        the dominant term in how long a turn runs; a timeout that can only be
-        set per provider therefore cannot bound a [max]-effort binding and a
-        [low]-effort one differently, and for claude-code / codex-app-server it
-        could not be set at all. [None] keeps the provider value where one
-        exists (antigravity [timeout-s]) and the adapter default otherwise.
+    (** [turn-timeout-s] — per-model liveness window for one official-client
+        turn, in seconds. Codex and Claude reset it on every protocol message,
+        so progressing turns have no wall-clock limit. Antigravity also passes
+        the value to its CLI-owned print boundary. [None] keeps the provider
+        value where one exists and the adapter default otherwise.
         Resolved via {!Runtime.turn_timeout_s_of_runtime_id} →
         {!Runtime_inference.resolve_turn_timeout_s}. *)
   ; max_prompt_bytes : int option

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -223,10 +223,10 @@ type model_spec =
         [temperature] path. *)
   ; turn_timeout_s : float option
     (** [turn-timeout-s] — per-model liveness window for one official-client
-        turn, in seconds. Codex and Claude reset it on every protocol message,
-        so progressing turns have no wall-clock limit. Antigravity also passes
-        the value to its CLI-owned print boundary. [None] keeps the provider
-        value where one exists and the adapter default otherwise.
+        turn, in seconds. Codex, Claude, and Antigravity reset it on every
+        protocol message, so progressing turns have no wall-clock limit.
+        [None] keeps the provider value where one exists and the adapter default
+        otherwise.
         Resolved via {!Runtime.turn_timeout_s_of_runtime_id} →
         {!Runtime_inference.resolve_turn_timeout_s}. *)
   ; max_prompt_bytes : int option

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -837,8 +837,8 @@ let start_keeper_loops_owned
     match
       Keeper_owner_registry.install_from_store
         ~sw
-        ~operation_executor:
-          (Some (Server_routes_http_keeper_stream.operation_executor ~state ~clock))
+        ~operation_runner:
+          (Some (Server_routes_http_keeper_stream.operation_runner ~state ~clock))
         config
     with
     | Ok count -> count

--- a/lib/server/server_keeper_chat_agui_projection.ml
+++ b/lib/server/server_keeper_chat_agui_projection.ml
@@ -19,6 +19,7 @@ type custom_event_name =
   | Continuation_checkpoint
   | External_effect_completed
   | Reply_details
+  | Tool_result_ready
 
 let initial =
   { thread_id = Ag_ui.default_thread_id
@@ -51,6 +52,7 @@ let custom_event_name_to_string = function
   | Continuation_checkpoint -> "KEEPER_CONTINUATION_CHECKPOINT"
   | External_effect_completed -> "KEEPER_EXTERNAL_EFFECT_COMPLETED"
   | Reply_details -> "KEEPER_REPLY_DETAILS"
+  | Tool_result_ready -> "KEEPER_TOOL_RESULT_READY"
 
 let custom ~timestamp ~redact_json state name value =
   Ag_ui.make_event ~timestamp ~thread_id:state.thread_id ~run_id:state.run_id
@@ -197,6 +199,11 @@ let project ~timestamp ~redact_text ~redact_json state event =
           (Ag_ui.make_event ~timestamp ~thread_id:state.thread_id
              ~run_id:state.run_id ~tool_call_id:(Some tool_call_id)
              Ag_ui.Tool_call_end) )
+  | Tool_result_ready { tool_call_id } ->
+      ( state
+      , Some
+          (custom ~timestamp ~redact_json state Tool_result_ready
+             (`Assoc [ "tool_call_id", `String tool_call_id ])) )
   | Link_block _
   | Image_block _
   | Status_block _

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2028,6 +2028,18 @@ let operation_executor ~state ~clock : Keeper_owner.operation_executor =
   | execution -> execution
 ;;
 
+let operation_runner ~state ~clock : Keeper_owner.operation_runner =
+  let base_path = (Mcp_server.workspace_config state).base_path in
+  { ready =
+      (fun ~keeper_name ->
+         match Keeper_registry.get_with_health ~base_path keeper_name with
+         | Some (_, Keeper_registry.Healthy) -> true
+         | Some (_, _)
+         | None -> false)
+  ; execute = operation_executor ~state ~clock
+  }
+;;
+
 let keeper_chat_stream_headers origin =
   Httpun.Headers.of_list
     ([

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -596,6 +596,7 @@ let execute_keeper_stream_tool_streaming
       ~clock
       ?auth_token:_
       ?on_event
+      ?on_tool_result_ready
       ~admission_token
       state
       ~agent_name
@@ -625,6 +626,7 @@ let execute_keeper_stream_tool_streaming
           ~admission_token
           ~on_text_delta
           ?on_event
+          ?on_tool_result_ready
           keeper_ctx
           ~continuation_channel
           ~message
@@ -881,6 +883,7 @@ let keeper_request_terminal_status_is_routine = function
 
 type keeper_stream_worker_event =
   | Stream_event of Agent_core.Types.sse_event
+  | Stream_chat_event of Keeper_chat_events.keeper_chat_event
   | Stream_client_disconnected
   | Stream_terminal of
       { status : keeper_stream_terminal_status
@@ -1066,7 +1069,7 @@ let process_single_turn ~user_row_origin ~submission
       Atomic.set client_disconnected true;
       let (_ : bool) = Eio.Promise.try_resolve client_disconnect_resolver () in
       ()
-    | Stream_event stream_event ->
+    | (Stream_event _ | Stream_chat_event _) as event ->
         if !closed
         then observe_stream_event_cutoff "writer_closed"
         else if Atomic.get terminal_pushed
@@ -1082,7 +1085,7 @@ let process_single_turn ~user_row_origin ~submission
                 | `Terminal, _ | _, `Terminal -> `Terminal
                 | `Client_disconnected, `Client_disconnected -> `Client_disconnected)
               (fun () ->
-                 Eio.Stream.add worker_events stream_event;
+                 Eio.Stream.add worker_events event;
                  `Added)
               await_projection_cutoff
           with
@@ -1217,6 +1220,10 @@ let process_single_turn ~user_row_origin ~submission
     Keeper_stream_tool_accum.on_event worker_tool_accum evt;
     push_worker_event (Stream_event evt)
   in
+  let on_tool_result_ready ~tool_call_id =
+    push_worker_event
+      (Stream_chat_event (Keeper_chat_events.Tool_result_ready { tool_call_id }))
+  in
   let accumulated_media_blocks () =
     match
       Keeper_stream_media_accum.to_chat_blocks ~base_dir:base_path
@@ -1304,6 +1311,7 @@ let process_single_turn ~user_row_origin ~submission
                 ~clock
                 ?auth_token
                 state ~agent_name ~message:direct_message ~on_event
+                ~on_tool_result_ready
                 ~continuation_channel ~on_text_delta:(fun _ -> ())
                 ~admission_token
             in
@@ -1674,17 +1682,17 @@ let process_single_turn ~user_row_origin ~submission
     then `Client_disconnected
     else (
       match Eio.Stream.take_nonblocking worker_events with
-      | Some event -> `Stream_event event
+      | Some event -> `Worker_event event
       | None ->
         Eio.Fiber.first
           ~combine:(fun left right ->
             match left, right with
-            | `Stream_event _, _ -> left
-            | _, `Stream_event _ -> right
+            | `Worker_event _, _ -> left
+            | _, `Worker_event _ -> right
             | `Completion _, _ -> left
             | _, `Completion _ -> right
             | `Client_disconnected, `Client_disconnected -> `Client_disconnected)
-          (fun () -> `Stream_event (Eio.Stream.take worker_events))
+          (fun () -> `Worker_event (Eio.Stream.take worker_events))
           (fun () ->
              let completion_or_disconnect =
                Eio.Fiber.first
@@ -1702,19 +1710,24 @@ let process_single_turn ~user_row_origin ~submission
              (completion_or_disconnect
               :> [ `Client_disconnected
                   | `Completion of keeper_stream_completion
-                  | `Stream_event of Agent_core.Types.sse_event
+                  | `Worker_event of keeper_stream_worker_event
                   ])))
   in
   let rec consume_worker_events bridge_state =
     match next_worker_projection () with
     | `Client_disconnected -> None
-    | `Stream_event evt ->
+    | `Worker_event (Stream_event evt) ->
         let translated =
           translate_agent_core_stream_event ~redact_text
             ~base_dir:base_path bridge_state evt
         in
         List.iter (Keeper_chat_events.publish events) translated.chat_events;
         consume_worker_events translated.bridge_state
+    | `Worker_event (Stream_chat_event event) ->
+        Keeper_chat_events.publish events event;
+        consume_worker_events bridge_state
+    | `Worker_event (Stream_terminal _ | Stream_client_disconnected) ->
+        assert false
     | `Completion
         (Completion_terminal
         { status = Stream_cancelled

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -199,13 +199,14 @@ val process_single_turn :
     With no visible blocks, the operation records a typed terminal failure
     rather than inventing assistant prose. *)
 
-val operation_executor :
+val operation_runner :
   state:Mcp_server.server_state ->
   clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
-  Keeper_owner.operation_executor
-(** Production executor installed into every Keeper Owner. It claims the FIFO
-    head only after the Keeper Owner starts it, streams Dashboard events by
-    operation id, and joins Discord/Slack terminal delivery before returning. *)
+  Keeper_owner.operation_runner
+(** Production runner installed into every Keeper Owner. It leaves the FIFO
+    head Queued until the Keeper registry entry exists and is healthy, then
+    claims exactly once, streams events by operation id, and joins terminal
+    connector delivery before returning. *)
 
 (** {1 Testing helpers} *)
 

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -80,6 +80,7 @@ normal_targets=(
   @test/runtest-test_keeper_lifecycle_global_gate
   @test/runtest-test_tool_blob_store
   @test/runtest-test_keeper_tool_call_log
+  @test/runtest-test_keeper_external_resource_lease
   @test/runtest-test_keeper_wire_capture
   @test/runtest-test_runtime_provider_auth_headers
   @test/runtest-test_keeper_official_client_host

--- a/test/dune
+++ b/test/dune
@@ -1651,6 +1651,11 @@
  (modules test_keeper_chat_broadcast)
  (libraries alcotest masc_test_deps))
 
+(test
+ (name test_keeper_external_resource_lease)
+ (modules test_keeper_external_resource_lease)
+ (libraries alcotest masc_test_deps))
+
 (include stanzas/test_ci_run_tests_script.inc)
 
 (include stanzas/test_contract_harness_auth_script.inc)

--- a/test/keeper_chat_operations/test_keeper_chat_operation_store.ml
+++ b/test/keeper_chat_operations/test_keeper_chat_operation_store.ml
@@ -43,6 +43,18 @@ let get_exn store operation_id =
 
 let state operation = Operation.state_to_string operation.Operation.state
 
+let finalize_statement stmt =
+  let rc = Sqlite3.finalize stmt in
+  ignore (Sys.opaque_identity stmt);
+  rc
+;;
+
+let close_database db =
+  let closed = Sqlite3.db_close db in
+  ignore (Sys.opaque_identity db);
+  closed
+;;
+
 let test_schema_identity_and_budget () =
   with_store "schema" @@ fun path store ->
   check string "database file" "chat-operations.sqlite3" (Filename.basename path);
@@ -54,12 +66,12 @@ let test_schema_identity_and_budget () =
   store_ok (Store.close store);
   let db = Sqlite3.db_open ~mode:`READONLY path in
   Fun.protect
-    ~finally:(fun () -> ignore (Sqlite3.db_close db : bool))
+    ~finally:(fun () -> ignore (close_database db : bool))
     (fun () ->
        let text sql =
          let stmt = Sqlite3.prepare db sql in
          Fun.protect
-           ~finally:(fun () -> ignore (Sqlite3.finalize stmt : Sqlite3.Rc.t))
+           ~finally:(fun () -> ignore (finalize_statement stmt : Sqlite3.Rc.t))
            (fun () ->
               check bool "schema row" true (Sqlite3.step stmt = Sqlite3.Rc.ROW);
               Sqlite3.column_text stmt 0)
@@ -310,7 +322,7 @@ let test_terminal_row_is_sql_immutable () =
   store_ok (Store.close store);
   let db = Sqlite3.db_open path in
   Fun.protect
-    ~finally:(fun () -> ignore (Sqlite3.db_close db : bool))
+    ~finally:(fun () -> ignore (close_database db : bool))
     (fun () ->
        let rc =
          Sqlite3.exec
@@ -345,6 +357,18 @@ let test_close_is_idempotent_and_refuses_later_operations () =
   | Error _ -> fail "a repeated close must stay successful"
 ;;
 
+let test_statement_finalize_survives_gc_pressure () =
+  with_store "finalize-gc-pressure" @@ fun _path store ->
+  let churn = ref [] in
+  for i = 1 to 2_000 do
+    ignore (store_ok (Store.inventory store));
+    churn := String.make 256 'x' :: (if i mod 16 = 0 then [] else !churn);
+    if i mod 64 = 0 then Gc.minor ()
+  done;
+  ignore (Sys.opaque_identity !churn);
+  check bool "all inventory statements finalized under GC pressure" true
+;;
+
 let () =
   run
     "keeper-chat-operation-store"
@@ -361,5 +385,7 @@ let () =
         ; test_case "commit failure and uncertain read-back" `Quick
             test_commit_failure_and_uncertain_readback
         ; test_case "terminal SQL immutability" `Quick test_terminal_row_is_sql_immutable
+        ; test_case "statement finalize survives GC pressure" `Quick
+            test_statement_finalize_survives_gc_pressure
         ] )
     ]

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -541,7 +541,7 @@ let test_event_operator_uses_exact_source_refs_across_unrelated_enqueues () =
        (match
           Masc.Keeper_owner_registry.install_from_store
             ~sw
-            ~operation_executor:None
+            ~operation_runner:None
             config
         with
         | Ok _ -> ()
@@ -3045,7 +3045,7 @@ let prepare_config_sync_keeper ~sw config name =
   (match Masc.Keeper_meta_store.replace_snapshot config meta with
    | Ok () -> ()
    | Error error -> fail ("write meta: " ^ error));
-  match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+  match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
   | Ok _ -> ()
   | Error error ->
     fail (Masc.Keeper_owner_registry.install_error_to_string error)

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -42,7 +42,7 @@ let with_workspace f =
   Eio.Switch.on_release sw (fun () -> Masc_test_deps.cleanup_test_workspace dir);
   let config = Workspace_core.default_config dir in
   ignore (Workspace_core.init config ~agent_name:(Some "test"));
-  (match Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+  (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
    | Ok _ -> ()
    | Error error ->
      fail

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -65,7 +65,7 @@ let write_file path content =
 ;;
 
 let install_owner_inventory_exn ~sw config =
-  match Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+  match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
   | Ok _ -> ()
   | Error error -> fail (Keeper_owner_registry.install_error_to_string error)
 ;;

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -278,6 +278,7 @@ let test_keeper_projects_mcp_tool_and_settles () =
       in
       let observed_trace_ref = ref None in
       let observed_initial_prompt = ref None in
+      let stream_events = ref [] in
       let cli_path = fixture_script ~base_path in
       let runtime_path = Filename.concat base_path "runtime.toml" in
       write_file ~mode:0o600 runtime_path (runtime_toml ~cli_path ~oauth_source);
@@ -352,6 +353,7 @@ let test_keeper_projects_mcp_tool_and_settles () =
                       ~initial_messages:large_history
                       ~context:(Agent_core.Context.create ())
                       ~raw_trace
+                      ~on_event:(fun event -> stream_events := event :: !stream_events)
                       ~sw
                       ~net:(Eio.Stdenv.net env)
                       ()
@@ -365,6 +367,34 @@ let test_keeper_projects_mcp_tool_and_settles () =
                       "MASC_ANTIGRAVITY_KEEPER_OK"
                       (keeper_response_text turn);
                     check int "turn count" 1 turn.turns;
+                    (match List.rev !stream_events with
+                     | [ Agent_core.Types.MessageStart
+                           { id = "conversation-antigravity-fixture:ordinal:1"
+                           ; model = "gemini-fixture"
+                           ; usage = None
+                           }
+                       ; ContentBlockStart
+                           { index = 1
+                           ; content_type = "tool_use"
+                           ; tool_id = Some "call-1"
+                           ; tool_name = Some "masc_probe"
+                           }
+                       ; ContentBlockDelta
+                           { index = 1
+                           ; delta = InputJsonSnapshot arguments
+                           }
+                       ; ContentBlockStop { index = 1 }
+                       ; ContentBlockDelta
+                           { index = 0
+                           ; delta = TextDelta "MASC_ANTIGRAVITY_KEEPER_OK"
+                           }
+                       ; MessageStop
+                       ] ->
+                       check string
+                         "streamed tool arguments"
+                         {|{"marker":"from-antigravity"}|}
+                         arguments
+                     | _ -> fail "Keeper did not project the exact Antigravity stream");
                     observed_initial_prompt :=
                       Some
                         (In_channel.with_open_bin

--- a/test/test_keeper_chat_broadcast.ml
+++ b/test/test_keeper_chat_broadcast.ml
@@ -97,6 +97,25 @@ let test_projection_covers_thinking_and_tool_args () =
     (Some "TOOL_CALL_ARGS")
     (Yojson.Safe.Util.member "type" tool_args |> Yojson.Safe.Util.to_string_option)
 
+let test_tool_result_ready_projection_has_exact_identity () =
+  let state, _ =
+    project P.initial
+      (E.Run_started
+         { run_id = "run-3"; thread_id = "keeper-consumer:taskmaster" })
+  in
+  let _, ready =
+    project state (E.Tool_result_ready { tool_call_id = "tool-use-7" })
+  in
+  let ready = Ag_ui.event_to_json (projected_exn (state, ready)) in
+  Alcotest.(check (option string)) "result-ready custom event"
+    (Some "KEEPER_TOOL_RESULT_READY")
+    (Yojson.Safe.Util.member "name" ready |> Yojson.Safe.Util.to_string_option);
+  Alcotest.(check (option string)) "exact tool identity"
+    (Some "tool-use-7")
+    (Yojson.Safe.Util.member "value" ready
+     |> Yojson.Safe.Util.member "tool_call_id"
+     |> Yojson.Safe.Util.to_string_option)
+
 let () =
   Alcotest.run "keeper_chat_broadcast"
     [ ( "turn_event"
@@ -106,5 +125,7 @@ let () =
             test_projection_preserves_stream_identity
         ; Alcotest.test_case "projection covers thinking and tool args" `Quick
             test_projection_covers_thinking_and_tool_args
+        ; Alcotest.test_case "tool result readiness preserves exact identity" `Quick
+            test_tool_result_ready_projection_has_exact_identity
         ] )
     ]

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -188,14 +188,14 @@ let test_final_message_blocks_merges_text_and_event_blocks () =
   check bool "event block preserved" true
     (contains second "https://event.example.com")
 
-let run_adapter ?post_stream ?edit_stream ?edit_blocks ?now
+let run_adapter ?post_stream ?edit_stream ?edit_blocks ?delete_stream ?now ?sleep
     ?set_activity_status events ~send_plain ~send_blocks =
   Eio_main.run @@ fun _env ->
   let stream = Masc.Keeper_chat_events.create () in
   List.iter (Masc.Keeper_chat_events.publish stream) events;
   let outcomes = ref [] in
   S.adapter_loop ~events:stream ~send_plain ~send_blocks
-    ?post_stream ?edit_stream ?edit_blocks ?now
+    ?post_stream ?edit_stream ?edit_blocks ?delete_stream ?now ?sleep
     ?set_activity_status
     ~on_send_result:(fun result -> outcomes := result :: !outcomes)
     ();
@@ -225,6 +225,8 @@ let test_adapter_streams_one_edited_reply () =
         check string "final message identity" "slack-message-1" message_id;
         final_edits := (content, blocks) :: !final_edits;
         Ok ())
+      ~delete_stream:(fun ~message_id:_ ->
+        fail "successful streaming reply must not be deleted")
       [ Masc.Keeper_chat_events.Run_started
           { run_id = "run-stream"; thread_id = "thread-stream" }
       ; Masc.Keeper_chat_events.Text_delta "hello "
@@ -242,9 +244,8 @@ let test_adapter_streams_one_edited_reply () =
     "rate-limited incremental edit"
     [ "hello world " ]
     (List.rev !stream_edits);
-  match List.rev !final_edits with
-  | [ content, [] ] -> check string "final exact text" "hello world " content
-  | _ -> fail "terminal delivery did not edit the streaming message exactly once"
+  check int "unchanged terminal content skips duplicate edit" 0
+    (List.length !final_edits)
 ;;
 
 let test_adapter_stream_error_edits_accepted_reply () =
@@ -257,6 +258,8 @@ let test_adapter_stream_error_edits_accepted_reply () =
         Ok ())
       ~edit_blocks:(fun ~message_id:_ ~content:_ ~blocks:_ ->
         fail "failed run must not use the success finalizer")
+      ~delete_stream:(fun ~message_id:_ ->
+        fail "failed run must not delete its error reply")
       [ Masc.Keeper_chat_events.Run_started
           { run_id = "run-error"; thread_id = "thread-error" }
       ; Masc.Keeper_chat_events.Text_delta "partial "
@@ -355,6 +358,62 @@ let test_completed_external_effect_settles_without_duplicate_send () =
   check int "completed effect makes no Slack call" 0 !sends;
   check bool "completed effect settles the receipt" true
     (outcomes = [ Ok () ])
+
+let test_completed_external_effect_deletes_streamed_draft () =
+  let deleted = ref [] in
+  let outcomes =
+    run_adapter
+      ~post_stream:(fun ~content:_ -> Ok "slack-draft")
+      ~edit_stream:(fun ~message_id:_ ~content:_ -> Ok ())
+      ~edit_blocks:(fun ~message_id:_ ~content:_ ~blocks:_ ->
+        fail "external effect must not finalize the streamed draft")
+      ~delete_stream:(fun ~message_id ->
+        deleted := message_id :: !deleted;
+        Ok ())
+      [ Masc.Keeper_chat_events.Text_delta "partial "
+      ; Masc.Keeper_chat_events.External_effect_completed
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-effect-draft" }
+      ]
+      ~send_plain:(fun ~content:_ -> fail "external effect needs no side message")
+      ~send_blocks:(fun ~content:_ ~blocks:_ ->
+        fail "external effect needs no final message")
+  in
+  check (list string) "streamed draft deleted once" [ "slack-draft" ]
+    (List.rev !deleted);
+  check bool "draft cleanup settles the receipt" true (outcomes = [ Ok () ])
+
+let test_terminal_edit_waits_for_slack_interval () =
+  let clock = ref 0.0 in
+  let sleeps = ref [] in
+  let edits = ref [] in
+  let outcomes =
+    run_adapter
+      ~now:(fun () -> !clock)
+      ~sleep:(fun seconds ->
+        sleeps := seconds :: !sleeps;
+        clock := !clock +. seconds)
+      ~post_stream:(fun ~content:_ -> Ok "slack-paced")
+      ~edit_stream:(fun ~message_id ~content ->
+        edits := (message_id, content) :: !edits;
+        Ok ())
+      ~edit_blocks:(fun ~message_id:_ ~content:_ ~blocks:_ ->
+        fail "unchanged terminal content must not be edited twice")
+      ~delete_stream:(fun ~message_id:_ ->
+        fail "successful streaming reply must not be deleted")
+      [ Masc.Keeper_chat_events.Text_delta "hello "
+      ; Masc.Keeper_chat_events.Text_delta "world"
+      ; Masc.Keeper_chat_events.Text_message_end
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-paced" }
+      ]
+      ~send_plain:(fun ~content:_ -> fail "streaming success needs no side message")
+      ~send_blocks:(fun ~content:_ ~blocks:_ ->
+        fail "streaming success must not create a second message")
+  in
+  check (list (float 0.0001)) "terminal edit sleeps for remaining interval"
+    [ 3.0 ] (List.rev !sleeps);
+  check (list (pair string string)) "terminal edit uses accepted message"
+    [ "slack-paced", "hello world" ] (List.rev !edits);
+  check bool "paced delivery settles successfully" true (outcomes = [ Ok () ])
 
 let test_adapter_external_effect_status_is_terminal_success () =
   let sends = ref [] in
@@ -501,6 +560,10 @@ let () =
             test_adapter_empty_terminal_is_error
         ; test_case "completed effect sends no duplicate reply" `Quick
             test_completed_external_effect_settles_without_duplicate_send
+        ; test_case "completed effect deletes streamed draft" `Quick
+            test_completed_external_effect_deletes_streamed_draft
+        ; test_case "terminal edit observes Slack interval" `Quick
+            test_terminal_edit_waits_for_slack_interval
         ; test_case "typed external-effect status settles successfully" `Quick
             test_adapter_external_effect_status_is_terminal_success
         ; test_case "native activity failure is isolated" `Quick

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -188,16 +188,90 @@ let test_final_message_blocks_merges_text_and_event_blocks () =
   check bool "event block preserved" true
     (contains second "https://event.example.com")
 
-let run_adapter ?set_activity_status events ~send_plain ~send_blocks =
+let run_adapter ?post_stream ?edit_stream ?edit_blocks ?now
+    ?set_activity_status events ~send_plain ~send_blocks =
   Eio_main.run @@ fun _env ->
   let stream = Masc.Keeper_chat_events.create () in
   List.iter (Masc.Keeper_chat_events.publish stream) events;
   let outcomes = ref [] in
   S.adapter_loop ~events:stream ~send_plain ~send_blocks
+    ?post_stream ?edit_stream ?edit_blocks ?now
     ?set_activity_status
     ~on_send_result:(fun result -> outcomes := result :: !outcomes)
     ();
   List.rev !outcomes
+
+let test_adapter_streams_one_edited_reply () =
+  let posts = ref [] in
+  let stream_edits = ref [] in
+  let final_edits = ref [] in
+  let clock = ref 0.0 in
+  let now () =
+    let current = !clock in
+    clock := current +. 4.0;
+    current
+  in
+  let outcomes =
+    run_adapter
+      ~now
+      ~post_stream:(fun ~content ->
+        posts := content :: !posts;
+        Ok "slack-message-1")
+      ~edit_stream:(fun ~message_id ~content ->
+        check string "stream message identity" "slack-message-1" message_id;
+        stream_edits := content :: !stream_edits;
+        Ok ())
+      ~edit_blocks:(fun ~message_id ~content ~blocks ->
+        check string "final message identity" "slack-message-1" message_id;
+        final_edits := (content, blocks) :: !final_edits;
+        Ok ())
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-stream"; thread_id = "thread-stream" }
+      ; Masc.Keeper_chat_events.Text_delta "hello "
+      ; Masc.Keeper_chat_events.Text_delta "world "
+      ; Masc.Keeper_chat_events.Text_message_end
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-stream" }
+      ]
+      ~send_plain:(fun ~content:_ -> fail "streaming success needs no side message")
+      ~send_blocks:(fun ~content:_ ~blocks:_ ->
+        fail "streaming success must finalize the accepted message")
+  in
+  check bool "terminal callback succeeds" true (outcomes = [ Ok () ]);
+  check (list string) "one initial Slack post" [ "hello " ] (List.rev !posts);
+  check (list string)
+    "rate-limited incremental edit"
+    [ "hello world " ]
+    (List.rev !stream_edits);
+  match List.rev !final_edits with
+  | [ content, [] ] -> check string "final exact text" "hello world " content
+  | _ -> fail "terminal delivery did not edit the streaming message exactly once"
+;;
+
+let test_adapter_stream_error_edits_accepted_reply () =
+  let error_edits = ref [] in
+  let outcomes =
+    run_adapter
+      ~post_stream:(fun ~content:_ -> Ok "slack-message-error")
+      ~edit_stream:(fun ~message_id ~content ->
+        error_edits := (message_id, content) :: !error_edits;
+        Ok ())
+      ~edit_blocks:(fun ~message_id:_ ~content:_ ~blocks:_ ->
+        fail "failed run must not use the success finalizer")
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-error"; thread_id = "thread-error" }
+      ; Masc.Keeper_chat_events.Text_delta "partial "
+      ; Masc.Keeper_chat_events.Event_error { message = "tool failed" }
+      ]
+      ~send_plain:(fun ~content:_ ->
+        fail "streaming error must replace the accepted reply")
+      ~send_blocks:(fun ~content:_ ~blocks:_ ->
+        fail "streaming error must not create a second reply")
+  in
+  check bool "error callback succeeds" true (outcomes = [ Ok () ]);
+  check (list (pair string string)) "same reply becomes terminal error"
+    [ "slack-message-error", "Keeper error: tool failed" ]
+    (List.rev !error_edits)
+;;
 
 let test_adapter_terminal_success_once () =
   let sends = ref [] in
@@ -417,6 +491,10 @@ let () =
     ; ( "terminal-receipt"
       , [ test_case "terminal success settles once" `Quick
             test_adapter_terminal_success_once
+        ; test_case "streams one edited reply" `Quick
+            test_adapter_streams_one_edited_reply
+        ; test_case "stream error edits accepted reply" `Quick
+            test_adapter_stream_error_edits_accepted_reply
         ; test_case "protocol diagnostic cannot mask final failure" `Quick
             test_protocol_diagnostic_cannot_mask_final_failure
         ; test_case "empty terminal is explicit failure" `Quick

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -179,7 +179,7 @@ let content_of_wire_message raw =
 ;;
 
 let run_keeper_turn ?(tools = []) ?(tools_support = true) ?(initial_messages = []) ?event_bus
-    ?event_capture ?agent_core_checkpoint ?runtime_manifest_context
+    ?event_capture ?on_event ?agent_core_checkpoint ?runtime_manifest_context
     ?runtime_manifest_append ?raw_trace ~base_path ~cli_path ~goal () =
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
@@ -215,6 +215,7 @@ let run_keeper_turn ?(tools = []) ?(tools_support = true) ?(initial_messages = [
                            ~initial_messages
                            ?context
                            ?event_bus
+                           ?on_event
                            ?agent_core_checkpoint
                            ?runtime_manifest_context
                            ?runtime_manifest_append
@@ -549,6 +550,74 @@ let test_keeper_projects_masc_tool () =
                (String_util.contains_substring raw "MASC_TOOL_RESULT")))
 ;;
 
+let test_keeper_streams_text_and_tool_events () =
+  let base_path = temp_workspace () in
+  let events = ref [] in
+  let marker_param : Agent_core.Types.tool_param =
+    { name = "marker"
+    ; description = "Fixture marker"
+    ; param_type = String
+    ; required = true
+    }
+  in
+  let tool =
+    Agent_core.Tool.create
+      ~name:"masc_probe"
+      ~description:"Return a deterministic fixture marker"
+      ~parameters:[ marker_param ]
+      (fun _ ->
+        Ok { Agent_core.Types.content = "MASC_TOOL_RESULT"; _meta = None })
+  in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ Emit_and_read mcp_initialize
+         ; Emit mcp_initialized_notification
+         ; Emit_and_read mcp_list
+         ; Emit (assistant ~turn_id:"turn-stream-1" "MASC_CLAUDE_STREAM")
+         ; Emit_and_read mcp_call
+         ; Emit (result ~turn_id:"turn-stream-1" "MASC_CLAUDE_STREAM")
+         ]
+         (fun cli_path ->
+           match
+             run_keeper_turn
+               ~tools:[ tool ]
+               ~on_event:(fun event -> events := event :: !events)
+               ~base_path
+               ~cli_path
+               ~goal:"USE_TOOL"
+               ()
+           with
+           | Error error -> fail (Agent_core.Error.to_string error)
+           | Ok _ ->
+             match List.rev !events with
+             | [ Agent_core.Types.MessageStart
+                   { id = "assistant-turn-stream-1"
+                   ; model = "claude-fixture"
+                   ; usage = None
+                   }
+               ; ContentBlockDelta { index = 0; delta = TextDelta "MASC_CLAUDE_STREAM" }
+               ; ContentBlockStart
+                   { index = 1
+                   ; content_type = "tool_use"
+                   ; tool_id = Some "call-1"
+                   ; tool_name = Some "masc_probe"
+                   }
+               ; ContentBlockDelta
+                   { index = 1
+                   ; delta = InputJsonSnapshot arguments
+                   }
+               ; ContentBlockStop { index = 1 }
+               ; MessageStop
+               ] ->
+               check string
+                 "exact keeper tool arguments"
+                 {|{"marker":"from-claude"}|}
+                 arguments
+             | _ -> fail "Keeper did not project the exact Claude stream") )
+;;
+
 let test_tools_support_false_omits_mcp_bridge () =
   let base_path = temp_workspace () in
   let called = ref false in
@@ -778,6 +847,10 @@ let () =
             `Quick
             test_keeper_projects_typed_tool_history_and_lifecycle
         ; test_case "projects MASC tool" `Quick test_keeper_projects_masc_tool
+        ; test_case
+            "streams text and tool events"
+            `Quick
+            test_keeper_streams_text_and_tool_events
         ; test_case
             "tools-support false omits MCP bridge"
             `Quick

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -575,7 +575,7 @@ let test_keeper_streams_text_and_tool_events () =
          [ Emit_and_read mcp_initialize
          ; Emit mcp_initialized_notification
          ; Emit_and_read mcp_list
-         ; Emit (assistant ~turn_id:"turn-stream-1" "MASC_CLAUDE_STREAM")
+         ; Emit (assistant ~turn_id:"turn-stream-1" "MASC_")
          ; Emit_and_read mcp_call
          ; Emit (result ~turn_id:"turn-stream-1" "MASC_CLAUDE_STREAM")
          ]
@@ -597,7 +597,7 @@ let test_keeper_streams_text_and_tool_events () =
                    ; model = "claude-fixture"
                    ; usage = None
                    }
-               ; ContentBlockDelta { index = 0; delta = TextDelta "MASC_CLAUDE_STREAM" }
+               ; ContentBlockDelta { index = 0; delta = TextDelta "MASC_" }
                ; ContentBlockStart
                    { index = 1
                    ; content_type = "tool_use"
@@ -609,6 +609,8 @@ let test_keeper_streams_text_and_tool_events () =
                    ; delta = InputJsonSnapshot arguments
                    }
                ; ContentBlockStop { index = 1 }
+               ; ContentBlockDelta
+                   { index = 0; delta = TextDelta "CLAUDE_STREAM" }
                ; MessageStop
                ] ->
                check string

--- a/test/test_keeper_compaction_outcome_counters.ml
+++ b/test/test_keeper_compaction_outcome_counters.ml
@@ -24,7 +24,7 @@ let with_workspace f =
        Eio.Switch.run @@ fun sw ->
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+       (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
         | Ok 0 -> ()
         | Ok count -> failf "unexpected initial owner count: %d" count
         | Error error ->

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -20,7 +20,7 @@ let with_owner_inventory config f =
   Eio_main.run @@ fun env ->
   if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
-  (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+  (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
    | Ok _ -> ()
    | Error error ->
      Alcotest.fail (Masc.Keeper_owner_registry.install_error_to_string error));
@@ -1106,7 +1106,7 @@ let test_status_surfaces_chat_operation_runtime () =
       (match
          Masc.Keeper_owner_registry.install_from_store
            ~sw
-           ~operation_executor:None
+           ~operation_runner:None
            config
        with
        | Ok 1 -> ()

--- a/test/test_keeper_external_resource_lease.ml
+++ b/test/test_keeper_external_resource_lease.ml
@@ -1,0 +1,97 @@
+open Alcotest
+
+module Lease = Masc.Keeper_external_resource_lease
+
+let eio_test name fn =
+  test_case name `Quick (fun () ->
+    Eio_main.run @@ fun _env ->
+    Eio.Switch.run fn)
+;;
+
+let test_same_resource_serializes sw =
+  let first_entered, resolve_first_entered = Eio.Promise.create () in
+  let release_first, resolve_release_first = Eio.Promise.create () in
+  let second_attempting, resolve_second_attempting = Eio.Promise.create () in
+  let second_entered, resolve_second_entered = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Lease.with_lease (Lease.File_path "/tmp/shared") (fun () ->
+      Eio.Promise.resolve resolve_first_entered ();
+      Eio.Promise.await release_first));
+  Eio.Promise.await first_entered;
+  Eio.Fiber.fork ~sw (fun () ->
+    Eio.Promise.resolve resolve_second_attempting ();
+    Lease.with_lease (Lease.File_path "/tmp/shared") (fun () ->
+      Eio.Promise.resolve resolve_second_entered ()));
+  Eio.Promise.await second_attempting;
+  Eio.Fiber.yield ();
+  check bool
+    "second holder waits"
+    true
+    (Option.is_none (Eio.Promise.peek second_entered));
+  Eio.Promise.resolve resolve_release_first ();
+  Eio.Promise.await second_entered
+;;
+
+let test_distinct_resources_overlap sw =
+  let first_entered, resolve_first_entered = Eio.Promise.create () in
+  let release_first, resolve_release_first = Eio.Promise.create () in
+  let second_entered, resolve_second_entered = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Lease.with_lease (Lease.Host_cwd "/tmp/repo-a") (fun () ->
+      Eio.Promise.resolve resolve_first_entered ();
+      Eio.Promise.await release_first));
+  Eio.Promise.await first_entered;
+  Eio.Fiber.fork ~sw (fun () ->
+    Lease.with_lease (Lease.Host_cwd "/tmp/repo-b") (fun () ->
+      Eio.Promise.resolve resolve_second_entered ()));
+  Eio.Promise.await second_entered;
+  Eio.Promise.resolve resolve_release_first ()
+;;
+
+let test_resource_kinds_do_not_alias sw =
+  let first_entered, resolve_first_entered = Eio.Promise.create () in
+  let release_first, resolve_release_first = Eio.Promise.create () in
+  let second_entered, resolve_second_entered = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Lease.with_lease (Lease.File_path "/tmp/same-bytes") (fun () ->
+      Eio.Promise.resolve resolve_first_entered ();
+      Eio.Promise.await release_first));
+  Eio.Promise.await first_entered;
+  Eio.Fiber.fork ~sw (fun () ->
+    Lease.with_lease (Lease.Host_cwd "/tmp/same-bytes") (fun () ->
+      Eio.Promise.resolve resolve_second_entered ()));
+  Eio.Promise.await second_entered;
+  Eio.Promise.resolve resolve_release_first ()
+;;
+
+let test_cancelled_holder_releases _sw =
+  let entered, resolve_entered = Eio.Promise.create () in
+  let never, _resolve_never = Eio.Promise.create () in
+  (match
+     Eio.Switch.run (fun child_sw ->
+       Eio.Fiber.fork ~sw:child_sw (fun () ->
+         Lease.with_lease (Lease.File_path "/tmp/cancelled") (fun () ->
+           Eio.Promise.resolve resolve_entered ();
+           Eio.Promise.await never));
+       Eio.Promise.await entered;
+       Eio.Switch.fail child_sw Exit)
+   with
+   | () -> fail "child switch unexpectedly completed"
+   | exception Exit -> ());
+  let reacquired = ref false in
+  Lease.with_lease (Lease.File_path "/tmp/cancelled") (fun () ->
+    reacquired := true);
+  check bool "cancelled holder released lease" true !reacquired
+;;
+
+let () =
+  run
+    "keeper_external_resource_lease"
+    [ ( "lease"
+      , [ eio_test "same resource serializes" test_same_resource_serializes
+        ; eio_test "different resources overlap" test_distinct_resources_overlap
+        ; eio_test "resource kinds do not alias" test_resource_kinds_do_not_alias
+        ; eio_test "cancellation releases resource" test_cancelled_holder_releases
+        ] )
+    ]
+;;

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -158,7 +158,7 @@ let test_grpc_pause_directive_records_reason () =
        let meta = make_meta keeper_name in
        Keeper_meta_store.replace_snapshot config meta
        |> Result.get_ok;
-       Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config
+       Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config
        |> Result.get_ok
        |> ignore;
        Keeper_registry.For_testing.clear ();

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -95,7 +95,10 @@ let start_owner_with_executor
     ~store
     ~operation_store_path:path
     ~now:(fun () -> 42.0)
-    ~operation_executor
+    ~operation_runner:
+      (Option.map
+         (fun execute -> Owner.{ ready = (fun ~keeper_name:_ -> true); execute })
+         operation_executor)
     ~keeper_name
     ~initial_meta
 ;;
@@ -1031,7 +1034,7 @@ let test_startup_interrupts_running_without_requeue () =
               ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
               ~operation_store_path:path
               ~now:(fun () -> 20.0)
-              ~operation_executor:None
+              ~operation_runner:None
               ~keeper_name:"interrupted-restart"
               ~initial_meta:(Some (make_meta "interrupted-restart")))
        in
@@ -1048,6 +1051,87 @@ let test_startup_interrupts_running_without_requeue () =
          "restart never requeues Running"
          true
          (Option.is_none (owner_ok (Owner.claim_next_operation owner))))
+;;
+
+let test_startup_queued_waits_for_runner_readiness () =
+  Eio_main.run @@ fun _env ->
+  let path = Filename.temp_file "keeper-owner-ready-" ".sqlite3" in
+  Unix.unlink path;
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Unix.unlink path)
+    (fun () ->
+       let first_id = operation_id "kmsg-ready-first" in
+       let second_id = operation_id "kmsg-ready-second" in
+       let seed =
+         Keeper_chat_operation_store.open_or_create ~path
+         |> Result.map_error Keeper_chat_operation_store.error_to_string
+         |> Result.get_ok
+       in
+       List.iter
+         (fun (operation_id, input) ->
+            Keeper_chat_operation_store.submit
+              seed
+              ~now:10.0
+              ~operation_id
+              ~source:operation_source
+              ~input
+            |> Result.get_ok
+            |> ignore)
+         [ first_id, operation_input "first"
+         ; second_id, operation_input "second"
+         ];
+       Keeper_chat_operation_store.close seed |> Result.get_ok;
+       let ready = ref false in
+       let executed = ref [] in
+       let execute ~sw:_ ~keeper_name:_ ~claim =
+         match claim () with
+         | Error error -> fail (Owner.error_to_string error)
+         | Ok None -> fail "ready operation runner did not find its FIFO head"
+         | Ok (Some (operation : Chat_operation.t)) ->
+           executed := operation.operation_id :: !executed;
+           Owner.Operation_succeeded
+             { outcome_ref =
+                 "turn:"
+                 ^ Chat_operation.Operation_id.to_string operation.operation_id
+             }
+       in
+       Eio.Switch.run @@ fun sw ->
+       let owner =
+         owner_ok
+           (Owner.start
+              ~sw
+              ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
+              ~operation_store_path:path
+              ~now:(fun () -> 20.0)
+              ~operation_runner:
+                (Some Owner.{ ready = (fun ~keeper_name:_ -> !ready); execute })
+              ~keeper_name:"ready-after-registration"
+              ~initial_meta:(Some (make_meta "ready-after-registration")))
+       in
+       let first_before =
+         Option.get (owner_ok (Owner.exact_operation owner first_id))
+       in
+       let second_before =
+         Option.get (owner_ok (Owner.exact_operation owner second_id))
+       in
+       (match first_before.state, second_before.state with
+        | Chat_operation.Queued, Chat_operation.Queued -> ()
+        | _ -> fail "startup claimed Queued operations before runner readiness");
+       check int "executor did not run before readiness" 0 (List.length !executed);
+       ready := true;
+       ignore (owner_ok (Owner.wake_operation_drain owner));
+       let first = await_terminal owner first_id 1_000 in
+       let second = await_terminal owner second_id 1_000 in
+       (match first.state, second.state with
+        | Chat_operation.Succeeded _, Chat_operation.Succeeded _ -> ()
+        | _ -> fail "ready wake did not drain both Queued operations");
+       check
+         (list string)
+         "registration wake preserves FIFO"
+         [ Chat_operation.Operation_id.to_string first_id
+         ; Chat_operation.Operation_id.to_string second_id
+         ]
+         (List.rev_map Chat_operation.Operation_id.to_string !executed))
 ;;
 
 let test_operation_store_failure_fences_owner_mutations () =
@@ -1427,7 +1511,7 @@ let test_root_inventory_loads_and_extends_exactly_once () =
        (match Keeper_meta_store.replace_snapshot config first with
         | Ok () -> ()
         | Error detail -> fail ("failed to seed owner meta: " ^ detail));
-       (match Owner_registry.install_from_store ~sw ~operation_executor:None config with
+       (match Owner_registry.install_from_store ~sw ~operation_runner:None config with
         | Ok count -> check int "strict startup owner count" 1 count
         | Error error -> fail (Owner_registry.install_error_to_string error));
        let loaded =
@@ -1495,7 +1579,7 @@ let test_agent_delegate_submits_owner_operation_without_waiting () =
        ignore (Workspace.init config ~agent_name:(Some "owner-tool-test"));
        let meta = make_meta "agent-operation-target" in
        Keeper_meta_store.replace_snapshot config meta |> Result.get_ok;
-       Owner_registry.install_from_store ~sw ~operation_executor:None config
+       Owner_registry.install_from_store ~sw ~operation_runner:None config
        |> Result.get_ok
        |> ignore;
        let ctx : _ Keeper_tool_surface.context =
@@ -1652,7 +1736,7 @@ let test_connector_submit_uses_owner_operation_idempotency () =
        (match Keeper_meta_store.replace_snapshot config meta with
         | Ok () -> ()
         | Error detail -> fail detail);
-       (match Owner_registry.install_from_store ~sw ~operation_executor:None config with
+       (match Owner_registry.install_from_store ~sw ~operation_runner:None config with
         | Ok 1 -> ()
         | Ok count -> failf "unexpected owner count %d" count
         | Error error -> fail (Owner_registry.install_error_to_string error));
@@ -1752,7 +1836,7 @@ let test_root_inventory_isolates_invalid_owner_snapshots () =
        Yojson.Safe.to_file
          (Filename.concat keepers_dir "inventory-path-name.json")
          (Keeper_meta_json.meta_to_json (make_meta "inventory-payload-name"));
-       (match Owner_registry.install_from_store ~sw ~operation_executor:None config with
+       (match Owner_registry.install_from_store ~sw ~operation_runner:None config with
         | Ok count -> check int "only valid owner starts" 1 count
         | Error error -> fail (Owner_registry.install_error_to_string error));
        (match Owner_registry.get ~base_path ~keeper_name:valid.name with
@@ -1805,7 +1889,7 @@ let test_registry_reads_owner_atomic_projection () =
        ignore (Workspace.init config ~agent_name:(Some "owner-projection-test"));
        let initial = make_meta "atomic-projection" in
        Keeper_meta_store.replace_snapshot config initial |> Result.get_ok;
-       Owner_registry.install_from_store ~sw ~operation_executor:None config
+       Owner_registry.install_from_store ~sw ~operation_runner:None config
        |> Result.get_ok
        |> ignore;
        let stale_entry =
@@ -1848,7 +1932,7 @@ let test_lifecycle_reservation_remains_owner_admission_authority () =
        (match Keeper_meta_store.replace_snapshot config meta with
         | Ok () -> ()
         | Error detail -> fail ("failed to seed reserved owner meta: " ^ detail));
-       (match Owner_registry.install_from_store ~sw ~operation_executor:None config with
+       (match Owner_registry.install_from_store ~sw ~operation_runner:None config with
         | Ok count -> check int "reserved owner count" 1 count
         | Error error -> fail (Owner_registry.install_error_to_string error));
        let token =
@@ -1900,7 +1984,7 @@ let test_create_waits_for_lifecycle_admission_before_installing_owner () =
        Eio.Switch.run @@ fun sw ->
        let config = Workspace.default_config base_path in
        ignore (Workspace.init config ~agent_name:(Some "owner-create-reservation-test"));
-       (match Owner_registry.install_from_store ~sw ~operation_executor:None config with
+       (match Owner_registry.install_from_store ~sw ~operation_runner:None config with
         | Ok count -> check int "empty owner inventory" 0 count
         | Error error -> fail (Owner_registry.install_error_to_string error));
        let meta = make_meta "create-reserved" in
@@ -2023,6 +2107,10 @@ let () =
             "startup interrupts Running without requeue"
             `Quick
             test_startup_interrupts_running_without_requeue
+        ; test_case
+            "startup Queued waits for runner readiness"
+            `Quick
+            test_startup_queued_waits_for_runner_readiness
         ; test_case
             "operation store failure fences owner mutations"
             `Quick

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -63,7 +63,7 @@ let with_seeded_owner ?(registered = true) ?latched_reason ~paused ~generation f
          |> require_ok "read persisted Keeper metadata"
          |> require_some "persisted Keeper metadata"
        in
-       (match Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+       (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
         | Ok count -> Alcotest.(check int) "installed owner count" 1 count
         | Error error ->
           Alcotest.fail

--- a/test/test_keeper_paused_work_operator.ml
+++ b/test/test_keeper_paused_work_operator.ml
@@ -119,7 +119,7 @@ let with_source_terminal_lane f =
        (match
           Keeper_owner_registry.install_from_store
             ~sw:(current_switch ())
-            ~operation_executor:None
+            ~operation_runner:None
             config
         with
         | Ok count -> Alcotest.(check int) "installed owner count" 1 count

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -102,7 +102,7 @@ let with_source_terminal_lane f =
        (match
           Keeper_owner_registry.install_from_store
             ~sw:(current_switch ())
-            ~operation_executor:None
+            ~operation_runner:None
             config
         with
         | Ok count -> Alcotest.(check int) "installed owner count" 1 count

--- a/test/test_keeper_paused_work_transfer_transaction.ml
+++ b/test/test_keeper_paused_work_transfer_transaction.ml
@@ -132,7 +132,7 @@ let with_transfer_lane f =
            ~paused:false
        in
        let _, sw = current_test_context () in
-       (match Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+       (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
         | Ok count -> Alcotest.(check int) "installed owner count" 2 count
         | Error error ->
           Alcotest.fail (Keeper_owner_registry.install_error_to_string error));

--- a/test/test_keeper_shutdown_reconciliation_settlement.ml
+++ b/test/test_keeper_shutdown_reconciliation_settlement.ml
@@ -49,7 +49,7 @@ let with_workspace f =
             let config = Workspace.default_config base in
             let (_init_msg : string) = Workspace.init config ~agent_name:None in
             Eio.Switch.run @@ fun sw ->
-            (match Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+            (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
              | Ok 0 -> ()
              | Ok count -> failf "unexpected initial owner count: %d" count
              | Error error ->

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -67,7 +67,7 @@ let with_owner_inventory config f =
   Eio_main.run @@ fun env ->
   if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
-  (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+  (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
    | Ok _ -> ()
    | Error error ->
      failwith (Masc.Keeper_owner_registry.install_error_to_string error));

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -1247,6 +1247,50 @@ let test_async_append_defers_until_flush env =
           (Safe_ops.json_string_opt "keeper" entry)
       | _ -> Alcotest.fail "expected exactly one entry"))
 
+let test_commit_callback_bypasses_async_queue env =
+  with_tmp_log_dir (fun _dir ->
+    Eio.Switch.run (fun sw ->
+      Keeper_tool_call_log.start_flush_fiber
+        ~sw
+        ~clock:(Eio.Stdenv.clock env);
+      let committed = ref false in
+      Keeper_tool_call_log.log_call
+        ~keeper_name:"chat-k"
+        ~tool_name:"masc_status"
+        ~input:(`Assoc [])
+        ~output_text:"ready"
+        ~success:true
+        ~duration_ms:1.0
+        ~on_committed:(fun () -> committed := true)
+        ();
+      Alcotest.(check bool) "callback observed committed row" true !committed;
+      Alcotest.(check int)
+        "committed row did not enter async queue"
+        0
+        (Keeper_tool_call_log.queued_count_for_testing ());
+      Alcotest.(check int)
+        "committed row is immediately readable"
+        1
+        (List.length (Keeper_tool_call_log.read_recent ~n:1 ()))))
+
+let test_commit_callback_fails_closed_without_store () =
+  Keeper_tool_call_log.reset_for_testing ();
+  let raised =
+    try
+      Keeper_tool_call_log.log_call
+        ~keeper_name:"chat-k"
+        ~tool_name:"masc_status"
+        ~input:(`Assoc [])
+        ~output_text:"unavailable"
+        ~success:true
+        ~duration_ms:1.0
+        ~on_committed:(fun () -> Alcotest.fail "callback must not run")
+        ();
+      false
+    with _ -> true
+  in
+  Alcotest.(check bool) "required commit fails closed" true raised
+
 let () =
   Alcotest.run "keeper_tool_call_log"
     [ ( "read_recent",
@@ -1321,5 +1365,9 @@ let () =
     ; ( "async_append",
         [ eio_env_test "append queues until flush when async fiber is active"
             test_async_append_defers_until_flush
+        ; eio_env_test "commit callback runs after synchronous readable append"
+            test_commit_callback_bypasses_async_queue
+        ; eio_test "commit callback fails closed without store"
+            test_commit_callback_fails_closed_without_store
         ] )
     ]

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -51,7 +51,7 @@ let with_workspace f =
   Eio.Switch.on_release sw (fun () -> rm_rf dir);
   let config = Workspace_core.default_config dir in
   ignore (Workspace_core.init config ~agent_name:(Some "test"));
-  (match Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+  (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
    | Ok 0 -> ()
    | Ok count -> failf "expected empty owner inventory, got %d owners" count
    | Error error ->

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -284,7 +284,7 @@ let test_snapshot_keeps_context_unobserved_and_usage_separate () =
       init_runtime_default_for_snapshot base_dir;
       ignore (Workspace.init config ~agent_name:(Some "owner"));
       ignore (Workspace.bind_session config ~agent_name:"owner" ~capabilities:[] ());
-      (match Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+      (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
        | Ok _ -> ()
        | Error error ->
          Alcotest.fail (Keeper_owner_registry.install_error_to_string error));

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -106,6 +106,7 @@ let run_fixture
     ?conversation_mode
     ?home_dir
     ?on_conversation_ready
+    ?on_stream_event
     ?(timeout_s = 2.0)
     ?(prompt = "Return the fixture marker")
     path
@@ -121,11 +122,35 @@ let run_fixture
       ?conversation_mode
       ?home_dir
       ?on_conversation_ready
+      ?on_stream_event
       ~mgr:(Eio.Stdenv.process_mgr env)
       ~clock:(Eio.Stdenv.clock env)
       ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
       config
       ~prompt)
+;;
+
+let test_stream_events_preserve_available_wire_data () =
+  let events = ref [] in
+  with_fixture
+    [ init (); result () ]
+    (fun path ->
+       match
+         run_fixture
+           ~on_stream_event:(fun event -> events := event :: !events)
+           path
+       with
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok _ ->
+         match List.rev !events with
+         | [ Runtime_antigravity.Turn_started
+               { conversation_id = "conversation-1"
+               ; model = "gemini-fixture"
+               }
+           ; Text_delta "MASC_ANTIGRAVITY_OK\n"
+           ; Turn_finished { text = "MASC_ANTIGRAVITY_OK\n" }
+           ] -> ()
+         | _ -> fail "Antigravity stream did not preserve available wire data")
 ;;
 
 let test_successful_official_client_turn () =
@@ -459,6 +484,10 @@ let () =
             "successful official-client turn"
             `Quick
             test_successful_official_client_turn
+        ; test_case
+            "stream preserves available wire data"
+            `Quick
+            test_stream_events_preserve_available_wire_data
         ; test_case
             "resume identity and argv"
             `Quick

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -59,6 +59,7 @@ let fixture_script
     ?(require_resume = false)
     ?required_home
     ?(sleep_s = 0.0)
+    ?line_delay_s
     ?(exit_code = 0)
     lines
   =
@@ -68,6 +69,9 @@ let fixture_script
   output_string output
     "test -z \"${GEMINI_API_KEY+x}\" && test -z \"${GEMINI_API_KEY_WORK+x}\" && test -z \"${GOOGLE_API_TOKEN+x}\" && test -z \"${OPENAI_API_KEY+x}\" && test -z \"${OPENAI_API_KEY_MAIN+x}\" && test -z \"${ANTHROPIC_API_KEY+x}\" && test -z \"${ANTHROPIC_API_KEY_WORK+x}\" && test -z \"${AGY_ADC_AUTH+x}\" && test -z \"${MASC_PUBLIC_FIXTURE+x}\" || exit 92\n";
   output_string output "case \" $* \" in *\" --print \"*) exit 98 ;; esac\n";
+  output_string
+    output
+    "case \" $* \" in *\" --print-timeout 2562047h47m16.854775807s \"*) ;; *) exit 99 ;; esac\n";
   if require_resume
   then (
     output_string
@@ -89,7 +93,12 @@ let fixture_script
   output_string output "cat >/dev/null\n";
   if sleep_s > 0.0 then output_string output (Printf.sprintf "sleep %.3f\n" sleep_s);
   List.iter
-    (fun line -> output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
+    (fun line ->
+       Option.iter
+         (fun seconds ->
+            output_string output (Printf.sprintf "sleep %.3f\n" seconds))
+         line_delay_s;
+       output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
     lines;
   output_string output (Printf.sprintf "exit %d\n" exit_code);
   close_out output;
@@ -97,8 +106,16 @@ let fixture_script
   path
 ;;
 
-let with_fixture ?require_resume ?required_home ?sleep_s ?exit_code lines f =
-  let path = fixture_script ?require_resume ?required_home ?sleep_s ?exit_code lines in
+let with_fixture ?require_resume ?required_home ?sleep_s ?line_delay_s ?exit_code lines f =
+  let path =
+    fixture_script
+      ?require_resume
+      ?required_home
+      ?sleep_s
+      ?line_delay_s
+      ?exit_code
+      lines
+  in
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
@@ -404,15 +421,27 @@ let test_unknown_protocol_vocabulary_fails_closed () =
     cases
 ;;
 
-let test_timeout_is_typed () =
+let test_progress_resets_stream_idle_timeout () =
+  with_fixture
+    ~line_delay_s:0.4
+    [ init (); step ~index:1 (); result () ]
+    (fun path ->
+       match run_fixture ~timeout_s:0.75 path with
+       | Ok turn ->
+         check string "progressing turn completes" "MASC_ANTIGRAVITY_OK\n" turn.text
+       | Error error -> fail (Runtime_antigravity.error_to_string error))
+;;
+
+let test_stream_idle_timeout_is_typed () =
   with_fixture
     ~sleep_s:1.0
     [ init (); result () ]
     (fun path ->
        match run_fixture ~timeout_s:0.05 path with
-       | Error (Runtime_antigravity.Timeout _) -> ()
+       | Error (Runtime_antigravity.Timeout seconds) ->
+         check (float 0.001) "exact idle timeout" 0.05 seconds
        | Error error -> fail (Runtime_antigravity.error_to_string error)
-       | Ok _ -> fail "slow CLI ignored the runtime timeout")
+       | Ok _ -> fail "silent Antigravity stream ignored its idle timeout")
 ;;
 
 let test_admission_is_process_free () =
@@ -535,7 +564,14 @@ let () =
             "unknown protocol vocabulary fails closed"
             `Quick
             test_unknown_protocol_vocabulary_fails_closed
-        ; test_case "typed timeout" `Quick test_timeout_is_typed
+        ; test_case
+            "progress resets stream idle timeout"
+            `Quick
+            test_progress_resets_stream_idle_timeout
+        ; test_case
+            "stream idle timeout is typed"
+            `Quick
+            test_stream_idle_timeout_is_typed
         ; test_case "process-free admission" `Quick test_admission_is_process_free
         ] )
     ; "live official client", [ test_case "official agy start and resume" `Slow test_live_start_and_resume ]

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -30,6 +30,7 @@ type fixture_step =
   | Emit_and_read of string
   | Emit_and_expect_request_id of string * string
   | Emit_after_closing_input of string
+  | Pause of float
 
 let fixture_script
       ?(auth_json = auth_subscription)
@@ -53,6 +54,8 @@ let fixture_script
     | Emit_after_closing_input line ->
       output_string output "exec 0<&-\n";
       output_string output ("emit " ^ shell_quote line ^ "\n")
+    | Pause seconds ->
+      output_string output (Printf.sprintf "sleep %.3f\n" seconds)
   in
   output_string output "#!/bin/sh\n";
   output_string output "set -eu\n";
@@ -115,12 +118,13 @@ let with_fixture ?auth_json ?before_initialize_response steps f =
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
-let run_fixture ?(dynamic_tools = []) ?session_mode ?on_stream_event path =
+let run_fixture ?(dynamic_tools = []) ?session_mode ?(timeout_s = 2.0)
+    ?on_stream_event path =
   Eio_main.run (fun env ->
     let config =
       { (Runtime_claude_code.default_config ~cwd:"/tmp") with
         cli_path = path
-      ; timeout_s = 2.0
+      ; timeout_s
       }
     in
     Runtime_claude_code.run_turn
@@ -172,6 +176,25 @@ let test_subscription_turn_and_env_scrub () =
       check string "subscription" "team" turn.subscription.subscription_type;
       check bool "new session" false turn.resumed;
       check bool "no usage block yields none" true (Option.is_none turn.usage))
+;;
+
+let test_progress_resets_stream_idle_timeout () =
+  with_fixture
+    [ Emit assistant; Pause 0.4; Emit assistant; Pause 0.4; Emit result ]
+    (fun path ->
+       match run_fixture ~timeout_s:0.75 path with
+       | Ok turn ->
+         check string "progressing turn completes" "MASC_CLAUDE_OK" turn.text
+       | Error error -> fail (Runtime_claude_code.error_to_string error))
+;;
+
+let test_stream_idle_timeout_is_typed () =
+  with_fixture [ Pause 0.2; Emit assistant; Emit result ] (fun path ->
+    match run_fixture ~timeout_s:0.05 path with
+    | Error (Runtime_claude_code.Timeout seconds) ->
+      check (float 0.001) "exact idle timeout" 0.05 seconds
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "silent Claude stream ignored its idle timeout")
 ;;
 
 (* [dynamic_tool_bytes] measures what the tool declarations add to a request.
@@ -922,6 +945,14 @@ let () =
             "subscription auth and env scrub"
             `Quick
             test_subscription_turn_and_env_scrub
+        ; test_case
+            "progress resets stream idle timeout"
+            `Quick
+            test_progress_resets_stream_idle_timeout
+        ; test_case
+            "stream idle timeout is typed"
+            `Quick
+            test_stream_idle_timeout_is_typed
         ; test_case
             "non-subscription rejected"
             `Quick

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -115,7 +115,7 @@ let with_fixture ?auth_json ?before_initialize_response steps f =
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
-let run_fixture ?(dynamic_tools = []) ?session_mode path =
+let run_fixture ?(dynamic_tools = []) ?session_mode ?on_stream_event path =
   Eio_main.run (fun env ->
     let config =
       { (Runtime_claude_code.default_config ~cwd:"/tmp") with
@@ -129,6 +129,7 @@ let run_fixture ?(dynamic_tools = []) ?session_mode path =
       ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
       ~dynamic_tools
       ?session_mode
+      ?on_stream_event
       config
       ~prompt:"Return the fixture marker")
 ;;
@@ -372,7 +373,7 @@ let test_post_effect_response_failure_requires_recovery () =
   let call_count = ref 0 in
   with_fixture
     [ Emit_and_read mcp_initialize
-    ; Emit mcp_initialized_notification
+    ; Emit_and_read mcp_initialized_notification
     ; Emit_after_closing_input mcp_call
     ]
     (fun path ->
@@ -423,6 +424,52 @@ let test_dynamic_tool_callback () =
           "arguments"
           {|{"marker":"from-claude"}|}
           (Yojson.Safe.to_string !observed_input))
+;;
+
+let test_stream_events_preserve_text_and_tool_identity () =
+  let events = ref [] in
+  let tool : Runtime_claude_code.dynamic_tool =
+    { name = "masc_probe"
+    ; description = "Return a fixture marker"
+    ; input_schema = `Assoc [ "type", `String "object" ]
+    ; call =
+        (fun ~call_id:_ _ ->
+          { success = true; content = "MASC_TOOL_RESULT" })
+    }
+  in
+  with_fixture
+    [ Emit_and_read mcp_initialize
+    ; Emit mcp_initialized_notification
+    ; Emit_and_read mcp_list
+    ; Emit assistant
+    ; Emit_and_read mcp_call
+    ; Emit result
+    ]
+    (fun path ->
+      match
+        run_fixture
+          ~dynamic_tools:[ tool ]
+          ~on_stream_event:(fun event -> events := event :: !events)
+          path
+      with
+      | Error error -> fail (Runtime_claude_code.error_to_string error)
+      | Ok _ ->
+        match List.rev !events with
+        | [ Turn_started { turn_id = "assistant-fixture-1"; model = "claude-fixture" }
+          ; Text_delta "MASC_CLAUDE_OK"
+          ; Dynamic_tool_started
+              { call_id = "call-1"
+              ; tool_name = "masc_probe"
+              ; arguments
+              }
+          ; Dynamic_tool_finished { call_id = "call-1" }
+          ; Turn_finished { text = "MASC_CLAUDE_OK" }
+          ] ->
+          check string
+            "exact tool arguments"
+            {|{"marker":"from-claude"}|}
+            (Yojson.Safe.to_string arguments)
+        | _ -> fail "Claude stream events did not preserve wire order and identity")
 ;;
 
 (* This test used to assert the opposite: that an MCP notification draws no
@@ -911,6 +958,10 @@ let () =
         ] )
     ; ( "mcp"
       , [ test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
+        ; test_case
+            "stream preserves text and tool identity"
+            `Quick
+            test_stream_events_preserve_text_and_tool_identity
         ; test_case
             "pre-admission tool call is rejected"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -54,7 +54,7 @@ let rec drop count values =
     | _ :: rest -> drop (count - 1) rest
 ;;
 
-let fixture_script ?capture_path lines =
+let fixture_script ?capture_path ?terminal_line_delay_s lines =
   let path = Filename.temp_file "masc-codex-app-server-" ".sh" in
   let output = open_out_bin path in
   let read_request ?(expect_version = false) () =
@@ -82,7 +82,12 @@ let fixture_script ?capture_path lines =
   output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 2) ^ "\n");
   read_request ();
   List.iter
-    (fun line -> output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
+    (fun line ->
+       Option.iter
+         (fun seconds ->
+            output_string output (Printf.sprintf "sleep %.3f\n" seconds))
+         terminal_line_delay_s;
+       output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
     (drop 3 lines);
   output_string output "while IFS= read -r ignored; do :; done\n";
   close_out output;
@@ -90,8 +95,8 @@ let fixture_script ?capture_path lines =
   path
 ;;
 
-let with_fixture ?capture_path lines f =
-  let path = fixture_script ?capture_path lines in
+let with_fixture ?capture_path ?terminal_line_delay_s lines f =
+  let path = fixture_script ?capture_path ?terminal_line_delay_s lines in
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
 ;;
 
@@ -129,12 +134,12 @@ let with_fixture_sequence ?capture_path first_lines second_lines f =
 ;;
 
 let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp")
-    ?on_stream_event path =
+    ?(timeout_s = 2.0) ?on_stream_event path =
   Eio_main.run (fun env ->
     let config =
       { (Runtime_codex_app_server.default_config ()) with
         cli_path = path
-      ; timeout_s = 2.0
+      ; timeout_s
       }
     in
     Runtime_codex_app_server.run_turn
@@ -668,7 +673,8 @@ let test_retry_notifications_are_observational () =
   (* Live incident 2026-08-10 (masc#27953): one upstream degradation window
      drove three keepers into Recovery_required twice in two hours because the
      turn died at the fourth willRetry:true. The app-server retrying upstream
-     is progress, not failure; the turn deadline is the liveness boundary. *)
+     is progress, not failure; the stream-idle deadline is the liveness
+     boundary. *)
   let retry = {|{"method":"error","params":{"willRetry":true}}|} in
   with_fixture
     ([ init_result; account_chatgpt; thread_result; turn_result ]
@@ -689,6 +695,38 @@ let test_retry_notifications_are_observational () =
        | Error (Runtime_codex_app_server.Turn_failed "provider gave up") -> ()
        | Error error -> fail (Runtime_codex_app_server.error_to_string error)
        | Ok _ -> fail "terminal error notification did not fail the turn")
+;;
+
+let test_progress_resets_stream_idle_timeout () =
+  let retry = {|{"method":"error","params":{"willRetry":true}}|} in
+  with_fixture
+    ~terminal_line_delay_s:0.4
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; retry
+    ; retry
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun path ->
+       match run_fixture ~timeout_s:0.75 path with
+       | Ok turn ->
+         check string "progressing turn completes" "MASC_SUBSCRIPTION_OK" turn.text
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error))
+;;
+
+let test_stream_idle_timeout_is_typed () =
+  with_fixture
+    ~terminal_line_delay_s:0.2
+    [ init_result; account_chatgpt; thread_result; turn_result; turn_completed ]
+    (fun path ->
+       match run_fixture ~timeout_s:0.05 path with
+       | Error (Runtime_codex_app_server.Timeout seconds) ->
+         check (float 0.001) "exact idle timeout" 0.05 seconds
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok _ -> fail "silent app-server stream ignored its idle timeout")
 ;;
 
 let test_terminal_error_notification_uses_official_context_error_enum () =
@@ -2679,6 +2717,14 @@ let () =
             "retry notifications are observational"
             `Quick
             test_retry_notifications_are_observational
+        ; test_case
+            "progress resets stream idle timeout"
+            `Quick
+            test_progress_resets_stream_idle_timeout
+        ; test_case
+            "stream idle timeout is typed"
+            `Quick
+            test_stream_idle_timeout_is_typed
         ; test_case
             "terminal error notification uses official context error enum"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -15,6 +15,10 @@ let thread_result =
 
 let turn_result = {|{"id":4,"result":{"turn":{"id":"turn-1"}}}|}
 
+let agent_message_delta =
+  {|{"method":"item/agentMessage/delta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"message-1","delta":"MASC_"}}|}
+;;
+
 let item_completed =
   {|{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-1","completedAtMs":1,"item":{"type":"agentMessage","id":"message-1","text":"MASC_SUBSCRIPTION_OK","phase":"final_answer"}}}|}
 ;;
@@ -124,7 +128,8 @@ let with_fixture_sequence ?capture_path first_lines second_lines f =
     (fun () -> f path)
 ;;
 
-let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp") path =
+let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp")
+    ?on_stream_event path =
   Eio_main.run (fun env ->
     let config =
       { (Runtime_codex_app_server.default_config ()) with
@@ -139,6 +144,7 @@ let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp
       ~dynamic_tools
       ?thread_mode
       ~history
+      ?on_stream_event
       config
       ~prompt:"Return the fixture marker")
 ;;
@@ -166,6 +172,7 @@ let tool_call_request =
 let test_dynamic_tool_callback () =
   let call_id = ref None in
   let arguments = ref `Null in
+  let stream_events = ref [] in
   let tool : Runtime_codex_app_server.dynamic_tool =
     { name = "masc_probe"
     ; description = "Return a deterministic fixture marker"
@@ -187,12 +194,18 @@ let test_dynamic_tool_callback () =
     ; account_chatgpt
     ; thread_result
     ; turn_result
+    ; agent_message_delta
     ; tool_call_request
     ; item_completed
     ; turn_completed
     ]
     (fun path ->
-       match run_fixture ~dynamic_tools:[ tool ] path with
+       match
+         run_fixture
+           ~dynamic_tools:[ tool ]
+           ~on_stream_event:(fun event -> stream_events := event :: !stream_events)
+           path
+       with
        | Error error -> fail (Runtime_codex_app_server.error_to_string error)
        | Ok result ->
          check int "measured tool calls" 1 result.dynamic_tool_calls;
@@ -200,7 +213,21 @@ let test_dynamic_tool_callback () =
          check string
            "arguments"
            {|{"marker":"from-codex"}|}
-           (Yojson.Safe.to_string !arguments))
+           (Yojson.Safe.to_string !arguments);
+         let open Runtime_codex_app_server in
+         (match List.rev !stream_events with
+          | [ Turn_started { turn_id = "turn-1"; model = "gpt-fixture" }
+            ; Text_delta "MASC_"
+            ; Dynamic_tool_started
+                { call_id = "call-1"; tool_name = "masc_probe"; arguments }
+            ; Dynamic_tool_finished { call_id = "call-1" }
+            ; Turn_finished { text = "MASC_SUBSCRIPTION_OK" }
+            ] ->
+            check string
+              "stream arguments"
+              {|{"marker":"from-codex"}|}
+              (Yojson.Safe.to_string arguments)
+          | _ -> fail "Codex live stream events were not projected in wire order"))
 ;;
 
 let test_context_error_records_prior_tool_effect () =
@@ -1095,6 +1122,7 @@ let run_production_keeper_turn ~base_path ~trace_id ~user_message ~cli_path ~mod
 
 let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projection
     ?(initial_messages = []) ?base_path ?raw_trace_path
+    ?on_event
     ?(goal = "Reply with exactly MASC_SUBSCRIPTION_OK and do not use tools.") ~cli_path
     ~model () =
   let owns_base_path = Option.is_none base_path in
@@ -1150,6 +1178,7 @@ let run_keeper_turn ?(tools = []) ?hooks ?context_injector ?model_input_projecti
                       ?context_injector
                       ?context
                       ?raw_trace
+                      ?on_event
                       ~sw
                       ~net:(Eio.Stdenv.net env)
                       ()
@@ -1299,6 +1328,68 @@ let test_keeper_dispatches_codex_turn_runtime () =
        | Ok result ->
          check string "Keeper response" "MASC_SUBSCRIPTION_OK" (keeper_response_text result);
          check bool "measured observation" true (Option.is_some result.runtime_observation))
+;;
+
+let test_keeper_projects_codex_live_stream () =
+  let stream_events = ref [] in
+  let tool =
+    Agent_core.Tool.create
+      ~name:"masc_probe"
+      ~description:"Return a deterministic fixture marker"
+      ~parameters:
+        [ { Agent_core.Types.name = "marker"
+          ; description = "Fixture marker"
+          ; param_type = String
+          ; required = true
+          }
+        ]
+      (fun _ ->
+         Ok { Agent_core.Types.content = "MASC_TOOL_RESULT"; _meta = None })
+  in
+  with_fixture
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; agent_message_delta
+    ; tool_call_request
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun cli_path ->
+       match
+         run_keeper_turn
+           ~tools:[ tool ]
+           ~on_event:(fun event -> stream_events := event :: !stream_events)
+           ~cli_path
+           ~model:"gpt-fixture"
+           ()
+       with
+       | Error error -> fail (Agent_core.Error.to_string error)
+       | Ok _ ->
+         let open Agent_core.Types in
+         (match List.rev !stream_events with
+          | [ MessageStart { id = "turn-1"; model = "gpt-fixture"; usage = None }
+            ; ContentBlockDelta { index = 0; delta = TextDelta "MASC_" }
+            ; ContentBlockStart
+                { index = 1
+                ; content_type = "tool_use"
+                ; tool_id = Some "call-1"
+                ; tool_name = Some "masc_probe"
+                }
+            ; ContentBlockDelta
+                { index = 1; delta = InputJsonSnapshot arguments }
+            ; ContentBlockStop { index = 1 }
+            ; MessageStop
+            ; MessageStart
+                { id = "turn-1-terminal"; model = "gpt-fixture"; usage = None }
+            ; MessageStop
+            ] ->
+            check string
+              "Keeper stream arguments"
+              {|{"marker":"from-codex"}|}
+              arguments
+          | _ -> fail "Keeper did not preserve the Codex live event sequence"))
 ;;
 
 let test_keeper_preserves_typed_history_on_codex_wire () =
@@ -2353,6 +2444,7 @@ let test_live_keeper_dynamic_tool_subscription () =
   then Alcotest.skip ()
   else
     let tool_calls = ref 0 in
+    let stream_events = ref [] in
     let tool =
       Agent_core.Tool.create
         ~name:"masc_probe"
@@ -2370,6 +2462,7 @@ let test_live_keeper_dynamic_tool_subscription () =
          match
            run_keeper_turn
              ~tools:[ tool ]
+             ~on_event:(fun event -> stream_events := event :: !stream_events)
              ~base_path
              ~raw_trace_path
              ~goal:
@@ -2381,6 +2474,50 @@ let test_live_keeper_dynamic_tool_subscription () =
          | Error error -> fail (Agent_core.Error.to_string error)
          | Ok result ->
            check int "live typed tool calls" 1 !tool_calls;
+           let stream_events = List.rev !stream_events in
+           check bool
+             "live Keeper emitted text delta"
+             true
+             (List.exists
+                (function
+                  | Agent_core.Types.ContentBlockDelta
+                      { delta = Agent_core.Types.TextDelta text; _ } ->
+                    String.trim text <> ""
+                  | _ -> false)
+                stream_events);
+           let tool_index =
+             List.find_map
+               (function
+                 | Agent_core.Types.ContentBlockStart
+                     { index; tool_id = Some _; tool_name = Some "masc_probe"; _ } ->
+                   Some index
+                 | _ -> None)
+               stream_events
+           in
+           let tool_index =
+             match tool_index with
+             | Some index -> index
+             | None -> fail "live Keeper omitted masc_probe tool start"
+           in
+           check bool
+             "live Keeper emitted tool args snapshot"
+             true
+             (List.exists
+                (function
+                  | Agent_core.Types.ContentBlockDelta
+                      { index; delta = Agent_core.Types.InputJsonSnapshot _ } ->
+                    index = tool_index
+                  | _ -> false)
+                stream_events);
+           check bool
+             "live Keeper emitted matching tool stop"
+             true
+             (List.exists
+                (function
+                  | Agent_core.Types.ContentBlockStop { index } ->
+                    index = tool_index
+                  | _ -> false)
+                stream_events);
            check string
              "live tool Keeper response"
              "MASC_TOOL_OK"
@@ -2596,6 +2733,10 @@ let () =
             "Keeper shrinks history after typed context error"
             `Quick
             test_keeper_shrinks_history_after_typed_context_error
+        ; test_case
+            "Keeper projects Codex live stream"
+            `Quick
+            test_keeper_projects_codex_live_stream
         ; test_case
             "Keeper preserves typed history on Codex wire"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -1418,9 +1418,8 @@ let test_keeper_projects_codex_live_stream () =
             ; ContentBlockDelta
                 { index = 1; delta = InputJsonSnapshot arguments }
             ; ContentBlockStop { index = 1 }
-            ; MessageStop
-            ; MessageStart
-                { id = "turn-1-terminal"; model = "gpt-fixture"; usage = None }
+            ; ContentBlockDelta
+                { index = 0; delta = TextDelta "SUBSCRIPTION_OK" }
             ; MessageStop
             ] ->
             check string

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -99,7 +99,7 @@ let with_workspace f =
   Board_dispatch.init_jsonl ();
   let config = Workspace.default_config dir in
   ignore (Workspace.init config ~agent_name:(Some "test"));
-  (match Keeper_owner_registry.install_from_store ~sw ~operation_executor:None config with
+  (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
    | Ok _ -> ()
    | Error error -> fail (Keeper_owner_registry.install_error_to_string error));
   Executor_pool_ref.For_testing.with_pool

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1524,7 +1524,7 @@ let test_health_json_observes_owner_turn () =
           (match
              Keeper_owner_registry.install_from_store
                ~sw
-               ~operation_executor:None
+               ~operation_runner:None
                config
            with
            | Ok _ -> ()
@@ -2895,7 +2895,7 @@ let test_health_json_keeps_in_flight_running_keeper_executable () =
           (match
              Keeper_owner_registry.install_from_store
                ~sw
-               ~operation_executor:None
+               ~operation_runner:None
                config
            with
            | Ok _ -> ()


### PR DESCRIPTION
## Summary

- Keep durable chat operations Queued until the Keeper registry entry is healthy, then wake the single Owner actor without polling.
- Project official Codex text deltas and exact dynamic-tool start/input/stop events into the existing typed Keeper event stream.

## Product impact

- User-visible change: queued Dashboard/connector chat no longer fails during the startup gap before Keeper registration; Codex Dashboard/Discord consumers receive incremental text and tool activity instead of only a terminal reply.

## Evidence

- Reproduced before the fix: restart drained durable Queued rows before registry installation and failed them with `keeper_turn_resources_unavailable`; a pre-restart Running row settled once as `Interrupted_by_restart`.
- `scripts/dune-local.sh build test/test_keeper_owner.exe test/test_runtime_codex_app_server.exe` — PASS.
- `./_build/default/test/test_keeper_owner.exe` — PASS, 33/33 in 0.607s, including readiness hold/wake, FIFO, mailbox backpressure, and distinct Owners not cross-blocking.
- `./_build/default/test/test_runtime_codex_app_server.exe` — PASS, 41/41 in 26.237s.
- `MASC_CODEX_APP_SERVER_LIVE=1 ... test 'live subscription' 4` — PASS in 16.187s against the actual Codex app-server and `masc_probe`; observed non-empty text delta plus matching tool start, JSON input, and stop.
- `bash scripts/check-variants.sh` — PASS.
- Read-only `/health?full=1` at 2026-08-11 10:49 KST: 8 Owners, 3 simultaneous autonomous turns, chat queued=0/running=0/terminal=15/interrupted=1/store-unavailable=0. Independent Event Queue backlog remains outside this PR.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/3
provenance: direct
stages:
  - stage: startup_owner_regression
    evidence: focused Keeper Owner executable
  - stage: typed_projection_regression
    evidence: focused Codex app-server executable
  - stage: actual_provider_tool_stream
    evidence: live Codex app-server plus masc_probe test
```

## GOAL LOOP ACT checklist

- [x] Observe — startup failure and terminal-only live Codex behavior were reproduced.
- [x] Orient — traced to Owner claiming before registry installation and official Codex dropping its live callback.
- [x] Decide — preserve the single-owner linearization boundary; add readiness admission and exact provider event projection only.
- [x] Act — changed the Owner runner contract, post-registration wake, and Codex event adapter without timers, drops, recovery state, or compatibility paths.
- [x] Verify — focused deterministic and actual-provider tests pass.
- [x] Loop — no remaining defect in this bounded Codex/startup scope; Claude/Antigravity provider event parity is not claimed by this PR.

## Review evidence

- Draft: exact-head review and CI pending.

## Linked issue

- Relates #

## Variant addition checklist

- [x] **OCaml** — the new internal `stream_event` variant is exhaustively mapped and fixture-tested.
- [x] **TypeScript** — N/A; no public TypeScript union changed.
- [x] **TLA+ spec** — N/A; no state-machine domain literal changed.
- [x] **Event / JSON schema** — N/A; existing typed Keeper events are reused.
- [x] **`make check-variants` passes** — `bash scripts/check-variants.sh` PASS.
