### PR TITLE
fix(dashboard): drop dead schedule refresh binding

### DIFF
--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -129,7 +129,6 @@ export function ScheduleSurface() {
     setView(next)
   }
 
-  const refresh = (): Promise<void> => loadScheduledAutomation()
   async function handlePrune() {
     if (
       !window.confirm(


### PR DESCRIPTION
## Why

The current main Dashboard typecheck fails with TS6133 because ScheduleSurface declares refresh but never reads it. Mutation refresh already calls loadScheduledAutomation with fresh true directly, so the closure has no behavior or owner.

## Change

- delete the unused refresh binding
- keep the existing fresh post-prune read unchanged

## Verification

- pnpm typecheck: pass
- git diff --check: pass