### PR TITLE
refactor(auth): resolve request policy at bootstrap

### DIFF
--- a/docs/rfc/RFC-0371-effect-boundary-restoration.md
+++ b/docs/rfc/RFC-0371-effect-boundary-restoration.md
@@ -77,17 +77,15 @@ else `Bad_gateway
 
 ### (b) 요청 경로의 env-as-bus
 
-`lib/server/server_auth.ml:563` — mutation 인가 게이트가 **요청마다** `MASC_ALLOW_ANONYMOUS_MUTATIONS` 를 재독. `lib/tool_workspace.ml:60` — 부팅 시 프로세스 자신이 `putenv` 로 써넣은 `MASC_INTERNAL_MCP_TOKEN`(auth_credential_base.ml:119)을 툴 호출마다 `getenv` 로 되읽는다. env 가 in-process mutable 채널이 됐다(쓰기 2곳, 읽기 3곳). `lib/keeper/keeper_tool_execute_runtime.ml:388` — 툴 실행마다 env 읽고 `<> Some "false"` permissive 파싱.
+`lib/tool_workspace.ml:60` — 부팅 시 프로세스 자신이 `putenv` 로 써넣은 `MASC_INTERNAL_MCP_TOKEN`(auth_credential_base.ml:119)을 툴 호출마다 `getenv` 로 되읽는다. env 가 in-process mutable 채널이 됐다. `lib/keeper/keeper_tool_execute_runtime.ml:388` — 툴 실행마다 env 읽고 `<> Some "false"` permissive 파싱.
 
 ### (c) 존재/meta 검증의 다층 반복
 
 `lib/keeper/keeper_turn.ml:439` — 직접 메시지 턴 1건에 keeper 존재 검증 4회(디스크 읽기 3회 + 레지스트리 1회). resolve 가 meta 를 버리고 이름만 반환하는 API shape 이 하류 재검증을 강제한다. `lib/keeper/keeper_tool_registered_runtime.ml:115` — `mint_token` + `guarded_dispatch` 를 이미 실행했는데 fallthrough 가 같은 디스패치를 다시 실행(pre-hook 2회, observer 2회, span 2-3회 — 텔레메트리 오염).
 
-### (d) 부분 타입이 강제하는 dead guard
+### (d) 생산자 0 dead guard
 
-`lib/keeper/keeper_board_attention_candidate.ml:1757` — `resumable_status` 가 Option 으로 정보를 버려서, 호출부가 같은 값을 재match 하며 1,600행 떨어진 불변식에 `assert false` 로 베팅한다. `lib/keeper/keeper_heartbeat_loop.ml:1205` — 3-생성자 `cycle_status` 를 bool 로 파생한 뒤 false 분기에서 재match(boolean blindness). 실사고 전례: keeper_registry.ml:721 sparse-match `Assert_failure`(2026-05-08), 닫힌 어휘 파스 실패 → keeper 정지 사슬(#27967, #28008).
-
-생산자 0 가드도 이 계열이다: `keeper_error_classify.ml:184` 의 `"empty completion (no thinking"` 은 저장소 전체에 생산자가 없고, 주석이 스스로 "no production producer" 를 자백한다. `server_dashboard_http_runtime_info.ml:709,719` 의 가드 2건도 생산자 0.
+`keeper_error_classify.ml:184` 의 `"empty completion (no thinking"` 은 저장소 전체에 생산자가 없고, 주석이 스스로 "no production producer" 를 자백한다. `server_dashboard_http_runtime_info.ml:709,719` 의 가드 2건도 생산자 0.
 
 ## 2. 원칙 (판정 기준)
 
@@ -95,7 +93,7 @@ else `Bad_gateway
 
 1. **Functional core / imperative shell** — env·FS·clock·예외 제어흐름을 그 값을 소유하는 경계 또는 orchestration 에 둔다. 판정 질문은 하나: *이 값이 무엇을 결정하고, 어느 계층이 그 결정을 소유하는가.* 파서/스토어/클라이언트 내부의 이펙트와 명시적으로 clock·cancel·resource lifecycle 을 소유하는 실행 계층은 그 모듈의 존재 이유이므로 위반이 아니다.
 2. **Parse, don't validate** — 경계에서 1회 파싱해 typed 값으로 내부 전달. validate-then-discard 금지.
-3. **Option/Result 의 정보를 버린 뒤 추측으로 복원하지 않는다** — 중간 계층 해소 자체를 금지하지 않는다. `failwith`/`Option.get`/wildcard fallback 으로 실패 의미를 없앤 뒤 bool·문구·재match 로 복원하는 경로가 대상이다.
+3. **Option/Result 의 정보를 버린 뒤 추측으로 복원하지 않는다** — 중간 계층 해소 자체를 금지하지 않는다. `failwith`/`Option.get`/wildcard fallback 으로 실패 의미를 없앤 뒤 bool·문구로 복원하는 경로가 대상이다.
 4. **In-process 계약은 typed** — 같은 프로세스 안에서 자기 타입을 렌더해 되읽는 채널 금지. 에러 메시지·env·description·브로드캐스트 본문은 제어 흐름 채널이 아니다.
 5. **존재/권위 검증은 소유 계층에서 1회** — 동시성 권위(레지스트리)가 최종 확인을 소유하고, resolve 결과는 typed handle 로 운반한다.
 
@@ -104,9 +102,9 @@ else `Bad_gateway
 아래 항목은 텍스트가 매치됐다는 이유만으로 reject 하지 않는다. 해당 PR이 새 implicit control channel 을 만들거나, 이미 보유한 typed 정보를 버린 뒤 문자열·환경·파일을 통해 재구성한다는 데이터 흐름 증거가 있을 때만 blocker 다. 외부 wire/프로세스 경계의 직렬화, 설정 로더의 env 읽기, store의 FS 접근, 명시적 오류 표시를 위한 문자열은 대상이 아니다.
 
 1. **typed→string→재파싱**: tool_input_validation:835, channel_gate:298/:323, proactive_refresh:36 → server_routes_http_runtime:311(`label=` 필드를 문자열에 박고 되꺼냄), failure_envelope:59-64(string→string→string 3단).
-2. **요청 경로에서 이미 주입된 값을 env 로 재조회**: server_auth:563, keeper_tool_execute_runtime:388, tool_workspace:60. 요청별 환경 정책을 명시적으로 소유하는 loader는 예외지만, `<> Some "false"` 같은 permissive 파싱으로 오타와 부재를 같은 값으로 합치는 경로는 허용하지 않는다.
-3. **결정 로직에서 owner API를 우회한 FS 접근·레이아웃 지식 이중화**: masc_grpc_service:246(생산자 0 필드 raw 프로브 — 이미 drift), :117 vs :365(.json 필터 불일치), mcp_server:342(writer 레이아웃 재구현). store/loader가 자기 레이아웃을 읽는 것은 대상이 아니다.
-4. **Option/Result 의미 붕괴 후 재추론**: keeper_board_attention_candidate:1757, keeper_heartbeat_loop:1205, dashboard_verification:160(Result→failwith 로 실패 브랜치가 타입에서 소멸). 경계에서 모든 분기를 명시적으로 처리하는 정상 해소는 대상이 아니다.
+2. **요청 경로에서 이미 주입된 값을 env 로 재조회**: keeper_tool_execute_runtime:388, tool_workspace:60. 요청별 환경 정책을 명시적으로 소유하는 loader는 예외지만, `<> Some "false"` 같은 permissive 파싱으로 오타와 부재를 같은 값으로 합치는 경로는 허용하지 않는다.
+3. **결정 로직에서 owner API를 우회한 FS 접근·레이아웃 지식 이중화**: mcp_server:342(writer 레이아웃 재구현). store/loader가 자기 레이아웃을 읽는 것은 대상이 아니다.
+4. **Option/Result 의미 붕괴 후 재추론**: dashboard_verification:160(Result→failwith 로 실패 브랜치가 타입에서 소멸). 경계에서 모든 분기를 명시적으로 처리하는 정상 해소는 대상이 아니다.
 5. **catch-all 의 Cancelled 삼킴**: otel_spans:107(Cancelled→false), keeper_compact_audit:232. 형제 6곳의 `Eio.Cancel.Cancelled _ as e -> raise e` 규율이 표준.
 6. **이름/prefix 관습 분류기**: tool_dispatch:107, tool_telemetry:39(주석이 스스로 탈출구를 인정), workspace_task_receipts:23(keeper↔agent 이름의 매직 오프셋 역파싱).
 7. **닫힌 세계에서 생산자 없는 가드**: keeper_error_classify:184, runtime_info 가드 2건, prompt_defaults:22, voice_runtime_overlay:168(then/else 동일 분기). 저장소 내부의 exhaustive typed producer만 입력한다는 증거와 회귀 테스트가 있을 때 삭제한다. 외부 입력·persisted data·version-skew가 도달 가능한 경로는 `rg` 0건만으로 dead라 판정하지 않는다. 미래 upstream 변화는 가능하면 typed variant와 exhaustive match로 잡고, 불가능한 wire 경계는 명시적 unknown/error 분기를 유지한다.

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -541,9 +541,6 @@ let sanitized_dashboard_actor_for_request ~base_path request =
       if String.equal sanitized "" then None else Some sanitized
   | None -> None
 
-let split_csv_nonempty raw =
-  raw |> String.split_on_char ',' |> List.filter_map String_util.trim_nonempty
-
 type browser_origin_admission =
   | Same_origin
   | Allowed_dev_origin
@@ -558,42 +555,32 @@ type request_origin_admission =
   | Multiple_origins
   | Malformed_origin
 
-(* Boot-time snapshots (RFC-0371 B11). The previous spelling re-read both
-   env vars on every request "so they can be toggled without restarting" —
-   a toggle nothing performs: no setter exists in the repository, shell
-   config, deploy scripts, or the live server's process environment
-   (verified 2026-08-12, #28221). An authorization input read from ambient
-   env per request is a mutable channel into the auth gate; live policy
-   changes belong to the operator control plane, not putenv. *)
-let allow_anonymous_mutations_snapshot =
-  lazy
-    (match Sys.getenv_opt "MASC_ALLOW_ANONYMOUS_MUTATIONS" with
-     | Some ("1" | "true") -> true
-     | _ -> false)
+type configure_error = Already_configured
 
-let allow_anonymous_mutations () = Lazy.force allow_anonymous_mutations_snapshot
+type resolved_config_state =
+  | Unconfigured
+  | Configured of Server_auth_config.t
 
-let default_loopback_dev_mutation_origins =
-  Masc_network_defaults.vite_dev_default_origins
+let resolved_config = Atomic.make Unconfigured
 
-let loopback_dev_mutation_origins_snapshot =
-  lazy
-    (match Sys.getenv_opt "MASC_HTTP_DEV_MUTATION_ORIGINS" with
-     | Some raw -> split_csv_nonempty raw
-     | None -> default_loopback_dev_mutation_origins)
+let configure config =
+  let current = Atomic.get resolved_config in
+  match current with
+  | Configured _ -> Error Already_configured
+  | Unconfigured ->
+    if Atomic.compare_and_set resolved_config current (Configured config)
+    then Ok ()
+    else Error Already_configured
+;;
 
-let configured_loopback_dev_mutation_origins () =
-  Lazy.force loopback_dev_mutation_origins_snapshot
+let configure_error_to_string = function
+  | Already_configured -> "HTTP authorization policy is already configured"
+;;
 
-let parse_configured_dev_origins () =
-  let rec parse_all parsed = function
-    | [] -> Ok (List.rev parsed)
-    | raw :: rest ->
-      (match Server_request_authority.parse_serialized_origin raw with
-       | Ok origin -> parse_all (origin :: parsed) rest
-       | Error `Malformed -> Error raw)
-  in
-  parse_all [] (configured_loopback_dev_mutation_origins ())
+let current_resolved_config () =
+  match Atomic.get resolved_config with
+  | Configured config -> config
+  | Unconfigured -> Server_auth_config.fail_closed
 ;;
 
 let allowlisted_dev_origin_matches_request ~request_authority origin =
@@ -602,16 +589,8 @@ let allowlisted_dev_origin_matches_request ~request_authority origin =
   if not (is_loopback_host request_host && is_loopback_host origin_host)
   then false
   else
-    match parse_configured_dev_origins () with
-    | Ok configured ->
-      List.exists
-        (Server_request_authority.serialized_origin_equal origin)
-        configured
-    | Error malformed ->
-      Log.Auth.warn
-        "rejecting dev Origin because MASC_HTTP_DEV_MUTATION_ORIGINS contains a malformed serialized origin: %S"
-        malformed;
-      false
+    Server_auth_config.loopback_dev_mutation_origins (current_resolved_config ())
+    |> List.exists (Server_request_authority.serialized_origin_equal origin)
 ;;
 
 let admission_of_serialized_origin ~request_authority origin =
@@ -708,7 +687,9 @@ let ensure_same_origin_browser_request ~request_authority request :
        when referer_matches_request_authority ~request_authority referer ->
        Ok ()
      | [] | [ _ ] | _ :: _ :: _ ->
-       if allow_anonymous_mutations () then Ok ()
+       if
+         Server_auth_config.allow_anonymous_mutations (current_resolved_config ())
+       then Ok ()
        else
          Error (Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized
            { reason = Missing_token
@@ -1263,4 +1244,15 @@ module For_testing = struct
   let admin_token_equal = admin_token_equal
   let snapshot_server_state = current_server_state
   let restore_server_state state = Atomic.set server_state state
+
+  let snapshot_auth_config () =
+    match Atomic.get resolved_config with
+    | Unconfigured -> None
+    | Configured config -> Some config
+  ;;
+
+  let restore_auth_config = function
+    | None -> Atomic.set resolved_config Unconfigured
+    | Some config -> Atomic.set resolved_config (Configured config)
+  ;;
 end

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -21,9 +21,6 @@ val strip_suffix : suffix:string -> string -> string
 
 (** [Some trimmed] when non-empty, else [None]. *)
 
-val split_csv_nonempty : string -> string list
-(** Comma-separated split with empty entries dropped. *)
-
 (** {1 Bind host / loopback classification} *)
 
 val configured_bind_host : unit -> string
@@ -180,9 +177,14 @@ val sanitized_dashboard_actor_for_request :
 
 (** {1 Origin / CORS} *)
 
-val allow_anonymous_mutations : unit -> bool
-(** Re-reads [MASC_ALLOW_ANONYMOUS_MUTATIONS] on each call.
-    When [true] non-loopback mutations skip auth (test fixtures only). *)
+type configure_error = Already_configured
+
+val configure : Server_auth_config.t -> (unit, configure_error) result
+(** Install the boot-resolved authorization policy before request handlers are
+    constructed. The policy is single-assignment for the process lifetime;
+    request handlers cannot turn it into a runtime control channel. *)
+
+val configure_error_to_string : configure_error -> string
 
 type browser_origin_admission =
   | Same_origin
@@ -456,4 +458,6 @@ module For_testing : sig
   val admin_token_equal : string -> string -> bool
   val snapshot_server_state : unit -> Mcp_server.server_state option
   val restore_server_state : Mcp_server.server_state option -> unit
+  val snapshot_auth_config : unit -> Server_auth_config.t option
+  val restore_auth_config : Server_auth_config.t option -> unit
 end

--- a/lib/server/server_auth_config.ml
+++ b/lib/server/server_auth_config.ml
@@ -1,0 +1,91 @@
+let allow_anonymous_mutations_env = "MASC_ALLOW_ANONYMOUS_MUTATIONS"
+let loopback_dev_mutation_origins_env = "MASC_HTTP_DEV_MUTATION_ORIGINS"
+
+type raw =
+  { allow_anonymous_mutations : string option
+  ; loopback_dev_mutation_origins : string option
+  }
+
+type resolve_error =
+  | Malformed_boolean of
+      { name : string
+      ; raw : string
+      }
+  | Malformed_origin of
+      { name : string
+      ; raw : string
+      }
+
+type t =
+  { allow_anonymous_mutations : bool
+  ; loopback_dev_mutation_origins : Server_request_authority.serialized_origin list
+  }
+
+let read_env () =
+  { allow_anonymous_mutations =
+      Env_config_core.raw_value_opt allow_anonymous_mutations_env
+  ; loopback_dev_mutation_origins =
+      Env_config_core.raw_value_opt loopback_dev_mutation_origins_env
+  }
+;;
+
+let parse_boolean ~name = function
+  | None -> Ok false
+  | Some raw ->
+    (match String.trim raw |> String.lowercase_ascii with
+     | "1" | "true" | "yes" | "on" -> Ok true
+     | "0" | "false" | "no" | "off" -> Ok false
+     | _ -> Error (Malformed_boolean { name; raw }))
+;;
+
+let split_csv_nonempty raw =
+  raw |> String.split_on_char ',' |> List.filter_map String_util.trim_nonempty
+;;
+
+let parse_origins values =
+  let rec loop parsed = function
+    | [] -> Ok (List.rev parsed)
+    | raw :: rest ->
+      (match Server_request_authority.parse_serialized_origin raw with
+       | Ok origin -> loop (origin :: parsed) rest
+       | Error `Malformed ->
+         Error (Malformed_origin { name = loopback_dev_mutation_origins_env; raw }))
+  in
+  loop [] values
+;;
+
+let resolve raw =
+  let open Result.Syntax in
+  let* allow_anonymous_mutations =
+    parse_boolean
+      ~name:allow_anonymous_mutations_env
+      raw.allow_anonymous_mutations
+  in
+  let origin_values =
+    match raw.loopback_dev_mutation_origins with
+    | Some configured -> split_csv_nonempty configured
+    | None -> Masc_network_defaults.vite_dev_default_origins
+  in
+  let+ loopback_dev_mutation_origins = parse_origins origin_values in
+  { allow_anonymous_mutations; loopback_dev_mutation_origins }
+;;
+
+let fail_closed =
+  { allow_anonymous_mutations = false; loopback_dev_mutation_origins = [] }
+;;
+
+let allow_anonymous_mutations config = config.allow_anonymous_mutations
+let loopback_dev_mutation_origins config = config.loopback_dev_mutation_origins
+
+let resolve_error_to_string = function
+  | Malformed_boolean { name; raw } ->
+    Printf.sprintf
+      "malformed env %s=%S (expected true/false boolean)"
+      name
+      raw
+  | Malformed_origin { name; raw } ->
+    Printf.sprintf
+      "malformed env %s entry %S (expected serialized HTTP(S) origin)"
+      name
+      raw
+;;

--- a/lib/server/server_auth_config.mli
+++ b/lib/server/server_auth_config.mli
@@ -1,0 +1,37 @@
+(** Boot-resolved HTTP authorization policy.
+
+    Environment reads belong to the server composition root. Request handlers
+    receive this closed, parsed policy through {!Server_auth.configure} and do
+    not re-read or re-parse ambient process state. *)
+
+type raw =
+  { allow_anonymous_mutations : string option
+  ; loopback_dev_mutation_origins : string option
+  }
+
+type resolve_error =
+  | Malformed_boolean of
+      { name : string
+      ; raw : string
+      }
+  | Malformed_origin of
+      { name : string
+      ; raw : string
+      }
+
+type t
+
+val read_env : unit -> raw
+(** Read the two HTTP authorization environment inputs once. *)
+
+val resolve : raw -> (t, resolve_error) result
+(** Parse the complete policy. Missing values use the current defaults;
+    present malformed values are errors rather than implicit defaults. *)
+
+val fail_closed : t
+(** Policy used before the composition root installs configuration: anonymous
+    mutations are denied and no development origin is allowlisted. *)
+
+val allow_anonymous_mutations : t -> bool
+val loopback_dev_mutation_origins : t -> Server_request_authority.serialized_origin list
+val resolve_error_to_string : resolve_error -> string

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1275,6 +1275,20 @@ let activate_owner_state
 
 let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_request_handler
     ~make_h2_request_handler ~make_h2_error_handler () =
+  let resolved_auth_config =
+    match Server_auth_config.resolve (Server_auth_config.read_env ()) with
+    | Ok config -> config
+    | Error error ->
+      raise
+        (Env_config_core.Config_error
+           (Server_auth_config.resolve_error_to_string error))
+  in
+  (match Server_auth.configure resolved_auth_config with
+   | Ok () -> ()
+   | Error error ->
+     raise
+       (Env_config_core.Config_error
+          (Server_auth.configure_error_to_string error)));
   let clock, mono_clock, net, domain_mgr, proc_mgr, fs =
     init_runtime_context env
   in

--- a/test/test_server_request_authority.ml
+++ b/test/test_server_request_authority.ml
@@ -2,6 +2,24 @@ open Alcotest
 
 module Authority = Server_request_authority
 
+let resolve_auth_config raw =
+  match Server_auth_config.resolve raw with
+  | Ok config -> config
+  | Error error -> fail (Server_auth_config.resolve_error_to_string error)
+;;
+
+let default_auth_config =
+  resolve_auth_config
+    Server_auth_config.
+      { allow_anonymous_mutations = None; loopback_dev_mutation_origins = None }
+;;
+
+let () =
+  match Server_auth.configure default_auth_config with
+  | Ok () -> ()
+  | Error error -> fail (Server_auth.configure_error_to_string error)
+;;
+
 let trust_policy ?(bind_host = "127.0.0.1") ?(bind_port = 8935)
     ?explicit_base_url () =
   match
@@ -52,6 +70,52 @@ let check_classification expected actual =
   | `Single, Authority.Single _ ->
     ()
   | _ -> fail "unexpected request-authority classification"
+;;
+
+let test_auth_config_rejects_malformed_values () =
+  (match
+     Server_auth_config.resolve
+       { allow_anonymous_mutations = Some "sometimes"
+       ; loopback_dev_mutation_origins = None
+       }
+   with
+   | Error
+       (Server_auth_config.Malformed_boolean
+          { name = "MASC_ALLOW_ANONYMOUS_MUTATIONS"; raw = "sometimes" }) ->
+     ()
+   | Error _ | Ok _ -> fail "malformed anonymous-mutation flag was not rejected");
+  match
+    Server_auth_config.resolve
+      { allow_anonymous_mutations = None
+      ; loopback_dev_mutation_origins = Some "http://localhost:4173/path"
+      }
+  with
+  | Error
+      (Server_auth_config.Malformed_origin
+         { name = "MASC_HTTP_DEV_MUTATION_ORIGINS"
+         ; raw = "http://localhost:4173/path"
+         }) ->
+    ()
+  | Error _ | Ok _ -> fail "malformed development Origin was not rejected"
+;;
+
+let test_auth_config_resolves_typed_policy () =
+  let config =
+    resolve_auth_config
+      { allow_anonymous_mutations = Some "on"
+      ; loopback_dev_mutation_origins = Some ""
+      }
+  in
+  check
+    bool
+    "anonymous mutations"
+    true
+    (Server_auth_config.allow_anonymous_mutations config);
+  check
+    int
+    "explicit empty development allowlist"
+    0
+    (List.length (Server_auth_config.loopback_dev_mutation_origins config))
 ;;
 
 let test_http1_closed_classification () =
@@ -367,6 +431,34 @@ let check_origin_admission label expected request_authority headers =
     failf "%s did not produce one parsed Origin" label
 ;;
 
+let test_auth_config_is_resolved_once_before_origin_admission () =
+  let configured =
+    resolve_auth_config
+      { allow_anonymous_mutations = None
+      ; loopback_dev_mutation_origins = Some "http://localhost:4173"
+      }
+  in
+  (match Server_auth.configure configured with
+   | Error Server_auth.Already_configured -> ()
+   | Ok () -> fail "authorization policy accepted a second production install");
+  Fun.protect
+    ~finally:(fun () ->
+      Server_auth.For_testing.restore_auth_config (Some default_auth_config))
+    (fun () ->
+      Server_auth.For_testing.restore_auth_config (Some configured);
+      let request_authority = admitted_http1 [ "host", "localhost:8935" ] in
+      check_origin_admission
+        "configured development Origin"
+        Server_auth.Allowed_dev_origin
+        request_authority
+        [ "origin", "http://localhost:4173" ];
+      check_origin_admission
+        "unconfigured default Origin"
+        Server_auth.Rejected
+        request_authority
+        [ "origin", "http://localhost:5173" ])
+;;
+
 let test_origin_exact_grammar_and_cardinality () =
   let request_authority = admitted_http1 [ "host", "localhost:8935" ] in
   check_origin_admission
@@ -608,7 +700,21 @@ let test_fiber_binding_has_no_fallback () =
 let () =
   run
     "server-request-authority"
-    [ ( "HTTP/1.1"
+    [ ( "auth config"
+      , [ test_case
+            "malformed values are rejected"
+            `Quick
+            test_auth_config_rejects_malformed_values
+        ; test_case
+            "policy is typed"
+            `Quick
+            test_auth_config_resolves_typed_policy
+        ; test_case
+            "policy is resolved before admission"
+            `Quick
+            test_auth_config_is_resolved_once_before_origin_admission
+        ] )
+    ; ( "HTTP/1.1"
       , [ test_case "closed classification" `Quick test_http1_closed_classification
         ; test_case "normalization" `Quick test_http1_normalizes_authority
         ; test_case


### PR DESCRIPTION
## Summary

- add a closed `Raw -> Resolved` contract for HTTP authorization environment inputs
- parse anonymous-mutation policy and development Origins once at the server composition root
- make production policy installation single-assignment and fail closed before installation
- remove module-load lazy env snapshots, request-path Origin parsing, and dead public helpers
- reject malformed security configuration during bootstrap and refresh RFC-0371 to list only live debt

## Verification

- `ocamlformat --check` on all touched OCaml files
- `ocamlc -stop-after parsing` on all touched OCaml files
- `git diff --check`
- static zero-match check for env reads, `Lazy.force`, and old snapshot/parser symbols in `server_auth.ml`

Local Dune build/tests were intentionally not run; GitHub CI is the build authority for this slice.