### PR TITLE
fix(ide): invalidate the cached writer when rotation moves the inode

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -116,7 +116,12 @@ let maybe_rotate ~path ~max_segment_bytes =
     | Some size when size >= max_segment_bytes ->
       let next = 1 + List.fold_left max 0 (archive_indices ~path) in
       ignore
-        (Fs_compat.rename_if_exists ~src:path ~dst:(archive_path ~path next) : bool)
+        (Fs_compat.rename_if_exists ~src:path ~dst:(archive_path ~path next) : bool);
+      (* The rename moves the inode out from under any cached O_APPEND channel
+         for [path]. Without this the next append writes into the archive we
+         just created and the live segment is never recreated, so readers that
+         tail the live path see the stream stop. *)
+      Fs_compat.invalidate_cached_writer path
     | Some _ | None -> ())
 ;;
 

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=673
+UNWIRED_BASELINE=672
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -101,6 +101,7 @@ normal_targets=(
   @test/runtest-test_exec_policy_cwd_hint
   @test/runtest-test_server_runtime_startup_maintenance
   @test/runtest-test_runtime_per_keeper_routing
+  @test/runtest-test_ide_bridge
   @test/runtest-test_host_fd_pressure_poller
   @test/runtest-test_keeper_turn_driver_failover
   @test/runtest-test_keeper_turn_driver_accept


### PR DESCRIPTION
## 무엇을

`maybe_rotate` 가 inode 를 옮긴 뒤 캐시된 writer 를 무효화하도록 한 줄 추가합니다. **프로덕션 결함 수정**입니다.

```ocaml
ignore (Fs_compat.rename_if_exists ~src:path ~dst:(archive_path ~path next) : bool);
Fs_compat.invalidate_cached_writer path      ← 추가
```

## 왜 — 회전 이후 라이브 세그먼트가 다시 생기지 않습니다

회전이 라이브 파일을 아카이브로 rename 하는데, 그 경로의 `O_APPEND` 채널이 캐시에 그대로 남습니다. 다음 append 는 **방금 만든 아카이브 inode** 로 들어가고 라이브 경로는 영영 생기지 않습니다. 라이브를 tail 하는 소비자에게는 **스트림이 멈춘 것**으로 보이고, 이벤트는 보이지 않는 곳에 쌓입니다.

100바이트 임계로 6회 append 한 뒤 디렉터리 상태입니다.

```
base_dir listing:
  tool_events.jsonl.1        ← 라이브 tool_events.jsonl 없음
```

## 주석이 이 실패를 회피한다고 적혀 있었습니다

```ocaml
(* Fresh-fd append (not the fd-cached [Fs_compat.append_jsonl]): a cached
   writer keyed by the live path would keep writing into a just-renamed
   archive inode after rotation. [append_file] opens/closes per call ... *)
```

**결함을 정확히 서술하고, 없는 완화책을 근거로 댔습니다.** `append_file` 은 호출마다 열지 않습니다.

```ocaml
(* fs_compat.ml:199 *)
let append_file_unix path content =
  Stdlib.Mutex.protect mu (fun () -> Fd_cache.with_writer path (fun oc -> …))

(* fd_cache.ml:65 *)
let with_writer path f = … get_or_open_locked path now …     ← 캐시 조회
```

그리고 `Fd_cache.invalidate` 는 `lib/` 전체에서 한 곳에서만 불리는데, rename 경로가 아닙니다.

## 쓰는 primitive 가 이미 이 경우를 위해 있습니다

```
(** [invalidate_cached_writer path] … Call it after replacing the inode at
    [path] with [save_file_atomic]: the cached [O_APPEND] channel still points
    at the pre-rename inode, so without this a later [append_jsonl] would
    write to the orphaned file. Serialization with concurrent [append_jsonl]
    calls is handled by the same per-path append mutex used by the append
    path. *)
```

`maybe_rotate` 가 하는 일이 정확히 *"replacing the inode at [path]"* 입니다.

동시성도 안전합니다 — `Fd_cache.invalidate` 는 사용 중인 fd 를 닫지 않고 `close_on_release` 로 미룹니다. 그리고 `append_rotating` 은 이미 `with_rotation_lock ~path` 안에서 돕니다.

## 뮤테이션

무효화 호출을 지우면 **원래 실패 2건이 그대로 재현**됩니다.

```
FAIL live segment exists
2 failures!
```

복원하면 `31 tests, Test Successful`. 실패 2건이 모두 이 한 줄 때문이었습니다.

## 배선

```
[ci-test-targets] OK - 672 suites unwired, at baseline
```

`UNWIRED_BASELINE` 673 → 672. **이 스위트에 CI 타깃이 없었던 것이, 라이브 스트림을 멈추는 회전이 머지된 채 남은 이유입니다.**

## 검증

```
dune build @test/runtest-test_ide_bridge   31 tests, Test Successful
뮤테이션(무효화 제거)                        2 failures
audit-ci-test-targets.sh                   OK, 672 at baseline
ocamlformat --check                        clean
```

RFC-WAIVED: `lib/ide/ide_bridge.ml` 은 RFC 게이트 대상(credential / repo_manager / operator_control / keeper sandbox / dashboard credential / hooks) 이 아닙니다. durable 스키마나 wire 형식을 바꾸지 않고, 회전 후 append 가 향하는 inode 만 바로잡습니다.

Closes #28152

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
