### PR TITLE
fix(keeper): close official-client host-stop review gaps

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -593,7 +593,11 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
       try
         match run_client () with
         | Error error -> Error error
-        | Ok (`Stopped stop) -> settle_host_stop stop
+        | Ok (`Stopped stop) ->
+          recovery_failure := Session_store.Host_hook_failed;
+          (match !terminal_error with
+           | Some detail -> Error (internal_error detail)
+           | None -> settle_host_stop stop)
         | Ok (`Completed turn) ->
           recovery_failure := Session_store.Protocol_failed;
           let turn_id =

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -13,6 +13,10 @@ type attempt_outcome =
 
 let runtime_label = "Claude Code"
 
+let host_stop_turn_identity ~session_id ~turn_count =
+  Printf.sprintf "%s:host-stop:%d" session_id turn_count
+;;
+
 let bounded_probe_config ~fallback_timeout_s
   (config : Runtime_claude_code.config)
   =
@@ -23,6 +27,7 @@ let bounded_probe_config ~fallback_timeout_s
 
 module For_testing = struct
   let bounded_probe_config = bounded_probe_config
+  let host_stop_turn_identity = host_stop_turn_identity
 end
 
 let project_messages messages =
@@ -547,7 +552,28 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     let started_at = Time_compat.now () in
     let settle_host_stop stop =
       match (!session_state).Session_store.phase with
-      | Turn_inflight { session_id; turn_id = Some turn_id; _ } ->
+      | Turn_inflight { session_id; turn_id; _ } ->
+        let turn_id =
+          Option.value
+            turn_id
+            ~default:(host_stop_turn_identity ~session_id ~turn_count)
+        in
+        let* () =
+          match turn_id, (!session_state).phase with
+          | turn_id, Turn_inflight { turn_id = None; _ } ->
+            update_session "host-stop turn identity transition" (fun expected ->
+              Session_store.mark_turn_started
+                ~base_path
+                ~keeper_name
+                ~expected
+                ~session_id
+                ~turn_id
+                ~turn_count
+                ~updated_at:(Time_compat.now ()))
+            |> Result.map_error internal_error
+          | _, Turn_inflight { turn_id = Some _; _ } -> Ok ()
+          | _, _ -> assert false
+        in
         recovery_failure := Session_store.State_persistence_failed;
         (match
            Session_store.settle
@@ -571,8 +597,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                 ~turn_id
                 ~turns_used:turn_count
                 stop))
-      | Ready | Start _ | Active _ | Turn_inflight { turn_id = None; _ }
-      | Recovery_required _ | Settled _ ->
+      | Ready | Start _ | Active _ | Recovery_required _ | Settled _ ->
         Error
           (internal_error
              "Claude Code host stop arrived without an acknowledged provider turn")
@@ -625,7 +650,10 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         in
         (match client_result with
          | Error (Runtime_claude_code.Stopped_by_host stop) ->
-           settle_host_stop stop
+           recovery_failure := Session_store.Host_hook_failed;
+           (match !terminal_error with
+            | Some detail -> Error (internal_error detail)
+            | None -> settle_host_stop stop)
          | Error error ->
            context_overflow_retry_safe :=
              (match error with

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -16,6 +16,10 @@ module For_testing : sig
     -> Runtime_claude_code.config
   (** Keep an explicit turn bound unchanged and give an unbounded turn config a
       finite login-probe fallback. *)
+
+  val host_stop_turn_identity : session_id:string -> turn_count:int -> string
+  (** Deterministic durable identity used when a dynamic-tool host stop arrives
+      before Claude emits its terminal result-frame turn id. *)
 end
 
 val run :

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -691,7 +691,10 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
          ~prompt
      with
      | Error (Runtime_codex_app_server.Stopped_by_host stop) ->
-       settle_host_stop stop
+       recovery_failure := Keeper_official_client_session_store.Host_hook_failed;
+       (match !terminal_error with
+        | Some detail -> Error (internal_error detail)
+        | None -> settle_host_stop stop)
      | Error error ->
        recovery_failure := recovery_failure_of_client_error error;
        Error (codex_error_to_core_error error)

--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -78,7 +78,8 @@ let codex_failure_status = function
   | Timeout _ -> "timeout"
   | Protocol_error _ | Rpc_error _ | Unsupported_server_request _ ->
     "protocol_error"
-  | Context_window_exceeded _ | Turn_failed _ | Turn_interrupted ->
+  | Context_window_exceeded _ | Turn_failed _ | Turn_interrupted
+  | Stopped_by_host _ ->
     "probe_contract_error"
 ;;
 
@@ -91,7 +92,8 @@ let claude_failure_status = function
   | Turn_transport_interrupted _
   | Context_window_exceeded _
   | Turn_failed _
-  | Quota_blocked _ ->
+  | Quota_blocked _
+  | Stopped_by_host _ ->
     "probe_contract_error"
 ;;
 

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -47,9 +47,14 @@ let mcp_list =
   {|{"type":"control_request","request_id":"mcp-list-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}}}|}
 ;;
 
-let mcp_call =
-  {|{"type":"control_request","request_id":"mcp-call-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"masc_probe","arguments":{"marker":"from-claude"}}}}}|}
+let mcp_call_with_id id =
+  Printf.sprintf
+    {|{"type":"control_request","request_id":"mcp-call-%s","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":"call-%s","method":"tools/call","params":{"name":"masc_probe","arguments":{"marker":"from-claude"}}}}}|}
+    id
+    id
 ;;
+
+let mcp_call = mcp_call_with_id "1"
 
 type fixture_step =
   | Emit of string
@@ -1069,7 +1074,7 @@ let test_spawn_failure_releases_claim () =
          | _ -> fail "transient release evidence was not persisted"))
 ;;
 
-let run_direct_attempt ~base_path ~cli_path ~goal ~tools =
+let run_direct_attempt ?hooks ~base_path ~cli_path ~goal ~tools =
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
     ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
@@ -1104,7 +1109,7 @@ let run_direct_attempt ~base_path ~cli_path ~goal ~tools =
                     ~tools
                     ~initial_messages:[]
                     ~model_input_projection:None
-                    ~hooks:None
+                    ~hooks
                     ~context_injector:None
                       (* Dynamic tools require the Keeper shared context
                          ([Keeper_official_client_host.dynamic_tools] rejects
@@ -1180,6 +1185,98 @@ let test_unbounded_turn_keeps_subscription_probe_bounded () =
   | None -> fail "unbounded turn config leaked into the subscription probe"
 ;;
 
+let repeated_tool_fixture =
+  [ Emit_and_read mcp_initialize
+  ; Emit mcp_initialized_notification
+  ; Emit_and_read mcp_list
+  ; Emit_and_read (mcp_call_with_id "repeat-1")
+  ; Emit_and_read (mcp_call_with_id "repeat-2")
+  ; Emit_and_read (mcp_call_with_id "repeat-3")
+  ]
+;;
+
+let repeated_tool () =
+  Agent_core.Tool.create
+    ~name:"masc_probe"
+    ~description:"Return the same deterministic result"
+    ~parameters:
+      [ { Agent_core.Types.name = "marker"
+        ; description = "Fixture marker"
+        ; param_type = String
+        ; required = true
+        }
+      ]
+    (fun _ ->
+      Ok { Agent_core.Types.content = "MASC_TOOL_RESULT"; _meta = None })
+;;
+
+let test_repeated_tool_stop_records_pre_result_turn_identity () =
+  let base_path = temp_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture repeated_tool_fixture (fun cli_path ->
+         let attempt =
+           run_direct_attempt
+             ~base_path
+             ~cli_path
+             ~goal:"REPEAT_TOOL"
+             ~tools:[ repeated_tool () ]
+         in
+         (match attempt.result with
+          | Error error -> fail (Agent_core.Error.to_string error)
+          | Ok result ->
+            (match result.stop_reason with
+             | Runtime_agent.Yielded_after_repeated_tool_call
+                 { tool_name; repeated_count; _ } ->
+               check string "repeated tool" "masc_probe" tool_name;
+               check int "repeat threshold" 3 repeated_count
+             | _ -> fail "repeated Claude tool call was not a checkpoint yield"));
+         match (load_state base_path).phase with
+         | Settled { session_id; turn_id; _ } ->
+           check
+             string
+             "deterministic pre-result turn identity"
+             (Keeper_claude_code_runtime.For_testing.host_stop_turn_identity
+                ~session_id
+                ~turn_count:1)
+             turn_id
+         | _ -> fail "repeated Claude tool call did not settle durable state"))
+;;
+
+let test_repeated_tool_stop_preserves_terminal_hook_failure () =
+  let base_path = temp_workspace () in
+  let hooks =
+    { Agent_core.Hooks.empty with
+      post_tool_use =
+        Some
+          (fun _ ->
+             raise (Failure "post-tool fixture terminal failure"))
+    }
+  in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tree base_path)
+    (fun () ->
+       with_fixture repeated_tool_fixture (fun cli_path ->
+         let attempt =
+           run_direct_attempt
+             ~hooks
+             ~base_path
+             ~cli_path
+             ~goal:"REPEAT_FAILED_HOOK"
+             ~tools:[ repeated_tool () ]
+         in
+         match attempt.result with
+         | Ok _ -> fail "repeated host stop hid the terminal hook failure"
+         | Error error ->
+           check bool
+             "terminal hook detail survives"
+             true
+             (String_util.contains_substring
+                (Agent_core.Error.to_string error)
+                "post-tool fixture terminal failure")))
+;;
+
 let () =
   run
     "keeper_claude_code_runtime"
@@ -1231,6 +1328,14 @@ let () =
             "unbounded turn keeps subscription probe bounded"
             `Quick
             test_unbounded_turn_keeps_subscription_probe_bounded
+        ; test_case
+            "repeated tool stop records pre-result turn identity"
+            `Quick
+            test_repeated_tool_stop_records_pre_result_turn_identity
+        ; test_case
+            "repeated tool stop preserves terminal hook failure"
+            `Quick
+            test_repeated_tool_stop_preserves_terminal_hook_failure
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- record a deterministic Claude turn identity when a repeated-tool host stop arrives before the terminal result frame
- preserve terminal tool-hook failures instead of projecting them as a successful checkpoint yield across Claude, Codex, and Antigravity
- add Claude repeated-tool lifecycle regressions for the pre-result stop and terminal hook failure paths

## Review follow-up

- closes the Claude pre-result P1 on #28335: https://github.com/jeong-sik/masc/pull/28335#discussion_r3764002138
- closes the terminal hook P2 on #28335: https://github.com/jeong-sik/masc/pull/28335#discussion_r3764002142
- probe classifier P1 was split and merged first as #28350: https://github.com/jeong-sik/masc/pull/28335#discussion_r3764002147
- the typed test fixture required by the current Agent Core tool_error contract was split and merged first as #28349

## Verification

- ocamlformat check on all five final changed files
- OCaml parser check on all five final changed files
- Eio conventions check
- dead-export baseline unchanged at 548
- git diff check
- local Dune intentionally not run at user request; exact-main GitHub CI is the build and test authority

## Final revisions

- rebased head: a17c50bb024dfdc8d5e47b48c84aa930cd67a7ee
- merge: 9e0aa5e3a7a626eb03ab22ee2854e5eee633200f

## CI status at merge

The PR was merged before Build and Test completed. The exact merge-SHA main run is authoritative and must pass before this repair is called green.