### PR TITLE
perf(tool-log): 과다 스캔을 keeper 필터 경로로 한정 (콜드 12.7~41.2s → 0.08~0.18s)

### DIFF
--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -673,7 +673,22 @@ let read_recent ?keeper_name ?(n = 100) () : Yojson.Safe.t list =
   if n <= 0
   then []
   else (
-    let raw = read_recent_rows ~n:(n * read_over_scan_factor) () in
+    (* The over-scan pays for the keeper filter: to end up with [n] rows from
+       one keeper you must read more than [n] fleet rows. With no keeper the
+       filter keeps everything, so the extra rows are read, parsed, and then
+       discarded by [ring_keep_last] — four fifths of the work for an answer
+       that cannot change.
+
+       It is not a rounding error at this size. The tool-call log averages
+       6.8 KB per row on this host, so the fleet-wide dashboard aggregate
+       (n = 5000) read 25,000 rows = 165 MB and took 3.5 s in the tail read
+       alone, where 5,000 rows = 33 MB and 0.65 s answer the same question. *)
+    let scan_factor =
+      match keeper_name with
+      | None -> 1
+      | Some _ -> read_over_scan_factor
+    in
+    let raw = read_recent_rows ~n:(n * scan_factor) () in
     let keep =
       match keeper_name with
       | None -> fun (_ : Yojson.Safe.t) -> true

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -189,13 +189,20 @@ val read_recent :
   unit ->
   Yojson.Safe.t list
 (** [read_recent ?keeper_name ?n ()] returns the [n] most recent entries,
-    optionally filtered by keeper name. Default [n=100]. *)
+    optionally filtered by keeper name. Default [n=100]. Reads the store tail
+    only far enough to answer: [n] rows unfiltered, [n *
+    {!read_over_scan_factor}] when filtering by keeper. *)
 
 val read_over_scan_factor : int
-(** Scan multiplier [read_recent] applies before its keeper filter: it
-    reads [n * read_over_scan_factor] fleet rows to find [n] matching
-    entries. Callers sharing one fleet read ({!read_recent_rows}) size
-    their window with this to reproduce [read_recent]'s coverage. *)
+(** Scan multiplier [read_recent] applies before its keeper filter: to end up
+    with [n] rows from one keeper it reads [n * read_over_scan_factor] fleet
+    rows. Callers sharing one fleet read ({!read_recent_rows}) size their
+    window with this to reproduce a per-keeper [read_recent]'s coverage.
+
+    It applies only when [keeper_name] is given. Without one the filter keeps
+    every row, so reading past [n] would parse rows that {!read_recent} then
+    discards — on a store averaging 6.8 KB per row that was 165 MB read for an
+    answer 33 MB contains. *)
 
 val read_recent_rows : n:int -> unit -> Yojson.Safe.t list
 (** [read_recent_rows ~n ()] returns the [n] most recent fleet-wide rows

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -108,6 +108,43 @@ let test_read_recent_keeper_filter () =
 (* The dashboard /tool-calls handler derives each keeper's slice from one
    shared fleet read instead of per-keeper [read_recent] calls. The
    derivation must be observationally equal to [read_recent]. *)
+(* The unfiltered read stops at [n]; the keeper-filtered one still scans past
+   it to find [n] matches. Both have to hold at once — dropping the over-scan
+   everywhere would silently shorten per-keeper answers, and keeping it
+   everywhere reads five times the store for a fleet answer that cannot
+   change. *)
+let test_unfiltered_read_is_exactly_n_and_filtered_still_finds_n () =
+  with_tmp_log (fun () ->
+    List.iter
+      (fun (keeper, tool) ->
+        Keeper_tool_call_log.log_call
+          ~keeper_name:keeper ~tool_name:tool
+          ~input:(`Assoc []) ~output_text:"out"
+          ~success:true ~duration_ms:1.0 ())
+      [ ("alice", "t1"); ("bob", "t2"); ("bob", "t3"); ("bob", "t4")
+      ; ("bob", "t5"); ("bob", "t6"); ("bob", "t7"); ("bob", "t8")
+      ; ("bob", "t9"); ("alice", "t10")
+      ];
+    let tools rows =
+      List.map
+        (fun json ->
+          match Safe_ops.json_string_opt "tool" json with
+          | Some tool -> tool
+          | None -> "?")
+        rows
+    in
+    Alcotest.(check (list string))
+      "unfiltered read returns exactly the newest n"
+      [ "t9"; "t10" ]
+      (tools (Keeper_tool_call_log.read_recent ~n:2 ()));
+    (* alice's two rows sit at opposite ends of the store, so finding both
+       requires reading well past n — this is what the over-scan buys. *)
+    Alcotest.(check (list string))
+      "keeper-filtered read still scans past n to find n matches"
+      [ "t1"; "t10" ]
+      (tools (Keeper_tool_call_log.read_recent ~keeper_name:"alice" ~n:2 ())))
+;;
+
 let test_fleet_rows_derivation_matches_read_recent () =
   with_tmp_log (fun () ->
     List.iter
@@ -1299,6 +1336,8 @@ let () =
         ; eio_test "keeper filter" test_read_recent_keeper_filter
         ; eio_test "fleet-row derivation equals read_recent"
             test_fleet_rows_derivation_matches_read_recent
+        ; eio_test "unfiltered read is exactly n; filtered still finds n"
+            test_unfiltered_read_is_exactly_n_and_filtered_still_finds_n
         ; eio_test "exact AGENT_CORE occurrence" test_exact_agent_core_occurrence_persisted
         ] )
     ; ( "redaction",


### PR DESCRIPTION
## 문제

`read_recent ~n`이 저장소 읽기량에 `read_over_scan_factor`(5)를 **조건 없이** 곱했습니다.

이 배수의 존재 이유는 keeper 필터입니다 — 한 keeper의 행 n개를 얻으려면 fleet 행을 n개보다 많이 읽어야 합니다. 그런데 **keeper를 안 줄 때 필터는 `fun _ -> true`**입니다. 여분의 행을 읽고, 파싱하고, `ring_keep_last`가 버립니다. 바뀔 수 없는 답을 위해 5분의 4를 낭비합니다.

이 저장소 크기에서는 반올림 오차가 아닙니다. tool-call 로그는 행당 평균 **6.8 KB**입니다 (하루치 195 MB / 29,497행). 대시보드 fleet 집계는 `n=5000`이므로 25,000행을 읽고 있었습니다.

```
tail 25,000행 = 165 MB = 3.47 s   (before)
tail  5,000행 =  33 MB = 0.65 s   (after, 같은 답)
```

## 측정 (A/B, 동일 격리 base-path, 매 요청 전 서버 재시작 = 캐시 콜드)

| | 콜드 |
|---|---|
| 과다 스캔 전면 적용 (before) | **12.66 s / 41.24 s** |
| 필터 경로로 한정 (after) | **0.18 s / 0.08 s** |

41초 표본이 I/O 압박 상황의 실제 모습입니다. 그리고 이 문제는 이미 알려져 있었습니다 — `dashboard_http_tool_quality`에 *"aggregate ~n:5000 over a 24h window was measured at 30s cache miss"* 주석이 있고, 대응은 **캐시 TTL을 5s→30s로 늘린 것**이었습니다. 덜 읽는 쪽이 아니라요.

## 집계 결과는 불변

```
total=5000  success=4843  sampling_mode=recent_n  by_tool=43개
```

버려지던 행만 안 읽습니다. 표본 크기도, 표본 모드도, 결과도 그대로입니다.

## 계약 보존

`read_over_scan_factor`는 public 그대로이고 **필터 경로에서는 여전히 5**입니다. 이 상수의 소비자는 두 곳인데 둘 다 *per-keeper* `read_recent`를 재현하려는 목적입니다 — keeper API의 fleet-rows 캐시(`server_dashboard_http_keeper_api.ml:1806`)와 파생 테스트(`test_keeper_tool_call_log.ml:124`). 무필터 경로의 배수에 의존하는 소비자는 없습니다.

같은 파일 몇 함수 아래 `scan_limit`이 **이미 정확히 이 형태**입니다 (무필터 1, 필터 16). 새 패턴이 아니라 기존 패턴에 맞추는 변경입니다.

## 테스트

새 테스트가 두 성질을 **동시에** 고정합니다.

1. 무필터 읽기는 정확히 최신 n개를 반환
2. keeper 필터 읽기는 그 keeper 행이 저장소 양 끝에 있어도 n개를 찾을 때까지 n을 넘어 스캔

검증: 과다 스캔을 전면 제거하면 이 테스트와 기존 파생 테스트가 **함께 실패**합니다.
```
[FAIL] read_recent 3  fleet-row derivation equals read_recent
[FAIL] read_recent 4  unfiltered read is exactly n; filtered still finds n
ASSERT derived slice equals read_recent for alice
```

`test_keeper_tool_call_log.exe` 36/36 통과.

## 남은 것

콜드 0.18 s는 예산 안이지만, **진짜 콜드 디스크**(페이지 캐시까지 비어 있는 첫 요청)에서는 33 MB 읽기 비용이 남습니다. 근본적으로는 6.8 KB 레코드를 5,000개 읽어 소수 필드만 집계하는 구조 자체가 문제이고, `jsonl_incremental_projection`(O(추가된 바이트)) 패턴으로 옮기는 것이 정답입니다. 별도 작업으로 다룹니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
