### PR TITLE
refactor(dashboard): admit typed prompt override requests

### DIFF
--- a/lib/server/server_prompt_override_request.ml
+++ b/lib/server/server_prompt_override_request.ml
@@ -1,0 +1,114 @@
+(** Pure admission for the dashboard prompt-override request body. *)
+
+let ( let* ) = Result.bind
+
+type t =
+  | Set of
+      { key : string
+      ; value : string
+      }
+  | Clear of { key : string }
+
+type error =
+  | Invalid_json of string
+  | Expected_object
+  | Missing_key
+  | Key_must_be_string
+  | Empty_key
+  | Key_has_surrounding_whitespace
+  | Duplicate_key
+  | Missing_action
+  | Action_must_be_string
+  | Duplicate_action
+  | Unsupported_action of string
+  | Missing_value
+  | Value_must_be_string
+  | Duplicate_value
+
+type field =
+  | Absent
+  | Present of Yojson.Safe.t
+  | Duplicate
+
+let field name fields =
+  match List.filter_map (fun (key, value) -> if String.equal key name then Some value else None) fields with
+  | [] -> Absent
+  | [ value ] -> Present value
+  | _ :: _ :: _ -> Duplicate
+;;
+
+let key_of_fields fields =
+  match field "key" fields with
+  | Absent -> Error Missing_key
+  | Duplicate -> Error Duplicate_key
+  | Present (`String key) ->
+    let canonical = String.trim key in
+    if String.equal canonical ""
+    then Error Empty_key
+    else if not (String.equal canonical key)
+    then Error Key_has_surrounding_whitespace
+    else Ok key
+  | Present _ -> Error Key_must_be_string
+;;
+
+let action_of_fields fields =
+  match field "action" fields with
+  | Absent -> Error Missing_action
+  | Duplicate -> Error Duplicate_action
+  | Present (`String action) -> Ok action
+  | Present _ -> Error Action_must_be_string
+;;
+
+let value_of_fields fields =
+  match field "value" fields with
+  | Absent -> Error Missing_value
+  | Duplicate -> Error Duplicate_value
+  | Present (`String value) -> Ok value
+  | Present _ -> Error Value_must_be_string
+;;
+
+let decode_json = function
+  | `Assoc fields ->
+    let* key = key_of_fields fields in
+    let* action = action_of_fields fields in
+    (match action with
+     | "clear" -> Ok (Clear { key })
+     | "set" ->
+       let* value = value_of_fields fields in
+       Ok (Set { key; value })
+     | action -> Error (Unsupported_action action))
+  | `Null
+  | `Bool _
+  | `Int _
+  | `Intlit _
+  | `Float _
+  | `String _
+  | `List _
+  | `Tuple _
+  | `Variant _ -> Error Expected_object
+;;
+
+let decode body =
+  try decode_json (Yojson.Safe.from_string body) with
+  | Yojson.Json_error message -> Error (Invalid_json message)
+;;
+
+let key = function
+  | Set { key; _ } | Clear { key } -> key
+;;
+
+let error_message = function
+  | Invalid_json message -> "Invalid JSON: " ^ message
+  | Expected_object -> "request body must be an object"
+  | Missing_key | Empty_key -> "key is required"
+  | Key_must_be_string -> "key must be a string"
+  | Key_has_surrounding_whitespace -> "key must not contain surrounding whitespace"
+  | Duplicate_key -> "duplicate key field"
+  | Missing_action -> "action is required"
+  | Action_must_be_string -> "action must be a string"
+  | Duplicate_action -> "duplicate action field"
+  | Unsupported_action action -> Printf.sprintf "unsupported action: %s" action
+  | Missing_value -> "value is required for set"
+  | Value_must_be_string -> "value must be a string"
+  | Duplicate_value -> "duplicate value field"
+;;

--- a/lib/server/server_prompt_override_request.mli
+++ b/lib/server/server_prompt_override_request.mli
@@ -1,0 +1,17 @@
+(** Current-only typed admission for dashboard prompt-override writes. *)
+
+type t =
+  | Set of
+      { key : string
+      ; value : string
+      }
+  | Clear of { key : string }
+
+type error
+
+val decode : string -> (t, error) result
+(** Parse and validate one complete request body. Required fields must occur
+    exactly once and prompt keys must already be canonical. *)
+
+val key : t -> string
+val error_message : error -> string

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -1282,84 +1282,66 @@ let add_routes ~sw ~clock router =
        with_tool_auth ~tool_name:"masc_prompt_override"
          (fun state _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
-           try
-             let args = Yojson.Safe.from_string body_str in
-             let key = Json_util.get_string args "key"
-               |> Option.value ~default:"" in
-             let action = Json_util.get_string args "action" in
-             if key = "" then
-               respond_json_value_with_cors ~status:`Bad_request request reqd
-                 (`Assoc
-                    [ ("ok", `Bool false); ("error", `String "key is required") ])
-             else match action with
-             | None ->
-               respond_json_value_with_cors ~status:`Bad_request request reqd
-                 (`Assoc
-                    [
-                      ("ok", `Bool false);
-                      ("error", `String "action is required");
-                    ])
-             | Some action ->
-               let result = match action with
-                 | "clear" ->
-                   (match
-                      Prompt_registry.clear_prompt_override_persisted
-                        ~base_path:
-                          (Mcp_server.workspace_config state).base_path
-                        key
-                    with
-                    | Ok () -> Ok "override cleared"
-                    | Error message ->
-                        Error (`Persistence message))
-                 | "set" ->
-                   let value = Json_util.get_string args "value"
-                     |> Option.value ~default:"" in
-                   (match
-                      Prompt_registry.set_override_persisted
-                        ~base_path:
-                          (Mcp_server.workspace_config state).base_path
-                        key value
-                    with
-                    | Ok () -> Ok "override set"
-                    | Error (Prompt_registry.Validation_error message) ->
-                        Error (`Validation message)
-                    | Error (Prompt_registry.Persistence_error message) ->
-                        Error (`Persistence message))
-                 | unsupported ->
-                     Error
-                       (`Validation
-                         (Printf.sprintf "unsupported action: %s" unsupported))
-               in
-               match result with
-               | Ok msg ->
-                 respond_json_value_with_cors request reqd
-                   (`Assoc
-                      [
-                        ("ok", `Bool true);
-                        ("message", `String msg);
-                        ("key", `String key);
-                        ("source", `String (Prompt_registry.prompt_source key));
-                        ("effective", `String (Prompt_registry.get_prompt key));
-                      ])
-               | Error (`Validation msg) ->
-                 respond_json_value_with_cors ~status:`Bad_request request reqd
-                   (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
-               | Error (`Persistence msg) ->
-                 Log.Pages.error "prompt override persist failed: %s" msg;
-                 respond_json_value_with_cors ~status:`Internal_server_error
-                   request reqd
-                   (`Assoc
-                      [
-                        ("ok", `Bool false);
-                        ("error", `String "prompt override persistence failed");
-                      ])
-           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+           match Server_prompt_override_request.decode body_str with
+           | Error error ->
              respond_json_value_with_cors ~status:`Bad_request request reqd
                (`Assoc
                   [
                     ("ok", `Bool false);
-                    ("error", `String (Printexc.to_string exn));
+                    ( "error"
+                    , `String (Server_prompt_override_request.error_message error) );
                   ])
+           | Ok override_request ->
+             let key = Server_prompt_override_request.key override_request in
+             let result =
+               match override_request with
+               | Server_prompt_override_request.Clear _ ->
+                 (match
+                    Prompt_registry.clear_prompt_override_persisted
+                      ~base_path:
+                        (Mcp_server.workspace_config state).base_path
+                      key
+                  with
+                  | Ok () -> Ok "override cleared"
+                  | Error message -> Error (`Persistence message))
+               | Server_prompt_override_request.Set { value; _ } ->
+                 (match
+                    Prompt_registry.set_override_persisted
+                      ~base_path:
+                        (Mcp_server.workspace_config state).base_path
+                      key
+                      value
+                  with
+                  | Ok () -> Ok "override set"
+                  | Error (Prompt_registry.Validation_error message) ->
+                    Error (`Validation message)
+                  | Error (Prompt_registry.Persistence_error message) ->
+                    Error (`Persistence message))
+             in
+             (match result with
+              | Ok message ->
+                respond_json_value_with_cors request reqd
+                  (`Assoc
+                     [
+                       ("ok", `Bool true);
+                       ("message", `String message);
+                       ("key", `String key);
+                       ("source", `String (Prompt_registry.prompt_source key));
+                       ("effective", `String (Prompt_registry.get_prompt key));
+                     ])
+              | Error (`Validation message) ->
+                respond_json_value_with_cors ~status:`Bad_request request reqd
+                  (`Assoc [ ("ok", `Bool false); ("error", `String message) ])
+              | Error (`Persistence message) ->
+                Log.Pages.error "prompt override persist failed: %s" message;
+                respond_json_value_with_cors ~status:`Internal_server_error
+                  request
+                  reqd
+                  (`Assoc
+                     [
+                       ("ok", `Bool false);
+                       ("error", `String "prompt override persistence failed");
+                     ]))
          )
        ) request reqd)
 

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -6,6 +6,7 @@ lib/keeper_runtime/keeper_event_queue_state.ml
 lib/config/env_config_snapshot_core.ml
 packages/agent_core/lib/llm_provider/provider_registry_state.ml
 lib/server/server_runtime_param_request.ml
+lib/server/server_prompt_override_request.ml
 lib/schedule/schedule_domain.ml
 lib/turn_fsm/turn_fsm.ml
 lib/types/masc_domain.ml

--- a/test/test_server_activity_http.ml
+++ b/test/test_server_activity_http.ml
@@ -115,6 +115,84 @@ let test_count_and_limit_updated () =
   check (option int) "count updated" (Some 2) (get_int_field "count" got);
   check (option int) "limit updated" (Some 2) (get_int_field "limit" got)
 
+let prompt_request_error expected body =
+  match Server_prompt_override_request.decode body with
+  | Error error ->
+    check
+      string
+      expected
+      expected
+      (Server_prompt_override_request.error_message error)
+  | Ok _ -> fail ("accepted invalid prompt override request: " ^ body)
+;;
+
+let test_prompt_override_request_decodes_once () =
+  (match
+     Server_prompt_override_request.decode
+       {|{"action":"set","key":"keeper","value":"custom"}|}
+   with
+   | Ok (Server_prompt_override_request.Set { key; value }) ->
+     check string "set key" "keeper" key;
+     check string "set value" "custom" value
+   | Ok (Server_prompt_override_request.Clear _) -> fail "decoded set as clear"
+   | Error error -> fail (Server_prompt_override_request.error_message error));
+  (match
+     Server_prompt_override_request.decode
+       {|{"action":"clear","key":"keeper"}|}
+   with
+   | Ok (Server_prompt_override_request.Clear { key }) ->
+     check string "clear key" "keeper" key
+   | Ok (Server_prompt_override_request.Set _) -> fail "decoded clear as set"
+   | Error error -> fail (Server_prompt_override_request.error_message error));
+  match
+    Server_prompt_override_request.decode
+      {|{"action":"set","key":"keeper","value":""}|}
+  with
+  | Ok (Server_prompt_override_request.Set { value; _ }) ->
+    check string "content validation stays in prompt registry" "" value
+  | Ok (Server_prompt_override_request.Clear _) -> fail "decoded set as clear"
+  | Error error -> fail (Server_prompt_override_request.error_message error)
+;;
+
+let test_prompt_override_request_rejects_noncanonical_shapes () =
+  (match Server_prompt_override_request.decode "{" with
+   | Error _ -> ()
+   | Ok _ -> fail "accepted malformed JSON");
+  prompt_request_error "request body must be an object" "[]";
+  prompt_request_error "key is required" {|{"action":"clear"}|};
+  prompt_request_error
+    "key must be a string"
+    {|{"action":"clear","key":1}|};
+  prompt_request_error
+    "key is required"
+    {|{"action":"clear","key":" "}|};
+  prompt_request_error
+    "key must not contain surrounding whitespace"
+    {|{"action":"clear","key":" keeper"}|};
+  prompt_request_error
+    "duplicate key field"
+    {|{"action":"clear","key":"keeper","key":"keeper"}|};
+  prompt_request_error "action is required" {|{"key":"keeper"}|};
+  prompt_request_error
+    "action must be a string"
+    {|{"action":false,"key":"keeper"}|};
+  prompt_request_error
+    "duplicate action field"
+    {|{"action":"clear","action":"clear","key":"keeper"}|};
+  prompt_request_error
+    "unsupported action: reset"
+    {|{"action":"reset","key":"keeper"}|};
+  prompt_request_error
+    "value is required for set"
+    {|{"action":"set","key":"keeper"}|};
+  prompt_request_error
+    "value must be a string"
+    {|{"action":"set","key":"keeper","value":null}|};
+  prompt_request_error
+    "duplicate value field"
+    {|{"action":"set","key":"keeper","value":"a","value":"b"}|}
+;;
+
 let () =
   run "Server_activity_http"
     [ ( "slice_default_events_to_limit"
@@ -125,5 +203,11 @@ let () =
         ; test_case "missing seq fallback" `Quick test_missing_seq
         ; test_case "non-Assoc passthrough" `Quick test_non_assoc_passthrough
         ; test_case "count and limit updated" `Quick test_count_and_limit_updated
+        ] )
+    ; ( "prompt_override_request"
+      , [ test_case "decodes current request once" `Quick
+            test_prompt_override_request_decodes_once
+        ; test_case "rejects noncanonical request shapes" `Quick
+            test_prompt_override_request_rejects_noncanonical_shapes
         ] )
     ]


### PR DESCRIPTION
## Summary

- Decode the prompt override POST body once into the closed `Set | Clear` domain request before persistence.
- Reject malformed, missing, duplicate, non-string, and noncanonical fields with typed admission errors.
- Keep prompt-content validation in Prompt Registry, which still owns the atomic persist-then-memory commit.
- Remove empty-string field defaults and the catch-all exception-to-Bad_request conversion from the route.

## Verification

- `ocamlformat --check` on all touched OCaml files
- `ocamlc -stop-after parsing` on touched implementations/interfaces
- `git diff --check`
- `scripts/dune-local.sh build test/test_server_activity_http.exe`
- `scripts/dune-local.sh exec test/test_server_activity_http.exe`: 9/9 passed

The request decoder is registered in the typed pure-module ratchet. Full typed-tree coverage and the complete test suite remain exact-head CI requirements.