### PR TITLE
fix(keeper): main does not compile — close two stream callbacks and finish an assertion

### DIFF
--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -113,7 +113,7 @@ let claude_stream_callback on_event =
                          (String.sub text (String.length streamed) suffix_length)
                    })
           end;
-          emit Agent_core.Types.MessageStop
+          emit Agent_core.Types.MessageStop)
 ;;
 
 let retry_after_of_rate_limit = function

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -201,7 +201,7 @@ let codex_stream_callback on_event =
                          (String.sub text (String.length streamed) suffix_length)
                    })
           end;
-          emit Agent_core.Types.MessageStop
+          emit Agent_core.Types.MessageStop)
 ;;
 
 let codex_error_to_core_error = function

--- a/test/keeper_chat_operations/test_keeper_chat_operation_store.ml
+++ b/test/keeper_chat_operations/test_keeper_chat_operation_store.ml
@@ -366,7 +366,16 @@ let test_statement_finalize_survives_gc_pressure () =
     if i mod 64 = 0 then Gc.minor ()
   done;
   ignore (Sys.opaque_identity !churn);
-  check bool "all inventory statements finalized under GC pressure" true
+  (* [check bool msg true] is a partial application: it is [bool -> unit], so
+     this case had the type [unit -> bool -> unit] and never ran an assertion.
+     The observable it was reaching for is that the store still answers after
+     the churn — a statement finalized out from under it surfaces as a failing
+     inventory, not as a silent one, so the read has to be taken and checked. *)
+  check
+    bool
+    "inventory still answers after GC pressure"
+    true
+    (Result.is_ok (Store.inventory store))
 ;;
 
 let () =


### PR DESCRIPTION
fix(keeper): close two stream callbacks and finish an assertion — main does not compile

main has not compiled since b72c7cae79 (#28136, 2026-08-11 16:58 KST). Three
defects, all from that merge:

  lib/keeper/keeper_claude_code_runtime.ml:117  Syntax error: ) expected
  lib/keeper/keeper_codex_runtime.ml:205        Syntax error: ) expected
  test/keeper_chat_operations/test_keeper_chat_operation_store.ml:389
      test_statement_finalize_survives_gc_pressure has type
      unit -> bool -> unit but unit -> unit was expected

Both runtimes open `Some (function ...` for the new stream callback and never
close it, so the following `;;` lands inside the match.

The third is not only a type error. The case ended on

  check bool "all inventory statements finalized under GC pressure" true

which is a partial application — [check bool msg true] is [bool -> unit], with
the actual value missing. Had it compiled it would have asserted nothing: the
case churns 2,000 inventory reads under Gc.minor and then tests nothing. It
now takes the read it was reaching for, because a statement finalized out from
under the store surfaces as a failing inventory rather than as a silent one.

Why this reached main: the merge commit's checks are

  CI: completed/cancelled
  Fundamental Check: completed/cancelled
  Build and Test: skipping

and #28136's own checks were red at merge time — check, Lint Suite,
ocamlformat-check, and TLA+ annotation drift all `fail`, with Build and Test
`skipping`. A cancelled run is not a failed run, so a listing that filters on
failure shows this commit as clean.

  dune build @check                                    clean (was 3 errors)
  @test/runtest-test_keeper_chat_operation_store       9 tests, Test Successful
  ocamlformat --check (3 changed files)                clean

Verified against the baseline: origin/main at 17e5eee868 with an empty working
tree reproduces all three errors, so none of them is mine.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

