### PR TITLE
fix(ci): keep Claude probe helper private

### DIFF
--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -132,13 +132,6 @@ val validate_turn :
   prompt:string ->
   (unit, error) result
 
-val bounded_subscription_probe_config
-  :  fallback_timeout_s:float
-  -> config
-  -> config
-(** Preserve an existing finite bound, or give an unbounded model turn a
-    finite authentication-preflight fallback. *)
-
 val probe_subscription :
   mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->


### PR DESCRIPTION
## Summary

Fix the main CI dead-surface regression introduced by #28315.

- keep bounded_subscription_probe_config private to runtime_claude_code.ml
- remove only the unnecessary public .mli export
- restore the dead-export count from 549 to the frozen 548 baseline

## Evidence

Failing main run: https://github.com/jeong-sik/masc/actions/runs/31566004415

- python3 scripts/audit-dead-surface.py --exports --ratchet: PASS (548, at baseline)
- ocamlformat --check lib/runtime/runtime_claude_code.mli: PASS
- git diff --check: PASS

No local Dune build was run; CI remains build/test authority.