### PR TITLE
fix(keeper): preserve official client system context

### DIFF
--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -52,6 +52,19 @@ let user_message text : Agent_core.Types.message =
   }
 ;;
 
+(* Official-client adapters own their provider instruction projection. Keep
+   dynamic context on that System path rather than copying Agent Core's
+   synthetic User-message encoding, while retaining the shared typed identity
+   used by prompt attribution and input-window projection. *)
+let extra_system_context_message text : Agent_core.Types.message =
+  { role = System
+  ; content = [ Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = Agent_core.Types.Extra_system_context_provenance.metadata
+  }
+;;
+
 let last_tool_results messages =
   messages
   |> List.rev
@@ -215,16 +228,7 @@ let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
   let messages =
     match turn_params.extra_system_context with
     | None -> messages
-    | Some text ->
-      messages
-      @ [ { Agent_core.Types.role = Agent_core.Types.User
-          ; content = [ Agent_core.Types.Text ("[system context] " ^ text) ]
-          ; name = None
-          ; tool_call_id = None
-          ; metadata =
-              Agent_core.Types.Extra_system_context_provenance.metadata
-          }
-        ]
+    | Some text -> messages @ [ extra_system_context_message text ]
   in
   let* messages =
     match model_input_projection with

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -127,6 +127,11 @@ val prepare_turn :
 (** [configured_reasoning_effort] seeds the turn params the
     [before_turn_params] hook receives, so a hook can still override it.
 
+    The hook's [extra_system_context] is appended as a raw [System] message
+    carrying {!Agent_core.Types.Extra_system_context_provenance}. Official
+    adapters must keep that message on their provider instruction surface; it
+    is not an Agent Core synthetic User carrier.
+
     [max_prompt_bytes] bounds the history a start turn seeds its conversation
     with, keeping the newest messages. [None] applies no ceiling, which is the
     behaviour before this parameter existed. [seed_dropped_atoms] on the result

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -333,15 +333,31 @@ let test_extra_system_context_keeps_typed_provenance () =
   | None -> fail "official-client projection did not observe the provider input"
   | Some messages ->
     check int "one typed context carrier appended" 2 (List.length messages);
+    let carrier = List.nth messages 1 in
+    check bool "context stays on the system channel" true (carrier.role = System);
+    check string
+      "context text stays byte-identical"
+      "dynamic context"
+      (Agent_core.Types.text_of_content carrier.content);
     check
       bool
-      "input composition can remove the typed carrier"
+      "context retains typed provenance"
       true
-      (Option.is_some
-         (Keeper_agent_prompt_metrics.provider_content_messages
-            ~prompt_context_present:true
-            ~projection_input:messages
-            ~projected_messages:messages))
+      (Agent_core.Types.Extra_system_context_provenance.classify carrier.metadata
+       = Agent_core.Types.Extra_system_context_provenance.Present);
+    (match
+       Keeper_agent_prompt_metrics.provider_content_messages
+         ~prompt_context_present:true
+         ~projection_input:messages
+         ~projected_messages:messages
+     with
+     | None -> fail "input composition could not identify the typed carrier"
+     | Some retained ->
+       check int "typed carrier is removed exactly once" 1 (List.length retained);
+       check string
+         "original history remains"
+         "history"
+         (Agent_core.Types.text_of_content (List.hd retained).content))
 ;;
 
 let text_of (m : Agent_core.Types.message) =

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -1925,6 +1925,115 @@ let test_keeper_resumes_persisted_codex_thread () =
        | Ok (Some binding) -> check int "stored turns" 2 binding.turn_count)
 ;;
 
+let test_keeper_dynamic_context_stays_on_codex_instruction_wire () =
+  let base_path = temp_workspace "masc-codex-context-wire-" in
+  let start_capture = Filename.temp_file "masc-codex-context-start-" ".jsonl" in
+  let resume_capture = Filename.temp_file "masc-codex-context-resume-" ".jsonl" in
+  let dynamic_context = "DYNAMIC_CONTEXT_RAW\nsecond line" in
+  let goal = "WIRE_GOAL_EXACT\nsecond line" in
+  let hooks : Agent_core.Hooks.hooks =
+    { Agent_core.Hooks.empty with
+      before_turn_params =
+        Some
+          (function
+            | BeforeTurnParams { current_params; _ } ->
+              AdjustParams
+                { current_params with
+                  extra_system_context = Some dynamic_context
+                }
+            | _ -> Continue)
+    }
+  in
+  let request capture_path method_ =
+    In_channel.with_open_bin capture_path (fun input ->
+      In_channel.input_lines input
+      |> List.map Yojson.Safe.from_string
+      |> List.find (fun json ->
+        Yojson.Safe.Util.member "method" json = `String method_))
+  in
+  let request_param_string name request =
+    request
+    |> Yojson.Safe.Util.member "params"
+    |> Yojson.Safe.Util.member name
+    |> Yojson.Safe.Util.to_string
+  in
+  let turn_prompt capture_path =
+    request capture_path "turn/start"
+    |> Yojson.Safe.Util.member "params"
+    |> Yojson.Safe.Util.member "input"
+    |> Yojson.Safe.Util.to_list
+    |> List.hd
+    |> Yojson.Safe.Util.member "text"
+    |> Yojson.Safe.Util.to_string
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_tree base_path;
+      Sys.remove start_capture;
+      Sys.remove resume_capture)
+    (fun () ->
+       with_fixture
+         ~capture_path:start_capture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; turn_result
+         ; item_completed
+         ; turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~base_path
+                ~hooks
+                ~goal
+                ~cli_path
+                ~model:"gpt-fixture"
+                ()
+            with
+            | Error error -> fail (Agent_core.Error.to_string error)
+            | Ok result -> check int "initial context turn" 1 result.turns);
+       with_fixture
+         ~capture_path:resume_capture
+         [ init_result
+         ; account_chatgpt
+         ; thread_result
+         ; resumed_turn_result
+         ; resumed_item_completed
+         ; resumed_turn_completed
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~base_path
+                ~hooks
+                ~goal
+                ~cli_path
+                ~model:"gpt-fixture"
+                ()
+            with
+            | Error error -> fail (Agent_core.Error.to_string error)
+            | Ok result -> check int "resumed context turn" 2 result.turns);
+       let start_instructions =
+         request start_capture "thread/start"
+         |> request_param_string "developerInstructions"
+       in
+       let resume_instructions =
+         request resume_capture "thread/resume"
+         |> request_param_string "developerInstructions"
+       in
+       check string
+         "start and resume receive identical developer instructions"
+         start_instructions
+         resume_instructions;
+       check string
+         "dynamic context is verbatim on the instruction channel"
+         dynamic_context
+         start_instructions;
+       check string "start prompt stays exact" goal (turn_prompt start_capture);
+       check string "resume prompt stays exact" goal (turn_prompt resume_capture))
+;;
+
 (* A changed tool surface must not RESUME the settled thread. It used to be
    pinned as "the turn fails", which also left the session with no way forward:
    Settled never becomes Recovery_required, so no operator action cleared it
@@ -2160,9 +2269,9 @@ let test_keeper_projects_typed_tools_and_hooks () =
     projection_saw_context :=
       List.exists
         (fun (message : Agent_core.Types.message) ->
-          message.role = User
+          message.role = System
           && String.equal
-               "[system context] fixture-context"
+               "fixture-context"
                (Agent_core.Types.text_of_content message.content)
           && Agent_core.Types.Extra_system_context_provenance.classify
                message.metadata
@@ -2181,8 +2290,7 @@ let test_keeper_projects_typed_tools_and_hooks () =
     [ init_result
     ; account_chatgpt
     ; thread_result
-    ; {|{"id":4,"result":{}}|}
-    ; {|{"id":5,"result":{"turn":{"id":"turn-1"}}}|}
+    ; turn_result
     ; tool_call_request
     ; item_completed
     ; turn_completed
@@ -2616,6 +2724,10 @@ let () =
             "Keeper resumes persisted Codex thread"
             `Quick
             test_keeper_resumes_persisted_codex_thread
+        ; test_case
+            "Keeper dynamic context stays on Codex instruction wire"
+            `Quick
+            test_keeper_dynamic_context_stays_on_codex_instruction_wire
         ; test_case
             "Keeper starts fresh on a changed Codex tool surface"
             `Quick


### PR DESCRIPTION
## Summary\n- keep before_turn_params extra_system_context as a typed raw System carrier\n- preserve byte-identical Codex developerInstructions on thread start and resume\n- keep the user turn prompt unchanged and retain provenance-based prompt accounting\n\n## Regression coverage\n- host projection asserts role, bytes, provenance, and exact carrier removal\n- Codex wire fixture captures thread/start and thread/resume and compares developerInstructions\n\n## Verification\n- ocamlformat --check\n- git diff --check\n- focused tests passed in the source worktree before rebasing onto current main\n- full build/test intentionally delegated to CI per operator request\n\nCorrects the provider-meaning regression introduced by #28138.