### PR TITLE
fix(keeper): restore owner run-if-idle match closure

### DIFF
--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -840,7 +840,7 @@ let start
                        (request
                           t
                           (Child_finished
-                             (Autonomous_child_finished { outcome; resolve }))))));
+                             (Autonomous_child_finished { outcome; resolve })))))));
           loop state shutdown_operation_id
         | Command (Child_finished completion, resolve) ->
           let result =


### PR DESCRIPTION
## Summary
- restore the closing parenthesis removed from the nested `Run_if_idle` match
- no behavior or ownership change

## Evidence
- main CI Build: `keeper_owner.ml:889` syntax error, unmatched `(` at line 806
- `ocamlformat --check lib/keeper/keeper_owner.ml`
- `git diff --check`
- focused Dune was correctly refused because unrelated bare Dune processes were active; CI is the clean-runner compile authority

RFC-WAIVED: one-character syntax repair only.