### PR TITLE
fix(ci): enforce Keeper acceptance on protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
         id: scope
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GITHUB_BEFORE: ${{ github.event.before }}
@@ -393,6 +394,15 @@ jobs:
             # workflow/action edits should still validate the core OCaml/repo
             # guard lanes and Health, but they should not fan out into every
             # feature surface.
+          fi
+
+          # Push CI is latest-state authority: a newer main push cancels the
+          # prior run, so every surviving protected-main run must carry the
+          # real-world obligation even when its own diff is Keeper-neutral.
+          # Otherwise a docs-only follow-up can cancel the Keeper acceptance
+          # for the commit immediately before it and then skip RW01-RW16.
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            keeper_realworld=true
           fi
 
           echo "build=${build}" >> "$GITHUB_OUTPUT"
@@ -1400,7 +1410,10 @@ jobs:
       - name: Package exact-revision Keeper acceptance runtime
         if: >-
           needs.changes.outputs.keeper_realworld == 'true' &&
-          github.event_name == 'workflow_dispatch' &&
+          (
+            github.event_name == 'push' ||
+            github.event_name == 'workflow_dispatch'
+          ) &&
           github.ref == 'refs/heads/main' &&
           github.ref_protected == true
         env:
@@ -1417,10 +1430,13 @@ jobs:
           runtime_dir=keeper-realworld-runtime
           mkdir -p "$runtime_dir"
           expected_workflow_ref="${GITHUB_REPOSITORY}/.github/workflows/ci.yml@refs/heads/main"
-          if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
-            echo "trusted runtime packaging requires workflow_dispatch, got $EVENT_NAME" >&2
-            exit 1
-          fi
+          case "$EVENT_NAME" in
+            push|workflow_dispatch) ;;
+            *)
+              echo "trusted runtime packaging requires push or workflow_dispatch, got $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
           if [ "$EXPECTED_SOURCE_REF" != "refs/heads/main" ]; then
             echo "trusted runtime packaging requires refs/heads/main, got $EXPECTED_SOURCE_REF" >&2
             exit 1
@@ -1472,7 +1488,10 @@ jobs:
       - name: Upload exact-revision Keeper acceptance runtime
         if: >-
           needs.changes.outputs.keeper_realworld == 'true' &&
-          github.event_name == 'workflow_dispatch' &&
+          (
+            github.event_name == 'push' ||
+            github.event_name == 'workflow_dispatch'
+          ) &&
           github.ref == 'refs/heads/main' &&
           github.ref_protected == true
         uses: actions/upload-artifact@v7
@@ -1533,7 +1552,10 @@ jobs:
       ${{
         always() &&
         !cancelled() &&
-        github.event_name == 'workflow_dispatch' &&
+        (
+          github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch'
+        ) &&
         github.ref == 'refs/heads/main' &&
         github.ref_protected == true &&
         needs.pr-live-gate.outputs.run_heavy == 'true' &&
@@ -1579,6 +1601,7 @@ jobs:
           KEEPER_ACCEPTANCE_BINARY: ${{ github.workspace }}/keeper-realworld-runtime/masc
           KEEPER_ACCEPTANCE_MANIFEST: ${{ github.workspace }}/keeper-realworld-runtime/manifest.json
           KEEPER_ACCEPTANCE_OUTPUT_DIR: ${{ runner.temp }}/keeper-realworld-evidence
+          KEEPER_ACCEPTANCE_EXPECTED_EVENT: ${{ github.event_name }}
           KEEPER_ACCEPTANCE_EXPECTED_SHA: ${{ github.sha }}
           KEEPER_ACCEPTANCE_EXPECTED_REF: ${{ github.ref }}
           KEEPER_ACCEPTANCE_EXPECTED_REF_PROTECTED: ${{ github.ref_protected }}
@@ -1629,13 +1652,15 @@ jobs:
           ACCEPTANCE_RESULT: ${{ needs.keeper-realworld-acceptance.result }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] || {
+            [ "$EVENT_NAME" = "push" ] && [ "$EVENT_REF" = "refs/heads/main" ];
+          }; then
             if [ "$EVENT_REF" != "refs/heads/main" ]; then
-              echo "STOP Keeper Real-World Gate: trusted dispatch requires refs/heads/main, got $EVENT_REF" >&2
+              echo "STOP Keeper Real-World Gate: trusted acceptance requires refs/heads/main, got $EVENT_REF" >&2
               exit 1
             fi
             if [ "$EVENT_REF_PROTECTED" != "true" ]; then
-              echo "STOP Keeper Real-World Gate: trusted dispatch requires protected main" >&2
+              echo "STOP Keeper Real-World Gate: trusted acceptance requires protected main" >&2
               exit 1
             fi
             expected_workflow_ref="$REPOSITORY/.github/workflows/ci.yml@refs/heads/main"
@@ -1652,8 +1677,12 @@ jobs:
               exit 1
             fi
             if [ "$REALWORLD_REQUIRED" != "true" ]; then
-              echo "STOP Keeper Real-World Gate: workflow_dispatch did not select product acceptance" >&2
-              exit 1
+              if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+                echo "STOP Keeper Real-World Gate: workflow_dispatch did not select product acceptance" >&2
+                exit 1
+              fi
+              echo "PASS Keeper Real-World Gate: product-critical Keeper surfaces unchanged on protected main"
+              exit 0
             fi
             if [ "$BUILD_RESULT" != "success" ]; then
               echo "STOP Keeper Real-World Gate: exact-revision runtime was not built successfully" >&2
@@ -1663,7 +1692,7 @@ jobs:
               echo "FAIL Keeper Real-World Gate: acceptance result=$ACCEPTANCE_RESULT" >&2
               exit 1
             fi
-            echo "PASS Keeper Real-World Gate: trusted ref=$EVENT_REF workflow=$EVENT_WORKFLOW_REF candidate=$TESTED_SOURCE_SHA passed RW01-RW16"
+            echo "PASS Keeper Real-World Gate: trusted event=$EVENT_NAME ref=$EVENT_REF workflow=$EVENT_WORKFLOW_REF candidate=$TESTED_SOURCE_SHA passed RW01-RW16"
             exit 0
           fi
           if [ "$EVENT_NAME" != "pull_request" ]; then
@@ -1687,8 +1716,8 @@ jobs:
             echo "STOP Keeper Real-World Gate: PR head moved expected=$EXPECTED_HEAD_SHA actual=$live_head_sha" >&2
             exit 1
           fi
-          echo "::warning::Secret-bearing RW01-RW16 is deferred to a protected main workflow_dispatch after merge"
-          echo "PASS Keeper Real-World Gate: stable PR head=$live_head_sha passed source gates; protected-main product acceptance required after merge"
+          echo "::warning::Secret-bearing RW01-RW16 is deferred to the automatic protected-main CI after merge"
+          echo "PASS Keeper Real-World Gate: stable PR head=$live_head_sha passed source gates; protected-main product acceptance is automatically enforced after merge"
 
   lint:
     name: Lint

--- a/scripts/ci/check-keeper-realworld-secret-boundary.py
+++ b/scripts/ci/check-keeper-realworld-secret-boundary.py
@@ -36,6 +36,7 @@ workflow = WORKFLOW.read_text(encoding="utf-8")
 runner = RUNNER.read_text(encoding="utf-8")
 
 live_gate = indented_block(workflow, "pr-live-gate:", 2)
+changes = indented_block(workflow, "changes:", 2)
 acceptance = indented_block(workflow, "keeper-realworld-acceptance:", 2)
 product_gate = indented_block(workflow, "keeper-realworld-gate:", 2)
 package_step = indented_block(
@@ -55,18 +56,31 @@ for context, block in (
     require(block, "refs/heads/main", context)
     require(block, "ref_protected", context)
 
-require(acceptance, "github.event_name == 'workflow_dispatch'", "acceptance job")
+for trusted_event in ("push", "workflow_dispatch"):
+    require(
+        acceptance,
+        f"github.event_name == '{trusted_event}'",
+        "acceptance job",
+    )
 if "github.event_name == 'pull_request'" in acceptance:
     fail("acceptance job still admits pull_request refs")
 require(acceptance, "ZAI_API_KEY_SB: ${{ secrets.ZAI_API_KEY_SB }}", "acceptance job")
 if workflow.count("ZAI_API_KEY_SB: ${{ secrets.ZAI_API_KEY_SB }}") != 1:
     fail("CI workflow must expose ZAI_API_KEY_SB in exactly one guarded job")
 
+for main_push_guard in (
+    '${GITHUB_EVENT_NAME}" = "push"',
+    '${GITHUB_REF}" = "refs/heads/main"',
+    "keeper_realworld=true",
+):
+    require(changes, main_push_guard, "protected-main acceptance obligation")
+
 for context, block in (
     ("runtime package step", package_step),
     ("runtime upload step", upload_step),
 ):
-    require(block, "github.event_name == 'workflow_dispatch'", context)
+    for trusted_event in ("push", "workflow_dispatch"):
+        require(block, f"github.event_name == '{trusted_event}'", context)
     if "github.event_name == 'pull_request'" in block:
         fail(f"{context} still admits pull_request refs")
 
@@ -80,6 +94,8 @@ for field in (
     require(package_step, field, "runtime manifest")
 
 for evidence in (
+    '"$EVENT_NAME" = "push"',
+    '"$EVENT_NAME" = "workflow_dispatch"',
     "EVENT_REF_PROTECTED",
     "EVENT_WORKFLOW_REF",
     "EVENT_WORKFLOW_SHA",
@@ -87,11 +103,13 @@ for evidence in (
     require(product_gate, evidence, "product gate")
 
 for check in (
+    "KEEPER_ACCEPTANCE_EXPECTED_EVENT",
     "KEEPER_ACCEPTANCE_EXPECTED_REF",
     "KEEPER_ACCEPTANCE_EXPECTED_REF_PROTECTED",
     "KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_REF",
     "KEEPER_ACCEPTANCE_EXPECTED_WORKFLOW_SHA",
     "masc.keeper_acceptance_runtime.v2",
+    "manifest_event",
     "manifest_ref_protected",
     "manifest_workflow_ref",
     "manifest_workflow_sha",

--- a/scripts/ci/run-keeper-realworld-acceptance.sh
+++ b/scripts/ci/run-keeper-realworld-acceptance.sh
@@ -11,6 +11,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BINARY="${KEEPER_ACCEPTANCE_BINARY:?KEEPER_ACCEPTANCE_BINARY is required}"
 MANIFEST="${KEEPER_ACCEPTANCE_MANIFEST:?KEEPER_ACCEPTANCE_MANIFEST is required}"
 OUTPUT_DIR="${KEEPER_ACCEPTANCE_OUTPUT_DIR:?KEEPER_ACCEPTANCE_OUTPUT_DIR is required}"
+EXPECTED_EVENT="${KEEPER_ACCEPTANCE_EXPECTED_EVENT:?KEEPER_ACCEPTANCE_EXPECTED_EVENT is required}"
 EXPECTED_SHA="${KEEPER_ACCEPTANCE_EXPECTED_SHA:?KEEPER_ACCEPTANCE_EXPECTED_SHA is required}"
 EXPECTED_REF="${KEEPER_ACCEPTANCE_EXPECTED_REF:?KEEPER_ACCEPTANCE_EXPECTED_REF is required}"
 EXPECTED_REF_PROTECTED="${KEEPER_ACCEPTANCE_EXPECTED_REF_PROTECTED:?KEEPER_ACCEPTANCE_EXPECTED_REF_PROTECTED is required}"
@@ -33,6 +34,10 @@ done
 
 [[ -f "$BINARY" ]] || fail "binary not found: $BINARY"
 [[ -f "$MANIFEST" ]] || fail "manifest not found: $MANIFEST"
+case "$EXPECTED_EVENT" in
+  push|workflow_dispatch) ;;
+  *) fail "expected event must be push or workflow_dispatch: $EXPECTED_EVENT" ;;
+esac
 [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] \
   || fail "expected source SHA must be a full 40-character lowercase SHA"
 [[ "$EXPECTED_REF" == "refs/heads/main" ]] \
@@ -59,8 +64,8 @@ manifest_binary_sha="$(jq -er '.binary_sha256' "$MANIFEST")"
 actual_binary_sha="$(sha256sum "$BINARY" | awk '{print $1}')"
 [[ "$manifest_schema" == "masc.keeper_acceptance_runtime.v2" ]] \
   || fail "manifest schema mismatch: $manifest_schema"
-[[ "$manifest_event" == "workflow_dispatch" ]] \
-  || fail "manifest event mismatch: $manifest_event"
+[[ "$manifest_event" == "$EXPECTED_EVENT" ]] \
+  || fail "manifest event mismatch: expected=$EXPECTED_EVENT actual=$manifest_event"
 [[ "$manifest_sha" == "$EXPECTED_SHA" ]] \
   || fail "manifest source mismatch: expected=$EXPECTED_SHA actual=$manifest_sha"
 [[ "$manifest_ref" == "$EXPECTED_REF" ]] \
@@ -75,7 +80,7 @@ actual_binary_sha="$(sha256sum "$BINARY" | awk '{print $1}')"
   || fail "binary digest mismatch: expected=$manifest_binary_sha actual=$actual_binary_sha"
 
 if [[ "$MODE" == "--verify-provenance-only" ]]; then
-  echo "keeper-realworld-acceptance: provenance PASS source=$EXPECTED_SHA ref=$EXPECTED_REF"
+  echo "keeper-realworld-acceptance: provenance PASS event=$EXPECTED_EVENT source=$EXPECTED_SHA ref=$EXPECTED_REF"
   exit 0
 fi
 
@@ -196,6 +201,7 @@ python3 "$ROOT_DIR/scripts/harness/workload/keeper_multi_collaboration_acceptanc
 jq -n \
   --arg schema "masc.keeper_realworld_gate.v1" \
   --arg status "passed" \
+  --arg event_name "$EXPECTED_EVENT" \
   --arg source_sha "$EXPECTED_SHA" \
   --arg source_ref "$EXPECTED_REF" \
   --arg workflow_ref "$EXPECTED_WORKFLOW_REF" \
@@ -208,6 +214,7 @@ jq -n \
   '{
     schema: $schema,
     status: $status,
+    event_name: $event_name,
     source_sha: $source_sha,
     source_ref: $source_ref,
     source_ref_protected: true,
@@ -220,4 +227,4 @@ jq -n \
     github_run_attempt: $run_attempt
   }' >"$OUTPUT_DIR/gate-result.json"
 
-echo "keeper-realworld-acceptance: PASS source=$EXPECTED_SHA evidence=$evidence_dir"
+echo "keeper-realworld-acceptance: PASS event=$EXPECTED_EVENT source=$EXPECTED_SHA evidence=$evidence_dir"

--- a/test/test_keeper_realworld_secret_boundary.sh
+++ b/test/test_keeper_realworld_secret_boundary.sh
@@ -18,12 +18,13 @@ printf 'exact-runtime-fixture\n' >"$binary"
 binary_sha="$(sha256sum "$binary" | awk '{print $1}')"
 
 write_manifest() {
-  local ref="${1:?ref is required}"
-  local protected="${2:?protected is required}"
-  local workflow_sha="${3:?workflow_sha is required}"
+  local event_name="${1:?event_name is required}"
+  local ref="${2:?ref is required}"
+  local protected="${3:?protected is required}"
+  local workflow_sha="${4:?workflow_sha is required}"
   jq -n \
     --arg schema "masc.keeper_acceptance_runtime.v2" \
-    --arg event_name "workflow_dispatch" \
+    --arg event_name "$event_name" \
     --arg source_sha "$source_sha" \
     --arg source_ref "$ref" \
     --argjson source_ref_protected "$protected" \
@@ -43,11 +44,13 @@ write_manifest() {
 }
 
 run_provenance() {
+  local expected_event="${1:?expected_event is required}"
   env \
     GITHUB_REPOSITORY="$repository" \
     KEEPER_ACCEPTANCE_BINARY="$binary" \
     KEEPER_ACCEPTANCE_MANIFEST="$manifest" \
     KEEPER_ACCEPTANCE_OUTPUT_DIR="$output_dir" \
+    KEEPER_ACCEPTANCE_EXPECTED_EVENT="$expected_event" \
     KEEPER_ACCEPTANCE_EXPECTED_SHA="$source_sha" \
     KEEPER_ACCEPTANCE_EXPECTED_REF="$source_ref" \
     KEEPER_ACCEPTANCE_EXPECTED_REF_PROTECTED=true \
@@ -60,22 +63,28 @@ run_provenance() {
 
 expect_failure() {
   local label="${1:?label is required}"
-  if run_provenance >"$tmp_root/$label.out" 2>"$tmp_root/$label.err"; then
+  local expected_event="${2:?expected_event is required}"
+  if run_provenance "$expected_event" >"$tmp_root/$label.out" 2>"$tmp_root/$label.err"; then
     echo "expected provenance failure: $label" >&2
     exit 1
   fi
 }
 
-write_manifest "$source_ref" true "$source_sha"
-run_provenance >/dev/null
+for trusted_event in push workflow_dispatch; do
+  write_manifest "$trusted_event" "$source_ref" true "$source_sha"
+  run_provenance "$trusted_event" >/dev/null
+done
 
-write_manifest "refs/heads/attacker" true "$source_sha"
-expect_failure branch-ref
+write_manifest push "refs/heads/attacker" true "$source_sha"
+expect_failure branch-ref push
 
-write_manifest "$source_ref" false "$source_sha"
-expect_failure unprotected-ref
+write_manifest push "$source_ref" false "$source_sha"
+expect_failure unprotected-ref push
 
-write_manifest "$source_ref" true "0000000000000000000000000000000000000000"
-expect_failure workflow-sha
+write_manifest push "$source_ref" true "0000000000000000000000000000000000000000"
+expect_failure workflow-sha push
+
+write_manifest push "$source_ref" true "$source_sha"
+expect_failure event-mismatch workflow_dispatch
 
 echo "keeper real-world secret boundary tests: PASS"


### PR DESCRIPTION
## Summary

Post-merge corrective for the unresolved P1 on #28317.

- keep PR refs credential-free
- run secret-bearing RW01-RW16 automatically on every protected-main push and trusted main dispatch
- make the final main CI Gate wait for the exact-SHA acceptance result
- preserve the obligation across superseding pushes by forcing real-world acceptance on every latest main run
- bind manifest and runner provenance to event, protected ref, workflow ref, workflow SHA, source SHA, and binary digest

## Why every main push

Main CI cancels an older push run when a newer push arrives. If acceptance stayed path-scoped, a docs-only follow-up could cancel a Keeper acceptance and then skip it. Every surviving protected-main run therefore carries RW01-RW16.

## Validation

- python3 scripts/ci/check-yaml-syntax.py — 38 YAML files pass
- python3 scripts/ci/check-keeper-realworld-secret-boundary.py — pass
- bash test/test_keeper_realworld_secret_boundary.sh — pass for push and workflow_dispatch; rejects ref/protection/workflow/event mismatches
- pyright --outputjson scripts/ci/check-keeper-realworld-secret-boundary.py — 0 errors
- ruff check and ruff format --check — pass
- shellcheck on both changed shell files — pass
- actionlint -ignore SC2129 .github/workflows/ci.yml — pass
- git diff --check — pass

No local Dune build was run; CI remains build/test authority.

## Exact revision

- base: 81c68bd882488fad9dd873f53071bb304abd8a07
- head: ce9e69b19fd2137cafa2c403034617fe8c7fb42c