### PR TITLE
refactor(runtime): share the official-client JSON shape checks

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -108,46 +108,19 @@ let error_to_string = function
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
 let ( let* ) result f = Result.bind result f
 
-let rec validate_unique_object_keys ~stage ~path = function
-  | `Assoc fields ->
-    let rec loop seen = function
-      | [] -> Ok ()
-      | (name, value) :: rest ->
-        if List.mem name seen
-        then protocol_error stage (Printf.sprintf "duplicate object key %S at %s" name path)
-        else
-          let* () =
-            validate_unique_object_keys ~stage ~path:(path ^ "." ^ name) value
-          in
-          loop (name :: seen) rest
-    in
-    loop [] fields
-  | `List values ->
-    let rec loop index = function
-      | [] -> Ok ()
-      | value :: rest ->
-        let* () =
-          validate_unique_object_keys
-            ~stage
-            ~path:(Printf.sprintf "%s[%d]" path index)
-            value
-        in
-        loop (index + 1) rest
-    in
-    loop 0 values
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
-;;
+(* The three official-client runtimes speak the same line-delimited JSON
+   protocol and differ only in the error constructor they fail with. The shape
+   checks live once in {!Runtime_official_client_json}; this instantiates them
+   against this runtime's own [error]. *)
+module Shared_json = Runtime_official_client_json.Make (struct
+  type t = error
 
-let assoc_at stage = function
-  | `Assoc fields -> Ok fields
-  | _ -> protocol_error stage "expected a JSON object"
-;;
+  let protocol ~stage ~detail = Protocol_error { stage; detail }
+end)
 
-let required_member stage name fields =
-  match List.assoc_opt name fields with
-  | Some value -> Ok value
-  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
-;;
+open Shared_json
+
+let bounded_tail = Runtime_official_client_json.bounded_tail
 
 let required_string ?(nonempty = true) stage name fields =
   match List.assoc_opt name fields with
@@ -156,13 +129,6 @@ let required_string ?(nonempty = true) stage name fields =
     protocol_error stage (Printf.sprintf "field %S must not be empty" name)
   | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string" name)
   | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
-;;
-
-let optional_string stage name fields =
-  match List.assoc_opt name fields with
-  | None | Some `Null -> Ok None
-  | Some (`String value) -> Ok (Some value)
-  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
 ;;
 
 let required_nonnegative_int stage name fields =
@@ -477,12 +443,6 @@ let argv config ~conversation_mode =
     match conversation_mode with
     | Start -> values @ [ "--new-project" ]
     | Resume { conversation_id } -> values @ [ "--conversation"; conversation_id ])
-;;
-
-let bounded_tail ~limit current addition =
-  let combined = current ^ addition in
-  let length = String.length combined in
-  if length <= limit then combined else String.sub combined (length - limit) limit
 ;;
 
 let drain_stderr flow tail =

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -165,41 +165,19 @@ let error_kind = function
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
 let ( let* ) result f = Result.bind result f
 
-let rec validate_unique_object_keys ~stage ~path = function
-  | `Assoc fields ->
-    let rec loop seen = function
-      | [] -> Ok ()
-      | (name, value) :: rest ->
-        if List.mem name seen
-        then
-          protocol_error
-            stage
-            (Printf.sprintf "duplicate object key %S at %s" name path)
-        else
-          let* () =
-            validate_unique_object_keys
-              ~stage
-              ~path:(path ^ "." ^ name)
-              value
-          in
-          loop (name :: seen) rest
-    in
-    loop [] fields
-  | `List values ->
-    let rec loop index = function
-      | [] -> Ok ()
-      | value :: rest ->
-        let* () =
-          validate_unique_object_keys
-            ~stage
-            ~path:(Printf.sprintf "%s[%d]" path index)
-            value
-        in
-        loop (index + 1) rest
-    in
-    loop 0 values
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
-;;
+(* The three official-client runtimes speak the same line-delimited JSON
+   protocol and differ only in the error constructor they fail with. The shape
+   checks live once in {!Runtime_official_client_json}; this instantiates them
+   against this runtime's own [error]. *)
+module Shared_json = Runtime_official_client_json.Make (struct
+  type t = error
+
+  let protocol ~stage ~detail = Protocol_error { stage; detail }
+end)
+
+open Shared_json
+
+let bounded_tail = Runtime_official_client_json.bounded_tail
 
 let parse_json ~stage text =
   let parsed =
@@ -209,40 +187,6 @@ let parse_json ~stage text =
   let* json = parsed in
   let* () = validate_unique_object_keys ~stage ~path:"$" json in
   Ok json
-;;
-
-let assoc_at stage = function
-  | `Assoc fields -> Ok fields
-  | _ -> protocol_error stage "expected a JSON object"
-;;
-
-let required_member stage name fields =
-  match List.assoc_opt name fields with
-  | Some value -> Ok value
-  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
-;;
-
-let required_string stage name fields =
-  match List.assoc_opt name fields with
-  | Some (`String value) when String.trim value <> "" -> Ok value
-  | Some _ ->
-    protocol_error stage (Printf.sprintf "field %S must be a non-empty string" name)
-  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
-;;
-
-let optional_string stage name fields =
-  match List.assoc_opt name fields with
-  | None | Some `Null -> Ok None
-  | Some (`String value) -> Ok (Some value)
-  | Some _ ->
-    protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
-;;
-
-let required_bool stage name fields =
-  match List.assoc_opt name fields with
-  | Some (`Bool value) -> Ok value
-  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a boolean" name)
-  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
 ;;
 
 let optional_int stage name fields =
@@ -885,12 +829,6 @@ let command config ~dynamic_tools ~reasoning_effort ~session_mode ~session_id =
     @ [ "--input-format"; "stream-json" ]
   in
   Ok args
-;;
-
-let bounded_tail ~limit current addition =
-  let combined = current ^ addition in
-  let length = String.length combined in
-  if length <= limit then combined else String.sub combined (length - limit) limit
 ;;
 
 let drain_stderr flow tail =

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -155,66 +155,19 @@ let error_kind = function
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
 let ( let* ) result f = Result.bind result f
 
-let rec validate_unique_object_keys ~stage ~path = function
-  | `Assoc fields ->
-    let rec loop seen = function
-      | [] -> Ok ()
-      | (name, value) :: rest ->
-        if List.mem name seen
-        then
-          protocol_error
-            stage
-            (Printf.sprintf "duplicate object key %S at %s" name path)
-        else
-          let* () =
-            validate_unique_object_keys
-              ~stage
-              ~path:(path ^ "." ^ name)
-              value
-          in
-          loop (name :: seen) rest
-    in
-    loop [] fields
-  | `List values ->
-    let rec loop index = function
-      | [] -> Ok ()
-      | value :: rest ->
-        let* () =
-          validate_unique_object_keys
-            ~stage
-            ~path:(Printf.sprintf "%s[%d]" path index)
-            value
-        in
-        loop (index + 1) rest
-    in
-    loop 0 values
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
-;;
+(* The three official-client runtimes speak the same line-delimited JSON
+   protocol and differ only in the error constructor they fail with. The shape
+   checks live once in {!Runtime_official_client_json}; this instantiates them
+   against this runtime's own [error]. *)
+module Shared_json = Runtime_official_client_json.Make (struct
+  type t = error
 
-let assoc_at stage = function
-  | `Assoc fields -> Ok fields
-  | _ -> protocol_error stage "expected a JSON object"
-;;
+  let protocol ~stage ~detail = Protocol_error { stage; detail }
+end)
 
-let required_member stage name fields =
-  match List.assoc_opt name fields with
-  | Some value -> Ok value
-  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
-;;
+open Shared_json
 
-let required_string stage name fields =
-  match List.assoc_opt name fields with
-  | Some (`String value) when String.trim value <> "" -> Ok value
-  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a non-empty string" name)
-  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
-;;
-
-let optional_string stage name fields =
-  match List.assoc_opt name fields with
-  | None | Some `Null -> Ok None
-  | Some (`String value) -> Ok (Some value)
-  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
-;;
+let bounded_tail = Runtime_official_client_json.bounded_tail
 
 (* Present and a string, with no constraint on its contents. For payload
    fields whose value this decoder does not read: an emptiness rule there
@@ -223,13 +176,6 @@ let required_string_any stage name fields =
   match List.assoc_opt name fields with
   | Some (`String value) -> Ok value
   | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a string" name)
-  | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
-;;
-
-let required_bool stage name fields =
-  match List.assoc_opt name fields with
-  | Some (`Bool value) -> Ok value
-  | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a boolean" name)
   | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
 ;;
 
@@ -918,12 +864,6 @@ let subscription_only_environment () =
   |> Array.to_list
   |> List.filter (fun entry -> child_environment_key_allowed (env_key entry))
   |> Array.of_list
-;;
-
-let bounded_tail ~limit current addition =
-  let combined = current ^ addition in
-  let length = String.length combined in
-  if length <= limit then combined else String.sub combined (length - limit) limit
 ;;
 
 let drain_stderr flow tail =

--- a/lib/runtime/runtime_official_client_json.ml
+++ b/lib/runtime/runtime_official_client_json.ml
@@ -1,0 +1,86 @@
+module type Error = sig
+  type t
+
+  val protocol : stage:string -> detail:string -> t
+end
+
+module Make (E : Error) = struct
+  let protocol_error stage detail = Error (E.protocol ~stage ~detail)
+  let ( let* ) result f = Result.bind result f
+
+  let rec validate_unique_object_keys ~stage ~path = function
+    | `Assoc fields ->
+      let rec loop seen = function
+        | [] -> Ok ()
+        | (name, value) :: rest ->
+          if List.mem name seen
+          then
+            protocol_error
+              stage
+              (Printf.sprintf "duplicate object key %S at %s" name path)
+          else
+            let* () =
+              validate_unique_object_keys
+                ~stage
+                ~path:(path ^ "." ^ name)
+                value
+            in
+            loop (name :: seen) rest
+      in
+      loop [] fields
+    | `List values ->
+      let rec loop index = function
+        | [] -> Ok ()
+        | value :: rest ->
+          let* () =
+            validate_unique_object_keys
+              ~stage
+              ~path:(Printf.sprintf "%s[%d]" path index)
+              value
+          in
+          loop (index + 1) rest
+      in
+      loop 0 values
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> Ok ()
+  ;;
+
+  let assoc_at stage = function
+    | `Assoc fields -> Ok fields
+    | _ -> protocol_error stage "expected a JSON object"
+  ;;
+
+  let required_member stage name fields =
+    match List.assoc_opt name fields with
+    | Some value -> Ok value
+    | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+  ;;
+
+  let required_string stage name fields =
+    match List.assoc_opt name fields with
+    | Some (`String value) when String.trim value <> "" -> Ok value
+    | Some _ ->
+      protocol_error stage (Printf.sprintf "field %S must be a non-empty string" name)
+    | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+  ;;
+
+  let optional_string stage name fields =
+    match List.assoc_opt name fields with
+    | None | Some `Null -> Ok None
+    | Some (`String value) -> Ok (Some value)
+    | Some _ ->
+      protocol_error stage (Printf.sprintf "field %S must be a string or null" name)
+  ;;
+
+  let required_bool stage name fields =
+    match List.assoc_opt name fields with
+    | Some (`Bool value) -> Ok value
+    | Some _ -> protocol_error stage (Printf.sprintf "field %S must be a boolean" name)
+    | None -> protocol_error stage (Printf.sprintf "missing field %S" name)
+  ;;
+end
+
+let bounded_tail ~limit current addition =
+  let combined = current ^ addition in
+  let length = String.length combined in
+  if length <= limit then combined else String.sub combined (length - limit) limit
+;;

--- a/lib/runtime/runtime_official_client_json.mli
+++ b/lib/runtime/runtime_official_client_json.mli
@@ -1,0 +1,44 @@
+(** Runtime_official_client_json — JSON shape checks shared by the official
+    client runtimes.
+
+    {!Runtime_antigravity}, {!Runtime_claude_code} and
+    {!Runtime_codex_app_server} each speak a line-delimited JSON protocol and
+    each carries its own [error] sum type. The shape checks were identical in
+    all three; only the constructor they fail with differed. {!Make} takes
+    that constructor so the checks live once and each runtime keeps its own
+    error type. *)
+
+module type Error = sig
+  type t
+
+  val protocol : stage:string -> detail:string -> t
+  (** Build the runtime's protocol-failure error. [stage] names the protocol
+      step being parsed; [detail] describes what was wrong with the payload. *)
+end
+
+module Make (E : Error) : sig
+  val validate_unique_object_keys :
+    stage:string -> path:string -> Yojson.Safe.t -> (unit, E.t) result
+  (** Reject duplicate keys anywhere in the tree. `Yojson` keeps every
+      occurrence, so a payload that repeats a key parses but reads
+      ambiguously; [path] is the dotted position reported on failure. *)
+
+  val assoc_at : string -> Yojson.Safe.t -> ((string * Yojson.Safe.t) list, E.t) result
+  val required_member :
+    string -> string -> (string * Yojson.Safe.t) list -> (Yojson.Safe.t, E.t) result
+
+  val required_string :
+    string -> string -> (string * Yojson.Safe.t) list -> (string, E.t) result
+  (** Absent, non-string and whitespace-only all fail. *)
+
+  val optional_string :
+    string -> string -> (string * Yojson.Safe.t) list -> (string option, E.t) result
+  (** Absent and [`Null] are both [None]; a non-string present value fails. *)
+
+  val required_bool :
+    string -> string -> (string * Yojson.Safe.t) list -> (bool, E.t) result
+end
+
+val bounded_tail : limit:int -> string -> string -> string
+(** [bounded_tail ~limit current addition] appends and keeps the last [limit]
+    bytes. Used for the rolling stderr tail each runtime reports on failure. *)


### PR DESCRIPTION
## 중복

세 official-client 런타임이 같은 line-delimited JSON 프로토콜을 파싱하면서 shape check 를 각자 복사해 갖고 있었다:

| 헬퍼 | 사본 |
|---|---|
| `validate_unique_object_keys` (30L) | ×3 |
| `assoc_at` · `required_member` · `optional_string` · `bounded_tail` | ×3 |
| `required_string` · `required_bool` | ×2 |

## 왜 그냥 모듈로 못 빼는가

전부 `protocol_error` 를 통해 **그 런타임의 `Protocol_error` 생성자**로 실패한다. 세 `error` 타입은 접두만 공유하는 서로 다른 합타입이다:

```ocaml
(* antigravity *)  Invalid_config | Spawn_failed | Protocol_error | State_callback_failed | Turn_failed | ...
(* claude_code *)  Invalid_config | Spawn_failed | Protocol_error | Subscription_required | Turn_transport_interrupted | ...
(* codex *)        Invalid_config | Spawn_failed | Protocol_error | Rpc_error | Context_window_exceeded | ...
```

그래서 `Runtime_official_client_json.Make` 가 생성자를 파라미터로 받는다. 검사는 한 곳에 살고, 각 런타임은 자기 에러 타입과 **호출부를 그대로** 유지한다.

## 의도적으로 남긴 사본 1개

`runtime_antigravity.required_string` 은 `?nonempty` 를 받고 `"must not be empty"` 와 `"must be a string"` 을 분리해 보고한다. 나머지 둘은 한 메시지로 합치고 그 문구를 호출부가 단언한다. 공유 시그니처를 넓혀 둘 다 수용하면 한쪽 메시지가 바뀌므로, 이 사본은 남기고 주석으로 이유를 적었다.

`bounded_tail` 은 에러를 만들지 않으므로 functor 밖에 둔다.

## 검증

- `dune build --root . @default @check @install` → exit 0
- `python3 scripts/check_test_coverage.py` → exit 0
- `test_runtime_codex_app_server` 44/44 · `test_runtime_antigravity` 17/17 · `test_runtime_claude_code_config` 5/5 · `test_keeper_antigravity_runtime` 2/2

### flaky 하나를 구분해 두었다

`test_keeper_claude_code_runtime` 의 `post-effect transport enters recovery` 가 간헐 실패한다 (`tool effect count: expected 1, received 0`).

- 이 브랜치: 5회 중 1회 실패
- **수정 없는 `origin/main` 워크트리: 5회 중 1회 실패** (같은 케이스, 같은 메시지)
- `runtime_claude_code.ml` 만 원본으로 되돌려도 재현

기존 flakiness 이지 이 PR 의 회귀가 아니다.

5 files changed, 164 insertions(+), 196 deletions(-)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
