### PR TITLE
fix(keeper): let R2 reach reasoning that sits beside a tool_use (-55.4% → -73.8%)

### DIFF
--- a/lib/keeper/keeper_checkpoint_purge.ml
+++ b/lib/keeper/keeper_checkpoint_purge.ml
@@ -57,16 +57,26 @@ let is_text_only (message : Agent_core.Types.message) =
        message.content
 ;;
 
-let has_tool_use (message : Agent_core.Types.message) =
-  List.exists
-    (function
-      | Agent_core.Types.ToolUse _ -> true
-      | _ -> false)
-    message.content
+let is_assistant (message : Agent_core.Types.message) =
+  match message.role with
+  | Agent_core.Types.Assistant -> true
+  | Agent_core.Types.User | Agent_core.Types.System | Agent_core.Types.Tool -> false
 ;;
 
 (* R2: remove unsigned reasoning blocks. Signed thinking and
-   [RedactedThinking] replay byte-exact on tool turns and are kept. *)
+   [RedactedThinking] replay byte-exact on tool turns and are kept — that
+   distinction lives in the match below, which is the whole safety argument.
+
+   R2 originally also skipped any assistant message carrying a ToolUse
+   (#25537). That outer guard had no rationale of its own: the commit message
+   justified it with "providers replay [signed thinking] byte-exact", which the
+   [signature = None] pattern already enforces per block. On an agentic keeper
+   the guard swallows nearly everything — measured on the sangsu checkpoint
+   after a full purge, 418 of 422 surviving unsigned Thinking blocks (490,370 B,
+   41.0% of the 1,196,574 B file) sat in messages that also carried a ToolUse.
+   Unsigned thinking additionally cannot be replayed to Anthropic in that
+   position at all: extended-thinking replay requires the signature, so these
+   blocks originate from non-Anthropic runtimes and are inert bulk on the wire. *)
 let strip_reasoning_blocks (message : Agent_core.Types.message) =
   let kept, stripped =
     List.fold_left
@@ -215,13 +225,7 @@ let purge_messages ~config messages =
         else (
           match item.unit_ with
           | Keeper_compaction_unit.Ordinary_message message ->
-            if config.strip_thinking
-               && (match message.role with
-                   | Agent_core.Types.Assistant -> true
-                   | Agent_core.Types.User
-                   | Agent_core.Types.System
-                   | Agent_core.Types.Tool -> false)
-               && not (has_tool_use message)
+            if config.strip_thinking && is_assistant message
             then (
               let stripped_message, stripped = strip_reasoning_blocks message in
               reasoning_blocks_stripped := !reasoning_blocks_stripped + stripped;
@@ -245,6 +249,33 @@ let purge_messages ~config messages =
                      in
                      tool_results_cleared := !tool_results_cleared + cleared;
                      cleared_message)
+                  cycle_messages
+              else cycle_messages
+            in
+            (* R2 inside the cycle. The assistant message that OPENS a tool
+               cycle is grouped here, never in [Ordinary_message], so before
+               this branch existed R2 could not reach it at all — the single
+               largest reason unsigned reasoning survived a full purge.
+               A cycle message is never dropped even if stripping empties it:
+               that would break the ToolUse/ToolResult pairing the cycle is
+               indivisible for, and [Keeper_compaction_unit.validate] would
+               reject the output. In practice the opening message always keeps
+               its ToolUse block, so the empty case is defensive only. *)
+            let cycle_messages =
+              if config.strip_thinking
+              then
+                List.map
+                  (fun message ->
+                     if not (is_assistant message)
+                     then message
+                     else (
+                       let stripped, count = strip_reasoning_blocks message in
+                       match stripped.Agent_core.Types.content with
+                       | [] -> message
+                       | _ :: _ ->
+                         reasoning_blocks_stripped
+                         := !reasoning_blocks_stripped + count;
+                         stripped))
                   cycle_messages
               else cycle_messages
             in

--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -78,8 +78,11 @@ let codex_failure_status = function
   | Timeout _ -> "timeout"
   | Protocol_error _ | Rpc_error _ | Unsupported_server_request _ ->
     "protocol_error"
-  | Context_window_exceeded _ | Turn_failed _ | Turn_interrupted ->
-    "probe_contract_error"
+  | Context_window_exceeded _ | Turn_failed _ | Turn_interrupted
+  (* A host stop ends the probe turn without a provider verdict, so it says
+     nothing about login or transport — same bucket as the other
+     turn-did-not-complete outcomes. *)
+  | Stopped_by_host _ -> "probe_contract_error"
 ;;
 
 let claude_failure_status = function
@@ -91,8 +94,10 @@ let claude_failure_status = function
   | Turn_transport_interrupted _
   | Context_window_exceeded _
   | Turn_failed _
-  | Quota_blocked _ ->
-    "probe_contract_error"
+  | Quota_blocked _
+  (* See [codex_failure_status]: a host stop is a turn outcome, not a
+     connectivity or auth signal. *)
+  | Stopped_by_host _ -> "probe_contract_error"
 ;;
 
 let probe_codex ~mgr ~clock ~process_cwd ~runtime_id ~model

--- a/test/test_keeper_checkpoint_purge.ml
+++ b/test/test_keeper_checkpoint_purge.ml
@@ -127,17 +127,66 @@ let test_reasoning_strip_scope () =
     [ "answer"; "<thinking>|signed" ]
     (message_texts purged)
 
-let test_reasoning_inside_tool_cycle_is_kept () =
+(* Contract change: R2 used to skip any message carrying a ToolUse, so the
+   assistant message that opens a tool cycle kept its unsigned reasoning. On an
+   agentic keeper that is almost every assistant message — measured on the
+   sangsu checkpoint, 418 of 422 surviving unsigned Thinking blocks (490,370 B,
+   41.0% of the file) were held by this rule. Unsigned reasoning carries no
+   signature to replay, so the exemption bought nothing. *)
+let test_unsigned_reasoning_inside_tool_cycle_is_stripped () =
   let messages =
     [ block_message Types.Assistant [ unsigned_thinking "pre-tool"; tool_use "a" ]
     ; { (block_message Types.Tool [ tool_result "a" ]) with tool_call_id = Some "a" }
     ]
   in
-  let _purged, report = run messages in
+  let purged, report = run messages in
   Alcotest.(check int)
-    "a tool-use message keeps its reasoning"
+    "unsigned reasoning is stripped even beside a tool_use"
+    1
+    report.reasoning_blocks_stripped;
+  Alcotest.(check int) "no cycle message dropped" 2 (List.length purged);
+  (match List.hd purged with
+   | { Types.content = [ Types.ToolUse { id; _ } ]; _ } ->
+     Alcotest.(check string) "the tool_use itself survives" "a" id
+   | other ->
+     Alcotest.failf
+       "expected a lone surviving ToolUse, got %s"
+       (Types.show_message other))
+
+(* The safety line the old guard was reaching for, pinned where it belongs:
+   per block, by signature — not per message, by "has a tool_use". *)
+let test_signed_reasoning_inside_tool_cycle_is_kept () =
+  let messages =
+    [ block_message Types.Assistant [ signed_thinking "pre-tool"; tool_use "a" ]
+    ; { (block_message Types.Tool [ tool_result "a" ]) with tool_call_id = Some "a" }
+    ]
+  in
+  let purged, report = run messages in
+  Alcotest.(check int)
+    "signed reasoning beside a tool_use is untouched"
     0
-    report.reasoning_blocks_stripped
+    report.reasoning_blocks_stripped;
+  Alcotest.(check int) "no cycle message dropped" 2 (List.length purged);
+  match List.hd purged with
+  | { Types.content = [ Types.Thinking { signature = Some _; _ }; Types.ToolUse _ ]; _ } ->
+    ()
+  | other ->
+    Alcotest.failf
+      "signed thinking must replay byte-exact, got %s"
+      (Types.show_message other)
+
+(* A cycle message is never dropped, even when stripping would empty it:
+   dropping it would orphan the paired ToolResult and fail structural
+   validation. *)
+let test_thinking_only_cycle_message_is_not_dropped () =
+  let messages =
+    [ block_message Types.Assistant [ unsigned_thinking "only-thinking"; tool_use "a" ]
+    ; { (block_message Types.Tool [ tool_result "a" ]) with tool_call_id = Some "a" }
+    ; text_message Types.User "after"
+    ]
+  in
+  let purged, _report = run messages in
+  Alcotest.(check int) "pairing intact" 3 (List.length purged)
 
 let test_tool_result_clear_preserves_pairing () =
   let messages = cycle "a" @ [ text_message Types.User "after" ] in
@@ -347,9 +396,17 @@ let () =
             test_duplicate_tool_cycles_are_never_collapsed
         ; Alcotest.test_case "reasoning strip scope" `Quick test_reasoning_strip_scope
         ; Alcotest.test_case
-            "reasoning inside a tool cycle is kept"
+            "unsigned reasoning inside a tool cycle is stripped"
             `Quick
-            test_reasoning_inside_tool_cycle_is_kept
+            test_unsigned_reasoning_inside_tool_cycle_is_stripped
+        ; Alcotest.test_case
+            "signed reasoning inside a tool cycle is kept"
+            `Quick
+            test_signed_reasoning_inside_tool_cycle_is_kept
+        ; Alcotest.test_case
+            "a thinking-only cycle message is not dropped"
+            `Quick
+            test_thinking_only_cycle_message_is_not_dropped
         ; Alcotest.test_case
             "tool result clear preserves pairing"
             `Quick


### PR DESCRIPTION
## 무엇이 문제였나

RFC-0351 S1 의 R2(unsigned reasoning strip)가 **tool_use 를 가진 assistant 메시지를 통째로 건너뛰고** 있었다. 게다가 tool cycle 을 여는 assistant 메시지는 `Closed_tool_cycle` 로 묶여 `Ordinary_message` 분기에 아예 도달하지 않으므로, 그 경로에서는 R2 가 **한 번도 호출되지 않았다**.

에이전틱 keeper 에서는 거의 모든 assistant 메시지가 도구를 부른다. 결과적으로 R2 는 사실상 아무것도 못 걷어냈다.

## 실측 (live sangsu checkpoint, 전체 purge 적용 후)

| | 값 |
|---|---|
| 살아남은 unsigned Thinking 블록 | 422 |
| 그중 tool_use 면제로 살아남은 것 | **418 (490,370 B)** |
| purge 결과 파일(1,196,574 B) 대비 | **41.0%** |
| 그중 signed 블록 | **0** |

signed 가 0 인 이유: 이 블록들은 deepseek/glm 같은 비-Anthropic 런타임이 서명 없이 돌려준 reasoning 이다.

## 왜 면제가 불필요한가

#25537 이 든 근거는 "providers replay [signed thinking] byte-exact" 하나뿐인데, 그 보장은 이미 `strip_reasoning_blocks` 안의 `Thinking { signature = None }` 패턴이 **블록 단위로** 강제한다. 바깥 게이트는 같은 목적을 **메시지 단위**로 다시 걸면서 서명 있는 것과 없는 것을 함께 살렸다.

추가로 unsigned reasoning 은 애초에 그 자리에서 Anthropic 으로 재생될 수 없다 — extended-thinking 재생은 서명을 요구한다.

## 변경

- `Ordinary_message`: `not (has_tool_use message)` 제거. assistant 역할 가드는 유지(`is_assistant` 로 추출).
- `Closed_tool_cycle`: cycle 내 assistant 메시지에 R2 적용. **stripping 이 메시지를 비워도 절대 드롭하지 않는다** — 짝지어진 ToolResult 가 고아가 되어 `Keeper_compaction_unit.validate` 가 출력을 거부한다.

## A/B (동일 checkpoint, 동일 CLI, 규칙만 변경)

```
before   R2 stripped  68    2,673,724 -> 1,192,540   (-55.4%)
after    R2 stripped 481    2,673,724 ->   699,290   (-73.8%)
```

추가 절감 493,250 B (-41.4%p). 메시지 수는 990 으로 양쪽 동일 — 드롭이 아니라 블록 제거다.

## 테스트

옛 동작을 고정하던 `test_reasoning_inside_tool_cycle_is_kept` 를 폐기하고 새 계약과 그 경계를 고정하는 3 개로 교체:

- `unsigned reasoning inside a tool cycle is stripped` — tool_use 는 살아남는지까지 확인
- `signed reasoning inside a tool cycle is kept` — 옛 게이트가 노렸던 안전선을 **블록·서명 단위**로 다시 고정
- `a thinking-only cycle message is not dropped` — pairing 보존

기존 불변식(멱등성, protected tail byte-exact, 구조 검증 거부)은 그대로. **16/16 통과.**

## 함께 들어간 커밋: main 빌드 복구

`cba35ea` — `runtime_claude_code` / `runtime_codex_app_server` 에 `Stopped_by_host` 가 추가됐는데 `server_dashboard_official_client_probe` 가 안 따라와 **dev 프로파일에서 origin/main(40f05fce29) 이 빌드되지 않는다**:

```
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
  Here is an example of a case that is not matched: Stopped_by_host _
```

clean 체크아웃 두 곳(main worktree + 신규 worktree)에서 재현했으므로 로컬 상태가 아니다. release 프로파일은 warn-error 가 없어 가려진다. 이 커밋 없이는 어떤 테스트도 로컬에서 못 돌리므로 함께 넣었고, 분리를 원하면 첫 커밋만 떼면 된다.

host stop 은 provider 판정 없이 턴이 끝난 것이므로 로그인/전송 오류가 아니라 다른 "턴 미완료" 결과들과 같은 `probe_contract_error` 로 분류했다.

RFC-0351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
