### PR TITLE
fix(keeper): preserve typed pre-dispatch failover

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -468,6 +468,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
           Runtime_antigravity.run_turn
             ~conversation_mode
             ~home_dir:(Runtime_antigravity_home.home_dir home)
+            ?on_spawn_failure:on_pre_dispatch_failure
             ~mgr:process_mgr
             ~clock
             ~cwd:process_cwd
@@ -492,16 +493,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             client_config
             ~prompt
           |> Result.map_error (fun error ->
-            (match error with
-             | Runtime_antigravity.Spawn_failed _ ->
-               Option.iter (fun callback -> callback ()) on_pre_dispatch_failure
-             | Runtime_antigravity.Invalid_config _
-             | Runtime_antigravity.Turn_failed _
-             | Runtime_antigravity.Timeout _
-             | Runtime_antigravity.Process_exited _
-             | Runtime_antigravity.Protocol_error _
-             | Runtime_antigravity.State_callback_failed _ ->
-               ());
             recovery_failure := recovery_failure_of_runtime_error error;
             runtime_error_to_core_error error))
       in

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -204,6 +204,7 @@ let stream_projection ~turn_count on_event =
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
     ~context_injector ~context ~event_bus ~raw_trace ~on_event
+    ?on_pre_dispatch_failure
     ~(config : Runtime_execution.antigravity_cli) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
@@ -491,6 +492,16 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             client_config
             ~prompt
           |> Result.map_error (fun error ->
+            (match error with
+             | Runtime_antigravity.Spawn_failed _ ->
+               Option.iter (fun callback -> callback ()) on_pre_dispatch_failure
+             | Runtime_antigravity.Invalid_config _
+             | Runtime_antigravity.Turn_failed _
+             | Runtime_antigravity.Timeout _
+             | Runtime_antigravity.Process_exited _
+             | Runtime_antigravity.Protocol_error _
+             | Runtime_antigravity.State_callback_failed _ ->
+               ());
             recovery_failure := recovery_failure_of_runtime_error error;
             runtime_error_to_core_error error))
       in
@@ -680,7 +691,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~raw_trace ~on_event ~config =
+    ~context ~event_bus ~raw_trace ~on_event ?on_pre_dispatch_failure ~config =
   Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
     run_without_lifecycle
       ~runtime_id
@@ -698,5 +709,6 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       ~event_bus
       ~raw_trace
       ~on_event
+      ?on_pre_dispatch_failure
       ~config)
 ;;

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -16,5 +16,6 @@ val run :
   event_bus:Agent_core.Event_bus.t option ->
   raw_trace:Agent_core.Raw_trace.t option ->
   on_event:(Agent_core.Types.sse_event -> unit) option ->
+  ?on_pre_dispatch_failure:(unit -> unit) ->
   config:Runtime_execution.antigravity_cli ->
   (Runtime_agent.run_result, Agent_core.Error.t) result

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -331,14 +331,17 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
           client_config
       with
       | Ok subscription -> Ok subscription
-      | Error error ->
+      | Error
+          ((Runtime_claude_code.Spawn_failed _ | Runtime_claude_code.Timeout _) as error) ->
         (* The subscription probe is a separate, pre-dispatch CLI process. No
            Claude turn (and therefore no dynamic tool) can have started when
-           it fails. Let the turn driver keep the same-turn fallback lane
-           available for this case; failures returned by [run_turn] below
-           remain observation-unavailable and fail closed. *)
+           it cannot start or times out. Let the turn driver keep the same-turn
+           fallback lane available for only these typed transport outcomes;
+           every other probe error and every [run_turn] failure remains
+           observation-unavailable and fails closed. *)
         Option.iter (fun callback -> callback ()) on_pre_dispatch_failure;
         Error (claude_error_to_core_error error)
+      | Error error -> Error (claude_error_to_core_error error)
     in
     let raw_trace_run =
       Host.start_raw_trace

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -468,6 +468,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       try
         (match
            Runtime_claude_code.run_turn
+             ?on_spawn_failure:on_pre_dispatch_failure
              ~mgr:process_mgr
              ~clock
              ~cwd:process_cwd

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -185,7 +185,7 @@ let recovery_failure_of_client_error = function
 
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~raw_trace ~on_event
+    ~context ~event_bus ~raw_trace ~on_event ?on_pre_dispatch_failure
     ~(config : Runtime_execution.claude_code) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
@@ -331,7 +331,14 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
           client_config
       with
       | Ok subscription -> Ok subscription
-      | Error error -> Error (claude_error_to_core_error error)
+      | Error error ->
+        (* The subscription probe is a separate, pre-dispatch CLI process. No
+           Claude turn (and therefore no dynamic tool) can have started when
+           it fails. Let the turn driver keep the same-turn fallback lane
+           available for this case; failures returned by [run_turn] below
+           remain observation-unavailable and fail closed. *)
+        Option.iter (fun callback -> callback ()) on_pre_dispatch_failure;
+        Error (claude_error_to_core_error error)
     in
     let raw_trace_run =
       Host.start_raw_trace
@@ -709,7 +716,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~raw_trace ~on_event ~config =
+    ~context ~event_bus ~raw_trace ~on_event ?on_pre_dispatch_failure ~config =
   Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
     run_without_lifecycle
       ~runtime_id
@@ -727,5 +734,6 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       ~event_bus
       ~raw_trace
       ~on_event
+      ?on_pre_dispatch_failure
       ~config)
 ;;

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -16,5 +16,6 @@ val run :
   event_bus:Agent_core.Event_bus.t option ->
   raw_trace:Agent_core.Raw_trace.t option ->
   on_event:(Agent_core.Types.sse_event -> unit) option ->
+  ?on_pre_dispatch_failure:(unit -> unit) ->
   config:Runtime_execution.claude_code ->
   (Runtime_agent.run_result, Agent_core.Error.t) result

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -8,6 +8,11 @@ let internal_error detail = Agent_core.Error.Internal detail
 
 module Host = Keeper_official_client_host
 
+type attempt_outcome =
+  { result : (Runtime_agent.run_result, Agent_core.Error.t) result
+  ; effect_disposition : Keeper_provider_attempt_effect.t
+  }
+
 let runtime_label = "Codex"
 
 let finish_raw_error ~keeper_name raw_trace_run error =
@@ -148,13 +153,18 @@ let model_input_projection_for_capacity
   Ok projected
 ;;
 
-let codex_dynamic_tool (tool : Host.dynamic_tool) :
+let codex_dynamic_tool ~observe_effect_attempted (tool : Host.dynamic_tool) :
     Runtime_codex_app_server.dynamic_tool =
   { name = tool.name
   ; description = tool.description
   ; input_schema = tool.input_schema
   ; call =
       (fun ~call_id input ->
+        (* Close the outer same-turn retry boundary before entering user/tool
+           code. The handler may commit and then raise or be cancelled, so
+           observing only its returned value would reopen a duplicate-effect
+           window. *)
+        observe_effect_attempted ();
         let result = tool.call ~call_id input in
         { Runtime_codex_app_server.success = result.success
         ; content = result.content
@@ -311,6 +321,7 @@ let recovery_failure_of_client_error = function
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
     ~context_injector ~context ~event_bus ~raw_trace ~on_event
+    ~observe_effect_attempted
     ~(config : Runtime_execution.codex_app_server) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
@@ -441,7 +452,9 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~terminal_error
         ~raw_trace_run:None
     in
-    let dynamic_tools = List.map codex_dynamic_tool host_dynamic_tools in
+    let dynamic_tools =
+      List.map (codex_dynamic_tool ~observe_effect_attempted) host_dynamic_tools
+    in
     (* The only size this tree reports for a turn is
        [keeper_unified_turn.ml]'s [system_and_user_bytes], which sums
        [system_prompt + world_state + user_message] and nothing else. The
@@ -508,7 +521,9 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~terminal_error
         ~raw_trace_run
     in
-    let dynamic_tools = List.map codex_dynamic_tool host_dynamic_tools in
+    let dynamic_tools =
+      List.map (codex_dynamic_tool ~observe_effect_attempted) host_dynamic_tools
+    in
     let* claimed_session =
       match
         Keeper_official_client_session_store.claim
@@ -800,6 +815,12 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
     ~context_injector ~context ~event_bus ~raw_trace ~on_event ~config =
+  let effect_disposition =
+    Atomic.make Keeper_provider_attempt_effect.No_effect_observed
+  in
+  let observe_effect_attempted () =
+    Atomic.set effect_disposition Keeper_provider_attempt_effect.Effect_attempted
+  in
   let observed_next_shrink_capacity_bytes = ref None in
   let starting_capacity_bytes =
     Keeper_context_overflow_shrink_state.starting_capacity_bytes
@@ -807,11 +828,14 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ~runtime_id
       ~max_capacity_bytes:unbounded_model_input_capacity_bytes
   in
-  Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
-    Keeper_turn_driver_try_provider.context_overflow_shrink_sequence
+  let result =
+    Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
+      Keeper_turn_driver_try_provider.context_overflow_shrink_sequence
       ~starting_capacity_bytes
       ~same_run_retry_authorized:(fun () ->
-        Option.is_some !observed_next_shrink_capacity_bytes)
+        Keeper_provider_attempt_effect.allows_same_turn_retry
+          (Atomic.get effect_disposition)
+        && Option.is_some !observed_next_shrink_capacity_bytes)
       ~shrink_capacity:(fun ~capacity_bytes:_ ~default_capacity_bytes ->
         Option.value
           !observed_next_shrink_capacity_bytes
@@ -853,8 +877,11 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
           ~event_bus
           ~raw_trace
           ~on_event
+          ~observe_effect_attempted
           ~config)
       ())
+  in
+  { result; effect_disposition = Atomic.get effect_disposition }
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -1,5 +1,13 @@
 (** Keeper projection for the official Codex app-server turn runtime. *)
 
+type attempt_outcome =
+  { result : (Runtime_agent.run_result, Agent_core.Error.t) result
+  ; effect_disposition : Keeper_provider_attempt_effect.t
+  }
+(** One Codex candidate result plus the typed tool-effect fact observed while
+    producing it. The outer runtime-lane owner consumes [effect_disposition]
+    directly; provider error strings carry no retry authority. *)
+
 val run :
   runtime_id:string ->
   keeper_name:string ->
@@ -17,7 +25,7 @@ val run :
   raw_trace:Agent_core.Raw_trace.t option ->
   on_event:(Agent_core.Types.sse_event -> unit) option ->
   config:Runtime_execution.codex_app_server ->
-  (Runtime_agent.run_result, Agent_core.Error.t) result
+  attempt_outcome
 
 module For_testing : sig
   (** Typed carriage of Codex app-server client errors into agent-core

--- a/lib/keeper/keeper_provider_attempt_effect.ml
+++ b/lib/keeper/keeper_provider_attempt_effect.ml
@@ -1,0 +1,9 @@
+type t =
+  | No_effect_observed
+  | Effect_attempted
+  | Observation_unavailable
+
+let allows_same_turn_retry = function
+  | No_effect_observed -> true
+  | Effect_attempted | Observation_unavailable -> false
+;;

--- a/lib/keeper/keeper_provider_attempt_effect.mli
+++ b/lib/keeper/keeper_provider_attempt_effect.mli
@@ -1,0 +1,22 @@
+(** Typed observation of tool effects within one provider candidate attempt.
+
+    This value is carried separately from the provider error. Provider error
+    text and subtypes are diagnostic evidence; they must never be parsed to
+    recover whether trying another candidate could repeat an external effect. *)
+
+type t =
+  | No_effect_observed
+      (** The attempt boundary did not observe a dynamic tool invocation. This
+          does not override another retry fence such as an AGENT_CORE checkpoint. *)
+  | Effect_attempted
+      (** A dynamic tool handler was entered. The effect may have committed, so
+          another provider candidate must not receive the same turn. *)
+  | Observation_unavailable
+      (** This runtime path has no complete tool-effect observer. Same-turn
+          retry is fail-closed until the adapter supplies one. *)
+
+(** [allows_same_turn_retry disposition] is the effect-side half of the
+    same-turn retry gate. Callers must compose it with every other retry
+    authority, notably the typed AGENT_CORE checkpoint fence. Unknown
+    observation is denied rather than treated as evidence of no effect. *)
+val allows_same_turn_retry : t -> bool

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -791,7 +791,10 @@ let run_named
         , codex_attempt.effect_disposition )
       | Runtime_execution.Antigravity_cli config ->
         let antigravity_effect_disposition =
-          ref Keeper_provider_attempt_effect.Observation_unavailable
+          ref
+            (match tools with
+             | [] -> Keeper_provider_attempt_effect.No_effect_observed
+             | _ :: _ -> Keeper_provider_attempt_effect.Observation_unavailable)
         in
         let run_antigravity ~initial_messages () =
           Keeper_antigravity_runtime.run
@@ -874,11 +877,16 @@ let run_named
            an absent AGENT_CORE checkpoint after dispatch. *)
         , effect_disposition )
       | Runtime_execution.Claude_code config ->
+        let effective_claude_tools =
+          if runtime.model.tools_support then tools else []
+        in
         let claude_effect_disposition =
-          ref Keeper_provider_attempt_effect.Observation_unavailable
+          ref
+            (match effective_claude_tools with
+             | [] -> Keeper_provider_attempt_effect.No_effect_observed
+             | _ :: _ -> Keeper_provider_attempt_effect.Observation_unavailable)
         in
         let run_claude ~initial_messages () =
-          let tools = if runtime.model.tools_support then tools else [] in
           Keeper_claude_code_runtime.run
             ~runtime_id:attempt_runtime_id
             ~keeper_name
@@ -886,7 +894,7 @@ let run_named
             ~goal
             ~goal_blocks
             ~system_prompt
-            ~tools
+            ~tools:effective_claude_tools
             ~initial_messages
             ~model_input_projection
             ~hooks

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -791,10 +791,7 @@ let run_named
         , codex_attempt.effect_disposition )
       | Runtime_execution.Antigravity_cli config ->
         let antigravity_effect_disposition =
-          ref
-            (match tools with
-             | [] -> Keeper_provider_attempt_effect.No_effect_observed
-             | _ :: _ -> Keeper_provider_attempt_effect.Observation_unavailable)
+          ref Keeper_provider_attempt_effect.Observation_unavailable
         in
         let run_antigravity ~initial_messages () =
           Keeper_antigravity_runtime.run

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -790,6 +790,9 @@ let run_named
         , None
         , codex_attempt.effect_disposition )
       | Runtime_execution.Antigravity_cli config ->
+        let antigravity_effect_disposition =
+          ref Keeper_provider_attempt_effect.Observation_unavailable
+        in
         let run_antigravity ~initial_messages () =
           Keeper_antigravity_runtime.run
             ~runtime_id:attempt_runtime_id
@@ -807,6 +810,9 @@ let run_named
             ~event_bus
             ~raw_trace
             ~on_event
+            ~on_pre_dispatch_failure:(fun () ->
+              antigravity_effect_disposition :=
+                Keeper_provider_attempt_effect.No_effect_observed)
             ~config
         in
         let run_antigravity_with_history () =
@@ -840,11 +846,11 @@ let run_named
                     , `String "official_client_session_store_owns_resume" )
                   ])
               Keeper_runtime_manifest.Runtime_routed;
-            ( run_antigravity_with_history ()
-            , Keeper_provider_attempt_effect.Observation_unavailable )
+            let result = run_antigravity_with_history () in
+            result, !antigravity_effect_disposition
           | None, None ->
-            ( run_antigravity_with_history ()
-            , Keeper_provider_attempt_effect.Observation_unavailable )
+            let result = run_antigravity_with_history () in
+            result, !antigravity_effect_disposition
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let antigravity_result =
@@ -868,6 +874,9 @@ let run_named
            an absent AGENT_CORE checkpoint after dispatch. *)
         , effect_disposition )
       | Runtime_execution.Claude_code config ->
+        let claude_effect_disposition =
+          ref Keeper_provider_attempt_effect.Observation_unavailable
+        in
         let run_claude ~initial_messages () =
           let tools = if runtime.model.tools_support then tools else [] in
           Keeper_claude_code_runtime.run
@@ -886,6 +895,9 @@ let run_named
             ~event_bus
             ~raw_trace
             ~on_event
+            ~on_pre_dispatch_failure:(fun () ->
+              claude_effect_disposition :=
+                Keeper_provider_attempt_effect.No_effect_observed)
             ~config
         in
         let claude_result, effect_disposition =
@@ -921,11 +933,11 @@ let run_named
                     , `String "official_client_session_store_owns_resume" )
                   ])
               Keeper_runtime_manifest.Runtime_routed;
-            ( run_claude ~initial_messages ()
-            , Keeper_provider_attempt_effect.Observation_unavailable )
+            let result = run_claude ~initial_messages () in
+            result, !claude_effect_disposition
           | None, None ->
-            ( run_claude ~initial_messages ()
-            , Keeper_provider_attempt_effect.Observation_unavailable )
+            let result = run_claude ~initial_messages () in
+            result, !claude_effect_disposition
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let claude_result =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -203,7 +203,7 @@ let attempt_runtime_candidates
       (match
          run_attempt ~idx ~runtime_id:attempt_runtime_id candidate
        with
-       | Ok value, _checkpoint_after ->
+       | Ok value, _checkpoint_after, _effect_disposition ->
          emit_runtime_manifest
            ~status:"completed"
            ~decision:(runtime_attempt_decision ~idx ~runtime_id:attempt_runtime_id)
@@ -216,13 +216,17 @@ let attempt_runtime_candidates
               ~candidate:attempt_runtime_id
           | None -> ());
          Ok value
-       | Error error, _checkpoint_after ->
+       | Error error, _checkpoint_after, effect_disposition ->
          emit_runtime_manifest
            ~status:"failed"
            ~decision:(runtime_failed_decision ~idx ~runtime_id:attempt_runtime_id error)
            Keeper_runtime_manifest.Runtime_failed;
          let retry_admitted =
            allow_retry ~runtime_id:attempt_runtime_id ~attempt:idx error
+         in
+         let effect_retry_admitted =
+           Keeper_provider_attempt_effect.allows_same_turn_retry
+             effect_disposition
          in
          let allow_accept_no_progress_retry =
            if
@@ -235,7 +239,7 @@ let attempt_runtime_candidates
                error
            else true
          in
-         let retryable_with_input_authority =
+         let error_is_retryable =
            lane_should_retry
              ~is_last
              ~allow_retry:true
@@ -252,7 +256,7 @@ let attempt_runtime_candidates
              then Some error
              else None
          in
-         if retry_admitted && retryable_with_input_authority
+         if retry_admitted && effect_retry_admitted && error_is_retryable
          then loop ~observed_overflow (idx + 1) rest
          else if is_last
          then (
@@ -264,8 +268,8 @@ let attempt_runtime_candidates
            | Some overflow_error -> Error overflow_error
            | None -> Error error)
          else (
-           (match retryable_with_input_authority, rest with
-            | true, next :: later ->
+           (match error_is_retryable, effect_retry_admitted, rest with
+            | true, true, next :: later ->
               on_retry_deferred
                 { assignment_id = runtime_id
                 ; failed_runtime_id = attempt_runtime_id
@@ -273,7 +277,7 @@ let attempt_runtime_candidates
                 ; later_runtime_ids = List.map runtime_id_of later
                 ; failure = error
                 }
-            | false, _ | true, [] -> ());
+            | false, _, _ | true, false, _ | true, true, [] -> ());
            Error error))
   in
   loop ~observed_overflow:None 0 candidates
@@ -695,7 +699,9 @@ let run_named
       match candidate with
       | Missing_runtime runtime_id ->
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
-        Error (runtime_candidate_missing_error runtime_id), None
+        ( Error (runtime_candidate_missing_error runtime_id)
+        , None
+        , Keeper_provider_attempt_effect.No_effect_observed )
       | Resolved_runtime runtime ->
       let error_runtime_id = attempt_runtime_id in
       let inference_policy =
@@ -725,17 +731,21 @@ let run_named
             ~on_event
             ~config
         in
-        let codex_result =
+        let codex_attempt =
           match provider_config_transform, agent_core_checkpoint with
           | Some _, _ ->
-            Error
-              (Agent_core.Error.Config
-                 (Agent_core.Error.InvalidConfig
-                    { field = "provider_config_transform"
-                    ; detail =
-                        "provider config transforms cannot target a \
-                         codex-app-server runtime"
-                    }))
+            { Keeper_codex_runtime.result =
+                Error
+                  (Agent_core.Error.Config
+                     (Agent_core.Error.InvalidConfig
+                        { field = "provider_config_transform"
+                        ; detail =
+                            "provider config transforms cannot target a \
+                             codex-app-server runtime"
+                        }))
+            ; effect_disposition =
+                Keeper_provider_attempt_effect.No_effect_observed
+            }
           | None, checkpoint ->
             (* The official-client session store is the start-or-resume
                authority ([Keeper_codex_runtime] reads the durable
@@ -764,7 +774,7 @@ let run_named
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let codex_result =
-          Result.bind codex_result (fun run_result ->
+          Result.bind codex_attempt.result (fun run_result ->
             Keeper_turn_driver_try_provider.apply_accept
               ~runtime_id:attempt_runtime_id
               ~accept
@@ -776,7 +786,9 @@ let run_named
              (fun observe -> Option.iter observe run_result.Runtime_agent.runtime_observation)
              on_runtime_observation
          | Error _ -> ());
-        selected_runtime_result runtime codex_result, None
+        ( selected_runtime_result runtime codex_result
+        , None
+        , codex_attempt.effect_disposition )
       | Runtime_execution.Antigravity_cli config ->
         let run_antigravity ~initial_messages () =
           Keeper_antigravity_runtime.run
@@ -800,16 +812,17 @@ let run_named
         let run_antigravity_with_history () =
           run_antigravity ~initial_messages ()
         in
-        let antigravity_result =
+        let antigravity_result, effect_disposition =
           match provider_config_transform, agent_core_checkpoint with
           | Some _, _ ->
-            Error
-              (Agent_core.Error.Config
-                 (Agent_core.Error.InvalidConfig
-                    { field = "provider_config_transform"
-                    ; detail =
-                        "provider config transforms cannot target an antigravity-cli runtime"
-                    }))
+            ( Error
+                (Agent_core.Error.Config
+                   (Agent_core.Error.InvalidConfig
+                      { field = "provider_config_transform"
+                      ; detail =
+                          "provider config transforms cannot target an antigravity-cli runtime"
+                      }))
+            , Keeper_provider_attempt_effect.No_effect_observed )
           | None, Some _ ->
             Log.Keeper.info
               "%s: official-client runtime %s resolves start-or-resume from \
@@ -827,8 +840,11 @@ let run_named
                     , `String "official_client_session_store_owns_resume" )
                   ])
               Keeper_runtime_manifest.Runtime_routed;
-            run_antigravity_with_history ()
-          | None, None -> run_antigravity_with_history ()
+            ( run_antigravity_with_history ()
+            , Keeper_provider_attempt_effect.Observation_unavailable )
+          | None, None ->
+            ( run_antigravity_with_history ()
+            , Keeper_provider_attempt_effect.Observation_unavailable )
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let antigravity_result =
@@ -845,7 +861,12 @@ let run_named
                Option.iter observe run_result.Runtime_agent.runtime_observation)
              on_runtime_observation
          | Error _ -> ());
-        selected_runtime_result runtime antigravity_result, None
+        ( selected_runtime_result runtime antigravity_result
+        , None
+        (* Antigravity executes dynamic tools but does not yet return a
+           complete attempt-local effect observation. Never infer safety from
+           an absent AGENT_CORE checkpoint after dispatch. *)
+        , effect_disposition )
       | Runtime_execution.Claude_code config ->
         let run_claude ~initial_messages () =
           let tools = if runtime.model.tools_support then tools else [] in
@@ -867,16 +888,17 @@ let run_named
             ~on_event
             ~config
         in
-        let claude_result =
+        let claude_result, effect_disposition =
           match provider_config_transform, agent_core_checkpoint with
           | Some _, _ ->
-            Error
-              (Agent_core.Error.Config
-                 (Agent_core.Error.InvalidConfig
-                    { field = "provider_config_transform"
-                    ; detail =
-                        "provider config transforms cannot target a claude-code runtime"
-                    }))
+            ( Error
+                (Agent_core.Error.Config
+                   (Agent_core.Error.InvalidConfig
+                      { field = "provider_config_transform"
+                      ; detail =
+                          "provider config transforms cannot target a claude-code runtime"
+                      }))
+            , Keeper_provider_attempt_effect.No_effect_observed )
           | None, Some _ ->
             (* The durable official-client session store owns start-or-resume
                (Keeper_claude_code_runtime reads [previous_settlement]), so a
@@ -899,8 +921,11 @@ let run_named
                     , `String "official_client_session_store_owns_resume" )
                   ])
               Keeper_runtime_manifest.Runtime_routed;
-            run_claude ~initial_messages ()
-          | None, None -> run_claude ~initial_messages ()
+            ( run_claude ~initial_messages ()
+            , Keeper_provider_attempt_effect.Observation_unavailable )
+          | None, None ->
+            ( run_claude ~initial_messages ()
+            , Keeper_provider_attempt_effect.Observation_unavailable )
         in
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let claude_result =
@@ -917,7 +942,11 @@ let run_named
                Option.iter observe run_result.Runtime_agent.runtime_observation)
              on_runtime_observation
          | Error _ -> ());
-        selected_runtime_result runtime claude_result, None
+        ( selected_runtime_result runtime claude_result
+        , None
+        (* Claude Code has the same post-dispatch observation gap. Until its
+           adapter carries the dynamic-tool fact, lane fallback is fail-closed. *)
+        , effect_disposition )
       | Runtime_execution.Agent_core runtime_provider_config ->
        (match
           match provider_config_transform with
@@ -926,7 +955,7 @@ let run_named
         with
       | Error err ->
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
-        Error err, None
+        Error err, None, Keeper_provider_attempt_effect.No_effect_observed
       | Ok provider_config ->
         (match
            validate_provider_request_cap
@@ -935,7 +964,7 @@ let run_named
          with
          | Error err ->
            Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
-           Error err, None
+           Error err, None, Keeper_provider_attempt_effect.No_effect_observed
          | Ok max_request_body_bytes ->
           let candidate = Runtime_candidate.of_provider_config provider_config in
           (* Cached provider health is observation only. Every eligible runtime
@@ -1009,7 +1038,9 @@ let run_named
               ~replay_prefix_projection
               provider_result
           in
-          selected_runtime_result runtime outcomes.turn_result, checkpoint_after))
+          ( selected_runtime_result runtime outcomes.turn_result
+          , checkpoint_after
+          , Keeper_provider_attempt_effect.No_effect_observed )))
        )
     attempt_candidates
 

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -244,7 +244,9 @@ module For_testing : sig
       (idx:int ->
       runtime_id:string ->
       'candidate ->
-      ('result, Agent_core.Error.t) result * Agent_core.Checkpoint.t option) ->
+      ('result, Agent_core.Error.t) result
+      * Agent_core.Checkpoint.t option
+      * Keeper_provider_attempt_effect.t) ->
     'candidate list ->
     ('result, Agent_core.Error.t) result
 

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -656,23 +656,29 @@ let status_to_string = function
   | `Signaled signal -> Printf.sprintf "signal %d" signal
 ;;
 
-let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
-    ~on_conversation_ready ~on_stream_event =
+let run_spawned ?home_dir ?on_spawn_failure ~mgr ~clock ~cwd config
+    ~conversation_mode ~prompt ~on_conversation_ready ~on_stream_event =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
     let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
     let stderr_tail = ref "" in
     let proc =
-      Eio.Process.spawn
-        ~sw
-        mgr
-        ~cwd
-        ~env:(official_client_environment ?home_dir ())
-        ~stdin:stdin_r
-        ~stdout:stdout_w
-        ~stderr:stderr_w
-        (argv config ~conversation_mode)
+      try
+        Eio.Process.spawn
+          ~sw
+          mgr
+          ~cwd
+          ~env:(official_client_environment ?home_dir ())
+          ~stdin:stdin_r
+          ~stdout:stdout_w
+          ~stderr:stderr_w
+          (argv config ~conversation_mode)
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        Option.iter (fun callback -> callback ()) on_spawn_failure;
+        raise exn
     in
     Eio.Flow.close stdin_r;
     Eio.Flow.close stdout_w;
@@ -741,9 +747,9 @@ let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
     status, !state, String.trim !stderr_tail)
 ;;
 
-let run_turn ?(conversation_mode = Start) ?home_dir ~mgr ~clock ~cwd
-    ?(on_conversation_ready = fun ~conversation_id:_ -> Ok ()) ?on_stream_event
-    config ~prompt =
+let run_turn ?(conversation_mode = Start) ?home_dir ?on_spawn_failure ~mgr ~clock
+    ~cwd ?(on_conversation_ready = fun ~conversation_id:_ -> Ok ())
+    ?on_stream_event config ~prompt =
   let* () =
     match home_dir with
     | None -> Ok ()
@@ -758,6 +764,7 @@ let run_turn ?(conversation_mode = Start) ?home_dir ~mgr ~clock ~cwd
       Ok
         (run_spawned
            ?home_dir
+           ?on_spawn_failure
            ~mgr
            ~clock
            ~cwd

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -659,21 +659,24 @@ let status_to_string = function
 let run_spawned ?home_dir ?on_spawn_failure ~mgr ~clock ~cwd config
     ~conversation_mode ~prompt ~on_conversation_ready ~on_stream_event =
   Eio.Switch.run (fun sw ->
-    let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
-    let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
-    let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
     let stderr_tail = ref "" in
-    let proc =
+    let stdin_r, stdin_w, stdout_r, stdout_w, stderr_r, stderr_w, proc =
       try
-        Eio.Process.spawn
-          ~sw
-          mgr
-          ~cwd
-          ~env:(official_client_environment ?home_dir ())
-          ~stdin:stdin_r
-          ~stdout:stdout_w
-          ~stderr:stderr_w
-          (argv config ~conversation_mode)
+        let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
+        let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
+        let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
+        let proc =
+          Eio.Process.spawn
+            ~sw
+            mgr
+            ~cwd
+            ~env:(official_client_environment ?home_dir ())
+            ~stdin:stdin_r
+            ~stdout:stdout_w
+            ~stderr:stderr_w
+            (argv config ~conversation_mode)
+        in
+        stdin_r, stdin_w, stdout_r, stdout_w, stderr_r, stderr_w, proc
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -96,6 +96,7 @@ val validate_turn :
 val run_turn :
   ?conversation_mode:conversation_mode ->
   ?home_dir:string ->
+  ?on_spawn_failure:(unit -> unit) ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -1049,9 +1049,9 @@ let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
     ~ignored:0
 ;;
 
-let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
-    ~session_mode ~session_id ~subscription ~prompt ~on_session_ready
-    ~on_turn_starting ~on_turn_started ~on_stream_event =
+let run_spawned ?on_spawn_failure ~mgr ~clock ~cwd config ~dynamic_tools
+    ~reasoning_effort ~session_mode ~session_id ~subscription ~prompt
+    ~on_session_ready ~on_turn_starting ~on_turn_started ~on_stream_event =
   let* argv =
     command config ~dynamic_tools ~reasoning_effort ~session_mode ~session_id
   in
@@ -1061,15 +1061,21 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
     let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
     let stderr_tail = ref "" in
     let proc =
-      Eio.Process.spawn
-        ~sw
-        mgr
-        ~cwd
-        ~env:(subscription_only_environment ())
-        ~stdin:stdin_r
-        ~stdout:stdout_w
-        ~stderr:stderr_w
-        argv
+      try
+        Eio.Process.spawn
+          ~sw
+          mgr
+          ~cwd
+          ~env:(subscription_only_environment ())
+          ~stdin:stdin_r
+          ~stdout:stdout_w
+          ~stderr:stderr_w
+          argv
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        Option.iter (fun callback -> callback ()) on_spawn_failure;
+        raise exn
     in
     Eio.Flow.close stdin_r;
     Eio.Flow.close stdout_w;
@@ -1174,8 +1180,8 @@ let probe_subscription ~mgr ~clock ~cwd config =
 ;;
 
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
-    ?admitted_subscription
-    ~mgr ~clock ~cwd ?(on_session_ready = fun ~session_id:_ -> Ok ())
+    ?admitted_subscription ?on_spawn_failure ~mgr ~clock ~cwd
+    ?(on_session_ready = fun ~session_id:_ -> Ok ())
     ?(on_turn_starting = fun ~session_id:_ -> Ok ())
     ?(on_turn_started = fun ~session_id:_ ~turn_id:_ -> Ok ()) ?on_stream_event config
     ~prompt =
@@ -1197,6 +1203,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
       subscription.subscription_type;
     try
       run_spawned
+        ?on_spawn_failure
         ~mgr
         ~clock
         ~cwd

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -1056,21 +1056,24 @@ let run_spawned ?on_spawn_failure ~mgr ~clock ~cwd config ~dynamic_tools
     command config ~dynamic_tools ~reasoning_effort ~session_mode ~session_id
   in
   Eio.Switch.run (fun sw ->
-    let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
-    let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
-    let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
     let stderr_tail = ref "" in
-    let proc =
+    let stdin_r, stdin_w, stdout_r, stdout_w, stderr_r, stderr_w, proc =
       try
-        Eio.Process.spawn
-          ~sw
-          mgr
-          ~cwd
-          ~env:(subscription_only_environment ())
-          ~stdin:stdin_r
-          ~stdout:stdout_w
-          ~stderr:stderr_w
-          argv
+        let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
+        let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
+        let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
+        let proc =
+          Eio.Process.spawn
+            ~sw
+            mgr
+            ~cwd
+            ~env:(subscription_only_environment ())
+            ~stdin:stdin_r
+            ~stdout:stdout_w
+            ~stderr:stderr_w
+            argv
+        in
+        stdin_r, stdin_w, stdout_r, stdout_w, stderr_r, stderr_w, proc
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -134,6 +134,7 @@ val run_turn :
   ?reasoning_effort:Llm_provider.Reasoning_effort.t ->
   ?session_mode:session_mode ->
   ?admitted_subscription:subscription ->
+  ?on_spawn_failure:(unit -> unit) ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -631,6 +631,78 @@ let test_blank_success_requires_fresh_conversation () =
       | _ -> fail "fresh Antigravity conversation did not settle")
 ;;
 
+let test_spawn_failure_is_pre_dispatch () =
+  let base_path = temp_workspace () |> Unix.realpath in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+      Unix.mkdir (Filename.concat base_path ".masc") 0o700;
+      let oauth_source = Filename.concat base_path "operator-oauth-token" in
+      write_file ~mode:0o600 oauth_source "operator-oauth-fixture";
+      let missing_cli = Filename.concat base_path "missing-antigravity" in
+      let runtime_path = Filename.concat base_path "runtime.toml" in
+      write_file
+        ~mode:0o600
+        runtime_path
+        (runtime_toml ~cli_path:missing_cli ~oauth_source);
+      let runtime_snapshot = Runtime.For_testing.snapshot () in
+      Fun.protect
+        ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+        (fun () ->
+          Eio_main.run (fun env ->
+            Eio.Switch.run (fun sw ->
+              Eio_context.set_env env;
+              Eio_context.with_test_env
+                ~net:(Eio.Stdenv.net env)
+                ~clock:(Eio.Stdenv.clock env)
+                ~mono_clock:(Eio.Stdenv.mono_clock env)
+                ~sw
+                (fun () ->
+                  Runtime.init_default ~config_path:runtime_path |> Result.get_ok;
+                  let config =
+                    match Runtime.get_runtime_by_id "antigravity.gemini" with
+                    | Some
+                        { Runtime.execution =
+                            Runtime_execution.Antigravity_cli config
+                        ; _
+                        } ->
+                      config
+                    | Some _ | None -> fail "Antigravity runtime fixture did not resolve"
+                  in
+                  let pre_dispatch_failures = ref 0 in
+                  let result =
+                    Keeper_antigravity_runtime.run
+                      ~runtime_id:"antigravity.gemini"
+                      ~keeper_name:"antigravity-pre-dispatch"
+                      ~base_path
+                      ~goal:"spawn should fail"
+                      ~goal_blocks:None
+                      ~system_prompt:""
+                      ~tools:[]
+                      ~initial_messages:[]
+                      ~model_input_projection:None
+                      ~hooks:None
+                      ~context_injector:None
+                      ~context:None
+                      ~event_bus:None
+                      ~raw_trace:None
+                      ~on_event:None
+                      ~on_pre_dispatch_failure:(fun () -> incr pre_dispatch_failures)
+                      ~config
+                  in
+                  (match result with
+                   | Error
+                       (Agent_core.Error.Provider
+                          (Llm_provider.Error.ProviderUnavailable _)) ->
+                     ()
+                   | Error error -> fail (Agent_core.Error.to_string error)
+                   | Ok _ -> fail "missing Antigravity CLI unexpectedly ran");
+                  check int
+                    "spawn is proven pre-dispatch"
+                    1
+                    !pre_dispatch_failures)))))
+;;
+
 let () =
   run
     "keeper_antigravity_runtime"
@@ -643,6 +715,10 @@ let () =
               "blank result starts fresh next turn"
               `Quick
               test_blank_success_requires_fresh_conversation
+          ; test_case
+              "spawn failure is pre-dispatch"
+              `Quick
+              test_spawn_failure_is_pre_dispatch
         ] )
     ]
 ;;

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -835,6 +835,72 @@ let test_spawn_failure_releases_claim () =
          | _ -> fail "transient release evidence was not persisted"))
 ;;
 
+let test_subscription_spawn_failure_is_pre_dispatch () =
+  let base_path = temp_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       let missing_cli = Filename.concat base_path "missing-claude" in
+       let runtime_snapshot = Runtime.For_testing.snapshot () in
+       Fun.protect
+         ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+         (fun () ->
+            with_runtime_config missing_cli (fun runtime_path ->
+              Eio_main.run (fun env ->
+                Eio.Switch.run (fun sw ->
+                  Eio_context.set_env env;
+                  Eio_context.with_test_env
+                    ~net:(Eio.Stdenv.net env)
+                    ~clock:(Eio.Stdenv.clock env)
+                    ~mono_clock:(Eio.Stdenv.mono_clock env)
+                    ~sw
+                    (fun () ->
+                       Runtime.init_default ~config_path:runtime_path |> Result.get_ok;
+                       let config =
+                         match Runtime.get_runtime_by_id "claude.claude" with
+                         | Some
+                             { Runtime.execution =
+                                 Runtime_execution.Claude_code config
+                             ; _
+                             } ->
+                           config
+                         | Some _ | None -> fail "Claude runtime fixture did not resolve"
+                       in
+                       let pre_dispatch_failures = ref 0 in
+                       let result =
+                         Keeper_claude_code_runtime.run
+                           ~runtime_id:"claude.claude"
+                           ~keeper_name:"claude-pre-dispatch"
+                           ~base_path
+                           ~goal:"subscription probe should fail"
+                           ~goal_blocks:None
+                           ~system_prompt:""
+                           ~tools:[]
+                           ~initial_messages:[]
+                           ~model_input_projection:None
+                           ~hooks:None
+                           ~context_injector:None
+                           ~context:None
+                           ~event_bus:None
+                           ~raw_trace:None
+                           ~on_event:None
+                           ~on_pre_dispatch_failure:(fun () ->
+                             incr pre_dispatch_failures)
+                           ~config
+                       in
+                       (match result with
+                        | Error
+                            (Agent_core.Error.Provider
+                               (Llm_provider.Error.ProviderUnavailable _)) ->
+                          ()
+                        | Error error -> fail (Agent_core.Error.to_string error)
+                        | Ok _ -> fail "missing subscription CLI unexpectedly ran");
+                       check int
+                         "subscription spawn is proven pre-dispatch"
+                         1
+                         !pre_dispatch_failures))))))
+;;
+
 let () =
   run
     "keeper_claude_code_runtime"
@@ -866,6 +932,10 @@ let () =
             "spawn failure releases claim"
             `Quick
             test_spawn_failure_releases_claim
+        ; test_case
+            "subscription spawn failure is pre-dispatch"
+            `Quick
+            test_subscription_spawn_failure_is_pre_dispatch
         ] )
     ]
 ;;

--- a/test/test_keeper_rotation_eligibility_census.ml
+++ b/test/test_keeper_rotation_eligibility_census.ml
@@ -37,9 +37,11 @@ let attempted_candidates error =
       ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
         attempts := !attempts @ [ runtime_id ];
         if String.equal candidate first_candidate
-        then Error error, None
+        then
+          Error error, None, Masc.Keeper_provider_attempt_effect.No_effect_observed
         else if String.equal candidate second_candidate
-        then Ok runtime_id, None
+        then
+          Ok runtime_id, None, Masc.Keeper_provider_attempt_effect.No_effect_observed
         else Alcotest.failf "unexpected candidate %s" candidate)
       [ first_candidate; second_candidate ]
   in

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -88,6 +88,10 @@ let retryable_network_error message =
     (Agent_core.Retry.NetworkError
        { message; kind = Llm_provider.Http_client.Unknown })
 
+let attempt_without_effect result checkpoint =
+  result, checkpoint, Masc.Keeper_provider_attempt_effect.No_effect_observed
+;;
+
 let accept_empty_no_progress_error scope =
   Driver.core_error_of_masc_internal_error
     (Driver.Accept_rejected
@@ -974,8 +978,10 @@ let test_attempt_loop_stops_on_nonretryable_failure () =
         attempts := !attempts @ [ runtime_id ];
         match candidate with
         | "primary.test_model" ->
-          Error (Agent_core.Error.Internal "primary terminal failure"), None
-        | "fallback.test_model" -> Ok runtime_id, None
+          attempt_without_effect
+            (Error (Agent_core.Error.Internal "primary terminal failure"))
+            None
+        | "fallback.test_model" -> attempt_without_effect (Ok runtime_id) None
         | other -> Alcotest.failf "unexpected candidate %s" other)
       [ "primary.test_model"; "fallback.test_model" ]
   in
@@ -1018,8 +1024,10 @@ let test_attempt_loop_retries_transport_failure_before_checkpoint () =
         attempts := !attempts @ [ runtime_id ];
         match candidate with
         | "primary.test_model" ->
-          Error (retryable_network_error "primary network failed"), None
-        | "fallback.test_model" -> Ok runtime_id, None
+          attempt_without_effect
+            (Error (retryable_network_error "primary network failed"))
+            None
+        | "fallback.test_model" -> attempt_without_effect (Ok runtime_id) None
         | other -> Alcotest.failf "unexpected candidate %s" other)
       [ "primary.test_model"; "fallback.test_model" ]
   in
@@ -1066,12 +1074,16 @@ let test_cross_owner_fallback_returns_winning_runtime_authority () =
         ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
         ~run_attempt:(fun ~idx:_ ~runtime_id runtime ->
           if String.equal runtime_id primary.id
-          then Error (retryable_network_error "primary failed"), None
+          then
+            attempt_without_effect
+              (Error (retryable_network_error "primary failed"))
+              None
           else
-            ( Driver.For_testing.selected_runtime_result
-                runtime
-                (Ok (completed_run_result ()))
-            , None ))
+            attempt_without_effect
+              (Driver.For_testing.selected_runtime_result
+                 runtime
+                 (Ok (completed_run_result ())))
+              None)
         [ primary; fallback ]
     in
     match result with
@@ -1115,8 +1127,9 @@ let test_attempt_loop_retries_provider_wire_failure_same_turn () =
       ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
         attempts := !attempts @ [ runtime_id ];
         match candidate with
-        | "primary.test_model" -> Error provider_wire_error, None
-        | "fallback.test_model" -> Ok runtime_id, None
+        | "primary.test_model" ->
+          attempt_without_effect (Error provider_wire_error) None
+        | "fallback.test_model" -> attempt_without_effect (Ok runtime_id) None
         | other -> Alcotest.failf "unexpected candidate %s" other)
       [ "primary.test_model"; "fallback.test_model" ]
   in
@@ -1141,6 +1154,50 @@ let test_attempt_loop_retries_provider_wire_failure_same_turn () =
   let events = List.rev !events in
   Alcotest.(check int) "both candidate attempts remain observable" 4 (List.length events)
 
+let check_effect_disposition_blocks_same_turn_retry label effect_disposition =
+  let attempts = ref [] in
+  let deferred = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~allow_retry:(fun ~runtime_id:_ ~attempt:_ _ -> true)
+      ~on_retry_deferred:(fun hint -> deferred := hint :: !deferred)
+      ~runtime_id:"primary.test_model"
+      ~runtime_id_of:Fun.id
+      ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
+      ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        match candidate with
+        | "primary.test_model" ->
+          ( Error (retryable_network_error "primary failed after possible effect")
+          , None
+          , effect_disposition )
+        | "fallback.test_model" ->
+          Alcotest.failf "%s allowed duplicate-capable fallback" label
+        | other -> Alcotest.failf "unexpected candidate %s" other)
+      [ "primary.test_model"; "fallback.test_model" ]
+  in
+  (match result with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.failf "%s unexpectedly succeeded" label);
+  Alcotest.(check (list string))
+    (label ^ " attempts only the effect owner")
+    [ "primary.test_model" ]
+    !attempts;
+  Alcotest.(check int)
+    (label ^ " does not defer the same unsafe suffix")
+    0
+    (List.length !deferred)
+
+let test_attempt_loop_stops_after_effect_attempt () =
+  check_effect_disposition_blocks_same_turn_retry
+    "effect attempted"
+    Masc.Keeper_provider_attempt_effect.Effect_attempted
+
+let test_attempt_loop_fails_closed_without_effect_observation () =
+  check_effect_disposition_blocks_same_turn_retry
+    "effect observation unavailable"
+    Masc.Keeper_provider_attempt_effect.Observation_unavailable
+
 let test_attempt_loop_blocks_no_progress_when_gate_denies () =
   let attempts = ref [] in
   let gate_calls = ref [] in
@@ -1163,7 +1220,9 @@ let test_attempt_loop_blocks_no_progress_when_gate_denies () =
         attempts := !attempts @ [ runtime_id ];
         match candidate with
         | "primary.test_model" ->
-          Error primary_error, Some checkpoint_after_primary
+          attempt_without_effect
+            (Error primary_error)
+            (Some checkpoint_after_primary)
         | "fallback.test_model" ->
           Alcotest.fail "no-progress retry gate should block fallback candidate"
         | other -> Alcotest.failf "unexpected candidate %s" other)
@@ -1218,8 +1277,10 @@ let test_attempt_loop_does_not_gate_network_retry () =
         attempts := !attempts @ [ runtime_id ];
         match candidate with
         | "primary.test_model" ->
-          Error (retryable_network_error "primary network failed"), None
-        | "fallback.test_model" -> Ok runtime_id, None
+          attempt_without_effect
+            (Error (retryable_network_error "primary network failed"))
+            None
+        | "fallback.test_model" -> attempt_without_effect (Ok runtime_id) None
         | other -> Alcotest.failf "unexpected candidate %s" other)
       [ "primary.test_model"; "fallback.test_model" ]
   in
@@ -1267,7 +1328,8 @@ let test_typed_checkpoint_is_the_same_run_retry_authority () =
            ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
              attempts := !attempts @ [ runtime_id ];
              match candidate with
-             | "primary.test_model" -> Error primary_error, None
+             | "primary.test_model" ->
+               attempt_without_effect (Error primary_error) None
              | "fallback.test_model" ->
                Alcotest.fail "checkpoint stage must block same-run fallback"
              | other -> Alcotest.failf "unexpected candidate %s" other)
@@ -1299,7 +1361,9 @@ let test_attempt_loop_preserves_last_core_error () =
       ~runtime_id_of:(fun runtime_id -> runtime_id)
       ~emit_runtime_manifest:(emit_manifest_collector events)
       ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
-        Error (retryable_network_error (runtime_id ^ " failed")), None)
+        attempt_without_effect
+          (Error (retryable_network_error (runtime_id ^ " failed")))
+          None)
       [ "primary.test_model"; "fallback.test_model" ]
   in
   (match result with
@@ -1359,11 +1423,12 @@ let test_attempt_loop_input_capacity_does_not_advance_masc_lane () =
         attempts := !attempts @ [ runtime_id ];
         match candidate with
         | "unmeasurable.test_model" ->
-          Error
-            (input_capacity_error
-               (Agent_core.Retry.Token_measurement_unavailable
-                  Llm_provider.Input_token_count.Anthropic_messages_count_tokens)),
-          None
+          attempt_without_effect
+            (Error
+               (input_capacity_error
+                  (Agent_core.Retry.Token_measurement_unavailable
+                     Llm_provider.Input_token_count.Anthropic_messages_count_tokens)))
+            None
         | other ->
           Alcotest.failf
             "MASC advanced to candidate %s without an AGENT_CORE flow receipt"
@@ -1397,8 +1462,10 @@ let test_attempt_loop_overflow_tries_next_candidate () =
         attempts := !attempts @ [ runtime_id ];
         match candidate with
         | "small.test_model" ->
-          Error (context_overflow_error "prompt exceeds context window"), None
-        | "large.test_model" -> Ok runtime_id, None
+          attempt_without_effect
+            (Error (context_overflow_error "prompt exceeds context window"))
+            None
+        | "large.test_model" -> attempt_without_effect (Ok runtime_id) None
         | other -> Alcotest.failf "unexpected candidate %s" other)
       [ "small.test_model"; "large.test_model" ]
   in
@@ -1431,7 +1498,9 @@ let test_attempt_loop_overflow_on_last_candidate_is_terminal () =
       ~emit_runtime_manifest:(emit_manifest_collector events)
       ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
         attempts := !attempts @ [ runtime_id ];
-        Error (context_overflow_error (runtime_id ^ " overflow")), None)
+        attempt_without_effect
+          (Error (context_overflow_error (runtime_id ^ " overflow")))
+          None)
       [ "small.test_model"; "smaller.test_model" ]
   in
   (match result with
@@ -1462,13 +1531,16 @@ let test_attempt_loop_exhaustion_preserves_earlier_overflow () =
         attempts := !attempts @ [ runtime_id ];
         match candidate with
         | "small.test_model" ->
-          Error (context_overflow_error "prompt exceeds context window"), None
+          attempt_without_effect
+            (Error (context_overflow_error "prompt exceeds context window"))
+            None
         | "fallback.test_model" ->
-          ( Error
-              (Agent_core.Error.Api
-                 (Agent_core.Retry.RateLimited
-                    { retry_after = None; message = "weekly usage limit" }))
-          , None )
+          attempt_without_effect
+            (Error
+               (Agent_core.Error.Api
+                  (Agent_core.Retry.RateLimited
+                     { retry_after = None; message = "weekly usage limit" })))
+            None
         | other -> Alcotest.failf "unexpected candidate %s" other)
       [ "small.test_model"; "fallback.test_model" ]
   in
@@ -1498,9 +1570,13 @@ let test_attempt_loop_midwalk_terminal_outranks_observed_overflow () =
         attempts := !attempts @ [ runtime_id ];
         match candidate with
         | "small.test_model" ->
-          Error (context_overflow_error "prompt exceeds context window"), None
+          attempt_without_effect
+            (Error (context_overflow_error "prompt exceeds context window"))
+            None
         | "broken.test_model" ->
-          Error (Agent_core.Error.Internal "hard mid-lane failure"), None
+          attempt_without_effect
+            (Error (Agent_core.Error.Internal "hard mid-lane failure"))
+            None
         | other ->
           Alcotest.failf "walk must stop before candidate %s" other)
       [ "small.test_model"; "broken.test_model"; "fallback.test_model" ]
@@ -1538,7 +1614,7 @@ let test_checkpoint_denial_defers_exact_frozen_suffix_once () =
       ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
       ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
         attempts := runtime_id :: !attempts;
-        Error err, None)
+        attempt_without_effect (Error err) None)
       [ "runtime.a"; "runtime.b"; "runtime.c"; "runtime.d" ]
   in
   (match result with
@@ -1571,8 +1647,9 @@ let test_deferred_cycle_starts_at_supplied_successor_and_keeps_tail () =
       ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
         attempts := runtime_id :: !attempts;
         match runtime_id with
-        | "runtime.b" -> Error (retryable_network_error "b failed"), None
-        | "runtime.c" -> Ok runtime_id, None
+        | "runtime.b" ->
+          attempt_without_effect (Error (retryable_network_error "b failed")) None
+        | "runtime.c" -> attempt_without_effect (Ok runtime_id) None
         | "runtime.a" ->
           Alcotest.fail "failed lane prefix must not replay on the next cycle"
         | other -> Alcotest.failf "unexpected runtime %s" other)
@@ -1599,7 +1676,9 @@ let test_deferred_cycle_post_checkpoint_replaces_hint_with_tail () =
       ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
       ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
         Alcotest.(check string) "only B attempted" "runtime.b" runtime_id;
-        Error (retryable_network_error "b checkpoint failure"), None)
+        attempt_without_effect
+          (Error (retryable_network_error "b checkpoint failure"))
+          None)
       [ "runtime.b"; "runtime.c"; "runtime.d" ]
   in
   (match result with Error _ -> () | Ok _ -> Alcotest.fail "expected B failure");
@@ -1622,7 +1701,9 @@ let test_single_candidate_checkpoint_failure_has_no_hint () =
       ~runtime_id_of:Fun.id
       ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
       ~run_attempt:(fun ~idx:_ ~runtime_id:_ _candidate ->
-        Error (retryable_network_error "only failed"), None)
+        attempt_without_effect
+          (Error (retryable_network_error "only failed"))
+          None)
       [ "runtime.only" ]
   in
   (match result with Error _ -> () | Ok _ -> Alcotest.fail "expected failure");
@@ -1783,6 +1864,14 @@ let () =
             "provider-wire failure rotates in the same turn"
             `Quick
             test_attempt_loop_retries_provider_wire_failure_same_turn;
+          Alcotest.test_case
+            "effect attempt blocks same-turn fallback"
+            `Quick
+            test_attempt_loop_stops_after_effect_attempt;
+          Alcotest.test_case
+            "missing effect observation fails closed"
+            `Quick
+            test_attempt_loop_fails_closed_without_effect_observation;
           Alcotest.test_case
             "attempt loop blocks no-progress when gate denies"
             `Quick


### PR DESCRIPTION
## Summary

- rebase the provider-effect retry fence from #28178 onto current `main`
- preserve Codex typed error carriage added by #28192
- allow same-turn fallback only from typed, provably pre-dispatch failures
- keep Antigravity post-spawn failures and Claude non-transport probe failures fail-closed
- retain adapter-level missing-CLI regression tests

## Review response

Supersedes #28178 because its branch diverged and conflicted with current `main`.

- Antigravity: only `Runtime_antigravity.Spawn_failed` reports no effect observed
- Claude: only subscription-probe `Spawn_failed | Timeout` reports no effect observed
- no provider error strings or detail fields are parsed for retry authority

## Validation

CI is the validation path for this rebased branch.
