### PR TITLE
fix(runtime): consume the CLI terminal_reason verdict for context overflow

### DIFF
--- a/docs/rfc/RFC-claude-code-context-overflow-bounded-restart.md
+++ b/docs/rfc/RFC-claude-code-context-overflow-bounded-restart.md
@@ -303,9 +303,19 @@ generic untyped `tool_call(name, json)`로 policy boundary를 우회하는 설�
 
 ### 11.1 Adapter classification
 
-1. exact prompt-too-long 400만 typed context overflow가 된다.
-2. unrelated 400, case drift, 중간 substring은 generic failure로 남는다.
-3. tool/response activity flag가 terminal error에 보존된다.
+(2026-08-12 개정: CLI 2.1.228 result frame의 `terminal_reason` enum이
+`prompt_too_long`을 실제 방출함을 강제 overflow stdio 캡처로 확증하여 분류
+권위를 typed 축으로 이관했다. prose prefix는 enum 미방출 구버전 CLI 전용
+폴백으로만 남으며 범위를 확장하지 않는다.)
+
+1. `terminal_reason:"prompt_too_long"`을 보고한 frame은 status·문구와 무관하게
+   typed context overflow가 된다.
+2. `terminal_reason`이 다른 값이면 문구가 overflow prefix와 일치해도 generic
+   failure로 남는다 (typed 판정이 양방향 권위).
+3. `terminal_reason`이 없는 frame(구버전 CLI)에서만 exact prompt-too-long 400이
+   typed context overflow가 된다.
+4. unrelated 400, case drift, 중간 substring은 generic failure로 남는다.
+5. tool/response activity flag가 terminal error에 보존된다.
 
 ### 11.2 Frozen episode
 

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -681,6 +681,7 @@ let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
   else
     let* turn_id = required_string stage "uuid" fields in
     let* api_error_status = optional_int stage "api_error_status" fields in
+    let* terminal_reason = optional_string stage "terminal_reason" fields in
     let result =
       match List.assoc_opt "result" fields with
       | None | Some `Null -> Ok None
@@ -690,11 +691,11 @@ let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
     let* result = result in
     (* The keeper side of this runtime hardcoded [usage = None] while the
        antigravity runtime fills the same slot from its CLI stream, which is why
-       official-client turns carry no input_tokens (#28023) and why a turn that
-       exceeds the window is only discoverable from the provider's prose
-       (#27427). Read leniently: a turn must not fail because its usage block is
-       absent or shaped differently than expected, and an absent value after
-       this lands means the CLI does not send one. *)
+       official-client turns carry no input_tokens (#28023) and why a window
+       overflow is discovered from the result frame's own verdict below rather
+       than from token counts (#27427). Read leniently: a turn must not fail
+       because its usage block is absent or shaped differently than expected,
+       and an absent value after this lands means the CLI does not send one. *)
     let usage =
       match List.assoc_opt "usage" fields with
       | None | Some `Null -> None
@@ -731,13 +732,25 @@ let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
          | Some _ | None -> "")
     in
     let provider_reported_context_window_exceeded =
-      Option.equal Int.equal api_error_status (Some 400)
-      && Option.exists
-           (fun detail ->
-              String.starts_with
-                ~prefix:"Prompt is too long"
-                (String.trim detail))
-           result
+      (* The CLI states why its query loop terminated as a typed enum on this
+         frame; [prompt_too_long] is the CLI's own promotion of every provider
+         context-window rejection ("Prompt is too long" / "Input is too long
+         for requested model", either status, or a 413 naming the window). A
+         frame that carries the verdict is authoritative in both directions,
+         like the codex lane's [codexErrorInfo]. Frames from CLIs that predate
+         the enum carry no [terminal_reason]; only those fall back to the
+         historical exact-prefix 400, unchanged in scope (RFC amendment
+         2026-08-12). *)
+      match terminal_reason with
+      | Some reason -> String.equal reason "prompt_too_long"
+      | None ->
+        Option.equal Int.equal api_error_status (Some 400)
+        && Option.exists
+             (fun detail ->
+                String.starts_with
+                  ~prefix:"Prompt is too long"
+                  (String.trim detail))
+             result
     in
     if structurally_quota_blocked
     then Error (Quota_blocked { api_error_status; rate_limit })
@@ -752,7 +765,8 @@ let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
     else if is_error
     then
       (* [result] is the one field on this frame that says why the turn failed.
-         The exact prompt-too-long 400 prefix above has its own typed path;
+         The prompt-too-long verdict above (typed [terminal_reason], or the
+         exact 400 prefix for pre-enum CLIs) has its own typed path;
          unrelated 400s and every other terminal rejection still retain the
          provider's sentence instead of collapsing to the status code
          (#28071). *)

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -408,10 +408,19 @@ let generic_400_result =
   {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-generic","result":"request rejected; diagnostic mentioned Prompt is too long without the provider prefix","api_error_status":400}|}
 ;;
 
+let prompt_too_long_typed_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-413-1","result":"Input is too long for requested model","api_error_status":413,"terminal_reason":"prompt_too_long"}|}
+;;
+
+let non_overflow_reason_with_prefix_prose_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-misprose","result":"Prompt is too long · gateway relayed the sentence for an unrelated rejection","api_error_status":400,"terminal_reason":"api_error"}|}
+;;
+
 (* A live keeper reported Claude's explicit "prompt is too long" terminal as a
    generic 400, so the provider-bound history shrinker never saw the typed
-   ContextOverflow it consumes. The status and provider sentence together are
-   the admission evidence; unrelated 400s stay generic below. *)
+   ContextOverflow it consumes. This fixture carries no [terminal_reason], so
+   it now exercises the pre-enum fallback: the status and provider sentence
+   together are the admission evidence; unrelated 400s stay generic below. *)
 let test_terminal_prompt_too_long_is_typed () =
   with_fixture [ Emit prompt_too_long_result ] (fun path ->
     match run_fixture path with
@@ -443,6 +452,40 @@ let test_unrelated_400_remains_turn_failed () =
         (Astring.String.is_infix ~affix:"diagnostic mentioned" detail)
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "an unrelated 400 terminal was reported as completion")
+;;
+
+(* CLI 2.1.228+ states the loop outcome as [terminal_reason]; a live forced
+   overflow emitted "prompt_too_long" while the sentence and status took the
+   413 shape. The typed verdict must classify without the prefix-400 shape. *)
+let test_terminal_reason_prompt_too_long_is_typed () =
+  with_fixture [ Emit prompt_too_long_typed_result ] (fun path ->
+    match run_fixture path with
+    | Error
+        (Runtime_claude_code.Context_window_exceeded
+          { message; tool_effect_attempted = false; response_emitted = false }) ->
+      check
+        bool
+        "provider sentence survives into the typed failure"
+        true
+        (Astring.String.is_infix ~affix:"Input is too long" message)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "a typed overflow terminal was reported as completion")
+;;
+
+(* When the frame carries a verdict it is authoritative in both directions: a
+   non-overflow reason stays generic even when the prose repeats the exact
+   overflow prefix. *)
+let test_non_overflow_reason_beats_prefix_prose () =
+  with_fixture [ Emit non_overflow_reason_with_prefix_prose_result ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Turn_failed detail) ->
+      check
+        bool
+        "generic rejection keeps the provider sentence"
+        true
+        (Astring.String.is_infix ~affix:"gateway relayed" detail)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "a non-overflow terminal was reported as completion")
 ;;
 
 let test_quota_is_structurally_classified () =
@@ -1199,6 +1242,14 @@ let () =
             "terminal prompt too long is typed"
             `Quick
             test_terminal_prompt_too_long_is_typed
+        ; test_case
+            "terminal_reason prompt_too_long is typed"
+            `Quick
+            test_terminal_reason_prompt_too_long_is_typed
+        ; test_case
+            "non-overflow terminal_reason beats prefix prose"
+            `Quick
+            test_non_overflow_reason_beats_prefix_prose
         ; test_case
             "unrelated 400 remains turn failed"
             `Quick


### PR DESCRIPTION
## 배경 — 검사≠의미 감사의 P0

#28284는 context overflow를 `api_error_status=400 ∧ starts_with "Prompt is too long"`으로 분류합니다. CLI 자체 분류표는 같은 실패에 문구 2종("Prompt is too long" / "Input is too long for requested model") · status 무관 · 413을 인정하므로 검사가 의미보다 좁고, 미스매치는 이 수정이 닫으려던 livelock(generic Turn_failed → Recovery_required → auto-supersede → 재렌더 → 400 반복)으로 무신호 회귀합니다.

당초 정당화 전제("CLI가 이 failure에 구조화 enum을 제공하지 않는다")는 이중으로 반증됐습니다.

- 스키마: CLI 2.1.228 바이너리의 result frame 스키마에 `terminal_reason` enum이 있고 `prompt_too_long`이 일급 값입니다.
- 방출 (2026-08-12 라이브 캡처): 강제 overflow에서 `"terminal_reason":"prompt_too_long"` + `api_error_status:400` + `is_error:true` 실측. 대조 실측 — 1M 창 성공 턴은 `"completed"`, 401은 `"api_error"`. optional 스키마지만 세 경로 모두 실제로 채워집니다.

## 변경

- `parse_result`가 result frame의 `terminal_reason`을 읽습니다 (`optional_string` — 구버전 CLI frame에는 없음).
- overflow 판별 권위를 typed 축으로 이관:
  - `terminal_reason`이 있으면 그 값이 양방향 권위입니다. `"prompt_too_long"`이면 status·문구와 무관하게 `Context_window_exceeded`, 다른 값이면 문구가 overflow prefix와 일치해도 generic으로 남습니다. codex 레인의 `codexErrorInfo = "contextWindowExceeded"` 소비와 동형입니다.
  - `terminal_reason`이 없으면(enum 미방출 구버전 CLI) 기존 400+prefix 폴백이 그대로 결정합니다 — 문자열 분류 축의 범위 확장 없음.
- RFC(`docs/rfc/RFC-claude-code-context-overflow-bounded-restart.md`) §11.1 개정: typed 권위와 폴백 경계를 요구 테스트로 명문화.
- 테스트 4분면 고정: typed-양성(413+enum), typed-음성(다른 enum + prefix 문구 → generic), 폴백-양성(enum 없는 400+prefix, 기존 유지), 폴백-음성(기존 generic 400 유지).

## 검증

- 로컬 빌드·테스트는 이 PR 생성 시점에 **미완료**입니다 — 소유자가 직접 빌드하기로 하여 PR을 먼저 올립니다.
- 세션의 격리 빌드(`dune build --root .` + `test_runtime_claude_code.exe` 전체 + fmt)는 백그라운드 진행 중이며, 완료되는 대로 결과를 이 PR 코멘트로 남깁니다.
- 계획된 mutation check: 새 typed-양성 테스트(413+enum)는 변경 전 분류기(400+prefix 요구)에서 generic으로 떨어져 실패해야 합니다 — 결과도 코멘트로.

## 영향 범위

`parse_result` 내부 분류식 하나입니다. 에러 variant, shrink 시퀀스, keeper 매핑은 무변경. 방출 확증 근거와 무비용 재현 명령(200K 창 모델 + 초과 프롬프트)은 세션 메모리에 기록돼 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
