### PR TITLE
refactor(dashboard): move keeper GitHub identity into the config access tab

### DIFF
--- a/dashboard/src/api/dashboard-keeper-github.test.ts
+++ b/dashboard/src/api/dashboard-keeper-github.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchKeeperGithubIdentity,
+  streamKeeperGithubLogin,
+  type KeeperGithubIdentityObservation,
+  type KeeperGithubLoginEvent,
+} from './dashboard-keeper-github'
+
+// The dev-token bootstrap owns its own fetch traffic. Stubbing it out pins
+// every `fetch` call observed below to the github-identity surface itself.
+vi.mock('./dev-token', () => ({
+  ensureDevToken: vi.fn(async () => undefined),
+}))
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const observation: KeeperGithubIdentityObservation = {
+  ok: true,
+  keeper: 'sangsu',
+  hostname: 'github.com',
+  config_dir: '/tmp/base/.masc/keepers/sangsu/github-cli',
+  projected_token_env_names: ['GH_TOKEN'],
+  stored: { authenticated: true, login: 'masc-sangsu-bot', error: null },
+  effective: { authenticated: false, login: null, error: 'HTTP 401' },
+  effective_probe_scope: 'host_process_credential_only',
+  checked_at_unix: 1786000000,
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('fetchKeeperGithubIdentity', () => {
+  it('encodes the keeper and hostname into the request path', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) => jsonResponse(observation))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const decoded = await fetchKeeperGithubIdentity('keeper one', 'github.com')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const requested = fetchMock.mock.calls[0]?.[0]
+    expect(requested).toBe(
+      '/api/v1/keepers/keeper%20one/github-identity?hostname=github.com',
+    )
+    expect(decoded.stored.login).toBe('masc-sangsu-bot')
+    expect(decoded.effective.authenticated).toBe(false)
+    expect(decoded.projected_token_env_names).toEqual(['GH_TOKEN'])
+  })
+
+  it('rejects when the server refuses the observation', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ error: 'unknown keeper' }, 404)),
+    )
+    await expect(fetchKeeperGithubIdentity('ghost')).rejects.toThrow()
+  })
+})
+
+function sseBody(chunks: readonly string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+      controller.close()
+    },
+  })
+}
+
+function stubStreamFetch(chunks: readonly string[]) {
+  const fetchMock = vi.fn(async () =>
+    ({ ok: true, body: sseBody(chunks) }) as unknown as Response,
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+async function collectLoginEvents(
+  chunks: readonly string[],
+): Promise<KeeperGithubLoginEvent[]> {
+  stubStreamFetch(chunks)
+  const events: KeeperGithubLoginEvent[] = []
+  await streamKeeperGithubLogin(
+    'sangsu',
+    'github.com',
+    event => events.push(event),
+    new AbortController().signal,
+  )
+  return events
+}
+
+describe('streamKeeperGithubLogin', () => {
+  it('decodes output, complete, and error frames in order', async () => {
+    const events = await collectLoginEvents([
+      'event: output\ndata: {"stream":"stdout","text":"code: ABCD-1234"}\n\n',
+      'event: output\ndata: {"stream":"stderr","text":"open https://github.com/login/device"}\n\n',
+      `event: complete\ndata: ${JSON.stringify({ observation })}\n\n`,
+    ])
+
+    expect(events).toEqual([
+      { event: 'output', stream: 'stdout', text: 'code: ABCD-1234' },
+      { event: 'output', stream: 'stderr', text: 'open https://github.com/login/device' },
+      { event: 'complete', observation },
+    ])
+  })
+
+  it('reassembles a frame that arrives split across chunks', async () => {
+    const events = await collectLoginEvents([
+      'event: output\ndata: {"stream":"stdo',
+      'ut","text":"first half+second half"}\n\n',
+    ])
+    expect(events).toEqual([
+      { event: 'output', stream: 'stdout', text: 'first half+second half' },
+    ])
+  })
+
+  it('accepts CRLF framing from the wire', async () => {
+    const events = await collectLoginEvents([
+      'event: error\r\ndata: {"message":"gh exited with 1"}\r\n\r\n',
+    ])
+    expect(events).toEqual([{ event: 'error', message: 'gh exited with 1' }])
+  })
+
+  it('surfaces the response body when the login request is refused', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        ({ ok: false, status: 409, text: async () => 'login already running' }) as unknown as Response,
+      ),
+    )
+    await expect(
+      streamKeeperGithubLogin('sangsu', 'github.com', () => {}, new AbortController().signal),
+    ).rejects.toThrow('login already running')
+  })
+
+  it('rejects a response without a stream body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, body: null }) as unknown as Response),
+    )
+    await expect(
+      streamKeeperGithubLogin('sangsu', 'github.com', () => {}, new AbortController().signal),
+    ).rejects.toThrow('GitHub login stream is unavailable')
+  })
+})

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -853,6 +853,26 @@ vi.mock('./common/toast', () => ({
   showToast: mocks.showToast,
 }))
 
+const githubIdentityMocks = vi.hoisted(() => ({
+  fetchKeeperGithubIdentity: vi.fn(async () => ({
+    ok: true as const,
+    keeper: 'keeper-sangsu',
+    hostname: 'github.com',
+    config_dir: '/tmp/base/.masc/keepers/keeper-sangsu/github-cli',
+    projected_token_env_names: [],
+    stored: { authenticated: true, login: 'masc-sangsu-bot', error: null },
+    effective: { authenticated: false, login: null, error: null },
+    effective_probe_scope: 'host_process_credential_only' as const,
+    checked_at_unix: 1786000000,
+  })),
+  streamKeeperGithubLogin: vi.fn(async () => undefined),
+}))
+
+vi.mock('../api/dashboard-keeper-github', () => ({
+  fetchKeeperGithubIdentity: githubIdentityMocks.fetchKeeperGithubIdentity,
+  streamKeeperGithubLogin: githubIdentityMocks.streamKeeperGithubLogin,
+}))
+
 import {
   KeeperConfigPanel,
   buildKcfAssemblySegments,
@@ -899,6 +919,8 @@ describe('KeeperConfigPanel', () => {
     mocks.pauseKeeper.mockClear()
     mocks.resumeKeeper.mockClear()
     mocks.wakeKeeper.mockClear()
+    githubIdentityMocks.fetchKeeperGithubIdentity.mockClear()
+    githubIdentityMocks.streamKeeperGithubLogin.mockClear()
   })
 
   afterEach(() => {
@@ -906,6 +928,31 @@ describe('KeeperConfigPanel', () => {
     container.remove()
     resetKeeperConfig()
     resetRuntimeCatalog()
+  })
+
+  it('exposes the keeper GitHub CLI identity under the 권한·샌드박스 tab', async () => {
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    // The identity tab is active by default; the GitHub account card must not
+    // leak outside its owning tab.
+    expect(container.textContent).not.toContain('GitHub CLI 계정')
+
+    selectKcfTab(container, '권한·샌드박스')
+    await flush()
+    await flush()
+
+    expect(container.textContent).toContain('GitHub CLI 계정')
+    expect(container.textContent).toContain('호스트 자격 증명 확인')
+    expect(githubIdentityMocks.fetchKeeperGithubIdentity).toHaveBeenCalledWith(
+      'keeper-sangsu',
+      'github.com',
+      expect.any(AbortSignal),
+    )
+    await flush()
+    expect(container.textContent).toContain('@masc-sangsu-bot')
+    expect(container.textContent).toContain('연결 안 됨')
   })
 
   it('separates editable prompt controls from read-only runtime metadata', async () => {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -61,6 +61,7 @@ import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { BTN_FILLED_BASE } from './common/button-filled-base'
 import { ExpandableTextarea } from './common/expandable-textarea'
+import { KeeperGithubIdentityPanel } from './keeper-github-identity-panel'
 import { createAsyncResource } from '../lib/async-state'
 import {
   findRuntimeCatalogEntry,
@@ -164,6 +165,8 @@ export type KeeperConfigControlEndpoint =
   | '/api/v1/keepers/:name/directive'
   | '/api/v1/dashboard/goals'
   | '/api/v1/providers'
+  | '/api/v1/keepers/:name/github-identity'
+  | '/api/v1/keepers/:name/github-login'
 
 export type KeeperConfigBrowserStateKey =
   | 'promptPreviewTab'
@@ -682,6 +685,18 @@ export function keeperConfigControlInventory(
           source: `${configApiSource} effective_allowed_paths + workspace.bound_workspace_ids`,
           action: 'read-only computed access projection',
           contracts: configReadContracts(['effective_allowed_paths', 'workspace.bound_workspace_ids']),
+        },
+        {
+          id: 'kcf-access-github-identity',
+          tab,
+          label: 'GitHub CLI identity',
+          kind: 'live-write',
+          source: 'GET /api/v1/keepers/:name/github-identity stored/effective probes',
+          action: 'POST /api/v1/keepers/:name/github-login operator web login stream',
+          contracts: [
+            apiContract('GET', '/api/v1/keepers/:name/github-identity'),
+            apiContract('POST', '/api/v1/keepers/:name/github-login'),
+          ],
         },
       ]
     case 'goals':
@@ -2041,6 +2056,8 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
       <${SectionHeader} size="xs" class="mb-1">참여 네임스페이스</${SectionHeader}>
       <${ModelList} models=${c.workspace.bound_workspace_ids} />
     </div>
+
+    <${KeeperGithubIdentityPanel} keeperName=${keeperName} />
 
   `
 

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -31,7 +31,6 @@ import {
   KeeperDetailSection,
 } from './keeper-detail-shell'
 import { KeeperCheckpointPanel } from './keeper-detail-history'
-import { KeeperGithubIdentityPanel } from './keeper-github-identity-panel'
 import {
   KeeperDiagnosticSummary,
   KeeperRuntimeActions,
@@ -192,7 +191,6 @@ export function KeeperDetailBody({
           <${KeeperRuntimeModelEditor} keeperName=${keeper.name} onOpenRuntimeConfig=${onOpenRuntimeConfig} />
           <${KeeperToolTelemetry} keeperName=${keeper.name} />
           <${KeeperSecretProjectionPanel} keeperName=${keeper.name} projection=${compositeSnapshot?.secret_projection} />
-          <${KeeperGithubIdentityPanel} keeperName=${keeper.name} />
           <${KeeperEvalQualityPanel} keeperName=${keeper.name} />
           <${CollapsibleSection} title="Live Truth (composite/runtime 합성)" open=${false}>
             <${KeeperLiveTruthPanel}

--- a/dashboard/src/components/keeper-github-identity-panel.test.ts
+++ b/dashboard/src/components/keeper-github-identity-panel.test.ts
@@ -1,0 +1,154 @@
+import { html } from 'htm/preact'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+const apiRefs = vi.hoisted(() => ({
+  fetchKeeperGithubIdentity: vi.fn(),
+  streamKeeperGithubLogin: vi.fn(),
+}))
+
+vi.mock('../api/dashboard-keeper-github', () => ({
+  fetchKeeperGithubIdentity: apiRefs.fetchKeeperGithubIdentity,
+  streamKeeperGithubLogin: apiRefs.streamKeeperGithubLogin,
+}))
+
+import type {
+  KeeperGithubIdentityObservation,
+  KeeperGithubLoginEvent,
+} from '../api/dashboard-keeper-github'
+import { KeeperGithubIdentityPanel } from './keeper-github-identity-panel'
+
+function makeObservation(
+  overrides: Partial<KeeperGithubIdentityObservation> = {},
+): KeeperGithubIdentityObservation {
+  return {
+    ok: true,
+    keeper: 'sangsu',
+    hostname: 'github.com',
+    config_dir: '/tmp/base/.masc/keepers/sangsu/github-cli',
+    projected_token_env_names: [],
+    stored: { authenticated: true, login: 'masc-sangsu-bot', error: null },
+    effective: { authenticated: false, login: null, error: null },
+    effective_probe_scope: 'host_process_credential_only',
+    checked_at_unix: 1786000000,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  apiRefs.fetchKeeperGithubIdentity.mockReset()
+  apiRefs.streamKeeperGithubLogin.mockReset()
+  apiRefs.fetchKeeperGithubIdentity.mockResolvedValue(makeObservation())
+  apiRefs.streamKeeperGithubLogin.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('KeeperGithubIdentityPanel', () => {
+  it('shows the stored account and the unauthenticated effective probe', async () => {
+    apiRefs.fetchKeeperGithubIdentity.mockResolvedValue(
+      makeObservation({
+        projected_token_env_names: ['GH_TOKEN'],
+        effective: { authenticated: false, login: null, error: 'HTTP 401' },
+      }),
+    )
+    render(html`<${KeeperGithubIdentityPanel} keeperName="sangsu" />`)
+
+    await waitFor(() => {
+      expect(screen.getByText('@masc-sangsu-bot')).toBeInTheDocument()
+    })
+    expect(apiRefs.fetchKeeperGithubIdentity).toHaveBeenCalledWith(
+      'sangsu',
+      'github.com',
+      expect.any(AbortSignal),
+    )
+    expect(screen.getByText('연결 안 됨')).toBeInTheDocument()
+    expect(screen.getByText(/확인 실패: HTTP 401/)).toBeInTheDocument()
+    expect(screen.getByText(/투영된 토큰 변수: GH_TOKEN/)).toBeInTheDocument()
+  })
+
+  it('surfaces a failed observation fetch as a load error', async () => {
+    apiRefs.fetchKeeperGithubIdentity.mockRejectedValue(
+      new Error('keeper is not registered'),
+    )
+    render(html`<${KeeperGithubIdentityPanel} keeperName="ghost" />`)
+
+    await waitFor(() => {
+      expect(screen.getByText('keeper is not registered')).toBeInTheDocument()
+    })
+  })
+
+  it('re-probes the identity when 새로고침 is pressed', async () => {
+    render(html`<${KeeperGithubIdentityPanel} keeperName="sangsu" />`)
+    await waitFor(() => {
+      expect(screen.getByText('@masc-sangsu-bot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('새로고침'))
+
+    await waitFor(() => {
+      expect(apiRefs.fetchKeeperGithubIdentity).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('streams login output into the modal and closes by aborting the request', async () => {
+    const captured: {
+      onEvent: ((event: KeeperGithubLoginEvent) => void) | null
+      signal: AbortSignal | null
+    } = { onEvent: null, signal: null }
+    apiRefs.streamKeeperGithubLogin.mockImplementation(
+      (
+        _keeper: string,
+        _hostname: string,
+        onEvent: (event: KeeperGithubLoginEvent) => void,
+        signal: AbortSignal,
+      ) => {
+        captured.onEvent = onEvent
+        captured.signal = signal
+        // The stream stays open until the operator finishes or cancels.
+        return new Promise<void>(() => {})
+      },
+    )
+
+    render(html`<${KeeperGithubIdentityPanel} keeperName="sangsu" />`)
+    await waitFor(() => {
+      expect(screen.getByText('@masc-sangsu-bot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('GitHub 로그인'))
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+    expect(apiRefs.streamKeeperGithubLogin).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      captured.onEvent?.({
+        event: 'output',
+        stream: 'stdout',
+        text: 'one-time code: ABCD-1234 open https://github.com/login/device',
+      })
+    })
+    expect(screen.getByText(/ABCD-1234/)).toBeInTheDocument()
+    const deviceLink = screen.getByText('GitHub 페이지 열기')
+    expect(deviceLink).toHaveAttribute('href', 'https://github.com/login/device')
+
+    await act(async () => {
+      captured.onEvent?.({
+        event: 'complete',
+        observation: makeObservation({
+          effective: { authenticated: true, login: 'masc-sangsu-bot', error: null },
+        }),
+      })
+    })
+    expect(screen.getAllByText('@masc-sangsu-bot')).toHaveLength(2)
+
+    fireEvent.click(screen.getByText('취소'))
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+    expect(captured.signal?.aborted).toBe(true)
+  })
+})

--- a/dashboard/src/components/keeper-github-identity-panel.ts
+++ b/dashboard/src/components/keeper-github-identity-panel.ts
@@ -104,38 +104,36 @@ export function KeeperGithubIdentityPanel({
   }
 
   return html`
-    <section class="rounded-xl border border-slate-200 bg-[linear-gradient(135deg,#fffdf7_0%,#f4f8ff_100%)] p-4 shadow-sm">
-      <div class="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">GitHub CLI identity</p>
-          <h3 class="mt-1 font-semibold text-slate-900">Keeper 전용 GitHub 계정</h3>
-          <p class="mt-1 text-xs text-slate-500">저장 계정과 호스트에 투영된 자격 증명을 GitHub API로 각각 확인합니다.</p>
-        </div>
-        <div class="flex gap-2">
-          <button type="button" onClick=${() => void refresh()} class="rounded-lg border border-slate-300 bg-white px-3 py-2 text-xs font-medium text-slate-700 hover:bg-slate-50">새로고침</button>
-          <button type="button" onClick=${() => void startLogin()} class="rounded-lg bg-slate-950 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-800">GitHub 로그인</button>
+    <section class="kcf-sec">
+      <div class="kcf-sec-h">
+        <h3>GitHub CLI 계정</h3>
+        <div class="ml-auto flex gap-2">
+          <button type="button" onClick=${() => void refresh()} class="kcf-btn ghost">새로고침</button>
+          <button type="button" onClick=${() => void startLogin()} class="kcf-btn save">GitHub 로그인</button>
         </div>
       </div>
-
-      ${loadError && html`<p class="mt-3 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">${loadError}</p>`}
-      ${observation && html`
-        <div class="mt-4 grid gap-3 sm:grid-cols-2">
-          <div class="rounded-lg border border-slate-200 bg-[var(--white-80)] p-3">
-            <span class="text-3xs font-semibold uppercase tracking-wider text-slate-400">Keeper 저장소</span>
-            <p class="mt-1 text-sm font-semibold text-slate-900">${authLabel(observation.stored.authenticated, observation.stored.login)}</p>
-            ${observation.stored.error && html`<p class="mt-1 text-3xs text-red-700">확인 실패: ${observation.stored.error}</p>`}
+      <p class="kcf-sec-desc">Keeper 전용으로 저장된 GitHub CLI 계정과 호스트에 투영된 자격 증명을 GitHub API로 각각 확인합니다.</p>
+      <div class="kcf-sec-body">
+        ${loadError && html`<p class="text-2xs text-[var(--color-status-err)]">${loadError}</p>`}
+        ${observation && html`
+          <div class="kcf-facts">
+            <div class="kcf-fact">
+              <span class="kcf-fact-k">Keeper 저장소</span>
+              <span class="kcf-fact-v mono">${authLabel(observation.stored.authenticated, observation.stored.login)}</span>
+              ${observation.stored.error && html`<span class="text-3xs text-[var(--color-status-err)]">확인 실패: ${observation.stored.error}</span>`}
+            </div>
+            <div class="kcf-fact">
+              <span class="kcf-fact-k">호스트 자격 증명 확인</span>
+              <span class="kcf-fact-v mono">${authLabel(observation.effective.authenticated, observation.effective.login)}</span>
+              <span class="text-3xs text-[var(--color-fg-muted)]">Docker 이미지의 gh·네트워크 동작을 증명하지 않습니다.</span>
+              ${observation.effective.error && html`<span class="text-3xs text-[var(--color-status-err)]">확인 실패: ${observation.effective.error}</span>`}
+              ${observation.projected_token_env_names.length > 0 && html`
+                <span class="text-3xs text-[var(--color-status-warn)]">투영된 토큰 변수: ${observation.projected_token_env_names.join(', ')}</span>
+              `}
+            </div>
           </div>
-          <div class="rounded-lg border border-slate-200 bg-[var(--white-80)] p-3">
-            <span class="text-3xs font-semibold uppercase tracking-wider text-slate-400">호스트 자격 증명 확인</span>
-            <p class="mt-1 text-sm font-semibold text-slate-900">${authLabel(observation.effective.authenticated, observation.effective.login)}</p>
-            <p class="mt-1 text-3xs text-slate-500">Docker 이미지의 gh·네트워크 동작을 증명하지 않습니다.</p>
-            ${observation.effective.error && html`<p class="mt-1 text-3xs text-red-700">확인 실패: ${observation.effective.error}</p>`}
-            ${observation.projected_token_env_names.length > 0 && html`
-              <p class="mt-1 text-3xs text-amber-700">투영된 토큰 변수: ${observation.projected_token_env_names.join(', ')}</p>
-            `}
-          </div>
-        </div>
-      `}
+        `}
+      </div>
 
       ${loginOpen && html`
         <div class="fixed inset-0 z-50 grid place-items-center bg-slate-950/55 p-4" role="dialog" aria-modal="true" aria-label="GitHub 로그인">
@@ -145,13 +143,13 @@ export function KeeperGithubIdentityPanel({
                 <p class="text-sm font-semibold text-white">${keeperName} GitHub 로그인</p>
                 <p class="text-xs text-slate-400">아래 코드와 URL은 gh가 직접 출력한 내용입니다.</p>
               </div>
-              <button type="button" onClick=${closeLogin} class="rounded-lg border border-slate-700 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-800">${loginRunning ? '취소' : '닫기'}</button>
+              <button type="button" onClick=${closeLogin} class="kcf-btn ghost">${loginRunning ? '취소' : '닫기'}</button>
             </div>
             <pre class="max-h-[52vh] min-h-48 overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-6 text-emerald-300">${output || 'GitHub 웹 인증 응답을 기다리는 중...'}</pre>
             ${urls.length > 0 && html`
               <div class="flex flex-wrap gap-2 border-t border-slate-800 px-4 py-3">
                 ${urls.map(url => html`
-                  <a key=${url} href=${url} target="_blank" rel="noreferrer" class="rounded-lg bg-amber-300 px-3 py-2 text-xs font-semibold text-slate-950 hover:bg-amber-200">GitHub 페이지 열기</a>
+                  <a key=${url} href=${url} target="_blank" rel="noreferrer" class="kcf-btn save inline-block no-underline">GitHub 페이지 열기</a>
                 `)}
               </div>
             `}

--- a/docs/rfc/RFC-per-keeper-github-cli-identity.md
+++ b/docs/rfc/RFC-per-keeper-github-cli-identity.md
@@ -52,7 +52,8 @@ masc keeper-github status --keeper NAME [--hostname HOST] [--base-path PATH]
 masc keeper-github logout --keeper NAME [--hostname HOST] [--base-path PATH]
 ```
 
-The Keeper runtime panel exposes status, refresh, and `GitHub 로그인`. The POST
+The Keeper config panel (권한·샌드박스 tab) exposes status, refresh, and
+`GitHub 로그인`. The POST
 response streams secret-redacted stdout/stderr from `gh`. The browser only
 recognizes generic HTTP URLs for links; it does not parse device codes or GitHub
 prose. Closing the modal aborts the request.

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -133,6 +133,8 @@ normal_targets=(
   @test/runtest-test_telemetry_eio_pbt
   @test/runtest-test_process_eio_coverage
   @test/runtest-test_keeper_secret_redaction
+  @test/runtest-test_keeper_sandbox_docker_route
+  @test/keeper_github_identity/runtest
 )
 
 board_attention_targets=(


### PR DESCRIPTION
## 배경

Keeper 상세(detail body)는 은퇴 중인 표면이라, #28215 로 들어온 GitHub CLI identity 패널을 keeper 설정 오버레이(권한·샌드박스 탭)로 이식한다. RFC: `docs/rfc/RFC-per-keeper-github-cli-identity.md` — 본 PR 이 RFC 의 Dashboard surface 문구도 config panel 기준으로 갱신한다.

## 변경

- **이식**: `KeeperGithubIdentityPanel` 을 keeper config 오버레이 `권한·샌드박스` 탭 끝에 렌더. keeper-detail-body 에서는 제거 (표면 단일화).
- **심리스 재스타일**: 패널 마크업을 kcf 디자인 어휘로 교체 — `kcf-sec` 헤더, `kcf-facts` 관측 카드, `kcf-btn ghost/save` 액션. detail 용 slate 하드코딩 제거.
- **Control ledger**: access 탭 인벤토리에 `kcf-access-github-identity` (GET `/github-identity`, POST `/github-login`) 등록, endpoint union 확장.
- **CI 배선**: `ci-run-focused-tests.sh` 에 `@test/keeper_github_identity/runtest` 와 `@test/runtest-test_keeper_sandbox_docker_route` 추가 — 두 스위트 모두 지금까지 CI 에서 실행되지 않았다 (스위트는 존재하나 focused 목록에 부재).
- **신규 테스트**:
  - `dashboard-keeper-github.test.ts`: 경로 인코딩, SSE 프레임 디코딩(청크 분할·CRLF), 거부/무바디 오류 (7 cases)
  - `keeper-github-identity-panel.test.ts`: 관측 렌더, 로드 오류, 새로고침 재프로브, 로그인 스트림→모달 출력→URL 추출→취소 시 abort (4 cases)
  - `keeper-config-panel.test.ts`: 진입점 단언 — 권한·샌드박스 탭 활성 시 패널이 실제 마운트되고 identity 탭에서는 누출되지 않음

## 검증

- vitest: 관련 5개 파일 **127/127 pass** (신규 11 포함), `tsc --noEmit` clean, `eslint src` clean
- dune: `dune build @test/runtest-test_keeper_sandbox_docker_route @test/keeper_github_identity/runtest` → exit 0 (github identity 15/15, 0.6s)
- 라이브 증명: vite dev + 실서버(:8935) 프록시로 sangsu 설정 오버레이 → 권한·샌드박스 탭에서 패널이 실제 관측(`Keeper GitHub CLI identity is not configured` 미설정 상태)을 렌더하는 스크린샷 확보. GET 은 CanAdmin 게이트가 살아있음도 확인 (worker 토큰 403).

## 남은 것 / 비고

- `gh auth login` 실 로그인은 운영자 인터랙티브 웹 인증이 필요해 이 PR 범위 밖 (버튼·스트림 UI 는 테스트로 검증).
- MASC MCP 미연결 세션이라 coordination 은 본 PR 기록으로 갈음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
