### PR TITLE
fix(keeper): refresh GitHub identity within turns

### DIFF
--- a/lib/keeper/keeper_github_identity.ml
+++ b/lib/keeper/keeper_github_identity.ml
@@ -290,8 +290,13 @@ type docker_tool_projection =
   { args : string list
   ; identity_state : tool_identity_state
   ; host_snapshot_dir : string
+  ; revision : string
   ; cleanup : unit -> unit
   }
+
+let unconfigured_tool_identity_revision =
+  Digestif.SHA256.(digest_string "masc.github-tool-identity.unconfigured.v1" |> to_hex)
+;;
 
 let yaml_scalar_has_value value =
   let value = String.trim value in
@@ -436,13 +441,74 @@ let existing_config_dir ~config ~keeper_name =
   end
 ;;
 
+let load_optional_config_file config_dir filename =
+  let path = Filename.concat config_dir filename in
+  match Fs_compat.load_owned_regular_file ~ownership_root:config_dir path with
+  | Error error -> Error (Fs_compat.owned_regular_file_read_error_to_string error)
+  | Ok content -> Ok content
+;;
+
+let configured_tool_identity_revision config_dir =
+  match load_optional_config_file config_dir "hosts.yml" with
+  | Error _ as error -> error
+  | Ok None -> Error "configured GitHub CLI identity has no hosts.yml"
+  | Ok (Some hosts) ->
+    (match load_optional_config_file config_dir "config.yml" with
+     | Error _ as error -> error
+     | Ok config ->
+       let material =
+         Yojson.Safe.to_string
+           (`Assoc
+              [ "schema", `String "masc.github-tool-identity-revision.v1"
+              ; "hosts.yml", `String hosts
+              ; ( "config.yml"
+                , match config with
+                  | None -> `Null
+                  | Some value -> `String value )
+              ])
+       in
+       Ok Digestif.SHA256.(digest_string material |> to_hex))
+;;
+
+let current_tool_identity_revision ~config ~keeper_name =
+  match existing_config_dir ~config ~keeper_name with
+  | Error _ as error -> error
+  | Ok None -> Ok unconfigured_tool_identity_revision
+  | Ok (Some config_dir) -> configured_tool_identity_revision config_dir
+;;
+
+let snapshot_cleanup snapshot =
+  let descriptor = Unix.openfile snapshot [ Unix.O_RDONLY ] 0 in
+  Unix.set_close_on_exec descriptor;
+  let created = Unix.fstat descriptor in
+  let claimed = Atomic.make false in
+  fun () ->
+    if Atomic.compare_and_set claimed false true
+    then
+      Fun.protect
+        ~finally:(fun () -> Unix.close descriptor)
+        (fun () ->
+           match lstat_opt snapshot with
+           | Ok None -> ()
+           | Ok (Some current)
+             when current.Unix.st_kind = Unix.S_DIR
+                  && current.Unix.st_dev = created.Unix.st_dev
+                  && current.Unix.st_ino = created.Unix.st_ino ->
+             (* Change permissions through the descriptor captured before the
+                child ran. A pathname chmod could follow a replacement
+                symlink between validation and cleanup. *)
+             Unix.fchmod descriptor 0o700;
+             Fs_compat.remove_tree snapshot
+           | Ok (Some _) | Error _ ->
+             (* The non-following tree remover unlinks a replacement entry
+                directly and never traverses a replacement symlink. *)
+             Fs_compat.remove_tree snapshot)
+;;
+
 let copy_local_tool_config_snapshot existing =
   let snapshot = Filename.temp_dir "masc-gh-tool-" "" in
   Unix.chmod snapshot 0o700;
-  let cleanup () =
-    if Sys.file_exists snapshot then Unix.chmod snapshot 0o700;
-    Fs_compat.remove_tree snapshot
-  in
+  let cleanup = snapshot_cleanup snapshot in
   let copy_file filename =
     let source = Filename.concat existing filename in
     let target = Filename.concat snapshot filename in
@@ -473,11 +539,9 @@ let copy_local_tool_config_snapshot existing =
 
 let empty_local_tool_config_snapshot () =
   let snapshot = Filename.temp_dir "masc-gh-tool-empty-" "" in
+  let cleanup = snapshot_cleanup snapshot in
   Unix.chmod snapshot 0o500;
-  ( snapshot
-  , fun () ->
-      if Sys.file_exists snapshot then Unix.chmod snapshot 0o700;
-      Fs_compat.remove_tree snapshot )
+  snapshot, cleanup
 ;;
 
 let runtime_env_for_tool ~config ~keeper_name env =
@@ -521,24 +585,31 @@ let docker_args_for_tool ~config ~keeper_name ~container_masc_dir =
           ]
       ; identity_state = Unconfigured
       ; host_snapshot_dir = snapshot
+      ; revision = unconfigured_tool_identity_revision
       ; cleanup
       }
   | Ok (Some host_dir) ->
     (match copy_local_tool_config_snapshot host_dir with
      | Error _ as error -> error
      | Ok (snapshot, cleanup) ->
-       let container_dir = container_config_dir ~container_masc_dir ~keeper_name in
-       Ok
-         { args =
-             [ "--env"
-             ; "GH_CONFIG_DIR=" ^ container_dir
-             ; "-v"
-             ; snapshot ^ ":" ^ container_dir ^ ":ro"
-             ]
-         ; identity_state = Configured host_dir
-         ; host_snapshot_dir = snapshot
-         ; cleanup
-         })
+       (match configured_tool_identity_revision snapshot with
+        | Error error ->
+          cleanup ();
+          Error error
+        | Ok revision ->
+          let container_dir = container_config_dir ~container_masc_dir ~keeper_name in
+          Ok
+            { args =
+                [ "--env"
+                ; "GH_CONFIG_DIR=" ^ container_dir
+                ; "-v"
+                ; snapshot ^ ":" ^ container_dir ^ ":ro"
+                ]
+            ; identity_state = Configured host_dir
+            ; host_snapshot_dir = snapshot
+            ; revision
+            ; cleanup
+            }))
 ;;
 
 let login_argv ~hostname =

--- a/lib/keeper/keeper_github_identity.mli
+++ b/lib/keeper/keeper_github_identity.mli
@@ -43,8 +43,14 @@ type docker_tool_projection =
   { args : string list
   ; identity_state : tool_identity_state
   ; host_snapshot_dir : string
+  ; revision : string
   ; cleanup : unit -> unit
   }
+
+val current_tool_identity_revision :
+  config:Workspace.config -> keeper_name:string -> (string, string) result
+(** SHA-256 identity of the exact files a new tool snapshot would receive.
+    The digest is comparison authority only and never exposes token bytes. *)
 
 (** Projects the deterministic Keeper path without provisioning it. Missing
     state and a safe directory without a stored token in [hosts.yml] are

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -165,7 +165,7 @@ type dispatch_bundle =
   { sandbox : Masc_exec.Sandbox_target.t
   ; fields : (string * Yojson.Safe.t) list
   ; base_host_env : string array option
-  ; github_config_dir : unit -> (string, string) result
+  ; github_secret_files : unit -> (string list, string) result
   ; cleanup : unit -> unit
   }
 
@@ -307,7 +307,9 @@ let handle_tool_execute_typed
                           ; fields =
                               ("github_identity", `String identity_field) :: extra_fields
                           ; base_host_env = Some env
-                          ; github_config_dir = (fun () -> Ok github_config_dir)
+                          ; github_secret_files =
+                              (fun () ->
+                                 Ok [ Filename.concat github_config_dir "hosts.yml" ])
                           ; cleanup
                           }))))
         in
@@ -348,9 +350,9 @@ let handle_tool_execute_typed
                       ; "sandbox_profile", `String "docker"
                       ]
                   ; base_host_env = None
-                  ; github_config_dir =
+                  ; github_secret_files =
                       (fun () ->
-                         Keeper_turn_sandbox_runtime.prepare_github_identity_snapshot
+                         Keeper_turn_sandbox_runtime.prepare_github_identity_secret_files
                            ?timeout_sec
                            dispatch.runtime)
                   ; cleanup = Fun.id
@@ -480,17 +482,16 @@ let handle_tool_execute_typed
           let authorized result =
             Keeper_tool_execution.with_gate_authorization authorization result
           in
-          (match dispatch_bundle.github_config_dir () with
+          (match dispatch_bundle.github_secret_files () with
            | Error err ->
              authorized
                (typed_error_json
                   ~extra_fields:[ "error", `String "github_identity_snapshot_unavailable" ]
                   ("GitHub identity snapshot unavailable: " ^ err))
-           | Ok github_config_dir ->
+           | Ok github_secret_files ->
           let output_redaction =
             execute_secret_redaction
-              ~additional_secret_files:
-                [ Filename.concat github_config_dir "hosts.yml" ]
+              ~additional_secret_files:github_secret_files
               ~base_path:config.base_path
               ~keeper_name:meta.name
           in

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -37,6 +37,13 @@ type t =
 let get_state t = Atomic.get t.state
 let set_state t state = Atomic.set t.state state
 
+let rec update_github_identity_snapshots t update =
+  let current = Atomic.get t.github_identity_snapshots in
+  let updated = update current in
+  if not (Atomic.compare_and_set t.github_identity_snapshots current updated)
+  then update_github_identity_snapshots t update
+;;
+
 let release_github_identity_snapshot t =
   let snapshots = Atomic.exchange t.github_identity_snapshots no_github_identity_snapshots in
   Option.iter (fun snapshot -> snapshot.cleanup ()) snapshots.current;
@@ -499,10 +506,8 @@ let start_container ?timeout_sec (t : t) =
              with
              | Ok () ->
                if github_identity_is_new
-               then (
-                 let snapshots = Atomic.get t.github_identity_snapshots in
-                 Atomic.set
-                   t.github_identity_snapshots
+               then
+                 update_github_identity_snapshots t (fun snapshots ->
                    { snapshots with current = Some github_identity });
                keep_github_identity_snapshot := true;
                set_state t (Running { container_name });
@@ -568,13 +573,11 @@ let ensure_started ?(validate_running = false) ?timeout_sec (t : t) =
 ;;
 
 let retire_current_github_identity_snapshot t =
-  let snapshots = Atomic.get t.github_identity_snapshots in
-  match snapshots.current with
-  | None -> ()
-  | Some current ->
-    Atomic.set
-      t.github_identity_snapshots
-      { current = None; retired = current :: snapshots.retired }
+  update_github_identity_snapshots t (fun snapshots ->
+    match snapshots.current with
+    | None -> snapshots
+    | Some current ->
+      { current = None; retired = current :: snapshots.retired })
 ;;
 
 let stop_container_for_github_identity_refresh ?timeout_sec t =

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -9,8 +9,16 @@ type state =
 type github_identity_snapshot =
   { args : string list
   ; host_dir : string
+  ; revision : string
   ; cleanup : unit -> unit
   }
+
+type github_identity_snapshots =
+  { current : github_identity_snapshot option
+  ; retired : github_identity_snapshot list
+  }
+
+let no_github_identity_snapshots = { current = None; retired = [] }
 
 type t =
   { config : Workspace.config
@@ -23,20 +31,26 @@ type t =
   ; gid : int
   ; network_mode : network_mode
   ; state : state Atomic.t
-  ; github_identity_snapshot : github_identity_snapshot option Atomic.t
+  ; github_identity_snapshots : github_identity_snapshots Atomic.t
   }
 
 let get_state t = Atomic.get t.state
 let set_state t state = Atomic.set t.state state
 
 let release_github_identity_snapshot t =
-  match Atomic.exchange t.github_identity_snapshot None with
-  | None -> ()
-  | Some snapshot -> snapshot.cleanup ()
+  let snapshots = Atomic.exchange t.github_identity_snapshots no_github_identity_snapshots in
+  Option.iter (fun snapshot -> snapshot.cleanup ()) snapshots.current;
+  List.iter (fun snapshot -> snapshot.cleanup ()) snapshots.retired
 ;;
 
-let github_identity_snapshot_dir t =
-  Option.map (fun snapshot -> snapshot.host_dir) (Atomic.get t.github_identity_snapshot)
+let github_identity_secret_files t =
+  let snapshots = Atomic.get t.github_identity_snapshots in
+  let snapshots =
+    match snapshots.current with
+    | None -> snapshots.retired
+    | Some current -> current :: snapshots.retired
+  in
+  List.map (fun snapshot -> Filename.concat snapshot.host_dir "hosts.yml") snapshots
 ;;
 
 module For_testing = struct
@@ -51,7 +65,7 @@ module For_testing = struct
     ; gid = 0
     ; network_mode = Network_none
     ; state = Atomic.make state
-    ; github_identity_snapshot = Atomic.make None
+    ; github_identity_snapshots = Atomic.make no_github_identity_snapshots
     }
   ;;
 
@@ -86,7 +100,7 @@ let create
   ; gid = Unix.getgid ()
   ; network_mode
   ; state = Atomic.make Not_started
-  ; github_identity_snapshot = Atomic.make None
+  ; github_identity_snapshots = Atomic.make no_github_identity_snapshots
   }
 ;;
 
@@ -391,7 +405,7 @@ let start_container ?timeout_sec (t : t) =
         | Error err -> Error ("docker_container_start_failed: secret_projection: " ^ err)
         | Ok secret_projection ->
          let github_identity_result =
-           match Atomic.get t.github_identity_snapshot with
+           match (Atomic.get t.github_identity_snapshots).current with
           | Some snapshot -> Ok (snapshot, false)
           | None ->
             (match
@@ -407,6 +421,7 @@ let start_container ?timeout_sec (t : t) =
                Ok
                  ( { args = projection.args
                    ; host_dir = projection.host_snapshot_dir
+                   ; revision = projection.revision
                    ; cleanup = projection.cleanup
                    }
                  , true ))
@@ -484,7 +499,11 @@ let start_container ?timeout_sec (t : t) =
              with
              | Ok () ->
                if github_identity_is_new
-               then Atomic.set t.github_identity_snapshot (Some github_identity);
+               then (
+                 let snapshots = Atomic.get t.github_identity_snapshots in
+                 Atomic.set
+                   t.github_identity_snapshots
+                   { snapshots with current = Some github_identity });
                keep_github_identity_snapshot := true;
                set_state t (Running { container_name });
                Ok container_name
@@ -548,13 +567,80 @@ let ensure_started ?(validate_running = false) ?timeout_sec (t : t) =
   | Not_started -> start_container ?timeout_sec t
 ;;
 
-let prepare_github_identity_snapshot ?timeout_sec t =
-  match ensure_started ?timeout_sec t with
+let retire_current_github_identity_snapshot t =
+  let snapshots = Atomic.get t.github_identity_snapshots in
+  match snapshots.current with
+  | None -> ()
+  | Some current ->
+    Atomic.set
+      t.github_identity_snapshots
+      { current = None; retired = current :: snapshots.retired }
+;;
+
+let stop_container_for_github_identity_refresh ?timeout_sec t =
+  let retire () =
+    set_state t Not_started;
+    retire_current_github_identity_snapshot t;
+    Ok ()
+  in
+  match get_state t with
+  | Not_started -> retire ()
+  | Running { container_name } ->
+    let timeout_sec =
+      Option.value
+        timeout_sec
+        ~default:
+          (Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Cleanup_rm ())
+    in
+    let argv =
+      Keeper_sandbox_runtime.docker_command_argv () @ [ "rm"; "-f"; container_name ]
+    in
+    let status, output = run_argv_with_status ~timeout_sec argv in
+    (match status with
+     | Unix.WEXITED 0 -> retire ()
+     | _ ->
+       (match
+          Keeper_sandbox_runtime.probe_container_state_optional
+            ~container_name
+            ~timeout_sec
+            ()
+        with
+        | Ok Keeper_sandbox_runtime.Docker_container_absent -> retire ()
+        | Ok Keeper_sandbox_runtime.Docker_container_running
+        | Ok Keeper_sandbox_runtime.Docker_container_stopped
+        | Error _ ->
+          Error
+            (Printf.sprintf
+               "cannot refresh GitHub identity while turn container %s remains: status=%s output=%s"
+               container_name
+               (Keeper_sandbox_exec_failure.status_label status)
+               (Exec_policy.truncate_for_log output))))
+;;
+
+let prepare_github_identity_secret_files ?timeout_sec t =
+  let ensure_bound () =
+    match ensure_started ?timeout_sec t with
+    | Error _ as error -> error
+    | Ok _container_name ->
+      (match (Atomic.get t.github_identity_snapshots).current with
+       | None -> Error "running container has no GitHub identity snapshot"
+       | Some _ -> Ok (github_identity_secret_files t))
+  in
+  match
+    Keeper_github_identity.current_tool_identity_revision
+      ~config:t.config
+      ~keeper_name:t.meta.name
+  with
   | Error _ as error -> error
-  | Ok _container_name ->
-    (match github_identity_snapshot_dir t with
-     | Some path -> Ok path
-     | None -> Error "running container has no GitHub identity snapshot")
+  | Ok central_revision ->
+    (match (Atomic.get t.github_identity_snapshots).current with
+     | None -> ensure_bound ()
+     | Some snapshot when String.equal snapshot.revision central_revision ->
+       ensure_bound ()
+     | Some _ ->
+       (match stop_container_for_github_identity_refresh ?timeout_sec t with
+        | Error _ as error -> error
+        | Ok () -> ensure_bound ()))
 ;;
 
 let run_exec_with_status_split_once

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -20,11 +20,13 @@ val create :
 
 val turn_id : t -> int
 val host_root : t -> string
-val prepare_github_identity_snapshot :
-  ?timeout_sec:float -> t -> (string, string) result
-(** Start the turn container if needed and return the exact host snapshot
-    mounted as its GitHub CLI config. Callers that authorize external effects
-    must invoke this only after authorization. *)
+val prepare_github_identity_secret_files :
+  ?timeout_sec:float -> t -> (string list, string) result
+(** After authorization, observe and bind the container to the current GitHub
+    identity, then return every turn snapshot whose token must remain
+    redacted. The observation is the operation's linearization point: a later
+    central login change is picked up by the next Execute. Superseded snapshots
+    remain redaction-only until turn cleanup. *)
 
 val cleanup : t -> unit
 (** Best-effort teardown. Safe to call multiple times. *)

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -30,10 +30,15 @@ let github_login_stream_headers origin =
      @ Server_auth.cors_headers origin)
 ;;
 
-let github_login_stream_send writer event json =
-  Httpun.Body.Writer.write_string
-    writer
-    (Printf.sprintf "event: %s\ndata: %s\n\n" event (Yojson.Safe.to_string json))
+let github_login_stream_send_with ~write ~flush event json =
+  write (Printf.sprintf "event: %s\ndata: %s\n\n" event (Yojson.Safe.to_string json));
+  flush ()
+;;
+
+let github_login_stream_send writer =
+  github_login_stream_send_with
+    ~write:(Httpun.Body.Writer.write_string writer)
+    ~flush:(fun () -> Httpun.Body.Writer.flush writer (fun _ -> ()))
 ;;
 
 let handle_keeper_github_login_post state req reqd =
@@ -1184,6 +1189,7 @@ let parse_bulk_directive_json json =
 
 module For_testing = struct
   let github_login_stream_headers = github_login_stream_headers
+  let github_login_stream_send_with = github_login_stream_send_with
 
   let parse_resume_request json =
     match parse_keeper_directive_json json with

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -143,6 +143,12 @@ val handle_keeper_bulk_directive_post :
 
 module For_testing : sig
   val github_login_stream_headers : string -> Httpun.Headers.t
+  val github_login_stream_send_with :
+    write:(string -> unit) ->
+    flush:(unit -> unit) ->
+    string ->
+    Yojson.Safe.t ->
+    unit
 
   val parse_resume_request :
     Yojson.Safe.t -> (int * string, string) result

--- a/test/keeper_github_identity/dune
+++ b/test/keeper_github_identity/dune
@@ -13,4 +13,4 @@
   time_compat
   keeper_github_identity
   test_keeper_github_identity)
- (libraries alcotest eio masc.fs_compat masc.masc_eio_context yojson unix))
+ (libraries alcotest digestif eio masc.fs_compat masc.masc_eio_context yojson unix))

--- a/test/keeper_github_identity/test_keeper_github_identity.ml
+++ b/test/keeper_github_identity/test_keeper_github_identity.ml
@@ -385,6 +385,28 @@ let test_malformed_hosts_yaml_is_rejected () =
     Alcotest.fail "malformed hosts.yml was collapsed into unconfigured state"
 ;;
 
+let test_local_snapshot_cleanup_does_not_follow_replacement_symlink () =
+  with_temp_base @@ fun base_path config ->
+  let env, _state, cleanup =
+    match Github.runtime_env_for_tool ~config ~keeper_name:"cleanup-symlink" [||] with
+    | Error message -> Alcotest.fail message
+    | Ok projection -> projection
+  in
+  let snapshot = env_value "GH_CONFIG_DIR" env |> Option.get in
+  let target = Filename.concat base_path "cleanup-target" in
+  Unix.mkdir target 0o755;
+  Unix.chmod snapshot 0o700;
+  Unix.rmdir snapshot;
+  Unix.symlink target snapshot;
+  cleanup ();
+  Alcotest.(check int) "replacement target mode is unchanged" 0o755
+    ((Unix.stat target).Unix.st_perm land 0o777);
+  Alcotest.(check bool) "replacement symlink is removed" false
+    (match Unix.lstat snapshot with
+     | _ -> true
+     | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false)
+;;
+
 let test_observe_does_not_provision_missing_identity () =
   with_temp_base @@ fun base_path config ->
   let keeper_name = "observe-missing-identity" in
@@ -558,6 +580,10 @@ let () =
             "malformed hosts yaml is rejected"
             `Quick
             test_malformed_hosts_yaml_is_rejected
+        ; Alcotest.test_case
+            "local snapshot cleanup does not follow replacement symlink"
+            `Quick
+            test_local_snapshot_cleanup_does_not_follow_replacement_symlink
         ; Alcotest.test_case
             "observation does not provision missing identity"
             `Quick

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -3003,6 +3003,18 @@ let test_keeper_github_login_stream_headers_include_cors () =
     (Httpun.Headers.get headers "access-control-allow-credentials")
 ;;
 
+let test_keeper_github_login_stream_flushes_each_event () =
+  let actions = ref [] in
+  Keeper_config_post.For_testing.github_login_stream_send_with
+    ~write:(fun frame -> actions := !actions @ [ "write:" ^ frame ])
+    ~flush:(fun () -> actions := !actions @ [ "flush" ])
+    "device_code"
+    (`Assoc [ "code", `String "ABCD-EFGH" ]);
+  Alcotest.(check (list string)) "frame is written before it is flushed"
+    [ "write:event: device_code\ndata: {\"code\":\"ABCD-EFGH\"}\n\n"; "flush" ]
+    !actions
+;;
+
 let shrink_base_meta () =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -3501,6 +3513,8 @@ let () =
       ( "dashboard behavior contracts",
         [ test_case "GitHub login stream includes CORS" `Quick
             test_keeper_github_login_stream_headers_include_cors;
+          test_case "GitHub login stream flushes each event" `Quick
+            test_keeper_github_login_stream_flushes_each_event;
           test_case "operator snapshot rejects stale publication races" `Quick
             test_operator_snapshot_publication_rejects_stale_races;
           test_case "operator snapshot error clears previous success" `Quick

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -110,6 +110,11 @@ let mount_source_for_destination line destination =
   in
   loop (String.split_on_char ' ' line)
 
+let mount_sources_for_destination log destination =
+  String.split_on_char '\n' log
+  |> List.filter_map (fun line -> mount_source_for_destination line destination)
+;;
+
 let rec ensure_dir path =
   if path = "" || path = "." || path = "/" then ()
   else if Sys.file_exists path then ()
@@ -900,7 +905,10 @@ if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ]; then\n\
   exit 0\n\
 fi\n\
 if [ \"$1\" = \"inspect\" ]; then\n\
-  printf 'fake-container-id\\n'\n\
+  case \"$3\" in\n\
+    *State.Running*) printf 'true\\n' ;;\n\
+    *) printf 'fake-container-id\\n' ;;\n\
+  esac\n\
   exit 0\n\
 fi\n\
 if [ \"$1\" = \"ps\" ]; then\n\
@@ -1842,6 +1850,7 @@ let test_turn_runtime_redacts_the_mounted_github_snapshot () =
   @@ fun ~config ~meta ~playground ->
   let snapshot_token = "snapshot-token-before-central-rotation" in
   let rotated_token = "central-token-after-container-start" in
+  let relogin_token = "central-token-after-relogin" in
   let github_config_dir =
     match
       Keeper_github_identity.ensure_config_dir
@@ -1852,12 +1861,15 @@ let test_turn_runtime_redacts_the_mounted_github_snapshot () =
     | Error message -> Alcotest.fail message
   in
   let hosts_path = Filename.concat github_config_dir "hosts.yml" in
+  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
   write_file
     hosts_path
     ("github.com:\n  user: keeper-user\n  oauth_token: " ^ snapshot_token ^ "\n");
   Unix.chmod hosts_path 0o600;
   with_env "MASC_STREAM_EXECUTE_OUTPUT" "false" @@ fun () ->
-  with_turn_sandbox_factory ~config ~meta @@ fun factory ->
+  with_env "MASC_KEEPER_TEST_DOCKER_LOG" log_path @@ fun () ->
+  let snapshots = ref [] in
+  with_turn_sandbox_factory ~config ~meta (fun factory ->
   let execute value =
     Keeper_tool_execute_runtime.handle_tool_execute
       ~turn_sandbox_factory:(Some factory)
@@ -1872,10 +1884,50 @@ let test_turn_runtime_redacts_the_mounted_github_snapshot () =
     ("github.com:\n  user: keeper-user\n  oauth_token: " ^ rotated_token ^ "\n");
   Unix.chmod hosts_path 0o600;
   let raw = execute snapshot_token in
-  Alcotest.(check bool) "mounted snapshot token never reaches response" false
+  Alcotest.(check bool) "superseded snapshot token never reaches response" false
     (String_util.contains_substring raw snapshot_token);
   if not (String_util.contains_substring raw "[REDACTED]")
-  then Alcotest.failf "exact snapshot token was not redacted: %s" raw
+  then Alcotest.failf "superseded snapshot token was not redacted: %s" raw;
+  let rotated_raw = execute rotated_token in
+  Alcotest.(check bool) "current snapshot token never reaches response" false
+    (String_util.contains_substring rotated_raw rotated_token);
+  write_file hosts_path "{}\n";
+  Unix.chmod hosts_path 0o600;
+  let logout_raw = execute rotated_token in
+  Alcotest.(check bool) "logout retains previous token redaction" false
+    (String_util.contains_substring logout_raw rotated_token);
+  write_file
+    hosts_path
+    ("github.com:\n  user: keeper-user\n  oauth_token: " ^ relogin_token ^ "\n");
+  Unix.chmod hosts_path 0o600;
+  let relogin_raw = execute relogin_token in
+  Alcotest.(check bool) "re-login snapshot token never reaches response" false
+    (String_util.contains_substring relogin_raw relogin_token);
+  let container_root = Keeper_sandbox.container_root meta.name in
+  let container_masc_dir =
+    Keeper_sandbox_runtime.container_masc_config_dir ~container_root
+    |> Filename.dirname
+  in
+  let github_container_dir =
+    Keeper_github_identity.container_config_dir
+      ~container_masc_dir
+      ~keeper_name:meta.name
+  in
+  snapshots :=
+    mount_sources_for_destination (read_file log_path) github_container_dir
+    |> List.sort_uniq String.compare;
+  Alcotest.(check int) "rotation logout and re-login each mount a fresh snapshot" 4
+    (List.length !snapshots);
+  List.iter
+    (fun snapshot ->
+       Alcotest.(check bool) "turn retains snapshot for redaction" true
+         (Sys.file_exists snapshot))
+    !snapshots);
+  List.iter
+    (fun snapshot ->
+       Alcotest.(check bool) "turn cleanup removes every identity snapshot" false
+         (Sys.file_exists snapshot))
+    !snapshots
 
 let test_execute_allows_validator_safe_pipe_redirect_in_docker_route () =
   with_tool_policy_config @@ fun () ->


### PR DESCRIPTION
## Summary
- refresh a running Docker turn container when its Keeper GitHub identity changes
- retain superseded credential snapshots only for output redaction until turn cleanup
- flush every HTTP/1 GitHub login SSE frame
- make local snapshot cleanup descriptor-bound and non-following
- linearize current/retired snapshot transitions with CAS

## RFC and relation
- RFC: docs/rfc/RFC-per-keeper-github-cli-identity.md
- This PR is the forward-fix for #28215 review findings; it does not replace or precede that merged change.
- The identity revision and snapshot copy use the same closed file set: hosts.yml plus optional config.yml. No other GitHub CLI identity file is projected into a tool runtime.

Forward-fixes review findings from #28215:
- https://github.com/jeong-sik/masc/pull/28215#discussion_r3761263808
- https://github.com/jeong-sik/masc/pull/28215#discussion_r3761263815
- https://github.com/jeong-sik/masc/pull/28215#discussion_r3762232174

## Verification
- focused build: keeper GitHub identity, Docker route, dashboard HTTP core, secret redaction targets
- keeper GitHub identity: 15/15 passed before rebase
- Docker route after rebase: 50/50 passed
- secret redaction: 12/12 passed before rebase
- HTTP/1 SSE flush regression: 1/1 passed before rebase
- Docker same-turn identity sequence: token rotation, logout, and re-login each mounted a fresh snapshot; old and current tokens stayed redacted; all snapshots were removed at turn cleanup

The full dashboard_http_core executable also exposed three pre-existing order-dependent fixture failures outside this diff; the new flush regression passes in isolation.

[근거] exact source at 0a8fcc81d8 and focused Docker executable, 2026-08-12 KST, confidence High
