### PR TITLE
fix(main): main does not compile — a shadowed field and an unclosed match

### DIFF
--- a/lib/config/env_config_snapshot_collector.ml
+++ b/lib/config/env_config_snapshot_collector.ml
@@ -34,7 +34,10 @@ let effective_entry ?(sensitive = false) ~default ~read env_name description =
   }
 ;;
 
-let collect collector =
+(* [t] and [observed] both carry a [spec], and [observed] is declared second,
+   so an unannotated [collector.spec] resolves against [observed] and the next
+   field access has nowhere to go. The annotation names which record this is. *)
+let collect (collector : t) : observed =
   { spec = collector.spec; observation = collector.collect () }
 
 let project observed =

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -1312,8 +1312,8 @@ let dispatch_message cs msg =
                           cs
                           n
                           Mcp_error_code.(to_wire_code Invalid_params)
-                          ("No LSP server for: " ^ request.relative_path)))
-             | None -> ())))
+                          ("No LSP server for: " ^ request.relative_path))))
+             | None -> ()))
        (* No method field *)
        | None, Some n -> send_error cs n Mcp_error_code.(to_wire_code Invalid_request) "Missing method field"
        | None, None -> ())


### PR DESCRIPTION
## main 이 컴파일되지 않는다

`origin/main` `7f70fd434f` 에서:

```
$ dune build --root . @check
File "lib/config/env_config_snapshot_collector.ml", line 38:
Error: This expression has type observed
       There is no field collect within type observed
File "lib/server/server_ide_lsp_proxy.ml", line 1316:
Error: This variant pattern is expected to have type method_disposition
       There is no constructor None within type method_disposition
exit=1
```

깨끗한 워크트리를 origin/main 에 새로 만들어 확인했다. 내 브랜치에서 처음 보였지만 base 가 원인이었다.

## 두 결함

**`env_config_snapshot_collector`** — `t` 와 `observed` 가 **둘 다 `spec` 필드를 갖는다.** `observed` 가 나중에 선언되므로 무주석 `collector.spec` 이 `observed` 로 해석되고, 이어지는 `collector.collect` 는 갈 곳이 없어진다. 매개변수와 결과에 타입을 명시해 어느 레코드인지 이름으로 고정한다.

전형적인 OCaml 필드 섀도잉이고, 두 타입이 같은 필드명을 공유하는 한 무주석 접근은 계속 마지막 선언을 고른다.

**`server_ide_lsp_proxy`** — `match classify_forwarded_method ... with` 가 닫히지 않아서, 바깥 `match id_opt` 의 arm 인 `| None -> ()` 가 **`method_disposition` 의 네 번째 생성자로 읽혔다.** 괄호 한 짝 문제다.

## 검증

```
dune build --root . @check                       exit=0
@test/runtest-test_server_ide_lsp_proxy          Test Successful  17 tests
@fmt                                             두 파일 모두 diff 없음
```

## 왜 머지됐나

어제 같은 사고가 있었고 (#28212 로 수습), 오늘 또 났다. 게이트 상태는 그대로다:

```
branches/main/protection   enforce_admins: False   required: ['CI Gate']
rulesets/18802107          enforcement: active     bypass_actors: 0   rules: []
                           name: "main merge gate (no bypass)"
```

관리자 병합이 통과해야 하는 게이트가 0 개다. 추적은 #26306 에 있고 설정 변경안도 거기 적어뒀다 — 룰셋에 `required_status_checks` 를 넣고 context 를 `Build and Test` 로 지정하는 것. 이 PR 은 그 설정을 건드리지 않는다.

RFC-WAIVED: credential / identity / repo_manager / operator_control / keeper_sandbox / hooks / workflow 문서를 건드리지 않는다. 컴파일 수리 2 파일뿐이다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
