### PR TITLE
fix(build): auth_config 라벨 해석 오류 + codex 테스트 abort_turn 누락 (main 컴파일 잔여 2건)

### DIFF
--- a/lib/server/server_auth_config.ml
+++ b/lib/server/server_auth_config.ml
@@ -21,7 +21,7 @@ type t =
   ; loopback_dev_mutation_origins : Server_request_authority.serialized_origin list
   }
 
-let read_env () =
+let read_env () : raw =
   { allow_anonymous_mutations =
       Env_config_core.raw_value_opt allow_anonymous_mutations_env
   ; loopback_dev_mutation_origins =

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -972,7 +972,10 @@ let test_no_deadline_keeps_post_accept_writes_bounded () =
     ; input_schema = `Assoc [ "type", `String "object" ]
     ; call =
         (fun ~call_id:_ _ ->
-          { success = true; content = String.make (1024 * 1024) 'x' })
+          { success = true
+          ; content = String.make (1024 * 1024) 'x'
+          ; abort_turn = None
+          })
     }
   in
   with_fixture


### PR DESCRIPTION
## 무엇을

#28350·#28349 이후에도 main 이 컴파일되지 않는다. 남은 파손 2건을 수리한다.

1. **`lib/server/server_auth_config.ml`** (#28345 도입): `raw` 와 `t` 가 같은 필드명을 공유하고 `t` 가 나중에 정의되어, 주석 없는 `read_env` 의 record literal 이 `t`(bool 필드) 로 해석 → `raw_value_opt` 의 `string option` 이 `bool` 자리에 놓여 타입 에러. `read_env () : raw` 주석으로 해소.
2. **`test/test_runtime_codex_app_server.ml`** (#28335 계열): `dynamic_tool_result` literal 1곳이 `abort_turn` 필드 추가 이전 형태로 남음. 같은 파일의 나머지 literal 3곳과 동일하게 `abort_turn = None` 추가.

## 왜 CI 를 통과해 들어왔나

두 PR 모두 자기 base 에서는 green 이었고, 머지된 조합은 어떤 CI 도 빌드하지 않았다. #28327 에 기록된 full-tree compile 게이트 부재의 3·4번째 실증 (1: yojson3 #28338, 2: probe #28350). 오늘 하루에만 같은 계열 파손 4건 — 게이트 도입의 우선순위 근거로 남긴다.

## 검증

- origin/main head (9e0aa5e3a7) 에서 두 에러 재현
- 수정 적용 후 full `dune build --root .` 진행 중 — green 확인 시 코멘트 갱신

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
