### PR TITLE
fix(dashboard): surface unavailable schedule evidence

### DIFF
--- a/dashboard/src/api/dashboard-scheduled-automation.test.ts
+++ b/dashboard/src/api/dashboard-scheduled-automation.test.ts
@@ -12,54 +12,61 @@ afterEach(() => {
 describe('normalizeScheduledAutomation', () => {
   it('keeps a schedule-store read failure reported as unknown, not as zero', () => {
     // Exactly what the owner emits when Schedule_store.read_state_result fails:
-    // every count null, status unknown, the reason carried alongside.
+    // every ledger count null, status unknown, the reason carried alongside.
     const normalized = normalizeScheduledAutomation({
       schema: 'masc.dashboard.scheduled_automation.v1',
       source: 'schedule_store',
       status: 'unknown',
+      schedule_store_known: false,
       schedule_store_read_error: 'schedule store read failed: corrupt ledger',
       request_count: null,
-      request_limit: null,
+      request_limit: 20,
+      truncated: false,
       counts: null,
       fsm: { state: 'unknown', active_count: null, terminal_count: null, next_due_at: null },
       requests: [],
       signals: [],
     })
 
-    expect(normalized.request_count).toBeNull()
-    expect(normalized.request_limit).toBeNull()
-    expect(normalized.counts).toBeNull()
-    expect(normalized.fsm.active_count).toBeNull()
-    expect(normalized.fsm.terminal_count).toBeNull()
-    expect(normalized.fsm.state).toBe('unknown')
-    expect(normalized.schedule_store_read_error).toBe(
-      'schedule store read failed: corrupt ledger',
-    )
-    // The row list is empty on a read failure, but that must not be laundered
-    // into a request_count of 0.
-    expect(normalized.requests).toEqual([])
+    expect(normalized).toEqual({
+      state: 'unavailable',
+      reason: 'schedule store read failed: corrupt ledger',
+    })
   })
 
   it('preserves a genuine zero as zero', () => {
     const normalized = normalizeScheduledAutomation({
-      status: 'idle',
+      status: 'ok',
+      schedule_store_known: true,
+      schedule_store_read_error: null,
       request_count: 0,
       request_limit: 20,
+      truncated: false,
       counts: {},
       fsm: { state: 'idle', active_count: 0, terminal_count: 0, next_due_at: null },
       requests: [],
       signals: [],
     })
 
-    expect(normalized.request_count).toBe(0)
-    expect(normalized.counts).toEqual({})
-    expect(normalized.fsm.active_count).toBe(0)
-    expect(normalized.fsm.terminal_count).toBe(0)
+    expect(normalized.state).toBe('available')
+    if (normalized.state !== 'available') throw new Error(normalized.reason)
+    expect(normalized.data.request_count).toBe(0)
+    expect(normalized.data.counts).toEqual({})
+    expect(normalized.data.fsm.active_count).toBe(0)
+    expect(normalized.data.fsm.terminal_count).toBe(0)
+    expect(normalized.page).toEqual({
+      visibleCount: 0,
+      totalCount: 0,
+      limit: 20,
+      truncated: false,
+    })
   })
 
   it('carries populated counts through unchanged', () => {
     const normalized = normalizeScheduledAutomation({
-      status: 'active',
+      status: 'ok',
+      schedule_store_known: true,
+      schedule_store_read_error: null,
       request_count: 3,
       request_limit: 20,
       truncated: true,
@@ -70,26 +77,44 @@ describe('normalizeScheduledAutomation', () => {
       warnings: ['late', 42],
     })
 
-    expect(normalized.request_count).toBe(3)
-    expect(normalized.truncated).toBe(true)
+    expect(normalized.state).toBe('available')
+    if (normalized.state !== 'available') throw new Error(normalized.reason)
+    expect(normalized.data.request_count).toBe(3)
+    expect(normalized.data.truncated).toBe(true)
     // A non-numeric count is dropped rather than coerced to 0.
-    expect(normalized.counts).toEqual({ scheduled: 2, due: 1 })
-    expect(normalized.fsm.next_due_at).toBe('2026-08-11T00:00:00Z')
-    expect(normalized.signals).toHaveLength(1)
-    expect(normalized.warnings).toEqual(['late'])
+    expect(normalized.data.counts).toEqual({ scheduled: 2, due: 1 })
+    expect(normalized.data.fsm.next_due_at).toBe('2026-08-11T00:00:00Z')
+    expect(normalized.data.signals).toHaveLength(1)
+    expect(normalized.data.warnings).toEqual(['late'])
+    expect(normalized.page).toEqual({
+      visibleCount: 3,
+      totalCount: 3,
+      limit: 20,
+      truncated: true,
+    })
   })
 
-  it('totalizes array and object fields when the server omits them', () => {
+  it('fails closed when required ledger fields are omitted', () => {
     const normalized = normalizeScheduledAutomation({})
-    expect(normalized.requests).toEqual([])
-    expect(normalized.signals).toEqual([])
-    expect(normalized.warnings).toEqual([])
-    expect(normalized.fsm).toEqual({
-      state: 'unknown',
-      active_count: null,
-      terminal_count: null,
-      next_due_at: null,
+    expect(normalized).toEqual({
+      state: 'unavailable',
+      reason: 'schedule ledger projection is incomplete',
     })
+  })
+
+  it('does not infer a healthy zero from null counts even without an error string', () => {
+    const normalized = normalizeScheduledAutomation({
+      status: 'ok',
+      schedule_store_known: true,
+      request_count: null,
+      request_limit: 20,
+      truncated: false,
+      counts: null,
+      fsm: { state: 'unknown', active_count: null, terminal_count: null },
+      requests: [],
+    })
+
+    expect(normalized.state).toBe('unavailable')
   })
 })
 

--- a/dashboard/src/api/dashboard-scheduled-automation.ts
+++ b/dashboard/src/api/dashboard-scheduled-automation.ts
@@ -12,6 +12,56 @@ import type {
   DashboardScheduledAutomationFsm,
 } from './dashboard-tools-prompts'
 
+export interface DashboardScheduledAutomationPage {
+  /** Rows materialized in this response. */
+  visibleCount: number
+  /** Total rows in the schedule ledger. */
+  totalCount: number
+  /** Maximum rows this projection may materialize. */
+  limit: number
+  /** Whether the server omitted rows beyond [limit]. */
+  truncated: boolean
+}
+
+export type DashboardScheduledAutomationAvailableData =
+  Omit<
+    DashboardScheduledAutomation,
+    | 'status'
+    | 'schedule_store_known'
+    | 'schedule_store_read_error'
+    | 'request_count'
+    | 'request_limit'
+    | 'counts'
+    | 'fsm'
+  > & {
+    status: 'ok'
+    schedule_store_known: true
+    schedule_store_read_error: null
+    request_count: number
+    request_limit: number
+    counts: Record<string, number>
+    fsm: DashboardScheduledAutomationFsm & {
+      active_count: number
+      terminal_count: number
+    }
+  }
+
+/** A ledger-backed projection is either completely countable or unavailable.
+ *
+ * Keeping the failure as a discriminant prevents downstream components from
+ * turning the server's null counts and empty placeholder row list into a
+ * healthy-looking zero. */
+export type DashboardScheduledAutomationProjection =
+  | {
+    state: 'available'
+    data: DashboardScheduledAutomationAvailableData
+    page: DashboardScheduledAutomationPage
+  }
+  | {
+    state: 'unavailable'
+    reason: string
+  }
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -25,7 +75,12 @@ function asRecord(value: unknown): Record<string, unknown> | null {
  *  to 0 would render an unreadable ledger as "no schedules", which is the one
  *  substitution this projection must never make. */
 function countOrNull(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null
+  return typeof value === 'number'
+    && Number.isFinite(value)
+    && Number.isInteger(value)
+    && value >= 0
+    ? value
+    : null
 }
 
 function normalizeFsm(raw: unknown): DashboardScheduledAutomationFsm {
@@ -54,7 +109,7 @@ function normalizeCounts(raw: unknown): Record<string, number> | null {
   return counts
 }
 
-export function normalizeScheduledAutomation(raw: unknown): DashboardScheduledAutomation {
+function normalizeScheduledAutomationPayload(raw: unknown): DashboardScheduledAutomation {
   const record = asRecord(raw) ?? {}
   const requests = Array.isArray(record.requests) ? record.requests : []
   const signals = Array.isArray(record.signals) ? record.signals : []
@@ -77,9 +132,79 @@ export function normalizeScheduledAutomation(raw: unknown): DashboardScheduledAu
   } as DashboardScheduledAutomation
 }
 
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
+}
+
+export function normalizeScheduledAutomation(
+  raw: unknown,
+): DashboardScheduledAutomationProjection {
+  const record = asRecord(raw) ?? {}
+  const data = normalizeScheduledAutomationPayload(record)
+  const status = nonEmptyString(record.status)
+  const readError = nonEmptyString(record.schedule_store_read_error)
+
+  if (readError) {
+    return { state: 'unavailable', reason: readError }
+  }
+  if (record.schedule_store_known === false || status === 'unknown') {
+    return {
+      state: 'unavailable',
+      reason: 'schedule ledger status is unknown',
+    }
+  }
+
+  const requestCount = data.request_count
+  const requestLimit = data.request_limit
+  const counts = data.counts
+  const activeCount = data.fsm.active_count
+  const terminalCount = data.fsm.terminal_count
+  if (
+    status !== 'ok'
+    || record.schedule_store_known !== true
+    || record.schedule_store_read_error !== null
+    || requestCount === null
+    || requestLimit === null
+    || counts === null
+    || activeCount === null
+    || terminalCount === null
+    || typeof record.truncated !== 'boolean'
+  ) {
+    return {
+      state: 'unavailable',
+      reason: 'schedule ledger projection is incomplete',
+    }
+  }
+
+  const availableData: DashboardScheduledAutomationAvailableData = {
+    ...data,
+    status: 'ok',
+    schedule_store_known: true,
+    schedule_store_read_error: null,
+    request_count: requestCount,
+    request_limit: requestLimit,
+    counts,
+    fsm: {
+      ...data.fsm,
+      active_count: activeCount,
+      terminal_count: terminalCount,
+    },
+  }
+  return {
+    state: 'available',
+    data: availableData,
+    page: {
+      visibleCount: data.requests.length,
+      totalCount: requestCount,
+      limit: requestLimit,
+      truncated: data.truncated,
+    },
+  }
+}
+
 export async function fetchDashboardScheduledAutomation(
   opts?: AbortableRequestOptions,
-): Promise<DashboardScheduledAutomation> {
+): Promise<DashboardScheduledAutomationProjection> {
   await ensureDevToken()
   const raw = await get<unknown>('/api/v1/dashboard/scheduled-automation', {
     signal: opts?.signal,

--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -278,6 +278,7 @@ export interface DashboardScheduledAutomation {
   schema?: string
   source?: string
   generated_at?: string
+  schedule_store_known?: boolean
   schedule_store_read_error?: string | null
   status?: string
   request_count: number | null

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -231,6 +231,17 @@ export {
   parseDashboardKeeperWaitingSource,
 } from './dashboard-tools-prompts'
 
+export {
+  fetchDashboardScheduledAutomation,
+  normalizeScheduledAutomation,
+} from './dashboard-scheduled-automation'
+
+export type {
+  DashboardScheduledAutomationAvailableData,
+  DashboardScheduledAutomationPage,
+  DashboardScheduledAutomationProjection,
+} from './dashboard-scheduled-automation'
+
 export { fetchDashboardMissionBriefing, fetchDashboardPlanning } from './dashboard-mission'
 
 

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -22,7 +22,8 @@ import {
   Overview,
 } from './overview'
 import type {
-  DashboardScheduledAutomation,
+  DashboardScheduledAutomationAvailableData,
+  DashboardScheduledAutomationProjection,
   DashboardScheduledAutomationRequest,
   DashboardScheduleRunnerStatus,
   FusionRunRecord,
@@ -33,11 +34,11 @@ import { keepers, boardPosts, boardTotal, lastBoardRefreshAt, shellRuntimeResolu
 import type { Goal } from '../../types/core'
 
 const overviewMocks = vi.hoisted(() => ({
-  scheduledAutomation: { value: null as null | DashboardScheduledAutomation },
+  scheduledAutomationProjection: { value: null as null | DashboardScheduledAutomationProjection },
 }))
 
 vi.mock('../schedule/schedule-state', () => ({
-  scheduledAutomation: overviewMocks.scheduledAutomation,
+  scheduledAutomationProjection: overviewMocks.scheduledAutomationProjection,
   subscribeScheduledAutomationRefresh: () => () => {},
 }))
 
@@ -90,8 +91,13 @@ function makeBoardPost(partial: Partial<BoardPost>): BoardPost {
   }
 }
 
-function makeScheduledAutomation(partial: Partial<DashboardScheduledAutomation> = {}): DashboardScheduledAutomation {
-  return {
+function makeScheduledAutomation(
+  partial: Partial<DashboardScheduledAutomationAvailableData> = {},
+): DashboardScheduledAutomationProjection {
+  const data: DashboardScheduledAutomationAvailableData = {
+    status: 'ok',
+    schedule_store_known: true,
+    schedule_store_read_error: null,
     request_count: 3,
     request_limit: 10,
     truncated: false,
@@ -128,6 +134,16 @@ function makeScheduledAutomation(partial: Partial<DashboardScheduledAutomation> 
       },
     ],
     ...partial,
+  }
+  return {
+    state: 'available',
+    data,
+    page: {
+      visibleCount: data.requests.length,
+      totalCount: data.request_count,
+      limit: data.request_limit,
+      truncated: data.truncated,
+    },
   }
 }
 
@@ -914,9 +930,12 @@ describe('computeOverviewDigest', () => {
         },
       }),
     )
-    expect(digest.scheduledAutomation.hasProjection).toBe(true)
-    expect(digest.scheduledAutomation.requestCount).toBe(5)
-    expect(digest.scheduledAutomation.requestLimit).toBe(10)
+    expect(digest.scheduledAutomation.state).toBe('available')
+    if (digest.scheduledAutomation.state !== 'available') {
+      throw new Error('expected available schedule projection')
+    }
+    expect(digest.scheduledAutomation.totalCount).toBe(5)
+    expect(digest.scheduledAutomation.limit).toBe(10)
     expect(digest.scheduledAutomation.fsmState).toBe('due')
     expect(digest.scheduledAutomation.dueCount).toBe(1)
     expect(digest.scheduledAutomation.runningCount).toBe(0)
@@ -942,7 +961,24 @@ describe('computeOverviewDigest', () => {
         ],
       }),
     )
+    expect(digest.scheduledAutomation.state).toBe('available')
+    if (digest.scheduledAutomation.state !== 'available') {
+      throw new Error('expected available schedule projection')
+    }
     expect(digest.scheduledAutomation.scheduledCount).toBe(0)
+  })
+
+  it('keeps an unreadable schedule ledger unavailable instead of summarizing zero', () => {
+    const digest = computeOverviewDigest(0, [], [], {
+      state: 'unavailable',
+      reason: 'schedule store read failed: corrupt ledger',
+    })
+
+    expect(digest.scheduledAutomation).toEqual({
+      state: 'unavailable',
+      reason: 'schedule store read failed: corrupt ledger',
+      tone: 'bad',
+    })
   })
 
   it('summarizes schedule runner status from /health as a digest field', () => {
@@ -1133,8 +1169,8 @@ describe('Overview prototype surface', () => {
   })
 
   it('renders live scheduled-automation summary from the schedule projection', () => {
-    const previousScheduledAutomation = overviewMocks.scheduledAutomation.value
-    overviewMocks.scheduledAutomation.value = makeScheduledAutomation({
+    const previousScheduledAutomation = overviewMocks.scheduledAutomationProjection.value
+    overviewMocks.scheduledAutomationProjection.value = makeScheduledAutomation({
       fsm: {
         state: 'active',
         active_count: 2,
@@ -1159,14 +1195,35 @@ describe('Overview prototype surface', () => {
       expect(bodyText).toContain('Due 2')
       expect(bodyText).toContain('Running 1')
       expect(bodyText).toContain('projection warning 1')
+      expect(bodyText).toContain('표시 3 / 전체 3 · 최대 10')
       expect(bodyText).not.toContain('예약 자동화 projection 미연결')
     } finally {
-      overviewMocks.scheduledAutomation.value = previousScheduledAutomation
+      overviewMocks.scheduledAutomationProjection.value = previousScheduledAutomation
+    }
+  })
+
+  it('renders an unreadable schedule ledger as an error with no zero count', () => {
+    const previousProjection = overviewMocks.scheduledAutomationProjection.value
+    overviewMocks.scheduledAutomationProjection.value = {
+      state: 'unavailable',
+      reason: 'schedule store read failed: corrupt ledger',
+    }
+
+    try {
+      const { container } = render(h(Overview, null))
+      const card = container.querySelector('[data-testid="domain-schedule"]')
+
+      expect(card?.querySelector('.ov-dcount')?.textContent).toBe('—')
+      expect(card?.querySelector('[data-testid="overview-schedule-unavailable"]')).not.toBeNull()
+      expect(card?.textContent).toContain('schedule store read failed: corrupt ledger')
+      expect(card?.textContent).not.toContain('Due 0')
+    } finally {
+      overviewMocks.scheduledAutomationProjection.value = previousProjection
     }
   })
 
   it('renders schedule_runner liveness row in the 예약 · 자동화 card when full health returns runner status', async () => {
-    const previousScheduledAutomation = overviewMocks.scheduledAutomation.value
+    const previousScheduledAutomation = overviewMocks.scheduledAutomationProjection.value
     const previousFetch = global.fetch
     const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL) => {
       const url = `${input}`
@@ -1212,7 +1269,7 @@ describe('Overview prototype surface', () => {
       return Promise.reject(new Error(`unexpected url: ${url}`))
     })
     try {
-      overviewMocks.scheduledAutomation.value = makeScheduledAutomation({
+      overviewMocks.scheduledAutomationProjection.value = makeScheduledAutomation({
         request_count: 1,
         request_limit: 1,
         counts: { scheduled: 1 },
@@ -1231,7 +1288,7 @@ describe('Overview prototype surface', () => {
         expect(card?.textContent).toContain('runner: ok')
       })
     } finally {
-      overviewMocks.scheduledAutomation.value = previousScheduledAutomation
+      overviewMocks.scheduledAutomationProjection.value = previousScheduledAutomation
       if (previousFetch) {
         vi.stubGlobal('fetch', previousFetch)
       } else {

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -22,7 +22,7 @@ import { SCHED_TERMINAL_SET } from '../v2/schedule-constants'
 import { tasks, keepers, boardPosts, boardTotal, lastBoardRefreshAt, goals, fusionRuns, shellRuntimeResolution } from '../../store'
 import type { Agent, Task, Keeper, Message, BoardPost, Goal, KeeperRuntimeBlockerClass } from '../../types/core'
 import type {
-  DashboardScheduledAutomation,
+  DashboardScheduledAutomationProjection,
   DashboardScheduledAutomationRequest,
   FusionRunRecord,
 } from '../../api/dashboard'
@@ -51,7 +51,7 @@ import { navigate } from '../../router'
 import { gateData } from '../gate-signals'
 import type { TabId } from '../../types/sse'
 import {
-  scheduledAutomation,
+  scheduledAutomationProjection,
   subscribeScheduledAutomationRefresh,
 } from '../schedule/schedule-state'
 import {
@@ -244,13 +244,14 @@ export interface OverviewScheduleRunnerDigest {
     | null
 }
 
-export interface OverviewScheduledAutomationDigest {
-  /** Whether the scheduled-automation projection is present on this surface. */
-  hasProjection: boolean
-  /** Total request count (projection or inferred). */
-  requestCount: number
+interface OverviewScheduledAutomationAvailableDigest {
+  state: 'available'
+  /** Rows materialized in this projection page. */
+  visibleCount: number
+  /** Total rows reported by the schedule ledger. */
+  totalCount: number
   /** Projection quota metadata for diagnostics. */
-  requestLimit: number
+  limit: number
   /** FSM state from the scheduler surface. */
   fsmState: string
   /** FSM active_count from scheduler projection. */
@@ -276,6 +277,18 @@ export interface OverviewScheduledAutomationDigest {
   /** Recommended card tone derived from the above state. */
   tone: 'ok' | 'warn' | 'bad' | 'volt'
 }
+
+export type OverviewScheduledAutomationDigest =
+  | OverviewScheduledAutomationAvailableDigest
+  | {
+    state: 'unavailable'
+    reason: string
+    tone: 'bad'
+  }
+  | {
+    state: 'not_loaded'
+    tone: 'warn'
+  }
 
 function requestCountByStatus(requests: readonly DashboardScheduledAutomationRequest[], target: string): number {
   let count = 0
@@ -427,30 +440,25 @@ function summarizeScheduleRunnerStatus(
 }
 
 export function summarizeScheduledAutomation(
-  automation: DashboardScheduledAutomation | null | undefined,
+  projection: DashboardScheduledAutomationProjection | null | undefined,
 ): OverviewScheduledAutomationDigest {
-  if (!automation) {
+  if (!projection) {
     return {
-      hasProjection: false,
-      requestCount: 0,
-      requestLimit: 0,
-      fsmState: 'unknown',
-      fsmActiveCount: 0,
-      fsmTerminalCount: 0,
-      nextDueAt: null,
-      dueCount: 0,
-      runningCount: 0,
-      scheduledCount: 0,
-      warningCount: 0,
-      unsupportedPayloadCount: 0,
-      unknownPayloadCount: 0,
-      truncated: false,
+      state: 'not_loaded',
       tone: 'warn',
     }
   }
+  if (projection.state === 'unavailable') {
+    return {
+      state: 'unavailable',
+      reason: projection.reason,
+      tone: 'bad',
+    }
+  }
 
+  const automation = projection.data
   const requests = automation.requests ?? []
-  const counts = automation.counts && typeof automation.counts === 'object' ? automation.counts : {}
+  const counts = automation.counts
   const payloadSupport = automation.payload_support
 
   const warningCount = automation.warnings?.length ?? 0
@@ -463,29 +471,15 @@ export function summarizeScheduledAutomation(
     requestCountByPayloadSupport(requests, 'unknown'),
   )
 
-  const fsmActiveCount = Math.max(0, Number(automation.fsm?.active_count ?? 0))
+  const fsmActiveCount = Math.max(0, automation.fsm.active_count)
   const fsmTerminalCount = Math.max(
     0,
-    Number(automation.fsm?.terminal_count ?? 0),
+    automation.fsm.terminal_count,
     sumTerminalCountFromProjection(counts),
   )
   const dueCount = requestCountByProjectionCount(requests, counts, 'due')
   const runningCount = requestCountByProjectionCount(requests, counts, 'running')
   const scheduledCount = requestCountByProjectionCount(requests, counts, 'scheduled')
-
-  const hasProjection = true
-  const requestCount = Math.max(
-    0,
-    Number.isFinite(automation.request_count ?? Number.NaN)
-      ? Number(automation.request_count)
-      : requests.length,
-  )
-  const requestLimit = Math.max(
-    0,
-    Number.isFinite(automation.request_limit ?? Number.NaN)
-      ? Number(automation.request_limit)
-      : requests.length,
-  )
 
   const fsmState = automation.fsm?.state?.trim() ? automation.fsm.state.trim() : 'unknown'
   const nextDueAt = automation.fsm?.next_due_at?.trim() ? automation.fsm.next_due_at.trim() : null
@@ -494,9 +488,10 @@ export function summarizeScheduledAutomation(
   const hasWarnings = unsupportedPayloadCount > 0 || unknownPayloadCount > 0 || warningCount > 0
 
   return {
-    hasProjection,
-    requestCount,
-    requestLimit,
+    state: 'available',
+    visibleCount: projection.page.visibleCount,
+    totalCount: projection.page.totalCount,
+    limit: projection.page.limit,
     fsmState,
     fsmActiveCount,
     fsmTerminalCount,
@@ -507,7 +502,7 @@ export function summarizeScheduledAutomation(
     warningCount,
     unsupportedPayloadCount,
     unknownPayloadCount,
-    truncated: typeof automation.truncated === 'boolean' ? automation.truncated : false,
+    truncated: projection.page.truncated,
     tone: hasWarnings ? 'warn' : hasActive ? 'volt' : 'ok',
   }
 }
@@ -523,7 +518,7 @@ export function computeOverviewDigest(
   openGateRequests: number | null,
   goalList: readonly Goal[],
   fusionList: readonly FusionRunRecord[],
-  scheduledAutomation?: DashboardScheduledAutomation | null,
+  scheduledAutomation?: DashboardScheduledAutomationProjection | null,
   scheduleRunnerStatus?: DashboardScheduleRunnerStatus | null,
 ): OverviewDigest {
   // Highest priority first; ties keep input order (stable sort).
@@ -1339,15 +1334,21 @@ function OverviewDomainSection({
       <!-- SCHEDULE · overview.jsx:201-215 -->
       <${DomainCard}
         title="예약 · 자동화"
-        count=${scheduleSummary.hasProjection ? String(scheduleSummary.requestCount) : null}
-        tone=${scheduleSummary.hasProjection ? scheduleSummary.tone : 'warn'}
+        count=${scheduleSummary.state === 'available' ? String(scheduleSummary.totalCount) : '—'}
+        tone=${scheduleSummary.tone}
         linkLabel="예약"
         nav=${{ tab: 'schedule' }}
         testId="domain-schedule"
       >
-      ${scheduleSummary.hasProjection
+      ${scheduleSummary.state === 'available'
         ? html`
               <div class="ov-mini-list">
+                <div class="ov-mini-row" data-testid="overview-schedule-page-metadata">
+                  <span class="inline-block size-1.5 rounded-full bg-warning"></span>
+                  <span class="ov-mini-txt">
+                    ${`표시 ${scheduleSummary.visibleCount} / 전체 ${scheduleSummary.totalCount} · 최대 ${scheduleSummary.limit}${scheduleSummary.truncated ? ' · 일부만 표시' : ''}`}
+                  </span>
+                </div>
                 <div class="ov-mini-row">
                   <span class="inline-block size-1.5 rounded-full bg-warning"></span>
                   <span class="ov-mini-txt">상태: ${scheduleSummary.fsmState}</span>
@@ -1392,7 +1393,22 @@ function OverviewDomainSection({
                 `)}
               </div>
             `
-          : html`
+          : scheduleSummary.state === 'unavailable'
+            ? html`
+              <div class="ov-mini-list" data-testid="overview-schedule-unavailable">
+                <div class="ov-mini-row">
+                  <span class="inline-block size-1.5 rounded-full bg-destructive"></span>
+                  <span class="ov-mini-txt">schedule ledger 읽기 실패: ${scheduleSummary.reason}</span>
+                </div>
+                ${scheduleRunnerRows.map((row, index) => html`
+                  <div class="ov-mini-row" key=${index}>
+                    <span class="inline-block size-1.5 rounded-full bg-warning"></span>
+                    <span class="ov-mini-txt">${row}</span>
+                  </div>
+                `)}
+              </div>
+            `
+            : html`
               <div class="ov-mini-list">
                 <div class="ov-mini-empty ov-empty">예약 자동화 projection 미연결</div>
                 ${scheduleRunnerRows.map((row, index) => html`
@@ -1502,7 +1518,7 @@ export function Overview() {
     approvalQueueState?.state === 'ready'
       ? gateData.value?.approval_queue?.length ?? null
       : null
-  const scheduledAutomationData = scheduledAutomation.value ?? null
+  const scheduledAutomationData = scheduledAutomationProjection.value ?? null
   const scheduleRunnerStatus =
     overviewFullHealthResource.state.value.status === 'loaded'
       ? overviewFullHealthResource.state.value.data.schedule_runner ?? null

--- a/dashboard/src/components/schedule/schedule-state.test.ts
+++ b/dashboard/src/components/schedule/schedule-state.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardScheduledAutomationProjection } from '../../api'
+
+const mocks = vi.hoisted(() => ({
+  fetchDashboardScheduledAutomation: vi.fn(),
+}))
+
+vi.mock('../../api/dashboard-scheduled-automation', () => ({
+  fetchDashboardScheduledAutomation: mocks.fetchDashboardScheduledAutomation,
+}))
+
+import {
+  SCHEDULED_AUTOMATION_REFRESH_MS,
+  subscribeScheduledAutomationRefresh,
+} from './schedule-state'
+
+function emptyProjection(): DashboardScheduledAutomationProjection {
+  return {
+    state: 'available',
+    data: {
+      status: 'ok',
+      schedule_store_known: true,
+      schedule_store_read_error: null,
+      request_count: 0,
+      request_limit: 20,
+      truncated: false,
+      counts: {},
+      fsm: {
+        state: 'idle',
+        active_count: 0,
+        terminal_count: 0,
+        next_due_at: null,
+      },
+      requests: [],
+    },
+    page: {
+      visibleCount: 0,
+      totalCount: 0,
+      limit: 20,
+      truncated: false,
+    },
+  }
+}
+
+describe('scheduled automation refresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.fetchDashboardScheduledAutomation.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('keeps a 35s request alive across 15s polling ticks and starts the next request later', async () => {
+    let resolveFirst!: (projection: DashboardScheduledAutomationProjection) => void
+    let firstSignal: AbortSignal | undefined
+    mocks.fetchDashboardScheduledAutomation
+      .mockImplementationOnce(({ signal }: { signal?: AbortSignal }) => {
+        firstSignal = signal
+        return new Promise<DashboardScheduledAutomationProjection>((resolve) => {
+          resolveFirst = resolve
+        })
+      })
+      .mockResolvedValue(emptyProjection())
+
+    const stop = subscribeScheduledAutomationRefresh()
+    try {
+      expect(mocks.fetchDashboardScheduledAutomation).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(SCHEDULED_AUTOMATION_REFRESH_MS * 2)
+      expect(mocks.fetchDashboardScheduledAutomation).toHaveBeenCalledTimes(1)
+      expect(firstSignal?.aborted).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(5_000)
+      resolveFirst(emptyProjection())
+      await Promise.resolve()
+      await Promise.resolve()
+
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(mocks.fetchDashboardScheduledAutomation).toHaveBeenCalledTimes(2)
+      expect(firstSignal?.aborted).toBe(false)
+    } finally {
+      stop()
+    }
+  })
+})

--- a/dashboard/src/components/schedule/schedule-state.ts
+++ b/dashboard/src/components/schedule/schedule-state.ts
@@ -43,9 +43,23 @@ export const scheduledAutomationLoading = computed(
 )
 
 let loadInFlight: Promise<void> | null = null
+let freshLoadQueued: Promise<void> | null = null
 
-export function loadScheduledAutomation(): Promise<void> {
-  if (loadInFlight) return loadInFlight
+export function loadScheduledAutomation(
+  { fresh = false }: { fresh?: boolean } = {},
+): Promise<void> {
+  if (loadInFlight) {
+    if (!fresh) return loadInFlight
+    if (freshLoadQueued) return freshLoadQueued
+
+    freshLoadQueued = loadInFlight
+      .catch(() => undefined)
+      .then(() => loadScheduledAutomation())
+      .finally(() => {
+        freshLoadQueued = null
+      })
+    return freshLoadQueued
+  }
 
   let request: Promise<void>
   request = scheduledAutomationResource
@@ -68,7 +82,11 @@ let stopRefresh: (() => void) | null = null
 export function subscribeScheduledAutomationRefresh(): () => void {
   subscriberCount += 1
   if (subscriberCount === 1) {
-    if (!scheduledAutomationProjection.value && !scheduledAutomationLoading.value) {
+    const projection = scheduledAutomationProjection.value
+    if (
+      (!projection || projection.state === 'unavailable')
+      && !scheduledAutomationLoading.value
+    ) {
       void loadScheduledAutomation()
     }
     stopRefresh = setupVisibleAutoRefresh(() => {

--- a/dashboard/src/components/schedule/schedule-state.ts
+++ b/dashboard/src/components/schedule/schedule-state.ts
@@ -9,21 +9,31 @@ import { computed } from '@preact/signals'
 import {
   fetchDashboardScheduledAutomation,
 } from '../../api/dashboard-scheduled-automation'
-import type { DashboardScheduledAutomation } from '../../api/dashboard'
+import type {
+  DashboardScheduledAutomation,
+  DashboardScheduledAutomationProjection,
+} from '../../api/dashboard'
 import { createManagedAsyncResource } from '../../lib/async-state'
 import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
 
 // Managed (stale-while-revalidate) for the same reason tool-state is: the
 // surfaces poll on a timer, and a plain resource would blank the projection on
-// every cycle. This does NOT deduplicate concurrent loads into one in-flight
-// request — createAsyncResource does that but drops last-good data. Unifying
-// the two is the async-state consolidation, not this change; doing it for this
-// one resource would leave the other 38 consumers on the old shape.
+// every cycle. The schedule-specific load wrapper below adds single-flight
+// semantics so a slow request is never aborted by the next polling tick.
 const scheduledAutomationResource =
-  createManagedAsyncResource<DashboardScheduledAutomation>()
+  createManagedAsyncResource<DashboardScheduledAutomationProjection>()
 
-export const scheduledAutomation = computed(
+export const scheduledAutomationProjection = computed(
   () => scheduledAutomationResource.state.value.data,
+)
+
+/** Available ledger data only. An unavailable projection deliberately appears
+ *  as null here so legacy detail panels cannot totalize its placeholder rows. */
+export const scheduledAutomation = computed<DashboardScheduledAutomation | null>(
+  () => {
+    const projection = scheduledAutomationProjection.value
+    return projection?.state === 'available' ? projection.data : null
+  },
 )
 export const scheduledAutomationError = computed<string | null>(
   () => scheduledAutomationResource.state.value.error,
@@ -32,10 +42,20 @@ export const scheduledAutomationLoading = computed(
   () => scheduledAutomationResource.state.value.loading,
 )
 
-export async function loadScheduledAutomation(): Promise<void> {
-  await scheduledAutomationResource.load(signal =>
-    fetchDashboardScheduledAutomation({ signal }),
-  )
+let loadInFlight: Promise<void> | null = null
+
+export function loadScheduledAutomation(): Promise<void> {
+  if (loadInFlight) return loadInFlight
+
+  let request: Promise<void>
+  request = scheduledAutomationResource
+    .load(signal => fetchDashboardScheduledAutomation({ signal }))
+    .then(() => undefined)
+    .finally(() => {
+      if (loadInFlight === request) loadInFlight = null
+    })
+  loadInFlight = request
+  return request
 }
 
 export const SCHEDULED_AUTOMATION_REFRESH_MS = 15_000
@@ -48,7 +68,7 @@ let stopRefresh: (() => void) | null = null
 export function subscribeScheduledAutomationRefresh(): () => void {
   subscriberCount += 1
   if (subscriberCount === 1) {
-    if (!scheduledAutomation.value && !scheduledAutomationLoading.value) {
+    if (!scheduledAutomationProjection.value && !scheduledAutomationLoading.value) {
       void loadScheduledAutomation()
     }
     stopRefresh = setupVisibleAutoRefresh(() => {

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -4,7 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   DashboardKeeperBackground,
   DashboardKeeperWaitingInventory,
-  DashboardScheduledAutomation,
+  DashboardScheduledAutomationAvailableData,
+  DashboardScheduledAutomationProjection,
 } from '../../api'
 
 type MockToolsResponse = {
@@ -20,7 +21,7 @@ const mocks = vi.hoisted(() => ({
   toolsData: { value: null as null | MockToolsResponse },
   toolsLoading: { value: false },
   loadScheduledAutomation: vi.fn(),
-  scheduledAutomation: { value: null as null | DashboardScheduledAutomation },
+  scheduledAutomationProjection: { value: null as null | DashboardScheduledAutomationProjection },
   scheduledAutomationLoading: { value: false },
   scheduledAutomationError: { value: null as string | null },
   subscribeScheduledAutomationRefresh: vi.fn(() => () => {}),
@@ -35,7 +36,7 @@ vi.mock('../tools/tool-state', () => ({
 
 vi.mock('./schedule-state', () => ({
   loadScheduledAutomation: mocks.loadScheduledAutomation,
-  scheduledAutomation: mocks.scheduledAutomation,
+  scheduledAutomationProjection: mocks.scheduledAutomationProjection,
   scheduledAutomationError: mocks.scheduledAutomationError,
   scheduledAutomationLoading: mocks.scheduledAutomationLoading,
   subscribeScheduledAutomationRefresh: mocks.subscribeScheduledAutomationRefresh,
@@ -47,11 +48,14 @@ vi.mock('../../api/dashboard-schedule', () => ({
 
 import { ScheduleSurface } from './schedule-surface'
 
-function sampleAutomation(): DashboardScheduledAutomation {
+function sampleAutomation(): DashboardScheduledAutomationAvailableData {
   return {
     schema: 'masc.dashboard.scheduled_automation.v1',
     source: 'schedule_runner_signals',
     generated_at: '2026-06-21T00:00:00Z',
+    status: 'ok',
+    schedule_store_known: true,
+    schedule_store_read_error: null,
     request_count: 1,
     request_limit: 20,
     truncated: false,
@@ -85,6 +89,19 @@ function sampleAutomation(): DashboardScheduledAutomation {
         due_at_iso: '2026-06-21T01:00:00Z',
       },
     ],
+  }
+}
+
+function setAutomation(data: DashboardScheduledAutomationAvailableData): void {
+  mocks.scheduledAutomationProjection.value = {
+    state: 'available',
+    data,
+    page: {
+      visibleCount: data.requests.length,
+      totalCount: data.request_count,
+      limit: data.request_limit,
+      truncated: data.truncated,
+    },
   }
 }
 
@@ -178,7 +195,7 @@ describe('ScheduleSurface', () => {
     mocks.toolsLoading.value = false
     mocks.loadScheduledAutomation.mockClear()
     mocks.subscribeScheduledAutomationRefresh.mockClear()
-    mocks.scheduledAutomation.value = null
+    mocks.scheduledAutomationProjection.value = null
     mocks.scheduledAutomationLoading.value = false
     mocks.scheduledAutomationError.value = null
   })
@@ -206,7 +223,7 @@ describe('ScheduleSurface', () => {
   })
 
   it('renders backed schedule summary and reuses read-only schedule cards', async () => {
-    mocks.scheduledAutomation.value = sampleAutomation()
+    setAutomation(sampleAutomation())
     mocks.toolsData.value = {
       generated_at: '2026-06-21T00:00:00Z',
       tool_inventory: { tools: [] },
@@ -261,7 +278,7 @@ describe('ScheduleSurface', () => {
   })
 
   it('renders the read-only operations aside in a two-column shell', async () => {
-    mocks.scheduledAutomation.value = sampleAutomation()
+    setAutomation(sampleAutomation())
     mocks.toolsData.value = {
       generated_at: '2026-06-21T00:00:00Z',
       tool_inventory: { tools: [] },
@@ -294,7 +311,7 @@ describe('ScheduleSurface', () => {
         status: 'scheduled',
       },
     ]
-    mocks.scheduledAutomation.value = automation
+    setAutomation(automation)
     mocks.toolsData.value = {
       generated_at: '2026-06-21T00:00:00Z',
       tool_inventory: { tools: [] },
@@ -327,7 +344,7 @@ describe('ScheduleSurface', () => {
         keeper_reaction_evidence: { projection_status: 'not_found' },
       },
     ]
-    mocks.scheduledAutomation.value = automation
+    setAutomation(automation)
     mocks.toolsData.value = {
       generated_at: '2026-06-21T00:00:00Z',
       tool_inventory: { tools: [] },
@@ -345,7 +362,7 @@ describe('ScheduleSurface', () => {
 
   it('surfaces projection load errors without hiding stale schedule data', async () => {
     mocks.scheduledAutomationError.value = 'schedule projection unavailable'
-    mocks.scheduledAutomation.value = sampleAutomation()
+    setAutomation(sampleAutomation())
     mocks.toolsData.value = {
       tool_inventory: { tools: [] },
       tool_usage: {},
@@ -358,8 +375,51 @@ describe('ScheduleSurface', () => {
     expect(container.querySelector('[data-schedule-id="sched-1"]')).not.toBeNull()
   })
 
+  it('renders an unreadable ledger as unavailable and keeps every KPI unknown', async () => {
+    mocks.scheduledAutomationProjection.value = {
+      state: 'unavailable',
+      reason: 'schedule store read failed: corrupt ledger',
+    }
+    mocks.toolsData.value = {
+      tool_inventory: { tools: [] },
+      tool_usage: {},
+    }
+
+    render(html`<${ScheduleSurface} />`, container)
+    await flush()
+
+    expect(container.querySelector('[data-testid="schedule-projection-unavailable"]')?.textContent)
+      .toContain('schedule store read failed: corrupt ledger')
+    expect(Array.from(container.querySelectorAll('.ov-kpi-v')).map(node => node.textContent))
+      .toEqual(['—', '—', '—', '—'])
+    expect(container.querySelector('[data-testid="schedule-viewbar"]')).toBeNull()
+    expect(container.textContent).not.toContain('다가오는 7일에 예정된 예약이 없습니다')
+  })
+
+  it('distinguishes visible rows from the total when the projection is truncated', async () => {
+    const automation = sampleAutomation()
+    automation.request_count = 42
+    automation.request_limit = 20
+    automation.truncated = true
+    setAutomation(automation)
+    mocks.toolsData.value = {
+      tool_inventory: { tools: [] },
+      tool_usage: {},
+    }
+
+    render(html`<${ScheduleSurface} />`, container)
+    await flush()
+
+    const summary = container.querySelector('[aria-label="예약 요약"]')
+    const totalKpi = Array.from(summary?.querySelectorAll('.ov-kpi') ?? [])
+      .find(element => element.textContent?.includes('총 예약'))
+    expect(totalKpi?.textContent).toContain('42')
+    expect(container.querySelector('[data-testid="schedule-page-metadata"]')?.textContent)
+      .toContain('표시 1 / 전체 42 · 최대 20 · 일부만 표시')
+  })
+
   it('prunes completed schedules through the live dashboard API and refreshes projection', async () => {
-    mocks.scheduledAutomation.value = sampleAutomation()
+    setAutomation(sampleAutomation())
     mocks.toolsData.value = {
       generated_at: '2026-06-21T00:00:00Z',
       tool_inventory: { tools: [] },
@@ -410,7 +470,7 @@ describe('ScheduleSurface', () => {
   })
 
   it('toggles to the list view revealing the diagnostic wake-signal feed', async () => {
-    mocks.scheduledAutomation.value = sampleAutomation()
+    setAutomation(sampleAutomation())
     mocks.toolsData.value = {
       generated_at: '2026-06-21T00:00:00Z',
       tool_inventory: { tools: [] },
@@ -436,7 +496,7 @@ describe('ScheduleSurface', () => {
       { ...automation.requests[0]!, schedule_id: 'sched-oneshot', recurrence: { kind: 'one_shot' }, recurrence_kind: 'one_shot' },
       { ...automation.requests[0]!, schedule_id: 'sched-interval', recurrence: { kind: 'interval', interval_sec: 3600 }, recurrence_kind: 'interval' },
     ]
-    mocks.scheduledAutomation.value = automation
+    setAutomation(automation)
     mocks.toolsData.value = {
       generated_at: '2026-06-21T00:00:00Z',
       tool_inventory: { tools: [] },

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -35,17 +35,17 @@ import {
 } from '../tools/tool-state'
 import {
   loadScheduledAutomation,
-  scheduledAutomation,
   scheduledAutomationError,
   scheduledAutomationLoading,
+  scheduledAutomationProjection,
   subscribeScheduledAutomationRefresh,
 } from './schedule-state'
 import { pruneSchedules } from '../../api/dashboard-schedule'
 
 type ScheduleView = 'calendar' | 'list'
 
-function countLabel(count: number): string {
-  return count.toLocaleString()
+function countLabel(count: number | null): string {
+  return count === null ? '—' : count.toLocaleString()
 }
 
 // Narrow the projection handed to the list view so the cadence chip filters
@@ -63,10 +63,9 @@ function filterAutomationByCadence(
 }
 
 function countByStatus(
-  automation: DashboardScheduledAutomation | null,
+  automation: DashboardScheduledAutomation,
   statuses: readonly string[],
 ): number {
-  if (!automation) return 0
   const wireStatuses = statuses.map(scheduleWireValue)
   const fromCounts = wireStatuses.reduce(
     (sum, status) => sum + (automation.counts?.[status] ?? 0),
@@ -82,21 +81,27 @@ export function ScheduleSurface() {
   const data = toolsData.value
   // Schedule rows come from the schedule projection; the keeper diagnostics
   // panels below still read the tool inventory, which is why both are loaded.
-  const automation = scheduledAutomation.value ?? null
+  const projection = scheduledAutomationProjection.value
+  const automation = projection?.state === 'available' ? projection.data : null
+  const page = projection?.state === 'available' ? projection.page : null
+  const projectionError = projection?.state === 'unavailable' ? projection.reason : null
   const waitingInventory = data?.keeper_waiting_inventory ?? null
   const keeperBackground = data?.keeper_background ?? null
   const loading = scheduledAutomationLoading.value
   const error = scheduledAutomationError.value
-  const scheduledCount = countByStatus(automation, ['scheduled'])
-  const dueCount = countByStatus(automation, ['due'])
-  const runningCount = countByStatus(automation, ['running'])
-  const dueRunning = dueCount + runningCount
+  const blockingError = automation ? null : projectionError ?? error
+  const scheduledCount = automation ? countByStatus(automation, ['scheduled']) : null
+  const dueCount = automation ? countByStatus(automation, ['due']) : null
+  const runningCount = automation ? countByStatus(automation, ['running']) : null
+  const dueRunning = dueCount === null || runningCount === null
+    ? null
+    : dueCount + runningCount
   const requests = automation?.requests ?? []
-  const totalCount = requests.length
+  const totalCount = page?.totalCount ?? null
   const cadCounts = cadenceCounts(requests)
   // Scheduled keeper wakes that were dispatched but are in neither queue AND
   // never recorded as reacted — the drain-miss the calendar surfaces per row.
-  const queueMisses = countQueueDrainMisses(requests)
+  const queueMisses = automation ? countQueueDrainMisses(requests) : null
 
   const [view, setView] = useState<ScheduleView>('calendar')
   const [cadenceFilter, setCadenceFilter] = useState<Cadence | null>(null)
@@ -174,16 +179,22 @@ export function ScheduleSurface() {
           </div>
         </header>
 
-        ${error ? html`<${ErrorState} message=${error} class="mb-4" />` : null}
+        ${error || projectionError
+          ? html`
+              <div data-testid=${projectionError ? 'schedule-projection-unavailable' : undefined}>
+                <${ErrorState} message=${error ?? projectionError ?? ''} class="mb-4" />
+              </div>
+            `
+          : null}
 
         <section class="ov-kpis" style=${{ gridTemplateColumns: 'repeat(4, 1fr)' }} aria-label="예약 요약">
           <div class="ov-kpi">
             <div class="ov-kpi-k">예약됨</div>
-            <div class=${`ov-kpi-v ${scheduledCount > 0 ? 'info' : ''}`}>${countLabel(scheduledCount)}</div>
+            <div class=${`ov-kpi-v ${scheduledCount !== null && scheduledCount > 0 ? 'info' : ''}`}>${countLabel(scheduledCount)}</div>
           </div>
           <div class="ov-kpi">
             <div class="ov-kpi-k">due · 실행</div>
-            <div class=${`ov-kpi-v ${dueRunning > 0 ? 'warn' : ''}`}>${countLabel(dueRunning)}</div>
+            <div class=${`ov-kpi-v ${dueRunning !== null && dueRunning > 0 ? 'warn' : ''}`}>${countLabel(dueRunning)}</div>
           </div>
           <div class="ov-kpi">
             <div class="ov-kpi-k">총 예약</div>
@@ -192,13 +203,27 @@ export function ScheduleSurface() {
           <div class="ov-kpi" data-testid="schedule-kpi-queue-miss">
             <div class="ov-kpi-k">큐 누락</div>
             <div
-              class=${`ov-kpi-v ${queueMisses > 0 ? 'warn' : 'ok'}`}
+              class=${`ov-kpi-v ${queueMisses === null ? '' : queueMisses > 0 ? 'warn' : 'ok'}`}
               title="dispatch됐으나 pending 큐에도 없고 keeper 반응 기록도 없는 예약 실행 수 — 실행 누락"
             >${countLabel(queueMisses)}</div>
           </div>
         </section>
 
-        <div class="sch-viewbar" data-testid="schedule-viewbar">
+        ${page
+          ? html`
+              <div class="mb-3 text-2xs text-[var(--color-fg-muted)]" data-testid="schedule-page-metadata">
+                ${`표시 ${page.visibleCount.toLocaleString()} / 전체 ${page.totalCount.toLocaleString()} · 최대 ${page.limit.toLocaleString()}${page.truncated ? ' · 일부만 표시' : ''}`}
+              </div>
+            `
+          : null}
+
+        ${blockingError
+          ? html`
+              <div class="ov-card mb-4 text-sm text-[var(--color-fg-muted)]" data-testid="schedule-ledger-unknown">
+                schedule projection을 확인할 수 없어 예약 수와 일정을 표시할 수 없습니다.
+              </div>
+            `
+          : html`<div class="sch-viewbar" data-testid="schedule-viewbar">
           <div class="sch-viewseg" role="tablist" aria-label="예약 뷰">
             <button
               type="button"
@@ -218,9 +243,11 @@ export function ScheduleSurface() {
             >≡ 목록</button>
           </div>
           <${CadenceSummary} counts=${cadCounts} active=${cadenceFilter} onFilter=${setCadenceFilter} />
-        </div>
+        </div>`}
 
-        ${loading && !automation
+        ${blockingError
+          ? null
+          : loading && !automation
           ? html`<${LoadingState}>예약 자동화 projection 불러오는 중...<//>`
           : view === 'calendar'
             ? html`<${ScheduleCalendar}
@@ -277,7 +304,7 @@ export function ScheduleSurface() {
             : null}
         </section>
       </div>
-      ${automation
+      ${automation && scheduledCount !== null && dueRunning !== null && totalCount !== null
         ? html`<${ScheduleAside}
             requests=${automation.requests ?? []}
             sum=${{ scheduled: scheduledCount, dueRunning, total: totalCount }}

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -142,7 +142,7 @@ export function ScheduleSurface() {
     try {
       const result = await pruneSchedules()
       showToast(`완료된 예약 ${result.pruned_count.toLocaleString()}개를 정리했습니다.`, 'success')
-      await refresh()
+      await loadScheduledAutomation({ fresh: true })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       console.error('[ScheduleSurface] prune failed:', error)

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { DashboardKeeperWaitingInventory, DashboardScheduledAutomation } from '../../api'
+import type { DashboardKeeperWaitingInventory, DashboardScheduledAutomationProjection } from '../../api'
 
 type MockToolsResponse = {
   generated_at?: string
@@ -20,11 +20,11 @@ const mocks = vi.hoisted(() => ({
   toolsData: { value: null as null | MockToolsResponse },
   toolsLoading: { value: false },
   toolsError: { value: null as string | null },
-  scheduledAutomation: { value: null as null | DashboardScheduledAutomation },
+  scheduledAutomationProjection: { value: null as null | DashboardScheduledAutomationProjection },
 }))
 
 vi.mock('../schedule/schedule-state', () => ({
-  scheduledAutomation: mocks.scheduledAutomation,
+  scheduledAutomationProjection: mocks.scheduledAutomationProjection,
   subscribeScheduledAutomationRefresh: () => () => {},
 }))
 
@@ -112,6 +112,7 @@ describe('Tools', () => {
     mocks.toolsData.value = null
     mocks.toolsLoading.value = false
     mocks.toolsError.value = null
+    mocks.scheduledAutomationProjection.value = null
   })
 
   afterEach(() => {
@@ -143,48 +144,55 @@ describe('Tools', () => {
   })
 
   it('renders scheduled automation FSM projection', async () => {
-    mocks.scheduledAutomation.value = {
-      schema: 'masc.dashboard.scheduled_automation.v1',
-      source: 'schedule_store',
-      generated_at: '2026-06-13T00:00:00Z',
-      request_count: 1,
-      request_limit: 20,
-      truncated: false,
-      counts: { due: 1 },
-      payload_support: {
-        supported_kinds: ['masc.board_post'],
-        unsupported_request_count: 1,
-        unsupported_kinds: [{ kind: 'test.reminder', count: 1 }],
-        unknown_request_count: 0,
-      },
-      fsm: {
-        state: 'due',
-        active_count: 1,
-        terminal_count: 0,
-        next_due_at: '2026-06-13T01:00:00Z',
-      },
-      requests: [
-        {
-          schedule_id: 'sched-1',
-          status: 'due',
-          source: 'operator_request',
-          requested_by: { id: 'operator', kind: 'human_operator', display_name: null },
-          scheduled_by: { id: 'scheduler-agent', kind: 'automated_actor', display_name: null },
-          recurrence: { kind: 'cron', expression: '0 9 * * 1-5', timezone: 'Asia/Seoul' },
-          recurrence_kind: 'cron',
-          payload_kind: 'test.reminder',
-          payload_support: 'unsupported',
-          requested_at_iso: '2026-06-13T00:00:00Z',
-          due_at_iso: '2026-06-13T01:00:00Z',
-          expires_at_iso: '2026-06-13T02:00:00Z',
-          last_wake: {
-            schedule_id: 'sched-1',
-            started_at_iso: '2026-06-13T00:30:00Z',
-            finished_at_iso: '2026-06-13T00:30:01Z',
-            status: 'succeeded',
-          },
+    mocks.scheduledAutomationProjection.value = {
+      state: 'available',
+      page: { visibleCount: 1, totalCount: 1, limit: 20, truncated: false },
+      data: {
+        schema: 'masc.dashboard.scheduled_automation.v1',
+        source: 'schedule_store',
+        generated_at: '2026-06-13T00:00:00Z',
+        status: 'ok',
+        schedule_store_known: true,
+        schedule_store_read_error: null,
+        request_count: 1,
+        request_limit: 20,
+        truncated: false,
+        counts: { due: 1 },
+        payload_support: {
+          supported_kinds: ['masc.board_post'],
+          unsupported_request_count: 1,
+          unsupported_kinds: [{ kind: 'test.reminder', count: 1 }],
+          unknown_request_count: 0,
         },
-      ],
+        fsm: {
+          state: 'due',
+          active_count: 1,
+          terminal_count: 0,
+          next_due_at: '2026-06-13T01:00:00Z',
+        },
+        requests: [
+          {
+            schedule_id: 'sched-1',
+            status: 'due',
+            source: 'operator_request',
+            requested_by: { id: 'operator', kind: 'human_operator', display_name: null },
+            scheduled_by: { id: 'scheduler-agent', kind: 'automated_actor', display_name: null },
+            recurrence: { kind: 'cron', expression: '0 9 * * 1-5', timezone: 'Asia/Seoul' },
+            recurrence_kind: 'cron',
+            payload_kind: 'test.reminder',
+            payload_support: 'unsupported',
+            requested_at_iso: '2026-06-13T00:00:00Z',
+            due_at_iso: '2026-06-13T01:00:00Z',
+            expires_at_iso: '2026-06-13T02:00:00Z',
+            last_wake: {
+              schedule_id: 'sched-1',
+              started_at_iso: '2026-06-13T00:30:00Z',
+              finished_at_iso: '2026-06-13T00:30:01Z',
+              status: 'succeeded',
+            },
+          },
+        ],
+      },
     }
     mocks.toolsData.value = {
       tool_inventory: { tools: [] },

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -21,7 +21,7 @@ import { sourceHealthClass, coverageGapDisplay } from '../common/source-health'
 import { ScheduledAutomationPanel } from './scheduled-automation-panel'
 import { KeeperWaitingInventoryPanel } from './keeper-waiting-inventory-panel'
 import {
-  scheduledAutomation,
+  scheduledAutomationProjection,
   subscribeScheduledAutomationRefresh,
 } from '../schedule/schedule-state'
 
@@ -78,7 +78,17 @@ export function Tools() {
       <//>
 
       <${SectionCard} label="예약 자동화 FSM" class="section v2-lab-panel mb-4">
-        <${ScheduledAutomationPanel} automation=${scheduledAutomation.value ?? null} />
+        ${scheduledAutomationProjection.value?.state === 'unavailable'
+          ? html`
+              <div class="text-xs text-[var(--color-status-bad)]" data-testid="tools-schedule-unavailable">
+                schedule ledger 읽기 실패: ${scheduledAutomationProjection.value.reason}
+              </div>
+            `
+          : html`<${ScheduledAutomationPanel}
+              automation=${scheduledAutomationProjection.value?.state === 'available'
+                ? scheduledAutomationProjection.value.data
+                : null}
+            />`}
       <//>
 
       <${SectionCard} label="Keeper Waiting Inventory" class="section v2-lab-panel mb-4">


### PR DESCRIPTION
## Summary\n- decode scheduled automation into a strict available or unavailable projection\n- require canonical ok status, known store, no read error, and complete counts before rendering data\n- show unavailable evidence as an error and dash instead of healthy zeroes\n- distinguish visible rows, total rows, limit, and truncation\n- make the 15-second refresh single-flight so it cannot repeatedly abort a slower 35-second request\n\n## Regression coverage\n- API/state/Schedule/Lab focused suites: 22 tests\n- Overview unavailable rendering focused test\n- earlier full Overview suite: 100 tests\n- strict TypeScript check passed in the source worktree\n- git diff --check\n- full build/test delegated to CI per operator request\n\nCorrects post-merge operator and polling failures from #28134. The server read-path lock/scan fix is being prepared separately.