### PR TITLE
fix(ci): isolate Keeper acceptance secrets to protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,34 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          EVENT_REF_PROTECTED: ${{ github.ref_protected }}
+          SOURCE_SHA: ${{ github.sha }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            expected_workflow_ref="${GITHUB_REPOSITORY}/.github/workflows/ci.yml@refs/heads/main"
+            if [ "$EVENT_REF" != "refs/heads/main" ]; then
+              echo "::error::Trusted dispatch requires refs/heads/main, got $EVENT_REF"
+              exit 1
+            fi
+            if [ "$EVENT_REF_PROTECTED" != "true" ]; then
+              echo "::error::Trusted dispatch requires a protected main ref"
+              exit 1
+            fi
+            if [ "$WORKFLOW_REF" != "$expected_workflow_ref" ]; then
+              echo "::error::Trusted dispatch workflow mismatch: expected=$expected_workflow_ref actual=$WORKFLOW_REF"
+              exit 1
+            fi
+            if [ "$WORKFLOW_SHA" != "$SOURCE_SHA" ]; then
+              echo "::error::Trusted dispatch workflow/source mismatch: workflow=$WORKFLOW_SHA source=$SOURCE_SHA"
+              exit 1
+            fi
+          fi
 
           if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
             # This workflow only listens to branch pushes for main/develop
@@ -472,6 +497,11 @@ jobs:
       # the code they pin. Seconds, and the deleting PR sees it.
       - name: Check CI test targets
         run: bash scripts/audit-ci-test-targets.sh
+
+      - name: Check Keeper real-world secret boundary
+        run: |
+          python3 scripts/ci/check-keeper-realworld-secret-boundary.py
+          bash test/test_keeper_realworld_secret_boundary.sh
 
       # Eleven repo-scanning audits that existed and never ran. scripts/ holds
       # 182 scripts and ci.yml called 63 of them; these are the audit/check
@@ -1342,7 +1372,10 @@ jobs:
             .release-evidence/main-release-evidence.md
 
       - name: Generate trusted-dispatch release evidence bundle
-        if: github.event_name == 'workflow_dispatch'
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/main' &&
+          github.ref_protected == true
         run: |
           chmod +x scripts/release-evidence.sh
           mkdir -p .release-evidence
@@ -1354,7 +1387,11 @@ jobs:
         if: >-
           (github.event_name == 'pull_request') ||
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          (github.event_name == 'workflow_dispatch')
+          (
+            github.event_name == 'workflow_dispatch' &&
+            github.ref == 'refs/heads/main' &&
+            github.ref_protected == true
+          )
         run: |
           python3 scripts/keeper-full-lifecycle-evidence.py \
             --verify \
@@ -1363,18 +1400,43 @@ jobs:
       - name: Package exact-revision Keeper acceptance runtime
         if: >-
           needs.changes.outputs.keeper_realworld == 'true' &&
-          (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/main' &&
+          github.ref_protected == true
         env:
           EXPECTED_SOURCE_SHA: ${{ github.sha }}
-          PR_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          PR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
-          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'workflow-dispatch' }}
+          EXPECTED_SOURCE_REF: ${{ github.ref }}
+          EXPECTED_REF_PROTECTED: ${{ github.ref_protected }}
+          EXPECTED_WORKFLOW_REF: ${{ github.workflow_ref }}
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
           runtime_dir=keeper-realworld-runtime
           mkdir -p "$runtime_dir"
+          expected_workflow_ref="${GITHUB_REPOSITORY}/.github/workflows/ci.yml@refs/heads/main"
+          if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+            echo "trusted runtime packaging requires workflow_dispatch, got $EVENT_NAME" >&2
+            exit 1
+          fi
+          if [ "$EXPECTED_SOURCE_REF" != "refs/heads/main" ]; then
+            echo "trusted runtime packaging requires refs/heads/main, got $EXPECTED_SOURCE_REF" >&2
+            exit 1
+          fi
+          if [ "$EXPECTED_REF_PROTECTED" != "true" ]; then
+            echo "trusted runtime packaging requires protected main" >&2
+            exit 1
+          fi
+          if [ "$EXPECTED_WORKFLOW_REF" != "$expected_workflow_ref" ]; then
+            echo "workflow ref mismatch: expected=$expected_workflow_ref actual=$EXPECTED_WORKFLOW_REF" >&2
+            exit 1
+          fi
+          if [ "$EXPECTED_WORKFLOW_SHA" != "$EXPECTED_SOURCE_SHA" ]; then
+            echo "workflow/source mismatch: workflow=$EXPECTED_WORKFLOW_SHA source=$EXPECTED_SOURCE_SHA" >&2
+            exit 1
+          fi
           actual_source_sha="$(git rev-parse HEAD)"
           if [ "$actual_source_sha" != "$EXPECTED_SOURCE_SHA" ]; then
             echo "checkout mismatch: expected=$EXPECTED_SOURCE_SHA actual=$actual_source_sha" >&2
@@ -1384,20 +1446,24 @@ jobs:
           chmod +x "$runtime_dir/masc"
           binary_sha256="$(sha256sum "$runtime_dir/masc" | awk '{print $1}')"
           jq -n \
-            --arg schema "masc.keeper_acceptance_runtime.v1" \
+            --arg schema "masc.keeper_acceptance_runtime.v2" \
+            --arg event_name "$EVENT_NAME" \
             --arg source_sha "$actual_source_sha" \
-            --arg pr_head_sha "$PR_HEAD_SHA" \
-            --arg pr_base_sha "$PR_BASE_SHA" \
-            --arg pr_number "$PR_NUMBER" \
+            --arg source_ref "$EXPECTED_SOURCE_REF" \
+            --argjson source_ref_protected "$EXPECTED_REF_PROTECTED" \
+            --arg workflow_ref "$EXPECTED_WORKFLOW_REF" \
+            --arg workflow_sha "$EXPECTED_WORKFLOW_SHA" \
             --arg workflow_run_id "$WORKFLOW_RUN_ID" \
             --arg workflow_run_attempt "$WORKFLOW_RUN_ATTEMPT" \
             --arg binary_sha256 "$binary_sha256" \
             '{
               schema: $schema,
+              event_name: $event_name,
               source_sha: $source_sha,
-              pr_head_sha: $pr_head_sha,
-              pr_base_sha: $pr_base_sha,
-              pr_number: $pr_number,
+              source_ref: $source_ref,
+              source_ref_protected: $source_ref_protected,
+              workflow_ref: $workflow_ref,
+              workflow_sha: $workflow_sha,
               workflow_run_id: $workflow_run_id,
               workflow_run_attempt: $workflow_run_attempt,
               binary_sha256: $binary_sha256
@@ -1406,7 +1472,9 @@ jobs:
       - name: Upload exact-revision Keeper acceptance runtime
         if: >-
           needs.changes.outputs.keeper_realworld == 'true' &&
-          (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/main' &&
+          github.ref_protected == true
         uses: actions/upload-artifact@v7
         with:
           name: keeper-realworld-runtime-${{ github.run_id }}-${{ github.run_attempt }}
@@ -1431,7 +1499,14 @@ jobs:
           include-hidden-files: true
 
       - name: Upload trusted-dispatch release evidence
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && steps.build_step.outcome == 'success' }}
+        if: >-
+          ${{
+            always() &&
+            github.event_name == 'workflow_dispatch' &&
+            github.ref == 'refs/heads/main' &&
+            github.ref_protected == true &&
+            steps.build_step.outcome == 'success'
+          }}
         uses: actions/upload-artifact@v7
         with:
           name: release-evidence-dispatch-${{ github.run_id }}-${{ github.run_attempt }}
@@ -1458,16 +1533,9 @@ jobs:
       ${{
         always() &&
         !cancelled() &&
-        (
-          (
-            github.event_name == 'workflow_dispatch' &&
-            github.ref == 'refs/heads/main'
-          ) ||
-          (
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.full_name == github.repository
-          )
-        ) &&
+        github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/main' &&
+        github.ref_protected == true &&
         needs.pr-live-gate.outputs.run_heavy == 'true' &&
         needs.changes.result == 'success' &&
         needs.changes.outputs.keeper_realworld == 'true' &&
@@ -1512,6 +1580,10 @@ jobs:
           KEEPER_ACCEPTANCE_MANIFEST: ${{ github.workspace }}/keeper-realworld-runtime/manifest.json
           KEEPER_ACCEPTANCE_OUTPUT_DIR: ${{ runner.temp }}/keeper-realworld-evidence
           KEEPER_ACCEPTANCE_EXPECTED_SHA: ${{ github.sha }}
+          KEEPER_ACCEPTANCE_EXPECTED_REF: ${{ github.ref }}
+          KEEPER_ACCEPTANCE_EXPECTED_REF_PROTECTED: ${{ github.ref_protected }}
+          KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_REF: ${{ github.workflow_ref }}
+          KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
           KEEPER_ACCEPTANCE_RUNTIME_ID: glm-coding.glm-4-7-coding
           KEEPER_ACCEPTANCE_TURN_TIMEOUT_SEC: 300
           ZAI_API_KEY_SB: ${{ secrets.ZAI_API_KEY_SB }}
@@ -1543,6 +1615,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_REF: ${{ github.ref }}
+          EVENT_REF_PROTECTED: ${{ github.ref_protected }}
+          EVENT_WORKFLOW_REF: ${{ github.workflow_ref }}
+          EVENT_WORKFLOW_SHA: ${{ github.workflow_sha }}
           REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -1557,6 +1632,19 @@ jobs:
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             if [ "$EVENT_REF" != "refs/heads/main" ]; then
               echo "STOP Keeper Real-World Gate: trusted dispatch requires refs/heads/main, got $EVENT_REF" >&2
+              exit 1
+            fi
+            if [ "$EVENT_REF_PROTECTED" != "true" ]; then
+              echo "STOP Keeper Real-World Gate: trusted dispatch requires protected main" >&2
+              exit 1
+            fi
+            expected_workflow_ref="$REPOSITORY/.github/workflows/ci.yml@refs/heads/main"
+            if [ "$EVENT_WORKFLOW_REF" != "$expected_workflow_ref" ]; then
+              echo "STOP Keeper Real-World Gate: workflow ref mismatch expected=$expected_workflow_ref actual=$EVENT_WORKFLOW_REF" >&2
+              exit 1
+            fi
+            if [ "$EVENT_WORKFLOW_SHA" != "$TESTED_SOURCE_SHA" ]; then
+              echo "STOP Keeper Real-World Gate: workflow/source mismatch workflow=$EVENT_WORKFLOW_SHA source=$TESTED_SOURCE_SHA" >&2
               exit 1
             fi
             if [ "$CHANGES_RESULT" != "success" ]; then
@@ -1575,7 +1663,7 @@ jobs:
               echo "FAIL Keeper Real-World Gate: acceptance result=$ACCEPTANCE_RESULT" >&2
               exit 1
             fi
-            echo "PASS Keeper Real-World Gate: trusted dispatch candidate=$TESTED_SOURCE_SHA passed RW01-RW16"
+            echo "PASS Keeper Real-World Gate: trusted ref=$EVENT_REF workflow=$EVENT_WORKFLOW_REF candidate=$TESTED_SOURCE_SHA passed RW01-RW16"
             exit 0
           fi
           if [ "$EVENT_NAME" != "pull_request" ]; then
@@ -1590,16 +1678,8 @@ jobs:
             echo "PASS Keeper Real-World Gate: product-critical Keeper surfaces unchanged"
             exit 0
           fi
-          if [ "$HEAD_REPOSITORY" != "$REPOSITORY" ]; then
-            echo "STOP Keeper Real-World Gate: secrets are unavailable to fork PRs; replay from a trusted branch" >&2
-            exit 1
-          fi
           if [ "$BUILD_RESULT" != "success" ]; then
             echo "STOP Keeper Real-World Gate: exact-revision runtime was not built successfully" >&2
-            exit 1
-          fi
-          if [ "$ACCEPTANCE_RESULT" != "success" ]; then
-            echo "FAIL Keeper Real-World Gate: acceptance result=$ACCEPTANCE_RESULT" >&2
             exit 1
           fi
           live_head_sha="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')"
@@ -1607,7 +1687,8 @@ jobs:
             echo "STOP Keeper Real-World Gate: PR head moved expected=$EXPECTED_HEAD_SHA actual=$live_head_sha" >&2
             exit 1
           fi
-          echo "PASS Keeper Real-World Gate: stable head=$live_head_sha candidate=$TESTED_SOURCE_SHA passed RW01-RW16"
+          echo "::warning::Secret-bearing RW01-RW16 is deferred to a protected main workflow_dispatch after merge"
+          echo "PASS Keeper Real-World Gate: stable PR head=$live_head_sha passed source gates; protected-main product acceptance required after merge"
 
   lint:
     name: Lint

--- a/scripts/ci/check-keeper-realworld-secret-boundary.py
+++ b/scripts/ci/check-keeper-realworld-secret-boundary.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Fail closed when Keeper real-world credentials can reach an untrusted ref."""
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+RUNNER = ROOT / "scripts" / "ci" / "run-keeper-realworld-acceptance.sh"
+
+
+def fail(message: str) -> None:
+    print(f"keeper-realworld-secret-boundary: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def indented_block(text: str, header: str, indent: int) -> str:
+    marker = " " * indent + header
+    start = text.find(marker)
+    if start < 0:
+        fail(f"missing block: {header}")
+    remainder = text[start + len(marker) :]
+    next_header = re.search(rf"^{' ' * indent}\S", remainder, re.MULTILINE)
+    end = start + len(marker) + (next_header.start() if next_header else len(remainder))
+    return text[start:end]
+
+
+def require(block: str, needle: str, context: str) -> None:
+    if needle not in block:
+        fail(f"{context} is missing {needle!r}")
+
+
+workflow = WORKFLOW.read_text(encoding="utf-8")
+runner = RUNNER.read_text(encoding="utf-8")
+
+live_gate = indented_block(workflow, "pr-live-gate:", 2)
+acceptance = indented_block(workflow, "keeper-realworld-acceptance:", 2)
+product_gate = indented_block(workflow, "keeper-realworld-gate:", 2)
+package_step = indented_block(
+    workflow, "- name: Package exact-revision Keeper acceptance runtime", 6
+)
+upload_step = indented_block(
+    workflow, "- name: Upload exact-revision Keeper acceptance runtime", 6
+)
+
+for context, block in (
+    ("PR live gate", live_gate),
+    ("acceptance job", acceptance),
+    ("runtime package step", package_step),
+    ("runtime upload step", upload_step),
+    ("product gate", product_gate),
+):
+    require(block, "refs/heads/main", context)
+    require(block, "ref_protected", context)
+
+require(acceptance, "github.event_name == 'workflow_dispatch'", "acceptance job")
+if "github.event_name == 'pull_request'" in acceptance:
+    fail("acceptance job still admits pull_request refs")
+require(acceptance, "ZAI_API_KEY_SB: ${{ secrets.ZAI_API_KEY_SB }}", "acceptance job")
+if workflow.count("ZAI_API_KEY_SB: ${{ secrets.ZAI_API_KEY_SB }}") != 1:
+    fail("CI workflow must expose ZAI_API_KEY_SB in exactly one guarded job")
+
+for context, block in (
+    ("runtime package step", package_step),
+    ("runtime upload step", upload_step),
+):
+    require(block, "github.event_name == 'workflow_dispatch'", context)
+    if "github.event_name == 'pull_request'" in block:
+        fail(f"{context} still admits pull_request refs")
+
+for field in (
+    "masc.keeper_acceptance_runtime.v2",
+    "source_ref",
+    "source_ref_protected",
+    "workflow_ref",
+    "workflow_sha",
+):
+    require(package_step, field, "runtime manifest")
+
+for evidence in (
+    "EVENT_REF_PROTECTED",
+    "EVENT_WORKFLOW_REF",
+    "EVENT_WORKFLOW_SHA",
+):
+    require(product_gate, evidence, "product gate")
+
+for check in (
+    "KEEPER_ACCEPTANCE_EXPECTED_REF",
+    "KEEPER_ACCEPTANCE_EXPECTED_REF_PROTECTED",
+    "KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_REF",
+    "KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_SHA",
+    "masc.keeper_acceptance_runtime.v2",
+    "manifest_ref_protected",
+    "manifest_workflow_ref",
+    "manifest_workflow_sha",
+):
+    require(runner, check, "acceptance runner")
+
+print("keeper-realworld-secret-boundary: OK")

--- a/scripts/ci/run-keeper-realworld-acceptance.sh
+++ b/scripts/ci/run-keeper-realworld-acceptance.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+MODE="${1:-run}"
+if [[ "$#" -gt 1 ]] || [[ "$MODE" != "run" && "$MODE" != "--verify-provenance-only" ]]; then
+  echo "usage: $0 [--verify-provenance-only]" >&2
+  exit 64
+fi
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BINARY="${KEEPER_ACCEPTANCE_BINARY:?KEEPER_ACCEPTANCE_BINARY is required}"
 MANIFEST="${KEEPER_ACCEPTANCE_MANIFEST:?KEEPER_ACCEPTANCE_MANIFEST is required}"
 OUTPUT_DIR="${KEEPER_ACCEPTANCE_OUTPUT_DIR:?KEEPER_ACCEPTANCE_OUTPUT_DIR is required}"
 EXPECTED_SHA="${KEEPER_ACCEPTANCE_EXPECTED_SHA:?KEEPER_ACCEPTANCE_EXPECTED_SHA is required}"
+EXPECTED_REF="${KEEPER_ACCEPTANCE_EXPECTED_REF:?KEEPER_ACCEPTANCE_EXPECTED_REF is required}"
+EXPECTED_REF_PROTECTED="${KEEPER_ACCEPTANCE_EXPECTED_REF_PROTECTED:?KEEPER_ACCEPTANCE_EXPECTED_REF_PROTECTED is required}"
+EXPECTED_WORKFLOW_REF="${KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_REF:?KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_REF is required}"
+EXPECTED_WORKFLOW_SHA="${KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_SHA:?KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_SHA is required}"
 RUNTIME_ID="${KEEPER_ACCEPTANCE_RUNTIME_ID:-glm-coding.glm-4-7-coding}"
 TURN_TIMEOUT_SEC="${KEEPER_ACCEPTANCE_TURN_TIMEOUT_SEC:-300}"
 RUNNER_TEMP_ROOT="${RUNNER_TEMP:?RUNNER_TEMP is required}"
@@ -25,18 +35,49 @@ done
 [[ -f "$MANIFEST" ]] || fail "manifest not found: $MANIFEST"
 [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] \
   || fail "expected source SHA must be a full 40-character lowercase SHA"
+[[ "$EXPECTED_REF" == "refs/heads/main" ]] \
+  || fail "expected source ref must be refs/heads/main: $EXPECTED_REF"
+[[ "$EXPECTED_REF_PROTECTED" == "true" ]] \
+  || fail "expected source ref must be protected"
+[[ "$EXPECTED_WORKFLOW_REF" == "$GITHUB_REPOSITORY/.github/workflows/ci.yml@refs/heads/main" ]] \
+  || fail "expected workflow ref is not the trusted main workflow: $EXPECTED_WORKFLOW_REF"
+[[ "$EXPECTED_WORKFLOW_SHA" == "$EXPECTED_SHA" ]] \
+  || fail "expected workflow/source mismatch: workflow=$EXPECTED_WORKFLOW_SHA source=$EXPECTED_SHA"
 
 runner_sha="$(git -C "$ROOT_DIR" rev-parse HEAD)"
 [[ "$runner_sha" == "$EXPECTED_SHA" ]] \
   || fail "runner checkout mismatch: expected=$EXPECTED_SHA actual=$runner_sha"
 
+manifest_schema="$(jq -er '.schema' "$MANIFEST")"
+manifest_event="$(jq -er '.event_name' "$MANIFEST")"
 manifest_sha="$(jq -er '.source_sha' "$MANIFEST")"
+manifest_ref="$(jq -er '.source_ref' "$MANIFEST")"
+manifest_ref_protected="$(jq -er '.source_ref_protected' "$MANIFEST")"
+manifest_workflow_ref="$(jq -er '.workflow_ref' "$MANIFEST")"
+manifest_workflow_sha="$(jq -er '.workflow_sha' "$MANIFEST")"
 manifest_binary_sha="$(jq -er '.binary_sha256' "$MANIFEST")"
 actual_binary_sha="$(sha256sum "$BINARY" | awk '{print $1}')"
+[[ "$manifest_schema" == "masc.keeper_acceptance_runtime.v2" ]] \
+  || fail "manifest schema mismatch: $manifest_schema"
+[[ "$manifest_event" == "workflow_dispatch" ]] \
+  || fail "manifest event mismatch: $manifest_event"
 [[ "$manifest_sha" == "$EXPECTED_SHA" ]] \
   || fail "manifest source mismatch: expected=$EXPECTED_SHA actual=$manifest_sha"
+[[ "$manifest_ref" == "$EXPECTED_REF" ]] \
+  || fail "manifest ref mismatch: expected=$EXPECTED_REF actual=$manifest_ref"
+[[ "$manifest_ref_protected" == "$EXPECTED_REF_PROTECTED" ]] \
+  || fail "manifest protected-ref mismatch: expected=$EXPECTED_REF_PROTECTED actual=$manifest_ref_protected"
+[[ "$manifest_workflow_ref" == "$EXPECTED_WORKFLOW_REF" ]] \
+  || fail "manifest workflow ref mismatch: expected=$EXPECTED_WORKFLOW_REF actual=$manifest_workflow_ref"
+[[ "$manifest_workflow_sha" == "$EXPECTED_WORKFLOW_SHA" ]] \
+  || fail "manifest workflow SHA mismatch: expected=$EXPECTED_WORKFLOW_SHA actual=$manifest_workflow_sha"
 [[ "$actual_binary_sha" == "$manifest_binary_sha" ]] \
   || fail "binary digest mismatch: expected=$manifest_binary_sha actual=$actual_binary_sha"
+
+if [[ "$MODE" == "--verify-provenance-only" ]]; then
+  echo "keeper-realworld-acceptance: provenance PASS source=$EXPECTED_SHA ref=$EXPECTED_REF"
+  exit 0
+fi
 
 base_path="$(mktemp -d "$RUNNER_TEMP_ROOT/keeper-realworld-base.XXXXXX")"
 case "$base_path" in
@@ -156,6 +197,9 @@ jq -n \
   --arg schema "masc.keeper_realworld_gate.v1" \
   --arg status "passed" \
   --arg source_sha "$EXPECTED_SHA" \
+  --arg source_ref "$EXPECTED_REF" \
+  --arg workflow_ref "$EXPECTED_WORKFLOW_REF" \
+  --arg workflow_sha "$EXPECTED_WORKFLOW_SHA" \
   --arg binary_sha256 "$actual_binary_sha" \
   --arg effective_base_path "$base_path" \
   --arg runtime_id "$RUNTIME_ID" \
@@ -165,6 +209,10 @@ jq -n \
     schema: $schema,
     status: $status,
     source_sha: $source_sha,
+    source_ref: $source_ref,
+    source_ref_protected: true,
+    workflow_ref: $workflow_ref,
+    workflow_sha: $workflow_sha,
     binary_sha256: $binary_sha256,
     effective_base_path: $effective_base_path,
     runtime_id: $runtime_id,

--- a/test/test_keeper_realworld_secret_boundary.sh
+++ b/test/test_keeper_realworld_secret_boundary.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+runner="$repo_root/scripts/ci/run-keeper-realworld-acceptance.sh"
+source_sha="$(git -C "$repo_root" rev-parse HEAD)"
+source_ref="refs/heads/main"
+repository="jeong-sik/masc"
+workflow_ref="$repository/.github/workflows/ci.yml@refs/heads/main"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/keeper-secret-boundary.XXXXXX")"
+trap 'rm -rf -- "$tmp_root"' EXIT
+
+binary="$tmp_root/masc"
+manifest="$tmp_root/manifest.json"
+output_dir="$tmp_root/output"
+mkdir -p "$output_dir"
+printf 'exact-runtime-fixture\n' >"$binary"
+binary_sha="$(sha256sum "$binary" | awk '{print $1}')"
+
+write_manifest() {
+  local ref="${1:?ref is required}"
+  local protected="${2:?protected is required}"
+  local workflow_sha="${3:?workflow_sha is required}"
+  jq -n \
+    --arg schema "masc.keeper_acceptance_runtime.v2" \
+    --arg event_name "workflow_dispatch" \
+    --arg source_sha "$source_sha" \
+    --arg source_ref "$ref" \
+    --argjson source_ref_protected "$protected" \
+    --arg workflow_ref "$workflow_ref" \
+    --arg workflow_sha "$workflow_sha" \
+    --arg binary_sha256 "$binary_sha" \
+    '{
+      schema: $schema,
+      event_name: $event_name,
+      source_sha: $source_sha,
+      source_ref: $source_ref,
+      source_ref_protected: $source_ref_protected,
+      workflow_ref: $workflow_ref,
+      workflow_sha: $workflow_sha,
+      binary_sha256: $binary_sha256
+    }' >"$manifest"
+}
+
+run_provenance() {
+  env \
+    GITHUB_REPOSITORY="$repository" \
+    KEEPER_ACCEPTANCE_BINARY="$binary" \
+    KEEPER_ACCEPTANCE_MANIFEST="$manifest" \
+    KEEPER_ACCEPTANCE_OUTPUT_DIR="$output_dir" \
+    KEEPER_ACCEPTANCE_EXPECTED_SHA="$source_sha" \
+    KEEPER_ACCEPTANCE_EXPECTED_REF="$source_ref" \
+    KEEPER_ACCEPTANCE_EXPECTED_REF_PROTECTED=true \
+    KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_REF="$workflow_ref" \
+    KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_SHA="$source_sha" \
+    RUNNER_TEMP="$tmp_root" \
+    ZAI_API_KEY_SB=provenance-only-fixture \
+    "$runner" --verify-provenance-only
+}
+
+expect_failure() {
+  local label="${1:?label is required}"
+  if run_provenance >"$tmp_root/$label.out" 2>"$tmp_root/$label.err"; then
+    echo "expected provenance failure: $label" >&2
+    exit 1
+  fi
+}
+
+write_manifest "$source_ref" true "$source_sha"
+run_provenance >/dev/null
+
+write_manifest "refs/heads/attacker" true "$source_sha"
+expect_failure branch-ref
+
+write_manifest "$source_ref" false "$source_sha"
+expect_failure unprotected-ref
+
+write_manifest "$source_ref" true "0000000000000000000000000000000000000000"
+expect_failure workflow-sha
+
+echo "keeper real-world secret boundary tests: PASS"


### PR DESCRIPTION
## What changed

- fail `workflow_dispatch` before heavy CI unless it targets protected `refs/heads/main` and the workflow ref/SHA matches that source revision
- remove the secret-bearing Keeper real-world acceptance job from all pull request refs
- package and upload the acceptance runtime only for protected-main dispatches
- record source ref, protected status, workflow ref, and workflow SHA in the v2 runtime manifest and verify them again in the acceptance runner and final gate
- add a repository guard plus positive/negative provenance tests for branch-ref, unprotected-ref, and workflow-SHA substitution

## Why

PR #28310 allowed an arbitrary workflow-dispatch branch or tag to enter the `keeper-realworld-acceptance` environment and run that ref's script with `ZAI_API_KEY_SB`. PR #28314 added a main-ref condition but left the same-repository PR secret path and did not bind the runtime manifest to the protected ref or trusted workflow revision.

This PR makes PR checks credential-free. PRs still require a successful exact-head build and stable head; RW01-RW16 is explicitly deferred to the protected-main dispatch after merge.

## Validation

- `python3 scripts/ci/check-keeper-realworld-secret-boundary.py`
- `bash test/test_keeper_realworld_secret_boundary.sh`
- `bash -n` and `shellcheck` for the acceptance runner and regression test
- `actionlint -ignore 'SC2129' .github/workflows/ci.yml`
- Ruby YAML parse of `.github/workflows/ci.yml`
- `bash scripts/audit-unwired-audits.sh`
- `git diff --check origin/main...HEAD`

No local Dune build or provider-backed acceptance run was executed.

## External environment blocker

The live GitHub environment still reports `deployment_branch_policy: null` and `prevent_self_review: false`. Because a write-capable branch can change workflow YAML itself, complete P1 closure also requires configuring `keeper-realworld-acceptance` to allow only protected `main` deployments and disabling self-review before the secret-bearing dispatch is approved.
