### PR TITLE
refactor(ocaml): add typed functional-core boundary audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,6 +797,17 @@ jobs:
           wait "${heartbeat_pid}" 2>/dev/null || true
           exit "${build_status}"
 
+      - name: Run typed functional-core boundary audit
+        env:
+          OCAML_BOUNDARY_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}"
+          fi
+          opam exec -- dune build --root . @tools/ocaml_boundary_audit/runtest
+          bash scripts/ocaml-boundary-ratchet.sh
+
       - name: Run runtime deployment preflight self-test
         if: ${{ always() && steps.build_step.outcome == 'success' }}
         env:

--- a/docs/architecture/functional-core-effect-boundary.md
+++ b/docs/architecture/functional-core-effect-boundary.md
@@ -1,0 +1,172 @@
+# Functional Core / Effect Shell
+
+This is the living implementation contract for new and refactored OCaml in
+`lib/`, `bin/`, and `packages/agent_core/lib/`. RFC-0371 records the campaign
+evidence; this document owns the lasting code shape.
+
+The target flow is concrete and intentionally small:
+
+```text
+wire / env / clock / disk
+          |
+          v
+resolve : Raw.t -> (Resolved.t, Resolve_error.t) result
+          |
+          v
+decide  : State.t -> Resolved.t -> (State.t * Command.t list, Domain_error.t) result
+          |
+          v
+execute : effects -> Command.t -> (Receipt.t, Effect_error.t) result
+```
+
+Do not introduce a generic monad transformer or application-wide Async layer.
+Eio remains direct style; domain-specific `resolve`, `decide`, and `execute`
+functions make the boundary visible in ordinary OCaml types.
+
+## Meanings of absence and failure
+
+- `option` means a value may genuinely be absent while the containing value is
+  still valid. Each public optional field documents what `None` means.
+- `result` means a named operation can fail in a way its caller can decide.
+  Recoverable errors are closed variants until an HTTP, MCP, persistence, or
+  logging renderer turns them into bytes.
+- Missing, malformed, unavailable, and rejected are different states. Do not
+  collapse them into `None`, a boolean, or a message that another in-process
+  consumer must parse.
+- Exceptions are for cancellation and defects the current layer cannot decide.
+  A handler must translate a specific exception or let it unwind. In
+  particular, `Eio.Cancel.Cancelled` is never turned into a default or domain
+  error.
+
+Use `let*` to sequence one `option` or one `result` happy path. It does not make
+nested uncertainty clearer, and it does not justify mixing I/O with pure
+decision logic in one chain.
+
+## Resolve once, carry the value
+
+Partial extraction and anonymous failure erasure are forbidden:
+
+```ocaml
+(* Wrong: validation and use can drift apart. *)
+if Option.is_some request.owner then dispatch (Option.get request.owner)
+
+(* Right: the boundary resolves one domain value. *)
+let resolve_owner = function
+  | Some owner -> Ok owner
+  | None -> Error Missing_owner
+
+let* owner = resolve_owner request.owner in
+dispatch owner
+```
+
+- Do not add `Option.get` or `Result.get_ok`.
+- Do not erase an error with `Result.to_option` or
+  `Parse_outcome.to_option`. If a product boundary intentionally maps named
+  errors to absence, implement an explicit policy function whose match and
+  tests say which errors become `None`.
+- `Option.value` is not globally forbidden. A default is valid when the owning
+  boundary defines it as domain policy. Prefer a named resolver and an explicit
+  match so the policy is reviewable.
+- Do not validate a field, discard the proof, and inspect the raw field again.
+  A private `Resolved.t` or closed variant should make invalid internal states
+  unrepresentable.
+
+## Pure decision cores
+
+A pure module consumes time, randomness, identity, and configuration as
+ordinary values supplied by its caller. It does not read the environment,
+clock, filesystem, network, process state, random generator, mutable global, or
+logger itself.
+
+```ocaml
+val decide : now:float -> State.t -> Command.t ->
+  (State.t * Effect_command.t list, Domain_error.t) result
+```
+
+Only modules listed in `scripts/ocaml-pure-modules.txt` carry this mechanically
+enforced promise. Grow that list after a module has a focused pure interface and
+tests. Living entries cannot be removed, and there is no effect exception list
+for a registered module.
+
+## Eio, locks, and exact effects
+
+- The creator of an `Eio.Switch.t` owns child fibers and resource lifetime. A
+  live resource does not escape its switch.
+- Snapshot immutable state while holding a mutex, release the lock, then do
+  I/O, logging, callbacks, or awaits. State changes are pure transitions and
+  the synchronization holder swaps or commits their result.
+- Moving an effect outward must not weaken durable authority. Stores retain
+  atomic state plus WAL/outbox/receipt commits; publish occurs from the durable
+  receipt rather than a reconstructed guess.
+- Invalid input produces no filesystem mutation, queue append, memory swap, or
+  success SSE event.
+- External formats are current-only and fail closed. Update every in-repo
+  producer and consumer in the same PR; do not add compatibility readers,
+  deprecated aliases, fallback shapes, or dual writes.
+
+## Typed-tree gate
+
+`tools/ocaml_boundary_audit` reads Dune-produced `.cmt` files and uses resolved
+compiler paths. Aliasing `Option` cannot hide `Stdlib.Option.get`, while an
+unrelated local module named `Option` is not a false positive. It also fails if
+any production `.ml` lacks a typed tree, so an unwired source cannot disappear
+from the audit silently.
+
+The hard gate is deliberately narrow:
+
+- partial extraction: `Option.get`, `Result.get_ok`;
+- failure erasure: `Result.to_option`, `Parse_outcome.to_option`;
+- canonical effect APIs inside explicitly registered pure modules.
+
+The first two categories have an exact baseline keyed by source, lexical
+binding, resolved callee, and count. It may only decrease. Pure-module effects
+have no baseline and fail immediately.
+
+The audit does **not** globally reject `Option.value`, catch-all handlers, or
+every filesystem call. Those require ownership and data-flow evidence. Repeated
+inspection of the same optional binding, cancellation absorption, and effects
+inside critical sections become hard rules only as category-specific analyses
+prove the bad flow without rejecting legitimate boundary orchestration.
+
+CI runs the audit after the authoritative `@default @check @install` build:
+
+```sh
+bash scripts/ocaml-boundary-ratchet.sh
+bash scripts/ocaml-boundary-ratchet.sh --json
+bash scripts/ocaml-boundary-ratchet.sh --regenerate  # reductions only
+```
+
+## PR shape and proof
+
+Use a small PR when one debt bucket can fall without changing a cross-module
+contract. Use a larger PR only when the boundary type must cross all producers
+and consumers together.
+
+Every slice states:
+
+1. which uncertainty or effect moves to which owner;
+2. the characterization test that pins observable behavior;
+3. unhappy paths proving resolution failure has zero side effects;
+4. focused Dune targets for touched modules plus this boundary audit; and
+5. source, exact-head CI, merge, deployment, and live evidence as separate
+   claims.
+
+## Sources
+
+- OCaml distinguishes optional absence from explicit success/failure
+  composition. [근거] [OCaml error handling](https://ocaml.org/docs/error-handling),
+  checked 2026-08-12, confidence High.
+- OCaml effect handlers are a low-level language mechanism; application
+  concurrency here follows Eio structured direct style. [근거]
+  [OCaml 5.5 effect handlers](https://ocaml.org/manual/5.5/effects.html) and
+  [Eio documentation](https://ocaml.org/p/eio/latest/doc/README.html), checked
+  2026-08-12, confidence High.
+- Haskell `Maybe`/`Either` motivate composing one uncertainty value instead of
+  reopening it branch by branch. [근거]
+  [Data.Maybe](https://hackage.haskell.org/package/base/docs/Data-Maybe.html) and
+  [Data.Either](https://hackage.haskell.org/package/base/docs/Data-Either.html),
+  checked 2026-08-12, confidence High.
+- Clojure's separation of immutable values from coordinated identity updates
+  informs pure transitions plus an outer commit boundary. [근거]
+  [Clojure values and change](https://clojure.org/about/state), checked
+  2026-08-12, confidence High.

--- a/lib/dune
+++ b/lib/dune
@@ -4,7 +4,8 @@
  (flags :standard)
  (public_name masc)
  (private_modules
-  keeper_fs_durable_directory)
+  keeper_fs_durable_directory
+  keeper_runtime_trust_snapshot_core)
  (libraries
   mcp_protocol
   mcp_protocol.eio

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -3,6 +3,8 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_runtime_trust_timeline
 
+module Trust_core = Keeper_runtime_trust_snapshot_core
+
 (** Short-lived cache for [snapshot_json]. The result is expensive to compute
     (tail-reads decision log, tool-call log, receipts, approval audit, and
     pending approvals) and is requested repeatedly by dashboard renders. The
@@ -161,13 +163,14 @@ let current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
   then None
   else latest_receipt
 
-let runtime_blocker_timeline_ts ~meta ~runtime_blocker_fields latest_receipt =
+let runtime_blocker_timeline_ts ~observed_at_unix ~meta
+    ~runtime_blocker_fields latest_receipt =
   if
     runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
       latest_receipt
     && meta.runtime.usage.last_turn_ts > 0.0
   then meta.runtime.usage.last_turn_ts
-  else Time_compat.now ()
+  else observed_at_unix
 
 let latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
     ~latest_receipt =
@@ -263,12 +266,6 @@ let pending_approval_projection_with_reader
         error = Some error;
       }
 
-let pending_approval_projection ~base_path ~keeper_name =
-  pending_approval_projection_with_reader
-    ~read_pending:
-      Keeper_approval_queue.list_pending_dashboard_json_for_workspace
-    ~base_path ~keeper_name
-
 let approval_queue_attention_of_projection
       ~base_path
       (projection : pending_approval_projection)
@@ -282,54 +279,6 @@ let approval_queue_attention_of_projection
       ; reason = "approval queue projection has no current state"
       }
 
-let disposition_of_snapshot ~pending_approval_projection
-    ~runtime_blocker_fields =
-  let blocker_class = assoc_string_opt "runtime_blocker_class" runtime_blocker_fields in
-  let blocker_summary =
-    assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields
-  in
-  let sandbox_summary =
-    match blocker_summary with
-    | Some summary when String_util.contains_substring_ci summary "sandbox" ->
-        Some ("Alert", "sandbox_violation")
-    | _ -> None
-  in
-  match pending_approval_projection.count with
-  | None -> ("Alert", "approval_queue_unavailable")
-  | Some pending_approval_count when pending_approval_count > 0 ->
-      ("Alert", "pending_operator_decision")
-  | Some _ ->
-    match blocker_class with
-    | Some raw_blocker_class -> (
-      match
-        Keeper_meta_contract.blocker_class_of_serialized_string raw_blocker_class
-      with
-      | Some (Keeper_meta_contract.Runtime_exhausted _) ->
-          ("Alert", "runtime_exhausted")
-      | Some _ | None -> (
-        match sandbox_summary with
-        | Some disposition -> disposition
-        | None -> ("Alert", "critical_block")))
-    | None -> (
-      match sandbox_summary with
-      | Some disposition -> disposition
-      | None -> ("Pass", "healthy"))
-
-let operator_disposition_of_display ~disposition ~disposition_reason =
-  match disposition with
-  | "Pass" -> ("pass", disposition_reason)
-  | "Blocked" | "Pause" -> ("fail_open_next_runtime", disposition_reason)
-  | "Alert" | _ -> ("unknown", disposition_reason)
-
-let display_disposition_of_operator ~operator_disposition
-    ~operator_disposition_reason =
-  Keeper_operator_disposition_display.of_wire ~operator_disposition
-    ~operator_disposition_reason
-
-let display_disposition_requires_attention = function
-  | "Blocked" | "Pause" | "Alert" -> true
-  | _ -> false
-
 let receipt_operator_disposition receipt =
   match
     ( json_string_opt_member "operator_disposition" receipt,
@@ -339,46 +288,44 @@ let receipt_operator_disposition receipt =
   | Some disposition, None -> Some (disposition, "")
   | None, _ -> None
 
-let effective_disposition_fields ~approval_queue_available
-    ~fallback_disposition ~fallback_reason
-    latest_receipt =
-  match
-    if approval_queue_available
-    then Option.bind latest_receipt receipt_operator_disposition
-    else None
-  with
-  | Some (operator_disposition, operator_disposition_reason) ->
-      let disposition, disposition_reason =
-        display_disposition_of_operator ~operator_disposition
-          ~operator_disposition_reason
-      in
-      ( disposition,
-        disposition_reason,
-        operator_disposition,
-        operator_disposition_reason )
-  | None ->
-      let operator_disposition, operator_disposition_reason =
-        operator_disposition_of_display ~disposition:fallback_disposition
-          ~disposition_reason:fallback_reason
-      in
-      ( fallback_disposition,
-        fallback_reason,
-        operator_disposition,
-        operator_disposition_reason )
+let approval_queue_state_of_projection
+    (projection : pending_approval_projection) =
+  match projection.count, projection.error with
+  | Some count, None -> Trust_core.Approval_queue_available count
+  | _, Some _ | None, None -> Trust_core.Approval_queue_unavailable
+;;
 
-let attention_reason_or_disposition ~needs_attention ~disposition_reason
-    attention_fields =
-  match assoc_string_opt "attention_reason" attention_fields with
-  | Some _ as value -> value
-  | None when needs_attention -> Some disposition_reason
-  | None -> None
+let trust_model_of_observations ~pending_approval_projection
+    ~runtime_blocker_fields ~latest_receipt ~latest_next_action
+    ~attention_fields =
+  Trust_core.decide
+    { approval_queue =
+        approval_queue_state_of_projection pending_approval_projection
+    ; runtime_blocker_class =
+        assoc_string_opt "runtime_blocker_class" runtime_blocker_fields
+    ; runtime_blocker_summary =
+        assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields
+    ; receipt_operator_disposition =
+        Option.bind latest_receipt receipt_operator_disposition
+    ; attention_needs_attention =
+        assoc_bool_default "needs_attention" ~default:false attention_fields
+    ; attention_reason = assoc_string_opt "attention_reason" attention_fields
+    ; attention_next_human_action =
+        assoc_string_opt "next_human_action" attention_fields
+    ; terminal_next_human_action = latest_next_action
+    }
+;;
 
-let next_human_action_or_terminal ~needs_attention ~latest_next_action
-    attention_fields =
-  match assoc_string_opt "next_human_action" attention_fields with
-  | Some _ as value -> value
-  | None when needs_attention -> latest_next_action
-  | None -> None
+let trust_model_json_fields (model : Trust_core.t) =
+  [ "disposition", `String model.disposition
+  ; "disposition_reason", `String model.disposition_reason
+  ; "operator_disposition", `String model.operator_disposition
+  ; "operator_disposition_reason", `String model.operator_disposition_reason
+  ; "needs_attention", `Bool model.needs_attention
+  ; "attention_reason", Json_util.string_opt_to_json model.attention_reason
+  ; "next_human_action", Json_util.string_opt_to_json model.next_human_action
+  ]
+;;
 
 let decision_log_persistence_surface = "keeper_runtime_trust_decision_log"
 
@@ -548,11 +495,12 @@ let approval_state_json ~pending_approval_projection
         | None -> `Null );
     ]
 
-let approval_queue_unavailable_timeline_event pending_approval_projection =
+let approval_queue_unavailable_timeline_event ~observed_at_unix
+    pending_approval_projection =
   match pending_approval_projection.error with
   | None -> None
   | Some (error : Keeper_approval_queue.storage_error) ->
-      let ts_unix = Time_compat.now () in
+      let ts_unix = observed_at_unix in
       Some
         (`Assoc
           [
@@ -667,11 +615,12 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
         Json_util.string_opt_to_json (Option.bind latest_receipt (json_string_opt_member "ended_at")) );
     ]
 
-let latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
-    ~latest_tool_call ~latest_approval_audit ~runtime_blocker_fields
-    ~next_human_action =
-  let observed_at_unix =
-    runtime_blocker_timeline_ts ~meta ~runtime_blocker_fields latest_receipt
+let latest_causal_event_summary ~observed_at_unix ~meta ~latest_decision
+    ~latest_receipt ~latest_tool_call ~latest_approval_audit
+    ~runtime_blocker_fields ~next_human_action =
+  let blocker_ts_unix =
+    runtime_blocker_timeline_ts ~observed_at_unix ~meta
+      ~runtime_blocker_fields latest_receipt
   in
   let blocker_observation_only =
     not
@@ -687,7 +636,8 @@ let latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
     Option.bind latest_receipt receipt_timeline_event;
     Option.bind latest_tool_call tool_call_timeline_event;
     Option.bind latest_approval_audit approval_event_timeline_event;
-    blocker_timeline_event ~ts_unix:observed_at_unix ~observed_at_unix
+    blocker_timeline_event ~ts_unix:blocker_ts_unix
+      ~observed_at_unix:blocker_ts_unix
       ~runtime_blocker_fields ?task_id ~goal_ids
       ~trace_id ~next_human_action
       ~observation_only:blocker_observation_only ();
@@ -704,41 +654,50 @@ let approval_audit_rows_or_fail = function
        ^ Keeper_approval.Audit.read_error_to_string error)
 ;;
 
-let summary_json ~(config : Workspace.config) ~(meta : keeper_meta) =
+type raw_observations =
+  { latest_decision : Yojson.Safe.t option
+  ; latest_tool_call : Yojson.Safe.t option
+  ; latest_receipt : Yojson.Safe.t option
+  ; latest_approval_audit : Yojson.Safe.t option
+  ; pending_approval_projection : pending_approval_projection
+  ; runtime_blocker_fields : (string * Yojson.Safe.t) list
+  ; attention_fields : (string * Yojson.Safe.t) list
+  ; observed_at_unix : float
+  }
+
+type raw_snapshot =
+  { observations : raw_observations
+  ; registry_entry : Keeper_registry.registry_entry option
+  ; runtime_contract : Yojson.Safe.t
+  ; recent_tool_call_rows : Yojson.Safe.t list
+  ; recent_approval_audit_rows : Yojson.Safe.t list
+  ; recent_transition_rows : Yojson.Safe.t list
+  }
+
+let collect_raw_observations_with_pending_reader
+    ~(read_pending :
+       base_path:string ->
+       (Yojson.Safe.t list, Keeper_approval_queue.storage_error) result)
+    ~approval_audit_limit ~(config : Workspace.config) ~(meta : keeper_meta) =
   let latest_decision = latest_decision_json ~config ~keeper_name:meta.name in
   let latest_tool_call = latest_tool_call_json ~keeper_name:meta.name in
   let latest_receipt = latest_receipt_json ~config ~keeper_name:meta.name in
+  let recent_approval_audit_rows =
+    Keeper_approval.Audit.read_recent ~base_path:config.base_path
+      ~keeper_name:meta.name ~n:approval_audit_limit ()
+    |> approval_audit_rows_or_fail
+  in
   let latest_approval_audit =
-    match
-      Keeper_approval.Audit.read_recent ~base_path:config.base_path
-        ~keeper_name:meta.name ~n:1 ()
-      |> approval_audit_rows_or_fail
-    with
+    match recent_approval_audit_rows with
     | json :: _ -> Some json
     | [] -> None
   in
   let pending_approval_projection =
-    pending_approval_projection ~base_path:config.base_path
-      ~keeper_name:meta.name
+    pending_approval_projection_with_reader ~read_pending
+      ~base_path:config.base_path ~keeper_name:meta.name
   in
   let runtime_blocker_fields =
     Keeper_status_bridge.runtime_blocker_fields_json config meta
-  in
-  let latest_receipt_for_runtime_state =
-    current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
-      latest_receipt
-  in
-  let latest_terminal_reason =
-    latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
-      ~latest_receipt
-  in
-  let latest_terminal_reason_json =
-    latest_terminal_reason
-    |> Option.map Keeper_turn_terminal.to_json
-    |> Option.value ~default:`Null
-  in
-  let latest_next_action =
-    Option.bind latest_terminal_reason (fun reason -> reason.next_action)
   in
   let attention_fields =
     Keeper_status_bridge.attention_fields_json_with_approval_queue
@@ -748,80 +707,103 @@ let summary_json ~(config : Workspace.config) ~(meta : keeper_meta) =
          ~base_path:config.base_path
          pending_approval_projection)
   in
-  let fallback_disposition, fallback_disposition_reason =
-    disposition_of_snapshot ~pending_approval_projection
-      ~runtime_blocker_fields
+  let observed_at_unix = Time_compat.now () in
+  ( { latest_decision
+    ; latest_tool_call
+    ; latest_receipt
+    ; latest_approval_audit
+    ; pending_approval_projection
+    ; runtime_blocker_fields
+    ; attention_fields
+    ; observed_at_unix
+    }
+  , recent_approval_audit_rows )
+;;
+
+let collect_summary_raw ~(config : Workspace.config) ~(meta : keeper_meta) =
+  collect_raw_observations_with_pending_reader
+    ~read_pending:
+      Keeper_approval_queue.list_pending_dashboard_json_for_workspace
+    ~approval_audit_limit:1 ~config ~meta
+  |> fst
+;;
+
+let summary_json_of_raw ~(meta : keeper_meta) (raw : raw_observations) =
+  let latest_receipt_for_runtime_state =
+    current_receipt_for_runtime_state ~meta
+      ~runtime_blocker_fields:raw.runtime_blocker_fields raw.latest_receipt
   in
-  let disposition, disposition_reason, operator_disposition,
-      operator_disposition_reason =
-    effective_disposition_fields ~fallback_disposition
-      ~approval_queue_available:(Option.is_none pending_approval_projection.error)
-      ~fallback_reason:fallback_disposition_reason
-      latest_receipt_for_runtime_state
+  let latest_terminal_reason =
+    latest_terminal_reason_opt ~meta
+      ~runtime_blocker_fields:raw.runtime_blocker_fields
+      ~latest_decision:raw.latest_decision ~latest_receipt:raw.latest_receipt
   in
-  let needs_attention =
-    assoc_bool_default "needs_attention" ~default:false attention_fields
-    || display_disposition_requires_attention disposition
+  let latest_terminal_reason_json =
+    latest_terminal_reason
+    |> Option.map Keeper_turn_terminal.to_json
+    |> Option.value ~default:`Null
   in
-  let attention_reason =
-    attention_reason_or_disposition ~needs_attention ~disposition_reason
-      attention_fields
+  let latest_next_action =
+    Option.bind latest_terminal_reason (fun reason -> reason.next_action)
   in
-  let next_human_action =
-    next_human_action_or_terminal ~needs_attention ~latest_next_action
-      attention_fields
+  let trust_model =
+    trust_model_of_observations
+      ~pending_approval_projection:raw.pending_approval_projection
+      ~runtime_blocker_fields:raw.runtime_blocker_fields
+      ~latest_receipt:latest_receipt_for_runtime_state
+      ~latest_next_action ~attention_fields:raw.attention_fields
   in
   let execution_summary =
-    execution_summary_json ~meta ~latest_receipt
+    execution_summary_json ~meta ~latest_receipt:raw.latest_receipt
   in
   let approval_state =
-    approval_state_json ~pending_approval_projection ~latest_approval_audit
+    approval_state_json
+      ~pending_approval_projection:raw.pending_approval_projection
+      ~latest_approval_audit:raw.latest_approval_audit
   in
   let latest_causal_event =
     match
-      approval_queue_unavailable_timeline_event pending_approval_projection
+      approval_queue_unavailable_timeline_event
+        ~observed_at_unix:raw.observed_at_unix
+        raw.pending_approval_projection
     with
     | Some event -> event
     | None ->
-        latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
-          ~latest_tool_call ~latest_approval_audit
-          ~runtime_blocker_fields ~next_human_action
+        latest_causal_event_summary ~observed_at_unix:raw.observed_at_unix
+          ~meta ~latest_decision:raw.latest_decision
+          ~latest_receipt:raw.latest_receipt
+          ~latest_tool_call:raw.latest_tool_call
+          ~latest_approval_audit:raw.latest_approval_audit
+          ~runtime_blocker_fields:raw.runtime_blocker_fields
+          ~next_human_action:trust_model.next_human_action
   in
   `Assoc
-    [
-      ("disposition", `String disposition);
-      ("disposition_reason", `String disposition_reason);
-      ("operator_disposition", `String operator_disposition);
-      ("operator_disposition_reason", `String operator_disposition_reason);
-      ("needs_attention", `Bool needs_attention);
-      ("attention_reason", Json_util.string_opt_to_json attention_reason);
-      ("next_human_action", Json_util.string_opt_to_json next_human_action);
-      ("approval_queue_state", pending_approval_projection.state);
-      ("approval", approval_state);
-      ("execution", execution_summary);
-      ("latest_terminal_reason", latest_terminal_reason_json);
-      ("latest_next_action", Json_util.string_opt_to_json latest_next_action);
-      ("latest_causal_event", latest_causal_event);
-    ]
+    (trust_model_json_fields trust_model
+     @ [ ("approval_queue_state", raw.pending_approval_projection.state)
+       ; ("approval", approval_state)
+       ; ("execution", execution_summary)
+       ; ("latest_terminal_reason", latest_terminal_reason_json)
+       ; ("latest_next_action", Json_util.string_opt_to_json latest_next_action)
+       ; ("latest_causal_event", latest_causal_event)
+       ])
 
-let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
-    ~latest_tool_call ~latest_approval_audit ~runtime_blocker_fields
-    ~next_human_action ~pending_approval_projection =
+let summary_json ~(config : Workspace.config) ~(meta : keeper_meta) =
+  collect_summary_raw ~config ~meta |> summary_json_of_raw ~meta
+;;
+
+let causal_timeline_json ~observed_at_unix ~recent_tool_call_rows
+    ~recent_approval_audit_rows ~recent_transition_rows ~meta
+    ~latest_decision ~latest_receipt ~latest_tool_call
+    ~latest_approval_audit ~runtime_blocker_fields ~next_human_action
+    ~pending_approval_projection =
   let tool_events =
-    Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:6 ()
-    |> List.filter_map tool_call_timeline_event
+    List.filter_map tool_call_timeline_event recent_tool_call_rows
   in
   let approval_events =
-    Keeper_approval.Audit.read_recent ~base_path ~keeper_name:meta.name
-      ~n:8 ()
-    |> approval_audit_rows_or_fail
-    |> List.filter_map approval_event_timeline_event
+    List.filter_map approval_event_timeline_event recent_approval_audit_rows
   in
   let transition_events =
-    match Keeper_transition_audit.recent_transitions_json
-            ~keeper_name:meta.name ~limit:6 with
-    | `List items -> items |> List.filter_map transition_timeline_event
-    | _ -> []
+    List.filter_map transition_timeline_event recent_transition_rows
   in
   let decision_events =
     (match latest_decision with
@@ -843,8 +825,9 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
     let task_id = Keeper_runtime_contract.current_task_id_opt meta in
     let goal_ids = meta.active_goal_ids in
     let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-    let observed_at_unix =
-      runtime_blocker_timeline_ts ~meta ~runtime_blocker_fields latest_receipt
+    let blocker_ts_unix =
+      runtime_blocker_timeline_ts ~observed_at_unix ~meta
+        ~runtime_blocker_fields latest_receipt
     in
     let blocker_observation_only =
       not
@@ -852,7 +835,8 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
            latest_receipt)
     in
     [
-      blocker_timeline_event ~ts_unix:observed_at_unix ~observed_at_unix
+      blocker_timeline_event ~ts_unix:blocker_ts_unix
+        ~observed_at_unix:blocker_ts_unix
         ~runtime_blocker_fields ?task_id ~goal_ids
         ~trace_id ~next_human_action
         ~observation_only:blocker_observation_only ()
@@ -890,7 +874,7 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
   let approval_queue_state_events =
     List.filter_map Fun.id
       [
-        approval_queue_unavailable_timeline_event
+        approval_queue_unavailable_timeline_event ~observed_at_unix
           pending_approval_projection;
       ]
   in
@@ -903,7 +887,7 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
   |> take 12
   |> fun items -> `List items
 
-let snapshot_json_inner_with_pending_reader
+let collect_raw_snapshot_with_pending_reader
     ~(read_pending :
        base_path:string ->
        (Yojson.Safe.t list, Keeper_approval_queue.storage_error) result)
@@ -911,32 +895,45 @@ let snapshot_json_inner_with_pending_reader
   let registry_entry =
     Keeper_registry.get ~base_path:config.base_path meta.name
   in
-  let latest_decision = latest_decision_json ~config ~keeper_name:meta.name in
-  let latest_tool_call = latest_tool_call_json ~keeper_name:meta.name in
-  let latest_receipt = latest_receipt_json ~config ~keeper_name:meta.name in
-  let latest_approval_audit =
+  let runtime_contract =
+    Keeper_runtime_contract.runtime_observability_contract_json ~config meta
+  in
+  let recent_tool_call_rows =
+    Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:6 ()
+  in
+  let recent_transition_rows =
     match
-      Keeper_approval.Audit.read_recent ~base_path:config.base_path
-        ~keeper_name:meta.name ~n:1 ()
-      |> approval_audit_rows_or_fail
+      Keeper_transition_audit.recent_transitions_json
+        ~keeper_name:meta.name ~limit:6
     with
-    | json :: _ -> Some json
-    | [] -> None
+    | `List items -> items
+    | _ -> []
   in
-  let pending_approval_projection =
-    pending_approval_projection_with_reader ~read_pending
-      ~base_path:config.base_path ~keeper_name:meta.name
+  let observations, recent_approval_audit_rows =
+    collect_raw_observations_with_pending_reader ~read_pending
+      ~approval_audit_limit:8 ~config ~meta
   in
-  let runtime_blocker_fields =
-    Keeper_status_bridge.runtime_blocker_fields_json config meta
-  in
+  { observations
+  ; registry_entry
+  ; runtime_contract
+  ; recent_tool_call_rows
+  ; recent_approval_audit_rows
+  ; recent_transition_rows
+  }
+;;
+
+let snapshot_json_of_raw ~(meta : keeper_meta) (raw : raw_snapshot) =
+  let observations = raw.observations in
   let latest_receipt_for_runtime_state =
-    current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
-      latest_receipt
+    current_receipt_for_runtime_state ~meta
+      ~runtime_blocker_fields:observations.runtime_blocker_fields
+      observations.latest_receipt
   in
   let latest_terminal_reason =
-    latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
-      ~latest_receipt
+    latest_terminal_reason_opt ~meta
+      ~runtime_blocker_fields:observations.runtime_blocker_fields
+      ~latest_decision:observations.latest_decision
+      ~latest_receipt:observations.latest_receipt
   in
   let latest_terminal_reason_json =
     latest_terminal_reason
@@ -947,114 +944,111 @@ let snapshot_json_inner_with_pending_reader
     Option.bind latest_terminal_reason (fun reason -> reason.next_action)
   in
   let selected_model =
-    selected_model_of_latest_decision_or_receipt latest_decision latest_receipt
-  in
-  let attention_fields =
-    Keeper_status_bridge.attention_fields_json_with_approval_queue
-      config
-      meta
-      (approval_queue_attention_of_projection
-         ~base_path:config.base_path
-         pending_approval_projection)
+    selected_model_of_latest_decision_or_receipt observations.latest_decision
+      observations.latest_receipt
   in
   let runtime_phase =
-    match registry_entry with
+    match raw.registry_entry with
     | Some entry -> `String (Keeper_state_machine.phase_to_string entry.phase)
     | None -> `Null
   in
-  let runtime_contract =
-    Keeper_runtime_contract.runtime_observability_contract_json ~config meta
-  in
-  let fallback_disposition, fallback_disposition_reason =
-    disposition_of_snapshot ~pending_approval_projection
-      ~runtime_blocker_fields
-  in
-  let disposition, disposition_reason, operator_disposition,
-      operator_disposition_reason =
-    effective_disposition_fields ~fallback_disposition
-      ~approval_queue_available:(Option.is_none pending_approval_projection.error)
-      ~fallback_reason:fallback_disposition_reason
-      latest_receipt_for_runtime_state
-  in
-  let needs_attention =
-    assoc_bool_default "needs_attention" ~default:false attention_fields
-    || display_disposition_requires_attention disposition
-  in
-  let attention_reason =
-    attention_reason_or_disposition ~needs_attention ~disposition_reason
-      attention_fields
-  in
-  let next_human_action =
-    next_human_action_or_terminal ~needs_attention ~latest_next_action
-      attention_fields
+  let trust_model =
+    trust_model_of_observations
+      ~pending_approval_projection:observations.pending_approval_projection
+      ~runtime_blocker_fields:observations.runtime_blocker_fields
+      ~latest_receipt:latest_receipt_for_runtime_state ~latest_next_action
+      ~attention_fields:observations.attention_fields
   in
   let approval_state =
-    approval_state_json ~pending_approval_projection ~latest_approval_audit
+    approval_state_json
+      ~pending_approval_projection:observations.pending_approval_projection
+      ~latest_approval_audit:observations.latest_approval_audit
   in
   let execution_summary =
-    execution_summary_json ~meta ~latest_receipt
+    execution_summary_json ~meta ~latest_receipt:observations.latest_receipt
   in
   let causal_timeline =
-    causal_timeline_json ~base_path:config.base_path ~meta ~latest_decision
-      ~latest_receipt
-      ~latest_tool_call ~latest_approval_audit
-      ~runtime_blocker_fields ~next_human_action
-      ~pending_approval_projection
+    causal_timeline_json
+      ~observed_at_unix:observations.observed_at_unix
+      ~recent_tool_call_rows:raw.recent_tool_call_rows
+      ~recent_approval_audit_rows:raw.recent_approval_audit_rows
+      ~recent_transition_rows:raw.recent_transition_rows ~meta
+      ~latest_decision:observations.latest_decision
+      ~latest_receipt:observations.latest_receipt
+      ~latest_tool_call:observations.latest_tool_call
+      ~latest_approval_audit:observations.latest_approval_audit
+      ~runtime_blocker_fields:observations.runtime_blocker_fields
+      ~next_human_action:trust_model.next_human_action
+      ~pending_approval_projection:observations.pending_approval_projection
   in
   let latest_causal_event =
     latest_causal_from_timeline causal_timeline
   in
   `Assoc
-    [
-      ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
-      ("generation", `Int meta.runtime.nonce);
-      ( "turn_id",
-        match
-          latest_turn_id ~registry_entry ~latest_decision ~latest_tool_call
-            ~latest_receipt
-        with
-        | Some turn_id -> `Int turn_id
-        | None -> `Null );
-      ("phase", runtime_phase);
-      ("raw_phase", runtime_phase);
-      ("current_task_id", Json_util.string_opt_to_json (Keeper_runtime_contract.current_task_id_opt meta));
-      ("goal_id", Json_util.string_opt_to_json (Keeper_runtime_contract.primary_goal_id_opt meta));
-      ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
-      ("active_model", Json_util.string_opt_to_json selected_model);
-      ("selected_model", Json_util.string_opt_to_json selected_model);
-      ("runtime_contract", runtime_contract);
-      ("runtime_blockers", `Assoc runtime_blocker_fields);
-      ("disposition", `String disposition);
-      ("disposition_reason", `String disposition_reason);
-      ("operator_disposition", `String operator_disposition);
-      ("operator_disposition_reason", `String operator_disposition_reason);
-      ("needs_attention", `Bool needs_attention);
-      ("attention_reason", Json_util.string_opt_to_json attention_reason);
-      ("next_human_action", Json_util.string_opt_to_json next_human_action);
-      ("approval_queue_state", pending_approval_projection.state);
-      ("approval", approval_state);
-      ("execution", execution_summary);
-      ("latest_terminal_reason", latest_terminal_reason_json);
-      ("latest_next_action", Json_util.string_opt_to_json latest_next_action);
-      ( "pending_approval_count",
-        match pending_approval_projection.count with
-        | Some count -> `Int count
-        | None -> `Null );
-      ( "pending_approvals",
-        match pending_approval_projection.entries with
-        | Some entries -> `List entries
-        | None -> `Null );
-      ("latest_decision", Option.value ~default:`Null latest_decision);
-      ("latest_tool_call", Option.value ~default:`Null latest_tool_call);
-      ("latest_receipt", Option.value ~default:`Null latest_receipt);
-      ("latest_causal_event", latest_causal_event);
-      ("causal_timeline", causal_timeline);
-      ( "last_event_bus_correlation",
-        match registry_entry with
-        | Some entry ->
-            Json_util.string_opt_to_json entry.last_event_bus_correlation
-        | None -> `Null );
-    ]
+    ([ ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id))
+     ; ("generation", `Int meta.runtime.nonce)
+     ; ( "turn_id"
+       , match
+           latest_turn_id ~registry_entry:raw.registry_entry
+             ~latest_decision:observations.latest_decision
+             ~latest_tool_call:observations.latest_tool_call
+             ~latest_receipt:observations.latest_receipt
+         with
+         | Some turn_id -> `Int turn_id
+         | None -> `Null )
+     ; ("phase", runtime_phase)
+     ; ("raw_phase", runtime_phase)
+     ; ( "current_task_id"
+       , Json_util.string_opt_to_json
+           (Keeper_runtime_contract.current_task_id_opt meta) )
+     ; ( "goal_id"
+       , Json_util.string_opt_to_json
+           (Keeper_runtime_contract.primary_goal_id_opt meta) )
+     ; ( "goal_ids"
+       , `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids) )
+     ; ("active_model", Json_util.string_opt_to_json selected_model)
+     ; ("selected_model", Json_util.string_opt_to_json selected_model)
+     ; ("runtime_contract", raw.runtime_contract)
+     ; ("runtime_blockers", `Assoc observations.runtime_blocker_fields)
+     ]
+     @ trust_model_json_fields trust_model
+     @ [ ("approval_queue_state", observations.pending_approval_projection.state)
+       ; ("approval", approval_state)
+       ; ("execution", execution_summary)
+       ; ("latest_terminal_reason", latest_terminal_reason_json)
+       ; ("latest_next_action", Json_util.string_opt_to_json latest_next_action)
+       ; ( "pending_approval_count"
+         , match observations.pending_approval_projection.count with
+           | Some count -> `Int count
+           | None -> `Null )
+       ; ( "pending_approvals"
+         , match observations.pending_approval_projection.entries with
+           | Some entries -> `List entries
+           | None -> `Null )
+       ; ( "latest_decision"
+         , Option.value ~default:`Null observations.latest_decision )
+       ; ( "latest_tool_call"
+         , Option.value ~default:`Null observations.latest_tool_call )
+       ; ( "latest_receipt"
+         , Option.value ~default:`Null observations.latest_receipt )
+       ; ("latest_causal_event", latest_causal_event)
+       ; ("causal_timeline", causal_timeline)
+       ; ( "last_event_bus_correlation"
+         , match raw.registry_entry with
+           | Some entry ->
+               Json_util.string_opt_to_json entry.last_event_bus_correlation
+           | None -> `Null )
+       ])
+;;
+
+let snapshot_json_inner_with_pending_reader
+    ~(read_pending :
+       base_path:string ->
+       (Yojson.Safe.t list, Keeper_approval_queue.storage_error) result)
+    ~(config : Workspace.config) ~(meta : keeper_meta) =
+  collect_raw_snapshot_with_pending_reader ~read_pending ~config ~meta
+  |> snapshot_json_of_raw ~meta
+;;
 
 let snapshot_json_inner ~(config : Workspace.config) ~(meta : keeper_meta) =
   snapshot_json_inner_with_pending_reader

--- a/lib/keeper/keeper_runtime_trust_snapshot_core.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot_core.ml
@@ -1,0 +1,119 @@
+type approval_queue =
+  | Approval_queue_available of int
+  | Approval_queue_unavailable
+
+type raw =
+  { approval_queue : approval_queue
+  ; runtime_blocker_class : string option
+  ; runtime_blocker_summary : string option
+  ; receipt_operator_disposition : (string * string) option
+  ; attention_needs_attention : bool
+  ; attention_reason : string option
+  ; attention_next_human_action : string option
+  ; terminal_next_human_action : string option
+  }
+
+type t =
+  { disposition : string
+  ; disposition_reason : string
+  ; operator_disposition : string
+  ; operator_disposition_reason : string
+  ; needs_attention : bool
+  ; attention_reason : string option
+  ; next_human_action : string option
+  }
+
+let fallback_disposition raw =
+  let sandbox_summary =
+    match raw.runtime_blocker_summary with
+    | Some summary when String_util.contains_substring_ci summary "sandbox" ->
+      Some ("Alert", "sandbox_violation")
+    | Some _ | None -> None
+  in
+  match raw.approval_queue with
+  | Approval_queue_unavailable -> "Alert", "approval_queue_unavailable"
+  | Approval_queue_available pending_approval_count when pending_approval_count > 0 ->
+    "Alert", "pending_operator_decision"
+  | Approval_queue_available _ ->
+    (match raw.runtime_blocker_class with
+     | Some raw_blocker_class ->
+       (match
+          Keeper_meta_contract.blocker_class_of_serialized_string raw_blocker_class
+        with
+        | Some (Keeper_meta_contract.Runtime_exhausted _) ->
+          "Alert", "runtime_exhausted"
+        | Some _ | None ->
+          (match sandbox_summary with
+           | Some disposition -> disposition
+           | None -> "Alert", "critical_block"))
+     | None ->
+       (match sandbox_summary with
+        | Some disposition -> disposition
+        | None -> "Pass", "healthy"))
+;;
+
+let operator_disposition_of_display ~disposition ~disposition_reason =
+  match disposition with
+  | "Pass" -> "pass", disposition_reason
+  | "Blocked" | "Pause" -> "fail_open_next_runtime", disposition_reason
+  | "Alert" | _ -> "unknown", disposition_reason
+;;
+
+let display_disposition_requires_attention = function
+  | "Blocked" | "Pause" | "Alert" -> true
+  | _ -> false
+;;
+
+let effective_disposition raw ~fallback_disposition ~fallback_reason =
+  match raw.approval_queue, raw.receipt_operator_disposition with
+  | Approval_queue_available _, Some (operator_disposition, operator_reason) ->
+    let disposition, disposition_reason =
+      Keeper_operator_disposition_display.of_wire
+        ~operator_disposition
+        ~operator_disposition_reason:operator_reason
+    in
+    disposition, disposition_reason, operator_disposition, operator_reason
+  | Approval_queue_unavailable, _
+  | Approval_queue_available _, None ->
+    let operator_disposition, operator_disposition_reason =
+      operator_disposition_of_display
+        ~disposition:fallback_disposition
+        ~disposition_reason:fallback_reason
+    in
+    ( fallback_disposition
+    , fallback_reason
+    , operator_disposition
+    , operator_disposition_reason )
+;;
+
+let decide raw =
+  let fallback_disposition, fallback_reason = fallback_disposition raw in
+  let disposition, disposition_reason, operator_disposition,
+      operator_disposition_reason =
+    effective_disposition raw ~fallback_disposition ~fallback_reason
+  in
+  let needs_attention =
+    raw.attention_needs_attention
+    || display_disposition_requires_attention disposition
+  in
+  let attention_reason =
+    match raw.attention_reason with
+    | Some _ as reason -> reason
+    | None when needs_attention -> Some disposition_reason
+    | None -> None
+  in
+  let next_human_action =
+    match raw.attention_next_human_action with
+    | Some _ as action -> action
+    | None when needs_attention -> raw.terminal_next_human_action
+    | None -> None
+  in
+  { disposition
+  ; disposition_reason
+  ; operator_disposition
+  ; operator_disposition_reason
+  ; needs_attention
+  ; attention_reason
+  ; next_human_action
+  }
+;;

--- a/lib/keeper/keeper_runtime_trust_snapshot_core.mli
+++ b/lib/keeper/keeper_runtime_trust_snapshot_core.mli
@@ -1,0 +1,34 @@
+(** Pure trust decision for one already-collected Keeper runtime snapshot.
+
+    This module does no I/O, time observation, logging, or synchronization.
+    The effect shell decodes external JSON/options into [raw], calls [decide]
+    once, and projects the returned model at the HTTP/dashboard boundary. *)
+
+type approval_queue =
+  | Approval_queue_available of int
+  | Approval_queue_unavailable
+
+type raw =
+  { approval_queue : approval_queue
+  ; runtime_blocker_class : string option
+  ; runtime_blocker_summary : string option
+  ; receipt_operator_disposition : (string * string) option
+  ; attention_needs_attention : bool
+  ; attention_reason : string option
+  ; attention_next_human_action : string option
+  ; terminal_next_human_action : string option
+  }
+
+type t =
+  { disposition : string
+  ; disposition_reason : string
+  ; operator_disposition : string
+  ; operator_disposition_reason : string
+  ; needs_attention : bool
+  ; attention_reason : string option
+  ; next_human_action : string option
+  }
+
+val decide : raw -> t
+(** Resolve the display/operator disposition and attention contract exactly
+    once from immutable observations. *)

--- a/lib/parse_outcome/parse_outcome.ml
+++ b/lib/parse_outcome/parse_outcome.ml
@@ -37,8 +37,3 @@ let map (f : 'a -> 'b) (o : 'a t) : 'b t =
   match o with
   | Ok x -> Ok (f x)
   | Error _ as e -> e
-
-let to_option (o : 'a t) : 'a option =
-  match o with
-  | Ok x -> Some x
-  | Error _ -> None

--- a/lib/parse_outcome/parse_outcome.mli
+++ b/lib/parse_outcome/parse_outcome.mli
@@ -47,8 +47,3 @@ val bind : 'a t -> ('a -> 'b t) -> 'b t
 
 val map : ('a -> 'b) -> 'a t -> 'b t
 (** Functorial map over [Ok]. *)
-
-val to_option : 'a t -> 'a option
-(** [to_option o] discards the error payload.
-    Provided as a *migration shim* for sites that currently return
-    [option] — new code should pattern-match on the [error] instead. *)

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -61,7 +61,7 @@ let quota_scope_of_materialized
   Runtime_quota_window.scope_of_credential ~provider_id:provider.id credential
 ;;
 
-let of_binding_result (cfg : config) (b : binding) : (t, string) result =
+let of_binding (cfg : config) (b : binding) : (t, string) result =
   if not b.enabled
   then Error "binding is disabled by runtime.toml"
   else match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
@@ -82,12 +82,6 @@ let of_binding_result (cfg : config) (b : binding) : (t, string) result =
        | Error reason -> Error reason)
   | None, _ -> Error (Printf.sprintf "provider not found: %s" b.provider_id)
   | Some _, None -> Error (Printf.sprintf "model not found: %s" b.model_id)
-;;
-
-(** {!of_binding_result} 의 option 투영. materialize 실패 이유가 필요 없는
-    호출자(단일 binding 성공 여부만 확인)를 위한 유지 API. *)
-let of_binding (cfg : config) (b : binding) : t option =
-  Result.to_option (of_binding_result cfg b)
 ;;
 
 let is_local_provider (provider : provider) =
@@ -115,7 +109,7 @@ let partition_bindings (cfg : config) (bindings : binding list)
   let runtimes, dropped =
     List.fold_left
       (fun (runtimes, dropped) (b : binding) ->
-         match of_binding_result cfg b with
+         match of_binding cfg b with
          | Ok rt -> rt :: runtimes, dropped
          | Error reason -> runtimes, (id_of_binding b, reason) :: dropped)
       ([], [])
@@ -1377,7 +1371,7 @@ let provider_id_of_runtime_id (id : string) : string option =
   | None -> None
 ;;
 
-(* Reads the scope frozen at materialization ({!of_binding_result}); no
+(* Reads the scope frozen at materialization ({!of_binding}); no
    environment access here, so a post-load env change cannot re-select the
    credential alias out from under the recorded window. *)
 let quota_scope_of_runtime (rt : t) : Runtime_quota_window.scope =

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -22,11 +22,11 @@ type t =
   }
 
 val id_of_binding : binding -> string
-val of_binding : config -> binding -> t option
-
-(** Reason-preserving form of {!of_binding}. [Error reason] when the binding's
-    provider/model id is unresolved or the provider transport/protocol cannot be
-    materialized into a {!Llm_provider.Provider_config.t} (e.g. a [messages-http]
+val of_binding : config -> binding -> (t, string) result
+(** Materialize one binding while preserving failure information. [Error reason]
+    when the binding is disabled, its provider/model id is unresolved, or the
+    provider transport/protocol cannot be materialized into a
+    {!Llm_provider.Provider_config.t} (e.g. a [messages-http]
     provider the runtime adapter has no provider_config path for). The binding is
     still excluded from the runtime list (fail-closed, RFC-0206 §2.1); this
     surfaces *why*, so [\[runtime\].default] / [\[runtime.assignments\]] / lane

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -46,6 +46,17 @@ type resolved_lang =
   | Known_lang of string
   | Unknown_lang
 
+type document_request_error =
+  | Missing_document_uri
+  | Document_uri_outside_workspace
+
+type resolved_document_request =
+  { uri : string
+  ; relative_path : string
+  ; line : int option
+  ; language : resolved_lang
+  }
+
 (** Per-connection state shared across frame handler and relay fibers.
 
     [sw] is the server-lifetime switch (LSP processes + their reader
@@ -600,6 +611,21 @@ let extract_line params =
   | _ -> None
 ;;
 
+let resolve_document_request ~base params =
+  match extract_uri params with
+  | None -> Error Missing_document_uri
+  | Some uri ->
+    (match resolve_relative ~base uri with
+     | None -> Error Document_uri_outside_workspace
+     | Some relative_path ->
+       let line =
+         match extract_line params with
+         | Some line when line >= 0 -> Some line
+         | Some _ | None -> None
+       in
+       Ok { uri; relative_path; line; language = resolve_lang relative_path })
+;;
+
 (** Ensure LSP process exists for a language.
     Spawns + initializes on first use, blocking until ready. *)
 let ensure_lsp_process cs lang_id =
@@ -713,20 +739,17 @@ let forward_notification cs lang_id method_ params =
 
 let forward_document_sync_notification cs method_ params =
   let wire_method = lsp_method_to_string method_ in
-  match extract_uri params with
-  | None -> ()
-  | Some uri ->
-    (match resolve_relative ~base:cs.base_path uri with
-     | None -> ()
-     | Some relative ->
-       if method_ = Did_save
-       then
-         Lsp_overlay_provider.invalidate_cache
-           ~base_dir:cs.base_path
-           ~file_path:relative;
-       (match resolve_lang relative with
-        | Unknown_lang -> ()
-        | Known_lang lang_id -> forward_notification cs lang_id wire_method params))
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> ()
+  | Ok request ->
+    if method_ = Did_save
+    then
+      Lsp_overlay_provider.invalidate_cache
+        ~base_dir:cs.base_path
+        ~file_path:request.relative_path;
+    (match request.language with
+     | Unknown_lang -> ()
+     | Known_lang lang_id -> forward_notification cs lang_id wire_method params)
 ;;
 
 (* Read-only method allowlist for the catch-all forwarder (task-1692). The
@@ -783,13 +806,13 @@ let classify_forwarded_method method_ =
 
 (** Handle textDocument/codeLens — merge LSP response with MASC overlays. *)
 let handle_codelens cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
+    let relative = request.relative_path in
     let masc = Lsp_overlay_provider.codelenses ~base_dir:base ~file_path:relative in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -813,13 +836,13 @@ let handle_codelens cs params id =
 
 (** Handle textDocument/inlayHint — merge LSP response with MASC overlays. *)
 let handle_inlay_hint cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
+    let relative = request.relative_path in
     let masc = Lsp_overlay_provider.inlay_hints ~base_dir:base ~file_path:relative in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -843,12 +866,12 @@ let handle_inlay_hint cs params id =
 
 (** Handle textDocument/diagnostic — merge LSP response with MASC diagnostics. *)
 let handle_diagnostic cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`Assoc [ "items", `List [] ])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`Assoc [ "items", `List [] ])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    (match resolve_lang relative with
+    let relative = request.relative_path in
+    (match request.language with
      | Unknown_lang ->
       let diags =
         Lsp_overlay_provider.diagnostics
@@ -897,25 +920,31 @@ let handle_diagnostic cs params id =
 
 (** Handle textDocument/hover — enrich LSP response with MASC annotations. *)
 let handle_hover cs params id =
-  match extract_uri params with
-  | None -> send_response cs id `Null
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id `Null
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
-    (match resolve_lang relative with
+    let relative = request.relative_path in
+    (match request.language with
      | Unknown_lang ->
-      if line >= 0 && Lsp_overlay_provider.has_annotations_at_line ~base_dir:base ~file_path:relative ~line
-      then (
-        let enriched =
-          Lsp_overlay_provider.enrich_hover
-            ~base_dir:base
-            ~file_path:relative
-            ~line
-            (`Assoc [ ("contents", `Assoc [ ("kind", `String "markdown"); ("value", `String "") ]) ])
-        in
-        send_response cs id enriched)
-      else send_response cs id `Null
+      (match request.line with
+       | Some line
+         when Lsp_overlay_provider.has_annotations_at_line
+                ~base_dir:base
+                ~file_path:relative
+                ~line ->
+         let enriched =
+           Lsp_overlay_provider.enrich_hover
+             ~base_dir:base
+             ~file_path:relative
+             ~line
+             (`Assoc
+                [ ( "contents"
+                  , `Assoc [ ("kind", `String "markdown"); ("value", `String "") ] )
+                ])
+         in
+         send_response cs id enriched
+       | Some _ | None -> send_response cs id `Null)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
       | Error msg ->
@@ -924,19 +953,23 @@ let handle_hover cs params id =
            broke the client on an unavailable LSP. Mirrors the unknown-lang
            branch above. *)
         note_overlay_only cs ~lang_id ~error:msg;
-        if line >= 0
-           && Lsp_overlay_provider.has_annotations_at_line ~base_dir:base
-                ~file_path:relative ~line
-        then
-          send_response cs id
-            (Lsp_overlay_provider.enrich_hover ~base_dir:base ~file_path:relative
-               ~line
-               (`Assoc
-                  [ ( "contents"
-                    , `Assoc
-                        [ ("kind", `String "markdown"); ("value", `String "") ] )
-                  ]))
-        else send_response cs id `Null
+        (match request.line with
+         | Some line
+           when Lsp_overlay_provider.has_annotations_at_line
+                  ~base_dir:base
+                  ~file_path:relative
+                  ~line ->
+           send_response cs id
+             (Lsp_overlay_provider.enrich_hover
+                ~base_dir:base
+                ~file_path:relative
+                ~line
+                (`Assoc
+                   [ ( "contents"
+                     , `Assoc
+                         [ ("kind", `String "markdown"); ("value", `String "") ] )
+                   ]))
+         | Some _ | None -> send_response cs id `Null)
       | Ok proc ->
         let promise =
           Lsp_message_router.send_request
@@ -948,32 +981,32 @@ let handle_hover cs params id =
         in
         (match Eio.Promise.await promise with
          | Ok result ->
-           if line >= 0
-           then
-             send_response cs id
-               (Lsp_overlay_provider.enrich_hover
-                  ~base_dir:base
-                  ~file_path:relative
-                  ~line
-                  result)
-           else send_response cs id result
+           (match request.line with
+            | Some line ->
+              send_response cs id
+                (Lsp_overlay_provider.enrich_hover
+                   ~base_dir:base
+                   ~file_path:relative
+                   ~line
+                   result)
+            | None -> send_response cs id result)
          | Error msg -> send_error cs id Mcp_error_code.(to_wire_code Internal_error) msg))
 ;;
 
 (** Handle textDocument/definition — merge LSP response with MASC annotation links. *)
 let handle_definition cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
+    let relative = request.relative_path in
     let masc =
-      if line >= 0 then
+      match request.line with
+      | Some line ->
         Lsp_overlay_provider.definition_links ~base_dir:base ~file_path:relative ~line
-      else []
+      | None -> []
     in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -995,19 +1028,19 @@ let handle_definition cs params id =
 
 (** Handle textDocument/references — merge LSP response with MASC annotation locations. *)
 let handle_references cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
+    let relative = request.relative_path in
     let masc =
-      if line >= 0 then
+      match request.line with
+      | Some line ->
         Lsp_overlay_provider.reference_locations
           ~base_dir:base ~file_path:relative ~line ~include_declaration:true
-      else []
+      | None -> []
     in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1029,18 +1062,18 @@ let handle_references cs params id =
 
 (** Handle textDocument/completion — merge LSP response with MASC annotation snippets. *)
 let handle_completion cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
+    let relative = request.relative_path in
     let masc =
-      if line >= 0 then
+      match request.line with
+      | Some line ->
         Lsp_overlay_provider.completion_items ~base_dir:base ~file_path:relative ~line
-      else []
+      | None -> []
     in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1062,19 +1095,19 @@ let handle_completion cs params id =
 
 (** Handle textDocument/codeAction — inject MASC annotation actions. *)
 let handle_code_action cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
+    let relative = request.relative_path in
     let masc =
-      if line >= 0 then
+      match request.line with
+      | Some line ->
         Lsp_overlay_provider.code_actions
           ~base_dir:base ~file_path:relative ~line ~diagnostics:[]
-      else []
+      | None -> []
     in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1096,13 +1129,13 @@ let handle_code_action cs params id =
 
 (** Handle textDocument/documentSymbol — inject MASC annotation symbols. *)
 let handle_document_symbol cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
+    let relative = request.relative_path in
     let masc = Lsp_overlay_provider.document_symbols ~base_dir:base ~file_path:relative in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1124,13 +1157,13 @@ let handle_document_symbol cs params id =
 
 (** Handle textDocument/foldingRange — inject MASC annotation folding ranges. *)
 let handle_folding_range cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
+    let relative = request.relative_path in
     let masc = Lsp_overlay_provider.folding_ranges ~base_dir:base ~file_path:relative in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1152,18 +1185,18 @@ let handle_folding_range cs params id =
 
 (** Handle textDocument/documentHighlight — highlight related MASC annotations. *)
 let handle_document_highlight cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
+    let relative = request.relative_path in
     let masc =
-      if line >= 0 then
+      match request.line with
+      | Some line ->
         Lsp_overlay_provider.document_highlights ~base_dir:base ~file_path:relative ~line
-      else []
+      | None -> []
     in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1259,33 +1292,28 @@ let dispatch_message cs msg =
                     Mcp_error_code.(to_wire_code Method_not_found)
                     ("Read-only LSP proxy: unknown method not permitted: " ^ unknown)
                 | Forward_read_only ->
-                  (match extract_uri params with
-                   | None ->
+                  (match resolve_document_request ~base:cs.base_path params with
+                   | Error Missing_document_uri ->
                      send_error cs n
                        Mcp_error_code.(to_wire_code Method_not_found)
                        ("Unhandled method: " ^ method_str)
-                   | Some uri ->
-                     (* Resolve the URI explicitly: an out-of-workspace or malformed
-                        URI ([None]) is rejected here rather than collapsed to a
-                        path, so the forward is only reached for a resolved
-                        in-workspace file. *)
-                     (match resolve_relative ~base:cs.base_path uri with
-                      | None ->
+                   | Error Document_uri_outside_workspace ->
+                     send_error
+                       cs
+                       n
+                       Mcp_error_code.(to_wire_code Invalid_params)
+                       "Path is outside the workspace"
+                   | Ok request ->
+                     (match request.language with
+                      | Known_lang lang_id ->
+                        forward_request cs lang_id method_str params n
+                      | Unknown_lang ->
                         send_error
                           cs
                           n
                           Mcp_error_code.(to_wire_code Invalid_params)
-                          "Path is outside the workspace"
-                      | Some relative ->
-                        (match resolve_lang relative with
-                         | Known_lang lang_id -> forward_request cs lang_id method_str params n
-                         | Unknown_lang ->
-                           send_error
-                             cs
-                             n
-                             Mcp_error_code.(to_wire_code Invalid_params)
-                             ("No LSP server for: " ^ relative)))))
-             | None -> ()))
+                          ("No LSP server for: " ^ request.relative_path)))
+             | None -> ())))
        (* No method field *)
        | None, Some n -> send_error cs n Mcp_error_code.(to_wire_code Invalid_request) "Missing method field"
        | None, None -> ())
@@ -1417,6 +1445,19 @@ module For_testing = struct
 
   let resolve_lang = resolve_lang
 
+  type nonrec document_request_error = document_request_error =
+    | Missing_document_uri
+    | Document_uri_outside_workspace
+
+  type nonrec resolved_document_request = resolved_document_request =
+    { uri : string
+    ; relative_path : string
+    ; line : int option
+    ; language : resolved_lang
+    }
+
+  let resolve_document_request = resolve_document_request
+
   (* task-1691: the LSP health type + its pure wire projection. *)
   type health = lang_health =
     | Connected
@@ -1451,5 +1492,4 @@ module For_testing = struct
     Option.map lsp_method_classification (lsp_method_of_string method_)
   ;;
 
-  let resolve_lang = resolve_lang
 end

--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -26,6 +26,26 @@ module For_testing : sig
       permissive default. *)
   val resolve_lang : string -> resolved_lang
 
+  type document_request_error =
+    | Missing_document_uri
+    | Document_uri_outside_workspace
+
+  type resolved_document_request =
+    { uri : string
+    ; relative_path : string
+    ; line : int option
+    ; language : resolved_lang
+    }
+
+  (** Decode the document URI, workspace-relative path, optional non-negative
+      line, and language verdict once. Missing/out-of-workspace documents stay
+      typed errors rather than becoming [""] paths, and malformed/negative
+      positions stay [None] rather than [-1]. *)
+  val resolve_document_request :
+    base:string ->
+    Yojson.Safe.t ->
+    (resolved_document_request, document_request_error) result
+
   (** Per-language LSP health (task-1691). [Overlay_only] carries the last
       error that forced the language into overlay-only mode. *)
   type health =

--- a/packages/agent_core/lib/llm_provider/exact_output_generation_receipt.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_generation_receipt.ml
@@ -179,19 +179,19 @@ let merge_state current desired =
     in
     Response_received_state { status; provider_trace }
   | Response_received_state current, Terminal_state desired ->
-    let status, provider_trace =
+    let _, provider_trace =
       merge_response_fields
         (current.status, current.provider_trace)
         (Some desired.status, desired.provider_trace)
     in
-    Terminal_state { status = Option.get status; provider_trace }
+    Terminal_state { status = desired.status; provider_trace }
   | Terminal_state current, Terminal_state desired ->
-    let status, provider_trace =
+    let _, provider_trace =
       merge_response_fields
         (Some current.status, current.provider_trace)
         (Some desired.status, desired.provider_trace)
     in
-    Terminal_state { status = Option.get status; provider_trace }
+    Terminal_state { status = desired.status; provider_trace }
   | _ -> desired
 ;;
 

--- a/packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml
@@ -15,6 +15,11 @@ type 'callback_error error =
 
 type connection = [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t
 
+type validated_origin =
+  { uri : Uri.t
+  ; host : string
+  }
+
 let create_dispatch_intent ~commit_fence ~mark_dispatch_started =
   { committed = Atomic.make false
   ; dispatch_started = Atomic.make false
@@ -88,7 +93,7 @@ let validate_uri url =
   try
     let uri = Uri.of_string url in
     match Uri.host uri with
-    | Some host when String.trim host <> "" -> Ok uri
+    | Some host when String.trim host <> "" -> Ok { uri; host }
     | Some _ | None ->
       Error
         (NetworkError
@@ -135,9 +140,8 @@ let https_init_error_network_kind = function
   | Api_common.Ca_certs_unavailable _ | Api_common.Tls_config_unavailable _ -> Tls_error
 ;;
 
-let resolve_origin net uri =
+let resolve_origin net ({ uri; host } : validated_origin) =
   let net = (net :> [ `Generic ] Eio.Net.ty Eio.Resource.t) in
-  let host = Option.get (Uri.host uri) in
   let service =
     match Uri.port uri with
     | Some port -> Int.to_string port
@@ -181,13 +185,13 @@ let resolve_origin net uri =
   Ok (net, addr, tls_wrap)
 ;;
 
-let make_connection ~sw ~net ~uri =
-  let* net, address, tls_wrap = resolve_origin net uri in
+let make_connection ~sw ~net ~origin =
+  let* net, address, tls_wrap = resolve_origin net origin in
   try
     let socket = Eio.Net.connect ~sw net address in
     let connection : connection =
       match tls_wrap with
-      | Some wrap -> (wrap uri socket :> connection)
+      | Some wrap -> (wrap origin.uri socket :> connection)
       | None -> (socket :> connection)
     in
     Ok connection
@@ -236,7 +240,7 @@ let post_sync_once_after_commit
       ~connect_deadline
       ~body_deadline
       ~net
-      ~uri
+      ~origin
       ~header
       ~body
       ~dispatch_intent
@@ -319,7 +323,7 @@ let post_sync_once_after_commit
   let post_result =
     try
       with_headers_deadline (fun () ->
-        let* current = make_connection ~sw ~net ~uri in
+        let* current = make_connection ~sw ~net ~origin in
         connection := Some current;
         let client =
           Cohttp_eio.Client.make_generic (fun ~sw:_ _uri ->
@@ -331,14 +335,19 @@ let post_sync_once_after_commit
         then invalid_arg "exact-output measurement dispatch was already started";
         dispatch_intent.mark_dispatch_started ();
         let response, response_body =
-          Cohttp_eio.Client.post ~sw client ~headers:header ~body:request_body uri
+          Cohttp_eio.Client.post
+            ~sw
+            client
+            ~headers:header
+            ~body:request_body
+            origin.uri
         in
         let response_status =
           Cohttp.Response.status response |> Cohttp.Code.code_of_status
         in
         phase := Response_received;
         status := Some response_status;
-        Ok (response, response_body))
+        Ok (response, response_body, response_status))
     with
     | Eio.Time.Timeout as exn ->
       release_connection ();
@@ -349,7 +358,7 @@ let post_sync_once_after_commit
   | Error error ->
     release_connection ();
     Error (staged_error error)
-  | Ok (response, response_body) ->
+  | Ok (response, response_body, response_status) ->
     let body_result =
       try
         match body_deadline, total_started_at with
@@ -378,7 +387,6 @@ let post_sync_once_after_commit
        release_connection ();
        Error (staged_error error)
      | Ok response_body ->
-       let response_status = Option.get !status in
        let retry_after_header = retry_after_header response in
        release_connection ();
        Ok
@@ -418,7 +426,7 @@ let post_sync_once
      | Ok body_deadline ->
        (match validate_uri url with
         | Error error -> before_dispatch error
-        | Ok uri ->
+        | Ok origin ->
           (match validate_headers_and_body headers body with
            | Error error -> before_dispatch error
            | Ok header ->
@@ -432,7 +440,7 @@ let post_sync_once
                   ~connect_deadline
                   ~body_deadline
                   ~net
-                  ~uri
+                  ~origin
                   ~header
                   ~body
                   ~dispatch_intent

--- a/packages/agent_core/lib/llm_provider/exact_output_plan.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_plan.ml
@@ -1,5 +1,7 @@
 module Sha256 = Digestif.SHA256
 
+let ( let* ) = Result.bind
+
 type fingerprint = Fingerprint of string
 
 type output_admission_error =
@@ -108,9 +110,16 @@ let contract_is_supported
   | Types.JsonSchema _ -> capabilities.supports_structured_output
 ;;
 
-let timeout_is_valid = function
-  | None -> true
-  | Some seconds -> Float.is_finite seconds && seconds > 0.0
+let validate_timeout ~invalid = function
+  | None -> Ok ()
+  | Some seconds when Float.is_finite seconds && seconds > 0.0 -> Ok ()
+  | Some seconds -> Error (invalid seconds)
+;;
+
+let%test "timeout validation preserves the invalid value" =
+  match validate_timeout ~invalid:Fun.id (Some (-1.5)) with
+  | Error seconds -> Float.equal seconds (-1.5)
+  | Ok () -> false
 ;;
 
 let content_uses_exact_cross_feature = function
@@ -390,11 +399,18 @@ let preflight
     then Error Unsupported_exact_cross_feature
     else if Option.is_some config.max_concurrent_requests
     then Error Global_admission_not_allowed
-    else if not (timeout_is_valid config.connect_timeout_s)
-    then Error (Invalid_connect_timeout (Option.get config.connect_timeout_s))
-    else if not (timeout_is_valid request.body_timeout_s)
-    then Error (Invalid_body_timeout (Option.get request.body_timeout_s))
-    else if not (contract_is_supported config capabilities)
+    else
+      let* () =
+        validate_timeout
+          ~invalid:(fun seconds -> Invalid_connect_timeout seconds)
+          config.connect_timeout_s
+      in
+      let* () =
+        validate_timeout
+          ~invalid:(fun seconds -> Invalid_body_timeout seconds)
+          request.body_timeout_s
+      in
+      if not (contract_is_supported config capabilities)
     then
       Error
         (Unsupported_output_contract

--- a/packages/agent_core/lib/llm_provider/http_client.ml
+++ b/packages/agent_core/lib/llm_provider/http_client.ml
@@ -1946,7 +1946,13 @@ let post_sync_once_after_validation
         status := Some response_status;
         Http_client_phase_observer.observe
           (Http_client_phase_observer.Response_received response_status);
-        Ok (conn, response, response_body, response_header_evidence, retry_after_header))
+        Ok
+          ( conn
+          , response
+          , response_body
+          , response_status
+          , response_header_evidence
+          , retry_after_header ))
     with
     | Eio.Time.Timeout as exn ->
       release_connection ();
@@ -1957,7 +1963,13 @@ let post_sync_once_after_validation
   | Error error ->
     release_connection ();
     fail error
-  | Ok (conn, response, response_body, response_header_evidence, retry_after_header) ->
+  | Ok
+      ( conn
+      , response
+      , response_body
+      , response_status
+      , response_header_evidence
+      , retry_after_header ) ->
     let body_result =
       try
         match body_deadline, total_started_at with
@@ -2008,7 +2020,7 @@ let post_sync_once_after_validation
           fail error
         | Ok () ->
           Ok
-            ( { status = Option.get !status; body = response_body; retry_after_header }
+            ( { status = response_status; body = response_body; retry_after_header }
             , response_header_evidence )))
 ;;
 

--- a/scripts/audit-unwired-audits.sh
+++ b/scripts/audit-unwired-audits.sh
@@ -26,7 +26,7 @@ cd "$(git rev-parse --show-toplevel)"
 # and did not match lint-* names, so three self-declared gates
 # (check-logging-consistency, lint-cancel-guard, tla-mutation-lint-ratchet)
 # were invisible to it. See #27626.
-UNWIRED_BASELINE=14
+UNWIRED_BASELINE=13
 
 all="$(mktemp)"
 called="$(mktemp)"

--- a/scripts/ocaml-boundary-baseline.tsv
+++ b/scripts/ocaml-boundary-baseline.tsv
@@ -1,8 +1,2 @@
 # ocaml-boundary-audit-v2 typed-tree baseline
 # category<TAB>path<TAB>scope<TAB>resolved-callee<TAB>count
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_generation_receipt.ml	merge_state	Stdlib.Option.get	2
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml	post_sync_once_after_commit/response_status	Stdlib.Option.get	1
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml	resolve_origin/host	Stdlib.Option.get	1
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_plan.ml	preflight	Stdlib.Option.get	2
-partial_extraction	packages/agent_core/lib/llm_provider/http_client.ml	post_sync_once_after_validation	Stdlib.Option.get	1
-failure_erasure	lib/runtime/runtime.ml	of_binding	Stdlib.Result.to_option	1

--- a/scripts/ocaml-boundary-baseline.tsv
+++ b/scripts/ocaml-boundary-baseline.tsv
@@ -1,0 +1,8 @@
+# ocaml-boundary-audit-v2 typed-tree baseline
+# category<TAB>path<TAB>scope<TAB>resolved-callee<TAB>count
+partial_extraction	packages/agent_core/lib/llm_provider/exact_output_generation_receipt.ml	merge_state	Stdlib.Option.get	2
+partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml	post_sync_once_after_commit/response_status	Stdlib.Option.get	1
+partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml	resolve_origin/host	Stdlib.Option.get	1
+partial_extraction	packages/agent_core/lib/llm_provider/exact_output_plan.ml	preflight	Stdlib.Option.get	2
+partial_extraction	packages/agent_core/lib/llm_provider/http_client.ml	post_sync_once_after_validation	Stdlib.Option.get	1
+failure_erasure	lib/runtime/runtime.ml	of_binding	Stdlib.Result.to_option	1

--- a/scripts/ocaml-boundary-ratchet.sh
+++ b/scripts/ocaml-boundary-ratchet.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+mode="check"
+previous_baseline=""
+previous_pure_modules=""
+
+cleanup() {
+  if [[ -n "${previous_baseline}" ]]; then
+    rm -f -- "${previous_baseline}"
+  fi
+  if [[ -n "${previous_pure_modules}" ]]; then
+    rm -f -- "${previous_pure_modules}"
+  fi
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/ocaml-boundary-ratchet.sh [--regenerate|--json]
+
+  no argument    verify the typed mechanical baseline and pure-module contract
+  --regenerate   write an initial or strictly smaller baseline
+  --json         print the current typed-tree site report as JSON
+
+The production .cmt graph must already exist. CI runs this after @check; local
+callers should build the relevant full graph only when they intentionally run
+the repository-wide audit.
+USAGE
+}
+
+if [[ "$#" -gt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+case "${1:-}" in
+  "") ;;
+  --regenerate) mode="write" ;;
+  --json) mode="json" ;;
+  -h|--help) usage; exit 0 ;;
+  *) usage >&2; exit 2 ;;
+esac
+
+args=(
+  --root "${repo_root}"
+  --build-dir "${repo_root}/_build/default"
+  --pure-modules scripts/ocaml-pure-modules.txt
+  --baseline scripts/ocaml-boundary-baseline.tsv
+)
+
+case "${mode}" in
+  check) args+=(--check) ;;
+  write) args+=(--write-baseline) ;;
+  json) args+=(--format json) ;;
+esac
+
+if [[ "${mode}" != "json" ]]; then
+  base_ref="${OCAML_BOUNDARY_BASE_REF:-origin/main}"
+  if [[ -n "${base_ref}" ]]; then
+    if ! git cat-file -e "${base_ref}^{commit}" 2>/dev/null; then
+      echo "ocaml-boundary-ratchet: base revision is unavailable: ${base_ref}" >&2
+      exit 1
+    fi
+    if git cat-file -e "${base_ref}:scripts/ocaml-boundary-baseline.tsv" 2>/dev/null; then
+      previous_baseline="$(mktemp "${TMPDIR:-/tmp}/ocaml-boundary-baseline.XXXXXX")"
+      git show "${base_ref}:scripts/ocaml-boundary-baseline.tsv" > "${previous_baseline}"
+      args+=(--previous-baseline "${previous_baseline}")
+    fi
+    if git cat-file -e "${base_ref}:scripts/ocaml-pure-modules.txt" 2>/dev/null; then
+      previous_pure_modules="$(mktemp "${TMPDIR:-/tmp}/ocaml-pure-modules.XXXXXX")"
+      git show "${base_ref}:scripts/ocaml-pure-modules.txt" > "${previous_pure_modules}"
+      args+=(--previous-pure-modules "${previous_pure_modules}")
+    fi
+  fi
+fi
+
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  opam exec -- dune exec --root "${repo_root}" \
+    tools/ocaml_boundary_audit/main.exe -- "${args[@]}"
+else
+  "${repo_root}/scripts/dune-local.sh" \
+    exec --root "${repo_root}" \
+    tools/ocaml_boundary_audit/main.exe -- "${args[@]}"
+fi

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -1,6 +1,7 @@
 # Modules whose implementations are pure decision cores. Registry growth is
 # the one-way ratchet: a registered module may not call canonical env, clock,
 # random, filesystem, Eio, mutation, or logging APIs.
+lib/keeper/keeper_runtime_trust_snapshot_core.ml
 lib/keeper_runtime/keeper_event_queue_state.ml
 lib/schedule/schedule_domain.ml
 lib/turn_fsm/turn_fsm.ml

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -1,0 +1,8 @@
+# Modules whose implementations are pure decision cores. Registry growth is
+# the one-way ratchet: a registered module may not call canonical env, clock,
+# random, filesystem, Eio, mutation, or logging APIs.
+lib/keeper_runtime/keeper_event_queue_state.ml
+lib/schedule/schedule_domain.ml
+lib/turn_fsm/turn_fsm.ml
+lib/types/masc_domain.ml
+lib/workspace/workspace_task_lifecycle.ml

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -313,6 +313,49 @@ let test_observation_not_dispatched_receipt_remains_non_blocking () =
          (snapshot |> member "operator_disposition_reason" |> to_string))
 ;;
 
+let test_summary_and_snapshot_share_trust_projection () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       let keeper_name = "runtime-trust-shared-projection" in
+       let meta = make_meta keeper_name in
+       let receipt_store =
+         Masc.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+       in
+       Dated_jsonl.append
+         receipt_store
+         (`Assoc
+             [ "ended_at", `String "2026-06-01T00:00:00Z"
+             ; "operator_disposition", `String "pass"
+             ; "operator_disposition_reason", `String "healthy"
+             ; "terminal_reason_code", `String "success"
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let summary = K.summary_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       List.iter
+         (fun field ->
+            Alcotest.(check bool)
+              (field ^ " uses the shared trust projection")
+              true
+              (snapshot |> member field = (summary |> member field)))
+         [ "disposition"
+         ; "disposition_reason"
+         ; "operator_disposition"
+         ; "operator_disposition_reason"
+         ; "needs_attention"
+         ; "attention_reason"
+         ; "next_human_action"
+         ])
+;;
+
 let test_unknown_completion_contract_result_stays_visible () =
   Eio_main.run
   @@ fun env ->
@@ -967,6 +1010,10 @@ let () =
             "not-dispatched observation remains non-blocking"
             `Quick
             test_observation_not_dispatched_receipt_remains_non_blocking
+        ; Alcotest.test_case
+            "summary and snapshot share one trust projection"
+            `Quick
+            test_summary_and_snapshot_share_trust_projection
         ; Alcotest.test_case
             "unknown completion-contract result remains visible"
             `Quick

--- a/test/test_parse_outcome.ml
+++ b/test/test_parse_outcome.ml
@@ -46,12 +46,6 @@ let test_map () =
   in
   check int "map increments" 8 (match r with Ok v -> v | Error _ -> -1)
 
-let test_to_option () =
-  check (option int) "Ok -> Some"
-    (Some 5) (Parse_outcome.to_option (Ok 5));
-  check (option int) "Error -> None"
-    None (Parse_outcome.to_option (Error (`Other (Failure "x"))))
-
 (* RFC-0145 §Design — cancellation MUST re-raise. We drive an Eio
    fiber and cancel it from a sibling; inside the cancelled context
    the parser raises Cancelled which parse_safe must propagate. *)
@@ -87,7 +81,6 @@ let () =
           test_case "of_exn classifies Failure as `Other" `Quick test_of_exn_other;
           test_case "bind" `Quick test_bind;
           test_case "map" `Quick test_map;
-          test_case "to_option" `Quick test_to_option;
         ] );
       ( "cancellation",
         [

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1170,8 +1170,27 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     }
   in
   match Runtime.of_binding cfg runpod_binding with
-  | Some runtime -> runtime
-  | None -> fail "expected runtime binding to materialize"
+  | Ok runtime -> runtime
+  | Error reason -> failf "expected runtime binding to materialize: %s" reason
+
+let test_runtime_of_binding_preserves_failure_reason () =
+  let cfg =
+    { Runtime_schema.providers = [ runpod_provider ]
+    ; models = [ qwen_model ]
+    ; bindings = [ runpod_binding ]
+    ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; cross_verifier_runtime_id = None
+    ; keeper_assignments = []
+    ; media_failover = []
+    ; lane_decls = []
+    ; exact_output_lane_decls = []
+    }
+  in
+  match Runtime.of_binding cfg { runpod_binding with enabled = false } with
+  | Ok _ -> fail "expected disabled binding materialization to fail"
+  | Error reason ->
+    check string "disabled binding reason"
+      "binding is disabled by runtime.toml" reason
 
 let with_dashboard_probe_http_get hook f =
   Server_dashboard_http_runtime_info.set_dashboard_runtime_provider_http_get_for_tests
@@ -1923,6 +1942,10 @@ let () =
         ] )
     ; ( "provider_config"
       , [ test_case
+            "runtime binding materialization preserves failure reason"
+            `Quick
+            test_runtime_of_binding_preserves_failure_reason
+        ; test_case
             "adapter stamps declared provider id"
             `Quick
             test_adapter_stamps_declared_provider_id

--- a/test/test_server_ide_lsp_proxy.ml
+++ b/test/test_server_ide_lsp_proxy.ml
@@ -121,6 +121,50 @@ let test_file_uri_resolution_rejects_symlink_escape () =
          (Lsp.resolve_relative ~base ("file://" ^ link)))
 ;;
 
+let document_params ~uri line =
+  `Assoc
+    [ "textDocument", `Assoc [ "uri", `String uri ]
+    ; "position", `Assoc [ "line", line ]
+    ]
+;;
+
+let test_document_request_is_resolved_once () =
+  let base = "/workspace/masc" in
+  let uri = "file:///workspace/masc/lib/server.ml" in
+  match Lsp.resolve_document_request ~base (document_params ~uri (`Int 7)) with
+  | Error _ -> fail "expected an in-workspace document request"
+  | Ok request ->
+    check string "URI retained" uri request.uri;
+    check string "relative path resolved" "lib/server.ml" request.relative_path;
+    check (option int) "line resolved" (Some 7) request.line;
+    (match request.language with
+     | Lsp.Known_lang "ocaml" -> ()
+     | Lsp.Known_lang language -> failf "unexpected language: %s" language
+     | Lsp.Unknown_lang -> fail "expected the .ml language to resolve")
+;;
+
+let test_document_request_keeps_decode_failures_typed () =
+  let base = "/workspace/masc" in
+  let missing_uri = `Assoc [ "position", `Assoc [ "line", `Int 1 ] ] in
+  (match Lsp.resolve_document_request ~base missing_uri with
+   | Error Lsp.Missing_document_uri -> ()
+   | Error Lsp.Document_uri_outside_workspace ->
+     fail "missing URI must not be classified as an out-of-workspace path"
+   | Ok _ -> fail "missing URI must fail decoding");
+  let outside_uri = "file:///tmp/outside.ml" in
+  (match
+     Lsp.resolve_document_request ~base (document_params ~uri:outside_uri (`Int 1))
+   with
+   | Error Lsp.Document_uri_outside_workspace -> ()
+   | Error Lsp.Missing_document_uri ->
+     fail "outside URI must not be classified as missing"
+   | Ok _ -> fail "outside URI must fail decoding");
+  let inside_uri = "file:///workspace/masc/lib/server.ml" in
+  match Lsp.resolve_document_request ~base (document_params ~uri:inside_uri (`Int (-1))) with
+  | Error _ -> fail "negative line must not invalidate a document path"
+  | Ok request -> check (option int) "negative line is absent" None request.line
+;;
+
 let test_dispatch_workers_are_parallelized () =
   check
     bool
@@ -401,6 +445,10 @@ let () =
             test_file_uri_resolution_is_workspace_scoped
         ; test_case "file uri resolution rejects symlink escape" `Quick
             test_file_uri_resolution_rejects_symlink_escape
+        ; test_case "document request resolves once" `Quick
+            test_document_request_is_resolved_once
+        ; test_case "document request decode failures stay typed" `Quick
+            test_document_request_keeps_decode_failures_typed
         ; test_case "dispatch workers are parallelized" `Quick
             test_dispatch_workers_are_parallelized
         ; test_case "/api/v1/ide/lsp is a Ws upgrade route" `Quick

--- a/tools/ocaml_boundary_audit/dune
+++ b/tools/ocaml_boundary_audit/dune
@@ -1,0 +1,15 @@
+(library
+ (name ocaml_boundary_audit_lib)
+ (wrapped false)
+ (modules ocaml_boundary_audit)
+ (libraries compiler-libs.common unix yojson))
+
+(executable
+ (name main)
+ (modules main)
+ (libraries ocaml_boundary_audit_lib unix))
+
+(test
+ (name test_ocaml_boundary_audit)
+ (modules test_ocaml_boundary_audit)
+ (libraries alcotest ocaml_boundary_audit_lib))

--- a/tools/ocaml_boundary_audit/main.ml
+++ b/tools/ocaml_boundary_audit/main.ml
@@ -1,0 +1,220 @@
+type action = Report | Check | Write_baseline
+type output_format = Text | Json
+
+let usage =
+  "ocaml_boundary_audit [--root DIR] [--build-dir DIR] [--pure-modules FILE] \
+   [--previous-pure-modules FILE] [--baseline FILE] [--previous-baseline FILE] \
+   [--check|--write-baseline] [--format text|json]"
+;;
+
+let () =
+  let root = ref "." in
+  let build_dir = ref "_build/default" in
+  let pure_modules_path = ref "scripts/ocaml-pure-modules.txt" in
+  let previous_pure_modules_path = ref None in
+  let baseline_path = ref "scripts/ocaml-boundary-baseline.tsv" in
+  let previous_baseline_path = ref None in
+  let action = ref Report in
+  let output_format = ref Text in
+  let set_action next () =
+    match !action with
+    | Report -> action := next
+    | Check | Write_baseline ->
+      raise (Arg.Bad "--check and --write-baseline are mutually exclusive")
+  in
+  let set_format = function
+    | "text" -> output_format := Text
+    | "json" -> output_format := Json
+    | value -> raise (Arg.Bad (Printf.sprintf "unknown format %S" value))
+  in
+  Arg.parse
+    [ "--root", Arg.Set_string root, "DIR repository root"
+    ; "--build-dir", Arg.Set_string build_dir, "DIR Dune build directory containing .cmt files"
+    ; ( "--pure-modules"
+      , Arg.Set_string pure_modules_path
+      , "FILE repository-relative pure-module registry" )
+    ; ( "--previous-pure-modules"
+      , Arg.String (fun path -> previous_pure_modules_path := Some path)
+      , "FILE PR-base pure-module registry; living entries may not be removed" )
+    ; "--baseline", Arg.Set_string baseline_path, "FILE exact-site baseline"
+    ; ( "--previous-baseline"
+      , Arg.String (fun path -> previous_baseline_path := Some path)
+      , "FILE base revision baseline; current baseline may only decrease" )
+    ; "--check", Arg.Unit (set_action Check), "fail on any baseline drift"
+    ; ( "--write-baseline"
+      , Arg.Unit (set_action Write_baseline)
+      , "write only an initial or downward baseline" )
+    ; "--format", Arg.String set_format, "text|json report format"
+    ]
+    (fun value -> raise (Arg.Bad (Printf.sprintf "unexpected argument %S" value)))
+    usage;
+  let run () =
+    let open Result.Syntax in
+    let* root =
+      match Unix.realpath !root with
+      | root -> Ok root
+      | exception Unix.Unix_error (error, operation, target) ->
+        Error
+          (Printf.sprintf
+             "%s(%s): %s"
+             operation
+             target
+             (Unix.error_message error))
+    in
+    let resolve path =
+      if Filename.is_relative path then Filename.concat root path else path
+    in
+    let* pure_modules =
+      Ocaml_boundary_audit.read_pure_modules ~root (resolve !pure_modules_path)
+    in
+    let* () =
+      match !previous_pure_modules_path with
+      | None -> Ok ()
+      | Some path ->
+        let* previous = Ocaml_boundary_audit.read_module_paths (resolve path) in
+        let current = List.sort_uniq String.compare pure_modules in
+        let removed_living_modules =
+          List.filter
+            (fun module_path ->
+               Sys.file_exists (Filename.concat root module_path)
+               && not (List.mem module_path current))
+            previous
+        in
+        if removed_living_modules = []
+        then Ok ()
+        else
+          Error
+            ("The pure-module registry may only grow; these living modules were removed:\n"
+             ^ String.concat "\n" removed_living_modules)
+    in
+    let* report =
+      Ocaml_boundary_audit.audit_repository
+        ~root
+        ~build_dir:(resolve !build_dir)
+        ~source_roots:Ocaml_boundary_audit.default_source_roots
+        ~pure_modules
+    in
+    let hard_entries =
+      List.filter
+        (fun (entry : Ocaml_boundary_audit.entry) ->
+           entry.category <> Ocaml_boundary_audit.Effect_in_pure_module)
+        report.entries
+    in
+    let pure_effect_sites =
+      List.filter
+        (fun (site : Ocaml_boundary_audit.site) ->
+           site.category = Ocaml_boundary_audit.Effect_in_pure_module)
+        report.sites
+    in
+    let validate_baseline baseline =
+      match
+        List.find_opt
+          (fun (entry : Ocaml_boundary_audit.entry) ->
+             entry.category = Ocaml_boundary_audit.Effect_in_pure_module)
+          baseline
+      with
+      | None -> Ok ()
+      | Some entry ->
+        Error
+          (Printf.sprintf
+             "pure-module effects cannot be baselined: %s %s\n"
+             entry.path
+             entry.callee)
+    in
+    let validate_baseline_direction baseline =
+      let* () = validate_baseline baseline in
+      match !previous_baseline_path with
+      | None -> Ok ()
+      | Some path ->
+        let* previous = Ocaml_boundary_audit.read_baseline (resolve path) in
+        let* () = validate_baseline previous in
+        let comparison =
+          Ocaml_boundary_audit.compare ~baseline:previous ~current:baseline
+        in
+        if comparison.increases = []
+        then Ok ()
+        else
+          Error
+            (Ocaml_boundary_audit.comparison_to_text comparison
+             ^ "The committed baseline may only decrease from its base revision.\n")
+    in
+    match !action with
+    | Report ->
+      let output =
+        match !output_format with
+        | Text -> Ocaml_boundary_audit.report_to_text report
+        | Json -> Ocaml_boundary_audit.report_to_json report ^ "\n"
+      in
+      print_string output;
+      Ok ()
+    | Check ->
+      if pure_effect_sites <> []
+      then
+        Error
+          ("A registered pure module performs an external effect:\n"
+           ^ Ocaml_boundary_audit.report_to_text
+               { report with sites = pure_effect_sites })
+      else (
+        let baseline_path = resolve !baseline_path in
+        let* baseline = Ocaml_boundary_audit.read_baseline baseline_path in
+        let* () = validate_baseline_direction baseline in
+        let comparison =
+          Ocaml_boundary_audit.compare ~baseline ~current:hard_entries
+        in
+        if comparison.increases = [] && comparison.reductions = []
+        then (
+          Printf.printf
+            "ocaml-boundary-audit: PASS (%d typed sources, %d mechanical debt buckets)\n"
+            report.scanned_sources
+            (List.length hard_entries);
+          Ok ())
+        else
+          Error
+            (Ocaml_boundary_audit.comparison_to_text comparison
+             ^ (if comparison.increases <> []
+                then
+                  "New partial extraction or failure erasure is forbidden. Resolve the boundary instead of raising the baseline.\n"
+                else "")
+             ^ (if comparison.reductions <> []
+                then
+                  "Debt decreased; run --write-baseline and commit the downward baseline update.\n"
+                else "")))
+    | Write_baseline ->
+      if pure_effect_sites <> []
+      then Error "Refusing to baseline effects inside a registered pure module.\n"
+      else (
+        let baseline_path = resolve !baseline_path in
+        let* () =
+          if Sys.file_exists baseline_path
+          then
+            let* baseline = Ocaml_boundary_audit.read_baseline baseline_path in
+            let* () = validate_baseline_direction baseline in
+            let comparison =
+              Ocaml_boundary_audit.compare ~baseline ~current:hard_entries
+            in
+            if comparison.increases = []
+            then Ok ()
+            else
+              Error
+                (Ocaml_boundary_audit.comparison_to_text comparison
+                 ^ "Refusing to raise the mechanical-debt baseline.\n")
+          else (
+            match !previous_baseline_path with
+            | None -> Ok ()
+            | Some _ ->
+              Error
+                "The current baseline is missing although the base revision has one.\n")
+        in
+        let* () = Ocaml_boundary_audit.write_baseline baseline_path hard_entries in
+        Printf.printf
+          "ocaml-boundary-audit: wrote %d typed mechanical buckets to %s\n"
+          (List.length hard_entries)
+          baseline_path;
+        Ok ())
+  in
+  match run () with
+  | Ok () -> ()
+  | Error message ->
+    prerr_endline ("ocaml-boundary-audit: FAIL\n" ^ message);
+    exit 1
+;;

--- a/tools/ocaml_boundary_audit/ocaml_boundary_audit.ml
+++ b/tools/ocaml_boundary_audit/ocaml_boundary_audit.ml
@@ -1,0 +1,777 @@
+open Typedtree
+
+type category =
+  | Partial_extraction
+  | Failure_erasure
+  | Effect_in_pure_module
+
+type site =
+  { category : category
+  ; path : string
+  ; scope : string
+  ; callee : string
+  ; line : int
+  ; column : int
+  }
+
+type entry =
+  { category : category
+  ; path : string
+  ; scope : string
+  ; callee : string
+  ; count : int
+  }
+
+type report =
+  { sites : site list
+  ; entries : entry list
+  ; scanned_sources : int
+  ; scanned_cmt_files : int
+  }
+
+type drift =
+  { entry : entry
+  ; baseline_count : int
+  ; current_count : int
+  }
+
+type comparison =
+  { increases : drift list
+  ; reductions : drift list
+  }
+
+let default_source_roots = [ "lib"; "bin"; "packages/agent_core/lib" ]
+
+let category_to_string = function
+  | Partial_extraction -> "partial_extraction"
+  | Failure_erasure -> "failure_erasure"
+  | Effect_in_pure_module -> "effect_in_pure_module"
+;;
+
+let category_of_string = function
+  | "partial_extraction" -> Ok Partial_extraction
+  | "failure_erasure" -> Ok Failure_erasure
+  | "effect_in_pure_module" -> Ok Effect_in_pure_module
+  | value -> Error (Printf.sprintf "unknown boundary-audit category %S" value)
+;;
+
+let ( let* ) = Result.bind
+
+let starts_with ~prefix value =
+  let prefix_length = String.length prefix in
+  String.length value >= prefix_length
+  && String.equal (String.sub value 0 prefix_length) prefix
+;;
+
+let ends_with ~suffix value =
+  let suffix_length = String.length suffix in
+  let value_length = String.length value in
+  value_length >= suffix_length
+  && String.equal
+       (String.sub value (value_length - suffix_length) suffix_length)
+       suffix
+;;
+
+let normalize_resolved_callee value =
+  let value =
+    value |> String.to_seq |> Seq.filter (fun character -> character <> '!')
+    |> String.of_seq
+  in
+  let buffer = Buffer.create (String.length value) in
+  let rec copy index =
+    if index >= String.length value
+    then Buffer.contents buffer
+    else if
+      index + 1 < String.length value
+      && Char.equal value.[index] '_'
+      && Char.equal value.[index + 1] '_'
+    then (
+      Buffer.add_char buffer '.';
+      copy (index + 2))
+    else (
+      Buffer.add_char buffer value.[index];
+      copy (index + 1))
+  in
+  copy 0
+;;
+
+let category_for_resolved_callee raw =
+  match normalize_resolved_callee raw with
+  | "Stdlib.Option.get" | "Option.get"
+  | "Stdlib.Result.get_ok" | "Result.get_ok" ->
+    Some Partial_extraction
+  | "Stdlib.Result.to_option" | "Result.to_option" -> Some Failure_erasure
+  | callee when String.equal callee "Parse_outcome.to_option" ->
+    Some Failure_erasure
+  | callee when ends_with ~suffix:".Parse_outcome.to_option" callee ->
+    Some Failure_erasure
+  | _ -> None
+;;
+
+module String_set = Set.Make (String)
+
+let effectful_exact =
+  [ "Stdlib.close_in"
+  ; "Stdlib.close_in_noerr"
+  ; "Stdlib.close_out"
+  ; "Stdlib.close_out_noerr"
+  ; "Stdlib.flush"
+  ; "Stdlib.input"
+  ; "Stdlib.input_binary_int"
+  ; "Stdlib.input_byte"
+  ; "Stdlib.input_char"
+  ; "Stdlib.input_line"
+  ; "Stdlib.open_in"
+  ; "Stdlib.open_in_bin"
+  ; "Stdlib.open_in_gen"
+  ; "Stdlib.open_out"
+  ; "Stdlib.open_out_bin"
+  ; "Stdlib.open_out_gen"
+  ; "Stdlib.output"
+  ; "Stdlib.output_binary_int"
+  ; "Stdlib.output_byte"
+  ; "Stdlib.output_char"
+  ; "Stdlib.output_string"
+  ; "Stdlib.Format.eprintf"
+  ; "Stdlib.Format.fprintf"
+  ; "Stdlib.Format.ifprintf"
+  ; "Stdlib.Format.kfprintf"
+  ; "Stdlib.Format.printf"
+  ; "Stdlib.Printf.eprintf"
+  ; "Stdlib.Printf.fprintf"
+  ; "Stdlib.Printf.ifprintf"
+  ; "Stdlib.Printf.kfprintf"
+  ; "Stdlib.Printf.printf"
+  ; "Stdlib.prerr_endline"
+  ; "Stdlib.print_endline"
+  ; "Stdlib.read_line"
+  ; "Stdlib.Sys.chdir"
+  ; "Stdlib.Sys.command"
+  ; "Stdlib.Sys.file_exists"
+  ; "Stdlib.Sys.getcwd"
+  ; "Stdlib.Sys.getenv"
+  ; "Stdlib.Sys.getenv_opt"
+  ; "Stdlib.Sys.is_directory"
+  ; "Stdlib.Sys.mkdir"
+  ; "Stdlib.Sys.readdir"
+  ; "Stdlib.Sys.remove"
+  ; "Stdlib.Sys.rename"
+  ; "Stdlib.Sys.rmdir"
+  ; "Stdlib.Sys.time"
+  ; "Unix.accept"
+  ; "Unix.bind"
+  ; "Unix.chdir"
+  ; "Unix.close"
+  ; "Unix.connect"
+  ; "Unix.create_process"
+  ; "Unix.create_process_env"
+  ; "Unix.fsync"
+  ; "Unix.gettimeofday"
+  ; "Unix.kill"
+  ; "Unix.link"
+  ; "Unix.listen"
+  ; "Unix.lseek"
+  ; "Unix.lstat"
+  ; "Unix.mkdir"
+  ; "Unix.openfile"
+  ; "Unix.pipe"
+  ; "Unix.read"
+  ; "Unix.readdir"
+  ; "Unix.rename"
+  ; "Unix.rmdir"
+  ; "Unix.select"
+  ; "Unix.sleep"
+  ; "Unix.sleepf"
+  ; "Unix.socket"
+  ; "Unix.stat"
+  ; "Unix.symlink"
+  ; "Unix.time"
+  ; "Unix.truncate"
+  ; "Unix.unlink"
+  ; "Unix.wait"
+  ; "Unix.waitpid"
+  ; "Unix.write"
+  ]
+  |> String_set.of_list
+;;
+
+let contains_path_segment path wanted =
+  path |> String.split_on_char '.' |> List.exists (String.equal wanted)
+;;
+
+let effectful_resolved_callee raw =
+  let callee = normalize_resolved_callee raw in
+  String_set.mem callee effectful_exact
+  || (starts_with ~prefix:"Stdlib.Sys." callee
+      && not (String.equal callee "Stdlib.Sys.opaque_identity"))
+  || (starts_with ~prefix:"Unix." callee
+      && not (String.equal callee "Unix.gmtime"))
+  || starts_with ~prefix:"Eio." callee
+  || starts_with ~prefix:"Eio_main." callee
+  || starts_with ~prefix:"Stdlib.Atomic." callee
+  || starts_with ~prefix:"Stdlib.Domain." callee
+  || starts_with ~prefix:"Stdlib.In_channel." callee
+  || starts_with ~prefix:"Stdlib.Mutex." callee
+  || starts_with ~prefix:"Stdlib.Out_channel." callee
+  || starts_with ~prefix:"Stdlib.Random." callee
+  || starts_with ~prefix:"Stdlib.Thread." callee
+  || starts_with ~prefix:"Atomic." callee
+  || starts_with ~prefix:"Domain." callee
+  || starts_with ~prefix:"Fs_compat." callee
+  || starts_with ~prefix:"In_channel." callee
+  || starts_with ~prefix:"Mutex." callee
+  || starts_with ~prefix:"Out_channel." callee
+  || starts_with ~prefix:"Random." callee
+  || starts_with ~prefix:"Thread." callee
+  || starts_with ~prefix:"Time_compat.now" callee
+  || starts_with ~prefix:"Mtime_clock." callee
+  || starts_with ~prefix:"Ptime_clock." callee
+  || starts_with ~prefix:"Mirage_crypto_rng." callee
+  || contains_path_segment callee "Log"
+  || contains_path_segment callee "Logs"
+;;
+
+let location_start location =
+  let position = location.Location.loc_start in
+  position.Lexing.pos_lnum, position.pos_cnum - position.pos_bol
+;;
+
+let rec pattern_scope_name (pattern : pattern) =
+  match pattern.pat_desc with
+  | Tpat_var (_, name, _) -> Some name.txt
+  | Tpat_alias (nested, _, name, _, _) ->
+    (match pattern_scope_name nested with
+     | Some nested_name -> Some nested_name
+     | None -> Some name.txt)
+  | _ -> None
+;;
+
+let compare_site (left : site) (right : site) =
+  let compare_field first second next =
+    let ordering = String.compare first second in
+    if ordering = 0 then next () else ordering
+  in
+  compare_field
+    left.path
+    right.path
+    (fun () ->
+       compare_field
+         (category_to_string left.category)
+         (category_to_string right.category)
+         (fun () ->
+            compare_field
+              left.scope
+              right.scope
+              (fun () ->
+                 compare_field
+                   left.callee
+                   right.callee
+                   (fun () ->
+                      let line_order = Int.compare left.line right.line in
+                      if line_order = 0
+                      then Int.compare left.column right.column
+                      else line_order))))
+;;
+
+let audit_structure ~path ~pure structure =
+  let sites = ref [] in
+  let scopes = ref [] in
+  let current_scope () =
+    match List.rev !scopes with
+    | [] -> "<toplevel>"
+    | names -> String.concat "/" names
+  in
+  let add_site ~category ~callee location =
+    let line, column = location_start location in
+    sites :=
+      { category; path; scope = current_scope (); callee; line; column }
+      :: !sites
+  in
+  let with_scope name run =
+    scopes := name :: !scopes;
+    Fun.protect run ~finally:(fun () -> scopes := List.tl !scopes)
+  in
+  let iterator =
+    { Tast_iterator.default_iterator with
+      value_binding =
+        (fun self binding ->
+           let name =
+             match pattern_scope_name binding.vb_pat with
+             | Some name -> name
+             | None ->
+               let line, column = location_start binding.vb_loc in
+               Printf.sprintf "<pattern@%d:%d>" line column
+           in
+           with_scope name (fun () ->
+             Tast_iterator.default_iterator.value_binding self binding))
+    ; module_binding =
+        (fun self binding ->
+           let name =
+             match binding.mb_name.txt with
+             | Some name -> "module:" ^ name
+             | None ->
+               let line, column = location_start binding.mb_loc in
+               Printf.sprintf "module:<anonymous@%d:%d>" line column
+           in
+           with_scope name (fun () ->
+             Tast_iterator.default_iterator.module_binding self binding))
+    ; expr =
+        (fun self expression ->
+           (match expression.exp_desc with
+            | Texp_apply
+                ({ exp_desc = Texp_ident (resolved_path, _, _); _ }, _) ->
+              let callee =
+                resolved_path |> Path.name |> normalize_resolved_callee
+              in
+              Option.iter
+                (fun category ->
+                   add_site ~category ~callee expression.exp_loc)
+                (category_for_resolved_callee callee);
+              if pure && effectful_resolved_callee callee
+              then
+                add_site
+                  ~category:Effect_in_pure_module
+                  ~callee
+                  expression.exp_loc
+            | _ -> ());
+           Tast_iterator.default_iterator.expr self expression)
+    }
+  in
+  iterator.structure iterator structure;
+  List.sort compare_site !sites
+;;
+
+module Entry_key = struct
+  type t = category * string * string * string
+
+  let compare = compare
+end
+
+module Entry_map = Map.Make (Entry_key)
+module Entry_key_set = Set.Make (Entry_key)
+
+let entry_key (entry : entry) =
+  entry.category, entry.path, entry.scope, entry.callee
+;;
+
+let compare_entry (left : entry) (right : entry) =
+  Entry_key.compare (entry_key left) (entry_key right)
+;;
+
+let entries_of_sites (sites : site list) : entry list =
+  let counts =
+    List.fold_left
+      (fun acc (site : site) ->
+         let key = site.category, site.path, site.scope, site.callee in
+         let count = Option.value ~default:0 (Entry_map.find_opt key acc) in
+         Entry_map.add key (count + 1) acc)
+      Entry_map.empty
+      sites
+  in
+  Entry_map.bindings counts
+  |> List.map (fun ((category, path, scope, callee), count) ->
+    { category; path; scope; callee; count })
+;;
+
+let rec files_with_suffix ~suffix directory acc =
+  match Sys.readdir directory with
+  | exception Sys_error _ -> acc
+  | entries ->
+    Array.fold_left
+      (fun acc name ->
+         let path = Filename.concat directory name in
+         match (Unix.lstat path).st_kind with
+         | Unix.S_DIR -> files_with_suffix ~suffix path acc
+         | Unix.S_REG when Filename.check_suffix name suffix -> path :: acc
+         | Unix.S_REG | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK | Unix.S_FIFO
+         | Unix.S_SOCK -> acc
+         | exception Unix.Unix_error _ -> acc)
+      acc
+      entries
+;;
+
+let normalize_relative_path path =
+  let path = if starts_with ~prefix:"./" path then String.sub path 2 (String.length path - 2) else path in
+  let components = String.split_on_char '/' path in
+  if path = ""
+     || not (Filename.is_relative path)
+     || List.exists (String.equal "..") components
+  then Error (Printf.sprintf "expected repository-relative path, got %S" path)
+  else Ok (String.concat "/" (List.filter (fun part -> part <> ".") components))
+;;
+
+let strip_root_prefix ~root path =
+  let prefix = root ^ Filename.dir_sep in
+  if starts_with ~prefix path
+  then Some (String.sub path (String.length prefix) (String.length path - String.length prefix))
+  else None
+;;
+
+let source_candidate_of_location ~root path =
+  let path =
+    if Filename.is_relative path
+    then path
+    else Option.value ~default:path (strip_root_prefix ~root path)
+  in
+  let candidates =
+    if Filename.check_suffix path ".pp.ml"
+    then
+      [ String.sub path 0 (String.length path - String.length ".pp.ml") ^ ".ml"
+      ; path
+      ]
+    else [ path ]
+  in
+  List.find_opt (fun candidate -> Sys.file_exists (Filename.concat root candidate)) candidates
+;;
+
+let source_path_of_structure ~root ~fallback (structure : structure) =
+  let from_items =
+    List.find_map
+      (fun item ->
+         source_candidate_of_location
+           ~root
+           item.str_loc.Location.loc_start.Lexing.pos_fname)
+      structure.str_items
+  in
+  match from_items with
+  | Some _ as source -> source
+  | None -> Option.bind fallback (source_candidate_of_location ~root)
+;;
+
+let path_under_roots ~source_roots path =
+  List.exists
+    (fun root -> String.equal path root || starts_with ~prefix:(root ^ "/") path)
+    source_roots
+;;
+
+module String_map = Map.Make (String)
+
+let read_cmt_implementation path =
+  try
+    let info = Cmt_format.read_cmt path in
+    match info.cmt_annots with
+    | Cmt_format.Implementation structure -> Ok (Some (info, structure))
+    | Packed _ | Interface _ | Partial_implementation _ | Partial_interface _ ->
+      Ok None
+  with
+  | Sys_error message -> Error message
+  | Cmt_format.Error _ as error ->
+    Error (Format.asprintf "%a" Location.report_exception error)
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let audit_repository ~root ~build_dir ~source_roots ~pure_modules =
+  let* normalized_roots =
+    List.fold_left
+      (fun result path ->
+         let* paths = result in
+         let* path = normalize_relative_path path in
+         Ok (path :: paths))
+      (Ok [])
+      source_roots
+    |> Result.map List.rev
+  in
+  let* normalized_pure =
+    List.fold_left
+      (fun result path ->
+         let* paths = result in
+         let* path = normalize_relative_path path in
+         Ok (path :: paths))
+      (Ok [])
+      pure_modules
+    |> Result.map List.rev
+  in
+  let pure_set = String_set.of_list normalized_pure in
+  let required_directories = build_dir :: List.map (Filename.concat root) normalized_roots in
+  let missing_directories =
+    List.filter
+      (fun path ->
+         try not (Sys.is_directory path) with
+         | Sys_error _ -> true)
+      required_directories
+  in
+  if missing_directories <> []
+  then Error ("required audit directories are missing:\n" ^ String.concat "\n" missing_directories)
+  else
+  let production_sources =
+    List.fold_left
+      (fun acc source_root ->
+         files_with_suffix ~suffix:".ml" (Filename.concat root source_root) acc)
+      []
+      normalized_roots
+    |> List.filter_map (strip_root_prefix ~root)
+    |> List.sort_uniq String.compare
+  in
+  let production_set = String_set.of_list production_sources in
+  let unknown_pure = String_set.diff pure_set production_set |> String_set.elements in
+  if unknown_pure <> []
+  then
+    Error
+      ("pure-module registry contains non-production paths:\n"
+       ^ String.concat "\n" unknown_pure)
+  else (
+    let cmt_files = files_with_suffix ~suffix:".cmt" build_dir [] |> List.sort String.compare in
+    let* source_cmts =
+      List.fold_left
+        (fun result cmt_path ->
+           let* source_cmts = result in
+           let* implementation = read_cmt_implementation cmt_path in
+           match implementation with
+           | None -> Ok source_cmts
+           | Some (info, structure) ->
+             let fallback = info.Cmt_format.cmt_sourcefile in
+             (match source_path_of_structure ~root ~fallback structure with
+              | Some source when path_under_roots ~source_roots:normalized_roots source ->
+                if String_map.mem source source_cmts
+                then Ok source_cmts
+                else Ok (String_map.add source (cmt_path, structure) source_cmts)
+              | Some _ | None -> Ok source_cmts))
+        (Ok String_map.empty)
+        cmt_files
+    in
+    let compiled_set =
+      source_cmts |> String_map.bindings |> List.map fst |> String_set.of_list
+    in
+    let missing = String_set.diff production_set compiled_set |> String_set.elements in
+    if missing <> []
+    then
+      Error
+        (Printf.sprintf
+           "typed-tree coverage is incomplete: %d production source(s) have no .cmt:\n%s"
+           (List.length missing)
+           (String.concat "\n" missing))
+    else (
+      let sites =
+        source_cmts
+        |> String_map.bindings
+        |> List.concat_map (fun (path, (_cmt_path, structure)) ->
+          audit_structure ~path ~pure:(String_set.mem path pure_set) structure)
+        |> List.sort compare_site
+      in
+      Ok
+        { sites
+        ; entries = entries_of_sites sites
+        ; scanned_sources = List.length production_sources
+        ; scanned_cmt_files = List.length cmt_files
+        }))
+;;
+
+let trim = String.trim
+
+let read_lines path =
+  match In_channel.open_text path with
+  | exception Sys_error message -> Error message
+  | channel ->
+    let rec loop line_number lines =
+      match In_channel.input_line channel with
+      | Some line -> loop (line_number + 1) ((line_number, line) :: lines)
+      | None -> Ok (List.rev lines)
+      | exception Sys_error message -> Error message
+    in
+    let result = loop 1 [] in
+    In_channel.close channel;
+    result
+;;
+
+let read_module_paths path =
+  let* lines = read_lines path in
+  let rec collect modules = function
+    | [] -> Ok (List.sort_uniq String.compare modules)
+    | (line_number, raw) :: rest ->
+      let value = trim raw in
+      if value = "" || value.[0] = '#'
+      then collect modules rest
+      else (
+        match normalize_relative_path value with
+        | Error message -> Error (Printf.sprintf "%s:%d: %s" path line_number message)
+        | Ok relative -> collect (relative :: modules) rest)
+  in
+  collect [] lines
+;;
+
+let read_pure_modules ~root path =
+  let* modules = read_module_paths path in
+  match
+    List.find_opt
+      (fun relative -> not (Sys.file_exists (Filename.concat root relative)))
+      modules
+  with
+  | None -> Ok modules
+  | Some relative -> Error (Printf.sprintf "pure module does not exist: %s" relative)
+;;
+
+let parse_positive_int ~path ~line_number value =
+  match int_of_string_opt value with
+  | Some count when count > 0 -> Ok count
+  | _ ->
+    Error
+      (Printf.sprintf
+         "%s:%d: expected positive count, got %S"
+         path
+         line_number
+         value)
+;;
+
+let read_baseline path =
+  let* lines = read_lines path in
+  let rec collect entries = function
+    | [] -> Ok (List.sort compare_entry entries)
+    | (line_number, raw) :: rest ->
+      let value = trim raw in
+      if value = "" || value.[0] = '#'
+      then collect entries rest
+      else (
+        match String.split_on_char '\t' raw with
+        | [ category; entry_path; scope; callee; count ] ->
+          let* category = category_of_string category in
+          let* count = parse_positive_int ~path ~line_number count in
+          collect ({ category; path = entry_path; scope; callee; count } :: entries) rest
+        | _ ->
+          Error
+            (Printf.sprintf
+               "%s:%d: expected category<TAB>path<TAB>scope<TAB>callee<TAB>count"
+               path
+               line_number))
+  in
+  let* entries = collect [] lines in
+  let rec reject_duplicates = function
+    | left :: right :: _ when Entry_key.compare (entry_key left) (entry_key right) = 0 ->
+      Error
+        (Printf.sprintf
+           "%s: duplicate baseline key: %s %s %s %s"
+           path
+           (category_to_string left.category)
+           left.path
+           left.scope
+           left.callee)
+    | _ :: rest -> reject_duplicates rest
+    | [] -> Ok entries
+  in
+  reject_duplicates entries
+;;
+
+let write_baseline path entries =
+  match Out_channel.open_text path with
+  | exception Sys_error message -> Error message
+  | channel ->
+    let result =
+      try
+        output_string channel "# ocaml-boundary-audit-v2 typed-tree baseline\n";
+        output_string channel "# category<TAB>path<TAB>scope<TAB>resolved-callee<TAB>count\n";
+        entries
+        |> List.sort compare_entry
+        |> List.iter (fun entry ->
+          Printf.fprintf
+            channel
+            "%s\t%s\t%s\t%s\t%d\n"
+            (category_to_string entry.category)
+            entry.path
+            entry.scope
+            entry.callee
+            entry.count);
+        Ok ()
+      with
+      | Sys_error message -> Error message
+    in
+    Out_channel.close channel;
+    result
+;;
+
+let entry_map entries =
+  List.fold_left
+    (fun map entry -> Entry_map.add (entry_key entry) entry.count map)
+    Entry_map.empty
+    entries
+;;
+
+let compare ~baseline ~current =
+  let baseline_map = entry_map baseline in
+  let current_map = entry_map current in
+  let keys =
+    Entry_map.fold
+      (fun key _ keys -> Entry_key_set.add key keys)
+      baseline_map
+      Entry_key_set.empty
+  in
+  let keys =
+    Entry_map.fold (fun key _ keys -> Entry_key_set.add key keys) current_map keys
+  in
+  let increases, reductions =
+    Entry_key_set.fold
+      (fun ((category, path, scope, callee) as key) (increases, reductions) ->
+         let baseline_count = Option.value ~default:0 (Entry_map.find_opt key baseline_map) in
+         let current_count = Option.value ~default:0 (Entry_map.find_opt key current_map) in
+         let entry = { category; path; scope; callee; count = current_count } in
+         if current_count > baseline_count
+         then { entry; baseline_count; current_count } :: increases, reductions
+         else if current_count < baseline_count
+         then increases, { entry; baseline_count; current_count } :: reductions
+         else increases, reductions)
+      keys
+      ([], [])
+  in
+  { increases = List.rev increases; reductions = List.rev reductions }
+;;
+
+let site_to_text (site : site) =
+  Printf.sprintf
+    "%s:%d:%d [%s] %s (%s)"
+    site.path
+    site.line
+    site.column
+    (category_to_string site.category)
+    site.callee
+    site.scope
+;;
+
+let report_to_text report =
+  let header =
+    Printf.sprintf
+      "typed sources=%d cmt files inspected=%d findings=%d\n"
+      report.scanned_sources
+      report.scanned_cmt_files
+      (List.length report.sites)
+  in
+  header ^ String.concat "\n" (List.map site_to_text report.sites)
+  ^ if report.sites = [] then "" else "\n"
+;;
+
+let report_to_json report =
+  `Assoc
+    [ "schema_version", `Int 2
+    ; "scanned_sources", `Int report.scanned_sources
+    ; "scanned_cmt_files", `Int report.scanned_cmt_files
+    ; ( "sites"
+      , `List
+          (List.map
+             (fun (site : site) ->
+                `Assoc
+                  [ "category", `String (category_to_string site.category)
+                  ; "path", `String site.path
+                  ; "scope", `String site.scope
+                  ; "callee", `String site.callee
+                  ; "line", `Int site.line
+                  ; "column", `Int site.column
+                  ])
+             report.sites) )
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let drift_to_text direction drift =
+  Printf.sprintf
+    "%s %s %s %s %s: %d -> %d\n"
+    direction
+    (category_to_string drift.entry.category)
+    drift.entry.path
+    drift.entry.scope
+    drift.entry.callee
+    drift.baseline_count
+    drift.current_count
+;;
+
+let comparison_to_text comparison =
+  String.concat ""
+    (List.map (drift_to_text "INCREASE") comparison.increases
+     @ List.map (drift_to_text "REDUCTION") comparison.reductions)
+;;

--- a/tools/ocaml_boundary_audit/ocaml_boundary_audit.mli
+++ b/tools/ocaml_boundary_audit/ocaml_boundary_audit.mli
@@ -1,0 +1,83 @@
+(** Typed-tree audit for the mechanical part of the functional-core boundary.
+
+    The audit reads compiler-produced [.cmt] files. It therefore classifies
+    resolved value paths rather than source spellings: a module alias of
+    [Option.get] is still found, while an unrelated local [Option.get] is not. *)
+
+type category =
+  | Partial_extraction
+  | Failure_erasure
+  | Effect_in_pure_module
+
+type site =
+  { category : category
+  ; path : string
+  ; scope : string
+  ; callee : string
+  ; line : int
+  ; column : int
+  }
+
+type entry =
+  { category : category
+  ; path : string
+  ; scope : string
+  ; callee : string
+  ; count : int
+  }
+
+type report =
+  { sites : site list
+  ; entries : entry list
+  ; scanned_sources : int
+  ; scanned_cmt_files : int
+  }
+
+type drift =
+  { entry : entry
+  ; baseline_count : int
+  ; current_count : int
+  }
+
+type comparison =
+  { increases : drift list
+  ; reductions : drift list
+  }
+
+val default_source_roots : string list
+val category_to_string : category -> string
+val category_of_string : string -> (category, string) result
+
+val normalize_resolved_callee : string -> string
+(** Normalize compiler path presentation without changing module identity. *)
+
+val category_for_resolved_callee : string -> category option
+(** Classify only mechanically forbidden operations. In particular this does
+    not classify [Option.value] or catch-all handlers. *)
+
+val effectful_resolved_callee : string -> bool
+(** Whether a resolved callee is a canonical external-effect API forbidden in
+    a module explicitly registered as pure. *)
+
+val entries_of_sites : site list -> entry list
+
+val audit_repository :
+  root:string ->
+  build_dir:string ->
+  source_roots:string list ->
+  pure_modules:string list ->
+  (report, string) result
+(** Audit every production source and fail if its typed tree is missing. *)
+
+val read_pure_modules : root:string -> string -> (string list, string) result
+val read_module_paths : string -> (string list, string) result
+(** Parse a module-path registry without requiring the paths to exist in the
+    current checkout. Used only to compare a PR-base pure registry after a
+    module was legitimately deleted. *)
+val read_baseline : string -> (entry list, string) result
+val write_baseline : string -> entry list -> (unit, string) result
+val compare : baseline:entry list -> current:entry list -> comparison
+
+val report_to_text : report -> string
+val report_to_json : report -> string
+val comparison_to_text : comparison -> string

--- a/tools/ocaml_boundary_audit/test_ocaml_boundary_audit.ml
+++ b/tools/ocaml_boundary_audit/test_ocaml_boundary_audit.ml
@@ -1,0 +1,136 @@
+open Ocaml_boundary_audit
+
+let category = Alcotest.testable (fun formatter value ->
+  Format.pp_print_string formatter (category_to_string value)) ( = )
+;;
+
+let test_resolved_partial_extraction () =
+  List.iter
+    (fun callee ->
+       Alcotest.(check (option category))
+         callee
+         (Some Partial_extraction)
+         (category_for_resolved_callee callee))
+    [ "Stdlib!.Option.get"
+    ; "Stdlib.Option.get"
+    ; "Stdlib!.Result.get_ok"
+    ];
+  Alcotest.(check (option category))
+    "local module with the same final name is not Stdlib"
+    None
+    (category_for_resolved_callee "Example.Option.get")
+;;
+
+let test_resolved_failure_erasure () =
+  List.iter
+    (fun callee ->
+       Alcotest.(check (option category))
+         callee
+         (Some Failure_erasure)
+         (category_for_resolved_callee callee))
+    [ "Stdlib!.Result.to_option"
+    ; "Result.to_option"
+    ; "Agent_core__Parse_outcome.to_option"
+    ]
+;;
+
+let test_resolved_effects () =
+  List.iter
+    (fun callee -> Alcotest.(check bool) callee true (effectful_resolved_callee callee))
+    [ "Stdlib!.Sys.getenv_opt"
+    ; "Unix!.gettimeofday"
+    ; "Unix!.putenv"
+    ; "Eio!.Time.sleep"
+    ; "Fs_compat.read_file"
+    ; "Masc_log__Log.Keeper.info"
+    ];
+  Alcotest.(check bool)
+    "gmtime is a pure conversion of supplied data"
+    false
+    (effectful_resolved_callee "Unix!.gmtime")
+;;
+
+let site ?(scope = "decode") ?(callee = "Stdlib.Option.get") category =
+  { category
+  ; path = "lib/sample.ml"
+  ; scope
+  ; callee
+  ; line = 10
+  ; column = 2
+  }
+;;
+
+let test_downward_comparison () =
+  let baseline =
+    entries_of_sites [ site Partial_extraction; site Partial_extraction ]
+  in
+  let reduced = entries_of_sites [ site Partial_extraction ] in
+  let increased =
+    entries_of_sites
+      [ site Partial_extraction; site Partial_extraction; site Partial_extraction ]
+  in
+  let reduction = compare ~baseline ~current:reduced in
+  let increase = compare ~baseline ~current:increased in
+  Alcotest.(check int) "one reduced bucket" 1 (List.length reduction.reductions);
+  Alcotest.(check int) "no increase" 0 (List.length reduction.increases);
+  Alcotest.(check int) "one increased bucket" 1 (List.length increase.increases)
+;;
+
+let test_baseline_round_trip () =
+  let path = Filename.temp_file "ocaml-boundary-test-" ".tsv" in
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+       let expected =
+         entries_of_sites
+           [ site Partial_extraction
+           ; site Failure_erasure ~callee:"Stdlib.Result.to_option"
+           ]
+       in
+       (match write_baseline path expected with
+        | Ok () -> ()
+        | Error message -> Alcotest.fail message);
+       match read_baseline path with
+       | Error message -> Alcotest.fail message
+       | Ok actual -> Alcotest.(check bool) "round trip" true (expected = actual))
+;;
+
+let test_pure_registry_rejects_escape () =
+  let root = Filename.temp_file "ocaml-boundary-root-" "" in
+  Sys.remove root;
+  Unix.mkdir root 0o755;
+  let registry = Filename.concat root "pure.txt" in
+  let channel = open_out registry in
+  output_string channel "../outside.ml\n";
+  close_out channel;
+  Fun.protect
+    ~finally:(fun () ->
+      Sys.remove registry;
+      Unix.rmdir root)
+    (fun () ->
+       match read_pure_modules ~root registry with
+       | Ok _ -> Alcotest.fail "registry path escape was accepted"
+       | Error _ -> ())
+;;
+
+let () =
+  Alcotest.run
+    "ocaml-boundary-audit"
+    [ ( "typed path classification"
+      , [ Alcotest.test_case
+            "partial extraction"
+            `Quick
+            test_resolved_partial_extraction
+        ; Alcotest.test_case "failure erasure" `Quick test_resolved_failure_erasure
+        ; Alcotest.test_case "effect APIs" `Quick test_resolved_effects
+        ] )
+    ; ( "ratchet"
+      , [ Alcotest.test_case "downward only" `Quick test_downward_comparison
+        ; Alcotest.test_case "baseline round trip" `Quick test_baseline_round_trip
+        ; Alcotest.test_case
+            "pure registry rejects path escape"
+            `Quick
+            test_pure_registry_rejects_escape
+        ] )
+    ]
+;;


### PR DESCRIPTION
Part of #28221 and RFC-0371 (#28220). Stacked on #28261 so deletion of the dead scaffold and introduction of the new gate remain independently reviewable.

## What changed

- Added the living functional-core/effect-shell architecture contract.
- Added `tools/ocaml_boundary_audit`, which reads compiler-produced `.cmt` files and classifies resolved value paths.
- Added an exact downward-only baseline for the mechanically forbidden operations:
  - `Option.get`
  - `Result.get_ok`
  - `Result.to_option`
  - `Parse_outcome.to_option`
- Added a monotonic pure-module registry. Registered modules have zero tolerance for canonical env/clock/random/fs/Eio/mutation/logging calls.
- Wired the audit after the authoritative `@default @check @install` build, and lowered the unwired-audit baseline because this audit is actually invoked.
- Fail closed when any production `.ml` in `lib`, `bin`, or `packages/agent_core/lib` lacks a `.cmt`.

## Deliberate exclusions

This does **not** resurrect #28222's rejected global syntax ratchet:

- no global `Option.value` ban;
- no global catch-all exception count;
- no 1,789-bucket baseline;
- no file-move failure for legitimate boundary defaults or orchestration.

Repeated optional-binding inspection, cancellation absorption, and effects under locks require category-specific data-flow proof before they can become hard gates. The living doc records that boundary.

## Current typed inventory

The current main build contains 1,533 production source implementations and the audit inspected 3,036 `.cmt` files. Coverage was complete.

| Category | Buckets | Sites |
|---|---:|---:|
| partial extraction | 5 | 7 |
| failure erasure | 1 | 1 |
| effects in registered pure modules | 0 | 0 |

## Validation

- repo `-w +32 -warn-error +a` direct compiler-libs compilation of library, CLI, and test — PASS, warnings 0
- focused audit self-test — 6/6 PASS
- real `.cmt` full-source coverage and baseline check — PASS (`1533 typed sources`, `6 mechanical debt buckets`)
- `ocamlformat --check` — PASS
- `shellcheck scripts/ocaml-boundary-ratchet.sh` — PASS
- `actionlint -shellcheck= .github/workflows/ci.yml` — PASS
- `git diff --check` — PASS
- `scripts/ci/check-ocaml-compile-authority.sh` — PASS
- `scripts/audit-ci-test-targets.sh` — PASS
- `scripts/audit-unwired-audits.sh` — PASS at lowered 13 baseline
- `scripts/check-doc-truth.sh` — PASS
- `scripts/ocaml-structure-ratchet.sh` — PASS
- `scripts/ci/check-determinism-contract.sh` — PASS
- exact-head GitHub CI — running

Focused local Dune is pending because another session owns the machine-wide bare-Dune lock; it was not killed or bypassed. The equivalent code was compiled directly under the repo warning policy and exact-head CI owns the full Dune verdict.

## Review focus

- resolved-path normalization (`Stdlib!` and wrapped-library `__` path presentation);
- complete source→`.cmt` coverage failure mode;
- pure effect API set and monotonic registry comparison;
- CI base-baseline comparison on PR and non-PR events.

RFC-WAIVED: CI/tooling and architecture policy only; no runtime, credential, persistence, or operator behavior changes.
