### PR TITLE
test(keeper): repair the four post-#28178 failures closing CI Gate

### DIFF
--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -707,10 +707,24 @@ let test_post_effect_transport_enters_recovery () =
                 ~goal:"USE_TOOL_ONCE"
                 ()
             with
-            | Error
-                (Agent_core.Error.Provider
-                  (Llm_provider.Error.ProviderUnavailable _)) -> ()
-            | Error error -> fail (Agent_core.Error.to_string error)
+            | Error error ->
+              (* Since #28178 the provider-attempt effect fence wraps the
+                 provider error once an effect was attempted, so the caller no
+                 longer sees the raw [ProviderUnavailable]. The recovery phase
+                 asserted below is what this test is named for and is
+                 unchanged; here we only pin that the failure is the fence and
+                 that it forbids same-turn retry. *)
+              (match Keeper_internal_error.classify_masc_internal_error error with
+               | Some
+                   (Keeper_internal_error.Provider_attempt_effect_fenced
+                      { effect_disposition; _ }) ->
+                 check
+                   bool
+                   "post-effect failure is fenced against same-turn retry"
+                   false
+                   (Keeper_provider_attempt_effect.allows_same_turn_retry
+                      effect_disposition)
+               | _ -> fail (Agent_core.Error.to_string error))
             | Ok _ -> fail "post-effect response failure completed the Keeper turn");
        check int "tool effect count" 1 !call_count;
        let state = load_state base_path in
@@ -797,8 +811,28 @@ let test_quota_enters_typed_recovery () =
     (fun () ->
        with_fixture [ Emit rate_limit_rejected; Emit quota_result ] (fun cli_path ->
          (match run_keeper_turn ~base_path ~cli_path ~goal:"QUOTA_GOAL" () with
-          | Error (Agent_core.Error.Provider (Llm_provider.Error.HardQuota _)) -> ()
-          | Error error -> fail (Agent_core.Error.to_string error)
+          | Error error ->
+            (* Since #28178 the fence also wraps failures where the runtime
+               lost complete effect observation, which is this path: the
+               caller no longer sees the raw [HardQuota]. The recovery
+               assertions below still carry the quota identity; here we pin
+               the fence and that the quota diagnostic survives it. *)
+            (match Keeper_internal_error.classify_masc_internal_error error with
+             | Some
+                 (Keeper_internal_error.Provider_attempt_effect_fenced
+                    { effect_disposition; diagnostic; _ }) ->
+               check
+                 bool
+                 "quota rejection is fenced against same-turn retry"
+                 false
+                 (Keeper_provider_attempt_effect.allows_same_turn_retry
+                    effect_disposition);
+               check
+                 bool
+                 "the fenced envelope keeps the quota diagnostic"
+                 true
+                 (Astring.String.is_infix ~affix:"quota" diagnostic)
+             | _ -> fail (Agent_core.Error.to_string error))
           | Ok _ -> fail "quota rejection completed the Keeper turn");
          let state = load_state base_path in
          match state.phase with
@@ -872,7 +906,13 @@ let run_direct_attempt ~base_path ~cli_path ~goal ~tools =
                     ~model_input_projection:None
                     ~hooks:None
                     ~context_injector:None
-                    ~context:None
+                      (* Dynamic tools require the Keeper shared context
+                         ([Keeper_official_client_host.dynamic_tools] rejects
+                         [tools <> []] with [context = None]). Supply one
+                         unconditionally: with [~tools:[]] the gate returns
+                         [Ok []] either way, so the no-tools attempts are
+                         unaffected. *)
+                    ~context:(Some (Agent_core.Context.create ()))
                     ~event_bus:None
                     ~raw_trace:None
                     ~on_event:None

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -1290,15 +1290,31 @@ let test_keeper_does_not_retry_context_error_after_tool_effect () =
            ~model:"gpt-fixture"
            ()
        with
-       | Error
-           (Agent_core.Error.Provider
-              (Llm_provider.Error.ProviderReportedError
-                 { provider = "codex_app_server"
-                 ; error_type = Some "context_window_exceeded_after_tool_effect"
-                 ; _
-                 })) ->
-         ()
-       | Error error -> fail (Agent_core.Error.to_string error)
+       | Error error ->
+         (* Since #28178 the provider-attempt effect fence intercepts this
+            failure before the raw provider error reaches the caller: an
+            observed tool effect forbids same-turn retry. Decode the typed
+            envelope rather than matching its rendered prose — the fence is
+            what this test is about, and [effect_disposition] is the field
+            that carries it. *)
+         (match Keeper_internal_error.classify_masc_internal_error error with
+          | Some
+              (Keeper_internal_error.Provider_attempt_effect_fenced
+                 { effect_disposition; diagnostic; _ }) ->
+            check
+              bool
+              "the fence forbids same-turn retry"
+              false
+              (Keeper_provider_attempt_effect.allows_same_turn_retry
+                 effect_disposition);
+            check
+              bool
+              "the fenced envelope keeps the provider diagnostic"
+              true
+              (Astring.String.is_infix
+                 ~affix:"context_window_exceeded_after_tool_effect"
+                 diagnostic)
+          | _ -> fail (Agent_core.Error.to_string error))
        | Ok _ -> fail "Keeper retried a context overflow after a tool effect")
 ;;
 


### PR DESCRIPTION
`CI Gate` 는 main 의 유일한 required check 인데, **최근 main 22 커밋 중 green 이 하나도 없습니다.** 전부 `failure` 또는 `cancelled` 입니다. 이 PR 은 그 게이트를 닫고 있는 테스트 실패 4건을 고칩니다.

## 게이트가 닫혀 있는 상태 (실측)

`bash gatehist.sh 22` — main 커밋별 `CI Gate` / `Build and Test` conclusion:

```
2026-08-12T04:04  gate=failure     build=failure     docs(rfc): execution design for the terminal-code su
2026-08-12T03:59  gate=cancelled   build=cancelled   fix(ci): repair inherited OCaml compile and effect-f
2026-08-11T21:54  gate=failure     build=failure     chore(runtime): purge the dead local-runtime bench+s
...
2026-08-11T18:44  gate=failure     build=failure     fix(keeper): fence fallback after provider effects (#28178)
```

22/22 이 non-green 입니다. `ci-gate` 의 `needs` 에 `build` 가 있고(`ci.yml:1566`), `build` 는 `scripts/ci-run-focused-tests.sh` 를 hard-required 로 돌립니다(`ci.yml:1191`, `continue-on-error` 의도적 부재).

#28212 가 컴파일 3건을 고쳐 main 은 이제 빌드됩니다. 남은 건 테스트 실패이고, **전부 #28178 에서 왔습니다** — 그 PR 의 `Build and Test` 자체가 `failure` 였습니다.

#28212 의 CI 로그(run `31524451490`, 실패 스텝 `40. Run focused OCaml behavior suites`)에서 실패한 스위트는 정확히 2개입니다:

| 스위트 | 실패 |
|---|---|
| `runtime codex app-server` | 1 (`subscription boundary 33`) |
| `keeper_claude_code_runtime` | 3 (`lifecycle 6, 7, 10`) |

## 무엇을 고쳤나

### 1. `test_runtime_codex_app_server` — test 33

`test_keeper_does_not_retry_context_error_after_tool_effect` 가 #28178 이전의 typed `ProviderReportedError` 를 기대합니다. 이제 fence 봉투가 옵니다:

```
[masc_agent_core_error] {"kind":"provider_attempt_effect_fenced","runtime_id":"codex.codex",
 "effect_disposition":"effect_attempted","diagnostic":"Provider 'codex_app_server' reported an
 error (context_window_exceeded_after_tool_effect): ..."}
```

### 2. `test_keeper_claude_code_runtime` — lifecycle 6, 7

같은 원인입니다. 두 테스트는 이름 그대로 **recovery 진입**을 검증하는데, 그 단언에 도달하기 전에 **에러 shape** 에서 죽습니다.

이게 shape 변경인지 실제 동작 회귀인지 확인했습니다. shape 검사만 풀고 돌린 결과 test 6 의 나머지 단언이 **전부 통과**합니다:

- `check int "tool effect count" 1` ✅
- `state.phase = Recovery_required { failure = Transport_interrupted }` ✅

즉 fence 는 recovery 를 깨지 않았고 caller 가 보는 shape 만 바꿨습니다. 그래서 **recovery 단언들은 손대지 않고** shape arm 만 typed 디코딩으로 교체했습니다. 이 PR 적용 후 두 테스트 모두 recovery 단언까지 통과합니다.

### 3. `test_keeper_claude_code_runtime` — lifecycle 10

`test_turn_spawn_failure_is_pre_dispatch_with_tools` 는 **#28178 이 추가했고 한 번도 통과한 적이 없습니다** (`git log -S`). `run_direct_attempt` 이 `~context:None` 을 넘기는데, `Keeper_official_client_host.dynamic_tools` (`:628`) 가 tool 이 있는데 context 가 없으면 거부합니다:

```ocaml
match tools, context with
| [], _ -> Ok []
| _ :: _, None -> Error (config_error ~field:"context" (... "dynamic tools require the Keeper shared context"))
| tools, Some context -> ...
```

게이트가 맞습니다 — dynamic tool 은 실제로 공유 context 가 필요합니다. 테스트가 그걸 주지 않았을 뿐입니다. `Agent_core.Context.create ()` 를 넘깁니다(`keeper_run_context.ml:82` 와 같은 관용구). `~tools:[]` 경로는 게이트가 `Ok []` 을 주므로 영향 없습니다(테스트 8·9 통과 유지).

## 왜 substring 이 아니라 typed 인가

`Keeper_internal_error.classify_masc_internal_error : Agent_core.Error.t -> masc_internal_error option` 이 export 되어 있고(`keeper_internal_error.mli:210`), fence variant 는 타입이 살아 있습니다(`:157`):

```ocaml
| Provider_attempt_effect_fenced of
    { runtime_id : string
    ; effect_disposition : Keeper_provider_attempt_effect_core.t
    ; diagnostic : string
    }
```

렌더된 메시지를 `is_infix` 로 훑으면 **fence 의 핵심인 "same-turn retry 가 금지되었는가" 를 단언하지 않고** 라벨 문자열의 존재만 봅니다. 세 곳 모두 `effect_disposition` 을 `allows_same_turn_retry` 로 직접 검사하고, prose 는 `diagnostic` 필드로 좁혔습니다.

선례: `test_keeper_compaction_unit.ml:486`. `Astring` 은 두 파일 모두 이미 사용 중이라 dune 변경이 없습니다.

## 로컬 검증 (base `50123ae456`)

| 스위트 | 이 PR 없이 | 이 PR |
|---|---|---|
| `test_runtime_codex_app_server` | **exit 1** — `1 failure! in 25.669s. 49 tests run.` | **exit 0** — `Test Successful in 28.274s. 49 tests run.` |
| `test_keeper_claude_code_runtime` | **exit 1** — `3 failures! in 4.789s. 11 tests run.` | **exit 0** — `Test Successful in 7.536s. 11 tests run.` |

같은 base 에서 이 변경만 되돌려 A/B 로 확인했습니다. `ocamlformat --check` 두 파일 exit 0. 프로덕션 코드 변경 없음.

환경: OCaml 5.5.0, `dune build --root . -j 2`.

## 관련

#28213 도 test 33 을 고치지만 현재 `CONFLICTING/DIRTY` 이고 자체 `Build and Test` 도 failure 입니다. 이게 먼저 들어가면 그쪽은 본론(`turn_accepted` 운반)만 남습니다.

경위 기록: #26306.

RFC-WAIVED: 테스트를 현재 타입 계약에 맞추는 변경. 프로덕션 코드 무변경, credential / operator control / sandbox / hooks 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
