### PR TITLE
fix(ci): close remaining agent-core boundary review gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
             tla=true
           fi
 
-          if has_match '^(packages/agent_core/|lib/keeper/keeper_event_bridge\.ml$|scripts/check-agent-core-boundary\.sh$|test/test_agent_core_boundary\.sh$|test/test_keeper_execution_join\.ml$|test/test_keeper_hooks_agent_core_introspection\.ml$|dune-project$|.*\.opam$|masc\.opam\.locked$)'; then
+          if has_match '^(\.github/workflows/ci\.yml$|packages/agent_core/|lib/(.*/)?(dune|[^/]+\.inc)$|lib/keeper/keeper_event_bridge\.ml$|scripts/check-agent-core-boundary\.sh$|test/test_agent_core_boundary\.sh$|test/test_keeper_execution_join\.ml$|test/test_keeper_hooks_agent_core_introspection\.ml$|dune-project$|.*\.opam$|masc\.opam\.locked$)'; then
             agent_core=true
           fi
 

--- a/scripts/check-agent-core-boundary.sh
+++ b/scripts/check-agent-core-boundary.sh
@@ -38,11 +38,125 @@ coordinator_library_pattern="$(
   printf '%s\n' "${coordinator_library_names}" | paste -sd '|' -
 )" || fail "could not build coordinator library matcher"
 
+emit_agent_core_dune_files() {
+  find "${core_root}" -type f -name dune -print0 \
+    | AGENT_CORE_SCAN_ROOT="${core_root}" perl -0 -e '
+      use strict;
+      use warnings;
+      use Cwd qw(abs_path);
+      use File::Basename qw(dirname);
+      use File::Spec;
+
+      my $root = abs_path($ENV{AGENT_CORE_SCAN_ROOT});
+      die "could not resolve agent core root\n" unless defined $root;
+
+      my @queue;
+      while (defined(my $path = <STDIN>)) {
+        $path =~ s/\0\z//;
+        push @queue, $path if length $path;
+      }
+
+      my %seen;
+      while (@queue) {
+        my $candidate = shift @queue;
+        my $path = abs_path($candidate);
+        die "missing Dune include: $candidate\n"
+          unless defined $path && -f $path;
+        die "Dune include escapes agent core: $path\n"
+          unless $path eq $root || index($path, $root . "/") == 0;
+        next if $seen{$path}++;
+
+        print $path, "\0";
+        open my $fh, "<", $path or die "could not read $path: $!\n";
+        local $/;
+        my $raw = <$fh>;
+        close $fh or die "could not close $path: $!\n";
+
+        my $code = "";
+        my $in_string = 0;
+        my $escaped = 0;
+        for (my $idx = 0; $idx < length($raw); $idx++) {
+          my $ch = substr($raw, $idx, 1);
+          if (!$in_string && $ch eq ";") {
+            $idx++ while $idx + 1 < length($raw)
+              && substr($raw, $idx + 1, 1) ne "\n";
+            next;
+          }
+          $code .= $ch;
+          if ($in_string && $escaped) {
+            $escaped = 0;
+          } elsif ($in_string && $ch eq "\\") {
+            $escaped = 1;
+          } elsif ($ch eq "\"") {
+            $in_string = !$in_string;
+          }
+        }
+        die "unterminated Dune string in $path\n" if $in_string;
+
+        my @tokens;
+        for (my $idx = 0; $idx < length($code); ) {
+          my $ch = substr($code, $idx, 1);
+          if ($ch =~ /\s/) {
+            $idx++;
+          } elsif ($ch eq "(") {
+            push @tokens, ["open", $ch];
+            $idx++;
+          } elsif ($ch eq ")") {
+            push @tokens, ["close", $ch];
+            $idx++;
+          } elsif ($ch eq "\"") {
+            $idx++;
+            my $value = "";
+            my $closed = 0;
+            while ($idx < length($code)) {
+              $ch = substr($code, $idx, 1);
+              if ($ch eq "\\") {
+                die "unterminated Dune escape in $path\n"
+                  if $idx + 1 >= length($code);
+                $value .= substr($code, $idx + 1, 1);
+                $idx += 2;
+              } elsif ($ch eq "\"") {
+                $closed = 1;
+                $idx++;
+                last;
+              } else {
+                $value .= $ch;
+                $idx++;
+              }
+            }
+            die "unterminated Dune string in $path\n" unless $closed;
+            push @tokens, ["value", $value];
+          } else {
+            my $start = $idx;
+            $idx++ while $idx < length($code)
+              && substr($code, $idx, 1) !~ /[\s()]/;
+            push @tokens, ["atom", substr($code, $start, $idx - $start)];
+          }
+        }
+
+        for (my $idx = 0; $idx + 3 < @tokens; $idx++) {
+          next unless $tokens[$idx][0] eq "open";
+          next unless $tokens[$idx + 1][0] eq "atom"
+            && $tokens[$idx + 1][1] eq "include";
+          next unless $tokens[$idx + 2][0] eq "atom"
+            || $tokens[$idx + 2][0] eq "value";
+          next unless $tokens[$idx + 3][0] eq "close";
+          my $target = $tokens[$idx + 2][1];
+          die "dynamic Dune include is unsupported in $path: $target\n"
+            if $target =~ /%\{/;
+          die "absolute Dune include is forbidden in $path: $target\n"
+            if File::Spec->file_name_is_absolute($target);
+          push @queue, File::Spec->catfile(dirname($path), $target);
+        }
+      }
+    '
+}
+
 dune_violations="$({
   # In Dune syntax, [;] starts a comment through end-of-line unless it appears
   # inside a quoted string. Preserve quoted semicolons while scanning the code
   # prefix so comments cannot hide or imitate a library dependency.
-  find "${core_root}" -type f \( -name dune -o -name '*.inc' \) -print0 \
+  emit_agent_core_dune_files \
     | while IFS= read -r -d '' dune_file; do
         if code="$(awk '
           BEGIN {
@@ -94,7 +208,7 @@ dune_violations="$({
           [[ "${status}" -eq 1 ]] || exit "${status}"
         fi
       done
-})"
+})" || fail "could not resolve or scan agent core Dune files"
 [[ -z "${dune_violations}" ]] || {
   printf '%s\n' "${dune_violations}" >&2
   fail "agent core must not depend on MASC coordinator libraries"
@@ -104,7 +218,7 @@ coordinator_module_pattern='(Masc_[A-Za-z0-9_]*|Keeper_[A-Za-z0-9_]*|Board_[A-Za
 if module_violations="$(rg -n \
   -e "\\b${coordinator_module_pattern}\\." \
   -e "\\b(open!?|include)[[:space:]]+${coordinator_module_pattern}\\b" \
-  -e "\\bmodule([[:space:]]+type)?[[:space:]]+[A-Z][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*${coordinator_module_pattern}\\b" \
+  -e "\\bmodule([[:space:]]+type)?[[:space:]]+[A-Z][A-Za-z0-9_]*([[:space:]]*:[^=[:cntrl:]]+)?[[:space:]]*=[[:space:]]*${coordinator_module_pattern}\\b" \
   -e "\\([[:space:]]*module[[:space:]]+${coordinator_module_pattern}\\b" \
   "${core_root}/lib" \
   --glob '*.ml' --glob '*.mli')"; then

--- a/test/test_agent_core_boundary.sh
+++ b/test/test_agent_core_boundary.sh
@@ -62,6 +62,18 @@ fi
 
 cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
 rm "${fixture}/lib/deps.inc"
+mkdir -p "${fixture}/lib/fragments/nested"
+printf '(include nested/deps.data)\n' > "${fixture}/lib/fragments/outer.sexp"
+printf '(library (name bad) (libraries masc_keeper_runtime))\n' \
+  > "${fixture}/lib/fragments/nested/deps.data"
+printf '\n(include fragments/outer.sexp)\n' >> "${fixture}/lib/dune"
+if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
+  echo "boundary self-test: nested arbitrary Dune include was accepted" >&2
+  exit 1
+fi
+
+cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
+rm -rf "${fixture:?}/lib/fragments"
 printf '\n(library (name bad) (libraries voice_config))\n' >> "${fixture}/lib/dune"
 if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
   echo "boundary self-test: private coordinator library name was accepted" >&2
@@ -75,6 +87,14 @@ if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
   exit 1
 fi
 rm "${fixture}/lib/open_bypass.ml"
+
+printf 'module M : sig end = Server_runtime\n' \
+  > "${fixture}/lib/constrained_alias_bypass.ml"
+if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
+  echo "boundary self-test: constrained coordinator alias was accepted" >&2
+  exit 1
+fi
+rm "${fixture}/lib/constrained_alias_bypass.ml"
 
 rm -rf "${fixture:?}/lib"
 if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Follow-up to merged #28245. It addresses all three unresolved P2 review findings:

- reject constrained coordinator aliases such as `module M : S = Server_runtime`
- recursively resolve the actual files named by Dune `(include ...)` stanzas, regardless of extension, while failing closed on missing, dynamic, absolute, or escaping paths
- run the Agent Core CI surface when its workflow or coordinator library registry inputs under `lib/**/dune|*.inc` change

## Regression coverage

- nested arbitrary-extension include chain ending in `masc_keeper_runtime` must fail
- constrained coordinator alias must fail
- existing constructor-like identifiers must continue to pass

## Local validation

- changed-surface matcher manually exercised: accepts root/nested Dune stanzas, rejects an ordinary unrelated `lib/**/*.ml` path (no automated harness exists for `ci.yml` `has_match` patterns — this PR's own CI run is the live accept-side evidence)
- `bash -n scripts/check-agent-core-boundary.sh`
- `bash -n test/test_agent_core_boundary.sh`
- `shellcheck scripts/check-agent-core-boundary.sh test/test_agent_core_boundary.sh`
- `bash test/test_agent_core_boundary.sh`
- `bash scripts/check-agent-core-boundary.sh`
- `git diff --check`

All pass. Per user request, local Dune build was not duplicated; exact-head GitHub CI remains authoritative.

Follow-up to #28245.

