### PR TITLE
refactor(agent-core): swap immutable provider registry snapshots

### DIFF
--- a/packages/agent_core/lib/llm_provider/dune
+++ b/packages/agent_core/lib/llm_provider/dune
@@ -16,6 +16,7 @@
   exact_output_measurement_transport
   prepared_completion_request
   http_client_phase_observer
+  provider_registry_state
   exact_output_catalog_binding
   exact_output_resolver
   exact_output_execution

--- a/packages/agent_core/lib/llm_provider/provider_registry.ml
+++ b/packages/agent_core/lib/llm_provider/provider_registry.ml
@@ -2,14 +2,14 @@
 
     @since 0.69.0 *)
 
-type provider_defaults =
+type provider_defaults = Provider_registry_state.provider_defaults =
   { kind : Provider_config.provider_kind
   ; base_url : string
   ; api_key_env : string
   ; request_path : string
   }
 
-type entry =
+type entry = Provider_registry_state.entry =
   { name : string
   ; defaults : provider_defaults
   ; max_context : int option
@@ -17,31 +17,20 @@ type entry =
   ; is_available : unit -> bool
   }
 
-type mutex =
-  | Stdlib_mu of Mutex.t
-  | Eio_mu of Eio.Mutex.t
+type t = Provider_registry_state.t Atomic.t
 
-type t =
-  { mu : mutex
-  ; entries : (string, entry) Hashtbl.t
-  }
+let create () = Atomic.make_contended Provider_registry_state.empty
 
-let create () = { mu = Eio_mu (Eio.Mutex.create ()); entries = Hashtbl.create 8 }
-let create_sync () = { mu = Stdlib_mu (Mutex.create ()); entries = Hashtbl.create 8 }
-
-let with_lock t f =
-  match t.mu with
-  | Stdlib_mu mu ->
-    Mutex.lock mu;
-    Fun.protect f ~finally:(fun () -> Mutex.unlock mu)
-  | Eio_mu mu -> Eio.Mutex.use_rw ~protect:true mu f
+let rec apply t event =
+  let current = Atomic.get t in
+  let next = Provider_registry_state.apply current event in
+  if not (Atomic.compare_and_set t current next) then apply t event
 ;;
 
-let register' t entry = Hashtbl.replace t.entries entry.name entry
-let register t entry = with_lock t (fun () -> register' t entry)
-let unregister t name = with_lock t (fun () -> Hashtbl.remove t.entries name)
-let find t name = with_lock t (fun () -> Hashtbl.find_opt t.entries name)
-let all t = with_lock t (fun () -> Hashtbl.fold (fun _k v acc -> v :: acc) t.entries [])
+let register t entry = apply t (Provider_registry_state.Register entry)
+let unregister t name = apply t (Provider_registry_state.Unregister name)
+let find t name = Provider_registry_state.find name (Atomic.get t)
+let all t = Provider_registry_state.all (Atomic.get t)
 let available t = all t |> List.filter (fun e -> e.is_available ())
 let find_capable t pred = all t |> List.filter (fun e -> pred e.capabilities)
 
@@ -97,31 +86,29 @@ let catalog_auth_available (entry : Provider_catalog.entry) =
 let catalog_entry_available = catalog_auth_available
 
 let register_catalog_entry t (entry : Provider_catalog.entry) =
-  with_lock t (fun () ->
-    let max_context =
-      match entry.max_context with
-      | Some _ as declared -> declared
-      | None -> entry.capabilities.Capabilities.max_context_tokens
-    in
-    let defaults : provider_defaults =
-      { kind = entry.kind
-      ; base_url = entry.base_url
-      ; api_key_env = entry.api_key_env
-      ; request_path = entry.request_path
+  let max_context =
+    match entry.max_context with
+    | Some _ as declared -> declared
+    | None -> entry.capabilities.Capabilities.max_context_tokens
+  in
+  let defaults : provider_defaults =
+    { kind = entry.kind
+    ; base_url = entry.base_url
+    ; api_key_env = entry.api_key_env
+    ; request_path = entry.request_path
+    }
+  in
+  if String.trim entry.id = ""
+  then invalid_arg "Provider_registry.register_catalog_entry: empty provider id"
+  else
+    register
+      t
+      { name = entry.id
+      ; defaults
+      ; max_context
+      ; capabilities = entry.capabilities
+      ; is_available = (fun () -> catalog_entry_available entry)
       }
-    in
-    if String.trim entry.id = ""
-    then invalid_arg "Provider_registry.register_catalog_entry: empty provider id"
-    else
-      Hashtbl.replace
-        t.entries
-        entry.id
-        { name = entry.id
-        ; defaults
-        ; max_context
-        ; capabilities = entry.capabilities
-        ; is_available = (fun () -> catalog_entry_available entry)
-        })
 ;;
 
 let overlay_provider_catalog t =
@@ -206,10 +193,7 @@ let discovered_endpoint_max_context (url : string) =
 ;;
 
 let default () =
-  (* The default registry uses Stdlib.Mutex because its guarded sections are
-     short Hashtbl operations and the returned value still exposes the mutable
-     registry API. *)
-  let t = create_sync () in
+  let t = create () in
   let capabilities_for_registered_label label =
     match Capabilities.capabilities_for_provider_label label with
     | Some caps -> caps

--- a/packages/agent_core/lib/llm_provider/provider_registry.mli
+++ b/packages/agent_core/lib/llm_provider/provider_registry.mli
@@ -29,15 +29,12 @@ type entry =
   ; is_available : unit -> bool
   }
 
-(** Mutable provider registry. *)
+(** Provider registry backed by atomic immutable snapshots. *)
 type t
 
-(** Create an empty registry using {!Eio.Mutex}. *)
+(** Create an empty registry. Reads observe one immutable snapshot and writes
+    atomically swap a pure state transition. *)
 val create : unit -> t
-
-(** Create an empty registry using {!Stdlib.Mutex} for synchronous tests and
-    serialization code that runs outside of an Eio scheduler. *)
-val create_sync : unit -> t
 
 (** Register a provider. Overwrites if name already exists. *)
 val register : t -> entry -> unit

--- a/packages/agent_core/lib/llm_provider/provider_registry_state.ml
+++ b/packages/agent_core/lib/llm_provider/provider_registry_state.ml
@@ -1,0 +1,34 @@
+(** Pure immutable state for the provider registry. *)
+
+module By_name = Map.Make (String)
+
+type provider_defaults =
+  { kind : Provider_config.provider_kind
+  ; base_url : string
+  ; api_key_env : string
+  ; request_path : string
+  }
+
+type entry =
+  { name : string
+  ; defaults : provider_defaults
+  ; max_context : int option
+  ; capabilities : Capabilities.capabilities
+  ; is_available : unit -> bool
+  }
+
+type event =
+  | Register of entry
+  | Unregister of string
+
+type t = entry By_name.t
+
+let empty = By_name.empty
+
+let apply state = function
+  | Register entry -> By_name.add entry.name entry state
+  | Unregister name -> By_name.remove name state
+;;
+
+let find name state = By_name.find_opt name state
+let all state = By_name.bindings state |> List.map snd

--- a/packages/agent_core/lib/llm_provider/provider_registry_state.mli
+++ b/packages/agent_core/lib/llm_provider/provider_registry_state.mli
@@ -1,0 +1,27 @@
+(** Pure immutable state transition for provider registration. *)
+
+type provider_defaults =
+  { kind : Provider_config.provider_kind
+  ; base_url : string
+  ; api_key_env : string
+  ; request_path : string
+  }
+
+type entry =
+  { name : string
+  ; defaults : provider_defaults
+  ; max_context : int option
+  ; capabilities : Capabilities.capabilities
+  ; is_available : unit -> bool
+  }
+
+type event =
+  | Register of entry
+  | Unregister of string
+
+type t
+
+val empty : t
+val apply : t -> event -> t
+val find : string -> t -> entry option
+val all : t -> entry list

--- a/packages/agent_core/test/test_provider_registry.ml
+++ b/packages/agent_core/test/test_provider_registry.ml
@@ -17,13 +17,13 @@ let with_env key value f =
 (* ── Registry CRUD ──────────────────────────────────── *)
 
 let test_empty_registry () =
-  let reg = Provider_registry.create_sync () in
+  let reg = Provider_registry.create () in
   check int "empty has 0 entries" 0 (List.length (Provider_registry.all reg));
   check (option reject) "find on empty is None" None (Provider_registry.find reg "nope")
 ;;
 
 let test_register_and_find () =
-  let reg = Provider_registry.create_sync () in
+  let reg = Provider_registry.create () in
   let entry : Provider_registry.entry =
     { name = "test-provider"
     ; defaults =
@@ -45,7 +45,7 @@ let test_register_and_find () =
 ;;
 
 let test_overwrite () =
-  let reg = Provider_registry.create_sync () in
+  let reg = Provider_registry.create () in
   let mk url : Provider_registry.entry =
     { name = "p"
     ; defaults =
@@ -68,7 +68,7 @@ let test_overwrite () =
 ;;
 
 let test_unregister () =
-  let reg = Provider_registry.create_sync () in
+  let reg = Provider_registry.create () in
   let entry : Provider_registry.entry =
     { name = "temp"
     ; defaults =
@@ -86,6 +86,36 @@ let test_unregister () =
   Provider_registry.unregister reg "temp";
   check (option reject) "gone" None (Provider_registry.find reg "temp");
   check int "0 entries" 0 (List.length (Provider_registry.all reg))
+;;
+
+let test_concurrent_register_keeps_every_snapshot_update () =
+  let reg = Provider_registry.create () in
+  let register worker index =
+    let name = Printf.sprintf "worker-%d-provider-%d" worker index in
+    let entry : Provider_registry.entry =
+      { name
+      ; defaults =
+          { kind = OpenAI_compat
+          ; base_url = "http://localhost"
+          ; api_key_env = ""
+          ; request_path = "/v1/chat/completions"
+          }
+      ; max_context = Some 128_000
+      ; capabilities = Capabilities.default_capabilities
+      ; is_available = (fun () -> true)
+      }
+    in
+    Provider_registry.register reg entry
+  in
+  let workers =
+    Array.init 4 (fun worker ->
+      Domain.spawn (fun () ->
+        for index = 0 to 49 do
+          register worker index
+        done))
+  in
+  Array.iter Domain.join workers;
+  check int "all CAS updates retained" 200 (List.length (Provider_registry.all reg))
 ;;
 
 let test_refresh_rejects_missing_endpoint_declarations () =
@@ -113,7 +143,7 @@ let test_refresh_rejects_missing_endpoint_declarations () =
 (* ── Availability ───────────────────────────────────── *)
 
 let test_available_filter () =
-  let reg = Provider_registry.create_sync () in
+  let reg = Provider_registry.create () in
   let mk name avail : Provider_registry.entry =
     { name
     ; defaults =
@@ -176,7 +206,7 @@ let test_command_in_path_misses_unknown_binary () =
 (* ── Capability queries ─────────────────────────────── *)
 
 let test_find_capable_tools () =
-  let reg = Provider_registry.create_sync () in
+  let reg = Provider_registry.create () in
   let mk name caps : Provider_registry.entry =
     { name
     ; defaults =
@@ -202,7 +232,7 @@ let test_find_capable_tools () =
 ;;
 
 let test_find_capable_composite () =
-  let reg = Provider_registry.create_sync () in
+  let reg = Provider_registry.create () in
   let mk name caps : Provider_registry.entry =
     { name
     ; defaults =
@@ -1086,6 +1116,10 @@ let () =
         ; test_case "register and find" `Quick test_register_and_find
         ; test_case "overwrite" `Quick test_overwrite
         ; test_case "unregister" `Quick test_unregister
+        ; test_case
+            "concurrent register retains every update"
+            `Quick
+            test_concurrent_register_keeps_every_snapshot_update
         ] )
     ; ( "endpoint_refresh"
       , [ test_case

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -4,6 +4,7 @@
 lib/keeper/keeper_runtime_trust_snapshot_core.ml
 lib/keeper_runtime/keeper_event_queue_state.ml
 lib/config/env_config_snapshot_core.ml
+packages/agent_core/lib/llm_provider/provider_registry_state.ml
 lib/schedule/schedule_domain.ml
 lib/turn_fsm/turn_fsm.ml
 lib/types/masc_domain.ml


### PR DESCRIPTION
## Summary

- Move provider registry CRUD into a pure immutable map transition.
- Replace mutable Hashtbl plus Eio/Stdlib mutex variants with an atomic snapshot holder and CAS retry.
- Resolve catalog entries before the atomic commit; availability callbacks continue to run after a read snapshot, outside synchronization.
- Delete the obsolete `create_sync` API and update every Provider Registry caller.
- Make registry enumeration deterministic by provider name.

## Verification

- `ocamlformat --check` and parser checks for touched OCaml files
- `git diff --check`
- `scripts/dune-local.sh build packages/agent_core/test/test_provider_registry.exe`
- `scripts/dune-local.sh exec packages/agent_core/test/test_provider_registry.exe`: 48/48 passed
- New four-domain test proves 200 concurrent registrations retain every update

The immutable state module is registered in the pure-module ratchet; full typed-tree coverage remains an exact-head CI requirement.