### PR TITLE
fix(keeper): bound official-client state callbacks

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -554,6 +554,7 @@ let invoke_state_callback ~stage callback =
     | Error detail -> protocol_error stage detail
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Eio.Time.Timeout as exn -> raise exn
   | exn -> protocol_error stage (Printexc.to_string exn)
 ;;
 
@@ -959,6 +960,7 @@ let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
       Ok ()
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Eio.Time.Timeout as exn -> raise exn
     | exn ->
       Error
         (Turn_transport_interrupted
@@ -1039,6 +1041,9 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
     Fun.protect
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
+        let with_timeout callback =
+          Eio.Time.with_timeout_exn clock config.timeout_s callback
+        in
         run_protocol
           { send; receive }
           ~dynamic_tools
@@ -1046,9 +1051,12 @@ let run_spawned ~mgr ~clock ~cwd config ~dynamic_tools ~reasoning_effort
           ~session_mode
           ~session_id
           ~prompt
-          ~on_session_ready
-          ~on_turn_starting
-          ~on_turn_started
+          ~on_session_ready:(fun ~session_id ->
+            with_timeout (fun () -> on_session_ready ~session_id))
+          ~on_turn_starting:(fun ~session_id ->
+            with_timeout (fun () -> on_turn_starting ~session_id))
+          ~on_turn_started:(fun ~session_id ~turn_id ->
+            with_timeout (fun () -> on_turn_started ~session_id ~turn_id))
           ~on_stream_event))
 ;;
 

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -742,6 +742,7 @@ let invoke_state_callback ~stage callback =
     | Error detail -> protocol_error stage detail
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Eio.Time.Timeout as exn -> raise exn
   | exn -> protocol_error stage (Printexc.to_string exn)
 ;;
 
@@ -1006,6 +1007,9 @@ let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
     ~reasoning_effort ~thread_mode ~history ~prompt ~on_thread_ready
     ~on_turn_starting ~on_turn_started ~on_stream_event =
   with_spawned_client ~mgr ~clock ~cwd config (fun io ->
+    let with_timeout callback =
+      Eio.Time.with_timeout_exn clock config.timeout_s callback
+    in
     run_protocol
       io
       config
@@ -1015,9 +1019,12 @@ let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
       ~thread_mode
       ~history
       ~prompt
-      ~on_thread_ready
-      ~on_turn_starting
-      ~on_turn_started
+      ~on_thread_ready:(fun ~thread_id ->
+        with_timeout (fun () -> on_thread_ready ~thread_id))
+      ~on_turn_starting:(fun ~thread_id ->
+        with_timeout (fun () -> on_turn_starting ~thread_id))
+      ~on_turn_started:(fun ~thread_id ~turn_id ->
+        with_timeout (fun () -> on_turn_started ~thread_id ~turn_id))
       ~on_stream_event)
 ;;
 

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -119,20 +119,29 @@ let with_fixture ?auth_json ?before_initialize_response steps f =
 ;;
 
 let run_fixture ?(dynamic_tools = []) ?session_mode ?(timeout_s = 2.0)
-    ?on_stream_event path =
+    ?on_session_ready_delay_s ?on_stream_event path =
   Eio_main.run (fun env ->
+    let clock = Eio.Stdenv.clock env in
     let config =
       { (Runtime_claude_code.default_config ~cwd:"/tmp") with
         cli_path = path
       ; timeout_s
       }
     in
+    let on_session_ready =
+      Option.map
+        (fun delay_s ~session_id:_ ->
+           Eio.Time.sleep clock delay_s;
+           Ok ())
+        on_session_ready_delay_s
+    in
     Runtime_claude_code.run_turn
       ~mgr:(Eio.Stdenv.process_mgr env)
-      ~clock:(Eio.Stdenv.clock env)
+      ~clock
       ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
       ~dynamic_tools
       ?session_mode
+      ?on_session_ready
       ?on_stream_event
       config
       ~prompt:"Return the fixture marker")
@@ -195,6 +204,20 @@ let test_stream_idle_timeout_is_typed () =
       check (float 0.001) "exact idle timeout" 0.05 seconds
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "silent Claude stream ignored its idle timeout")
+;;
+
+let test_state_callback_timeout_is_typed () =
+  with_fixture [] (fun path ->
+    match
+      run_fixture
+        ~timeout_s:0.05
+        ~on_session_ready_delay_s:0.2
+        path
+    with
+    | Error (Runtime_claude_code.Timeout seconds) ->
+      check (float 0.001) "exact callback timeout" 0.05 seconds
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "blocking Claude callback ignored its timeout")
 ;;
 
 (* [dynamic_tool_bytes] measures what the tool declarations add to a request.
@@ -953,6 +976,10 @@ let () =
             "stream idle timeout is typed"
             `Quick
             test_stream_idle_timeout_is_typed
+        ; test_case
+            "state callback timeout is typed"
+            `Quick
+            test_state_callback_timeout_is_typed
         ; test_case
             "non-subscription rejected"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -134,21 +134,30 @@ let with_fixture_sequence ?capture_path first_lines second_lines f =
 ;;
 
 let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp")
-    ?(timeout_s = 2.0) ?on_stream_event path =
+    ?(timeout_s = 2.0) ?on_thread_ready_delay_s ?on_stream_event path =
   Eio_main.run (fun env ->
+    let clock = Eio.Stdenv.clock env in
     let config =
       { (Runtime_codex_app_server.default_config ()) with
         cli_path = path
       ; timeout_s
       }
     in
+    let on_thread_ready =
+      Option.map
+        (fun delay_s ~thread_id:_ ->
+           Eio.Time.sleep clock delay_s;
+           Ok ())
+        on_thread_ready_delay_s
+    in
     Runtime_codex_app_server.run_turn
       ~mgr:(Eio.Stdenv.process_mgr env)
-      ~clock:(Eio.Stdenv.clock env)
+      ~clock
       ~cwd:Eio.Path.(Eio.Stdenv.fs env / cwd)
       ~dynamic_tools
       ?thread_mode
       ~history
+      ?on_thread_ready
       ?on_stream_event
       config
       ~prompt:"Return the fixture marker")
@@ -727,6 +736,20 @@ let test_stream_idle_timeout_is_typed () =
          check (float 0.001) "exact idle timeout" 0.05 seconds
        | Error error -> fail (Runtime_codex_app_server.error_to_string error)
        | Ok _ -> fail "silent app-server stream ignored its idle timeout")
+;;
+
+let test_state_callback_timeout_is_typed () =
+  with_fixture [ init_result; account_chatgpt; thread_result ] (fun path ->
+    match
+      run_fixture
+        ~timeout_s:0.05
+        ~on_thread_ready_delay_s:0.2
+        path
+    with
+    | Error (Runtime_codex_app_server.Timeout seconds) ->
+      check (float 0.001) "exact callback timeout" 0.05 seconds
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+    | Ok _ -> fail "blocking app-server callback ignored its timeout")
 ;;
 
 let test_terminal_error_notification_uses_official_context_error_enum () =
@@ -2929,6 +2952,10 @@ let () =
             "stream idle timeout is typed"
             `Quick
             test_stream_idle_timeout_is_typed
+        ; test_case
+            "state callback timeout is typed"
+            `Quick
+            test_state_callback_timeout_is_typed
         ; test_case
             "terminal error notification uses official context error enum"
             `Quick


### PR DESCRIPTION
## What changed

- Bound Codex thread/turn state callbacks with the configured official-client timeout.
- Bound Claude session/turn state callbacks with the same timeout.
- Preserve `Eio.Time.Timeout` as the typed provider `Timeout` result instead of converting it to a protocol or transport error.
- Added deterministic timeout regression coverage for both official clients.

## Why

Follow-up to #28136. That PR restored deadlines around provider writes, but state callbacks still ran outside any deadline. A callback that blocks could therefore hold a Keeper Owner indefinitely and stall queued operations behind it. Claude's user-message write path also caught the timeout as a generic transport interruption instead of preserving the typed timeout.

## Impact

Codex and Claude official-client turns now fail through the existing typed timeout path when a state callback exceeds `timeout_s`, allowing normal Keeper recovery instead of an unbounded owner stall.

## Validation

- `git diff --check`: pass on current branch rebased onto `main@a76f9b6e6d`.
- `test_runtime_codex_app_server.exe`: 48 tests passed on the immediately preceding `main@e8ba4cb072` snapshot, including the new callback-timeout test.
- `test_runtime_claude_code.exe`: 26 tests passed on `main@e8ba4cb072`, including the new callback-timeout test.
- The final `main@a76f9b6e6d` Dune rebuild was intentionally stopped at user request; CI/local rerun remains required before marking ready.

Related: #28136, #28188.
