### PR TITLE
Harden shared state with immutable snapshots

### DIFF
--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -304,18 +304,19 @@ let resolve_with inputs =
     keepers;
   }
 
-let cached_resolution : resolution option ref = ref None
+let cached_resolution : resolution option Atomic.t = Atomic.make None
 
-let resolve () =
-  match !cached_resolution with
+let rec resolve () =
+  match Atomic.get cached_resolution with
   | Some r -> r
   | None ->
       let r = resolve_with (inputs_from_env ()) in
-      cached_resolution := Some r;
-      r
+      if Atomic.compare_and_set cached_resolution None (Some r)
+      then r
+      else resolve ()
 
 let reset () =
-  cached_resolution := None
+  Atomic.set cached_resolution None
 
 let prompts_dir () =
   (resolve ()).prompts.path
@@ -353,7 +354,15 @@ let keeper_toml_path_opt_for_base_path ~base_path name =
 let warnings () =
   (resolve ()).warnings
 
-let last_logged_signature : string option ref = ref None
+let last_logged_signature : string option Atomic.t = Atomic.make None
+
+let rec claim_new_signature cell signature =
+  let previous = Atomic.get cell in
+  if previous = Some signature
+  then false
+  else if Atomic.compare_and_set cell previous (Some signature)
+  then true
+  else claim_new_signature cell signature
 
 let log_warnings ?(context = "ConfigDir") () =
   let resolution = resolve () in
@@ -361,16 +370,17 @@ let log_warnings ?(context = "ConfigDir") () =
     String.concat "\n"
       ((status_to_string resolution.status) :: resolution.warnings)
   in
-  if resolution.warnings <> [] && !last_logged_signature <> Some signature then begin
+  if resolution.warnings <> []
+     && claim_new_signature last_logged_signature signature
+  then begin
     List.iter (fun warning ->
         Log.warn ~ctx:context "%s" warning)
-      resolution.warnings;
-    last_logged_signature := Some signature
+      resolution.warnings
   end
 
 (* Track the last resolution signature we info-logged so startup banner is
    idempotent across repeated [log_resolution] calls (bootstrap + per-query). *)
-let last_logged_resolution_signature : string option ref = ref None
+let last_logged_resolution_signature : string option Atomic.t = Atomic.make None
 
 (** Emit a single info-level line stating the resolved config root source and
     path. When [MASC_CONFIG_DIR] is set, also note whether a [<base_path>/.masc/config]
@@ -400,10 +410,8 @@ let log_resolution ?(context = "ConfigDir") () =
   let signature =
     Printf.sprintf "source=%s path=%s%s" source item.path shadow_note
   in
-  if !last_logged_resolution_signature <> Some signature then begin
-    Log.info ~ctx:context "resolved: %s" signature;
-    last_logged_resolution_signature := Some signature
-  end
+  if claim_new_signature last_logged_resolution_signature signature
+  then Log.info ~ctx:context "resolved: %s" signature
 
 (* RFC-0121 — .masc/<sub> sub-directory accessors.
 

--- a/lib/core/validation.ml
+++ b/lib/core/validation.ml
@@ -13,23 +13,33 @@
     for security monitoring and debugging.
 *)
 
-(** MAGI: Validation rejection counters for observability *)
-let rejection_count = Atomic.make 0
-let last_rejection_time = ref 0.0
+(** MAGI: Validation rejection counters for observability.
+
+    Keep the related values in one immutable snapshot.  A count Atomic beside a
+    plain timestamp ref allowed cross-domain readers to observe a count from one
+    rejection and a timestamp from another (and the ref itself was a data race). *)
+type rejection_stats =
+  { count : int
+  ; last_rejection_time : float
+  }
+
+let rejection_stats =
+  Atomic.make { count = 0; last_rejection_time = 0.0 }
 
 (** Get validation statistics *)
 let get_rejection_stats () =
-  (Atomic.get rejection_count, !last_rejection_time)
+  let snapshot = Atomic.get rejection_stats in
+  snapshot.count, snapshot.last_rejection_time
 
 (** Reset validation statistics *)
 let reset_rejection_stats () =
-  Atomic.set rejection_count 0;
-  last_rejection_time := 0.0
+  Atomic.set rejection_stats { count = 0; last_rejection_time = 0.0 }
 
 (** Internal: Log validation rejection at WARN level *)
 let log_rejection ~validator ~input ~reason =
-  Atomic.incr rejection_count;
-  last_rejection_time := Time_compat.now ();
+  let now = Time_compat.now () in
+  Atomic_util.update rejection_stats (fun snapshot ->
+    { count = snapshot.count + 1; last_rejection_time = now });
   let safe_input =
     String_util.utf8_safe ~max_bytes:35 ~suffix:"..." input
     |> String_util.to_string

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -102,7 +102,7 @@ let store_ref : Dated_jsonl.t option Atomic.t = Atomic.make None
 let base_path () =
   Filename.concat (Env_config_core.base_path ()) "data/verdicts"
 
-let get_store () =
+let rec get_store () =
   match Atomic.get store_ref with
   | Some s -> s
   | None ->
@@ -113,7 +113,7 @@ let get_store () =
       (* Another domain published the process-wide store while this domain
          created its candidate.  All writers must use that single instance so
          Dated_jsonl's per-store serialization remains authoritative. *)
-      Option.get (Atomic.get store_ref)
+      get_store ()
 
 module For_testing = struct
   let reset_store () = Atomic.set store_ref None

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -97,22 +97,28 @@ type calibration_example = {
 (* Store                                                             *)
 (* ================================================================ *)
 
-let store_ref : Dated_jsonl.t option ref = ref None
+let store_ref : Dated_jsonl.t option Atomic.t = Atomic.make None
 
 let base_path () =
   Filename.concat (Env_config_core.base_path ()) "data/verdicts"
 
 let get_store () =
-  match !store_ref with
+  match Atomic.get store_ref with
   | Some s -> s
   | None ->
     let s = Dated_jsonl.create ~base_dir:(base_path ()) () in
-    store_ref := Some s;
-    s
+    if Atomic.compare_and_set store_ref None (Some s)
+    then s
+    else
+      (* Another domain published the process-wide store while this domain
+         created its candidate.  All writers must use that single instance so
+         Dated_jsonl's per-store serialization remains authoritative. *)
+      Option.get (Atomic.get store_ref)
 
 module For_testing = struct
-  let reset_store () = store_ref := None
-  let set_store ~base_dir = store_ref := Some (Dated_jsonl.create ~base_dir ())
+  let reset_store () = Atomic.set store_ref None
+  let set_store ~base_dir =
+    Atomic.set store_ref (Some (Dated_jsonl.create ~base_dir ()))
 end
 
 (** Resolve where an offline eval tool's [--record-verdicts] verdicts are

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -750,19 +750,3 @@ let accountability_summary_json (config : Workspace_query.config) ~keeper_name ~
   accountability_summary_lookup config ~keeper_name ~agent_name
 ;;
 
-let enable_window_read_count_for_testing () =
-  (* tla-lint: allow-mutation: test hook — initialise opt-in counter from test setup *)
-  window_read_count_for_testing_ref := Some 0
-;;
-
-let disable_window_read_count_for_testing () =
-  (* tla-lint: allow-mutation: test hook — clear opt-in counter from test teardown *)
-  window_read_count_for_testing_ref := None
-;;
-
-let window_read_count_for_testing () =
-  match !window_read_count_for_testing_ref with
-  | Some count -> count
-  | None -> 0
-;;
-

--- a/lib/keeper/keeper_accountability_types_codec.ml
+++ b/lib/keeper/keeper_accountability_types_codec.ml
@@ -50,7 +50,7 @@ type claim_snapshot =
 
 let store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 let store_cache_mu = Eio.Mutex.create ()
-let window_read_count_for_testing_ref : int option ref = ref None
+let window_read_count_for_testing_state : int option Atomic.t = Atomic.make None
 let task_commitment_expiry_sec = 72.0 *. Masc_time_constants.hour
 let completion_claim_expiry_sec = 24.0 *. Masc_time_constants.hour
 let dedupe_window_sec = Masc_time_constants.hour
@@ -272,12 +272,23 @@ let resolution_event_of_json json =
 ;;
 
 let read_window_entries (config : Workspace_query.config) =
-  (match !window_read_count_for_testing_ref with
-   (* tla-lint: allow-mutation: test hook — opt-in counter for window-read assertions *)
-   | Some count -> window_read_count_for_testing_ref := Some (count + 1)
-   | None -> ());
+  Atomic_util.update window_read_count_for_testing_state (function
+    | Some count -> Some (count + 1)
+    | None -> None);
   let now = Time_compat.now () in
   let since = event_date_string (now -. (float_of_int summary_window_days *. Masc_time_constants.day)) in
   let until = event_date_string now in
   Dated_jsonl.read_range (get_store config) ~since ~until
+;;
+
+let enable_window_read_count_for_testing () =
+  Atomic.set window_read_count_for_testing_state (Some 0)
+;;
+
+let disable_window_read_count_for_testing () =
+  Atomic.set window_read_count_for_testing_state None
+;;
+
+let window_read_count_for_testing () =
+  Option.value (Atomic.get window_read_count_for_testing_state) ~default:0
 ;;

--- a/lib/keeper/keeper_accountability_types_codec.ml
+++ b/lib/keeper/keeper_accountability_types_codec.ml
@@ -290,5 +290,7 @@ let disable_window_read_count_for_testing () =
 ;;
 
 let window_read_count_for_testing () =
-  Option.value (Atomic.get window_read_count_for_testing_state) ~default:0
+  match Atomic.get window_read_count_for_testing_state with
+  | Some count -> count
+  | None -> 0
 ;;

--- a/lib/keeper/keeper_accountability_types_codec.mli
+++ b/lib/keeper/keeper_accountability_types_codec.mli
@@ -41,11 +41,13 @@ type claim_snapshot = {
 }
 val store_cache : (string, Dated_jsonl.t) Hashtbl.t
 val store_cache_mu : Eio.Mutex.t
-val window_read_count_for_testing_ref : int option ref
 val task_commitment_expiry_sec : float
 val completion_claim_expiry_sec : float
 val dedupe_window_sec : float
 val summary_window_days : int
+val enable_window_read_count_for_testing : unit -> unit
+val disable_window_read_count_for_testing : unit -> unit
+val window_read_count_for_testing : unit -> int
 val claim_kind_to_string :
   Keeper_accountability_claim_types.claim_kind -> string
 val claim_kind_of_string :

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -207,7 +207,7 @@ let startup_not_ready_error_data elapsed =
     ; ("retry_after_ms", `Int 3000)
     ]
 let with_keeper_startup_gate f =
-  if not Server_startup_state.((!state).state_ready) then begin
+  if not (Server_startup_state.snapshot ()).state_ready then begin
     let elapsed = Server_startup_state.elapsed_since_start () in
     Log.Keeper.warn "keeper_up rejected: server not ready (%.1fs since start)" elapsed;
     tool_result_error_data (startup_not_ready_error_data elapsed)

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -71,10 +71,10 @@ let sink_path () =
    same store name it from here instead of spelling the literal. *)
 let store_dirname = "transition-audit"
 
-let default_store_ref : Dated_jsonl.t option ref = ref None
+let default_store = Atomic.make None
 
 let get_default_store () =
-  match !default_store_ref with
+  match Atomic.get default_store with
   | Some store -> Some store
   | None ->
     (try
@@ -84,8 +84,9 @@ let get_default_store () =
            store_dirname
        in
        let store = Dated_jsonl.create ~base_dir:dir () in
-       default_store_ref := Some store;
-       Some store
+       if Atomic.compare_and_set default_store None (Some store)
+       then Some store
+       else Atomic.get default_store
      with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->
@@ -437,7 +438,7 @@ module For_testing = struct
     with_append_queue_lock (fun () -> Stdlib.Queue.clear append_queue);
     Atomic.set async_append_active false;
     Atomic.set append_queue_dropped 0;
-    default_store_ref := None
+    Atomic.set default_store None
   ;;
 
   let queued_count = queued_count_for_testing

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -58,8 +58,12 @@ let route_evidence_json_of_tool_io ~tool_name ~input ~output_text =
     ~output_text
 ;;
 
-let store_ref : Dated_jsonl.t option ref = ref None
-let configured_store_ref : (string * string) option ref = ref None
+type store_state =
+  { store : Dated_jsonl.t option
+  ; configured : (string * string) option
+  }
+
+let store_state = Atomic.make { store = None; configured = None }
 
 type append_entry =
   { store : Dated_jsonl.t
@@ -114,15 +118,16 @@ let init ?cluster_name ~base_path () =
   in
   let masc_root = Workspace_utils.masc_root_dir_from ~base_path ~cluster_name in
   let dir = Filename.concat masc_root "tool_calls" in
-  configured_store_ref := Some (masc_root, dir);
+  Atomic.set store_state { store = None; configured = Some (masc_root, dir) };
   try
     let retention_days = retention_days () in
     let store = Dated_jsonl.create ~base_dir:dir ?retention_days () in
-    store_ref := Some store
+    Atomic.set store_state
+      { store = Some store; configured = Some (masc_root, dir) }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-    store_ref := None;
+    Atomic_util.update store_state (fun state -> { state with store = None });
     Log.Misc.warn "keeper_tool_call_log: init failed: %s" (Printexc.to_string exn);
     (try
        Telemetry_coverage_gap.record
@@ -143,8 +148,7 @@ let init ?cluster_name ~base_path () =
 ;;
 
 let reset_for_testing () =
-  store_ref := None;
-  configured_store_ref := None;
+  Atomic.set store_state { store = None; configured = None };
   Atomic.set async_append_active false;
   Atomic.set append_queue_dropped 0;
   with_append_queue_lock (fun () -> Stdlib.Queue.clear append_queue);
@@ -152,7 +156,7 @@ let reset_for_testing () =
 ;;
 
 let store_dir () =
-  match !store_ref with
+  match (Atomic.get store_state).store with
   | Some store -> Some (Dated_jsonl.base_dir store)
   | None -> None
 ;;
@@ -169,7 +173,8 @@ let current_log_path () =
     Some (Filename.concat (Filename.concat dir month) day)
 ;;
 
-let configured_masc_root () = Option.map fst !configured_store_ref
+let configured_masc_root () =
+  Option.map fst (Atomic.get store_state).configured
 
 let record_append_coverage_gap ~store ~keeper_name ~tool_name ?trace_id exn =
   let durable_store = Dated_jsonl.base_dir store in
@@ -198,7 +203,7 @@ let record_append_coverage_gap ~store ~keeper_name ~tool_name ?trace_id exn =
 ;;
 
 let record_unavailable_coverage_gap ~keeper_name ~tool_name ?trace_id () =
-  match !configured_store_ref with
+  match (Atomic.get store_state).configured with
   | None -> ()
   | Some (masc_root, durable_store) ->
     (try
@@ -390,7 +395,7 @@ let log_call
       ?truncated_to
       ()
   =
-  match !store_ref with
+  match (Atomic.get store_state).store with
     | None -> record_unavailable_coverage_gap ~keeper_name ~tool_name ?trace_id ()
     | Some store ->
       (* RFC-0225 §3.3: no ambient turn-context fallback. Both production
@@ -633,7 +638,7 @@ let read_recent_rows ~n () : Yojson.Safe.t list =
   if n <= 0
   then []
   else (
-    match !store_ref with
+    match (Atomic.get store_state).store with
     | None -> []
     | Some store -> Dated_jsonl.read_recent store n)
 ;;
@@ -671,7 +676,7 @@ let read_window ?keeper_name ~(window_hours : float) () : Yojson.Safe.t list =
   if window_hours <= 0.0
   then []
   else (
-    match !store_ref with
+    match (Atomic.get store_state).store with
     | None -> []
     | Some store ->
       let now = Time_compat.now () in
@@ -703,7 +708,7 @@ let read_latest ?keeper_name () : Yojson.Safe.t option =
     | Some k -> String.equal k name
     | None -> false
   in
-  match !store_ref with
+  match (Atomic.get store_state).store with
   | None -> None
   | Some store ->
     let scan_limit =

--- a/lib/local_runtime_pool/local_runtime_pool.ml
+++ b/lib/local_runtime_pool/local_runtime_pool.ml
@@ -66,12 +66,12 @@ let empty_pool = {
   measured_ceiling = None;
 }
 
-let pool : pool_state ref = ref empty_pool
-let pool_mu = Eio.Mutex.create ()
+let pool : pool_state Atomic.t = Atomic.make empty_pool
+let pool_mu = Stdlib.Mutex.create ()
 
-let with_pool_lock f = Eio_guard.with_mutex pool_mu f
+let with_pool_lock f = Stdlib.Mutex.protect pool_mu f
 
-let reset () = with_pool_lock (fun () -> pool := empty_pool)
+let reset () = with_pool_lock (fun () -> Atomic.set pool empty_pool)
 
 let parse_int_opt raw =
   int_of_string_opt ((String.trim raw))
@@ -224,8 +224,8 @@ let load_runtimes_from_env () =
       if runtimes = [] then ([ default_runtime () ], []) else (runtimes, [])
 
 (* ensure_loaded: the only function that may yield (debug_log calls Log.LocalWorker.debug).
-   Yield happens AFTER the ref swap, so callers reading !pool after this
-   function returns see a consistent snapshot.
+   Yield happens AFTER the atomic swap, so later callers see a consistent
+   snapshot.
 
    The [load_runtimes_from_env] call and the fingerprint paired with it
    must be captured atomically: both functions read environment
@@ -240,7 +240,8 @@ let load_runtimes_from_env () =
 let ensure_loaded () =
   let fingerprint = current_fingerprint () in
   let needs_reload =
-    with_pool_lock (fun () -> not (String.equal fingerprint (!pool).fingerprint))
+    with_pool_lock (fun () ->
+      not (String.equal fingerprint (Atomic.get pool).fingerprint))
   in
   if needs_reload then begin
     let loaded, errors = load_runtimes_from_env () in
@@ -249,9 +250,10 @@ let ensure_loaded () =
       let refreshed = List.map refresh_runtime_metrics loaded in
       let reloaded =
         with_pool_lock (fun () ->
-          let state = !pool in
+          let state = Atomic.get pool in
           if not (String.equal fingerprint state.fingerprint) then begin
-            pool := { state with runtimes = refreshed; fingerprint; parse_errors = errors };
+            Atomic.set pool
+              { state with runtimes = refreshed; fingerprint; parse_errors = errors };
             true
           end else
             false)
@@ -267,18 +269,19 @@ let ensure_loaded () =
         fingerprint loaded_fingerprint
   end else begin
     with_pool_lock (fun () ->
-      let state = !pool in
+      let state = Atomic.get pool in
       let refreshed = List.map refresh_runtime_metrics state.runtimes in
-      pool := { state with runtimes = refreshed })
+      Atomic.set pool { state with runtimes = refreshed })
   end
 
 let parse_errors () =
   ensure_loaded ();
-  with_pool_lock (fun () -> (!pool).parse_errors)
+  with_pool_lock (fun () -> (Atomic.get pool).parse_errors)
 
 let snapshots () =
   ensure_loaded ();
-  with_pool_lock (fun () -> List.map runtime_to_snapshot (!pool).runtimes)
+  with_pool_lock (fun () ->
+    List.map runtime_to_snapshot (Atomic.get pool).runtimes)
 
 let configured_capacity () =
   snapshots ()
@@ -301,18 +304,26 @@ let allocated_slots () =
        (fun acc (runtime : runtime_snapshot) -> acc + runtime.active_slots)
        0
 
-let measured_ceiling () = with_pool_lock (fun () -> (!pool).measured_ceiling)
+let measured_ceiling () =
+  with_pool_lock (fun () -> (Atomic.get pool).measured_ceiling)
 
 let record_measured_ceiling value =
   with_pool_lock (fun () ->
-    let state = !pool in
+    let state = Atomic.get pool in
     let bounded = max 0 value in
     let new_ceiling =
       match state.measured_ceiling with
       | Some current -> Some (max current bounded)
       | None -> Some bounded
     in
-    pool := { state with measured_ceiling = new_ceiling })
+    Atomic.set pool { state with measured_ceiling = new_ceiling })
+
+module For_testing = struct
+  let install_pool runtimes =
+    let fingerprint = current_fingerprint () in
+    with_pool_lock (fun () ->
+      Atomic.set pool { empty_pool with runtimes; fingerprint })
+end
 
 (* [acquire] / [release] / [model_label_of_assignment] removed 2026-05-05 —
    zero production callers; see [docs/audit-responses/2026-05-05-dashboard-heuristic.md]

--- a/lib/local_runtime_pool/local_runtime_pool.mli
+++ b/lib/local_runtime_pool/local_runtime_pool.mli
@@ -21,12 +21,9 @@
     [docs/audit-responses/2026-05-05-dashboard-heuristic.md]
     §7.1 for the verification matrix.
 
-    Ref-cell architecture: {!pool} is a global [pool_state ref]
-    guarded by an [Eio.Mutex].  The ref is exposed because
-    [test/test_local_runtime_pool.ml] needs to install a
-    custom seed state without rebuilding the discovery cache
-    on every test.  Production code paths reach {!pool}
-    only through the locked accessors below. *)
+    State architecture: the process-global value is an atomic reference to an
+    immutable [pool_state], with compound refreshes serialized by a standard
+    mutex. Production and test code reach it only through typed accessors. *)
 
 (** {1 Runtime + snapshot records} *)
 
@@ -85,22 +82,16 @@ val default_pool_label : string
 (** ["local64"] — the canonical label used when the caller
     does not specify a [preferred_pool]. *)
 
-val empty_pool : pool_state
-(** Zero-valued [pool_state] used as the reset target and
-    the test-seed scaffolding template. *)
-
-val pool : pool_state ref
-(** Global pool ref.  Production code reaches this only
-    through the locked accessors below; the ref is exposed
-    because [test/test_local_runtime_pool.ml] installs a
-    fixed runtime list ([Local_runtime_pool.pool := ...])
-    to drive deterministic acquire / release scenarios. *)
-
 (** {1 Lifecycle} *)
 
 val reset : unit -> unit
-(** Reinstalls {!empty_pool} under the pool lock.  Used by
+(** Reinstalls the empty state under the pool lock.  Used by
     tests to clear state between cases. *)
+
+module For_testing : sig
+  val install_pool : runtime list -> unit
+  (** Install a deterministic runtime snapshot under the pool lock. *)
+end
 
 val current_fingerprint : unit -> string
 (** Stable hash of the current discovery cache snapshot.

--- a/lib/otel_runtime_observables.ml
+++ b/lib/otel_runtime_observables.ml
@@ -88,11 +88,11 @@ let walk_dir_totals root =
   (!bytes, !files)
 ;;
 
-let store_cache : (float * Otel_metrics.sample list) ref = ref (neg_infinity, [])
+let store_cache = Atomic.make (neg_infinity, [])
 
-let store_samples ~masc_root () =
+let rec store_samples ~masc_root () =
   let now = Unix.gettimeofday () in
-  let last, cached = !store_cache in
+  let ((last, cached) as current) = Atomic.get store_cache in
   if now -. last < store_walk_min_interval_sec
   then cached
   else (
@@ -109,8 +109,10 @@ let store_samples ~masc_root () =
           else [])
         watched_store_dirs
     in
-    store_cache := now, samples;
-    samples)
+    let next = now, samples in
+    if Atomic.compare_and_set store_cache current next
+    then samples
+    else store_samples ~masc_root ())
 ;;
 
 let fd_samples () =
@@ -234,13 +236,19 @@ let samples ~masc_root () =
 ;;
 
 let registered = Atomic.make false
+let registration_mu = Stdlib.Mutex.create ()
 
 let register_once ~masc_root () =
-  if not (Atomic.exchange registered true)
-  then Otel_metrics.register_source (fun () -> samples ~masc_root ())
+  if not (Atomic.get registered)
+  then
+    Stdlib.Mutex.protect registration_mu (fun () ->
+      if not (Atomic.get registered)
+      then (
+        Otel_metrics.register_source (fun () -> samples ~masc_root ());
+        Atomic.set registered true))
 ;;
 
 module For_testing = struct
   let samples = samples
-  let reset_store_cache () = store_cache := neg_infinity, []
+  let reset_store_cache () = Atomic.set store_cache (neg_infinity, [])
 end

--- a/lib/prompt_registry/prompt_registry.ml
+++ b/lib/prompt_registry/prompt_registry.ml
@@ -748,13 +748,13 @@ let clear_prompt_override_persisted ~base_path key =
 
 (** Restore overrides from JSON file, applying the same validation as
     [set_override] so that stale or manually-edited entries are rejected. *)
-let restore_failure_observer : (unit -> unit) ref = ref (fun () -> ())
+let restore_failure_observer = Atomic.make (fun () -> ())
 
 let set_restore_failure_observer observer =
-  restore_failure_observer := observer
+  Atomic.set restore_failure_observer observer
 
 let record_override_restore_failure () =
-  !restore_failure_observer ()
+  (Atomic.get restore_failure_observer) ()
 
 let restore_overrides base_path =
   let path =

--- a/lib/runtime/dashboard_agent_core_bridge.ml
+++ b/lib/runtime/dashboard_agent_core_bridge.ml
@@ -1,7 +1,7 @@
 (** See [Dashboard_agent_core_bridge.mli]. *)
 
-let broadcast_hook = ref (fun _json -> ())
-let set_broadcast_hook f = broadcast_hook := f
+let broadcast_hook = Atomic.make (fun _json -> ())
+let set_broadcast_hook f = Atomic.set broadcast_hook f
 
 let per_provider_cap = 200
 let default_duration_ms = 0.0
@@ -129,7 +129,7 @@ let broadcast_sample_entry entry =
         ("ts_unix", `Float recorded_at);
       ]
   in
-  try !broadcast_hook json
+  try Atomic.get broadcast_hook json
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -13,8 +13,11 @@ type agent_core_tool_projector =
   (Yojson.Safe.t -> Tool_result.result) ->
   Agent_core.Tool.t
 
-let agent_core_tool_of_masc_hook : agent_core_tool_projector option ref = ref None
-let set_agent_core_tool_of_masc_hook f = agent_core_tool_of_masc_hook := Some f
+let agent_core_tool_of_masc_hook : agent_core_tool_projector option Atomic.t =
+  Atomic.make None
+
+let set_agent_core_tool_of_masc_hook f =
+  Atomic.set agent_core_tool_of_masc_hook (Some f)
 
 let agent_core_tool_hook_unset_error () =
   Agent_core.Error.Internal
@@ -800,12 +803,10 @@ let prefer_cooperative_probe_error probe_error advanced_result =
 
 module For_testing = struct
   let with_agent_core_tool_of_masc_hook_unset f =
-    let original = !agent_core_tool_of_masc_hook in
+    let original = Atomic.exchange agent_core_tool_of_masc_hook None in
     Fun.protect
-      ~finally:(fun () -> agent_core_tool_of_masc_hook := original)
-      (fun () ->
-         agent_core_tool_of_masc_hook := None;
-         f ())
+      ~finally:(fun () -> Atomic.set agent_core_tool_of_masc_hook original)
+      f
   ;;
 
   let runtime_observation_for_completed_config =
@@ -1331,7 +1332,7 @@ let run_with_masc_tools
   | [] ->
       run ~sw ~net ~config ?on_event ?on_yield ?on_resume goal
   | _ when provider_supports_inline_tools config.provider_cfg ->
-      (match !agent_core_tool_of_masc_hook with
+      (match Atomic.get agent_core_tool_of_masc_hook with
        | None -> Error (agent_core_tool_hook_unset_error ())
        | Some agent_core_tool_of_masc ->
          let agent_core_tools =

--- a/lib/runtime_params.ml
+++ b/lib/runtime_params.ml
@@ -54,7 +54,7 @@ let registry_tbl : (string, erased) Hashtbl.t = Hashtbl.create 64
 
 (** Workspace base path used for automatic persistence and audit.
     Set via [initialize]; optional [?base_path] overrides it per call. *)
-let global_base_path : string option ref = ref None
+let global_base_path = Atomic.make None
 
 (** Eio.Mutex for all mutable state.
     Falls back to lock-free when Eio scheduler is absent (tests, init). *)
@@ -63,10 +63,10 @@ let mu = Eio.Mutex.create ()
 let with_rw f = Eio_guard.with_mutex mu f
 let with_ro f = Eio_guard.with_mutex_ro mu f
 
-let initialize ~base_path = global_base_path := Some base_path
+let initialize ~base_path = Atomic.set global_base_path (Some base_path)
 
 let effective_base_path ?base_path () =
-  match base_path with Some p -> Some p | None -> !global_base_path
+  match base_path with Some p -> Some p | None -> Atomic.get global_base_path
 
 (* ── registration ────────────────────────────────────────────── *)
 

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -785,8 +785,14 @@ let http_status_of_auth_error = function
   | Masc_domain.RateLimitExceeded _ -> `Too_many_requests
   | Masc_domain.CacheError _ -> `Internal_server_error
 
-(** Server state - initialized at startup *)
-let server_state : Mcp_server.server_state option ref = ref None
+(** Server state - initialized at startup.  The published handle is replaced
+    atomically so request domains never race a plain ref read with startup or
+    shutdown publication. *)
+let server_state : Mcp_server.server_state option Atomic.t = Atomic.make None
+
+let current_server_state () = Atomic.get server_state
+let publish_server_state state = Atomic.set server_state (Some state)
+let clear_server_state () = Atomic.set server_state None
 
 (** CORS origin *)
 exception Invalid_origin_header
@@ -939,7 +945,7 @@ let check_agent_rate_limit request reqd =
 let admin_token_equal = Eqaf.equal
 
 let with_admin_auth handler request reqd =
-  match !server_state with
+  match current_server_state () with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
       let admin_token = Env_config_core.admin_token_opt () in
@@ -1141,7 +1147,7 @@ let rec with_public_read handler request reqd =
   if strict && not (is_public_read_path path) then
     with_read_auth handler request reqd
   else
-    match !server_state with
+    match current_server_state () with
     | None -> Http_server_eio.Response.json (not_initialized_response path) reqd
     | Some state -> handler state request reqd
 
@@ -1149,7 +1155,7 @@ and with_observer_sse_read_auth handler request reqd =
   let strict = http_auth_strict_enabled () in
   let path = Http_server_eio.Request.path request in
   if strict && not (is_public_read_path path) then
-    match !server_state with
+    match current_server_state () with
     | None -> Http_server_eio.Response.json (not_initialized_response path) reqd
     | Some state ->
       let base_path = (Mcp_server.workspace_config state).base_path in
@@ -1168,7 +1174,7 @@ and with_observer_sse_read_auth handler request reqd =
     with_public_read handler request reqd
 
 and with_read_auth handler request reqd =
-  match !server_state with
+  match current_server_state () with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
       let base_path = (Mcp_server.workspace_config state).base_path in
@@ -1180,7 +1186,7 @@ and with_read_auth handler request reqd =
       | Error err -> respond_auth_error request reqd err)
 
 and with_permission_auth ~permission handler request reqd =
-  match !server_state with
+  match current_server_state () with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
       let base_path = (Mcp_server.workspace_config state).base_path in
@@ -1192,7 +1198,7 @@ and with_permission_auth ~permission handler request reqd =
       | Error err -> respond_auth_error request reqd err)
 
 and with_tool_auth ~tool_name handler request reqd =
-  match !server_state with
+  match current_server_state () with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
       let base_path = (Mcp_server.workspace_config state).base_path in
@@ -1211,7 +1217,7 @@ and with_tool_auth ~tool_name handler request reqd =
       | Error err -> respond_auth_error request reqd err)
 
 and with_tool_actor_auth ~tool_name handler request reqd =
-  match !server_state with
+  match current_server_state () with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
     let base_path = (Mcp_server.workspace_config state).base_path in
@@ -1230,7 +1236,7 @@ and with_tool_actor_auth ~tool_name handler request reqd =
      | Error err -> respond_auth_error request reqd err)
 
 and with_token_permission_auth ~permission handler request reqd =
-  match !server_state with
+  match current_server_state () with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
       let base_path = (Mcp_server.workspace_config state).base_path in
@@ -1243,4 +1249,6 @@ and with_token_permission_auth ~permission handler request reqd =
 
 module For_testing = struct
   let admin_token_equal = admin_token_equal
+  let snapshot_server_state = current_server_state
+  let restore_server_state state = Atomic.set server_state state
 end

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -244,9 +244,14 @@ val http_status_of_auth_error :
     [H2.Status.t] at the use site — both protocols include this
     six-tag subset. *)
 
-val server_state : Mcp_server.server_state option ref
-(** Process-wide server state handle used by auth helpers when no
-    state is threaded through. *)
+val current_server_state : unit -> Mcp_server.server_state option
+(** Return the currently published process-wide server state snapshot. *)
+
+val publish_server_state : Mcp_server.server_state -> unit
+(** Atomically publish the initialized process-wide server state. *)
+
+val clear_server_state : unit -> unit
+(** Atomically remove the process-wide server state during shutdown/reset. *)
 
 val get_origin : Httpun.Request.t -> Httpun.Headers.value
 (** Return the one syntactically valid serialized [Origin], or ["*"] when the
@@ -449,4 +454,6 @@ val with_token_permission_auth :
 
 module For_testing : sig
   val admin_token_equal : string -> string -> bool
+  val snapshot_server_state : unit -> Mcp_server.server_state option
+  val restore_server_state : Mcp_server.server_state option -> unit
 end

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1229,7 +1229,7 @@ let start_keeper_loops_owned
       Log.Keeper.info
         "broadcast without mention -> keeper wakeup suppressed (passive fanout)"
   in
-  Workspace_broadcast.on_broadcast_mention := broadcast_mention_handler;
+  Workspace_broadcast.set_on_broadcast_mention broadcast_mention_handler;
   (* Orchestrator needs synchronous registration for shutdown hook *)
   (try
      let cancel_orchestrator =

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -42,10 +42,17 @@ let initialized_json_opt = Server_dashboard_http_core_cache.initialized_json_opt
 type operator_snapshot_publication =
   Server_dashboard_http_core_operator.operator_snapshot_publication
 
-let operator_snapshot_broadcast_ref =
-  Server_dashboard_http_core_operator.operator_snapshot_broadcast_ref
+let set_operator_snapshot_broadcaster =
+  Server_dashboard_http_core_operator.set_operator_snapshot_broadcaster
 ;;
-let operator_digest_broadcast_ref = Server_dashboard_http_core_operator.operator_digest_broadcast_ref
+
+let set_operator_digest_broadcaster =
+  Server_dashboard_http_core_operator.set_operator_digest_broadcaster
+;;
+
+let broadcast_operator_snapshot =
+  Server_dashboard_http_core_operator.broadcast_operator_snapshot
+;;
 let operator_snapshot_cache_diagnostics_json =
   Server_dashboard_http_core_operator.operator_snapshot_cache_diagnostics_json
 ;;
@@ -699,7 +706,7 @@ let dashboard_shell_http_json
        @ shell_projection_trace_diagnostics cache_key)
   in
   let startup_shell_bootstrap_pending =
-    let current = Server_startup_state.(!state) in
+    let current = Server_startup_state.snapshot () in
     (not (Atomic.get shell_warmed))
     && current.state_ready
     && Server_startup_state.elapsed_since_start () < dashboard_shell_timeout_s +. startup_grace_period_s

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -43,8 +43,11 @@ val last_good_shell_light : Yojson.Safe.t Atomic.t
 type operator_snapshot_publication =
   Server_dashboard_http_core_operator.operator_snapshot_publication
 
-val operator_snapshot_broadcast_ref : (operator_snapshot_publication -> unit) ref
-val operator_digest_broadcast_ref : (Yojson.Safe.t -> unit) ref
+val set_operator_snapshot_broadcaster :
+  (operator_snapshot_publication -> unit) -> unit
+
+val set_operator_digest_broadcaster : (Yojson.Safe.t -> unit) -> unit
+val broadcast_operator_snapshot : operator_snapshot_publication -> unit
 val mission_cache : cached_surface
 
 (** {1 Dashboard Timeout} *)

--- a/lib/server/server_dashboard_http_core_digest_refresh.ml
+++ b/lib/server/server_dashboard_http_core_digest_refresh.ml
@@ -9,7 +9,7 @@
     ~target_type:"workspace"] under a fresh [Operator_control.context],
     decorates the result with [with_projection_diagnostics] /
     [with_operator_digest_metadata], and republishes via
-    [!operator_digest_broadcast_ref].
+    [broadcast_operator_digest].
 
     Pure helper move (no callback injection). All cross-module
     references reach existing siblings or top-level libraries — no
@@ -97,7 +97,7 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
     ~compute
     ~on_result:(fun json ->
       mark_cached_surface_success Core_operator.operator_digest_cache json;
-      !Core_operator.operator_digest_broadcast_ref
+      Core_operator.broadcast_operator_digest
         (cached_surface_json Core_operator.operator_digest_cache
          |> Core_operator_query.with_operator_digest_metadata
               ~config

--- a/lib/server/server_dashboard_http_core_operator.ml
+++ b/lib/server/server_dashboard_http_core_operator.ml
@@ -23,14 +23,30 @@ type operator_snapshot_compute =
    Default requests read the background-refreshed publication and synchronously
    replace it when stale. Parameterized requests compute directly. *)
 
-(* Late-bound broadcast refs — set by server_dashboard_http.ml after
-   Sse module is in scope.  Same pattern as _broadcast_workspace_truth_ref. *)
-let operator_snapshot_broadcast_ref : (operator_snapshot_publication -> unit) ref =
-  ref (fun (_publication : operator_snapshot_publication) -> ())
+(* Late-bound broadcasters — installed after [Sse] is in scope.  Atomic
+   replacement keeps refresh domains from racing initialization or tests. *)
+let operator_snapshot_broadcaster =
+  Atomic.make (fun (_publication : operator_snapshot_publication) -> ())
 ;;
 
-let operator_digest_broadcast_ref : (Yojson.Safe.t -> unit) ref =
-  ref (fun (_json : Yojson.Safe.t) -> ())
+let operator_digest_broadcaster =
+  Atomic.make (fun (_json : Yojson.Safe.t) -> ())
+;;
+
+let set_operator_snapshot_broadcaster broadcaster =
+  Atomic.set operator_snapshot_broadcaster broadcaster
+;;
+
+let set_operator_digest_broadcaster broadcaster =
+  Atomic.set operator_digest_broadcaster broadcaster
+;;
+
+let broadcast_operator_snapshot publication =
+  (Atomic.get operator_snapshot_broadcaster) publication
+;;
+
+let broadcast_operator_digest json =
+  (Atomic.get operator_digest_broadcaster) json
 ;;
 
 let operator_snapshot_cache =
@@ -293,6 +309,10 @@ let operator_snapshot_extra () =
 ;;
 
 module For_testing = struct
+  let replace_operator_snapshot_broadcaster broadcaster =
+    Atomic.exchange operator_snapshot_broadcaster broadcaster
+  ;;
+
   let publish_operator_snapshot_success ?(fresh_for_s = operator_snapshot_freshness_ttl_s) json =
     let compute = begin_operator_snapshot_compute () in
     publish_operator_snapshot_if_current_with_freshness

--- a/lib/server/server_dashboard_http_core_operator.mli
+++ b/lib/server/server_dashboard_http_core_operator.mli
@@ -15,8 +15,12 @@ type operator_snapshot_compute =
   ; sequence : int
   }
 
-val operator_snapshot_broadcast_ref : (operator_snapshot_publication -> unit) ref
-val operator_digest_broadcast_ref : (Yojson.Safe.t -> unit) ref
+val set_operator_snapshot_broadcaster :
+  (operator_snapshot_publication -> unit) -> unit
+
+val set_operator_digest_broadcaster : (Yojson.Safe.t -> unit) -> unit
+val broadcast_operator_snapshot : operator_snapshot_publication -> unit
+val broadcast_operator_digest : Yojson.Safe.t -> unit
 val operator_snapshot_publication : unit -> operator_snapshot_publication
 val operator_snapshot_publication_with_freshness :
   unit -> operator_snapshot_publication * bool
@@ -49,6 +53,10 @@ val operator_refresh_interval_s : float
 val operator_snapshot_extra : unit -> (string * Yojson.Safe.t) list
 
 module For_testing : sig
+  val replace_operator_snapshot_broadcaster :
+    (operator_snapshot_publication -> unit) ->
+    (operator_snapshot_publication -> unit)
+
   val publish_operator_snapshot_success :
     ?fresh_for_s:float ->
     Yojson.Safe.t ->

--- a/lib/server/server_dashboard_http_core_operator_snapshot_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_snapshot_http.ml
@@ -102,7 +102,7 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
         let publication =
           match Core_operator.mark_operator_snapshot_error_if_current ~compute exn with
           | Some publication ->
-            !Core_operator.operator_snapshot_broadcast_ref publication;
+            Core_operator.broadcast_operator_snapshot publication;
             publication
           | None -> Core_operator.operator_snapshot_publication ()
         in

--- a/lib/server/server_dashboard_http_core_snapshot_refresh.ml
+++ b/lib/server/server_dashboard_http_core_snapshot_refresh.ml
@@ -7,7 +7,7 @@
     cycle invokes [Operator_control.snapshot_json] under a fresh
     [Operator_control.context], decorates the result with
     [with_projection_diagnostics] / [with_operator_snapshot_metadata],
-    and republishes via [!operator_snapshot_broadcast_ref].
+    and republishes via [broadcast_operator_snapshot].
 
     Pure helper move (no callback injection). All cross-module
     references reach existing siblings or top-level libraries — no
@@ -97,7 +97,7 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
        with
        | None -> ()
        | Some publication ->
-         !Core_operator.operator_snapshot_broadcast_ref publication);
+         Core_operator.broadcast_operator_snapshot publication);
       raise exn
   in
   Proactive_refresh.start
@@ -118,5 +118,5 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
       with
       | None -> ()
       | Some publication ->
-        !Core_operator.operator_snapshot_broadcast_ref publication)
+        Core_operator.broadcast_operator_snapshot publication)
 ;;

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -125,8 +125,8 @@ let execution_actor_for_request ~base_path request =
 
 (* Wire operator broadcast refs now that Sse is in scope. *)
 let () =
-  operator_snapshot_broadcast_ref
-  := (fun
+  set_operator_snapshot_broadcaster
+    (fun
        (publication :
          Server_dashboard_http_core_operator.operator_snapshot_publication)
      ->
@@ -157,11 +157,12 @@ let () =
            ~generation
        with
        | None -> ()
-       | Some publication -> !operator_snapshot_broadcast_ref publication)
+       | Some publication -> broadcast_operator_snapshot publication)
 ;;
 
 let () =
-  operator_digest_broadcast_ref := broadcast_cached_surface ~event_type:"operator_digest"
+  set_operator_digest_broadcaster
+    (broadcast_cached_surface ~event_type:"operator_digest")
 ;;
 
 let execution_cache : cached_surface =

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -280,7 +280,7 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
           h2_respond_json_value h2_reqd json ~extra_headers:cors
 
       | `GET, p when String.equal p Server_health_paths.readiness ->
-          let current = Server_startup_state.(!state) in
+          let current = Server_startup_state.snapshot () in
           let json, status =
             if current.state_ready then
               (`Assoc [
@@ -514,7 +514,7 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             else Server_mcp_transport_http.Full
           in
           (* HTTP-level auth check for MCP endpoints *)
-          let base_path = match !server_state with
+          let base_path = match current_server_state () with
             | Some s -> (Mcp_server.workspace_config s).base_path
             | None -> default_base_path ()
           in
@@ -684,7 +684,7 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             then Server_mcp_transport_http.Managed_agent
             else Server_mcp_transport_http.Full
           in
-          let base_path = match !server_state with
+          let base_path = match current_server_state () with
             | Some s -> (Mcp_server.workspace_config s).base_path
             | None -> default_base_path ()
           in
@@ -1074,7 +1074,7 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
                ~config:
                  (Option.map
                     (fun state -> (Mcp_server.workspace_config state))
-                    !server_state)
+                    (current_server_state ()))
                httpun_meth ->
           ()
 

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -77,7 +77,7 @@ let get_protocol_version_for_session =
 
 (** Prefer runtime capabilities captured in [server_state] and only fall back to
     the legacy global Eio context for compatibility with older test helpers. *)
-let current_server_state_opt () = !server_state
+let current_server_state_opt () = current_server_state ()
 
 let state_switch_opt = function
   | Some state -> (
@@ -141,7 +141,7 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
       (fun () ->
         match current_server_state_opt () with
         | None -> false
-        | Some _ -> Server_startup_state.(!state).state_ready);
+        | Some _ -> (Server_startup_state.snapshot ()).state_ready);
     get_runtime_result =
       (fun () ->
         match current_server_state_opt () with

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -479,7 +479,7 @@ let keepers_summary_from_registry ~base_path
   }
 
 let bonsai_api_keepers_summary request reqd =
-  match !server_state with
+  match current_server_state () with
   | None ->
       respond_public_read_json_value
         ~status:`Internal_server_error
@@ -532,7 +532,7 @@ let http_status_of_graphql = function
 
 (** Shared by HTTP/2 gateway handlers that require initialized server state. *)
 let get_server_state_result () =
-  match !server_state with
+  match current_server_state () with
   | Some s -> Ok s
   | None -> Error "server state not initialized"
 

--- a/lib/server/server_routes_http_pages.mli
+++ b/lib/server/server_routes_http_pages.mli
@@ -167,7 +167,7 @@ val serve_dashboard_static :
 
 val get_server_state_result :
   unit -> (Mcp_server.server_state, string) result
-(** Returns [Ok state] when {!Server_auth.server_state}
+(** Returns [Ok state] when {!Server_auth.current_server_state}
     has been wired, [Error "server state not initialized"]
     otherwise.  Used by every handler that needs the
     runtime state to satisfy the request. *)

--- a/lib/server/server_routes_http_routes_multimodal.ml
+++ b/lib/server/server_routes_http_routes_multimodal.ml
@@ -8,9 +8,9 @@ module W = Multimodal.Workspace
 module A = Multimodal.Artifact
 module Aid = Shared_types.Artifact_id
 
-let workspace_getter : (unit -> W.t) ref = ref (fun () -> W.empty)
+let workspace_getter = Atomic.make (fun () -> W.empty)
 
-let bind_workspace_getter f = workspace_getter := f
+let bind_workspace_getter f = Atomic.set workspace_getter f
 
 (* Tier D3 — server-side filter helpers for /api/v1/multimodal/list.
 
@@ -86,7 +86,7 @@ let artifact_passes
   kind_ok && created_by_ok && q_ok
 
 let list_response ?kind_filter ?created_by_filter ?query () =
-  let ws = !workspace_getter () in
+  let ws = Atomic.get workspace_getter () in
   let arts = W.all ws in
   let json_arts = List.map A.any_to_json arts in
   let filtered =
@@ -108,7 +108,7 @@ let list_response ?kind_filter ?created_by_filter ?query () =
 let parse_id id_str = Aid.of_string id_str
 
 let artifact_response ~id_str =
-  let ws = !workspace_getter () in
+  let ws = Atomic.get workspace_getter () in
   match parse_id id_str with
   | Error e ->
       ( `Assoc
@@ -133,7 +133,7 @@ let aid_list_to_json lst =
   `List (List.map (fun a -> `String (Aid.to_string a)) lst)
 
 let provenance_response ~id_str =
-  let ws = !workspace_getter () in
+  let ws = Atomic.get workspace_getter () in
   match parse_id id_str with
   | Error e ->
       ( `Assoc

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -1328,7 +1328,7 @@ let liveness_handler _request reqd =
 
 (** Readiness probe: responds 200 only when server_state is initialized. *)
 let readiness_handler _request reqd =
-  let current = Server_startup_state.(!state) in
+  let current = Server_startup_state.snapshot () in
   if current.state_ready then
     Http.Response.json_value
       (`Assoc

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1190,7 +1190,7 @@ let mark_owner_state_ready () =
   match Server_startup_state.mark_state_ready () with
   | Error error -> Error (Readiness_transition_failed error)
   | Ok () ->
-    let observed = Server_startup_state.(!state) in
+    let observed = Server_startup_state.snapshot () in
     if observed.state_ready then Ok ()
     else
       Error
@@ -1368,7 +1368,7 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
   in
   let socket = Server_bootstrap_http.listen_socket ~sw ~net config in
   Transport_metrics.set_ws_same_origin_runtime_ready false;
-  server_state := None;
+  clear_server_state ();
   Server_startup_state.reset ();
 
   (* 2. Run owner initialization outside the accept loop. The state and
@@ -1380,7 +1380,7 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
     let handle_initialization_failure error =
       match
         startup_failure_disposition
-          ~state_ready:Server_startup_state.(!state).state_ready
+          ~state_ready:(Server_startup_state.snapshot ()).state_ready
       with
       | Fatal_pre_ready ->
         Log.Server.error
@@ -1412,7 +1412,7 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
       (* Authentication wrappers treat [server_state = Some _] as the mutation
          capability boundary. Publish only after transport-neutral activation
          has restored Gate state and started the owner persistence lanes. *)
-      server_state := Some state;
+      publish_server_state state;
       (* Global readiness is the transport-neutral owner capability, not a
          quorum over optional transports. Mark it before starting fallible
          Discord/gRPC/WS/WebRTC/dashboard auxiliaries so one transport cannot
@@ -1703,7 +1703,7 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
     try
       let timeout_sec = Server_startup_state.watchdog_timeout_sec () in
       Eio.Time.sleep clock timeout_sec;
-      let current = Server_startup_state.(!state) in
+      let current = Server_startup_state.snapshot () in
       if not current.state_ready then (
         let elapsed = Server_startup_state.elapsed_since_start () in
         Log.Server.error

--- a/lib/server_base_path_diagnostics.ml
+++ b/lib/server_base_path_diagnostics.ml
@@ -198,12 +198,11 @@ let startup_lines (diag : t) =
   in
   List.filter_map (fun line -> line) lines
 
-let logged_once : bool ref = ref false
+let logged_once = Atomic.make false
 
 let log_startup_warning (diag : t) =
   match diag.warning with
-  | Some message when not !logged_once ->
-      logged_once := true;
+  | Some message when Atomic.compare_and_set logged_once false true ->
       Log.Server.warn "%s%s" message
         (if diag.strict_mode_requested then " (strict mode enabled)" else "")
   | Some message ->

--- a/lib/server_startup_state.ml
+++ b/lib/server_startup_state.ml
@@ -82,6 +82,10 @@ let snapshot () = Atomic.get state
 
 let update f = Atomic_util.update state f
 
+(* NDT-OK: startup elapsed time is operational telemetry and timeout budgeting;
+   wall-clock sampling is confined to this observation boundary. *)
+let wall_clock_now = Unix.gettimeofday
+
 let phase_to_string = function
   | Blocking -> "blocking"
   | Lazy -> "lazy"
@@ -93,7 +97,7 @@ let phase_to_string = function
 let is_live () = true
 
 let elapsed_since_start () =
-  Unix.gettimeofday () -. (snapshot ()).started_at
+  wall_clock_now () -. (snapshot ()).started_at
 
 let watchdog_timeout_sec () = Env_config.Transport.startup_watchdog_sec ()
 
@@ -308,7 +312,7 @@ let to_yojson () =
         | Some value -> value
         | None -> `Null );
       ( "elapsed_sec",
-        `Float (Unix.gettimeofday () -. current.started_at) );
+        `Float (wall_clock_now () -. current.started_at) );
       ("watchdog_timeout_sec", `Float (watchdog_timeout_sec ()));
       ("product", Server_state_product.product_to_json product);
     ]

--- a/lib/server_startup_state.ml
+++ b/lib/server_startup_state.ml
@@ -65,8 +65,7 @@ let of_product (product : Server_state_product.product) (started_at : float)
 
 (* ── State reference ────────────────────────────────────── *)
 
-let state =
-  ref
+let initial_state () =
     {
       phase = Blocking;
       state_ready = false;
@@ -77,7 +76,11 @@ let state =
       started_at = Unix.gettimeofday ();
     }
 
-let update f = state := f !state
+let state = Atomic.make (initial_state ())
+
+let snapshot () = Atomic.get state
+
+let update f = Atomic_util.update state f
 
 let phase_to_string = function
   | Blocking -> "blocking"
@@ -90,7 +93,7 @@ let phase_to_string = function
 let is_live () = true
 
 let elapsed_since_start () =
-  Unix.gettimeofday () -. !state.started_at
+  Unix.gettimeofday () -. (snapshot ()).started_at
 
 let watchdog_timeout_sec () = Env_config.Transport.startup_watchdog_sec ()
 
@@ -101,21 +104,12 @@ let remaining_watchdog_budget_sec ~reserve_sec =
 ;;
 
 let pending_lazy_tasks () =
-  !state.pending_lazy_tasks
+  (snapshot ()).pending_lazy_tasks
 
 (* ── Transitions (with product-state invariant checking) ── *)
 
 let reset () =
-  state :=
-    {
-      phase = Blocking;
-      state_ready = false;
-      pending_lazy_tasks = [];
-      last_error = None;
-      path_diagnostics = None;
-      config_resolution = None;
-      started_at = Unix.gettimeofday ();
-    }
+  Atomic.set state (initial_state ())
 
 let mark_blocking () =
   update (fun current ->
@@ -175,8 +169,8 @@ let state_ready_error_to_string = function
 let transition_error stage reason =
   Error (State_ready_transition_rejected { stage; reason })
 
-let mark_state_ready () =
-  let current = !state in
+let rec mark_state_ready () =
+  let current = snapshot () in
   let open Server_state_product in
   let product = to_product current in
   let after_boot =
@@ -211,13 +205,16 @@ let mark_state_ready () =
   match ready with
   | Error _ as error -> error
   | Ok product ->
-    state :=
+    let next =
       of_product
         product
         current.started_at
         current.path_diagnostics
-        current.config_resolution;
-    Ok ()
+        current.config_resolution
+    in
+    if Atomic.compare_and_set state current next
+    then Ok ()
+    else mark_state_ready ()
 
 type lazy_prepare_error =
   | Lazy_state_transition_rejected of string
@@ -226,8 +223,8 @@ let lazy_prepare_error_to_string = function
   | Lazy_state_transition_rejected reason ->
     "lazy startup barrier transition rejected: " ^ reason
 
-let prepare_lazy_tasks ~tasks =
-  let current = !state in
+let rec prepare_lazy_tasks ~tasks =
+  let current = snapshot () in
   let open Server_state_product in
   let product = to_product current in
   let transition =
@@ -238,13 +235,16 @@ let prepare_lazy_tasks ~tasks =
   match transition with
   | Error reason -> Error (Lazy_state_transition_rejected reason)
   | Ok prepared ->
-    state :=
+    let next =
       of_product
         prepared
         current.started_at
         current.path_diagnostics
-        current.config_resolution;
-    Ok ()
+        current.config_resolution
+    in
+    if Atomic.compare_and_set state current next
+    then Ok ()
+    else prepare_lazy_tasks ~tasks
 
 let finish_lazy_task ~task =
   update (fun current ->
@@ -289,7 +289,7 @@ let note_runtime_resolution ~path_diagnostics ~config_resolution =
 (* ── Serialization ──────────────────────────────────────── *)
 
 let to_yojson () =
-  let current = !state in
+  let current = snapshot () in
   let product = to_product current in
   `Assoc
     [
@@ -307,7 +307,12 @@ let to_yojson () =
         match current.config_resolution with
         | Some value -> value
         | None -> `Null );
-      ("elapsed_sec", `Float (elapsed_since_start ()));
+      ( "elapsed_sec",
+        `Float (Unix.gettimeofday () -. current.started_at) );
       ("watchdog_timeout_sec", `Float (watchdog_timeout_sec ()));
       ("product", Server_state_product.product_to_json product);
     ]
+
+module For_testing = struct
+  let restore snapshot = Atomic.set state snapshot
+end

--- a/lib/server_startup_state.mli
+++ b/lib/server_startup_state.mli
@@ -3,9 +3,9 @@
     and path/config
     resolution snapshots.
 
-    The state is a process-global mutable [ref]. All observers and
-    mutators go through this module so [to_yojson] can render a
-    consistent snapshot. *)
+    The state is a process-global atomic reference to an immutable record.
+    All observers and mutators go through this module so transitions cannot
+    lose concurrent updates and [to_yojson] renders one coherent snapshot. *)
 
 (** {1 Types} *)
 
@@ -18,10 +18,6 @@ type phase =
 (** Wire string: ["blocking" | "lazy" | "ready" | "degraded"]. *)
 val phase_to_string : phase -> string
 
-(** Singleton record. Exposed because a handful of callers use
-    [Server_startup_state.((!state).state_ready)] etc. instead of
-    going through a getter. Prefer {!is_live} / {!to_yojson} /
-    {!elapsed_since_start} for new code. *)
 type t = {
   phase : phase;
   state_ready : bool;
@@ -32,10 +28,8 @@ type t = {
   started_at : float;
 }
 
-(** Process-global state reference. Observers should prefer the
-    typed accessors above; [state] is exposed only to preserve the
-    existing [(!state)] call sites. *)
-val state : t ref
+(** Return the current immutable state snapshot. *)
+val snapshot : unit -> t
 
 (** {1 Observation} *)
 
@@ -74,6 +68,11 @@ val to_yojson : unit -> Yojson.Safe.t
 val reset : unit -> unit
 
 val mark_blocking : unit -> unit
+
+module For_testing : sig
+  val restore : t -> unit
+  (** Restore an exact prior snapshot. Test isolation only. *)
+end
 
 type state_ready_transition_stage =
   | Boot_completion

--- a/lib/shared_audit/envelope.ml
+++ b/lib/shared_audit/envelope.ml
@@ -6,6 +6,8 @@ type t = {
   prev_hash : string option;
 }
 
+(* Audit IDs intentionally use independent per-domain entropy;
+   NDT-OK: nondeterminism is confined to envelope ID generation. *)
 let random_state =
   Domain.DLS.new_key Random.State.make_self_init
 
@@ -14,8 +16,10 @@ let generate_id () =
   let random = Domain.DLS.get random_state in
   let now_ms = Int64.of_float (Unix.gettimeofday () *. 1000.0) in
   let ts_hex = Printf.sprintf "%016Lx" now_ms in
+  (* NDT-OK: these values are opaque identifier entropy, never branch inputs. *)
   let r1 = Random.State.int64 random 0x100000000L in
   let r2 = Random.State.int64 random 0x100000000L in
+  (* NDT-OK: same entropy boundary as the preceding random components. *)
   let r3 = Random.State.int64 random 0x10000L in
   let r_hex = Printf.sprintf "%08Lx%08Lx%04Lx" r1 r2 r3 in
   ts_hex ^ "-" ^ r_hex

--- a/lib/shared_audit/envelope.ml
+++ b/lib/shared_audit/envelope.ml
@@ -6,22 +6,17 @@ type t = {
   prev_hash : string option;
 }
 
-let initialized = ref false
-
-let init_random () =
-  if not !initialized then begin
-    Random.self_init ();
-    initialized := true
-  end
+let random_state =
+  Domain.DLS.new_key Random.State.make_self_init
 
 (* ULID-lite: 16 hex chars timestamp-ms + "-" + 26 hex chars random. *)
 let generate_id () =
-  init_random ();
+  let random = Domain.DLS.get random_state in
   let now_ms = Int64.of_float (Unix.gettimeofday () *. 1000.0) in
   let ts_hex = Printf.sprintf "%016Lx" now_ms in
-  let r1 = Random.int64 0x100000000L in
-  let r2 = Random.int64 0x100000000L in
-  let r3 = Random.int64 0x10000L in
+  let r1 = Random.State.int64 random 0x100000000L in
+  let r2 = Random.State.int64 random 0x100000000L in
+  let r3 = Random.State.int64 random 0x10000L in
   let r_hex = Printf.sprintf "%08Lx%08Lx%04Lx" r1 r2 r3 in
   ts_hex ^ "-" ^ r_hex
 

--- a/lib/subscriptions.ml
+++ b/lib/subscriptions.ml
@@ -61,9 +61,18 @@ type notification = {
 
 (** Subscription store *)
 module SubscriptionStore = struct
-  let subscriptions : (string, subscription) Hashtbl.t = Hashtbl.create 64
-  (* Use Queue for O(1) append instead of O(n) list append *)
-  let pending_notifications : (string, notification Queue.t) Hashtbl.t = Hashtbl.create 64
+  module StringMap = Map.Make (String)
+
+  type state =
+    { subscriptions : subscription StringMap.t
+    ; pending_notifications : notification list StringMap.t
+    }
+
+  let state =
+    Atomic.make
+      { subscriptions = StringMap.empty
+      ; pending_notifications = StringMap.empty
+      }
 
   (** Generate subscription ID *)
   let generate_id () : string =
@@ -78,72 +87,93 @@ module SubscriptionStore = struct
       filter;
       created_at = Time_compat.now ();
     } in
-    Hashtbl.add subscriptions sub.id sub;
+    Atomic_util.update state (fun current ->
+      { current with
+        subscriptions = StringMap.add sub.id sub current.subscriptions
+      });
     Log.Sub.info "%s subscribed to %s" subscriber (resource_type_to_string resource);
     sub
 
   (** Unsubscribe *)
   let unsubscribe (id : string) : bool =
-    if Hashtbl.mem subscriptions id then begin
-      Hashtbl.remove subscriptions id;
-      Hashtbl.remove pending_notifications id;
-      true
-    end else false
+    Lockfree_atomic.update_with_result state (fun current ->
+      if StringMap.mem id current.subscriptions
+      then
+        ( { subscriptions = StringMap.remove id current.subscriptions
+          ; pending_notifications =
+              StringMap.remove id current.pending_notifications
+          }
+        , true )
+      else current, false)
 
   (** Get subscription by ID *)
   let get (id : string) : subscription option =
-    Hashtbl.find_opt subscriptions id
+    StringMap.find_opt id (Atomic.get state).subscriptions
 
   (** Find subscriptions for a resource change *)
   let find_matching ~(resource : resource_type) ~(resource_id : string) : subscription list =
-    Hashtbl.fold (fun _ (sub : subscription) (acc : subscription list) ->
-      if sub.resource = resource then
-        match sub.filter with
-        | None -> sub :: acc  (* No filter = match all *)
-        | Some f when f = resource_id -> sub :: acc
-        | Some f when f = "*" -> sub :: acc
-        | _ -> acc
-      else acc
-    ) subscriptions []
+    StringMap.fold
+      (fun _ (sub : subscription) (acc : subscription list) ->
+        if sub.resource = resource
+        then
+          match sub.filter with
+          | None -> sub :: acc
+          | Some f when f = resource_id -> sub :: acc
+          | Some f when f = "*" -> sub :: acc
+          | _ -> acc
+        else acc)
+      (Atomic.get state).subscriptions
+      []
 
   (** Get all subscriptions for a subscriber *)
   let get_for_subscriber (subscriber : string) : subscription list =
-    Hashtbl.fold (fun _ sub acc ->
-      if sub.subscriber = subscriber then sub :: acc else acc
-    ) subscriptions []
+    StringMap.fold
+      (fun _ sub acc ->
+        if sub.subscriber = subscriber then sub :: acc else acc)
+      (Atomic.get state).subscriptions
+      []
 
   (** Queue notification for a subscription - O(1) with Queue *)
   let queue_notification (sub_id : string) (notif : notification) : unit =
-    let q = match Hashtbl.find_opt pending_notifications sub_id with
-      | Some q -> q
-      | None ->
-        let q = Queue.create () in
-        Hashtbl.add pending_notifications sub_id q;
-        q
-    in
-    Queue.add notif q
+    Atomic_util.update state (fun current ->
+      let pending =
+        Option.value
+          (StringMap.find_opt sub_id current.pending_notifications)
+          ~default:[]
+      in
+      { current with
+        pending_notifications =
+          StringMap.add sub_id (notif :: pending) current.pending_notifications
+      })
 
   (** Pop notifications for a subscription - returns all pending as list *)
   let pop_notifications (sub_id : string) : notification list =
-    match Hashtbl.find_opt pending_notifications sub_id with
-    | Some q ->
-      Hashtbl.remove pending_notifications sub_id;
-      Queue.fold (fun acc n -> n :: acc) [] q |> List.rev
-    | None -> []
+    Lockfree_atomic.update_with_result state (fun current ->
+      match StringMap.find_opt sub_id current.pending_notifications with
+      | Some notifications ->
+        ( { current with
+            pending_notifications =
+              StringMap.remove sub_id current.pending_notifications
+          }
+        , List.rev notifications )
+      | None -> current, [])
 
   (** List all subscriptions *)
   let list_all () : subscription list =
-    Hashtbl.fold (fun _ s acc -> s :: acc) subscriptions []
+    StringMap.fold
+      (fun _ subscription acc -> subscription :: acc)
+      (Atomic.get state).subscriptions
+      []
 
   (** Count subscriptions *)
   let count () : int =
-    Hashtbl.length subscriptions
+    StringMap.cardinal (Atomic.get state).subscriptions
 end
 
 (** Session registry bridge for notification harness.
     When set, notify_change also pushes events to all active agent sessions
     so agents can poll notifications without SSE subscription. *)
-let session_registry_ref : (Yojson.Safe.t -> int) option ref = ref None
+let session_registry : (Yojson.Safe.t -> int) option Atomic.t = Atomic.make None
 
 (** One-shot gate for the "registry not wired" message below. Keeps the
     log from flooding when callers on a hot path (Task.Tool,
@@ -153,19 +183,16 @@ let session_registry_ref : (Yojson.Safe.t -> int) option ref = ref None
 let unwired_warned = Atomic.make false
 
 let set_session_push_fn (fn : Yojson.Safe.t -> int) =
-  (match !session_registry_ref with
+  (match Atomic.exchange session_registry (Some fn) with
    | Some _ -> Log.Sub.warn "WARNING: session push fn already set, overwriting"
    | None -> ());
-  session_registry_ref := Some fn;
-  (* Reset the one-shot gate so a subsequent unwire (if any future
-     code paths clear the ref) would warn again. Current code never
-     clears the ref, but the reset keeps the gate honest. *)
+  (* Reset the one-shot gate so a future explicit unwire would warn again. *)
   Atomic.set unwired_warned false
 
 (** Push a structured event to all active agent sessions.
     Used by modules (e.g. Task.Tool) that lack direct Session.registry access. *)
 let push_event_to_sessions (event : Yojson.Safe.t) : unit =
-  match !session_registry_ref with
+  match Atomic.get session_registry with
   | Some push_fn ->
       (try let _ = push_fn event in ()
        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Sub.error "push_event failed: %s" (Printexc.to_string exn))
@@ -192,7 +219,7 @@ let notify_change ~(resource : resource_type) ~(change : change_type)
     SubscriptionStore.queue_notification sub.id notif
   ) subs;
   (* Bridge: also push to session queues for notification harness *)
-  (match !session_registry_ref with
+  (match Atomic.get session_registry with
    | Some push_fn ->
        let event = `Assoc [
          ("type", `String "masc/notification");

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -13,10 +13,15 @@ type handler = name:string -> args:Yojson.Safe.t -> Tool_result.result
 let registry : (string, handler) Hashtbl.t = Hashtbl.create 256
 
 (** Mutex protecting all mutable state in this module.
-    Uses Eio_guard for dual-mode (pre/post Eio runtime) locking. *)
-let dispatch_mu = Eio.Mutex.create ()
-let with_dispatch_rw f = Eio_guard.with_mutex dispatch_mu f
-let with_dispatch_ro f = Eio_guard.with_mutex_ro dispatch_mu f
+
+    Registration and snapshot reads are short and never perform Eio effects,
+    so a system mutex is the correct cross-domain boundary.  [Eio_guard]
+    deliberately skips locking before the Eio runtime starts and rejects raw
+    Domain callers after startup; either behavior is unsound for this
+    process-global registry. *)
+let dispatch_mu = Stdlib.Mutex.create ()
+let with_dispatch_rw f = Stdlib.Mutex.protect dispatch_mu f
+let with_dispatch_ro f = Stdlib.Mutex.protect dispatch_mu f
 
 (** Register a single tool name → handler mapping. *)
 let register ~tool_name ~(handler : handler) =
@@ -123,6 +128,7 @@ let clear_hooks () =
     First [Reject] wins (short-circuit). [Proceed] replaces args for
     subsequent hooks and the final handler. *)
 let run_pre_hooks ~name ~args =
+  let hooks = with_dispatch_ro (fun () -> !pre_hooks) in
   let rec go current_args = function
     | [] -> (None, current_args)
     | hook :: rest ->
@@ -131,7 +137,7 @@ let run_pre_hooks ~name ~args =
        | Proceed new_args -> go new_args rest
        | Pass -> go current_args rest)
   in
-  go args !pre_hooks
+  go args hooks
 
 (** Run observers in order against the typed dispatch outcome.
     Each hook is invoked for its side-effects; mutation of the
@@ -142,7 +148,8 @@ let run_pre_hooks ~name ~args =
 let run_dispatch_observers
     (outcome : Dispatch_outcome.t)
     (result : Tool_result.result option) : unit =
-  List.iter (fun hook -> hook outcome result) !dispatch_observers
+  let observers = with_dispatch_ro (fun () -> !dispatch_observers) in
+  List.iter (fun hook -> hook outcome result) observers
 
 (** Single dispatch entry. The lifecycle is:
 
@@ -152,11 +159,12 @@ let run_dispatch_observers
       3. registry lookup + handler     (handler exception capture)
       4. observer fan-out              ([run_dispatch_observers]) *)
 let guarded_dispatch ~(token : Tool_token.t) ~args () : Tool_result.result option =
+  let span_wrapper = with_dispatch_ro (fun () -> !span_wrapper_ref) in
   let result, _outcome =
     (* Injected telemetry span wrapper (default identity). The composition
        root registers [Tool_telemetry.with_span] so this lib stays free of
        the Otel/Otel_metric_store stack. *)
-    !span_wrapper_ref
+    span_wrapper
       ~tool_name:token.name
       ~surface:(surface_of_tool_name token.name)
       (fun _trace_id_thunk ->
@@ -165,7 +173,7 @@ let guarded_dispatch ~(token : Tool_token.t) ~args () : Tool_result.result optio
         match run_pre_hooks ~name ~args with
         | (Some _ as blocked, _) -> blocked
         | (None, coerced_args) ->
-          (match Hashtbl.find_opt registry name with
+          (match with_dispatch_ro (fun () -> Hashtbl.find_opt registry name) with
            | Some handler ->
              let start_time = Time_compat.now () in
              (try Some (handler ~name ~args:coerced_args)
@@ -185,10 +193,11 @@ let guarded_dispatch ~(token : Tool_token.t) ~args () : Tool_result.result optio
 ;;
 
 (** Number of registered tool names. *)
-let registered_count () = Hashtbl.length registry
+let registered_count () = with_dispatch_ro (fun () -> Hashtbl.length registry)
 
 (** Check whether a tool name is registered. *)
-let is_registered name = Hashtbl.mem registry name
+let is_registered name =
+  with_dispatch_ro (fun () -> Hashtbl.mem registry name)
 
 (** {2 Module Tag Dispatch}
 

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -60,12 +60,6 @@ type dispatch_observer =
     arm; other arms receive [None].  Observer-only ([unit] return) —
     cannot mutate the outcome. *)
 
-val pre_hooks : pre_hook list ref
-(** Mutable list of registered pre-hooks. *)
-
-val dispatch_observers : dispatch_observer list ref
-(** Mutable list of registered dispatch observers. *)
-
 val register_pre_hook : pre_hook -> unit
 
 val register_dispatch_observer : dispatch_observer -> unit

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -29,7 +29,7 @@ let write_queue_mu = Mutex.create ()
 let write_queue : Yojson.Safe.t Queue.t = Queue.create ()
 let dropped_full_queue = Atomic.make 0
 
-let store_ref : (string * Dated_jsonl.t) option ref = ref None
+let store = Atomic.make None
 
 let with_write_queue_lock f = Mutex.protect write_queue_mu f
 
@@ -48,10 +48,11 @@ let reset_for_testing () =
   if dropped > 0 then
     Log.Metrics.warn "tool_metrics_persist: reset dropped %d queued records" dropped;
   Atomic.set dropped_full_queue 0;
-  store_ref := None
+  Atomic.set store None
 
-let get_or_create_store ~base_path : Dated_jsonl.t =
-  match !store_ref with
+let rec get_or_create_store ~base_path : Dated_jsonl.t =
+  let current = Atomic.get store in
+  match current with
   | Some (cached_path, s) when String.equal cached_path base_path -> s
   | _ ->
     (* RFC-0121: layout SSOT via [Config_dir_resolver.data_dir]. *)
@@ -61,9 +62,10 @@ let get_or_create_store ~base_path : Dated_jsonl.t =
         "tool-metrics"
     in
     Fs_compat.mkdir_p dir;
-    let s = Dated_jsonl.create ~base_dir:dir () in
-    store_ref := Some (base_path, s);
-    s
+    let candidate = Dated_jsonl.create ~base_dir:dir () in
+    if Atomic.compare_and_set store current (Some (base_path, candidate))
+    then candidate
+    else get_or_create_store ~base_path
 
 let enqueue (result : Tool_result.result) =
   let json = record_to_json result in

--- a/lib/tool_telemetry.ml
+++ b/lib/tool_telemetry.ml
@@ -48,20 +48,24 @@ let tool_type_of_name name =
 ;;
 
 let counter_name = "tool_dispatch_total"
-let counter_registered = ref false
+let counter_registered = Atomic.make false
+let counter_registration_mu = Stdlib.Mutex.create ()
 
 let register_metrics () =
-  if not !counter_registered
-  then begin
-    Otel_metric_store.register_counter
-      ~name:counter_name
-      ~help:
-        "Total tool dispatches by tool name, outcome, surface, and tool_type \
-         (RFC-0084 §2.1 4-tuple emission invariant)."
-      ~labels:[ "tool", ""; "outcome", ""; "surface", ""; "tool_type", "" ]
-      ();
-    counter_registered := true
-  end
+  if not (Atomic.get counter_registered)
+  then
+    Stdlib.Mutex.protect counter_registration_mu (fun () ->
+      if not (Atomic.get counter_registered)
+      then begin
+        Otel_metric_store.register_counter
+          ~name:counter_name
+          ~help:
+            "Total tool dispatches by tool name, outcome, surface, and tool_type \
+             (RFC-0084 §2.1 4-tuple emission invariant)."
+          ~labels:[ "tool", ""; "outcome", ""; "surface", ""; "tool_type", "" ]
+          ();
+        Atomic.set counter_registered true
+      end)
 ;;
 
 let with_span ?(force_new_trace_id = false) ?(surface = "unknown") ~tool_name f =

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -15,7 +15,7 @@ let is_non_public name = not (Tool_catalog.is_public_mcp name)
 
 (* -- Store management -- *)
 
-let store_ref : Dated_jsonl.t option ref = ref None
+let store_ref : Dated_jsonl.t option Atomic.t = Atomic.make None
 let source_name = "tool_usage"
 let source_producer = "tool_usage_log"
 let dashboard_surface = "/api/v1/dashboard/tools"
@@ -165,9 +165,9 @@ let init ?cluster_name ~base_path () =
      Fs_compat.mkdir_p dir;
      let retention_days = retention_days () in
      let store = Dated_jsonl.create ~base_dir:dir ?retention_days () in
-     store_ref := Some store
+     Atomic.set store_ref (Some store)
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     store_ref := None;
+     Atomic.set store_ref None;
      Log.Misc.warn "tool_usage_log: init failed: %s" (Stdlib.Printexc.to_string exn);
      record_coverage_gap
        ~masc_root
@@ -200,7 +200,7 @@ let record_to_json ~tool_name ~disposition ~caller =
    the whole surface). Keeper-facing IO-failure handling is supplied at the
    install boundary (lib/server/server_bootstrap_maintenance.ml). *)
 let log_call ~on_io_failure ~tool_name ~disposition ~caller =
-  match !store_ref with
+  match Atomic.get store_ref with
   | None ->
       Log.Misc.debug "tool_usage_log: store not initialized, skipping %s" tool_name
   | Some store ->
@@ -250,7 +250,7 @@ let install ~on_io_failure =
 (* -- Read utilities (for analysis) -- *)
 
 let read_recent ?(n = 10_000) () : Yojson.Safe.t list =
-  match !store_ref with
+  match Atomic.get store_ref with
   | None -> []
   | Some store -> Dated_jsonl.read_recent store n
 

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -246,9 +246,6 @@ type webrtc_status =
   ; connected_channels : int
   }
 
-let grpc_service_name = ref "MascGrpcService"
-let grpc_health_service_name = ref "grpc.health.v1.Health"
-
 let default_webrtc_status () =
   { ice_server_urls = []
   ; pending_offers = 0
@@ -257,11 +254,30 @@ let default_webrtc_status () =
   ; connected_channels = 0
   }
 
-let webrtc_status_callback = ref default_webrtc_status
+type runtime_registrations =
+  { grpc_service_name : string
+  ; grpc_health_service_name : string
+  ; webrtc_status : unit -> webrtc_status
+  }
 
-let register_grpc_service_name name = grpc_service_name := name
-let register_grpc_health_service_name name = grpc_health_service_name := name
-let register_webrtc_status fn = webrtc_status_callback := fn
+let runtime_registrations =
+  Atomic.make
+    { grpc_service_name = "MascGrpcService"
+    ; grpc_health_service_name = "grpc.health.v1.Health"
+    ; webrtc_status = default_webrtc_status
+    }
+
+let register_grpc_service_name name =
+  Atomic_util.update runtime_registrations (fun current ->
+    { current with grpc_service_name = name })
+
+let register_grpc_health_service_name name =
+  Atomic_util.update runtime_registrations (fun current ->
+    { current with grpc_health_service_name = name })
+
+let register_webrtc_status fn =
+  Atomic_util.update runtime_registrations (fun current ->
+    { current with webrtc_status = fn })
 
 let enabled_protocols_json () =
   let protocols =
@@ -275,6 +291,7 @@ let enabled_protocols_json () =
 ;;
 
 let transport_status_json (ctx : http_context) =
+  let registrations = Atomic.get runtime_registrations in
   let grpc_enabled = Env_config.Transport.grpc_enabled () in
   let grpc_port = Env_config.Transport.grpc_port in
   let grpc_reachable =
@@ -284,7 +301,7 @@ let transport_status_json (ctx : http_context) =
     Env_config.Transport.http_auth_strict_env_enabled ()
   in
   let webrtc_enabled = Env_config.Transport.webrtc_enabled () in
-  let w_status = !webrtc_status_callback () in
+  let w_status = registrations.webrtc_status () in
   `Assoc
     [ "streamable_http_default", `Bool true
     ; "legacy_endpoints_deprecated", `Bool true
@@ -308,8 +325,8 @@ let transport_status_json (ctx : http_context) =
              ; "reachable", `Bool grpc_reachable
              ; "listen_status", `String (Atomic.get Transport_metrics.grpc_listen_status)
              ; "port", `Int grpc_port
-             ; "service", `String !grpc_service_name
-             ; "health_service", `String !grpc_health_service_name
+             ; "service", `String registrations.grpc_service_name
+             ; "health_service", `String registrations.grpc_health_service_name
              ]
            @
            if grpc_enabled

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -54,8 +54,13 @@ let emit_message_activity config ~from_agent ~content ~mention
 let broadcast_channel config =
   Printf.sprintf "broadcast:%s:default" (project_prefix config)
 
-let on_broadcast_mention : (string option -> unit) ref =
-  ref (fun _mention -> ())
+type mention_handler = string option -> unit
+
+let on_broadcast_mention : mention_handler Atomic.t =
+  Atomic.make (fun _mention -> ())
+
+let set_on_broadcast_mention handler =
+  Atomic.set on_broadcast_mention handler
 
 let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~content =
   let started_at = Time_compat.now () in
@@ -154,7 +159,7 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
        Log.Misc.error "broadcast publish failed: %s" (Backend_types.show_error e));
   emit_message_activity config ~from_agent:safe_agent ~content:safe_content
     ~mention ();
-  (try !on_broadcast_mention mention
+  (try (Atomic.get on_broadcast_mention) mention
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
      Log.Misc.warn "on_broadcast_mention callback failed: %s"
        (Printexc.to_string exn));
@@ -165,3 +170,8 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
   ; mention
   ; msg_type = safe_msg_type
   }
+
+module For_testing = struct
+  let replace_on_broadcast_mention handler =
+    Atomic.exchange on_broadcast_mention handler
+end

--- a/lib/workspace/workspace_broadcast.mli
+++ b/lib/workspace/workspace_broadcast.mli
@@ -19,8 +19,17 @@ val emit_message_activity : Workspace_utils_backend_setup.config ->
            ?worker_run_id:string ->
            ?evidence_refs:string list -> unit -> unit
 val broadcast_channel : Workspace_utils_backend_setup.config -> string
-val on_broadcast_mention : (string option -> unit) ref
+
+(** Atomically replace the process-wide mention notification handler. *)
+val set_on_broadcast_mention : (string option -> unit) -> unit
+
 val broadcast : ?trace_context:string ->
            ?msg_type:string ->
            Workspace_utils_backend_setup.config ->
            from_agent:string -> content:string -> broadcast_delivery
+
+module For_testing : sig
+  (** Replace the handler and return the prior one. Test isolation only. *)
+  val replace_on_broadcast_mention :
+    (string option -> unit) -> string option -> unit
+end

--- a/lib/workspace/workspace_utils_backend_setup.ml
+++ b/lib/workspace/workspace_utils_backend_setup.ml
@@ -160,13 +160,13 @@ let resolve_requested_base_path path =
       ignored unless it matches the requested path or the test explicitly opts
       in via [MASC_TEST_ALLOW_BASE_PATH_OVERRIDE]
     - otherwise resolve the requested path to its git root *)
-let resolved_base_path_cache : string option ref = ref None
+let resolved_base_path_cache = Atomic.make None
 
 let cache_resolved_base_path path =
-  resolved_base_path_cache := Some path
+  Atomic.set resolved_base_path_cache (Some path)
 
 let resolve_masc_base_path path =
-  match !resolved_base_path_cache with
+  match Atomic.get resolved_base_path_cache with
   | Some cached -> cached
   | None ->
     let requested = resolve_requested_base_path path in

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -62,6 +62,23 @@ let test_envelope_make_basic () =
   check bool "id non-empty" true (String.length e.id > 0);
   check bool "ts > 0" true (e.ts > 0.0)
 
+let test_envelope_ids_unique_across_domains () =
+  let ids_per_domain = 256 in
+  let domains =
+    List.init 4 (fun _ ->
+      Domain.spawn (fun () ->
+        Array.init ids_per_domain (fun _ ->
+          (Env.make ~category:"Concurrent" ~payload:`Null ~prev_hash:None).id)))
+  in
+  let ids =
+    List.map Domain.join domains
+    |> List.map Array.to_list
+    |> List.concat
+  in
+  let unique = List.sort_uniq String.compare ids in
+  check int "all domain-local random ids are unique" (4 * ids_per_domain)
+    (List.length unique)
+
 let test_envelope_canonical_json_deterministic () =
   let e = Env.make
     ~category:"X"
@@ -307,6 +324,8 @@ let () =
   run "Shared_audit" [
     "Envelope", [
       test_case "make basic" `Quick test_envelope_make_basic;
+      test_case "ids unique across domains" `Quick
+        test_envelope_ids_unique_across_domains;
       test_case "canonical_json deterministic" `Quick test_envelope_canonical_json_deterministic;
       test_case "compute_hash deterministic" `Quick test_envelope_compute_hash_deterministic;
       test_case "hash changes with payload" `Quick test_envelope_hash_changes_with_payload;

--- a/test/test_artifacts_endpoint.ml
+++ b/test/test_artifacts_endpoint.ml
@@ -177,11 +177,11 @@ let test_artifact_route_enforces_admin_token () =
       | O.Stored { sha256; _ } -> sha256
       | O.Inline _ -> Alcotest.fail "expected stored artifact"
     in
-    let saved_state = !Server_auth.server_state in
+    let saved_state = Server_auth.For_testing.snapshot_server_state () in
     Fun.protect
-      ~finally:(fun () -> Server_auth.server_state := saved_state)
+      ~finally:(fun () -> Server_auth.For_testing.restore_server_state @@ saved_state)
       (fun () ->
-         Server_auth.server_state :=
+         Server_auth.For_testing.restore_server_state @@
            Some (Masc.Mcp_server.For_testing.create_state ~base_path);
          let router = A.add_routes (Http.Router.create ()) in
          let path = "/api/v1/artifacts/" ^ sha256 in

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -496,6 +496,18 @@ let test_base_path_or_cwd_falls_back_to_cwd () =
       (Config_dir_resolver.current_working_dir ())
       (Config_dir_resolver.base_path_or_cwd ()))
 
+let test_resolve_publishes_one_immutable_snapshot_across_domains () =
+  Config_dir_resolver.reset ();
+  let resolutions =
+    List.init 4 (fun _ -> Domain.spawn Config_dir_resolver.resolve)
+    |> List.map Domain.join
+  in
+  match resolutions with
+  | [] -> fail "expected concurrent resolver snapshots"
+  | first :: rest ->
+    check bool "all domains receive the published snapshot" true
+      (List.for_all (fun resolution -> resolution == first) rest)
+
 let () =
   run "config_dir_resolver"
     [
@@ -520,6 +532,8 @@ let () =
             test_external_config_is_not_a_fallback;
           test_case "does not fallback to legacy me_root repo path" `Quick
             test_no_legacy_me_root_fallback;
+          test_case "publishes one immutable snapshot across domains" `Quick
+            test_resolve_publishes_one_immutable_snapshot_across_domains;
         ] );
       ( "test_env_sanitization",
         [

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1056,15 +1056,17 @@ let test_operator_snapshot_publication_rejects_stale_races () =
   in
   let broadcasts = ref [] in
   let original_broadcast =
-    !(Server_dashboard_http_core_operator.operator_snapshot_broadcast_ref)
+    Server_dashboard_http_core_operator.For_testing
+    .replace_operator_snapshot_broadcaster
+      (fun _publication -> ())
   in
   Fun.protect
     ~finally:(fun () ->
-      Server_dashboard_http_core_operator.operator_snapshot_broadcast_ref
-      := original_broadcast)
+      Server_dashboard_http_core_operator.set_operator_snapshot_broadcaster
+        original_broadcast)
     (fun () ->
-      Server_dashboard_http_core_operator.operator_snapshot_broadcast_ref
-      := (fun publication -> broadcasts := publication :: !broadcasts);
+      Server_dashboard_http_core_operator.set_operator_snapshot_broadcaster
+        (fun publication -> broadcasts := publication :: !broadcasts);
       Dashboard_projection_cache.invalidate_snapshot_json ~config;
       check int "one invalidation publishes exactly once" 1
         (List.length !broadcasts);

--- a/test/test_guarded_dispatch_telemetry.ml
+++ b/test/test_guarded_dispatch_telemetry.ml
@@ -43,8 +43,11 @@ let test_trace_id_thunk_is_callable () =
 ;;
 
 let test_register_metrics_idempotent () =
-  (* Calling twice must not raise (Otel_metric_store would otherwise reject
-     duplicate counter registration). *)
+  (* Concurrent and repeated calls must not raise (Otel_metric_store would
+     otherwise reject duplicate counter registration). *)
+  List.init 4 (fun _ ->
+    Domain.spawn Masc.Tool_telemetry.register_metrics)
+  |> List.iter Domain.join;
   Masc.Tool_telemetry.register_metrics ();
   Masc.Tool_telemetry.register_metrics ();
   (check bool) "register_metrics idempotent across repeated calls" true true

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1767,10 +1767,10 @@ let test_keeper_up_shared_boundary_outlives_calling_turn () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir "cross-keeper-up-lifetime" in
   let target_name = "cross-keeper-target" in
-  let previous_startup_state = !(Masc.Server_startup_state.state) in
+  let previous_startup_state = Masc.Server_startup_state.snapshot () in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Server_startup_state.state := previous_startup_state;
+      Masc.Server_startup_state.For_testing.restore previous_startup_state;
       R.For_testing.clear ();
       cleanup_dir base_dir)
     (fun () ->

--- a/test/test_local_runtime_pool.ml
+++ b/test/test_local_runtime_pool.ml
@@ -27,12 +27,7 @@ let make_runtime ?model ?(max_concurrency = 2) id base_url =
   }
 
 let install_pool runtimes =
-  Local_runtime_pool.pool :=
-    {
-      Local_runtime_pool.empty_pool with
-      runtimes;
-      fingerprint = Local_runtime_pool.current_fingerprint ();
-    }
+  Local_runtime_pool.For_testing.install_pool runtimes
 
 let test_parse_runtime_env () =
   Local_runtime_pool.reset ();

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -300,15 +300,15 @@ let annotation_count router path =
 let setup_state base_path =
   save_auth_config base_path;
   let state = Masc.Mcp_server.For_testing.create_state ~base_path in
-  Server_auth.server_state := Some state;
+  Server_auth.For_testing.restore_server_state @@ Some state;
   state
 ;;
 
 let with_ide_server f =
   with_temp_workspace (fun base_path ->
-    let saved_state = !Server_auth.server_state in
+    let saved_state = Server_auth.For_testing.snapshot_server_state () in
     Fun.protect
-      ~finally:(fun () -> Server_auth.server_state := saved_state)
+      ~finally:(fun () -> Server_auth.For_testing.restore_server_state @@ saved_state)
       (fun () ->
          let state = setup_state base_path in
          let router = Server_ide_http.add_routes (Http.Router.create ()) in

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1312,15 +1312,15 @@ let test_health_json_surfaces_durable_paused_keepers () =
         (write_config_root_keeper_toml config_root)
         [ "durable-paused" ];
       with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-      let previous_state = !Server_auth.server_state in
+      let previous_state = Server_auth.For_testing.snapshot_server_state () in
       Config_dir_resolver.reset ();
       Fun.protect
         ~finally:(fun () ->
-          Server_auth.server_state := previous_state;
+          Server_auth.For_testing.restore_server_state @@ previous_state;
           Config_dir_resolver.reset ())
         (fun () ->
           let state = Mcp_server.For_testing.create_state ~base_path:dir in
-          Server_auth.server_state := Some state;
+          Server_auth.For_testing.restore_server_state @@ Some state;
           let config = (Mcp_server.workspace_config state) in
           write_keeper_meta_exn config
             (make_keeper_meta ~name:"durable-paused" ~trace_id:"trace-paused"
@@ -1506,15 +1506,15 @@ let test_health_json_observes_owner_turn () =
   with_temp_dir "health-keeper-owner-work" (fun dir ->
     let config_root = make_config_root dir in
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let keeper_name = "example" in
         let config = Mcp_server.workspace_config state in
         write_keeper_meta_exn
@@ -1588,17 +1588,17 @@ let test_health_json_surfaces_board_event_collection_failure () =
   with_temp_dir "health-board-event-collection-failure" (fun dir ->
     let config_root = make_config_root dir in
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Keeper_heartbeat_loop_board_events.For_testing.reset ();
     Fun.protect
       ~finally:(fun () ->
         Keeper_heartbeat_loop_board_events.For_testing.reset ();
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let keeper_name = "example" in
         Keeper_heartbeat_loop_board_events.For_testing.record_collection_failure
           ~base_path:dir
@@ -1659,15 +1659,15 @@ let test_keeper_identity_drift_health_json_surfaces_config_meta_split () =
       (Filename.concat (Filename.concat config_root "keepers") "operator.toml")
       "[keeper]\nautoboot_enabled = false\n";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         write_keeper_meta_exn config
           (make_keeper_meta ~name:"masc-improver" ~trace_id:"trace-masc-improver" ());
@@ -1730,15 +1730,15 @@ let test_keeper_identity_drift_treats_explicit_autoboot_base_as_materializable
       "base"
       "default keeper\n";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         write_keeper_meta_exn config
           (make_keeper_meta ~name:"base" ~trace_id:"trace-base" ());
@@ -1764,15 +1764,15 @@ let test_health_json_reports_unclassified_timeout_pause_without_mutation () =
   with_temp_dir "health-timeout-paused-without-policy" (fun dir ->
     let config_root = make_config_root dir in
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = (Mcp_server.workspace_config state) in
         let timeout_paused =
           { (make_keeper_meta
@@ -1816,15 +1816,15 @@ let test_health_json_reports_dormant_task_owner_as_advisory () =
       (Filename.concat (Filename.concat config_root "keepers") "executor.toml")
       "[keeper]\nautoboot_enabled = false\n";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let executor =
           make_keeper_meta ~name:"executor" ~trace_id:"trace-executor" ()
@@ -1892,15 +1892,15 @@ let test_health_json_ignores_stale_active_task_alias_when_agent_executable () =
     Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
     List.iter (write_config_root_keeper_toml config_root) [ "executor"; "executor-stale" ];
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let executor =
           make_keeper_meta ~name:"executor" ~trace_id:"trace-executor" ()
@@ -2000,15 +2000,15 @@ let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
     let config_root = make_config_root dir in
     Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let assignee = "missing-keeper-agent" in
         let task =
@@ -2095,15 +2095,15 @@ let test_health_json_keeps_awaiting_verification_in_system_llm_lane () =
     let config_root = make_config_root dir in
     Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let task =
           make_task
@@ -2214,15 +2214,15 @@ let test_health_json_reports_non_keeper_active_task_owner_as_advisory () =
     let config_root = make_config_root dir in
     Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let assignee = "codex-mcp-client" in
         (match
@@ -2290,15 +2290,15 @@ let test_health_json_preserves_active_task_owner_meta_read_error () =
     Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
     write_config_root_keeper_toml config_root "broken";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         write_file (Keeper_types_profile.keeper_meta_path config "broken")
           "{ invalid keeper meta";
@@ -2368,12 +2368,12 @@ let test_health_json_preserves_active_task_owner_meta_read_error () =
 
 let test_health_json_degrades_recovery_backed_owner_scan () =
   with_temp_dir "health-recovery-backed-owner-scan" (fun dir ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Fun.protect
-      ~finally:(fun () -> Server_auth.server_state := previous_state)
+      ~finally:(fun () -> Server_auth.For_testing.restore_server_state @@ previous_state)
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         Workspace.write_backlog config
           {
@@ -2429,15 +2429,15 @@ let test_health_json_reuses_canonical_owner_execution_snapshot () =
   with_temp_dir "health-canonical-owner-execution-snapshot" (fun dir ->
     let config_root = make_config_root dir in
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let cached_missing =
           make_keeper_meta
@@ -2543,11 +2543,11 @@ let test_health_json_reuses_canonical_owner_execution_snapshot () =
 ;;
 
 let test_health_json_capacity_uses_execution_snapshot () =
-  let previous_state = !Server_auth.server_state in
+  let previous_state = Server_auth.For_testing.snapshot_server_state () in
   Fun.protect
-    ~finally:(fun () -> Server_auth.server_state := previous_state)
+    ~finally:(fun () -> Server_auth.For_testing.restore_server_state @@ previous_state)
     (fun () ->
-      Server_auth.server_state := None;
+      Server_auth.For_testing.restore_server_state @@ None;
       let running_names = [ "running-a"; "running-b"; "running-c" ] in
       let recovering_names =
         [ "recovering-a"; "recovering-b"; "recovering-c"; "recovering-d" ]
@@ -2616,15 +2616,15 @@ let test_health_json_degrades_when_only_one_running_phase_lane_is_live () =
         "capacity-missing";
       ];
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = (Mcp_server.workspace_config state) in
         let paused =
           make_keeper_meta ~name:"capacity-paused" ~trace_id:"trace-capacity-paused"
@@ -2783,15 +2783,15 @@ let test_health_json_exposes_closed_non_executable_causes () =
     let names = [ "fiber-dead"; "lane-exited"; "completion-settled" ] in
     List.iter (write_config_root_keeper_toml config_root) names;
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let metas =
           List.map
@@ -2868,15 +2868,15 @@ let test_health_json_keeps_in_flight_running_keeper_executable () =
     let keeper_name = "in-flight-running" in
     write_config_root_keeper_toml config_root keeper_name;
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let meta =
           make_keeper_meta
@@ -2946,15 +2946,15 @@ let test_health_json_blocked_count_matches_blocked_names_with_non_target_capacit
       (write_config_root_keeper_toml config_root)
       [ "target-missing"; "target-running" ];
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let target_running =
           make_keeper_meta ~name:"target-running" ~trace_id:"trace-target-running" ()
@@ -2992,15 +2992,15 @@ let test_health_json_exposes_disabled_keeper_bootstrap_blocker () =
     let config_root = make_config_root dir in
     write_config_root_keeper_toml config_root "boot-disabled";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = (Mcp_server.workspace_config state) in
         let phase_counts :
             Server_routes_http_runtime_fleet_scan.keeper_phase_counts =
@@ -3065,15 +3065,15 @@ let test_health_json_ignores_persisted_only_keeper_for_capacity_target () =
   with_temp_dir "health-persisted-only-keeper-target" (fun dir ->
     let config_root = make_config_root dir in
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = (Mcp_server.workspace_config state) in
         write_keeper_meta_exn config
           (make_keeper_meta ~name:"retired-keeper" ~trace_id:"trace-retired" ());
@@ -3105,15 +3105,15 @@ let test_health_json_explains_phase_paused_capacity_blocker () =
     let config_root = make_config_root dir in
     write_config_root_keeper_toml config_root "phase-paused";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = (Mcp_server.workspace_config state) in
         let phase_paused =
           make_keeper_meta ~name:"phase-paused" ~trace_id:"trace-phase-paused" ()
@@ -3150,15 +3150,15 @@ let test_health_json_exposes_dead_keeper_registry_cause () =
     let config_root = make_config_root dir in
     write_config_root_keeper_toml config_root "phase-dead";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = (Mcp_server.workspace_config state) in
         let phase_dead =
           make_keeper_meta ~name:"phase-dead" ~trace_id:"trace-phase-dead" ()
@@ -3239,15 +3239,15 @@ let test_health_json_explains_terminal_capacity_blocker
     let config_root = make_config_root dir in
     write_config_root_keeper_toml config_root keeper_name;
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let terminal = make_keeper_meta ~name:keeper_name ~trace_id () in
         write_keeper_meta_exn config terminal;
@@ -3313,15 +3313,15 @@ let test_health_json_distinguishes_failing_executable_keepers () =
       (write_config_root_keeper_toml config_root)
       [ "capacity-paused"; "capacity-failing" ];
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = (Mcp_server.workspace_config state) in
         let paused =
           make_keeper_meta ~name:"capacity-paused" ~trace_id:"trace-capacity-paused"
@@ -3365,15 +3365,15 @@ let test_health_json_explains_nonrecoverable_failing_keeper () =
     let config_root = make_config_root dir in
     write_config_root_keeper_toml config_root "capacity-failing";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = (Mcp_server.workspace_config state) in
         let failing =
           make_keeper_meta ~name:"capacity-failing"
@@ -3433,15 +3433,15 @@ let test_health_json_redacts_registry_failure_reason () =
     let config_root = make_config_root dir in
     write_config_root_keeper_toml config_root "secret-failing";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let failing =
           make_keeper_meta ~name:"secret-failing" ~trace_id:"trace-secret" ()
@@ -3508,15 +3508,15 @@ let test_health_json_uses_crash_log_when_restore_clears_failure_reason () =
     let config_root = make_config_root dir in
     write_config_root_keeper_toml config_root "restored-crash-log";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
-    let previous_state = !Server_auth.server_state in
+    let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
     Fun.protect
       ~finally:(fun () ->
-        Server_auth.server_state := previous_state;
+        Server_auth.For_testing.restore_server_state @@ previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
+        Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let restored =
           make_keeper_meta ~name:"restored-crash-log"
@@ -3567,11 +3567,11 @@ let test_health_json_uses_crash_log_when_restore_clears_failure_reason () =
               (row |> member "last_failure_reason" |> to_string))))
 
 let test_health_json_reaction_ledger_unavailable_shape () =
-  let previous_state = !Server_auth.server_state in
+  let previous_state = Server_auth.For_testing.snapshot_server_state () in
   Fun.protect
-    ~finally:(fun () -> Server_auth.server_state := previous_state)
+    ~finally:(fun () -> Server_auth.For_testing.restore_server_state @@ previous_state)
     (fun () ->
-       Server_auth.server_state := None;
+       Server_auth.For_testing.restore_server_state @@ None;
        let request = Httpun.Request.create `GET "/health" in
        let json = Server_routes_http_runtime.make_health_json request in
        let open Yojson.Safe.Util in
@@ -3605,11 +3605,11 @@ let test_health_json_reaction_ledger_unavailable_shape () =
           |> List.length))
 
 let test_health_json_owner_unavailable_shape () =
-  let previous_state = !Server_auth.server_state in
+  let previous_state = Server_auth.For_testing.snapshot_server_state () in
   Fun.protect
-    ~finally:(fun () -> Server_auth.server_state := previous_state)
+    ~finally:(fun () -> Server_auth.For_testing.restore_server_state @@ previous_state)
     (fun () ->
-       Server_auth.server_state := None;
+       Server_auth.For_testing.restore_server_state @@ None;
        let request = Httpun.Request.create `GET "/health" in
        let json = Server_routes_http_runtime.make_health_json request in
        let open Yojson.Safe.Util in
@@ -3762,16 +3762,16 @@ let test_health_response_full_query_uses_snapshot_cache () =
       let config_root = make_config_root dir in
       with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
       with_config_input "MASC_BASE_PATH" (Some dir) @@ fun () ->
-      let previous_state = !Server_auth.server_state in
+      let previous_state = Server_auth.For_testing.snapshot_server_state () in
       Config_dir_resolver.reset ();
       Server_routes_http_runtime.For_testing.reset_full_health_snapshot ();
       Fun.protect
         ~finally:(fun () ->
-          Server_auth.server_state := previous_state;
+          Server_auth.For_testing.restore_server_state @@ previous_state;
           Config_dir_resolver.reset ();
           Server_routes_http_runtime.For_testing.reset_full_health_snapshot ())
         (fun () ->
-          Server_auth.server_state := Some (Mcp_server.For_testing.create_state ~base_path:dir);
+          Server_auth.For_testing.restore_server_state @@ Some (Mcp_server.For_testing.create_state ~base_path:dir);
           let request = Httpun.Request.create `GET "/health?full=1" in
           let first =
             Server_routes_http_runtime.make_health_response_json request
@@ -4024,7 +4024,7 @@ let test_startup_state_catalog_degraded_survives_lazy_activation () =
   Server_startup_state.mark_degraded
     ~error:"startup catalog validation failed: synthetic";
   Server_startup_state.finish_lazy_task ~task:"restore_sessions";
-  let current = Server_startup_state.(!state) in
+  let current = Server_startup_state.snapshot () in
   Alcotest.(check string) "phase stays degraded after lazy task completes"
     "degraded"
     (Server_startup_state.phase_to_string current.phase);
@@ -4035,6 +4035,35 @@ let test_startup_state_catalog_degraded_survives_lazy_activation () =
     (Some "startup catalog validation failed: synthetic")
     current.last_error
 
+let test_startup_state_concurrent_lazy_completions_preserve_all_updates () =
+  let previous = Server_startup_state.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Server_startup_state.For_testing.restore previous)
+    (fun () ->
+      let tasks = List.init 4 (Printf.sprintf "lazy-%d") in
+      for _iteration = 1 to 32 do
+        Server_startup_state.reset ();
+        Server_startup_state.mark_state_ready () |> Result.get_ok;
+        Server_startup_state.prepare_lazy_tasks ~tasks |> Result.get_ok;
+        let ready = Atomic.make 0 in
+        let workers =
+          List.map
+            (fun task ->
+              Domain.spawn (fun () ->
+                ignore (Atomic.fetch_and_add ready 1 : int);
+                while Atomic.get ready < List.length tasks do
+                  Domain.cpu_relax ()
+                done;
+                Server_startup_state.finish_lazy_task ~task))
+            tasks
+        in
+        List.iter Domain.join workers;
+        Alcotest.(check (list string))
+          "all concurrent completions are retained"
+          []
+          (Server_startup_state.pending_lazy_tasks ())
+      done)
+
 let test_startup_state_liveness () =
   Server_startup_state.reset ();
   Alcotest.(check bool) "is_live returns true even during init" true
@@ -4044,7 +4073,7 @@ let test_startup_state_liveness () =
 
 let test_startup_state_readiness_before_init () =
   Server_startup_state.reset ();
-  let current = Server_startup_state.(!state) in
+  let current = Server_startup_state.snapshot () in
   Alcotest.(check bool) "not ready before init" false current.state_ready;
   Alcotest.(check string) "phase is blocking" "blocking"
     (Server_startup_state.phase_to_string current.phase)
@@ -4053,19 +4082,19 @@ let test_startup_state_readiness_after_init () =
   Server_startup_state.reset ();
   Server_startup_state.mark_state_ready ()
   |> Result.get_ok;
-  let current = Server_startup_state.(!state) in
+  let current = Server_startup_state.snapshot () in
   Alcotest.(check bool) "ready after init" true current.state_ready;
   Alcotest.(check string) "phase is ready" "ready"
     (Server_startup_state.phase_to_string current.phase)
 
 let test_mcp_transport_requires_explicit_readiness () =
-  let previous_state = !Server_auth.server_state in
+  let previous_state = Server_auth.For_testing.snapshot_server_state () in
   Fun.protect
-    ~finally:(fun () -> Server_auth.server_state := previous_state)
+    ~finally:(fun () -> Server_auth.For_testing.restore_server_state @@ previous_state)
     (fun () ->
        Server_startup_state.reset ();
        Server_startup_state.mark_blocking ();
-       Server_auth.server_state :=
+       Server_auth.For_testing.restore_server_state @@
          Some
            (Mcp_server.For_testing.create_state
               ~base_path:(Filename.get_temp_dir_name ()));
@@ -4092,7 +4121,7 @@ let test_startup_state_lazy_inventory_does_not_publish_readiness () =
    | Error error ->
      Alcotest.fail
        (Server_startup_state.lazy_prepare_error_to_string error));
-  let current = Server_startup_state.(!state) in
+  let current = Server_startup_state.snapshot () in
   Alcotest.(check bool) "lazy inventory remains not ready" false current.state_ready;
   Alcotest.(check string) "startup remains blocking" "blocking"
     (Server_startup_state.phase_to_string current.phase);
@@ -4102,7 +4131,7 @@ let test_startup_state_lazy_inventory_does_not_publish_readiness () =
     current.pending_lazy_tasks;
   Server_startup_state.mark_state_ready ()
   |> Result.get_ok;
-  let ready = Server_startup_state.(!state) in
+  let ready = Server_startup_state.snapshot () in
   Alcotest.(check bool) "consumer ACK may publish readiness" true ready.state_ready;
   Alcotest.(check string) "pending lazy work projects lazy phase" "lazy"
     (Server_startup_state.phase_to_string ready.phase)
@@ -5161,6 +5190,10 @@ let () =
             "startup catalog degradation survives lazy activation"
             `Quick
             test_startup_state_catalog_degraded_survives_lazy_activation;
+          Alcotest.test_case
+            "startup state retains concurrent lazy completions"
+            `Quick
+            test_startup_state_concurrent_lazy_completions_preserve_all_updates;
           Alcotest.test_case "liveness probe is always true" `Quick
             test_startup_state_liveness;
           Alcotest.test_case

--- a/test/test_subscriptions.ml
+++ b/test/test_subscriptions.ml
@@ -252,6 +252,65 @@ let hook_tests = [
   "notify_message", `Quick, test_notify_message;
 ]
 
+let test_concurrent_notification_queue_preserves_every_event () =
+  let sub =
+    Subscriptions.SubscriptionStore.subscribe
+      ~subscriber:"concurrent-notification-test"
+      ~resource:(Subscriptions.Custom "concurrent")
+      ()
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Subscriptions.SubscriptionStore.unsubscribe sub.id : bool))
+    (fun () ->
+      let domain_count = 4 in
+      let events_per_domain = 64 in
+      let ready = Atomic.make 0 in
+      let workers =
+        List.init domain_count (fun domain_index ->
+          Domain.spawn (fun () ->
+            ignore (Atomic.fetch_and_add ready 1 : int);
+            while Atomic.get ready < domain_count do
+              Domain.cpu_relax ()
+            done;
+            for event_index = 1 to events_per_domain do
+              let resource_id =
+                Printf.sprintf "%d:%d" domain_index event_index
+              in
+              Subscriptions.SubscriptionStore.queue_notification
+                sub.id
+                { subscription_id = sub.id
+                ; resource = Subscriptions.Custom "concurrent"
+                ; change = Subscriptions.Updated
+                ; resource_id
+                ; data = `String resource_id
+                ; timestamp = 0.0
+                }
+            done))
+      in
+      List.iter Domain.join workers;
+      let notifications =
+        Subscriptions.SubscriptionStore.pop_notifications sub.id
+      in
+      check int "every concurrent event retained"
+        (domain_count * events_per_domain)
+        (List.length notifications);
+      let ids =
+        notifications
+        |> List.map (fun (notification : Subscriptions.notification) ->
+          notification.resource_id)
+        |> List.sort_uniq String.compare
+      in
+      check int "every concurrent event remains distinct"
+        (domain_count * events_per_domain)
+        (List.length ids))
+
+let concurrency_tests =
+  [ ( "concurrent queue retains every event"
+    , `Quick
+    , test_concurrent_notification_queue_preserves_every_event )
+  ]
+
 let () =
   run "Subscriptions" [
     "types", type_tests;
@@ -260,4 +319,5 @@ let () =
     "notification", notification_tests;
     "json", json_tests;
     "hooks", hook_tests;
+    "concurrency", concurrency_tests;
   ]

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -197,6 +197,37 @@ let () =
               check bool "contains error info" true
                 (String.length msg > 0 && Astring.String.is_infix ~affix:"boom" msg));
         ] );
+      ( "immutable_registry_snapshots",
+        [
+          test_case "concurrent registration and lookup stay coherent" `Quick
+            (fun () ->
+              let registrations_per_domain = 24 in
+              let domains =
+                List.init 4 (fun domain_index ->
+                  Domain.spawn (fun () ->
+                    for registration_index = 1 to registrations_per_domain do
+                      let tool_name =
+                        Printf.sprintf "__test_dispatch_concurrent_%d_%d"
+                          domain_index registration_index
+                      in
+                      Tool_dispatch.register ~tool_name ~handler:echo_handler;
+                      if not (Tool_dispatch.is_registered tool_name) then
+                        Alcotest.failf "registered handler %s was not visible"
+                          tool_name
+                    done))
+              in
+              List.iter Domain.join domains;
+              for domain_index = 0 to 3 do
+                for registration_index = 1 to registrations_per_domain do
+                  let tool_name =
+                    Printf.sprintf "__test_dispatch_concurrent_%d_%d"
+                      domain_index registration_index
+                  in
+                  check bool "registered snapshot contains handler" true
+                    (Tool_dispatch.is_registered tool_name)
+                done
+              done);
+        ] );
       (* PR-S3: the OTel/Otel_metric_store span wrapper is injected, not referenced
          inline. These tests assert the injection MECHANISM fires — they prove
          guarded_dispatch routes through [!span_wrapper_ref], so registering

--- a/test/test_validation_coverage.ml
+++ b/test/test_validation_coverage.ml
@@ -173,6 +173,24 @@ let test_rejection_stats_increment () =
   check int "exactly 2 rejections" 2 count;
   check bool "time > 0" true (time > 0.0)
 
+let test_rejection_stats_concurrent_snapshot () =
+  Validation.reset_rejection_stats ();
+  let writes_per_domain = 8 in
+  let domains =
+    List.init 4 (fun domain_index ->
+      Domain.spawn (fun () ->
+        for write_index = 1 to writes_per_domain do
+          ignore
+            (Validation.Agent_id.validate
+               (Printf.sprintf "invalid/%d/%d" domain_index write_index))
+        done))
+  in
+  List.iter Domain.join domains;
+  let count, last_rejection_time = Validation.get_rejection_stats () in
+  check int "no concurrent increments lost" (4 * writes_per_domain) count;
+  check bool "snapshot timestamp accompanies count" true
+    (last_rejection_time > 0.0)
+
 (* ============================================================
    Edge Cases
    ============================================================ *)
@@ -305,6 +323,8 @@ let () =
     "rejection_stats", [
       test_case "reset" `Quick test_reset_rejection_stats;
       test_case "increment" `Quick test_rejection_stats_increment;
+      test_case "concurrent immutable snapshot" `Quick
+        test_rejection_stats_concurrent_snapshot;
     ];
     "edge_cases", [
       test_case "agent max length" `Quick test_agent_id_max_length;

--- a/test/test_workspace_messages_raw.ml
+++ b/test/test_workspace_messages_raw.ml
@@ -67,11 +67,14 @@ let test_get_messages_raw_large_history_keeps_newest_window () =
 let test_repeated_mention_delivers_each_canonical_event () =
   with_test_env (fun config ->
     let previous_activity = Atomic.get Workspace_hooks.activity_emit_fn in
-    let previous_wake = !Workspace_broadcast.on_broadcast_mention in
+    let previous_wake =
+      Workspace_broadcast.For_testing.replace_on_broadcast_mention
+        (fun _mention -> ())
+    in
     Eio.Switch.run @@ fun sw ->
     Eio.Switch.on_release sw (fun () ->
       Atomic.set Workspace_hooks.activity_emit_fn previous_activity;
-      Workspace_broadcast.on_broadcast_mention := previous_wake);
+      Workspace_broadcast.set_on_broadcast_mention previous_wake);
     let publications = ref [] in
     let activities = ref [] in
     let wakes = ref [] in
@@ -91,7 +94,7 @@ let test_repeated_mention_delivers_each_canonical_event () =
             subject
         in
         activities := (kind, subject) :: !activities);
-    Workspace_broadcast.on_broadcast_mention :=
+    Workspace_broadcast.set_on_broadcast_mention
       (fun mention -> wakes := mention :: !wakes);
     let content = "@gemini review the canonical event" in
     ignore (Workspace.broadcast config ~from_agent:"claude" ~content);


### PR DESCRIPTION
## Summary

- Replace unsynchronized process-global refs and sibling cells with atomic immutable snapshots.
- Close raw mutable APIs behind typed setters, snapshots, and test helpers.
- Use `Stdlib.Mutex` or CAS at cross-domain boundaries and domain-local RNG where appropriate.

## Root cause

Several process-global states used plain refs or multiple independently updated cells while request and worker domains could observe them concurrently. That allowed lost updates, mixed snapshots, and public mutation bypasses.

## Impact

- Startup, auth, transport, telemetry, and logging state now publish coherently.
- Concurrent subscriptions and lazy startup completions retain all updates.
- Existing unrelated changes in the root worktree are excluded from this PR.

## Validation

- `dune build @check --display=quiet`
- Focused suites passed: validation (44), tool dispatch (15), config resolver (37), eval calibration (38), transport read model (17), subscriptions (19), shared audit (21), keeper tool-call log (33), selected bootstrap (72), and related suites.
- Post-rebase concurrency regressions passed for validation rejection stats, tool registry snapshots, subscription queues, and startup lazy completions.
- Known unrelated stale Keeper-health contract cases were excluded from the focused bootstrap run.
