### PR TITLE
fix(claude-code): declare Runtime_error exception (main build broken)

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -139,6 +139,8 @@ type error =
   | Process_exited of string
   | Timeout of float
 
+exception Runtime_error of error
+
 let error_to_string = function
   | Invalid_config detail -> "invalid Claude Code config: " ^ detail
   | Spawn_failed detail -> "failed to start Claude Code: " ^ detail


### PR DESCRIPTION
## main 빌드 깨짐 핫픽스

`lib/runtime/runtime_claude_code.ml`이 컴파일 실패 → main이 빌드 안 됨.

```
File "lib/runtime/runtime_claude_code.ml", line 1014, characters 22-35:
1014 |  | exn -> raise (Runtime_error (Spawn_failed (Printexc.to_string exn)))
Error: This variant expression is expected to have type exn
       There is no constructor Runtime_error within type exn
```

## 원인

**#28178** (`fix(keeper): fence fallback after provider effects`)이 Claude Code 턴 spawn 실패를 타입화하면서:
- `run_spawned`: spawn을 try/with로 감싸 `raise (Runtime_error (Spawn_failed ...))` (1014행)
- `run_turn` 핸들러: `| Runtime_error error -> Error error` 추가, catch-all은 `Protocol_error`로 (1159행)

그런데 **`exception Runtime_error of error` 선언을 빠뜨림**. `git log -S`로 확인 시 이 파일엔 그 예외가 한 번도 존재한 적 없음 → 회귀가 아니라 #28178의 선언 누락.

## 수정

형제 모듈 `runtime_antigravity.ml`(124행)과 동일하게 `type error` 블록 직후 한 줄 추가:

```ocaml
exception Runtime_error of error
```

예외는 모듈 내부 전용(`run_spawned`에서 raise, `run_turn`에서 catch)이라 `.mli` 변경 불필요 — antigravity·codex_app_server와 동일 패턴.

## 검증

| 상태 | `dune build lib/runtime/` |
|---|---|
| origin/main (fix 없음) | **exit 1** — 위 에러 재현 |
| 이 PR | **exit 0** |

lib/runtime/ + lib/keeper_runtime/ 빌드 통과. 워크어라운드 아님(누락된 타입 선언 복원). 레거시 리더 추가 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)