### PR TITLE
fix(keeper): stop cutting the official-client seed, and stop demanding a cap

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -266,8 +266,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       Host.prepare_turn
         ~configured_reasoning_effort:
           (Runtime_inference.resolve_reasoning_effort ~runtime_id)
-        ~max_prompt_bytes:
-          (Runtime_inference.resolve_max_prompt_bytes ~runtime_id)
         ~runtime_label
         ~keeper_name
         ~turn_count

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -254,8 +254,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       Host.prepare_turn
         ~configured_reasoning_effort:
           (Runtime_inference.resolve_reasoning_effort ~runtime_id)
-        ~max_prompt_bytes:
-          (Runtime_inference.resolve_max_prompt_bytes ~runtime_id)
         ~runtime_label
         ~keeper_name
         ~turn_count

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -325,8 +325,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       Host.prepare_turn
         ~configured_reasoning_effort:
           (Runtime_inference.resolve_reasoning_effort ~runtime_id)
-        ~max_prompt_bytes:
-          (Runtime_inference.resolve_max_prompt_bytes ~runtime_id)
         ~runtime_label
         ~keeper_name
         ~turn_count

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -143,7 +143,6 @@ type prepared_turn =
   ; system_prompt : string
   ; tools : Agent_core.Tool.t list
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
-  ; seed_dropped_atoms : int
   }
 
 let resolve_reasoning_effort ~enable_thinking ~reasoning_effort =
@@ -168,7 +167,7 @@ let measure_message_bytes (message : Agent_core.Types.message) =
 
 let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
     ~initial_messages ~model_input_projection ~hooks ~configured_reasoning_effort
-    ~max_prompt_bytes =
+    =
   let hooks = match hooks with Some hooks -> hooks | None -> Agent_core.Hooks.empty in
   let before_turn =
     invoke_turn_hook
@@ -250,56 +249,19 @@ let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
   let system_prompt =
     Option.value turn_params.system_prompt_override ~default:system_prompt
   in
-  (* An official-client turn 1 seeds the vendor conversation with the whole
-     projected history; from turn 2 the client owns the transcript and the
-     adapters send only the goal. So an unbounded seed does not fail once — it
-     fails on turn 1, never reaches turn 2, and re-renders a larger history on
-     the next cycle. Recovery closes the loop rather than breaking it: a fresh
-     session resets the counter, which makes the next turn a start turn again.
-     Measured on the live fleet with three keepers pinned at turn_count = 1,
-     one of them auto-superseding to a fresh session 293 times in a single log.
+  (* No preemptive cut of the seed. The provider owns its own window and says
+     so in a typed terminal — glm code 1261, Codex "Context overflow" — which
+     [Keeper_turn_driver_try_provider.context_overflow_shrink_sequence] already
+     consumes to shrink and retry, starting from
+     [unbounded_model_input_capacity_bytes]. Cutting here as well meant two
+     authorities over the same window, and the one that ran first measured in
+     wire bytes rather than tokens and discarded the oldest atoms outright.
 
-     The newest messages are kept, since the goal answers the most recent turn
-     and trimming the tail would drop exactly the context it refers to.
-     [dropped_atoms] is returned to the caller rather than logged here so the
-     loss lands on the keeper's own line; a silent window would read as "the
-     model saw everything".
-
-     Applied here rather than in each adapter because all three consume
-     [messages] for the same purpose and would otherwise carry three copies of
-     one rule. Resume paths ignore [messages] entirely, so windowing is a no-op
-     for them. *)
-  let* messages, seed_dropped_atoms =
-    match max_prompt_bytes with
-    | None -> Ok (messages, 0)
-    | Some capacity_bytes ->
-      let reserved_bytes = String.length system_prompt in
-      (match
-         Runtime_model_input_tail_window.project_with_drop
-           ~measure_message_bytes
-           ~capacity_bytes
-           ~reserved_bytes
-           messages
-       with
-       | Ok projection ->
-         let dropped = projection.Runtime_model_input_tail_window.dropped_atoms in
-         if dropped > 0
-         then
-           Log.Keeper.warn
-             "%s: %s start-turn seed dropped %d oldest message atom(s) to fit               the declared %d-byte prompt budget"
-             keeper_name
-             runtime_label
-             dropped
-             capacity_bytes;
-         Ok (projection.Runtime_model_input_tail_window.messages, dropped)
-       | Error error ->
-         Error
-           (config_error
-              ~field:"max_prompt_bytes"
-              (runtime_label
-               ^ " start-turn seed does not fit the declared prompt budget: "
-               ^ Runtime_model_input_tail_window.budget_error_to_string error)))
-  in
+     The discard was the part that could not be justified: it removed
+     conversation the keeper had already committed to, kept no copy, and its
+     [seed_dropped_atoms] receipt had no reader anywhere in the tree — the loss
+     was reported to nobody. Reactive shrink loses nothing the provider has not
+     already refused to accept. *)
   let unsupported_parameter field value =
     match value with
     | None -> Ok ()
@@ -337,7 +299,6 @@ let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
     ; system_prompt
     ; tools
     ; reasoning_effort
-    ; seed_dropped_atoms
     }
 ;;
 

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -9,7 +9,6 @@ type prepared_turn =
   ; system_prompt : string
   ; tools : Agent_core.Tool.t list
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
-  ; seed_dropped_atoms : int
   }
 
 type dynamic_tool_result =
@@ -122,7 +121,6 @@ val prepare_turn :
   model_input_projection:Agent_core.Agent.model_input_projection option ->
   hooks:Agent_core.Hooks.hooks option ->
   configured_reasoning_effort:Llm_provider.Reasoning_effort.t option ->
-  max_prompt_bytes:int option ->
   (prepared_turn, Agent_core.Error.t) result
 (** [configured_reasoning_effort] seeds the turn params the
     [before_turn_params] hook receives, so a hook can still override it.
@@ -132,10 +130,13 @@ val prepare_turn :
     adapters must keep that message on their provider instruction surface; it
     is not an Agent Core synthetic User carrier.
 
-    [max_prompt_bytes] bounds the history a start turn seeds its conversation
-    with, keeping the newest messages. [None] applies no ceiling, which is the
-    behaviour before this parameter existed. [seed_dropped_atoms] on the result
-    reports what was left out so the caller can say so on its own log line. *)
+    The seed carries the projected history as-is. Nothing is cut here: the
+    provider owns its context window and reports exceeding it as a typed
+    terminal, which the shrink sequence in
+    {!Keeper_turn_driver_try_provider.context_overflow_shrink_sequence}
+    consumes to retry with less. A second ceiling applied before that one
+    measured wire bytes instead of tokens and dropped the oldest atoms with no
+    copy kept. *)
 
 val dynamic_tools :
   runtime_label:string ->

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -604,22 +604,14 @@ let validate_keeper_dispatch_request_caps
   let runtime_by_id id =
     List.find_opt (fun (runtime : t) -> String.equal runtime.id id) runtimes
   in
-  (* Both execution kinds need a declared ceiling on what a turn may send; they
-     differ only in which one, because they are bounded at different places.
-
-     Agent_core measures the serialized request body, so its ceiling is
-     max-request-body-bytes. An official-client turn never builds that body —
-     it seeds a spawned client's conversation on turn 1 and sends only the goal
-     afterwards — so its ceiling is max-prompt-bytes, on the seed.
-
-     Leaving official-client unbounded was not a smaller version of the same
-     rule; it was the absence of one. An undeclared seed does not fail once: it
-     overflows the model window on turn 1, so the session never reaches turn 2,
-     and a recovery to a fresh session makes the next turn a start turn again.
-     Measured while rotating keepers across the declared runtimes: 13 of 13
-     official-client runtimes without the declaration failed this way, and all
-     13 completed once it was declared. The four that already carried it were
-     the four that were already working. *)
+  (* Only Agent_core is checked here, because only Agent_core builds the
+     request whose size this bounds. An official-client turn hands its
+     conversation to a spawned vendor client that owns its own context window
+     and refuses an oversized one in a typed terminal; the shrink sequence
+     consumes that terminal and retries with less. Requiring a declared
+     max-prompt-bytes there added a second authority over the same window,
+     measured in wire bytes rather than tokens, and made its absence a boot
+     refusal — so a deployment could not choose to let the provider decide. *)
   let missing_ceiling runtime =
     match runtime.execution with
     | Runtime_execution.Agent_core provider_config ->
@@ -629,34 +621,23 @@ let validate_keeper_dispatch_request_caps
          Some
            ( runtime
            , Otoml.string_of_path
-               [ runtime.binding.provider_id; runtime.binding.model_id ]
-           , "max-request-body-bytes"
-           , "the exact serialized request" ))
+               [ runtime.binding.provider_id; runtime.binding.model_id ] ))
     | Runtime_execution.Codex_app_server _
     | Runtime_execution.Claude_code _
-    | Runtime_execution.Antigravity_cli _ ->
-      (match runtime.model.max_prompt_bytes with
-       | Some n when n > 0 -> None
-       | Some _ | None ->
-         Some
-           ( runtime
-           , Otoml.string_of_path [ "models"; runtime.binding.model_id ]
-           , "max-prompt-bytes"
-           , "the start-turn conversation seed" ))
+    | Runtime_execution.Antigravity_cli _ -> None
   in
   match List.find_map (fun id -> Option.bind (runtime_by_id id) missing_ceiling) ids with
   | None -> Ok ()
-  | Some (runtime, table_path, key, what) ->
+  | Some (runtime, table_path) ->
     Error
       (Printf.sprintf
-         "%s: Keeper-dispatch runtime %S has no positive %s; declare \
-          [%s].%s before dispatch so %s has an explicit admission ceiling"
+         "%s: Keeper-dispatch runtime %S has no positive \
+          max-request-body-bytes; declare [%s].max-request-body-bytes before \
+          dispatch so the exact serialized request has an explicit admission \
+          ceiling"
          config_path
          runtime.id
-         key
-         table_path
-         key
-         what)
+         table_path)
 ;;
 
 (* Every runtime binding's provider/model pair must be known to the AGENT_CORE

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -278,7 +278,7 @@ let msg role text : Agent_core.Types.message =
   ; tool_call_id = None; metadata = [] }
 ;;
 
-let prepare ?max_prompt_bytes messages =
+let prepare messages =
   Host.prepare_turn
     ~runtime_label:"Fixture"
     ~keeper_name:"seed-fixture"
@@ -289,7 +289,6 @@ let prepare ?max_prompt_bytes messages =
     ~model_input_projection:None
     ~hooks:None
     ~configured_reasoning_effort:None
-    ~max_prompt_bytes
 ;;
 
 let test_extra_system_context_keeps_typed_provenance () =
@@ -324,7 +323,6 @@ let test_extra_system_context_keeps_typed_provenance () =
               Ok messages))
       ~hooks:(Some hooks)
       ~configured_reasoning_effort:None
-      ~max_prompt_bytes:None
   in
   (match result with
    | Error error -> fail (Agent_core.Error.to_string error)
@@ -385,38 +383,33 @@ let seed_history () =
       (Printf.sprintf "history message %03d" i))
 ;;
 
-let test_seed_is_bounded_and_keeps_the_newest () =
+(* The seed reaches the provider whole. This is the assertion that fails if a
+   preemptive cut is reintroduced here: the provider owns its context window
+   and refuses an oversized conversation in a typed terminal that the shrink
+   sequence retries, so a second ceiling applied before that one could only
+   discard history the provider had not yet objected to. Byte count is checked
+   alongside the message count because a cut that replaced content while
+   keeping the list length would pass a count-only check. *)
+let test_seed_reaches_the_provider_whole () =
   let messages = seed_history () in
   let total = List.fold_left (fun acc m -> acc + Host.measure_message_bytes m) 0 messages in
-  (* Controls first. Without them a bound that dropped everything, or one that
-     refused every turn, would still look correct below. *)
-  (match prepare messages with
-   | Error _ -> fail "an undeclared ceiling must not fail the turn"
-   | Ok prepared ->
-     check int "keeps every message" 240 (List.length prepared.messages);
-     check int "reports no drop" 0 prepared.seed_dropped_atoms);
-  (match prepare ~max_prompt_bytes:(total * 2) messages with
-   | Error _ -> fail "a generous ceiling must not fail the turn"
-   | Ok prepared ->
-     check int "keeps every message" 240 (List.length prepared.messages);
-     check int "reports no drop" 0 prepared.seed_dropped_atoms);
-  (* Half the history's worth of budget has to cut, and what survives must be
-     the newest: the goal answers the most recent turn, so trimming the tail
-     would drop exactly the context it refers to. *)
-  match prepare ~max_prompt_bytes:(total / 2) messages with
+  match prepare messages with
   | Error e ->
-    fail ("a partial fit must window rather than fail: " ^ Agent_core.Error.to_string e)
+    fail ("a large seed must not fail the turn: " ^ Agent_core.Error.to_string e)
   | Ok prepared ->
-    check bool "drops something" true (prepared.seed_dropped_atoms > 0);
-    check bool "keeps fewer than all" true (List.length prepared.messages < 240);
+    check int "keeps every message" 240 (List.length prepared.messages);
     let kept =
       List.fold_left (fun acc m -> acc + Host.measure_message_bytes m) 0 prepared.messages
     in
-    check bool "fits the declared budget" true (kept <= total / 2);
+    check int "keeps every byte" total kept;
+    (match prepared.messages with
+     | first :: _ ->
+       check string "keeps the oldest" "history message 000" (text_of first)
+     | [] -> fail "the seed must not be emptied");
     (match List.rev prepared.messages with
      | last :: _ ->
        check string "keeps the newest" "history message 239" (text_of last)
-     | [] -> fail "the window must not empty the history")
+     | [] -> fail "the seed must not be emptied")
 ;;
 
 let () =
@@ -472,9 +465,9 @@ let () =
             `Quick
             test_extra_system_context_keeps_typed_provenance
         ; test_case
-            "bounds the seed and keeps the newest messages"
+            "seed reaches the provider whole"
             `Quick
-            test_seed_is_bounded_and_keeps_the_newest
+            test_seed_reaches_the_provider_whole
         ] )
     ]
 ;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1839,19 +1839,20 @@ let test_runtime_config_validation_rejects_uncapped_keeper_candidate () =
            (String_util.contains_substring detail "local.lane"))
 ;;
 
-(* The Agent_core rule above bounds the serialized request body. An
-   official-client turn never builds that body — it seeds a spawned client's
-   conversation on turn 1 and sends only the goal afterwards — so its ceiling
-   sits on the seed instead. Leaving that side unbounded was the absence of a
-   rule, not a lighter version of one: an undeclared seed overflows the model
-   window on turn 1, the session never reaches turn 2, and recovery to a fresh
-   session makes the next turn a start turn again.
+(* The Agent_core rule above bounds the serialized request body, and stops
+   there. An official-client turn never builds that body: it hands its
+   conversation to a spawned vendor client that owns its own context window and
+   refuses an oversized one in a typed terminal, which the shrink sequence
+   retries with less. Requiring a declared max-prompt-bytes there made the
+   provider's own window a boot-time obligation on the operator, so a
+   deployment could not choose to let the provider decide — and the ceiling it
+   demanded was in wire bytes, which is not the unit the window is in.
 
-   Measured while rotating keepers across the declared runtimes: 13 of 13
-   official-client runtimes without the declaration failed this way, and all 13
-   completed once it was declared. *)
-let test_runtime_config_validation_rejects_unbounded_official_client_seed () =
-  let content bound =
+   This pins the removal in both directions: the official-client side must
+   load undeclared, and the Agent_core side must still reject. Without the
+   second half, deleting the whole check would also pass. *)
+let test_runtime_config_validation_admits_undeclared_official_client_seed () =
+  let content ~bound ~agent_core_cap =
     Printf.sprintf
       "[providers.local]\n\
        protocol = \"openai-compatible-http\"\n\
@@ -1870,8 +1871,7 @@ let test_runtime_config_validation_rejects_unbounded_official_client_seed () =
        api-name = \"seeded\"\n\
        max-context = 1024\n%s\
        \n\
-       [local.sample]\n\
-       max-request-body-bytes = 65536\n\
+       [local.sample]\n%s\
        \n\
        [subscription.seeded]\n\
        \n\
@@ -1881,7 +1881,9 @@ let test_runtime_config_validation_rejects_unbounded_official_client_seed () =
        [runtime.assignments]\n\
        \"probe\" = \"subscription.seeded\"\n"
       bound
+      agent_core_cap
   in
+  let declared_agent_core_cap = "max-request-body-bytes = 65536\n" in
   let attempt text =
     let snapshot = Runtime.For_testing.snapshot () in
     let path = Filename.temp_file "official_seed_" ".toml" in
@@ -1895,30 +1897,43 @@ let test_runtime_config_validation_rejects_unbounded_official_client_seed () =
         | Sys_error _ -> ())
       (fun () -> Runtime.save_config_text ~runtime_config_path:path text)
   in
-  (match attempt (content "") with
-   | Ok () ->
-     fail "an official-client Keeper runtime with no max-prompt-bytes must be rejected"
+  (match
+     attempt (content ~bound:"" ~agent_core_cap:declared_agent_core_cap)
+   with
+   | Ok () -> ()
    | Error detail ->
-     check bool "the diagnostic names the key an operator must add" true
-     (String_util.contains_substring detail "max-prompt-bytes");
-     check bool "the diagnostic names the runtime" true
-       (String_util.contains_substring detail "subscription.seeded");
-     check bool
-       "the remediation points at the model table that owns the key"
-       true
-       (String_util.contains_substring
-          detail
-          "[models.seeded].max-prompt-bytes");
-     (* The Agent_core key would send the operator to the wrong line. *)
-     check bool "the diagnostic does not name the Agent_core key" false
-       (String_util.contains_substring detail "max-request-body-bytes"));
-  (* Control and remediation round-trip: the same table/key emitted above is
-     applied to the config and must make it load. Without this, a diagnostic
-     that pointed at a syntactically plausible but unconsumed table could pass
-     the substring assertions while startup remained stuck. *)
-  match attempt (content "max-prompt-bytes = 131072\n") with
-  | Ok () -> ()
-  | Error detail -> failf "a declared seed bound must load: %s" detail
+     failf
+       "an official-client Keeper runtime with no max-prompt-bytes must load: %s"
+       detail);
+  (* Declaring it stays legal — the key still exists for operators who want the
+     seed bounded; it is simply no longer an admission condition. *)
+  (match
+     attempt
+       (content
+          ~bound:"max-prompt-bytes = 131072\n"
+          ~agent_core_cap:declared_agent_core_cap)
+   with
+   | Ok () -> ()
+   | Error detail -> failf "a declared seed bound must still load: %s" detail);
+  (* Control. The Agent_core half of this validator must still reject, or the
+     two assertions above would also pass with the whole check deleted. The
+     remediation assertion is kept from #28175: a diagnostic naming a
+     syntactically plausible but unconsumed table would satisfy a bare key
+     substring while startup stayed stuck. *)
+  match attempt (content ~bound:"" ~agent_core_cap:"") with
+  | Ok () ->
+    fail "an Agent_core Keeper runtime with no max-request-body-bytes must be rejected"
+  | Error detail ->
+    check bool "the diagnostic names the Agent_core key" true
+      (String_util.contains_substring detail "max-request-body-bytes");
+    check bool
+      "the remediation points at the binding table that owns the key"
+      true
+      (String_util.contains_substring
+         detail
+         "[local.sample].max-request-body-bytes");
+    check bool "the diagnostic does not demand the seed key" false
+      (String_util.contains_substring detail "max-prompt-bytes")
 ;;
 
 let test_runtime_config_validation_rejects_uncapped_special_runtime () =
@@ -3890,9 +3905,9 @@ let () =
             `Quick
             test_runtime_config_validation_rejects_uncapped_special_runtime;
           test_case
-            "runtime config rejects an unbounded official-client seed"
+            "runtime config admits an undeclared official-client seed"
             `Quick
-            test_runtime_config_validation_rejects_unbounded_official_client_seed;
+            test_runtime_config_validation_admits_undeclared_official_client_seed;
           test_case
             "runtime config allows uncapped dormant lane candidate"
             `Quick


### PR DESCRIPTION
fix(keeper): stop cutting the official-client seed, and stop demanding a cap

The official-client start turn ran its projected history through
Runtime_model_input_tail_window.project_with_drop before handing it to the
spawned vendor client, discarding the oldest atoms to fit a declared
max-prompt-bytes. #28157 then made that declaration a boot refusal, so a
deployment could not decline the cut.

Three things were wrong with it.

The provider already owns this window and already says so. glm answers
{"code":"1261","message":"Prompt exceeds max length"} and Codex answers
"Context overflow: Codex ran out of room in the model's context window"; both
reach Llm_provider.Retry.ContextOverflow, and
Keeper_turn_driver_try_provider.context_overflow_shrink_sequence consumes that
to shrink and retry -- starting from unbounded_model_input_capacity_bytes. The
seed cut was a second authority over the same window, running first.

Its unit is wrong. runtime_codex_app_server.mli says it plainly of the measure
this used: "Bytes this process sends, not provider tokens." The window is in
tokens; the cut was in wire bytes, anchored to no derivation. The live config
records the anchoring it did use -- "이 배포에서 실제로 동작 중인 캡에
앵커한다" -- which is another invented number, not a derived one.

And it discarded. The reactive path retries with less; this one removed
conversation the keeper had already committed to and kept no copy. Its
[seed_dropped_atoms] receipt had no reader anywhere in the tree, so the loss
was reported to nobody. Live today: 783 cuts, 2280-3060 atoms each.

None of Orca, Hermes, or claw-orchestrator does this. Read from source, not
docs: claw-orchestrator's only production Buffer.byteLength is an HTTP
Content-Length and its one truncation is COMPACT_CONTEXT_CHARS = 300, in
chars, for council summaries; Hermes truncates history only by user ordinal
behind a confirm_truncate gate that logs "prompt.submit: REFUSED unconfirmed
truncation" without it, and caps tool output by char_limit while storing the
full text on disk; Orca runs the CLI under node-pty and re-attaches with
['claude', '--resume', id], so it never builds a prompt to cut.

Removes the cut, the ~max_prompt_bytes parameter on the three adapters that
threaded it, the unread seed_dropped_atoms field, and the official-client half
of validate_keeper_dispatch_request_caps. The Agent_core half is untouched --
it bounds the serialized request body, which Agent_core does build.

max-prompt-bytes stays a legal declaration; it is simply no longer an
admission condition. Nothing in the live config needs to change.

Both removals are pinned by an inverted control, since a deletion passes any
test that only asserts the old behaviour is gone:

  seed reaches the provider whole      counts messages AND bytes, so a cut
                                       that preserved list length would still
                                       fail
  admits an undeclared seed            asserts the official-client side loads
                                       undeclared, and that the Agent_core
                                       side still rejects -- without the
                                       second half, deleting the whole
                                       validator would also pass

Verified by mutation in both directions. Restoring the boot gate:

  FAIL an official-client Keeper runtime with no max-prompt-bytes must load
  1 failure! 74 tests run

Reintroducing a cut in prepare_turn:

  FAIL keeps every message
  [FAIL] start-turn seed budget 1 seed reaches the provider whole

Both green when restored.

  dune build @check                                     clean
  @test/runtest-test_keeper_official_client_host        12 tests, Test Successful
  @test/runtest-test_runtime_config_validity            74 tests, Test Successful
  audit-ci-test-targets.sh                              OK, 186 CI targets
  ocamlformat --check (8 changed files)                 clean

Reverts the official-client rule from #28157. Does not address the reason a
seed is that large: the turn takes Start rather than Resume whenever
previous_settlement is None, so a failed turn re-seeds the whole history on the
next one. Filed separately.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

