### PR TITLE
fix(keeper): anchor effect safety at process dispatch

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -473,6 +473,10 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             Runtime_antigravity.run_turn
               ~conversation_mode
               ~home_dir:(Runtime_antigravity_home.home_dir home)
+              ~on_spawned:(fun () ->
+                Atomic.set
+                  effect_disposition
+                  Keeper_provider_attempt_effect.Observation_unavailable)
               ~mgr:process_mgr
               ~clock
               ~cwd:process_cwd
@@ -497,16 +501,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
               client_config
               ~prompt
           in
-          Atomic.set
-            effect_disposition
-            (match client_result with
-             | Error (Runtime_antigravity.Spawn_failed _) ->
-               Keeper_provider_attempt_effect.No_effect_observed
-             | Ok _ | Error _ ->
-               (match tools with
-                | [] -> Keeper_provider_attempt_effect.No_effect_observed
-                | _ :: _ ->
-                  Keeper_provider_attempt_effect.Observation_unavailable));
           Result.map_error
             (fun error ->
                recovery_failure := recovery_failure_of_runtime_error error;

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -463,6 +463,10 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       try
         let client_result =
            Runtime_claude_code.run_turn
+             ~on_spawned:(fun () ->
+               Atomic.set
+                 effect_disposition
+                 Keeper_provider_attempt_effect.Observation_unavailable)
              ~mgr:process_mgr
              ~clock
              ~cwd:process_cwd
@@ -500,15 +504,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
              client_config
              ~prompt
         in
-        Atomic.set
-          effect_disposition
-          (match client_result with
-           | Error (Runtime_claude_code.Spawn_failed _) ->
-             Keeper_provider_attempt_effect.No_effect_observed
-           | Ok _ | Error _ ->
-             (match tools with
-              | [] -> Keeper_provider_attempt_effect.No_effect_observed
-              | _ :: _ -> Keeper_provider_attempt_effect.Observation_unavailable));
         (match client_result with
          | Error error ->
            if not !state_persistence_failed

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -616,8 +616,8 @@ let status_to_string = function
   | `Signaled signal -> Printf.sprintf "signal %d" signal
 ;;
 
-let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
-    ~on_conversation_ready ~on_stream_event =
+let run_spawned ?home_dir ?on_spawned ~mgr ~clock ~cwd config ~conversation_mode
+    ~prompt ~on_conversation_ready ~on_stream_event =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -638,6 +638,7 @@ let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> raise (Runtime_error (Spawn_failed (Printexc.to_string exn)))
     in
+    Option.iter (fun callback -> callback ()) on_spawned;
     Eio.Flow.close stdin_r;
     Eio.Flow.close stdout_w;
     Eio.Flow.close stderr_w;
@@ -705,7 +706,7 @@ let run_spawned ?home_dir ~mgr ~clock ~cwd config ~conversation_mode ~prompt
     status, !state, String.trim !stderr_tail)
 ;;
 
-let run_turn ?(conversation_mode = Start) ?home_dir ~mgr ~clock ~cwd
+let run_turn ?(conversation_mode = Start) ?home_dir ?on_spawned ~mgr ~clock ~cwd
     ?(on_conversation_ready = fun ~conversation_id:_ -> Ok ()) ?on_stream_event
     config ~prompt =
   let* () =
@@ -722,6 +723,7 @@ let run_turn ?(conversation_mode = Start) ?home_dir ~mgr ~clock ~cwd
       Ok
         (run_spawned
            ?home_dir
+           ?on_spawned
            ~mgr
            ~clock
            ~cwd

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -96,6 +96,7 @@ val validate_turn :
 val run_turn :
   ?conversation_mode:conversation_mode ->
   ?home_dir:string ->
+  ?on_spawned:(unit -> unit) ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -987,9 +987,9 @@ let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
     ~ignored:0
 ;;
 
-let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
-    ~session_mode ~session_id ~subscription ~prompt ~on_session_ready
-    ~on_turn_starting ~on_turn_started ~on_stream_event =
+let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
+    ~reasoning_effort ~session_mode ~session_id ~subscription ~prompt
+    ~on_session_ready ~on_turn_starting ~on_turn_started ~on_stream_event =
   let* argv =
     command config ~dynamic_tools ~reasoning_effort ~session_mode ~session_id
   in
@@ -1013,6 +1013,7 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> raise (Runtime_error (Spawn_failed (Printexc.to_string exn)))
     in
+    Option.iter (fun callback -> callback ()) on_spawned;
     Eio.Flow.close stdin_r;
     Eio.Flow.close stdout_w;
     Eio.Flow.close stderr_w;
@@ -1116,8 +1117,8 @@ let probe_subscription ~mgr ~clock ~cwd config =
 ;;
 
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
-    ?admitted_subscription
-    ~mgr ~clock ~cwd ?(on_session_ready = fun ~session_id:_ -> Ok ())
+    ?admitted_subscription ?on_spawned ~mgr ~clock ~cwd
+    ?(on_session_ready = fun ~session_id:_ -> Ok ())
     ?(on_turn_starting = fun ~session_id:_ -> Ok ())
     ?(on_turn_started = fun ~session_id:_ ~turn_id:_ -> Ok ()) ?on_stream_event config
     ~prompt =
@@ -1139,6 +1140,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
       subscription.subscription_type;
     try
       run_spawned
+        ?on_spawned
         ~mgr
         ~clock
         ~cwd

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -134,6 +134,7 @@ val run_turn :
   ?reasoning_effort:Llm_provider.Reasoning_effort.t ->
   ?session_mode:session_mode ->
   ?admitted_subscription:subscription ->
+  ?on_spawned:(unit -> unit) ->
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->

--- a/test/test_keeper_rotation_eligibility_census.ml
+++ b/test/test_keeper_rotation_eligibility_census.ml
@@ -37,9 +37,11 @@ let attempted_candidates error =
       ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
         attempts := !attempts @ [ runtime_id ];
         if String.equal candidate first_candidate
-        then Error error, None
+        then
+          Error error, None, Masc.Keeper_provider_attempt_effect.No_effect_observed
         else if String.equal candidate second_candidate
-        then Ok runtime_id, None
+        then
+          Ok runtime_id, None, Masc.Keeper_provider_attempt_effect.No_effect_observed
         else Alcotest.failf "unexpected candidate %s" candidate)
       [ first_candidate; second_candidate ]
   in


### PR DESCRIPTION
## Summary
- follow up on merged #28178 without replaying its implementation
- transition provider effect disposition at the exact successful process-spawn boundary
- keep pre-spawn failures retryable while failing closed after provider dispatch
- remove broad `Spawn_failed` and empty-tool heuristics
- update the rotation census caller for the attempt tuple

## Validation
- CI only, per repository workflow
