### PR TITLE
fix(keeper): settle terminal reaction before next turn

### DIFF
--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -97,7 +97,8 @@ let project_source_ack_result ~base_path ~keeper_name result =
       Keeper_reaction_ledger.project_event_queue_transition_outbox_result
         ~base_path
         ~keeper_name
-        ~expected_transition_id:receipt.transition_id
+        ~expected_transition_id:
+          receipt.Keeper_event_queue_state.transition_id
     with
     | Ok () -> Ok (success receipt)
     | Error detail ->

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -87,6 +87,32 @@ type source_ack_result =
       ; detail : string
       }
 
+(* A source has not settled while its exact reaction evidence is still waiting
+   in the transition outbox: the next terminal ACK is deliberately rejected in
+   that state. Complete the existing handoff on the owner-facing path instead
+   of making the next Keeper turn wait for the maintenance sweep. *)
+let project_source_ack_result ~base_path ~keeper_name result =
+  let project receipt success =
+    match
+      Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+        ~base_path
+        ~keeper_name
+        ~expected_transition_id:receipt.transition_id
+    with
+    | Ok () -> Ok (success receipt)
+    | Error detail ->
+      Ok
+        (Ack_committed_followup_failed
+           { receipt; stage = `Projection; detail })
+  in
+  match result with
+  | Error _ as error -> error
+  | Ok (Transition_applied receipt) -> project receipt (fun receipt -> Acked receipt)
+  | Ok (Transition_already_applied receipt) ->
+    project receipt (fun receipt -> Already_acked receipt)
+  | Ok (Transition_committed_followup_failed { receipt; stage; detail }) ->
+    Ok (Ack_committed_followup_failed { receipt; stage; detail })
+;;
 
 let enqueue_if_missing queue stimulus =
   if Keeper_event_queue.contains queue stimulus
@@ -730,11 +756,7 @@ let ack_pending_source_terminal_result
     ~source_terminal
     ~after_commit:(publish_pending ~base_path name)
     ()
-  |> Result.map (function
-    | Transition_applied receipt -> Acked receipt
-    | Transition_already_applied receipt -> Already_acked receipt
-    | Transition_committed_followup_failed { receipt; stage; detail } ->
-      Ack_committed_followup_failed { receipt; stage; detail })
+  |> project_source_ack_result ~base_path ~keeper_name:name
 ;;
 
 let terminalize_pending_turn_attempt_result
@@ -754,11 +776,7 @@ let terminalize_pending_turn_attempt_result
     ~detail
     ~after_commit:(publish_pending ~base_path name)
     ()
-  |> Result.map (function
-    | Transition_applied receipt -> Acked receipt
-    | Transition_already_applied receipt -> Already_acked receipt
-    | Transition_committed_followup_failed { receipt; stage; detail } ->
-      Ack_committed_followup_failed { receipt; stage; detail })
+  |> project_source_ack_result ~base_path ~keeper_name:name
 ;;
 
 let terminalize_pending_turn_completed_result
@@ -776,9 +794,5 @@ let terminalize_pending_turn_completed_result
     ~selection
     ~after_commit:(publish_pending ~base_path name)
     ()
-  |> Result.map (function
-    | Transition_applied receipt -> Acked receipt
-    | Transition_already_applied receipt -> Already_acked receipt
-    | Transition_committed_followup_failed { receipt; stage; detail } ->
-      Ack_committed_followup_failed { receipt; stage; detail })
+  |> project_source_ack_result ~base_path ~keeper_name:name
 ;;

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -91,26 +91,36 @@ type source_ack_result =
    in the transition outbox: the next terminal ACK is deliberately rejected in
    that state. Complete the existing handoff on the owner-facing path instead
    of making the next Keeper turn wait for the maintenance sweep. *)
+let project_source_ack_receipt ~base_path ~keeper_name receipt success =
+  match
+    Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+      ~base_path
+      ~keeper_name
+      ~expected_transition_id:
+        receipt.Keeper_event_queue_state.transition_id
+  with
+  | Ok () -> Ok (success receipt)
+  | Error detail ->
+    Ok
+      (Ack_committed_followup_failed
+         { receipt; stage = `Projection; detail })
+;;
+
 let project_source_ack_result ~base_path ~keeper_name result =
-  let project receipt success =
-    match
-      Keeper_reaction_ledger.project_event_queue_transition_outbox_result
-        ~base_path
-        ~keeper_name
-        ~expected_transition_id:
-          receipt.Keeper_event_queue_state.transition_id
-    with
-    | Ok () -> Ok (success receipt)
-    | Error detail ->
-      Ok
-        (Ack_committed_followup_failed
-           { receipt; stage = `Projection; detail })
-  in
   match result with
   | Error _ as error -> error
-  | Ok (Transition_applied receipt) -> project receipt (fun receipt -> Acked receipt)
+  | Ok (Transition_applied receipt) ->
+    project_source_ack_receipt
+      ~base_path
+      ~keeper_name
+      receipt
+      (fun receipt -> Acked receipt)
   | Ok (Transition_already_applied receipt) ->
-    project receipt (fun receipt -> Already_acked receipt)
+    project_source_ack_receipt
+      ~base_path
+      ~keeper_name
+      receipt
+      (fun receipt -> Already_acked receipt)
   | Ok (Transition_committed_followup_failed { receipt; stage; detail }) ->
     Ok (Ack_committed_followup_failed { receipt; stage; detail })
 ;;

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -128,8 +128,9 @@ val ack_pending_source_terminal_result :
   acked_at:float ->
   source_terminal:accepted_source_terminal ->
   (source_ack_result, string) result
-(** Commit one exact terminal source ACK and publish the post-commit pending
-    projection when the owner is registered. *)
+(** Commit one exact terminal source ACK, publish the post-commit pending
+    projection when the owner is registered, and project its durable reaction
+    evidence before another source can settle. *)
 
 val terminalize_pending_turn_attempt_result :
   base_path:string ->
@@ -139,8 +140,9 @@ val terminalize_pending_turn_attempt_result :
   selection:Keeper_event_queue_state.pending_selection ->
   detail:string ->
   (source_ack_result, string) result
-(** Commit a source-bearing terminal receipt for one failed admitted turn and
-    publish the post-commit pending projection. *)
+(** Commit a source-bearing terminal receipt for one failed admitted turn,
+    publish the post-commit pending projection, and project its durable reaction
+    evidence before another source can settle. *)
 
 val terminalize_pending_turn_completed_result :
   base_path:string ->
@@ -149,8 +151,9 @@ val terminalize_pending_turn_completed_result :
   applied_at:float ->
   selection:Keeper_event_queue_state.pending_selection ->
   (source_ack_result, string) result
-(** Commit a source-bearing completion receipt for one successful admitted turn
-    and publish the post-commit pending projection. *)
+(** Commit a source-bearing completion receipt for one successful admitted
+    turn, publish the post-commit pending projection, and project its durable
+    reaction evidence before another source can settle. *)
 
 (** Enqueue a stimulus on the keeper's event queue. An owner not registered yet
     may receive durable work so a later lane can replay it. A finalized

--- a/scripts/keeper_event_queue_projection_boundary_check.ml
+++ b/scripts/keeper_event_queue_projection_boundary_check.ml
@@ -661,6 +661,9 @@ let run () =
   let ledger_ml = "lib/keeper/keeper_reaction_ledger.ml" in
   let ledger_mli = "lib/keeper/keeper_reaction_ledger.mli" in
   let recovery_ml = "lib/keeper/keeper_event_queue_recovery.ml" in
+  let registry_event_queue_ml =
+    "lib/keeper/keeper_registry_event_queue.ml"
+  in
   let schedule_consumers_ml = "lib/server/server_schedule_consumers.ml" in
   let definition_expectations =
     [ "append_event_queue_transition_outbox_result", []
@@ -709,6 +712,7 @@ let run () =
       , [ persistence_ml, "project_transition_outbox_result" ] )
     ; ( "project_event_queue_transition_outbox_result"
       , [ recovery_ml, "project_open_owner"
+        ; registry_event_queue_ml, "project_source_ack_receipt"
         ; schedule_consumers_ml, "accept_terminal"
         ] )
     ; "project_transition_outbox_after_append_result", []

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -2,6 +2,7 @@ module Queue = Keeper_event_queue
 module State = Keeper_event_queue_state
 module Persistence = Keeper_event_queue_persistence
 module Keeper_reaction_ledger = Masc.Keeper_reaction_ledger
+module Registry_event_queue = Masc.Keeper_registry_event_queue
 
 let require_ok label = function
   | Ok value -> value
@@ -816,6 +817,60 @@ let test_durable_completed_turn_projects_reaction_ack () =
         (Keeper_reaction_ledger.event_queue_reaction_evidence_error_to_string error))
 ;;
 
+let test_owner_terminalizes_consecutive_turns_without_projection_gap () =
+  with_temp_dir "keeper-owner-consecutive-terminal" (fun base_path ->
+    let keeper_name = "consecutive-turn-keeper" in
+    let first = stimulus "first" 1.0 in
+    let second = stimulus "second" 2.0 in
+    List.iter
+      (Keeper_reaction_ledger.record_event_queue_stimulus
+         ~base_path
+         ~keeper_name)
+      [ first; second ];
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue (Queue.enqueue pending first) second)
+    |> require_ok "seed consecutive turn sources";
+    let terminalize applied_at =
+      let selection =
+        Persistence.select_when_result
+          ~base_path
+          ~keeper_name
+          ~ready:(fun _ -> true)
+        |> require_ok "select consecutive turn source"
+        |> require_some "consecutive turn selection"
+      in
+      match
+        Registry_event_queue.terminalize_pending_turn_completed_result
+          ~base_path
+          keeper_name
+          ~current_owner_nonce:7
+          ~applied_at
+          ~selection
+      with
+      | Ok (Registry_event_queue.Acked _)
+      | Ok (Registry_event_queue.Already_acked _) -> ()
+      | Ok
+          (Registry_event_queue.Ack_committed_followup_failed
+             { detail; _ }) ->
+        Alcotest.fail detail
+      | Error detail -> Alcotest.fail detail
+    in
+    terminalize 3.0;
+    terminalize 4.0;
+    let settled =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "reload consecutive turn state"
+    in
+    Alcotest.(check int)
+      "both successful turns leave no pending source"
+      0
+      (Queue.length (State.pending settled));
+    Alcotest.(check int)
+      "owner projects each terminal receipt before the next turn"
+      0
+      (List.length (State.transition_outbox settled)))
+;;
+
 let () =
   Alcotest.run
     "keeper pending queue current schema"
@@ -866,6 +921,10 @@ let () =
             "durable completed turn projects reaction ACK"
             `Quick
             test_durable_completed_turn_projects_reaction_ack
+        ; Alcotest.test_case
+            "owner terminalizes consecutive turns without projection gap"
+            `Quick
+            test_owner_terminalizes_consecutive_turns_without_projection_gap
         ; Alcotest.test_case
             "durable in-flight selection rejects reinserted source"
             `Quick

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -160,6 +160,19 @@ let check_applied = function
          { cause = failure; reservation_release = None })
 ;;
 
+let transition_receipt_of_applied = function
+  | Transaction.Applied
+      (Keeper_registry_event_queue.Acked receipt
+      | Keeper_registry_event_queue.Already_acked receipt) -> receipt
+  | Transaction.Applied
+      (Keeper_registry_event_queue.Ack_committed_followup_failed { detail; _ }) ->
+    Alcotest.fail detail
+  | Transaction.Committed_followup_failed failure ->
+    Alcotest.fail
+      (Transaction.error_to_string
+         { cause = failure; reservation_release = None })
+;;
+
 let replace_field name value fields =
   List.map (fun (field, current) -> if String.equal field name then field, value else field, current) fields
 ;;
@@ -501,23 +514,22 @@ let test_terminal_ack_replays_after_projection_and_snapshot_reload () =
       |> require_ok "commit source-terminal ACK"
     in
     check_applied first.projection;
+    let transition_receipt =
+      transition_receipt_of_applied first.projection
+    in
     let staged =
       Persistence.load_state_result
         ~base_path:config.Workspace.base_path
         ~keeper_name
-      |> require_ok "load unprojected source-terminal ACK"
+      |> require_ok "load owner-projected source-terminal ACK"
     in
-    let outbox_entry =
-      match State.transition_outbox staged with
-      | [ entry ] -> entry
-      | [] | _ :: _ :: _ ->
-        Alcotest.fail "source-terminal ACK must retain one transition outbox entry"
+    Alcotest.(check int)
+      "owner-facing source-terminal ACK retires its transition outbox"
+      0
+      (List.length (State.transition_outbox staged));
+    let outbox_entry : State.outbox_entry =
+      { receipt = transition_receipt; stimuli = [ request.source ] }
     in
-    Persistence.project_transition_outbox_result
-      ~append_before_retire:(fun _entry -> Ok ())
-      ~base_path:config.Workspace.base_path
-      ~keeper_name
-    |> require_ok "project source-terminal ACK transition";
     let projected =
       Persistence.load_state_result
         ~base_path:config.Workspace.base_path
@@ -631,22 +643,22 @@ let test_projected_wal_recovery_allows_next_source_ack () =
       |> require_ok "commit first source-terminal ACK"
     in
     check_applied first.projection;
+    let first_transition_receipt =
+      transition_receipt_of_applied first.projection
+    in
     let staged =
       Persistence.load_state_result
         ~base_path:config.Workspace.base_path
         ~keeper_name
-      |> require_ok "load first source-terminal ACK outbox"
+      |> require_ok "load first owner-projected source-terminal ACK"
     in
-    let first_outbox =
-      match State.transition_outbox staged with
-      | [ entry ] -> entry
-      | [] | _ :: _ :: _ -> Alcotest.fail "first ACK must retain one transition outbox entry"
+    Alcotest.(check int)
+      "first owner-facing ACK retires its transition outbox"
+      0
+      (List.length (State.transition_outbox staged));
+    let first_outbox : State.outbox_entry =
+      { receipt = first_transition_receipt; stimuli = [ first_request.source ] }
     in
-    Persistence.project_transition_outbox_result
-      ~append_before_retire:(fun _entry -> Ok ())
-      ~base_path:config.Workspace.base_path
-      ~keeper_name
-    |> require_ok "project first source-terminal ACK";
     let transition_wal_path =
       Filename.concat
         (Filename.concat
@@ -691,11 +703,6 @@ let test_projected_wal_recovery_allows_next_source_ack () =
       |> require_ok "commit second source-terminal ACK"
     in
     check_applied second.projection;
-    Persistence.project_transition_outbox_result
-      ~append_before_retire:(fun _entry -> Ok ())
-      ~base_path:config.Workspace.base_path
-      ~keeper_name
-    |> require_ok "project second source-terminal ACK after recovery";
     let final =
       Persistence.load_state_result
         ~base_path:config.Workspace.base_path

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -679,8 +679,8 @@ let test_reused_schedule_id_does_not_match_pruned_terminal_receipt () =
        ~base_path
        ~keeper_name
    with
-   | Ok Keeper_event_queue_recovery.Transition_converged -> ()
-   | Ok _ -> fail "first terminal receipt projection did not converge"
+   | Ok Keeper_event_queue_recovery.No_pending_transition -> ()
+   | Ok _ -> fail "owner terminalization left a transition for recovery"
    | Error error ->
      fail (Keeper_event_queue_recovery.projection_error_to_string error));
   (match Schedule_store.prune_completed config with


### PR DESCRIPTION
## Defect

A successful Keeper Event Queue turn commits its exact source terminal receipt, but the owner-facing path returned while that receipt still occupied transition_outbox. The next successful turn could therefore finish provider work and then fail with:

    event queue cannot ACK pending source while an outbox transition exists

Live runtime build 2569193032 recorded this 38 times from 00:00 through 01:47 UTC across rondo, code-reviewer, analyst, sangsu, lane-smith, and taskmaster. At 01:47:32 UTC rondo completed its model turn, failed the source ACK, and only the maintenance sweep at 01:47:34 UTC projected the prior outbox. The exact pending source then remained for another model execution.

## Change

- complete the existing source-terminal handoff on the owner-facing path by projecting the exact committed receipt before returning Acked or Already_acked
- preserve projection failure as the existing typed Ack_committed_followup_failed with stage Projection
- apply the same contract to completed turns, terminal failed turns, and exact external source terminal ACKs
- add a regression proving two consecutive successful source turns settle without a maintenance sweep or transition collision

No new queue state, retry policy, heuristic, compatibility decoder, or migration is added.

## Verification

- git diff --check
- local build and tests intentionally not run per operator instruction; GitHub CI is the build and test authority

## Live evidence

- process: /private/tmp/masc-live-main-20260810-v6 at build 2569193032
- runtime root: /Users/dancer/me/.masc
- health observation: 96 runnable pending Events, oldest about 100 minutes, transition outbox count 1
- source baseline: 78a9d48b5c27058a5246223b1bfcf8e5793fd507