### PR TITLE
fix(mcp): repair typed call request build

### DIFF
--- a/lib/mcp_server_eio_call_request.ml
+++ b/lib/mcp_server_eio_call_request.ml
@@ -51,9 +51,7 @@ let decode = function
              | `Intlit _
              | `Float _
              | `String _
-             | `List _
-             | `Tuple _
-             | `Variant _)
+             | `List _)
            ->
            Error (Arguments_must_be_object requested_name))
      | Present
@@ -63,9 +61,7 @@ let decode = function
          | `Intlit _
          | `Float _
          | `Assoc _
-         | `List _
-         | `Tuple _
-         | `Variant _)
+         | `List _)
        -> Error Name_must_be_string)
   | Some
       (`Null
@@ -74,9 +70,7 @@ let decode = function
       | `Intlit _
       | `Float _
       | `String _
-      | `List _
-      | `Tuple _
-      | `Variant _) ->
+      | `List _) ->
     Error Expected_object
 ;;
 

--- a/test/test_identity_edge_cases.ml
+++ b/test/test_identity_edge_cases.ml
@@ -96,7 +96,11 @@ let test_null_payload () =
      && String.sub identity.agent_name 0 6 = "agent-")
 
 let check_arguments label expected params =
-  let actual = Mcp_server_eio_call_tool.For_testing.arguments_of_params params in
+  let actual =
+    match Mcp_server_eio_call_request.decode (Some params) with
+    | Ok request -> Mcp_server_eio_call_request.arguments request
+    | Error _ -> `Null
+  in
   check string label (Yojson.Safe.to_string expected) (Yojson.Safe.to_string actual)
 ;;
 

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -134,7 +134,6 @@ let test_call_request_rejects_noncanonical_shapes () =
   in
   rejected "Missing params" None;
   rejected "Invalid params: expected object" (Some (`List []));
-  rejected "Invalid params: expected object" (Some (`Tuple []));
   rejected "Invalid params: name must be a string" (Some (`Assoc []));
   rejected
     "Invalid params: name must be a non-empty string"
@@ -147,13 +146,6 @@ let test_call_request_rejects_noncanonical_shapes () =
     (Some
        (`Assoc
          [ "name", `String "masc_status"; "arguments", `Null ]));
-  rejected
-    "Invalid params: arguments must be an object"
-    (Some
-       (`Assoc
-         [ "name", `String "masc_status"
-         ; "arguments", `Variant ("invalid", None)
-         ]));
   rejected
     "Invalid params: duplicate name field"
     (Some


### PR DESCRIPTION
## Summary
- remove unsupported Yojson Tuple and Variant branches from the typed MCP call-request decoder
- update the identity regression to use Mcp_server_eio_call_request after the old test-only projection was removed
- remove impossible Yojson.Safe fixtures from the call-tool tests

## Why
Exact-head main run 31566004415 failed Build and Test after #28296 with three compile errors:
- invalid Tuple pattern in lib/mcp_server_eio_call_request.ml
- removed Mcp_server_eio_call_tool.For_testing.arguments_of_params reference
- invalid Tuple fixture in test/test_mcp_server_eio_call_tool.ml

## Verification
- ocamlformat --check on all changed OCaml files — passed
- ocamlc -stop-after parsing on all changed implementations/tests — passed
- python3 scripts/audit-dead-surface.py --exports --ratchet — 548, at baseline
- git diff --check — passed
- local Dune intentionally not run; exact-head CI remains the build/test authority

## Evidence
- failing main run: https://github.com/jeong-sik/masc/actions/runs/31566004415
- exact base: c76d4677b5a2bbdd2164d137459a39aeb055b37f
- exact head: 73f4e9afbb