### PR TITLE
fix(runtime): require a seed ceiling on official-client keeper runtimes

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -604,38 +604,50 @@ let validate_keeper_dispatch_request_caps
   let runtime_by_id id =
     List.find_opt (fun (runtime : t) -> String.equal runtime.id id) runtimes
   in
-  match
-    List.find_map
-      (fun id ->
-         match runtime_by_id id with
-         | None -> None
-         | Some runtime ->
-           (match runtime.execution with
-            | Runtime_execution.Codex_app_server _
-            | Runtime_execution.Claude_code _
-            | Runtime_execution.Antigravity_cli _ -> None
-            | Runtime_execution.Agent_core provider_config ->
-              (match
-                 validate_request_body_cap
-                   ~runtime_id:runtime.id
-                   provider_config
-               with
-               | Ok _ -> None
-               | Error _ -> Some runtime)))
-      ids
-  with
+  (* Both execution kinds need a declared ceiling on what a turn may send; they
+     differ only in which one, because they are bounded at different places.
+
+     Agent_core measures the serialized request body, so its ceiling is
+     max-request-body-bytes. An official-client turn never builds that body —
+     it seeds a spawned client's conversation on turn 1 and sends only the goal
+     afterwards — so its ceiling is max-prompt-bytes, on the seed.
+
+     Leaving official-client unbounded was not a smaller version of the same
+     rule; it was the absence of one. An undeclared seed does not fail once: it
+     overflows the model window on turn 1, so the session never reaches turn 2,
+     and a recovery to a fresh session makes the next turn a start turn again.
+     Measured while rotating keepers across the declared runtimes: 13 of 13
+     official-client runtimes without the declaration failed this way, and all
+     13 completed once it was declared. The four that already carried it were
+     the four that were already working. *)
+  let missing_ceiling runtime =
+    match runtime.execution with
+    | Runtime_execution.Agent_core provider_config ->
+      (match validate_request_body_cap ~runtime_id:runtime.id provider_config with
+       | Ok _ -> None
+       | Error _ -> Some (runtime, "max-request-body-bytes", "the exact serialized request"))
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _
+    | Runtime_execution.Antigravity_cli _ ->
+      (match runtime.model.max_prompt_bytes with
+       | Some n when n > 0 -> None
+       | Some _ | None ->
+         Some (runtime, "max-prompt-bytes", "the start-turn conversation seed"))
+  in
+  match List.find_map (fun id -> Option.bind (runtime_by_id id) missing_ceiling) ids with
   | None -> Ok ()
-  | Some runtime ->
+  | Some (runtime, key, what) ->
     Error
       (Printf.sprintf
-         "%s: Keeper-dispatch runtime %S has no positive \
-          max-request-body-bytes; declare [%s.%s].max-request-body-bytes before \
-          dispatch so the exact serialized request has an explicit admission \
-          ceiling"
+         "%s: Keeper-dispatch runtime %S has no positive %s; declare \
+          [%s.%s].%s before dispatch so %s has an explicit admission ceiling"
          config_path
          runtime.id
+         key
          runtime.binding.provider_id
-         runtime.binding.model_id)
+         runtime.binding.model_id
+         key
+         what)
 ;;
 
 (* Every runtime binding's provider/model pair must be known to the AGENT_CORE

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1839,6 +1839,80 @@ let test_runtime_config_validation_rejects_uncapped_keeper_candidate () =
            (String_util.contains_substring detail "local.lane"))
 ;;
 
+(* The Agent_core rule above bounds the serialized request body. An
+   official-client turn never builds that body — it seeds a spawned client's
+   conversation on turn 1 and sends only the goal afterwards — so its ceiling
+   sits on the seed instead. Leaving that side unbounded was the absence of a
+   rule, not a lighter version of one: an undeclared seed overflows the model
+   window on turn 1, the session never reaches turn 2, and recovery to a fresh
+   session makes the next turn a start turn again.
+
+   Measured while rotating keepers across the declared runtimes: 13 of 13
+   official-client runtimes without the declaration failed this way, and all 13
+   completed once it was declared. *)
+let test_runtime_config_validation_rejects_unbounded_official_client_seed () =
+  let content bound =
+    Printf.sprintf
+      "[providers.local]\n\
+       protocol = \"openai-compatible-http\"\n\
+       endpoint = \"http://127.0.0.1:1/v1\"\n\
+       \n\
+       [providers.subscription]\n\
+       protocol = \"claude-code\"\n\
+       command = \"/usr/bin/true\"\n\
+       is-non-interactive = true\n\
+       \n\
+       [models.sample]\n\
+       api-name = \"sample\"\n\
+       max-context = 1024\n\
+       \n\
+       [models.seeded]\n\
+       api-name = \"seeded\"\n\
+       max-context = 1024\n%s\
+       \n\
+       [local.sample]\n\
+       max-request-body-bytes = 65536\n\
+       \n\
+       [subscription.seeded]\n\
+       \n\
+       [runtime]\n\
+       default = \"local.sample\"\n\
+       \n\
+       [runtime.assignments]\n\
+       \"probe\" = \"subscription.seeded\"\n"
+      bound
+  in
+  let attempt text =
+    let snapshot = Runtime.For_testing.snapshot () in
+    let path = Filename.temp_file "official_seed_" ".toml" in
+    let oc = open_out path in
+    output_string oc text;
+    close_out oc;
+    Fun.protect
+      ~finally:(fun () ->
+        Runtime.For_testing.restore snapshot;
+        try Sys.remove path with
+        | Sys_error _ -> ())
+      (fun () -> Runtime.save_config_text ~runtime_config_path:path text)
+  in
+  (match attempt (content "") with
+   | Ok () ->
+     fail "an official-client Keeper runtime with no max-prompt-bytes must be rejected"
+   | Error detail ->
+     check bool "the diagnostic names the key an operator must add" true
+       (String_util.contains_substring detail "max-prompt-bytes");
+     check bool "the diagnostic names the runtime" true
+       (String_util.contains_substring detail "subscription.seeded");
+     (* The Agent_core key would send the operator to the wrong line. *)
+     check bool "the diagnostic does not name the Agent_core key" false
+       (String_util.contains_substring detail "max-request-body-bytes"));
+  (* Control: the same config with the bound declared must load. Without this a
+     check that rejected every official-client runtime would pass. *)
+  match attempt (content "max-prompt-bytes = 131072\n") with
+  | Ok () -> ()
+  | Error detail -> failf "a declared seed bound must load: %s" detail
+;;
+
 let test_runtime_config_validation_rejects_uncapped_special_runtime () =
   let content route =
     Printf.sprintf
@@ -3807,6 +3881,10 @@ let () =
             "runtime config rejects an uncapped cross-verifier runtime"
             `Quick
             test_runtime_config_validation_rejects_uncapped_special_runtime;
+          test_case
+            "runtime config rejects an unbounded official-client seed"
+            `Quick
+            test_runtime_config_validation_rejects_unbounded_official_client_seed;
           test_case
             "runtime config allows uncapped dormant lane candidate"
             `Quick


### PR DESCRIPTION
Refs #28111.

## 문제

키퍼-디스패치 런타임은 **한 턴이 무엇을 보낼 수 있는지**를 선언해야 한다. Agent_core 는 이미 그렇다 — `validate_keeper_dispatch_request_caps` 가 양수 `max-request-body-bytes` 없는 바인딩의 로드를 거부한다.

official-client 바인딩은 그 검사에서 **면제**돼 있었고, `max-prompt-bytes` 는 미선언 시 **상한 없음**이 기본이었다.

이건 더 가벼운 규칙이 아니라 **규칙의 부재**다. official-client 턴 1 은 spawn 된 클라이언트의 대화를 히스토리 전량으로 시드하고 턴 2 부터는 goal 만 보낸다. 그래서 상한 없는 시드는 턴 1 에서 모델 창을 넘고, 세션은 턴 2 에 도달하지 못하며, fresh session 복구는 다음 턴을 다시 start 턴으로 만든다.

## 실측 — 상관이 완전하다

키퍼 한 대를 선언된 전 런타임에 순환시켜 쟀다.

| | 1차 (미선언) | 2차 (선언 후) |
|---|---|---|
| official-client 런타임 | **13/13 실패** | **13/13 완주** |

실패 문구는 계열마다 달랐지만 같은 것을 말한다:

```
codex:       Codex ran out of room in the model's context window.
claude_code: Prompt is too long · the request is ~2227119 tokens (limit 1000000)
```

그리고 **이미 키를 선언하고 있던 4개가 정확히 이미 동작하던 4개**였다 (`claude-opus-5-max`, `gpt-5.6-sol`, `gpt-5.3-codex-spark`, `gemini-3-6-flash-high`). 58개 모델 중 4개만 선언돼 있었고 그 4개만 살아 있었다.

키퍼 커버리지: 순환 전 7/44 → 1차 후 17/44 → 선언 후 2차에서 22/44 로 계속 오르는 중.

## 왜 키가 두 개인가

같은 규칙의 두 이름이 아니라, **두 경로가 서로 다른 지점에서 바운드되기 때문**이다.

| | 무엇을 재나 | 키 |
|---|---|---|
| Agent_core | 직렬화된 요청 본문 | `max-request-body-bytes` |
| official-client | start 턴 대화 시드 | `max-prompt-bytes` |

official-client 턴은 그 요청 본문을 **만들지 않는다**. 그래서 진단이 해당하는 키를 이름으로 부른다 — 운영자를 엉뚱한 줄로 보내지 않기 위해서이고, 테스트가 **다른 키를 부르지 않는 것**까지 고정한다.

## 검증

```
dune build @check                                      OK (트리 전체)
dune build @test/runtest-test_runtime_config_validity  74 tests, OK
```

새 테스트 `runtime config rejects an unbounded official-client seed`:

1. `max-prompt-bytes` 없는 official-client 배정 → **거부**, 진단이 키와 런타임 id 를 이름으로 부름
2. 진단이 `max-request-body-bytes`(다른 경로의 키)를 **부르지 않음**
3. **대조군**: 같은 config 에 바운드를 선언하면 **로드됨**

3번이 없으면 "official-client 를 전부 거부" 하는 구현도 통과한다.

배선 증명: `missing_ceiling` 의 official-client 분기를 `None` 으로 단락시키면 이 테스트가 red 가 된다.

## 범위

저장소 `config/runtime.toml` 에는 official-client 바인딩이 0개라 CI 에서 이 게이트는 발화하지 않는다. 발화하는 곳은 그런 바인딩을 가진 배포다 — 이 게이트가 겨냥하는 것이 정확히 그 경우다.

RFC-WAIVED: 런타임 config 로드 검증 한 곳과 그 테스트다. credential / identity / repo_manager / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 어느 것도 건드리지 않는다.

WORKAROUND-WAIVED: 증상 억제가 아니라 **없던 선언 요구를 형제 경로와 대칭으로 추가**하는 변경이다. 로드 시점에 fail-closed 하며, 재시도/캡/쿨다운/문자열 분류기/카운터 없음.

Co-Authored-By: Claude Opus 5 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrQctrmuNds4HVg9sHgicM
