### PR TITLE
fix(build): official-client probe status map 에 Stopped_by_host 처리 (main 컴파일 복구)

### DIFF
--- a/lib/server/server_dashboard_official_client_probe.ml
+++ b/lib/server/server_dashboard_official_client_probe.ml
@@ -78,7 +78,13 @@ let codex_failure_status = function
   | Timeout _ -> "timeout"
   | Protocol_error _ | Rpc_error _ | Unsupported_server_request _ ->
     "protocol_error"
-  | Context_window_exceeded _ | Turn_failed _ | Turn_interrupted ->
+  | Context_window_exceeded _ | Turn_failed _ | Turn_interrupted
+  (* The host raises [Stopped_by_host] to abort a repeated tool loop mid-turn,
+     and this probe measures [initialize] plus login only — see "The probe
+     never starts a turn" at runtime_codex_app_server.ml. It joins the other
+     turn-shaped outcomes the probe's no-turn contract already rules out; it
+     is matched because [error] is the one sum type [run_turn] also returns. *)
+  | Stopped_by_host _ ->
     "probe_contract_error"
 ;;
 
@@ -91,7 +97,11 @@ let claude_failure_status = function
   | Turn_transport_interrupted _
   | Context_window_exceeded _
   | Turn_failed _
-  | Quota_blocked _ ->
+  | Quota_blocked _
+  (* Same reading as [codex_failure_status]: [probe_subscription] measures
+     "the official CLI login without submitting a model turn"
+     (runtime_claude_code.mli), so a mid-turn host abort cannot reach here. *)
+  | Stopped_by_host _ ->
     "probe_contract_error"
 ;;
 


### PR DESCRIPTION
## 무엇을

main 전체 빌드를 다시 복구한다. `server_dashboard_official_client_probe.ml` 의 `codex_failure_status` / `claude_failure_status` 가 `Stopped_by_host _` 를 다루지 않아 warning 8 (partial-match) 로 컴파일이 실패한다. 두 match 에 `Stopped_by_host _ -> "probe_contract_error"` arm 을 추가한다.

## 왜 깨졌나 (merge-train 조합 파손)

- #28335 가 `Stopped_by_host of host_stop` 을 `Runtime_codex_app_server.error` 와 `Runtime_claude_code.error` 양쪽에 추가했다. keeper 소비자들은 같은 PR 에서 갱신됐지만, probe 파일(#28288 이후 무변경)의 두 exhaustive match 는 누락됐다.
- #28338 (yojson 3 수리) 의 CI 는 base 가 #28335 이전이라 green — 머지된 조합은 어떤 CI 도 빌드한 적이 없다. #28327 에 기록한 "full-tree compile 게이트 부재"의 두 번째 실증이다.

## 라벨 선택 근거

probe 의 기존 버킷 의미: `protocol_error` = wire/프로토콜 실패, `probe_contract_error` = 턴이 probe 계약을 못 지킨 실패 (`Turn_failed`, `Turn_interrupted`, `Context_window_exceeded`). host stop 은 모델이 dynamic tool 을 반복 호출해 호스트가 턴을 중단시킨 것 — 모델의 턴 수행 실패이므로 `probe_contract_error` 로 분류. (keeper 쪽 `Session_store.Protocol_failed` 는 세션 재사용 판단용 다른 enum 이라 관례 이전 대상이 아님.)

## 검증

- origin/main head 에서 `dune build --root .` 실패 재현 (probe 파일 warning 8, 두 match 모두)
- 본 수정 적용 후 full `dune build --root .` 진행 중 — green 확인 시 코멘트로 갱신 (변경은 exhaustivity arm 2개 추가뿐)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
