### PR TITLE
refactor(config): isolate snapshot observation effects

### DIFF
--- a/lib/config/dune
+++ b/lib/config/dune
@@ -16,6 +16,7 @@
   env_config_slack
   env_config_discord
   env_config_snapshot
+  env_config_snapshot_collector
   env_config_snapshot_core
   feature_flag_registry
   keeper_sandbox_config

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -223,7 +223,7 @@ module Transport = struct
   let effective_h2_mode () = (effective_h2_resolution ()).value
 
   let h2_snapshot_entry =
-    Env_config_snapshot_core.effective_entry
+    Env_config_snapshot_collector.effective_entry
       ~default:(h2_mode_to_string h2_default)
       ~read:(fun () ->
         let resolution = effective_h2_resolution () in

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -83,7 +83,7 @@ module Transport : sig
   val h2_mode_to_string : h2_mode -> string
   val configure_h2_from_env : unit -> h2_mode
   val effective_h2_mode : unit -> h2_mode
-  val h2_snapshot_entry : Env_config_snapshot_core.entry
+  val h2_snapshot_entry : Env_config_snapshot_collector.t
 
   val grpc_port : int
   val grpc_enabled : unit -> bool

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -4,8 +4,8 @@
     and root-level wrappers such as [Env_config_introspect] can reuse the same
     category definitions, masking rules, and source attribution logic. *)
 
-let entry = Env_config_snapshot_core.entry
-let category = Env_config_snapshot_core.category
+let entry = Env_config_snapshot_collector.entry
+let category = Env_config_snapshot_collector.category
 
 let server_entries =
   [

--- a/lib/config/env_config_snapshot_collector.ml
+++ b/lib/config/env_config_snapshot_collector.ml
@@ -1,0 +1,47 @@
+(** Effect shell for {!Env_config_snapshot_core}.
+
+    Each collector owns exactly one environment or applied-runtime read. The
+    resulting observation is handed to the pure projection core. *)
+
+type t =
+  { spec : Env_config_snapshot_core.spec
+  ; collect : unit -> Env_config_snapshot_core.observation
+  }
+
+type observed =
+  { spec : Env_config_snapshot_core.spec
+  ; observation : Env_config_snapshot_core.observation
+  }
+
+let entry
+      ?(getenv = Sys.getenv_opt)
+      ?(sensitive = false)
+      ~default
+      env_name
+      description
+  =
+  { spec = Env_config_snapshot_core.make_spec ~sensitive ~default env_name description
+  ; collect = (fun () -> Env_config_snapshot_core.Raw_environment (getenv env_name))
+  }
+;;
+
+let effective_entry ?(sensitive = false) ~default ~read env_name description =
+  { spec = Env_config_snapshot_core.make_spec ~sensitive ~default env_name description
+  ; collect =
+      (fun () ->
+        let value, source = read () in
+        Env_config_snapshot_core.Applied_value { value; source })
+  }
+;;
+
+let collect collector =
+  { spec = collector.spec; observation = collector.collect () }
+
+let project observed =
+  Env_config_snapshot_core.to_json observed.spec observed.observation
+
+let to_json collector = collector |> collect |> project
+
+let category name collectors =
+  let observed = List.map collect collectors in
+  name, `List (List.map project observed)

--- a/lib/config/env_config_snapshot_collector.mli
+++ b/lib/config/env_config_snapshot_collector.mli
@@ -1,0 +1,25 @@
+(** Effect shell for config-snapshot projection.
+
+    A collector performs one owned read and passes the resulting value to
+    {!Env_config_snapshot_core}. *)
+
+type t
+
+val entry :
+  ?getenv:(string -> string option) ->
+  ?sensitive:bool ->
+  default:string ->
+  string ->
+  string ->
+  t
+
+val effective_entry :
+  ?sensitive:bool ->
+  default:string ->
+  read:(unit -> string * Env_config_snapshot_core.effective_source) ->
+  string ->
+  string ->
+  t
+
+val to_json : t -> Yojson.Safe.t
+val category : string -> t list -> string * Yojson.Safe.t

--- a/lib/config/env_config_snapshot_core.ml
+++ b/lib/config/env_config_snapshot_core.ml
@@ -1,6 +1,13 @@
-(** Core entry/provenance helpers for {!Env_config_snapshot}. *)
+(** Pure entry/provenance projection for {!Env_config_snapshot}. *)
 
 let mask_sensitive _value = "[REDACTED]"
+
+let trim_nonempty = function
+  | None -> None
+  | Some value ->
+    let trimmed = String.trim value in
+    if String.equal trimmed "" then None else Some trimmed
+;;
 
 let is_sensitive_name name =
   let lower = String.lowercase_ascii name in
@@ -16,21 +23,23 @@ let is_sensitive_name name =
       contains_at 0)
     [ "token"; "password"; "secret"; "key"; "credential"; "neo4j_url"; "supabase" ]
 
-type entry =
+type spec =
   { env_name : string
   ; description : string
   ; default_display : string
   ; sensitive : bool
-  ; reader : reader
   }
 
-and effective_source =
+type effective_source =
   | Default
   | Environment
 
-and reader =
-  | Raw_env
-  | Effective of (unit -> string * effective_source)
+type observation =
+  | Raw_environment of string option
+  | Applied_value of
+      { value : string
+      ; source : effective_source
+      }
 
 type source_provenance =
   { kind : string
@@ -45,56 +54,50 @@ type source_provenance =
   ; value_redacted : bool
   }
 
-let make_entry ?(sensitive = false) ~default ~reader env_name description =
+let make_spec ?(sensitive = false) ~default env_name description =
   let sensitive = sensitive || is_sensitive_name env_name in
-  { env_name; description; default_display = default; sensitive; reader }
+  { env_name; description; default_display = default; sensitive }
 
-let entry ?sensitive ~default env_name description =
-  make_entry ?sensitive ~default ~reader:Raw_env env_name description
-
-let effective_entry ?sensitive ~default ~read env_name description =
-  make_entry ?sensitive ~default ~reader:(Effective read) env_name description
-
-let default_provenance (e : entry) =
-  match e.default_display with
+let default_provenance (spec : spec) =
+  match spec.default_display with
   | "(derived)" ->
       { kind = "derived"
       ; detail = "computed by runtime config helpers from related settings"
       ; derived_from = []
-      ; env_name = e.env_name
+      ; env_name = spec.env_name
       ; raw_source = "derived_runtime"
       ; raw_env_present = false
       ; raw_env_blank = false
-      ; default_display = e.default_display
-      ; sensitive = e.sensitive
+      ; default_display = spec.default_display
+      ; sensitive = spec.sensitive
       ; value_redacted = false
       }
   | "(cwd)" ->
       { kind = "runtime"
       ; detail = "resolved from the process working directory or base path"
       ; derived_from = []
-      ; env_name = e.env_name
+      ; env_name = spec.env_name
       ; raw_source = "runtime"
       ; raw_env_present = false
       ; raw_env_blank = false
-      ; default_display = e.default_display
-      ; sensitive = e.sensitive
+      ; default_display = spec.default_display
+      ; sensitive = spec.sensitive
       ; value_redacted = false
       }
   | _ ->
       { kind = "default"
       ; detail = "compiled default value"
       ; derived_from = []
-      ; env_name = e.env_name
+      ; env_name = spec.env_name
       ; raw_source = "compiled_default"
       ; raw_env_present = false
       ; raw_env_blank = false
-      ; default_display = e.default_display
-      ; sensitive = e.sensitive
+      ; default_display = spec.default_display
+      ; sensitive = spec.sensitive
       ; value_redacted = false
       }
 
-let source_provenance (e : entry) ~raw_env raw =
+let source_provenance (spec : spec) ~raw_env raw =
   let raw_env_present = Option.is_some raw_env in
   let raw_env_blank =
     match raw_env with
@@ -104,32 +107,32 @@ let source_provenance (e : entry) ~raw_env raw =
   match raw with
   | Some _ ->
       { kind = "env"
-      ; detail = "environment variable " ^ e.env_name
+      ; detail = "environment variable " ^ spec.env_name
       ; derived_from = []
-      ; env_name = e.env_name
+      ; env_name = spec.env_name
       ; raw_source = "environment"
       ; raw_env_present
       ; raw_env_blank
-      ; default_display = e.default_display
-      ; sensitive = e.sensitive
-      ; value_redacted = e.sensitive
+      ; default_display = spec.default_display
+      ; sensitive = spec.sensitive
+      ; value_redacted = spec.sensitive
       }
   | None ->
-      let provenance = default_provenance e in
+      let provenance = default_provenance spec in
       { provenance with raw_env_present; raw_env_blank }
 
-let applied_provenance (e : entry) source =
+let applied_provenance (spec : spec) source =
   let raw_env_present = match source with Default -> false | Environment -> true in
   { kind = (match source with Default -> "default" | Environment -> "env")
   ; detail = "typed value resolved by the runtime owner"
   ; derived_from = []
-  ; env_name = e.env_name
+  ; env_name = spec.env_name
   ; raw_source = "applied_runtime"
   ; raw_env_present
   ; raw_env_blank = false
-  ; default_display = e.default_display
-  ; sensitive = e.sensitive
-  ; value_redacted = e.sensitive
+  ; default_display = spec.default_display
+  ; sensitive = spec.sensitive
+  ; value_redacted = spec.sensitive
   }
 
 let provenance_to_json p =
@@ -149,34 +152,30 @@ let provenance_to_json p =
      then []
      else [ "derived_from", `List (List.map (fun v -> `String v) p.derived_from) ])
 
-let read_entry (e : entry) =
+let to_json (spec : spec) observation =
   let provenance, display_value =
-    match e.reader with
-    | Effective read ->
-      let value, source = read () in
-      let value = if e.sensitive then mask_sensitive value else value in
-      applied_provenance e source, Some value
-    | Raw_env ->
-      let raw_env = Sys.getenv_opt e.env_name in
-      let raw = Env_config_core.trim_opt raw_env in
-      let provenance = source_provenance e ~raw_env raw in
+    match observation with
+    | Applied_value { value; source } ->
+      let value = if spec.sensitive then mask_sensitive value else value in
+      applied_provenance spec source, Some value
+    | Raw_environment raw_env ->
+      let raw = trim_nonempty raw_env in
+      let provenance = source_provenance spec ~raw_env raw in
       let display_value =
         match raw with
         | None -> None
-        | Some v when e.sensitive -> Some (mask_sensitive v)
+        | Some v when spec.sensitive -> Some (mask_sensitive v)
         | Some v -> Some v
       in
       provenance, display_value
   in
   `Assoc
-    [ "env", `String e.env_name
-    ; "description", `String e.description
+    [ "env", `String spec.env_name
+    ; "description", `String spec.description
     ; "value", Json_util.string_opt_to_json display_value
-    ; "default", `String e.default_display
+    ; "default", `String spec.default_display
     ; "source", `String provenance.kind
     ; "source_detail", `String provenance.detail
     ; "provenance", provenance_to_json provenance
-    ; "sensitive", `Bool e.sensitive
+    ; "sensitive", `Bool spec.sensitive
     ]
-
-let category name entries = name, `List (List.map read_entry entries)

--- a/lib/config/env_config_snapshot_core.mli
+++ b/lib/config/env_config_snapshot_core.mli
@@ -1,20 +1,22 @@
-(** Core entry/provenance helpers for {!Env_config_snapshot}. *)
+(** Pure config-snapshot projection for {!Env_config_snapshot}.
 
-type entry
+    This module consumes already-collected observations. It neither reads the
+    environment nor retains reader closures. *)
+
+type spec
 
 type effective_source =
   | Default
   | Environment
 
-val entry :
-  ?sensitive:bool -> default:string -> string -> string -> entry
+type observation =
+  | Raw_environment of string option
+  | Applied_value of
+      { value : string
+      ; source : effective_source
+      }
 
-val effective_entry :
-  ?sensitive:bool ->
-  default:string ->
-  read:(unit -> string * effective_source) ->
-  string ->
-  string ->
-  entry
+val make_spec :
+  ?sensitive:bool -> default:string -> string -> string -> spec
 
-val category : string -> entry list -> string * Yojson.Safe.t
+val to_json : spec -> observation -> Yojson.Safe.t

--- a/lib/config/masc_grpc_transport.ml
+++ b/lib/config/masc_grpc_transport.ml
@@ -69,7 +69,7 @@ let to_string = function
 ;;
 
 let snapshot_entry =
-  Env_config_snapshot_core.effective_entry
+  Env_config_snapshot_collector.effective_entry
     ~default:(to_string default)
     ~read:(fun () ->
       let resolution = effective_resolution () in

--- a/lib/config/masc_grpc_transport.mli
+++ b/lib/config/masc_grpc_transport.mli
@@ -22,4 +22,4 @@ val configure_from_env : unit -> t
 val to_string : t -> string
 
 (** Operator snapshot entry projected from the same typed process resolution. *)
-val snapshot_entry : Env_config_snapshot_core.entry
+val snapshot_entry : Env_config_snapshot_collector.t

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -3,6 +3,7 @@
 # random, filesystem, Eio, mutation, or logging APIs.
 lib/keeper/keeper_runtime_trust_snapshot_core.ml
 lib/keeper_runtime/keeper_event_queue_state.ml
+lib/config/env_config_snapshot_core.ml
 lib/schedule/schedule_domain.ml
 lib/turn_fsm/turn_fsm.ml
 lib/types/masc_domain.ml

--- a/test/test_env_snapshot_reports_applied_default.ml
+++ b/test/test_env_snapshot_reports_applied_default.ml
@@ -69,6 +69,54 @@ let test_host_entry_still_names_its_constant () =
   | many -> failf "MASC_HTTP_HOST appears %d times" (List.length many)
 ;;
 
+let test_collector_reads_environment_once () =
+  let reads = ref 0 in
+  let getenv name =
+    incr reads;
+    if String.equal name "MASC_TEST_SNAPSHOT_VALUE" then Some "  resolved  " else None
+  in
+  let collector =
+    Env_config_snapshot_collector.entry
+      ~getenv
+      ~default:"fallback"
+      "MASC_TEST_SNAPSHOT_VALUE"
+      "test value"
+  in
+  let json = Env_config_snapshot_collector.to_json collector in
+  check int "one boundary read" 1 !reads;
+  check
+    string
+    "pure projection receives the trimmed observed value"
+    "resolved"
+    Yojson.Safe.Util.(json |> member "value" |> to_string)
+;;
+
+let test_pure_projection_redacts_explicit_observation () =
+  let spec =
+    Env_config_snapshot_core.make_spec
+      ~sensitive:true
+      ~default:"(none)"
+      "MASC_TEST_SNAPSHOT_TOKEN"
+      "test token"
+  in
+  let json =
+    Env_config_snapshot_core.to_json
+      spec
+      (Env_config_snapshot_core.Applied_value
+         { value = "secret-value"; source = Env_config_snapshot_core.Environment })
+  in
+  check
+    string
+    "core redacts the supplied value"
+    "[REDACTED]"
+    Yojson.Safe.Util.(json |> member "value" |> to_string);
+  check
+    string
+    "core preserves applied provenance"
+    "env"
+    Yojson.Safe.Util.(json |> member "source" |> to_string)
+;;
+
 let () =
   run
     "env snapshot reports the applied default"
@@ -82,6 +130,14 @@ let () =
             "the host precedent still holds"
             `Quick
             test_host_entry_still_names_its_constant
+        ; test_case
+            "collector reads environment once"
+            `Quick
+            test_collector_reads_environment_once
+        ; test_case
+            "pure projection redacts explicit observations"
+            `Quick
+            test_pure_projection_redacts_explicit_observation
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- move environment and applied-runtime reads out of `Env_config_snapshot_core`
- pass immutable observations into a pure JSON/provenance projection
- keep effectful reader closures in an explicit collector shell
- register the projection core in the one-way pure-module AST ratchet

## Characterization

- existing dashboard/config snapshot wire fields and provenance meanings are unchanged
- an injected environment boundary is read exactly once per projection
- sensitive already-resolved values remain redacted by the pure core

## Verification

- parser check for all ten touched OCaml source/interface/test files
- `ocamlformat --check` for all touched OCaml files
- `ocamldep -sort lib/config/*.ml`
- `git diff --check`
- focused Dune targets requested through `scripts/dune-local.sh`; wrapper exited 75 because an unrelated bare Dune process is active, so no bypass was used

## Stack

Base: `refactor/functional-core-agent-option` (#28275). First small PR in the global config/dashboard boundary sweep.