### PR TITLE
fix(antigravity): acknowledge tool response before host stop

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -513,12 +513,22 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                     ~finally:(fun () -> stream.on_tool_finished ~call_id)
                     (fun () ->
                       let result = tool.call ~call_id arguments in
-                      Option.iter
-                        (fun detail ->
-                           if Atomic.compare_and_set abort_turn_resolved false true
-                           then Eio.Promise.resolve resolve_abort_turn detail)
-                        result.abort_turn;
-                      tool_result result)))
+                      { Runtime_official_client_mcp_http.outcome = tool_result result
+                      ; after_response_sent =
+                          (fun () ->
+                             Option.iter
+                               (fun detail ->
+                                  if
+                                    Atomic.compare_and_set
+                                      abort_turn_resolved
+                                      false
+                                      true
+                                  then
+                                    Eio.Promise.resolve
+                                      resolve_abort_turn
+                                      detail)
+                               result.abort_turn)
+                      })))
               ()
           in
           let* () =

--- a/lib/runtime/runtime_official_client_mcp_http.ml
+++ b/lib/runtime/runtime_official_client_mcp_http.ml
@@ -28,6 +28,11 @@ type t =
   ; dispatch_mutex : Eio.Mutex.t
   }
 
+type tool_response =
+  { outcome : Runtime_official_client_mcp.tool_result
+  ; after_response_sent : unit -> unit
+  }
+
 let max_body_bytes = 1024 * 1024
 
 let hex_of_cstruct bytes =
@@ -159,6 +164,7 @@ let dispatch t ~request ~tool_specs ~call_tool message =
     | Ok () ->
       let inventory_failure = ref None in
       let tool_failure = ref None in
+      let after_response_sent = ref None in
       let guarded_tool_specs () =
         try tool_specs () with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -167,7 +173,13 @@ let dispatch t ~request ~tool_specs ~call_tool message =
           raise exn
       in
       let guarded_call_tool ~name ~call_id ~arguments =
-        try call_tool ~name ~call_id ~arguments with
+        try
+          match call_tool ~name ~call_id ~arguments with
+          | None -> None
+          | Some response ->
+            after_response_sent := Some response.after_response_sent;
+            Some response.outcome
+        with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
           tool_failure := Some (name, call_id, exn);
@@ -189,7 +201,7 @@ let dispatch t ~request ~tool_specs ~call_tool message =
           then
             Eio.Mutex.use_rw ~protect:true t.state_mutex (fun () ->
               t.state.tool_calls <- t.state.tool_calls + 1);
-          Ok result
+          Ok (result, !after_response_sent)
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->
@@ -309,10 +321,16 @@ let handle_message t ~request ~tool_specs ~call_tool body =
             id
             (-32603)
             "MCP tool outcome is unknown; do not retry this call id")
-     | Ok { response = None; _ } -> respond `Accepted ""
-     | Ok { response = Some response; _ } ->
+     | Ok ({ response = None; _ }, _) -> respond `Accepted ""
+     | Ok ({ response = Some response; _ }, after_response_sent) ->
        let protocol_version = (snapshot t).negotiated_protocol_version in
-       respond_json ?protocol_version `OK response)
+       let response = respond_json ?protocol_version `OK response in
+       (match after_response_sent with
+        | None -> response
+        | Some notify ->
+          fun writer ->
+            response writer;
+            notify ()))
 ;;
 
 let handle_post t ~tool_specs ~call_tool request body =

--- a/lib/runtime/runtime_official_client_mcp_http.mli
+++ b/lib/runtime/runtime_official_client_mcp_http.mli
@@ -7,6 +7,13 @@
 
 type t
 
+type tool_response =
+  { outcome : Runtime_official_client_mcp.tool_result
+  ; after_response_sent : unit -> unit
+  }
+(** A completed tool outcome and the acknowledgement to run only after its
+    HTTP response body has been written and flushed. *)
+
 val start :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
@@ -17,7 +24,7 @@ val start :
     (name:string ->
      call_id:string ->
      arguments:Yojson.Safe.t ->
-     Runtime_official_client_mcp.tool_result option) ->
+     tool_response option) ->
   unit ->
   t
 

--- a/test/test_runtime_official_client_mcp_http.ml
+++ b/test/test_runtime_official_client_mcp_http.ml
@@ -138,6 +138,7 @@ let test_turn_scoped_capability_and_protocol () =
   Eio.Switch.run
   @@ fun sw ->
   let calls = ref [] in
+  let responses_sent = ref [] in
   let tool_specs () =
     [ `Assoc
         [ "name", `String "masc_probe"
@@ -149,8 +150,12 @@ let test_turn_scoped_capability_and_protocol () =
   let call_tool ~name ~call_id ~arguments =
     calls := (name, call_id, arguments) :: !calls;
     Some
-      { Runtime_official_client_mcp.success = true
-      ; content = "MASC_TOOL_OK"
+      { Runtime_official_client_mcp_http.outcome =
+          { Runtime_official_client_mcp.success = true
+          ; content = "MASC_TOOL_OK"
+          }
+      ; after_response_sent =
+          (fun () -> responses_sent := call_id :: !responses_sent)
       }
   in
   let bridge =
@@ -314,6 +319,7 @@ let test_turn_scoped_capability_and_protocol () =
       (json_request 5 "tools/call" call_params)
   in
   check int "tools/call" 200 called.status;
+  check (list string) "response acknowledgement" [ "5" ] !responses_sent;
   check string
     "tool result"
     "MASC_TOOL_OK"


### PR DESCRIPTION
## Summary

- carry a per-tool completion acknowledgement through the loopback MCP HTTP transport
- invoke that acknowledgement only after Cohttp writes and flushes the HTTP response
- let Antigravity resolve its repeated-tool stop only from that post-response boundary
- cover the acknowledgement on the real loopback HTTP fixture

## Root cause

The repeated-tool guard resolved Antigravity's abort promise inside the tool
callback. `Eio.Fiber.first` could therefore cancel the MCP request fiber before
the authoritative third tool result had been written to the provider.

## Impact

Antigravity now receives the deterministic tool outcome before the host ends
the provider loop and projects the typed checkpoint yield.

## Verification

- `ocamlformat --check` on all four changed OCaml files passed
- `git diff --check` passed
- local Dune build/test intentionally not run at user request; exact-head GitHub CI is the build/test authority

## Follow-up

- fixes the unresolved P1 on #28318: https://github.com/jeong-sik/masc/pull/28318#discussion_r3763859501

## Exact revision

- base: `659c29500f5ed187ee44aaac801c6aa30fed8456`
- head: `e3e8c6ff0eb17db2af4d37dea49a0acd6a4181eb`
