### PR TITLE
refactor(keeper): make cycle accounting typed

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -117,18 +117,18 @@ type keepalive_cycle_status =
   | Turn_cycle_crashed
   | Turn_cycle_busy of Keeper_owner.autonomous_block
 
-type keepalive_cycle_accounting =
-  { record_turn_status : bool
-  ; refresh_work_heartbeat : bool
-  }
+type work_heartbeat_action =
+  | Refresh_work_heartbeat
+  | Preserve_work_heartbeat
 
-let keepalive_cycle_accounting = function
-  | Turn_cycle_completed ->
-    { record_turn_status = true; refresh_work_heartbeat = true }
-  | Turn_cycle_crashed ->
-    { record_turn_status = true; refresh_work_heartbeat = false }
-  | Turn_cycle_busy _ ->
-    { record_turn_status = false; refresh_work_heartbeat = false }
+type keepalive_cycle_action =
+  | Defer_autonomous_work of Keeper_owner.autonomous_block
+  | Record_turn_status of work_heartbeat_action
+
+let decide_keepalive_cycle_action = function
+  | Turn_cycle_completed -> Record_turn_status Refresh_work_heartbeat
+  | Turn_cycle_crashed -> Record_turn_status Preserve_work_heartbeat
+  | Turn_cycle_busy block -> Defer_autonomous_work block
 ;;
 
 type keepalive_turn_outcome = {
@@ -1527,11 +1527,8 @@ let run_heartbeat_loop
             r)
         in
         let meta_after_proactive = turn_outcome.meta in
-        let accounting = keepalive_cycle_accounting turn_outcome.cycle_status in
-        if not accounting.record_turn_status
-        then (
-          match turn_outcome.cycle_status with
-          | Turn_cycle_busy block ->
+        (match decide_keepalive_cycle_action turn_outcome.cycle_status with
+         | Defer_autonomous_work block ->
             Keeper_registry.record_skip_reasons
               ~base_path:ctx.config.base_path
               m.name
@@ -1544,9 +1541,8 @@ let run_heartbeat_loop
               "Keeper Owner deferred autonomous work: %s; this keepalive cycle \
                records no turn status, crash, or work-health refresh"
               (Keeper_owner.autonomous_block_to_string block)
-          | Turn_cycle_completed | Turn_cycle_crashed -> assert false)
-        else if not lifecycle_blocked
-        then (
+         | Record_turn_status _ when lifecycle_blocked -> ()
+         | Record_turn_status work_heartbeat_action ->
              (* The registry tracks failure count as observation. A
                 lifecycle-blocked cycle did not run a turn and must not emit a
                 false [Turn_succeeded]. *)
@@ -1573,8 +1569,8 @@ let run_heartbeat_loop
                 On failure: leave timestamp unchanged → presence sync resumes next cycle.
                 T6 audit: a crashed cycle proves nothing about health — do not
                 refresh the lease or reset consecutive_failures for it. *)
-             if accounting.refresh_work_heartbeat
-             then
+             (match work_heartbeat_action with
+              | Refresh_work_heartbeat ->
                refresh_work_as_heartbeat
                  ~ctx
                  ~meta_after_proactive
@@ -1582,10 +1578,10 @@ let run_heartbeat_loop
                  ~work_as_hb
                  ~last_successful_heartbeat_ts
                  ~consecutive_failures
-             else
+              | Preserve_work_heartbeat ->
                Log.Keeper.info
                  "%s: skipping work-as-heartbeat refresh after crashed keepalive cycle"
-                 m.name);
+                 m.name));
         let t_turn_end = Time_compat.now () in
         (* Phase 0: push stage timing to ring buffer *)
         record_keepalive_stage_timing

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -107,15 +107,20 @@ type keepalive_cycle_status =
   | Turn_cycle_crashed
   | Turn_cycle_busy of Keeper_owner.autonomous_block
 
-type keepalive_cycle_accounting =
-  { record_turn_status : bool
-  ; refresh_work_heartbeat : bool
-  }
+type work_heartbeat_action =
+  | Refresh_work_heartbeat
+  | Preserve_work_heartbeat
 
-val keepalive_cycle_accounting :
-  keepalive_cycle_status -> keepalive_cycle_accounting
-(** Closed accounting policy used by the heartbeat loop. Busy cycles record
-    neither turn completion nor work-heartbeat success. *)
+type keepalive_cycle_action =
+  | Defer_autonomous_work of Keeper_owner.autonomous_block
+  | Record_turn_status of work_heartbeat_action
+
+val decide_keepalive_cycle_action :
+  keepalive_cycle_status -> keepalive_cycle_action
+(** Total accounting decision used by the heartbeat effect shell. Completed
+    cycles record and refresh, crashed cycles record while preserving the
+    existing work-health lease, and busy cycles retain their typed admission
+    block without recording a turn. *)
 
 (** Outcome of one keepalive cycle evaluation.
 

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -206,18 +206,33 @@ let test_freshness_disabled_flag () =
   let fresh = work_as_hb && (now -. last_hb < max_silence) in
   check bool "feature disabled → always stale" false fresh
 
-let test_busy_cycle_records_no_turn_status_or_work_heartbeat () =
-  let accounting =
-    Masc.Keeper_heartbeat_loop.keepalive_cycle_accounting
+let test_completed_cycle_records_and_refreshes () =
+  match
+    Masc.Keeper_heartbeat_loop.decide_keepalive_cycle_action
+      Masc.Keeper_heartbeat_loop.Turn_cycle_completed
+  with
+  | Masc.Keeper_heartbeat_loop.Record_turn_status Refresh_work_heartbeat -> ()
+  | _ -> fail "completed cycle must record and refresh work-heartbeat"
+;;
+
+let test_crashed_cycle_records_and_preserves_work_heartbeat () =
+  match
+    Masc.Keeper_heartbeat_loop.decide_keepalive_cycle_action
+      Masc.Keeper_heartbeat_loop.Turn_cycle_crashed
+  with
+  | Masc.Keeper_heartbeat_loop.Record_turn_status Preserve_work_heartbeat -> ()
+  | _ -> fail "crashed cycle must record without refreshing work-heartbeat"
+;;
+
+let test_busy_cycle_defers_typed_block () =
+  match
+    Masc.Keeper_heartbeat_loop.decide_keepalive_cycle_action
       (Masc.Keeper_heartbeat_loop.Turn_cycle_busy
          (Masc.Keeper_owner.Turn_busy None))
-  in
-  check bool "busy cycle records no turn status" false accounting.record_turn_status;
-  check
-    bool
-    "busy cycle refreshes no work-heartbeat success"
-    false
-    accounting.refresh_work_heartbeat
+  with
+  | Masc.Keeper_heartbeat_loop.Defer_autonomous_work
+      (Masc.Keeper_owner.Turn_busy None) -> ()
+  | _ -> fail "busy cycle must preserve its typed admission block"
 ;;
 
 (* ── Percentile function (Phase 0 profiling) ────────────── *)
@@ -299,11 +314,19 @@ let () =
       test_case "never heartbeated → stale" `Quick test_freshness_never_heartbeated;
       test_case "feature disabled → always stale" `Quick test_freshness_disabled_flag;
     ];
-    "cycle_accounting", [
+    "cycle_action", [
       test_case
-        "busy records no completion or work-heartbeat success"
+        "completed records and refreshes work-heartbeat"
         `Quick
-        test_busy_cycle_records_no_turn_status_or_work_heartbeat;
+        test_completed_cycle_records_and_refreshes;
+      test_case
+        "crashed records and preserves work-heartbeat"
+        `Quick
+        test_crashed_cycle_records_and_preserves_work_heartbeat;
+      test_case
+        "busy defers with its typed admission block"
+        `Quick
+        test_busy_cycle_defers_typed_block;
     ];
     "config_invariants", [
       test_case "max_silence >= interval" `Quick test_config_invariant_silence_ge_interval;


### PR DESCRIPTION
## Summary

- replace the two-boolean keepalive accounting projection with a closed cycle action
- carry the typed `Keeper_owner.autonomous_block` directly into the defer branch
- remove the second match on `cycle_status` and its impossible `assert false`
- characterize completed, crashed, and busy decisions exhaustively

## Boundary moved

`keepalive_cycle_status` is now resolved once by `decide_keepalive_cycle_action`. The heartbeat shell executes that action without reconstructing the discarded status from booleans. This is the RFC-0371 boolean-blindness site identified in the original inventory.

## Verification

- `ocamlc -stop-after parsing` on the two implementation/interface files and focused test
- `ocamlformat --check` on all changed OCaml files
- `git diff origin/main...HEAD --check`
- static census: old accounting API, boolean field reads, and the removed `assert false` are absent from the touched surface

Per operator instruction, no local Dune build was run. Exact-head GitHub CI is the build authority.

RFC: `docs/rfc/RFC-0371-effect-boundary-restoration.md`
