### PR TITLE
refactor: fold five spellings of float_opt_to_json into the one in Json_util

### DIFF
--- a/lib/keeper/keeper_board_attention_quarantine_command.ml
+++ b/lib/keeper/keeper_board_attention_quarantine_command.ml
@@ -639,10 +639,6 @@ let inventory_error_kind_to_string = function
   | Inventory_candidate_ledger_unavailable -> "candidate_ledger_unavailable"
 ;;
 
-let option_float_to_json = function
-  | None -> `Null
-  | Some value -> `Float value
-;;
 
 let attempt_provenance_to_json = function
   | None -> `Null
@@ -667,8 +663,8 @@ let inventory_item_to_json (item : inventory_item) =
           (Candidate.quarantine_failure_category_to_string item.failure_category) )
     ; "attempt_provenance", attempt_provenance_to_json item.attempt_provenance
     ; "quarantined_at", `Float item.quarantined_at
-    ; "requested_at", option_float_to_json item.requested_at
-    ; "requeued_at", option_float_to_json item.requeued_at
+    ; "requested_at", Json_util.float_opt_to_json item.requested_at
+    ; "requeued_at", Json_util.float_opt_to_json item.requeued_at
     ]
 ;;
 

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -205,10 +205,6 @@ let int_option_to_json = function
   | Some value -> `Int value
 ;;
 
-let float_option_to_json = function
-  | None -> `Null
-  | Some value -> `Float value
-;;
 
 let active_turn_to_json turn =
   `Assoc
@@ -216,9 +212,9 @@ let active_turn_to_json turn =
       , match turn.lane with
         | None -> `Null
         | Some lane -> `String (admission_lane_to_string lane) )
-    ; "admitted_at", float_option_to_json turn.admitted_at
+    ; "admitted_at", Json_util.float_opt_to_json turn.admitted_at
     ; "observed_turn_id", int_option_to_json turn.observed_turn_id
-    ; "observation_started_at", float_option_to_json turn.observation_started_at
+    ; "observation_started_at", Json_util.float_opt_to_json turn.observation_started_at
     ]
 ;;
 

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -1259,10 +1259,6 @@ let min_float_opt left right =
   | Some left, Some right -> Some (Float.min left right)
 ;;
 
-let json_of_float_opt = function
-  | None -> `Null
-  | Some value -> `Float value
-;;
 
 let age_seconds_json ~now = function
   | None -> `Null
@@ -1342,9 +1338,9 @@ let keeper_summary_json ~now (summary : keeper_summary) =
     ; "owner_lifecycle", `String (owner_lifecycle_wire summary.owner_lifecycle)
     ; "pending_count", `Int summary.pending_count
     ; "total_count", `Int summary.pending_count
-    ; "oldest_arrived_at_unix", json_of_float_opt summary.pending_oldest
+    ; "oldest_arrived_at_unix", Json_util.float_opt_to_json summary.pending_oldest
     ; "oldest_age_seconds", age_seconds_json ~now summary.pending_oldest
-    ; "pending_oldest_arrived_at_unix", json_of_float_opt summary.pending_oldest
+    ; "pending_oldest_arrived_at_unix", Json_util.float_opt_to_json summary.pending_oldest
     ; "pending_oldest_age_seconds", age_seconds_json ~now summary.pending_oldest
     ; "transition_outbox_count", `Int summary.outbox_count
     ; "counts_complete", `Bool summary.counts_complete
@@ -1520,11 +1516,11 @@ let fleet_summary_json ~now ~base_path ~owner_lifecycle =
     ; "total_count", `Int pending_count
     ; "transition_outbox_count", `Int outbox_count
     ; "counts_complete", `Bool counts_complete
-    ; "oldest_arrived_at_unix", json_of_float_opt oldest
+    ; "oldest_arrived_at_unix", Json_util.float_opt_to_json oldest
     ; "oldest_age_seconds", age_seconds_json ~now oldest
     ; "runnable_pending_count", `Int runnable.pending_count
     ; "runnable_backlog_count", `Int runnable.pending_count
-    ; "runnable_oldest_arrived_at_unix", json_of_float_opt runnable.oldest
+    ; "runnable_oldest_arrived_at_unix", Json_util.float_opt_to_json runnable.oldest
     ; "runnable_oldest_age_seconds", age_seconds_json ~now runnable.oldest
     ; ( "runnable_by_keeper"
       , `List
@@ -1533,7 +1529,7 @@ let fleet_summary_json ~now ~base_path ~owner_lifecycle =
            |> List.map (compact_backlog_count_json ~now)) )
     ; "recoverable_pending_count", `Int recoverable.pending_count
     ; "recoverable_backlog_count", `Int recoverable.pending_count
-    ; "recoverable_oldest_arrived_at_unix", json_of_float_opt recoverable.oldest
+    ; "recoverable_oldest_arrived_at_unix", Json_util.float_opt_to_json recoverable.oldest
     ; "recoverable_oldest_age_seconds", age_seconds_json ~now recoverable.oldest
     ; ( "recoverable_by_keeper"
       , `List
@@ -1543,7 +1539,7 @@ let fleet_summary_json ~now ~base_path ~owner_lifecycle =
     ; "retained_disabled_pending_count", `Int retained_disabled.pending_count
     ; "retained_disabled_backlog_count", `Int retained_disabled.pending_count
     ; ( "retained_disabled_oldest_arrived_at_unix"
-      , json_of_float_opt retained_disabled.oldest )
+      , Json_util.float_opt_to_json retained_disabled.oldest )
     ; ( "retained_disabled_oldest_age_seconds"
       , age_seconds_json ~now retained_disabled.oldest )
     ; ( "retained_disabled_by_keeper"
@@ -1553,7 +1549,7 @@ let fleet_summary_json ~now ~base_path ~owner_lifecycle =
            |> List.map (compact_backlog_count_json ~now)) )
     ; "paused_dead_pending_count", `Int paused_dead.pending_count
     ; "paused_dead_backlog_count", `Int paused_dead.pending_count
-    ; "paused_dead_oldest_arrived_at_unix", json_of_float_opt paused_dead.oldest
+    ; "paused_dead_oldest_arrived_at_unix", Json_util.float_opt_to_json paused_dead.oldest
     ; "paused_dead_oldest_age_seconds", age_seconds_json ~now paused_dead.oldest
     ; ( "paused_dead_by_keeper"
       , `List
@@ -1563,7 +1559,7 @@ let fleet_summary_json ~now ~base_path ~owner_lifecycle =
     ; "shutdown_fenced_pending_count", `Int shutdown_fenced.pending_count
     ; "shutdown_fenced_backlog_count", `Int shutdown_fenced.pending_count
     ; ( "shutdown_fenced_oldest_arrived_at_unix"
-      , json_of_float_opt shutdown_fenced.oldest )
+      , Json_util.float_opt_to_json shutdown_fenced.oldest )
     ; ( "shutdown_fenced_oldest_age_seconds"
       , age_seconds_json ~now shutdown_fenced.oldest )
     ; ( "shutdown_fenced_by_keeper"
@@ -1573,7 +1569,7 @@ let fleet_summary_json ~now ~base_path ~owner_lifecycle =
            |> List.map (compact_backlog_count_json ~now)) )
     ; "unclassified_pending_count", `Int unclassified.pending_count
     ; "unclassified_count", `Int unclassified.pending_count
-    ; "unclassified_oldest_arrived_at_unix", json_of_float_opt unclassified.oldest
+    ; "unclassified_oldest_arrived_at_unix", Json_util.float_opt_to_json unclassified.oldest
     ; "unclassified_oldest_age_seconds", age_seconds_json ~now unclassified.oldest
     ; ( "unclassified_by_keeper"
       , `List

--- a/lib/schedule/schedule_runner_status.ml
+++ b/lib/schedule/schedule_runner_status.ml
@@ -168,10 +168,6 @@ let record_tick_crash ~started_at ~finished_at error =
 
 let snapshot () = with_lock (fun () -> !state)
 
-let option_float_json = function
-  | None -> `Null
-  | Some value -> `Float value
-;;
 
 let option_int_counts_json = function
   | None -> `Null
@@ -244,7 +240,7 @@ let snapshot_to_yojson ?now ?stale_after_sec snapshot =
   let age_field name timestamp =
     match now with
     | None -> name, `Null
-    | Some now -> name, option_float_json (option_age ~now timestamp)
+    | Some now -> name, Json_util.float_opt_to_json (option_age ~now timestamp)
   in
   `Assoc
     [ "schema", `String "masc.schedule.runner_status.v1"
@@ -254,15 +250,15 @@ let snapshot_to_yojson ?now ?stale_after_sec snapshot =
     ; "success_count", `Int snapshot.success_count
     ; "failure_count", `Int snapshot.failure_count
     ; "crash_count", `Int snapshot.crash_count
-    ; "last_tick_started_at", option_float_json snapshot.last_tick_started_at
-    ; "last_tick_finished_at", option_float_json snapshot.last_tick_finished_at
-    ; "last_success_at", option_float_json snapshot.last_success_at
-    ; "last_error_at", option_float_json snapshot.last_error_at
+    ; "last_tick_started_at", Json_util.float_opt_to_json snapshot.last_tick_started_at
+    ; "last_tick_finished_at", Json_util.float_opt_to_json snapshot.last_tick_finished_at
+    ; "last_success_at", Json_util.float_opt_to_json snapshot.last_success_at
+    ; "last_error_at", Json_util.float_opt_to_json snapshot.last_error_at
     ; ( "last_error"
       , match snapshot.last_error with
         | None -> `Null
         | Some error -> `String error )
-    ; "last_duration_sec", option_float_json snapshot.last_duration_sec
+    ; "last_duration_sec", Json_util.float_opt_to_json snapshot.last_duration_sec
     ; "last_counts", option_int_counts_json snapshot.last_counts
     ; ( "stale_after_sec"
       , match stale_after_sec with

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -125,10 +125,6 @@ let unix_iso_json = function
   | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
 ;;
 
-let float_json = function
-  | None -> `Null
-  | Some value -> `Float value
-;;
 
 let waiting_row_json (row : waiting_row) =
   `Assoc
@@ -136,9 +132,9 @@ let waiting_row_json (row : waiting_row) =
     ; "source", `String (source_to_string row.source)
     ; "waiting_on", `String row.waiting_on
     ; "wake_producer", `String (wake_producer_to_string row.wake_producer)
-    ; "since", float_json row.since
+    ; "since", Json_util.float_opt_to_json row.since
     ; "since_iso", unix_iso_json row.since
-    ; "due_at", float_json row.due_at
+    ; "due_at", Json_util.float_opt_to_json row.due_at
     ; "due_at_iso", unix_iso_json row.due_at
     ; "next_action", `String row.next_action
     ; "detail", row.detail
@@ -774,9 +770,9 @@ let keeper_json ~base_path keeper_name ~busy ~external_attention_truncated rows 
            then [ "external_attention", `Bool true ]
            else []) )
     ; "sources", `Assoc (source_counts rows)
-    ; "since", float_json since
+    ; "since", Json_util.float_opt_to_json since
     ; "since_iso", unix_iso_json since
-    ; "due_at", float_json due_at
+    ; "due_at", Json_util.float_opt_to_json due_at
     ; "due_at_iso", unix_iso_json due_at
     ; "source_next_actions", `Assoc (source_next_actions rows)
     ; "current_execution", current_execution_json ~base_path keeper_name


### PR DESCRIPTION
## 발견 방법 — 이름이 아니라 본문으로

`lib/` 의 모든 top-level 함수 본문을 정규화한 뒤 **함수 자신의 이름을 지우고** 해시했다. 그래서 "구현은 같은데 이름만 다른" 것들이 같은 버킷에 들어온다.

결과: 같은 라이브러리 안 **79 그룹**, 라이브러리 경계를 넘는 것 **82 그룹**.

## 이 PR — 정본이 이미 있던 것

`Json_util.float_opt_to_json` 이 이미 존재하는데, 다섯 모듈이 같은 함수를 다섯 이름으로 다시 썼다:

| 모듈 | 이름 |
|---|---|
| `keeper_board_attention_quarantine_command` | `option_float_to_json` |
| `keeper_shutdown_store` | `float_option_to_json` |
| `keeper_event_queue_persistence` | `json_of_float_opt` |
| `schedule_runner_status` | `option_float_json` |
| `server_keeper_waiting_inventory` | `float_json` |

전부 바이트 단위로 동일하다:

```ocaml
function
| None -> `Null
| Some value -> `Float value
```

다섯 모듈 모두 `masc` 라이브러리에 있고 `masc` 는 이미 `masc_core` 에 의존하므로, 호출부 23곳을 정본으로 옮기고 지역 정의를 지우면 끝난다. 새 의존 간선은 없다.

## 다음

`lib/runtime/` 의 세 official-client 런타임(`runtime_antigravity` / `runtime_claude_code` / `runtime_codex_app_server`)이 프로토콜 헬퍼 11종을 복사해 갖고 있다 — `validate_unique_object_keys`(30L×3), `dynamic_tool_bytes`, `invoke_state_callback`, `required_string` 등 약 145줄. 같은 라이브러리라 역시 의존 추가 없이 통합 가능하고, 별도 PR 로 올린다.

## 검증

- `dune build --root . @default @check @install` → exit 0
- `python3 scripts/check_test_coverage.py` → exit 0

5 files changed, 23 insertions(+), 43 deletions(-)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
