### PR TITLE
fix(tools): declare unix for the boundary audit test stanza (main 루트 빌드 복구)

### DIFF
--- a/tools/ocaml_boundary_audit/dune
+++ b/tools/ocaml_boundary_audit/dune
@@ -12,4 +12,4 @@
 (test
  (name test_ocaml_boundary_audit)
  (modules test_ocaml_boundary_audit)
- (libraries alcotest ocaml_boundary_audit_lib))
+ (libraries alcotest ocaml_boundary_audit_lib unix))


### PR DESCRIPTION
`dune build .` 가 저장소 루트에서 실패합니다. main 기준입니다.

```
File "tools/ocaml_boundary_audit/test_ocaml_boundary_audit.ml", line 101, characters 2-6:
101 |   Unix.mkdir root 0o755;
        ^^^^
Error: Unbound module Unix
```

## 원인

같은 `dune` 파일 안에서 세 stanza 중 test 만 `unix` 를 선언하지 않습니다:

```
(library    ... (libraries compiler-libs.common unix yojson))   ← 있음
(executable ... (libraries ocaml_boundary_audit_lib unix))      ← 있음
(test       ... (libraries alcotest ocaml_boundary_audit_lib))  ← 없음
```

그리고 `dune-project:9` 에 `(implicit_transitive_deps false)` 가 있어, 라이브러리가 가진 `unix` 의존성이 test 로 전파되지 않습니다. 직접 선언해야 합니다.

## 수정

```diff
 (test
  (name test_ocaml_boundary_audit)
  (modules test_ocaml_boundary_audit)
- (libraries alcotest ocaml_boundary_audit_lib))
+ (libraries alcotest ocaml_boundary_audit_lib unix))
```

## 검증

```
dune build --root . tools/ocaml_boundary_audit/     → exit 0
dune test  --root . tools/ocaml_boundary_audit/     → Test Successful in 0.004s. 6 tests run.
```

6 케이스 전부 통과합니다 (`typed path classification` 3건, `ratchet` 3건). **링크가 안 돼서 여태 한 번도 실행되지 않았던 테스트**입니다.

## 왜 아무도 못 봤나

`4d236b5be0` (#28261, "delete dead exhaustive codemod scaffold") 이 `Unix.mkdir`/`Unix.rmdir` 사용과 이 `dune` 변경을 같이 넣었습니다.

`ci.yml:807-816` 의 "Run typed functional-core boundary audit" 스텝은 조건 없이 항상 돌고 `dune build --root . @tools/ocaml_boundary_audit/runtest` 를 실행하므로, **원래대로면 CI 가 잡았어야 합니다.** 잡지 못한 이유는 별개입니다:

| main 커밋 | `Build and Test` |
|---|---|
| `fd367e7ed0` (HEAD, #28273) | in_progress |
| `d12e15e1b9` (#28280) | **cancelled** |
| `8876ca669a` | **cancelled** |
| `4d236b5be0` (#28261 — 파손 도입) | **cancelled** |
| `d4668756d6` | success |

파손을 들여온 커밋의 빌드가 **실패가 아니라 취소**됐고, 이후 두 머지도 취소됐습니다. `ci.yml` 의 push concurrency 그룹이 `CI-push-main` 하나이고 `cancel-in-progress: true` 라서, 머지 간격이 빌드 시간보다 짧으면 신호가 구조적으로 완주하지 못합니다. `cancelled` 는 `failure` 가 아니므로 rollup 은 초록으로 보입니다.

즉 이 PR 은 한 줄짜리 수정이지만, **main 이 3커밋 동안 루트 빌드가 안 되는 상태였고 그것을 알려준 체크가 없었다**는 것이 같이 기록되어야 할 부분입니다.

## 형제 사례 확인

`tools/` 와 `test/` 의 모든 `dune` 을 대상으로 "`Unix.` 를 쓰는 모듈이 속한 stanza 에 `unix` 가 있는가" 를 훑었습니다. 처음에 26건이 더 나왔는데 전수 확인 결과 **전부 오탐**이었습니다 — `test/dune` 은 stanza 127개짜리 파일이고 해당 stanza 들이 `unix` 를 정상적으로 선언합니다(`:621`, `:832`, `:869`, `:922`, `:1248` 등). 제 stanza 분리가 틀렸던 것입니다.

**실제 결함은 이 한 곳뿐입니다.**

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
