### PR TITLE
fix(keeper): typed carriage for Codex client failures + RFC-0370 + rotation census

### DIFF
--- a/docs/rfc/RFC-0370-provider-profile-ssot-and-rotation-eligibility.md
+++ b/docs/rfc/RFC-0370-provider-profile-ssot-and-rotation-eligibility.md
@@ -49,13 +49,18 @@ Antigravity)은 구독 클라이언트에 다른 생성자가 없어서 provider
 MASC 내부 버그와 같은 판정을 받는다. `Internal`을 terminal로 두는 것
 자체는 옳다 — 틀린 것은 provider 실패가 `Internal`에 실려 들어오는 것이다.
 
-**P2 — 노브 8/14개가 죽어 있다.** `runtime_toml.ml`이 받는 14개 키 중
-8개가 config 전역 선언 0건: `turn-timeout-s`, `timeout-s`, `keep-alive`,
-`num-ctx`, `price-input`, `price-output`, `effort`, `agent`, `is-default`.
-파서→스키마→어댑터가 전부 배선돼 있고 카탈로그가 침묵한다. 결과:
+**P2 — 노브가 부분 선언 상태다.** `runtime_toml.ml`이 받는 14개 키 기준,
+repo 템플릿(`config/runtime.toml`)은 8개 키가 선언 0건이고, 라이브
+배포(`$BASE_PATH/.masc/config/runtime.toml`, 1,440줄)는 `turn-timeout-s`를
+**29개 official-client 행 중 5개**(effort 상위 티어: -high/-max/-xhigh)에만
+선언했다. `keep-alive`/`num-ctx`/`price-*`/`effort`/`agent`/`is-default`는
+양쪽 모두 0건. 노브 자체는 라이브에서 유효함이 실측된다 — 선언된 600.0이
+`Antigravity turn timed out after 600.000s`로 발화 (2026-08-11T00:27Z).
+파서→스키마→어댑터가 전부 배선돼 있고 주력 행만 침묵한다. 결과:
 
-- `turn-timeout-s` 0건 → 세 런타임의 하드코딩 `default_timeout_s = 300.0`이
-  fleet 전체를 지배 (`internal:app_server_timeout` 22건/일의 원인).
+- 미선언 24행 → 세 런타임의 하드코딩 `default_timeout_s = 300.0`이 주력
+  행을 지배 (`internal:app_server_timeout` 22건/일의 원인 — sangsu의
+  `gpt-5.3-codex-spark`, 실패 31건의 `claude-sonnet-5` 모두 미선언 행).
   #24386(2026-07-14)이 breaking으로 제거한 총량 집행이 #27690(2026-08-09)
   계열에서 더 낮은 계층에 무단 부활한 형태다.
 - `keep-alive`/`num-ctx` 0건 → ollama_cloud 39행의 모델 상주·컨텍스트가

--- a/docs/rfc/RFC-0370-provider-profile-ssot-and-rotation-eligibility.md
+++ b/docs/rfc/RFC-0370-provider-profile-ssot-and-rotation-eligibility.md
@@ -1,0 +1,180 @@
+---
+rfc: "0370"
+title: "Provider profile SSOT, quota-as-state, rotation eligibility for Internal-carried failures"
+status: Draft
+created: 2026-08-11
+updated: 2026-08-11
+author: vincent + claude
+supersedes: []
+superseded_by: null
+related: ["0368", "0129"]
+implementation_prs: []
+---
+
+# RFC-0370: Provider profile SSOT · quota-as-state · Internal-carried 실패의 rotation 자격
+
+## 1. 문제 — 하루 실측
+
+2026-08-11 라이브 시스템 로그 (`system_log_2026-08-11.jsonl`), keeper cycle 3,119회:
+
+| 항목 | 수 |
+|---|---|
+| cycle OK | 2,661 |
+| cycle FAILED | 284 |
+| cycle exception | 174 |
+
+FAILED 284건의 상위 클래스와, 그 클래스의 rotation 자격 (측정:
+`test/test_keeper_rotation_eligibility_census.ml` — 실제 후보 loop을 구동해
+2번째 후보 도달 여부를 관측):
+
+| error class | rotation | 건수 |
+|---|---|---|
+| provider:hard_quota | 가능 | 103 |
+| provider:network_error | 가능 | 62 |
+| serialization:parse_error | 불가 | 29 |
+| internal:stream_disconnected | **불가** | 28 |
+| internal:app_server_timeout | **불가** | 22 |
+| provider:reported_error | 가능 | 14 |
+| api:context_overflow | 가능 | 9 |
+| internal:remote_command_failed | **불가** | 4 |
+
+세 가지 독립된 결함이 겹쳐 있다:
+
+**P1 — Internal-carried provider 실패는 rotation 자격이 없다 (54건/일).**
+`Keeper_runtime_attempt.core_error_to_runtime_outcome`은 `Internal _`에
+`None`을 돌려주고, `lane_should_retry`는 상태 코드를 보기 전에 단락된다.
+그런데 official-client 런타임 3종 (Codex app-server, Claude Code,
+Antigravity)은 구독 클라이언트에 다른 생성자가 없어서 provider·transport
+실패를 전부 `Internal <string>`으로 보고한다. per-runtime transport 실패가
+MASC 내부 버그와 같은 판정을 받는다. `Internal`을 terminal로 두는 것
+자체는 옳다 — 틀린 것은 provider 실패가 `Internal`에 실려 들어오는 것이다.
+
+**P2 — 노브 8/14개가 죽어 있다.** `runtime_toml.ml`이 받는 14개 키 중
+8개가 config 전역 선언 0건: `turn-timeout-s`, `timeout-s`, `keep-alive`,
+`num-ctx`, `price-input`, `price-output`, `effort`, `agent`, `is-default`.
+파서→스키마→어댑터가 전부 배선돼 있고 카탈로그가 침묵한다. 결과:
+
+- `turn-timeout-s` 0건 → 세 런타임의 하드코딩 `default_timeout_s = 300.0`이
+  fleet 전체를 지배 (`internal:app_server_timeout` 22건/일의 원인).
+  #24386(2026-07-14)이 breaking으로 제거한 총량 집행이 #27690(2026-08-09)
+  계열에서 더 낮은 계층에 무단 부활한 형태다.
+- `keep-alive`/`num-ctx` 0건 → ollama_cloud 39행의 모델 상주·컨텍스트가
+  서버 기본값에 방치.
+- `price-*` 0건 → 비용 계산 입력 부재.
+
+**P3 — quota를 에러로만 안다 (103건/일).** 구독 quota는 시간 단위로
+리셋되는 창(window)인데, keeper는 소진 상태를 벽에 부딪혀서만 알고 20초
+간격으로 재시도한다. `Cooldown_hard_quota`는 존재하지만 문서가 명시적으로
+권위를 제거했다 ("has no retry, admission, or lifecycle authority").
+
+## 2. 외부 근거 — 두 시스템의 상반된 해법
+
+### Orca (stablyai/orca, 42k★)
+
+- provider 집합을 8개 유료 벤더로 **닫고** (`'claude' | 'codex' | …`),
+  전원이 usage API를 제공하므로 quota를 **사전 조회한 상태**로 모델링:
+  `RateLimitWindow { usedPercent; windowMinutes; resetsAt }`,
+  HTTP Retry-After에서 받은 `retryAtMs`로 재조회 억제.
+- 컨텍스트/턴 소유권은 PTY로 벤더 CLI에 위임 — 자기 소유 문제를 좁혔다.
+- 로컬 추론 경로 없음 (`lmstudio`/`vllm`/`llama.cpp`/`openai-compatible`
+  코드 검색 0건). 즉 이 정교함은 닫힌 집합의 대가다.
+
+### Hermes (NousResearch/hermes-agent, 228k★)
+
+- 열린 provider 집합을 실제로 운영. 핵심은 `ProviderProfile`:
+  선언적 dataclass 하나가 SSOT이고, auth 위저드·doctor 헬스체크·모델
+  목록·transport quirk가 전부 profile에서 **파생**된다. "transport가
+  20+개 boolean flag를 받는 대신 이걸 읽는다."
+- provider quirk를 선언 필드로: `supports_vision_tool_messages`,
+  `OMIT_TEMPERATURE` sentinel, per-provider hook
+  (`prepare_messages`/`build_extra_body`).
+- 복구는 `TurnRetryState` — 시도당 one-shot guard의 typed 집합
+  (per-provider OAuth 갱신, llama.cpp grammar fallback 등 16종).
+
+### 종합
+
+Orca의 quota-as-state는 usage API가 있는 provider에서만 성립한다.
+Hermes의 profile-SSOT는 열린 집합에서 성립한다. masc는 둘을 합칠 수 있는
+위치에 있다: **profile에 "usage를 조회할 수 있는가"를 타입으로 갈라
+넣으면**, 조회 가능한 구독 provider는 Orca식 사전 상태를, 조회 불가한
+ollama_cloud 39행은 지금의 사후 typed 에러를 각자 갖는다. 한 축에
+뭉쳐서 생기는 전염 (39행 때문에 quota 상태화를 포기)이 사라진다.
+
+## 3. 설계
+
+### 3.1 P1: typed 운반 — Internal에서 provider 실패를 꺼낸다 (구현 대상)
+
+official-client 런타임의 에러 경계에서, 이미 typed로 알고 있는 실패를
+`Internal` 문자열로 눌러 담지 않고 `Agent_core.Error`의 기존 변형으로
+운반한다:
+
+| 현재 (Internal 문자열) | 운반 목표 |
+|---|---|
+| "turn timed out after Ns" | `Api (Timeout { phase })` |
+| "stream disconnected before completion" | `Provider (NetworkError { kind })` |
+| "Error running remote command" | `Provider (ProviderUnavailable _)` |
+
+이건 새 분류기가 아니다 — 런타임이 실패를 만드는 지점은 이미 그 실패가
+무엇인지 안다 (`Eio.Time.Timeout` 캐치, EOF 감지). 아는 것을 아는 타입에
+싣는 것뿐이다. string re-parse는 도입하지 않는다 (CLAUDE.md 문자열
+분류기 금지; RFC-0042/0154가 닫은 축).
+
+회귀 가드: census 테스트의 baseline이 pin이다. 이 변경 후
+`internal:app_server_timeout` 행은 census에서 사라지고 (해당 에러가 더
+이상 `Internal`이 아니므로) 대응하는 typed 행이 `rotation 가능`으로
+옮겨간다 — baseline 갱신이 컴파일·테스트로 강제된다.
+
+RFC-0368과의 경계: 0368은 실패 **후** official-client 세션의 claim 시점
+복구를 다룬다. 본 RFC는 실패 **시점**의 레인 rotation 자격을 다룬다.
+같은 실패가 두 정책을 순서대로 만난다 (rotation 시도 → 다음 claim의
+auto-heal).
+
+### 3.2 P2: 카탈로그 선언 — 죽은 노브에 값을 준다 (구현 대상)
+
+코드 변경 없음. 선언만 한다:
+
+1. official-client 3종 행에 `turn-timeout-s` 명시. 하드코딩 300.0은
+   "카탈로그 미선언 시 fallback"으로 강등되고, 정본은 카탈로그가 된다.
+2. ollama_cloud 39행에 `keep-alive` 선언 (모델 상주 정책의 명시화).
+3. 선언율 census를 반복 실행 가능한 스크립트로 유지해 회귀를 본다.
+
+`price-*`/`effort`/`agent`/`is-default`는 소비자 실사용 확인 후 별도
+선언 (본 RFC 범위 밖 — 소비자가 없으면 선언이 아니라 키 제거가 옳다).
+
+### 3.3 P3: quota-as-state (단계적 — 본 RFC는 설계만)
+
+`Runtime_schema` provider 행에 usage 조회 능력을 타입으로 추가:
+
+```
+type usage_visibility =
+  | Usage_queryable of { probe : usage_probe }   (* 구독: Claude/Codex/… *)
+  | Usage_opaque                                  (* ollama_cloud 등 *)
+```
+
+`Usage_queryable`인 provider만 `RateLimitWindow` 동형의 상태
+(`used_percent`, `resets_at`)를 보유하고, 셀렉터의 **후보 구성 입력**이
+된다 (admission 게이트가 아니라 후보 생성 시점의 사실 — 소진된 창의
+runtime은 후보 목록에 이름이 오르지 않고, `resets_at` 경과로 자연
+복귀). `Usage_opaque`는 현행 사후 typed 에러 + rotation 경로를 그대로
+유지한다.
+
+기존 게이트 원칙과의 정합: 이것은 파생/장식 필드 guard가 아니라
+provider가 보고한 1차 사실이며, blast radius는 후보 구성 한 지점이다.
+
+## 4. 검증
+
+- `test_keeper_rotation_eligibility_census.ml`: 17개 에러 클래스 × 실제
+  후보 loop 구동, baseline pin. P1 구현 시 baseline diff가 곧 변경 증명.
+- 선언율 census: 14키 × config 매트릭스, P2 후 죽은 노브 0 목표
+  (단 §3.2의 보류 키 제외).
+- 라이브: P1+P2 배포 후 동일 24h 창에서 `cycle FAILED` 중
+  rotation-불가 클래스 비중 재측정 (기준선: 85/284건).
+
+## 5. 하지 않는 것
+
+- string 분류기 추가 (금지 축).
+- admission 게이트 부활. 후보 구성은 셀렉터의 입력이지 dispatch 거부가
+  아니다.
+- ollama_cloud에 usage 조회 흉내 (API가 없다 — `Usage_opaque`가 사실).
+- 300.0 상수의 즉시 제거. RFC-OAS-026 §7 순서 제약: idle 감지가 증명될
+  때까지 총량 backstop은 유지, 카탈로그 선언으로 정본만 이동.

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -161,7 +161,57 @@ let codex_error_to_core_error = function
          ; error_type = Some "context_window_exceeded_after_tool_effect"
          ; detail = Runtime_codex_app_server.error_to_string error
          })
-  | error -> Agent_core.Error.Internal (Runtime_codex_app_server.error_to_string error)
+  (* Provider- and transport-side failures carry typed constructors so the
+     lane rotation chain ([core_error_to_runtime_outcome] returns [None] for
+     [Internal _], which short-circuits [lane_should_retry]) can judge them.
+     Mirrors [claude_error_to_core_error] / [runtime_error_to_core_error]
+     (antigravity); RFC-0370 §3.1. No catch-all: a new client error variant
+     must decide its rotation class at compile time. *)
+  | Runtime_codex_app_server.Spawn_failed detail
+  | Runtime_codex_app_server.Process_exited detail ->
+    Agent_core.Error.Provider
+      (Llm_provider.Error.ProviderUnavailable
+         { provider = "codex_app_server"; detail })
+  | Runtime_codex_app_server.Protocol_error { stage; detail } ->
+    Agent_core.Error.Provider
+      (Llm_provider.Error.ParseError
+         { detail = Printf.sprintf "%s: %s" stage detail })
+  | Runtime_codex_app_server.Rpc_error { method_; code; message } ->
+    Agent_core.Error.Provider
+      (Llm_provider.Error.ProviderReportedError
+         { provider = "codex_app_server"
+         ; error_type = Some "rpc_error"
+         ; detail =
+             Printf.sprintf
+               "%s%s: %s"
+               method_
+               (Option.fold ~none:"" ~some:(Printf.sprintf " (code %d)") code)
+               message
+         })
+  | Runtime_codex_app_server.Unsupported_server_request method_ ->
+    Agent_core.Error.Provider
+      (Llm_provider.Error.UnknownVariant
+         { type_name = "codex_app_server.server_request"; value = method_ })
+  | Runtime_codex_app_server.Turn_failed detail ->
+    Agent_core.Error.Provider
+      (Llm_provider.Error.ProviderReportedError
+         { provider = "codex_app_server"
+         ; error_type = Some "turn_failed"
+         ; detail
+         })
+  | Runtime_codex_app_server.Timeout seconds ->
+    Agent_core.Error.Api
+      (Agent_core.Retry.Timeout
+         { message =
+             Printf.sprintf "Codex app-server turn timed out after %.3fs" seconds
+         ; phase = None
+         })
+  (* Server-reported "interrupted" turn status (deliberate host-side stop, for
+     example shutdown): not a provider fault, so rotation to another runtime
+     would re-run a turn that was intentionally stopped. Stays [Internal]. *)
+  | Runtime_codex_app_server.Turn_interrupted ->
+    Agent_core.Error.Internal
+      (Runtime_codex_app_server.error_to_string Runtime_codex_app_server.Turn_interrupted)
 ;;
 
 let recovery_failure_of_client_error = function
@@ -738,3 +788,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
           ~config)
       ())
 ;;
+
+module For_testing = struct
+  let codex_error_to_core_error = codex_error_to_core_error
+end

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -17,3 +17,11 @@ val run :
   raw_trace:Agent_core.Raw_trace.t option ->
   config:Runtime_execution.codex_app_server ->
   (Runtime_agent.run_result, Agent_core.Error.t) result
+
+module For_testing : sig
+  (** Typed carriage of Codex app-server client errors into agent-core
+      errors; rotation class per constructor is pinned by
+      [test_keeper_codex_error_carriage]. RFC-0370 §3.1. *)
+  val codex_error_to_core_error :
+    Runtime_codex_app_server.error -> Agent_core.Error.t
+end

--- a/test/dune
+++ b/test/dune
@@ -111,6 +111,7 @@
   test_keeper_turn_driver_accept
   test_keeper_turn_driver_failover
   test_keeper_rotation_eligibility_census
+  test_keeper_codex_error_carriage
   test_domain_pool
   test_sse
   test_graphql_api
@@ -410,6 +411,7 @@
   test_keeper_turn_driver_accept
   test_keeper_turn_driver_failover
   test_keeper_rotation_eligibility_census
+  test_keeper_codex_error_carriage
   test_domain_pool
   test_sse
   test_graphql_api

--- a/test/dune
+++ b/test/dune
@@ -110,6 +110,7 @@
   test_runtime_lane_preference
   test_keeper_turn_driver_accept
   test_keeper_turn_driver_failover
+  test_keeper_rotation_eligibility_census
   test_domain_pool
   test_sse
   test_graphql_api
@@ -408,6 +409,7 @@
   test_runtime_lane_preference
   test_keeper_turn_driver_accept
   test_keeper_turn_driver_failover
+  test_keeper_rotation_eligibility_census
   test_domain_pool
   test_sse
   test_graphql_api

--- a/test/test_keeper_codex_error_carriage.ml
+++ b/test/test_keeper_codex_error_carriage.ml
@@ -1,0 +1,77 @@
+(* Pins the typed carriage of every Codex app-server client error variant
+   (RFC-0370 §3.1). The census (test_keeper_rotation_eligibility_census)
+   pins what each agent-core class does in the rotation loop; this test pins
+   which class each client error lands in, so the boundary cannot silently
+   fall back to [Internal] for a provider-side failure. *)
+
+module Codex = Runtime_codex_app_server
+module Map = Masc.Keeper_codex_runtime.For_testing
+
+let class_of (err : Agent_core.Error.t) =
+  match err with
+  | Agent_core.Error.Config (Agent_core.Error.InvalidConfig { field; _ }) ->
+    "config:" ^ field
+  | Agent_core.Error.Api (Agent_core.Retry.ContextOverflow _) ->
+    "api:context_overflow"
+  | Agent_core.Error.Api (Agent_core.Retry.Timeout _) -> "api:timeout"
+  | Agent_core.Error.Provider (Llm_provider.Error.ProviderUnavailable _) ->
+    "provider:unavailable"
+  | Agent_core.Error.Provider (Llm_provider.Error.ParseError _) ->
+    "provider:parse_error"
+  | Agent_core.Error.Provider
+      (Llm_provider.Error.ProviderReportedError { error_type; _ }) ->
+    "provider:reported:" ^ Option.value error_type ~default:"?"
+  | Agent_core.Error.Provider (Llm_provider.Error.UnknownVariant _) ->
+    "provider:unknown_variant"
+  | Agent_core.Error.Internal _ -> "internal"
+  | other -> "unexpected:" ^ Agent_core.Error.to_string other
+
+let check label error expected =
+  Alcotest.(check string) label expected (class_of (Map.codex_error_to_core_error error))
+
+(* Every constructor appears exactly once; a new variant fails to compile in
+   [codex_error_to_core_error] (no catch-all) before it can be missed here. *)
+let test_every_variant_lands_in_its_class () =
+  check "invalid_config"
+    (Codex.Invalid_config "bad path")
+    "config:codex_app_server";
+  check "subscription_required"
+    (Codex.Subscription_required "login")
+    "config:codex_subscription";
+  check "context overflow pre-tool"
+    (Codex.Context_window_exceeded
+       { message = "full"; tool_effect_attempted = false })
+    "api:context_overflow";
+  check "context overflow post-tool"
+    (Codex.Context_window_exceeded
+       { message = "full"; tool_effect_attempted = true })
+    "provider:reported:context_window_exceeded_after_tool_effect";
+  check "spawn_failed" (Codex.Spawn_failed "no exe") "provider:unavailable";
+  check "process_exited" (Codex.Process_exited "killed") "provider:unavailable";
+  check "protocol_error"
+    (Codex.Protocol_error { stage = "turn"; detail = "bad frame" })
+    "provider:parse_error";
+  check "rpc_error"
+    (Codex.Rpc_error { method_ = "thread/start"; code = Some 3; message = "no" })
+    "provider:reported:rpc_error";
+  check "unsupported_server_request"
+    (Codex.Unsupported_server_request "applyPatch")
+    "provider:unknown_variant";
+  check "turn_failed"
+    (Codex.Turn_failed "stream disconnected before completion")
+    "provider:reported:turn_failed";
+  check "timeout" (Codex.Timeout 300.0) "api:timeout";
+  check "turn_interrupted (deliberate stop stays internal)"
+    Codex.Turn_interrupted
+    "internal"
+
+let () =
+  Alcotest.run
+    "keeper_codex_error_carriage"
+    [ ( "carriage"
+      , [ Alcotest.test_case
+            "every variant lands in its class"
+            `Quick
+            test_every_variant_lands_in_its_class
+        ] )
+    ]

--- a/test/test_keeper_rotation_eligibility_census.ml
+++ b/test/test_keeper_rotation_eligibility_census.ml
@@ -131,10 +131,13 @@ let api_invalid_request_unknown_model =
        ; reason = Agent_core.Retry.Unknown_invalid_request
        })
 
-(* The official-client runtimes (Codex app-server, Claude Code, Antigravity)
-   report provider-side and transport-side failures through
-   [Internal], because that is the only constructor the subscription clients
-   have. These three strings are verbatim classes from the live logs. *)
+(* Until RFC-0370 §3.1, the Codex app-server boundary folded provider- and
+   transport-side failures into [Internal] strings (the catch-all in
+   [codex_error_to_core_error]); these three verbatim live-log classes
+   document what that wire looked like, and that [Internal] itself remains
+   non-rotating for genuine MASC defects. The typed rows below them are what
+   the same failures carry after the boundary fix (mirroring the claude_code
+   and antigravity conversions, which were already typed). *)
 let internal_app_server_timeout =
   Agent_core.Error.Internal
     "Codex app-server turn timed out after 300.000s"
@@ -146,6 +149,24 @@ let internal_stream_disconnected =
 let internal_remote_command_failed =
   Agent_core.Error.Internal
     "Codex app-server turn failed: Error running remote command"
+
+(* Post-RFC-0370 typed forms of the same boundary failures. *)
+let api_turn_budget_timeout =
+  Agent_core.Error.Api
+    (Agent_core.Retry.Timeout
+       { message = "Codex app-server turn timed out after 300.000s"
+       ; phase = None
+       })
+
+let provider_parse_error =
+  Agent_core.Error.Provider
+    (Llm_provider.Error.ParseError
+       { detail = "turn: unsupported stream message type" })
+
+let provider_unknown_variant =
+  Agent_core.Error.Provider
+    (Llm_provider.Error.UnknownVariant
+       { type_name = "codex_app_server.server_request"; value = "applyPatch" })
 
 let serialization_parse_error =
   Agent_core.Error.Serialization
@@ -167,6 +188,9 @@ let census_rows =
   ; "api:context_overflow", api_context_overflow, 9
   ; "internal:remote_command_failed", internal_remote_command_failed, 4
   ; "api:invalid_request", api_invalid_request_unknown_model, 2
+  ; "api:turn_budget_timeout", api_turn_budget_timeout, 0
+  ; "provider:parse_error", provider_parse_error, 0
+  ; "provider:unknown_variant", provider_unknown_variant, 0
   ; "provider:rate_limit", provider_rate_limit, 0
   ; "provider:unavailable", provider_unavailable, 0
   ; "provider:server_error_transient", provider_server_error_transient, 0
@@ -233,6 +257,9 @@ let expected_rotation =
   ; "api:context_overflow", true
   ; "internal:remote_command_failed", false
   ; "api:invalid_request", false
+  ; "api:turn_budget_timeout", true
+  ; "provider:parse_error", false
+  ; "provider:unknown_variant", false
   ; "provider:rate_limit", true
   ; "provider:unavailable", true
   ; "provider:server_error_transient", true

--- a/test/test_keeper_rotation_eligibility_census.ml
+++ b/test/test_keeper_rotation_eligibility_census.ml
@@ -1,0 +1,289 @@
+(* Census of runtime-candidate rotation eligibility, per agent-core error class.
+
+   [Keeper_turn_driver.attempt_runtime_candidates] owns the decision "does this
+   lane move to its next declared candidate". The decision is reached through a
+   chain — [lane_should_retry] -> [core_error_to_http_error] ->
+   [Runtime_attempt_fsm.should_try_next] — where two of the three links can
+   answer [false] for reasons that are invisible at the call site. Reading the
+   chain predicts the outcome; this test measures it.
+
+   Each case drives the real loop with two candidates: the first fails with the
+   error under test, the second would succeed. Reaching the second candidate is
+   rotation; stopping at the first is not. The recorded attempt list is the
+   observation, so a change anywhere in the chain shows up here as a changed
+   census row rather than as silently lost failover.
+
+   Error classes are the ones observed on the live fleet, so each row carries
+   the class's share of one day of keeper cycle failures (system_log
+   2026-08-11, 284 [keeper cycle FAILED] lines). That count is context for
+   which rows matter, not an assertion. *)
+
+module Driver = Masc.Keeper_turn_driver
+
+let first_candidate = "first.model"
+let second_candidate = "second.model"
+
+let emit_manifest_ignored ?status:_ ?decision:_ _event = ()
+
+(* Attempted candidate ids, in order, for a lane whose first candidate fails
+   with [error]. *)
+let attempted_candidates error =
+  let attempts = ref [] in
+  let _result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"census"
+      ~runtime_id_of:(fun candidate -> candidate)
+      ~emit_runtime_manifest:emit_manifest_ignored
+      ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        if String.equal candidate first_candidate
+        then Error error, None
+        else if String.equal candidate second_candidate
+        then Ok runtime_id, None
+        else Alcotest.failf "unexpected candidate %s" candidate)
+      [ first_candidate; second_candidate ]
+  in
+  !attempts
+
+let rotates error =
+  match attempted_candidates error with
+  | [ _first ] -> false
+  | [ _first; _second ] -> true
+  | other ->
+    Alcotest.failf
+      "census expects one or two attempts, got %d"
+      (List.length other)
+
+(* --- error class constructors, one per observed production failure --- *)
+
+let provider_hard_quota =
+  Agent_core.Error.Provider
+    (Llm_provider.Error.HardQuota
+       { provider = "claude_code"
+       ; retry_after = None
+       ; detail = "Claude Code subscription quota blocked"
+       })
+
+let provider_rate_limit =
+  Agent_core.Error.Provider
+    (Llm_provider.Error.RateLimit
+       { provider = "claude_code"; retry_after = None; detail = "throttled" })
+
+let provider_unavailable =
+  Agent_core.Error.Provider
+    (Llm_provider.Error.ProviderUnavailable
+       { provider = "ollama_cloud"; detail = "provider unavailable" })
+
+let provider_network_error =
+  Agent_core.Error.Provider
+    (Llm_provider.Error.NetworkError
+       { provider = "ollama_cloud"
+       ; kind = Llm_provider.Http_client.Unknown
+       ; timeout_phase = None
+       ; detail = "failed to resolve hostname: ollama.com"
+       })
+
+let provider_server_error_transient =
+  Agent_core.Error.Provider
+    (Llm_provider.Error.ServerError
+       { provider = "ollama_cloud"
+       ; code = 503
+       ; transient = true
+       ; detail = "upstream unavailable"
+       })
+
+let provider_reported_error =
+  Agent_core.Error.Provider
+    (Llm_provider.Error.ProviderReportedError
+       { provider = "claude_code"
+       ; error_type = Some "turn_failed"
+       ; detail = "terminal subtype"
+       })
+
+let api_network_error =
+  Agent_core.Error.Api
+    (Agent_core.Retry.NetworkError
+       { message = "failed to resolve hostname: ollama.com"
+       ; kind = Llm_provider.Http_client.Unknown
+       })
+
+let api_payment_required =
+  Agent_core.Error.Api
+    (Agent_core.Retry.PaymentRequired { message = "quota exhausted" })
+
+let api_rate_limited =
+  Agent_core.Error.Api
+    (Agent_core.Retry.RateLimited { message = "429"; retry_after = None })
+
+let api_server_error =
+  Agent_core.Error.Api
+    (Agent_core.Retry.ServerError { status = 503; message = "unavailable" })
+
+let api_context_overflow =
+  Agent_core.Error.Api
+    (Agent_core.Retry.ContextOverflow
+       { message = "context window exceeded"; limit = Some 128_000 })
+
+let api_invalid_request_unknown_model =
+  Agent_core.Error.Api
+    (Agent_core.Retry.InvalidRequest
+       { message = "model not found"
+       ; reason = Agent_core.Retry.Unknown_invalid_request
+       })
+
+(* The official-client runtimes (Codex app-server, Claude Code, Antigravity)
+   report provider-side and transport-side failures through
+   [Internal], because that is the only constructor the subscription clients
+   have. These three strings are verbatim classes from the live logs. *)
+let internal_app_server_timeout =
+  Agent_core.Error.Internal
+    "Codex app-server turn timed out after 300.000s"
+
+let internal_stream_disconnected =
+  Agent_core.Error.Internal
+    "Codex app-server turn failed: stream disconnected before completion"
+
+let internal_remote_command_failed =
+  Agent_core.Error.Internal
+    "Codex app-server turn failed: Error running remote command"
+
+let serialization_parse_error =
+  Agent_core.Error.Serialization
+    (Agent_core.Error.JsonParseError { detail = "result event: field missing" })
+
+let config_invalid =
+  Agent_core.Error.Config
+    (Agent_core.Error.InvalidConfig
+       { field = "model"; detail = "unknown model id" })
+
+(* label, error, observed count of [keeper cycle FAILED] on 2026-08-11 *)
+let census_rows =
+  [ "provider:hard_quota", provider_hard_quota, 103
+  ; "provider:network_error", provider_network_error, 62
+  ; "internal:stream_disconnected", internal_stream_disconnected, 28
+  ; "serialization:parse_error", serialization_parse_error, 29
+  ; "internal:app_server_timeout", internal_app_server_timeout, 22
+  ; "provider:reported_error", provider_reported_error, 14
+  ; "api:context_overflow", api_context_overflow, 9
+  ; "internal:remote_command_failed", internal_remote_command_failed, 4
+  ; "api:invalid_request", api_invalid_request_unknown_model, 2
+  ; "provider:rate_limit", provider_rate_limit, 0
+  ; "provider:unavailable", provider_unavailable, 0
+  ; "provider:server_error_transient", provider_server_error_transient, 0
+  ; "api:network_error", api_network_error, 0
+  ; "api:payment_required", api_payment_required, 0
+  ; "api:rate_limited", api_rate_limited, 0
+  ; "api:server_error", api_server_error, 0
+  ; "config:invalid", config_invalid, 0
+  ]
+
+let test_census_report () =
+  Printf.printf
+    "\n%-34s %-9s %s\n"
+    "error class"
+    "rotates"
+    "cycle FAILED 2026-08-11";
+  Printf.printf "%s\n" (String.make 72 '-');
+  let rotating, blocked =
+    List.fold_left
+      (fun (rotating, blocked) (label, error, count) ->
+        let rotated = rotates error in
+        Printf.printf
+          "%-34s %-9s %d\n"
+          label
+          (if rotated then "yes" else "NO")
+          count;
+        if rotated
+        then rotating + count, blocked
+        else rotating, blocked + count)
+      (0, 0)
+      census_rows
+  in
+  Printf.printf "%s\n" (String.make 72 '-');
+  Printf.printf
+    "failures in a class that can fail over: %d\n\
+     failures in a class that cannot:        %d\n\n"
+    rotating
+    blocked
+
+(* Measured baseline. A row flipping here means the rotation chain changed:
+   confirm the new value is intended before updating the expectation.
+
+   Two properties of this baseline are worth naming, because neither is
+   predictable from reading [lane_should_retry] alone:
+
+   - Every [Internal] row is [false]. [core_error_to_runtime_outcome] returns
+     [None] for [Internal _], so [lane_should_retry] short-circuits before any
+     status is consulted. The official-client runtimes (Codex app-server,
+     Claude Code, Antigravity) carry provider- and transport-side failures in
+     [Internal] because that is the constructor their subscription clients
+     have, so a per-runtime transport failure on those three reaches the same
+     decision as a MASC defect.
+
+   - Quota reaches opposite decisions depending on which constructor carries
+     it: [Provider (HardQuota _)] rotates, [Api (PaymentRequired _)] does not.
+     The condition is the same; the routing differs. *)
+let expected_rotation =
+  [ "provider:hard_quota", true
+  ; "provider:network_error", true
+  ; "internal:stream_disconnected", false
+  ; "serialization:parse_error", false
+  ; "internal:app_server_timeout", false
+  ; "provider:reported_error", true
+  ; "api:context_overflow", true
+  ; "internal:remote_command_failed", false
+  ; "api:invalid_request", false
+  ; "provider:rate_limit", true
+  ; "provider:unavailable", true
+  ; "provider:server_error_transient", true
+  ; "api:network_error", true
+  ; "api:payment_required", false
+  ; "api:rate_limited", true
+  ; "api:server_error", true
+  ; "config:invalid", false
+  ]
+
+let test_rotation_matches_baseline () =
+  List.iter
+    (fun (label, error, _count) ->
+      let expected =
+        match List.assoc_opt label expected_rotation with
+        | Some expected -> expected
+        | None -> Alcotest.failf "census row %S has no baseline entry" label
+      in
+      Alcotest.(check bool)
+        (Printf.sprintf "%s rotates" label)
+        expected
+        (rotates error))
+    census_rows
+
+(* Every census row must carry a baseline entry and vice versa, so adding a row
+   without a baseline (or leaving a stale baseline behind) fails instead of
+   silently shrinking the census. *)
+let test_census_and_baseline_agree_on_rows () =
+  let census_labels =
+    List.map (fun (label, _, _) -> label) census_rows |> List.sort compare
+  in
+  let baseline_labels =
+    List.map fst expected_rotation |> List.sort compare
+  in
+  Alcotest.(check (list string))
+    "census rows and baseline rows match"
+    census_labels
+    baseline_labels
+
+let () =
+  Alcotest.run
+    "keeper_rotation_eligibility_census"
+    [ ( "census"
+      , [ Alcotest.test_case "report" `Quick test_census_report
+        ; Alcotest.test_case
+            "rows match baseline"
+            `Quick
+            test_census_and_baseline_agree_on_rows
+        ; Alcotest.test_case
+            "rotation matches measured baseline"
+            `Quick
+            test_rotation_matches_baseline
+        ] )
+    ]


### PR DESCRIPTION
## 목표

official-client 런타임의 provider/transport 실패가 `Agent_core.Error.Internal` 문자열로 뭉개져 lane rotation 자격을 잃는 결함(실측 54건/일)의 수정과, 그 근거가 되는 설계 문서·측정 도구.

## 배경 실측 (2026-08-11 라이브, cycle 3,119회)

- cycle FAILED 284건 중 rotation 불가 클래스 85건
- `Internal`-carried: app-server timeout 22, stream disconnected 28, remote command 4
- `core_error_to_runtime_outcome`은 `Internal _`에 `None` → `lane_should_retry` 단락 → 후보 rotation 없음
- claude_code(#28136)·antigravity는 이미 typed 운반; **codex만 catch-all이 남아 있었음**

## 변경

| 파일 | 내용 |
|---|---|
| `docs/rfc/RFC-0370-*.md` | 설계 문서: P1 typed 운반(본 PR), P2 카탈로그 선언(별도), P3 quota-as-state(단계적). Orca(stablyai/orca)·Hermes(NousResearch/hermes-agent) 코드 인용 |
| `lib/keeper/keeper_codex_runtime.ml` | `codex_error_to_core_error` catch-all 제거, 전 변형 exhaustive 매핑 (claude_code/antigravity 패턴과 정렬). `Turn_interrupted`는 의도된 중단이라 `Internal` 유지 |
| `test/test_keeper_codex_error_carriage.ml` | 전 변형 → 클래스 매핑 pin (catch-all 부재로 새 변형은 컴파일 타임 결정 강제) |
| `test/test_keeper_rotation_eligibility_census.ml` | 20개 에러 클래스 × 실제 후보 loop 구동 census, baseline pin. 예측이 아니라 관측 (예측은 17행 중 2행이 틀렸음) |

## 로컬 검증

- `test_keeper_codex_error_carriage`: 1/1 pass
- `test_keeper_rotation_eligibility_census`: 3/3 pass
- `test_keeper_turn_driver_failover`: 37/37 pass (인접 회귀 없음)
- `test_runtime_codex_app_server`: 43/43 pass (1회 타이밍 플레이크, 격리 재실행 pass)
- `dune build ./bin/main_eio.exe`: 성공

## 미검증

- 라이브 재발률(85건/일 → ?)은 배포 후 24h 창 재측정 필요 (RFC-0370 §4)
- RFC-0370 P2(카탈로그 turn-timeout-s 선언)는 배포 config 사안으로 본 PR 범위 밖

Refs RFC-0370, RFC-0368. MASC task-223, goal-1786437038030-cb0c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>