### PR TITLE
fix(build): restore main — unclosed stream-callback match and a 3-arg Alcotest check

### DIFF
--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -113,7 +113,7 @@ let claude_stream_callback on_event =
                          (String.sub text (String.length streamed) suffix_length)
                    })
           end;
-          emit Agent_core.Types.MessageStop
+          emit Agent_core.Types.MessageStop)
 ;;
 
 let retry_after_of_rate_limit = function

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -201,7 +201,7 @@ let codex_stream_callback on_event =
                          (String.sub text (String.length streamed) suffix_length)
                    })
           end;
-          emit Agent_core.Types.MessageStop
+          emit Agent_core.Types.MessageStop)
 ;;
 
 let codex_error_to_core_error = function

--- a/test/keeper_chat_operations/test_keeper_chat_operation_store.ml
+++ b/test/keeper_chat_operations/test_keeper_chat_operation_store.ml
@@ -359,14 +359,17 @@ let test_close_is_idempotent_and_refuses_later_operations () =
 
 let test_statement_finalize_survives_gc_pressure () =
   with_store "finalize-gc-pressure" @@ fun _path store ->
+  let iterations = 2_000 in
   let churn = ref [] in
-  for i = 1 to 2_000 do
+  let inventoried = ref 0 in
+  for i = 1 to iterations do
     ignore (store_ok (Store.inventory store));
+    incr inventoried;
     churn := String.make 256 'x' :: (if i mod 16 = 0 then [] else !churn);
     if i mod 64 = 0 then Gc.minor ()
   done;
   ignore (Sys.opaque_identity !churn);
-  check bool "all inventory statements finalized under GC pressure" true
+  check int "all inventory statements finalized under GC pressure" iterations !inventoried
 ;;
 
 let () =


### PR DESCRIPTION
main이 #28136(`b72c7cae79`) 이후 컴파일되지 않습니다. 세 곳을 복구합니다.

## 증상

```
$ dune build lib/masc.cma
File "lib/keeper/keeper_codex_runtime.ml", line 205, characters 0-2:
Error: Syntax error: ) expected
File "lib/keeper/keeper_codex_runtime.ml", line 156, characters 6-7:
  This '(' might be unmatched
```

`git show origin/main:lib/keeper/keeper_codex_runtime.ml` 의 괄호 delta = `+1`. `keeper_claude_code_runtime.ml` 도 동일하게 `+1`.

## 원인

| 파일 | 내용 |
|---|---|
| `lib/keeper/keeper_codex_runtime.ml` | `codex_stream_callback` 의 `Some (function ...` 가 닫히지 않음 |
| `lib/keeper/keeper_claude_code_runtime.ml` | `claude_stream_callback` 이 같은 형태, 같은 누락 |
| `test/keeper_chat_operations/test_keeper_chat_operation_store.ml` | `check bool msg true` 가 Alcotest `check` 4인자 중 3개만 전달 → 케이스 타입이 `unit -> bool -> unit` |

두 런타임 파일은 같은 템플릿에서 복제되며 같은 결함을 함께 옮겼습니다.

## 변경

- 스트림 콜백 두 곳의 마지막 arm 뒤에 `)` 추가
- 테스트는 빠진 인자를 `true` 로 채우지 않고 **완주 횟수를 세어 비교**하도록 변경. `check bool msg true true` 는 스토어가 망가져도 통과하는 항등식이 됩니다. 지금은 루프가 중간에 멈추면 실패합니다.

## 검증 (로컬)

| 명령 | 결과 |
|---|---|
| `dune build --root . lib/masc.cma` | exit 0 |
| `dune build --root . @check` (전체 트리) | exit 0, Error 0건 |
| `test_keeper_chat_operation_store.exe` | 9 tests, 전부 통과 |
| `test_runtime_codex_app_server.exe` | 47 tests, 전부 통과 |

수정 전 동일 트리에서 `@check` 는 위 3건으로 실패합니다.

## CI 가 놓친 경로

머지 커밋 5건의 `Build and Test` 결론:

```
b72c7cae79  cancelled
6f23f6f25a  cancelled
6aba658d32  cancelled
33fb613f91  cancelled
17e5eee868  failure
```

`cancelled` 는 `failure` 로 집계되지 않아 rollup 이 red 를 드러내지 않습니다. 4커밋 동안 깨진 채로 머지가 계속됐고, 그 위에 열린 PR 이 현재 10건입니다.

RFC-WAIVED: 빌드 복구. 동작 변경 없음(괄호 2개 + 테스트 단언 인자). credential / operator control / sandbox / hooks 어느 subsystem 도 건드리지 않음.
