### PR TITLE
refactor(server): decode runtime param requests once

### DIFF
--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -1368,67 +1368,61 @@ let add_routes ~sw ~clock router =
        with_tool_auth ~tool_name:"masc_set_param"
          (fun state _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
-           try
-             let args = Yojson.Safe.from_string body_str in
+           match Server_runtime_param_request.decode_set body_str with
+           | Error error ->
+             respond_json_value_with_cors ~status:`Bad_request request reqd
+               (`Assoc
+                  [ ("ok", `Bool false)
+                  ; ( "error"
+                    , `String
+                        (Server_runtime_param_request.error_message error) )
+                  ])
+           | Ok runtime_param_request ->
              let base_path = (Mcp_server.workspace_config state).base_path in
              let actor =
                sanitized_dashboard_actor_for_request ~base_path request
                |> Option.value ~default:"dashboard"
              in
-             let param_key = Json_util.get_string args "param_key"
-               |> Option.value ~default:"" |> String.trim in
-             let value_json = Json_util.assoc_member_opt "value" args in
-            if param_key = "" then
-               respond_json_value_with_cors ~status:`Bad_request request reqd
-                 (`Assoc
-                    [ ("ok", `Bool false); ("error", `String "param_key is required") ])
-             else match value_json with
-             | None ->
-               respond_json_value_with_cors ~status:`Bad_request request reqd
-                 (`Assoc
-                    [ ("ok", `Bool false); ("error", `String "value is required") ])
-             | Some value ->
-               (match
-                  mutate_runtime_param_with_effects
-                    ~base_path
-                    ~param_key
-                    (fun () ->
-                      Runtime_params.set_by_key_with_change
-                        param_key
-                        value
-                        ~actor)
-                with
-                | Error msg ->
-                  respond_json_value_with_cors ~status:`Bad_request request reqd
-                    (`Assoc [ "ok", `Bool false; "error", `String msg ])
-                | Ok (change, effect_fields) ->
-                  Sse.broadcast
-                    (`Assoc
-                       ([ "type", `String "runtime_param_changed"
-                        ; "param_key", `String param_key
-                        ; "old_value", change.old_value
-                        ; "new_value", change.new_value
-                        ; "actor", `String actor
-                        ]
-                        @ effect_fields));
-                  respond_json_value_with_cors request reqd
-                    (`Assoc
-                       ([ "ok", `Bool true
-                        ; ( "message"
-                          , `String
-                              (Printf.sprintf
-                                 "Set %s = %s"
-                                 param_key
-                                 (Yojson.Safe.to_string change.new_value)) )
-                        ]
-                        @ effect_fields)))
-           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-             respond_json_value_with_cors ~status:`Bad_request request reqd
-               (`Assoc
-                  [
-                    ("ok", `Bool false);
-                    ("error", `String (Printexc.to_string exn));
-                  ])
+             let param_key =
+               Server_runtime_param_request.set_param_key runtime_param_request
+             in
+             let value =
+               Server_runtime_param_request.set_value runtime_param_request
+             in
+             (match
+                mutate_runtime_param_with_effects
+                  ~base_path
+                  ~param_key
+                  (fun () ->
+                    Runtime_params.set_by_key_with_change
+                      param_key
+                      value
+                      ~actor)
+              with
+              | Error msg ->
+                respond_json_value_with_cors ~status:`Bad_request request reqd
+                  (`Assoc [ "ok", `Bool false; "error", `String msg ])
+              | Ok (change, effect_fields) ->
+                Sse.broadcast
+                  (`Assoc
+                     ([ "type", `String "runtime_param_changed"
+                      ; "param_key", `String param_key
+                      ; "old_value", change.old_value
+                      ; "new_value", change.new_value
+                      ; "actor", `String actor
+                      ]
+                      @ effect_fields));
+                respond_json_value_with_cors request reqd
+                  (`Assoc
+                     ([ "ok", `Bool true
+                      ; ( "message"
+                        , `String
+                            (Printf.sprintf
+                               "Set %s = %s"
+                               param_key
+                               (Yojson.Safe.to_string change.new_value)) )
+                      ]
+                      @ effect_fields)))
          )
        ) request reqd)
 
@@ -1436,53 +1430,51 @@ let add_routes ~sw ~clock router =
        with_tool_auth ~tool_name:"masc_set_param"
          (fun state _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
-           try
-             let args = Yojson.Safe.from_string body_str in
-             let param_key = Json_util.get_string args "param_key"
-               |> Option.value ~default:"" in
+           match Server_runtime_param_request.decode_clear body_str with
+           | Error error ->
+             respond_json_value_with_cors ~status:`Bad_request request reqd
+               (`Assoc
+                  [ ("ok", `Bool false)
+                  ; ( "error"
+                    , `String
+                        (Server_runtime_param_request.error_message error) )
+                  ])
+           | Ok runtime_param_request ->
+             let param_key =
+               Server_runtime_param_request.clear_param_key runtime_param_request
+             in
              let base_path = (Mcp_server.workspace_config state).base_path in
              let actor =
                sanitized_dashboard_actor_for_request ~base_path request
                |> Option.value ~default:"dashboard"
              in
-            if param_key = "" then
-               respond_json_value_with_cors ~status:`Bad_request request reqd
-                 (`Assoc
-                    [ ("ok", `Bool false); ("error", `String "param_key is required") ])
-             else
-               (match
-                  mutate_runtime_param_with_effects
-                    ~base_path
-                    ~param_key
-                    (fun () ->
-                      Runtime_params.clear_by_key_with_change param_key ~actor)
-                with
-                | Error msg ->
-                  respond_json_value_with_cors ~status:`Bad_request request reqd
-                    (`Assoc [ "ok", `Bool false; "error", `String msg ])
-                | Ok (change, effect_fields) ->
-                  Sse.broadcast
-                    (`Assoc
-                       ([ "type", `String "runtime_param_changed"
-                        ; "param_key", `String param_key
-                        ; "old_value", change.old_value
-                        ; "new_value", change.new_value
-                        ; "actor", `String actor
-                        ]
-                        @ effect_fields));
-                  respond_json_value_with_cors request reqd
-                    (`Assoc
-                       ([ "ok", `Bool true
-                        ; ( "message"
-                          , `String (Printf.sprintf "Cleared %s to default" param_key) )
-                        ]
-                        @ effect_fields)))
-           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-             respond_json_value_with_cors ~status:`Bad_request request reqd
-               (`Assoc
-                  [
-                    ("ok", `Bool false);
-                    ("error", `String (Printexc.to_string exn));
-                  ])
+             (match
+                mutate_runtime_param_with_effects
+                  ~base_path
+                  ~param_key
+                  (fun () ->
+                    Runtime_params.clear_by_key_with_change param_key ~actor)
+              with
+              | Error msg ->
+                respond_json_value_with_cors ~status:`Bad_request request reqd
+                  (`Assoc [ "ok", `Bool false; "error", `String msg ])
+              | Ok (change, effect_fields) ->
+                Sse.broadcast
+                  (`Assoc
+                     ([ "type", `String "runtime_param_changed"
+                      ; "param_key", `String param_key
+                      ; "old_value", change.old_value
+                      ; "new_value", change.new_value
+                      ; "actor", `String actor
+                      ]
+                      @ effect_fields));
+                respond_json_value_with_cors request reqd
+                  (`Assoc
+                     ([ "ok", `Bool true
+                      ; ( "message"
+                        , `String
+                            (Printf.sprintf "Cleared %s to default" param_key) )
+                      ]
+                      @ effect_fields)))
          )
        ) request reqd)

--- a/lib/server/server_runtime_param_request.ml
+++ b/lib/server/server_runtime_param_request.ml
@@ -1,0 +1,104 @@
+(** Pure admission for dashboard runtime-parameter request bodies. *)
+
+let ( let* ) = Result.bind
+
+type set_request =
+  { param_key : string
+  ; value : Yojson.Safe.t
+  }
+
+type clear_request = { param_key : string }
+
+type error =
+  | Invalid_json of string
+  | Expected_object
+  | Missing_param_key
+  | Param_key_must_be_string
+  | Empty_param_key
+  | Param_key_has_surrounding_whitespace
+  | Duplicate_param_key
+  | Missing_value
+  | Duplicate_value
+
+type field =
+  | Absent
+  | Present of Yojson.Safe.t
+  | Duplicate
+
+let field name fields =
+  match
+    List.filter_map
+      (fun (key, value) -> if String.equal key name then Some value else None)
+      fields
+  with
+  | [] -> Absent
+  | [ value ] -> Present value
+  | _ :: _ :: _ -> Duplicate
+;;
+
+let param_key_of_fields fields =
+  match field "param_key" fields with
+  | Absent -> Error Missing_param_key
+  | Duplicate -> Error Duplicate_param_key
+  | Present (`String param_key) ->
+    let canonical = String.trim param_key in
+    if String.equal canonical ""
+    then Error Empty_param_key
+    else if not (String.equal canonical param_key)
+    then Error Param_key_has_surrounding_whitespace
+    else Ok param_key
+  | Present _ -> Error Param_key_must_be_string
+;;
+
+let decode_json decode_fields = function
+  | `Assoc fields -> decode_fields fields
+  | `Null
+  | `Bool _
+  | `Int _
+  | `Intlit _
+  | `Float _
+  | `String _
+  | `List _
+  | `Tuple _
+  | `Variant _ -> Error Expected_object
+;;
+
+let decode_body decode_fields body =
+  try decode_json decode_fields (Yojson.Safe.from_string body) with
+  | Yojson.Json_error message -> Error (Invalid_json message)
+;;
+
+let decode_set body =
+  decode_body
+    (fun fields ->
+       let* param_key = param_key_of_fields fields in
+       match field "value" fields with
+       | Absent -> Error Missing_value
+       | Duplicate -> Error Duplicate_value
+       | Present value -> Ok { param_key; value })
+    body
+;;
+
+let decode_clear body =
+  decode_body
+    (fun fields ->
+       let* param_key = param_key_of_fields fields in
+       Ok { param_key })
+    body
+;;
+
+let set_param_key (request : set_request) = request.param_key
+let set_value (request : set_request) = request.value
+let clear_param_key (request : clear_request) = request.param_key
+
+let error_message = function
+  | Invalid_json message -> "Invalid JSON: " ^ message
+  | Expected_object -> "request body must be an object"
+  | Missing_param_key | Empty_param_key -> "param_key is required"
+  | Param_key_must_be_string -> "param_key must be a string"
+  | Param_key_has_surrounding_whitespace ->
+    "param_key must not contain surrounding whitespace"
+  | Duplicate_param_key -> "duplicate param_key field"
+  | Missing_value -> "value is required"
+  | Duplicate_value -> "duplicate value field"
+;;

--- a/lib/server/server_runtime_param_request.mli
+++ b/lib/server/server_runtime_param_request.mli
@@ -1,0 +1,19 @@
+(** Current-only typed admission for dashboard runtime-parameter writes. *)
+
+type set_request
+type clear_request
+
+type error
+
+val decode_set : string -> (set_request, error) result
+(** Parse one complete set request. [param_key] and [value] must each occur
+    exactly once; the value may be any JSON value accepted by the registered
+    runtime parameter. *)
+
+val decode_clear : string -> (clear_request, error) result
+(** Parse one complete clear request. [param_key] must occur exactly once. *)
+
+val set_param_key : set_request -> string
+val set_value : set_request -> Yojson.Safe.t
+val clear_param_key : clear_request -> string
+val error_message : error -> string

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -5,6 +5,7 @@ lib/keeper/keeper_runtime_trust_snapshot_core.ml
 lib/keeper_runtime/keeper_event_queue_state.ml
 lib/config/env_config_snapshot_core.ml
 packages/agent_core/lib/llm_provider/provider_registry_state.ml
+lib/server/server_runtime_param_request.ml
 lib/schedule/schedule_domain.ml
 lib/turn_fsm/turn_fsm.ml
 lib/types/masc_domain.ml

--- a/test/test_board_context_inference_resolution.ml
+++ b/test/test_board_context_inference_resolution.ml
@@ -153,6 +153,86 @@ let test_target_resolution_implicit_unregistered_author () =
          "error message"
          "target_keeper is required because board post author \"operator\" is not a registered keeper")
 
+let expect_runtime_param_request_error ~label decode body expected =
+  match decode body with
+  | Error error ->
+    check string label expected
+      (Server_runtime_param_request.error_message error)
+  | Ok _ -> fail (Printf.sprintf "accepted invalid runtime-param request: %s" body)
+
+let test_runtime_param_request_admission () =
+  (match
+     Server_runtime_param_request.decode_set
+       {|{"param_key":"keeper.max_turns","value":12}|}
+   with
+   | Ok request ->
+     check string "set key" "keeper.max_turns"
+       (Server_runtime_param_request.set_param_key request);
+     check bool "set value" true
+       (Yojson.Safe.equal (`Int 12)
+          (Server_runtime_param_request.set_value request))
+   | Error error -> fail (Server_runtime_param_request.error_message error));
+  (match
+     Server_runtime_param_request.decode_clear
+       {|{"param_key":"keeper.max_turns"}|}
+   with
+   | Ok request ->
+     check string "clear key" "keeper.max_turns"
+       (Server_runtime_param_request.clear_param_key request)
+   | Error error -> fail (Server_runtime_param_request.error_message error));
+  (match
+     Server_runtime_param_request.decode_set
+       {|{"param_key":"feature.flag","value":null}|}
+   with
+   | Ok request ->
+     check bool "explicit null remains a present value" true
+       (Yojson.Safe.equal `Null
+          (Server_runtime_param_request.set_value request))
+   | Error error -> fail (Server_runtime_param_request.error_message error));
+  List.iter
+    (fun (label, decode, body, expected) ->
+       expect_runtime_param_request_error ~label decode body expected)
+    [ ( "object required"
+      , Server_runtime_param_request.decode_set
+      , "[]"
+      , "request body must be an object" )
+    ; ( "key required"
+      , Server_runtime_param_request.decode_set
+      , {|{"value":1}|}
+      , "param_key is required" )
+    ; ( "key type"
+      , Server_runtime_param_request.decode_set
+      , {|{"param_key":1,"value":1}|}
+      , "param_key must be a string" )
+    ; ( "blank key"
+      , Server_runtime_param_request.decode_set
+      , {|{"param_key":"  ","value":1}|}
+      , "param_key is required" )
+    ; ( "duplicate key"
+      , Server_runtime_param_request.decode_set
+      , {|{"param_key":"a","param_key":"b","value":1}|}
+      , "duplicate param_key field" )
+    ; ( "value required"
+      , Server_runtime_param_request.decode_set
+      , {|{"param_key":"keeper.max_turns"}|}
+      , "value is required" )
+    ; ( "duplicate value"
+      , Server_runtime_param_request.decode_set
+      , {|{"param_key":"keeper.max_turns","value":1,"value":2}|}
+      , "duplicate value field" )
+    ];
+  expect_runtime_param_request_error
+    ~label:"canonical clear key"
+    Server_runtime_param_request.decode_clear
+    {|{"param_key":" keeper.max_turns "}|}
+    "param_key must not contain surrounding whitespace";
+  match Server_runtime_param_request.decode_clear "{" with
+  | Error error ->
+    let message = Server_runtime_param_request.error_message error in
+    check bool "malformed JSON is classified" true
+      (String.starts_with ~prefix:"Invalid JSON:" message)
+  | Ok _ -> fail "accepted malformed runtime-param request"
+
 let test_cadence_change_wakes_only_live_sleepers_when_shortened () =
   let base_path = "/tmp/test_runtime_param_keeper_wakeup" in
   Keeper_registry.For_testing.clear ();
@@ -355,7 +435,9 @@ let () =
         ; test_case "implicit unregistered author" `Quick test_target_resolution_implicit_unregistered_author
         ] )
     ; ( "runtime_params",
-        [ test_case "cadence decrease wakes only live sleepers" `Quick
+        [ test_case "request admission is typed and strict" `Quick
+            test_runtime_param_request_admission
+        ; test_case "cadence decrease wakes only live sleepers" `Quick
             test_cadence_change_wakes_only_live_sleepers_when_shortened
         ; test_case "cadence mutation and wake are serialized" `Quick
             test_cadence_mutation_and_wake_are_serialized


### PR DESCRIPTION
## Summary
- parse dashboard runtime-parameter set and clear bodies once into typed requests
- reject malformed, duplicate, non-canonical, and missing fields before any mutation
- carry the decoded key/value to the effect shell and stop classifying unexpected defects as bad input
- register the decoder as a pure decision core

## Verification
- scripts/dune-local.sh build test/test_board_context_inference_resolution.exe
- _build/default/test/test_board_context_inference_resolution.exe (9/9)
- ocamlformat --check on changed OCaml files
- git diff --check origin/main...HEAD

## Boundary note
The existing cadence mutation/wakeup serialization remains unchanged. Removing its effect mutex safely requires a separate revisioned persistence/receipt authority change.