### PR TITLE
fix(server): install keeper owner inventory before shutdown persistence restore

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -833,20 +833,10 @@ let start_keeper_loops_owned
       f
   in
   let config = workspace_scope.Mcp_server.config in
-  let keeper_owner_count =
-    match
-      Keeper_owner_registry.install_from_store
-        ~sw
-        ~operation_runner:
-          (Some (Server_routes_http_keeper_stream.operation_runner ~state ~clock))
-        config
-    with
-    | Ok count -> count
-    | Error error -> raise (Keeper_owner_registry.Install_failed error)
-  in
-  Log.Keeper.info
-    "keeper_owner: installed %d single-owner actor(s) under server root switch"
-    keeper_owner_count;
+  (* The owner inventory is installed by [initialize_owner_state_blocking]
+     before persistence preparation. Shutdown admission recovery is itself an
+     Owner command after the single-owner hard cut, so installing it here was
+     too late whenever a durable shutdown fence survived process death. *)
   (* [claimed_persistence] can only be constructed by the typed one-shot claim
      boundary before readiness publication. No late exception can turn an
      already-visible HTTP state into a degraded bootstrap. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -898,6 +898,25 @@ let initialize_owner_state_blocking
   sync_admin_token_env state;
   sync_internal_keeper_token_env state;
   sync_bootable_keeper_credentials state;
+  (* Shutdown admission restore below is mailbox-linearized by the Keeper
+     Owner. Install the inventory before persistence preparation so a durable
+     shutdown fence can be restored on a real process restart. The operation
+     runner remains dormant until the corresponding Keeper registry entry is
+     healthy, so queued chat work cannot run across this pre-ready boundary. *)
+  let keeper_owner_count =
+    match
+      Keeper_owner_registry.install_from_store
+        ~sw
+        ~operation_runner:
+          (Some (Server_routes_http_keeper_stream.operation_runner ~state ~clock))
+        (Mcp_server.workspace_config state)
+    with
+    | Ok count -> count
+    | Error error -> raise (Keeper_owner_registry.Install_failed error)
+  in
+  Log.Keeper.info
+    "keeper_owner: installed %d single-owner actor(s) before persistence recovery"
+    keeper_owner_count;
   let prepared_keeper_persistence =
     match
       Server_bootstrap_loops.prepare_keeper_persistence

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -1162,6 +1162,30 @@ let test_stdio_entrypoint_uses_shared_base_path_guard () =
   check bool "HTTP runtime uses common owner activation" true
     (String_util.contains_substring http_runtime_source "activate_owner_state")
 
+let test_keeper_owner_inventory_precedes_persistence_recovery () =
+  let source = read_file (source_file "lib/server/server_runtime_bootstrap.ml") in
+  let find needle =
+    let nlen = String.length needle in
+    let rec loop index =
+      if index + nlen > String.length source then None
+      else if String.sub source index nlen = needle then Some index
+      else loop (index + 1)
+    in
+    loop 0
+  in
+  let owner_install =
+    find "Keeper_owner_registry.install_from_store"
+    |> Option.get
+  in
+  let persistence_prepare =
+    find "Server_bootstrap_loops.prepare_keeper_persistence"
+    |> Option.get
+  in
+  check bool
+    "Owner inventory is installed before shutdown persistence restore"
+    true
+    (owner_install < persistence_prepare)
+
 let test_stdio_skips_dashboard_build_and_http_preflight () =
   with_temp_dir "start-masc-script-stdio" (fun dir ->
       let script = Filename.concat dir "start-masc.sh" in
@@ -1734,6 +1758,10 @@ let () =
 	            test_default_build_lock_is_worktree_local;
 	          test_case "stdio entrypoint uses shared base path guard" `Quick
 	            test_stdio_entrypoint_uses_shared_base_path_guard;
+	          test_case
+	            "Keeper Owner inventory precedes persistence recovery"
+	            `Quick
+	            test_keeper_owner_inventory_precedes_persistence_recovery;
 	          test_case "stdio skips dashboard build and HTTP preflight" `Quick
             test_stdio_skips_dashboard_build_and_http_preflight;
           test_case


### PR DESCRIPTION
## 문제

2026-08-12 02:32:05Z, main 기반 빌드 부팅이 결정론적으로 거부되었습니다:

```
[FATAL] Critical startup failed before readiness; refusing partial BasePath ownership:
Keeper persistence preparation failed: shutdown admission restore unavailable:
Keeper owner inventory is not installed for BasePath /Users/dancer/me
```

- shutdown admission restore 는 Owner-registry 명령이라 BasePath 의 owner pool 이 필요한데, pool 설치(`install_from_store`)가 `start_keeper_loops_owned`(persistence 준비 **뒤**)에 있었습니다.
- 트리거: `.masc/keepers/.shutdown-operations/` 에 admission fence 가 필요한 레코드 4건 (`operator_stop_retain_meta` — analyst·full-cycle-probe×2·sangsu).
- 01:31:13Z 부팅이 성공했던 이유는 그 바이너리가 **이 fix 를 미커밋 로컬 패치로 품고 있었기** 때문입니다 (`keeper-autonomy-recovery` 워크트리, git 히스토리에 부재). 로그 대조: 성공 부팅 `keeper_owner: installed 8 single-owner actor(s) before persistence recovery` + `stage=shutdown examined=4 failures=0`, 실패 부팅은 그 줄 없이 `examined=0 failures=1`.

## 변경

- `initialize_owner_state_blocking` 에서 `prepare_keeper_persistence` **이전에** `Keeper_owner_registry.install_from_store` 실행. operation runner 는 keeper registry 엔트리가 healthy 해질 때까지 dormant 라 pre-ready 경계를 넘는 chat 작업은 없습니다.
- `start_keeper_loops_owned` 의 늦은 설치 지점 제거 (설명 주석으로 대체).
- `test_start_masc_script`: owner 설치가 persistence 준비보다 소스 순서상 선행함을 단언하는 회귀 테스트 (이 파일의 기존 source-order 단언 관례를 따름). 35/35 PASS.

## 검증

- `dune build --root . @check` clean (main 94d3bae913 위)
- `test_start_masc_script` 35/35 PASS (신규 케이스 포함)
- 동작 증명은 라이브 선례: 동일 diff 를 품은 빌드가 01:31:13Z 에 같은 레코드 4건을 `examined=4 failures=0` 으로 통과.

## 후속 (이 PR 범위 밖)

- 행동 레벨 회귀 테스트: temp base 에 fence-요구 shutdown 레코드를 심고 main_eio 부팅 → ready 도달을 단언하는 `Slow` 테스트 (`test_server_runtime_bootstrap` 관례). 소스 순서 단언보다 강한 가드.
- stuck operation `full-cycle-probe/shutdown-06e24456` 처리 — 01:31:55Z recovery 실패 후 매분 "shutdown reserved" 에러 방출 중.
- 라이브 워크트리의 잔여 미커밋 diff (keeper_owner.ml 괄호, event_queue_persistence 인자, local_runtime_verify 계열) 의 처분 결정.

RFC-WAIVED: workflow-pr.md §11 필수 subsystem 해당 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
