### PR TITLE
test(board): drop removed contributor quality fixture

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -568,13 +568,6 @@ describe('fetchBoard', () => {
           has_voted: true,
           report_count: 2,
           moderation_status: 'flagged',
-          contributor_quality: {
-            source: 'agent_reputation',
-            completion_rate: 0.8,
-            response_rate: 0.6,
-            board_posts: 3,
-            board_comments: 5,
-          },
           reactions: [
             {
               emoji: '🔥',
@@ -611,13 +604,6 @@ describe('fetchBoard', () => {
       has_voted: true,
       report_count: 2,
       moderation_status: 'flagged',
-      contributor_quality: {
-        source: 'agent_reputation',
-        completion_rate: 0.8,
-        response_rate: 0.6,
-        board_posts: 3,
-        board_comments: 5,
-      },
       reactions: [
         {
           emoji: '🔥',


### PR DESCRIPTION
## Why

PR #28190 deleted the accountability-to-reputation chain and the Board contributor_quality wire/type/parser, but one board API test still constructed and expected that removed field. Full Dashboard CI therefore failed 1 of 8,773 tests after the current contract correctly dropped it.

## Change

- delete the stale contributor_quality fixture and assertion
- do not restore compatibility parsing for the dead concept

## Verification

- focused board Vitest: 69/69 passed
- active Dashboard source search for contributor_quality and BoardContributorQuality: 0
- git diff --check: pass