### PR TITLE
test(strings): converge the remaining 86 contains_substring copies (91 -> 0)

### DIFF
--- a/lib/exec/test/test_shell_ir_oracle.ml
+++ b/lib/exec/test/test_shell_ir_oracle.ml
@@ -11,19 +11,6 @@ let load name =
   | Error message -> Alcotest.failf "%s: %s" name message
 ;;
 
-let contains_substring haystack needle =
-  let hay_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop index =
-    if index + needle_len > hay_len
-    then false
-    else if String.sub haystack index needle_len = needle
-    then true
-    else loop (index + 1)
-  in
-  needle_len = 0 || loop 0
-;;
-
 let test_simple_fixture () =
   let facts = load "simple" in
   Alcotest.(check int) "schema" 1 facts.Oracle.schema_version;
@@ -55,7 +42,7 @@ let assert_incompatible name feature =
   | Ok () -> Alcotest.failf "%s must be structurally incompatible" name
   | Error message ->
     Alcotest.(check bool) ("mentions " ^ feature) true
-      (contains_substring message feature)
+      (String_util.contains_substring message feature)
 ;;
 
 let test_redirect_fixture () =

--- a/packages/agent_core/test/dune
+++ b/packages/agent_core/test/dune
@@ -4,6 +4,7 @@
  (wrapped false)
  (libraries
   (re_export agent_core)
+  (re_export agent_core_strings)
   (re_export llm_provider)
   (re_export eio)
   (re_export eio.unix)

--- a/packages/agent_core/test/test_agent_pipeline.ml
+++ b/packages/agent_core/test/test_agent_pipeline.ml
@@ -28,20 +28,6 @@ let escape_json_string s =
   Buffer.contents buf
 ;;
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if needle_len = 0
-    then true
-    else if idx + needle_len > haystack_len
-    then false
-    else if String.sub haystack idx needle_len = needle
-    then true
-    else loop (idx + 1)
-  in
-  loop 0
-;;
 
 let openai_tool_use_response tool_name input_json =
   Printf.sprintf

--- a/packages/agent_core/test/test_agent_turn.ml
+++ b/packages/agent_core/test/test_agent_turn.ml
@@ -264,20 +264,6 @@ let starts_with ~prefix s =
   String.length s >= prefix_len && String.sub s 0 prefix_len = prefix
 ;;
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if needle_len = 0
-    then true
-    else if idx + needle_len > haystack_len
-    then false
-    else if String.sub haystack idx needle_len = needle
-    then true
-    else loop (idx + 1)
-  in
-  loop 0
-;;
 
 let message_text_exn (msg : Types.message) =
   match msg.content with

--- a/packages/agent_core/test/test_body_timeout.ml
+++ b/packages/agent_core/test/test_body_timeout.ml
@@ -51,20 +51,6 @@ let starts_with ~prefix s =
   String.length s >= lp && String.equal (String.sub s 0 lp) prefix
 ;;
 
-let contains_substring ~needle s =
-  let ln = String.length needle in
-  let ls = String.length s in
-  if ln > ls
-  then false
-  else (
-    let found = ref false in
-    let i = ref 0 in
-    while (not !found) && !i <= ls - ln do
-      if String.equal (String.sub s !i ln) needle then found := true;
-      incr i
-    done;
-    !found)
-;;
 
 let test_message_has_promotion_prefix () =
   let msg = body_timeout_message 180.0 in
@@ -79,7 +65,7 @@ let test_message_includes_configured_value () =
   Alcotest.(check bool)
     "message records the configured deadline (180.0)"
     true
-    (contains_substring ~needle:"180.0" msg)
+    (Agent_core_strings.contains_substring ~needle:"180.0" ~haystack:msg)
 ;;
 
 let test_message_distinguishes_from_idle_timeout () =
@@ -90,11 +76,11 @@ let test_message_distinguishes_from_idle_timeout () =
   Alcotest.(check bool)
     "message names Complete.complete path"
     true
-    (contains_substring ~needle:"Complete.complete non-streaming path" msg);
+    (Agent_core_strings.contains_substring ~needle:"Complete.complete non-streaming path" ~haystack:msg);
   Alcotest.(check bool)
     "message disambiguates from stream_idle_timeout_s"
     true
-    (contains_substring ~needle:"Complete.complete non-streaming path" msg)
+    (Agent_core_strings.contains_substring ~needle:"Complete.complete non-streaming path" ~haystack:msg)
 ;;
 
 let () =

--- a/packages/agent_core/test/test_builder.ml
+++ b/packages/agent_core/test/test_builder.ml
@@ -26,20 +26,6 @@ let make_tool name =
     Ok { Types.content = Yojson.Safe.to_string input; _meta = None })
 ;;
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if needle_len = 0
-    then true
-    else if idx + needle_len > haystack_len
-    then false
-    else if String.sub haystack idx needle_len = needle
-    then true
-    else loop (idx + 1)
-  in
-  loop 0
-;;
 
 (** Helper: compare model fields via string. *)
 let check_model msg expected actual = Alcotest.(check string) msg expected actual
@@ -605,25 +591,23 @@ let test_with_contract_composes_prompt () =
   Alcotest.(check bool)
     "base prompt preserved"
     true
-    (contains_substring ~needle:"Base prompt." prompt);
+    (Agent_core_strings.contains_substring ~needle:"Base prompt." ~haystack:prompt);
   Alcotest.(check bool)
     "runtime awareness section"
     true
-    (contains_substring ~needle:"[Runtime Awareness]" prompt
-     && contains_substring
-          ~needle:"You are running inside an explicit runtime contract."
-          prompt);
+    (Agent_core_strings.contains_substring ~needle:"[Runtime Awareness]" ~haystack:prompt
+     && Agent_core_strings.contains_substring ~needle:"You are running inside an explicit runtime contract." ~haystack:prompt);
   Alcotest.(check bool)
     "trigger section rendered"
     true
-    (contains_substring ~needle:"[Trigger Context]" prompt
-     && contains_substring ~needle:"kind: direct_mention" prompt
-     && contains_substring ~needle:"source: room" prompt);
+    (Agent_core_strings.contains_substring ~needle:"[Trigger Context]" ~haystack:prompt
+     && Agent_core_strings.contains_substring ~needle:"kind: direct_mention" ~haystack:prompt
+     && Agent_core_strings.contains_substring ~needle:"source: room" ~haystack:prompt);
   Alcotest.(check bool)
     "instruction layer rendered"
     true
-    (contains_substring ~needle:"[Instruction Layer: role]" prompt
-     && contains_substring ~needle:"Prefer concise, factual answers." prompt)
+    (Agent_core_strings.contains_substring ~needle:"[Instruction Layer: role]" ~haystack:prompt
+     && Agent_core_strings.contains_substring ~needle:"Prefer concise, factual answers." ~haystack:prompt)
 ;;
 
 (* --- 19. with_skill appends skill prompt --- *)
@@ -654,11 +638,11 @@ let test_with_skill_appends_prompt () =
   Alcotest.(check bool)
     "skill label present"
     true
-    (contains_substring ~needle:"[Skill: reviewer]" prompt);
+    (Agent_core_strings.contains_substring ~needle:"[Skill: reviewer]" ~haystack:prompt);
   Alcotest.(check bool)
     "skill body present"
     true
-    (contains_substring ~needle:"State concrete findings first." prompt)
+    (Agent_core_strings.contains_substring ~needle:"State concrete findings first." ~haystack:prompt)
 ;;
 
 (* --- 20. with_contract injects context metadata --- *)

--- a/packages/agent_core/test/test_complete_ext.ml
+++ b/packages/agent_core/test/test_complete_ext.ml
@@ -3,18 +3,6 @@
 open Alcotest
 open Llm_provider
 
-let contains_substring ~sub text =
-  let sub_len = String.length sub in
-  let text_len = String.length text in
-  let rec loop index =
-    if index + sub_len > text_len
-    then false
-    else if String.sub text index sub_len = sub
-    then true
-    else loop (index + 1)
-  in
-  sub_len = 0 || loop 0
-;;
 
 let make_config
       ?(kind = Provider_config.OpenAI_compat)
@@ -609,8 +597,8 @@ let test_custom_stream_wire_observer_and_telemetry_exceptions_are_nonfatal () =
          (List.exists
             (fun (ctx, message) ->
                String.equal ctx "wire_observer"
-               && contains_substring ~sub:"telemetry unavailable" message
-               && contains_substring ~sub:"observer unavailable" message)
+               && Agent_core_strings.contains_substring ~needle:"telemetry unavailable" ~haystack:message
+               && Agent_core_strings.contains_substring ~needle:"observer unavailable" ~haystack:message)
             !diagnostics))
 ;;
 

--- a/packages/agent_core/test/test_complete_http.ml
+++ b/packages/agent_core/test/test_complete_http.ml
@@ -187,18 +187,6 @@ let make_kimi_config ?request_path base_url =
 
 let messages = [ Types.user_msg "hello" ]
 
-let contains_substring ~sub text =
-  let sub_len = String.length sub in
-  let text_len = String.length text in
-  let rec loop idx =
-    if idx + sub_len > text_len
-    then false
-    else if String.sub text idx sub_len = sub
-    then true
-    else loop (idx + 1)
-  in
-  sub_len = 0 || loop 0
-;;
 
 let mock_transport_response text =
   { Types.id = "transport-response"
@@ -2277,7 +2265,7 @@ let test_complete_stream_wire_observer_rejection_is_typed_nonfatal () =
              bool
              "raw token absent"
              false
-             (contains_substring ~sub:token observation.redacted_chunk))
+             (Agent_core_strings.contains_substring ~needle:token ~haystack:observation.redacted_chunk))
         !observations;
       check
         bool
@@ -2285,7 +2273,7 @@ let test_complete_stream_wire_observer_rejection_is_typed_nonfatal () =
         true
         (List.exists
            (fun (observation : Wire_observer.observation) ->
-              contains_substring ~sub:"[REDACTED]" observation.redacted_chunk)
+              Agent_core_strings.contains_substring ~needle:"[REDACTED]" ~haystack:observation.redacted_chunk)
            !observations);
       let failures =
         List.filter_map
@@ -2362,8 +2350,8 @@ let test_complete_stream_wire_failure_telemetry_exception_is_nonfatal () =
            (List.exists
               (fun (ctx, message) ->
                  String.equal ctx "wire_observer"
-                 && contains_substring ~sub:"telemetry observer unavailable" message
-                 && contains_substring ~sub:"wire observer unavailable" message)
+                 && Agent_core_strings.contains_substring ~needle:"telemetry observer unavailable" ~haystack:message
+                 && Agent_core_strings.contains_substring ~needle:"wire observer unavailable" ~haystack:message)
               !diagnostics);
          Eio.Switch.fail sw Exit
        with
@@ -3345,7 +3333,7 @@ let test_complete_deadline_preflight_precedes_cache_hit () =
 
 let check_accept_rejected ~label ~needle = function
   | Error (Http_client.AcceptRejected { reason }) ->
-    check bool (label ^ " reason") true (contains_substring ~sub:needle reason)
+    check bool (label ^ " reason") true (Agent_core_strings.contains_substring ~needle:needle ~haystack:reason)
   | Ok _ -> failf "%s unexpectedly succeeded" label
   | Error _ -> failf "%s returned a non-AcceptRejected error" label
 ;;

--- a/packages/agent_core/test/test_context_flow_proof.ml
+++ b/packages/agent_core/test/test_context_flow_proof.ml
@@ -90,17 +90,6 @@ let require_run_success label = function
 ;;
 
 (** Substring search — checks if [sub] appears anywhere in [s]. *)
-let contains_substring s sub =
-  let len_s = String.length s
-  and len_sub = String.length sub in
-  if len_sub > len_s
-  then false
-  else (
-    let found = ref false in
-    for i = 0 to len_s - len_sub do
-      if (not !found) && String.sub s i len_sub = sub then found := true
-    done;
-    !found)
 ;;
 
 (* ── Test 1: Full chain — injector → Context.t → hook → LLM ── *)
@@ -172,7 +161,9 @@ let test_full_chain_across_turns () =
        Alcotest.(check bool)
          "API body contains context string"
          true
-         (contains_substring !captured_turn1_body "proof_marker=context_reached_llm"))
+         (Agent_core_strings.contains_substring
+            ~haystack:!captured_turn1_body
+            ~needle:"proof_marker=context_reached_llm"))
 ;;
 
 (* ── Test 2: No injector → no context pollution ────────── *)
@@ -295,7 +286,7 @@ let test_accumulation_across_tool_calls () =
     Alcotest.(check bool)
       "API body has accumulation"
       true
-      (contains_substring !captured2 "count=2"))
+      (Agent_core_strings.contains_substring ~haystack:!captured2 ~needle:"count=2"))
 ;;
 
 (* ── Test 4: Context.t identity — same object across pipeline ── *)

--- a/packages/agent_core/test/test_guardrails_async.ml
+++ b/packages/agent_core/test/test_guardrails_async.ml
@@ -41,24 +41,6 @@ let fail_output reason : Guardrails_async.output_validator =
   { name = "fail_out"; validate = (fun _ -> Error reason) }
 ;;
 
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec matches_at haystack_pos needle_pos =
-    needle_pos = needle_len
-    ||
-    let haystack_idx = haystack_pos + needle_pos in
-    haystack_idx < haystack_len
-    && String.get haystack haystack_idx = String.get needle needle_pos
-    && matches_at haystack_pos (needle_pos + 1)
-  in
-  let rec search haystack_pos =
-    haystack_pos + needle_len <= haystack_len
-    && (matches_at haystack_pos 0 || search (haystack_pos + 1))
-  in
-  needle_len = 0 || search 0
-;;
-
 (* ── Input validators ─────────────────────────────── *)
 
 let test_input_empty () =
@@ -115,7 +97,7 @@ let test_input_exception_is_local_failure () =
   match result with
   | Fail { validator_name = "raise_in"; reason } ->
     check string "reason says raised" "validator raised" reason;
-    check bool "reason redacts exception detail" false (contains_substring reason "boom")
+    check bool "reason redacts exception detail" false (Agent_core_strings.contains_substring ~haystack:reason ~needle:"boom")
   | Fail _ -> fail "wrong failure info"
   | Pass -> fail "should have failed"
 ;;

--- a/packages/agent_core/test/test_hooks.ml
+++ b/packages/agent_core/test/test_hooks.ml
@@ -427,12 +427,6 @@ let test_invoke_validated_legal () =
   check bool "validated Block at pre_tool_use passes" true (result = Hooks.Block "blocked")
 ;;
 
-let contains_substring ~needle haystack =
-  let n = String.length needle in
-  let h = String.length haystack in
-  let rec loop i = i + n <= h && (String.sub haystack i n = needle || loop (i + 1)) in
-  n = 0 || loop 0
-;;
 
 let capture_traceln f =
   Eio_main.run
@@ -520,7 +514,7 @@ let test_invoke_validated_illegal_returns_hook_failed () =
   (match result with
    | Hooks.HookFailed { stage; detail } ->
      check bool "stage" true (stage = Hooks.Before_turn);
-     check bool "detail names Block" true (contains_substring ~needle:"Block" detail)
+     check bool "detail names Block" true (Agent_core_strings.contains_substring ~needle:"Block" ~haystack:detail)
    | _ -> fail "expected HookFailed");
   check bool "on_illegal was called" true !called
 ;;
@@ -555,7 +549,7 @@ let test_invoke_validated_pre_tool_use_fail_closed_pinned () =
          true
          (match result with
           | Hooks.HookFailed { stage; detail } ->
-            stage = Hooks.Pre_tool_use && contains_substring ~needle:kind_name detail
+            stage = Hooks.Pre_tool_use && Agent_core_strings.contains_substring ~needle:kind_name ~haystack:detail
           | _ -> false);
        match !seen with
        | None -> fail (Printf.sprintf "on_illegal not called for %s" kind_name)
@@ -570,7 +564,7 @@ let test_invoke_validated_pre_tool_use_fail_closed_pinned () =
            bool
            (Printf.sprintf "msg names %s" kind_name)
            true
-           (contains_substring ~needle:kind_name msg))
+           (Agent_core_strings.contains_substring ~needle:kind_name ~haystack:msg))
     illegal
 ;;
 
@@ -584,7 +578,7 @@ let test_invoke_validated_fail_closed_without_hook_name () =
     true
     (match result with
      | Hooks.HookFailed { stage = Hooks.Pre_tool_use; detail } ->
-       contains_substring ~needle:"Nudge" detail
+       Agent_core_strings.contains_substring ~needle:"Nudge" ~haystack:detail
      | _ -> false)
 ;;
 

--- a/packages/agent_core/test/test_provider_admission.ml
+++ b/packages/agent_core/test/test_provider_admission.ml
@@ -7,18 +7,6 @@
 open Alcotest
 open Llm_provider
 
-let contains_substring ~sub text =
-  let sub_len = String.length sub in
-  let text_len = String.length text in
-  let rec loop index =
-    if index + sub_len > text_len
-    then false
-    else if String.sub text index sub_len = sub
-    then true
-    else loop (index + 1)
-  in
-  sub_len = 0 || loop 0
-;;
 
 let make_config
       ?(base_url = "http://admission.test:1")
@@ -147,18 +135,18 @@ let test_conflict_warning_sanitizes_base_url () =
     bool
     "the conflict warning was emitted"
     true
-    (contains_substring ~sub:"conflicting max_concurrent_requests" logged);
-  check bool "sanitized host survives" true (contains_substring ~sub:"leak.test:1" logged);
+    (Agent_core_strings.contains_substring ~needle:"conflicting max_concurrent_requests" ~haystack:logged);
+  check bool "sanitized host survives" true (Agent_core_strings.contains_substring ~needle:"leak.test:1" ~haystack:logged);
   check
     bool
     "userinfo credential is stripped from the log"
     false
-    (contains_substring ~sub:"secret" logged);
+    (Agent_core_strings.contains_substring ~needle:"secret" ~haystack:logged);
   check
     bool
     "query credential is stripped from the log"
     false
-    (contains_substring ~sub:"token=abc" logged)
+    (Agent_core_strings.contains_substring ~needle:"token=abc" ~haystack:logged)
 ;;
 
 let reject_dispatch_transport : Llm_transport.t =
@@ -191,7 +179,7 @@ let test_zero_declaration_rejected_before_dispatch () =
       bool
       "rejection names the offending field"
       true
-      (contains_substring ~sub:"max_concurrent_requests" reason)
+      (Agent_core_strings.contains_substring ~needle:"max_concurrent_requests" ~haystack:reason)
   | Ok _ -> fail "expected AcceptRejected for max_concurrent_requests = 0"
   | Error _ -> fail "expected AcceptRejected, got a different error kind"
 ;;

--- a/packages/agent_core/test/test_provider_complete.ml
+++ b/packages/agent_core/test/test_provider_complete.ml
@@ -19,18 +19,6 @@ let () =
      | Error msg -> Alcotest.failf "failed to load %s: %s" path msg)
 ;;
 
-let contains_substring ~sub text =
-  let sub_len = String.length sub in
-  let text_len = String.length text in
-  let rec loop idx =
-    if idx + sub_len > text_len
-    then false
-    else if String.sub text idx sub_len = sub
-    then true
-    else loop (idx + 1)
-  in
-  if sub_len = 0 then true else loop 0
-;;
 
 let catalog_capabilities ?provider_label model_id =
   let capabilities =
@@ -1184,8 +1172,8 @@ let test_complete_rejects_glm_named_forced_tool_choice_before_request () =
       Alcotest.(check bool)
         label
         true
-        (contains_substring ~sub:"tool_choice" reason
-         && contains_substring ~sub:"calculator" reason)
+        (Agent_core_strings.contains_substring ~needle:"tool_choice" ~haystack:reason
+         && Agent_core_strings.contains_substring ~needle:"calculator" ~haystack:reason)
     | Ok _ -> Alcotest.failf "%s: expected AcceptRejected" label
     | Error _ -> Alcotest.failf "%s: expected AcceptRejected" label
   in
@@ -1329,7 +1317,7 @@ let test_unknown_openai_compat_enable_rejected_sync_and_stream () =
        Alcotest.(check bool)
          ("rejection contains " ^ fragment)
          true
-         (contains_substring ~sub:fragment chat_sync))
+         (Agent_core_strings.contains_substring ~needle:fragment ~haystack:chat_sync))
     [ "enable_thinking=true"
     ; "thinking_control_format=No_thinking_control"
     ; "supports_reasoning=false"
@@ -1625,9 +1613,9 @@ let test_provider_default_thinking_drift_is_info () =
        (fun (level, ctx, message) ->
           level = Llm_provider.Diag.Info
           && ctx = "complete"
-          && contains_substring ~sub:"capability_observation" message
-          && contains_substring ~sub:"provider_default" message
-          && contains_substring ~sub:"low" message)
+          && Agent_core_strings.contains_substring ~needle:"capability_observation" ~haystack:message
+          && Agent_core_strings.contains_substring ~needle:"provider_default" ~haystack:message
+          && Agent_core_strings.contains_substring ~needle:"low" ~haystack:message)
        entries)
 ;;
 
@@ -1649,9 +1637,9 @@ let test_model_capability_thinking_drift_remains_warn () =
        (fun (level, ctx, message) ->
           level = Llm_provider.Diag.Warn
           && ctx = "complete"
-          && contains_substring ~sub:"capability_drift" message
-          && contains_substring ~sub:"model" message
-          && contains_substring ~sub:"high" message)
+          && Agent_core_strings.contains_substring ~needle:"capability_drift" ~haystack:message
+          && Agent_core_strings.contains_substring ~needle:"model" ~haystack:message
+          && Agent_core_strings.contains_substring ~needle:"high" ~haystack:message)
        entries)
 ;;
 
@@ -1671,8 +1659,8 @@ let test_declared_glm_model_thinking_uses_model_capability () =
     (List.exists
        (fun (_level, ctx, message) ->
           ctx = "complete"
-          && (contains_substring ~sub:"capability_observation" message
-              || contains_substring ~sub:"capability_drift" message))
+          && (Agent_core_strings.contains_substring ~needle:"capability_observation" ~haystack:message
+              || Agent_core_strings.contains_substring ~needle:"capability_drift" ~haystack:message))
        entries)
 ;;
 
@@ -1697,7 +1685,7 @@ let test_complete_rejects_output_schema_for_glm () =
     Alcotest.(check bool)
       "mentions glm json mode"
       true
-      (contains_substring ~sub:"json mode" (String.lowercase_ascii reason))
+      (Agent_core_strings.contains_substring ~needle:"json mode" ~haystack:(String.lowercase_ascii reason))
   | Ok _ -> Alcotest.fail "expected AcceptRejected for glm output_schema"
   | Error _ -> Alcotest.fail "expected AcceptRejected for glm output_schema"
 ;;
@@ -1732,7 +1720,7 @@ let test_complete_stream_rejects_output_schema_for_glm () =
     Alcotest.(check bool)
       "mentions glm json mode"
       true
-      (contains_substring ~sub:"json mode" (String.lowercase_ascii reason))
+      (Agent_core_strings.contains_substring ~needle:"json mode" ~haystack:(String.lowercase_ascii reason))
   | Ok _ -> Alcotest.fail "expected stream AcceptRejected for glm output_schema"
   | Error _ -> Alcotest.fail "expected stream AcceptRejected for glm output_schema"
 ;;

--- a/packages/agent_core/test/test_provider_config.ml
+++ b/packages/agent_core/test/test_provider_config.ml
@@ -1949,18 +1949,6 @@ let telemetry_with_kind (pk : Provider_config.provider_kind option)
 ;;
 
 (** Substring search helper local to this module. *)
-let contains_substring ~sub text =
-  let sub_len = String.length sub in
-  let text_len = String.length text in
-  let rec loop i =
-    if i + sub_len > text_len
-    then false
-    else if String.sub text i sub_len = sub
-    then true
-    else loop (i + 1)
-  in
-  sub_len = 0 || loop 0
-;;
 
 let test_wire_kind_lowercase () =
   let cases =
@@ -1981,7 +1969,7 @@ let test_wire_kind_lowercase () =
             (Provider_config.string_of_provider_kind kind)
             expected_substring)
          true
-         (contains_substring ~sub:expected_substring encoded))
+         (Agent_core_strings.contains_substring ~needle:expected_substring ~haystack:encoded))
     cases
 ;;
 
@@ -1994,7 +1982,7 @@ let test_wire_kind_none_roundtrip () =
        Alcotest.(check bool)
          (Printf.sprintf "None telemetry must not contain %S" s)
          false
-         (contains_substring ~sub:s encoded))
+         (Agent_core_strings.contains_substring ~needle:s ~haystack:encoded))
     [ "\"anthropic\""; "\"ollama\""; "\"openai_compat\"" ]
 ;;
 
@@ -2004,7 +1992,7 @@ let test_wire_unknown_latency_is_null () =
   Alcotest.(check bool)
     "unknown latency encoded as JSON null"
     true
-    (contains_substring ~sub:"\"request_latency_ms\":null" encoded);
+    (Agent_core_strings.contains_substring ~needle:"\"request_latency_ms\":null" ~haystack:encoded);
   let decoded =
     match Types.inference_telemetry_of_yojson (Yojson.Safe.from_string encoded) with
     | Ok t -> t
@@ -2022,7 +2010,7 @@ let test_wire_measured_zero_latency_is_distinct () =
   Alcotest.(check bool)
     "measured zero encoded as JSON zero"
     true
-    (contains_substring ~sub:"\"request_latency_ms\":0" encoded);
+    (Agent_core_strings.contains_substring ~needle:"\"request_latency_ms\":0" ~haystack:encoded);
   let decoded =
     match Types.inference_telemetry_of_yojson (Yojson.Safe.from_string encoded) with
     | Ok t -> t

--- a/packages/agent_core/test/test_telemetry_pipeline.ml
+++ b/packages/agent_core/test/test_telemetry_pipeline.ml
@@ -18,20 +18,6 @@ let local_provider_config ~base_url ~model_id =
     ()
 ;;
 
-let contains_substring ~sub text =
-  let sub_len = String.length sub in
-  let text_len = String.length text in
-  let rec loop index =
-    if sub_len = 0
-    then true
-    else if index + sub_len > text_len
-    then false
-    else if String.sub text index sub_len = sub
-    then true
-    else loop (index + 1)
-  in
-  loop 0
-;;
 
 let make_mock_transport () : Llm_provider.Llm_transport.t =
   let response : Types.api_response =
@@ -418,7 +404,7 @@ let test_checkpoint_sink_failure_fails_turn () =
     Alcotest.(check bool)
       "error mentions checkpoint sink"
       true
-      (contains_substring ~sub:"checkpoint sink failed" (Error.to_string err));
+      (Agent_core_strings.contains_substring ~needle:"checkpoint sink failed" ~haystack:(Error.to_string err));
     let event_payloads =
       Event_bus.drain event_sub |> List.map (fun event -> event.Event_bus.payload)
     in
@@ -552,7 +538,7 @@ let test_post_hook_failure_commits_tool_result_before_surface () =
      Alcotest.(check bool)
        "hook detail retained"
        true
-       (contains_substring ~sub:"post hook failed" detail)
+       (Agent_core_strings.contains_substring ~needle:"post hook failed" ~haystack:detail)
    | Ok _ -> Alcotest.fail "expected typed post-hook failure"
    | Error error -> Alcotest.fail ("unexpected post-hook error: " ^ Error.to_string error));
   Alcotest.(check int) "tool ran once before hook failure" 1 !tool_runs;
@@ -633,7 +619,7 @@ let test_context_injection_failure_keeps_base_tool_result () =
      Alcotest.(check bool)
        "context error retained"
        true
-       (contains_substring ~sub:"context projection failed" detail)
+       (Agent_core_strings.contains_substring ~needle:"context projection failed" ~haystack:detail)
    | Ok _ -> Alcotest.fail "expected context injection failure"
    | Error error ->
      Alcotest.fail ("unexpected context injection error: " ^ Error.to_string error));

--- a/packages/agent_core/test/test_tool_execution.ml
+++ b/packages/agent_core/test/test_tool_execution.ml
@@ -10,20 +10,6 @@ let result_id (result : Agent_tools.tool_execution_result) =
   Tool_contract.Invocation.tool_use_id result.invocation
 ;;
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if needle_len = 0
-    then true
-    else if idx + needle_len > haystack_len
-    then false
-    else if String.sub haystack idx needle_len = needle
-    then true
-    else loop (idx + 1)
-  in
-  loop 0
-;;
 
 (** Helper: create a simple tool that echoes its input as JSON string *)
 let make_echo_tool ?descriptor name =
@@ -294,7 +280,7 @@ let test_pre_tool_approval_callback_failure_is_typed () =
       bool
       "callback failure detail is retained"
       true
-      (contains_substring ~needle:"approval unavailable" detail)
+      (Agent_core_strings.contains_substring ~needle:"approval unavailable" ~haystack:detail)
   | Error _ -> fail "callback failure returned the wrong typed error"
   | Ok _ -> fail "callback failure did not fail closed"
 ;;
@@ -529,7 +515,7 @@ let test_post_hook_failure_is_typed_agent_error () =
        bool
        "hook exception detail retained"
        true
-       (contains_substring ~needle:"post hook boom" detail);
+       (Agent_core_strings.contains_substring ~needle:"post hook boom" ~haystack:detail);
      check string "completed result retained" "done" completed.content
    | Ok _ -> fail "post hook failure was returned as successful tool results"
    | Error _ -> fail "unexpected hook execution error payload");
@@ -1214,7 +1200,7 @@ let test_tool_exception_still_publishes_tool_completed () =
        bool
        "tool result reports exception"
        true
-       (contains_substring ~needle:"Tool 'boom' raised" result.content)
+       (Agent_core_strings.contains_substring ~needle:"Tool 'boom' raised" ~haystack:result.content)
    | _ -> fail "expected exactly one result");
   match
     List.map
@@ -1233,7 +1219,7 @@ let test_tool_exception_still_publishes_tool_completed () =
       bool
       "completion event reports exception"
       true
-      (contains_substring ~needle:"Tool 'boom' raised" message);
+      (Agent_core_strings.contains_substring ~needle:"Tool 'boom' raised" ~haystack:message);
     (* Both events carry the same exact occurrence, while the provider ID
        remains available as a boundary projection. *)
     check

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -37,6 +37,7 @@
   (re_export masc_backend)
   (re_export masc_compression)
   (re_export masc_core)
+  (re_export masc.string_util)
   (re_export masc_eio_context)
   ; RFC-0107 Phase D.2d — pool unit tests need access to Pool module.
   (re_export masc.http_client)

--- a/test/dune
+++ b/test/dune
@@ -618,7 +618,7 @@
 (test
  (name test_repo_store)
  (modules test_repo_store)
- (libraries alcotest repo_manager unix))
+ (libraries alcotest repo_manager unix masc.string_util))
 
 ; Request-authority admission uses Eio fiber-local bindings and therefore owns
 ; an explicit executable stanza instead of borrowing the pure synchronous test
@@ -822,7 +822,7 @@
 (test
  (name test_fusion_run_registry_persist)
  (modules test_fusion_run_registry_persist)
- (libraries alcotest fs_compat yojson masc.fusion_core))
+ (libraries alcotest fs_compat yojson masc.fusion_core masc.string_util))
 
 ; RFC-0207: per-keeper LLM runtime routing (runtime assignment + driver fail-fast).
 

--- a/test/dune
+++ b/test/dune
@@ -1245,7 +1245,7 @@
 (test
  (name test_voice_config)
  (modules test_voice_config)
- (libraries alcotest yojson masc.voice_config unix))
+ (libraries alcotest yojson masc.voice_config masc.string_util unix))
 
 ; MCP HTTP session persistence: save/forget/load round-trip through the
 ; fd-safe write path (close_out_noerr finally guard).
@@ -2277,7 +2277,7 @@
 (test
  (name test_eval_tool_selector_boundary)
  (modules test_eval_tool_selector_boundary)
- (libraries alcotest)
+ (libraries alcotest masc.string_util)
  (deps
   (source_tree ../lib/keeper)
   (source_tree ../lib/runtime)))

--- a/test/stanzas/test_board_api_e2e.inc
+++ b/test/stanzas/test_board_api_e2e.inc
@@ -1,7 +1,7 @@
 (test
  (name test_board_api_e2e)
  (modules test_board_api_e2e)
- (libraries alcotest masc_test_runtime unix)
+ (libraries alcotest masc_test_runtime masc.string_util unix)
  (deps ../bin/main_eio.exe)
  (enabled_if (= %{env:MASC_E2E_TESTS=false} "true"))
  (action

--- a/test/stanzas/test_ci_run_tests_script.inc
+++ b/test/stanzas/test_ci_run_tests_script.inc
@@ -1,4 +1,4 @@
 (test
  (name test_ci_run_tests_script)
  (modules test_ci_run_tests_script)
- (libraries alcotest unix))
+ (libraries alcotest unix masc.string_util))

--- a/test/stanzas/test_contract_harness_auth_script.inc
+++ b/test/stanzas/test_contract_harness_auth_script.inc
@@ -1,4 +1,4 @@
 (test
  (name test_contract_harness_auth_script)
  (modules test_contract_harness_auth_script)
- (libraries alcotest unix))
+ (libraries alcotest unix masc.string_util))

--- a/test/stanzas/test_discord_rest_client.inc
+++ b/test/stanzas/test_discord_rest_client.inc
@@ -4,4 +4,4 @@
 (test
  (name test_discord_rest_client)
  (modules test_discord_rest_client)
- (libraries alcotest yojson masc.gate))
+ (libraries alcotest yojson masc.gate masc.string_util))

--- a/test/stanzas/test_docker_playground_gc_script.inc
+++ b/test/stanzas/test_docker_playground_gc_script.inc
@@ -1,4 +1,4 @@
 (test
  (name test_docker_playground_gc_script)
  (modules test_docker_playground_gc_script)
- (libraries alcotest unix))
+ (libraries alcotest unix masc.string_util))

--- a/test/stanzas/test_dune_local_script.inc
+++ b/test/stanzas/test_dune_local_script.inc
@@ -1,4 +1,4 @@
 (test
  (name test_dune_local_script)
  (modules test_dune_local_script)
- (libraries alcotest unix))
+ (libraries alcotest unix masc.string_util))

--- a/test/stanzas/test_git_fetch_retry_script.inc
+++ b/test/stanzas/test_git_fetch_retry_script.inc
@@ -1,4 +1,4 @@
 (test
  (name test_git_fetch_retry_script)
  (modules test_git_fetch_retry_script)
- (libraries alcotest unix))
+ (libraries alcotest unix masc.string_util))

--- a/test/stanzas/test_mcp_post_sse_e2e.inc
+++ b/test/stanzas/test_mcp_post_sse_e2e.inc
@@ -1,7 +1,7 @@
 (test
  (name test_mcp_post_sse_e2e)
  (modules test_mcp_post_sse_e2e)
- (libraries alcotest masc_test_runtime yojson unix)
+ (libraries alcotest masc_test_runtime masc.string_util yojson unix)
  (deps ../bin/main_eio.exe)
  (enabled_if (= %{env:MASC_E2E_TESTS=false} "true"))
  (action

--- a/test/stanzas/test_pr_open_script.inc
+++ b/test/stanzas/test_pr_open_script.inc
@@ -1,4 +1,4 @@
 (test
  (name test_pr_open_script)
  (modules test_pr_open_script)
- (libraries alcotest unix))
+ (libraries alcotest unix masc.string_util))

--- a/test/stanzas/test_release_train_guard_script.inc
+++ b/test/stanzas/test_release_train_guard_script.inc
@@ -1,4 +1,4 @@
 (test
  (name test_release_train_guard_script)
  (modules test_release_train_guard_script)
- (libraries alcotest unix))
+ (libraries alcotest unix masc.string_util))

--- a/test/stanzas/test_tool_call_replay_harness.inc
+++ b/test/stanzas/test_tool_call_replay_harness.inc
@@ -1,4 +1,4 @@
 (test
  (name test_tool_call_replay_harness)
  (modules test_tool_call_replay_harness)
- (libraries masc masc.masc_tool_surface fs_compat alcotest yojson unix))
+ (libraries masc masc.masc_tool_surface fs_compat alcotest yojson unix masc.string_util))

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -48,24 +48,6 @@ let with_env name value f =
      | None -> Unix.putenv name "");
     raise exn
 
-let contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  if needle_len = 0 then
-    true
-  else if needle_len > text_len then
-    false
-  else
-    let rec loop i =
-      if i + needle_len > text_len then
-        false
-      else if String.sub text i needle_len = needle then
-        true
-      else
-        loop (i + 1)
-    in
-    loop 0
-
 let read_file path =
   let ic = open_in_bin path in
   Fun.protect
@@ -219,7 +201,7 @@ let test_load_auth_config_rejects_malformed_file () =
       | exception (Auth.Auth_config_error { file = actual_file; reason } as error) ->
         check string "error identifies config file" file actual_file;
         check bool "error identifies invalid field" true
-          (contains_substring reason "require_token");
+          (String_util.contains_substring reason "require_token");
         check string "public exception hides path and parser detail"
           "Auth.Auth_config_error"
           (Printexc.to_string error))
@@ -469,9 +451,9 @@ let test_verify_token_reports_token_owner_on_agent_mismatch () =
       let rendered = Masc_domain.masc_error_to_string (Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized msg)) in
       check bool "mismatch message names token owner" true
         (String.contains rendered '('
-         && contains_substring rendered "bearer token belongs to codex");
+         && String_util.contains_substring rendered "bearer token belongs to codex");
       check bool "mismatch message explains fix" true
-        (contains_substring rendered
+        (String_util.contains_substring rendered
            "masc login --agent gemini --role worker --shell")
   | Ok _, Ok _ ->
       fail "verify_token should fail when token owner and requested agent differ"
@@ -736,7 +718,7 @@ let test_verify_token_rejects_dashboard_dev_legacy_alias () =
   | Error e ->
       let rendered = Masc_domain.masc_error_to_string e in
       check bool "legacy dashboard-dev bearer rejected for dashboard" true
-        (contains_substring rendered "bearer token belongs to dashboard-dev")
+        (String_util.contains_substring rendered "bearer token belongs to dashboard-dev")
 
 let test_save_raw_token_credential_uses_provided_token () =
   let dir = setup_test_workspace () in

--- a/test/test_auth_login.ml
+++ b/test/test_auth_login.ml
@@ -19,20 +19,6 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
-let contains_substring ~needle s =
-  let nl = String.length needle in
-  let sl = String.length s in
-  if nl = 0 || nl > sl then
-    false
-  else
-    let limit = sl - nl in
-    let rec loop i =
-      if i > limit then false
-      else if String.sub s i nl = needle then true
-      else loop (i + 1)
-    in
-    loop 0
-
 (* With_expiry path: caller passes the default env var name, mint
    honors it verbatim. Agent_name is just a free string — the server
    no longer derives env names from it. *)
@@ -91,7 +77,7 @@ let test_login_with_expiry_uses_caller_env_var () =
              (Masc_domain.masc_error_to_string err));
       let shell = Auth_login.render_shell report in
       check bool "shell exports caller-named env var" true
-        (contains_substring ~needle:"export MASC_TOKEN="
+        (String_util.string_contains_substring ~needle:"export MASC_TOKEN="
            shell);
       let json = Auth_login.to_yojson report in
       check string "json status" "ok"
@@ -129,7 +115,7 @@ let test_login_long_lived_passes_env_var_through () =
              (Masc_domain.masc_error_to_string err));
       let shell = Auth_login.render_shell report in
       check bool "shell exports caller-named env var" true
-        (contains_substring ~needle:"export CUSTOM_MCP_TOKEN="
+        (String_util.string_contains_substring ~needle:"export CUSTOM_MCP_TOKEN="
            shell);
       let json = Auth_login.to_yojson report in
       check string "json client env passthrough" "CUSTOM_MCP_TOKEN"

--- a/test/test_board_api_e2e.ml
+++ b/test/test_board_api_e2e.ml
@@ -78,16 +78,6 @@ let run_curl ~port ~path () =
   (try Sys.remove body_file with _ -> ());
   { status; body; curl_exit; stderr }
 
-let contains_substr needle haystack =
-  let n = String.length needle in
-  let h = String.length haystack in
-  let rec loop i =
-    if i + n > h then false
-    else if String.sub haystack i n = needle then true
-    else loop (i + 1)
-  in
-  n = 0 || loop 0
-
 let find_free_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Fun.protect
@@ -111,7 +101,8 @@ let wait_for_health ~port ~timeout_s =
     else
       let res = run_curl ~port ~path:"/health" () in
       match res.status with
-      | Some 200 when contains_substr "\"state_ready\":true" res.body -> true
+      | Some 200
+        when String_util.contains_substring res.body "\"state_ready\":true" -> true
       | _ ->
           Unix.sleepf 0.1;
           loop ()
@@ -202,7 +193,9 @@ let test_board_missing_post_returns_404 () =
     match (res.status, retries_left) with
     | Some 503, retries
       when retries > 0
-           && contains_substr "Server is starting up, not ready yet" res.body ->
+           && String_util.contains_substring
+                res.body
+                "Server is starting up, not ready yet" ->
         Unix.sleepf 0.5;
         get_until_ready (retries - 1)
     | None, retries when retries > 0 && res.curl_exit = 28 ->
@@ -220,7 +213,7 @@ let test_board_missing_post_returns_404 () =
             res.curl_exit
             res.stderr));
   check bool "error payload contains message" true
-    (contains_substr "Post not found" res.body)
+    (String_util.contains_substring res.body "Post not found")
 
 let () =
   run "board_api_e2e"

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -295,21 +295,12 @@ let meta_has_source (meta : Yojson.Safe.t option) : bool =
   | _ -> false
 
 (* stdlib-only substring containment; avoids a [re] dep for this test exe. *)
-let contains_substring ~(needle : string) (haystack : string) : bool =
-  let nlen = String.length needle and hlen = String.length haystack in
-  let rec scan i =
-    if i + nlen > hlen then false
-    else if String.equal (String.sub haystack i nlen) needle then true
-    else scan (i + 1)
-  in
-  nlen = 0 || scan 0
-
 let check_io_error ~where = function
   | Error (Board.Io_error msg) ->
       Alcotest.(check bool)
         ("error includes " ^ where)
         true
-        (contains_substring ~needle:where msg)
+        (String_util.string_contains_substring ~needle:where msg)
   | Error e -> Alcotest.fail ("expected Io_error, got " ^ Board.show_board_error e)
   | Ok _ -> Alcotest.fail "expected Io_error"
 

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -162,9 +162,10 @@ let test_deadline_terminates_command_once () =
       check bool "timed-out command did not complete" false (Sys.file_exists done_log);
       let observed = String.concat "\n" [ read_file ci_log; stdout; stderr ] in
       check bool "active process diagnostics" true
-        (contains_substring observed "[ci-diag] reason=timeout_1s");
+        (String_util.contains_substring observed "[ci-diag] reason=timeout_1s");
       check bool "timeout reported" true
-        (contains_substring observed "test command timed out after 1s"))
+        (String_util.contains_substring observed
+           "test command timed out after 1s"))
 
 let test_deadline_kills_reparented_term_ignoring_child () =
   with_temp_dir "ci-run-tests-descendant" (fun dir ->

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -13,15 +13,6 @@ let source_root () =
 let script_path () =
   Filename.concat (source_root ()) "scripts/ci-run-tests.sh"
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
@@ -128,7 +119,7 @@ let test_dune_command_is_observed_once_and_sanitized () =
       check string "DUNE_RPC removed" "unset" (read_file rpc_log);
       let observed = String.concat "\n" [ read_file ci_log; stdout; stderr ] in
       check bool "success reported" true
-        (contains_substring observed "tests completed successfully"))
+        (String_util.contains_substring observed "tests completed successfully"))
 
 let test_failure_is_not_retried () =
   with_temp_dir "ci-run-tests-failure" (fun dir ->
@@ -149,9 +140,9 @@ let test_failure_is_not_retried () =
       check int "one attempt" 1 (count_lines count_log);
       let observed = String.concat "\n" [ read_file ci_log; stdout; stderr ] in
       check bool "failure diagnostics" true
-        (contains_substring observed "[ci-diag] reason=nonzero_exit_7");
+        (String_util.contains_substring observed "[ci-diag] reason=nonzero_exit_7");
       check bool "failure reported" true
-        (contains_substring observed "test command failed with exit=7"))
+        (String_util.contains_substring observed "test command failed with exit=7"))
 
 let test_deadline_terminates_command_once () =
   with_temp_dir "ci-run-tests-deadline" (fun dir ->
@@ -217,14 +208,14 @@ let test_contract_harness_runs_once () =
       check int "one contract attempt" 1 (count_lines count_log);
       let observed = String.concat "\n" [ read_file ci_log; stdout; stderr ] in
       check bool "contract success reported" true
-        (contains_substring observed "contract harness completed successfully"))
+        (String_util.contains_substring observed "contract harness completed successfully"))
 
 let test_retry_layers_are_absent () =
   let script = read_file (script_path ()) in
   List.iter
     (fun forbidden ->
       check bool ("absent: " ^ forbidden) false
-        (contains_substring script forbidden))
+        (String_util.contains_substring script forbidden))
     [
       "CI_TEST_ALLOW_FLAKY_RETRY";
       "CI_TEST_ALLOW_RPC_RETRY";

--- a/test/test_code_navigation_eio.ml
+++ b/test/test_code_navigation_eio.ml
@@ -17,16 +17,6 @@ let with_eio_context env sw f =
     ~mono_clock:(Eio.Stdenv.mono_clock env)
     ~sw f
 
-let contains_substring s needle =
-  let s_len = String.length s in
-  let n_len = String.length needle in
-  let rec loop i =
-    if i + n_len > s_len then false
-    else if String.sub s i n_len = needle then true
-    else loop (i + 1)
-  in
-  if n_len = 0 then true else loop 0
-
 let json_get_field obj field =
   match obj with
   | `Assoc fields ->
@@ -141,11 +131,11 @@ let test_code_search_basic () =
   if is_error then begin
     (* Error is acceptable if rg not installed *)
     check bool "error mentions ripgrep or command" true
-      (contains_substring text "ripgrep" ||
-       contains_substring text "command" ||
-       contains_substring text "rg" ||
-       contains_substring text "git" ||
-       contains_substring text "Internal error")
+      (String_util.contains_substring text "ripgrep" ||
+       String_util.contains_substring text "command" ||
+       String_util.contains_substring text "rg" ||
+       String_util.contains_substring text "git" ||
+       String_util.contains_substring text "Internal error")
   end else begin
     (* Parse the tool-specific JSON from text *)
     let tool_result = Yojson.Safe.from_string text in
@@ -169,7 +159,7 @@ let test_code_search_basic () =
                     (match json_get_string first "path" with
                      | Some path ->
                          check bool "path contains lib/" true
-                           (contains_substring path "lib/")
+                           (String_util.contains_substring path "lib/")
                      | None -> fail "missing path field");
                     (match json_get_int first "line" with
                      | Some line -> check bool "line > 0" true (line > 0)

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -119,15 +119,6 @@ let parse_json raw =
   try Yojson.Safe.from_string raw with
   | Yojson.Json_error err -> fail ("invalid json: " ^ err)
 
-let contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    idx + needle_len <= text_len
-    && (String.sub text idx needle_len = needle || loop (idx + 1))
-  in
-  needle_len = 0 || loop 0
-
 (* Owner of a task if it is currently Claimed/InProgress, else None. *)
 let assignee_of config task_id =
   match
@@ -388,7 +379,7 @@ let test_llm_rejection_keeps_task_active_then_approval_completes () =
     check string "LLM reject controls outcome" "failure"
       (outcome_label rejected.KTE.disposition);
     check bool "LLM reason is returned" true
-      (contains_substring rejected.KTE.raw_output "deliverable is not complete");
+      (String_util.contains_substring rejected.KTE.raw_output "deliverable is not complete");
     (match assignee_of config "task-001" with
      | Some assignee ->
        check string "task remains active for the same keeper"
@@ -448,7 +439,7 @@ let test_unavailable_evaluator_keeps_task_active () =
     check string "unavailable evaluator rejects" "failure"
       (outcome_label result.KTE.disposition);
     check bool "typed evaluator failure is visible" true
-      (contains_substring result.KTE.raw_output "evaluator unavailable");
+      (String_util.contains_substring result.KTE.raw_output "evaluator unavailable");
     match assignee_of config "task-001" with
     | Some assignee ->
       check string "only task remains active" meta.agent_name assignee

--- a/test/test_contract_harness_auth_script.ml
+++ b/test/test_contract_harness_auth_script.ml
@@ -9,15 +9,6 @@ let read_file path = In_channel.with_open_bin path In_channel.input_all
 
 let read_source_file rel = read_file (Filename.concat (source_root ()) rel)
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let substring_index haystack needle =
   let hlen = String.length haystack in
   let nlen = String.length needle in
@@ -30,10 +21,10 @@ let substring_index haystack needle =
   loop 0
 
 let require_contains label source needle =
-  check bool label true (contains_substring source needle)
+  check bool label true (String_util.contains_substring source needle)
 
 let require_not_contains label source needle =
-  check bool label false (contains_substring source needle)
+  check bool label false (String_util.contains_substring source needle)
 
 let require_order label source first second =
   match (substring_index source first, substring_index source second) with

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -40,15 +40,6 @@ let invalid_utf8_byte_count s =
   in
   loop 0 0
 
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop i =
-    i + needle_len <= haystack_len
-    && (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
-  in
-  needle_len = 0 || loop 0
-
 let nested_path_string_present_or_null json key =
   let open Yojson.Safe.Util in
   match json |> member key with
@@ -256,7 +247,7 @@ let test_event_queue_operator_routes_are_exact () =
     "board_signal"
     (pending_json |> member "payload_kind" |> to_string);
   check bool "event pending projection omits raw payload content" false
-    (contains_substring (Yojson.Safe.to_string pending_json) sensitive_content);
+    (String_util.contains_substring (Yojson.Safe.to_string pending_json) sensitive_content);
   check bool "event pending projection has no raw source object" true
     (pending_json |> member "source" = `Null);
   let same_post_id_source : Keeper_event_queue.stimulus =
@@ -403,7 +394,7 @@ let test_event_pending_projection_omits_non_rejection_payloads () =
   let open Yojson.Safe.Util in
   check bool "board content still omitted after the rejection field landed"
     false
-    (contains_substring (Yojson.Safe.to_string pending_json) sensitive);
+    (String_util.contains_substring (Yojson.Safe.to_string pending_json) sensitive);
   check bool "no rejection field on a non-rejection payload" true
     (pending_json |> member "rejection_reason" = `Null)
 ;;
@@ -1471,9 +1462,9 @@ let test_dashboard_proof_route_registered_in_http_routers () =
   let http1 = read_file "lib/server/server_routes_http_routes_dashboard.ml" in
   let h2 = read_file "lib/server/server_h2_gateway.ml" in
   check bool "HTTP/1 dashboard proof route registered" true
-    (contains_substring http1 "\"/api/v1/dashboard/proof\"");
+    (String_util.contains_substring http1 "\"/api/v1/dashboard/proof\"");
   check bool "HTTP/2 dashboard proof route registered" true
-    (contains_substring h2 "\"/api/v1/dashboard/proof\"")
+    (String_util.contains_substring h2 "\"/api/v1/dashboard/proof\"")
 
 let config_sync_runtime_toml =
   {|[runtime]
@@ -1595,7 +1586,7 @@ let test_execution_trust_does_not_call_full_keeper_projection () =
   check bool
     "execution-trust refresh cannot reintroduce the full compact projection"
     false
-    (contains_substring
+    (String_util.contains_substring
        source
        "keepers_dashboard_json ~compact:true")
 
@@ -2242,7 +2233,7 @@ let test_offline_keeper_composite_exposes_secret_projection () =
   Alcotest.(check bool)
     "offline composite redacts secret values"
     false
-    (contains_substring (Yojson.Safe.to_string json) sentinel)
+    (String_util.contains_substring (Yojson.Safe.to_string json) sentinel)
 
 let keeper_state_diagram_meta ?last_runtime_attempt_provider name =
   let runtime_attempt_fields =
@@ -2303,7 +2294,7 @@ let test_state_diagram_runtime_projection_redacts_live_runtime_evidence () =
   Alcotest.(check bool)
     "projection JSON does not leak raw provider id"
     false
-    (contains_substring json raw_provider);
+    (String_util.contains_substring json raw_provider);
   let mermaid =
     Server_dashboard_http_keeper_api.state_diagram_runtime_fsm_mermaid
       projection
@@ -2311,15 +2302,15 @@ let test_state_diagram_runtime_projection_redacts_live_runtime_evidence () =
   Alcotest.(check bool)
     "runtime FSM contains the redacted runtime node"
     true
-    (contains_substring mermaid {|state "runtime" as P0|});
+    (String_util.contains_substring mermaid {|state "runtime" as P0|});
   Alcotest.(check bool)
     "runtime FSM no longer renders fake candidate node"
     false
-    (contains_substring mermaid "candidate");
+    (String_util.contains_substring mermaid "candidate");
   Alcotest.(check bool)
     "runtime FSM does not leak raw provider id"
     false
-    (contains_substring mermaid raw_provider)
+    (String_util.contains_substring mermaid raw_provider)
 
 let test_state_diagram_runtime_projection_missing_meta_stays_empty () =
   let projection =
@@ -2344,11 +2335,11 @@ let test_state_diagram_runtime_projection_missing_meta_stays_empty () =
   Alcotest.(check bool)
     "missing meta FSM reports zero models"
     true
-    (contains_substring mermaid "Models: 0");
+    (String_util.contains_substring mermaid "Models: 0");
   Alcotest.(check bool)
     "missing meta FSM has no fake candidate node"
     false
-    (contains_substring mermaid "candidate")
+    (String_util.contains_substring mermaid "candidate")
 
 let test_dashboard_shell_separates_configured_and_persisted_keeper_counts () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
@@ -3195,7 +3186,7 @@ let test_catchup_judge_prompt_failure_is_server_error () =
       check bool
         "response identifies the unavailable prompt"
         true
-        (contains_substring raw "judge.catchup prompt unavailable"))
+        (String_util.contains_substring raw "judge.catchup prompt unavailable"))
 ;;
 
 let test_config_post_restarts_from_atomic_toml () =

--- a/test/test_dashboard_k2_feeds.ml
+++ b/test/test_dashboard_k2_feeds.ml
@@ -88,18 +88,6 @@ let append_jsonl path json =
 
 let strings json = json |> Json.to_list |> List.map Json.to_string
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if idx + needle_len > haystack_len
-    then false
-    else if String.equal (String.sub haystack idx needle_len) needle
-    then true
-    else loop (idx + 1)
-  in
-  String.equal needle "" || loop 0
-;;
 
 (* --- Decision log tests --- *)
 
@@ -197,7 +185,7 @@ let test_decisions_log_json_shape () =
     "summary contains blocker"
     true
     (let s = Json.(event |> member "summary" |> to_string) in
-     contains_substring ~needle:"blocked" s)
+     String_util.string_contains_substring ~needle:"blocked" s)
 ;;
 
 let test_decisions_json_terminal_reason_duration_fallback () =
@@ -276,7 +264,7 @@ let test_decisions_json_terminal_reason_duration_fallback () =
     Json.(log_event |> member "duration_ms" |> to_float);
   check bool "log summary includes reason" true
     (let s = Json.(log_event |> member "summary" |> to_string) in
-     contains_substring ~needle:"reason: provider_error" s)
+     String_util.string_contains_substring ~needle:"reason: provider_error" s)
 ;;
 
 let () =

--- a/test/test_discord_rest_client.ml
+++ b/test/test_discord_rest_client.ml
@@ -80,16 +80,6 @@ let test_build_typing_request_authorization_uses_bot_scheme () =
     (String.length ua >= 10
      && String.sub ua 0 10 = "DiscordBot")
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop offset =
-    if offset + needle_len > haystack_len then false
-    else if String.sub haystack offset needle_len = needle then true
-    else loop (offset + 1)
-  in
-  needle_len = 0 || loop 0
-
 let test_snowflake_decoder_rejects_non_decimal_ids () =
   List.iter
     (fun value ->
@@ -105,9 +95,9 @@ let test_error_rendering_does_not_disclose_response_body () =
   | Error error ->
     let rendered = Format.asprintf "%a" R.pp_error error in
     check bool "raw response is not rendered" false
-      (contains_substring ~needle:secret rendered);
+      (String_util.string_contains_substring ~needle:secret rendered);
     check bool "request correlation is rendered" true
-      (contains_substring ~needle:"req-1" rendered)
+      (String_util.string_contains_substring ~needle:"req-1" rendered)
 
 let test_build_channel_read_request_url () =
   let url, headers, body =
@@ -125,11 +115,11 @@ let test_build_messages_read_request_query () =
       ~limit:25 ~before:(sf "456") ()
   in
   check bool "messages read path"
-    true (contains_substring ~needle:"/channels/123/messages?" url);
+    true (String_util.string_contains_substring ~needle:"/channels/123/messages?" url);
   check bool "messages limit" true
-    (contains_substring ~needle:"limit=25" url);
+    (String_util.string_contains_substring ~needle:"limit=25" url);
   check bool "messages before" true
-    (contains_substring ~needle:"before=456" url);
+    (String_util.string_contains_substring ~needle:"before=456" url);
   check string "GET body" "" body
 
 let test_build_member_search_request_escapes_query () =
@@ -138,11 +128,11 @@ let test_build_member_search_request_escapes_query () =
       ~query:"min su" ~limit:10 ()
   in
   check bool "member search path" true
-    (contains_substring ~needle:"/guilds/123/members/search?" url);
+    (String_util.string_contains_substring ~needle:"/guilds/123/members/search?" url);
   check bool "member search query" true
-    (contains_substring ~needle:"query=min%20su" url);
+    (String_util.string_contains_substring ~needle:"query=min%20su" url);
   check bool "member search limit" true
-    (contains_substring ~needle:"limit=10" url)
+    (String_util.string_contains_substring ~needle:"limit=10" url)
 
 let test_build_member_request_url () =
   let url, _, _ =
@@ -248,7 +238,7 @@ let test_parse_response_rejects_duplicate_id () =
   match R.parse_response ~status:200 ~body () with
   | Error (R.Other { reason; _ }) ->
     check bool "duplicate id is named" true
-      (contains_substring ~needle:"duplicate response field \"id\"" reason)
+      (String_util.string_contains_substring ~needle:"duplicate response field \"id\"" reason)
   | Ok _ -> fail "duplicate response id must not be selected"
   | Error error ->
     failf "expected duplicate id rejection, got %s"

--- a/test/test_disk_hygiene_script.ml
+++ b/test/test_disk_hygiene_script.ml
@@ -36,15 +36,6 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let env_array overrides =
   let table = Hashtbl.create 64 in
   Unix.environment ()
@@ -192,11 +183,11 @@ let test_disk_hygiene_fix_path () =
       in
       check bool "warn-only run returns nonzero" true (code1 <> 0);
       check bool "reports dune cache warning" true
-        (contains_substring stdout1 "dune_cache");
+        (String_util.contains_substring stdout1 "dune_cache");
       check bool "reports tlc artefacts warning" true
-        (contains_substring stdout1 "tlc_artifacts");
+        (String_util.contains_substring stdout1 "tlc_artifacts");
       check bool "reports build dirs warning" true
-        (contains_substring stdout1 "build_dirs");
+        (String_util.contains_substring stdout1 "build_dirs");
       check bool "stderr empty on report run" true (String.trim stderr1 = "");
 
       let code2, stdout2, stderr2 =
@@ -224,11 +215,11 @@ let test_disk_hygiene_fix_path () =
         (Sys.file_exists (Filename.concat home_dir ".cache/dune"));
       let dune_log_contents = read_file dune_log in
       check bool "trim invoked with default size" true
-        (contains_substring dune_log_contents "cache trim --size=20GB");
+        (String_util.contains_substring dune_log_contents "cache trim --size=20GB");
       check bool "post-fix summary printed" true
-        (contains_substring stdout2 "Post-fix:");
+        (String_util.contains_substring stdout2 "Post-fix:");
       check bool "post-fix summary is clean" true
-        (contains_substring stdout2 "summary ok=4 warn=0"))
+        (String_util.contains_substring stdout2 "summary ok=4 warn=0"))
 
 let test_tla_check_cleans_generated_artifacts_by_default () =
   with_temp_dir "tla-check-cleanup" (fun dir ->
@@ -263,7 +254,7 @@ let test_tla_check_cleans_generated_artifacts_by_default () =
         failf "tla-check failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       check bool "cleanup message emitted" true
-        (contains_substring stdout "cleanup-tlc-artifacts:");
+        (String_util.contains_substring stdout "cleanup-tlc-artifacts:");
       check bool "states dir removed" false
         (Sys.file_exists (Filename.concat repo_dir "specs/states"));
       check bool "trace data removed" false
@@ -302,7 +293,7 @@ let test_tla_check_respects_keep_tlc_artifacts () =
         failf "tla-check failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       check bool "preserve message emitted" true
-        (contains_substring stdout "KEEP_TLC_ARTIFACTS=1");
+        (String_util.contains_substring stdout "KEEP_TLC_ARTIFACTS=1");
       check bool "states dir preserved" true
         (Sys.file_exists (Filename.concat repo_dir "specs/states"));
       check bool "trace data preserved" true
@@ -331,13 +322,13 @@ let read_makefile_surface () =
 let test_makefile_exposes_disk_hygiene_targets () =
   let makefile = read_makefile_surface () in
   check bool "diagnostics target exists" true
-    (contains_substring makefile "diagnostics-disk-hygiene:");
+    (String_util.contains_substring makefile "diagnostics-disk-hygiene:");
   check bool "safe fix target exists" true
-    (contains_substring makefile "fix-disk-hygiene:");
+    (String_util.contains_substring makefile "fix-disk-hygiene:");
   check bool "hard fix target exists" true
-    (contains_substring makefile "fix-disk-hygiene-hard:");
+    (String_util.contains_substring makefile "fix-disk-hygiene-hard:");
   check bool "clean target runs tlc cleanup" true
-    (contains_substring makefile "bash scripts/cleanup-tlc-artifacts.sh")
+    (String_util.contains_substring makefile "bash scripts/cleanup-tlc-artifacts.sh")
 
 let () =
   run "disk_hygiene_script"

--- a/test/test_docker_playground_gc_script.ml
+++ b/test/test_docker_playground_gc_script.ml
@@ -100,15 +100,6 @@ let run_process_ok ?(env = []) ~cwd prog argv =
 let git_ok ?(env = []) ~cwd args =
   ignore (run_process_ok ~env ~cwd "git" (Array.of_list ("git" :: args)))
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let init_repo repo_dir =
   mkdir_p repo_dir;
   git_ok ~cwd:repo_dir [ "init"; "-q" ];
@@ -179,23 +170,23 @@ EOF
         |]
     in
     check bool "worktree entries surfaced" true
-      (contains_substring stdout "worktree_entries=2");
+      (String_util.contains_substring stdout "worktree_entries=2");
     check bool "worktree fanout columns surfaced" true
-      (contains_substring stdout
+      (String_util.contains_substring stdout
          "worktree_fanout_columns=count keeper repo worktrees_dir");
     check bool "keeper fanout row surfaced" true
-      (contains_substring stdout "2 keeper-a masc");
+      (String_util.contains_substring stdout "2 keeper-a masc");
     check bool "top fanout cleanup command surfaced" true
-      (contains_substring stdout
+      (String_util.contains_substring stdout
          "top_fanout_cleanup_dry_run_command=");
     check bool "top holder count surfaced" true
-      (contains_substring stdout "top_holder_fd_count=2");
+      (String_util.contains_substring stdout "top_holder_fd_count=2");
     check bool "warning surfaced" true
-      (contains_substring stdout "hotspot_status=warning");
+      (String_util.contains_substring stdout "hotspot_status=warning");
     check bool "cleanup dry-run surfaced" true
-      (contains_substring stdout "cleanup_dry_run_command=");
+      (String_util.contains_substring stdout "cleanup_dry_run_command=");
     check bool "restart recommendation surfaced" true
-      (contains_substring stdout "docker_desktop_restart_recommended=true"))
+      (String_util.contains_substring stdout "docker_desktop_restart_recommended=true"))
 
 let test_status_warns_on_worktree_hotspot_when_lsof_fails () =
   with_temp_dir "docker-playground-status-no-lsof" (fun dir ->
@@ -227,15 +218,15 @@ let test_status_warns_on_worktree_hotspot_when_lsof_fails () =
         |]
     in
     check bool "lsof failure surfaced" true
-      (contains_substring stdout "fd_holders=unavailable (lsof failed)");
+      (String_util.contains_substring stdout "fd_holders=unavailable (lsof failed)");
     check bool "worktree-only warning surfaced" true
-      (contains_substring stdout "hotspot_status=warning");
+      (String_util.contains_substring stdout "hotspot_status=warning");
     check bool "worktree reason surfaced" true
-      (contains_substring stdout "hotspot_reasons=worktree_entries");
+      (String_util.contains_substring stdout "hotspot_reasons=worktree_entries");
     check bool "fanout still surfaces on lsof failure" true
-      (contains_substring stdout "2 keeper-a masc");
+      (String_util.contains_substring stdout "2 keeper-a masc");
     check bool "top fanout action still surfaces on lsof failure" true
-      (contains_substring stdout
+      (String_util.contains_substring stdout
          "top_fanout_cleanup_dry_run_command="))
 
 let test_status_cleanup_summary_surfaces_candidate_counts () =
@@ -275,23 +266,23 @@ let test_status_cleanup_summary_surfaces_candidate_counts () =
         |]
     in
     check bool "cleanup summary surfaced" true
-      (contains_substring stdout "Cleanup dry-run summary:");
+      (String_util.contains_substring stdout "Cleanup dry-run summary:");
     check bool "root candidate count surfaced" true
-      (contains_substring stdout "cleanup_summary_candidates=1");
+      (String_util.contains_substring stdout "cleanup_summary_candidates=1");
     check bool "root projected count surfaced" true
-      (contains_substring stdout
+      (String_util.contains_substring stdout
          "cleanup_summary_projected_worktree_entries=0");
     check bool "top fanout candidate count surfaced" true
-      (contains_substring stdout "top_fanout_cleanup_summary_candidates=1");
+      (String_util.contains_substring stdout "top_fanout_cleanup_summary_candidates=1");
     check bool "top fanout projected count surfaced" true
-      (contains_substring stdout "top_fanout_cleanup_summary_projected_count=0");
+      (String_util.contains_substring stdout "top_fanout_cleanup_summary_projected_count=0");
     check bool "aggressive summary surfaced" true
-      (contains_substring stdout "aggressive_cleanup_summary_candidates=1");
+      (String_util.contains_substring stdout "aggressive_cleanup_summary_candidates=1");
     check bool "aggressive projected count surfaced" true
-      (contains_substring stdout
+      (String_util.contains_substring stdout
          "aggressive_cleanup_summary_projected_worktree_entries=0");
     check bool "top aggressive projected count surfaced" true
-      (contains_substring stdout
+      (String_util.contains_substring stdout
          "top_fanout_aggressive_cleanup_summary_projected_count=0");
     check bool "dry-run does not remove worktree" true (Sys.file_exists wt_path))
 
@@ -310,8 +301,8 @@ let test_dry_run_lists_stale_clean_worktree () =
       run_process_ok ~cwd:(source_root ()) (cleanup_script_path ())
         [| cleanup_script_path (); "--root"; root; "--days"; "1"; "--repo"; "masc" |]
     in
-    check bool "candidate listed" true (contains_substring stdout "CANDID");
-    check bool "dry-run reminder" true (contains_substring stdout "Pass --apply");
+    check bool "candidate listed" true (String_util.contains_substring stdout "CANDID");
+    check bool "dry-run reminder" true (String_util.contains_substring stdout "Pass --apply");
     check bool "worktree retained" true (Sys.file_exists wt_path))
 
 let test_recent_checkout_of_old_commit_is_not_candidate () =
@@ -328,8 +319,8 @@ let test_recent_checkout_of_old_commit_is_not_candidate () =
       run_process_ok ~cwd:(source_root ()) (cleanup_script_path ())
         [| cleanup_script_path (); "--root"; root; "--days"; "1"; "--repo"; "masc" |]
     in
-    check bool "candidate not listed" false (contains_substring stdout "CANDID");
-    check bool "recent counted" true (contains_substring stdout "recent=1");
+    check bool "candidate not listed" false (String_util.contains_substring stdout "CANDID");
+    check bool "recent counted" true (String_util.contains_substring stdout "recent=1");
     check bool "worktree retained" true (Sys.file_exists wt_path))
 
 let test_apply_removes_stale_clean_worktree () =
@@ -356,7 +347,7 @@ let test_apply_removes_stale_clean_worktree () =
           "--apply";
         |]
     in
-    check bool "removed listed" true (contains_substring stdout "REMOVED");
+    check bool "removed listed" true (String_util.contains_substring stdout "REMOVED");
     check bool "worktree removed" false (Sys.file_exists wt_path))
 
 let test_apply_skips_dirty_worktree () =
@@ -384,7 +375,7 @@ let test_apply_skips_dirty_worktree () =
           "--apply";
         |]
     in
-    check bool "dirty listed" true (contains_substring stdout "DIRTY");
+    check bool "dirty listed" true (String_util.contains_substring stdout "DIRTY");
     check bool "dirty worktree retained" true (Sys.file_exists wt_path))
 
 let test_include_broken_removes_old_non_git_directory () =
@@ -410,7 +401,7 @@ let test_include_broken_removes_old_non_git_directory () =
         |]
     in
     check bool "broken candidate listed" true
-      (contains_substring dry_stdout "BROKEN_CANDID");
+      (String_util.contains_substring dry_stdout "BROKEN_CANDID");
     check bool "broken retained after dry-run" true (Sys.file_exists broken_path);
     let apply_stdout, _ =
       run_process_ok ~cwd:(source_root ()) (cleanup_script_path ())
@@ -427,7 +418,7 @@ let test_include_broken_removes_old_non_git_directory () =
         |]
     in
     check bool "broken removed listed" true
-      (contains_substring apply_stdout "BROKEN_REMOVED");
+      (String_util.contains_substring apply_stdout "BROKEN_REMOVED");
     check bool "broken removed" false (Sys.file_exists broken_path))
 
 let () =

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -13,17 +13,8 @@ let quote = Filename.quote
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let check_contains label haystack needle =
-  if not (contains_substring haystack needle) then
+  if not (String_util.contains_substring haystack needle) then
     failf "%s: missing %S in stderr:\n%s" label needle haystack
 
 let substring_index haystack needle =
@@ -336,7 +327,7 @@ exec "$@"
         if Sys.file_exists lockf_log then read_file lockf_log else ""
       in
       check bool "opam lockf not invoked" false
-        (contains_substring lock_log opam_lock_path);
+        (String_util.contains_substring lock_log opam_lock_path);
       check bool "dune was not invoked" false (Sys.file_exists dune_log))
 
 let test_dune_lock_wait_reports_holder () =
@@ -386,9 +377,9 @@ exit 1
       in
       check int "exits zero through lockf reexec" 0 code;
       check bool "reports Dune lock holders" true
-        (contains_substring stderr "Dune lock holder(s)");
+        (String_util.contains_substring stderr "Dune lock holder(s)");
       check bool "reports holder command" true
-        (contains_substring stderr "fake-dune-holder --target test");
+        (String_util.contains_substring stderr "fake-dune-holder --target test");
       check bool "dune was invoked after reexec" true
         (Sys.file_exists dune_log))
 
@@ -426,11 +417,11 @@ exit 1
       in
       check int "exits tempfail on live build-dir lock" 75 code;
       check bool "reports live build-dir lock" true
-        (contains_substring stderr "live Dune build-dir lock holder");
+        (String_util.contains_substring stderr "live Dune build-dir lock holder");
       check bool "reports holder command" true
-        (contains_substring stderr "dune build --root stale-worktree");
+        (String_util.contains_substring stderr "dune build --root stale-worktree");
       check bool "explains bare dune bypass" true
-        (contains_substring stderr "bare `dune` process");
+        (String_util.contains_substring stderr "bare `dune` process");
       check bool "dune was not invoked" false (Sys.file_exists dune_log))
 
 let write_bare_dune_ps bin_dir =
@@ -464,18 +455,18 @@ let test_bare_dune_bypass_aborts_before_dune () =
       in
       check int "exits tempfail on bare dune bypass" 75 code;
       check bool "reports unwrapped Dune" true
-        (contains_substring stderr "outside scripts/dune-local.sh");
+        (String_util.contains_substring stderr "outside scripts/dune-local.sh");
       check bool "reports bare dune command" true
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "dune exec --root . test/test_config_dir_resolver.exe");
       check bool "reports dune with leading global option" true
-        (contains_substring stderr "dune --root . build");
+        (String_util.contains_substring stderr "dune --root . build");
       check bool "reports opam exec dune with leading global option" true
-        (contains_substring stderr "opam exec -- dune --build-dir _build test");
+        (String_util.contains_substring stderr "opam exec -- dune --build-dir _build test");
       check bool "reports bare dune clean" true
-        (contains_substring stderr "dune clean --root .");
+        (String_util.contains_substring stderr "dune clean --root .");
       check bool "does not report wrapped child" false
-        (contains_substring stderr "wrapped-worktree");
+        (String_util.contains_substring stderr "wrapped-worktree");
       check bool "dune was not invoked" false (Sys.file_exists dune_log))
 
 let test_bare_dune_bypass_can_be_overridden () =
@@ -525,7 +516,7 @@ exec "$@"
       let lock_log = read_file lockf_log in
       let dune_lock_path = Filename.concat dir "dune-local.lock" in
       check bool "lock path passed to lockf" true
-        (contains_substring lock_log opam_lock_path);
+        (String_util.contains_substring lock_log opam_lock_path);
       check bool "dune lock acquired before opam lock" true
         (match
            ( substring_index lock_log dune_lock_path,
@@ -534,9 +525,9 @@ exec "$@"
         | Some dune_pos, Some opam_pos -> dune_pos < opam_pos
         | _ -> false);
       check bool "held env passed through argv" true
-        (contains_substring lock_log "MASC_OPAM_LOCK_HELD=1");
+        (String_util.contains_substring lock_log "MASC_OPAM_LOCK_HELD=1");
       check bool "dune held env passed through argv" true
-        (contains_substring lock_log "MASC_DUNE_LOCK_HELD=1");
+        (String_util.contains_substring lock_log "MASC_DUNE_LOCK_HELD=1");
       check bool "dune was invoked after reexec" true
         (Sys.file_exists dune_log))
 
@@ -577,7 +568,7 @@ exec "$@"
       in
       check int "opam lock timeout exits with lockf status" 75 code;
       check bool "timeout explains Dune lock release" true
-        (contains_substring stderr "releasing Dune lock");
+        (String_util.contains_substring stderr "releasing Dune lock");
       check bool "dune was not invoked after opam timeout" false
         (Sys.file_exists dune_log))
 
@@ -615,9 +606,9 @@ exec "$@"
       check int "unset timeout keeps historical wait-forever path" 0 code;
       let lock_log = read_file lockf_log in
       check bool "lockf timeout flag not used by default" false
-        (contains_substring lock_log "timeout=");
+        (String_util.contains_substring lock_log "timeout=");
       check bool "timeout message not emitted" false
-        (contains_substring stderr "releasing Dune lock");
+        (String_util.contains_substring stderr "releasing Dune lock");
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
 let test_zero_like_opam_lock_timeout_waits_forever () =
@@ -650,9 +641,9 @@ exec "$@"
       check int "zero-like timeout waits forever" 0 code;
       let lock_log = read_file lockf_log in
       check bool "lockf timeout flag not used for zero-like value" false
-        (contains_substring lock_log "timeout=");
+        (String_util.contains_substring lock_log "timeout=");
       check bool "timeout message not emitted for zero-like value" false
-        (contains_substring stderr "releasing Dune lock");
+        (String_util.contains_substring stderr "releasing Dune lock");
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
 let test_opam_lock_timeout_env_must_be_numeric () =
@@ -679,7 +670,7 @@ exec "$@"
       in
       check int "invalid timeout exits usage error" 2 code;
       check bool "invalid timeout named" true
-        (contains_substring stderr "invalid MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT");
+        (String_util.contains_substring stderr "invalid MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT");
       check bool "dune was not invoked" false (Sys.file_exists dune_log))
 
 let test_missing_lock_tools_warn_once () =
@@ -743,7 +734,7 @@ exit 1
       check bool "fake opam kept in PATH" true (Sys.file_exists opam_path);
       check bool "warning emitted exactly once" true only_once;
       check bool "opam lock warning suppressed" false
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "neither lockf nor flock found; opam switch checks are unlocked");
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
@@ -803,9 +794,9 @@ exec "$@"
       check bool "flock invoked" true (Sys.file_exists flock_log);
       let lock_log = read_file flock_log in
       check bool "lock path passed to flock" true
-        (contains_substring lock_log opam_lock_path);
+        (String_util.contains_substring lock_log opam_lock_path);
       check bool "held env passed through argv" true
-        (contains_substring lock_log "MASC_OPAM_LOCK_HELD=1");
+        (String_util.contains_substring lock_log "MASC_OPAM_LOCK_HELD=1");
       check bool "dune was invoked after flock reexec" true
         (Sys.file_exists dune_log))
 
@@ -875,9 +866,9 @@ exec "$@"
       check int "opam flock timeout exits with flock status" 1 code;
       let lock_log = read_file flock_log in
       check bool "flock timeout flag used" true
-        (contains_substring lock_log "timeout=2");
+        (String_util.contains_substring lock_log "timeout=2");
       check bool "timeout explains Dune lock release" true
-        (contains_substring stderr "releasing Dune lock");
+        (String_util.contains_substring stderr "releasing Dune lock");
       check bool "dune was not invoked after opam timeout" false
         (Sys.file_exists dune_log))
 
@@ -1044,14 +1035,14 @@ let test_missing_deps_aborts_build () =
     in
     check int "exits non-zero on missing deps" 1 code;
     check bool "missing deps message present" true
-      (contains_substring stderr "missing or incompatible findlib libraries");
+      (String_util.contains_substring stderr "missing or incompatible findlib libraries");
     check_contains "piaf stream is checked" stderr "piaf.stream";
     check_contains "OpenTelemetry API layout is checked" stderr
       "opentelemetry.client";
     check bool "repair hint present" true
-      (contains_substring stderr "opam-pin-external-deps.sh --install");
+      (String_util.contains_substring stderr "opam-pin-external-deps.sh --install");
     check bool "skip hint present" true
-      (contains_substring stderr "MASC_SKIP_DEPS_CHECK=1");
+      (String_util.contains_substring stderr "MASC_SKIP_DEPS_CHECK=1");
     check bool "dune not invoked" false (Sys.file_exists dune_log))
 
 let test_skip_deps_check_env_bypasses_guard () =
@@ -1144,9 +1135,9 @@ let test_ocaml_version_comes_from_dune_project () =
     in
     check int "exits non-zero on dune-project version mismatch" 1 code;
     check bool "live OCaml version message present" true
-      (contains_substring stderr "OCaml 5.5.0 detected");
+      (String_util.contains_substring stderr "OCaml 5.5.0 detected");
     check bool "dune-project exact version mentioned" true
-      (contains_substring stderr "exactly 5.6.0");
+      (String_util.contains_substring stderr "exactly 5.6.0");
     check bool "dune not invoked" false (Sys.file_exists dune_log))
 
 let test_split_opam_prefix_aborts_build () =

--- a/test/test_eval_tool_selector_boundary.ml
+++ b/test/test_eval_tool_selector_boundary.ml
@@ -26,25 +26,13 @@ let read_file path =
     (fun () -> really_input_string ic (in_channel_length ic))
 ;;
 
-let contains_substring ~needle text =
-  let nlen = String.length needle in
-  let tlen = String.length text in
-  let rec loop i =
-    if i + nlen > tlen
-    then false
-    else if String.sub text i nlen = needle
-    then true
-    else loop (i + 1)
-  in
-  loop 0
-;;
 
 let test_not_used_by_live_keeper_or_runtime () =
   let files = List.fold_left (fun acc root -> collect_sources root acc) [] guarded_roots in
   let offenders =
     files
     |> List.filter (fun path ->
-      contains_substring ~needle:"Eval_tool_selector" (read_file path))
+      String_util.string_contains_substring ~needle:"Eval_tool_selector" (read_file path))
     |> List.sort String.compare
   in
   match offenders with

--- a/test/test_fusion_run_registry_persist.ml
+++ b/test/test_fusion_run_registry_persist.ml
@@ -15,19 +15,6 @@ let remove_if_exists path =
   | Sys_error _ -> ()
 ;;
 
-let contains_substring value needle =
-  let value_len = String.length value in
-  let needle_len = String.length needle in
-  let rec loop index =
-    if needle_len = 0
-    then true
-    else if index + needle_len > value_len
-    then false
-    else if String.sub value index needle_len = needle
-    then true
-    else loop (index + 1)
-  in
-  loop 0
 ;;
 
 let fresh_path suffix =
@@ -126,7 +113,7 @@ let test_replay_prunes_completed () =
   check bool "replayed running run dropped" true
     (Option.is_none (R.get t2 ~run_id:"r-running"));
   check bool "compacted log omits stale running run" false
-    (contains_substring (Fs_compat.load_file path) "r-running");
+    (String_util.contains_substring (Fs_compat.load_file path) "r-running");
   (* Newest completed run (r70) must be present; oldest (r1) pruned. *)
   check bool "newest completed kept" true (Option.is_some (R.get t2 ~run_id:"r70"));
   check bool "oldest completed pruned" true (Option.is_none (R.get t2 ~run_id:"r1"))
@@ -161,7 +148,7 @@ let test_replay_skips_malformed_lines () =
    | Some _ -> fail "expected replayed run to be completed as failed"
    | None -> fail "expected valid replay events around malformed line to load");
   check bool "malformed evidence is preserved" true
-    (contains_substring (Fs_compat.load_file path) "not-json")
+    (String_util.contains_substring (Fs_compat.load_file path) "not-json")
 ;;
 
 (* (5) Replay streams raw JSONL lines and compacts the retained state. *)

--- a/test/test_git_fetch_retry_script.ml
+++ b/test/test_git_fetch_retry_script.ml
@@ -8,15 +8,6 @@ let source_root () =
 let script_path () =
   Filename.concat (source_root ()) "scripts/ci/git-fetch-retry.sh"
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
@@ -153,12 +144,12 @@ let test_retries_until_fetch_succeeds () =
         failf "git-fetch-retry failed (%d)\nstdout:\n%s\nstderr:\n%s" code
           stdout stderr;
       check bool "reports eventual success" true
-        (contains_substring stdout "fetch ok on attempt 3");
+        (String_util.contains_substring stdout "fetch ok on attempt 3");
       check bool "first retry warning emitted" true
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "::warning::git fetch attempt 1/3 failed with exit 128; retrying in 0s");
       check bool "second retry warning emitted" true
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "::warning::git fetch attempt 2/3 failed with exit 128; retrying in 0s");
       let git_calls = nonempty_lines (read_file fake_git_log) in
       check (list string) "fetch retried three times"
@@ -192,7 +183,7 @@ let test_reports_failure_after_last_attempt () =
       in
       check bool "command fails after attempts exhausted" true (code <> 0);
       check bool "final failure message emitted" true
-        (contains_substring stderr "git fetch failed after 3 attempt(s)");
+        (String_util.contains_substring stderr "git fetch failed after 3 attempt(s)");
       let git_calls = nonempty_lines (read_file fake_git_log) in
       check (list string) "fetch attempted exactly three times"
         [ "fetch origin main --depth=1"; "fetch origin main --depth=1";

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -40,11 +40,6 @@ let iso_now () = Masc_domain.now_iso ()
 let goals_recovery_path config =
   Goal_store.goals_path config ^ ".last-good"
 
-let contains_substring haystack needle =
-  let hl = String.length haystack and nl = String.length needle in
-  let rec scan i = i + nl <= hl && (String.sub haystack i nl = needle || scan (i + 1)) in
-  nl = 0 || scan 0
-
 let make_goal id title =
   let ts = iso_now () in
   {
@@ -213,7 +208,7 @@ let test_status_field_no_longer_decodes () =
    | Ok _ -> fail "upsert_goal wrote over an undecodable store"
    | Error msg ->
        check bool "refusal names the store path" true
-         (contains_substring msg (Goal_store.goals_path config)));
+         (String_util.contains_substring msg (Goal_store.goals_path config)));
   let on_disk_after = In_channel.with_open_bin (Goal_store.goals_path config)
     In_channel.input_all
   in

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -57,19 +57,6 @@ let get_string_field json field =
   | _ -> fail (field ^ " missing")
 ;;
 
-let contains_substring s needle =
-  let s_len = String.length s in
-  let n_len = String.length needle in
-  let rec loop i =
-    if n_len = 0
-    then true
-    else if i + n_len > s_len
-    then false
-    else if String.sub s i n_len = needle
-    then true
-    else loop (i + 1)
-  in
-  loop 0
 ;;
 
 let expect_error (result : Tool_result.result option) =
@@ -236,7 +223,7 @@ let test_goal_list_rejects_status_filter () =
     bool
     "error points to removed status"
     true
-    (contains_substring (Yojson.Safe.to_string error_json) "status filter was removed");
+    (String_util.contains_substring (Yojson.Safe.to_string error_json) "status filter was removed");
   let field_errors =
     Yojson.Safe.Util.member "field_errors" error_json |> Yojson.Safe.Util.to_list
   in
@@ -265,7 +252,7 @@ let test_goal_upsert_rejects_lifecycle_fields () =
     bool
     "phase error points at transition"
     true
-    (contains_substring (Yojson.Safe.to_string phase_error) "masc_goal_transition");
+    (String_util.contains_substring (Yojson.Safe.to_string phase_error) "masc_goal_transition");
   let goal, _kind =
     match Goal_store.upsert_goal config ~title:"Existing goal" () with
     | Ok payload -> payload

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -483,15 +483,6 @@ let request_tests =
 (* RFC 7230 §3.3.2: a 204 response with no payload should still carry
    an explicit [Content-Length: 0] so keep-alive clients and proxies
    know the body is empty. *)
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec scan i =
-    if i + nlen > hlen then false
-    else if String.equal (String.sub haystack i nlen) needle then true
-    else scan (i + 1)
-  in
-  nlen = 0 || scan 0
 ;;
 
 let test_response_empty_includes_content_length_zero () =
@@ -519,7 +510,7 @@ let test_response_empty_includes_content_length_zero () =
   Alcotest.(check bool)
     "204 Response.empty includes Content-Length: 0"
     true
-    (contains_substring response "content-length: 0")
+    (String_util.contains_substring response "content-length: 0")
 ;;
 
 let response_tests =

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -19,16 +19,6 @@ let make_meta ?(allowed_paths = []) ~name () =
 let sandbox_roots meta =
   [ KAP.sandbox_path_of_meta ~meta ]
 
-let contains_substring s needle =
-  let s_len = String.length s in
-  let n_len = String.length needle in
-  let rec loop i =
-    if i + n_len > s_len then false
-    else if String.sub s i n_len = needle then true
-    else loop (i + 1)
-  in
-  n_len = 0 || loop 0
-
 let test_empty_paths_default_to_sandbox_root () =
   let meta = make_meta ~name:"keeper" () in
   let expected = sandbox_roots meta in
@@ -66,9 +56,9 @@ let test_validate_rejects_globs_and_traversal () =
   | Ok () -> fail "expected path-shape rejection"
   | Error err ->
       check bool "error mentions rejected path" true
-        (contains_substring err "workspace/../outside");
+        (String_util.contains_substring err "workspace/../outside");
       check bool "error mentions glob" true
-        (contains_substring err "logs/*.txt")
+        (String_util.contains_substring err "logs/*.txt")
 
 let test_validate_accepts_plain_paths () =
   match

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -48,9 +48,6 @@ let with_env key value f =
       | None -> Unix.putenv key "")
     f
 
-let contains_substring haystack needle =
-  String_util.contains_substring haystack needle
-
 let with_eio_fs f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -327,13 +324,13 @@ let test_recent_direct_context_renders_prior_reply_and_tool_evidence () =
         (recent_roles lines);
       let rendered = MS.render_recent_direct_conversation_context lines in
       Alcotest.(check bool) "previous assistant utterance is visible" true
-        (contains_substring rendered "I was reading the board.");
+        (String_util.contains_substring rendered "I was reading the board.");
       Alcotest.(check bool) "tool evidence keeps only call name" true
-        (contains_substring rendered "tool_call: masc_board_list");
+        (String_util.contains_substring rendered "tool_call: masc_board_list");
       Alcotest.(check bool) "tool args are not prompt evidence" false
-        (contains_substring rendered {|{"limit":20}|});
+        (String_util.contains_substring rendered {|{"limit":20}|});
       Alcotest.(check bool) "grounding guard present" true
-        (contains_substring rendered "without tool evidence"))
+        (String_util.contains_substring rendered "without tool evidence"))
 
 let test_recent_direct_context_omits_transport_failure_as_self_reply () =
   let base_dir = temp_base_path "keeper-chat-recent-failure" in
@@ -356,7 +353,7 @@ let test_recent_direct_context_omits_transport_failure_as_self_reply () =
         [ "user" ] (recent_roles lines);
       let rendered = MS.render_recent_direct_conversation_context lines in
       Alcotest.(check bool) "failure text is not a self utterance" false
-        (contains_substring rendered "Keeper request failed"))
+        (String_util.contains_substring rendered "Keeper request failed"))
 
 let test_recent_direct_context_omits_voice_audio_self_echo () =
   let base_dir = temp_base_path "keeper-chat-recent-voice" in
@@ -385,7 +382,7 @@ let test_recent_direct_context_omits_voice_audio_self_echo () =
         [] (recent_roles lines);
       let rendered = MS.render_recent_direct_conversation_context lines in
       Alcotest.(check bool) "spoken text is not re-injected" false
-        (contains_substring rendered "I will say this out loud now."))
+        (String_util.contains_substring rendered "I will say this out loud now."))
 
 let test_direct_owner_context_excludes_connector_turns () =
   with_eio_fs (fun () ->
@@ -408,7 +405,7 @@ let test_direct_owner_context_excludes_connector_turns () =
         in
         let owner_context = context ~direct_reply:true ~channel:"" () in
         Alcotest.(check bool) "owner direct receives recent transcript" true
-          (contains_substring
+          (String_util.contains_substring
              owner_context
              "I just answered from direct chat.");
         Alcotest.(check string) "connector channel suppresses transcript" ""
@@ -451,15 +448,15 @@ let test_append_turn_redacts_projected_secrets () =
         ();
       let raw = read_file (chat_path ~base_dir ~keeper_name) in
       Alcotest.(check bool) "env secret not persisted" false
-        (contains_substring raw env_secret);
+        (String_util.contains_substring raw env_secret);
       Alcotest.(check bool) "file secret not persisted" false
-        (contains_substring raw file_secret);
+        (String_util.contains_substring raw file_secret);
       let messages = K.load ~base_dir ~keeper_name in
       let rendered = Yojson.Safe.to_string (K.to_json_array messages) in
       Alcotest.(check bool) "loaded view stays redacted" false
-        (contains_substring rendered env_secret);
+        (String_util.contains_substring rendered env_secret);
       Alcotest.(check bool) "redaction marker present" true
-        (contains_substring rendered "[REDACTED]"))
+        (String_util.contains_substring rendered "[REDACTED]"))
 
 let test_load_redacts_raw_persisted_secret_rows () =
   let base_dir = temp_base_path "keeper-chat-store-read-redact" in
@@ -483,9 +480,9 @@ let test_load_redacts_raw_persisted_secret_rows () =
       match K.load ~base_dir ~keeper_name with
       | [ msg ] ->
           Alcotest.(check bool) "raw persisted value hidden on read" false
-            (contains_substring msg.K.content secret);
+            (String_util.contains_substring msg.K.content secret);
           Alcotest.(check bool) "marker present on read" true
-            (contains_substring msg.K.content "[REDACTED]")
+            (String_util.contains_substring msg.K.content "[REDACTED]")
       | messages ->
           Alcotest.failf "expected 1 message, got %d" (List.length messages))
 
@@ -970,7 +967,7 @@ let test_failure_turn_kind_roundtrip () =
             (K.Row_kind.equal asst.kind K.Row_kind.Transport_failure);
           let raw = read_file (chat_path ~base_dir ~keeper_name) in
           Alcotest.(check bool) "failure row persists the kind field" true
-            (contains_substring raw {|"kind":"transport_failure"|})
+            (String_util.contains_substring raw {|"kind":"transport_failure"|})
       | messages ->
           Alcotest.failf "expected 2 rows, got %d" (List.length messages))
 
@@ -988,7 +985,7 @@ let test_kind_absent_reads_utterance () =
         ~assistant_content:"world" ();
       let raw = read_file (chat_path ~base_dir ~keeper_name) in
       Alcotest.(check bool) "utterance rows carry no kind field" false
-        (contains_substring raw {|"kind"|});
+        (String_util.contains_substring raw {|"kind"|});
       match K.load ~base_dir ~keeper_name with
       | [ user; asst ] ->
           Alcotest.(check bool) "user reads as utterance" true
@@ -1112,10 +1109,10 @@ let test_audio_url_and_device_id_persist () =
       let raw = read_file (chat_path ~base_dir ~keeper_name) in
       Alcotest.(check bool) "audio_url persisted"
         true
-        (contains_substring raw "\"audio_url\":\"https://example.com/audio.mp3\"");
+        (String_util.contains_substring raw "\"audio_url\":\"https://example.com/audio.mp3\"");
       Alcotest.(check bool) "device_id persisted"
         true
-        (contains_substring raw "\"device_id\":\"device-42\"");
+        (String_util.contains_substring raw "\"device_id\":\"device-42\"");
       let messages = K.load ~base_dir ~keeper_name in
       match K.to_json_array messages with
       | `List [ `Assoc fields ] -> (
@@ -1254,9 +1251,9 @@ let test_append_turn_redacts_supplied_thinking_blocks () =
         ();
       let raw = read_file (chat_path ~base_dir ~keeper_name) in
       Alcotest.(check bool) "thinking secret not persisted" false
-        (contains_substring raw secret);
+        (String_util.contains_substring raw secret);
       Alcotest.(check bool) "redaction marker persisted" true
-        (contains_substring raw "[REDACTED]");
+        (String_util.contains_substring raw "[REDACTED]");
       let messages = K.load ~base_dir ~keeper_name in
       let assistant =
         List.find
@@ -1266,9 +1263,9 @@ let test_append_turn_redacts_supplied_thinking_blocks () =
       match assistant.K.blocks with
       | Some [ B.Thinking thinking ] ->
         Alcotest.(check bool) "thinking content redacted on load" false
-          (contains_substring thinking.content secret);
+          (String_util.contains_substring thinking.content secret);
         Alcotest.(check bool) "thinking redaction marker visible" true
-          (contains_substring thinking.content "[REDACTED]")
+          (String_util.contains_substring thinking.content "[REDACTED]")
       | Some _ -> Alcotest.fail "expected exactly one thinking block"
       | None -> Alcotest.fail "assistant thinking block missing")
 
@@ -1339,13 +1336,13 @@ let test_append_turn_redacts_all_supplied_block_strings () =
         ();
       let raw = read_file (chat_path ~base_dir ~keeper_name) in
       Alcotest.(check bool) "rich block secret not persisted" false
-        (contains_substring raw secret);
+        (String_util.contains_substring raw secret);
       Alcotest.(check bool) "sensitive keyed value not persisted" false
-        (contains_substring raw "plain-non-pattern-value");
+        (String_util.contains_substring raw "plain-non-pattern-value");
       Alcotest.(check bool) "sensitive password value not persisted" false
-        (contains_substring raw "ordinary-value");
+        (String_util.contains_substring raw "ordinary-value");
       Alcotest.(check bool) "rich block redaction marker persisted" true
-        (contains_substring raw "[REDACTED]");
+        (String_util.contains_substring raw "[REDACTED]");
       let messages = K.load ~base_dir ~keeper_name in
       let assistant =
         List.find
@@ -1356,13 +1353,13 @@ let test_append_turn_redacts_all_supplied_block_strings () =
       | Some blocks ->
         let json = Yojson.Safe.to_string (B.blocks_to_yojson blocks) in
         Alcotest.(check bool) "loaded blocks hide secret" false
-          (contains_substring json secret);
+          (String_util.contains_substring json secret);
         Alcotest.(check bool) "loaded blocks hide sensitive keyed value" false
-          (contains_substring json "plain-non-pattern-value");
+          (String_util.contains_substring json "plain-non-pattern-value");
         Alcotest.(check bool) "loaded blocks hide sensitive password value" false
-          (contains_substring json "ordinary-value");
+          (String_util.contains_substring json "ordinary-value");
         Alcotest.(check bool) "loaded blocks keep redaction marker" true
-          (contains_substring json "[REDACTED]")
+          (String_util.contains_substring json "[REDACTED]")
       | None -> Alcotest.fail "assistant rich blocks missing")
 
 (* Fusion board_post_id/run_id are opaque lookup keys the dashboard uses to
@@ -1401,7 +1398,7 @@ let test_append_turn_preserves_fusion_lookup_ids () =
           messages
       in
       Alcotest.(check bool) "free-form assistant content still redacted" false
-        (contains_substring assistant.K.content secret);
+        (String_util.contains_substring assistant.K.content secret);
       match assistant.K.blocks with
       | Some [ B.Fusion fusion ] ->
         Alcotest.(check string) "board_post_id preserved verbatim"
@@ -1453,14 +1450,14 @@ let test_load_redacts_raw_persisted_blocks_and_audio () =
       match messages with
       | [ msg ] ->
         Alcotest.(check bool) "raw content redacted on load" false
-          (contains_substring msg.K.content secret);
+          (String_util.contains_substring msg.K.content secret);
         (match msg.K.audio with
          | Some audio ->
            Alcotest.(check bool) "raw audio message_text redacted on load" false
-             (contains_substring audio.message_text secret);
+             (String_util.contains_substring audio.message_text secret);
            let audio_url_contains_secret =
              match audio.audio_url with
-             | Some url -> contains_substring url secret
+             | Some url -> String_util.contains_substring url secret
              | None -> false
            in
            Alcotest.(check bool) "raw audio audio_url redacted on load" false
@@ -1469,14 +1466,14 @@ let test_load_redacts_raw_persisted_blocks_and_audio () =
         Alcotest.(check bool) "raw blocks redacted on load" false
           (match msg.K.blocks with
            | Some blocks ->
-             contains_substring (Yojson.Safe.to_string (B.blocks_to_yojson blocks)) secret
+             String_util.contains_substring (Yojson.Safe.to_string (B.blocks_to_yojson blocks)) secret
            | None -> true);
         let json = K.to_json_array messages in
         let s = Yojson.Safe.to_string json in
         Alcotest.(check bool) "to_json_array hides raw persisted secret" false
-          (contains_substring s secret);
+          (String_util.contains_substring s secret);
         Alcotest.(check bool) "redaction marker present in served payload" true
-          (contains_substring s "[REDACTED]")
+          (String_util.contains_substring s "[REDACTED]")
       | messages ->
         Alcotest.failf "expected 1 message, got %d" (List.length messages))
 
@@ -1507,25 +1504,25 @@ let test_append_assistant_message_redacts_audio () =
         ();
       let raw = read_file (chat_path ~base_dir ~keeper_name) in
       Alcotest.(check bool) "assistant content secret not persisted" false
-        (contains_substring raw secret);
+        (String_util.contains_substring raw secret);
       Alcotest.(check bool) "assistant audio_url secret not persisted" false
-        (contains_substring raw ("https://cdn.example.com/audio?sig=" ^ secret));
+        (String_util.contains_substring raw ("https://cdn.example.com/audio?sig=" ^ secret));
       Alcotest.(check bool) "assistant audio message_text secret not persisted" false
-        (contains_substring raw ("caption " ^ secret));
+        (String_util.contains_substring raw ("caption " ^ secret));
       Alcotest.(check bool) "redaction marker persisted" true
-        (contains_substring raw "[REDACTED]");
+        (String_util.contains_substring raw "[REDACTED]");
       let messages = K.load ~base_dir ~keeper_name in
       match messages with
       | [ msg ] ->
         Alcotest.(check bool) "loaded assistant content redacted" false
-          (contains_substring msg.K.content secret);
+          (String_util.contains_substring msg.K.content secret);
         (match msg.K.audio with
          | Some audio ->
            Alcotest.(check bool) "loaded audio message_text redacted" false
-             (contains_substring audio.message_text secret);
+             (String_util.contains_substring audio.message_text secret);
            let audio_url_contains_secret =
              match audio.audio_url with
-             | Some url -> contains_substring url secret
+             | Some url -> String_util.contains_substring url secret
              | None -> false
            in
            Alcotest.(check bool) "loaded audio audio_url redacted" false
@@ -1561,7 +1558,7 @@ let test_turn_ref_persisted_on_turn_rows () =
         messages;
       let s = Yojson.Safe.to_string (K.to_json_array messages) in
       Alcotest.(check bool) "turn_ref present in to_json_array" true
-        (contains_substring s "trace-abc#7"))
+        (String_util.contains_substring s "trace-abc#7"))
 
 let test_to_json_array_appends_trace_block_to_assistant_turn () =
   let base_dir = temp_base_path "keeper-chat-store-turn-trace" in
@@ -1665,7 +1662,7 @@ let test_to_json_array_stream_contract_without_turn_ref () =
           Alcotest.(check string) "delivery receipt absent" "no_delivery_receipt"
             (contract |> member "delivery_receipt" |> to_string);
           Alcotest.(check bool) "reason says no turn_ref" true
-            (contains_substring
+            (String_util.contains_substring
                (contract |> member "reason" |> to_string)
                "no persisted turn_ref")
       | other ->
@@ -1745,7 +1742,7 @@ let test_to_json_array_stream_contract_trace_unavailable () =
         "no_delivery_receipt"
         (contract |> member "delivery_receipt" |> to_string);
       Alcotest.(check bool) "reason says no retained trace" true
-        (contains_substring
+        (String_util.contains_substring
            (contract |> member "reason" |> to_string)
            "no retained trajectory/internal-history events"))
 
@@ -2083,16 +2080,16 @@ let test_transcript_of_messages_joins_turn_ref () =
         (fun (m : K.chat_message) ->
           Alcotest.(check bool)
             "no turn-B content in turn-A transcript" false
-            (contains_substring m.content "B"))
+            (String_util.contains_substring m.content "B"))
         (t.user @ t.assistant);
       let json =
         K.turn_transcript_to_json ~keeper:keeper_name ~turn_ref:tref_a t
       in
       let s = Yojson.Safe.to_string json in
       Alcotest.(check bool) "found=true when rows present" true
-        (contains_substring s "\"found\":true");
+        (String_util.contains_substring s "\"found\":true");
       Alcotest.(check bool) "turn_ref echoed" true
-        (contains_substring s "trace-xyz#3"))
+        (String_util.contains_substring s "trace-xyz#3"))
 
 (* An unmatched turn_ref yields empty lists and found=false — explicit
    absence, never a fabricated transcript. *)
@@ -2116,7 +2113,7 @@ let test_transcript_absent_returns_empty () =
         K.turn_transcript_to_json ~keeper:keeper_name ~turn_ref:missing t
       in
       Alcotest.(check bool) "found=false when no rows match" true
-        (contains_substring (Yojson.Safe.to_string json) "\"found\":false"))
+        (String_util.contains_substring (Yojson.Safe.to_string json) "\"found\":false"))
 
 let () =
   Alcotest.run "keeper_chat_store"

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -90,15 +90,6 @@ let restore_env name = function
   | Some value -> Unix.putenv name value
   | None -> Unix.putenv name ""
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop index =
-    index + needle_len <= haystack_len
-    && (String.sub haystack index needle_len = needle || loop (index + 1))
-  in
-  needle_len = 0 || loop 0
-
 let json_string_field key = function
   | `Assoc fields -> (
       match List.assoc_opt key fields with
@@ -647,7 +638,7 @@ let test_missing_sandbox_profile_fails_loud_for_profile_source () =
       Alcotest.(check bool)
         "error names missing sandbox_profile"
         true
-        (contains_substring ~needle:"sandbox_profile is required" err)
+        (String_util.string_contains_substring ~needle:"sandbox_profile is required" err)
 
 let test_keeper_up_rejects_profile_source_without_sandbox_profile () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
@@ -679,7 +670,7 @@ let test_keeper_up_rejects_profile_source_without_sandbox_profile () =
   Alcotest.(check bool)
     "keeper_up error names missing sandbox_profile"
     true
-    (contains_substring
+    (String_util.string_contains_substring
        ~needle:"sandbox_profile is required"
        (Profile.tool_result_body result))
 
@@ -886,7 +877,7 @@ let test_status_rejects_tail_order_outside_schema () =
   Alcotest.(check bool)
     "error names exact allowed values"
     true
-    (contains_substring
+    (String_util.string_contains_substring
        ~needle:"allowed: oldest_first, newest_first"
        (Profile.tool_result_body result))
 
@@ -909,7 +900,7 @@ let test_status_rejects_malformed_options () =
     Alcotest.(check bool)
       (label ^ " explains the rejected field")
       true
-      (contains_substring ~needle (Profile.tool_result_body result))
+      (String_util.string_contains_substring ~needle (Profile.tool_result_body result))
   in
   check_rejected
     "tail bytes below schema minimum"

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -109,15 +109,6 @@ let remove_payload_field ~kind ~field =
     (fun fields ->
        if List.mem_assoc field fields then List.remove_assoc field fields else fields)
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec scan offset =
-    offset + needle_len <= haystack_len
-    && (String.equal (String.sub haystack offset needle_len) needle || scan (offset + 1))
-  in
-  String.equal needle "" || scan 0
-
 let event_queue_test_meta keeper_name trace_id =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -613,7 +604,7 @@ let () =
     | Masc.Keeper_world_observation.Goal_reconciliation_ready -> true
     | _ -> false);
   assert (
-    contains_substring
+    String_util.string_contains_substring
       ~needle:"Re-read Goal and Task SSOT"
       prompt_event.preview);
   (* The Board-activity partition decides which prompt section renders this
@@ -708,7 +699,7 @@ let () =
       decoded = rejection
     | _ -> false);
   assert (String.equal rejection_event.post_id rejection_stimulus.post_id);
-  assert (contains_substring ~needle:rejection.car_reason rejection_event.preview);
+  assert (String_util.string_contains_substring ~needle:rejection.car_reason rejection_event.preview);
   assert (
     not (Masc.Keeper_world_observation.is_board_activity_event rejection_event));
   assert (
@@ -1566,14 +1557,14 @@ let () =
            Alcotest.(check bool)
              (label ^ " error requires reset")
              true
-             (contains_substring ~needle:"reset required" detail);
+             (String_util.string_contains_substring ~needle:"reset required" detail);
            (match expected_detail with
             | None -> ()
             | Some expected ->
               Alcotest.(check bool)
                 (label ^ " error preserves decoder detail")
                 true
-                (contains_substring ~needle:expected detail)));
+                (String_util.string_contains_substring ~needle:expected detail)));
         Alcotest.(check string)
           (label ^ " evidence is not rewritten")
           malformed

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -98,23 +98,6 @@ let wait_for_cancelled ~base_path request_id =
   loop 200
 ;;
 
-let contains_substring ~needle value =
-  let needle_len = String.length needle in
-  let value_len = String.length value in
-  if needle_len = 0
-  then true
-  else if needle_len > value_len
-  then false
-  else (
-    let rec loop i =
-      if i + needle_len > value_len
-      then false
-      else if String.equal (String.sub value i needle_len) needle
-      then true
-      else loop (i + 1)
-    in
-    loop 0)
-;;
 
 let temp_dir prefix =
   let path = Filename.temp_file prefix "" in
@@ -930,7 +913,7 @@ let test_keeper_msg_async_marks_cancelled_worker_cancelled () =
   | { Keeper_msg_async.status = Cancelled { reason; cancelled_by }; completed_at = Some _; _ } ->
     Alcotest.(check string) "cancelled_by runtime" "runtime" cancelled_by;
     Alcotest.(check bool) "cancelled reason mentions cancellation" true
-      (contains_substring ~needle:"cancelled" (String.lowercase_ascii reason))
+      (String_util.string_contains_substring ~needle:"cancelled" (String.lowercase_ascii reason))
   | { Keeper_msg_async.status = Cancelled _; completed_at = None; _ } ->
     Alcotest.fail "expected cancelled request to have completed_at"
   | entry ->
@@ -970,7 +953,7 @@ let test_keeper_msg_async_operator_cancel_is_terminal_cancelled () =
    | { Keeper_msg_async.status = Cancelled { reason; cancelled_by }; completed_at = Some _; _ } ->
      Alcotest.(check string) "cancelled_by operator" "operator" cancelled_by;
      Alcotest.(check bool) "reason mentions operator" true
-       (contains_substring ~needle:"operator" (String.lowercase_ascii reason))
+       (String_util.string_contains_substring ~needle:"operator" (String.lowercase_ascii reason))
    | { Keeper_msg_async.status = Cancelled _; completed_at = None; _ } ->
      Alcotest.fail "expected operator-cancelled request to have completed_at"
    | entry ->
@@ -2264,7 +2247,7 @@ let test_keeper_msg_async_load_record_missing_status_is_unreadable () =
          Alcotest.(check bool)
            "reason mentions missing fields"
            true
-           (contains_substring ~needle:"missing required string field \"status\"" reason)
+           (String_util.string_contains_substring ~needle:"missing required string field \"status\"" reason)
        | Keeper_msg_async.Found _ -> Alcotest.fail "expected unreadable, got found"
        | Keeper_msg_async.Absent -> Alcotest.fail "expected unreadable, got absent"
        | Keeper_msg_async.Rejected _ -> Alcotest.fail "expected unreadable, got rejected")
@@ -2296,7 +2279,7 @@ let test_keeper_msg_async_load_record_unknown_status_is_unreadable () =
          Alcotest.(check bool)
            "reason mentions unknown status"
            true
-           (contains_substring ~needle:"unknown status" reason)
+           (String_util.string_contains_substring ~needle:"unknown status" reason)
        | Keeper_msg_async.Found _ -> Alcotest.fail "expected unreadable, got found"
        | Keeper_msg_async.Absent -> Alcotest.fail "expected unreadable, got absent"
        | Keeper_msg_async.Rejected _ -> Alcotest.fail "expected unreadable, got rejected")
@@ -2328,7 +2311,7 @@ let test_keeper_msg_async_rejects_filename_request_id_mismatch () =
          Alcotest.(check bool)
            "filename/request id consistency is enforced"
            true
-           (contains_substring ~needle:"does not match filename request_id" reason)
+           (String_util.string_contains_substring ~needle:"does not match filename request_id" reason)
        | Keeper_msg_async.Found _ -> Alcotest.fail "mismatched request id must not load"
        | Keeper_msg_async.Absent -> Alcotest.fail "mismatched record unexpectedly absent"
        | Keeper_msg_async.Rejected _ -> Alcotest.fail "mismatched id is a record error")

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -1249,14 +1249,6 @@ let test_terminal_hook_degradation_does_not_invalidate_task_commit () =
        | Some _ | None -> fail "cancellation propagation invalidated committed Task")
 ;;
 
-let contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    idx + needle_len <= text_len
-    && (String.sub text idx needle_len = needle || loop (idx + 1))
-  in
-  needle_len = 0 || loop 0
 ;;
 
 let test_tool_dispatch_preserves_exact_meta_after_replacement () =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1873,8 +1873,8 @@ let test_turn_runtime_redacts_the_mounted_github_snapshot () =
   Unix.chmod hosts_path 0o600;
   let raw = execute snapshot_token in
   Alcotest.(check bool) "mounted snapshot token never reaches response" false
-    (contains_substring raw snapshot_token);
-  if not (contains_substring raw "[REDACTED]")
+    (String_util.contains_substring raw snapshot_token);
+  if not (String_util.contains_substring raw "[REDACTED]")
   then Alcotest.failf "exact snapshot token was not redacted: %s" raw
 
 let test_execute_allows_validator_safe_pipe_redirect_in_docker_route () =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -86,19 +86,9 @@ let read_file path =
   Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
   really_input_string ic (in_channel_length ic)
 
-let contains_substring haystack needle =
-  let len = String.length needle in
-  let n = String.length haystack in
-  let rec loop i =
-    if i + len > n then false
-    else if String.sub haystack i len = needle then true
-    else loop (i + 1)
-  in
-  loop 0
-
 let docker_log_has_container_execution log =
-  contains_substring ("\n" ^ log) "\nrun "
-  || contains_substring ("\n" ^ log) "\nexec "
+  String_util.contains_substring ("\n" ^ log) "\nrun "
+  || String_util.contains_substring ("\n" ^ log) "\nexec "
 
 let env_file_path_from_docker_line line =
   let rec loop = function
@@ -775,7 +765,7 @@ let test_execute_typed_pipeline_falls_back_to_local_playground () =
     (Some "local_fallback")
     (parse_string_field raw "via");
   Alcotest.(check bool) "fallback response exposes actual Local host namespace" true
-    (contains_substring raw config.Workspace.base_path);
+    (String_util.contains_substring raw config.Workspace.base_path);
   Alcotest.(check (option string)) "fallback top-level cwd is Local host cwd"
     (Some local_cwd)
     (parse_string_field raw "cwd");
@@ -1055,7 +1045,7 @@ let test_docker_run_does_not_retry_generic_timeout () =
        | Unix.WEXITED n -> n
        | _ -> -1);
     Alcotest.(check bool) "second run was not replayed" false
-      (contains_substring result.output "retry-ok")
+      (String_util.contains_substring result.output "retry-ok")
 
 let test_docker_run_does_not_retry_daemon_unavailable () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
@@ -1078,9 +1068,9 @@ let test_docker_run_does_not_retry_daemon_unavailable () =
        | Unix.WEXITED n -> n
        | _ -> -1);
     Alcotest.(check bool) "daemon error output is preserved" true
-      (contains_substring result.output "Cannot connect to the Docker daemon");
+      (String_util.contains_substring result.output "Cannot connect to the Docker daemon");
     Alcotest.(check bool) "daemon failure is not replayed" false
-      (contains_substring result.output "retry-ok")
+      (String_util.contains_substring result.output "retry-ok")
 
 let test_execute_git_routes_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
@@ -1130,9 +1120,9 @@ let test_execute_git_uses_turn_runtime () =
        raw);
   let log = read_file log_path in
   Alcotest.(check bool) "git started docker session" true
-    (contains_substring log "run -d");
+    (String_util.contains_substring log "run -d");
   Alcotest.(check bool) "git used docker exec" true
-    (contains_substring log "\nexec ")
+    (String_util.contains_substring log "\nexec ")
 
 let test_execute_git_without_github_bundle_succeeds () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
@@ -1159,7 +1149,7 @@ let test_execute_git_without_github_bundle_succeeds () =
     (parse_bool_field raw "ok");
   let log = if Sys.file_exists log_path then read_file log_path else "" in
   Alcotest.(check bool) "typed git uses docker exec" true
-    (contains_substring log "\nexec ");
+    (String_util.contains_substring log "\nexec ");
   Alcotest.(check bool) "typed git has no failure class" true
     Yojson.Safe.Util.(member "failure_class" (Yojson.Safe.from_string raw) = `Null)
 
@@ -1213,15 +1203,15 @@ let test_execute_missing_playground_blocks_before_docker () =
   Alcotest.(check bool)
     "missing bind source is typed"
     true
-    (contains_substring err "mount_source_not_found");
+    (String_util.contains_substring err "mount_source_not_found");
   Alcotest.(check bool)
     "full mount path is surfaced"
     true
-    (contains_substring err mount_source);
+    (String_util.contains_substring err mount_source);
   Alcotest.(check bool)
     "base path hash is surfaced"
     true
-    (contains_substring err "base_path_hash=");
+    (String_util.contains_substring err "base_path_hash=");
   Alcotest.(check bool) "docker was not invoked" false (Sys.file_exists log_path)
 
 let test_execute_git_c_bare_worktrees_is_owned_by_cli () =
@@ -1334,9 +1324,9 @@ let test_execute_git_push_routes_through_docker () =
     (parse_string_field raw "via");
   let log = read_file log_path in
   Alcotest.(check bool) "git push started docker session" true
-    (contains_substring log "run -d");
+    (String_util.contains_substring log "run -d");
   Alcotest.(check bool) "git push used typed docker exec argv" true
-    (contains_substring log "\nexec ")
+    (String_util.contains_substring log "\nexec ")
 
 let test_tool_search_files_repo_review_is_unsupported () =
   with_tool_policy_config @@ fun () ->
@@ -1394,14 +1384,14 @@ let test_docker_shell_missing_image_fails_before_run () =
   | Ok _ -> Alcotest.fail "expected missing image preflight error"
   | Error msg ->
     Alcotest.(check bool) "structured image inspect error" true
-      (contains_substring msg "image_inspect_error");
+      (String_util.contains_substring msg "image_inspect_error");
     Alcotest.(check bool) "next action preserves generic inspection guidance" true
-      (contains_substring msg "exact command output above");
+      (String_util.contains_substring msg "exact command output above");
     let log = read_file log_path in
     Alcotest.(check bool) "image inspect attempted" true
-      (contains_substring log "image inspect missing:test");
+      (String_util.contains_substring log "image inspect missing:test");
     Alcotest.(check bool) "docker run skipped" false
-      (contains_substring log "\nrun ")
+      (String_util.contains_substring log "\nrun ")
 
 let test_docker_shell_ir_parse_failure_blocks_before_run () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
@@ -1424,11 +1414,11 @@ let test_docker_shell_ir_parse_failure_blocks_before_run () =
     Alcotest.(check bool)
       "parse failure is explicit"
       true
-      (contains_substring msg "unsupported shell command shape");
+      (String_util.contains_substring msg "unsupported shell command shape");
     Alcotest.(check bool)
       "blocked command is attached"
       true
-      (contains_substring msg "[blocked_cmd=echo \"unterminated]");
+      (String_util.contains_substring msg "[blocked_cmd=echo \"unterminated]");
     Alcotest.(check bool)
       "docker preflight not reached"
       false
@@ -1461,9 +1451,9 @@ let test_execute_missing_image_falls_back_to_local_playground () =
     (parse_string_field raw "sandbox_fallback");
   let log = read_file log_path in
   Alcotest.(check bool) "image inspect attempted" true
-    (contains_substring log "image inspect missing:test");
+    (String_util.contains_substring log "image inspect missing:test");
   Alcotest.(check bool) "docker run skipped" false
-    (contains_substring log "\nrun ")
+    (String_util.contains_substring log "\nrun ")
 
 let test_execute_outside_playground_rejects_before_image_preflight () =
   with_fake_docker fake_docker_missing_image_script @@ fun () ->
@@ -1496,9 +1486,9 @@ let test_execute_outside_playground_rejects_before_image_preflight () =
     (parse_string_field raw "requested_sandbox");
   let log = if Sys.file_exists log_path then read_file log_path else "" in
   Alcotest.(check bool) "image inspect skipped" false
-    (contains_substring log "image inspect missing:test");
+    (String_util.contains_substring log "image inspect missing:test");
   Alcotest.(check bool) "docker run skipped" false
-    (contains_substring log "\nrun ")
+    (String_util.contains_substring log "\nrun ")
 
 let test_docker_shell_mounts_masc_config_runtime_paths () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
@@ -1544,31 +1534,31 @@ let test_docker_shell_mounts_masc_config_runtime_paths () =
       Masc.Keeper_sandbox_runtime.container_masc_config_dir ~container_root
     in
     Alcotest.(check bool) "MASC config mounted read-only" true
-      (contains_substring
+      (String_util.contains_substring
          line
          (host_config_dir ^ ":" ^ container_config_dir ^ ":ro"));
     Alcotest.(check bool) "container MASC_BASE_PATH pinned" true
-      (contains_substring line "MASC_BASE_PATH=/tmp/masc-runtime");
+      (String_util.contains_substring line "MASC_BASE_PATH=/tmp/masc-runtime");
     Alcotest.(check bool) "container MASC_CONFIG_DIR pinned" true
-      (contains_substring line ("MASC_CONFIG_DIR=" ^ container_config_dir));
+      (String_util.contains_substring line ("MASC_CONFIG_DIR=" ^ container_config_dir));
     Alcotest.(check bool) "oneshot container has ttl label" true
-      (contains_substring line "masc.mcp.ttl_sec=");
+      (String_util.contains_substring line "masc.mcp.ttl_sec=");
     Alcotest.(check bool) "oneshot cleanup attempts docker rm" true
-      (contains_substring log "\nrm -f masc-keeper-");
+      (String_util.contains_substring log "\nrm -f masc-keeper-");
     Alcotest.(check bool) "tasks mounted under runtime root" true
-      (contains_substring
+      (String_util.contains_substring
          line
          (tasks_host ^ ":/tmp/masc-runtime/.masc/tasks:ro"));
     Alcotest.(check bool) "tasks not nested under playground bind mount" false
-      (contains_substring
+      (String_util.contains_substring
          line
          (tasks_host ^ ":" ^ container_root ^ "/.masc/tasks:ro"));
     Alcotest.(check bool) "tasks not mounted at host absolute target" false
-      (contains_substring
+      (String_util.contains_substring
          line
          (tasks_host ^ ":" ^ tasks_host ^ ":ro"));
     Alcotest.(check bool) "auth state not mounted" false
-      (contains_substring line "/.masc/auth/")
+      (String_util.contains_substring line "/.masc/auth/")
 
 let run_docker_shell_command ~config ~(meta : Keeper_meta_contract.keeper_meta) ~playground
     ~log_path =
@@ -1622,9 +1612,9 @@ let test_docker_shell_skips_missing_ssh_auth_sock () =
     run_docker_shell_command ~config ~meta ~playground ~log_path
   in
   Alcotest.(check bool) "missing ssh-agent socket is not mounted" false
-    (contains_substring line missing_sock);
+    (String_util.contains_substring line missing_sock);
   Alcotest.(check bool) "missing ssh-agent env is not forwarded" false
-    (contains_substring line "SSH_AUTH_SOCK=")
+    (String_util.contains_substring line "SSH_AUTH_SOCK=")
 
 let test_docker_shell_inherit_network_omits_invalid_network_flag () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
@@ -1635,7 +1625,7 @@ let test_docker_shell_inherit_network_omits_invalid_network_flag () =
     run_docker_shell_command ~config ~meta ~playground ~log_path
   in
   Alcotest.(check bool) "network inherit never uses invalid flag value" false
-    (contains_substring line "--network inherit")
+    (String_util.contains_substring line "--network inherit")
 
 let test_docker_shell_mounts_numeric_user_identity () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
@@ -1648,23 +1638,23 @@ let test_docker_shell_mounts_numeric_user_identity () =
     run_docker_shell_command ~config ~meta ~playground ~log_path
   in
   Alcotest.(check bool) "ambient GH_TOKEN not forwarded" false
-    (contains_substring line "GH_TOKEN=");
+    (String_util.contains_substring line "GH_TOKEN=");
   Alcotest.(check bool) "ambient GITHUB_TOKEN not forwarded" false
-    (contains_substring line "GITHUB_TOKEN=");
+    (String_util.contains_substring line "GITHUB_TOKEN=");
   let identity_dir = Filename.concat playground ".docker-identity" in
   let passwd_path = Filename.concat identity_dir "passwd" in
   let group_path = Filename.concat identity_dir "group" in
   Alcotest.(check bool) "passwd file mounted" true
-    (contains_substring line (passwd_path ^ ":/etc/passwd:ro"));
+    (String_util.contains_substring line (passwd_path ^ ":/etc/passwd:ro"));
   Alcotest.(check bool) "group file mounted" true
-    (contains_substring line (group_path ^ ":/etc/group:ro"));
+    (String_util.contains_substring line (group_path ^ ":/etc/group:ro"));
   Alcotest.(check bool) "USER env forwarded" true
-    (contains_substring line "USER=keeper");
+    (String_util.contains_substring line "USER=keeper");
   Alcotest.(check bool) "passwd maps host uid" true
-    (contains_substring (read_file passwd_path)
+    (String_util.contains_substring (read_file passwd_path)
        (Printf.sprintf "keeper:x:%d:%d:" (Unix.getuid ()) (Unix.getgid ())));
   Alcotest.(check bool) "group maps host gid" true
-    (contains_substring (read_file group_path)
+    (String_util.contains_substring (read_file group_path)
        (Printf.sprintf "keeper:x:%d:" (Unix.getgid ())))
 
 let test_docker_shell_projects_keeper_secret_dir () =
@@ -1717,11 +1707,11 @@ let test_docker_shell_projects_keeper_secret_dir () =
   Alcotest.(check bool) "one-shot GitHub snapshot is cleaned" false
     (Sys.file_exists github_snapshot);
   Alcotest.(check bool) "projected raw token not in docker argv" false
-    (contains_substring line "projected-token");
+    (String_util.contains_substring line "projected-token");
   Alcotest.(check bool) "projected env uses env-file" true
-    (contains_substring line "--env-file ");
+    (String_util.contains_substring line "--env-file ");
   Alcotest.(check bool) "projected file mounted read-only" true
-    (contains_substring line (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
+    (String_util.contains_substring line (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
   (match env_file_path_from_docker_line line with
    | None -> Alcotest.fail "missing --env-file path in docker log"
    | Some env_file ->
@@ -1737,13 +1727,13 @@ let test_docker_shell_does_not_synthesize_git_author_identity () =
     run_docker_shell_command ~config ~meta ~playground ~log_path
   in
   Alcotest.(check bool) "does not synthesize git author name" false
-    (contains_substring line "GIT_AUTHOR_NAME=");
+    (String_util.contains_substring line "GIT_AUTHOR_NAME=");
   Alcotest.(check bool) "does not synthesize git author email" false
-    (contains_substring line "GIT_AUTHOR_EMAIL=");
+    (String_util.contains_substring line "GIT_AUTHOR_EMAIL=");
   Alcotest.(check bool) "does not synthesize git committer name" false
-    (contains_substring line "GIT_COMMITTER_NAME=");
+    (String_util.contains_substring line "GIT_COMMITTER_NAME=");
   Alcotest.(check bool) "does not synthesize git committer email" false
-    (contains_substring line "GIT_COMMITTER_EMAIL=")
+    (String_util.contains_substring line "GIT_COMMITTER_EMAIL=")
 
 let test_execute_fake_docker_executes () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
@@ -1808,11 +1798,12 @@ let test_turn_runtime_projects_keeper_secret_dir () =
     (parse_bool_field raw "ok");
   let log = read_file log_path in
   Alcotest.(check bool) "projected raw token not in docker argv" false
-    (contains_substring log "projected-token");
+    (String_util.contains_substring log "projected-token");
   Alcotest.(check bool) "turn container uses env-file" true
-    (contains_substring log "--env-file ");
+    (String_util.contains_substring log "--env-file ");
   Alcotest.(check bool) "turn container mounts file read-only" true
-    (contains_substring log (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
+    (String_util.contains_substring log
+       (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
   let container_root = Keeper_sandbox.container_root meta.name in
   let container_masc_dir =
     Keeper_sandbox_runtime.container_masc_config_dir ~container_root
@@ -2065,11 +2056,11 @@ let test_docker_mount_failure_message_preserves_path () =
       ~output
   in
   Alcotest.(check bool) "full mount path preserved" true
-    (contains_substring message mount_path);
+    (String_util.contains_substring message mount_path);
   Alcotest.(check bool) "mount marker emitted" true
-    (contains_substring message "docker_mount_failure=true");
+    (String_util.contains_substring message "docker_mount_failure=true");
   Alcotest.(check bool) "status emitted" true
-    (contains_substring message "status=\"exit=125\"")
+    (String_util.contains_substring message "status=\"exit=125\"")
 
 let test_docker_mount_failure_structured_details () =
   let mount_path =

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -56,17 +56,6 @@ let read_file path =
   Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
   really_input_string ic (in_channel_length ic)
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop i =
-    if nlen = 0 then true
-    else if i + nlen > hlen then false
-    else if String.sub haystack i nlen = needle then true
-    else loop (i + 1)
-  in
-  loop 0
-
 let env_file_path_from_docker_line line =
   let rec loop = function
     | "--env-file" :: path :: _ -> Some path
@@ -268,11 +257,11 @@ let test_read_directory_names_a_real_listing_tool () =
   | Ok _ -> Alcotest.fail "expected path_is_directory error for a directory"
   | Error msg ->
       Alcotest.(check bool) "error reports path_is_directory" true
-        (contains_substring msg "path_is_directory");
+        (String_util.contains_substring msg "path_is_directory");
       Alcotest.(check bool)
         "error names a real listing command"
         true
-        (contains_substring msg "argv=['ls'")
+        (String_util.contains_substring msg "argv=['ls'")
 
 (* ── run_command error paths
    (exercised without invoking docker) ──────────────────────────── *)
@@ -1120,7 +1109,7 @@ let test_docker_workspace_state_mount_args_expose_safe_subset () =
          | _ -> false)
        specs);
   Alcotest.(check bool) "does not mount auth" false
-    (List.exists (fun spec -> contains_substring spec "/auth/") specs)
+    (List.exists (fun spec -> String_util.contains_substring spec "/auth/") specs)
 
 let test_cleanup_stale_containers_removes_only_stale_masc_scope () =
   with_fake_docker fake_docker_cleanup_script @@ fun () ->
@@ -1140,9 +1129,9 @@ let test_cleanup_stale_containers_removes_only_stale_masc_scope () =
   Alcotest.(check (list string)) "no cleanup errors" [] result.errors;
   let log = read_file log_path in
   Alcotest.(check bool) "removes old container" true
-    (contains_substring log "rm -f -v old-container");
+    (String_util.contains_substring log "rm -f -v old-container");
   Alcotest.(check bool) "keeps fresh container" false
-    (contains_substring log "rm -f -v fresh-container")
+    (String_util.contains_substring log "rm -f -v fresh-container")
 
 let test_cleanup_stale_containers_accepts_concurrent_disappearance () =
   with_fake_docker fake_docker_cleanup_disappeared_script @@ fun () ->
@@ -1163,11 +1152,11 @@ let test_cleanup_stale_containers_accepts_concurrent_disappearance () =
   Alcotest.(check bool)
     "inspect-absent container is not removed again"
     false
-    (contains_substring log "rm -f -v inspect-gone");
+    (String_util.contains_substring log "rm -f -v inspect-gone");
   Alcotest.(check bool)
     "remove race reaches docker rm"
     true
-    (contains_substring log "rm -f -v rm-gone")
+    (String_util.contains_substring log "rm -f -v rm-gone")
 
 let test_cleanup_stale_containers_preserves_present_failure () =
   with_fake_docker fake_docker_cleanup_present_failure_script @@ fun () ->
@@ -1187,7 +1176,7 @@ let test_cleanup_stale_containers_preserves_present_failure () =
     Alcotest.(check bool)
       "original inspect failure remains explicit"
       true
-      (contains_substring error "synthetic inspect failure")
+      (String_util.contains_substring error "synthetic inspect failure")
   | errors -> Alcotest.failf "expected one explicit cleanup error, got %d" (List.length errors)
 
 let test_maybe_cleanup_disappearance_allows_next_interval () =
@@ -1262,7 +1251,7 @@ let test_maybe_cleanup_stale_containers_runs_once_per_interval () =
     |> String.split_on_char '\n'
     |> List.filter (fun line ->
       String.starts_with ~prefix:"ps -aq " line
-      && contains_substring
+      && String_util.contains_substring
            line
            "label=masc.mcp.component=keeper-sandbox")
     |> List.length
@@ -1477,7 +1466,7 @@ let test_run_command_fallback_uses_docker_spawn_slot ~clock () =
                  ~max_bytes:4096 ~timeout_sec:5.0 ()));
       let run_started () =
         Sys.file_exists log_path
-        && contains_substring (read_file log_path) "run-started"
+        && String_util.contains_substring (read_file log_path) "run-started"
       in
       Alcotest.(check bool)
         "fallback docker run holds Docker_spawn slot after run starts"
@@ -1536,11 +1525,11 @@ let test_run_command_projects_keeper_secret_dir () =
   | Ok (_st, _out) ->
     let line = read_file log_path in
     Alcotest.(check bool) "projected raw token not in docker argv" false
-      (contains_substring line "projected-token");
+      (String_util.contains_substring line "projected-token");
     Alcotest.(check bool) "projected env uses env-file" true
-      (contains_substring line "--env-file ");
+      (String_util.contains_substring line "--env-file ");
     Alcotest.(check bool) "projected file mounted read-only" true
-      (contains_substring line (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
+      (String_util.contains_substring line (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
     (match env_file_path_from_docker_line line with
      | None -> Alcotest.fail "missing --env-file path in docker log"
      | Some env_file ->
@@ -1565,9 +1554,9 @@ let test_run_command_scrubs_sensitive_env () =
       let env_dump_path = log_path ^ ".env" in
       let env_dump = read_file env_dump_path in
       Alcotest.(check bool) "GH_TOKEN scrubbed" false
-        (contains_substring env_dump "GH_TOKEN=");
+        (String_util.contains_substring env_dump "GH_TOKEN=");
       Alcotest.(check bool) "ANTHROPIC_API_KEY scrubbed" false
-        (contains_substring env_dump "ANTHROPIC_API_KEY=")
+        (String_util.contains_substring env_dump "ANTHROPIC_API_KEY=")
 
 let test_turn_runtime_reuses_single_container () =
   with_fake_docker fake_docker_turn_runtime_script @@ fun () ->
@@ -1637,13 +1626,13 @@ let test_turn_runtime_reuses_single_container () =
     |> Option.value ~default:""
   in
   Alcotest.(check bool) "turn run mounts config read-only" true
-    (contains_substring
+    (String_util.contains_substring
        run_line
        (host_config_dir ^ ":" ^ container_config_dir ^ ":ro"));
   Alcotest.(check bool) "turn run pins MASC_CONFIG_DIR" true
-    (contains_substring run_line ("MASC_CONFIG_DIR=" ^ container_config_dir));
+    (String_util.contains_substring run_line ("MASC_CONFIG_DIR=" ^ container_config_dir));
   Alcotest.(check bool) "turn exec pins MASC_CONFIG_DIR" true
-    (contains_substring exec_line ("MASC_CONFIG_DIR=" ^ container_config_dir))
+    (String_util.contains_substring exec_line ("MASC_CONFIG_DIR=" ^ container_config_dir))
 
 let test_streaming_exec_validates_cached_container_before_retry () =
   with_fake_docker fake_docker_stale_streaming_retry_script @@ fun () ->
@@ -1694,7 +1683,7 @@ let test_streaming_exec_validates_cached_container_before_retry () =
   Alcotest.(check bool)
     "stale container error is not streamed"
     false
-    (contains_substring streamed_stderr "synthetic opaque state inspection failure")
+    (String_util.contains_substring streamed_stderr "synthetic opaque state inspection failure")
 
 let test_streaming_exec_preserves_split_stderr () =
   with_fake_docker fake_docker_turn_runtime_script @@ fun () ->
@@ -1769,7 +1758,7 @@ let test_streaming_exec_forwards_timeout_to_split_exec () =
        Alcotest.(check bool)
          "timeout stderr surfaced"
          true
-         (contains_substring stderr "timeout after")
+         (String_util.contains_substring stderr "timeout after")
    | Ok _ -> Alcotest.fail "expected split exec timeout exit 124");
   let elapsed = Unix.gettimeofday () -. start in
   Alcotest.(check bool)
@@ -1815,7 +1804,7 @@ let test_streaming_pipeline_forwards_timeout_to_split_exec () =
        Alcotest.(check bool)
          "pipeline timeout stderr surfaced"
          true
-         (contains_substring stderr "timeout after")
+         (String_util.contains_substring stderr "timeout after")
    | Ok _ -> Alcotest.fail "expected pipeline timeout exit 124");
   let elapsed = Unix.gettimeofday () -. start in
   Alcotest.(check string)
@@ -1872,7 +1861,7 @@ let test_streaming_exec_restarts_stopped_container_before_exec () =
   Alcotest.(check bool)
     "stopped container error is not streamed"
     false
-    (contains_substring streamed_stderr "synthetic opaque stopped-container exec failure")
+    (String_util.contains_substring streamed_stderr "synthetic opaque stopped-container exec failure")
 
 let test_streaming_exec_surfaces_process_failure_once () =
   with_fake_docker fake_docker_streaming_script @@ fun () ->
@@ -2059,7 +2048,7 @@ let test_default_fs_hardening_helpers () =
     [ "--read-only" ]
     (Env_config_sandbox.Hardening.read_only_rootfs_args ());
   Alcotest.(check bool) "default helper keeps tmpfs noexec" true
-    (contains_substring
+    (String_util.contains_substring
        (Env_config_sandbox.Hardening.tmpfs_mount ())
        "/tmp:rw,nosuid,nodev,noexec,size=")
 
@@ -2068,11 +2057,11 @@ let test_relaxed_fs_helpers () =
   Alcotest.(check (list string)) "relaxed helper drops read-only rootfs"
     [] (Env_config_sandbox.Hardening.read_only_rootfs_args ());
   Alcotest.(check bool) "relaxed helper drops tmpfs noexec" false
-    (contains_substring
+    (String_util.contains_substring
        (Env_config_sandbox.Hardening.tmpfs_mount ())
        "/tmp:rw,nosuid,nodev,noexec,size=");
   Alcotest.(check bool) "relaxed helper keeps writable tmpfs mount" true
-    (contains_substring
+    (String_util.contains_substring
        (Env_config_sandbox.Hardening.tmpfs_mount ())
        "/tmp:rw,nosuid,nodev,size=")
 
@@ -2110,11 +2099,11 @@ let test_turn_runtime_relaxed_fs_omits_readonly_and_noexec () =
   | None -> Alcotest.fail "expected docker run log line"
   | Some line ->
       Alcotest.(check bool) "relaxed runtime drops read-only rootfs" false
-        (contains_substring line "--read-only");
+        (String_util.contains_substring line "--read-only");
       Alcotest.(check bool) "relaxed runtime drops tmpfs noexec" false
-        (contains_substring line "/tmp:rw,nosuid,nodev,noexec,size=");
+        (String_util.contains_substring line "/tmp:rw,nosuid,nodev,noexec,size=");
       Alcotest.(check bool) "relaxed runtime keeps tmpfs mount" true
-        (contains_substring line "/tmp:rw,nosuid,nodev,size=")
+        (String_util.contains_substring line "/tmp:rw,nosuid,nodev,size=")
 
 let run_tests ~clock () =
   Alcotest.run "Keeper_sandbox_read_backend"

--- a/test/test_keeper_secret_projection.ml
+++ b/test/test_keeper_secret_projection.ml
@@ -53,16 +53,6 @@ let read_file path =
   really_input_string ic (in_channel_length ic)
 ;;
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop i =
-    if nlen = 0 then true
-    else if i + nlen > hlen then false
-    else if String.sub haystack i nlen = needle then true
-    else loop (i + 1)
-  in
-  loop 0
 ;;
 
 let assoc_member name = function
@@ -174,9 +164,9 @@ let test_env_and_files_project_to_docker_args () =
   | Ok projection ->
     let args = String.concat " " projection.docker_args in
     Alcotest.(check bool) "raw secret not in argv" false
-      (contains_substring args "projected_secret");
+      (String_util.contains_substring args "projected_secret");
     Alcotest.(check bool) "ssh file mounted read-only" true
-      (contains_substring
+      (String_util.contains_substring
          args
          (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
     (match env_file_arg projection.docker_args with
@@ -186,9 +176,9 @@ let test_env_and_files_project_to_docker_args () =
        Alcotest.(check bool)
          "env file content"
          true
-         (contains_substring env "SERVICE_TOKEN=projected_secret\n");
+         (String_util.contains_substring env "SERVICE_TOKEN=projected_secret\n");
        Alcotest.(check bool) "no product-specific env synthesized" false
-         (contains_substring env "GIT_CONFIG_GLOBAL=");
+         (String_util.contains_substring env "GIT_CONFIG_GLOBAL=");
        projection.cleanup ();
        Alcotest.(check bool) "env file cleaned up" false (Sys.file_exists env_file))
 ;;
@@ -219,7 +209,7 @@ let test_secret_dir_override_uses_keeper_subdir () =
           | None -> Alcotest.fail "missing --env-file"
           | Some env_file ->
             Alcotest.(check bool) "override env content" true
-              (contains_substring (read_file env_file) "SERVICE_TOKEN=override\n");
+              (String_util.contains_substring (read_file env_file) "SERVICE_TOKEN=override\n");
             projection.cleanup ()))
 ;;
 
@@ -250,14 +240,14 @@ let test_base_secret_env_and_files_project_to_keeper_docker_args () =
      | Some env_file ->
        let env = read_file env_file in
        Alcotest.(check bool) "base token projected" true
-         (contains_substring env "SERVICE_TOKEN=base-token\n");
+         (String_util.contains_substring env "SERVICE_TOKEN=base-token\n");
        Alcotest.(check bool) "no product-specific env projected" false
-         (contains_substring env "GIT_CONFIG_GLOBAL="));
+         (String_util.contains_substring env "GIT_CONFIG_GLOBAL="));
     let args = String.concat " " projection.docker_args in
     Alcotest.(check bool) "base ssh file mounted" true
-      (contains_substring args (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
+      (String_util.contains_substring args (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
     Alcotest.(check bool) "no generated product config mounted" false
-      (contains_substring args ":/tmp/masc-runtime/.masc/gitconfig:ro");
+      (String_util.contains_substring args ":/tmp/masc-runtime/.masc/gitconfig:ro");
     projection.cleanup ()
 ;;
 
@@ -295,14 +285,14 @@ let test_keeper_secret_overrides_base_secret_entries () =
      | Some env_file ->
        let env = read_file env_file in
        Alcotest.(check bool) "keeper token wins" true
-         (contains_substring env "SERVICE_TOKEN=keeper-token\n");
+         (String_util.contains_substring env "SERVICE_TOKEN=keeper-token\n");
        Alcotest.(check bool) "base token omitted" false
-         (contains_substring env "SERVICE_TOKEN=base-token\n"));
+         (String_util.contains_substring env "SERVICE_TOKEN=base-token\n"));
     let args = String.concat " " projection.docker_args in
     Alcotest.(check bool) "keeper ssh mount wins" true
-      (contains_substring args (keeper_ssh ^ ":/home/keeper/.ssh/id_ed25519:ro"));
+      (String_util.contains_substring args (keeper_ssh ^ ":/home/keeper/.ssh/id_ed25519:ro"));
     Alcotest.(check bool) "base ssh mount omitted" false
-      (contains_substring args (base_ssh ^ ":/home/keeper/.ssh/id_ed25519:ro"));
+      (String_util.contains_substring args (base_ssh ^ ":/home/keeper/.ssh/id_ed25519:ro"));
     projection.cleanup ()
 ;;
 
@@ -453,7 +443,7 @@ let test_invalid_env_name_rejects () =
   | Ok _ -> Alcotest.fail "expected invalid env name rejection"
   | Error err ->
     Alcotest.(check bool) "mentions invalid env name" true
-      (contains_substring err "invalid keeper secret env name")
+      (String_util.contains_substring err "invalid keeper secret env name")
 ;;
 
 let test_symlink_file_rejects () =
@@ -478,7 +468,7 @@ let test_symlink_file_rejects () =
   | Ok _ -> Alcotest.fail "expected symlink rejection"
   | Error err ->
     Alcotest.(check bool) "mentions symlink" true
-      (contains_substring err "symlink")
+      (String_util.contains_substring err "symlink")
 ;;
 
 let test_symlink_env_dir_rejects () =
@@ -505,7 +495,7 @@ let test_symlink_env_dir_rejects () =
        | Ok _ -> Alcotest.fail "expected env directory symlink rejection"
        | Error err ->
          Alcotest.(check bool) "mentions symlink" true
-           (contains_substring err "symlink"))
+           (String_util.contains_substring err "symlink"))
 ;;
 
 let test_dashboard_status_absent_root () =
@@ -567,9 +557,9 @@ let test_dashboard_status_redacts_values () =
   Alcotest.(check (list string)) "env names" [ "SECOND_SERVICE_TOKEN"; "SERVICE_TOKEN" ]
     (json_string_list "env_names" json);
   Alcotest.(check bool) "raw env value redacted" false
-    (contains_substring raw "ghs_dashboard_secret");
+    (String_util.contains_substring raw "ghs_dashboard_secret");
   Alcotest.(check bool) "shared env value redacted" false
-    (contains_substring raw "ghs_shared_dashboard_secret");
+    (String_util.contains_substring raw "ghs_shared_dashboard_secret");
   let roots = json_list "effective_roots" json in
   Alcotest.(check int) "effective root count" 2 (List.length roots);
   (match roots with
@@ -598,7 +588,7 @@ let test_dashboard_status_reports_projection_error () =
   in
   Alcotest.(check string) "status" "error" (json_string "status" json);
   Alcotest.(check bool) "mentions invalid env name" true
-    (contains_substring (Yojson.Safe.to_string json) "invalid keeper secret env name")
+    (String_util.contains_substring (Yojson.Safe.to_string json) "invalid keeper secret env name")
 ;;
 
 let test_set_and_delete_env_entry_updates_projection () =
@@ -641,9 +631,9 @@ let test_set_and_delete_env_entry_updates_projection () =
   Alcotest.(check string) "status" "ready" (json_string "status" json);
   Alcotest.(check int) "effective env count" 1 (json_int "env_count" json);
   Alcotest.(check bool) "shared value redacted" false
-    (contains_substring (Yojson.Safe.to_string json) "ghs_shared_from_ui");
+    (String_util.contains_substring (Yojson.Safe.to_string json) "ghs_shared_from_ui");
   Alcotest.(check bool) "keeper value redacted" false
-    (contains_substring (Yojson.Safe.to_string json) "ghs_keeper_from_ui");
+    (String_util.contains_substring (Yojson.Safe.to_string json) "ghs_keeper_from_ui");
   (match
      Keeper_secret_projection.delete_env_entry
        ~base_path:base
@@ -687,7 +677,7 @@ let test_set_env_entry_rejects_invalid_inputs () =
    | Ok () -> Alcotest.fail "expected invalid env name rejection"
    | Error msg ->
      Alcotest.(check bool) "mentions env name" true
-       (contains_substring msg "invalid keeper secret env name"));
+       (String_util.contains_substring msg "invalid keeper secret env name"));
   (match
      Keeper_secret_projection.set_env_entry
        ~base_path:base
@@ -699,7 +689,7 @@ let test_set_env_entry_rejects_invalid_inputs () =
    | Ok () -> Alcotest.fail "expected multiline value rejection"
    | Error msg ->
      Alcotest.(check bool) "mentions single-line" true
-       (contains_substring msg "single-line"))
+       (String_util.contains_substring msg "single-line"))
 ;;
 
 let test_set_and_delete_file_entry_updates_projection () =
@@ -751,9 +741,9 @@ let test_set_and_delete_file_entry_updates_projection () =
   Alcotest.(check string) "status" "ready" (json_string "status" json);
   Alcotest.(check int) "effective file count" 1 (json_int "file_count" json);
   Alcotest.(check bool) "shared file value redacted" false
-    (contains_substring (Yojson.Safe.to_string json) "SHARED");
+    (String_util.contains_substring (Yojson.Safe.to_string json) "SHARED");
   Alcotest.(check bool) "keeper file value redacted" false
-    (contains_substring (Yojson.Safe.to_string json) "KEEPER");
+    (String_util.contains_substring (Yojson.Safe.to_string json) "KEEPER");
   (match
      Keeper_secret_projection.docker_args_for_keeper
        ~base_path:base
@@ -765,9 +755,9 @@ let test_set_and_delete_file_entry_updates_projection () =
    | Ok projection ->
      let args = String.concat " " projection.docker_args in
      Alcotest.(check bool) "keeper file mount wins" true
-       (contains_substring args (keeper_path ^ ":" ^ container_path ^ ":ro"));
+       (String_util.contains_substring args (keeper_path ^ ":" ^ container_path ^ ":ro"));
      Alcotest.(check bool) "shared file mount omitted" false
-       (contains_substring args (shared_path ^ ":" ^ container_path ^ ":ro"));
+       (String_util.contains_substring args (shared_path ^ ":" ^ container_path ^ ":ro"));
      projection.cleanup ());
   (match
      Keeper_secret_projection.delete_file_entry
@@ -796,7 +786,7 @@ let test_set_and_delete_file_entry_updates_projection () =
    | Ok projection ->
      let args = String.concat " " projection.docker_args in
      Alcotest.(check bool) "shared file mount inherited" true
-       (contains_substring args (shared_path ^ ":" ^ container_path ^ ":ro"));
+       (String_util.contains_substring args (shared_path ^ ":" ^ container_path ^ ":ro"));
      projection.cleanup ());
   (match
      Keeper_secret_projection.delete_file_entry
@@ -825,7 +815,7 @@ let test_set_file_entry_rejects_invalid_inputs () =
    | Ok () -> Alcotest.fail "expected relative path rejection"
    | Error msg ->
      Alcotest.(check bool) "mentions absolute path" true
-       (contains_substring msg "absolute"));
+       (String_util.contains_substring msg "absolute"));
   (match
      Keeper_secret_projection.set_file_entry
        ~base_path:base
@@ -837,7 +827,7 @@ let test_set_file_entry_rejects_invalid_inputs () =
    | Ok () -> Alcotest.fail "expected traversal rejection"
    | Error msg ->
      Alcotest.(check bool) "mentions path component" true
-       (contains_substring msg "invalid keeper secret file path component"));
+       (String_util.contains_substring msg "invalid keeper secret file path component"));
   (match
      Keeper_secret_projection.set_file_entry
        ~base_path:base
@@ -848,7 +838,7 @@ let test_set_file_entry_rejects_invalid_inputs () =
    with
    | Ok () -> Alcotest.fail "expected NUL value rejection"
    | Error msg ->
-     Alcotest.(check bool) "mentions NUL" true (contains_substring msg "NUL"))
+     Alcotest.(check bool) "mentions NUL" true (String_util.contains_substring msg "NUL"))
 ;;
 
 let test_env_value_leading_hash_rejects () =
@@ -867,7 +857,7 @@ let test_env_value_leading_hash_rejects () =
   | Ok _ -> Alcotest.fail "expected leading-hash env value rejection"
   | Error err ->
     Alcotest.(check bool) "mentions docker env-file comment" true
-      (contains_substring err "docker --env-file")
+      (String_util.contains_substring err "docker --env-file")
 ;;
 
 let test_base_keeper_scope_mutation_rejected () =

--- a/test/test_keeper_tag_dispatch.ml
+++ b/test/test_keeper_tag_dispatch.ml
@@ -6,16 +6,6 @@
 open Alcotest
 open Masc
 
-let contains_substring s needle =
-  let s_len = String.length s in
-  let n_len = String.length needle in
-  let rec loop i =
-    if i + n_len > s_len then false
-    else if String.sub s i n_len = needle then true
-    else loop (i + 1)
-  in
-  if n_len = 0 then true else loop 0
-
 (* Temp directory setup matching test_keeper_task_dispatch.ml pattern. *)
 let with_workspace f =
   Eio_main.run @@ fun _env ->
@@ -86,7 +76,7 @@ let test_other_inline_blocked () =
     match dispatch_inline config "masc_agents" with
     | Some tr when not (Tool_result.is_success tr) ->
         check bool "error mentions MCP context" true
-          (contains_substring (Tool_result.message tr) "requires MCP session context")
+          (String_util.contains_substring (Tool_result.message tr) "requires MCP session context")
     | Some _tr ->
         fail "masc_agents should remain blocked in keeper context"
     | None ->

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -37,16 +37,6 @@ let request_authority_exn request =
     fail "expected valid authority"
 ;;
 
-let contains_substring s needle =
-  let s_len = String.length s in
-  let n_len = String.length needle in
-  let rec loop i =
-    if i + n_len > s_len then false
-    else if String.sub s i n_len = needle then true
-    else loop (i + 1)
-  in
-  if n_len = 0 then true else loop 0
-
 let has_repo_keeper_config root =
   let keepers_dir = Filename.concat root "config/keepers" in
   Sys.file_exists keepers_dir && Sys.is_directory keepers_dir
@@ -558,9 +548,9 @@ let test_profile_rejects_unknown_key () =
      | Ok _ -> fail "unknown Keeper field must fail closed"
      | Error detail ->
        check bool "generic unknown-key error" true
-         (contains_substring detail "unknown keeper TOML keys");
+         (String_util.contains_substring detail "unknown keeper TOML keys");
        check bool "names unknown key" true
-         (contains_substring detail "keeper.typo_field"))
+         (String_util.contains_substring detail "keeper.typo_field"))
 
 let test_profile_full () =
   let input = {|
@@ -600,9 +590,9 @@ autoboot_enabled = [true, false]
      | Ok _ -> fail "known scalar field must not silently use its default"
      | Error message ->
        check bool "names field" true
-         (contains_substring message "keeper.autoboot_enabled");
+         (String_util.contains_substring message "keeper.autoboot_enabled");
        check bool "names expected type" true
-         (contains_substring message "boolean"))
+         (String_util.contains_substring message "boolean"))
 
 let test_profile_rejects_invalid_max_context_override () =
   let input =
@@ -618,7 +608,7 @@ max_context_override = 0
      | Ok _ -> fail "expected invalid max_context_override error"
      | Error message ->
        check bool "names max_context_override" true
-         (contains_substring message "max_context_override"))
+         (String_util.contains_substring message "max_context_override"))
 
 let test_profile_parses_multimodal_policy () =
   let input = {|
@@ -646,9 +636,9 @@ multimodal_policy = "silent_default"
      | Ok _ -> fail "expected invalid multimodal_policy error"
      | Error msg ->
        check bool "mentions multimodal_policy" true
-         (contains_substring msg "invalid multimodal_policy");
+         (String_util.contains_substring msg "invalid multimodal_policy");
        check bool "mentions allowed values" true
-         (contains_substring msg "delegate"))
+         (String_util.contains_substring msg "delegate"))
 
 (* ================================================================ *)
 (* File loading tests                                                *)
@@ -886,7 +876,7 @@ AGENT_CORE_OPENAI_BASE_URL = "http://127.0.0.1:1"
     | Ok content -> content
   in
   check bool "comment survives" true
-    (contains_substring content "# operator comment");
+    (String_util.contains_substring content "# operator comment");
   match TL.parse_toml content with
   | Error error -> fail error
   | Ok doc ->
@@ -916,7 +906,7 @@ let test_keeper_toml_writer_rejects_table_assignment_shapes () =
       | Ok () -> failf "%s must not be rendered as a key assignment" label
       | Error message ->
         check bool (label ^ " error is explicit") true
-          (contains_substring message "cannot be rendered");
+          (String_util.contains_substring message "cannot be rendered");
         check bool (label ^ " file is not created") false (Sys.file_exists path))
     shapes
 
@@ -1046,7 +1036,7 @@ let test_invalid_child_profile_fails_closed_before_dispatch () =
          (Agent_core.Error.InvalidConfig { field; detail })) ->
     check string "typed agent-core config field" "keeper.profile" field;
     check bool "agent-core error retains failing path" true
-      (contains_substring detail keeper_path)
+      (String_util.contains_substring detail keeper_path)
   | Error err ->
     failf "expected typed InvalidConfig, got %s" (Agent_core.Error.to_string err)
 
@@ -1116,7 +1106,7 @@ let test_empty_keeper_agent_prompt_is_typed_profile_error () =
     check string "keeper TOML retains dependency owner" keeper_path error.keeper_path;
     check string "keeper instructions are the failing path" instructions_path error.failing_path;
     check bool "error reports profile dependency" true
-      (contains_substring
+      (String_util.contains_substring
          (KTP.keeper_toml_load_error_to_string error)
          "profile dependency")
 
@@ -1368,9 +1358,9 @@ let test_load_keeper_toml_rejects_unknown_keys () =
     Sys.remove tmp;
     check bool "profile error" true (error.kind = KTP.Profile_error);
     check bool "generic unknown-key error" true
-      (contains_substring error.detail "unknown keeper TOML keys");
+      (String_util.contains_substring error.detail "unknown keeper TOML keys");
     check bool "unknown key retained" true
-      (contains_substring error.detail "keeper.typo_field")
+      (String_util.contains_substring error.detail "keeper.typo_field")
 
 let test_keeper_toml_unknown_keys_in_dir_reports_files () =
   with_temp_dir "keeper-unknown-dir" @@ fun dir ->

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -58,18 +58,6 @@ let descriptor_internal_name_set () =
   tbl
 ;;
 
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0
-  then true
-  else
-    let rec loop i =
-      i + needle_len <= haystack_len
-      &&
-      (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
-    in
-    loop 0
 ;;
 
 let source_path rel =
@@ -1294,7 +1282,7 @@ let test_run_tools_setup_has_no_direct_public_mcp_catalog_read () =
   Alcotest.(check bool)
     "keeper_run_tools_setup does not classify with Tool_catalog.is_public_mcp"
     false
-    (contains_substring source "Tool_catalog.is_public_mcp")
+    (String_util.contains_substring source "Tool_catalog.is_public_mcp")
 ;;
 
 (* RFC-0182 §3.1 — verify keeper descriptors project from name → descriptor

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -175,15 +175,6 @@ let with_exec_fixture
                    run
                else run ())))
 
-let contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    idx + needle_len <= text_len
-    && (String.sub text idx needle_len = needle || loop (idx + 1))
-  in
-  needle_len = 0 || loop 0
-
 let parse_json raw =
   try Yojson.Safe.from_string raw with
   | Yojson.Json_error err -> fail ("invalid json: " ^ err)
@@ -285,9 +276,9 @@ let test_public_read_rejects_unsupported_range_fields () =
         |> Option.value ~default:""
       in
       check bool "error mentions unsupported field" true
-        (contains_substring error "unsupported field");
+        (String_util.contains_substring error "unsupported field");
       check bool "error mentions start_line" true
-        (contains_substring error "start_line");
+        (String_util.contains_substring error "start_line");
       check string "validation source" "agent_core_tool_middleware"
         Yojson.Safe.Util.(member "validation" json |> to_string);
       check string "failure class" "policy_rejection"
@@ -355,12 +346,12 @@ let test_surface_read_rejects_duplicate_dispatch_fields () =
              ; "channel_id", `String "456" ])
       in
       check bool "duplicate fields produce validation output" true
-        (contains_substring duplicate_mode.raw_output "error_code");
+        (String_util.contains_substring duplicate_mode.raw_output "error_code");
       check string "duplicate mode is named"
         "keeper_surface_read arguments contains duplicate field \"mode\""
         Yojson.Safe.Util.(member "message" (parse_json duplicate_mode.raw_output) |> to_string);
       check bool "duplicate channel produces validation output" true
-        (contains_substring duplicate_channel.raw_output "error_code");
+        (String_util.contains_substring duplicate_channel.raw_output "error_code");
       check string "duplicate channel is not silently selected"
         "keeper_surface_read arguments contains duplicate field \"channel_id\""
         Yojson.Safe.Util.(member "message" (parse_json duplicate_channel.raw_output) |> to_string))
@@ -722,7 +713,7 @@ let check_publication_recovery_failure
        check bool
          (label ^ " " ^ sentinel_label ^ " is absent from tool output")
          false
-         (contains_substring public_output sentinel))
+         (String_util.contains_substring public_output sentinel))
     sentinels;
   check bool (label ^ " created no file") false (Sys.file_exists target)
 ;;
@@ -1114,21 +1105,21 @@ let test_publication_initialization_crash_is_redacted () =
        check bool
          "exception payload is absent from message"
          false
-         (contains_substring result.raw_output exception_text);
+         (String_util.contains_substring result.raw_output exception_text);
        check bool
          "exception payload is absent from data"
          false
-         (contains_substring rendered_data exception_text);
+         (String_util.contains_substring rendered_data exception_text);
        if backtrace_text <> ""
        then (
          check bool
            "backtrace is absent from message"
            false
-           (contains_substring result.raw_output backtrace_text);
+           (String_util.contains_substring result.raw_output backtrace_text);
          check bool
            "backtrace is absent from data"
            false
-           (contains_substring rendered_data backtrace_text));
+           (String_util.contains_substring rendered_data backtrace_text));
        check bool "crashed initialization created no file" false
          (Sys.file_exists path))
 ;;
@@ -1972,9 +1963,9 @@ let test_model_visible_local_tools_dispatch_to_runtime_handlers () =
       check string "Grep translates to rg op" "rg"
         (json_string_field ~default:"" "op" grep_json);
       check bool "Grep returns real match" true
-        (contains_substring grep_result.raw_output visible_file_path);
+        (String_util.contains_substring grep_result.raw_output visible_file_path);
       check bool "Grep match includes content" true
-        (contains_substring grep_result.raw_output "gamma");
+        (String_util.contains_substring grep_result.raw_output "gamma");
       let execute_result =
         run
           "Execute"
@@ -2142,7 +2133,7 @@ let test_model_visible_web_fetch_dispatches_to_misc_runtime () =
             (List.exists
                (fun (key, value) ->
                  String.equal key "User-Agent"
-                 && contains_substring value "MASC-FetchWeb")
+                 && String_util.contains_substring value "MASC-FetchWeb")
                headers);
           Ok (Some 200, html))
         (fun () ->
@@ -2181,11 +2172,11 @@ let test_model_visible_web_fetch_dispatches_to_misc_runtime () =
           check string "description" "Alias description & detail"
             Yojson.Safe.Util.(member "description" json |> to_string);
           check bool "heading rendered as markdown" true
-            (contains_substring
+            (String_util.contains_substring
                Yojson.Safe.Util.(member "text" json |> to_string)
                "# Alias Fetch");
           check bool "body text cleaned" true
-            (contains_substring
+            (String_util.contains_substring
                Yojson.Safe.Util.(member "text" json |> to_string)
                "Body content & proof.")))
 
@@ -2473,7 +2464,7 @@ let test_approved_web_search_replays_without_model_resubmission () =
                  check bool
                    "stored WebSearch effect executed"
                    true
-                   (contains_substring output "Replayed result")
+                   (String_util.contains_substring output "Replayed result")
                | Some
                    { outcome = Masc.Keeper_gate_replay.Applied _; _ } ->
                  fail
@@ -2514,7 +2505,7 @@ let test_approved_web_search_replays_without_model_resubmission () =
             check bool
               "replayed WebSearch output survives behind the durable reference"
               true
-              (contains_substring output "Replayed result")
+              (String_util.contains_substring output "Replayed result")
           | Ok None -> fail "durable replay output artifact is missing"
           | Error error ->
             fail (Tool_blob_store.fetch_error_to_string error));
@@ -2539,7 +2530,7 @@ let test_approved_web_search_replays_without_model_resubmission () =
          check bool
            "durable replay output stays outside the provider-only projection"
            false
-           (contains_substring projected_message "Replayed result");
+           (String_util.contains_substring projected_message "Replayed result");
          (match
             projected_evidence
             |> Yojson.Safe.Util.member "untrusted_tool_output_ref"
@@ -2557,7 +2548,7 @@ let test_approved_web_search_replays_without_model_resubmission () =
          check bool
            "model is forbidden to request the consumed operation again"
            true
-           (contains_substring
+           (String_util.contains_substring
               model_message.text
               "Do not request the approved operation again")
        | Ok _ -> fail "durable WebSearch replay result was missing"
@@ -2849,7 +2840,7 @@ let test_blob_failure_repairs_journal_without_second_effect () =
          check bool
            "journal-only repair persisted the exact prior outcome"
            true
-           (contains_substring output "Exactly once")
+           (String_util.contains_substring output "Exactly once")
        | outcome ->
          failf
            "in-memory journal-only repair failed: %s"
@@ -3215,11 +3206,11 @@ let test_unsupported_approved_operation_retains_exact_model_issued_path () =
        check bool
          "unsupported exact input remains in the model-issued path"
          true
-         (contains_substring model_message "UNSUPPORTED-END");
+         (String_util.contains_substring model_message "UNSUPPORTED-END");
        check bool
          "unsupported approval does not invent operator repair"
          false
-         (contains_substring model_message "Operator repair is required"))
+         (String_util.contains_substring model_message "Operator repair is required"))
 ;;
 
 let workflow_rejection_message =
@@ -3579,7 +3570,7 @@ let test_registered_dispatch_preserves_workflow_failure_class () =
          | Tool_result.Completed () -> fail "expected typed failure"
          | Tool_result.Deferred () -> fail "expected typed failure, got deferred");
         check bool "error message preserved" true
-          (contains_substring execution.raw_output "Self-approval"))
+          (String_util.contains_substring execution.raw_output "Self-approval"))
 
 (* ── Agent Core descriptor execution mode ───────────────────────────
 
@@ -3721,7 +3712,7 @@ let test_surface_post_bundle_names_reader_and_repeat_cost () =
             check bool
               (Printf.sprintf "projected description contains %S" phrase)
               true
-              (contains_substring description phrase))
+              (String_util.contains_substring description phrase))
          [ "read by a person"
          ; "unchanged status reposted every cycle"
          ; "the turn ends without a post"
@@ -4026,7 +4017,7 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
          ~id:subscriber_id
          ~callback:(fun (ev : Masc.Sse.external_event) ->
             let event = ev.Masc.Sse.ext_frame in
-           if contains_substring event "\"type\":\"keeper_chat_appended\""
+           if String_util.contains_substring event "\"type\":\"keeper_chat_appended\""
            then incr chat_broadcast_count)
          ();
        Fun.protect
@@ -4056,7 +4047,7 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                check bool
                  "raw append failure retains the exact full chat target"
                  true
-                 (contains_substring error_detail chat_path)
+                 (String_util.contains_substring error_detail chat_path)
              | Ok _ -> fail "durable dashboard append failure became Completed");
             check int
               "failed append emits no keeper chat broadcast"
@@ -4077,7 +4068,7 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                check bool
                  "terminal failure retains the exact full chat target"
                  true
-                 (contains_substring failure.diagnostic chat_path)
+                 (String_util.contains_substring failure.diagnostic chat_path)
              | Masc.Keeper_tools_agent_core.Terminal_effect_open ->
                fail "failed surface delivery left the terminal effect open"
              | Masc.Keeper_tools_agent_core.Deferred_tool_result ->
@@ -4189,7 +4180,7 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                check bool
                  "Runtime_agent error retains the exact full chat target"
                  true
-                 (contains_substring diagnostic chat_path)
+                 (String_util.contains_substring diagnostic chat_path)
              | Some other ->
                failf
                  "Runtime_agent returned %s instead of terminal_effect_failed"
@@ -4209,7 +4200,7 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
                check bool
                  "runtime terminal state retains the exact full chat target"
                  true
-                 (contains_substring failure.diagnostic chat_path)
+                 (String_util.contains_substring failure.diagnostic chat_path)
              | Masc.Keeper_tools_agent_core.Terminal_effect_open ->
                fail "runtime terminal failure was not recorded"
              | Masc.Keeper_tools_agent_core.Deferred_tool_result ->

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -52,16 +52,6 @@ match Masc_test_deps.meta_of_json_fixture json with
 | Ok meta -> meta
 | Error e -> failwith e
 
-let contains_substring s needle =
-  let s_len = String.length s in
-  let n_len = String.length needle in
-  let rec loop i =
-    if i + n_len > s_len then false
-    else if String.sub s i n_len = needle then true
-    else loop (i + 1)
-  in
-  if n_len = 0 then true else loop 0
-
 let substring_index s needle =
   let s_len = String.length s in
   let n_len = String.length needle in
@@ -210,9 +200,9 @@ let test_message_of_request () =
     assert (msg.Agent_core.Types.role = Agent_core.Types.User);
     (match msg.Agent_core.Types.content with
      | [ Agent_core.Types.Text q; Agent_core.Types.Image img ] ->
-       assert (contains_substring q "what color?");
-       assert (contains_substring q "Return only a JSON object");
-       assert (contains_substring q "field named text");
+       assert (String_util.contains_substring q "what color?");
+       assert (String_util.contains_substring q "Return only a JSON object");
+       assert (String_util.contains_substring q "field named text");
        assert (String.equal img.media_type "image/png");
        assert (
          String.equal
@@ -673,7 +663,7 @@ let test_invalid_structured_vision_response_is_runtime_failure () =
            (assoc_string "error" json)
            "invalid_structured_response");
       assert (String.equal (assoc_string "failure_class" json) "runtime_failure");
-      assert (contains_substring (assoc_string "detail" json) "JSON parse error")))
+      assert (String_util.contains_substring (assoc_string "detail" json) "JSON parse error")))
 
 let test_run_vision_invalid_structured_response_is_typed () =
   with_temp_runtime_toml single_vision_runtime_toml (fun () ->
@@ -695,7 +685,7 @@ let test_run_vision_invalid_structured_response_is_typed () =
     in
     match outcome with
     | Vt.Vo_invalid_structured_response detail ->
-      assert (contains_substring detail "JSON parse error")
+      assert (String_util.contains_substring detail "JSON parse error")
     | _ -> failwith "expected Vo_invalid_structured_response")
 
 let test_retryable_provider_error_tries_next_runtime () =
@@ -902,9 +892,9 @@ let test_delegate_eager_eviction_stores_image_and_removes_inline_block () =
       ; Agent_core.Types.Text placeholder
       ; Agent_core.Types.Text "after"
       ] ->
-      assert (contains_substring placeholder "[image artifact:");
-      assert (contains_substring placeholder "media_type:image/png");
-      assert (contains_substring placeholder "not yet read");
+      assert (String_util.contains_substring placeholder "[image artifact:");
+      assert (String_util.contains_substring placeholder "media_type:image/png");
+      assert (String_util.contains_substring placeholder "not yet read");
       let handle = artifact_handle_of_placeholder placeholder in
       (match
          Store.load
@@ -942,7 +932,7 @@ let test_delegate_eviction_rejects_invalid_media_type_before_store () =
         ]
     with
     | [ Agent_core.Types.Text placeholder ] ->
-      assert (contains_substring placeholder "unsupported image media type");
+      assert (String_util.contains_substring placeholder "unsupported image media type");
       assert_metric_increment
         "vision_ingest invalid_media_type"
         before
@@ -967,7 +957,7 @@ let test_delegate_eviction_rejects_oversize_before_store () =
           ]
       with
       | [ Agent_core.Types.Text placeholder ] ->
-        assert (contains_substring placeholder "image too large")
+        assert (String_util.contains_substring placeholder "image too large")
       | _ -> failwith "oversize image must surface as a text placeholder"))
 
 let test_delegate_eviction_bad_base64_surfaces_redacted_text_error () =
@@ -984,9 +974,9 @@ let test_delegate_eviction_bad_base64_surfaces_redacted_text_error () =
       ]
   with
   | [ Agent_core.Types.Text placeholder ] ->
-    assert (contains_substring placeholder "could not store");
-    assert (contains_substring placeholder "invalid image payload");
-    assert (not (contains_substring placeholder "bad base64"))
+    assert (String_util.contains_substring placeholder "could not store");
+    assert (String_util.contains_substring placeholder "invalid image payload");
+    assert (not (String_util.contains_substring placeholder "bad base64"))
   | _ -> failwith "bad base64 must surface as a redacted text placeholder"
 
 let test_delegate_eviction_rejects_non_base64_source_before_store () =
@@ -1012,8 +1002,8 @@ let test_delegate_eviction_rejects_non_base64_source_before_store () =
           ]
       with
       | [ Agent_core.Types.Text placeholder ] ->
-        assert (contains_substring placeholder "could not store");
-        assert (contains_substring placeholder "unsupported image source");
+        assert (String_util.contains_substring placeholder "could not store");
+        assert (String_util.contains_substring placeholder "unsupported image source");
         assert_metric_increment
           ("vision_ingest invalid_source_type " ^ source_name)
           before

--- a/test/test_mcp_auth_gate.ml
+++ b/test/test_mcp_auth_gate.ml
@@ -61,22 +61,6 @@ let error_code_exn response =
   | _ -> fail "response not an object"
 ;;
 
-let contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  if needle_len = 0
-  then true
-  else if needle_len > text_len
-  then false
-  else (
-    let rec loop i =
-      if i + needle_len > text_len
-      then false
-      else if String.sub text i needle_len = needle
-      then true
-      else loop (i + 1)
-    in
-    loop 0)
 ;;
 
 let error_message_exn response =
@@ -165,7 +149,7 @@ let test_tools_list_requires_auth_missing_token () =
        check int "auth error code" (-32001) (error_code_exn response);
        check bool "missing token message"
          true
-         (contains_substring (error_message_exn response) "bearer token required"))
+         (String_util.contains_substring (error_message_exn response) "bearer token required"))
 ;;
 
 let test_tools_list_requires_auth_invalid_token () =
@@ -178,7 +162,7 @@ let test_tools_list_requires_auth_invalid_token () =
        check int "auth error code" (-32001) (error_code_exn response);
        check bool "invalid token message"
          true
-         (contains_substring (error_message_exn response) "invalid bearer token"))
+         (String_util.contains_substring (error_message_exn response) "invalid bearer token"))
 ;;
 
 let test_tools_list_succeeds_with_valid_token () =

--- a/test/test_mcp_post_sse_e2e.ml
+++ b/test/test_mcp_post_sse_e2e.ml
@@ -145,16 +145,6 @@ let run_curl_get ?(max_time_sec = 1) ~port ~path () =
   (try Sys.remove body_file with _ -> ());
   { status; body; curl_exit; stderr }
 
-let contains_substr needle haystack =
-  let n = String.length needle in
-  let h = String.length haystack in
-  let rec loop i =
-    if i + n > h then false
-    else if String.sub haystack i n = needle then true
-    else loop (i + 1)
-  in
-  n = 0 || loop 0
-
 let normalize_mcp_body body =
   let lines = String.split_on_char '\n' body |> List.map trim_cr in
   let prefix = "data: " in
@@ -196,7 +186,7 @@ let wait_for_health ~port ~timeout_s =
     else
       let res = run_curl_get ~max_time_sec:1 ~port ~path:"/health" () in
       match res.status with
-      | Some 200 when contains_substr "\"state_ready\":true" res.body -> true
+      | Some 200 when String_util.contains_substring res.body "\"state_ready\":true" -> true
       | _ ->
           Unix.sleepf 0.1;
           loop ()
@@ -317,12 +307,12 @@ let rec call_status_until_ready ~port ~retries_left =
   match (result.status, retries_left) with
   | Some 500, retries
     when retries > 0
-         && contains_substr "Server state not initialized" result.body ->
+         && String_util.contains_substring result.body "Server state not initialized" ->
       Unix.sleepf 0.5;
       call_status_until_ready ~port ~retries_left:(retries - 1)
   | Some 503, retries
     when retries > 0
-         && contains_substr "Server is starting up, not ready yet" result.body ->
+         && String_util.contains_substring result.body "Server is starting up, not ready yet" ->
       Unix.sleepf 0.5;
       call_status_until_ready ~port ~retries_left:(retries - 1)
   | _ -> result
@@ -336,9 +326,9 @@ let test_post_tools_call_streams_sse_framing () =
   let result = call_status_until_ready ~port ~retries_left:40 in
   require_http_ok "streaming tools/call" result;
   check int "curl exits cleanly" 0 result.curl_exit;
-  check bool "prime event sent" true (contains_substr "retry: 3000" result.body);
+  check bool "prime event sent" true (String_util.contains_substring result.body "retry: 3000");
   check bool "message event sent" true
-    (contains_substr "event: message" result.body);
+    (String_util.contains_substring result.body "event: message");
   let json = parse_json_body "streaming tools/call" result in
   check bool "json-rpc error absent" true (json |> U.member "error" = `Null);
   check bool "tool succeeded" false
@@ -362,12 +352,12 @@ let rec join_until_ready ~port ~retries_left =
   match (result.status, retries_left) with
   | Some 500, retries
     when retries > 0
-         && contains_substr "Server state not initialized" result.body ->
+         && String_util.contains_substring result.body "Server state not initialized" ->
       Unix.sleepf 0.5;
       join_until_ready ~port ~retries_left:(retries - 1)
   | Some 503, retries
     when retries > 0
-         && contains_substr "Server is starting up, not ready yet" result.body ->
+         && String_util.contains_substring result.body "Server is starting up, not ready yet" ->
       Unix.sleepf 0.5;
       join_until_ready ~port ~retries_left:(retries - 1)
   | _ -> result
@@ -386,9 +376,9 @@ let test_post_tools_call_preserves_explicit_tool_agent_name () =
     |> U.member "text" |> U.to_string
   in
   check bool "explicit tool agent_name preserved" true
-    (contains_substr "Type: gemini" text);
+    (String_util.contains_substring text "Type: gemini");
   check bool "header actor not used as tool target agent_name" false
-    (contains_substr "Type: dashboard-header-actor" text)
+    (String_util.contains_substring text "Type: dashboard-header-actor")
 
 let () =
   run "mcp_post_sse_e2e"

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -52,16 +52,6 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
-let contains_substring s needle =
-  let s_len = String.length s in
-  let n_len = String.length needle in
-  let rec loop i =
-    if i + n_len > s_len then false
-    else if String.sub s i n_len = needle then true
-    else loop (i + 1)
-  in
-  if n_len = 0 then true else loop 0
-
 let with_env key value f =
   let old = Sys.getenv_opt key in
   Unix.putenv key value;
@@ -464,7 +454,7 @@ let test_protocol_version () =
   match Mcp.validate_protocol_version "unknown" with
   | Error msg ->
       Alcotest.(check bool) "unsupported version rejected" true
-        (contains_substring msg "Unsupported protocolVersion")
+        (String_util.contains_substring msg "Unsupported protocolVersion")
   | Ok _ -> Alcotest.fail "expected unsupported protocol version to be rejected"
 
 (* ===== Unit Tests for Response Builders ===== *)
@@ -564,7 +554,7 @@ let test_handle_request_initialize_rejects_unsupported_protocol_version () =
   let response = Mcp_eio.handle_request ~clock ~sw state request in
   Alcotest.(check int) "invalid params code" (-32602) (error_code_exn response);
   Alcotest.(check bool) "unsupported protocol message" true
-    (contains_substring (error_message_exn response) "Unsupported protocolVersion");
+    (String_util.contains_substring (error_message_exn response) "Unsupported protocolVersion");
 
   cleanup_dir base_path
 
@@ -744,11 +734,11 @@ let test_handle_request_initialize_operator_profile () =
               | _ -> ""
             in
             Alcotest.(check bool) "mentions operator profile" true
-              (contains_substring instructions "six operator tools");
+              (String_util.contains_substring instructions "six operator tools");
             Alcotest.(check bool) "does not mention surface audit" false
-              (contains_substring instructions "surface audit");
+              (String_util.contains_substring instructions "surface audit");
             Alcotest.(check bool) "mentions confirm workflow" true
-              (contains_substring instructions "confirm_required=true")
+              (String_util.contains_substring instructions "confirm_required=true")
         | _ -> Alcotest.fail "result not an object")
    | _ -> Alcotest.fail "response not an object");
   cleanup_dir base_path
@@ -879,9 +869,9 @@ let test_handle_request_initialize_managed_profile () =
               | _ -> ""
             in
             Alcotest.(check bool) "mentions managed profile" true
-              (contains_substring instructions "managed-agent profile");
+              (String_util.contains_substring instructions "managed-agent profile");
             Alcotest.(check bool) "mentions canonical task control" true
-              (contains_substring instructions "masc_transition")
+              (String_util.contains_substring instructions "masc_transition")
         | _ -> Alcotest.fail "result not an object")
    | _ -> Alcotest.fail "response not an object");
   cleanup_dir base_path
@@ -1004,7 +994,7 @@ let test_handle_request_tools_call_managed_profile_rejects_hidden_claim_alias ()
   in
   let response_text = Yojson.Safe.to_string response in
   Alcotest.(check bool) "removed alias rejected" true
-    (contains_substring response_text
+    (String_util.contains_substring response_text
        "Tool 'masc_claim_task' is not available on this MCP endpoint");
   Alcotest.(check (float 0.0001)) "rejected tools/call records duration count"
     1.0
@@ -1057,7 +1047,7 @@ let test_handle_request_tools_call_missing_params_records_duration () =
   in
   let response_text = Yojson.Safe.to_string response in
   Alcotest.(check bool) "missing params rejected" true
-    (contains_substring response_text "Missing params");
+    (String_util.contains_substring response_text "Missing params");
   Alcotest.(check (float 0.0001)) "missing params records duration count"
     1.0
     (Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
@@ -1115,7 +1105,7 @@ let test_handle_request_tools_call_managed_translation_error_records_duration ()
   in
   let response_text = Yojson.Safe.to_string response in
   Alcotest.(check bool) "translation error is returned" true
-    (contains_substring response_text "managed agent tool translation failed");
+    (String_util.contains_substring response_text "managed agent tool translation failed");
   Alcotest.(check (float 0.0001)) "translation error records duration count"
     1.0
     (Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
@@ -1323,8 +1313,8 @@ let test_handle_request_tools_call_transition_claim_requires_action () =
   in
   let response_text = Yojson.Safe.to_string response in
   Alcotest.(check bool) "missing action rejected" true
-    (contains_substring response_text "action"
-     && contains_substring response_text "MISSING");
+    (String_util.contains_substring response_text "action"
+     && String_util.contains_substring response_text "MISSING");
   cleanup_dir base_path
 
 let test_handle_request_tools_call_operator_profile_rejects_non_operator () =
@@ -1353,7 +1343,7 @@ let test_handle_request_tools_call_operator_profile_rejects_non_operator () =
             Alcotest.(check bool) "method not available" true
               (match List.assoc_opt "message" error_fields with
                | Some (`String msg) ->
-                   contains_substring msg "not available on this MCP endpoint"
+                   String_util.contains_substring msg "not available on this MCP endpoint"
                | _ -> false)
         | _ -> Alcotest.fail "error missing")
    | _ -> Alcotest.fail "response not an object");
@@ -1684,9 +1674,9 @@ let check_auth_preflight_result ~tool_name result =
     false
     (Tool_result.is_success result);
   Alcotest.(check bool) (tool_name ^ " reports auth/credential blocker") true
-    (contains_substring msg "Token required"
-     || contains_substring msg "Unauthorized"
-     || contains_substring msg "No credential");
+    (String_util.contains_substring msg "Token required"
+     || String_util.contains_substring msg "Unauthorized"
+     || String_util.contains_substring msg "No credential");
   Alcotest.(check (option string))
     (tool_name ^ " policy rejection class")
     (Some "policy_rejection")
@@ -1811,7 +1801,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_rejected_without_mut
   Alcotest.(check bool) "claim_next rejected by public MCP path" false
     (Tool_result.is_success result);
   Alcotest.(check bool) "claim_next points to in-process task handler" true
-    (contains_substring
+    (String_util.contains_substring
        (Tool_result.message result)
        "keeper in-process task handler");
   check_task_still_todo (Mcp_server.workspace_config state) "task-001";
@@ -1915,7 +1905,7 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
   in
   Alcotest.(check bool) "add_task succeeds" true (Tool_result.is_success result);
   Alcotest.(check bool) "response mentions added task" true
-    (contains_substring ((Tool_result.message result)) "Added task-001");
+    (String_util.contains_substring ((Tool_result.message result)) "Added task-001");
   let task =
     match Masc.Workspace.get_tasks_raw (Mcp_server.workspace_config state) with
     | [ task ] -> task
@@ -2250,7 +2240,7 @@ let test_handle_request_tools_call_blocks_keeper_internal_tool () =
     | _ -> Alcotest.fail "missing content"
   in
   Alcotest.(check bool) "mentions unknown keeper internal tool" true
-    (contains_substring msg "Unknown tool: keeper_time_now");
+    (String_util.contains_substring msg "Unknown tool: keeper_time_now");
   cleanup_dir base_path
 
 let tool_names_from_list_response response =
@@ -2347,9 +2337,9 @@ let test_handle_request_tools_call_internal_keeper_runtime_rejects_unknown_execu
         | _ -> Alcotest.fail "missing content"
       in
       Alcotest.(check bool) "mentions unknown tool_execute" true
-        (contains_substring msg "Unknown tool: tool_execute");
+        (String_util.contains_substring msg "Unknown tool: tool_execute");
       Alcotest.(check bool) "mentions registry inconsistency" true
-        (contains_substring msg "registry inconsistency"))
+        (String_util.contains_substring msg "registry inconsistency"))
 
 let test_handle_request_batch_rejected () =
   Eio_main.run @@ fun env ->
@@ -2374,7 +2364,7 @@ let test_handle_request_batch_rejected () =
   let response = Mcp_eio.handle_request ~clock ~sw state request in
   Alcotest.(check int) "batch rejected" (-32600) (error_code_exn response);
   Alcotest.(check bool) "mentions batch unsupported" true
-    (contains_substring (error_message_exn response) "batch requests are not supported");
+    (String_util.contains_substring (error_message_exn response) "batch requests are not supported");
   cleanup_dir base_path
 
 let test_handle_request_jsonrpc_response_returns_null () =
@@ -2471,7 +2461,7 @@ let test_handle_request_tools_list_rejects_tier_field () =
   let response = Mcp_eio.handle_request ~clock ~sw state request in
   Alcotest.(check int) "invalid params code" (-32602) (error_code_exn response);
   Alcotest.(check bool) "unsupported tier error" true
-    (contains_substring (error_message_exn response) "unsupported field(s): tier");
+    (String_util.contains_substring (error_message_exn response) "unsupported field(s): tier");
   cleanup_dir base_path
 
 let test_handle_request_resources_list_rejects_unknown_field () =
@@ -2494,7 +2484,7 @@ let test_handle_request_resources_list_rejects_unknown_field () =
   let response = Mcp_eio.handle_request ~clock ~sw state request in
   Alcotest.(check int) "invalid params code" (-32602) (error_code_exn response);
   Alcotest.(check bool) "unknown field rejected" true
-    (contains_substring (error_message_exn response) "unsupported field");
+    (String_util.contains_substring (error_message_exn response) "unsupported field");
   cleanup_dir base_path
 
 let test_handle_request_resources_templates_rejects_invalid_cursor () =
@@ -2519,10 +2509,10 @@ let test_handle_request_resources_templates_rejects_invalid_cursor () =
   let msg = error_message_exn response in
   Alcotest.(check bool)
     "invalid cursor error preserves contract label" true
-    (contains_substring msg "Invalid params: cursor");
+    (String_util.contains_substring msg "Invalid params: cursor");
   Alcotest.(check bool)
     "invalid cursor error names received string" true
-    (contains_substring msg "not-base64");
+    (String_util.contains_substring msg "not-base64");
   cleanup_dir base_path
 
 let test_handle_request_prompts_list_rejects_invalid_cursor () =
@@ -2547,10 +2537,10 @@ let test_handle_request_prompts_list_rejects_invalid_cursor () =
   let msg = error_message_exn response in
   Alcotest.(check bool)
     "invalid cursor error preserves contract label" true
-    (contains_substring msg "Invalid params: cursor");
+    (String_util.contains_substring msg "Invalid params: cursor");
   Alcotest.(check bool)
     "invalid cursor error names received string" true
-    (contains_substring msg "bad-cursor");
+    (String_util.contains_substring msg "bad-cursor");
   cleanup_dir base_path
 
 let test_handle_request_prompts_list_non_empty () =
@@ -2662,7 +2652,7 @@ let test_handle_request_prompts_get_tool_help () =
     | _ -> Alcotest.fail "response not an object"
   in
   Alcotest.(check bool) "description contains help intent" true
-    (contains_substring description "tool");
+    (String_util.contains_substring description "tool");
   Alcotest.(check bool) "prompt has one or more messages" true
     (messages <> []);
   cleanup_dir base_path
@@ -2804,7 +2794,7 @@ let test_handle_request_tool_help_resource_read () =
     | _ -> Alcotest.fail "response not an object"
   in
   Alcotest.(check bool) "resource contains heading" true
-    (contains_substring text "# masc_status");
+    (String_util.contains_substring text "# masc_status");
   cleanup_dir base_path
 
 let test_handle_request_resources_read_matrix () =
@@ -2864,7 +2854,7 @@ Alpha body
       Alcotest.(check string) (uri ^ " mime type") expected_mime
         (resource_mime_type_exn response);
       Alcotest.(check bool) (uri ^ " text contains expected") true
-        (contains_substring (resource_text_exn response) expected_text))
+        (String_util.contains_substring (resource_text_exn response) expected_text))
     cases;
   cleanup_dir base_path
 
@@ -2912,7 +2902,7 @@ let test_handle_request_dashboard_ping_requires_session () =
   in
   let response = Mcp_eio.handle_request ~clock ~sw state request in
   Alcotest.(check bool) "ping requires ws session" true
-    (contains_substring
+    (String_util.contains_substring
        (Yojson.Safe.to_string response)
        "dashboard/ping requires a WebSocket session");
   cleanup_dir base_path
@@ -2943,7 +2933,7 @@ let test_handle_request_dashboard_ping_reports_unknown_ws_session () =
       request
   in
   Alcotest.(check bool) "unknown ws session reported" true
-    (contains_substring
+    (String_util.contains_substring
        (Yojson.Safe.to_string response)
        "WebSocket session not found");
   cleanup_dir base_path

--- a/test/test_mcp_server_eio_tool_dispatch.ml
+++ b/test/test_mcp_server_eio_tool_dispatch.ml
@@ -29,16 +29,6 @@ let create_admin_token ?(agent_name = "stable-admin") base_path =
   | Ok (token, _cred) -> token
   | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
 
-let contains_substring s needle =
-  let s_len = String.length s in
-  let n_len = String.length needle in
-  let rec loop i =
-    if i + n_len > s_len then false
-    else if String.sub s i n_len = needle then true
-    else loop (i + 1)
-  in
-  if n_len = 0 then true else loop 0
-
 let extract_json_from_text text =
   try
     let idx = String.index text '{' in

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -1,15 +1,5 @@
 open Alcotest
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop index =
-    if nlen = 0 then true
-    else if index + nlen > hlen then false
-    else if String.sub haystack index nlen = needle then true
-    else loop (index + 1)
-  in
-  loop 0
 ;;
 
 let annotation_fields tool_name =

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -120,25 +120,8 @@ let string_starts_with ~prefix s =
   let slen = String.length s in
   slen >= plen && String.sub s 0 plen = prefix
 
-let contains_substring haystack needle =
-  let haystack = String.lowercase_ascii haystack in
-  let needle = String.lowercase_ascii needle in
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    if nlen = 0 then
-      true
-    else if idx + nlen > hlen then
-      false
-    else if String.sub haystack idx nlen = needle then
-      true
-    else
-      loop (idx + 1)
-  in
-  loop 0
-
 let contains_any haystack needles =
-  List.exists (fun needle -> contains_substring haystack needle) needles
+  List.exists (fun needle -> String_util.contains_substring haystack needle) needles
 
 let assoc_field name = function
   | `Assoc fields -> List.assoc_opt name fields
@@ -325,7 +308,7 @@ let ensure_bound fixture =
   if (Tool_result.is_success result) then ()
   else begin
     let body = (Tool_result.message result) in
-    if contains_substring body "already joined" then ()
+    if String_util.contains_substring body "already joined" then ()
     else failwith ("masc_start failed: " ^ body)
   end
 

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -121,7 +121,9 @@ let string_starts_with ~prefix s =
   slen >= plen && String.sub s 0 plen = prefix
 
 let contains_any haystack needles =
-  List.exists (fun needle -> String_util.contains_substring haystack needle) needles
+  List.exists
+    (fun needle -> String_util.contains_substring_ci haystack needle)
+    needles
 
 let assoc_field name = function
   | `Assoc fields -> List.assoc_opt name fields
@@ -308,7 +310,7 @@ let ensure_bound fixture =
   if (Tool_result.is_success result) then ()
   else begin
     let body = (Tool_result.message result) in
-    if String_util.contains_substring body "already joined" then ()
+    if String_util.contains_substring_ci body "already joined" then ()
     else failwith ("masc_start failed: " ^ body)
   end
 

--- a/test/test_mcp_tool_runtime_workspace_path.ml
+++ b/test/test_mcp_tool_runtime_workspace_path.ml
@@ -6,19 +6,6 @@ module Mcp_eio = Masc.Mcp_server_eio
 module Mcp_server = Masc.Mcp_server
 module Recovery_test = Fs_compat_test_support.Publication_recovery_for_testing
 
-let contains_substring text fragment =
-  let text_len = String.length text in
-  let fragment_len = String.length fragment in
-  let rec loop index =
-    if fragment_len = 0
-    then true
-    else if index + fragment_len > text_len
-    then false
-    else if String.sub text index fragment_len = fragment
-    then true
-    else loop (index + 1)
-  in
-  loop 0
 ;;
 
 let restore_env name = function
@@ -63,7 +50,7 @@ let test_masc_start_tilde_rejects_empty_initial_home () =
       Alcotest.(check bool)
         "reports missing HOME"
         true
-        (contains_substring message "HOME is required to expand '~'"))
+        (String_util.contains_substring message "HOME is required to expand '~'"))
 ;;
 
 let test_masc_start_surfaces_claim_failure_after_task_commit () =
@@ -116,7 +103,7 @@ let test_masc_start_surfaces_claim_failure_after_task_commit () =
         (Tool_result.failure_class result
          |> Option.map Tool_result.tool_failure_class_to_string);
       Alcotest.(check bool) "claim failure is explicit" true
-        (contains_substring (Tool_result.message result) "claim failed");
+        (String_util.contains_substring (Tool_result.message result) "claim failed");
       let data = Tool_result.data result in
       Alcotest.(check string) "created task remains a post-effect"
         "proven_post_effect"
@@ -125,7 +112,7 @@ let test_masc_start_surfaces_claim_failure_after_task_commit () =
         "task-002"
         Yojson.Safe.Util.(data |> member "task_id" |> to_string);
       Alcotest.(check bool) "committed task result is preserved" true
-      (contains_substring
+      (String_util.contains_substring
            Yojson.Safe.Util.(data |> member "primary_result" |> to_string)
            "Added task-002"))
 ;;
@@ -188,7 +175,7 @@ let test_masc_start_surfaces_current_task_failure_after_claim_commit () =
             "task-001"
             Yojson.Safe.Util.(data |> member "task_id" |> to_string);
           Alcotest.(check bool) "committed task result is preserved" true
-            (contains_substring
+            (String_util.contains_substring
                Yojson.Safe.Util.(data |> member "primary_result" |> to_string)
                "Added task-001")))
 ;;

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -98,18 +98,6 @@ let recent_hour_bucket_timestamp () =
 let runtime_lane_label_for_test model_key =
   "runtime_lane_" ^ String.sub (Digest.to_hex (Digest.string model_key)) 0 12
 
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0 then true
-  else
-    let rec loop i =
-      if i + needle_len > haystack_len then false
-      else if String.sub haystack i needle_len = needle then true
-      else loop (i + 1)
-    in
-    loop 0
-
 let success_entry ~model ~ts ?identity_seed ?(input_tokens=100) ?(output_tokens=50)
     ?(cache_read_tokens=0) ?(cache_creation_tokens=0)
     ?(latency_ms=500) ?prompt_per_second ?peak_memory_gb
@@ -1063,7 +1051,7 @@ let test_cost_read_failure_is_not_empty_success () =
       Yojson.Safe.Util.(diagnostics |> member "state" |> to_string);
     let detail = Yojson.Safe.Util.(diagnostics |> member "detail" |> to_string) in
     check bool "typed read detail is surfaced" true
-      (contains_substring detail costs_dir))
+      (String_util.contains_substring detail costs_dir))
 ;;
 
 let test_cost_latency_json_composes_axes_and_percentiles () =
@@ -1521,11 +1509,11 @@ let test_prompt_feedback_redacts_provider_model_identity () =
     }
   in
   let text = M.render_keeper_prompt_feedback agg in
-  check bool "contains redacted lane label" true (contains_substring text lane);
-  check bool "contains total turns" true (contains_substring text "total_turns=10");
-  check bool "contains error rate" true (contains_substring text "error_rate=30.0%");
-  check bool "does not expose provider" false (contains_substring text "openrouter");
-  check bool "does not expose raw model" false (contains_substring text "secret-model")
+  check bool "contains redacted lane label" true (String_util.contains_substring text lane);
+  check bool "contains total turns" true (String_util.contains_substring text "total_turns=10");
+  check bool "contains error rate" true (String_util.contains_substring text "error_rate=30.0%");
+  check bool "does not expose provider" false (String_util.contains_substring text "openrouter");
+  check bool "does not expose raw model" false (String_util.contains_substring text "secret-model")
 
 let test_prompt_feedback_is_cost_independent () =
   let render total_cost_usd =
@@ -1553,7 +1541,7 @@ let test_prompt_feedback_is_cost_independent () =
   List.iter
     (fun forbidden ->
        check bool ("planning feedback excludes " ^ forbidden) false
-         (contains_substring baseline forbidden))
+         (String_util.contains_substring baseline forbidden))
     [ "cost="; "cost_usd"; "$" ]
 
 let test_usage_signal_uses_tokens_not_cost () =

--- a/test/test_notify_coverage.ml
+++ b/test/test_notify_coverage.ml
@@ -25,16 +25,6 @@ let source_file rel =
   Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () ->
   really_input_string ic (in_channel_length ic)
 
-let contains_substring haystack needle =
-  let len = String.length needle in
-  let n = String.length haystack in
-  let rec loop i =
-    if i + len > n then false
-    else if String.sub haystack i len = needle then true
-    else loop (i + 1)
-  in
-  loop 0
-
 (* ============================================================
    sanitize_token Tests
    ============================================================ *)
@@ -336,11 +326,11 @@ let test_focus_payload_all_none () =
 let test_terminal_notifier_execute_requires_opt_in () =
   let src = source_file "lib/notify.ml" in
   check bool "execute opt-in env is present" true
-    (contains_substring src "MASC_NOTIFY_ALLOW_SHELL_EXECUTE");
+    (String_util.contains_substring src "MASC_NOTIFY_ALLOW_SHELL_EXECUTE");
   check bool "focus builder defaults to no shell command" true
-    (contains_substring src "if not (shell_execute_clicks_enabled ())");
+    (String_util.contains_substring src "if not (shell_execute_clicks_enabled ())");
   check bool "terminal-notifier execute is guarded" true
-    (contains_substring src
+    (String_util.contains_substring src
        "Some cmd when shell_execute_clicks_enabled () -> base @ [\"-execute\"; cmd]")
 
 (* ============================================================

--- a/test/test_observability_redact_private_material.ml
+++ b/test/test_observability_redact_private_material.ml
@@ -1,14 +1,5 @@
 let redact s = Masc.Observability_redact.redact_text s
 
-let contains_substring haystack needle =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let max_start = haystack_len - needle_len in
-  let rec loop idx =
-    idx <= max_start
-    && (String.sub haystack idx needle_len = needle || loop (idx + 1))
-  in
-  needle_len = 0 || loop 0
 ;;
 
 let test_private_key_pem_redacted () =
@@ -24,11 +15,11 @@ let test_private_key_pem_redacted () =
   in
   let masked = redact pem in
   Alcotest.(check bool) "begin marker removed" false
-    (contains_substring masked "-----BEGIN RSA PRIVATE KEY-----");
+    (String_util.contains_substring masked "-----BEGIN RSA PRIVATE KEY-----");
   Alcotest.(check bool) "end marker removed" false
-    (contains_substring masked "-----END RSA PRIVATE KEY-----");
+    (String_util.contains_substring masked "-----END RSA PRIVATE KEY-----");
   Alcotest.(check bool) "private body removed" false
-    (contains_substring masked "MIIEpAIBAAKCAQEAprivate-material");
+    (String_util.contains_substring masked "MIIEpAIBAAKCAQEAprivate-material");
   Alcotest.(check bool) "prefix preserved" true
     (String.starts_with ~prefix:"before" masked);
   Alcotest.(check bool) "suffix preserved" true

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -178,16 +178,6 @@ let run_curl_get ~port ~path () =
   let (status, _headers) = parse_headers header_raw in
   { status; body; curl_exit; stderr }
 
-let contains_substr needle haystack =
-  let n = String.length needle in
-  let h = String.length haystack in
-  let rec loop i =
-    if i + n > h then false
-    else if String.sub haystack i n = needle then true
-    else loop (i + 1)
-  in
-  n = 0 || loop 0
-
 let find_free_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Fun.protect
@@ -210,7 +200,8 @@ let wait_for_health ~port ~timeout_s =
     else
       let res = run_curl_get ~port ~path:"/health" () in
       match res.status with
-      | Some 200 when contains_substr "\"state_ready\":true" res.body -> true
+      | Some 200
+        when String_util.contains_substring res.body "\"state_ready\":true" -> true
       | _ ->
           Unix.sleepf 0.1;
           loop ()
@@ -453,7 +444,9 @@ let test_mcp_requires_auth_when_bound_non_loopback () =
     match (result.status, retries_left) with
     | Some 503, retries
       when retries > 0
-           && contains_substr "Server is starting up, not ready yet" result.body ->
+           && String_util.contains_substring
+                result.body
+                "Server is starting up, not ready yet" ->
         Unix.sleepf 0.5;
         call_until_ready (retries - 1)
     | _ -> result
@@ -461,8 +454,9 @@ let test_mcp_requires_auth_when_bound_non_loopback () =
   let result = call_until_ready 40 in
   Alcotest.(check (option int)) "returns unauthorized" (Some 401) result.status;
   check bool "strict auth message" true
-    (contains_substr "requires workspace auth enabled with require_token=true"
-       result.body)
+    (String_util.contains_substring
+       result.body
+       "requires workspace auth enabled with require_token=true")
 
 let test_agent_json_route_served_on_canonical_path () =
   with_server ~enable_auth:false

--- a/test/test_pr_open_script.ml
+++ b/test/test_pr_open_script.ml
@@ -8,15 +8,6 @@ let source_root () =
 let script_path () =
   Filename.concat (source_root ()) "scripts/pr-open.sh"
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
@@ -238,11 +229,11 @@ let init_repo_with_remote dir =
 let test_source_avoids_mapfile_only_bash4_features () =
   let content = read_file (script_path ()) in
   check bool "script no longer uses mapfile" false
-    (contains_substring content "mapfile ");
+    (String_util.contains_substring content "mapfile ");
   check bool "script no longer uses readarray" false
-    (contains_substring content "readarray ");
+    (String_util.contains_substring content "readarray ");
   check bool "script has bash-compatible changed file loader" true
-    (contains_substring content "load_changed_files()")
+    (String_util.contains_substring content "load_changed_files()")
 
 let test_script_runs_under_system_bash_without_watch () =
   with_temp_dir "pr-open-script" (fun dir ->
@@ -278,27 +269,27 @@ let test_script_runs_under_system_bash_without_watch () =
       if code <> 0 then
         failf "pr-open failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       check bool "prints PR url" true
-        (contains_substring stdout "PR: https://github.com/example/test/pull/42");
+        (String_util.contains_substring stdout "PR: https://github.com/example/test/pull/42");
       check bool "does not mention mapfile failure" false
-        (contains_substring stderr "mapfile: command not found");
+        (String_util.contains_substring stderr "mapfile: command not found");
       let log = read_file gh_log in
-      check bool "creates draft PR" true (contains_substring log "pr create");
+      check bool "creates draft PR" true (String_util.contains_substring log "pr create");
       check bool "does not create legacy failing status" false
-        (contains_substring log "api repos/example/test/statuses/abc123");
+        (String_util.contains_substring log "api repos/example/test/statuses/abc123");
       check bool "skips watched checks with --no-watch" false
-        (contains_substring log "pr checks");
+        (String_util.contains_substring log "pr checks");
       check bool "syncs commit lineage" true
-        (contains_substring log "pr edit");
+        (String_util.contains_substring log "pr edit");
       let synced_body = read_file (gh_labels ^ ".body") in
       check bool "writes commit lineage marker" true
-        (contains_substring synced_body "<!-- COMMIT-LINEAGE:START -->");
+        (String_util.contains_substring synced_body "<!-- COMMIT-LINEAGE:START -->");
       check bool "writes commit lineage commit subject" true
-        (contains_substring synced_body "feature commit");
+        (String_util.contains_substring synced_body "feature commit");
       let labels = read_file gh_labels in
       check bool "adds enhancement label for code changes" true
-        (contains_substring labels "\"enhancement\"");
+        (String_util.contains_substring labels "\"enhancement\"");
       check bool "does not add docs label for code-only change" false
-        (contains_substring labels "\"docs\""))
+        (String_util.contains_substring labels "\"docs\""))
 
 let test_script_restores_draft_when_create_returns_ready () =
   with_temp_dir "pr-open-script-draft-restore" (fun dir ->
@@ -336,11 +327,11 @@ let test_script_restores_draft_when_create_returns_ready () =
         failf "pr-open failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       let log = read_file gh_log in
       check bool "restores draft state" true
-        (contains_substring log "pr ready");
+        (String_util.contains_substring log "pr ready");
       check bool "reports restoration" true
-        (contains_substring stderr "restoring draft state");
+        (String_util.contains_substring stderr "restoring draft state");
       check bool "prints PR url" true
-        (contains_substring stdout "PR: https://github.com/example/test/pull/42"))
+        (String_util.contains_substring stdout "PR: https://github.com/example/test/pull/42"))
 
 let test_script_prints_final_status_after_watch () =
   with_temp_dir "pr-open-script-watch-status" (fun dir ->
@@ -376,13 +367,13 @@ let test_script_prints_final_status_after_watch () =
       if code <> 0 then
         failf "pr-open failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       check bool "runs watched checks" true
-        (contains_substring (read_file gh_log) "pr checks");
+        (String_util.contains_substring (read_file gh_log) "pr checks");
       check bool "prints final status heading" true
-        (contains_substring stdout "PR status:");
+        (String_util.contains_substring stdout "PR status:");
       check bool "prints final draft state" true
-        (contains_substring stdout "draft=true");
+        (String_util.contains_substring stdout "draft=true");
       check bool "prints final merge state" true
-        (contains_substring stdout "mergeState=CLEAN"))
+        (String_util.contains_substring stdout "mergeState=CLEAN"))
 
 let test_script_rejects_body_missing_required_sections () =
   with_temp_dir "pr-open-script-missing-sections" (fun dir ->
@@ -418,13 +409,13 @@ let test_script_rejects_body_missing_required_sections () =
       check bool "command fails" true (code <> 0);
       check bool "stdout empty" true (String.trim stdout = "");
       check bool "mentions hygiene failure" true
-        (contains_substring stderr "body file is missing required PR hygiene sections:");
+        (String_util.contains_substring stderr "body file is missing required PR hygiene sections:");
       check bool "mentions product impact heading" true
-        (contains_substring stderr "## Product impact");
+        (String_util.contains_substring stderr "## Product impact");
       check bool "mentions direct evidence heading" true
-        (contains_substring stderr "## Direct evidence");
+        (String_util.contains_substring stderr "## Direct evidence");
       check bool "mentions linked issue heading" true
-        (contains_substring stderr "## Linked issue");
+        (String_util.contains_substring stderr "## Linked issue");
       check bool "gh never invoked before validation" false
         (Sys.file_exists gh_log))
 
@@ -475,10 +466,10 @@ let test_script_rejects_body_missing_direct_evidence_schema () =
       check bool "command fails" true (code <> 0);
       check bool "stdout empty" true (String.trim stdout = "");
       check bool "mentions direct evidence schema failure" true
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "body file is missing required Direct evidence schema fields:");
       check bool "mentions direct_ratio" true
-        (contains_substring stderr "direct_ratio");
+        (String_util.contains_substring stderr "direct_ratio");
       check bool "gh never invoked before direct evidence validation" false
         (Sys.file_exists gh_log))
 
@@ -518,9 +509,9 @@ let test_script_rejects_staged_changes_before_push () =
       check bool "command fails" true (code <> 0);
       check bool "stdout empty" true (String.trim stdout = "");
       check bool "mentions staged changes" true
-        (contains_substring stderr "staged changes detected");
+        (String_util.contains_substring stderr "staged changes detected");
       check bool "mentions staged path" true
-        (contains_substring stderr "lib/staged.ml");
+        (String_util.contains_substring stderr "lib/staged.ml");
       check bool "gh never invoked before staged validation" false
         (Sys.file_exists gh_log))
 

--- a/test/test_release_train_guard_script.ml
+++ b/test/test_release_train_guard_script.ml
@@ -8,15 +8,6 @@ let source_root () =
 let script_path () =
   Filename.concat (source_root ()) "scripts/check-release-train-guard.sh"
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
@@ -137,7 +128,7 @@ let test_cross_major_reset_ignores_legacy_2x_tags () =
       if code <> 0 then
         failf "guard failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       check bool "uses base major tag lineage" true
-        (contains_substring stdout
+        (String_util.contains_substring stdout
            "Release train guard OK: base=2.263.0 head=0.2.0 latest_tag_ref=v2.263.0 latest_tag_version=2.263.0"))
 
 let test_cross_major_reset_rejects_older_head_series_version () =
@@ -153,7 +144,7 @@ let test_cross_major_reset_rejects_older_head_series_version () =
       in
       check bool "command fails" true (code <> 0);
       check bool "mentions older head series tag" true
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "older than latest tag v0.1.1 in major 0"))
 
 let test_train_build_suffix_tag_matches_package_version () =
@@ -172,7 +163,7 @@ let test_train_build_suffix_tag_matches_package_version () =
       if code <> 0 then
         failf "guard failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       check bool "normalizes train build tag suffix" true
-        (contains_substring stdout
+        (String_util.contains_substring stdout
            "Release train guard OK: base=0.19.10 head=0.19.10 latest_tag_ref=v0.19.10-505 latest_tag_version=0.19.10"))
 
 let test_no_base_logs_raw_suffixed_tag_ref () =
@@ -190,7 +181,7 @@ let test_no_base_logs_raw_suffixed_tag_ref () =
       if code <> 0 then
         failf "guard failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       check bool "prints raw tag ref and normalized version" true
-        (contains_substring stdout
+        (String_util.contains_substring stdout
            "Release train guard OK: no base ref provided, head=0.19.10 latest_tag_ref=v0.19.10-505 latest_tag_version=0.19.10"))
 
 let test_pending_bootstrap_series_warns_without_blocking_same_version () =
@@ -207,7 +198,7 @@ let test_pending_bootstrap_series_warns_without_blocking_same_version () =
       if code <> 0 then
         failf "guard failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       check bool "warns for pending tag" true
-        (contains_substring stdout
+        (String_util.contains_substring stdout
            "Release train guard OK (warn): base=0.2.0 head=0.2.0 latest_tag_ref=v0.1.1 latest_tag_version=0.1.1 (pending release)"))
 
 let test_pending_bootstrap_series_blocks_next_train_until_tagged () =
@@ -226,7 +217,7 @@ let test_pending_bootstrap_series_blocks_next_train_until_tagged () =
       in
       check bool "command fails" true (code <> 0);
       check bool "requires pending tag first" true
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "publish/tag v0.2.0 before widening the release train"))
 
 let () =

--- a/test/test_repo_git.ml
+++ b/test/test_repo_git.ml
@@ -79,18 +79,6 @@ let init_local_repo path =
   in
   ()
 
-let contains_substring s sub =
-  let sub_len = String.length sub in
-  sub_len = 0
-  ||
-  let s_len = String.length s in
-  let rec aux i =
-    if i + sub_len > s_len then false
-    else if String.sub s i sub_len = sub then true
-    else aux (i + 1)
-  in
-  aux 0
-
 let sample_repo ~url local_path =
   {
     id = "test-repo";
@@ -172,7 +160,7 @@ let test_get_recent_commits () =
               Alcotest.(check bool) "at least 1 commit" true
                 (List.length commits >= 1);
               Alcotest.(check bool) "contains initial" true
-                (List.exists (fun s -> contains_substring s "initial") commits)))
+                (List.exists (fun s -> String_util.contains_substring s "initial") commits)))
 
 let test_status_summary_counts_porcelain_rows () =
   with_temp_dir (fun tmp ->
@@ -230,10 +218,10 @@ let test_status_summary_uses_read_only_git_conventions () =
               let joined = String.concat "\n" (List.rev !captured) in
               Alcotest.(check bool)
                 "uses --no-optional-locks" true
-                (contains_substring joined "--no-optional-locks");
+                (String_util.contains_substring joined "--no-optional-locks");
 	              Alcotest.(check bool)
 	                "sets GIT_OPTIONAL_LOCKS env key" true
-	                (contains_substring joined "\"GIT_OPTIONAL_LOCKS\"")))
+	                (String_util.contains_substring joined "\"GIT_OPTIONAL_LOCKS\"")))
 
 let test_origin_head_branch_preserves_slash_branch () =
   with_temp_dir (fun tmp ->

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -2,16 +2,6 @@
 
 open Repo_manager_types
 
-let contains_substring s needle =
-  let s_len = String.length s in
-  let n_len = String.length needle in
-  let rec loop i =
-    if i + n_len > s_len then false
-    else if String.sub s i n_len = needle then true
-    else loop (i + 1)
-  in
-  if n_len = 0 then true else loop 0
-
 let is_symlink path =
   try (Unix.lstat path).st_kind = Unix.S_LNK
   with Unix.Unix_error _ | Sys_error _ -> false
@@ -140,7 +130,7 @@ let test_add_duplicate_fails () =
           | Ok _ -> Alcotest.fail "expected error for duplicate"
           | Error msg ->
               Alcotest.(check bool) "mentions already exists" true
-              (contains_substring msg "already exists")))
+              (String_util.contains_substring msg "already exists")))
 
 let test_add_rejects_blank_local_path () =
   with_temp_base_path (fun base_path ->
@@ -149,7 +139,7 @@ let test_add_rejects_blank_local_path () =
       | Ok _ -> Alcotest.fail "blank local_path must be rejected"
       | Error error ->
         Alcotest.(check bool) "names local_path" true
-          (contains_substring error "local_path"))
+          (String_util.contains_substring error "local_path"))
 
 let test_find_existing () =
   with_temp_base_path (fun base_path ->
@@ -166,7 +156,7 @@ let test_find_missing () =
       match Repo_store.find ~base_path "missing" with
       | Ok _ -> Alcotest.fail "expected error for missing repo"
       | Error msg ->
-          Alcotest.(check bool) "mentions not found" true (contains_substring msg "not found"))
+          Alcotest.(check bool) "mentions not found" true (String_util.contains_substring msg "not found"))
 
 let test_remove_existing () =
   with_temp_base_path (fun base_path ->
@@ -187,7 +177,7 @@ let test_remove_missing () =
       match Repo_store.remove ~base_path "missing" with
       | Ok _ -> Alcotest.fail "expected error for missing repo"
       | Error msg ->
-          Alcotest.(check bool) "mentions not found" true (contains_substring msg "not found"))
+          Alcotest.(check bool) "mentions not found" true (String_util.contains_substring msg "not found"))
 
 let test_update_status_existing () =
   with_temp_base_path (fun base_path ->
@@ -210,7 +200,7 @@ let test_update_status_missing () =
       match Repo_store.update_status ~base_path "missing" Paused with
       | Ok _ -> Alcotest.fail "expected error for missing repo"
       | Error msg ->
-          Alcotest.(check bool) "mentions not found" true (contains_substring msg "not found"))
+          Alcotest.(check bool) "mentions not found" true (String_util.contains_substring msg "not found"))
 
 let test_update_existing () =
   with_temp_base_path (fun base_path ->
@@ -231,7 +221,7 @@ let test_update_missing () =
       match Repo_store.update ~base_path "missing" (sample_repo "missing") with
       | Ok _ -> Alcotest.fail "expected error for missing repo"
       | Error msg ->
-          Alcotest.(check bool) "mentions not found" true (contains_substring msg "not found"))
+          Alcotest.(check bool) "mentions not found" true (String_util.contains_substring msg "not found"))
 
 let test_update_rejects_blank_local_path () =
   with_temp_base_path (fun base_path ->
@@ -244,7 +234,7 @@ let test_update_rejects_blank_local_path () =
         | Ok _ -> Alcotest.fail "blank local_path must be rejected"
         | Error error ->
           Alcotest.(check bool) "names local_path" true
-            (contains_substring error "local_path"))
+            (String_util.contains_substring error "local_path"))
 
 let test_local_path_absolute_preserved () =
   let repo = { (sample_repo "abs") with local_path = "/absolute/path" } in
@@ -286,7 +276,7 @@ let test_load_rejects_incomplete_repository () =
       | Ok _ -> Alcotest.fail "incomplete repository row must be rejected"
       | Error error ->
           Alcotest.(check bool) "names first missing field" true
-            (contains_substring error "repository.demo.local_path"))
+            (String_util.contains_substring error "repository.demo.local_path"))
 
 let test_load_rejects_missing_repository_table () =
   with_temp_base_path (fun base_path ->
@@ -296,7 +286,7 @@ let test_load_rejects_missing_repository_table () =
       | Ok _ -> Alcotest.fail "catalog without repository table must be rejected"
       | Error error ->
           Alcotest.(check bool) "names required table" true
-            (contains_substring error "required repository table"))
+            (String_util.contains_substring error "required repository table"))
 
 let test_load_rejects_unknown_top_level_field () =
   with_temp_base_path (fun base_path ->
@@ -306,7 +296,7 @@ let test_load_rejects_unknown_top_level_field () =
       | Ok _ -> Alcotest.fail "unknown top-level field must be rejected"
       | Error error ->
         Alcotest.(check bool) "names unknown top-level field" true
-          (contains_substring error "unknown top-level field answer"))
+          (String_util.contains_substring error "unknown top-level field answer"))
 
 let test_load_rejects_noncanonical_status () =
   with_temp_base_path (fun base_path ->
@@ -328,7 +318,7 @@ let test_load_rejects_noncanonical_status () =
       | Ok _ -> Alcotest.fail "noncanonical status must be rejected"
       | Error error ->
           Alcotest.(check bool) "names rejected status" true
-            (contains_substring error "Unknown repository status: active"))
+            (String_util.contains_substring error "Unknown repository status: active"))
 
 let test_load_rejects_unknown_field () =
   with_temp_base_path (fun base_path ->
@@ -351,7 +341,7 @@ let test_load_rejects_unknown_field () =
       | Ok _ -> Alcotest.fail "unknown repository field must be rejected"
       | Error error ->
           Alcotest.(check bool) "names unknown field" true
-            (contains_substring error "repository.demo.retired_path"))
+            (String_util.contains_substring error "repository.demo.retired_path"))
 
 let test_load_rejects_wrong_field_type () =
   with_temp_base_path (fun base_path ->
@@ -361,7 +351,7 @@ let test_load_rejects_wrong_field_type () =
       | Ok _ -> Alcotest.fail "wrong field type must be rejected"
       | Error error ->
         Alcotest.(check bool) "names wrong field" true
-          (contains_substring error "repository.demo.aliases"))
+          (String_util.contains_substring error "repository.demo.aliases"))
 
 let test_error_status_requires_message () =
   with_temp_base_path (fun base_path ->
@@ -371,7 +361,7 @@ let test_error_status_requires_message () =
       | Ok _ -> Alcotest.fail "Error status without status_error must be rejected"
       | Error error ->
         Alcotest.(check bool) "names required status_error" true
-          (contains_substring error "repository.demo.status_error"))
+          (String_util.contains_substring error "repository.demo.status_error"))
 
 let run_git_quiet args =
   let devnull = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
@@ -727,7 +717,7 @@ let test_lookup_preserves_catalog_error () =
       match Repo_store.find_url_by_id ~base_path "masc" with
       | Error error ->
         Alcotest.(check bool) "catalog error preserved" true
-          (contains_substring error "repository must be a table")
+          (String_util.contains_substring error "repository must be a table")
       | Ok _ -> Alcotest.fail "catalog error must not become a missing lookup")
 
 let () =

--- a/test/test_run_local_script.ml
+++ b/test/test_run_local_script.ml
@@ -16,15 +16,6 @@ let build_dashboard_if_needed_script_path () =
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
@@ -181,17 +172,17 @@ let test_bootstraps_local_config_and_sets_http_only_env () =
         (Sys.file_exists
            (Filename.concat target_abs ".masc/config/keepers/sangsu.toml"));
       check bool "base path set" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ target_abs));
+        (String_util.contains_substring captured ("MASC_BASE_PATH=" ^ target_abs));
       check bool "config dir set" true
-        (contains_substring captured ("MASC_CONFIG_DIR=" ^ Filename.concat target_abs ".masc/config"));
+        (String_util.contains_substring captured ("MASC_CONFIG_DIR=" ^ Filename.concat target_abs ".masc/config"));
       check bool "grpc disabled by default" true
-        (contains_substring captured "MASC_GRPC_ENABLED=0");
+        (String_util.contains_substring captured "MASC_GRPC_ENABLED=0");
       check bool "ws disabled by default" true
-        (contains_substring captured "MASC_WS_ENABLED=0");
+        (String_util.contains_substring captured "MASC_WS_ENABLED=0");
       check bool "webrtc disabled by default" true
-        (contains_substring captured "MASC_WEBRTC_ENABLED=0");
+        (String_util.contains_substring captured "MASC_WEBRTC_ENABLED=0");
       check bool "port passed through" true
-        (contains_substring captured "ARGS=--host=127.0.0.1 --port=9955"))
+        (String_util.contains_substring captured "ARGS=--host=127.0.0.1 --port=9955"))
 
 let test_bootstrap_keepers_flag_is_opt_in () =
   with_temp_dir "run-local-script" (fun dir ->
@@ -220,7 +211,7 @@ let test_bootstrap_keepers_flag_is_opt_in () =
       check bool "bootstrapped keeper copied with flag" true
         (Sys.file_exists (Filename.concat target ".masc/config/keepers/sangsu.toml"));
       check bool "keepers included message" true
-        (contains_substring stderr "keepers included"))
+        (String_util.contains_substring stderr "keepers included"))
 
 let test_print_port_is_stable_for_target_dir () =
   with_temp_dir "run-local-script" (fun dir ->
@@ -325,9 +316,9 @@ esac
         failf "dashboard build helper failed (%d)\nstdout:\n%s\nstderr:\n%s"
           code stdout stderr;
       check bool "stale generated index forced rebuild" true
-        (contains_substring (read_file pnpm_capture) "run build");
+        (String_util.contains_substring (read_file pnpm_capture) "run build");
       check bool "stale reason was explicit" true
-        (contains_substring stderr "remote startup resources"))
+        (String_util.contains_substring stderr "remote startup resources"))
 
 let test_existing_target_config_is_not_overwritten () =
   with_temp_dir "run-local-script" (fun dir ->
@@ -372,7 +363,7 @@ let test_explicit_config_env_is_preserved_without_bootstrap () =
           code stdout stderr;
       let captured = read_file capture in
       check bool "explicit config dir preserved" true
-        (contains_substring captured ("MASC_CONFIG_DIR=" ^ override_root));
+        (String_util.contains_substring captured ("MASC_CONFIG_DIR=" ^ override_root));
       check bool "target config not bootstrapped" false
         (Sys.file_exists (Filename.concat target ".masc/config/runtime.toml")))
 
@@ -406,7 +397,7 @@ let test_bootstrap_only_materializes_state_without_exec () =
         (Sys.file_exists (Filename.concat target ".masc/config/runtime.json"));
       check bool "fake exe not invoked" false (Sys.file_exists capture);
       check bool "bootstrap ready message" true
-        (contains_substring stderr "[local-run] Bootstrap ready"))
+        (String_util.contains_substring stderr "[local-run] Bootstrap ready"))
 
 let () =
   run "run_local_script"

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -77,15 +77,6 @@ let has_prefix ~prefix value =
   String.length value >= prefix_len
   && String.equal prefix (String.sub value 0 prefix_len)
 
-let contains_substring ~needle value =
-  let needle_len = String.length needle in
-  let value_len = String.length value in
-  let rec loop i =
-    i + needle_len <= value_len
-    && (String.equal needle (String.sub value i needle_len) || loop (i + 1))
-  in
-  String.equal needle "" || loop 0
-
 let test_parse_json_safe_rate_limits_repeated_utf8_repair_logs () =
   let open Safe_ops in
   reset_persistence_utf8_repair_stats_for_tests ();
@@ -374,7 +365,7 @@ let test_get_env_bool_logged_invalid_redacts_value () =
   let logs =
     Log.Ring.recent ~limit:20 ~module_filter:"Misc" ~since_seq:baseline ()
     |> List.filter (fun (entry : Log.Ring.entry) ->
-      contains_substring ~needle:"MASC_TEST_BOOL_SECRET_VAR" entry.message)
+      String_util.string_contains_substring ~needle:"MASC_TEST_BOOL_SECRET_VAR" entry.message)
   in
   check int "invalid bool warning emitted" 1 (List.length logs);
   let message =
@@ -383,9 +374,9 @@ let test_get_env_bool_logged_invalid_redacts_value () =
     | _ -> fail "expected exactly one invalid bool warning"
   in
   check bool "raw value is redacted" false
-    (contains_substring ~needle:"secret-token-value" message);
+    (String_util.string_contains_substring ~needle:"secret-token-value" message);
   check bool "redaction is explicit" true
-    (contains_substring ~needle:"value redacted" message)
+    (String_util.string_contains_substring ~needle:"value redacted" message)
 
 
 (* json_int_opt *)

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -89,21 +89,6 @@ let local_runtime_toml = "# local runtime seed\n"
 let repo_model_catalog_overlay_toml =
   "[[models]]\nid_prefix = \"repo-runtime\"\nprovider_name = \"repo-provider\"\n"
 
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    if needle_len = 0 then
-      true
-    else if idx + needle_len > haystack_len then
-      false
-    else if String.sub haystack idx needle_len = needle then
-      true
-    else
-      loop (idx + 1)
-  in
-  loop 0
-
 let test_grpc_tool_arguments_fail_closed_before_dispatch () =
   let dispatch_calls = ref 0 in
   let dispatch _arguments =
@@ -315,7 +300,7 @@ let test_model_catalog_overlay_invalid_fails_loud () =
       Alcotest.(check bool)
         "error names overlay path"
         true
-        (contains_substring message "agent-core-models-overlay.toml");
+        (String_util.contains_substring message "agent-core-models-overlay.toml");
       Alcotest.(check int) "no install" 0 !set_overlay_calls)
 
 let test_explicit_model_catalog_replacement_precedes_overlay () =
@@ -2423,7 +2408,7 @@ let test_health_json_degrades_recovery_backed_owner_scan () =
            |> List.hd
            |> member "error"
            |> to_string
-           |> fun error -> contains_substring error "observing recovery snapshot")))
+           |> fun error -> String_util.contains_substring error "observing recovery snapshot")))
 
 let test_health_json_reuses_canonical_owner_execution_snapshot () =
   with_temp_dir "health-canonical-owner-execution-snapshot" (fun dir ->
@@ -3186,26 +3171,26 @@ let test_health_json_exposes_dead_keeper_registry_cause () =
             detail |> member "last_failure_reason" |> to_string
           in
           Alcotest.(check bool) "health preserves failure reason class" true
-            (contains_substring last_failure_reason "provider_runtime_error");
+            (String_util.contains_substring last_failure_reason "provider_runtime_error");
           Alcotest.(check bool) "health redacts failure reason token" false
-            (contains_substring last_failure_reason "sk-testsecret");
+            (String_util.contains_substring last_failure_reason "sk-testsecret");
           Alcotest.(check bool) "health redacts failure reason base path" false
-            (contains_substring last_failure_reason config.Workspace.base_path);
+            (String_util.contains_substring last_failure_reason config.Workspace.base_path);
           Alcotest.(check bool) "health marks redacted failure reason" true
-            (contains_substring last_failure_reason "[REDACTED]");
+            (String_util.contains_substring last_failure_reason "[REDACTED]");
           Alcotest.(check bool) "health marks redacted failure reason path" true
-            (contains_substring last_failure_reason "[REDACTED_PATH]");
+            (String_util.contains_substring last_failure_reason "[REDACTED_PATH]");
           let last_error = detail |> member "last_error" |> to_string in
           Alcotest.(check bool) "health preserves last error class" true
-            (contains_substring last_error "synthetic cancelled by parent");
+            (String_util.contains_substring last_error "synthetic cancelled by parent");
           Alcotest.(check bool) "health redacts last error token" false
-            (contains_substring last_error "sk-testsecret");
+            (String_util.contains_substring last_error "sk-testsecret");
           Alcotest.(check bool) "health redacts last error base path" false
-            (contains_substring last_error config.Workspace.base_path);
+            (String_util.contains_substring last_error config.Workspace.base_path);
           Alcotest.(check bool) "health marks redacted last error" true
-            (contains_substring last_error "[REDACTED]");
+            (String_util.contains_substring last_error "[REDACTED]");
           Alcotest.(check bool) "health marks redacted last error path" true
-            (contains_substring last_error "[REDACTED_PATH]");
+            (String_util.contains_substring last_error "[REDACTED_PATH]");
           Alcotest.(check int) "health surfaces registry restart count" 2
             (detail |> member "restart_count" |> to_int);
           Alcotest.(check (option (float 0.0001)))
@@ -3218,15 +3203,15 @@ let test_health_json_exposes_dead_keeper_registry_cause () =
             detail |> member "latest_crash_reason" |> to_string
           in
           Alcotest.(check bool) "health preserves crash reason class" true
-            (contains_substring latest_crash_reason "synthetic crash record");
+            (String_util.contains_substring latest_crash_reason "synthetic crash record");
           Alcotest.(check bool) "health redacts crash reason token" false
-            (contains_substring latest_crash_reason "github_pat_secret");
+            (String_util.contains_substring latest_crash_reason "github_pat_secret");
           Alcotest.(check bool) "health redacts crash reason base path" false
-            (contains_substring latest_crash_reason config.Workspace.base_path);
+            (String_util.contains_substring latest_crash_reason config.Workspace.base_path);
           Alcotest.(check bool) "health marks redacted crash reason" true
-            (contains_substring latest_crash_reason "[REDACTED]");
+            (String_util.contains_substring latest_crash_reason "[REDACTED]");
           Alcotest.(check bool) "health marks redacted crash reason path" true
-            (contains_substring latest_crash_reason "[REDACTED_PATH]"))))
+            (String_util.contains_substring latest_crash_reason "[REDACTED_PATH]"))))
 
 let test_health_json_explains_terminal_capacity_blocker
     ~dir_name
@@ -3493,15 +3478,15 @@ let test_health_json_redacts_registry_failure_reason () =
           | Some row ->
               let reason = row |> member "last_failure_reason" |> to_string in
               Alcotest.(check bool) "redacts bearer token" false
-                (contains_substring reason "ghp_healthsecret");
+                (String_util.contains_substring reason "ghp_healthsecret");
               Alcotest.(check bool) "redacts exact keeper secret" false
-                (contains_substring reason keeper_secret);
+                (String_util.contains_substring reason keeper_secret);
               Alcotest.(check bool) "redacts workspace base path" false
-                (contains_substring reason base_path);
+                (String_util.contains_substring reason base_path);
               Alcotest.(check bool) "retains explicit redaction marker" true
-                (contains_substring reason "[REDACTED]");
+                (String_util.contains_substring reason "[REDACTED]");
               Alcotest.(check bool) "retains workspace path redaction marker" true
-                (contains_substring reason "[REDACTED_PATH]"))))
+                (String_util.contains_substring reason "[REDACTED_PATH]"))))
 
 let test_health_json_uses_crash_log_when_restore_clears_failure_reason () =
   with_temp_dir "health-restored-crash-log-keeper" (fun dir ->
@@ -3699,7 +3684,7 @@ let test_health_json_surfaces_internal_mcp_auth_diagnostics () =
   Alcotest.(check string) "ready operator next action" "none"
     (ready |> member "operator_next_action" |> to_string);
   Alcotest.(check bool) "raw token not exposed" false
-    (contains_substring (Yojson.Safe.to_string ready) raw_token);
+    (String_util.contains_substring (Yojson.Safe.to_string ready) raw_token);
   let hash_file = Auth.internal_keeper_token_hash_file dir in
   write_file hash_file " \n";
   let empty_hash =
@@ -4849,9 +4834,9 @@ let test_main_eio_rejects_same_base_path_on_second_server () =
               (read_file secondary_log);
           let secondary_text = read_file secondary_log in
           Alcotest.(check bool) "secondary log mentions base-path owner" true
-            (contains_substring secondary_text "already owns base path");
+            (String_util.contains_substring secondary_text "already owns base path");
           Alcotest.(check bool) "secondary log mentions primary pid" true
-            (contains_substring secondary_text (string_of_int primary_pid));
+            (String_util.contains_substring secondary_text (string_of_int primary_pid));
           Alcotest.(check bool) "primary server stays healthy" true
             (wait_for_health ~pid:primary_pid ~port:primary_port ~timeout_s:1.0)))
 
@@ -5079,7 +5064,7 @@ let test_main_eio_invalid_default_partial_catalog_stays_degraded () =
           Alcotest.(check bool) "last error includes default-profile failure" true
             (List.exists
                (fun error ->
-                  contains_substring error "required default profile")
+                  String_util.contains_substring error "required default profile")
                rejection_errors)))
 
 let test_transition_projection_cursor_commits_before_isolated_owner_recovery () =

--- a/test/test_session_coverage.ml
+++ b/test/test_session_coverage.ml
@@ -302,14 +302,6 @@ let test_status_string_empty () =
    Notification queue overflow logging
    ============================================================ *)
 
-let contains_substring s sub =
-  let len = String.length sub in
-  let rec scan i =
-    if i + len > String.length s then false
-    else if String.sub s i len = sub then true
-    else scan (i + 1)
-  in
-  scan 0
 ;;
 
 let test_message_queue_overflow_is_logged () =
@@ -352,8 +344,8 @@ let test_message_queue_overflow_is_logged () =
   let found =
     List.exists
       (fun (entry : Log.Ring.entry) ->
-         contains_substring entry.Log.Ring.message "Dropped oldest notification"
-         && contains_substring entry.Log.Ring.message "drop-test")
+         String_util.contains_substring entry.Log.Ring.message "Dropped oldest notification"
+         && String_util.contains_substring entry.Log.Ring.message "drop-test")
       entries
   in
   check bool "overflow produced a structured warning" true found

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -62,13 +62,6 @@ let attempt_next_retry_at (record : Routes.attempt_record) =
   Option.map Masc_domain.iso8601_of_unix_seconds record.Routes.attempt.next_retry_unix
 ;;
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
 ;;
 
 let rec mkdir_p path =
@@ -275,12 +268,12 @@ let test_runtime_base_path_result_fails_without_base_path () =
   match Routes.runtime_sidecar_dir_result "discord" with
   | Ok dir -> failf "expected missing base path error, got %s" dir
   | Error msg ->
-    check bool "mentions request base path" true (contains_substring msg "base_path");
+    check bool "mentions request base path" true (String_util.contains_substring msg "base_path");
     check
       bool
       "mentions env base path"
       true
-      (contains_substring msg Env_config_core.base_path_env_key)
+      (String_util.contains_substring msg Env_config_core.base_path_env_key)
 ;;
 
 let test_missing_sidecar_dir_message_mentions_sidecar_root_hint () =
@@ -294,22 +287,22 @@ let test_missing_sidecar_dir_message_mentions_sidecar_root_hint () =
     bool
     "mentions explicit env hint"
     true
-    (contains_substring message "MASC_SIDECAR_ROOT=/path/to/masc");
+    (String_util.contains_substring message "MASC_SIDECAR_ROOT=/path/to/masc");
   check
     bool
     "mentions launcher flag hint"
     true
-    (contains_substring message "--sidecar-root /path/to/masc");
+    (String_util.contains_substring message "--sidecar-root /path/to/masc");
   check
     bool
     "includes searched runtime path"
     true
-    (contains_substring message "/tmp/runtime-root/sidecars/discord-bot");
+    (String_util.contains_substring message "/tmp/runtime-root/sidecars/discord-bot");
   check
     bool
     "includes searched project path"
     true
-    (contains_substring message "/tmp/project-root/sidecars/discord-bot")
+    (String_util.contains_substring message "/tmp/project-root/sidecars/discord-bot")
 ;;
 
 let test_runtime_base_path_uses_resolver_precedence () =
@@ -986,8 +979,8 @@ let test_read_attempt_record_result_reports_semantic_corruption () =
       {|{"connector_id":"discord","generation":1,"attempt_id":"1:1","attempt_number":1,"last_attempt_result":"start_dispatched","next_retry_at":"not-an-iso-stamp","operator_next_action":"none","updated_at":"2026-01-01T00:00:00Z"}|};
     match Routes.read_attempt_record_result ~base_path "discord" with
     | Error msg ->
-      check bool "mentions field" true (contains_substring msg "next_retry_at");
-      check bool "mentions bad value" true (contains_substring msg "not-an-iso-stamp")
+      check bool "mentions field" true (String_util.contains_substring msg "next_retry_at");
+      check bool "mentions bad value" true (String_util.contains_substring msg "not-an-iso-stamp")
     | Ok None -> failf "corrupt persisted attempt state must not look absent"
     | Ok (Some _) -> failf "corrupt persisted attempt state should not decode")
 ;;
@@ -1006,8 +999,8 @@ let test_status_json_surfaces_invalid_attempt_state () =
       | `String msg -> msg
       | other -> failf "expected attempt_read_error string, got %s" (Yojson.Safe.to_string other)
     in
-    check bool "mentions field" true (contains_substring error "next_retry_at");
-    check bool "mentions bad value" true (contains_substring error "not-an-iso-stamp"))
+    check bool "mentions field" true (String_util.contains_substring error "next_retry_at");
+    check bool "mentions bad value" true (String_util.contains_substring error "not-an-iso-stamp"))
 ;;
 
 let test_retry_backoff_fail_closed_on_malformed_now () =
@@ -1101,7 +1094,7 @@ let test_fetch_schema_error_on_nonzero_exit () =
         bool
         "error mentions schema_dump failure"
         true
-        (contains_substring msg "schema_dump failed"))
+        (String_util.contains_substring msg "schema_dump failed"))
 ;;
 
 let () =

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -19,15 +19,6 @@ let read_file path =
 let canonical_path path =
   try Unix.realpath path with _ -> path
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
@@ -345,12 +336,12 @@ let test_explicit_env_overrides_repo_env_files () =
           stderr;
       let captured = read_file capture in
       check bool "explicit env wins over env file" true
-        (contains_substring captured "MASC_WS_ENABLED=1");
+        (String_util.contains_substring captured "MASC_WS_ENABLED=1");
       check bool "base path passed through" true
-        (contains_substring captured
+        (String_util.contains_substring captured
            ("MASC_BASE_PATH=" ^ canonical_path dir));
       check bool "explicit config dir preserved" true
-        (contains_substring captured ("MASC_CONFIG_DIR=" ^ Filename.concat dir "config")))
+        (String_util.contains_substring captured ("MASC_CONFIG_DIR=" ^ Filename.concat dir "config")))
 
 let test_realtime_transports_default_to_base_path_config_and_preserve_override ()
     =
@@ -382,11 +373,11 @@ let test_realtime_transports_default_to_base_path_config_and_preserve_override (
           code_default stdout_default stderr_default;
       let captured_default = read_file capture_default in
       check bool "ws enabled by default" true
-        (contains_substring captured_default "MASC_WS_ENABLED=1");
+        (String_util.contains_substring captured_default "MASC_WS_ENABLED=1");
       check bool "webrtc enabled by default" true
-        (contains_substring captured_default "MASC_WEBRTC_ENABLED=1");
+        (String_util.contains_substring captured_default "MASC_WEBRTC_ENABLED=1");
       check bool "config dir defaults to base path config" true
-        (contains_substring captured_default
+        (String_util.contains_substring captured_default
            ("MASC_CONFIG_DIR=" ^ bootstrapped_config));
       check bool "base path config bootstrapped" true
         (Sys.file_exists (Filename.concat bootstrapped_config "runtime.toml"));
@@ -408,12 +399,12 @@ let test_realtime_transports_default_to_base_path_config_and_preserve_override (
           code_override stdout_override stderr_override;
       let captured_override = read_file capture_override in
       check bool "config dir override preserved" true
-        (contains_substring captured_override
+        (String_util.contains_substring captured_override
            ("MASC_CONFIG_DIR=" ^ Filename.concat dir "custom-config"));
       check bool "ws override preserved" true
-        (contains_substring captured_override "MASC_WS_ENABLED=0");
+        (String_util.contains_substring captured_override "MASC_WS_ENABLED=0");
       check bool "webrtc override preserved" true
-        (contains_substring captured_override "MASC_WEBRTC_ENABLED=0"))
+        (String_util.contains_substring captured_override "MASC_WEBRTC_ENABLED=0"))
 
 let test_bootstraps_base_path_config_from_repo_when_unset () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -441,7 +432,7 @@ let test_bootstraps_base_path_config_from_repo_when_unset () =
           code stdout stderr;
       let captured = read_file capture in
       check bool "defaults to base path config" true
-        (contains_substring captured
+        (String_util.contains_substring captured
            ("MASC_CONFIG_DIR=" ^ bootstrapped_config));
       check bool "repo config copied to base path config" true
         (Sys.file_exists (Filename.concat bootstrapped_config "runtime.toml")))
@@ -471,9 +462,9 @@ let test_default_base_path_requires_explicit_base_path () =
       check bool "does not invoke server executable" false
         (Sys.file_exists capture);
       check bool "stderr names required base path" true
-        (contains_substring stderr "MASC base path is required");
+        (String_util.contains_substring stderr "MASC base path is required");
       check bool "stderr rejects HOME inference" true
-        (contains_substring stderr "Refusing to infer a runtime root from HOME");
+        (String_util.contains_substring stderr "Refusing to infer a runtime root from HOME");
       ignore stdout)
 
 let test_absolute_env_base_path_is_preserved () =
@@ -503,7 +494,7 @@ let test_absolute_env_base_path_is_preserved () =
       let captured = read_file capture in
       let expected_root = canonical_path stale_root in
       check bool "absolute env base path preserved" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
+        (String_util.contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_absolute_parent_project_base_path_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -534,7 +525,7 @@ let test_absolute_parent_project_base_path_is_preserved () =
       let captured = read_file capture in
       let expected_root = canonical_path parent in
       check bool "absolute parent root inheritance preserved" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
+        (String_util.contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_cli_sidecar_root_is_exported () =
   with_temp_dir "start-masc-script-sidecar-root" (fun dir ->
@@ -568,7 +559,7 @@ let test_cli_sidecar_root_is_exported () =
           stderr;
       let captured = read_file capture in
       check bool "sidecar root exported to server env" true
-        (contains_substring captured
+        (String_util.contains_substring captured
            ("MASC_SIDECAR_ROOT=" ^ canonical_path sidecar_root)))
 
 let test_zshenv_base_path_is_ignored () =
@@ -597,7 +588,7 @@ let test_zshenv_base_path_is_ignored () =
       in
       check int "missing explicit base path fails closed" 2 code;
       check bool "zshenv is not a runtime-root source" true
-        (contains_substring stderr "MASC base path is required");
+        (String_util.contains_substring stderr "MASC base path is required");
       check bool "server was not started" false (Sys.file_exists capture);
       ignore stdout)
 
@@ -628,7 +619,7 @@ let test_shared_root_env_base_path_is_preserved () =
       let captured = read_file capture in
       let expected_root = canonical_path inherited_root in
       check bool "shared-root env base path preserved" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
+        (String_util.contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_worktree_prefers_local_build_over_workspace_build () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -660,7 +651,7 @@ let test_worktree_prefers_local_build_over_workspace_build () =
           stderr;
       let captured = read_file capture in
       check bool "local build wins in worktree" true
-        (contains_substring captured "FAKE_EXE_MARKER=local"))
+        (String_util.contains_substring captured "FAKE_EXE_MARKER=local"))
 
 let test_explicit_base_path_execs_from_base_path () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -691,7 +682,7 @@ let test_explicit_base_path_execs_from_base_path () =
       let captured = read_file capture in
       let expected_root = canonical_path parent in
       check bool "exec cwd matches explicit base path" true
-        (contains_substring captured ("PWD=" ^ expected_root)))
+        (String_util.contains_substring captured ("PWD=" ^ expected_root)))
 
 let test_explicit_base_path_does_not_load_config_from_zshenv () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -724,10 +715,10 @@ let test_explicit_base_path_does_not_load_config_from_zshenv () =
       let captured = read_file capture in
       let expected_parent = canonical_path parent in
       check bool "explicit base path resets config root to base path" true
-        (contains_substring captured
+        (String_util.contains_substring captured
            ("MASC_CONFIG_DIR=" ^ Filename.concat expected_parent ".masc/config"));
       check bool "zshenv config was not imported" false
-        (contains_substring captured ("MASC_CONFIG_DIR=" ^ Filename.concat repo "config"));
+        (String_util.contains_substring captured ("MASC_CONFIG_DIR=" ^ Filename.concat repo "config"));
       ignore stderr)
 
 let test_explicit_base_path_ignores_repo_local_config_from_parent_env () =
@@ -756,10 +747,10 @@ let test_explicit_base_path_ignores_repo_local_config_from_parent_env () =
       let expected_parent = canonical_path parent in
       check bool "parent env repo-local config ignored under external base path"
         true
-        (contains_substring captured
+        (String_util.contains_substring captured
            ("MASC_CONFIG_DIR=" ^ Filename.concat expected_parent ".masc/config"));
       check bool "parent env repo-local config ignore is logged" true
-        (contains_substring stderr "Ignoring repo-local MASC_CONFIG_DIR"))
+        (String_util.contains_substring stderr "Ignoring repo-local MASC_CONFIG_DIR"))
 
 let test_explicit_http_port_derives_sidecar_ports () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -781,9 +772,9 @@ let test_explicit_http_port_derives_sidecar_ports () =
           stderr;
       let captured = read_file capture in
       check bool "grpc port derived from explicit http port" true
-        (contains_substring captured "MASC_GRPC_PORT=9952");
+        (String_util.contains_substring captured "MASC_GRPC_PORT=9952");
       check bool "ws port derived from explicit http port" true
-        (contains_substring captured "MASC_WS_PORT=9953"))
+        (String_util.contains_substring captured "MASC_WS_PORT=9953"))
 
 let test_grpc_direct_banner_is_preserved_in_stderr () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -802,11 +793,11 @@ let test_grpc_direct_banner_is_preserved_in_stderr () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       check bool "grpc-direct tls banner preserved" true
-        (contains_substring stderr "Running without TLS (plaintext h2c)");
+        (String_util.contains_substring stderr "Running without TLS (plaintext h2c)");
       check bool "grpc-direct server banner preserved" true
-        (contains_substring stderr "gRPC server on 127.0.0.1:9952");
+        (String_util.contains_substring stderr "gRPC server on 127.0.0.1:9952");
       check bool "other stderr preserved" true
-        (contains_substring stderr "stderr-keep"))
+        (String_util.contains_substring stderr "stderr-keep"))
 
 let test_stale_dune_artifacts_are_cleaned_and_retried () =
   with_temp_dir "start-masc-script-stale-dune" (fun dir ->
@@ -845,27 +836,27 @@ let test_stale_dune_artifacts_are_cleaned_and_retried () =
               code stdout stderr;
           let captured = read_file capture in
           check bool "server started from retry-built executable" true
-            (contains_substring captured
+            (String_util.contains_substring captured
                "FAKE_EXE_MARKER=eio-after-stale-retry");
           check bool "dune clean ran before retry" true
             (Sys.file_exists clean_marker);
           let dune_local_calls = read_file dune_local_log in
           check bool "startup build uses dune-local wrapper" true
-            (contains_substring dune_local_calls
+            (String_util.contains_substring dune_local_calls
                "dune-local build bin/main_eio.exe");
           check bool "startup forwards DUNE_JOBS into wrapper under CI" true
-            (contains_substring dune_local_calls
+            (String_util.contains_substring dune_local_calls
                "DUNE_JOBS=2");
           check bool "stale cleanup uses dune-local wrapper" true
-            (contains_substring dune_local_calls "dune-local clean");
+            (String_util.contains_substring dune_local_calls "dune-local clean");
           check bool "original stale artifact error preserved" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "make inconsistent assumptions over implementation Agent_core__Streaming");
           check bool "retry is explained" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "Stale Dune artifacts detected while building main_eio.exe");
           check bool "retry output preserved" true
-            (contains_substring stderr "fake dune build recovered")))
+            (String_util.contains_substring stderr "fake dune build recovered")))
 
 let test_dune_cache_temp_error_retries_with_cache_disabled () =
   with_temp_dir "start-masc-script-cache-temp-dune" (fun dir ->
@@ -904,25 +895,25 @@ let test_dune_cache_temp_error_retries_with_cache_disabled () =
               code stdout stderr;
           let captured = read_file capture in
           check bool "server started from cache-disabled retry executable" true
-            (contains_substring captured
+            (String_util.contains_substring captured
                "FAKE_EXE_MARKER=eio-after-cache-temp-retry");
           check bool "dune clean was not used for cache temp retry" false
             (Sys.file_exists clean_marker);
           let dune_local_calls = read_file dune_local_log in
           check bool "initial startup build used cache default" true
-            (contains_substring dune_local_calls
+            (String_util.contains_substring dune_local_calls
                "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_CACHE=");
           check bool "retry disabled Dune cache" true
-            (contains_substring dune_local_calls
+            (String_util.contains_substring dune_local_calls
                "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_CACHE=disabled");
           check bool "original cache temp error preserved" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "rmdir(/Users/test/.cache/dune/db/temp/dune_6eb519_artifacts): Directory not empty");
           check bool "cache retry is explained" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "Dune cache temp cleanup failed while building main_eio.exe");
           check bool "cache retry output preserved" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "fake dune build recovered with cache disabled")))
 
 let test_stale_executable_requires_build_lock () =
@@ -960,9 +951,9 @@ let test_stale_executable_requires_build_lock () =
           check bool "stale executable was not started" false
             (Sys.file_exists capture);
           check bool "lock holder is reported" true
-            (contains_substring stderr "Another MASC build in progress");
+            (String_util.contains_substring stderr "Another MASC build in progress");
           check bool "stale executable refusal is explicit" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "refusing to continue with a stale or missing executable")))
 
 let test_stdio_skips_dashboard_build_and_http_preflight () =
@@ -1007,11 +998,11 @@ exit 0
           stderr;
       let captured = read_file capture in
       check bool "stdio executable selected without HTTP build" true
-        (contains_substring captured "FAKE_EXE_MARKER=stdio");
+        (String_util.contains_substring captured "FAKE_EXE_MARKER=stdio");
       check bool "dashboard helper not invoked in stdio mode" false
         (Sys.file_exists dashboard_marker);
       check bool "stderr explains stdio dashboard skip" true
-        (contains_substring stderr "Skipping SPA build in stdio mode."))
+        (String_util.contains_substring stderr "Skipping SPA build in stdio mode."))
 
 let test_http_dashboard_build_failure_is_non_blocking_by_default () =
   with_temp_dir "start-masc-script-dashboard-nonblocking" (fun dir ->
@@ -1032,9 +1023,9 @@ let test_http_dashboard_build_failure_is_non_blocking_by_default () =
           stderr;
       let captured = read_file capture in
       check bool "HTTP server starts despite dashboard helper failure" true
-        (contains_substring captured "FAKE_EXE_MARKER=local");
+        (String_util.contains_substring captured "FAKE_EXE_MARKER=local");
       check bool "dashboard build is non-blocking by default" true
-        (contains_substring stderr "Background SPA build started"))
+        (String_util.contains_substring stderr "Background SPA build started"))
 
 let test_http_dashboard_build_blocking_mode_fails_closed () =
   with_temp_dir "start-masc-script-dashboard-blocking" (fun dir ->
@@ -1060,9 +1051,9 @@ let test_http_dashboard_build_blocking_mode_fails_closed () =
       check bool "HTTP server is not launched after blocking build failure" false
         (Sys.file_exists capture);
       check bool "blocking dashboard build is explicit in stderr" true
-        (contains_substring stderr "Building SPA before server start");
+        (String_util.contains_substring stderr "Building SPA before server start");
       check bool "helper failure is surfaced in blocking mode" true
-        (contains_substring stderr "dashboard build failed"))
+        (String_util.contains_substring stderr "dashboard build failed"))
 
 let test_http_preflight_waits_for_port_to_clear_before_build () =
   with_temp_dir "start-masc-script-port-wait" (fun dir ->
@@ -1107,9 +1098,9 @@ exit 1
           stderr;
       let captured = read_file capture in
       check bool "server started after transient port conflict" true
-        (contains_substring captured "FAKE_EXE_MARKER=local");
+        (String_util.contains_substring captured "FAKE_EXE_MARKER=local");
       check bool "preflight waited before build" true
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "HTTP Port 9954 in use, waiting before build/init"))
 
 let test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in ()
@@ -1142,7 +1133,7 @@ let test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in ()
           code_default stdout_default stderr_default;
       let captured_default = read_file capture_default in
       check bool "loopback disables keeper autoboot by default" true
-        (contains_substring captured_default "MASC_KEEPER_BOOTSTRAP_ENABLED=false");
+        (String_util.contains_substring captured_default "MASC_KEEPER_BOOTSTRAP_ENABLED=false");
       let capture_override =
         Filename.concat dir "captured-loopback-override.txt"
       in
@@ -1161,7 +1152,7 @@ let test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in ()
           code_override stdout_override stderr_override;
       let captured_override = read_file capture_override in
       check bool "loopback honors explicit keeper autoboot opt-in" true
-        (contains_substring captured_override "MASC_KEEPER_BOOTSTRAP_ENABLED=true"))
+        (String_util.contains_substring captured_override "MASC_KEEPER_BOOTSTRAP_ENABLED=true"))
 
 let () =
   run "start_masc_script"

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -27,15 +27,6 @@ let read_file path =
 let canonical_path path =
   try Unix.realpath path with _ -> path
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    idx + nlen <= hlen
-    && (String.sub haystack idx nlen = needle || loop (idx + 1))
-  in
-  nlen = 0 || loop 0
-
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
@@ -374,12 +365,12 @@ let test_explicit_env_overrides_repo_env_files () =
           stderr;
       let captured = read_file capture in
       check bool "explicit env wins over env file" true
-        (contains_substring captured "MASC_WS_ENABLED=1");
+        (String_util.contains_substring captured "MASC_WS_ENABLED=1");
       check bool "base path passed through" true
-        (contains_substring captured
+        (String_util.contains_substring captured
            ("MASC_BASE_PATH=" ^ canonical_path dir));
       check bool "explicit config dir preserved" true
-        (contains_substring captured ("MASC_CONFIG_DIR=" ^ Filename.concat dir "config")))
+        (String_util.contains_substring captured ("MASC_CONFIG_DIR=" ^ Filename.concat dir "config")))
 
 let test_realtime_transports_default_to_base_path_config_and_preserve_override ()
     =
@@ -411,11 +402,11 @@ let test_realtime_transports_default_to_base_path_config_and_preserve_override (
           code_default stdout_default stderr_default;
       let captured_default = read_file capture_default in
       check bool "ws enabled by default" true
-        (contains_substring captured_default "MASC_WS_ENABLED=1");
+        (String_util.contains_substring captured_default "MASC_WS_ENABLED=1");
       check bool "webrtc enabled by default" true
-        (contains_substring captured_default "MASC_WEBRTC_ENABLED=1");
+        (String_util.contains_substring captured_default "MASC_WEBRTC_ENABLED=1");
       check bool "config dir defaults to base path config" true
-        (contains_substring captured_default
+        (String_util.contains_substring captured_default
            ("MASC_CONFIG_DIR=" ^ bootstrapped_config));
       check bool "base path config bootstrapped" true
         (Sys.file_exists (Filename.concat bootstrapped_config "runtime.toml"));
@@ -437,12 +428,12 @@ let test_realtime_transports_default_to_base_path_config_and_preserve_override (
           code_override stdout_override stderr_override;
       let captured_override = read_file capture_override in
       check bool "config dir override preserved" true
-        (contains_substring captured_override
+        (String_util.contains_substring captured_override
            ("MASC_CONFIG_DIR=" ^ Filename.concat dir "custom-config"));
       check bool "ws override preserved" true
-        (contains_substring captured_override "MASC_WS_ENABLED=0");
+        (String_util.contains_substring captured_override "MASC_WS_ENABLED=0");
       check bool "webrtc override preserved" true
-        (contains_substring captured_override "MASC_WEBRTC_ENABLED=0"))
+        (String_util.contains_substring captured_override "MASC_WEBRTC_ENABLED=0"))
 
 let test_bootstraps_base_path_config_from_repo_when_unset () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -470,7 +461,7 @@ let test_bootstraps_base_path_config_from_repo_when_unset () =
           code stdout stderr;
       let captured = read_file capture in
       check bool "defaults to base path config" true
-        (contains_substring captured
+        (String_util.contains_substring captured
            ("MASC_CONFIG_DIR=" ^ bootstrapped_config));
       check bool "repo config copied to base path config" true
         (Sys.file_exists (Filename.concat bootstrapped_config "runtime.toml")))
@@ -500,9 +491,9 @@ let test_default_base_path_requires_explicit_base_path () =
       check bool "does not invoke server executable" false
         (Sys.file_exists capture);
       check bool "stderr names required base path" true
-        (contains_substring stderr "MASC base path is required");
+        (String_util.contains_substring stderr "MASC base path is required");
       check bool "stderr rejects HOME inference" true
-        (contains_substring stderr "Refusing to infer a runtime root from HOME");
+        (String_util.contains_substring stderr "Refusing to infer a runtime root from HOME");
       ignore stdout)
 
 let test_absolute_env_base_path_is_preserved () =
@@ -532,7 +523,7 @@ let test_absolute_env_base_path_is_preserved () =
       let captured = read_file capture in
       let expected_root = canonical_path stale_root in
       check bool "absolute env base path preserved" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
+        (String_util.contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_absolute_parent_project_base_path_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -563,7 +554,7 @@ let test_absolute_parent_project_base_path_is_preserved () =
       let captured = read_file capture in
       let expected_root = canonical_path parent in
       check bool "absolute parent root inheritance preserved" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
+        (String_util.contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_cli_sidecar_root_is_exported () =
   with_temp_dir "start-masc-script-sidecar-root" (fun dir ->
@@ -597,7 +588,7 @@ let test_cli_sidecar_root_is_exported () =
           stderr;
       let captured = read_file capture in
       check bool "sidecar root exported to server env" true
-        (contains_substring captured
+        (String_util.contains_substring captured
            ("MASC_SIDECAR_ROOT=" ^ canonical_path sidecar_root)))
 
 let test_zshenv_absolute_base_path_is_ignored () =
@@ -627,7 +618,7 @@ let test_zshenv_absolute_base_path_is_ignored () =
       let _ = stdout in
       check bool "zshenv base path alone is rejected" true (code <> 0);
       check bool "stderr rejects HOME/profile inference" true
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "Refusing to infer a runtime root from HOME"))
 
 let test_shared_root_env_base_path_is_preserved () =
@@ -657,7 +648,7 @@ let test_shared_root_env_base_path_is_preserved () =
       let captured = read_file capture in
       let expected_root = canonical_path inherited_root in
       check bool "shared-root env base path preserved" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
+        (String_util.contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_worktree_prefers_local_build_over_workspace_build () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -689,7 +680,7 @@ let test_worktree_prefers_local_build_over_workspace_build () =
           stderr;
       let captured = read_file capture in
       check bool "local build wins in worktree" true
-        (contains_substring captured "FAKE_EXE_MARKER=local"))
+        (String_util.contains_substring captured "FAKE_EXE_MARKER=local"))
 
 let test_explicit_base_path_execs_from_base_path () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -720,7 +711,7 @@ let test_explicit_base_path_execs_from_base_path () =
       let captured = read_file capture in
       let expected_root = canonical_path parent in
       check bool "exec cwd matches explicit base path" true
-        (contains_substring captured ("PWD=" ^ expected_root)))
+        (String_util.contains_substring captured ("PWD=" ^ expected_root)))
 
 let test_explicit_base_path_ignores_config_from_zshenv () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -753,10 +744,10 @@ let test_explicit_base_path_ignores_config_from_zshenv () =
       let captured = read_file capture in
       let expected_parent = canonical_path parent in
       check bool "explicit base path resets config root to base path" true
-        (contains_substring captured
+        (String_util.contains_substring captured
            ("MASC_CONFIG_DIR=" ^ Filename.concat expected_parent ".masc/config"));
       check bool "zshenv config was not imported" false
-        (contains_substring stderr "Ignoring repo-local MASC_CONFIG_DIR"))
+        (String_util.contains_substring stderr "Ignoring repo-local MASC_CONFIG_DIR"))
 
 let test_explicit_base_path_ignores_repo_local_config_from_parent_env () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -784,10 +775,10 @@ let test_explicit_base_path_ignores_repo_local_config_from_parent_env () =
       let expected_parent = canonical_path parent in
       check bool "parent env repo-local config ignored under external base path"
         true
-        (contains_substring captured
+        (String_util.contains_substring captured
            ("MASC_CONFIG_DIR=" ^ Filename.concat expected_parent ".masc/config"));
       check bool "parent env repo-local config ignore is logged" true
-        (contains_substring stderr "Ignoring repo-local MASC_CONFIG_DIR"))
+        (String_util.contains_substring stderr "Ignoring repo-local MASC_CONFIG_DIR"))
 
 let test_explicit_http_port_derives_sidecar_ports () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -809,9 +800,9 @@ let test_explicit_http_port_derives_sidecar_ports () =
           stderr;
       let captured = read_file capture in
       check bool "grpc port derived from explicit http port" true
-        (contains_substring captured "MASC_GRPC_PORT=9952");
+        (String_util.contains_substring captured "MASC_GRPC_PORT=9952");
       check bool "ws port derived from explicit http port" true
-        (contains_substring captured "MASC_WS_PORT=9953"))
+        (String_util.contains_substring captured "MASC_WS_PORT=9953"))
 
 let test_grpc_direct_banner_is_preserved_in_stderr () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -830,11 +821,11 @@ let test_grpc_direct_banner_is_preserved_in_stderr () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       check bool "grpc-direct tls banner preserved" true
-        (contains_substring stderr "Running without TLS (plaintext h2c)");
+        (String_util.contains_substring stderr "Running without TLS (plaintext h2c)");
       check bool "grpc-direct server banner preserved" true
-        (contains_substring stderr "gRPC server on 127.0.0.1:9952");
+        (String_util.contains_substring stderr "gRPC server on 127.0.0.1:9952");
       check bool "other stderr preserved" true
-        (contains_substring stderr "stderr-keep"))
+        (String_util.contains_substring stderr "stderr-keep"))
 
 let test_stale_dune_artifacts_are_cleaned_and_retried () =
   with_temp_dir "start-masc-script-stale-dune" (fun dir ->
@@ -873,27 +864,27 @@ let test_stale_dune_artifacts_are_cleaned_and_retried () =
               code stdout stderr;
           let captured = read_file capture in
           check bool "server started from retry-built executable" true
-            (contains_substring captured
+            (String_util.contains_substring captured
                "FAKE_EXE_MARKER=eio-after-stale-retry");
           check bool "dune clean ran before retry" true
             (Sys.file_exists clean_marker);
           let dune_local_calls = read_file dune_local_log in
           check bool "startup build uses dune-local wrapper" true
-            (contains_substring dune_local_calls
+            (String_util.contains_substring dune_local_calls
                "dune-local build bin/main_eio.exe");
           check bool "startup forwards DUNE_JOBS into wrapper under CI" true
-            (contains_substring dune_local_calls
+            (String_util.contains_substring dune_local_calls
                "DUNE_JOBS=2");
           check bool "stale cleanup uses dune-local wrapper" true
-            (contains_substring dune_local_calls "dune-local clean");
+            (String_util.contains_substring dune_local_calls "dune-local clean");
           check bool "original stale artifact error preserved" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "make inconsistent assumptions over implementation Agent_core__Streaming");
           check bool "retry is explained" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "Stale Dune artifacts detected while building main_eio.exe");
           check bool "retry output preserved" true
-            (contains_substring stderr "fake dune build recovered")))
+            (String_util.contains_substring stderr "fake dune build recovered")))
 
 let test_dune_cache_temp_error_retries_with_cache_disabled () =
   with_temp_dir "start-masc-script-cache-temp-dune" (fun dir ->
@@ -932,25 +923,25 @@ let test_dune_cache_temp_error_retries_with_cache_disabled () =
               code stdout stderr;
           let captured = read_file capture in
           check bool "server started from cache-disabled retry executable" true
-            (contains_substring captured
+            (String_util.contains_substring captured
                "FAKE_EXE_MARKER=eio-after-cache-temp-retry");
           check bool "dune clean was not used for cache temp retry" false
             (Sys.file_exists clean_marker);
           let dune_local_calls = read_file dune_local_log in
           check bool "initial startup build used cache default" true
-            (contains_substring dune_local_calls
+            (String_util.contains_substring dune_local_calls
                "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_CACHE=");
           check bool "retry disabled Dune cache" true
-            (contains_substring dune_local_calls
+            (String_util.contains_substring dune_local_calls
                "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_CACHE=disabled");
           check bool "original cache temp error preserved" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "rmdir(/Users/test/.cache/dune/db/temp/dune_6eb519_artifacts): Directory not empty");
           check bool "cache retry is explained" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "Dune cache temp cleanup failed while building main_eio.exe");
           check bool "cache retry output preserved" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "fake dune build recovered with cache disabled")))
 
 let test_stale_executable_requires_build_lock () =
@@ -988,9 +979,9 @@ let test_stale_executable_requires_build_lock () =
           check bool "stale executable was not started" false
             (Sys.file_exists capture);
           check bool "lock holder is reported" true
-            (contains_substring stderr "Another MASC build in progress");
+            (String_util.contains_substring stderr "Another MASC build in progress");
 	          check bool "stale executable refusal is explicit" true
-	            (contains_substring stderr
+	            (String_util.contains_substring stderr
 	               "refusing to continue with a stale or missing executable")))
 
 let test_build_tempfail_runs_only_hash_verified_lkg () =
@@ -1040,17 +1031,17 @@ let test_build_tempfail_runs_only_hash_verified_lkg () =
               code stdout stderr;
           let captured = read_file capture in
           check bool "verified LKG executable was selected" true
-            (contains_substring captured "FAKE_EXE_MARKER=verified-lkg");
+            (String_util.contains_substring captured "FAKE_EXE_MARKER=verified-lkg");
           check bool "unverified stale executable was not selected" false
-            (contains_substring captured "FAKE_EXE_MARKER=local");
+            (String_util.contains_substring captured "FAKE_EXE_MARKER=local");
           check bool "fallback decision is explicit" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "using health-verified last-known-good artifact");
           check bool "launched artifact candidate is published" true
             (Sys.file_exists candidate_file);
           let candidate = read_file candidate_file in
           check bool "candidate preserves exact LKG hash" true
-            (contains_substring candidate lkg_hash)))
+            (String_util.contains_substring candidate lkg_hash)))
 
 let test_build_tempfail_rejects_lkg_hash_mismatch () =
   with_temp_dir "start-masc-invalid-lkg" (fun dir ->
@@ -1096,7 +1087,7 @@ let test_build_tempfail_rejects_lkg_hash_mismatch () =
           check bool "mismatched LKG never executed" false
             (Sys.file_exists capture);
           check bool "hash mismatch is operator-visible" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "last-known-good artifact failed exact verification")))
 
 let test_promoted_dune_lkg_survives_build_tree_cleanup () =
@@ -1124,7 +1115,7 @@ let test_promoted_dune_lkg_survives_build_tree_cleanup () =
       let descriptor_lines = String.split_on_char '\n' (read_file lkg_file) in
       let promoted_path = List.nth descriptor_lines 2 in
       check bool "promoted path is outside dune build tree" false
-        (contains_substring promoted_path "/_build/");
+        (String_util.contains_substring promoted_path "/_build/");
       rm_rf build_root;
       let verify_code, verify_stdout, verify_stderr =
         run_contract ~cwd:repo_root [ "verify"; lkg_file ]
@@ -1137,18 +1128,18 @@ let test_promoted_dune_lkg_survives_build_tree_cleanup () =
 let test_log_tee_preserves_server_pid () =
   let source = read_file (script_path ()) in
   check bool "log tee uses PID-preserving process substitution" true
-    (contains_substring source
+    (String_util.contains_substring source
        "exec \"$@\" > >(tee -a \"$MASC_LOG_FILE\") 2>&1");
   check bool "log tee does not retain a pipeline wrapper" false
-    (contains_substring source "exec \"$@\" 2>&1 | tee")
+    (String_util.contains_substring source "exec \"$@\" 2>&1 | tee")
 
 let test_default_build_lock_is_worktree_local () =
   let source = read_file (script_path ()) in
   check bool "default build lock is worktree-local" true
-    (contains_substring source
+    (String_util.contains_substring source
        "MASC_BUILD_LOCK=\"${MASC_BUILD_LOCK_PATH:-$SCRIPT_DIR/.masc-build.lock}\"");
   check bool "default build lock is not global /tmp" false
-    (contains_substring source "MASC_BUILD_LOCK_PATH:-/tmp/masc-build.lock")
+    (String_util.contains_substring source "MASC_BUILD_LOCK_PATH:-/tmp/masc-build.lock")
 
 let test_stdio_entrypoint_uses_shared_base_path_guard () =
   let source = read_file (source_file "bin/main_stdio_eio.ml") in
@@ -1156,20 +1147,20 @@ let test_stdio_entrypoint_uses_shared_base_path_guard () =
     read_file (source_file "lib/server/server_runtime_bootstrap.ml")
   in
   check bool "stdio resolves base path through shared guard" true
-    (contains_substring source
+    (String_util.contains_substring source
        "Server_base_path_guard.resolve_startup_base_path");
   check bool "stdio enforces shared base path guard" true
-    (contains_substring source "Server_base_path_guard.enforce");
+    (String_util.contains_substring source "Server_base_path_guard.enforce");
   check bool "stdio uses common owner initialization" true
-    (contains_substring source
+    (String_util.contains_substring source
        "Server_runtime_bootstrap.initialize_owner_state_blocking");
   check bool "HTTP runtime uses common owner initialization" true
-    (contains_substring http_runtime_source
+    (String_util.contains_substring http_runtime_source
        "initialize_owner_state_blocking ~sw ~env ~base_path");
   check bool "stdio uses common owner activation" true
-    (contains_substring source "Server_runtime_bootstrap.activate_owner_state");
+    (String_util.contains_substring source "Server_runtime_bootstrap.activate_owner_state");
   check bool "HTTP runtime uses common owner activation" true
-    (contains_substring http_runtime_source "activate_owner_state")
+    (String_util.contains_substring http_runtime_source "activate_owner_state")
 
 let test_stdio_skips_dashboard_build_and_http_preflight () =
   with_temp_dir "start-masc-script-stdio" (fun dir ->
@@ -1213,11 +1204,11 @@ exit 0
           stderr;
       let captured = read_file capture in
       check bool "stdio executable selected without HTTP build" true
-        (contains_substring captured "FAKE_EXE_MARKER=stdio");
+        (String_util.contains_substring captured "FAKE_EXE_MARKER=stdio");
       check bool "dashboard helper not invoked in stdio mode" false
         (Sys.file_exists dashboard_marker);
       check bool "stderr explains stdio dashboard skip" true
-        (contains_substring stderr "Skipping SPA build in stdio mode."))
+        (String_util.contains_substring stderr "Skipping SPA build in stdio mode."))
 
 let test_http_dashboard_build_failure_is_non_blocking_by_default () =
   with_temp_dir "start-masc-script-dashboard-nonblocking" (fun dir ->
@@ -1238,9 +1229,9 @@ let test_http_dashboard_build_failure_is_non_blocking_by_default () =
           stderr;
       let captured = read_file capture in
       check bool "HTTP server starts despite dashboard helper failure" true
-        (contains_substring captured "FAKE_EXE_MARKER=local");
+        (String_util.contains_substring captured "FAKE_EXE_MARKER=local");
       check bool "dashboard build is non-blocking by default" true
-        (contains_substring stderr "Background SPA build started"))
+        (String_util.contains_substring stderr "Background SPA build started"))
 
 let test_http_dashboard_build_blocking_mode_fails_closed () =
   with_temp_dir "start-masc-script-dashboard-blocking" (fun dir ->
@@ -1266,9 +1257,9 @@ let test_http_dashboard_build_blocking_mode_fails_closed () =
       check bool "HTTP server is not launched after blocking build failure" false
         (Sys.file_exists capture);
       check bool "blocking dashboard build is explicit in stderr" true
-        (contains_substring stderr "Building SPA before server start");
+        (String_util.contains_substring stderr "Building SPA before server start");
       check bool "helper failure is surfaced in blocking mode" true
-        (contains_substring stderr "dashboard build failed"))
+        (String_util.contains_substring stderr "dashboard build failed"))
 
 let test_http_preflight_waits_for_port_to_clear_before_build () =
   with_temp_dir "start-masc-script-port-wait" (fun dir ->
@@ -1313,9 +1304,9 @@ exit 1
           stderr;
       let captured = read_file capture in
       check bool "server started after transient port conflict" true
-        (contains_substring captured "FAKE_EXE_MARKER=local");
+        (String_util.contains_substring captured "FAKE_EXE_MARKER=local");
       check bool "preflight waited before build" true
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "HTTP Port 9954 in use, waiting before build/init"))
 
 let test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in ()
@@ -1348,7 +1339,7 @@ let test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in ()
           code_default stdout_default stderr_default;
       let captured_default = read_file capture_default in
       check bool "loopback disables keeper autoboot by default" true
-        (contains_substring captured_default "MASC_KEEPER_BOOTSTRAP_ENABLED=false");
+        (String_util.contains_substring captured_default "MASC_KEEPER_BOOTSTRAP_ENABLED=false");
       let capture_override =
         Filename.concat dir "captured-loopback-override.txt"
       in
@@ -1367,7 +1358,7 @@ let test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in ()
           code_override stdout_override stderr_override;
       let captured_override = read_file capture_override in
       check bool "loopback honors explicit keeper autoboot opt-in" true
-        (contains_substring captured_override "MASC_KEEPER_BOOTSTRAP_ENABLED=true"))
+        (String_util.contains_substring captured_override "MASC_KEEPER_BOOTSTRAP_ENABLED=true"))
 
 let test_supervisor_stops_on_startup_without_candidate () =
   with_temp_dir "start-masc-supervisor-terminal" (fun repo_root ->
@@ -1401,7 +1392,7 @@ let test_supervisor_stops_on_startup_without_candidate () =
         (read_file invocation_count);
       check string "supervisor writes no stdout" "" stdout;
       check bool "terminal startup state is operator-visible" true
-        (contains_substring stderr
+        (String_util.contains_substring stderr
            "terminal startup state: no runtime candidate was published"))
 
 let test_supervisor_zero_exit_without_health_proof_fails_closed () =
@@ -1455,9 +1446,9 @@ hash="$(${MASC_RUNTIME_ARTIFACT_CONTRACT:?} hash "$0")"
           (read_file invocation_count);
         check string "supervisor writes no stdout" "" stdout;
         check bool "terminal state is operator-visible" true
-          (contains_substring stderr terminal_message);
+          (String_util.contains_substring stderr terminal_message);
         check bool "successful child is reclassified as supervisor failure" true
-          (contains_substring stderr
+          (String_util.contains_substring stderr
              "child exited successfully without a health-verified runtime"))
   in
   run_case ~name:"start-masc-supervisor-zero-without-candidate"
@@ -1537,12 +1528,12 @@ exit 72
             (Sys.file_exists lkg_file);
           let expected_hash = artifact_hash ~cwd:repo_root child_script in
           check bool "promoted descriptor retains exact artifact hash" true
-            (contains_substring (read_file lkg_file) expected_hash);
+            (String_util.contains_substring (read_file lkg_file) expected_hash);
           check bool "configured bind host determines health probe" true
-            (contains_substring (read_file curl_capture)
+            (String_util.contains_substring (read_file curl_capture)
                "http://192.0.2.10:9999/health");
           check bool "promotion is operator-visible" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "health-verified runtime artifact promoted")))
 
 let test_supervisor_rejects_malformed_health_proof () =
@@ -1597,7 +1588,7 @@ exit 23
             (read_file invocation_count);
           check string "supervisor writes no stdout" "" stdout;
           check bool "invalid proof is operator-visible" true
-            (contains_substring stderr
+            (String_util.contains_substring stderr
                "lacks an exact PID-bound health proof")))
 
 let test_supervisor_restarts_without_exit_limit_and_preserves_status () =
@@ -1675,16 +1666,16 @@ exit 23
             "6\n" (read_file invocation_count);
           let log = read_file log_file in
           check bool "real child exit status is recorded" true
-            (contains_substring log "masc exited code=23");
+            (String_util.contains_substring log "masc exited code=23");
           check bool "each restart is preceded by health proof" true
-            (contains_substring log "health-verified runtime artifact promoted");
+            (String_util.contains_substring log "health-verified runtime artifact promoted");
           check bool "child failure is not rewritten as success" false
-            (contains_substring log "masc exited code=0");
+            (String_util.contains_substring log "masc exited code=0");
           check string "supervisor writes no stdout" "" stdout;
           check bool "external stop is logged" true
-            (contains_substring stderr "supervisor received SIGTERM");
+            (String_util.contains_substring stderr "supervisor received SIGTERM");
           check bool "finite crash-loop abort is absent" false
-            (contains_substring stderr "ABORT:")))
+            (String_util.contains_substring stderr "ABORT:")))
 
 let () =
   run "start_masc_script"

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -103,12 +103,6 @@ let make_keeper_meta ?(name = "judge-keeper") () : Keeper_meta_contract.keeper_m
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_keeper_meta failed: %s" e)
 
-let contains_substring haystack needle =
-  try
-    ignore (Str.search_forward (Str.regexp_string needle) haystack 0);
-    true
-  with Not_found -> false
-
 let source_text rel = Masc_test_deps.read_file (Masc_test_deps.source_path rel)
 
 let slice_between text ~start_marker ~end_marker =
@@ -137,15 +131,15 @@ let test_moderation_http_identity_bound_to_auth_source () =
       ~start_marker:{|Http.Router.post "/api/v1/dashboard/board/moderation/action"|}
   in
   Alcotest.(check bool) "flag route binds authenticated agent" true
-    (contains_substring flag_route "(fun _state agent_name req reqd ->");
+    (String_util.contains_substring flag_route "(fun _state agent_name req reqd ->");
   Alcotest.(check bool) "flag reporter uses authenticated agent" true
-    (contains_substring flag_route "let reporter = agent_name");
+    (String_util.contains_substring flag_route "let reporter = agent_name");
   Alcotest.(check bool) "flag route ignores body reporter" false
-    (contains_substring flag_route {|json_string_opt "reporter"|});
+    (String_util.contains_substring flag_route {|json_string_opt "reporter"|});
   Alcotest.(check bool) "action actor uses authenticated agent" true
-    (contains_substring action_route "let actor = agent_name");
+    (String_util.contains_substring action_route "let actor = agent_name");
   Alcotest.(check bool) "action route ignores body actor" false
-    (contains_substring action_route {|json_string_opt "actor"|})
+    (String_util.contains_substring action_route {|json_string_opt "actor"|})
 
 (** {2 Group 1: Helper / Formatting Functions} *)
 
@@ -812,9 +806,9 @@ let test_post_create_sources_footer_and_meta () =
   let json = parse_create_response_json body in
   let content = Yojson.Safe.Util.(json |> member "content" |> to_string) in
   Alcotest.(check bool) "sources footer appended" true
-    (contains_substring content "## Sources");
+    (String_util.contains_substring content "## Sources");
   Alcotest.(check bool) "source url rendered" true
-    (contains_substring content "<https://example.com/docs>");
+    (String_util.contains_substring content "<https://example.com/docs>");
   Alcotest.(check string) "source url persisted" "https://example.com/docs"
     Yojson.Safe.Util.(
       json |> member "meta" |> member "sources" |> index 0 |> member "url"
@@ -877,7 +871,7 @@ let test_keeper_board_sub_board_owner_is_runtime_bound () =
            ])
   in
   Alcotest.(check bool) "sub-board create succeeds" false
-    (contains_substring created "error");
+    (String_util.contains_substring created "error");
   let fetched =
     Keeper_tool_board_runtime.handle_board_tool
       ~meta:keeper_meta
@@ -885,9 +879,9 @@ let test_keeper_board_sub_board_owner_is_runtime_bound () =
       ~args:(make_args [ "sub_board_id", `String slug ])
   in
   Alcotest.(check bool) "owner is keeper identity" true
-    (contains_substring fetched "Owner: sub-board-keeper");
+    (String_util.contains_substring fetched "Owner: sub-board-keeper");
   Alcotest.(check bool) "spoofed owner is absent" false
-    (contains_substring fetched "spoofed-owner")
+    (String_util.contains_substring fetched "spoofed-owner")
 
 let test_direct_board_reaction_binds_keeper_identity () =
   with_eio @@ fun env ->
@@ -962,7 +956,7 @@ let test_model_visible_board_maintenance_dispatches_in_process () =
            [ "post_id", `String post_id; "author", `String "spoofed-author" ])
   in
   Alcotest.(check bool) "delete reaches its Board handler" true
-    (contains_substring delete_result post_id);
+    (String_util.contains_substring delete_result post_id);
   match Board_dispatch.get_post ~post_id with
   | Ok _ -> Alcotest.fail "model-visible in-process delete left the post behind"
   | Error _ -> ()
@@ -979,7 +973,7 @@ let test_keeper_board_dispatch_uses_typed_tool_names () =
       ~args:(make_args [])
   in
   Alcotest.(check bool) "fake board name rejected" true
-    (contains_substring fake "unknown_board_tool");
+    (String_util.contains_substring fake "unknown_board_tool");
   let comment_vote =
     Keeper_tool_board_runtime.handle_board_tool
       ~meta:keeper_meta
@@ -987,9 +981,9 @@ let test_keeper_board_dispatch_uses_typed_tool_names () =
       ~args:(make_args [ ("comment_id", `String "") ])
   in
   Alcotest.(check bool) "typed comment vote reaches board handler" true
-    (contains_substring comment_vote "comment_id required");
+    (String_util.contains_substring comment_vote "comment_id required");
   Alcotest.(check bool) "typed comment vote is not unknown" false
-    (contains_substring comment_vote "unknown_board_tool");
+    (String_util.contains_substring comment_vote "unknown_board_tool");
   let curation =
     Keeper_tool_board_runtime.handle_board_tool
       ~meta:keeper_meta
@@ -998,7 +992,7 @@ let test_keeper_board_dispatch_uses_typed_tool_names () =
   in
   Alcotest.(check string) "typed curation read reaches board handler" "null" curation;
   Alcotest.(check bool) "typed curation read is not unknown" false
-    (contains_substring curation "unknown_board_tool");
+    (String_util.contains_substring curation "unknown_board_tool");
   let curation_submit =
     Keeper_tool_board_runtime.handle_board_tool
       ~meta:keeper_meta
@@ -1035,7 +1029,7 @@ let test_keeper_board_dispatch_uses_typed_tool_names () =
            ])
   in
   Alcotest.(check bool) "typed curation submit is not unknown" false
-    (contains_substring curation_submit "unknown_board_tool");
+    (String_util.contains_substring curation_submit "unknown_board_tool");
   let submit_json = Yojson.Safe.from_string curation_submit in
   Alcotest.(check string) "keeper source injected for curation" "typed-keeper"
     Yojson.Safe.Util.(submit_json |> member "submitted_by" |> to_string);
@@ -1074,7 +1068,7 @@ let test_board_curation_submit_roundtrips_to_read () =
   Alcotest.(check bool) "raw submit rejects non-object provenance" false
     invalid_provenance_ok;
   Alcotest.(check bool) "invalid provenance error mentions object" true
-    (contains_substring invalid_provenance_body "object");
+    (String_util.contains_substring invalid_provenance_body "object");
   let ok, body =
     dispatch "masc_board_curation_submit"
       (make_args
@@ -1213,7 +1207,7 @@ let test_post_create_accepts_automation_rejects_system () =
   in
   Alcotest.(check bool) "system rejected" false ok_sys;
   Alcotest.(check bool) "error mentions reserved" true
-    (contains_substring body_sys "reserved")
+    (String_util.contains_substring body_sys "reserved")
 
 let test_post_create_empty_content () =
   with_eio @@ fun env ->
@@ -1237,7 +1231,7 @@ let test_post_create_empty_title_rejected () =
          ("author", `String "tester") ]) in
   Alcotest.(check bool) "empty title rejected" false ok;
   Alcotest.(check bool) "error mentions title" true
-    (contains_substring body "title" || contains_substring body "Title")
+    (String_util.contains_substring body "title" || String_util.contains_substring body "Title")
 
 let test_post_create_missing_author_rejected () =
   with_eio @@ fun env ->
@@ -1247,7 +1241,7 @@ let test_post_create_missing_author_rejected () =
     (make_args [("content", `String "Hello board")]) in
   Alcotest.(check bool) "missing author rejected" false ok;
   Alcotest.(check bool) "error mentions author" true
-    (contains_substring body "author")
+    (String_util.contains_substring body "author")
 
 let test_post_create_anonymous_author_rejected () =
   with_eio @@ fun env ->
@@ -1257,7 +1251,7 @@ let test_post_create_anonymous_author_rejected () =
     (make_args [("content", `String "Hello board"); ("author", `String "anonymous")]) in
   Alcotest.(check bool) "anonymous author rejected" false ok;
   Alcotest.(check bool) "error mentions author" true
-    (contains_substring body "author")
+    (String_util.contains_substring body "author")
 
 let test_post_list_empty () =
   with_eio @@ fun env ->
@@ -1281,7 +1275,7 @@ let test_cleanup_clears_persisted_jsonl () =
   let ok2, body = dispatch "masc_board_list" (make_args []) in
   Alcotest.(check bool) "list ok after cleanup" true ok2;
   Alcotest.(check bool) "persisted content removed" false
-    (contains_substring body "persist me")
+    (String_util.contains_substring body "persist me")
 
 let test_post_list_with_posts () =
   with_eio @@ fun env ->
@@ -1338,7 +1332,7 @@ let test_post_list_invalid_sort_rejected () =
     (make_args [("sort", `String "invalid_xyz")]) in
   Alcotest.(check bool) "invalid sort rejected" false ok;
   Alcotest.(check bool) "error mentions valid sorts" true
-    (contains_substring body "invalid sort. Valid: hot, trending, recent, updated, discussed")
+    (String_util.contains_substring body "invalid sort. Valid: hot, trending, recent, updated, discussed")
 
 let test_post_list_filter_combinations () =
   with_eio @@ fun env ->
@@ -1364,21 +1358,21 @@ let test_post_list_filter_combinations () =
   Alcotest.(check bool) "exclude_automation ok" true ok2;
   Alcotest.(check bool) "exclude both ok" true ok3;
   Alcotest.(check bool) "exclude_system hides system" false
-    (contains_substring body1 "keeper-alert-bot");
+    (String_util.contains_substring body1 "keeper-alert-bot");
   Alcotest.(check bool) "exclude_system keeps keeper" true
-    (contains_substring body1 "dm-keeper");
+    (String_util.contains_substring body1 "dm-keeper");
   Alcotest.(check bool) "exclude_automation keeps system" true
-    (contains_substring body2 "keeper-alert-bot");
+    (String_util.contains_substring body2 "keeper-alert-bot");
   Alcotest.(check bool) "exclude_automation hides keeper" false
-    (contains_substring body2 "dm-keeper");
+    (String_util.contains_substring body2 "dm-keeper");
   Alcotest.(check bool) "exclude_automation hides harness" false
-    (contains_substring body2 "dashboard-harness-bot");
+    (String_util.contains_substring body2 "dashboard-harness-bot");
   Alcotest.(check bool) "exclude both keeps human" true
-    (contains_substring body3 "human-author");
+    (String_util.contains_substring body3 "human-author");
   Alcotest.(check bool) "exclude both hides keeper" false
-    (contains_substring body3 "dm-keeper");
+    (String_util.contains_substring body3 "dm-keeper");
   Alcotest.(check bool) "exclude both hides harness" false
-    (contains_substring body3 "dashboard-harness-bot")
+    (String_util.contains_substring body3 "dashboard-harness-bot")
 
 let test_dispatch_delete_success () =
   with_eio @@ fun env ->
@@ -1398,7 +1392,7 @@ let test_dispatch_delete_success () =
   in
   Alcotest.(check bool) "delete ok" true ok_del;
   Alcotest.(check bool) "delete msg contains id" true
-    (contains_substring msg_del post_id)
+    (String_util.contains_substring msg_del post_id)
 
 let test_dispatch_delete_not_found () =
   with_eio @@ fun env ->
@@ -1411,7 +1405,7 @@ let test_dispatch_delete_not_found () =
   in
   Alcotest.(check bool) "delete not found" false ok;
   Alcotest.(check bool) "error message present" true
-    (contains_substring body "Post not found" || contains_substring body "nonexistent-id")
+    (String_util.contains_substring body "Post not found" || String_util.contains_substring body "nonexistent-id")
 
 let test_dispatch_delete_empty_id () =
   with_eio @@ fun env ->
@@ -1421,7 +1415,7 @@ let test_dispatch_delete_empty_id () =
     (make_args [("post_id", `String "")]) in
   Alcotest.(check bool) "empty id rejected" false ok;
   Alcotest.(check bool) "error mentions required" true
-    (contains_substring body "required")
+    (String_util.contains_substring body "required")
 
 let test_dispatch_post_update_success () =
   with_eio @@ fun env ->
@@ -1449,7 +1443,7 @@ let test_dispatch_post_update_success () =
   in
   Alcotest.(check bool) "edit ok" true ok_edit;
   Alcotest.(check bool) "edit msg contains new body" true
-    (contains_substring msg_edit "edited tool body");
+    (String_util.contains_substring msg_edit "edited tool body");
   (match Board_dispatch.get_post ~post_id with
    | Error e -> Alcotest.fail (Board.show_board_error e)
    | Ok post -> Alcotest.(check string) "edit persisted" "edited tool body" post.content)
@@ -1511,7 +1505,7 @@ let test_dispatch_post_update_transfers_author () =
   in
   Alcotest.(check bool) "transfer edit ok" true ok_edit;
   Alcotest.(check bool) "edit msg contains new author" true
-    (contains_substring msg_edit "tool-transfer-next");
+    (String_util.contains_substring msg_edit "tool-transfer-next");
   match Board_dispatch.get_post ~post_id with
   | Error e -> Alcotest.fail (Board.show_board_error e)
   | Ok post ->
@@ -1530,7 +1524,7 @@ let test_dispatch_post_update_missing_id () =
       (make_args [ ("author", `String "x"); ("content", `String "y") ])
   in
   Alcotest.(check bool) "missing post_id rejected" false ok;
-  Alcotest.(check bool) "error mentions required" true (contains_substring body "required")
+  Alcotest.(check bool) "error mentions required" true (String_util.contains_substring body "required")
 
 let test_post_get_success () =
   with_eio @@ fun env ->
@@ -1584,7 +1578,7 @@ let check_get_footer ~label post_id args expected =
     dispatch "masc_board_post_get" (make_args (("post_id", `String post_id) :: args))
   in
   Alcotest.(check bool) (label ^ " get ok") true ok;
-  Alcotest.(check bool) label true (contains_substring body expected)
+  Alcotest.(check bool) label true (String_util.contains_substring body expected)
 
 let test_post_get_comment_pagination_clamps_and_advances () =
   with_eio @@ fun env ->
@@ -1736,7 +1730,7 @@ let test_comment_add_missing_author_rejected () =
     (make_args [("post_id", `String "missing"); ("content", `String "hi")]) in
   Alcotest.(check bool) "missing author rejected" false ok;
   Alcotest.(check bool) "error mentions author" true
-    (contains_substring body "author")
+    (String_util.contains_substring body "author")
 
 let test_comment_add_anonymous_author_rejected () =
   with_eio @@ fun env ->
@@ -1747,7 +1741,7 @@ let test_comment_add_anonymous_author_rejected () =
        [("post_id", `String "missing"); ("content", `String "hi"); ("author", `String "anonymous")]) in
   Alcotest.(check bool) "anonymous author rejected" false ok;
   Alcotest.(check bool) "error mentions author" true
-    (contains_substring body "author")
+    (String_util.contains_substring body "author")
 
 let test_comment_vote_missing () =
   with_eio @@ fun env ->

--- a/test/test_tool_call_replay_harness.ml
+++ b/test/test_tool_call_replay_harness.ml
@@ -81,17 +81,6 @@ let load_single_fixture file_name =
 let load_fixture () =
   load_single_fixture "openai_tool_call.jsonl"
 
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    if needle_len = 0 then true
-    else if idx + needle_len > haystack_len then false
-    else if String.sub haystack idx needle_len = needle then true
-    else loop (idx + 1)
-  in
-  loop 0
-
 let read_nonempty_lines path =
   let input = open_in path in
   Fun.protect
@@ -166,9 +155,9 @@ let test_validate_rejects_undeclared_tool () =
   | Error errors ->
       let joined = String.concat " | " errors in
       check bool "expected tool error" true
-        (contains_substring joined "expected tool 'masc_add_task' is not declared");
+        (String_util.contains_substring joined "expected tool 'masc_add_task' is not declared");
       check bool "response tool error" true
-        (contains_substring joined "response tool 'masc_add_task' is not declared")
+        (String_util.contains_substring joined "response tool 'masc_add_task' is not declared")
 
 let test_validate_rejects_argument_mismatch () =
   let snapshot = load_fixture () in
@@ -194,7 +183,7 @@ let test_validate_rejects_argument_mismatch () =
   | Error errors ->
       let joined = String.concat " | " errors in
       check bool "argument mismatch surfaced" true
-        (contains_substring joined "arguments mismatch for tool 'masc_add_task'")
+        (String_util.contains_substring joined "arguments mismatch for tool 'masc_add_task'")
 
 let test_fixture_catalog_rejects_empty_provider () =
   let snapshot = load_single_fixture "empty_provider.jsonl" in
@@ -203,7 +192,7 @@ let test_fixture_catalog_rejects_empty_provider () =
   | Error errors ->
       let joined = String.concat " | " errors in
       check bool "empty provider surfaced" true
-        (contains_substring joined "snapshot provider must be non-empty")
+        (String_util.contains_substring joined "snapshot provider must be non-empty")
 
 let test_fixture_catalog_rejects_missing_fields () =
   let rows = read_nonempty_lines (fixture_path "missing_fields.jsonl") in
@@ -223,7 +212,7 @@ let test_fixture_catalog_rejects_missing_fields () =
         | Ok _ -> Alcotest.failf "expected row to fail: %s" expected_error
         | Error msg ->
             check bool ("missing field surfaced: " ^ expected_error) true
-              (contains_substring msg expected_error)))
+              (String_util.contains_substring msg expected_error)))
     rows expected_errors
 
 let test_load_rejects_malformed_jsonl () =
@@ -234,7 +223,7 @@ let test_load_rejects_malformed_jsonl () =
   | Ok _ -> Alcotest.fail "expected malformed JSONL fixture to fail"
   | Error msg ->
       check bool "malformed line surfaced" true
-        (contains_substring msg "malformed JSONL line")
+        (String_util.contains_substring msg "malformed JSONL line")
 
 let () =
   Alcotest.run "tool_call_replay_harness"

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -3,19 +3,6 @@ open Alcotest
 let check_float_close label expected actual =
   check bool label true (Float.abs (expected -. actual) < 0.001)
 
-let contains_substring text needle =
-  let len_text = String.length text in
-  let len_needle = String.length needle in
-  if len_needle = 0 then true
-  else if len_needle > len_text then false
-  else
-    let rec loop idx =
-      if idx > len_text - len_needle then false
-      else if String.equal (String.sub text idx len_needle) needle then true
-      else loop (idx + 1)
-    in
-    loop 0
-
 let test_ollama_ps_parser_extracts_loaded_models () =
   let json =
     Yojson.Safe.from_string
@@ -243,8 +230,8 @@ let test_curl_get_argv_keeps_curl_as_executable_with_headers () =
   check bool "curl emits structured metadata" true
     (List.exists
        (fun arg ->
-         contains_substring arg "%{url_effective}"
-         && contains_substring arg "%{content_type}")
+         String_util.contains_substring arg "%{url_effective}"
+         && String_util.contains_substring arg "%{content_type}")
        argv);
   check bool "curl is not repeated after headers" false (List.mem "curl" (List.tl argv))
 

--- a/test/test_tool_misc_web_fetch.ml
+++ b/test/test_tool_misc_web_fetch.ml
@@ -1,18 +1,5 @@
 open Alcotest
 
-let contains_substring text needle =
-  let len_text = String.length text in
-  let len_needle = String.length needle in
-  if len_needle = 0 then true
-  else if len_needle > len_text then false
-  else
-    let rec loop idx =
-      if idx > len_text - len_needle then false
-      else if String.equal (String.sub text idx len_needle) needle then true
-      else loop (idx + 1)
-    in
-    loop 0
-
 let handle ?(extract_mode = "markdown") ?(max_chars = 5_000) url =
   Eio_main.run @@ fun _env ->
   Masc.Tool_misc_web_fetch.handle ~tool_name:"masc_web_fetch"
@@ -75,10 +62,10 @@ let test_html_metadata_and_article_extraction () =
       check int "downloaded bytes" (String.length html)
         (json |> member "downloaded_bytes" |> to_int);
       let text = json |> member "text" |> to_string in
-      check bool "heading rendered" true (contains_substring text "# Primary Article");
+      check bool "heading rendered" true (String_util.contains_substring text "# Primary Article");
       check bool "link rendered" true
-        (contains_substring text "[ref](https://example.com/ref)");
-      check bool "nav dropped" false (contains_substring text "drop me"))
+        (String_util.contains_substring text "[ref](https://example.com/ref)");
+      check bool "nav dropped" false (String_util.contains_substring text "drop me"))
 
 let test_plain_text_preserves_angle_brackets () =
   let body = "Keep <literal> tokens\nand second line." in
@@ -100,7 +87,7 @@ let test_plain_text_preserves_angle_brackets () =
         (json |> member "extraction_source" |> to_string);
       let text = json |> member "text" |> to_string in
       check bool "literal brackets preserved" true
-        (contains_substring text "<literal>"))
+        (String_util.contains_substring text "<literal>"))
 
 let test_invalid_redirect_is_workflow_rejection () =
   Masc.Tool_misc_web_fetch.with_http_fetch_for_test
@@ -118,7 +105,7 @@ let test_invalid_redirect_is_workflow_rejection () =
         (Tool_result.failure_class result
         |> Option.map Tool_result.tool_failure_class_to_string);
       check bool "message" true
-        (contains_substring (Tool_result.message result) "invalid redirect"))
+        (String_util.contains_substring (Tool_result.message result) "invalid redirect"))
 
 let () =
   run "tool_misc_web_fetch"

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -66,16 +66,6 @@ let property_description schema property =
        | _ -> None)
   | Some _ | None -> None
 
-let contains_substring ~needle value =
-  let needle_len = String.length needle in
-  let value_len = String.length value in
-  let rec loop index =
-    if index + needle_len > value_len then false
-    else if String.sub value index needle_len = needle then true
-    else loop (index + 1)
-  in
-  needle_len = 0 || loop 0
-
 (* ============================================================ *)
 (* 1. Schema Structure Tests                                     *)
 (* ============================================================ *)
@@ -226,22 +216,22 @@ let test_masc_transition_schema () =
   | Some schema ->
       Alcotest.(check bool) "description omits task required_tools"
         false
-        (contains_substring ~needle:"required_tools" schema.description);
+        (String_util.string_contains_substring ~needle:"required_tools" schema.description);
       Alcotest.(check bool) "description omits mandatory tools routing"
         false
-        (contains_substring ~needle:"mandatory tools" schema.description);
+        (String_util.string_contains_substring ~needle:"mandatory tools" schema.description);
       Alcotest.(check bool) "description omits requires tools routing"
         false
-        (contains_substring ~needle:"requires tools" schema.description);
+        (String_util.string_contains_substring ~needle:"requires tools" schema.description);
       Alcotest.(check bool) "description omits configured completion reviewer"
         false
-        (contains_substring
+        (String_util.string_contains_substring
            ~needle:"configured LLM completion reviewer"
            schema.description);
       (* RFC-0323 G-4: the weak-lane teaching sentence must stay gone. *)
       Alcotest.(check bool) "description omits the verifier-bypass teaching"
         false
-        (contains_substring
+        (String_util.string_contains_substring
            ~needle:"do not route normal completion"
            schema.description);
       (match get_json_assoc "properties" schema.input_schema with
@@ -331,11 +321,11 @@ let test_masc_add_task_schema () =
                   Option.value ~default:"" (get_json_string "description" goal_id_schema)
                 in
                 Alcotest.(check bool) "goal_id is optional in prose" true
-                  (contains_substring ~needle:"Optional structured goal link" description);
+                  (String_util.string_contains_substring ~needle:"Optional structured goal link" description);
                 Alcotest.(check bool) "goal_id does not reference prompt markers" false
-                  (contains_substring ~needle:"<available_goals>" description);
+                  (String_util.string_contains_substring ~needle:"<available_goals>" description);
                 Alcotest.(check bool) "goal_id does not label omitted links orphaned" false
-                  (contains_substring ~needle:"orphaned" description)
+                  (String_util.string_contains_substring ~needle:"orphaned" description)
             | None -> Alcotest.fail "masc_add_task missing goal_id property")
           ; (match List.assoc_opt "contract" props with
              | Some contract_schema ->

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -67,16 +67,6 @@ let ensure_keeper_meta config name =
   | Error detail -> Alcotest.failf "write keeper meta failed: %s" detail
 ;;
 
-let contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  let rec loop offset =
-    if offset + needle_len > text_len then false
-    else if String.sub text offset needle_len = needle then true
-    else loop (offset + 1)
-  in
-  needle_len = 0 || loop 0
-
 let test_verdict_event_preserves_typed_authority () =
   let event =
     VP.For_testing.verdict_event_json
@@ -289,55 +279,55 @@ let test_system_llm_review_notes_are_metadata_only () =
   Alcotest.(check bool)
     "artifact content is not duplicated into task notes"
     false
-    (contains_substring notes "secret artifact content must not be duplicated");
+    (String_util.contains_substring notes "secret artifact content must not be duplicated");
   Alcotest.(check bool)
     "narrative content is not duplicated into task notes"
     false
-    (contains_substring notes "secret narrative must not be duplicated");
+    (String_util.contains_substring notes "secret narrative must not be duplicated");
   Alcotest.(check bool)
     "verification output is not duplicated into task notes"
     false
-    (contains_substring notes "must not be duplicated");
+    (String_util.contains_substring notes "must not be duplicated");
   Alcotest.(check bool)
     "verification criteria are not duplicated into task notes"
     false
-    (contains_substring notes "secret criterion should stay in the audit store");
+    (String_util.contains_substring notes "secret criterion should stay in the audit store");
   Alcotest.(check bool)
     "artifact reference remains observable"
     true
-    (contains_substring notes "artifact:proof.txt");
+    (String_util.contains_substring notes "artifact:proof.txt");
   Alcotest.(check bool)
     "truncation remains observable"
     true
-    (contains_substring notes "truncated");
+    (String_util.contains_substring notes "truncated");
   Alcotest.(check bool)
     "verification creation time remains observable"
     true
-    (contains_substring notes "1234.5");
+    (String_util.contains_substring notes "1234.5");
   Alcotest.(check bool)
     "rejection reason remains observable"
     true
-    (contains_substring notes "insufficient proof");
+    (String_util.contains_substring notes "insufficient proof");
   Alcotest.(check bool)
     "verification identity remains observable"
     true
-    (contains_substring notes "vrf-metadata-only");
+    (String_util.contains_substring notes "vrf-metadata-only");
   Alcotest.(check bool)
     "read error detail is not duplicated into task notes"
     false
-    (contains_substring notes "/private/producer/secret.txt");
+    (String_util.contains_substring notes "/private/producer/secret.txt");
   Alcotest.(check bool)
     "stable read error code remains observable"
     true
-    (contains_substring notes "read_error");
+    (String_util.contains_substring notes "read_error");
   Alcotest.(check bool)
     "invalid raw reference is not duplicated into task notes"
     false
-    (contains_substring notes "/private/producer/invalid-reference.txt");
+    (String_util.contains_substring notes "/private/producer/invalid-reference.txt");
   Alcotest.(check bool)
     "stable invalid-reference code remains observable"
     true
-    (contains_substring notes "invalid_reference");
+    (String_util.contains_substring notes "invalid_reference");
   let unavailable_metadata =
     VS.submitted_evidence_access_metadata_to_yojson
       (VS.Evidence_unavailable
@@ -350,11 +340,11 @@ let test_system_llm_review_notes_are_metadata_only () =
   Alcotest.(check bool)
     "unavailable detail is not duplicated into metadata"
     false
-    (contains_substring unavailable_metadata "/private/producer/request.json")
+    (String_util.contains_substring unavailable_metadata "/private/producer/request.json")
   ; Alcotest.(check bool)
       "unavailable reason code remains observable"
       true
-      (contains_substring unavailable_metadata "request_load_error")
+      (String_util.contains_substring unavailable_metadata "request_load_error")
   ; let unavailable_audit =
       VS.submitted_evidence_access_to_yojson
         (VS.Evidence_unavailable
@@ -367,7 +357,7 @@ let test_system_llm_review_notes_are_metadata_only () =
     Alcotest.(check bool)
       "full audit keeps the unavailable detail"
       true
-      (contains_substring unavailable_audit "/private/producer/request.json")
+      (String_util.contains_substring unavailable_audit "/private/producer/request.json")
 
 let test_unreadable_evidence_uses_structured_current_contract () =
   let request : VS.request_header =
@@ -449,7 +439,7 @@ let test_invalid_reference_snapshot_rejects_hidden_payload () =
       Alcotest.(check bool)
         "hidden invalid-reference payload is rejected"
         true
-        (contains_substring detail "payload-free")
+        (String_util.contains_substring detail "payload-free")
     | _ -> Alcotest.fail "hidden invalid-reference payload was accepted")
 
 let test_system_llm_rejection_is_durably_delivered_to_producer_keeper () =
@@ -999,19 +989,19 @@ let test_system_llm_agent_uses_persisted_request_contract_snapshot () =
              Alcotest.(check bool)
                "prompt uses persisted completion criterion"
                true
-               (contains_substring prompt "persisted completion criterion");
+               (String_util.contains_substring prompt "persisted completion criterion");
              Alcotest.(check bool)
                "prompt does not use mutated live completion criterion"
                false
-               (contains_substring prompt "mutated live completion criterion");
+               (String_util.contains_substring prompt "mutated live completion criterion");
              Alcotest.(check bool)
                "prompt uses persisted required artifact"
                true
-               (contains_substring prompt "persisted required artifact");
+               (String_util.contains_substring prompt "persisted required artifact");
              Alcotest.(check bool)
                "prompt does not use mutated live required artifact"
                false
-               (contains_substring prompt "mutated live required artifact"));
+               (String_util.contains_substring prompt "mutated live required artifact"));
           match W.get_tasks_raw config with
           | [ { task_status = Masc_domain.Done _; _ } ] -> ()
           | [ task ] ->
@@ -1736,8 +1726,8 @@ let test_submit_snapshot_rejects_bare_and_absolute_references () =
     Alcotest.(check bool)
       "invalid references are absent from the persisted snapshot"
       false
-      (contains_substring persisted_snapshot "artifacts/bare.txt"
-       || contains_substring persisted_snapshot absolute_path);
+      (String_util.contains_substring persisted_snapshot "artifacts/bare.txt"
+       || String_util.contains_substring persisted_snapshot absolute_path);
     ignore
       (match
          V.create_request
@@ -2071,12 +2061,12 @@ let test_keeper_task_projection_never_exposes_snapshot_or_verdict_action () =
     Alcotest.(check bool)
       "row identifies the completion-authority wait"
       true
-      (contains_substring projection
+      (String_util.contains_substring projection
          "awaiting_completion_authority task_id=task-001");
     Alcotest.(check bool)
       "keeper row does not choose a verdict action"
       false
-      (contains_substring projection "ACTION:");
+      (String_util.contains_substring projection "ACTION:");
     (match
        W.claim_task_r config ~agent_name:"keeper-executor-agent" ~task_id:"task-001" ()
      with
@@ -2095,19 +2085,19 @@ let test_keeper_task_projection_never_exposes_snapshot_or_verdict_action () =
     Alcotest.(check bool)
       "task projection contains no evidence bytes"
       false
-      (contains_substring projection "full-cycle-evidence");
+      (String_util.contains_substring projection "full-cycle-evidence");
     Alcotest.(check bool)
       "task projection keeps request metadata"
       true
-      (contains_substring projection request_id);
+      (String_util.contains_substring projection request_id);
     Alcotest.(check bool)
       "task projection has no assigned verifier"
       false
-      (contains_substring projection "assigned_verifier=");
+      (String_util.contains_substring projection "assigned_verifier=");
     Alcotest.(check bool)
       "task projection has no verdict action"
       false
-      (contains_substring projection "ACTION:"))
+      (String_util.contains_substring projection "ACTION:"))
 
 (* --- ID generation property test (#7544) --- *)
 

--- a/test/test_verification_run_registry.ml
+++ b/test/test_verification_run_registry.ml
@@ -40,19 +40,6 @@ let str json key =
   | _ -> None
 ;;
 
-let contains_substring value needle =
-  let value_length = String.length value in
-  let needle_length = String.length needle in
-  let rec loop index =
-    if needle_length = 0
-    then true
-    else if index + needle_length > value_length
-    then false
-    else if String.sub value index needle_length = needle
-    then true
-    else loop (index + 1)
-  in
-  loop 0
 ;;
 
 let register t ~verification_id ~started_at =
@@ -248,7 +235,7 @@ let test_unknown_outcome_label_is_an_error () =
   check bool "unknown outcome is not replayed" true
     (Option.is_none (R.get replayed ~verification_id:"vrf-unknown"));
   check bool "unknown outcome evidence is preserved" true
-    (contains_substring (Fs_compat.load_file path) "probably_fine");
+    (String_util.contains_substring (Fs_compat.load_file path) "probably_fine");
   remove_if_exists path
 ;;
 

--- a/test/test_voice_config.ml
+++ b/test/test_voice_config.ml
@@ -56,17 +56,6 @@ let parse json_str =
   let json = Yojson.Safe.from_string json_str in
   Vc.parse_json json
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len = 0 then true
-  else
-    let rec loop idx =
-      idx + needle_len <= haystack_len
-      && (String.sub haystack idx needle_len = needle || loop (idx + 1))
-    in
-    loop 0
-
 let rec mkdir_p path =
   if path <> "" && not (Sys.file_exists path) then begin
     mkdir_p (Filename.dirname path);
@@ -108,7 +97,7 @@ let test_load_detailed_invalid_json () =
     match Vc.load_detailed () with
     | Error (Vc.Invalid msg) ->
       check bool "json syntax error surfaced" true
-        (contains_substring ~needle:"invalid voice config json" msg)
+        (String_util.string_contains_substring ~needle:"invalid voice config json" msg)
     | Error Vc.Not_configured ->
       fail "expected Invalid, got Not_configured"
     | Ok _ -> fail "expected Invalid, got Ok")
@@ -118,7 +107,7 @@ let test_load_detailed_schema_error_is_invalid () =
     match Vc.load_detailed () with
     | Error (Vc.Invalid msg) ->
       check bool "schema error surfaced" true
-        (contains_substring ~needle:"required" msg)
+        (String_util.string_contains_substring ~needle:"required" msg)
     | Error Vc.Not_configured ->
       fail "expected Invalid, got Not_configured"
     | Ok _ -> fail "expected Invalid, got Ok")
@@ -143,13 +132,13 @@ let test_load_legacy_strings_preserved () =
     match Vc.load () with
     | Error msg ->
       check bool "missing reported" true
-        (contains_substring ~needle:"voice config missing at" msg)
+        (String_util.string_contains_substring ~needle:"voice config missing at" msg)
     | Ok _ -> fail "expected missing-config Error, got Ok");
   with_explicit_voice_config "{ this is not json" (fun () ->
     match Vc.load () with
     | Error msg ->
       check bool "json error surfaced" true
-        (contains_substring ~needle:"invalid voice config json" msg)
+        (String_util.string_contains_substring ~needle:"invalid voice config json" msg)
     | Ok _ -> fail "expected invalid-config Error, got Ok")
 
 let test_session_empty_endpoints_ok () =

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -69,20 +69,8 @@ let mkdir_if_missing path =
   if not (Sys.file_exists path) then Unix.mkdir path 0o755
 ;;
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len = 0 then true
-  else
-    let rec loop idx =
-      idx + needle_len <= haystack_len
-      && (String.sub haystack idx needle_len = needle || loop (idx + 1))
-    in
-    loop 0
-;;
-
 let check_json_omits label needle json =
-  check bool label false (contains_substring ~needle (Yojson.Safe.to_string json))
+  check bool label false (String_util.string_contains_substring ~needle (Yojson.Safe.to_string json))
 ;;
 
 let test_resolve_voice_aliases () =

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -46,12 +46,6 @@ let () =
     let assets = Filename.concat (project_root ()) "assets" in
     if Sys.file_exists assets then Unix.putenv "MASC_ASSETS_DIR" assets
 
-let contains_substr sub s =
-  try
-    let _ = Str.search_forward (Str.regexp_string sub) s 0 in
-    true
-  with Not_found -> false
-
 let contains_re re s =
   try
     let _ = Str.search_forward (Str.regexp re) s 0 in
@@ -122,37 +116,37 @@ let test_html_starts_with_doctype () =
       (String.length html >= 15 && String.sub html 0 15 = "<!DOCTYPE html>")
   else
     check bool "fallback contains error" true
-      (contains_substr "Dashboard build not found" html)
+      (String_util.contains_substring html "Dashboard build not found")
 
 let test_html_contains_head () =
   let html = Web_dashboard.html () in
   if dashboard_built () then
-    check bool "has head" true (contains_substr "<head>" html)
+    check bool "has head" true (String_util.contains_substring html "<head>")
   else
     check bool "fallback is non-empty" true (String.length html > 0)
 
 let test_html_contains_body () =
   let html = Web_dashboard.html () in
-  check bool "has body" true (contains_substr "<body>" html)
+  check bool "has body" true (String_util.contains_substring html "<body>")
 
 let test_html_contains_title () =
   let html = Web_dashboard.html () in
   if dashboard_built () then
-    check bool "has MASC title" true (contains_substr "MASC Dashboard" html)
+    check bool "has MASC title" true (String_util.contains_substring html "MASC Dashboard")
   else
     check bool "fallback mentions dashboard" true
-      (contains_substr "Dashboard" html)
+      (String_util.contains_substring html "Dashboard")
 
 let test_html_contains_stylesheet () =
   let html = Web_dashboard.html () in
   if dashboard_built () then
     check bool "has stylesheet link" true
       (contains_re "rel=\"stylesheet\"" html
-       || contains_substr "<style>" html)
+       || String_util.contains_substring html "<style>")
   else
     check bool "fallback has no stylesheet" true
       (not (contains_re "rel=\"stylesheet\"" html)
-       && not (contains_substr "<style>" html))
+       && not (String_util.contains_substring html "<style>"))
 
 let test_html_contains_script () =
   let html = Web_dashboard.html () in
@@ -165,10 +159,10 @@ let test_html_contains_script () =
 let test_html_contains_app_mount () =
   let html = Web_dashboard.html () in
   if dashboard_built () then
-    check bool "has app mount div" true (contains_substr "id=\"app\"" html)
+    check bool "has app mount div" true (String_util.contains_substring html "id=\"app\"")
   else
     check bool "fallback has no app mount" true
-      (not (contains_substr "id=\"app\"" html))
+      (not (String_util.contains_substring html "id=\"app\""))
 
 let test_html_ends_with_html_tag () =
   let html = Web_dashboard.html () in
@@ -181,10 +175,10 @@ let test_html_references_dashboard_assets () =
   let html = Web_dashboard.html () in
   if dashboard_built () then
     check bool "references dashboard assets" true
-      (contains_substr "/dashboard/assets/" html)
+      (String_util.contains_substring html "/dashboard/assets/")
   else
     check bool "fallback does not reference assets" false
-      (contains_substr "/dashboard/assets/" html)
+      (String_util.contains_substring html "/dashboard/assets/")
 
 
 (* ============================================================
@@ -223,7 +217,7 @@ let test_fallback_on_missing_asset () =
           let html = Web_dashboard.html () in
           let etag = Web_dashboard.etag () in
           check bool "fallback html contains error message" true
-            (contains_substr "Dashboard build not found" html);
+            (String_util.contains_substring html "Dashboard build not found");
           check string "fallback etag is none" "none" etag))
     ~finally:(fun () -> Unix.rmdir missing_assets_root)
 
@@ -239,7 +233,7 @@ let test_html_ignores_invalid_explicit_assets_dir () =
         (fun () ->
           let html = Web_dashboard.html () in
           check bool "does not fall back to base_path assets" false
-            (contains_substr "dashboard-from-base-path" html)))
+            (String_util.contains_substring html "dashboard-from-base-path")))
     ~finally:(fun () -> cleanup_temp_dashboard_root base_root)
 
 let test_html_ignores_base_path_assets () =
@@ -254,7 +248,7 @@ let test_html_ignores_base_path_assets () =
         (fun () ->
           let html = Web_dashboard.html () in
           check bool "ignores base_path assets" false
-            (contains_substr "dashboard-from-base-path" html)))
+            (String_util.contains_substring html "dashboard-from-base-path")))
     ~finally:(fun () ->
       cleanup_temp_dashboard_root base_root)
 
@@ -342,7 +336,9 @@ let test_bundle_freshness_fresh_when_stamp_after_binary () =
 let test_bundle_freshness_build_stamp_path_under_dashboard_assets () =
   with_temp_dashboard_root (fun () ->
     check bool "build_stamp_path lives under assets/dashboard/" true
-      (contains_substr "/dashboard/.build-stamp" (Web_dashboard.build_stamp_path ())))
+      (String_util.contains_substring
+         (Web_dashboard.build_stamp_path ())
+         "/dashboard/.build-stamp"))
 
 (* log_bundle_freshness_warning has no return value to assert on (there is no
    existing Log capture harness in this suite) — these are smoke tests

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -30,15 +30,6 @@ let source_root () =
 
 let read_source_file rel = read_file (Filename.concat (source_root ()) rel)
 
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop i =
-    i + needle_len <= haystack_len
-    && (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
-  in
-  needle_len = 0 || loop 0
-
 let sse_frame json = Printf.sprintf "data: %s\n\n" json
 
 let count_substring haystack needle =
@@ -163,22 +154,22 @@ let test_session_close_wire_calls_stay_outside_registry_lock () =
   Alcotest.(check bool)
     "detaching from the registry does not wait on the session writer lock"
     false
-    (contains_substring detach_helper "write_mutex");
+    (String_util.contains_substring detach_helper "write_mutex");
   Alcotest.(check bool)
     "detaching from the registry does not close the wire"
     false
-    (contains_substring detach_helper close_marker);
+    (String_util.contains_substring detach_helper close_marker);
   Alcotest.(check bool)
     "wire close helper does not acquire sessions_mutex"
     false
-    (contains_substring close_helper "with_sessions_rw");
+    (String_util.contains_substring close_helper "with_sessions_rw");
   List.iteri
     (fun i span ->
       Alcotest.(check bool)
         (Printf.sprintf
            "registry lock span %d does not invoke detached wire close" i)
         false
-        (contains_substring span "close_detached_session_wsd"))
+        (String_util.contains_substring span "close_detached_session_wsd"))
     (function_call_spans source "with_sessions_rw")
 
 (* ====== SHA1 (httpun-ws handshake) ====== *)
@@ -420,15 +411,6 @@ let test_bigstring_of_shared_text_content_matches () =
   Alcotest.(check string) "content round-trips" text
     (Bigstringaf.to_string payload)
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop i =
-    i + nlen <= hlen
-    && (String.sub haystack i nlen = needle || loop (i + 1))
-  in
-  nlen = 0 || loop 0
-
 let test_bigstring_of_shared_text_repairs_invalid_utf8_for_text_frames () =
   let text =
     "id: 42\nevent: message\ndata: {\"type\":\"transport_health_snapshot\",\
@@ -439,7 +421,7 @@ let test_bigstring_of_shared_text_repairs_invalid_utf8_for_text_frames () =
   Alcotest.(check bool) "wire payload is valid UTF-8"
     true (String.is_valid_utf_8 wire);
   Alcotest.(check bool) "invalid byte is replaced"
-    true (contains_substring wire "\xEF\xBF\xBD")
+    true (String_util.contains_substring wire "\xEF\xBF\xBD")
 
 let test_bigstring_of_shared_text_invalidates_on_new_ref () =
   (* Force two distinct string allocations so physical equality differs
@@ -470,13 +452,13 @@ let test_shared_send_avoids_per_session_payload_string_copy () =
       ~end_marker:"let send_text_checked"
   in
   Alcotest.(check bool) "send path uses ws-direct bigstring API" true
-    (contains_substring send_span "Ws_wsd.send_text_bigstring");
+    (String_util.contains_substring send_span "Ws_wsd.send_text_bigstring");
   Alcotest.(check bool) "send path avoids payload string copy" false
-    (contains_substring send_span "Bytes.sub_string");
+    (String_util.contains_substring send_span "Bytes.sub_string");
   Alcotest.(check bool) "shared cache encodes to bigstring" true
-    (contains_substring cache_span "Bigstringaf.of_string");
+    (String_util.contains_substring cache_span "Bigstringaf.of_string");
   Alcotest.(check bool) "shared cache avoids bytes payload copy" false
-    (contains_substring cache_span "Bytes.of_string")
+    (String_util.contains_substring cache_span "Bytes.of_string")
 
 (* Observability: the Otel_metric_store counters must account exactly for the
    traffic the cache absorbs — hits for reuse, misses for fresh


### PR DESCRIPTION
Replaces #28206 after its stacked base #28245 merged and GitHub auto-closed the PR. This branch is now conflict-resolved directly on main.

#28187 의 후속. 그 PR 이 "사본을 만들 이유"를 없앴고, 이 PR 이 남은 사본 86개를 전부 수렴시킨다. **트리의 지역 `contains_substring` 정의: 91 → 0.**

## 3개 본체 커밋 + 리뷰 수정 2개

| 커밋 | 대상 | 위험 | 방법 |
|---|---|---|---|
| 1 | 같은 시그니처(`haystack needle`) 29파일 | 낮음 | 정의 삭제 + 이름 교체 |
| 2 | 파라미터명만 다른 위치 인자 23파일 | 낮음 | 동일. 빈-needle 가드가 없는 본문 7개는 개별 판독 |
| 3 | **라벨 인자 24파일 + 역순 4파일** | **높음** | 아래 |
| 4 | matrix guard 1파일 | 리뷰 수정 | 기존 case-insensitive 의미 복원 |
| 5 | 최신 main 동시 변경 2파일 | 리뷰 수정 | 남은 unqualified 호출 4곳 수렴 |

4번째 커밋은 리뷰에서 발견된 의미 보존 누락을 수정한다. 기존 matrix helper는 양쪽 문자열을 소문자화했으므로 `contains_any`와 `already joined` 검사는 `String_util.contains_substring_ci`로 수렴시켜 capitalized MCP 오류도 계속 잡는다.

5번째 커밋은 최신 main이 같은 파일에 추가한 테스트 문맥에서 남아 있던 unqualified 호출 4곳을 canonical helper로 수렴시킨다. 전체 테스트 범위 역스캔으로 코드상 잔여 호출이 없음을 확인했다.

## 배치 3 이 위험했던 이유와 회피

**라벨 107곳** — 처음 계획은 위치 인자 정본으로의 통일이었다. `String_util` 자체의 주석이 이를 막았다:

> Labeled-arg wrappers. Keeper/runtime modules use `~needle` to avoid positional-argument mistakes at call sites with multiple string parameters.

호출부의 라벨은 우연이 아니라 안전장치다. 그래서 라벨 정본(`string_contains_substring`, `Agent_core_strings.contains_substring ~needle ~haystack`)으로 수렴했다 — 변환에서 **인자 재배열이 문법적으로 사라진다**(이름 변경 또는 라벨 삽입만 남음).

**역순 30곳** — `contains_substr needle haystack` 은 정본과 인자 순서가 반대다. 둘 다 `string` 이라 뒤집힌 변환도 컴파일되고, 단언은 조용히 항상-참/항상-거짓이 된다. 손으로 옮기고 리터럴 needle 로 방향을 매 사이트 확인했다. `test_web_dashboard_coverage` 의 사본은 트리에 마지막으로 남아 있던 `Str` 기반이기도 했다.

## dune

최소 스탠자 5개(`masc_test_deps` superset 파손으로부터 의도적으로 격리된 것들)에 `masc.string_util` 을 명시했다. leaf 는 의존성이 0이라 그 격리를 깨지 않는다 — #28187 이 leaf 를 만든 이유가 정확히 이 지점이다.

## 검증

```
dune build @check                                  clean
수정 스위트 직접 실행                                19 PASS
```

직접 실행에서 실패한 나머지는 **이 diff 없는 베이스 트리에서 바이트 동일하게 재현**된다 (stash A/B):

| 실패 | 귀속 |
|---|---|
| `models.toml not found` ×2 | 테스트가 cwd 를 추측해 fixture 를 찾음 (`["models.toml"; "../models.toml"]`) |
| E2E ×3 | dune action 이 넣는 `MASC_MAIN_EIO_EXE` env 없이 직접 실행한 하네스 문제 |
| board_dispatch/event_queue/tools_coverage | 베이스에서 동일 서명 실패 (keeper meta / event-queue 상태) |
| complete_http | flake — 베이스·본 트리 각 3회 재실행 전부 PASS |

이 diff 가 도입한 실패: 0.

RFC-WAIVED: 테스트 전용 변경 + dune 스탠자 라이브러리 추가. RFC 필수 subsystem 에 해당 없음.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>



