### PR TITLE
fix(runtime): keep host callbacks and writes bounded

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -1081,8 +1081,8 @@ let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
     Fun.protect
       ~finally:(fun () -> terminate_spawned_process ~clock proc stdin_w)
       (fun () ->
-        let with_timeout callback =
-          with_optional_timeout clock (current_timeout_s ()) callback
+        let with_admission_timeout callback =
+          with_optional_timeout clock (Some config.admission_timeout_s) callback
         in
         run_protocol
           { send; receive }
@@ -1092,11 +1092,11 @@ let run_spawned ?on_spawned ~mgr ~clock ~cwd config ~dynamic_tools
           ~session_id
           ~prompt
           ~on_session_ready:(fun ~session_id ->
-            with_timeout (fun () -> on_session_ready ~session_id))
+            with_admission_timeout (fun () -> on_session_ready ~session_id))
           ~on_turn_starting:(fun ~session_id ->
-            with_timeout (fun () -> on_turn_starting ~session_id))
+            with_admission_timeout (fun () -> on_turn_starting ~session_id))
           ~on_turn_started:(fun ~session_id ~turn_id ->
-            with_timeout (fun () -> on_turn_started ~session_id ~turn_id))
+            with_admission_timeout (fun () -> on_turn_started ~session_id ~turn_id))
           ~on_stream_event
           ~turn_admitted))
   with

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -275,7 +275,7 @@ let parse_wire_line line =
 type io =
   { send : Yojson.Safe.t -> unit
   ; receive : unit -> (wire_message, error) result
-  ; set_timeout_s : float option -> unit
+  ; set_receive_timeout_s : float option -> unit
   }
 
 let send_request io ~id ~method_ ~params =
@@ -742,8 +742,8 @@ let history_item (message : history_message) =
 ;;
 
 let run_protocol io (config : config) ~protocol_cwd ~dynamic_tools ~reasoning_effort
-    ~thread_mode ~history ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_started
-    ~on_stream_event =
+    ~thread_mode ~history ~prompt ~on_thread_ready ~on_turn_starting ~on_turn_dispatched
+    ~on_turn_started ~on_stream_event =
   send_request io ~id:1 ~method_:"initialize"
     ~params:
       (`Assoc
@@ -840,10 +840,11 @@ let run_protocol io (config : config) ~protocol_cwd ~dynamic_tools ~reasoning_ef
           @ optional_field
               "effort"
               (Option.map Llm_provider.Reasoning_effort.to_string reasoning_effort)));
+  on_turn_dispatched ();
   (* The complete request is now outside this process. Admission stays finite
      through dispatch; only the subsequent model turn adopts its declared
      idle policy, including [None]. *)
-  io.set_timeout_s config.timeout_s;
+  io.set_receive_timeout_s config.timeout_s;
   let* turn =
     match await_response io ~id:turn_request_id ~method_:"turn/start" with
     | Error (Timeout { seconds; turn_accepted = _ }) ->
@@ -983,15 +984,15 @@ let with_spawned_client ~mgr ~clock ~cwd ~initial_timeout_s config run =
     Eio.Flow.close stderr_w;
     Eio.Fiber.fork ~sw (fun () -> drain_stderr stderr_r stderr_tail);
     let reader = Eio.Buf_read.of_flow ~max_size:max_wire_line_bytes stdout_r in
-    let active_timeout_s = ref initial_timeout_s in
+    let active_receive_timeout_s = ref initial_timeout_s in
     let send json =
-      with_optional_timeout clock !active_timeout_s (fun () ->
+      with_optional_timeout clock (Some config.admission_timeout_s) (fun () ->
         Eio.Flow.copy_string (Yojson.Safe.to_string json) stdin_w;
         Eio.Flow.copy_string "\n" stdin_w)
     in
     let receive () =
       try
-        with_optional_timeout clock !active_timeout_s (fun () ->
+        with_optional_timeout clock !active_receive_timeout_s (fun () ->
           Eio.Buf_read.line reader)
         |> parse_wire_line
       with
@@ -1016,13 +1017,14 @@ let with_spawned_client ~mgr ~clock ~cwd ~initial_timeout_s config run =
          run
            { send
            ; receive
-           ; set_timeout_s = (fun timeout_s -> active_timeout_s := timeout_s)
+           ; set_receive_timeout_s =
+               (fun timeout_s -> active_receive_timeout_s := timeout_s)
            }))
 ;;
 
 let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
     ~reasoning_effort ~thread_mode ~history ~prompt ~on_thread_ready
-    ~on_turn_starting ~on_turn_started ~on_stream_event =
+    ~on_turn_starting ~on_turn_dispatched ~on_turn_started ~on_stream_event =
   with_spawned_client
     ~mgr
     ~clock
@@ -1032,9 +1034,6 @@ let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
     (fun io ->
     let with_admission_timeout callback =
       with_optional_timeout clock (Some config.admission_timeout_s) callback
-    in
-    let with_turn_timeout callback =
-      with_optional_timeout clock config.timeout_s callback
     in
     run_protocol
       io
@@ -1049,8 +1048,9 @@ let run_spawned ~mgr ~clock ~cwd ~protocol_cwd config ~dynamic_tools
         with_admission_timeout (fun () -> on_thread_ready ~thread_id))
       ~on_turn_starting:(fun ~thread_id ->
         with_admission_timeout (fun () -> on_turn_starting ~thread_id))
+      ~on_turn_dispatched
       ~on_turn_started:(fun ~thread_id ~turn_id ->
-        with_turn_timeout (fun () -> on_turn_started ~thread_id ~turn_id))
+        with_admission_timeout (fun () -> on_turn_started ~thread_id ~turn_id))
       ~on_stream_event)
 ;;
 
@@ -1187,6 +1187,7 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr
               ~prompt
               ~on_thread_ready
               ~on_turn_starting
+              ~on_turn_dispatched:(fun () -> turn_accepted := true)
               ~on_turn_started
               ~on_stream_event
           with

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -120,7 +120,7 @@ let with_fixture ?auth_json ?before_initialize_response steps f =
 
 let run_fixture ?(dynamic_tools = []) ?session_mode ?(timeout_s = 2.0)
     ?admission_timeout_s ?(no_turn_deadline = false) ?on_session_ready_delay_s
-    ?on_stream_event path =
+    ?on_turn_started_delay_s ?on_stream_event path =
   Eio_main.run (fun env ->
     let clock = Eio.Stdenv.clock env in
     let config =
@@ -137,6 +137,13 @@ let run_fixture ?(dynamic_tools = []) ?session_mode ?(timeout_s = 2.0)
            Ok ())
         on_session_ready_delay_s
     in
+    let on_turn_started =
+      Option.map
+        (fun delay_s ~session_id:_ ~turn_id:_ ->
+           Eio.Time.sleep clock delay_s;
+           Ok ())
+        on_turn_started_delay_s
+    in
     Runtime_claude_code.run_turn
       ~mgr:(Eio.Stdenv.process_mgr env)
       ~clock
@@ -144,6 +151,7 @@ let run_fixture ?(dynamic_tools = []) ?session_mode ?(timeout_s = 2.0)
       ~dynamic_tools
       ?session_mode
       ?on_session_ready
+      ?on_turn_started
       ?on_stream_event
       config
       ~prompt:"Return the fixture marker")
@@ -237,6 +245,21 @@ let test_no_deadline_starts_after_user_message () =
        with
        | Ok turn -> check string "unbounded result" "MASC_CLAUDE_OK" turn.text
        | Error error -> fail (Runtime_claude_code.error_to_string error))
+;;
+
+let test_no_deadline_keeps_turn_started_callback_bounded () =
+  with_fixture [ Emit assistant; Emit result ] (fun path ->
+    match
+      run_fixture
+        ~admission_timeout_s:0.05
+        ~no_turn_deadline:true
+        ~on_turn_started_delay_s:0.2
+        path
+    with
+    | Error (Runtime_claude_code.Timeout seconds) ->
+      check (float 0.001) "host callback timeout" 0.05 seconds
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "no-deadline turn made the host state callback unbounded")
 ;;
 
 let test_state_callback_timeout_is_typed () =
@@ -1087,6 +1110,10 @@ let () =
             "no deadline starts after user message"
             `Quick
             test_no_deadline_starts_after_user_message
+        ; test_case
+            "no deadline keeps turn-started callback bounded"
+            `Quick
+            test_no_deadline_keeps_turn_started_callback_bounded
         ; test_case
             "state callback timeout is typed"
             `Quick

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -55,7 +55,7 @@ let rec drop count values =
 ;;
 
 let fixture_script ?capture_path ?initial_line_delay_s ?terminal_line_delay_s
-    ?(terminal_line_delay_start_index = 0) lines =
+    ?(terminal_line_delay_start_index = 0) ?before_final_stdin_drain_s lines =
   let path = Filename.temp_file "masc-codex-app-server-" ".sh" in
   let output = open_out_bin path in
   let read_request ?(expect_version = false) () =
@@ -95,6 +95,9 @@ let fixture_script ?capture_path ?initial_line_delay_s ?terminal_line_delay_s
            terminal_line_delay_s;
        output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
     (drop 3 lines);
+  Option.iter
+    (fun seconds -> output_string output (Printf.sprintf "sleep %.3f\n" seconds))
+    before_final_stdin_drain_s;
   output_string output "while IFS= read -r ignored; do :; done\n";
   close_out output;
   Unix.chmod path 0o700;
@@ -102,13 +105,14 @@ let fixture_script ?capture_path ?initial_line_delay_s ?terminal_line_delay_s
 ;;
 
 let with_fixture ?capture_path ?initial_line_delay_s ?terminal_line_delay_s
-    ?terminal_line_delay_start_index lines f =
+    ?terminal_line_delay_start_index ?before_final_stdin_drain_s lines f =
   let path =
     fixture_script
       ?capture_path
       ?initial_line_delay_s
       ?terminal_line_delay_s
       ?terminal_line_delay_start_index
+      ?before_final_stdin_drain_s
       lines
   in
   Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
@@ -149,7 +153,7 @@ let with_fixture_sequence ?capture_path first_lines second_lines f =
 
 let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp")
     ?(timeout_s = 2.0) ?admission_timeout_s ?(no_turn_deadline = false)
-    ?on_thread_ready_delay_s ?on_stream_event path =
+    ?on_thread_ready_delay_s ?on_turn_started_delay_s ?on_stream_event path =
   Eio_main.run (fun env ->
     let clock = Eio.Stdenv.clock env in
     let config =
@@ -166,6 +170,13 @@ let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp
            Ok ())
         on_thread_ready_delay_s
     in
+    let on_turn_started =
+      Option.map
+        (fun delay_s ~thread_id:_ ~turn_id:_ ->
+           Eio.Time.sleep clock delay_s;
+           Ok ())
+        on_turn_started_delay_s
+    in
     Runtime_codex_app_server.run_turn
       ~mgr:(Eio.Stdenv.process_mgr env)
       ~clock
@@ -174,6 +185,7 @@ let run_fixture ?(dynamic_tools = []) ?thread_mode ?(history = []) ?(cwd = "/tmp
       ?thread_mode
       ~history
       ?on_thread_ready
+      ?on_turn_started
       ?on_stream_event
       config
       ~prompt:"Return the fixture marker")
@@ -889,6 +901,90 @@ let test_no_deadline_begins_after_turn_dispatch () =
        match outcome with
        | Ok turn -> check string "turn completes" "MASC_SUBSCRIPTION_OK" turn.text
        | Error error -> fail (Runtime_codex_app_server.error_to_string error))
+;;
+
+let test_no_deadline_keeps_turn_started_callback_bounded () =
+  with_fixture
+    [ init_result; account_chatgpt; thread_result; turn_result ]
+    (fun path ->
+       match
+         run_fixture
+           ~admission_timeout_s:0.05
+           ~no_turn_deadline:true
+           ~on_turn_started_delay_s:0.2
+           path
+       with
+       | Error
+           (Runtime_codex_app_server.Timeout
+              { seconds; turn_accepted = true }) ->
+         check (float 0.001) "host callback timeout" 0.05 seconds
+       | Error
+           (Runtime_codex_app_server.Timeout
+              { turn_accepted = false; _ }) ->
+         fail "accepted turn callback timeout lost dispatch ambiguity"
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok _ -> fail "no-deadline turn made the host state callback unbounded")
+;;
+
+let test_no_deadline_keeps_post_accept_writes_bounded () =
+  let tool : Runtime_codex_app_server.dynamic_tool =
+    { name = "masc_probe"
+    ; description = "Return enough data to fill an unread transport pipe"
+    ; input_schema = `Assoc [ "type", `String "object" ]
+    ; call =
+        (fun ~call_id:_ _ ->
+          { success = true; content = String.make (1024 * 1024) 'x' })
+    }
+  in
+  with_fixture
+    ~before_final_stdin_drain_s:0.2
+    [ init_result; account_chatgpt; thread_result; turn_result; tool_call_request ]
+    (fun path ->
+       match
+         run_fixture
+           ~dynamic_tools:[ tool ]
+           ~admission_timeout_s:0.05
+           ~no_turn_deadline:true
+           path
+       with
+       | Error
+           (Runtime_codex_app_server.Timeout
+              { seconds; turn_accepted = true }) ->
+         check (float 0.001) "post-accept write timeout" 0.05 seconds
+       | Error
+           (Runtime_codex_app_server.Timeout
+              { turn_accepted = false; _ }) ->
+         fail "post-accept write timeout lost dispatch ambiguity"
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok _ -> fail "no-deadline turn made a post-accept tool write unbounded")
+;;
+
+let test_dispatch_ambiguity_precedes_turn_start_ack () =
+  let request index =
+    Printf.sprintf
+      {|{"id":"unsupported-%d","method":"item/commandExecution/requestApproval","params":{}}|}
+      index
+  in
+  let requests = List.init 2048 request in
+  with_fixture
+    ([ init_result; account_chatgpt; thread_result ] @ requests)
+    (fun path ->
+       match
+         run_fixture
+           ~admission_timeout_s:0.05
+           ~no_turn_deadline:true
+           path
+       with
+       | Error
+           (Runtime_codex_app_server.Timeout
+              { seconds; turn_accepted = true }) ->
+         check (float 0.001) "pre-ack response write timeout" 0.05 seconds
+       | Error
+           (Runtime_codex_app_server.Timeout
+              { turn_accepted = false; _ }) ->
+         fail "complete turn dispatch was classified as safe to retry"
+       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
+       | Ok _ -> fail "unread pre-ack server responses did not hit the write bound")
 ;;
 
 let test_callback_timeout_origin_is_preserved_without_deadline () =
@@ -3196,6 +3292,18 @@ let () =
             "no deadline begins after turn dispatch"
             `Quick
             test_no_deadline_begins_after_turn_dispatch
+        ; test_case
+            "no deadline keeps turn-started callback bounded"
+            `Quick
+            test_no_deadline_keeps_turn_started_callback_bounded
+        ; test_case
+            "no deadline keeps post-accept writes bounded"
+            `Quick
+            test_no_deadline_keeps_post_accept_writes_bounded
+        ; test_case
+            "dispatch ambiguity precedes turn-start acknowledgement"
+            `Quick
+            test_dispatch_ambiguity_precedes_turn_start_ack
         ; test_case
             "callback timeout origin is preserved without deadline"
             `Quick


### PR DESCRIPTION
## Summary

Follow-up to #28315 for the final review findings left on #28288.

- keep Claude and Codex host state callbacks on the finite admission timeout even when model reads are unbounded
- keep every Codex write, including dynamic-tool and pre-ack server responses, finitely bounded
- mark dispatch ambiguity immediately after the complete `turn/start` write, before acknowledgement
- add regressions for stalled host callbacks, post-accept tool writes, and pre-ack response writes

## Validation

- `git diff --check`
- changed OCaml files: `ocamlformat --check`
- changed OCaml files: `ocamlc -stop-after parsing`
- local Dune build/tests not run; CI is the build/test authority

Draft until exact-head CI completes.