### PR TITLE
refactor(keeper): share config_error and internal_error with the host module

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -5,11 +5,8 @@ module Session_store = Keeper_official_client_session_store
 
 let runtime_label = "Antigravity"
 
-let config_error ~field detail =
-  Agent_core.Error.Config (Agent_core.Error.InvalidConfig { field; detail })
-;;
-
-let internal_error detail = Agent_core.Error.Internal detail
+let config_error = Keeper_official_client_host.config_error
+let internal_error = Keeper_official_client_host.internal_error
 
 let runtime_error_to_core_error = function
   | Runtime_antigravity.Invalid_config detail ->

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -1,10 +1,7 @@
 open Result.Syntax
 
-let config_error ~field detail =
-  Agent_core.Error.Config (Agent_core.Error.InvalidConfig { field; detail })
-;;
-
-let internal_error detail = Agent_core.Error.Internal detail
+let config_error = Keeper_official_client_host.config_error
+let internal_error = Keeper_official_client_host.internal_error
 
 module Host = Keeper_official_client_host
 module Session_store = Keeper_official_client_session_store

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -1,10 +1,7 @@
 open Result.Syntax
 
-let config_error ~field detail =
-  Agent_core.Error.Config (Agent_core.Error.InvalidConfig { field; detail })
-;;
-
-let internal_error detail = Agent_core.Error.Internal detail
+let config_error = Keeper_official_client_host.config_error
+let internal_error = Keeper_official_client_host.internal_error
 
 module Host = Keeper_official_client_host
 

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -4,6 +4,15 @@
     injection. Protocol adapters only translate the resulting tool records to
     their official client's wire format. *)
 
+val config_error : field:string -> string -> Agent_core.Error.t
+(** Build the [InvalidConfig] error the official-client adapters report when a
+    runtime is misconfigured. Shared so the three adapters name the offending
+    field the same way. *)
+
+val internal_error : string -> Agent_core.Error.t
+(** Build the [Internal] error for a failure that is neither configuration nor
+    provider behaviour. *)
+
 type prepared_turn =
   { messages : Agent_core.Types.message list
   ; system_prompt : string


### PR DESCRIPTION
## 중복

`config_error` / `internal_error` 가 네 번 작성돼 있었다 — `keeper_official_client_host` 에 한 번, 그리고 그 모듈을 **이미 `Host` 로 별칭 잡아 쓰는** 세 어댑터에 각각 한 번씩:

```ocaml
let config_error ~field detail =
  Agent_core.Error.Config (Agent_core.Error.InvalidConfig { field; detail })

let internal_error detail = Agent_core.Error.Internal detail
```

- `keeper_antigravity_runtime`
- `keeper_claude_code_runtime`
- `keeper_codex_runtime`

## #28195 와 다른 점

runtime 쪽 헬퍼는 각자 다른 `error` 합타입으로 실패해서 functor 가 필요했다. 여기는 넷 다 같은 `Agent_core.Error.t` 를 만들므로, host 모듈의 짝을 `.mli` 에 노출하고 어댑터가 그것을 가리키면 끝난다. 호출부는 그대로다.

## 검증

- `dune build --root . @check` → exit 0
- `python3 scripts/check_test_coverage.py` → exit 0

`@default @check @install` 전체 게이트는 워크트리 두 개가 동시에 빌드하다 OOM killer 에 두 번 죽어서, 통과했다고 보고하지 않고 CI 에 맡긴다.

4 files changed, 15 insertions(+), 15 deletions(-)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
