### PR TITLE
fix(schedule): keep dashboard evidence reads non-mutating

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -894,108 +894,196 @@ let max_recorded_at current candidate =
   | Some left, Some right -> Some (Float.max left right)
 ;;
 
-let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
-  if String.equal stimulus_id ""
+type event_queue_reaction_evidence_accumulator =
+  { mutable stimulus_seen : bool
+  ; mutable turn_started_seen : bool
+  ; mutable event_queue_ack_seen : bool
+  ; mutable event_queue_cancelled_seen : bool
+  ; mutable stimulus_recorded_at : float option
+  ; mutable turn_started_recorded_at : float option
+  ; mutable event_queue_ack_recorded_at : float option
+  ; mutable event_queue_cancelled_recorded_at : float option
+  ; mutable latest_recorded_at : float option
+  ; mutable matched_record_count : int
+  ; mutable quarantined_record_count : int
+  ; mutable first_matching_quarantine_reason : row_quarantine_reason option
+  ; mutable seen_event_ids : Event_id_set.t
+  }
+
+let empty_event_queue_reaction_evidence_accumulator () =
+  { stimulus_seen = false
+  ; turn_started_seen = false
+  ; event_queue_ack_seen = false
+  ; event_queue_cancelled_seen = false
+  ; stimulus_recorded_at = None
+  ; turn_started_recorded_at = None
+  ; event_queue_ack_recorded_at = None
+  ; event_queue_cancelled_recorded_at = None
+  ; latest_recorded_at = None
+  ; matched_record_count = 0
+  ; quarantined_record_count = 0
+  ; first_matching_quarantine_reason = None
+  ; seen_event_ids = Event_id_set.empty
+  }
+;;
+
+let note_event_queue_reaction_evidence_row ~keeper_name accumulator row =
+  let is_replay =
+    match string_field "event_id" row with
+    | Some event_id
+      when not (String.equal event_id "")
+           && Event_id_set.mem event_id accumulator.seen_event_ids -> true
+    | Some event_id when not (String.equal event_id "") ->
+      accumulator.seen_event_ids
+        <- Event_id_set.add event_id accumulator.seen_event_ids;
+      false
+    | Some _ | None -> false
+  in
+  if not is_replay
+  then
+    match decode_current_row ~keeper_name row with
+    | Error reason ->
+      accumulator.quarantined_record_count
+        <- accumulator.quarantined_record_count + 1;
+      (match accumulator.first_matching_quarantine_reason with
+       | Some _ -> ()
+       | None -> accumulator.first_matching_quarantine_reason <- Some reason)
+    | Ok current_row ->
+      accumulator.matched_record_count <- accumulator.matched_record_count + 1;
+      let metadata =
+        match current_row with
+        | Current_stimulus { metadata; _ }
+        | Current_reaction { metadata; _ } -> metadata
+      in
+      let recorded_at = Some metadata.recorded_at in
+      accumulator.latest_recorded_at
+        <- max_recorded_at accumulator.latest_recorded_at recorded_at;
+      (match current_row with
+       | Current_stimulus _ ->
+         accumulator.stimulus_seen <- true;
+         accumulator.stimulus_recorded_at
+           <- max_recorded_at accumulator.stimulus_recorded_at recorded_at
+       | Current_reaction { reaction_kind = Turn_started; _ } ->
+         accumulator.turn_started_seen <- true;
+         accumulator.turn_started_recorded_at
+           <- max_recorded_at accumulator.turn_started_recorded_at recorded_at
+       | Current_reaction { reaction_kind = Event_queue_ack; _ } ->
+         accumulator.event_queue_ack_seen <- true;
+         accumulator.event_queue_ack_recorded_at
+           <- max_recorded_at accumulator.event_queue_ack_recorded_at recorded_at
+       | Current_reaction { reaction_kind = Event_queue_cancelled; _ } ->
+         accumulator.event_queue_cancelled_seen <- true;
+         accumulator.event_queue_cancelled_recorded_at
+           <- max_recorded_at
+                accumulator.event_queue_cancelled_recorded_at
+                recorded_at)
+;;
+
+let event_queue_reaction_evidence_of_accumulator
+      ~keeper_name
+      ~stimulus_id
+      accumulator
+  =
+  let evidence =
+    { keeper_name
+    ; stimulus_id
+    ; stimulus_seen = accumulator.stimulus_seen
+    ; turn_started_seen = accumulator.turn_started_seen
+    ; event_queue_ack_seen = accumulator.event_queue_ack_seen
+    ; event_queue_cancelled_seen = accumulator.event_queue_cancelled_seen
+    ; stimulus_recorded_at = accumulator.stimulus_recorded_at
+    ; turn_started_recorded_at = accumulator.turn_started_recorded_at
+    ; event_queue_ack_recorded_at = accumulator.event_queue_ack_recorded_at
+    ; event_queue_cancelled_recorded_at =
+        accumulator.event_queue_cancelled_recorded_at
+    ; latest_recorded_at = accumulator.latest_recorded_at
+    ; matched_record_count = accumulator.matched_record_count
+    ; quarantined_record_count = accumulator.quarantined_record_count
+    }
+  in
+  match accumulator.first_matching_quarantine_reason with
+  | Some first_reason -> Evidence_quarantined { evidence; first_reason }
+  | None -> Evidence_complete evidence
+;;
+
+let unique_stimulus_ids stimulus_ids =
+  let seen = Hashtbl.create (List.length stimulus_ids) in
+  List.fold_left
+    (fun unique stimulus_id ->
+       if Hashtbl.mem seen stimulus_id
+       then unique
+       else (
+         Hashtbl.add seen stimulus_id ();
+         stimulus_id :: unique))
+    []
+    stimulus_ids
+  |> List.rev
+;;
+
+let event_queue_reaction_evidence_batch_result
+      ~base_path
+      ~keeper_name
+      ~stimulus_ids
+  =
+  if List.exists (String.equal "") stimulus_ids
   then Error Evidence_invalid_stimulus_id
-  else begin
-  let stimulus_seen = ref false in
-  let turn_started_seen = ref false in
-  let event_queue_ack_seen = ref false in
-  let event_queue_cancelled_seen = ref false in
-  let stimulus_recorded_at = ref None in
-  let turn_started_recorded_at = ref None in
-  let event_queue_ack_recorded_at = ref None in
-  let event_queue_cancelled_recorded_at = ref None in
-  let latest_recorded_at = ref None in
-  let matched_record_count = ref 0 in
-  let quarantined_record_count = ref 0 in
-  let first_matching_quarantine_reason = ref None in
-  let seen_event_ids = ref Event_id_set.empty in
-  let remember_first slot value =
-    match !slot with
-    | Some _ -> ()
-    | None -> slot := Some value
-  in
-  let note_matching_row row =
-    let is_replay =
-      match string_field "event_id" row with
-      | Some event_id
-        when not (String.equal event_id "")
-             && Event_id_set.mem event_id !seen_event_ids -> true
-      | Some event_id when not (String.equal event_id "") ->
-        seen_event_ids := Event_id_set.add event_id !seen_event_ids;
-        false
-      | Some _ | None -> false
-    in
-    if not is_replay
-    then
-      match decode_current_row ~keeper_name row with
-      | Error reason ->
-        incr quarantined_record_count;
-        remember_first first_matching_quarantine_reason reason
-      | Ok current_row ->
-        incr matched_record_count;
-        let metadata =
-          match current_row with
-          | Current_stimulus { metadata; _ }
-          | Current_reaction { metadata; _ } -> metadata
-        in
-        let recorded_at = Some metadata.recorded_at in
-        latest_recorded_at := max_recorded_at !latest_recorded_at recorded_at;
-        (match current_row with
-         | Current_stimulus _ ->
-           stimulus_seen := true;
-           stimulus_recorded_at
-             := max_recorded_at !stimulus_recorded_at recorded_at
-         | Current_reaction { reaction_kind = Turn_started; _ } ->
-           turn_started_seen := true;
-           turn_started_recorded_at
-             := max_recorded_at !turn_started_recorded_at recorded_at
-         | Current_reaction { reaction_kind = Event_queue_ack; _ } ->
-           event_queue_ack_seen := true;
-           event_queue_ack_recorded_at
-             := max_recorded_at !event_queue_ack_recorded_at recorded_at
-         | Current_reaction { reaction_kind = Event_queue_cancelled; _ } ->
-           event_queue_cancelled_seen := true;
-           event_queue_cancelled_recorded_at
-             := max_recorded_at !event_queue_cancelled_recorded_at recorded_at)
-  in
-  let note_parsed_row row =
-    match string_field "stimulus_id" row with
-    | Some row_stimulus_id when String.equal row_stimulus_id stimulus_id ->
-      note_matching_row row
-    | Some _ | None -> ()
-  in
-  let store = store_for_base_path ~base_path ~keeper_name in
-  let iteration =
-    Dated_jsonl.iter_all_entries_result store (function
-      | Dated_jsonl.Parsed row -> note_parsed_row row
-      | Dated_jsonl.Malformed_json _ -> ())
-  in
-  match iteration with
-  | Error error -> Error (Evidence_read_error error)
-  | Ok () ->
-    let evidence =
-      { keeper_name
-      ; stimulus_id
-      ; stimulus_seen = !stimulus_seen
-      ; turn_started_seen = !turn_started_seen
-      ; event_queue_ack_seen = !event_queue_ack_seen
-      ; event_queue_cancelled_seen = !event_queue_cancelled_seen
-      ; stimulus_recorded_at = !stimulus_recorded_at
-      ; turn_started_recorded_at = !turn_started_recorded_at
-      ; event_queue_ack_recorded_at = !event_queue_ack_recorded_at
-      ; event_queue_cancelled_recorded_at = !event_queue_cancelled_recorded_at
-      ; latest_recorded_at = !latest_recorded_at
-      ; matched_record_count = !matched_record_count
-      ; quarantined_record_count = !quarantined_record_count
-      }
-    in
-    (match !first_matching_quarantine_reason with
-     | Some first_reason ->
-       Ok (Evidence_quarantined { evidence; first_reason })
-     | None -> Ok (Evidence_complete evidence))
-  end
+  else
+    let stimulus_ids = unique_stimulus_ids stimulus_ids in
+    match stimulus_ids with
+    | [] -> Ok []
+    | _ ->
+      let accumulators = Hashtbl.create (List.length stimulus_ids) in
+      let requested =
+        List.map
+          (fun stimulus_id ->
+             stimulus_id, empty_event_queue_reaction_evidence_accumulator ())
+          stimulus_ids
+      in
+      List.iter
+        (fun (stimulus_id, accumulator) ->
+           Hashtbl.add accumulators stimulus_id accumulator)
+        requested;
+      let note_parsed_row row =
+        match string_field "stimulus_id" row with
+        | Some stimulus_id ->
+          (match Hashtbl.find_opt accumulators stimulus_id with
+           | Some accumulator ->
+             note_event_queue_reaction_evidence_row
+               ~keeper_name
+               accumulator
+               row
+           | None -> ())
+        | None -> ()
+      in
+      let store = store_for_base_path ~base_path ~keeper_name in
+      (match
+         Dated_jsonl.iter_all_entries_result store (function
+           | Dated_jsonl.Parsed row -> note_parsed_row row
+           | Dated_jsonl.Malformed_json _ -> ())
+       with
+       | Error error -> Error (Evidence_read_error error)
+       | Ok () ->
+         Ok
+           (List.map
+              (fun (stimulus_id, accumulator) ->
+                 ( stimulus_id
+                 , event_queue_reaction_evidence_of_accumulator
+                     ~keeper_name
+                     ~stimulus_id
+                     accumulator ))
+              requested))
+;;
+
+let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
+  match
+    event_queue_reaction_evidence_batch_result
+      ~base_path
+      ~keeper_name
+      ~stimulus_ids:[ stimulus_id ]
+  with
+  | Error _ as error -> error
+  | Ok [ (_, evidence) ] -> Ok evidence
+  | Ok _ -> Error Evidence_invalid_stimulus_id
 ;;
 
 let event_queue_turn_started_seen_for_source_result

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -120,6 +120,21 @@ val event_queue_reaction_evidence_result :
     terminals remain distinct typed evidence. Empty query identities and
     storage failures remain typed errors. *)
 
+val event_queue_reaction_evidence_batch_result :
+  base_path:string ->
+  keeper_name:string ->
+  stimulus_ids:string list ->
+  ( (string * event_queue_reaction_evidence_outcome) list
+  , event_queue_reaction_evidence_error )
+  result
+(** Read the complete keeper-local ledger exactly once and build exact
+    evidence for every requested stimulus identity. Duplicate identities are
+    collapsed while preserving first-request order. This is the request-level
+    projection seam for bounded dashboards: rendering N rows for one Keeper
+    performs one ledger scan, not N complete scans. An empty identity rejects
+    the whole batch with {!Evidence_invalid_stimulus_id}; an empty query list
+    returns [Ok []]. *)
+
 val event_queue_turn_started_seen_for_source_result :
   base_path:string ->
   keeper_name:string ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -177,6 +177,7 @@ type snapshot_read_error_kind =
   | Invalid_path
   | Read_failed
   | Parse_failed
+  | Incoherent_read
 
 type snapshot_read_error =
   { kind : snapshot_read_error_kind
@@ -188,6 +189,7 @@ let snapshot_read_error_kind_to_string = function
   | Invalid_path -> "invalid_path"
   | Read_failed -> "read_failed"
   | Parse_failed -> "parse_failed"
+  | Incoherent_read -> "incoherent_read"
 ;;
 
 let reset_required_message ~path ~surface detail =
@@ -540,46 +542,60 @@ let validate_state_read_only_result_with ~require_existing ~base_path ~keeper_na
             (Printexc.to_string exn)))
 ;;
 
+type read_only_observation_error =
+  | Observation_read_failed of string
+  | Observation_changed of
+      { keeper_name : string
+      ; first_revision : int64
+      ; second_revision : int64
+      }
+
+let read_only_observation_error_to_string = function
+  | Observation_read_failed message -> message
+  | Observation_changed { keeper_name; first_revision; second_revision } ->
+    Printf.sprintf
+      "event queue changed during lock-free observation keeper=%s first_revision=%Ld second_revision=%Ld"
+      keeper_name
+      first_revision
+      second_revision
+;;
+
 let stable_read_only_observation ~keeper_name first second =
   if State.to_yojson first = State.to_yojson second
   then Ok second
   else
     Error
-      (Printf.sprintf
-         "event queue changed during lock-free observation keeper=%s first_revision=%Ld second_revision=%Ld"
-         keeper_name
-         (State.revision first)
-         (State.revision second))
+      (Observation_changed
+         { keeper_name
+         ; first_revision = State.revision first
+         ; second_revision = State.revision second
+         })
 ;;
 
-let observe_state_read_only_result_with ~between_samples ~base_path ~keeper_name =
+let observe_state_read_only_typed_with ~between_samples ~base_path ~keeper_name =
   match resolve_owner ~base_path ~keeper_name with
-  | Error _ as error -> error
+  | Error message -> Error (Observation_read_failed message)
   | Ok owner ->
     (try
        Result.bind
-         (read_state_read_only_unlocked ~require_existing:false owner)
+         (read_state_read_only_unlocked ~require_existing:false owner
+          |> Result.map_error (fun message -> Observation_read_failed message))
          (fun first ->
             between_samples ();
             Result.bind
-              (read_state_read_only_unlocked ~require_existing:false owner)
+              (read_state_read_only_unlocked ~require_existing:false owner
+               |> Result.map_error (fun message -> Observation_read_failed message))
               (stable_read_only_observation ~keeper_name))
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
        Error
-         (Printf.sprintf
-            "event queue lock-free observation raised keeper=%s path=%s: %s"
-            (keeper_name_of_owner owner)
-            (snapshot_path_of_owner owner)
-            (Printexc.to_string exn)))
-;;
-
-let observe_state_read_only_result ~base_path ~keeper_name =
-  observe_state_read_only_result_with
-    ~between_samples:(fun () -> ())
-    ~base_path
-    ~keeper_name
+         (Observation_read_failed
+            (Printf.sprintf
+               "event queue lock-free observation raised keeper=%s path=%s: %s"
+               (keeper_name_of_owner owner)
+               (snapshot_path_of_owner owner)
+               (Printexc.to_string exn))))
 ;;
 
 let validate_state_read_only_result ~base_path ~keeper_name =
@@ -651,18 +667,39 @@ let load_snapshot_with_errors ~base_path ~keeper_name =
     }
 ;;
 
-let observe_snapshot_with_errors ~base_path ~keeper_name =
-  match observe_state_read_only_result ~base_path ~keeper_name with
+let observe_snapshot_with_errors_with ~between_samples ~base_path ~keeper_name =
+  match
+    observe_state_read_only_typed_with
+      ~between_samples
+      ~base_path
+      ~keeper_name
+  with
   | Ok state -> { pending = State.pending state; read_errors = [] }
-  | Error message ->
+  | Error (Observation_read_failed message) ->
     { pending = Keeper_event_queue.empty
     ; read_errors = diagnose_snapshot_read_error ~base_path ~keeper_name message
     }
+  | Error (Observation_changed _ as error) ->
+    { pending = Keeper_event_queue.empty
+    ; read_errors =
+        [ { kind = Incoherent_read
+          ; path = None
+          ; message = read_only_observation_error_to_string error
+          }
+        ]
+    }
+;;
+
+let observe_snapshot_with_errors ~base_path ~keeper_name =
+  observe_snapshot_with_errors_with
+    ~between_samples:(fun () -> ())
+    ~base_path
+    ~keeper_name
 ;;
 
 module For_testing = struct
-  let observe_state_read_only_result_with_interleave =
-    observe_state_read_only_result_with
+  let observe_snapshot_with_errors_with_interleave =
+    observe_snapshot_with_errors_with
   ;;
 end
 

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -502,35 +502,54 @@ let load_existing_state_result ~base_path ~keeper_name =
             (Printexc.to_string exn)))
 ;;
 
+let read_state_read_only_unlocked ~require_existing owner =
+  match read_primary_unlocked owner with
+  | Error _ as error -> error
+  | Ok (Primary_current state) ->
+    replay_transition_wal_read_only_unlocked owner state
+  | Ok Primary_missing
+    when require_existing && not (durable_state_exists_unlocked owner) ->
+    Error
+      (Printf.sprintf
+         "event queue durable state is missing keeper=%s snapshot_path=%s wal_path=%s"
+         (keeper_name_of_owner owner)
+         (snapshot_path_of_owner owner)
+         (transition_wal_path_of_owner owner))
+  | Ok Primary_missing ->
+    replay_transition_wal_read_only_unlocked
+      ~wal_only:true
+      owner
+      State.empty
+;;
+
 let validate_state_read_only_result_with ~require_existing ~base_path ~keeper_name =
   match resolve_owner ~base_path ~keeper_name with
   | Error _ as error -> error
   | Ok owner ->
     (try
        Owner_lock.with_durable_lock owner (fun () ->
-         match read_primary_unlocked owner with
-         | Error _ as error -> error
-         | Ok (Primary_current state) ->
-           replay_transition_wal_read_only_unlocked owner state
-         | Ok Primary_missing
-           when require_existing && not (durable_state_exists_unlocked owner) ->
-           Error
-             (Printf.sprintf
-                "event queue durable state is missing keeper=%s snapshot_path=%s wal_path=%s"
-                (keeper_name_of_owner owner)
-                (snapshot_path_of_owner owner)
-                (transition_wal_path_of_owner owner))
-         | Ok Primary_missing ->
-           replay_transition_wal_read_only_unlocked
-             ~wal_only:true
-             owner
-             State.empty)
+         read_state_read_only_unlocked ~require_existing owner)
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
        Error
          (Printf.sprintf
             "event queue read-only validation raised keeper=%s path=%s: %s"
+            (keeper_name_of_owner owner)
+            (snapshot_path_of_owner owner)
+            (Printexc.to_string exn)))
+;;
+
+let observe_state_read_only_result ~base_path ~keeper_name =
+  match resolve_owner ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok owner ->
+    (try read_state_read_only_unlocked ~require_existing:false owner with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "event queue lock-free observation raised keeper=%s path=%s: %s"
             (keeper_name_of_owner owner)
             (snapshot_path_of_owner owner)
             (Printexc.to_string exn)))
@@ -598,6 +617,15 @@ let diagnose_snapshot_read_error ~base_path ~keeper_name message =
 
 let load_snapshot_with_errors ~base_path ~keeper_name =
   match load_state_result ~base_path ~keeper_name with
+  | Ok state -> { pending = State.pending state; read_errors = [] }
+  | Error message ->
+    { pending = Keeper_event_queue.empty
+    ; read_errors = diagnose_snapshot_read_error ~base_path ~keeper_name message
+    }
+;;
+
+let observe_snapshot_with_errors ~base_path ~keeper_name =
+  match observe_state_read_only_result ~base_path ~keeper_name with
   | Ok state -> { pending = State.pending state; read_errors = [] }
   | Error message ->
     { pending = Keeper_event_queue.empty

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -540,11 +540,31 @@ let validate_state_read_only_result_with ~require_existing ~base_path ~keeper_na
             (Printexc.to_string exn)))
 ;;
 
-let observe_state_read_only_result ~base_path ~keeper_name =
+let stable_read_only_observation ~keeper_name first second =
+  if State.to_yojson first = State.to_yojson second
+  then Ok second
+  else
+    Error
+      (Printf.sprintf
+         "event queue changed during lock-free observation keeper=%s first_revision=%Ld second_revision=%Ld"
+         keeper_name
+         (State.revision first)
+         (State.revision second))
+;;
+
+let observe_state_read_only_result_with ~between_samples ~base_path ~keeper_name =
   match resolve_owner ~base_path ~keeper_name with
   | Error _ as error -> error
   | Ok owner ->
-    (try read_state_read_only_unlocked ~require_existing:false owner with
+    (try
+       Result.bind
+         (read_state_read_only_unlocked ~require_existing:false owner)
+         (fun first ->
+            between_samples ();
+            Result.bind
+              (read_state_read_only_unlocked ~require_existing:false owner)
+              (stable_read_only_observation ~keeper_name))
+     with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
        Error
@@ -553,6 +573,13 @@ let observe_state_read_only_result ~base_path ~keeper_name =
             (keeper_name_of_owner owner)
             (snapshot_path_of_owner owner)
             (Printexc.to_string exn)))
+;;
+
+let observe_state_read_only_result ~base_path ~keeper_name =
+  observe_state_read_only_result_with
+    ~between_samples:(fun () -> ())
+    ~base_path
+    ~keeper_name
 ;;
 
 let validate_state_read_only_result ~base_path ~keeper_name =
@@ -632,6 +659,12 @@ let observe_snapshot_with_errors ~base_path ~keeper_name =
     ; read_errors = diagnose_snapshot_read_error ~base_path ~keeper_name message
     }
 ;;
+
+module For_testing = struct
+  let observe_state_read_only_result_with_interleave =
+    observe_state_read_only_result_with
+  ;;
+end
 
 type durable_state_discovery =
   { keeper_names : string list

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -159,10 +159,17 @@ val observe_snapshot_with_errors :
 (** Read-only operator projection of the pending queue. Unlike
     {!load_snapshot_with_errors}, this observer never acquires the canonical
     queue-owner transaction lock and never checkpoints or compacts the
-    transition WAL. Snapshot replacement and WAL reads remain atomic at their
-    individual file boundaries; a concurrent transition may therefore yield
-    an earlier coherent snapshot or an explicit read error, but cannot turn a
-    dashboard GET into queue-owner work. *)
+    transition WAL. It accepts only two identical full-state observations, so
+    a concurrent snapshot/WAL generation change is an explicit read error
+    rather than a healthy empty projection. *)
+
+module For_testing : sig
+  val observe_state_read_only_result_with_interleave :
+    between_samples:(unit -> unit) ->
+    base_path:string ->
+    keeper_name:string ->
+    (Keeper_event_queue_state.t, string) result
+end
 
 val load_state_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -131,6 +131,7 @@ type snapshot_read_error_kind =
   | Invalid_path
   | Read_failed
   | Parse_failed
+  | Incoherent_read
 
 type snapshot_read_error =
   { kind : snapshot_read_error_kind
@@ -164,11 +165,11 @@ val observe_snapshot_with_errors :
     rather than a healthy empty projection. *)
 
 module For_testing : sig
-  val observe_state_read_only_result_with_interleave :
+  val observe_snapshot_with_errors_with_interleave :
     between_samples:(unit -> unit) ->
     base_path:string ->
     keeper_name:string ->
-    (Keeper_event_queue_state.t, string) result
+    snapshot_with_errors
 end
 
 val load_state_result :

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -154,6 +154,16 @@ val discover_keeper_names_with_durable_state :
 val load_snapshot_with_errors :
   base_path:string -> keeper_name:string -> snapshot_with_errors
 
+val observe_snapshot_with_errors :
+  base_path:string -> keeper_name:string -> snapshot_with_errors
+(** Read-only operator projection of the pending queue. Unlike
+    {!load_snapshot_with_errors}, this observer never acquires the canonical
+    queue-owner transaction lock and never checkpoints or compacts the
+    transition WAL. Snapshot replacement and WAL reads remain atomic at their
+    individual file boundaries; a concurrent transition may therefore yield
+    an earlier coherent snapshot or an explicit read error, but cannot turn a
+    dashboard GET into queue-owner work. *)
+
 val load_state_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
 (** Strict state read used by tests and operator projection. A malformed

--- a/lib/server/server_dashboard_schedule_projection.ml
+++ b/lib/server/server_dashboard_schedule_projection.ml
@@ -189,8 +189,9 @@ let schedule_evidence_snapshot ~config wakes =
        | None -> ()
        | Some (keeper_name, stimulus_id) ->
          let existing =
-           Hashtbl.find_opt requested_stimulus_ids keeper_name
-           |> Option.value ~default:String_set.empty
+           match Hashtbl.find_opt requested_stimulus_ids keeper_name with
+           | Some existing -> existing
+           | None -> String_set.empty
          in
          let requested =
            match stimulus_id with

--- a/lib/server/server_dashboard_schedule_projection.ml
+++ b/lib/server/server_dashboard_schedule_projection.ml
@@ -18,12 +18,12 @@
     never flattened to zero, which would read as "no schedules" rather than
     "the ledger could not be read". *)
 
-(* TEL-OK: every function here is a pure [record -> Yojson.Safe.t] renderer over
-   state the caller already read. The module takes no action to observe: it
-   dispatches nothing, mutates nothing, and its one read (the schedule ledger)
-   reports its own failure in the payload as [schedule_store_read_error] rather
-   than swallowing it. Telemetry for the actions these rows describe lives with
-   the actors that perform them — Schedule_runner for dispatch, and
+(* TEL-OK: this projection dispatches nothing and mutates no durable state.
+   Schedule, queue, signal, and reaction-ledger reads report failures in the
+   payload rather than swallowing them. Queue evidence uses the non-locking,
+   non-compacting observer, while reaction evidence is one request-local batch
+   per Keeper. Telemetry for the actions these rows describe lives with the
+   actors that perform them — Schedule_runner for dispatch, and
    Keeper_event_queue for wake delivery.
 
    The telemetry ratchet flags these as new handlers because this module is a
@@ -153,6 +153,90 @@ let schedule_dispatch_receipt_dashboard_json
          ]))
 ;;
 
+module String_set = Set.Make (String)
+
+type keeper_reaction_evidence_batch =
+  ( (string * Keeper_reaction_ledger.event_queue_reaction_evidence_outcome) list
+  , Keeper_reaction_ledger.event_queue_reaction_evidence_error )
+  result
+
+type schedule_evidence_snapshot =
+  { queue_by_keeper :
+      (string, Keeper_event_queue_persistence.snapshot_with_errors) Hashtbl.t
+  ; reaction_by_keeper : (string, keeper_reaction_evidence_batch) Hashtbl.t
+  }
+
+let schedule_keeper_receipt_identity (wake : Schedule_domain.wake_record option) =
+  match wake with
+  | None -> None
+  | Some wake ->
+    (match wake.Schedule_domain.detail with
+     | None -> None
+     | Some detail ->
+       (match Server_schedule_consumers.dispatch_receipt_of_detail detail with
+        | Error _ -> None
+        | Ok
+            (Server_schedule_consumers.Keeper_wake_enqueued
+              { keeper_name; stimulus_id; _ }) ->
+          Some (keeper_name, stimulus_id)))
+;;
+
+let schedule_evidence_snapshot ~config wakes =
+  let requested_stimulus_ids = Hashtbl.create (List.length wakes) in
+  List.iter
+    (fun wake ->
+       match schedule_keeper_receipt_identity wake with
+       | None -> ()
+       | Some (keeper_name, stimulus_id) ->
+         let existing =
+           Hashtbl.find_opt requested_stimulus_ids keeper_name
+           |> Option.value ~default:String_set.empty
+         in
+         let requested =
+           match stimulus_id with
+           | None -> existing
+           | Some stimulus_id -> String_set.add stimulus_id existing
+         in
+         Hashtbl.replace requested_stimulus_ids keeper_name requested)
+    wakes;
+  let queue_by_keeper = Hashtbl.create (Hashtbl.length requested_stimulus_ids) in
+  let reaction_by_keeper = Hashtbl.create (Hashtbl.length requested_stimulus_ids) in
+  Hashtbl.iter
+    (fun keeper_name stimulus_ids ->
+       Hashtbl.add
+         queue_by_keeper
+         keeper_name
+         (Keeper_event_queue_persistence.observe_snapshot_with_errors
+            ~base_path:config.Workspace_utils.base_path
+            ~keeper_name);
+       Hashtbl.add
+         reaction_by_keeper
+         keeper_name
+         (Keeper_reaction_ledger.event_queue_reaction_evidence_batch_result
+            ~base_path:config.Workspace_utils.base_path
+            ~keeper_name
+            ~stimulus_ids:(String_set.elements stimulus_ids)))
+    requested_stimulus_ids;
+  { queue_by_keeper; reaction_by_keeper }
+;;
+
+type schedule_reaction_evidence_lookup =
+  | Reaction_evidence_observed of
+      Keeper_reaction_ledger.event_queue_reaction_evidence_outcome
+  | Reaction_evidence_failed of
+      Keeper_reaction_ledger.event_queue_reaction_evidence_error
+  | Reaction_evidence_not_captured
+
+let schedule_reaction_evidence_lookup snapshot ~keeper_name ~stimulus_id =
+  match Hashtbl.find_opt snapshot.reaction_by_keeper keeper_name with
+  | None -> Reaction_evidence_not_captured
+  | Some (Error error) -> Reaction_evidence_failed error
+  | Some (Ok evidence_by_id) ->
+    (match List.assoc_opt stimulus_id evidence_by_id with
+     | Some evidence -> Reaction_evidence_observed evidence
+     | None -> Reaction_evidence_not_captured)
+;;
+
 let schedule_queue_read_error_dashboard_json
   (error : Keeper_event_queue_persistence.snapshot_read_error)
   =
@@ -227,7 +311,7 @@ let schedule_queue_match_fields ~now bucket (stimulus : Keeper_event_queue.stimu
 
 let schedule_keeper_queue_evidence_dashboard_json
   ~now
-  (config : Workspace.config)
+  ~evidence_snapshot
   (wake : Schedule_domain.wake_record option)
   =
   match wake with
@@ -259,9 +343,18 @@ let schedule_keeper_queue_evidence_dashboard_json
           let due_at = wake.Schedule_domain.due_at in
           let payload_digest = wake.Schedule_domain.payload_digest in
           let snapshot =
-            Keeper_event_queue_persistence.load_snapshot_with_errors
-              ~base_path:config.Workspace_utils.base_path
-              ~keeper_name
+            match Hashtbl.find_opt evidence_snapshot.queue_by_keeper keeper_name with
+            | Some snapshot -> snapshot
+            | None ->
+              { Keeper_event_queue_persistence.pending = Keeper_event_queue.empty
+              ; read_errors =
+                  [ { kind = Keeper_event_queue_persistence.Read_failed
+                    ; path = None
+                    ; message =
+                        "queue evidence was not captured in the request snapshot"
+                    }
+                  ]
+              }
           in
           let pending_match =
             schedule_queue_match
@@ -303,7 +396,7 @@ let schedule_keeper_queue_evidence_dashboard_json
 ;;
 
 let schedule_keeper_reaction_evidence_dashboard_json
-  (config : Workspace.config)
+  ~evidence_snapshot
   (wake : Schedule_domain.wake_record option)
   =
   match wake with
@@ -415,12 +508,13 @@ let schedule_keeper_reaction_evidence_dashboard_json
                   @ extra_fields)
              in
              (match
-                Keeper_reaction_ledger.event_queue_reaction_evidence_result
-                  ~base_path:config.Workspace_utils.base_path
+                schedule_reaction_evidence_lookup
+                  evidence_snapshot
                   ~keeper_name
                   ~stimulus_id
               with
-              | Error Keeper_reaction_ledger.Evidence_invalid_stimulus_id ->
+              | Reaction_evidence_failed
+                  Keeper_reaction_ledger.Evidence_invalid_stimulus_id ->
                 let error =
                   Keeper_reaction_ledger.Evidence_invalid_stimulus_id
                 in
@@ -433,7 +527,8 @@ let schedule_keeper_reaction_evidence_dashboard_json
                              error) )
                    :: base_fields
                    @ [ "stimulus_id", `String stimulus_id ])
-              | Error (Keeper_reaction_ledger.Evidence_read_error _ as error) ->
+              | Reaction_evidence_failed
+                  (Keeper_reaction_ledger.Evidence_read_error _ as error) ->
                 `Assoc
                   (("projection_status", `String "read_error")
                    :: ( "reason"
@@ -443,7 +538,16 @@ let schedule_keeper_reaction_evidence_dashboard_json
                              error) )
                    :: base_fields
                    @ [ "stimulus_id", `String stimulus_id ])
-              | Ok (Keeper_reaction_ledger.Evidence_complete evidence) ->
+              | Reaction_evidence_not_captured ->
+                `Assoc
+                  (("projection_status", `String "read_error")
+                   :: ( "reason"
+                      , `String
+                          "reaction evidence was not captured in the request snapshot" )
+                   :: base_fields
+                   @ [ "stimulus_id", `String stimulus_id ])
+              | Reaction_evidence_observed
+                  (Keeper_reaction_ledger.Evidence_complete evidence) ->
                 let projection_status =
                   if
                     evidence.event_queue_ack_seen
@@ -460,7 +564,7 @@ let schedule_keeper_reaction_evidence_dashboard_json
                   else "not_found"
                 in
                 projection_json projection_status evidence
-              | Ok
+              | Reaction_evidence_observed
                   (Keeper_reaction_ledger.Evidence_quarantined
                     { evidence; first_reason }) ->
                 projection_json
@@ -530,7 +634,7 @@ let schedule_signal_rows_and_errors config limit =
 
 let schedule_request_dashboard_json
   ~now
-  ~config
+  ~evidence_snapshot
   ?last_wake
   (request : Schedule_domain.schedule_request)
   =
@@ -596,9 +700,15 @@ let schedule_request_dashboard_json
         | None -> `Null
         | Some wake -> wake_record_dashboard_json wake )
     ; "dispatch_receipt", schedule_dispatch_receipt_dashboard_json last_wake
-    ; "keeper_queue_evidence", schedule_keeper_queue_evidence_dashboard_json ~now config last_wake
+    ; ( "keeper_queue_evidence"
+      , schedule_keeper_queue_evidence_dashboard_json
+          ~now
+          ~evidence_snapshot
+          last_wake )
     ; ( "keeper_reaction_evidence"
-      , schedule_keeper_reaction_evidence_dashboard_json config last_wake )
+      , schedule_keeper_reaction_evidence_dashboard_json
+          ~evidence_snapshot
+          last_wake )
     ]
 ;;
 
@@ -787,6 +897,22 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
         | _ -> String.compare left.schedule_id right.schedule_id)
     in
     let request_rows = take schedule_projection_request_limit sorted in
+    let request_rows_with_wakes =
+      List.map
+        (fun (request : Schedule_domain.schedule_request) ->
+           let last_wake =
+             Schedule_store.last_wake_for_schedule_instance state
+               ~schedule_instance_id:request.Schedule_domain.schedule_instance_id
+               ~schedule_id:request.Schedule_domain.schedule_id
+           in
+           request, last_wake)
+        request_rows
+    in
+    let evidence_snapshot =
+      schedule_evidence_snapshot
+        ~config
+        (List.map snd request_rows_with_wakes)
+    in
     `Assoc
       (base_fields
        @ [ "status", `String "ok"
@@ -809,14 +935,12 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
          ; ( "requests"
            , `List
                (List.map
-                  (fun (request : Schedule_domain.schedule_request) ->
-                     let last_wake =
-                       Schedule_store.last_wake_for_schedule_instance state
-                         ~schedule_instance_id:
-                           request.Schedule_domain.schedule_instance_id
-                         ~schedule_id:request.Schedule_domain.schedule_id
-                     in
-                     schedule_request_dashboard_json ~now ~config ?last_wake request)
-                  request_rows) )
+                  (fun (request, last_wake) ->
+                     schedule_request_dashboard_json
+                       ~now
+                       ~evidence_snapshot
+                       ?last_wake
+                       request)
+                  request_rows_with_wakes) )
          ])
 ;;

--- a/lib/server/server_dashboard_schedule_projection.mli
+++ b/lib/server/server_dashboard_schedule_projection.mli
@@ -13,6 +13,11 @@ val scheduled_automation_dashboard_json : Workspace.config -> Yojson.Safe.t
     Reads the schedule ledger from disk, so callers on an Eio fiber wrap this
     in [Domain_pool_ref.submit_io_or_inline].
 
+    Keeper queue evidence uses a lock-free, non-compacting durable observer,
+    and reaction evidence is indexed once per Keeper for the bounded request
+    rows. A GET therefore never enters the queue-owner transaction boundary
+    and never rescans one Keeper's complete reaction ledger per row.
+
     A ledger read failure is reported, not hidden: [status] is ["unknown"],
     [counts] / [request_count] / [fsm.active_count] are [null], and
     [schedule_store_read_error] carries the reason. Consumers must render that

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -557,6 +557,23 @@ let test_terminal_ack_replays_after_projection_and_snapshot_reload () =
     in
     let residual_wal_bytes = Yojson.Safe.to_string residual_wal_row ^ "\n" in
     write_text transition_wal_path residual_wal_bytes;
+    let observed =
+      Persistence.observe_snapshot_with_errors
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+    in
+    Alcotest.(check int)
+      "lock-free operator observation reports no read errors"
+      0
+      (List.length observed.read_errors);
+    Alcotest.(check int)
+      "lock-free operator observation preserves the pending projection"
+      (Queue.length (State.pending projected))
+      (Queue.length observed.pending);
+    Alcotest.(check string)
+      "lock-free operator observation preserves residual WAL bytes"
+      residual_wal_bytes
+      (In_channel.with_open_bin transition_wal_path In_channel.input_all);
     let validated =
       Persistence.validate_existing_state_read_only_result
         ~base_path:config.Workspace.base_path

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -644,9 +644,9 @@ let test_lock_free_observation_rejects_generation_change () =
     ~base_path
     ~keeper_name
     first;
-  match
+  let observed =
     Keeper_event_queue_persistence.For_testing
-    .observe_state_read_only_result_with_interleave
+    .observe_snapshot_with_errors_with_interleave
       ~between_samples:(fun () ->
         Keeper_reaction_ledger.record_event_queue_stimulus
           ~base_path
@@ -654,18 +654,20 @@ let test_lock_free_observation_rejects_generation_change () =
           second)
       ~base_path
       ~keeper_name
-  with
-  | Error message ->
-    check bool
-      "concurrent generation change is typed unavailable"
-      true
-      (String_util.contains_substring
-         message
-         "event queue changed during lock-free observation")
-  | Ok state ->
-    failf
-      "concurrent generation change returned healthy revision %Ld"
-      (Keeper_event_queue_state.revision state)
+  in
+  check int
+    "incoherent observation returns exactly one typed error"
+    1
+    (List.length observed.read_errors);
+  let error = List.hd observed.read_errors in
+  check string
+    "concurrent generation change is typed unavailable"
+    "incoherent_read"
+    (Keeper_event_queue_persistence.snapshot_read_error_kind_to_string error.kind);
+  check int
+    "incoherent observation cannot return a healthy queue"
+    0
+    (Keeper_event_queue.length observed.pending)
 ;;
 
 let test_unknown_reaction_is_quarantined_without_clearing_pending () =

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -1006,6 +1006,71 @@ let test_missing_identity_does_not_claim_an_occurrence_identity () =
   check_member_string "identity quarantine reason" "missing_stimulus_id" "reason" reason
 ;;
 
+let test_event_queue_reaction_evidence_batch_indexes_multiple_occurrences () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "batch-evidence-keeper" in
+  let first = schedule_due_stimulus ~schedule_id:"batch-first" () in
+  let second = schedule_due_stimulus ~schedule_id:"batch-second" () in
+  let first_id = Keeper_reaction_ledger.stimulus_id_of_event_queue first in
+  let second_id = Keeper_reaction_ledger.stimulus_id_of_event_queue second in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    first;
+  Keeper_reaction_ledger.record_event_queue_turn_started
+    ~base_path
+    ~keeper_name
+    first;
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    second;
+  let batch =
+    match
+      Keeper_reaction_ledger.event_queue_reaction_evidence_batch_result
+        ~base_path
+        ~keeper_name
+        ~stimulus_ids:[ second_id; first_id; second_id ]
+    with
+    | Ok batch -> batch
+    | Error error ->
+      fail
+        (Keeper_reaction_ledger.event_queue_reaction_evidence_error_to_string
+           error)
+  in
+  check (list string) "first-request order with duplicates collapsed"
+    [ second_id; first_id ]
+    (List.map fst batch);
+  let complete stimulus_id =
+    match List.assoc_opt stimulus_id batch with
+    | Some (Keeper_reaction_ledger.Evidence_complete evidence) -> evidence
+    | Some (Keeper_reaction_ledger.Evidence_quarantined _) ->
+      fail "batch evidence unexpectedly quarantined"
+    | None -> fail "requested batch evidence is missing"
+  in
+  let second_evidence = complete second_id in
+  check bool "second stimulus is visible" true second_evidence.stimulus_seen;
+  check bool "second turn has not started" false second_evidence.turn_started_seen;
+  check int "second has one exact row" 1 second_evidence.matched_record_count;
+  let first_evidence = complete first_id in
+  check bool "first stimulus is visible" true first_evidence.stimulus_seen;
+  check bool "first turn start is visible" true first_evidence.turn_started_seen;
+  check int "first has two exact rows" 2 first_evidence.matched_record_count;
+  match
+    Keeper_reaction_ledger.event_queue_reaction_evidence_batch_result
+      ~base_path
+      ~keeper_name
+      ~stimulus_ids:[ "" ]
+  with
+  | Error Keeper_reaction_ledger.Evidence_invalid_stimulus_id -> ()
+  | Error error ->
+    failf
+      "empty batch identity returned the wrong error: %s"
+      (Keeper_reaction_ledger.event_queue_reaction_evidence_error_to_string
+         error)
+  | Ok _ -> fail "empty batch identity was accepted"
+;;
+
 
 (* The post-append fault seam is declared in the .mli as a boundary contract:
    it must exist exactly once as a definition and once as a declaration, so the
@@ -1109,6 +1174,10 @@ let () =
             "reaction_kind string round-trip drift guard"
             `Quick
             test_reaction_kind_string_roundtrip
+        ; test_case
+            "reaction evidence batch indexes multiple occurrences"
+            `Quick
+            test_event_queue_reaction_evidence_batch_indexes_multiple_occurrences
         ; test_case
             "after_ledger_append seam is reachable through the interface"
             `Quick

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -635,6 +635,39 @@ let test_fleet_summary_surfaces_durable_event_queue_parse_error () =
   check_member_string "durable queue parse error path" path "path" read_error
 ;;
 
+let test_lock_free_observation_rejects_generation_change () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "observation-generation-change" in
+  let first = schedule_due_stimulus ~schedule_id:"before-observation" () in
+  let second = schedule_due_stimulus ~schedule_id:"during-observation" () in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    first;
+  match
+    Keeper_event_queue_persistence.For_testing
+    .observe_state_read_only_result_with_interleave
+      ~between_samples:(fun () ->
+        Keeper_reaction_ledger.record_event_queue_stimulus
+          ~base_path
+          ~keeper_name
+          second)
+      ~base_path
+      ~keeper_name
+  with
+  | Error message ->
+    check bool
+      "concurrent generation change is typed unavailable"
+      true
+      (String_util.contains_substring
+         message
+         "event queue changed during lock-free observation")
+  | Ok state ->
+    failf
+      "concurrent generation change returned healthy revision %Ld"
+      (Keeper_event_queue_state.revision state)
+;;
+
 let test_unknown_reaction_is_quarantined_without_clearing_pending () =
   with_temp_base @@ fun base_path ->
   let keeper_name = "unknown-reaction-keeper" in
@@ -1158,6 +1191,10 @@ let () =
             "fleet summary surfaces durable event queue parse errors"
             `Quick
             test_fleet_summary_surfaces_durable_event_queue_parse_error
+        ; test_case
+            "lock-free observation rejects generation change"
+            `Quick
+            test_lock_free_observation_rejects_generation_change
         ; test_case
             "unknown reaction is quarantined without clearing pending"
             `Quick


### PR DESCRIPTION
## Summary

- add a lock-free, non-compacting operator snapshot for Keeper event-queue evidence
- build one request-local reaction-ledger batch per Keeper and index all requested stimulus IDs
- render bounded schedule rows from those snapshots while preserving typed read, quarantine, and missing-evidence states
- add regression coverage for residual WAL preservation and multi-occurrence batch evidence

## Root cause

The scheduled-automation GET projection called the owner-facing queue loader for every rendered row. That loader enters the canonical durable queue transaction lock and may compact an already-projected transition WAL during a read.

The same row renderer also called the exact reaction-evidence API independently for each row. With the 20-row response cap, one Keeper's complete reaction ledger could therefore be scanned up to 20 times for a single GET.

## Impact

Dashboard reads no longer enter the durable queue-owner transaction boundary or checkpoint/compact transition WALs. Queue evidence is observed once per Keeper, and reaction evidence performs one complete ledger scan per Keeper per dashboard request rather than one scan per row.

Concurrent multi-file queue changes can yield an earlier coherent observation or an explicit read error; the projection does not manufacture healthy empty evidence.

## Validation

- `ocamlformat --check` on all changed OCaml sources and tests
- `git diff --check origin/main...HEAD`
- `ocamlc -stop-after parsing` on all changed `.ml` and `.mli` files
- source sweep confirms the schedule projection uses `observe_snapshot_with_errors` and `event_queue_reaction_evidence_batch_result`

Build and test execution were intentionally not run locally per operator request and are delegated to CI.

## Related

- corrective server follow-up to #28134
- #28180 covers the separate dashboard unavailable-state and polling behavior; it has no file overlap with this PR
