### PR TITLE
fix(test): use typed keeper tool error fixture

### DIFF
--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -224,7 +224,11 @@ let test_repeated_exact_dynamic_tool_call_aborts_the_turn () =
     let tool, terminal_error =
       one_dynamic_tool ~active (fun _input ->
         incr executions;
-        Error "same deterministic failure")
+        Error
+          { Agent_core.Types.message = "same deterministic failure"
+          ; recoverable = false
+          ; error_class = Some Agent_core.Types.Deterministic
+          })
     in
     let call index =
       let input =


### PR DESCRIPTION
## Why\nLatest main CI run 31569738919 fails while compiling test_keeper_official_client_host.ml:227: the fixture still returns Error string after Agent_core tool errors became a typed record.\n\n## Change\nRepresent the deterministic failure with message, recoverable=false, and error_class=Deterministic. Production behavior is unchanged.\n\n## Checks\n- git diff --check\n- ocamlformat --check test/test_keeper_official_client_host.ml\n- local Dune build intentionally not run per operator request; GitHub CI is authoritative