### PR TITLE
fix(keeper): 전이적으로 못 읽는 stimulus 가 큐 전체를 막지 않게

### DIFF
--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -465,7 +465,26 @@ let heartbeat_event_intake
      checkpoints while that exact source stays pending for continuation. *)
   let base_path = ctx.config.base_path in
   let keeper_name = meta_after_triage.name in
+  (* A stimulus whose intake fails transiently keeps its pending entry — it is
+     never acked and never dropped — but it must not hold the selection for the
+     rest of this cycle, or one unreadable entry stops every entry behind it.
+     [select_when] already scans with [first_ready_entry], so withdrawing the
+     observed failure from [ready] hands the turn to the next entry instead.
+
+     The withdrawal set grows by one entry per iteration over a finite pending
+     list, so the walk terminates on the list itself. That is why this is not a
+     retry count, a cooldown, or a cap: nothing here suppresses the failure or
+     defers it on a clock. The entry is reconsidered on the next cycle exactly
+     as before. *)
+  let withdrawn_this_cycle = ref [] in
   let select_pending_matching ready =
+    let ready (stimulus : Keeper_event_queue.stimulus) =
+      (not
+         (List.exists
+            (Keeper_event_queue.stimulus_identity_equal stimulus)
+            !withdrawn_this_cycle))
+      && ready stimulus
+    in
     Keeper_registry_event_queue.select_when_result
       ~base_path
       keeper_name
@@ -514,16 +533,22 @@ let heartbeat_event_intake
            keeper_name;
          select_pending_after_spent_reconciliation ())
   in
-  let pending_selection = select_pending_after_spent_reconciliation () in
-  let queued_observations, consumed_stimuli, pending_selection, event_queue_intake_error =
-    match pending_selection with
+  (* [first_withdrawn] keeps the first transient failure of the cycle so the
+     reported error still names the entry that was actually unavailable, even
+     when a later entry supplies the turn. *)
+  let rec intake_selection first_withdrawn =
+    match select_pending_after_spent_reconciliation () with
     | Error message ->
       Log.Keeper.error
         "turn entry: event queue selection failed keeper=%s: %s"
         keeper_name
         message;
       [], [], None, Some (Pending_selection_failed message)
-    | Ok None -> [], [], None, None
+    | Ok None ->
+      (match first_withdrawn with
+       | None -> [], [], None, None
+       | Some (selection, unavailable) ->
+         [], [], Some selection, Some (Transient_board_read unavailable))
     | Ok (Some selection) ->
       (match
          consume_single_heartbeat_stimulus
@@ -534,7 +559,22 @@ let heartbeat_event_intake
        | Stimulus_consumed observations ->
          observations, [ selection.source ], Some selection, None
        | Stimulus_retry_later unavailable ->
-         [], [], Some selection, Some (Transient_board_read unavailable))
+         withdrawn_this_cycle := selection.source :: !withdrawn_this_cycle;
+         Log.Keeper.info
+           "turn entry: withdrew transiently unavailable stimulus from this \
+            cycle keeper=%s: %s"
+           keeper_name
+           (Keeper_world_observation_board_signal.unavailable_to_string
+              unavailable);
+         let first_withdrawn =
+           match first_withdrawn with
+           | None -> Some (selection, unavailable)
+           | Some _ as kept -> kept
+         in
+         intake_selection first_withdrawn)
+  in
+  let queued_observations, consumed_stimuli, pending_selection, event_queue_intake_error =
+    intake_selection None
   in
   let consumed_stimulus_count = List.length consumed_stimuli in
   let event_queue_triggers = List.filter_map event_queue_trigger_of_stimulus consumed_stimuli in

--- a/test/test_keeper_board_unavailable.ml
+++ b/test/test_keeper_board_unavailable.ml
@@ -343,6 +343,108 @@ let test_transient_intake_retains_pending_source_and_blocks_dispatch () =
     (Keeper_event_queue.length settled)
 ;;
 
+(* (4) A transiently unavailable entry must not hold the cycle for the entries
+   behind it. The test above seeds one stimulus, so withdrawal has nothing to
+   fall through to and the blocked-dispatch contract is unchanged. This one
+   seeds two: the head read fails transiently, and the cycle must still render
+   and consume the entry behind it.
+
+   Against the pre-fix intake this fails at the first assertion — a transient
+   head returned [consumed_stimuli = []] and every entry behind it waited for
+   the head to become readable, for as long as that took. *)
+let test_transient_head_does_not_block_the_entry_behind_it () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = fresh_test_base_path () in
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  Keeper_registry.For_testing.clear ();
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_heartbeat_stimulus_intake.For_testing.force_transient_board_reads 0;
+      Keeper_registry.For_testing.clear ())
+  @@ fun () ->
+  let meta = test_meta "transient-head" in
+  let config = Workspace.default_config base_path in
+  let ctx : _ Keeper_types_profile.context =
+    { config
+    ; agent_name = "board-unavailable-test"
+    ; sw
+    ; clock = Eio.Stdenv.clock env
+    ; proc_mgr = None
+    ; net = None
+    ; publication_recovery_provider =
+        Masc_test_deps.non_runtime_publication_recovery_provider
+    }
+  in
+  ignore (Keeper_registry.For_testing.register ~base_path meta.name meta);
+  let create_source label =
+    match
+      Board_dispatch.create_post
+        ~author:"external-author"
+        ~content:label
+        ~post_kind:Board.Human_post
+        ~visibility:Board.Internal
+        ()
+    with
+    | Ok post -> Board.Post_id.to_string post.id
+    | Error error ->
+      failf "failed to create Board source: %s" (Board.show_board_error error)
+  in
+  let head_post_id = create_source "head source, read fails transiently" in
+  let trailing_post_id = create_source "trailing source, read succeeds" in
+  let seed post_id =
+    match
+      Keeper_registry_event_queue.enqueue_durable_result
+        ~base_path
+        meta.name
+        { (poison_board_signal_stimulus ()) with post_id }
+    with
+    | Ok () -> ()
+    | Error message -> failf "failed to seed durable stimulus: %s" message
+  in
+  seed head_post_id;
+  seed trailing_post_id;
+  (* Exactly one forced transient read: the head. The entry behind it reads
+     normally, so any consumption observed below came from the fall-through
+     and not from the forcing hook running out. *)
+  Keeper_heartbeat_stimulus_intake.For_testing.force_transient_board_reads 1;
+  let intake =
+    Keeper_heartbeat_stimulus_intake.heartbeat_event_intake
+      ~ctx
+      ~meta_after_triage:meta
+      ~pending_board_events:[]
+  in
+  check int "the entry behind the transient head is consumed" 1
+    intake.consumed_stimulus_count;
+  (match intake.consumed_stimuli with
+   | [ consumed ] ->
+     check string "the consumed entry is the trailing one, not the head"
+       trailing_post_id consumed.Keeper_event_queue.post_id
+   | other ->
+     failf "expected exactly one consumed stimulus, got %d" (List.length other));
+  check bool "a cycle that consumed an entry reports no intake error" true
+    (Option.is_none intake.event_queue_intake_error);
+  check
+    bool
+    "provider dispatch proceeds on the entry that could be rendered"
+    true
+    (Keeper_heartbeat_loop.should_run_turn_after_event_intake
+       ~scheduled:true
+       ~event_queue_intake_error:intake.event_queue_intake_error);
+  let queued =
+    match Keeper_registry_event_queue.snapshot_result ~base_path meta.name with
+    | Ok queue -> queue
+    | Error message -> failf "failed to reload durable queue: %s" message
+  in
+  check int "withdrawal drops nothing: both entries are still durable" 2
+    (Keeper_event_queue.length queued)
+;;
+
 let () =
   run
     "keeper_board_unavailable"
@@ -371,6 +473,10 @@ let () =
             "pending source is retained and provider dispatch is blocked"
             `Quick
             test_transient_intake_retains_pending_source_and_blocks_dispatch
+        ; test_case
+            "a transient head does not block the entry behind it"
+            `Quick
+            test_transient_head_does_not_block_the_entry_behind_it
         ] )
     ]
 ;;


### PR DESCRIPTION
전이적으로 읽히지 않는 stimulus 하나가 그 뒤의 모든 항목을 무기한 대기시킵니다. 라이브에서 실측했습니다.

## 실측 (2026-08-12, `base_path=/Users/dancer/me`)

`~/.masc/keepers/<name>/event-queue-v15.json` 을 2분 간격 10회, 18분 창:

| keeper | pending | head 전진 | 최고령 |
|---|---|---|---|
| **sangsu** | **90 고정** | 2150 → 2152 (첫 3분에만, 이후 **14분 정지**) | **8.6h** |
| analyst | 31 → 28 | 1275 → 1278 | 10.5h |
| code-reviewer | 13 | 998 → 1000 | 7h |

sangsu 는 턴을 정상 수행 중이었습니다 — 최근 execution-receipt 20건이 전부 `success`, 마지막이 측정 시점 14분 전. 그리고 지배적 유입인 `board_attention`(큐의 69%)은 **3.2시간 전에 도착이 멈췄습니다.** 유입 과다도, 키퍼 정지도 아닙니다.

analyst / code-reviewer 가 같은 창에서 정상 배출한 것이 대조군입니다 — FIFO 구조나 턴당 1건 규칙 자체의 문제가 아닙니다.

## 사슬

```
select_when = first_ready_entry ~ready          (스캔은 한다)
  ↓ stimulus_ready_for_intake 는 board_attention 에 true → 항상 머리가 뽑힌다
consume_single_heartbeat_stimulus  (RFC-0020 §3 Rule 4: 사이클당 1건)
  ├─ Stimulus_consumed     → consumed_stimuli = [x]  → 큐 전진
  └─ Stimulus_retry_later  → consumed_stimuli = []   → 선택 유지, 다음 사이클 동일
```

`Stimulus_retry_later` 는 `Board.Io_error → Transient` 에서만 나옵니다. 그 분류의 근거 주석은 이렇습니다:

> "Store/disk-level hiccup unrelated to whether the target exists; the next read is expected to succeed once the environment recovers."

가정이 성립하지 않으면 — 그리고 sangsu 에서 8.6시간 동안 성립하지 않았습니다 — 뒤의 89건이 그 한 번의 읽기에 인질로 잡힙니다.

## 수정 — 스캔을 쓰고, cap 을 쓰지 않습니다

`select_when` 이 이미 `first_ready_entry` 로 **스캔**합니다. 관측된 실패를 그 사이클의 `ready` 에서만 빼면 다음 항목이 턴을 가져갑니다.

```ocaml
let withdrawn_this_cycle = ref [] in
let select_pending_matching ready =
  let ready stimulus =
    (not (List.exists (Keeper_event_queue.stimulus_identity_equal stimulus)
            !withdrawn_this_cycle))
    && ready stimulus
  in
  ...
```

그리고 소비 지점이 재귀가 됩니다: `Stimulus_retry_later` → 그 source 를 withdraw → 재선택.

**의도적으로 하지 않은 것**:

- 재시도 횟수 · 쿨다운 · cap 없음. `software-development.md` §워크어라운드 거부 기준의 "cap/cooldown 으로 symptom 억제" 에 해당하지 않도록, 종료 근거를 **자료구조**에 둡니다 — 제외 집합이 유한한 pending 리스트 위에서 단조 증가하므로 walk 는 리스트 자체에서 끝납니다.
- ACK 도 drop 도 없음. withdraw 된 항목은 durable 에 그대로 남아 **다음 사이클에 이전과 똑같이** 재고려됩니다. 이 PR 은 무엇을 버릴지 결정하지 않습니다.
- 실패를 숨기지 않음. 첫 transient 실패는 `first_withdrawn` 으로 보존되어, 결국 아무것도 소비하지 못하면 **기존과 동일한 `Transient_board_read` 에러**로 보고됩니다. withdraw 자체는 `Log.Keeper.info` 로 남습니다.

## 테스트

기존 `test_transient_intake_retains_pending_source_and_blocks_dispatch` 는 stimulus 를 **1건만** 심습니다. withdraw 후 떨어질 곳이 없으므로 그 계약(선택 유지 + dispatch 차단)은 **변하지 않고 그대로 통과**합니다.

새 케이스 `test_transient_head_does_not_block_the_entry_behind_it` 는 2건을 심고 머리 읽기 1회만 강제 실패시킵니다:

- 뒤 항목이 소비됨 (`consumed_stimulus_count = 1`)
- 소비된 것이 **뒤 항목**임을 post_id 로 확인 (머리가 아님)
- 소비한 사이클은 intake 에러 없음 → `should_run_turn_after_event_intake = true`
- durable 큐 길이 **2 유지** (withdraw 는 아무것도 버리지 않음)

**대조군**: 수정 전 코드에 이 테스트를 걸면

```
FAIL the entry behind the transient head is consumed
   Expected: `1'    Received: `0'
```

로 실패하고 **기존 5건은 그대로 통과**합니다. 테스트가 정확히 이 결함만 겨냥한다는 증거입니다.

```
dune build --root . @test/runtest-test_keeper_board_unavailable
  6 tests run, Test Successful
```

## 이 PR 이 고치지 않는 것

- **`stimulus_ready_for_intake` 의 `Error _ -> false`** (`:365`). 승인 저장소 읽기 실패가 "아직 대기 중" 과 같은 값으로 뭉개져, 읽기가 계속 실패하면 그 `Hitl_resolved` 는 영원히 선택 후보에서 빠집니다. 같은 파일의 `reconcile_spent_selection` 은 같은 상황을 `Error _ -> Ok Selection_actionable` 로 **반대로** 처리합니다. 별개 수정이 필요합니다.
- **`reconcile_spent_selection` 의 적용 범위.** 그 주석이 위험을 정확히 기술합니다 — "the Keeper makes no progress for as long as that entry stays spent" — 그런데 실제 은퇴는 `Hitl_resolved` + `Hitl_approved` 조합 하나뿐이고 나머지 11개 payload 는 무조건 `Ok Selection_actionable` 입니다.
- **#26193 의 P1/P2** (운영자 명령 선점 · 배치 배달 · 턴 종결 시 즉시 재-admission). 이 PR 은 그 중 어느 것도 대체하지 않습니다. 한 항목이 큐를 인질로 잡는 것만 막습니다.

Refs #26193 — 2026-07-29 에 같은 배달 경제를 pending 37건에서 측정하고 "밀릴수록 느려지고, 느릴수록 더 밀리는" 양의 되먹임을 명명했습니다. 2주 뒤 같은 자리가 90건입니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
