### PR TITLE
fix(dashboard): keep bearer identity authority over _agent_name hint

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -193,6 +193,32 @@ describe('MCP 2026-07-28 dashboard client', () => {
     expect(body.params.arguments).toEqual({})
   })
 
+  it('does not let _agent_name override a bearer credential owner', async () => {
+    getStoredToken.mockReturnValue('dashboard-token')
+    getStoredTokenMeta.mockReturnValue({
+      source: 'manual',
+      actor: 'dashboard',
+      scope: null,
+    })
+    authHeaders.mockReturnValue({ Authorization: 'Bearer dashboard-token' })
+    fetchWithTimeout.mockResolvedValueOnce(okToolResponse())
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_transition', {
+      task_id: 'task-223',
+      agent_name: 'dashboard-admin-deft-cobra',
+      _agent_name: 'dashboard-admin-deft-cobra',
+    })
+
+    const [, init] = callsByMethod('tools/call')[0]!
+    const body = JSON.parse(init.body as string)
+    expect(body.params.arguments).toEqual({
+      task_id: 'task-223',
+      agent_name: 'dashboard-admin-deft-cobra',
+    })
+    expect(authHeaders).toHaveBeenLastCalledWith({ actorName: null })
+  })
+
   // Pagination stops on absence of a cursor, and the guard is progress rather
   // than a page budget: #26771 capped at 50 pages, which refused a server with
   // 51 legitimate pages and let a non-progressing one run 50 round trips first.

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -281,14 +281,27 @@ async function callMcpToolInternal(
 ): Promise<string> {
   const requestId = randomUuid()
   synchronizeMcpAuthRevision()
-  const explicitActor = explicitToolActor(args)
+  // A bearer credential is the identity authority. Never let a caller-supplied
+  // transport hint override it: besides sending a contradictory X-MASC-Agent
+  // header, the old path also preserved the foreign _agent_name in tool args.
+  // For managed dev credentials we can mirror their known actor; for every
+  // other bearer the server injects the canonical owner after authentication.
+  const hasBearer = getStoredToken() !== null
+  const explicitActor = hasBearer ? null : explicitToolActor(args)
   try {
     const binding = await ensureBinding()
     const actor = explicitActor ?? implicitToolActor()
-    const toolArgs =
-      explicitActor == null && actor
+    const toolArgs = (() => {
+      if (hasBearer) {
+        const { _agent_name: _untrustedActor, ...credentialBoundArgs } = args
+        return actor
+          ? { ...credentialBoundArgs, _agent_name: actor }
+          : credentialBoundArgs
+      }
+      return explicitActor == null && actor
         ? { ...args, _agent_name: actor }
         : args
+    })()
     const text = await mcpPost({
       jsonrpc: '2.0',
       method: 'tools/call',


### PR DESCRIPTION
## 배경

`fix/keeper-autonomy-recovery-20260811` worktree는 자체 커밋 0개 상태에서 디렉터리가 소실되어 미커밋 작업 전체(13개 파일)가 유실됐습니다. 삭제 직전 캡처해 둔 diff에서 dashboard 절반을 재상륙합니다.

- 보존 diff: `~/me/.tmp/keeper-autonomy-recovery-lost-diffs/dashboard-bearer-transport-hint.diff` (유실 경위는 같은 디렉터리 README)
- 배경 감사 문서: https://claude.ai/code/artifact/1bea21c5-450c-4bac-ab22-0664ad8ab87e
- 같은 worktree에 있던 wire-capture TOML 키 개방 diff는 registry `Env_only` 계약 위반(부팅 FATAL 전례)이라 재상륙 대상에서 제외했습니다.

## 변경

bearer credential이 저장된 상태에서는 caller-supplied `_agent_name` transport hint가 identity를 결정하지 못합니다.

- bearer 존재 시 `explicitToolActor(args)`를 사용하지 않고, tool args에서 `_agent_name`을 제거합니다.
- managed dev credential은 `implicitToolActor()`가 아는 actor를 미러링하고, 그 외 bearer는 서버가 인증 후 canonical owner를 주입합니다.
- 기존 경로는 모순된 `X-MASC-Agent` 헤더를 보내면서 args의 외부 `_agent_name`도 그대로 보존했습니다 (mcp.ts 주석에 명시).

## 검증

- `npm test -- src/api/mcp.test.ts` → 1 file, 21/21 PASS (신규 회귀 테스트 `does not let _agent_name override a bearer credential owner` 포함)
- base: origin/main `0f148ab853`

## 재상륙 노트

보존된 원본 diff 그대로이며 현재 main에 충돌 없이 적용됐습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
