### PR TITLE
test(mcp): drop the pin on instruction prose #26123 deliberately removed

### DIFF
--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -145,27 +145,6 @@ let test_descriptor_resolution_capabilities_for_public_names () =
     (capability_has Tool_capability.Read_only "Execute")
 ;;
 
-let test_default_instructions_pin_start_transition_workflow () =
-  let instructions = Masc.Mcp_server_eio_tool_profile.default_instructions () in
-  check
-    bool
-    "write summary names start"
-    true
-    (contains_substring instructions "claim/start/done");
-  check
-    bool
-    "workflow includes start transition"
-    true
-    (contains_substring instructions "masc_transition(start)");
-  check
-    bool
-    "workflow does not skip start"
-    false
-    (contains_substring
-       instructions
-       "masc_transition(claim) -> work in a repo-local worktree")
-;;
-
 let test_full_profile_admission_uses_catalog_direct_call_policy () =
   let state =
     Masc.Mcp_server.For_testing.create_state
@@ -235,10 +214,6 @@ let () =
             "descriptor-resolution-capabilities-for-public-names"
             `Quick
             test_descriptor_resolution_capabilities_for_public_names
-        ; test_case
-            "default-instructions-pin-start-transition-workflow"
-            `Quick
-            test_default_instructions_pin_start_transition_workflow
         ; test_case
             "full-profile-admission-uses-catalog-direct-call-policy"
             `Quick


### PR DESCRIPTION
## 무엇을

MCP 기본 지시문에서 **`#26123` 이 의도적으로 지운 산문**을 고정하던 단언을 제거합니다. 프로덕션 무변경.

## 왜

```
FAIL write summary names start
   Expected: `true'   (instructions contains "claim/start/done")
   Received: `false'
```

현재 지시문은 PROJECT · CLUSTER · READ · WRITE 만 다루고 **어떤 도구 이름도 부르지 않습니다.**

`29fa165932` (#26123) 이 LLM 을 향한 텍스트에서 runtime 이 쓴 도구 지시를 전부 걷어냈고, 그 근거를 이렇게 적었습니다.

> the active typed schema is the sole callable catalog ... never infer a name or argument from this prompt

산문에서 `masc_transition` 을 부르는 것이 정확히 그 계약이 금지하는 바입니다. 이 pin 은 **코드베이스가 지우기로 결정한 텍스트를 유지하라고 요구**하고 있었습니다.

세 번째 단언(옛 claim-only 문구가 **없어야** 한다)은 섹션 자체가 사라져 공허하게 참이 됩니다.

## 배선하지 않습니다 — 남은 실패는 진짜 신호입니다

```
FAIL contract corpus includes a hidden direct-call denial
   Expected: `true'   (!hidden_disallowed > 0)
   Received: `false'
```

이건 stale pin 이 아니라 **대조군**입니다. 위 루프가 `visibility = Hidden && not allow_direct_call_when_hidden` 분기를 실제로 시험하는지 확인합니다. 지금 0 이므로 **그 분기가 커버되지 않습니다.**

원인은 카탈로그가 아니라 corpus 입니다. 카탈로그에는 그런 도구가 있습니다.

```ocaml
(* lib/tool/tool_catalog.ml:260 — masc_operator_task_recovery_* *)
(hidden_active
   ~allow_direct_call_when_hidden:false
   ~required_permission:Masc_domain.CanAdmin
   "Operator-profile-only exact recovery of one Board-attention quarantine.")
```

테스트가 순회하는 `Masc.Config.raw_all_tool_schemas` 가 operator 프로파일 도구를 포함하지 않습니다. 별도 이슈로 올립니다 — 대조군을 침묵시키는 대신 그것이 가리키는 공백을 다뤄야 합니다.

## 검증

```
dune build @test/runtest-test_mcp_server_eio_tool_profile_capability
  6 tests, 1 failure   (이전: 7 tests, 2 failures)
ocamlformat --check    clean
```

RFC-WAIVED: 테스트에서 제거된 산문을 고정하던 단언 하나를 삭제합니다. 프로덕션 코드·durable 스키마·CI 목록을 바꾸지 않습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
