### PR TITLE
fix(ci): derive Agent Core boundary from Dune graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
             tla=true
           fi
 
-          if has_match '^(\.github/workflows/ci\.yml$|packages/agent_core/|lib/(.*/)?(dune|[^/]+\.inc)$|lib/keeper/keeper_event_bridge\.ml$|scripts/check-agent-core-boundary\.sh$|test/test_agent_core_boundary\.sh$|test/test_keeper_execution_join\.ml$|test/test_keeper_hooks_agent_core_introspection\.ml$|dune-project$|.*\.opam$|masc\.opam\.locked$)'; then
+          if has_match '^(\.github/workflows/ci\.yml$|packages/agent_core/|packages/(dune|dune-file|dune-project)$|lib/(.*/)?(dune|dune-file|[^/]+\.inc)$|lib/keeper/(keeper_event_bridge|keeper_execution_join|hitl_summary_worker|keeper_hooks_agent_core(_introspection)?|keeper_run_tools[^/]*)\.mli?$|scripts/(check-agent-core-boundary\.sh|audit-sublib-cycle\.py|ci-run-focused-tests\.sh)$|test/(dune|test_agent_core_boundary\.sh|test_keeper_execution_join\.ml|test_keeper_hooks_agent_core_introspection\.ml|test_hitl_summary_worker\.ml|stanzas/test_keeper_execution_join\.inc|stanzas/test_hitl_summary_worker\.inc)$|(dune|dune-file)$|dune-project$|dune-workspace$|.*\.opam$|masc\.opam\.locked$)'; then
             agent_core=true
           fi
 
@@ -330,6 +330,14 @@ jobs:
 
           if has_match '^(lib/keeper/|scripts/keeper-cwd-leak-gate\.sh$|scripts/turn-path-provider-agnostic-gate\.sh$|\.github/workflows/ci\.yml$)'; then
             keeper_cwd=true
+          fi
+
+          # Agent Core owns non-source build inputs such as models.toml. Its
+          # focused behavior suite and resolved graph must not be reported as
+          # gate-skipped merely because the generic suffix classifier missed
+          # one of those inputs.
+          if [ "${agent_core}" = true ]; then
+            build=true
           fi
 
           if [ "${ci_core}" = true ]; then
@@ -542,7 +550,6 @@ jobs:
           scripts/check-sandbox-dune-version.sh
 
       - name: Check agent core ownership boundary
-        if: needs.changes.outputs.agent_core == 'true'
         run: |
           bash scripts/check-agent-core-boundary.sh
           bash test/test_agent_core_boundary.sh
@@ -810,7 +817,7 @@ jobs:
           chmod +x scripts/check-keeper-event-queue-projection-boundary.sh
           scripts/check-keeper-event-queue-projection-boundary.sh
 
-      - name: Sublib boundary gate against real dune graph (RFC-0056 G1)
+      - name: Library boundaries against resolved Dune graphs
         # The self-test (in the Meta Guards job) only validates the checker
         # against synthetic fixtures. This step runs the SAME checker against
         # the REAL dependency graph emitted by `dune describe`, asserting that
@@ -829,8 +836,65 @@ jobs:
         # describe sexp to the pure-python checker via --describe-file.
         # See: docs/rfc/RFC-0056-incremental-sublib-extraction.md G1, #19824.
         run: |
-          opam exec -- dune describe --root . > "$RUNNER_TEMP/sublib-describe.sexp"
-          python3 scripts/audit-sublib-cycle.py --describe-file "$RUNNER_TEMP/sublib-describe.sexp"
+          opam exec -- dune describe workspace \
+            --root . --format sexp --lang 0.1 \
+            > "$RUNNER_TEMP/sublib-describe.sexp"
+          python3 scripts/audit-sublib-cycle.py \
+            --describe-file "$RUNNER_TEMP/sublib-describe.sexp"
+
+          # Restrict Dune's project roots to Agent Core, then inspect the
+          # resolved dependency closure. Installed dependencies are explicit
+          # `local false` nodes; any `local true` library owned elsewhere in
+          # the workspace is a reverse MASC dependency. --with-pps also places
+          # compile-time PPX libraries in this restricted closure.
+          opam exec -- dune describe workspace packages/agent_core \
+            --root . --format sexp --lang 0.1 --with-pps \
+            > "$RUNNER_TEMP/agent-core-describe.sexp"
+          python3 scripts/audit-sublib-cycle.py \
+            --describe-file "$RUNNER_TEMP/agent-core-describe.sexp" \
+            --closed-source-root packages/agent_core \
+            --required-local-library masc.agent_core
+
+          # Every file below packages/agent_core already triggers this Build
+          # proof. A Dune include could move a library stanza to an arbitrary
+          # file outside that classifier, so use Dune's own parser/formatter
+          # and keep the package plus active ancestor Dune files include-free.
+          # Introducing the first include necessarily changes a classified
+          # dune file, so this check closes the input set inductively.
+          for control_file in packages dune-project dune-workspace packages/dune-project; do
+            if [[ -L "$control_file" ]]; then
+              echo "agent-core boundary: symlinked control input is forbidden: $control_file" >&2
+              exit 1
+            fi
+          done
+          while IFS= read -r dune_file; do
+            if [[ -L "$dune_file" ]]; then
+              echo "agent-core boundary: symlinked Dune input is forbidden: $dune_file" >&2
+              exit 1
+            fi
+            if [[ "$(head -c 20 "$dune_file")" == '(* -*- tuareg -*- *)' ]]; then
+              echo "agent-core boundary: OCaml-syntax Dune file is forbidden: $dune_file" >&2
+              exit 1
+            fi
+            formatted="$RUNNER_TEMP/agent-core-formatted.dune"
+            opam exec -- dune format-dune-file "$dune_file" > "$formatted"
+            if rg -n '^[[:space:]]*\((dynamic_)?include([[:space:]]|$)' "$formatted"; then
+              echo "agent-core boundary: Dune include stanza is forbidden: $dune_file" >&2
+              exit 1
+            fi
+          done < <(
+            {
+              find packages/agent_core -type f \
+                \( -name dune -o -name dune-file \) -print
+              printf '%s\n' dune
+              [[ ! -f packages/dune && ! -L packages/dune ]] \
+                || printf '%s\n' packages/dune
+              [[ ! -f dune-file && ! -L dune-file ]] \
+                || printf '%s\n' dune-file
+              [[ ! -f packages/dune-file && ! -L packages/dune-file ]] \
+                || printf '%s\n' packages/dune-file
+            } | LC_ALL=C sort -u
+          )
 
       - name: Runtime TOML validity gate
         # RFC-0058 §9: config/keeper_runtime.toml is the authoring SSOT.

--- a/docs/spec/13-agent-core.md
+++ b/docs/spec/13-agent-core.md
@@ -1,6 +1,6 @@
 ---
 status: Active
-last_verified: 2026-08-08
+last_verified: 2026-08-12
 code_refs:
   - packages/agent_core/lib
   - lib/runtime/runtime_agent.ml
@@ -20,9 +20,17 @@ orchestration.
 MASC coordinator -> masc.agent_core
 ```
 
-`packages/agent_core` must not import MASC coordinator libraries or product
-concepts. `scripts/check-agent-core-boundary.sh` checks this one-way dependency,
-and CI executes the package behavior suite with
+`packages/agent_core` must not depend on MASC coordinator libraries. CI asks
+Dune for the resolved library dependency closure rooted at
+`packages/agent_core` and `scripts/audit-sublib-cycle.py` rejects every
+workspace-local library owned outside that source root. Installed libraries
+remain allowed. `scripts/check-agent-core-boundary.sh` separately checks the
+package's required filesystem shape and rejects nested package/release surfaces
+and source symlinks. CI rejects Dune's legacy OCaml-syntax escape hatch; Dune
+itself then formats the package and active ancestor Dune files before CI rejects
+include stanzas, keeping every dependency input inside the path-classified
+graph proof. The existing coordinator-module name scan
+remains as defense in depth. CI also executes the package behavior suite with
 `@packages/agent_core/test/runtest`.
 
 ## Runtime flow
@@ -68,6 +76,7 @@ payload variants to MASC SSE events, and appends replayable JSONL under
 ## Required proof
 
 - `test/test_agent_core_boundary.sh`
+- `scripts/audit-sublib-cycle.py --closed-source-root packages/agent_core --required-local-library masc.agent_core`
 - `@packages/agent_core/test/runtest`
 - `@test/runtest-test_keeper_hooks_agent_core_introspection`
 - `@test/runtest-test_keeper_execution_join`

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=671
+UNWIRED_BASELINE=662
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/audit-sublib-cycle.py
+++ b/scripts/audit-sublib-cycle.py
@@ -37,6 +37,9 @@ Relationship to existing tooling (complementary, not duplicate)
 Usage
 -----
   audit-sublib-cycle.py [--root DIR] [--describe-file FILE] [--leaf LIB]...
+  audit-sublib-cycle.py --describe-file FILE \
+    --closed-source-root packages/agent_core \
+    --required-local-library masc.agent_core
   audit-sublib-cycle.py --self-test     # clean + buggy fixture dual-check
 
 Exit codes: 0 = all leaves clean, 1 = boundary violation, 2 = usage/parse error.
@@ -49,6 +52,7 @@ import subprocess
 import sys
 from collections import deque
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import Union
 
 MEGA_LIB = "masc"
@@ -156,13 +160,21 @@ class Library:
 
     name: str
     uid: str
+    local: bool
     requires: tuple[str, ...]
+    source_dir: str
 
 
 @dataclass(frozen=True)
 class Violation:
     leaf: str
     path: tuple[str, ...]  # human-readable lib names: leaf -> ... -> mega
+
+
+@dataclass(frozen=True)
+class SourceRootViolation:
+    library: str
+    source_dir: str
 
 
 # --- minimal s-expression parser (atoms + lists; no external deps) -----------
@@ -219,49 +231,87 @@ def parse(tokens: list[str]) -> list[Sexp]:
     return items
 
 
-def _child(node: "list[Sexp]", key: str) -> "list[Sexp] | None":
-    """Return the first child sublist whose head atom equals ``key``."""
-    for ch in node:
-        if isinstance(ch, list) and ch and ch[0] == key:
-            return ch
-    return None
+def _required_field(record: "list[Sexp]", key: str) -> Sexp:
+    matches = [
+        child
+        for child in record
+        if isinstance(child, list) and child and child[0] == key
+    ]
+    if len(matches) != 1 or len(matches[0]) != 2:
+        raise ValueError(
+            f"library record requires exactly one single-valued {key!r} field"
+        )
+    return matches[0][1]
 
 
 def find_libraries(sexp: Sexp) -> list[Library]:
-    """Walk the describe tree and collect every node with both name and uid.
-
-    Library nodes carry ``(name ...)`` and ``(uid ...)``; module nodes carry
-    ``(name ...)`` only, so requiring uid cleanly selects libraries.
-    """
+    """Walk the Dune 0.1 describe tree and decode library variants strictly."""
     libs: list[Library] = []
 
     def visit(node: Sexp) -> None:
         if not isinstance(node, list):
             return
-        name_node = _child(node, "name")
-        uid_node = _child(node, "uid")
-        if (
-            name_node is not None
-            and uid_node is not None
-            and len(name_node) >= 2
-            and len(uid_node) >= 2
-            and isinstance(name_node[1], str)
-            and isinstance(uid_node[1], str)
-        ):
-            req_node = _child(node, "requires")
-            requires: tuple[str, ...] = ()
-            if (
-                req_node is not None
-                and len(req_node) >= 2
-                and isinstance(req_node[1], list)
+        if node and node[0] == "library":
+            if len(node) != 2 or not isinstance(node[1], list):
+                raise ValueError("malformed library variant in describe output")
+            record = node[1]
+            name = _required_field(record, "name")
+            uid = _required_field(record, "uid")
+            local = _required_field(record, "local")
+            requires = _required_field(record, "requires")
+            source_dir = _required_field(record, "source_dir")
+            if not isinstance(name, str) or not isinstance(uid, str):
+                raise ValueError("library name and uid must be atoms")
+            if not isinstance(local, str) or local not in ("true", "false"):
+                raise ValueError(f"library {name!r} has malformed local field")
+            if not isinstance(requires, list) or not all(
+                isinstance(dependency_uid, str) for dependency_uid in requires
             ):
-                requires = tuple(u for u in req_node[1] if isinstance(u, str))
-            libs.append(Library(name=name_node[1], uid=uid_node[1], requires=requires))
+                raise ValueError(f"library {name!r} has malformed requires field")
+            if not isinstance(source_dir, str):
+                raise ValueError(f"library {name!r} has malformed source_dir field")
+            libs.append(
+                Library(
+                    name=name,
+                    uid=uid,
+                    local=local == "true",
+                    requires=tuple(requires),
+                    source_dir=source_dir,
+                )
+            )
         for ch in node:
             visit(ch)
 
     visit(sexp)
+    seen_uids: dict[str, Library] = {}
+    for lib in libs:
+        previous = seen_uids.get(lib.uid)
+        if previous is not None:
+            raise ValueError(
+                f"duplicate library uid {lib.uid!r}: {previous.name!r} and {lib.name!r}"
+            )
+        seen_uids[lib.uid] = lib
     return libs
+
+
+def find_build_context(sexp: Sexp) -> str:
+    contexts: list[str] = []
+
+    def visit(node: Sexp) -> None:
+        if not isinstance(node, list):
+            return
+        if len(node) == 2 and node[0] == "build_context" and isinstance(node[1], str):
+            contexts.append(node[1])
+        for child in node:
+            visit(child)
+
+    visit(sexp)
+    unique = sorted(set(contexts))
+    if len(unique) != 1:
+        raise ValueError(
+            f"expected exactly one build_context, found {len(unique)}: {unique}"
+        )
+    return unique[0]
 
 
 # --- core boundary check (pure; operates on a list of Library) ---------------
@@ -323,15 +373,122 @@ def _path_to(start: str, target: str, by_uid: dict[str, Library]) -> "list[str] 
     return None
 
 
+def validate_graph(libs: list[Library]) -> None:
+    """Fail closed when describe output is not a complete UID graph."""
+    by_uid = {lib.uid: lib for lib in libs}
+    dangling = sorted(
+        (lib.name, uid) for lib in libs for uid in lib.requires if uid not in by_uid
+    )
+    if dangling:
+        rendered = ", ".join(f"{name} -> {uid}" for name, uid in dangling[:8])
+        suffix = " ..." if len(dangling) > 8 else ""
+        raise ValueError(
+            f"describe graph has dangling requires UIDs: {rendered}{suffix}"
+        )
+
+
+def _source_root_path(value: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if path.is_absolute() or not path.parts or ".." in path.parts:
+        raise ValueError(
+            f"closed source root must be a normalized relative path: {value!r}"
+        )
+    return path
+
+
+def _local_source_relative(lib: Library, build_context: str) -> PurePosixPath:
+    if not lib.local:
+        raise ValueError(f"cannot classify external library {lib.name!r} as local")
+    source = PurePosixPath(lib.source_dir)
+    context = PurePosixPath(build_context)
+    try:
+        relative = source.relative_to(context)
+    except ValueError as exc:
+        raise ValueError(
+            f"local library {lib.name!r} source_dir {lib.source_dir!r} "
+            f"is outside build_context {build_context!r}"
+        ) from exc
+    if ".." in relative.parts:
+        raise ValueError(
+            f"local library {lib.name!r} has non-normal source_dir {lib.source_dir!r}"
+        )
+    return relative
+
+
+def check_closed_source_root(
+    libs: list[Library],
+    *,
+    build_context: str,
+    source_root: str,
+    required_local_library: "str | None" = None,
+) -> list[SourceRootViolation]:
+    """Reject local libraries outside a directory-restricted describe graph.
+
+    The caller must capture ``dune describe workspace SOURCE_ROOT``. Dune then
+    emits the libraries declared below SOURCE_ROOT plus their resolved
+    dependency closure. External libraries are represented explicitly as
+    ``local false`` and remain allowed; any ``local true`` node owned elsewhere
+    in the workspace is a reverse dependency across the package boundary.
+    """
+    root = _source_root_path(source_root)
+    local_libs = [lib for lib in libs if lib.local]
+    if not local_libs:
+        raise ValueError("closed source-root graph contains no local libraries")
+
+    relative_by_uid = {
+        lib.uid: _local_source_relative(lib, build_context) for lib in local_libs
+    }
+
+    if required_local_library is not None:
+        anchors = [lib for lib in local_libs if lib.name == required_local_library]
+        if len(anchors) != 1:
+            raise ValueError(
+                f"required local library {required_local_library!r} must appear "
+                f"exactly once, found {len(anchors)}"
+            )
+        anchor_path = relative_by_uid[anchors[0].uid]
+        if anchor_path != root and root not in anchor_path.parents:
+            raise ValueError(
+                f"required local library {required_local_library!r} is owned by "
+                f"{anchors[0].source_dir!r}, not {source_root!r}"
+            )
+
+    violations: list[SourceRootViolation] = []
+    for lib in local_libs:
+        relative = relative_by_uid[lib.uid]
+        if relative != root and root not in relative.parents:
+            violations.append(
+                SourceRootViolation(library=lib.name, source_dir=lib.source_dir)
+            )
+    return sorted(violations, key=lambda item: (item.library, item.source_dir))
+
+
 # --- describe acquisition ----------------------------------------------------
 
 
-def load_describe(root: str, describe_file: "str | None") -> Sexp:
+def load_describe(
+    root: str,
+    describe_file: "str | None",
+    closed_source_root: "str | None" = None,
+) -> Sexp:
     if describe_file is not None:
         text = open(describe_file, encoding="utf-8").read()
     else:
+        command = [
+            "dune",
+            "describe",
+            "workspace",
+            "--root",
+            root,
+            "--format",
+            "sexp",
+            "--lang",
+            "0.1",
+        ]
+        if closed_source_root is not None:
+            command.extend(["--with-pps", closed_source_root])
         proc = subprocess.run(
-            ["dune", "describe", "--root", root],
+            command,
             capture_output=True,
             text=True,
             check=False,
@@ -352,21 +509,91 @@ def load_describe(root: str, describe_file: "str | None") -> Sexp:
 def self_test() -> int:
     """RFC-0001 / TLA bug-model homolog: a gate is only valid if it PASSES on a
     clean graph AND FAILS on a graph with the bug injected. Both must hold."""
-    mega = Library(name="masc", uid="MEGA", requires=("LEAF", "OTHER"))
-    neutral = Library(name="masc_core", uid="CORE", requires=())
+
+    described = parse(
+        tokenize(
+            """(
+              (root /WORKSPACE_ROOT)
+              (build_context _build/default)
+              (executables
+                ((names (probe))
+                 (requires (AGENT_CORE))
+                 (modules ())
+                 (include_dirs ())))
+              (library
+                ((name masc.agent_core)
+                 (uid AGENT_CORE)
+                 (local true)
+                 (requires (YOJSON))
+                 (source_dir _build/default/packages/agent_core/lib)
+                 (modules ())
+                 (include_dirs ())))
+              (library
+                ((name yojson)
+                 (uid YOJSON)
+                 (local false)
+                 (requires ())
+                 (source_dir /FINDLIB/yojson)
+                 (modules ())
+                 (include_dirs ()))))
+            """
+        )
+    )
+    described = described[0] if len(described) == 1 else described
+    decoded = find_libraries(described)
+    if [lib.name for lib in decoded] != ["masc.agent_core", "yojson"]:
+        print(
+            f"SELF-TEST FAIL: describe schema decoded unexpected libraries: {decoded}"
+        )
+        return 1
+    if find_build_context(described) != "_build/default":
+        print("SELF-TEST FAIL: describe schema decoded unexpected build context")
+        return 1
+    validate_graph(decoded)
+    print("self-test: Dune 0.1 describe schema decodes strictly (PASS)")
+
+    def local(
+        name: str, uid: str, requires: tuple[str, ...], source_dir: str
+    ) -> Library:
+        return Library(
+            name=name,
+            uid=uid,
+            local=True,
+            requires=requires,
+            source_dir=source_dir,
+        )
+
+    def external(name: str, uid: str, requires: tuple[str, ...] = ()) -> Library:
+        return Library(
+            name=name,
+            uid=uid,
+            local=False,
+            requires=requires,
+            source_dir=f"/FINDLIB/{name}",
+        )
+
+    mega = local("masc", "MEGA", ("LEAF", "OTHER"), "_build/default/lib")
+    neutral = local("masc_core", "CORE", (), "_build/default/lib/core")
+    other = external("other", "OTHER")
     # clean: leaf depends only on neutral; mega depends on leaf (allowed direction)
-    clean_leaf = Library(name="masc.masc_goal", uid="LEAF", requires=("CORE",))
-    clean = [mega, neutral, clean_leaf]
+    clean_leaf = local("masc.masc_goal", "LEAF", ("CORE",), "_build/default/lib/goal")
+    clean = [mega, neutral, clean_leaf, other]
     # buggy: leaf re-couples to the mega-lib (direct)
-    buggy_leaf = Library(name="masc.masc_goal", uid="LEAF", requires=("CORE", "MEGA"))
-    buggy = [mega, neutral, buggy_leaf]
+    buggy_leaf = local(
+        "masc.masc_goal", "LEAF", ("CORE", "MEGA"), "_build/default/lib/goal"
+    )
+    buggy = [mega, neutral, buggy_leaf, other]
     # buggy-transitive: leaf -> mid -> mega
-    mid = Library(name="masc.mid", uid="MID", requires=("MEGA",))
-    trans_leaf = Library(name="masc.masc_goal", uid="LEAF", requires=("MID",))
-    buggy_trans = [mega, neutral, mid, trans_leaf]
+    mid = local("masc.mid", "MID", ("MEGA",), "_build/default/lib/mid")
+    trans_leaf = local("masc.masc_goal", "LEAF", ("MID",), "_build/default/lib/goal")
+    buggy_trans = [mega, neutral, mid, trans_leaf, other]
 
     leaves = ("masc.masc_goal",)
     ok = True
+
+    validate_graph(clean)
+    validate_graph(buggy)
+    validate_graph(buggy_trans)
 
     v_clean = check(clean, leaves)
     if v_clean:
@@ -390,6 +617,101 @@ def self_test() -> int:
         print(
             f"self-test: buggy graph (transitive) -> violation {v_trans[0].path} (PASS)"
         )
+
+    build_context = "_build/default"
+    source_root = "packages/agent_core"
+    agent_core = local(
+        "masc.agent_core",
+        "AGENT_CORE",
+        ("AGENT_STRINGS", "YOJSON"),
+        "_build/default/packages/agent_core/lib",
+    )
+    agent_strings = local(
+        "masc.agent_core.strings",
+        "AGENT_STRINGS",
+        (),
+        "_build/default/packages/agent_core/lib/strings",
+    )
+    yojson = external("yojson", "YOJSON")
+    closed_clean = [agent_core, agent_strings, yojson]
+    validate_graph(closed_clean)
+    v_closed_clean = check_closed_source_root(
+        closed_clean,
+        build_context=build_context,
+        source_root=source_root,
+        required_local_library="masc.agent_core",
+    )
+    if v_closed_clean:
+        ok = False
+        print(
+            f"SELF-TEST FAIL: clean closed source-root graph reported {v_closed_clean}"
+        )
+    else:
+        print("self-test: closed source root with external deps -> clean (PASS)")
+
+    coordinator = local(
+        "masc.keeper_runtime",
+        "KEEPER",
+        (),
+        "_build/default/lib/keeper_runtime",
+    )
+    closed_buggy = [
+        Library(
+            name=agent_core.name,
+            uid=agent_core.uid,
+            local=agent_core.local,
+            requires=("AGENT_STRINGS", "KEEPER"),
+            source_dir=agent_core.source_dir,
+        ),
+        agent_strings,
+        coordinator,
+    ]
+    validate_graph(closed_buggy)
+    v_closed_buggy = check_closed_source_root(
+        closed_buggy,
+        build_context=build_context,
+        source_root=source_root,
+        required_local_library="masc.agent_core",
+    )
+    if len(v_closed_buggy) != 1 or v_closed_buggy[0].library != coordinator.name:
+        ok = False
+        print(
+            "SELF-TEST FAIL: closed source-root graph did not reject local "
+            f"coordinator dependency: {v_closed_buggy}"
+        )
+    else:
+        print("self-test: closed source root rejects local coordinator dep (PASS)")
+
+    try:
+        check_closed_source_root(
+            [agent_strings, yojson],
+            build_context=build_context,
+            source_root=source_root,
+            required_local_library="masc.agent_core",
+        )
+    except ValueError:
+        print("self-test: missing required local library fails closed (PASS)")
+    else:
+        ok = False
+        print("SELF-TEST FAIL: missing required local library was accepted")
+
+    try:
+        validate_graph(
+            [
+                Library(
+                    name=agent_core.name,
+                    uid=agent_core.uid,
+                    local=agent_core.local,
+                    requires=("MISSING",),
+                    source_dir=agent_core.source_dir,
+                )
+            ]
+        )
+    except ValueError:
+        print("self-test: dangling UID fails closed (PASS)")
+    else:
+        ok = False
+        print("SELF-TEST FAIL: dangling UID was accepted")
 
     print("SELF-TEST: ALL PASS" if ok else "SELF-TEST: FAILED")
     return 0 if ok else 1
@@ -416,6 +738,24 @@ def main(argv: list[str]) -> int:
         help="leaf library that must not depend on the mega-lib (repeatable; adds to defaults)",
     )
     ap.add_argument(
+        "--closed-source-root",
+        default=None,
+        metavar="DIR",
+        help=(
+            "require every local library in this directory-restricted describe "
+            "graph to be owned below DIR"
+        ),
+    )
+    ap.add_argument(
+        "--required-local-library",
+        default=None,
+        metavar="LIB",
+        help=(
+            "with --closed-source-root, require exactly one local anchor library "
+            "named LIB below that source root"
+        ),
+    )
+    ap.add_argument(
         "--self-test",
         action="store_true",
         help="run the clean+buggy fixture dual-check and exit",
@@ -425,18 +765,27 @@ def main(argv: list[str]) -> int:
     if args.self_test:
         return self_test()
 
+    if args.required_local_library is not None and args.closed_source_root is None:
+        ap.error("--required-local-library requires --closed-source-root")
+
     leaves = DEFAULT_LEAVES + tuple(args.leaf)
     try:
-        sexp = load_describe(args.root, args.describe_file)
+        sexp = load_describe(args.root, args.describe_file, args.closed_source_root)
+        libs = find_libraries(sexp)
     except (RuntimeError, ValueError, OSError) as exc:
         print(f"audit-sublib-cycle: {exc}", file=sys.stderr)
         return 2
 
-    libs = find_libraries(sexp)
     if not libs:
         print(
             "audit-sublib-cycle: no libraries found in describe output", file=sys.stderr
         )
+        return 2
+
+    try:
+        validate_graph(libs)
+    except ValueError as exc:
+        print(f"audit-sublib-cycle: {exc}", file=sys.stderr)
         return 2
 
     violations = check(libs, leaves)
@@ -454,11 +803,45 @@ def main(argv: list[str]) -> int:
         )
         return 1
 
+    if args.closed_source_root is not None:
+        try:
+            build_context = find_build_context(sexp)
+            source_root_violations = check_closed_source_root(
+                libs,
+                build_context=build_context,
+                source_root=args.closed_source_root,
+                required_local_library=args.required_local_library,
+            )
+        except ValueError as exc:
+            print(f"audit-sublib-cycle: {exc}", file=sys.stderr)
+            return 2
+        if source_root_violations:
+            print(
+                "BOUNDARY VIOLATION: directory-restricted graph contains "
+                "workspace-local libraries owned outside the package",
+                file=sys.stderr,
+            )
+            for violation in source_root_violations:
+                print(f"  {violation.library}: {violation.source_dir}", file=sys.stderr)
+            print(
+                f"\nLibraries described from `{args.closed_source_root}` may depend only "
+                "on libraries owned below that source root or on external installed "
+                "libraries.",
+                file=sys.stderr,
+            )
+            return 1
+
     checked = [name for name in leaves if any(lib.name == name for lib in libs)]
     noun = "library" if len(checked) == 1 else "libraries"
     print(
         f"audit-sublib-cycle: OK - {len(checked)} leaf {noun} clean: {', '.join(checked) or '(none present)'}"
     )
+    if args.closed_source_root is not None:
+        local_count = sum(1 for lib in libs if lib.local)
+        print(
+            "audit-sublib-cycle: OK - "
+            f"{local_count} local libraries remain below {args.closed_source_root}"
+        )
     return 0
 
 

--- a/scripts/check-agent-core-boundary.sh
+++ b/scripts/check-agent-core-boundary.sh
@@ -9,211 +9,45 @@ fail() {
   exit 1
 }
 
+[[ ! -L "${core_root}" ]] || fail "package root must not be a symlink: ${core_root}"
 [[ -d "${core_root}/lib" ]] || fail "missing required source tree: ${core_root}/lib"
 [[ -f "${core_root}/lib/dune" ]] || fail "missing required root library stanza"
 [[ -f "${core_root}/test/dune" ]] || fail "missing required behavior suite"
 [[ -f "${core_root}/models.toml" ]] || fail "missing required model catalog"
 
-for forbidden in dune-project agent_core.opam .github release-please-config.json; do
-  [[ ! -e "${core_root}/${forbidden}" ]] \
-    || fail "independent package surface is forbidden: ${core_root}/${forbidden}"
-done
-
-# Dune accepts both an installed [public_name] and its workspace-private
-# [name] in a [libraries] field.  Build the private-name denylist from the
-# coordinator-owned library tree so a dependency such as [voice_config] or
-# [run_registry_core] cannot bypass the public [masc.*] namespace check.
-coordinator_library_names="$({
-  find "${repo_root}/lib" -type f \( -name dune -o -name '*.inc' \) \
-    -exec perl -0777 -ne '
-      while (/\(\s*name\s+([A-Za-z0-9_-]+)\s*\)/g) {
-        print "$1\n";
-      }
-    ' {} + \
-    | LC_ALL=C sort -u
-})" || fail "could not derive coordinator library names"
-[[ -n "${coordinator_library_names}" ]] \
-  || fail "coordinator library name registry is empty"
-coordinator_library_pattern="$(
-  printf '%s\n' "${coordinator_library_names}" | paste -sd '|' -
-)" || fail "could not build coordinator library matcher"
-
-emit_agent_core_dune_files() {
-  find "${core_root}" -type f -name dune -print0 \
-    | AGENT_CORE_SCAN_ROOT="${core_root}" perl -0 -e '
-      use strict;
-      use warnings;
-      use Cwd qw(abs_path);
-      use File::Basename qw(dirname);
-      use File::Spec;
-
-      my $root = abs_path($ENV{AGENT_CORE_SCAN_ROOT});
-      die "could not resolve agent core root\n" unless defined $root;
-
-      my @queue;
-      while (defined(my $path = <STDIN>)) {
-        $path =~ s/\0\z//;
-        push @queue, $path if length $path;
-      }
-
-      my %seen;
-      while (@queue) {
-        my $candidate = shift @queue;
-        my $path = abs_path($candidate);
-        die "missing Dune include: $candidate\n"
-          unless defined $path && -f $path;
-        die "Dune include escapes agent core: $path\n"
-          unless $path eq $root || index($path, $root . "/") == 0;
-        next if $seen{$path}++;
-
-        print $path, "\0";
-        open my $fh, "<", $path or die "could not read $path: $!\n";
-        local $/;
-        my $raw = <$fh>;
-        close $fh or die "could not close $path: $!\n";
-
-        my $code = "";
-        my $in_string = 0;
-        my $escaped = 0;
-        for (my $idx = 0; $idx < length($raw); $idx++) {
-          my $ch = substr($raw, $idx, 1);
-          if (!$in_string && $ch eq ";") {
-            $idx++ while $idx + 1 < length($raw)
-              && substr($raw, $idx + 1, 1) ne "\n";
-            next;
-          }
-          $code .= $ch;
-          if ($in_string && $escaped) {
-            $escaped = 0;
-          } elsif ($in_string && $ch eq "\\") {
-            $escaped = 1;
-          } elsif ($ch eq "\"") {
-            $in_string = !$in_string;
-          }
-        }
-        die "unterminated Dune string in $path\n" if $in_string;
-
-        my @tokens;
-        for (my $idx = 0; $idx < length($code); ) {
-          my $ch = substr($code, $idx, 1);
-          if ($ch =~ /\s/) {
-            $idx++;
-          } elsif ($ch eq "(") {
-            push @tokens, ["open", $ch];
-            $idx++;
-          } elsif ($ch eq ")") {
-            push @tokens, ["close", $ch];
-            $idx++;
-          } elsif ($ch eq "\"") {
-            $idx++;
-            my $value = "";
-            my $closed = 0;
-            while ($idx < length($code)) {
-              $ch = substr($code, $idx, 1);
-              if ($ch eq "\\") {
-                die "unterminated Dune escape in $path\n"
-                  if $idx + 1 >= length($code);
-                $value .= substr($code, $idx + 1, 1);
-                $idx += 2;
-              } elsif ($ch eq "\"") {
-                $closed = 1;
-                $idx++;
-                last;
-              } else {
-                $value .= $ch;
-                $idx++;
-              }
-            }
-            die "unterminated Dune string in $path\n" unless $closed;
-            push @tokens, ["value", $value];
-          } else {
-            my $start = $idx;
-            $idx++ while $idx < length($code)
-              && substr($code, $idx, 1) !~ /[\s()]/;
-            push @tokens, ["atom", substr($code, $start, $idx - $start)];
-          }
-        }
-
-        for (my $idx = 0; $idx + 3 < @tokens; $idx++) {
-          next unless $tokens[$idx][0] eq "open";
-          next unless $tokens[$idx + 1][0] eq "atom"
-            && $tokens[$idx + 1][1] eq "include";
-          next unless $tokens[$idx + 2][0] eq "atom"
-            || $tokens[$idx + 2][0] eq "value";
-          next unless $tokens[$idx + 3][0] eq "close";
-          my $target = $tokens[$idx + 2][1];
-          die "dynamic Dune include is unsupported in $path: $target\n"
-            if $target =~ /%\{/;
-          die "absolute Dune include is forbidden in $path: $target\n"
-            if File::Spec->file_name_is_absolute($target);
-          push @queue, File::Spec->catfile(dirname($path), $target);
-        }
-      }
-    '
+# Agent Core is a source subtree in the MASC workspace, not an independently
+# released package. Dune owns dependency resolution; this cheap guard owns only
+# the filesystem/package shape that Dune's library graph does not describe.
+if independent_surfaces="$(find "${core_root}" -mindepth 1 \
+  \( -name dune-project -o -name 'dune-workspace*' -o -name '*.opam' \
+     -o -name .github -o -name release-please-config.json \
+     -o -name .release-please-manifest.json \) -print)"; then
+  :
+else
+  fail "could not inspect package surfaces below ${core_root}"
+fi
+[[ -z "${independent_surfaces}" ]] || {
+  printf '%s\n' "${independent_surfaces}" >&2
+  fail "independent package surface is forbidden"
 }
 
-dune_violations="$({
-  # In Dune syntax, [;] starts a comment through end-of-line unless it appears
-  # inside a quoted string. Preserve quoted semicolons while scanning the code
-  # prefix so comments cannot hide or imitate a library dependency.
-  emit_agent_core_dune_files \
-    | while IFS= read -r -d '' dune_file; do
-        if code="$(awk '
-          BEGIN {
-            in_string = 0
-            escaped = 0
-          }
-          {
-            code = ""
-            for (i = 1; i <= length($0); i++) {
-              ch = substr($0, i, 1)
-              if (!in_string && ch == ";") break
-              code = code ch
-              if (in_string && escaped) {
-                escaped = 0
-              } else if (in_string && ch == "\\") {
-                escaped = 1
-              } else if (ch == "\"") {
-                in_string = !in_string
-              }
-            }
-            print code
-          }
-        ' "${dune_file}")"; then
-          :
-        else
-          exit $?
-        fi
-        if code="$(perl -0777 -pe '
-          s{\(\s*public_name\s+masc\.agent_core(?:\.[a-z_]+)?\s*\)}{
-            my $allowed = $&;
-            $allowed =~ s/[^\n]/ /g;
-            $allowed
-          }gex
-        ' <<< "${code}")"; then
-          :
-        else
-          exit $?
-        fi
-        if matches="$(rg -n \
-          -e 'masc[._]' \
-          -e "(^|[^A-Za-z0-9_.-])(${coordinator_library_pattern})([^A-Za-z0-9_.-]|$)" \
-          <<< "${code}")"; then
-          printf '%s\n' "${matches}" | sed "s#^#${dune_file}:#"
-        else
-          status=$?
-          # ripgrep uses 1 for "no matches". Any other status means the
-          # scanner itself failed, which must fail closed rather than silently
-          # accepting a dependency.
-          [[ "${status}" -eq 1 ]] || exit "${status}"
-        fi
-      done
-})" || fail "could not resolve or scan agent core Dune files"
-[[ -z "${dune_violations}" ]] || {
-  printf '%s\n' "${dune_violations}" >&2
-  fail "agent core must not depend on MASC coordinator libraries"
+# A source symlink can make Dune compile a coordinator-owned file while the
+# library itself still appears to live below packages/agent_core. Reject that
+# direct filesystem escape; generated-source provenance is outside this guard.
+if source_symlinks="$(find "${core_root}" -mindepth 1 -type l -print)"; then
+  :
+else
+  fail "could not inspect source links below ${core_root}"
+fi
+[[ -z "${source_symlinks}" ]] || {
+  printf '%s\n' "${source_symlinks}" >&2
+  fail "source symlinks are forbidden"
 }
 
+# Dune's resolved graph is the authority for library dependencies. Keep the
+# existing source-level coordinator-name guard as defense in depth until the
+# parser-backed replacement tracked by #28258 lands; it is intentionally not
+# presented as the dependency authority.
 coordinator_module_pattern='(Masc_[A-Za-z0-9_]*|Keeper_[A-Za-z0-9_]*|Board_[A-Za-z0-9_]*|Gate_[A-Za-z0-9_]*|Server_[A-Za-z0-9_]*|Operator_[A-Za-z0-9_]*|Runtime_agent|Runtime_toml|Workspace_[A-Za-z0-9_]*)'
 if module_violations="$(rg -n \
   -e "\\b${coordinator_module_pattern}\\." \
@@ -236,4 +70,4 @@ fi
   fail "agent core source imports a MASC coordinator module"
 }
 
-echo "agent-core boundary: ok"
+echo "agent-core package shape: ok"

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -70,6 +70,9 @@ normal_targets=(
   @test/runtest-test_schedule_store
   @test/runtest-test_schedule_consumer_dispatch
   @test/runtest-test_keeper_registry_hardening
+  @test/runtest-test_keeper_reaction_ledger
+  @test/runtest-test_exact_lane_run_registry
+  @test/runtest-test_ci_run_tests_script
   @test/runtest-test_keeper_unified_verification_surface
   @test/runtest-test_schedule_tool_wiring
   @test/runtest-test_keeper_system_prompt_bytes

--- a/test/stanzas/test_ci_run_tests_script.inc
+++ b/test/stanzas/test_ci_run_tests_script.inc
@@ -1,4 +1,5 @@
 (test
  (name test_ci_run_tests_script)
  (modules test_ci_run_tests_script)
+ (deps %{workspace_root}/scripts/ci-run-tests.sh)
  (libraries alcotest unix masc.string_util))

--- a/test/test_agent_core_boundary.sh
+++ b/test/test_agent_core_boundary.sh
@@ -6,100 +6,53 @@ gate="${repo_root}/scripts/check-agent-core-boundary.sh"
 fixture="$(mktemp -d)"
 trap 'rm -rf "${fixture}"' EXIT
 
-mkdir -p "${fixture}/lib" "${fixture}/test"
-touch "${fixture}/models.toml" "${fixture}/test/dune"
-cat > "${fixture}/lib/dune" <<'EOF'
-; masc.string_util is documentation, not a dependency.
-(library
- (name agent_core_fixture)
- (public_name
-  masc.agent_core)
- (wrapped false)) ; masc.coordinator is also only a comment.
-EOF
+make_valid_fixture() {
+  rm -rf "${fixture:?}"/*
+  mkdir -p "${fixture}/lib" "${fixture}/test"
+  : > "${fixture}/lib/dune"
+  : > "${fixture}/test/dune"
+  : > "${fixture}/models.toml"
+}
 
+expect_rejected() {
+  local label="$1"
+  if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
+    echo "boundary self-test: ${label} was accepted" >&2
+    exit 1
+  fi
+}
+
+make_valid_fixture
 AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null
 
+rm "${fixture}/models.toml"
+expect_rejected "missing model catalog"
+
+make_valid_fixture
+mkdir -p "${fixture}/nested"
+: > "${fixture}/nested/dune-project"
+expect_rejected "nested independent Dune project"
+
+make_valid_fixture
+: > "${fixture}/nested.opam"
+expect_rejected "independent opam package"
+
+make_valid_fixture
+ln -s "${repo_root}/scripts/check-agent-core-boundary.sh" \
+  "${fixture}/lib/coordinator_source.ml"
+expect_rejected "source symlink"
+
+make_valid_fixture
 printf 'type event = Operator_requested | Operator_repair_required | Server_error\n' \
   > "${fixture}/lib/allowed_constructors.ml"
 AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null
-rm "${fixture}/lib/allowed_constructors.ml"
 
-cp "${fixture}/lib/dune" "${fixture}/lib/dune.safe"
-printf '\n(rule (action (echo "documentation; still a string"))) (library (name bad) (libraries masc.keeper))\n' >> "${fixture}/lib/dune"
-if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
-  echo "boundary self-test: quoted semicolon hid a reverse MASC dependency" >&2
-  exit 1
-fi
-
-cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
-printf '\n(rule (action (echo "documentation\nstill; a string"))) (library (name bad) (libraries masc.keeper))\n' >> "${fixture}/lib/dune"
-if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
-  echo "boundary self-test: multiline quoted semicolon hid a reverse MASC dependency" >&2
-  exit 1
-fi
-
-cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
-printf '\n(library (name bad) (libraries masc.keeper))\n' >> "${fixture}/lib/dune"
-if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
-  echo "boundary self-test: reverse MASC dependency was accepted" >&2
-  exit 1
-fi
-
-cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
-printf '\n(library (name bad) (public_name masc.agent_core.bad) (libraries masc.keeper))\n' >> "${fixture}/lib/dune"
-if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
-  echo "boundary self-test: public_name line hid a reverse MASC dependency" >&2
-  exit 1
-fi
-
-cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
-printf '(library (name bad) (libraries masc_keeper_runtime))\n' > "${fixture}/lib/deps.inc"
-printf '\n(include deps.inc)\n' >> "${fixture}/lib/dune"
-if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
-  echo "boundary self-test: included internal MASC dependency was accepted" >&2
-  exit 1
-fi
-
-cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
-rm "${fixture}/lib/deps.inc"
-mkdir -p "${fixture}/lib/fragments/nested"
-printf '(include nested/deps.data)\n' > "${fixture}/lib/fragments/outer.sexp"
-printf '(library (name bad) (libraries masc_keeper_runtime))\n' \
-  > "${fixture}/lib/fragments/nested/deps.data"
-printf '\n(include fragments/outer.sexp)\n' >> "${fixture}/lib/dune"
-if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
-  echo "boundary self-test: nested arbitrary Dune include was accepted" >&2
-  exit 1
-fi
-
-cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
-rm -rf "${fixture:?}/lib/fragments"
-printf '\n(library (name bad) (libraries voice_config))\n' >> "${fixture}/lib/dune"
-if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
-  echo "boundary self-test: private coordinator library name was accepted" >&2
-  exit 1
-fi
-
-cp "${fixture}/lib/dune.safe" "${fixture}/lib/dune"
 printf 'open Server_runtime\n' > "${fixture}/lib/open_bypass.ml"
-if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
-  echo "boundary self-test: opened coordinator module was accepted" >&2
-  exit 1
-fi
-rm "${fixture}/lib/open_bypass.ml"
+expect_rejected "opened coordinator module"
 
+make_valid_fixture
 printf 'module M : sig end = Server_runtime\n' \
   > "${fixture}/lib/constrained_alias_bypass.ml"
-if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
-  echo "boundary self-test: constrained coordinator alias was accepted" >&2
-  exit 1
-fi
-rm "${fixture}/lib/constrained_alias_bypass.ml"
-
-rm -rf "${fixture:?}/lib"
-if AGENT_CORE_ROOT="${fixture}" "${gate}" >/dev/null 2>&1; then
-  echo "boundary self-test: missing core tree was accepted" >&2
-  exit 1
-fi
+expect_rejected "constrained coordinator alias"
 
 echo "agent-core boundary self-test: ok"


### PR DESCRIPTION
## Summary

Closes #28254 by replacing the hand-written Dune dependency parser from #28253 with Dune's resolved workspace graph.

- capture a directory-restricted `dune describe workspace packages/agent_core --with-pps` graph in the existing Build job
- fail closed when any resolved `local true` library is owned outside `packages/agent_core`; installed `local false` dependencies remain allowed
- require the canonical `masc.agent_core` anchor, strict Dune 0.1 fields, unique UIDs, and a complete `requires` graph
- retain the existing coordinator-module source scan only as defense in depth, and reduce the shell guard to package-shape/symlink checks
- make Agent Core inputs force Build, run its cheap shape guard unconditionally, and wire three previously compile-only focused suites
- keep the classifier inductive by rejecting Agent Core/ancestor `include` and `dynamic_include` stanzas through Dune-normalized input, OCaml-syntax Dune files, alternative `dune-file` escape hatches, and symlinked active package/project/workspace authorities

This proves the resolved Dune library-dependency boundary, including ordinary, runtime-PPX, and `--with-pps` compile-time PPX closure. It deliberately does not claim generated-source or arbitrary compiler-flag provenance; the source-name scan remains separately tracked by #28258.

## Regression coverage

- captured Dune 0.1 schema decode: `local`, `source_dir`, `requires`, `build_context`
- clean in-package local libraries plus installed external dependency
- direct local coordinator dependency rejected
- missing canonical anchor rejected
- dangling dependency UID rejected
- Agent Core shape: missing catalog, nested package surface, opam surface, and source symlink rejected
- existing constructor-like names remain allowed while coordinator `open` and constrained aliases remain rejected
- active Dune input closure: root/package/core `dune` and `dune-file`, ancestor project/workspace inputs, nested include forms, OCaml-syntax files, and dangling symlinks

## Static validation

- `ruff check scripts/audit-sublib-cycle.py`
- `ruff format --check scripts/audit-sublib-cycle.py`
- `bash -n` and `shellcheck` on changed shell scripts
- `scripts/audit-ci-test-targets.sh`: 190 targets declared, 662 unwired at the tightened baseline
- `git diff --check`

Local Dune build/test/describe was not run; exact-head GitHub CI is the build and behavior authority.
