### PR TITLE
refactor(mcp): admit typed tool call requests

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -139,7 +139,7 @@ let handle_request
         ~internal_keeper_runtime
         state
         id
-        params ->
+        call ->
       Mcp_server_eio_call_tool.handle_call_tool_eio
         ~execute_tool_eio
         ~maybe_emit_resource_notifications:
@@ -153,7 +153,7 @@ let handle_request
         ~internal_keeper_runtime
         state
         id
-        params)
+        call)
     ~handle_read_resource_eio:Mcp_server_eio_resource.handle_read_resource_eio
     ~clock
     ~sw

--- a/lib/mcp_server_eio_call_request.ml
+++ b/lib/mcp_server_eio_call_request.ml
@@ -1,0 +1,107 @@
+(** Pure admission for MCP [tools/call] parameters. *)
+
+type t =
+  { requested_name : string
+  ; arguments : Yojson.Safe.t
+  }
+
+type error =
+  | Missing_params
+  | Expected_object
+  | Name_must_be_string
+  | Name_must_be_nonempty
+  | Name_has_surrounding_whitespace
+  | Duplicate_name
+  | Arguments_must_be_object of string
+  | Duplicate_arguments of string
+
+type field =
+  | Absent
+  | Present of Yojson.Safe.t
+  | Duplicate
+
+let field name fields =
+  match List.filter_map (fun (key, value) -> if String.equal key name then Some value else None) fields with
+  | [] -> Absent
+  | [ value ] -> Present value
+  | _ :: _ :: _ -> Duplicate
+;;
+
+let decode = function
+  | None -> Error Missing_params
+  | Some (`Assoc fields) ->
+    (match field "name" fields with
+     | Absent -> Error Name_must_be_string
+     | Duplicate -> Error Duplicate_name
+     | Present (`String requested_name) ->
+       let canonical_name = String.trim requested_name in
+       if String.equal canonical_name ""
+       then Error Name_must_be_nonempty
+       else if not (String.equal canonical_name requested_name)
+       then Error Name_has_surrounding_whitespace
+       else (
+         match field "arguments" fields with
+         | Absent -> Ok { requested_name; arguments = `Assoc [] }
+         | Duplicate -> Error (Duplicate_arguments requested_name)
+         | Present (`Assoc _ as arguments) -> Ok { requested_name; arguments }
+         | Present
+             (`Null
+             | `Bool _
+             | `Int _
+             | `Intlit _
+             | `Float _
+             | `String _
+             | `List _
+             | `Tuple _
+             | `Variant _)
+           ->
+           Error (Arguments_must_be_object requested_name))
+     | Present
+         (`Null
+         | `Bool _
+         | `Int _
+         | `Intlit _
+         | `Float _
+         | `Assoc _
+         | `List _
+         | `Tuple _
+         | `Variant _)
+       -> Error Name_must_be_string)
+  | Some
+      (`Null
+      | `Bool _
+      | `Int _
+      | `Intlit _
+      | `Float _
+      | `String _
+      | `List _
+      | `Tuple _
+      | `Variant _) ->
+    Error Expected_object
+;;
+
+let requested_name (request : t) = request.requested_name
+let arguments (request : t) = request.arguments
+
+let error_message = function
+  | Missing_params -> "Missing params"
+  | Expected_object -> "Invalid params: expected object"
+  | Name_must_be_string -> "Invalid params: name must be a string"
+  | Name_must_be_nonempty -> "Invalid params: name must be a non-empty string"
+  | Name_has_surrounding_whitespace ->
+    "Invalid params: name must not contain surrounding whitespace"
+  | Duplicate_name -> "Invalid params: duplicate name field"
+  | Arguments_must_be_object _ -> "Invalid params: arguments must be an object"
+  | Duplicate_arguments _ -> "Invalid params: duplicate arguments field"
+;;
+
+let error_requested_name = function
+  | Arguments_must_be_object requested_name
+  | Duplicate_arguments requested_name -> Some requested_name
+  | Missing_params
+  | Expected_object
+  | Name_must_be_string
+  | Name_must_be_nonempty
+  | Name_has_surrounding_whitespace
+  | Duplicate_name -> None
+;;

--- a/lib/mcp_server_eio_call_request.mli
+++ b/lib/mcp_server_eio_call_request.mli
@@ -1,0 +1,14 @@
+(** Current-only typed admission for MCP [tools/call] parameters.
+
+    A request has exactly one canonical non-empty string [name]. [arguments]
+    is either absent (the MCP-defined empty object) or exactly one JSON object.
+    Invalid and duplicate fields are rejected before dispatch. *)
+
+type t
+type error
+
+val decode : Yojson.Safe.t option -> (t, error) result
+val requested_name : t -> string
+val arguments : t -> Yojson.Safe.t
+val error_message : error -> string
+val error_requested_name : error -> string option

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -149,18 +149,6 @@ let record_mcp_server_operation_duration result ~duration_ms =
     ~duration_seconds:(float_of_int duration_ms /. 1000.0)
 ;;
 
-(** MCP tools/call [arguments] is optional (spec: "arguments?: object").
-    Absence therefore means an empty object. An explicitly supplied [`Null]
-    is not absence and must remain [`Null] so AGENT_CORE strict validation rejects it
-    instead of silently repairing an invalid wire value. *)
-let arguments_of_params = function
-  | `Assoc fields ->
-    (match List.assoc_opt "arguments" fields with
-     | None -> `Assoc []
-     | Some value -> value)
-  | _ -> `Null
-;;
-
 let failure_observation ~duration_ms
     : Tool_result.result -> (Tool_result.tool_failure_class * string) option
   = function
@@ -176,7 +164,6 @@ let failure_observation ~duration_ms
 
 module For_testing = struct
   let activity_tool_called_payload = activity_tool_called_payload
-  let arguments_of_params = arguments_of_params
   let failure_observation = failure_observation
   let record_mcp_server_operation_duration = record_mcp_server_operation_duration
   let record_mcp_server_operation_duration_sample =
@@ -477,9 +464,9 @@ let record_runtime_mcp_keeper_tool_trace
        ~message)
 
 (** Resolve managed agent tool call to canonical operation *)
-let resolve_managed_agent_call ?mcp_session_id params =
-  let requested_name = Json_util.get_string params "name" |> Option.value ~default:"" in
-  let arguments = arguments_of_params params in
+let resolve_managed_agent_call ?mcp_session_id request =
+  let requested_name = Mcp_server_eio_call_request.requested_name request in
+  let arguments = Mcp_server_eio_call_request.arguments request in
   let identity =
     Client_registry_eio.get_or_create_identity ?mcp_session_id arguments
   in
@@ -490,7 +477,7 @@ let resolve_managed_agent_call ?mcp_session_id params =
 (** Handle tools/call JSON-RPC method *)
 let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     ~broadcast_tools_list_changed ~sw ~clock ?(profile = Full) ?mcp_session_id
-    ?auth_token ?(internal_keeper_runtime = false) state id params =
+    ?auth_token ?(internal_keeper_runtime = false) state id request =
   (* The active workspace is an admission fact for this call.  In particular,
      [masc_start] may publish a new current scope while executing, but the
      initiating call and every post-execution observation remain attributed to
@@ -519,18 +506,18 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
            ("handle_call_tool_eio admitted an invalid MCP invocation scope: "
             ^ Tool_invocation_ref.error_to_string error))
   in
-  let (name, arguments) =
+  let requested_name = Mcp_server_eio_call_request.requested_name request in
+  let admitted_arguments = Mcp_server_eio_call_request.arguments request in
+  let name, arguments =
     match profile with
     | Managed_agent -> (
-        match resolve_managed_agent_call ?mcp_session_id params with
+        match resolve_managed_agent_call ?mcp_session_id request with
         | Ok resolved -> resolved
         | Error msg ->
             raise
               (Invalid_argument
                  ("managed agent tool translation failed: " ^ msg)))
-    | Full | Operator_remote ->
-        (* DET-OK: pre-existing empty-name default fails typed downstream; arguments_of_params maps MCP-optional absence to a typed empty object. *)
-        (Json_util.get_string params "name" |> Option.value ~default:"", arguments_of_params params)
+    | Full | Operator_remote -> requested_name, admitted_arguments
   in
   (* Measure execution time for telemetry *)
   let start_time = Eio.Time.now clock in

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -34,8 +34,6 @@ val record_mcp_server_operation_duration_sample :
     {!Otel_dispatch_hook.with_request_context}. *)
 
 module For_testing : sig
-  val arguments_of_params : Yojson.Safe.t -> Yojson.Safe.t
-
   val failure_observation :
     duration_ms:int ->
     Tool_result.result ->
@@ -139,7 +137,7 @@ val handle_call_tool_eio :
   ?internal_keeper_runtime:bool ->
   Mcp_server.server_state ->
   Yojson.Safe.t ->
-  Yojson.Safe.t ->
+  Mcp_server_eio_call_request.t ->
   Yojson.Safe.t
 (** Handles a [tools/call] JSON-RPC request.
 

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -939,15 +939,18 @@ let handle_request
                            (max 0.0 (Eio.Time.now clock -. operation_start_time));
                        make_error_typed ~id code message)
 	                in
-	                (match req.params with
-	                 | Some params ->
-	                   let params_tool_name () =
-	                     match Json_util.get_string params "name" with
-	                     | Some name -> name
-	                     | None -> ""
-	                   in
+	                (match Mcp_server_eio_call_request.decode req.params with
+	                 | Error error ->
+	                   failed_tool_call_error
+	                     ~tool_name:
+	                       (Option.value
+	                          ~default:""
+	                          (Mcp_server_eio_call_request.error_requested_name error))
+	                     Mcp_error_code.Invalid_params
+	                     (Mcp_server_eio_call_request.error_message error)
+	                 | Ok call ->
+	                   let name = Mcp_server_eio_call_request.requested_name call in
 	                   (try
-	                      let name = params_tool_name () in
 	                      (* Issue #8699: exhaustive match on tool_profile.
 	                               Catch-all `_ -> Full` would silently elevate any
 	                               future restricted profile to full tool access
@@ -1000,7 +1003,7 @@ let handle_request
                                  ~internal_keeper_runtime
                                  state
                                  id
-                                 params)
+                                 call)
                         in
                         let outcome = tool_call_outcome result in
                         let outcome_s = Tool_result.string_of_tool_call_outcome outcome in
@@ -1021,24 +1024,14 @@ let handle_request
                              outcome_s);
                         result)
 	                    with
-	                    | Yojson.Safe.Util.Type_error (_, _) ->
-	                      failed_tool_call_error
-	                        Mcp_error_code.Invalid_params
-	                        "Invalid params: name must be a string"
 	                    | Invalid_argument msg
 		                      when String.starts_with
 		                             ~prefix:"managed agent tool translation failed:"
 		                             msg ->
-		                      let name =
-		                        try params_tool_name () with
-		                        | Yojson.Safe.Util.Type_error (_, _) -> ""
-		                      in
 		                      failed_tool_call_error
 		                        ~tool_name:name
 		                        Mcp_error_code.Invalid_params
-	                        msg)
-	                 | None ->
-	                   failed_tool_call_error Mcp_error_code.Invalid_params "Missing params")
+	                        msg))
                 in
                 with_required_auth
                   ~base_path

--- a/lib/mcp_server_eio_protocol.mli
+++ b/lib/mcp_server_eio_protocol.mli
@@ -120,7 +120,7 @@ val handle_request :
      internal_keeper_runtime:bool ->
      Mcp_server.server_state ->
      Yojson.Safe.t ->
-     Yojson.Safe.t ->
+     Mcp_server_eio_call_request.t ->
      Yojson.Safe.t) ->
   handle_read_resource_eio:
     (Mcp_server.server_state ->

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -7,6 +7,7 @@ lib/config/env_config_snapshot_core.ml
 packages/agent_core/lib/llm_provider/provider_registry_state.ml
 lib/server/server_runtime_param_request.ml
 lib/server/server_prompt_override_request.ml
+lib/mcp_server_eio_call_request.ml
 lib/schedule/schedule_domain.ml
 lib/turn_fsm/turn_fsm.ml
 lib/types/masc_domain.ml

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -98,6 +98,127 @@ let with_call_tool_state f =
       f env sw state)
 ;;
 
+let admit_call params =
+  match Masc.Mcp_server_eio_call_request.decode (Some params) with
+  | Ok request -> request
+  | Error error ->
+    fail
+      ("test supplied invalid tools/call params: "
+       ^ Masc.Mcp_server_eio_call_request.error_message error)
+;;
+
+let test_call_request_decodes_current_shape_once () =
+  let module Call = Masc.Mcp_server_eio_call_request in
+  let arguments = `Assoc [ "query", `String "status" ] in
+  (match
+     Call.decode
+       (Some
+          (`Assoc
+            [ "name", `String "masc_status"; "arguments", arguments ]))
+   with
+   | Ok request ->
+     check string "typed name" "masc_status" (Call.requested_name request);
+     check yojson "typed arguments" arguments (Call.arguments request)
+   | Error error -> fail (Call.error_message error));
+  (match Call.decode (Some (`Assoc [ "name", `String "masc_status" ])) with
+   | Ok request -> check yojson "absent arguments mean empty object" (`Assoc []) (Call.arguments request)
+   | Error error -> fail (Call.error_message error))
+;;
+
+let test_call_request_rejects_noncanonical_shapes () =
+  let module Call = Masc.Mcp_server_eio_call_request in
+  let rejected expected params =
+    match Call.decode params with
+    | Error error -> check string expected expected (Call.error_message error)
+    | Ok _ -> fail ("accepted invalid tools/call params: " ^ expected)
+  in
+  rejected "Missing params" None;
+  rejected "Invalid params: expected object" (Some (`List []));
+  rejected "Invalid params: expected object" (Some (`Tuple []));
+  rejected "Invalid params: name must be a string" (Some (`Assoc []));
+  rejected
+    "Invalid params: name must be a non-empty string"
+    (Some (`Assoc [ "name", `String "  " ]));
+  rejected
+    "Invalid params: name must not contain surrounding whitespace"
+    (Some (`Assoc [ "name", `String " masc_status" ]));
+  rejected
+    "Invalid params: arguments must be an object"
+    (Some
+       (`Assoc
+         [ "name", `String "masc_status"; "arguments", `Null ]));
+  rejected
+    "Invalid params: arguments must be an object"
+    (Some
+       (`Assoc
+         [ "name", `String "masc_status"
+         ; "arguments", `Variant ("invalid", None)
+         ]));
+  rejected
+    "Invalid params: duplicate name field"
+    (Some
+       (`Assoc
+         [ "name", `String "masc_status"; "name", `String "masc_status" ]));
+  rejected
+    "Invalid params: duplicate arguments field"
+    (Some
+       (`Assoc
+         [ "name", `String "masc_status"
+         ; "arguments", `Assoc []
+         ; "arguments", `Assoc []
+         ]))
+;;
+
+let test_invalid_call_params_do_not_reach_dispatch_handler () =
+  with_call_tool_state (fun env sw state ->
+    Auth.disable_auth (Masc.Mcp_server.workspace_config state).base_path;
+    let handler_calls = ref 0 in
+    let handle_call_tool_eio
+          ~sw:_
+          ~clock:_
+          ~profile:_
+          ?mcp_session_id:_
+          ?auth_token:_
+          ~internal_keeper_runtime:_
+          _state
+          _id
+          _request
+      =
+      incr handler_calls;
+      `Assoc []
+    in
+    let request params =
+      Yojson.Safe.to_string
+        (`Assoc
+          [ "jsonrpc", `String "2.0"
+          ; "id", `Int 1
+          ; "method", `String "tools/call"
+          ; "params", params
+          ])
+    in
+    List.iter
+      (fun params ->
+         let response =
+           Masc.Mcp_server_eio_protocol.handle_request
+             ~handle_call_tool_eio
+             ~handle_read_resource_eio:(fun _state _id _params -> `Assoc [])
+             ~clock:(Eio.Stdenv.clock env)
+             ~sw
+             state
+             (request params)
+         in
+         check
+           int
+           "wire error is Invalid_params"
+           (Masc.Mcp_error_code.to_wire_code Masc.Mcp_error_code.Invalid_params)
+           U.(response |> member "error" |> member "code" |> to_int))
+      [ `Assoc [ "name", `String "masc_status"; "arguments", `Null ]
+      ; `Assoc [ "name", `String " " ]
+      ; `Assoc [ "name", `String "masc_status"; "name", `String "masc_status" ]
+      ];
+    check int "invalid calls never reach dispatch" 0 !handler_calls)
+;;
+
 let call_with_result ?mcp_session_id ?observe_invocation ~env ~sw state result =
   Masc.Mcp_server_eio_call_tool.handle_call_tool_eio
     ~execute_tool_eio:
@@ -122,10 +243,11 @@ let call_with_result ?mcp_session_id ?observe_invocation ~env ~sw state result =
     ?mcp_session_id
     state
     (`Int 1)
-    (`Assoc
-      [ "name", `String "masc_status"
-      ; "arguments", `Assoc [ "_agent_name", `String "projection-test" ]
-      ])
+    (admit_call
+       (`Assoc
+         [ "name", `String "masc_status"
+         ; "arguments", `Assoc [ "_agent_name", `String "projection-test" ]
+         ]))
 ;;
 
 let test_threads_exact_mcp_invocation_identity () =
@@ -308,10 +430,11 @@ let test_handle_call_executes_transient_failure_once () =
           ~clock:(Eio.Stdenv.clock env)
           state
           (`Int 1)
-          (`Assoc
-            [ "name", `String "masc_status"
-            ; "arguments", `Assoc [ "_agent_name", `String "single-call-test" ]
-            ])
+          (admit_call
+             (`Assoc
+               [ "name", `String "masc_status"
+               ; "arguments", `Assoc [ "_agent_name", `String "single-call-test" ]
+               ]))
       in
       check int "transient tool invoked once" 1 !calls;
       check int
@@ -385,11 +508,12 @@ let test_call_captures_admission_scope_across_workspace_switch () =
           ~clock:(Eio.Stdenv.clock env)
           state
           (`Int 41)
-          (`Assoc
-            [ "name", `String "masc_status"
-            ; ( "arguments"
-              , `Assoc [ "_agent_name", `String "scope-admission-test" ] )
-            ])
+          (admit_call
+             (`Assoc
+               [ "name", `String "masc_status"
+               ; ( "arguments"
+                 , `Assoc [ "_agent_name", `String "scope-admission-test" ] )
+               ]))
       in
       check string "tool call succeeds" "ok"
         (result_envelope response |> U.member "status" |> U.to_string);
@@ -790,6 +914,12 @@ let () =
         [
           test_case "free-form text does not control response" `Quick
             test_free_form_failure_text_does_not_control_response;
+          test_case "call request decodes current shape once" `Quick
+            test_call_request_decodes_current_shape_once;
+          test_case "call request rejects noncanonical shapes" `Quick
+            test_call_request_rejects_noncanonical_shapes;
+          test_case "invalid call params stop before dispatch" `Quick
+            test_invalid_call_params_do_not_reach_dispatch_handler;
           test_case "typed outcome alone controls projection" `Quick
             test_typed_outcome_alone_controls_projection;
           test_case "transient failure executes once" `Quick


### PR DESCRIPTION
## Summary

- Decode tools/call params once into an abstract typed request before profile dispatch.
- Preserve recoverable admission failures as a closed error variant and render messages only at the protocol boundary.
- Reject missing, duplicate, blank, whitespace-padded, and non-object fields instead of reopening JSON with permissive defaults.
- Thread the admitted name and arguments through the call handler and remove the old repeated extraction helper.

## Verification

- ocamlformat --check on touched OCaml files
- ocamlc parsing checks on the new request module
- git diff --check
- scripts/dune-local.sh build test/test_mcp_server_eio_call_tool.exe
- scripts/dune-local.sh exec test/test_mcp_server_eio_call_tool.exe: 14/14 passed
- Invalid request matrix asserts the dispatch callback is never invoked

The full typed-tree boundary ratchet remains an exact-head CI requirement. A focused local build intentionally lacks the complete production CMT set, so the local ratchet stopped at its coverage guard rather than reporting a semantic finding.