### PR TITLE
fix(ide): 레거시 route-context 주석 스키마를 다시 읽는다

### DIFF
--- a/lib/ide/ide_annotation_types.ml
+++ b/lib/ide/ide_annotation_types.ml
@@ -142,6 +142,25 @@ let annotation_of_json (json : Yojson.Safe.t) : (annotation, string) result =
       ; "updated_at_ms"
       ]
     in
+    (* Closed list of fields the #15398 route-context schema wrote flat on
+       every record until #24332 removed them from the writer while this
+       reader started rejecting unknown fields — which made every record
+       written in between unreadable (the live store's by-url/_orphan files
+       are full of them). They are known-legacy, not unknown: each non-empty
+       value is preserved as an opaque {relation; reference} pair, so the
+       read stays lossless without a disk migration. Fields outside
+       [allowed_fields @ legacy_reference_fields] are still rejected. *)
+    let legacy_reference_fields =
+      [ "board_post_id"
+      ; "comment_id"
+      ; "git_ref"
+      ; "log_id"
+      ; "operation_id"
+      ; "pr_id"
+      ; "session_id"
+      ; "worker_run_id"
+      ]
+    in
     let find_string key default =
       match List.assoc_opt key fields with
       | Some (`String s) -> s
@@ -177,7 +196,14 @@ let annotation_of_json (json : Yojson.Safe.t) : (annotation, string) result =
       | Some k -> k
       | None -> Comment
     in
-    (match List.find_opt (fun (key, _) -> not (List.mem key allowed_fields)) fields with
+    (match
+       List.find_opt
+         (fun (key, _) ->
+           not
+             (List.mem key allowed_fields
+              || List.mem key legacy_reference_fields))
+         fields
+     with
      | Some (key, _) -> Error (Printf.sprintf "Unknown annotation field: %s" key)
      | None ->
        let references_json =
@@ -186,6 +212,14 @@ let annotation_of_json (json : Yojson.Safe.t) : (annotation, string) result =
        (match annotation_references_of_json references_json with
         | Error msg -> Error msg
         | Ok references ->
+          let legacy_references =
+            List.filter_map
+              (fun key ->
+                match find_opt_string key with
+                | Some value -> Some { relation = key; reference = value }
+                | None -> None)
+              legacy_reference_fields
+          in
           Ok
             { id = find_string "id" ""
             ; file_path = find_string "file_path" ""
@@ -196,7 +230,7 @@ let annotation_of_json (json : Yojson.Safe.t) : (annotation, string) result =
             ; content = find_string "content" ""
             ; goal_id = find_opt_string "goal_id"
             ; task_id = find_opt_string "task_id"
-            ; references
+            ; references = references @ legacy_references
             ; created_at_ms = find_int64 "created_at_ms" 0L
             ; updated_at_ms = find_int64 "updated_at_ms" 0L
             }))

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -996,10 +996,86 @@ let test_cas_absent_version_is_legacy () =
     | Error msg -> failf "legacy delete without version must succeed: %s" msg)
 ;;
 
+(* ---- Legacy route-context fields (#15398 schema, rejected since #24332) ----
+
+   Live-store shape: every record written between #15398 and #24332 carries
+   eight flat route-context fields. The reader's unknown-field rejection made
+   all of them unparseable — the by-url/masc partition's four real records
+   returned [] through the scoped API while sitting on disk. *)
+
+let legacy_disk_record ~extra =
+  Printf.sprintf
+    {|{"id":"30d1bcc0-60f9-458d-a7b1-2070ae187638","file_path":".masc/board.json","line_start":3,"line_end":3,"keeper_id":"taskmaster","kind":"Comment","content":"gate note","goal_id":null,"task_id":null,"board_post_id":null,"comment_id":null,"git_ref":null,"log_id":null,"operation_id":null,"pr_id":null,"session_id":null,"worker_run_id":null,"created_at_ms":531679440,"updated_at_ms":531679440%s}|}
+    extra
+
+let test_legacy_fields_parse_with_all_null () =
+  match Types.annotation_of_json (Yojson.Safe.from_string (legacy_disk_record ~extra:"")) with
+  | Error msg -> failf "all-null legacy fields must parse: %s" msg
+  | Ok a ->
+    check string "id survives" "30d1bcc0-60f9-458d-a7b1-2070ae187638" a.Types.id;
+    check int "null legacy fields add no references" 0 (List.length a.Types.references)
+;;
+
+let test_legacy_fields_promote_to_references () =
+  let json =
+    Yojson.Safe.from_string (legacy_disk_record ~extra:"")
+    |> function
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (function
+             | "pr_id", _ -> ("pr_id", `String "27446")
+             | "session_id", _ -> ("session_id", `String "sess-a1")
+             | other -> other)
+           fields)
+    | other -> other
+  in
+  match Types.annotation_of_json json with
+  | Error msg -> failf "valued legacy fields must parse: %s" msg
+  | Ok a ->
+    let refs =
+      List.map (fun r -> (r.Types.relation, r.Types.reference)) a.Types.references
+    in
+    check
+      (list (pair string string))
+      "non-null legacy fields promote losslessly, in closed-list order"
+      [ ("pr_id", "27446"); ("session_id", "sess-a1") ]
+      refs
+;;
+
+let test_truly_unknown_field_still_rejected () =
+  match
+    Types.annotation_of_json
+      (Yojson.Safe.from_string
+         (legacy_disk_record ~extra:{|,"totally_new_field":"x"|}))
+  with
+  | Error msg ->
+    check
+      bool
+      "error names the unknown field"
+      true
+      (Astring.String.is_infix ~affix:"totally_new_field" msg)
+  | Ok _ -> fail "fields outside allowed+legacy closed lists must stay rejected"
+;;
+
 let () =
   run
     "ide_annotations"
-    [ ( "compact"
+    [ ( "legacy_fields"
+      , [ test_case
+            "all-null legacy route-context record parses"
+            `Quick
+            test_legacy_fields_parse_with_all_null
+        ; test_case
+            "valued legacy fields promote to references"
+            `Quick
+            test_legacy_fields_promote_to_references
+        ; test_case
+            "truly unknown field still rejected"
+            `Quick
+            test_truly_unknown_field_still_rejected
+        ] )
+    ; ( "compact"
       , [ test_case
             "compact preserves annotations"
             `Quick


### PR DESCRIPTION
## 무엇

#15398~#24332 사이에 기록된 모든 주석(flat route-context 8필드: `board_post_id`, `comment_id`, `git_ref`, `log_id`, `operation_id`, `pr_id`, `session_id`, `worker_run_id`)이 읽기 불가였습니다. #24332가 writer에서 필드를 제거하면서 reader에 미지-필드-전체-거부를 도입했는데 마이그레이션이 없었습니다.

**라이브 실측으로 발견** (orca 감사 G6 후속): `by-url/github.com_jeong-sik_masc/annotations.jsonl`에 실레코드 4건이 있는데 `GET /api/v1/ide/annotations?canonical_url=…`이 빈 배열을 반환. 슬러그·파티션·필터 전부 무죄, 파서가 범인이었습니다 — 전부-null인 레거시 키조차 **키 존재만으로** 레코드 전체가 거부됩니다.

## 어떻게

8개 이름을 **닫힌 known-legacy 목록**으로 선언하고, 값이 있는 것만 `{relation; reference}` 쌍으로 references에 무손실 승격(중립 — 해석 없음), null/빈 값은 스킵. 닫힌 두 목록(allowed+legacy) 밖 필드는 **여전히 거부** — permissive default 없음, 디스크 마이그레이션 없음.

## 검증

- 신규 3건: 전부-null 실디스크형 레코드 파싱 / 값 승격(닫힌 목록 순서) / 진짜 미지 필드 거부 유지
- **수정 전 파서(origin/main)로 되돌리면 3건 전부 FAIL** — 결함 재현 증명 후 복원
- 전체 `test_ide_annotations` 32건 green (`test/dune:181` 배선 기존재)
- 미검증: 라이브 API 재실측 (머지·배포 후 같은 쿼리가 4건을 반환하는지 — 완료 기준)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>