### PR TITLE
refactor(keeper): isolate runtime trust decision core

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -4,7 +4,8 @@
  (flags :standard)
  (public_name masc)
  (private_modules
-  keeper_fs_durable_directory)
+  keeper_fs_durable_directory
+  keeper_runtime_trust_snapshot_core)
  (libraries
   mcp_protocol
   mcp_protocol.eio

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -3,6 +3,8 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_runtime_trust_timeline
 
+module Trust_core = Keeper_runtime_trust_snapshot_core
+
 (** Short-lived cache for [snapshot_json]. The result is expensive to compute
     (tail-reads decision log, tool-call log, receipts, approval audit, and
     pending approvals) and is requested repeatedly by dashboard renders. The
@@ -161,13 +163,14 @@ let current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
   then None
   else latest_receipt
 
-let runtime_blocker_timeline_ts ~meta ~runtime_blocker_fields latest_receipt =
+let runtime_blocker_timeline_ts ~observed_at_unix ~meta
+    ~runtime_blocker_fields latest_receipt =
   if
     runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
       latest_receipt
     && meta.runtime.usage.last_turn_ts > 0.0
   then meta.runtime.usage.last_turn_ts
-  else Time_compat.now ()
+  else observed_at_unix
 
 let latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
     ~latest_receipt =
@@ -263,12 +266,6 @@ let pending_approval_projection_with_reader
         error = Some error;
       }
 
-let pending_approval_projection ~base_path ~keeper_name =
-  pending_approval_projection_with_reader
-    ~read_pending:
-      Keeper_approval_queue.list_pending_dashboard_json_for_workspace
-    ~base_path ~keeper_name
-
 let approval_queue_attention_of_projection
       ~base_path
       (projection : pending_approval_projection)
@@ -282,54 +279,6 @@ let approval_queue_attention_of_projection
       ; reason = "approval queue projection has no current state"
       }
 
-let disposition_of_snapshot ~pending_approval_projection
-    ~runtime_blocker_fields =
-  let blocker_class = assoc_string_opt "runtime_blocker_class" runtime_blocker_fields in
-  let blocker_summary =
-    assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields
-  in
-  let sandbox_summary =
-    match blocker_summary with
-    | Some summary when String_util.contains_substring_ci summary "sandbox" ->
-        Some ("Alert", "sandbox_violation")
-    | _ -> None
-  in
-  match pending_approval_projection.count with
-  | None -> ("Alert", "approval_queue_unavailable")
-  | Some pending_approval_count when pending_approval_count > 0 ->
-      ("Alert", "pending_operator_decision")
-  | Some _ ->
-    match blocker_class with
-    | Some raw_blocker_class -> (
-      match
-        Keeper_meta_contract.blocker_class_of_serialized_string raw_blocker_class
-      with
-      | Some (Keeper_meta_contract.Runtime_exhausted _) ->
-          ("Alert", "runtime_exhausted")
-      | Some _ | None -> (
-        match sandbox_summary with
-        | Some disposition -> disposition
-        | None -> ("Alert", "critical_block")))
-    | None -> (
-      match sandbox_summary with
-      | Some disposition -> disposition
-      | None -> ("Pass", "healthy"))
-
-let operator_disposition_of_display ~disposition ~disposition_reason =
-  match disposition with
-  | "Pass" -> ("pass", disposition_reason)
-  | "Blocked" | "Pause" -> ("fail_open_next_runtime", disposition_reason)
-  | "Alert" | _ -> ("unknown", disposition_reason)
-
-let display_disposition_of_operator ~operator_disposition
-    ~operator_disposition_reason =
-  Keeper_operator_disposition_display.of_wire ~operator_disposition
-    ~operator_disposition_reason
-
-let display_disposition_requires_attention = function
-  | "Blocked" | "Pause" | "Alert" -> true
-  | _ -> false
-
 let receipt_operator_disposition receipt =
   match
     ( json_string_opt_member "operator_disposition" receipt,
@@ -339,46 +288,44 @@ let receipt_operator_disposition receipt =
   | Some disposition, None -> Some (disposition, "")
   | None, _ -> None
 
-let effective_disposition_fields ~approval_queue_available
-    ~fallback_disposition ~fallback_reason
-    latest_receipt =
-  match
-    if approval_queue_available
-    then Option.bind latest_receipt receipt_operator_disposition
-    else None
-  with
-  | Some (operator_disposition, operator_disposition_reason) ->
-      let disposition, disposition_reason =
-        display_disposition_of_operator ~operator_disposition
-          ~operator_disposition_reason
-      in
-      ( disposition,
-        disposition_reason,
-        operator_disposition,
-        operator_disposition_reason )
-  | None ->
-      let operator_disposition, operator_disposition_reason =
-        operator_disposition_of_display ~disposition:fallback_disposition
-          ~disposition_reason:fallback_reason
-      in
-      ( fallback_disposition,
-        fallback_reason,
-        operator_disposition,
-        operator_disposition_reason )
+let approval_queue_state_of_projection
+    (projection : pending_approval_projection) =
+  match projection.count, projection.error with
+  | Some count, None -> Trust_core.Approval_queue_available count
+  | _, Some _ | None, None -> Trust_core.Approval_queue_unavailable
+;;
 
-let attention_reason_or_disposition ~needs_attention ~disposition_reason
-    attention_fields =
-  match assoc_string_opt "attention_reason" attention_fields with
-  | Some _ as value -> value
-  | None when needs_attention -> Some disposition_reason
-  | None -> None
+let trust_model_of_observations ~pending_approval_projection
+    ~runtime_blocker_fields ~latest_receipt ~latest_next_action
+    ~attention_fields =
+  Trust_core.decide
+    { approval_queue =
+        approval_queue_state_of_projection pending_approval_projection
+    ; runtime_blocker_class =
+        assoc_string_opt "runtime_blocker_class" runtime_blocker_fields
+    ; runtime_blocker_summary =
+        assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields
+    ; receipt_operator_disposition =
+        Option.bind latest_receipt receipt_operator_disposition
+    ; attention_needs_attention =
+        assoc_bool_default "needs_attention" ~default:false attention_fields
+    ; attention_reason = assoc_string_opt "attention_reason" attention_fields
+    ; attention_next_human_action =
+        assoc_string_opt "next_human_action" attention_fields
+    ; terminal_next_human_action = latest_next_action
+    }
+;;
 
-let next_human_action_or_terminal ~needs_attention ~latest_next_action
-    attention_fields =
-  match assoc_string_opt "next_human_action" attention_fields with
-  | Some _ as value -> value
-  | None when needs_attention -> latest_next_action
-  | None -> None
+let trust_model_json_fields (model : Trust_core.t) =
+  [ "disposition", `String model.disposition
+  ; "disposition_reason", `String model.disposition_reason
+  ; "operator_disposition", `String model.operator_disposition
+  ; "operator_disposition_reason", `String model.operator_disposition_reason
+  ; "needs_attention", `Bool model.needs_attention
+  ; "attention_reason", Json_util.string_opt_to_json model.attention_reason
+  ; "next_human_action", Json_util.string_opt_to_json model.next_human_action
+  ]
+;;
 
 let decision_log_persistence_surface = "keeper_runtime_trust_decision_log"
 
@@ -548,11 +495,12 @@ let approval_state_json ~pending_approval_projection
         | None -> `Null );
     ]
 
-let approval_queue_unavailable_timeline_event pending_approval_projection =
+let approval_queue_unavailable_timeline_event ~observed_at_unix
+    pending_approval_projection =
   match pending_approval_projection.error with
   | None -> None
   | Some (error : Keeper_approval_queue.storage_error) ->
-      let ts_unix = Time_compat.now () in
+      let ts_unix = observed_at_unix in
       Some
         (`Assoc
           [
@@ -667,11 +615,12 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
         Json_util.string_opt_to_json (Option.bind latest_receipt (json_string_opt_member "ended_at")) );
     ]
 
-let latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
-    ~latest_tool_call ~latest_approval_audit ~runtime_blocker_fields
-    ~next_human_action =
-  let observed_at_unix =
-    runtime_blocker_timeline_ts ~meta ~runtime_blocker_fields latest_receipt
+let latest_causal_event_summary ~observed_at_unix ~meta ~latest_decision
+    ~latest_receipt ~latest_tool_call ~latest_approval_audit
+    ~runtime_blocker_fields ~next_human_action =
+  let blocker_ts_unix =
+    runtime_blocker_timeline_ts ~observed_at_unix ~meta
+      ~runtime_blocker_fields latest_receipt
   in
   let blocker_observation_only =
     not
@@ -687,7 +636,8 @@ let latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
     Option.bind latest_receipt receipt_timeline_event;
     Option.bind latest_tool_call tool_call_timeline_event;
     Option.bind latest_approval_audit approval_event_timeline_event;
-    blocker_timeline_event ~ts_unix:observed_at_unix ~observed_at_unix
+    blocker_timeline_event ~ts_unix:blocker_ts_unix
+      ~observed_at_unix:blocker_ts_unix
       ~runtime_blocker_fields ?task_id ~goal_ids
       ~trace_id ~next_human_action
       ~observation_only:blocker_observation_only ();
@@ -704,41 +654,50 @@ let approval_audit_rows_or_fail = function
        ^ Keeper_approval.Audit.read_error_to_string error)
 ;;
 
-let summary_json ~(config : Workspace.config) ~(meta : keeper_meta) =
+type raw_observations =
+  { latest_decision : Yojson.Safe.t option
+  ; latest_tool_call : Yojson.Safe.t option
+  ; latest_receipt : Yojson.Safe.t option
+  ; latest_approval_audit : Yojson.Safe.t option
+  ; pending_approval_projection : pending_approval_projection
+  ; runtime_blocker_fields : (string * Yojson.Safe.t) list
+  ; attention_fields : (string * Yojson.Safe.t) list
+  ; observed_at_unix : float
+  }
+
+type raw_snapshot =
+  { observations : raw_observations
+  ; registry_entry : Keeper_registry.registry_entry option
+  ; runtime_contract : Yojson.Safe.t
+  ; recent_tool_call_rows : Yojson.Safe.t list
+  ; recent_approval_audit_rows : Yojson.Safe.t list
+  ; recent_transition_rows : Yojson.Safe.t list
+  }
+
+let collect_raw_observations_with_pending_reader
+    ~(read_pending :
+       base_path:string ->
+       (Yojson.Safe.t list, Keeper_approval_queue.storage_error) result)
+    ~approval_audit_limit ~(config : Workspace.config) ~(meta : keeper_meta) =
   let latest_decision = latest_decision_json ~config ~keeper_name:meta.name in
   let latest_tool_call = latest_tool_call_json ~keeper_name:meta.name in
   let latest_receipt = latest_receipt_json ~config ~keeper_name:meta.name in
+  let recent_approval_audit_rows =
+    Keeper_approval.Audit.read_recent ~base_path:config.base_path
+      ~keeper_name:meta.name ~n:approval_audit_limit ()
+    |> approval_audit_rows_or_fail
+  in
   let latest_approval_audit =
-    match
-      Keeper_approval.Audit.read_recent ~base_path:config.base_path
-        ~keeper_name:meta.name ~n:1 ()
-      |> approval_audit_rows_or_fail
-    with
+    match recent_approval_audit_rows with
     | json :: _ -> Some json
     | [] -> None
   in
   let pending_approval_projection =
-    pending_approval_projection ~base_path:config.base_path
-      ~keeper_name:meta.name
+    pending_approval_projection_with_reader ~read_pending
+      ~base_path:config.base_path ~keeper_name:meta.name
   in
   let runtime_blocker_fields =
     Keeper_status_bridge.runtime_blocker_fields_json config meta
-  in
-  let latest_receipt_for_runtime_state =
-    current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
-      latest_receipt
-  in
-  let latest_terminal_reason =
-    latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
-      ~latest_receipt
-  in
-  let latest_terminal_reason_json =
-    latest_terminal_reason
-    |> Option.map Keeper_turn_terminal.to_json
-    |> Option.value ~default:`Null
-  in
-  let latest_next_action =
-    Option.bind latest_terminal_reason (fun reason -> reason.next_action)
   in
   let attention_fields =
     Keeper_status_bridge.attention_fields_json_with_approval_queue
@@ -748,80 +707,103 @@ let summary_json ~(config : Workspace.config) ~(meta : keeper_meta) =
          ~base_path:config.base_path
          pending_approval_projection)
   in
-  let fallback_disposition, fallback_disposition_reason =
-    disposition_of_snapshot ~pending_approval_projection
-      ~runtime_blocker_fields
+  let observed_at_unix = Time_compat.now () in
+  ( { latest_decision
+    ; latest_tool_call
+    ; latest_receipt
+    ; latest_approval_audit
+    ; pending_approval_projection
+    ; runtime_blocker_fields
+    ; attention_fields
+    ; observed_at_unix
+    }
+  , recent_approval_audit_rows )
+;;
+
+let collect_summary_raw ~(config : Workspace.config) ~(meta : keeper_meta) =
+  collect_raw_observations_with_pending_reader
+    ~read_pending:
+      Keeper_approval_queue.list_pending_dashboard_json_for_workspace
+    ~approval_audit_limit:1 ~config ~meta
+  |> fst
+;;
+
+let summary_json_of_raw ~(meta : keeper_meta) (raw : raw_observations) =
+  let latest_receipt_for_runtime_state =
+    current_receipt_for_runtime_state ~meta
+      ~runtime_blocker_fields:raw.runtime_blocker_fields raw.latest_receipt
   in
-  let disposition, disposition_reason, operator_disposition,
-      operator_disposition_reason =
-    effective_disposition_fields ~fallback_disposition
-      ~approval_queue_available:(Option.is_none pending_approval_projection.error)
-      ~fallback_reason:fallback_disposition_reason
-      latest_receipt_for_runtime_state
+  let latest_terminal_reason =
+    latest_terminal_reason_opt ~meta
+      ~runtime_blocker_fields:raw.runtime_blocker_fields
+      ~latest_decision:raw.latest_decision ~latest_receipt:raw.latest_receipt
   in
-  let needs_attention =
-    assoc_bool_default "needs_attention" ~default:false attention_fields
-    || display_disposition_requires_attention disposition
+  let latest_terminal_reason_json =
+    latest_terminal_reason
+    |> Option.map Keeper_turn_terminal.to_json
+    |> Option.value ~default:`Null
   in
-  let attention_reason =
-    attention_reason_or_disposition ~needs_attention ~disposition_reason
-      attention_fields
+  let latest_next_action =
+    Option.bind latest_terminal_reason (fun reason -> reason.next_action)
   in
-  let next_human_action =
-    next_human_action_or_terminal ~needs_attention ~latest_next_action
-      attention_fields
+  let trust_model =
+    trust_model_of_observations
+      ~pending_approval_projection:raw.pending_approval_projection
+      ~runtime_blocker_fields:raw.runtime_blocker_fields
+      ~latest_receipt:latest_receipt_for_runtime_state
+      ~latest_next_action ~attention_fields:raw.attention_fields
   in
   let execution_summary =
-    execution_summary_json ~meta ~latest_receipt
+    execution_summary_json ~meta ~latest_receipt:raw.latest_receipt
   in
   let approval_state =
-    approval_state_json ~pending_approval_projection ~latest_approval_audit
+    approval_state_json
+      ~pending_approval_projection:raw.pending_approval_projection
+      ~latest_approval_audit:raw.latest_approval_audit
   in
   let latest_causal_event =
     match
-      approval_queue_unavailable_timeline_event pending_approval_projection
+      approval_queue_unavailable_timeline_event
+        ~observed_at_unix:raw.observed_at_unix
+        raw.pending_approval_projection
     with
     | Some event -> event
     | None ->
-        latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
-          ~latest_tool_call ~latest_approval_audit
-          ~runtime_blocker_fields ~next_human_action
+        latest_causal_event_summary ~observed_at_unix:raw.observed_at_unix
+          ~meta ~latest_decision:raw.latest_decision
+          ~latest_receipt:raw.latest_receipt
+          ~latest_tool_call:raw.latest_tool_call
+          ~latest_approval_audit:raw.latest_approval_audit
+          ~runtime_blocker_fields:raw.runtime_blocker_fields
+          ~next_human_action:trust_model.next_human_action
   in
   `Assoc
-    [
-      ("disposition", `String disposition);
-      ("disposition_reason", `String disposition_reason);
-      ("operator_disposition", `String operator_disposition);
-      ("operator_disposition_reason", `String operator_disposition_reason);
-      ("needs_attention", `Bool needs_attention);
-      ("attention_reason", Json_util.string_opt_to_json attention_reason);
-      ("next_human_action", Json_util.string_opt_to_json next_human_action);
-      ("approval_queue_state", pending_approval_projection.state);
-      ("approval", approval_state);
-      ("execution", execution_summary);
-      ("latest_terminal_reason", latest_terminal_reason_json);
-      ("latest_next_action", Json_util.string_opt_to_json latest_next_action);
-      ("latest_causal_event", latest_causal_event);
-    ]
+    (trust_model_json_fields trust_model
+     @ [ ("approval_queue_state", raw.pending_approval_projection.state)
+       ; ("approval", approval_state)
+       ; ("execution", execution_summary)
+       ; ("latest_terminal_reason", latest_terminal_reason_json)
+       ; ("latest_next_action", Json_util.string_opt_to_json latest_next_action)
+       ; ("latest_causal_event", latest_causal_event)
+       ])
 
-let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
-    ~latest_tool_call ~latest_approval_audit ~runtime_blocker_fields
-    ~next_human_action ~pending_approval_projection =
+let summary_json ~(config : Workspace.config) ~(meta : keeper_meta) =
+  collect_summary_raw ~config ~meta |> summary_json_of_raw ~meta
+;;
+
+let causal_timeline_json ~observed_at_unix ~recent_tool_call_rows
+    ~recent_approval_audit_rows ~recent_transition_rows ~meta
+    ~latest_decision ~latest_receipt ~latest_tool_call
+    ~latest_approval_audit ~runtime_blocker_fields ~next_human_action
+    ~pending_approval_projection =
   let tool_events =
-    Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:6 ()
-    |> List.filter_map tool_call_timeline_event
+    List.filter_map tool_call_timeline_event recent_tool_call_rows
   in
   let approval_events =
-    Keeper_approval.Audit.read_recent ~base_path ~keeper_name:meta.name
-      ~n:8 ()
-    |> approval_audit_rows_or_fail
-    |> List.filter_map approval_event_timeline_event
+    List.filter_map approval_event_timeline_event recent_approval_audit_rows
   in
   let transition_events =
-    match Keeper_transition_audit.recent_transitions_json
-            ~keeper_name:meta.name ~limit:6 with
-    | `List items -> items |> List.filter_map transition_timeline_event
-    | _ -> []
+    List.filter_map transition_timeline_event recent_transition_rows
   in
   let decision_events =
     (match latest_decision with
@@ -843,8 +825,9 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
     let task_id = Keeper_runtime_contract.current_task_id_opt meta in
     let goal_ids = meta.active_goal_ids in
     let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-    let observed_at_unix =
-      runtime_blocker_timeline_ts ~meta ~runtime_blocker_fields latest_receipt
+    let blocker_ts_unix =
+      runtime_blocker_timeline_ts ~observed_at_unix ~meta
+        ~runtime_blocker_fields latest_receipt
     in
     let blocker_observation_only =
       not
@@ -852,7 +835,8 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
            latest_receipt)
     in
     [
-      blocker_timeline_event ~ts_unix:observed_at_unix ~observed_at_unix
+      blocker_timeline_event ~ts_unix:blocker_ts_unix
+        ~observed_at_unix:blocker_ts_unix
         ~runtime_blocker_fields ?task_id ~goal_ids
         ~trace_id ~next_human_action
         ~observation_only:blocker_observation_only ()
@@ -890,7 +874,7 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
   let approval_queue_state_events =
     List.filter_map Fun.id
       [
-        approval_queue_unavailable_timeline_event
+        approval_queue_unavailable_timeline_event ~observed_at_unix
           pending_approval_projection;
       ]
   in
@@ -903,7 +887,7 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
   |> take 12
   |> fun items -> `List items
 
-let snapshot_json_inner_with_pending_reader
+let collect_raw_snapshot_with_pending_reader
     ~(read_pending :
        base_path:string ->
        (Yojson.Safe.t list, Keeper_approval_queue.storage_error) result)
@@ -911,32 +895,45 @@ let snapshot_json_inner_with_pending_reader
   let registry_entry =
     Keeper_registry.get ~base_path:config.base_path meta.name
   in
-  let latest_decision = latest_decision_json ~config ~keeper_name:meta.name in
-  let latest_tool_call = latest_tool_call_json ~keeper_name:meta.name in
-  let latest_receipt = latest_receipt_json ~config ~keeper_name:meta.name in
-  let latest_approval_audit =
+  let runtime_contract =
+    Keeper_runtime_contract.runtime_observability_contract_json ~config meta
+  in
+  let recent_tool_call_rows =
+    Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:6 ()
+  in
+  let recent_transition_rows =
     match
-      Keeper_approval.Audit.read_recent ~base_path:config.base_path
-        ~keeper_name:meta.name ~n:1 ()
-      |> approval_audit_rows_or_fail
+      Keeper_transition_audit.recent_transitions_json
+        ~keeper_name:meta.name ~limit:6
     with
-    | json :: _ -> Some json
-    | [] -> None
+    | `List items -> items
+    | _ -> []
   in
-  let pending_approval_projection =
-    pending_approval_projection_with_reader ~read_pending
-      ~base_path:config.base_path ~keeper_name:meta.name
+  let observations, recent_approval_audit_rows =
+    collect_raw_observations_with_pending_reader ~read_pending
+      ~approval_audit_limit:8 ~config ~meta
   in
-  let runtime_blocker_fields =
-    Keeper_status_bridge.runtime_blocker_fields_json config meta
-  in
+  { observations
+  ; registry_entry
+  ; runtime_contract
+  ; recent_tool_call_rows
+  ; recent_approval_audit_rows
+  ; recent_transition_rows
+  }
+;;
+
+let snapshot_json_of_raw ~(meta : keeper_meta) (raw : raw_snapshot) =
+  let observations = raw.observations in
   let latest_receipt_for_runtime_state =
-    current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
-      latest_receipt
+    current_receipt_for_runtime_state ~meta
+      ~runtime_blocker_fields:observations.runtime_blocker_fields
+      observations.latest_receipt
   in
   let latest_terminal_reason =
-    latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
-      ~latest_receipt
+    latest_terminal_reason_opt ~meta
+      ~runtime_blocker_fields:observations.runtime_blocker_fields
+      ~latest_decision:observations.latest_decision
+      ~latest_receipt:observations.latest_receipt
   in
   let latest_terminal_reason_json =
     latest_terminal_reason
@@ -947,114 +944,111 @@ let snapshot_json_inner_with_pending_reader
     Option.bind latest_terminal_reason (fun reason -> reason.next_action)
   in
   let selected_model =
-    selected_model_of_latest_decision_or_receipt latest_decision latest_receipt
-  in
-  let attention_fields =
-    Keeper_status_bridge.attention_fields_json_with_approval_queue
-      config
-      meta
-      (approval_queue_attention_of_projection
-         ~base_path:config.base_path
-         pending_approval_projection)
+    selected_model_of_latest_decision_or_receipt observations.latest_decision
+      observations.latest_receipt
   in
   let runtime_phase =
-    match registry_entry with
+    match raw.registry_entry with
     | Some entry -> `String (Keeper_state_machine.phase_to_string entry.phase)
     | None -> `Null
   in
-  let runtime_contract =
-    Keeper_runtime_contract.runtime_observability_contract_json ~config meta
-  in
-  let fallback_disposition, fallback_disposition_reason =
-    disposition_of_snapshot ~pending_approval_projection
-      ~runtime_blocker_fields
-  in
-  let disposition, disposition_reason, operator_disposition,
-      operator_disposition_reason =
-    effective_disposition_fields ~fallback_disposition
-      ~approval_queue_available:(Option.is_none pending_approval_projection.error)
-      ~fallback_reason:fallback_disposition_reason
-      latest_receipt_for_runtime_state
-  in
-  let needs_attention =
-    assoc_bool_default "needs_attention" ~default:false attention_fields
-    || display_disposition_requires_attention disposition
-  in
-  let attention_reason =
-    attention_reason_or_disposition ~needs_attention ~disposition_reason
-      attention_fields
-  in
-  let next_human_action =
-    next_human_action_or_terminal ~needs_attention ~latest_next_action
-      attention_fields
+  let trust_model =
+    trust_model_of_observations
+      ~pending_approval_projection:observations.pending_approval_projection
+      ~runtime_blocker_fields:observations.runtime_blocker_fields
+      ~latest_receipt:latest_receipt_for_runtime_state ~latest_next_action
+      ~attention_fields:observations.attention_fields
   in
   let approval_state =
-    approval_state_json ~pending_approval_projection ~latest_approval_audit
+    approval_state_json
+      ~pending_approval_projection:observations.pending_approval_projection
+      ~latest_approval_audit:observations.latest_approval_audit
   in
   let execution_summary =
-    execution_summary_json ~meta ~latest_receipt
+    execution_summary_json ~meta ~latest_receipt:observations.latest_receipt
   in
   let causal_timeline =
-    causal_timeline_json ~base_path:config.base_path ~meta ~latest_decision
-      ~latest_receipt
-      ~latest_tool_call ~latest_approval_audit
-      ~runtime_blocker_fields ~next_human_action
-      ~pending_approval_projection
+    causal_timeline_json
+      ~observed_at_unix:observations.observed_at_unix
+      ~recent_tool_call_rows:raw.recent_tool_call_rows
+      ~recent_approval_audit_rows:raw.recent_approval_audit_rows
+      ~recent_transition_rows:raw.recent_transition_rows ~meta
+      ~latest_decision:observations.latest_decision
+      ~latest_receipt:observations.latest_receipt
+      ~latest_tool_call:observations.latest_tool_call
+      ~latest_approval_audit:observations.latest_approval_audit
+      ~runtime_blocker_fields:observations.runtime_blocker_fields
+      ~next_human_action:trust_model.next_human_action
+      ~pending_approval_projection:observations.pending_approval_projection
   in
   let latest_causal_event =
     latest_causal_from_timeline causal_timeline
   in
   `Assoc
-    [
-      ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
-      ("generation", `Int meta.runtime.nonce);
-      ( "turn_id",
-        match
-          latest_turn_id ~registry_entry ~latest_decision ~latest_tool_call
-            ~latest_receipt
-        with
-        | Some turn_id -> `Int turn_id
-        | None -> `Null );
-      ("phase", runtime_phase);
-      ("raw_phase", runtime_phase);
-      ("current_task_id", Json_util.string_opt_to_json (Keeper_runtime_contract.current_task_id_opt meta));
-      ("goal_id", Json_util.string_opt_to_json (Keeper_runtime_contract.primary_goal_id_opt meta));
-      ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
-      ("active_model", Json_util.string_opt_to_json selected_model);
-      ("selected_model", Json_util.string_opt_to_json selected_model);
-      ("runtime_contract", runtime_contract);
-      ("runtime_blockers", `Assoc runtime_blocker_fields);
-      ("disposition", `String disposition);
-      ("disposition_reason", `String disposition_reason);
-      ("operator_disposition", `String operator_disposition);
-      ("operator_disposition_reason", `String operator_disposition_reason);
-      ("needs_attention", `Bool needs_attention);
-      ("attention_reason", Json_util.string_opt_to_json attention_reason);
-      ("next_human_action", Json_util.string_opt_to_json next_human_action);
-      ("approval_queue_state", pending_approval_projection.state);
-      ("approval", approval_state);
-      ("execution", execution_summary);
-      ("latest_terminal_reason", latest_terminal_reason_json);
-      ("latest_next_action", Json_util.string_opt_to_json latest_next_action);
-      ( "pending_approval_count",
-        match pending_approval_projection.count with
-        | Some count -> `Int count
-        | None -> `Null );
-      ( "pending_approvals",
-        match pending_approval_projection.entries with
-        | Some entries -> `List entries
-        | None -> `Null );
-      ("latest_decision", Option.value ~default:`Null latest_decision);
-      ("latest_tool_call", Option.value ~default:`Null latest_tool_call);
-      ("latest_receipt", Option.value ~default:`Null latest_receipt);
-      ("latest_causal_event", latest_causal_event);
-      ("causal_timeline", causal_timeline);
-      ( "last_event_bus_correlation",
-        match registry_entry with
-        | Some entry ->
-            Json_util.string_opt_to_json entry.last_event_bus_correlation
-        | None -> `Null );
-    ]
+    ([ ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id))
+     ; ("generation", `Int meta.runtime.nonce)
+     ; ( "turn_id"
+       , match
+           latest_turn_id ~registry_entry:raw.registry_entry
+             ~latest_decision:observations.latest_decision
+             ~latest_tool_call:observations.latest_tool_call
+             ~latest_receipt:observations.latest_receipt
+         with
+         | Some turn_id -> `Int turn_id
+         | None -> `Null )
+     ; ("phase", runtime_phase)
+     ; ("raw_phase", runtime_phase)
+     ; ( "current_task_id"
+       , Json_util.string_opt_to_json
+           (Keeper_runtime_contract.current_task_id_opt meta) )
+     ; ( "goal_id"
+       , Json_util.string_opt_to_json
+           (Keeper_runtime_contract.primary_goal_id_opt meta) )
+     ; ( "goal_ids"
+       , `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids) )
+     ; ("active_model", Json_util.string_opt_to_json selected_model)
+     ; ("selected_model", Json_util.string_opt_to_json selected_model)
+     ; ("runtime_contract", raw.runtime_contract)
+     ; ("runtime_blockers", `Assoc observations.runtime_blocker_fields)
+     ]
+     @ trust_model_json_fields trust_model
+     @ [ ("approval_queue_state", observations.pending_approval_projection.state)
+       ; ("approval", approval_state)
+       ; ("execution", execution_summary)
+       ; ("latest_terminal_reason", latest_terminal_reason_json)
+       ; ("latest_next_action", Json_util.string_opt_to_json latest_next_action)
+       ; ( "pending_approval_count"
+         , match observations.pending_approval_projection.count with
+           | Some count -> `Int count
+           | None -> `Null )
+       ; ( "pending_approvals"
+         , match observations.pending_approval_projection.entries with
+           | Some entries -> `List entries
+           | None -> `Null )
+       ; ( "latest_decision"
+         , Option.value ~default:`Null observations.latest_decision )
+       ; ( "latest_tool_call"
+         , Option.value ~default:`Null observations.latest_tool_call )
+       ; ( "latest_receipt"
+         , Option.value ~default:`Null observations.latest_receipt )
+       ; ("latest_causal_event", latest_causal_event)
+       ; ("causal_timeline", causal_timeline)
+       ; ( "last_event_bus_correlation"
+         , match raw.registry_entry with
+           | Some entry ->
+               Json_util.string_opt_to_json entry.last_event_bus_correlation
+           | None -> `Null )
+       ])
+;;
+
+let snapshot_json_inner_with_pending_reader
+    ~(read_pending :
+       base_path:string ->
+       (Yojson.Safe.t list, Keeper_approval_queue.storage_error) result)
+    ~(config : Workspace.config) ~(meta : keeper_meta) =
+  collect_raw_snapshot_with_pending_reader ~read_pending ~config ~meta
+  |> snapshot_json_of_raw ~meta
+;;
 
 let snapshot_json_inner ~(config : Workspace.config) ~(meta : keeper_meta) =
   snapshot_json_inner_with_pending_reader

--- a/lib/keeper/keeper_runtime_trust_snapshot_core.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot_core.ml
@@ -1,0 +1,119 @@
+type approval_queue =
+  | Approval_queue_available of int
+  | Approval_queue_unavailable
+
+type raw =
+  { approval_queue : approval_queue
+  ; runtime_blocker_class : string option
+  ; runtime_blocker_summary : string option
+  ; receipt_operator_disposition : (string * string) option
+  ; attention_needs_attention : bool
+  ; attention_reason : string option
+  ; attention_next_human_action : string option
+  ; terminal_next_human_action : string option
+  }
+
+type t =
+  { disposition : string
+  ; disposition_reason : string
+  ; operator_disposition : string
+  ; operator_disposition_reason : string
+  ; needs_attention : bool
+  ; attention_reason : string option
+  ; next_human_action : string option
+  }
+
+let fallback_disposition raw =
+  let sandbox_summary =
+    match raw.runtime_blocker_summary with
+    | Some summary when String_util.contains_substring_ci summary "sandbox" ->
+      Some ("Alert", "sandbox_violation")
+    | Some _ | None -> None
+  in
+  match raw.approval_queue with
+  | Approval_queue_unavailable -> "Alert", "approval_queue_unavailable"
+  | Approval_queue_available pending_approval_count when pending_approval_count > 0 ->
+    "Alert", "pending_operator_decision"
+  | Approval_queue_available _ ->
+    (match raw.runtime_blocker_class with
+     | Some raw_blocker_class ->
+       (match
+          Keeper_meta_contract.blocker_class_of_serialized_string raw_blocker_class
+        with
+        | Some (Keeper_meta_contract.Runtime_exhausted _) ->
+          "Alert", "runtime_exhausted"
+        | Some _ | None ->
+          (match sandbox_summary with
+           | Some disposition -> disposition
+           | None -> "Alert", "critical_block"))
+     | None ->
+       (match sandbox_summary with
+        | Some disposition -> disposition
+        | None -> "Pass", "healthy"))
+;;
+
+let operator_disposition_of_display ~disposition ~disposition_reason =
+  match disposition with
+  | "Pass" -> "pass", disposition_reason
+  | "Blocked" | "Pause" -> "fail_open_next_runtime", disposition_reason
+  | "Alert" | _ -> "unknown", disposition_reason
+;;
+
+let display_disposition_requires_attention = function
+  | "Blocked" | "Pause" | "Alert" -> true
+  | _ -> false
+;;
+
+let effective_disposition raw ~fallback_disposition ~fallback_reason =
+  match raw.approval_queue, raw.receipt_operator_disposition with
+  | Approval_queue_available _, Some (operator_disposition, operator_reason) ->
+    let disposition, disposition_reason =
+      Keeper_operator_disposition_display.of_wire
+        ~operator_disposition
+        ~operator_disposition_reason:operator_reason
+    in
+    disposition, disposition_reason, operator_disposition, operator_reason
+  | Approval_queue_unavailable, _
+  | Approval_queue_available _, None ->
+    let operator_disposition, operator_disposition_reason =
+      operator_disposition_of_display
+        ~disposition:fallback_disposition
+        ~disposition_reason:fallback_reason
+    in
+    ( fallback_disposition
+    , fallback_reason
+    , operator_disposition
+    , operator_disposition_reason )
+;;
+
+let decide raw =
+  let fallback_disposition, fallback_reason = fallback_disposition raw in
+  let disposition, disposition_reason, operator_disposition,
+      operator_disposition_reason =
+    effective_disposition raw ~fallback_disposition ~fallback_reason
+  in
+  let needs_attention =
+    raw.attention_needs_attention
+    || display_disposition_requires_attention disposition
+  in
+  let attention_reason =
+    match raw.attention_reason with
+    | Some _ as reason -> reason
+    | None when needs_attention -> Some disposition_reason
+    | None -> None
+  in
+  let next_human_action =
+    match raw.attention_next_human_action with
+    | Some _ as action -> action
+    | None when needs_attention -> raw.terminal_next_human_action
+    | None -> None
+  in
+  { disposition
+  ; disposition_reason
+  ; operator_disposition
+  ; operator_disposition_reason
+  ; needs_attention
+  ; attention_reason
+  ; next_human_action
+  }
+;;

--- a/lib/keeper/keeper_runtime_trust_snapshot_core.mli
+++ b/lib/keeper/keeper_runtime_trust_snapshot_core.mli
@@ -1,0 +1,34 @@
+(** Pure trust decision for one already-collected Keeper runtime snapshot.
+
+    This module does no I/O, time observation, logging, or synchronization.
+    The effect shell decodes external JSON/options into [raw], calls [decide]
+    once, and projects the returned model at the HTTP/dashboard boundary. *)
+
+type approval_queue =
+  | Approval_queue_available of int
+  | Approval_queue_unavailable
+
+type raw =
+  { approval_queue : approval_queue
+  ; runtime_blocker_class : string option
+  ; runtime_blocker_summary : string option
+  ; receipt_operator_disposition : (string * string) option
+  ; attention_needs_attention : bool
+  ; attention_reason : string option
+  ; attention_next_human_action : string option
+  ; terminal_next_human_action : string option
+  }
+
+type t =
+  { disposition : string
+  ; disposition_reason : string
+  ; operator_disposition : string
+  ; operator_disposition_reason : string
+  ; needs_attention : bool
+  ; attention_reason : string option
+  ; next_human_action : string option
+  }
+
+val decide : raw -> t
+(** Resolve the display/operator disposition and attention contract exactly
+    once from immutable observations. *)

--- a/lib/parse_outcome/parse_outcome.ml
+++ b/lib/parse_outcome/parse_outcome.ml
@@ -37,8 +37,3 @@ let map (f : 'a -> 'b) (o : 'a t) : 'b t =
   match o with
   | Ok x -> Ok (f x)
   | Error _ as e -> e
-
-let to_option (o : 'a t) : 'a option =
-  match o with
-  | Ok x -> Some x
-  | Error _ -> None

--- a/lib/parse_outcome/parse_outcome.mli
+++ b/lib/parse_outcome/parse_outcome.mli
@@ -47,8 +47,3 @@ val bind : 'a t -> ('a -> 'b t) -> 'b t
 
 val map : ('a -> 'b) -> 'a t -> 'b t
 (** Functorial map over [Ok]. *)
-
-val to_option : 'a t -> 'a option
-(** [to_option o] discards the error payload.
-    Provided as a *migration shim* for sites that currently return
-    [option] — new code should pattern-match on the [error] instead. *)

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -61,7 +61,7 @@ let quota_scope_of_materialized
   Runtime_quota_window.scope_of_credential ~provider_id:provider.id credential
 ;;
 
-let of_binding_result (cfg : config) (b : binding) : (t, string) result =
+let of_binding (cfg : config) (b : binding) : (t, string) result =
   if not b.enabled
   then Error "binding is disabled by runtime.toml"
   else match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
@@ -82,12 +82,6 @@ let of_binding_result (cfg : config) (b : binding) : (t, string) result =
        | Error reason -> Error reason)
   | None, _ -> Error (Printf.sprintf "provider not found: %s" b.provider_id)
   | Some _, None -> Error (Printf.sprintf "model not found: %s" b.model_id)
-;;
-
-(** {!of_binding_result} 의 option 투영. materialize 실패 이유가 필요 없는
-    호출자(단일 binding 성공 여부만 확인)를 위한 유지 API. *)
-let of_binding (cfg : config) (b : binding) : t option =
-  Result.to_option (of_binding_result cfg b)
 ;;
 
 let is_local_provider (provider : provider) =
@@ -115,7 +109,7 @@ let partition_bindings (cfg : config) (bindings : binding list)
   let runtimes, dropped =
     List.fold_left
       (fun (runtimes, dropped) (b : binding) ->
-         match of_binding_result cfg b with
+         match of_binding cfg b with
          | Ok rt -> rt :: runtimes, dropped
          | Error reason -> runtimes, (id_of_binding b, reason) :: dropped)
       ([], [])
@@ -1377,7 +1371,7 @@ let provider_id_of_runtime_id (id : string) : string option =
   | None -> None
 ;;
 
-(* Reads the scope frozen at materialization ({!of_binding_result}); no
+(* Reads the scope frozen at materialization ({!of_binding}); no
    environment access here, so a post-load env change cannot re-select the
    credential alias out from under the recorded window. *)
 let quota_scope_of_runtime (rt : t) : Runtime_quota_window.scope =

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -22,11 +22,11 @@ type t =
   }
 
 val id_of_binding : binding -> string
-val of_binding : config -> binding -> t option
-
-(** Reason-preserving form of {!of_binding}. [Error reason] when the binding's
-    provider/model id is unresolved or the provider transport/protocol cannot be
-    materialized into a {!Llm_provider.Provider_config.t} (e.g. a [messages-http]
+val of_binding : config -> binding -> (t, string) result
+(** Materialize one binding while preserving failure information. [Error reason]
+    when the binding is disabled, its provider/model id is unresolved, or the
+    provider transport/protocol cannot be materialized into a
+    {!Llm_provider.Provider_config.t} (e.g. a [messages-http]
     provider the runtime adapter has no provider_config path for). The binding is
     still excluded from the runtime list (fail-closed, RFC-0206 §2.1); this
     surfaces *why*, so [\[runtime\].default] / [\[runtime.assignments\]] / lane

--- a/packages/agent_core/lib/llm_provider/exact_output_generation_receipt.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_generation_receipt.ml
@@ -179,19 +179,19 @@ let merge_state current desired =
     in
     Response_received_state { status; provider_trace }
   | Response_received_state current, Terminal_state desired ->
-    let status, provider_trace =
+    let _, provider_trace =
       merge_response_fields
         (current.status, current.provider_trace)
         (Some desired.status, desired.provider_trace)
     in
-    Terminal_state { status = Option.get status; provider_trace }
+    Terminal_state { status = desired.status; provider_trace }
   | Terminal_state current, Terminal_state desired ->
-    let status, provider_trace =
+    let _, provider_trace =
       merge_response_fields
         (Some current.status, current.provider_trace)
         (Some desired.status, desired.provider_trace)
     in
-    Terminal_state { status = Option.get status; provider_trace }
+    Terminal_state { status = desired.status; provider_trace }
   | _ -> desired
 ;;
 

--- a/packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml
@@ -15,6 +15,11 @@ type 'callback_error error =
 
 type connection = [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t
 
+type validated_origin =
+  { uri : Uri.t
+  ; host : string
+  }
+
 let create_dispatch_intent ~commit_fence ~mark_dispatch_started =
   { committed = Atomic.make false
   ; dispatch_started = Atomic.make false
@@ -88,7 +93,7 @@ let validate_uri url =
   try
     let uri = Uri.of_string url in
     match Uri.host uri with
-    | Some host when String.trim host <> "" -> Ok uri
+    | Some host when String.trim host <> "" -> Ok { uri; host }
     | Some _ | None ->
       Error
         (NetworkError
@@ -135,9 +140,8 @@ let https_init_error_network_kind = function
   | Api_common.Ca_certs_unavailable _ | Api_common.Tls_config_unavailable _ -> Tls_error
 ;;
 
-let resolve_origin net uri =
+let resolve_origin net ({ uri; host } : validated_origin) =
   let net = (net :> [ `Generic ] Eio.Net.ty Eio.Resource.t) in
-  let host = Option.get (Uri.host uri) in
   let service =
     match Uri.port uri with
     | Some port -> Int.to_string port
@@ -181,13 +185,13 @@ let resolve_origin net uri =
   Ok (net, addr, tls_wrap)
 ;;
 
-let make_connection ~sw ~net ~uri =
-  let* net, address, tls_wrap = resolve_origin net uri in
+let make_connection ~sw ~net ~origin =
+  let* net, address, tls_wrap = resolve_origin net origin in
   try
     let socket = Eio.Net.connect ~sw net address in
     let connection : connection =
       match tls_wrap with
-      | Some wrap -> (wrap uri socket :> connection)
+      | Some wrap -> (wrap origin.uri socket :> connection)
       | None -> (socket :> connection)
     in
     Ok connection
@@ -236,7 +240,7 @@ let post_sync_once_after_commit
       ~connect_deadline
       ~body_deadline
       ~net
-      ~uri
+      ~origin
       ~header
       ~body
       ~dispatch_intent
@@ -319,7 +323,7 @@ let post_sync_once_after_commit
   let post_result =
     try
       with_headers_deadline (fun () ->
-        let* current = make_connection ~sw ~net ~uri in
+        let* current = make_connection ~sw ~net ~origin in
         connection := Some current;
         let client =
           Cohttp_eio.Client.make_generic (fun ~sw:_ _uri ->
@@ -331,14 +335,19 @@ let post_sync_once_after_commit
         then invalid_arg "exact-output measurement dispatch was already started";
         dispatch_intent.mark_dispatch_started ();
         let response, response_body =
-          Cohttp_eio.Client.post ~sw client ~headers:header ~body:request_body uri
+          Cohttp_eio.Client.post
+            ~sw
+            client
+            ~headers:header
+            ~body:request_body
+            origin.uri
         in
         let response_status =
           Cohttp.Response.status response |> Cohttp.Code.code_of_status
         in
         phase := Response_received;
         status := Some response_status;
-        Ok (response, response_body))
+        Ok (response, response_body, response_status))
     with
     | Eio.Time.Timeout as exn ->
       release_connection ();
@@ -349,7 +358,7 @@ let post_sync_once_after_commit
   | Error error ->
     release_connection ();
     Error (staged_error error)
-  | Ok (response, response_body) ->
+  | Ok (response, response_body, response_status) ->
     let body_result =
       try
         match body_deadline, total_started_at with
@@ -378,7 +387,6 @@ let post_sync_once_after_commit
        release_connection ();
        Error (staged_error error)
      | Ok response_body ->
-       let response_status = Option.get !status in
        let retry_after_header = retry_after_header response in
        release_connection ();
        Ok
@@ -418,7 +426,7 @@ let post_sync_once
      | Ok body_deadline ->
        (match validate_uri url with
         | Error error -> before_dispatch error
-        | Ok uri ->
+        | Ok origin ->
           (match validate_headers_and_body headers body with
            | Error error -> before_dispatch error
            | Ok header ->
@@ -432,7 +440,7 @@ let post_sync_once
                   ~connect_deadline
                   ~body_deadline
                   ~net
-                  ~uri
+                  ~origin
                   ~header
                   ~body
                   ~dispatch_intent

--- a/packages/agent_core/lib/llm_provider/exact_output_plan.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_plan.ml
@@ -1,5 +1,7 @@
 module Sha256 = Digestif.SHA256
 
+let ( let* ) = Result.bind
+
 type fingerprint = Fingerprint of string
 
 type output_admission_error =
@@ -108,9 +110,16 @@ let contract_is_supported
   | Types.JsonSchema _ -> capabilities.supports_structured_output
 ;;
 
-let timeout_is_valid = function
-  | None -> true
-  | Some seconds -> Float.is_finite seconds && seconds > 0.0
+let validate_timeout ~invalid = function
+  | None -> Ok ()
+  | Some seconds when Float.is_finite seconds && seconds > 0.0 -> Ok ()
+  | Some seconds -> Error (invalid seconds)
+;;
+
+let%test "timeout validation preserves the invalid value" =
+  match validate_timeout ~invalid:Fun.id (Some (-1.5)) with
+  | Error seconds -> Float.equal seconds (-1.5)
+  | Ok () -> false
 ;;
 
 let content_uses_exact_cross_feature = function
@@ -390,11 +399,18 @@ let preflight
     then Error Unsupported_exact_cross_feature
     else if Option.is_some config.max_concurrent_requests
     then Error Global_admission_not_allowed
-    else if not (timeout_is_valid config.connect_timeout_s)
-    then Error (Invalid_connect_timeout (Option.get config.connect_timeout_s))
-    else if not (timeout_is_valid request.body_timeout_s)
-    then Error (Invalid_body_timeout (Option.get request.body_timeout_s))
-    else if not (contract_is_supported config capabilities)
+    else
+      let* () =
+        validate_timeout
+          ~invalid:(fun seconds -> Invalid_connect_timeout seconds)
+          config.connect_timeout_s
+      in
+      let* () =
+        validate_timeout
+          ~invalid:(fun seconds -> Invalid_body_timeout seconds)
+          request.body_timeout_s
+      in
+      if not (contract_is_supported config capabilities)
     then
       Error
         (Unsupported_output_contract

--- a/packages/agent_core/lib/llm_provider/http_client.ml
+++ b/packages/agent_core/lib/llm_provider/http_client.ml
@@ -1946,7 +1946,13 @@ let post_sync_once_after_validation
         status := Some response_status;
         Http_client_phase_observer.observe
           (Http_client_phase_observer.Response_received response_status);
-        Ok (conn, response, response_body, response_header_evidence, retry_after_header))
+        Ok
+          ( conn
+          , response
+          , response_body
+          , response_status
+          , response_header_evidence
+          , retry_after_header ))
     with
     | Eio.Time.Timeout as exn ->
       release_connection ();
@@ -1957,7 +1963,13 @@ let post_sync_once_after_validation
   | Error error ->
     release_connection ();
     fail error
-  | Ok (conn, response, response_body, response_header_evidence, retry_after_header) ->
+  | Ok
+      ( conn
+      , response
+      , response_body
+      , response_status
+      , response_header_evidence
+      , retry_after_header ) ->
     let body_result =
       try
         match body_deadline, total_started_at with
@@ -2008,7 +2020,7 @@ let post_sync_once_after_validation
           fail error
         | Ok () ->
           Ok
-            ( { status = Option.get !status; body = response_body; retry_after_header }
+            ( { status = response_status; body = response_body; retry_after_header }
             , response_header_evidence )))
 ;;
 

--- a/scripts/ocaml-boundary-baseline.tsv
+++ b/scripts/ocaml-boundary-baseline.tsv
@@ -5,4 +5,3 @@ partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement
 partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml	resolve_origin/host	Stdlib.Option.get	1
 partial_extraction	packages/agent_core/lib/llm_provider/exact_output_plan.ml	preflight	Stdlib.Option.get	2
 partial_extraction	packages/agent_core/lib/llm_provider/http_client.ml	post_sync_once_after_validation	Stdlib.Option.get	1
-failure_erasure	lib/runtime/runtime.ml	of_binding	Stdlib.Result.to_option	1

--- a/scripts/ocaml-boundary-baseline.tsv
+++ b/scripts/ocaml-boundary-baseline.tsv
@@ -1,7 +1,2 @@
 # ocaml-boundary-audit-v2 typed-tree baseline
 # category<TAB>path<TAB>scope<TAB>resolved-callee<TAB>count
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_generation_receipt.ml	merge_state	Stdlib.Option.get	2
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml	post_sync_once_after_commit/response_status	Stdlib.Option.get	1
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_measurement_transport.ml	resolve_origin/host	Stdlib.Option.get	1
-partial_extraction	packages/agent_core/lib/llm_provider/exact_output_plan.ml	preflight	Stdlib.Option.get	2
-partial_extraction	packages/agent_core/lib/llm_provider/http_client.ml	post_sync_once_after_validation	Stdlib.Option.get	1

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -1,6 +1,7 @@
 # Modules whose implementations are pure decision cores. Registry growth is
 # the one-way ratchet: a registered module may not call canonical env, clock,
 # random, filesystem, Eio, mutation, or logging APIs.
+lib/keeper/keeper_runtime_trust_snapshot_core.ml
 lib/keeper_runtime/keeper_event_queue_state.ml
 lib/schedule/schedule_domain.ml
 lib/turn_fsm/turn_fsm.ml

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -313,6 +313,49 @@ let test_observation_not_dispatched_receipt_remains_non_blocking () =
          (snapshot |> member "operator_disposition_reason" |> to_string))
 ;;
 
+let test_summary_and_snapshot_share_trust_projection () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       let keeper_name = "runtime-trust-shared-projection" in
+       let meta = make_meta keeper_name in
+       let receipt_store =
+         Masc.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+       in
+       Dated_jsonl.append
+         receipt_store
+         (`Assoc
+             [ "ended_at", `String "2026-06-01T00:00:00Z"
+             ; "operator_disposition", `String "pass"
+             ; "operator_disposition_reason", `String "healthy"
+             ; "terminal_reason_code", `String "success"
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let summary = K.summary_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       List.iter
+         (fun field ->
+            Alcotest.(check bool)
+              (field ^ " uses the shared trust projection")
+              true
+              (snapshot |> member field = (summary |> member field)))
+         [ "disposition"
+         ; "disposition_reason"
+         ; "operator_disposition"
+         ; "operator_disposition_reason"
+         ; "needs_attention"
+         ; "attention_reason"
+         ; "next_human_action"
+         ])
+;;
+
 let test_unknown_completion_contract_result_stays_visible () =
   Eio_main.run
   @@ fun env ->
@@ -967,6 +1010,10 @@ let () =
             "not-dispatched observation remains non-blocking"
             `Quick
             test_observation_not_dispatched_receipt_remains_non_blocking
+        ; Alcotest.test_case
+            "summary and snapshot share one trust projection"
+            `Quick
+            test_summary_and_snapshot_share_trust_projection
         ; Alcotest.test_case
             "unknown completion-contract result remains visible"
             `Quick

--- a/test/test_parse_outcome.ml
+++ b/test/test_parse_outcome.ml
@@ -46,12 +46,6 @@ let test_map () =
   in
   check int "map increments" 8 (match r with Ok v -> v | Error _ -> -1)
 
-let test_to_option () =
-  check (option int) "Ok -> Some"
-    (Some 5) (Parse_outcome.to_option (Ok 5));
-  check (option int) "Error -> None"
-    None (Parse_outcome.to_option (Error (`Other (Failure "x"))))
-
 (* RFC-0145 §Design — cancellation MUST re-raise. We drive an Eio
    fiber and cancel it from a sibling; inside the cancelled context
    the parser raises Cancelled which parse_safe must propagate. *)
@@ -87,7 +81,6 @@ let () =
           test_case "of_exn classifies Failure as `Other" `Quick test_of_exn_other;
           test_case "bind" `Quick test_bind;
           test_case "map" `Quick test_map;
-          test_case "to_option" `Quick test_to_option;
         ] );
       ( "cancellation",
         [

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1170,8 +1170,27 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     }
   in
   match Runtime.of_binding cfg runpod_binding with
-  | Some runtime -> runtime
-  | None -> fail "expected runtime binding to materialize"
+  | Ok runtime -> runtime
+  | Error reason -> failf "expected runtime binding to materialize: %s" reason
+
+let test_runtime_of_binding_preserves_failure_reason () =
+  let cfg =
+    { Runtime_schema.providers = [ runpod_provider ]
+    ; models = [ qwen_model ]
+    ; bindings = [ runpod_binding ]
+    ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; cross_verifier_runtime_id = None
+    ; keeper_assignments = []
+    ; media_failover = []
+    ; lane_decls = []
+    ; exact_output_lane_decls = []
+    }
+  in
+  match Runtime.of_binding cfg { runpod_binding with enabled = false } with
+  | Ok _ -> fail "expected disabled binding materialization to fail"
+  | Error reason ->
+    check string "disabled binding reason"
+      "binding is disabled by runtime.toml" reason
 
 let with_dashboard_probe_http_get hook f =
   Server_dashboard_http_runtime_info.set_dashboard_runtime_provider_http_get_for_tests
@@ -1923,6 +1942,10 @@ let () =
         ] )
     ; ( "provider_config"
       , [ test_case
+            "runtime binding materialization preserves failure reason"
+            `Quick
+            test_runtime_of_binding_preserves_failure_reason
+        ; test_case
             "adapter stamps declared provider id"
             `Quick
             test_adapter_stamps_declared_provider_id


### PR DESCRIPTION
## Summary

- collect Keeper trust file/store reads and clock observation into immutable raw snapshot boundaries
- move disposition and attention decisions into a registered pure core with no I/O, time, Eio, logging, JSON, or mutable state
- project the canonical trust fields once for both summary and detailed snapshots
- build causal timelines only from already-collected rows and add a characterization test pinning shared wire output

## Local verification

- `ocamlformat --check` for touched OCaml files
- `ocamlc -stop-after parsing` for touched implementations/interfaces and test
- `git diff --check`
- focused Dune target attempted, but `scripts/dune-local.sh` refused with exit 75 because another session owns live unwrapped Dune builds; no bypass was used

Stacked on `refactor/functional-core-agent-option`.
