### PR TITLE
refactor(gate): remove duplicated connector projections

### DIFF
--- a/dashboard/design-system/prototype-v2/notes/grounding.md
+++ b/dashboard/design-system/prototype-v2/notes/grounding.md
@@ -36,8 +36,8 @@ mention-inbox, composer-v2, message-workspace-timeline.
 ## Connectors (api/schemas/gate-connectors.ts)
 - GET /api/v1/gate/connectors → { connectors[], total, active_count, generated_at }
 - Connector: connector_id, display_name, channel, capabilities[], status, available, connected, stale, stale_after_sec, error, updated_at, reply_mode, self_chat_guid (iMessage), last_ready_at, bot_user_name/id, guild_count, gate_base_url, gate_healthy, pid.
-- configured_bindings: [{channel_id, keeper_name}]; recent_audit: [{timestamp, action, guild_id, channel_id, keeper_name, actor_id, actor_name, previous_keeper}]
-- binding_summary {binding_source, runtime_bindings_count, configured_bindings_count}; names {guild_names, channel_names}.
+- configured_bindings: [{channel_id, keeper_name}]; recent_audit: [{timestamp, action, guild_id?, channel_id, keeper_name, actor_id, actor_name, previous_keeper}]
+- Discord names: {guild_names, channel_names, channel_to_guild, channel_to_parent}.
 
 ## Repo stack
 dashboard = Preact + htm + lucide-preact + Tailwind tokens (--color-bg-page/surface/elevated, --color-border-default/strong, --color-fg-*, text-ok). Tests everywhere (vitest).

--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -13,7 +13,6 @@ module type S = sig
   val channel : string
   val status_json : ?audit_limit:int -> unit -> Yojson.Safe.t
   val connector_json :
-    ?gate_status_json:Yojson.Safe.t ->
     ?audit_limit:int ->
     unit ->
     Yojson.Safe.t
@@ -62,12 +61,12 @@ let all () =
   with_registry_lock (fun () ->
     Hashtbl.fold (fun _k v acc -> v :: acc) registry [])
 
-let connectors_json ?gate_status_json ?(audit_limit = 10) () =
+let connectors_json ?(audit_limit = 10) () =
   let connectors = all () in
   let connector_jsons =
     List.map
       (fun (module C : S) ->
-        C.connector_json ?gate_status_json ~audit_limit ())
+        C.connector_json ~audit_limit ())
       connectors
   in
   let active_count =

--- a/lib/gate/channel_gate_connector.mli
+++ b/lib/gate/channel_gate_connector.mli
@@ -34,7 +34,6 @@ module type S = sig
   (** Runtime status snapshot for this connector. *)
 
   val connector_json :
-    ?gate_status_json:Yojson.Safe.t ->
     ?audit_limit:int ->
     unit ->
     Yojson.Safe.t
@@ -91,6 +90,6 @@ val find : string -> (module S) option
 val all : unit -> (module S) list
 (** Snapshot of all registered connectors, in unspecified order. *)
 
-val connectors_json : ?gate_status_json:Yojson.Safe.t -> ?audit_limit:int -> unit -> Yojson.Safe.t
+val connectors_json : ?audit_limit:int -> unit -> Yojson.Safe.t
 (** Aggregate descriptor for all registered connectors.
     Returns [{connectors: [...], total: N, active_count: N, generated_at: "..."}]. *)

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -269,74 +269,8 @@ let status_json ?(audit_limit = 10) () =
       ("recent_audit", `List recent_audit);
     ]
 
-let list_assoc_field key = function
-  | `Assoc fields -> List.assoc_opt key fields
-  | _ -> None
-
-let connector_json ?gate_status_json ?(audit_limit = 10) () =
+let connector_json ?(audit_limit = 10) () =
   let status = status_json ~audit_limit () in
-  let observed_channel =
-    match gate_status_json with
-    | None -> `Null
-    | Some json -> (
-        match list_assoc_field "channels" json with
-        | Some channels -> (
-            match
-              Json_util.find_assoc_row_by_string_field ~field:"channel"
-                ~value:channel channels
-            with
-            | Some row -> row
-            | None -> `Null)
-        | None -> `Null)
-  in
-  let storage_paths =
-    `Assoc
-      [
-        ("status_path", `String (string_member status "status_path"));
-        ( "binding_store_path",
-          `String (string_member status "binding_store_path") );
-        ("audit_path", `String (string_member status "audit_path"));
-        ("names_path", `String (string_member status "names_path"));
-      ]
-  in
-  let runtime_summary =
-    `Assoc
-      [
-        ("available", `Bool (bool_member status "available"));
-        ("connected", `Bool (bool_member status "connected"));
-        ("stale", `Bool (bool_member status "stale"));
-        ("stale_after_sec", `Int (int_member status "stale_after_sec"));
-        ("status", `String (string_member status "status"));
-        ("error", `String (string_member status "error"));
-        ("updated_at", `String (string_member status "updated_at"));
-        ("last_ready_at", `String (string_member status "last_ready_at"));
-        ("bot_user_name", `String (string_member status "bot_user_name"));
-        ("bot_user_id", `String (string_member status "bot_user_id"));
-        ("guild_count", `Int (int_member status "guild_count"));
-        ("gate_base_url", `String (string_member status "gate_base_url"));
-        ( "gate_healthy",
-          Option.value ~default:`Null
-            (Option.map (fun value -> `Bool value)
-               (bool_option_member status "gate_healthy")) );
-        ( "gate_health_checked_at",
-          `String (string_member status "gate_health_checked_at") );
-        ("pid", `Int (int_member status "pid"));
-      ]
-  in
-  let binding_summary =
-    `Assoc
-      [
-        ("binding_source", `String (string_member status "binding_source"));
-        ( "runtime_bindings_count",
-          `Int (int_member status "runtime_bindings_count") );
-        ( "configured_bindings_count",
-          `Int
-            (Json_util.get_array status "configured_bindings"
-             |> Option.map (function `List l -> List.length l | _ -> 0)
-             |> Option.value ~default:0)
-        );
-      ]
-  in
   `Assoc
     [
       ("connector_id", `String connector_id);
@@ -349,9 +283,13 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("connected", `Bool (bool_member status "connected"));
       ("stale", `Bool (bool_member status "stale"));
       ("stale_after_sec", `Int (int_member status "stale_after_sec"));
+      ("status_source", status |> U.member "status_source");
+      ("gateway_state", status |> U.member "gateway_state");
       ("error", `String (string_member status "error"));
       ("status_path", `String (string_member status "status_path"));
       ("binding_store_path", `String (string_member status "binding_store_path"));
+      ("binding_store_read_ok", status |> U.member "binding_store_read_ok");
+      ("binding_store_error", status |> U.member "binding_store_error");
       ("audit_path", `String (string_member status "audit_path"));
       ("names_path", `String (string_member status "names_path"));
       ("names", status |> U.member "names");
@@ -372,10 +310,6 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("pid", `Int (int_member status "pid"));
       ("configured_bindings", status |> U.member "configured_bindings");
       ("recent_audit", status |> U.member "recent_audit");
-      ("storage_paths", storage_paths);
-      ("runtime_summary", runtime_summary);
-      ("binding_summary", binding_summary);
-      ("observed_channel", observed_channel);
     ]
 
 let bind ~channel_id ~keeper_name ~actor_name =

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -34,12 +34,10 @@ val status_json : ?audit_limit:int -> unit -> Yojson.Safe.t
     audit-history slice (default [10]). *)
 
 val connector_json :
-  ?gate_status_json:Yojson.Safe.t ->
   ?audit_limit:int ->
   unit ->
   Yojson.Safe.t
-(** Full connector descriptor for the dashboard, layering
-    [gate_status_json] (if provided) on top of {!status_json}. *)
+(** Full connector descriptor for the dashboard. *)
 
 (** {1 Binding lifecycle} *)
 

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -168,26 +168,8 @@ let status_json ?(audit_limit = 10) () =
       ("recent_audit", `List recent_audit);
     ]
 
-let list_assoc_field key = function
-  | `Assoc fields -> List.assoc_opt key fields
-  | _ -> None
-
-let connector_json ?gate_status_json ?(audit_limit = 10) () =
+let connector_json ?(audit_limit = 10) () =
   let status = status_json ~audit_limit () in
-  let observed_channel =
-    match gate_status_json with
-    | None -> `Null
-    | Some json -> (
-        match list_assoc_field "channels" json with
-        | Some channels -> (
-            match
-              Json_util.find_assoc_row_by_string_field ~field:"channel"
-                ~value:channel channels
-            with
-            | Some row -> row
-            | None -> `Null)
-        | None -> `Null)
-  in
   `Assoc
     [
       ("connector_id", `String connector_id);
@@ -220,7 +202,6 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("pid", `Int (int_member status "pid"));
       ("configured_bindings", status |> U.member "configured_bindings");
       ("recent_audit", status |> U.member "recent_audit");
-      ("observed_channel", observed_channel);
     ]
 
 let bind ~channel_id ~keeper_name ~actor_name =

--- a/lib/gate/channel_gate_imessage_state.mli
+++ b/lib/gate/channel_gate_imessage_state.mli
@@ -29,12 +29,10 @@ val status_json : ?audit_limit:int -> unit -> Yojson.Safe.t
     audit-history slice (default [10]). *)
 
 val connector_json :
-  ?gate_status_json:Yojson.Safe.t ->
   ?audit_limit:int ->
   unit ->
   Yojson.Safe.t
-(** Full connector descriptor for the dashboard, layering
-    [gate_status_json] (if provided) on top of {!status_json}. *)
+(** Full connector descriptor for the dashboard. *)
 
 (** {1 Binding lifecycle} *)
 

--- a/lib/gate/channel_gate_sidecar_state.ml
+++ b/lib/gate/channel_gate_sidecar_state.ml
@@ -184,80 +184,8 @@ module Make (Config : Config) = struct
         ("recent_audit", `List recent_audit);
       ]
 
-  let list_assoc_field key = function
-    | `Assoc fields -> List.assoc_opt key fields
-    | _ -> None
-
-  let find_assoc_by_string_field ~field ~value = function
-    | `List rows ->
-        List.find_map
-          (function
-            | (`Assoc _ as row) -> (
-                match list_assoc_field field row with
-                | Some (`String candidate) when String.equal candidate value -> Some row
-                | _ -> None)
-            | _ -> None)
-          rows
-    | _ -> None
-
-  let connector_json ?gate_status_json ?(audit_limit = 10) () =
+  let connector_json ?(audit_limit = 10) () =
     let status = status_json ~audit_limit () in
-    let observed_channel =
-      match gate_status_json with
-      | None -> `Null
-      | Some json -> (
-          match list_assoc_field "channels" json with
-          | Some channels -> (
-              match find_assoc_by_string_field ~field:"channel" ~value:channel channels with
-              | Some row -> row
-              | None -> `Null)
-          | None -> `Null)
-    in
-    let storage_paths =
-      `Assoc
-        [
-          ("status_path", `String (string_member status "status_path"));
-          ( "binding_store_path",
-            `String (string_member status "binding_store_path") );
-          ("audit_path", `String (string_member status "audit_path"));
-          ("names_path", `String "");
-        ]
-    in
-    let runtime_summary =
-      `Assoc
-        [
-          ("available", `Bool (bool_member status "available"));
-          ("connected", `Bool (bool_member status "connected"));
-          ("stale", `Bool (bool_member status "stale"));
-          ("stale_after_sec", `Int (int_member status "stale_after_sec"));
-          ("status", `String (string_member status "status"));
-          ("error", `String (string_member status "error"));
-          ("updated_at", `String (string_member status "updated_at"));
-          ("last_message_at", `String (string_member status "last_message_at"));
-          ("gate_base_url", `String (string_member status "gate_base_url"));
-          ( "gate_healthy",
-            Option.value ~default:`Null
-              (Option.map (fun value -> `Bool value)
-                 (bool_option_member status "gate_healthy")) );
-          ( "gate_health_checked_at",
-            `String (string_member status "gate_health_checked_at") );
-          ("pid", `Int (int_member status "pid"));
-        ]
-    in
-    let configured_bindings =
-      match status |> U.member "configured_bindings" with
-      | `List rows -> rows
-      | _ -> []
-    in
-    let binding_summary =
-      `Assoc
-        [
-          ("binding_source", `String (string_member status "binding_source"));
-          ( "runtime_bindings_count",
-            `Int (int_member status "runtime_bindings_count") );
-          ("configured_bindings_count", `Int (List.length configured_bindings));
-        ]
-    in
     `Assoc
       [
         ("connector_id", `String connector_id);
@@ -292,18 +220,6 @@ module Make (Config : Config) = struct
         ("pid", `Int (int_member status "pid"));
         ("configured_bindings", status |> U.member "configured_bindings");
         ("recent_audit", status |> U.member "recent_audit");
-        ("storage_paths", storage_paths);
-        ("runtime_summary", runtime_summary);
-        ("binding_summary", binding_summary);
-        ("observed_channel", observed_channel);
-        ( "names",
-          `Assoc
-            [
-              ("guild_names", `Assoc []);
-              ("channel_names", `Assoc []);
-              ("channel_to_guild", `Assoc []);
-              ("updated_at", `String "");
-            ] );
       ]
 
   let bind ~channel_id ~keeper_name ~actor_name =

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -10,6 +10,7 @@
    typing indicator (Slack's is a separate Web API we don't surface yet). *)
 
 module Store = Channel_gate_binding_store
+module U = Yojson.Safe.Util
 
 type binding = Store.binding = {
   channel_id : string;
@@ -64,6 +65,12 @@ let set_trigger_policy (p : Slack_gateway_state.trigger_policy) =
   trigger_policy_ref := Some p
 
 let get_trigger_policy () = !trigger_policy_ref
+
+let trigger_policy_json () =
+  match get_trigger_policy () with
+  | None -> `Null
+  | Some policy ->
+    `String (Slack_gateway_state.trigger_policy_to_string policy)
 
 (* Outbound REST uses the bot token (xoxb-...). The app token (xapp-...) is read
    only by {!Slack_socket_client} for apps.connections.open. Both resolve
@@ -141,6 +148,7 @@ let status_json ?(audit_limit = 10) () =
   `Assoc
     [ ("channel", `String channel)
     ; ("capabilities", Channel_gate_connector_capability.all_json)
+    ; ("trigger_policy", trigger_policy_json ())
     ; ("available", `Bool available)
     ; ("connected", `Bool connected)
     ; ("stale", `Bool stale)
@@ -161,8 +169,6 @@ let status_json ?(audit_limit = 10) () =
     ; ("runtime_bindings_count", `Int (List.length configured_bindings))
     ; ("configured_bindings", `List configured_binding_json)
     ; ("recent_audit", `List recent_audit)
-    ; ("bindings", `List configured_binding_json)
-    ; ("audit", `List recent_audit)
     ; ("bot_token_present", `Bool bot_present)
     ; ("app_token_present", `Bool app_present)
     ; ("updated_at", `String updated_at)
@@ -178,39 +184,38 @@ let status_json ?(audit_limit = 10) () =
            | None -> "") )
     ]
 
-let connector_json ?gate_status_json ?(audit_limit = 10) () =
+let connector_json ?(audit_limit = 10) () =
   let status = status_json ~audit_limit () in
-  let base =
-    match gate_status_json with
-    | None -> status
-    | Some extra ->
-      `Assoc
-        (match (status, extra) with
-         | `Assoc s, `Assoc e -> s @ e
-         | _ -> [ ("status", status); ("gate_status", extra) ])
+  let fields =
+    [ "channel"
+    ; "capabilities"
+    ; "trigger_policy"
+    ; "available"
+    ; "connected"
+    ; "stale"
+    ; "stale_after_sec"
+    ; "status"
+    ; "error"
+    ; "status_source"
+    ; "gateway_state"
+    ; "status_path"
+    ; "binding_store_path"
+    ; "audit_path"
+    ; "binding_source"
+    ; "binding_store_read_ok"
+    ; "binding_store_error"
+    ; "runtime_bindings_count"
+    ; "configured_bindings"
+    ; "recent_audit"
+    ; "updated_at"
+    ; "last_ready_at"
+    ; "bot_user_id"
+    ]
   in
-  (* The dashboard connectors endpoint
-     ([Channel_gate_connector.connectors_json]) matches each connector to its
-     tile by [connector_id]; the dashboard's [findConnector(connectors,
-     "slack")] returns null without it, so a connected Slack gateway rendered
-     as an unstarted "설정 필요" placeholder. Mirror Discord/Telegram
-     [connector_json], which carry both identity fields at the top level.
-     Prepend (with a dedupe filter) so the identity is authoritative even if a
-     merged [gate_status_json] also supplied the keys. *)
-  match base with
-  | `Assoc fields ->
-    let without_identity =
-      List.filter
-        (fun (k, _) ->
-          not
-            (String.equal k "connector_id" || String.equal k "display_name"))
-        fields
-    in
-    `Assoc
-      (("connector_id", `String connector_id)
-      :: ("display_name", `String display_name)
-      :: without_identity)
-  | other -> other
+  `Assoc
+    (("connector_id", `String connector_id)
+     :: ("display_name", `String display_name)
+     :: List.map (fun field -> field, status |> U.member field) fields)
 
 let bind ~channel_id ~keeper_name ~actor_name =
   let channel_id = String.trim channel_id in

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -229,11 +229,7 @@ let handle_gate_connectors _state request reqd =
     int_query_param request "audit_limit" ~default:10
     |> fun value -> max 1 (min 50 value)
   in
-  let gate_status = Channel_gate_metrics.snapshot_json () in
-  let json =
-    Channel_gate_connector.connectors_json ~gate_status_json:gate_status
-      ~audit_limit ()
-  in
+  let json = Channel_gate_connector.connectors_json ~audit_limit () in
   respond_public_read_json_value ~status:`OK request reqd json
 
 (** GET /api/v1/gate/connector/status?name=<connector>&audit_limit=<n>

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -238,17 +238,11 @@ let test_slack_connector_json_carries_identity () =
       "connector capabilities use the canonical projection"
       Channel_gate_connector_capability.all_json
       (json |> U.member "capabilities");
-    (* The endpoint passes [~gate_status_json]; identity must survive the
-       merge, since it is the tile-matching key. *)
-    let merged =
-      Channel_gate_slack_state.connector_json
-        ~gate_status_json:(`Assoc [ ("channels", `List []) ])
-        ()
-    in
-    check string "connector id survives gate_status merge" "slack"
-      (merged |> U.member "connector_id" |> U.to_string);
-    check string "display name survives gate_status merge" "Slack"
-      (merged |> U.member "display_name" |> U.to_string))
+    check string "status source" "in_process_gateway"
+      (json |> U.member "status_source" |> U.to_string);
+    check bool "gateway state surfaced" true
+      (json |> U.member "gateway_state" |> U.to_string
+       |> String.trim |> String.length > 0))
 
 let () =
   run "channel_gate_connector_routes"

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -8,8 +8,7 @@ module Registry_test_connector_a = struct
   let display_name = "Registry Test A"
   let channel = "registry-test"
   let status_json ?(audit_limit = 10) () = ignore audit_limit; `Assoc []
-  let connector_json ?gate_status_json ?(audit_limit = 10) () =
-    ignore gate_status_json;
+  let connector_json ?(audit_limit = 10) () =
     ignore audit_limit;
     `Assoc
       [ "connector_id", `String connector_id
@@ -26,8 +25,7 @@ module Registry_test_connector_b = struct
   include Registry_test_connector_a
 
   let display_name = "Registry Test B"
-  let connector_json ?gate_status_json ?(audit_limit = 10) () =
-    ignore gate_status_json;
+  let connector_json ?(audit_limit = 10) () =
     ignore audit_limit;
     `Assoc
       [ "connector_id", `String connector_id
@@ -243,23 +241,8 @@ let test_connectors_json_advertises_gate_connector_descriptor () =
           ("runtime_bindings_count", `Int 1);
           ("pid", `Int 4242);
         ]);
-    let gate_status_json =
-      `Assoc
-        [
-          ( "channels",
-            `List
-              [
-                `Assoc
-                  [
-                    ("channel", `String "discord");
-                    ("message_count", `Int 3);
-                    ("success_rate_pct", `Int 100);
-                  ];
-              ] );
-        ]
-    in
     Channel_gate_connector.register (module Discord_state);
-    let json = Channel_gate_connector.connectors_json ~gate_status_json () in
+    let json = Channel_gate_connector.connectors_json () in
     let connectors = json |> U.member "connectors" |> U.to_list in
     check int "one connector" 1 (List.length connectors);
     let connector = List.hd connectors in
@@ -279,9 +262,11 @@ let test_connectors_json_advertises_gate_connector_descriptor () =
        |> List.exists (function
             | `String "bindings" -> true
             | _ -> false));
-    check string "observed channel surfaced" "discord"
-      (connector |> U.member "observed_channel" |> U.member "channel"
-       |> U.to_string))
+    check string "status source surfaced" "in_process_gateway"
+      (connector |> U.member "status_source" |> U.to_string);
+    check bool "gateway state surfaced" true
+      (connector |> U.member "gateway_state" |> U.to_string
+       |> String.trim |> String.length > 0))
 
 let test_registry_register_replaces_and_all_snapshots () =
   Channel_gate_connector.register (module Registry_test_connector_a);


### PR DESCRIPTION
## Summary

- stop injecting the gate metrics snapshot into every connector descriptor
- remove the duplicate connector projections and fake empty name maps
- make Slack emit an explicit descriptor and expose in-process trigger/gateway state consistently with Discord
- remove the unused Slack binding/audit aliases and update the current wire notes

This leaves `/api/v1/gate/status` and `/api/v1/gate/connectors` as independent producer contracts before their dashboard Effect migrations.

## Verification

- `opam exec -- ocamlformat --check` on all changed OCaml files
- `git diff --check`
- `test_channel_gate_connector_routes.exe`: 12/12 passed
- `test_channel_gate_discord_state.exe`: 19/19 passed

The focused Dune build currently hits the unrelated current-main Yojson 3 compile regression tracked in #28319. For the two focused tests only, I removed those invalid match arms locally, built and ran the tests, then restored the file; it is absent from this PR diff.
