### PR TITLE
fix(keeper): contain owner child stop signal

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -895,6 +895,9 @@ let run_keepalive_unified_turn
     { meta = meta_after_triage; cycle_status = Turn_cycle_busy block }
   | Ok (`Busy block) ->
     { meta = meta_after_triage; cycle_status = Turn_cycle_busy block }
+  | Error
+      (Keeper_owner_registry.Command_rejected Keeper_owner.Owner_stopping) ->
+    { meta = meta_after_triage; cycle_status = Turn_cycle_completed }
   | Error error ->
     Log.Keeper.error
       ~keeper_name:meta_after_triage.name

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -933,6 +933,7 @@ let run_if_idle t lane run =
   | Error _ as error -> error
   | Ok (Autonomous_ran value) -> Ok (`Ran value)
   | Ok (Autonomous_busy block) -> Ok (`Busy block)
+  | Ok (Autonomous_raised (Stop_active_child, _)) -> Error Owner_stopping
   | Ok (Autonomous_raised (exn, backtrace)) ->
     Printexc.raise_with_backtrace exn backtrace
 ;;

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -146,7 +146,9 @@ val run_autonomous_if_idle
 (** Mailbox-linearized autonomous admission. The callback runs in the Owner's
     child switch, while the actor remains responsive. An already-started child
     returns [`Busy] without consuming turn input. A Queued chat whose runner is
-    not ready does not block autonomous admission. *)
+    not ready does not block autonomous admission. Owner-directed cancellation
+    returns [Error Owner_stopping]; its private child-stop signal never escapes
+    this boundary. *)
 
 val run_maintenance_if_idle
   :  t

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -763,7 +763,7 @@ let test_stopping_cancels_and_joins_autonomous_child () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
   let child_started, resolve_child_started = Eio.Promise.create () in
-  let caller_done, resolve_caller_done = Eio.Promise.create () in
+  let caller_result = Eio.Stream.create 1 in
   let never, _resolve_never = Eio.Promise.create () in
   let owner =
     owner_ok
@@ -774,17 +774,19 @@ let test_stopping_cancels_and_joins_autonomous_child () =
          ~initial_meta:(Some (make_meta "stopping-autonomous-child")))
   in
   Eio.Fiber.fork ~sw (fun () ->
-    (try
-       ignore
-         (Owner.run_autonomous_if_idle owner (fun () ->
-            Eio.Promise.resolve resolve_child_started ();
-            Eio.Promise.await never))
-     with
-     | _ -> ());
-    Eio.Promise.resolve resolve_caller_done ());
+    let result =
+      Owner.run_autonomous_if_idle owner (fun () ->
+        Eio.Promise.resolve resolve_child_started ();
+        Eio.Promise.await never)
+    in
+    Eio.Stream.add caller_result result);
   Eio.Promise.await child_started;
   ignore (owner_ok (Owner.begin_stopping owner));
-  Eio.Promise.await caller_done;
+  (match Eio.Stream.take caller_result with
+   | Error Owner.Owner_stopping -> ()
+   | Error error -> fail ("wrong stopped-child error: " ^ Owner.error_to_string error)
+   | Ok (`Ran _) -> fail "stopped autonomous child reported success"
+   | Ok (`Busy _) -> fail "admitted autonomous child became busy");
   check bool
     "stopping clears autonomous projection"
     true

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -4411,6 +4411,52 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
       with_cwd (project_root ()) @@ fun () ->
       Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
       let expected_config = Filename.concat dir ".masc/config" in
+      let workspace_config = Workspace.default_config dir in
+      ignore (Workspace.init workspace_config ~agent_name:(Some "startup-test"));
+      let fenced_keeper =
+        make_keeper_meta
+          ~name:"restart-fenced-keeper"
+          ~trace_id:"trace-restart-fenced-keeper"
+          ()
+      in
+      write_keeper_meta_exn workspace_config fenced_keeper;
+      let expected_backlog_version =
+        match Workspace_backlog.read_backlog_r workspace_config with
+        | Ok backlog -> backlog.version
+        | Error detail -> Alcotest.fail detail
+      in
+      let operation_id =
+        Keeper_shutdown_types.Operation_id.of_string
+          "shutdown-00000000-0000-4000-8000-000000000001"
+        |> Result.get_ok
+      in
+      let now = Masc_domain.now_iso () in
+      let fenced_operation : Keeper_shutdown_types.t =
+        { schema_version = Keeper_shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id
+        ; keeper_name = fenced_keeper.name
+        ; lane_ownership = Keeper_shutdown_types.Dormant_meta
+        ; trace_id = fenced_keeper.runtime.trace_id
+        ; generation = fenced_keeper.runtime.nonce
+        ; actor = "startup-test"
+        ; cleanup_intent =
+            { reason = Keeper_shutdown_types.Operator_stop_retain_meta
+            ; remove_session = false
+            }
+        ; turn_disposition = Keeper_shutdown_types.No_inflight_turn
+        ; expected_backlog_version
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase = Keeper_shutdown_types.Prepared
+        ; created_at = now
+        ; updated_at = now
+        }
+      in
+      (match Keeper_shutdown_store.persist_new ~config:workspace_config fenced_operation with
+       | Ok () -> ()
+       | Error error ->
+         Alcotest.fail (Keeper_shutdown_store.error_to_string error));
       let env =
         main_eio_env_overrides
           [
@@ -4442,11 +4488,9 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
         ~finally:(fun () -> stop_process pid)
         (fun () ->
           if not (wait_for_startup_phase ~pid ~port ~timeout_s:10.0 "ready") then begin
-            prerr_endline
-              (Printf.sprintf
-                 "main_eio fresh boot did not reach startup.phase=ready within timeout in this environment.\nlog:\n%s"
-                 (read_file log_file));
-            Alcotest.skip ()
+            Alcotest.failf
+              "main_eio fresh boot did not reach startup.phase=ready within timeout.\nlog:\n%s"
+              (read_file log_file)
           end;
           let health_headers, health_body =
             curl_request_capture ~output_dir:dir ~name:"health" ~method_:"GET"
@@ -4473,6 +4517,12 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
           in
           Alcotest.(check string) "startup phase ready" "ready"
             Yojson.Safe.Util.(startup |> member "phase" |> to_string);
+          Alcotest.(check bool)
+            "durable shutdown admission restores after Owner inventory install"
+            false
+            (String_util.contains_substring
+               (read_file log_file)
+               "Keeper owner inventory is not installed");
           Alcotest.(check string) "effective base path matches fresh dir"
             (canonical_path dir) (canonical_path effective_base_path);
           Alcotest.(check string) "config root matches fresh dir"


### PR DESCRIPTION
## Summary

- contain the Owner-private `Stop_active_child` signal at the autonomous child boundary
- return the existing typed `Owner_stopping` result to the admitted caller instead of re-raising into the Keeper lane
- treat that typed shutdown result as a completed heartbeat cycle, without recording a false turn or lane crash
- exercise a real child `main_eio` restart with a durable Prepared shutdown operation and fail if the process cannot become ready

## Root cause

During process shutdown, `begin_stopping_all` cancels each active Owner child. Operation children already terminalized this signal, but autonomous children re-raised it from `run_if_idle`. The Keeper lane then recorded a normal shutdown as `fiber_terminated(exception(Masc.Keeper_owner_signals.Stop_active_child))` and an exact-lane crash.

The durable restart regression was exposed while validating this path. Main already contains the production ordering fix from #28283, so this branch deliberately does not duplicate it; it retains the process-level regression test that seeds a durable shutdown fence and verifies readiness plus MCP handshake.

## Verification

- focused build: `test/test_keeper_owner.exe`, `test/test_server_runtime_bootstrap.exe`, and `bin/main_eio.exe`
- Keeper Owner: 36/36 passed
- durable shutdown restart process E2E: 1/1 passed in 5.05s
- process E2E fails instead of skipping when the child server cannot start
- heartbeat integration: 50 passed; 2 pre-existing shared-inventory order-dependent failures tracked in #28279
- `git diff --check`

[근거] live shutdown log at 2026-08-12 09:51:32 KST; focused tests and process E2E at `53635b07db` on 2026-08-12 12:12 KST; confidence High
