### PR TITLE
fix(audit): share append ownership per directory

### DIFF
--- a/lib/shared_audit/dune
+++ b/lib/shared_audit/dune
@@ -6,4 +6,4 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4) + unused-value ratchet (warning 32)
  (flags
   (:standard -w +4 -w +33 -w +37))
- (libraries unix yojson digestif digestif.c jsonl_writer fs_compat))
+ (libraries unix yojson digestif digestif.c jsonl_writer fs_compat masc_core))

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -60,101 +60,31 @@ let read_jsonl_file path =
        with End_of_file -> ());
       List.rev !entries)
 
-let load_latest_hash ~base_dir =
-  if not (Sys.file_exists base_dir) then None
-  else if not (Sys.is_directory base_dir) then None
-  else
-    let months =
-      Sys.readdir base_dir
-      |> Array.to_list
-      |> List.filter (fun s -> String.length s = 7 && s.[4] = '-')
-      |> List.sort (fun a b -> String.compare b a)
-    in
-    let rec find_in_months = function
-      | [] -> None
-      | m :: rest ->
-        let m_dir = Filename.concat base_dir m in
-        if not (Sys.is_directory m_dir) then find_in_months rest
-        else
-          let days =
-            Sys.readdir m_dir
-            |> Array.to_list
-            |> List.filter (fun s -> Filename.check_suffix s ".jsonl")
-            |> List.sort (fun a b -> String.compare b a)
-          in
-          (match days with
-           | [] -> find_in_months rest
-           | d :: _ ->
-             let path = Filename.concat m_dir d in
-             let entries = read_jsonl_file path in
-             (match List.rev entries with
-              | last :: _ -> Some (Envelope.hash_for_chain last)
-              | [] -> find_in_months rest))
-    in
-    find_in_months months
-
-let writer_owner_for_base_dir ~base_dir ~canonical_base_dir =
-  let find () =
-    Stdlib.Mutex.protect writer_owners_mutex (fun () ->
-      Writer_owner_table.find_opt writer_owners canonical_base_dir)
+let verify_chain entries =
+  let rec check idx prev = function
+    | [] -> Ok ()
+    | (e : Envelope.t) :: rest ->
+      if e.prev_hash <> prev then
+        Error (idx, Printf.sprintf "prev_hash mismatch at index %d" idx)
+      else
+        let h = Envelope.hash_for_chain e in
+        check (idx + 1) (Some h) rest
   in
-  match find () with
-  | Some owner -> owner, false
-  | None ->
-    let candidate =
-      { canonical_base_dir
-      ; append_lock = Cross_context_mutex.create ()
-      ; latest_hash = load_latest_hash ~base_dir
-      }
-    in
-    Stdlib.Mutex.protect writer_owners_mutex (fun () ->
-      match Writer_owner_table.find_opt writer_owners canonical_base_dir with
-      | Some owner -> owner, false
-      | None ->
-        Writer_owner_table.clean writer_owners;
-        Writer_owner_table.add writer_owners canonical_base_dir candidate;
-        candidate, true)
+  check 0 None entries
 
-let create ~base_dir =
-  if not (Sys.file_exists base_dir) then Fs_compat.mkdir_p base_dir;
-  let canonical_base_dir = Fs_compat.realpath base_dir in
-  let writer_owner, owner_is_new =
-    writer_owner_for_base_dir ~base_dir ~canonical_base_dir
-  in
-  if not owner_is_new
-  then
-    Cross_context_mutex.with_durable_lock writer_owner.append_lock (fun () ->
-      writer_owner.latest_hash <- load_latest_hash ~base_dir);
-  { base_dir; writer_owner }
-
-let base_dir t = t.base_dir
-
-let append t ~category ~payload =
-  let owner = t.writer_owner in
-  Cross_context_mutex.with_durable_lock owner.append_lock (fun () ->
-    let entry = Envelope.make ~category ~payload ~prev_hash:owner.latest_hash in
-    ignore
-      (Jsonl_writer.append_dated_jsonl
-         ~base_dir:t.base_dir
-         ~ts:entry.ts
-         (Envelope.to_json entry)
-        : Jsonl_writer.dated_path);
-    owner.latest_hash <- Some (Envelope.hash_for_chain entry);
-    entry)
-
-let read_all_entries t =
-  if not (Sys.file_exists t.base_dir) then []
-  else if not (Sys.is_directory t.base_dir) then []
+let read_all_entries_from_base_dir base_dir =
+  if not (Sys.file_exists base_dir) then []
+  else if not (Sys.is_directory base_dir) then []
   else
     let entries = ref [] in
     let months =
-      Sys.readdir t.base_dir
+      Sys.readdir base_dir
       |> Array.to_list
       |> List.filter (fun s -> String.length s = 7 && s.[4] = '-')
       |> List.sort String.compare
     in
     List.iter (fun m ->
-      let m_dir = Filename.concat t.base_dir m in
+      let m_dir = Filename.concat base_dir m in
       if Sys.is_directory m_dir then begin
         let days =
           Sys.readdir m_dir
@@ -169,6 +99,58 @@ let read_all_entries t =
       end
     ) months;
     List.rev !entries
+
+let load_latest_hash ~base_dir =
+  match List.rev (read_all_entries_from_base_dir base_dir) with
+  | [] -> None
+  | last :: _ -> Some (Envelope.hash_for_chain last)
+
+let writer_owner_for_base_dir ~canonical_base_dir =
+  (* Publish the canonical writer identity before reading its cursor. Every
+     creator initializes under this owner's append lock below, so no append can
+     overlap the first disk read and unrelated directories do not hold the
+     process-wide registry mutex while doing I/O. *)
+  Stdlib.Mutex.protect writer_owners_mutex (fun () ->
+    match Writer_owner_table.find_opt writer_owners canonical_base_dir with
+    | Some owner -> owner
+    | None ->
+      let owner =
+        { canonical_base_dir
+        ; append_lock = Cross_context_mutex.create ()
+        ; latest_hash = None
+        }
+      in
+      Writer_owner_table.clean writer_owners;
+      Writer_owner_table.add writer_owners canonical_base_dir owner;
+      owner)
+
+let create ~base_dir =
+  if not (Sys.file_exists base_dir) then Fs_compat.mkdir_p base_dir;
+  let canonical_base_dir = Fs_compat.realpath base_dir in
+  let writer_owner = writer_owner_for_base_dir ~canonical_base_dir in
+  Cross_context_mutex.with_durable_lock writer_owner.append_lock (fun () ->
+    writer_owner.latest_hash <- load_latest_hash ~base_dir:canonical_base_dir);
+  { base_dir = canonical_base_dir; writer_owner }
+
+let base_dir t = t.base_dir
+
+let append t ~category ~payload =
+  let owner = t.writer_owner in
+  Cross_context_mutex.with_durable_lock owner.append_lock (fun () ->
+    let entry = Envelope.make ~category ~payload ~prev_hash:owner.latest_hash in
+    ignore
+      (Jsonl_writer.append_dated_jsonl
+         ~base_dir:owner.canonical_base_dir
+         ~ts:entry.ts
+         (Envelope.to_json entry)
+        : Jsonl_writer.dated_path);
+    owner.latest_hash <- Some (Envelope.hash_for_chain entry);
+    entry)
+
+let read_all_entries t =
+  let owner = t.writer_owner in
+  Cross_context_mutex.with_durable_lock owner.append_lock (fun () ->
+    read_all_entries_from_base_dir owner.canonical_base_dir)
 
 let recent t ~n =
   let all = read_all_entries t in
@@ -186,18 +168,6 @@ let recent t ~n =
 let since t ~ts =
   read_all_entries t
   |> List.filter (fun (e : Envelope.t) -> e.ts >= ts)
-
-let verify_chain entries =
-  let rec check idx prev = function
-    | [] -> Ok ()
-    | (e : Envelope.t) :: rest ->
-      if e.prev_hash <> prev then
-        Error (idx, Printf.sprintf "prev_hash mismatch at index %d" idx)
-      else
-        let h = Envelope.hash_for_chain e in
-        check (idx + 1) (Some h) rest
-  in
-  check 0 None entries
 
 let verify t =
   let entries = read_all_entries t in

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -1,5 +1,15 @@
-type writer_owner = {
+type directory_identity = {
+  device_id : int;
+  inode_id : int;
+}
+
+type writer_owner_key = {
   canonical_base_dir : string;
+  directory_identity : directory_identity;
+}
+
+type writer_owner = {
+  key : writer_owner_key;
   append_lock : Cross_context_mutex.t;
   mutable latest_hash : string option;
 }
@@ -10,10 +20,17 @@ type t = {
 }
 
 module Writer_owner_key = struct
-  type t = string
+  type t = writer_owner_key
 
-  let equal = String.equal
-  let hash = Hashtbl.hash
+  let equal left right =
+    String.equal left.canonical_base_dir right.canonical_base_dir
+    && left.directory_identity = right.directory_identity
+
+  let hash key =
+    Hashtbl.hash
+      ( key.canonical_base_dir
+      , key.directory_identity.device_id
+      , key.directory_identity.inode_id )
 end
 
 module Writer_owner_table = Ephemeron.K1.Make (Writer_owner_key)
@@ -29,6 +46,14 @@ exception Corrupt_jsonl of {
   path : string;
   line_number : int;
   detail : string;
+}
+
+exception Base_directory_replaced of {
+  path : string;
+  expected_device_id : int;
+  expected_inode_id : int;
+  actual_device_id : int option;
+  actual_inode_id : int option;
 }
 
 type verify_report = {
@@ -59,6 +84,26 @@ let read_jsonl_file path =
          done
        with End_of_file -> ());
       List.rev !entries)
+
+let read_latest_jsonl_entry path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let latest = ref None in
+      let line_number = ref 0 in
+      (try
+         while true do
+           let line = input_line ic in
+           incr line_number;
+           if String.length line > 0 then
+             match parse_jsonl_line line with
+             | Ok env -> latest := Some env
+             | Error detail ->
+               raise (Corrupt_jsonl { path; line_number = !line_number; detail })
+         done
+       with End_of_file -> ());
+      !latest)
 
 let verify_chain entries =
   let rec check idx prev = function
@@ -101,34 +146,93 @@ let read_all_entries_from_base_dir base_dir =
     List.rev !entries
 
 let load_latest_hash ~base_dir =
-  match List.rev (read_all_entries_from_base_dir base_dir) with
-  | [] -> None
-  | last :: _ -> Some (Envelope.hash_for_chain last)
+  if not (Sys.file_exists base_dir) then None
+  else if not (Sys.is_directory base_dir) then None
+  else
+    let months =
+      Sys.readdir base_dir
+      |> Array.to_list
+      |> List.filter (fun name -> String.length name = 7 && name.[4] = '-')
+      |> List.sort (fun left right -> String.compare right left)
+    in
+    let rec find_in_months = function
+      | [] -> None
+      | month :: remaining_months ->
+        let month_dir = Filename.concat base_dir month in
+        if not (Sys.is_directory month_dir) then find_in_months remaining_months
+        else
+          let days =
+            Sys.readdir month_dir
+            |> Array.to_list
+            |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
+            |> List.sort (fun left right -> String.compare right left)
+          in
+          let rec find_in_days = function
+            | [] -> find_in_months remaining_months
+            | day :: remaining_days ->
+              let path = Filename.concat month_dir day in
+              (match read_latest_jsonl_entry path with
+               | Some entry -> Some (Envelope.hash_for_chain entry)
+               | None -> find_in_days remaining_days)
+          in
+          find_in_days days
+    in
+    find_in_months months
 
-let writer_owner_for_base_dir ~canonical_base_dir =
+let directory_identity path =
+  let stats = Unix.stat path in
+  if stats.st_kind <> Unix.S_DIR then
+    raise (Unix.Unix_error (Unix.ENOTDIR, "stat", path));
+  { device_id = stats.st_dev; inode_id = stats.st_ino }
+
+let current_directory_identity path =
+  try Some (directory_identity path) with
+  | Unix.Unix_error ((Unix.ENOENT | Unix.ENOTDIR), _, _) -> None
+
+let ensure_owner_directory_identity owner =
+  let expected = owner.key.directory_identity in
+  match current_directory_identity owner.key.canonical_base_dir with
+  | Some actual when actual = expected -> ()
+  | actual ->
+    raise
+      (Base_directory_replaced
+         { path = owner.key.canonical_base_dir
+         ; expected_device_id = expected.device_id
+         ; expected_inode_id = expected.inode_id
+         ; actual_device_id = Option.map (fun identity -> identity.device_id) actual
+         ; actual_inode_id = Option.map (fun identity -> identity.inode_id) actual
+         })
+
+let writer_owner_for_key key =
   (* Publish the canonical writer identity before reading its cursor. Every
      creator initializes under this owner's append lock below, so no append can
      overlap the first disk read and unrelated directories do not hold the
      process-wide registry mutex while doing I/O. *)
   Stdlib.Mutex.protect writer_owners_mutex (fun () ->
-    match Writer_owner_table.find_opt writer_owners canonical_base_dir with
+    match Writer_owner_table.find_opt writer_owners key with
     | Some owner -> owner
     | None ->
       let owner =
-        { canonical_base_dir
+        { key
         ; append_lock = Cross_context_mutex.create ()
         ; latest_hash = None
         }
       in
       Writer_owner_table.clean writer_owners;
-      Writer_owner_table.add writer_owners canonical_base_dir owner;
+      Writer_owner_table.add writer_owners key owner;
       owner)
 
 let create ~base_dir =
   if not (Sys.file_exists base_dir) then Fs_compat.mkdir_p base_dir;
   let canonical_base_dir = Fs_compat.realpath base_dir in
-  let writer_owner = writer_owner_for_base_dir ~canonical_base_dir in
+  let key =
+    { canonical_base_dir
+    ; directory_identity = directory_identity canonical_base_dir
+    }
+  in
+  let writer_owner = writer_owner_for_key key in
   Cross_context_mutex.with_durable_lock writer_owner.append_lock (fun () ->
+    ensure_owner_directory_identity writer_owner;
     writer_owner.latest_hash <- load_latest_hash ~base_dir:canonical_base_dir);
   { base_dir = canonical_base_dir; writer_owner }
 
@@ -137,10 +241,11 @@ let base_dir t = t.base_dir
 let append t ~category ~payload =
   let owner = t.writer_owner in
   Cross_context_mutex.with_durable_lock owner.append_lock (fun () ->
+    ensure_owner_directory_identity owner;
     let entry = Envelope.make ~category ~payload ~prev_hash:owner.latest_hash in
     ignore
       (Jsonl_writer.append_dated_jsonl
-         ~base_dir:owner.canonical_base_dir
+         ~base_dir:owner.key.canonical_base_dir
          ~ts:entry.ts
          (Envelope.to_json entry)
         : Jsonl_writer.dated_path);
@@ -150,7 +255,8 @@ let append t ~category ~payload =
 let read_all_entries t =
   let owner = t.writer_owner in
   Cross_context_mutex.with_durable_lock owner.append_lock (fun () ->
-    read_all_entries_from_base_dir owner.canonical_base_dir)
+    ensure_owner_directory_identity owner;
+    read_all_entries_from_base_dir owner.key.canonical_base_dir)
 
 let recent t ~n =
   let all = read_all_entries t in

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -1,7 +1,29 @@
-type t = {
-  base_dir : string;
+type writer_owner = {
+  canonical_base_dir : string;
+  append_lock : Cross_context_mutex.t;
   mutable latest_hash : string option;
 }
+
+type t = {
+  base_dir : string;
+  writer_owner : writer_owner;
+}
+
+module Writer_owner_key = struct
+  type t = string
+
+  let equal = String.equal
+  let hash = Hashtbl.hash
+end
+
+module Writer_owner_table = Ephemeron.K1.Make (Writer_owner_key)
+
+(* The key is also held by every live [writer_owner]. Ephemeron ownership lets
+   an inactive base directory disappear without an arbitrary registry cap,
+   while every store for a live canonical directory resolves to one cursor and
+   one cross-context append lock. *)
+let writer_owners : writer_owner Writer_owner_table.t = Writer_owner_table.create 0
+let writer_owners_mutex = Stdlib.Mutex.create ()
 
 exception Corrupt_jsonl of {
   path : string;
@@ -71,23 +93,54 @@ let load_latest_hash ~base_dir =
     in
     find_in_months months
 
+let writer_owner_for_base_dir ~base_dir ~canonical_base_dir =
+  let find () =
+    Stdlib.Mutex.protect writer_owners_mutex (fun () ->
+      Writer_owner_table.find_opt writer_owners canonical_base_dir)
+  in
+  match find () with
+  | Some owner -> owner, false
+  | None ->
+    let candidate =
+      { canonical_base_dir
+      ; append_lock = Cross_context_mutex.create ()
+      ; latest_hash = load_latest_hash ~base_dir
+      }
+    in
+    Stdlib.Mutex.protect writer_owners_mutex (fun () ->
+      match Writer_owner_table.find_opt writer_owners canonical_base_dir with
+      | Some owner -> owner, false
+      | None ->
+        Writer_owner_table.clean writer_owners;
+        Writer_owner_table.add writer_owners canonical_base_dir candidate;
+        candidate, true)
+
 let create ~base_dir =
   if not (Sys.file_exists base_dir) then Fs_compat.mkdir_p base_dir;
-  let latest_hash = load_latest_hash ~base_dir in
-  { base_dir; latest_hash }
+  let canonical_base_dir = Fs_compat.realpath base_dir in
+  let writer_owner, owner_is_new =
+    writer_owner_for_base_dir ~base_dir ~canonical_base_dir
+  in
+  if not owner_is_new
+  then
+    Cross_context_mutex.with_durable_lock writer_owner.append_lock (fun () ->
+      writer_owner.latest_hash <- load_latest_hash ~base_dir);
+  { base_dir; writer_owner }
 
 let base_dir t = t.base_dir
 
 let append t ~category ~payload =
-  let entry = Envelope.make ~category ~payload ~prev_hash:t.latest_hash in
-  ignore
-    (Jsonl_writer.append_dated_jsonl
-       ~base_dir:t.base_dir
-       ~ts:entry.ts
-       (Envelope.to_json entry)
-      : Jsonl_writer.dated_path);
-  t.latest_hash <- Some (Envelope.hash_for_chain entry);
-  entry
+  let owner = t.writer_owner in
+  Cross_context_mutex.with_durable_lock owner.append_lock (fun () ->
+    let entry = Envelope.make ~category ~payload ~prev_hash:owner.latest_hash in
+    ignore
+      (Jsonl_writer.append_dated_jsonl
+         ~base_dir:t.base_dir
+         ~ts:entry.ts
+         (Envelope.to_json entry)
+        : Jsonl_writer.dated_path);
+    owner.latest_hash <- Some (Envelope.hash_for_chain entry);
+    entry)
 
 let read_all_entries t =
   if not (Sys.file_exists t.base_dir) then []

--- a/lib/shared_audit/store.mli
+++ b/lib/shared_audit/store.mli
@@ -40,9 +40,9 @@ val create : base_dir:string -> t
     created (with parents) if it does not exist. Stores for equivalent
     realpath-resolved directories share one in-process writer owner.
     A new owner loads the latest entry's hash from disk; reopening an
-    existing owner refreshes that cursor under its append lock, preserving
-    fail-closed validation of on-disk evidence. Thus [append] continues the
-    chain across sessions. *)
+    existing owner refreshes that cursor under its append lock. The canonical
+    path is retained for all later I/O, so aliases cannot silently retarget a
+    live writer. Thus [append] continues the chain across sessions. *)
 
 val append :
   t ->

--- a/lib/shared_audit/store.mli
+++ b/lib/shared_audit/store.mli
@@ -8,13 +8,17 @@
 
     The store maintains in-memory state for the latest entry's hash
     so [append] can chain automatically without re-reading the
-    full log on each call. On creation, the latest hash is loaded
-    from the most recent JSONL file (if any) so sessions that resume
-    an existing audit log continue the chain correctly.
+    full log on each call. All stores whose [base_dir] resolves to the
+    same canonical directory share one in-process writer owner: its
+    cursor and cross-context durable lock make append one serialized
+    read-write-update transaction across instances, Eio fibers,
+    system threads, and Domains. The owner is initialized from the
+    most recent JSONL file (if any) so sessions that resume an existing
+    audit log continue the chain correctly.
 
     {b Single-process design}: this implementation does not orchestrate
-    across processes. For multi-process audit (e.g., concurrent keepers
-    writing to the same log), a follow-up PR will add file-locking
+    across processes. For multi-process audit (e.g., concurrent processes
+    writing to the same log), a follow-up PR must add file-locking
     or a single-writer dispatcher.
 
     @stability Evolving
@@ -33,9 +37,12 @@ exception Corrupt_jsonl of {
 
 val create : base_dir:string -> t
 (** Create or open a store rooted at [base_dir]. The directory is
-    created (with parents) if it does not exist. The latest entry's
-    hash is loaded from the most recent JSONL file in [base_dir],
-    so [append] continues the chain across sessions. *)
+    created (with parents) if it does not exist. Stores for equivalent
+    realpath-resolved directories share one in-process writer owner.
+    A new owner loads the latest entry's hash from disk; reopening an
+    existing owner refreshes that cursor under its append lock, preserving
+    fail-closed validation of on-disk evidence. Thus [append] continues the
+    chain across sessions. *)
 
 val append :
   t ->
@@ -43,7 +50,9 @@ val append :
   payload:Yojson.Safe.t ->
   Envelope.t
 (** Append a new entry with [prev_hash] computed from the latest
-    on-disk entry. Returns the appended entry. *)
+    hash owned for this canonical base directory. Cursor read, durable
+    append, and cursor update are serialized as one transaction across
+    every in-process store instance. Returns the appended entry. *)
 
 val recent : t -> n:int -> Envelope.t list
 (** Read the most recent [n] entries (chronologically increasing).

--- a/lib/shared_audit/store.mli
+++ b/lib/shared_audit/store.mli
@@ -35,14 +35,28 @@ exception Corrupt_jsonl of {
     invalid audit envelope. Audit-chain corruption is fail-closed rather than
     skipped, and identifies the exact file and line. *)
 
+exception Base_directory_replaced of {
+  path : string;
+  expected_device_id : int;
+  expected_inode_id : int;
+  actual_device_id : int option;
+  actual_inode_id : int option;
+}
+(** Raised when the canonical audit directory no longer names the filesystem
+    directory captured by [create]. A missing, non-directory, renamed, or
+    replaced base directory is rejected before further audit I/O so an
+    in-memory cursor cannot be applied to a different log. *)
+
 val create : base_dir:string -> t
 (** Create or open a store rooted at [base_dir]. The directory is
     created (with parents) if it does not exist. Stores for equivalent
     realpath-resolved directories share one in-process writer owner.
-    A new owner loads the latest entry's hash from disk; reopening an
-    existing owner refreshes that cursor under its append lock. The canonical
-    path is retained for all later I/O, so aliases cannot silently retarget a
-    live writer. Thus [append] continues the chain across sessions. *)
+    A new owner loads the latest entry's hash from the newest non-empty
+    partition; reopening an existing owner refreshes that cursor under its
+    append lock. The canonical path and its filesystem identity are retained
+    for all later I/O, so aliases cannot silently retarget a live writer and
+    replacing the canonical directory fails closed. Thus [append] continues
+    the chain across sessions. *)
 
 val append :
   t ->
@@ -52,11 +66,13 @@ val append :
 (** Append a new entry with [prev_hash] computed from the latest
     hash owned for this canonical base directory. Cursor read, durable
     append, and cursor update are serialized as one transaction across
-    every in-process store instance. Returns the appended entry. *)
+    every in-process store instance. Returns the appended entry. Raises
+    {!Base_directory_replaced} if the canonical directory identity changed. *)
 
 val recent : t -> n:int -> Envelope.t list
 (** Read the most recent [n] entries (chronologically increasing).
-    Raises {!Corrupt_jsonl} when persisted audit evidence is malformed. *)
+    Raises {!Corrupt_jsonl} when persisted audit evidence is malformed, and
+    {!Base_directory_replaced} if the canonical directory identity changed. *)
 
 val since : t -> ts:float -> Envelope.t list
 (** Read all entries whose [ts] is >= the given timestamp.

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -274,6 +274,29 @@ let test_store_resume_continues_chain () =
       "resumed chain: e2.prev_hash = hash of e1"
       (Some (Env.hash_for_chain e1)) e2.prev_hash)
 
+let test_store_instances_share_append_cursor () =
+  let dir = unique_temp_dir "audit_shared_cursor" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    (* Create both handles before either append. Independent cached cursors
+       would therefore both start at [None] and deterministically fork. *)
+    let store_a = Store.create ~base_dir:dir in
+    let store_b = Store.create ~base_dir:dir in
+    let e1 = Store.append store_a ~category:"A" ~payload:(`Int 1) in
+    let e2 = Store.append store_b ~category:"B" ~payload:(`Int 2) in
+    let e3 = Store.append store_a ~category:"A" ~payload:(`Int 3) in
+    check (option string)
+      "B observes A's cursor"
+      (Some (Env.hash_for_chain e1))
+      e2.prev_hash;
+    check (option string)
+      "A observes B's cursor"
+      (Some (Env.hash_for_chain e2))
+      e3.prev_hash;
+    match Store.verify_chain [ e1; e2; e3 ] with
+    | Ok () -> ()
+    | Error (idx, reason) ->
+      fail (Printf.sprintf "shared-store chain broken at %d: %s" idx reason))
+
 let test_store_rejects_malformed_jsonl_lines () =
   let dir = unique_temp_dir "audit_malformed" in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
@@ -343,6 +366,7 @@ let () =
       test_case "verify reports intact chain" `Quick test_store_verify_reports_intact_chain;
       test_case "verify reports on-disk tampering" `Quick test_store_verify_reports_on_disk_tampering;
       test_case "resume continues chain" `Quick test_store_resume_continues_chain;
+      test_case "instances share append cursor" `Quick test_store_instances_share_append_cursor;
       test_case "rejects malformed JSONL lines" `Quick test_store_rejects_malformed_jsonl_lines;
       test_case "rejects invalid envelope JSONL lines" `Quick test_store_rejects_invalid_envelope_jsonl_lines;
       test_case "resume rejects malformed JSONL lines" `Quick test_store_resume_rejects_malformed_jsonl_lines;

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -32,6 +32,7 @@ let cleanup_dir dir =
   try rm_rf dir with _ -> ()
 
 let audit_path ~base_dir ~ts =
+  let base_dir = Unix.realpath base_dir in
   let tm = Unix.gmtime ts in
   let yyyy_mm =
     Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1)
@@ -297,6 +298,52 @@ let test_store_instances_share_append_cursor () =
     | Error (idx, reason) ->
       fail (Printf.sprintf "shared-store chain broken at %d: %s" idx reason))
 
+let test_store_resume_skips_empty_newer_partition () =
+  let dir = unique_temp_dir "audit_empty_newer_partition" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let month_dir = Filename.concat dir "2020-01" in
+    Unix.mkdir month_dir 0o755;
+    let first =
+      { (Env.make ~category:"X" ~payload:(`Int 1) ~prev_hash:None) with
+        ts = 1_577_836_800.0 }
+    in
+    let first_path = Filename.concat month_dir "01.jsonl" in
+    let oc = open_out first_path in
+    output_string oc (Yojson.Safe.to_string (Env.to_json first));
+    output_char oc '\n';
+    close_out oc;
+    let empty_path = Filename.concat month_dir "02.jsonl" in
+    close_out (open_out empty_path);
+    let store = Store.create ~base_dir:dir in
+    let next = Store.append store ~category:"X" ~payload:(`Int 2) in
+    check (option string)
+      "empty newer day does not reset cursor"
+      (Some (Env.hash_for_chain first))
+      next.prev_hash)
+
+let test_store_alias_keeps_canonical_io_target () =
+  let root = unique_temp_dir "audit_canonical_io" in
+  let actual = Filename.concat root "actual" in
+  let redirected = Filename.concat root "redirected" in
+  let alias = Filename.concat root "alias" in
+  Unix.mkdir actual 0o755;
+  Unix.mkdir redirected 0o755;
+  Unix.symlink actual alias;
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove alias with Sys_error _ -> ());
+      cleanup_dir root)
+    (fun () ->
+      let store = Store.create ~base_dir:alias in
+      Sys.remove alias;
+      Unix.symlink redirected alias;
+      ignore (Store.append store ~category:"X" ~payload:(`Int 1));
+      let canonical_store = Store.create ~base_dir:actual in
+      check int "entry stayed in canonical directory" 1
+        (List.length (Store.recent canonical_store ~n:10));
+      check int "retargeted alias received no files" 0
+        (Array.length (Sys.readdir redirected)))
+
 let test_store_rejects_malformed_jsonl_lines () =
   let dir = unique_temp_dir "audit_malformed" in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
@@ -336,7 +383,7 @@ let test_store_base_dir_inspector () =
   let dir = unique_temp_dir "audit_inspector" in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
     let store = Store.create ~base_dir:dir in
-    check string "base_dir reported" dir (Store.base_dir store))
+    check string "canonical base_dir reported" (Unix.realpath dir) (Store.base_dir store))
 
 (* ──────────────────────────────────────────────────────────── *)
 (* Suite                                                         *)
@@ -367,6 +414,10 @@ let () =
       test_case "verify reports on-disk tampering" `Quick test_store_verify_reports_on_disk_tampering;
       test_case "resume continues chain" `Quick test_store_resume_continues_chain;
       test_case "instances share append cursor" `Quick test_store_instances_share_append_cursor;
+      test_case "resume skips empty newer partition" `Quick
+        test_store_resume_skips_empty_newer_partition;
+      test_case "alias keeps canonical I/O target" `Quick
+        test_store_alias_keeps_canonical_io_target;
       test_case "rejects malformed JSONL lines" `Quick test_store_rejects_malformed_jsonl_lines;
       test_case "rejects invalid envelope JSONL lines" `Quick test_store_rejects_invalid_envelope_jsonl_lines;
       test_case "resume rejects malformed JSONL lines" `Quick test_store_resume_rejects_malformed_jsonl_lines;

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -321,6 +321,33 @@ let test_store_resume_skips_empty_newer_partition () =
       (Some (Env.hash_for_chain first))
       next.prev_hash)
 
+let test_store_resume_scans_only_latest_non_empty_partition () =
+  let dir = unique_temp_dir "audit_latest_partition_only" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let old_month_dir = Filename.concat dir "2019-01" in
+    let latest_month_dir = Filename.concat dir "2020-01" in
+    Unix.mkdir old_month_dir 0o755;
+    Unix.mkdir latest_month_dir 0o755;
+    let old_path = Filename.concat old_month_dir "01.jsonl" in
+    let old_channel = open_out old_path in
+    output_string old_channel "{historical entry need not be materialized\n";
+    close_out old_channel;
+    let latest =
+      { (Env.make ~category:"X" ~payload:(`Int 1) ~prev_hash:None) with
+        ts = 1_577_836_800.0 }
+    in
+    let latest_path = Filename.concat latest_month_dir "01.jsonl" in
+    let latest_channel = open_out latest_path in
+    output_string latest_channel (Yojson.Safe.to_string (Env.to_json latest));
+    output_char latest_channel '\n';
+    close_out latest_channel;
+    let store = Store.create ~base_dir:dir in
+    let next = Store.append store ~category:"X" ~payload:(`Int 2) in
+    check (option string)
+      "cursor comes from latest non-empty partition"
+      (Some (Env.hash_for_chain latest))
+      next.prev_hash)
+
 let test_store_alias_keeps_canonical_io_target () =
   let root = unique_temp_dir "audit_canonical_io" in
   let actual = Filename.concat root "actual" in
@@ -343,6 +370,39 @@ let test_store_alias_keeps_canonical_io_target () =
         (List.length (Store.recent canonical_store ~n:10));
       check int "retargeted alias received no files" 0
         (Array.length (Sys.readdir redirected)))
+
+let test_store_rejects_replaced_canonical_directory () =
+  let root = unique_temp_dir "audit_replaced_directory" in
+  let active = Filename.concat root "audit" in
+  let rotated = Filename.concat root "audit.rotated" in
+  Unix.mkdir active 0o755;
+  Fun.protect ~finally:(fun () -> cleanup_dir root) (fun () ->
+    let old_store = Store.create ~base_dir:active in
+    ignore (Store.append old_store ~category:"old" ~payload:(`Int 1));
+    Unix.rename active rotated;
+    Unix.mkdir active 0o755;
+    let replacement_store = Store.create ~base_dir:active in
+    let replacement_entry =
+      Store.append replacement_store ~category:"new" ~payload:(`Int 1)
+    in
+    check (option string) "replacement starts its own chain" None
+      replacement_entry.prev_hash;
+    match Store.append old_store ~category:"old" ~payload:(`Int 2) with
+    | exception
+        Store.Base_directory_replaced
+          { path
+          ; expected_device_id
+          ; expected_inode_id
+          ; actual_device_id
+          ; actual_inode_id
+          } ->
+      check string "reports canonical path" (Unix.realpath active) path;
+      check bool "device or inode changed" true
+        (actual_device_id <> Some expected_device_id
+         || actual_inode_id <> Some expected_inode_id);
+      check int "old handle did not write into replacement" 1
+        (List.length (Store.recent replacement_store ~n:10))
+    | _ -> fail "expected Store.Base_directory_replaced")
 
 let test_store_rejects_malformed_jsonl_lines () =
   let dir = unique_temp_dir "audit_malformed" in
@@ -416,8 +476,12 @@ let () =
       test_case "instances share append cursor" `Quick test_store_instances_share_append_cursor;
       test_case "resume skips empty newer partition" `Quick
         test_store_resume_skips_empty_newer_partition;
+      test_case "resume scans only latest non-empty partition" `Quick
+        test_store_resume_scans_only_latest_non_empty_partition;
       test_case "alias keeps canonical I/O target" `Quick
         test_store_alias_keeps_canonical_io_target;
+      test_case "rejects replaced canonical directory" `Quick
+        test_store_rejects_replaced_canonical_directory;
       test_case "rejects malformed JSONL lines" `Quick test_store_rejects_malformed_jsonl_lines;
       test_case "rejects invalid envelope JSONL lines" `Quick test_store_rejects_invalid_envelope_jsonl_lines;
       test_case "resume rejects malformed JSONL lines" `Quick test_store_resume_rejects_malformed_jsonl_lines;


### PR DESCRIPTION
## Summary\n- resolve every live store for one canonical audit directory to one process-local writer owner\n- serialize cursor read, durable append, and cursor update across instances, fibers, threads, and Domains\n- refresh a reopened owner from disk under the same durable lock\n- keep the documented multi-process boundary explicit\n\n## Regression coverage\n- create two stores before either writes, then append A/B/A and verify one continuous hash chain\n\n## Verification\n- shared-audit focused suite: 21/21 passed before rebasing onto current main\n- ocamlformat --check\n- git diff --check\n- full build/test delegated to CI per operator request\n\nSupersedes the closed #28116 with the missing cross-instance ownership fix.