### PR TITLE
fix(tools): pin masc_runtime_verify to its local pool scope

### DIFF
--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -262,6 +262,9 @@ let runtime_verify_json_from_discovery ?runtime_pool ?expected_slots ?expected_c
       ("checked_at", `String (Masc_domain.now_iso ()));
       ("runtime_pool", Json_util.string_opt_to_json runtime_pool);
       ("source", `String "agent_core_discovery");
+      ("verification_scope", `String "local_openai_compatible_runtime_pool");
+      ("blocks_keeper_turns", `Bool false);
+      ("fleet_provider_health", `String "not_assessed");
       ("cache_age_seconds", `Float (Discovery_cache.cache_age_seconds ()));
       ("provider_base_url", Json_util.string_opt_to_json (first_endpoint_url endpoints));
       ("slot_url", Json_util.string_opt_to_json (first_endpoint_url endpoints));
@@ -291,6 +294,9 @@ let runtime_verify_json_missing_discovery ?runtime_pool ?expected_slots
       ("checked_at", `String (Masc_domain.now_iso ()));
       ("runtime_pool", Json_util.string_opt_to_json runtime_pool);
       ("source", `String "agent_core_discovery");
+      ("verification_scope", `String "local_openai_compatible_runtime_pool");
+      ("blocks_keeper_turns", `Bool false);
+      ("fleet_provider_health", `String "not_assessed");
       ("cache_age_seconds", `Float (Discovery_cache.cache_age_seconds ()));
       ("provider_base_url", `Null);
       ("slot_url", `Null);
@@ -308,7 +314,9 @@ let runtime_verify_json_missing_discovery ?runtime_pool ?expected_slots
       ("configured_capacity", `Int 0);
       ("configured_max_concurrent_models", `Int Inference_utils.max_concurrent_models);
       ("runtime_blocker", `String "agent_core_discovery_unavailable");
-      ("detail", `String "runtime verification requires AGENT_CORE discovery endpoints");
+      ( "detail",
+        `String
+          "No typed local OpenAI-compatible discovery endpoint is registered. This diagnostic does not assess or block official-client, CLI, or remote Keeper provider lanes." );
       ("pass", `Bool false);
       ("runtimes", `List []);
     ]

--- a/lib/tool_local_runtime_verify.mli
+++ b/lib/tool_local_runtime_verify.mli
@@ -68,5 +68,9 @@ val runtime_verify_json :
     diagnostics + the {!classify_runtime_blocker} verdict.  [?runtime_pool]
     selects the pool by name; default behaviour is "use the
     default pool" via {!Local_runtime_pool.default_pool_label}.  When
-    discovery has no resolvable endpoints, the result fails closed with
-    [runtime_blocker = "agent_core_discovery_unavailable"]. *)
+    discovery has no resolvable endpoints, the local-runtime diagnostic fails
+    closed with [runtime_blocker = "agent_core_discovery_unavailable"]. The
+    response also pins [verification_scope =
+    "local_openai_compatible_runtime_pool"], [blocks_keeper_turns = false],
+    and [fleet_provider_health = "not_assessed"] so callers cannot treat
+    absence of this optional local pool as a fleet-wide provider outage. *)

--- a/lib/tool_schemas/tool_schemas_local_runtime.ml
+++ b/lib/tool_schemas/tool_schemas_local_runtime.ml
@@ -42,7 +42,7 @@ let definitions : definition list =
     { operation = Verify; schema = {
       name = "masc_runtime_verify";
       description =
-        "Strictly verify the active provider/runtime contract used for swarm and benchmark runs. Returns reachability, chat-completions contract status, model match, slots, ctx, configured capacity, active slots, and blocker codes such as provider_unreachable, provider_model_mismatch, slot_count_insufficient, ctx_mismatch, or chat_contract_incompatible.";
+        "Verify only the optional typed local OpenAI-compatible runtime pool used for local benchmarks. Returns reachability, chat-completions contract status, model match, slots, ctx, configured capacity, active slots, and local blocker codes. Missing local discovery does not assess or block official-client, CLI, or remote Keeper provider lanes.";
       input_schema =
         `Assoc
           [

--- a/test/test_local_runtime_pool.ml
+++ b/test/test_local_runtime_pool.ml
@@ -75,6 +75,18 @@ let test_parse_llm_endpoints_env () =
 (* [test_acquire_requires_explicit_or_runtime_model] removed 2026-05-05 —
    covered the acquire surface that was archived. *)
 
+let test_missing_discovery_is_scoped_not_fleet_health () =
+  let open Yojson.Safe.Util in
+  let result = Masc.Tool_local_runtime_verify.runtime_verify_json () in
+  Alcotest.(check string) "local verification scope"
+    "local_openai_compatible_runtime_pool"
+    (result |> member "verification_scope" |> to_string);
+  Alcotest.(check bool) "does not block Keeper turns" false
+    (result |> member "blocks_keeper_turns" |> to_bool);
+  Alcotest.(check string) "fleet provider health is not assessed"
+    "not_assessed"
+    (result |> member "fleet_provider_health" |> to_string)
+
 (* [test_failure_cooldown_from_env] removed 2026-05-05 — exercised the
    failure-streak path through release/acquire which was archived. *)
 
@@ -86,5 +98,7 @@ let () =
           Alcotest.test_case "parse runtime env" `Quick test_parse_runtime_env;
           Alcotest.test_case "parse LLM_ENDPOINTS env" `Quick
             test_parse_llm_endpoints_env;
+          Alcotest.test_case "missing discovery is local-only" `Quick
+            test_missing_discovery_is_scoped_not_fleet_health;
         ] );
     ]


### PR DESCRIPTION
## 배경

`fix/keeper-autonomy-recovery-20260811` worktree는 자체 커밋 0개 상태에서 디렉터리가 소실되어 미커밋 작업 전체(13개 파일)가 유실됐습니다. 삭제 직전 캡처해 둔 diff에서 runtime-verify 절반을 재상륙합니다.

- 보존 diff: `~/me/.tmp/keeper-autonomy-recovery-lost-diffs/runtime-verify-scope-fields.diff` (유실 경위는 같은 디렉터리 README)
- 배경 감사 문서: https://claude.ai/code/artifact/1bea21c5-450c-4bac-ab22-0664ad8ab87e

## 변경

`masc_runtime_verify`는 optional local OpenAI-compatible pool 진단인데, 응답만 보면 fleet 전체 provider health 판정으로 읽혔습니다 — lane-smith가 `agent_core_discovery_unavailable`을 매 턴 동일 확인 반복한 원인입니다. 응답에 스코프를 상수로 고정합니다.

- `verification_scope = "local_openai_compatible_runtime_pool"`
- `blocks_keeper_turns = false`
- `fleet_provider_health = "not_assessed"`
- missing-discovery `detail` 문구와 tool description을 local-only 의미로 교체
- `.mli` 계약 문서화 + 구조 테스트 1건 (`missing discovery is local-only`)

필드 추가 기준: 파생 상태가 아니라 응답 payload에 스코프 의미를 선언하는 상수이며, blast radius는 `masc_runtime_verify` 응답 소비자로 한정됩니다. gate를 만들지 않습니다 — `blocks_keeper_turns=false`는 판정 입력이 아니라 오독 방지 선언입니다.

## 재상륙 노트 (원본 diff 대비 조정 1건)

보존 diff의 base(2ce4feb43b) 이후 #28209가 `test_local_runtime_pool.ml`의 `test_record_measured_ceiling`을 숙청해 컨텍스트 충돌이 났습니다. 3-way 적용 후 숙청은 유지하고 신규 테스트 케이스만 추가했습니다. lib 3개 파일은 원본 diff 그대로입니다.

## 검증

- `dune build --root . test/test_local_runtime_pool.exe` — exit 0 (worktree 격리 빌드)
- `./_build/default/test/test_local_runtime_pool.exe` — 3/3 통과 (`missing discovery is local-only` 신규 케이스 포함)
- `dune build --root . @lib/fmt @test/fmt` — 이 PR의 4개 파일에 대한 지적 없음. 잔여 실패분은 이 PR이 건드리지 않은 `test/dune`의 기존 포맷 drift (CI ocamlformat은 changed-files만 검사)
- base: origin/main `0f148ab853`

같은 유실 worktree의 dashboard 절반은 #28334로 재상륙 후 병합됐고, bearer 판정 시점 결함이 후속 #28336에서 정정됐습니다 (회귀 테스트는 보존).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
