### PR TITLE
test(exec_policy): expect the sorted order the hint actually produces

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=676
+UNWIRED_BASELINE=675
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -98,6 +98,7 @@ normal_targets=(
   @test/runtest-test_operator_control_actions
   @test/runtest-test_masc_log
   @test/runtest-test_schema_surface_index
+  @test/runtest-test_exec_policy_cwd_hint
   @test/runtest-test_host_fd_pressure_poller
   @test/runtest-test_keeper_turn_driver_failover
   @test/runtest-test_keeper_turn_driver_accept

--- a/test/test_exec_policy_cwd_hint.ml
+++ b/test/test_exec_policy_cwd_hint.ml
@@ -41,7 +41,11 @@ let test_lists_existing_sibling_dirs () =
     let hint = Exec_policy.existing_sibling_dirs_hint ~workdir:root "repos/masc-mcp" in
     Alcotest.(check (option string))
       "stale repos/masc-mcp surfaces the real repos/ entries (sorted, no rename table)"
-      (Some "(existing directories under repos/: masc, agent_core)")
+      (* Sorted by String.compare, so agent_core precedes masc. The literal is
+         written out rather than derived from the mkdir_p calls above: deriving
+         it would call the same sort the subject uses and pass whatever order
+         the subject produced. *)
+      (Some "(existing directories under repos/: agent_core, masc)")
       hint)
 ;;
 


### PR DESCRIPTION
## 무엇을

`existing_sibling_dirs_hint` 의 기대값을 **실제 정렬 순서**로 고치고, 그 스위트를 CI 에 배선합니다. 프로덕션 코드는 변경하지 않습니다.

## 왜 — 검사 이름이 "sorted" 인데 기대값이 정렬돼 있지 않습니다

```
FAIL stale repos/masc-mcp surfaces the real repos/ entries (sorted, no rename table)
   Expected: `Some "(existing directories under repos/: masc, agent_core)"'
   Received: `Some "(existing directories under repos/: agent_core, masc)"'
```

프로덕션은 정렬합니다.

```ocaml
(* lib/exec_policy/exec_policy.ml *)
|> List.filter (fun e -> is_dir (Filename.concat ancestor e))
|> List.sort String.compare
```

`a < m` 이므로 `agent_core, masc` 가 정답입니다.

## 리터럴은 처음엔 맞았습니다

```
a04ab4fa6b (#21139)  "masc, oas"           ← m < o, 정렬됨
ea17e01c89 (#27945)  "masc, agent_core"    ← a < m, 정렬 깨짐
```

`#27945` 가 픽스처 디렉터리와 리터럴을 `oas` → `agent_core` 로 개명하면서 **정렬 순서가 뒤집혔는데 기대값이 따라오지 않았습니다.** 개명 시 순서 의존 리터럴을 같이 봐야 했던 사례입니다.

이번 주에 `#27945` 에서 나온 세 번째 결함입니다 — 나머지 둘(schema-surface 구분자·버전)은 `#28139` 에서 고쳤습니다. 셋 다 미배선 스위트라 머지 시점에 아무도 보지 못했습니다.

## 뮤테이션 — 첫 시도는 판별하지 못했습니다

`List.sort String.compare` 를 `List.rev` 로 바꿨더니 **exit 0** 이었습니다. `Sys.readdir` 이 돌려주는 순서에서 `rev` 가 우연히 정렬과 같아진 것입니다.

역순 비교자로 바꾸니 판별됐습니다.

```
Received: `Some "(existing directories under repos/: masc, agent_core)"'
```

정확히 **옛 기대값**이 나옵니다. 이제 이 단언은 정렬을 *따라가는* 것이 아니라 *고정*합니다.

`--force` 가 필요합니다 — 테스트가 만드는 픽스처 디렉터리를 dune 이 입력으로 추적하지 않습니다(`#28140` 과 같은 부류).

## 배선

```
[ci-test-targets] OK - 675 suites unwired, at baseline
```

`UNWIRED_BASELINE` 676 → 675.

## 검증

```
dune build @test/runtest-test_exec_policy_cwd_hint   6 tests, Test Successful
뮤테이션(역순 비교자)                                  FAIL, 옛 리터럴 재현
audit-ci-test-targets.sh                             OK, 675 at baseline
ocamlformat --check                                  clean
```

RFC-WAIVED: 테스트 기대 리터럴 한 곳과 CI 목록·ratchet baseline 만 변경합니다. 프로덕션 코드와 durable 스키마를 건드리지 않습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
