### PR TITLE
fix(keeper): pass the first sample to the stable observation check

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -585,7 +585,7 @@ let observe_state_read_only_typed_with ~between_samples ~base_path ~keeper_name 
             Result.bind
               (read_state_read_only_unlocked ~require_existing:false owner
                |> Result.map_error (fun message -> Observation_read_failed message))
-              (stable_read_only_observation ~keeper_name))
+              (stable_read_only_observation ~keeper_name first))
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->


### PR DESCRIPTION
## 목표

main 빌드 복구. `keeper_event_queue_persistence.ml:588`의 two-sample 안정성 검사가 inner `Result.bind`에 `stable_read_only_observation ~keeper_name`을 부분 적용 상태로 넘겨 타입 에러 — `first` 한 토큰 누락.

```
Error: This expression has type
         State.t -> State.t -> (State.t, read_only_observation_error) result
       but an expression was expected of type
         State.t -> ('a, read_only_observation_error) result
```

## 검증

- `dune build ./bin/main_eio.exe`: **exit 0** (수정 전 main의 유일한 빌드 에러)
- `test_keeper_event_queue`: 마지막 정상 base(06caa05a68)와 **동일 지점 동일 실패** — 기존 로컬 red, 본 수정과 무관

## 참고

main push 런 다수가 cancelled로 끝나는 상태에서는 컴파일 실패도 머지를 통과합니다 (#27760 관련).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>