### PR TITLE
fix(h2): apply the H1 read gate to /graphql and two dashboard reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,6 +555,7 @@ jobs:
           bash scripts/check-spec-truth.sh
           python3 scripts/ci/check-spec-file-refs.py
           bash scripts/ci/check-silent-failure-patterns.sh
+          python3 scripts/ci/check_h2_route_auth_parity.py
           bash scripts/ci/check-enum-string-safety.sh
           python3 scripts/ci/check-env-snapshot-default-drift.py
           bash scripts/ci/check-publication-recovery-test-boundary.sh

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -219,25 +219,6 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
              | Error () -> ())
         | Error err -> h2_respond_auth_error h2_reqd err)
     in
-    (* H2 counterpart of [Server_auth.with_read_auth]: authorize on every
-       request, with no [http_auth_strict_enabled] / [is_public_read_path]
-       precondition. [with_h2_public_read] applies those preconditions and is
-       therefore NOT interchangeable — a route the H1 side guards with
-       [with_read_auth] must use this one, or the same path enforces different
-       authorization depending on which transport the client negotiated. *)
-    let with_h2_read_auth h2_reqd f =
-      with_server_state h2_reqd (fun state ->
-        match
-          authorize_read_request
-            ~base_path:(Mcp_server.workspace_config state).base_path
-            httpun_request
-        with
-        | Ok () ->
-            (match h2_check_agent_rate_limit h2_reqd with
-             | Ok () -> f state
-             | Error () -> ())
-        | Error err -> h2_respond_auth_error h2_reqd err)
-    in
     let h2_respond_board_reaction_result h2_reqd = function
       | Ok json -> h2_respond_json_value h2_reqd json ~extra_headers:cors
       | Error error ->
@@ -779,23 +760,18 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
       (* ─────────────────────────────────────────────────────────────────────
          GraphQL
          ───────────────────────────────────────────────────────────────────── *)
-      (* Both arms carry the same read gate the H1 route applies
-         (server_routes_http_routes_frontend.ml wraps GET and POST /graphql in
-         [with_read_auth]). /graphql is not in [is_public_read_path], so an
-         unauthenticated caller must be rejected on either transport. *)
       | `GET, "/graphql" ->
-          with_h2_read_auth h2_reqd (fun _state ->
-            let nonce =
-              let rng = Random.State.make_self_init () in
-              let bytes = Bytes.init 16 (fun _ -> Char.chr (Random.State.int rng 256)) in
-              Base64.encode_string (Bytes.to_string bytes)
-            in
-            let csp_header = ("content-security-policy", graphql_csp_header nonce) in
-            h2_respond_html h2_reqd (graphql_playground_html ~nonce) ~extra_headers:(csp_header :: cors))
+          let nonce =
+            let rng = Random.State.make_self_init () in
+            let bytes = Bytes.init 16 (fun _ -> Char.chr (Random.State.int rng 256)) in
+            Base64.encode_string (Bytes.to_string bytes)
+          in
+          let csp_header = ("content-security-policy", graphql_csp_header nonce) in
+          h2_respond_html h2_reqd (graphql_playground_html ~nonce) ~extra_headers:(csp_header :: cors)
 
       | `POST, "/graphql" ->
           h2_read_body h2_reqd (fun body_str ->
-            with_h2_read_auth h2_reqd (fun state ->
+            with_server_state h2_reqd (fun state ->
               let response = Graphql_api.handle_request ~config:(Mcp_server.workspace_config state) body_str in
               let status = match response.status with `OK -> `OK | `Bad_request -> `Bad_request in
               h2_respond_json h2_reqd response.body ~status ~extra_headers:cors))
@@ -827,12 +803,8 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
-      (* H1 serves this through [with_public_read]
-         (server_routes_http_routes_dashboard.ml). [with_server_state] only
-         fetches state; under MASC_HTTP_AUTH_STRICT it left the workspace
-         timeline readable over h2c while H1 demanded a token. *)
       | `GET, "/api/v1/dashboard/workspace" ->
-          with_h2_public_read h2_reqd (fun state ->
+          with_server_state h2_reqd (fun state ->
             let limit =
               Server_utils.int_query_param httpun_request "limit" ~default:50
               |> Server_utils.clamp ~min_v:1 ~max_v:200
@@ -1017,9 +989,8 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
 
-      (* H1 serves this through [with_public_read] (server_ide_http.ml:609). *)
       | `GET, "/api/v1/status" ->
-          with_h2_public_read h2_reqd (fun state ->
+          with_server_state h2_reqd (fun state ->
             let config = (Mcp_server.workspace_config state) in
             let workspace_state = Workspace.read_state config in
             let tempo = Tempo.get_tempo config in

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -219,6 +219,25 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
              | Error () -> ())
         | Error err -> h2_respond_auth_error h2_reqd err)
     in
+    (* H2 counterpart of [Server_auth.with_read_auth]: authorize on every
+       request, with no [http_auth_strict_enabled] / [is_public_read_path]
+       precondition. [with_h2_public_read] applies those preconditions and is
+       therefore NOT interchangeable — a route the H1 side guards with
+       [with_read_auth] must use this one, or the same path enforces different
+       authorization depending on which transport the client negotiated. *)
+    let with_h2_read_auth h2_reqd f =
+      with_server_state h2_reqd (fun state ->
+        match
+          authorize_read_request
+            ~base_path:(Mcp_server.workspace_config state).base_path
+            httpun_request
+        with
+        | Ok () ->
+            (match h2_check_agent_rate_limit h2_reqd with
+             | Ok () -> f state
+             | Error () -> ())
+        | Error err -> h2_respond_auth_error h2_reqd err)
+    in
     let h2_respond_board_reaction_result h2_reqd = function
       | Ok json -> h2_respond_json_value h2_reqd json ~extra_headers:cors
       | Error error ->
@@ -760,18 +779,23 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
       (* ─────────────────────────────────────────────────────────────────────
          GraphQL
          ───────────────────────────────────────────────────────────────────── *)
+      (* Both arms carry the same read gate the H1 route applies
+         (server_routes_http_routes_frontend.ml wraps GET and POST /graphql in
+         [with_read_auth]). /graphql is not in [is_public_read_path], so an
+         unauthenticated caller must be rejected on either transport. *)
       | `GET, "/graphql" ->
-          let nonce =
-            let rng = Random.State.make_self_init () in
-            let bytes = Bytes.init 16 (fun _ -> Char.chr (Random.State.int rng 256)) in
-            Base64.encode_string (Bytes.to_string bytes)
-          in
-          let csp_header = ("content-security-policy", graphql_csp_header nonce) in
-          h2_respond_html h2_reqd (graphql_playground_html ~nonce) ~extra_headers:(csp_header :: cors)
+          with_h2_read_auth h2_reqd (fun _state ->
+            let nonce =
+              let rng = Random.State.make_self_init () in
+              let bytes = Bytes.init 16 (fun _ -> Char.chr (Random.State.int rng 256)) in
+              Base64.encode_string (Bytes.to_string bytes)
+            in
+            let csp_header = ("content-security-policy", graphql_csp_header nonce) in
+            h2_respond_html h2_reqd (graphql_playground_html ~nonce) ~extra_headers:(csp_header :: cors))
 
       | `POST, "/graphql" ->
           h2_read_body h2_reqd (fun body_str ->
-            with_server_state h2_reqd (fun state ->
+            with_h2_read_auth h2_reqd (fun state ->
               let response = Graphql_api.handle_request ~config:(Mcp_server.workspace_config state) body_str in
               let status = match response.status with `OK -> `OK | `Bad_request -> `Bad_request in
               h2_respond_json h2_reqd response.body ~status ~extra_headers:cors))
@@ -803,8 +827,12 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
+      (* H1 serves this through [with_public_read]
+         (server_routes_http_routes_dashboard.ml). [with_server_state] only
+         fetches state; under MASC_HTTP_AUTH_STRICT it left the workspace
+         timeline readable over h2c while H1 demanded a token. *)
       | `GET, "/api/v1/dashboard/workspace" ->
-          with_server_state h2_reqd (fun state ->
+          with_h2_public_read h2_reqd (fun state ->
             let limit =
               Server_utils.int_query_param httpun_request "limit" ~default:50
               |> Server_utils.clamp ~min_v:1 ~max_v:200
@@ -989,8 +1017,9 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
 
+      (* H1 serves this through [with_public_read] (server_ide_http.ml:609). *)
       | `GET, "/api/v1/status" ->
-          with_server_state h2_reqd (fun state ->
+          with_h2_public_read h2_reqd (fun state ->
             let config = (Mcp_server.workspace_config state) in
             let workspace_state = Workspace.read_state config in
             let tempo = Tempo.get_tempo config in

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -219,6 +219,25 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
              | Error () -> ())
         | Error err -> h2_respond_auth_error h2_reqd err)
     in
+    (* H2 counterpart of [Server_auth.with_read_auth]: authorize on every
+       request, with no [http_auth_strict_enabled] / [is_public_read_path]
+       precondition. [with_h2_public_read] applies those preconditions and is
+       therefore NOT interchangeable — a route the H1 side guards with
+       [with_read_auth] must use this one, or the same path enforces different
+       authorization depending on which transport the client negotiated. *)
+    let with_h2_read_auth h2_reqd f =
+      with_server_state h2_reqd (fun state ->
+        match
+          authorize_read_request
+            ~base_path:(Mcp_server.workspace_config state).base_path
+            httpun_request
+        with
+        | Ok () ->
+            (match h2_check_agent_rate_limit h2_reqd with
+             | Ok () -> f state
+             | Error () -> ())
+        | Error err -> h2_respond_auth_error h2_reqd err)
+    in
     let h2_respond_board_reaction_result h2_reqd = function
       | Ok json -> h2_respond_json_value h2_reqd json ~extra_headers:cors
       | Error error ->
@@ -760,18 +779,19 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
       (* ─────────────────────────────────────────────────────────────────────
          GraphQL
          ───────────────────────────────────────────────────────────────────── *)
+      (* Both arms carry the same read gate the H1 route applies
+         (server_routes_http_routes_frontend.ml wraps GET and POST /graphql in
+         [with_read_auth]). /graphql is not in [is_public_read_path], so an
+         unauthenticated caller must be rejected on either transport. *)
       | `GET, "/graphql" ->
-          let nonce =
-            let rng = Random.State.make_self_init () in
-            let bytes = Bytes.init 16 (fun _ -> Char.chr (Random.State.int rng 256)) in
-            Base64.encode_string (Bytes.to_string bytes)
-          in
-          let csp_header = ("content-security-policy", graphql_csp_header nonce) in
-          h2_respond_html h2_reqd (graphql_playground_html ~nonce) ~extra_headers:(csp_header :: cors)
+          with_h2_read_auth h2_reqd (fun _state ->
+            let nonce = fresh_graphql_csp_nonce () in
+            let csp_header = ("content-security-policy", graphql_csp_header nonce) in
+            h2_respond_html h2_reqd (graphql_playground_html ~nonce) ~extra_headers:(csp_header :: cors))
 
       | `POST, "/graphql" ->
           h2_read_body h2_reqd (fun body_str ->
-            with_server_state h2_reqd (fun state ->
+            with_h2_read_auth h2_reqd (fun state ->
               let response = Graphql_api.handle_request ~config:(Mcp_server.workspace_config state) body_str in
               let status = match response.status with `OK -> `OK | `Bad_request -> `Bad_request in
               h2_respond_json h2_reqd response.body ~status ~extra_headers:cors))
@@ -803,8 +823,12 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
+      (* H1 serves this through [with_public_read]
+         (server_routes_http_routes_dashboard.ml). [with_server_state] only
+         fetches state; under MASC_HTTP_AUTH_STRICT it left the workspace
+         timeline readable over h2c while H1 demanded a token. *)
       | `GET, "/api/v1/dashboard/workspace" ->
-          with_server_state h2_reqd (fun state ->
+          with_h2_public_read h2_reqd (fun state ->
             let limit =
               Server_utils.int_query_param httpun_request "limit" ~default:50
               |> Server_utils.clamp ~min_v:1 ~max_v:200
@@ -989,8 +1013,9 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
 
+      (* H1 serves this through [with_public_read] (server_ide_http.ml:609). *)
       | `GET, "/api/v1/status" ->
-          with_server_state h2_reqd (fun state ->
+          with_h2_public_read h2_reqd (fun state ->
             let config = (Mcp_server.workspace_config state) in
             let workspace_state = Workspace.read_state config in
             let tempo = Tempo.get_tempo config in

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -539,12 +539,26 @@ let get_server_state_result () =
 let server_state_error_json message =
   Yojson.Safe.to_string (`Assoc [ ("error", `String message) ])
 
+(* DET-OK: the non-determinism is the point. A CSP nonce must differ per
+   response, so a deterministic value would defeat the header. It is confined
+   to one output boundary — the response's CSP header and the matching script
+   tag — and nothing branches on it, parses it, or stores it.
+
+   The ratchet flags these two lines as new debt because they moved here; they
+   are unchanged from the copy that lived in handle_get_graphql, and the H2
+   gateway now calls this instead of keeping a second copy.
+
+   Scope limit, deliberately not claimed above: Random is a PRNG, not a
+   CSPRNG, so this nonce is unguessable only to the extent the seed is. That
+   property predates this function and is not what DET-OK asserts. *)
+let fresh_graphql_csp_nonce () =
+  (* DET-OK: per-response CSP nonce, rationale above. *)
+  let rng = Random.State.make_self_init () in
+  let bytes = Bytes.init 16 (fun _ -> Char.chr (Random.State.int rng 256)) in
+  Base64.encode_string (Bytes.to_string bytes)
+
 let handle_get_graphql _request reqd =
-  let nonce =
-    let rng = Random.State.make_self_init () in
-    let bytes = Bytes.init 16 (fun _ -> Char.chr (Random.State.int rng 256)) in
-    Base64.encode_string (Bytes.to_string bytes)
-  in
+  let nonce = fresh_graphql_csp_nonce () in
   let headers = [
     ("content-security-policy", graphql_csp_header nonce);
   ] in

--- a/lib/server/server_routes_http_pages.mli
+++ b/lib/server/server_routes_http_pages.mli
@@ -64,6 +64,11 @@ val graphql_playground_html : nonce:string -> string
     CSP nonce inlined into the boot script. *)
 
 val graphql_csp_header : string -> string
+
+val fresh_graphql_csp_nonce : unit -> string
+(** Per-response CSP nonce for the GraphQL playground. Both transports call
+    this so the playground is served with one nonce implementation rather than
+    a copy per route table. *)
 (** Builds the [Content-Security-Policy] header value
     pinned to the GraphQL Playground asset set, threading
     the per-request nonce. *)

--- a/scripts/ci/check_h2_route_auth_parity.py
+++ b/scripts/ci/check_h2_route_auth_parity.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""CI gate: an H2 route arm must not read server state without authorizing.
+
+Background
+    Server_bootstrap_http.serve_auto sniffs the connection preface on ONE port
+    and hands h2c connections to Server_h2_gateway while everything else goes
+    to the HTTP/1 router. The two route tables are written by hand, so the
+    wrapper a route gets is decided independently on each side.
+
+    That let POST /graphql diverge: the H1 route wrapped it in
+    [with_read_auth], the H2 arm used [with_server_state] -- which fetches the
+    server state and applies no authorization at all. An unauthenticated caller
+    got 401 over HTTP/1 and an executed query over h2c, so the client's
+    protocol choice decided whether authorization applied.
+
+Contract
+    Every ``| `METHOD, "/path" ->`` arm whose body calls [with_server_state]
+    must either
+      (a) authorize itself -- the body names an authorize_*_request call, as
+          POST /webrtc/* does, or
+      (b) run the MCP admission gate via [verify_mcp_auth].
+    Anything else must use [with_h2_public_read], [with_h2_read_auth], or
+    [with_h2_token_permission_auth], which mirror the H1 wrappers.
+
+Why source analysis, and why comments are stripped first
+    The runtime proof lives in
+    scripts/harness/contract/graphql_transport_auth_parity_contract.sh, which
+    probes a live server over both transports. That contract can only assert
+    the routes it names; this gate is the part that scales to every arm and
+    fires when a NEW arm is written.
+
+    Comments are removed before scanning because the first draft of this gate
+    counted the word [with_server_state] inside a comment that *documented* the
+    fix, and reported a route that was already correctly wrapped. OCaml
+    comments nest and can contain string literals, so the stripper below tracks
+    depth and quotes rather than pattern-matching (* ... *).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GATEWAY = ROOT / "lib" / "server" / "server_h2_gateway.ml"
+
+NON_AUTHORIZING_HELPER = "with_server_state"
+SELF_AUTHORIZING = re.compile(r"authorize_[a-z_]+_request|verify_mcp_auth")
+ROUTE_ARM = re.compile(r"^\s*\|\s*`(GET|POST|PUT|DELETE|PATCH),")
+MIRRORED_WRAPPERS = (
+    "with_h2_public_read",
+    "with_h2_read_auth",
+    "with_h2_token_permission_auth",
+)
+
+
+def strip_comments(source: str) -> str:
+    """Blank out OCaml comments, preserving every byte offset and newline.
+
+    Handles nesting ((* a (* b *) c *)) and skips string literals so that a
+    "(*" inside a string does not open a comment. Characters are replaced with
+    spaces rather than deleted so reported line numbers stay true to the file.
+    """
+    out = list(source)
+    i = 0
+    depth = 0
+    n = len(source)
+    while i < n:
+        if depth == 0 and source.startswith('"', i):
+            # Skip a string literal verbatim.
+            i += 1
+            while i < n:
+                if source[i] == "\\":
+                    i += 2
+                    continue
+                if source[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if source.startswith("(*", i):
+            depth += 1
+            out[i] = out[i + 1] = " "
+            i += 2
+            continue
+        if depth > 0 and source.startswith("*)", i):
+            depth -= 1
+            out[i] = out[i + 1] = " "
+            i += 2
+            continue
+        if depth > 0 and source[i] != "\n":
+            out[i] = " "
+        i += 1
+    return "".join(out)
+
+
+def main() -> int:
+    if not GATEWAY.is_file():
+        print(f"FAIL: {GATEWAY} not found (did the H2 gateway move?)", file=sys.stderr)
+        return 1
+
+    raw = GATEWAY.read_text(encoding="utf-8")
+    code = strip_comments(raw)
+    raw_lines = raw.splitlines()
+    code_lines = code.splitlines()
+
+    print("=== H2 route auth parity gate ===")
+
+    # Collect (line_index, arm_text) for every route arm, then treat the span
+    # up to the next arm as that arm's body.
+    arms = [i for i, line in enumerate(code_lines) if ROUTE_ARM.match(line)]
+    violations = []
+    for pos, start in enumerate(arms):
+        end = arms[pos + 1] if pos + 1 < len(arms) else len(code_lines)
+        body = "\n".join(code_lines[start:end])
+        if NON_AUTHORIZING_HELPER not in body:
+            continue
+        if SELF_AUTHORIZING.search(body):
+            continue
+        violations.append((start + 1, raw_lines[start].strip()))
+
+    for lineno, arm in violations:
+        rel = GATEWAY.relative_to(ROOT)
+        print(
+            "FAIL: H2 arm reads server state with no authorization wrapper",
+            file=sys.stderr,
+        )
+        print(f"  {rel}:{lineno}: {arm}", file=sys.stderr)
+        print(
+            "  Use " + " / ".join(MIRRORED_WRAPPERS)
+            + " to mirror the wrapper the HTTP/1 route for this path applies.",
+            file=sys.stderr,
+        )
+
+    if violations:
+        print(
+            f"=== H2 route auth parity gate: FAIL ({len(violations)}) ===",
+            file=sys.stderr,
+        )
+        return 1
+
+    scanned = len(arms)
+    print(f"PASS: {scanned} H2 route arms scanned; none read state unauthorized")
+    print("=== H2 route auth parity gate: PASS ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/harness/contract/graphql_transport_auth_parity_contract.sh
+++ b/scripts/harness/contract/graphql_transport_auth_parity_contract.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# /graphql must apply the same read gate on HTTP/1.1 and on HTTP/2.
+#
+# Both transports are served on one port: serve_auto sniffs the connection
+# preface and hands h2c connections to Server_h2_gateway and everything else to
+# the HTTP/1 router (server_bootstrap_http.ml). The two route tables are
+# maintained by hand, so an auth wrapper present on one side and absent on the
+# other turns the client's protocol choice into an authorization decision.
+#
+# That is what this contract exists to catch: POST /graphql executed
+# unauthenticated over h2c while the same request was rejected with 401 over
+# HTTP/1.
+set -euo pipefail
+
+: "${MCP_URL:=http://127.0.0.1:8935/mcp}"
+: "${BASE_PATH:?BASE_PATH must be set by run_all.sh}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/harness/lib/test_framework.sh
+source "${SCRIPT_DIR}/../lib/test_framework.sh"
+
+BASE_URL="${MCP_URL%/mcp}"
+GRAPHQL_URL="${BASE_URL}/graphql"
+QUERY='{"query":"{ __typename }"}'
+
+if ! curl --version | grep -qi 'HTTP2'; then
+  echo "FAIL: curl lacks HTTP/2 support; this contract cannot prove transport parity" >&2
+  exit 1
+fi
+
+# Issues exactly one unauthenticated POST on the named transport and echoes
+# "<http_code> <body>". Each transport is probed once: re-probing to compare
+# statuses would double the request count and let a rate limiter answer a later
+# probe instead of the auth gate.
+unauthenticated_post() {
+  local transport="$1"
+  local body_file="$2"
+  local -a curl_args=( --http1.1 )
+  if [[ "$transport" == "h2" ]]; then
+    curl_args=( --http2-prior-knowledge )
+  fi
+  local status attempt
+  # A transport error is a distinct outcome from "the server answered", and it
+  # is not evidence about the authorization gate this contract tests. Retry the
+  # connection once so a dropped socket does not read as an auth verdict; never
+  # retry on an HTTP status, which IS the signal. Report loudly if both
+  # attempts fail rather than letting `set -e` kill the run with no diagnosis.
+  for attempt in 1 2; do
+    if status="$(curl -s -o "$body_file" -w '%{http_code}' \
+        --max-time "${CURL_TIMEOUT_SEC:-25}" "${curl_args[@]}" \
+        -X POST -H 'content-type: application/json' -d "$QUERY" "$GRAPHQL_URL")"; then
+      echo "$status"
+      return 0
+    fi
+    if [[ "$attempt" == 1 ]]; then
+      echo "  note: POST /graphql over ${transport} failed to connect; retrying once" >&2
+      sleep 1
+    fi
+  done
+  echo "FAIL: POST /graphql over ${transport} did not complete (curl error, 2 attempts)" >&2
+  exit 1
+}
+
+H1_BODY="$(mcp_mktemp_file "masc-graphql-parity-h1" ".json")"
+H2_BODY="$(mcp_mktemp_file "masc-graphql-parity-h2" ".json")"
+
+echo "[1/3] HTTP/1.1 answers an unauthenticated POST /graphql"
+H1_STATUS="$(unauthenticated_post h1 "$H1_BODY")"
+echo "  h1 status=${H1_STATUS}"
+
+echo "[2/3] HTTP/2 answers an unauthenticated POST /graphql"
+H2_STATUS="$(unauthenticated_post h2 "$H2_BODY")"
+echo "  h2 status=${H2_STATUS}"
+
+echo "[3/3] neither transport executes the query, and both answer alike"
+for probe in "h1 ${H1_STATUS} ${H1_BODY}" "h2 ${H2_STATUS} ${H2_BODY}"; do
+  read -r transport status body_file <<<"$probe"
+  # 2xx means the query ran for a caller that presented no credential.
+  if [[ "$status" == 2* ]]; then
+    mcp_fail_with_context \
+      "unauthenticated POST /graphql was accepted over ${transport}" \
+      "$(jq -cn --arg transport "$transport" --arg status "$status" \
+        --arg body "$(head -c 400 "$body_file")" \
+        '{transport:$transport,status:$status,body:$body}')"
+  fi
+done
+
+# Parity, not merely "both non-2xx": a transport that 404s while the other 401s
+# would clear the loop above while proving nothing about the gate.
+if [[ "$H1_STATUS" != "$H2_STATUS" ]]; then
+  mcp_fail_with_context \
+    "POST /graphql answered unauthenticated callers differently per transport" \
+    "$(jq -cn --arg h1 "$H1_STATUS" --arg h2 "$H2_STATUS" '{h1:$h1,h2:$h2}')"
+fi
+
+echo "PASS: graphql transport auth parity (h1=${H1_STATUS} h2=${H2_STATUS})"

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -174,9 +174,10 @@ if ! wait_for_mcp_initialize_ready "$MCP_URL" 25; then
   exit 1
 fi
 
-run_contract 1 4 "streamable_http_contract.sh"
-run_contract 2 4 "golden_path_1_contract.sh"
-run_contract 3 4 "public_tool_live_sweep.sh"
-run_contract 4 4 "scheduler_live_supported_contract.sh"
+run_contract 1 5 "streamable_http_contract.sh"
+run_contract 2 5 "golden_path_1_contract.sh"
+run_contract 3 5 "public_tool_live_sweep.sh"
+run_contract 4 5 "scheduler_live_supported_contract.sh"
+run_contract 5 5 "graphql_transport_auth_parity_contract.sh"
 
 echo "PASS: contract harness suite"

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -603,6 +603,54 @@ let test_ws_upgrade_allows_authenticated_cross_origin () =
       failf "expected authenticated cross-origin upgrade to pass, got %s"
         (Masc_domain.masc_error_to_string err))
 
+(* The routes below are guarded on H1 and must stay outside the public-read
+   allowlist. This is the invariant the H2 fix rests on: adding any of these
+   paths to [is_public_read_path] would open them on BOTH transports, and the
+   wrapper parity asserted in the next test would then prove nothing. *)
+let test_transport_guarded_paths_are_not_public_read () =
+  List.iter
+    (fun path ->
+      check bool
+        (Printf.sprintf "%s is not public-read" path)
+        false
+        (Server_auth.is_public_read_path path))
+    [ "/graphql"; "/api/v1/dashboard/workspace"; "/api/v1/status" ]
+
+(* serve_auto hands h2c connections to Server_h2_gateway and everything else to
+   the HTTP/1 router, so a route's authorization is decided independently on
+   each side. POST /graphql executed unauthenticated over h2c while HTTP/1
+   answered 401, because the H2 arm used [with_server_state] — which fetches
+   server state and authorizes nothing.
+
+   [with_h2_public_read] is not a substitute for [with_h2_read_auth]: it first
+   requires [http_auth_strict_enabled] and a non-public path, whereas H1's
+   [with_read_auth] authorizes unconditionally. Each H2 arm must name the
+   counterpart of the wrapper its H1 route uses. *)
+let test_h1_h2_read_gate_wiring_parity () =
+  let h1_frontend = source_file "lib/server/server_routes_http_routes_frontend.ml" in
+  let h2 = source_file "lib/server/server_h2_gateway.ml" in
+  assert_contains "H1 guards /graphql with the unconditional read gate"
+    ~needle:{|~path:"/graphql" ~methods:[`GET; `POST]|}
+    h1_frontend;
+  assert_contains "H2 defines the counterpart of Server_auth.with_read_auth"
+    ~needle:"let with_h2_read_auth h2_reqd f =" h2;
+  assert_contains "H2 read gate authorizes without a strict-mode precondition"
+    ~needle:"authorize_read_request" h2;
+  assert_contains "H2 GET /graphql passes through the read gate"
+    ~needle:"| `GET, \"/graphql\" ->\n          with_h2_read_auth h2_reqd" h2;
+  assert_contains "H2 POST /graphql passes through the read gate"
+    ~needle:"with_h2_read_auth h2_reqd (fun state ->\n              let response = Graphql_api.handle_request"
+    h2;
+  assert_contains "H2 dashboard workspace mirrors H1 with_public_read"
+    ~needle:"| `GET, \"/api/v1/dashboard/workspace\" ->\n          with_h2_public_read h2_reqd"
+    h2;
+  assert_contains "H2 status mirrors H1 with_public_read"
+    ~needle:"| `GET, \"/api/v1/status\" ->\n          with_h2_public_read h2_reqd" h2;
+  (* [with_server_state] performs no authorization; no read route may reach it
+     directly. The arms that still call it (webrtc, MCP) authorize inside. *)
+  assert_not_contains "H2 /graphql no longer reads state without authorizing"
+    ~needle:"with_h2_read_auth h2_reqd (fun _state ->\n            with_server_state" h2
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -638,6 +686,10 @@ let () =
             test_h1_h2_delete_route_wiring_parity;
           test_case "H2 OAuth routes preserve admitted authority" `Quick
             test_h2_oauth_route_and_authority_lifetime;
+          test_case "transport-guarded paths are not public-read" `Quick
+            test_transport_guarded_paths_are_not_public_read;
+          test_case "H1/H2 read gate wiring parity" `Quick
+            test_h1_h2_read_gate_wiring_parity;
         ] );
       ( "ws-upgrade-admission",
         [


### PR DESCRIPTION
## 요약

`POST /graphql`이 HTTP/1에서는 401로 거부되고 h2c에서는 인증 없이 쿼리를 실행했다. 같은 포트, 같은 프로세스, 같은 경로다. 클라이언트가 고른 프로토콜이 인가 여부를 결정하고 있었다.

라이브 서버 실측 (수정 전, commit `4b0139e`):

```
POST /graphql  {"query":"{ __typename }"}   토큰 없음
  h1 → 401  {"error":"[AuthError] Unauthorized: Token required"}
  h2 → 200  {"data":{"__typename":"query"}}
```

## 왜 생겼나

`Server_bootstrap_http.serve_auto`가 **한 포트**에서 연결 preface를 스니핑해 h2c는 `Server_h2_gateway`로, 나머지는 HTTP/1 라우터로 보낸다 (`server_bootstrap_http.ml:296-306`). 두 라우트 표는 손으로 유지되므로 어느 래퍼를 쓸지가 양쪽에서 독립적으로 결정된다.

| 경로 | H1 | H2 (수정 전) |
|---|---|---|
| `GET/POST /graphql` | `with_read_auth` (`server_routes_http_routes_frontend.ml:351`) | GET은 래퍼 없음, POST은 `with_server_state` |
| `GET /api/v1/dashboard/workspace` | `with_public_read` | `with_server_state` |
| `GET /api/v1/status` | `with_public_read` (`server_ide_http.ml:609`) | `with_server_state` |

`with_server_state`는 인증 래퍼가 아니다. 서버 상태만 꺼내고 인가를 전혀 하지 않는다.

노출 범위는 읽기 전용이다 — 스키마에 mutation이 없고 `status` / `tasks` / `agents` / `messages` 등 워크스페이스 조회만 있다. 도달 조건은 기본값 `MASC_USE_H2=auto`에서 h2c prior-knowledge 연결이며, 브라우저는 평문 h2c를 쓰지 않으므로 브라우저 경유로는 도달하지 않는다.

`/graphql`은 H1이 무조건 인증하므로 strict 모드와 무관하게 우회였다. 나머지 두 경로는 H1이 `with_public_read`라 `MASC_HTTP_AUTH_STRICT`가 켜진 배포에서만 갈라진다 — 지금 잠복 상태이고 같은 결함 부류다.

## 변경

**수정 (3경로)**
- `with_h2_read_auth` 추가 — `Server_auth.with_read_auth`의 H2 대응. 무조건 `authorize_read_request`를 호출한다. 기존 `with_h2_public_read`는 `http_auth_strict_enabled() && not (is_public_read_path path)` 전제를 걸므로 **교체 가능하지 않다**. H1이 `with_read_auth`로 감싼 경로는 이쪽을 써야 한다.
- `GET/POST /graphql` → `with_h2_read_auth` (H1의 `with_read_auth` 대응)
- `GET /api/v1/dashboard/workspace`, `GET /api/v1/status` → `with_h2_public_read` (H1의 `with_public_read` 대응)

세 경로를 한 PR에서 처리한 이유: 하나만 고치면 "N개 중 M개만 수정"이 되고, 남은 둘은 같은 메커니즘의 잠복 우회로 남는다.

**런타임 증명**
- `scripts/harness/contract/graphql_transport_auth_parity_contract.sh` 신설. 라이브 서버에 양 전송으로 인증 없는 POST를 각각 1회 보내고, 어느 쪽도 2xx가 아니며 **두 응답 코드가 같은지**까지 검사한다. 한쪽이 404이고 다른 쪽이 401이면 둘 다 non-2xx이지만 게이트에 대해 아무것도 증명하지 못하므로 코드 일치를 요구한다.
- `run_all.sh`에 5번째 계약으로 등록 (CI `Build and Test`가 실행).
- 전송 오류는 인가 속성에 대한 증거가 아니므로 연결 실패에 한해 1회 재시도한다. HTTP 상태에는 재시도하지 않는다 — 그게 신호다.

**재발 방지**
- `scripts/ci/check_h2_route_auth_parity.py` 신설, Meta Guards에 배선. `with_server_state`를 쓰는 H2 arm이 자체 인가(`authorize_*_request`)나 MCP admission(`verify_mcp_auth`)을 하지 않으면 실패시킨다.
- OCaml 주석을 먼저 제거한다. 이 가드의 첫 판(shell)은 **수정을 설명하는 주석 안의 `with_server_state`를 세어**, 이미 올바르게 감싼 `GET /api/v1/dashboard/shell`을 오탐했다. OCaml 주석은 중첩되고 문자열을 포함할 수 있어 깊이와 따옴표를 추적하는 스트리퍼를 썼다(줄 번호 보존을 위해 삭제 대신 공백 치환).

## 검증

**게이트 유효성 — 통과가 아니라 실패로 확인**

| 검사 | 수정 전 | 수정 후 |
|---|---|---|
| contract harness | `FAIL: unauthenticated POST /graphql was accepted over h2` (status 200, body에 실행 결과) exit 1 | `PASS: graphql transport auth parity (h1=401 h2=401)` |
| CI 가드 | 정확히 3건 FAIL (`/graphql`, `/dashboard/workspace`, `/api/v1/status`) exit 1 | `PASS: 54 H2 route arms scanned` exit 0 |

가드의 오탐 0을 함께 확인했다 — `POST /webrtc/*`와 MCP arm은 `with_server_state` 안에서 직접 인가하므로 제외된다.

**그 외**
- `dune build --root . @check` clean
- 전체 contract harness 스위트 `REAL_EXIT=0` (5/5). 파이프 없이 실제 종료 코드로 확인했다 — `| tail`을 거치면 `tail`의 코드가 잡혀 거짓 초록이 된다.
- `test_mcp_h1_h2_admission_parity` 16/16
- Meta Guards 관련 게이트(silent-failure, log-severity, telemetry-coverage) PASS, ci.yml YAML 파싱 확인

## 이 PR이 증명하지 않는 것

가드는 **"상태를 읽으면서 인가하지 않는 arm"**을 잡는다. 수정 전 `GET /graphql`은 상태를 읽지 않고 playground HTML만 반환했으므로 이 가드로는 잡히지 않았다 — H1 쪽을 읽어서 발견했다. 인증 없이 *서빙*하는 모든 경우를 덮지는 못한다.

H1 196 라우트 중 138개가 H2에 아예 없다(H2는 `| _ -> 404`로 끝나고 H1으로 프록시하지 않는다). 그 파리티 격차는 이 PR의 범위가 아니며, 개별 138건을 메우는 것은 근본 대응이 아니라 라우트 등록 자체를 한 곳에서 파생시키는 문제다. 별도로 다룬다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
