### PR TITLE
feat(runtime): demote quota-exhausted providers in lane candidate order

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -237,6 +237,8 @@ let attempt_runtime_candidates
              | Some provider_id ->
                Runtime_quota_window.note_exhausted
                  ~provider_id
+                 (* NDT-OK: [retry_after] is relative to the provider response;
+                    convert it to the wall-clock expiry at this ingress. *)
                  ~resets_at:(Unix.gettimeofday () +. retry_after_s)
              | None -> ())
           | _ -> ());
@@ -534,6 +536,8 @@ let run_named
            Runtime_lane_preference.prefer_order ~lane_id
              (Runtime_lane.ordered_candidates lane)
            |> Runtime_quota_window.demote_order
+                (* NDT-OK: scheduling intentionally compares the stored expiry
+                   with wall clock; [demote_order] stays pure via injected [now]. *)
                 ~now:(Unix.gettimeofday ())
                 ~provider_id_of:Runtime.provider_id_of_runtime_id ))
   in

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -221,6 +221,25 @@ let attempt_runtime_candidates
            ~status:"failed"
            ~decision:(runtime_failed_decision ~idx ~runtime_id:attempt_runtime_id error)
            Keeper_runtime_manifest.Runtime_failed;
+         (* A hard-quota rejection with a provider-stated reset time is an
+            account-scoped fact; remember it so later lane ordering stops
+            re-dispatching into the exhausted window (RFC-0370 §3.3). The
+            provider identity comes from the attempted candidate's catalog
+            row, not the error payload, so both sides of the window share
+            one namespace. Quota errors without [retry_after] record
+            nothing — a cooldown the provider never stated would be a
+            synthesized default. *)
+         (match error with
+          | Agent_core.Error.Provider
+              (Llm_provider.Error.HardQuota { retry_after = Some retry_after_s; _ })
+            ->
+            (match Runtime.provider_id_of_runtime_id attempt_runtime_id with
+             | Some provider_id ->
+               Runtime_quota_window.note_exhausted
+                 ~provider_id
+                 ~resets_at:(Unix.gettimeofday () +. retry_after_s)
+             | None -> ())
+          | _ -> ());
          let retry_admitted =
            allow_retry ~runtime_id:attempt_runtime_id ~attempt:idx error
          in
@@ -507,8 +526,16 @@ let run_named
        | `Lane lane ->
          let lane_id = Runtime_lane.id lane in
          ( Some lane_id
-         , Runtime_lane_preference.prefer_order ~lane_id
-             (Runtime_lane.ordered_candidates lane) ))
+         , (* Quota-window demotion runs after sticky preference: a provider
+              that stated "exhausted until T" outranks a remembered last-good
+              candidate on that same provider. Ordering only — a demoted
+              candidate is still attempted when the lane has nothing else.
+              RFC-0370 §3.3. *)
+           Runtime_lane_preference.prefer_order ~lane_id
+             (Runtime_lane.ordered_candidates lane)
+           |> Runtime_quota_window.demote_order
+                ~now:(Unix.gettimeofday ())
+                ~provider_id_of:Runtime.provider_id_of_runtime_id ))
   in
   if lane_candidate_ids = []
   then

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1336,6 +1336,12 @@ let turn_timeout_s_of_runtime_id (id : string) : float option =
   | None -> None
 ;;
 
+let provider_id_of_runtime_id (id : string) : string option =
+  match get_runtime_by_id id with
+  | Some rt -> Some rt.provider.id
+  | None -> None
+;;
+
 let max_prompt_bytes_of_runtime_id (id : string) : int option =
   match get_runtime_by_id id with
   | Some rt -> rt.model.max_prompt_bytes

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -363,6 +363,12 @@ val turn_timeout_s_of_runtime_id : string -> float option
     "keep whatever bound the caller already has". Consumed by
     {!Runtime_inference.resolve_turn_timeout_s}. *)
 
+val provider_id_of_runtime_id : string -> string option
+(** Owning provider id ([providers.<id>] in runtime.toml) of the runtime with
+    this binding-key id, or [None] when the runtime id is unknown. Consumed by
+    {!Runtime_quota_window.demote_order} so lane ordering can act on
+    account-scoped provider quota windows. *)
+
 val max_prompt_bytes_of_runtime_id : string -> int option
 (** Declared [max-prompt-bytes] for the model bound to this runtime id, or
     [None] when the model declares none. *)

--- a/lib/runtime/runtime_quota_window.ml
+++ b/lib/runtime/runtime_quota_window.ml
@@ -1,0 +1,54 @@
+(** Process-local provider quota windows.  See the [.mli] for the contract.
+
+    Implementation notes, mirroring {!Runtime_lane_preference}:
+
+    - State is a small [Hashtbl] guarded by [Stdlib.Mutex] (record/read may
+      be called from outside Eio fibers, so [Eio.Mutex] is not required).
+    - Expiry is lazy against the provider-stated [resets_at]; reads prune
+      passed windows.  [now] is a parameter rather than a wall-clock read
+      so the ordering decision is testable without stubbing time. *)
+
+let windows : (string, float) Hashtbl.t = Hashtbl.create 4
+let mu = Stdlib.Mutex.create ()
+
+let note_exhausted ~provider_id ~resets_at =
+  Stdlib.Mutex.protect mu (fun () ->
+    match Hashtbl.find_opt windows provider_id with
+    | Some existing when Float.compare existing resets_at >= 0 -> ()
+    | Some _ | None -> Hashtbl.replace windows provider_id resets_at)
+
+let active_until ~provider_id ~now =
+  Stdlib.Mutex.protect mu (fun () ->
+    match Hashtbl.find_opt windows provider_id with
+    | None -> None
+    | Some resets_at ->
+      if Float.compare now resets_at < 0
+      then Some resets_at
+      else begin
+        Hashtbl.remove windows provider_id;
+        None
+      end)
+
+let demote_order ~now ~provider_id_of candidates =
+  let demoted =
+    List.filter
+      (fun candidate ->
+        match provider_id_of candidate with
+        | None -> false
+        | Some provider_id ->
+          Option.is_some (active_until ~provider_id ~now))
+      candidates
+  in
+  match demoted with
+  | [] -> candidates
+  | _ ->
+    let kept =
+      List.filter
+        (fun candidate ->
+          not (List.exists (String.equal candidate) demoted))
+        candidates
+    in
+    kept @ demoted
+
+let reset_for_testing () =
+  Stdlib.Mutex.protect mu (fun () -> Hashtbl.reset windows)

--- a/lib/runtime/runtime_quota_window.mli
+++ b/lib/runtime/runtime_quota_window.mli
@@ -1,0 +1,48 @@
+(** Process-local provider quota windows for runtime lane failover.
+
+    A hard-quota rejection that carries a provider [retry_after] is a fact
+    with a stated end time: the account's quota window is exhausted until
+    [resets_at].  Without remembering it, lane failover re-dispatches into
+    the same provider on every turn until the window resets (measured
+    2026-08-11: 103 keeper cycle failures in one day from exactly this).
+
+    This module remembers that fact and lets candidate ordering act on it.
+    It is an ordering preference, not an admission gate — a demoted
+    candidate is still attempted when it is all the lane has left, so no
+    new fail-closed path exists.  Sibling of {!Runtime_lane_preference};
+    the table is shared across keepers on purpose because provider quota
+    windows are account-scoped.
+
+    Windows are recorded only when the provider stated a reset time.  A
+    quota failure without [retry_after] records nothing: inventing a
+    cooldown here would be a synthesized default the provider never
+    reported.  Expiry is the provider-stated [resets_at] itself, pruned
+    lazily on read; there is no background sweeper and no TTL knob.
+    RFC-0370 §3.3. *)
+
+val note_exhausted : provider_id:string -> resets_at:float -> unit
+(** Remember that [provider_id]'s quota window is exhausted until
+    [resets_at] (Unix epoch seconds).  A later [resets_at] for the same
+    provider extends the window; an earlier one is ignored so a stale
+    retry hint cannot shorten a window a fresher response already
+    established. *)
+
+val active_until : provider_id:string -> now:float -> float option
+(** [Some resets_at] when [provider_id] has a recorded window that has not
+    yet passed at [now]; [None] otherwise.  Expired entries are pruned on
+    read. *)
+
+val demote_order :
+  now:float ->
+  provider_id_of:(string -> string option) ->
+  string list ->
+  string list
+(** Stable-partition [candidates]: those whose provider (via
+    [provider_id_of]) has an active window at [now] move to the tail,
+    preserving declared relative order within both partitions.  Candidates
+    whose provider is unknown ([provider_id_of] returns [None]) are left in
+    place — an unresolved id is not evidence of exhaustion.  Returns the
+    input unchanged when no candidate is demoted. *)
+
+val reset_for_testing : unit -> unit
+(** Drop every remembered window.  Test-only. *)

--- a/test/dune
+++ b/test/dune
@@ -106,6 +106,7 @@
   test_attempt_state
   test_runtime_attempt_fsm
   test_runtime_lane_preference
+  test_runtime_quota_window
   test_keeper_turn_driver_accept
   test_keeper_turn_driver_failover
   test_keeper_rotation_eligibility_census
@@ -399,6 +400,7 @@
   test_attempt_state
   test_runtime_attempt_fsm
   test_runtime_lane_preference
+  test_runtime_quota_window
   test_keeper_turn_driver_accept
   test_keeper_turn_driver_failover
   test_keeper_rotation_eligibility_census

--- a/test/test_runtime_quota_window.ml
+++ b/test/test_runtime_quota_window.ml
@@ -1,0 +1,129 @@
+(* Pins Runtime_quota_window: account-scoped provider quota windows consumed
+   as a lane-ordering preference (RFC-0370 §3.3). [now] is a parameter
+   everywhere, so no time stubbing. *)
+
+module Q = Runtime_quota_window
+
+let reset () = Q.reset_for_testing ()
+
+(* provider mapping used by demote tests: "prov.model" ids, unknown for
+   ids without a dot — mirrors candidates the driver cannot resolve. *)
+let provider_id_of candidate =
+  match String.index_opt candidate '.' with
+  | Some i -> Some (String.sub candidate 0 i)
+  | None -> None
+
+let test_window_lifecycle () =
+  reset ();
+  Alcotest.(check (option (float 0.0)))
+    "no window recorded"
+    None
+    (Q.active_until ~provider_id:"claude_code" ~now:100.0);
+  Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
+  Alcotest.(check (option (float 0.0)))
+    "active before reset"
+    (Some 500.0)
+    (Q.active_until ~provider_id:"claude_code" ~now:499.9);
+  Alcotest.(check (option (float 0.0)))
+    "expired at reset"
+    None
+    (Q.active_until ~provider_id:"claude_code" ~now:500.0);
+  Alcotest.(check (option (float 0.0)))
+    "expiry pruned the entry (no resurrection at an earlier now)"
+    None
+    (Q.active_until ~provider_id:"claude_code" ~now:0.0)
+
+let test_later_reset_extends_earlier_is_ignored () =
+  reset ();
+  Q.note_exhausted ~provider_id:"codex_subscription" ~resets_at:500.0;
+  Q.note_exhausted ~provider_id:"codex_subscription" ~resets_at:900.0;
+  Alcotest.(check (option (float 0.0)))
+    "later reset extends"
+    (Some 900.0)
+    (Q.active_until ~provider_id:"codex_subscription" ~now:100.0);
+  Q.note_exhausted ~provider_id:"codex_subscription" ~resets_at:600.0;
+  Alcotest.(check (option (float 0.0)))
+    "earlier reset cannot shorten"
+    (Some 900.0)
+    (Q.active_until ~provider_id:"codex_subscription" ~now:100.0)
+
+let candidates =
+  [ "claude_code.sonnet"; "ollama.qwen"; "claude_code.opus"; "codex.spark" ]
+
+let test_demote_moves_exhausted_provider_to_tail () =
+  reset ();
+  Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
+  Alcotest.(check (list string))
+    "exhausted provider's candidates keep order at the tail"
+    [ "ollama.qwen"; "codex.spark"; "claude_code.sonnet"; "claude_code.opus" ]
+    (Q.demote_order ~now:100.0 ~provider_id_of candidates)
+
+let test_demote_noop_paths () =
+  reset ();
+  Alcotest.(check (list string))
+    "no windows: unchanged"
+    candidates
+    (Q.demote_order ~now:100.0 ~provider_id_of candidates);
+  Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
+  Alcotest.(check (list string))
+    "window passed: unchanged"
+    candidates
+    (Q.demote_order ~now:501.0 ~provider_id_of candidates);
+  Q.note_exhausted ~provider_id:"unrelated_provider" ~resets_at:900.0;
+  Alcotest.(check (list string))
+    "window on a provider with no candidate: unchanged"
+    candidates
+    (Q.demote_order ~now:100.0 ~provider_id_of candidates)
+
+let test_unknown_provider_stays_in_place () =
+  reset ();
+  Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
+  Alcotest.(check (list string))
+    "unresolvable id is not demoted"
+    [ "no-dot-id"; "ollama.qwen"; "claude_code.sonnet" ]
+    (Q.demote_order
+       ~now:100.0
+       ~provider_id_of
+       [ "no-dot-id"; "claude_code.sonnet"; "ollama.qwen" ]
+     |> fun reordered ->
+     (* stable partition keeps no-dot-id and ollama.qwen in declared order,
+        claude_code.sonnet at the tail *)
+     reordered)
+
+let test_all_demoted_keeps_declared_order () =
+  reset ();
+  Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
+  Alcotest.(check (list string))
+    "every candidate demoted: declared order preserved, still attemptable"
+    [ "claude_code.sonnet"; "claude_code.opus" ]
+    (Q.demote_order
+       ~now:100.0
+       ~provider_id_of
+       [ "claude_code.sonnet"; "claude_code.opus" ])
+
+let () =
+  Alcotest.run
+    "runtime_quota_window"
+    [ ( "window"
+      , [ Alcotest.test_case "lifecycle" `Quick test_window_lifecycle
+        ; Alcotest.test_case
+            "later reset extends, earlier ignored"
+            `Quick
+            test_later_reset_extends_earlier_is_ignored
+        ] )
+    ; ( "demote"
+      , [ Alcotest.test_case
+            "exhausted provider to tail"
+            `Quick
+            test_demote_moves_exhausted_provider_to_tail
+        ; Alcotest.test_case "no-op paths" `Quick test_demote_noop_paths
+        ; Alcotest.test_case
+            "unknown provider stays"
+            `Quick
+            test_unknown_provider_stays_in_place
+        ; Alcotest.test_case
+            "all demoted keeps order"
+            `Quick
+            test_all_demoted_keeps_declared_order
+        ] )
+    ]


### PR DESCRIPTION
## 목표

hard-quota 거부가 provider가 명시한 reset 시각(`retry_after`)을 들고 오는데 아무도 기억하지 않아, lane failover가 매 턴 같은 소진 provider로 재진입하는 문제의 수정. 실측 (2026-08-11 라이브): quota 클래스 cycle 실패 103건/일, 20초 간격 재시도.

## 설계 (RFC-0370 §3.3)

`Runtime_lane_preference`(sticky last-good ordering)와 같은 패턴의 자매 모듈:

- `Runtime_quota_window.note_exhausted`: typed `HardQuota { retry_after = Some s }`가 관측될 때만 `provider_id → resets_at` 기록. **retry_after 없는 quota 실패는 기록하지 않음** — provider가 말하지 않은 cooldown을 지어내면 synthesized default.
- `demote_order`: sticky preference 적용 **후** stable partition으로 소진 provider의 후보를 꼬리로. **ordering이지 gate가 아님** — 레인에 다른 후보가 없으면 여전히 시도되므로 새 fail-closed 경로 없음.
- 만료 = provider가 말한 `resets_at` 자체, 읽기 시 lazy prune. TTL 노브 없음, 백그라운드 스위퍼 없음.
- provider 식별은 에러 payload 문자열이 아니라 **시도한 후보의 카탈로그 행** (`Runtime.provider_id_of_runtime_id`) — 기록·소비 양쪽이 한 네임스페이스.

## 변경

| 파일 | 내용 |
|---|---|
| `lib/runtime/runtime_quota_window.{ml,mli}` | 신규 모듈 |
| `lib/runtime/runtime.{ml,mli}` | `provider_id_of_runtime_id` accessor (기존 `*_of_runtime_id` 자매) |
| `lib/keeper/keeper_turn_driver.ml` | note 지점 (실패 arm, typed match) + demote 지점 (prefer_order 직후) |
| `test/test_runtime_quota_window.ml` | 6 케이스: lifecycle, 연장/단축 금지, 꼬리 demote, no-op 3경로, 미해석 id 비강등, 전량 demote 시 순서 보존 |

## 로컬 검증

- `test_runtime_quota_window`: 6/6 pass
- `test_runtime_lane_preference`: 10/10 pass
- `test_keeper_turn_driver_failover`: 40/40 pass
- `dune build ./bin/main_eio.exe`: 성공

## 미검증

- 라이브 효과 (103건/일 → ?): 배포 후 24h 창 재측정 필요
- usage API 사전 조회(Orca 방식 전체)는 본 PR 범위 밖 — 이 PR은 사후 관측된 사실의 기억만 추가

Refs RFC-0370 (PR #28192), RFC-0368. MASC task-223, goal-1786437038030-cb0c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>