### PR TITLE
refactor(dashboard): isolate gate keeper effects

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -123,7 +123,6 @@ const LEGACY_VALIBOT_FILES = [
   'src/api/schemas/drift-error.test.ts',
   'src/api/schemas/drift-error.ts',
   'src/api/schemas/gate-connectors.ts',
-  'src/api/schemas/gate-keepers.ts',
   'src/api/schemas/gate-status.ts',
   'src/api/schemas/keeper-catchup-digest.ts',
   'src/api/schemas/keeper-chat-history.ts',

--- a/dashboard/src/api/gate-keepers.test.ts
+++ b/dashboard/src/api/gate-keepers.test.ts
@@ -1,0 +1,78 @@
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import {
+  DashboardHttp,
+  DashboardTransportError,
+  type DashboardHttpService,
+} from './effect-http'
+import {
+  fetchGateKeepers,
+  GateKeepersSchemaDriftError,
+} from './gate-keepers'
+
+const currentWire = {
+  count: 1,
+  keepers: [{
+    runtime_class: 'keeper',
+    name: 'planner',
+    meta: {
+      name: 'planner',
+      trace_id: 'trace-planner',
+      created_at: '2026-08-12T00:00:00Z',
+      updated_at: '2026-08-12T00:01:00Z',
+    },
+    agent_name: 'keeper-planner-agent',
+    status: 'running',
+    keepalive_running: true,
+    autoboot_enabled: true,
+    proactive_enabled: false,
+    runtime_id: 'runtime-planner',
+    created_at: '2026-08-12T00:00:00Z',
+    updated_at: '2026-08-12T00:01:00Z',
+  }],
+} as const
+
+function runWithHttp<A, E>(
+  program: Effect.Effect<A, E, DashboardHttp>,
+  http: DashboardHttpService,
+): Effect.Effect<A, E> {
+  return program.pipe(Effect.provideService(DashboardHttp, http))
+}
+
+describe('fetchGateKeepers', () => {
+  it('fetches and decodes unknown data at the typed endpoint boundary', () => {
+    const data = Effect.runSync(runWithHttp(fetchGateKeepers(), {
+      getUnknown: path => {
+        expect(path).toBe('/api/v1/gate/keepers?limit=50&detailed=true')
+        return Effect.succeed(currentWire)
+      },
+    }))
+
+    expect(data.keepers[0]?.name).toBe('planner')
+  })
+
+  it('preserves transport failures as typed values', () => {
+    const transportError = new DashboardTransportError({
+      method: 'GET',
+      path: '/api/v1/gate/keepers?limit=50&detailed=true',
+      message: 'offline',
+      cause: new Error('offline'),
+    })
+    const error = Effect.runSync(Effect.flip(runWithHttp(
+      fetchGateKeepers(),
+      { getUnknown: () => Effect.fail(transportError) },
+    )))
+
+    expect(error).toBe(transportError)
+  })
+
+  it('preserves schema drift as a typed endpoint error', () => {
+    const error = Effect.runSync(Effect.flip(runWithHttp(
+      fetchGateKeepers(),
+      { getUnknown: () => Effect.succeed({ count: 1, keepers: [] }) },
+    )))
+
+    expect(error).toBeInstanceOf(GateKeepersSchemaDriftError)
+  })
+})

--- a/dashboard/src/api/gate-keepers.ts
+++ b/dashboard/src/api/gate-keepers.ts
@@ -1,0 +1,39 @@
+import { Effect } from 'effect'
+
+import {
+  DashboardHttp,
+  type DashboardTransportError,
+} from './effect-http'
+import {
+  decodeGateKeepers,
+  type GateKeepersData,
+  type GateKeepersSchemaDriftError,
+} from './schemas/gate-keepers'
+
+export type {
+  GateKeeper,
+  GateKeeperDirectoryIssue,
+  GateKeepersData,
+} from './schemas/gate-keepers'
+export {
+  decodeGateKeepers,
+  GateKeepersSchemaDriftError,
+} from './schemas/gate-keepers'
+
+export type GateKeepersError =
+  | DashboardTransportError
+  | GateKeepersSchemaDriftError
+
+const GATE_KEEPERS_PATH = '/api/v1/gate/keepers?limit=50&detailed=true'
+
+export function fetchGateKeepers(): Effect.Effect<
+  GateKeepersData,
+  GateKeepersError,
+  DashboardHttp
+> {
+  return Effect.gen(function*() {
+    const http = yield* DashboardHttp
+    const raw = yield* http.getUnknown(GATE_KEEPERS_PATH)
+    return yield* decodeGateKeepers(raw)
+  })
+}

--- a/dashboard/src/api/gate.ts
+++ b/dashboard/src/api/gate.ts
@@ -7,11 +7,6 @@ import {
   type GateStatusData,
 } from './schemas/gate-status'
 import {
-  parseGateKeepersData,
-  type GateKeeperInfo,
-  type GateKeepersData,
-} from './schemas/gate-keepers'
-import {
   parseGateConnectorsData,
   type ConnectorBindingSummary,
   type ConnectorNames,
@@ -25,8 +20,6 @@ import {
 
 export type { BindingInfo, ChannelInfo, GateEventInfo, GateStatusData }
 export { GateStatusSchemaDriftError } from './schemas/gate-status'
-export type { GateKeeperInfo, GateKeepersData }
-export { GateKeepersSchemaDriftError } from './schemas/gate-keepers'
 export type {
   ConnectorBindingSummary,
   ConnectorNames,
@@ -47,9 +40,4 @@ export async function fetchGateStatus(signal?: AbortSignal): Promise<GateStatusD
 export async function fetchGateConnectors(signal?: AbortSignal): Promise<GateConnectorsData> {
   const raw = await get<unknown>('/api/v1/gate/connectors', { signal })
   return parseGateConnectorsData(raw)
-}
-
-export async function fetchGateKeepers(signal?: AbortSignal): Promise<GateKeepersData> {
-  const raw = await get<unknown>('/api/v1/gate/keepers?limit=50&detailed=true', { signal })
-  return parseGateKeepersData(raw)
 }

--- a/dashboard/src/api/schemas/gate-keepers.test.ts
+++ b/dashboard/src/api/schemas/gate-keepers.test.ts
@@ -1,80 +1,169 @@
+import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import {
   GateKeepersSchemaDriftError,
-  parseGateKeepersData,
+  decodeGateKeepers,
 } from './gate-keepers'
 
-describe('parseGateKeepersData', () => {
-  it('accepts an empty payload', () => {
-    const out = parseGateKeepersData({})
-    expect(out.count).toBe(0)
-    expect(out.keepers).toHaveLength(0)
-  })
+function keeperWire(name = 'planner') {
+  return {
+    runtime_class: 'keeper',
+    name,
+    meta: {
+      name,
+      trace_id: `trace-${name}`,
+      created_at: '2026-08-12T00:00:00Z',
+      updated_at: '2026-08-12T00:01:00Z',
+    },
+    agent_name: `keeper-${name}-agent`,
+    status: 'running',
+    keepalive_running: true,
+    autoboot_enabled: true,
+    proactive_enabled: false,
+    runtime_id: `runtime-${name}`,
+    created_at: '2026-08-12T00:00:00Z',
+    updated_at: '2026-08-12T00:01:00Z',
+  }
+}
 
-  it('accepts a minimal keeper with only name', () => {
-    const out = parseGateKeepersData({
+function issueWire(name = 'broken') {
+  return {
+    status: 'error',
+    runtime_class: 'keeper',
+    name,
+    keepalive_running: false,
+    effective_meta_error: {
+      keeper: name,
+      message: 'invalid keeper config',
+      terminal_reason: 'effective_meta_read_failed',
+      severity: 'error',
+      operator_action_required: true,
+      next_action: 'fix_keeper_toml_or_keeper_instructions',
+    },
+    meta: null,
+    agent_name: null,
+    created_at: null,
+    updated_at: null,
+  }
+}
+
+function expectDrift(value: unknown): GateKeepersSchemaDriftError {
+  const error = Effect.runSync(Effect.flip(decodeGateKeepers(value)))
+  expect(error).toBeInstanceOf(GateKeepersSchemaDriftError)
+  expect(error.message).toContain('gate-keepers schema drift')
+  return error
+}
+
+describe('decodeGateKeepers', () => {
+  it('decodes the current detailed wire shape into concrete product values', () => {
+    const data = Effect.runSync(decodeGateKeepers({
       count: 1,
-      keepers: [{ name: 'greeter' }],
+      keepers: [keeperWire()],
+    }))
+
+    expect(data).toEqual({
+      keepers: [{
+        name: 'planner',
+        runtimeLabel: 'keeper-planner-agent',
+        status: 'running',
+      }],
+      directoryIssues: [],
     })
-    expect(out.keepers).toHaveLength(1)
-    expect(out.keepers[0]!.name).toBe('greeter')
-    expect(out.keepers[0]!.status).toBeUndefined()
-    // last_turn_ago_s collapses absent → null (matches prior decoder);
-    // downstream renders '—' uniformly whether the field is absent or
-    // explicitly null.
-    expect(out.keepers[0]!.last_turn_ago_s).toBeNull()
   })
 
-  it('preserves explicit null last_turn_ago_s separate from absent', () => {
-    const out = parseGateKeepersData({
-      count: 1,
-      keepers: [{ name: 'cold-start', last_turn_ago_s: null }],
-    })
-    expect(out.keepers[0]!.last_turn_ago_s).toBeNull()
-  })
-
-  it('parses a populated keeper with all metadata', () => {
-    const out = parseGateKeepersData({
-      count: 1,
-      keepers: [
-        {
-          name: 'planner',
-          agent_name: 'planner',
-          status: 'running',
-          model: 'claude-opus',
-          active_model: 'claude-opus',
-          primary_model: 'claude-opus',
-          keepalive_running: true,
-          last_turn_ago_s: 42,
-        },
-      ],
-    })
-    expect(out.keepers[0]!.keepalive_running).toBe(true)
-    expect(out.keepers[0]!.last_turn_ago_s).toBe(42)
-  })
-
-  it('drops entries without name (lenient-per-entry)', () => {
-    const out = parseGateKeepersData({
+  it('separates producer-declared error rows from usable keepers once', () => {
+    const data = Effect.runSync(decodeGateKeepers({
       count: 2,
-      keepers: [{ name: 'greeter' }, { status: 'orphan' }],
+      keepers: [keeperWire(), issueWire()],
+    }))
+
+    expect(data.keepers.map(keeper => keeper.name)).toEqual(['planner'])
+    expect(data.directoryIssues).toEqual([{
+      keeperName: 'broken',
+      message: 'invalid keeper config',
+    }])
+  })
+
+  it('accepts a directory issue that retains persisted keeper metadata', () => {
+    const row = issueWire('broken')
+    const meta = keeperWire('broken').meta
+    const data = Effect.runSync(decodeGateKeepers({
+      count: 1,
+      keepers: [{
+        ...row,
+        meta,
+        agent_name: 'keeper-broken-agent',
+        created_at: meta.created_at,
+        updated_at: meta.updated_at,
+        autoboot_enabled: false,
+        proactive_enabled: false,
+      }],
+    }))
+
+    expect(data).toEqual({
+      keepers: [],
+      directoryIssues: [{
+        keeperName: 'broken',
+        message: 'invalid keeper config',
+      }],
     })
-    expect(out.keepers).toHaveLength(1)
-    expect(out.keepers[0]!.name).toBe('greeter')
   })
 
-  it('tolerates non-array keepers field by returning empty list', () => {
-    const out = parseGateKeepersData({ count: 0, keepers: null })
-    expect(out.keepers).toHaveLength(0)
+  it('resolves an identical runtime identity to an empty display label once', () => {
+    const row = keeperWire('planner')
+    const data = Effect.runSync(decodeGateKeepers({
+      count: 1,
+      keepers: [{ ...row, agent_name: row.name }],
+    }))
+
+    expect(data.keepers[0]?.runtimeLabel).toBe('')
   })
 
-  it('defaults count to 0 when backend omits it', () => {
-    const out = parseGateKeepersData({ keepers: [{ name: 'k1' }] })
-    expect(out.count).toBe(0)
+  it('accepts an explicit empty directory', () => {
+    expect(Effect.runSync(decodeGateKeepers({ count: 0, keepers: [] })))
+      .toEqual({ keepers: [], directoryIssues: [] })
   })
 
-  it('throws on non-object payload', () => {
-    expect(() => parseGateKeepersData(null)).toThrow(GateKeepersSchemaDriftError)
-    expect(() => parseGateKeepersData('oops')).toThrow(GateKeepersSchemaDriftError)
+  it.each([
+    ['missing outer fields', {}],
+    ['non-object payload', null],
+    ['malformed row', { count: 1, keepers: [{ name: 'orphan' }] }],
+    ['excess row property', {
+      count: 1,
+      keepers: [{ ...keeperWire(), unexpected: true }],
+    }],
+  ])('rejects %s instead of defaulting or dropping data', (_name, value) => {
+    expectDrift(value)
+  })
+
+  it('rejects a count that disagrees with the returned rows', () => {
+    const error = expectDrift({ count: 2, keepers: [keeperWire()] })
+    expect(error.message).toContain('count')
+    expect(error.message).toContain('keepers.length')
+  })
+
+  it('rejects identity disagreement inside a row', () => {
+    const row = keeperWire()
+    const error = expectDrift({
+      count: 1,
+      keepers: [{ ...row, meta: { ...row.meta, name: 'other' } }],
+    })
+    expect(error.message).toContain('keepers.0.meta.name')
+  })
+
+  it('rejects an error envelope attributed to another keeper', () => {
+    const row = issueWire()
+    const error = expectDrift({
+      count: 1,
+      keepers: [{
+        ...row,
+        effective_meta_error: {
+          ...row.effective_meta_error,
+          keeper: 'other',
+        },
+      }],
+    })
+    expect(error.message).toContain('effective_meta_error.keeper')
   })
 })

--- a/dashboard/src/api/schemas/gate-keepers.ts
+++ b/dashboard/src/api/schemas/gate-keepers.ts
@@ -1,73 +1,217 @@
-// Gate keepers schema — schema-at-boundary for
-// `GET /api/v1/gate/keepers`.
-//
-// `name` is the only required field per-entry — matches the prior
-// decoder's `if (!name) return null` guard. Every other attribute is
-// optional because the backend probes them lazily and a keeper with
-// only name + status should still render as "exists but metadata
-// pending" rather than drop off the list.
-//
-// Outer shape is strict-with-fallbacks; per-entry is lenient (bad
-// rows drop silently so one corrupt keeper never blanks the whole
-// list). Same pattern as #7768 gate-status and #7746 logs.
-//
-// Uses the shared `SchemaDriftError` base landed in #7732.
+import { Data, Effect, ParseResult, Schema } from 'effect'
 
-import {
-  boolean,
-  fallback,
-  nullable,
-  number,
-  object,
-  optional,
-  safeParse,
-  string,
-  unknown,
-  type BaseIssue,
-  type InferOutput,
-} from 'valibot'
-
-import { SchemaDriftError, parseOrThrow } from './drift-error'
-
-const GateKeeperInfoSchema = object({
-  name: string(),
-  agent_name: optional(string()),
-  status: optional(string()),
-  model: optional(string()),
-  active_model: optional(string()),
-  primary_model: optional(string()),
-  keepalive_running: optional(boolean()),
-  // Original decoder: `asNumber(raw.last_turn_ago_s) ?? null`. Absent
-  // field collapses to `null` (never `undefined`) so downstream renders
-  // '—' uniformly.
-  last_turn_ago_s: fallback(nullable(number()), null),
+const KeeperMetaWireSchema = Schema.Struct({
+  name: Schema.NonEmptyString,
+  trace_id: Schema.NonEmptyString,
+  created_at: Schema.NonEmptyString,
+  updated_at: Schema.NonEmptyString,
 })
 
-export type GateKeeperInfo = InferOutput<typeof GateKeeperInfoSchema>
-
-const GateKeepersOuterSchema = object({
-  count: fallback(number(), 0),
-  keepers: optional(unknown()),
+const GateKeeperWireSchema = Schema.Struct({
+  runtime_class: Schema.Literal('keeper'),
+  name: Schema.NonEmptyString,
+  meta: KeeperMetaWireSchema,
+  agent_name: Schema.NonEmptyString,
+  status: Schema.NonEmptyString,
+  keepalive_running: Schema.Boolean,
+  autoboot_enabled: Schema.Boolean,
+  proactive_enabled: Schema.Boolean,
+  runtime_id: Schema.NonEmptyString,
+  created_at: Schema.NonEmptyString,
+  updated_at: Schema.NonEmptyString,
 })
+
+const GateKeeperDirectoryIssueWireSchema = Schema.Struct({
+  keeper: Schema.NonEmptyString,
+  message: Schema.NonEmptyString,
+  terminal_reason: Schema.Literal('effective_meta_read_failed'),
+  severity: Schema.Literal('error'),
+  operator_action_required: Schema.Literal(true),
+  next_action: Schema.Literal('fix_keeper_toml_or_keeper_instructions'),
+})
+
+const GateKeeperIssueBaseWireSchema = Schema.Struct({
+  status: Schema.Literal('error'),
+  runtime_class: Schema.Literal('keeper'),
+  name: Schema.NonEmptyString,
+  keepalive_running: Schema.Boolean,
+  effective_meta_error: GateKeeperDirectoryIssueWireSchema,
+})
+
+const GateKeeperIssueWithMetaWireSchema = Schema.extend(
+  GateKeeperIssueBaseWireSchema,
+  Schema.Struct({
+    meta: KeeperMetaWireSchema,
+    agent_name: Schema.NonEmptyString,
+    created_at: Schema.NonEmptyString,
+    updated_at: Schema.NonEmptyString,
+    autoboot_enabled: Schema.Boolean,
+    proactive_enabled: Schema.Boolean,
+  }),
+)
+
+const GateKeeperIssueWithoutMetaWireSchema = Schema.extend(
+  GateKeeperIssueBaseWireSchema,
+  Schema.Struct({
+    meta: Schema.Null,
+    agent_name: Schema.Null,
+    created_at: Schema.Null,
+    updated_at: Schema.Null,
+  }),
+)
+
+const GateKeeperEntryWireSchema = Schema.Union(
+  GateKeeperWireSchema,
+  GateKeeperIssueWithMetaWireSchema,
+  GateKeeperIssueWithoutMetaWireSchema,
+)
+
+const GateKeepersWireSchema = Schema.Struct({
+  count: Schema.NonNegativeInt,
+  keepers: Schema.Array(GateKeeperEntryWireSchema),
+})
+
+type GateKeeperEntryWire = Schema.Schema.Type<
+  typeof GateKeeperEntryWireSchema
+>
+type GateKeepersWire = Schema.Schema.Type<typeof GateKeepersWireSchema>
+
+function gateKeepersInvariantIssues(data: GateKeepersWire) {
+  const issues: Array<{
+    readonly path: ReadonlyArray<PropertyKey>
+    readonly message: string
+  }> = []
+
+  if (data.count !== data.keepers.length) {
+    issues.push({
+      path: ['count'],
+      message: 'must equal keepers.length',
+    })
+  }
+
+  const seenNames = new Set<string>()
+  for (const [index, keeper] of data.keepers.entries()) {
+    if (seenNames.has(keeper.name)) {
+      issues.push({
+        path: ['keepers', index, 'name'],
+        message: 'must be unique',
+      })
+    }
+    seenNames.add(keeper.name)
+
+    if ('effective_meta_error' in keeper) {
+      if (keeper.effective_meta_error.keeper !== keeper.name) {
+        issues.push({
+          path: ['keepers', index, 'effective_meta_error', 'keeper'],
+          message: 'must match the row name',
+        })
+      }
+      if (keeper.meta !== null && keeper.meta.name !== keeper.name) {
+        issues.push({
+          path: ['keepers', index, 'meta', 'name'],
+          message: 'must match the row name',
+        })
+      }
+    } else if (keeper.meta.name !== keeper.name) {
+      issues.push({
+        path: ['keepers', index, 'meta', 'name'],
+        message: 'must match the row name',
+      })
+    }
+  }
+
+  return issues
+}
+
+const GateKeepersValidatedWireSchema = GateKeepersWireSchema.pipe(
+  Schema.filter(gateKeepersInvariantIssues),
+)
+
+export interface GateKeeper {
+  readonly name: string
+  readonly runtimeLabel: string
+  readonly status: string
+}
+
+export interface GateKeeperDirectoryIssue {
+  readonly keeperName: string
+  readonly message: string
+}
 
 export interface GateKeepersData {
-  count: number
-  keepers: GateKeeperInfo[]
+  readonly keepers: readonly GateKeeper[]
+  readonly directoryIssues: readonly GateKeeperDirectoryIssue[]
 }
 
-export class GateKeepersSchemaDriftError extends SchemaDriftError {
-  constructor(issues: readonly BaseIssue<unknown>[]) {
-    super('gate-keepers', issues)
+export class GateKeepersSchemaDriftError extends Data.TaggedError(
+  'GateKeepersSchemaDriftError',
+)<{
+  readonly domain: 'gate-keepers'
+  readonly issues: ReadonlyArray<ParseResult.ArrayFormatterIssue>
+  readonly message: string
+}> {}
+
+function schemaDriftError(
+  error: ParseResult.ParseError,
+): GateKeepersSchemaDriftError {
+  const issues = ParseResult.ArrayFormatter.formatErrorSync(error)
+  const details = issues
+    .map(issue => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '<root>'
+      return `${path}: ${issue.message}`
+    })
+    .join('; ')
+  return new GateKeepersSchemaDriftError({
+    domain: 'gate-keepers',
+    issues,
+    message: `gate-keepers schema drift: ${details}`,
+  })
+}
+
+function isDirectoryIssue(
+  entry: GateKeeperEntryWire,
+): entry is Extract<GateKeeperEntryWire, { readonly status: 'error' }> {
+  return 'effective_meta_error' in entry
+}
+
+function toGateKeepersData(wire: GateKeepersWire): GateKeepersData {
+  const keepers: GateKeeper[] = []
+  const directoryIssues: GateKeeperDirectoryIssue[] = []
+
+  for (const entry of wire.keepers) {
+    if (isDirectoryIssue(entry)) {
+      directoryIssues.push({
+        keeperName: entry.name,
+        message: entry.effective_meta_error.message,
+      })
+    } else {
+      keepers.push({
+        name: entry.name,
+        runtimeLabel: entry.agent_name === entry.name ? '' : entry.agent_name,
+        status: entry.status,
+      })
+    }
+  }
+
+  return {
+    keepers,
+    directoryIssues,
   }
 }
 
-export function parseGateKeepersData(data: unknown): GateKeepersData {
-  const outer = parseOrThrow(GateKeepersSchemaDriftError, GateKeepersOuterSchema, data)
-  const rawEntries = Array.isArray(outer.keepers) ? outer.keepers : []
-  const keepers: GateKeeperInfo[] = []
-  for (const raw of rawEntries) {
-    const parsed = safeParse(GateKeeperInfoSchema, raw, { abortEarly: true })
-    if (parsed.success) keepers.push(parsed.output)
-  }
-  return { count: outer.count, keepers }
+const STRICT_PARSE_OPTIONS = {
+  errors: 'all',
+  onExcessProperty: 'error',
+} as const
+
+export function decodeGateKeepers(
+  data: unknown,
+): Effect.Effect<GateKeepersData, GateKeepersSchemaDriftError> {
+  return Schema.decodeUnknown(
+    GateKeepersValidatedWireSchema,
+    STRICT_PARSE_OPTIONS,
+  )(data).pipe(
+    Effect.map(toGateKeepersData),
+    Effect.mapError(schemaDriftError),
+  )
 }

--- a/dashboard/src/components/connector-keeper-matrix.test.ts
+++ b/dashboard/src/components/connector-keeper-matrix.test.ts
@@ -11,7 +11,7 @@ import {
   type MatrixRow,
 } from './connector-keeper-matrix'
 import type { GateConnectorInfo } from '../api/gate'
-import type { GateKeeperInfo } from '../api/schemas/gate-keepers'
+import type { GateKeeper } from '../api/gate-keepers'
 
 const mkConnector = (id: string, overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo => ({
   connector_id: id,
@@ -24,8 +24,11 @@ const mkConnector = (id: string, overrides: Partial<GateConnectorInfo> = {}): Ga
   ...(overrides as object),
 }) as GateConnectorInfo
 
-const mkKeeper = (name: string): GateKeeperInfo =>
-  ({ name }) as GateKeeperInfo
+const mkKeeper = (name: string): GateKeeper => ({
+  name,
+  runtimeLabel: '',
+  status: 'idle',
+})
 
 describe('deriveMatrix', () => {
   it('returns 4 columns in known order', () => {

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -18,7 +18,7 @@
 
 import { html } from 'htm/preact'
 import type { GateConnectorInfo } from '../api/gate'
-import type { GateKeeperInfo } from '../api/schemas/gate-keepers'
+import type { GateKeeper } from '../api/gate-keepers'
 import {
   CONNECTOR_DISPLAY_NAMES,
   KNOWN_CONNECTOR_IDS,
@@ -94,7 +94,7 @@ function findConnector(connectors: GateConnectorInfo[], id: string): GateConnect
 /** Derive the matrix from connectors + keepers. Pure, unit-testable. */
 export function deriveMatrix(
   connectors: GateConnectorInfo[],
-  keepers: GateKeeperInfo[],
+  keepers: readonly GateKeeper[],
 ): MatrixData {
   const columns: KnownConnectorId[] = [...KNOWN_CONNECTOR_IDS]
   const knownKeeperNames = new Set(keepers.map(k => k.name))

--- a/dashboard/src/components/connector-quick-bind.test.ts
+++ b/dashboard/src/components/connector-quick-bind.test.ts
@@ -7,9 +7,13 @@ import {
   resetQuickBindState,
   channelIdPlaceholder,
 } from './connector-quick-bind'
-import type { GateKeeperInfo } from '../api/gate'
+import type { GateKeeper } from '../api/gate-keepers'
 
-const mkKeeper = (name: string): GateKeeperInfo => ({ name } as GateKeeperInfo)
+const mkKeeper = (name: string): GateKeeper => ({
+  name,
+  runtimeLabel: '',
+  status: 'idle',
+})
 
 const flushUi = async () => {
   for (let i = 0; i < 4; i++) await Promise.resolve()

--- a/dashboard/src/components/connector-quick-bind.ts
+++ b/dashboard/src/components/connector-quick-bind.ts
@@ -11,7 +11,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import type { GateKeeperInfo } from '../api/gate'
+import type { GateKeeper } from '../api/gate-keepers'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { Select } from './common/select'
@@ -26,7 +26,7 @@ interface FormEntry {
 
 const formState = signal<Record<string, FormEntry>>({})
 
-function getEntry(connectorId: string, keepers: GateKeeperInfo[]): FormEntry {
+function getEntry(connectorId: string, keepers: readonly GateKeeper[]): FormEntry {
   const existing = formState.value[connectorId]
   if (existing) return existing
   const firstKeeper = keepers[0]?.name ?? ''
@@ -87,7 +87,7 @@ async function submit(connectorId: string, entry: FormEntry) {
 
 export function QuickBindForm({ connectorId, keepers }: {
   connectorId: string
-  keepers: GateKeeperInfo[]
+  keepers: readonly GateKeeper[]
 }) {
   if (keepers.length === 0) return null
   const entry = getEntry(connectorId, keepers)

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { signal } from '@preact/signals'
+import { Effect } from 'effect'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // 90s window absorbs cold-build transform overhead (observed 60-140s on
@@ -163,23 +164,19 @@ function sampleConnectorsResponse(overrides?: Partial<Record<string, unknown>>) 
 
 function sampleKeepersResponse(overrides?: Partial<Record<string, unknown>>) {
   return {
-    count: 2,
     keepers: [
       {
         name: 'luna',
-        agent_name: 'keeper-luna-agent',
+        runtimeLabel: 'keeper-luna-agent',
         status: 'idle',
-        model: 'glm-5',
-        keepalive_running: true,
       },
       {
         name: 'nova',
-        agent_name: 'keeper-nova-agent',
+        runtimeLabel: 'keeper-nova-agent',
         status: 'busy',
-        model: 'gemini-3-flash-preview',
-        keepalive_running: true,
       },
     ],
+    directoryIssues: [],
     ...overrides,
   }
 }
@@ -206,7 +203,9 @@ async function loadComponentWithApi(api: {
   vi.doMock('../api/gate', () => ({
     fetchGateStatus: api.fetchGateStatus,
     fetchGateConnectors: api.fetchGateConnectors,
-    fetchGateKeepers: api.fetchGateKeepers,
+  }))
+  vi.doMock('../api/gate-keepers', () => ({
+    fetchGateKeepers: () => Effect.promise(api.fetchGateKeepers),
   }))
   vi.doMock('../sse', () => ({
     lastEvent: api.lastEvent,
@@ -242,6 +241,7 @@ describe('ConnectorStatusPanel', () => {
     vi.clearAllMocks()
     vi.doUnmock('../api/core')
     vi.doUnmock('../api/gate')
+    vi.doUnmock('../api/gate-keepers')
     vi.doUnmock('../sse')
     vi.doUnmock('./common/toast')
   })
@@ -501,8 +501,8 @@ describe('ConnectorStatusPanel', () => {
     expect(text).toContain('stale')
     expect(text).toContain('메트릭 없음')
     expect(text).toContain('connector runtime은 등록됐으나 게이트가 관찰한 트래픽은 아직 없습니다')
-    expect(text).toContain('keeper 디렉토리 사용 불가, 수동 입력만 가능')
-    expect(text).toContain('Next: 지금은 수동 입력으로 진행')
+    expect(text).toContain('GET /api/v1/gate/keepers: 401 Unauthorized')
+    expect(text).toContain('Next: 정상 keeper만 사용')
     expect(text).toContain('config/keepers/')
     expect(text).toContain('/api/v1/gate/keepers')
 
@@ -516,7 +516,33 @@ describe('ConnectorStatusPanel', () => {
     expect(dirPanel!.className).toContain('border-l-[var(--color-warn)]')
     // Named chip: "Directory error" is what AT hears.
     const dirChip = dirPanel!.querySelector('[aria-label]')
-    expect(dirChip?.getAttribute('aria-label')).toContain('사용 불가')
+    expect(dirChip?.getAttribute('aria-label')).toContain('오류 감지')
+  })
+
+  it('surfaces directory issues without mixing broken rows into usable keepers', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse())
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse({
+      directoryIssues: [{
+        keeperName: 'broken',
+        message: 'invalid keeper config',
+      }],
+    }))
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+    expect(text).toContain('broken: invalid keeper config')
+    expect(container.querySelector('[data-keeper="broken"]')).toBeNull()
+    expect(container.querySelector('[data-keeper="luna"]')).not.toBeNull()
   })
 
   it('pairs connector API failures with a browser/server next action', async () => {
@@ -941,7 +967,10 @@ describe('ConnectorStatusPanel', () => {
         configured_bindings: [],
       }],
     }))
-    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue({ count: 0, keepers: [] })
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue({
+      keepers: [],
+      directoryIssues: [],
+    })
 
     const { ConnectorStatusPanel } = await loadComponentWithApi({
       fetchGateStatus,
@@ -1018,8 +1047,6 @@ describe('ConnectorStatusPanel', () => {
     expect(novaGroup).not.toBeNull()
     const novaText = novaGroup!.textContent ?? ''
     expect(novaText).toContain('status busy')
-    expect(novaText).not.toContain('gemini-3-flash-preview')
-    expect(novaText).not.toContain('model ')
     expect(novaText).toContain('runtime keeper-nova-agent')
   })
 
@@ -1045,16 +1072,14 @@ describe('ConnectorStatusPanel', () => {
 
 describe('filterKeeperGroups', () => {
   // Shape-compatible sample. `filterKeeperGroups` only reads `name` and
-  // `keeper.agent_name` so bindings
+  // `keeper.runtimeLabel` so bindings
   // are allowed to be empty and `unknown` never matters.
   type GroupLike = {
     name: string
     keeper: {
       name: string
-      active_model?: string
-      model?: string
-      primary_model?: string
-      agent_name?: string
+      runtimeLabel: string
+      status: string
     } | null
     bindings: Array<{ channel_id: string; keeper_name: string }>
     unknown: boolean
@@ -1062,7 +1087,11 @@ describe('filterKeeperGroups', () => {
 
   function group(
     name: string,
-    keeper: GroupLike['keeper'] = { name },
+    keeper: GroupLike['keeper'] = {
+      name,
+      runtimeLabel: '',
+      status: 'idle',
+    },
   ): GroupLike {
     return { name, keeper, bindings: [], unknown: false }
   }
@@ -1098,44 +1127,20 @@ describe('filterKeeperGroups', () => {
     expect(filtered[0]!.name).toBe('Nova')
   })
 
-  it('does not match on active_model via substring', async () => {
+  it('matches on the resolved runtime label', async () => {
     const filterKeeperGroups = await loadFilter()
     const rows = [
-      group('nova', { name: 'nova', active_model: 'gemini-3-flash-preview' }),
-      group('luna', { name: 'luna', active_model: 'claude-opus' }),
-    ]
-    const filtered = filterKeeperGroups(rows, 'gemini')
-    expect(filtered).toHaveLength(0)
-  })
-
-  it('does not fall back from active_model to model', async () => {
-    const filterKeeperGroups = await loadFilter()
-    const rows = [
-      group('nova', { name: 'nova', active_model: '   ', model: 'gemini-flash' }),
-    ]
-    const filtered = filterKeeperGroups(rows, 'gemini')
-    expect(filtered).toHaveLength(0)
-  })
-
-  it('matches on agent_name runtime label when distinct from keeper name', async () => {
-    const filterKeeperGroups = await loadFilter()
-    const rows = [
-      group('nova', { name: 'nova', agent_name: 'keeper-nova-agent' }),
+      group('nova', { name: 'nova', runtimeLabel: 'keeper-nova-agent', status: 'idle' }),
     ]
     expect(filterKeeperGroups(rows, 'keeper-nova-agent')).toHaveLength(1)
   })
 
-  it('does not match agent_name when it equals the keeper name', async () => {
-    // Runtime label helper returns '' when agent_name === name, so the
-    // query should not match via the runtime field. It still matches on
-    // the name field itself.
+  it('does not reopen the wire identity after the runtime label is resolved', async () => {
     const filterKeeperGroups = await loadFilter()
-    const rows = [group('nova', { name: 'nova', agent_name: 'nova' })]
+    const rows = [group('nova', { name: 'nova', runtimeLabel: '', status: 'idle' })]
     expect(filterKeeperGroups(rows, 'nova')).toHaveLength(1)
-    // But a query targeting only the runtime label must miss when no
-    // fields contain it.
     const onlyRuntime = [
-      group('nova', { name: 'nova', agent_name: 'nova' }),
+      group('nova', { name: 'nova', runtimeLabel: '', status: 'idle' }),
     ]
     expect(filterKeeperGroups(onlyRuntime, 'keeper-nova-agent')).toEqual([])
   })
@@ -1183,6 +1188,7 @@ describe('ConnectorStatusPanel v2 surface layout', () => {
     vi.clearAllMocks()
     vi.doUnmock('../api/core')
     vi.doUnmock('../api/gate')
+    vi.doUnmock('../api/gate-keepers')
     vi.doUnmock('../sse')
     vi.doUnmock('./common/toast')
   })

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -10,7 +10,6 @@ import { post } from '../api/core'
 import { DEFAULT_MASC_ORIGIN } from '../config/constants'
 import {
   fetchGateConnectors,
-  fetchGateKeepers,
   fetchGateStatus,
   type BindingInfo,
   type ChannelInfo,
@@ -19,9 +18,13 @@ import {
   type GateConnectorInfo,
   type GateConnectorsData,
   type GateEventInfo,
-  type GateKeeperInfo,
   type GateStatusData,
 } from '../api/gate'
+import {
+  fetchGateKeepers,
+  type GateKeeper,
+} from '../api/gate-keepers'
+import { dashboardRuntime } from '../api/effect-http'
 import {
   KNOWN_CONNECTOR_IDS,
   IN_PROCESS_CONNECTOR_ENV,
@@ -158,7 +161,7 @@ function patchConnectorUiState(connectorId: string, patch: Partial<ConnectorUiSt
  * Pure filter for keeper groups rendered in the "Keeper-first" panel.
  *
  * Case-insensitive substring match on `group.name` and the keeper's
- * resolved runtime label (agent_name when distinct from
+ * resolved runtime label when distinct from
  * name). Operators on a crowded connector can locate a keeper by
  * partial name or by its runtime agent.
  *
@@ -177,7 +180,7 @@ export function filterKeeperGroups(
   if (needle === '') return groups
   return groups.filter(group => {
     if (group.name.toLowerCase().includes(needle)) return true
-    const runtime = runtimeLabelForKeeper(group.keeper).toLowerCase()
+    const runtime = group.keeper?.runtimeLabel.toLowerCase() ?? ''
     if (runtime !== '' && runtime.includes(needle)) return true
     return false
   })
@@ -186,7 +189,7 @@ export function filterKeeperGroups(
 type ConnectorStatusSnapshot = {
   gate: GateStatusData | null
   connectors: GateConnectorsData | null
-  keepers: GateKeeperInfo[]
+  keepers: readonly GateKeeper[]
   gateError: string | null
   connectorError: string | null
   keeperError: string | null
@@ -217,7 +220,7 @@ async function refresh() {
     const [gateResult, connResult, keeperResult] = await Promise.allSettled([
       fetchGateStatus(signal),
       fetchGateConnectors(signal),
-      fetchGateKeepers(signal),
+      dashboardRuntime.runPromise(fetchGateKeepers(), { signal }),
     ])
 
     if (gateResult.status === 'fulfilled') {
@@ -233,7 +236,12 @@ async function refresh() {
     }
 
     if (keeperResult.status === 'fulfilled') {
-      next.keepers = keeperResult.value.keepers ?? []
+      next.keepers = keeperResult.value.keepers
+      next.keeperError = keeperResult.value.directoryIssues.length === 0
+        ? null
+        : keeperResult.value.directoryIssues
+            .map(issue => `${issue.keeperName}: ${issue.message}`)
+            .join('; ')
     } else {
       next.keepers = []
       next.keeperError = keeperResult.reason instanceof Error ? keeperResult.reason.message : 'fetch failed'
@@ -334,12 +342,6 @@ function uniqueStrings(values: string[]): string[] {
     ordered.push(trimmed)
   })
   return ordered
-}
-
-function runtimeLabelForKeeper(keeper: GateKeeperInfo | null | undefined): string {
-  const runtime = keeper?.agent_name?.trim()
-  if (!runtime || runtime === keeper?.name) return ''
-  return runtime
 }
 
 function findKnownConnector(connectors: GateConnectorInfo[], connectorId: KnownConnectorId): GateConnectorInfo | null {
@@ -590,7 +592,7 @@ async function unbindConnector(connectorId: string, channelId: string) {
 
 type KeeperGroup = {
   name: string
-  keeper: GateKeeperInfo | null
+  keeper: GateKeeper | null
   bindings: Array<{ channel_id: string; keeper_name: string }>
   unknown: boolean
 }
@@ -607,7 +609,7 @@ function ConnectorLivePanel({
 }: {
   connector: GateConnectorInfo | null
   gate: GateStatusData | null
-  keepers: GateKeeperInfo[]
+  keepers: readonly GateKeeper[]
   connectorError: string | null
   keeperDirectoryError: string | null
   loading: boolean
@@ -916,7 +918,7 @@ function ConnectorLivePanel({
         : null}
       <${ConnectorConfigForm} connectorId=${connectorId} />
 
-      ${keeperDirectoryError && keepers.length === 0
+      ${keeperDirectoryError
         ? html`
             <${SurfaceCard}
               class="mt-3 !border-[var(--warn-20)] !border-l-4 !border-l-[var(--color-warn)] !bg-[var(--warn-10)] !px-3 !py-2 text-2xs text-[var(--color-status-warn)]"
@@ -924,7 +926,7 @@ function ConnectorLivePanel({
             >
               <span
                 class="mr-2 inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-status-warn)]"
-                aria-label="키퍼 디렉토리 상태: 사용 불가"
+                aria-label="키퍼 디렉토리 상태: 오류 감지"
               >
                 <span aria-hidden="true">⚠</span>
                 <span>디렉토리 오류</span>
@@ -933,10 +935,10 @@ function ConnectorLivePanel({
                 ? html`<span class="text-3xs text-[var(--color-fg-disabled)]">checked ${timeAgo(connector.gate_health_checked_at)}</span>`
                 : null}
               <div class="mt-1">
-                <${BoldLabel}>Cause: </${BoldLabel}> keeper 디렉토리 사용 불가, 수동 입력만 가능.
+                <${BoldLabel}>Cause: </${BoldLabel}> ${keeperDirectoryError}
               </div>
               <div class="mt-1">
-                <${BoldLabel}>Next: </${BoldLabel}> 지금은 수동 입력으로 진행, 이후 <${Tk}>config/keepers/<//> 복원 또는 <${Tk}>/api/v1/gate/keepers<//> 수정 후 디렉토리 추천에 의존하세요.
+                <${BoldLabel}>Next: </${BoldLabel}> 정상 keeper만 사용하고 <${Tk}>config/keepers/<//> 또는 <${Tk}>/api/v1/gate/keepers<//> 계약 오류를 수정하세요.
               </div>
             </${SurfaceCard}>
           `
@@ -1129,7 +1131,7 @@ function ConnectorLivePanel({
                         ? html`
                             <div class="text-3xs text-[var(--color-fg-disabled)]">
                               status ${keeper.status || 'unknown'}
-                              ${runtimeLabelForKeeper(keeper) ? ` · runtime ${runtimeLabelForKeeper(keeper)}` : ''}
+                              ${keeper.runtimeLabel === '' ? '' : ` · runtime ${keeper.runtimeLabel}`}
                             </div>
                           `
                         : null}

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -24,7 +24,7 @@ import {
   CompositeSchemaDriftError,
   type KeeperCompositeSnapshot,
 } from '../api/schemas/keeper-composite'
-import type { GateKeepersData } from '../api/gate'
+import type { GateKeepersData } from '../api/gate-keepers'
 import { normalizeKeepers } from '../keeper-store-normalize'
 import {
   isCompositeFetchNotFound,
@@ -100,22 +100,21 @@ const REAL_COMPOSITE_PAYLOAD = {
   last_outcome: null,
 }
 
-/** Server-shaped gate keepers response. */
+/** Decoded gate keeper product values consumed by FsmHub. */
 const REAL_GATE_KEEPERS_SHAPE: GateKeepersData = {
-  count: 5,
   keepers: [
-    { name: 'analyst', status: 'busy', last_turn_ago_s: null },
-    { name: 'ani1999', status: 'inactive', last_turn_ago_s: null },
-    { name: 'cheolsu', status: 'active', last_turn_ago_s: null },
-    { name: 'janitor', status: 'active', last_turn_ago_s: null },
-    { name: 'masc-improver', status: 'active', last_turn_ago_s: null },
+    { name: 'analyst', runtimeLabel: 'keeper-analyst-agent', status: 'busy' },
+    { name: 'ani1999', runtimeLabel: 'keeper-ani1999-agent', status: 'inactive' },
+    { name: 'cheolsu', runtimeLabel: 'keeper-cheolsu-agent', status: 'active' },
+    { name: 'janitor', runtimeLabel: 'keeper-janitor-agent', status: 'active' },
+    { name: 'masc-improver', runtimeLabel: 'keeper-masc-improver-agent', status: 'active' },
   ],
+  directoryIssues: [],
 }
 
 describe('FSM Hub integration — API response shape', () => {
   describe('gate keepers response', () => {
-    it('declares a number for count and an array for keepers', () => {
-      expect(typeof REAL_GATE_KEEPERS_SHAPE.count).toBe('number')
+    it('declares a concrete array for keepers', () => {
       expect(Array.isArray(REAL_GATE_KEEPERS_SHAPE.keepers)).toBe(true)
       expect(REAL_GATE_KEEPERS_SHAPE.keepers.length).toBeGreaterThan(0)
     })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -11,7 +11,8 @@ import {
   type KeeperCompositeSnapshot,
   type KeeperRuntimeTraceResponse,
 } from '../api/keeper'
-import { fetchGateKeepers } from '../api/gate'
+import { fetchGateKeepers } from '../api/gate-keepers'
+import { dashboardRuntime } from '../api/effect-http'
 import { executionLoaded, keepers, refreshExecution } from '../store'
 import { compositeTick } from '../composite-signals'
 import { nowSecondsSignal, useNowSecondsTicker } from '../lib/now-signal'
@@ -545,23 +546,22 @@ export function FsmHub(props: FsmHubProps = {}) {
   )
   useEffect(() => {
     if (!shouldUseGateKeeperFallback(executionLoadedValue, storeNames)) return
-    let cancelled = false
-    void (async () => {
-      try {
-        const data = await fetchGateKeepers()
-        if (cancelled) return
+    const controller = new AbortController()
+    void dashboardRuntime
+      .runPromise(fetchGateKeepers(), { signal: controller.signal })
+      .then(data => {
         const next = data.keepers.map(k => k.name).sort()
         setGateKeeperNames(prev =>
           prev.length === next.length && prev.every((v, i) => v === next[i])
             ? prev
             : next,
         )
-      } catch {
+      })
+      .catch(() => {
         // Gate endpoint auth failure or network error — keep the last
         // successful fallback snapshot until the primary store path lands.
-      }
-    })()
-    return () => { cancelled = true }
+      })
+    return () => { controller.abort() }
   }, [executionLoadedValue, storeNames, pollTick])
 
   const keeperNames = shouldUseGateKeeperFallback(executionLoadedValue, storeNames)


### PR DESCRIPTION
## Summary

- decode the current detailed gate keeper wire contract with strict Effect Schema variants and producer invariants
- map wire identity and error envelopes once into null-free keeper values plus explicit directory issues
- expose the endpoint as a typed Effect and execute it only at the connector refresh and FSM fallback boundaries, with AbortSignal cancellation
- remove the gate keeper schema from the Valibot migration allowlist and retire the broad gate barrel exports

Part of #28260.

## Verification

- `pnpm exec tsc --noEmit --pretty false --incremental false`
- `pnpm lint`
- `pnpm exec vitest run src/api/schemas/gate-keepers.test.ts src/api/gate-keepers.test.ts src/components/connector-status.test.ts src/components/connector-keeper-matrix.test.ts src/components/connector-quick-bind.test.ts src/components/fsm-hub.integration.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1` (6 files, 100 tests)
- `pnpm build`
