### PR TITLE
fix(runtime): point seed remediation at model table

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -625,27 +625,36 @@ let validate_keeper_dispatch_request_caps
     | Runtime_execution.Agent_core provider_config ->
       (match validate_request_body_cap ~runtime_id:runtime.id provider_config with
        | Ok _ -> None
-       | Error _ -> Some (runtime, "max-request-body-bytes", "the exact serialized request"))
+       | Error _ ->
+         Some
+           ( runtime
+           , Otoml.string_of_path
+               [ runtime.binding.provider_id; runtime.binding.model_id ]
+           , "max-request-body-bytes"
+           , "the exact serialized request" ))
     | Runtime_execution.Codex_app_server _
     | Runtime_execution.Claude_code _
     | Runtime_execution.Antigravity_cli _ ->
       (match runtime.model.max_prompt_bytes with
        | Some n when n > 0 -> None
        | Some _ | None ->
-         Some (runtime, "max-prompt-bytes", "the start-turn conversation seed"))
+         Some
+           ( runtime
+           , Otoml.string_of_path [ "models"; runtime.binding.model_id ]
+           , "max-prompt-bytes"
+           , "the start-turn conversation seed" ))
   in
   match List.find_map (fun id -> Option.bind (runtime_by_id id) missing_ceiling) ids with
   | None -> Ok ()
-  | Some (runtime, key, what) ->
+  | Some (runtime, table_path, key, what) ->
     Error
       (Printf.sprintf
          "%s: Keeper-dispatch runtime %S has no positive %s; declare \
-          [%s.%s].%s before dispatch so %s has an explicit admission ceiling"
+          [%s].%s before dispatch so %s has an explicit admission ceiling"
          config_path
          runtime.id
          key
-         runtime.binding.provider_id
-         runtime.binding.model_id
+         table_path
          key
          what)
 ;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1900,14 +1900,22 @@ let test_runtime_config_validation_rejects_unbounded_official_client_seed () =
      fail "an official-client Keeper runtime with no max-prompt-bytes must be rejected"
    | Error detail ->
      check bool "the diagnostic names the key an operator must add" true
-       (String_util.contains_substring detail "max-prompt-bytes");
+     (String_util.contains_substring detail "max-prompt-bytes");
      check bool "the diagnostic names the runtime" true
        (String_util.contains_substring detail "subscription.seeded");
+     check bool
+       "the remediation points at the model table that owns the key"
+       true
+       (String_util.contains_substring
+          detail
+          "[models.seeded].max-prompt-bytes");
      (* The Agent_core key would send the operator to the wrong line. *)
      check bool "the diagnostic does not name the Agent_core key" false
        (String_util.contains_substring detail "max-request-body-bytes"));
-  (* Control: the same config with the bound declared must load. Without this a
-     check that rejected every official-client runtime would pass. *)
+  (* Control and remediation round-trip: the same table/key emitted above is
+     applied to the config and must make it load. Without this, a diagnostic
+     that pointed at a syntactically plausible but unconsumed table could pass
+     the substring assertions while startup remained stuck. *)
   match attempt (content "max-prompt-bytes = 131072\n") with
   | Ok () -> ()
   | Error detail -> failf "a declared seed bound must load: %s" detail


### PR DESCRIPTION
## Summary\n- render the official-client prompt ceiling remediation from the actual models table path\n- retain provider/model paths for Agent Core request ceilings\n- verify that applying the emitted models.seeded.max-prompt-bytes location makes the config load\n\n## Verification\n- ocamlformat --check\n- git diff --check\n- focused runtime-config suite passed before rebasing onto current main\n- full build/test delegated to CI per operator request\n\nCorrects the post-merge diagnostic from #28157, which pointed operators at an unconsumed provider/model table.