### PR TITLE
perf(keeper): 대화 히스토리의 턴당 트레이스 단계 상한 (2.51MB → 0.69MB)

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1712,7 +1712,7 @@ function ChatTraceStep({
   `
 }
 
-function ChatTraceBlock({ trace }: { trace: ChatTraceStep[] }) {
+function ChatTraceBlock({ trace, omitted = 0 }: { trace: ChatTraceStep[]; omitted?: number }) {
   const [open, setOpen] = useState(true)
   const toolN = trace.filter((s) => s.kind === 'tool').length
   const dur = traceDur(trace)
@@ -1729,6 +1729,13 @@ function ChatTraceBlock({ trace }: { trace: ChatTraceStep[] }) {
         <span>◈</span>
         <span class="chat-block-trace-label">작업 과정</span>
         <span class="chat-block-trace-count">${trace.length}단계</span>
+        <!-- A nested template literal inside an htm template corrupts its
+             parse and breaks unrelated components in the same module, so the
+             two counts are separate spans rather than one interpolated
+             string. -->
+        ${omitted > 0
+          ? html`<span class="chat-block-trace-count" data-chat-trace-omitted=${omitted}>앞 ${omitted}단계 생략</span>`
+          : null}
         <span class="chat-block-trace-meta">
           ${toolN > 0 ? html`<span>도구 ${toolN}</span>` : null}
           ${dur ? html`<span class="tnum">${dur}</span>` : null}
@@ -1738,6 +1745,12 @@ function ChatTraceBlock({ trace }: { trace: ChatTraceStep[] }) {
         ? html`
             <div class="chat-block-trace-steps">
               <span class="chat-block-trace-rail"></span>
+              ${omitted > 0
+                ? html`<div class="chat-block-tstep-text" data-chat-trace-omitted=${omitted}>
+                    이 턴의 앞 ${omitted}단계는 대화 화면에 싣지 않았습니다 — 전체는 Turn
+                    Inspector의 raw trace에서 확인합니다.
+                  </div>`
+                : null}
               ${trace.map((s, i) => html`<${ChatTraceStep} key=${i} step=${s} />`)}
             </div>
           `
@@ -2097,7 +2110,7 @@ function ChatBlock({ block, fallbackText }: { block: ChatBlock; fallbackText?: s
     case 'image': return html`<${ChatImageBlock} src=${block.src} ph=${block.ph} cap=${block.cap} />`
     case 'svg': return html`<${ChatSvgBlock} svg=${block.svg} cap=${block.cap} />`
     case 'mermaid': return html`<${ChatMermaidBlock} source=${block.source} caption=${block.caption} />`
-    case 'trace': return html`<${ChatTraceBlock} trace=${block.trace} />`
+    case 'trace': return html`<${ChatTraceBlock} trace=${block.trace} omitted=${block.omitted} />`
     case 'thinking': return html`<${ChatPersistedThinkingBlock} content=${block.content} redacted=${block.redacted} />`
     case 'link': return html`<${ChatLinkBlock} url=${block.url} title=${block.title} desc=${block.desc} meta=${block.meta} fav=${block.fav} kind=${block.kind} />`
     case 'broadcast': return html`<${ChatBroadcastBlock} scope=${block.scope} via=${block.via} note=${block.note} recipients=${block.recipients} />`

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -806,7 +806,10 @@ export type ChatTraceToolStep = {
   agentCoreBlockIndex?: number
 }
 export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceProgressStep | ChatTraceToolStep
-export type ChatTraceBlock = { t: 'trace'; trace: ChatTraceStep[] }
+// `omitted` counts steps this surface did not carry (absent or 0 when whole).
+// A shorter `trace` with no count would read as a shorter turn, which is a
+// different fact from a turn whose trace was abridged for transport.
+export type ChatTraceBlock = { t: 'trace'; trace: ChatTraceStep[]; omitted?: number }
 export type ChatThinkingBlock = { t: 'thinking'; content: string; redacted: boolean }
 
 export type ChatLinkBlock = { t: 'link'; url: string; title: string; desc?: string; meta?: string; fav?: string; kind?: string }

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -146,7 +146,10 @@ type trace_step =
       agent_core_block_index : int option;
     }
 
-type trace_block = { trace : trace_step list }
+type trace_block =
+  { trace : trace_step list
+  ; omitted : int
+  }
 
 type thinking_block = {
   content : string;
@@ -586,11 +589,15 @@ let block_to_yojson = function
       [ ("t", `String "status")
       ; ("kind", `String (status_kind_to_label kind))
       ]
-  | Trace { trace } ->
+  | Trace { trace; omitted } ->
+    (* [omitted] is emitted only when non-zero, so a normal turn's wire shape
+       is unchanged. It states how many steps this surface did not carry — a
+       shorter [trace] with no count would read as a shorter turn. *)
     `Assoc
-      [ ("t", `String "trace")
-      ; ("trace", `List (List.map trace_step_to_yojson trace))
-      ]
+      ([ ("t", `String "trace")
+       ; ("trace", `List (List.map trace_step_to_yojson trace))
+       ]
+       @ (if omitted > 0 then [ ("omitted", `Int omitted) ] else []))
   | Thinking { content; redacted } ->
     (* redacted defaults to false (omitted); only emit when true so the
        common non-redacted case stays minimal and legacy decoders that do
@@ -789,7 +796,15 @@ let block_of_yojson json : chat_block option =
      | Some "trace" ->
        Option.bind (List.assoc_opt "trace" fields) (fun trace_json ->
          Option.bind (trace_steps_of_yojson trace_json) (fun trace ->
-           if trace = [] then None else Some (Trace { trace })))
+           if trace = []
+           then None
+           else (
+             let omitted =
+               match List.assoc_opt "omitted" fields with
+               | Some (`Int n) when n > 0 -> n
+               | _ -> 0
+             in
+             Some (Trace { trace; omitted }))))
      | Some "thinking" ->
        (* content is required (empty string for signature-only redacted thinking);
           redacted defaults to false and is only honoured when explicitly

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -163,7 +163,18 @@ type trace_step =
       agent_core_block_index : int option;
     }
 
-type trace_block = { trace : trace_step list }
+type trace_block =
+  { trace : trace_step list
+  ; omitted : int
+      (** Steps this surface did not carry, 0 when the trace is whole. A
+          truncated [trace] with no count reads as a shorter turn, which is a
+          different fact from a turn whose trace was abridged for transport.
+
+          The chat transcript sets it: a trace block is one turn's steps, and
+          one runaway turn on the author's host held 16,882 of the 22,296 steps
+          in a keeper's whole transcript (1.65 MB of 2.29 MB) while the median
+          block held 17. The turn's steps stay available in full from the
+          raw-trace surface. *) }
 
 (** A block of keeper/assistant reasoning persisted so the dashboard can
     replay assistant thinking on reload (RFC-0302). [content] is the

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -384,9 +384,9 @@ let redact_block redaction = function
     Keeper_chat_blocks.Fusion { board_post_id; run_id }
   | Keeper_chat_blocks.Status { kind } ->
     Keeper_chat_blocks.Status { kind }
-  | Keeper_chat_blocks.Trace { trace } ->
+  | Keeper_chat_blocks.Trace { trace; omitted } ->
     Keeper_chat_blocks.Trace
-      { trace = List.map (redact_trace_step redaction) trace }
+      { trace = List.map (redact_trace_step redaction) trace; omitted }
   | Keeper_chat_blocks.Thinking { content; redacted } ->
     Keeper_chat_blocks.Thinking
       { content = redact_string redaction content; redacted }

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1290,7 +1290,7 @@ let autonomous_turn_json (turn : Keeper_autonomous_turn_source.turn) =
     | trace ->
       [ ( "blocks"
         , Keeper_chat_blocks.blocks_to_yojson
-            [ Keeper_chat_blocks.Trace { trace } ] ) ]
+            [ Keeper_chat_blocks.Trace { trace; omitted = 0 } ] ) ]
   in
   `Assoc
     ([ "role", `String "assistant"

--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -194,6 +194,20 @@ let allowed_trace_id_set trace_ids =
     trace_ids
 ;;
 
+(* How many of one turn's trace steps the chat transcript carries.
+
+   A trace block is one turn's steps, and the transcript embeds every block.
+   Measured on this host: one keeper's transcript held 22,296 steps across 162
+   blocks, of which a single runaway turn held 16,882 — 1.65 MB of the 2.29 MB
+   that trace blocks contributed to a 2.51 MB response, against 0.02 MB of
+   actual conversation prose. The median block held 17 steps and the
+   second-largest 175, so this cap leaves every ordinary turn whole and abridges
+   only the pathological one.
+
+   The block reports how many steps it dropped rather than just being shorter,
+   and the turn's steps stay available in full from the raw-trace surface. *)
+let chat_trace_steps_per_turn = 200
+
 let chat_trace_block_by_turn_ref ~max_lines ~max_internal_lines
     ~(config : Workspace.config)
     ~(keeper_name : string)
@@ -236,5 +250,15 @@ let chat_trace_block_by_turn_ref ~max_lines ~max_internal_lines
       in
       (match trace with
        | [] -> None
-       | trace -> Some (Keeper_chat_blocks.Trace { trace }))
+       | trace ->
+         (* Newest steps are the ones an operator is reading toward, so the
+            tail is what survives the cap. *)
+         let total = List.length trace in
+         let omitted = max 0 (total - chat_trace_steps_per_turn) in
+         let trace =
+           if omitted = 0
+           then trace
+           else List.filteri (fun index _ -> index >= omitted) trace
+         in
+         Some (Keeper_chat_blocks.Trace { trace; omitted }))
 ;;

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -223,6 +223,7 @@ let test_dashboard_rich_blocks_roundtrip () =
         };
       B.Trace
         {
+          omitted = 0;
           trace =
             [
               B.Trace_think
@@ -286,7 +287,8 @@ let test_trace_decoder_accepts_dashboard_fallbacks () =
   match B.blocks_of_yojson json with
   | Some
       [ B.Trace
-          { trace =
+          { omitted = 0
+          ; trace =
               [ B.Trace_think { agent_core_block_index = Some 7; _ }
               ; B.Trace_tool { status = None; agent_core_block_index = Some 8; _ }
               ]
@@ -503,7 +505,7 @@ let test_thinking_block_requires_content () =
        (`List [ `Assoc [ ("t", `String "thinking"); ("redacted", `Bool true) ] ])
      = None)
 
-let withheld_think_trace steps = [ B.Trace { trace = steps } ]
+let withheld_think_trace steps = [ B.Trace { trace = steps; omitted = 0 } ]
 
 let test_withheld_think_step_roundtrip () =
   (* The public autonomous projection admits the step and its timestamp with no
@@ -612,6 +614,43 @@ let test_withheld_think_step_still_requires_text_field () =
           ])
      = None)
 
+(* A trace block that was abridged has to say so. A shorter [trace] with no
+   count reads as a shorter turn, which is a different fact from a turn whose
+   trace did not fit this surface. Zero stays off the wire so an ordinary
+   turn's shape is unchanged. *)
+let test_omitted_step_count_survives_the_wire () =
+  let step =
+    B.Trace_think
+      { text = "checking"
+      ; content_withheld = false
+      ; ts = Some "2026-07-01T00:00:00Z"
+      ; agent_core_block_index = None
+      }
+  in
+  let json_of omitted =
+    B.blocks_to_yojson [ B.Trace { trace = [ step ]; omitted } ]
+  in
+  let has_omitted json =
+    match json with
+    | `List [ `Assoc fields ] -> List.assoc_opt "omitted" fields
+    | _ -> None
+  in
+  Alcotest.(check bool)
+    "a whole trace does not carry the field"
+    true
+    (Option.is_none (has_omitted (json_of 0)));
+  Alcotest.(check (option int))
+    "an abridged trace reports how many steps it dropped"
+    (Some 16682)
+    (match has_omitted (json_of 16682) with
+     | Some (`Int n) -> Some n
+     | _ -> None);
+  match B.blocks_of_yojson (json_of 16682) with
+  | Some [ B.Trace { omitted; _ } ] ->
+    Alcotest.(check int) "round trip keeps the count" 16682 omitted
+  | _ -> Alcotest.fail "abridged trace block did not round trip"
+;;
+
 let () =
   Alcotest.run "keeper_chat_blocks"
     [
@@ -692,6 +731,8 @@ let () =
             test_withheld_think_step_encoder_scrubs_smuggled_text;
           Alcotest.test_case "withheld think decoder scrubs smuggled text" `Quick
             test_withheld_think_step_decoder_scrubs_smuggled_text;
+          Alcotest.test_case "abridged trace reports its omitted step count" `Quick
+            test_omitted_step_count_survives_the_wire;
           Alcotest.test_case "withheld think step still requires text field" `Quick
             test_withheld_think_step_still_requires_text_field;
         ] );

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1296,7 +1296,8 @@ let test_append_turn_redacts_all_supplied_block_strings () =
               ; caption = Some ("flow " ^ secret)
               }
           ; B.Trace
-              { trace =
+              { omitted = 0
+              ; trace =
                   [ B.Trace_think
                       { text = "thinking " ^ secret
                       ; content_withheld = false
@@ -1578,6 +1579,7 @@ let test_to_json_array_appends_trace_block_to_assistant_turn () =
           Some
             (B.Trace
                {
+                 omitted = 0;
                  trace =
                    [
                      B.Trace_think
@@ -1681,7 +1683,8 @@ let test_to_json_array_stream_contract_trace_join () =
         if Ids.Turn_ref.equal turn_ref tref then
           Some
             (B.Trace
-               { trace =
+               { omitted = 0
+               ; trace =
                    [ B.Trace_think
                        { text = "thinking";
                          content_withheld = false;
@@ -1801,7 +1804,8 @@ let test_to_json_array_stream_contract_lifecycle_replay () =
         if Ids.Turn_ref.equal turn_ref tref then
           Some
             (B.Trace
-               { trace =
+               { omitted = 0
+               ; trace =
                    [ B.Trace_think
                        { text = "retained trace";
                          content_withheld = false;


### PR DESCRIPTION
## 문제

대화 히스토리(`GET /api/v1/keepers/<name>/chat/history`)가 **모든 턴의 트레이스 전체를 인라인**으로 실었습니다.

실측: 한 keeper의 응답 2.51 MB 중
- `t=trace` 블록 **2.29 MB (91%)**
- 실제 대화 산문(`t=p`) **0.02 MB**

## 첫 시도가 틀렸고, 측정이 그걸 잡았습니다

처음엔 단계별 `args`+`result`를 8 KiB로 제한했습니다. 캡처한 실제 payload에 같은 술어를 적용해 보니 **22,296개 단계 중 0개가 발화**했습니다. 부피는 단계 *크기*가 아니라 *개수*였습니다. 그 접근은 이 PR에 없습니다.

정확한 분포:

| | 값 |
|---|---|
| trace 블록 | 162개 |
| 총 단계 | 22,296 |
| **최대 블록** | **16,882단계 (1,653 KB)** |
| 2위 블록 | 175단계 |
| 중앙값 | 17단계 |

한 블록이 전체의 76%입니다. 앞서 보고한 폭주 턴(도구 실행 16,801회, raw-trace 372.5 MB)과 **같은 턴**입니다.

## 변경

턴당 트레이스 단계를 **200개**로 제한합니다. 중앙값 17, 2위 175이므로 **일반 턴은 전부 온전**하고 병적인 하나만 축약됩니다.

`trace_block`에 `omitted`(싣지 않은 단계 수)를 추가했습니다. 잘린 트레이스에 개수가 없으면 **짧은 턴으로 읽힙니다** — 이건 "전송을 위해 축약된 턴"과 다른 사실입니다. 그래서 개수를 와이어에 싣고 패널이 `앞 N단계 생략`이라고 말합니다. 0일 때는 필드를 내보내지 않아 **일반 턴의 와이어 형태는 불변**입니다.

남은 단계는 raw-trace 표면에서 전부 읽을 수 있습니다(#28272로 이미 16.45s → 0.116s가 된 그 표면).

최신 단계가 운영자가 읽어가는 방향이므로 **꼬리를 남깁니다**.

## 측정

캡처한 라이브 payload에 구현한 술어를 그대로 적용:

```
2.51 MB → 0.69 MB   (69.8% 감소)
축약된 블록 1개 / 162개, 생략된 단계 16,682개
```

## 함정 하나 기록

패널의 단계 수를 처음엔 `htm` 템플릿 안의 **중첩 템플릿 리터럴**로 썼습니다. 이게 htm의 파스를 망가뜨려 **같은 모듈의 무관한 fusion 카드 테스트를 깼습니다** — 있을 때 270/271, 없을 때 271/271. 단독 실행에서는 재현되지 않고 디렉터리 실행에서만 나타났습니다. 지금은 두 span으로 분리했고 이유를 주석으로 남겼습니다.

## 테스트

- `test_keeper_chat_blocks.exe` 38/38 (`omitted` 와이어 계약 테스트 추가: 0이면 필드 부재, >0이면 개수 왕복)
- `test_keeper_chat_store.exe` 57/57 (redaction이 `omitted`를 통과시키는지 포함)
- `dashboard src/components/chat` 271/271
- `tsc --noEmit` 통과

## 남은 것

- `operator` 4.68 s 콜드 — `lib/operator/operator_control*`는 RFC 선행 의무 subsystem이라 별도 절차 필요
- `bootstrap` 2.01 s 콜드 — 미조사

🤖 Generated with [Claude Code](https://claude.com/claude-code)
