### PR TITLE
fix(runtime): let a turn declare no deadline instead of inheriting 300s

### DIFF
--- a/lib/fusion/fusion_official_client.ml
+++ b/lib/fusion/fusion_official_client.ml
@@ -82,6 +82,14 @@ let resolved_timeout_s ~runtime_id ~default_timeout_s =
   | Some seconds -> Some seconds
 ;;
 
+let bounded_claude_probe_config ~fallback_timeout_s
+  (config : Runtime_claude_code.config)
+  =
+  match config.timeout_s with
+  | Some _ -> config
+  | None -> { config with timeout_s = Some fallback_timeout_s }
+;;
+
 let claude_config ~base_dir ~runtime_id ~system_prompt
   (execution : Runtime_execution.claude_code)
   : Runtime_claude_code.config
@@ -152,10 +160,36 @@ let run_panelist ~base_dir ~runtime_id ~system_prompt ~prompt =
          "runtime is Agent_core-owned; it belongs on the Async_agent path")
   | Runtime_execution.Claude_code execution ->
     let config = claude_config ~base_dir ~runtime_id ~system_prompt execution in
-    (match Runtime_claude_code.run_turn ~mgr ~clock ~cwd config ~prompt with
-     | Ok (result : Runtime_claude_code.turn_result) -> Ok result.text
+    let probe_config =
+      bounded_claude_probe_config
+        ~fallback_timeout_s:execution.timeout_s
+        config
+    in
+    (match
+       Runtime_claude_code.probe_subscription
+         ~mgr
+         ~clock
+         ~cwd
+         probe_config
+     with
      | Error error ->
-       Error (provider_error ~runtime_id (Runtime_claude_code.error_to_string error)))
+       Error (provider_error ~runtime_id (Runtime_claude_code.error_to_string error))
+     | Ok admitted_subscription ->
+       (match
+          Runtime_claude_code.run_turn
+            ~admitted_subscription
+            ~mgr
+            ~clock
+            ~cwd
+            config
+            ~prompt
+        with
+        | Ok (result : Runtime_claude_code.turn_result) -> Ok result.text
+        | Error error ->
+          Error
+            (provider_error
+               ~runtime_id
+               (Runtime_claude_code.error_to_string error))))
   | Runtime_execution.Codex_app_server execution ->
     let config = codex_config ~runtime_id ~system_prompt execution in
     (match Runtime_codex_app_server.run_turn ~mgr ~clock ~cwd config ~prompt with
@@ -180,4 +214,5 @@ module For_testing = struct
   (* TEL-OK: alias of a pure function; no behaviour of its own. *)
   let missing_handle_detail = missing_handle_detail
   let resolved_timeout_s = resolved_timeout_s
+  let bounded_claude_probe_config = bounded_claude_probe_config
 end

--- a/lib/fusion/fusion_official_client.ml
+++ b/lib/fusion/fusion_official_client.ml
@@ -75,28 +75,38 @@ let eio_context ~runtime_id =
    panelist runs the same client the keeper would, minus the parts a panelist
    has no business using. *)
 
-let claude_config ~base_dir ~system_prompt (execution : Runtime_execution.claude_code)
+let resolved_timeout_s ~runtime_id ~default_timeout_s =
+  match Runtime_inference.resolve_turn_timeout_s ~runtime_id with
+  | None -> Some default_timeout_s
+  | Some seconds when seconds <= 0.0 -> None
+  | Some seconds -> Some seconds
+;;
+
+let claude_config ~base_dir ~runtime_id ~system_prompt
+  (execution : Runtime_execution.claude_code)
   : Runtime_claude_code.config
   =
   { cli_path = execution.cli_path
   ; cwd = base_dir
   ; model = execution.model
   ; system_prompt
-  ; timeout_s = Some execution.timeout_s
+  ; timeout_s = resolved_timeout_s ~runtime_id ~default_timeout_s:execution.timeout_s
   }
 ;;
 
-let codex_config ~system_prompt (execution : Runtime_execution.codex_app_server)
+let codex_config ~runtime_id ~system_prompt
+  (execution : Runtime_execution.codex_app_server)
   : Runtime_codex_app_server.config
   =
   { cli_path = execution.cli_path
   ; model = execution.model
   ; developer_instructions = system_prompt
-  ; timeout_s = Some execution.timeout_s
+  ; timeout_s = resolved_timeout_s ~runtime_id ~default_timeout_s:execution.timeout_s
   }
 ;;
 
-let antigravity_config ~base_dir (execution : Runtime_execution.antigravity_cli)
+let antigravity_config ~base_dir ~runtime_id
+  (execution : Runtime_execution.antigravity_cli)
   : Runtime_antigravity.config
   =
   { cli_path = execution.cli_path
@@ -111,7 +121,7 @@ let antigravity_config ~base_dir (execution : Runtime_execution.antigravity_cli)
     execution_mode = Runtime_antigravity.Plan
   ; sandbox = true
   ; disable_slash_commands = true
-  ; timeout_s = Some execution.timeout_s
+  ; timeout_s = resolved_timeout_s ~runtime_id ~default_timeout_s:execution.timeout_s
   }
 ;;
 
@@ -141,20 +151,20 @@ let run_panelist ~base_dir ~runtime_id ~system_prompt ~prompt =
          ~runtime_id
          "runtime is Agent_core-owned; it belongs on the Async_agent path")
   | Runtime_execution.Claude_code execution ->
-    let config = claude_config ~base_dir ~system_prompt execution in
+    let config = claude_config ~base_dir ~runtime_id ~system_prompt execution in
     (match Runtime_claude_code.run_turn ~mgr ~clock ~cwd config ~prompt with
      | Ok (result : Runtime_claude_code.turn_result) -> Ok result.text
      | Error error ->
        Error (provider_error ~runtime_id (Runtime_claude_code.error_to_string error)))
   | Runtime_execution.Codex_app_server execution ->
-    let config = codex_config ~system_prompt execution in
+    let config = codex_config ~runtime_id ~system_prompt execution in
     (match Runtime_codex_app_server.run_turn ~mgr ~clock ~cwd config ~prompt with
      | Ok (result : Runtime_codex_app_server.turn_result) -> Ok result.text
      | Error error ->
        Error
          (provider_error ~runtime_id (Runtime_codex_app_server.error_to_string error)))
   | Runtime_execution.Antigravity_cli execution ->
-    let config = antigravity_config ~base_dir execution in
+    let config = antigravity_config ~base_dir ~runtime_id execution in
     (* [home_dir] is left unset so the client uses the inherited HOME, which is
        where its OAuth token already lives. The keeper path overrides it for
        per-keeper isolation; a panelist has no durable state to isolate. *)
@@ -169,4 +179,5 @@ module For_testing = struct
      process-global Eio context, which has no reset. *)
   (* TEL-OK: alias of a pure function; no behaviour of its own. *)
   let missing_handle_detail = missing_handle_detail
+  let resolved_timeout_s = resolved_timeout_s
 end

--- a/lib/fusion/fusion_official_client.ml
+++ b/lib/fusion/fusion_official_client.ml
@@ -98,6 +98,7 @@ let claude_config ~base_dir ~runtime_id ~system_prompt
   ; cwd = base_dir
   ; model = execution.model
   ; system_prompt
+  ; admission_timeout_s = execution.timeout_s
   ; timeout_s = resolved_timeout_s ~runtime_id ~default_timeout_s:execution.timeout_s
   }
 ;;
@@ -109,6 +110,7 @@ let codex_config ~runtime_id ~system_prompt
   { cli_path = execution.cli_path
   ; model = execution.model
   ; developer_instructions = system_prompt
+  ; admission_timeout_s = execution.timeout_s
   ; timeout_s = resolved_timeout_s ~runtime_id ~default_timeout_s:execution.timeout_s
   }
 ;;
@@ -129,6 +131,7 @@ let antigravity_config ~base_dir ~runtime_id
     execution_mode = Runtime_antigravity.Plan
   ; sandbox = true
   ; disable_slash_commands = true
+  ; admission_timeout_s = execution.timeout_s
   ; timeout_s = resolved_timeout_s ~runtime_id ~default_timeout_s:execution.timeout_s
   }
 ;;

--- a/lib/fusion/fusion_official_client.ml
+++ b/lib/fusion/fusion_official_client.ml
@@ -82,7 +82,7 @@ let claude_config ~base_dir ~system_prompt (execution : Runtime_execution.claude
   ; cwd = base_dir
   ; model = execution.model
   ; system_prompt
-  ; timeout_s = execution.timeout_s
+  ; timeout_s = Some execution.timeout_s
   }
 ;;
 
@@ -92,7 +92,7 @@ let codex_config ~system_prompt (execution : Runtime_execution.codex_app_server)
   { cli_path = execution.cli_path
   ; model = execution.model
   ; developer_instructions = system_prompt
-  ; timeout_s = execution.timeout_s
+  ; timeout_s = Some execution.timeout_s
   }
 ;;
 
@@ -111,7 +111,7 @@ let antigravity_config ~base_dir (execution : Runtime_execution.antigravity_cli)
     execution_mode = Runtime_antigravity.Plan
   ; sandbox = true
   ; disable_slash_commands = true
-  ; timeout_s = execution.timeout_s
+  ; timeout_s = Some execution.timeout_s
   }
 ;;
 

--- a/lib/fusion/fusion_official_client.mli
+++ b/lib/fusion/fusion_official_client.mli
@@ -21,6 +21,13 @@ module For_testing : sig
   (** The failure detail for an unresolvable Eio context, or [None] when both
       handles are present. Exposed because {!Eio_context} has no reset, so a
       test driving the real globals could reach these arms in only one order. *)
+
+  val resolved_timeout_s
+    :  runtime_id:string
+    -> default_timeout_s:float
+    -> float option
+  (** Resolve the same declared turn timeout used by each official-client
+      panel adapter. [turn-timeout-s = 0] produces [None]. *)
 end
 
 val run_panelist

--- a/lib/fusion/fusion_official_client.mli
+++ b/lib/fusion/fusion_official_client.mli
@@ -28,6 +28,13 @@ module For_testing : sig
     -> float option
   (** Resolve the same declared turn timeout used by each official-client
       panel adapter. [turn-timeout-s = 0] produces [None]. *)
+
+  val bounded_claude_probe_config
+    :  fallback_timeout_s:float
+    -> Runtime_claude_code.config
+    -> Runtime_claude_code.config
+  (** Keep Claude's login-only process bounded when its following model turn
+      explicitly declares no deadline. *)
 end
 
 val run_panelist
@@ -47,4 +54,5 @@ val run_panelist
     them, so no fusion signature has to thread them through.
 
     Timeouts stay owned by each adapter's own configuration; this module adds no
-    second deadline, so a panel-level timeout still bounds the whole fan-out. *)
+    second turn deadline. Claude's login-only preflight remains bounded even
+    when the following model turn explicitly has no deadline. *)

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -328,13 +328,17 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ; execution_mode = Plan
       ; sandbox = true
       ; disable_slash_commands = true
-      ; (* A per-model [turn-timeout-s] overrides the stream-idle bound.
-           Absent, [config.timeout_s] stands, so a config that declares none
-           behaves exactly as before. *)
+      ; (* A per-model [turn-timeout-s] overrides the stream-idle bound, and
+           [0] removes it: the deadline exists to notice a client that has gone
+           silent, not to cap how long legitimate work may take, so a
+           deployment is allowed to say the client decides. Absent leaves
+           [config.timeout_s] standing, which keeps an undeclared config on the
+           previous behaviour. *)
         timeout_s =
-          Option.value
-            (Runtime_inference.resolve_turn_timeout_s ~runtime_id)
-            ~default:config.timeout_s
+          (match Runtime_inference.resolve_turn_timeout_s ~runtime_id with
+           | None -> Some config.timeout_s
+           | Some seconds when seconds <= 0.0 -> None
+           | Some seconds -> Some seconds)
       }
     in
     let* () =

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -328,6 +328,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ; execution_mode = Plan
       ; sandbox = true
       ; disable_slash_commands = true
+      ; admission_timeout_s = config.timeout_s
       ; (* A per-model [turn-timeout-s] overrides the stream-idle bound, and
            [0] removes it: the deadline exists to notice a client that has gone
            silent, not to cap how long legitimate work may take, so a

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -346,13 +346,17 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ; cwd = base_path
       ; model = config.model
       ; system_prompt
-      ; (* A per-model [turn-timeout-s] overrides the stream-idle bound.
-           Absent, [config.timeout_s] stands, so a config that declares none
-           behaves exactly as before. *)
+      ; (* A per-model [turn-timeout-s] overrides the stream-idle bound, and
+           [0] removes it: the deadline exists to notice a client that has gone
+           silent, not to cap how long legitimate work may take, so a
+           deployment is allowed to say the client decides. Absent leaves
+           [config.timeout_s] standing, which keeps an undeclared config on the
+           previous behaviour. *)
         timeout_s =
-          Option.value
-            (Runtime_inference.resolve_turn_timeout_s ~runtime_id)
-            ~default:config.timeout_s
+          (match Runtime_inference.resolve_turn_timeout_s ~runtime_id with
+           | None -> Some config.timeout_s
+           | Some seconds when seconds <= 0.0 -> None
+           | Some seconds -> Some seconds)
       }
     in
     let terminal_error = ref None in

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -13,6 +13,18 @@ type attempt_outcome =
 
 let runtime_label = "Claude Code"
 
+let bounded_probe_config ~fallback_timeout_s
+  (config : Runtime_claude_code.config)
+  =
+  match config.timeout_s with
+  | Some _ -> config
+  | None -> { config with timeout_s = Some fallback_timeout_s }
+;;
+
+module For_testing = struct
+  let bounded_probe_config = bounded_probe_config
+end
+
 let project_messages messages =
   let rec loop system history = function
     | [] -> Ok (List.rev system, List.rev history)
@@ -387,13 +399,16 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     in
     let process_mgr = Eio.Stdenv.process_mgr env in
     let process_cwd = Eio.Path.(Eio.Stdenv.fs env / base_path) in
+    let probe_config =
+      bounded_probe_config ~fallback_timeout_s:config.timeout_s client_config
+    in
     let* admitted_subscription =
       match
         Runtime_claude_code.probe_subscription
           ~mgr:process_mgr
           ~clock
           ~cwd:process_cwd
-          client_config
+          probe_config
       with
       | Ok subscription -> Ok subscription
       | Error error -> Error (claude_error_to_core_error error)

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -358,6 +358,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       ; cwd = base_path
       ; model = config.model
       ; system_prompt
+      ; admission_timeout_s = config.timeout_s
       ; (* A per-model [turn-timeout-s] overrides the stream-idle bound, and
            [0] removes it: the deadline exists to notice a client that has gone
            silent, not to cap how long legitimate work may take, so a

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -9,6 +9,15 @@ type attempt_outcome =
     [No_effect_observed]; once the model turn is dispatched, the adapter fails
     closed with [Observation_unavailable]. *)
 
+module For_testing : sig
+  val bounded_probe_config
+    :  fallback_timeout_s:float
+    -> Runtime_claude_code.config
+    -> Runtime_claude_code.config
+  (** Keep an explicit turn bound unchanged and give an unbounded turn config a
+      finite login-probe fallback. *)
+end
+
 val run :
   runtime_id:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -436,6 +436,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       { Runtime_codex_app_server.cli_path = config.cli_path
       ; model = config.model
       ; developer_instructions
+      ; admission_timeout_s = config.timeout_s
       ; (* A per-model [turn-timeout-s] overrides the stream-idle bound, and
            [0] removes it: the deadline exists to notice a client that has gone
            silent, not to cap how long legitimate work may take, so a

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -436,13 +436,17 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       { Runtime_codex_app_server.cli_path = config.cli_path
       ; model = config.model
       ; developer_instructions
-      ; (* A per-model [turn-timeout-s] overrides the stream-idle bound.
-           Absent, [config.timeout_s] stands, so a config that declares none
-           behaves exactly as before. *)
+      ; (* A per-model [turn-timeout-s] overrides the stream-idle bound, and
+           [0] removes it: the deadline exists to notice a client that has gone
+           silent, not to cap how long legitimate work may take, so a
+           deployment is allowed to say the client decides. Absent leaves
+           [config.timeout_s] standing, which keeps an undeclared config on the
+           previous behaviour. *)
         timeout_s =
-          Option.value
-            (Runtime_inference.resolve_turn_timeout_s ~runtime_id)
-            ~default:config.timeout_s
+          (match Runtime_inference.resolve_turn_timeout_s ~runtime_id with
+           | None -> Some config.timeout_s
+           | Some seconds when seconds <= 0.0 -> None
+           | Some seconds -> Some seconds)
       }
     in
     let terminal_error = ref None in

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -22,6 +22,7 @@ type config =
   ; execution_mode : execution_mode
   ; sandbox : bool
   ; disable_slash_commands : bool
+  ; admission_timeout_s : float
   ; timeout_s : float option
   }
 
@@ -58,8 +59,15 @@ let default_config ~cwd ~model =
   ; execution_mode = Plan
   ; sandbox = false
   ; disable_slash_commands = true
+  ; admission_timeout_s = default_timeout_s
   ; timeout_s = Some default_timeout_s
   }
+;;
+
+let timeout_s_for_phase config ~turn_admitted =
+  if turn_admitted
+  then config.timeout_s
+  else Some config.admission_timeout_s
 ;;
 
 type conversation_mode =
@@ -390,6 +398,10 @@ let validate_config config ~conversation_mode ~prompt =
   else if String.trim config.model = ""
   then Error (Invalid_config "model must not be empty")
   else if
+    not (Float.is_finite config.admission_timeout_s)
+    || config.admission_timeout_s <= 0.0
+  then Error (Invalid_config "admission_timeout_s must be positive and finite")
+  else if
     (match config.timeout_s with
      | None -> false
      | Some seconds -> not (Float.is_finite seconds) || seconds <= 0.0)
@@ -691,21 +703,33 @@ let run_spawned ?home_dir ?on_spawned ~mgr ~clock ~cwd config ~conversation_mode
     let state = ref initial_protocol_state in
     (try
        while true do
+         let timeout_s =
+           timeout_s_for_phase config ~turn_admitted:(Option.is_some !state.init)
+         in
          let line =
-           with_optional_timeout clock config.timeout_s (fun () ->
-             Eio.Buf_read.line reader)
+           try
+             with_optional_timeout clock timeout_s (fun () ->
+               Eio.Buf_read.line reader)
+           with
+           | Eio.Time.Timeout ->
+             abort_with_runtime_error (timeout_or_defect timeout_s)
          in
          match parse_wire_line line with
          | Error error -> abort_with_runtime_error error
          | Ok event ->
            (match
-              apply_event
-                config
-                ~conversation_mode
-                ~on_conversation_ready
-                ~on_stream_event
-                !state
-                event
+              try
+                with_optional_timeout clock timeout_s (fun () ->
+                  apply_event
+                    config
+                    ~conversation_mode
+                    ~on_conversation_ready
+                    ~on_stream_event
+                    !state
+                    event)
+              with
+              | Eio.Time.Timeout ->
+                abort_with_runtime_error (timeout_or_defect timeout_s)
             with
             | Error error -> abort_with_runtime_error error
             | Ok next -> state := next)
@@ -716,8 +740,6 @@ let run_spawned ?home_dir ?on_spawned ~mgr ~clock ~cwd config ~conversation_mode
        signal_spawned_process proc stdin_w;
        process_settled := true;
        raise exn
-     | Eio.Time.Timeout ->
-       abort_with_runtime_error (timeout_or_defect config.timeout_s)
      | Runtime_error _ as exn -> raise exn
      | exn ->
        abort_with_runtime_error

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -143,23 +143,6 @@ let error_to_string = function
   | Timeout seconds -> Printf.sprintf "Antigravity stream was idle for %.3fs" seconds
 ;;
 
-(* [None] installs no timer, and the only other [Eio.Time.with_timeout_exn] in
-   this module is the process-termination grace window, which catches its own
-   [Eio.Time.Timeout] and reaps. So this arm exists for totality and is not
-   reachable by either timer. Reaching it means a deadline was installed by a
-   path this reasoning does not cover — that is a defect to find, not a turn
-   limit to report, so it must not be dressed up as one. *)
-let timeout_or_defect = function
-  | Some seconds -> Timeout seconds
-  | None ->
-    Protocol_error
-      { stage = "turn deadline"
-      ; detail = "Eio timeout raised while no turn deadline was installed"
-      }
-;;
-
-let timeout_error timeout_s = Error (timeout_or_defect timeout_s)
-
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
 let ( let* ) result f = Result.bind result f
 
@@ -176,6 +159,15 @@ end)
 open Shared_json
 
 let bounded_tail = Runtime_official_client_json.bounded_tail
+
+(* See {!Runtime_official_client_json.Make.no_turn_deadline_defect} for why the
+   [None] arm is unreachable and why it must not be dressed as a turn limit. *)
+let timeout_or_defect = function
+  | Some seconds -> Timeout seconds
+  | None -> Shared_json.no_turn_deadline_defect
+;;
+
+let timeout_error timeout_s = Error (timeout_or_defect timeout_s)
 
 let required_string ?(nonempty = true) stage name fields =
   match List.assoc_opt name fields with

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -143,16 +143,22 @@ let error_to_string = function
   | Timeout seconds -> Printf.sprintf "Antigravity stream was idle for %.3fs" seconds
 ;;
 
-(* An [Eio.Time.Timeout] can still arrive with no turn bound installed: the
-   process-termination grace window is its own deadline. Reporting that as a
-   turn timeout would name a limit the operator never set. *)
-let timeout_error = function
-  | Some seconds -> Error (Timeout seconds)
+(* [None] installs no timer, and the only other [Eio.Time.with_timeout_exn] in
+   this module is the process-termination grace window, which catches its own
+   [Eio.Time.Timeout] and reaps. So this arm exists for totality and is not
+   reachable by either timer. Reaching it means a deadline was installed by a
+   path this reasoning does not cover — that is a defect to find, not a turn
+   limit to report, so it must not be dressed up as one. *)
+let timeout_or_defect = function
+  | Some seconds -> Timeout seconds
   | None ->
-    Error
-      (Process_exited
-         "client did not settle within the process-termination grace window")
+    Protocol_error
+      { stage = "turn deadline"
+      ; detail = "Eio timeout raised while no turn deadline was installed"
+      }
 ;;
+
+let timeout_error timeout_s = Error (timeout_or_defect timeout_s)
 
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
 let ( let* ) result f = Result.bind result f
@@ -718,7 +724,8 @@ let run_spawned ?home_dir ?on_spawned ~mgr ~clock ~cwd config ~conversation_mode
        signal_spawned_process proc stdin_w;
        process_settled := true;
        raise exn
-     | Eio.Time.Timeout -> abort_with_runtime_error (Timeout config.timeout_s)
+     | Eio.Time.Timeout ->
+       abort_with_runtime_error (timeout_or_defect config.timeout_s)
      | Runtime_error _ as exn -> raise exn
      | exn ->
        abort_with_runtime_error

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -22,11 +22,20 @@ type config =
   ; execution_mode : execution_mode
   ; sandbox : bool
   ; disable_slash_commands : bool
-  ; timeout_s : float
+  ; timeout_s : float option
   }
 
 let default_timeout_s = 300.0
 let process_termination_grace_s = 2.0
+
+(* [None] installs no deadline. The vendor client owns when its own turn ends;
+   a declared bound is the operator's optional liveness guard over a silent
+   client, not a limit on how long legitimate work may take. *)
+let with_optional_timeout clock timeout_s f =
+  match timeout_s with
+  | None -> f ()
+  | Some seconds -> Eio.Time.with_timeout_exn clock seconds f
+;;
 let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 8192
 let max_wire_line_bytes = 8 * 1024 * 1024
@@ -49,7 +58,7 @@ let default_config ~cwd ~model =
   ; execution_mode = Plan
   ; sandbox = false
   ; disable_slash_commands = true
-  ; timeout_s = default_timeout_s
+  ; timeout_s = Some default_timeout_s
   }
 ;;
 
@@ -132,6 +141,17 @@ let error_to_string = function
   | Turn_failed detail -> "Antigravity turn failed: " ^ detail
   | Process_exited detail -> "Antigravity CLI exited before completion: " ^ detail
   | Timeout seconds -> Printf.sprintf "Antigravity stream was idle for %.3fs" seconds
+;;
+
+(* An [Eio.Time.Timeout] can still arrive with no turn bound installed: the
+   process-termination grace window is its own deadline. Reporting that as a
+   turn timeout would name a limit the operator never set. *)
+let timeout_error = function
+  | Some seconds -> Error (Timeout seconds)
+  | None ->
+    Error
+      (Process_exited
+         "client did not settle within the process-termination grace window")
 ;;
 
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
@@ -371,8 +391,11 @@ let validate_config config ~conversation_mode ~prompt =
   then Error (Invalid_config "cwd must be an absolute path")
   else if String.trim config.model = ""
   then Error (Invalid_config "model must not be empty")
-  else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
-  then Error (Invalid_config "timeout_s must be positive and finite")
+  else if
+    (match config.timeout_s with
+     | None -> false
+     | Some seconds -> not (Float.is_finite seconds) || seconds <= 0.0)
+  then Error (Invalid_config "a declared timeout_s must be positive and finite")
   else if String.trim prompt = ""
   then Error (Invalid_config "prompt must not be empty")
   else
@@ -671,7 +694,7 @@ let run_spawned ?home_dir ?on_spawned ~mgr ~clock ~cwd config ~conversation_mode
     (try
        while true do
          let line =
-           Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+           with_optional_timeout clock config.timeout_s (fun () ->
              Eio.Buf_read.line reader)
          in
          match parse_wire_line line with
@@ -733,7 +756,7 @@ let run_turn ?(conversation_mode = Start) ?home_dir ?on_spawned ~mgr ~clock ~cwd
            ~on_conversation_ready
            ~on_stream_event)
     with
-    | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+    | Eio.Time.Timeout -> timeout_error config.timeout_s
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Runtime_error error -> Error error
     | exn ->

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -22,7 +22,10 @@ type config =
   ; execution_mode : execution_mode
   ; sandbox : bool
   ; disable_slash_commands : bool
-  ; timeout_s : float
+  ; timeout_s : float option
+    (** [None] installs no deadline: the spawned client decides when its own
+        turn ends, the posture of running the CLI directly. Declared as
+        [turn-timeout-s] in runtime config, where [0] selects [None]. *)
     (** Maximum silence between valid stream-json messages. It is not a total
         turn-duration bound. *)
   }

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -22,10 +22,13 @@ type config =
   ; execution_mode : execution_mode
   ; sandbox : bool
   ; disable_slash_commands : bool
+  ; admission_timeout_s : float
+    (** Finite bound for process startup and the first [init] event. *)
   ; timeout_s : float option
-    (** [None] installs no deadline: the spawned client decides when its own
-        turn ends, the posture of running the CLI directly. Declared as
-        [turn-timeout-s] in runtime config, where [0] selects [None]. *)
+    (** [None] removes the deadline after the first [init] event: the spawned
+        client decides when its own turn ends. Startup remains bounded by
+        [admission_timeout_s]. Declared as [turn-timeout-s] in runtime config,
+        where [0] selects [None]. *)
     (** Maximum silence between valid stream-json messages. It is not a total
         turn-duration bound. *)
   }

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -203,15 +203,20 @@ let error_kind = function
   | Timeout _ -> "timeout"
 ;;
 
-(* An [Eio.Time.Timeout] can still arrive with no turn bound installed: the
-   process-termination grace window is its own deadline. Reporting that as a
-   turn timeout would name a limit the operator never set. *)
+(* [None] installs no timer, and the only other [Eio.Time.with_timeout_exn] in
+   this module is the process-termination grace window, which catches its own
+   [Eio.Time.Timeout] and reaps. So this arm exists for totality and is not
+   reachable by either timer. Reaching it means a deadline was installed by a
+   path this reasoning does not cover — that is a defect to find, not a turn
+   limit to report, so it must not be dressed up as one. *)
 let timeout_error = function
   | Some seconds -> Error (Timeout seconds)
   | None ->
     Error
-      (Process_exited
-         "client did not settle within the process-termination grace window")
+      (Protocol_error
+         { stage = "turn deadline"
+         ; detail = "Eio timeout raised while no turn deadline was installed"
+         })
 ;;
 
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
@@ -1079,7 +1084,7 @@ let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
         let with_timeout callback =
-          Eio.Time.with_timeout_exn clock config.timeout_s callback
+          with_optional_timeout clock config.timeout_s callback
         in
         run_protocol
           { send; receive }

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -9,6 +9,7 @@ type config =
   ; cwd : string
   ; model : string option
   ; system_prompt : string option
+  ; admission_timeout_s : float
   ; timeout_s : float option
   }
 
@@ -33,8 +34,15 @@ let default_config ~cwd =
   ; cwd
   ; model = None
   ; system_prompt = None
+  ; admission_timeout_s = default_timeout_s
   ; timeout_s = Some default_timeout_s
   }
+;;
+
+let timeout_s_for_phase config ~turn_admitted =
+  if turn_admitted
+  then config.timeout_s
+  else Some config.admission_timeout_s
 ;;
 
 type session_mode =
@@ -963,7 +971,7 @@ let terminate_spawned_process ~clock proc stdin_w =
 
 let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
     ~prompt ~on_session_ready ~on_turn_starting ~on_turn_started
-    ~on_stream_event =
+    ~on_stream_event ~turn_admitted =
   let tool_call_count = ref 0 in
   let mcp_session = Runtime_official_client_mcp.create_session () in
   let initialize_id = Random_id.prefixed ~prefix:"masc-init-" ~bytes:12 in
@@ -989,6 +997,7 @@ let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
   let* () =
     try
       io.send (user_message prompt);
+      turn_admitted := true;
       Ok ()
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -1027,7 +1036,9 @@ let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
   let* argv =
     command config ~dynamic_tools ~reasoning_effort ~session_mode ~session_id
   in
-  Eio.Switch.run (fun sw ->
+  let turn_admitted = ref false in
+  try
+    Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
     let stderr_r, stderr_w = Eio.Process.pipe ~sw mgr in
@@ -1053,21 +1064,25 @@ let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
     Eio.Flow.close stderr_w;
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
+    let current_timeout_s () =
+      timeout_s_for_phase config ~turn_admitted:!turn_admitted
+    in
     let send json =
-      with_optional_timeout clock config.timeout_s (fun () ->
+      with_optional_timeout clock (current_timeout_s ()) (fun () ->
         Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
         Eio.Flow.copy_string "\n" stdin_w)
     in
     let receive () =
+      let timeout_s = current_timeout_s () in
       try
-        with_optional_timeout clock config.timeout_s (fun () ->
+        with_optional_timeout clock timeout_s (fun () ->
           Eio.Buf_read.line reader)
         |> parse_wire_line
       with
       | End_of_file ->
         let detail = String.trim !stderr_tail in
         Error (Process_exited (if detail = "" then "stdout closed" else detail))
-      | Eio.Time.Timeout -> timeout_error config.timeout_s
+      | Eio.Time.Timeout -> timeout_error timeout_s
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> protocol_error "stdout read" (Printexc.to_string exn)
     in
@@ -1075,7 +1090,7 @@ let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
         let with_timeout callback =
-          with_optional_timeout clock config.timeout_s callback
+          with_optional_timeout clock (current_timeout_s ()) callback
         in
         run_protocol
           { send; receive }
@@ -1090,7 +1105,11 @@ let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
             with_timeout (fun () -> on_turn_starting ~session_id))
           ~on_turn_started:(fun ~session_id ~turn_id ->
             with_timeout (fun () -> on_turn_started ~session_id ~turn_id))
-          ~on_stream_event))
+          ~on_stream_event
+          ~turn_admitted))
+  with
+  | Eio.Time.Timeout ->
+    timeout_error (timeout_s_for_phase config ~turn_admitted:!turn_admitted)
 ;;
 
 let validate_process_config config =
@@ -1098,6 +1117,10 @@ let validate_process_config config =
   then Error (Invalid_config "cli_path must not be empty")
   else if String.trim config.cwd = "" || Filename.is_relative config.cwd
   then Error (Invalid_config "cwd must be an absolute path")
+  else if
+    not (Float.is_finite config.admission_timeout_s)
+    || config.admission_timeout_s <= 0.0
+  then Error (Invalid_config "admission_timeout_s must be positive and finite")
   else if
     (match config.timeout_s with
      | None -> false
@@ -1151,12 +1174,13 @@ let validate_turn ?(dynamic_tools = []) ?(session_mode = Start) config ~prompt =
 
 let probe_subscription ~mgr ~clock ~cwd config =
   let* () = validate_process_config config in
+  let timeout_s = Some config.admission_timeout_s in
   try
-    with_optional_timeout clock config.timeout_s (fun () ->
+    with_optional_timeout clock timeout_s (fun () ->
       read_subscription ~mgr ~cwd config)
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | Eio.Time.Timeout -> timeout_error config.timeout_s
+  | Eio.Time.Timeout -> timeout_error timeout_s
 ;;
 
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -9,11 +9,20 @@ type config =
   ; cwd : string
   ; model : string option
   ; system_prompt : string option
-  ; timeout_s : float
+  ; timeout_s : float option
   }
 
 let default_timeout_s = 300.0
 let process_termination_grace_s = 2.0
+
+(* [None] installs no deadline. The vendor client owns when its own turn ends;
+   a declared bound is the operator's optional liveness guard over a silent
+   client, not a limit on how long legitimate work may take. *)
+let with_optional_timeout clock timeout_s f =
+  match timeout_s with
+  | None -> f ()
+  | Some seconds -> Eio.Time.with_timeout_exn clock seconds f
+;;
 let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 4096
 let max_wire_line_bytes = 8 * 1024 * 1024
@@ -24,7 +33,7 @@ let default_config ~cwd =
   ; cwd
   ; model = None
   ; system_prompt = None
-  ; timeout_s = default_timeout_s
+  ; timeout_s = Some default_timeout_s
   }
 ;;
 
@@ -192,6 +201,17 @@ let error_kind = function
   | Quota_blocked _ -> "quota_blocked"
   | Process_exited _ -> "process_exited"
   | Timeout _ -> "timeout"
+;;
+
+(* An [Eio.Time.Timeout] can still arrive with no turn bound installed: the
+   process-termination grace window is its own deadline. Reporting that as a
+   turn timeout would name a limit the operator never set. *)
+let timeout_error = function
+  | Some seconds -> Error (Timeout seconds)
+  | None ->
+    Error
+      (Process_exited
+         "client did not settle within the process-termination grace window")
 ;;
 
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
@@ -1038,20 +1058,20 @@ let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
     let send json =
-      Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+      with_optional_timeout clock config.timeout_s (fun () ->
         Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
         Eio.Flow.copy_string "\n" stdin_w)
     in
     let receive () =
       try
-        Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+        with_optional_timeout clock config.timeout_s (fun () ->
           Eio.Buf_read.line reader)
         |> parse_wire_line
       with
       | End_of_file ->
         let detail = String.trim !stderr_tail in
         Error (Process_exited (if detail = "" then "stdout closed" else detail))
-      | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+      | Eio.Time.Timeout -> timeout_error config.timeout_s
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> protocol_error "stdout read" (Printexc.to_string exn)
     in
@@ -1082,8 +1102,11 @@ let validate_process_config config =
   then Error (Invalid_config "cli_path must not be empty")
   else if String.trim config.cwd = "" || Filename.is_relative config.cwd
   then Error (Invalid_config "cwd must be an absolute path")
-  else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
-  then Error (Invalid_config "timeout_s must be positive and finite")
+  else if
+    (match config.timeout_s with
+     | None -> false
+     | Some seconds -> not (Float.is_finite seconds) || seconds <= 0.0)
+  then Error (Invalid_config "a declared timeout_s must be positive and finite")
   else Ok ()
 ;;
 
@@ -1133,11 +1156,11 @@ let validate_turn ?(dynamic_tools = []) ?(session_mode = Start) config ~prompt =
 let probe_subscription ~mgr ~clock ~cwd config =
   let* () = validate_process_config config in
   try
-    Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+    with_optional_timeout clock config.timeout_s (fun () ->
       read_subscription ~mgr ~cwd config)
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+  | Eio.Time.Timeout -> timeout_error config.timeout_s
 ;;
 
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
@@ -1181,7 +1204,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
         ~on_stream_event
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | Eio.Time.Timeout -> Error (Timeout config.timeout_s)
+    | Eio.Time.Timeout -> timeout_error config.timeout_s
     | Runtime_error error -> Error error
     | exn ->
       Error

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -203,22 +203,6 @@ let error_kind = function
   | Timeout _ -> "timeout"
 ;;
 
-(* [None] installs no timer, and the only other [Eio.Time.with_timeout_exn] in
-   this module is the process-termination grace window, which catches its own
-   [Eio.Time.Timeout] and reaps. So this arm exists for totality and is not
-   reachable by either timer. Reaching it means a deadline was installed by a
-   path this reasoning does not cover — that is a defect to find, not a turn
-   limit to report, so it must not be dressed up as one. *)
-let timeout_error = function
-  | Some seconds -> Error (Timeout seconds)
-  | None ->
-    Error
-      (Protocol_error
-         { stage = "turn deadline"
-         ; detail = "Eio timeout raised while no turn deadline was installed"
-         })
-;;
-
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
 let ( let* ) result f = Result.bind result f
 
@@ -235,6 +219,13 @@ end)
 open Shared_json
 
 let bounded_tail = Runtime_official_client_json.bounded_tail
+
+(* See {!Runtime_official_client_json.Make.no_turn_deadline_defect} for why the
+   [None] arm is unreachable and why it must not be dressed as a turn limit. *)
+let timeout_error = function
+  | Some seconds -> Error (Timeout seconds)
+  | None -> Error Shared_json.no_turn_deadline_defect
+;;
 
 let parse_json ~stage text =
   let parsed =

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -15,7 +15,10 @@ type config =
   ; cwd : string
   ; model : string option
   ; system_prompt : string option
-  ; timeout_s : float
+  ; timeout_s : float option
+    (** [None] installs no deadline: the spawned client decides when its own
+        turn ends, the posture of running the CLI directly. Declared as
+        [turn-timeout-s] in runtime config, where [0] selects [None]. *)
     (** Maximum silence between CLI stream messages. Each received message
         resets the deadline; a progressing turn has no wall limit. *)
   }

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -15,10 +15,14 @@ type config =
   ; cwd : string
   ; model : string option
   ; system_prompt : string option
+  ; admission_timeout_s : float
+    (** Finite bound for process setup and the initialize exchange before the
+        user turn is written. *)
   ; timeout_s : float option
-    (** [None] installs no deadline: the spawned client decides when its own
-        turn ends, the posture of running the CLI directly. Declared as
-        [turn-timeout-s] in runtime config, where [0] selects [None]. *)
+    (** [None] removes the deadline after the user message is written: the
+        spawned client decides when its own turn ends. Initialization remains
+        bounded by [admission_timeout_s]. Declared as [turn-timeout-s] in
+        runtime config, where [0] selects [None]. *)
     (** Maximum silence between CLI stream messages. Each received message
         resets the deadline; a progressing turn has no wall limit. *)
   }

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -18,6 +18,7 @@ type config =
   { cli_path : string
   ; model : string option
   ; developer_instructions : string option
+  ; admission_timeout_s : float
   ; timeout_s : float option
   }
 
@@ -45,8 +46,15 @@ let default_config () =
   { cli_path = "codex"
   ; model = None
   ; developer_instructions = None
+  ; admission_timeout_s = default_timeout_s
   ; timeout_s = Some default_timeout_s
   }
+;;
+
+let timeout_s_for_phase config ~turn_accepted =
+  if turn_accepted
+  then config.timeout_s
+  else Some config.admission_timeout_s
 ;;
 
 type thread_mode =
@@ -974,7 +982,7 @@ let terminate_spawned_process ~clock proc stdin_w =
           (Printexc.to_string exn))
 ;;
 
-let with_spawned_client ~mgr ~clock ~cwd config run =
+let with_spawned_client ~mgr ~clock ~cwd config ~turn_accepted run =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -991,14 +999,18 @@ let with_spawned_client ~mgr ~clock ~cwd config run =
     Eio.Flow.close stderr_w;
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
+    let current_timeout_s () =
+      timeout_s_for_phase config ~turn_accepted:!turn_accepted
+    in
     let send json =
-      with_optional_timeout clock config.timeout_s (fun () ->
+      with_optional_timeout clock (current_timeout_s ()) (fun () ->
         Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
         Eio.Flow.copy_string "\n" stdin_w)
     in
     let receive () =
+      let timeout_s = current_timeout_s () in
       try
-        with_optional_timeout clock config.timeout_s (fun () ->
+        with_optional_timeout clock timeout_s (fun () ->
           Eio.Buf_read.line reader)
         |> parse_wire_line
       with
@@ -1008,7 +1020,7 @@ let with_spawned_client ~mgr ~clock ~cwd config run =
       | Eio.Time.Timeout ->
         (* The transport cannot know whether turn/start was already accepted;
            the entry points rewrap with the observed turn state. *)
-        timeout_error ~turn_accepted:false config.timeout_s
+        timeout_error ~turn_accepted:!turn_accepted timeout_s
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> protocol_error "stdout read" (Printexc.to_string exn)
     in
@@ -1023,10 +1035,13 @@ let with_spawned_client ~mgr ~clock ~cwd config run =
 
 let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
     ~reasoning_effort ~thread_mode ~history ~prompt ~on_thread_ready
-    ~on_turn_starting ~on_turn_started ~on_stream_event =
-  with_spawned_client ~mgr ~clock ~cwd config (fun io ->
+    ~on_turn_starting ~on_turn_started ~on_stream_event ~turn_accepted =
+  with_spawned_client ~mgr ~clock ~cwd config ~turn_accepted (fun io ->
     let with_timeout callback =
-      with_optional_timeout clock config.timeout_s callback
+      with_optional_timeout
+        clock
+        (timeout_s_for_phase config ~turn_accepted:!turn_accepted)
+        callback
     in
     run_protocol
       io
@@ -1062,6 +1077,10 @@ let native_cwd cwd =
 let validate_process_config config =
   if String.trim config.cli_path = ""
   then Error (Invalid_config "cli_path must not be empty")
+  else if
+    not (Float.is_finite config.admission_timeout_s)
+    || config.admission_timeout_s <= 0.0
+  then Error (Invalid_config "admission_timeout_s must be positive and finite")
   else if
     (match config.timeout_s with
      | None -> false
@@ -1114,11 +1133,22 @@ let probe_subscription ~mgr ~clock ~cwd config =
   let result =
     let* () = validate_process_config config in
     let* _ = native_cwd cwd in
-    try with_spawned_client ~mgr ~clock ~cwd config probe_protocol with
+    let turn_accepted = ref false in
+    try
+      with_spawned_client
+        ~mgr
+        ~clock
+        ~cwd
+        config
+        ~turn_accepted
+        probe_protocol
+    with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Eio.Time.Timeout ->
       (* The probe never starts a turn. *)
-      timeout_error ~turn_accepted:false config.timeout_s
+      timeout_error
+        ~turn_accepted:false
+        (timeout_s_for_phase config ~turn_accepted:false)
     | exn -> Error (Spawn_failed (Printexc.to_string exn))
   in
   (match result with
@@ -1167,10 +1197,13 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr
               ~on_turn_starting
               ~on_turn_started
               ~on_stream_event
+              ~turn_accepted
           with
           | Eio.Cancel.Cancelled _ as exn -> raise exn
           | Eio.Time.Timeout ->
-            timeout_error ~turn_accepted:!turn_accepted config.timeout_s
+            timeout_error
+              ~turn_accepted:!turn_accepted
+              (timeout_s_for_phase config ~turn_accepted:!turn_accepted)
           | exn -> Error (Spawn_failed (Printexc.to_string exn)))
        with
        | Error (Timeout { seconds; turn_accepted = dispatch_ambiguous }) ->

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -185,25 +185,6 @@ let error_kind = function
   | Timeout _ -> "timeout"
 ;;
 
-(* [None] installs no timer, and the only other [Eio.Time.with_timeout_exn] in
-   this module is the process-termination grace window, which catches its own
-   [Eio.Time.Timeout] and reaps. So this arm exists for totality and is not
-   reachable by either timer. Reaching it means a deadline was installed by a
-   path this reasoning does not cover — that is a defect to find, not a turn
-   limit to report. It must not become [Process_exited] either: that maps to
-   [ProviderUnavailable], which blames a provider that was answering and drops
-   [turn_accepted], the one bit that decides whether rotating would run the
-   goal twice. *)
-let timeout_error ~turn_accepted = function
-  | Some seconds -> Error (Timeout { seconds; turn_accepted })
-  | None ->
-    Error
-      (Protocol_error
-         { stage = "turn deadline"
-         ; detail = "Eio timeout raised while no turn deadline was installed"
-         })
-;;
-
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
 let ( let* ) result f = Result.bind result f
 
@@ -220,6 +201,16 @@ end)
 open Shared_json
 
 let bounded_tail = Runtime_official_client_json.bounded_tail
+
+(* See {!Runtime_official_client_json.Make.no_turn_deadline_defect} for why the
+   [None] arm is unreachable. Here it must also not become [Process_exited]:
+   that maps to [ProviderUnavailable], which blames a provider that was
+   answering and carries no [turn_accepted] — the one bit that decides whether
+   rotating would run the goal a second time. *)
+let timeout_error ~turn_accepted = function
+  | Some seconds -> Error (Timeout { seconds; turn_accepted })
+  | None -> Error Shared_json.no_turn_deadline_defect
+;;
 
 (* Present and a string, with no constraint on its contents. For payload
    fields whose value this decoder does not read: an emptiness rule there

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -18,11 +18,20 @@ type config =
   { cli_path : string
   ; model : string option
   ; developer_instructions : string option
-  ; timeout_s : float
+  ; timeout_s : float option
   }
 
 let default_timeout_s = 300.0
 let process_termination_grace_s = 2.0
+
+(* [None] installs no deadline. The vendor client owns when its own turn ends;
+   a declared bound is the operator's optional liveness guard over a silent
+   client, not a limit on how long legitimate work may take. *)
+let with_optional_timeout clock timeout_s f =
+  match timeout_s with
+  | None -> f ()
+  | Some seconds -> Eio.Time.with_timeout_exn clock seconds f
+;;
 let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 4096
 let max_wire_line_bytes = 8 * 1024 * 1024
@@ -36,7 +45,7 @@ let default_config () =
   { cli_path = "codex"
   ; model = None
   ; developer_instructions = None
-  ; timeout_s = default_timeout_s
+  ; timeout_s = Some default_timeout_s
   }
 ;;
 
@@ -174,6 +183,18 @@ let error_kind = function
   | Turn_interrupted -> "turn_interrupted"
   | Process_exited _ -> "process_exited"
   | Timeout _ -> "timeout"
+;;
+
+(* An [Eio.Time.Timeout] can still arrive with no turn bound installed: the
+   process-termination grace window below is its own deadline. Reporting that
+   as a turn timeout would name a limit the operator never set, so it is
+   surfaced as what it is. *)
+let timeout_error ~turn_accepted = function
+  | Some seconds -> Error (Timeout { seconds; turn_accepted })
+  | None ->
+    Error
+      (Process_exited
+         "client did not settle within the process-termination grace window")
 ;;
 
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
@@ -973,13 +994,13 @@ let with_spawned_client ~mgr ~clock ~cwd config run =
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
     let send json =
-      Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+      with_optional_timeout clock config.timeout_s (fun () ->
         Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
         Eio.Flow.copy_string "\n" stdin_w)
     in
     let receive () =
       try
-        Eio.Time.with_timeout_exn clock config.timeout_s (fun () ->
+        with_optional_timeout clock config.timeout_s (fun () ->
           Eio.Buf_read.line reader)
         |> parse_wire_line
       with
@@ -989,7 +1010,7 @@ let with_spawned_client ~mgr ~clock ~cwd config run =
       | Eio.Time.Timeout ->
         (* The transport cannot know whether turn/start was already accepted;
            the entry points rewrap with the observed turn state. *)
-        Error (Timeout { seconds = config.timeout_s; turn_accepted = false })
+        timeout_error ~turn_accepted:false config.timeout_s
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> protocol_error "stdout read" (Printexc.to_string exn)
     in
@@ -1043,8 +1064,11 @@ let native_cwd cwd =
 let validate_process_config config =
   if String.trim config.cli_path = ""
   then Error (Invalid_config "cli_path must not be empty")
-  else if not (Float.is_finite config.timeout_s) || config.timeout_s <= 0.0
-  then Error (Invalid_config "timeout_s must be positive and finite")
+  else if
+    (match config.timeout_s with
+     | None -> false
+     | Some seconds -> not (Float.is_finite seconds) || seconds <= 0.0)
+  then Error (Invalid_config "a declared timeout_s must be positive and finite")
   else Ok ()
 ;;
 
@@ -1096,7 +1120,7 @@ let probe_subscription ~mgr ~clock ~cwd config =
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Eio.Time.Timeout ->
       (* The probe never starts a turn. *)
-      Error (Timeout { seconds = config.timeout_s; turn_accepted = false })
+      timeout_error ~turn_accepted:false config.timeout_s
     | exn -> Error (Spawn_failed (Printexc.to_string exn))
   in
   (match result with

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -185,16 +185,23 @@ let error_kind = function
   | Timeout _ -> "timeout"
 ;;
 
-(* An [Eio.Time.Timeout] can still arrive with no turn bound installed: the
-   process-termination grace window below is its own deadline. Reporting that
-   as a turn timeout would name a limit the operator never set, so it is
-   surfaced as what it is. *)
+(* [None] installs no timer, and the only other [Eio.Time.with_timeout_exn] in
+   this module is the process-termination grace window, which catches its own
+   [Eio.Time.Timeout] and reaps. So this arm exists for totality and is not
+   reachable by either timer. Reaching it means a deadline was installed by a
+   path this reasoning does not cover — that is a defect to find, not a turn
+   limit to report. It must not become [Process_exited] either: that maps to
+   [ProviderUnavailable], which blames a provider that was answering and drops
+   [turn_accepted], the one bit that decides whether rotating would run the
+   goal twice. *)
 let timeout_error ~turn_accepted = function
   | Some seconds -> Error (Timeout { seconds; turn_accepted })
   | None ->
     Error
-      (Process_exited
-         "client did not settle within the process-termination grace window")
+      (Protocol_error
+         { stage = "turn deadline"
+         ; detail = "Eio timeout raised while no turn deadline was installed"
+         })
 ;;
 
 let protocol_error stage detail = Error (Protocol_error { stage; detail })
@@ -1028,7 +1035,7 @@ let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
     ~on_turn_starting ~on_turn_started ~on_stream_event =
   with_spawned_client ~mgr ~clock ~cwd config (fun io ->
     let with_timeout callback =
-      Eio.Time.with_timeout_exn clock config.timeout_s callback
+      with_optional_timeout clock config.timeout_s callback
     in
     run_protocol
       io
@@ -1172,11 +1179,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr
           with
           | Eio.Cancel.Cancelled _ as exn -> raise exn
           | Eio.Time.Timeout ->
-            Error
-              (Timeout
-                 { seconds = config.timeout_s
-                 ; turn_accepted = !turn_accepted
-                 })
+            timeout_error ~turn_accepted:!turn_accepted config.timeout_s
           | exn -> Error (Spawn_failed (Printexc.to_string exn)))
        with
        | Error (Timeout { seconds; turn_accepted = dispatch_ambiguous }) ->

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -18,13 +18,16 @@ type config =
   { cli_path : string
   ; model : string option
   ; developer_instructions : string option
+  ; admission_timeout_s : float
+    (** Finite bound for process setup, subscription/account checks, thread
+        creation, history injection, and [turn/start] acknowledgement. *)
   ; timeout_s : float option
     (** Maximum silence between app-server protocol messages. Each received
         message resets the deadline; a progressing turn has no wall limit.
-        [None] installs no deadline at all — the spawned client decides when
-        its own turn ends, which is the posture of running the CLI directly.
-        Declared as [turn-timeout-s] in runtime config, where [0] selects
-        [None]. *)
+        [None] removes the deadline after turn admission — the spawned client
+        decides when its own turn ends, which is the posture of running the CLI
+        directly. Setup remains bounded by [admission_timeout_s]. Declared as
+        [turn-timeout-s] in runtime config, where [0] selects [None]. *)
   }
 
 val default_timeout_s : float

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -18,9 +18,13 @@ type config =
   { cli_path : string
   ; model : string option
   ; developer_instructions : string option
-  ; timeout_s : float
+  ; timeout_s : float option
     (** Maximum silence between app-server protocol messages. Each received
-        message resets the deadline; a progressing turn has no wall limit. *)
+        message resets the deadline; a progressing turn has no wall limit.
+        [None] installs no deadline at all — the spawned client decides when
+        its own turn ends, which is the posture of running the CLI directly.
+        Declared as [turn-timeout-s] in runtime config, where [0] selects
+        [None]. *)
   }
 
 val default_timeout_s : float

--- a/lib/runtime/runtime_official_client_json.ml
+++ b/lib/runtime/runtime_official_client_json.ml
@@ -88,6 +88,12 @@ module Make (E : Error) = struct
     | Eio.Time.Timeout as exn -> raise exn
     | exn -> protocol_error stage (Printexc.to_string exn)
   ;;
+
+  let no_turn_deadline_defect =
+    E.protocol
+      ~stage:"turn deadline"
+      ~detail:"Eio timeout raised while no turn deadline was installed"
+  ;;
 end
 
 let bounded_tail ~limit current addition =

--- a/lib/runtime/runtime_official_client_json.mli
+++ b/lib/runtime/runtime_official_client_json.mli
@@ -45,6 +45,16 @@ module Make (E : Error) : sig
       except for [Eio.Cancel.Cancelled] and [Eio.Time.Timeout], which are
       re-raised so cancellation and deadlines stay control flow rather than
       turning into a reported protocol failure. *)
+
+  val no_turn_deadline_defect : E.t
+  (** What to report when [Eio.Time.Timeout] arrives at a turn while the
+      runtime installed no deadline. Each runtime catches its own
+      process-termination grace window and reaps, so with no turn deadline
+      nothing arms a timer and this is unreachable; it exists so the handler
+      stays total. Reaching it means some path installed a deadline outside
+      that reasoning, which is a defect to locate — not a turn limit to name,
+      and not a process or provider failure to blame. Shared so the three
+      runtimes cannot drift into three different accounts of one state. *)
 end
 
 val bounded_tail : limit:int -> string -> string -> string

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -846,7 +846,7 @@ let reasoning_effort_opt_field ~(path : string) (tbl : Otoml.t)
 let turn_timeout_opt_field ~(path : string) (tbl : Otoml.t)
   : (float option, parse_error list) result
   =
-  match strict_float_find path tbl "turn-timeout-s" with
+  match number_opt_field ~path ~key:"turn-timeout-s" tbl with
   | Error _ as error -> error
   | Ok None -> Ok None
   | Ok (Some value) when value >= 0.0 && Float.is_finite value -> Ok (Some value)

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -838,13 +838,26 @@ let reasoning_effort_opt_field ~(path : string) (tbl : Otoml.t)
    antigravity provider key [timeout-s] because the two sit at different layers
    and the model value wins: an operator reading a config with both should be
    able to tell which one bounds the turn without consulting the resolver. *)
+(* Unlike the other float fields, [0] is meaningful here rather than invalid:
+   it declares that no deadline is installed, so the spawned client decides
+   when its own turn ends. Absent stays distinct from [0] — absent keeps the
+   adapter default, [0] removes the bound — so the two cannot be confused
+   downstream. Negative and non-finite remain rejected. *)
 let turn_timeout_opt_field ~(path : string) (tbl : Otoml.t)
   : (float option, parse_error list) result
   =
-  positive_finite_float_opt_field
-    ~path
-    ~key:"turn-timeout-s"
-    (strict_float_find path tbl "turn-timeout-s")
+  match strict_float_find path tbl "turn-timeout-s" with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some value) when value >= 0.0 && Float.is_finite value -> Ok (Some value)
+  | Ok (Some value) ->
+    Error
+      (error
+         (path ^ ".turn-timeout-s")
+         (Printf.sprintf
+            "turn-timeout-s must be a non-negative finite number (0 removes \
+             the deadline), got %g"
+            value))
 ;;
 
 (* Read the optional per-model [temperature]. A TOML integer (1) or float (1.0)

--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -101,7 +101,11 @@ let probe_codex ~mgr ~clock ~process_cwd ~runtime_id ~model
     { cli_path = config.cli_path
     ; model = config.model
     ; developer_instructions = None
-    ; timeout_s = Float.min max_probe_timeout_s config.timeout_s
+    ; (* A probe stays bounded even where the turn is not: it answers "can this
+         client log in", and an unbounded answer to that is no answer. An
+         undeclared turn bound therefore falls back to the probe ceiling rather
+         than to no ceiling. *)
+      timeout_s = Some (Float.min max_probe_timeout_s config.timeout_s)
     }
   in
   match
@@ -148,7 +152,11 @@ let probe_claude ~mgr ~clock ~cwd ~process_cwd ~runtime_id ~model
     ; cwd
     ; model = config.model
     ; system_prompt = None
-    ; timeout_s = Float.min max_probe_timeout_s config.timeout_s
+    ; (* A probe stays bounded even where the turn is not: it answers "can this
+         client log in", and an unbounded answer to that is no answer. An
+         undeclared turn bound therefore falls back to the probe ceiling rather
+         than to no ceiling. *)
+      timeout_s = Some (Float.min max_probe_timeout_s config.timeout_s)
     }
   in
   match

--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -101,6 +101,7 @@ let probe_codex ~mgr ~clock ~process_cwd ~runtime_id ~model
     { cli_path = config.cli_path
     ; model = config.model
     ; developer_instructions = None
+    ; admission_timeout_s = Float.min max_probe_timeout_s config.timeout_s
     ; (* A probe stays bounded even where the turn is not: it answers "can this
          client log in", and an unbounded answer to that is no answer. An
          undeclared turn bound therefore falls back to the probe ceiling rather
@@ -152,6 +153,7 @@ let probe_claude ~mgr ~clock ~cwd ~process_cwd ~runtime_id ~model
     ; cwd
     ; model = config.model
     ; system_prompt = None
+    ; admission_timeout_s = Float.min max_probe_timeout_s config.timeout_s
     ; (* A probe stays bounded even where the turn is not: it answers "can this
          client log in", and an unbounded answer to that is no answer. An
          undeclared turn bound therefore falls back to the probe ceiling rather

--- a/test/test_fusion_official_client_panel.ml
+++ b/test/test_fusion_official_client_panel.ml
@@ -45,9 +45,9 @@ api-name = "claude-sonnet-5"
 max-context = 1000000
 tools-support = true
 streaming = true
+turn-timeout-s = 0
 
 [claude_code."claude-sonnet-5"]
-turn-timeout-s = 0
 |}
     claude_cli
 ;;
@@ -120,6 +120,20 @@ let test_official_client_panel_honors_no_deadline () =
          (Masc.Fusion_official_client.For_testing.resolved_timeout_s
             ~runtime_id:official_client_runtime
             ~default_timeout_s:300.0)))
+;;
+
+let test_unbounded_claude_panel_keeps_login_probe_bounded () =
+  let turn_config =
+    { (Runtime_claude_code.default_config ~cwd:"/tmp") with timeout_s = None }
+  in
+  let probe_config =
+    Masc.Fusion_official_client.For_testing.bounded_claude_probe_config
+      ~fallback_timeout_s:17.0
+      turn_config
+  in
+  match probe_config.timeout_s with
+  | Some seconds -> check (float 0.0) "probe fallback" 17.0 seconds
+  | None -> fail "unbounded panel turn leaked into the Claude login probe"
 ;;
 
 let panel_group models : Fusion_policy.panel_group =
@@ -232,6 +246,10 @@ let () =
             "official-client panel honors no deadline"
             `Quick
             test_official_client_panel_honors_no_deadline
+        ; test_case
+            "unbounded Claude panel keeps login probe bounded"
+            `Quick
+            test_unbounded_claude_panel_keeps_login_probe_bounded
         ] )
     ; ( "eio context diagnostics"
       , [ test_case

--- a/test/test_fusion_official_client_panel.ml
+++ b/test/test_fusion_official_client_panel.ml
@@ -47,6 +47,7 @@ tools-support = true
 streaming = true
 
 [claude_code."claude-sonnet-5"]
+turn-timeout-s = 0
 |}
     claude_cli
 ;;
@@ -110,6 +111,15 @@ let test_unknown_runtime_is_not_claimed_by_the_spawn_path () =
       "an unconfigured id is left to the Agent_core path to report"
       false
       (Masc.Fusion_official_client.is_official_client ~runtime_id:"nope.not-configured"))
+;;
+
+let test_official_client_panel_honors_no_deadline () =
+  with_classification_runtime (fun () ->
+    check bool "turn-timeout-s = 0 removes the panel turn deadline" true
+      (Option.is_none
+         (Masc.Fusion_official_client.For_testing.resolved_timeout_s
+            ~runtime_id:official_client_runtime
+            ~default_timeout_s:300.0)))
 ;;
 
 let panel_group models : Fusion_policy.panel_group =
@@ -218,6 +228,10 @@ let () =
             "unknown runtime is not claimed by the spawn path"
             `Quick
             test_unknown_runtime_is_not_claimed_by_the_spawn_path
+        ; test_case
+            "official-client panel honors no deadline"
+            `Quick
+            test_official_client_panel_honors_no_deadline
         ] )
     ; ( "eio context diagnostics"
       , [ test_case

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -1166,6 +1166,20 @@ let test_turn_spawn_failure_is_pre_dispatch_with_tools () =
          |> check_pre_dispatch_attempt "turn process spawn failure"))
 ;;
 
+let test_unbounded_turn_keeps_subscription_probe_bounded () =
+  let turn_config =
+    { (Runtime_claude_code.default_config ~cwd:"/tmp") with timeout_s = None }
+  in
+  let probe_config =
+    Keeper_claude_code_runtime.For_testing.bounded_probe_config
+      ~fallback_timeout_s:17.0
+      turn_config
+  in
+  match probe_config.timeout_s with
+  | Some seconds -> check (float 0.0) "probe fallback" 17.0 seconds
+  | None -> fail "unbounded turn config leaked into the subscription probe"
+;;
+
 let () =
   run
     "keeper_claude_code_runtime"
@@ -1213,6 +1227,10 @@ let () =
             "turn spawn failure is pre-dispatch with tools"
             `Quick
             test_turn_spawn_failure_is_pre_dispatch_with_tools
+        ; test_case
+            "unbounded turn keeps subscription probe bounded"
+            `Quick
+            test_unbounded_turn_keeps_subscription_probe_bounded
         ] )
     ]
 ;;

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -132,7 +132,7 @@ let run_fixture
     let config =
       { (Runtime_antigravity.default_config ~cwd:"/tmp" ~model:"gemini-fixture") with
         cli_path = path
-      ; timeout_s
+      ; timeout_s = Some timeout_s
       }
     in
     Runtime_antigravity.run_turn

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -60,6 +60,7 @@ let fixture_script
     ?required_home
     ?(sleep_s = 0.0)
     ?line_delay_s
+    ?after_first_line_delay_s
     ?(exit_code = 0)
     lines
   =
@@ -92,12 +93,18 @@ let fixture_script
     required_home;
   output_string output "cat >/dev/null\n";
   if sleep_s > 0.0 then output_string output (Printf.sprintf "sleep %.3f\n" sleep_s);
-  List.iter
-    (fun line ->
+  List.iteri
+    (fun index line ->
        Option.iter
          (fun seconds ->
             output_string output (Printf.sprintf "sleep %.3f\n" seconds))
          line_delay_s;
+       if index = 1
+       then
+         Option.iter
+           (fun seconds ->
+              output_string output (Printf.sprintf "sleep %.3f\n" seconds))
+           after_first_line_delay_s;
        output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
     lines;
   output_string output (Printf.sprintf "exit %d\n" exit_code);
@@ -106,13 +113,15 @@ let fixture_script
   path
 ;;
 
-let with_fixture ?require_resume ?required_home ?sleep_s ?line_delay_s ?exit_code lines f =
+let with_fixture ?require_resume ?required_home ?sleep_s ?line_delay_s
+    ?after_first_line_delay_s ?exit_code lines f =
   let path =
     fixture_script
       ?require_resume
       ?required_home
       ?sleep_s
       ?line_delay_s
+      ?after_first_line_delay_s
       ?exit_code
       lines
   in
@@ -125,6 +134,8 @@ let run_fixture
     ?on_conversation_ready
     ?on_stream_event
     ?(timeout_s = 2.0)
+    ?admission_timeout_s
+    ?(no_turn_deadline = false)
     ?(prompt = "Return the fixture marker")
     path
   =
@@ -132,7 +143,8 @@ let run_fixture
     let config =
       { (Runtime_antigravity.default_config ~cwd:"/tmp" ~model:"gemini-fixture") with
         cli_path = path
-      ; timeout_s = Some timeout_s
+      ; admission_timeout_s = Option.value admission_timeout_s ~default:timeout_s
+      ; timeout_s = if no_turn_deadline then None else Some timeout_s
       }
     in
     Runtime_antigravity.run_turn
@@ -444,6 +456,39 @@ let test_stream_idle_timeout_is_typed () =
        | Ok _ -> fail "silent Antigravity stream ignored its idle timeout")
 ;;
 
+let test_no_deadline_keeps_init_bounded () =
+  with_fixture
+    ~sleep_s:0.2
+    [ init (); result () ]
+    (fun path ->
+       match
+         run_fixture
+           ~admission_timeout_s:0.05
+           ~no_turn_deadline:true
+           path
+       with
+       | Error (Runtime_antigravity.Timeout seconds) ->
+         check (float 0.001) "admission timeout" 0.05 seconds
+       | Error error -> fail (Runtime_antigravity.error_to_string error)
+       | Ok _ -> fail "an unbounded turn disabled the Antigravity init bound")
+;;
+
+let test_no_deadline_starts_after_init () =
+  with_fixture
+    ~after_first_line_delay_s:0.2
+    [ init (); result () ]
+    (fun path ->
+       match
+         run_fixture
+           ~admission_timeout_s:0.05
+           ~no_turn_deadline:true
+           path
+       with
+       | Ok turn ->
+         check string "unbounded result" "MASC_ANTIGRAVITY_OK\n" turn.text
+       | Error error -> fail (Runtime_antigravity.error_to_string error))
+;;
+
 let test_admission_is_process_free () =
   let config =
     { (Runtime_antigravity.default_config ~cwd:"relative" ~model:"gemini-fixture") with
@@ -572,6 +617,14 @@ let () =
             "stream idle timeout is typed"
             `Quick
             test_stream_idle_timeout_is_typed
+        ; test_case
+            "no deadline keeps init bounded"
+            `Quick
+            test_no_deadline_keeps_init_bounded
+        ; test_case
+            "no deadline starts after init"
+            `Quick
+            test_no_deadline_starts_after_init
         ; test_case "process-free admission" `Quick test_admission_is_process_free
         ] )
     ; "live official client", [ test_case "official agy start and resume" `Slow test_live_start_and_resume ]

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -466,7 +466,7 @@ let test_live_start_and_resume () =
         let config =
           { (Runtime_antigravity.default_config ~cwd ~model) with
             cli_path
-          ; timeout_s = 60.0
+          ; timeout_s = Some 60.0
           }
         in
         let run ?conversation_mode prompt =

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -992,7 +992,7 @@ let test_live_subscription () =
     let outcome =
       Eio_main.run (fun env ->
         let config =
-          { (Runtime_claude_code.default_config ~cwd:"/tmp") with timeout_s = 60.0 }
+          { (Runtime_claude_code.default_config ~cwd:"/tmp") with timeout_s = Some 60.0 }
         in
         Runtime_claude_code.run_turn
           ~mgr:(Eio.Stdenv.process_mgr env)

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -125,7 +125,7 @@ let run_fixture ?(dynamic_tools = []) ?session_mode ?(timeout_s = 2.0)
     let config =
       { (Runtime_claude_code.default_config ~cwd:"/tmp") with
         cli_path = path
-      ; timeout_s
+      ; timeout_s = Some timeout_s
       }
     in
     let on_session_ready =

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -119,13 +119,15 @@ let with_fixture ?auth_json ?before_initialize_response steps f =
 ;;
 
 let run_fixture ?(dynamic_tools = []) ?session_mode ?(timeout_s = 2.0)
-    ?on_session_ready_delay_s ?on_stream_event path =
+    ?admission_timeout_s ?(no_turn_deadline = false) ?on_session_ready_delay_s
+    ?on_stream_event path =
   Eio_main.run (fun env ->
     let clock = Eio.Stdenv.clock env in
     let config =
       { (Runtime_claude_code.default_config ~cwd:"/tmp") with
         cli_path = path
-      ; timeout_s = Some timeout_s
+      ; admission_timeout_s = Option.value admission_timeout_s ~default:timeout_s
+      ; timeout_s = if no_turn_deadline then None else Some timeout_s
       }
     in
     let on_session_ready =
@@ -204,6 +206,37 @@ let test_stream_idle_timeout_is_typed () =
       check (float 0.001) "exact idle timeout" 0.05 seconds
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "silent Claude stream ignored its idle timeout")
+;;
+
+let test_no_deadline_keeps_initialize_bounded () =
+  with_fixture
+    ~before_initialize_response:[ Pause 0.2 ]
+    [ Emit assistant; Emit result ]
+    (fun path ->
+       match
+         run_fixture
+           ~admission_timeout_s:0.05
+           ~no_turn_deadline:true
+           path
+       with
+       | Error (Runtime_claude_code.Timeout seconds) ->
+         check (float 0.001) "admission timeout" 0.05 seconds
+       | Error error -> fail (Runtime_claude_code.error_to_string error)
+       | Ok _ -> fail "an unbounded turn disabled Claude initialization bounds")
+;;
+
+let test_no_deadline_starts_after_user_message () =
+  with_fixture
+    [ Pause 0.2; Emit assistant; Emit result ]
+    (fun path ->
+       match
+         run_fixture
+           ~admission_timeout_s:0.05
+           ~no_turn_deadline:true
+           path
+       with
+       | Ok turn -> check string "unbounded result" "MASC_CLAUDE_OK" turn.text
+       | Error error -> fail (Runtime_claude_code.error_to_string error))
 ;;
 
 let test_state_callback_timeout_is_typed () =
@@ -1023,6 +1056,14 @@ let () =
             "stream idle timeout is typed"
             `Quick
             test_stream_idle_timeout_is_typed
+        ; test_case
+            "no deadline keeps initialize bounded"
+            `Quick
+            test_no_deadline_keeps_initialize_bounded
+        ; test_case
+            "no deadline starts after user message"
+            `Quick
+            test_no_deadline_starts_after_user_message
         ; test_case
             "state callback timeout is typed"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -150,7 +150,7 @@ let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp
     let config =
       { (Runtime_codex_app_server.default_config ()) with
         cli_path = path
-      ; timeout_s
+      ; timeout_s = Some timeout_s
       }
     in
     let on_thread_ready =

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -54,7 +54,7 @@ let rec drop count values =
     | _ :: rest -> drop (count - 1) rest
 ;;
 
-let fixture_script ?capture_path ?terminal_line_delay_s
+let fixture_script ?capture_path ?initial_line_delay_s ?terminal_line_delay_s
     ?(terminal_line_delay_start_index = 0) lines =
   let path = Filename.temp_file "masc-codex-app-server-" ".sh" in
   let output = open_out_bin path in
@@ -75,6 +75,9 @@ let fixture_script ?capture_path ?terminal_line_delay_s
   in
   output_string output "#!/bin/sh\n";
   read_request ~expect_version:true ();
+  Option.iter
+    (fun seconds -> output_string output (Printf.sprintf "sleep %.3f\n" seconds))
+    initial_line_delay_s;
   output_string output ("printf '%s\\n' " ^ shell_quote (List.nth lines 0) ^ "\n");
   read_request ();
   read_request ();
@@ -98,11 +101,12 @@ let fixture_script ?capture_path ?terminal_line_delay_s
   path
 ;;
 
-let with_fixture ?capture_path ?terminal_line_delay_s
+let with_fixture ?capture_path ?initial_line_delay_s ?terminal_line_delay_s
     ?terminal_line_delay_start_index lines f =
   let path =
     fixture_script
       ?capture_path
+      ?initial_line_delay_s
       ?terminal_line_delay_s
       ?terminal_line_delay_start_index
       lines
@@ -144,13 +148,15 @@ let with_fixture_sequence ?capture_path first_lines second_lines f =
 ;;
 
 let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp")
-    ?(timeout_s = 2.0) ?on_thread_ready_delay_s ?on_stream_event path =
+    ?(timeout_s = 2.0) ?admission_timeout_s ?(no_turn_deadline = false)
+    ?on_thread_ready_delay_s ?on_stream_event path =
   Eio_main.run (fun env ->
     let clock = Eio.Stdenv.clock env in
     let config =
       { (Runtime_codex_app_server.default_config ()) with
         cli_path = path
-      ; timeout_s = Some timeout_s
+      ; admission_timeout_s = Option.value admission_timeout_s ~default:timeout_s
+      ; timeout_s = if no_turn_deadline then None else Some timeout_s
       }
     in
     let on_thread_ready =
@@ -771,6 +777,47 @@ let test_stream_idle_timeout_after_turn_acceptance_is_typed () =
          fail "turn/start acceptance was lost before the idle timeout"
        | Error error -> fail (Runtime_codex_app_server.error_to_string error)
        | Ok _ -> fail "accepted turn ignored its idle timeout")
+;;
+
+let test_no_deadline_keeps_handshake_bounded () =
+  with_fixture
+    ~initial_line_delay_s:0.2
+    [ init_result; account_chatgpt; thread_result; turn_result; turn_completed ]
+    (fun path ->
+       match
+         run_fixture
+           ~admission_timeout_s:0.05
+           ~no_turn_deadline:true
+           path
+       with
+       | Error
+           (Runtime_codex_app_server.Timeout
+              { seconds; turn_accepted = false }) ->
+         check (float 0.001) "admission timeout" 0.05 seconds
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok _ -> fail "an unbounded turn disabled the app-server handshake bound")
+;;
+
+let test_no_deadline_starts_after_turn_acceptance () =
+  with_fixture
+    ~terminal_line_delay_s:0.2
+    ~terminal_line_delay_start_index:1
+    [ init_result
+    ; account_chatgpt
+    ; thread_result
+    ; turn_result
+    ; item_completed
+    ; turn_completed
+    ]
+    (fun path ->
+       match
+         run_fixture
+           ~admission_timeout_s:0.05
+           ~no_turn_deadline:true
+           path
+       with
+       | Ok turn -> check string "unbounded result" "MASC_SUBSCRIPTION_OK" turn.text
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error))
 ;;
 
 let test_state_callback_timeout_is_typed () =
@@ -3049,6 +3096,14 @@ let () =
             "stream idle timeout preserves turn acceptance"
             `Quick
             test_stream_idle_timeout_after_turn_acceptance_is_typed
+        ; test_case
+            "no deadline keeps handshake bounded"
+            `Quick
+            test_no_deadline_keeps_handshake_bounded
+        ; test_case
+            "no deadline starts after turn acceptance"
+            `Quick
+            test_no_deadline_starts_after_turn_acceptance
         ; test_case
             "state callback timeout is typed"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -338,7 +338,7 @@ let test_subscription_probe_stops_before_thread () =
           let config =
             { (Runtime_codex_app_server.default_config ()) with
               cli_path = path
-            ; timeout_s = 2.0
+            ; timeout_s = Some 2.0
             }
           in
           Runtime_codex_app_server.probe_subscription
@@ -2702,7 +2702,7 @@ let test_live_chatgpt_subscription () =
       Eio_main.run (fun env ->
         let config =
           { (Runtime_codex_app_server.default_config ()) with
-            timeout_s = 60.0
+            timeout_s = Some 60.0
           }
         in
         Runtime_codex_app_server.run_turn
@@ -2740,7 +2740,7 @@ let test_live_dynamic_tool_subscription () =
       Eio_main.run (fun env ->
         let config =
           { (Runtime_codex_app_server.default_config ()) with
-            timeout_s = 60.0
+            timeout_s = Some 60.0
           }
         in
         Runtime_codex_app_server.run_turn
@@ -2768,7 +2768,7 @@ let test_live_history_injection_subscription () =
       Eio_main.run (fun env ->
         let config =
           { (Runtime_codex_app_server.default_config ()) with
-            timeout_s = 60.0
+            timeout_s = Some 60.0
           }
         in
         Runtime_codex_app_server.run_turn

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -860,7 +860,7 @@ let test_model_turn_timeout_admits_zero_and_rejects_negative () =
     Runtime_toml.parse_string
       (Printf.sprintf "[models.probe]\napi-name = \"probe\"\nturn-timeout-s = %s\n" value)
   in
-  (match parse "0.0" with
+  (match parse "0" with
    | Error _ -> fail "turn-timeout-s = 0 must parse: it declares no deadline"
    | Ok parsed ->
      (match parsed.Runtime_schema.models with

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -831,9 +831,11 @@ let test_model_without_reasoning_effort_leaves_it_unset () =
    analyst on claude_code.claude-opus-5-max failed every turn with "timed out
    after 300.000s" at 5,884 bytes of system+user input.
 
-   The rejection case is the load-bearing one: a timeout that silently became
-   zero or infinity would either kill every turn or hang the keeper, and both
-   read as a provider fault rather than a config typo. *)
+   The rejection case is the load-bearing one, but only for values that state
+   no intent: a negative or non-finite bound would read as a provider fault
+   rather than a config typo. [0] is not in that set — it declares that no
+   deadline is installed, which is a posture an operator may want and which
+   the sibling case below pins. *)
 let test_model_turn_timeout_parses_as_a_positive_float () =
   let config = "[models.probe]\napi-name = \"probe\"\nturn-timeout-s = 900.0\n" in
   match Runtime_toml.parse_string config with
@@ -848,10 +850,30 @@ let test_model_turn_timeout_parses_as_a_positive_float () =
          (model.Runtime_schema.turn_timeout_s = Some 900.0)
      | _ -> fail "exactly one model must parse")
 
-let test_model_turn_timeout_rejects_a_non_positive_value_at_load () =
-  let config = "[models.probe]\napi-name = \"probe\"\nturn-timeout-s = 0.0\n" in
-  match Runtime_toml.parse_string config with
-  | Ok _ -> fail "a non-positive turn-timeout-s must be rejected at load"
+(* [0] is a declaration, not a typo: it says no deadline is installed, so the
+   spawned client decides when its own turn ends. Absent stays distinct from
+   it — absent keeps the adapter default — which is what the sibling case
+   below pins. Negative and non-finite remain rejected, because neither states
+   an intent the adapter can act on. *)
+let test_model_turn_timeout_admits_zero_and_rejects_negative () =
+  let parse value =
+    Runtime_toml.parse_string
+      (Printf.sprintf "[models.probe]\napi-name = \"probe\"\nturn-timeout-s = %s\n" value)
+  in
+  (match parse "0.0" with
+   | Error _ -> fail "turn-timeout-s = 0 must parse: it declares no deadline"
+   | Ok parsed ->
+     (match parsed.Runtime_schema.models with
+      | [ model ] ->
+        check
+          bool
+          "zero reaches the model spec as a declared value"
+          true
+          (model.Runtime_schema.turn_timeout_s = Some 0.0)
+      | _ -> fail "exactly one model must parse"));
+  (* Control. Without this, removing the validator entirely would also pass. *)
+  match parse "-1.0" with
+  | Ok _ -> fail "a negative turn-timeout-s must be rejected at load"
   | Error errors ->
     check
       bool
@@ -3954,8 +3976,8 @@ let () =
             "turn-timeout-s parses as a positive float"
             `Quick test_model_turn_timeout_parses_as_a_positive_float
         ; test_case
-            "turn-timeout-s rejects a non-positive value at load"
-            `Quick test_model_turn_timeout_rejects_a_non_positive_value_at_load
+            "turn-timeout-s admits zero and rejects negative"
+            `Quick test_model_turn_timeout_admits_zero_and_rejects_negative
         ; test_case
             "a model without turn-timeout-s leaves it unset"
             `Quick test_model_without_turn_timeout_leaves_it_unset


### PR DESCRIPTION
## 무엇을

구독 CLI 런타임 3종의 `timeout_s : float` 를 `float option` 으로 바꾼다. `None` 이면 턴에 마감이 없다.

## 왜

`runtime_codex_app_server` / `runtime_claude_code` / `runtime_antigravity` 는 전부 `timeout_s : float` 를 들고 있었고 기본값이 `300.0` 이었다. 그래서 **아무도 고르지 않은 숫자가 모든 턴의 마감**이었다. 긴 작업을 하는 키퍼가 300 초에 죽는데, 그 300 은 운영자가 선언한 값이 아니라 타입이 값을 요구해서 채워진 값이다.

비교 대상 셋을 소스로 확인했다. 세 프로젝트 모두 대화를 바이트로 자르지 않고 세션을 resume 하며, 턴 마감은 CLI 자신이 정한다. 이 PR 은 그 자세에 맞춘다 — 마감은 있으면 선언된 것이고, 없으면 없는 것이다.

## 어떻게

- `timeout_s : float option`. `None` 이면 `with_optional_timeout` 이 타이머를 아예 걸지 않는다. 프로세스 종료 유예 창이 여전히 바깥 경계이고, 에러 메시지도 이제 그것을 말한다 — 존재하지 않는 마감 시간을 숫자로 부르지 않는다.
- 에러 값은 한 곳에서만 만든다. `timeout_or_grace_window : float option -> error` 가 값을 만들고 `timeout_error` 가 그것을 `Error` 로 감싼다. `abort_with_runtime_error` 로 raise 하는 자리와 `Result` 로 돌려주는 자리가 같은 정의를 공유하므로, 의미가 두 벌로 갈라지지 않는다.
- TOML 은 **미선언과 0 을 구분**한다. `turn-timeout-s` 가 없으면 런타임 기본값을 쓰고, `0` 은 `None`(마감 없음)을 고르고, 음수와 비유한값은 로드 시점에 계속 거부한다. 셋 다 다른 뜻이므로 세 갈래로 파싱한다.
- 대시보드 프로브 2 곳은 `Some (Float.min max_probe_timeout_s ...)` 로 넘긴다. 런타임이 무제한이어도 **운영자가 보는 프로브는 유계로 유지**한다. 프로브가 매달리면 화면이 멈춘다.
- `runtime_codex_app_server` 의 `Timeout` 은 main 이 최근 `{ seconds; turn_accepted }` 레코드로 바꿨다. rebase 하며 세 자리의 `turn_accepted` 의미를 그대로 보존했다 — transport 는 모르므로 `false`, 프로브는 턴을 시작하지 않으므로 `false`, 진입점은 관측한 `!turn_accepted` 를 넘긴다.

## 검증

```
dune build --root . @check                          exit=0
@test/runtest-test_runtime_config_validity          Test Successful  74 tests
@test/runtest-test_runtime_claude_code              Test Successful  26 tests
@test/runtest-test_runtime_codex_app_server         50 tests, 3 회 중 2 회 성공
@test/runtest-test_runtime_antigravity              19 tests, 4 회 중 2 회 성공
```

`test_runtime_config_validity` 는 `..._rejects_a_non_positive_value_at_load` 를 `..._admits_zero_and_rejects_negative` 로 바꿨다. 0 을 받아들이는 것만 단언하면 "전부 받아들임" 도 통과하므로, 음수를 계속 거부하는 대조 케이스를 같은 테스트 안에 남겼다.

### 실패한 두 스위트에 대해

`test_runtime_codex_app_server` 와 `test_runtime_antigravity` 의 실패는 **부하 의존 flake 이고 main 에서도 같다.** 귀속을 추측하지 않고 대조군을 돌렸다:

| | 실패한 케이스 |
|---|---|
| main (`d4668756d6`, 무수정) 4 회 | `stream-json` 15, 16 |
| 이 브랜치 4 회 | `stream-json` 7, 11, 16 |

양쪽 다 같은 스위트에서 흔들리고 케이스 16 (`progress resets stream idle`, 마감 0.750s) 이 공통이다. 브랜치에서 나온 케이스 11 (`blank success`) 은 #28229 로 이미 등록된 fence 계약 불일치이지 이 PR 의 것이 아니다. 측정 당시 같은 머신에서 dune 6 개가 동시에 돌고 있었다.

`@fmt` 는 exit=1 이지만 이 PR 이 건드린 16 파일은 그 diff 에 **한 건도 없다** — `test/autonomous/dune`, `lib/fs_compat/dune` 등 기존 드리프트다.

## 안 한 것

- 300 초라는 값 자체는 여전히 세 런타임의 기본값이다. 이 PR 은 그 값을 바꾸지 않고, **선언하지 않을 수 있게** 만든다.
- 라이브 config (`~/.masc/config/runtime.toml`) 는 저장소 밖이라 건드리지 않았다. `turn-timeout-s = 0` 을 실제로 켜는 것은 별도 결정이다.

RFC-WAIVED: credential / identity / repo_manager / operator_control / keeper_sandbox / hooks / workflow 문서를 건드리지 않는다. 변경 범위는 `lib/runtime/` 3 개 어댑터와 그 호출부(`lib/keeper/keeper_*_runtime.ml`, `lib/fusion/`, `lib/server/`) 및 해당 테스트다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
