### PR TITLE
feat(auth): issue the loopback dashboard dev-token as Admin

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -41,14 +41,14 @@ describe('stored token metadata', () => {
     setStoredToken('loopback-dev-token', {
       source: 'dev',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     })
 
     expect(getStoredToken()).toBe('loopback-dev-token')
     expect(getStoredTokenMeta()).toEqual({
       source: 'dev',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     })
     expect(currentDashboardActor()).toBe('dashboard')
     expect(authHeaders()).toMatchObject({
@@ -75,7 +75,7 @@ describe('stored token metadata', () => {
     setStoredToken('manual-token', {
       source: 'dev',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     })
     clearStoredToken()
     clearStoredToken()
@@ -89,7 +89,7 @@ describe('stored token metadata', () => {
     })
     expect(listener).toHaveBeenNthCalledWith(2, {
       token: 'manual-token',
-      meta: { source: 'dev', actor: 'dashboard', role: 'worker' },
+      meta: { source: 'dev', actor: 'dashboard', role: 'admin' },
     })
     expect(listener).toHaveBeenNthCalledWith(3, {
       token: null,

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -27,7 +27,7 @@ const TOKEN_STORAGE_KEY = 'masc_bearer_token'
 const TOKEN_META_STORAGE_KEY = 'masc_bearer_token_meta'
 
 export type StoredTokenMeta =
-  | { source: 'dev'; actor: 'dashboard'; role: 'worker' }
+  | { source: 'dev'; actor: 'dashboard'; role: 'admin' }
   | { source: 'manual' }
   | { source: 'url' }
 
@@ -73,10 +73,13 @@ function normalizeStoredTokenMeta(value: unknown): StoredTokenMeta | null {
   if (
     record.source === 'dev'
     && record.actor === 'dashboard'
-    && record.role === 'worker'
+    && record.role === 'admin'
   ) {
-    return { source: 'dev', actor: 'dashboard', role: 'worker' }
+    return { source: 'dev', actor: 'dashboard', role: 'admin' }
   }
+  // A stored 'worker' dev meta from an older build parses as null, which
+  // shouldRefreshDevToken treats as "re-bootstrap" — the migration is a
+  // single silent re-fetch.
   return null
 }
 

--- a/dashboard/src/api/dev-token.test.ts
+++ b/dashboard/src/api/dev-token.test.ts
@@ -71,7 +71,7 @@ describe('ensureDevToken', () => {
       .mockResolvedValueOnce(jsonResponse({
         token: 'ready-dev-token',
         actor: 'dashboard',
-        role: 'worker',
+        role: 'admin',
       }))
 
     const bootstrap = ensureDevToken()
@@ -82,7 +82,7 @@ describe('ensureDevToken', () => {
     expect(setStoredToken).toHaveBeenCalledWith('ready-dev-token', {
       source: 'dev',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     })
     expect(devTokenBootstrapStatus.value).toBe('ok')
   })
@@ -114,7 +114,7 @@ describe('ensureDevToken', () => {
       .mockResolvedValueOnce(jsonResponse({
         token: 'fresh-dev-token',
         actor: 'dashboard',
-        role: 'worker',
+        role: 'admin',
       }))
 
     await ensureDevToken()
@@ -128,7 +128,7 @@ describe('ensureDevToken', () => {
     expect(setStoredToken).toHaveBeenCalledWith('fresh-dev-token', {
       source: 'dev',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     })
     expect(devTokenBootstrapStatus.value).toBe('ok')
   })
@@ -137,7 +137,7 @@ describe('ensureDevToken', () => {
     fetchWithTimeout.mockResolvedValueOnce(jsonResponse({
       token: 'loopback-dev-token',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     }))
 
     await ensureDevToken()
@@ -159,11 +159,11 @@ describe('ensureDevToken', () => {
     expect(devTokenBootstrapStatus.value).toBe('no_endpoint')
   })
 
-  it('rejects a bootstrap response without the exact worker identity contract', async () => {
+  it('rejects a bootstrap response without the exact admin identity contract', async () => {
     fetchWithTimeout.mockResolvedValueOnce(jsonResponse({
-      token: 'overprivileged-token',
+      token: 'stale-worker-token',
       actor: 'dashboard',
-      role: 'admin',
+      role: 'worker',
     }))
 
     await ensureDevToken()
@@ -174,10 +174,10 @@ describe('ensureDevToken', () => {
 
   it('refreshes a managed loopback token only for a typed refreshable auth code', async () => {
     let token: string | null = 'stale-token'
-    let meta: { source: 'dev'; actor: 'dashboard'; role: 'worker' } | null = {
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'admin' } | null = {
       source: 'dev',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     }
     getStoredToken.mockImplementation(() => token)
     getStoredTokenMeta.mockImplementation(() => meta)
@@ -192,7 +192,7 @@ describe('ensureDevToken', () => {
     fetchWithTimeout.mockResolvedValueOnce(jsonResponse({
       token: 'fresh-token',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     }))
 
     await expect(refreshDevTokenAfterAuthError('invalid_token')).resolves.toBe(true)
@@ -206,10 +206,10 @@ describe('ensureDevToken', () => {
 
   it('coalesces concurrent stale-token recovery onto one refresh', async () => {
     let token: string | null = 'stale-token'
-    let meta: { source: 'dev'; actor: 'dashboard'; role: 'worker' } | null = {
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'admin' } | null = {
       source: 'dev',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     }
     let resolveFetch!: (response: Response) => void
     const pendingFetch = new Promise<Response>((resolve) => {
@@ -235,7 +235,7 @@ describe('ensureDevToken', () => {
     resolveFetch(jsonResponse({
       token: 'fresh-token',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     }))
 
     await expect(Promise.all([first, second])).resolves.toEqual([true, true])

--- a/dashboard/src/api/dev-token.ts
+++ b/dashboard/src/api/dev-token.ts
@@ -119,7 +119,7 @@ export async function ensureDevToken(): Promise<void> {
           continue
         }
         const token = typeof payload.token === 'string' ? payload.token.trim() : ''
-        if (!token || payload.actor !== 'dashboard' || payload.role !== 'worker') {
+        if (!token || payload.actor !== 'dashboard' || payload.role !== 'admin') {
           ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'invalid_response'
           devTokenBootstrapPromise = null
           return
@@ -140,7 +140,7 @@ export async function ensureDevToken(): Promise<void> {
           setStoredToken(token, {
             source: 'dev',
             actor: 'dashboard',
-            role: 'worker',
+            role: 'admin',
           })
         }
         ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'ok'

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -241,6 +241,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | RFC-claude-code-context-overflow-bounded-restart | Admit Claude Code bootstrap input without replaying rejected episodes | Draft | - |
 | RFC-compaction-deterministic-floor | Compaction must never deadlock: a deterministic structural floor, typed outco... | Draft | - |
 | RFC-connector-ambient-attention-wake | Connector ambient attention wake: drive an idle keeper turn from external-att... | Draft | - |
+| RFC-dashboard-dev-token-configured-role | Loopback dashboard dev-token issues Admin | Draft | - |
 | RFC-keeper-conversation-hitl-flow | Keeper conversation and non-blocking HITL | Draft | - |
 | RFC-keeper-memory-consolidation | Keeper durable memory consolidation — deprecate memory_bank into Memory OS | Implemented | - |
 | RFC-keeper-runtime-context-observation-phase0 | Keeper runtime context observation Phase 0 | Draft | - |

--- a/docs/rfc/RFC-dashboard-dev-token-configured-role.md
+++ b/docs/rfc/RFC-dashboard-dev-token-configured-role.md
@@ -1,0 +1,46 @@
+# RFC: Loopback dashboard dev-token issues Admin
+
+Status: Draft
+
+## Problem
+
+The loopback dashboard bootstraps its bearer via
+`GET /api/v1/dashboard/dev-token`, which issued the `dashboard` credential
+as `Worker`. Admin-gated dashboard surfaces (Keeper GitHub CLI identity,
+operator controls behind `CanAdmin`) therefore refused the bootstrapped
+session, and the only admin path was pasting a long-lived bearer from
+`.masc/auth/` by hand — which the route's role-aware rotation then revoked
+on the next bootstrap cycle because its role differed from the Worker
+target. The local operator experienced this as recurring, silent
+de-authorization.
+
+The Worker ceiling defended nothing: the endpoint answers exact loopback
+Hosts only and is absent under strict-auth, and any process on the machine
+can already read `.masc/auth/*.token`. On this surface the restriction was
+friction, not a boundary.
+
+## Decision
+
+The loopback dev-token issues the `dashboard` credential as `Admin`. No
+configuration is added; the role is a compile-time constant, and the
+role-aware rotation that previously enforced Worker now converges stored
+Worker tokens to Admin on their first bootstrap after upgrade. The
+dashboard client's identity contract (`actor === 'dashboard'`,
+`role === 'admin'`) rejects a stale Worker response the same way it
+previously rejected a non-Worker one, and an older stored `worker` dev
+meta parses as null, which triggers one silent re-bootstrap.
+
+## Explicit non-goals
+
+- No env knob, endpoint, header, or query parameter; the role is not
+  selectable anywhere.
+- No change to remote or OAuth dashboard authentication, keeper/agent
+  credentials, or strict-auth behavior.
+- No TTL semantics change; file-token credentials remain non-expiring.
+
+## Failure behavior
+
+Unchanged from the existing rotation transaction: a failure after the
+pending-journal write leaves the exact raw token available for an
+idempotent retry, and non-loopback Hosts are refused before any token or
+credential I/O.

--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -1,14 +1,22 @@
 (** Dashboard dev-token issuance and role-aware rotation.
 
     Rotation is a resumable transaction:
-    journal -> credential revocation -> Worker credential -> public raw token
+    journal -> credential revocation -> Admin credential -> public raw token
     -> journal removal. A failure after the journal write leaves the exact raw
     token available for an idempotent retry. *)
 
 let ( let* ) = Result.bind
 
 let dashboard_dev_actor_name = "dashboard"
-let dashboard_dev_role = Masc_domain.Worker
+
+(* The loopback dev-token is the local operator's own session. The endpoint
+   answers exact loopback Hosts only and is absent under strict-auth, and any
+   process on this machine can already read [.masc/auth/*.token] — a Worker
+   ceiling here was friction, not a boundary: admin-gated dashboard surfaces
+   refused the bootstrapped session while a hand-pasted admin bearer died on
+   the next role-aware rotation. Remote and OAuth dashboard authentication
+   are unaffected. *)
+let dashboard_dev_role = Masc_domain.Admin
 
 type dashboard_dev_token =
   { raw : string

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -32,11 +32,13 @@ val ensure_dashboard_dev_token :
   ?load:(string -> string) ->
   ?write:(string -> string -> (unit, string) result) ->
   string -> (dashboard_dev_token, token_error) result
-(** Return the reusable Worker token or resume/create one role-aware rotation.
-    Rotation is serialized across Eio and non-Eio callers and is protected
-    against cancellation after the durable transaction starts. Optional I/O
-    functions are scoped to this call so failure-path tests do not mutate
-    process-global credential behavior. *)
+(** Return the reusable Admin token or resume/create one role-aware rotation.
+    The loopback dev-token is the local operator's own session, so the
+    dashboard credential is issued as Admin; a stored token whose credential
+    role differs rotates. Rotation is serialized across Eio and non-Eio
+    callers and is protected against cancellation after the durable
+    transaction starts. Optional I/O functions are scoped to this call so
+    failure-path tests do not mutate process-global credential behavior. *)
 
 val ensure_dashboard_dev_token_for_authority :
   request_authority:Server_request_authority.authority ->

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -134,6 +134,7 @@ normal_targets=(
   @test/runtest-test_process_eio_coverage
   @test/runtest-test_keeper_secret_redaction
   @test/runtest-test_keeper_sandbox_docker_route
+  @test/runtest-test_dashboard_dev_token_host_gate
   @test/keeper_github_identity/runtest
 )
 

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -104,20 +104,20 @@ let create_persisted_dashboard_token base_path role =
     raw
 ;;
 
-let test_existing_admin_token_rotates_to_worker () =
+let test_existing_worker_token_rotates_to_admin () =
   with_temp_base "masc-dev-token-role-" (fun base_path ->
-    let admin_raw = create_persisted_dashboard_token base_path Masc_domain.Admin in
+    let worker_raw = create_persisted_dashboard_token base_path Masc_domain.Worker in
     match Dev_token.ensure_dashboard_dev_token base_path with
     | Error error -> fail (Dev_token.token_error_to_string error)
     | Ok token ->
-      check bool "admin bearer rotated" true (not (String.equal admin_raw token.raw));
+      check bool "worker bearer rotated" true (not (String.equal worker_raw token.raw));
       check string "canonical actor" "dashboard" token.actor;
-      check string "declared role" "worker"
+      check string "declared role" "admin"
         (Masc_domain.agent_role_to_string token.role);
       (match Auth.find_credential_by_token base_path ~token:token.raw with
        | Error err -> fail (Masc_domain.masc_error_to_string err)
        | Ok credential ->
-         check string "persisted credential role" "worker"
+         check string "persisted credential role" "admin"
            (Masc_domain.agent_role_to_string credential.role));
       (match
          Auth.check_permission
@@ -126,23 +126,10 @@ let test_existing_admin_token_rotates_to_worker () =
            ~token:(Some token.raw)
            ~permission:Masc_domain.CanAdmin
        with
-       | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
-       | Error err ->
-         failf
-           "Worker CanAdmin denial had wrong reason: %s"
-           (Masc_domain.masc_error_to_string err)
-       | Ok () -> fail "dashboard Worker token retained CanAdmin");
-      (match
-         Auth.check_permission
-           base_path
-           ~agent_name:"dashboard"
-           ~token:(Some token.raw)
-           ~permission:Masc_domain.CanVote
-       with
        | Ok () -> ()
        | Error err ->
          failf
-           "dashboard Worker token lost CanVote: %s"
+           "dashboard Admin token denied CanAdmin: %s"
            (Masc_domain.masc_error_to_string err));
       check
         int
@@ -150,21 +137,21 @@ let test_existing_admin_token_rotates_to_worker () =
         0o600
         ((Unix.stat (Dev_token.dashboard_dev_token_path base_path)).Unix.st_perm
          land 0o777);
-      (match Auth.find_credential_by_token base_path ~token:admin_raw with
+      (match Auth.find_credential_by_token base_path ~token:worker_raw with
        | Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _)) -> ()
        | Error err ->
          failf
-           "old admin token failed with wrong reason: %s"
+           "old worker token failed with wrong reason: %s"
            (Masc_domain.masc_error_to_string err)
-       | Ok _ -> fail "old admin token remains valid after rotation"))
+       | Ok _ -> fail "old worker token remains valid after rotation"))
 ;;
 
-let test_existing_worker_token_is_reused () =
+let test_existing_admin_token_is_reused () =
   with_temp_base "masc-dev-token-reuse-" (fun base_path ->
-    let worker_raw = create_persisted_dashboard_token base_path Masc_domain.Worker in
+    let admin_raw = create_persisted_dashboard_token base_path Masc_domain.Admin in
     match Dev_token.ensure_dashboard_dev_token base_path with
     | Error error -> fail (Dev_token.token_error_to_string error)
-    | Ok token -> check string "worker bearer reused" worker_raw token.raw)
+    | Ok token -> check string "admin bearer reused" admin_raw token.raw)
 ;;
 
 let test_invalid_pending_token_fails_closed () =
@@ -183,7 +170,7 @@ let test_invalid_pending_token_fails_closed () =
 
 let test_rotation_write_failure_reuses_pending_token () =
   with_temp_base "masc-dev-token-pending-" (fun base_path ->
-    let admin_raw = create_persisted_dashboard_token base_path Masc_domain.Admin in
+    let stale_raw = create_persisted_dashboard_token base_path Masc_domain.Worker in
     let token_path = Dev_token.dashboard_dev_token_path base_path in
     let write path raw =
       if String.equal path token_path
@@ -200,18 +187,43 @@ let test_rotation_write_failure_reuses_pending_token () =
     let pending_path = Dev_token.dashboard_dev_token_pending_path base_path in
     check bool "pending token retained" true (Sys.file_exists pending_path);
     let pending_raw = String.trim (Fs_compat.load_file pending_path) in
-    (match Auth.find_credential_by_token base_path ~token:admin_raw with
+    (match Auth.find_credential_by_token base_path ~token:stale_raw with
      | Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _)) -> ()
      | Error err ->
        failf
-         "old admin token failed with wrong reason: %s"
+         "old worker token failed with wrong reason: %s"
          (Masc_domain.masc_error_to_string err)
-     | Ok _ -> fail "old admin token reactivated after partial rotation");
+     | Ok _ -> fail "old worker token reactivated after partial rotation");
     match Dev_token.ensure_dashboard_dev_token base_path with
     | Error error -> fail (Dev_token.token_error_to_string error)
     | Ok token ->
       check string "exact pending token published" pending_raw token.raw;
       check bool "pending token cleared" false (Sys.file_exists pending_path))
+;;
+
+let test_fresh_issuance_grants_admin () =
+  with_temp_base "masc-dev-token-fresh-" (fun base_path ->
+    match Dev_token.ensure_dashboard_dev_token base_path with
+    | Error error -> fail (Dev_token.token_error_to_string error)
+    | Ok token ->
+      check string "canonical actor" "dashboard" token.actor;
+      check string "declared role" "admin"
+        (Masc_domain.agent_role_to_string token.role);
+      (match
+         Auth.check_permission
+           base_path
+           ~agent_name:"dashboard"
+           ~token:(Some token.raw)
+           ~permission:Masc_domain.CanAdmin
+       with
+       | Ok () -> ()
+       | Error err ->
+         failf
+           "fresh dev token denied CanAdmin: %s"
+           (Masc_domain.masc_error_to_string err));
+      (match Dev_token.ensure_dashboard_dev_token base_path with
+       | Error error -> fail (Dev_token.token_error_to_string error)
+       | Ok reissued -> check string "admin bearer reused" token.raw reissued.raw))
 ;;
 
 let () =
@@ -228,13 +240,13 @@ let () =
             `Quick
             test_read_failure_does_not_mint_credential
         ; test_case
-            "existing admin token rotates to worker"
+            "existing worker token rotates to admin"
             `Quick
-            test_existing_admin_token_rotates_to_worker
+            test_existing_worker_token_rotates_to_admin
         ; test_case
-            "existing worker token is reused"
+            "existing admin token is reused"
             `Quick
-            test_existing_worker_token_is_reused
+            test_existing_admin_token_is_reused
         ; test_case
             "invalid pending token fails closed"
             `Quick
@@ -243,6 +255,12 @@ let () =
             "rotation write failure reuses pending token"
             `Quick
             test_rotation_write_failure_reuses_pending_token
+        ] )
+    ; ( "loopback admin issuance"
+      , [ test_case
+            "fresh issuance grants admin"
+            `Quick
+            test_fresh_issuance_grants_admin
         ] )
     ]
 ;;


### PR DESCRIPTION
## 배경

로컬 대시보드의 admin 세션이 반복적으로 끊긴다. 원인은 두 겹:

1. dev-token 부트스트랩이 `dashboard` credential 을 항상 **Worker** 로 발급 → admin 게이트 표면(Keeper GitHub CLI identity 등 `CanAdmin`)이 자동 세션을 거부.
2. 수동으로 붙여넣은 admin 토큰은 dev-token 경로의 **role-aware rotation** 이 "role 이 다른 dashboard credential" 로 판정해 다음 부트스트랩 사이클에 revoke — 조용한 탈인가가 반복 (`test_existing_admin_token_rotates_to_worker` 가 이 동작을 고정하고 있었다).

Worker 상한이 지키는 것은 없다: 엔드포인트는 exact loopback Host 전용 + strict-auth 에서 부재, 같은 머신 프로세스는 어차피 `.masc/auth/*.token` 을 읽을 수 있다. 이 표면에서 Worker 는 경계가 아니라 마찰이었다.

RFC: `docs/rfc/RFC-dashboard-dev-token-configured-role.md` (신규, 본 PR 포함).

## 변경 (설정 없음 — 상수 전환)

- 발급 role 상수 `Worker → Admin`. env knob·엔드포인트·파라미터 추가 없음.
- 기존 role-aware rotation 이 업그레이드 후 첫 부트스트랩에서 저장된 Worker 토큰을 Admin 으로 자연 수렴.
- 클라이언트 identity 계약을 `role === 'admin'` 으로 전환 (stale Worker 응답은 기존의 non-Worker 거부와 동일하게 거부). 구버전 저장 meta(`worker`)는 파싱 null → 조용한 재부트스트랩 1회로 이행.
- **CI 배선 동봉**: `test_dashboard_dev_token_host_gate` 스위트도 focused 목록에 없던 미배선 상태 — normal_targets 에 추가, 본 PR CI 부터 실제 실행.

## 검증

- `dune build @check` clean (cold worktree)
- `@test/runtest-test_dashboard_dev_token_host_gate`: 기존 게이트/회전 계약 유지 + 방향 반전 (worker→admin 회전·구토큰 무효화·0600 모드, admin 재사용, fresh 발급 CanAdmin 통과)
- dashboard vitest (`core.test.ts`, `dev-token.test.ts`) + `tsc --noEmit` + eslint

## 적용 (로컬)

머지 후 masc-mcp pull → rebuild → 재기동이 전부다. env 설정 불필요. 브라우저는 스스로 재부트스트랩한다 (수동 paste 토큰이 남아 있으면 그것만 한 번 비우면 됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
