### PR TITLE
fix(keeper): preserve repeated tool loop as checkpoint yield

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -439,6 +439,55 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     let process_cwd = Eio.Path.(Eio.Stdenv.fs env / base_path) in
     let started_at = Time_compat.now () in
     let stream = stream_projection ~turn_count on_event in
+    let settle_host_stop stop =
+      match (!session_state).Session_store.phase with
+      | Turn_inflight { session_id; turn_id; _ } ->
+        let turn_id =
+          Option.value
+            turn_id
+            ~default:(provider_turn_identity ~conversation_id:session_id ~num_turns:turn_count)
+        in
+        let* () =
+          match turn_id, (!session_state).phase with
+          | turn_id, Turn_inflight { turn_id = None; _ } ->
+            update_session "host-stop turn identity transition" (fun expected ->
+              Session_store.mark_turn_started
+                ~base_path
+                ~keeper_name
+                ~expected
+                ~session_id
+                ~turn_id
+                ~turn_count
+                ~updated_at:(Time_compat.now ()))
+            |> Result.map_error internal_error
+          | _, Turn_inflight { turn_id = Some _; _ } -> Ok ()
+          | _, _ -> assert false
+        in
+        recovery_failure := Session_store.State_persistence_failed;
+        let* settled =
+          Session_store.settle
+            ~base_path
+            ~keeper_name
+            ~expected:!session_state
+            ~session_id
+            ~turn_id
+            ~updated_at:(Time_compat.now ())
+          |> Result.map_error (fun detail ->
+            internal_error ("Antigravity host-stop settlement failed: " ^ detail))
+        in
+        session_state := settled;
+        Ok
+          (Host.repeated_tool_call_result
+             ~model:config.model
+             ~session_id
+             ~turn_id
+             ~turns_used:turn_count
+             stop)
+      | Ready | Start _ | Active _ | Recovery_required _ | Settled _ ->
+        Error
+          (internal_error
+             "Antigravity host stop arrived without an admitted provider turn")
+    in
     let run_client () =
       let cleanup_error = ref None in
       let turn_result =
@@ -517,14 +566,12 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
               (fun () -> `Abort (Eio.Promise.await abort_turn))
           with
           | `Runtime client_result ->
-            Result.map_error
-              (fun error ->
-                 recovery_failure := recovery_failure_of_runtime_error error;
-                 runtime_error_to_core_error error)
-              client_result
-          | `Abort detail ->
-            recovery_failure := Session_store.Protocol_failed;
-            Error (internal_error detail))
+            client_result
+            |> Result.map (fun turn -> `Completed turn)
+            |> Result.map_error (fun error ->
+              recovery_failure := recovery_failure_of_runtime_error error;
+              runtime_error_to_core_error error)
+          | `Abort stop -> Ok (`Stopped stop))
       in
       match !cleanup_error with
       | None -> turn_result
@@ -536,7 +583,8 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       try
         match run_client () with
         | Error error -> Error error
-        | Ok turn ->
+        | Ok (`Stopped stop) -> settle_host_stop stop
+        | Ok (`Completed turn) ->
           recovery_failure := Session_store.Protocol_failed;
           let turn_id =
             provider_turn_identity

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -242,6 +242,9 @@ let claude_error_to_core_error = function
     Agent_core.Error.Provider
       (Llm_provider.Error.UnknownVariant
          { type_name = "claude_code.control_request"; value = subtype })
+  | Runtime_claude_code.Stopped_by_host _ ->
+    Agent_core.Error.Internal
+      "Claude Code host stop escaped the typed checkpoint boundary"
 ;;
 
 let recovery_failure_of_client_error = function
@@ -259,6 +262,7 @@ let recovery_failure_of_client_error = function
   | Runtime_claude_code.Turn_failed _
   | Runtime_claude_code.Quota_blocked _ ->
     Session_store.Provider_rejected
+  | Runtime_claude_code.Stopped_by_host _ -> Session_store.Protocol_failed
 ;;
 
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
@@ -541,6 +545,38 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       (List.length dynamic_tools)
       (Runtime_claude_code.dynamic_tool_bytes dynamic_tools);
     let started_at = Time_compat.now () in
+    let settle_host_stop stop =
+      match (!session_state).Session_store.phase with
+      | Turn_inflight { session_id; turn_id = Some turn_id; _ } ->
+        recovery_failure := Session_store.State_persistence_failed;
+        (match
+           Session_store.settle
+             ~base_path
+             ~keeper_name
+             ~expected:!session_state
+             ~session_id
+             ~turn_id
+             ~updated_at:(Time_compat.now ())
+         with
+         | Error detail ->
+           Error
+             (internal_error
+                ("Claude Code host-stop settlement failed: " ^ detail))
+         | Ok settled ->
+           session_state := settled;
+           Ok
+             (Host.repeated_tool_call_result
+                ~model:(Option.value config.model ~default:runtime_id)
+                ~session_id
+                ~turn_id
+                ~turns_used:turn_count
+                stop))
+      | Ready | Start _ | Active _ | Turn_inflight { turn_id = None; _ }
+      | Recovery_required _ | Settled _ ->
+        Error
+          (internal_error
+             "Claude Code host stop arrived without an acknowledged provider turn")
+    in
     let turn_result =
       let on_stream_event = claude_stream_callback on_event in
       try
@@ -588,6 +624,8 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
              ~prompt
         in
         (match client_result with
+         | Error (Runtime_claude_code.Stopped_by_host stop) ->
+           settle_host_stop stop
          | Error error ->
            context_overflow_retry_safe :=
              (match error with

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -305,6 +305,9 @@ let codex_error_to_core_error = function
   | Runtime_codex_app_server.Turn_interrupted ->
     Agent_core.Error.Internal
       (Runtime_codex_app_server.error_to_string Runtime_codex_app_server.Turn_interrupted)
+  | Runtime_codex_app_server.Stopped_by_host _ ->
+    Agent_core.Error.Internal
+      "Codex host stop escaped the typed checkpoint boundary"
 ;;
 
 let recovery_failure_of_client_error = function
@@ -323,6 +326,8 @@ let recovery_failure_of_client_error = function
   | Runtime_codex_app_server.Context_window_exceeded _
   | Runtime_codex_app_server.Turn_failed _ ->
     Keeper_official_client_session_store.Provider_rejected
+  | Runtime_codex_app_server.Stopped_by_host _ ->
+    Keeper_official_client_session_store.Protocol_failed
 ;;
 
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
@@ -613,6 +618,36 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       | Ambiguous | Fatal -> require_recovery detail
     in
     let started_at = Time_compat.now () in
+    let settle_host_stop stop =
+      match (!session_state).Keeper_official_client_session_store.phase with
+      | Turn_inflight { session_id; turn_id = Some turn_id; _ } ->
+        recovery_failure := Keeper_official_client_session_store.State_persistence_failed;
+        (match
+           Keeper_official_client_session_store.settle
+             ~base_path
+             ~keeper_name
+             ~expected:!session_state
+             ~session_id
+             ~turn_id
+             ~updated_at:(Time_compat.now ())
+         with
+         | Error detail ->
+           Error (internal_error ("Codex host-stop settlement failed: " ^ detail))
+         | Ok settled ->
+           session_state := settled;
+           Ok
+             (Host.repeated_tool_call_result
+                ~model:(Option.value client_config.model ~default:runtime_id)
+                ~session_id
+                ~turn_id
+                ~turns_used:turn_count
+                stop))
+      | Ready | Start _ | Active _ | Turn_inflight { turn_id = None; _ }
+      | Recovery_required _ | Settled _ ->
+        Error
+          (internal_error
+             "Codex host stop arrived without an acknowledged provider turn")
+    in
     let turn_result =
       try
         let on_stream_event = codex_stream_callback on_event in
@@ -655,6 +690,8 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
          client_config
          ~prompt
      with
+     | Error (Runtime_codex_app_server.Stopped_by_host stop) ->
+       settle_host_stop stop
      | Error error ->
        recovery_failure := recovery_failure_of_client_error error;
        Error (codex_error_to_core_error error)

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -6,6 +6,12 @@ let config_error ~field detail =
 
 let internal_error detail = Agent_core.Error.Internal detail
 
+type host_stop = Runtime_official_client_tool.host_stop =
+  | Repeated_tool_call of
+      { tool_name : string
+      ; repeated_count : int
+      }
+
 let text_of_blocks ~runtime_label ~field blocks =
   let rec loop texts = function
     | [] -> Ok (String.concat "\n" (List.rev texts))
@@ -114,6 +120,34 @@ let with_run_lifecycle_events ~event_bus ~keeper_name run =
     ~current_run_id:(fun () -> None)
     ~classify:lifecycle_outcome
     run
+;;
+
+let repeated_tool_call_result ~model ~session_id ~turn_id ~turns_used = function
+  | Repeated_tool_call { tool_name; repeated_count } ->
+    let response : Agent_core.Types.api_response =
+      { id = turn_id
+      ; model
+      ; stop_reason = Agent_core.Types.EndTurn
+      ; content = []
+      ; usage = None
+      ; telemetry =
+          Some
+            { Agent_core.Types.default_inference_telemetry with
+              canonical_model_id = Some model
+            }
+      }
+    in
+    { Runtime_agent.response
+    ; checkpoint = None
+    ; session_id
+    ; turns = turns_used
+    ; trace_ref = None
+    ; run_validation = None
+    ; runtime_observation = None
+    ; stop_reason =
+        Runtime_agent.Yielded_after_repeated_tool_call
+          { turns_used; tool_name; repeated_count }
+    }
 ;;
 
 type prepared_turn =
@@ -278,7 +312,7 @@ let prepare_turn ~runtime_label ~keeper_name ~turn_count ~system_prompt ~tools
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
-  ; abort_turn : string option
+  ; abort_turn : host_stop option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -633,8 +667,11 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
                 tool.schema.name
                 repeated_count
             in
-            record_terminal_error terminal_error detail;
-            { result with abort_turn = Some detail }
+            Log.Keeper.warn ~keeper_name "%s" detail;
+            { result with
+              abort_turn =
+                Some (Repeated_tool_call { tool_name = tool.schema.name; repeated_count })
+            }
         | exception exn ->
           let backtrace = Printexc.get_raw_backtrace () in
           Eio.Cancel.protect (fun () ->

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -20,10 +20,16 @@ type prepared_turn =
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
   }
 
+type host_stop = Runtime_official_client_tool.host_stop =
+  | Repeated_tool_call of
+      { tool_name : string
+      ; repeated_count : int
+      }
+
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
-  ; abort_turn : string option
+  ; abort_turn : host_stop option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -173,3 +179,14 @@ val with_run_lifecycle_events :
 (** Publish the same typed start and terminal lifecycle owned by Agent Core.
     Official clients own their internal model loop, so this host boundary is
     the single MASC owner for those events. *)
+
+val repeated_tool_call_result :
+  model:string ->
+  session_id:string ->
+  turn_id:string ->
+  turns_used:int ->
+  host_stop ->
+  Runtime_agent.run_result
+(** Build the provider-neutral checkpoint terminal after an official-client
+    adapter stops its vendor-owned loop. The external client session is the
+    durable continuation owner, so no Agent Core checkpoint is synthesized. *)

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -80,10 +80,16 @@ type turn_result =
   ; usage : turn_usage option
   }
 
+type host_stop = Runtime_official_client_tool.host_stop =
+  | Repeated_tool_call of
+      { tool_name : string
+      ; repeated_count : int
+      }
+
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
-  ; abort_turn : string option
+  ; abort_turn : host_stop option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -141,6 +147,7 @@ type error =
       ; response_emitted : bool
       }
   | Turn_failed of string
+  | Stopped_by_host of host_stop
   | Quota_blocked of
       { api_error_status : int option
       ; rate_limit : rate_limit option
@@ -173,6 +180,11 @@ let error_to_string = function
       response_emitted
       message
   | Turn_failed detail -> "Claude Code turn failed: " ^ detail
+  | Stopped_by_host (Repeated_tool_call { tool_name; repeated_count }) ->
+    Printf.sprintf
+      "Claude Code stopped after repeated tool call: tool=%s count=%d"
+      tool_name
+      repeated_count
   | Quota_blocked { api_error_status; rate_limit } ->
     let status =
       Option.fold
@@ -202,6 +214,7 @@ let error_kind = function
   | Turn_transport_interrupted _ -> "turn_transport_interrupted"
   | Context_window_exceeded _ -> "context_window_exceeded"
   | Turn_failed _ -> "turn_failed"
+  | Stopped_by_host _ -> "stopped_by_host"
   | Quota_blocked _ -> "quota_blocked"
   | Process_exited _ -> "process_exited"
   | Timeout _ -> "timeout"
@@ -484,7 +497,7 @@ let handle_control_request
       in
       (match !abort_turn with
        | None -> Ok ()
-       | Some detail -> Error (Turn_failed detail))
+       | Some stop -> Error (Stopped_by_host stop))
   | unsupported ->
     let* () =
       send_control_response

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -66,10 +66,16 @@ type turn_result =
   ; usage : turn_usage option
   }
 
+type host_stop = Runtime_official_client_tool.host_stop =
+  | Repeated_tool_call of
+      { tool_name : string
+      ; repeated_count : int
+      }
+
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
-  ; abort_turn : string option
+  ; abort_turn : host_stop option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -117,6 +123,7 @@ type error =
       ; response_emitted : bool
       }
   | Turn_failed of string
+  | Stopped_by_host of host_stop
   | Quota_blocked of
       { api_error_status : int option
       ; rate_limit : rate_limit option

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -61,10 +61,16 @@ type turn_result =
   ; resumed : bool
   }
 
+type host_stop = Runtime_official_client_tool.host_stop =
+  | Repeated_tool_call of
+      { tool_name : string
+      ; repeated_count : int
+      }
+
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
-  ; abort_turn : string option
+  ; abort_turn : host_stop option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -133,6 +139,7 @@ type error =
       ; tool_effect_attempted : bool
       }
   | Turn_failed of string
+  | Stopped_by_host of host_stop
   | Turn_interrupted
   | Process_exited of string
   | Timeout of
@@ -158,6 +165,11 @@ let error_to_string = function
       tool_effect_attempted
       message
   | Turn_failed detail -> "Codex app-server turn failed: " ^ detail
+  | Stopped_by_host (Repeated_tool_call { tool_name; repeated_count }) ->
+    Printf.sprintf
+      "Codex app-server stopped after repeated tool call: tool=%s count=%d"
+      tool_name
+      repeated_count
   | Turn_interrupted -> "Codex app-server turn was interrupted"
   | Process_exited detail -> "Codex app-server exited before completion: " ^ detail
   | Timeout { seconds; turn_accepted } ->
@@ -178,6 +190,7 @@ let error_kind = function
   | Unsupported_server_request _ -> "unsupported_server_request"
   | Context_window_exceeded _ -> "context_window_exceeded"
   | Turn_failed _ -> "turn_failed"
+  | Stopped_by_host _ -> "stopped_by_host"
   | Turn_interrupted -> "turn_interrupted"
   | Process_exited _ -> "process_exited"
   | Timeout _ -> "timeout"
@@ -368,7 +381,7 @@ let handle_dynamic_tool_call io ~tools ~thread_id ~turn_id ~tool_call_count
       send_dynamic_tool_response io ~id result;
       (match result.abort_turn with
        | None -> Ok ()
-       | Some detail -> Error (Turn_failed detail))
+       | Some stop -> Error (Stopped_by_host stop))
 ;;
 
 let rec await_response io ~id ~method_ =

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -49,10 +49,16 @@ type turn_result =
   ; resumed : bool
   }
 
+type host_stop = Runtime_official_client_tool.host_stop =
+  | Repeated_tool_call of
+      { tool_name : string
+      ; repeated_count : int
+      }
+
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
   { success : bool
   ; content : string
-  ; abort_turn : string option
+  ; abort_turn : host_stop option
   }
 
 type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
@@ -114,6 +120,7 @@ type error =
       ; tool_effect_attempted : bool
       }
   | Turn_failed of string
+  | Stopped_by_host of host_stop
   | Turn_interrupted
   | Process_exited of string
   | Timeout of

--- a/lib/runtime/runtime_official_client_tool.ml
+++ b/lib/runtime/runtime_official_client_tool.ml
@@ -1,7 +1,13 @@
+type host_stop =
+  | Repeated_tool_call of
+      { tool_name : string
+      ; repeated_count : int
+      }
+
 type dynamic_tool_result =
   { success : bool
   ; content : string
-  ; abort_turn : string option
+  ; abort_turn : host_stop option
   }
 
 type dynamic_tool =

--- a/lib/runtime/runtime_official_client_tool.mli
+++ b/lib/runtime/runtime_official_client_tool.mli
@@ -10,13 +10,22 @@
     here once and the three re-export it by type equation, which makes those
     copies unnecessary rather than merely shorter. *)
 
+type host_stop =
+  | Repeated_tool_call of
+      { tool_name : string
+      ; repeated_count : int
+      }
+(** A host-owned, non-failure terminal that must stop a vendor-owned model
+    loop after the current tool outcome has been returned. *)
+
 type dynamic_tool_result =
   { success : bool
   ; content : string
-  ; abort_turn : string option
+  ; abort_turn : host_stop option
     (** Host-owned terminal reason. The transport returns the current tool
         outcome, then stops the provider loop instead of admitting another
-        tool call. *)
+        tool call. The typed reason must remain a checkpoint terminal rather
+        than being projected as a provider failure. *)
   }
 
 type dynamic_tool =

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -240,11 +240,14 @@ let test_repeated_exact_dynamic_tool_call_aborts_the_turn () =
     let second = call 2 in
     let third = call 3 in
     check int "three calls executed" 3 !executions;
-    check (option string) "first call continues" None first.abort_turn;
-    check (option string) "second call continues" None second.abort_turn;
-    check bool "reordered object still aborts third call" true
-      (Option.is_some third.abort_turn);
-    check bool "terminal cause is retained" true (Option.is_some !terminal_error))
+    check bool "first call continues" true (Option.is_none first.abort_turn);
+    check bool "second call continues" true (Option.is_none second.abort_turn);
+    (match third.abort_turn with
+     | Some (Repeated_tool_call { tool_name; repeated_count }) ->
+       check string "repeated tool" "masc_probe" tool_name;
+       check int "repeat count" 3 repeated_count
+     | None -> fail "reordered object did not produce a typed host stop");
+    check (option string) "host stop is not a terminal error" None !terminal_error)
 ;;
 
 let test_dynamic_tool_progress_does_not_trip_the_repeat_guard () =
@@ -261,10 +264,32 @@ let test_dynamic_tool_progress_does_not_trip_the_repeat_guard () =
           ~call_id:(Printf.sprintf "progress-%d" index)
           (`Assoc [ "same", `String "input" ])
       in
-      check (option string) "changing result continues" None result.abort_turn
+      check bool "changing result continues" true (Option.is_none result.abort_turn)
     done;
     check int "all progressing calls execute" 10 !executions;
     check (option string) "progress is not terminal" None !terminal_error)
+;;
+
+let test_repeated_tool_host_stop_is_a_checkpoint_yield () =
+  let result =
+    Host.repeated_tool_call_result
+      ~model:"official-client-model"
+      ~session_id:"session-1"
+      ~turn_id:"turn-2"
+      ~turns_used:2
+      (Repeated_tool_call { tool_name = "masc_probe"; repeated_count = 3 })
+  in
+  check string "session" "session-1" result.session_id;
+  check int "turns" 2 result.turns;
+  check bool "no synthetic Agent Core checkpoint" true
+    (Option.is_none result.checkpoint);
+  match result.stop_reason with
+  | Runtime_agent.Yielded_after_repeated_tool_call
+      { turns_used; tool_name; repeated_count } ->
+    check int "typed turns" 2 turns_used;
+    check string "typed tool" "masc_probe" tool_name;
+    check int "typed count" 3 repeated_count
+  | _ -> fail "host stop was not projected as a repeated-tool checkpoint yield"
 ;;
 
 let msg role content : Agent_core.Types.message =
@@ -693,6 +718,10 @@ let () =
             "dynamic tool progress does not trip repeat guard"
             `Quick
             test_dynamic_tool_progress_does_not_trip_the_repeat_guard
+        ; test_case
+            "repeated host stop is a checkpoint yield"
+            `Quick
+            test_repeated_tool_host_stop_is_a_checkpoint_yield
         ] )
     ; ( "history encoding"
       , [ test_case

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -586,7 +586,10 @@ let test_dynamic_tool_abort_stops_the_provider_loop () =
         (fun ~call_id:_ _ ->
           { success = false
           ; content = "same deterministic failure"
-          ; abort_turn = Some "repeated exact dynamic tool call detected"
+          ; abort_turn =
+              Some
+                (Repeated_tool_call
+                   { tool_name = "masc_probe"; repeated_count = 3 })
           })
     }
   in
@@ -598,9 +601,11 @@ let test_dynamic_tool_abort_stops_the_provider_loop () =
     ]
     (fun path ->
       match run_fixture ~dynamic_tools:[ tool ] path with
-      | Error (Runtime_claude_code.Turn_failed detail) ->
-        check bool "abort cause" true
-          (Astring.String.is_infix ~affix:"repeated exact" detail)
+      | Error
+          (Runtime_claude_code.Stopped_by_host
+            (Repeated_tool_call { tool_name; repeated_count })) ->
+        check string "tool" "masc_probe" tool_name;
+        check int "repeat count" 3 repeated_count
       | Error error -> fail (Runtime_claude_code.error_to_string error)
       | Ok _ -> fail "dynamic tool abort did not stop the Claude turn")
 ;;

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -281,7 +281,10 @@ let test_dynamic_tool_abort_stops_the_provider_loop () =
         (fun ~call_id:_ _ ->
           { success = false
           ; content = "same deterministic failure"
-          ; abort_turn = Some "repeated exact dynamic tool call detected"
+          ; abort_turn =
+              Some
+                (Repeated_tool_call
+                   { tool_name = "masc_probe"; repeated_count = 3 })
           })
     }
   in
@@ -289,9 +292,11 @@ let test_dynamic_tool_abort_stops_the_provider_loop () =
     [ init_result; account_chatgpt; thread_result; turn_result; tool_call_request ]
     (fun path ->
       match run_fixture ~dynamic_tools:[ tool ] path with
-      | Error (Runtime_codex_app_server.Turn_failed detail) ->
-        check bool "abort cause" true
-          (Astring.String.is_infix ~affix:"repeated exact" detail)
+      | Error
+          (Runtime_codex_app_server.Stopped_by_host
+            (Repeated_tool_call { tool_name; repeated_count })) ->
+        check string "tool" "masc_probe" tool_name;
+        check int "repeat count" 3 repeated_count
       | Error error -> fail (Runtime_codex_app_server.error_to_string error)
       | Ok _ -> fail "dynamic tool abort did not stop the Codex turn")
 ;;


### PR DESCRIPTION
## Summary
- replace the stringly official-client abort marker with typed Repeated_tool_call evidence
- project Codex, Claude Code, and Antigravity loop fences as Runtime_agent.Yielded_after_repeated_tool_call
- settle the durable official-client session before returning the checkpoint terminal
- keep provider failures and deliberate host stops distinct in lifecycle and fleet health

## Review follow-up
Post-merge corrective for the lifecycle P1 on #28318:
https://github.com/jeong-sik/masc/pull/28318#discussion_r3763870673

The Antigravity response-flush P1 remains separately open and is not claimed fixed here:
https://github.com/jeong-sik/masc/pull/28318#discussion_r3763859501

## Verification
- ocamlformat --check on all 14 changed OCaml files — passed
- ocamlc -stop-after parsing on all changed implementations/tests — passed
- python3 scripts/audit-dead-surface.py --exports --ratchet — 548, at baseline
- scripts/check-eio-conventions.sh — passed
- git diff --check — passed
- local Dune intentionally not run; exact-head CI is build/test authority

## Exact revision
- base: 55a59617a5a4336c49ad90ca440977dfa0a0fb52
- head: 66e143281db940d43b8a3a1134380f6f82f995a7