### PR TITLE
fix(keeper): main does not compile — three dropped arguments/parens

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -585,7 +585,7 @@ let observe_state_read_only_typed_with ~between_samples ~base_path ~keeper_name 
             Result.bind
               (read_state_read_only_unlocked ~require_existing:false owner
                |> Result.map_error (fun message -> Observation_read_failed message))
-              (stable_read_only_observation ~keeper_name))
+              (stable_read_only_observation ~keeper_name first))
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->

--- a/test/test_exact_lane_run_registry.ml
+++ b/test/test_exact_lane_run_registry.ml
@@ -171,11 +171,13 @@ let test_failed_durable_completion_is_explicitly_visible () =
      check bool "serialized persistence state" true
        (List.mem_assoc "persistence_state" fields);
      check (option string) "serialized intended failure code" (Some "model_error")
-       (List.assoc_opt "intended_code" fields
-        |> Option.bind (function `String value -> Some value | _ -> None));
+       (match List.assoc_opt "intended_code" fields with
+        | Some (`String value) -> Some value
+        | Some _ | None -> None);
      check (option string) "serialized intended failure detail" (Some "typed failure detail")
-       (List.assoc_opt "intended_detail" fields
-        |> Option.bind (function `String value -> Some value | _ -> None))
+       (match List.assoc_opt "intended_detail" fields with
+        | Some (`String value) -> Some value
+        | Some _ | None -> None)
    | _ -> fail "run serializer must emit an object");
   Unix.rmdir path
 ;;
@@ -203,7 +205,15 @@ let test_observation_reads_do_not_wait_for_durable_writer () =
     Unix.close ready_read;
     Fun.protect
       ~finally:(fun () ->
-        (match Unix.waitpid [] child with
+        (* [waitpid] is interruptible: a signal delivered while this test is
+           blocked raises EINTR, which Fun.protect then re-raises from the
+           finally clause and reports as a failure of the case rather than of
+           the wait. The child is still there, so the answer is to ask again. *)
+        let rec wait_for_child () =
+          try Unix.waitpid [] child with
+          | Unix.Unix_error (Unix.EINTR, _, _) -> wait_for_child ()
+        in
+        (match wait_for_child () with
          | _, Unix.WEXITED 0 -> ()
          | _, status ->
            failf

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -699,7 +699,7 @@ let test_spawn_failure_is_pre_dispatch () =
                     "spawn is proven pre-dispatch"
                     "no_effect_observed"
                     (Keeper_provider_attempt_effect.to_string
-                       attempt.effect_disposition)))))
+                       attempt.effect_disposition))))))
 ;;
 
 let () =


### PR DESCRIPTION
fix(keeper): make main compile again — three defects, and what they were hiding

main does not compile. `dune build @check` on c69ea8a3ea reports:

  lib/keeper_runtime/keeper_event_queue_persistence.ml:588
      This expression has type
        State.t -> State.t -> (State.t, read_only_observation_error) result
      but an expression was expected of type
        State.t -> ('a, read_only_observation_error) result
  test/test_keeper_antigravity_runtime.ml:703   Syntax error: ) expected
  test/test_exact_lane_run_registry.ml:175      This expression should not be a
                                                function, the expected type is
                                                'a option

Each is a dropped argument or paren:

- stable_read_only_observation takes [first second]; the call site passed it as
  the continuation of a Result.bind that supplies only [second], leaving
  [first] — already bound by the enclosing lambda — unapplied.
- The Fun.protect body opened at line 638 is never closed.
- `x |> Option.bind f` is `Option.bind f x`, so the function landed where the
  option belongs. Rewritten as a match, which cannot take the arguments in the
  wrong order.

CI is not misconfigured. It compiles every test — ci.yml:773 runs
`dune build --root . @default @check @install` under "NO continue-on-error:
dune build is deterministic and must hard-fail" — and both suites are wired
(ci-run-focused-tests.sh:95). The gap is at the merge, not the check:

  65be32ffdb (#28179)   CI: cancelled    Fundamental Check: success
  a76f9b6e6d (#28178)   CI: failure      Fundamental Check: success

One merged with CI cancelled and one with CI outright failing, while a sibling
check reported success beside it. Separately, the ruleset named "main merge
gate (no bypass)" is enforcement=active with `rules: []` — it requires nothing.

Compiling the two suites for the first time in days ran them for the first time
in days, and both had something to say.

test_exact_lane_run_registry then failed in teardown:

  [exception] Fun.Finally_raised: Unix.Unix_error(Unix.EINTR, "waitpid", "")

waitpid is interruptible; a signal during the wait raised out of the finally
clause and was reported as a failure of the case rather than of the wait. The
child is still there, so it now asks again. Suite is 7/7.

test_keeper_antigravity_runtime "blank result starts fresh next turn" still
fails, and is left failing deliberately:

  provider_attempt_effect_fenced ... "successful result response has no
  deliverable content"

The runtime now fences that attempt where the test expects a fresh
conversation on the next turn. That is a contract disagreement between
#28178's fence and this suite's expectation, not a typo, and picking a side
belongs with whoever owns the fence. Filed separately. The other two cases in
that suite pass, including the one whose paren this commit closed.

  dune build @check                              exit 0 (was 3 errors)
  @test/runtest-test_exact_lane_run_registry     7 tests, Test Successful
  @test/runtest-test_keeper_antigravity_runtime  3 tests, 1 failure (above)
  ocamlformat --check (3 changed files)          clean

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

