### PR TITLE
fix(build): stop raw and parsed auth policy sharing field names

### DIFF
--- a/lib/server/server_auth_config.ml
+++ b/lib/server/server_auth_config.ml
@@ -16,9 +16,17 @@ type resolve_error =
       ; raw : string
       }
 
+(* [t] holds what [raw] parsed to. Its fields are named apart from [raw]'s
+   on purpose: while both records described the same two settings under the
+   same two names, every field access resolved against whichever type was
+   defined last, and read as a type error at some unrelated line -- twice so
+   far, at [read_env] and at [resolve]. Distinct names close that off instead
+   of asking each new function to annotate its way out. [t] is abstract in
+   the interface, so these names stay internal and the accessors below keep
+   the public vocabulary. *)
 type t =
-  { allow_anonymous_mutations : bool
-  ; loopback_dev_mutation_origins : Server_request_authority.serialized_origin list
+  { anonymous_mutations_allowed : bool
+  ; allowlisted_dev_origins : Server_request_authority.serialized_origin list
   }
 
 let read_env () : raw =
@@ -56,7 +64,7 @@ let parse_origins values =
 
 let resolve raw =
   let open Result.Syntax in
-  let* allow_anonymous_mutations =
+  let* anonymous_mutations_allowed =
     parse_boolean
       ~name:allow_anonymous_mutations_env
       raw.allow_anonymous_mutations
@@ -66,16 +74,16 @@ let resolve raw =
     | Some configured -> split_csv_nonempty configured
     | None -> Masc_network_defaults.vite_dev_default_origins
   in
-  let+ loopback_dev_mutation_origins = parse_origins origin_values in
-  { allow_anonymous_mutations; loopback_dev_mutation_origins }
+  let+ allowlisted_dev_origins = parse_origins origin_values in
+  { anonymous_mutations_allowed; allowlisted_dev_origins }
 ;;
 
 let fail_closed =
-  { allow_anonymous_mutations = false; loopback_dev_mutation_origins = [] }
+  { anonymous_mutations_allowed = false; allowlisted_dev_origins = [] }
 ;;
 
-let allow_anonymous_mutations config = config.allow_anonymous_mutations
-let loopback_dev_mutation_origins config = config.loopback_dev_mutation_origins
+let allow_anonymous_mutations config = config.anonymous_mutations_allowed
+let loopback_dev_mutation_origins config = config.allowlisted_dev_origins
 
 let resolve_error_to_string = function
   | Malformed_boolean { name; raw } ->

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -260,7 +260,16 @@ let test_dynamic_tool_progress_does_not_trip_the_repeat_guard () =
     let tool, terminal_error =
       one_dynamic_tool ~active (fun _input ->
         incr executions;
-        Error (Printf.sprintf "changing failure %d" !executions))
+        (* Identical in every field to the repeat-guard fixture above except
+           the message, which is the variable under test: the guard
+           fingerprints the tool's output, so a message that changes must not
+           accumulate toward the repeat threshold. *)
+        Error
+          { Agent_core.Types.message =
+              Printf.sprintf "changing failure %d" !executions
+          ; recoverable = false
+          ; error_class = Some Agent_core.Types.Deterministic
+          })
     in
     for index = 1 to 10 do
       let result =


### PR DESCRIPTION
main 이 컴파일되지 않습니다. 두 건이 남았고, 둘 다 **한 결함이 파일 안 여러 지점에 있는데 지점 단위로 고쳐지는** 형태입니다.

## 1. `server_auth_config.ml` — 레코드 필드 섀도잉

```
File "lib/server/server_auth_config.ml", line 62, characters 6-35:
62 |       raw.allow_anonymous_mutations
Error: The field access raw.allow_anonymous_mutations has type bool
       but an expression was expected of type string option
```

`raw` 와 `t` 가 **같은 두 필드 이름**을 씁니다.

```ocaml
type raw =
  { allow_anonymous_mutations : string option
  ; loopback_dev_mutation_origins : string option
  }

type t =
  { allow_anonymous_mutations : bool
  ; loopback_dev_mutation_origins : Server_request_authority.serialized_origin list
  }
```

OCaml 은 필드 접근을 **나중에 정의된 타입**으로 해석하므로, `raw` 를 다루는 모든 코드가 `t` 로 읽힙니다. 에러는 필드가 겹치는 지점이 아니라 그 값을 쓰는 엉뚱한 줄에서 납니다.

이게 이 파일에서 **두 번째**입니다. `#28345` 가 도입했고, `#28351` 이 `read_env` 에 `: raw` 어노테이션을 달아 한 지점을 막았습니다. `resolve` 는 그대로 남아 이번에 터졌습니다.

**어노테이션 한 줄(`let resolve (raw : raw) =`)로도 빌드는 통과합니다.** 그렇게 하지 않은 이유는, 그게 두 번째 지점별 패치이고 세 번째를 막지 못하기 때문입니다. 함정은 남고, 이 두 타입을 건드리는 다음 함수가 같은 방식으로 걸립니다.

대신 겹침 자체를 없앱니다. `t` 는 `.mli` 에서 **abstract** 이므로 필드 이름이 모듈 밖으로 나가지 않습니다:

```ocaml
type t =
  { anonymous_mutations_allowed : bool
  ; allowlisted_dev_origins : Server_request_authority.serialized_origin list
  }
```

접근자는 공개 어휘를 그대로 유지합니다:

```ocaml
let allow_anonymous_mutations config = config.anonymous_mutations_allowed
let loopback_dev_mutation_origins config = config.allowlisted_dev_origins
```

**`.mli` 는 변경되지 않습니다.** 공개 API 동일, 동작 동일. 이제 어떤 함수도 어노테이션 없이 옳게 해석됩니다.

## 2. `test_keeper_official_client_host.ml:263` — 타입 없는 tool error

```
263 |         Error (Printf.sprintf "changing failure %d" !executions))
Error: This expression has type string but an expression was expected of type
         Llm_provider.Types.tool_error
```

같은 파일 `:227` 이 이미 같은 이유로 고쳐졌고 이 지점만 남았습니다. 위 fixture 와 **메시지를 빼고 전 필드를 동일하게** 맞춥니다:

```ocaml
Error
  { Agent_core.Types.message =
      Printf.sprintf "changing failure %d" !executions
  ; recoverable = false
  ; error_class = Some Agent_core.Types.Deterministic
  }
```

이 테스트(`test_dynamic_tool_progress_does_not_trip_the_repeat_guard`)의 독립 변수는 **메시지가 매번 달라진다**는 것 하나입니다. repeat guard 는 툴 출력을 fingerprint 하므로, 나머지 필드를 위 fixture 와 같게 두어야 "메시지가 달라지면 임계에 누적되지 않는다"만 검증됩니다.

`error_class = Some Deterministic` 이 매번 달라지는 실패에 어울리지 않는다는 반론이 가능합니다. `Transient` / `None` 도 후보였지만, 두 테스트 사이에 두 개의 변수를 두지 않는 쪽을 택했습니다. 다르게 보시면 바꾸겠습니다.

## 검증

```
dune build --root . lib/server/    → exit 0, Error 0 건
```

1 번(`server_auth_config.ml`)은 이것으로 확인됩니다.

2 번(테스트 fixture)은 **확인하지 않았습니다.** 전체 빌드가 이 환경에서 툴 시간 한도를 넘고, 사용자가 직접 빌드하기로 했습니다. 테스트 실행도 하지 않았습니다 — 타입이 맞는지도 컴파일러로 확인되지 않은 상태입니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
