### PR TITLE
refactor(surface): agent_card 하드코딩 도구 광고 + dispatch_v2 유령 필드 숙청

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -50,7 +50,6 @@ export interface ToolMetricsResponse extends TelemetryFreshnessMetadata {
   top_20: ToolMetricsTopEntry[]
   never_called_count: number
   tool_distribution?: { total: number; public: number; visible: number; hidden: number } | null
-  dispatch_v2_enabled: boolean
   registered_count: number
 }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1067,7 +1067,7 @@ describe('fetchDashboardTools', () => {
           { name: 'tool_c', tier: 'essential' },
         ],
       },
-      tool_usage: { total_calls: 0, distinct_tools_called: 0, top_20: [], never_called_count: 0, dispatch_v2_enabled: false, registered_count: 3 },
+      tool_usage: { total_calls: 0, distinct_tools_called: 0, top_20: [], never_called_count: 0, registered_count: 3 },
     }
 
     const fetchMock = vi.fn().mockResolvedValue(
@@ -1101,7 +1101,7 @@ describe('fetchDashboardTools', () => {
           { name: 'tool_with_surfaces', surfaces: ['public_mcp'] },
         ],
       },
-      tool_usage: { total_calls: 0, distinct_tools_called: 0, top_20: [], never_called_count: 0, dispatch_v2_enabled: false, registered_count: 2 },
+      tool_usage: { total_calls: 0, distinct_tools_called: 0, top_20: [], never_called_count: 0, registered_count: 2 },
     }
 
     const fetchMock = vi.fn().mockResolvedValue(
@@ -1123,7 +1123,7 @@ describe('fetchDashboardTools', () => {
     const tools = [{ name: 'tool_x' }]
     const rawResponse = {
       tool_inventory: { tools },
-      tool_usage: { total_calls: 0, distinct_tools_called: 0, top_20: [], never_called_count: 0, dispatch_v2_enabled: false, registered_count: 1 },
+      tool_usage: { total_calls: 0, distinct_tools_called: 0, top_20: [], never_called_count: 0, registered_count: 1 },
     }
 
     const fetchMock = vi.fn().mockResolvedValue(
@@ -1146,7 +1146,7 @@ describe('fetchDashboardTools', () => {
   it('handles missing tool_inventory gracefully', async () => {
     const rawResponse = {
       tool_inventory: {},
-      tool_usage: { total_calls: 0, distinct_tools_called: 0, top_20: [], never_called_count: 0, dispatch_v2_enabled: false, registered_count: 0 },
+      tool_usage: { total_calls: 0, distinct_tools_called: 0, top_20: [], never_called_count: 0, registered_count: 0 },
     }
 
     const fetchMock = vi.fn().mockResolvedValue(
@@ -1169,7 +1169,6 @@ describe('fetchDashboardTools', () => {
         distinct_tools_called: 0,
         top_20: [],
         never_called_count: 0,
-        dispatch_v2_enabled: false,
         registered_count: 0,
         source: 'tool_usage',
         health: 'coverage_gap',

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -167,12 +167,11 @@ export function ToolMetrics() {
         <div class="text-2xs text-[var(--color-fg-muted)] mb-3">
           서버 시작 이후 메모리 기반 집계. 재시작 시 초기화됩니다.
         </div>
-        <div class="grid grid-cols-[repeat(5,minmax(0,1fr))] gap-3 max-[880px]:grid-cols-[repeat(2,minmax(0,1fr))]">
+        <div class="grid grid-cols-[repeat(4,minmax(0,1fr))] gap-3 max-[880px]:grid-cols-[repeat(2,minmax(0,1fr))]">
           <${StatTile} label="총 호출 수" value=${String(data.total_calls)} status="brass" />
           <${StatTile} label="사용된 도구" value=${String(data.distinct_tools_called)} status="ok" delta=${{ direction: 'up', text: '활성' }} />
           <${StatTile} label="미사용 도구" value=${String(data.never_called_count)} status=${data.never_called_count > 0 ? 'warn' : 'ok'} delta=${data.never_called_count > 0 ? { direction: 'flat', text: '유휴' } : undefined} />
-          <${StatTile} label="등록됨 (v2)" value=${String(data.registered_count)} status="brass" />
-          <${StatTile} label="Dispatch v2" value=${data.dispatch_v2_enabled ? 'ON' : 'OFF'} status=${data.dispatch_v2_enabled ? 'ok' : 'crit'} delta=${data.dispatch_v2_enabled ? { direction: 'up', text: '활성' } : { direction: 'down', text: '비활성' }} />
+          <${StatTile} label="등록됨" value=${String(data.registered_count)} status="brass" />
         </div>
 
         <div class="tool-metrics-sections">

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2445,7 +2445,6 @@ let dashboard_tools_warming_json ~actor =
           ; "distinct_tools_called", `Int 0
           ; "top_20", `List []
           ; "never_called_count", `Int 0
-          ; "dispatch_v2_enabled", `Bool false
           ; "registered_count", `Int 0
           ; "source", `String "dashboard_cache_warming"
           ; "health", `String "warming"

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -334,24 +334,6 @@ let handle_agent_card ?(tool_name = "masc_agent_card") ?(start_time = 0.0) ctx a
             match target_agent with
             | Some agent -> Masc_domain.agent_to_yojson agent
             | None -> `Null );
-          ( "capabilities",
-            `Assoc [
-              ("workspace", `Bool true);
-              ("task_backlog", `Bool true);
-              ("keeper_runtime", `Bool true);
-              ("dashboard", `Bool true);
-            ] );
-          ( "tools",
-            `List
-              (List.map
-                 (fun name -> `String name)
-                 [
-                   "masc_status";
-                   "masc_tasks";
-                   "masc_transition";
-                   "masc_dashboard";
-                   "masc_tool_help";
-                 ]) );
         ]
       in
       json_ok ~tool_name ~start_time json


### PR DESCRIPTION
## 무엇을

에이전트/대시보드에 거짓 정보를 광고하던 하드코딩 표면 2종을 제거한다 (Closes #28316, Closes #28328).

1. **`masc_agent_card` 하드코딩 광고 제거** (`lib/tool_agent.ml`)
   - `tools` 필드: 리터럴 5종(`masc_status` 포함) — keeper 는 #26924 이후 `masc_status` 를 호출할 수 없는데 카드가 계속 광고했다. descriptor registry 를 거치지 않는 사본이라 가드 테스트 밖.
   - `capabilities` 필드: 4개 무조건 `true` boilerplate.
   - 도구 표면의 SSOT 는 registry projection(`keeper_tools_list` / MCP `tools/list`)이므로 카드에서 목록 광고 자체를 삭제. 카드의 나머지 필드(agent, agent_count, base_path 등)는 전부 실측값 유지.

2. **`dispatch_v2_enabled` 유령 필드 제거**
   - lib 전체 유일 발생이 warming 스텁의 `` `Bool false`` 리터럴(`server_dashboard_http_runtime_info.ml`). "dispatch v2" 서브시스템은 lib 에 존재하지 않는다. 실제 tool_usage 생산자(`tool_unified.ml`)는 이 필드를 만들지 않아, TS 타입만 required 로 주장하고 칩은 영구 OFF(crit) 를 그렸다.
   - 제거: 스텁 필드, `tool-metrics.ts` "Dispatch v2" 칩(그리드 5→4), `dashboard-tools-prompts.ts` 타입 필드, `dashboard.test.ts` 픽스처 5곳. "등록됨 (v2)" 라벨의 유령 접미사도 "등록됨" 으로.
   - #27520 (존재하지 않는 개념 제거) 스윕의 누락분.

## 소비자 확인

- agent_card 의 `tools`/`capabilities` 필드를 단언하는 테스트 없음 (`test_tools_coverage.ml` 은 input schema 의 `agent_name` 속성만, `test_transport_coverage.ml` 은 REST 엔드포인트 매핑만 검증).
- dashboard 에서 agent_card payload 의 `.tools`/`.capabilities` 를 읽는 코드 없음 (`tool-call-shared.ts` 는 도구 *이름* 문자열 매칭만).

## 검증

- dashboard: `vitest run src/api/dashboard.test.ts` 145/145 green, `tsc --noEmit` 0 에러
- OCaml: origin/main (#28338 yojson 3 수리 포함) 위로 rebase 완료, `dune build --root .` 증분 빌드 진행 중 — green 확인 시 코멘트로 갱신 (변경은 JSON payload 필드 2건 삭제라 컴파일 표면 최소)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
