### PR TITLE
fix(ide): 주석 타임스탬프를 boot-relative mtime이 아니라 wall-clock ms로 기록

### DIFF
--- a/lib/ide/dune
+++ b/lib/ide/dune
@@ -18,8 +18,6 @@
  (libraries
   unix
   eio
-  mtime
-  mtime.clock.os
   yojson
   uuidm
   fs_compat

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -37,8 +37,13 @@ let ensure_store ~base_dir ?(partition = Ide_paths.Legacy_default) () =
 ;;
 
 let now_ms () =
-  let ns = Mtime.to_uint64_ns (Mtime_clock.now ()) in
-  Int64.div ns 1_000_000L
+  (* NDT-OK: annotation timestamps are operator-facing metadata and the CAS
+     version token; they make no deterministic decisions. This must be wall
+     clock, matching Ide_bridge.now_ms — the Mtime_clock (monotonic,
+     boot-relative) that sat here stamped records with 1970-era values that
+     were meaningless to operators and not comparable across restarts
+     (#28148). *)
+  Int64.of_float (Unix.gettimeofday () *. 1000.0)
 ;;
 
 let next_compaction_id () =

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -996,10 +996,37 @@ let test_cas_absent_version_is_legacy () =
     | Error msg -> failf "legacy delete without version must succeed: %s" msg)
 ;;
 
+(* 2020-01-01T00:00:00Z as epoch ms. A monotonic boot-relative clock — the
+   #28148 regression this pins against — yields values three orders of
+   magnitude below this floor on any realistic uptime, so the comparison
+   separates the two sources without depending on the test host's clock. *)
+let wall_clock_floor_ms = 1_577_836_800_000L
+
+let test_create_stamps_wall_clock_ms () =
+  with_temp_dir (fun base_dir ->
+    let created = make_cas_annotation base_dir in
+    check
+      bool
+      "created_at_ms is epoch wall clock, not boot-relative"
+      true
+      (Int64.compare created.Types.created_at_ms wall_clock_floor_ms > 0);
+    check
+      bool
+      "updated_at_ms (the CAS version token) uses the same source"
+      true
+      (Int64.compare created.Types.updated_at_ms wall_clock_floor_ms > 0))
+;;
+
 let () =
   run
     "ide_annotations"
-    [ ( "compact"
+    [ ( "clock"
+      , [ test_case
+            "create stamps epoch wall-clock ms"
+            `Quick
+            test_create_stamps_wall_clock_ms
+        ] )
+    ; ( "compact"
       , [ test_case
             "compact preserves annotations"
             `Quick


### PR DESCRIPTION
## 무엇

`Ide_annotations.now_ms`가 `Mtime_clock`(monotonic, 부팅 기준)을 읽어 `created_at_ms`/`updated_at_ms`에 저장 — 모든 주석이 1970년대 값(라이브 실측 5.2e8 ms = 호스트 업타임 6일)을 달고 있었습니다. 운영자에게 무의미하고 재시작 간 비교 불가이며, `updated_at_ms`는 CAS 버전 토큰을 겸합니다. #28148.

## 어떻게

같은 라이브러리의 `Ide_bridge.now_ms`가 이미 쓰는 epoch 소스(`Unix.gettimeofday`, NDT-OK 마커 동일 관례)로 통일하고, 용도가 사라진 `mtime`/`mtime.clock.os` 의존을 dune에서 제거했습니다.

**과거 데이터 처리 없음**: mono 값을 달고 있던 옛 스키마 레코드는 오늘 no-legacy-readers 지침에 따라 숙청 완료(현행 스키마 2건만 잔존, newest-first 정렬에서 신규 wall-clock 값이 항상 위이고 CAS는 레코드별 자기 값 비교라 read-side 처리 불요).

## 검증

- 신규 `clock` 스위트: 2020-01-01 epoch floor 비교 (boot-relative 값은 3자릿수 아래라 호스트 시계에 무의존). **옛 시계로 되돌리면 FAIL 재현 후 복원.**
- 전체 `test_ide_annotations` 30건 green (`test/dune:181` 배선 기존재).
- 미검증: 머지·배포 후 신규 주석의 created_at_ms 라이브 실측.

Closes #28148.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>