### PR TITLE
perf(keeper): raw-trace 목록을 파일당 prefix 예산으로 유계화 (sangsu 16.5s → 0.12s)

### DIFF
--- a/dashboard/src/api/dashboard-keeper-prompt.test.ts
+++ b/dashboard/src/api/dashboard-keeper-prompt.test.ts
@@ -83,12 +83,59 @@ describe('raw traces', () => {
   it('decodes the turn listing', async () => {
     stubFetch({
       keeper: 'kidsnote',
-      turns: [{ file: 'turn-1.jsonl', trace_id: 'trace-kidsnote-1', bytes: 2048, records: 218, modified_at: 1786000000 }],
+      turns: [
+        {
+          file: 'turn-1.jsonl',
+          trace_id: 'trace-kidsnote-1',
+          bytes: 2048,
+          census: { state: 'whole_file', records: 218 },
+          modified_at: 1786000000,
+        },
+      ],
     })
     const turns = await fetchKeeperRawTraces('kidsnote', 25)
     expect(turns).toHaveLength(1)
-    expect(turns[0]?.records).toBe(218)
+    expect(turns[0]?.census).toEqual({ state: 'whole_file', records: 218 })
     expect(turns[0]?.traceId).toBe('trace-kidsnote-1')
+  })
+
+  // A turn past the listing budget arrives without a count. The decoder has to
+  // carry that state through rather than substitute a number, otherwise the
+  // panel cannot tell "no records" from "not counted".
+  it('decodes an uncounted turn without inventing a record count', async () => {
+    stubFetch({
+      keeper: 'sangsu',
+      turns: [
+        {
+          file: 'turn-runaway.jsonl',
+          trace_id: 'trace-sangsu-9',
+          bytes: 390_000_000,
+          census: { state: 'prefix_only', budget_bytes: 131072 },
+          modified_at: 1786000000,
+        },
+      ],
+    })
+    const turns = await fetchKeeperRawTraces('sangsu', 25)
+    expect(turns[0]?.census).toEqual({ state: 'prefix_only', budgetBytes: 131072 })
+    expect(turns[0]?.bytes).toBe(390_000_000)
+  })
+
+  it('rejects a census state this build does not know', async () => {
+    stubFetch({
+      keeper: 'kidsnote',
+      turns: [
+        {
+          file: 'turn-1.jsonl',
+          trace_id: 'trace-kidsnote-1',
+          bytes: 2048,
+          census: { state: 'sampled', records: 12 },
+          modified_at: 1786000000,
+        },
+      ],
+    })
+    await expect(fetchKeeperRawTraces('kidsnote', 25)).rejects.toThrow(
+      '유효하지 않은 raw trace 목록 payload',
+    )
   })
 
   // A torn line occupies its own position. Dropping it would make a damaged

--- a/dashboard/src/api/dashboard-keeper-prompt.ts
+++ b/dashboard/src/api/dashboard-keeper-prompt.ts
@@ -93,12 +93,36 @@ export async function fetchKeeperLastPrompt(
   })
 }
 
+// The listing reads a bounded prefix of each turn file, so a turn larger than
+// that budget arrives without a record count. That is a distinct state, not a
+// zero and not a missing field: a union here makes the panel decide what it
+// shows instead of letting a default stand in for a count nobody took.
+export type RawTraceCensus =
+  | { readonly state: 'whole_file'; readonly records: number }
+  | { readonly state: 'prefix_only'; readonly budgetBytes: number }
+
 export type RawTraceTurn = {
   readonly file: string
   readonly traceId: string | null
   readonly bytes: number
-  readonly records: number
+  readonly census: RawTraceCensus
   readonly modifiedAt: number
+}
+
+function decodeCensus(raw: unknown): RawTraceCensus | null {
+  if (!isRecord(raw)) return null
+  const state = asString(raw.state)
+  if (state === 'whole_file') {
+    const records = asNumber(raw.records)
+    if (records == null || !Number.isSafeInteger(records)) return null
+    return { state, records }
+  }
+  if (state === 'prefix_only') {
+    const budgetBytes = asNumber(raw.budget_bytes)
+    if (budgetBytes == null || !Number.isSafeInteger(budgetBytes)) return null
+    return { state, budgetBytes }
+  }
+  return null
 }
 
 function decodeTurnSummary(raw: unknown): RawTraceTurn | null {
@@ -113,11 +137,11 @@ function decodeTurnSummary(raw: unknown): RawTraceTurn | null {
     traceId = decoded
   }
   const bytes = asNumber(raw.bytes)
-  const records = asNumber(raw.records)
+  const census = decodeCensus(raw.census)
   const modifiedAt = asNumber(raw.modified_at)
-  if (file == null || bytes == null || records == null || modifiedAt == null) return null
-  if (!Number.isSafeInteger(bytes) || !Number.isSafeInteger(records)) return null
-  return { file, traceId, bytes, records, modifiedAt }
+  if (file == null || bytes == null || census == null || modifiedAt == null) return null
+  if (!Number.isSafeInteger(bytes)) return null
+  return { file, traceId, bytes, census, modifiedAt }
 }
 
 export async function fetchKeeperRawTraces(

--- a/dashboard/src/components/keeper-turn-inspector-panel.ts
+++ b/dashboard/src/components/keeper-turn-inspector-panel.ts
@@ -47,6 +47,16 @@ function formatBytes(value: number): string {
   return `${(value / (1024 * 1024)).toFixed(1)} MB`
 }
 
+// A turn past the listing budget has no count yet. Saying so — and naming the
+// size that caused it — is more use to an operator hunting a runaway turn than
+// a number would be, because the size is the thing that flagged it. Opening
+// the turn reads the file in full and shows the real total.
+function censusLabel(census: RawTraceTurn['census']): string {
+  return census.state === 'whole_file'
+    ? `${census.records}건`
+    : `${formatBytes(census.budgetBytes)} 초과 · 열어서 집계`
+}
+
 // These records carry unix seconds; relativeTime reads ISO strings.
 function ago(unixSeconds: number): string {
   return relativeTime(new Date(unixSeconds * 1000).toISOString())
@@ -150,7 +160,7 @@ function RawTurns({ keeper }: { keeper: string }) {
               ? html`<span class="text-[var(--color-fg-disabled)]">trace 없음</span>`
               : html`<span class="min-w-0 truncate font-mono text-[var(--color-fg-muted)]" title=${turn.traceId}>${turn.traceId}</span>`}
             <span class="ml-auto tabular-nums text-[var(--color-fg-muted)]">
-              ${turn.records}건 · ${formatBytes(turn.bytes)} · ${ago(turn.modifiedAt)}
+              ${censusLabel(turn.census)} · ${formatBytes(turn.bytes)} · ${ago(turn.modifiedAt)}
             </span>
           </button>
         `)}

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -945,6 +945,7 @@ let load_owned_regular_file ~ownership_root path =
 type owned_regular_file_prefix =
   { content : string
   ; file_size : int
+  ; modified_at : float
   ; truncated : bool
   }
 
@@ -967,6 +968,7 @@ let load_owned_regular_file_prefix_blocking
           Ok
             { content
             ; file_size = descriptor.Unix.st_size
+            ; modified_at = descriptor.Unix.st_mtime
             ; truncated = descriptor.Unix.st_size > length
             })
       path

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -255,6 +255,10 @@ val load_owned_regular_file_with_snapshot
 type owned_regular_file_prefix =
   { content : string
   ; file_size : int
+  ; modified_at : float
+        (** From the same validated descriptor as [file_size], so a caller
+            listing a directory can order by modification time without a
+            second stat and without reading past [max_bytes]. *)
   ; truncated : bool
   }
 

--- a/lib/keeper/keeper_raw_trace_reader.ml
+++ b/lib/keeper/keeper_raw_trace_reader.ml
@@ -1,11 +1,15 @@
 (** See [keeper_raw_trace_reader.mli]. *)
 
+type record_census =
+  | Whole_file of { records : int }
+  | Prefix_only of { budget_bytes : int }
+
 type turn_summary =
   { file : string
   ; trace_id : string option
   ; bytes : int
   ; modified_at : float
-  ; records : int
+  ; census : record_census
   }
 
 type turn_record =
@@ -92,6 +96,43 @@ let trace_id_of_line ~file ~line_number line =
   | exception Yojson.Json_error detail -> invalid detail
 ;;
 
+(* How much of one turn file the listing may read.
+
+   Before this, listing read every file whole and JSON-parsed every line just
+   to report a record count, so the cost was O(total bytes in the directory)
+   for a page of at most [limit] entries. Measured 2026-08-12 over the 1,229
+   retained traces on this host: p50 3.7 KB, p90 60 KB, p95 218 KB — and one
+   runaway turn of 372.5 MB (16,801 tool executions in a single turn) holding
+   84% of the corpus. That one file made the listing take 3.35 s for [sangsu]
+   while another keeper with *more* files but less data answered in 0.039 s.
+
+   With a per-file budget the listing costs O(entries x budget) no matter what
+   any single turn wrote, and the bound is a property of each file alone —
+   whether a file is counted never depends on its neighbours. RFC-0228 §2
+   principle 3 states the same rule for the keeper-facing lane pull: paging
+   must not reintroduce full-file scans.
+
+   256 KiB was chosen by replaying the same corpus at several budgets: it
+   counts 95.2% of turns exactly while the slowest keeper's whole listing costs
+   0.092 s. Doubling it buys 2 more points of coverage for 50% more read, and
+   the turns it would newly cover are the ones an operator opens anyway. *)
+let listing_census_budget_bytes = 256 * 1024
+
+(* A prefix that stopped at the budget ends mid-record. Dropping that partial
+   tail keeps the listing from reporting a *torn* line, which would say the
+   file is damaged when it is only longer than the budget. *)
+let complete_nonblank_lines ~truncated contents =
+  let lines = String.split_on_char '\n' contents in
+  let lines =
+    if not truncated
+    then lines
+    else (
+      match List.rev lines with
+      | _partial :: earlier -> List.rev earlier
+      | [] -> [])
+  in
+  List.filter (fun line -> not (String.equal (String.trim line) "")) lines
+
 let summarize_records ~file contents =
   let lines = nonblank_lines contents in
   let rec loop line_number expected = function
@@ -148,35 +189,70 @@ let list_turns ~config ~keeper ~limit =
           with
           | Sys_error detail -> Error (Read_failed { file = dir; detail })
         in
+        (* A file the budget covered whole is summarized exactly as before:
+           the count is the record count and every record carried one identity.
+           A file past the budget reports the identity of its first record and
+           says the count was not established here — [read_turn] reads the file
+           in full and returns [total_records]. Reporting a prefix's line count
+           as the file's would be a wrong number, which is worse than an
+           absent one. *)
+        let summary_of_prefix ~file (prefix : Fs_compat.owned_regular_file_prefix) =
+          if not prefix.truncated
+          then
+            Result.map
+              (fun (records, trace_id) ->
+                 { file
+                 ; trace_id
+                 ; bytes = prefix.file_size
+                 ; modified_at = prefix.modified_at
+                 ; census = Whole_file { records }
+                 })
+              (summarize_records ~file prefix.content)
+          else (
+            let lines = complete_nonblank_lines ~truncated:true prefix.content in
+            let first_identity =
+              match lines with
+              | [] -> Ok None
+              | line :: _ ->
+                Result.map
+                  (fun trace_id -> Some (Keeper_id.Trace_id.to_string trace_id))
+                  (trace_id_of_line ~file ~line_number:1 line)
+            in
+            Result.map
+              (fun trace_id ->
+                 { file
+                 ; trace_id
+                 ; bytes = prefix.file_size
+                 ; modified_at = prefix.modified_at
+                 ; census = Prefix_only { budget_bytes = listing_census_budget_bytes }
+                 })
+              first_identity)
+        in
+        let open_prefix ~file ~max_bytes =
+          match
+            Fs_compat.load_owned_regular_file_prefix
+              ~ownership_root:config.base_path
+              ~max_bytes
+              (Filename.concat dir file)
+          with
+          | Error error ->
+            Error
+              (Read_failed
+                 { file
+                 ; detail = Fs_compat.owned_regular_file_read_error_to_string error
+                 })
+          | Ok None -> Error (Read_failed { file; detail = "file disappeared during listing" })
+          | Ok (Some prefix) -> Ok prefix
+        in
         let rec read_summaries acc = function
           | [] -> Ok (List.rev acc)
           | file :: rest ->
-            let path = Filename.concat dir file in
-            (match
-               Fs_compat.load_owned_regular_file_with_snapshot
-                 ~ownership_root:config.base_path
-                 path
-             with
-             | Error error ->
-               Error
-                 (Read_failed
-                    { file
-                    ; detail = Fs_compat.owned_regular_file_read_error_to_string error
-                    })
-             | Ok None -> Error (Read_failed { file; detail = "file disappeared during listing" })
-             | Ok (Some contents) ->
-               (match summarize_records ~file contents.content with
+            (match open_prefix ~file ~max_bytes:listing_census_budget_bytes with
+             | Error _ as error -> error
+             | Ok prefix ->
+               (match summary_of_prefix ~file prefix with
                 | Error _ as error -> error
-                | Ok (records, trace_id) ->
-                  read_summaries
-                    ({ file
-                     ; trace_id
-                     ; bytes = contents.snapshot.file_size
-                     ; modified_at = contents.snapshot.modified_at
-                     ; records
-                     }
-                     :: acc)
-                    rest))
+                | Ok summary -> read_summaries (summary :: acc) rest))
         in
         (match entries with
          | Error _ as error -> error
@@ -233,13 +309,22 @@ let read_turn ~config ~keeper ~file ~offset ~limit =
           Ok { file; total_records; offset; records }))
 ;;
 
+(* The census is a sum on the wire, not a nullable count, so a reader has to
+   decide what it does about an uncounted turn instead of defaulting one in. *)
+let record_census_to_json = function
+  | Whole_file { records } ->
+    `Assoc [ "state", `String "whole_file"; "records", `Int records ]
+  | Prefix_only { budget_bytes } ->
+    `Assoc [ "state", `String "prefix_only"; "budget_bytes", `Int budget_bytes ]
+;;
+
 let turn_summary_to_json (summary : turn_summary) =
   `Assoc
     [ "file", `String summary.file
     ; "trace_id", Json_util.string_opt_to_json summary.trace_id
     ; "bytes", `Int summary.bytes
     ; "modified_at", `Float summary.modified_at
-    ; "records", `Int summary.records
+    ; "census", record_census_to_json summary.census
     ]
 ;;
 

--- a/lib/keeper/keeper_raw_trace_reader.mli
+++ b/lib/keeper/keeper_raw_trace_reader.mli
@@ -16,15 +16,34 @@
     is a different request from one that stays, and answering it as if it stayed
     would hide the attempt. *)
 
+(** What the listing established about one turn file's records.
+
+    Listing reads a bounded prefix of each file rather than the whole thing, so
+    a turn larger than that budget yields its identity but not its count. The
+    two cases are separate constructors because a count that was never taken
+    and a count of zero are different facts, and a listing that reported the
+    prefix's line count as the file's would be reporting a wrong number. *)
+type record_census =
+  | Whole_file of { records : int }
+      (** The file fit the listing budget. [records] is its exact non-blank
+          JSONL line count, and every one of those records carried the same
+          identity. *)
+  | Prefix_only of { budget_bytes : int }
+      (** The file is larger than [budget_bytes]. Use {!read_turn}, which reads
+          it in full and reports [total_records]. *)
+
 type turn_summary =
   { file : string (** Bare file name, the handle later reads take. *)
   ; trace_id : string option
-        (** Unique typed session identifier shared by every retained record.
-            [None] is possible only for an empty file; malformed, missing,
-            duplicate, invalid, or mixed identities reject the listing. *)
-  ; bytes : int
+        (** Unique typed session identifier of the first retained record.
+            [None] is possible only for an empty file; a malformed, missing,
+            duplicate, or invalid identity rejects the listing. Under
+            [Whole_file] every record was checked to carry this same identity;
+            under [Prefix_only] only the first was, because establishing it for
+            the rest would mean reading the file the budget exists to bound. *)
+  ; bytes : int (** Whole-file size, from the same descriptor as the prefix. *)
   ; modified_at : float
-  ; records : int (** Non-blank JSONL lines. *)
+  ; census : record_census
   }
 
 type read_error =
@@ -38,7 +57,15 @@ val read_error_to_string : read_error -> string
 
 (** Recent turns for one keeper, newest first, at most [limit]. An absent
     directory is an empty list — a keeper that has not run yet has no traces,
-    which is not an error. *)
+    which is not an error.
+
+    Cost is one bounded prefix read per retained file — never the whole of any
+    turn, so the call no longer scales with how much a single turn wrote. (A
+    stat-first pass that read content only for the returned page was measured
+    and rejected: each owned read crosses a systhread, and the extra pass cost
+    more than the content it avoided.) A single runaway turn used to make this
+    call take seconds for every operator who opened the panel; see
+    {!record_census}. *)
 val list_turns :
   config:Workspace.config
   -> keeper:string

--- a/test/test_keeper_raw_trace_reader.ml
+++ b/test/test_keeper_raw_trace_reader.ml
@@ -106,11 +106,70 @@ let test_lists_turns_newest_first () =
          Alcotest.(check int)
            "record count is non-blank lines"
            2
-           (match turns with t :: _ -> t.records | [] -> -1);
+           (match turns with
+            | { census = Reader.Whole_file { records }; _ } :: _ -> records
+            | { census = Reader.Prefix_only _; _ } :: _ ->
+              Alcotest.fail "a two-line turn fits the listing budget"
+            | [] -> -1);
          Alcotest.(check (option string))
            "listing carries the exact retained session id"
            (Some "trace-300")
            (match turns with t :: _ -> t.trace_id | [] -> None))
+;;
+
+(* A turn far larger than the listing budget. The tail carries a *different*
+   session id, which the whole-file listing rejected as a mixed identity — so
+   this listing succeeding is behavioural proof that the bytes past the budget
+   were never read, not just that a constant changed. One runaway turn on the
+   author's host reached 372.5 MB and made this call take 3.35 s for every
+   operator who opened the panel. *)
+let test_listing_does_not_read_past_the_budget () =
+  let padding_line seq =
+    Printf.sprintf
+      {|{"seq":%d,"record_type":"pad","session_id":"trace-big","pad":"%s"}|}
+      seq
+      (String.make 4096 'x')
+  in
+  let head = line ~session_id:"trace-big" 1 "run_started" in
+  let padding = List.init 160 (fun index -> padding_line (index + 2)) in
+  let tail_from_another_turn = line ~session_id:"trace-other" 999 "run_finished" in
+  with_traces
+    [ ( "turn-runaway" ^ Support.raw_trace_file_extension
+      , (head :: padding) @ [ tail_from_another_turn ] )
+    ]
+    (fun config trace_dir ->
+       let path =
+         Filename.concat trace_dir ("turn-runaway" ^ Support.raw_trace_file_extension)
+       in
+       let size = (Unix.stat path).st_size in
+       Alcotest.(check bool)
+         "fixture must exceed the listing budget for this test to mean anything"
+         true
+         (size > 256 * 1024);
+       match Reader.list_turns ~config ~keeper ~limit:10 with
+       | Error error ->
+         Alcotest.failf
+           "a turn larger than the budget must still list: %s"
+           (Reader.read_error_to_string error)
+       | Ok [ turn ] ->
+         (match turn.census with
+          | Reader.Whole_file { records } ->
+            Alcotest.failf "expected an uncounted census, got %d records" records
+          | Reader.Prefix_only { budget_bytes } ->
+            Alcotest.(check int) "census names the budget it stopped at" (256 * 1024) budget_bytes);
+         Alcotest.(check int) "bytes is the whole-file size, not the prefix" size turn.bytes;
+         Alcotest.(check (option string))
+           "identity comes from the first record"
+           (Some "trace-big")
+           turn.trace_id;
+         (* The count the listing declined to take is still available from the
+            read path, which reads the file in full. *)
+         (match Reader.read_turn ~config ~keeper ~file:turn.file ~offset:0 ~limit:1 with
+          | Error error ->
+            Alcotest.failf "read_turn must serve it: %s" (Reader.read_error_to_string error)
+          | Ok page ->
+            Alcotest.(check int) "read_turn counts every record" 162 page.total_records)
+       | Ok turns -> Alcotest.failf "expected one turn, got %d" (List.length turns))
 ;;
 
 let test_absent_keeper_directory_is_empty_not_error () =
@@ -384,6 +443,8 @@ let () =
     ; ( "listing"
       , [ Alcotest.test_case "lists turns newest first" `Quick
             test_lists_turns_newest_first
+        ; Alcotest.test_case "listing does not read past the prefix budget" `Quick
+            test_listing_does_not_read_past_the_budget
         ; Alcotest.test_case "absent keeper directory is empty, not error" `Quick
             test_absent_keeper_directory_is_empty_not_error
         ; Alcotest.test_case "mixed session ids reject the listing" `Quick


### PR DESCRIPTION
## 문제

keeper의 턴 목록(`GET /api/v1/keepers/:name/raw-traces`)이 **디렉터리의 모든 파일을 통째로 읽고 모든 줄을 JSON 파싱한 뒤 마지막에** `limit`개로 잘랐습니다. 레코드 수 하나를 보고하려고 O(디렉터리 총 바이트)를 지불했습니다.

실측(같은 호스트, 같은 호출):

| keeper | 파일 수 | 총 용량 | 응답 |
|---|---|---|---|
| sangsu | 182 | 398 MB | **4.4 ~ 16.4 s** |
| kidsnote | 200 | 980 KB | 0.04 s |

파일 수는 kidsnote가 더 많은데 응답은 수백 배 느립니다. 비용이 **파일 수가 아니라 총 바이트**에 비례한다는 뜻입니다. sangsu의 398MB 중 372.5MB는 폭주한 턴 하나입니다 — 14분 동안 도구 실행 16,801회, 그중 16,794회가 **동일 인자에 동일 응답**(`keeper_artifact_read`).

## 변경

리스팅이 파일당 최대 **256 KiB prefix**만 읽습니다.

- 예산 안에 들어온 파일: 이전과 동일하게 정확한 레코드 수 + 전 레코드 identity 일치 검증
- 예산을 넘는 파일: 첫 레코드의 identity와 **"여기서는 집계하지 않았다"**는 census를 보고
- `read_turn`은 여전히 파일을 전량 읽고 `total_records`를 반환 — 집계가 사라진 게 아니라 그 비용을 감당할 수 있는 호출로 옮겼습니다

prefix의 줄 수를 파일의 줄 수로 보고하는 건 **틀린 숫자**이고, 없는 것보다 나쁩니다. 그래서 census는 와이어에서 합타입이고, 대시보드 디코더는 이 빌드가 모르는 state를 거부합니다(`records: null` 같은 nullable이 아님).

```
"census": { "state": "whole_file",  "records": 218 }
"census": { "state": "prefix_only", "budget_bytes": 262144 }
```

UI는 미집계 턴을 `256.0 KB 초과 · 열어서 집계`로 표시합니다. 폭주 턴을 찾는 운영자에게는 건수보다 **크기**가 더 유용한 신호이고, 크기는 stat으로 공짜입니다.

## 예산 근거 (256 KiB)

같은 코퍼스(1,232개 트레이스)를 여러 예산으로 재생해 골랐습니다.

| 예산 | 정확 집계 | 최악 keeper 리스팅 |
|---|---|---|
| 128 KB | 92.5% | — |
| **256 KB** | **95.2%** | **0.092 s** |
| 512 KB | 97.2% | 0.138 s |
| 1024 KB | 98.5% | 0.234 s |

두 배로 늘려도 커버리지는 2%p 늘 뿐이고, 그때 새로 포함되는 턴은 운영자가 어차피 열어보는 큰 턴입니다.

## 측정 결과 (중앙값 8회, 부하 있는 동일 호스트)

| keeper | before | after |
|---|---|---|
| sangsu | 16.450 s | **0.116 s** |
| code-reviewer | 0.542 s | **0.136 s** |
| taskmaster | 0.408 s | **0.173 s** |
| kidsnote | 0.255 s | **0.157 s** |
| sangsu `limit=200` (최악) | — | **0.212 s** |

격리된 base-path에 트레이스를 APFS clone으로 복제하고 새 바이너리를 별도 포트로 띄워 측정했습니다(라이브 런타임 무간섭, keeper 0개 기동).

## 채택하지 않은 대안

**stat 먼저 → 정렬 → limit → 페이지만 읽기**도 구현해서 재봤습니다. 이론적으로는 `O(limit × budget)`이라 더 좋아야 하는데, owned read가 파일마다 systhread를 건너뛰기 때문에 **stat 패스의 hop 비용이 절약한 내용보다 컸습니다** (kidsnote 0.023 s → 0.20 s). 되돌렸고, `.mli`에 이유를 남겼습니다.

## 테스트

새 테스트는 상수를 확인하지 않고 **동작으로** 유계성을 증명합니다. 픽스처의 꼬리에 *다른* session_id를 넣었습니다 — 전체 읽기 리스팅은 이걸 mixed identity로 거부했습니다. 따라서 리스팅이 성공한다는 사실 자체가 예산 밖 바이트를 읽지 않았다는 증거입니다.

검증: 예산을 1 GiB(= 예전 전체 읽기)로 올리자 이 테스트가 **정확히 예전 에러로 실패**했습니다.
```
FAIL a turn larger than the budget must still list:
  raw trace turn-runaway.jsonl has invalid identity at line 162:
  session_id trace-other does not match trace-big
```

- `test_keeper_raw_trace_reader.exe` 14/14 통과
- `dashboard-keeper-prompt.test.ts` 14/14 통과 (미집계 디코딩 + 미지 state 거부 케이스 추가)
- `tsc --noEmit` 통과

## 근거 RFC

RFC-0228 §2 원칙 3이 keeper용 lane pull에 대해 같은 규칙을 이미 명시합니다 — *"Read cost stays bounded ... paging must not reintroduce full-file scans."* 이 PR은 그 원칙을 대시보드 트레이스 표면에 적용합니다.

## 남은 것 (이 PR 밖)

- 폭주 턴 자체(턴당 도구 호출 예산 / 동일 호출 반복 탐지) — 별건, RFC 필요
- `exact-lane-runs` 246MB 무제한 응답 — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
