### PR TITLE
fix(dashboard): make keeper text streaming idempotent per messageId

### DIFF
--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -52,6 +52,55 @@ describe('Keeper operation stream projection', () => {
     expect(entry?.delivery).toBe('streaming')
   })
 
+  const streamMessageOnce = (): void => {
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_START', messageId: 'm-1' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm-1', delta: '네.' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm-1', delta: ' 현재 상태:' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_END', messageId: 'm-1' })
+  }
+
+  it('applies a full message sequence delivered twice exactly once', () => {
+    assistantEntry()
+    streamMessageOnce()
+    streamMessageOnce()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.rawText).toBe('네. 현재 상태:')
+  })
+
+  it('drops content re-delivered after the message ended', () => {
+    assistantEntry()
+    streamMessageOnce()
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm-1', delta: ' 현재 상태:' })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.rawText).toBe('네. 현재 상태:')
+  })
+
+  it('restarts the buffer when the in-flight message re-STARTs', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_START', messageId: 'm-1' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm-1', delta: '네.' })
+    // The observer socket replays START+CONTENT for the same in-flight message.
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_START', messageId: 'm-1' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm-1', delta: '네.' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_END', messageId: 'm-1' })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.rawText).toBe('네.')
+  })
+
+  it('keeps two distinct messages in one entry (no false dedup)', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_START', messageId: 'm-1' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm-1', delta: '첫째' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_START', messageId: 'm-2' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm-2', delta: '둘째' })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.rawText).toBe('첫째둘째')
+  })
+
   it('projects queued acceptance without a receipt or queue revision', () => {
     assistantEntry()
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -54,8 +54,41 @@ interface PendingThinkingState {
 
 const pendingThinkingDeltas = new Map<string, PendingThinkingState>()
 
+// AG-UI text messages are delivered at-least-once: a WS/SSE reconnect can
+// replay a message's START/CONTENT/END, and an overlapping observer socket can
+// re-deliver the same operation event. TEXT_MESSAGE_CONTENT carries a messageId
+// but no per-chunk sequence, so the reducer keys idempotency on messageId — a
+// completed message is never re-applied, and a re-START of the in-flight message
+// restarts its buffer instead of appending on top. The terminal reply is an
+// absolute snapshot (already idempotent), which is why only streaming text
+// doubled before this guard.
+interface TextMessageStreamState {
+  activeMessageId: string | null
+  endedMessageIds: Set<string>
+}
+
+const textMessageStreamStates = new Map<string, TextMessageStreamState>()
+
 function streamEntryKey(keeperName: string, assistantEntryId: string): string {
   return `${keeperName}\u0000${assistantEntryId}`
+}
+
+function textMessageStreamState(keeperName: string, assistantEntryId: string): TextMessageStreamState {
+  const key = streamEntryKey(keeperName, assistantEntryId)
+  let state = textMessageStreamStates.get(key)
+  if (!state) {
+    state = { activeMessageId: null, endedMessageIds: new Set() }
+    textMessageStreamStates.set(key, state)
+  }
+  return state
+}
+
+function textStreamMessageId(value: unknown): string | null {
+  return typeof value === 'string' && value ? value : null
+}
+
+function clearTextMessageStreamState(keeperName: string, assistantEntryId: string): void {
+  textMessageStreamStates.delete(streamEntryKey(keeperName, assistantEntryId))
 }
 
 function scheduleThinkingFlush(callback: () => void): ScheduledFlushHandle {
@@ -174,6 +207,7 @@ export function _resetKeeperStreamBuffersForTests(): void {
   pendingThinkingDeltas.clear()
   pendingAgentCoreToolBlockIndexes.clear()
   pendingAgentCoreTextBlockIndexes.clear()
+  textMessageStreamStates.clear()
 }
 
 export interface KeeperThreadAbortResult {
@@ -481,7 +515,24 @@ export function applyKeeperStreamEvent(
         keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
       )
       return null
-    case 'TEXT_MESSAGE_START':
+    case 'TEXT_MESSAGE_START': {
+      const messageId = textStreamMessageId(event.messageId)
+      const streamState = textMessageStreamState(keeperName, assistantEntryId)
+      if (messageId !== null && streamState.endedMessageIds.has(messageId)) {
+        // Replay of a completed message: the transcript already holds its text.
+        return null
+      }
+      if (messageId !== null && messageId === streamState.activeMessageId) {
+        // Duplicate in-flight START (reconnect/observer replay): restart this
+        // message's buffer so re-sent content re-accumulates identically instead
+        // of appending on top of the partial text already shown.
+        updateThreadEntry(keeperName, assistantEntryId, entry => ({
+          ...entry,
+          text: '',
+          rawText: '',
+        }))
+      }
+      streamState.activeMessageId = messageId
       // Flush any buffered thinking deltas before entering the text phase so a
       // pending scheduled flush cannot run later and revert streamState to
       // 'thinking' after text streaming has begun. Mirrors TEXT_MESSAGE_END and
@@ -495,15 +546,37 @@ export function applyKeeperStreamEvent(
         keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
       )
       return null
+    }
     case 'TEXT_MESSAGE_CONTENT': {
+      const messageId = textStreamMessageId(event.messageId)
+      if (messageId !== null) {
+        const streamState = textMessageStreamState(keeperName, assistantEntryId)
+        if (streamState.endedMessageIds.has(messageId)) {
+          // Content re-delivered after the message ended: already rendered.
+          return null
+        }
+        if (streamState.activeMessageId !== null && streamState.activeMessageId !== messageId) {
+          // Content for a different message than the one in flight: stale copy.
+          return null
+        }
+        // Adopt the id when START was coalesced away by the guards above.
+        streamState.activeMessageId = messageId
+      }
       applyTextDelta(event.delta)
       return null
     }
-    case 'TEXT_MESSAGE_END':
+    case 'TEXT_MESSAGE_END': {
+      const messageId = textStreamMessageId(event.messageId)
+      if (messageId !== null) {
+        const streamState = textMessageStreamState(keeperName, assistantEntryId)
+        streamState.endedMessageIds.add(messageId)
+        if (streamState.activeMessageId === messageId) streamState.activeMessageId = null
+      }
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
       clearPendingAgentCoreToolBlockIndexesForEntry(keeperName, assistantEntryId)
       markFinalizingIfLive('TEXT_MESSAGE_END')
       return null
+    }
     case 'TOOL_CALL_START': {
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
       const toolCallId = nonBlankToolCallId(event.toolCallId)
@@ -886,6 +959,7 @@ export function applyKeeperStreamEvent(
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
       clearPendingAgentCoreToolBlockIndexesForEntry(keeperName, assistantEntryId)
       clearPendingAgentCoreTextBlockIndex(keeperName, assistantEntryId)
+      clearTextMessageStreamState(keeperName, assistantEntryId)
       if (source.kind !== 'operation') return null
       updateThreadEntry(keeperName, assistantEntryId, entry => {
         if (entry.requestId !== source.operationId) return entry
@@ -912,6 +986,7 @@ export function applyKeeperStreamEvent(
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
       clearPendingAgentCoreToolBlockIndexesForEntry(keeperName, assistantEntryId)
       clearPendingAgentCoreTextBlockIndex(keeperName, assistantEntryId)
+      clearTextMessageStreamState(keeperName, assistantEntryId)
       return asString(event.message, '').trim() || 'Keeper stream failed'
     default:
       return 'Unsupported Keeper stream event'


### PR DESCRIPTION
## 문제

라이브 관측: keeper 턴이 스트리밍되는 동안 대시보드가 각 청크를 2번 렌더했고("네.네. 현재현재 상태"), settled 최종 답변은 1번만 렌더됐습니다.

## 근본 원인

스트림 리듀서의 비대칭입니다.
- `TEXT_MESSAGE_CONTENT` → `appendAssistantDelta` 는 **무조건 concat** (`keeper-state.ts`), AG-UI 이벤트는 `messageId` 는 있으나 **per-chunk 시퀀스가 없어** 재전달 청크를 구분 불가 (`schemas/sse.ts:209`).
- `TEXT_MESSAGE_START` 도 버퍼를 리셋하지 않음.
- 최종 답변은 `finalizeAssistantEntry` 의 절대 스냅샷이라 **멱등** → 그래서 스트리밍만 2번, 최종은 1번.

SSE/WS 전달은 **at-least-once** 입니다: 재접속이 메시지의 START/CONTENT/END 를 리플레이하고, 겹친 observer 소켓이 같은 operation 이벤트를 재배달할 수 있습니다. 리듀서가 멱등이어야 하며, 중복 배달 억제는 증상 통제일 뿐 불변식이 아닙니다.

## 변경

리듀서를 `messageId` 기준으로 멱등화. 엔트리별로 활성 id + 종료 id 집합 추적:
- `TEXT_MESSAGE_START`: 이미 종료된 메시지의 재-START 무시, **진행 중 같은 메시지의 재-START 는 버퍼 재시작**(재전송 content 가 동일 재누적).
- `TEXT_MESSAGE_CONTENT`: messageId 가 종료됐거나 활성 메시지와 다르면 **드롭**, 아니면 append.
- `TEXT_MESSAGE_END`: 종료 등록 + active 해제.
- 상태는 `RUN_FINISHED`/`RUN_ERROR` 및 테스트 reset 에서 정리. `messageId` 없는 레거시 스트림은 기존 append-always 유지(무회귀).

## 검증

- `keeper-stream.test.ts` 신규 4건: 전체 시퀀스 2회 배달=텍스트 1번 · END 후 재전달 드롭 · 진행 중 재-START 버퍼 재시작 · 서로 다른 두 메시지 오탐 없음.
- 표적 회귀: keeper-stream / keeper-state / sse / dashboard-ws 7파일 244 테스트 pass.
- `tsc --noEmit` clean, `eslint src/keeper-stream.*` clean.

## 범위 밖 (후속)

이 PR 은 **소비 계층의 근본 픽스**입니다 — 전달 계층이 무엇을 하든 화면 정합성을 강제합니다. 실제로 중복을 배달하는 주체(관측 소켓 이중화 vs 백엔드 이중 방출) 조사는 별도 트랙이며, 발견 시 링크하겠습니다.

RFC-WAIVED: workflow-pr.md §11 필수 subsystem 해당 없음 (dashboard 스트림 소비 계층).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
