### PR TITLE
refactor(refresh): carry typed failure outcomes

### DIFF
--- a/docs/rfc/RFC-0371-effect-boundary-restoration.md
+++ b/docs/rfc/RFC-0371-effect-boundary-restoration.md
@@ -101,7 +101,7 @@ else `Bad_gateway
 
 아래 항목은 텍스트가 매치됐다는 이유만으로 reject 하지 않는다. 해당 PR이 새 implicit control channel 을 만들거나, 이미 보유한 typed 정보를 버린 뒤 문자열·환경·파일을 통해 재구성한다는 데이터 흐름 증거가 있을 때만 blocker 다. 외부 wire/프로세스 경계의 직렬화, 설정 로더의 env 읽기, store의 FS 접근, 명시적 오류 표시를 위한 문자열은 대상이 아니다.
 
-1. **typed→string→재파싱**: tool_input_validation:835, channel_gate:298/:323, proactive_refresh:36 → server_routes_http_runtime:311(`label=` 필드를 문자열에 박고 되꺼냄), failure_envelope:59-64(string→string→string 3단).
+1. **typed→string→재파싱**: tool_input_validation:835, channel_gate:298/:323, failure_envelope:59-64(string→string→string 3단).
 2. **요청 경로에서 이미 주입된 값을 env 로 재조회**: keeper_tool_execute_runtime:388, tool_workspace:60. 요청별 환경 정책을 명시적으로 소유하는 loader는 예외지만, `<> Some "false"` 같은 permissive 파싱으로 오타와 부재를 같은 값으로 합치는 경로는 허용하지 않는다.
 3. **결정 로직에서 owner API를 우회한 FS 접근·레이아웃 지식 이중화**: mcp_server:342(writer 레이아웃 재구현). store/loader가 자기 레이아웃을 읽는 것은 대상이 아니다.
 4. **Option/Result 의미 붕괴 후 재추론**: dashboard_verification:160(Result→failwith 로 실패 브랜치가 타입에서 소멸). 경계에서 모든 분기를 명시적으로 처리하는 정상 해소는 대상이 아니다.
@@ -210,7 +210,6 @@ Agent_core.Error.t ─(terminal_reason_code_of_core_error: typed→wire 렌더)�
 | `lib/keeper_runtime/keeper_internal_error.ml:963` | core-violation | confirmed | typed masc_internal_error 를 JSON 렌더해 Error.Internal 메시지 문자열에 박고 같은 프로세스가 재파싱 |
 | `lib/runtime/runtime_agent.ml:259` | core-violation | confirmed | 사람용 description 필드에 "runtime:%s/runtime" 를 밀수해 되읽음 |
 | `lib/server/masc_grpc_service.ml:246` | core-violation | confirmed | directive 계산이 workspace store 의 typed 읽기를 우회해 raw JSON 프로브 — 생산자 0 필드로 이미 drift |
-| `lib/server/proactive_refresh.ml:36` | core-violation | confirmed | timeout 조건(label/phase)을 Failure 문자열로 렌더해 던지고 소비자가 substring 재파싱 |
 | `lib/server/server_auth.ml:563` | core-violation | confirmed | mutation 인가 게이트가 요청마다 env 재독 |
 | `lib/server/server_routes_http_routes_channel_gate.ml:298` | core-violation | confirmed | 존재 확인을 위해 status 전체 디스패치 실행, typed Ok None 이 문자열이 되어 substring 재분류 |
 | `lib/tool_input_validation.ml:835` | core-violation | confirmed | typed params → JSON 렌더 → 재파싱 → failwith. typed 직접 생성자 존재(types.mli:183) |

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -5,13 +5,47 @@
     (exponential backoff, capped at [max_backoff_s]).  On recovery the
     interval resets and a log message is emitted. *)
 
+type phase =
+  | Warm_cache
+  | Refresh
+
+type timeout =
+  { label : string
+  ; phase : phase
+  ; timeout_s : float
+  ; elapsed_s : float
+  }
+
+type failure =
+  | Timed_out of timeout
+  | Raised of exn
+
+let phase_to_string = function
+  | Warm_cache -> "warm_cache"
+  | Refresh -> "refresh"
+;;
+
+let timeout_detail timeout =
+  Printf.sprintf
+    "refresh_timeout label=%s phase=%s timeout_s=%.1f elapsed_s=%.1f"
+    timeout.label
+    (phase_to_string timeout.phase)
+    timeout.timeout_s
+    timeout.elapsed_s
+;;
+
+let failure_message = function
+  | Timed_out timeout -> Printf.sprintf "Failure(%S)" (timeout_detail timeout)
+  | Raised exn -> Printexc.to_string exn
+;;
+
 type config = {
   label : string;
   interval_s : float;
   max_backoff_s : float;
   failure_threshold : int;
   timeout_s : float;
-  on_error : (exn -> unit) option;
+  on_failure : (failure -> unit) option;
   warm_delay_s : float;
   warn_first_failure : bool;
 }
@@ -23,7 +57,7 @@ let default_config ~label ~interval_s =
     max_backoff_s = 60.0;
     failure_threshold = 3;
     timeout_s = 10.0;
-    on_error = None;
+    on_failure = None;
     warm_delay_s = 0.0;
     warn_first_failure = true;
   }
@@ -33,21 +67,13 @@ let should_reraise_cancel exn =
   | Eio.Cancel.Cancelled _ -> not (Cancel_safe.is_internal_race_cancel exn)
   | _ -> false
 
-let timeout_failure_message ~label ~phase ~timeout_s ~elapsed_s =
-  Printf.sprintf
-    "refresh_timeout label=%s phase=%s timeout_s=%.1f elapsed_s=%.1f"
-    label
-    phase
-    timeout_s
-    elapsed_s
-
-let timeout_exception ~config ~phase ~elapsed_s =
-  Failure
-    (timeout_failure_message
-       ~label:config.label
-       ~phase
-       ~timeout_s:config.timeout_s
-       ~elapsed_s)
+let timeout_failure ~config ~phase ~elapsed_s =
+  Timed_out
+    { label = config.label
+    ; phase
+    ; timeout_s = config.timeout_s
+    ; elapsed_s
+    }
 
 let is_power_of_two n = n > 0 && n land (n - 1) = 0
 
@@ -62,7 +88,7 @@ let log_dashboard_refresh_failure ~warn message =
   if warn then Log.Dashboard.warn "%s" message
   else Log.Dashboard.debug "%s" message
 
-let log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt exn =
+let log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt failure =
   incr consecutive_failures;
   if !consecutive_failures >= config.failure_threshold then
     current_interval :=
@@ -71,7 +97,7 @@ let log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt exn 
     Printf.sprintf
       "%s refresh failed (%d consecutive, next in %.0fs, %.1fs): %s"
       config.label !consecutive_failures !current_interval dt
-      (Printexc.to_string exn)
+      (failure_message failure)
   in
   log_dashboard_refresh_failure message
     ~warn:
@@ -80,9 +106,9 @@ let log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt exn 
          ~warn_first_failure:config.warn_first_failure
          !consecutive_failures)
 
-let notify_error config exn =
-  match config.on_error with
-  | Some f -> Safe_ops.protect ~default:() (fun () -> f exn)
+let notify_failure config failure =
+  match config.on_failure with
+  | Some f -> Safe_ops.protect ~default:() (fun () -> f failure)
   | None -> ()
 
 let start ~sw ~clock ~config:raw_config ~compute ~on_result =
@@ -115,18 +141,19 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
            (Time_compat.now () -. t0)
        | Error `Timeout ->
          let dt = Time_compat.now () -. t0 in
-         let timeout_exn = timeout_exception ~config ~phase:"warm_cache" ~elapsed_s:dt in
-         notify_error config timeout_exn;
+         let failure = timeout_failure ~config ~phase:Warm_cache ~elapsed_s:dt in
+         notify_failure config failure;
          Log.Dashboard.warn "%s warm cache skipped (%.1fs timeout=%.1fs): %s"
-           config.label dt config.timeout_s (Printexc.to_string timeout_exn)
+           config.label dt config.timeout_s (failure_message failure)
      with
      | exn ->
        if should_reraise_cancel exn then
          raise exn
        else begin
-         notify_error config exn;
+         let failure = Raised exn in
+         notify_failure config failure;
          Log.Dashboard.warn "%s warm cache failed (%.1fs): %s" config.label
-           (Time_compat.now () -. t0) (Printexc.to_string exn)
+           (Time_compat.now () -. t0) (failure_message failure)
        end));
   Eio.Fiber.fork ~sw (fun () ->
     Log.Dashboard.info "starting %s refresh loop" config.label;
@@ -164,21 +191,21 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
            Log.Dashboard.debug "%s refreshed (%.1fs)" config.label dt
          | Error `Timeout ->
              let dt = Time_compat.now () -. t0 in
-             let timeout_exn = timeout_exception ~config ~phase:"refresh" ~elapsed_s:dt in
-             notify_error config timeout_exn;
+             let failure = timeout_failure ~config ~phase:Refresh ~elapsed_s:dt in
+             notify_failure config failure;
              log_refresh_failure ~config ~consecutive_failures ~current_interval
-               ~dt timeout_exn
+               ~dt failure
        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          if should_reraise_cancel exn then raise exn;
          let dt = Time_compat.now () -. t0 in
-         notify_error config exn;
+         let failure = Raised exn in
+         notify_failure config failure;
          log_refresh_failure ~config ~consecutive_failures ~current_interval
-           ~dt exn);
+           ~dt failure);
       loop ()
     in
     loop ())
 
 module For_testing = struct
-  let timeout_failure_message = timeout_failure_message
   let should_warn_refresh_failure = should_warn_refresh_failure
 end

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -3,25 +3,41 @@
     Runs a compute function periodically, with exponential backoff on
     consecutive failures. *)
 
+type phase =
+  | Warm_cache
+  | Refresh
+
+type timeout =
+  { label : string
+  ; phase : phase
+  ; timeout_s : float
+  ; elapsed_s : float
+  }
+
+type failure =
+  | Timed_out of timeout
+  | Raised of exn
+
+val failure_message : failure -> string
+(** Render a failure only at an operator/cache/wire boundary. Timeout rendering
+    preserves the existing [Failure("refresh_timeout ...")] text contract. *)
+
 type config = {
   label : string;           (** Log prefix, e.g. "execution" or "mission". *)
   interval_s : float;       (** Base refresh interval in seconds. *)
   max_backoff_s : float;    (** Cap for exponential backoff. *)
   failure_threshold : int;  (** Consecutive failures before backoff kicks in. *)
-  timeout_s : float;        (** Warm-cache timeout. *)
-  on_error : (exn -> unit) option;  (** Called on timeout or exception. *)
+  timeout_s : float;        (** Per-attempt timeout. *)
+  on_failure : (failure -> unit) option;  (** Called on timeout or exception. *)
   warm_delay_s : float;    (** Delay before cold-start warm-cache compute (0.0 = immediate). *)
   warn_first_failure : bool;  (** Log a warning on the very first refresh failure. *)
 }
 
 val default_config : label:string -> interval_s:float -> config
 (** [default_config ~label ~interval_s] returns a config with
-    [max_backoff_s = 120.0], [failure_threshold = 5], [timeout_s = 10.0]. *)
+    [max_backoff_s = 60.0], [failure_threshold = 3], [timeout_s = 10.0]. *)
 
 module For_testing : sig
-  val timeout_failure_message :
-    label:string -> phase:string -> timeout_s:float -> elapsed_s:float -> string
-
   val should_warn_refresh_failure :
     ?warn_first_failure:bool -> failure_threshold:int -> int -> bool
 end
@@ -36,8 +52,8 @@ val start :
 (** Start a refresh loop with warm cache and circuit breaker.
 
     [compute] produces a value; [on_result] stores it (typically writing
-    to a ref).  A warm-cache run executes synchronously before the async
-    loop, bounded by [config.timeout_s].
+    to a ref).  Warm-cache and recurring runs live in child fibers owned by
+    [sw], with every attempt bounded by [config.timeout_s].
 
-    When [config.on_error] is set, it is called on timeout or exception,
+    When [config.on_failure] is set, it is called on timeout or exception,
     allowing callers to record the failure (e.g. mark_cached_surface_error). *)

--- a/lib/server/server_dashboard_http_cache.ml
+++ b/lib/server/server_dashboard_http_cache.ml
@@ -56,14 +56,18 @@ let mark_cached_surface_success surface json =
     ; last_error_unix = None
     }
 
-let mark_cached_surface_error surface exn =
+let mark_cached_surface_error_message surface message =
   let ts, iso = now_cache_stamp () in
   surface.current <-
     { surface.current with
-      last_error = Some (Printexc.to_string exn)
+      last_error = Some message
     ; last_error_at = Some iso
     ; last_error_unix = Some ts
     }
+
+let mark_cached_surface_error surface exn =
+  mark_cached_surface_error_message surface (Printexc.to_string exn)
+;;
 
 let invalidate_cached_surface surface =
   surface.current <-

--- a/lib/server/server_dashboard_http_cache.mli
+++ b/lib/server/server_dashboard_http_cache.mli
@@ -66,6 +66,10 @@ val mark_cached_surface_error : cached_surface -> exn -> unit
     touch [last_success_*] or [s.json] — the previous successful
     snapshot remains served until the next success refreshes it. *)
 
+val mark_cached_surface_error_message : cached_surface -> string -> unit
+(** Store an already-rendered boundary failure without recreating an exception
+    solely to transport its text. *)
+
 val invalidate_cached_surface : cached_surface -> unit
 (** [invalidate_cached_surface s] clears all six timestamps but
     leaves [s.json] intact.  Used by tests to reset surface state

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -126,7 +126,12 @@ let start_mission_refresh_loop ~state ~sw ~clock =
     ~config:
       { (Proactive_refresh.default_config ~label:"mission" ~interval_s:120.0) with
         timeout_s = mission_refresh_timeout_s
-      ; on_error = Some (mark_cached_surface_error mission_cache)
+      ; on_failure =
+          Some
+            (fun failure ->
+              mark_cached_surface_error_message
+                mission_cache
+                (Proactive_refresh.failure_message failure))
       ; warm_delay_s = 90.0
       }
     ~compute

--- a/lib/server/server_dashboard_http_core_digest_refresh.ml
+++ b/lib/server/server_dashboard_http_core_digest_refresh.ml
@@ -91,7 +91,12 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
            ~interval_s:Core_operator.operator_refresh_interval_s)
         with
         timeout_s = Core_operator.operator_refresh_interval_s *. 0.8
-      ; on_error = Some (mark_cached_surface_error Core_operator.operator_digest_cache)
+      ; on_failure =
+          Some
+            (fun failure ->
+              mark_cached_surface_error_message
+                Core_operator.operator_digest_cache
+                (Proactive_refresh.failure_message failure))
       ; warm_delay_s = 150.0
       }
     ~compute

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -878,11 +878,13 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
     ~config:
       { (Proactive_refresh.default_config ~label:"execution" ~interval_s:60.0) with
         timeout_s = execution_refresh_timeout_s
-      ; on_error =
+      ; on_failure =
           Some
-            (fun exn ->
+            (fun failure ->
               clear_execution_default_light_http_body ();
-              Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn)
+              Server_dashboard_http_cache.mark_cached_surface_error_message
+                execution_cache
+                (Proactive_refresh.failure_message failure))
       ; warm_delay_s = 0.0
       }
     ~compute
@@ -931,10 +933,12 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
     ~config:
       { (Proactive_refresh.default_config ~label:"transport_health" ~interval_s) with
         timeout_s
-      ; on_error =
+      ; on_failure =
           Some
-            (fun exn ->
-              Server_dashboard_http_cache.mark_cached_surface_error transport_health_cache exn;
+            (fun failure ->
+              Server_dashboard_http_cache.mark_cached_surface_error_message
+                transport_health_cache
+                (Proactive_refresh.failure_message failure);
               broadcast_snapshot ())
       ; warm_delay_s = 0.0
       }
@@ -978,13 +982,13 @@ let start_execution_trust_refresh_loop ~state ~sw ~clock =
            ~interval_s:Dashboard_http_keeper_types.execution_trust_refresh_interval_s)
         with
         timeout_s = Env_config_runtime.Dashboard.execution_trust_timeout_sec
-      ; on_error =
+      ; on_failure =
           Some
-            (fun exn ->
+            (fun failure ->
               with_execution_trust_cache (fun () ->
-                Server_dashboard_http_cache.mark_cached_surface_error
+                Server_dashboard_http_cache.mark_cached_surface_error_message
                   execution_trust_cache
-                  exn))
+                  (Proactive_refresh.failure_message failure)))
       ; warm_delay_s = 0.0
       }
     ~compute

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -307,9 +307,6 @@ include Server_routes_http_runtime_fleet_scan
    [Server_routes_http_runtime_health_fleet] (godfile decomp). *)
 include Server_routes_http_runtime_health_fleet
 
-let full_health_refresh_timeout_error error =
-  String_util.contains_substring error "refresh_timeout label=full_health_snapshot"
-
 let full_health_component_placeholder ?error ?(component_timed_out = false) ~status
     component =
   let error_fields =
@@ -342,9 +339,11 @@ let compute_section ~name ?section_timings_ref f =
        | Some ref -> ref := (name, elapsed_ms) :: !ref
        | None -> ());
       let error = Printexc.to_string exn in
-      let timed_out = full_health_refresh_timeout_error error in
-      let status = if timed_out then "timeout" else "error" in
-      full_health_component_placeholder ~error ~component_timed_out:true ~status name
+      full_health_component_placeholder
+        ~error
+        ~component_timed_out:false
+        ~status:"error"
+        name
 
 let assoc_member_opt name = function
   | `Assoc fields -> List.assoc_opt name fields
@@ -718,7 +717,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref
 (* [stale_since_ts] records the wall-clock time of the FIRST refresh
    failure since the last successful refresh.  It is preserved across
    subsequent consecutive failures (never overwritten — see
-   [mark_full_health_snapshot_error]) and cleared on the next
+   [mark_full_health_snapshot_failure]) and cleared on the next
    successful [store_full_health_snapshot].  This lets downstream
    consumers compute "how long has the snapshot been stale?" without
    relying on the per-failure [computed_at] timestamp, which under
@@ -728,7 +727,7 @@ type full_health_snapshot = {
   fields : (string * Yojson.Safe.t) list;
   computed_at : float;
   duration_ms : int;
-  error : string option;
+  failure : Proactive_refresh.failure option;
   stale_since_ts : float option;
   last_good_available : bool;
   section_timings : (string * int) list;
@@ -742,7 +741,7 @@ let full_health_refresh_requested = ref false
 (* Consecutive [/health?full=1] refresh failures (timeouts or
    exceptions).  Reset to 0 on every successful
    [store_full_health_snapshot]; incremented inside
-   [mark_full_health_snapshot_error].  Guarded by
+   [mark_full_health_snapshot_failure].  Guarded by
    [full_health_snapshot_mu] like every other piece of refresh
    bookkeeping. *)
 let full_health_consecutive_failures = ref 0
@@ -993,7 +992,7 @@ let compute_full_health_snapshot ?(listener = "http/1.1") ~request_authority
       fields;
       computed_at = finished_at;
       duration_ms = duration_ms ~started_at ~finished_at;
-      error = None;
+      failure = None;
       stale_since_ts = None;
       last_good_available = true;
       section_timings = List.rev !section_timings_ref;
@@ -1002,12 +1001,13 @@ let compute_full_health_snapshot ?(listener = "http/1.1") ~request_authority
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
       let finished_at = Unix.gettimeofday () in
-      let error = Printexc.to_string exn in
+      let failure = Proactive_refresh.Raised exn in
+      let error = Proactive_refresh.failure_message failure in
       {
         fields = full_health_placeholder_fields ~error ~status:"error" ();
         computed_at = finished_at;
         duration_ms = duration_ms ~started_at ~finished_at;
-        error = Some error;
+        failure = Some failure;
         stale_since_ts = Some finished_at;
         last_good_available = false;
         section_timings = List.rev !section_timings_ref;
@@ -1021,20 +1021,24 @@ let store_full_health_snapshot snapshot =
       full_health_refresh_requested := false;
       (* Successful refresh — clear consecutive-failure counter so the
          critical alarm only re-fires after another N successive
-         failures.  A snapshot is "successful" iff [error] is None;
+         failures.  A snapshot is "successful" iff [failure] is None;
          the inline error path in [compute_full_health_snapshot]
          routes through here too, so guard on the field. *)
-      match snapshot.error with
+      match snapshot.failure with
       | None -> full_health_consecutive_failures := 0
       | Some _ -> ())
 
-let mark_full_health_snapshot_error exn =
+let mark_full_health_snapshot_failure failure =
   let now = Unix.gettimeofday () in
-  let error = Printexc.to_string exn in
-  let timed_out = full_health_refresh_timeout_error error in
+  let error = Proactive_refresh.failure_message failure in
+  let timed_out =
+    match failure with
+    | Proactive_refresh.Timed_out _ -> true
+    | Proactive_refresh.Raised _ -> false
+  in
   with_full_health_snapshot_lock (fun () ->
       (* Partial degradation: preserve the last successful snapshot's
-         per-component [fields] and overwrite only the [error] /
+         per-component [fields] and overwrite only the [failure] /
          [stale_since_ts] / refresh-bookkeeping signals.  If we have
          no prior snapshot (warm path on cold boot), fall back to the
          all-error placeholder so the field set stays well-typed. *)
@@ -1087,7 +1091,7 @@ let mark_full_health_snapshot_error exn =
             fields = preserved_fields;
             computed_at = preserved_computed_at;
             duration_ms = preserved_duration_ms;
-            error = Some error;
+            failure = Some failure;
             stale_since_ts;
             last_good_available;
             section_timings = preserved_section_timings;
@@ -1130,15 +1134,13 @@ let full_health_snapshot_stale_reason ~now snapshot =
   match snapshot with
   | None -> None
   | Some snapshot ->
-      (match snapshot.error with
-       | Some error
-         when snapshot.last_good_available
-              && full_health_refresh_timeout_error error ->
+      (match snapshot.failure with
+       | Some (Proactive_refresh.Timed_out _) when snapshot.last_good_available ->
            Some "last_good_refresh_timeout"
-       | Some _ when snapshot.last_good_available -> Some "last_good_refresh_error"
-       | Some error when full_health_refresh_timeout_error error ->
-           Some "refresh_timeout"
-       | Some _ -> Some "refresh_error"
+       | Some (Proactive_refresh.Raised _) when snapshot.last_good_available ->
+           Some "last_good_refresh_error"
+       | Some (Proactive_refresh.Timed_out _) -> Some "refresh_timeout"
+       | Some (Proactive_refresh.Raised _) -> Some "refresh_error"
        | None when snapshot_is_stale ~now snapshot -> Some "ttl_expired"
        | None -> None)
 
@@ -1166,7 +1168,7 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
         now -. started_at > full_health_refresh_timeout_sec
     | _ ->
         (match snapshot with
-         | Some { error = Some error; _ } -> full_health_refresh_timeout_error error
+         | Some { failure = Some (Proactive_refresh.Timed_out _); _ } -> true
          | _ -> false)
   in
   let snapshot_age_ms, computed_at, duration_ms, error, stale_since_ts, status =
@@ -1174,10 +1176,12 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
     | None -> (`Null, `Null, `Null, `Null, `Null, "warming")
     | Some snapshot ->
         let status =
-          match snapshot.error with
-          | Some _ when snapshot.last_good_available -> "stale"
-          | Some error when full_health_refresh_timeout_error error -> "timeout"
-          | Some _ -> "error"
+          match snapshot.failure with
+          | Some (Proactive_refresh.Timed_out _ | Proactive_refresh.Raised _)
+            when snapshot.last_good_available ->
+            "stale"
+          | Some (Proactive_refresh.Timed_out _) -> "timeout"
+          | Some (Proactive_refresh.Raised _) -> "error"
           | None when snapshot_is_stale ~now snapshot -> "stale"
           | None -> "ready"
         in
@@ -1189,7 +1193,9 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
         ( `Int (duration_ms ~started_at:snapshot.computed_at ~finished_at:now),
           `Float snapshot.computed_at,
           `Int snapshot.duration_ms,
-          (Json_util.string_opt_to_json snapshot.error),
+          (match snapshot.failure with
+           | Some failure -> `String (Proactive_refresh.failure_message failure)
+           | None -> `Null),
           stale_since_ts_json,
           status )
   in
@@ -1290,7 +1296,7 @@ let start_full_health_snapshot_refresh_loop ~sw ~clock ~request_authority =
            ~interval_s:full_health_refresh_interval_sec)
         with
         timeout_s = full_health_refresh_timeout_sec;
-        on_error = Some mark_full_health_snapshot_error;
+        on_failure = Some mark_full_health_snapshot_failure;
         warm_delay_s = 0.5;
         warn_first_failure = false;
       }
@@ -1322,7 +1328,7 @@ module For_testing = struct
       ~request_authority request =
     refresh_full_health_snapshot_sync ~listener ~request_authority request
 
-  let mark_full_health_snapshot_error = mark_full_health_snapshot_error
+  let mark_full_health_snapshot_failure = mark_full_health_snapshot_failure
 
   let full_health_refresh_timing () =
     ( full_health_refresh_interval_sec,

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -261,7 +261,7 @@ module For_testing : sig
     unit
   (** Synchronously recomputes and stores the cached full-health snapshot. *)
 
-  val mark_full_health_snapshot_error : exn -> unit
+  val mark_full_health_snapshot_failure : Proactive_refresh.failure -> unit
   (** Records a failed background refresh without recomputing the snapshot. *)
 
   val full_health_refresh_timing : unit -> float * float * float

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -15,19 +15,25 @@ let check_json msg expected actual =
 let timeout_kind json =
   Yojson.Safe.Util.(member "timeout_kind" json |> to_string)
 
-let test_proactive_refresh_timeout_message_names_phase () =
-  let msg =
-    Proactive_refresh.For_testing.timeout_failure_message
-      ~label:"operator_snapshot"
-      ~phase:"refresh"
-      ~timeout_s:24.0
-      ~elapsed_s:33.2
+let test_proactive_refresh_timeout_is_typed_and_rendered_at_boundary () =
+  let failure =
+    Proactive_refresh.Timed_out
+      { label = "operator_snapshot"
+      ; phase = Proactive_refresh.Refresh
+      ; timeout_s = 24.0
+      ; elapsed_s = 33.2
+      }
   in
+  (match failure with
+   | Proactive_refresh.Timed_out { phase = Proactive_refresh.Refresh; _ } -> ()
+   | Proactive_refresh.Timed_out { phase = Proactive_refresh.Warm_cache; _ }
+   | Proactive_refresh.Raised _ ->
+     Alcotest.fail "refresh timeout lost its typed phase");
   Alcotest.(check string)
-    "typed proactive refresh timeout"
-    "refresh_timeout label=operator_snapshot phase=refresh timeout_s=24.0 \
-     elapsed_s=33.2"
-    msg
+    "operator boundary rendering"
+    "Failure(\"refresh_timeout label=operator_snapshot phase=refresh timeout_s=24.0 \
+     elapsed_s=33.2\")"
+    (Proactive_refresh.failure_message failure)
 
 let test_proactive_refresh_failure_warn_throttle () =
   let should_warn =
@@ -745,8 +751,8 @@ let () =
         ] );
       ( "timeout",
         [
-          test_case "proactive refresh timeout names phase" `Quick
-            test_proactive_refresh_timeout_message_names_phase;
+          test_case "proactive refresh timeout is typed" `Quick
+            test_proactive_refresh_timeout_is_typed_and_rendered_at_boundary;
           test_case "proactive refresh failure WARN throttle" `Quick
             test_proactive_refresh_failure_warn_throttle;
           test_case "proactive refresh can suppress first WARN" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -3885,12 +3885,16 @@ let test_full_health_refresh_timeout_preserves_last_snapshot () =
   let before = Server_routes_http_runtime.make_health_response_json request in
   let open Yojson.Safe.Util in
   let before_reaction_ledger = before |> member "keeper_reaction_ledger" in
-  let timeout_error =
-    Failure
-      "refresh_timeout label=full_health_snapshot phase=refresh timeout_s=16.0 \
-       elapsed_s=17.0"
+  let timeout_failure =
+    Proactive_refresh.Timed_out
+      { label = "full_health_snapshot"
+      ; phase = Proactive_refresh.Refresh
+      ; timeout_s = 16.0
+      ; elapsed_s = 17.0
+      }
   in
-  Server_routes_http_runtime.For_testing.mark_full_health_snapshot_error timeout_error;
+  Server_routes_http_runtime.For_testing.mark_full_health_snapshot_failure
+    timeout_failure;
   let after = Server_routes_http_runtime.make_health_response_json request in
   Alcotest.(check string) "timeout marks snapshot stale" "stale"
     (after |> member "full_health_snapshot" |> member "status" |> to_string);
@@ -3900,7 +3904,9 @@ let test_full_health_refresh_timeout_preserves_last_snapshot () =
   Alcotest.(check bool) "timeout keeps last-good marker" true
     (after |> member "full_health_snapshot" |> member "last_good_available"
      |> to_bool);
-  Alcotest.(check string) "timeout error is surfaced" (Printexc.to_string timeout_error)
+  Alcotest.(check string)
+    "timeout error is surfaced"
+    (Proactive_refresh.failure_message timeout_failure)
     (after |> member "full_health_snapshot" |> member "error" |> to_string);
   Alcotest.(check string) "timeout stale reason" "last_good_refresh_timeout"
     (after |> member "full_health_snapshot" |> member "stale_reason" |> to_string);
@@ -3919,12 +3925,16 @@ let test_full_health_refresh_timeout_preserves_last_snapshot () =
 let test_full_health_cold_refresh_timeout_is_timeout_not_error () =
   Server_routes_http_runtime.For_testing.reset_full_health_snapshot ();
   let request = Httpun.Request.create `GET "/health?full=1" in
-  let timeout_error =
-    Failure
-      "refresh_timeout label=full_health_snapshot phase=refresh timeout_s=16.0 \
-       elapsed_s=17.0"
+  let timeout_failure =
+    Proactive_refresh.Timed_out
+      { label = "full_health_snapshot"
+      ; phase = Proactive_refresh.Refresh
+      ; timeout_s = 16.0
+      ; elapsed_s = 17.0
+      }
   in
-  Server_routes_http_runtime.For_testing.mark_full_health_snapshot_error timeout_error;
+  Server_routes_http_runtime.For_testing.mark_full_health_snapshot_failure
+    timeout_failure;
   let after = Server_routes_http_runtime.make_health_response_json request in
   let open Yojson.Safe.Util in
   Alcotest.(check string) "cold timeout status" "timeout"


### PR DESCRIPTION
## Summary

- carry proactive refresh timeouts and raised exceptions as a closed `failure` variant
- keep full-health stale/status decisions typed until the HTTP/cache rendering boundary
- remove the timeout exception-string classifier and its stale RFC finding

## Product impact

- User-visible change: none intended; existing timeout error text and health status fields are preserved

## Evidence

- `ocamlformat --check` passed for all 11 touched OCaml source/test files
- `ocamlc -stop-after parsing` passed for all 11 touched OCaml source/test files
- `git diff --check` passed
- deleted-symbol/static flow checks passed
- `bash scripts/check-variants.sh` passed
- local Dune build/tests intentionally not run per operator request; exact-head CI is the build authority

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

## GOAL LOOP ACT checklist

- [x] Observe — RFC-0371 recorded timeout metadata rendered into `Failure` text and reparsed by the full-health consumer
- [x] Orient — mapped to the functional-core/effect-shell typed-to-string-to-reparse finding
- [x] Decide — bounded HTTP refresh slice; no unrelated durable authority changes
- [x] Act — typed failure flows through refresh, cache callbacks, and health snapshot state
- [ ] Verify — parser/format/static checks passed; exact-head CI pending
- [x] Loop — remaining campaign findings stay tracked in RFC-0371 and subsequent PR slices

## Review evidence

- Self-review: all `Proactive_refresh.start` consumers checked; legacy callback/classifier symbols are absent
- CI review pending

## Linked issue

- Relates #28221

## Variant addition checklist

- [x] **OCaml** — `phase` and `failure` added in `.ml`/`.mli`; all in-repo consumers match typed cases
- [x] **TypeScript** — N/A: no dashboard union or external wire enum changed
- [x] **TLA+ spec** — N/A: no modeled domain literal changed
- [x] **Event / JSON schema** — N/A: existing JSON strings/status values are preserved
- [x] **`make check-variants` passes** — equivalent `bash scripts/check-variants.sh` passed