### PR TITLE
fix(dashboard): bind bearer authority after bootstrap

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -422,6 +422,41 @@ describe('MCP 2026-07-28 dashboard client', () => {
       .toEqual(['/api/v1/dashboard/dev-token', '/mcp'])
   })
 
+  it('binds identity to a bearer bootstrapped during the call', async () => {
+    let token: string | null = null
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'worker' } | null = null
+    let revision = 0
+    getStoredToken.mockImplementation(() => token)
+    getStoredTokenMeta.mockImplementation(() => meta)
+    currentStoredTokenRevision.mockImplementation(() => revision)
+    setStoredToken.mockImplementationOnce((nextToken, nextMeta) => {
+      token = nextToken
+      meta = nextMeta
+      revision += 1
+    })
+    fetchWithTimeout
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        token: 'loopback-dev-token', actor: 'dashboard', role: 'worker',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(okToolResponse())
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_transition', {
+      task_id: 'task-223',
+      agent_name: 'target-keeper',
+      _agent_name: 'foreign-caller',
+    })
+
+    const [, init] = callsByMethod('tools/call')[0]!
+    const body = JSON.parse(init.body as string)
+    expect(body.params.arguments).toEqual({
+      task_id: 'task-223',
+      agent_name: 'target-keeper',
+      _agent_name: 'dashboard',
+    })
+    expect(authHeaders).toHaveBeenLastCalledWith({ actorName: 'dashboard' })
+  })
+
   it('uses distinct platform UUIDs for consecutive tool request identities', async () => {
     fetchWithTimeout
       .mockResolvedValueOnce(okToolResponse('first'))

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -281,15 +281,14 @@ async function callMcpToolInternal(
 ): Promise<string> {
   const requestId = randomUuid()
   synchronizeMcpAuthRevision()
-  // A bearer credential is the identity authority. Never let a caller-supplied
-  // transport hint override it: besides sending a contradictory X-MASC-Agent
-  // header, the old path also preserved the foreign _agent_name in tool args.
-  // For managed dev credentials we can mirror their known actor; for every
-  // other bearer the server injects the canonical owner after authentication.
-  const hasBearer = getStoredToken() !== null
-  const explicitActor = hasBearer ? null : explicitToolActor(args)
+  let explicitActor: string | null = null
   try {
     const binding = await ensureBinding()
+    // ensureBinding may install the loopback dev credential, so classify
+    // identity authority only after it returns. Never let a caller-supplied
+    // transport hint override the credential used by this request.
+    const hasBearer = getStoredToken() !== null
+    explicitActor = hasBearer ? null : explicitToolActor(args)
     const actor = explicitActor ?? implicitToolActor()
     const toolArgs = (() => {
       if (hasBearer) {


### PR DESCRIPTION
## Summary

- classify MCP caller identity after `ensureBinding()` installs any loopback bearer
- replace an untrusted `_agent_name` with the managed dev credential actor
- preserve domain-level `agent_name` arguments unchanged
- add a regression test for the no-token to dev-token transition inside one call

## Root cause

#28334 snapshotted `hasBearer` before `ensureBinding()`. On a first loopback call,
`ensureDevToken()` can install a bearer after that snapshot, so the request could
still forward the caller-provided `_agent_name` and actor header while using the
new credential.

## Impact

The transport identity now follows the credential actually bound to the request,
including the first call that bootstraps the loopback dev token.

## Verification

- `git diff --check` passed
- local build/test intentionally not run at user request; exact-head GitHub CI is the build/test authority

## Follow-up

- post-merge correction for #28334

## Exact revision

- base: `ee4218914df7fdc375c44c1f6838f1e35a8e2558`
- head: `bf61ec540075c613ba835a92834bcf9f68728a41`
