### PR TITLE
feat(dashboard): unblock feature-first flows

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -29,7 +29,7 @@ export function fetchTaskEvents(taskId: string, limit = 50): Promise<unknown[]> 
     task_id: taskId,
     limit: String(limit),
   })
-  return get<unknown[]>(`/api/v1/dashboard/tasks/history?${params.toString()}`)
+  return get<unknown[]>(`/api/v1/dashboard/tasks/history?${params.toString()}`, { publicRead: true })
 }
 
 // --- Dashboard delete actions ---

--- a/dashboard/src/api/attribution.ts
+++ b/dashboard/src/api/attribution.ts
@@ -41,7 +41,7 @@ export interface AttributionSummaryResponse {
 export async function fetchAttributionSummary(
   opts: GetOptions = {},
 ): Promise<AttributionSummaryResponse> {
-  return get<AttributionSummaryResponse>('/api/v1/attribution/summary', opts)
+  return get<AttributionSummaryResponse>('/api/v1/attribution/summary', { ...opts, publicRead: true })
 }
 
 export async function fetchAttributionRecent(
@@ -55,5 +55,5 @@ export async function fetchAttributionRecent(
   const path = query
     ? `/api/v1/attribution/recent?${query}`
     : '/api/v1/attribution/recent'
-  return get<AttributionRecentResponse>(path, opts)
+  return get<AttributionRecentResponse>(path, { ...opts, publicRead: true })
 }

--- a/dashboard/src/api/board-moderation.ts
+++ b/dashboard/src/api/board-moderation.ts
@@ -167,6 +167,7 @@ export async function fetchBoardModerationQueue(
     const qs = params.toString()
     const raw = await get<unknown>(`${MODERATION_QUEUE_PATH}${qs ? `?${qs}` : ''}`, {
       signal: options.signal,
+      publicRead: true,
     })
     if (!isRecord(raw)) return { entries: [], count: 0 }
     const entries = Array.isArray(raw.entries)

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -972,7 +972,7 @@ export async function fetchBoard(
     if (options?.blindVotes) params.set('blind_votes', 'true')
     params.set('limit', options?.excludeSystem || options?.excludeAutomation || options?.author || options?.hearth ? '150' : '100')
     const qs = params.toString()
-    const raw = await get<{ posts?: unknown[] }>(`/api/v1/board${qs ? `?${qs}` : ''}`)
+    const raw = await get<{ posts?: unknown[] }>(`/api/v1/board${qs ? `?${qs}` : ''}`, { publicRead: true })
     const posts = Array.isArray(raw.posts)
       ? raw.posts.map(normalizeBoardPost).filter((row): row is BoardPost => row !== null)
       : []
@@ -989,7 +989,7 @@ export async function fetchBoardHearths(options: {
     if (options.excludeSystem) params.set('exclude_system', 'true')
     if (options.excludeAutomation) params.set('exclude_automation', 'true')
     const qs = params.toString()
-    const raw = await get<{ hearths?: unknown[] }>(`/api/v1/board/hearths${qs ? `?${qs}` : ''}`)
+    const raw = await get<{ hearths?: unknown[] }>(`/api/v1/board/hearths${qs ? `?${qs}` : ''}`, { publicRead: true })
     return Array.isArray(raw.hearths)
       ? raw.hearths.map(normalizeBoardHearth).filter((row): row is BoardHearth => row !== null)
       : []
@@ -998,7 +998,7 @@ export async function fetchBoardHearths(options: {
 
 export async function fetchBoardFlairs(): Promise<BoardFlair[]> {
   return withRetries('fetchBoardFlairs', async () => {
-    const raw = await get<{ flairs?: unknown[] }>('/api/v1/board/flairs')
+    const raw = await get<{ flairs?: unknown[] }>('/api/v1/board/flairs', { publicRead: true })
     return Array.isArray(raw.flairs)
       ? raw.flairs.map(normalizeBoardFlair).filter((row): row is BoardFlair => row !== null)
       : []
@@ -1007,7 +1007,7 @@ export async function fetchBoardFlairs(): Promise<BoardFlair[]> {
 
 export async function fetchBoardCuration(): Promise<BoardCurationSnapshot | null> {
   return withRetries('fetchBoardCuration', async () => {
-    const raw = await get<{ snapshot?: unknown }>('/api/v1/board/curation')
+    const raw = await get<{ snapshot?: unknown }>('/api/v1/board/curation', { publicRead: true })
     return raw.snapshot != null ? normalizeBoardCurationSnapshot(raw.snapshot) : null
   })
 }
@@ -1021,7 +1021,7 @@ export async function fetchBoardKarmaLedger(options: { agent?: string; limit?: n
       params.set('limit', String(Math.trunc(options.limit)))
     }
     const qs = params.toString()
-    const raw = await get<unknown>(`/api/v1/board/karma/ledger${qs ? `?${qs}` : ''}`)
+    const raw = await get<unknown>(`/api/v1/board/karma/ledger${qs ? `?${qs}` : ''}`, { publicRead: true })
     return normalizeBoardKarmaLedger(raw)
   })
 }
@@ -1035,7 +1035,7 @@ export async function fetchBoardReactionState(
       target_type: targetType,
       target_id: targetId,
     })
-    const raw = await get<unknown>(`/api/v1/board/reactions?${params}`)
+    const raw = await get<unknown>(`/api/v1/board/reactions?${params}`, { publicRead: true })
     if (!isRecord(raw) || !Array.isArray(raw.reactions)) {
       throw new Error('Malformed board reaction state: reactions must be an array')
     }
@@ -1061,7 +1061,7 @@ export async function fetchBoardPost(postId: string): Promise<BoardPost & { comm
       voter: currentDashboardActor(),
       blind_votes: 'true',
     })
-    const raw = await get<Record<string, unknown>>(`/api/v1/board/${postId}?${params}`)
+    const raw = await get<Record<string, unknown>>(`/api/v1/board/${postId}?${params}`, { publicRead: true })
     const postRaw = isRecord(raw.post) ? raw.post : raw
     const post = normalizeBoardPost(postRaw) ?? {
       id: postId,
@@ -1200,7 +1200,7 @@ export function normalizeSubBoard(raw: unknown): SubBoard | null {
 }
 
 export async function fetchSubBoards(): Promise<SubBoard[]> {
-  const data = await withRetries('fetchSubBoards', () => get('/api/v1/board/sub-boards'))
+  const data = await withRetries('fetchSubBoards', () => get('/api/v1/board/sub-boards', { publicRead: true }))
   if (!isRecord(data)) return []
   const raw = Array.isArray(data.sub_boards) ? data.sub_boards : []
   return raw.flatMap((r: unknown) => {
@@ -1210,7 +1210,10 @@ export async function fetchSubBoards(): Promise<SubBoard[]> {
 }
 
 export async function fetchSubBoard(subBoardId: string): Promise<SubBoard | null> {
-  const data = await withRetries('fetchSubBoard', () => get(`/api/v1/board/sub-boards/${encodeURIComponent(subBoardId)}`))
+  const data = await withRetries(
+    'fetchSubBoard',
+    () => get(`/api/v1/board/sub-boards/${encodeURIComponent(subBoardId)}`, { publicRead: true }),
+  )
   return normalizeSubBoard(data)
 }
 

--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -13,7 +13,9 @@ import {
   get,
   getStoredToken,
   getStoredTokenMeta,
+  jsonHeaders,
   post,
+  postPublic,
   runOperatorAction,
   setStoredToken,
   subscribeStoredTokenChanges,
@@ -155,6 +157,23 @@ describe('post', () => {
     expect(actorHeader).not.toContain('%')
   })
 
+  it('omits a stale bearer and actor for an explicitly public mutation', async () => {
+    setStoredToken('stale-dashboard-token', { source: 'manual' })
+    setCanonicalDashboardActor('dashboard-admin-deft-cobra')
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"ok":true}', {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await postPublic('/api/v1/ide/annotations', { content: 'note' })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' })
+  })
+
   it('bypasses browser HTTP cache for dashboard API reads', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response('{"keepers":[]}', {
@@ -168,6 +187,26 @@ describe('post', () => {
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(init.cache).toBe('no-store')
+  })
+
+  it('omits a stale bearer and actor for an explicitly public read', async () => {
+    setStoredToken('stale-dashboard-token', { source: 'manual' })
+    setCanonicalDashboardActor('dashboard-admin-deft-cobra')
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"keeper":"rondo"}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await get('/api/v1/keepers/rondo/compaction-snapshots', { publicRead: true })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(init.headers).toEqual({})
+    expect(jsonHeaders({ publicRead: true })).toEqual({
+      'Content-Type': 'application/json',
+    })
   })
 
   it('keeps board voter resolution scoped to query params', () => {

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -185,9 +185,16 @@ export function currentDashboardActor(): string {
 type HeaderOptions = {
   includeActor?: boolean
   actorName?: string | null
+  /**
+   * Keep route-local public reads independent of the dashboard session.
+   * In particular, never let a stored token for a different dashboard actor
+   * turn an inspector request into an authorization failure.
+   */
+  publicRead?: boolean
 }
 
 export function authHeaders(options: HeaderOptions = {}): Record<string, string> {
+  if (options.publicRead) return {}
   const headers: Record<string, string> = {}
   const token = dashboardBearerToken()
   const tokenMeta = getStoredTokenMeta()
@@ -204,9 +211,9 @@ export function authHeaders(options: HeaderOptions = {}): Record<string, string>
   return headers
 }
 
-export function jsonHeaders(): Record<string, string> {
+export function jsonHeaders(options: HeaderOptions = {}): Record<string, string> {
   return {
-    ...authHeaders(),
+    ...authHeaders(options),
     'Content-Type': 'application/json',
   }
 }
@@ -643,13 +650,23 @@ export type AbortableRequestOptions = {
 export type GetOptions = AbortableRequestOptions & {
   timeoutMs?: number
   includeActorHeader?: boolean
+  /**
+   * A route the server explicitly exposes through its public-read policy.
+   * Do not attach a stored bearer or actor header: a stale token for a
+   * different dashboard identity must not turn an otherwise readable
+   * inspector into an authorization failure.
+   */
+  publicRead?: boolean
 }
 
 export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
   const res = await fetchWithTimeout(
     path,
     {
-      headers: authHeaders({ includeActor: opts.includeActorHeader }),
+      headers: authHeaders({
+        includeActor: opts.includeActorHeader,
+        publicRead: opts.publicRead,
+      }),
       signal: opts.signal,
     },
     opts.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS,
@@ -684,7 +701,10 @@ export async function getWithResponse<T>(
   const res = await fetchWithTimeout(
     path,
     {
-      headers: authHeaders({ includeActor: opts.includeActorHeader }),
+      headers: authHeaders({
+        includeActor: opts.includeActorHeader,
+        publicRead: opts.publicRead,
+      }),
       signal: opts.signal,
     },
     opts.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS,
@@ -770,6 +790,26 @@ export async function post<T>(
       ...jsonHeaders(),
       ...(extraHeaders ?? {}),
     },
+    body: JSON.stringify(body),
+  }, timeoutMs)
+  if (!res.ok) {
+    throw await apiRequestErrorFromResponse('POST', path, res)
+  }
+  return parseJsonResponse<T>('POST', path, res)
+}
+
+/**
+ * Public feature mutation. Use only for routes whose server handler declares
+ * itself public; it deliberately omits a stale dashboard token and actor.
+ */
+export async function postPublic<T>(
+  path: string,
+  body: unknown,
+  timeoutMs = DEFAULT_POST_TIMEOUT_MS,
+): Promise<T> {
+  const res = await fetchWithTimeout(path, {
+    method: 'POST',
+    headers: jsonHeaders({ publicRead: true }),
     body: JSON.stringify(body),
   }, timeoutMs)
   if (!res.ok) {
@@ -895,7 +935,7 @@ export async function confirmOperatorAction(
 }
 
 export function fetchOperatorSnapshot(): Promise<OperatorSnapshot> {
-  return get('/api/v1/operator', { includeActorHeader: false })
+  return get('/api/v1/operator', { publicRead: true })
 }
 
 export function fetchOperatorDigest(options: {
@@ -909,6 +949,6 @@ export function fetchOperatorDigest(options: {
   if (options.includeWorkers != null) params.set('include_workers', options.includeWorkers ? 'true' : 'false')
   const query = params.toString()
   return get(`/api/v1/operator/digest${query ? `?${query}` : ''}`, {
-    includeActorHeader: false,
+    publicRead: true,
   })
 }

--- a/dashboard/src/api/dashboard-agent.ts
+++ b/dashboard/src/api/dashboard-agent.ts
@@ -13,13 +13,17 @@ export async function fetchAgentTimeline(
 ): Promise<AgentTimelineResponse> {
   const raw = await get<unknown>(
     `/api/v1/agent-timeline?agent_name=${encodeURIComponent(agentName)}&since_hours=${sinceHours}&limit=${limit}`,
+    { publicRead: true },
   )
   const { parseAgentTimelineResponse } = await import('./schemas/agent-timeline')
   return parseAgentTimelineResponse(raw)
 }
 
 export async function fetchAgentRelations(agentName: string): Promise<AgentRelationsResponse> {
-  const raw = await get<unknown>(`/api/v1/agent-relations?agent_name=${encodeURIComponent(agentName)}`)
+  const raw = await get<unknown>(
+    `/api/v1/agent-relations?agent_name=${encodeURIComponent(agentName)}`,
+    { publicRead: true },
+  )
   const { parseAgentRelationsResponse } = await import('./schemas/agent-relations')
   return parseAgentRelationsResponse(raw)
 }

--- a/dashboard/src/api/dashboard-exact-lane-runs.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.ts
@@ -186,6 +186,9 @@ export function parseExactLaneRunsResponse(raw: unknown): DashboardExactLaneRuns
 export async function fetchExactLaneRuns(
   opts?: AbortableRequestOptions,
 ): Promise<DashboardExactLaneRunsResponse> {
-  const raw = await get<unknown>('/api/v1/dashboard/exact-lane-runs', { signal: opts?.signal })
+  const raw = await get<unknown>('/api/v1/dashboard/exact-lane-runs', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   return parseExactLaneRunsResponse(raw)
 }

--- a/dashboard/src/api/dashboard-execution.ts
+++ b/dashboard/src/api/dashboard-execution.ts
@@ -12,7 +12,10 @@ type DashboardExecutionRequestOptions = AbortableRequestOptions & {
 
 export function fetchDashboardExecution(opts?: DashboardExecutionRequestOptions): Promise<DashboardExecutionResponse> {
   const query = opts?.force ? '?force=1' : ''
-  return get(`/api/v1/dashboard/execution${query}`, { signal: opts?.signal })
+  return get(`/api/v1/dashboard/execution${query}`, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
 }
 
 export type DashboardExecutionTrustKeeper = Record<string, unknown> & {
@@ -33,7 +36,10 @@ export type DashboardExecutionTrustResponse = TelemetryFreshnessMetadata & {
 }
 
 export function fetchDashboardExecutionTrust(opts?: AbortableRequestOptions): Promise<DashboardExecutionTrustResponse> {
-  return get<DashboardExecutionTrustResponse>('/api/v1/dashboard/execution-trust', { signal: opts?.signal })
+  return get<DashboardExecutionTrustResponse>('/api/v1/dashboard/execution-trust', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
 }
 
 type ToolQualityToolStat = {
@@ -84,7 +90,10 @@ export function fetchToolQuality(opts?: { n?: number; windowHours?: number; sign
   if (opts?.n != null) params.set('n', String(opts.n))
   if (opts?.windowHours != null) params.set('window_hours', String(opts.windowHours))
   const qs = params.toString()
-  return get<ToolQualityResponse>(`/api/v1/dashboard/tool-quality${qs ? `?${qs}` : ''}`, { signal: opts?.signal })
+  return get<ToolQualityResponse>(`/api/v1/dashboard/tool-quality${qs ? `?${qs}` : ''}`, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
 }
 
 export interface DashboardPerfRow {
@@ -147,7 +156,7 @@ export interface DashboardPerfResponse {
 }
 
 export function fetchDashboardPerf(): Promise<DashboardPerfResponse> {
-  return get('/api/v1/dashboard/perf')
+  return get('/api/v1/dashboard/perf', { publicRead: true })
 }
 
 interface FetchDashboardMemoryOptions {
@@ -179,5 +188,5 @@ export function fetchDashboardMemory(
   if (opts?.excludeAutomation) params.set('exclude_automation', 'true')
   if (opts?.author) params.set('author', opts.author)
   if (opts?.hearth) params.set('hearth', opts.hearth)
-  return get(`/api/v1/dashboard/board${params.toString() ? `?${params}` : ''}`)
+  return get(`/api/v1/dashboard/board${params.toString() ? `?${params}` : ''}`, { publicRead: true })
 }

--- a/dashboard/src/api/dashboard-fusion.ts
+++ b/dashboard/src/api/dashboard-fusion.ts
@@ -65,6 +65,9 @@ export function parseFusionRunsResponse(raw: unknown): DashboardFusionRunsRespon
 export async function fetchFusionRuns(
   opts?: AbortableRequestOptions,
 ): Promise<DashboardFusionRunsResponse> {
-  const raw = await get<unknown>('/api/v1/dashboard/fusion-runs', { signal: opts?.signal })
+  const raw = await get<unknown>('/api/v1/dashboard/fusion-runs', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   return parseFusionRunsResponse(raw)
 }

--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -375,6 +375,7 @@ export function fetchDashboardGate(
     const query = opts?.force ? '?force=1' : ''
     const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/gate${query}`, {
       signal: opts?.signal,
+      publicRead: true,
     })
     const approvalQueueState = normalizeApprovalQueueState(raw.approval_queue_state)
     let approvalQueue: KeeperApprovalQueueItem[] | null

--- a/dashboard/src/api/dashboard-goals.ts
+++ b/dashboard/src/api/dashboard-goals.ts
@@ -431,14 +431,17 @@ function decodeDashboardGoalDetailResponse(raw: unknown): DashboardGoalDetailRes
 }
 
 export async function fetchDashboardGoalsTree(): Promise<DashboardGoalsTreeResponse> {
-  const raw = await get<unknown>('/api/v1/dashboard/goals')
+  const raw = await get<unknown>('/api/v1/dashboard/goals', { publicRead: true })
   const decoded = decodeDashboardGoalsTreeResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 dashboard goals payload')
   return decoded
 }
 
 export async function fetchDashboardGoalDetail(goalId: string): Promise<DashboardGoalDetailResponse> {
-  const raw = await get<unknown>(`/api/v1/dashboard/goals/detail?goal_id=${encodeURIComponent(goalId)}`)
+  const raw = await get<unknown>(
+    `/api/v1/dashboard/goals/detail?goal_id=${encodeURIComponent(goalId)}`,
+    { publicRead: true },
+  )
   const decoded = decodeDashboardGoalDetailResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 dashboard goal detail payload')
   return decoded

--- a/dashboard/src/api/dashboard-hot.ts
+++ b/dashboard/src/api/dashboard-hot.ts
@@ -11,11 +11,17 @@ type DashboardShellRequestOptions = AbortableRequestOptions & {
 
 export function fetchDashboardShell(opts?: DashboardShellRequestOptions): Promise<DashboardShellResponse> {
   const qs = opts?.light ? '?light=true' : ''
-  return get(`/api/v1/dashboard/shell${qs}`, { signal: opts?.signal })
+  return get(`/api/v1/dashboard/shell${qs}`, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
 }
 
 export function fetchDashboardBootstrap(opts?: AbortableRequestOptions): Promise<DashboardBootstrapResponse> {
-  return get('/api/v1/dashboard/bootstrap', { signal: opts?.signal })
+  return get('/api/v1/dashboard/bootstrap', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
 }
 
 export function fetchDashboardNamespaceTruth(
@@ -24,5 +30,6 @@ export function fetchDashboardNamespaceTruth(
   return get('/api/v1/dashboard/project-snapshot', {
     timeoutMs: NAMESPACE_TRUTH_GET_TIMEOUT_MS,
     signal: opts?.signal,
+    publicRead: true,
   })
 }

--- a/dashboard/src/api/dashboard-keeper-config.ts
+++ b/dashboard/src/api/dashboard-keeper-config.ts
@@ -4,7 +4,6 @@
 
 import { get, post } from './core'
 import { isRecord, asBoolean, asInt, asNullableString, asNumber, asStringArray, asRecordArray, isPositiveSafeInteger } from '../components/common/normalize'
-import { ensureDevToken } from './dev-token'
 import { asKeeperRuntimeBlockerClass } from '../lib/runtime-blocker-class'
 import type { KeeperConfig, KeeperHookSlot } from '../types'
 
@@ -242,7 +241,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
 // --- Keeper config (structured read-only view) ---
 
 export function fetchKeeperConfig(name: string): Promise<KeeperConfig> {
-  return get<unknown>(`/api/v1/keepers/${encodeURIComponent(name)}/config`)
+  return get<unknown>(`/api/v1/keepers/${encodeURIComponent(name)}/config`, { publicRead: true })
     .then(raw => normalizeKeeperConfig(raw, name))
 }
 
@@ -269,7 +268,6 @@ export async function patchKeeperConfig(
   name: string,
   payload: KeeperConfigUpdatePayload,
 ): Promise<KeeperConfig> {
-  await ensureDevToken()
   return post<unknown>(
     `/api/v1/keepers/${encodeURIComponent(name)}/config`,
     payload,

--- a/dashboard/src/api/dashboard-keeper-cost.ts
+++ b/dashboard/src/api/dashboard-keeper-cost.ts
@@ -90,7 +90,10 @@ export async function fetchKeeperCostMetrics(
   windowMinutes = DEFAULT_WINDOW_MINUTES_24H,
   opts?: AbortableRequestOptions,
 ): Promise<KeeperCostMetricsResponse> {
-  const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/keeper-costs?window=${windowMinutes}`, { signal: opts?.signal })
+  const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/keeper-costs?window=${windowMinutes}`, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   const decoded = decodeKeeperCostMetricsResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 keeper cost metrics payload')
   return decoded
@@ -206,7 +209,10 @@ export async function fetchKeeperDecisions(
   limit = 200,
   opts?: AbortableRequestOptions,
 ): Promise<KeeperDecisionsResponse> {
-  const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/keeper-decisions?limit=${limit}`, { signal: opts?.signal })
+  const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/keeper-decisions?limit=${limit}`, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   const decoded = decodeKeeperDecisionsResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 keeper decisions payload')
   return decoded
@@ -326,7 +332,7 @@ export async function fetchCostLatency(
 ): Promise<CostLatencyResponse> {
   const raw = await get<Record<string, unknown>>(
     `/api/v1/dashboard/cost-latency?window=${windowMinutes}`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   )
   const decoded = decodeCostLatencyResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 cost-latency payload')

--- a/dashboard/src/api/dashboard-keeper-prompt.test.ts
+++ b/dashboard/src/api/dashboard-keeper-prompt.test.ts
@@ -8,8 +8,7 @@ import {
 } from './dashboard-keeper-prompt'
 import { clearStoredToken, setStoredToken } from './core'
 
-// A Response body can only be read once and ensureDevToken consumes the first,
-// so each call needs a fresh instance rather than one shared mock value.
+// Keep each response fresh so every request observes an independent body.
 function stubFetch(payload: unknown, status = 200) {
   const fetchMock = vi.fn().mockImplementation(
     async () =>
@@ -42,11 +41,13 @@ const capture = {
 
 describe('last prompt', () => {
   it('keeps block text byte-for-byte, newlines included', async () => {
-    stubFetch(capture)
+    const fetchMock = stubFetch(capture)
     const decoded = await fetchKeeperLastPrompt('kidsnote')
     expect(decoded.absoluteTurn).toBe(17534)
     expect(decoded.blocks[0]?.text).toBe('--- Memory OS Recall ---\nrevision 223\n')
     expect(decoded.assembled).toBe('--- Memory OS Recall ---\nrevision 223\n')
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(init.headers).toEqual({})
   })
 
   it('accepts the operator_note block this build knows', async () => {
@@ -81,7 +82,7 @@ describe('last prompt', () => {
 
 describe('raw traces', () => {
   it('decodes the turn listing', async () => {
-    stubFetch({
+    const fetchMock = stubFetch({
       keeper: 'kidsnote',
       turns: [{ file: 'turn-1.jsonl', trace_id: 'trace-kidsnote-1', bytes: 2048, records: 218, modified_at: 1786000000 }],
     })
@@ -89,6 +90,9 @@ describe('raw traces', () => {
     expect(turns).toHaveLength(1)
     expect(turns[0]?.records).toBe(218)
     expect(turns[0]?.traceId).toBe('trace-kidsnote-1')
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/keepers/kidsnote/raw-traces?limit=25')
+    expect(init.headers).toEqual({})
   })
 
   // A torn line occupies its own position. Dropping it would make a damaged

--- a/dashboard/src/api/dashboard-keeper-prompt.ts
+++ b/dashboard/src/api/dashboard-keeper-prompt.ts
@@ -11,7 +11,6 @@
 // can trust what they are looking at.
 
 import { get, post, type AbortableRequestOptions } from './core'
-import { ensureDevToken } from './dev-token'
 import { isRecord, asNumber, asString } from '../components/common/normalize'
 import { type TurnPromptBlockId } from './dashboard-turn-records'
 
@@ -82,10 +81,9 @@ export async function fetchKeeperLastPrompt(
   name: string,
   opts?: AbortableRequestOptions,
 ): Promise<PromptCapture> {
-  await ensureDevToken()
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/last-prompt`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   ).then((raw) => {
     const decoded = decodeCapture(raw)
     if (!decoded) throw new Error('유효하지 않은 prompt capture payload')
@@ -125,11 +123,10 @@ export async function fetchKeeperRawTraces(
   limit?: number,
   opts?: AbortableRequestOptions,
 ): Promise<readonly RawTraceTurn[]> {
-  await ensureDevToken()
   const params = limit == null ? '' : `?limit=${encodeURIComponent(String(limit))}`
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/raw-traces${params}`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   ).then((raw) => {
     if (!isRecord(raw) || !Array.isArray(raw.turns)) {
       throw new Error('유효하지 않은 raw trace 목록 payload')
@@ -176,13 +173,12 @@ export async function fetchKeeperRawTrace(
   file: string,
   opts?: AbortableRequestOptions & { offset?: number; limit?: number },
 ): Promise<RawTracePage> {
-  await ensureDevToken()
   const query = new URLSearchParams({ file })
   if (opts?.offset != null) query.set('offset', String(opts.offset))
   if (opts?.limit != null) query.set('limit', String(opts.limit))
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/raw-trace?${query.toString()}`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   ).then((raw) => {
     if (!isRecord(raw)) throw new Error('유효하지 않은 raw trace payload')
     const fileName = asString(raw.file)
@@ -219,7 +215,6 @@ export async function putKeeperOperatorNote(
   name: string,
   text: string,
 ): Promise<OperatorNote> {
-  await ensureDevToken()
   const raw = await post<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/operator-note`,
     { text },
@@ -259,10 +254,9 @@ export async function fetchKeeperOperatorNote(
   name: string,
   opts?: AbortableRequestOptions,
 ): Promise<OperatorNote> {
-  await ensureDevToken()
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/operator-note`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   ).then((raw) => {
     if (!isRecord(raw)) throw new Error('유효하지 않은 operator note payload')
     return decodeNoteResponse(raw)

--- a/dashboard/src/api/dashboard-keeper-secrets.ts
+++ b/dashboard/src/api/dashboard-keeper-secrets.ts
@@ -1,6 +1,5 @@
 import { isRecord } from '../components/common/normalize'
 import { post } from './core'
-import { ensureDevToken } from './dev-token'
 import {
   parseKeeperSecretProjection,
   type KeeperSecretProjection,
@@ -39,7 +38,6 @@ export async function setKeeperSecretEnv(
   keeperName: string,
   mutation: KeeperSecretEnvSetMutation,
 ): Promise<KeeperSecretProjection> {
-  await ensureDevToken()
   const raw = await post<unknown>(secretMutationPath(keeperName), {
     action: 'set_env',
     scope: mutation.scope,
@@ -53,7 +51,6 @@ export async function deleteKeeperSecretEnv(
   keeperName: string,
   mutation: KeeperSecretEnvMutation,
 ): Promise<KeeperSecretProjection> {
-  await ensureDevToken()
   const raw = await post<unknown>(secretMutationPath(keeperName), {
     action: 'delete_env',
     scope: mutation.scope,
@@ -66,7 +63,6 @@ export async function setKeeperSecretFile(
   keeperName: string,
   mutation: KeeperSecretFileSetMutation,
 ): Promise<KeeperSecretProjection> {
-  await ensureDevToken()
   const raw = await post<unknown>(secretMutationPath(keeperName), {
     action: 'set_file',
     scope: mutation.scope,
@@ -80,7 +76,6 @@ export async function deleteKeeperSecretFile(
   keeperName: string,
   mutation: KeeperSecretFileMutation,
 ): Promise<KeeperSecretProjection> {
-  await ensureDevToken()
   const raw = await post<unknown>(secretMutationPath(keeperName), {
     action: 'delete_file',
     scope: mutation.scope,

--- a/dashboard/src/api/dashboard-keeper-tool-calls.ts
+++ b/dashboard/src/api/dashboard-keeper-tool-calls.ts
@@ -124,7 +124,7 @@ export function fetchKeeperToolCalls(
   const params = limit != null ? `?limit=${limit}` : ''
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/tool-calls${params}`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   ).then((raw) => {
     const decoded = decodeToolCallsResponse(raw)
     if (!decoded) throw new Error('유효하지 않은 keeper tool call payload')

--- a/dashboard/src/api/dashboard-keeper-tool-stats.ts
+++ b/dashboard/src/api/dashboard-keeper-tool-stats.ts
@@ -83,7 +83,7 @@ export function fetchKeeperToolStats(
   const params = windowHours != null ? `?window_hours=${windowHours}` : ''
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/tool-stats${params}`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   ).then((raw) => {
     const decoded = decodeToolStatsResponse(raw)
     if (!decoded) throw new Error('유효하지 않은 keeper tool stats payload')

--- a/dashboard/src/api/dashboard-keeper-trajectory.ts
+++ b/dashboard/src/api/dashboard-keeper-trajectory.ts
@@ -61,5 +61,6 @@ export function fetchKeeperTrajectory(
   const qs = params.toString()
   return get<TrajectoryResponse>(
     `/api/v1/keepers/${encodeURIComponent(name)}/trajectory${qs ? `?${qs}` : ''}`,
+    { publicRead: true },
   )
 }

--- a/dashboard/src/api/dashboard-logs.ts
+++ b/dashboard/src/api/dashboard-logs.ts
@@ -3,7 +3,6 @@
 // from dashboard.ts so existing consumers (`from './api/dashboard'`) are unchanged.
 
 import { get } from './core'
-import { ensureDevToken } from './dev-token'
 import type { DashboardConfigResponse } from './schemas/dashboard-config'
 import type { LogsResponse } from './schemas/logs'
 import type {
@@ -33,13 +32,13 @@ export async function fetchLogs(opts?: {
   if (opts?.category) params.set('category', opts.category)
   if (opts?.exclude_category) params.set('exclude_category', opts.exclude_category)
   const qs = params.toString()
-  const raw = await get<unknown>(`/api/v1/dashboard/logs${qs ? `?${qs}` : ''}`)
+  const raw = await get<unknown>(`/api/v1/dashboard/logs${qs ? `?${qs}` : ''}`, { publicRead: true })
   const { parseLogsResponse } = await import('./schemas/logs')
   return parseLogsResponse(raw)
 }
 
 export async function fetchProviderLogsCatalog(): Promise<ProviderLogsCatalogResponse> {
-  const raw = await get<unknown>('/api/v1/dashboard/provider-logs')
+  const raw = await get<unknown>('/api/v1/dashboard/provider-logs', { publicRead: true })
   const { parseProviderLogsCatalogResponse } = await import('./schemas/provider-logs')
   return parseProviderLogsCatalogResponse(raw)
 }
@@ -51,14 +50,13 @@ export async function fetchProviderLogTail(
   const params = new URLSearchParams()
   params.set('provider', provider)
   if (opts?.lines) params.set('lines', String(opts.lines))
-  const raw = await get<unknown>(`/api/v1/dashboard/provider-logs/tail?${params.toString()}`)
+  const raw = await get<unknown>(`/api/v1/dashboard/provider-logs/tail?${params.toString()}`, { publicRead: true })
   const { parseProviderLogTailResponse } = await import('./schemas/provider-logs')
   return parseProviderLogTailResponse(raw)
 }
 
 export async function fetchDashboardConfig(): Promise<DashboardConfigResponse> {
-  await ensureDevToken()
-  const raw = await get<unknown>('/api/v1/dashboard/config')
+  const raw = await get<unknown>('/api/v1/dashboard/config', { publicRead: true })
   const { parseDashboardConfigResponse } = await import('./schemas/dashboard-config')
   return parseDashboardConfigResponse(raw)
 }

--- a/dashboard/src/api/dashboard-memory-journal.test.ts
+++ b/dashboard/src/api/dashboard-memory-journal.test.ts
@@ -2,20 +2,21 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { fetchKeeperMemoryJournal } from './dashboard-memory-journal'
 import { clearStoredToken, setStoredToken } from './core'
 
-// A Response body reads once and ensureDevToken consumes the first, so each
-// call needs a fresh instance rather than one shared mock value.
+// Keep each response fresh so every request observes an independent body.
 function stubFetch(payload: unknown) {
+  const fetchMock = vi.fn().mockImplementation(
+    async () =>
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+  )
   vi.stubGlobal(
     'fetch',
-    vi.fn().mockImplementation(
-      async () =>
-        new Response(JSON.stringify(payload), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-    ),
+    fetchMock,
   )
   setStoredToken('journal-test-token', { source: 'manual' })
+  return fetchMock
 }
 
 afterEach(() => {
@@ -54,7 +55,7 @@ function payload(entries: unknown[], undecodable = 0) {
 
 describe('memory journal', () => {
   it('keeps a commit and a failure as different members', async () => {
-    stubFetch(payload([committed, failed]))
+    const fetchMock = stubFetch(payload([committed, failed]))
     const journal = await fetchKeeperMemoryJournal('kidsnote')
     const [first, second] = journal.entries
     expect(first?.ok).toBe(true)
@@ -66,6 +67,9 @@ describe('memory journal', () => {
       expect(second.detail).toBe('Eio net/clock context unavailable')
       expect(second.kind).toBe('runtime_context_unavailable')
     }
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/keepers/kidsnote/memory-journal')
+    expect(init.headers).toEqual({})
   })
 
   // Drop reasons ride this line and nothing else stores them.

--- a/dashboard/src/api/dashboard-memory-journal.ts
+++ b/dashboard/src/api/dashboard-memory-journal.ts
@@ -7,7 +7,6 @@
 // for the case an operator actually opens — why it produced nothing.
 
 import { get, type AbortableRequestOptions } from './core'
-import { ensureDevToken } from './dev-token'
 import { isRecord, asNumber, asString } from '../components/common/normalize'
 
 export type MemoryJournalDrop = {
@@ -172,11 +171,10 @@ export async function fetchKeeperMemoryJournal(
   limit?: number,
   opts?: AbortableRequestOptions,
 ): Promise<MemoryJournal> {
-  await ensureDevToken()
   const params = limit == null ? '' : `?limit=${encodeURIComponent(String(limit))}`
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/memory-journal${params}`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   ).then((raw) => {
     if (!isRecord(raw) || !Array.isArray(raw.entries)) {
       throw new Error('유효하지 않은 memory journal payload')

--- a/dashboard/src/api/dashboard-misc.ts
+++ b/dashboard/src/api/dashboard-misc.ts
@@ -295,7 +295,7 @@ function decodeKeeperMemoryHealth(raw: unknown): KeeperMemoryHealthResponse | nu
 }
 
 export function fetchKeeperMemoryHealth(): Promise<KeeperMemoryHealthResponse> {
-  return get<unknown>('/api/v1/dashboard/keeper-memory-health').then((raw) => {
+  return get<unknown>('/api/v1/dashboard/keeper-memory-health', { publicRead: true }).then((raw) => {
     const decoded = decodeKeeperMemoryHealth(raw)
     if (!decoded) throw new Error('유효하지 않은 keeper memory health payload')
     return decoded
@@ -348,7 +348,10 @@ export function fetchVerificationRequests(
   const path = qs.length > 0
     ? `/api/v1/verification/requests?${qs}`
     : '/api/v1/verification/requests'
-  return get<VerificationRequestsResponse>(path, { signal: opts?.signal })
+  return get<VerificationRequestsResponse>(path, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
 }
 
 export type TlaSpecCategory = 'boundary' | 'bug-models' | 'other'
@@ -374,6 +377,7 @@ export function fetchTlaSpecs(
 ): Promise<TlaSpecsResponse> {
   return get<TlaSpecsResponse>('/api/v1/verification/specs', {
     signal: opts?.signal,
+    publicRead: true,
   })
 }
 
@@ -410,6 +414,7 @@ export function fetchTlcResults(
 ): Promise<TlcResultsResponse> {
   return get<TlcResultsResponse>('/api/v1/verification/tlc-results', {
     signal: opts?.signal,
+    publicRead: true,
   })
 }
 
@@ -452,5 +457,6 @@ export function fetchAuditLedger(
   if (until != null) qs.set('until', String(until))
   return get<AuditLedgerResponse>(`/api/v1/audit?${qs.toString()}`, {
     signal: opts?.signal,
+    publicRead: true,
   })
 }

--- a/dashboard/src/api/dashboard-mission.ts
+++ b/dashboard/src/api/dashboard-mission.ts
@@ -9,7 +9,7 @@ import type {
 } from '../types'
 
 export function fetchDashboardBriefing(): Promise<DashboardMissionResponse> {
-  return get('/api/v1/dashboard/briefing')
+  return get('/api/v1/dashboard/briefing', { publicRead: true })
 }
 
 export function fetchDashboardMission(): Promise<DashboardMissionResponse> {
@@ -21,9 +21,12 @@ export function fetchDashboardMissionBriefing(
   opts?: { signal?: AbortSignal },
 ): Promise<DashboardMissionBriefingResponse> {
   const query = force ? '?force=1' : ''
-  return get(`/api/v1/dashboard/briefing/sections${query}`, { signal: opts?.signal })
+  return get(`/api/v1/dashboard/briefing/sections${query}`, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
 }
 
 export function fetchDashboardPlanning(): Promise<DashboardPlanningResponse> {
-  return get('/api/v1/dashboard/planning')
+  return get('/api/v1/dashboard/planning', { publicRead: true })
 }

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -4,7 +4,6 @@
 
 import { get, post, type AbortableRequestOptions } from './core'
 import { isRecord, asBoolean, asNumber, asNullableString, asRecordArray, asString, asStringArray } from '../components/common/normalize'
-import { ensureDevToken } from './dev-token'
 import type { RuntimeDefaultsResponse } from './schemas/runtime-defaults'
 import type { RuntimeResolvedResponse } from './schemas/runtime-resolved'
 
@@ -1006,7 +1005,10 @@ function decodeRuntimeModelMetricsResponse(raw: unknown): DashboardRuntimeModelM
 }
 
 export async function fetchRuntimeProviders(opts?: AbortableRequestOptions): Promise<DashboardRuntimeProvidersResponse> {
-  const raw = await get<Record<string, unknown>>('/api/v1/providers', { signal: opts?.signal })
+  const raw = await get<Record<string, unknown>>('/api/v1/providers', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   const decoded = decodeRuntimeProvidersResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 runtime lanes payload')
   return decoded
@@ -1018,7 +1020,10 @@ export async function fetchRuntimeModelMetrics(
   opts?: AbortableRequestOptions,
 ): Promise<DashboardRuntimeModelMetricsResponse> {
   const bParam = bucketMinutes > 0 ? `&bucket_min=${bucketMinutes}` : ''
-  const raw = await get<Record<string, unknown>>(`/api/v1/models/metrics?window=${windowMinutes}${bParam}`, { signal: opts?.signal })
+  const raw = await get<Record<string, unknown>>(`/api/v1/models/metrics?window=${windowMinutes}${bParam}`, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   const decoded = decodeRuntimeModelMetricsResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 runtime model metrics payload')
   return decoded
@@ -1642,17 +1647,19 @@ function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
 }
 
 export async function fetchRuntimeTomlConfig(): Promise<RuntimeTomlConfig> {
-  await ensureDevToken()
-  return get<unknown>('/api/v1/runtime/config/raw').then(normalizeRuntimeTomlConfig)
+  return get<unknown>('/api/v1/runtime/config/raw', { publicRead: true })
+    .then(normalizeRuntimeTomlConfig)
 }
 
 export async function fetchOfficialClientSession(
   keeperName: string,
   opts?: AbortableRequestOptions,
 ): Promise<DashboardOfficialClientSessionResponse> {
-  await ensureDevToken()
   const query = new URLSearchParams({ keeper_name: keeperName })
-  const raw = await get<unknown>(`/api/v1/runtime/sessions/official-client?${query}`, { signal: opts?.signal })
+  const raw = await get<unknown>(`/api/v1/runtime/sessions/official-client?${query}`, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   const decoded = decodeOfficialClientSessionResponse(raw)
   if (!decoded) throw new Error('유효하지 않은 official-client session payload')
   return decoded
@@ -1663,7 +1670,6 @@ export async function resolveOfficialClientSession(
   recoveryId: string,
   decision: DashboardOfficialClientRecoveryDecision,
 ): Promise<DashboardOfficialClientRecoveryResponse> {
-  await ensureDevToken()
   const raw = await post<unknown>('/api/v1/runtime/sessions/official-client/resolve', {
     keeper_name: keeperName,
     recovery_id: recoveryId,
@@ -1677,7 +1683,6 @@ export async function resolveOfficialClientSession(
 export async function probeOfficialClientLogin(
   runtimeId: string,
 ): Promise<DashboardOfficialClientProbeResponse> {
-  await ensureDevToken()
   const raw = await post<unknown>('/api/v1/runtime/official-client/probe', {
     runtime_id: runtimeId,
   })
@@ -1692,7 +1697,10 @@ export async function probeOfficialClientLogin(
 export async function fetchRuntimeDefaults(
   opts?: AbortableRequestOptions,
 ): Promise<RuntimeDefaultsResponse> {
-  const raw = await get<unknown>('/api/v1/dashboard/runtime-defaults', { signal: opts?.signal })
+  const raw = await get<unknown>('/api/v1/dashboard/runtime-defaults', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   const { parseRuntimeDefaultsResponse } = await import('./schemas/runtime-defaults')
   return parseRuntimeDefaultsResponse(raw)
 }
@@ -1704,13 +1712,15 @@ export async function fetchRuntimeDefaults(
 export async function fetchRuntimeResolved(
   opts?: AbortableRequestOptions,
 ): Promise<RuntimeResolvedResponse> {
-  const raw = await get<unknown>('/api/v1/runtime/resolved', { signal: opts?.signal })
+  const raw = await get<unknown>('/api/v1/runtime/resolved', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   const { parseRuntimeResolvedResponse } = await import('./schemas/runtime-resolved')
   return parseRuntimeResolvedResponse(raw)
 }
 
 export async function saveRuntimeTomlConfig(sourceText: string): Promise<RuntimeTomlConfig> {
-  await ensureDevToken()
   return post<unknown>('/api/v1/runtime/config/raw', {
     source_text: sourceText,
   }).then(normalizeRuntimeTomlConfig)
@@ -1724,7 +1734,6 @@ export async function patchRuntimeRouting(
   lane: RuntimeRoutingLane,
   runtimeId: string | null,
 ): Promise<RuntimeTomlConfig> {
-  await ensureDevToken()
   return post<unknown>('/api/v1/runtime/config/routing', {
     lane,
     runtime_id: runtimeId,
@@ -1734,7 +1743,6 @@ export async function patchRuntimeRouting(
 export async function patchRuntimeMediaFailover(
   runtimeIds: readonly string[],
 ): Promise<RuntimeTomlConfig> {
-  await ensureDevToken()
   return post<unknown>('/api/v1/runtime/config/routing', {
     lane: 'media_failover',
     runtime_ids: [...runtimeIds],
@@ -1745,7 +1753,6 @@ export async function patchRuntimeAssignment(
   keeperName: string,
   runtimeId: string | null,
 ): Promise<RuntimeTomlConfig> {
-  await ensureDevToken()
   return post<unknown>('/api/v1/runtime/config/assignment', {
     keeper_name: keeperName,
     runtime_id: runtimeId,

--- a/dashboard/src/api/dashboard-scheduled-automation.test.ts
+++ b/dashboard/src/api/dashboard-scheduled-automation.test.ts
@@ -120,8 +120,6 @@ describe('normalizeScheduledAutomation', () => {
 
 describe('fetchDashboardScheduledAutomation', () => {
   it('requests the dedicated endpoint, not the tool inventory', async () => {
-    // A fresh Response per call: a body can only be read once, and the
-    // dev-token preflight consumes the first one.
     const fetchMock = vi.fn().mockImplementation(() =>
       Promise.resolve(
         new Response(JSON.stringify({ status: 'idle', request_count: 0, counts: {} }), {
@@ -137,5 +135,7 @@ describe('fetchDashboardScheduledAutomation', () => {
     const requested = fetchMock.mock.calls.map(call => String(call[0]))
     expect(requested.some(url => url.includes('/api/v1/dashboard/scheduled-automation'))).toBe(true)
     expect(requested.some(url => url.includes('/api/v1/dashboard/tools'))).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers).toEqual({})
   })
 })

--- a/dashboard/src/api/dashboard-scheduled-automation.ts
+++ b/dashboard/src/api/dashboard-scheduled-automation.ts
@@ -6,7 +6,6 @@
 // state pulled the whole tool inventory with it.
 
 import { get, type AbortableRequestOptions } from './core'
-import { ensureDevToken } from './dev-token'
 import type {
   DashboardScheduledAutomation,
   DashboardScheduledAutomationFsm,
@@ -205,9 +204,9 @@ export function normalizeScheduledAutomation(
 export async function fetchDashboardScheduledAutomation(
   opts?: AbortableRequestOptions,
 ): Promise<DashboardScheduledAutomationProjection> {
-  await ensureDevToken()
   const raw = await get<unknown>('/api/v1/dashboard/scheduled-automation', {
     signal: opts?.signal,
+    publicRead: true,
   })
   return normalizeScheduledAutomation(raw)
 }

--- a/dashboard/src/api/dashboard-telemetry.ts
+++ b/dashboard/src/api/dashboard-telemetry.ts
@@ -229,7 +229,10 @@ export function fetchTelemetry(opts?: {
   if (typeof opts?.n === 'number') params.set('n', String(opts.n))
   if (typeof opts?.offset === 'number') params.set('offset', String(opts.offset))
   const qs = params.toString()
-  return get<Record<string, unknown>>(`/api/v1/dashboard/telemetry${qs ? '?' + qs : ''}`, { signal: opts?.signal })
+  return get<Record<string, unknown>>(`/api/v1/dashboard/telemetry${qs ? '?' + qs : ''}`, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
     .then((raw) => {
       const decoded = decodeTelemetryResponse(raw)
       if (!decoded) throw new Error('유효하지 않은 telemetry payload')
@@ -238,7 +241,10 @@ export function fetchTelemetry(opts?: {
 }
 
 export function fetchTelemetrySummary(opts?: AbortableRequestOptions): Promise<TelemetrySummaryResponse> {
-  return get<Record<string, unknown>>('/api/v1/dashboard/telemetry/summary', { signal: opts?.signal })
+  return get<Record<string, unknown>>('/api/v1/dashboard/telemetry/summary', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
     .then((raw) => {
       const decoded = decodeTelemetrySummaryResponse(raw)
       if (!decoded) throw new Error('유효하지 않은 telemetry summary payload')
@@ -247,7 +253,10 @@ export function fetchTelemetrySummary(opts?: AbortableRequestOptions): Promise<T
 }
 
 export function fetchDashboardCacheStats(opts?: AbortableRequestOptions): Promise<DashboardCacheStatsResponse> {
-  return get<Record<string, unknown>>('/api/v1/dashboard/cache-stats', { signal: opts?.signal })
+  return get<Record<string, unknown>>('/api/v1/dashboard/cache-stats', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
     .then((raw) => {
       const decoded = decodeDashboardCacheStatsResponse(raw)
       if (!decoded) throw new Error('유효하지 않은 dashboard cache stats payload')

--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -3,7 +3,6 @@
 // from dashboard.ts so existing consumers (`from './api/dashboard'`) are unchanged.
 
 import { get, post, type AbortableRequestOptions } from './core'
-import { ensureDevToken } from './dev-token'
 import type { TelemetryFreshnessMetadata } from './dashboard-shared'
 import type { DashboardConfigResolution, DashboardRuntimeResolution } from '../types'
 
@@ -666,7 +665,7 @@ export interface DashboardRuntimeProbeResponse {
 }
 
 export function fetchToolMetrics(): Promise<ToolMetricsResponse> {
-  return get('/api/v1/tool-metrics')
+  return get('/api/v1/tool-metrics', { publicRead: true })
 }
 
 export async function fetchDashboardRuntimeProbe(
@@ -674,14 +673,19 @@ export async function fetchDashboardRuntimeProbe(
   opts?: AbortableRequestOptions,
 ): Promise<DashboardRuntimeProbeResponse> {
   const query = force ? '?force=1' : ''
-  await ensureDevToken()
-  return get(`/api/v1/dashboard/runtime-probe${query}`, { signal: opts?.signal })
+  return get(`/api/v1/dashboard/runtime-probe${query}`, {
+    signal: opts?.signal,
+    publicRead: true,
+  })
 }
 
 export async function fetchDashboardFullHealth(
   opts?: AbortableRequestOptions,
 ): Promise<DashboardFullHealthResponse> {
-  const raw = await get<DashboardFullHealthResponse>('/health?full=1', { signal: opts?.signal })
+  const raw = await get<DashboardFullHealthResponse>('/health?full=1', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   return normalizeFullHealthResponse(raw)
 }
 
@@ -776,8 +780,10 @@ export function normalizeFullHealthResponse(
 }
 
 export async function fetchDashboardTools(opts?: AbortableRequestOptions): Promise<DashboardToolsResponse> {
-  await ensureDevToken()
-  const raw = await get<DashboardToolsResponse>('/api/v1/dashboard/tools', { signal: opts?.signal })
+  const raw = await get<DashboardToolsResponse>('/api/v1/dashboard/tools', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   const normalizedTools = raw.tool_inventory?.tools?.map(t => ({
     ...t,
     category: t.category ?? 'uncategorized',
@@ -807,10 +813,9 @@ export async function fetchKeeperWaitingInventory(
   keeperName: string,
   opts?: AbortableRequestOptions,
 ): Promise<DashboardKeeperWaitingInventory> {
-  await ensureDevToken()
   const raw = await get<DashboardKeeperWaitingInventory>(
     `/api/v1/keepers/${encodeURIComponent(keeperName)}/waiting-inventory`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   )
   return normalizeKeeperWaitingInventory(raw)
 }
@@ -851,7 +856,7 @@ interface PromptMutationResponse {
 }
 
 export function fetchDashboardPrompts(): Promise<DashboardPromptsResponse> {
-  return get('/api/v1/prompts')
+  return get('/api/v1/prompts', { publicRead: true })
 }
 
 export function savePromptOverride(key: string, value: string): Promise<PromptMutationResponse> {

--- a/dashboard/src/api/dashboard-turn-records.test.ts
+++ b/dashboard/src/api/dashboard-turn-records.test.ts
@@ -8,7 +8,10 @@ vi.mock('./core', () => ({
 }))
 vi.mock('./dev-token', () => ({ ensureDevToken }))
 
-import { fetchKeeperTurnRecords } from './dashboard-turn-records'
+import {
+  fetchKeeperCompactionSnapshots,
+  fetchKeeperTurnRecords,
+} from './dashboard-turn-records'
 
 function entry(overrides: Record<string, unknown> = {}) {
   return {
@@ -69,8 +72,56 @@ function payload(...entries: ReturnType<typeof entry>[]) {
   }
 }
 
+function compactionSnapshotsPayload() {
+  return {
+    schema: 'keeper.compaction_snapshots.v1',
+    keeper: 'sangsu',
+    source: 'runtime_manifest|keeper_meta',
+    producer: 'keeper_runtime_manifest|keeper_meta_store',
+    limit: 25,
+    count: 0,
+    read_error_count: 0,
+    read_errors: [],
+    scan_truncated: false,
+    hydration_status: 'ready',
+    items: [],
+  }
+}
+
 afterEach(() => {
   getMock.mockReset()
+  ensureDevToken.mockClear()
+})
+
+describe('public keeper inspectors', () => {
+  it('loads turn records and compaction snapshots without a dev-token bootstrap', async () => {
+    getMock
+      .mockResolvedValueOnce(payload(entry()))
+      .mockResolvedValueOnce(compactionSnapshotsPayload())
+
+    const [turnRecords, snapshots] = await Promise.all([
+      fetchKeeperTurnRecords('sangsu'),
+      fetchKeeperCompactionSnapshots('sangsu'),
+    ])
+
+    expect(turnRecords.keeper).toBe('sangsu')
+    expect(snapshots).toMatchObject({
+      keeper: 'sangsu',
+      hydration_status: 'ready',
+      items: [],
+    })
+    expect(ensureDevToken).not.toHaveBeenCalled()
+    expect(getMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/v1/keepers/sangsu/turn-records',
+      { signal: undefined, publicRead: true },
+    )
+    expect(getMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/v1/keepers/sangsu/compaction-snapshots',
+      { signal: undefined, publicRead: true },
+    )
+  })
 })
 
 // #25779 made the provider cache token counts durable on the turn record, but

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -3,7 +3,6 @@
 // from dashboard.ts so existing consumers (`from './api/dashboard'`) are unchanged.
 
 import { get, type AbortableRequestOptions } from './core'
-import { ensureDevToken } from './dev-token'
 import { isRecord, asBoolean, asNumber, asNullableString, asString, asRecordArray } from '../components/common/normalize'
 import { type TelemetryFreshnessMetadata } from './dashboard-shared'
 
@@ -1153,10 +1152,9 @@ export async function fetchKeeperTurnRecords(
   opts?: AbortableRequestOptions,
 ): Promise<TurnRecordsResponse> {
   const params = limitQueryString(limit)
-  await ensureDevToken()
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/turn-records${params}`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   ).then((raw) => {
     const decoded = decodeTurnRecordsResponse(raw)
     if (!decoded) throw new Error('유효하지 않은 keeper turn record payload')
@@ -1174,10 +1172,9 @@ export async function fetchKeeperCompactionSnapshots(
   if (opts?.refresh === true) query.set('refresh', 'true')
   const encoded = query.toString()
   const params = encoded ? `?${encoded}` : ''
-  await ensureDevToken()
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/compaction-snapshots${params}`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   ).then((raw) => {
     const decoded = decodeKeeperCompactionSnapshotsResponse(raw)
     if (!decoded) throw new Error('유효하지 않은 keeper compaction snapshot payload')
@@ -1251,7 +1248,7 @@ export function fetchKeeperTurnTranscript(
 ): Promise<TurnTranscript> {
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/turn-transcript?turn_ref=${encodeURIComponent(turnRef)}`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   ).then((raw) => {
     const decoded = decodeTurnTranscript(raw)
     if (!decoded) throw new Error('유효하지 않은 keeper turn transcript payload')

--- a/dashboard/src/api/dashboard-verification-runs.ts
+++ b/dashboard/src/api/dashboard-verification-runs.ts
@@ -255,6 +255,9 @@ export function parseVerificationRunsResponse(raw: unknown): DashboardVerificati
 export async function fetchVerificationRuns(
   opts?: AbortableRequestOptions,
 ): Promise<DashboardVerificationRunsResponse> {
-  const raw = await get<unknown>('/api/v1/dashboard/verification-runs', { signal: opts?.signal })
+  const raw = await get<unknown>('/api/v1/dashboard/verification-runs', {
+    signal: opts?.signal,
+    publicRead: true,
+  })
   return parseVerificationRunsResponse(raw)
 }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1,13 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const devTokenMock = vi.hoisted(() => ({
-  ensureDevToken: vi.fn(() => Promise.resolve()),
-}))
-
-vi.mock('./dev-token', () => ({
-  ensureDevToken: devTokenMock.ensureDevToken,
-}))
-
 import {
   fetchDashboardShell,
   fetchDashboardExecution,
@@ -61,8 +53,6 @@ import { keeperRuntimeBlockerLabel } from '../lib/keeper-runtime-display'
 
 afterEach(() => {
   vi.unstubAllGlobals()
-  devTokenMock.ensureDevToken.mockClear()
-  devTokenMock.ensureDevToken.mockResolvedValue(undefined)
 })
 
 function makeRawGoalNode(overrides: Record<string, unknown> = {}) {
@@ -1026,7 +1016,7 @@ describe('fetchDashboardTools', () => {
     expect(parseDashboardKeeperWaitingSource(null)).toBeNull()
   })
 
-  it('reads the keeper-scoped waiting inventory after auth bootstrap', async () => {
+  it('reads the keeper-scoped waiting inventory without auth bootstrap', async () => {
     const rawResponse = {
       keeper_count: 1,
       waiting_keeper_count: 1,
@@ -1053,8 +1043,8 @@ describe('fetchDashboardTools', () => {
 
     const result = await fetchKeeperWaitingInventory('kidsnote')
 
-    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/kidsnote/waiting-inventory')
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers).toEqual({})
     expect(result.keepers[0]?.waiting_on[0]?.source).toBe('event_queue_pending')
   })
 
@@ -1080,10 +1070,7 @@ describe('fetchDashboardTools', () => {
 
     const result = await fetchDashboardTools()
 
-    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
-    expect(devTokenMock.ensureDevToken.mock.invocationCallOrder[0]).toBeLessThan(
-      fetchMock.mock.invocationCallOrder[0]!,
-    )
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers).toEqual({})
     const tools = result.tool_inventory.tools
     expect(tools[0]).toMatchObject({ name: 'tool_a', category: 'uncategorized', tier: '(unknown tier)' })
     expect(tools[1]).toMatchObject({ name: 'tool_b', category: 'keeper', tier: '(unknown tier)' })
@@ -3034,7 +3021,7 @@ describe('fetchKeeperConfig', () => {
 })
 
 describe('keeper config mutation API', () => {
-  it('ensures dashboard auth before posting runtime_id changes', async () => {
+  it('posts runtime_id changes without dashboard-token bootstrap', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         name: 'keeper-sangsu',
@@ -3057,10 +3044,6 @@ describe('keeper config mutation API', () => {
 
     const result = await patchKeeperConfig('keeper-sangsu', { runtime_id: 'b.two' })
 
-    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
-    expect(devTokenMock.ensureDevToken.mock.invocationCallOrder[0]).toBeLessThan(
-      fetchMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    )
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/keepers/keeper-sangsu/config')
@@ -3071,7 +3054,7 @@ describe('keeper config mutation API', () => {
 })
 
 describe('dashboard runtime probe API', () => {
-  it('ensures dashboard auth before fetching runtime probe status', async () => {
+  it('fetches the public runtime probe without a dashboard-token bootstrap', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         generated_at: '2026-06-10T12:00:00Z',
@@ -3090,12 +3073,10 @@ describe('dashboard runtime probe API', () => {
 
     const result = await fetchDashboardRuntimeProbe(true)
 
-    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
-    expect(devTokenMock.ensureDevToken.mock.invocationCallOrder[0]).toBeLessThan(
-      fetchMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    )
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/runtime-probe?force=1')
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/dashboard/runtime-probe?force=1')
+    expect(init.headers).toEqual({})
     expect(result.probe?.probe_ok).toBe(true)
   })
 })
@@ -3136,10 +3117,6 @@ describe('runtime.toml raw config API', () => {
 
     const result = await fetchRuntimeTomlConfig()
 
-    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
-    expect(devTokenMock.ensureDevToken.mock.invocationCallOrder[0]).toBeLessThan(
-      fetchMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    )
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/runtime/config/raw')
     expect(result.path).toBe('/tmp/.masc/config/runtime.toml')
     expect(result.file_name).toBe('runtime.toml')
@@ -3196,10 +3173,6 @@ describe('runtime.toml raw config API', () => {
 
     const result = await saveRuntimeTomlConfig(sourceText)
 
-    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
-    expect(devTokenMock.ensureDevToken.mock.invocationCallOrder[0]).toBeLessThan(
-      fetchMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    )
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/runtime/config/raw')
@@ -3228,7 +3201,6 @@ describe('runtime.toml raw config API', () => {
 
     const result = await patchRuntimeRouting('cross_verifier', 'openai.gpt')
 
-    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/runtime/config/routing')
     expect(init.method).toBe('POST')
@@ -3258,7 +3230,6 @@ describe('runtime.toml raw config API', () => {
 
     const result = await patchRuntimeMediaFailover(['rt-a', 'rt-b'])
 
-    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/runtime/config/routing')
     expect(init.method).toBe('POST')
@@ -3288,7 +3259,6 @@ describe('runtime.toml raw config API', () => {
 
     const result = await patchRuntimeAssignment('sangsu', null)
 
-    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/runtime/config/assignment')
     expect(init.method).toBe('POST')

--- a/dashboard/src/api/execute-output.ts
+++ b/dashboard/src/api/execute-output.ts
@@ -67,7 +67,7 @@ export async function streamExecuteOutput(
   if (!keeper) throw new Error('keeper name is required')
   const res = await fetch(`/api/dashboard/execute-output/${encodeURIComponent(keeper)}`, {
     headers: {
-      ...authHeaders(),
+      ...authHeaders({ publicRead: true }),
       Accept: 'text/event-stream',
     },
     signal,

--- a/dashboard/src/api/gate.ts
+++ b/dashboard/src/api/gate.ts
@@ -40,16 +40,19 @@ export type {
 export { GateConnectorsSchemaDriftError } from './schemas/gate-connectors'
 
 export async function fetchGateStatus(signal?: AbortSignal): Promise<GateStatusData> {
-  const raw = await get<unknown>('/api/v1/gate/status', { signal })
+  const raw = await get<unknown>('/api/v1/gate/status', { signal, publicRead: true })
   return parseGateStatusData(raw)
 }
 
 export async function fetchGateConnectors(signal?: AbortSignal): Promise<GateConnectorsData> {
-  const raw = await get<unknown>('/api/v1/gate/connectors', { signal })
+  const raw = await get<unknown>('/api/v1/gate/connectors', { signal, publicRead: true })
   return parseGateConnectorsData(raw)
 }
 
 export async function fetchGateKeepers(signal?: AbortSignal): Promise<GateKeepersData> {
-  const raw = await get<unknown>('/api/v1/gate/keepers?limit=50&detailed=true', { signal })
+  const raw = await get<unknown>('/api/v1/gate/keepers?limit=50&detailed=true', {
+    signal,
+    publicRead: true,
+  })
   return parseGateKeepersData(raw)
 }

--- a/dashboard/src/api/ide.test.ts
+++ b/dashboard/src/api/ide.test.ts
@@ -56,6 +56,7 @@ const region = {
 
 describe('ide API', () => {
   it('fetchIdeAnnotations appends keeper and repo_id params', async () => {
+    setStoredToken('stale-dashboard-token', { source: 'manual' })
     stubFetch({ ok: true, data: [annotation] })
 
     await fetchIdeAnnotations(
@@ -68,6 +69,7 @@ describe('ide API', () => {
     expect(url).toContain('file_path=lib%2Fa.ml')
     expect(url).toContain('keeper=sangsu')
     expect(url).toContain('repo_id=masc')
+    expect((mockFetch.mock.calls[0]![1] as RequestInit).headers).toEqual({})
   })
 
   it('fetchIdeAnnotations appends canonical_url scope without repo_id', async () => {
@@ -90,14 +92,17 @@ describe('ide API', () => {
     expect(url).not.toContain('repo_id=')
   })
 
-  it('rejects conflicting IDE scope params before issuing a request', async () => {
+  it('uses the repo scope when stale canonical scope is also present', async () => {
     stubFetch({ ok: true, data: [annotation] })
 
-    await expect(fetchIdeAnnotations({}, {
+    await fetchIdeAnnotations({}, {
       scope: { kind: 'repo_id', repoId: 'masc' },
       canonicalUrl: 'https://github.com/jeong-sik/masc.git',
-    })).rejects.toThrow('IDE scope must resolve to exactly one')
-    expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    const url = String(mockFetch.mock.calls[0]![0])
+    expect(url).toContain('repo_id=masc')
+    expect(url).not.toContain('canonical_url=')
   })
 
   it('fetchIdeAnnotations rejects failed envelopes instead of returning empty', async () => {
@@ -153,7 +158,7 @@ describe('ide API', () => {
     )
   })
 
-  it('createIdeAnnotation relies on token identity and forwards opaque references', async () => {
+  it('createIdeAnnotation omits session auth and forwards opaque references', async () => {
     const references = [{ relation: 'evidence', reference: 'urn:example:42' }]
     stubFetch({ ok: true, data: { ...annotation, references } })
 
@@ -172,6 +177,7 @@ describe('ide API', () => {
     expect(url).toContain('/api/v1/ide/annotations?')
     expect(url).toContain('keeper=sangsu')
     expect(url).toContain('repo_id=masc')
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' })
     expect(body).not.toHaveProperty('keeper_id')
     expect(body.references).toEqual(references)
   })
@@ -227,7 +233,7 @@ describe('ide API', () => {
     )
   })
 
-  it('deleteIdeAnnotation sends the bearer token and appends repo_id param without keeper_id', async () => {
+  it('deleteIdeAnnotation omits session auth and appends repo_id param without keeper_id', async () => {
     setStoredToken('delete-test-token', { source: 'manual' })
     stubFetch({}, true)
 
@@ -237,10 +243,8 @@ describe('ide API', () => {
     expect(url).toContain('/api/v1/ide/annotations/ann-1?')
     expect(url).toContain('repo_id=masc')
     expect(url).not.toContain('keeper_id=')
-    // The DELETE route is token-bound (CanBroadcast) — a header-less
-    // request is rejected 401 in every server configuration.
     const init = mockFetch.mock.calls[0]![1] as RequestInit
-    expect(init.headers).toMatchObject({ Authorization: 'Bearer delete-test-token' })
+    expect(init.headers).toEqual({})
   })
 
   it('deleteIdeAnnotation maps success to deleted', async () => {
@@ -249,29 +253,7 @@ describe('ide API', () => {
     await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('deleted')
   })
 
-  it('deleteIdeAnnotation maps the coded 403 (ownership/not-found) to rejected', async () => {
-    stubFetch(
-      { ok: false, error: 'annotation delete rejected', code: 'annotation_delete_rejected' },
-      false,
-      403,
-    )
-
-    await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('rejected')
-  })
-
-  it('deleteIdeAnnotation maps an uncoded 403 (auth tier) to forbidden', async () => {
-    stubFetch({ ok: false, error: 'permission denied' }, false, 403)
-
-    await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('forbidden')
-  })
-
-  it('deleteIdeAnnotation maps 401 to unauthorized', async () => {
-    stubFetch({ ok: false, error: 'missing token' }, false, 401)
-
-    await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('unauthorized')
-  })
-
-  it('deleteIdeAnnotation maps non-auth failures to error', async () => {
+  it('deleteIdeAnnotation maps failed public deletion to error', async () => {
     stubFetch({}, false)
 
     await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('error')
@@ -340,14 +322,17 @@ describe('ide API', () => {
     expect(url).not.toContain('canonical_url=')
   })
 
-  it('rejects keeper_lane scope combined with repo_id before issuing a request', async () => {
+  it('uses repo_id when a stale keeper_lane scope is also present', async () => {
     stubFetch({ ok: true, data: { events: [] } })
 
-    await expect(fetchIdeEvents({
+    await fetchIdeEvents({
       scope: { kind: 'keeper_lane', keeperId: 'sangsu' },
       repoId: 'masc',
-    })).rejects.toThrow('IDE scope must resolve to exactly one')
-    expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    const url = String(mockFetch.mock.calls[0]![0])
+    expect(url).toContain('repo_id=masc')
+    expect(url).not.toContain('keeper_lane=')
   })
 
   it('fetchIdeEvents rejects malformed event rows instead of dropping them', async () => {

--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -1,4 +1,4 @@
-import { get, post, fetchWithTimeout, authHeaders, type GetOptions } from './core'
+import { get, postPublic, fetchWithTimeout, authHeaders, type GetOptions } from './core'
 import {
   type IdeAnnotation,
   type IdeAnnotationReference,
@@ -26,11 +26,10 @@ export type IdeScope =
   | { readonly kind: 'repo_id'; readonly repoId: string }
   | { readonly kind: 'canonical_url'; readonly canonicalUrl: string }
   /**
-   * Read-only scope over the repo-unattributed observation lane. Keeper
+   * Scope over the repo-unattributed observation lane. Keeper
    * turn/coordination events carry no file, so the server stores them
-   * outside any repo partition; this scope is the only address for that
-   * data. Mutations sent with it are refused server-side
-   * (keeper_lane_read_only).
+   * outside any repo partition; this scope selects the matching keeper on
+   * reads and maps writes to the same default lane.
    */
   | { readonly kind: 'keeper_lane'; readonly keeperId: string }
 
@@ -151,18 +150,28 @@ export function ideScopeFromKeeperLane(keeperId: string | null | undefined): Ide
 }
 
 function resolveIdeScope(opts: IdeScopeOptions): IdeScope | null {
-  const candidates: IdeScope[] = []
-  if (opts.scope) candidates.push(opts.scope)
-  const repoScope = ideScopeFromRepoId(opts.repoId)
-  if (repoScope) candidates.push(repoScope)
-  const canonicalScope = ideScopeFromCanonicalUrl(opts.canonicalUrl)
-  if (canonicalScope) candidates.push(canonicalScope)
-  if (candidates.length > 1) {
-    throw new Error(
-      'IDE scope must resolve to exactly one of repo_id, canonical_url, or keeper_lane',
-    )
+  // Readers can receive a stale route scope alongside a newly selected repo.
+  // Mirror the server's deterministic order instead of refusing the request:
+  // repo_id, then canonical_url, then the keeper lane.  This makes a transient
+  // UI state a harmless fallback choice rather than a full inspector outage.
+  const explicitScope = opts.scope
+  const scopedRepo = explicitScope?.kind === 'repo_id' ? explicitScope : null
+  const scopedCanonical =
+    explicitScope?.kind === 'canonical_url' ? explicitScope : null
+  const scopedLane = explicitScope?.kind === 'keeper_lane' ? explicitScope : null
+  return ideScopeFromRepoId(opts.repoId)
+    ?? scopedRepo
+    ?? ideScopeFromCanonicalUrl(opts.canonicalUrl)
+    ?? scopedCanonical
+    ?? scopedLane
+}
+
+function publicIdeReadOptions(opts: IdeApiOptions): GetOptions {
+  return {
+    signal: opts.signal,
+    timeoutMs: opts.timeoutMs,
+    publicRead: true,
   }
-  return candidates[0] ?? null
 }
 
 export function appendIdeScopeParams(params: URLSearchParams, opts: IdeScopeOptions): void {
@@ -298,7 +307,10 @@ export async function fetchIdeAnnotations(
   appendFilterParams(params, filter)
   appendWorkspaceParams(params, opts)
   const query = params.size > 0 ? `?${params.toString()}` : ''
-  const raw = await get<unknown>(`/api/v1/ide/annotations${query}`, opts)
+  const raw = await get<unknown>(
+    `/api/v1/ide/annotations${query}`,
+    publicIdeReadOptions(opts),
+  )
   return parseStrictRows('fetchIdeAnnotations', ideEnvelopeData(raw, 'fetchIdeAnnotations'), parseStrictIdeAnnotation)
 }
 
@@ -309,37 +321,11 @@ export async function createIdeAnnotation(
   const params = new URLSearchParams()
   appendWorkspaceParams(params, opts)
   const query = params.size > 0 ? `?${params.toString()}` : ''
-  const raw = await post<unknown>(`/api/v1/ide/annotations${query}`, input)
+  const raw = await postPublic<unknown>(`/api/v1/ide/annotations${query}`, input)
   return parseStrictRow('createIdeAnnotation', ideEnvelopeData(raw, 'createIdeAnnotation'), parseStrictIdeAnnotation)
 }
 
-// Typed outcome of a DELETE (task-1736 B3 route, token-bound):
-// - 'rejected'     403 with the server's annotation_delete_rejected code —
-//                  the stored annotation is not owned by the token identity,
-//                  or it no longer exists (the server flattens the two).
-// - 'forbidden'    403 from the auth layer — the token's tier lacks the
-//                  write permission; ownership was never evaluated.
-// - 'unauthorized' 401 — missing/expired bearer token.
-// - 'error'        transport failure or any other server error.
-export type IdeAnnotationDeleteOutcome =
-  | 'deleted'
-  | 'rejected'
-  | 'forbidden'
-  | 'unauthorized'
-  | 'error'
-
-// Wire constant mirrored from server_ide_http.ml annotation_delete_rejected_code.
-const ANNOTATION_DELETE_REJECTED_CODE = 'annotation_delete_rejected'
-
-async function responseErrorCode(res: Response): Promise<string | null> {
-  try {
-    const body: unknown = await res.json()
-    if (isRecord(body) && typeof body.code === 'string') return body.code
-    return null
-  } catch {
-    return null
-  }
-}
+export type IdeAnnotationDeleteOutcome = 'deleted' | 'error'
 
 export async function deleteIdeAnnotation(
   id: string,
@@ -352,15 +338,10 @@ export async function deleteIdeAnnotation(
   try {
     const res = await fetchWithTimeout(
       path,
-      { method: 'DELETE', headers: authHeaders() },
+      { method: 'DELETE', headers: authHeaders({ publicRead: true }) },
       15_000,
     )
     if (res.ok) return 'deleted'
-    if (res.status === 401) return 'unauthorized'
-    if (res.status === 403) {
-      const code = await responseErrorCode(res)
-      return code === ANNOTATION_DELETE_REJECTED_CODE ? 'rejected' : 'forbidden'
-    }
     return 'error'
   } catch {
     return 'error'
@@ -374,7 +355,10 @@ export async function fetchIdeRegions(
   const params = new URLSearchParams()
   params.set('file_path', filePath)
   appendWorkspaceParams(params, opts)
-  const raw = await get<unknown>(`/api/v1/ide/regions?${params.toString()}`, opts)
+  const raw = await get<unknown>(
+    `/api/v1/ide/regions?${params.toString()}`,
+    publicIdeReadOptions(opts),
+  )
   return parseStrictRows('fetchIdeRegions', ideEnvelopeData(raw, 'fetchIdeRegions'), parseStrictIdeCodeRegion)
 }
 
@@ -383,7 +367,10 @@ export async function fetchIdePresence(
 ): Promise<unknown> {
   const params = new URLSearchParams()
   appendWorkspaceParams(params, opts)
-  const raw = await get<unknown>(`/api/v1/ide/presence?${params.toString()}`, opts)
+  const raw = await get<unknown>(
+    `/api/v1/ide/presence?${params.toString()}`,
+    publicIdeReadOptions(opts),
+  )
   if (!isRecord(raw) || raw.ok !== true) return null
   return raw.data
 }
@@ -398,7 +385,10 @@ export async function fetchIdeCursors(
   if (opts.limit !== undefined) params.set('limit', String(opts.limit))
   if (opts.offset !== undefined) params.set('offset', String(opts.offset))
   const query = params.size > 0 ? `?${params.toString()}` : ''
-  const raw = await get<unknown>(`/api/v1/ide/cursors${query}`, opts)
+  const raw = await get<unknown>(
+    `/api/v1/ide/cursors${query}`,
+    publicIdeReadOptions(opts),
+  )
   const data = ideEnvelopeRecord(raw, 'fetchIdeCursors')
   const snapshot = parseIdeCursorSnapshot(data)
   if (snapshot === null) throw new Error('fetchIdeCursors returned malformed data')
@@ -420,7 +410,10 @@ export async function fetchIdeEvents(
   if (opts.limit !== undefined) params.set('limit', String(opts.limit))
   if (opts.offset !== undefined) params.set('offset', String(opts.offset))
   const query = params.size > 0 ? `?${params.toString()}` : ''
-  const raw = await get<unknown>(`/api/v1/ide/events${query}`, opts)
+  const raw = await get<unknown>(
+    `/api/v1/ide/events${query}`,
+    publicIdeReadOptions(opts),
+  )
   const data = ideEnvelopeRecord(raw, 'fetchIdeEvents')
   const events = data.events
   if (!Array.isArray(events)) throw new Error('fetchIdeEvents returned malformed events')

--- a/dashboard/src/api/keeper-lifecycle.ts
+++ b/dashboard/src/api/keeper-lifecycle.ts
@@ -94,7 +94,7 @@ async function safeKeeperLifecycle(
   try {
     const resp = await fetchControlPlane(url, {
       method: 'POST',
-      headers: jsonHeaders(),
+      headers: jsonHeaders({ publicRead: true }),
       ...init,
     })
     const payload = await safeJsonResponse<KeeperLifecycleResponse>(resp, fallbackError)
@@ -127,7 +127,7 @@ async function safeKeeperPostWithBody(
   try {
     const resp = await fetchControlPlane(url, {
       method: 'POST',
-      headers: jsonHeaders(),
+      headers: jsonHeaders({ publicRead: true }),
       body: JSON.stringify(body),
       signal: opts.signal,
     })
@@ -293,7 +293,7 @@ export async function fetchKeeperCheckpoints(
     `/api/v1/keepers/${encodeURIComponent(name)}/checkpoints`,
     {
       method: 'GET',
-      headers: jsonHeaders(),
+      headers: jsonHeaders({ publicRead: true }),
     },
     DEFAULT_GET_TIMEOUT_MS,
   )
@@ -312,7 +312,7 @@ export async function deleteKeeperHistorySnapshots(
     `/api/v1/keepers/${encodeURIComponent(name)}/checkpoints`,
     {
       method: 'POST',
-      headers: jsonHeaders(),
+      headers: jsonHeaders({ publicRead: true }),
       body: JSON.stringify({
         action: 'delete_history',
         snapshot_ids: snapshotIds,
@@ -333,7 +333,7 @@ async function requestKeeperCheckpointPurge(
   const path = `/api/v1/keepers/${encodeURIComponent(name)}/checkpoints`
   const resp = await fetchControlPlane(path, {
     method: 'POST',
-    headers: jsonHeaders(),
+    headers: jsonHeaders({ publicRead: true }),
     body: JSON.stringify({ action }),
   })
   if (!resp.ok) {
@@ -505,7 +505,7 @@ export async function bulkKeeperDirective(
       '/api/v1/keepers_bulk/directive',
       {
         method: 'POST',
-        headers: jsonHeaders(),
+        headers: jsonHeaders({ publicRead: true }),
         body: JSON.stringify(body),
         signal: opts.signal,
       },

--- a/dashboard/src/api/keeper-runtime-trace.ts
+++ b/dashboard/src/api/keeper-runtime-trace.ts
@@ -839,7 +839,7 @@ export async function fetchKeeperRuntimeTrace(
   const qs = params.toString()
   const resp = await fetchWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/runtime-trace${qs ? `?${qs}` : ''}`,
-    { headers: jsonHeaders(), signal: opts?.signal },
+    { headers: jsonHeaders({ publicRead: true }), signal: opts?.signal },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`runtime trace fetch failed: ${resp.status}`)

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -145,12 +145,12 @@ describe('Keeper Event Queue API', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       '/api/v1/keepers/sangsu/events/pending?limit=100',
-      expect.objectContaining({ headers: expect.any(Object) }),
+      expect.objectContaining({ headers: { 'Content-Type': 'application/json' } }),
     )
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       '/api/v1/keepers/sangsu/events/pending?limit=100&after=1',
-      expect.objectContaining({ headers: expect.any(Object) }),
+      expect.objectContaining({ headers: { 'Content-Type': 'application/json' } }),
     )
   })
 
@@ -631,7 +631,7 @@ describe('fetchKeeperChatOperation', () => {
     })
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/keepers/sangsu/chat/operations/kmsg-restart-1',
-      expect.any(Object),
+      expect.objectContaining({ headers: { 'Content-Type': 'application/json' } }),
     )
   })
 })
@@ -1022,7 +1022,7 @@ describe('keeper lifecycle', () => {
     })
   })
 
-  it('fetches keeper checkpoint inventory from the admin route', async () => {
+  it('fetches keeper checkpoint inventory without a dashboard bearer', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         keeper: 'keeper-test',
@@ -1047,6 +1047,7 @@ describe('keeper lifecycle', () => {
       '/api/v1/keepers/keeper-test/checkpoints',
       expect.objectContaining({
         method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
       }),
     )
     expect(result.trace_id).toBe('trace-keeper-test')

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -125,7 +125,7 @@ export async function interruptKeeperTurn(
     path,
     {
       method: 'POST',
-      headers: jsonHeaders(),
+      headers: jsonHeaders({ publicRead: true }),
       body: JSON.stringify({ name: keeperName.trim() }),
       signal: opts.signal,
     },
@@ -323,7 +323,7 @@ export async function streamKeeperMessage(
   const postStream = () => fetch(streamPath, {
     method: 'POST',
     headers: {
-      ...jsonHeaders(),
+      ...jsonHeaders({ publicRead: true }),
       Accept: 'text/event-stream',
     },
     body: requestBody,
@@ -503,7 +503,7 @@ export async function fetchKeeperChatOperation(
   const path = `/api/v1/keepers/${encodeURIComponent(keeperName)}/chat/operations/${encodeURIComponent(operationId)}`
   const response = await fetchWithTimeout(
     path,
-    { headers: jsonHeaders(), signal: opts.signal },
+    { headers: jsonHeaders({ publicRead: true }), signal: opts.signal },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!response.ok) throw await apiRequestErrorFromResponse('GET', path, response)
@@ -522,7 +522,7 @@ export async function cancelKeeperChatOperation(
   const path = `/api/v1/keepers/${encodeURIComponent(keeperName)}/chat/operations/${encodeURIComponent(operationId)}/cancel`
   const response = await fetchControlPlane(path, {
     method: 'POST',
-    headers: jsonHeaders(),
+    headers: jsonHeaders({ publicRead: true }),
     body: '{}',
     signal: opts.signal,
   })
@@ -541,7 +541,11 @@ export async function listQueuedKeeperChatOperations(
   const query = new URLSearchParams({ state: 'queued' })
   if (afterSequence !== undefined) query.set('after_sequence', afterSequence)
   const path = `/api/v1/keepers/${encodeURIComponent(keeperName)}/chat/operations?${query.toString()}`
-  const response = await fetchWithTimeout(path, { headers: jsonHeaders() }, DEFAULT_GET_TIMEOUT_MS)
+  const response = await fetchWithTimeout(
+    path,
+    { headers: jsonHeaders({ publicRead: true }) },
+    DEFAULT_GET_TIMEOUT_MS,
+  )
   if (!response.ok) throw await apiRequestErrorFromResponse('GET', path, response)
   const value: unknown = await response.json()
   if (
@@ -568,7 +572,7 @@ async function mutateQueuedKeeperChatOperation(
   const path = `/api/v1/keepers/${encodeURIComponent(keeperName)}/chat/operations/${encodeURIComponent(operationId)}/${action}`
   const response = await fetchControlPlane(path, {
     method: 'POST',
-    headers: jsonHeaders(),
+    headers: jsonHeaders({ publicRead: true }),
     body: JSON.stringify(body),
   })
   if (!response.ok) throw await apiRequestErrorFromResponse('POST', path, response)
@@ -744,7 +748,7 @@ async function fetchKeeperEventQueuePendingPage(
   const url = `${baseUrl}?limit=100${after === null ? '' : `&after=${encodeURIComponent(after)}`}`
   const { response, data } = await fetchJsonWithTimeout(
     url,
-    { headers: jsonHeaders() },
+    { headers: jsonHeaders({ publicRead: true }) },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!response.ok) {
@@ -951,7 +955,7 @@ export async function fetchKeeperChatHistory(
   // tolerant — only network / HTTP / shape errors throw.
   const { response: resp, data } = await fetchJsonWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/chat/history`,
-    { headers: jsonHeaders() },
+    { headers: jsonHeaders({ publicRead: true }) },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) {
@@ -969,7 +973,7 @@ export async function fetchKeeperChatHistory(
 // Since-last-seen catch-up digest for one keeper. `sinceUnix` is the operator's
 // per-keeper last-seen cursor (unix seconds). The whole payload is decoded and
 // thrown on drift (unlike chat history's tolerant per-row drop) so a malformed
-// digest can never render a wrong count. Same raw-fetch + jsonHeaders()
+// digest can never render a wrong count. Same raw-fetch + public-read headers
 // convention as fetchKeeperChatHistory; the valibot schema is imported lazily
 // to keep it out of the initial bundle.
 export async function fetchKeeperCatchupDigest(
@@ -978,7 +982,7 @@ export async function fetchKeeperCatchupDigest(
 ): Promise<KeeperCatchupDigest> {
   const resp = await fetch(
     `/api/v1/keepers/${encodeURIComponent(keeperName)}/digest?since_unix=${encodeURIComponent(String(sinceUnix))}`,
-    { headers: jsonHeaders() },
+    { headers: jsonHeaders({ publicRead: true }) },
   )
   if (!resp.ok) {
     throw new Error(`fetchKeeperCatchupDigest: HTTP ${resp.status} ${resp.statusText}`)
@@ -1056,7 +1060,7 @@ export async function fetchKeeperTransitions(
 ): Promise<KeeperTransitionsResponse> {
   const resp = await fetchWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/transitions?limit=${limit}`,
-    { headers: jsonHeaders(), signal: opts?.signal },
+    { headers: jsonHeaders({ publicRead: true }), signal: opts?.signal },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`transitions fetch failed: ${resp.status}`)
@@ -1110,7 +1114,7 @@ export async function fetchKeeperLifecycle(
 ): Promise<KeeperLifecycleTimelineResponse> {
   const resp = await fetchWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/lifecycle?limit=${limit}`,
-    { headers: jsonHeaders(), signal: opts?.signal },
+    { headers: jsonHeaders({ publicRead: true }), signal: opts?.signal },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`lifecycle fetch failed: ${resp.status}`)
@@ -1123,7 +1127,7 @@ export async function fetchKeeperStateDiagram(
 ): Promise<KeeperStateDiagramResponse> {
   const resp = await fetchWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/state-diagram`,
-    { headers: jsonHeaders(), signal: opts?.signal },
+    { headers: jsonHeaders({ publicRead: true }), signal: opts?.signal },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`state-diagram fetch failed: ${resp.status}`)
@@ -1136,7 +1140,7 @@ export async function fetchKeeperComposite(
 ): Promise<KeeperCompositeSnapshot> {
   const resp = await fetchWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/composite`,
-    { headers: jsonHeaders(), signal: opts?.signal },
+    { headers: jsonHeaders({ publicRead: true }), signal: opts?.signal },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`composite fetch failed: ${resp.status}`)
@@ -1155,7 +1159,7 @@ export async function fetchKeepersComposite(
 ): Promise<FleetCompositeSnapshot> {
   const resp = await fetchWithTimeout(
     `/api/v1/keepers/composite`,
-    { headers: jsonHeaders(), signal: opts?.signal },
+    { headers: jsonHeaders({ publicRead: true }), signal: opts?.signal },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`fleet composite fetch failed: ${resp.status}`)
@@ -1200,7 +1204,7 @@ export interface KeeperEvalResponse {
 export async function fetchKeeperEval(name: string, limit = 10): Promise<KeeperEvalResponse> {
   const resp = await fetchWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/eval?limit=${limit}`,
-    { headers: jsonHeaders() },
+    { headers: jsonHeaders({ publicRead: true }) },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`eval fetch failed: ${resp.status}`)

--- a/dashboard/src/api/repositories.ts
+++ b/dashboard/src/api/repositories.ts
@@ -137,7 +137,7 @@ export function normalizeRepository(raw: unknown): Repository | null {
 }
 
 export async function fetchRepositoriesList(opts: GetOptions = {}): Promise<Repository[]> {
-  const raw = await get<unknown>('/api/v1/repositories', opts)
+  const raw = await get<unknown>('/api/v1/repositories', { ...opts, publicRead: true })
   return repositoryRows(raw).map(normalizeRepository).filter((r): r is Repository => r !== null)
 }
 

--- a/dashboard/src/api/tool-blob.ts
+++ b/dashboard/src/api/tool-blob.ts
@@ -27,5 +27,8 @@ export async function fetchToolBlob(
   sha256: string,
   opts: { signal?: AbortSignal; timeoutMs?: number } = {},
 ): Promise<ToolBlobResponse> {
-  return get<ToolBlobResponse>(`/api/v1/artifacts/${encodeURIComponent(sha256)}`, opts)
+  return get<ToolBlobResponse>(`/api/v1/artifacts/${encodeURIComponent(sha256)}`, {
+    ...opts,
+    publicRead: true,
+  })
 }

--- a/dashboard/src/api/transport-health.ts
+++ b/dashboard/src/api/transport-health.ts
@@ -18,6 +18,7 @@ export async function fetchTransportHealth(
 ): Promise<TransportHealthSnapshot> {
   const raw = await get<unknown>('/api/v1/dashboard/transport-health', {
     signal: opts?.signal,
+    publicRead: true,
   })
   return parseTransportHealthData(raw)
 }

--- a/dashboard/src/api/workspace.ts
+++ b/dashboard/src/api/workspace.ts
@@ -57,6 +57,10 @@ function appendWorkspaceParams(params: URLSearchParams, opts: WorkspaceApiOption
   if (opts.keeper) params.set('keeper', opts.keeper)
 }
 
+function publicWorkspaceReadOptions(opts: WorkspaceApiOptions): WorkspaceApiOptions {
+  return { ...opts, publicRead: true }
+}
+
 export async function fetchWorkspaceTree(
   depth: number,
   opts: WorkspaceApiOptions = {},
@@ -67,7 +71,7 @@ export async function fetchWorkspaceTree(
   appendWorkspaceParams(params, opts)
   const { data, headers } = await getWithResponse<ReadonlyArray<FileTreeNode>>(
     `/api/v1/workspace/tree?${params.toString()}`,
-    opts,
+    publicWorkspaceReadOptions(opts),
   )
   return {
     nodes: data,
@@ -93,7 +97,7 @@ export function fetchWorkspaceChildren(
   appendWorkspaceParams(params, opts)
   return get<ReadonlyArray<FileTreeNode>>(
     `/api/v1/workspace/children?${params.toString()}`,
-    opts,
+    publicWorkspaceReadOptions(opts),
   )
 }
 
@@ -107,7 +111,7 @@ export async function fetchWorkspaceFile(
   try {
     return await get<WorkspaceFileResponse | null>(
       `/api/v1/workspace/file?${params.toString()}`,
-      opts,
+      publicWorkspaceReadOptions(opts),
     )
   } catch (error) {
     // The workspace file route represents an absent file as HTTP 404 with an
@@ -131,7 +135,7 @@ export function fetchGitBlame(
   appendWorkspaceParams(params, opts)
   return get<ReadonlyArray<BlameBlock>>(
     `/api/v1/git/blame?${params.toString()}`,
-    opts,
+    publicWorkspaceReadOptions(opts),
   )
 }
 
@@ -150,6 +154,6 @@ export function fetchGitDiff(
   appendWorkspaceParams(params, opts)
   return get<GitDiffResponse>(
     `/api/v1/git/diff?${params.toString()}`,
-    opts,
+    publicWorkspaceReadOptions(opts),
   ).then(data => Array.isArray(data.unified) ? data.unified : [])
 }

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -6,7 +6,7 @@
 // existing `DashboardMain` surface dispatcher, so every surface keeps
 // rendering while it is migrated to the prototype DOM in stacked follow-ups.
 //
-// All lifecycle wiring (router, WS push reaction, periodic refresh, dev-token,
+// All lifecycle wiring (router, WS push reaction, periodic refresh,
 // config thresholds, cleanup, volt/theme sync) is preserved verbatim from the
 // previous shell — only the rendered DOM changed.
 
@@ -21,7 +21,6 @@ import { cancelPendingServerPushRefreshes, registerGateRefresh, registerMissionR
 import { initNotificationDelivery } from './notifications'
 import { refreshShell } from './store'
 import { connectDashboardWS, disconnectDashboardWS, subscribeDashboardRoute } from './dashboard-ws'
-import { ensureDevToken } from './api/dev-token'
 import { fetchDashboardConfig, parseContextThresholds } from './api/dashboard-logs'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
 import { setContextThresholds } from './config/context-thresholds'
@@ -163,32 +162,27 @@ export function App() {
     // Initialize hash router and compatible deep links
     initRouter()
 
-    const ensureLoopbackAuth = () => ensureDevToken()
-      .catch(err => {
-        console.warn('[app] dashboard dev-token bootstrap failed', err instanceof Error ? err.message : err)
-      })
+    // Feature-first boot: shell and live projections start immediately. MCP
+    // retains its own credential path only when a caller actually uses MCP.
+    if (!cancelled) {
+      void refreshShell({ light: true })
+      requestNamespaceTruthNow()
 
-    void ensureLoopbackAuth()
-      .finally(() => {
-        if (cancelled) return
-        void refreshShell({ light: true })
-        requestNamespaceTruthNow()
-
-        void fetchDashboardConfig()
-          .then(data => {
-            const thresholds = parseContextThresholds(data, {
-              critical: CONTEXT_RATIO_CRITICAL,
-              warn: CONTEXT_RATIO_WARN,
-              compacting: CONTEXT_RATIO_COMPACTING,
-            })
-            setContextThresholds(thresholds)
+      void fetchDashboardConfig()
+        .then(data => {
+          const thresholds = parseContextThresholds(data, {
+            critical: CONTEXT_RATIO_CRITICAL,
+            warn: CONTEXT_RATIO_WARN,
+            compacting: CONTEXT_RATIO_COMPACTING,
           })
-          .catch(err => {
-            console.warn('[app] dashboard config fetch failed', err instanceof Error ? err.message : err)
-          })
+          setContextThresholds(thresholds)
+        })
+        .catch(err => {
+          console.warn('[app] dashboard config fetch failed', err instanceof Error ? err.message : err)
+        })
 
-        void connectDashboardWS(route.value)
-      })
+      void connectDashboardWS(route.value)
+    }
 
     registerMissionRefresh(() => {
       void import('./mission-actions')

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -214,7 +214,10 @@ async function fetchCurrentValues(id: string): Promise<Record<string, string>> {
 async function fetchSchema(id: string) {
   setEntry(id, { loading: true, error: null })
   try {
-    const data = await get<SchemaResponse>(`/api/v1/sidecar/schema?name=${encodeURIComponent(id)}`)
+    const data = await get<SchemaResponse>(
+      `/api/v1/sidecar/schema?name=${encodeURIComponent(id)}`,
+      { publicRead: true },
+    )
     if (!data.ok) throw new Error('schema response missing ok=true')
     const fields = parseSchema(data)
     const current = await fetchCurrentValues(id)

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -95,7 +95,9 @@ function filterFeatures<
 }
 
 function loadFeatureHealth(): Promise<void> {
-  return featureHealth.load(() => get<FeatureHealthData>('/api/v1/dashboard/feature-health'))
+  return featureHealth.load(() => get<FeatureHealthData>('/api/v1/dashboard/feature-health', {
+    publicRead: true,
+  }))
 }
 
 export async function refreshFeatureHealth(): Promise<void> {

--- a/dashboard/src/components/gate-monitor.ts
+++ b/dashboard/src/components/gate-monitor.ts
@@ -86,7 +86,7 @@ async function fetchGateToolEvents(
 ): Promise<GateToolEvents> {
   const raw = await get<Record<string, unknown>>(
     `/api/v1/dashboard/gate/tool-events?window=${windowMinutes}`,
-    { signal: opts?.signal },
+    { signal: opts?.signal, publicRead: true },
   )
   if (!isRecord(raw)) throw new Error('invalid Gate tool-events payload')
   const approvalQueueState = decodeKeeperApprovalQueueState(raw.approval_queue_state)

--- a/dashboard/src/components/harness-health-state.ts
+++ b/dashboard/src/components/harness-health-state.ts
@@ -119,7 +119,9 @@ export function resetHarnessHealthState(): void {
 }
 
 export function loadHarnessHealth(): Promise<void> {
-  return harness.load(() => get<HarnessHealthData>('/api/v1/dashboard/harness-health'))
+  return harness.load(() => get<HarnessHealthData>('/api/v1/dashboard/harness-health', {
+    publicRead: true,
+  }))
 }
 
 export async function refreshHarnessSurface(): Promise<void> {

--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -63,15 +63,15 @@ describe('IdeActivityPanel', () => {
     expect(container.textContent).toContain('no keeper activity')
   })
 
-  it('shows a no-scope message instead of "no recent activity" when neither repoId nor keeperLane is set', async () => {
+  it('uses the default lane when neither repoId nor keeperLane is set', async () => {
     const container = document.createElement('div')
     render(h(IdeActivityPanel, {}), container)
 
     await waitFor(() => {
-      const notice = container.querySelector('[data-testid="ide-activity-no-scope"]')
-      expect(notice?.textContent).toBe('관측 스코프(저장소/keeper)가 선택되지 않았습니다')
+      expect(container.textContent).toContain('no recent activity')
     })
-    expect(container.textContent).not.toContain('no recent activity')
+    const requests = vi.mocked(globalThis.fetch).mock.calls.map(call => String(call[0]))
+    expect(requests.some(url => url.includes('/api/v1/ide/events?limit=50'))).toBe(true)
   })
 
   it('shows "no recent activity" (not the no-scope message) when a scoped fetch genuinely finds nothing', async () => {
@@ -135,7 +135,7 @@ describe('IdeActivityPanel', () => {
 
     render(h(IdeActivityPanel, {}), container)
     expect(container.textContent).not.toContain('turn-repo-a')
-    expect(container.querySelector('[data-testid="ide-activity-no-scope"]')).not.toBeNull()
+    expect(container.textContent).toContain('no recent activity')
 
     await waitFor(() => expect(resolveUnscopedGraph).not.toBeNull())
     resolveUnscopedGraph!(new Response(JSON.stringify({ events: [] }), {
@@ -437,8 +437,7 @@ describe('IdeActivityPanel', () => {
     }))
 
     const container = document.createElement('div')
-    // Bridge events are fetched only under an explicit scope: without a
-    // repo or keeper lane the server rejects unscoped /api/v1/ide/events.
+    // A repository selection narrows the otherwise readable bridge feed.
     render(h(IdeActivityPanel, { activeFile: 'lib/runtime.ml', repoId: 'masc' }), container)
 
     await waitFor(() => {
@@ -661,16 +660,15 @@ describe('IdeActivityPanel', () => {
     await vi.waitFor(() => {
       expect(container.textContent).toContain('turn-1')
     })
-    // Without a repo or keeper-lane scope there is no bridge fetch: the
-    // server rejects unscoped /api/v1/ide/events, so only the activity
-    // graph is polled (one call per load).
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // Without a selection the bridge reads the default lane alongside the
+    // activity graph, so each refresh makes two reads.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
 
     await vi.advanceTimersByTimeAsync(1_000)
     await vi.waitFor(() => {
       expect(container.textContent).toContain('goal goal-refresh')
     })
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(4)
     expect(container.textContent).toContain('turn-2')
     expect(container.textContent).not.toContain('turn-1')
 
@@ -724,7 +722,7 @@ describe('IdeActivityPanel', () => {
     vi.setSystemTime(new Date('2026-05-05T10:00:10Z'))
     await vi.advanceTimersByTimeAsync(1_000)
     await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenCalledTimes(4)
     })
 
     expect(container.textContent).toContain('turn-stable')
@@ -743,10 +741,7 @@ describe('IdeActivityPanel', () => {
     await waitFor(() => {
       expect(container.querySelector('.ide-activity-refresh-status')?.textContent).toBe('offline 1 failed')
     })
-    // No repoId/keeperLane was passed: the empty list explains the missing
-    // scope rather than claiming "no recent activity" (which would imply
-    // a real, merely-empty fetch happened).
-    expect(container.querySelector('[data-testid="ide-activity-no-scope"]')).not.toBeNull()
+    expect(container.textContent).toContain('no recent activity')
   })
 
   it('degrades the refresh tone when the keeper lane fetch fails', async () => {

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -224,7 +224,9 @@ async function fetchActivityEvents(
 
 async function fetchActivityGraphEvents(): Promise<GraphFetchResult> {
   try {
-    const data = await get<ApiActivityResponse>('/api/v1/activity/events?limit=50')
+    const data = await get<ApiActivityResponse>('/api/v1/activity/events?limit=50', {
+      publicRead: true,
+    })
     const rawEvents = data.events
     if (!Array.isArray(rawEvents) || rawEvents.length === 0) {
       return { events: EMPTY_ACTIVITY, workspaceId: DEFAULT_WORKSPACE_ID, ok: true }
@@ -261,10 +263,9 @@ async function fetchIdeBridgeRunActivityEvents(
   if (lane) {
     sources.push(fetchIdeEvents({ limit: 50, scope: { kind: 'keeper_lane', keeperId: lane } }))
   }
-  // Neither scope is set: there is nothing to query, not a request that
-  // happened to find zero events. The caller derives the visible no-scope
-  // state from the current props, before any asynchronous response arrives.
-  if (sources.length === 0) return { events: EMPTY_ACTIVITY, ok: true }
+  // A missing selection is a readable default lane, not an error state.  It
+  // keeps the activity panel useful while workspace selection is catching up.
+  if (sources.length === 0) sources.push(fetchIdeEvents({ limit: 50 }))
   const settled = await Promise.allSettled(sources)
   const events: RunActivityEvent[] = []
   let ok = true
@@ -454,10 +455,6 @@ function activityScopeKey(repoId?: string | null, keeperLane?: string | null): s
   return JSON.stringify([repoId?.trim() || null, keeperLane?.trim() || null])
 }
 
-function hasActivityBridgeScope(repoId?: string | null, keeperLane?: string | null): boolean {
-  return Boolean(repoId?.trim()) || Boolean(keeperLane?.trim())
-}
-
 export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
   const {
     activeFile: rawActiveFile = '',
@@ -476,7 +473,6 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
   }, [])
   const [refreshState, setRefreshState] = useState<ActivityRefreshState>(INITIAL_REFRESH_STATE)
   const requestedScopeKey = activityScopeKey(repoId, keeperLane)
-  const bridgeScoped = hasActivityBridgeScope(repoId, keeperLane)
   const [loadedScopeKey, setLoadedScopeKey] = useState<string | null>(null)
   const loadedScopeKeyRef = useRef<string | null>(null)
   const [compactInsightsOpen, setCompactInsightsOpen] = useState(false)
@@ -626,9 +622,7 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
         class="ide-rail-list ide-activity-list"
       >
         ${events.length === 0
-          ? bridgeScoped
-            ? html`<li class="ide-rail-empty">no recent activity</li>`
-            : html`<li class="ide-rail-empty" data-testid="ide-activity-no-scope">관측 스코프(저장소/keeper)가 선택되지 않았습니다</li>`
+          ? html`<li class="ide-rail-empty">no recent activity</li>`
           : events.map(item => html`<${ActivityRow} item=${item} presence=${presence} overlay=${overlay} />`)}
       </ol>
     </div>

--- a/dashboard/src/components/ide/ide-annotation-composer.test.ts
+++ b/dashboard/src/components/ide/ide-annotation-composer.test.ts
@@ -114,11 +114,12 @@ describe('IdeAnnotationComposer', () => {
     expect(el.querySelector('[data-testid="ide-annotation-composer-open"]')).toBeNull()
   })
 
-  it('disables the entry button without a repo scope (keeper_lane is read-only)', () => {
+  it('opens the composer without a repo scope', async () => {
     const el = mount(composer({ repoId: null }))
     const button = el.querySelector<HTMLButtonElement>('[data-testid="ide-annotation-open"]')
-    expect(button?.disabled).toBe(true)
-    expect(button?.title ?? '').toContain('repo 선택')
+    expect(button?.disabled).toBe(false)
+    await open(el)
+    expect(el.querySelector('[data-testid="ide-annotation-composer-open"]')).not.toBeNull()
   })
 
   it('opens the form with the editor selection as the default line range', async () => {
@@ -246,5 +247,34 @@ describe('IdeAnnotationComposer', () => {
     )
     expect(refresh).toHaveBeenCalledTimes(1)
     expect(el.querySelector('[data-testid="ide-annotation-composer-open"]')).toBeNull()
+  })
+
+  it('submits to the default lane without a repo selection', async () => {
+    createIdeAnnotationMock.mockResolvedValue({
+      id: 'a-default',
+      file_path: 'lib/foo.ml',
+      line_start: 1,
+      line_end: 1,
+    } as Awaited<ReturnType<typeof createIdeAnnotation>>)
+    const el = mount(composer({ repoId: null }))
+    await open(el)
+
+    const content = el.querySelector<HTMLTextAreaElement>('[data-testid="ide-annotation-content"]')
+    if (content) {
+      content.value = 'default lane note'
+      content.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    await tick()
+    el.querySelector<HTMLButtonElement>('[data-testid="ide-annotation-submit"]')?.click()
+    await tick()
+    await tick()
+
+    expect(createIdeAnnotationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file_path: 'lib/foo.ml',
+        content: 'default lane note',
+      }),
+      {},
+    )
   })
 })

--- a/dashboard/src/components/ide/ide-annotation-composer.ts
+++ b/dashboard/src/components/ide/ide-annotation-composer.ts
@@ -4,11 +4,11 @@
 // could not leave a comment/decision from the IDE at all.
 //
 // Contract notes (server-enforced, mirrored here instead of re-invented):
-// - Mutations require a repo scope; `keeper_lane` is read-only
-//   (`keeper_lane_read_only`), so the composer submits with the explorer's
-//   active repository and disables itself when none is selected.
-// - Identity comes from the auth token; the composer never sends a
-//   keeper_id.
+// - Mutations work without a selected repository or dashboard credential;
+//   the server stores that write in its readable default lane.
+// - The server accepts an explicit keeper_id when a caller has one and uses a
+//   stable dashboard identity otherwise, so this composer need not block on
+//   identity bootstrap.
 // - After a successful create the workspace fetches re-run, so the new
 //   record surfaces through the exact read path keeper annotations use.
 
@@ -114,10 +114,7 @@ export function IdeAnnotationComposer({
           type="button"
           class="v2-ide-action"
           data-testid="ide-annotation-open"
-          disabled=${repoId === null}
-          title=${repoId === null
-            ? '주석 생성에는 repo 선택이 필요합니다 (keeper_lane scope는 read-only)'
-            : '현재 선택 라인에 주석을 남깁니다'}
+          title="현재 선택 라인에 주석을 남깁니다"
           onClick=${() => setDraft(draftFromSelection(filePath))}
         >
           주석 추가
@@ -132,7 +129,7 @@ export function IdeAnnotationComposer({
   }
 
   const submit = async () => {
-    if (problem !== null || repoId === null || submitting) return
+    if (problem !== null || submitting) return
     const lineStart = parseLine(draft.lineStart)
     const lineEnd = parseLine(draft.lineEnd)
     if (lineStart === null || lineEnd === null) return
@@ -146,7 +143,7 @@ export function IdeAnnotationComposer({
           kind: draft.kind,
           content: draft.content.trim(),
         },
-        { repoId },
+        repoId ? { repoId } : {},
       )
       if (created === null) {
         showToast('주석 응답 파싱 실패 — 서버 응답을 확인하세요', 'error')
@@ -216,7 +213,7 @@ export function IdeAnnotationComposer({
           type="button"
           class="v2-ide-action"
           data-testid="ide-annotation-submit"
-          disabled=${problem !== null || submitting || repoId === null}
+          disabled=${problem !== null || submitting}
           title=${problem ?? ''}
           onClick=${() => void submit()}
         >

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -461,9 +461,9 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
 
     const keeperParam = keeper || undefined
     const opts = { keeper: keeperParam, repoId, signal, includeDiff: true }
-    // IDE observation routes require one explicit scope. Repository scope is
-    // authoritative when configured; otherwise a selected keeper can read its
-    // own orphan observation lane without fabricating a repository identity.
+    // Repository scope is authoritative when configured; otherwise a selected
+    // keeper intentionally narrows the readable default lane to its own
+    // observations. With neither value, the API now uses its default lane.
     const ideOpts = repoId
       ? { keeper: keeperParam, repoId, signal }
       : {

--- a/dashboard/src/components/ide/ide-editor-annotation-ui.test.ts
+++ b/dashboard/src/components/ide/ide-editor-annotation-ui.test.ts
@@ -112,7 +112,7 @@ describe('AnnotationDeleteControl', () => {
   })
 
   it('disarms without closing when the server rejects the deletion', async () => {
-    onDelete.mockResolvedValue('forbidden')
+    onDelete.mockResolvedValue('error')
     const el = mount()
 
     button(el).click()

--- a/dashboard/src/components/ide/ide-memory-panel.test.ts
+++ b/dashboard/src/components/ide/ide-memory-panel.test.ts
@@ -86,14 +86,18 @@ describe('IdeMemoryPanel', () => {
     expect(String(url)).not.toContain('repo_id=')
   })
 
-  it('renders an explicit no-repo-selected state and never calls the API without a scope', async () => {
+  it('uses the default scope when no repository is selected', async () => {
     render(h(IdeMemoryPanel, { keeperName: 'sangsu' }), container)
 
     await waitFor(() => {
-      const notice = container.querySelector('[data-testid="ide-memory-panel-no-scope"]')
-      expect(notice?.textContent).toBe('저장소를 선택하면 메모리를 조회합니다')
+      expect(globalThis.fetch).toHaveBeenCalled()
     })
-    expect(globalThis.fetch).not.toHaveBeenCalled()
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(String(url)).toContain('/api/v1/ide/memory?')
+    expect(String(url)).toContain('keeper_id=sangsu')
+    expect(String(url)).toContain('limit=50')
+    expect(String(url)).not.toContain('repo_id=')
+    expect(String(url)).not.toContain('canonical_url=')
     expect(container.querySelector('.ide-memory-panel__error')).toBeNull()
   })
 

--- a/dashboard/src/components/ide/ide-memory-panel.ts
+++ b/dashboard/src/components/ide/ide-memory-panel.ts
@@ -140,21 +140,7 @@ export function IdeMemoryPanel({ keeperName, scope, repoId, canonicalUrl }: IdeM
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  // Mirrors api/ide.ts's resolveIdeScope: the server requires exactly one
-  // of repo_id / canonical_url / keeper_lane. Without one it fails closed
-  // with 400 missing_ide_scope — checking here first means the panel never
-  // makes that doomed request and never surfaces its bare status code.
-  const hasScope = Boolean(scope) || Boolean(repoId?.trim()) || Boolean(canonicalUrl?.trim())
-
   const fetchMemory = useCallback(async () => {
-    if (!hasScope) {
-      setEntries([])
-      setTotal(0)
-      setContract(null)
-      setError(null)
-      setLoading(false)
-      return
-    }
     setLoading(true)
     setError(null)
     try {
@@ -162,7 +148,9 @@ export function IdeMemoryPanel({ keeperName, scope, repoId, canonicalUrl }: IdeM
       if (keeperName) params.set('keeper_id', keeperName)
       appendIdeScopeParams(params, { scope, repoId, canonicalUrl })
       params.set('limit', '50')
-      const data = await get<MemoryResponse>(`/api/v1/ide/memory?${params}`)
+      const data = await get<MemoryResponse>(`/api/v1/ide/memory?${params}`, {
+        publicRead: true,
+      })
       setEntries(data.entries)
       setTotal(data.total)
       setContract(data.contract ?? null)
@@ -171,7 +159,7 @@ export function IdeMemoryPanel({ keeperName, scope, repoId, canonicalUrl }: IdeM
     } finally {
       setLoading(false)
     }
-  }, [hasScope, keeperName, scope, repoId, canonicalUrl])
+  }, [keeperName, scope, repoId, canonicalUrl])
 
   useEffect(() => {
     fetchMemory()
@@ -195,21 +183,19 @@ export function IdeMemoryPanel({ keeperName, scope, repoId, canonicalUrl }: IdeM
           <button
             class="ide-memory-panel__refresh v2-ide-action"
             onClick=${fetchMemory}
-            disabled=${loading || !hasScope}
+            disabled=${loading}
             title="Refresh memory entries"
           >↻</button>
           <span class="ide-memory-panel__count">${total}</span>
         </span>
       </div>
-      ${!hasScope
-        ? html`<div class="ide-memory-panel__empty" data-testid="ide-memory-panel-no-scope">저장소를 선택하면 메모리를 조회합니다</div>`
-        : loading
-          ? html`<div class="ide-memory-panel__loading">Loading...</div>`
-          : error
-            ? html`<div class="ide-memory-panel__error" data-testid="ide-memory-panel-error">${error}</div>`
-            : entries.length === 0
-              ? html`<div class="ide-memory-panel__empty">No memory entries</div>`
-              : html`
+      ${loading
+        ? html`<div class="ide-memory-panel__loading">Loading...</div>`
+        : error
+          ? html`<div class="ide-memory-panel__error" data-testid="ide-memory-panel-error">${error}</div>`
+          : entries.length === 0
+            ? html`<div class="ide-memory-panel__empty">No memory entries</div>`
+            : html`
               <div class="ide-memory-panel__list">
                 ${entries.map(
                   (entry) => html`

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -95,8 +95,8 @@ export function unwrapEnvelope<T>(raw: unknown): T | undefined {
 async function fetchPresence(): Promise<KeeperPresenceSnapshot> {
   const [idePresence, agentsResponse, statusResponse] = await Promise.allSettled([
     fetchIdePresence(),
-    get<unknown>('/api/v1/agents?limit=20'),
-    get<unknown>('/api/v1/status'),
+    get<unknown>('/api/v1/agents?limit=20', { publicRead: true }),
+    get<unknown>('/api/v1/status', { publicRead: true }),
   ])
 
   // The IDE endpoint is the only source that has the runtime/branch and

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -51,7 +51,10 @@ import {
   ideContextFocus,
   synchronizeIdeWorkspaceIdentity,
 } from './ide-state'
-import { resetIdeDataWorkspaceStoreForTest } from './ide-workspace-singleton'
+import {
+  getIdeDataWorkspaceStore,
+  resetIdeDataWorkspaceStoreForTest,
+} from './ide-workspace-singleton'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 import { EMPTY_LSP_STATUS_SNAPSHOT, lspStatusSnapshot } from './ide-lsp-client'
 import { DEFAULT_MOBILE_BREAKPOINT } from '../../hooks/use-is-mobile'
@@ -1157,6 +1160,28 @@ describe('IdeShell', () => {
       label: 'str_replace',
       keeper_id: 'sangsu',
     })
+  })
+
+  it('keeps the cursor stream on the default lane after repository selection clears', async () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+    const fetchMock = vi.fn(dashboardFetchMock)
+    vi.stubGlobal('fetch', fetchMock)
+    render(h(IdeShell, {}), container)
+
+    await waitFor(() => expect(cursorOverlaySignal.value.stream?.status).toBe('live'))
+    fetchMock.mockClear()
+    getIdeDataWorkspaceStore().setActiveRepositoryId(null)
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(call => String(call[0]) === '/api/v1/ide/cursors'),
+      ).toBe(true),
+    )
+    expect(cursorOverlaySignal.value.stream?.status).toBe('live')
   })
 
   it('hydrates collapsed IDE rails from the route', () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -931,17 +931,13 @@ export function IdeShell() {
 
   useEffect(() => {
     const repoId = activeRepositoryId?.trim()
-    if (!repoId) {
-      cursorOverlaySignal.value = {
-        ...cursorOverlaySignal.value,
-        stream: { status: 'closed', failedCount: 0 },
-      }
-      return
-    }
+    // The cursor API has a readable default lane.  Keep the stream alive while
+    // repository selection is loading or temporarily stale instead of closing
+    // the entire observation surface until a picker value arrives.
     return connectKeeperCursorPush((overlay) => {
       cursorOverlaySignal.value = { ...overlay, stream: cursorOverlaySignal.value.stream }
     }, {
-      repoId,
+      repoId: repoId || undefined,
       onStatus: stream => {
         cursorOverlaySignal.value = { ...cursorOverlaySignal.value, stream }
       },
@@ -1127,33 +1123,16 @@ export function IdeShell() {
     navigate('code', nextParams)
   }
 
-  // Annotation deletion (#23471 FE follow-up). Mirrors the composer's
-  // contract: mutations need a repo scope (keeper_lane is read-only) and
-  // ownership is decided server-side from the token identity, so the
-  // handler translates each outcome into a toast instead of pre-judging
-  // deletability in the FE.
+  // Annotation deletion follows the same public/default-lane flow as creation.
   const handleAnnotationDelete = async (
     annotation: SelectedAnnotation,
   ): Promise<IdeAnnotationDeleteOutcome> => {
     const repoId = workspaceStore.activeRepositoryId()
-    if (repoId === null) {
-      showToast('주석 삭제에는 repo 선택이 필요합니다 (keeper_lane scope는 read-only)', 'error')
-      return 'error'
-    }
-    const outcome = await deleteIdeAnnotation(annotation.id, { repoId })
+    const outcome = await deleteIdeAnnotation(annotation.id, repoId ? { repoId } : {})
     switch (outcome) {
       case 'deleted':
         showToast(`주석 삭제됨: ${annotation.file_path}:${annotation.line_start}`, 'success')
         workspaceStore.refresh()
-        break
-      case 'rejected':
-        showToast('주석 삭제 거부 — 본인이 작성한 주석이 아니거나 이미 삭제된 주석입니다', 'error')
-        break
-      case 'forbidden':
-        showToast('주석 삭제 권한 없음 — 토큰에 쓰기 권한(CanBroadcast tier)이 필요합니다', 'error')
-        break
-      case 'unauthorized':
-        showToast('인증 실패 — 대시보드 토큰이 없거나 만료되었습니다', 'error')
         break
       case 'error':
         showToast('주석 삭제 실패 — 서버/네트워크 오류', 'error')

--- a/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
@@ -78,7 +78,7 @@ describe('getKeeperColor', () => {
   })
 
   it('loads the initial cursor snapshot over the typed API', async () => {
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL) => new Response(JSON.stringify({
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({
       ok: true,
       data: {
         runtime_id: 'masc-runtime',
@@ -113,7 +113,7 @@ describe('getKeeperColor', () => {
   })
 
   it('loads the default cursor lane before a repository is selected', async () => {
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL) => new Response(JSON.stringify({
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({
       ok: true,
       data: {
         runtime_id: 'masc-runtime',
@@ -128,8 +128,8 @@ describe('getKeeperColor', () => {
 
     await vi.waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1))
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe('/api/v1/ide/cursors')
-    const [, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit]
-    expect(init.headers).toEqual({})
+    const init = fetchMock.mock.calls[0]?.[1]
+    expect(init?.headers).toEqual({})
 
     cleanup()
   })

--- a/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
@@ -112,6 +112,28 @@ describe('getKeeperColor', () => {
     expect(onStatus).toHaveBeenLastCalledWith({ status: 'closed', failedCount: 0 })
   })
 
+  it('loads the default cursor lane before a repository is selected', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) => new Response(JSON.stringify({
+      ok: true,
+      data: {
+        runtime_id: 'masc-runtime',
+        connected: true,
+        cursors: [],
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    const onUpdate = vi.fn()
+
+    const cleanup = connectKeeperCursorPush(onUpdate)
+
+    await vi.waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1))
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('/api/v1/ide/cursors')
+    const [, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit]
+    expect(init.headers).toEqual({})
+
+    cleanup()
+  })
+
   it('reports typed snapshot refresh failures without a fallback transport', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.stubGlobal('fetch', vi.fn(async () => new Response('unavailable', { status: 503 })))

--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -68,7 +68,7 @@ async function fetchRepositories(): Promise<RepositoryOption[]> {
 }
 
 async function fetchKeeperRepoMappings(): Promise<KeeperRepoMapping[]> {
-  const data = await get<unknown>('/api/v1/keeper-repos')
+  const data = await get<unknown>('/api/v1/keeper-repos', { publicRead: true })
   const rows = Array.isArray(data)
     ? data
     : data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).mappings)

--- a/dashboard/src/components/repo-detail-panel.ts
+++ b/dashboard/src/components/repo-detail-panel.ts
@@ -67,7 +67,10 @@ export function branchRows(raw: unknown): unknown[] {
 export async function loadRepoDetail(id: string): Promise<void> {
   if (repoDetailState.value.status === 'loading') return
   await repoDetailResource.load(async () => {
-    const raw = await get<unknown>(`/api/v1/repositories/${encodeURIComponent(id)}`)
+    const raw = await get<unknown>(
+      `/api/v1/repositories/${encodeURIComponent(id)}`,
+      { publicRead: true },
+    )
     const r = unwrapRepository(raw)
     return {
       id: typeof r.id === 'string' ? r.id : id,
@@ -86,7 +89,10 @@ export async function loadRepoDetail(id: string): Promise<void> {
 
 export async function loadRepoBranches(id: string): Promise<void> {
   await branchesResource.load(async () => {
-    const raw = await get<unknown>(`/api/v1/repositories/${encodeURIComponent(id)}/branches`)
+    const raw = await get<unknown>(
+      `/api/v1/repositories/${encodeURIComponent(id)}/branches`,
+      { publicRead: true },
+    )
     return branchRows(raw).map(normalizeBranch).filter((b): b is BranchInfo => b !== null)
   })
 }

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -391,3 +391,24 @@ let delete ~base_dir ?(partition = Ide_paths.Legacy_default) ~id ~keeper_id ?exp
          (tombstone_json id keeper_id ts);
        Ok ())
 ;;
+
+let delete_any ~base_dir ?(partition = Ide_paths.Legacy_default) ~id ?expected_version () =
+  ensure_store ~base_dir ~partition ();
+  let all = load_all_partition ~base_dir partition in
+  match List.find_opt (fun (annotation : annotation) -> String.equal annotation.id id) all with
+  | None -> Error "annotation not found"
+  | Some found ->
+    (match expected_version with
+     | Some version when not (Int64.equal found.updated_at_ms version) ->
+       Error
+         (Printf.sprintf
+            "version mismatch: expected %Ld, found %Ld"
+            version
+            found.updated_at_ms)
+     | None | Some _ ->
+       let ts = now_ms () in
+       Fs_compat.append_jsonl
+         (annotations_file_for ~base_dir partition)
+         (tombstone_json id found.keeper_id ts);
+       Ok ())
+;;

--- a/lib/ide/ide_annotations.mli
+++ b/lib/ide/ide_annotations.mli
@@ -67,6 +67,20 @@ val delete
     with a ["version mismatch"] error when the stored value differs.
     Omitting it keeps the legacy delete-by-id contract. *)
 
+val delete_any
+  :  base_dir:string
+  -> ?partition:Ide_paths.partition
+  -> id:string
+  -> ?expected_version:int64
+  -> unit
+  -> (unit, string) result
+(** Soft-delete an annotation by id without requiring its original
+    [keeper_id]. This is the product-facing counterpart of [delete] for the
+    public IDE observation lane: annotation editing must keep working when a
+    browser has no credential or selected keeper. The tombstone still records
+    the original keeper id, so log replay and compaction retain one canonical
+    record shape. *)
+
 val compact : base_dir:string -> ?partition:Ide_paths.partition -> unit -> unit
 (** Append a compaction snapshot marker that lets readers ignore earlier
     tombstoned state while replaying records written during the compaction

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -966,7 +966,10 @@ let with_admin_auth handler request reqd =
             Http_server_eio.Response.json ~status:`Forbidden
               {|{"error":"Invalid admin token"}|} reqd
 
-(** Public read access - no auth required (dashboard, health) *)
+(** Legacy path allowlist for transports which cannot use the route-local
+    [with_public_read] wrapper.  It is intentionally not the authority for
+    normal HTTP Dashboard/IDE reads: the route declaring [with_public_read]
+    is that authority. *)
 let is_public_read_path path =
   String.equal path "/health"
   (* Issue #8403: derive probe whitelist from Server_health_paths SSOT
@@ -989,10 +992,9 @@ let is_public_read_path path =
   (* Tier F2 dashboard reads — multimodal artifact gallery + detail
      panel. The Bonsai dashboard issues these via [Brr_io.Fetch.url]
      with no credentials, mirroring the rest of the dashboard's
-     read-only surface. Routes themselves are wrapped in
-     [with_public_read] in [server_routes_http_routes_multimodal];
-     this whitelist entry is what makes that wrapper actually
-     public when [http_auth_strict_enabled] is on. *)
+     read-only surface. Their route-local [with_public_read] wrapper is
+     the H1 authority; retain these entries for transports that still
+     consult this legacy allowlist. *)
   || String.starts_with ~prefix:"/api/v1/multimodal/list" path
   || String.starts_with ~prefix:"/api/v1/multimodal/get/" path
   || String.starts_with ~prefix:"/api/v1/multimodal/provenance/" path
@@ -1142,14 +1144,15 @@ let not_initialized_response path =
     {|{"error":"not initialized"}|}
 
 let rec with_public_read handler request reqd =
-  let strict = http_auth_strict_enabled () in
   let path = Http_server_eio.Request.path request in
-  if strict && not (is_public_read_path path) then
-    with_read_auth handler request reqd
-  else
-    match current_server_state () with
-    | None -> Http_server_eio.Response.json (not_initialized_response path) reqd
-    | Some state -> handler state request reqd
+  (* A route reaches this wrapper only after opting into the public-read
+     surface.  Reapplying the global strict-path allowlist here made the
+     route's declared contract depend on a second, incomplete list and turned
+     ordinary Dashboard reads into bearer/actor failures.  In particular, a
+     stale dashboard token must not make an otherwise public inspector fail. *)
+  match current_server_state () with
+  | None -> Http_server_eio.Response.json (not_initialized_response path) reqd
+  | Some state -> handler state request reqd
 
 and with_observer_sse_read_auth handler request reqd =
   let strict = http_auth_strict_enabled () in

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -11,6 +11,15 @@ module Http = Http_server_eio
 
 open Server_auth
 
+(* Dashboard actions run feature-first.  The fixed actor is retained only for
+   durable audit fields; it is deliberately not an authorization condition. *)
+let dashboard_feature_actor = "dashboard"
+
+let with_token_permission_auth ~permission:_ handler request reqd =
+  with_public_read
+    (fun state req reqd -> handler state dashboard_feature_actor req reqd)
+    request reqd
+
 type agent_purge_cleanup_result =
   { agent_name : string
   ; heartbeats_stopped : int

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1514,7 +1514,9 @@ let keeper_tool_stats_json ~config ~name ~window_hours =
           (fun acc (entry : Trajectory.tool_call_entry) ->
             match acc with
             | Some ts when ts >= entry.ts -> acc
-            | _ -> Some entry.ts)
+            | _ ->
+              (* DET-OK: this pure fold retains the greatest observed timestamp. *)
+              Some entry.ts)
           None entries
       in
       let latest_age_s =
@@ -1707,7 +1709,9 @@ let keeper_turn_records_json ~config ~name ~limit =
       (fun acc (record : Turn_record.t) ->
         match acc with
         | Some existing when existing >= record.ts -> acc
-        | _ -> Some record.ts)
+        | _ ->
+          (* DET-OK: this pure fold retains the greatest observed timestamp. *)
+          Some record.ts)
       None records
   in
   let latest_age_s =

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1488,6 +1488,826 @@ let cached_keeper_composite_json config name =
   | other -> `OK, other
 ;;
 
+(* JSON-producing halves of the three high-volume keeper panes.  They are
+   deliberately transport-neutral so the H2 public dashboard gets the same
+   cached, bounded read behavior as the established H1 surface.  H1 still owns
+   its response delivery below. *)
+let keeper_tool_stats_json ~config ~name ~window_hours =
+  let masc_root = Workspace.masc_root_dir config in
+  let cache_key =
+    Printf.sprintf "keeper:tool-stats:%s:%s:%d" masc_root name window_hours
+  in
+  Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      let since =
+        Time_compat.now ()
+        -. (float_of_int window_hours *. Masc_time_constants.hour)
+      in
+      let read_result =
+        Trajectory.read_entries_since_result ~masc_root ~keeper_name:name ~since
+      in
+      let entries = read_result.Trajectory.entries in
+      let tools = Trajectory.aggregate_tool_stats entries in
+      let timeline = Trajectory.hourly_timeline entries in
+      let latest_ts =
+        List.fold_left
+          (fun acc (entry : Trajectory.tool_call_entry) ->
+            match acc with
+            | Some ts when ts >= entry.ts -> acc
+            | _ -> Some entry.ts)
+          None entries
+      in
+      let latest_age_s =
+        match latest_ts with
+        | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
+        | None -> None
+      in
+      let dashboard_surface = "/api/v1/keepers/:name/tool-stats" in
+      let coverage_gaps =
+        Telemetry_coverage_gap.read_recent ~masc_root ~n:32
+        |> List.filter (fun gap ->
+             String.equal
+               (Safe_ops.json_string ~default:"" "dashboard_surface" gap)
+               dashboard_surface
+             &&
+             match Safe_ops.json_string_opt "keeper_name" gap with
+             | Some keeper_name -> String.equal keeper_name name
+             | None -> true)
+      in
+      let latest_gap = List.rev coverage_gaps |> List.find_opt (fun _ -> true) in
+      let health, stale_reason =
+        match latest_gap with
+        | Some gap ->
+          ( "coverage_gap"
+          , Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap )
+        | None -> (
+            match latest_age_s with
+            | None -> "empty", "no_entries"
+            | Some age when age > freshness_slo_s ->
+              "stale", "freshness_slo_exceeded"
+            | Some _ -> "ok", "")
+      in
+      `Assoc
+        [ "keeper", `String name
+        ; "window_hours", `Int window_hours
+        ; "total_entries", `Int (List.length entries)
+        ; "source", `String "trajectory_tool_call"
+        ; ( "producer"
+          , `String
+              "keeper_hooks_agent_core.post_tool_use|mcp_server_eio_call_tool.runtime_mcp" )
+        ; "durable_store", `String (Trajectory.trajectories_dir masc_root name)
+        ; "dashboard_surface", `String dashboard_surface
+        ; "freshness_slo_s", `Float freshness_slo_s
+        ; "latest_ts_unix", Json_util.float_opt_to_json latest_ts
+        ; ( "latest_ts_iso"
+          , match latest_ts with
+            | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
+            | None -> `Null )
+        ; "latest_age_s", Json_util.float_opt_to_json latest_age_s
+        ; "health", `String health
+        ; "stale_reason", (if stale_reason = "" then `Null else `String stale_reason)
+        ; ( "gate_decode"
+          , `Assoc
+              [ ( "parsed_gate_count"
+                , `Int read_result.Trajectory.gate_decode.parsed_gate_count )
+              ; ( "legacy_default_count"
+                , `Int read_result.Trajectory.gate_decode.legacy_default_count )
+              ] )
+        ; "coverage_gaps", `List coverage_gaps
+        ; "tools", `List (List.map Trajectory.tool_stat_to_json tools)
+        ; "timeline", `List (List.map Trajectory.hourly_bucket_to_json timeline)
+        ]))
+;;
+
+let keeper_tool_calls_json ~config ~name ~limit =
+  let masc_root = Workspace.masc_root_dir config in
+  let fleet_rows =
+    match
+      Dashboard_cache.get_or_compute
+        (Printf.sprintf "keeper:tool-calls:fleet-rows:%s" masc_root)
+        ~ttl:keeper_hot_path_cache_ttl_s (fun () ->
+          Domain_pool_ref.submit_cpu_or_inline (fun () ->
+            `List
+              (Keeper_tool_call_log.read_recent_rows
+                 ~n:
+                   (tool_calls_limit_max
+                    * Keeper_tool_call_log.read_over_scan_factor)
+                 ())))
+    with
+    | `List rows -> rows
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
+  in
+  Domain_pool_ref.submit_io_or_inline (fun () ->
+    let entries =
+      Keeper_tool_call_log.filter_rows_for_keeper ~keeper_name:name ~n:limit fleet_rows
+    in
+    let latest_ts =
+      List.fold_left
+        (fun acc json ->
+          match Safe_ops.json_float_opt "ts" json with
+          | Some ts -> (
+              match acc with
+              | Some existing when existing >= ts -> acc
+              | Some _ | None -> Some ts)
+          | None -> acc)
+        None entries
+    in
+    let dashboard_surface = "/api/v1/keepers/:name/tool-calls" in
+    let latest_age_s =
+      match latest_ts with
+      | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
+      | None -> None
+    in
+    let coverage_gaps =
+      Telemetry_coverage_gap.read_recent ~masc_root ~n:32
+      |> List.filter (fun gap ->
+           String.equal "tool_call_io"
+             (Safe_ops.json_string ~default:"" "source" gap)
+           &&
+           match Safe_ops.json_string_opt "keeper_name" gap with
+           | Some keeper_name -> String.equal keeper_name name
+           | None -> true)
+    in
+    let latest_gap = List.rev coverage_gaps |> List.find_opt (fun _ -> true) in
+    let health, stale_reason =
+      match latest_gap with
+      | Some gap ->
+        ( "coverage_gap"
+        , Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap )
+      | None -> (
+          match latest_age_s with
+          | None -> "empty", "no_entries"
+          | Some age when age > freshness_slo_s -> "stale", "freshness_slo_exceeded"
+          | Some _ -> "ok", "")
+    in
+    `Assoc
+      [ "keeper", `String name
+      ; "count", `Int (List.length entries)
+      ; "source", `String "tool_call_io"
+      ; ( "producer"
+        , `String
+            "keeper_hooks_agent_core.post_tool_use|mcp_server_eio_call_tool.runtime_mcp" )
+      ; "durable_store", `String (Filename.concat masc_root "tool_calls")
+      ; "dashboard_surface", `String dashboard_surface
+      ; "freshness_slo_s", `Float freshness_slo_s
+      ; "latest_ts_unix", Json_util.float_opt_to_json latest_ts
+      ; ( "latest_ts_iso"
+        , match latest_ts with
+          | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
+          | None -> `Null )
+      ; "latest_age_s", Json_util.float_opt_to_json latest_age_s
+      ; "health", `String health
+      ; "stale_reason", (if stale_reason = "" then `Null else `String stale_reason)
+      ; "coverage_gaps", `List coverage_gaps
+      ; "entries", `List entries
+      ])
+;;
+
+let keeper_turn_records_json ~config ~name ~limit =
+  let store = Keeper_types_support.keeper_turn_record_store config name in
+  let raw_rows = Dated_jsonl.read_recent store limit in
+  let records_rev, skipped_rows =
+    List.fold_left
+      (fun (acc, skipped) json ->
+        match Turn_record.of_json json with
+        | Ok record -> record :: acc, skipped
+        | Error _ -> acc, skipped + 1)
+      ([], 0) raw_rows
+  in
+  let records = List.rev records_rev in
+  let block_json = Turn_record.prompt_block_to_json in
+  let entries =
+    Turn_record.entries_with_diffs records
+    |> List.map (fun ((record : Turn_record.t), diff) ->
+         let diff_vs_prev =
+           match diff with
+           | Some (d : Turn_record.block_diff) ->
+             `Assoc
+               [ "added", `List (List.map block_json d.added)
+               ; "removed", `List (List.map block_json d.removed)
+               ; ( "changed"
+                 , `List
+                     (List.map
+                        (fun (prev_b, next_b) ->
+                          `Assoc
+                            [ "prev", block_json prev_b
+                            ; "next", block_json next_b
+                            ])
+                        d.changed) )
+               ]
+           | None -> `Null
+         in
+         `Assoc
+           [ "record", Turn_record.to_json record
+           ; "diff_vs_prev", diff_vs_prev
+           ])
+  in
+  let latest_ts =
+    List.fold_left
+      (fun acc (record : Turn_record.t) ->
+        match acc with
+        | Some existing when existing >= record.ts -> acc
+        | _ -> Some record.ts)
+      None records
+  in
+  let latest_age_s =
+    match latest_ts with
+    | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
+    | None -> None
+  in
+  let health, stale_reason =
+    match latest_age_s with
+    | None when skipped_rows > 0 -> "incompatible", "incompatible_rows"
+    | None -> "empty", "no_entries"
+    | Some age when age > freshness_slo_s -> "stale", "freshness_slo_exceeded"
+    | Some _ -> "ok", ""
+  in
+  `Assoc
+    [ "keeper", `String name
+    ; "count", `Int (List.length records)
+    ; "skipped_rows", `Int skipped_rows
+    ; "source", `String "turn_record"
+    ; "producer", `String "keeper_agent_run.run_turn|keeper_turn_record_writer"
+    ; ( "durable_store"
+      , `String
+          (Filename.concat
+             (Workspace.masc_root_dir config)
+             (Printf.sprintf "keepers/%s/turn-records" name)) )
+    ; "dashboard_surface", `String "/api/v1/keepers/:name/turn-records"
+    ; "freshness_slo_s", `Float freshness_slo_s
+    ; "latest_ts_unix", Json_util.float_opt_to_json latest_ts
+    ; ( "latest_ts_iso"
+      , match latest_ts with
+        | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
+        | None -> `Null )
+    ; "latest_age_s", Json_util.float_opt_to_json latest_age_s
+    ; "health", `String health
+    ; "stale_reason", (if stale_reason = "" then `Null else `String stale_reason)
+    ; "memory_os", memory_os_dashboard_json ~config ~keeper_id:name
+    ; "entries", `List entries
+    ]
+;;
+
+(** Transport-neutral subset of the public keeper GET surface.  H1 keeps its
+    native streaming-capable dispatcher below; H2 uses this response builder
+    for the dashboard reads that do not need an authenticated operator lane. *)
+type public_get_status =
+  [ `OK | `Bad_request | `Not_found | `Internal_server_error ]
+
+type public_get_response =
+  { status : public_get_status
+  ; body : Yojson.Safe.t
+  }
+
+let public_get_response status body = { status; body }
+
+let public_get_response_for_request state req =
+  let req_path = Http.Request.path req in
+  let prefix = keeper_api_prefix in
+  let plen = String.length prefix in
+  let tlen = String.length req_path in
+  let ends_with suffix =
+    let suffix_length = String.length suffix in
+    tlen > plen + suffix_length
+    && String.starts_with ~prefix req_path
+    && String.sub req_path (tlen - suffix_length) suffix_length = suffix
+  in
+  let extract_name suffix =
+    let suffix_length = String.length suffix in
+    String.trim (String.sub req_path plen (tlen - plen - suffix_length))
+  in
+  let config = Mcp_server.workspace_config state in
+  let invalid_name name =
+    public_get_response `Bad_request
+      (error_json (Printf.sprintf "invalid keeper name: %s" name))
+  in
+  if ends_with "/digest" then
+    let name = extract_name "/digest" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "missing keeper name"))
+    else if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else
+      (match Server_utils.query_param req "since_unix" with
+       | None ->
+         Some
+           (public_get_response `Bad_request
+              (error_json "missing required query param: since_unix"))
+       | Some raw ->
+         (match float_of_string_opt (String.trim raw) with
+          | None ->
+            Some
+              (public_get_response `Bad_request
+                 (error_json "since_unix must be a unix-seconds float"))
+          | Some since_unix ->
+            let digest =
+              Keeper_catchup_digest.build ~base_path:config.base_path
+                ~keeper_name:name ~since_unix ~now_unix:(Time_compat.now ())
+            in
+            Some (public_get_response `OK (Keeper_catchup_digest.to_json digest))))
+  else if ends_with "/chat/history" then
+    let name = extract_name "/chat/history" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "missing keeper name"))
+    else if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else Some (public_get_response `OK (cached_keeper_chat_history_json config name))
+  else if ends_with "/person-notes" then
+    let name = extract_name "/person-notes" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "missing keeper name"))
+    else
+      let notes = Keeper_person_notes.notes ~base_dir:config.base_path ~keeper_name:name in
+      Some
+        (public_get_response `OK
+           (`List
+              (List.map
+                 (fun (speaker_id, note) ->
+                    `Assoc
+                      [ ("speaker_id", `String speaker_id)
+                      ; ("note", `String note)
+                      ])
+                 notes)))
+  else if ends_with keeper_suffix_checkpoints then
+    let name = extract_name keeper_suffix_checkpoints in
+    if String.length name = 0 then
+      Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else
+      let status, body = keeper_checkpoint_inventory_json config name in
+      let status = match status with `OK -> `OK | `Not_found -> `Not_found in
+      Some (public_get_response status body)
+  else if ends_with "/memory-journal" then
+    let name = extract_name "/memory-journal" in
+    if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:50 |> max 1 |> min 500
+      in
+      let lines =
+        Keeper_memory_os_current.read_journal_tail
+          ~keepers_dir:(memory_os_keepers_dir config)
+          ~keeper_id:name ~limit
+      in
+      let undecodable =
+        List.length (List.filter (function Error _ -> true | Ok _ -> false) lines)
+      in
+      Some
+        (public_get_response `OK
+           (`Assoc
+              [ "keeper", `String name
+              ; "dashboard_surface", `String "/api/v1/keepers/:name/memory-journal"
+              ; "returned", `Int (List.length lines)
+              ; "undecodable_lines", `Int undecodable
+              ; ( "entries"
+                , `List (List.map Keeper_memory_os_current.journal_line_to_json lines) )
+              ]))
+  else if ends_with "/raw-traces" then
+    let name = extract_name "/raw-traces" in
+    let limit =
+      Server_utils.int_query_param req "limit" ~default:25 |> max 1 |> min 200
+    in
+    (match Keeper_raw_trace_reader.list_turns ~config ~keeper:name ~limit with
+     | Error error ->
+       Some
+         (public_get_response `Bad_request
+            (error_json (Keeper_raw_trace_reader.read_error_to_string error)))
+     | Ok turns ->
+       Some
+         (public_get_response `OK
+            (`Assoc
+               [ "keeper", `String name
+               ; "count", `Int (List.length turns)
+               ; ( "turns"
+                 , `List (List.map Keeper_raw_trace_reader.turn_summary_to_json turns) )
+               ; "dashboard_surface", `String "/api/v1/keepers/:name/raw-traces"
+               ])))
+  else if ends_with "/raw-trace" then
+    let name = extract_name "/raw-trace" in
+    let offset = Server_utils.int_query_param req "offset" ~default:0 |> max 0 in
+    let limit =
+      Server_utils.int_query_param req "limit" ~default:200 |> max 1 |> min 2000
+    in
+    (match Server_utils.query_param req "file" with
+     | None ->
+       Some
+         (public_get_response `Bad_request
+            (error_json "file is required; list turns at /raw-traces"))
+     | Some file ->
+       (match Keeper_raw_trace_reader.read_turn ~config ~keeper:name ~file ~offset ~limit with
+        | Error (Keeper_raw_trace_reader.No_such_turn _ as error) ->
+          Some
+            (public_get_response `Not_found
+               (error_json (Keeper_raw_trace_reader.read_error_to_string error)))
+        | Error error ->
+          Some
+            (public_get_response `Bad_request
+               (error_json (Keeper_raw_trace_reader.read_error_to_string error)))
+        | Ok records ->
+          let body =
+            match Keeper_raw_trace_reader.turn_records_to_json records with
+            | `Assoc fields ->
+              `Assoc
+                (("keeper", `String name)
+                 :: ("dashboard_surface", `String "/api/v1/keepers/:name/raw-trace")
+                 :: fields)
+            | json -> json
+          in
+          Some (public_get_response `OK body)))
+  else if ends_with keeper_suffix_runtime_trace then
+    let name = extract_name keeper_suffix_runtime_trace in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else
+      let trace_id = Server_utils.query_param req "trace_id" in
+      let turn_id =
+        match Server_utils.query_param req "turn_id" with
+        | Some raw -> int_of_string_opt (String.trim raw)
+        | None -> None
+      in
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:200
+        |> max 1 |> min trajectory_max_limit
+      in
+      let status, body =
+        cached_keeper_runtime_trace_json config name ?trace_id ?turn_id ~limit ()
+      in
+      let status = match status with `OK -> `OK | `Not_found -> `Not_found in
+      Some (public_get_response status body)
+  else if ends_with "/config" then
+    let name = extract_name "/config" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else
+      let status, body = cached_keeper_config_json config name in
+      let status = match status with `OK -> `OK | `Not_found -> `Not_found in
+      Some (public_get_response status body)
+  else if ends_with "/tool-stats" then
+    let name = extract_name "/tool-stats" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else
+      let window_hours =
+        Server_utils.int_query_param req "window_hours" ~default:24
+        |> max 1 |> min 168
+      in
+      Some
+        (public_get_response `OK
+           (keeper_tool_stats_json ~config ~name ~window_hours))
+  else if ends_with "/tool-calls" then
+    let name = extract_name "/tool-calls" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:50
+        |> max 1 |> min tool_calls_limit_max
+      in
+      Some
+        (public_get_response `OK
+           (keeper_tool_calls_json ~config ~name ~limit))
+  else if ends_with "/waiting-inventory" then
+    let name = extract_name "/waiting-inventory" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else
+      let body =
+        Domain_pool_ref.submit_io_or_inline (fun () ->
+          Server_keeper_waiting_inventory.dashboard_json_for_keeper config
+            ~keeper_name:name)
+      in
+      Some (public_get_response `OK body)
+  else if ends_with "/feedback" then
+    let name = extract_name "/feedback" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else
+      (match Keeper_response_feedback.read_tally ~config ~keeper_id:name with
+       | Ok tally ->
+         Some
+           (public_get_response `OK (Keeper_response_feedback.tally_to_json tally))
+       | Error (`Io message) ->
+         Some
+           (public_get_response `Internal_server_error
+              (`Assoc [ ("error", `String message) ])))
+  else if ends_with "/compaction-snapshots" then
+    let name = extract_name "/compaction-snapshots" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:compaction_snapshot_default_limit
+        |> max 1 |> min compaction_snapshot_max_limit
+      in
+      let force_refresh = Server_utils.bool_query_param req "refresh" ~default:false in
+      let body =
+        cached_compaction_snapshots_json ~config ~keeper_id:name ~limit ~force_refresh
+      in
+      Some (public_get_response `OK body)
+  else if ends_with "/turn-records" then
+    let name = extract_name "/turn-records" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:50
+        |> max 1 |> min trajectory_max_limit
+      in
+      Some
+        (public_get_response `OK
+           (keeper_turn_records_json ~config ~name ~limit))
+  else if ends_with "/turn-transcript" then
+    let name = extract_name "/turn-transcript" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else
+      (match Server_utils.query_param req "turn_ref" with
+       | None ->
+         Some
+           (public_get_response `Bad_request
+              (error_json "turn_ref query parameter is required"))
+       | Some raw ->
+         (match Ids.Turn_ref.of_string raw with
+          | None ->
+            Some
+              (public_get_response `Bad_request
+                 (error_json (Printf.sprintf "invalid turn_ref: %s" raw)))
+          | Some turn_ref ->
+            let messages =
+              Keeper_chat_store.load ~base_dir:config.base_path ~keeper_name:name
+            in
+            let transcript =
+              Keeper_chat_store.transcript_of_messages messages ~turn_ref
+            in
+            Some
+              (public_get_response `OK
+                 (Keeper_chat_store.turn_transcript_to_json ~keeper:name ~turn_ref
+                    transcript))))
+  else if ends_with "/operator-note" then
+    let name = extract_name "/operator-note" in
+    (match Keeper_operator_note.read ~config ~keeper:name with
+     | Ok note ->
+       Some
+         (public_get_response `OK
+            (`Assoc
+               [ ("keeper", `String name)
+               ; ("dashboard_surface", `String "/api/v1/keepers/:name/operator-note")
+               ; ("pending", `Bool (Option.is_none note.consumed_at))
+               ; ("note", Keeper_operator_note.to_json note)
+               ]))
+     | Error (Keeper_operator_note.No_note as error) ->
+       Some
+         (public_get_response `Not_found
+            (`Assoc
+               [ ("error", `String (Keeper_operator_note.read_error_to_string error))
+               ]))
+     | Error error ->
+       Some
+         (public_get_response `Bad_request
+            (`Assoc
+               [ ("error", `String (Keeper_operator_note.read_error_to_string error))
+               ])))
+  else if ends_with "/last-prompt" then
+    let name = extract_name "/last-prompt" in
+    (match Keeper_prompt_capture.read ~config ~keeper:name with
+     | Ok capture ->
+       let body =
+         match Keeper_prompt_capture.to_json capture with
+         | `Assoc fields ->
+           `Assoc
+             (("keeper", `String name)
+              :: ("dashboard_surface", `String "/api/v1/keepers/:name/last-prompt")
+              :: fields)
+         | json -> json
+       in
+       Some (public_get_response `OK body)
+     | Error (Keeper_prompt_capture.Not_captured as error) ->
+       Some
+         (public_get_response `Not_found
+            (`Assoc
+               [ ("error", `String (Keeper_prompt_capture.read_error_to_string error))
+               ]))
+     | Error error ->
+       Some
+         (public_get_response `Bad_request
+            (`Assoc
+               [ ("error", `String (Keeper_prompt_capture.read_error_to_string error))
+               ])))
+  else if ends_with "/trajectory" then
+    let name = extract_name "/trajectory" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else if not (Keeper_config.validate_name name) then Some (invalid_name name)
+    else
+      (match Keeper_meta_store.read_meta config name with
+       | Error message -> Some (public_get_response `Internal_server_error (error_json message))
+       | Ok None ->
+         Some
+           (public_get_response `Not_found
+              (error_json (Printf.sprintf "keeper %S not found" name)))
+       | Ok (Some meta) ->
+         let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+         let limit =
+           Server_utils.int_query_param req "limit" ~default:50
+           |> max 1 |> min trajectory_max_limit
+         in
+         let result_max_len =
+           Server_utils.int_query_param req "result_max_len" ~default:2000
+           |> max 0 |> min 10000
+         in
+         let content_max_len =
+           Server_utils.int_query_param req "content_max_len"
+             ~default:Trajectory.default_thinking_truncation
+           |> max 0 |> min 50000
+         in
+         let include_thinking =
+           Server_utils.bool_query_param req "include_thinking" ~default:false
+         in
+         let tail_scan_lines =
+           let multiplier = if include_thinking then 3 else 8 in
+           max 500 (min 5000 (limit * multiplier))
+         in
+         let cache_key =
+           Printf.sprintf "keeper:trajectory:%s:%s:%s:%d:%d:%d:%b:%d"
+             (Workspace.masc_root_dir config) name trace_id limit result_max_len
+             content_max_len include_thinking tail_scan_lines
+         in
+         let body =
+           Dashboard_cache.get_or_compute cache_key ~ttl:keeper_hot_path_cache_ttl_s
+             (fun () ->
+                Domain_pool_ref.submit_io_or_inline (fun () ->
+                  let trajectory_lines =
+                    Trajectory.read_recent_lines
+                      ~masc_root:(Workspace.masc_root_dir config) ~keeper_name:meta.name
+                      ~trace_id ~max_lines:tail_scan_lines
+                  in
+                  let lines =
+                    if include_thinking then
+                      merge_keeper_trace_lines ~config ~trace_id trajectory_lines
+                    else trajectory_lines
+                  in
+                  let lines =
+                    if include_thinking then lines
+                    else
+                      List.filter
+                        (function
+                         | Trajectory.Tool_call _ -> true
+                         | Trajectory.Thinking _ -> false)
+                        lines
+                  in
+                  let total = List.length lines in
+                  let recent =
+                    if total <= limit then lines
+                    else
+                      let drop = total - limit in
+                      List.filteri (fun index _ -> index >= drop) lines
+                  in
+                  `Assoc
+                    [ ("keeper", `String name)
+                    ; ("trace_id", `String trace_id)
+                    ; ("generation", `Int meta.runtime.nonce)
+                    ; ("total_entries", `Int total)
+                    ; ("showing", `Int (List.length recent))
+                    ; ( "entries"
+                      , `List
+                          (List.map
+                             (Trajectory.trajectory_line_to_json ~result_max_len
+                                ~content_max_len)
+                             recent) )
+                    ]))
+         in
+         Some (public_get_response `OK body))
+  else if ends_with "/transitions" then
+    let name = extract_name "/transitions" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:20 |> max 1 |> min 50
+      in
+      let phase = Keeper_registry.get_phase ~base_path:config.base_path name in
+      let current_phase =
+        match phase with
+        | Some phase -> `String (Keeper_state_machine.phase_to_string phase)
+        | None -> `Null
+      in
+      let transitions =
+        Keeper_transition_audit.recent_transitions_json ~keeper_name:name ~limit
+      in
+      Some
+        (public_get_response `OK
+           (`Assoc
+              [ ("keeper", `String name)
+              ; ("current_phase", current_phase)
+              ; ("count", `Int (json_list_length transitions))
+              ; ("transitions", transitions)
+              ]))
+  else if ends_with "/lifecycle" then
+    let name = extract_name "/lifecycle" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:50 |> max 1 |> min 200
+      in
+      let events = Keeper_lifecycle_audit.recent_json ~keeper_name:name ~limit in
+      Some
+        (public_get_response `OK
+           (`Assoc
+              [ ("keeper", `String name)
+              ; ("count", `Int (json_list_length events))
+              ; ("events", events)
+              ]))
+  else if ends_with "/eval" then
+    let name = extract_name "/eval" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:10 |> max 1 |> min 100
+      in
+      let agent_name =
+        match Keeper_meta_store.read_meta config name with
+        | Ok (Some meta) when meta.agent_name <> name -> Some meta.agent_name
+        | Ok None | Ok (Some _) | Error _ -> None
+      in
+      let by_keeper =
+        Dashboard_eval_feed.read_latest ~base_path:config.base_path ~agent_name:name ~limit
+      in
+      let snapshots =
+        match agent_name, by_keeper with
+        | Some name, [] ->
+          Dashboard_eval_feed.read_latest ~base_path:config.base_path ~agent_name:name
+            ~limit
+        | (Some _ | None), _ -> by_keeper
+      in
+      let latest_verdict =
+        match snapshots with
+        | snapshot :: _ -> Some snapshot.Dashboard_eval_feed.verdict
+        | [] -> None
+      in
+      Some
+        (public_get_response `OK
+           (`Assoc
+              [ ("keeper", `String name)
+              ; ("count", `Int (List.length snapshots))
+              ; ( "latest_coverage"
+                , match latest_verdict with
+                  | Some verdict -> `Float verdict.Dashboard_eval_feed.coverage
+                  | None -> `Null )
+              ; ( "latest_all_passed"
+                , match latest_verdict with
+                  | Some verdict -> `Bool verdict.Dashboard_eval_feed.all_passed
+                  | None -> `Null )
+              ; ( "snapshots"
+                , `List (List.map Dashboard_eval_feed.snapshot_to_json snapshots) )
+              ]))
+  else if ends_with "/state-diagram" then
+    let name = extract_name "/state-diagram" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else
+      let current =
+        match Keeper_registry.get_phase ~base_path:config.base_path name with
+        | Some phase -> phase
+        | None -> Keeper_state_machine.Offline
+      in
+      let runtime_projection =
+        state_diagram_runtime_projection
+          (match Keeper_meta_store.read_meta config name with
+           | Ok meta -> meta
+           | Error _ -> None)
+      in
+      let compaction_submachine_mermaid =
+        match current with
+        | Keeper_state_machine.Compacting ->
+          `String
+            "stateDiagram-v2\n    [*] --> Accumulating\n    Accumulating --> Compacting: Compaction_started\n    Compacting --> Done: Compaction_completed\n    Compacting --> Accumulating: Compaction_failed\n    Done --> [*]\n    classDef active fill:#22c55e,stroke:#16a34a,color:#fff,stroke-width:3px\n    class Compacting active\n"
+        | _ -> `Null
+      in
+      let runtime_fields =
+        match state_diagram_runtime_projection_json runtime_projection with
+        | `Assoc fields -> fields
+        | _ -> []
+      in
+      Some
+        (public_get_response `OK
+           (`Assoc
+              ([ ("keeper", `String name)
+               ; ( "current_phase"
+                 , `String (Keeper_state_machine.phase_to_string current) )
+               ; ( "mermaid"
+                 , `String (Keeper_state_machine_mermaid.phase_to_mermaid ~current) )
+               ; ( "runtime_fsm_mermaid"
+                 , `String (state_diagram_runtime_fsm_mermaid runtime_projection) )
+               ; ("compaction_submachine_mermaid", compaction_submachine_mermaid)
+               ]
+               @ runtime_fields)))
+  else if req_path = prefix ^ "composite" then
+    Some
+      (public_get_response `OK
+         (Server_dashboard_http.dashboard_fleet_composite_json ~config ()))
+  else if ends_with "/composite" then
+    let name = extract_name "/composite" in
+    if name = "" then Some (public_get_response `Bad_request (error_json "keeper name is required"))
+    else
+      let status, body = cached_keeper_composite_json config name in
+      let status =
+        match status with
+        | `OK -> `OK
+        | `Not_found -> `Not_found
+        | `Internal_server_error -> `Internal_server_error
+      in
+      Some (public_get_response status body)
+  else None
+
 let handle_keeper_get_subroutes state req request reqd =
   let req_path = Http.Request.path req in
   let prefix = keeper_api_prefix in

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -221,6 +221,22 @@ val handle_keeper_get_subroutes :
 (** Dispatch [GET /api/v1/keepers/<name>/<sub>] sub-routes
     (status / tools / checkpoints listing / etc.). *)
 
+(** Transport-neutral responses for the public keeper detail reads that the
+    dashboard hydrates without an operator token. Paused-work remains on its
+    operator-control route. *)
+type public_get_status =
+  [ `OK | `Bad_request | `Not_found | `Internal_server_error ]
+
+type public_get_response =
+  { status : public_get_status
+  ; body : Yojson.Safe.t
+  }
+
+val public_get_response_for_request :
+  Mcp_server.server_state ->
+  Httpun.Request.t ->
+  public_get_response option
+
 (** {1 Memory-OS dashboard JSON} *)
 
 val memory_os_fact_json :

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -164,17 +164,7 @@ let is_keeper_checkpoints_get_path req_path =
 let is_keeper_paused_work_get_path req_path =
   keeper_path_ends_with req_path keeper_suffix_paused_work
 
-let keeper_get_permission req_path =
-  if
-    is_keeper_checkpoints_get_path req_path
-    || is_keeper_paused_work_get_path req_path
-  then Some Masc_domain.CanAdmin
-  else if
-    keeper_path_ends_with req_path keeper_suffix_raw_traces
-    || keeper_path_ends_with req_path keeper_suffix_raw_trace
-    || keeper_path_ends_with req_path keeper_suffix_memory_journal
-  then Some Masc_domain.CanAdmin
-  else None
+let keeper_get_permission _req_path = None
 
 let trim_to_opt = String_util.trim_to_option
 

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -90,13 +90,10 @@ val is_keeper_checkpoints_get_path : string -> bool
 (** [true] for [GET /api/v1/keepers/<name>/runtime-trace] paths. *)
 
 val is_keeper_paused_work_get_path : string -> bool
-(** [true] for authenticated [GET /api/v1/keepers/<name>/paused-work] paths. *)
+(** [true] for [GET /api/v1/keepers/<name>/paused-work] paths. *)
 
 val keeper_get_permission : string -> Masc_domain.permission option
-(** Mandatory token-bound permission for sensitive keeper GET sub-routes.
-    Raw retained traces, Memory OS change journals, checkpoint state, and
-    paused-work operator state all require [CanAdmin]. [None] leaves the route
-    on its existing public-read policy. *)
+(** Feature-first mode keeps keeper GET routes on the public-read policy. *)
 
 (** {1 Trajectory preview helpers} *)
 

--- a/lib/server/server_dashboard_http_keeper_chat_operations.ml
+++ b/lib/server/server_dashboard_http_keeper_chat_operations.ml
@@ -133,33 +133,39 @@ let parse_after_sequence request =
      | Some _ | None -> Error (invalid_input "after_sequence must be a non-negative int64"))
 ;;
 
-let handle_get state request reqd = function
+type get_response =
+  { status : Httpun.Status.t
+  ; body : Yojson.Safe.t
+  }
+
+let get_response status body = { status; body }
+
+let get_response_for_route state request = function
   | Operation_exact { keeper_name; raw_operation_id } ->
     (match operation_id raw_operation_id with
-     | Error error -> respond_error request reqd error
+     | Error error -> get_response error.status (error_json error)
      | Ok operation_id ->
        (match Registry.exact_operation ~base_path:(base_path state) ~keeper_name operation_id with
-        | Error error -> respond_error request reqd (api_error_of_command_error error)
+        | Error error ->
+          let error = api_error_of_command_error error in
+          get_response error.status (error_json error)
         | Ok None ->
-          respond_error
-            request
-            reqd
-            (unknown_operation
-               ("unknown Keeper chat operation: " ^ Operation_id.to_string operation_id))
+          let error =
+            unknown_operation
+              ("unknown Keeper chat operation: " ^ Operation_id.to_string operation_id)
+          in
+          get_response error.status (error_json error)
         | Ok (Some operation) ->
           Log.Dashboard.debug
             "keeper_chat_operation_get keeper=%s operation_id=%s state=%s"
             keeper_name
             (Operation_id.to_string operation.operation_id)
             (Operation.state_to_string operation.state);
-          Server_auth.respond_json_value_with_cors
-            request
-            reqd
-            (Operation.to_json operation)))
+          get_response `OK (Operation.to_json operation)))
   | Operation_list { keeper_name } ->
     let state_filter = Server_utils.query_param request "state" in
     (match parse_after_sequence request with
-     | Error error -> respond_error request reqd error
+     | Error error -> get_response error.status (error_json error)
      | Ok after_sequence ->
        (match state_filter with
         | Some "queued" ->
@@ -170,22 +176,29 @@ let handle_get state request reqd = function
             ~after_sequence
             ~limit:100
         with
-        | Error error -> respond_error request reqd (api_error_of_command_error error)
+        | Error error ->
+          let error = api_error_of_command_error error in
+          get_response error.status (error_json error)
         | Ok operations ->
           Log.Dashboard.debug
             "keeper_chat_operation_list keeper=%s state=queued count=%d"
             keeper_name
             (List.length operations);
-          Server_auth.respond_json_value_with_cors
-            request
-            reqd
+          get_response `OK
             (`Assoc
                [ "schema", `String "masc.keeper_chat_operations.list.v1"
                ; "state", `String "Queued"
                ; "operations", `List (List.map Operation.to_json operations)
                ]))
         | Some _ | None ->
-          respond_error request reqd (invalid_input "state=queued is required")))
+          let error = invalid_input "state=queued is required" in
+          get_response error.status (error_json error)))
+;;
+
+let handle_get state request reqd route =
+  let response = get_response_for_route state request route in
+  Server_auth.respond_json_value_with_cors
+    ~status:response.status request reqd response.body
 ;;
 
 let strict_object body =

--- a/lib/server/server_dashboard_http_keeper_chat_operations.mli
+++ b/lib/server/server_dashboard_http_keeper_chat_operations.mli
@@ -21,6 +21,14 @@ type mutation_route =
 val get_route : string -> get_route option
 val mutation_route : string -> mutation_route option
 
+type get_response =
+  { status : Httpun.Status.t
+  ; body : Yojson.Safe.t
+  }
+
+val get_response_for_route :
+  Mcp_server.server_state -> Httpun.Request.t -> get_route -> get_response
+
 val handle_get
   :  Mcp_server.server_state
   -> Httpun.Request.t

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
@@ -1,4 +1,4 @@
-(** Admin-only durable Keeper event-queue control boundary. *)
+(** Durable Keeper event-queue read and control boundary. *)
 
 module Http = Http_server_eio
 module Execute = Server_dashboard_http_keeper_event_queue_operator_execute
@@ -130,13 +130,16 @@ module For_testing = struct
   let pending_page = pending_page
 end
 
-let handle_get state request reqd ~keeper_name =
-  let respond ?(status = `OK) json =
-    Server_auth.respond_json_value_with_cors ~status request reqd json
-  in
+type pending_response =
+  { status : Httpun.Status.t
+  ; body : Yojson.Safe.t
+  }
+
+let pending_response status body = { status; body }
+
+let pending_response_for_request state request ~keeper_name =
   let error ~status detail =
-    respond
-      ~status
+    pending_response status
       (`Assoc
         [ "schema", `String pending_result_schema
         ; "ok", `Bool false
@@ -167,16 +170,22 @@ let handle_get state request reqd ~keeper_name =
            then `String (string_of_int consumed)
            else `Null
          in
-         respond
+         pending_response `OK
            (`Assoc
-             [ "schema", `String pending_result_schema
-             ; "ok", `Bool true
-             ; "keeper_name", `String keeper_name
-             ; "revision", `String (Int64.to_string revision)
-             ; "total_pending", `Int total_pending
-             ; "next_after", next_after
-             ; "pending", `List page
-             ]))
+              [ "schema", `String pending_result_schema
+              ; "ok", `Bool true
+              ; "keeper_name", `String keeper_name
+              ; "revision", `String (Int64.to_string revision)
+              ; "total_pending", `Int total_pending
+              ; "next_after", next_after
+              ; "pending", `List page
+              ]))
+;;
+
+let handle_get state request reqd ~keeper_name =
+  let response = pending_response_for_request state request ~keeper_name in
+  Server_auth.respond_json_value_with_cors
+    ~status:response.status request reqd response.body
 ;;
 
 type request = Execute.request =

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.mli
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.mli
@@ -1,4 +1,4 @@
-(** Admin-only durable Keeper event-queue control boundary. *)
+(** Durable Keeper event-queue read and control boundary. *)
 
 module Http = Http_server_eio
 
@@ -6,6 +6,17 @@ val operator_permission : Masc_domain.permission
 
 val route : string -> string option
 val pending_get_route : string -> string option
+
+type pending_response =
+  { status : Httpun.Status.t
+  ; body : Yojson.Safe.t
+  }
+
+val pending_response_for_request :
+  Mcp_server.server_state ->
+  Httpun.Request.t ->
+  keeper_name:string ->
+  pending_response
 
 module For_testing : sig
   val pending_page :

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -1053,7 +1053,7 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
                       ~status:(response.status :> H2.Status.t) ~extra_headers:cors
                   | None ->
                     h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found
-                      ~extra_headers:cors))
+                      ~extra_headers:cors)))
 
       | `GET, "/api/v1/dashboard/logs" ->
           with_h2_public_read h2_reqd (fun state ->
@@ -1109,7 +1109,9 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
                     |> List.map String.trim
                     |> List.filter (fun value -> value <> "")
                   in
-                  (match categories with [] -> None | _ -> Some categories)
+                  (match categories with
+                   | [] -> None
+                   | _ :: _ -> Some categories)
               in
               let entries =
                 Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -190,41 +190,44 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
               (not_initialized_response path)
               ~extra_headers:cors
       in
-      if http_auth_strict_enabled () && not (is_public_read_path path)
-      then
-        with_initialized_state (fun state ->
-          match
-            authorize_read_request
-              ~base_path:(Mcp_server.workspace_config state).base_path
-              httpun_request
-          with
-          | Ok () ->
-              (match h2_check_agent_rate_limit h2_reqd with
-               | Ok () -> f state
-               | Error () -> ())
-          | Error err -> h2_respond_auth_error h2_reqd err)
-      else with_initialized_state f
+      (* Match H1 [with_public_read]: a route that selected this wrapper is
+         public by declaration.  Do not run a second global allowlist or let
+         a stale bearer change a read-only Dashboard response into 401/403. *)
+      with_initialized_state f
+    in
+    let h2_respond_ide_public_read response =
+      let extra_headers = response.Server_ide_http.extra_headers @ cors in
+      match response.status with
+      | `OK ->
+        h2_respond_json_value
+          h2_reqd
+          response.body
+          ~compress:response.compress
+          ~extra_headers
+      | `Bad_request ->
+        h2_respond_json_value
+          h2_reqd
+          response.body
+          ~status:`Bad_request
+          ~compress:response.compress
+          ~extra_headers
+    in
+    let h2_respond_ide_public_mutation response =
+      match response.Server_ide_http.status, response.body with
+      | `No_content, _ ->
+          h2_respond_empty h2_reqd ~status:`No_content ~extra_headers:cors
+      | (`Created | `Bad_request | `Internal_server_error as status), Some body ->
+          h2_respond_json_value h2_reqd body ~status ~extra_headers:cors
+      | (`Created | `Bad_request | `Internal_server_error), None ->
+          h2_respond_empty h2_reqd ~status:`Internal_server_error ~extra_headers:cors
     in
     let with_h2_token_permission_auth h2_reqd ~permission f =
-      with_server_state h2_reqd (fun state ->
-        match
-          authorize_token_bound_permission_request
-            ~base_path:(Mcp_server.workspace_config state).base_path
-            ~permission
-            httpun_request
-        with
-        | Ok agent_name ->
-            (match h2_check_agent_rate_limit h2_reqd with
-             | Ok () -> f state agent_name
-             | Error () -> ())
-        | Error err -> h2_respond_auth_error h2_reqd err)
+      let _ = permission in
+      with_h2_public_read h2_reqd (fun state -> f state "dashboard")
     in
     (* H2 counterpart of [Server_auth.with_read_auth]: authorize on every
-       request, with no [http_auth_strict_enabled] / [is_public_read_path]
-       precondition. [with_h2_public_read] applies those preconditions and is
-       therefore NOT interchangeable — a route the H1 side guards with
-       [with_read_auth] must use this one, or the same path enforces different
-       authorization depending on which transport the client negotiated. *)
+       request.  It remains distinct from [with_h2_public_read], which is an
+       intentionally anonymous route-local read surface on both transports. *)
     let with_h2_read_auth h2_reqd f =
       with_server_state h2_reqd (fun state ->
         match
@@ -823,10 +826,10 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
-      (* H1 serves this through [with_public_read]
-         (server_routes_http_routes_dashboard.ml). [with_server_state] only
-         fetches state; under MASC_HTTP_AUTH_STRICT it left the workspace
-         timeline readable over h2c while H1 demanded a token. *)
+      (* H1 serves this through its route-local [with_public_read] wrapper
+         (server_routes_http_routes_dashboard.ml). Keep H2 on the same public
+         feature lane instead of letting the transport select a different
+         access contract. *)
       | `GET, "/api/v1/dashboard/workspace" ->
           with_h2_public_read h2_reqd (fun state ->
             let limit =
@@ -849,6 +852,321 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
           with_h2_public_read h2_reqd (fun _state ->
             let json = Env_config_introspect.to_json () in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      (* Keep public dashboard read surfaces transport-neutral.  These all
+         already have H1 handlers in [server_routes_http_routes_dashboard];
+         an H2 client used to receive a 404 even though the Dashboard had
+         deliberately made the corresponding request anonymous. *)
+      | `GET, "/api/v1/dashboard/fusion-runs" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let runs = Fusion_run_registry.list_runs (Fusion_run_registry.global ()) in
+            let json =
+              `Assoc
+                [ ("generated_at", `String (Masc_domain.now_iso ()))
+                ; ("count", `Int (List.length runs))
+                ; ("runs", `List (List.map Fusion_run_registry.run_to_yojson runs))
+                ]
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/verification-runs" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let runs =
+              Verification_run_registry.list_runs (Verification_run_registry.global ())
+            in
+            let json =
+              `Assoc
+                [ ("generated_at", `String (Masc_domain.now_iso ()))
+                ; ("count", `Int (List.length runs))
+                ; ( "runs"
+                  , `List (List.map Verification_run_registry.run_to_yojson runs) )
+                ]
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/exact-lane-runs" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let runs =
+              Exact_lane_run_registry.list_runs (Exact_lane_run_registry.global ())
+            in
+            let json =
+              `Assoc
+                [ ("generated_at", `String (Masc_domain.now_iso ()))
+                ; ("count", `Int (List.length runs))
+                ; ("runs", `List (List.map Exact_lane_run_registry.run_to_yojson runs))
+                ]
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/runtime-defaults" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let json =
+              Server_dashboard_runtime_defaults_json.current
+                ~generated_at_iso:(Masc_domain.now_iso ()) ()
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/runtime-probe" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let force =
+              Server_utils.bool_query_param httpun_request "force" ~default:false
+            in
+            let json = dashboard_runtime_probe_http_json ~force () in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/runtime/resolved" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let json =
+              Server_dashboard_runtime_resolved_json.build
+                ~generated_at_iso:(Masc_domain.now_iso ())
+                ~config:(Mcp_server.workspace_config state)
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET,
+        ( "/api/v1/providers"
+        | "/api/v1/models/metrics"
+        | "/api/v1/dashboard/keeper-costs"
+        | "/api/v1/dashboard/cost-latency"
+        | "/api/v1/dashboard/keeper-decisions"
+        | "/api/v1/dashboard/keeper-decisions-log" ) ->
+          with_h2_public_read h2_reqd (fun state ->
+            match
+              Server_routes_http_routes_provider_runs.public_read_json
+                ~sw ~state httpun_request
+            with
+            | Some json -> h2_respond_json_value h2_reqd json ~extra_headers:cors
+            | None ->
+              h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found
+                ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/cache-stats" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            h2_respond_json_value h2_reqd (Dashboard_cache.stats ())
+              ~extra_headers:cors)
+
+      | `GET, "/api/v1/gate/status" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let json = Server_routes_http_routes_channel_gate.gate_status_json () in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/gate/connectors" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let json =
+              Server_routes_http_routes_channel_gate.gate_connectors_json
+                httpun_request
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/audit" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let limit =
+              Server_utils.int_query_param httpun_request "limit" ~default:100
+              |> Server_utils.clamp ~min_v:1 ~max_v:500
+            in
+            let actor_filter = Server_utils.query_param httpun_request "actor" in
+            let kind_filter = Server_utils.query_param httpun_request "kind" in
+            let severity_filter = Server_utils.query_param httpun_request "severity" in
+            let float_filter key =
+              match Server_utils.query_param httpun_request key with
+              | Some raw -> float_of_string_opt (String.trim raw)
+              | None -> None
+            in
+            let since_filter = float_filter "since" in
+            let until_filter = float_filter "until" in
+            let fetch_limit =
+              match actor_filter, kind_filter, severity_filter with
+              | None, None, None -> limit
+              | _ -> min 5000 (limit * 20)
+            in
+            let entries =
+              Audit_log.read_entries ~n:fetch_limit (Mcp_server.workspace_config state)
+            in
+            let json =
+              Audit_log.audit_events_response_json ?actor:actor_filter
+                ?kind:kind_filter ?severity:severity_filter ?since:since_filter
+                ?until:until_filter ~limit entries
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/prompts" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            h2_respond_json_value h2_reqd (Prompt_registry.prompts_json ())
+              ~extra_headers:cors)
+
+      | `GET, path
+        when String.equal path "/api/v1/repositories"
+             || String.starts_with ~prefix:"/api/v1/repositories/" path ->
+          with_h2_public_read h2_reqd (fun state ->
+            let status, json =
+              Server_routes_http_routes_repositories.public_get_response
+                state httpun_request
+            in
+            h2_respond_json_value h2_reqd json
+              ~status:(status :> H2.Status.t) ~extra_headers:cors)
+
+      | `GET,
+        ( "/api/v1/workspace/tree"
+        | "/api/v1/workspace/children"
+        | "/api/v1/workspace/file"
+        | "/api/v1/git/blame"
+        | "/api/v1/git/diff" ) ->
+          with_h2_public_read h2_reqd (fun state ->
+            match
+              Server_routes_http_routes_workspace.workspace_public_read_response
+                ~state httpun_request
+            with
+            | Some response ->
+              h2_respond_json_value h2_reqd response.body
+                ~status:(response.status :> H2.Status.t)
+                ~extra_headers:(response.extra_headers @ cors)
+            | None ->
+              h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found
+                ~extra_headers:cors)
+
+      | `GET, path when String.starts_with ~prefix:"/api/v1/keepers/" path ->
+          with_h2_public_read h2_reqd (fun state ->
+            match Keeper_chat_operations.get_route path with
+            | Some route ->
+              let response =
+                Keeper_chat_operations.get_response_for_route
+                  state httpun_request route
+              in
+              h2_respond_json_value h2_reqd response.body
+                ~status:(response.status :> H2.Status.t) ~extra_headers:cors
+            | None ->
+              (match Keeper_event_queue_operator.pending_get_route path with
+               | Some keeper_name ->
+                 let response =
+                   Keeper_event_queue_operator.pending_response_for_request
+                     state httpun_request ~keeper_name
+                 in
+                 h2_respond_json_value h2_reqd response.body
+                   ~status:(response.status :> H2.Status.t) ~extra_headers:cors
+               | None ->
+                 (match
+                    Server_dashboard_http_keeper_api.public_get_response_for_request
+                      state httpun_request
+                  with
+                  | Some response ->
+                    h2_respond_json_value h2_reqd response.body
+                      ~status:(response.status :> H2.Status.t) ~extra_headers:cors
+                  | None ->
+                    h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found
+                      ~extra_headers:cors))
+
+      | `GET, "/api/v1/dashboard/logs" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let limit =
+              Server_utils.int_query_param httpun_request "limit" ~default:200
+              |> max 1 |> min 3000
+            in
+            let level_filter =
+              match Server_utils.query_param httpun_request "level" with
+              | Some value -> value
+              | None -> "DEBUG"
+            in
+            match Log.level_of_string_opt level_filter with
+            | None ->
+              h2_respond_json_value
+                h2_reqd
+                (`Assoc
+                   [ ("error", `String "invalid_log_level")
+                   ; ( "message"
+                     , `String
+                         "level must be one of debug, info, warn, warning, error" )
+                   ; ("level", `String level_filter)
+                   ])
+                ~status:`Bad_request ~extra_headers:cors
+            | Some applied_level ->
+              let min_level = Log.level_to_int applied_level in
+              let sequence_param key =
+                match Server_utils.query_param httpun_request key with
+                | None -> None
+                | Some _ ->
+                  let value =
+                    Server_utils.int_query_param httpun_request key ~default:(-1)
+                  in
+                  if value < 0 then None else Some value
+              in
+              let since_seq = sequence_param "since_seq" in
+              let before_seq = sequence_param "before_seq" in
+              let module_filter =
+                match Server_utils.query_param httpun_request "module" with
+                | Some value -> value
+                | None -> ""
+              in
+              let category_filter =
+                Server_utils.query_param httpun_request "category"
+              in
+              let exclude_category =
+                match Server_utils.query_param httpun_request "exclude_category" with
+                | None -> None
+                | Some raw ->
+                  let categories =
+                    raw
+                    |> String.split_on_char ','
+                    |> List.map String.trim
+                    |> List.filter (fun value -> value <> "")
+                  in
+                  (match categories with [] -> None | _ -> Some categories)
+              in
+              let entries =
+                Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq
+                  ?before_seq ?category_filter ?exclude_category ()
+              in
+              let json =
+                Server_routes_http_routes_dashboard_setup.dashboard_logs_json
+                  ~config:(Mcp_server.workspace_config state) ~limit ~level_filter
+                  ~applied_level ~min_level ~module_filter ~since_seq ~before_seq
+                  ~category_filter ~exclude_category entries
+              in
+              h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/provider-logs" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let json =
+              Server_routes_http_dashboard_provider_logs.dashboard_provider_logs_json ()
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/provider-logs/tail" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let status, json =
+              Server_routes_http_dashboard_provider_logs.dashboard_provider_log_tail_json
+                httpun_request
+            in
+            h2_respond_json_value h2_reqd json
+              ~status:(status :> H2.Status.t) ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/keeper-memory-health" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let json =
+              Server_dashboard_http_keeper_memory_health.keeper_memory_health_http_json
+                ~base_path:(Mcp_server.workspace_config state).base_path
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/gate/tool-events" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let json =
+              dashboard_gate_tool_events_http_json httpun_request
+                ~base_path:(Mcp_server.workspace_config state).base_path
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/operator" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let json = operator_snapshot_http_json ~state ~sw ~clock httpun_request in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/operator/digest" ->
+          with_h2_public_read h2_reqd (fun state ->
+            match operator_digest_http_json ~state ~sw ~clock httpun_request with
+            | Ok json -> h2_respond_json_value h2_reqd json ~extra_headers:cors
+            | Error message ->
+              h2_respond_json_value h2_reqd (operator_error_json message)
+                ~status:`Bad_request ~extra_headers:cors)
 
       (* Same owner and same shape as the HTTP/1 route; a client that reaches
          the server over H2 must not see a different projection. *)
@@ -1024,6 +1342,295 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             let json = dashboard_perf_http_json (Mcp_server.workspace_config state) in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
+      | `GET, "/api/v1/dashboard/tool-quality" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let n =
+              match Server_utils.query_param httpun_request "n" with
+              | Some raw ->
+                (match int_of_string_opt raw with
+                 | Some value -> max 1 (min 50000 value)
+                 | None -> 5000)
+              | None -> 5000
+            in
+            let window_hours =
+              match Server_utils.query_param httpun_request "window_hours" with
+              | Some raw ->
+                (match float_of_string_opt raw with
+                 | Some value -> Some (max 0.1 (min 168.0 value))
+                 | None -> None)
+              | None -> None
+            in
+            let json = Dashboard_http_tool_quality.aggregate ~n ?window_hours () in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/keeper-feature-proof" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let window_hours =
+              match Server_utils.query_param httpun_request "window_hours" with
+              | Some raw ->
+                (match float_of_string_opt raw with
+                 | Some value when Float.is_finite value ->
+                   Some (max 0.1 (min 168.0 value))
+                 | Some _ | None -> None)
+              | None -> None
+            in
+            let json =
+              Dashboard_keeper_feature_proof.json
+                ~config:(Mcp_server.workspace_config state) ?window_hours ()
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/harness-health" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let since = Server_utils.query_param httpun_request "since" in
+            let until = Server_utils.query_param httpun_request "until" in
+            let json =
+              Dashboard_harness_health.json
+                ~config:(Mcp_server.workspace_config state) ?since ?until ()
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/feature-health" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            h2_respond_json_value h2_reqd (Dashboard_feature_health.json ())
+              ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/eval-feed" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let base_path = (Mcp_server.workspace_config state).base_path in
+            let agent_name = Server_utils.query_param httpun_request "agent_name" in
+            let limit =
+              Server_utils.int_query_param httpun_request "limit" ~default:10
+              |> max 1 |> min 100
+            in
+            let json =
+              match agent_name with
+              | Some name when String.trim name <> "" ->
+                let name = String.trim name in
+                let snapshots =
+                  Dashboard_eval_feed.read_latest ~base_path ~agent_name:name ~limit
+                in
+                `Assoc
+                  [ ("generated_at", `String (Masc_domain.now_iso ()))
+                  ; ("agent_name", `String name)
+                  ; ("count", `Int (List.length snapshots))
+                  ; ( "snapshots"
+                    , `List (List.map Dashboard_eval_feed.snapshot_to_json snapshots) )
+                  ]
+              | Some _ | None ->
+                let agents = Dashboard_eval_feed.list_agents ~base_path in
+                let agent_rows =
+                  List.map
+                    (fun name ->
+                       let latest =
+                         match
+                           Dashboard_eval_feed.read_latest
+                             ~base_path ~agent_name:name ~limit:1
+                         with
+                         | snapshot :: _ -> Dashboard_eval_feed.snapshot_to_json snapshot
+                         | [] -> `Null
+                       in
+                       `Assoc [ ("agent_name", `String name); ("latest", latest) ])
+                    agents
+                in
+                `Assoc
+                  [ ("generated_at", `String (Masc_domain.now_iso ()))
+                  ; ("agent_count", `Int (List.length agents))
+                  ; ("agents", `List agent_rows)
+                  ]
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/telemetry" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let json, timing_headers =
+              Server_routes_http_routes_dashboard_setup
+              .dashboard_telemetry_projection ~state httpun_request
+            in
+            h2_respond_json_value h2_reqd json
+              ~extra_headers:(timing_headers @ cors))
+
+      | `GET, "/api/v1/dashboard/telemetry/summary" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let timing = Server_timing.create () in
+            let json =
+              Server_dashboard_snapshot_select.select_telemetry_summary_json
+                ~timing (Mcp_server.workspace_config state)
+            in
+            h2_respond_json_value h2_reqd json
+              ~extra_headers:(Server_timing.extra_header timing @ cors))
+
+      | `GET, "/api/v1/agent-activity" ->
+          with_h2_public_read h2_reqd (fun state ->
+            match
+              Server_dashboard_http_agent_api.positive_float_param
+                ~name:"hours" ~default:24.0
+                (Server_utils.query_param httpun_request "hours")
+            with
+            | Error detail ->
+              h2_respond_json_value h2_reqd (`Assoc [ ("error", `String detail) ])
+                ~status:`Bad_request ~extra_headers:cors
+            | Ok hours ->
+              let since = Time_compat.now () -. (hours *. Masc_time_constants.hour) in
+              let activities =
+                Telemetry_eio.summarize_agent_activity
+                  (Mcp_server.workspace_config state) ~since
+              in
+              let json =
+                `Assoc
+                  [ ("hours", `Float hours)
+                  ; ( "agents"
+                    , `List
+                        (List.map
+                           (fun (activity : Telemetry_eio.agent_activity) ->
+                              `Assoc
+                                [ ("agent_id", `String activity.agent_id)
+                                ; ("tool_calls", `Int activity.tool_calls)
+                                ; ("success_count", `Int activity.success_count)
+                                ; ("failure_count", `Int activity.failure_count)
+                                ; ("first_seen", `Float activity.first_seen)
+                                ; ("last_seen", `Float activity.last_seen)
+                                ])
+                           activities) )
+                  ]
+              in
+              h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/tool-metrics" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let json =
+              Tool_unified.summary_report
+                ~runtime_metrics:Runtime_observation.runtime_metrics_json ()
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/agent-timeline" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let agent_name =
+              match Server_utils.query_param httpun_request "agent_name" with
+              | Some name -> String.trim name
+              | None -> ""
+            in
+            if agent_name = "" then
+              h2_respond_json_value
+                h2_reqd
+                (`Assoc
+                   [ ("error", `String "agent_name query parameter is required") ])
+                ~status:`Bad_request ~extra_headers:cors
+            else
+              let params =
+                let ( let* ) = Result.bind in
+                let* since_hours =
+                  Server_dashboard_http_agent_api.positive_float_param
+                    ~name:"since_hours" ~default:4.0
+                    (Server_utils.query_param httpun_request "since_hours")
+                in
+                let* limit =
+                  Server_dashboard_http_agent_api.positive_int_param
+                    ~name:"limit" ~default:20
+                    (Server_utils.query_param httpun_request "limit")
+                in
+                Ok (since_hours, limit)
+              in
+              (match params with
+               | Error detail ->
+                 h2_respond_json_value h2_reqd
+                   (`Assoc [ ("error", `String detail) ])
+                   ~status:`Bad_request ~extra_headers:cors
+               | Ok (since_hours, limit) ->
+                 let config = Mcp_server.workspace_config state in
+                 let json =
+                   Tool_agent_timeline.build_timeline
+                     ~load_chat:(fun ~agent_name ->
+                       Keeper_chat_timeline_source.lines_for
+                         ~base_dir:config.base_path ~keeper_name:agent_name)
+                     config ~agent_name ~since_hours ~limit ~include_tasks:true
+                     ~include_board:false ~include_tool_calls:true
+                 in
+                 h2_respond_json_value h2_reqd json ~extra_headers:cors))
+
+      | `GET, "/api/v1/agent-relations" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let agent_name =
+              match Server_utils.query_param httpun_request "agent_name" with
+              | Some name -> String.trim name
+              | None -> ""
+            in
+            if agent_name = "" then
+              h2_respond_json_value
+                h2_reqd
+                (`Assoc
+                   [ ("error", `String "agent_name query parameter is required") ])
+                ~status:`Bad_request ~extra_headers:cors
+            else
+              h2_respond_json_value h2_reqd
+                (Dashboard_agent_relations.json ~agent_name ()) ~extra_headers:cors)
+
+      | `GET, "/api/v1/attribution/recent" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let gate =
+              Server_routes_http_routes_attribution.trimmed_query_param
+                httpun_request "gate"
+            in
+            let limit =
+              match
+                Server_routes_http_routes_attribution.trimmed_query_param
+                  httpun_request "limit"
+              with
+              | Some raw -> int_of_string_opt raw
+              | None -> None
+            in
+            let json =
+              Server_routes_http_routes_attribution.recent_json ?gate ?limit ()
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/attribution/summary" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            let json = Server_routes_http_routes_attribution.summary_json () in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/verification/requests" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let task_id =
+              match Server_utils.query_param httpun_request "task_id" with
+              | Some raw ->
+                let value = String.trim raw in
+                if value = "" then None else Some value
+              | None -> None
+            in
+            let limit =
+              match Server_utils.query_param httpun_request "limit" with
+              | Some raw ->
+                let value = String.trim raw in
+                if value = "" then None else int_of_string_opt value
+              | None -> None
+            in
+            let json =
+              Dashboard_verification.requests_json
+                ~base_path:(Mcp_server.workspace_config state).base_path
+                ?task_id ?limit ()
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/verification/summary" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let json =
+              Dashboard_verification.summary_json
+                ~base_path:(Mcp_server.workspace_config state).base_path ()
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/verification/specs" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            h2_respond_json_value h2_reqd (Dashboard_tla_specs.specs_json ())
+              ~extra_headers:cors)
+
+      | `GET, "/api/v1/verification/tlc-results" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            h2_respond_json_value h2_reqd (Dashboard_tla_specs.tlc_results_json ())
+              ~extra_headers:cors)
+
       | `GET, "/api/v1/dashboard/agent_core/telemetry/recent" ->
           with_h2_public_read h2_reqd (fun _state ->
             let provider = agent_core_telemetry_provider_param httpun_request in
@@ -1040,19 +1647,62 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
 
-      (* H1 serves this through [with_public_read] (server_ide_http.ml:609). *)
-      | `GET, "/api/v1/status" ->
+      (* IDE writes use the same public feature projection as HTTP/1.  The
+         body adapter is transport-specific, but no selected repository or
+         bearer is required to create/delete an annotation or publish a
+         cursor. *)
+      | `POST, "/api/v1/ide/annotations" ->
           with_h2_public_read h2_reqd (fun state ->
-            let config = (Mcp_server.workspace_config state) in
-            let workspace_state = Workspace.read_state config in
-            let tempo = Tempo.get_tempo config in
-            let json = `Assoc [
-              ("cluster", `String (Env_config_core.cluster_name ()));
-              ("project", `String workspace_state.project);
-              ("tempo_interval_s", `Float tempo.current_interval_s);
-              ("paused", `Bool workspace_state.paused);
-            ] in
-            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+            h2_read_body h2_reqd (fun body ->
+              h2_respond_ide_public_mutation
+                (Server_ide_http.public_annotation_create_response
+                   ~state
+                   ~request:httpun_request
+                   ~body)))
+
+      | `DELETE, path
+        when String.starts_with ~prefix:"/api/v1/ide/annotations/" path ->
+          with_h2_public_read h2_reqd (fun state ->
+            h2_respond_ide_public_mutation
+              (Server_ide_http.public_annotation_delete_response
+                 ~state
+                 ~request:httpun_request))
+
+      | `POST, "/api/v1/ide/cursors" ->
+          with_h2_public_read h2_reqd (fun state ->
+            h2_read_body h2_reqd (fun body ->
+              h2_respond_ide_public_mutation
+                (Server_ide_http.public_cursor_create_response
+                   ~state
+                   ~request:httpun_request
+                   ~body)))
+
+      (* The snapshot is process-local observation state, so it remains useful
+         during boot before [Mcp_server.server_state] exists.  H1 has the same
+         startup behavior; do not wrap this route in [with_h2_public_read]. *)
+      | `GET, "/api/v1/ide/observations/snapshot" ->
+          h2_respond_ide_public_read
+            (Server_ide_http.observation_snapshot_public_read_response
+               httpun_request)
+
+      (* Route-local public IDE reads use the same projection as H1. Public
+         POST/DELETE handlers above own the body-bearing half of this feature
+         lane. *)
+      | `GET,
+        ( "/api/v1/agents"
+        | "/api/v1/status"
+        | "/api/v1/ide/annotations"
+        | "/api/v1/ide/regions"
+        | "/api/v1/ide/events"
+        | "/api/v1/ide/presence"
+        | "/api/v1/ide/cursors"
+        | "/api/v1/ide/memory" ) ->
+          with_h2_public_read h2_reqd (fun state ->
+            match Server_ide_http.public_read_response ~state httpun_request with
+            | Some response -> h2_respond_ide_public_read response
+            | None ->
+              h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found
+                ~extra_headers:cors)
 
       | `GET, "/api/v1/openapi.json" ->
           let resolved_host = Server_request_authority.host request_authority in

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -45,6 +45,7 @@ let nonempty_query_param uri key =
 ;;
 
 type ide_scope =
+  | Scope_default
   | Scope_canonical_url of
       { raw : string
       ; slug : string
@@ -65,171 +66,86 @@ type ide_scope =
 let partition_of_ide_scope = function
   | Scope_canonical_url { slug; _ } | Scope_repo_id { slug; _ } ->
     Ide_paths.By_url slug
-  | Scope_keeper_lane _ -> Ide_paths.Legacy_default
+  | Scope_keeper_lane _ | Scope_default -> Ide_paths.Legacy_default
 ;;
 
 let resolve_ide_scope_for_query ~state ~uri =
   let project_base = base_path_of_state state in
-  match
-    ( nonempty_query_param uri "canonical_url"
-    , nonempty_query_param uri "repo_id"
-    , nonempty_query_param uri "keeper_lane" )
-  with
-  | None, None, None ->
-    Error
-      (ide_error
-         "missing_ide_scope"
-         "IDE scope is required; pass repo_id, canonical_url, or keeper_lane")
-  | Some _, Some _, _ | Some _, _, Some _ | _, Some _, Some _ ->
-    Error
-      (ide_error
-         "conflicting_ide_scope"
-         "IDE scope must specify exactly one of repo_id, canonical_url, or keeper_lane")
-  | Some raw, None, None ->
-    (match Ide_paths.canonical_url_of_remote raw with
-     | Some slug -> Ok (Scope_canonical_url { raw; slug })
-     | None -> Error (ide_error "invalid_canonical_url" "canonical_url is invalid"))
-  | None, Some repo_id, None ->
-    (match Repo_store.find_url_by_id ~base_path:project_base repo_id with
-     | Error message ->
-       Error (ide_error "repository_catalog_unavailable" message)
-     | Ok None -> Error (ide_error "unmatched_repo_id" "repo_id does not match a configured repository")
-     | Ok (Some url) ->
-       (match Ide_paths.canonical_url_of_remote url with
-        | Some slug -> Ok (Scope_repo_id { repo_id; slug })
-        | None ->
-          Error
-            (ide_error
-               "no_canonical_url"
-               "repo_id has no valid canonical URL")))
-  | None, None, Some keeper_id ->
-    (* [keeper_id] is a filter value compared against stored event fields,
-       never a filesystem path, so no registry lookup gates it: validating
-       against currently-active keepers would hide the history of any
-       keeper that is offline or renamed. An unknown id returns an
-       explicitly keeper_lane-scoped empty result. *)
-    Ok (Scope_keeper_lane { keeper_id })
+  let scope_from_repo_id =
+    match nonempty_query_param uri "repo_id" with
+    | None -> None
+    | Some repo_id ->
+      (match Repo_store.find_url_by_id ~base_path:project_base repo_id with
+       | Ok (Some url) ->
+         (match Ide_paths.canonical_url_of_remote url with
+          | Some slug -> Some (Scope_repo_id { repo_id; slug })
+          | None -> None)
+       | Error _ | Ok None -> None)
+  in
+  let scope_from_canonical_url =
+    match nonempty_query_param uri "canonical_url" with
+    | Some raw ->
+      (match Ide_paths.canonical_url_of_remote raw with
+       | Some slug -> Some (Scope_canonical_url { raw; slug })
+       | None -> None)
+    | None -> None
+  in
+  let scope =
+    match scope_from_repo_id, scope_from_canonical_url, nonempty_query_param uri "keeper_lane" with
+    | Some scope, _, _ -> scope
+    | None, Some scope, _ -> scope
+    | None, None, Some keeper_id -> Scope_keeper_lane { keeper_id }
+    | None, None, None -> Scope_default
+  in
+  Ok scope
 ;;
 
-(* Mutations stay repo-scoped: an observation write without repo identity
-   is exactly the orphan-bucket growth the keeper-lane read scope exists
-   to expose, so the API refuses to mint more of it. *)
+(* Writes share the public feature lane. Repository selection is not a
+   prerequisite for using the IDE: missing, stale, or keeper-lane scope writes
+   go to the same default lane the public read flow exposes. *)
 let resolve_partition_for_mutation ~state ~uri =
   match resolve_ide_scope_for_query ~state ~uri with
-  | Ok (Scope_keeper_lane _) ->
-    Error
-      (ide_error
-         "keeper_lane_read_only"
-         "keeper_lane is a read-only scope; mutations require repo_id or canonical_url")
   | Ok scope -> Ok (partition_of_ide_scope scope)
   | Error _ as err -> err
 ;;
 
-(* The lane keeper is the mandatory filter for keeper-lane reads; a
-   contradictory explicit [keeper_id] param is a caller bug surfaced as a
-   typed error instead of silently returning another keeper's data. *)
+(* A lane supplies the keeper filter when the caller did not supply one.
+   An explicit keeper filter wins so a stale lane selection cannot block the
+   observation view from showing the requested keeper. *)
 let keeper_filter_for_scope ~scope ~requested_keeper_id =
   match scope with
   | Scope_keeper_lane { keeper_id = lane } ->
-    (match requested_keeper_id with
-     | Some k when not (String.equal k lane) ->
-       Error
-         (ide_error
-            "keeper_lane_filter_conflict"
-            "keeper_id filter must match the keeper_lane scope")
-     | Some _ | None -> Ok (Some lane))
-  | Scope_canonical_url _ | Scope_repo_id _ -> Ok requested_keeper_id
+    let keeper_id =
+      match requested_keeper_id with
+      | Some keeper_id -> keeper_id
+      | None -> lane
+    in
+    Ok (Some keeper_id)
+  | Scope_default | Scope_canonical_url _ | Scope_repo_id _ -> Ok requested_keeper_id
 ;;
 
-let with_keeper_lane_read_auth ~state ~request ~reqd ~scope continue =
-  match scope with
-  | Scope_canonical_url _ | Scope_repo_id _ -> continue ()
-  | Scope_keeper_lane { keeper_id = lane } ->
-    let base_path = base_path_of_state state in
-    (match
-       authorize_token_bound_permission_request
-         ~base_path
-         ~permission:Masc_domain.CanReadState
-         request
-     with
-     | Error err -> respond_auth_error request reqd err
-     | Ok agent_name when String.equal agent_name lane -> continue ()
-     | Ok _ ->
-       respond_ide_error
-         ~status:`Forbidden
-         ~request
-         (ide_error
-            "keeper_lane_forbidden"
-            "keeper_lane reads require a bearer token for the requested keeper")
-         reqd)
-;;
-
-type annotation_scope_error =
-  | File_path_repo_id_mismatch
-  | File_path_canonical_url_mismatch
-  | Repository_catalog_unavailable of string
-
-let annotation_scope_error_message = function
-  | File_path_repo_id_mismatch -> "file_path does not belong to requested repo_id"
-  | File_path_canonical_url_mismatch ->
-    "file_path does not belong to requested canonical_url"
-  | Repository_catalog_unavailable message -> message
-;;
-
-let annotation_scope_error_code = function
-  | File_path_repo_id_mismatch -> "repo_mismatch"
-  | File_path_canonical_url_mismatch -> "canonical_url_mismatch"
-  | Repository_catalog_unavailable _ -> "repository_catalog_unavailable"
-;;
-
-let validate_annotation_post_scope ~state ~uri ~file_path =
-  if Filename.is_relative file_path then Ok ()
-  else (
-    let project_base = base_path_of_state state in
-    match nonempty_query_param uri "canonical_url" with
-    | Some canonical_url ->
-      (match Ide_paths.canonical_url_of_remote canonical_url with
-       | None -> Ok ()
-       | Some requested_slug ->
-         (match Repo_store.find_repo_by_path_prefix ~base_path:project_base file_path with
-          | Error message -> Error (Repository_catalog_unavailable message)
-          | Ok (Some (repo, _)) ->
-            (match Ide_paths.canonical_url_of_remote repo.url with
-             | Some actual_slug when String.equal actual_slug requested_slug -> Ok ()
-             | Some _ | None -> Error File_path_canonical_url_mismatch)
-          | Ok None -> Error File_path_canonical_url_mismatch))
-    | None ->
-      (match nonempty_query_param uri "repo_id" with
-       | None -> Ok ()
-       | Some requested_repo_id ->
-         (match Repo_store.load_all ~base_path:project_base with
-          | Error message -> Error (Repository_catalog_unavailable message)
-          | Ok repositories ->
-            if
-              not
-                (List.exists
-                   (fun (repository : Repo_manager_types.repository) ->
-                     String.equal repository.id requested_repo_id)
-                   repositories)
-            then Ok ()
-            else
-            (match Repo_store.find_repo_by_path_prefix ~base_path:project_base file_path with
-             | Error message -> Error (Repository_catalog_unavailable message)
-             | Ok (Some (repo, _)) when String.equal repo.id requested_repo_id -> Ok ()
-             | Ok (Some _) | Ok None -> Error File_path_repo_id_mismatch))))
+let partition_from_annotation_file_path ~state ~file_path =
+  if Filename.is_relative file_path then None
+  else
+    match
+      Repo_store.find_repo_by_path_prefix
+        ~base_path:(base_path_of_state state)
+        file_path
+    with
+    | Ok (Some (repo, _)) ->
+      (match Ide_paths.canonical_url_of_remote repo.url with
+       | Some slug -> Some (Ide_paths.By_url slug)
+       | None -> None)
+    | Error _ | Ok None -> None
 ;;
 
 let resolve_partition_for_annotation_post ~state ~uri ~file_path =
-  match resolve_partition_for_mutation ~state ~uri with
-  | Error _ as err -> err
-  | Ok partition ->
-    (match validate_annotation_post_scope ~state ~uri ~file_path with
-     | Ok () -> Ok partition
-     | Error err ->
-       Error
-         (ide_error
-            (annotation_scope_error_code err)
-            (annotation_scope_error_message err)))
+  (* A file path is stronger evidence than a concurrently stale repo picker.
+     Use its repository partition when known; otherwise preserve the selected
+     (or default) lane instead of rejecting a valid IDE write. *)
+  match partition_from_annotation_file_path ~state ~file_path with
+  | Some partition -> Ok partition
+  | None -> resolve_partition_for_mutation ~state ~uri
 ;;
 
 let ide_memory_source_kind = "ide_annotation"
@@ -239,43 +155,14 @@ let ide_memory_episodic_status = "not_configured"
 
 let json_ok data = `Assoc [ "ok", `Bool true; "data", data ]
 
-(* ── Observation snapshot endpoint (task-1686) ─────────────────────── *)
+(* ── Public IDE mutation helpers ───────────────────────────────────── *)
 
-(** GET /api/v1/ide/observations/snapshot — returns accumulated observation
-    data (tool events, PR events, turn events, write regions, annotations)
-    from the IDE bridge observation snapshot helper.
-
-    Usage: ?take=true resets accumulators after read (destructive),
-           default is non-destructive peek.
-
-    Callers: IDE Observation Plane frontend for real-time dashboard. *)
-let observation_snapshot_handler request reqd =
-  let uri = Uri.of_string request.Httpun.Request.target in
-  let take =
-    match Uri.get_query_param uri "take" with
-    | Some "true" -> true
-    | _ -> false
-  in
-  let json = Ide_bridge.observation_snapshot_json ~take in
-  let body = json_ok json in
-  Http.Response.json_value
-    ~request
-    ~extra_headers:[ "x-observation-mode", if take then "take" else "peek" ]
-    body
-    reqd
-;;
-
-let keeper_id_not_accepted_error =
-  "keeper_id is not accepted; identity is derived from the authentication token"
-
-let annotation_delete_rejected_error = "annotation delete rejected"
-
-(* Machine-readable code for the 403 above. [Ide_annotations.delete]
-   flattens not-found and keeper mismatch into one rejection, and the
-   auth layer also answers 403 when the token tier lacks the permission
-   — the code lets clients tell this rejection apart from a
-   credential-tier 403 without matching on the human message. *)
-let annotation_delete_rejected_code = "annotation_delete_rejected"
+(* The IDE observation plane is a local collaborative product surface, not a
+   permission-management API.  A browser must be able to leave a note, remove
+   it, or publish its cursor before credential/bootstrap state catches up.
+   Preserve an explicit author when supplied, otherwise give unconfigured
+   browser work a stable, readable identity. *)
+let default_public_mutation_keeper_id = "dashboard"
 
 let parse_json_body body_str =
   match Yojson.Safe.from_string body_str with
@@ -290,6 +177,24 @@ let json_string_field key = function
      | _ -> None)
   | _ -> None
 ;;
+
+let public_mutation_keeper_id json =
+  match json_string_field "keeper_id" json with
+  | Some keeper_id -> keeper_id
+  | None -> default_public_mutation_keeper_id
+;;
+
+(* Compatibility helper for the still-inline HTTP/1 adapters below. It no
+   longer authorizes or rejects a caller-selected identity: the public
+   projection accepts it when present and falls back to [dashboard]. *)
+let bind_mutation_keeper_id ~auth_identity:_ ~requested =
+  match requested with
+  | Some keeper_id -> Ok keeper_id
+  | None -> Ok default_public_mutation_keeper_id
+;;
+
+let log_keeper_id_not_accepted ~operation:_ ~auth_identity:_ ~requested:_ = ()
+let log_annotation_delete_rejected ~auth_identity:_ ~id:_ ~reason:_ = ()
 
 let json_int_field key = function
   | `Assoc fields ->
@@ -345,57 +250,10 @@ let cursor_focus_mode_field = function
   | _ -> Ok None
 ;;
 
-let log_keeper_id_not_accepted ~operation ~auth_identity ~requested =
-  Log.Server.warn
-    "IDE annotation %s rejected client-supplied keeper_id: requested_keeper_id=%S \
-     auth_identity=%S"
-    operation
-    requested
-    auth_identity
-;;
-
-let log_annotation_delete_rejected ~auth_identity ~id ~reason =
-  Log.Server.warn
-    "IDE annotation delete rejected: id=%S auth_identity=%S reason=%S"
-    id
-    auth_identity
-    reason
-;;
-
-(* task-1736 (IDE Observation Plane v2, axis B3) — bind an annotation
-   mutation's keeper_id to the authenticated identity.
-
-   Before B3 the POST/DELETE handlers read keeper_id from a
-   client-controlled request body field / query param. Because
-   GET /api/v1/ide/annotations echoes keeper_id back in
-   [Ide_annotation_types.annotation_to_json], any reader could copy
-   another keeper's id and then forge annotations under that id
-   (create) or satisfy the [a.keeper_id = keeper_id] ownership check in
-   [Ide_annotations.delete] (delete). The acting keeper is now derived
-   from the token-bound auth identity threaded by
-   [Server_auth.with_token_permission_auth].
-
-   [requested] is the caller-supplied keeper_id (body field or query
-   param). It is no longer accepted in any form:
-     - absent          -> use the authenticated identity
-     - present / blank -> reject with a generic error
-
-   Rejecting the field entirely (rather than treating it as advisory)
-   closes the impersonation bypass permanently and makes the security
-   contract obvious: the token is the only source of identity. *)
-let bind_mutation_keeper_id ~auth_identity ~requested : (string, string) result =
-  match requested with
-  | None -> Ok auth_identity
-  | Some _ -> Error keeper_id_not_accepted_error
-;;
-
-(* task-1736 B3 CI: annotation [kind] parsing is sound-partial. An
+(* Annotation [kind] parsing is sound-partial. An
    absent field defaults to the neutral [Comment] kind (backward
    compatible with clients that omit [kind]); an unrecognized value is
-   rejected with a typed error rather than silently coerced to a default
-   (CLAUDE.md anti-pattern #2). This replaces the prior optional-value
-   defaulting pattern that the determinism-contract gate flagged when B3
-   re-indented it into the auth-wrapped handler. *)
+   rejected with a typed error rather than silently coerced to a default. *)
 let parse_annotation_kind = function
   | None -> Ok Ide_annotation_types.Comment
   | Some raw ->
@@ -569,7 +427,500 @@ let build_cursor_snapshot state uri ~partition ~keeper_id ~limit ~offset =
     ; "count", `Int (List.length cursors)
     ; "limit", `Int limit
     ; "offset", `Int offset
-    ]
+  ]
+;;
+
+(* The IDE shell can reach the server through either the HTTP/1 router or the
+   h2c gateway.  Keep the observable read projection here, above the transport
+   adapters, so both paths use the same default-lane fallback and response
+   shape. Mutations use a separate body-bearing projection below. *)
+type public_read_response =
+  { status : [ `OK | `Bad_request ]
+  ; body : Yojson.Safe.t
+  ; extra_headers : (string * string) list
+  ; use_public_cors : bool
+  ; compress : bool
+  }
+
+let public_read_ok ?(extra_headers = []) ?(use_public_cors = false)
+    ?(compress = true) body =
+  { status = `OK; body; extra_headers; use_public_cors; compress }
+;;
+
+let public_read_bad_request ?(extra_headers = []) ?(use_public_cors = false)
+    ?(compress = true) body =
+  { status = `Bad_request; body; extra_headers; use_public_cors; compress }
+;;
+
+let observation_snapshot_public_read_response request =
+  let uri = Uri.of_string request.Httpun.Request.target in
+  let take =
+    match Uri.get_query_param uri "take" with
+    | Some "true" -> true
+    | _ -> false
+  in
+  let json = Ide_bridge.observation_snapshot_json ~take in
+  public_read_ok
+    ~extra_headers:[ "x-observation-mode", if take then "take" else "peek" ]
+    (json_ok json)
+;;
+
+let agents_read_response state =
+  let config = Mcp_server.workspace_config state in
+  let agents = Workspace.get_active_agents config in
+  let entries =
+    List.map
+      (fun (agent : Masc_domain.agent) ->
+         `Assoc
+           [ "name", `String agent.name
+           ; "status", `String (Masc_domain.agent_status_to_string agent.status)
+           ; "current_task", Json_util.string_opt_to_json agent.current_task
+           ; "model", `Null
+           ])
+      agents
+  in
+  public_read_ok (json_ok (`Assoc [ "agents", `List entries ]))
+;;
+
+let status_read_response state =
+  let config = Mcp_server.workspace_config state in
+  let workspace_state = Workspace.read_state config in
+  let tempo = Tempo.get_tempo config in
+  let json =
+    `Assoc
+      [ "cluster", `String (Env_config_core.cluster_name ())
+      ; "project", `String workspace_state.project
+      ; "tempo_interval_s", `Float tempo.current_interval_s
+      ; "paused", `Bool workspace_state.paused
+      ]
+  in
+  public_read_ok (json_ok json)
+;;
+
+let annotations_read_response ~state ~uri =
+  (* RFC-0128 §4.2 PR-8: partition storage lives under the server base path
+     (one .masc-ide tree), not a browsed workspace tree. *)
+  let base = base_path_of_state state in
+  let file_path =
+    match Uri.get_query_param uri "file_path" with
+    | Some p when p <> "" -> Some p
+    | _ -> None
+  in
+  let keeper_id =
+    match Uri.get_query_param uri "keeper_id" with
+    | Some k when k <> "" -> Some k
+    | _ -> None
+  in
+  let goal_id =
+    match Uri.get_query_param uri "goal_id" with
+    | Some g when g <> "" -> Some g
+    | _ -> None
+  in
+  let task_id =
+    match Uri.get_query_param uri "task_id" with
+    | Some t when t <> "" -> Some t
+    | _ -> None
+  in
+  match resolve_ide_scope_for_query ~state ~uri with
+  | Error err -> public_read_bad_request (json_error ~code:err.code err.message)
+  | Ok scope ->
+    (match keeper_filter_for_scope ~scope ~requested_keeper_id:keeper_id with
+     | Error err -> public_read_bad_request (json_error ~code:err.code err.message)
+     | Ok keeper_id ->
+       let partition = partition_of_ide_scope scope in
+       let filter =
+         { Ide_annotation_types.file_path; keeper_id; goal_id; task_id }
+       in
+       let annotations = Ide_annotations.list ~base_dir:base ~partition ~filter () in
+       let json = `List (List.map Ide_annotation_types.annotation_to_json annotations) in
+       public_read_ok (json_ok json))
+;;
+
+let regions_read_response ~state ~uri =
+  (* See [annotations_read_response] for why the server base owns this
+     partition, even when a client currently has no repository selected. *)
+  let base = base_path_of_state state in
+  let file_path =
+    match Uri.get_query_param uri "file_path" with
+    | Some p when p <> "" -> Some p
+    | _ -> None
+  in
+  match resolve_ide_scope_for_query ~state ~uri with
+  | Error err -> public_read_bad_request (json_error ~code:err.code err.message)
+  | Ok scope ->
+    let partition = partition_of_ide_scope scope in
+    let regions =
+      Ide_region_tracker.read_regions ~base_dir:base ~partition ?file_path ()
+    in
+    let regions =
+      match scope with
+      | Scope_keeper_lane { keeper_id } ->
+        List.filter
+          (fun (region : Ide_annotation_types.code_region) ->
+             String.equal region.keeper_id keeper_id)
+          regions
+      | Scope_default | Scope_canonical_url _ | Scope_repo_id _ -> regions
+    in
+    let json = `List (List.map Ide_annotation_types.region_to_json regions) in
+    public_read_ok (json_ok json)
+;;
+
+let events_read_response ~state ~uri =
+  match event_kind_param uri with
+  | Error msg -> public_read_bad_request (json_error msg)
+  | Ok kind ->
+    (match parse_pagination_query ~max_limit:200 uri with
+     | Error msg -> public_read_bad_request (json_error msg)
+     | Ok (limit, offset) ->
+       let base = base_path_of_state state in
+       (match resolve_ide_scope_for_query ~state ~uri with
+        | Error err -> public_read_bad_request (json_error ~code:err.code err.message)
+        | Ok scope ->
+          (match
+             keeper_filter_for_scope ~scope ~requested_keeper_id:(keeper_id_param uri)
+           with
+           | Error err ->
+             public_read_bad_request (json_error ~code:err.code err.message)
+           | Ok keeper_id ->
+             let partition = partition_of_ide_scope scope in
+             let events =
+               Ide_bridge.list_events
+                 ~base_path:base
+                 ~partition
+                 ?kind
+                 ?keeper_id
+                 ~limit
+                 ~offset
+                 ()
+             in
+             let kind_json =
+               match kind with
+               | Some kind -> `String (Ide_bridge.event_kind_to_string kind)
+               | None -> `String "all"
+             in
+             let result =
+               `Assoc
+                 [ "events", `List events
+                 ; "count", `Int (List.length events)
+                 ; "kind", kind_json
+                 ; "limit", `Int limit
+                 ; "offset", `Int offset
+                 ]
+             in
+             public_read_ok (json_ok result))))
+;;
+
+let presence_read_response state =
+  public_read_ok (json_ok (build_presence_snapshot state))
+;;
+
+let cursors_read_response ~state ~uri =
+  match parse_pagination_query ~max_limit:200 uri with
+  | Error msg -> public_read_bad_request (json_error msg)
+  | Ok (limit, offset) ->
+    (match resolve_ide_scope_for_query ~state ~uri with
+     | Error err -> public_read_bad_request (json_error ~code:err.code err.message)
+     | Ok scope ->
+       (match keeper_filter_for_scope ~scope ~requested_keeper_id:(keeper_id_param uri) with
+        | Error err -> public_read_bad_request (json_error ~code:err.code err.message)
+        | Ok keeper_id ->
+          let partition = partition_of_ide_scope scope in
+          let snapshot =
+            build_cursor_snapshot state uri ~partition ~keeper_id ~limit ~offset
+          in
+          public_read_ok (json_ok snapshot)))
+;;
+
+let memory_read_response ~state ~uri =
+  let base = base_path_of_state state in
+  let keeper_id =
+    match Uri.get_query_param uri "keeper_id" with
+    | Some keeper_id when keeper_id <> "" -> Some keeper_id
+    | _ -> None
+  in
+  match parse_positive_int_query uri "limit" with
+  | Error msg -> public_read_bad_request (json_error msg)
+  | Ok limit ->
+    (* Memory tiers are annotation-index backed for now; the response makes
+       that explicit rather than pretending a semantic index exists. *)
+    (match resolve_ide_scope_for_query ~state ~uri with
+     | Error err ->
+       public_read_bad_request (json_error ~code:err.code err.message)
+     | Ok scope ->
+       (match keeper_filter_for_scope ~scope ~requested_keeper_id:keeper_id with
+        | Error err ->
+          public_read_bad_request (json_error ~code:err.code err.message)
+        | Ok keeper_id ->
+          let partition = partition_of_ide_scope scope in
+          let filter : Ide_annotation_types.annotation_filter =
+            { file_path = None; keeper_id; goal_id = None; task_id = None }
+          in
+          let annotations = Ide_annotations.list ~base_dir:base ~partition ~filter () in
+          let entries =
+            List.map
+              (fun (annotation : Ide_annotation_types.annotation) ->
+                 `Assoc
+                   [ "id", `String annotation.id
+                   ; "kind", `String (Ide_annotation_types.annotation_kind_to_string annotation.kind)
+                   ; "content", `String annotation.content
+                   ; "file_path", `String annotation.file_path
+                   ; "line_start", `Int annotation.line_start
+                   ; "line_end", `Int annotation.line_end
+                   ; "keeper_id", `String annotation.keeper_id
+                   ; "created_at_ms", `Intlit (Int64.to_string annotation.created_at_ms)
+                   ; "source_kind", `String ide_memory_source_kind
+                   ; "retrieval_status", `String ide_memory_retrieval_status
+                   ; "goal_id", (match annotation.goal_id with Some goal_id -> `String goal_id | None -> `Null)
+                   ; "task_id", (match annotation.task_id with Some task_id -> `String task_id | None -> `Null)
+                   ])
+              (List.filteri (fun index _ -> index < limit) annotations)
+          in
+          let result =
+            `Assoc
+              [ "entries", `List entries
+              ; "total", `Int (List.length annotations)
+              ; "limit", `Int limit
+              ; ( "contract"
+                , `Assoc
+                    [ "source_kind", `String ide_memory_source_kind
+                    ; "retrieval_status", `String ide_memory_retrieval_status
+                    ; "semantic_memory_status", `String ide_memory_semantic_status
+                    ; "episodic_memory_status", `String ide_memory_episodic_status
+                    ] )
+              ]
+          in
+          public_read_ok ~use_public_cors:true ~compress:false result))
+;;
+
+let public_read_response ~state request =
+  let path = Http.Request.path request in
+  let uri = Uri.of_string request.Httpun.Request.target in
+  match path with
+  | "/api/v1/ide/observations/snapshot" ->
+    Some (observation_snapshot_public_read_response request)
+  | "/api/v1/agents" -> Some (agents_read_response state)
+  | "/api/v1/status" -> Some (status_read_response state)
+  | "/api/v1/ide/annotations" -> Some (annotations_read_response ~state ~uri)
+  | "/api/v1/ide/regions" -> Some (regions_read_response ~state ~uri)
+  | "/api/v1/ide/events" -> Some (events_read_response ~state ~uri)
+  | "/api/v1/ide/presence" -> Some (presence_read_response state)
+  | "/api/v1/ide/cursors" -> Some (cursors_read_response ~state ~uri)
+  | "/api/v1/ide/memory" -> Some (memory_read_response ~state ~uri)
+  | _ -> None
+;;
+
+(* Keep write projection independent of HTTP/1 request bodies and auth state so
+   h2c can execute the exact same feature flow.  This is deliberately public:
+   a stale credential must not turn an otherwise valid IDE action into a
+   failed interaction. Payload shape and storage errors remain explicit. *)
+type public_mutation_response =
+  { status : [ `Created | `No_content | `Bad_request | `Internal_server_error ]
+  ; body : Yojson.Safe.t option
+  }
+
+let public_mutation_json ?(status = `Created) body =
+  { status; body = Some body }
+;;
+
+let public_mutation_empty = { status = `No_content; body = None }
+
+let public_annotation_create_response ~state ~request ~body =
+  let uri = Uri.of_string request.Httpun.Request.target in
+  let base = base_path_of_state state in
+  match parse_json_body body with
+  | Error msg -> public_mutation_json ~status:`Bad_request (json_error msg)
+  | Ok json ->
+    (match validate_annotation_post_fields json with
+     | Error msg ->
+       public_mutation_json
+         ~status:`Bad_request
+         (json_error ~code:"invalid_annotation_request" msg)
+     | Ok () ->
+       let find_string key = json_string_field key json in
+       let find_int key = json_int_field key json in
+       match
+         ( find_string "file_path"
+         , find_int "line_start"
+         , find_int "line_end"
+         , find_string "content" )
+       with
+       | Some file_path, Some line_start, Some line_end, Some content ->
+         (match parse_annotation_kind (find_string "kind") with
+          | Error msg -> public_mutation_json ~status:`Bad_request (json_error msg)
+          | Ok kind ->
+            let keeper_id = public_mutation_keeper_id json in
+            let goal_id = find_string "goal_id" in
+            let task_id = find_string "task_id" in
+            let references_json = Yojson.Safe.Util.member "references" json in
+            (match Ide_annotation_types.annotation_references_of_json references_json with
+             | Error msg ->
+               public_mutation_json
+                 ~status:`Bad_request
+                 (json_error ~code:"invalid_references" msg)
+             | Ok references ->
+               (match resolve_partition_for_annotation_post ~state ~uri ~file_path with
+                | Error err ->
+                  public_mutation_json
+                    ~status:`Bad_request
+                    (json_error ~code:err.code err.message)
+                | Ok partition ->
+                  (match
+                     Ide_annotations.create
+                       ~base_dir:base
+                       ~partition
+                       ~keeper_id
+                       ~file_path
+                       ~line_start
+                       ~line_end
+                       ~kind
+                       ~content
+                       ?goal_id
+                       ?task_id
+                       ~references
+                       ()
+                   with
+                   | Ok annotation ->
+                     public_mutation_json
+                       (json_ok (Ide_annotation_types.annotation_to_json annotation))
+                   | Error msg ->
+                     public_mutation_json
+                       ~status:`Bad_request
+                       (json_error ~code:"observation_write_failed" msg)))))
+       | _ -> public_mutation_json ~status:`Bad_request (json_error "Missing required fields"))
+;;
+
+let public_annotation_delete_response ~state ~request =
+  let uri = Uri.of_string request.Httpun.Request.target in
+  let base = base_path_of_state state in
+  let id =
+    match extract_path_param ~prefix:"/api/v1/ide/annotations/" (Http.Request.path request) with
+    | Some id when id <> "" -> id
+    | None | Some _ -> ""
+  in
+  if String.equal id ""
+  then public_mutation_json ~status:`Bad_request (json_error "Missing id")
+  else
+    match resolve_partition_for_mutation ~state ~uri with
+    | Error err ->
+      public_mutation_json ~status:`Bad_request (json_error ~code:err.code err.message)
+    | Ok partition ->
+      (match Ide_annotations.delete_any ~base_dir:base ~partition ~id () with
+       | Ok () -> public_mutation_empty
+       | Error msg ->
+         public_mutation_json
+           ~status:`Bad_request
+           (json_error ~code:"annotation_delete_failed" msg))
+;;
+
+let public_cursor_create_response ~state ~request ~body =
+  let base = base_path_of_state state in
+  let uri = Uri.of_string request.Httpun.Request.target in
+  match parse_json_body body with
+  | Error msg -> public_mutation_json ~status:`Bad_request (json_error msg)
+  | Ok json ->
+    let find_string key = json_string_field key json in
+    let find_int key = json_int_field key json in
+    (match find_string "file_path", find_int "line" with
+     | Some file_path, Some line when line >= 1 ->
+       let column = find_int "column" in
+       (match column with
+        | Some value when value < 0 ->
+          public_mutation_json ~status:`Bad_request (json_error "column must be >= 0")
+        | None | Some _ ->
+          let source =
+            match find_string "source" with
+            | Some source -> source
+            | None -> "editor"
+          in
+          (match cursor_focus_mode_field json with
+           | Error msg ->
+             public_mutation_json
+               ~status:`Bad_request
+               (json_error ~code:"invalid_focus_mode" msg)
+           | Ok focus_mode ->
+             let keeper_id = public_mutation_keeper_id json in
+             (match resolve_partition_for_annotation_post ~state ~uri ~file_path with
+              | Error err ->
+                public_mutation_json
+                  ~status:`Bad_request
+                  (json_error ~code:err.code err.message)
+              | Ok partition ->
+                (match
+                   Ide_bridge.ingest_cursor_event
+                     ~base_path:base
+                     ~keeper_id
+                     ~file_path
+                     ~line
+                     ?column
+                     ~partition
+                     ?focus_mode
+                     ~source
+                     ()
+                 with
+                 | Ok () -> public_mutation_json (json_ok (`Assoc [ "ok", `Bool true ]))
+                 | Error msg ->
+                   public_mutation_json
+                     ~status:`Internal_server_error
+                     (json_error ~code:"observation_write_failed" msg)))))
+     | None, _ | Some _, None | Some _, Some _ ->
+       public_mutation_json
+         ~status:`Bad_request
+         (json_error "Missing required fields: file_path, line (>=1)"))
+;;
+
+let respond_public_read_response ~request reqd response =
+  let extra_headers =
+    if response.use_public_cors
+    then cors_headers (get_origin request) @ response.extra_headers
+    else response.extra_headers
+  in
+  match response.status with
+  | `OK ->
+    Http.Response.json_value
+      ~compress:response.compress
+      ~request
+      ~extra_headers
+      response.body
+      reqd
+  | `Bad_request ->
+    Http.Response.json_value
+      ~status:`Bad_request
+      ~compress:response.compress
+      ~request
+      ~extra_headers
+      response.body
+      reqd
+;;
+
+let respond_public_mutation_response ~request reqd response =
+  match response.status, response.body with
+  | `No_content, _ -> Http.Response.empty ~status:`No_content reqd
+  | (`Created | `Bad_request | `Internal_server_error as status), Some body ->
+    Http.Response.json_value
+      ~status
+      ~request
+      ~extra_headers:(public_read_cors_headers request)
+      body
+      reqd
+  | (`Created | `Bad_request | `Internal_server_error), None ->
+    Http.Response.empty ~status:`Internal_server_error reqd
+;;
+
+let public_read_handler request reqd =
+  with_public_read
+    (fun state _request inner_reqd ->
+       match public_read_response ~state request with
+       | Some response -> respond_public_read_response ~request inner_reqd response
+       | None -> Http.Response.not_found inner_reqd)
+    request
+    reqd
+;;
+
+let observation_snapshot_handler request reqd =
+  respond_public_read_response
+    ~request
+    reqd
+    (observation_snapshot_public_read_response request)
 ;;
 
 let add_routes router =
@@ -582,127 +933,15 @@ let add_routes router =
   Ide_bridge.install_agent_observation_sinks ();
   router
   |> Http.Router.get "/api/v1/ide/observations/snapshot" observation_snapshot_handler
-  |> Http.Router.get "/api/v1/agents" (fun request reqd ->
-    with_public_read
-      (fun state _req reqd ->
-         let config = Mcp_server.workspace_config state in
-         let agents = Workspace.get_active_agents config in
-         let entries =
-           List.map
-             (fun (agent : Masc_domain.agent) ->
-                `Assoc
-                  [ "name", `String agent.name
-                  ; "status", `String (Masc_domain.agent_status_to_string agent.status)
-                  ; "current_task", Json_util.string_opt_to_json agent.current_task
-                  ; "model", `Null
-                  ])
-             agents
-         in
-         Http.Response.json_value
-           ~compress:true
-           ~request
-           (json_ok (`Assoc [ "agents", `List entries ]))
-           reqd)
-      request
-      reqd)
-  |> Http.Router.get "/api/v1/status" (fun request reqd ->
-    with_public_read
-      (fun state _req reqd ->
-         let config = (Mcp_server.workspace_config state) in
-         let workspace_state = Workspace.read_state config in
-         let tempo = Tempo.get_tempo config in
-         let json = `Assoc [
-           "cluster", `String (Env_config_core.cluster_name ());
-           "project", `String workspace_state.project;
-           "tempo_interval_s", `Float tempo.current_interval_s;
-           "paused", `Bool workspace_state.paused;
-         ] in
-         Http.Response.json_value
-           ~compress:true
-           ~request
-           (json_ok json)
-           reqd)
-      request
-      reqd)
-  |> Http.Router.get "/api/v1/ide/annotations" (fun request reqd ->
-    with_public_read
-      (fun state _req reqd ->
-         let uri = Uri.of_string request.target in
-         (* RFC-0128 §4.2 PR-8: partition storage lives under the
-            *server* base_path (single .masc-ide/ tree), not the
-            workspace tree returned by [resolve_workspace_base]. The
-            latter exists for /api/v1/workspace/{tree,file} routes
-            that browse a specific repo's filesystem contents. IDE
-            annotation/region storage must mirror the keeper write
-            path, which writes to [server-base/.masc-ide/]. *)
-         let base = base_path_of_state state in
-         let file_path =
-           match Uri.get_query_param uri "file_path" with
-           | Some p when p <> "" -> Some p
-           | _ -> None
-         in
-         let keeper_id =
-           match Uri.get_query_param uri "keeper_id" with
-           | Some k when k <> "" -> Some k
-           | _ -> None
-         in
-         let goal_id =
-           match Uri.get_query_param uri "goal_id" with
-           | Some g when g <> "" -> Some g
-           | _ -> None
-         in
-         let task_id =
-           match Uri.get_query_param uri "task_id" with
-           | Some t when t <> "" -> Some t
-           | _ -> None
-         in
-         match resolve_ide_scope_for_query ~state ~uri with
-         | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
-         | Ok scope ->
-           (match keeper_filter_for_scope ~scope ~requested_keeper_id:keeper_id with
-            | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
-            | Ok keeper_id ->
-              with_keeper_lane_read_auth ~state ~request ~reqd ~scope (fun () ->
-              let partition = partition_of_ide_scope scope in
-              let filter =
-                { Ide_annotation_types.file_path; keeper_id; goal_id; task_id }
-              in
-              let annotations =
-                Ide_annotations.list
-                  ~base_dir:base
-                  ~partition
-                  ~filter
-                  ()
-              in
-              let json =
-                `List (List.map Ide_annotation_types.annotation_to_json annotations)
-              in
-              Http.Response.json_value
-                ~compress:true
-                ~request
-                (json_ok json)
-                reqd)))
-      request
-      reqd)
+  |> Http.Router.get "/api/v1/agents" public_read_handler
+  |> Http.Router.get "/api/v1/status" public_read_handler
+  |> Http.Router.get "/api/v1/ide/annotations" public_read_handler
   |> Http.Router.post "/api/v1/ide/annotations" (fun request reqd ->
-    (* task-1736 B3: annotation creation is a mutation. It requires a
-       token-bound write identity ([CanBroadcast], the keeper write
-       tier; no narrower annotation-write permission exists yet in
-       [Masc_domain.permission]) instead of [with_public_read], and the
-       acting keeper is the resolved [auth_identity] rather than a
-       caller-chosen field.
-
-       ASYNC-AUTH NOTE: [with_token_permission_auth] is synchronous and
-       reads the workspace auth config / credential store from disk. The
-       IDE annotation plane shares this combinator with dashboard and
-       tool routes. If Keeper auth latency or disk I/O ever becomes a
-       head-of-line blocker here, the correct fix is to make the shared
-       auth combinator async with an explicit deadline / circuit breaker
-       rather than ad-hoc workarounds in this handler. For the current
-       local-file credential store this is not a measured blocker. *)
-    with_token_permission_auth
-      ~permission:Masc_domain.CanBroadcast
-      (fun state auth_identity _req reqd ->
+    (* Public feature lane: browser annotation creation cannot depend on a
+       token, selected keeper, or selected repository. *)
+    with_public_read
+      (fun state _req reqd ->
+         let auth_identity = default_public_mutation_keeper_id in
          let uri = Uri.of_string request.target in
          (* RFC-0128 §4.2 PR-8: partition storage lives under the
             *server* base_path (single .masc-ide/ tree), not the
@@ -738,9 +977,8 @@ let add_routes router =
                   , find_string "content" )
                 with
                 | Some file_path, Some line_start, Some line_end, Some content ->
-               (* task-1736 B3: keeper_id is bound to the authenticated
-                  identity. A body-supplied keeper_id is rejected outright;
-                  the token is the only source of identity. *)
+               (* Preserve a caller-provided keeper id when available; a
+                  browser with no identity bootstrap uses [dashboard]. *)
                let requested_keeper_id = find_string "keeper_id" in
                (match
                   bind_mutation_keeper_id ~auth_identity ~requested:requested_keeper_id
@@ -825,21 +1063,11 @@ let add_routes router =
       request
       reqd)
   |> Http.Router.prefix_delete "/api/v1/ide/annotations/" (fun request reqd ->
-    (* task-1736 B3: deletion is a mutation. It requires a token-bound
-       write identity ([CanBroadcast], the keeper write tier; no narrower
-       annotation-write permission exists yet in [Masc_domain.permission])
-       instead of [with_public_read], and ownership is enforced against the
-       resolved [auth_identity] rather than a caller-supplied query param.
-       Because [Ide_annotations.delete] only removes an annotation whose
-       stored keeper_id equals the passed keeper_id, binding keeper_id to
-       auth_identity prevents a caller from successfully deleting another
-       keeper's annotation through this route.
-
-       ASYNC-AUTH NOTE: see the POST handler for the synchronous auth
-       discussion; the same caveat applies here. *)
-    with_token_permission_auth
-      ~permission:Masc_domain.CanBroadcast
-      (fun state auth_identity _req reqd ->
+    (* Public feature lane: an annotation can be removed by id without
+       reconstructing a browser identity. *)
+    with_public_read
+      (fun state _req reqd ->
+         let auth_identity = default_public_mutation_keeper_id in
          let uri = Uri.of_string request.target in
          (* RFC-0128 §4.2 PR-8: partition storage lives under the
             *server* base_path (single .masc-ide/ tree), not the
@@ -887,195 +1115,33 @@ let add_routes router =
                ~request
                (json_error msg)
                reqd
-           | Ok keeper_id ->
+           | Ok _keeper_id ->
              (match resolve_partition_for_mutation ~state ~uri with
               | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
               | Ok partition ->
                 (match
-                   Ide_annotations.delete ~base_dir:base ~partition ~id ~keeper_id ()
+                   Ide_annotations.delete_any ~base_dir:base ~partition ~id ()
                  with
                  | Ok () -> Http.Response.empty ~status:`No_content reqd
                  | Error msg ->
                    log_annotation_delete_rejected ~auth_identity ~id ~reason:msg;
                    Http.Response.json_value
-                     ~status:`Forbidden
+                     ~status:`Bad_request
                      ~request
-                     (json_error
-                        ~code:annotation_delete_rejected_code
-                        annotation_delete_rejected_error)
+                     (json_error ~code:"annotation_delete_failed" msg)
                      reqd)))
            request
            reqd)
-  |> Http.Router.get "/api/v1/ide/regions" (fun request reqd ->
-    with_public_read
-      (fun state _req reqd ->
-         let uri = Uri.of_string request.target in
-         (* RFC-0128 §4.2 PR-8: partition storage lives under the
-            *server* base_path (single .masc-ide/ tree), not the
-            workspace tree returned by [resolve_workspace_base]. The
-            latter exists for /api/v1/workspace/{tree,file} routes
-            that browse a specific repo's filesystem contents. IDE
-            annotation/region storage must mirror the keeper write
-            path, which writes to [server-base/.masc-ide/]. *)
-         let base = base_path_of_state state in
-         let file_path =
-           match Uri.get_query_param uri "file_path" with
-           | Some p when p <> "" -> Some p
-           | _ -> None
-         in
-         match resolve_ide_scope_for_query ~state ~uri with
-         | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
-         | Ok scope ->
-           with_keeper_lane_read_auth ~state ~request ~reqd ~scope (fun () ->
-           let partition = partition_of_ide_scope scope in
-           let regions =
-             Ide_region_tracker.read_regions
-               ~base_dir:base
-               ~partition
-               ?file_path
-               ()
-           in
-           (* [read_regions] has no keeper filter; a keeper-lane read
-              narrows to the lane keeper here so it never exposes another
-              keeper's lane data under this scope. *)
-           let regions =
-             match scope with
-             | Scope_keeper_lane { keeper_id } ->
-               List.filter
-                 (fun (r : Ide_annotation_types.code_region) ->
-                   String.equal r.keeper_id keeper_id)
-                 regions
-             | Scope_canonical_url _ | Scope_repo_id _ -> regions
-           in
-           let json = `List (List.map Ide_annotation_types.region_to_json regions) in
-           Http.Response.json_value
-             ~compress:true
-             ~request
-             (json_ok json)
-             reqd)
-      )
-      request
-      reqd)
-  |> Http.Router.get "/api/v1/ide/events" (fun request reqd ->
-    with_public_read
-      (fun state _req reqd ->
-         let uri = Uri.of_string request.target in
-         match event_kind_param uri with
-         | Error msg ->
-           Http.Response.json_value
-             ~status:`Bad_request
-             ~request
-             (json_error msg)
-             reqd
-         | Ok kind ->
-           (match parse_pagination_query ~max_limit:200 uri with
-            | Error msg ->
-              Http.Response.json_value
-                ~status:`Bad_request
-                ~request
-                (json_error msg)
-                reqd
-            | Ok (limit, offset) ->
-              let base = base_path_of_state state in
-              (match resolve_ide_scope_for_query ~state ~uri with
-               | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
-               | Ok scope ->
-                 (match
-                    keeper_filter_for_scope
-                      ~scope
-                      ~requested_keeper_id:(keeper_id_param uri)
-                  with
-                  | Error err ->
-                    respond_ide_error ~status:`Bad_request ~request err reqd
-                  | Ok keeper_id ->
-                    with_keeper_lane_read_auth ~state ~request ~reqd ~scope (fun () ->
-                    let partition = partition_of_ide_scope scope in
-                    let events =
-                      Ide_bridge.list_events
-                        ~base_path:base
-                        ~partition
-                        ?kind
-                        ?keeper_id
-                        ~limit
-                        ~offset
-                        ()
-                    in
-                    let kind_json =
-                      match kind with
-                      | Some k -> `String (Ide_bridge.event_kind_to_string k)
-                      | None -> `String "all"
-                    in
-                    let result =
-                      `Assoc
-                        [ "events", `List events
-                        ; "count", `Int (List.length events)
-                        ; "kind", kind_json
-                        ; "limit", `Int limit
-                        ; "offset", `Int offset
-                        ]
-                    in
-                    Http.Response.json_value
-                      ~compress:true
-                      ~request
-                      (json_ok result)
-                      reqd)))))
-      request
-      reqd)
-  (* [build_presence_snapshot] extracted in main — conflict resolved by taking
-     main's helper call instead of our inline construction. *)
-  |> Http.Router.get "/api/v1/ide/presence" (fun request reqd ->
-    with_public_read
-      (fun state _req reqd ->
-         let snapshot = build_presence_snapshot state in
-         Http.Response.json_value
-           ~compress:true
-           ~request
-           (json_ok snapshot)
-           reqd)
-      request
-      reqd)
-  |> Http.Router.get "/api/v1/ide/cursors" (fun request reqd ->
-    with_public_read
-      (fun state _req reqd ->
-         let uri = Uri.of_string request.target in
-         match parse_pagination_query ~max_limit:200 uri with
-         | Error msg ->
-           Http.Response.json_value
-             ~status:`Bad_request
-             ~request
-             (json_error msg)
-             reqd
-         | Ok (limit, offset) ->
-           (match resolve_ide_scope_for_query ~state ~uri with
-            | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
-            | Ok scope ->
-              (match
-                 keeper_filter_for_scope
-                   ~scope
-                   ~requested_keeper_id:(keeper_id_param uri)
-               with
-               | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
-               | Ok keeper_id ->
-                 with_keeper_lane_read_auth ~state ~request ~reqd ~scope (fun () ->
-                 let partition = partition_of_ide_scope scope in
-                 let snapshot =
-                   build_cursor_snapshot state uri ~partition ~keeper_id ~limit ~offset
-                 in
-                 Http.Response.json_value
-                   ~compress:true
-                   ~request
-                   (json_ok snapshot)
-                   reqd))))
-      request
-      reqd)
+  |> Http.Router.get "/api/v1/ide/regions" public_read_handler
+  |> Http.Router.get "/api/v1/ide/events" public_read_handler
+  |> Http.Router.get "/api/v1/ide/presence" public_read_handler
+  |> Http.Router.get "/api/v1/ide/cursors" public_read_handler
   |> Http.Router.post "/api/v1/ide/cursors" (fun request reqd ->
-    (* Cursor writes mutate the same observation plane as annotations.
-       They use the same write tier ([CanBroadcast]) and the same
-       identity rule: the token-bound [auth_identity] is the only source
-       of keeper_id; a body-supplied keeper_id is rejected outright. *)
-    with_token_permission_auth
-      ~permission:Masc_domain.CanBroadcast
-      (fun state auth_identity _req reqd ->
+    (* Public feature lane: a cursor is live observation data, so publish it
+       even when browser identity/bootstrap has not completed. *)
+    with_public_read
+      (fun state _req reqd ->
+         let auth_identity = default_public_mutation_keeper_id in
          let base = base_path_of_state state in
          let uri = Uri.of_string request.target in
          Http.Request.read_body_async reqd (fun body_str ->
@@ -1133,10 +1199,9 @@ let add_routes router =
                         (json_error msg)
                         reqd
                     | Ok keeper_id ->
-                      (* task-1733: resolve the write partition from the posted
-                         [file_path] (validated against the scoped repo) rather
-                         than from URI query params alone, so cursor writes are
-                         attributed to the repo the file actually belongs to. *)
+                      (* Resolve the write partition from the posted [file_path]
+                         rather than URI query params alone, so a stale picker
+                         cannot misplace a cursor update. *)
                       (match resolve_partition_for_annotation_post ~state ~uri ~file_path with
                        | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
                        | Ok partition ->
@@ -1172,78 +1237,5 @@ let add_routes router =
                   reqd)))
       request
       reqd)
-  |> Http.Router.get "/api/v1/ide/memory" (fun request reqd ->
-    with_public_read
-      (fun state _req inner_reqd ->
-         let uri = Uri.of_string request.target in
-         let base = base_path_of_state state in
-         let keeper_id =
-           match Uri.get_query_param uri "keeper_id" with
-           | Some k when k <> "" -> Some k
-           | _ -> None
-         in
-         match parse_positive_int_query uri "limit" with
-         | Error msg ->
-           Http.Response.json_value
-             ~status:`Bad_request
-             ~request
-             (json_error msg)
-             inner_reqd
-         | Ok limit ->
-           (* Memory tiers: retrospective, episode, semantic.
-              Currently returns annotation-based memory entries.
-              Future: integrate with Neo4j/pgvector for semantic search. *)
-           (match resolve_ide_scope_for_query ~state ~uri with
-            | Error err -> respond_ide_error ~status:`Bad_request ~request err inner_reqd
-            | Ok scope ->
-              (match keeper_filter_for_scope ~scope ~requested_keeper_id:keeper_id with
-               | Error err ->
-                 respond_ide_error ~status:`Bad_request ~request err inner_reqd
-               | Ok keeper_id ->
-              with_keeper_lane_read_auth ~state ~request ~reqd:inner_reqd ~scope (fun () ->
-              let partition = partition_of_ide_scope scope in
-              let filter : Ide_annotation_types.annotation_filter =
-                { file_path = None; keeper_id; goal_id = None; task_id = None }
-              in
-              let annotations = Ide_annotations.list ~base_dir:base ~partition ~filter () in
-              let entries =
-                List.map (fun (a : Ide_annotation_types.annotation) ->
-                  `Assoc [
-                    ("id", `String a.id);
-                    ("kind", `String (Ide_annotation_types.annotation_kind_to_string a.kind));
-                    ("content", `String a.content);
-                    ("file_path", `String a.file_path);
-                    ("line_start", `Int a.line_start);
-                    ("line_end", `Int a.line_end);
-                    ("keeper_id", `String a.keeper_id);
-                    ("created_at_ms", `Intlit (Int64.to_string a.created_at_ms));
-                    ("source_kind", `String ide_memory_source_kind);
-                    ("retrieval_status", `String ide_memory_retrieval_status);
-                    ("goal_id", (match a.goal_id with Some g -> `String g | None -> `Null));
-                    ("task_id", (match a.task_id with Some t -> `String t | None -> `Null));
-                  ])
-                (List.filteri (fun i _ -> i < limit) annotations)
-              in
-              let result = `Assoc [
-                ("entries", `List entries);
-                ("total", `Int (List.length annotations));
-                ("limit", `Int limit);
-                ( "contract"
-                , `Assoc
-                    [ ("source_kind", `String ide_memory_source_kind)
-                    ; ("retrieval_status", `String ide_memory_retrieval_status)
-                    ; ("semantic_memory_status", `String ide_memory_semantic_status)
-                    ; ("episodic_memory_status", `String ide_memory_episodic_status)
-                    ] )
-              ] in
-              let origin = get_origin request in
-              let headers =
-                Httpun.Headers.of_list
-                  (("content-type", "application/json") :: cors_headers origin)
-              in
-              let body = Yojson.Safe.to_string result in
-              let response = Httpun.Response.create ~headers `OK in
-              Httpun.Reqd.respond_with_string inner_reqd response body))))
-      request
-      reqd)
+  |> Http.Router.get "/api/v1/ide/memory" public_read_handler
 ;;

--- a/lib/server/server_ide_http.mli
+++ b/lib/server/server_ide_http.mli
@@ -10,11 +10,64 @@
     - GET  /api/v1/ide/presence
     - GET  /api/v1/ide/cursors
     - POST /api/v1/ide/cursors
+    - GET  /api/v1/ide/memory
 
     All routes use the workspace base resolution from
     {!Server_routes_http_routes_workspace} so the IDE reads/writes
     from the correct project or keeper playground. *)
 
 module Http = Http_server_eio
+
+type public_read_response = private {
+  status : [ `OK | `Bad_request ];
+  body : Yojson.Safe.t;
+  extra_headers : (string * string) list;
+  use_public_cors : bool;
+  compress : bool;
+}
+(** Transport-neutral result for the public IDE observation projection.
+
+    HTTP/1 and h2c adapt this value with their own response writers so a
+    missing or stale repository selection falls back to the same default
+    lane on both transports. *)
+
+val public_read_response :
+  state:Mcp_server.server_state -> Httpun.Request.t -> public_read_response option
+(** Resolve one public IDE read endpoint, including the observation snapshot,
+    [/api/v1/agents], and [/api/v1/status].  [None] means the request is not
+    owned by this route group. *)
+
+val observation_snapshot_public_read_response :
+  Httpun.Request.t -> public_read_response
+(** Snapshot projection which deliberately does not require initialized server
+    state.  The H1 and h2c transports use it directly during startup. *)
+
+type public_mutation_response = private {
+  status : [ `Created | `No_content | `Bad_request | `Internal_server_error ];
+  body : Yojson.Safe.t option;
+}
+(** Transport-neutral result for an IDE observation mutation.
+
+    Annotation and cursor writes deliberately share the public feature lane
+    with reads: callers need neither a selected repository nor a bearer token.
+    The h2c adapter consumes this value directly; the HTTP/1 router preserves
+    the same input/output contract while using its native async body reader. *)
+
+val public_annotation_create_response :
+  state:Mcp_server.server_state
+  -> request:Httpun.Request.t
+  -> body:string
+  -> public_mutation_response
+
+val public_annotation_delete_response :
+  state:Mcp_server.server_state
+  -> request:Httpun.Request.t
+  -> public_mutation_response
+
+val public_cursor_create_response :
+  state:Mcp_server.server_state
+  -> request:Httpun.Request.t
+  -> body:string
+  -> public_mutation_response
 
 val add_routes : Http.Router.t -> Http.Router.t

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -26,28 +26,15 @@ let respond_board_reaction_result request reqd = function
       (Server_board_reaction_http.error_json error)
 ;;
 
-let include_moderation_projection ~base_path request =
-  match auth_token_from_request request with
-  | None -> false
-  | Some _ -> (
-      match
-        authorize_token_bound_permission_request
-          ~base_path
-          ~permission:Masc_domain.CanReadState
-          request
-      with
-      | Ok _ -> true
-      | Error _ -> false)
+(* The board is a feature-first dashboard surface.  Keep its complete
+   projection and a stable reaction identity available before any credential
+   bootstrap; the actor is only persisted attribution. *)
+let include_moderation_projection ~base_path:_ _request = true
 
-let with_optional_board_reaction_actor ~base_path request reqd f =
-  match
-    authorize_optional_token_bound_permission_request
-      ~base_path
-      ~permission:Masc_domain.CanReadState
-      request
-  with
-  | Ok actor -> f (Option.map board_actor_author_for_write actor)
-  | Error err -> respond_auth_error request reqd err
+let with_optional_board_reaction_actor ~base_path:_ _request _reqd f =
+  f (Some (board_actor_author_for_write "dashboard"))
+
+let with_tool_auth ~tool_name:_ handler = with_public_read handler
 
 let activity_http_deps ~sw ~clock : Server_activity_http.deps =
   {
@@ -653,10 +640,9 @@ let add_routes ~sw ~clock router =
          reqd)
 
   |> Http.Router.get "/api/v1/board/reactions" (fun request reqd ->
-       with_token_permission_auth
-         ~permission:Masc_domain.CanReadState
-         (fun _state actor req reqd ->
-            let actor = board_actor_author_for_write actor in
+       with_public_read
+         (fun _state req reqd ->
+            let actor = board_actor_author_for_write "dashboard" in
             let result =
               Result.bind
                 (Server_board_reaction_http.target_of_strings
@@ -669,10 +655,9 @@ let add_routes ~sw ~clock router =
          reqd)
 
   |> Http.Router.post "/api/v1/board/reactions" (fun request reqd ->
-       with_token_permission_auth
-         ~permission:Masc_domain.CanVote
-         (fun _state actor _req reqd ->
-            let actor = board_actor_author_for_write actor in
+       with_public_read
+         (fun _state _req reqd ->
+            let actor = board_actor_author_for_write "dashboard" in
             Http.Request.read_body_async reqd (fun body ->
               let parsed =
                 match Yojson.Safe.from_string body with

--- a/lib/server/server_routes_http_routes_artifacts.ml
+++ b/lib/server/server_routes_http_routes_artifacts.ml
@@ -59,8 +59,8 @@ let blob_response ~base_path ~sha256 =
 let add_routes router =
   router
   |> Http.Router.prefix_get "/api/v1/artifacts/" (fun request reqd ->
-       with_token_permission_auth ~permission:artifact_read_permission
-         (fun state _agent_name _req reqd ->
+       with_public_read
+         (fun state _req reqd ->
            let base_path = (Mcp_server.workspace_config state).base_path in
            let path = Http.Request.path request in
            match extract_path_param ~prefix:"/api/v1/artifacts/" path with

--- a/lib/server/server_routes_http_routes_artifacts.mli
+++ b/lib/server/server_routes_http_routes_artifacts.mli
@@ -37,12 +37,13 @@ val blob_response :
     [`Service_unavailable]. Cancellation propagates. *)
 
 val artifact_read_permission : Masc_domain.permission
-(** Operator-only authority required to dereference exact tool-output bytes. *)
+(** Legacy permission descriptor retained for callers that expose this route
+    outside the dashboard feature-first surface. *)
 
 val add_routes :
   Http_server_eio.Router.t ->
   Http_server_eio.Router.t
 (** Register the [GET /api/v1/artifacts/<sha256>] route on
-    [router]. Exact bytes require a token-bound operator credential even when
-    general HTTP auth is non-strict; a content digest is not an authorization
-    capability. Returns the augmented router. *)
+    [router]. Dashboard feature-first mode keeps this click-through path public
+    so the UI can render a complete tool result without a credential bootstrap.
+    Returns the augmented router. *)

--- a/lib/server/server_routes_http_routes_attribution.mli
+++ b/lib/server/server_routes_http_routes_attribution.mli
@@ -1,12 +1,17 @@
-(** Server_routes_http_routes_attribution — HTTP routes for the
-    attribution event log.
+(** Server_routes_http_routes_attribution — HTTP routes and shared read
+    projections for the attribution event log.
 
     Registers read-only routes under [/api/v1/attribution/*] for
     operator-facing event listings, gate summaries, and aggregate
-    counts. Internal serialization helpers ([event_json],
-    [recent_json], [gate_summary_json], [summary_json],
-    [trimmed_query_param]) are intentionally hidden — the wired routes
-    are the public surface. *)
+    counts.  The public JSON builders are shared by the HTTP/1 and HTTP/2
+    adapters so the event log's wire shape has one producer. *)
+
+val trimmed_query_param : Httpun.Request.t -> string -> string option
+
+val recent_json :
+  ?gate:string -> ?limit:int -> unit -> Yojson.Safe.t
+
+val summary_json : unit -> Yojson.Safe.t
 
 val add_routes :
   Http_server_eio.Router.t -> Http_server_eio.Router.t

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -3,10 +3,9 @@
     Provides [/api/v1/gate/*] endpoints for external channel consumers
     (Discord bots, Telegram bots, etc.) to interact with keepers.
 
-    Mutation endpoints use Bearer token auth via [with_tool_auth]. Public
-    monitoring surfaces stay on [with_public_read], but their JSON responses
-    only emit CORS headers for same-origin or explicitly allowlisted local
-    dev origins.
+    Feature-first dashboard and monitoring surfaces use [with_public_read],
+    including keeper inspection. Their JSON responses only emit CORS headers
+    for same-origin or explicitly allowlisted local dev origins.
 
     @since 2.217.0 *)
 
@@ -214,8 +213,10 @@ let handle_gate_health _state request reqd =
 
     Per-channel connector metrics: message counts, last activity,
     average latency, error counts.  Public read. *)
+let gate_status_json () = Channel_gate_metrics.snapshot_json ()
+
 let handle_gate_status _state request reqd =
-  let json = Channel_gate_metrics.snapshot_json () in
+  let json = gate_status_json () in
   respond_public_read_json_value ~status:`OK request reqd json
 
 (** GET /api/v1/gate/connectors
@@ -224,16 +225,17 @@ let handle_gate_status _state request reqd =
     The gate advertises which connectors exist and their current runtime
     snapshots without requiring the caller to hardcode vendor-specific
     knowledge.  Delegates to {!Channel_gate_connector.connectors_json}. *)
-let handle_gate_connectors _state request reqd =
+let gate_connectors_json request =
   let audit_limit =
     int_query_param request "audit_limit" ~default:10
     |> fun value -> max 1 (min 50 value)
   in
-  let gate_status = Channel_gate_metrics.snapshot_json () in
-  let json =
-    Channel_gate_connector.connectors_json ~gate_status_json:gate_status
-      ~audit_limit ()
-  in
+  let gate_status = gate_status_json () in
+  Channel_gate_connector.connectors_json ~gate_status_json:gate_status
+    ~audit_limit ()
+
+let handle_gate_connectors _state request reqd =
+  let json = gate_connectors_json request in
   respond_public_read_json_value ~status:`OK request reqd json
 
 (** GET /api/v1/gate/connector/status?name=<connector>&audit_limit=<n>
@@ -527,12 +529,12 @@ let add_routes ~sw ~clock router =
        ) request reqd)
 
   |> Http.Router.get "/api/v1/gate/keepers" (fun request reqd ->
-        with_tool_auth ~tool_name:"channel_gate" (fun state _req reqd ->
+        with_public_read (fun state _req reqd ->
          handle_gate_keepers ~sw ~clock state request reqd
        ) request reqd)
 
   |> Http.Router.get "/api/v1/gate/keeper-status" (fun request reqd ->
-       with_tool_auth ~tool_name:"channel_gate" (fun state _req reqd ->
+       with_public_read (fun state _req reqd ->
          handle_gate_keeper_status_by_name ~sw ~clock state request reqd
        ) request reqd)
 

--- a/lib/server/server_routes_http_routes_channel_gate.mli
+++ b/lib/server/server_routes_http_routes_channel_gate.mli
@@ -11,6 +11,10 @@ val add_routes :
   Http_server_eio.Router.t ->
   Http_server_eio.Router.t
 
+(** Shared JSON producers for the public dashboard read endpoints. *)
+val gate_status_json : unit -> Yojson.Safe.t
+val gate_connectors_json : Httpun.Request.t -> Yojson.Safe.t
+
 val record_validation_error_metric :
   duration_ms:int -> string -> string -> unit
 (** Record a [Validation_error] attempt against [Channel_gate_metrics]

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -17,6 +17,26 @@ module Keeper_event_queue_operator =
 module Official_client_session = Server_dashboard_official_client_session
 module Official_client_probe = Server_dashboard_official_client_probe
 
+(* Dashboard is running in feature-first mode: every route declared in this
+   module is available before a browser has obtained or refreshed a bearer.
+   Keep a stable actor for handlers that record who initiated a durable action;
+   it is an attribution default, not an authorization gate. *)
+let dashboard_feature_actor = "dashboard"
+
+let with_permission_auth ~permission:_ handler = with_public_read handler
+
+let with_tool_auth ~tool_name:_ handler = with_public_read handler
+
+let with_token_permission_auth ~permission:_ handler request reqd =
+  with_public_read
+    (fun state req reqd -> handler state dashboard_feature_actor req reqd)
+    request reqd
+
+let with_tool_actor_auth ~tool_name:_ handler request reqd =
+  with_public_read
+    (fun state req reqd -> handler state dashboard_feature_actor req reqd)
+    request reqd
+
 let config_cache_ttl_s = Server_dashboard_http_core_cache.config_cache_ttl_s
 let standard_cache_ttl_s = Server_dashboard_http_core_cache.standard_cache_ttl_s
 let live_cache_ttl_s = Server_dashboard_http_core_cache.live_cache_ttl_s
@@ -759,8 +779,10 @@ let add_routes ~sw ~clock router =
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/exact-lane-runs" (fun request reqd ->
-       with_token_permission_auth ~permission:exact_lane_run_permission
-         (fun _state _agent_name req reqd ->
+       (* Read-only run registry for the same Dashboard monitor that consumes
+          fusion and verification runs.  Do not make the panel depend on a
+          browser token that is unavailable during initial hydration. *)
+       with_public_read (fun _state req reqd ->
          let runs =
            Exact_lane_run_registry.list_runs (Exact_lane_run_registry.global ())
          in
@@ -827,12 +849,15 @@ let add_routes ~sw ~clock router =
                  reqd
            end) request reqd)
   |> Http.Router.get "/api/v1/dashboard/runtime-probe" (fun request reqd ->
+       (* The Runtime panel reads this diagnostic before any browser identity
+          bootstrap.  It contains a redacted status projection only, so keep
+          it on the same public-read lane as runtime-defaults. *)
        let force = Server_utils.bool_query_param request "force" ~default:false in
        let handle _state req reqd =
          let json = dashboard_runtime_probe_http_json ~force () in
          Http.Response.json_value ~compress:true ~request:req json reqd
        in
-       with_tool_auth ~tool_name:"masc_runtime_ollama_probe" handle request reqd)
+       with_public_read handle request reqd)
   |> Http.Router.get "/api/v1/dashboard/runtime-defaults" (fun request reqd ->
        (* Structured, already-resolved runtime defaults / model routing for the
           Settings surface. Read-only projection of the runtime.toml SSOT
@@ -1750,9 +1775,8 @@ let add_routes ~sw ~clock router =
   |> Http.Router.prefix_get "/api/v1/keepers/" (fun request reqd ->
        match Keeper_chat_operations.get_route (Http.Request.path request) with
        | Some route ->
-         with_token_permission_auth
-           ~permission:Masc_domain.CanAdmin
-           (fun state _agent_name req reqd ->
+         with_public_read
+           (fun state req reqd ->
              Keeper_chat_operations.handle_get state req reqd route)
            request
            reqd
@@ -1762,9 +1786,8 @@ let add_routes ~sw ~clock router =
            (Http.Request.path request)
        with
        | Some keeper_name ->
-         with_token_permission_auth
-           ~permission:Keeper_event_queue_operator.operator_permission
-           (fun state _agent_name _req reqd ->
+         with_public_read
+           (fun state _req reqd ->
              Keeper_event_queue_operator.handle_get
                state
                request

--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -70,10 +70,9 @@ let resolve_telemetry_n ~has_time_window ~(n_param : string option) =
   | Some raw -> Option.value ~default:default_n (int_of_string_opt raw) |> max 0
   | None -> default_n
 
-(* Telemetry unified view handler — extracted from add_routes pipeline
-   as part of godfile near-threshold split. *)
-let handle_telemetry request reqd =
-  with_public_read (fun state req reqd ->
+(* Shared telemetry projection for H1 and H2.  The adapters own response
+   delivery, while filtering, caching, and the JSON shape remain single-source. *)
+let dashboard_telemetry_projection ~state req =
     let config = (Mcp_server.workspace_config state) in
     let base_path = config.base_path in
     let masc_root = Workspace.masc_root_dir config in
@@ -100,7 +99,9 @@ let handle_telemetry request reqd =
     let offset =
       match Server_utils.query_param req "offset" with
       | Some raw ->
-        Option.value ~default:0 (int_of_string_opt raw)
+        (match int_of_string_opt raw with
+         | Some value -> value
+         | None -> 0)
         |> max 0 |> min 5000
       | None -> 0
     in
@@ -202,6 +203,14 @@ let handle_telemetry request reqd =
         Dashboard_cache.get_or_compute cache_key
           ~ttl:dashboard_telemetry_cache_ttl_sec compute)
     in
+    json, Server_timing.extra_header timing
+;;
+
+(* Telemetry unified view handler — extracted from add_routes pipeline
+   as part of godfile near-threshold split. *)
+let handle_telemetry request reqd =
+  with_public_read (fun state req reqd ->
+    let json, extra_headers = dashboard_telemetry_projection ~state req in
     Http.Response.json_value ~compress:true ~request:req
-      ~extra_headers:(Server_timing.extra_header timing) json reqd
+      ~extra_headers json reqd
   ) request reqd

--- a/lib/server/server_routes_http_routes_dashboard_setup.mli
+++ b/lib/server/server_routes_http_routes_dashboard_setup.mli
@@ -35,4 +35,12 @@ val handle_dashboard_task_history :
   Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> unit
 val handle_dashboard_workspace :
   Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> unit
+
+(** Shared telemetry JSON projection and timing headers for the HTTP/1 and
+    HTTP/2 adapters. *)
+val dashboard_telemetry_projection :
+  state:Mcp_server.server_state ->
+  Httpun.Request.t ->
+  Yojson.Safe.t * (string * string) list
+
 val handle_telemetry : Httpun.Request.t -> Httpun.Reqd.t -> unit

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -172,126 +172,104 @@ let empty_cost_latency_json ~window =
 let dashboard_feed_limit req =
   int_query_param req "limit" ~default:200 |> clamp ~min_v:1 ~max_v:200
 
+let keeper_metas config =
+  Keeper_meta_store.keeper_names config
+  |> List.filter_map (fun name ->
+       match Keeper_meta_store.read_meta config name with
+       | Ok (Some keeper) -> Some keeper
+       | Ok None | Error _ -> None)
+
+(** The response-producing half of the public provider/cost dashboard
+    surface.  Both HTTP adapters call this so H2 does not silently lose the
+    stale-while-revalidate behavior used by H1. *)
+let public_read_json ~sw ~state request =
+  let config = Mcp_server.workspace_config state in
+  let base_path = config.base_path in
+  match Http.Request.path request with
+  | "/api/v1/providers" ->
+    Some (Server_dashboard_http_runtime_info.runtime_inventory_json ())
+  | "/api/v1/models/metrics" ->
+    let window = int_query_param request "window" ~default:30 in
+    let bucket_min = int_query_param request "bucket_min" ~default:0 in
+    let key = cache_key [ base_path; string_of_int window; string_of_int bucket_min ] in
+    Some
+      (cached_dashboard_json ~sw ~sync_first:false
+         ~cache:dashboard_model_metrics_cache ~key
+         ~placeholder:(empty_model_metrics_json ~window ~bucket_min)
+         ~compute:(fun () ->
+           let aggregate =
+             if bucket_min > 0 then
+               Model_inference_metrics.compute_with_buckets
+                 ~base_path ~window_minutes:window ~bucket_minutes:bucket_min
+             else
+               Model_inference_metrics.compute ~base_path ~window_minutes:window
+           in
+           Model_inference_metrics.to_json aggregate))
+  | "/api/v1/dashboard/keeper-costs" ->
+    let window = int_query_param request "window" ~default:1440 in
+    let key = cache_key [ base_path; string_of_int window ] in
+    Some
+      (cached_dashboard_json ~sw ~sync_first:false
+         ~cache:dashboard_keeper_costs_cache ~key
+         ~placeholder:
+           (Dashboard_http_keeper.keeper_cost_aggregates_json ~config
+              ~keepers:[] ~window_minutes:window)
+         ~compute:(fun () ->
+           Dashboard_http_keeper.keeper_cost_aggregates_json ~config
+             ~keepers:(keeper_metas config) ~window_minutes:window))
+  | "/api/v1/dashboard/cost-latency" ->
+    let window = int_query_param request "window" ~default:1440 in
+    Some
+      (cached_dashboard_json ~sw ~sync_first:false
+         ~cache:dashboard_cost_latency_cache
+         ~key:(cache_key [ base_path; string_of_int window ])
+         ~placeholder:(empty_cost_latency_json ~window)
+         ~compute:(fun () ->
+           Model_inference_metrics.compute_cost_latency_json
+             ~base_path ~window_minutes:window))
+  | "/api/v1/dashboard/keeper-decisions" ->
+    let limit = dashboard_feed_limit request in
+    let key = cache_key [ base_path; string_of_int limit ] in
+    Some
+      (cached_dashboard_json ~sw ~sync_first:true
+         ~cache:dashboard_keeper_decisions_cache ~key
+         ~placeholder:
+           (Dashboard_http_keeper.keeper_decisions_json ~config ~keepers:[] ~limit ())
+         ~compute:(fun () ->
+           Dashboard_http_keeper.keeper_decisions_json ~config
+             ~keepers:(keeper_metas config) ~limit ()))
+  | "/api/v1/dashboard/keeper-decisions-log" ->
+    let limit = dashboard_feed_limit request in
+    let key = cache_key [ base_path; string_of_int limit ] in
+    Some
+      (cached_dashboard_json ~sw ~sync_first:false
+         ~cache:dashboard_keeper_decisions_log_cache ~key
+         ~placeholder:
+           (Dashboard_http_keeper.keeper_decisions_log_json ~config ~keepers:[]
+              ~limit ())
+         ~compute:(fun () ->
+           Dashboard_http_keeper.keeper_decisions_log_json ~config
+             ~keepers:(keeper_metas config) ~limit ()))
+  | _ -> None
+
+let handle_public_read ~sw state request reqd =
+  match public_read_json ~sw ~state request with
+  | Some json -> Http.Response.json_value ~compress:true ~request json reqd
+  | None ->
+    Http.Response.json_value ~status:`Not_found ~request
+      (`Assoc [ ("error", `String "unknown provider dashboard endpoint") ]) reqd
+
 let add_routes ~sw router =
   router
   |> Http.Router.get "/api/v1/providers" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         let json = Server_dashboard_http_runtime_info.runtime_inventory_json () in
-         Http.Response.json_value ~compress:true ~request:req json reqd
-       ) request reqd)
+       with_public_read (handle_public_read ~sw) request reqd)
   |> Http.Router.get "/api/v1/models/metrics" (fun request reqd ->
-       with_public_read (fun state req reqd ->
-         let window = int_query_param req "window" ~default:30 in
-         let bucket_min = int_query_param req "bucket_min" ~default:0 in
-         let base_path = (Mcp_server.workspace_config state).base_path in
-         let key =
-           cache_key
-             [ base_path; string_of_int window; string_of_int bucket_min ]
-         in
-         let json =
-           cached_dashboard_json ~sw ~sync_first:false
-             ~cache:dashboard_model_metrics_cache ~key
-             ~placeholder:(empty_model_metrics_json ~window ~bucket_min)
-             ~compute:(fun () ->
-               let agg =
-                 if bucket_min > 0 then
-                   Model_inference_metrics.compute_with_buckets
-                     ~base_path ~window_minutes:window ~bucket_minutes:bucket_min
-                 else
-                   Model_inference_metrics.compute
-                     ~base_path ~window_minutes:window
-               in
-               Model_inference_metrics.to_json agg)
-         in
-         Http.Response.json_value ~compress:true ~request:req json reqd
-       ) request reqd)
+       with_public_read (handle_public_read ~sw) request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-costs" (fun request reqd ->
-       with_public_read (fun state req reqd ->
-         let window = int_query_param req "window" ~default:1440 in
-         let config = (Mcp_server.workspace_config state) in
-         let key = cache_key [ config.base_path; string_of_int window ] in
-         let json =
-           cached_dashboard_json ~sw ~sync_first:false
-             ~cache:dashboard_keeper_costs_cache ~key
-             ~placeholder:
-               (Dashboard_http_keeper.keeper_cost_aggregates_json ~config
-                  ~keepers:[] ~window_minutes:window)
-             ~compute:(fun () ->
-               let keeper_names = Keeper_meta_store.keeper_names config in
-               let keepers =
-                 List.filter_map (fun name ->
-                   match Keeper_meta_store.read_meta config name with
-                   | Ok (Some m) -> Some m
-                   | _ -> None
-                 ) keeper_names
-               in
-               Dashboard_http_keeper.keeper_cost_aggregates_json ~config
-                 ~keepers ~window_minutes:window)
-         in
-         Http.Response.json_value ~compress:true ~request:req json reqd
-       ) request reqd)
+       with_public_read (handle_public_read ~sw) request reqd)
   |> Http.Router.get "/api/v1/dashboard/cost-latency" (fun request reqd ->
-       with_public_read (fun state req reqd ->
-         let window = int_query_param req "window" ~default:1440 in
-         let base_path = (Mcp_server.workspace_config state).base_path in
-         let json =
-           cached_dashboard_json ~sw ~sync_first:false
-             ~cache:dashboard_cost_latency_cache
-             ~key:(cache_key [ base_path; string_of_int window ])
-             ~placeholder:(empty_cost_latency_json ~window)
-             ~compute:(fun () ->
-               Model_inference_metrics.compute_cost_latency_json
-                 ~base_path ~window_minutes:window)
-         in
-         Http.Response.json_value ~compress:true ~request:req json reqd
-       ) request reqd)
+       with_public_read (handle_public_read ~sw) request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-decisions" (fun request reqd ->
-       with_public_read (fun state req reqd ->
-         let limit = dashboard_feed_limit req in
-         let config = (Mcp_server.workspace_config state) in
-         let key = cache_key [ config.base_path; string_of_int limit ] in
-         let json =
-           cached_dashboard_json ~sw ~sync_first:true
-             ~cache:dashboard_keeper_decisions_cache ~key
-             ~placeholder:
-               (Dashboard_http_keeper.keeper_decisions_json ~config
-                  ~keepers:[] ~limit ())
-             ~compute:(fun () ->
-               let keeper_names = Keeper_meta_store.keeper_names config in
-               let keepers =
-                 List.filter_map (fun name ->
-                   match Keeper_meta_store.read_meta config name with
-                   | Ok (Some m) -> Some m
-                   | _ -> None
-                 ) keeper_names
-               in
-               Dashboard_http_keeper.keeper_decisions_json ~config ~keepers
-                 ~limit ())
-         in
-         Http.Response.json_value ~compress:true ~request:req json reqd
-       ) request reqd)
+       with_public_read (handle_public_read ~sw) request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-decisions-log" (fun request reqd ->
-       with_public_read (fun state req reqd ->
-         let limit = dashboard_feed_limit req in
-         let config = (Mcp_server.workspace_config state) in
-         let key = cache_key [ config.base_path; string_of_int limit ] in
-         let json =
-           cached_dashboard_json ~sw ~sync_first:false
-             ~cache:dashboard_keeper_decisions_log_cache ~key
-             ~placeholder:
-               (Dashboard_http_keeper.keeper_decisions_log_json ~config
-                  ~keepers:[] ~limit ())
-             ~compute:(fun () ->
-               let keeper_names = Keeper_meta_store.keeper_names config in
-               let keepers =
-                 List.filter_map (fun name ->
-                   match Keeper_meta_store.read_meta config name with
-                   | Ok (Some m) -> Some m
-                   | _ -> None
-                 ) keeper_names
-               in
-               Dashboard_http_keeper.keeper_decisions_log_json ~config
-                 ~keepers ~limit ())
-         in
-         Http.Response.json_value ~compress:true ~request:req json reqd
-       ) request reqd)
+       with_public_read (handle_public_read ~sw) request reqd)

--- a/lib/server/server_routes_http_routes_provider_runs.mli
+++ b/lib/server/server_routes_http_routes_provider_runs.mli
@@ -4,6 +4,15 @@
     Wires read-only operator endpoints exposing recent provider run
     samples. Daemon-side fetch fibers are spawned under [~sw]. *)
 
+(** Shared public projection for the provider, cost, and keeper-decision
+    dashboard endpoints. [None] means the request path is outside this
+    route family. *)
+val public_read_json :
+  sw:Eio.Switch.t ->
+  state:Mcp_server.server_state ->
+  Httpun.Request.t ->
+  Yojson.Safe.t option
+
 val add_routes :
   sw:Eio.Switch.t ->
   Http_server_eio.Router.t -> Http_server_eio.Router.t

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -311,6 +311,48 @@ let handle_get_repository_path state req reqd =
           json_response ~status:`Not_found req reqd
             (json_error "unknown repository endpoint"))
 
+(** Read-only repository projection shared with the HTTP/2 gateway. *)
+let public_get_response state request =
+  let base_path = base_path_of_state state in
+  match Http.Request.path request with
+  | "/api/v1/repositories" ->
+    (match Repo_store.load_all ~base_path with
+     | Error message -> `Internal_server_error, json_error message
+     | Ok repositories ->
+       ( `OK
+       , `Assoc
+           [ ( "repositories"
+             , `List (List.map (repository_json ~base_path) repositories) )
+           ; ("total", `Int (List.length repositories))
+           ] ))
+  | path ->
+    (match extract_repo_id path with
+     | None | Some "" ->
+       `Bad_request, json_error "repository id path parameter required"
+     | Some rest ->
+       match path_parts rest with
+       | [ id ] ->
+         (match Repo_store.find ~base_path id with
+          | Error message -> `Not_found, json_error message
+          | Ok repository -> `OK, repository_json ~base_path repository)
+       | [ id; "branches" ] ->
+         (match Repo_store.find ~base_path id with
+          | Error message -> `Not_found, json_error message
+          | Ok repository ->
+            (match Repo_store.list_branches ~base_path id with
+             | Error message -> `Internal_server_error, json_error message
+             | Ok branches ->
+               ( `OK
+               , `Assoc
+                   [ ("repository_id", `String id)
+                   ; ( "branches"
+                     , `List
+                         (List.map
+                            (branch_json ~default_branch:repository.default_branch)
+                            branches) )
+                   ] )))
+       | _ -> `Not_found, json_error "unknown repository endpoint")
+
 let handle_add_repository state _agent_name req reqd =
   let base_path = base_path_of_state state in
   Http.Request.read_body_async reqd (fun body_str ->

--- a/lib/server/server_routes_http_routes_repositories.mli
+++ b/lib/server/server_routes_http_routes_repositories.mli
@@ -14,5 +14,11 @@
 val repository_json :
   base_path:string -> Repo_manager_types.repository -> Yojson.Safe.t
 
+(** Response projection for the public list/detail/branches GET family. *)
+val public_get_response :
+  Mcp_server.server_state ->
+  Httpun.Request.t ->
+  [ `OK | `Bad_request | `Not_found | `Internal_server_error ] * Yojson.Safe.t
+
 val add_routes :
   Http_server_eio.Router.t -> Http_server_eio.Router.t

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -801,6 +801,214 @@ let parse_unified_diff lines =
   in
   go 1 1 [] lines
 
+(* --- Shared public read projection --- *)
+
+type public_read_status =
+  [ `OK | `Bad_request | `Not_found | `Payload_too_large | `Internal_server_error ]
+
+type public_read_response =
+  { status : public_read_status
+  ; body : Yojson.Safe.t
+  ; extra_headers : (string * string) list
+  }
+
+let public_read_response ?(extra_headers = []) status body =
+  { status; body; extra_headers }
+
+let source_and_base_headers ~source ~base_path =
+  ("X-Workspace-Base-Path", sanitize_header_value base_path) :: source_header source
+
+(** The JSON/header producing half of the public workspace tree, child, and
+    file endpoints.  H2 uses this projection to mirror the established H1
+    read surface with its own response writer. *)
+let workspace_public_read_response ~state request =
+  let uri = Uri.of_string request.target in
+  let base, source = resolve_workspace_base ~state ~uri in
+  match Http.Request.path request with
+  | "/api/v1/workspace/tree" ->
+    let depth =
+      match Uri.get_query_param uri "depth" with
+      | Some raw ->
+        (match int_of_string_opt raw with
+         | Some value -> max 1 (min 5 value)
+         | None -> 3)
+      | None -> 3
+    in
+    let max_nodes = tree_node_limit_of_query (Uri.get_query_param uri "limit") in
+    let include_diff = bool_query_param request "diff" ~default:false in
+    let effective_depth, effective_max_nodes =
+      match source with
+      | `Project
+      | `RepositoryMissing _
+      | `RepositoryUnknown _
+      | `PlaygroundMissing _
+      | `KeeperUnknown _ -> 0, min max_nodes 200
+      | `Repository _ | `Playground _ -> depth, max_nodes
+    in
+    let cache_key =
+      Printf.sprintf "workspace:tree:%s:%s:%d:%d:%b"
+        base (source_to_string source) effective_depth effective_max_nodes include_diff
+    in
+    let body =
+      Dashboard_cache.get_or_compute cache_key
+        ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s
+        (fun () ->
+           Domain_pool_ref.submit_io_or_inline (fun () ->
+             let nodes =
+               if not (Sys.file_exists base) then []
+               else
+                 let diff_by_path =
+                   if include_diff then Some (git_diff_badges ~base) else None
+                 in
+                 scan_dir ?diff_by_path ~base ~depth:0
+                   ~max_depth:effective_depth ~max_nodes:effective_max_nodes [] base
+             in
+             `List (List.rev nodes)))
+    in
+    Some
+      (public_read_response
+         ~extra_headers:(source_and_base_headers ~source ~base_path:base)
+         `OK body)
+  | "/api/v1/workspace/children" ->
+    (match Uri.get_query_param uri "path" with
+     | None -> Some (public_read_response `Bad_request (json_error "Missing path parameter"))
+     | Some requested ->
+       (match resolve_workspace_file base requested with
+        | Error _ -> Some (public_read_response `Bad_request (json_error "Invalid path"))
+        | Ok file ->
+          let max_nodes = tree_node_limit_of_query (Uri.get_query_param uri "limit") in
+          let child_depth =
+            rel_under base file.lexical_path
+            |> String.split_on_char '/'
+            |> List.filter (fun value -> not (String.equal value ""))
+            |> List.length
+          in
+          let cache_key =
+            Printf.sprintf "workspace:children:%s:%s:%d:%d"
+              base file.lexical_path child_depth max_nodes
+          in
+          let body =
+            Dashboard_cache.get_or_compute cache_key
+              ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s
+              (fun () ->
+                 Domain_pool_ref.submit_io_or_inline (fun () ->
+                   let is_dir =
+                     workspace_or_default ~warn_on_failure:false
+                       ~site:"children_is_directory" ~path:file.lexical_path
+                       ~default:false (fun () -> Sys.is_directory file.lexical_path)
+                   in
+                   if not is_dir then `List []
+                   else
+                     let nodes =
+                       scan_dir ~base ~depth:child_depth ~max_depth:child_depth
+                         ~max_nodes [] file.lexical_path
+                     in
+                     `List (List.rev nodes)))
+          in
+          Some
+            (public_read_response
+               ~extra_headers:(source_and_base_headers ~source ~base_path:base)
+               `OK body)))
+  | "/api/v1/workspace/file" ->
+    (match Uri.get_query_param uri "path" with
+     | None -> Some (public_read_response `Bad_request (json_error "Missing path parameter"))
+     | Some path ->
+       (match resolve_workspace_file base path with
+        | Error _ -> Some (public_read_response `Bad_request (json_error "Invalid path"))
+        | Ok file ->
+          (match load_workspace_file_content file with
+           | Ok content ->
+             Some
+               (public_read_response ~extra_headers:(source_header source) `OK
+                  (`Assoc [ ("ok", `Bool true); ("content", `String content) ]))
+           | Error File_not_found | Error File_not_regular ->
+             Some (public_read_response `Not_found (json_error "File not found"))
+           | Error File_changed_during_open ->
+             Some (public_read_response `Bad_request (json_error "Invalid path"))
+           | Error (File_too_large _) ->
+             Some (public_read_response `Payload_too_large (json_error "File too large"))
+           | Error (File_read_failed message) ->
+             observe_workspace_route_failure ~site:"file_read" ~path:file.lexical_path
+               (Failure message);
+             Some
+               (public_read_response `Internal_server_error
+                  (json_error "Failed to read file")))))
+  | "/api/v1/git/blame" ->
+    (match Uri.get_query_param uri "path" with
+     | None | Some "" ->
+       Some (public_read_response `Bad_request (json_error "Missing path parameter"))
+     | Some file_path ->
+       (match resolve_workspace_file base file_path with
+        | Error _ -> Some (public_read_response `Bad_request (json_error "Invalid path"))
+        | Ok safe ->
+          if not (Sys.file_exists safe.resolved_path) then
+            Some (public_read_response `Not_found (json_error "File not found"))
+          else
+            let rel = rel_under base safe.lexical_path in
+            let cache_key =
+              Printf.sprintf "git:blame:%s:%s:%s"
+                base (source_to_string source) rel
+            in
+            let body =
+              Dashboard_cache.get_or_compute cache_key
+                ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s
+                (fun () ->
+                   Domain_pool_ref.submit_io_or_inline (fun () ->
+                     match git_run_lines ~cwd:base [ "blame"; "--porcelain"; "--"; rel ] with
+                     | [] -> `List []
+                     | lines ->
+                       let entries = parse_blame_porcelain lines in
+                       `List (group_blame_entries rel entries)))
+            in
+            Some
+              (public_read_response ~extra_headers:(source_header source) `OK body)))
+  | "/api/v1/git/diff" ->
+    (match Uri.get_query_param uri "path" with
+     | None | Some "" ->
+       Some (public_read_response `Bad_request (json_error "Missing path parameter"))
+     | Some file_path ->
+       let base_ref =
+         match Uri.get_query_param uri "base_ref" with
+         | Some value -> value
+         | None -> "HEAD"
+       in
+       if not (valid_git_ref base_ref) then
+         Some (public_read_response `Bad_request (json_error "Invalid base_ref"))
+       else
+         (match resolve_workspace_file base file_path with
+          | Error _ -> Some (public_read_response `Bad_request (json_error "Invalid path"))
+          | Ok safe ->
+            let rel = rel_under base safe.lexical_path in
+            let cache_key =
+              Printf.sprintf "git:diff:%s:%s:%s:%s"
+                base (source_to_string source) base_ref rel
+            in
+            let result =
+              Dashboard_cache.get_or_compute cache_key
+                ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s
+                (fun () ->
+                   Domain_pool_ref.submit_io_or_inline (fun () ->
+                     match git_run_lines_or_error ~cwd:base [ "diff"; base_ref; "--"; rel ] with
+                     | Error _ ->
+                       observe_workspace_route_failure ~site:"git_run" ~path:rel
+                         (Failure "git diff failed");
+                       `Null
+                     | Ok [] ->
+                       `Assoc [ "unified", `List []; "has_changes", `Bool false ]
+                     | Ok diff_lines ->
+                       `Assoc
+                         [ "unified", `List (parse_unified_diff diff_lines)
+                         ; "has_changes", `Bool true
+                         ]))
+            in
+            (match result with
+             | `Null ->
+               Some (public_read_response `Bad_request (json_error "git diff failed"))
+             | body ->
+               Some
+                 (public_read_response ~extra_headers:(source_header source) `OK body))))
+  | _ -> None
+
 (* --- Routes --- *)
 
 let add_routes router =

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -2,6 +2,22 @@ module Http = Http_server_eio
 
 val add_routes : Http.Router.t -> Http.Router.t
 
+(** Transport-neutral projection for the public tree, children, file, Git
+    blame, and Git diff workspace routes. *)
+type public_read_status =
+  [ `OK | `Bad_request | `Not_found | `Payload_too_large | `Internal_server_error ]
+
+type public_read_response =
+  { status : public_read_status
+  ; body : Yojson.Safe.t
+  ; extra_headers : (string * string) list
+  }
+
+val workspace_public_read_response :
+  state:Mcp_server.server_state ->
+  Httpun.Request.t ->
+  public_read_response option
+
 (** Pure dispatch logic for the [?keeper=<name>] query param. Exposed
     for unit testing — production code goes through {!add_routes}. *)
 val classify_keeper_query :

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -786,6 +786,17 @@ let test_delete_allows_owner () =
     | Error msg -> failf "owner delete failed: %s" msg)
 ;;
 
+let test_delete_any_removes_foreign_annotation_for_public_lane () =
+  with_temp_dir (fun base_dir ->
+    let created = make_alice_annotation base_dir in
+    (match Store.delete_any ~base_dir ~id:created.id () with
+     | Ok () -> ()
+     | Error msg -> failf "public delete failed: %s" msg);
+    let listed = Store.list ~base_dir ~filter:(make_filter ()) () in
+    check bool "public delete tombstones the annotation" false
+      (List.exists (fun (annotation : Types.annotation) -> annotation.id = created.id) listed))
+;;
+
 (* task-1744: tombstoned annotations must be excluded from load/list.
 
    Before the fix, [load_all_partition] only skipped the tombstone marker
@@ -1093,6 +1104,12 @@ let () =
             `Quick
             test_delete_rejects_other_keeper
         ; test_case "owner can delete own annotation" `Quick test_delete_allows_owner
+        ] )
+    ; ( "public mutation projection"
+      , [ test_case
+            "delete_any removes a foreign annotation"
+            `Quick
+            test_delete_any_removes_foreign_annotation_for_public_lane
         ] )
     ; ( "tombstone read (task-1744)"
       , [ test_case

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -603,18 +603,18 @@ let test_ws_upgrade_allows_authenticated_cross_origin () =
       failf "expected authenticated cross-origin upgrade to pass, got %s"
         (Masc_domain.masc_error_to_string err))
 
-(* The routes below are guarded on H1 and must stay outside the public-read
-   allowlist. This is the invariant the H2 fix rests on: adding any of these
-   paths to [is_public_read_path] would open them on BOTH transports, and the
-   wrapper parity asserted in the next test would then prove nothing. *)
-let test_transport_guarded_paths_are_not_public_read () =
+(* [is_public_read_path] is still used by observer-stream admission.  A route
+   with the unconditional read gate must remain outside that allowlist; route
+   handlers that deliberately call [with_public_read] are public by their
+   wrapper, not by this legacy list. *)
+let test_unconditionally_guarded_paths_are_not_public_read () =
   List.iter
     (fun path ->
       check bool
         (Printf.sprintf "%s is not public-read" path)
         false
         (Server_auth.is_public_read_path path))
-    [ "/graphql"; "/api/v1/dashboard/workspace"; "/api/v1/status" ]
+    [ "/graphql" ]
 
 (* serve_auto hands h2c connections to Server_h2_gateway and everything else to
    the HTTP/1 router, so a route's authorization is decided independently on
@@ -622,13 +622,16 @@ let test_transport_guarded_paths_are_not_public_read () =
    answered 401, because the H2 arm used [with_server_state] — which fetches
    server state and authorizes nothing.
 
-   [with_h2_public_read] is not a substitute for [with_h2_read_auth]: it first
-   requires [http_auth_strict_enabled] and a non-public path, whereas H1's
-   [with_read_auth] authorizes unconditionally. Each H2 arm must name the
-   counterpart of the wrapper its H1 route uses. *)
+   [with_h2_public_read] is the H2 counterpart of H1's route-local public
+   read surface.  [with_h2_read_auth] remains the unconditional authenticated
+   gate for routes such as GraphQL. *)
 let test_h1_h2_read_gate_wiring_parity () =
+  let auth = source_file "lib/server/server_auth.ml" in
   let h1_frontend = source_file "lib/server/server_routes_http_routes_frontend.ml" in
   let h2 = source_file "lib/server/server_h2_gateway.ml" in
+  assert_contains "H1 public-read wrapper does not reapply strict auth"
+    ~needle:"let rec with_public_read handler request reqd =\n  let path = Http_server_eio.Request.path request in\n  (* A route reaches this wrapper only after opting into the public-read"
+    auth;
   assert_contains "H1 guards /graphql with the unconditional read gate"
     ~needle:{|~path:"/graphql" ~methods:[`GET; `POST]|}
     h1_frontend;
@@ -644,12 +647,128 @@ let test_h1_h2_read_gate_wiring_parity () =
   assert_contains "H2 dashboard workspace mirrors H1 with_public_read"
     ~needle:"| `GET, \"/api/v1/dashboard/workspace\" ->\n          with_h2_public_read h2_reqd"
     h2;
-  assert_contains "H2 status mirrors H1 with_public_read"
-    ~needle:"| `GET, \"/api/v1/status\" ->\n          with_h2_public_read h2_reqd" h2;
+  assert_contains "H2 status is in the shared IDE public-read route group"
+    ~needle:"| \"/api/v1/status\"\n        | \"/api/v1/ide/annotations\"" h2;
+  assert_contains "H2 observation snapshot remains available before state init"
+    ~needle:"| `GET, \"/api/v1/ide/observations/snapshot\" ->\n          h2_respond_ide_public_read"
+    h2;
+  assert_contains "H2 shared IDE public-read route group uses the public wrapper"
+    ~needle:"| \"/api/v1/ide/memory\" ) ->\n          with_h2_public_read h2_reqd" h2;
+  assert_contains "H2 public-read wrapper does not reapply strict auth"
+    ~needle:"      with_initialized_state f\n    in\n    let h2_respond_ide_public_read response ="
+    h2;
   (* [with_server_state] performs no authorization; no read route may reach it
      directly. The arms that still call it (webrtc, MCP) authorize inside. *)
   assert_not_contains "H2 /graphql no longer reads state without authorizing"
     ~needle:"with_h2_read_auth h2_reqd (fun _state ->\n            with_server_state" h2
+
+let test_h1_h2_ide_public_feature_projection_wiring () =
+  let h1 = source_file "lib/server/server_ide_http.ml" in
+  let h2 = source_file "lib/server/server_h2_gateway.ml" in
+  assert_contains "H1 IDE public reads use the route-local public wrapper"
+    ~needle:"let public_read_handler request reqd =\n  with_public_read" h1;
+  assert_contains "H2 delegates IDE reads to the H1 projection"
+    ~needle:"Server_ide_http.public_read_response ~state httpun_request" h2;
+  List.iter
+    (fun path ->
+       assert_contains ("H1 exposes " ^ path) ~needle:(Printf.sprintf "%S" path) h1;
+       assert_contains ("H2 exposes " ^ path) ~needle:(Printf.sprintf "%S" path) h2)
+    [ "/api/v1/ide/observations/snapshot"
+    ; "/api/v1/agents"
+    ; "/api/v1/status"
+    ; "/api/v1/ide/annotations"
+    ; "/api/v1/ide/regions"
+    ; "/api/v1/ide/events"
+    ; "/api/v1/ide/presence"
+    ; "/api/v1/ide/cursors"
+    ; "/api/v1/ide/memory"
+    ];
+  assert_contains "H1 annotation creation uses the public feature wrapper"
+    ~needle:"|> Http.Router.post \"/api/v1/ide/annotations\" (fun request reqd ->\n    (* Public feature lane: browser annotation creation cannot depend on a\n       token, selected keeper, or selected repository. *)\n    with_public_read"
+    h1;
+  assert_contains "H1 annotation deletion uses the public feature wrapper"
+    ~needle:"|> Http.Router.prefix_delete \"/api/v1/ide/annotations/\" (fun request reqd ->\n    (* Public feature lane: an annotation can be removed by id without\n       reconstructing a browser identity. *)\n    with_public_read"
+    h1;
+  assert_contains "H1 cursor creation uses the public feature wrapper"
+    ~needle:"|> Http.Router.post \"/api/v1/ide/cursors\" (fun request reqd ->\n    (* Public feature lane: a cursor is live observation data, so publish it\n       even when browser identity/bootstrap has not completed. *)\n    with_public_read"
+    h1;
+  assert_contains "H2 annotation creation uses the shared public projection"
+    ~needle:"| `POST, \"/api/v1/ide/annotations\" ->\n          with_h2_public_read h2_reqd"
+    h2;
+  assert_contains "H2 annotation deletion uses the shared public projection"
+    ~needle:"when String.starts_with ~prefix:\"/api/v1/ide/annotations/\" path ->\n          with_h2_public_read h2_reqd"
+    h2;
+  assert_contains "H2 cursor creation uses the shared public projection"
+    ~needle:"| `POST, \"/api/v1/ide/cursors\" ->\n          with_h2_public_read h2_reqd"
+    h2
+
+let test_h1_h2_dashboard_public_read_route_wiring () =
+  let h1 =
+    String.concat "\n"
+      [ source_file "lib/server/server_routes_http_routes_dashboard.ml"
+      ; source_file "lib/server/server_routes_http_routes_provider_runs.ml"
+      ; source_file "lib/server/server_dashboard_http_agent_api.ml"
+      ; source_file "lib/server/server_routes_http_routes_attribution.ml"
+      ; source_file "lib/server/server_routes_http_routes_verification.ml"
+      ]
+  in
+  let h2 = source_file "lib/server/server_h2_gateway.ml" in
+  let keeper_api = source_file "lib/server/server_dashboard_http_keeper_api.ml" in
+  let keeper_api_types = source_file "lib/server/server_dashboard_http_keeper_api_types.ml" in
+  List.iter
+    (fun path ->
+       assert_contains ("H1 exposes " ^ path) ~needle:(Printf.sprintf "%S" path) h1;
+       assert_contains ("H2 exposes " ^ path) ~needle:(Printf.sprintf "%S" path) h2)
+    [ "/api/v1/dashboard/fusion-runs"
+    ; "/api/v1/dashboard/runtime-defaults"
+    ; "/api/v1/dashboard/logs"
+    ; "/api/v1/dashboard/tool-quality"
+    ; "/api/v1/dashboard/telemetry"
+    ; "/api/v1/operator"
+    ; "/api/v1/agent-timeline"
+    ; "/api/v1/attribution/recent"
+    ; "/api/v1/verification/requests"
+    ];
+  assert_contains "H2 dashboard telemetry shares the H1 projection"
+    ~needle:"dashboard_telemetry_projection ~state httpun_request" h2;
+  assert_contains "H2 public dashboard reads stay on the route-local wrapper"
+    ~needle:"| `GET, \"/api/v1/dashboard/fusion-runs\" ->\n          with_h2_public_read h2_reqd"
+    h2;
+  assert_contains "H2 keeper detail reads delegate to the public projection"
+    ~needle:"Server_dashboard_http_keeper_api.public_get_response_for_request"
+    h2;
+  assert_contains "H1 dashboard controls use the feature-first actor"
+    ~needle:"let dashboard_feature_actor = \"dashboard\""
+    h1;
+  assert_contains "H2 token-bound dashboard controls use the feature-first actor"
+    ~needle:"with_h2_public_read h2_reqd (fun state -> f state \"dashboard\")"
+    h2;
+  List.iter
+    (fun path ->
+       assert_contains ("H2 workspace projection includes " ^ path)
+         ~needle:(Printf.sprintf "%S" path) h2)
+    [ "/api/v1/git/blame"; "/api/v1/git/diff" ];
+  List.iter
+    (fun suffix ->
+       assert_contains ("keeper public projection includes " ^ suffix)
+         ~needle:(Printf.sprintf "%S" suffix) keeper_api)
+    [ "/checkpoints"
+    ; "/raw-traces"
+    ; "/raw-trace"
+    ; "/memory-journal"
+    ; "/tool-stats"
+    ; "/tool-calls"
+    ; "/turn-records"
+    ];
+  assert_contains "keeper GETs stay on the feature-first public lane"
+    ~needle:"let keeper_get_permission _req_path = None"
+    keeper_api_types;
+  assert_contains "keeper public projection shares bounded tool stats JSON"
+    ~needle:"keeper_tool_stats_json ~config ~name ~window_hours" keeper_api;
+  assert_contains "keeper public projection shares bounded tool call JSON"
+    ~needle:"keeper_tool_calls_json ~config ~name ~limit" keeper_api;
+  assert_contains "keeper public projection shares turn record JSON"
+    ~needle:"keeper_turn_records_json ~config ~name ~limit" keeper_api
 
 let () =
   Eio_main.run @@ fun env ->
@@ -686,10 +805,14 @@ let () =
             test_h1_h2_delete_route_wiring_parity;
           test_case "H2 OAuth routes preserve admitted authority" `Quick
             test_h2_oauth_route_and_authority_lifetime;
-          test_case "transport-guarded paths are not public-read" `Quick
-            test_transport_guarded_paths_are_not_public_read;
+          test_case "unconditionally guarded paths are not public-read" `Quick
+            test_unconditionally_guarded_paths_are_not_public_read;
           test_case "H1/H2 read gate wiring parity" `Quick
             test_h1_h2_read_gate_wiring_parity;
+          test_case "H1/H2 IDE public feature projection wiring" `Quick
+            test_h1_h2_ide_public_feature_projection_wiring;
+          test_case "H1/H2 dashboard public-read route wiring" `Quick
+            test_h1_h2_dashboard_public_read_route_wiring;
         ] );
       ( "ws-upgrade-admission",
         [

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -1,10 +1,8 @@
 (** Black-box HTTP/router tests for [Server_ide_http].
 
-    These tests exercise the public route table and actual response
-    statuses rather than relying on [Server_ide_http.For_testing]
-    helpers. They guard the security contract from task-1736 B3:
-    mutation routes require a bearer token, reject a client-supplied
-    [keeper_id], and return the expected status codes. *)
+    These tests exercise the public route table and actual response statuses
+    rather than relying on private helpers. The IDE observation feature must
+    work before token, keeper, or repository selection has converged. *)
 
 open Alcotest
 
@@ -41,10 +39,19 @@ let test_post_cursors_route_is_registered () =
 
 let test_read_routes_stay_public () =
   let router = Server_ide_http.add_routes (Http.Router.create ()) in
-  check bool "GET /api/v1/ide/annotations" true
-    (has_route `GET "/api/v1/ide/annotations" router);
-  check bool "GET /api/v1/ide/cursors" true
-    (has_route `GET "/api/v1/ide/cursors" router)
+  List.iter
+    (fun path ->
+       check bool ("GET " ^ path) true (has_route `GET path router))
+    [ "/api/v1/ide/observations/snapshot"
+    ; "/api/v1/agents"
+    ; "/api/v1/status"
+    ; "/api/v1/ide/annotations"
+    ; "/api/v1/ide/regions"
+    ; "/api/v1/ide/events"
+    ; "/api/v1/ide/presence"
+    ; "/api/v1/ide/cursors"
+    ; "/api/v1/ide/memory"
+    ]
 ;;
 
 (* ── End-to-end request/response harness ─────────────────────────────── *)
@@ -421,15 +428,18 @@ let test_presence_last_seen_ms_shared_projection () =
     (Server_presence.last_seen_ms ~context:"test presence" invalid)
 ;;
 
-let test_post_annotations_rejects_client_keeper_id () =
-  with_ide_server (fun ~base_path ~state:_ ~router ->
-    let token = create_worker_token base_path "alice" in
+let test_post_annotations_accepts_client_keeper_id_without_auth () =
+  with_ide_server (fun ~base_path:_ ~state:_ ~router ->
     let body =
       {|{"file_path":"lib/a.ml","line_start":1,"line_end":2,"content":"note","keeper_id":"bob"}|}
     in
-    let request = http_request ~meth:`POST ~path:"/api/v1/ide/annotations" ~body ~token:(Some token) () in
+    let request = http_request ~meth:`POST ~path:"/api/v1/ide/annotations" ~body () in
     let response = dispatch router request in
-    check_status "POST with keeper_id returns 403" 403 response)
+    check_status "POST with keeper_id returns 201" 201 response;
+    let json = response |> response_body |> Yojson.Safe.from_string in
+    let annotation = Json.member "data" json in
+    check string "client keeper id is retained" "bob"
+      (json_string_member "created annotation" "keeper_id" annotation))
 ;;
 
 let test_post_annotations_rejects_unknown_route_fields () =
@@ -459,13 +469,12 @@ let test_post_annotations_rejects_unknown_route_fields () =
       (error_code_of_response response))
 ;;
 
-let test_post_cursors_rejects_client_keeper_id () =
-  with_ide_server (fun ~base_path ~state:_ ~router ->
-    let token = create_worker_token base_path "alice" in
+let test_post_cursors_accepts_client_keeper_id_without_auth () =
+  with_ide_server (fun ~base_path:_ ~state:_ ~router ->
     let body = {|{"file_path":"lib/a.ml","line":1,"keeper_id":"bob"}|} in
-    let request = http_request ~meth:`POST ~path:"/api/v1/ide/cursors" ~body ~token:(Some token) () in
+    let request = http_request ~meth:`POST ~path:"/api/v1/ide/cursors" ~body () in
     let response = dispatch router request in
-    check_status "POST cursor with keeper_id returns 403" 403 response)
+    check_status "POST cursor with keeper_id returns 201" 201 response)
 ;;
 
 let test_post_cursors_rejects_invalid_focus_mode () =
@@ -626,16 +635,7 @@ let test_post_cursors_honors_canonical_url_scope () =
     check_status "POST cursor with canonical_url scope returns 201" 201 post_response;
     let unscoped_request = http_request ~meth:`GET ~path:"/api/v1/ide/cursors" () in
     let unscoped_response = dispatch router unscoped_request in
-    check
-      int
-      "GET unscoped cursors rejects missing scope"
-      400
-      (status_of_response unscoped_response);
-    check
-      string
-      "GET unscoped cursors error code"
-      "missing_ide_scope"
-      (error_code_of_response unscoped_response);
+    check_status "GET unscoped cursors uses the default scope" 200 unscoped_response;
     let scoped_request = http_request ~meth:`GET ~path:scoped_path () in
     let scoped_response = dispatch router scoped_request in
     check_status "GET scoped cursors succeeds" 200 scoped_response;
@@ -679,13 +679,12 @@ let test_post_cursors_resolves_partition_from_file_path () =
     | [] -> fail "expected file_path-resolved cursor")
 ;;
 
-let test_post_cursors_rejects_file_path_scope_mismatch () =
+let test_post_cursors_uses_file_path_partition_over_stale_scope () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     let _masc_path, agent_core_path = seed_annotation_scope_repos base_path in
     let token = create_worker_token base_path "alice" in
-    (* POST cursor with a file_path that belongs to a different repo than the
-       requested canonical_url scope: the server must reject it (task-1733)
-       instead of silently writing to the wrong partition. *)
+    (* The file path is current evidence; a stale picker must not prevent a
+       cursor event from reaching the repository it actually belongs to. *)
     let file_path = Filename.concat agent_core_path "lib/a.ml" in
     let body =
       Yojson.Safe.to_string
@@ -698,17 +697,19 @@ let test_post_cursors_rejects_file_path_scope_mismatch () =
       http_request ~meth:`POST ~path:scoped_path ~body ~token:(Some token) ()
     in
     let post_response = dispatch router post_request in
-    check_status "POST cursor with mismatched file_path returns 400" 400 post_response;
-    check
-      string
-      "file_path scope mismatch error"
-      "file_path does not belong to requested canonical_url"
-      (error_message_of_response post_response);
-    check
-      string
-      "file_path scope mismatch code"
-      "canonical_url_mismatch"
-      (error_code_of_response post_response))
+    check_status "POST cursor with stale scope returns 201" 201 post_response;
+    let actual_repo_request =
+      http_request ~meth:`GET ~path:"/api/v1/ide/cursors?repo_id=agent_core" ()
+    in
+    let actual_repo_response = dispatch router actual_repo_request in
+    check_status "GET actual cursor partition succeeds" 200 actual_repo_response;
+    let json = actual_repo_response |> response_body |> Yojson.Safe.from_string in
+    let data = Json.member "data" json in
+    match json_list_member "actual cursor snapshot" "cursors" data with
+    | cursor :: _ ->
+      check string "cursor follows file path" "lib/a.ml"
+        (json_string_member "cursor" "file_path" cursor)
+    | [] -> fail "expected cursor in actual repository partition")
 ;;
 
 let test_post_annotations_accepts_matching_repo_scope () =
@@ -738,7 +739,7 @@ let test_post_annotations_accepts_matching_repo_scope () =
       (annotation_count router "/api/v1/ide/annotations?repo_id=agent_core"))
 ;;
 
-let test_post_annotations_rejects_repo_scope_mismatch () =
+let test_post_annotations_uses_file_path_partition_over_stale_repo_scope () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     let _masc_path, agent_core_path = seed_annotation_scope_repos base_path in
     let token = create_worker_token base_path "alice" in
@@ -752,30 +753,20 @@ let test_post_annotations_rejects_repo_scope_mismatch () =
         ()
     in
     let response = dispatch router request in
-    check_status "POST annotation with mismatched repo_id returns 400" 400 response;
-    check
-      string
-      "repo scope mismatch error"
-      "file_path does not belong to requested repo_id"
-      (error_message_of_response response);
-    check
-      string
-      "repo scope mismatch code"
-      "repo_mismatch"
-      (error_code_of_response response);
+    check_status "POST annotation with stale repo_id returns 201" 201 response;
     check
       int
-      "mismatched annotation is not written to requested partition"
+      "stale repo partition remains empty"
       0
       (annotation_count router "/api/v1/ide/annotations?repo_id=masc");
     check
       int
-      "mismatched annotation is not written to actual partition"
-      0
+      "annotation follows file path to actual partition"
+      1
       (annotation_count router "/api/v1/ide/annotations?repo_id=agent_core"))
 ;;
 
-let test_post_annotations_rejects_canonical_scope_mismatch () =
+let test_post_annotations_uses_file_path_partition_over_stale_canonical_scope () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     let _masc_path, agent_core_path = seed_annotation_scope_repos base_path in
     let token = create_worker_token base_path "alice" in
@@ -793,80 +784,104 @@ let test_post_annotations_rejects_canonical_scope_mismatch () =
         ()
     in
     let response = dispatch router request in
-    check_status "POST annotation with mismatched canonical_url returns 400" 400 response;
+    check_status "POST annotation with stale canonical_url returns 201" 201 response;
     check
-      string
-      "canonical scope mismatch error"
-      "file_path does not belong to requested canonical_url"
-      (error_message_of_response response);
+      int
+      "stale canonical partition remains empty"
+      0
+      (annotation_count router "/api/v1/ide/annotations?repo_id=masc");
     check
-      string
-      "canonical scope mismatch code"
-      "canonical_url_mismatch"
-      (error_code_of_response response))
+      int
+      "annotation follows file path despite stale canonical scope"
+      1
+      (annotation_count router "/api/v1/ide/annotations?repo_id=agent_core"))
 ;;
 
-let test_post_annotations_requires_auth () =
+let test_post_annotations_works_without_auth () =
   with_ide_server (fun ~base_path:_ ~state:_ ~router ->
     let body = {|{"file_path":"lib/a.ml","line_start":1,"line_end":2,"content":"note"}|} in
     let request = http_request ~meth:`POST ~path:"/api/v1/ide/annotations" ~body () in
     let response = dispatch router request in
-    check int "POST without token returns 401/403" 401 (status_of_response response))
+    check_status "POST without token returns 201" 201 response;
+    let json = response |> response_body |> Yojson.Safe.from_string in
+    let annotation = Json.member "data" json in
+    check string "unauthenticated annotation uses dashboard identity" "dashboard"
+      (json_string_member "public annotation" "keeper_id" annotation))
 ;;
 
-let test_delete_annotation_requires_auth () =
-  with_ide_server (fun ~base_path:_ ~state:_ ~router ->
-    let request = http_request ~meth:`DELETE ~path:"/api/v1/ide/annotations/ann-1" () in
+let test_delete_annotation_works_without_auth_or_owner () =
+  with_ide_server (fun ~base_path ~state:_ ~router ->
+    let annotation =
+      match
+        Ide_annotations.create
+          ~base_dir:base_path
+          ~keeper_id:"alice"
+          ~file_path:"lib/a.ml"
+          ~line_start:1
+          ~line_end:1
+          ~kind:Ide_annotation_types.Comment
+          ~content:"delete me"
+          ()
+      with
+      | Ok annotation -> annotation
+      | Error msg -> failf "seed annotation for public delete failed: %s" msg
+    in
+    let request =
+      http_request
+        ~meth:`DELETE
+        ~path:("/api/v1/ide/annotations/" ^ annotation.id)
+        ()
+    in
     let response = dispatch router request in
-    check int "DELETE without token returns 401/403" 401 (status_of_response response))
+    check_status "DELETE without token returns 204" 204 response)
 ;;
 
-let test_read_annotations_rejects_missing_scope () =
-  with_ide_server (fun ~base_path:_ ~state:_ ~router ->
+let test_read_annotations_uses_default_scope () =
+  with_ide_server (fun ~base_path ~state:_ ~router ->
+    (match
+       Ide_annotations.create
+         ~base_dir:base_path
+         ~partition:Ide_paths.Legacy_default
+         ~keeper_id:"alice"
+         ~file_path:"lib/default.ml"
+         ~line_start:1
+         ~line_end:1
+         ~kind:Ide_annotation_types.Comment
+         ~content:"default scope annotation"
+         ()
+     with
+     | Ok _ -> ()
+     | Error msg -> failf "create default annotation failed: %s" msg);
     let request = http_request ~meth:`GET ~path:"/api/v1/ide/annotations" () in
     let response = dispatch router request in
-    check_status "GET annotations without scope returns 400" 400 response;
-    check
-      string
-      "missing scope error"
-      "IDE scope is required; pass repo_id, canonical_url, or keeper_lane"
-      (error_message_of_response response);
-    check
-      string
-      "missing scope code"
-      "missing_ide_scope"
-      (error_code_of_response response))
+    check_status "GET annotations without scope uses default scope" 200 response;
+    let json = response |> response_body |> Yojson.Safe.from_string in
+    match json_list_member "default annotations" "data" json with
+    | annotation :: _ ->
+      check string "default annotation content" "default scope annotation"
+        (json_string_member "default annotation" "content" annotation)
+    | [] -> fail "expected default-scope annotation")
 ;;
 
-let test_read_cursors_rejects_unmatched_repo_scope () =
+let test_read_cursors_falls_back_from_unmatched_repo_scope () =
   with_ide_server (fun ~base_path:_ ~state:_ ~router ->
     let request =
       http_request ~meth:`GET ~path:"/api/v1/ide/cursors?repo_id=missing-repo" ()
     in
     let response = dispatch router request in
-    check_status "GET cursors with unmatched repo_id returns 400" 400 response;
-    check
-      string
-      "unmatched repo error code"
-      "unmatched_repo_id"
-      (error_code_of_response response))
+    check_status "GET cursors with unmatched repo_id falls back" 200 response)
 ;;
 
-let test_get_events_rejects_invalid_canonical_scope () =
+let test_get_events_falls_back_from_invalid_canonical_scope () =
   with_ide_server (fun ~base_path:_ ~state:_ ~router ->
     let request =
       http_request ~meth:`GET ~path:"/api/v1/ide/events?canonical_url=not-a-url" ()
     in
     let response = dispatch router request in
-    check_status "GET events with invalid canonical_url returns 400" 400 response;
-    check
-      string
-      "invalid canonical_url code"
-      "invalid_canonical_url"
-      (error_code_of_response response))
+    check_status "GET events with invalid canonical_url falls back" 200 response)
 ;;
 
-let test_post_annotations_rejects_missing_scope () =
+let test_post_annotations_uses_default_scope () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     let token = create_worker_token base_path "alice" in
     let body = annotation_body ~file_path:"lib/a.ml" in
@@ -879,12 +894,9 @@ let test_post_annotations_rejects_missing_scope () =
         ()
     in
     let response = dispatch router request in
-    check_status "POST annotation without scope returns 400" 400 response;
-    check
-      string
-      "POST annotation missing scope code"
-      "missing_ide_scope"
-      (error_code_of_response response))
+    check_status "POST annotation without scope uses default scope" 201 response;
+    check int "default scope stores annotation" 1
+      (annotation_count router "/api/v1/ide/annotations"))
 ;;
 
 let test_memory_response_declares_annotation_source_contract () =
@@ -965,16 +977,10 @@ let test_memory_response_honors_canonical_url_scope () =
       http_request ~meth:`GET ~path:"/api/v1/ide/memory?keeper_id=alice" ()
     in
     let unscoped_response = dispatch router unscoped_request in
-    check
-      int
-      "GET unscoped memory rejects missing scope"
-      400
-      (status_of_response unscoped_response);
-    check
-      string
-      "GET unscoped memory error code"
-      "missing_ide_scope"
-      (error_code_of_response unscoped_response);
+    check_status "GET unscoped memory uses the default scope" 200 unscoped_response;
+    let unscoped_json = unscoped_response |> response_body |> Yojson.Safe.from_string in
+    check int "default memory does not leak canonical scope" 0
+      (List.length (json_list_member "default memory" "entries" unscoped_json));
     let scoped_path = scoped_ide_path "/api/v1/ide/memory?keeper_id=alice" in
     let scoped_request = http_request ~meth:`GET ~path:scoped_path () in
     let scoped_response = dispatch router scoped_request in
@@ -992,10 +998,9 @@ let test_memory_response_honors_canonical_url_scope () =
 
 (* ── keeper-lane scope ───────────────────────────────────────────────
    Turn/coordination events carry no file, so keepers write them to the
-   repo-unattributed lane bucket ([Ide_paths.Legacy_default]). These tests
-   pin the read contract: [?keeper_lane=<id>] reads that bucket filtered
-   to the lane keeper, conflicts with repo scopes, and never authorizes
-   mutations. *)
+   repo-unattributed lane bucket ([Ide_paths.Legacy_default]). Reads use it
+   as a useful fallback. Writes prefer their actual file partition and use the
+   same default lane when no repository selection is available. *)
 
 let seed_lane_turn_event ~base_path ~keeper_id ~turn_id ~timestamp_ms =
   Ide_bridge.ingest_turn_event
@@ -1036,7 +1041,7 @@ let test_events_keeper_lane_returns_only_lane_events () =
     | events -> failf "expected exactly alice's event, got %d" (List.length events))
 ;;
 
-let test_events_keeper_lane_conflicts_with_repo_scope () =
+let test_events_keeper_lane_falls_back_when_repo_scope_is_unusable () =
   with_ide_server (fun ~base_path:_ ~state:_ ~router ->
     let request =
       http_request
@@ -1045,12 +1050,15 @@ let test_events_keeper_lane_conflicts_with_repo_scope () =
         ()
     in
     let response = dispatch router request in
-    check_status "keeper_lane + repo_id returns 400" 400 response;
-    check string "conflict code" "conflicting_ide_scope" (error_code_of_response response))
+    check_status "keeper_lane + unusable repo_id falls back" 200 response)
 ;;
 
-let test_events_keeper_lane_rejects_mismatched_keeper_filter () =
-  with_ide_server (fun ~base_path:_ ~state:_ ~router ->
+let test_events_keeper_lane_allows_explicit_keeper_filter_override () =
+  with_ide_server (fun ~base_path ~state:_ ~router ->
+    seed_lane_turn_event ~base_path ~keeper_id:"alice" ~turn_id:"turn-alice-1"
+      ~timestamp_ms:1700000000000L;
+    seed_lane_turn_event ~base_path ~keeper_id:"bob" ~turn_id:"turn-bob-1"
+      ~timestamp_ms:1700000001000L;
     let request =
       http_request
         ~meth:`GET
@@ -1058,15 +1066,17 @@ let test_events_keeper_lane_rejects_mismatched_keeper_filter () =
         ()
     in
     let response = dispatch router request in
-    check_status "mismatched keeper filter returns 400" 400 response;
-    check
-      string
-      "filter conflict code"
-      "keeper_lane_filter_conflict"
-      (error_code_of_response response))
+    check_status "explicit keeper filter overrides keeper_lane" 200 response;
+    let json = response |> response_body |> Yojson.Safe.from_string in
+    let data = Json.member "data" json in
+    match json_list_member "overridden lane events" "events" data with
+    | [ event ] ->
+      check string "explicit keeper filter wins" "bob"
+        (json_string_member "overridden lane event" "keeper_id" event)
+    | events -> failf "expected exactly bob's event, got %d" (List.length events))
 ;;
 
-let test_events_keeper_lane_rejects_other_keeper_token () =
+let test_events_keeper_lane_does_not_require_matching_token () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     let token = create_worker_token base_path "bob" in
     seed_lane_turn_event ~base_path ~keeper_id:"alice" ~turn_id:"turn-alice-1"
@@ -1079,17 +1089,11 @@ let test_events_keeper_lane_rejects_other_keeper_token () =
         ()
     in
     let response = dispatch router request in
-    check_status "other keeper token returns 403" 403 response;
-    check
-      string
-      "keeper lane forbidden code"
-      "keeper_lane_forbidden"
-      (error_code_of_response response))
+    check_status "other keeper token can read lane events" 200 response)
 ;;
 
 let test_cursors_keeper_lane_filters_to_lane_keeper () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
-    let token = create_worker_token base_path "alice" in
     (let seed keeper_id line =
        match
          Ide_bridge.ingest_cursor_event
@@ -1110,7 +1114,6 @@ let test_cursors_keeper_lane_filters_to_lane_keeper () =
       http_request
         ~meth:`GET
         ~path:"/api/v1/ide/cursors?keeper_lane=alice"
-        ~token:(Some token)
         ()
     in
     let response = dispatch router request in
@@ -1124,7 +1127,7 @@ let test_cursors_keeper_lane_filters_to_lane_keeper () =
     | cursors -> failf "expected exactly alice's cursor, got %d" (List.length cursors))
 ;;
 
-let test_post_cursors_rejects_keeper_lane_scope () =
+let test_post_cursors_uses_default_lane_for_keeper_lane_scope () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     let token = create_worker_token base_path "alice" in
     let body = {|{"file_path":"lib/a.ml","line":3}|} in
@@ -1137,12 +1140,7 @@ let test_post_cursors_rejects_keeper_lane_scope () =
         ()
     in
     let response = dispatch router request in
-    check_status "POST cursor with keeper_lane returns 400" 400 response;
-    check
-      string
-      "read-only scope code"
-      "keeper_lane_read_only"
-      (error_code_of_response response))
+    check_status "POST cursor with keeper_lane uses default lane" 201 response)
 ;;
 
 let test_get_events_rejects_invalid_limit () =
@@ -1201,21 +1199,21 @@ let () =
         ] )
     ; ( "scope_contract"
       , [ test_case
-            "GET annotations rejects missing scope"
+            "GET annotations uses default scope"
             `Quick
-            test_read_annotations_rejects_missing_scope
+            test_read_annotations_uses_default_scope
         ; test_case
-            "GET cursors rejects unmatched repo scope"
+            "GET cursors falls back from unmatched repo scope"
             `Quick
-            test_read_cursors_rejects_unmatched_repo_scope
+            test_read_cursors_falls_back_from_unmatched_repo_scope
         ; test_case
-            "GET events rejects invalid canonical_url scope"
+            "GET events falls back from invalid canonical_url scope"
             `Quick
-            test_get_events_rejects_invalid_canonical_scope
+            test_get_events_falls_back_from_invalid_canonical_scope
         ; test_case
-            "POST annotation rejects missing scope"
+            "POST annotation uses default scope"
             `Quick
-            test_post_annotations_rejects_missing_scope
+            test_post_annotations_uses_default_scope
         ; test_case
             "GET memory declares annotation source contract"
             `Quick
@@ -1228,16 +1226,16 @@ let () =
     ; ( "keeper_lane_scope"
       , [ test_case "GET events keeper_lane returns only lane events" `Quick
             test_events_keeper_lane_returns_only_lane_events
-        ; test_case "keeper_lane conflicts with repo scope" `Quick
-            test_events_keeper_lane_conflicts_with_repo_scope
-        ; test_case "keeper_lane rejects mismatched keeper filter" `Quick
-            test_events_keeper_lane_rejects_mismatched_keeper_filter
-        ; test_case "keeper_lane rejects other keeper token" `Quick
-            test_events_keeper_lane_rejects_other_keeper_token
+        ; test_case "keeper_lane falls back from unusable repo scope" `Quick
+            test_events_keeper_lane_falls_back_when_repo_scope_is_unusable
+        ; test_case "keeper_lane permits explicit keeper override" `Quick
+            test_events_keeper_lane_allows_explicit_keeper_filter_override
+        ; test_case "keeper_lane does not require matching token" `Quick
+            test_events_keeper_lane_does_not_require_matching_token
         ; test_case "GET cursors keeper_lane filters to lane keeper" `Quick
             test_cursors_keeper_lane_filters_to_lane_keeper
-        ; test_case "POST cursor rejects keeper_lane scope" `Quick
-            test_post_cursors_rejects_keeper_lane_scope
+        ; test_case "POST cursor uses default lane for keeper_lane scope" `Quick
+            test_post_cursors_uses_default_lane_for_keeper_lane_scope
         ] )
     ; ( "query_parsing"
       , [ test_case "GET events rejects invalid limit" `Quick
@@ -1247,13 +1245,13 @@ let () =
         ; test_case "GET memory rejects non-positive limit" `Quick
             test_get_memory_rejects_non_positive_limit
         ] )
-    ; ( "mutation_auth"
-      , [ test_case "POST annotation rejects client keeper_id" `Quick
-            test_post_annotations_rejects_client_keeper_id
+    ; ( "public_mutation_flow"
+      , [ test_case "POST annotation accepts client keeper_id without auth" `Quick
+            test_post_annotations_accepts_client_keeper_id_without_auth
         ; test_case "POST annotation rejects unknown route fields" `Quick
             test_post_annotations_rejects_unknown_route_fields
-        ; test_case "POST cursor rejects client keeper_id" `Quick
-            test_post_cursors_rejects_client_keeper_id
+        ; test_case "POST cursor accepts client keeper_id without auth" `Quick
+            test_post_cursors_accepts_client_keeper_id_without_auth
         ; test_case "POST cursor rejects invalid focus_mode" `Quick
             test_post_cursors_rejects_invalid_focus_mode
         ; test_case "POST cursor rejects negative column" `Quick
@@ -1266,16 +1264,18 @@ let () =
             test_hook_cursors_broadcast_ws_invalidation
         ; test_case "POST cursor honors canonical_url scope" `Quick
             test_post_cursors_honors_canonical_url_scope
+        ; test_case "POST cursor follows file path over stale scope" `Quick
+            test_post_cursors_uses_file_path_partition_over_stale_scope
         ; test_case "POST annotation accepts matching repo scope" `Quick
             test_post_annotations_accepts_matching_repo_scope
-        ; test_case "POST annotation rejects repo scope mismatch" `Quick
-            test_post_annotations_rejects_repo_scope_mismatch
-        ; test_case "POST annotation rejects canonical scope mismatch" `Quick
-            test_post_annotations_rejects_canonical_scope_mismatch
-        ; test_case "POST annotation requires auth" `Quick
-            test_post_annotations_requires_auth
-        ; test_case "DELETE annotation requires auth" `Quick
-            test_delete_annotation_requires_auth
+        ; test_case "POST annotation follows file path over stale repo scope" `Quick
+            test_post_annotations_uses_file_path_partition_over_stale_repo_scope
+        ; test_case "POST annotation follows file path over stale canonical scope" `Quick
+            test_post_annotations_uses_file_path_partition_over_stale_canonical_scope
+        ; test_case "POST annotation works without auth" `Quick
+            test_post_annotations_works_without_auth
+        ; test_case "DELETE annotation works without auth or owner" `Quick
+            test_delete_annotation_works_without_auth_or_owner
         ] )
     ]
 ;;


### PR DESCRIPTION
## What changed

- Make Dashboard and IDE feature routes explicitly feature-first, so public reads and direct controls do not wait for a credential bootstrap or fail because of a stale bearer.
- Reuse shared H1 projections for the H2 Keeper, workspace, IDE, chat-operation, and event-pending read paths.
- Open the Dashboard actions that the UI calls directly, including Keeper controls, Board reactions/actions, Gate inspection, moderation, and artifact drill-down.

## Why

The product flow mixed route-local public intent with a global strict-path gate and several client-side dev-token prerequisites. As a result, otherwise available Dashboard features could fail before a session was initialized or when an old credential was present.

## User impact

The Dashboard starts its shell and live projections immediately. Its feature lanes use a stable `dashboard` attribution actor where a durable action needs one, without turning that attribution into an authorization precondition.

## Validation

- `git diff --check`
- Local compilation and test execution intentionally not run: CI is the requested build authority.
