### PR TITLE
test(dashboard): drop the assertion on the message field #27383 removed

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=672
+UNWIRED_BASELINE=671
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -102,6 +102,7 @@ normal_targets=(
   @test/runtest-test_server_runtime_startup_maintenance
   @test/runtest-test_runtime_per_keeper_routing
   @test/runtest-test_ide_bridge
+  @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller
   @test/runtest-test_keeper_turn_driver_failover
   @test/runtest-test_keeper_turn_driver_accept

--- a/test/test_dashboard_workspace.ml
+++ b/test/test_dashboard_workspace.ml
@@ -63,7 +63,6 @@ let test_workspace_projection_includes_messages_and_mentions () =
   let first = List.hd messages in
   Alcotest.(check string) "first sender" "operator" (string_field "sender" first);
   Alcotest.(check string) "first type" "broadcast" (string_field "type" first);
-  Alcotest.(check string) "first relevance" "medium" (string_field "relevance" first);
   Alcotest.(check bool)
     "first expires_at null"
     true


### PR DESCRIPTION
## 무엇을

`#27383` 이 제거한 메시지 필드 `relevance` 를 읽던 단언을 삭제하고, 그 스위트를 CI 에 배선합니다. 프로덕션 무변경.

## 왜

```ocaml
(* test/test_dashboard_workspace.ml:66 *)
Alcotest.(check string) "first relevance" "medium" (string_field "relevance" first);
```

그 필드는 없습니다.

```
f767d26d15  refactor(types): remove the message relevance field that never decayed (#27383)
```

저장소 전수 검색에 생산자가 없습니다 — 남은 `relevance` 매치는 board-signal 판정자와 library 검색 점수로, 메시지 필드와 무관합니다.

## 부재를 문자열로 읽으면 단언이 아니라 예외가 됩니다

```
Yojson.Safe.Util.Type_error("Expected string, got null")
test/test_dashboard_workspace.ml, line 66
```

**불일치를 보고하는 대신 케이스 전체가 죽었습니다.** 그래서 이 스위트의 실패는 "값이 다르다"가 아니라 "읽을 수 없다"로 나타났고, 같은 형태가 인벤토리의 `OTHER` 25건에 여럿 있습니다.

## 남은 단언이 공허하지 않은지 확인

한 줄을 지우면 케이스가 아무것도 안 지키게 될 수 있으므로 뮤테이션했습니다. 기대 sender 를 틀린 값으로 바꾸면:

```
FAIL first sender
exit 1
```

메시지 투영은 여전히 고정됩니다.

## 배선

```
[ci-test-targets] OK - 671 suites unwired, at baseline
```

`UNWIRED_BASELINE` 672 → 671. **CI 타깃이 없던 것이, 단언이 자기 필드보다 오래 살아남은 이유입니다.**

## 검증

```
dune build @test/runtest-test_dashboard_workspace   2 tests, Test Successful
뮤테이션(sender 왜곡)                                 FAIL, exit 1
audit-ci-test-targets.sh                            OK, 671 at baseline
ocamlformat --check                                 clean
```

RFC-WAIVED: 제거된 필드를 읽던 테스트 단언 한 줄과 CI 목록·ratchet baseline 만 변경합니다. 프로덕션 코드·durable 스키마를 건드리지 않습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
