### PR TITLE
fix(dev): allow concurrent opam switch readers

### DIFF
--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -2,16 +2,16 @@
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-lock_path="${DUNE_LOCAL_LOCK:-/tmp/me-dune-local.lock}"
-opam_lock_path="${MASC_OPAM_LOCK_PATH:-/tmp/me-opam-switch.lock}"
+repo_lock_key="$(printf '%s' "${repo_root}" | cksum | awk '{print $1}')"
+lock_path="${DUNE_LOCAL_LOCK:-${TMPDIR:-/tmp}/masc-dune-${UID:-$(id -u)}-${repo_lock_key}.lock}"
 
 usage() {
   cat <<'USAGE'
 Usage: scripts/dune-local.sh [dune-subcommand] [args...]
 
 Local Dune wrapper for multi-agent development:
-  - serializes local Dune invocations with a machine-wide lock
-  - serializes opam switch validation with external dependency pin mutations
+  - serializes Dune invocations only inside the same worktree
+  - shares one read lease across builds while excluding opam switch mutations
   - defaults local concurrency to DUNE_JOBS, or 2
   - disables the shared Dune artifact cache by default for local builds
   - injects --root <repo-root> unless --root is already present
@@ -21,13 +21,9 @@ Local Dune wrapper for multi-agent development:
 
 Set MASC_DUNE_THROTTLE=0 to bypass the local lock.
 Set MASC_DUNE_CACHE=enabled or enabled-except-user-rules to opt into the shared Dune cache.
-Set MASC_SKIP_OPAM_LOCK=1 to bypass the shared opam switch lock.
-Set MASC_OPAM_LOCK_PATH=/path/to/lock to override the shared opam lock path.
-Set MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=seconds to bound opam-lock wait after the Dune lock (0 = wait forever).
 Set MASC_DUNE_LOCK_DIAG=0 to suppress best-effort lock holder diagnostics.
 Set MASC_DUNE_DRY_RUN=1 to print the command without running it.
 Set MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 to wait behind a live _build/.lock holder.
-Set MASC_DUNE_ALLOW_BARE_DUNE=1 to run despite a live Dune process outside this wrapper.
 Set MASC_SKIP_DEPS_CHECK=1 to skip the required-findlib guard.
 Set MASC_SKIP_OCAML_VERSION_CHECK=1 to skip the exact OCaml toolchain guard.
 USAGE
@@ -152,119 +148,8 @@ _print_lock_holders() {
   done <<< "$pids"
 }
 
-_list_unwrapped_dune_processes() {
-  command -v ps >/dev/null 2>&1 || return 0
-
-  ps ax -o pid=,ppid=,command= 2>/dev/null \
-    | awk '
-        /^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+/ {
-          pid = $1
-          ppid = $2
-          $1 = ""
-          $2 = ""
-          sub(/^[[:space:]]+/, "", $0)
-          parent[pid] = ppid
-          cmd[pid] = $0
-        }
-
-        function has_wrapper_ancestor(pid, cur, depth) {
-          cur = pid
-          depth = 0
-          while ((cur in cmd) && depth < 64) {
-            if (cmd[cur] ~ /dune-local[.]sh/ ||
-                cmd[cur] ~ /me-dune-local[.]lock/ ||
-                cmd[cur] ~ /MASC_DUNE_LOCK_HELD=1/) {
-              return 1
-            }
-            cur = parent[cur]
-            depth++
-          }
-          return 0
-        }
-
-        function basename(token, parts, n) {
-          n = split(token, parts, "/")
-          return parts[n]
-        }
-
-        function is_dune_subcommand(token) {
-          return token == "build" || token == "test" || token == "exec" || token == "runtest" || token == "clean"
-        }
-
-        function is_dune_option(token) {
-          return token ~ /^--[[:alnum:]][[:alnum:]_-]*(=.*)?$/ ||
-                 token ~ /^-[[:alnum:]][[:alnum:]_-]*$/
-        }
-
-        function dune_subcommand_index(argc, argv, dune_index, i, token) {
-          i = dune_index + 1
-          while (i <= argc) {
-            token = argv[i]
-            if (is_dune_subcommand(token)) {
-              return i
-            } else if (token ~ /^--[[:alnum:]][[:alnum:]_-]*=/) {
-              i++
-            } else if (is_dune_option(token) && i + 1 <= argc && !is_dune_subcommand(argv[i + 1]) && argv[i + 1] !~ /^-/) {
-              i += 2
-            } else if (is_dune_option(token)) {
-              i++
-            } else {
-              return 0
-            }
-          }
-          return 0
-        }
-
-        function is_dune_command(text, argv, argc, i) {
-          argc = split(text, argv, /[[:space:]]+/)
-          if (argc < 2) {
-            return 0
-          }
-          if (basename(argv[1]) == "dune") {
-            return dune_subcommand_index(argc, argv, 1) > 0
-          }
-          if (basename(argv[1]) == "opam" && argv[2] == "exec") {
-            for (i = 3; i <= argc; i++) {
-              if (basename(argv[i]) == "dune") {
-                return dune_subcommand_index(argc, argv, i) > 0
-              }
-            }
-          }
-          return 0
-        }
-
-        END {
-          for (pid in cmd) {
-            if (is_dune_command(cmd[pid]) && !has_wrapper_ancestor(pid)) {
-              printf "%s %s %s\n", pid, parent[pid], cmd[pid]
-            }
-          }
-        }'
-}
-
-_check_unwrapped_dune_processes() {
-  [[ "${GITHUB_ACTIONS:-}" != "true" ]] || return 0
-  [[ "${MASC_DUNE_DRY_RUN:-0}" != "1" ]] || return 0
-  [[ "${MASC_DUNE_ALLOW_BARE_DUNE:-0}" != "1" ]] || return 0
-  [[ "${_subcommand}" != "clean" ]] || return 0
-
-  local rows
-  rows="$(_list_unwrapped_dune_processes || true)"
-  [[ -n "$rows" ]] || return 0
-
-  printf '[dune-local] live Dune process outside scripts/dune-local.sh detected:\n' >&2
-  printf '%s\n' "$rows" | sed 's/^/[dune-local]   /' >&2
-  printf '[dune-local] refusing to start another local build while the machine-wide Dune lock is bypassed\n' >&2
-  printf '[dune-local] stop the bare Dune process, rerun it via scripts/dune-local.sh, or set MASC_DUNE_ALLOW_BARE_DUNE=1 to proceed anyway\n' >&2
-  exit 75
-}
-
-_check_unwrapped_dune_processes
-
-# Acquire the build throttle before the opam-switch lock.  The opam lock is
-# intentionally held while the active build uses the shared switch, but queued
-# builds must not hold it while waiting for the Dune throttle; otherwise stale
-# worktrees can block pin repair before they are actually compiling.
+# This throttle is scoped by the canonical worktree path. Dune already gives
+# each worktree its own build directory, so unrelated Keepers do not queue here.
 if _needs_dune_lock; then
   printf '[dune-local] waiting for lock %s\n' "$lock_path" >&2
   _print_lock_holders "$lock_path" "Dune"
@@ -279,104 +164,19 @@ if _needs_dune_lock; then
   fi
 fi
 
-_check_unwrapped_dune_processes
-
-_needs_opam_lock() {
+_needs_opam_read_lease() {
   [[ "${GITHUB_ACTIONS:-}" != "true" ]] || return 1
-  # MASC_OPAM_LOCK=0 was retired (masc#25123 Wave 2): MASC_SKIP_OPAM_LOCK=1
-  # is the single opt-out. Warn so an operator habit does not silently stop
-  # working.
-  if [[ "${MASC_OPAM_LOCK:-1}" == "0" ]]; then
-    echo "[dune-local] MASC_OPAM_LOCK is retired and ignored; use MASC_SKIP_OPAM_LOCK=1" >&2
-  fi
-  [[ "${MASC_SKIP_OPAM_LOCK:-0}" != "1" ]] || return 1
   [[ "${MASC_DUNE_DRY_RUN:-0}" != "1" ]] || return 1
   [[ "${_subcommand}" != "clean" ]] || return 1
-  [[ "${MASC_OPAM_LOCK_HELD:-0}" != "1" ]] || return 1
+  [[ "${MASC_OPAM_READ_LEASE_HELD:-0}" != "1" ]] || return 1
   command -v opam >/dev/null 2>&1 || return 1
   return 0
 }
 
-if _needs_opam_lock; then
-  printf '[dune-local] waiting for opam switch lock %s\n' "$opam_lock_path" >&2
-  _print_lock_holders "$opam_lock_path" "opam switch"
-  # Apply the bounded-wait deadlock guard whenever this invocation is
-  # already holding the Dune lock AND the operator opted in by setting
-  # MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=<positive integer>. Default is
-  # unset, which preserves the historical "wait indefinitely" semantics
-  # so existing operators are not surprised by builds that suddenly
-  # fail under long-lived opam lock holders.
-  opam_bounded_wait=0
-  opam_lock_timeout=""
-  if [[ "${MASC_DUNE_LOCK_HELD:-0}" = "1" \
-        && -n "${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT:-}" ]]; then
-    opam_lock_timeout="${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT}"
-    if ! [[ "$opam_lock_timeout" =~ ^[0-9]+$ ]]; then
-      printf '[dune-local] invalid MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=%q; expected non-negative integer seconds\n' \
-        "$opam_lock_timeout" >&2
-      exit 2
-    fi
-    opam_lock_timeout="$((10#$opam_lock_timeout))"
-    if (( opam_lock_timeout > 0 )); then
-      opam_bounded_wait=1
-    fi
-  fi
-  if command -v lockf >/dev/null 2>&1; then
-    if [[ "$opam_bounded_wait" = "1" ]]; then
-      set +e
-      env_cmd="${ENV_CMD:-/usr/bin/env}"
-      lockf -k -t "$opam_lock_timeout" "$opam_lock_path" \
-        "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
-      status=$?
-      set -e
-      if [[ "$status" -eq 0 ]]; then
-        exit 0
-      fi
-      if [[ "$status" -eq 75 ]]; then
-        printf '[dune-local] opam switch lock stayed busy for %ss after acquiring Dune lock; releasing Dune lock to avoid mixed lock-order deadlock\n' \
-          "$opam_lock_timeout" >&2
-        printf '[dune-local] retry after older dune-local invocations drain, or unset MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT (or set =0) to wait indefinitely\n' >&2
-      fi
-      exit "$status"
-    fi
-    env_cmd="${ENV_CMD:-/usr/bin/env}"
-    exec lockf -k "$opam_lock_path" "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
-  elif command -v flock >/dev/null 2>&1; then
-    if [[ "$opam_bounded_wait" = "1" ]]; then
-      # flock(1) honors -w/--timeout to bound the wait; without it the
-      # mixed-lock-order deadlock the lockf branch above already handles
-      # would resurface on flock-only hosts (Linux without lockf).
-      set +e
-      env_cmd="${ENV_CMD:-/usr/bin/env}"
-      flock -w "$opam_lock_timeout" "$opam_lock_path" \
-        "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
-      status=$?
-      set -e
-      if [[ "$status" -eq 0 ]]; then
-        exit 0
-      fi
-      # flock returns 1 when the lock cannot be acquired within the
-      # timeout (vs >1 for command failures). Match the lockf message
-      # so operators see consistent diagnostics across hosts.
-      if [[ "$status" -eq 1 ]]; then
-        printf '[dune-local] opam switch lock stayed busy for %ss after acquiring Dune lock; releasing Dune lock to avoid mixed lock-order deadlock\n' \
-          "$opam_lock_timeout" >&2
-        printf '[dune-local] retry after older dune-local invocations drain, or unset MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT (or set =0) to wait indefinitely\n' >&2
-      fi
-      exit "$status"
-    fi
-    env_cmd="${ENV_CMD:-/usr/bin/env}"
-    exec flock "$opam_lock_path" "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
-  elif [[ "$dune_lock_warning_emitted" != "1" ]]; then
-    # Skip the warning when the Dune-lock branch above already printed
-    # an equivalent "neither lockf nor flock found" message in this
-    # process. The Dune-lock branch tracks that via the local
-    # [dune_lock_warning_emitted] flag (not MASC_DUNE_LOCK_HELD, which
-    # is only set when the Dune lock was actually acquired); using the
-    # flag avoids the case where opam is available but neither lock
-    # tool is, where the env-var check would let both warnings print.
-    printf '[dune-local] warning: neither lockf nor flock found; opam switch checks are unlocked\n' >&2
-  fi
+if _needs_opam_read_lease; then
+  exec "$(dirname "${script_path}")/opam-switch-rw-lock.sh" \
+    read -- "${ENV_CMD:-/usr/bin/env}" MASC_OPAM_READ_LEASE_HELD=1 \
+    "${script_path}" "$@"
 fi
 
 if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
@@ -403,9 +203,8 @@ fi
 # socket, or exclusive-lock spin on a stale file).
 #
 # This guard removes stale artifacts when no live Dune process holds them.
-# It runs after the machine-wide dune-local lock is acquired, so no other
-# dune-local.sh wrapper is active — but a bare `dune` invocation outside
-# the wrapper could still hold them.
+# It runs after the worktree-local wrapper lock is acquired. Other worktrees
+# use independent build directories and do not participate in this decision.
 #
 # Skipped when:
 #   GITHUB_ACTIONS=true     – CI builds are clean-workspace

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -28,25 +28,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-opam_lock_path="${MASC_OPAM_LOCK_PATH:-/tmp/me-opam-switch.lock}"
 
-if [[ "${MASC_OPAM_LOCK:-1}" == "0" ]]; then
-  # Retired alias (masc#25123 Wave 2): MASC_SKIP_OPAM_LOCK=1 is the single
-  # opt-out.
-  echo "[opam-pin] MASC_OPAM_LOCK is retired and ignored; use MASC_SKIP_OPAM_LOCK=1" >&2
-fi
-if [[ "${MASC_SKIP_OPAM_LOCK:-0}" != "1" \
-      && "${MASC_OPAM_LOCK_HELD:-0}" != "1" ]]; then
+if [[ "${MASC_OPAM_WRITE_LEASE_HELD:-0}" != "1" ]]; then
   script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
-  env_cmd="${ENV_CMD:-/usr/bin/env}"
-  echo "[opam-pin] waiting for opam switch lock ${opam_lock_path}" >&2
-  if command -v lockf >/dev/null 2>&1; then
-    exec lockf -k "$opam_lock_path" "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
-  elif command -v flock >/dev/null 2>&1; then
-    exec flock "$opam_lock_path" "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
-  else
-    echo "[opam-pin] WARN: neither lockf nor flock found; mutating opam switch unlocked" >&2
-  fi
+  exec "${SCRIPT_DIR}/opam-switch-rw-lock.sh" \
+    write -- "${ENV_CMD:-/usr/bin/env}" MASC_OPAM_WRITE_LEASE_HELD=1 \
+    "${script_path}" "$@"
 fi
 
 # Refuse to mutate a different or unsupported switch.  This script is the

--- a/scripts/opam-switch-rw-lock.sh
+++ b/scripts/opam-switch-rw-lock.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/opam-switch-rw-lock.sh read|write -- command [args...]" >&2
+  exit 2
+}
+
+mode="${1:-}"
+shift
+case "${mode}" in
+  read|write)
+    [[ "${1:-}" = "--" ]] || usage
+    shift
+    [[ "$#" -gt 0 ]] || usage
+    ;;
+  __run_read)
+    reader_path="${1:-}"
+    shift
+    [[ -n "${reader_path}" && "${1:-}" = "--" ]] || usage
+    shift
+    [[ "$#" -gt 0 ]] || usage
+    ;;
+  __run_write)
+    [[ "${1:-}" = "--" ]] || usage
+    shift
+    [[ "$#" -gt 0 ]] || usage
+    ;;
+  __admit_read)
+    reader_path="${1:-}"
+    [[ -n "${reader_path}" && "$#" -eq 1 ]] || usage
+    ;;
+  __admit_write)
+    [[ "$#" -eq 0 ]] || usage
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+switch_identity="${OPAM_SWITCH_PREFIX:-}"
+if [[ -z "${switch_identity}" ]] && command -v opam >/dev/null 2>&1; then
+  switch_identity="$(opam var prefix 2>/dev/null || true)"
+fi
+[[ -n "${switch_identity}" ]] || {
+  echo "[opam-rw-lock] cannot resolve the active opam switch prefix" >&2
+  exit 69
+}
+
+switch_key="$(printf '%s' "${switch_identity}" | cksum | awk '{print $1}')"
+lock_base="${MASC_OPAM_LOCK_PATH:-${TMPDIR:-/tmp}/masc-opam-switch-${UID:-$(id -u)}-${switch_key}}"
+gate_path="${lock_base}.gate"
+state_dir="${lock_base}.state"
+readers_dir="${state_dir}/readers"
+writer_path="${state_dir}/writer"
+script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+prepare_state_dir() {
+  mkdir -p "${readers_dir}"
+  chmod 700 "${state_dir}" "${readers_dir}"
+}
+
+lock_backend() {
+  if command -v lockf >/dev/null 2>&1; then
+    printf 'lockf\n'
+  elif command -v flock >/dev/null 2>&1; then
+    printf 'flock\n'
+  else
+    echo "[opam-rw-lock] neither lockf nor flock is available" >&2
+    return 69
+  fi
+}
+
+with_gate() {
+  case "$(lock_backend)" in
+    lockf) lockf -k -t 5 "${gate_path}" "$@" ;;
+    flock) flock -w 5 -E 75 "${gate_path}" "$@" ;;
+  esac
+}
+
+exec_holder() {
+  local holder_mode="$1"
+  local holder_path="$2"
+  shift 2
+  case "$(lock_backend)" in
+    lockf)
+      if [[ "${holder_mode}" = "write" ]]; then
+        exec lockf -k -t 0 "${holder_path}" "$@"
+      else
+        exec lockf -k "${holder_path}" "$@"
+      fi
+      ;;
+    flock)
+      exec flock -n -E 75 "${holder_path}" "$@"
+      ;;
+  esac
+}
+
+probe_lock_state() {
+  local path="$1"
+  local status=0
+  set +e
+  case "$(lock_backend)" in
+    lockf) lockf -k -t 0 "${path}" true >/dev/null 2>&1 ;;
+    flock) flock -n -E 75 "${path}" true >/dev/null 2>&1 ;;
+  esac
+  status=$?
+  set -e
+  case "${status}" in
+    0) printf 'free\n' ;;
+    75) printf 'held\n' ;;
+    *)
+      echo "[opam-rw-lock] lock probe failed path=${path} exit=${status}" >&2
+      return 69
+      ;;
+  esac
+}
+
+clean_stale_readers() {
+  local reader_path=""
+  local state=""
+  for reader_path in "${readers_dir}"/*; do
+    [[ -f "${reader_path}" ]] || continue
+    state="$(probe_lock_state "${reader_path}")"
+    if [[ "${state}" = "free" ]]; then
+      rm -f "${reader_path}"
+    fi
+  done
+}
+
+active_reader_paths() {
+  local reader_path=""
+  local state=""
+  for reader_path in "${readers_dir}"/*; do
+    [[ -f "${reader_path}" ]] || continue
+    state="$(probe_lock_state "${reader_path}")"
+    if [[ "${state}" = "held" ]]; then
+      printf '%s\n' "${reader_path}"
+    fi
+  done
+}
+
+admit_read() {
+  local writer_state="free"
+  clean_stale_readers
+  if [[ -f "${writer_path}" ]]; then
+    writer_state="$(probe_lock_state "${writer_path}")"
+    if [[ "${writer_state}" = "held" ]]; then
+      echo "[opam-rw-lock] switch mutation is active; read lease rejected" >&2
+      return 75
+    fi
+    rm -f "${writer_path}"
+  fi
+}
+
+admit_write() {
+  local readers=""
+  clean_stale_readers
+  readers="$(active_reader_paths)"
+  if [[ -n "${readers}" ]]; then
+    echo "[opam-rw-lock] switch readers are active holders=$(printf '%s' "${readers}" | tr '\n' ',')" >&2
+    return 75
+  fi
+}
+
+prepare_state_dir
+case "${mode}" in
+  read)
+    reader_path="$(mktemp "${readers_dir%/}/reader.XXXXXX")"
+    chmod 600 "${reader_path}"
+    exec_holder read "${reader_path}" "${script_path}" __run_read "${reader_path}" -- "$@"
+    ;;
+  write)
+    exec_holder write "${writer_path}" "${script_path}" __run_write -- "$@"
+    ;;
+  __run_read)
+    with_gate "${script_path}" __admit_read "${reader_path}"
+    export MASC_OPAM_READ_LEASE_HELD=1
+    exec "$@"
+    ;;
+  __run_write)
+    with_gate "${script_path}" __admit_write
+    export MASC_OPAM_WRITE_LEASE_HELD=1
+    exec "$@"
+    ;;
+  __admit_read)
+    admit_read
+    ;;
+  __admit_write)
+    admit_write
+    ;;
+esac

--- a/scripts/opam-switch-rw-lock.sh
+++ b/scripts/opam-switch-rw-lock.sh
@@ -59,6 +59,7 @@ state_dir="${lock_base}.state"
 readers_dir="${state_dir}/readers"
 writer_path="${state_dir}/writer"
 script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+readonly gate_timeout_seconds=5
 
 prepare_state_dir() {
   mkdir -p "${readers_dir}"
@@ -77,39 +78,68 @@ lock_backend() {
 }
 
 with_gate() {
-  case "$(lock_backend)" in
-    lockf) lockf -k -t 5 "${gate_path}" "$@" ;;
-    flock) flock -w 5 -E 75 "${gate_path}" "$@" ;;
+  local backend=""
+  local status=0
+  backend="$(lock_backend)" || return $?
+  set +e
+  case "${backend}" in
+    lockf)
+      lockf -k -t "${gate_timeout_seconds}" "${gate_path}" "$@"
+      status=$?
+      ;;
+    flock)
+      flock -w "${gate_timeout_seconds}" -E 75 "${gate_path}" "$@"
+      status=$?
+      ;;
+    *)
+      echo "[opam-rw-lock] unknown lock backend ${backend}" >&2
+      status=69
+      ;;
   esac
+  set -e
+  if [[ "${status}" -eq 75 ]]; then
+    echo "[opam-rw-lock] gate acquisition or lease admission rejected within ${gate_timeout_seconds}s" >&2
+  fi
+  return "${status}"
 }
 
 exec_holder() {
   local holder_mode="$1"
   local holder_path="$2"
+  local backend=""
   shift 2
-  case "$(lock_backend)" in
+  backend="$(lock_backend)" || return $?
+  case "${backend}" in
     lockf)
-      if [[ "${holder_mode}" = "write" ]]; then
-        exec lockf -k -t 0 "${holder_path}" "$@"
-      else
-        exec lockf -k "${holder_path}" "$@"
-      fi
+      exec lockf -k -t 0 "${holder_path}" "$@"
       ;;
     flock)
       exec flock -n -E 75 "${holder_path}" "$@"
+      ;;
+    *)
+      echo "[opam-rw-lock] unknown lock backend ${backend}" >&2
+      return 69
       ;;
   esac
 }
 
 probe_lock_state() {
   local path="$1"
+  local backend=""
   local status=0
+  backend="$(lock_backend)" || return $?
   set +e
-  case "$(lock_backend)" in
-    lockf) lockf -k -t 0 "${path}" true >/dev/null 2>&1 ;;
-    flock) flock -n -E 75 "${path}" true >/dev/null 2>&1 ;;
+  case "${backend}" in
+    lockf)
+      lockf -k -t 0 "${path}" true >/dev/null 2>&1
+      status=$?
+      ;;
+    flock)
+      flock -n -E 75 "${path}" true >/dev/null 2>&1
+      status=$?
+      ;;
+    *) status=69 ;;
   esac
-  status=$?
   set -e
   case "${status}" in
     0) printf 'free\n' ;;

--- a/scripts/opam-switch-rw-lock.sh
+++ b/scripts/opam-switch-rw-lock.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Exit 75 is reserved for lease-admission rejection. After admission, the
+# wrapped command's status (including 75) is forwarded unchanged; callers that
+# need to distinguish them must also inspect the explicit admission diagnostic.
+
 usage() {
   echo "usage: scripts/opam-switch-rw-lock.sh read|write -- command [args...]" >&2
   exit 2
@@ -28,7 +32,8 @@ case "${mode}" in
     ;;
   __admit_read)
     reader_path="${1:-}"
-    [[ -n "${reader_path}" && "$#" -eq 1 ]] || usage
+    reader_identity="${2:-}"
+    [[ -n "${reader_path}" && -n "${reader_identity}" && "$#" -eq 2 ]] || usage
     ;;
   __admit_write)
     [[ "$#" -eq 0 ]] || usage
@@ -116,6 +121,17 @@ probe_lock_state() {
   esac
 }
 
+file_identity() {
+  local path="$1"
+  if stat -f '%d:%i' "${path}" >/dev/null 2>&1; then
+    stat -f '%d:%i' "${path}"
+  elif stat -c '%d:%i' "${path}" >/dev/null 2>&1; then
+    stat -c '%d:%i' "${path}"
+  else
+    return 1
+  fi
+}
+
 clean_stale_readers() {
   local reader_path=""
   local state=""
@@ -141,15 +157,28 @@ active_reader_paths() {
 }
 
 admit_read() {
+  local reader_path="$1"
+  local expected_reader_identity="$2"
+  local current_reader_identity=""
+  local reader_state="free"
   local writer_state="free"
   clean_stale_readers
+  current_reader_identity="$(file_identity "${reader_path}" 2>/dev/null || true)"
+  if [[ -z "${current_reader_identity}" || "${current_reader_identity}" != "${expected_reader_identity}" ]]; then
+    echo "[opam-rw-lock] reader lease path no longer names its locked inode; read lease rejected" >&2
+    return 75
+  fi
+  reader_state="$(probe_lock_state "${reader_path}")"
+  if [[ "${reader_state}" != "held" ]]; then
+    echo "[opam-rw-lock] reader lease path is not held; read lease rejected" >&2
+    return 75
+  fi
   if [[ -f "${writer_path}" ]]; then
     writer_state="$(probe_lock_state "${writer_path}")"
     if [[ "${writer_state}" = "held" ]]; then
       echo "[opam-rw-lock] switch mutation is active; read lease rejected" >&2
       return 75
     fi
-    rm -f "${writer_path}"
   fi
 }
 
@@ -174,7 +203,12 @@ case "${mode}" in
     exec_holder write "${writer_path}" "${script_path}" __run_write -- "$@"
     ;;
   __run_read)
-    with_gate "${script_path}" __admit_read "${reader_path}"
+    reader_identity="$(file_identity "${reader_path}" 2>/dev/null || true)"
+    if [[ -z "${reader_identity}" ]]; then
+      echo "[opam-rw-lock] reader lease path disappeared before admission; read lease rejected" >&2
+      exit 75
+    fi
+    with_gate "${script_path}" __admit_read "${reader_path}" "${reader_identity}"
     export MASC_OPAM_READ_LEASE_HELD=1
     exec "$@"
     ;;
@@ -184,7 +218,7 @@ case "${mode}" in
     exec "$@"
     ;;
   __admit_read)
-    admit_read
+    admit_read "${reader_path}" "${reader_identity}"
     ;;
   __admit_write)
     admit_write

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -524,6 +524,105 @@ test "$status" -eq 75
            stderr
            "no longer names its locked inode"))
 
+let minimal_lock_script_path dir =
+  let bin_dir = Filename.concat dir "minimal-bin" in
+  mkdir_p bin_dir;
+  List.iter
+    (fun (name, target) ->
+       write_executable
+         (Filename.concat bin_dir name)
+         (Printf.sprintf "#!/bin/sh\nexec %s \"$@\"\n" target))
+    [ "awk", "/usr/bin/awk"
+    ; "basename", "/usr/bin/basename"
+    ; "bash", "/bin/bash"
+    ; "chmod", "/bin/chmod"
+    ; "dirname", "/usr/bin/dirname"
+    ; "mkdir", "/bin/mkdir"
+    ];
+  write_executable
+    (Filename.concat bin_dir "cksum")
+    "#!/bin/sh\nprintf '1 1\\n'\n";
+  bin_dir
+;;
+
+let run_lock_script ~dir ~bin_dir ~lock_base ~marker =
+  run_process
+    ~cwd:dir
+    "/bin/bash"
+    ~env:
+      [ "PATH", bin_dir
+      ; "OPAM_SWITCH_PREFIX", "/tmp/masc-test-switch"
+      ; "MASC_OPAM_LOCK_PATH", lock_base
+      ]
+    [| "/bin/bash"
+     ; opam_switch_rw_lock_script_path ()
+     ; "write"
+     ; "--"
+     ; "/bin/sh"
+     ; "-c"
+     ; "touch " ^ quote marker
+    |]
+;;
+
+let test_opam_lock_backend_absence_fails_closed () =
+  with_temp_dir "opam-switch-rw-lock-no-backend" (fun dir ->
+    let bin_dir = minimal_lock_script_path dir in
+    let marker = Filename.concat dir "wrapped-command-ran" in
+    let code, _stdout, stderr =
+      run_lock_script
+        ~dir
+        ~bin_dir
+        ~lock_base:(Filename.concat dir "switch")
+        ~marker
+    in
+    check int "missing lock tools fail closed" 69 code;
+    check bool "wrapped command did not run" false (Sys.file_exists marker);
+    check bool
+      "missing backend is explicit"
+      true
+      (String_util.contains_substring
+         stderr
+         "neither lockf nor flock is available"))
+;;
+
+let test_opam_gate_timeout_has_admission_diagnostic () =
+  with_temp_dir "opam-switch-rw-lock-gate-timeout" (fun dir ->
+    let bin_dir = minimal_lock_script_path dir in
+    write_executable
+      (Filename.concat bin_dir "lockf")
+      {|#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -k) shift ;;
+    -t) shift 2 ;;
+    *) break ;;
+  esac
+done
+lock_path="$1"
+shift
+case "$lock_path" in
+  *.gate) exit 75 ;;
+  *) exec "$@" ;;
+esac
+|};
+    let marker = Filename.concat dir "wrapped-command-ran" in
+    let code, _stdout, stderr =
+      run_lock_script
+        ~dir
+        ~bin_dir
+        ~lock_base:(Filename.concat dir "switch")
+        ~marker
+    in
+    check int "gate timeout is admission rejection" 75 code;
+    check bool "wrapped command did not run" false (Sys.file_exists marker);
+    check bool
+      "gate timeout is explicit"
+      true
+      (String_util.contains_substring
+         stderr
+         "gate acquisition or lease admission rejected within 5s"))
+;;
+
 let test_dune_runs_under_opam_read_lease () =
   with_temp_dir "dune-local-opam-read-lease" (fun dir ->
       let bin_dir, dune_log = setup_fake_repo dir in
@@ -838,6 +937,10 @@ let () =
             test_opam_read_leases_overlap_and_exclude_writer;
           test_case "opam reader admission requires its held inode" `Quick
             test_opam_reader_admission_requires_held_inode_and_keeps_writer_file;
+          test_case "missing opam lock tools fail closed" `Quick
+            test_opam_lock_backend_absence_fails_closed;
+          test_case "opam gate timeout emits admission diagnostic" `Quick
+            test_opam_gate_timeout_has_admission_diagnostic;
           test_case "Dune executes under an opam read lease" `Quick
             test_dune_runs_under_opam_read_lease;
           test_case "clean subcommand reaches Dune" `Quick

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -8,6 +8,11 @@ let source_root () =
 let dune_local_script_path () =
   Filename.concat (Filename.concat (source_root ()) "scripts") "dune-local.sh"
 
+let opam_switch_rw_lock_script_path () =
+  Filename.concat
+    (Filename.concat (source_root ()) "scripts")
+    "opam-switch-rw-lock.sh"
+
 let quote = Filename.quote
 
 let read_file path =
@@ -128,18 +133,24 @@ let setup_fake_repo ?(ocaml_version = "5.5.0") base =
   write_executable
     (Filename.concat scripts_dir "dune-local.sh")
     (read_file (dune_local_script_path ()));
+  write_executable
+    (Filename.concat scripts_dir "opam-switch-rw-lock.sh")
+    (read_file (opam_switch_rw_lock_script_path ()));
   (* Fake opam: present in PATH and echoes back the queried package
      for `opam list --installed --short PKG` so the deps-installed
      guard treats core deps as present. Other
      subcommands return 0 with empty stdout. *)
   write_executable (Filename.concat bin_dir "opam")
-    {|#!/bin/sh
+    (Printf.sprintf
+       {|#!/bin/sh
 if [ "$1" = "list" ] && [ "$2" = "--installed" ] && [ -n "$4" ]; then
-  printf '%s\n' "$4"; exit 0
+  printf '%%s\n' "$4"; exit 0
 fi
 if [ "$1" = "switch" ] && [ "$2" = "show" ]; then printf 'fake-switch\n'; exit 0; fi
+if [ "$1" = "var" ] && [ "$2" = "prefix" ]; then printf '%%s\n' %s; exit 0; fi
 exit 0
-|};
+|}
+       (quote base));
   (* Fake findlib/ocamlobjinfo provider surface. Keep this deterministic so
      tests never inspect the real opam switch. *)
   let fake_llm_provider_dir =
@@ -189,7 +200,7 @@ exit 0
     (Printf.sprintf
        {|#!/bin/sh
 if [ "${1:-}" = "--version" ]; then printf '3.21.0\n'; exit 0; fi
-printf '%%s\n' "${1:-build}" >> %s
+printf '%%s read_lease=%%s\n' "${1:-build}" "${MASC_OPAM_READ_LEASE_HELD:-0}" >> %s
 exit 0
 |}
        (quote dune_log));
@@ -207,16 +218,6 @@ let run_dune_local base bin_dir ?(env = []) ?(unset_env = []) subcommand =
   in
   let path = Printf.sprintf "%s:%s" bin_dir system_path in
   let lock_path = Filename.concat base "dune-local.lock" in
-  let opam_lock_path = Filename.concat base "opam-switch.lock" in
-  (* Most tests exercise fake Dune behavior inside an isolated temp repo. The
-     production bare-Dune guard scans the host process table, so unrelated
-     developer Dune processes would otherwise make these hermetic tests flaky.
-     Tests that target the guard pass [~unset_env] for this variable. *)
-  let allow_bare_dune_env =
-    if List.exists (String.equal "MASC_DUNE_ALLOW_BARE_DUNE") unset_env
-    then []
-    else [ ("MASC_DUNE_ALLOW_BARE_DUNE", "1") ]
-  in
   let default_skip_env name =
     if List.exists (String.equal name) unset_env || List.mem_assoc name env
     then []
@@ -228,11 +229,9 @@ let run_dune_local base bin_dir ?(env = []) ?(unset_env = []) subcommand =
       ("GIT_CEILING_DIRECTORIES", base);
       ("DUNE_LOCAL_LOCK", lock_path);
       ("DUNE_BUILD_DIR", Filename.concat base "_build");
-      ("MASC_OPAM_LOCK_PATH", opam_lock_path);
       ("MASC_DUNE_LOCK_HELD", "0");
-      ("MASC_OPAM_LOCK_HELD", "0");
+      ("MASC_OPAM_READ_LEASE_HELD", "0");
     ]
-    @ allow_bare_dune_env
     @ default_skip_env "MASC_SKIP_DEPS_CHECK"
     @ default_skip_env "MASC_SKIP_OCAML_VERSION_CHECK"
     @ List.filter
@@ -279,31 +278,9 @@ printf '%%s\n' "${1:-build}" >> %s
 exit 0
 |}
            (quote dune_log));
-      let opam_lock_path = Filename.concat dir "opam.lock" in
-      let lockf_log = Filename.concat dir "lockf-calls.log" in
-      write_executable
-        (Filename.concat bin_dir "lockf")
-        (Printf.sprintf
-           {|#!/bin/sh
-printf 'argv=%%s\n' "$*" >> %s
-while [ "${1#-}" != "$1" ]; do
-  case "$1" in
-    -t) shift 2 ;;
-    *) shift ;;
-  esac
-done
-lock_path="$1"
-printf 'lock=%%s\n' "$lock_path" >> %s
-if [ "$lock_path" = %s ]; then exit 97; fi
-shift
-exec "$@"
-|}
-           (quote lockf_log) (quote lockf_log) (quote opam_lock_path));
       (* Use a minimal PATH (no opam install directories) so that
          'command -v opam' fails and the guard is skipped.
-         opam is typically in ~/.opam/SWITCH/bin/, not in /usr/bin or /bin.
-         The bare-Dune guard is not under test here, so keep the isolated fake
-         repo independent of host Dune processes. *)
+         opam is typically in ~/.opam/SWITCH/bin/, not in /usr/bin or /bin. *)
       let minimal_path = Printf.sprintf "%s:/usr/bin:/bin" bin_dir in
       let lock_path = Filename.concat dir "dune-local.lock" in
       let script = Filename.concat scripts_dir "dune-local.sh" in
@@ -314,8 +291,6 @@ exec "$@"
               ("PATH", minimal_path);
               ("GIT_CEILING_DIRECTORIES", dir);
               ("DUNE_LOCAL_LOCK", lock_path);
-              ("MASC_OPAM_LOCK_PATH", opam_lock_path);
-              ("MASC_DUNE_ALLOW_BARE_DUNE", "1");
             ]
           ~unset_env:[ "GITHUB_ACTIONS" ]
           [| "/bin/bash"; script; "build" |]
@@ -323,11 +298,6 @@ exec "$@"
       check int "exits non-zero when opam absent" 1 code;
       check_contains "opam requirement is explicit" stderr
         "opam is unavailable; MASC requires an opam-managed OCaml 5.5.0 switch";
-      let lock_log =
-        if Sys.file_exists lockf_log then read_file lockf_log else ""
-      in
-      check bool "opam lockf not invoked" false
-        (String_util.contains_substring lock_log opam_lock_path);
       check bool "dune was not invoked" false (Sys.file_exists dune_log))
 
 let test_dune_lock_wait_reports_holder () =
@@ -424,453 +394,94 @@ exit 1
         (String_util.contains_substring stderr "bare `dune` process");
       check bool "dune was not invoked" false (Sys.file_exists dune_log))
 
-let write_bare_dune_ps bin_dir =
-  write_executable
-    (Filename.concat bin_dir "ps")
-    {|#!/bin/sh
-if [ "${1:-}" = "ax" ]; then
-  cat <<'PS'
- 111 1 dune exec --root . test/test_config_dir_resolver.exe
- 112 1 dune --root . build
- 113 1 opam exec -- dune --build-dir _build test
- 114 1 dune clean --root .
- 222 333 dune build --root wrapped-worktree
- 333 1 lockf -k /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 scripts/dune-local.sh build
-PS
-  exit 0
-fi
-exit 1
+let test_opam_read_leases_overlap_and_exclude_writer () =
+  with_temp_dir "opam-switch-rw-lock" (fun dir ->
+      let script = opam_switch_rw_lock_script_path () in
+      let lock_base = Filename.concat dir "switch" in
+      let readers_dir = lock_base ^ ".state/readers" in
+      let reader_one_started = Filename.concat dir "reader-one-started" in
+      let reader_two_started = Filename.concat dir "reader-two-started" in
+      let writer_started = Filename.concat dir "writer-started" in
+      let command =
+        Printf.sprintf
+          {|set -eu
+export OPAM_SWITCH_PREFIX=/tmp/masc-test-switch
+export MASC_OPAM_LOCK_PATH=%s
+%s read -- /bin/sh -c %s &
+first_reader=$!
+for _ in $(seq 1 50); do
+  test -f %s && break
+  sleep 0.02
+done
+%s read -- /bin/sh -c %s &
+second_reader=$!
+for _ in $(seq 1 50); do
+  test -f %s && break
+  sleep 0.02
+done
+test -f %s
+test -f %s
+set +e
+%s write -- true
+writer_while_readers=$?
+set -e
+wait "$first_reader"
+wait "$second_reader"
+test "$writer_while_readers" -eq 75
+%s write -- /bin/sh -c %s &
+writer=$!
+for _ in $(seq 1 50); do
+  test -f %s && break
+  sleep 0.02
+done
+set +e
+%s read -- true
+reader_while_writer=$?
+set -e
+wait "$writer"
+test "$reader_while_writer" -eq 75
+%s write -- true
+printf 'stale-reader-lock\n' > %s/$$
+%s write -- true
+test ! -e %s/$$
 |}
-
-let test_bare_dune_bypass_aborts_before_dune () =
-  with_temp_dir "dune-local-bare-dune-bypass" (fun dir ->
-      let bin_dir, dune_log =
-        setup_fake_repo dir
+          (quote lock_base)
+          (quote script)
+          (quote (Printf.sprintf "touch %s; sleep 1" (quote reader_one_started)))
+          (quote reader_one_started)
+          (quote script)
+          (quote (Printf.sprintf "touch %s; sleep 1" (quote reader_two_started)))
+          (quote reader_two_started)
+          (quote reader_one_started)
+          (quote reader_two_started)
+          (quote script)
+          (quote script)
+          (quote (Printf.sprintf "touch %s; sleep 1" (quote writer_started)))
+          (quote writer_started)
+          (quote script)
+          (quote script)
+          (quote readers_dir)
+          (quote script)
+          (quote readers_dir)
       in
-      write_bare_dune_ps bin_dir;
       let code, _stdout, stderr =
-        run_dune_local dir bin_dir
-          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_DUNE_ALLOW_BARE_DUNE" ]
-          "build"
+        run_process ~cwd:dir "/bin/bash" [| "/bin/bash"; "-c"; command |]
       in
-      check int "exits tempfail on bare dune bypass" 75 code;
-      check bool "reports unwrapped Dune" true
-        (String_util.contains_substring stderr "outside scripts/dune-local.sh");
-      check bool "reports bare dune command" true
-        (String_util.contains_substring stderr
-           "dune exec --root . test/test_config_dir_resolver.exe");
-      check bool "reports dune with leading global option" true
-        (String_util.contains_substring stderr "dune --root . build");
-      check bool "reports opam exec dune with leading global option" true
-        (String_util.contains_substring stderr "opam exec -- dune --build-dir _build test");
-      check bool "reports bare dune clean" true
-        (String_util.contains_substring stderr "dune clean --root .");
-      check bool "does not report wrapped child" false
-        (String_util.contains_substring stderr "wrapped-worktree");
-      check bool "dune was not invoked" false (Sys.file_exists dune_log))
+      check int "reader overlap and writer exclusion" 0 code;
+      check bool "writer rejection is explicit" true
+        (String_util.contains_substring stderr "switch readers are active");
+      check bool "reader rejection is explicit" true
+        (String_util.contains_substring stderr "switch mutation is active"))
 
-let test_bare_dune_bypass_can_be_overridden () =
-  with_temp_dir "dune-local-bare-dune-override" (fun dir ->
-      let bin_dir, dune_log =
-        setup_fake_repo dir
-      in
-      write_bare_dune_ps bin_dir;
+let test_dune_runs_under_opam_read_lease () =
+  with_temp_dir "dune-local-opam-read-lease" (fun dir ->
+      let bin_dir, dune_log = setup_fake_repo dir in
       let code, _stdout, _stderr =
-        run_dune_local dir bin_dir
-          ~env:[ ("MASC_DUNE_ALLOW_BARE_DUNE", "1") ]
-          ~unset_env:[ "GITHUB_ACTIONS" ] "build"
+        run_dune_local dir bin_dir ~unset_env:[ "GITHUB_ACTIONS" ] "build"
       in
-      check int "exits zero when bare dune guard is overridden" 0 code;
-      check bool "dune was invoked" true (Sys.file_exists dune_log))
-
-let test_opam_lockf_reexec_env_passthrough () =
-  with_temp_dir "dune-local-opam-lockf" (fun dir ->
-      let bin_dir, dune_log =
-        setup_fake_repo dir
-      in
-      let lockf_log = Filename.concat dir "lockf-calls.log" in
-      write_executable
-        (Filename.concat bin_dir "lockf")
-        (Printf.sprintf
-           {|#!/bin/sh
-printf 'held=%%s argv=%%s\n' "${MASC_OPAM_LOCK_HELD:-unset}" "$*" >> %s
-while [ "${1#-}" != "$1" ]; do
-  case "$1" in
-    -t) shift 2 ;;
-    *) shift ;;
-  esac
-done
-shift
-exec "$@"
-|}
-           (quote lockf_log));
-      let opam_lock_path = Filename.concat dir "opam.lock" in
-      let code, _stdout, _stderr =
-        run_dune_local dir bin_dir
-          ~env:[ ("MASC_OPAM_LOCK_PATH", opam_lock_path) ]
-          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
-          "build"
-      in
-      check int "exits zero through lockf reexec" 0 code;
-      check bool "lockf invoked" true (Sys.file_exists lockf_log);
-      let lock_log = read_file lockf_log in
-      let dune_lock_path = Filename.concat dir "dune-local.lock" in
-      check bool "lock path passed to lockf" true
-        (String_util.contains_substring lock_log opam_lock_path);
-      check bool "dune lock acquired before opam lock" true
-        (match
-           ( substring_index lock_log dune_lock_path,
-             substring_index lock_log opam_lock_path )
-         with
-        | Some dune_pos, Some opam_pos -> dune_pos < opam_pos
-        | _ -> false);
-      check bool "held env passed through argv" true
-        (String_util.contains_substring lock_log "MASC_OPAM_LOCK_HELD=1");
-      check bool "dune held env passed through argv" true
-        (String_util.contains_substring lock_log "MASC_DUNE_LOCK_HELD=1");
-      check bool "dune was invoked after reexec" true
-        (Sys.file_exists dune_log))
-
-let test_opam_lock_timeout_releases_dune_lock () =
-  with_temp_dir "dune-local-opam-lock-timeout" (fun dir ->
-      let bin_dir, dune_log =
-        setup_fake_repo dir
-      in
-      let lockf_log = Filename.concat dir "lockf-calls.log" in
-      let opam_lock_path = Filename.concat dir "opam.lock" in
-      write_executable
-        (Filename.concat bin_dir "lockf")
-        (Printf.sprintf
-           {|#!/bin/sh
-printf 'argv=%%s\n' "$*" >> %s
-while [ "${1#-}" != "$1" ]; do
-  case "$1" in
-    -t) shift 2 ;;
-    *) shift ;;
-  esac
-done
-lock_path="$1"
-printf 'lock=%%s\n' "$lock_path" >> %s
-if [ "$lock_path" = %s ]; then exit 75; fi
-shift
-exec "$@"
-|}
-           (quote lockf_log) (quote lockf_log) (quote opam_lock_path));
-      let code, _stdout, stderr =
-        run_dune_local dir bin_dir
-          ~env:
-            [
-              ("MASC_OPAM_LOCK_PATH", opam_lock_path);
-              ("MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT", "1");
-            ]
-          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
-          "build"
-      in
-      check int "opam lock timeout exits with lockf status" 75 code;
-      check bool "timeout explains Dune lock release" true
-        (String_util.contains_substring stderr "releasing Dune lock");
-      check bool "dune was not invoked after opam timeout" false
-        (Sys.file_exists dune_log))
-
-let test_unset_opam_lock_timeout_waits_forever () =
-  with_temp_dir "dune-local-opam-lock-timeout-unset" (fun dir ->
-      let bin_dir, dune_log =
-        setup_fake_repo dir
-      in
-      let lockf_log = Filename.concat dir "lockf-calls.log" in
-      write_executable
-        (Filename.concat bin_dir "lockf")
-        (Printf.sprintf
-           {|#!/bin/sh
-printf 'argv=%%s\n' "$*" >> %s
-while [ "${1#-}" != "$1" ]; do
-  case "$1" in
-    -t) printf 'timeout=%%s\n' "$2" >> %s; exit 98 ;;
-    *) shift ;;
-  esac
-done
-shift
-exec "$@"
-|}
-           (quote lockf_log) (quote lockf_log));
-      let code, _stdout, stderr =
-        run_dune_local dir bin_dir
-          ~unset_env:
-            [
-              "GITHUB_ACTIONS";
-              "MASC_OPAM_LOCK_HELD";
-              "MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT";
-            ]
-          "build"
-      in
-      check int "unset timeout keeps historical wait-forever path" 0 code;
-      let lock_log = read_file lockf_log in
-      check bool "lockf timeout flag not used by default" false
-        (String_util.contains_substring lock_log "timeout=");
-      check bool "timeout message not emitted" false
-        (String_util.contains_substring stderr "releasing Dune lock");
-      check bool "dune was invoked" true (Sys.file_exists dune_log))
-
-let test_zero_like_opam_lock_timeout_waits_forever () =
-  with_temp_dir "dune-local-opam-lock-timeout-zero-like" (fun dir ->
-      let bin_dir, dune_log =
-        setup_fake_repo dir
-      in
-      let lockf_log = Filename.concat dir "lockf-calls.log" in
-      write_executable
-        (Filename.concat bin_dir "lockf")
-        (Printf.sprintf
-           {|#!/bin/sh
-printf 'argv=%%s\n' "$*" >> %s
-while [ "${1#-}" != "$1" ]; do
-  case "$1" in
-    -t) printf 'timeout=%%s\n' "$2" >> %s; exit 98 ;;
-    *) shift ;;
-  esac
-done
-shift
-exec "$@"
-|}
-           (quote lockf_log) (quote lockf_log));
-      let code, _stdout, stderr =
-        run_dune_local dir bin_dir
-          ~env:[ ("MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT", "00") ]
-          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
-          "build"
-      in
-      check int "zero-like timeout waits forever" 0 code;
-      let lock_log = read_file lockf_log in
-      check bool "lockf timeout flag not used for zero-like value" false
-        (String_util.contains_substring lock_log "timeout=");
-      check bool "timeout message not emitted for zero-like value" false
-        (String_util.contains_substring stderr "releasing Dune lock");
-      check bool "dune was invoked" true (Sys.file_exists dune_log))
-
-let test_opam_lock_timeout_env_must_be_numeric () =
-  with_temp_dir "dune-local-opam-timeout-invalid" (fun dir ->
-      let bin_dir, dune_log =
-        setup_fake_repo dir
-      in
-      write_executable (Filename.concat bin_dir "lockf")
-        {|#!/bin/sh
-while [ "${1#-}" != "$1" ]; do
-  case "$1" in
-    -t) shift 2 ;;
-    *) shift ;;
-  esac
-done
-shift
-exec "$@"
-|};
-      let code, _stdout, stderr =
-        run_dune_local dir bin_dir
-          ~env:[ ("MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT", "abc") ]
-          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
-          "build"
-      in
-      check int "invalid timeout exits usage error" 2 code;
-      check bool "invalid timeout named" true
-        (String_util.contains_substring stderr "invalid MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT");
-      check bool "dune was not invoked" false (Sys.file_exists dune_log))
-
-let test_missing_lock_tools_warn_once () =
-  with_temp_dir "dune-local-no-lock-tools" (fun dir ->
-      let bin_dir, dune_log =
-        setup_fake_repo dir
-      in
-      write_executable (Filename.concat bin_dir "dirname")
-        {|#!/bin/sh
-case "$1" in
-  */*) printf '%s\n' "${1%/*}" ;;
-  *) printf '.\n' ;;
-esac
-|};
-      write_executable (Filename.concat bin_dir "basename")
-        {|#!/bin/sh
-base="${1##*/}"
-printf '%s\n' "$base"
-|};
-      write_executable (Filename.concat bin_dir "awk")
-        {|#!/bin/sh
-while read -r first second rest; do
-  if [ "$second" = "Llm_provider__Provider_config" ]; then
-    printf '%s\n' "$first"
-    exit 0
-  fi
-done
-exit 1
-|};
-      let build_dir = Filename.concat dir "_build" in
-      mkdir_p build_dir;
-      let opam_path = Filename.concat bin_dir "opam" in
-      let script =
-        Filename.concat (Filename.concat dir "scripts") "dune-local.sh"
-      in
-      let code, _stdout, stderr =
-        run_process ~cwd:dir "/bin/bash"
-          ~env:
-            [
-              ("PATH", bin_dir);
-              ("GIT_CEILING_DIRECTORIES", dir);
-              ("DUNE_LOCAL_LOCK", Filename.concat dir "dune-local.lock");
-              ("DUNE_BUILD_DIR", build_dir);
-              ("MASC_SKIP_DEPS_CHECK", "1");
-              ("MASC_SKIP_OCAML_VERSION_CHECK", "1");
-              ("MASC_DUNE_ALLOW_BARE_DUNE", "1");
-            ]
-          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_DUNE_LOCK_HELD" ]
-          [| "/bin/bash"; script; "build" |]
-      in
-      let needle = "neither lockf nor flock found; running unlocked" in
-      let only_once =
-        match substring_index stderr needle with
-        | None -> false
-        | Some idx ->
-            let start = idx + String.length needle in
-            let tail = String.sub stderr start (String.length stderr - start) in
-            substring_index tail needle = None
-      in
-      check int "no-lock-tools run exits zero" 0 code;
-      check bool "fake opam kept in PATH" true (Sys.file_exists opam_path);
-      check bool "warning emitted exactly once" true only_once;
-      check bool "opam lock warning suppressed" false
-        (String_util.contains_substring stderr
-           "neither lockf nor flock found; opam switch checks are unlocked");
-      check bool "dune was invoked" true (Sys.file_exists dune_log))
-
-let test_opam_flock_reexec_env_passthrough () =
-  with_temp_dir "dune-local-opam-flock" (fun dir ->
-      let bin_dir, dune_log =
-        setup_fake_repo dir
-      in
-      write_executable (Filename.concat bin_dir "dirname")
-        {|#!/bin/sh
-case "$1" in
-  */*) printf '%s\n' "${1%/*}" ;;
-  *) printf '.\n' ;;
-esac
-|};
-      write_executable (Filename.concat bin_dir "basename")
-        {|#!/bin/sh
-base="${1##*/}"
-printf '%s\n' "$base"
-|};
-      let flock_log = Filename.concat dir "flock-calls.log" in
-      write_executable
-        (Filename.concat bin_dir "flock")
-        (Printf.sprintf
-           {|#!/bin/sh
-printf 'held=%%s argv=%%s\n' "${MASC_OPAM_LOCK_HELD:-unset}" "$*" >> %s
-shift
-if [ "${1:-}" = "env" ]; then
-  shift
-  export "$1"
-  shift
-fi
-exec "$@"
-|}
-           (quote flock_log));
-      let opam_lock_path = Filename.concat dir "opam.lock" in
-      let dune_lock_path = Filename.concat dir "dune-local.lock" in
-      let script =
-        Filename.concat (Filename.concat dir "scripts") "dune-local.sh"
-      in
-      let code, _stdout, _stderr =
-        run_process ~cwd:dir "/bin/bash"
-          ~env:
-            [
-              ("PATH", Printf.sprintf "%s:/bin" bin_dir);
-              ("GIT_CEILING_DIRECTORIES", dir);
-              ("DUNE_LOCAL_LOCK", dune_lock_path);
-              ("MASC_OPAM_LOCK_PATH", opam_lock_path);
-              ("MASC_SKIP_DEPS_CHECK", "1");
-              ("MASC_SKIP_OCAML_VERSION_CHECK", "1");
-              ("MASC_DUNE_ALLOW_BARE_DUNE", "1");
-            ]
-          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
-          [| "/bin/bash"; script; "build" |]
-      in
-      check int "exits zero through flock reexec" 0 code;
-      check bool "flock invoked" true (Sys.file_exists flock_log);
-      let lock_log = read_file flock_log in
-      check bool "lock path passed to flock" true
-        (String_util.contains_substring lock_log opam_lock_path);
-      check bool "held env passed through argv" true
-        (String_util.contains_substring lock_log "MASC_OPAM_LOCK_HELD=1");
-      check bool "dune was invoked after flock reexec" true
-        (Sys.file_exists dune_log))
-
-let test_opam_flock_timeout_releases_dune_lock () =
-  with_temp_dir "dune-local-opam-flock-timeout" (fun dir ->
-      let bin_dir, dune_log =
-        setup_fake_repo dir
-      in
-      write_executable (Filename.concat bin_dir "dirname")
-        {|#!/bin/sh
-case "$1" in
-  */*) printf '%s\n' "${1%/*}" ;;
-  *) printf '.\n' ;;
-esac
-|};
-      write_executable (Filename.concat bin_dir "basename")
-        {|#!/bin/sh
-base="${1##*/}"
-printf '%s\n' "$base"
-|};
-      let flock_log = Filename.concat dir "flock-calls.log" in
-      let opam_lock_path = Filename.concat dir "opam.lock" in
-      let dune_lock_path = Filename.concat dir "dune-local.lock" in
-      write_executable
-        (Filename.concat bin_dir "flock")
-        (Printf.sprintf
-           {|#!/bin/sh
-printf 'argv=%%s\n' "$*" >> %s
-timeout=""
-while [ "${1#-}" != "$1" ]; do
-  case "$1" in
-    -w) timeout="$2"; shift 2 ;;
-    *) shift ;;
-  esac
-done
-lock_path="$1"
-printf 'lock=%%s timeout=%%s\n' "$lock_path" "$timeout" >> %s
-if [ "$lock_path" = %s ] && [ -n "$timeout" ]; then exit 1; fi
-shift
-if [ "${1:-}" = "env" ]; then
-  shift
-  export "$1"
-  shift
-fi
-exec "$@"
-|}
-           (quote flock_log) (quote flock_log) (quote opam_lock_path));
-      let script =
-        Filename.concat (Filename.concat dir "scripts") "dune-local.sh"
-      in
-      let code, _stdout, stderr =
-        run_process ~cwd:dir "/bin/bash"
-          ~env:
-            [
-              ("PATH", Printf.sprintf "%s:/bin" bin_dir);
-              ("GIT_CEILING_DIRECTORIES", dir);
-              ("DUNE_LOCAL_LOCK", dune_lock_path);
-              ("MASC_OPAM_LOCK_PATH", opam_lock_path);
-              ("MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT", "2");
-              ("MASC_SKIP_DEPS_CHECK", "1");
-              ("MASC_SKIP_OCAML_VERSION_CHECK", "1");
-              ("MASC_DUNE_ALLOW_BARE_DUNE", "1");
-            ]
-          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
-          [| "/bin/bash"; script; "build" |]
-      in
-      check int "opam flock timeout exits with flock status" 1 code;
-      let lock_log = read_file flock_log in
-      check bool "flock timeout flag used" true
-        (String_util.contains_substring lock_log "timeout=2");
-      check bool "timeout explains Dune lock release" true
-        (String_util.contains_substring stderr "releasing Dune lock");
-      check bool "dune was not invoked after opam timeout" false
-        (Sys.file_exists dune_log))
+      check int "wrapper succeeds" 0 code;
+      check bool "Dune inherits the admitted read lease" true
+        (String_util.contains_substring (read_file dune_log) "read_lease=1"))
 
 let test_clean_subcommand_reaches_dune () =
   with_temp_dir "dune-local-clean" (fun dir ->
@@ -1172,26 +783,10 @@ let () =
             test_dune_lock_wait_reports_holder;
           test_case "live build-dir lock aborts before Dune" `Quick
             test_live_build_lock_aborts_before_dune;
-          test_case "bare Dune bypass aborts before Dune" `Quick
-            test_bare_dune_bypass_aborts_before_dune;
-          test_case "MASC_DUNE_ALLOW_BARE_DUNE=1 bypasses bare Dune guard"
-            `Quick test_bare_dune_bypass_can_be_overridden;
-          test_case "opam lockf reexec propagates env" `Quick
-            test_opam_lockf_reexec_env_passthrough;
-          test_case "opam lock timeout releases Dune lock" `Quick
-            test_opam_lock_timeout_releases_dune_lock;
-          test_case "unset opam lock timeout waits forever" `Quick
-            test_unset_opam_lock_timeout_waits_forever;
-          test_case "zero-like opam lock timeout waits forever" `Quick
-            test_zero_like_opam_lock_timeout_waits_forever;
-          test_case "opam lock timeout env must be numeric" `Quick
-            test_opam_lock_timeout_env_must_be_numeric;
-          test_case "missing lock tools warn once" `Quick
-            test_missing_lock_tools_warn_once;
-          test_case "opam flock reexec propagates env" `Quick
-            test_opam_flock_reexec_env_passthrough;
-          test_case "opam flock timeout releases Dune lock" `Quick
-            test_opam_flock_timeout_releases_dune_lock;
+          test_case "opam read leases overlap and exclude mutation" `Quick
+            test_opam_read_leases_overlap_and_exclude_writer;
+          test_case "Dune executes under an opam read lease" `Quick
+            test_dune_runs_under_opam_read_lease;
           test_case "clean subcommand reaches Dune" `Quick
             test_clean_subcommand_reaches_dune;
           test_case

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -312,6 +312,11 @@ let test_dune_lock_wait_reports_holder () =
         (Printf.sprintf
            {|#!/bin/sh
 printf 'argv=%%s\n' "$*" >> %s
+last=""
+for arg in "$@"; do last="$arg"; done
+case "$*:$last" in
+  *"/readers/reader."*:true) exit 75 ;;
+esac
 while [ "${1#-}" != "$1" ]; do
   case "$1" in
     -t) shift 2 ;;
@@ -472,6 +477,52 @@ test ! -e %s/$$
         (String_util.contains_substring stderr "switch readers are active");
       check bool "reader rejection is explicit" true
         (String_util.contains_substring stderr "switch mutation is active"))
+
+let test_opam_reader_admission_requires_held_inode_and_keeps_writer_file () =
+  with_temp_dir "opam-switch-rw-lock-inode" (fun dir ->
+      let script = opam_switch_rw_lock_script_path () in
+      let lock_base = Filename.concat dir "switch" in
+      let writer_path = lock_base ^ ".state/writer" in
+      let reader_path = lock_base ^ ".state/readers/unheld" in
+      let command =
+        Printf.sprintf
+          {|set -eu
+export OPAM_SWITCH_PREFIX=/tmp/masc-test-switch
+export MASC_OPAM_LOCK_PATH=%s
+%s write -- true
+test -f %s
+printf 'not-held\n' > %s
+if stat -f '%%d:%%i' %s >/dev/null 2>&1; then
+  identity=$(stat -f '%%d:%%i' %s)
+else
+  identity=$(stat -c '%%d:%%i' %s)
+fi
+set +e
+%s __admit_read %s "$identity"
+status=$?
+set -e
+test "$status" -eq 75
+|}
+          (quote lock_base)
+          (quote script)
+          (quote writer_path)
+          (quote reader_path)
+          (quote reader_path)
+          (quote reader_path)
+          (quote reader_path)
+          (quote script)
+          (quote reader_path)
+      in
+      let code, _stdout, stderr =
+        run_process ~cwd:dir "/bin/bash" [| "/bin/bash"; "-c"; command |]
+      in
+      check int "unheld reader is rejected" 0 code;
+      check bool "writer inode remains addressable" true
+        (Sys.file_exists writer_path);
+      check bool "reader rejection identifies the inode race" true
+        (String_util.contains_substring
+           stderr
+           "no longer names its locked inode"))
 
 let test_dune_runs_under_opam_read_lease () =
   with_temp_dir "dune-local-opam-read-lease" (fun dir ->
@@ -785,6 +836,8 @@ let () =
             test_live_build_lock_aborts_before_dune;
           test_case "opam read leases overlap and exclude mutation" `Quick
             test_opam_read_leases_overlap_and_exclude_writer;
+          test_case "opam reader admission requires its held inode" `Quick
+            test_opam_reader_admission_requires_held_inode_and_keeps_writer_file;
           test_case "Dune executes under an opam read lease" `Quick
             test_dune_runs_under_opam_read_lease;
           test_case "clean subcommand reaches Dune" `Quick


### PR DESCRIPTION
## Summary
- scope the Dune throttle to one canonical worktree instead of the entire machine
- replace the exclusive opam switch build lock with concurrent read leases and a fail-fast mutation writer
- route external dependency pin/install through the exclusive writer
- delete the bare-Dune process-table heuristic and retired lock compatibility controls
- keep the writer inode stable and validate each reader dev:ino under the admission gate
- fail closed when neither lock backend is available and make gate timeout rejection observable

## Why
A stale lockf process held the old machine-wide lock for about three hours even though its build child no longer existed. Every unrelated Keeper worktree then waited before it could run a focused build.

The opam switch is read-only during ordinary Dune compilation. Separate worktrees already have separate build directories, so ordinary builds can overlap safely. Only the pin/install mutation path needs exclusion.

## Linearization
- The writer lockfile is never unlinked, so all writers contend on one stable inode.
- A reader captures its dev:ino after acquiring the reader lock and revalidates both pathname identity and held status under the gate.
- If stale cleanup observed free before the reader acquired its lock and then unlinked that path, admission returns 75 before the wrapped command starts.
- Missing lock tools return 69 before the wrapped command starts; there is no unlocked fallback and no successful no-op.
- Gate acquisition timeout returns 75 with an explicit admission diagnostic.
- Exit 75 is the admission rejection code. An admitted wrapped command that itself exits 75 is forwarded unchanged; the explicit stderr diagnostic distinguishes admission failure.

## Verification
- bash syntax check passed
- ocamlformat check passed
- focused target built through the worktree-scoped wrapper
- test_dune_local_script: 22/22 passed
- missing-backend regression: exit 69 and wrapped command execution count 0
- gate-timeout regression: exit 75, explicit admission diagnostic, wrapped command execution count 0
- two real read leases each held for 2 seconds: total wall 2.183s, individual wall 1.981s and 2.013s
- writer during a live reader: exit 75 in 0.002s with active-reader evidence
- reader during a live writer: exit 75 in under 0.001s with active-mutation evidence
- regression proves the writer path remains addressable and an unheld/replaced reader inode cannot pass admission

This is a hard cut: no old lock env aliases, bypass facade, dual locking, or migration path remains.

[근거] exact source and focused executable at f4ae871a66, 2026-08-12 KST, confidence High
