### PR TITLE
fix(ci): hide Claude probe timeout helper

### DIFF
--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -132,13 +132,6 @@ val validate_turn :
   prompt:string ->
   (unit, error) result
 
-val bounded_subscription_probe_config
-  :  fallback_timeout_s:float
-  -> config
-  -> config
-(** Preserve an existing finite bound, or give an unbounded model turn a
-    finite authentication-preflight fallback. *)
-
 val probe_subscription :
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->


### PR DESCRIPTION
## Summary
- hide the accidental public Claude probe-timeout helper
- restore the dead-export baseline

## Why
Exact-head main run 31566004415 reported 549 dead exports against the 548 baseline after #28315 exposed bounded_subscription_probe_config in runtime_claude_code.mli.

## Verification
- python3 scripts/audit-dead-surface.py --exports --ratchet — 548, at baseline
- ocamlformat --check on the changed OCaml files — passed
- git diff --check — passed
- local Dune intentionally not run; exact-head CI remained the build/test authority

## Evidence
- failing main run: https://github.com/jeong-sik/masc/actions/runs/31566004415
- merged head: 91b0b2a43f9ad0cd4d384f6ed7ef4c83982d3306