### PR TITLE
fix(ci): make the Dune boundary scanner quote-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
             tla=true
           fi
 
-          if has_match '^(packages/agent_core/|lib/keeper/keeper_event_bridge\.ml$|test/test_keeper_execution_join\.ml$|test/test_keeper_hooks_agent_core_introspection\.ml$|dune-project$|.*\.opam$|masc\.opam\.locked$)'; then
+          if has_match '^(packages/agent_core/|lib/keeper/keeper_event_bridge\.ml$|scripts/check-agent-core-boundary\.sh$|test/test_agent_core_boundary\.sh$|test/test_keeper_execution_join\.ml$|test/test_keeper_hooks_agent_core_introspection\.ml$|dune-project$|.*\.opam$|masc\.opam\.locked$)'; then
             agent_core=true
           fi
 

--- a/scripts/check-agent-core-boundary.sh
+++ b/scripts/check-agent-core-boundary.sh
@@ -19,6 +19,25 @@ for forbidden in dune-project agent_core.opam .github release-please-config.json
     || fail "independent package surface is forbidden: ${core_root}/${forbidden}"
 done
 
+# Dune accepts both an installed [public_name] and its workspace-private
+# [name] in a [libraries] field.  Build the private-name denylist from the
+# coordinator-owned library tree so a dependency such as [voice_config] or
+# [run_registry_core] cannot bypass the public [masc.*] namespace check.
+coordinator_library_names="$({
+  find "${repo_root}/lib" -type f \( -name dune -o -name '*.inc' \) \
+    -exec perl -0777 -ne '
+      while (/\(\s*name\s+([A-Za-z0-9_-]+)\s*\)/g) {
+        print "$1\n";
+      }
+    ' {} + \
+    | LC_ALL=C sort -u
+})" || fail "could not derive coordinator library names"
+[[ -n "${coordinator_library_names}" ]] \
+  || fail "coordinator library name registry is empty"
+coordinator_library_pattern="$(
+  printf '%s\n' "${coordinator_library_names}" | paste -sd '|' -
+)" || fail "could not build coordinator library matcher"
+
 dune_violations="$({
   # In Dune syntax, [;] starts a comment through end-of-line unless it appears
   # inside a quoted string. Preserve quoted semicolons while scanning the code
@@ -62,7 +81,10 @@ dune_violations="$({
         else
           exit $?
         fi
-        if matches="$(rg -n 'masc[._]' <<< "${code}")"; then
+        if matches="$(rg -n \
+          -e 'masc[._]' \
+          -e "(^|[^A-Za-z0-9_.-])(${coordinator_library_pattern})([^A-Za-z0-9_.-]|$)" \
+          <<< "${code}")"; then
           printf '%s\n' "${matches}" | sed "s#^#${dune_file}:#"
         else
           status=$?
@@ -78,13 +100,23 @@ dune_violations="$({
   fail "agent core must not depend on MASC coordinator libraries"
 }
 
-module_violations="$({
-  rg -n \
-    '\b(Masc_[A-Za-z0-9_]*|Keeper_[A-Za-z0-9_]*|Board_[A-Za-z0-9_]*|Gate_[A-Za-z0-9_]*|Server_[A-Za-z0-9_]*|Operator_[A-Za-z0-9_]*|Runtime_agent|Runtime_toml|Workspace_[A-Za-z0-9_]*)\b' \
-    "${core_root}/lib" \
-    --glob '*.ml' --glob '*.mli' \
-    || true
-})"
+coordinator_module_pattern='(Masc_[A-Za-z0-9_]*|Keeper_[A-Za-z0-9_]*|Board_[A-Za-z0-9_]*|Gate_[A-Za-z0-9_]*|Server_[A-Za-z0-9_]*|Operator_[A-Za-z0-9_]*|Runtime_agent|Runtime_toml|Workspace_[A-Za-z0-9_]*)'
+if module_violations="$(rg -n \
+  -e "\\b${coordinator_module_pattern}\\." \
+  -e "\\b(open!?|include)[[:space:]]+${coordinator_module_pattern}\\b" \
+  -e "\\bmodule([[:space:]]+type)?[[:space:]]+[A-Z][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*${coordinator_module_pattern}\\b" \
+  -e "\\([[:space:]]*module[[:space:]]+${coordinator_module_pattern}\\b" \
+  "${core_root}/lib" \
+  --glob '*.ml' --glob '*.mli')"; then
+  :
+else
+  status=$?
+  if [[ "${status}" -eq 1 ]]; then
+    module_violations=""
+  else
+    fail "could not scan agent core source imports"
+  fi
+fi
 [[ -z "${module_violations}" ]] || {
   printf '%s\n' "${module_violations}" >&2
   fail "agent core source imports a MASC coordinator module"

--- a/scripts/check-agent-core-boundary.sh
+++ b/scripts/check-agent-core-boundary.sh
@@ -20,8 +20,10 @@ for forbidden in dune-project agent_core.opam .github release-please-config.json
 done
 
 dune_violations="$({
+  # In Dune syntax, [;] starts a comment through end-of-line. Inspect only the
+  # code prefix so documentation cannot be mistaken for a library dependency.
   find "${core_root}" -name dune -type f -print0 \
-    | xargs -0 rg -n 'masc\.' \
+    | xargs -0 rg -n '^[^;]*masc\.' \
     | rg -v '\(public_name masc\.agent_core(\.[a-z_]+)?\)' \
     || true
 })"

--- a/scripts/check-agent-core-boundary.sh
+++ b/scripts/check-agent-core-boundary.sh
@@ -23,9 +23,9 @@ dune_violations="$({
   # In Dune syntax, [;] starts a comment through end-of-line unless it appears
   # inside a quoted string. Preserve quoted semicolons while scanning the code
   # prefix so comments cannot hide or imitate a library dependency.
-  find "${core_root}" -name dune -type f -print0 \
+  find "${core_root}" -type f \( -name dune -o -name '*.inc' \) -print0 \
     | while IFS= read -r -d '' dune_file; do
-        if matches="$(awk '
+        if code="$(awk '
           BEGIN {
             in_string = 0
             escaped = 0
@@ -46,10 +46,23 @@ dune_violations="$({
             }
             print code
           }
-        ' "${dune_file}" \
-          | perl -0777 -pe \
-              's{\(\s*public_name\s+masc\.agent_core(?:\.[a-z_]+)?\s*\)}{}g' \
-          | rg -n 'masc\.')"; then
+        ' "${dune_file}")"; then
+          :
+        else
+          exit $?
+        fi
+        if code="$(perl -0777 -pe '
+          s{\(\s*public_name\s+masc\.agent_core(?:\.[a-z_]+)?\s*\)}{
+            my $allowed = $&;
+            $allowed =~ s/[^\n]/ /g;
+            $allowed
+          }gex
+        ' <<< "${code}")"; then
+          :
+        else
+          exit $?
+        fi
+        if matches="$(rg -n 'masc[._]' <<< "${code}")"; then
           printf '%s\n' "${matches}" | sed "s#^#${dune_file}:#"
         else
           status=$?
@@ -67,7 +80,7 @@ dune_violations="$({
 
 module_violations="$({
   rg -n \
-    '\b(Masc_[A-Za-z0-9_]*|Keeper_[A-Za-z0-9_]*|Board_[A-Za-z0-9_]*|Gate_[A-Za-z0-9_]*|Server_[A-Za-z0-9_]*|Operator_[A-Za-z0-9_]*|Runtime_agent|Runtime_toml|Workspace_[A-Za-z0-9_]*)\.' \
+    '\b(Masc_[A-Za-z0-9_]*|Keeper_[A-Za-z0-9_]*|Board_[A-Za-z0-9_]*|Gate_[A-Za-z0-9_]*|Server_[A-Za-z0-9_]*|Operator_[A-Za-z0-9_]*|Runtime_agent|Runtime_toml|Workspace_[A-Za-z0-9_]*)\b' \
     "${core_root}/lib" \
     --glob '*.ml' --glob '*.mli' \
     || true

--- a/scripts/check-agent-core-boundary.sh
+++ b/scripts/check-agent-core-boundary.sh
@@ -25,7 +25,7 @@ dune_violations="$({
   # prefix so comments cannot hide or imitate a library dependency.
   find "${core_root}" -name dune -type f -print0 \
     | while IFS= read -r -d '' dune_file; do
-        awk '
+        if matches="$(awk '
           BEGIN {
             in_string = 0
             escaped = 0
@@ -44,13 +44,21 @@ dune_violations="$({
                 in_string = !in_string
               }
             }
-            print FILENAME ":" FNR ":" code
+            print code
           }
-        ' "${dune_file}"
-      done \
-    | rg 'masc\.' \
-    | rg -v '\(public_name masc\.agent_core(\.[a-z_]+)?\)' \
-    || true
+        ' "${dune_file}" \
+          | perl -0777 -pe \
+              's{\(\s*public_name\s+masc\.agent_core(?:\.[a-z_]+)?\s*\)}{}g' \
+          | rg -n 'masc\.')"; then
+          printf '%s\n' "${matches}" | sed "s#^#${dune_file}:#"
+        else
+          status=$?
+          # ripgrep uses 1 for "no matches". Any other status means the
+          # scanner itself failed, which must fail closed rather than silently
+          # accepting a dependency.
+          [[ "${status}" -eq 1 ]] || exit "${status}"
+        fi
+      done
 })"
 [[ -z "${dune_violations}" ]] || {
   printf '%s\n' "${dune_violations}" >&2

--- a/scripts/check-agent-core-boundary.sh
+++ b/scripts/check-agent-core-boundary.sh
@@ -20,10 +20,35 @@ for forbidden in dune-project agent_core.opam .github release-please-config.json
 done
 
 dune_violations="$({
-  # In Dune syntax, [;] starts a comment through end-of-line. Inspect only the
-  # code prefix so documentation cannot be mistaken for a library dependency.
+  # In Dune syntax, [;] starts a comment through end-of-line unless it appears
+  # inside a quoted string. Preserve quoted semicolons while scanning the code
+  # prefix so comments cannot hide or imitate a library dependency.
   find "${core_root}" -name dune -type f -print0 \
-    | xargs -0 rg -n '^[^;]*masc\.' \
+    | while IFS= read -r -d '' dune_file; do
+        awk '
+          BEGIN {
+            in_string = 0
+            escaped = 0
+          }
+          {
+            code = ""
+            for (i = 1; i <= length($0); i++) {
+              ch = substr($0, i, 1)
+              if (!in_string && ch == ";") break
+              code = code ch
+              if (in_string && escaped) {
+                escaped = 0
+              } else if (in_string && ch == "\\") {
+                escaped = 1
+              } else if (ch == "\"") {
+                in_string = !in_string
+              }
+            }
+            print FILENAME ":" FNR ":" code
+          }
+        ' "${dune_file}"
+      done \
+    | rg 'masc\.' \
     | rg -v '\(public_name masc\.agent_core(\.[a-z_]+)?\)' \
     || true
 })"

--- a/test/test_agent_core_boundary.sh
+++ b/test/test_agent_core_boundary.sh
@@ -9,9 +9,11 @@ trap 'rm -rf "${fixture}"' EXIT
 mkdir -p "${fixture}/lib" "${fixture}/test"
 touch "${fixture}/models.toml" "${fixture}/test/dune"
 cat > "${fixture}/lib/dune" <<'EOF'
+; masc.string_util is documentation, not a dependency.
 (library
  (name agent_core_fixture)
- (public_name masc.agent_core))
+ (public_name masc.agent_core)
+ (wrapped false)) ; masc.coordinator is also only a comment.
 EOF
 
 AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null

--- a/test/test_agent_core_boundary.sh
+++ b/test/test_agent_core_boundary.sh
@@ -47,6 +47,23 @@ if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
   exit 1
 fi
 
+cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
+printf '(library (name bad) (libraries masc_keeper_runtime))\n' > "${fixture}/lib/deps.inc"
+printf '\n(include deps.inc)\n' >> "${fixture}/lib/dune"
+if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
+  echo "boundary self-test: included internal MASC dependency was accepted" >&2
+  exit 1
+fi
+
+cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
+rm "${fixture}/lib/deps.inc"
+printf 'open Server_runtime\n' > "${fixture}/lib/open_bypass.ml"
+if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
+  echo "boundary self-test: opened coordinator module was accepted" >&2
+  exit 1
+fi
+rm "${fixture}/lib/open_bypass.ml"
+
 rm -rf "${fixture}/lib"
 if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
   echo "boundary self-test: missing core tree was accepted" >&2

--- a/test/test_agent_core_boundary.sh
+++ b/test/test_agent_core_boundary.sh
@@ -12,7 +12,8 @@ cat > "${fixture}/lib/dune" <<'EOF'
 ; masc.string_util is documentation, not a dependency.
 (library
  (name agent_core_fixture)
- (public_name masc.agent_core)
+ (public_name
+  masc.agent_core)
  (wrapped false)) ; masc.coordinator is also only a comment.
 EOF
 
@@ -36,6 +37,13 @@ cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
 printf '\n(library (name bad) (libraries masc.keeper))\n' >> "${fixture}/lib/dune"
 if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
   echo "boundary self-test: reverse MASC dependency was accepted" >&2
+  exit 1
+fi
+
+cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
+printf '\n(library (name bad) (public_name masc.agent_core.bad) (libraries masc.keeper))\n' >> "${fixture}/lib/dune"
+if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
+  echo "boundary self-test: public_name line hid a reverse MASC dependency" >&2
   exit 1
 fi
 

--- a/test/test_agent_core_boundary.sh
+++ b/test/test_agent_core_boundary.sh
@@ -19,6 +19,11 @@ EOF
 
 AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null
 
+printf 'type event = Operator_requested | Operator_repair_required | Server_error\n' \
+  > "${fixture}/lib/allowed_constructors.ml"
+AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null
+rm "${fixture}/lib/allowed_constructors.ml"
+
 cp "${fixture}/lib/dune" "${fixture}/lib/dune.safe"
 printf '\n(rule (action (echo "documentation; still a string"))) (library (name bad) (libraries masc.keeper))\n' >> "${fixture}/lib/dune"
 if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then

--- a/test/test_agent_core_boundary.sh
+++ b/test/test_agent_core_boundary.sh
@@ -57,6 +57,13 @@ fi
 
 cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
 rm "${fixture}/lib/deps.inc"
+printf '\n(library (name bad) (libraries voice_config))\n' >> "${fixture}/lib/dune"
+if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
+  echo "boundary self-test: private coordinator library name was accepted" >&2
+  exit 1
+fi
+
+cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
 printf 'open Server_runtime\n' > "${fixture}/lib/open_bypass.ml"
 if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
   echo "boundary self-test: opened coordinator module was accepted" >&2
@@ -64,7 +71,7 @@ if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
 fi
 rm "${fixture}/lib/open_bypass.ml"
 
-rm -rf "${fixture}/lib"
+rm -rf "${fixture:?}/lib"
 if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
   echo "boundary self-test: missing core tree was accepted" >&2
   exit 1

--- a/test/test_agent_core_boundary.sh
+++ b/test/test_agent_core_boundary.sh
@@ -18,6 +18,21 @@ EOF
 
 AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null
 
+cp "${fixture}/lib/dune" "${fixture}/lib/dune.safe"
+printf '\n(rule (action (echo "documentation; still a string"))) (library (name bad) (libraries masc.keeper))\n' >> "${fixture}/lib/dune"
+if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
+  echo "boundary self-test: quoted semicolon hid a reverse MASC dependency" >&2
+  exit 1
+fi
+
+cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
+printf '\n(rule (action (echo "documentation\nstill; a string"))) (library (name bad) (libraries masc.keeper))\n' >> "${fixture}/lib/dune"
+if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
+  echo "boundary self-test: multiline quoted semicolon hid a reverse MASC dependency" >&2
+  exit 1
+fi
+
+cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
 printf '\n(library (name bad) (libraries masc.keeper))\n' >> "${fixture}/lib/dune"
 if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
   echo "boundary self-test: reverse MASC dependency was accepted" >&2


### PR DESCRIPTION
## Summary

- strip Dune semicolon comments only outside quoted strings
- remove only the allowed `public_name masc.agent_core...` expression before scanning the remaining code
- scan both `dune` and included `*.inc` fragments for public and workspace-private coordinator library names
- reject actual qualified/open/include/module-alias/first-class coordinator module references without rejecting similarly named constructors
- fail closed on scanner errors while preserving ripgrep no-match behavior
- make boundary script and self-test edits activate the Agent Core CI surface

## Stack

- #28212 has merged
- this branch is restacked directly on current main `50123ae456`
- #28206 is stacked on this PR and contains only substring convergence

## Validation

- `bash -n scripts/check-agent-core-boundary.sh`
- `bash -n test/test_agent_core_boundary.sh`
- `bash test/test_agent_core_boundary.sh`
- `bash scripts/check-agent-core-boundary.sh`
- `git diff --check`

All checks above pass locally. Per user request, local Dune build was not duplicated; exact-head GitHub CI remains authoritative.

Closes #28232
