### PR TITLE
perf(dashboard): exact-lane 목록을 페이징하고 payload는 열 때 로드 (246MB → 13KB)

### DIFF
--- a/dashboard/src/api/dashboard-exact-lane-runs.test.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.test.ts
@@ -1,28 +1,26 @@
 import { describe, expect, it } from 'vitest'
-import { parseExactLaneRunsResponse } from './dashboard-exact-lane-runs'
+import { parseExactLaneRunResponse, parseExactLaneRunsResponse } from './dashboard-exact-lane-runs'
 
 describe('parseExactLaneRunsResponse', () => {
   it('decodes one completed exact lane record', () => {
     const parsed = parseExactLaneRunsResponse({
       generated_at: '2026-08-06T00:00:00Z',
       count: 1,
+      total: 1,
+      has_more: false,
       runs: [{
         run_id: 'exact-librarian-1',
         lane: 'librarian_exact',
         subject_id: 'trace-1',
         actor: 'keeper-a',
         started_at: 1,
-        input: { kind: 'exact', payload: { message_count: 4 } },
         status: 'succeeded',
         elapsed_s: 0.4,
-        output: { fact_count: 3 },
       }],
     })
     expect(parsed.runs[0]).toMatchObject({
       lane: 'librarian_exact',
       status: 'succeeded',
-      input: { kind: 'exact', payload: { message_count: 4 } },
-      output: { fact_count: 3 },
     })
   })
 
@@ -30,37 +28,56 @@ describe('parseExactLaneRunsResponse', () => {
     expect(() => parseExactLaneRunsResponse({
       generated_at: '2026-08-06T00:00:00Z',
       count: 1,
+      total: 1,
+      has_more: false,
       runs: [{
         run_id: 'x', lane: 'mystery', subject_id: 's', actor: 'a',
-        started_at: 1, input: { kind: 'exact', payload: {} }, status: 'running',
+        started_at: 1, status: 'running',
       }],
     })).toThrow('unknown value')
   })
 
-  it('rejects removed research input instead of replaying it', () => {
+  // A listing row carries no payload at all, so a payload field appearing in
+  // one is a contract break rather than a value to inspect.
+  it('rejects a listing row that carries a payload', () => {
     expect(() => parseExactLaneRunsResponse({
       generated_at: '2026-08-09T00:00:00Z',
       count: 1,
+      total: 1,
+      has_more: false,
       runs: [{
-        run_id: 'librarian-research-1',
+        run_id: 'librarian-1',
         lane: 'librarian_exact',
         subject_id: 'trace-1',
         actor: 'keeper-a',
         started_at: 1,
-        input: {
-          kind: 'research',
-          raw_trace_path: '/tmp/raw-traces/librarian-research-1.jsonl',
-          payload: { message_count: 4 },
-        },
         status: 'running',
+        input: { kind: 'exact', payload: { message_count: 4 } },
       }],
-    })).toThrow('unknown value')
+    })).toThrow()
   })
 
+  it('reports the page it returned against the total retained', () => {
+    const parsed = parseExactLaneRunsResponse({
+      generated_at: '2026-08-12T00:00:00Z',
+      count: 1,
+      total: 5908,
+      has_more: true,
+      runs: [{
+        run_id: 'r', lane: 'librarian_exact', subject_id: 's', actor: 'a',
+        started_at: 1, status: 'running',
+      }],
+    })
+    expect(parsed.total).toBe(5908)
+    expect(parsed.hasMore).toBe(true)
+    expect(parsed.count).toBe(1)
+  })
   it('decodes both explicit completion persistence failure states', () => {
     const parsed = parseExactLaneRunsResponse({
       generated_at: '2026-08-11T00:00:00Z',
       count: 2,
+      total: 2,
+      has_more: false,
       runs: [
         {
           run_id: 'failed-append',
@@ -68,13 +85,11 @@ describe('parseExactLaneRunsResponse', () => {
           subject_id: 'trace-1',
           actor: 'keeper-a',
           started_at: 1,
-          input: { kind: 'exact', payload: {} },
           status: 'completion_persistence_failed',
           intended_status: 'failed',
           intended_code: 'model_error',
           intended_detail: 'typed failure detail',
           elapsed_s: 0.4,
-          output: { partial: true },
           persistence_error: 'append rejected before commit',
           persistence_state: 'not_persisted',
         },
@@ -84,11 +99,9 @@ describe('parseExactLaneRunsResponse', () => {
           subject_id: 'trace-2',
           actor: 'keeper-b',
           started_at: 2,
-          input: { kind: 'exact', payload: {} },
           status: 'completion_durability_unknown',
           intended_status: 'succeeded',
           elapsed_s: 0.5,
-          output: { fact_count: 2 },
           persistence_error: 'rollback settlement failed',
           persistence_state: 'durability_unknown',
         },
@@ -112,20 +125,60 @@ describe('parseExactLaneRunsResponse', () => {
     expect(() => parseExactLaneRunsResponse({
       generated_at: '2026-08-11T00:00:00Z',
       count: 1,
+      total: 1,
+      has_more: false,
       runs: [{
         run_id: 'mismatch',
         lane: 'compaction_exact',
         subject_id: 'trace',
         actor: 'keeper-a',
         started_at: 1,
-        input: { kind: 'exact', payload: {} },
         status: 'completion_persistence_failed',
         intended_status: 'succeeded',
         elapsed_s: 0.4,
-        output: {},
         persistence_error: 'append failed',
         persistence_state: 'durability_unknown',
       }],
     })).toThrow('persistence_state must be')
+  })
+})
+
+describe('parseExactLaneRunResponse', () => {
+  it('decodes one opened run with both payloads', () => {
+    const run = parseExactLaneRunResponse({
+      generated_at: '2026-08-12T00:00:00Z',
+      run: {
+        run_id: 'exact-librarian-1',
+        lane: 'librarian_exact',
+        subject_id: 'trace-1',
+        actor: 'keeper-a',
+        started_at: 1,
+        status: 'succeeded',
+        elapsed_s: 0.4,
+        input: { kind: 'exact', payload: { message_count: 4 } },
+        output: { fact_count: 3 },
+      },
+    })
+    expect(run.input).toEqual({ kind: 'exact', payload: { message_count: 4 } })
+    expect(run.output).toEqual({ fact_count: 3 })
+  })
+
+  it('rejects removed research input instead of replaying it', () => {
+    expect(() => parseExactLaneRunResponse({
+      generated_at: '2026-08-09T00:00:00Z',
+      run: {
+        run_id: 'librarian-research-1',
+        lane: 'librarian_exact',
+        subject_id: 'trace-1',
+        actor: 'keeper-a',
+        started_at: 1,
+        status: 'running',
+        input: {
+          kind: 'research',
+          raw_trace_path: '/tmp/raw-traces/librarian-research-1.jsonl',
+          payload: { message_count: 4 },
+        },
+      },
+    })).toThrow('unknown value')
   })
 })

--- a/dashboard/src/api/dashboard-exact-lane-runs.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.ts
@@ -20,16 +20,17 @@ export type ExactLanePersistenceState = 'not_persisted' | 'durability_unknown'
 
 export type ExactLaneRunInput = { kind: 'exact'; payload: unknown }
 
-export interface ExactLaneRunRecord {
+// A listing row. The exact input and output payloads are deliberately absent:
+// a lane run embeds the whole rendered prompt, so carrying them here made one
+// listing 246 MB. They arrive from fetchExactLaneRun when a row is opened.
+export interface ExactLaneRunSummary {
   runId: string
   lane: ExactLane
   subjectId: string
   actor: string
   startedAt: number
-  input: ExactLaneRunInput
   status: ExactLaneRunStatus
   elapsedSeconds?: number
-  output?: unknown
   code?: string
   detail?: string
   intendedStatus?: ExactLaneIntendedStatus
@@ -39,9 +40,17 @@ export interface ExactLaneRunRecord {
   persistenceState?: ExactLanePersistenceState
 }
 
+// One opened run, payloads included.
+export interface ExactLaneRunRecord extends ExactLaneRunSummary {
+  input: ExactLaneRunInput
+  output?: unknown
+}
+
 export interface DashboardExactLaneRunsResponse {
-  runs: ExactLaneRunRecord[]
+  runs: ExactLaneRunSummary[]
   count: number
+  total: number
+  hasMore: boolean
   generatedAt: string
 }
 
@@ -101,14 +110,19 @@ function parseInput(raw: unknown, context: string): ExactLaneRunInput {
   return fail(`${context}.kind has unknown value ${JSON.stringify(kind)}`)
 }
 
-function parseRun(raw: unknown, index: number): ExactLaneRunRecord {
-  const context = `runs[${index}]`
+function parseRun(raw: unknown, index: number, withPayloads: false): ExactLaneRunSummary
+function parseRun(raw: unknown, index: number, withPayloads: true): ExactLaneRunRecord
+function parseRun(raw: unknown, index: number, withPayloads: boolean): ExactLaneRunSummary {
+  const context = withPayloads ? 'root.run' : `runs[${index}]`
   if (!isRecord(raw)) fail(`${context} must be an object`)
   const status = string(raw.status, `${context}.status`)
   if (!STATUSES.includes(status)) fail(`${context}.status has unknown value ${JSON.stringify(status)}`)
   const lane = string(raw.lane, `${context}.lane`)
   if (!LANES.includes(lane)) fail(`${context}.lane has unknown value ${JSON.stringify(lane)}`)
-  const base = ['run_id', 'lane', 'subject_id', 'actor', 'started_at', 'input', 'status']
+  const base = ['run_id', 'lane', 'subject_id', 'actor', 'started_at', 'status']
+    .concat(withPayloads ? ['input'] : [])
+  // `output` rides with the payloads; a summary never carries it.
+  const completion = withPayloads ? ['elapsed_s', 'output'] : ['elapsed_s']
   const persistenceFailure = status === 'completion_persistence_failed'
     || status === 'completion_durability_unknown'
   const intendedStatus = persistenceFailure
@@ -124,15 +138,14 @@ function parseRun(raw: unknown, index: number): ExactLaneRunRecord {
       ? [
           ...base,
           'intended_status',
-          'elapsed_s',
-          'output',
+          ...completion,
           'persistence_error',
           'persistence_state',
           ...(intendedFailure ? ['intended_code', 'intended_detail'] : []),
         ]
       : status === 'failed'
-        ? [...base, 'elapsed_s', 'output', 'code', 'detail']
-        : [...base, 'elapsed_s', 'output']
+        ? [...base, ...completion, 'code', 'detail']
+        : [...base, ...completion]
   exactFields(raw, required, [], context)
   const persistenceState = persistenceFailure
     ? string(raw.persistence_state, `${context}.persistence_state`)
@@ -151,10 +164,14 @@ function parseRun(raw: unknown, index: number): ExactLaneRunRecord {
     subjectId: string(raw.subject_id, `${context}.subject_id`),
     actor: string(raw.actor, `${context}.actor`),
     startedAt: number(raw.started_at, `${context}.started_at`),
-    input: parseInput(raw.input, `${context}.input`),
+    ...(withPayloads
+      ? {
+          input: parseInput(raw.input, `${context}.input`),
+          output: status === 'running' ? undefined : raw.output,
+        }
+      : {}),
     status: status as ExactLaneRunStatus,
     elapsedSeconds: status === 'running' ? undefined : number(raw.elapsed_s, `${context}.elapsed_s`),
-    output: status === 'running' ? undefined : raw.output,
     code: status === 'failed' ? string(raw.code, `${context}.code`) : undefined,
     detail: status === 'failed' ? string(raw.detail, `${context}.detail`) : undefined,
     intendedStatus: intendedStatus as ExactLaneIntendedStatus | undefined,
@@ -169,23 +186,62 @@ function parseRun(raw: unknown, index: number): ExactLaneRunRecord {
 
 export function parseExactLaneRunsResponse(raw: unknown): DashboardExactLaneRunsResponse {
   if (!isRecord(raw)) fail('root must be an object')
-  exactFields(raw, ['runs', 'count', 'generated_at'], [], 'root')
+  exactFields(raw, ['runs', 'count', 'total', 'has_more', 'generated_at'], [], 'root')
   if (!Array.isArray(raw.runs)) fail('root.runs must be an array')
   if (!Number.isSafeInteger(raw.count) || (raw.count as number) < 0) {
     fail('root.count must be a non-negative safe integer')
   }
-  const runs = raw.runs.map(parseRun)
+  if (!Number.isSafeInteger(raw.total) || (raw.total as number) < 0) {
+    fail('root.total must be a non-negative safe integer')
+  }
+  if (typeof raw.has_more !== 'boolean') fail('root.has_more must be a boolean')
+  const runs = raw.runs.map((run, index) => parseRun(run, index, false))
   if (raw.count !== runs.length) fail('root.count must match runs.length')
   return {
     runs,
     count: raw.count as number,
+    total: raw.total as number,
+    hasMore: raw.has_more,
     generatedAt: string(raw.generated_at, 'root.generated_at'),
   }
 }
 
+export function parseExactLaneRunResponse(raw: unknown): ExactLaneRunRecord {
+  if (!isRecord(raw)) fail('root must be an object')
+  exactFields(raw, ['run', 'generated_at'], [], 'root')
+  return parseRun(raw.run, 0, true)
+}
+
+// The cursor is the caller's own last row, not server state: the server keeps
+// nothing between calls, and carrying the run_id alongside the timestamp is
+// what stops two runs recorded in the same float second from straddling a page
+// boundary.
+export type ExactLaneRunCursor = { startedAt: number; runId: string }
+
 export async function fetchExactLaneRuns(
-  opts?: AbortableRequestOptions,
+  opts?: AbortableRequestOptions & { limit?: number; before?: ExactLaneRunCursor },
 ): Promise<DashboardExactLaneRunsResponse> {
-  const raw = await get<unknown>('/api/v1/dashboard/exact-lane-runs', { signal: opts?.signal })
+  const params = new URLSearchParams()
+  if (opts?.limit != null) params.set('limit', String(opts.limit))
+  if (opts?.before != null) {
+    params.set('before_started_at', String(opts.before.startedAt))
+    params.set('before_run_id', opts.before.runId)
+  }
+  const query = params.toString()
+  const raw = await get<unknown>(
+    `/api/v1/dashboard/exact-lane-runs${query === '' ? '' : `?${query}`}`,
+    { signal: opts?.signal },
+  )
   return parseExactLaneRunsResponse(raw)
+}
+
+export async function fetchExactLaneRun(
+  runId: string,
+  opts?: AbortableRequestOptions,
+): Promise<ExactLaneRunRecord> {
+  const raw = await get<unknown>(
+    `/api/v1/dashboard/exact-lane-runs/${encodeURIComponent(runId)}`,
+    { signal: opts?.signal },
+  )
+  return parseExactLaneRunResponse(raw)
 }

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -61,11 +61,15 @@ export {
   fetchVerificationRuns,
 } from './dashboard-verification-runs'
 export {
+  fetchExactLaneRun,
   fetchExactLaneRuns,
+  parseExactLaneRunResponse,
   parseExactLaneRunsResponse,
   type DashboardExactLaneRunsResponse,
   type ExactLane,
+  type ExactLaneRunCursor,
   type ExactLaneRunRecord,
+  type ExactLaneRunSummary,
   type ExactLaneRunInput,
   type ExactLaneRunStatus,
 } from './dashboard-exact-lane-runs'

--- a/dashboard/src/components/internal-agents-monitor.test.ts
+++ b/dashboard/src/components/internal-agents-monitor.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { html } from 'htm/preact'
 
 const api = vi.hoisted(() => ({
+  fetchExactLaneRun: vi.fn(),
   fetchExactLaneRuns: vi.fn(),
   fetchVerificationRuns: vi.fn(),
   fetchFusionRuns: vi.fn(),
@@ -37,7 +38,7 @@ describe('InternalAgentsMonitor', () => {
   })
 
   it('keeps paused keepers with zero observed runs in the owner matrix', async () => {
-    api.fetchExactLaneRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchExactLaneRuns.mockResolvedValue({ runs: [], count: 0, total: 0, hasMore: false, generatedAt: 'now' })
     api.fetchFusionRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
     api.fetchVerificationRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
     shellRuntimeResolution.value = {
@@ -54,7 +55,7 @@ describe('InternalAgentsMonitor', () => {
   })
 
   it('expands a verification run and shows its ordered tool evidence', async () => {
-    api.fetchExactLaneRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchExactLaneRuns.mockResolvedValue({ runs: [], count: 0, total: 0, hasMore: false, generatedAt: 'now' })
     api.fetchFusionRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
     api.fetchVerificationRuns.mockResolvedValue({
       count: 1,
@@ -97,6 +98,8 @@ describe('InternalAgentsMonitor', () => {
     api.fetchVerificationRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
     api.fetchExactLaneRuns.mockResolvedValue({
       count: 2,
+      total: 2,
+      hasMore: false,
       generatedAt: 'now',
       runs: [
         {
@@ -145,6 +148,8 @@ describe('InternalAgentsMonitor', () => {
     api.fetchVerificationRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
     api.fetchExactLaneRuns.mockResolvedValue({
       count: 1,
+      total: 1,
+      hasMore: false,
       generatedAt: 'now',
       runs: [{
         runId: 'exact-lib-1',
@@ -152,21 +157,31 @@ describe('InternalAgentsMonitor', () => {
         subjectId: 'trace-1',
         actor: 'kidsnote',
         startedAt: 1786000000,
-        input: {
-          kind: 'exact',
-          payload: { current_fact_count: 1, message_count: 5 },
-        },
         status: 'succeeded',
         elapsedSeconds: 2,
-        output: {
-          before: { present: true, fact_count: 1 },
-          after: {
-            revision: 42,
-            fact_count: 1,
-            change: { added_count: 1, removed_count: 1, retained: 0 },
-          },
-        },
       }],
+    })
+    // The listing carries no payloads; opening the row is what fetches them.
+    api.fetchExactLaneRun.mockResolvedValue({
+      runId: 'exact-lib-1',
+      lane: 'librarian_exact',
+      subjectId: 'trace-1',
+      actor: 'kidsnote',
+      startedAt: 1786000000,
+      status: 'succeeded',
+      elapsedSeconds: 2,
+      input: {
+        kind: 'exact',
+        payload: { current_fact_count: 1, message_count: 5 },
+      },
+      output: {
+        before: { present: true, fact_count: 1 },
+        after: {
+          revision: 42,
+          fact_count: 1,
+          change: { added_count: 1, removed_count: 1, retained: 0 },
+        },
+      },
     })
     memoryApi.fetchKeeperMemoryJournal.mockResolvedValue({
       keeper: 'kidsnote',
@@ -209,6 +224,8 @@ describe('InternalAgentsMonitor', () => {
     api.fetchVerificationRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
     api.fetchExactLaneRuns.mockResolvedValue({
       count: 1,
+      total: 1,
+      hasMore: false,
       generatedAt: 'now',
       runs: [{
         runId: 'exact-lib-running',
@@ -216,9 +233,17 @@ describe('InternalAgentsMonitor', () => {
         subjectId: 'trace-shared',
         actor: 'full-cycle-probe',
         startedAt: 1786200000,
-        input: { kind: 'exact', payload: { current_fact_count: 2 } },
         status: 'running',
       }],
+    })
+    api.fetchExactLaneRun.mockResolvedValue({
+      runId: 'exact-lib-running',
+      lane: 'librarian_exact',
+      subjectId: 'trace-shared',
+      actor: 'full-cycle-probe',
+      startedAt: 1786200000,
+      status: 'running',
+      input: { kind: 'exact', payload: { current_fact_count: 2 } },
     })
     memoryApi.fetchKeeperMemoryJournal.mockResolvedValue({
       keeper: 'full-cycle-probe',

--- a/dashboard/src/components/internal-agents-monitor.ts
+++ b/dashboard/src/components/internal-agents-monitor.ts
@@ -1,10 +1,12 @@
 import { html } from 'htm/preact'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
+  fetchExactLaneRun,
   fetchExactLaneRuns,
   fetchFusionRuns,
   fetchVerificationRuns,
   type ExactLaneRunRecord,
+  type ExactLaneRunSummary,
   type FusionRunRecord,
   type VerificationRunRecord,
 } from '../api/dashboard'
@@ -33,7 +35,7 @@ type Filter =
   | 'verification'
   | 'fusion'
 type Row =
-  | { source: 'exact'; id: string; run: ExactLaneRunRecord }
+  | { source: 'exact'; id: string; run: ExactLaneRunSummary }
   | { source: 'verification'; id: string; run: VerificationRunRecord }
   | { source: 'fusion'; id: string; run: FusionRunRecord }
 type CommittedMemoryJournalEntry = Extract<MemoryJournalEntry, { ok: true; outcome: 'committed' }>
@@ -290,6 +292,82 @@ function LibrarianJournal({
   `
 }
 
+// The listing carries no payloads, so opening a row is what fetches them. The
+// alternative — shipping every run's input and output with the list — is what
+// made this panel download 246 MB before it could draw a single line.
+function ExactRunDetail({ runId }: { runId: string }) {
+  const [run, setRun] = useState<ExactLaneRunRecord | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setRun(null)
+    setError(null)
+    fetchExactLaneRun(runId, { signal: controller.signal })
+      .then(setRun)
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return
+        setError(String(cause))
+      })
+    return () => controller.abort()
+  }, [runId])
+
+  if (error !== null) {
+    return html`
+      <div class="grid gap-2 p-3 bg-[var(--color-bg-surface)] border-t border-[var(--color-border-default)] text-xs">
+        <p class="text-[var(--color-danger)]">이 실행의 typed 값을 읽지 못했습니다: ${error}</p>
+      </div>
+    `
+  }
+  if (run === null) {
+    return html`
+      <div class="grid gap-2 p-3 bg-[var(--color-bg-surface)] border-t border-[var(--color-border-default)] text-xs">
+        <p class="text-[var(--color-fg-muted)]">typed 입출력을 불러오는 중…</p>
+      </div>
+    `
+  }
+    const output = run.output ?? { code: run.code, detail: run.detail }
+    const memoryEvidence = run.lane === 'librarian_exact'
+      ? librarianMemoryEvidence(run.output)
+      : null
+    return html`
+      <div class="grid gap-3 p-3 bg-[var(--color-bg-surface)] border-t border-[var(--color-border-default)]">
+        <div class="flex flex-wrap items-center gap-2 text-xs">
+          <${EvidenceBadge} kind="typed" />
+          <strong>Exact-output registry metadata</strong>
+          <span class="text-[var(--color-fg-muted)]">Admin-only 실제 typed 값 · Librarian exact에는 research RAW 입력 없음</span>
+          <a class="ml-auto text-[var(--color-accent)] hover:underline" href=${keeperHref(run.actor)}>Keeper 전체 evidence 열기 →</a>
+        </div>
+        <div class="grid gap-3 lg:grid-cols-2">
+          <${JsonViewerCard} title="실제 입력 · typed" data=${run.input.payload} expandAll=${true} />
+          <${JsonViewerCard} title="실제 출력 · typed" data=${output} expandAll=${true} />
+        </div>
+        ${run.persistenceError === undefined
+          ? null
+          : html`<p class="text-xs text-[var(--color-danger)]">완료 의도 <code>${run.intendedStatus}</code> · persistence <code>${run.persistenceState}</code>: ${run.persistenceError}${run.intendedCode ? ` · ${run.intendedCode}: ${run.intendedDetail}` : ''}</p>`}
+        <p class="text-xs text-[var(--color-fg-muted)]"><span class="mr-2 inline-flex rounded border border-[var(--color-accent)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wide text-[var(--color-accent)]">TOOL-FREE</span>이 exact 실행은 immutable Librarian input만 사용하며 외부 research/RAW 입력을 받지 않습니다.</p>
+        ${memoryEvidence === null
+          ? null
+          : html`<div class="grid gap-2 border-t border-[var(--color-border-default)] pt-3">
+              <div class="flex items-center gap-2 text-xs"><${EvidenceBadge} kind="typed" /><strong>Memory before → after</strong><span class="text-[var(--color-fg-muted)]">registry에는 count/revision만, 실제 추가·제거는 아래 journal</span></div>
+              <div class="grid gap-3 lg:grid-cols-2">
+                <${JsonViewerCard} title="Before memory · typed" data=${memoryEvidence.before} expandAll=${true} />
+                <${JsonViewerCard} title="After memory + change · typed" data=${memoryEvidence.after} expandAll=${true} />
+              </div>
+            </div>`}
+        ${run.lane === 'librarian_exact'
+          ? html`<div class="border-t border-[var(--color-border-default)] pt-3">
+              <${LibrarianJournal}
+                keeper=${run.actor}
+                traceId=${run.subjectId}
+                revision=${librarianRevision(run.output)}
+              />
+            </div>`
+          : null}
+      </div>
+    `
+}
+
 function Details({ row }: { row: Row }) {
   if (row.source === 'verification') {
     const tools = row.run.tools ?? []
@@ -339,46 +417,7 @@ function Details({ row }: { row: Row }) {
     `
   }
   if (row.source === 'exact') {
-    const output = row.run.output ?? { code: row.run.code, detail: row.run.detail }
-    const memoryEvidence = row.run.lane === 'librarian_exact'
-      ? librarianMemoryEvidence(row.run.output)
-      : null
-    return html`
-      <div class="grid gap-3 p-3 bg-[var(--color-bg-surface)] border-t border-[var(--color-border-default)]">
-        <div class="flex flex-wrap items-center gap-2 text-xs">
-          <${EvidenceBadge} kind="typed" />
-          <strong>Exact-output registry metadata</strong>
-          <span class="text-[var(--color-fg-muted)]">Admin-only 실제 typed 값 · Librarian exact에는 research RAW 입력 없음</span>
-          <a class="ml-auto text-[var(--color-accent)] hover:underline" href=${keeperHref(row.run.actor)}>Keeper 전체 evidence 열기 →</a>
-        </div>
-        <div class="grid gap-3 lg:grid-cols-2">
-          <${JsonViewerCard} title="실제 입력 · typed" data=${row.run.input.payload} expandAll=${true} />
-          <${JsonViewerCard} title="실제 출력 · typed" data=${output} expandAll=${true} />
-        </div>
-        ${row.run.persistenceError === undefined
-          ? null
-          : html`<p class="text-xs text-[var(--color-danger)]">완료 의도 <code>${row.run.intendedStatus}</code> · persistence <code>${row.run.persistenceState}</code>: ${row.run.persistenceError}${row.run.intendedCode ? ` · ${row.run.intendedCode}: ${row.run.intendedDetail}` : ''}</p>`}
-        <p class="text-xs text-[var(--color-fg-muted)]"><span class="mr-2 inline-flex rounded border border-[var(--color-accent)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wide text-[var(--color-accent)]">TOOL-FREE</span>이 exact 실행은 immutable Librarian input만 사용하며 외부 research/RAW 입력을 받지 않습니다.</p>
-        ${memoryEvidence === null
-          ? null
-          : html`<div class="grid gap-2 border-t border-[var(--color-border-default)] pt-3">
-              <div class="flex items-center gap-2 text-xs"><${EvidenceBadge} kind="typed" /><strong>Memory before → after</strong><span class="text-[var(--color-fg-muted)]">registry에는 count/revision만, 실제 추가·제거는 아래 journal</span></div>
-              <div class="grid gap-3 lg:grid-cols-2">
-                <${JsonViewerCard} title="Before memory · typed" data=${memoryEvidence.before} expandAll=${true} />
-                <${JsonViewerCard} title="After memory + change · typed" data=${memoryEvidence.after} expandAll=${true} />
-              </div>
-            </div>`}
-        ${row.run.lane === 'librarian_exact'
-          ? html`<div class="border-t border-[var(--color-border-default)] pt-3">
-              <${LibrarianJournal}
-                keeper=${row.run.actor}
-                traceId=${row.run.subjectId}
-                revision=${librarianRevision(row.run.output)}
-              />
-            </div>`
-          : null}
-      </div>
-    `
+    return html`<${ExactRunDetail} runId=${row.run.runId} />`
   }
   return html`
     <div class="grid gap-2 p-3 bg-[var(--color-bg-surface)] border-t border-[var(--color-border-default)] text-xs">

--- a/lib/exact_lane_run_registry.ml
+++ b/lib/exact_lane_run_registry.ml
@@ -327,7 +327,46 @@ let mark_completed t ~run_id ~outcome ~elapsed_s ~output =
     Error error
 ;;
 
+(* [total] counts every retained run, not the page, so a caller can say
+   "50 of 5,908" without asking for the rest. *)
+type run_page =
+  { runs : run list
+  ; total : int
+  ; has_more : bool
+  }
+
 let list_runs t = Atomic.get t.projection
+
+(* Newest first, ties broken by run_id, so a page boundary is a total order and
+   two runs recorded in the same float second cannot straddle it. *)
+let newer_first left right =
+  match Float.compare right.started_at left.started_at with
+  | 0 -> String.compare right.run_id left.run_id
+  | order -> order
+;;
+
+let is_older_than ~before run =
+  match before with
+  | None -> true
+  | Some (started_at, run_id) ->
+    Float.compare run.started_at started_at < 0
+    || (Float.equal run.started_at started_at && String.compare run.run_id run_id < 0)
+;;
+
+let recent_runs t ~limit ~before =
+  if limit <= 0
+  then { runs = []; total = List.length (Atomic.get t.projection); has_more = false }
+  else (
+    let all = Atomic.get t.projection in
+    let candidates = List.filter (is_older_than ~before) all |> List.sort newer_first in
+    let rec take taken index = function
+      | [] -> List.rev taken, false
+      | _ :: _ when index >= limit -> List.rev taken, true
+      | run :: rest -> take (run :: taken) (index + 1) rest
+    in
+    let runs, has_more = take [] 0 candidates in
+    { runs; total = List.length all; has_more })
+;;
 
 let get t ~run_id =
   List.find_opt (fun run -> String.equal run.run_id run_id) (Atomic.get t.projection)
@@ -343,30 +382,35 @@ let status_label = function
     "completion_durability_unknown"
 ;;
 
-let run_to_yojson run =
+(* Identity and outcome of a run, without either exact payload. A lane run
+   embeds the whole rendered prompt — on this host one field,
+   [rendered_prompt_variables.conversation_history], was 136.6 MB of a 286 MB
+   store — so a list that carried payloads shipped hundreds of megabytes to
+   draw a table of timestamps. The payloads live behind {!run_to_yojson}, which
+   the detail route serves for one run at a time. *)
+let run_summary_fields run =
   let base =
     [ "run_id", `String run.run_id
     ; "lane", `String (lane_key run.lane)
     ; "subject_id", `String run.subject_id
     ; "actor", `String run.actor
     ; "started_at", `Float run.started_at
-    ; "input", input_to_yojson run.input
     ; "status", `String (status_label run.status)
     ]
   in
   let completion =
     match run.status with
     | Running -> []
-    | Completed { outcome; elapsed_s; output } ->
+    | Completed { outcome; elapsed_s; output = _ } ->
       let detail =
         match outcome with
         | Succeeded | Cancelled -> []
         | Failed { code; detail } ->
           [ "code", `String code; "detail", `String detail ]
       in
-      [ "elapsed_s", `Float elapsed_s; "output", output ] @ detail
+      [ "elapsed_s", `Float elapsed_s ] @ detail
     | Completion_persistence_failed
-        { intended_outcome; elapsed_s; output; failure } ->
+        { intended_outcome; elapsed_s; output = _; failure } ->
       let intended_failure =
         match intended_outcome with
         | Succeeded | Cancelled -> []
@@ -375,7 +419,6 @@ let run_to_yojson run =
       in
       [ "intended_status", `String (outcome_label intended_outcome)
       ; "elapsed_s", `Float elapsed_s
-      ; "output", output
       ; "persistence_error", `String failure.detail
       ; ( "persistence_state"
         , `String
@@ -385,7 +428,21 @@ let run_to_yojson run =
       ]
       @ intended_failure
   in
-  `Assoc (base @ completion)
+  base @ completion
+;;
+
+let run_summary_to_yojson run = `Assoc (run_summary_fields run)
+
+(* The whole record, exact payloads included. Served one run at a time by the
+   detail route; a list never carries these. *)
+let run_to_yojson run =
+  let output_field =
+    match run.status with
+    | Running -> []
+    | Completed { output; _ } | Completion_persistence_failed { output; _ } ->
+      [ "output", output ]
+  in
+  `Assoc ((run_summary_fields run @ [ "input", input_to_yojson run.input ]) @ output_field)
 ;;
 
 type global_install_error = Already_installed

--- a/lib/exact_lane_run_registry.mli
+++ b/lib/exact_lane_run_registry.mli
@@ -88,9 +88,33 @@ val mark_completed
     callers never silently present a terminal run as still executing. *)
 
 val list_runs : t -> run list
+
+(** A page of retained runs, newest first. [total] counts every retained run so
+    a caller can report "50 of 5,908" without asking for the rest. *)
+type run_page =
+  { runs : run list
+  ; total : int
+  ; has_more : bool
+  }
+
+(** At most [limit] runs strictly older than [before] in the (started_at
+    descending, run_id descending) order. [before] is the caller's own
+    (started_at, run_id) from the previous page, never server state: the server
+    remembers nothing between calls, and the run_id tie-break means two runs
+    recorded in the same float second cannot straddle a page boundary.
+
+    Listing everything was what made this surface unusable — 5,908 runs
+    serialized to 246 MB on every load, and again on every refresh event. *)
+val recent_runs : t -> limit:int -> before:(float * string) option -> run_page
 val get : t -> run_id:string -> run option
 val outcome_label : outcome -> string
 val status_label : run_status -> string
+(** Identity and outcome without either exact payload. A lane run embeds the
+    whole rendered prompt, so a list that carried payloads shipped hundreds of
+    megabytes to draw a table of timestamps. *)
+val run_summary_to_yojson : run -> Yojson.Safe.t
+
+(** The whole record, exact payloads included. For one run at a time. *)
 val run_to_yojson : run -> Yojson.Safe.t
 
 (** Called after a registry mutation is durable/in-memory-visible. The server

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -23,6 +23,13 @@ let live_cache_ttl_s = Server_dashboard_http_core_cache.live_cache_ttl_s
 let feature_health_cache_ttl_s = Server_dashboard_http_core_cache.feature_health_cache_ttl_s
 let exact_lane_run_permission = Masc_domain.CanAdmin
 
+(* The panel draws a table; a page an operator can actually scan is ~50 rows.
+   The ceiling exists so a caller cannot ask for the whole store back and
+   reinstate the 246 MB response this paging replaced. *)
+let exact_lane_run_page_default = 50
+let exact_lane_run_page_max = 200
+let exact_lane_run_detail_prefix = "/api/v1/dashboard/exact-lane-runs/"
+
 let dashboard_actor_cache_segment state req =
   dashboard_actor_for_request
     ~base_path:(Mcp_server.workspace_config state).base_path
@@ -758,20 +765,87 @@ let add_routes ~sw ~clock router =
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
+  (* Paged, and without either exact payload. Serving every retained run with
+     its payloads made this one response 246 MB for 5,908 runs — the whole
+     rendered prompt of every lane run, to draw a table of timestamps — and the
+     panel re-fetched it on every internal_agent_runs_changed event. A page
+     carries identity and outcome; [exact-lane-runs/<run_id>] carries the
+     payloads for the one run an operator opened. *)
   |> Http.Router.get "/api/v1/dashboard/exact-lane-runs" (fun request reqd ->
        with_token_permission_auth ~permission:exact_lane_run_permission
          (fun _state _agent_name req reqd ->
-         let runs =
-           Exact_lane_run_registry.list_runs (Exact_lane_run_registry.global ())
+         let limit =
+           Server_utils.int_query_param req "limit" ~default:exact_lane_run_page_default
+           |> Server_utils.clamp ~min_v:1 ~max_v:exact_lane_run_page_max
          in
-         let json =
-           `Assoc
-             [ ("generated_at", `String (Masc_domain.now_iso ()))
-             ; ("count", `Int (List.length runs))
-             ; ("runs", `List (List.map Exact_lane_run_registry.run_to_yojson runs))
-             ]
+         (* Both halves of the cursor or neither: a started_at without its
+            run_id cannot break a tie, and silently paging from a half-given
+            boundary would skip runs recorded in the same float second. *)
+         let before =
+           match
+             ( Option.bind (Server_utils.query_param req "before_started_at") float_of_string_opt
+             , Server_utils.query_param req "before_run_id" )
+           with
+           | Some started_at, Some run_id when not (String.equal (String.trim run_id) "") ->
+             Ok (Some (started_at, run_id))
+           | None, None -> Ok None
+           | _ -> Error "before_started_at and before_run_id must be given together"
          in
-         Http.Response.json_value ~compress:true ~request:req json reqd
+         match before with
+         | Error message -> respond_dashboard_error ~request:req reqd message
+         | Ok before ->
+           let page =
+             Exact_lane_run_registry.recent_runs
+               (Exact_lane_run_registry.global ())
+               ~limit
+               ~before
+           in
+           let json =
+             `Assoc
+               [ ("generated_at", `String (Masc_domain.now_iso ()))
+               ; ("count", `Int (List.length page.runs))
+               ; ("total", `Int page.total)
+               ; ("has_more", `Bool page.has_more)
+               ; ( "runs"
+                 , `List
+                     (List.map Exact_lane_run_registry.run_summary_to_yojson page.runs) )
+               ]
+           in
+           Http.Response.json_value ~compress:true ~request:req json reqd
+       ) request reqd)
+  |> Http.Router.prefix_get "/api/v1/dashboard/exact-lane-runs/" (fun request reqd ->
+       with_token_permission_auth ~permission:exact_lane_run_permission
+         (fun _state _agent_name req reqd ->
+         let run_id =
+           String.length exact_lane_run_detail_prefix
+           |> fun offset ->
+           let target = Uri.path (Uri.of_string req.Httpun.Request.target) in
+           if String.length target <= offset
+           then ""
+           else String.sub target offset (String.length target - offset)
+         in
+         let run_id = Uri.pct_decode run_id in
+         if String.equal (String.trim run_id) ""
+         then respond_dashboard_error ~request:req reqd "run_id is required"
+         else (
+           match
+             Exact_lane_run_registry.get (Exact_lane_run_registry.global ()) ~run_id
+           with
+           | None ->
+             respond_dashboard_error
+               ~status:`Not_found
+               ~request:req
+               reqd
+               ("no retained exact-lane run named " ^ run_id)
+           | Some run ->
+             Http.Response.json_value
+               ~compress:true
+               ~request:req
+               (`Assoc
+                  [ ("generated_at", `String (Masc_domain.now_iso ()))
+                  ; ("run", Exact_lane_run_registry.run_to_yojson run)
+                  ])
+               reqd)
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/workspace" (fun request reqd ->
        with_public_read handle_dashboard_workspace request reqd)

--- a/test/test_exact_lane_run_registry.ml
+++ b/test/test_exact_lane_run_registry.ml
@@ -245,6 +245,74 @@ let test_observation_reads_do_not_wait_for_durable_writer () =
            (read_elapsed_s < 0.2))
 ;;
 
+(* Paging exists because listing everything serialized 5,908 runs to 246 MB on
+   every load. The properties that make a page trustworthy are that it is a
+   total order (so a boundary cannot lose a run) and that a summary carries no
+   payload (so the size that forced paging cannot creep back). *)
+let test_pages_are_a_total_order_over_equal_timestamps () =
+  let registry = R.create () in
+  List.iter
+    (fun run_id ->
+       R.register_running
+         registry
+         ~run_id
+         ~lane:R.Librarian
+         ~subject_id:"trace-1"
+         ~actor:"keeper-a"
+         ~started_at:10.0
+         ~input:(R.Exact_input (`Assoc [ "n", `Int 1 ])))
+    [ "run-a"; "run-b"; "run-c"; "run-d" ];
+  let first = R.recent_runs registry ~limit:2 ~before:None in
+  check int "page size honoured" 2 (List.length first.runs);
+  check int "total counts every retained run, not the page" 4 first.total;
+  check bool "more remains" true first.has_more;
+  let last = List.nth first.runs 1 in
+  let second =
+    R.recent_runs registry ~limit:2 ~before:(Some (last.R.started_at, last.R.run_id))
+  in
+  check int "second page size" 2 (List.length second.runs);
+  check bool "no more after the last page" false second.has_more;
+  let ids page = List.map (fun (run : R.run) -> run.R.run_id) page in
+  let seen = ids first.runs @ ids second.runs in
+  check int "every run appears exactly once across pages" 4 (List.length (List.sort_uniq String.compare seen));
+  check
+    (list string)
+    "identical started_at is ordered by run_id, newest first"
+    [ "run-d"; "run-c"; "run-b"; "run-a" ]
+    seen
+;;
+
+let test_summary_carries_no_payload () =
+  let registry = R.create () in
+  R.register_running
+    registry
+    ~run_id:"run-1"
+    ~lane:R.Librarian
+    ~subject_id:"trace-1"
+    ~actor:"keeper-a"
+    ~started_at:10.0
+    ~input:(R.Exact_input (`Assoc [ "conversation_history", `String "…megabytes…" ]));
+  mark_completed_exn
+    registry
+    ~run_id:"run-1"
+    ~outcome:R.Succeeded
+    ~elapsed_s:0.5
+    ~output:(`Assoc [ "fact_count", `Int 3 ]);
+  let run = R.get registry ~run_id:"run-1" |> Option.get in
+  let field name json =
+    match json with
+    | `Assoc fields -> List.assoc_opt name fields
+    | _ -> None
+  in
+  let summary = R.run_summary_to_yojson run in
+  let detail = R.run_to_yojson run in
+  check bool "summary omits input" true (Option.is_none (field "input" summary));
+  check bool "summary omits output" true (Option.is_none (field "output" summary));
+  check bool "detail keeps input" true (Option.is_some (field "input" detail));
+  check bool "detail keeps output" true (Option.is_some (field "output" detail));
+  check bool "summary still identifies the run" true (Option.is_some (field "run_id" summary))
+;;
+
 let () =
   run
     "exact_lane_run_registry"
@@ -260,5 +328,8 @@ let () =
             test_failed_durable_completion_is_explicitly_visible
         ; test_case "observation reads do not wait for durable writer" `Quick
             test_observation_reads_do_not_wait_for_durable_writer
+        ; test_case "pages are a total order over equal timestamps" `Quick
+            test_pages_are_a_total_order_over_equal_timestamps
+        ; test_case "summary carries no payload" `Quick test_summary_carries_no_payload
         ] )
     ]


### PR DESCRIPTION
## 문제

`GET /api/v1/dashboard/exact-lane-runs`가 보존된 **모든 run을 exact payload까지 붙여** 직렬화했습니다.

- 5,908 runs → **246 MB** 응답 (zstd 12.7 MB, zstd 미지원 클라이언트는 279 MB 무압축)
- `internal_agent_runs_changed` SSE 이벤트에 **debounce가 0**이라, 그때마다 전량 재다운로드

크기의 정체는 payload입니다. lane run은 렌더된 프롬프트 전문을 품고 있고, 단일 필드 `registration.input.payload.actual_input.rendered_prompt_variables.conversation_history`가 286MB 저장소의 **136.6 MB**입니다. 그런데 패널은 이 payload를 **펼친 행에서만** 렌더합니다 — 타임스탬프 표를 그리려고 수백 MB를 보내고 있었습니다.

실측된 2차 피해: 같은 페이지를 권한만 바꿔 열면, 이 응답이 200으로 오는 세션에서만 **나머지 요청이 전부 밀립니다**.

| 동시 요청 | Lane List 403일 때 | Lane List 200일 때 |
|---|---|---|
| runtime-probe | 19 ms | 2,397 ms |
| project-snapshot | 6 ms | 3,221 ms |
| briefing | 39 ms | 2,377 ms |

## 변경

**1. 목록은 페이지 + payload 없음**

`recent_runs ~limit ~before`가 호출자의 (started_at, run_id)보다 엄격히 오래된 run을 최대 `limit`개 반환합니다.

- 커서는 **호출자 자신의 마지막 행**이지 서버 상태가 아닙니다 (RFC-0228 §2 원칙 2: *"No cursors. `before` is a caller-supplied argument, not server state."*)
- `run_id` tie-break가 있어 **같은 float 초에 기록된 run들이 페이지 경계를 가로지를 수 없습니다**
- 커서를 반쪽만 주면 페이징하지 않고 거부합니다 — 정렬할 수 없는 경계에서 조용히 건너뛰는 것보다 낫습니다

**2. 펼칠 때 그 run만 가져옴 (Lazy Load)**

`GET /api/v1/dashboard/exact-lane-runs/<run_id>` 신설. `ExactRunDetail`이 mount 시 fetch하므로 **아무도 열지 않은 run은 한 바이트도 내려오지 않습니다.**

## 측정 (동일 코퍼스 300MB / 5,955 runs, 격리 base-path)

| | before | after |
|---|---|---|
| 목록 `limit=50` | 246 MB · 0.93~1.61 s | **12,992 B · 0.003 s** |
| 커서 2페이지 | — | 0.019 s, 겹침 0건 |
| run 1건 열기 | (목록에 포함됨) | 0.018 s, input 12,650 B |

payload 약 **19,000배** 감소.

```
count=50 total=5955 has_more=True
첫 행 키: ['actor','elapsed_s','lane','run_id','started_at','status','subject_id']
```

## 호환성

`list_runs`는 그대로 두었습니다 (conformance 하네스가 씁니다). 페이징은 **교체가 아니라 새 진입점**이라, 전체 프로젝션을 원하던 호출자가 조용히 페이지를 받는 일은 없습니다.

## 테스트

레지스트리 테스트 2건 추가 — 페이지를 믿을 수 있게 하는 두 성질을 고정합니다.

1. `started_at`이 **완전히 동일한** run 4개가 유실·중복 없이 페이징되고, 순서가 `run_id` 역순으로 확정됨
2. summary 인코더는 `input`/`output` 둘 다 없고, detail 인코더는 둘 다 있음 — 페이징을 강제했던 크기가 다시 기어들어오지 못하게

- `test_exact_lane_run_registry.exe` 9/9 통과
- `test_compaction_exact_output_conformance.exe` 15/15 통과 (`list_runs` 소비자)
- `dashboard-exact-lane-runs.test.ts` 8/8, `internal-agents-monitor.test.ts` 6/6
- `tsc --noEmit` 통과

프론트 테스트도 계약 분리에 맞춰 재구성했습니다: 목록 행에 payload가 있으면 거부하는 케이스를 넣고, research input 거부 테스트는 이제 payload를 실제로 보는 detail 파서로 옮겼습니다.

## 남은 것 (이 PR 밖)

- `debounceMs: 0` — 이 PR로 재요청 비용이 246MB에서 13KB로 떨어지므로 **단독으로 디바운스를 올리면 안 됩니다**. 그건 원인이 아니라 증상 억제였습니다.
- 레코드에 대화 전문을 **복사**하는 것 자체 (SSOT 위반, 저장소 286MB의 47.7%) — 별도 RFC 필요
- 저장소 날짜 파티셔닝 (`tool_calls/`, `costs/` 규약) — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
