### PR TITLE
refactor(runtime): preserve binding failures as Result

### DIFF
--- a/lib/parse_outcome/parse_outcome.ml
+++ b/lib/parse_outcome/parse_outcome.ml
@@ -37,8 +37,3 @@ let map (f : 'a -> 'b) (o : 'a t) : 'b t =
   match o with
   | Ok x -> Ok (f x)
   | Error _ as e -> e
-
-let to_option (o : 'a t) : 'a option =
-  match o with
-  | Ok x -> Some x
-  | Error _ -> None

--- a/lib/parse_outcome/parse_outcome.mli
+++ b/lib/parse_outcome/parse_outcome.mli
@@ -47,8 +47,3 @@ val bind : 'a t -> ('a -> 'b t) -> 'b t
 
 val map : ('a -> 'b) -> 'a t -> 'b t
 (** Functorial map over [Ok]. *)
-
-val to_option : 'a t -> 'a option
-(** [to_option o] discards the error payload.
-    Provided as a *migration shim* for sites that currently return
-    [option] — new code should pattern-match on the [error] instead. *)

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -61,7 +61,7 @@ let quota_scope_of_materialized
   Runtime_quota_window.scope_of_credential ~provider_id:provider.id credential
 ;;
 
-let of_binding_result (cfg : config) (b : binding) : (t, string) result =
+let of_binding (cfg : config) (b : binding) : (t, string) result =
   if not b.enabled
   then Error "binding is disabled by runtime.toml"
   else match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
@@ -82,12 +82,6 @@ let of_binding_result (cfg : config) (b : binding) : (t, string) result =
        | Error reason -> Error reason)
   | None, _ -> Error (Printf.sprintf "provider not found: %s" b.provider_id)
   | Some _, None -> Error (Printf.sprintf "model not found: %s" b.model_id)
-;;
-
-(** {!of_binding_result} 의 option 투영. materialize 실패 이유가 필요 없는
-    호출자(단일 binding 성공 여부만 확인)를 위한 유지 API. *)
-let of_binding (cfg : config) (b : binding) : t option =
-  Result.to_option (of_binding_result cfg b)
 ;;
 
 let is_local_provider (provider : provider) =
@@ -115,7 +109,7 @@ let partition_bindings (cfg : config) (bindings : binding list)
   let runtimes, dropped =
     List.fold_left
       (fun (runtimes, dropped) (b : binding) ->
-         match of_binding_result cfg b with
+         match of_binding cfg b with
          | Ok rt -> rt :: runtimes, dropped
          | Error reason -> runtimes, (id_of_binding b, reason) :: dropped)
       ([], [])
@@ -1377,7 +1371,7 @@ let provider_id_of_runtime_id (id : string) : string option =
   | None -> None
 ;;
 
-(* Reads the scope frozen at materialization ({!of_binding_result}); no
+(* Reads the scope frozen at materialization ({!of_binding}); no
    environment access here, so a post-load env change cannot re-select the
    credential alias out from under the recorded window. *)
 let quota_scope_of_runtime (rt : t) : Runtime_quota_window.scope =

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -22,11 +22,11 @@ type t =
   }
 
 val id_of_binding : binding -> string
-val of_binding : config -> binding -> t option
-
-(** Reason-preserving form of {!of_binding}. [Error reason] when the binding's
-    provider/model id is unresolved or the provider transport/protocol cannot be
-    materialized into a {!Llm_provider.Provider_config.t} (e.g. a [messages-http]
+val of_binding : config -> binding -> (t, string) result
+(** Materialize one binding while preserving failure information. [Error reason]
+    when the binding is disabled, its provider/model id is unresolved, or the
+    provider transport/protocol cannot be materialized into a
+    {!Llm_provider.Provider_config.t} (e.g. a [messages-http]
     provider the runtime adapter has no provider_config path for). The binding is
     still excluded from the runtime list (fail-closed, RFC-0206 §2.1); this
     surfaces *why*, so [\[runtime\].default] / [\[runtime.assignments\]] / lane

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -46,6 +46,17 @@ type resolved_lang =
   | Known_lang of string
   | Unknown_lang
 
+type document_request_error =
+  | Missing_document_uri
+  | Document_uri_outside_workspace
+
+type resolved_document_request =
+  { uri : string
+  ; relative_path : string
+  ; line : int option
+  ; language : resolved_lang
+  }
+
 (** Per-connection state shared across frame handler and relay fibers.
 
     [sw] is the server-lifetime switch (LSP processes + their reader
@@ -600,6 +611,21 @@ let extract_line params =
   | _ -> None
 ;;
 
+let resolve_document_request ~base params =
+  match extract_uri params with
+  | None -> Error Missing_document_uri
+  | Some uri ->
+    (match resolve_relative ~base uri with
+     | None -> Error Document_uri_outside_workspace
+     | Some relative_path ->
+       let line =
+         match extract_line params with
+         | Some line when line >= 0 -> Some line
+         | Some _ | None -> None
+       in
+       Ok { uri; relative_path; line; language = resolve_lang relative_path })
+;;
+
 (** Ensure LSP process exists for a language.
     Spawns + initializes on first use, blocking until ready. *)
 let ensure_lsp_process cs lang_id =
@@ -713,20 +739,17 @@ let forward_notification cs lang_id method_ params =
 
 let forward_document_sync_notification cs method_ params =
   let wire_method = lsp_method_to_string method_ in
-  match extract_uri params with
-  | None -> ()
-  | Some uri ->
-    (match resolve_relative ~base:cs.base_path uri with
-     | None -> ()
-     | Some relative ->
-       if method_ = Did_save
-       then
-         Lsp_overlay_provider.invalidate_cache
-           ~base_dir:cs.base_path
-           ~file_path:relative;
-       (match resolve_lang relative with
-        | Unknown_lang -> ()
-        | Known_lang lang_id -> forward_notification cs lang_id wire_method params))
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> ()
+  | Ok request ->
+    if method_ = Did_save
+    then
+      Lsp_overlay_provider.invalidate_cache
+        ~base_dir:cs.base_path
+        ~file_path:request.relative_path;
+    (match request.language with
+     | Unknown_lang -> ()
+     | Known_lang lang_id -> forward_notification cs lang_id wire_method params)
 ;;
 
 (* Read-only method allowlist for the catch-all forwarder (task-1692). The
@@ -783,13 +806,13 @@ let classify_forwarded_method method_ =
 
 (** Handle textDocument/codeLens — merge LSP response with MASC overlays. *)
 let handle_codelens cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
+    let relative = request.relative_path in
     let masc = Lsp_overlay_provider.codelenses ~base_dir:base ~file_path:relative in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -813,13 +836,13 @@ let handle_codelens cs params id =
 
 (** Handle textDocument/inlayHint — merge LSP response with MASC overlays. *)
 let handle_inlay_hint cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
+    let relative = request.relative_path in
     let masc = Lsp_overlay_provider.inlay_hints ~base_dir:base ~file_path:relative in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -843,12 +866,12 @@ let handle_inlay_hint cs params id =
 
 (** Handle textDocument/diagnostic — merge LSP response with MASC diagnostics. *)
 let handle_diagnostic cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`Assoc [ "items", `List [] ])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`Assoc [ "items", `List [] ])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    (match resolve_lang relative with
+    let relative = request.relative_path in
+    (match request.language with
      | Unknown_lang ->
       let diags =
         Lsp_overlay_provider.diagnostics
@@ -897,25 +920,31 @@ let handle_diagnostic cs params id =
 
 (** Handle textDocument/hover — enrich LSP response with MASC annotations. *)
 let handle_hover cs params id =
-  match extract_uri params with
-  | None -> send_response cs id `Null
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id `Null
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
-    (match resolve_lang relative with
+    let relative = request.relative_path in
+    (match request.language with
      | Unknown_lang ->
-      if line >= 0 && Lsp_overlay_provider.has_annotations_at_line ~base_dir:base ~file_path:relative ~line
-      then (
-        let enriched =
-          Lsp_overlay_provider.enrich_hover
-            ~base_dir:base
-            ~file_path:relative
-            ~line
-            (`Assoc [ ("contents", `Assoc [ ("kind", `String "markdown"); ("value", `String "") ]) ])
-        in
-        send_response cs id enriched)
-      else send_response cs id `Null
+      (match request.line with
+       | Some line
+         when Lsp_overlay_provider.has_annotations_at_line
+                ~base_dir:base
+                ~file_path:relative
+                ~line ->
+         let enriched =
+           Lsp_overlay_provider.enrich_hover
+             ~base_dir:base
+             ~file_path:relative
+             ~line
+             (`Assoc
+                [ ( "contents"
+                  , `Assoc [ ("kind", `String "markdown"); ("value", `String "") ] )
+                ])
+         in
+         send_response cs id enriched
+       | Some _ | None -> send_response cs id `Null)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
       | Error msg ->
@@ -924,19 +953,23 @@ let handle_hover cs params id =
            broke the client on an unavailable LSP. Mirrors the unknown-lang
            branch above. *)
         note_overlay_only cs ~lang_id ~error:msg;
-        if line >= 0
-           && Lsp_overlay_provider.has_annotations_at_line ~base_dir:base
-                ~file_path:relative ~line
-        then
-          send_response cs id
-            (Lsp_overlay_provider.enrich_hover ~base_dir:base ~file_path:relative
-               ~line
-               (`Assoc
-                  [ ( "contents"
-                    , `Assoc
-                        [ ("kind", `String "markdown"); ("value", `String "") ] )
-                  ]))
-        else send_response cs id `Null
+        (match request.line with
+         | Some line
+           when Lsp_overlay_provider.has_annotations_at_line
+                  ~base_dir:base
+                  ~file_path:relative
+                  ~line ->
+           send_response cs id
+             (Lsp_overlay_provider.enrich_hover
+                ~base_dir:base
+                ~file_path:relative
+                ~line
+                (`Assoc
+                   [ ( "contents"
+                     , `Assoc
+                         [ ("kind", `String "markdown"); ("value", `String "") ] )
+                   ]))
+         | Some _ | None -> send_response cs id `Null)
       | Ok proc ->
         let promise =
           Lsp_message_router.send_request
@@ -948,32 +981,32 @@ let handle_hover cs params id =
         in
         (match Eio.Promise.await promise with
          | Ok result ->
-           if line >= 0
-           then
-             send_response cs id
-               (Lsp_overlay_provider.enrich_hover
-                  ~base_dir:base
-                  ~file_path:relative
-                  ~line
-                  result)
-           else send_response cs id result
+           (match request.line with
+            | Some line ->
+              send_response cs id
+                (Lsp_overlay_provider.enrich_hover
+                   ~base_dir:base
+                   ~file_path:relative
+                   ~line
+                   result)
+            | None -> send_response cs id result)
          | Error msg -> send_error cs id Mcp_error_code.(to_wire_code Internal_error) msg))
 ;;
 
 (** Handle textDocument/definition — merge LSP response with MASC annotation links. *)
 let handle_definition cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
+    let relative = request.relative_path in
     let masc =
-      if line >= 0 then
+      match request.line with
+      | Some line ->
         Lsp_overlay_provider.definition_links ~base_dir:base ~file_path:relative ~line
-      else []
+      | None -> []
     in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -995,19 +1028,19 @@ let handle_definition cs params id =
 
 (** Handle textDocument/references — merge LSP response with MASC annotation locations. *)
 let handle_references cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
+    let relative = request.relative_path in
     let masc =
-      if line >= 0 then
+      match request.line with
+      | Some line ->
         Lsp_overlay_provider.reference_locations
           ~base_dir:base ~file_path:relative ~line ~include_declaration:true
-      else []
+      | None -> []
     in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1029,18 +1062,18 @@ let handle_references cs params id =
 
 (** Handle textDocument/completion — merge LSP response with MASC annotation snippets. *)
 let handle_completion cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
+    let relative = request.relative_path in
     let masc =
-      if line >= 0 then
+      match request.line with
+      | Some line ->
         Lsp_overlay_provider.completion_items ~base_dir:base ~file_path:relative ~line
-      else []
+      | None -> []
     in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1062,19 +1095,19 @@ let handle_completion cs params id =
 
 (** Handle textDocument/codeAction — inject MASC annotation actions. *)
 let handle_code_action cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
+    let relative = request.relative_path in
     let masc =
-      if line >= 0 then
+      match request.line with
+      | Some line ->
         Lsp_overlay_provider.code_actions
           ~base_dir:base ~file_path:relative ~line ~diagnostics:[]
-      else []
+      | None -> []
     in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1096,13 +1129,13 @@ let handle_code_action cs params id =
 
 (** Handle textDocument/documentSymbol — inject MASC annotation symbols. *)
 let handle_document_symbol cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
+    let relative = request.relative_path in
     let masc = Lsp_overlay_provider.document_symbols ~base_dir:base ~file_path:relative in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1124,13 +1157,13 @@ let handle_document_symbol cs params id =
 
 (** Handle textDocument/foldingRange — inject MASC annotation folding ranges. *)
 let handle_folding_range cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
+    let relative = request.relative_path in
     let masc = Lsp_overlay_provider.folding_ranges ~base_dir:base ~file_path:relative in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1152,18 +1185,18 @@ let handle_folding_range cs params id =
 
 (** Handle textDocument/documentHighlight — highlight related MASC annotations. *)
 let handle_document_highlight cs params id =
-  match extract_uri params with
-  | None -> send_response cs id (`List [])
-  | Some uri ->
+  match resolve_document_request ~base:cs.base_path params with
+  | Error _ -> send_response cs id (`List [])
+  | Ok request ->
     let base = cs.base_path in
-    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
-    let line = extract_line params |> Option.value ~default:(-1) in
+    let relative = request.relative_path in
     let masc =
-      if line >= 0 then
+      match request.line with
+      | Some line ->
         Lsp_overlay_provider.document_highlights ~base_dir:base ~file_path:relative ~line
-      else []
+      | None -> []
     in
-    (match resolve_lang relative with
+    (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
       match ensure_lsp_process cs lang_id with
@@ -1259,33 +1292,28 @@ let dispatch_message cs msg =
                     Mcp_error_code.(to_wire_code Method_not_found)
                     ("Read-only LSP proxy: unknown method not permitted: " ^ unknown)
                 | Forward_read_only ->
-                  (match extract_uri params with
-                   | None ->
+                  (match resolve_document_request ~base:cs.base_path params with
+                   | Error Missing_document_uri ->
                      send_error cs n
                        Mcp_error_code.(to_wire_code Method_not_found)
                        ("Unhandled method: " ^ method_str)
-                   | Some uri ->
-                     (* Resolve the URI explicitly: an out-of-workspace or malformed
-                        URI ([None]) is rejected here rather than collapsed to a
-                        path, so the forward is only reached for a resolved
-                        in-workspace file. *)
-                     (match resolve_relative ~base:cs.base_path uri with
-                      | None ->
+                   | Error Document_uri_outside_workspace ->
+                     send_error
+                       cs
+                       n
+                       Mcp_error_code.(to_wire_code Invalid_params)
+                       "Path is outside the workspace"
+                   | Ok request ->
+                     (match request.language with
+                      | Known_lang lang_id ->
+                        forward_request cs lang_id method_str params n
+                      | Unknown_lang ->
                         send_error
                           cs
                           n
                           Mcp_error_code.(to_wire_code Invalid_params)
-                          "Path is outside the workspace"
-                      | Some relative ->
-                        (match resolve_lang relative with
-                         | Known_lang lang_id -> forward_request cs lang_id method_str params n
-                         | Unknown_lang ->
-                           send_error
-                             cs
-                             n
-                             Mcp_error_code.(to_wire_code Invalid_params)
-                             ("No LSP server for: " ^ relative)))))
-             | None -> ()))
+                          ("No LSP server for: " ^ request.relative_path)))
+             | None -> ())))
        (* No method field *)
        | None, Some n -> send_error cs n Mcp_error_code.(to_wire_code Invalid_request) "Missing method field"
        | None, None -> ())
@@ -1417,6 +1445,19 @@ module For_testing = struct
 
   let resolve_lang = resolve_lang
 
+  type nonrec document_request_error = document_request_error =
+    | Missing_document_uri
+    | Document_uri_outside_workspace
+
+  type nonrec resolved_document_request = resolved_document_request =
+    { uri : string
+    ; relative_path : string
+    ; line : int option
+    ; language : resolved_lang
+    }
+
+  let resolve_document_request = resolve_document_request
+
   (* task-1691: the LSP health type + its pure wire projection. *)
   type health = lang_health =
     | Connected
@@ -1451,5 +1492,4 @@ module For_testing = struct
     Option.map lsp_method_classification (lsp_method_of_string method_)
   ;;
 
-  let resolve_lang = resolve_lang
 end

--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -26,6 +26,26 @@ module For_testing : sig
       permissive default. *)
   val resolve_lang : string -> resolved_lang
 
+  type document_request_error =
+    | Missing_document_uri
+    | Document_uri_outside_workspace
+
+  type resolved_document_request =
+    { uri : string
+    ; relative_path : string
+    ; line : int option
+    ; language : resolved_lang
+    }
+
+  (** Decode the document URI, workspace-relative path, optional non-negative
+      line, and language verdict once. Missing/out-of-workspace documents stay
+      typed errors rather than becoming [""] paths, and malformed/negative
+      positions stay [None] rather than [-1]. *)
+  val resolve_document_request :
+    base:string ->
+    Yojson.Safe.t ->
+    (resolved_document_request, document_request_error) result
+
   (** Per-language LSP health (task-1691). [Overlay_only] carries the last
       error that forced the language into overlay-only mode. *)
   type health =

--- a/packages/agent_core/lib/llm_provider/exact_output_generation_receipt.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_generation_receipt.ml
@@ -179,19 +179,19 @@ let merge_state current desired =
     in
     Response_received_state { status; provider_trace }
   | Response_received_state current, Terminal_state desired ->
-    let status, provider_trace =
+    let _, provider_trace =
       merge_response_fields
         (current.status, current.provider_trace)
         (Some desired.status, desired.provider_trace)
     in
-    Terminal_state { status = Option.get status; provider_trace }
+    Terminal_state { status = desired.status; provider_trace }
   | Terminal_state current, Terminal_state desired ->
-    let status, provider_trace =
+    let _, provider_trace =
       merge_response_fields
         (Some current.status, current.provider_trace)
         (Some desired.status, desired.provider_trace)
     in
-    Terminal_state { status = Option.get status; provider_trace }
+    Terminal_state { status = desired.status; provider_trace }
   | _ -> desired
 ;;
 

--- a/packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml
@@ -15,6 +15,11 @@ type 'callback_error error =
 
 type connection = [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t
 
+type validated_origin =
+  { uri : Uri.t
+  ; host : string
+  }
+
 let create_dispatch_intent ~commit_fence ~mark_dispatch_started =
   { committed = Atomic.make false
   ; dispatch_started = Atomic.make false
@@ -88,7 +93,7 @@ let validate_uri url =
   try
     let uri = Uri.of_string url in
     match Uri.host uri with
-    | Some host when String.trim host <> "" -> Ok uri
+    | Some host when String.trim host <> "" -> Ok { uri; host }
     | Some _ | None ->
       Error
         (NetworkError
@@ -135,9 +140,8 @@ let https_init_error_network_kind = function
   | Api_common.Ca_certs_unavailable _ | Api_common.Tls_config_unavailable _ -> Tls_error
 ;;
 
-let resolve_origin net uri =
+let resolve_origin net ({ uri; host } : validated_origin) =
   let net = (net :> [ `Generic ] Eio.Net.ty Eio.Resource.t) in
-  let host = Option.get (Uri.host uri) in
   let service =
     match Uri.port uri with
     | Some port -> Int.to_string port
@@ -181,13 +185,13 @@ let resolve_origin net uri =
   Ok (net, addr, tls_wrap)
 ;;
 
-let make_connection ~sw ~net ~uri =
-  let* net, address, tls_wrap = resolve_origin net uri in
+let make_connection ~sw ~net ~origin =
+  let* net, address, tls_wrap = resolve_origin net origin in
   try
     let socket = Eio.Net.connect ~sw net address in
     let connection : connection =
       match tls_wrap with
-      | Some wrap -> (wrap uri socket :> connection)
+      | Some wrap -> (wrap origin.uri socket :> connection)
       | None -> (socket :> connection)
     in
     Ok connection
@@ -236,7 +240,7 @@ let post_sync_once_after_commit
       ~connect_deadline
       ~body_deadline
       ~net
-      ~uri
+      ~origin
       ~header
       ~body
       ~dispatch_intent
@@ -319,7 +323,7 @@ let post_sync_once_after_commit
   let post_result =
     try
       with_headers_deadline (fun () ->
-        let* current = make_connection ~sw ~net ~uri in
+        let* current = make_connection ~sw ~net ~origin in
         connection := Some current;
         let client =
           Cohttp_eio.Client.make_generic (fun ~sw:_ _uri ->
@@ -331,14 +335,19 @@ let post_sync_once_after_commit
         then invalid_arg "exact-output measurement dispatch was already started";
         dispatch_intent.mark_dispatch_started ();
         let response, response_body =
-          Cohttp_eio.Client.post ~sw client ~headers:header ~body:request_body uri
+          Cohttp_eio.Client.post
+            ~sw
+            client
+            ~headers:header
+            ~body:request_body
+            origin.uri
         in
         let response_status =
           Cohttp.Response.status response |> Cohttp.Code.code_of_status
         in
         phase := Response_received;
         status := Some response_status;
-        Ok (response, response_body))
+        Ok (response, response_body, response_status))
     with
     | Eio.Time.Timeout as exn ->
       release_connection ();
@@ -349,7 +358,7 @@ let post_sync_once_after_commit
   | Error error ->
     release_connection ();
     Error (staged_error error)
-  | Ok (response, response_body) ->
+  | Ok (response, response_body, response_status) ->
     let body_result =
       try
         match body_deadline, total_started_at with
@@ -378,7 +387,6 @@ let post_sync_once_after_commit
        release_connection ();
        Error (staged_error error)
      | Ok response_body ->
-       let response_status = Option.get !status in
        let retry_after_header = retry_after_header response in
        release_connection ();
        Ok
@@ -418,7 +426,7 @@ let post_sync_once
      | Ok body_deadline ->
        (match validate_uri url with
         | Error error -> before_dispatch error
-        | Ok uri ->
+        | Ok origin ->
           (match validate_headers_and_body headers body with
            | Error error -> before_dispatch error
            | Ok header ->
@@ -432,7 +440,7 @@ let post_sync_once
                   ~connect_deadline
                   ~body_deadline
                   ~net
-                  ~uri
+                  ~origin
                   ~header
                   ~body
                   ~dispatch_intent

--- a/packages/agent_core/lib/llm_provider/exact_output_plan.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_plan.ml
@@ -1,5 +1,7 @@
 module Sha256 = Digestif.SHA256
 
+let ( let* ) = Result.bind
+
 type fingerprint = Fingerprint of string
 
 type output_admission_error =
@@ -108,9 +110,16 @@ let contract_is_supported
   | Types.JsonSchema _ -> capabilities.supports_structured_output
 ;;
 
-let timeout_is_valid = function
-  | None -> true
-  | Some seconds -> Float.is_finite seconds && seconds > 0.0
+let validate_timeout ~invalid = function
+  | None -> Ok ()
+  | Some seconds when Float.is_finite seconds && seconds > 0.0 -> Ok ()
+  | Some seconds -> Error (invalid seconds)
+;;
+
+let%test "timeout validation preserves the invalid value" =
+  match validate_timeout ~invalid:Fun.id (Some (-1.5)) with
+  | Error seconds -> Float.equal seconds (-1.5)
+  | Ok () -> false
 ;;
 
 let content_uses_exact_cross_feature = function
@@ -390,11 +399,18 @@ let preflight
     then Error Unsupported_exact_cross_feature
     else if Option.is_some config.max_concurrent_requests
     then Error Global_admission_not_allowed
-    else if not (timeout_is_valid config.connect_timeout_s)
-    then Error (Invalid_connect_timeout (Option.get config.connect_timeout_s))
-    else if not (timeout_is_valid request.body_timeout_s)
-    then Error (Invalid_body_timeout (Option.get request.body_timeout_s))
-    else if not (contract_is_supported config capabilities)
+    else
+      let* () =
+        validate_timeout
+          ~invalid:(fun seconds -> Invalid_connect_timeout seconds)
+          config.connect_timeout_s
+      in
+      let* () =
+        validate_timeout
+          ~invalid:(fun seconds -> Invalid_body_timeout seconds)
+          request.body_timeout_s
+      in
+      if not (contract_is_supported config capabilities)
     then
       Error
         (Unsupported_output_contract

--- a/packages/agent_core/lib/llm_provider/http_client.ml
+++ b/packages/agent_core/lib/llm_provider/http_client.ml
@@ -1946,7 +1946,13 @@ let post_sync_once_after_validation
         status := Some response_status;
         Http_client_phase_observer.observe
           (Http_client_phase_observer.Response_received response_status);
-        Ok (conn, response, response_body, response_header_evidence, retry_after_header))
+        Ok
+          ( conn
+          , response
+          , response_body
+          , response_status
+          , response_header_evidence
+          , retry_after_header ))
     with
     | Eio.Time.Timeout as exn ->
       release_connection ();
@@ -1957,7 +1963,13 @@ let post_sync_once_after_validation
   | Error error ->
     release_connection ();
     fail error
-  | Ok (conn, response, response_body, response_header_evidence, retry_after_header) ->
+  | Ok
+      ( conn
+      , response
+      , response_body
+      , response_status
+      , response_header_evidence
+      , retry_after_header ) ->
     let body_result =
       try
         match body_deadline, total_started_at with
@@ -2008,7 +2020,7 @@ let post_sync_once_after_validation
           fail error
         | Ok () ->
           Ok
-            ( { status = Option.get !status; body = response_body; retry_after_header }
+            ( { status = response_status; body = response_body; retry_after_header }
             , response_header_evidence )))
 ;;
 

--- a/scripts/ocaml-boundary-baseline.tsv
+++ b/scripts/ocaml-boundary-baseline.tsv
@@ -5,4 +5,3 @@ partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement
 partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml	resolve_origin/host	Stdlib.Option.get	1
 partial_extraction	packages/agent_core/lib/llm_provider/exact_output_plan.ml	preflight	Stdlib.Option.get	2
 partial_extraction	packages/agent_core/lib/llm_provider/http_client.ml	post_sync_once_after_validation	Stdlib.Option.get	1
-failure_erasure	lib/runtime/runtime.ml	of_binding	Stdlib.Result.to_option	1

--- a/scripts/ocaml-boundary-baseline.tsv
+++ b/scripts/ocaml-boundary-baseline.tsv
@@ -1,7 +1,2 @@
 # ocaml-boundary-audit-v2 typed-tree baseline
 # category<TAB>path<TAB>scope<TAB>resolved-callee<TAB>count
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_generation_receipt.ml	merge_state	Stdlib.Option.get	2
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml	post_sync_once_after_commit/response_status	Stdlib.Option.get	1
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml	resolve_origin/host	Stdlib.Option.get	1
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_plan.ml	preflight	Stdlib.Option.get	2
-partial_extraction	packages/agent_core/lib/llm_provider/http_client.ml	post_sync_once_after_validation	Stdlib.Option.get	1

--- a/test/test_parse_outcome.ml
+++ b/test/test_parse_outcome.ml
@@ -46,12 +46,6 @@ let test_map () =
   in
   check int "map increments" 8 (match r with Ok v -> v | Error _ -> -1)
 
-let test_to_option () =
-  check (option int) "Ok -> Some"
-    (Some 5) (Parse_outcome.to_option (Ok 5));
-  check (option int) "Error -> None"
-    None (Parse_outcome.to_option (Error (`Other (Failure "x"))))
-
 (* RFC-0145 §Design — cancellation MUST re-raise. We drive an Eio
    fiber and cancel it from a sibling; inside the cancelled context
    the parser raises Cancelled which parse_safe must propagate. *)
@@ -87,7 +81,6 @@ let () =
           test_case "of_exn classifies Failure as `Other" `Quick test_of_exn_other;
           test_case "bind" `Quick test_bind;
           test_case "map" `Quick test_map;
-          test_case "to_option" `Quick test_to_option;
         ] );
       ( "cancellation",
         [

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1170,8 +1170,27 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     }
   in
   match Runtime.of_binding cfg runpod_binding with
-  | Some runtime -> runtime
-  | None -> fail "expected runtime binding to materialize"
+  | Ok runtime -> runtime
+  | Error reason -> failf "expected runtime binding to materialize: %s" reason
+
+let test_runtime_of_binding_preserves_failure_reason () =
+  let cfg =
+    { Runtime_schema.providers = [ runpod_provider ]
+    ; models = [ qwen_model ]
+    ; bindings = [ runpod_binding ]
+    ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; cross_verifier_runtime_id = None
+    ; keeper_assignments = []
+    ; media_failover = []
+    ; lane_decls = []
+    ; exact_output_lane_decls = []
+    }
+  in
+  match Runtime.of_binding cfg { runpod_binding with enabled = false } with
+  | Ok _ -> fail "expected disabled binding materialization to fail"
+  | Error reason ->
+    check string "disabled binding reason"
+      "binding is disabled by runtime.toml" reason
 
 let with_dashboard_probe_http_get hook f =
   Server_dashboard_http_runtime_info.set_dashboard_runtime_provider_http_get_for_tests
@@ -1923,6 +1942,10 @@ let () =
         ] )
     ; ( "provider_config"
       , [ test_case
+            "runtime binding materialization preserves failure reason"
+            `Quick
+            test_runtime_of_binding_preserves_failure_reason
+        ; test_case
             "adapter stamps declared provider id"
             `Quick
             test_adapter_stamps_declared_provider_id

--- a/test/test_server_ide_lsp_proxy.ml
+++ b/test/test_server_ide_lsp_proxy.ml
@@ -121,6 +121,50 @@ let test_file_uri_resolution_rejects_symlink_escape () =
          (Lsp.resolve_relative ~base ("file://" ^ link)))
 ;;
 
+let document_params ~uri line =
+  `Assoc
+    [ "textDocument", `Assoc [ "uri", `String uri ]
+    ; "position", `Assoc [ "line", line ]
+    ]
+;;
+
+let test_document_request_is_resolved_once () =
+  let base = "/workspace/masc" in
+  let uri = "file:///workspace/masc/lib/server.ml" in
+  match Lsp.resolve_document_request ~base (document_params ~uri (`Int 7)) with
+  | Error _ -> fail "expected an in-workspace document request"
+  | Ok request ->
+    check string "URI retained" uri request.uri;
+    check string "relative path resolved" "lib/server.ml" request.relative_path;
+    check (option int) "line resolved" (Some 7) request.line;
+    (match request.language with
+     | Lsp.Known_lang "ocaml" -> ()
+     | Lsp.Known_lang language -> failf "unexpected language: %s" language
+     | Lsp.Unknown_lang -> fail "expected the .ml language to resolve")
+;;
+
+let test_document_request_keeps_decode_failures_typed () =
+  let base = "/workspace/masc" in
+  let missing_uri = `Assoc [ "position", `Assoc [ "line", `Int 1 ] ] in
+  (match Lsp.resolve_document_request ~base missing_uri with
+   | Error Lsp.Missing_document_uri -> ()
+   | Error Lsp.Document_uri_outside_workspace ->
+     fail "missing URI must not be classified as an out-of-workspace path"
+   | Ok _ -> fail "missing URI must fail decoding");
+  let outside_uri = "file:///tmp/outside.ml" in
+  (match
+     Lsp.resolve_document_request ~base (document_params ~uri:outside_uri (`Int 1))
+   with
+   | Error Lsp.Document_uri_outside_workspace -> ()
+   | Error Lsp.Missing_document_uri ->
+     fail "outside URI must not be classified as missing"
+   | Ok _ -> fail "outside URI must fail decoding");
+  let inside_uri = "file:///workspace/masc/lib/server.ml" in
+  match Lsp.resolve_document_request ~base (document_params ~uri:inside_uri (`Int (-1))) with
+  | Error _ -> fail "negative line must not invalidate a document path"
+  | Ok request -> check (option int) "negative line is absent" None request.line
+;;
+
 let test_dispatch_workers_are_parallelized () =
   check
     bool
@@ -401,6 +445,10 @@ let () =
             test_file_uri_resolution_is_workspace_scoped
         ; test_case "file uri resolution rejects symlink escape" `Quick
             test_file_uri_resolution_rejects_symlink_escape
+        ; test_case "document request resolves once" `Quick
+            test_document_request_is_resolved_once
+        ; test_case "document request decode failures stay typed" `Quick
+            test_document_request_keeps_decode_failures_typed
         ; test_case "dispatch workers are parallelized" `Quick
             test_dispatch_workers_are_parallelized
         ; test_case "/api/v1/ide/lsp is a Ws upgrade route" `Quick


### PR DESCRIPTION
## Summary

- hard-cut `Runtime.of_binding` from `t option` to `(t, string) result`
- delete the producerless `of_binding_result`/`Result.to_option` compatibility projection
- delete the producerless `Parse_outcome.to_option` migration shim and its dedicated test
- make the direct test caller preserve and report the materialization failure reason
- reduce the typed boundary-audit `failure_erasure` baseline from one site to zero

## Why

The runtime implementation already computed a typed failure reason, then erased it solely to maintain an unused Option API. Keeping the Result as the single contract lets callers branch once at the boundary and prevents materialization failures from collapsing into absence.

## Validation

- `ocamlformat --check lib/runtime/runtime.ml lib/runtime/runtime.mli test/test_runtime_provider_auth_headers.ml`
- `ocamlc -stop-after parsing` for the changed `.ml`/`.mli` files
- `git diff --check`
- repository-wide call sweep: no production caller depended on the Option projection
- focused Dune invocation is temporarily serialized behind another live repository build; Draft CI is the compile/test authority

Stacked on #28268.
