### PR TITLE
fix(keeper): keep a failed turn's raw trace referenced by its TurnRecord

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1225,6 +1225,15 @@ jobs:
           opam exec -- dune build --root . \
             @test/runtest-test_keeper_raw_trace_reader
 
+      - name: Run raw-trace sink retention suite
+        # Retention deletes any trace no TurnRecord names, so the reference a
+        # turn records decides whether its trace still exists when someone
+        # goes looking. @check compiles those cases; only running them shows
+        # whether a failed turn still names the run its sink closed.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_keeper_raw_trace_sink
+
       - name: Run env snapshot applied-default suite
         # Asserts through the JSON operators actually receive. The script gate
         # cannot cover this knob any more -- the fix removed the literals it

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -314,6 +314,25 @@ let turn_record_raw_trace_run_ref
       }
 ;;
 
+(* Retention (RFC-0358) deletes every trace no TurnRecord names, so this
+   reference is what keeps a turn's trace on disk. [run_result] carries one
+   only when the turn succeeded: a failed turn still writes and closes its run
+   — [finish_raw_error] calls [Raw_trace.finish_run] — but the failure travels
+   up as [Error] with no result to read the reference from, so the record
+   named nothing and the next prune removed the one trace a failure
+   investigation needs.
+
+   The sink answers the same question for either outcome. A keeper sink is one
+   file per turn, so [Raw_trace.last_run] can only be the run this turn just
+   finished. It stays [None] when the turn failed before [start_run]; that
+   file holds no run and deleting it is correct. The turn's own reference
+   still wins when present, which leaves the succeeding path unchanged. *)
+let raw_trace_reference_for_turn ~turn_trace_ref ~sink =
+  match turn_trace_ref with
+  | Some _ as reference -> reference
+  | None -> Option.bind sink Agent_core.Raw_trace.last_run
+;;
+
 let terminal_effect_boundary_decision = Keeper_tool_terminal_boundary.decision
 
 module For_testing = struct
@@ -333,6 +352,7 @@ module For_testing = struct
   let dispatch_after_provider_transcript_admission =
     dispatch_after_provider_transcript_admission
   let turn_record_raw_trace_run_ref = turn_record_raw_trace_run_ref
+  let raw_trace_reference_for_turn = raw_trace_reference_for_turn
 end
 
 (** Run a single keeper turn via Agent_core.Agent.run().
@@ -1299,8 +1319,16 @@ let run_turn
           | None -> acc.prompt_blocks
         in
         let raw_trace_run_ref =
-          match turn_result with
-          | Ok { trace_ref = Some run_ref; _ } ->
+          let turn_trace_ref =
+            match turn_result with
+            | Ok { trace_ref; _ } -> trace_ref
+            | Error _ -> None
+          in
+          match
+            raw_trace_reference_for_turn ~turn_trace_ref ~sink:raw_trace
+          with
+          | None -> None
+          | Some run_ref ->
             (match
                turn_record_raw_trace_run_ref ~expected_session_id:trace_id run_ref
              with
@@ -1310,7 +1338,6 @@ let run_turn
                  "raw-trace run reference omitted from turn record: worker_run_id=%s: %s"
                  run_ref.worker_run_id detail;
                None)
-          | Ok { trace_ref = None; _ } | Error _ -> None
         in
         Keeper_turn_record_writer.write
           ~config

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -136,6 +136,15 @@ module For_testing : sig
     -> Agent_core.Raw_trace.run_ref
     -> (Turn_record.raw_trace_run_ref, string) result
 
+  val raw_trace_reference_for_turn
+    :  turn_trace_ref:Agent_core.Raw_trace.run_ref option
+    -> sink:Agent_core.Raw_trace.t option
+    -> Agent_core.Raw_trace.run_ref option
+  (** Which run this turn's TurnRecord names for retention. [turn_trace_ref] is
+      what the turn result reported and is absent on every failed turn; the
+      sink's last finished run covers that case, since a keeper sink holds one
+      turn. *)
+
 end
 
 (** {1 Turn execution} *)

--- a/test/test_keeper_raw_trace_sink.ml
+++ b/test/test_keeper_raw_trace_sink.ml
@@ -538,6 +538,62 @@ let test_traced_turn_yields_result_level_fields () =
       Alcotest.(check bool) "minimal traced run validates ok" true
         v.Agent_core.Raw_trace.ok
 
+(* The terminal append a failed turn performs is exactly
+   [finish_run ~error:(Some _)] — what
+   [Keeper_official_client_host.finish_raw_error] does. What a failed turn
+   cannot do is carry a reference up through [run_result], because the failure
+   travels as [Error]; its TurnRecord therefore named no trace at all.
+   Retention reaches traces only through TurnRecord references — the orphan
+   case above shows an unnamed file is deleted — so the trace of every failed
+   turn was removed by the next prune, which is the only trace a failure
+   investigation has. The reference has to come from the sink, which holds one
+   run per keeper turn whichever way that turn ended. *)
+let test_failed_turn_keeps_its_trace_through_retention () =
+  with_workspace @@ fun config ->
+  let meta = make_test_meta () in
+  let sink =
+    sink_or_fail "keeper_raw_trace_sink"
+      (Keeper_agent_run.For_testing.keeper_raw_trace_sink ~config ~meta)
+  in
+  let path = Agent_core.Raw_trace.file_path sink in
+  let active =
+    ok_or_fail "start_run"
+      (Agent_core.Raw_trace.start_run sink ~agent_name:meta.name
+         ~prompt:"turn that fails" ())
+  in
+  let (_ref : Agent_core.Raw_trace.run_ref) =
+    ok_or_fail "finish_run"
+      (Agent_core.Raw_trace.finish_run active ~final_text:None
+         ~stop_reason:None
+         ~error:(Some "Antigravity turn timed out after 600.000s"))
+  in
+  (* [turn_trace_ref] is [None] for every failed turn: [run_result] exists
+     only on the success branch. *)
+  (match
+     Keeper_agent_run.For_testing.raw_trace_reference_for_turn
+       ~turn_trace_ref:None ~sink:(Some sink)
+   with
+  | None -> Alcotest.fail "a failed turn must name the run its sink closed"
+  | Some r ->
+      Alcotest.(check string) "reference names this turn's trace file" path
+        r.Agent_core.Raw_trace.path);
+  (* [write_turn_record] records "completed"; retention reads the reference
+     alone, so the finish reason does not change which files survive. *)
+  write_turn_record config ~meta ~turn:1 ~raw_trace_path:path;
+  let summary = prune_or_fail config in
+  Alcotest.(check int) "the failed turn's trace is not a deletion candidate" 0
+    summary.removed;
+  Alcotest.(check bool) "the failed turn's trace survives retention" true
+    (Sys.file_exists path)
+
+(* Without a sink the turn ran untraced and there is no run to name. A
+   reference invented here would point at a file that does not exist. *)
+let test_untraced_turn_names_no_reference () =
+  Alcotest.(check bool) "untraced turn yields no reference" true
+    (Option.is_none
+       (Keeper_agent_run.For_testing.raw_trace_reference_for_turn
+          ~turn_trace_ref:None ~sink:None))
+
 let read_file path =
   let ic = open_in path in
   Fun.protect
@@ -646,6 +702,10 @@ let () =
             test_post_commit_cleanup_prunes_orphan_and_preserves_reference;
           Alcotest.test_case "traced turn yields result-level fields" `Quick
             test_traced_turn_yields_result_level_fields;
+          Alcotest.test_case "failed turn keeps its trace through retention"
+            `Quick test_failed_turn_keeps_its_trace_through_retention;
+          Alcotest.test_case "untraced turn names no reference" `Quick
+            test_untraced_turn_names_no_reference;
           Alcotest.test_case "dispatch passes ?raw_trace" `Quick
             test_keeper_dispatch_passes_raw_trace;
         ] );


### PR DESCRIPTION
실패한 키퍼 턴의 raw trace 가 기록 직후 삭제됩니다. 오늘(2026-08-12) 하루에 **179 턴**이 그렇게 사라졌습니다.

## 관측

fleet 전체 turn-record 를 `raw_trace_run_ref` 유무로 갈라 세면:

| keeper | ref 있음 | ref 없음 | ref 없는 레코드의 finish_reason |
|---|---:|---:|---|
| analyst | 34 | 15 | 전부 `None` |
| code-reviewer | 25 | 10 | 전부 `None` |
| kidsnote | 52 | 1 | 전부 `None` |
| lane-smith | 54 | 1 | 전부 `None` |
| rondo | 53 | 1 | 전부 `None` |
| sangsu | 67 | 143 | 전부 `None` |
| taskmaster | 37 | 8 | 전부 `None` |
| **합계** | **322** | **179** | |

`finish_reason = None` 은 실패한 턴입니다. **179/179 가 실패 턴이고, 성공 322건은 예외 없이 ref 를 가집니다.**

디스크에서도 같은 결과가 나옵니다. taskmaster 의 13:40 이후 12 턴:

```
R 13:40:54->13:41:15 dur=  21s  receipt_done     T 13:41:15  turn-...000017.jsonl
R 13:46:19->13:47:01 dur=  42s  receipt_done     T 13:47:01  turn-...000025.jsonl
R 13:47:52->13:58:07 dur= 615s  FENCED           (트레이스 없음)
R 14:03:37->14:04:05 dur=  28s  receipt_done     T 14:04:05  turn-...000080.jsonl
R 14:08:47->14:09:23 dur=  36s  receipt_done     T 14:09:23  turn-...000099.jsonl
R 14:14:35->14:24:55 dur= 620s  FENCED           (트레이스 없음)
R 14:30:08->14:30:34 dur=  26s  receipt_done     T 14:30:34  turn-...000192.jsonl
   ... 이하 성공 5건, 트레이스 5건
```

성공 10 턴 → 트레이스 10 개. 10 분씩 걸린 실패 2 턴 → 0 개. 그 두 턴의 진단은

```
provider_attempt_effect_fenced
diagnostic: "Timeout: Antigravity turn timed out after 600.000s"
effect_disposition: observation_unavailable
```

이고, 무엇을 하다 600 초를 썼는지 확인할 자료가 남아 있지 않습니다.

## 원인

`Keeper_raw_trace_retention` 은 TurnRecord 를 도달성 루트로 쓰는 mark-and-sweep 입니다. `.mli` 가 가정을 명시합니다:

> The current TurnRecord window is the reachability root. ... an unreferenced file is **diagnostic garbage**, not an in-flight write.

**실패 턴에 대해 이 가정이 거짓입니다.** 실패 경로가 mark 를 하지 않기 때문입니다:

1. 실패한 턴도 자기 run 을 쓰고 닫습니다 — `Keeper_official_client_host.finish_raw_error` 가 `Raw_trace.finish_run ~error:(Some _)` 를 호출합니다. 파일은 디스크에 존재합니다.
2. 그런데 그 실패는 `Error` 로 올라가고, 참조를 읽을 `run_result` 가 없습니다. `keeper_agent_run.ml` 은 그래서 `| Ok { trace_ref = None; _ } | Error _ -> None` 으로 참조를 버렸습니다.
3. TurnRecord 가 아무 파일도 지목하지 않으므로, `prune` (`keeper_raw_trace_retention.ml:113-127`) 이 방금 쓴 그 파일을 `Sys.remove` 합니다.

`prune_raw_traces_after_turn_record` 는 매 턴 TurnRecord 커밋 직후에 돌므로, 삭제는 실패한 바로 그 턴에서 일어납니다.

즉 **성공한 턴의 트레이스는 전부 보존되고 실패한 턴의 트레이스만 전부 삭제됩니다.** 진단 가치와 정확히 반대 방향입니다.

## 수정

싱크에게 물어봅니다. 키퍼 싱크는 **턴당 파일 하나**라서 `Raw_trace.last_run` 은 이번 턴이 방금 닫은 run 일 수밖에 없고, 성공/실패 양쪽에서 같은 답을 줍니다 (`raw_trace.ml:703` 이 `finish_run` 안에서 갱신).

```ocaml
let raw_trace_reference_for_turn ~turn_trace_ref ~sink =
  match turn_trace_ref with
  | Some _ as reference -> reference
  | None -> Option.bind sink Agent_core.Raw_trace.last_run
;;
```

- 턴이 스스로 보고한 참조가 있으면 그쪽이 이깁니다 → **성공 경로 동작은 그대로**입니다.
- `start_run` 전에 실패한 턴은 `last_run` 이 `None` 이라 참조가 없고, 그 파일에는 run 이 없으므로 삭제가 맞습니다.
- 세션 신원 검증(`turn_record_raw_trace_run_ref`)은 기존과 동일하게 통과해야 기록됩니다.

`Agent_core.Raw_trace.last_run` 은 이미 있던 API 입니다. 새 타입도, 새 시그니처 전파도 없습니다.

## 남는 구멍

`finish_run` 에 도달하지 못한 취소(cancellation)는 여전히 참조가 없습니다. 공식 클라이언트 런타임들은 `Eio.Cancel.protect` 안에서 `finish_raw_error` 를 부르므로 대부분 덮이지만, 전부라고 주장하지 않습니다. 이 PR 은 그 경로를 다루지 않습니다.

## 검증

```
dune build --root . lib/keeper/                          → clean
dune build --root . @test/runtest-test_keeper_raw_trace_sink → 14/14 통과
```

새 케이스 2 개를 추가했습니다.

- `failed turn keeps its trace through retention` — `finish_run ~error:(Some _)` 로 실패 턴을 재현하고, 참조가 그 파일을 지목하는지, prune 이후에도 파일이 남는지 확인합니다.
- `untraced turn names no reference` — 싱크가 없을 때 참조를 만들어내지 않는지 확인합니다.

**대조군**: 수정 부분만 되돌려(`| None -> None`) 돌리면 `failed turn keeps its trace through retention` **한 건만** 실패하고 나머지 13 건은 통과합니다.

```
> [FAIL]  keeper raw-trace sink  11  failed turn keeps its trac...
ASSERT a failed turn must name the run its sink closed
1 failure! in 2.019s. 14 tests run.
```

## CI 배선

`test_keeper_raw_trace_sink` 는 지금까지 CI 에서 한 번도 실행되지 않았습니다 (`ci.yml`, `scripts/ci-run-focused-tests.sh` 양쪽에 0 건. `test_keeper_raw_trace_reader` 만 배선돼 있었습니다). 고쳐도 다음 회귀를 잡을 것이 없으므로 같은 PR 에서 배선합니다. 현재 14/14 초록이라 배선이 main 을 빨갛게 만들지 않습니다.

## 참고

이 브랜치의 로컬 테스트 실행에는 `lib/server/server_dashboard_official_client_probe.ml` 의 `Stopped_by_host _` 누락(main 의 기존 파손)을 임시로 우회해야 했습니다. 그 수정은 **이 PR 에 포함돼 있지 않습니다** — 별도로 처리 중입니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
