### PR TITLE
test(dashboard): align raw trace census fixtures

### DIFF
--- a/dashboard/src/components/keeper-turn-inspector-panel.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector-panel.test.ts
@@ -28,7 +28,13 @@ function noTurns() {
 describe('KeeperTurnInspectorPanel', () => {
   it('lists a keeper\'s turn files and opens the one that is clicked', async () => {
     api.fetchKeeperRawTraces.mockResolvedValue([
-      { file: 'turn-0007.jsonl', traceId: 'trace-0007', bytes: 2048, records: 4, modifiedAt: 1786000000 },
+      {
+        file: 'turn-0007.jsonl',
+        traceId: 'trace-0007',
+        bytes: 2048,
+        census: { state: 'whole_file', records: 4 },
+        modifiedAt: 1786000000,
+      },
     ])
     const raw = '{"kind":"request","model":"qwen3-6-35b"}'
     api.fetchKeeperRawTrace.mockResolvedValue({
@@ -57,7 +63,13 @@ describe('KeeperTurnInspectorPanel', () => {
   // decode holds its position and says why, rather than being dropped.
   it('keeps an undecodable record in place with its reason', async () => {
     api.fetchKeeperRawTraces.mockResolvedValue([
-      { file: 'turn-0008.jsonl', traceId: 'trace-0008', bytes: 10, records: 2, modifiedAt: 1786000000 },
+      {
+        file: 'turn-0008.jsonl',
+        traceId: 'trace-0008',
+        bytes: 10,
+        census: { state: 'whole_file', records: 2 },
+        modifiedAt: 1786000000,
+      },
     ])
     api.fetchKeeperRawTrace.mockResolvedValue({
       file: 'turn-0008.jsonl',

--- a/dashboard/src/components/keeper-turn-inspector-panel.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector-panel.test.ts
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { html } from 'htm/preact'
+import type { RawTraceTurn } from '../api/dashboard-keeper-prompt'
 
 const api = vi.hoisted(() => ({
   fetchKeeperRawTraces: vi.fn(),
@@ -27,15 +28,14 @@ function noTurns() {
 
 describe('KeeperTurnInspectorPanel', () => {
   it('lists a keeper\'s turn files and opens the one that is clicked', async () => {
-    api.fetchKeeperRawTraces.mockResolvedValue([
-      {
-        file: 'turn-0007.jsonl',
-        traceId: 'trace-0007',
-        bytes: 2048,
-        census: { state: 'whole_file', records: 4 },
-        modifiedAt: 1786000000,
-      },
-    ])
+    const turn = {
+      file: 'turn-0007.jsonl',
+      traceId: 'trace-0007',
+      bytes: 390_000_000,
+      census: { state: 'prefix_only', budgetBytes: 262_144 },
+      modifiedAt: 1786000000,
+    } satisfies RawTraceTurn
+    api.fetchKeeperRawTraces.mockResolvedValue([turn])
     const raw = '{"kind":"request","model":"qwen3-6-35b"}'
     api.fetchKeeperRawTrace.mockResolvedValue({
       file: 'turn-0007.jsonl',
@@ -45,6 +45,7 @@ describe('KeeperTurnInspectorPanel', () => {
     })
 
     render(html`<${KeeperTurnInspectorPanel} keepers=${KEEPERS} />`)
+    expect(await screen.findByText(/256\.0 KB 초과 · 열어서 집계/)).toBeTruthy()
     fireEvent.click(await screen.findByText('turn-0007.jsonl'))
 
     // Literal JSONL is the default. A RAW badge must not hide it behind a
@@ -62,15 +63,14 @@ describe('KeeperTurnInspectorPanel', () => {
   // A damaged trace must not read as a shorter one: the record that failed to
   // decode holds its position and says why, rather than being dropped.
   it('keeps an undecodable record in place with its reason', async () => {
-    api.fetchKeeperRawTraces.mockResolvedValue([
-      {
-        file: 'turn-0008.jsonl',
-        traceId: 'trace-0008',
-        bytes: 10,
-        census: { state: 'whole_file', records: 2 },
-        modifiedAt: 1786000000,
-      },
-    ])
+    const turn = {
+      file: 'turn-0008.jsonl',
+      traceId: 'trace-0008',
+      bytes: 10,
+      census: { state: 'whole_file', records: 2 },
+      modifiedAt: 1786000000,
+    } satisfies RawTraceTurn
+    api.fetchKeeperRawTraces.mockResolvedValue([turn])
     api.fetchKeeperRawTrace.mockResolvedValue({
       file: 'turn-0008.jsonl',
       totalRecords: 2,
@@ -82,6 +82,7 @@ describe('KeeperTurnInspectorPanel', () => {
     })
 
     render(html`<${KeeperTurnInspectorPanel} keepers=${KEEPERS} />`)
+    expect(await screen.findByText(/2건/)).toBeTruthy()
     fireEvent.click(await screen.findByText('turn-0008.jsonl'))
 
     expect(await screen.findByText(/레코드 2 를 읽지 못했습니다: not valid JSON/)).toBeTruthy()


### PR DESCRIPTION
## Summary

Closes #28281 by updating the two Keeper turn-inspector fixtures to the current `RawTraceTurn.census` contract.

The stale mocks returned the removed `records` field. After the resolved mock updated component state, `censusLabel(undefined)` raised while rendering; the subsequent DOM query surfaced that crash as a 5-second timeout.

- keep the production decoder fail-closed; no missing-census fallback
- exercise both census variants in the panel: `prefix_only` and `whole_file`
- assert each operator-facing census label before opening the retained trace
- pin both fixtures with `satisfies RawTraceTurn` so future contract drift is a type error rather than a render timeout

## Validation

- `pnpm exec eslint src/components/keeper-turn-inspector-panel.test.ts`
- `git diff --check`

Per standing instruction, local Vitest/build was not rerun; exact-head GitHub Dashboard CI is the behavior authority.

Failure evidence: current-main run `31558629142`, Dashboard job `93996218843`; `Build and Test` was green on the same main head.
