### PR TITLE
refactor(dashboard): move config and logs to Effect boundaries

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -120,7 +120,6 @@ const DEFAULT_PROJECT_FILES = [
 const LEGACY_VALIBOT_FILES = [
   'src/api/schemas/agent-relations.ts',
   'src/api/schemas/agent-timeline.ts',
-  'src/api/schemas/dashboard-config.ts',
   'src/api/schemas/drift-error.test.ts',
   'src/api/schemas/drift-error.ts',
   'src/api/schemas/gate-connectors.ts',
@@ -131,7 +130,6 @@ const LEGACY_VALIBOT_FILES = [
   'src/api/schemas/keeper-composite.ts',
   'src/api/schemas/keeper-transitions.ts',
   'src/api/schemas/link-previews.ts',
-  'src/api/schemas/logs.ts',
   'src/api/schemas/operator-action.ts',
   'src/api/schemas/runtime-defaults.ts',
   'src/api/schemas/runtime-resolved.ts',

--- a/dashboard/src/api/dashboard-config.test.ts
+++ b/dashboard/src/api/dashboard-config.test.ts
@@ -1,0 +1,109 @@
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import {
+  DashboardHttp,
+  DashboardTransportError,
+  type DashboardHttpService,
+} from './effect-http'
+import {
+  DashboardConfigSchemaDriftError,
+  fetchDashboardConfig,
+  parseContextThresholds,
+} from './dashboard-config'
+
+const currentWire = {
+  generated_at: '2026-08-12T00:00:00Z',
+  server: {
+    version: '0.42.0',
+    git_commit: null,
+    ocaml_version: '5.4.0',
+    uptime_seconds: 10,
+    pid: 42,
+  },
+  categories: {},
+} as const
+
+function runWithHttp<A, E>(
+  program: Effect.Effect<A, E, DashboardHttp>,
+  http: DashboardHttpService,
+): Effect.Effect<A, E> {
+  return program.pipe(Effect.provideService(DashboardHttp, http))
+}
+
+describe('fetchDashboardConfig', () => {
+  it('fetches and decodes unknown config data at the typed boundary', () => {
+    const data = Effect.runSync(runWithHttp(fetchDashboardConfig(), {
+      getUnknown: path => {
+        expect(path).toBe('/api/v1/dashboard/config')
+        return Effect.succeed(currentWire)
+      },
+    }))
+
+    expect(data.server.version).toBe('0.42.0')
+  })
+
+  it('preserves transport failures as typed values', () => {
+    const transportError = new DashboardTransportError({
+      method: 'GET',
+      path: '/api/v1/dashboard/config',
+      message: 'offline',
+      cause: new Error('offline'),
+    })
+    const error = Effect.runSync(Effect.flip(runWithHttp(
+      fetchDashboardConfig(),
+      { getUnknown: () => Effect.fail(transportError) },
+    )))
+
+    expect(error).toBe(transportError)
+  })
+
+  it('maps malformed payloads to config drift', () => {
+    const error = Effect.runSync(Effect.flip(runWithHttp(
+      fetchDashboardConfig(),
+      { getUnknown: () => Effect.succeed({ generated_at: 'now' }) },
+    )))
+
+    expect(error).toBeInstanceOf(DashboardConfigSchemaDriftError)
+  })
+})
+
+describe('parseContextThresholds', () => {
+  it('uses already-resolved config values without reopening wire nulls', () => {
+    const data = Effect.runSync(runWithHttp(fetchDashboardConfig(), {
+      getUnknown: () => Effect.succeed({
+        ...currentWire,
+        categories: {
+          dashboard: [
+            {
+              env: 'MASC_DASHBOARD_CTX_PREPARING',
+              description: 'preparing',
+              value: null,
+              default: '0.71',
+              source: 'default',
+              source_detail: 'compiled default value',
+              provenance: {
+                kind: 'default',
+                detail: 'compiled default value',
+                env: 'MASC_DASHBOARD_CTX_PREPARING',
+                raw_source: 'compiled_default',
+                raw_env_present: false,
+                raw_env_blank: false,
+                default: '0.71',
+                sensitive: false,
+                value_redacted: false,
+              },
+              sensitive: false,
+            },
+          ],
+        },
+      }),
+    }))
+
+    expect(parseContextThresholds(data, {
+      critical: 0.9,
+      warn: 0.7,
+      compacting: 0.8,
+    })).toEqual({ critical: 0.9, warn: 0.71, compacting: 0.8 })
+  })
+})

--- a/dashboard/src/api/dashboard-config.ts
+++ b/dashboard/src/api/dashboard-config.ts
@@ -1,0 +1,81 @@
+import { Effect } from 'effect'
+
+import {
+  DashboardHttp,
+  type DashboardTransportError,
+} from './effect-http'
+import {
+  decodeDashboardConfig,
+  type ConfigEntry,
+  type DashboardConfig,
+  type DashboardConfigSchemaDriftError,
+} from './schemas/dashboard-config'
+
+export type {
+  ConfigEntry,
+  ConfigEntrySource,
+  DashboardConfig,
+} from './schemas/dashboard-config'
+export {
+  decodeDashboardConfig,
+  DashboardConfigSchemaDriftError,
+} from './schemas/dashboard-config'
+
+export type DashboardConfigError =
+  | DashboardTransportError
+  | DashboardConfigSchemaDriftError
+
+const DASHBOARD_CONFIG_PATH = '/api/v1/dashboard/config'
+
+export function fetchDashboardConfig(): Effect.Effect<
+  DashboardConfig,
+  DashboardConfigError,
+  DashboardHttp
+> {
+  return Effect.gen(function*() {
+    const http = yield* DashboardHttp
+    const raw = yield* http.getUnknown(DASHBOARD_CONFIG_PATH)
+    return yield* decodeDashboardConfig(raw)
+  })
+}
+
+function configEntry(
+  data: DashboardConfig,
+  env: string,
+): ConfigEntry | undefined {
+  return data.categories.dashboard?.find(entry => entry.env === env)
+}
+
+function threshold(
+  data: DashboardConfig,
+  env: string,
+  fallback: number,
+): number {
+  const entry = configEntry(data, env)
+  if (entry === undefined) return fallback
+  const value = Number.parseFloat(entry.displayValue)
+  return Number.isFinite(value) ? value : fallback
+}
+
+export function parseContextThresholds(
+  data: DashboardConfig,
+  defaults: { critical: number; warn: number; compacting: number },
+): { critical: number; warn: number; compacting: number } {
+  return {
+    critical: threshold(
+      data,
+      'MASC_DASHBOARD_CTX_HANDOFF_IMMINENT',
+      defaults.critical,
+    ),
+    warn: threshold(
+      data,
+      'MASC_DASHBOARD_CTX_PREPARING',
+      defaults.warn,
+    ),
+    compacting: threshold(
+      data,
+      'MASC_DASHBOARD_CTX_COMPACTING',
+      defaults.compacting,
+    ),
+  }
+}

--- a/dashboard/src/api/dashboard-logs.test.ts
+++ b/dashboard/src/api/dashboard-logs.test.ts
@@ -1,0 +1,110 @@
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import {
+  DashboardHttp,
+  DashboardTransportError,
+  type DashboardHttpService,
+} from './effect-http'
+import { fetchLogs, LogsSchemaDriftError } from './dashboard-logs'
+
+const currentWire = {
+  generated_at_iso: '2026-08-12T00:00:00Z',
+  dashboard_surface: '/api/v1/dashboard/logs',
+  source: 'masc_log_ring',
+  retention: {
+    scope: 'dashboard_logs',
+    workspace_root: '/workspace/.masc',
+    buffer: 'Log.Ring',
+    capacity: 50000,
+    durable_store: '/workspace/.masc/logs/system_log_2026-08-12.jsonl',
+    file_pattern: 'system_log_YYYY-MM-DD.jsonl',
+    keep_days: 7,
+    cache_policy: 'uncached',
+  },
+  query: {
+    limit: 200,
+    level: 'INFO',
+    applied_level: 'INFO',
+    min_level: 1,
+    module: '',
+    since_seq: null,
+    before_seq: null,
+    category: null,
+    exclude_category: null,
+  },
+  returned: 0,
+  latest_seq: null,
+  oldest_seq: null,
+  latest_ts_iso: null,
+  total: 0,
+  entries: [],
+} as const
+
+function runWithHttp<A, E>(
+  program: Effect.Effect<A, E, DashboardHttp>,
+  http: DashboardHttpService,
+): Effect.Effect<A, E> {
+  return program.pipe(Effect.provideService(DashboardHttp, http))
+}
+
+describe('fetchLogs', () => {
+  it('maps the product request to the current query wire and decodes once', () => {
+    const data = Effect.runSync(runWithHttp(fetchLogs({
+      limit: 200,
+      level: 'INFO',
+      sinceSeq: 10,
+      beforeSeq: 20,
+      category: 'tool',
+      excludeCategories: ['fsm', 'routine'],
+    }), {
+      getUnknown: path => {
+        const [, query = ''] = path.split('?')
+        const params = new URLSearchParams(query)
+        expect(path.startsWith('/api/v1/dashboard/logs?')).toBe(true)
+        expect(params.get('limit')).toBe('200')
+        expect(params.get('level')).toBe('INFO')
+        expect(params.get('since_seq')).toBe('10')
+        expect(params.get('before_seq')).toBe('20')
+        expect(params.get('category')).toBe('tool')
+        expect(params.get('exclude_category')).toBe('fsm,routine')
+        return Effect.succeed(currentWire)
+      },
+    }))
+
+    expect(data.entries).toEqual([])
+  })
+
+  it('omits negative cursors instead of emitting invalid query state', () => {
+    Effect.runSync(runWithHttp(fetchLogs({ beforeSeq: -1 }), {
+      getUnknown: path => {
+        expect(path).toBe('/api/v1/dashboard/logs')
+        return Effect.succeed(currentWire)
+      },
+    }))
+  })
+
+  it('preserves transport failures as typed values', () => {
+    const transportError = new DashboardTransportError({
+      method: 'GET',
+      path: '/api/v1/dashboard/logs',
+      message: 'offline',
+      cause: new Error('offline'),
+    })
+    const error = Effect.runSync(Effect.flip(runWithHttp(
+      fetchLogs(),
+      { getUnknown: () => Effect.fail(transportError) },
+    )))
+
+    expect(error).toBe(transportError)
+  })
+
+  it('maps malformed payloads to logs drift', () => {
+    const error = Effect.runSync(Effect.flip(runWithHttp(
+      fetchLogs(),
+      { getUnknown: () => Effect.succeed({ total: 0, entries: [] }) },
+    )))
+
+    expect(error).toBeInstanceOf(LogsSchemaDriftError)
+  })
+})

--- a/dashboard/src/api/dashboard-logs.ts
+++ b/dashboard/src/api/dashboard-logs.ts
@@ -1,62 +1,59 @@
-// MASC Dashboard — System logs / dashboard config fetchers.
-// Extracted from dashboard.ts (domain split). Public symbols re-exported
-// from dashboard.ts so existing consumers (`from './api/dashboard'`) are unchanged.
+import { Effect } from 'effect'
 
-import { get } from './core'
-import { ensureDevToken } from './dev-token'
-import type { DashboardConfigResponse } from './schemas/dashboard-config'
-import type { LogsResponse } from './schemas/logs'
+import {
+  DashboardHttp,
+  type DashboardTransportError,
+} from './effect-http'
+import {
+  decodeLogsData,
+  type LogCategory,
+  type LogLevel,
+  type LogsData,
+  type LogsSchemaDriftError,
+} from './schemas/logs'
 
-export async function fetchLogs(opts?: {
-  limit?: number
-  level?: string
-  module?: string
-  since_seq?: number
-  before_seq?: number
-  category?: string
-  exclude_category?: string
-}): Promise<LogsResponse> {
+export type { LogCategory, LogEntry, LogLevel, LogsData } from './schemas/logs'
+export { decodeLogsData, LogsSchemaDriftError } from './schemas/logs'
+
+export interface LogsRequest {
+  readonly limit?: number
+  readonly level?: LogLevel
+  readonly module?: string
+  readonly sinceSeq?: number
+  readonly beforeSeq?: number
+  readonly category?: LogCategory
+  readonly excludeCategories?: readonly LogCategory[]
+}
+
+export type LogsError = DashboardTransportError | LogsSchemaDriftError
+
+function logsPath(request: LogsRequest): string {
   const params = new URLSearchParams()
-  if (opts?.limit) params.set('limit', String(opts.limit))
-  if (opts?.level) params.set('level', opts.level)
-  if (opts?.module) params.set('module', opts.module)
-  if (typeof opts?.since_seq === 'number' && opts.since_seq >= 0) {
-    params.set('since_seq', String(opts.since_seq))
+  if (request.limit !== undefined) params.set('limit', String(request.limit))
+  if (request.level !== undefined) params.set('level', request.level)
+  if (request.module !== undefined && request.module !== '') {
+    params.set('module', request.module)
   }
-  if (typeof opts?.before_seq === 'number' && opts.before_seq >= 0) {
-    params.set('before_seq', String(opts.before_seq))
+  if (request.sinceSeq !== undefined && request.sinceSeq >= 0) {
+    params.set('since_seq', String(request.sinceSeq))
   }
-  if (opts?.category) params.set('category', opts.category)
-  if (opts?.exclude_category) params.set('exclude_category', opts.exclude_category)
-  const qs = params.toString()
-  const raw = await get<unknown>(`/api/v1/dashboard/logs${qs ? `?${qs}` : ''}`)
-  const { parseLogsResponse } = await import('./schemas/logs')
-  return parseLogsResponse(raw)
+  if (request.beforeSeq !== undefined && request.beforeSeq >= 0) {
+    params.set('before_seq', String(request.beforeSeq))
+  }
+  if (request.category !== undefined) params.set('category', request.category)
+  if (request.excludeCategories !== undefined && request.excludeCategories.length > 0) {
+    params.set('exclude_category', request.excludeCategories.join(','))
+  }
+  const query = params.toString()
+  return `/api/v1/dashboard/logs${query === '' ? '' : `?${query}`}`
 }
 
-export async function fetchDashboardConfig(): Promise<DashboardConfigResponse> {
-  await ensureDevToken()
-  const raw = await get<unknown>('/api/v1/dashboard/config')
-  const { parseDashboardConfigResponse } = await import('./schemas/dashboard-config')
-  return parseDashboardConfigResponse(raw)
-}
-
-/** Parse runtime context-ratio thresholds from the dashboard config response.
-    Falls back to the compiled defaults when keys are missing or malformed. */
-export function parseContextThresholds(
-  data: DashboardConfigResponse,
-  defaults: { critical: number; warn: number; compacting: number },
-): { critical: number; warn: number; compacting: number } {
-  const cat = data.categories.dashboard ?? []
-  const find = (env: string): number | null => {
-    const entry = cat.find(e => e.env === env)
-    if (!entry || entry.value == null) return null
-    const n = parseFloat(entry.value)
-    return Number.isFinite(n) ? n : null
-  }
-  return {
-    critical: find('MASC_DASHBOARD_CTX_HANDOFF_IMMINENT') ?? defaults.critical,
-    warn: find('MASC_DASHBOARD_CTX_PREPARING') ?? defaults.warn,
-    compacting: find('MASC_DASHBOARD_CTX_COMPACTING') ?? defaults.compacting,
-  }
+export function fetchLogs(
+  request: LogsRequest = {},
+): Effect.Effect<LogsData, LogsError, DashboardHttp> {
+  return Effect.gen(function*() {
+    const http = yield* DashboardHttp
+    const raw = yield* http.getUnknown(logsPath(request))
+    return yield* decodeLogsData(raw)
+  })
 }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -11,7 +11,6 @@ vi.mock('./dev-token', () => ({
 import {
   fetchDashboardShell,
   fetchDashboardExecution,
-  fetchLogs,
   fetchDashboardExecutionTrust,
   fetchDashboardGate,
   fetchDashboardGoalDetail,
@@ -4159,53 +4158,6 @@ describe('fetchCostLatency', () => {
     expect(result.matrix.providers).toEqual(['unknown_provider'])
     expect(result.matrix.models).toEqual(['unknown_model_1', 'unknown_model_2'])
     expect(result.matrix.grid).toEqual([[0.01, 0.02]])
-  })
-})
-
-describe('fetchLogs', () => {
-  function stubLogsFetch() {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ total: 0, entries: [] }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
-    vi.stubGlobal('fetch', fetchMock)
-    return fetchMock
-  }
-
-  function requestedUrl(fetchMock: ReturnType<typeof vi.fn>): string {
-    return String(fetchMock.mock.calls[0]?.[0])
-  }
-
-  it('sets before_seq for backward "load older" paging', async () => {
-    const fetchMock = stubLogsFetch()
-
-    await fetchLogs({ limit: 200, level: 'INFO', before_seq: 4096 })
-
-    const params = new URLSearchParams(requestedUrl(fetchMock).split('?')[1] ?? '')
-    expect(params.get('before_seq')).toBe('4096')
-    expect(params.get('limit')).toBe('200')
-    expect(params.get('level')).toBe('INFO')
-  })
-
-  it('omits before_seq when negative (no cursor)', async () => {
-    const fetchMock = stubLogsFetch()
-
-    await fetchLogs({ before_seq: -1 })
-
-    const params = new URLSearchParams(requestedUrl(fetchMock).split('?')[1] ?? '')
-    expect(params.has('before_seq')).toBe(false)
-  })
-
-  it('combines before_seq and since_seq into a bounded window', async () => {
-    const fetchMock = stubLogsFetch()
-
-    await fetchLogs({ since_seq: 10, before_seq: 20 })
-
-    const params = new URLSearchParams(requestedUrl(fetchMock).split('?')[1] ?? '')
-    expect(params.get('since_seq')).toBe('10')
-    expect(params.get('before_seq')).toBe('20')
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -4,7 +4,6 @@ import {
   type AgentTimelineEvent,
   type AgentTimelineResponse,
 } from './schemas/agent-timeline'
-import { type LogEntry, type LogsResponse } from './schemas/logs'
 import {
   type RuntimeDefaultsResponse,
   type RuntimeEntry,
@@ -35,12 +34,6 @@ export type {
   GoalTreeTask,
 } from '../types'
 export { fetchDashboardGoalsTree, fetchDashboardGoalDetail } from './dashboard-goals'
-export type {
-  ConfigEntry,
-  ConfigEntryProvenance,
-  ConfigEntrySource,
-  DashboardConfigResponse,
-} from './schemas/dashboard-config'
 export { reportToolHostFailure } from './tool-host-failure'
 export { fetchDashboardBootstrap, fetchDashboardShell } from './dashboard-hot'
 export type { FusionRunStatusLabel, FusionRunRecord, DashboardFusionRunsResponse } from './dashboard-fusion'
@@ -73,9 +66,6 @@ export {
 export type { DashboardFeedRetention, DashboardFeedMetadata } from './dashboard-shared'
 export { decodeDashboardFeedMetadata } from './dashboard-shared'
 
-// --- System logs ---
-
-export type { LogEntry, LogsResponse }
 export type { RuntimeDefaultsResponse, RuntimeEntry, ModelRouting }
 export type {
   RuntimeResolvedResponse,
@@ -85,12 +75,6 @@ export type {
   ResolvedAssignmentTarget,
   RuntimeAssignment,
 }
-export {
-  fetchLogs,
-  fetchDashboardConfig,
-  parseContextThresholds,
-} from './dashboard-logs'
-
 export type { AgentTimelineEvent, AgentTimelineResponse }
 
 export { fetchAgentTimeline } from './dashboard-agent'

--- a/dashboard/src/api/schemas/dashboard-config.test.ts
+++ b/dashboard/src/api/schemas/dashboard-config.test.ts
@@ -1,57 +1,125 @@
+import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
+
 import {
   DashboardConfigSchemaDriftError,
-  parseDashboardConfigResponse,
+  decodeDashboardConfig,
 } from './dashboard-config'
 
-const validDashboardConfig = {
-  generated_at: '2026-05-12T00:00:00Z',
-  server: {
-    version: '0.19.17',
-    git_commit: null,
-    ocaml_version: '5.4.0',
-    uptime_seconds: 42,
-    pid: 12345,
-  },
-  categories: {
-    dashboard: [
-      {
-        env: 'MASC_DASHBOARD_CTX_PREPARING',
-        description: 'Warn threshold',
-        value: '0.72',
-        default: '0.70',
-        source: 'env',
-        source_detail: 'process env',
-        provenance: {
-          kind: 'runtime',
-          detail: 'derived at boot',
-          derived_from: ['MASC_DASHBOARD_CTX_PREPARING'],
+function currentWire(value: string | null = '0.72') {
+  return {
+    generated_at: '2026-05-12T00:00:00Z',
+    server: {
+      version: '0.19.17',
+      git_commit: null,
+      ocaml_version: '5.4.0',
+      uptime_seconds: 42,
+      pid: 12345,
+    },
+    categories: {
+      dashboard: [
+        {
+          env: 'MASC_DASHBOARD_CTX_PREPARING',
+          description: 'Warn threshold',
+          value,
+          default: '0.70',
+          source: 'env',
+          source_detail: 'environment variable MASC_DASHBOARD_CTX_PREPARING',
+          provenance: {
+            kind: 'env',
+            detail: 'environment variable MASC_DASHBOARD_CTX_PREPARING',
+            env: 'MASC_DASHBOARD_CTX_PREPARING',
+            raw_source: 'environment',
+            raw_env_present: true,
+            raw_env_blank: false,
+            default: '0.70',
+            sensitive: false,
+            value_redacted: false,
+          },
+          sensitive: false,
         },
-        sensitive: false,
-      },
-    ],
-  },
+      ],
+    },
+  }
 }
 
-describe('dashboard config schema', () => {
-  it('parses valid dashboard config payloads', () => {
-    const parsed = parseDashboardConfigResponse(validDashboardConfig)
+function expectDrift(value: unknown): DashboardConfigSchemaDriftError {
+  const error = Effect.runSync(Effect.flip(decodeDashboardConfig(value)))
+  expect(error).toBeInstanceOf(DashboardConfigSchemaDriftError)
+  expect(error.message).toContain('dashboard-config schema drift')
+  return error
+}
 
-    expect(parsed.server.version).toBe('0.19.17')
-    expect(parsed.categories.dashboard?.[0]?.env).toBe('MASC_DASHBOARD_CTX_PREPARING')
+describe('decodeDashboardConfig', () => {
+  it('strictly decodes current wire data into the config domain', () => {
+    const parsed = Effect.runSync(decodeDashboardConfig(currentWire()))
+    const entry = parsed.categories.dashboard?.[0]
+
+    expect(parsed.server).toEqual({
+      version: '0.19.17',
+      ocamlVersion: '5.4.0',
+      uptimeSeconds: 42,
+      pid: 12345,
+    })
+    expect(entry).toEqual({
+      env: 'MASC_DASHBOARD_CTX_PREPARING',
+      description: 'Warn threshold',
+      displayValue: '0.72',
+      defaultValue: '0.70',
+      source: 'env',
+      sourceDetail: 'environment variable MASC_DASHBOARD_CTX_PREPARING',
+      sensitive: false,
+    })
   })
 
-  it('throws typed drift errors when required server fields are missing', () => {
-    const drifted = {
-      ...validDashboardConfig,
-      server: {
-        version: '0.19.17',
-        git_commit: null,
-        ocaml_version: '5.4.0',
-        uptime_seconds: 42,
-      },
-    }
+  it('resolves a missing wire value to its product default once', () => {
+    const parsed = Effect.runSync(decodeDashboardConfig(currentWire(null)))
+    expect(parsed.categories.dashboard?.[0]?.displayValue).toBe('0.70')
+  })
 
-    expect(() => parseDashboardConfigResponse(drifted)).toThrow(DashboardConfigSchemaDriftError)
+  it.each([
+    ['missing required server field', (() => {
+      const wire = currentWire()
+      const { pid: _pid, ...server } = wire.server
+      return { ...wire, server }
+    })()],
+    ['top-level excess property', { ...currentWire(), legacy: true }],
+    ['nested excess property', (() => {
+      const wire = currentWire()
+      return {
+        ...wire,
+        categories: {
+          dashboard: [{ ...wire.categories.dashboard[0], legacy_value: 'x' }],
+        },
+      }
+    })()],
+    ['unknown source variant', (() => {
+      const wire = currentWire()
+      return {
+        ...wire,
+        categories: {
+          dashboard: [{ ...wire.categories.dashboard[0], source: 'file' }],
+        },
+      }
+    })()],
+  ])('rejects %s', (_name, value) => {
+    expectDrift(value)
+  })
+
+  it('rejects provenance that disagrees with the entry', () => {
+    const wire = currentWire()
+    const entry = wire.categories.dashboard[0]
+    if (entry === undefined) throw new Error('dashboard config fixture missing')
+    const error = expectDrift({
+      ...wire,
+      categories: {
+        dashboard: [{
+          ...entry,
+          provenance: { ...entry.provenance, default: '0.65' },
+        }],
+      },
+    })
+
+    expect(error.message).toContain('provenance.default')
   })
 })

--- a/dashboard/src/api/schemas/dashboard-config.ts
+++ b/dashboard/src/api/schemas/dashboard-config.ts
@@ -1,73 +1,202 @@
-// Dashboard config schema — schema-at-boundary for
-// `GET /api/v1/dashboard/config`.
-//
-// The config panel renders operational truth from env/default/runtime
-// provenance. Missing required fields indicate backend/frontend
-// contract drift rather than a display-only absence.
+import { Data, Effect, Option, ParseResult, Schema } from 'effect'
 
-import {
-  array,
-  boolean,
-  nullable,
-  number,
-  object,
-  optional,
-  picklist,
-  record,
-  string,
-  type BaseIssue,
-  type InferOutput,
-} from 'valibot'
+const ConfigEntrySourceSchema = Schema.Literal(
+  'env',
+  'default',
+  'derived',
+  'runtime',
+)
 
-import { SchemaDriftError, parseOrThrow } from './drift-error'
-
-const ConfigEntrySourceSchema = picklist(['env', 'default', 'derived', 'runtime'])
-
-export type ConfigEntrySource = InferOutput<typeof ConfigEntrySourceSchema>
-
-const ConfigEntryProvenanceSchema = object({
+const ConfigEntryProvenanceWireSchema = Schema.Struct({
   kind: ConfigEntrySourceSchema,
-  detail: string(),
-  derived_from: optional(array(string())),
+  detail: Schema.NonEmptyString,
+  derived_from: Schema.optional(Schema.Array(Schema.NonEmptyString)),
+  env: Schema.NonEmptyString,
+  raw_source: Schema.NonEmptyString,
+  raw_env_present: Schema.Boolean,
+  raw_env_blank: Schema.Boolean,
+  default: Schema.String,
+  sensitive: Schema.Boolean,
+  value_redacted: Schema.Boolean,
 })
 
-export type ConfigEntryProvenance = InferOutput<typeof ConfigEntryProvenanceSchema>
-
-const ConfigEntrySchema = object({
-  env: string(),
-  description: string(),
-  value: nullable(string()),
-  default: string(),
+const ConfigEntryWireSchema = Schema.Struct({
+  env: Schema.NonEmptyString,
+  description: Schema.NonEmptyString,
+  value: Schema.OptionFromNullOr(Schema.String),
+  default: Schema.String,
   source: ConfigEntrySourceSchema,
-  source_detail: optional(string()),
-  provenance: optional(ConfigEntryProvenanceSchema),
-  sensitive: boolean(),
+  source_detail: Schema.NonEmptyString,
+  provenance: ConfigEntryProvenanceWireSchema,
+  sensitive: Schema.Boolean,
 })
 
-export type ConfigEntry = InferOutput<typeof ConfigEntrySchema>
-
-const DashboardConfigServerSchema = object({
-  version: string(),
-  git_commit: nullable(string()),
-  ocaml_version: string(),
-  uptime_seconds: number(),
-  pid: number(),
+const DashboardConfigServerWireSchema = Schema.Struct({
+  version: Schema.NonEmptyString,
+  git_commit: Schema.OptionFromNullOr(Schema.NonEmptyString),
+  ocaml_version: Schema.NonEmptyString,
+  uptime_seconds: Schema.JsonNumber.pipe(Schema.nonNegative()),
+  pid: Schema.NonNegativeInt,
 })
 
-const DashboardConfigResponseSchema = object({
-  generated_at: string(),
-  server: DashboardConfigServerSchema,
-  categories: record(string(), array(ConfigEntrySchema)),
+const DashboardConfigWireSchema = Schema.Struct({
+  generated_at: Schema.NonEmptyString,
+  server: DashboardConfigServerWireSchema,
+  categories: Schema.Record({
+    key: Schema.NonEmptyString,
+    value: Schema.Array(ConfigEntryWireSchema),
+  }),
 })
 
-export type DashboardConfigResponse = InferOutput<typeof DashboardConfigResponseSchema>
+type DashboardConfigWire = Schema.Schema.Type<
+  typeof DashboardConfigWireSchema
+>
 
-export class DashboardConfigSchemaDriftError extends SchemaDriftError {
-  constructor(issues: readonly BaseIssue<unknown>[]) {
-    super('dashboard-config', issues)
+function dashboardConfigInvariantIssues(data: DashboardConfigWire) {
+  const issues: Array<{
+    readonly path: ReadonlyArray<PropertyKey>
+    readonly message: string
+  }> = []
+
+  for (const [category, entries] of Object.entries(data.categories)) {
+    for (const [index, entry] of entries.entries()) {
+      const path = ['categories', category, index] as const
+      const provenance = entry.provenance
+      if (entry.source !== provenance.kind) {
+        issues.push({
+          path: [...path, 'source'],
+          message: 'must match provenance.kind',
+        })
+      }
+      if (entry.source_detail !== provenance.detail) {
+        issues.push({
+          path: [...path, 'source_detail'],
+          message: 'must match provenance.detail',
+        })
+      }
+      if (entry.env !== provenance.env) {
+        issues.push({
+          path: [...path, 'env'],
+          message: 'must match provenance.env',
+        })
+      }
+      if (entry.default !== provenance.default) {
+        issues.push({
+          path: [...path, 'default'],
+          message: 'must match provenance.default',
+        })
+      }
+      if (entry.sensitive !== provenance.sensitive) {
+        issues.push({
+          path: [...path, 'sensitive'],
+          message: 'must match provenance.sensitive',
+        })
+      }
+      if (provenance.value_redacted && !entry.sensitive) {
+        issues.push({
+          path: [...path, 'provenance', 'value_redacted'],
+          message: 'can only be true for sensitive entries',
+        })
+      }
+    }
+  }
+
+  return issues
+}
+
+const DashboardConfigValidatedWireSchema = DashboardConfigWireSchema.pipe(
+  Schema.filter(dashboardConfigInvariantIssues),
+)
+
+export type ConfigEntrySource = Schema.Schema.Type<
+  typeof ConfigEntrySourceSchema
+>
+
+export interface ConfigEntry {
+  readonly env: string
+  readonly description: string
+  readonly displayValue: string
+  readonly defaultValue: string
+  readonly source: ConfigEntrySource
+  readonly sourceDetail: string
+  readonly sensitive: boolean
+}
+
+export interface DashboardConfig {
+  readonly server: {
+    readonly version: string
+    readonly ocamlVersion: string
+    readonly uptimeSeconds: number
+    readonly pid: number
+  }
+  readonly categories: Readonly<Record<string, readonly ConfigEntry[]>>
+}
+
+export class DashboardConfigSchemaDriftError extends Data.TaggedError(
+  'DashboardConfigSchemaDriftError',
+)<{
+  readonly domain: 'dashboard-config'
+  readonly issues: ReadonlyArray<ParseResult.ArrayFormatterIssue>
+  readonly message: string
+}> {}
+
+function schemaDriftError(
+  error: ParseResult.ParseError,
+): DashboardConfigSchemaDriftError {
+  const issues = ParseResult.ArrayFormatter.formatErrorSync(error)
+  const details = issues
+    .map(issue => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '<root>'
+      return `${path}: ${issue.message}`
+    })
+    .join('; ')
+  return new DashboardConfigSchemaDriftError({
+    domain: 'dashboard-config',
+    issues,
+    message: `dashboard-config schema drift: ${details}`,
+  })
+}
+
+function toDashboardConfig(wire: DashboardConfigWire): DashboardConfig {
+  const categories = Object.fromEntries(
+    Object.entries(wire.categories).map(([category, entries]) => [
+      category,
+      entries.map(entry => ({
+        env: entry.env,
+        description: entry.description,
+        displayValue: Option.getOrElse(entry.value, () => entry.default),
+        defaultValue: entry.default,
+        source: entry.source,
+        sourceDetail: entry.source_detail,
+        sensitive: entry.sensitive,
+      })),
+    ]),
+  )
+
+  return {
+    server: {
+      version: wire.server.version,
+      ocamlVersion: wire.server.ocaml_version,
+      uptimeSeconds: wire.server.uptime_seconds,
+      pid: wire.server.pid,
+    },
+    categories,
   }
 }
 
-export function parseDashboardConfigResponse(data: unknown): DashboardConfigResponse {
-  return parseOrThrow(DashboardConfigSchemaDriftError, DashboardConfigResponseSchema, data)
+const STRICT_PARSE_OPTIONS = {
+  errors: 'all',
+  onExcessProperty: 'error',
+} as const
+
+export function decodeDashboardConfig(
+  data: unknown,
+): Effect.Effect<DashboardConfig, DashboardConfigSchemaDriftError> {
+  return Schema.decodeUnknown(
+    DashboardConfigValidatedWireSchema,
+    STRICT_PARSE_OPTIONS,
+  )(data).pipe(
+    Effect.map(toDashboardConfig),
+    Effect.mapError(schemaDriftError),
+  )
 }

--- a/dashboard/src/api/schemas/logs.test.ts
+++ b/dashboard/src/api/schemas/logs.test.ts
@@ -1,124 +1,148 @@
+import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import {
-  LogsSchemaDriftError,
-  parseLogsResponse,
-} from './logs'
+import { decodeLogsData, LogsSchemaDriftError } from './logs'
 
-// RFC-0079: backend writes a typed encoder (see lib/masc_log/log.ml
-// Ring.entry_to_json). The legacy fallback fields raw_level /
-// normalized_level / legacy_classified are gone with the string-prefix
-// classifier that produced them. dropped_entries is gone too — silent
-// per-entry skipping is now a strict schema-drift error.
-
-function validEntry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function currentEntry(overrides: Record<string, unknown> = {}) {
   return {
     seq: 42,
     ts: '2026-04-17T00:00:00Z',
     level: 'INFO',
     source: 'structured',
     module: 'Keeper',
-    message: 'booted',
-    keeper_name: null,
+    keeper_name: 'system',
     turn_id: null,
+    message: 'booted',
     details: null,
+    category: null,
     ...overrides,
   }
 }
 
-describe('parseLogsResponse', () => {
-  it('accepts an empty response', () => {
-    const out = parseLogsResponse({ total: 0, entries: [] })
-    expect(out.total).toBe(0)
-    expect(out.entries).toHaveLength(0)
+function currentWire(entries: readonly Record<string, unknown>[] = []) {
+  const newest = entries[0]
+  const oldest = entries[entries.length - 1]
+  return {
+    generated_at_iso: '2026-05-15T01:00:00Z',
+    dashboard_surface: '/api/v1/dashboard/logs',
+    source: 'masc_log_ring',
+    retention: {
+      scope: 'dashboard_logs',
+      workspace_root: '/Users/dancer/me/.masc',
+      buffer: 'Log.Ring',
+      capacity: 50000,
+      durable_store: '/Users/dancer/me/.masc/logs/system_log_2026-05-15.jsonl',
+      file_pattern: 'system_log_YYYY-MM-DD.jsonl',
+      keep_days: 7,
+      cache_policy: 'uncached',
+    },
+    query: {
+      limit: 200,
+      level: 'INFO',
+      applied_level: 'INFO',
+      min_level: 1,
+      module: '',
+      since_seq: null,
+      before_seq: null,
+      category: null,
+      exclude_category: null,
+    },
+    returned: entries.length,
+    latest_seq: typeof newest?.seq === 'number' ? newest.seq : null,
+    oldest_seq: typeof oldest?.seq === 'number' ? oldest.seq : null,
+    latest_ts_iso: typeof newest?.ts === 'string' ? newest.ts : null,
+    total: entries.length,
+    entries,
+  }
+}
+
+function expectDrift(value: unknown): LogsSchemaDriftError {
+  const error = Effect.runSync(Effect.flip(decodeLogsData(value)))
+  expect(error).toBeInstanceOf(LogsSchemaDriftError)
+  expect(error.message).toContain('logs schema drift')
+  return error
+}
+
+describe('decodeLogsData', () => {
+  it('strictly decodes the empty current response', () => {
+    const data = Effect.runSync(decodeLogsData(currentWire()))
+
+    expect(data.total).toBe(0)
+    expect(data.entries).toEqual([])
+    expect(data.retention.scope).toBe('dashboard_logs')
   })
 
-  it('parses a populated response', () => {
-    const out = parseLogsResponse({
-      total: 2,
-      generated_at_iso: '2026-05-15T01:00:00Z',
-      dashboard_surface: '/api/v1/dashboard/logs',
-      source: 'masc_log_ring',
-      retention: {
-        scope: 'dashboard_logs',
-        workspace_root: '/Users/dancer/me/.masc',
-        buffer: 'Log.Ring',
-        capacity: 50000,
-        durable_store: '/Users/dancer/me/.masc/logs/system_log_2026-05-15.jsonl',
-        file_pattern: 'system_log_YYYY-MM-DD.jsonl',
-        keep_days: 7,
-      },
-      query: {
-        limit: 200,
-        level: 'INFO',
-        applied_level: 'INFO',
-        min_level: 1,
-        module: '',
-        since_seq: null,
-        before_seq: 42,
-      },
-      returned: 2,
-      latest_seq: 43,
-      oldest_seq: 42,
-      latest_ts_iso: '2026-04-17T00:00:00Z',
-      entries: [validEntry(), validEntry({ seq: 43, message: 'booted again' })],
+  it('maps wire absence to product values once', () => {
+    const data = Effect.runSync(
+      decodeLogsData(currentWire([currentEntry()])),
+    )
+
+    expect(data.entries[0]).toEqual({
+      seq: 42,
+      timestamp: '2026-04-17T00:00:00Z',
+      level: 'INFO',
+      source: 'structured',
+      module: 'Keeper',
+      keeperName: 'system',
+      hasTurn: false,
+      message: 'booted',
+      details: {},
+      category: 'uncategorized',
+      hasExplicitCategory: false,
     })
-    expect(out.entries).toHaveLength(2)
-    expect(out.entries[1]!.seq).toBe(43)
-    expect(out.dashboard_surface).toBe('/api/v1/dashboard/logs')
-    expect(out.source).toBe('masc_log_ring')
-    expect(out.retention?.scope).toBe('dashboard_logs')
-    expect(out.retention?.capacity).toBe(50000)
-    expect(out.query?.applied_level).toBe('INFO')
-    // before_seq is the backward "load older" cursor echoed in the query meta.
-    expect(out.query?.before_seq).toBe(42)
-    // oldest_seq is the cursor the UI passes back as before_seq to page older.
-    expect(out.oldest_seq).toBe(42)
-    expect(out.latest_seq).toBe(43)
   })
 
-  it('throws on a row missing a required field instead of silently dropping it', () => {
-    expect(() =>
-      parseLogsResponse({
-        total: 2,
-        entries: [
-          validEntry(),
-          { seq: 99, ts: '2026-04-17T00:01:00Z' /* missing message/source/module/level */ },
-        ],
+  it('keeps current closed variants and structured details', () => {
+    const data = Effect.runSync(decodeLogsData(currentWire([
+      currentEntry({
+        keeper_name: 'reviewer',
+        turn_id: 7,
+        category: 'tool',
+        details: { tool_name: 'masc_status' },
       }),
-    ).toThrow(LogsSchemaDriftError)
+    ])))
+    const entry = data.entries[0]
+
+    expect(entry?.keeperName).toBe('reviewer')
+    expect(entry?.hasTurn).toBe(true)
+    expect(entry?.category).toBe('tool')
+    expect(entry?.hasExplicitCategory).toBe(true)
+    expect(entry?.details).toEqual({ tool_name: 'masc_status' })
   })
 
-  it('rejects rows that omit level (no fallback)', () => {
-    expect(() =>
-      parseLogsResponse({
-        total: 1,
-        entries: [
-          {
-            seq: 1,
-            ts: '2026-04-17T00:00:00Z',
-            source: 'structured',
-            module: '',
-            message: 'bare entry',
-          },
-        ],
-      }),
-    ).toThrow(LogsSchemaDriftError)
+  it.each([
+    ['non-array entries', { ...currentWire(), entries: null }],
+    ['missing required envelope field', (() => {
+      const wire = currentWire()
+      const { retention: _retention, ...rest } = wire
+      return rest
+    })()],
+    ['row missing a required field', currentWire([{ seq: 1, ts: 'now' }])],
+    ['unknown level', currentWire([currentEntry({ level: 'TRACE' })])],
+    ['unknown source', currentWire([currentEntry({ source: 'sse' })])],
+    ['unknown category', currentWire([currentEntry({ category: 'provider' })])],
+    ['excess property', { ...currentWire(), dropped_entries: 1 }],
+  ])('rejects %s', (_name, value) => {
+    expectDrift(value)
   })
 
-  it('tolerates a non-array entries field by returning an empty list', () => {
-    const out = parseLogsResponse({ total: 0, entries: null })
-    expect(out.entries).toHaveLength(0)
+  it('rejects envelope counts that disagree with entries', () => {
+    const error = expectDrift({
+      ...currentWire([currentEntry()]),
+      returned: 0,
+    })
+    expect(error.message).toContain('returned')
   })
 
-  it('throws on a payload without total', () => {
-    expect(() =>
-      parseLogsResponse({ entries: [] }),
-    ).toThrow(LogsSchemaDriftError)
-  })
-
-  it('throws on non-object payload', () => {
-    expect(() => parseLogsResponse(null)).toThrow(LogsSchemaDriftError)
-    expect(() => parseLogsResponse('not-an-object')).toThrow(LogsSchemaDriftError)
+  it('rejects entries that are not newest-seq-first', () => {
+    const entries = [currentEntry({ seq: 41 }), currentEntry({ seq: 42 })]
+    const wire = currentWire(entries)
+    const error = expectDrift({
+      ...wire,
+      latest_seq: 41,
+      oldest_seq: 42,
+      latest_ts_iso: entries[0]?.ts,
+    })
+    expect(error.message).toContain('newest-seq-first')
   })
 })

--- a/dashboard/src/api/schemas/logs.ts
+++ b/dashboard/src/api/schemas/logs.ts
@@ -1,133 +1,245 @@
-// System logs schema — schema-at-boundary for
-// `GET /api/v1/dashboard/logs`.
-//
-// RFC-0079: the backend now writes the wire format through a typed
-// encoder (`lib/masc_log/log.ml` `Ring.entry_to_json`). Every row carries
-// a valid `level` / `source` string from a closed sum on the producer
-// side, so the read-side no longer fabricates fallbacks or counts
-// silently-dropped rows. Per-entry validation failure is a strict
-// schema-drift error — it surfaces the producer/consumer mismatch
-// instead of hiding it behind a `dropped_entries` counter.
-//
-// The pre-RFC-0079 fields `raw_level` / `normalized_level` /
-// `legacy_classified` are gone with the typed encoder: they only ever
-// reflected the backend's string-prefix classifier, which has been
-// removed.
+import { Data, Effect, Option, ParseResult, Schema } from 'effect'
 
-import {
-  nullable,
-  number,
-  object,
-  optional,
-  record,
-  safeParse,
-  string,
-  unknown,
-  type BaseIssue,
-  type InferOutput,
-} from 'valibot'
-import { formatIssues } from './drift-error'
+const LogLevelSchema = Schema.Literal('DEBUG', 'INFO', 'WARN', 'ERROR')
+const LogSourceSchema = Schema.Literal(
+  'structured',
+  'legacy_stderr',
+  'legacy_traceln',
+  'client_tool_host',
+)
+const LogCategorySchema = Schema.Literal(
+  'fsm',
+  'lifecycle',
+  'directive',
+  'heartbeat',
+  'presence',
+  'task',
+  'tool',
+  'memory',
+  'telemetry',
+  'routine',
+  'boundary',
+  'uncategorized',
+)
 
-const LogEntrySchema = object({
-  seq: number(),
-  ts: string(),
-  level: string(),
-  source: string(),
-  module: string(),
-  message: string(),
-  keeper_name: optional(nullable(string())),
-  turn_id: optional(nullable(number())),
-  category: optional(nullable(string())),
-  details: optional(nullable(record(string(), unknown()))),
+const LogDetailsSchema = Schema.Record({
+  key: Schema.String,
+  value: Schema.Unknown,
 })
 
-export type LogEntry = InferOutput<typeof LogEntrySchema>
-
-const LogsResponseSchema = object({
-  total: number(),
-  entries: unknown(),
-  generated_at_iso: optional(string()),
-  dashboard_surface: optional(string()),
-  source: optional(string()),
-  retention: optional(record(string(), unknown())),
-  query: optional(record(string(), unknown())),
-  returned: optional(number()),
-  latest_seq: optional(nullable(number())),
-  oldest_seq: optional(nullable(number())),
-  latest_ts_iso: optional(nullable(string())),
+const LogEntryWireSchema = Schema.Struct({
+  seq: Schema.NonNegativeInt,
+  ts: Schema.NonEmptyString,
+  level: LogLevelSchema,
+  source: LogSourceSchema,
+  module: Schema.String,
+  keeper_name: Schema.NonEmptyString,
+  turn_id: Schema.OptionFromNullOr(Schema.NonNegativeInt),
+  message: Schema.String,
+  details: Schema.OptionFromNullOr(LogDetailsSchema),
+  category: Schema.OptionFromNullOr(LogCategorySchema),
 })
 
-export interface LogsRetention {
-  scope?: string
-  workspace_root?: string
-  buffer?: string
-  capacity?: number
-  durable_store?: string
-  file_pattern?: string
-  keep_days?: number
-  cache_policy?: string
-}
+const LogsRetentionWireSchema = Schema.Struct({
+  scope: Schema.Literal('dashboard_logs'),
+  workspace_root: Schema.NonEmptyString,
+  buffer: Schema.Literal('Log.Ring'),
+  capacity: Schema.NonNegativeInt,
+  durable_store: Schema.NonEmptyString,
+  file_pattern: Schema.Literal('system_log_YYYY-MM-DD.jsonl'),
+  keep_days: Schema.NonNegativeInt,
+  cache_policy: Schema.NonEmptyString,
+})
 
-export interface LogsQuery {
-  limit?: number
-  level?: string
-  applied_level?: string
-  min_level?: number
-  module?: string
-  since_seq?: number | null
-  before_seq?: number | null
-  category?: string
-  exclude_category?: string
-}
+const LogsQueryWireSchema = Schema.Struct({
+  limit: Schema.NonNegativeInt,
+  level: Schema.String,
+  applied_level: LogLevelSchema,
+  min_level: Schema.NonNegativeInt,
+  module: Schema.String,
+  since_seq: Schema.OptionFromNullOr(Schema.NonNegativeInt),
+  before_seq: Schema.OptionFromNullOr(Schema.NonNegativeInt),
+  category: Schema.OptionFromNullOr(LogCategorySchema),
+  exclude_category: Schema.OptionFromNullOr(Schema.Array(LogCategorySchema)),
+})
 
-export interface LogsResponse {
-  total: number
-  entries: LogEntry[]
-  generated_at_iso?: string
-  dashboard_surface?: string
-  source?: string
-  retention?: LogsRetention
-  query?: LogsQuery
-  returned?: number
-  latest_seq?: number | null
-  oldest_seq?: number | null
-  latest_ts_iso?: string | null
-}
+const LogsWireSchema = Schema.Struct({
+  generated_at_iso: Schema.NonEmptyString,
+  dashboard_surface: Schema.Literal('/api/v1/dashboard/logs'),
+  source: Schema.Literal('masc_log_ring'),
+  retention: LogsRetentionWireSchema,
+  query: LogsQueryWireSchema,
+  returned: Schema.NonNegativeInt,
+  latest_seq: Schema.OptionFromNullOr(Schema.NonNegativeInt),
+  oldest_seq: Schema.OptionFromNullOr(Schema.NonNegativeInt),
+  latest_ts_iso: Schema.OptionFromNullOr(Schema.NonEmptyString),
+  total: Schema.NonNegativeInt,
+  entries: Schema.Array(LogEntryWireSchema),
+})
 
-export class LogsSchemaDriftError extends Error {
-  readonly issues: readonly BaseIssue<unknown>[]
-  constructor(issues: readonly BaseIssue<unknown>[]) {
-    super(`logs schema drift: ${formatIssues(issues)}`)
-    this.name = LogsSchemaDriftError.name
-    this.issues = issues
+type LogsWire = Schema.Schema.Type<typeof LogsWireSchema>
+type LogEntryWire = Schema.Schema.Type<typeof LogEntryWireSchema>
+
+function logsInvariantIssues(data: LogsWire) {
+  const issues: Array<{
+    readonly path: ReadonlyArray<PropertyKey>
+    readonly message: string
+  }> = []
+  const newest = data.entries[0]
+  const oldest = data.entries[data.entries.length - 1]
+  const latestSeq = Option.getOrUndefined(data.latest_seq)
+  const oldestSeq = Option.getOrUndefined(data.oldest_seq)
+  const latestTimestamp = Option.getOrUndefined(data.latest_ts_iso)
+
+  if (data.returned !== data.entries.length) {
+    issues.push({
+      path: ['returned'],
+      message: 'must equal entries.length',
+    })
   }
+  if (data.total < data.returned) {
+    issues.push({
+      path: ['total'],
+      message: 'must be greater than or equal to returned',
+    })
+  }
+  if (data.query.limit < data.returned) {
+    issues.push({
+      path: ['query', 'limit'],
+      message: 'must be greater than or equal to returned',
+    })
+  }
+  if (latestSeq !== newest?.seq) {
+    issues.push({
+      path: ['latest_seq'],
+      message: 'must equal the newest entry seq, or null when entries is empty',
+    })
+  }
+  if (oldestSeq !== oldest?.seq) {
+    issues.push({
+      path: ['oldest_seq'],
+      message: 'must equal the oldest entry seq, or null when entries is empty',
+    })
+  }
+  if (latestTimestamp !== newest?.ts) {
+    issues.push({
+      path: ['latest_ts_iso'],
+      message: 'must equal the newest entry timestamp, or null when entries is empty',
+    })
+  }
+  if (data.entries.some((entry, index) => {
+    const next = data.entries[index + 1]
+    return next !== undefined && entry.seq <= next.seq
+  })) {
+    issues.push({
+      path: ['entries'],
+      message: 'must be strictly newest-seq-first',
+    })
+  }
+
+  return issues
 }
 
-export function parseLogsResponse(data: unknown): LogsResponse {
-  const outer = safeParse(LogsResponseSchema, data, { abortEarly: true })
-  if (!outer.success) {
-    throw new LogsSchemaDriftError(outer.issues)
+const LogsValidatedWireSchema = LogsWireSchema.pipe(
+  Schema.filter(logsInvariantIssues),
+)
+
+export type LogLevel = Schema.Schema.Type<typeof LogLevelSchema>
+export type LogSource = Schema.Schema.Type<typeof LogSourceSchema>
+export type LogCategory = Schema.Schema.Type<typeof LogCategorySchema>
+
+export interface LogEntry {
+  readonly seq: number
+  readonly timestamp: string
+  readonly level: LogLevel
+  readonly source: LogSource
+  readonly module: string
+  readonly keeperName: string
+  readonly hasTurn: boolean
+  readonly message: string
+  readonly details: Readonly<Record<string, unknown>>
+  readonly category: LogCategory
+  readonly hasExplicitCategory: boolean
+}
+
+export interface LogsData {
+  readonly generatedAt: string
+  readonly source: 'masc_log_ring'
+  readonly retention: {
+    readonly scope: 'dashboard_logs'
+    readonly durableStore: string
   }
-  const rawEntries = Array.isArray(outer.output.entries) ? outer.output.entries : []
-  const entries: LogEntry[] = []
-  for (const raw of rawEntries) {
-    const parsed = safeParse(LogEntrySchema, raw, { abortEarly: true })
-    if (!parsed.success) {
-      throw new LogsSchemaDriftError(parsed.issues)
-    }
-    entries.push(parsed.output)
-  }
+  readonly total: number
+  readonly entries: readonly LogEntry[]
+}
+
+export class LogsSchemaDriftError extends Data.TaggedError(
+  'LogsSchemaDriftError',
+)<{
+  readonly domain: 'logs'
+  readonly issues: ReadonlyArray<ParseResult.ArrayFormatterIssue>
+  readonly message: string
+}> {}
+
+function schemaDriftError(error: ParseResult.ParseError): LogsSchemaDriftError {
+  const issues = ParseResult.ArrayFormatter.formatErrorSync(error)
+  const details = issues
+    .map(issue => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '<root>'
+      return `${path}: ${issue.message}`
+    })
+    .join('; ')
+  return new LogsSchemaDriftError({
+    domain: 'logs',
+    issues,
+    message: `logs schema drift: ${details}`,
+  })
+}
+
+const EMPTY_LOG_DETAILS: Readonly<Record<string, unknown>> = Object.freeze({})
+
+function toLogEntry(wire: LogEntryWire): LogEntry {
   return {
-    total: outer.output.total,
-    entries,
-    generated_at_iso: outer.output.generated_at_iso,
-    dashboard_surface: outer.output.dashboard_surface,
-    source: outer.output.source,
-    retention: outer.output.retention as LogsRetention | undefined,
-    query: outer.output.query as LogsQuery | undefined,
-    returned: outer.output.returned,
-    latest_seq: outer.output.latest_seq,
-    oldest_seq: outer.output.oldest_seq,
-    latest_ts_iso: outer.output.latest_ts_iso,
+    seq: wire.seq,
+    timestamp: wire.ts,
+    level: wire.level,
+    source: wire.source,
+    module: wire.module,
+    keeperName: wire.keeper_name,
+    hasTurn: Option.isSome(wire.turn_id),
+    message: wire.message,
+    details: Option.getOrElse(wire.details, () => EMPTY_LOG_DETAILS),
+    category: Option.getOrElse(wire.category, () => 'uncategorized' as const),
+    hasExplicitCategory: Option.isSome(wire.category),
   }
+}
+
+function toLogsData(wire: LogsWire): LogsData {
+  return {
+    generatedAt: wire.generated_at_iso,
+    source: wire.source,
+    retention: {
+      scope: wire.retention.scope,
+      durableStore: wire.retention.durable_store,
+    },
+    total: wire.total,
+    entries: wire.entries.map(toLogEntry),
+  }
+}
+
+const STRICT_PARSE_OPTIONS = {
+  errors: 'all',
+  onExcessProperty: 'error',
+} as const
+
+export function decodeLogsData(
+  data: unknown,
+): Effect.Effect<LogsData, LogsSchemaDriftError> {
+  return Schema.decodeUnknown(
+    LogsValidatedWireSchema,
+    STRICT_PARSE_OPTIONS,
+  )(data).pipe(
+    Effect.map(toLogsData),
+    Effect.mapError(schemaDriftError),
+  )
 }

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -22,7 +22,6 @@ import { initNotificationDelivery } from './notifications'
 import { refreshShell } from './store'
 import { connectDashboardWS, disconnectDashboardWS, subscribeDashboardRoute } from './dashboard-ws'
 import { ensureDevToken } from './api/dev-token'
-import { fetchDashboardConfig, parseContextThresholds } from './api/dashboard-logs'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
 import { setContextThresholds } from './config/context-thresholds'
 import { DashboardMain, DashboardHealthStrip, isKeeperDetailDashboardRoute } from './components/dashboard-shell'
@@ -174,9 +173,17 @@ export function App() {
         void refreshShell({ light: true })
         requestNamespaceTruthNow()
 
-        void fetchDashboardConfig()
-          .then(data => {
-            const thresholds = parseContextThresholds(data, {
+        void Promise.all([
+          import('./api/dashboard-config'),
+          import('./api/effect-http'),
+        ])
+          .then(([configApi, effectHttp]) =>
+            effectHttp.dashboardRuntime
+              .runPromise(configApi.fetchDashboardConfig())
+              .then(data => ({ configApi, data })),
+          )
+          .then(({ configApi, data }) => {
+            const thresholds = configApi.parseContextThresholds(data, {
               critical: CONTEXT_RATIO_CRITICAL,
               warn: CONTEXT_RATIO_WARN,
               compacting: CONTEXT_RATIO_COMPACTING,

--- a/dashboard/src/components/log-classification.ts
+++ b/dashboard/src/components/log-classification.ts
@@ -1,4 +1,4 @@
-import type { LogEntry } from '../api/dashboard.js'
+import type { LogEntry } from '../api/dashboard-logs'
 
 export type LogDisplayKind =
   | 'tool'
@@ -11,9 +11,7 @@ export type LogDisplayKind =
   | 'log'
 
 export function entryDetails(entry: LogEntry): Record<string, unknown> | null {
-  const details = entry.details
-  if (!details || typeof details !== 'object' || Array.isArray(details)) return null
-  return details
+  return entry.details
 }
 
 export function detailLabel(details: Record<string, unknown> | null, key: string): string | null {
@@ -45,8 +43,8 @@ export function logDisplayKind(entry: LogEntry): LogDisplayKind {
     case 'memory':
       return 'telemetry'
     case 'routine':
-      return entry.turn_id ? 'turn' : 'log'
+      return entry.hasTurn ? 'turn' : 'log'
     default:
-      return entry.turn_id ? 'turn' : 'log'
+      return entry.hasTurn ? 'turn' : 'log'
   }
 }

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -3,7 +3,8 @@ import { resolve } from 'node:path'
 import { h } from 'preact'
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { LogEntry } from '../api/dashboard'
+import { Effect } from 'effect'
+import type { LogEntry, LogsData } from '../api/dashboard-logs'
 import {
   deltaMergeCap,
   logDiagnosticCause,
@@ -14,15 +15,33 @@ import {
 function entry(overrides: Partial<LogEntry>): LogEntry {
   return {
     seq: 1,
-    ts: '2026-05-14T00:00:00Z',
+    timestamp: '2026-05-14T00:00:00Z',
     level: 'INFO',
     source: 'structured',
     module: 'Keeper',
     message: 'ok',
-    keeper_name: null,
-    turn_id: null,
-    details: null,
-    category: null,
+    keeperName: 'system',
+    hasTurn: false,
+    details: {},
+    category: 'uncategorized',
+    hasExplicitCategory: false,
+    ...overrides,
+  }
+}
+
+function logData(
+  entries: readonly LogEntry[],
+  overrides: Partial<LogsData> = {},
+): LogsData {
+  return {
+    generatedAt: '2026-05-15T01:00:00Z',
+    source: 'masc_log_ring',
+    retention: {
+      scope: 'dashboard_logs',
+      durableStore: '/Users/dancer/me/.masc/logs/system_log_2026-05-15.jsonl',
+    },
+    total: entries.length,
+    entries,
     ...overrides,
   }
 }
@@ -39,8 +58,14 @@ async function loadLogs(
   fetchLogs: ReturnType<typeof vi.fn>,
 ) {
   vi.resetModules()
-  vi.doMock('../api/dashboard.js', () => ({
-    fetchLogs,
+  vi.doMock('../api/dashboard-logs', () => ({
+    fetchLogs: (request: unknown) => Effect.promise(async () => {
+      const callFetchLogs = fetchLogs as (request: unknown) => unknown
+      const response = await callFetchLogs(request) as Partial<LogsData> & {
+        readonly entries: readonly LogEntry[]
+      }
+      return logData(response.entries, response)
+    }),
   }))
   return import('./logs')
 }
@@ -195,18 +220,18 @@ describe('LogViewer Code links', () => {
     vi.useRealTimers()
     vi.clearAllMocks()
     vi.resetModules()
-    vi.doUnmock('../api/dashboard.js')
+    vi.doUnmock('../api/dashboard-logs')
     window.location.hash = ''
   })
 
-  it('preserves delta rows when an older page resolves after auto-refresh', async () => {
+  it('serializes older paging before the next delta refresh', async () => {
     vi.useFakeTimers()
     const olderPage = deferred<{ total: number; entries: LogEntry[] }>()
-    const fetchLogs = vi.fn((opts?: { since_seq?: number; before_seq?: number }) => {
-      if (typeof opts?.before_seq === 'number') {
+    const fetchLogs = vi.fn((opts?: { sinceSeq?: number; beforeSeq?: number }) => {
+      if (typeof opts?.beforeSeq === 'number') {
         return olderPage.promise
       }
-      if (typeof opts?.since_seq === 'number') {
+      if (typeof opts?.sinceSeq === 'number') {
         return Promise.resolve({
           total: 3,
           entries: [entry({ seq: 11, module: 'Keeper', message: 'delta fresh' })],
@@ -233,13 +258,13 @@ describe('LogViewer Code links', () => {
       fireEvent.click(loadOlderButton!)
     })
     await waitFor(() =>
-      expect(fetchLogs).toHaveBeenCalledWith(expect.objectContaining({ before_seq: 9 })),
+      expect(fetchLogs).toHaveBeenCalledWith(expect.objectContaining({ beforeSeq: 9 })),
     )
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(3000)
     })
-    await waitFor(() => expect(container.textContent).toContain('delta fresh'))
+    expect(container.textContent).not.toContain('delta fresh')
 
     await act(async () => {
       olderPage.resolve({
@@ -249,36 +274,30 @@ describe('LogViewer Code links', () => {
       await olderPage.promise
     })
 
+    await waitFor(() => expect(container.textContent).toContain('older page'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
     await waitFor(() => {
       expect(container.textContent).toContain('delta fresh')
       expect(container.textContent).toContain('newest visible')
       expect(container.textContent).toContain('oldest visible')
       expect(container.textContent).toContain('older page')
     })
-    expect(fetchLogs).toHaveBeenCalledWith(expect.objectContaining({ since_seq: 10 }))
+    expect(fetchLogs).toHaveBeenCalledWith(expect.objectContaining({ sinceSeq: 10 }))
   })
 
   it('links safe structured log file details back to the Code IDE route', async () => {
-    const fetchLogs = vi.fn().mockResolvedValue({
-      total: 1,
-      generated_at_iso: '2026-05-15T01:00:00Z',
-      dashboard_surface: '/api/v1/dashboard/logs',
-      source: 'masc_log_ring',
-      retention: {
-        scope: 'dashboard_logs',
-        durable_store: '/Users/dancer/me/.masc/logs/system_log_2026-05-15.jsonl',
-      },
-      latest_seq: 1,
-      entries: [{
+    const fetchLogs = vi.fn().mockResolvedValue(logData([entry({
         seq: 1,
-        ts: '2026-05-14T00:00:00Z',
+        timestamp: '2026-05-14T00:00:00Z',
         level: 'INFO',
         source: 'structured',
         module: 'keeper_tool',
         message: 'read file',
         details: { file_path: 'lib/runtime.ml', line: 12 },
-      }],
-    })
+      })]))
     const { LogViewer } = await loadLogs(fetchLogs)
     const { container } = render(h(LogViewer, {}))
 
@@ -299,49 +318,43 @@ describe('LogViewer Code links', () => {
     )
   })
 
-  // RFC-0079 removed the dropped-rows surface. parseLogsResponse now
+  // RFC-0079 removed the dropped-rows surface. decodeLogsData now
   // throws LogsSchemaDriftError instead of silently dropping bad rows,
   // so there is no "parser dropped N rows" state to render here.
 
   it('renders v2 surface marker classes for CSS scoping', async () => {
-    const fetchLogs = vi.fn().mockResolvedValue({
-      total: 1,
-      entries: [{
+    const fetchLogs = vi.fn().mockResolvedValue(logData([entry({
         seq: 1,
-        ts: '2026-05-14T00:00:00Z',
+        timestamp: '2026-05-14T00:00:00Z',
         level: 'INFO',
         source: 'structured',
         module: 'keeper_tool',
         message: 'read file',
         details: { file_path: 'lib/runtime.ml', line: 12 },
-      }],
-    })
+      })]))
     const { LogViewer } = await loadLogs(fetchLogs)
     const { container } = render(h(LogViewer, {}))
 
-    await waitFor(() => expect(container.querySelector('.v2-logs-surface')).not.toBeNull())
+    await waitFor(() => expect(container.querySelector('.v2-logs-row')).not.toBeNull())
+    expect(container.querySelector('.v2-logs-surface')).not.toBeNull()
     expect(container.querySelector('.v2-logs-panel')).not.toBeNull()
     expect(container.querySelector('.v2-logs-toolbar')).not.toBeNull()
     expect(container.querySelector('[data-testid="logs-filter-tool"]')).not.toBeNull()
     expect(container.querySelector('.v2-logs-table-header')).not.toBeNull()
-    expect(container.querySelector('.v2-logs-row')).not.toBeNull()
     expect(container.querySelector('[data-testid="logs-row"]')?.getAttribute('data-log-seq')).toBe('1')
     expect(container.querySelector('.v2-logs-summary')).not.toBeNull()
   })
 
   it('does not render Code links for unsafe absolute log file paths', async () => {
-    const fetchLogs = vi.fn().mockResolvedValue({
-      total: 1,
-      entries: [{
+    const fetchLogs = vi.fn().mockResolvedValue(logData([entry({
         seq: 2,
-        ts: '2026-05-14T00:00:00Z',
+        timestamp: '2026-05-14T00:00:00Z',
         level: 'INFO',
         source: 'structured',
         module: 'keeper_tool',
         message: 'read file',
         details: { file_path: '/tmp/runtime.ml', line: 12 },
-      }],
-    })
+      })]))
     const { LogViewer } = await loadLogs(fetchLogs)
     const { container } = render(h(LogViewer, {}))
 
@@ -350,11 +363,9 @@ describe('LogViewer Code links', () => {
   })
 
   it('links nested log evidence into operational IDE routes', async () => {
-    const fetchLogs = vi.fn().mockResolvedValue({
-      total: 1,
-      entries: [{
+    const fetchLogs = vi.fn().mockResolvedValue(logData([entry({
         seq: 3,
-        ts: '2026-05-14T00:00:00Z',
+        timestamp: '2026-05-14T00:00:00Z',
         level: 'WARN',
         source: 'structured',
         module: 'keeper_tool',
@@ -379,8 +390,7 @@ describe('LogViewer Code links', () => {
             },
           },
         },
-      }],
-    })
+      })]))
     const { LogViewer } = await loadLogs(fetchLogs)
     const { container } = render(h(LogViewer, {}))
 
@@ -405,23 +415,14 @@ describe('LogViewer Code links', () => {
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-nested&operation_id=op-nested&worker_run_id=wr-nested&q=turn-8')
   })
   it('filters rows by kind chips and keeps kind-aware details for toolbar view', async () => {
-    const fetchLogs = vi.fn().mockResolvedValue({
-      total: 3,
-      generated_at_iso: '2026-05-15T01:00:00Z',
-      dashboard_surface: '/api/v1/dashboard/logs',
-      source: 'masc_log_ring',
-      retention: {
-        scope: 'dashboard_logs',
-        durable_store: '/Users/dancer/me/.masc/logs/system_log_2026-05-15.jsonl',
-      },
-      latest_seq: 3,
-      entries: [
+    const fetchLogs = vi.fn().mockResolvedValue(logData([
         entry({
           seq: 1,
-          ts: '2026-05-14T00:00:00Z',
+          timestamp: '2026-05-14T00:00:00Z',
           level: 'INFO',
           module: 'keeper_tool',
           category: 'tool',
+          hasExplicitCategory: true,
           message: 'tool event',
           details: {
             tool_name: 'fs.ls',
@@ -432,11 +433,12 @@ describe('LogViewer Code links', () => {
         }),
         entry({
           seq: 2,
-          ts: '2026-05-14T00:00:01Z',
+          timestamp: '2026-05-14T00:00:01Z',
           level: 'INFO',
           module: 'keeper_turn',
           category: 'routine',
-          turn_id: 2,
+          hasExplicitCategory: true,
+          hasTurn: true,
           message: 'turn event',
           details: {
             model: 'gpt-4o-mini',
@@ -447,10 +449,11 @@ describe('LogViewer Code links', () => {
         }),
         entry({
           seq: 3,
-          ts: '2026-05-14T00:00:02Z',
+          timestamp: '2026-05-14T00:00:02Z',
           level: 'WARN',
           module: 'keeper_fsm',
           category: 'fsm',
+          hasExplicitCategory: true,
           message: 'lifecycle event',
           details: {
             from: 'idle',
@@ -458,8 +461,7 @@ describe('LogViewer Code links', () => {
             trigger: 'wake',
           },
         }),
-      ],
-    })
+      ]))
 
     const { LogViewer } = await loadLogs(fetchLogs)
     const { container } = render(h(LogViewer, {}))
@@ -522,14 +524,12 @@ describe('LogViewer kind column', () => {
     vi.useRealTimers()
     vi.clearAllMocks()
     vi.resetModules()
-    vi.doUnmock('../api/dashboard.js')
+    vi.doUnmock('../api/dashboard-logs')
     window.location.hash = ''
   })
 
   it('renders the logs surface with the kind column header and a kind cell per row', async () => {
-    const fetchLogs = vi.fn().mockResolvedValue({
-      total: 1,
-      entries: [
+    const fetchLogs = vi.fn().mockResolvedValue(logData([
         entry({
           seq: 42,
           level: 'INFO',
@@ -537,10 +537,10 @@ describe('LogViewer kind column', () => {
           module: 'keeper_tool',
           message: 'read file',
           category: 'tool',
+          hasExplicitCategory: true,
           details: { tool_name: 'tool_read_file', file_path: 'lib/runtime.ml' },
         }),
-      ],
-    })
+      ]))
     const { LogViewer } = await loadLogs(fetchLogs)
     const { container } = render(h(LogViewer, {}))
 

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -3,8 +3,17 @@ import type { VNode } from 'preact'
 import { signal } from '@preact/signals'
 import { useEffect, useMemo } from 'preact/hooks'
 import { ChevronDown, ChevronRight, RefreshCw } from 'lucide-preact'
-import { fetchLogs } from '../api/dashboard.js'
-import type { LogEntry } from '../api/dashboard.js'
+import { Effect, Option } from 'effect'
+import {
+  fetchLogs,
+  type LogCategory,
+  type LogEntry,
+  type LogLevel,
+  type LogsData,
+  type LogsError,
+  type LogsRequest,
+} from '../api/dashboard-logs'
+import { dashboardRuntime, type DashboardHttp } from '../api/effect-http'
 import { VirtualList } from './common/virtual-list'
 import { asRecord, asNullableString, mergeRouteRecord, hasRouteContext, type MutableRouteContext } from './common/normalize'
 import { TextInput } from './common/input'
@@ -13,7 +22,8 @@ import { Checkbox } from './common/checkbox'
 import { LogFilter } from './common/log-filter'
 import { RouteLink } from './common/route-link'
 import { KeeperBadge } from './keeper-badge'
-import { createAsyncResource, loaded } from '../lib/async-state'
+import { createEffectResource } from '../lib/effect-resource'
+import { remotePrevious } from '../lib/remote-data'
 import { toolCategory } from './tool-call-shared'
 import { StatusChip } from './common/status-chip'
 import {
@@ -27,9 +37,10 @@ import {
   routeLinksForContext,
   type IdeContextRouteLink,
 } from './ide/ide-context-lens'
-import type { LogsResponse } from '../api/schemas/logs'
-
-type LogData = LogsResponse
+interface LogData extends LogsData {
+  readonly pagedOlder: boolean
+  readonly noMoreOlder: boolean
+}
 
 export interface LogCauseCount {
   cause: string
@@ -49,15 +60,16 @@ export interface LogWindowSummary {
   topModules: LogModuleCount[]
 }
 
-const logResource = createAsyncResource<LogData>()
-const levelFilter = signal('INFO')
+const logResource = createEffectResource<DashboardHttp, LogsError, LogData>(
+  dashboardRuntime,
+)
+const levelFilter = signal<LogLevel>('INFO')
 const moduleInput = signal('')
 const appliedModuleFilter = signal('')
 const autoRefresh = signal(true)
 const DEFAULT_LOG_LIMIT = 200
 const logLimit = signal(DEFAULT_LOG_LIMIT)
-const latestSeq = signal<number | null>(null)
-const categoryFilter = signal('')
+const categoryFilter = signal<LogCategory | ''>('')
 // Client-side display-kind filter for the primary toolbar chips
 // (전체/Tool/Turn/Lifecycle/Approval/Broadcast). Complementary to the
 // backend categoryFilter above: kind slices the streamed rows in the view
@@ -72,17 +84,12 @@ const expandedLogSeq = signal<number | null>(null)
 // window (bounded memory, steady state), and once true the cap grows to cover
 // every shown row plus genuinely-new rows so neither path evicts history the
 // operator paged into.
-const pagedOlder = signal(false)
-const olderLoading = signal(false)
-const noMoreOlder = signal(false)
 
 const POLL_INTERVAL_MS = 3000
 const ESTIMATED_LOG_ROW_HEIGHT = 78
-const EMPTY_LOG_ENTRIES: LogEntry[] = []
+const EMPTY_LOG_ENTRIES: readonly LogEntry[] = []
 
 let moduleDebounceTimer: ReturnType<typeof setTimeout> | null = null
-let latestRequestId = 0
-let logQueryGeneration = 0
 
 function MetaTag({ children }: { children: unknown }) {
   return html`<${StatusChip} tone="neutral" uppercase=${false}>${children}</${StatusChip}>`
@@ -95,15 +102,14 @@ const LEVEL_COLORS: Record<string, string> = {
   ERROR: 'var(--color-status-err)',
 }
 
-const SOURCE_LABELS: Record<string, string> = {
+const SOURCE_LABELS: Record<LogEntry['source'], string> = {
   structured: 'structured',
   legacy_stderr: 'stderr',
   legacy_traceln: 'trace line',
   client_tool_host: 'client tool-host',
-  sse: 'sse',
 }
 
-const CATEGORY_LABELS: Record<string, string> = {
+const CATEGORY_LABELS: Record<LogCategory, string> = {
   fsm: 'FSM',
   lifecycle: 'Lifecycle',
   directive: 'Directive',
@@ -128,7 +134,16 @@ const LOG_KIND_FILTERS: readonly { value: LogDisplayKind | ''; label: string }[]
 ]
 // Backend log category, surfaced in the advanced (details) menu while the
 // primary toolbar uses the client-side display-kind chips above.
-const LOG_CATEGORY_OPTIONS: readonly { value: string; label: string }[] = [
+const LOG_LEVELS: readonly LogLevel[] = ['DEBUG', 'INFO', 'WARN', 'ERROR']
+
+function isLogLevel(value: string): value is LogLevel {
+  return LOG_LEVELS.some(level => level === value)
+}
+
+const LOG_CATEGORY_OPTIONS: readonly {
+  value: LogCategory | ''
+  label: string
+}[] = [
   { value: '', label: '전체 카테고리' },
   { value: 'tool', label: 'tool' },
   { value: 'task', label: 'task' },
@@ -137,9 +152,8 @@ const LOG_CATEGORY_OPTIONS: readonly { value: string; label: string }[] = [
   { value: 'telemetry', label: 'telemetry' },
 ]
 
-function categoryLabel(category: string | null | undefined): string | null {
-  if (!category) return null
-  return CATEGORY_LABELS[category] ?? category
+function categoryLabel(category: LogCategory): string {
+  return CATEGORY_LABELS[category]
 }
 
 const LOG_KIND_LABELS: Record<LogDisplayKind, string> = {
@@ -153,7 +167,7 @@ const LOG_KIND_LABELS: Record<LogDisplayKind, string> = {
   log: 'LOG',
 }
 
-type LoadMode = 'reset' | 'delta'
+type LoadMode = 'reset' | 'delta' | 'older'
 type FailureEnvelope = {
   surface: string
   entity_kind: string
@@ -167,24 +181,24 @@ type FailureEnvelope = {
 }
 
 function normalizedLevel(entry: LogEntry): string {
-  // RFC-0079: backend now emits a typed level via Log.Ring.entry_to_json.
-  // The schema rejects rows without `level`, so the read-side fallback
-  // chain (`normalized_level || level || 'INFO'`) is gone.
-  return entry.level.toUpperCase()
+  return entry.level
 }
 
-function sortLogEntries(entries: LogEntry[]): LogEntry[] {
+function sortLogEntries(entries: readonly LogEntry[]): LogEntry[] {
   return [...entries].sort((a, b) => b.seq - a.seq)
 }
 
-function latestLogSeq(entries: LogEntry[]): number | null {
-  if (entries.length === 0) return null
-  return entries.reduce((max, entry) => Math.max(max, entry.seq), entries[0]?.seq ?? 0)
+function latestLogSeq(entries: readonly LogEntry[]): Option.Option<number> {
+  const first = entries[0]
+  if (first === undefined) return Option.none()
+  return Option.some(
+    entries.reduce((max, entry) => Math.max(max, entry.seq), first.seq),
+  )
 }
 
 export function mergeLogEntries(
-  current: LogEntry[],
-  incoming: LogEntry[],
+  current: readonly LogEntry[],
+  incoming: readonly LogEntry[],
   maxEntries: number,
 ): LogEntry[] {
   const merged = new Map<number, LogEntry>()
@@ -216,8 +230,8 @@ export function deltaMergeCap(
   return current.length + freshCount
 }
 
-function sourceLabel(source: string): string {
-  return SOURCE_LABELS[source] ?? (source || '(unknown source)')
+function sourceLabel(source: LogEntry['source']): string {
+  return SOURCE_LABELS[source]
 }
 
 function logSeverity(entry: LogEntry): 'ok' | 'warn' | 'bad' | 'busy' | 'info' {
@@ -231,13 +245,13 @@ function logSeverity(entry: LogEntry): 'ok' | 'warn' | 'bad' | 'busy' | 'info' {
 }
 
 function keeperLabel(entry: LogEntry, details: Record<string, unknown> | null): string {
-  const keeper = entry.keeper_name?.trim()
-  if (keeper) return keeper
+  const keeper = entry.keeperName
+  if (keeper !== 'system') return keeper
   const clientName = detailLabel(details, 'client_name')
   if (clientName) return clientName
-  const moduleName = entry.module?.trim()
+  const moduleName = entry.module.trim()
   if (moduleName) return moduleName
-  return '(root)'
+  return 'system'
 }
 
 function formatLogClock(ts: string): string {
@@ -256,7 +270,7 @@ function formatLogClock(ts: string): string {
 }
 
 function logTimestampMs(entry: LogEntry): number | null {
-  const ms = Date.parse(entry.ts)
+  const ms = Date.parse(entry.timestamp)
   return Number.isFinite(ms) ? ms : null
 }
 
@@ -360,7 +374,9 @@ function topCounts(map: Map<string, number>, limit = 3): LogCauseCount[] {
     .slice(0, limit)
 }
 
-export function summarizeLogWindow(entries: LogEntry[]): LogWindowSummary {
+export function summarizeLogWindow(
+  entries: readonly LogEntry[],
+): LogWindowSummary {
   const causes = new Map<string, number>()
   const modules = new Map<string, number>()
   let errors = 0
@@ -427,7 +443,7 @@ function renderLogMessage(entry: LogEntry): string {
   return failure ? `${message} (${failure.summary})` : message
 }
 
-function sourceTone(source: string): string {
+function sourceTone(source: LogEntry['source']): string {
   switch (source) {
     case 'client_tool_host':
       return 'text-[var(--color-accent-fg)] bg-[var(--accent-10)] border-[var(--accent-22)]'
@@ -440,117 +456,104 @@ function sourceTone(source: string): string {
   }
 }
 
-async function loadLogs(mode: LoadMode = 'reset') {
-  const requestId = ++latestRequestId
-
-  if (mode === 'reset') {
-    logQueryGeneration += 1
-    pagedOlder.value = false
-    noMoreOlder.value = false
-    return logResource.load(async () => {
-      const resp = await fetchLogs({
-        limit: logLimit.value,
-        level: levelFilter.value,
-        module: appliedModuleFilter.value || undefined,
-        category: categoryFilter.value || undefined,
-        exclude_category: hideFsmTransitions.value ? 'fsm' : undefined,
-      })
-      const entries = sortLogEntries(resp.entries).slice(0, Math.max(1, logLimit.value))
-      latestSeq.value = latestLogSeq(entries)
-      return {
-        ...resp,
-        entries,
-        total: resp.total,
-      }
-    })
-  }
-
-  // delta mode — update existing loaded data
-  try {
-    const resp = await fetchLogs({
-      limit: logLimit.value,
-      level: levelFilter.value,
-      module: appliedModuleFilter.value || undefined,
-      since_seq: latestSeq.value ?? undefined,
-      category: categoryFilter.value || undefined,
-      exclude_category: hideFsmTransitions.value ? 'fsm' : undefined,
-    })
-    if (requestId !== latestRequestId) return
-
-    const s = logResource.state.value
-    const currentEntries = s.status === 'loaded' ? s.data.entries : []
-    const incoming = sortLogEntries(resp.entries)
-    const cap = deltaMergeCap(currentEntries, incoming, pagedOlder.value, logLimit.value)
-    const nextEntries = mergeLogEntries(currentEntries, incoming, cap)
-
-    latestSeq.value = latestLogSeq(nextEntries)
-    logResource.state.value = loaded({
-      ...resp,
-      entries: nextEntries,
-      total: resp.total,
-    })
-  } catch {
-    if (requestId !== latestRequestId) return
-    // Delta failures don't overwrite loaded state — keep existing data visible
+function baseLogsRequest(): LogsRequest {
+  return {
+    limit: logLimit.value,
+    level: levelFilter.value,
+    module: appliedModuleFilter.value || undefined,
+    category: categoryFilter.value || undefined,
+    excludeCategories: hideFsmTransitions.value ? ['fsm'] : undefined,
   }
 }
 
-function oldestLogSeq(entries: readonly LogEntry[]): number | null {
-  if (entries.length === 0) return null
-  return entries.reduce((min, entry) => Math.min(min, entry.seq), entries[0]?.seq ?? 0)
+function oldestLogSeq(entries: readonly LogEntry[]): Option.Option<number> {
+  const first = entries[0]
+  if (first === undefined) return Option.none()
+  return Option.some(
+    entries.reduce((min, entry) => Math.min(min, entry.seq), first.seq),
+  )
 }
 
-// "load older" backward paging: fetch entries strictly older than the smallest
-// seq currently shown and append them. The merge cap here covers current + newly
-// loaded rows so this merge keeps them, and [pagedOlder] then makes the delta
-// poller grow its cap so it does not trim them on the next poll.
-export async function loadOlder() {
-  const s = logResource.state.value
-  if (s.status !== 'loaded') return
-  const currentEntries = s.data.entries
-  const oldest = oldestLogSeq(currentEntries)
-  if (oldest === null || oldest <= 0) {
-    noMoreOlder.value = true
-    return
+function resetLogData(response: LogsData): LogData {
+  return {
+    ...response,
+    entries: sortLogEntries(response.entries).slice(
+      0,
+      Math.max(1, logLimit.value),
+    ),
+    pagedOlder: false,
+    noMoreOlder: false,
   }
-  if (olderLoading.value) return
-  const startedGeneration = logQueryGeneration
-  olderLoading.value = true
-  try {
-    const resp = await fetchLogs({
-      limit: logLimit.value,
-      level: levelFilter.value,
-      module: appliedModuleFilter.value || undefined,
-      before_seq: oldest,
-      category: categoryFilter.value || undefined,
-      exclude_category: hideFsmTransitions.value ? 'fsm' : undefined,
-    })
-    if (startedGeneration !== logQueryGeneration) return
-    const incoming = sortLogEntries(resp.entries)
-    if (incoming.length === 0) {
-      noMoreOlder.value = true
-      return
+}
+
+function mergeDeltaLogData(current: LogData, response: LogsData): LogData {
+  const incoming = sortLogEntries(response.entries)
+  const cap = deltaMergeCap(
+    current.entries,
+    incoming,
+    current.pagedOlder,
+    logLimit.value,
+  )
+  return {
+    ...response,
+    entries: mergeLogEntries(current.entries, incoming, cap),
+    pagedOlder: current.pagedOlder,
+    noMoreOlder: current.noMoreOlder,
+  }
+}
+
+function mergeOlderLogData(current: LogData, response: LogsData): LogData {
+  const incoming = sortLogEntries(response.entries)
+  if (incoming.length === 0) {
+    return { ...current, noMoreOlder: true }
+  }
+  return {
+    ...response,
+    entries: mergeLogEntries(
+      current.entries,
+      incoming,
+      current.entries.length + incoming.length,
+    ),
+    pagedOlder: true,
+    noMoreOlder: false,
+  }
+}
+
+async function loadLogs(mode: LoadMode = 'reset'): Promise<void> {
+  const state = logResource.state.value
+  if (mode !== 'reset' && state._tag === 'Loading') return
+
+  const current = Option.getOrUndefined(remotePrevious(state))
+
+  const request = baseLogsRequest()
+  let program: Effect.Effect<LogData, LogsError, DashboardHttp>
+  switch (mode) {
+    case 'reset':
+      program = fetchLogs(request).pipe(Effect.map(resetLogData))
+      break
+    case 'delta':
+      if (current === undefined) return
+      program = fetchLogs({
+        ...request,
+        sinceSeq: Option.getOrUndefined(latestLogSeq(current.entries)),
+      }).pipe(Effect.map(response => mergeDeltaLogData(current, response)))
+      break
+    case 'older': {
+      if (current === undefined) return
+      const beforeSeq = Option.getOrUndefined(oldestLogSeq(current.entries))
+      if (beforeSeq === undefined || beforeSeq <= 0 || current.noMoreOlder) return
+      program = fetchLogs({ ...request, beforeSeq }).pipe(
+        Effect.map(response => mergeOlderLogData(current, response)),
+      )
+      break
     }
-    const latestState = logResource.state.value
-    if (latestState.status !== 'loaded') return
-    const latestEntries = latestState.data.entries
-    const cap = latestEntries.length + incoming.length
-    const nextEntries = mergeLogEntries(latestEntries, incoming, cap)
-    // Mark the view as paged-open so the delta poller grows its cap for new
-    // rows instead of slicing the just-loaded older rows back off.
-    pagedOlder.value = true
-    // latestSeq stays untouched: older paging only extends the tail, the
-    // newest-cursor for delta polling is unaffected.
-    logResource.state.value = loaded({
-      ...latestState.data,
-      entries: nextEntries,
-      total: resp.total,
-    })
-  } catch {
-    // Keep existing data on failure; the affordance stays available for retry.
-  } finally {
-    olderLoading.value = false
   }
+
+  await logResource.load(program)
+}
+
+export function loadOlder(): Promise<void> {
+  return loadLogs('older')
 }
 
 // Pretty-print a nested details value as a JSON code block body, matching the
@@ -706,7 +709,7 @@ function renderLogKindGrid(
 
 function renderLogRow(entry: LogEntry) {
   const level = normalizedLevel(entry)
-  const source = entry.source || '(unknown source)'
+  const source = entry.source
   const details = entryDetails(entry)
   const clientName = detailLabel(details, 'client_name')
   const toolName = detailLabel(details, 'tool_name') ?? detailLabel(details, 'tool')
@@ -720,7 +723,9 @@ function renderLogRow(entry: LogEntry) {
   const sourceClass = sourceTone(source)
   const renderedMessage = renderLogMessage(entry)
   const routeLinks = logRouteLinks(entry)
-  const category = categoryLabel(entry.category)
+  const category = entry.hasExplicitCategory
+    ? categoryLabel(entry.category)
+    : undefined
   const displayKind = logDisplayKind(entry)
   const severity = logSeverity(entry)
   const identity = keeperLabel(entry, details)
@@ -763,7 +768,7 @@ function renderLogRow(entry: LogEntry) {
           expandedLogSeq.value = isExpanded ? null : entry.seq
         }}
       >
-        <span class="v2-logs-time lg-time mono">${formatLogClock(entry.ts)}</span>
+        <span class="v2-logs-time lg-time mono">${formatLogClock(entry.timestamp)}</span>
         <span class="v2-logs-who lg-who">
           <${KeeperBadge} id=${identity} variant="sigil" size="md" title=${identity} />
           <span class="v2-logs-identity lg-kid" title=${identity}>${identity}</span>
@@ -787,7 +792,7 @@ function renderLogRow(entry: LogEntry) {
               <div><span>level</span><b style=${{ color: LEVEL_COLORS[level] ?? 'inherit' }}>${level}</b></div>
               <div><span>module</span><b>${entry.module || '(root)'}</b></div>
               <div><span>source</span><b>${sourceLabel(source)}</b></div>
-              <div><span>timestamp</span><b>${entry.ts.replace('T', ' ').replace('Z', '')}</b></div>
+              <div><span>timestamp</span><b>${entry.timestamp.replace('T', ' ').replace('Z', '')}</b></div>
             </div>
             <div class="v2-logs-tags">
               <${StatusChip} tone=${sourceClass}>${sourceLabel(source)}</${StatusChip}>
@@ -847,25 +852,23 @@ function lastPathSegment(path: string | undefined): string | null {
 
 function renderLogProvenance(data: LogData | undefined) {
   if (!data) return null
-  const scope = data.retention?.scope
-  const store = lastPathSegment(data.retention?.durable_store)
-  const latestSeq = typeof data.latest_seq === 'number' ? String(data.latest_seq) : null
-  const generatedAt = data.generated_at_iso?.replace('T', ' ').replace('Z', '')
-
-  if (!data.source && !scope && !store && !latestSeq && !generatedAt) return null
+  const scope = data.retention.scope
+  const store = lastPathSegment(data.retention.durableStore)
+  const latestSeq = Option.getOrUndefined(latestLogSeq(data.entries))
+  const generatedAt = data.generatedAt.replace('T', ' ').replace('Z', '')
 
   return html`
     <div class="flex flex-wrap items-center gap-1.5" data-testid="logs-provenance">
-      ${data.source ? renderSummaryChip('source', data.source, 'info') : null}
-      ${scope ? renderSummaryChip('scope', scope) : null}
-      ${latestSeq ? renderSummaryChip('seq', latestSeq) : null}
+      ${renderSummaryChip('source', data.source, 'info')}
+      ${renderSummaryChip('scope', scope)}
+      ${latestSeq !== undefined ? renderSummaryChip('seq', latestSeq) : null}
       ${store ? html`
         <${StatusChip}
           tone="neutral"
           uppercase=${false}
         >store ${store}</${StatusChip}>
       ` : null}
-      ${generatedAt ? renderSummaryChip('at', generatedAt) : null}
+      ${renderSummaryChip('at', generatedAt)}
     </div>
   `
 }
@@ -879,7 +882,6 @@ export function LogViewer() {
         clearInterval(pollId)
         pollId = null
       }
-      latestSeq.value = null
       logResource.reset()
       void loadLogs('reset')
       if (!autoRefresh.value) return
@@ -907,6 +909,7 @@ export function LogViewer() {
       unsubscribeCategory()
       unsubscribeHideFsm()
       unsubscribeAutoRefresh()
+      logResource.cancel()
     }
   }, [])
 
@@ -918,11 +921,11 @@ export function LogViewer() {
   }, [])
 
   const s = logResource.state.value
-  const logData = s.status === 'loaded' ? s.data : undefined
+  const logData = Option.getOrUndefined(remotePrevious(s))
   const logEntries = logData?.entries ?? EMPTY_LOG_ENTRIES
   const logTotal = logData?.total ?? 0
-  const logLoading = s.status === 'loading'
-  const logError = s.status === 'error' ? s.message : null
+  const logLoading = s._tag === 'Initial' || s._tag === 'Loading'
+  const logError = s._tag === 'Failure' ? s.error.message : undefined
   // summarizeLogWindow iterates the full entries array (counts errors/warnings,
   // builds cause/module Maps). When logData is loaded the entries ref is stable
   // across unrelated re-renders (toolbar interactions, polling status flips);
@@ -1009,7 +1012,9 @@ export function LogViewer() {
                     { value: 'WARN', label: 'WARN+' },
                     { value: 'ERROR', label: 'ERROR' },
                   ]}
-                  onInput=${(v: string) => { levelFilter.value = v }}
+                  onInput=${(value: string) => {
+                    if (isLogLevel(value)) levelFilter.value = value
+                  }}
                 />
 
                 <${Select}
@@ -1018,7 +1023,12 @@ export function LogViewer() {
                   ariaLabel="카테고리"
                   value=${categoryFilter.value}
                   options=${LOG_CATEGORY_OPTIONS}
-                  onInput=${(v: string) => { categoryFilter.value = v }}
+                  onInput=${(value: string) => {
+                    const category = LOG_CATEGORY_OPTIONS.find(
+                      option => option.value === value,
+                    )?.value
+                    if (category !== undefined) categoryFilter.value = category
+                  }}
                 />
 
                 <${TextInput}
@@ -1078,7 +1088,6 @@ export function LogViewer() {
               class="logs-refresh-btn v2-logs-refresh"
               aria-label="새로고침"
               onClick=${() => {
-                latestSeq.value = null
                 logResource.reset()
                 void loadLogs('reset')
               }}
@@ -1133,7 +1142,7 @@ export function LogViewer() {
         ${logEntries.length > 0
           ? html`
               <div class="v2-logs-load-older flex items-center justify-center px-4 py-3">
-                ${noMoreOlder.value
+                ${logData?.noMoreOlder
                   ? html`<span class="text-2xs text-[var(--color-fg-muted)]">더 오래된 기록이 없습니다.</span>`
                   : html`
                       <button
@@ -1141,9 +1150,9 @@ export function LogViewer() {
                         class="logs-refresh-btn rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-2xs font-medium text-[var(--color-fg-muted)]"
                         data-testid="logs-load-older"
                         onClick=${() => { void loadOlder() }}
-                        disabled=${olderLoading.value}
+                        disabled=${logLoading}
                       >
-                        ${olderLoading.value ? '불러오는 중...' : '이전 기록 더 보기'}
+                        ${logLoading ? '불러오는 중...' : '이전 기록 더 보기'}
                       </button>
                     `}
               </div>

--- a/dashboard/src/components/server-config.test.ts
+++ b/dashboard/src/components/server-config.test.ts
@@ -2,8 +2,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
+import { Effect } from 'effect'
 
-vi.mock('../api/dashboard-logs', () => ({
+vi.mock('../api/dashboard-config', () => ({
   fetchDashboardConfig: vi.fn(),
 }))
 
@@ -17,17 +18,15 @@ vi.mock('../store', async (importOriginal) => {
   }
 })
 
-import { fetchDashboardConfig } from '../api/dashboard-logs'
+import { fetchDashboardConfig } from '../api/dashboard-config'
 import { refreshShell } from '../store'
 import { refreshServerConfig, ServerConfig } from './server-config'
 
 const dashboardConfigFixture = {
-  generated_at: '2026-04-10T00:00:00Z',
   server: {
     version: '1.0.0',
-    git_commit: null,
-    uptime_seconds: 0,
-    ocaml_version: '5.2.0',
+    uptimeSeconds: 0,
+    ocamlVersion: '5.2.0',
     pid: 1,
   },
   categories: {},
@@ -36,7 +35,9 @@ const dashboardConfigFixture = {
 describe('refreshServerConfig', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(fetchDashboardConfig).mockResolvedValue(dashboardConfigFixture)
+    vi.mocked(fetchDashboardConfig).mockReturnValue(
+      Effect.succeed(dashboardConfigFixture),
+    )
   })
 
   it('refreshes shell truth before loading config data', async () => {
@@ -53,7 +54,9 @@ describe('ServerConfig rendering', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(fetchDashboardConfig).mockResolvedValue(dashboardConfigFixture)
+    vi.mocked(fetchDashboardConfig).mockReturnValue(
+      Effect.succeed(dashboardConfigFixture),
+    )
     container = document.createElement('div')
     document.body.appendChild(container)
   })

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -1,30 +1,40 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { Option } from 'effect'
 import { SectionCard } from './common/card'
 import { TextInput } from './common/input'
 import { TransportHealthPanel } from './transport-health'
 import { ConfigResolutionPanel } from './tools/config-resolution-panel'
-import { fetchDashboardConfig } from '../api/dashboard-logs'
-import type { ConfigEntry, DashboardConfigResponse } from '../api/schemas/dashboard-config'
-import { createAsyncResource } from '../lib/async-state'
+import {
+  fetchDashboardConfig,
+  type DashboardConfig,
+  type DashboardConfigError,
+  type ConfigEntry,
+} from '../api/dashboard-config'
+import { dashboardRuntime, type DashboardHttp } from '../api/effect-http'
+import { createEffectResource } from '../lib/effect-resource'
+import { remotePrevious } from '../lib/remote-data'
 import { formatElapsedCompact } from '../lib/format-time'
 import { LoadingState } from './common/feedback-state'
 import { Eyebrow } from './common/eyebrow'
 import { refreshShell, shellConfigResolution, shellRuntimeResolution } from '../store'
 
-const configResource = createAsyncResource<DashboardConfigResponse>()
+const configResource = createEffectResource<
+  DashboardHttp,
+  DashboardConfigError,
+  DashboardConfig
+>(dashboardRuntime)
 const searchQuery = signal('')
 const expandedCategories = signal<Set<string>>(new Set())
 
 export function refreshServerConfig(): Promise<void> {
-  configResource.reset()
   void refreshShell({ force: true })
-  return configResource.load(async () => {
-    const data = await fetchDashboardConfig()
-    if (expandedCategories.value.size === 0) {
+  return configResource.load(fetchDashboardConfig()).then(() => {
+    const data = Option.getOrUndefined(remotePrevious(configResource.state.value))
+    if (data !== undefined && expandedCategories.value.size === 0) {
       expandedCategories.value = new Set(Object.keys(data.categories))
     }
-    return data
   })
 }
 
@@ -45,8 +55,8 @@ function matchesSearch(entry: ConfigEntry, query: string): boolean {
     entry.env.toLowerCase().includes(lower) ||
     entry.description.toLowerCase().includes(lower) ||
     entry.source.toLowerCase().includes(lower) ||
-    (entry.source_detail ?? '').toLowerCase().includes(lower) ||
-    (entry.value ?? '').toLowerCase().includes(lower)
+    entry.sourceDetail.toLowerCase().includes(lower) ||
+    entry.displayValue.toLowerCase().includes(lower)
   )
 }
 
@@ -75,17 +85,15 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
           ` : null}
         </div>
         <div class="text-xs text-[var(--color-fg-muted)] mt-0.5">${entry.description}</div>
-        ${entry.source_detail ? html`
-          <div class="text-3xs text-[var(--color-fg-muted)] mt-0.5">source: ${entry.source_detail}</div>
-        ` : null}
+        <div class="text-3xs text-[var(--color-fg-muted)] mt-0.5">source: ${entry.sourceDetail}</div>
       </div>
       <div class="text-right shrink-0">
         <div class=${`text-xs font-mono ${valueClass}`}>
-          ${entry.value ?? entry.default}
+          ${entry.displayValue}
         </div>
-        ${isEnv && entry.default ? html`
+        ${isEnv && entry.defaultValue ? html`
           <div class="text-3xs text-[var(--color-fg-muted)] mt-0.5">
-            default: ${entry.default}
+            default: ${entry.defaultValue}
           </div>
         ` : null}
       </div>
@@ -93,7 +101,7 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
   `
 }
 
-function CategoryPanel({ name, entries }: { name: string; entries: ConfigEntry[] }) {
+function CategoryPanel({ name, entries }: { name: string; entries: readonly ConfigEntry[] }) {
   const query = searchQuery.value
   const filtered = entries.filter(e => matchesSearch(e, query))
   const isExpanded = expandedCategories.value.has(name)
@@ -128,12 +136,7 @@ function CategoryPanel({ name, entries }: { name: string; entries: ConfigEntry[]
   `
 }
 
-function ServerMeta() {
-  const sm = configResource.state.value
-  const data = sm.status === 'loaded' ? sm.data : undefined
-  if (!data) return null
-  const { server } = data
-
+function ServerMeta({ server }: { server: DashboardConfig['server'] }) {
   return html`
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
       <div class="v2-connector-card px-3 py-2 rounded-[var(--r-1)] bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
@@ -142,11 +145,11 @@ function ServerMeta() {
       </div>
       <div class="v2-connector-card px-3 py-2 rounded-[var(--r-1)] bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
         <${Eyebrow}>가동시간</${Eyebrow}>
-        <div class="text-sm font-mono text-[var(--color-fg-secondary)]">${formatUptime(server.uptime_seconds)}</div>
+        <div class="text-sm font-mono text-[var(--color-fg-secondary)]">${formatUptime(server.uptimeSeconds)}</div>
       </div>
       <div class="v2-connector-card px-3 py-2 rounded-[var(--r-1)] bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
         <${Eyebrow}>OCaml</${Eyebrow}>
-        <div class="text-sm font-mono text-[var(--color-fg-secondary)]">${server.ocaml_version}</div>
+        <div class="text-sm font-mono text-[var(--color-fg-secondary)]">${server.ocamlVersion}</div>
       </div>
       <div class="v2-connector-card px-3 py-2 rounded-[var(--r-1)] bg-[var(--bg-surface)] border border-[var(--color-border-divider)]">
         <${Eyebrow}>PID</${Eyebrow}>
@@ -157,16 +160,19 @@ function ServerMeta() {
 }
 
 export function ServerConfig() {
+  useEffect(() => {
+    if (configResource.state.value._tag === 'Initial') {
+      void refreshServerConfig()
+    }
+    return () => configResource.cancel()
+  }, [])
+
   const s = configResource.state.value
-  const data = s.status === 'loaded' ? s.data : undefined
-  const loading = s.status === 'loading'
-  const error = s.status === 'error' ? s.message : null
+  const data = Option.getOrUndefined(remotePrevious(s))
+  const loading = s._tag === 'Initial' || s._tag === 'Loading'
+  const error = s._tag === 'Failure' ? s.error.message : null
   const configResolution = shellConfigResolution.value
   const runtimeResolution = shellRuntimeResolution.value
-
-  if (s.status === 'idle') {
-    void refreshServerConfig()
-  }
 
   return html`
     <div class="v2-connector-surface">
@@ -201,7 +207,7 @@ export function ServerConfig() {
         />
 
         ${data ? html`
-          <${ServerMeta} />
+          <${ServerMeta} server=${data.server} />
           ${Object.entries(data.categories).map(([name, entries]) =>
             html`<${CategoryPanel} name=${name} entries=${entries} />`
           )}

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
+import { Effect } from 'effect'
 import {
   SettingsSurface,
   mcpExposedToolNames,
@@ -12,15 +13,14 @@ import {
   settingsControlInventory,
 } from './settings-surface'
 import type {
-  ConfigEntry,
-  DashboardConfigResponse,
   DashboardRuntimeProviderSnapshot,
   DashboardRuntimeProvidersResponse,
   DashboardToolInventoryItem,
-  LogEntry,
   RuntimeDefaultsResponse,
   RuntimeResolvedResponse,
 } from '../api/dashboard'
+import type { ConfigEntry, DashboardConfig } from '../api/dashboard-config'
+import type { LogEntry, LogsData } from '../api/dashboard-logs'
 import { DashboardMain } from './dashboard-shell'
 import { SETTINGS_ROUTE_SECTION_IDS } from '../config/navigation'
 import { route } from '../router'
@@ -94,8 +94,6 @@ vi.mock('../api/dashboard.js', async () => {
   const actual = await vi.importActual<typeof import('../api/dashboard')>('../api/dashboard')
   return {
     ...actual,
-    fetchDashboardConfig: apiMock.fetchDashboardConfig,
-    fetchLogs: apiMock.fetchLogs,
     fetchDashboardTools: apiMock.fetchDashboardTools,
     fetchRuntimeDefaults: apiMock.fetchRuntimeDefaults,
     fetchRuntimeResolved: apiMock.fetchRuntimeResolved,
@@ -106,6 +104,14 @@ vi.mock('../api/dashboard.js', async () => {
     saveRuntimeTomlConfig: apiMock.saveRuntimeTomlConfig,
   }
 })
+
+vi.mock('../api/dashboard-config', () => ({
+  fetchDashboardConfig: apiMock.fetchDashboardConfig,
+}))
+
+vi.mock('../api/dashboard-logs', () => ({
+  fetchLogs: apiMock.fetchLogs,
+}))
 
 vi.mock('../lib/runtime-config-refresh', () => ({
   refreshRuntimeConfigConsumers: runtimeRefreshMock.refreshRuntimeConfigConsumers,
@@ -128,16 +134,30 @@ vi.mock('../api', async () => {
 function makeLogEntry(overrides: Partial<LogEntry> = {}): LogEntry {
   return {
     seq: 1,
-    ts: '2026-06-21T16:24:51Z',
+    timestamp: '2026-06-21T16:24:51Z',
     level: 'INFO',
     source: 'structured',
     module: 'Keeper',
     message: 'booted',
-    keeper_name: null,
-    turn_id: null,
-    category: null,
-    details: null,
+    keeperName: 'system',
+    hasTurn: false,
+    category: 'uncategorized',
+    hasExplicitCategory: false,
+    details: {},
     ...overrides,
+  }
+}
+
+function makeLogsData(entries: readonly LogEntry[]): LogsData {
+  return {
+    generatedAt: '2026-06-21T16:24:51Z',
+    source: 'masc_log_ring',
+    retention: {
+      scope: 'dashboard_logs',
+      durableStore: '/workspace/.masc/logs/system_log_2026-06-21.jsonl',
+    },
+    total: entries.length,
+    entries,
   }
 }
 
@@ -295,44 +315,38 @@ function makeConfigEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   return {
     env: 'MASC_BASE_PATH',
     description: 'Base storage directory',
-    value: null,
-    default: '(cwd)',
+    displayValue: '(cwd)',
+    defaultValue: '(cwd)',
     source: 'runtime',
-    source_detail: 'resolved from runtime',
-    provenance: {
-      kind: 'runtime',
-      detail: 'resolved from runtime',
-    },
+    sourceDetail: 'resolved from runtime',
     sensitive: false,
     ...overrides,
   }
 }
 
-function makeDashboardConfig(overrides: Partial<DashboardConfigResponse> = {}): DashboardConfigResponse {
+function makeDashboardConfig(overrides: Partial<DashboardConfig> = {}): DashboardConfig {
   return {
-    generated_at: '2026-06-21T00:00:00Z',
     server: {
       version: 'test',
-      git_commit: null,
-      ocaml_version: '5.4.0',
-      uptime_seconds: 12,
+      ocamlVersion: '5.4.0',
+      uptimeSeconds: 12,
       pid: 123,
     },
     categories: {
       server: [
-        makeConfigEntry({ env: 'MASC_URL', description: 'MCP URL', value: 'http://127.0.0.1:8935/mcp', default: '(derived)', source: 'env', source_detail: 'environment variable MASC_URL' }),
-        makeConfigEntry({ env: 'MASC_HTTP_BASE_URL', description: 'HTTP base URL', value: 'http://127.0.0.1:8935', default: '(derived)', source: 'env', source_detail: 'environment variable MASC_HTTP_BASE_URL' }),
-        makeConfigEntry({ env: 'MASC_BASE_PATH', description: 'Base storage directory', value: '/workspace', default: '(cwd)', source: 'env', source_detail: 'environment variable MASC_BASE_PATH' }),
+        makeConfigEntry({ env: 'MASC_URL', description: 'MCP URL', displayValue: 'http://127.0.0.1:8935/mcp', defaultValue: '(derived)', source: 'env', sourceDetail: 'environment variable MASC_URL' }),
+        makeConfigEntry({ env: 'MASC_HTTP_BASE_URL', description: 'HTTP base URL', displayValue: 'http://127.0.0.1:8935', defaultValue: '(derived)', source: 'env', sourceDetail: 'environment variable MASC_HTTP_BASE_URL' }),
+        makeConfigEntry({ env: 'MASC_BASE_PATH', description: 'Base storage directory', displayValue: '/workspace', defaultValue: '(cwd)', source: 'env', sourceDetail: 'environment variable MASC_BASE_PATH' }),
       ],
       path: [
-        makeConfigEntry({ env: 'MASC_CONFIG_DIR', description: 'Config directory override', value: null, default: '(none)', source: 'default', source_detail: 'compiled default value' }),
-        makeConfigEntry({ env: 'MASC_DATA_DIR', description: 'Data directory override', value: null, default: '(none)', source: 'default', source_detail: 'compiled default value' }),
+        makeConfigEntry({ env: 'MASC_CONFIG_DIR', description: 'Config directory override', displayValue: '(none)', defaultValue: '(none)', source: 'default', sourceDetail: 'compiled default value' }),
+        makeConfigEntry({ env: 'MASC_DATA_DIR', description: 'Data directory override', displayValue: '(none)', defaultValue: '(none)', source: 'default', sourceDetail: 'compiled default value' }),
       ],
       dashboard: [
-        makeConfigEntry({ env: 'MASC_DASHBOARD_CTX_PREPARING', description: 'Context preparing', value: '0.70', default: '0.70', source: 'default', source_detail: 'compiled default value' }),
-        makeConfigEntry({ env: 'MASC_DASHBOARD_CTX_HANDOFF_IMMINENT', description: 'Context imminent', value: '0.85', default: '0.85', source: 'default', source_detail: 'compiled default value' }),
-        makeConfigEntry({ env: 'MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO', description: 'Runtime warning', value: '0.95', default: '0.95', source: 'default', source_detail: 'compiled default value' }),
-        makeConfigEntry({ env: 'MASC_DASHBOARD_SIGNAL_STALE_SEC', description: 'Signal stale', value: '1200.0', default: '1200.0', source: 'default', source_detail: 'compiled default value' }),
+        makeConfigEntry({ env: 'MASC_DASHBOARD_CTX_PREPARING', description: 'Context preparing', displayValue: '0.70', defaultValue: '0.70', source: 'default', sourceDetail: 'compiled default value' }),
+        makeConfigEntry({ env: 'MASC_DASHBOARD_CTX_HANDOFF_IMMINENT', description: 'Context imminent', displayValue: '0.85', defaultValue: '0.85', source: 'default', sourceDetail: 'compiled default value' }),
+        makeConfigEntry({ env: 'MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO', description: 'Runtime warning', displayValue: '0.95', defaultValue: '0.95', source: 'default', sourceDetail: 'compiled default value' }),
+        makeConfigEntry({ env: 'MASC_DASHBOARD_SIGNAL_STALE_SEC', description: 'Signal stale', displayValue: '1200.0', defaultValue: '1200.0', source: 'default', sourceDetail: 'compiled default value' }),
       ],
     },
     ...overrides,
@@ -348,8 +362,8 @@ function stubRuntimeResolved(value: RuntimeResolvedResponse = makeRuntimeResolve
 }
 
 function stubEmptyApi() {
-  apiMock.fetchDashboardConfig.mockResolvedValue(makeDashboardConfig())
-  apiMock.fetchLogs.mockResolvedValue({ total: 0, entries: [] })
+  apiMock.fetchDashboardConfig.mockReturnValue(Effect.succeed(makeDashboardConfig()))
+  apiMock.fetchLogs.mockReturnValue(Effect.succeed(makeLogsData([])))
   apiMock.fetchDashboardTools.mockResolvedValue({ tool_inventory: { count: 0, tools: [] } })
   stubRuntimeDefaults()
   stubRuntimeResolved()
@@ -787,7 +801,9 @@ describe('SettingsSurface', () => {
   it('paths page does not fabricate unknown rows when path resolution is unavailable', async () => {
     shellRuntimeResolution.value = null
     shellConfigResolution.value = null
-    apiMock.fetchDashboardConfig.mockRejectedValueOnce(new Error('config unavailable'))
+    apiMock.fetchDashboardConfig.mockReturnValueOnce(
+      Effect.fail(new Error('config unavailable')),
+    )
     stubRuntimeDefaults(makeRuntimeDefaults({ config_path: null }))
     stubRuntimeResolved(makeRuntimeResolved({ config_path: null }))
     apiMock.fetchRuntimeProviders.mockResolvedValueOnce(makeRuntimeProviders({ config_path: null }))
@@ -808,7 +824,9 @@ describe('SettingsSurface', () => {
   it('paths page labels provider-only path data as partial resolution', async () => {
     shellRuntimeResolution.value = null
     shellConfigResolution.value = null
-    apiMock.fetchDashboardConfig.mockRejectedValueOnce(new Error('config unavailable'))
+    apiMock.fetchDashboardConfig.mockReturnValueOnce(
+      Effect.fail(new Error('config unavailable')),
+    )
 
     render(html`<${SettingsSurface} />`, container)
 
@@ -885,7 +903,9 @@ describe('SettingsSurface', () => {
   })
 
   it('notify page surfaces config projection failures instead of rendering missing thresholds', async () => {
-    apiMock.fetchDashboardConfig.mockRejectedValueOnce(new Error('config projection offline'))
+    apiMock.fetchDashboardConfig.mockReturnValueOnce(
+      Effect.fail(new Error('config projection offline')),
+    )
 
     render(html`<${SettingsSurface} />`, container)
 
@@ -1482,14 +1502,13 @@ describe('SettingsSurface', () => {
   it('log filter chips filter live rows from the ring', async () => {
     // 7 ring entries mapped to rows: tool(category/details or /masc_/)=4,
     // success(ok)=4, failure(fail)=2.
-    apiMock.fetchLogs.mockResolvedValue({
-      total: 7,
-      entries: [
+    apiMock.fetchLogs.mockReturnValue(Effect.succeed(makeLogsData([
         makeLogEntry({
           seq: 7,
           level: 'INFO',
           message: 'shell exec completed',
           category: 'tool',
+          hasExplicitCategory: true,
           details: { tool_name: 'shell.exec' },
         }),
         makeLogEntry({ seq: 6, level: 'INFO', message: 'masc_start 완료' }),
@@ -1498,8 +1517,7 @@ describe('SettingsSurface', () => {
         makeLogEntry({ seq: 3, level: 'ERROR', message: 'masc_trace_window 실패' }),
         makeLogEntry({ seq: 2, level: 'ERROR', message: 'restart failed (3/3)' }),
         makeLogEntry({ seq: 1, level: 'INFO', message: 'handoff 시작' }),
-      ],
-    })
+      ])))
 
     render(html`<${SettingsSurface} />`, container)
 
@@ -1672,9 +1690,9 @@ describe('settings read-surface helpers', () => {
   it('logEntryToSysRow maps a ring entry to [time, level, identity, message, status]', () => {
     const row = logEntryToSysRow(
       makeLogEntry({
-        ts: '2026-06-21T16:24:51Z',
+        timestamp: '2026-06-21T16:24:51Z',
         level: 'ERROR',
-        keeper_name: 'drifter',
+        keeperName: 'drifter',
         module: 'Keeper',
         message: 'masc_trace_window 실패',
       }),
@@ -1686,6 +1704,7 @@ describe('settings read-surface helpers', () => {
     const row = logEntryToSysRow(
       makeLogEntry({
         category: 'tool',
+        hasExplicitCategory: true,
         details: { tool_name: 'shell.exec' },
         message: 'shell exec completed',
       }),
@@ -1693,8 +1712,8 @@ describe('settings read-surface helpers', () => {
     expect(row[5]).toBe(true)
   })
 
-  it('logEntryToSysRow falls back to module then (root) for identity', () => {
-    expect(logEntryToSysRow(makeLogEntry({ keeper_name: null, module: 'Server' }))[2]).toBe('Server')
-    expect(logEntryToSysRow(makeLogEntry({ keeper_name: null, module: '' }))[2]).toBe('(root)')
+  it('logEntryToSysRow uses the normalized keeper identity', () => {
+    expect(logEntryToSysRow(makeLogEntry({ keeperName: 'system', module: 'Server' }))[2]).toBe('system')
+    expect(logEntryToSysRow(makeLogEntry({ keeperName: 'drifter', module: '' }))[2]).toBe('drifter')
   })
 })

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -4,22 +4,32 @@
 
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
+import { Effect, Option } from 'effect'
 import {
   SETTINGS_ROUTE_SECTION_IDS,
   type SettingsRouteSectionId,
 } from '../config/navigation'
 import { navigate, route } from '../router'
-import { fetchDashboardConfig, fetchDashboardTools, fetchLogs, fetchRuntimeDefaults, fetchRuntimeProviders, fetchRuntimeResolved } from '../api/dashboard.js'
+import { fetchDashboardTools, fetchRuntimeDefaults, fetchRuntimeProviders, fetchRuntimeResolved } from '../api/dashboard.js'
 import type {
-  ConfigEntry,
-  DashboardConfigResponse,
   DashboardRuntimeProviderSnapshot,
   DashboardRuntimeProvidersResponse,
   DashboardToolInventoryItem,
-  LogEntry,
   RuntimeDefaultsResponse,
   RuntimeResolvedResponse,
 } from '../api/dashboard.js'
+import {
+  fetchDashboardConfig,
+  type ConfigEntry,
+  type DashboardConfig,
+  type DashboardConfigError,
+} from '../api/dashboard-config'
+import {
+  fetchLogs,
+  type LogEntry,
+  type LogsError,
+} from '../api/dashboard-logs'
+import { dashboardRuntime, type DashboardHttp } from '../api/effect-http'
 import {
   patchRuntimeMediaFailover,
   patchRuntimeRouting,
@@ -64,6 +74,8 @@ import {
 } from '../notifications'
 import type { ComponentChildren } from 'preact'
 import { errorToString } from '../lib/format-string'
+import { createEffectResource } from '../lib/effect-resource'
+import { remotePrevious } from '../lib/remote-data'
 import { refreshRuntimeConfigConsumers } from '../lib/runtime-config-refresh'
 import {
   runtimeCatalogDeclaredSpec,
@@ -78,6 +90,12 @@ type SectionId = SettingsRouteSectionId
 type LogFilter = 'all' | 'tool' | 'success' | 'failure'
 type RuntimeRoutingSaveState = 'idle' | 'saving' | 'saved' | 'error'
 type SettingsControlKind = 'live-read' | 'live-write' | 'browser-local' | 'unsupported'
+
+const settingsConfigResource = createEffectResource<
+  DashboardHttp,
+  DashboardConfigError,
+  DashboardConfig
+>(dashboardRuntime)
 type RuntimeSelectOption = {
   readonly id: string
   readonly label: string
@@ -318,10 +336,16 @@ function logRowClock(ts: string): string {
 
 export function logEntryToSysRow(entry: LogEntry): SysLogRow {
   const level = entry.level.toLowerCase()
-  const identity = entry.keeper_name?.trim() || entry.module?.trim() || '(root)'
+  const identity = entry.keeperName
   const isTool = logDisplayKind(entry) === 'tool' || /masc_/.test(entry.message)
-  return [logRowClock(entry.ts), level, identity, entry.message, logRowStatus(entry.level), isTool]
+  return [logRowClock(entry.timestamp), level, identity, entry.message, logRowStatus(entry.level), isTool]
 }
+
+const settingsLogsResource = createEffectResource<
+  DashboardHttp,
+  LogsError,
+  readonly SysLogRow[]
+>(dashboardRuntime)
 
 function SetSeg({
   value,
@@ -751,29 +775,28 @@ function RuntimeMediaFailoverEditor({
   `
 }
 
-function configEntry(data: DashboardConfigResponse | null, env: string): ConfigEntry | null {
-  if (!data) return null
+function configEntry(data: DashboardConfig | undefined, env: string): ConfigEntry | undefined {
+  if (data === undefined) return undefined
   for (const entries of Object.values(data.categories)) {
     const found = entries.find(entry => entry.env === env)
     if (found) return found
   }
-  return null
+  return undefined
 }
 
-function configEntryDisplayValue(entry: ConfigEntry | null): string | null {
-  if (!entry) return null
-  return entry.value ?? entry.default
+function configEntryDisplayValue(entry: ConfigEntry | undefined): string | undefined {
+  return entry?.displayValue
 }
 
-function concreteConfigValue(entry: ConfigEntry | null): string | null {
+function concreteConfigValue(entry: ConfigEntry | undefined): string | undefined {
   const value = configEntryDisplayValue(entry)?.trim()
-  if (!value || /^\(.+\)$/.test(value)) return null
+  if (!value || /^\(.+\)$/.test(value)) return undefined
   return value
 }
 
-function formatConfigSource(entry: ConfigEntry | null): string {
+function formatConfigSource(entry: ConfigEntry | undefined): string {
   if (!entry) return 'missing'
-  return entry.source_detail ?? entry.source
+  return entry.sourceDetail
 }
 
 function endpointFromWindow(): string {
@@ -783,7 +806,7 @@ function endpointFromWindow(): string {
   return `${origin.replace(/\/$/, '')}/mcp`
 }
 
-function mcpEndpointFromConfig(config: DashboardConfigResponse | null): string {
+function mcpEndpointFromConfig(config: DashboardConfig | undefined): string {
   const mcpUrl = concreteConfigValue(configEntry(config, 'MASC_URL'))
   if (mcpUrl) return mcpUrl
   const httpBaseUrl = concreteConfigValue(configEntry(config, 'MASC_HTTP_BASE_URL'))
@@ -797,8 +820,8 @@ function mcpEndpointFromConfig(config: DashboardConfigResponse | null): string {
   return endpointFromWindow()
 }
 
-function formatThresholdPercent(value: string | null): string {
-  const parsed = value == null ? NaN : Number.parseFloat(value)
+function formatThresholdPercent(value: string | undefined): string {
+  const parsed = value === undefined ? NaN : Number.parseFloat(value)
   if (!Number.isFinite(parsed)) return value ?? '미수집'
   return `${Math.round(parsed * 100)}%`
 }
@@ -809,8 +832,8 @@ function ConfigTruthRow({
   fallback,
 }: {
   label: string
-  entry: ConfigEntry | null
-  fallback?: string | null
+  entry: ConfigEntry | undefined
+  fallback?: string
 }) {
   const value = configEntryDisplayValue(entry) ?? fallback ?? '미수집'
   return html`
@@ -829,7 +852,7 @@ function ThresholdTruthRow({
   value,
 }: {
   label: string
-  entry: ConfigEntry | null
+  entry: ConfigEntry | undefined
   value: string
 }) {
   return html`
@@ -999,38 +1022,42 @@ function LogFilter({
 
 function LogViewer() {
   const [filter, setFilter] = useState<LogFilter>('all')
-  const [allRows, setAllRows] = useState<SysLogRow[]>([])
-  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
 
   useEffect(() => {
-    let active = true
     let timer: ReturnType<typeof setInterval> | null = null
 
-    const tick = async () => {
-      try {
-        const resp = await fetchLogs({ limit: SETTINGS_LOG_LIMIT })
-        if (!active) return
-        const rows = [...resp.entries]
-          .sort((a, b) => b.seq - a.seq)
-          .map(logEntryToSysRow)
-        setAllRows(rows)
-        setStatus('ready')
-      } catch {
-        if (!active) return
-        // No fabricated rows on failure — surface the error state instead.
-        setStatus('error')
-      }
+    const tick = () => {
+      if (settingsLogsResource.state.value._tag === 'Loading') return
+      void settingsLogsResource.load(
+        fetchLogs({ limit: SETTINGS_LOG_LIMIT }).pipe(
+          Effect.map(resp => [...resp.entries]
+            .sort((a, b) => b.seq - a.seq)
+            .map(logEntryToSysRow)),
+        ),
+      )
     }
 
-    void tick()
-    timer = setInterval(() => { void tick() }, SETTINGS_LOG_POLL_MS)
+    settingsLogsResource.reset()
+    tick()
+    timer = setInterval(tick, SETTINGS_LOG_POLL_MS)
 
     return () => {
-      active = false
       if (timer) clearInterval(timer)
+      settingsLogsResource.cancel()
+      settingsLogsResource.reset()
     }
   }, [])
 
+  const resourceState = settingsLogsResource.state.value
+  const allRows = Option.getOrElse(
+    remotePrevious(resourceState),
+    () => [] as readonly SysLogRow[],
+  )
+  const status = resourceState._tag === 'Failure'
+    ? 'error'
+    : resourceState._tag === 'Success'
+      ? 'ready'
+      : 'loading'
   const rows = allRows.filter(r => {
     if (filter === 'all') return true
     if (filter === 'tool') return r[5]
@@ -1105,30 +1132,28 @@ export function SettingsSurface() {
   }
 
   // Server config projection — used by Paths, MCP and Notifications.
-  const [dashboardConfig, setDashboardConfig] = useState<DashboardConfigResponse | null>(null)
-  const [dashboardConfigStatus, setDashboardConfigStatus] = useState<'loading' | 'ready' | 'error'>('loading')
-  const [dashboardConfigError, setDashboardConfigError] = useState<string | null>(null)
-
   useEffect(() => {
-    let active = true
-    setDashboardConfigStatus('loading')
-    setDashboardConfigError(null)
-    void (async () => {
-      try {
-        const resp = await fetchDashboardConfig()
-        if (!active) return
-        setDashboardConfig(resp)
-        setDashboardConfigStatus('ready')
-        setDashboardConfigError(null)
-      } catch (err) {
-        if (!active) return
-        setDashboardConfig(null)
-        setDashboardConfigStatus('error')
-        setDashboardConfigError(err instanceof Error ? err.message : String(err))
-      }
-    })()
-    return () => { active = false }
+    settingsConfigResource.reset()
+    void settingsConfigResource.load(fetchDashboardConfig())
+    return () => {
+      settingsConfigResource.cancel()
+      settingsConfigResource.reset()
+    }
   }, [])
+
+  const dashboardConfigState = settingsConfigResource.state.value
+  const dashboardConfig = Option.getOrUndefined(
+    remotePrevious(dashboardConfigState),
+  )
+  const dashboardConfigStatus: 'loading' | 'ready' | 'error' =
+    dashboardConfigState._tag === 'Failure'
+      ? 'error'
+      : dashboardConfigState._tag === 'Success'
+        ? 'ready'
+        : 'loading'
+  const dashboardConfigError = dashboardConfigState._tag === 'Failure'
+    ? dashboardConfigState.error.message
+    : undefined
 
   // mcp — exposed tools come from the live capability registry (public_mcp surface)
   const [mcpTools, setMcpTools] = useState<string[]>([])


### PR DESCRIPTION
## Summary

- make dashboard config and system-log fetchers return typed `Effect` programs
- decode strict current wire payloads once with Effect Schema, then expose null-free camelCase product values
- collapse config/log loading, cancellation, stale-data, and error state into `EffectResource` / `RemoteData`
- serialize log paging and polling so concurrent requests no longer race or repeatedly reopen Option values
- keep Effect out of the initial static bundle closure by loading boot config at the app effect boundary
- shrink the Valibot migration allowlist from 17 files to 15

## Boundary contract

- snake_case, `null`, provenance wire metadata, query cursors, and schema drift stay in `api/schemas/*` and `api/dashboard-*`
- components consume `DashboardConfig`, `ConfigEntry`, `LogsData`, and `LogEntry` product values only
- transport failures and schema drift remain distinct typed error variants
- obsolete config/log exports were removed from the broad `dashboard.ts` barrel

## Verification

Exact local head: `107e75a9183f2d2fe3ff4cdccb1937949f2e5290`

- `pnpm exec tsc --noEmit --pretty false --incremental false`
- `pnpm lint`
- focused Vitest: 9 files, 99 tests passed
- `pnpm build`
- full dashboard Vitest: 646 files / 8826 tests passed; one unchanged out-of-scope SWR timing test exceeded the global 5s timeout under the 25-minute serial run
- isolated rerun of that file: 2/2 passed; tracked in #28305

Campaign: #28260