### PR TITLE
refactor(board): id 파스를 손수 흘려보내지 말고 bind (#28311 유실분 복구)

### DIFF
--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -4,6 +4,13 @@
 
 include Board_core_persist
 
+(* Every id parse and policy check in this module already returns
+   [(_, board_error) result] and the failure is always forwarded unchanged, so
+   the arms that spell that out by hand ([| Error e -> Error e]) are
+   [Result.bind] written out. Binding them keeps the happy path at one
+   indentation level. *)
+let ( let* ) = Result.bind
+
 let rollback_fresh_comment store ~(comment : comment) ~(previous_post : post) =
   with_lock store (fun () ->
     let post_key = Post_id.to_string comment.post_id in
@@ -221,32 +228,22 @@ let add_comment_with_audience
   =
   maybe_sweep store;
   (* Validate all IDs first *)
-  match Post_id.of_string post_id with
-  | Error e -> Error e
-  | Ok pid ->
-    (match Agent_id.of_string author with
-     | Error e -> Error e
-     | Ok author_id ->
-       let parent_result =
-         match parent_id with
-         | None -> Ok None
-         | Some p ->
-           (match Comment_id.of_string p with
-            | Ok cid -> Ok (Some cid)
-            | Error e -> Error e)
-       in
-       (match parent_result with
-        | Error e -> Error e
-        | Ok parent_cid ->
-          (* Validate content *)
-          if ttl_hours < 0
-          then Error (Validation_error "ttl_hours must be non-negative")
-          else if String.length content = 0
-          then Error (Validation_error "Content cannot be empty")
-          else
-            match Board_audience.audience_for_comment ~content with
-            | Error _ as error -> error
-            | Ok audience ->
+  let* pid = Post_id.of_string post_id in
+  let* author_id = Agent_id.of_string author in
+  let* parent_cid =
+    match parent_id with
+    | None -> Ok None
+    | Some p ->
+      let* cid = Comment_id.of_string p in
+      Ok (Some cid)
+  in
+  (* Validate content *)
+  if ttl_hours < 0
+  then Error (Validation_error "ttl_hours must be non-negative")
+  else if String.length content = 0
+  then Error (Validation_error "Content cannot be empty")
+  else
+    let* audience = Board_audience.audience_for_comment ~content in
             let board_result =
               with_lock store (fun () ->
                 (* Verify post exists *)
@@ -320,7 +317,7 @@ let add_comment_with_audience
                | Error e ->
                  rollback_fresh_comment store ~comment ~previous_post;
                  Error e)
-            | Error _ as e -> e))
+            | Error _ as e -> e
 ;;
 
 let add_comment store ~post_id ~author ~content ?parent_id ?ttl_hours () =


### PR DESCRIPTION
`board_core.ml` 은 실패한 파스를 그대로 흘려보내는 arm 을 **13 번** 손으로 씁니다:

```ocaml
match Post_id.of_string post_id with
| Error e -> Error e
| Ok pid -> ...
```

`Result.bind` 를 풀어 쓴 것입니다.

## 어디가 문제였나

`add_comment_with_audience` 가 그 중 4 개를 쌓아 5 중 중첩이 됐고, **자기 들여쓰기가 이미 깨져 있었습니다** — 가장 안쪽 정책 검사의 `| Error e -> Error e` 가 자신이 속한 `match` 보다 두 단계 어긋나 있었습니다:

```ocaml
                  match
                    validate_sub_board_post_policy_unlocked store ~author_id ~hearth:post.hearth
                  with
                      | Error e -> Error e      ← 소속 match 보다 안쪽
                      | Ok () ->
                    let now = Time_compat.now () in   ← 다시 바깥
```

## 수정

파일 상단에 `let ( let* ) = Result.bind` 를 두고 그 함수의 4 개를 바인딩합니다:

```ocaml
let* pid = Post_id.of_string post_id in
let* author_id = Agent_id.of_string author in
let* parent_cid =
  match parent_id with
  | None -> Ok None
  | Some p ->
    let* cid = Comment_id.of_string p in
    Ok (Some cid)
in
```

행복 경로가 한 들여쓰기 단계에 놓이고, 함수 끝의 `))` 가 `)` 로 줄어듭니다.

**나머지 9 개는 남겼습니다.** 전부 단일 단계라 지금 형태로도 읽히고, 얻는 것이 없습니다. 숨긴 부분 분할이 아니라 의도적인 경계입니다.

동작 변화는 없습니다 — `Result.bind` 가 대체하는 arm 과 정확히 같고, 에러 타입이 맞는지는 컴파일러가 검사합니다.

## 이 PR 이 왜 따로 있나

이 커밋은 원래 #28311 에 있었는데, **머지된 뒤 그 브랜치에 push** 해서 main 에 도달하지 못했습니다. squash merge 후 브랜치에 얹은 커밋은 버려집니다(`workflow-pr.md` §10, 근거 masc#5303 — 같은 방식으로 16 개 브랜치의 커밋이 유실). push 전에 PR 상태를 확인했어야 했습니다.

`#28311` 의 스케줄 변경은 정상적으로 main 에 있습니다(`Primary_absent` 7 건 확인). 이 커밋만 유실됐습니다.

## 검증

```
dune build --root . lib/board/          → clean
```

`test_board_dispatch` 는 이 변경과 무관하게 main 에서 이미 4 케이스 실패합니다(`posts 12`, `posts 19`, `posts 20`, `validation 3`). 변경을 적용/미적용한 양쪽에서 **같은 4 건**이고 다섯 번째는 나타나지 않습니다 — 대조군으로 확인했습니다. 그 실패와 이 스위트가 CI 에 배선되지 않은 사실은 #28321 에 따로 기록했습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
