### PR TITLE
refactor(ide): annotation_kind 이중 축을 observation bus 타입으로 수렴

### DIFF
--- a/lib/ide/ide_annotation_types.ml
+++ b/lib/ide/ide_annotation_types.ml
@@ -12,32 +12,22 @@ let string_opt_to_json = function
   | Some s -> `String s
 ;;
 
+(* Equality re-declaration of the observation bus's kind, same pattern as
+   {!annotation_reference} below: one variant, one codec, and the compiler
+   proves every consumer against the single axis. This module used to carry
+   its own copy of the type plus both codecs, which forced a hand-written
+   4-arm converter at the ide_bridge boundary — three artifacts that had to
+   move in lockstep with the bus on every new kind. *)
 type annotation_kind =
+  Agent_observation.annotation_kind =
   | Comment
   | Decision
   | Question
   | Bookmark
 [@@deriving show, eq]
 
-(** Stable wire format for {!annotation_kind}.  Pair-counterpart to
-    {!annotation_kind_of_string}; together they round-trip the JSON
-    [kind] field on annotation records.  Locks the contract against
-    [@@deriving show] template drift (and against accidental
-    constructor renames — both directions must update in lockstep). *)
-let annotation_kind_to_string = function
-  | Comment -> "Comment"
-  | Decision -> "Decision"
-  | Question -> "Question"
-  | Bookmark -> "Bookmark"
-;;
-
-let annotation_kind_of_string = function
-  | "Comment" -> Some Comment
-  | "Decision" -> Some Decision
-  | "Question" -> Some Question
-  | "Bookmark" -> Some Bookmark
-  | _ -> None
-;;
+let annotation_kind_to_string = Agent_observation.annotation_kind_to_string
+let annotation_kind_of_string = Agent_observation.annotation_kind_of_string
 
 type annotation_reference = Agent_observation.annotation_reference =
   { relation : string

--- a/lib/ide/ide_annotation_types.mli
+++ b/lib/ide/ide_annotation_types.mli
@@ -1,6 +1,10 @@
 (** Shared IDE annotation and code-region wire types. *)
 
+(** Equality re-declaration of {!Agent_observation.annotation_kind} — the
+    observation bus owns the axis; this module re-exports it (and its codec)
+    the same way it already shares {!annotation_reference}. *)
 type annotation_kind =
+  Agent_observation.annotation_kind =
   | Comment
   | Decision
   | Question

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -341,13 +341,6 @@ let now_ms () =
   Int64.of_float (Unix.gettimeofday () *. 1000.0)
 ;;
 
-let annotation_kind_to_ide = function
-  | Agent_observation.Comment -> Ide_annotation_types.Comment
-  | Agent_observation.Decision -> Ide_annotation_types.Decision
-  | Agent_observation.Question -> Ide_annotation_types.Question
-  | Agent_observation.Bookmark -> Ide_annotation_types.Bookmark
-;;
-
 (* Tail-read at most [scan_budget] newest rows for one kind, then filter.
    Replaces the previous whole-file [fold_jsonl_lines] fold (O(file size))
    with a segment tail-read (O(scan_budget)). Order of the result is not
@@ -835,7 +828,7 @@ let install_agent_observation_sinks () =
           ~file_path
           ~line_start
           ~line_end
-          ~kind:(annotation_kind_to_ide kind)
+          ~kind
           ~content
           ?goal_id
           ?task_id


### PR DESCRIPTION
## 무엇

한 개념 축(annotation kind)이 **5개 산출물**로 구현돼 있었습니다: 동일 variant 선언 2벌 + 동일 문자열 코덱 2벌 + 두 타입 사이 4-arm 수동 변환(`ide_bridge.ml annotation_kind_to_ide`). 새 kind 하나를 추가하면 다섯 지점이 동시 이동해야 하고, 하나라도 빠지면 경계에서 침묵 소실 — #28169가 라이브에서 보여준 것과 같은 드리프트 모양입니다.

`annotation_reference`가 이미 쓰는 동등 재선언 패턴을 kind에 적용: ide 타입을 `= Agent_observation.annotation_kind =`로 접고 코덱 재수출, 변환 함수 삭제(호출부는 값 그대로 통과). **-22/+19 순삭제**이며 이후 소비자 검증은 컴파일러 몫입니다.

## kind 축 자체를 숙청하지 않은 근거 (검토했음)

실데이터 역대 45건이 전부 `Comment`라 축 숙청도 검토했으나, `lsp_overlay_provider`에서 kind는 실제 행동 축입니다 — Decision/Question/Bookmark → codelens 생성(Comment 제외), Question → Information 진단 승격. 장식 필드가 아니므로 축은 유지하고 구현 중복만 제거합니다. (그 행동이 한 번도 발화된 적 없다는 사실은 IDE plane 실사용 검증 항목으로 남음)

## 검증

- `dune build lib/ide/ lib/server/ lib/keeper/` green — 컴파일러가 두 타입의 모든 소비자를 단일 축으로 재검증
- `test_ide_annotations` 30건 green (동작 불변 리팩토링 — wire 형식·코덱 출력 동일)
- 발견 경위: 파서 중복 전수 #28171 항목 1

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>