### PR TITLE
refactor(board): classify attention status once

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -88,6 +88,14 @@ type status =
   | Consumed of consumed_state
   | Quarantine of quarantine_state
 
+type status_view =
+  | Direct_resumable of resumable_status
+  | Requeued_resumable of
+      { resumable : resumable_status
+      ; quarantine : quarantine_state
+      }
+  | Suspended_quarantine of quarantine_state
+
 type candidate =
   { candidate_id : string
   ; keeper_name : string
@@ -145,17 +153,14 @@ let quarantine_failure_category_of_string = function
   | _ -> None
 ;;
 
-let resumable_status = function
-  | Pending pending -> Some (Resumable_pending pending)
-  | Judged judged -> Some (Resumable_judged judged)
-  | Consumed consumed -> Some (Resumable_consumed consumed)
-  | Quarantine { quarantine; phase = Requeued _ } -> Some quarantine.prior_status
-  | Quarantine { phase = (Quarantined | Requeue_requested _); _ } -> None
-;;
-
-let quarantine_state = function
-  | Quarantine state -> Some state
-  | Pending _ | Judged _ | Consumed _ -> None
+let status_view = function
+  | Pending pending -> Direct_resumable (Resumable_pending pending)
+  | Judged judged -> Direct_resumable (Resumable_judged judged)
+  | Consumed consumed -> Direct_resumable (Resumable_consumed consumed)
+  | Quarantine ({ quarantine; phase = Requeued _ } as state) ->
+    Requeued_resumable { resumable = quarantine.prior_status; quarantine = state }
+  | Quarantine ({ phase = (Quarantined | Requeue_requested _); _ } as state) ->
+    Suspended_quarantine state
 ;;
 
 let status_of_resumable = function
@@ -1572,9 +1577,10 @@ let resumable_with_delivery_failure resumable failure =
 ;;
 
 let candidate_with_delivery_failure current failure =
-  match resumable_status current.status with
-  | None -> current
-  | Some resumable ->
+  match status_view current.status with
+  | Suspended_quarantine _ -> current
+  | Direct_resumable resumable
+  | Requeued_resumable { resumable; _ } ->
     let updated = resumable_with_delivery_failure resumable failure in
     if updated = resumable
     then current
@@ -1600,8 +1606,9 @@ let record_judgment ~base_path candidate judgment =
            "Board attention candidate not found: %s"
            candidate.candidate_id)
     | Some current ->
-      (match resumable_status current.status with
-       | Some (Resumable_pending _) ->
+      (match status_view current.status with
+       | Direct_resumable (Resumable_pending _)
+       | Requeued_resumable { resumable = Resumable_pending _; _ } ->
          let updated =
            { current with
              status =
@@ -1611,17 +1618,23 @@ let record_judgment ~base_path candidate judgment =
            }
          in
          Ok (Some updated, updated)
-       | Some (Resumable_judged judged)
+       | Direct_resumable (Resumable_judged judged)
+       | Requeued_resumable
+           { resumable = Resumable_judged judged; _ }
          when same_judgment judged.judgment judgment ->
          Ok (None, current)
-       | Some (Resumable_consumed consumed)
+       | Direct_resumable (Resumable_consumed consumed)
+       | Requeued_resumable
+           { resumable = Resumable_consumed consumed; _ }
          when same_judgment consumed.judgment judgment ->
          Ok (None, current)
-       | Some (Resumable_judged _ | Resumable_consumed _) ->
+       | Direct_resumable (Resumable_judged _ | Resumable_consumed _)
+       | Requeued_resumable
+           { resumable = (Resumable_judged _ | Resumable_consumed _); _ } ->
          Error
            ("Board attention candidate judgment conflict: "
             ^ candidate.candidate_id)
-       | None ->
+       | Suspended_quarantine _ ->
          Error
            ("Quarantined Board attention candidate cannot be judged: "
             ^ candidate.candidate_id)))
@@ -1636,8 +1649,10 @@ let mark_consumed ~base_path candidate judgment delivery =
            "Board attention candidate not found: %s"
            candidate.candidate_id)
     | Some current ->
-      (match resumable_status current.status with
-       | Some (Resumable_judged judged)
+      (match status_view current.status with
+       | Direct_resumable (Resumable_judged judged)
+       | Requeued_resumable
+           { resumable = Resumable_judged judged; _ }
          when same_judgment judged.judgment judgment ->
          let updated =
            { current with
@@ -1648,18 +1663,23 @@ let mark_consumed ~base_path candidate judgment delivery =
            }
          in
          Ok (Some updated, updated)
-       | Some (Resumable_consumed consumed)
+       | Direct_resumable (Resumable_consumed consumed)
+       | Requeued_resumable
+           { resumable = Resumable_consumed consumed; _ }
          when same_judgment consumed.judgment judgment
               && consumed.delivery = delivery -> Ok (None, current)
-       | Some (Resumable_pending _) ->
+       | Direct_resumable (Resumable_pending _)
+       | Requeued_resumable { resumable = Resumable_pending _; _ } ->
          Error
            ("Pending Board attention candidate cannot be consumed: "
             ^ candidate.candidate_id)
-       | Some (Resumable_judged _ | Resumable_consumed _) ->
+       | Direct_resumable (Resumable_judged _ | Resumable_consumed _)
+       | Requeued_resumable
+           { resumable = (Resumable_judged _ | Resumable_consumed _); _ } ->
          Error
            ("Board attention candidate consumption conflict: "
             ^ candidate.candidate_id)
-       | None ->
+       | Suspended_quarantine _ ->
          Error
            ("Quarantined Board attention candidate cannot be consumed: "
             ^ candidate.candidate_id)))
@@ -1749,12 +1769,10 @@ let quarantine
       Error ("Board attention candidate not found: " ^ candidate.candidate_id)
     | Some current ->
       let prior_status =
-        match resumable_status current.status with
-        | Some status -> status
-        | None ->
-          (match current.status with
-           | Quarantine state -> state.quarantine.prior_status
-           | Pending _ | Judged _ | Consumed _ -> assert false)
+        match status_view current.status with
+        | Direct_resumable status
+        | Requeued_resumable { resumable = status; _ } -> status
+        | Suspended_quarantine state -> state.quarantine.prior_status
       in
       let requested =
         { quarantine_id
@@ -1961,10 +1979,14 @@ let record_and_wake ~base_path candidate =
     Ok { candidate = persisted; persistence = Candidate_recorded; wake }
   | Duplicate persisted ->
     let* wake =
-      match resumable_status persisted.status with
-      | Some (Resumable_pending _ | Resumable_judged _) ->
+      match status_view persisted.status with
+      | Direct_resumable (Resumable_pending _ | Resumable_judged _)
+      | Requeued_resumable
+          { resumable = (Resumable_pending _ | Resumable_judged _); _ } ->
         request_worker persisted
-      | Some (Resumable_consumed _) | None -> Ok Wake_not_required
+      | Direct_resumable (Resumable_consumed _)
+      | Requeued_resumable { resumable = Resumable_consumed _; _ }
+      | Suspended_quarantine _ -> Ok Wake_not_required
     in
     Ok
       { candidate = persisted
@@ -1981,41 +2003,55 @@ let apply_judgment_and_deliver ~base_path ~keeper_name ~candidate_id ~judgment =
     | None -> Error ("Board attention candidate not found: " ^ candidate_id)
   in
   let* judged_candidate =
-    match resumable_status candidate.status with
-    | Some (Resumable_pending _) ->
+    match status_view candidate.status with
+    | Direct_resumable (Resumable_pending _)
+    | Requeued_resumable { resumable = Resumable_pending _; _ } ->
       record_judgment ~base_path candidate judgment
-    | Some (Resumable_judged judged)
+    | Direct_resumable (Resumable_judged judged)
+    | Requeued_resumable
+        { resumable = Resumable_judged judged; _ }
       when same_judgment judged.judgment judgment ->
       Ok candidate
-    | Some (Resumable_consumed consumed)
+    | Direct_resumable (Resumable_consumed consumed)
+    | Requeued_resumable
+        { resumable = Resumable_consumed consumed; _ }
       when same_judgment consumed.judgment judgment ->
       Ok candidate
-    | Some (Resumable_judged _ | Resumable_consumed _) ->
+    | Direct_resumable (Resumable_judged _ | Resumable_consumed _)
+    | Requeued_resumable
+        { resumable = (Resumable_judged _ | Resumable_consumed _); _ } ->
       Error ("Board attention candidate judgment conflicts with worker result: " ^ candidate_id)
-    | None ->
+    | Suspended_quarantine _ ->
       Error
         ("Quarantined or requeue-requested Board attention candidate cannot be settled: "
          ^ candidate_id)
   in
-  match resumable_status judged_candidate.status with
-  | Some (Resumable_consumed _) ->
+  match status_view judged_candidate.status with
+  | Direct_resumable (Resumable_consumed _)
+  | Requeued_resumable { resumable = Resumable_consumed _; _ } ->
     normalize_requeued_consumed ~base_path ~keeper_name ~candidate_id
-  | Some (Resumable_pending _) ->
+  | Direct_resumable (Resumable_pending _)
+  | Requeued_resumable { resumable = Resumable_pending _; _ } ->
     Error ("Board attention candidate remained Pending after judgment commit: " ^ candidate_id)
-  | Some (Resumable_judged judged) ->
+  | Direct_resumable (Resumable_judged judged)
+  | Requeued_resumable
+      { resumable = Resumable_judged judged; _ } ->
     let* delivered = consume_judged ~base_path judged_candidate judged in
-    (match resumable_status delivered.status with
-     | Some (Resumable_consumed _) ->
+    (match status_view delivered.status with
+     | Direct_resumable (Resumable_consumed _)
+     | Requeued_resumable { resumable = Resumable_consumed _; _ } ->
        normalize_requeued_consumed ~base_path ~keeper_name ~candidate_id
-     | Some (Resumable_pending _ | Resumable_judged _) ->
+     | Direct_resumable (Resumable_pending _ | Resumable_judged _)
+     | Requeued_resumable
+         { resumable = (Resumable_pending _ | Resumable_judged _); _ } ->
        Error
          ("Board attention candidate delivery did not reach Consumed: "
           ^ candidate_id)
-     | None ->
+     | Suspended_quarantine _ ->
        Error
          ("Board attention candidate became quarantined during delivery: "
           ^ candidate_id))
-  | None ->
+  | Suspended_quarantine _ ->
     Error
       ("Quarantined or requeue-requested Board attention candidate cannot be settled: "
        ^ candidate_id)

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -95,6 +95,19 @@ type status =
   | Consumed of consumed_state
   | Quarantine of quarantine_state
 
+type status_view =
+  | Direct_resumable of resumable_status
+      (** A candidate that has never entered quarantine. *)
+  | Requeued_resumable of
+      { resumable : resumable_status
+      ; quarantine : quarantine_state
+      }
+      (** A requeued candidate is operationally resumable while retaining the
+          quarantine identity needed by reconciliation and audit. *)
+  | Suspended_quarantine of quarantine_state
+      (** A quarantined or requeue-requested candidate is not operationally
+          resumable. *)
+
 type candidate =
   { candidate_id : string
   ; keeper_name : string
@@ -156,8 +169,10 @@ exception Candidate_unavailable of string
 val judgment_to_yojson : judgment -> Yojson.Safe.t
 val judgment_of_yojson : Yojson.Safe.t -> (judgment, string) result
 val quarantine_failure_category_to_string : quarantine_failure_category -> string
-val resumable_status : status -> resumable_status option
-val quarantine_state : status -> quarantine_state option
+val status_view : status -> status_view
+(** Total classification of a durable status. Unlike the removed pair of
+    optional projections, this preserves both operational resumability and
+    quarantine provenance without forcing callers to inspect [status] again. *)
 val signal_to_yojson : Board_dispatch.board_signal -> Yojson.Safe.t
 
 val singleton_judgment_request : candidate -> (Yojson.Safe.t, string) result

--- a/lib/keeper/keeper_board_attention_exact_flow.ml
+++ b/lib/keeper/keeper_board_attention_exact_flow.ml
@@ -94,18 +94,32 @@ let flow_candidates selected_slots =
 
 let prepare ~base_path:_ ~keeper_name:_ ~net candidate =
   match
-    ( Keeper_board_attention_candidate.resumable_status
+    ( Keeper_board_attention_candidate.status_view
         candidate.Keeper_board_attention_candidate.status
     , net )
   with
-  | ( None
-    | Some
+  | ( Keeper_board_attention_candidate.Suspended_quarantine _
+    | Keeper_board_attention_candidate.Direct_resumable
         (Keeper_board_attention_candidate.Resumable_judged _
-        | Keeper_board_attention_candidate.Resumable_consumed _) ), _ ->
+        | Keeper_board_attention_candidate.Resumable_consumed _)
+    | Keeper_board_attention_candidate.Requeued_resumable
+        { resumable =
+            (Keeper_board_attention_candidate.Resumable_judged _
+            | Keeper_board_attention_candidate.Resumable_consumed _)
+        ; _
+        } ), _ ->
     Error Candidate_not_pending
-  | Some (Keeper_board_attention_candidate.Resumable_pending _), None ->
+  | ( Keeper_board_attention_candidate.Direct_resumable
+        (Keeper_board_attention_candidate.Resumable_pending _)
+    | Keeper_board_attention_candidate.Requeued_resumable
+        { resumable = Keeper_board_attention_candidate.Resumable_pending _; _ }
+    ), None ->
     Error Network_unavailable
-  | Some (Keeper_board_attention_candidate.Resumable_pending _), Some net ->
+  | ( Keeper_board_attention_candidate.Direct_resumable
+        (Keeper_board_attention_candidate.Resumable_pending _)
+    | Keeper_board_attention_candidate.Requeued_resumable
+        { resumable = Keeper_board_attention_candidate.Resumable_pending _; _ }
+    ), Some net ->
     let* messages =
       messages candidate
       |> Result.map_error (fun detail -> Prompt_contract_unavailable detail)

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -1149,11 +1149,21 @@ let ensure_roots ~base_path ~keeper_name candidates =
               then Error "candidate Keeper differs from partition ledger Keeper"
               else
                 let* () = valid_time "candidate recorded_at" candidate.recorded_at in
-                match Candidate.resumable_status candidate.status with
-                | None | Some (Candidate.Resumable_consumed _) -> Ok roots
-                | Some
+                match Candidate.status_view candidate.status with
+                | Candidate.Suspended_quarantine _
+                | Candidate.Direct_resumable (Candidate.Resumable_consumed _)
+                | Candidate.Requeued_resumable
+                    { resumable = Candidate.Resumable_consumed _; _ } ->
+                  Ok roots
+                | Candidate.Direct_resumable
                     (Candidate.Resumable_pending _
-                    | Candidate.Resumable_judged _) ->
+                    | Candidate.Resumable_judged _)
+                | Candidate.Requeued_resumable
+                    { resumable =
+                        (Candidate.Resumable_pending _
+                        | Candidate.Resumable_judged _)
+                    ; _
+                    } ->
                   let* context_key = Candidate.Context_key.of_candidate candidate in
                   (match Id_map.find_opt candidate.candidate_id view.live_candidate_owner with
                    | Some owner_id ->

--- a/lib/keeper/keeper_board_attention_quarantine_command.ml
+++ b/lib/keeper/keeper_board_attention_quarantine_command.ml
@@ -39,6 +39,7 @@ type execution_error =
 type report =
   { candidate : Candidate.candidate
   ; partition : Partition.t
+  ; failure_category : Candidate.quarantine_failure_category
   ; wake : Wake.wake_result
   }
 
@@ -245,14 +246,17 @@ let find_partition ~base_path command =
 ;;
 
 let matching_quarantine command candidate =
-  match Candidate.quarantine_state candidate.Candidate.status with
-  | Some state
+  match Candidate.status_view candidate.Candidate.status with
+  | (Candidate.Suspended_quarantine state
+    | Candidate.Requeued_resumable { quarantine = state; _ })
     when String.equal state.quarantine.partition_id command.partition_id
          && String.equal
               state.quarantine.quarantine_id
               command.request.expected_quarantine_id ->
     Ok state
-  | Some _ | None ->
+  | Candidate.Direct_resumable _
+  | Candidate.Suspended_quarantine _
+  | Candidate.Requeued_resumable _ ->
     Error
       (Candidate_state_conflict
          "candidate quarantine generation differs from the command")
@@ -297,9 +301,9 @@ let confirm_ready_partition ~base_path partition =
        Error (Durability_unconfirmed detail))
 ;;
 
-let request_wake ~base_path command candidate partition =
+let request_wake ~base_path ~failure_category command candidate partition =
   match Wake.request ~base_path ~keeper_name:command.keeper_name with
-  | Ok wake -> Ok { candidate; partition; wake }
+  | Ok wake -> Ok { candidate; partition; failure_category; wake }
   | Error detail -> Error (Wake_request_failed detail)
 ;;
 
@@ -404,14 +408,24 @@ let execute_with_before_partition_commit
   | Candidate.Requeued _, Partition.Blocked _ when generation_matches ->
     before_partition_commit partition;
     let* ready = commit_partition_ready ~base_path command partition in
-    request_wake ~base_path command candidate ready
+    request_wake
+      ~base_path
+      ~failure_category:observed.quarantine.failure_category
+      command
+      candidate
+      ready
   | Candidate.Requeued _, Partition.Blocked _ ->
     Error
       (Partition_state_conflict
          "a newer Blocked generation is awaiting candidate projection")
   | Candidate.Requeued _, Partition.Ready when ready_generation_matches ->
     let* ready = confirm_ready_partition ~base_path partition in
-    request_wake ~base_path command candidate ready
+    request_wake
+      ~base_path
+      ~failure_category:observed.quarantine.failure_category
+      command
+      candidate
+      ready
   | Candidate.Requeued _,
     Partition.Ready ->
     Error
@@ -451,7 +465,12 @@ let execute_with_before_partition_commit
     in
     before_partition_commit partition;
     let* ready = commit_partition_ready ~base_path command partition in
-    request_wake ~base_path command authorized ready
+    request_wake
+      ~base_path
+      ~failure_category:observed.quarantine.failure_category
+      command
+      authorized
+      ready
   | (Candidate.Quarantined | Candidate.Requeue_requested _),
     Partition.Blocked _ ->
     Error
@@ -509,11 +528,7 @@ let wake_to_string = function
 
 let success_json ~audit command report =
   let failure_category =
-    match Candidate.quarantine_state report.candidate.status with
-    | Some state ->
-      Candidate.quarantine_failure_category_to_string
-        state.quarantine.failure_category
-    | None -> "unknown"
+    Candidate.quarantine_failure_category_to_string report.failure_category
   in
   `Assoc
     [ "schema", `String result_schema

--- a/lib/keeper/keeper_board_attention_quarantine_command.mli
+++ b/lib/keeper/keeper_board_attention_quarantine_command.mli
@@ -42,6 +42,11 @@ type execution_error =
 type report =
   { candidate : Keeper_board_attention_candidate.candidate
   ; partition : Keeper_board_attention_partition.t
+  ; failure_category :
+      Keeper_board_attention_candidate.quarantine_failure_category
+      (** Typed category captured when the command resolves the quarantine;
+          renderers never reopen the candidate status or synthesize an
+          ["unknown"] success value. *)
   ; wake : Keeper_board_attention_worker_wake.wake_result
   }
 

--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1049,8 +1049,10 @@ let process_claimed
          partition
          (Partition.Candidate_membership_conflict detail)
      | Ok () ->
-       (match Candidate.resumable_status candidate.status with
-        | Some (Candidate.Resumable_pending _) ->
+       (match Candidate.status_view candidate.status with
+        | Candidate.Direct_resumable (Candidate.Resumable_pending _)
+        | Candidate.Requeued_resumable
+            { resumable = Candidate.Resumable_pending _; _ } ->
           (match prepared with
            | Some (candidate_id, prepared)
              when String.equal candidate_id candidate.candidate_id ->
@@ -1066,21 +1068,25 @@ let process_claimed
                ("Board attention claimed Pending candidate without successful "
                 ^ "pre-claim exact setup: "
                 ^ candidate.candidate_id))
-        | Some (Candidate.Resumable_judged judged) ->
+        | Candidate.Direct_resumable (Candidate.Resumable_judged judged)
+        | Candidate.Requeued_resumable
+            { resumable = Candidate.Resumable_judged judged; _ } ->
           complete_existing_judgment
             ~now
             ~worker_epoch
             ~base_path
             latest_partition
             judged.judgment
-        | Some (Candidate.Resumable_consumed consumed) ->
+        | Candidate.Direct_resumable (Candidate.Resumable_consumed consumed)
+        | Candidate.Requeued_resumable
+            { resumable = Candidate.Resumable_consumed consumed; _ } ->
           settle_existing_consumed
             ~now
             ~worker_epoch
             ~base_path
             latest_partition
             consumed.judgment
-        | None ->
+        | Candidate.Suspended_quarantine _ ->
           Error
             ("Quarantined Board attention candidate became claimable: "
              ^ candidate.candidate_id)))
@@ -1115,8 +1121,10 @@ let prepare_next_ready
        (match validate_partition_member partition candidate with
         | Error _ -> selected None
         | Ok () ->
-          (match Candidate.resumable_status candidate.status with
-           | Some (Candidate.Resumable_pending _) ->
+          (match Candidate.status_view candidate.status with
+           | Candidate.Direct_resumable (Candidate.Resumable_pending _)
+           | Candidate.Requeued_resumable
+               { resumable = Candidate.Resumable_pending _; _ } ->
              (match prepare candidate with
               | Ok prepared ->
                 selected (Some (candidate.candidate_id, prepared))
@@ -1124,10 +1132,16 @@ let prepare_next_ready
                 Error
                   ("Board attention exact setup unavailable before claim: "
                    ^ setup_error_detail error))
-           | Some
+           | Candidate.Direct_resumable
                (Candidate.Resumable_judged _
                | Candidate.Resumable_consumed _)
-           | None -> selected None)))
+           | Candidate.Requeued_resumable
+               { resumable =
+                   (Candidate.Resumable_judged _
+                   | Candidate.Resumable_consumed _)
+               ; _
+               }
+           | Candidate.Suspended_quarantine _ -> selected None)))
 ;;
 
 let confirm_requeue_transition ~base_path transition =
@@ -1170,10 +1184,13 @@ let rec converge_requeue_conflict
          ^ partition.candidate_id)
   in
   let* () =
-    match Candidate.quarantine_state candidate.status with
-    | Some
-        { quarantine
-        ; phase = Candidate.Requeued _
+    match Candidate.status_view candidate.status with
+    | Candidate.Requeued_resumable
+        { quarantine =
+            { quarantine
+            ; phase = Candidate.Requeued _
+            }
+        ; _
         }
       when String.equal quarantine.partition_id partition.partition_id
            && String.equal quarantine.quarantine_id expected_quarantine_id
@@ -1181,7 +1198,9 @@ let rec converge_requeue_conflict
                 quarantine.partition_generation
                 partition.generation ->
       Ok ()
-    | Some _ | None ->
+    | Candidate.Direct_resumable _
+    | Candidate.Requeued_resumable _
+    | Candidate.Suspended_quarantine _ ->
       Error
         ("candidate quarantine generation changed during requeue convergence: "
          ^ partition.partition_id)
@@ -1278,8 +1297,10 @@ let reconcile_quarantines ~now ~base_path ~keeper_name =
             ("partition candidate is absent during quarantine reconciliation: "
              ^ partition.candidate_id)
       in
-      (match partition.state, Candidate.quarantine_state candidate.status with
-       | Partition.Blocked _, Some state
+      (match partition.state, Candidate.status_view candidate.status with
+       | ( Partition.Blocked _
+         , (Candidate.Suspended_quarantine state
+           | Candidate.Requeued_resumable { quarantine = state; _ }) )
          when String.equal
                 state.quarantine.partition_id
                 partition.partition_id
@@ -1321,7 +1342,9 @@ let reconcile_quarantines ~now ~base_path ~keeper_name =
        | Partition.Blocked _, _ ->
          let* () = quarantine_blocked_partition ~base_path partition in
          loop rest
-       | Partition.Ready, Some state
+       | ( Partition.Ready
+         , (Candidate.Suspended_quarantine state
+           | Candidate.Requeued_resumable { quarantine = state; _ }) )
          when String.equal
                 state.quarantine.partition_id
                 partition.partition_id
@@ -1345,7 +1368,9 @@ let reconcile_quarantines ~now ~base_path ~keeper_name =
               confirm_requeue_transition ~base_path confirmation
             in
             loop rest)
-       | Partition.Ready, Some state
+       | ( Partition.Ready
+         , (Candidate.Suspended_quarantine state
+           | Candidate.Requeued_resumable { quarantine = state; _ }) )
          when String.equal
                 state.quarantine.partition_id
                 partition.partition_id ->

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -176,6 +176,48 @@ let judgment decision : A.judgment =
   }
 ;;
 
+let quarantine_state ~phase prior_status : A.quarantine_state =
+  { quarantine =
+      { quarantine_id = "ba-quarantine-status-view"
+      ; partition_id = "ba-partition-status-view"
+      ; partition_generation =
+          Masc.Keeper_board_attention_partition_generation.initial
+      ; failure_category = A.Unexpected_worker_failure
+      ; attempt_provenance = None
+      ; quarantined_at = 3.0
+      ; prior_status
+      }
+  ; phase
+  }
+;;
+
+let test_status_view_preserves_resumability_and_quarantine () =
+  let pending = A.Resumable_pending { last_delivery_failure = None } in
+  (match A.status_view (A.Pending { last_delivery_failure = None }) with
+   | A.Direct_resumable observed when observed = pending -> ()
+   | A.Direct_resumable _
+   | A.Requeued_resumable _
+   | A.Suspended_quarantine _ ->
+     Alcotest.fail "direct Pending status lost its typed resumable value");
+  let suspended = quarantine_state ~phase:A.Quarantined pending in
+  (match A.status_view (A.Quarantine suspended) with
+   | A.Suspended_quarantine observed when observed = suspended -> ()
+   | A.Direct_resumable _
+   | A.Requeued_resumable _
+   | A.Suspended_quarantine _ ->
+     Alcotest.fail "active quarantine was not classified as suspended");
+  let requeued =
+    quarantine_state ~phase:(A.Requeued { requeued_at = 4.0 }) pending
+  in
+  match A.status_view (A.Quarantine requeued) with
+  | A.Requeued_resumable { resumable; quarantine }
+    when resumable = pending && quarantine = requeued -> ()
+  | A.Direct_resumable _
+  | A.Requeued_resumable _
+  | A.Suspended_quarantine _ ->
+    Alcotest.fail "requeued quarantine lost resumability or quarantine identity"
+;;
+
 let invalid_judgment_fixtures () =
   let valid = judgment J.Not_relevant in
   [ ( "blank verdict rationale"
@@ -807,6 +849,10 @@ let () =
             "codec and context identity are strict"
             `Quick
             test_codec_and_context_identity_are_strict
+        ; Alcotest.test_case
+            "status view preserves resumability and quarantine"
+            `Quick
+            test_status_view_preserves_resumability_and_quarantine
         ; Alcotest.test_case
             "singleton request is canonical and identity bound"
             `Quick


### PR DESCRIPTION
## Summary

- replace the overlapping `resumable_status` / `quarantine_state` optional projections with one total `status_view`
- represent requeued candidates as both operationally resumable and quarantine-provenance-carrying without reopening raw status
- carry the resolved quarantine failure category into the command report, removing the `"unknown"` success fallback
- update every Board attention consumer in the same hard-cut and add a characterization test for direct, suspended, and requeued states

RFC: `docs/rfc/RFC-0371-effect-boundary-restoration.md`

## Verification

- `ocamlc -stop-after parsing` on all changed `.ml` / `.mli` files
- `ocamlformat --check` on all changed OCaml files
- `git diff --check origin/main...HEAD`
- static sweep: no remaining calls to the removed projections and no `assert false` at the quarantine transition

Per operator instruction, no local Dune build was run. Exact-head GitHub CI is the build authority.