### PR TITLE
fix(dashboard): authorize Keeper operation controls

### DIFF
--- a/lib/server/server_dashboard_http_keeper_chat_operations.ml
+++ b/lib/server/server_dashboard_http_keeper_chat_operations.ml
@@ -4,6 +4,9 @@ module Operation_id = Operation.Operation_id
 module Owner = Keeper_owner
 module Registry = Keeper_owner_registry
 
+let read_permission = Masc_domain.CanReadState
+let mutation_permission = Masc_domain.CanBroadcast
+
 type get_route =
   | Operation_list of { keeper_name : string }
   | Operation_exact of

--- a/lib/server/server_dashboard_http_keeper_chat_operations.mli
+++ b/lib/server/server_dashboard_http_keeper_chat_operations.mli
@@ -18,6 +18,9 @@ type mutation_route =
   ; mutation : mutation
   }
 
+val read_permission : Masc_domain.permission
+val mutation_permission : Masc_domain.permission
+
 val get_route : string -> get_route option
 val mutation_route : string -> mutation_route option
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1751,7 +1751,7 @@ let add_routes ~sw ~clock router =
        match Keeper_chat_operations.get_route (Http.Request.path request) with
        | Some route ->
          with_token_permission_auth
-           ~permission:Masc_domain.CanAdmin
+           ~permission:Keeper_chat_operations.read_permission
            (fun state _agent_name req reqd ->
              Keeper_chat_operations.handle_get state req reqd route)
            request
@@ -1792,7 +1792,7 @@ let add_routes ~sw ~clock router =
        match Keeper_chat_operations.mutation_route (Http.Request.path request) with
        | Some route ->
          with_token_permission_auth
-           ~permission:Masc_domain.CanAdmin
+           ~permission:Keeper_chat_operations.mutation_permission
            (fun state _agent_name req reqd ->
              Http.Request.read_body_async reqd (fun body_str ->
                Keeper_chat_operations.handle_mutation

--- a/test/test_keeper_chat_operation_http.ml
+++ b/test/test_keeper_chat_operation_http.ml
@@ -3,6 +3,17 @@ open Masc
 
 module Api = Server_dashboard_http_keeper_chat_operations
 
+let test_dashboard_worker_permissions () =
+  check bool
+    "operation reads use read-state authority"
+    true
+    (Api.read_permission = Masc_domain.CanReadState);
+  check bool
+    "queued mutations use chat broadcast authority"
+    true
+    (Api.mutation_permission = Masc_domain.CanBroadcast)
+;;
+
 let test_exact_routes () =
   (match Api.get_route "/api/v1/keepers/sangsu/chat/operations" with
    | Some (Api.Operation_list { keeper_name }) ->
@@ -85,7 +96,11 @@ let () =
   run
     "keeper chat operation http"
     [ ( "routes"
-      , [ test_case "exact operation routes" `Quick test_exact_routes
+      , [ test_case
+            "dashboard Worker permissions"
+            `Quick
+            test_dashboard_worker_permissions
+        ; test_case "exact operation routes" `Quick test_exact_routes
         ; test_case "unknown routes do not match" `Quick test_unknown_routes_do_not_match
         ; test_case "mutation bodies are closed" `Quick test_mutation_bodies_are_closed
         ] )

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -684,6 +684,53 @@ let test_dashboard_dev_token_cannot_call_admin_route () =
   in
   check_status "dashboard Worker token denied CanAdmin route" 403 result
 
+let check_operation_error label expected_code result =
+  match Yojson.Safe.from_string result.body with
+  | `Assoc fields ->
+    (match List.assoc_opt "error" fields with
+     | Some (`String code) -> check string label expected_code code
+     | _ -> fail (label ^ ": missing typed operation error: " ^ result.body))
+  | _ -> fail (label ^ ": non-object operation error: " ^ result.body)
+  | exception Yojson.Json_error detail ->
+    fail (label ^ ": invalid JSON operation error: " ^ detail)
+;;
+
+let test_dashboard_dev_token_can_use_keeper_operation_routes () =
+  with_server @@ fun ~port ~auth_token ~base_path:_ ->
+  let headers =
+    [ "Accept", "application/json"
+    ; "Authorization", "Bearer " ^ auth_token
+    ; "Content-Type", "application/json"
+    ]
+  in
+  let operation_path =
+    "/api/v1/keepers/absent-keeper/chat/operations/kmsg-worker-auth"
+  in
+  let get_result =
+    run_curl ~headers ~max_time:2.0 ~port ~path:operation_path ()
+  in
+  check_status "dashboard Worker operation lookup reaches handler" 404 get_result;
+  check_operation_error
+    "dashboard Worker operation lookup typed error"
+    "unknown_operation"
+    get_result;
+  let cancel_result =
+    run_curl
+      ~headers
+      ~method_:"POST"
+      ~body:"{}"
+      ~max_time:2.0
+      ~port
+      ~path:(operation_path ^ "/cancel")
+      ()
+  in
+  check_status "dashboard Worker operation cancel reaches handler" 404 cancel_result;
+  check_operation_error
+    "dashboard Worker operation cancel typed error"
+    "unknown_operation"
+    cancel_result
+;;
+
 let test_official_client_recovery_uses_real_admin_route () =
   with_server @@ fun ~port ~auth_token ~base_path ->
   let keeper_name = "official-client-http-fixture" in
@@ -873,6 +920,10 @@ let () =
             "dev-token cannot call admin route"
             `Slow
             test_dashboard_dev_token_cannot_call_admin_route
+        ; test_case
+            "dev-token can use Keeper operation routes"
+            `Slow
+            test_dashboard_dev_token_can_use_keeper_operation_routes
         ; test_case
             "official-client recovery uses real CanAdmin route"
             `Slow


### PR DESCRIPTION
## Summary

- allow the loopback Dashboard Worker to hydrate exact/queued Keeper chat operations with `CanReadState`
- authorize queued edit/move/cancel with the same `CanBroadcast` capability as Keeper chat submit and cancel
- keep unrelated administrative routes on `CanAdmin`; no role broadening, compatibility path, or legacy reader

## Root cause

The operation routes were wired to `CanAdmin`, while `/api/v1/dashboard/dev-token` intentionally issues a Worker credential that cannot administer. Durable submit and live SSE therefore worked, but reconnect hydration and queued controls always returned 403 in the real Dashboard.

## Verification

- `scripts/dune-local.sh build test/test_keeper_chat_operation_http.exe test/test_sse_storm_e2e.exe`
- `test_keeper_chat_operation_http`: 4/4
- `test_sse_storm_e2e` with loopback server: 7/7
- `ocamlformat --check` on all touched OCaml files
- `git diff --check`

[근거] exact head 9f348d8a5f + focused unit and loopback HTTP E2E, 2026-08-12 KST, confidence High