### PR TITLE
fix(test): give run_direct_attempt an erasable optional argument

### DIFF
--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -1074,7 +1074,7 @@ let test_spawn_failure_releases_claim () =
          | _ -> fail "transient release evidence was not persisted"))
 ;;
 
-let run_direct_attempt ?hooks ~base_path ~cli_path ~goal ~tools =
+let run_direct_attempt ?hooks ~base_path ~cli_path ~goal ~tools () =
   let runtime_snapshot = Runtime.For_testing.snapshot () in
   Fun.protect
     ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
@@ -1146,6 +1146,7 @@ let test_subscription_spawn_failure_is_pre_dispatch () =
          ~cli_path:missing_cli
          ~goal:"subscription probe should fail"
          ~tools:[]
+         ()
        |> check_pre_dispatch_attempt "subscription probe spawn failure")
 ;;
 
@@ -1168,6 +1169,7 @@ let test_turn_spawn_failure_is_pre_dispatch_with_tools () =
            ~cli_path
            ~goal:"turn process spawn should fail"
            ~tools:[ tool ]
+           ()
          |> check_pre_dispatch_attempt "turn process spawn failure"))
 ;;
 
@@ -1222,6 +1224,7 @@ let test_repeated_tool_stop_records_pre_result_turn_identity () =
              ~cli_path
              ~goal:"REPEAT_TOOL"
              ~tools:[ repeated_tool () ]
+             ()
          in
          (match attempt.result with
           | Error error -> fail (Agent_core.Error.to_string error)
@@ -1265,6 +1268,7 @@ let test_repeated_tool_stop_preserves_terminal_hook_failure () =
              ~cli_path
              ~goal:"REPEAT_FAILED_HOOK"
              ~tools:[ repeated_tool () ]
+             ()
          in
          match attempt.result with
          | Ok _ -> fail "repeated host stop hid the terminal hook failure"


### PR DESCRIPTION
main 이 컴파일되지 않습니다.

```
File "test/test_keeper_claude_code_runtime.ml", line 1077, characters 24-29:
1077 | let run_direct_attempt ?hooks ~base_path ~cli_path ~goal ~tools =
                               ^^^^^
Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.

File "test/test_keeper_claude_code_runtime.ml", lines 1144-1148:
Error: This expression has type
         ?hooks:Agent_core_base.Hooks.hooks -> Keeper_claude_code_runtime.attempt_outcome
       but an expression was expected of type
         Keeper_claude_code_runtime.attempt_outcome
```

`?hooks` 뒤에 라벨 인자만 오기 때문에 컴파일러가 옵셔널을 언제 지울지 결정할 수 없습니다. 정의(warning 16)와 `?hooks` 를 생략한 적용 양쪽이 거부됩니다. 호출 4곳 중 `~hooks` 를 넘기는 것은 `:1262` 하나뿐입니다.

## 수정

관용적인 형태 그대로, 끝에 unit 을 둡니다.

```ocaml
let run_direct_attempt ?hooks ~base_path ~cli_path ~goal ~tools () =
```

호출 4곳(`:1144`, `:1166`, `:1220`, `:1262`)에 `()` 를 추가합니다. 동작 변화는 없습니다.

## 범위

`#28351` 이 같은 빌드 파손의 다른 두 건(`server_auth_config.ml` 의 `read_env`, `test_runtime_codex_app_server.ml`)을 이미 고쳤습니다. 이것은 그때 남은 세 번째입니다.

## 검증

`dune build --root .` 는 돌리지 않았습니다 — 이 저장소의 전체 빌드가 이 환경에서 10분 툴 한도를 넘고, 사용자가 빌드를 직접 확인하기로 했습니다. 변경은 시그니처 한 줄과 호출 4곳의 `()` 뿐이며, 컴파일러가 지적한 두 에러에 정확히 대응합니다. 그 외 검증은 하지 않았습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
