### PR TITLE
fix(runtime): key quota windows by credential account, demote deferred suffixes

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -180,6 +180,7 @@ let attempt_runtime_candidates
       true)
     ?lane_id
     ?(on_retry_deferred = fun _ -> ())
+    ?quota_scope_of
     ~runtime_id ~runtime_id_of
     ~(emit_runtime_manifest :
        ?status:string ->
@@ -197,6 +198,13 @@ let attempt_runtime_candidates
      stops on a non-recoverable error keeps that error: it is the immediate
      operator signal, and the overflow will be observed again on the next
      cycle. *)
+  let quota_scope_of =
+    match quota_scope_of with
+    | Some quota_scope_of -> quota_scope_of
+    | None ->
+      fun candidate ->
+        Runtime.quota_scope_of_runtime_id (runtime_id_of candidate)
+  in
   let rec loop ~observed_overflow idx = function
     | [] ->
       (match observed_overflow with
@@ -210,6 +218,11 @@ let attempt_runtime_candidates
     | candidate :: rest ->
       let is_last = rest = [] in
       let attempt_runtime_id = runtime_id_of candidate in
+      (* Bind quota ownership to the exact candidate that will be dispatched.
+         [run_attempt] may span a runtime.toml reload; resolving the id after
+         the provider returns could then attribute the old credential's
+         response to the replacement catalog row. *)
+      let attempt_quota_scope = quota_scope_of candidate in
       emit_runtime_manifest
         ~status:"attempt"
         ~decision:(runtime_attempt_decision ~idx ~runtime_id:attempt_runtime_id)
@@ -250,7 +263,7 @@ let attempt_runtime_candidates
             (* Quota is credential-account-owned, so the window is keyed by
                the row's quota scope: siblings sharing the credential are
                demoted together (PR #28202 review P2). *)
-            (match Runtime.quota_scope_of_runtime_id attempt_runtime_id with
+            (match attempt_quota_scope with
              | Some scope ->
                Runtime_quota_window.note_exhausted
                  ~scope
@@ -268,8 +281,7 @@ let attempt_runtime_candidates
          let rest =
            Runtime_quota_window.demote_order
              ~now:(Unix.gettimeofday ())
-             ~quota_scope_of:(fun candidate ->
-               Runtime.quota_scope_of_runtime_id (runtime_id_of candidate))
+             ~quota_scope_of
              rest
          in
          let retry_admitted =
@@ -776,6 +788,9 @@ let run_named
     ~runtime_id_of:(function
       | Resolved_runtime runtime -> runtime.Runtime.id
       | Missing_runtime runtime_id -> runtime_id)
+    ~quota_scope_of:(function
+      | Resolved_runtime runtime -> Some (Runtime.quota_scope_of_runtime runtime)
+      | Missing_runtime _ -> None)
     ~emit_runtime_manifest
     ~run_attempt:(fun ~idx:_ ~runtime_id:attempt_runtime_id candidate ->
       match candidate with

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -233,7 +233,10 @@ let attempt_runtime_candidates
           | Agent_core.Error.Provider
               (Llm_provider.Error.HardQuota { retry_after = Some retry_after_s; _ })
             ->
-            (match Runtime.provider_id_of_runtime_id attempt_runtime_id with
+            (* Quota is credential-account-owned, so the window is keyed by
+               the row's quota scope: siblings sharing the credential are
+               demoted together (PR #28202 review P2). *)
+            (match Runtime.quota_scope_of_runtime_id attempt_runtime_id with
              | Some provider_id ->
                Runtime_quota_window.note_exhausted
                  ~provider_id
@@ -518,9 +521,23 @@ let run_named
      operators can route through explicit failover groups.  Lane candidate
      order passes through the sticky last-good preference so a known-healthy
      failover candidate is tried before re-hitting a dead head candidate. *)
+  (* Quota-window demotion is ordering only — a demoted candidate is still
+     attempted when the lane has nothing else (RFC-0370 §3.3). It applies to
+     both candidate sources: the declared lane walk and a frozen deferred
+     suffix, whose next candidate may sit on an account whose window was
+     recorded after the freeze (PR #28202 review P2). *)
+  let demote_quota_exhausted candidates =
+    Runtime_quota_window.demote_order
+      (* NDT-OK: scheduling intentionally compares the stored expiry with
+         wall clock; [demote_order] stays pure via injected [now]. *)
+      ~now:(Unix.gettimeofday ())
+      ~quota_scope_of:Runtime.quota_scope_of_runtime_id
+      candidates
+  in
   let lane_id_opt, lane_candidate_ids =
     match deferred_runtime_lane with
-    | Some hint -> Some hint.assignment_id, deferred_runtime_ids hint
+    | Some hint ->
+      Some hint.assignment_id, demote_quota_exhausted (deferred_runtime_ids hint)
     | None ->
       (match Runtime.resolve_assignment runtime_id with
        | `Missing -> None, []
@@ -528,18 +545,12 @@ let run_named
        | `Lane lane ->
          let lane_id = Runtime_lane.id lane in
          ( Some lane_id
-         , (* Quota-window demotion runs after sticky preference: a provider
-              that stated "exhausted until T" outranks a remembered last-good
-              candidate on that same provider. Ordering only — a demoted
-              candidate is still attempted when the lane has nothing else.
-              RFC-0370 §3.3. *)
+         , (* Demotion runs after sticky preference: a provider that stated
+              "exhausted until T" outranks a remembered last-good candidate
+              on that same account. *)
            Runtime_lane_preference.prefer_order ~lane_id
              (Runtime_lane.ordered_candidates lane)
-           |> Runtime_quota_window.demote_order
-                (* NDT-OK: scheduling intentionally compares the stored expiry
-                   with wall clock; [demote_order] stays pure via injected [now]. *)
-                ~now:(Unix.gettimeofday ())
-                ~provider_id_of:Runtime.provider_id_of_runtime_id ))
+           |> demote_quota_exhausted ))
   in
   if lane_candidate_ids = []
   then

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -91,6 +91,20 @@ type deferred_runtime_lane =
 let deferred_runtime_ids hint =
   hint.next_runtime_id :: hint.later_runtime_ids
 
+let quota_ordered_runtime_ids ~now runtime_ids =
+  Runtime_quota_window.demote_order
+    ~now
+    ~quota_scope_of:Runtime.quota_scope_of_runtime_id
+    runtime_ids
+;;
+
+let quota_ordered_deferred_runtime_lane ~now hint =
+  match quota_ordered_runtime_ids ~now (deferred_runtime_ids hint) with
+  | next_runtime_id :: later_runtime_ids ->
+    { hint with next_runtime_id; later_runtime_ids }
+  | [] -> hint
+;;
+
 let equal_deferred_runtime_lane left right =
   String.equal left.assignment_id right.assignment_id
   && String.equal left.failed_runtime_id right.failed_runtime_id
@@ -540,11 +554,10 @@ let run_named
      suffix, whose next candidate may sit on an account whose window was
      recorded after the freeze (PR #28202 review P2). *)
   let demote_quota_exhausted candidates =
-    Runtime_quota_window.demote_order
+    quota_ordered_runtime_ids
       (* NDT-OK: scheduling intentionally compares the stored expiry with
          wall clock; [demote_order] stays pure via injected [now]. *)
       ~now:(Unix.gettimeofday ())
-      ~quota_scope_of:Runtime.quota_scope_of_runtime_id
       candidates
   in
   let lane_id_opt, lane_candidate_ids =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -549,10 +549,10 @@ let run_named
      order passes through the sticky last-good preference so a known-healthy
      failover candidate is tried before re-hitting a dead head candidate. *)
   (* Quota-window demotion is ordering only — a demoted candidate is still
-     attempted when the lane has nothing else (RFC-0370 §3.3). It applies to
-     both candidate sources: the declared lane walk and a frozen deferred
-     suffix, whose next candidate may sit on an account whose window was
-     recorded after the freeze (PR #28202 review P2). *)
+     attempted when the lane has nothing else (RFC-0370 §3.3). Apply it while
+     selecting a fresh lane walk. A deferred suffix was already frozen before
+     pre-dispatch shaping, so re-reading wall-clock quota state here could make
+     the actual provider differ from the runtime used to shape the request. *)
   let demote_quota_exhausted candidates =
     quota_ordered_runtime_ids
       (* NDT-OK: scheduling intentionally compares the stored expiry with
@@ -563,7 +563,7 @@ let run_named
   let lane_id_opt, lane_candidate_ids =
     match deferred_runtime_lane with
     | Some hint ->
-      Some hint.assignment_id, demote_quota_exhausted (deferred_runtime_ids hint)
+      Some hint.assignment_id, deferred_runtime_ids hint
     | None ->
       (match Runtime.resolve_assignment runtime_id with
        | `Missing -> None, []

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -91,11 +91,23 @@ type deferred_runtime_lane =
 let deferred_runtime_ids hint =
   hint.next_runtime_id :: hint.later_runtime_ids
 
+(* Quota demotion must never promote a candidate the runtime table cannot
+   resolve (for example one removed by a runtime.toml reload while a deferred
+   suffix was frozen): a missing id at the head fails the attempt with a
+   non-rotating error before resolvable alternatives are tried. Order is
+   therefore resolvable-active, then resolvable-exhausted, then unresolvable —
+   declared relative order preserved within each class (PR #28219 review). *)
 let quota_ordered_runtime_ids ~now runtime_ids =
+  let resolvable, unresolvable =
+    List.partition
+      (fun id -> Option.is_some (Runtime.get_runtime_by_id id))
+      runtime_ids
+  in
   Runtime_quota_window.demote_order
     ~now
     ~quota_scope_of:Runtime.quota_scope_of_runtime_id
-    runtime_ids
+    resolvable
+  @ unresolvable
 ;;
 
 let quota_ordered_deferred_runtime_lane ~now hint =
@@ -205,6 +217,25 @@ let attempt_runtime_candidates
       fun candidate ->
         Runtime.quota_scope_of_runtime_id (runtime_id_of candidate)
   in
+  (* Mid-walk demotion shares the pre-walk rule: never move an
+     exhausted-but-resolvable candidate behind one the runtime table cannot
+     resolve, or the walk fails on the missing head with a non-rotating error
+     before real alternatives are tried (PR #28219 review). Candidates whose
+     id resolves keep quota ordering among themselves; unresolvable ones sink
+     to the tail in declared order. *)
+  let demote_rest rest =
+    let resolvable, unresolvable =
+      List.partition
+        (fun candidate ->
+          Option.is_some (Runtime.get_runtime_by_id (runtime_id_of candidate)))
+        rest
+    in
+    Runtime_quota_window.demote_order
+      ~now:(Unix.gettimeofday ())
+      ~quota_scope_of
+      resolvable
+    @ unresolvable
+  in
   let rec loop ~observed_overflow idx = function
     | [] ->
       (match observed_overflow with
@@ -278,12 +309,7 @@ let attempt_runtime_candidates
             that the shared account is exhausted.  This remains ordering,
             not admission: if every remaining candidate is demoted they are
             all still attempted in their prior relative order. *)
-         let rest =
-           Runtime_quota_window.demote_order
-             ~now:(Unix.gettimeofday ())
-             ~quota_scope_of
-             rest
-         in
+         let rest = demote_rest rest in
          let retry_admitted =
            allow_retry ~runtime_id:attempt_runtime_id ~attempt:idx error
          in

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -245,6 +245,19 @@ let attempt_runtime_candidates
                  ~resets_at:(Unix.gettimeofday () +. retry_after_s)
              | None -> ())
           | _ -> ());
+         (* The window just learned above must affect this same lane walk.
+            Otherwise a sibling on the same credential is retried before an
+            unrelated candidate even though the provider has already stated
+            that the shared account is exhausted.  This remains ordering,
+            not admission: if every remaining candidate is demoted they are
+            all still attempted in their prior relative order. *)
+         let rest =
+           Runtime_quota_window.demote_order
+             ~now:(Unix.gettimeofday ())
+             ~quota_scope_of:(fun candidate ->
+               Runtime.quota_scope_of_runtime_id (runtime_id_of candidate))
+             rest
+         in
          let retry_admitted =
            allow_retry ~runtime_id:attempt_runtime_id ~attempt:idx error
          in
@@ -623,7 +636,7 @@ let run_named
            match Runtime.get_runtime_by_id runtime_id with
            | Some runtime -> Resolved_runtime runtime
            | None -> Missing_runtime runtime_id)
-        (deferred_runtime_ids hint)
+        lane_candidate_ids
   in
   let assigned_runtime_context_window =
     Runtime.max_context_of_runtime first_candidate

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -193,6 +193,7 @@ let attempt_runtime_candidates
     ?lane_id
     ?(on_retry_deferred = fun _ -> ())
     ?quota_scope_of
+    ?candidate_dispatchable
     ~runtime_id ~runtime_id_of
     ~(emit_runtime_manifest :
        ?status:string ->
@@ -218,23 +219,32 @@ let attempt_runtime_candidates
         Runtime.quota_scope_of_runtime_id (runtime_id_of candidate)
   in
   (* Mid-walk demotion shares the pre-walk rule: never move an
-     exhausted-but-resolvable candidate behind one the runtime table cannot
-     resolve, or the walk fails on the missing head with a non-rotating error
-     before real alternatives are tried (PR #28219 review). Candidates whose
-     id resolves keep quota ordering among themselves; unresolvable ones sink
-     to the tail in declared order. *)
+     exhausted-but-dispatchable candidate behind one that cannot dispatch, or
+     the walk fails on the dead head with a non-rotating error before real
+     alternatives are tried (PR #28219 review). Dispatchability is judged on
+     the candidate value itself — production candidates are materialized
+     snapshots that stay dispatchable across a runtime.toml reload, so a
+     global-registry re-read here would wrongly sink a frozen [Resolved_runtime]
+     and promote a known-exhausted sibling ahead of it (PR #28219 review,
+     frozen-candidates thread). Callers with richer candidate types inject the
+     judgment; the id-table default serves plain-id callers, and a fixture-less
+     table judges everything undispatchable, which leaves order unchanged. *)
+  let candidate_dispatchable =
+    match candidate_dispatchable with
+    | Some candidate_dispatchable -> candidate_dispatchable
+    | None ->
+      fun candidate ->
+        Option.is_some (Runtime.get_runtime_by_id (runtime_id_of candidate))
+  in
   let demote_rest rest =
-    let resolvable, unresolvable =
-      List.partition
-        (fun candidate ->
-          Option.is_some (Runtime.get_runtime_by_id (runtime_id_of candidate)))
-        rest
+    let dispatchable, undispatchable =
+      List.partition candidate_dispatchable rest
     in
     Runtime_quota_window.demote_order
       ~now:(Unix.gettimeofday ())
       ~quota_scope_of
-      resolvable
-    @ unresolvable
+      dispatchable
+    @ undispatchable
   in
   let rec loop ~observed_overflow idx = function
     | [] ->
@@ -817,6 +827,12 @@ let run_named
     ~quota_scope_of:(function
       | Resolved_runtime runtime -> Some (Runtime.quota_scope_of_runtime runtime)
       | Missing_runtime _ -> None)
+    ~candidate_dispatchable:(function
+      (* A materialized snapshot stays dispatchable even if a runtime.toml
+         reload removed its id from the current table; only a candidate that
+         never resolved is a dead head. *)
+      | Resolved_runtime _ -> true
+      | Missing_runtime _ -> false)
     ~emit_runtime_manifest
     ~run_attempt:(fun ~idx:_ ~runtime_id:attempt_runtime_id candidate ->
       match candidate with

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -237,9 +237,9 @@ let attempt_runtime_candidates
                the row's quota scope: siblings sharing the credential are
                demoted together (PR #28202 review P2). *)
             (match Runtime.quota_scope_of_runtime_id attempt_runtime_id with
-             | Some provider_id ->
+             | Some scope ->
                Runtime_quota_window.note_exhausted
-                 ~provider_id
+                 ~scope
                  (* NDT-OK: [retry_after] is relative to the provider response;
                     convert it to the wall-clock expiry at this ingress. *)
                  ~resets_at:(Unix.gettimeofday () +. retry_after_s)

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -77,6 +77,12 @@ type deferred_runtime_lane = private
   }
 
 val deferred_runtime_ids : deferred_runtime_lane -> string list
+val quota_ordered_deferred_runtime_lane :
+  now:float -> deferred_runtime_lane -> deferred_runtime_lane
+(** Apply active quota-window ordering to a frozen deferred suffix while
+    preserving its assignment and failure evidence. Call once before building
+    pre-dispatch execution so prompt shaping and dispatch consume the same
+    selected runtime. *)
 val equal_deferred_runtime_lane :
   deferred_runtime_lane -> deferred_runtime_lane -> bool
 

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -240,6 +240,7 @@ module For_testing : sig
     ?lane_id:string ->
     ?on_retry_deferred:(deferred_runtime_lane -> unit) ->
     ?quota_scope_of:('candidate -> Runtime_quota_window.scope option) ->
+    ?candidate_dispatchable:('candidate -> bool) ->
     runtime_id:string ->
     runtime_id_of:('candidate -> string) ->
     emit_runtime_manifest:

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -239,6 +239,7 @@ module For_testing : sig
       (runtime_id:string -> attempt:int -> Agent_core.Error.t -> bool) ->
     ?lane_id:string ->
     ?on_retry_deferred:(deferred_runtime_lane -> unit) ->
+    ?quota_scope_of:('candidate -> Runtime_quota_window.scope option) ->
     runtime_id:string ->
     runtime_id_of:('candidate -> string) ->
     emit_runtime_manifest:

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -335,6 +335,15 @@ let run_keeper_cycle
      phases like Overflowed. *)
   let registry_base_path = config.base_path in
   let exact_failure_execution = ref None in
+  let deferred_runtime_lane =
+    Option.map
+      (Keeper_turn_driver.quota_ordered_deferred_runtime_lane
+         (* NDT-OK: quota expiry is wall-clock provider evidence. Freeze the
+            reordered typed hint once so pre-dispatch shaping and the driver
+            consume the same first runtime. *)
+         ~now:(Unix.gettimeofday ()))
+      deferred_runtime_lane
+  in
   (* Decide turn_id at function entry so phase-gate and runtime-routing
      terminal paths can include it in the receipt and observability stream. *)
   let keeper_turn_id = meta.runtime.usage.total_turns + 1 in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -335,13 +335,13 @@ let run_keeper_cycle
      phases like Overflowed. *)
   let registry_base_path = config.base_path in
   let exact_failure_execution = ref None in
+  (* Quota expiry is wall-clock provider evidence. Freeze this observation so
+     shaping and dispatch share one ordered runtime suffix. NDT-OK. *)
+  let quota_snapshot_now = Unix.gettimeofday () in
   let deferred_runtime_lane =
     Option.map
       (Keeper_turn_driver.quota_ordered_deferred_runtime_lane
-         (* NDT-OK: quota expiry is wall-clock provider evidence. Freeze the
-            reordered typed hint once so pre-dispatch shaping and the driver
-            consume the same first runtime. *)
-         ~now:(Unix.gettimeofday ()))
+         ~now:quota_snapshot_now)
       deferred_runtime_lane
   in
   (* Decide turn_id at function entry so phase-gate and runtime-routing

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1345,10 +1345,15 @@ let provider_id_of_runtime_id (id : string) : string option =
 let quota_scope_of_runtime_id (id : string) : Runtime_quota_window.scope option =
   match get_runtime_by_id id with
   | Some rt ->
+    let credential =
+      Runtime_adapter.effective_credential_reference
+        ~provider_id:rt.provider.id
+        rt.provider.credentials
+    in
     Some
       (Runtime_quota_window.scope_of_credential
          ~provider_id:rt.provider.id
-         rt.provider.credentials)
+         credential)
   | None -> None
 ;;
 

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -21,6 +21,10 @@ type t =
     (** Turn owner materialized at load time. HTTP bindings become
         [Agent_core]; official client runtimes remain distinct and can never
         be dispatched as a fake LLM provider config. *)
+  ; quota_scope : Runtime_quota_window.scope
+    (** Quota ownership key frozen at materialization, from the same
+        credential-alias selection that resolved the dispatched API key
+        (PR #28219 review). *)
   }
 
 (* id 파생의 단일 출처는 {!Runtime_schema.binding_key} — runtime 을 id 로
@@ -33,6 +37,30 @@ let id_of_binding (b : binding) : string = binding_key b
     제외)이되 왜 제외되는지 이유를 잃지 않는다. 이 이유는 assignment / default /
     task-route / lane 검증이 "not found" 대신 근본 원인을 표면화하는 데 쓰인다
     (Unknown→silent-drop 안티패턴 차단). *)
+(* Quota scope is frozen here, at materialization, from the same
+   credential-alias selection that resolves the dispatched API key. Deriving
+   it later would re-run alias selection against a possibly changed process
+   environment and charge the window to an account the dispatch never used
+   (PR #28219 review). *)
+let quota_scope_of_materialized
+    ~(provider : provider)
+    ~(execution : Runtime_execution.t) =
+  let credential =
+    match execution with
+    | Runtime_execution.Agent_core _ ->
+      Runtime_adapter.effective_credential_reference
+        ~provider_id:provider.id
+        provider.credentials
+    | Runtime_execution.Antigravity_cli _ -> provider.credentials
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _ ->
+      (* Official clients own subscription login. A registry API-key default
+         with the same provider label is a different account authority. *)
+      None
+  in
+  Runtime_quota_window.scope_of_credential ~provider_id:provider.id credential
+;;
+
 let of_binding_result (cfg : config) (b : binding) : (t, string) result =
   if not b.enabled
   then Error "binding is disabled by runtime.toml"
@@ -43,7 +71,14 @@ let of_binding_result (cfg : config) (b : binding) : (t, string) result =
     else
       (match Runtime_adapter.binding_to_execution cfg b with
        | Ok execution ->
-         Ok { id = id_of_binding b; provider; model; binding = b; execution }
+         Ok
+           { id = id_of_binding b
+           ; provider
+           ; model
+           ; binding = b
+           ; execution
+           ; quota_scope = quota_scope_of_materialized ~provider ~execution
+           }
        | Error reason -> Error reason)
   | None, _ -> Error (Printf.sprintf "provider not found: %s" b.provider_id)
   | Some _, None -> Error (Printf.sprintf "model not found: %s" b.model_id)
@@ -1342,23 +1377,11 @@ let provider_id_of_runtime_id (id : string) : string option =
   | None -> None
 ;;
 
+(* Reads the scope frozen at materialization ({!of_binding_result}); no
+   environment access here, so a post-load env change cannot re-select the
+   credential alias out from under the recorded window. *)
 let quota_scope_of_runtime (rt : t) : Runtime_quota_window.scope =
-  let credential =
-    match rt.execution with
-    | Runtime_execution.Agent_core _ ->
-      Runtime_adapter.effective_credential_reference
-        ~provider_id:rt.provider.id
-        rt.provider.credentials
-    | Runtime_execution.Antigravity_cli _ -> rt.provider.credentials
-    | Runtime_execution.Codex_app_server _
-    | Runtime_execution.Claude_code _ ->
-      (* Official clients own subscription login. A registry API-key default
-         with the same provider label is a different account authority. *)
-      None
-  in
-  Runtime_quota_window.scope_of_credential
-    ~provider_id:rt.provider.id
-    credential
+  rt.quota_scope
 ;;
 
 let quota_scope_of_runtime_id (id : string) : Runtime_quota_window.scope option =

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1342,6 +1342,16 @@ let provider_id_of_runtime_id (id : string) : string option =
   | None -> None
 ;;
 
+let quota_scope_of_runtime_id (id : string) : string option =
+  match get_runtime_by_id id with
+  | Some rt ->
+    Some
+      (Runtime_quota_window.scope_of_credential
+         ~provider_id:rt.provider.id
+         rt.provider.credentials)
+  | None -> None
+;;
+
 let max_prompt_bytes_of_runtime_id (id : string) : int option =
   match get_runtime_by_id id with
   | Some rt -> rt.model.max_prompt_bytes

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1342,7 +1342,7 @@ let provider_id_of_runtime_id (id : string) : string option =
   | None -> None
 ;;
 
-let quota_scope_of_runtime_id (id : string) : string option =
+let quota_scope_of_runtime_id (id : string) : Runtime_quota_window.scope option =
   match get_runtime_by_id id with
   | Some rt ->
     Some

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1346,9 +1346,17 @@ let quota_scope_of_runtime_id (id : string) : Runtime_quota_window.scope option 
   match get_runtime_by_id id with
   | Some rt ->
     let credential =
-      Runtime_adapter.effective_credential_reference
-        ~provider_id:rt.provider.id
-        rt.provider.credentials
+      match rt.execution with
+      | Runtime_execution.Agent_core _ ->
+        Runtime_adapter.effective_credential_reference
+          ~provider_id:rt.provider.id
+          rt.provider.credentials
+      | Runtime_execution.Antigravity_cli _ -> rt.provider.credentials
+      | Runtime_execution.Codex_app_server _
+      | Runtime_execution.Claude_code _ ->
+        (* Official clients own subscription login. A registry API-key default
+           with the same provider label is a different account authority. *)
+        None
     in
     Some
       (Runtime_quota_window.scope_of_credential

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1342,26 +1342,28 @@ let provider_id_of_runtime_id (id : string) : string option =
   | None -> None
 ;;
 
+let quota_scope_of_runtime (rt : t) : Runtime_quota_window.scope =
+  let credential =
+    match rt.execution with
+    | Runtime_execution.Agent_core _ ->
+      Runtime_adapter.effective_credential_reference
+        ~provider_id:rt.provider.id
+        rt.provider.credentials
+    | Runtime_execution.Antigravity_cli _ -> rt.provider.credentials
+    | Runtime_execution.Codex_app_server _
+    | Runtime_execution.Claude_code _ ->
+      (* Official clients own subscription login. A registry API-key default
+         with the same provider label is a different account authority. *)
+      None
+  in
+  Runtime_quota_window.scope_of_credential
+    ~provider_id:rt.provider.id
+    credential
+;;
+
 let quota_scope_of_runtime_id (id : string) : Runtime_quota_window.scope option =
   match get_runtime_by_id id with
-  | Some rt ->
-    let credential =
-      match rt.execution with
-      | Runtime_execution.Agent_core _ ->
-        Runtime_adapter.effective_credential_reference
-          ~provider_id:rt.provider.id
-          rt.provider.credentials
-      | Runtime_execution.Antigravity_cli _ -> rt.provider.credentials
-      | Runtime_execution.Codex_app_server _
-      | Runtime_execution.Claude_code _ ->
-        (* Official clients own subscription login. A registry API-key default
-           with the same provider label is a different account authority. *)
-        None
-    in
-    Some
-      (Runtime_quota_window.scope_of_credential
-         ~provider_id:rt.provider.id
-         credential)
+  | Some rt -> Some (quota_scope_of_runtime rt)
   | None -> None
 ;;
 

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -13,6 +13,12 @@ type t =
   ; model : model_spec
   ; binding : binding
   ; execution : Runtime_execution.t
+  ; quota_scope : Runtime_quota_window.scope
+    (** Quota ownership key frozen at materialization, from the same
+        credential-alias selection that resolved the dispatched API key. A
+        later environment change must not re-select the alias at
+        window-recording time, or the window is charged to an account the
+        dispatch never used (PR #28219 review). *)
   }
 
 val id_of_binding : binding -> string

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -365,9 +365,15 @@ val turn_timeout_s_of_runtime_id : string -> float option
 
 val provider_id_of_runtime_id : string -> string option
 (** Owning provider id ([providers.<id>] in runtime.toml) of the runtime with
-    this binding-key id, or [None] when the runtime id is unknown. Consumed by
-    {!Runtime_quota_window.demote_order} so lane ordering can act on
-    account-scoped provider quota windows. *)
+    this binding-key id, or [None] when the runtime id is unknown. *)
+
+val quota_scope_of_runtime_id : string -> string option
+(** Non-secret quota-scope identity of the runtime's provider
+    ({!Runtime_quota_window.scope_of_credential}): rows sharing one
+    credential account share one scope, so an exhausted window recorded on
+    one row demotes every sibling backed by the same account. [None] when
+    the runtime id is unknown. Consumed by
+    {!Runtime_quota_window.demote_order} and the matching note site. *)
 
 val max_prompt_bytes_of_runtime_id : string -> int option
 (** Declared [max-prompt-bytes] for the model bound to this runtime id, or

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -367,7 +367,7 @@ val provider_id_of_runtime_id : string -> string option
 (** Owning provider id ([providers.<id>] in runtime.toml) of the runtime with
     this binding-key id, or [None] when the runtime id is unknown. *)
 
-val quota_scope_of_runtime_id : string -> string option
+val quota_scope_of_runtime_id : string -> Runtime_quota_window.scope option
 (** Non-secret quota-scope identity of the runtime's provider
     ({!Runtime_quota_window.scope_of_credential}): rows sharing one
     credential account share one scope, so an exhausted window recorded on

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -367,6 +367,11 @@ val provider_id_of_runtime_id : string -> string option
 (** Owning provider id ([providers.<id>] in runtime.toml) of the runtime with
     this binding-key id, or [None] when the runtime id is unknown. *)
 
+val quota_scope_of_runtime : t -> Runtime_quota_window.scope
+(** Non-secret quota-scope identity derived from this resolved runtime
+    snapshot.  Use this form across a provider call so a concurrent catalog
+    reload cannot rebind the response to a different credential account. *)
+
 val quota_scope_of_runtime_id : string -> Runtime_quota_window.scope option
 (** Non-secret quota-scope identity of the runtime's provider
     ({!Runtime_quota_window.scope_of_credential}): rows sharing one

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -133,6 +133,19 @@ let find_registry_entry (provider_id : string)
      | None -> None)
 ;;
 
+let effective_credential_reference
+    ~(provider_id : string)
+    (credential : Runtime_schema.credential option) =
+  match credential with
+  | Some _ as explicit -> explicit
+  | None ->
+    (match find_registry_entry provider_id with
+     | Some entry ->
+       let env = entry.Llm_provider.Provider_registry.defaults.api_key_env in
+       if String.trim env = "" then None else Some (Runtime_schema.Env env)
+     | None -> None)
+;;
+
 (* --- Credential materialization --- *)
 
 let credential_env_candidates = function

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -133,19 +133,6 @@ let find_registry_entry (provider_id : string)
      | None -> None)
 ;;
 
-let effective_credential_reference
-    ~(provider_id : string)
-    (credential : Runtime_schema.credential option) =
-  match credential with
-  | Some _ as explicit -> explicit
-  | None ->
-    (match find_registry_entry provider_id with
-     | Some entry ->
-       let env = entry.Llm_provider.Provider_registry.defaults.api_key_env in
-       if String.trim env = "" then None else Some (Runtime_schema.Env env)
-     | None -> None)
-;;
-
 (* --- Credential materialization --- *)
 
 let credential_env_candidates = function
@@ -153,12 +140,35 @@ let credential_env_candidates = function
   | key -> [ key ]
 ;;
 
-let api_key_from_env key =
+let selected_credential_env key =
   credential_env_candidates key
-  |> List.find_map (fun env ->
-         match Sys.getenv_opt env with
-         | Some value when String.trim value <> "" -> Some value
-         | _ -> None)
+  |> List.find_opt (fun env ->
+    match Sys.getenv_opt env with
+    | Some value -> String.trim value <> ""
+    | None -> false)
+;;
+
+let effective_credential_reference
+    ~(provider_id : string)
+    (credential : Runtime_schema.credential option) =
+  let select_env key =
+    Runtime_schema.Env (Option.value ~default:key (selected_credential_env key))
+  in
+  match credential with
+  | Some (Runtime_schema.Env key) -> Some (select_env key)
+  | Some (Runtime_schema.File _ | Runtime_schema.Inline _) as explicit -> explicit
+  | None ->
+    (match find_registry_entry provider_id with
+     | Some entry ->
+       let env = entry.Llm_provider.Provider_registry.defaults.api_key_env in
+       if String.trim env = "" then None else Some (select_env env)
+     | None -> None)
+;;
+
+let api_key_from_env key =
+  (match selected_credential_env key with
+   | Some env -> Sys.getenv_opt env
+   | None -> None)
   |> Option.value ~default:""
 ;;
 

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -152,7 +152,9 @@ let effective_credential_reference
     ~(provider_id : string)
     (credential : Runtime_schema.credential option) =
   let select_env key =
-    Runtime_schema.Env (Option.value ~default:key (selected_credential_env key))
+    match selected_credential_env key with
+    | Some selected -> Runtime_schema.Env selected
+    | None -> Runtime_schema.Env key
   in
   match credential with
   | Some (Runtime_schema.Env key) -> Some (select_env key)

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -21,8 +21,9 @@ val effective_credential_reference :
   Runtime_schema.credential option
 (** Return the explicit credential reference, or the provider registry's
     declared default environment reference when the runtime row omits one.
-    The fallback path is metadata only: it never reads the process environment
-    or credential files.  Explicit credentials are preserved unchanged.
+    Environment aliases follow the same candidate selection as API-key
+    materialization, so the returned non-secret reference names the credential
+    that was actually selected. File and inline references are preserved.
     An unregistered provider with no explicit credential remains [None]. *)
 
 val binding_to_provider_config

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -15,6 +15,16 @@
     Matching is case-insensitive on the trimmed key. *)
 val is_auth_header_key : string -> bool
 
+val effective_credential_reference :
+  provider_id:string ->
+  Runtime_schema.credential option ->
+  Runtime_schema.credential option
+(** Return the explicit credential reference, or the provider registry's
+    declared default environment reference when the runtime row omits one.
+    The fallback path is metadata only: it never reads the process environment
+    or credential files.  Explicit credentials are preserved unchanged.
+    An unregistered provider with no explicit credential remains [None]. *)
+
 val binding_to_provider_config
   :  Runtime_schema.config
   -> Runtime_schema.binding

--- a/lib/runtime/runtime_quota_window.ml
+++ b/lib/runtime/runtime_quota_window.ml
@@ -35,24 +35,15 @@ let active_until ~scope ~now =
       end)
 
 let demote_order ~now ~quota_scope_of candidates =
-  let demoted =
-    List.filter
+  let kept, demoted =
+    List.partition
       (fun candidate ->
         match quota_scope_of candidate with
-        | None -> false
-        | Some scope -> Option.is_some (active_until ~scope ~now))
+        | None -> true
+        | Some scope -> Option.is_none (active_until ~scope ~now))
       candidates
   in
-  match demoted with
-  | [] -> candidates
-  | _ ->
-    let kept =
-      List.filter
-        (fun candidate ->
-          not (List.exists (String.equal candidate) demoted))
-        candidates
-    in
-    kept @ demoted
+  match demoted with [] -> candidates | _ -> kept @ demoted
 
 let scope_of_credential ~provider_id (credential : Runtime_schema.credential option) =
   match credential with

--- a/lib/runtime/runtime_quota_window.ml
+++ b/lib/runtime/runtime_quota_window.ml
@@ -8,24 +8,29 @@
       passed windows.  [now] is a parameter rather than a wall-clock read
       so the ordering decision is testable without stubbing time. *)
 
-let windows : (string, float) Hashtbl.t = Hashtbl.create 4
+type scope =
+  | Provider_row of string
+  | Credential_env of string
+  | Credential_file of string
+
+let windows : (scope, float) Hashtbl.t = Hashtbl.create 4
 let mu = Stdlib.Mutex.create ()
 
-let note_exhausted ~provider_id ~resets_at =
+let note_exhausted ~scope ~resets_at =
   Stdlib.Mutex.protect mu (fun () ->
-    match Hashtbl.find_opt windows provider_id with
+    match Hashtbl.find_opt windows scope with
     | Some existing when Float.compare existing resets_at >= 0 -> ()
-    | Some _ | None -> Hashtbl.replace windows provider_id resets_at)
+    | Some _ | None -> Hashtbl.replace windows scope resets_at)
 
-let active_until ~provider_id ~now =
+let active_until ~scope ~now =
   Stdlib.Mutex.protect mu (fun () ->
-    match Hashtbl.find_opt windows provider_id with
+    match Hashtbl.find_opt windows scope with
     | None -> None
     | Some resets_at ->
       if Float.compare now resets_at < 0
       then Some resets_at
       else begin
-        Hashtbl.remove windows provider_id;
+        Hashtbl.remove windows scope;
         None
       end)
 
@@ -35,8 +40,7 @@ let demote_order ~now ~quota_scope_of candidates =
       (fun candidate ->
         match quota_scope_of candidate with
         | None -> false
-        | Some provider_id ->
-          Option.is_some (active_until ~provider_id ~now))
+        | Some scope -> Option.is_some (active_until ~scope ~now))
       candidates
   in
   match demoted with
@@ -52,11 +56,11 @@ let demote_order ~now ~quota_scope_of candidates =
 
 let scope_of_credential ~provider_id (credential : Runtime_schema.credential option) =
   match credential with
-  | Some (Runtime_schema.Env key) -> "env:" ^ key
-  | Some (Runtime_schema.File path) -> "file:" ^ path
+  | Some (Runtime_schema.Env key) -> Credential_env key
+  | Some (Runtime_schema.File path) -> Credential_file path
   (* The inline carrier is the secret itself, so it cannot name a shared
      account without leaking; the row id is the narrowest honest scope. *)
-  | Some (Runtime_schema.Inline _) | None -> provider_id
+  | Some (Runtime_schema.Inline _) | None -> Provider_row provider_id
 
 let reset_for_testing () =
   Stdlib.Mutex.protect mu (fun () -> Hashtbl.reset windows)

--- a/lib/runtime/runtime_quota_window.ml
+++ b/lib/runtime/runtime_quota_window.ml
@@ -29,11 +29,11 @@ let active_until ~provider_id ~now =
         None
       end)
 
-let demote_order ~now ~provider_id_of candidates =
+let demote_order ~now ~quota_scope_of candidates =
   let demoted =
     List.filter
       (fun candidate ->
-        match provider_id_of candidate with
+        match quota_scope_of candidate with
         | None -> false
         | Some provider_id ->
           Option.is_some (active_until ~provider_id ~now))
@@ -49,6 +49,14 @@ let demote_order ~now ~provider_id_of candidates =
         candidates
     in
     kept @ demoted
+
+let scope_of_credential ~provider_id (credential : Runtime_schema.credential option) =
+  match credential with
+  | Some (Runtime_schema.Env key) -> "env:" ^ key
+  | Some (Runtime_schema.File path) -> "file:" ^ path
+  (* The inline carrier is the secret itself, so it cannot name a shared
+     account without leaking; the row id is the narrowest honest scope. *)
+  | Some (Runtime_schema.Inline _) | None -> provider_id
 
 let reset_for_testing () =
   Stdlib.Mutex.protect mu (fun () -> Hashtbl.reset windows)

--- a/lib/runtime/runtime_quota_window.mli
+++ b/lib/runtime/runtime_quota_window.mli
@@ -20,21 +20,26 @@
     lazily on read; there is no background sweeper and no TTL knob.
     RFC-0370 §3.3. *)
 
-val note_exhausted : provider_id:string -> resets_at:float -> unit
-(** Remember that [provider_id]'s quota window is exhausted until
+type scope
+(** A non-secret quota ownership key.  The representation is deliberately
+    abstract so provider row ids, environment references, and file references
+    cannot be mixed accidentally at call sites. *)
+
+val note_exhausted : scope:scope -> resets_at:float -> unit
+(** Remember that [scope]'s quota window is exhausted until
     [resets_at] (Unix epoch seconds).  A later [resets_at] for the same
-    provider extends the window; an earlier one is ignored so a stale
+    scope extends the window; an earlier one is ignored so a stale
     retry hint cannot shorten a window a fresher response already
     established. *)
 
-val active_until : provider_id:string -> now:float -> float option
-(** [Some resets_at] when [provider_id] has a recorded window that has not
+val active_until : scope:scope -> now:float -> float option
+(** [Some resets_at] when [scope] has a recorded window that has not
     yet passed at [now]; [None] otherwise.  Expired entries are pruned on
     read. *)
 
 val demote_order :
   now:float ->
-  quota_scope_of:(string -> string option) ->
+  quota_scope_of:(string -> scope option) ->
   string list ->
   string list
 (** Stable-partition [candidates]: those whose quota scope (via
@@ -45,11 +50,12 @@ val demote_order :
     input unchanged when no candidate is demoted. *)
 
 val scope_of_credential :
-  provider_id:string -> Runtime_schema.credential option -> string
+  provider_id:string -> Runtime_schema.credential option -> scope
 (** Non-secret quota-scope identity for a provider row.  Provider hard quota
     is credential-account-owned, not provider-row-owned: two rows sharing one
     credential share one window (PR #28202 review).  [Env]/[File] carriers
-    are named by their non-secret reference ("env:KEY" / "file:PATH");
+    are keyed by their non-secret reference without encoding the carrier kind
+    into a string prefix;
     [Inline] carries the secret itself, so it cannot serve as a shared name
     and falls back to the row's [provider_id], as does an absent
     credential. *)

--- a/lib/runtime/runtime_quota_window.mli
+++ b/lib/runtime/runtime_quota_window.mli
@@ -34,15 +34,25 @@ val active_until : provider_id:string -> now:float -> float option
 
 val demote_order :
   now:float ->
-  provider_id_of:(string -> string option) ->
+  quota_scope_of:(string -> string option) ->
   string list ->
   string list
-(** Stable-partition [candidates]: those whose provider (via
-    [provider_id_of]) has an active window at [now] move to the tail,
+(** Stable-partition [candidates]: those whose quota scope (via
+    [quota_scope_of]) has an active window at [now] move to the tail,
     preserving declared relative order within both partitions.  Candidates
-    whose provider is unknown ([provider_id_of] returns [None]) are left in
+    whose scope is unknown ([quota_scope_of] returns [None]) are left in
     place — an unresolved id is not evidence of exhaustion.  Returns the
     input unchanged when no candidate is demoted. *)
+
+val scope_of_credential :
+  provider_id:string -> Runtime_schema.credential option -> string
+(** Non-secret quota-scope identity for a provider row.  Provider hard quota
+    is credential-account-owned, not provider-row-owned: two rows sharing one
+    credential share one window (PR #28202 review).  [Env]/[File] carriers
+    are named by their non-secret reference ("env:KEY" / "file:PATH");
+    [Inline] carries the secret itself, so it cannot serve as a shared name
+    and falls back to the row's [provider_id], as does an absent
+    credential. *)
 
 val reset_for_testing : unit -> unit
 (** Drop every remembered window.  Test-only. *)

--- a/lib/runtime/runtime_quota_window.mli
+++ b/lib/runtime/runtime_quota_window.mli
@@ -39,9 +39,9 @@ val active_until : scope:scope -> now:float -> float option
 
 val demote_order :
   now:float ->
-  quota_scope_of:(string -> scope option) ->
-  string list ->
-  string list
+  quota_scope_of:('a -> scope option) ->
+  'a list ->
+  'a list
 (** Stable-partition [candidates]: those whose quota scope (via
     [quota_scope_of]) has an active window at [now] move to the tail,
     preserving declared relative order within both partitions.  Candidates

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -138,8 +138,9 @@ max-concurrent = 1
 max-request-body-bytes = 65536
 |}
 
-let runtime_toml_quota_lane =
-  {|
+let runtime_toml_quota_lane_with_shared_credential shared_credential =
+  Printf.sprintf
+    {|
 [runtime]
 default = "shared_a.test_model"
 
@@ -154,7 +155,7 @@ endpoint = "http://127.0.0.1:1"
 
 [providers.shared_a.credentials]
 type = "env"
-key = "SHARED_QUOTA_TEST_KEY"
+key = %S
 
 [providers.shared_b]
 display-name = "Shared account B"
@@ -163,7 +164,7 @@ endpoint = "http://127.0.0.1:2"
 
 [providers.shared_b.credentials]
 type = "env"
-key = "SHARED_QUOTA_TEST_KEY"
+key = %S
 
 [providers.other]
 display-name = "Other account"
@@ -190,6 +191,13 @@ max-request-body-bytes = 65536
 [other.test_model]
 max-request-body-bytes = 65536
 |}
+    shared_credential
+    shared_credential
+;;
+
+let runtime_toml_quota_lane =
+  runtime_toml_quota_lane_with_shared_credential "SHARED_QUOTA_TEST_KEY"
+;;
 
 let runtime_toml_official_provider_named_like_registry =
   {|
@@ -429,6 +437,18 @@ let with_runtime_config toml f =
        match Runtime.init_default ~config_path:path with
        | Ok () -> f ()
        | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e)
+
+let reload_runtime_config toml =
+  let path = Filename.temp_file "runtime_failover_reload_" ".toml" in
+  Fun.protect
+    ~finally:(fun () ->
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+       write_file path toml;
+       match Runtime.init_default ~config_path:path with
+       | Ok () -> ()
+       | Error e -> Alcotest.failf "Runtime.init_default reload failed: %s" e)
 
 let test_lane_loads_ordered_candidates () =
   with_runtime_config runtime_toml_with_lane (fun () ->
@@ -1482,6 +1502,59 @@ let test_attempt_loop_reorders_shared_quota_sibling_same_turn () =
            [ "shared_a.test_model"; "other.test_model" ]
            !attempts))
 
+let test_attempt_quota_scope_survives_runtime_reload () =
+  with_runtime_config runtime_toml_quota_lane (fun () ->
+    Runtime_quota_window.reset_for_testing ();
+    Fun.protect
+      ~finally:Runtime_quota_window.reset_for_testing
+      (fun () ->
+         let attempted_runtime =
+           Option.get (Runtime.get_runtime_by_id "shared_a.test_model")
+         in
+         let attempted_scope = Runtime.quota_scope_of_runtime attempted_runtime in
+         let result =
+           Driver.For_testing.attempt_runtime_candidates
+             ~runtime_id:"quota_lane"
+             ~runtime_id_of:(fun (runtime : Runtime.t) -> runtime.id)
+             ~quota_scope_of:(fun runtime ->
+               Some (Runtime.quota_scope_of_runtime runtime))
+             ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
+             ~run_attempt:(fun ~idx:_ ~runtime_id:_ _candidate ->
+               reload_runtime_config
+                 (runtime_toml_quota_lane_with_shared_credential
+                    "REBOUND_QUOTA_TEST_KEY");
+               attempt_without_effect
+                 (Error
+                    (Agent_core.Error.Provider
+                       (Llm_provider.Error.HardQuota
+                          { provider = "shared_a"
+                          ; retry_after = Some 300.0
+                          ; detail = "old account quota exhausted"
+                          })))
+                 None)
+             [ attempted_runtime ]
+         in
+         (match result with
+          | Error (Agent_core.Error.Provider (Llm_provider.Error.HardQuota _)) -> ()
+          | Error error ->
+            Alcotest.failf
+              "expected hard-quota result, got %s"
+              (Agent_core.Error.to_string error)
+          | Ok _ -> Alcotest.fail "hard-quota attempt unexpectedly succeeded");
+         let rebound_scope =
+           Option.get (Runtime.quota_scope_of_runtime_id "shared_a.test_model")
+         in
+         let now = Unix.gettimeofday () in
+         Alcotest.(check bool)
+           "response remains attributed to attempted credential"
+           true
+           (Option.is_some
+              (Runtime_quota_window.active_until ~scope:attempted_scope ~now));
+         Alcotest.(check (option (float 0.0)))
+           "replacement credential is not charged for old response"
+           None
+           (Runtime_quota_window.active_until ~scope:rebound_scope ~now)))
+
 let test_deferred_quota_order_is_frozen_before_predispatch () =
   with_runtime_config runtime_toml_quota_lane (fun () ->
     Runtime_quota_window.reset_for_testing ();
@@ -2185,6 +2258,10 @@ let () =
             "hard quota reorders shared sibling in same turn"
             `Quick
             test_attempt_loop_reorders_shared_quota_sibling_same_turn;
+          Alcotest.test_case
+            "hard quota keeps attempted scope across runtime reload"
+            `Quick
+            test_attempt_quota_scope_survives_runtime_reload;
           Alcotest.test_case
             "deferred quota order is frozen before pre-dispatch"
             `Quick

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -138,6 +138,56 @@ max-concurrent = 1
 max-request-body-bytes = 65536
 |}
 
+let runtime_toml_quota_lane =
+  {|
+[runtime]
+default = "shared_a.test_model"
+
+[runtime.lanes.quota_lane]
+strategy = "ordered"
+candidates = [ "shared_a.test_model", "shared_b.test_model", "other.test_model" ]
+
+[providers.shared_a]
+display-name = "Shared account A"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[providers.shared_a.credentials]
+type = "env"
+key = "SHARED_QUOTA_TEST_KEY"
+
+[providers.shared_b]
+display-name = "Shared account B"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:2"
+
+[providers.shared_b.credentials]
+type = "env"
+key = "SHARED_QUOTA_TEST_KEY"
+
+[providers.other]
+display-name = "Other account"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:3"
+
+[providers.other.credentials]
+type = "env"
+key = "OTHER_QUOTA_TEST_KEY"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[shared_a.test_model]
+is-default = true
+
+[shared_b.test_model]
+
+[other.test_model]
+|}
+
 let runtime_toml_checkpoint_lane =
   {|
 [runtime]
@@ -1365,6 +1415,53 @@ let test_attempt_loop_does_not_gate_network_retry () =
     4
     (List.length !events)
 
+let test_attempt_loop_reorders_shared_quota_sibling_same_turn () =
+  with_runtime_config runtime_toml_quota_lane (fun () ->
+    Runtime_quota_window.reset_for_testing ();
+    Fun.protect
+      ~finally:Runtime_quota_window.reset_for_testing
+      (fun () ->
+         let attempts = ref [] in
+         let result =
+           Driver.For_testing.attempt_runtime_candidates
+             ~runtime_id:"quota_lane"
+             ~runtime_id_of:Fun.id
+             ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
+             ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
+               attempts := !attempts @ [ runtime_id ];
+               match runtime_id with
+               | "shared_a.test_model" ->
+                 attempt_without_effect
+                   (Error
+                      (Agent_core.Error.Provider
+                         (Llm_provider.Error.HardQuota
+                            { provider = "shared_a"
+                            ; retry_after = Some 300.0
+                            ; detail = "account quota exhausted"
+                            })))
+                   None
+               | "other.test_model" -> attempt_without_effect (Ok runtime_id) None
+               | "shared_b.test_model" ->
+                 Alcotest.fail
+                   "same-credential sibling must move behind the unrelated account"
+               | other -> Alcotest.failf "unexpected candidate %s" other)
+             [ "shared_a.test_model"; "shared_b.test_model"; "other.test_model" ]
+         in
+         (match result with
+          | Ok runtime_id ->
+            Alcotest.(check string)
+              "unrelated account serves the turn"
+              "other.test_model"
+              runtime_id
+          | Error error ->
+            Alcotest.failf
+              "expected unrelated fallback success: %s"
+              (Agent_core.Error.to_string error));
+         Alcotest.(check (list string))
+           "new quota window reorders the remaining walk immediately"
+           [ "shared_a.test_model"; "other.test_model" ]
+           !attempts))
+
 let test_typed_checkpoint_is_the_same_run_retry_authority () =
   let stages =
     [ Agent_core.Agent.After_assistant_collected
@@ -1945,6 +2042,10 @@ let () =
             "attempt loop does not gate network retry"
             `Quick
             test_attempt_loop_does_not_gate_network_retry;
+          Alcotest.test_case
+            "hard quota reorders shared sibling in same turn"
+            `Quick
+            test_attempt_loop_reorders_shared_quota_sibling_same_turn;
           Alcotest.test_case
             "typed checkpoint is same-run retry authority"
             `Quick

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -188,6 +188,23 @@ is-default = true
 [other.test_model]
 |}
 
+let runtime_toml_official_provider_named_like_registry =
+  {|
+[runtime]
+default = "openai.official_model"
+
+[providers.openai]
+protocol = "codex-app-server"
+command = "/definitely/missing/masc-codex-app-server"
+is-non-interactive = true
+
+[models.official_model]
+api-name = "gpt-fixture"
+max-context = 400000
+
+[openai.official_model]
+|}
+
 let runtime_toml_checkpoint_lane =
   {|
 [runtime]
@@ -1462,6 +1479,62 @@ let test_attempt_loop_reorders_shared_quota_sibling_same_turn () =
            [ "shared_a.test_model"; "other.test_model" ]
            !attempts))
 
+let test_deferred_quota_order_is_frozen_before_predispatch () =
+  with_runtime_config runtime_toml_quota_lane (fun () ->
+    Runtime_quota_window.reset_for_testing ();
+    Fun.protect
+      ~finally:Runtime_quota_window.reset_for_testing
+      (fun () ->
+         let shared_scope =
+           Option.get (Runtime.quota_scope_of_runtime_id "shared_a.test_model")
+         in
+         Runtime_quota_window.note_exhausted
+           ~scope:shared_scope
+           ~resets_at:500.0;
+         let hint =
+           Driver.For_testing.make_deferred_runtime_lane
+             ~assignment_id:"quota_lane"
+             ~failed_runtime_id:"previous.test_model"
+             ~next_runtime_id:"shared_a.test_model"
+             ~later_runtime_ids:
+               [ "shared_b.test_model"; "other.test_model" ]
+             ~failure:(retryable_network_error "previous cycle failed")
+         in
+         let ordered =
+           Driver.quota_ordered_deferred_runtime_lane ~now:100.0 hint
+         in
+         Alcotest.(check (list string))
+           "pre-dispatch and driver share the same reordered suffix"
+           [ "other.test_model"
+           ; "shared_a.test_model"
+           ; "shared_b.test_model"
+           ]
+           (Driver.deferred_runtime_ids ordered)))
+
+let test_official_client_does_not_inherit_registry_api_key_scope () =
+  with_runtime_config runtime_toml_official_provider_named_like_registry (fun () ->
+    Runtime_quota_window.reset_for_testing ();
+    Fun.protect
+      ~finally:Runtime_quota_window.reset_for_testing
+      (fun () ->
+         let official_scope =
+           Option.get (Runtime.quota_scope_of_runtime_id "openai.official_model")
+         in
+         let registry_api_key_scope =
+           Runtime_quota_window.scope_of_credential
+             ~provider_id:"openai"
+             (Some (Runtime_schema.Env "OPENAI_API_KEY"))
+         in
+         Runtime_quota_window.note_exhausted
+           ~scope:official_scope
+           ~resets_at:500.0;
+         Alcotest.(check (option (float 0.0)))
+           "subscription quota does not demote an API-key account"
+           None
+           (Runtime_quota_window.active_until
+              ~scope:registry_api_key_scope
+              ~now:100.0)))
+
 let test_typed_checkpoint_is_the_same_run_retry_authority () =
   let stages =
     [ Agent_core.Agent.After_assistant_collected
@@ -2046,6 +2119,14 @@ let () =
             "hard quota reorders shared sibling in same turn"
             `Quick
             test_attempt_loop_reorders_shared_quota_sibling_same_turn;
+          Alcotest.test_case
+            "deferred quota order is frozen before pre-dispatch"
+            `Quick
+            test_deferred_quota_order_is_frozen_before_predispatch;
+          Alcotest.test_case
+            "official client quota excludes registry API-key scope"
+            `Quick
+            test_official_client_does_not_inherit_registry_api_key_scope;
           Alcotest.test_case
             "typed checkpoint is same-run retry authority"
             `Quick

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -182,10 +182,13 @@ streaming = true
 
 [shared_a.test_model]
 is-default = true
+max-request-body-bytes = 65536
 
 [shared_b.test_model]
+max-request-body-bytes = 65536
 
 [other.test_model]
+max-request-body-bytes = 65536
 |}
 
 let runtime_toml_official_provider_named_like_registry =
@@ -1511,6 +1514,69 @@ let test_deferred_quota_order_is_frozen_before_predispatch () =
            ]
            (Driver.deferred_runtime_ids ordered)))
 
+let test_deferred_dispatch_preserves_predispatch_quota_order () =
+  with_runtime_config runtime_toml_quota_lane (fun () ->
+    Runtime_quota_window.reset_for_testing ();
+    Fun.protect
+      ~finally:Runtime_quota_window.reset_for_testing
+      (fun () ->
+         let hint =
+           Driver.For_testing.make_deferred_runtime_lane
+             ~assignment_id:"quota_lane"
+             ~failed_runtime_id:"previous.test_model"
+             ~next_runtime_id:"shared_a.test_model"
+             ~later_runtime_ids:
+               [ "shared_b.test_model"; "other.test_model" ]
+             ~failure:(retryable_network_error "previous cycle failed")
+         in
+         let frozen =
+           Driver.quota_ordered_deferred_runtime_lane
+             ~now:(Unix.gettimeofday ())
+             hint
+         in
+         let shared_scope =
+           Option.get (Runtime.quota_scope_of_runtime_id "shared_a.test_model")
+         in
+         Runtime_quota_window.note_exhausted
+           ~scope:shared_scope
+           ~resets_at:(Unix.gettimeofday () +. 300.0);
+         Eio_main.run
+         @@ fun env ->
+         Eio.Switch.run
+         @@ fun sw ->
+         Masc_test_deps.init_eio_clock ~sw env;
+         let transformed_urls = ref [] in
+         let result =
+           Driver.run_named
+             ~runtime_id:"quota_lane"
+             ~keeper_name:"deferred-frozen-quota-order"
+             ~base_path:(Filename.get_temp_dir_name ())
+             ~goal:"preserve the pre-dispatch runtime binding"
+             ~deferred_runtime_lane:frozen
+             ~provider_config_transform:(fun provider_config ->
+               transformed_urls := provider_config.base_url :: !transformed_urls;
+               Error
+                 (Agent_core.Error.Config
+                    (Agent_core.Error.InvalidConfig
+                       { field = "provider-config-transform"
+                       ; detail = "stop after observing the selected runtime"
+                       })))
+             ~sw
+             ~net:env#net
+             ()
+         in
+         (match result with
+          | Error error when !transformed_urls = [] ->
+            Alcotest.failf
+              "dispatch did not reach the selected runtime: %s"
+              (Agent_core.Error.to_string error)
+          | Error _ -> ()
+          | Ok _ -> Alcotest.fail "test provider transform unexpectedly succeeded");
+         Alcotest.(check (list string))
+           "dispatch keeps the runtime frozen before pre-dispatch"
+           [ "http://127.0.0.1:1" ]
+           (List.rev !transformed_urls)))
+
 let test_official_client_does_not_inherit_registry_api_key_scope () =
   with_runtime_config runtime_toml_official_provider_named_like_registry (fun () ->
     Runtime_quota_window.reset_for_testing ();
@@ -2123,6 +2189,10 @@ let () =
             "deferred quota order is frozen before pre-dispatch"
             `Quick
             test_deferred_quota_order_is_frozen_before_predispatch;
+          Alcotest.test_case
+            "deferred dispatch preserves pre-dispatch quota order"
+            `Quick
+            test_deferred_dispatch_preserves_predispatch_quota_order;
           Alcotest.test_case
             "official client quota excludes registry API-key scope"
             `Quick

--- a/test/test_runtime_quota_window.ml
+++ b/test/test_runtime_quota_window.ml
@@ -152,6 +152,23 @@ let test_scope_kinds_do_not_collide () =
     None
     (Q.active_until ~scope:provider_row_scope ~now:100.0)
 
+let test_registry_default_credential_is_shared_scope () =
+  let credential provider_id =
+    Runtime_adapter.effective_credential_reference ~provider_id None
+  in
+  let glm_scope =
+    Q.scope_of_credential ~provider_id:"glm" (credential "glm")
+  in
+  let image_scope =
+    Q.scope_of_credential ~provider_id:"zai-image" (credential "zai-image")
+  in
+  reset ();
+  Q.note_exhausted ~scope:glm_scope ~resets_at:500.0;
+  Alcotest.(check bool)
+    "registry rows sharing ZAI_API_KEY share a quota window"
+    true
+    (Option.is_some (Q.active_until ~scope:image_scope ~now:100.0))
+
 let () =
   Alcotest.run
     "runtime_quota_window"
@@ -186,5 +203,9 @@ let () =
             "scope kinds do not collide"
             `Quick
             test_scope_kinds_do_not_collide
+        ; Alcotest.test_case
+            "registry default credential shares scope"
+            `Quick
+            test_registry_default_credential_is_shared_scope
         ] )
     ]

--- a/test/test_runtime_quota_window.ml
+++ b/test/test_runtime_quota_window.ml
@@ -6,53 +6,57 @@ module Q = Runtime_quota_window
 
 let reset () = Q.reset_for_testing ()
 
+let provider_scope provider_id = Q.scope_of_credential ~provider_id None
+
 (* scope mapping used by demote tests: "prov.model" ids, unknown for
    ids without a dot — mirrors candidates the driver cannot resolve. *)
 let quota_scope_of candidate =
   match String.index_opt candidate '.' with
-  | Some i -> Some (String.sub candidate 0 i)
+  | Some i -> Some (provider_scope (String.sub candidate 0 i))
   | None -> None
 
 let test_window_lifecycle () =
   reset ();
+  let scope = provider_scope "claude_code" in
   Alcotest.(check (option (float 0.0)))
     "no window recorded"
     None
-    (Q.active_until ~provider_id:"claude_code" ~now:100.0);
-  Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
+    (Q.active_until ~scope ~now:100.0);
+  Q.note_exhausted ~scope ~resets_at:500.0;
   Alcotest.(check (option (float 0.0)))
     "active before reset"
     (Some 500.0)
-    (Q.active_until ~provider_id:"claude_code" ~now:499.9);
+    (Q.active_until ~scope ~now:499.9);
   Alcotest.(check (option (float 0.0)))
     "expired at reset"
     None
-    (Q.active_until ~provider_id:"claude_code" ~now:500.0);
+    (Q.active_until ~scope ~now:500.0);
   Alcotest.(check (option (float 0.0)))
     "expiry pruned the entry (no resurrection at an earlier now)"
     None
-    (Q.active_until ~provider_id:"claude_code" ~now:0.0)
+    (Q.active_until ~scope ~now:0.0)
 
 let test_later_reset_extends_earlier_is_ignored () =
   reset ();
-  Q.note_exhausted ~provider_id:"codex_subscription" ~resets_at:500.0;
-  Q.note_exhausted ~provider_id:"codex_subscription" ~resets_at:900.0;
+  let scope = provider_scope "codex_subscription" in
+  Q.note_exhausted ~scope ~resets_at:500.0;
+  Q.note_exhausted ~scope ~resets_at:900.0;
   Alcotest.(check (option (float 0.0)))
     "later reset extends"
     (Some 900.0)
-    (Q.active_until ~provider_id:"codex_subscription" ~now:100.0);
-  Q.note_exhausted ~provider_id:"codex_subscription" ~resets_at:600.0;
+    (Q.active_until ~scope ~now:100.0);
+  Q.note_exhausted ~scope ~resets_at:600.0;
   Alcotest.(check (option (float 0.0)))
     "earlier reset cannot shorten"
     (Some 900.0)
-    (Q.active_until ~provider_id:"codex_subscription" ~now:100.0)
+    (Q.active_until ~scope ~now:100.0)
 
 let candidates =
   [ "claude_code.sonnet"; "ollama.qwen"; "claude_code.opus"; "codex.spark" ]
 
 let test_demote_moves_exhausted_provider_to_tail () =
   reset ();
-  Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
+  Q.note_exhausted ~scope:(provider_scope "claude_code") ~resets_at:500.0;
   Alcotest.(check (list string))
     "exhausted provider's candidates keep order at the tail"
     [ "ollama.qwen"; "codex.spark"; "claude_code.sonnet"; "claude_code.opus" ]
@@ -64,12 +68,12 @@ let test_demote_noop_paths () =
     "no windows: unchanged"
     candidates
     (Q.demote_order ~now:100.0 ~quota_scope_of candidates);
-  Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
+  Q.note_exhausted ~scope:(provider_scope "claude_code") ~resets_at:500.0;
   Alcotest.(check (list string))
     "window passed: unchanged"
     candidates
     (Q.demote_order ~now:501.0 ~quota_scope_of candidates);
-  Q.note_exhausted ~provider_id:"unrelated_provider" ~resets_at:900.0;
+  Q.note_exhausted ~scope:(provider_scope "unrelated_provider") ~resets_at:900.0;
   Alcotest.(check (list string))
     "window on a provider with no candidate: unchanged"
     candidates
@@ -77,7 +81,7 @@ let test_demote_noop_paths () =
 
 let test_unknown_provider_stays_in_place () =
   reset ();
-  Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
+  Q.note_exhausted ~scope:(provider_scope "claude_code") ~resets_at:500.0;
   Alcotest.(check (list string))
     "unresolvable id is not demoted"
     [ "no-dot-id"; "ollama.qwen"; "claude_code.sonnet" ]
@@ -92,7 +96,7 @@ let test_unknown_provider_stays_in_place () =
 
 let test_all_demoted_keeps_declared_order () =
   reset ();
-  Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
+  Q.note_exhausted ~scope:(provider_scope "claude_code") ~resets_at:500.0;
   Alcotest.(check (list string))
     "every candidate demoted: declared order preserved, still attemptable"
     [ "claude_code.sonnet"; "claude_code.opus" ]
@@ -109,11 +113,23 @@ let test_shared_credential_scope_demotes_siblings () =
   let scope_of = function
     (* two rows, one account *)
     | "ollama_cloud.qwen" | "ollama_cloud_native.qwen" ->
-      Some "env:OLLAMA_CLOUD_API_KEY"
-    | "claude_code.sonnet" -> Some "env:ANTHROPIC_KEY"
+      Some
+        (Q.scope_of_credential
+           ~provider_id:"ignored"
+           (Some (Runtime_schema.Env "OLLAMA_CLOUD_API_KEY")))
+    | "claude_code.sonnet" ->
+      Some
+        (Q.scope_of_credential
+           ~provider_id:"ignored"
+           (Some (Runtime_schema.Env "ANTHROPIC_KEY")))
     | _ -> None
   in
-  Q.note_exhausted ~provider_id:"env:OLLAMA_CLOUD_API_KEY" ~resets_at:500.0;
+  Q.note_exhausted
+    ~scope:
+      (Q.scope_of_credential
+         ~provider_id:"ollama_cloud"
+         (Some (Runtime_schema.Env "OLLAMA_CLOUD_API_KEY")))
+    ~resets_at:500.0;
   Alcotest.(check (list string))
     "both rows on the exhausted account move to the tail"
     [ "claude_code.sonnet"; "ollama_cloud.qwen"; "ollama_cloud_native.qwen" ]
@@ -122,27 +138,19 @@ let test_shared_credential_scope_demotes_siblings () =
        ~quota_scope_of:scope_of
        [ "ollama_cloud.qwen"; "claude_code.sonnet"; "ollama_cloud_native.qwen" ])
 
-let test_scope_of_credential () =
-  Alcotest.(check string)
-    "env credential names the account"
-    "env:OLLAMA_CLOUD_API_KEY"
-    (Q.scope_of_credential
-       ~provider_id:"ollama_cloud"
-       (Some (Runtime_schema.Env "OLLAMA_CLOUD_API_KEY")));
-  Alcotest.(check string)
-    "file credential names the file"
-    "file:/etc/key"
-    (Q.scope_of_credential
-       ~provider_id:"p"
-       (Some (Runtime_schema.File "/etc/key")));
-  Alcotest.(check string)
-    "inline credential cannot name a shared account: row scope"
-    "p"
-    (Q.scope_of_credential ~provider_id:"p" (Some (Runtime_schema.Inline "s3cret")));
-  Alcotest.(check string)
-    "absent credential: row scope"
-    "p"
-    (Q.scope_of_credential ~provider_id:"p" None)
+let test_scope_kinds_do_not_collide () =
+  reset ();
+  let env_scope =
+    Q.scope_of_credential
+      ~provider_id:"ignored"
+      (Some (Runtime_schema.Env "TOKEN"))
+  in
+  let provider_row_scope = provider_scope "env:TOKEN" in
+  Q.note_exhausted ~scope:env_scope ~resets_at:500.0;
+  Alcotest.(check (option (float 0.0)))
+    "an env reference cannot collide with a provider row that resembles it"
+    None
+    (Q.active_until ~scope:provider_row_scope ~now:100.0)
 
 let () =
   Alcotest.run
@@ -175,8 +183,8 @@ let () =
         ] )
     ; ( "scope"
       , [ Alcotest.test_case
-            "credential to scope"
+            "scope kinds do not collide"
             `Quick
-            test_scope_of_credential
+            test_scope_kinds_do_not_collide
         ] )
     ]

--- a/test/test_runtime_quota_window.ml
+++ b/test/test_runtime_quota_window.ml
@@ -6,9 +6,9 @@ module Q = Runtime_quota_window
 
 let reset () = Q.reset_for_testing ()
 
-(* provider mapping used by demote tests: "prov.model" ids, unknown for
+(* scope mapping used by demote tests: "prov.model" ids, unknown for
    ids without a dot — mirrors candidates the driver cannot resolve. *)
-let provider_id_of candidate =
+let quota_scope_of candidate =
   match String.index_opt candidate '.' with
   | Some i -> Some (String.sub candidate 0 i)
   | None -> None
@@ -56,24 +56,24 @@ let test_demote_moves_exhausted_provider_to_tail () =
   Alcotest.(check (list string))
     "exhausted provider's candidates keep order at the tail"
     [ "ollama.qwen"; "codex.spark"; "claude_code.sonnet"; "claude_code.opus" ]
-    (Q.demote_order ~now:100.0 ~provider_id_of candidates)
+    (Q.demote_order ~now:100.0 ~quota_scope_of candidates)
 
 let test_demote_noop_paths () =
   reset ();
   Alcotest.(check (list string))
     "no windows: unchanged"
     candidates
-    (Q.demote_order ~now:100.0 ~provider_id_of candidates);
+    (Q.demote_order ~now:100.0 ~quota_scope_of candidates);
   Q.note_exhausted ~provider_id:"claude_code" ~resets_at:500.0;
   Alcotest.(check (list string))
     "window passed: unchanged"
     candidates
-    (Q.demote_order ~now:501.0 ~provider_id_of candidates);
+    (Q.demote_order ~now:501.0 ~quota_scope_of candidates);
   Q.note_exhausted ~provider_id:"unrelated_provider" ~resets_at:900.0;
   Alcotest.(check (list string))
     "window on a provider with no candidate: unchanged"
     candidates
-    (Q.demote_order ~now:100.0 ~provider_id_of candidates)
+    (Q.demote_order ~now:100.0 ~quota_scope_of candidates)
 
 let test_unknown_provider_stays_in_place () =
   reset ();
@@ -83,7 +83,7 @@ let test_unknown_provider_stays_in_place () =
     [ "no-dot-id"; "ollama.qwen"; "claude_code.sonnet" ]
     (Q.demote_order
        ~now:100.0
-       ~provider_id_of
+       ~quota_scope_of
        [ "no-dot-id"; "claude_code.sonnet"; "ollama.qwen" ]
      |> fun reordered ->
      (* stable partition keeps no-dot-id and ollama.qwen in declared order,
@@ -98,8 +98,51 @@ let test_all_demoted_keeps_declared_order () =
     [ "claude_code.sonnet"; "claude_code.opus" ]
     (Q.demote_order
        ~now:100.0
-       ~provider_id_of
+       ~quota_scope_of
        [ "claude_code.sonnet"; "claude_code.opus" ])
+
+(* Quota is credential-account-owned: two provider rows sharing one
+   credential share one scope, so exhausting either demotes both
+   (PR #28202 review P2). *)
+let test_shared_credential_scope_demotes_siblings () =
+  reset ();
+  let scope_of = function
+    (* two rows, one account *)
+    | "ollama_cloud.qwen" | "ollama_cloud_native.qwen" ->
+      Some "env:OLLAMA_CLOUD_API_KEY"
+    | "claude_code.sonnet" -> Some "env:ANTHROPIC_KEY"
+    | _ -> None
+  in
+  Q.note_exhausted ~provider_id:"env:OLLAMA_CLOUD_API_KEY" ~resets_at:500.0;
+  Alcotest.(check (list string))
+    "both rows on the exhausted account move to the tail"
+    [ "claude_code.sonnet"; "ollama_cloud.qwen"; "ollama_cloud_native.qwen" ]
+    (Q.demote_order
+       ~now:100.0
+       ~quota_scope_of:scope_of
+       [ "ollama_cloud.qwen"; "claude_code.sonnet"; "ollama_cloud_native.qwen" ])
+
+let test_scope_of_credential () =
+  Alcotest.(check string)
+    "env credential names the account"
+    "env:OLLAMA_CLOUD_API_KEY"
+    (Q.scope_of_credential
+       ~provider_id:"ollama_cloud"
+       (Some (Runtime_schema.Env "OLLAMA_CLOUD_API_KEY")));
+  Alcotest.(check string)
+    "file credential names the file"
+    "file:/etc/key"
+    (Q.scope_of_credential
+       ~provider_id:"p"
+       (Some (Runtime_schema.File "/etc/key")));
+  Alcotest.(check string)
+    "inline credential cannot name a shared account: row scope"
+    "p"
+    (Q.scope_of_credential ~provider_id:"p" (Some (Runtime_schema.Inline "s3cret")));
+  Alcotest.(check string)
+    "absent credential: row scope"
+    "p"
+    (Q.scope_of_credential ~provider_id:"p" None)
 
 let () =
   Alcotest.run
@@ -125,5 +168,15 @@ let () =
             "all demoted keeps order"
             `Quick
             test_all_demoted_keeps_declared_order
+        ; Alcotest.test_case
+            "shared credential demotes siblings"
+            `Quick
+            test_shared_credential_scope_demotes_siblings
+        ] )
+    ; ( "scope"
+      , [ Alcotest.test_case
+            "credential to scope"
+            `Quick
+            test_scope_of_credential
         ] )
     ]

--- a/test/test_runtime_quota_window.ml
+++ b/test/test_runtime_quota_window.ml
@@ -169,6 +169,45 @@ let test_registry_default_credential_is_shared_scope () =
     true
     (Option.is_some (Q.active_until ~scope:image_scope ~now:100.0))
 
+let with_env_values bindings f =
+  let previous =
+    List.map (fun (key, _) -> key, Sys.getenv_opt key) bindings
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter
+        (fun (key, value) ->
+           Unix.putenv key (Option.value ~default:"" value))
+        previous)
+    (fun () ->
+       List.iter (fun (key, value) -> Unix.putenv key value) bindings;
+       f ())
+;;
+
+let test_selected_environment_alias_owns_scope () =
+  with_env_values
+    [ "OLLAMA_CLOUD_API_KEY", ""; "OLLAMA_API_KEY", "legacy-test-key" ]
+    (fun () ->
+       let selected =
+         Runtime_adapter.effective_credential_reference
+           ~provider_id:"ollama_cloud"
+           (Some (Runtime_schema.Env "OLLAMA_CLOUD_API_KEY"))
+       in
+       let selected_scope =
+         Q.scope_of_credential ~provider_id:"ollama_cloud" selected
+       in
+       let legacy_scope =
+         Q.scope_of_credential
+           ~provider_id:"ollama_cloud"
+           (Some (Runtime_schema.Env "OLLAMA_API_KEY"))
+       in
+       reset ();
+       Q.note_exhausted ~scope:selected_scope ~resets_at:500.0;
+       Alcotest.(check bool)
+         "the environment alias that supplied the key shares the window"
+         true
+         (Option.is_some (Q.active_until ~scope:legacy_scope ~now:100.0)))
+
 let () =
   Alcotest.run
     "runtime_quota_window"
@@ -207,5 +246,9 @@ let () =
             "registry default credential shares scope"
             `Quick
             test_registry_default_credential_is_shared_scope
+        ; Alcotest.test_case
+            "selected environment alias owns scope"
+            `Quick
+            test_selected_environment_alias_owns_scope
         ] )
     ]


### PR DESCRIPTION
## 목표

PR #28202 리뷰 P2 2건 대응 (머지된 브랜치 → 후속 PR).

| 스레드 | 조치 |
|---|---|
| P2: quota window를 credential 계정으로 키잉 | `scope_of_credential`: `Env`→`env:KEY`, `File`→`file:PATH` (비밀 아닌 참조명), `Inline`→row id (비밀 자체라 공유명 불가), 부재→row id. note/demote 양쪽이 같은 scope 사용 |
| P2: deferred lane suffix에도 demotion | freeze 시점에 굳은 suffix가 이후 기록된 window를 반영 못 하던 것 — `Some hint` arm에도 동일 demote 적용 |

## 주의

본 PR은 main 빌드 복구 커밋(#28217, `first` 한 토큰)을 base로 포함합니다 — 현재 main이 컴파일되지 않아 그 위에서만 검증 가능합니다. #28217 머지 후 rebase하면 이 PR은 자체 변경만 남습니다.

## 로컬 검증 (실제 exit code)

- `test_runtime_quota_window`: 8/8 (신규: 계정 공유 형제 demote, credential→scope 파생 4케이스)
- `test_runtime_lane_preference`: 10/10
- `test_keeper_turn_driver_failover`: 40/40
- `dune build ./bin/main_eio.exe`: exit 0

Refs PR #28202 리뷰 스레드, RFC-0370 §3.3. MASC task-223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>