### PR TITLE
perf(server): repository 목록에서 git 서브프로세스 제거 (4.0~7.5s → 0.0008s)

### DIFF
--- a/dashboard/src/api/repositories.ts
+++ b/dashboard/src/api/repositories.ts
@@ -141,6 +141,18 @@ export async function fetchRepositoriesList(opts: GetOptions = {}): Promise<Repo
   return repositoryRows(raw).map(normalizeRepository).filter((r): r is Repository => r !== null)
 }
 
+// git_status and sync_currency each cost a subprocess against the working
+// tree, so the list no longer carries them; this asks for one repository's
+// observation. The status bar shows one repository, which is why listing five
+// of them used to run ten git processes on every load.
+export async function fetchRepositoryObservation(
+  id: string,
+  opts: GetOptions = {},
+): Promise<Repository | null> {
+  const raw = await get<unknown>(`/api/v1/repositories/${encodeURIComponent(id)}`, opts)
+  return normalizeRepository(raw)
+}
+
 export async function discoverRepositories(): Promise<Repository[]> {
   const raw = await post<unknown>('/api/v1/repositories/discover', {})
   return repositoryRows(raw).map(normalizeRepository).filter((r): r is Repository => r !== null)

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -3,19 +3,26 @@ import { h } from 'preact'
 import { render } from 'preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
 
+const repositoryRow = {
+  id: 'masc',
+  name: 'masc',
+  url: '',
+  local_path: '/workspace/masc',
+  default_branch: 'main',
+  status: 'active',
+  auto_sync: false,
+  sync_interval: 300,
+  created_at: null,
+  updated_at: null,
+}
+
+// The list carries no git state; the status bar asks for the repository it
+// shows, which is the whole point of the split.
 vi.mock('../../api/repositories', () => ({
   discoverRepositories: vi.fn(() => Promise.resolve([])),
-  fetchRepositoriesList: vi.fn(() => Promise.resolve([{
-    id: 'masc',
-    name: 'masc',
-    url: '',
-    local_path: '/workspace/masc',
-    default_branch: 'main',
-    status: 'active',
-    auto_sync: false,
-    sync_interval: 300,
-    created_at: null,
-    updated_at: null,
+  fetchRepositoriesList: vi.fn(() => Promise.resolve([repositoryRow])),
+  fetchRepositoryObservation: vi.fn(() => Promise.resolve({
+    ...repositoryRow,
     git_status: {
       state: 'available',
       source: 'git-status-porcelain-v1',
@@ -26,7 +33,7 @@ vi.mock('../../api/repositories', () => ({
       untracked_files: 1,
       conflicted_files: 0,
     },
-  }])),
+  })),
 }))
 
 vi.mock('./ide-conversation-rail', () => ({

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -54,7 +54,7 @@ import { keepers } from '../../store'
 import { dashboardBearerToken } from '../../api/core'
 import { devTokenBootstrapStatus } from '../../api/dev-token'
 import { dashboardWsReady } from '../../dashboard-ws-state'
-import type { Repository } from '../../api/repositories'
+import { fetchRepositoryObservation, type Repository } from '../../api/repositories'
 import type { WorkspaceSource } from '../../api/workspace-source'
 import { KeeperBadge } from '../keeper-badge'
 import type { WorkspaceFetchIssue } from './ide-data-workspace-store'
@@ -802,8 +802,34 @@ function IdeCursorRailRow({ cursor }: { readonly cursor: KeeperCursor }) {
  * keeper-v2 `.ide-repo` / `.ide-remote` / `.ide-web` / `.br` skin classes.
  *
  */
-function repositoryGitStatusView(repository: Repository) {
-  const status = repository.git_status
+// The repository list carries no git state — deriving it is two subprocesses
+// per repository — so the status bar asks for the one repository it shows.
+// Nothing is spent on the four repositories nobody is looking at.
+function RepositoryGitStatus({ repositoryId }: { readonly repositoryId: string }) {
+  const [status, setStatus] = useState<Repository['git_status']>(undefined)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setStatus(undefined)
+    fetchRepositoryObservation(repositoryId, { signal: controller.signal })
+      .then(repository => {
+        if (controller.signal.aborted) return
+        setStatus(repository?.git_status ?? null)
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return
+        setStatus(null)
+      })
+    return () => controller.abort()
+  }, [repositoryId])
+
+  if (status === undefined) {
+    return html`<span data-state="loading" title="git status --porcelain=v1 조회 중">변경 확인 중</span>`
+  }
+  return repositoryGitStatusView(status)
+}
+
+function repositoryGitStatusView(status: Repository['git_status']) {
   if (!status) {
     return html`<span data-state="missing" title="repository git_status 필드 미수신">변경 상태 없음</span>`
   }
@@ -875,7 +901,7 @@ function IdeRepoOrigin({
         : null}
       ${branch ? html`<span class="br" title="기본 브랜치 (default_branch)">${branch}</span>` : null}
       ${' · '}
-      ${repositoryGitStatusView(repository)}
+      <${RepositoryGitStatus} repositoryId=${repository.id} />
     </span>
   `
 }

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -24,9 +24,14 @@ let handle_repository_observation_snapshot ~sw:_ ~clock request reqd =
         (`Assoc [ "ok", `Bool false; "error", `String error ])
         inner_reqd
     | Ok repos ->
+      (* Each repository's observation is two git subprocesses, and they do not
+         depend on one another, so the snapshot costs the slowest repository
+         rather than the sum of all of them. Sequentially this was 1.4-2.2 s for
+         2.9 KB. *)
       let repo_list =
-        List.map
-          (Server_routes_http_routes_repositories.repository_json ~base_path)
+        Eio.Fiber.List.map
+          (Server_routes_http_routes_repositories.repository_observation_json
+             ~base_path)
           repos
       in
       let snapshot =

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -101,8 +101,6 @@ let repository_json ~base_path (repo : Repo_manager_types.repository) =
       ("sync_interval", `Int repo.sync_interval);
       ("created_at", timestamp_json repo.created_at);
       ("updated_at", timestamp_json repo.updated_at);
-      ("git_status", git_status_json ~base_path repo);
-      ("sync_currency", sync_currency_json ~base_path repo);
     ]
   in
   let fields =
@@ -111,6 +109,23 @@ let repository_json ~base_path (repo : Repo_manager_types.repository) =
     | Some msg -> ("error_message", `String msg) :: fields
   in
   `Assoc fields
+
+(* The same repository, plus what only git can answer: whether the working tree
+   is dirty and how far it has drifted from its remote. Each of those is a
+   subprocess, so this is the shape a caller asks for one repository at a time —
+   never the shape a list is built from. Listing five registered repositories
+   used to run ten git processes and take 4.0-5.5 s to return 2.8 KB, on every
+   request, uncached; the dashboard needs this state for the one repository in
+   its status bar. *)
+let repository_observation_json ~base_path (repo : Repo_manager_types.repository) =
+  let git_fields =
+    [ ("git_status", git_status_json ~base_path repo)
+    ; ("sync_currency", sync_currency_json ~base_path repo)
+    ]
+  in
+  match repository_json ~base_path repo with
+  | `Assoc fields -> `Assoc (fields @ git_fields)
+  | other -> other
 
 let branch_json ~default_branch name =
   let remote_prefix = "remotes/" in
@@ -275,7 +290,8 @@ let handle_get_repository state id req reqd =
   match Repo_store.find ~base_path id with
   | Error msg -> json_response ~status:`Not_found req reqd (json_error msg)
   | Ok repo ->
-      Http.Response.json_value ~request:req (repository_json ~base_path repo) reqd
+      Http.Response.json_value ~request:req
+        (repository_observation_json ~base_path repo) reqd
 
 let handle_list_branches state id req reqd =
   let base_path = base_path_of_state state in

--- a/lib/server/server_routes_http_routes_repositories.mli
+++ b/lib/server/server_routes_http_routes_repositories.mli
@@ -11,7 +11,14 @@
     The repository JSON projection is shared so adjacent read-only dashboard
     surfaces cannot drift from the public repository API shape. *)
 
+(** Registry facts only. Deriving none of it runs a subprocess, so a list of
+    repositories costs what reading the registry costs. *)
 val repository_json :
+  base_path:string -> Repo_manager_types.repository -> Yojson.Safe.t
+
+(** {!repository_json} plus [git_status] and [sync_currency], each of which is
+    a git subprocess against the working tree. For one repository at a time. *)
+val repository_observation_json :
   base_path:string -> Repo_manager_types.repository -> Yojson.Safe.t
 
 val add_routes :


### PR DESCRIPTION
## 문제

`GET /api/v1/repositories`가 **JSON 인코더 안에서** repo마다 git 서브프로세스 2개를 돌렸습니다.

```ocaml
("git_status",    git_status_json ~base_path repo)    (* git status --porcelain *)
("sync_currency", sync_currency_json ~base_path repo) (* git rev-list --left-right --count *)
```

repo 5개 × 2 = **요청당 10개 서브프로세스**, 캐시 없음. 2.8 KB 응답에 **4.05~7.50초**가 걸렸고 매 호출 반복됐습니다. git 자체 원가는 1.75초이고, 나머지는 spawn 오버헤드를 10번 지불한 값입니다.

`/api/v1/dashboard/repository-observation-snapshot`도 **같은 인코더**를 불러 같은 10개를 또 돌렸습니다 (자기 몫 2.9 KB를 위해).

그런데 대시보드가 이 상태를 보여주는 대상은 **IDE 상태바의 repo 하나**입니다. 전부를, 두 번, 매 로드마다 계산하고 있었습니다.

## 변경

- `repository_json` — 레지스트리 사실만. 어느 필드도 서브프로세스를 띄우지 않습니다.
- `repository_observation_json` — 위 + `git_status` + `sync_currency`. `GET /api/v1/repositories/<id>`가 이걸 서빙합니다 (한 번에 repo 하나).
- **상태바는 자기가 표시하는 repo만 조회합니다.** 아무도 안 보는 repo에는 한 푼도 쓰지 않습니다.
- 스냅샷 라우트는 여전히 전체를 보고하되 `Eio.Fiber.List`로 병렬 관측합니다 — 각 repo의 관측은 서로 의존하지 않으므로, **합**이 아니라 **가장 느린 하나**만큼 듭니다.

## 측정 (격리 base-path, 등록 repo 4개)

| | before | after |
|---|---|---|
| `GET /api/v1/repositories` | 4.05~7.50 s | **0.0008 s** |
| `GET /api/v1/repositories/<id>` | — | 0.127~0.244 s (git 비용, 요청한 자리에서) |
| `repository-observation-snapshot` | 1.40~2.34 s | **0.263~0.300 s** |

목록 응답 키에 git 필드가 없음을 확인:
```
['aliases','auto_sync','created_at','default_branch','id','keepers',
 'local_path','name','status','sync_interval','updated_at','url']
```

## UI 영향

프론트 타입은 이미 `git_status?: RepositoryGitStatus | null`로 **선택적**이었습니다. 다만 미수신 시 `변경 상태 없음` placeholder를 그렸으므로, 그대로 두면 회귀입니다. 상태바가 조회 중에는 `변경 확인 중`을 보여주고 응답이 오면 실제 상태를 렌더하도록 바꿨습니다.

## 정직하게 남기는 한계

스냅샷 라우트 0.28 s는 500 ms 예산 안이지만 **3배 느린 환경에서는 0.84 s로 초과**합니다. 지배항은 가장 느린 repo 하나의 git 시간이라 병렬화로 더 줄지 않습니다. 다만 이 라우트는 **대시보드에 소비자가 없습니다**(`rg 'repository-observation-snapshot' dashboard/src/` → 0건). 사용자 경로인 목록 + 단건은 예산 안에 충분히 들어옵니다.

## 테스트

- `repositories.test.ts` + `ide-shell.test.ts` 48/48 통과
- `tsc --noEmit` 통과
- IDE 테스트 mock을 분리된 계약에 맞춰 갱신 — 목록은 git 없이, 상태바는 `fetchRepositoryObservation`으로

## RFC

변경 범위는 `lib/server/` 라우트/인코더와 대시보드이며 `lib/repo_manager/`의 credential·identity 표면은 건드리지 않습니다. `pr-rfc-check.sh` PASS (waiver 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
