### PR TITLE
fix(runtime): preserve official-client timeout authority

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -32,11 +32,6 @@ let process_termination_grace_s = 2.0
 (* [None] installs no deadline. The vendor client owns when its own turn ends;
    a declared bound is the operator's optional liveness guard over a silent
    client, not a limit on how long legitimate work may take. *)
-let with_optional_timeout clock timeout_s f =
-  match timeout_s with
-  | None -> f ()
-  | Some seconds -> Eio.Time.with_timeout_exn clock seconds f
-;;
 let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 8192
 let max_wire_line_bytes = 8 * 1024 * 1024
@@ -167,15 +162,6 @@ end)
 open Shared_json
 
 let bounded_tail = Runtime_official_client_json.bounded_tail
-
-(* See {!Runtime_official_client_json.Make.no_turn_deadline_defect} for why the
-   [None] arm is unreachable and why it must not be dressed as a turn limit. *)
-let timeout_or_defect = function
-  | Some seconds -> Timeout seconds
-  | None -> Shared_json.no_turn_deadline_defect
-;;
-
-let timeout_error timeout_s = Error (timeout_or_defect timeout_s)
 
 let required_string ?(nonempty = true) stage name fields =
   match List.assoc_opt name fields with
@@ -601,6 +587,7 @@ let apply_event (config : config) ~conversation_mode ~on_conversation_ready
         let callback_result =
           try on_conversation_ready ~conversation_id with
           | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | Eio.Time.Timeout as exn -> raise exn
           | exn -> Error (Printexc.to_string exn)
         in
         (match callback_result with
@@ -707,29 +694,21 @@ let run_spawned ?home_dir ?on_spawned ~mgr ~clock ~cwd config ~conversation_mode
            timeout_s_for_phase config ~turn_admitted:(Option.is_some !state.init)
          in
          let line =
-           try
-             with_optional_timeout clock timeout_s (fun () ->
-               Eio.Buf_read.line reader)
-           with
-           | Eio.Time.Timeout ->
-             abort_with_runtime_error (timeout_or_defect timeout_s)
+           with_optional_timeout clock timeout_s (fun () ->
+             Eio.Buf_read.line reader)
          in
          match parse_wire_line line with
          | Error error -> abort_with_runtime_error error
          | Ok event ->
            (match
-              try
-                with_optional_timeout clock timeout_s (fun () ->
-                  apply_event
-                    config
-                    ~conversation_mode
-                    ~on_conversation_ready
-                    ~on_stream_event
-                    !state
-                    event)
-              with
-              | Eio.Time.Timeout ->
-                abort_with_runtime_error (timeout_or_defect timeout_s)
+              with_optional_timeout clock timeout_s (fun () ->
+                apply_event
+                  config
+                  ~conversation_mode
+                  ~on_conversation_ready
+                  ~on_stream_event
+                  !state
+                  event)
             with
             | Error error -> abort_with_runtime_error error
             | Ok next -> state := next)
@@ -740,6 +719,9 @@ let run_spawned ?home_dir ?on_spawned ~mgr ~clock ~cwd config ~conversation_mode
        signal_spawned_process proc stdin_w;
        process_settled := true;
        raise exn
+     | Idle_timeout seconds ->
+       abort_with_runtime_error (Timeout seconds)
+     | Eio.Time.Timeout as exn -> raise exn
      | Runtime_error _ as exn -> raise exn
      | exn ->
        abort_with_runtime_error
@@ -777,7 +759,8 @@ let run_turn ?(conversation_mode = Start) ?home_dir ?on_spawned ~mgr ~clock ~cwd
            ~on_conversation_ready
            ~on_stream_event)
     with
-    | Eio.Time.Timeout -> timeout_error config.timeout_s
+    | Idle_timeout seconds -> Error (Timeout seconds)
+    | Eio.Time.Timeout as exn -> raise exn
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Runtime_error error -> Error error
     | exn ->

--- a/lib/runtime/runtime_antigravity.mli
+++ b/lib/runtime/runtime_antigravity.mli
@@ -23,12 +23,14 @@ type config =
   ; sandbox : bool
   ; disable_slash_commands : bool
   ; admission_timeout_s : float
-    (** Finite bound for process startup and the first [init] event. *)
+    (** Finite bound for the post-spawn wait for the first [init] event and its
+        admission callback. *)
   ; timeout_s : float option
-    (** [None] removes the deadline after the first [init] event: the spawned
-        client decides when its own turn ends. Startup remains bounded by
-        [admission_timeout_s]. Declared as [turn-timeout-s] in runtime config,
-        where [0] selects [None]. *)
+    (** [None] removes the deadline after the first valid [init] event and its
+        admission callback: the spawned client decides when its own turn ends.
+        The post-spawn pre-init phase remains bounded by [admission_timeout_s].
+        Declared as [turn-timeout-s] in runtime config, where [0] selects
+        [None]. *)
     (** Maximum silence between valid stream-json messages. It is not a total
         turn-duration bound. *)
   }

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -19,11 +19,6 @@ let process_termination_grace_s = 2.0
 (* [None] installs no deadline. The vendor client owns when its own turn ends;
    a declared bound is the operator's optional liveness guard over a silent
    client, not a limit on how long legitimate work may take. *)
-let with_optional_timeout clock timeout_s f =
-  match timeout_s with
-  | None -> f ()
-  | Some seconds -> Eio.Time.with_timeout_exn clock seconds f
-;;
 let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 4096
 let max_wire_line_bytes = 8 * 1024 * 1024
@@ -228,13 +223,6 @@ open Shared_json
 
 let bounded_tail = Runtime_official_client_json.bounded_tail
 
-(* See {!Runtime_official_client_json.Make.no_turn_deadline_defect} for why the
-   [None] arm is unreachable and why it must not be dressed as a turn limit. *)
-let timeout_error = function
-  | Some seconds -> Error (Timeout seconds)
-  | None -> Error Shared_json.no_turn_deadline_defect
-;;
-
 let parse_json ~stage text =
   let parsed =
     try Ok (Yojson.Safe.from_string text) with
@@ -380,6 +368,8 @@ let send_control_response
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Idle_timeout _ as exn -> raise exn
+  | Eio.Time.Timeout as exn -> raise exn
   | exn ->
     let detail = Printexc.to_string exn in
     (match control_phase with
@@ -1001,6 +991,7 @@ let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
       Ok ()
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Idle_timeout _ as exn -> raise exn
     | Eio.Time.Timeout as exn -> raise exn
     | exn ->
       Error
@@ -1082,8 +1073,9 @@ let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
       | End_of_file ->
         let detail = String.trim !stderr_tail in
         Error (Process_exited (if detail = "" then "stdout closed" else detail))
-      | Eio.Time.Timeout -> timeout_error timeout_s
+      | Idle_timeout seconds -> Error (Timeout seconds)
       | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | Eio.Time.Timeout as exn -> raise exn
       | exn -> protocol_error "stdout read" (Printexc.to_string exn)
     in
     Fun.protect
@@ -1108,8 +1100,8 @@ let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
           ~on_stream_event
           ~turn_admitted))
   with
-  | Eio.Time.Timeout ->
-    timeout_error (timeout_s_for_phase config ~turn_admitted:!turn_admitted)
+  | Idle_timeout seconds -> Error (Timeout seconds)
+  | Eio.Time.Timeout as exn -> raise exn
 ;;
 
 let validate_process_config config =
@@ -1172,6 +1164,15 @@ let validate_turn ?(dynamic_tools = []) ?(session_mode = Start) config ~prompt =
   validate_dynamic_tools dynamic_tools
 ;;
 
+let bounded_subscription_probe_config
+      ~fallback_timeout_s
+      (turn_config : config)
+  =
+  match turn_config.timeout_s with
+  | Some _ -> turn_config
+  | None -> { turn_config with timeout_s = Some fallback_timeout_s }
+;;
+
 let probe_subscription ~mgr ~clock ~cwd config =
   let* () = validate_process_config config in
   let timeout_s = Some config.admission_timeout_s in
@@ -1180,7 +1181,8 @@ let probe_subscription ~mgr ~clock ~cwd config =
       read_subscription ~mgr ~cwd config)
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | Eio.Time.Timeout -> timeout_error timeout_s
+  | Idle_timeout seconds -> Error (Timeout seconds)
+  | Eio.Time.Timeout as exn -> raise exn
 ;;
 
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
@@ -1195,7 +1197,13 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
     let* subscription =
       match admitted_subscription with
       | Some subscription -> Ok subscription
-      | None -> probe_subscription ~mgr ~clock ~cwd config
+      | None ->
+        let probe_config =
+          bounded_subscription_probe_config
+            ~fallback_timeout_s:default_timeout_s
+            config
+        in
+        probe_subscription ~mgr ~clock ~cwd probe_config
     in
     let session_id =
       match session_mode with
@@ -1224,7 +1232,8 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(session_mode = Start)
         ~on_stream_event
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | Eio.Time.Timeout -> timeout_error config.timeout_s
+    | Idle_timeout seconds -> Error (Timeout seconds)
+    | Eio.Time.Timeout as exn -> raise exn
     | Runtime_error error -> Error error
     | exn ->
       Error

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -16,8 +16,8 @@ type config =
   ; model : string option
   ; system_prompt : string option
   ; admission_timeout_s : float
-    (** Finite bound for process setup and the initialize exchange before the
-        user turn is written. *)
+    (** Finite bound for the post-spawn initialize exchange and callbacks
+        before the user turn is written. *)
   ; timeout_s : float option
     (** [None] removes the deadline after the user message is written: the
         spawned client decides when its own turn ends. Initialization remains
@@ -131,6 +131,13 @@ val validate_turn :
   config ->
   prompt:string ->
   (unit, error) result
+
+val bounded_subscription_probe_config
+  :  fallback_timeout_s:float
+  -> config
+  -> config
+(** Preserve an existing finite bound, or give an unbounded model turn a
+    finite authentication-preflight fallback. *)
 
 val probe_subscription :
   mgr:_ Eio.Process.mgr ->

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -28,11 +28,6 @@ let process_termination_grace_s = 2.0
 (* [None] installs no deadline. The vendor client owns when its own turn ends;
    a declared bound is the operator's optional liveness guard over a silent
    client, not a limit on how long legitimate work may take. *)
-let with_optional_timeout clock timeout_s f =
-  match timeout_s with
-  | None -> f ()
-  | Some seconds -> Eio.Time.with_timeout_exn clock seconds f
-;;
 let stderr_chunk_bytes = 4096
 let stderr_tail_bytes = 4096
 let max_wire_line_bytes = 8 * 1024 * 1024
@@ -49,12 +44,6 @@ let default_config () =
   ; admission_timeout_s = default_timeout_s
   ; timeout_s = Some default_timeout_s
   }
-;;
-
-let timeout_s_for_phase config ~turn_accepted =
-  if turn_accepted
-  then config.timeout_s
-  else Some config.admission_timeout_s
 ;;
 
 type thread_mode =
@@ -210,16 +199,6 @@ open Shared_json
 
 let bounded_tail = Runtime_official_client_json.bounded_tail
 
-(* See {!Runtime_official_client_json.Make.no_turn_deadline_defect} for why the
-   [None] arm is unreachable. Here it must also not become [Process_exited]:
-   that maps to [ProviderUnavailable], which blames a provider that was
-   answering and carries no [turn_accepted] — the one bit that decides whether
-   rotating would run the goal a second time. *)
-let timeout_error ~turn_accepted = function
-  | Some seconds -> Error (Timeout { seconds; turn_accepted })
-  | None -> Error Shared_json.no_turn_deadline_defect
-;;
-
 (* Present and a string, with no constraint on its contents. For payload
    fields whose value this decoder does not read: an emptiness rule there
    ends the turn over a byte nobody looks at. *)
@@ -296,6 +275,7 @@ let parse_wire_line line =
 type io =
   { send : Yojson.Safe.t -> unit
   ; receive : unit -> (wire_message, error) result
+  ; set_timeout_s : float option -> unit
   }
 
 let send_request io ~id ~method_ ~params =
@@ -860,6 +840,10 @@ let run_protocol io (config : config) ~protocol_cwd ~dynamic_tools ~reasoning_ef
           @ optional_field
               "effort"
               (Option.map Llm_provider.Reasoning_effort.to_string reasoning_effort)));
+  (* The complete request is now outside this process. Admission stays finite
+     through dispatch; only the subsequent model turn adopts its declared
+     idle policy, including [None]. *)
+  io.set_timeout_s config.timeout_s;
   let* turn =
     match await_response io ~id:turn_request_id ~method_:"turn/start" with
     | Error (Timeout { seconds; turn_accepted = _ }) ->
@@ -982,7 +966,7 @@ let terminate_spawned_process ~clock proc stdin_w =
           (Printexc.to_string exn))
 ;;
 
-let with_spawned_client ~mgr ~clock ~cwd config ~turn_accepted run =
+let with_spawned_client ~mgr ~clock ~cwd ~initial_timeout_s config run =
   Eio.Switch.run (fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw mgr in
     let stdout_r, stdout_w = Eio.Process.pipe ~sw mgr in
@@ -999,29 +983,27 @@ let with_spawned_client ~mgr ~clock ~cwd config ~turn_accepted run =
     Eio.Flow.close stderr_w;
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
-    let current_timeout_s () =
-      timeout_s_for_phase config ~turn_accepted:!turn_accepted
-    in
+    let active_timeout_s = ref initial_timeout_s in
     let send json =
-      with_optional_timeout clock (current_timeout_s ()) (fun () ->
+      with_optional_timeout clock !active_timeout_s (fun () ->
         Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
         Eio.Flow.copy_string "\n" stdin_w)
     in
     let receive () =
-      let timeout_s = current_timeout_s () in
       try
-        with_optional_timeout clock timeout_s (fun () ->
+        with_optional_timeout clock !active_timeout_s (fun () ->
           Eio.Buf_read.line reader)
         |> parse_wire_line
       with
       | End_of_file ->
         let detail = String.trim !stderr_tail in
         Error (Process_exited (if detail = "" then "stdout closed" else detail))
-      | Eio.Time.Timeout ->
+      | Idle_timeout seconds ->
         (* The transport cannot know whether turn/start was already accepted;
            the entry points rewrap with the observed turn state. *)
-        timeout_error ~turn_accepted:!turn_accepted timeout_s
+        Error (Timeout { seconds; turn_accepted = false })
       | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | Eio.Time.Timeout as exn -> raise exn
       | exn -> protocol_error "stdout read" (Printexc.to_string exn)
     in
     (* Cleanup must run before [Switch.run] waits for the stderr drainer. The
@@ -1030,18 +1012,29 @@ let with_spawned_client ~mgr ~clock ~cwd config ~turn_accepted run =
        preserves cleanup across fiber cancellation. *)
     Fun.protect
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
-      (fun () -> run { send; receive }))
+      (fun () ->
+         run
+           { send
+           ; receive
+           ; set_timeout_s = (fun timeout_s -> active_timeout_s := timeout_s)
+           }))
 ;;
 
 let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
     ~reasoning_effort ~thread_mode ~history ~prompt ~on_thread_ready
-    ~on_turn_starting ~on_turn_started ~on_stream_event ~turn_accepted =
-  with_spawned_client ~mgr ~clock ~cwd config ~turn_accepted (fun io ->
-    let with_timeout callback =
-      with_optional_timeout
-        clock
-        (timeout_s_for_phase config ~turn_accepted:!turn_accepted)
-        callback
+    ~on_turn_starting ~on_turn_started ~on_stream_event =
+  with_spawned_client
+    ~mgr
+    ~clock
+    ~cwd
+    ~initial_timeout_s:(Some config.admission_timeout_s)
+    config
+    (fun io ->
+    let with_admission_timeout callback =
+      with_optional_timeout clock (Some config.admission_timeout_s) callback
+    in
+    let with_turn_timeout callback =
+      with_optional_timeout clock config.timeout_s callback
     in
     run_protocol
       io
@@ -1053,11 +1046,11 @@ let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
       ~history
       ~prompt
       ~on_thread_ready:(fun ~thread_id ->
-        with_timeout (fun () -> on_thread_ready ~thread_id))
+        with_admission_timeout (fun () -> on_thread_ready ~thread_id))
       ~on_turn_starting:(fun ~thread_id ->
-        with_timeout (fun () -> on_turn_starting ~thread_id))
+        with_admission_timeout (fun () -> on_turn_starting ~thread_id))
       ~on_turn_started:(fun ~thread_id ~turn_id ->
-        with_timeout (fun () -> on_turn_started ~thread_id ~turn_id))
+        with_turn_timeout (fun () -> on_turn_started ~thread_id ~turn_id))
       ~on_stream_event)
 ;;
 
@@ -1133,22 +1126,20 @@ let probe_subscription ~mgr ~clock ~cwd config =
   let result =
     let* () = validate_process_config config in
     let* _ = native_cwd cwd in
-    let turn_accepted = ref false in
     try
       with_spawned_client
         ~mgr
         ~clock
         ~cwd
+        ~initial_timeout_s:(Some config.admission_timeout_s)
         config
-        ~turn_accepted
         probe_protocol
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | Eio.Time.Timeout ->
+    | Idle_timeout seconds ->
       (* The probe never starts a turn. *)
-      timeout_error
-        ~turn_accepted:false
-        (timeout_s_for_phase config ~turn_accepted:false)
+      Error (Timeout { seconds; turn_accepted = false })
+    | Eio.Time.Timeout as exn -> raise exn
     | exn -> Error (Spawn_failed (Printexc.to_string exn))
   in
   (match result with
@@ -1161,7 +1152,8 @@ let probe_subscription ~mgr ~clock ~cwd config =
 ;;
 
 let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr ~clock ~cwd
-    ?(history = []) ?(on_thread_ready = fun ~thread_id:_ -> Ok ())
+    ?(history = [])
+    ?(on_thread_ready = fun ~thread_id:_ -> Ok ())
     ?(on_turn_starting = fun ~thread_id:_ -> Ok ())
     ?(on_turn_started = fun ~thread_id:_ ~turn_id:_ -> Ok ()) ?on_stream_event
     config ~prompt =
@@ -1197,13 +1189,11 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr
               ~on_turn_starting
               ~on_turn_started
               ~on_stream_event
-              ~turn_accepted
           with
           | Eio.Cancel.Cancelled _ as exn -> raise exn
-          | Eio.Time.Timeout ->
-            timeout_error
-              ~turn_accepted:!turn_accepted
-              (timeout_s_for_phase config ~turn_accepted:!turn_accepted)
+          | Idle_timeout seconds ->
+            Error (Timeout { seconds; turn_accepted = !turn_accepted })
+          | Eio.Time.Timeout as exn -> raise exn
           | exn -> Error (Spawn_failed (Printexc.to_string exn)))
        with
        | Error (Timeout { seconds; turn_accepted = dispatch_ambiguous }) ->

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -19,15 +19,16 @@ type config =
   ; model : string option
   ; developer_instructions : string option
   ; admission_timeout_s : float
-    (** Finite bound for process setup, subscription/account checks, thread
-        creation, history injection, and [turn/start] acknowledgement. *)
+    (** Finite bound for post-spawn subscription/account checks, thread
+        creation, history injection, and the complete [turn/start] write. *)
   ; timeout_s : float option
     (** Maximum silence between app-server protocol messages. Each received
         message resets the deadline; a progressing turn has no wall limit.
-        [None] removes the deadline after turn admission — the spawned client
-        decides when its own turn ends, which is the posture of running the CLI
-        directly. Setup remains bounded by [admission_timeout_s]. Declared as
-        [turn-timeout-s] in runtime config, where [0] selects [None]. *)
+        [None] removes the deadline after the complete [turn/start] dispatch —
+        the spawned client decides when its own turn ends, which is the posture
+        of running the CLI directly. Setup and dispatch remain bounded by
+        [admission_timeout_s]. Declared as [turn-timeout-s] in runtime config,
+        where [0] selects [None]. *)
   }
 
 val default_timeout_s : float
@@ -161,3 +162,7 @@ val run_turn :
   config ->
   prompt:string ->
   (turn_result, error) result
+(** [config.admission_timeout_s] finitely bounds initialization, account
+    admission, thread preparation, and the complete [turn/start] write. The
+    model's [config.timeout_s] takes authority only after that dispatch
+    succeeds. *)

--- a/lib/runtime/runtime_official_client_json.ml
+++ b/lib/runtime/runtime_official_client_json.ml
@@ -7,6 +7,16 @@ end
 module Make (E : Error) = struct
   let protocol_error stage detail = Error (E.protocol ~stage ~detail)
   let ( let* ) result f = Result.bind result f
+  exception Idle_timeout of float
+
+  let with_optional_timeout clock timeout_s f =
+    match timeout_s with
+    | None -> f ()
+    | Some seconds ->
+      (match Eio.Time.with_timeout clock seconds (fun () -> Ok (f ())) with
+       | Ok value -> value
+       | Error `Timeout -> raise (Idle_timeout seconds))
+  ;;
 
   let rec validate_unique_object_keys ~stage ~path = function
     | `Assoc fields ->
@@ -85,15 +95,11 @@ module Make (E : Error) = struct
       | Error detail -> protocol_error stage detail
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Idle_timeout _ as exn -> raise exn
     | Eio.Time.Timeout as exn -> raise exn
     | exn -> protocol_error stage (Printexc.to_string exn)
   ;;
 
-  let no_turn_deadline_defect =
-    E.protocol
-      ~stage:"turn deadline"
-      ~detail:"Eio timeout raised while no turn deadline was installed"
-  ;;
 end
 
 let bounded_tail ~limit current addition =

--- a/lib/runtime/runtime_official_client_json.mli
+++ b/lib/runtime/runtime_official_client_json.mli
@@ -17,6 +17,17 @@ module type Error = sig
 end
 
 module Make (E : Error) : sig
+  exception Idle_timeout of float
+
+  val with_optional_timeout
+    :  _ Eio.Time.clock
+    -> float option
+    -> (unit -> 'a)
+    -> 'a
+  (** Install the adapter's optional idle deadline. A deadline owned by this
+      wrapper raises [Idle_timeout seconds]; an [Eio.Time.Timeout] raised by
+      [f] keeps its original identity and remains caller-owned control flow. *)
+
   val validate_unique_object_keys :
     stage:string -> path:string -> Yojson.Safe.t -> (unit, E.t) result
   (** Reject duplicate keys anywhere in the tree. `Yojson` keeps every
@@ -42,19 +53,9 @@ module Make (E : Error) : sig
     stage:string -> (unit -> (unit, string) result) -> (unit, E.t) result
   (** Run a caller-supplied state callback and convert its failure into a
       protocol error at [stage]. A raised exception becomes the same error,
-      except for [Eio.Cancel.Cancelled] and [Eio.Time.Timeout], which are
-      re-raised so cancellation and deadlines stay control flow rather than
-      turning into a reported protocol failure. *)
-
-  val no_turn_deadline_defect : E.t
-  (** What to report when [Eio.Time.Timeout] arrives at a turn while the
-      runtime installed no deadline. Each runtime catches its own
-      process-termination grace window and reaps, so with no turn deadline
-      nothing arms a timer and this is unreachable; it exists so the handler
-      stays total. Reaching it means some path installed a deadline outside
-      that reasoning, which is a defect to locate — not a turn limit to name,
-      and not a process or provider failure to blame. Shared so the three
-      runtimes cannot drift into three different accounts of one state. *)
+      except for [Eio.Cancel.Cancelled], [Idle_timeout], and
+      [Eio.Time.Timeout], which are re-raised so cancellation and deadlines
+      stay control flow rather than turning into a reported protocol failure. *)
 end
 
 val bounded_tail : limit:int -> string -> string -> string

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -304,6 +304,31 @@ let test_conversation_callback_failure_is_typed () =
     | Ok _ -> fail "callback exception was admitted as a successful turn")
 ;;
 
+let test_callback_timeout_origin_is_preserved_without_deadline () =
+  with_fixture [ init (); result () ] (fun path ->
+    check_raises
+      "callback-origin timeout escapes unchanged"
+      Eio.Time.Timeout
+      (fun () ->
+         Eio_main.run (fun env ->
+           let config =
+             { (Runtime_antigravity.default_config
+                  ~cwd:"/tmp"
+                  ~model:"gemini-fixture") with
+               cli_path = path
+             ; timeout_s = None
+             }
+           in
+           Runtime_antigravity.run_turn
+             ~mgr:(Eio.Stdenv.process_mgr env)
+             ~clock:(Eio.Stdenv.clock env)
+             ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+             ~on_conversation_ready:(fun ~conversation_id:_ -> raise Eio.Time.Timeout)
+             config
+             ~prompt:"fixture"
+           |> ignore)))
+;;
+
 let test_tool_steps_and_errors_are_measured () =
   with_fixture
     [ init ()
@@ -590,6 +615,10 @@ let () =
             "conversation callback failure"
             `Quick
             test_conversation_callback_failure_is_typed
+        ; test_case
+            "callback timeout origin is preserved without deadline"
+            `Quick
+            test_callback_timeout_origin_is_preserved_without_deadline
         ; test_case "tool measurements" `Quick test_tool_steps_and_errors_are_measured
         ; test_case "error result" `Quick test_result_error_is_not_success
         ; test_case

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -253,6 +253,29 @@ let test_state_callback_timeout_is_typed () =
     | Ok _ -> fail "blocking Claude callback ignored its timeout")
 ;;
 
+let test_callback_timeout_origin_is_preserved_without_deadline () =
+  with_fixture [] (fun path ->
+    check_raises
+      "callback-origin timeout escapes unchanged"
+      Eio.Time.Timeout
+      (fun () ->
+         Eio_main.run (fun env ->
+           let config =
+             { (Runtime_claude_code.default_config ~cwd:"/tmp") with
+               cli_path = path
+             ; timeout_s = None
+             }
+           in
+           Runtime_claude_code.run_turn
+             ~mgr:(Eio.Stdenv.process_mgr env)
+             ~clock:(Eio.Stdenv.clock env)
+             ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+             ~on_session_ready:(fun ~session_id:_ -> raise Eio.Time.Timeout)
+             config
+             ~prompt:"fixture"
+           |> ignore)))
+;;
+
 (* [dynamic_tool_bytes] measures what the tool declarations add to a request.
    The request-side check #27427 needs is a comparison against a declared
    window, and a size that silently ignores part of what it sends is what made
@@ -1068,6 +1091,10 @@ let () =
             "state callback timeout is typed"
             `Quick
             test_state_callback_timeout_is_typed
+        ; test_case
+            "callback timeout origin is preserved without deadline"
+            `Quick
+            test_callback_timeout_origin_is_preserved_without_deadline
         ; test_case
             "non-subscription rejected"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -834,6 +834,86 @@ let test_state_callback_timeout_is_typed () =
     | Ok _ -> fail "blocking app-server callback ignored its timeout")
 ;;
 
+let test_no_deadline_keeps_admission_bounded () =
+  with_fixture [ init_result; account_chatgpt; thread_result ] (fun path ->
+    let outcome =
+      Eio_main.run (fun env ->
+        let clock = Eio.Stdenv.clock env in
+        let config =
+          { (Runtime_codex_app_server.default_config ()) with
+            cli_path = path
+          ; admission_timeout_s = 0.05
+          ; timeout_s = None
+          }
+        in
+        Runtime_codex_app_server.run_turn
+          ~mgr:(Eio.Stdenv.process_mgr env)
+          ~clock
+          ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+          ~on_thread_ready:(fun ~thread_id:_ ->
+            Eio.Time.sleep clock 0.2;
+            Ok ())
+          config
+          ~prompt:"fixture")
+    in
+    match outcome with
+    | Error (Runtime_codex_app_server.Timeout { seconds; turn_accepted = false }) ->
+      check (float 0.001) "admission timeout" 0.05 seconds
+    | Error (Runtime_codex_app_server.Timeout { turn_accepted = true; _ }) ->
+      fail "pre-dispatch admission timeout was marked turn-accepted"
+    | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+    | Ok _ -> fail "no-deadline turn removed the admission timeout")
+;;
+
+let test_no_deadline_begins_after_turn_dispatch () =
+  with_fixture
+    ~terminal_line_delay_s:0.1
+    [ init_result; account_chatgpt; thread_result; turn_result; turn_completed ]
+    (fun path ->
+       let outcome =
+         Eio_main.run (fun env ->
+           let config =
+             { (Runtime_codex_app_server.default_config ()) with
+               cli_path = path
+             ; admission_timeout_s = 0.05
+             ; timeout_s = None
+             }
+           in
+           Runtime_codex_app_server.run_turn
+             ~mgr:(Eio.Stdenv.process_mgr env)
+             ~clock:(Eio.Stdenv.clock env)
+             ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+             config
+             ~prompt:"fixture")
+       in
+       match outcome with
+       | Ok turn -> check string "turn completes" "MASC_SUBSCRIPTION_OK" turn.text
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error))
+;;
+
+let test_callback_timeout_origin_is_preserved_without_deadline () =
+  with_fixture [ init_result; account_chatgpt; thread_result ] (fun path ->
+    check_raises
+      "callback-origin timeout escapes unchanged"
+      Eio.Time.Timeout
+      (fun () ->
+         Eio_main.run (fun env ->
+           let config =
+             { (Runtime_codex_app_server.default_config ()) with
+               cli_path = path
+             ; timeout_s = None
+             }
+           in
+           Runtime_codex_app_server.run_turn
+             ~mgr:(Eio.Stdenv.process_mgr env)
+             ~clock:(Eio.Stdenv.clock env)
+             ~cwd:Eio.Path.(Eio.Stdenv.fs env / "/tmp")
+             ~on_thread_ready:(fun ~thread_id:_ -> raise Eio.Time.Timeout)
+             config
+             ~prompt:"fixture"
+           |> ignore)))
+;;
+
 let test_terminal_error_notification_uses_official_context_error_enum () =
   let terminal =
     {|{"method":"error","params":{"threadId":"thread-1","turnId":"turn-1","willRetry":false,"error":{"message":"context is full","codexErrorInfo":"contextWindowExceeded"}}}|}
@@ -3108,6 +3188,18 @@ let () =
             "state callback timeout is typed"
             `Quick
             test_state_callback_timeout_is_typed
+        ; test_case
+            "no deadline keeps admission bounded"
+            `Quick
+            test_no_deadline_keeps_admission_bounded
+        ; test_case
+            "no deadline begins after turn dispatch"
+            `Quick
+            test_no_deadline_begins_after_turn_dispatch
+        ; test_case
+            "callback timeout origin is preserved without deadline"
+            `Quick
+            test_callback_timeout_origin_is_preserved_without_deadline
         ; test_case
             "terminal error notification uses official context error enum"
             `Quick


### PR DESCRIPTION
## Summary

Post-merge corrective for #28288 review feedback.

- keep Claude, Codex, and Antigravity admission phases finitely bounded while allowing the model turn to declare no deadline
- switch Codex to the turn timeout only after the complete `turn/start` write
- distinguish adapter-owned idle deadlines from callback-origin `Eio.Time.Timeout`
- preserve bounded Claude subscription probes and add phase/origin regressions

## Review threads

Closes the remaining actionable review findings from #28288:
- Codex pre-turn handshake must stay bounded
- Claude initialization must stay bounded
- Antigravity startup/init must stay bounded

## Validation

- `git diff --check`
- changed OCaml files: `ocamlformat --check`
- changed OCaml files: `ocamlc -stop-after parsing`
- local Dune build/tests not run; CI is the build/test authority

## Status

Draft until exact-head CI completes.