### PR TITLE
fix(test): type the remaining dynamic-tool failure fixture

### DIFF
--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -260,7 +260,12 @@ let test_dynamic_tool_progress_does_not_trip_the_repeat_guard () =
     let tool, terminal_error =
       one_dynamic_tool ~active (fun _input ->
         incr executions;
-        Error (Printf.sprintf "changing failure %d" !executions))
+        Error
+          { Agent_core.Types.message =
+              Printf.sprintf "changing failure %d" !executions
+          ; recoverable = false
+          ; error_class = Some Agent_core.Types.Deterministic
+          })
     in
     for index = 1 to 10 do
       let result =


### PR DESCRIPTION
## Why

PR #28349 converted one handler to the typed tool_error contract, but the same helper still had a second handler returning Error string. That leaves the test target uncompilable.

## Change

Convert the changing-failure fixture to Agent_core.Types.tool_error while preserving its distinct per-call message and deterministic classification.

## Checks

- git diff --check
- ocamlformat --check test/test_keeper_official_client_host.ml
- Local Dune build intentionally not run per operator request; exact-head CI is the build authority.

## Review

Addresses #28349 review thread.