### PR TITLE
fix(keeper): pass both samples to the read-only observation comparison

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -585,7 +585,7 @@ let observe_state_read_only_typed_with ~between_samples ~base_path ~keeper_name 
             Result.bind
               (read_state_read_only_unlocked ~require_existing:false owner
                |> Result.map_error (fun message -> Observation_read_failed message))
-              (stable_read_only_observation ~keeper_name))
+              (stable_read_only_observation ~keeper_name first))
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->

--- a/test/dune
+++ b/test/dune
@@ -302,6 +302,7 @@
   test_keeper_event_queue_owner_lock
   test_cross_context_mutex
   test_keeper_event_queue_persist_poison
+  test_keeper_event_queue_observe_coherence
   test_workspace_routes_keeper
   test_workspace_tree_exclusions
   test_workspace_file_confidentiality
@@ -597,6 +598,7 @@
   test_keeper_event_queue_owner_lock
   test_cross_context_mutex
   test_keeper_event_queue_persist_poison
+  test_keeper_event_queue_observe_coherence
   test_workspace_routes_keeper
   test_workspace_tree_exclusions
   test_workspace_file_confidentiality

--- a/test/test_keeper_event_queue_observe_coherence.ml
+++ b/test/test_keeper_event_queue_observe_coherence.ml
@@ -1,0 +1,96 @@
+(** Regression: the read-only queue observer must reject a torn read.
+
+    #28191 added the two-sample observer and the [For_testing] interleave seam
+    without a test that uses it. The sample comparison was written as a partial
+    application — [stable_read_only_observation ~keeper_name] handed to
+    [Result.bind], which supplies only the second sample — so
+    [lib/keeper_runtime] did not compile and [bin/main_eio.exe] could not be
+    built from main.
+
+    The compile fix is proven by the compiler. This test pins the part the
+    compiler cannot see: a comparison of the second sample with itself
+    type-checks and reports every read as coherent. Here the persisted queue
+    changes between the two samples, so only a genuine first-vs-second
+    comparison reports [Incoherent_read]. *)
+
+module Persistence = Keeper_event_queue_persistence
+module Queue = Keeper_event_queue
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
+(* [Bootstrap] is the one nullary payload, so the stimulus carries no producer
+   context the observer could read; the queue only has to differ. *)
+let bootstrap_stimulus post_id : Queue.stimulus =
+  { post_id; urgency = Queue.Normal; arrived_at = 0.0; payload = Queue.Bootstrap }
+;;
+
+let has_incoherent_read (snapshot : Persistence.snapshot_with_errors) =
+  List.exists
+    (fun (error : Persistence.snapshot_read_error) ->
+       error.kind = Persistence.Incoherent_read)
+    snapshot.read_errors
+;;
+
+let () =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio_context.with_test_env ~net ~clock ~mono_clock ~sw
+  @@ fun () ->
+  let keeper_name = "observe_coherence_probe" in
+  let base_path = Filename.temp_file "kq_observe_probe" "" in
+  Sys.remove base_path;
+  Unix.mkdir base_path 0o755;
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists base_path then rm_rf base_path)
+    (fun () ->
+       Persistence.persist ~base_path ~keeper_name Queue.empty;
+       (* Two identical samples: a coherent observation with no read errors. *)
+       let stable =
+         Persistence.For_testing.observe_snapshot_with_errors_with_interleave
+           ~between_samples:(fun () -> ())
+           ~base_path
+           ~keeper_name
+       in
+       Alcotest.(check int)
+         "an unchanged queue observes coherently"
+         0
+         (List.length stable.read_errors);
+       Alcotest.(check bool)
+         "the coherent observation projects the persisted queue"
+         true
+         (Queue.is_empty stable.pending);
+       (* The queue changes between the two samples. The observer must report
+          the torn read rather than project either half. *)
+       let torn =
+         Persistence.For_testing.observe_snapshot_with_errors_with_interleave
+           ~between_samples:(fun () ->
+             Persistence.persist
+               ~base_path
+               ~keeper_name
+               (Queue.enqueue Queue.empty (bootstrap_stimulus "torn-1")))
+           ~base_path
+           ~keeper_name
+       in
+       Alcotest.(check bool)
+         "a queue that changes between samples is an incoherent read"
+         true
+         (has_incoherent_read torn);
+       Alcotest.(check bool)
+         "an incoherent read projects no pending work"
+         true
+         (Queue.is_empty torn.pending));
+  print_endline "test_keeper_event_queue_observe_coherence: OK"
+;;


### PR DESCRIPTION
`main` 은 현재 `bin/main_eio.exe` 를 빌드하지 못합니다. 이 PR 은 그 컴파일 오류를 고치고, 그 오류가 통과할 수 있었던 의미론적 구멍을 테스트로 막습니다.

## 증상

```
File "lib/keeper_runtime/keeper_event_queue_persistence.ml", line 588, characters 14-57:
Error: This expression has type
         State.t -> State.t -> (State.t, read_only_observation_error) result
       but an expression was expected of type
         State.t -> ('a, read_only_observation_error) result
```

`lib/masc.cma` 는 초록입니다 — `keeper_runtime` 이 별도 라이브러리라서 부분 빌드로는 보이지 않습니다. 프로덕션 바이너리 타깃에서만 드러납니다.

## 원인

`stable_read_only_observation ~keeper_name first second` 는 두 샘플을 받는데, `Result.bind` 의 continuation 으로 **부분 적용** 상태로 넘어갔습니다. `Result.bind` 는 두 번째 샘플만 공급하므로 타입이 맞지 않습니다.

```ocaml
(fun first ->
   between_samples ();
   Result.bind
     (read_state_read_only_unlocked ~require_existing:false owner |> ...)
-    (stable_read_only_observation ~keeper_name))
+    (stable_read_only_observation ~keeper_name first))
```

`first` 는 바인드만 되고 어디에도 쓰이지 않았습니다.

## 유입 경로

`0ce48226bb` (#28191, `fix(schedule): keep dashboard evidence reads non-mutating`) 이 이 함수와 `For_testing` 시드를 함께 도입했습니다. 해당 PR 의 `Build and Test` 는 `cancelled` 로 끝났고 — `failure` 가 아니라서 rollup 에서 초록으로 보입니다 — 한 번도 컴파일되지 않은 채 머지됐습니다. 이후 `#28204`(failure), `#28202`, `#28205`, `#28203`, `#28207` 가 같은 red main 위에 연달아 올라갔고 그 체크는 전부 `cancelled` 입니다.

## 테스트

`#28191` 은 `For_testing.observe_snapshot_with_errors_with_interleave` 라는 시드를 만들어놓고 **쓰는 테스트를 만들지 않았습니다.** 저장소 전체에서 이 함수의 참조는 정의 1곳뿐이었습니다.

컴파일 수정 자체는 컴파일러가 증명합니다. 테스트는 컴파일러가 볼 수 없는 쪽을 고정합니다 — **두 번째 샘플을 자기 자신과 비교하는 버전은 타입이 맞고, 모든 읽기를 coherent 로 보고합니다.**

`test/test_keeper_event_queue_observe_coherence.ml`:

| 케이스 | 단언 |
|---|---|
| 두 샘플 동일 | `read_errors = []`, 투영된 큐가 저장된 큐와 일치 |
| 샘플 사이에 큐가 바뀜 | `Incoherent_read` 보고, `pending` 은 비어 있음 (반쪽 투영 금지) |

### 뮤테이션 대조 (이 테스트가 실제로 잡는지)

`(stable_read_only_observation ~keeper_name first)` 를 `(fun second -> stable_read_only_observation ~keeper_name second second)` 로 바꾸면:

| | 결과 |
|---|---|
| 빌드 | **exit 0** — 이 오타는 타입 검사를 통과합니다 |
| 테스트 | **exit 2** — `FAIL a queue that changes between samples is an incoherent read` (`Expected: true` / `Received: false`) |

수정본으로 되돌리면 빌드 exit 0, 테스트 exit 0.

## 로컬 검증

| 명령 | 결과 |
|---|---|
| `dune build --root . bin/main_eio.exe` | exit 0 (수정 전: 위 타입 에러) |
| `dune build --root . test/test_keeper_event_queue_observe_coherence.exe` | exit 0 |
| `./_build/default/test/test_keeper_event_queue_observe_coherence.exe` | exit 0, 4/4 |
| `ocamlformat --check` (변경된 2개 `.ml`) | exit 0 |

환경: OCaml 5.5.0, `-j 2`.

## 남은 문제 (이 PR 범위 밖)

컴파일되지 않는 코드가 머지된 것은 이 파일의 결함이 아니라 머지 게이트의 결함입니다. `Build and Test` 가 `cancelled` 로 끝나면 rollup 상태가 `failure` 가 되지 않아 red main 이 green 으로 보입니다. 오늘만 5개 머지가 이 상태로 통과했습니다. 별도 이슈로 다룰 사안입니다.

RFC-WAIVED: 컴파일 오류 수정 + 회귀 테스트 추가. credential / operator control / sandbox / hooks 어느 subsystem 도 건드리지 않고, 동작 계약 변경 없이 `#28191` 이 의도한 두 샘플 비교를 복원합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
