### PR TITLE
fix(grpc): preserve pause on heartbeat control stream

### DIFF
--- a/lib/server/masc_grpc_service.ml
+++ b/lib/server/masc_grpc_service.ml
@@ -189,7 +189,8 @@ type task_directive_decision =
       }
 
 type heartbeat_workspace_view =
-  { active_agent_count : int
+  { workspace_paused : bool
+  ; active_agent_count : int
   ; pending_task_count : int
   ; task_directive : task_directive_decision
   }
@@ -223,8 +224,9 @@ let decide_task_directive tasks =
 ;;
 
 (** Pure projection from one authoritative Workspace snapshot. *)
-let heartbeat_workspace_view ~active_agents ~tasks =
-  { active_agent_count = List.length active_agents
+let heartbeat_workspace_view ~workspace_paused ~active_agents ~tasks =
+  { workspace_paused
+  ; active_agent_count = List.length active_agents
   ; pending_task_count =
       List.fold_left
         (fun count task -> if task_is_pending task then count + 1 else count)
@@ -234,16 +236,22 @@ let heartbeat_workspace_view ~active_agents ~tasks =
   }
 ;;
 
-let directives_of_decision ~agent_name = function
-  | No_task_directive -> []
-  | Assign_task task_id -> [ Keeper_directive.Assign_task task_id ]
-  | Invalid_task_id { task_id; error } ->
-    Log.Transport.error
-      "gRPC heartbeat: invalid task id %S for keeper %s: %s"
-      task_id
-      agent_name
-      error;
-    []
+let directives_of_view ~agent_name view =
+  let task_directives =
+    match view.task_directive with
+    | No_task_directive -> []
+    | Assign_task task_id -> [ Keeper_directive.Assign_task task_id ]
+    | Invalid_task_id { task_id; error } ->
+      Log.Transport.error
+        "gRPC heartbeat: invalid task id %S for keeper %s: %s"
+        task_id
+        agent_name
+        error;
+      []
+  in
+  if view.workspace_paused
+  then Keeper_directive.Pause :: task_directives
+  else task_directives
 ;;
 
 (** Heartbeat bidi handler: receive pings, respond with acks. *)
@@ -290,10 +298,13 @@ let handle_heartbeat
                     actual_name);
               let active_agents = Workspace.get_active_agents workspace_config in
               let tasks = Workspace.get_tasks_safe workspace_config in
-              let view = heartbeat_workspace_view ~active_agents ~tasks in
-              let directives =
-                directives_of_decision ~agent_name:ping.agent_name view.task_directive
+              let view =
+                heartbeat_workspace_view
+                  ~workspace_paused:(Workspace.is_paused workspace_config)
+                  ~active_agents
+                  ~tasks
               in
+              let directives = directives_of_view ~agent_name:ping.agent_name view in
               let ack =
                 T.HeartbeatAck.
                   { timestamp_ms = now_ms ()

--- a/test/test_grpc_workspace.ml
+++ b/test/test_grpc_workspace.ml
@@ -684,6 +684,48 @@ let test_heartbeat_projects_workspace_view () =
     | _ -> Alcotest.fail "Heartbeat bidi handler missing")
 ;;
 
+let test_heartbeat_projects_workspace_pause_directive () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_temp_dir "masc-grpc-heartbeat-workspace-pause" (fun dir ->
+    let workspace_config = Workspace_utils.default_config dir in
+    ignore (Masc.Workspace.init workspace_config ~agent_name:(Some "alpha"));
+    Masc.Workspace.pause workspace_config ~by:"operator" ~reason:"maintenance";
+    let service =
+      Masc_grpc_service.create_service
+        ~workspace_config
+        ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
+        ~lsp_dispatcher:(fun ~language_id:_ ~jsonrpc_request_json:_ ~workspace_root:_ ->
+          Error "test stub")
+    in
+    match Grpc_eio.Service.get_method service "Heartbeat" with
+    | Some { handler = `Bidi handler; _ } ->
+      Eio.Switch.run
+      @@ fun sw ->
+      let request_stream = Grpc_eio.Stream.create 16 in
+      let response_stream = handler ~sw request_stream in
+      Grpc_eio.Stream.add
+        request_stream
+        (T.HeartbeatPing.to_bytes
+           { agent_name = "alpha"
+           ; session_id = "sess-workspace-pause"
+           ; timestamp_ms = 1700000000000L
+           ; current_task_id = ""
+           });
+      let ack =
+        Eio.Time.with_timeout_exn (Eio.Stdenv.clock env) 1.0 (fun () ->
+          Grpc_eio.Stream.take response_stream)
+        |> T.HeartbeatAck.of_bytes
+      in
+      Alcotest.(check (list string))
+        "workspace pause reaches keeper control stream"
+        [ "pause" ]
+        (List.map T.HeartbeatAck.directive_to_wire ack.directives);
+      Grpc_eio.Stream.close request_stream
+    | _ -> Alcotest.fail "Heartbeat bidi handler missing")
+;;
+
 (* ====== Test suite ====== *)
 
 let () =
@@ -752,6 +794,10 @@ let () =
             "heartbeat projects workspace view"
             `Quick
             test_heartbeat_projects_workspace_view
+        ; Alcotest.test_case
+            "heartbeat projects workspace pause directive"
+            `Quick
+            test_heartbeat_projects_workspace_pause_directive
         ] )
     ; ( "server_config"
       , [ Alcotest.test_case "default_port" `Quick test_grpc_default_port


### PR DESCRIPTION
## Summary

- restore the typed Pause directive removed by #28341
- derive pause authority through Workspace.is_paused instead of direct filesystem JSON reads
- keep task assignment and heartbeat counts on the same typed Workspace projection
- add a service-boundary regression proving a workspace pause reaches the Keeper control stream

## Review finding

#28341 removed the only producer of Keeper_directive.Pause while the 30-second gRPC stream remains the documented responsive control path. A paused Workspace would therefore keep a connected Keeper lane running without receiving the operator stop signal.

## Verification

- ocamlformat check on both changed files
- OCaml parser check on both changed files
- Eio conventions check
- dead-export baseline unchanged at 548
- git diff check
- local Dune intentionally not run at user request; exact-head GitHub CI is the build and test authority

## Exact revisions

- base: 8f88da8c654b3296ffb5784d4cd5cb9e4b42011d
- head: e8783aebcdb57750862cff23a2ad05aae61c3c08