### PR TITLE
fix(runtime): reject larger framed overflow retries

### DIFF
--- a/lib/runtime/runtime_model_input_tail_window.ml
+++ b/lib/runtime/runtime_model_input_tail_window.ml
@@ -128,6 +128,12 @@ let next_shrink_capacity_bytes
     ~measure_message_bytes
     ~target_capacity_bytes
     messages =
+  let rejected_window_bytes =
+    List.fold_left
+      (fun total message -> total + measure_message_bytes message)
+      0
+      messages
+  in
   (* A provider-bound list may already contain the preamble materialized by a
      previous cut. It is generated framing, not a durable conversation atom;
      never let it become the oldest removable atom of the next retry. *)
@@ -177,9 +183,15 @@ let next_shrink_capacity_bytes
         Some newest_atom_bytes
       | None -> None
     in
-    Option.map
-      (fun retained -> undroppable_bytes + retained)
-      retained_atom_bytes)
+    Option.bind retained_atom_bytes (fun retained ->
+      let framed_capacity = undroppable_bytes + retained in
+      (* Removing an atom is not sufficient when the retained suffix starts
+         with Assistant/Tool: [project] then adds the synthetic User preamble.
+         Never retry a size-driven refusal with framing that is equal to or
+         larger than the exact window the provider already rejected. *)
+      if framed_capacity < rejected_window_bytes
+      then Some framed_capacity
+      else None))
 ;;
 
 (* Smallest multiple of [atoms_per_window] whose remaining suffix fits

--- a/lib/runtime/runtime_model_input_tail_window.mli
+++ b/lib/runtime/runtime_model_input_tail_window.mli
@@ -86,12 +86,12 @@ val next_shrink_capacity_bytes
     removed while preserving the newest atom.
 
     The returned capacity is never below the bytes required by pinned
-    messages, the synthetic preamble, and the newest atom. It is also never
-    above the first strictly smaller atom suffix, so applying {!project} with
-    that capacity removes at least one older atom instead of repeating the
-    rejected request byte-for-byte. [target_capacity_bytes] is used when it
-    lies inside those structural bounds (for example, the ordinary halving
-    policy). *)
+    messages, the synthetic preamble, and the newest atom. It is also strictly
+    smaller than the exact rejected window after synthetic framing is charged;
+    otherwise this function returns [None]. Thus applying {!project} cannot
+    replace a size-driven refusal with an equal or larger request.
+    [target_capacity_bytes] is used when it lies inside those structural
+    bounds (for example, the ordinary halving policy). *)
 
 type budget_error =
   | Reservation_exceeds_capacity of

--- a/test/test_runtime_model_input_tail_window.ml
+++ b/test/test_runtime_model_input_tail_window.ml
@@ -244,6 +244,23 @@ let test_next_shrink_capacity_ignores_materialized_preamble () =
     Alcotest.fail
       "a materialized preamble must not create a retry boundary before the newest atom"
 ;;
+
+let test_next_shrink_rejects_larger_framed_retry () =
+  let oldest = padded ~role:Types.User ~tag:"oldest|" 100 in
+  let newest = padded ~role:Types.Assistant ~tag:"newest|" 600 in
+  match
+    Window.next_shrink_capacity_bytes
+      ~measure_message_bytes
+      ~target_capacity_bytes:350
+      [ oldest; newest ]
+  with
+  | None -> ()
+  | Some capacity_bytes ->
+    Alcotest.failf
+      "synthetic framing expanded a 700-byte refusal into a %d-byte retry"
+      capacity_bytes
+;;
+
 let test_cut_is_quantized_when_a_quantized_cut_fits () =
   (* Cache stability (#26535): when some multiple of [k] fits, the drop count
      is that multiple, so the transmitted prefix only moves in whole
@@ -500,6 +517,10 @@ let () =
             "next shrink ignores materialized preamble"
             `Quick
             test_next_shrink_capacity_ignores_materialized_preamble
+        ; Alcotest.test_case
+            "next shrink rejects larger framed retry"
+            `Quick
+            test_next_shrink_rejects_larger_framed_retry
         ; Alcotest.test_case "cut is quantized when a quantized cut fits" `Quick
             test_cut_is_quantized_when_a_quantized_cut_fits
         ; Alcotest.test_case "cut point is stable while the budget holds" `Quick


### PR DESCRIPTION
## What changed

- measure the exact rejected provider window before choosing a retry capacity
- refuse an atom-boundary retry when synthetic preamble framing would make it equal to or larger than the rejected request
- add the 100-byte User + 600-byte Assistant regression reported after #28184 merged

## Root cause

The shrink policy proved that an older atom was removed, but compared only retained atom bytes. When the retained suffix began with Assistant or Tool, projection added a synthetic User preamble after that comparison, so the first retry could be larger than the size-driven refusal it was meant to repair.

## Validation

- `git diff --check`
- `ocamlformat --check` for all changed OCaml files
- full build/test delegated to CI

Follow-up to #28184 and discussion `r3756790336`.
