### PR TITLE
fix(keeper): stop repeated official-client tool loops

### DIFF
--- a/docs/rfc/RFC-claude-code-context-overflow-bounded-restart.md
+++ b/docs/rfc/RFC-claude-code-context-overflow-bounded-restart.md
@@ -222,7 +222,7 @@ safe overflow 뒤 더 작은 view가 존재할 때만 현재 process가 exact re
 
 - error가 typed Claude context overflow다.
 - `tool_effect_attempted = false`
-- `response_started = false`
+- `response_emitted = false`
 - next view가 current view보다 strictly smaller다.
 - retry budget 안이다.
 
@@ -238,7 +238,7 @@ Claude process spawn 자체는 outer lane에서 계속
 다음 중 하나라도 참이면 automatic retry는 같은 run과 다음 cycle 모두 금지한다.
 
 - dynamic tool handler가 실행됨
-- assistant response stream이 시작됨
+- non-empty assistant text가 외부로 방출됨
 - terminal observation이 완전하지 않음
 
 이 경우 session state는 `Input_rejected Effect_fenced` 또는 기존 ambiguous recovery로

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -443,6 +443,8 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       let cleanup_error = ref None in
       let turn_result =
         Eio.Switch.run (fun sw ->
+          let abort_turn, resolve_abort_turn = Eio.Promise.create () in
+          let abort_turn_resolved = Atomic.make false in
           Eio.Switch.on_release sw (fun () ->
             match Eio.Cancel.protect (fun () -> Runtime_antigravity_home.clear_mcp_config home) with
             | Ok () -> ()
@@ -460,7 +462,14 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                   stream.on_tool_started ~call_id ~tool_name:name ~arguments;
                   Fun.protect
                     ~finally:(fun () -> stream.on_tool_finished ~call_id)
-                    (fun () -> tool.call ~call_id arguments |> tool_result)))
+                    (fun () ->
+                      let result = tool.call ~call_id arguments in
+                      Option.iter
+                        (fun detail ->
+                           if Atomic.compare_and_set abort_turn_resolved false true
+                           then Eio.Promise.resolve resolve_abort_turn detail)
+                        result.abort_turn;
+                      tool_result result)))
               ()
           in
           let* () =
@@ -471,43 +480,51 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
               recovery_failure := Session_store.State_persistence_failed;
               home_error_to_core_error error)
           in
-          let client_result =
-            Runtime_antigravity.run_turn
-              ~conversation_mode
-              ~home_dir:(Runtime_antigravity_home.home_dir home)
-              ~on_spawned:(fun () ->
-                Atomic.set
-                  effect_disposition
-                  Keeper_provider_attempt_effect.Observation_unavailable)
-              ~mgr:process_mgr
-              ~clock
-              ~cwd:process_cwd
-              ~on_conversation_ready:(fun ~conversation_id ->
-                let* () =
-                  update_session "active transition" (fun expected ->
-                    Session_store.mark_active
-                      ~base_path
-                      ~keeper_name
-                      ~expected
-                      ~session_id:conversation_id
-                      ~updated_at:(Time_compat.now ()))
-                in
-                update_session "turn-starting transition" (fun expected ->
-                  Session_store.mark_turn_starting
-                    ~base_path
-                    ~keeper_name
-                    ~expected
-                    ~session_id:conversation_id
-                    ~updated_at:(Time_compat.now ())))
-              ~on_stream_event:stream.on_runtime_event
-              client_config
-              ~prompt
-          in
-          Result.map_error
-            (fun error ->
-               recovery_failure := recovery_failure_of_runtime_error error;
-               runtime_error_to_core_error error)
-            client_result)
+          match
+            Eio.Fiber.first
+              (fun () ->
+                 `Runtime
+                   (Runtime_antigravity.run_turn
+                      ~conversation_mode
+                      ~home_dir:(Runtime_antigravity_home.home_dir home)
+                      ~on_spawned:(fun () ->
+                        Atomic.set
+                          effect_disposition
+                          Keeper_provider_attempt_effect.Observation_unavailable)
+                      ~mgr:process_mgr
+                      ~clock
+                      ~cwd:process_cwd
+                      ~on_conversation_ready:(fun ~conversation_id ->
+                        let* () =
+                          update_session "active transition" (fun expected ->
+                            Session_store.mark_active
+                              ~base_path
+                              ~keeper_name
+                              ~expected
+                              ~session_id:conversation_id
+                              ~updated_at:(Time_compat.now ()))
+                        in
+                        update_session "turn-starting transition" (fun expected ->
+                          Session_store.mark_turn_starting
+                            ~base_path
+                            ~keeper_name
+                            ~expected
+                            ~session_id:conversation_id
+                            ~updated_at:(Time_compat.now ())))
+                      ~on_stream_event:stream.on_runtime_event
+                      client_config
+                      ~prompt))
+              (fun () -> `Abort (Eio.Promise.await abort_turn))
+          with
+          | `Runtime client_result ->
+            Result.map_error
+              (fun error ->
+                 recovery_failure := recovery_failure_of_runtime_error error;
+                 runtime_error_to_core_error error)
+              client_result
+          | `Abort detail ->
+            recovery_failure := Session_store.Protocol_failed;
+            Error (internal_error detail))
       in
       match !cleanup_error with
       | None -> turn_result

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -224,7 +224,7 @@ let claude_error_to_core_error = function
          ; detail = Runtime_claude_code.error_to_string error
          })
   | Runtime_claude_code.Context_window_exceeded
-      { message; tool_effect_attempted = false; response_started = false } ->
+      { message; tool_effect_attempted = false; response_emitted = false } ->
     Agent_core.Error.Api
       (Llm_provider.Retry.ContextOverflow { message; limit = None })
   | Runtime_claude_code.Context_window_exceeded _ as error ->
@@ -592,7 +592,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
            context_overflow_retry_safe :=
              (match error with
               | Runtime_claude_code.Context_window_exceeded
-                  { tool_effect_attempted = false; response_started = false; _ } ->
+                  { tool_effect_attempted = false; response_emitted = false; _ } ->
                 true
               | _ -> false);
            if not !state_persistence_failed

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -308,12 +308,14 @@ type repeated_call_state =
   ; count : int
   }
 
+(* One exact retry may be deliberate; the third identical outcome proves two
+   consecutive transitions made no progress, matching the Agent Core guard. *)
 let repeated_call_abort_threshold = 3
 
 let dynamic_tool_fingerprint ~tool_name ~input result =
   let open Digestif.SHA256 in
   let context = feed_string empty tool_name in
-  let context = feed_string context (Yojson.Safe.to_string input) in
+  let context = feed_string context (input |> Yojson.Safe.sort |> Yojson.Safe.to_string) in
   let context = feed_string context (if result.success then "success" else "failure") in
   let context = feed_string context result.content in
   get context |> to_hex

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -278,6 +278,7 @@ let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
+  ; abort_turn : string option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -300,6 +301,35 @@ let tool_hook_error_to_string = function
 
 let record_terminal_error terminal_error detail =
   if Option.is_none !terminal_error then terminal_error := Some detail
+;;
+
+type repeated_call_state =
+  { fingerprint : string
+  ; count : int
+  }
+
+let repeated_call_abort_threshold = 3
+
+let dynamic_tool_fingerprint ~tool_name ~input result =
+  let open Digestif.SHA256 in
+  let context = feed_string empty tool_name in
+  let context = feed_string context (Yojson.Safe.to_string input) in
+  let context = feed_string context (if result.success then "success" else "failure") in
+  let context = feed_string context result.content in
+  get context |> to_hex
+;;
+
+let rec observe_repeated_call state fingerprint =
+  let before = Atomic.get state in
+  let after =
+    match before with
+    | Some previous when String.equal previous.fingerprint fingerprint ->
+      { fingerprint; count = previous.count + 1 }
+    | Some _ | None -> { fingerprint; count = 1 }
+  in
+  if Atomic.compare_and_set state before (Some after)
+  then after.count
+  else observe_repeated_call state fingerprint
 ;;
 
 type raw_trace_stage =
@@ -463,7 +493,7 @@ let apply_context_injection ~runtime_label ~terminal_error ~context
 
 let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context ~tools
     ~(hooks : Agent_core.Hooks.hooks) ~event_bus ~context_injector ~terminal_error
-    ~raw_trace_run ~next_dynamic_invocation_index
+    ~raw_trace_run ~next_dynamic_invocation_index ~repeated_call_state
     (tool : Agent_core.Tool.t) =
   { name = tool.schema.name
   ; description = tool.schema.description
@@ -515,7 +545,7 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
                  })
           in
           match pre_tool_use with
-          | Block detail -> { success = false; content = detail }
+          | Block detail -> { success = false; content = detail; abort_turn = None }
           | HookFailed { stage; detail } ->
             let detail =
               Printf.sprintf
@@ -523,7 +553,7 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
                 (Agent_core.Hooks.hook_stage_to_string stage)
                 detail
             in
-            { success = false; content = detail }
+            { success = false; content = detail; abort_turn = None }
           | (ElicitToolApproval _ | ElicitInput _) as decision ->
             let detail =
               Printf.sprintf
@@ -533,7 +563,7 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
                    (Agent_core.Hooks.classify_decision decision))
             in
             record_terminal_error terminal_error detail;
-            { success = false; content = detail }
+            { success = false; content = detail; abort_turn = None }
           | (AdjustParams _ | Nudge _) as decision ->
             let detail =
               Printf.sprintf
@@ -543,7 +573,7 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
                    (Agent_core.Hooks.classify_decision decision))
             in
             record_terminal_error terminal_error detail;
-            { success = false; content = detail }
+            { success = false; content = detail; abort_turn = None }
           | Continue ->
             (match
                Agent_core.Agent_tools.find_and_execute_tool
@@ -570,6 +600,7 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
                { success =
                    not (Agent_core.Types.tool_result_outcome_is_error result.outcome)
                ; content = result.content
+               ; abort_turn = None
                }
              | Error error ->
                let detail = tool_hook_error_to_string error in
@@ -579,12 +610,29 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
                   record_terminal_error terminal_error detail;
                   { success = true
                   ; content = "Tool completed, but its post-execution hook failed; do not retry"
+                  ; abort_turn = None
                   }
                 | Agent_core.Agent_tools.Hook_execution_failed _ ->
-                  { success = false; content = detail }))
+                  { success = false; content = detail; abort_turn = None }))
         in
         match execute () with
-        | result -> settle result
+        | result ->
+          let result = settle result in
+          let fingerprint =
+            dynamic_tool_fingerprint ~tool_name:tool.schema.name ~input result
+          in
+          let repeated_count = observe_repeated_call repeated_call_state fingerprint in
+          if repeated_count < repeated_call_abort_threshold
+          then result
+          else
+            let detail =
+              Printf.sprintf
+                "repeated exact dynamic tool call detected: tool=%s count=%d"
+                tool.schema.name
+                repeated_count
+            in
+            record_terminal_error terminal_error detail;
+            { result with abort_turn = Some detail }
         | exception exn ->
           let backtrace = Printexc.get_raw_backtrace () in
           Eio.Cancel.protect (fun () ->
@@ -592,6 +640,7 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
               (settle
                  { success = false
                  ; content = "dynamic tool call exited without an authoritative result"
+                 ; abort_turn = None
                  }));
           Printexc.raise_with_backtrace exn backtrace)
   }
@@ -608,6 +657,7 @@ let dynamic_tools ~runtime_label ~keeper_name ~turn_count ~tools ~hooks ~event_b
          (runtime_label ^ " dynamic tools require the Keeper shared context"))
   | tools, Some context ->
     let next_dynamic_invocation_index = Atomic.make 0 in
+    let repeated_call_state = Atomic.make None in
     Ok
       (List.map
          (dynamic_tool_of_agent_core
@@ -621,6 +671,7 @@ let dynamic_tools ~runtime_label ~keeper_name ~turn_count ~tools ~hooks ~event_b
             ~context_injector
             ~terminal_error
             ~raw_trace_run
-            ~next_dynamic_invocation_index)
+            ~next_dynamic_invocation_index
+            ~repeated_call_state)
          tools)
 ;;

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -23,6 +23,7 @@ type prepared_turn =
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
+  ; abort_turn : string option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -158,6 +159,11 @@ val dynamic_tools :
   terminal_error:string option ref ->
   raw_trace_run:Agent_core.Raw_trace.active_run option ->
   (dynamic_tool list, Agent_core.Error.t) result
+(** Project Agent Core tools onto one official-client turn. Three consecutive
+    calls with the same tool, canonical input, disposition, and output produce
+    [abort_turn]; this is the official-client equivalent of Agent Core's
+    repeated exact tool boundary and prevents a vendor-owned loop from holding
+    one Keeper and host resources indefinitely. *)
 
 val with_run_lifecycle_events :
   event_bus:Agent_core.Event_bus.t option ->

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -83,6 +83,7 @@ type turn_result =
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
+  ; abort_turn : string option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -137,7 +138,7 @@ type error =
   | Context_window_exceeded of
       { message : string
       ; tool_effect_attempted : bool
-      ; response_started : bool
+      ; response_emitted : bool
       }
   | Turn_failed of string
   | Quota_blocked of
@@ -165,11 +166,11 @@ let error_to_string = function
       tool_effect_attempted
       detail
   | Context_window_exceeded
-      { message; tool_effect_attempted; response_started } ->
+      { message; tool_effect_attempted; response_emitted } ->
     Printf.sprintf
-      "Claude Code context window exceeded (tool_effect_attempted=%b response_started=%b): %s"
+      "Claude Code context window exceeded (tool_effect_attempted=%b response_emitted=%b): %s"
       tool_effect_attempted
-      response_started
+      response_emitted
       message
   | Turn_failed detail -> "Claude Code turn failed: " ^ detail
   | Quota_blocked { api_error_status; rate_limit } ->
@@ -412,6 +413,7 @@ let handle_control_request
     else
       let* message = required_member stage "message" request_fields in
       let tool_specs () = List.map dynamic_tool_spec tools in
+      let abort_turn = ref None in
       let call_tool ~name ~call_id ~arguments =
         match find_dynamic_tool tools name with
         | None -> None
@@ -427,8 +429,12 @@ let handle_control_request
                 "Claude Code MCP tool handler raised (tool=%s error=%s)"
                 name
                 (Printexc.to_string exn);
-              { success = false; content = "MASC tool handler raised" }
+              { success = false
+              ; content = "MASC tool handler raised"
+              ; abort_turn = None
+              }
           in
+          abort_turn := result.abort_turn;
           emit_stream_event on_stream_event (Dynamic_tool_finished { call_id });
           Some
             { Runtime_official_client_mcp.success = result.success
@@ -468,12 +474,17 @@ let handle_control_request
         | Some mcp_response -> `Assoc [ "mcp_response", mcp_response ]
         | None -> `Assoc []
       in
-      send_control_response
-        io
-        ~control_phase
-        ~stage:"control success response"
-        ~tool_effect_attempted:dispatch.tool_called
-        (fun () -> send_control_success io ~request_id control_payload)
+      let* () =
+        send_control_response
+          io
+          ~control_phase
+          ~stage:"control success response"
+          ~tool_effect_attempted:dispatch.tool_called
+          (fun () -> send_control_success io ~request_id control_payload)
+      in
+      (match !abort_turn with
+       | None -> Ok ()
+       | Some detail -> Error (Turn_failed detail))
   | unsupported ->
     let* () =
       send_control_response
@@ -647,7 +658,7 @@ let parse_assistant ~expected_session_id fields =
 ;;
 
 let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
-    ~response_started fields =
+    ~response_emitted fields =
   let stage = "result message" in
   let* subtype = required_string stage "subtype" fields in
   let* is_error = required_bool stage "is_error" fields in
@@ -723,7 +734,7 @@ let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
         (Context_window_exceeded
            { message = terminal_failure_detail ()
            ; tool_effect_attempted
-           ; response_started
+           ; response_emitted
            })
     else if is_error
     then
@@ -742,7 +753,7 @@ let max_ignored_messages = 256
 
 let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session_id
     ~subscription ~resumed ~rate_limit ~assistant_model ~assistant_texts
-    ~on_turn_started ~on_stream_event ~stream_started ~ignored =
+    ~on_turn_started ~on_stream_event ~stream_started ~response_emitted ~ignored =
   let* json = io.receive () in
   let* type_, fields = wire_fields json in
   match type_ with
@@ -760,7 +771,7 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
     await_terminal
       io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit ~assistant_model ~assistant_texts ~on_turn_started ~ignored
-      ~on_stream_event ~stream_started
+      ~on_stream_event ~stream_started ~response_emitted
   | "control_response" ->
     protocol_error "turn" "received an unsolicited control response"
   | "assistant" ->
@@ -769,6 +780,8 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
     then (
       stream_started := true;
       emit_stream_event on_stream_event (Turn_started { turn_id = uuid; model }));
+    if List.exists (fun text -> String.length text > 0) texts
+    then response_emitted := true;
     List.iter
       (fun text -> emit_stream_event on_stream_event (Text_delta text))
       texts;
@@ -776,20 +789,20 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
       io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit ~assistant_model:(Some model)
       ~assistant_texts:(assistant_texts @ texts)
-      ~on_turn_started ~on_stream_event ~stream_started ~ignored
+      ~on_turn_started ~on_stream_event ~stream_started ~response_emitted ~ignored
   | "rate_limit_event" ->
     let* rate_limit = parse_rate_limit ~expected_session_id fields in
     await_terminal
       io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit:(Some rate_limit) ~assistant_model ~assistant_texts
-      ~on_turn_started ~on_stream_event ~stream_started ~ignored
+      ~on_turn_started ~on_stream_event ~stream_started ~response_emitted ~ignored
   | "result" ->
     let* turn_id, result, usage =
       parse_result
         ~expected_session_id
         ~rate_limit
         ~tool_effect_attempted:(!tool_call_count > 0)
-        ~response_started:!stream_started
+        ~response_emitted:!response_emitted
         fields
     in
     let* () =
@@ -831,7 +844,7 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
     await_terminal
       io ~mcp_session ~tools ~tool_call_count ~expected_session_id ~subscription ~resumed
       ~rate_limit ~assistant_model ~assistant_texts ~on_turn_started
-      ~on_stream_event ~stream_started
+      ~on_stream_event ~stream_started ~response_emitted
       ~ignored:(ignored + 1)
   | other ->
     protocol_error
@@ -1018,6 +1031,7 @@ let run_protocol io ~dynamic_tools ~subscription ~session_mode ~session_id
     ~on_turn_started
     ~on_stream_event
     ~stream_started:(ref false)
+    ~response_emitted:(ref false)
     ~ignored:0
 ;;
 

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -133,13 +133,6 @@ val validate_turn :
   prompt:string ->
   (unit, error) result
 
-val bounded_subscription_probe_config
-  :  fallback_timeout_s:float
-  -> config
-  -> config
-(** Preserve an existing finite bound, or give an unbounded model turn a
-    finite authentication-preflight fallback. *)
-
 val probe_subscription :
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -69,6 +69,7 @@ type turn_result =
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
+  ; abort_turn : string option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -113,7 +114,7 @@ type error =
   | Context_window_exceeded of
       { message : string
       ; tool_effect_attempted : bool
-      ; response_started : bool
+      ; response_emitted : bool
       }
   | Turn_failed of string
   | Quota_blocked of

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -64,6 +64,7 @@ type turn_result =
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
+  ; abort_turn : string option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -357,12 +358,17 @@ let handle_dynamic_tool_call io ~tools ~thread_id ~turn_id ~tool_call_count
             "Codex dynamic tool handler raised (tool=%s error=%s)"
             tool_name
             (Printexc.to_string exn);
-          { success = false; content = "dynamic tool handler raised" }
+          { success = false
+          ; content = "dynamic tool handler raised"
+          ; abort_turn = None
+          }
       in
       incr tool_call_count;
       emit_stream_event on_stream_event (Dynamic_tool_finished { call_id });
       send_dynamic_tool_response io ~id result;
-      Ok ()
+      (match result.abort_turn with
+       | None -> Ok ()
+       | Some detail -> Error (Turn_failed detail))
 ;;
 
 let rec await_response io ~id ~method_ =

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -52,6 +52,7 @@ type turn_result =
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
+  ; abort_turn : string option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =

--- a/lib/runtime/runtime_official_client_tool.ml
+++ b/lib/runtime/runtime_official_client_tool.ml
@@ -1,6 +1,7 @@
 type dynamic_tool_result =
   { success : bool
   ; content : string
+  ; abort_turn : string option
   }
 
 type dynamic_tool =

--- a/lib/runtime/runtime_official_client_tool.mli
+++ b/lib/runtime/runtime_official_client_tool.mli
@@ -13,6 +13,10 @@
 type dynamic_tool_result =
   { success : bool
   ; content : string
+  ; abort_turn : string option
+    (** Host-owned terminal reason. The transport returns the current tool
+        outcome, then stops the provider loop instead of admitting another
+        tool call. *)
   }
 
 type dynamic_tool =

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -218,6 +218,49 @@ let test_cancellation_records_terminal_raw_observation () =
     check int "one tool finish" 1 (count Agent_core.Raw_trace.Tool_execution_finished))
 ;;
 
+let test_repeated_exact_dynamic_tool_call_aborts_the_turn () =
+  with_active_raw_trace (fun ~path:_ ~active ->
+    let executions = ref 0 in
+    let tool, terminal_error =
+      one_dynamic_tool ~active (fun _input ->
+        incr executions;
+        Error "same deterministic failure")
+    in
+    let call index =
+      tool.call
+        ~call_id:(Printf.sprintf "repeat-%d" index)
+        (`Assoc [ "same", `String "input" ])
+    in
+    let first = call 1 in
+    let second = call 2 in
+    let third = call 3 in
+    check int "three calls executed" 3 !executions;
+    check (option string) "first call continues" None first.abort_turn;
+    check (option string) "second call continues" None second.abort_turn;
+    check bool "third call aborts" true (Option.is_some third.abort_turn);
+    check bool "terminal cause is retained" true (Option.is_some !terminal_error))
+;;
+
+let test_dynamic_tool_progress_does_not_trip_the_repeat_guard () =
+  with_active_raw_trace (fun ~path:_ ~active ->
+    let executions = ref 0 in
+    let tool, terminal_error =
+      one_dynamic_tool ~active (fun _input ->
+        incr executions;
+        Error (Printf.sprintf "changing failure %d" !executions))
+    in
+    for index = 1 to 10 do
+      let result =
+        tool.call
+          ~call_id:(Printf.sprintf "progress-%d" index)
+          (`Assoc [ "same", `String "input" ])
+      in
+      check (option string) "changing result continues" None result.abort_turn
+    done;
+    check int "all progressing calls execute" 10 !executions;
+    check (option string) "progress is not terminal" None !terminal_error)
+;;
+
 let msg role content : Agent_core.Types.message =
   { role; content; name = None; tool_call_id = None; metadata = [] }
 ;;
@@ -636,6 +679,14 @@ let () =
             "cancellation records terminal RAW observation"
             `Quick
             test_cancellation_records_terminal_raw_observation
+        ; test_case
+            "repeated exact dynamic tool call aborts the turn"
+            `Quick
+            test_repeated_exact_dynamic_tool_call_aborts_the_turn
+        ; test_case
+            "dynamic tool progress does not trip repeat guard"
+            `Quick
+            test_dynamic_tool_progress_does_not_trip_the_repeat_guard
         ] )
     ; ( "history encoding"
       , [ test_case

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -227,9 +227,14 @@ let test_repeated_exact_dynamic_tool_call_aborts_the_turn () =
         Error "same deterministic failure")
     in
     let call index =
+      let input =
+        if index mod 2 = 0
+        then `Assoc [ "second", `Int 2; "first", `Int 1 ]
+        else `Assoc [ "first", `Int 1; "second", `Int 2 ]
+      in
       tool.call
         ~call_id:(Printf.sprintf "repeat-%d" index)
-        (`Assoc [ "same", `String "input" ])
+        input
     in
     let first = call 1 in
     let second = call 2 in
@@ -237,7 +242,8 @@ let test_repeated_exact_dynamic_tool_call_aborts_the_turn () =
     check int "three calls executed" 3 !executions;
     check (option string) "first call continues" None first.abort_turn;
     check (option string) "second call continues" None second.abort_turn;
-    check bool "third call aborts" true (Option.is_some third.abort_turn);
+    check bool "reordered object still aborts third call" true
+      (Option.is_some third.abort_turn);
     check bool "terminal cause is retained" true (Option.is_some !terminal_error))
 ;;
 

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -13,6 +13,10 @@ let assistant =
   {|{"type":"assistant","session_id":"__SESSION__","uuid":"assistant-fixture-1","message":{"role":"assistant","model":"claude-fixture","content":[{"type":"text","text":"MASC_CLAUDE_OK"}]}}|}
 ;;
 
+let empty_assistant =
+  {|{"type":"assistant","session_id":"__SESSION__","uuid":"assistant-empty-1","message":{"role":"assistant","model":"claude-fixture","content":[]}}|}
+;;
+
 let result =
   {|{"type":"result","subtype":"success","is_error":false,"session_id":"__SESSION__","uuid":"turn-fixture-1","result":"MASC_CLAUDE_OK","api_error_status":null}|}
 ;;
@@ -286,7 +290,9 @@ let test_dynamic_tool_bytes_counts_every_field () =
     { Runtime_claude_code.name = "ab"
     ; description = "cde"
     ; input_schema = `Assoc [ "f", `String "g" ]
-    ; call = (fun ~call_id:_ _ -> { Runtime_claude_code.success = true; content = "" })
+    ; call =
+        (fun ~call_id:_ _ ->
+          { Runtime_claude_code.success = true; content = ""; abort_turn = None })
     }
   in
   let schema_bytes = String.length (Yojson.Safe.to_string tool.Runtime_claude_code.input_schema) in
@@ -388,7 +394,7 @@ let test_terminal_prompt_too_long_is_typed () =
     match run_fixture path with
     | Error
         (Runtime_claude_code.Context_window_exceeded
-          { message; tool_effect_attempted = false; response_started = false }) ->
+          { message; tool_effect_attempted = false; response_emitted = false }) ->
       check
         bool
         "provider reason survives into the typed failure"
@@ -467,7 +473,7 @@ let probe_tool call_count : Runtime_claude_code.dynamic_tool =
   ; call =
       (fun ~call_id:_ _ ->
         incr call_count;
-        { success = true; content = "MASC_TOOL_RESULT" })
+        { success = true; content = "MASC_TOOL_RESULT"; abort_turn = None })
   }
 ;;
 
@@ -520,7 +526,7 @@ let test_context_overflow_after_tool_records_effect () =
       match run_fixture ~dynamic_tools:[ probe_tool call_count ] path with
       | Error
           (Runtime_claude_code.Context_window_exceeded
-            { tool_effect_attempted = true; response_started = false; _ }) ->
+            { tool_effect_attempted = true; response_emitted = false; _ }) ->
         check int "tool effect count" 1 !call_count
       | Error error -> fail (Runtime_claude_code.error_to_string error)
       | Ok _ -> fail "post-effect context overflow completed the turn")
@@ -531,10 +537,49 @@ let test_context_overflow_after_response_records_activity () =
     match run_fixture path with
     | Error
         (Runtime_claude_code.Context_window_exceeded
-          { tool_effect_attempted = false; response_started = true; _ }) ->
+          { tool_effect_attempted = false; response_emitted = true; _ }) ->
       ()
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "post-response context overflow completed the turn")
+;;
+
+let test_context_overflow_after_empty_assistant_remains_retry_safe () =
+  with_fixture [ Emit empty_assistant; Emit prompt_too_long_result ] (fun path ->
+    match run_fixture path with
+    | Error
+        (Runtime_claude_code.Context_window_exceeded
+          { tool_effect_attempted = false; response_emitted = false; _ }) ->
+      ()
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "empty assistant frame made context overflow complete")
+;;
+
+let test_dynamic_tool_abort_stops_the_provider_loop () =
+  let tool : Runtime_claude_code.dynamic_tool =
+    { name = "masc_probe"
+    ; description = "Abort a repeated provider loop"
+    ; input_schema = `Assoc [ "type", `String "object" ]
+    ; call =
+        (fun ~call_id:_ _ ->
+          { success = false
+          ; content = "same deterministic failure"
+          ; abort_turn = Some "repeated exact dynamic tool call detected"
+          })
+    }
+  in
+  with_fixture
+    [ Emit_and_read mcp_initialize
+    ; Emit mcp_initialized_notification
+    ; Emit_and_read mcp_list
+    ; Emit_and_read mcp_call
+    ]
+    (fun path ->
+      match run_fixture ~dynamic_tools:[ tool ] path with
+      | Error (Runtime_claude_code.Turn_failed detail) ->
+        check bool "abort cause" true
+          (Astring.String.is_infix ~affix:"repeated exact" detail)
+      | Error error -> fail (Runtime_claude_code.error_to_string error)
+      | Ok _ -> fail "dynamic tool abort did not stop the Claude turn")
 ;;
 
 let test_dynamic_tool_callback () =
@@ -552,7 +597,7 @@ let test_dynamic_tool_callback () =
         (fun ~call_id input ->
           observed_call_id := Some call_id;
           observed_input := input;
-          { success = true; content = "MASC_TOOL_RESULT" })
+          { success = true; content = "MASC_TOOL_RESULT"; abort_turn = None })
     }
   in
   with_fixture
@@ -583,7 +628,7 @@ let test_stream_events_preserve_text_and_tool_identity () =
     ; input_schema = `Assoc [ "type", `String "object" ]
     ; call =
         (fun ~call_id:_ _ ->
-          { success = true; content = "MASC_TOOL_RESULT" })
+          { success = true; content = "MASC_TOOL_RESULT"; abort_turn = None })
     }
   in
   with_fixture
@@ -1012,7 +1057,9 @@ let test_allowed_tools_tokenizer_chars_are_validated () =
     { name = "bad,tool"
     ; description = "invalid fixture"
     ; input_schema = `Assoc []
-    ; call = (fun ~call_id:_ _ -> { success = true; content = "unused" })
+    ; call =
+        (fun ~call_id:_ _ ->
+          { success = true; content = "unused"; abort_turn = None })
     }
   in
   let config = Runtime_claude_code.default_config ~cwd:"/tmp" in
@@ -1155,6 +1202,14 @@ let () =
             "context overflow after response records activity"
             `Quick
             test_context_overflow_after_response_records_activity
+        ; test_case
+            "empty assistant keeps context overflow retry safe"
+            `Quick
+            test_context_overflow_after_empty_assistant_remains_retry_safe
+        ; test_case
+            "dynamic tool abort stops provider loop"
+            `Quick
+            test_dynamic_tool_abort_stops_the_provider_loop
         ; test_case
             "shared bridge owns exact dispatch"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -216,7 +216,7 @@ let test_dynamic_tool_callback () =
         (fun ~call_id:id input ->
           call_id := Some id;
           arguments := input;
-          { success = true; content = "MASC_TOOL_RESULT" })
+          { success = true; content = "MASC_TOOL_RESULT"; abort_turn = None })
     }
   in
   with_fixture
@@ -260,6 +260,30 @@ let test_dynamic_tool_callback () =
           | _ -> fail "Codex live stream events were not projected in wire order"))
 ;;
 
+let test_dynamic_tool_abort_stops_the_provider_loop () =
+  let tool : Runtime_codex_app_server.dynamic_tool =
+    { name = "masc_probe"
+    ; description = "Abort a repeated provider loop"
+    ; input_schema = `Assoc [ "type", `String "object" ]
+    ; call =
+        (fun ~call_id:_ _ ->
+          { success = false
+          ; content = "same deterministic failure"
+          ; abort_turn = Some "repeated exact dynamic tool call detected"
+          })
+    }
+  in
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result; tool_call_request ]
+    (fun path ->
+      match run_fixture ~dynamic_tools:[ tool ] path with
+      | Error (Runtime_codex_app_server.Turn_failed detail) ->
+        check bool "abort cause" true
+          (Astring.String.is_infix ~affix:"repeated exact" detail)
+      | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+      | Ok _ -> fail "dynamic tool abort did not stop the Codex turn")
+;;
+
 let test_context_error_records_prior_tool_effect () =
   let tool : Runtime_codex_app_server.dynamic_tool =
     { name = "masc_probe"
@@ -267,7 +291,10 @@ let test_context_error_records_prior_tool_effect () =
     ; input_schema = `Assoc [ "type", `String "object" ]
     ; call =
         (fun ~call_id:_ _ ->
-          { Runtime_codex_app_server.success = true; content = "effect applied" })
+          { Runtime_codex_app_server.success = true
+          ; content = "effect applied"
+          ; abort_turn = None
+          })
     }
   in
   let failed =
@@ -388,7 +415,9 @@ let test_thread_resume_sends_dynamic_tools () =
          { name = "masc_probe"
          ; description = "Return a deterministic fixture marker"
          ; input_schema = `Assoc [ "type", `String "object" ]
-         ; call = (fun ~call_id:_ _ -> { success = true; content = "unused" })
+         ; call =
+             (fun ~call_id:_ _ ->
+               { success = true; content = "unused"; abort_turn = None })
          }
        in
        with_fixture
@@ -662,7 +691,12 @@ let test_dynamic_tool_bytes_counts_name_description_and_schema () =
     { Runtime_codex_app_server.name
     ; description
     ; input_schema = schema
-    ; call = (fun ~call_id:_ _ -> { Runtime_codex_app_server.success = true; content = "" })
+    ; call =
+        (fun ~call_id:_ _ ->
+          { Runtime_codex_app_server.success = true
+          ; content = ""
+          ; abort_turn = None
+          })
     }
   in
   (* {"type":"object"} serializes to 17 bytes; name 2 + description 3 + 17 = 22. *)
@@ -2860,7 +2894,7 @@ let test_live_dynamic_tool_subscription () =
       ; call =
           (fun ~call_id:_ _ ->
             incr tool_calls;
-            { success = true; content = "MASC_TOOL_RESULT" })
+            { success = true; content = "MASC_TOOL_RESULT"; abort_turn = None })
       }
     in
     let result =
@@ -3221,6 +3255,10 @@ let () =
             `Quick
             test_dispatch_validation_is_process_free
         ; test_case "dynamic tool callback" `Quick test_dynamic_tool_callback
+        ; test_case
+            "dynamic tool abort stops provider loop"
+            `Quick
+            test_dynamic_tool_abort_stops_the_provider_loop
         ; test_case
             "context error records prior tool effect"
             `Quick


### PR DESCRIPTION
## 문제

라이브 sangsu turn 하나가 keeper_artifact_read의 동일 deterministic 실패를 같은 tool turn에서 16,801회 반복해 RAW trace 390,552,388 bytes를 만들었다. 별도의 context-overflow probe는 약 1.8M token request에서 빈 assistant frame만 관측해도 response_started=true로 분류되어 안전한 history 축소 retry가 차단됐다.

## 변경

- Claude context overflow의 retry fence를 assistant frame 관측이 아니라 non-empty text 방출(response_emitted) 기준으로 변경
- official-client 공통 dynamic tool projection에 exact consecutive call fingerprint 추가
- 같은 tool + canonical input + disposition + output이 3회 연속이면 abort_turn을 생성
- Claude/Codex는 세 번째 tool response 직후 provider loop를 terminal 처리
- Antigravity는 abort promise와 runtime을 race하여 child process와 MCP bridge를 owning switch에서 함께 종료
- 실제 결과가 달라지는 진행성 호출은 제한하지 않음

## 기대 효과

- 관측된 exact loop 상한: 16,801 calls -> 3 calls (99.98% 감소)
- 동일 형태 RAW trace의 tool rows: 33,602 -> 최대 6
- 빈 assistant frame 뒤 context overflow는 effect가 없을 때 smaller structural history view로 retry 가능
- 서로 다른 Keeper Owner 및 정상적인 서로 다른 tool 호출에는 새 전역 mutex/rate limit 없음

## 검증

로컬 build/test는 사용자 요청에 따라 실행하지 않았다. git diff --check만 통과했다.

사용자/CI focused commands:

    scripts/dune-local.sh build test/test_keeper_official_client_host.exe test/test_runtime_claude_code.exe test/test_runtime_codex_app_server.exe test/test_keeper_antigravity_runtime.exe
    _build/default/test/test_keeper_official_client_host.exe
    _build/default/test/test_runtime_claude_code.exe
    _build/default/test/test_runtime_codex_app_server.exe
    _build/default/test/test_keeper_antigravity_runtime.exe

## 라이브 근거

2026-08-12 KST read-only 확인: Keeper Owner status=ok, in-flight Keeper=2, queue=0. 외부 probe.py는 계속 고유 operation을 제출 중이며 terminal operation은 약 77에서 140으로 증가했다. 라이브 바이너리는 본 패치를 포함하지 않는다.