### PR TITLE
fix(audit): bind append to validated directory fd

### DIFF
--- a/lib/shared_audit/dune
+++ b/lib/shared_audit/dune
@@ -6,4 +6,7 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4) + unused-value ratchet (warning 32)
  (flags
   (:standard -w +4 -w +33 -w +37))
- (libraries unix yojson digestif digestif.c jsonl_writer fs_compat masc_core))
+ (libraries unix yojson digestif digestif.c jsonl_writer fs_compat masc_core)
+ (foreign_stubs
+  (language c)
+  (names store_stubs)))

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -19,6 +19,20 @@ type t = {
   writer_owner : writer_owner;
 }
 
+external open_directory_nofollow : string -> Unix.file_descr
+  = "caml_masc_shared_audit_open_directory"
+
+external mkdirat_if_missing : Unix.file_descr -> string -> unit
+  = "caml_masc_shared_audit_mkdirat_if_missing"
+
+external openat_directory_nofollow :
+  Unix.file_descr -> string -> Unix.file_descr
+  = "caml_masc_shared_audit_openat_directory"
+
+external openat_append_file_nofollow :
+  Unix.file_descr -> string -> Unix.file_descr
+  = "caml_masc_shared_audit_openat_append_file"
+
 module Writer_owner_key = struct
   type t = writer_owner_key
 
@@ -203,6 +217,82 @@ let ensure_owner_directory_identity owner =
          ; actual_inode_id = Option.map (fun identity -> identity.inode_id) actual
          })
 
+let raise_base_directory_replaced owner actual =
+  let expected = owner.key.directory_identity in
+  raise
+    (Base_directory_replaced
+       { path = owner.key.canonical_base_dir
+       ; expected_device_id = expected.device_id
+       ; expected_inode_id = expected.inode_id
+       ; actual_device_id = Option.map (fun identity -> identity.device_id) actual
+       ; actual_inode_id = Option.map (fun identity -> identity.inode_id) actual
+       })
+
+let close_noerr descriptor =
+  try Unix.close descriptor with
+  | Unix.Unix_error _ -> ()
+
+let with_descriptor open_descriptor use_descriptor =
+  let descriptor = open_descriptor () in
+  Fun.protect
+    ~finally:(fun () -> close_noerr descriptor)
+    (fun () -> use_descriptor descriptor)
+
+let open_validated_base_directory owner =
+  let descriptor =
+    try open_directory_nofollow owner.key.canonical_base_dir with
+    | Unix.Unix_error ((Unix.ENOENT | Unix.ENOTDIR | Unix.ELOOP), _, _) ->
+      raise_base_directory_replaced owner
+        (current_directory_identity owner.key.canonical_base_dir)
+  in
+  let stats =
+    match Unix.fstat descriptor with
+    | stats -> stats
+    | exception exn ->
+      close_noerr descriptor;
+      raise exn
+  in
+  let actual = { device_id = stats.st_dev; inode_id = stats.st_ino } in
+  if actual = owner.key.directory_identity then descriptor
+  else begin
+    close_noerr descriptor;
+    raise_base_directory_replaced owner (Some actual)
+  end
+
+let rec write_all descriptor content offset =
+  if offset < String.length content then
+    match
+      Unix.write_substring descriptor content offset
+        (String.length content - offset)
+    with
+    | 0 ->
+      raise
+        (Unix.Unix_error
+           (Unix.EIO, "write", "shared audit append made no progress"))
+    | written -> write_all descriptor content (offset + written)
+    | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+      write_all descriptor content offset
+
+let append_entry_at_validated_directory owner entry =
+  let dated =
+    Jsonl_writer.dated_path
+      ~base_dir:owner.key.canonical_base_dir
+      ~ts:entry.Envelope.ts
+  in
+  let line = Yojson.Safe.to_string (Envelope.to_json entry) ^ "\n" in
+  with_descriptor
+    (fun () -> open_validated_base_directory owner)
+    (fun base_descriptor ->
+      mkdirat_if_missing base_descriptor dated.month_dir;
+      with_descriptor
+        (fun () ->
+          openat_directory_nofollow base_descriptor dated.month_dir)
+        (fun month_descriptor ->
+          with_descriptor
+            (fun () ->
+              openat_append_file_nofollow month_descriptor dated.day_file)
+            (fun day_descriptor -> write_all day_descriptor line 0)))
+
 let writer_owner_for_key key =
   (* Publish the canonical writer identity before reading its cursor. Every
      creator initializes under this owner's append lock below, so no append can
@@ -241,14 +331,8 @@ let base_dir t = t.base_dir
 let append t ~category ~payload =
   let owner = t.writer_owner in
   Cross_context_mutex.with_durable_lock owner.append_lock (fun () ->
-    ensure_owner_directory_identity owner;
     let entry = Envelope.make ~category ~payload ~prev_hash:owner.latest_hash in
-    ignore
-      (Jsonl_writer.append_dated_jsonl
-         ~base_dir:owner.key.canonical_base_dir
-         ~ts:entry.ts
-         (Envelope.to_json entry)
-        : Jsonl_writer.dated_path);
+    append_entry_at_validated_directory owner entry;
     owner.latest_hash <- Some (Envelope.hash_for_chain entry);
     entry)
 

--- a/lib/shared_audit/store.mli
+++ b/lib/shared_audit/store.mli
@@ -55,8 +55,11 @@ val create : base_dir:string -> t
     partition; reopening an existing owner refreshes that cursor under its
     append lock. The canonical path and its filesystem identity are retained
     for all later I/O, so aliases cannot silently retarget a live writer and
-    replacing the canonical directory fails closed. Thus [append] continues
-    the chain across sessions. *)
+    replacing the canonical directory fails closed. Each append opens and
+    validates that directory, then resolves its partition and file relative to
+    the validated directory descriptor; pathname replacement cannot redirect
+    the write after validation. Thus [append] continues the chain across
+    sessions. *)
 
 val append :
   t ->
@@ -66,7 +69,9 @@ val append :
 (** Append a new entry with [prev_hash] computed from the latest
     hash owned for this canonical base directory. Cursor read, durable
     append, and cursor update are serialized as one transaction across
-    every in-process store instance. Returns the appended entry. Raises
+    every in-process store instance. The write is bound to a freshly validated
+    base-directory descriptor and does not use the process-wide pathname writer
+    or mkdir caches. Returns the appended entry. Raises
     {!Base_directory_replaced} if the canonical directory identity changed. *)
 
 val recent : t -> n:int -> Envelope.t list

--- a/lib/shared_audit/store_stubs.c
+++ b/lib/shared_audit/store_stubs.c
@@ -1,0 +1,131 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/signals.h>
+#include <caml/unixsupport.h>
+
+#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW)
+#error "shared audit append requires O_CLOEXEC, O_DIRECTORY, and O_NOFOLLOW"
+#endif
+
+static int
+open_directory(int directory_fd, const char *path, int *saved_errno)
+{
+  int descriptor;
+
+  caml_enter_blocking_section();
+  if (directory_fd == AT_FDCWD) {
+    descriptor = open(path, O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+  } else {
+    descriptor =
+      openat(
+        directory_fd,
+        path,
+        O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+  }
+  *saved_errno = errno;
+  caml_leave_blocking_section();
+  return descriptor;
+}
+
+CAMLprim value
+caml_masc_shared_audit_open_directory(value v_path)
+{
+  CAMLparam1(v_path);
+  char *path = caml_stat_strdup(String_val(v_path));
+  int saved_errno;
+  int descriptor = open_directory(AT_FDCWD, path, &saved_errno);
+  caml_stat_free(path);
+
+  if (descriptor == -1) {
+    errno = saved_errno;
+    uerror("open", v_path);
+  }
+
+  CAMLreturn(Val_int(descriptor));
+}
+
+CAMLprim value
+caml_masc_shared_audit_mkdirat_if_missing(value v_dirfd, value v_leaf)
+{
+  CAMLparam2(v_dirfd, v_leaf);
+  char *leaf = caml_stat_strdup(String_val(v_leaf));
+  int result;
+  int saved_errno;
+
+  caml_enter_blocking_section();
+  result = mkdirat(Int_val(v_dirfd), leaf, 0755);
+  saved_errno = errno;
+  caml_leave_blocking_section();
+
+  caml_stat_free(leaf);
+
+  if (result == -1 && saved_errno != EEXIST) {
+    errno = saved_errno;
+    uerror("mkdirat", v_leaf);
+  }
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value
+caml_masc_shared_audit_openat_directory(value v_dirfd, value v_leaf)
+{
+  CAMLparam2(v_dirfd, v_leaf);
+  char *leaf = caml_stat_strdup(String_val(v_leaf));
+  int saved_errno;
+  int descriptor = open_directory(Int_val(v_dirfd), leaf, &saved_errno);
+  caml_stat_free(leaf);
+
+  if (descriptor == -1) {
+    errno = saved_errno;
+    uerror("openat", v_leaf);
+  }
+
+  CAMLreturn(Val_int(descriptor));
+}
+
+CAMLprim value
+caml_masc_shared_audit_openat_append_file(value v_dirfd, value v_leaf)
+{
+  CAMLparam2(v_dirfd, v_leaf);
+  char *leaf = caml_stat_strdup(String_val(v_leaf));
+  int descriptor;
+  int saved_errno;
+
+  caml_enter_blocking_section();
+  descriptor =
+    openat(
+      Int_val(v_dirfd),
+      leaf,
+      O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC | O_NOFOLLOW,
+      0644);
+  saved_errno = errno;
+  caml_leave_blocking_section();
+
+  caml_stat_free(leaf);
+
+  if (descriptor == -1) {
+    errno = saved_errno;
+    uerror("openat", v_leaf);
+  }
+
+  CAMLreturn(Val_int(descriptor));
+}

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -387,6 +387,11 @@ let test_store_rejects_replaced_canonical_directory () =
     in
     check (option string) "replacement starts its own chain" None
       replacement_entry.prev_hash;
+    let rotated_store = Store.create ~base_dir:rotated in
+    check int "replacement append did not reuse rotated cached writer" 1
+      (List.length (Store.recent rotated_store ~n:10));
+    check int "replacement append reached replacement directory" 1
+      (List.length (Store.recent replacement_store ~n:10));
     match Store.append old_store ~category:"old" ~payload:(`Int 2) with
     | exception
         Store.Base_directory_replaced


### PR DESCRIPTION
## Summary

- bind each shared-audit append to a freshly opened and inode-validated base directory descriptor
- create/open the dated partition and file with `mkdirat`/`openat` relative to that descriptor
- bypass pathname-global mkdir and writer caches so a replacement directory cannot inherit a stale writer
- strengthen the directory-rotation regression to verify both old and replacement logs

## Review context

Follow-up to the post-merge P1/P2 findings on #28176:

- https://github.com/jeong-sik/masc/pull/28176#discussion_r3756718244
- https://github.com/jeong-sik/masc/pull/28176#discussion_r3756718238

The validation and write now share one filesystem capability: after the base directory FD is opened and its device/inode match is confirmed, every child lookup is relative to that pinned FD. No string re-check or cache invalidation is used as a substitute for binding the I/O target.

## Validation

- `git diff --check`
- `ocamlformat --check lib/shared_audit/store.ml lib/shared_audit/store.mli test/shared_audit/test_shared_audit.ml`
- C stub syntax/warning check with `cc -fsyntax-only -Wall -Wextra -Werror`
- OCaml danger-pattern scan on changed implementation/test files
- full build/test intentionally left to CI
