### PR TITLE
refactor(schedule): ledger load 를 두 probe 로 한 번에 결정 (무음 미러 복구 수정)

### DIFF
--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -204,6 +204,36 @@ let absent_primary_message path =
   Printf.sprintf "primary ledger file does not exist: %s" path
 ;;
 
+(* Probe result for the primary ledger. [Primary_absent] used to be an [if]
+   above the recovery match rather than a constructor, which split one decision
+   over two axes into two separate nested matches. The halves then drifted:
+   recovering from the mirror logged a warning when the primary was absent and
+   said nothing when the primary was corrupt — the more alarming of the two. *)
+type primary_failure =
+  | Primary_absent
+  | Primary_unparseable of string
+
+(* [read_json_result] folds file-read failure and JSON failure into one
+   [Error message], so an existing-but-broken primary surfaces as
+   [Primary_unparseable] rather than being silently swallowed. *)
+let load_primary config : (state, primary_failure) Result.t =
+  let path = schedules_path config in
+  if not (Workspace_utils.path_exists config path)
+  then Error Primary_absent
+  else (
+    match Workspace_utils.read_json_result config path with
+    | Ok json ->
+      (match state_of_yojson json with
+       | Ok state -> Ok state
+       | Error parse_err -> Error (Primary_unparseable parse_err))
+    | Error read_err -> Error (Primary_unparseable read_err))
+;;
+
+let primary_failure_message ~path = function
+  | Primary_absent -> absent_primary_message path
+  | Primary_unparseable detail -> detail
+;;
+
 (* Total load that distinguishes an uninitialised store from a corrupt one and
    from a primary removed out-of-band. [read_json_result] folds file-read failure
    and parse failure into a single [Error message], so an existing-but-broken
@@ -217,40 +247,39 @@ let absent_primary_message path =
 let load config : load_outcome =
   ensure_dirs config;
   let path = schedules_path config in
-  if not (Workspace_utils.path_exists config path) then (
-    match load_recovery config with
-    | Recovery_loaded state ->
-      (* The next [write_state] rewrites the primary from this state. The warning
-         records that the state came from the mirror, so the repair is visible
-         rather than silent. *)
-      Log.Misc.warn
-        "schedule_store: primary ledger %s does not exist; loaded %d schedules \
-         and %d wakes from recovery mirror %s"
-        path
-        (List.length state.schedules)
-        (List.length state.wakes)
-        (recovery_path config);
-      Loaded state
-    | Recovery_absent -> Fresh
-    | Recovery_unparseable recovery_err ->
-      Corrupt
-        { primary_err = absent_primary_message path
-        ; recovery_err = Some recovery_err
-        })
-  else (
-    let primary =
-      match Workspace_utils.read_json_result config path with
-      | Ok json -> state_of_yojson json
-      | Error read_err -> Error read_err
-    in
-    match primary with
-    | Ok state -> Loaded state
-    | Error primary_err ->
-      (match load_recovery config with
-       | Recovery_loaded state -> Loaded state
-       | Recovery_absent -> Corrupt { primary_err; recovery_err = None }
-       | Recovery_unparseable recovery_err ->
-         Corrupt { primary_err; recovery_err = Some recovery_err }))
+  (* The next [write_state] rewrites the primary from this state. The warning
+     records that the state came from the mirror, so the repair is visible
+     rather than silent — for either reason the primary was unusable. *)
+  let recovered_from_mirror ~primary_err state =
+    Log.Misc.warn
+      "schedule_store: %s; loaded %d schedules and %d wakes from recovery \
+       mirror %s"
+      primary_err
+      (List.length state.schedules)
+      (List.length state.wakes)
+      (recovery_path config);
+    Loaded state
+  in
+  match load_primary config with
+  | Ok state -> Loaded state
+  | Error primary ->
+    let primary_err = primary_failure_message ~path primary in
+    (* The outcome depends on both probes, so both are matched together. The
+       recovery axis is enumerated in full; the primary axis is collapsed only
+       where the answer provably does not depend on it, because [primary_err]
+       already carries the difference.
+
+       The one cell where the primary axis does decide is [Recovery_absent]:
+       no primary and no mirror is an uninitialised store ([Fresh]), while a
+       broken primary and no mirror is corruption the operator must see. *)
+    (match primary, load_recovery config with
+     | (Primary_absent | Primary_unparseable _), Recovery_loaded state ->
+       recovered_from_mirror ~primary_err state
+     | Primary_absent, Recovery_absent -> Fresh
+     | Primary_unparseable _, Recovery_absent ->
+       Corrupt { primary_err; recovery_err = None }
+     | (Primary_absent | Primary_unparseable _), Recovery_unparseable recovery_err
+       -> Corrupt { primary_err; recovery_err = Some recovery_err })
 ;;
 
 (* Read-only accessor used by [get_schedule]. [Fresh] yields the empty default,

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -576,6 +576,38 @@ let test_read_state_raises_on_corrupt () =
   | exception Schedule_store.Corrupt_ledger_exn _ -> ()
 ;;
 
+(* [load] decides over two probes — the primary ledger and its [.last-good]
+   mirror — and an absent mirror is the only recovery result whose meaning
+   depends on which way the primary failed: an uninitialised store is [Fresh],
+   a broken primary with no mirror is [Corrupt].
+
+   [corrupt_both] leaves the mirror present-but-unparseable, so neither of
+   these two inputs was covered. Collapsing the primary axis would turn the
+   second into an empty state, which is the silent-data-loss shape
+   [test_mutation_refused_and_preserves_corrupt_ledger] exists to prevent. *)
+let test_absent_mirror_separates_uninitialised_from_corrupt () =
+  with_workspace
+  @@ fun config ->
+  (match Schedule_store.read_state_result config with
+   | Ok state ->
+     check int "an uninitialised store reads as empty" 0
+       (List.length state.Schedule_store.schedules)
+   | Error error ->
+     failf
+       "an uninitialised store must not read as corrupt: %s"
+       (Schedule_store.read_error_to_string error));
+  let req = make_request () in
+  ignore (insert_ok config req);
+  Workspace_core.write_text config (schedules_path config) "{not json";
+  Workspace_core.delete_path config (recovery_path config);
+  check bool "recovery mirror removed" false
+    (Workspace_utils.path_exists config (recovery_path config));
+  match Schedule_store.read_state_result config with
+  | Ok _ -> fail "a broken primary with no mirror must not read as empty"
+  | Error (Schedule_store.Corrupt_read_ledger { recovery_err; _ }) ->
+    check (option string) "no mirror means no recovery detail" None recovery_err
+;;
+
 (* The core silent-failure-to-data-loss regression: a mutation on a corrupt
    ledger must be refused (typed [Corrupt_ledger]) and must NOT overwrite the
    present-but-corrupt files with an empty default. *)
@@ -941,6 +973,8 @@ let () =
             test_startup_recovery_refuses_corrupt_ledger;
           test_case "read_state raises on corrupt ledger" `Quick
             test_read_state_raises_on_corrupt;
+          test_case "absent mirror separates uninitialised from corrupt" `Quick
+            test_absent_mirror_separates_uninitialised_from_corrupt;
           test_case "mutation refused and corrupt ledger preserved" `Quick
             test_mutation_refused_and_preserves_corrupt_ledger;
           test_case "primary write failure is surfaced" `Quick


### PR DESCRIPTION
`schedule_store.load` 은 **두 축**으로 답을 정합니다 — primary 원장과 `.last-good` 미러. 그런데 variant 인 축이 하나뿐이라, primary 의 "부재"가 recovery match 위의 `if` 로 살아 있었습니다. 그래서 같은 결정이 분기마다 한 번씩, 총 두 번 쓰였고 **두 사본이 어긋났습니다**.

## 어긋난 지점

| recovery \ primary | 부재 | 파싱 실패 |
|---|---|---|
| `Recovery_loaded` | `Loaded` + **warn 로그** | `Loaded` — **무음** |
| `Recovery_absent` | `Fresh` | `Corrupt` |
| `Recovery_unparseable` | `Corrupt` | `Corrupt` |

primary 가 **깨져서** 미러로 복구하는 것은 primary 가 **없어서** 복구하는 것보다 최소한 같은 정도로 위험한데, 무음인 쪽이 그쪽이었습니다. 운영자는 스토어가 미러에서 수리되는 동안 아무것도 못 봅니다.

파일의 기존 주석은 두 분기가 "for the same reason" 미러를 참조한다고 적어두었는데, 보고 방식은 같지 않았습니다.

## 수정

primary probe 에 자기 variant 를 주고(`primary_failure`), 두 probe 를 **함께** 매치합니다:

```ocaml
match load_primary config with
| Ok state -> Loaded state
| Error primary ->
  let primary_err = primary_failure_message ~path primary in
  (match primary, load_recovery config with
   | (Primary_absent | Primary_unparseable _), Recovery_loaded state ->
     recovered_from_mirror ~primary_err state
   | Primary_absent, Recovery_absent -> Fresh
   | Primary_unparseable _, Recovery_absent ->
     Corrupt { primary_err; recovery_err = None }
   | (Primary_absent | Primary_unparseable _), Recovery_unparseable recovery_err ->
     Corrupt { primary_err; recovery_err = Some recovery_err })
```

- **recovery 축은 전부 열거**합니다. primary 축은 결과가 그것에 의존하지 **않음이 증명되는** 셀에서만 묶었습니다 — `primary_err` 가 이미 차이를 나릅니다.
- `Recovery_absent` 가 primary 축이 실제로 결정하는 유일한 셀이고, 이제 그게 **눈에 보이는 유일한 자리**입니다.
- 단축 평가 유지: 미러는 primary 가 상태를 못 내놓을 때만 읽습니다. 동작은 로그 외에 불변입니다.

## 테스트

`corrupt_both` 는 미러를 **존재하지만 파싱 불가** 상태로 남기므로, 다음 두 입력은 커버되지 않았습니다:

- 초기화 안 된 스토어 (primary 부재 + 미러 부재) → `Fresh`
- 깨진 primary + 미러 **부재** → `Corrupt`

이 둘이 primary 축이 가르는 쌍입니다. 새 케이스가 공개 표면(`read_state_result`)으로 고정합니다.

**대조군**: primary 축을 붕괴시키면(`Primary_unparseable _, Recovery_absent -> Fresh`)

```
FAIL a broken primary with no mirror must not read as empty
1 failure! in 2.475s. 33 tests run.
```

새 케이스만 실패하고 나머지 32개는 통과합니다.

```
dune build --root . @test/runtest-test_schedule_store   → 33 tests run, Test Successful
```

## 어떻게 찾았나

제품 전체의 variant 사용을 훑는 중에 나왔습니다 — `lib/` + `packages/` 의 `.ml`/`.mli` 3,167 파일에서 (모듈, 타입, 생성자) 10,247 쌍을 추출하고, **같은 source 생성자가 같은 타입의 서로 다른 생성자로 매핑되는** 지점을 찾았습니다. 그건 "이 생성자만으로는 답이 안 정해진다 = 두 번째 축이 있다" 는 신호이고, tuple match 후보입니다.

7건이 걸렸고 4건을 확인했습니다:

| 후보 | 판정 |
|---|---|
| `Recovery_absent -> Fresh \| Corrupt` (`schedule_store::load_outcome`) | **진짜** — 이 PR |
| `Json_read_exn -> Agent_fd_pressure \| Agent_read_error` | 정상 — `System_error_class.classify_exn` typed 술어 + 인접 arm |
| `Unsupported_construct -> Process_substitution \| Unsafe_redirect` | 정상 — payload 의 polymorphic variant 가 가름, 인접 arm |
| `Offline -> Fiber_unknown` / `Offline -> Dead` | 정상 — **타깃 타입이 다름**(fiber 생존 vs 대시보드 뱃지). 다른 질문이므로 다른 답이 맞음 |

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
