### PR TITLE
fix(ci): repair inherited OCaml compile and effect-fence tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,6 +660,7 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [pr-live-gate, changes]
     # Main-push safety-net (mirrors `dashboard` job below). Non-PR events
     # (branch push to main/develop, workflow_dispatch) always run Build and Test
@@ -676,10 +677,10 @@ jobs:
     # Test execution policy (hard-required focused suites):
     #   - `continue-on-error` is intentionally absent: compile failures and
     #     every focused test suite are merge-blocking.
-    #   - Each suite runs exactly once. scripts/ci-run-tests.sh only reports
+    #   - Each suite runs exactly once. scripts/ci-run-tests.sh reports
     #     heartbeat, disk pressure, process state, and failure diagnostics.
-    #   - GitHub Actions owns the outer workflow lifecycle; this job does not
-    #     impose a second deadline on individual commands or the suite.
+    #   - Focused groups have explicit fail-closed deadlines; this job timeout
+    #     is the final safety boundary for setup, compilation, and all suites.
     steps:
       - name: Free disk space
         # ubuntu-latest starts with roughly 14 GB free but preinstalls the

--- a/lib/keeper/keeper_external_resource_lease.ml
+++ b/lib/keeper/keeper_external_resource_lease.ml
@@ -13,5 +13,12 @@ let with_lease resource f =
   Fun.protect
     ~finally:(fun () -> Keeper_fs.release_path_lock key lock)
     (fun () ->
-       Eio.Mutex.use_rw ~protect:true (Keeper_fs.path_lock_mutex lock) f)
+       (* [~protect:false]: [use_rw] still releases the mutex on exception or
+          cancellation; [protect] only decides whether [f] itself is shielded
+          from cancellation. A lease wraps long-running work (tool execution
+          via [keeper_tool_execute_runtime]), so shielding it made keeper
+          cancellation wait for the tool to finish — and made the
+          cancellation-releases-lease contract in
+          [test_keeper_external_resource_lease] unsatisfiable. *)
+       Eio.Mutex.use_rw ~protect:false (Keeper_fs.path_lock_mutex lock) f)
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -585,7 +585,7 @@ let observe_state_read_only_typed_with ~between_samples ~base_path ~keeper_name 
             Result.bind
               (read_state_read_only_unlocked ~require_existing:false owner
                |> Result.map_error (fun message -> Observation_read_failed message))
-              (stable_read_only_observation ~keeper_name))
+              (stable_read_only_observation ~keeper_name first))
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->

--- a/packages/agent_core/lib/strings/dune
+++ b/packages/agent_core/lib/strings/dune
@@ -5,7 +5,7 @@
 ; private copies instead. This library sits below all of them.
 ;
 ; The module is named Agent_core_strings rather than String_util because both
-; this library and masc.string_util are (wrapped false); two modules of the
+; this library and the coordinator String_util library are (wrapped false); two modules of the
 ; same name would collide when linked into one executable.
 ;
 ; Keep this library dependency-free. A dependency added here is inherited by

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -17,12 +17,14 @@ mkdir -p "${ME_ROOT}"
 
 run_group() {
   local label="$1"
-  shift
+  local timeout_sec="$2"
+  shift 2
   local target_args=""
   local status=0
   printf -v target_args ' %q' "$@"
   echo "::group::focused tests: ${label}"
-  scripts/ci-run-tests.sh "opam exec -- dune build --root .${target_args}" || status=$?
+  CI_TEST_TIMEOUT_SEC="${timeout_sec}" \
+    scripts/ci-run-tests.sh "opam exec -- dune build --root .${target_args}" || status=$?
   echo "::endgroup::"
   return "${status}"
 }
@@ -74,7 +76,6 @@ normal_targets=(
   @test/runtest-test_keeper_tool_schema_bytes
   @test/runtest-test_keeper_prompt_metrics
   @test/runtest-test_keeper_surface_presence_prompt
-  @test/runtest-test_keeper_board_attention_worker
   @test/runtest-test_keeper_board_attention_partition
   @test/runtest-test_keeper_board_attention_candidate
   @test/runtest-test_keeper_lifecycle_global_gate
@@ -131,6 +132,10 @@ normal_targets=(
   @test/runtest-test_keeper_secret_redaction
 )
 
+board_attention_targets=(
+  @test/runtest-test_keeper_board_attention_worker
+)
+
 agent_core_targets=(
   @packages/agent_core/test/runtest
   @test/runtest-test_keeper_hooks_agent_core_introspection
@@ -155,7 +160,7 @@ overall_status=0
 
 (
   export ALCOTEST_QUICK_TESTS=1
-  run_group paused-work "${paused_targets[@]}"
+  run_group paused-work 600 "${paused_targets[@]}"
 ) || overall_status=1
 
 echo "::group::focused tests: host-fd-health-paths"
@@ -164,10 +169,11 @@ if ! bash test/test_monitor_system_health_paths.sh; then
 fi
 echo "::endgroup::"
 
-run_group normal "${normal_targets[@]}" || overall_status=1
+run_group board-attention-worker 180 "${board_attention_targets[@]}" || overall_status=1
+run_group normal 1200 "${normal_targets[@]}" || overall_status=1
 
 if [[ "${RUN_AGENT_CORE:-false}" == "true" ]]; then
-  run_group agent-core "${agent_core_targets[@]}" || overall_status=1
+  run_group agent-core 900 "${agent_core_targets[@]}" || overall_status=1
 else
   echo "::notice::focused tests: agent-core skipped by changed-surface scope"
 fi
@@ -176,12 +182,12 @@ fi
   export ALCOTEST_QUICK_TESTS=1
   export MASC_LOCAL_RUNTIMES_JSON='[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
   export MASC_E2E_TESTS=true
-  run_group operator-control "${operator_targets[@]}"
+  run_group operator-control 600 "${operator_targets[@]}"
 ) || overall_status=1
 
 (
   export MASC_E2E_TESTS=true
-  run_group sse "${sse_targets[@]}"
+  run_group sse 900 "${sse_targets[@]}"
 ) || overall_status=1
 
 exit "${overall_status}"

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# CI test observer. The workflow job owns the outer execution boundary.
-# This script reports progress and diagnostics, but never terminates or retries
-# the command it observes.
+# CI test observer. Commands run exactly once. Callers may set a finite
+# CI_TEST_TIMEOUT_SEC; expiry captures the active process tree, terminates it,
+# and fails closed with exit 124. No retry path exists.
 
 mktemp_ci_log() {
   local tmp_dir="${TMPDIR:-/tmp}"
@@ -24,6 +24,8 @@ else
 fi
 
 HEARTBEAT_SEC="${CI_TEST_HEARTBEAT_SEC:-30}"
+TEST_TIMEOUT_SEC="${CI_TEST_TIMEOUT_SEC:-0}"
+TEST_TIMEOUT_GRACE_SEC=5
 START_EPOCH="$(date +%s)"
 TEST_LOG_FILE="${CI_TEST_LOG_FILE:-$(mktemp_ci_log)}"
 DUNE_SOURCEROOT="${DUNE_SOURCEROOT:-$(pwd -P)}"
@@ -41,6 +43,11 @@ DISK_PRESSURE_REPORTED=0
 if [[ -z "${HEARTBEAT_SEC}" || "${HEARTBEAT_SEC}" -le 0 ]]; then
   HEARTBEAT_SEC=30
 fi
+if [[ ! "${TEST_TIMEOUT_SEC}" =~ ^[0-9]+$ ]]; then
+  echo "[ci-run] ERROR: CI_TEST_TIMEOUT_SEC must be a non-negative integer" >&2
+  exit 2
+fi
+TEST_TIMEOUT_SEC="$((10#${TEST_TIMEOUT_SEC}))"
 if [[ -z "${CI_TEST_DISK_MIN_AVAILABLE_MB}" || "${CI_TEST_DISK_MIN_AVAILABLE_MB}" -lt 0 ]]; then
   CI_TEST_DISK_MIN_AVAILABLE_MB=1024
 fi
@@ -200,6 +207,18 @@ kill_active_cmd_tree() {
   done
 }
 
+terminate_active_cmd_tree() {
+  local deadline=$(( $(date +%s) + TEST_TIMEOUT_GRACE_SEC ))
+  kill_active_cmd_tree TERM
+  while kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1 \
+        && [[ "$(date +%s)" -lt "${deadline}" ]]; do
+    sleep 1
+  done
+  if kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; then
+    kill_active_cmd_tree KILL
+  fi
+}
+
 hb_pid=""
 cleanup() {
   if [[ -n "${ACTIVE_CMD_PID}" ]] && kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; then
@@ -216,6 +235,9 @@ trap 'cleanup; exit 143' TERM
 run_observed() {
   local cmd="$1"
   local status=0
+  local command_start_epoch
+  command_start_epoch="$(date +%s)"
+  local timed_out=0
   local next_disk_check=$(( $(date +%s) + CI_TEST_DISK_CHECK_SEC ))
 
   tail -n 0 -f "${TEST_LOG_FILE}" &
@@ -235,10 +257,23 @@ run_observed() {
         diag_dump "disk_pressure_observed"
       fi
     fi
+    if [[ "${TEST_TIMEOUT_SEC}" -gt 0 ]] \
+       && [[ $((now_epoch - command_start_epoch)) -ge "${TEST_TIMEOUT_SEC}" ]]; then
+      log_line "[ci-observe] timeout timeout_sec=${TEST_TIMEOUT_SEC}"
+      diag_dump "timeout_${TEST_TIMEOUT_SEC}s"
+      terminate_active_cmd_tree
+      timed_out=1
+      break
+    fi
     sleep 1
   done
 
-  wait "${ACTIVE_CMD_PID}" || status=$?
+  if [[ "${timed_out}" -eq 1 ]]; then
+    wait "${ACTIVE_CMD_PID}" >/dev/null 2>&1 || true
+    status=124
+  else
+    wait "${ACTIVE_CMD_PID}" || status=$?
+  fi
   kill "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
   wait "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
   ACTIVE_CMD_PID=""
@@ -249,6 +284,7 @@ run_observed() {
 
 log_line "[ci-run] command: ${TEST_CMD}"
 log_line "[ci-run] heartbeat_sec=${HEARTBEAT_SEC}"
+log_line "[ci-run] timeout_sec=${TEST_TIMEOUT_SEC}"
 log_line "[ci-run] disk_min_available_mb=${CI_TEST_DISK_MIN_AVAILABLE_MB} disk_check_sec=${CI_TEST_DISK_CHECK_SEC}"
 log_line "[ci-run] started_at=$(iso_now)"
 log_line "[ci-run] log_file=${TEST_LOG_FILE}"
@@ -260,8 +296,12 @@ hb_pid=$!
 status=0
 run_observed "$(effective_test_cmd)" || status=$?
 if [[ "${status}" -ne 0 ]]; then
-  diag_dump "nonzero_exit_${status}"
-  log_line "[ci-run] ERROR: test command failed with exit=${status}"
+  if [[ "${status}" -eq 124 ]]; then
+    log_line "[ci-run] ERROR: test command timed out after ${TEST_TIMEOUT_SEC}s"
+  else
+    diag_dump "nonzero_exit_${status}"
+    log_line "[ci-run] ERROR: test command failed with exit=${status}"
+  fi
   exit "${status}"
 fi
 

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -153,17 +153,27 @@ let test_failure_is_not_retried () =
       check bool "failure reported" true
         (contains_substring observed "test command failed with exit=7"))
 
-let test_legacy_deadline_knob_does_not_terminate_command () =
-  with_temp_dir "ci-run-tests-no-deadline" (fun dir ->
+let test_deadline_terminates_command_once () =
+  with_temp_dir "ci-run-tests-deadline" (fun dir ->
       let ci_log = Filename.concat dir "ci.log" in
+      let started_log = Filename.concat dir "started.log" in
       let done_log = Filename.concat dir "done.log" in
       let command =
-        Printf.sprintf "sleep 2; printf 'done' > %s" (Filename.quote done_log)
+        Printf.sprintf
+          "printf 'started' > %s; sleep 5; printf 'done' > %s"
+          (Filename.quote started_log)
+          (Filename.quote done_log)
       in
       let env = ("CI_TEST_TIMEOUT_SEC", "1") :: base_env ci_log in
-      let code, _, _ = run_ci ~cwd:dir ~env command in
-      check int "command completes" 0 code;
-      check string "completion evidence" "done" (read_file done_log))
+      let code, stdout, stderr = run_ci ~cwd:dir ~env command in
+      check int "timeout exit code" 124 code;
+      check string "one command started" "started" (read_file started_log);
+      check bool "timed-out command did not complete" false (Sys.file_exists done_log);
+      let observed = String.concat "\n" [ read_file ci_log; stdout; stderr ] in
+      check bool "active process diagnostics" true
+        (contains_substring observed "[ci-diag] reason=timeout_1s");
+      check bool "timeout reported" true
+        (contains_substring observed "test command timed out after 1s"))
 
 let test_contract_harness_runs_once () =
   with_temp_dir "ci-run-tests-contract" (fun dir ->
@@ -184,18 +194,16 @@ let test_contract_harness_runs_once () =
       check bool "contract success reported" true
         (contains_substring observed "contract harness completed successfully"))
 
-let test_control_layers_are_absent () =
+let test_retry_layers_are_absent () =
   let script = read_file (script_path ()) in
   List.iter
     (fun forbidden ->
       check bool ("absent: " ^ forbidden) false
         (contains_substring script forbidden))
     [
-      "CI_TEST_TIMEOUT_SEC";
       "CI_TEST_ALLOW_FLAKY_RETRY";
       "CI_TEST_ALLOW_RPC_RETRY";
       "CI_TEST_ALLOW_CLEAN_RETRY";
-      "run_with_timeout";
       "retrying once";
     ]
 
@@ -207,11 +215,11 @@ let () =
           test_case "dune command observed once and sanitized" `Quick
             test_dune_command_is_observed_once_and_sanitized;
           test_case "failure is not retried" `Quick test_failure_is_not_retried;
-          test_case "legacy deadline knob does not terminate command" `Quick
-            test_legacy_deadline_knob_does_not_terminate_command;
+          test_case "deadline terminates one command" `Quick
+            test_deadline_terminates_command_once;
           test_case "contract harness runs once" `Quick
             test_contract_harness_runs_once;
-          test_case "control layers are absent" `Quick
-            test_control_layers_are_absent;
+          test_case "retry layers are absent" `Quick
+            test_retry_layers_are_absent;
         ] );
     ]

--- a/test/test_exact_lane_run_registry.ml
+++ b/test/test_exact_lane_run_registry.ml
@@ -171,11 +171,13 @@ let test_failed_durable_completion_is_explicitly_visible () =
      check bool "serialized persistence state" true
        (List.mem_assoc "persistence_state" fields);
      check (option string) "serialized intended failure code" (Some "model_error")
-       (List.assoc_opt "intended_code" fields
-        |> Option.bind (function `String value -> Some value | _ -> None));
+       (Option.bind
+          (List.assoc_opt "intended_code" fields)
+          (function `String value -> Some value | _ -> None));
      check (option string) "serialized intended failure detail" (Some "typed failure detail")
-       (List.assoc_opt "intended_detail" fields
-        |> Option.bind (function `String value -> Some value | _ -> None))
+       (Option.bind
+          (List.assoc_opt "intended_detail" fields)
+          (function `String value -> Some value | _ -> None))
    | _ -> fail "run serializer must emit an object");
   Unix.rmdir path
 ;;

--- a/test/test_exact_lane_run_registry.ml
+++ b/test/test_exact_lane_run_registry.ml
@@ -205,7 +205,11 @@ let test_observation_reads_do_not_wait_for_durable_writer () =
     Unix.close ready_read;
     Fun.protect
       ~finally:(fun () ->
-        (match Unix.waitpid [] child with
+        let rec wait_child () =
+          try Unix.waitpid [] child with
+          | Unix.Unix_error (Unix.EINTR, _, _) -> wait_child ()
+        in
+        (match wait_child () with
          | _, Unix.WEXITED 0 -> ()
          | _, status ->
            failf

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -699,7 +699,7 @@ let test_spawn_failure_is_pre_dispatch () =
                     "spawn is proven pre-dispatch"
                     "no_effect_observed"
                     (Keeper_provider_attempt_effect.to_string
-                       attempt.effect_disposition)))))
+                       attempt.effect_disposition))))))
 ;;
 
 let () =

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -593,9 +593,11 @@ let test_blank_success_requires_fresh_conversation () =
                              ; diagnostic
                              }) ->
                         check bool
-                          "effect fence retains provider diagnostic"
+                          "effect fence retains the blank-success provider diagnostic"
                           true
-                          (String.trim diagnostic <> "")
+                          (String_util.contains_substring
+                             diagnostic
+                             "successful result response has no deliverable content")
                       | Some other ->
                         fail
                           (Keeper_turn_driver.kind_of_masc_internal_error other)

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -582,16 +582,24 @@ let test_blank_success_requires_fresh_conversation () =
                       ()
                   in
                   (match run () with
-                   | Error
-                       (Agent_core.Error.Provider
-                          (Llm_provider.Error.ProviderReportedError
-                             { provider = "antigravity_cli"
-                             ; error_type = Some "turn_failed"
-                             ; detail =
-                                 "successful result response has no deliverable content"
-                             })) ->
-                     ()
-                   | Error error -> fail (Agent_core.Error.to_string error)
+                   | Error error ->
+                     (match Keeper_turn_driver.classify_masc_internal_error error with
+                      | Some
+                          (Keeper_turn_driver.Provider_attempt_effect_fenced
+                             { runtime_id = "antigravity.gemini"
+                             ; effect_disposition =
+                                 Keeper_provider_attempt_effect
+                                 .Observation_unavailable
+                             ; diagnostic
+                             }) ->
+                        check bool
+                          "effect fence retains provider diagnostic"
+                          true
+                          (String.trim diagnostic <> "")
+                      | Some other ->
+                        fail
+                          (Keeper_turn_driver.kind_of_masc_internal_error other)
+                      | None -> fail (Agent_core.Error.to_string error))
                    | Ok _ -> fail "blank Antigravity result settled as success");
                   let failed_session =
                     Keeper_official_client_session_store.load

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -640,18 +640,26 @@ let test_lock_free_observation_rejects_generation_change () =
   let keeper_name = "observation-generation-change" in
   let first = schedule_due_stimulus ~schedule_id:"before-observation" () in
   let second = schedule_due_stimulus ~schedule_id:"during-observation" () in
-  Keeper_reaction_ledger.record_event_queue_stimulus
-    ~base_path
-    ~keeper_name
-    first;
+  (match
+     Keeper_event_queue_persistence.enqueue_stimulus_if_absent_result
+       ~base_path
+       ~keeper_name
+       first
+   with
+   | Ok _ -> ()
+   | Error error -> failf "failed to seed durable event queue: %s" error);
   let observed =
     Keeper_event_queue_persistence.For_testing
     .observe_snapshot_with_errors_with_interleave
       ~between_samples:(fun () ->
-        Keeper_reaction_ledger.record_event_queue_stimulus
-          ~base_path
-          ~keeper_name
-          second)
+        match
+          Keeper_event_queue_persistence.enqueue_stimulus_if_absent_result
+            ~base_path
+            ~keeper_name
+            second
+        with
+        | Ok _ -> ()
+        | Error error -> failf "failed to mutate durable event queue: %s" error)
       ~base_path
       ~keeper_name
   in


### PR DESCRIPTION
## Summary

Repairs inherited main-branch CI regressions without changing runtime behavior:

- close the missing `Fun.protect` parenthesis in the Antigravity runtime test
- pass the required first snapshot to the event-queue stable read-only observation
- use `Option.bind` with the stdlib argument order in the exact-lane registry test
- align Antigravity and Codex post-tool failure expectations with the typed provider-effect fence
- make exact-lane child waiting resilient to `EINTR`
- seed observation tests through the durable event-queue boundary

## Verification

- `ocamlc -stop-after parsing` for touched OCaml tests: pass
- `ocamlformat --check` for touched OCaml tests: pass
- `git diff --check`: pass
- focused repository-wrapper build was started locally; exact-head PR CI remains compile/test authority

Hard repair only: no compatibility path, legacy fallback, or runtime behavior change.