### PR TITLE
fix(claude): balance retry-safe overflow streams

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -810,13 +810,23 @@ let rec await_terminal io ~mcp_session ~tools ~tool_call_count ~expected_session
       ~rate_limit:(Some rate_limit) ~assistant_model ~assistant_texts
       ~on_turn_started ~on_stream_event ~stream_started ~response_emitted ~ignored
   | "result" ->
-    let* turn_id, result, usage =
+    let parsed_result =
       parse_result
         ~expected_session_id
         ~rate_limit
         ~tool_effect_attempted:(!tool_call_count > 0)
         ~response_emitted:!response_emitted
         fields
+    in
+    let* turn_id, result, usage =
+      match parsed_result with
+      | Error
+          (Context_window_exceeded
+             { tool_effect_attempted = false; response_emitted = false; _ } as error) ->
+        if !stream_started
+        then emit_stream_event on_stream_event (Turn_finished { text = "" });
+        Error error
+      | result -> result
     in
     let* () =
       invoke_state_callback ~stage:"turn started callback" (fun () ->

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -567,12 +567,23 @@ let test_context_overflow_after_response_records_activity () =
 ;;
 
 let test_context_overflow_after_empty_assistant_remains_retry_safe () =
+  let events = ref [] in
   with_fixture [ Emit empty_assistant; Emit prompt_too_long_result ] (fun path ->
-    match run_fixture path with
+    match
+      run_fixture
+        ~on_stream_event:(fun event -> events := event :: !events)
+        path
+    with
     | Error
         (Runtime_claude_code.Context_window_exceeded
           { tool_effect_attempted = false; response_emitted = false; _ }) ->
-      ()
+      (match List.rev !events with
+       | [ Turn_started
+             { turn_id = "assistant-empty-1"; model = "claude-fixture" }
+         ; Turn_finished { text = "" }
+         ] ->
+         ()
+       | _ -> fail "retry-safe overflow left the first stream unbalanced")
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "empty assistant frame made context overflow complete")
 ;;


### PR DESCRIPTION
## Why\nAn empty Claude assistant frame emits Turn_started, but a retry-safe context overflow returned without Turn_finished. The next retry could therefore emit a second MessageStart on the same consumer stream.\n\n## Change\n- close an already-started empty stream before returning the typed retry-safe overflow\n- assert the exact Turn_started -> Turn_finished event sequence\n\nReview thread: https://github.com/jeong-sik/masc/pull/28318#discussion_r3763871449\n\n## Checks\n- git diff --check\n- ocamlformat --check lib/runtime/runtime_claude_code.ml test/test_runtime_claude_code.ml\n- local Dune build intentionally not run per operator request; GitHub CI is authoritative