### PR TITLE
fix(keeper): recover Claude context overflow safely

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -238,6 +238,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |
+| RFC-claude-code-context-overflow-bounded-restart | Recover Claude Code context overflow with an effect-safe bounded restart | Draft | - |
 | RFC-compaction-deterministic-floor | Compaction must never deadlock: a deterministic structural floor, typed outco... | Draft | - |
 | RFC-connector-ambient-attention-wake | Connector ambient attention wake: drive an idle keeper turn from external-att... | Draft | - |
 | RFC-keeper-conversation-hitl-flow | Keeper conversation and non-blocking HITL | Draft | - |

--- a/docs/rfc/RFC-claude-code-context-overflow-bounded-restart.md
+++ b/docs/rfc/RFC-claude-code-context-overflow-bounded-restart.md
@@ -1,0 +1,242 @@
+---
+rfc: "claude-code-context-overflow-bounded-restart"
+title: "Recover Claude Code context overflow with an effect-safe bounded restart"
+status: Draft
+created: 2026-08-12
+updated: 2026-08-12
+author: codex
+supersedes: []
+superseded_by: null
+related: ["0351", "0353", "0368", "0371"]
+implementation_prs: [28284]
+---
+
+# RFC: Claude Code context overflow bounded restart
+
+## 1. Decision
+
+Claude Code의 official-client adapter가 provider terminal frame에서 다음 세
+조건을 모두 직접 관측한 경우에만 이를 typed
+`Agent_core.Retry.ContextOverflow`로 승격한다.
+
+1. `is_error = true`
+2. `api_error_status = 400`
+3. trim한 provider `result`가 정확한 호환 prefix `Prompt is too long`으로 시작
+
+그 실패가 **dynamic tool 진입 전**이고 **assistant response stream 시작 전**이면,
+같은 runtime 안에서 fresh provider session을 만들고 provider-bound history 사본만
+더 작은 atom 경계로 다시 조립한다. durable checkpoint는 수정하지 않는다.
+
+아직 이 `(keeper, runtime)`에서 provider 거부를 관측하지 않은 첫 시도는 전체
+history를 그대로 보낸다. 같은 process에서 overflow 뒤 성공한 bounded capacity가
+있으면 다음 턴은 그 provider-derived capacity에서 시작할 수 있다. 운영자 선언
+예산으로 미리 자르는 선제 cap은 다시 도입하지 않는다.
+
+## 2. Problem and root cause
+
+2026-08-12 live `analyst`는 Claude Code가 요청을 context limit 초과로 거부한 뒤
+동일한 약 4.86 MB checkpoint seed를 3,144회 반복했다. 운영자가 checkpoint를
+백업한 뒤 비워야만 다시 진행했다. 이 작업은 state recovery였고 root fix가
+아니었다.
+
+반복은 네 경계의 결합으로 발생했다.
+
+1. Claude CLI는 terminal frame에 `api_error_status = 400`과
+   `Prompt is too long ...`을 함께 보냈다.
+2. `Runtime_claude_code`는 이를 generic `Turn_failed`로 납작하게 만들었다.
+3. 따라서 `Keeper_turn_driver_try_provider.context_overflow_shrink_sequence`가
+   소비하는 typed `ContextOverflow`에 도달하지 못했다.
+4. failed official-client claim은 `Recovery_required`가 된 뒤 다음 claim에서 fresh
+   session으로 자동 supersede되었다. fresh `Start`는 같은 durable history 전체를
+   다시 seed하므로 실패 조건이 그대로 재생산됐다.
+
+문제는 checkpoint가 크다는 사실 하나가 아니다. **provider가 이미 명시한 admission
+failure가 typed retry contract에 도달하지 않아, recovery가 같은 입력을 재생한 것**이
+근본 결함이다.
+
+## 3. Existing contracts
+
+### 3.1 `#28185`: no preemptive seed cut
+
+`#28185`는 declared byte ceiling으로 official-client seed를 미리 자르던 경로를
+삭제했다. byte cap이 provider token window의 권위인 것처럼 동작했고, provider가
+수락할 수도 있던 history를 먼저 버렸기 때문이다.
+
+본 RFC는 그 결정을 유지한다.
+
+- 아직 working capacity를 학습하지 않은 첫 attempt는 byte-identical full seed다.
+- 축소 권한은 provider의 실제 거부 이후에만 열린다.
+- 이후 턴의 bounded 시작점도 같은 process가 실제 성공으로 확인한 값만 쓴다.
+- 축소는 provider-bound 사본에만 적용된다.
+- 성공하거나 실패해도 durable checkpoint 원문은 그대로다.
+
+### 3.2 `#28128` / RFC-0351: reactive bounded transmission view
+
+Codex official-client 경로는 이미 typed context overflow 뒤 같은 runtime을
+구조적으로 축소해 재시도한다. 본 RFC는 새 retry 정책을 만들지 않고 그 shared
+`context_overflow_shrink_sequence`와 `Runtime_model_input_tail_window` 계약을 Claude
+Code에 연결한다.
+
+### 3.3 RFC-0371: effect boundary owns retry authority
+
+provider error 종류만으로 재시도를 허가하지 않는다. 재시도 권한은 adapter가
+관측한 effect/response 경계가 소유한다. outer runtime lane의 effect disposition은
+계속 fail-closed이고, 이 RFC가 여는 것은 Claude adapter 내부의 좁은 same-runtime
+restart 한 번뿐이다.
+
+## 4. Design
+
+### 4.1 Boundary classification
+
+Claude CLI는 이 failure에 구조화된 enum을 제공하지 않는다. 따라서 provider prose
+호환은 외부 adapter 한 곳에서만 수행하고 즉시 closed variant로 바꾼다.
+
+```text
+terminal JSON
+  -- is_error + status 400 + exact prefix --> Context_window_exceeded
+  -- every other 400 ----------------------> Turn_failed
+```
+
+substring 검색, case folding, token 수치 추출은 하지 않는다. 문구가 바뀌면 generic
+failure로 닫히며 자동 retry 권한이 생기지 않는다. Claude가 structured code를
+제공하면 이 prefix adapter를 삭제하고 그 code를 단일 권위로 교체한다.
+
+typed error는 진단 원문과 함께 다음 관측을 운반한다.
+
+- `tool_effect_attempted`: admitted dynamic tool handler가 실행됐는가
+- `response_started`: assistant stream이 시작됐는가
+
+### 4.2 State transition
+
+```text
+full Start or Resume
+  -> provider Context_window_exceeded
+  -> durable claim records Provider_rejected / Recovery_required
+  -> only when tool_effect_attempted=false and response_started=false:
+       fresh claim auto-supersedes recovery
+       Start with a smaller provider-bound history view
+  -> success: settle turn 1 and remember working capacity process-locally
+  -> overflow again: repeat at a strictly smaller atom boundary, shared max 3
+  -> no smaller boundary or attempts exhausted: return the original typed failure
+```
+
+session recovery evidence is not skipped or rewritten. Each failed provider process closes,
+the claim transitions durably, and the next internal attempt follows the existing fresh-claim
+path.
+
+### 4.3 Projection order
+
+각 attempt는 다음 순서를 지킨다.
+
+1. durable `initial_messages`에서 provider-bound working copy를 만든다.
+2. 첫 attempt면 그대로 두고, retry면 `Runtime_model_input_tail_window`로 atom-safe
+   suffix를 만든다.
+3. 현재 view에서 다음 **strictly smaller** structural boundary를 계산한다.
+4. Gate replay 같은 source projection은 그 뒤에 적용한다.
+5. Claude `Start` prompt를 조립한다. `Resume`은 provider session을 사용한다.
+
+tool use/result 쌍, pinned system context, newest atom floor는 기존 tail-window
+불변식을 그대로 사용한다. boundary가 더 작아지지 않으면 provider를 다시 호출하지
+않는다.
+
+### 4.4 Effect and response fence
+
+다음 중 하나라도 참이면 자동 shrink retry를 금지한다.
+
+- dynamic tool handler에 진입했다.
+- assistant response stream이 시작됐다.
+- terminal frame까지의 effect 관측이 불완전하다.
+
+금지된 실패는 기존 `Provider_attempt_effect_fenced` 경로를 유지한다. 다른 runtime
+후보로 회전하거나 provider effect를 보상·재생하지 않는다. tool handler가 한 번
+실행된 fixture에서는 호출 횟수가 반드시 1이어야 한다.
+
+### 4.5 Capacity memory
+
+성공한 bounded capacity는 `(keeper_name, runtime_id)` 키로 process-local하게만
+기억한다. 다음 턴은 그 크기에서 시작해 같은 overflow 탐색을 반복하지 않는다.
+
+이 값은 correctness state가 아니다.
+
+- restart 시 사라져도 full seed부터 다시 안전하게 탐색한다.
+- durable checkpoint나 session schema에 쓰지 않는다.
+- 성공하지 않은 capacity는 기록하지 않는다.
+- unbounded sentinel은 기록하지 않는다.
+
+## 5. Safety invariants
+
+1. **Durable fidelity**: checkpoint message를 삭제·요약·재작성하지 않는다.
+2. **Provider oracle**: 미학습 첫 attempt는 full seed이며 provider의 명시 거부만
+   축소 권한을 만든다. 이후 bounded 시작점은 같은 process에서 성공한 값만 쓴다.
+3. **Exact classification**: unrelated 400은 typed overflow가 아니다.
+4. **No effect replay**: tool 진입 뒤에는 같은 turn을 자동 재시도하지 않는다.
+5. **No response replay**: response stream 시작 뒤에는 자동 재시도하지 않는다.
+6. **Same runtime only**: shrink는 동일 Claude runtime의 fresh session 안에서만
+   일어나며 fallback/rotation 권한을 만들지 않는다.
+7. **Strict convergence**: 다음 capacity가 현재보다 작지 않으면 즉시 중단한다.
+8. **Bounded attempts**: shared policy의 최대 3회 shrink를 복제 없이 재사용한다.
+9. **Evidence retention**: 실패 claim과 recovery 기록은 정상 session transition을
+   거친다.
+
+## 6. Observability
+
+각 shrink retry는 keeper log에 다음을 남긴다.
+
+- `shrink_attempt`
+- `previous_capacity_bytes`
+- `capacity_bytes`
+
+기존 Claude composition log의 `mode`, `prompt_bytes`, `system_prompt_bytes`, tool 수,
+tool surface bytes를 함께 보면 full attempt와 bounded restart를 구분할 수 있다.
+byte 값은 provider token 수가 아니라 MASC가 소유한 transmission view의 구조적
+수렴 지표다.
+
+후속으로 runtime manifest에 Codex와 동일한 typed shrink observation을 붙일 수 있다.
+그 관측이 없다는 이유로 본 안전 수리를 지연하지 않는다.
+
+## 7. Verification and rollout
+
+### 7.1 Required tests
+
+1. exact prompt-too-long 400은 `Context_window_exceeded`가 된다.
+2. unrelated 400과 prefix가 아닌 문장 포함은 `Turn_failed`로 남는다.
+3. tool effect 뒤 overflow는 activity flag를 보존한다.
+4. response 시작 뒤 overflow는 activity flag를 보존한다.
+5. Keeper 첫 attempt는 full history를 보내고 두 번째는 더 작은 non-empty history로
+   성공한다.
+6. tool effect 뒤 overflow는 provider attempt와 tool effect 모두 한 번뿐이며
+   recovery evidence가 남는다.
+
+### 7.2 Deployment proof
+
+merge, build, deployment, live health를 분리해서 확인한다.
+
+1. PR exact head의 focused tests와 CI를 확인한다.
+2. main merge commit으로 `main_eio.exe`를 rebuild한다.
+3. 실행 중 process의 executable/commit이 그 build를 가리키는지 확인한다.
+4. oversized fixture 또는 다음 실제 Claude overflow에서 full attempt 뒤 smaller
+   attempt가 관측되고 turn이 settle되는지 확인한다.
+5. fleet health의 다른 degraded reason은 이 feature의 성공과 분리해 보고한다.
+
+## 8. Non-goals and rejected alternatives
+
+- **checkpoint clear/purge**: incident recovery일 뿐 root fix가 아니다.
+- **preemptive `max-prompt-bytes` cap**: `#28185`의 제거 사유를 되살린다.
+- **durable history truncation/compaction**: 본 수리는 transmission view만 바꾼다.
+- **string search anywhere else**: provider compatibility parser 밖의 prose 분류는
+  금지한다.
+- **retry after effects or streamed response**: duplicate effect/delivery 위험 때문에
+  금지한다.
+- **cross-provider fallback**: effect 관측이 불완전한 official-client attempt를 다른
+  provider로 재생하지 않는다.
+- **Claude context policy 일반화**: structured enum이 없는 이 transport의 좁은 adapter
+  수리다. shared retry/tail-window 정책 자체는 변경하지 않는다.
+
+## 9. Integration note
+
+`#28263`은 본 구현 전에 main에 머지되어 official-client context codec을 v2로
+hard-cut했다. shrink 측정기는 별도 JSON 형식을 복제하지 않고
+`Host.encode_history_message`에 위임한다. 따라서 System과 history role 모두 실제
+provider projection과 같은 v2 envelope를 사용한다. focused shrink fixture는 full
+attempt와 bounded retry 양쪽의 schema가 현재 codec인지 확인한다. compatibility
+reader나 v1/v2 이중 경로는 만들지 않는다.

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -42,6 +42,68 @@ let initial_turn_prompt ~history ~goal =
     |> Yojson.Safe.to_string
 ;;
 
+let unbounded_model_input_capacity_bytes = max_int
+
+let measure_model_input_message_bytes message =
+  String.length (Host.encode_history_message message)
+;;
+
+(* Keep the durable conversation intact and narrow only the provider-bound
+   start seed after Claude has explicitly rejected the prior view as too
+   large. The next structural boundary is computed before source projections
+   append synthetic evidence, matching the Codex official-client path. *)
+let model_input_projection_for_capacity
+    ~capacity_bytes
+    ~observed_next_shrink_capacity_bytes
+    source_projection
+    messages =
+  let windowed =
+    if capacity_bytes = unbounded_model_input_capacity_bytes
+    then Ok messages
+    else
+      Domain_pool_ref.submit_cpu_or_inline (fun () ->
+        match
+          Runtime_model_input_tail_window.project
+            ~measure_message_bytes:measure_model_input_message_bytes
+            ~capacity_bytes
+            ~reserved_bytes:0
+            messages
+        with
+        | Ok projected -> Ok projected
+        | Error error ->
+          Error
+            (Runtime_model_input_tail_window.budget_error_to_string error))
+  in
+  let* windowed = windowed in
+  let () =
+    Domain_pool_ref.submit_cpu_or_inline (fun () ->
+      let full_bytes =
+        List.fold_left
+          (fun total message ->
+             total + measure_model_input_message_bytes message)
+          0
+          windowed
+      in
+      let target_capacity_bytes =
+        if capacity_bytes = unbounded_model_input_capacity_bytes
+        then
+          Keeper_turn_driver_try_provider.default_context_overflow_shrink_capacity
+            ~capacity_bytes:full_bytes
+        else
+          Keeper_turn_driver_try_provider.default_context_overflow_shrink_capacity
+            ~capacity_bytes
+      in
+      observed_next_shrink_capacity_bytes :=
+        Runtime_model_input_tail_window.next_shrink_capacity_bytes
+          ~measure_message_bytes:measure_model_input_message_bytes
+          ~target_capacity_bytes
+          windowed)
+  in
+  match source_projection with
+  | None -> Ok windowed
+  | Some project -> project windowed
+;;
+
 let claude_stream_callback on_event =
   match on_event with
   | None -> None
@@ -142,6 +204,17 @@ let claude_error_to_core_error = function
          { provider = "claude_code"
          ; detail = Runtime_claude_code.error_to_string error
          })
+  | Runtime_claude_code.Context_window_exceeded
+      { message; tool_effect_attempted = false; response_started = false } ->
+    Agent_core.Error.Api
+      (Llm_provider.Retry.ContextOverflow { message; limit = None })
+  | Runtime_claude_code.Context_window_exceeded _ as error ->
+    Agent_core.Error.Provider
+      (Llm_provider.Error.ProviderReportedError
+         { provider = "claude_code"
+         ; error_type = Some "context_window_exceeded_after_observed_activity"
+         ; detail = Runtime_claude_code.error_to_string error
+         })
   | Runtime_claude_code.Protocol_error { stage; detail } ->
     Agent_core.Error.Provider
       (Llm_provider.Error.ParseError
@@ -163,6 +236,7 @@ let recovery_failure_of_client_error = function
   | Runtime_claude_code.Unsupported_control_request _ ->
     Session_store.Protocol_failed
   | Runtime_claude_code.Subscription_required _
+  | Runtime_claude_code.Context_window_exceeded _
   | Runtime_claude_code.Turn_failed _
   | Runtime_claude_code.Quota_blocked _ ->
     Session_store.Provider_rejected
@@ -171,7 +245,9 @@ let recovery_failure_of_client_error = function
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
     ~context ~event_bus ~raw_trace ~on_event ~effect_disposition
+    ~context_overflow_retry_safe
     ~(config : Runtime_execution.claude_code) =
+  context_overflow_retry_safe := false;
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
     Error
@@ -486,6 +562,12 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         in
         (match client_result with
          | Error error ->
+           context_overflow_retry_safe :=
+             (match error with
+              | Runtime_claude_code.Context_window_exceeded
+                  { tool_effect_attempted = false; response_started = false; _ } ->
+                true
+              | _ -> false);
            if not !state_persistence_failed
            then recovery_failure := recovery_failure_of_client_error error;
            Error (claude_error_to_core_error error)
@@ -703,26 +785,66 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
   let effect_disposition =
     Atomic.make Keeper_provider_attempt_effect.No_effect_observed
   in
+  let observed_next_shrink_capacity_bytes = ref None in
+  let context_overflow_retry_safe = ref false in
+  let starting_capacity_bytes =
+    Keeper_context_overflow_shrink_state.starting_capacity_bytes
+      ~keeper_name
+      ~runtime_id
+      ~max_capacity_bytes:unbounded_model_input_capacity_bytes
+  in
   let result =
     Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
-      run_without_lifecycle
-        ~runtime_id
-        ~keeper_name
-        ~base_path
-        ~goal
-        ~goal_blocks
-        ~system_prompt
-        ~tools
-        ~initial_messages
-        ~model_input_projection
-        ~hooks
-        ~context_injector
-        ~context
-        ~event_bus
-        ~raw_trace
-        ~on_event
-        ~effect_disposition
-        ~config)
+      Keeper_turn_driver_try_provider.context_overflow_shrink_sequence
+        ~starting_capacity_bytes
+        ~same_run_retry_authorized:(fun () ->
+          !context_overflow_retry_safe
+          && Option.is_some !observed_next_shrink_capacity_bytes)
+        ~shrink_capacity:(fun ~capacity_bytes:_ ~default_capacity_bytes ->
+          Option.value
+            !observed_next_shrink_capacity_bytes
+            ~default:(max 1 default_capacity_bytes))
+        ~record_success:(fun ~capacity_bytes ->
+          if capacity_bytes <> unbounded_model_input_capacity_bytes
+          then
+            Keeper_context_overflow_shrink_state.record_success
+              ~keeper_name
+              ~runtime_id
+              ~capacity_bytes)
+        ~on_shrink_retry:
+          (fun ~shrink_attempt ~previous_capacity_bytes ~capacity_bytes ->
+            Log.Keeper.warn
+              ~keeper_name
+              "Claude typed context overflow; shrinking provider-bound history: attempt=%d previous_capacity_bytes=%d capacity_bytes=%d"
+              shrink_attempt
+              previous_capacity_bytes
+              capacity_bytes)
+        ~attempt:(fun ~capacity_bytes ->
+          run_without_lifecycle
+            ~runtime_id
+            ~keeper_name
+            ~base_path
+            ~goal
+            ~goal_blocks
+            ~system_prompt
+            ~tools
+            ~initial_messages
+            ~model_input_projection:
+              (Some
+                 (model_input_projection_for_capacity
+                    ~capacity_bytes
+                    ~observed_next_shrink_capacity_bytes
+                    model_input_projection))
+            ~hooks
+            ~context_injector
+            ~context
+            ~event_bus
+            ~raw_trace
+            ~on_event
+            ~effect_disposition
+            ~context_overflow_retry_safe
+            ~config)
+        ())
   in
   { result; effect_disposition = Atomic.get effect_disposition }
 ;;

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -122,6 +122,11 @@ type error =
       ; tool_effect_attempted : bool
       ; detail : string
       }
+  | Context_window_exceeded of
+      { message : string
+      ; tool_effect_attempted : bool
+      ; response_started : bool
+      }
   | Turn_failed of string
   | Quota_blocked of
       { api_error_status : int option
@@ -147,6 +152,13 @@ let error_to_string = function
       stage
       tool_effect_attempted
       detail
+  | Context_window_exceeded
+      { message; tool_effect_attempted; response_started } ->
+    Printf.sprintf
+      "Claude Code context window exceeded (tool_effect_attempted=%b response_started=%b): %s"
+      tool_effect_attempted
+      response_started
+      message
   | Turn_failed detail -> "Claude Code turn failed: " ^ detail
   | Quota_blocked { api_error_status; rate_limit } ->
     let status =
@@ -175,6 +187,7 @@ let error_kind = function
   | Subscription_required _ -> "subscription_required"
   | Unsupported_control_request _ -> "unsupported_control_request"
   | Turn_transport_interrupted _ -> "turn_transport_interrupted"
+  | Context_window_exceeded _ -> "context_window_exceeded"
   | Turn_failed _ -> "turn_failed"
   | Quota_blocked _ -> "quota_blocked"
   | Process_exited _ -> "process_exited"
@@ -619,7 +632,8 @@ let parse_assistant ~expected_session_id fields =
     Ok (uuid, model, texts)
 ;;
 
-let parse_result ~expected_session_id ~rate_limit fields =
+let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
+    ~response_started fields =
   let stage = "result message" in
   let* subtype = required_string stage "subtype" fields in
   let* is_error = required_bool stage "is_error" fields in
@@ -666,30 +680,45 @@ let parse_result ~expected_session_id ~rate_limit fields =
            (fun (limit : rate_limit) -> limit.status = Rejected)
            rate_limit
     in
+    let terminal_failure_detail () =
+      Printf.sprintf
+        "terminal subtype=%s api_status=%s%s"
+        subtype
+        (Option.fold
+           ~none:"unknown"
+           ~some:string_of_int
+           api_error_status)
+        (match result with
+         | Some detail when String.trim detail <> "" -> ": " ^ String.trim detail
+         | Some _ | None -> "")
+    in
+    let provider_reported_context_window_exceeded =
+      Option.equal Int.equal api_error_status (Some 400)
+      && Option.exists
+           (fun detail ->
+              String.starts_with
+                ~prefix:"Prompt is too long"
+                (String.trim detail))
+           result
+    in
     if structurally_quota_blocked
     then Error (Quota_blocked { api_error_status; rate_limit })
+    else if is_error && provider_reported_context_window_exceeded
+    then
+      Error
+        (Context_window_exceeded
+           { message = terminal_failure_detail ()
+           ; tool_effect_attempted
+           ; response_started
+           })
     else if is_error
     then
-      (* [result] is the one field on this frame that says why the turn failed,
-         and it was parsed and dropped: a live keeper reported
-         "terminal subtype=success api_status=400" eleven times with no way to
-         tell a context overflow from anything else that returns 400 (#28071).
-         The 429 branch above already proves a status code can carry a typed
-         decision; until 400 gets the same treatment, the operator needs the
-         provider's own sentence. *)
-      Error
-        (Turn_failed
-           (Printf.sprintf
-              "terminal subtype=%s api_status=%s%s"
-              subtype
-              (Option.fold
-                 ~none:"unknown"
-                 ~some:string_of_int
-                 api_error_status)
-              (match result with
-               | Some detail when String.trim detail <> "" ->
-                 ": " ^ String.trim detail
-               | Some _ | None -> "")))
+      (* [result] is the one field on this frame that says why the turn failed.
+         The exact prompt-too-long 400 prefix above has its own typed path;
+         unrelated 400s and every other terminal rejection still retain the
+         provider's sentence instead of collapsing to the status code
+         (#28071). *)
+      Error (Turn_failed (terminal_failure_detail ()))
     else if subtype <> "success"
     then Error (Turn_failed (Printf.sprintf "terminal subtype=%s" subtype))
     else Ok (turn_id, result, usage)
@@ -742,7 +771,12 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
       ~on_turn_started ~on_stream_event ~stream_started ~ignored
   | "result" ->
     let* turn_id, result, usage =
-      parse_result ~expected_session_id ~rate_limit fields
+      parse_result
+        ~expected_session_id
+        ~rate_limit
+        ~tool_effect_attempted:(!tool_call_count > 0)
+        ~response_started:!stream_started
+        fields
     in
     let* () =
       invoke_state_callback ~stage:"turn started callback" (fun () ->

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -103,6 +103,11 @@ type error =
       ; tool_effect_attempted : bool
       ; detail : string
       }
+  | Context_window_exceeded of
+      { message : string
+      ; tool_effect_attempted : bool
+      ; response_started : bool
+      }
   | Turn_failed of string
   | Quota_blocked of
       { api_error_status : int option

--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -88,7 +88,10 @@ let claude_failure_status = function
   | Subscription_required _ -> "login_required"
   | Timeout _ -> "timeout"
   | Protocol_error _ | Unsupported_control_request _ -> "protocol_error"
-  | Turn_transport_interrupted _ | Turn_failed _ | Quota_blocked _ ->
+  | Turn_transport_interrupted _
+  | Context_window_exceeded _
+  | Turn_failed _
+  | Quota_blocked _ ->
     "probe_contract_error"
 ;;
 

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -31,6 +31,10 @@ let quota_result =
   {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-quota-1","result":"not inspected","api_error_status":429,"terminal_reason":"api_error"}|}
 ;;
 
+let prompt_too_long_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-overflow-1","result":"Prompt is too long · the request is ~250000 tokens (limit 200000)","api_error_status":400}|}
+;;
+
 let mcp_initialize =
   {|{"type":"control_request","request_id":"mcp-init-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"claude-code-fixture","version":"1"}}}}}|}
 ;;
@@ -110,6 +114,49 @@ let with_fixture ?prompt_marker ?remove_after_auth ?forbid_mcp lines f =
   let path = fixture_script ?prompt_marker ?remove_after_auth ?forbid_mcp lines in
   Fun.protect
     ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () -> f path)
+;;
+
+let with_fixture_sequence
+    ?first_prompt_marker
+    ?second_prompt_marker
+    first_lines
+    second_lines
+    f =
+  let first_path = fixture_script ?prompt_marker:first_prompt_marker first_lines in
+  let second_path = fixture_script ?prompt_marker:second_prompt_marker second_lines in
+  let counter_path = Filename.temp_file "masc-keeper-claude-sequence-" ".txt" in
+  Sys.remove counter_path;
+  let path = Filename.temp_file "masc-keeper-claude-sequence-" ".sh" in
+  let output = open_out_bin path in
+  output_string output "#!/bin/sh\n";
+  output_string output "set -eu\n";
+  output_string output "if [ \"${1-}\" = auth ]; then\n";
+  output_string output ("  printf '%s\\n' " ^ shell_quote auth_subscription ^ "\n");
+  output_string output "  exit 0\n";
+  output_string output "fi\n";
+  output_string output "count=0\n";
+  output_string output
+    ("if [ -f " ^ shell_quote counter_path ^ " ]; then\n"
+     ^ "  IFS= read -r count < " ^ shell_quote counter_path ^ "\n"
+     ^ "fi\n");
+  output_string output "count=$((count + 1))\n";
+  output_string output
+    ("printf '%s\\n' \"$count\" > " ^ shell_quote counter_path ^ "\n");
+  output_string output
+    ("if [ \"$count\" -eq 1 ]; then\n"
+     ^ "  exec " ^ shell_quote first_path ^ " \"$@\"\n"
+     ^ "else\n"
+     ^ "  exec " ^ shell_quote second_path ^ " \"$@\"\n"
+     ^ "fi\n");
+  close_out output;
+  Unix.chmod path 0o700;
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter
+        (fun candidate ->
+           if Sys.file_exists candidate then Sys.remove candidate)
+        [ path; first_path; second_path; counter_path ])
     (fun () -> f path)
 ;;
 
@@ -680,6 +727,91 @@ let load_state base_path =
   | Ok (Some state) -> state
 ;;
 
+let prompt_history path =
+  let raw =
+    In_channel.with_open_bin path (fun input -> In_channel.input_line input)
+  in
+  match raw with
+  | None -> fail "Claude fixture did not capture a prompt"
+  | Some raw ->
+    raw
+    |> content_of_wire_message
+    |> Yojson.Safe.from_string
+    |> Yojson.Safe.Util.member "history"
+    |> Yojson.Safe.Util.to_list
+;;
+
+let history_uses_current_schema history =
+  List.for_all
+    (fun value ->
+       Yojson.Safe.Util.(value |> member "schema" |> to_string)
+       = Keeper_official_client_context_codec.schema)
+    history
+;;
+
+let test_keeper_shrinks_history_after_typed_context_error () =
+  let base_path = temp_workspace () in
+  let first_prompt_marker = Filename.concat base_path "overflow-full-prompt.json" in
+  let second_prompt_marker = Filename.concat base_path "overflow-shrunk-prompt.json" in
+  let initial_messages =
+    List.init 240 (fun index ->
+      message
+        (if index mod 2 = 0 then User else Assistant)
+        (Printf.sprintf "%03d:%s" index (String.make 1_024 'x')))
+  in
+  let reset_shrink_state () =
+    Eio_main.run (fun _ ->
+      Keeper_context_overflow_shrink_state.For_testing.reset ())
+  in
+  reset_shrink_state ();
+  Fun.protect
+    ~finally:(fun () ->
+      reset_shrink_state ();
+      cleanup_tree base_path)
+    (fun () ->
+       with_fixture_sequence
+         ~first_prompt_marker
+         ~second_prompt_marker
+         [ Emit prompt_too_long_result ]
+         [ Emit (assistant ~turn_id:"turn-shrunk" "MASC_CLAUDE_SHRUNK")
+         ; Emit (result ~turn_id:"turn-shrunk" "MASC_CLAUDE_SHRUNK")
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~initial_messages
+                ~base_path
+                ~cli_path
+                ~goal:"SHRINK_HISTORY"
+                ()
+            with
+            | Error error -> fail (Agent_core.Error.to_string error)
+            | Ok turn ->
+              check string
+                "Keeper response"
+                "MASC_CLAUDE_SHRUNK"
+                (keeper_response_text turn));
+       let full_history = prompt_history first_prompt_marker in
+       let shrunk_history = prompt_history second_prompt_marker in
+       let full_count = List.length full_history in
+       let shrunk_count = List.length shrunk_history in
+       check int "first attempt keeps full history" 240 full_count;
+       check bool "full history uses current codec" true
+         (history_uses_current_schema full_history);
+       check bool "retry keeps non-empty history" true (shrunk_count > 0);
+       check bool "retry history uses current codec" true
+         (history_uses_current_schema shrunk_history);
+       check bool
+         "retry shrinks provider-bound history"
+         true
+         (shrunk_count < full_count);
+       let state = load_state base_path in
+       check int "fresh retry settles as turn one" 1 state.turn_count;
+       match state.phase with
+       | Settled { turn_id = "turn-shrunk"; _ } -> ()
+       | _ -> fail "shrunk Claude Code retry did not settle")
+;;
+
 let test_post_effect_transport_enters_recovery () =
   let base_path = temp_workspace () in
   let call_count = ref 0 in
@@ -741,6 +873,64 @@ let test_post_effect_transport_enters_recovery () =
        match state.phase with
        | Recovery_required { failure = Transport_interrupted; _ } -> ()
        | _ -> fail "post-effect transport failure released the durable claim")
+;;
+
+let test_keeper_does_not_retry_context_error_after_tool_effect () =
+  let base_path = temp_workspace () in
+  let call_count = ref 0 in
+  let marker_param : Agent_core.Types.tool_param =
+    { name = "marker"
+    ; description = "Fixture marker"
+    ; param_type = String
+    ; required = true
+    }
+  in
+  let tool =
+    Agent_core.Tool.create
+      ~name:"masc_probe"
+      ~description:"Record one deterministic fixture effect"
+      ~parameters:[ marker_param ]
+      (fun _input ->
+        incr call_count;
+        Ok { Agent_core.Types.content = "MASC_TOOL_RESULT"; _meta = None })
+  in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture
+         [ Emit_and_read mcp_initialize
+         ; Emit mcp_initialized_notification
+         ; Emit_and_read mcp_list
+         ; Emit_and_read mcp_call
+         ; Emit prompt_too_long_result
+         ]
+         (fun cli_path ->
+            match
+              run_keeper_turn
+                ~tools:[ tool ]
+                ~base_path
+                ~cli_path
+                ~goal:"USE_TOOL_THEN_OVERFLOW"
+                ()
+            with
+            | Error error ->
+              (match Keeper_internal_error.classify_masc_internal_error error with
+               | Some
+                   (Keeper_internal_error.Provider_attempt_effect_fenced
+                      { effect_disposition; _ }) ->
+                 check
+                   bool
+                   "post-effect overflow is fenced"
+                   false
+                   (Keeper_provider_attempt_effect.allows_same_turn_retry
+                      effect_disposition)
+               | _ -> fail (Agent_core.Error.to_string error))
+            | Ok _ -> fail "post-effect context overflow completed the Keeper turn");
+       check int "tool effect is not replayed" 1 !call_count;
+       let state = load_state base_path in
+       match state.phase with
+       | Recovery_required { failure = Provider_rejected; _ } -> ()
+       | _ -> fail "post-effect context overflow did not retain recovery evidence")
 ;;
 
 let test_keeper_settles_and_resumes () =
@@ -986,6 +1176,10 @@ let () =
             `Quick
             test_agent_core_checkpoint_starts_official_client_turn
         ; test_case
+            "shrinks history after typed context error"
+            `Quick
+            test_keeper_shrinks_history_after_typed_context_error
+        ; test_case
             "projects typed tool history and lifecycle"
             `Quick
             test_keeper_projects_typed_tool_history_and_lifecycle
@@ -1002,6 +1196,10 @@ let () =
             "post-effect transport enters recovery"
             `Quick
             test_post_effect_transport_enters_recovery
+        ; test_case
+            "does not retry context error after tool effect"
+            `Quick
+            test_keeper_does_not_retry_context_error_after_tool_effect
         ; test_case "quota enters recovery" `Quick test_quota_enters_typed_recovery
         ; test_case
             "spawn failure releases claim"

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -315,32 +315,49 @@ let quota_result_with_success_flag =
   {|{"type":"result","subtype":"success","is_error":false,"session_id":"__SESSION__","uuid":"turn-quota-flag-1","result":"must not settle","api_error_status":null}|}
 ;;
 
-let error_400_result =
-  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-1","result":"prompt is too long: 250000 tokens > 200000 maximum","api_error_status":400}|}
+let prompt_too_long_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-1","result":"Prompt is too long · the request is ~250000 tokens (limit 200000)","api_error_status":400}|}
 ;;
 
-(* A live keeper reported "terminal subtype=success api_status=400" eleven times
-   in fifteen minutes with no way to tell a context overflow from anything else
-   that returns 400. The frame carried the reason in [result] and the error path
-   parsed it and dropped it (#28071). The expectation is a substring of the
-   provider's own sentence, not a re-render of the format string, so it fails if
-   the field stops being carried. *)
-let test_terminal_error_carries_the_provider_reason () =
-  with_fixture [ Emit error_400_result ] (fun path ->
+let generic_400_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-generic","result":"request rejected; diagnostic mentioned Prompt is too long without the provider prefix","api_error_status":400}|}
+;;
+
+(* A live keeper reported Claude's explicit "prompt is too long" terminal as a
+   generic 400, so the provider-bound history shrinker never saw the typed
+   ContextOverflow it consumes. The status and provider sentence together are
+   the admission evidence; unrelated 400s stay generic below. *)
+let test_terminal_prompt_too_long_is_typed () =
+  with_fixture [ Emit prompt_too_long_result ] (fun path ->
     match run_fixture path with
-    | Error (Runtime_claude_code.Turn_failed detail) ->
+    | Error
+        (Runtime_claude_code.Context_window_exceeded
+          { message; tool_effect_attempted = false; response_started = false }) ->
       check
         bool
         "provider reason survives into the typed failure"
         true
-        (Astring.String.is_infix ~affix:"prompt is too long" detail);
+        (Astring.String.is_infix ~affix:"Prompt is too long" message);
       check
         bool
         "status code is still reported"
         true
-        (Astring.String.is_infix ~affix:"api_status=400" detail)
+        (Astring.String.is_infix ~affix:"api_status=400" message)
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "an is_error terminal was reported as completion")
+;;
+
+let test_unrelated_400_remains_turn_failed () =
+  with_fixture [ Emit generic_400_result ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Turn_failed detail) ->
+      check
+        bool
+        "generic rejection reason survives"
+        true
+        (Astring.String.is_infix ~affix:"diagnostic mentioned" detail)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "an unrelated 400 terminal was reported as completion")
 ;;
 
 let test_quota_is_structurally_classified () =
@@ -432,6 +449,36 @@ let test_post_effect_response_failure_requires_recovery () =
             }) -> check int "tool effect count" 1 !call_count
       | Error error -> fail (Runtime_claude_code.error_to_string error)
       | Ok _ -> fail "post-effect response failure completed the turn")
+;;
+
+let test_context_overflow_after_tool_records_effect () =
+  let call_count = ref 0 in
+  with_fixture
+    [ Emit_and_read mcp_initialize
+    ; Emit mcp_initialized_notification
+    ; Emit_and_read mcp_list
+    ; Emit_and_read mcp_call
+    ; Emit prompt_too_long_result
+    ]
+    (fun path ->
+      match run_fixture ~dynamic_tools:[ probe_tool call_count ] path with
+      | Error
+          (Runtime_claude_code.Context_window_exceeded
+            { tool_effect_attempted = true; response_started = false; _ }) ->
+        check int "tool effect count" 1 !call_count
+      | Error error -> fail (Runtime_claude_code.error_to_string error)
+      | Ok _ -> fail "post-effect context overflow completed the turn")
+;;
+
+let test_context_overflow_after_response_records_activity () =
+  with_fixture [ Emit assistant; Emit prompt_too_long_result ] (fun path ->
+    match run_fixture path with
+    | Error
+        (Runtime_claude_code.Context_window_exceeded
+          { tool_effect_attempted = false; response_started = true; _ }) ->
+      ()
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "post-response context overflow completed the turn")
 ;;
 
 let test_dynamic_tool_callback () =
@@ -991,9 +1038,13 @@ let () =
         ] )
     ; ( "terminal"
       , [ test_case
-            "terminal error carries the provider reason"
+            "terminal prompt too long is typed"
             `Quick
-            test_terminal_error_carries_the_provider_reason
+            test_terminal_prompt_too_long_is_typed
+        ; test_case
+            "unrelated 400 remains turn failed"
+            `Quick
+            test_unrelated_400_remains_turn_failed
         ; test_case
             "quota is structurally classified"
             `Quick
@@ -1028,6 +1079,14 @@ let () =
             "post-effect response failure requires recovery"
             `Quick
             test_post_effect_response_failure_requires_recovery
+        ; test_case
+            "context overflow after tool records effect"
+            `Quick
+            test_context_overflow_after_tool_records_effect
+        ; test_case
+            "context overflow after response records activity"
+            `Quick
+            test_context_overflow_after_response_records_activity
         ; test_case
             "shared bridge owns exact dispatch"
             `Quick


### PR DESCRIPTION
## Summary

- classify only Claude Code terminal frames with `is_error=true`, `api_error_status=400`, and the exact `Prompt is too long` prefix as typed context overflow
- retry the same Claude runtime with a strictly smaller atom-safe provider-bound history view, reusing the shared bounded shrink policy
- preserve the durable checkpoint, session recovery evidence, v2 official-client context codec, and outer effect fence
- add the design and rollout contract in `RFC-claude-code-context-overflow-bounded-restart`

## Root cause

The live `analyst` Keeper repeated the same approximately 4.86 MB seed 3,144 times. Claude Code supplied both status 400 and an explicit prompt-too-long terminal, but `Runtime_claude_code` flattened it into generic `Turn_failed`. The shared shrink sequence therefore never saw `Agent_core.Retry.ContextOverflow`.

Each failed official-client claim entered `Recovery_required`; the next claim auto-superseded it with a fresh session and seeded the unchanged full durable history again. Clearing the checkpoint recovered state but did not repair that loop.

## Safety

- no preemptive byte cap: an unlearned first attempt still sends the full seed, preserving the contract restored by #28185
- no durable truncation: only the provider-bound working copy is windowed
- no prose-wide classifier: unrelated 400s and non-prefix occurrences remain generic failures
- no effect replay: overflow after a dynamic tool call is not retried and retains `Provider_rejected` recovery evidence
- no response replay: overflow after assistant streaming starts is not retried
- no cross-provider replay: the outer official-client effect disposition stays fail-closed
- strict convergence: retries use existing structural atom boundaries and the shared maximum of three shrink attempts
- codec fidelity: both measurement and transmission use the v2 official-client encoder merged in #28263

## Verification

Code and tests were validated on code-identical predecessor `5f59590095` after rebasing onto `origin/main` base `d4668756d6`. Final PR head `12c200d2e9` changes only the RFC `implementation_prs` link; `git diff --check` and the RFC index check were rerun on that exact tree.

- `git diff --check`
- `python3 scripts/rfc-generate-index.py --check`
- `ocamlformat --check` for all changed OCaml files
- focused build of `test_runtime_claude_code.exe` and `test_keeper_claude_code_runtime.exe`
- 6 exact overflow regressions: typed terminal, generic-400 negative control, tool flag, response flag, bounded restart success, post-effect no-retry
- all 9 terminal cases
- 10 non-timing MCP cases, 6 non-timing admission cases, hard-cut and session cases
- 12 non-timing Keeper lifecycle cases, including v2 typed-history projection
- `dune build @check`

Not rerun locally: the existing timing-sensitive `progress resets stream idle timeout` and `post-effect response failure requires recovery` cases. Both have produced wall-clock flakes in prior isolated runs; this change does not alter their timeout logic. GitHub CI remains the build and merge authority.

## Deployment boundary

This PR is not deployed. After merge, live proof still requires rebuilding `main_eio.exe`, restarting from that exact merge commit, and observing one oversized Claude turn settle after a smaller second attempt. Fleet-wide degraded reasons remain separate from this feature's live result.

Related: #27427
