### PR TITLE
fix(keeper): pass both reads to stable_read_only_observation (main build broken)

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -585,7 +585,8 @@ let observe_state_read_only_typed_with ~between_samples ~base_path ~keeper_name 
             Result.bind
               (read_state_read_only_unlocked ~require_existing:false owner
                |> Result.map_error (fun message -> Observation_read_failed message))
-              (stable_read_only_observation ~keeper_name))
+              (fun second ->
+                 stable_read_only_observation ~keeper_name first second))
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->


### PR DESCRIPTION
## main 빌드 깨짐 핫픽스 (#28200에 이은 2번째)

origin/main의 `lib/keeper_runtime`가 컴파일 실패 → masc lib 전체 빌드 차단:

```
File "lib/keeper_runtime/keeper_event_queue_persistence.ml", line 588:
588 |  (stable_read_only_observation ~keeper_name))
Error: This function application is partial, maybe some arguments are missing.
```

## 원인

**#28191** (`fix(schedule): keep dashboard evidence reads non-mutating`)이 lock-free 이중읽기 안정성 검사 `stable_read_only_observation ~keeper_name first second`(positional 2-arg)를 추가했지만, 호출부를 `Result.bind` 연속으로 `(stable_read_only_observation ~keeper_name)`처럼 배선 — inner bind 값(`second`)만 받고 **`first`(outer bind 람다가 바인딩)를 전달하지 않음**. partial application이라 타입체크 실패.

## 수정

두 read를 모두 전달:
```ocaml
(fun second -> stable_read_only_observation ~keeper_name first second)
```
함수 arity + 의도(두 read의 `State.to_yojson`이 같으면 `Ok second`, 다르면 `Observation_changed`)와 일치.

## 검증

| 상태 | `dune build lib/keeper_runtime/` |
|---|---|
| origin/main | exit 1 (588행 partial application) |
| 이 PR | exit 0 |

워크어라운드 아님(호출부 arity 정정). 레거시 리더 추가 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)