### PR TITLE
fix(ci): restrict trusted acceptance dispatch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1459,7 +1459,10 @@ jobs:
         always() &&
         !cancelled() &&
         (
-          github.event_name == 'workflow_dispatch' ||
+          (
+            github.event_name == 'workflow_dispatch' &&
+            github.ref == 'refs/heads/main'
+          ) ||
           (
             github.event_name == 'pull_request' &&
             github.event.pull_request.head.repo.full_name == github.repository
@@ -1539,6 +1542,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
           REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -1551,6 +1555,10 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$EVENT_REF" != "refs/heads/main" ]; then
+              echo "STOP Keeper Real-World Gate: trusted dispatch requires refs/heads/main, got $EVENT_REF" >&2
+              exit 1
+            fi
             if [ "$CHANGES_RESULT" != "success" ]; then
               echo "STOP Keeper Real-World Gate: changed-surface detection did not complete" >&2
               exit 1


### PR DESCRIPTION
## Summary
- restrict the secret-bearing Keeper real-world acceptance job to `workflow_dispatch` runs on `refs/heads/main`
- recheck `EVENT_REF` in the downstream gate before accepting dispatch evidence

## Why
Post-merge follow-up for #28310 and https://github.com/jeong-sik/masc/pull/28310#discussion_r3763743781. The environment has no deployment branch policy, so a dispatch against another ref could otherwise execute that ref's acceptance script with `ZAI_API_KEY_SB`.

## Verification
- `python3 scripts/ci/check-yaml-syntax.py` — 38 YAML files passed
- `git diff --check 3210ec9481..8d33a1c351` — passed
- local OCaml build intentionally not duplicated; PR CI remains the build authority