### PR TITLE
refactor(registry): swap immutable client state

### DIFF
--- a/lib/client_identity.ml
+++ b/lib/client_identity.ml
@@ -10,8 +10,6 @@
     @since 0.5.0
 *)
 
-module StringMap = Set_util.StringMap
-
 (** Typed classification of a session_key's display prefix.
 
     Replaces the previous string-collapsing helpers that mapped
@@ -216,103 +214,6 @@ let anonymous () =
     last_seen = now;
     metadata = [];
   }
-
-(** {1 Identity Registry} *)
-
-module Registry = struct
-  type registry = {
-    identities : t StringMap.t ref;  (** session_key -> identity *)
-    by_agent_name : string StringMap.t ref;  (** agent_name -> session_key *)
-    lock : Eio.Mutex.t;
-  }
-
-  let create () = {
-    identities = ref StringMap.empty;
-    by_agent_name = ref StringMap.empty;
-    lock = Eio.Mutex.create ();
-  }
-
-  let with_lock reg f =
-    Eio_guard.with_mutex reg.lock f
-
-  (** Register or update identity *)
-  let register reg identity =
-    with_lock reg (fun () ->
-      reg.identities := StringMap.add identity.session_key identity !(reg.identities);
-      reg.by_agent_name := StringMap.add identity.agent_name identity.session_key !(reg.by_agent_name);
-      identity
-    )
-
-  (** Find by session key *)
-  let find_by_session reg session_key =
-    with_lock reg (fun () ->
-      StringMap.find_opt session_key !(reg.identities)
-    )
-
-  (** Find by agent name *)
-  let find_by_name reg agent_name =
-    with_lock reg (fun () ->
-      match StringMap.find_opt agent_name !(reg.by_agent_name) with
-      | Some session_key -> StringMap.find_opt session_key !(reg.identities)
-      | None -> None
-    )
-
-  (** Update last_seen *)
-  let touch reg session_key () =
-    with_lock reg (fun () ->
-      match StringMap.find_opt session_key !(reg.identities) with
-      | Some identity ->
-          (* The map owns the identity, so a touch rebinds the entry. Only
-             [identities] holds the record — [by_agent_name] maps a name to a
-             session key — so one rebind is the whole update. *)
-          reg.identities :=
-            StringMap.add session_key
-              { identity with last_seen = Time_compat.now () }
-              !(reg.identities)
-      | None -> ()
-    )
-
-  (** Remove identity *)
-  let unregister reg session_key =
-    with_lock reg (fun () ->
-      match StringMap.find_opt session_key !(reg.identities) with
-      | Some identity ->
-          reg.identities := StringMap.remove session_key !(reg.identities);
-          let by_agent_name = StringMap.remove identity.agent_name !(reg.by_agent_name) in
-          let replacement =
-            StringMap.fold
-              (fun replacement_session candidate found ->
-                 match found with
-                 | Some _ -> found
-                 | None when String.equal candidate.agent_name identity.agent_name ->
-                   Some replacement_session
-                 | None -> None)
-              !(reg.identities)
-              None
-          in
-          reg.by_agent_name :=
-            (match replacement with
-             | None -> by_agent_name
-             | Some replacement_session ->
-               StringMap.add identity.agent_name replacement_session by_agent_name)
-      | None -> ()
-    )
-
-  (** List all registered identities. Lifecycle authority belongs to explicit
-      registration/unregistration, not an elapsed-time cutoff. *)
-  let list_all reg =
-    with_lock reg (fun () ->
-      !(reg.identities)
-      |> StringMap.bindings
-      |> List.map snd
-    )
-
-  (** Get identity count *)
-  let count reg =
-    with_lock reg (fun () ->
-      StringMap.cardinal !(reg.identities)
-    )
-end
 
 (** {1 Utilities} *)
 

--- a/lib/client_identity.mli
+++ b/lib/client_identity.mli
@@ -51,23 +51,6 @@ val generate_session_key : unit -> string
 val from_mcp_params : Yojson.Safe.t -> t
 val anonymous : unit -> t
 
-(** {1 Identity Registry} *)
-
-module Registry : sig
-  type registry
-
-  val create : unit -> registry
-  val register : registry -> t -> t
-  val find_by_session : registry -> string -> t option
-  val find_by_name : registry -> string -> t option
-  val touch : registry -> string -> unit -> unit
-  val unregister : registry -> string -> unit
-  val list_all : registry -> t list
-  (** All explicitly registered identities. [last_seen] remains observation
-      data and is not used as lifecycle authority. *)
-  val count : registry -> int
-end
-
 (** {1 Utilities} *)
 
 val has_capability : t -> string -> bool
@@ -79,4 +62,3 @@ val same_agent : t -> t -> bool
 val channel_to_yojson : channel -> Yojson.Safe.t
 val channel_of_yojson : Yojson.Safe.t -> (channel, string) Result.t
 val to_yojson : t -> Yojson.Safe.t
-

--- a/lib/client_registry_eio.ml
+++ b/lib/client_registry_eio.ml
@@ -3,67 +3,41 @@
     Provides a singleton registry for tracking agent identities across
     MCP tool calls. Integrates with Client_identity module.
 
-    Actor model: all mutable state is encapsulated in a single Mutex-protected
-    record.  The three previously independent global stores (identity registry,
-    session→key map, resolved-name cache) are now one coherent unit, eliminating
-    the TOCTOU window that existed between the old separate Atomic.t updates.
-
-    Usage:
-    - Call [init ()] once during server startup (within Eio context)
-    - Use [get_or_create_identity] in tool handlers
-    - Identity persists across tool calls via MCP session ID
+    Actor model: one immutable identity/session/cache snapshot is swapped behind
+    a single mutex. Identity materialization and logging stay outside the
+    critical section; pure transitions close creation races.
 
     @since 0.5.0
 *)
 
-module SMap = Set_util.StringMap
-
 (** {1 Actor State} *)
 
-(** Consolidated actor state – replaces three separate mutable globals.
-    Held behind a single Mutex so that read-modify-write sequences are
-    atomic (e.g. cache-miss create + map insert in [get_or_create_identity]). *)
-type state = {
-  registry : Client_identity.Registry.registry;
-  session_map : string SMap.t;   (** mcp_session_id → session_key *)
-  resolved_map : (string * bool) SMap.t;
-      (** mcp_session_id → (resolved agent_name, is_ephemeral).
-
-          [is_ephemeral] is decided at the write site from the typed
-          origin (identity provenance / own generated fallback), not
-          re-derived from the name string on read. *)
-}
-
-let make_state () = {
-  registry = Client_identity.Registry.create ();
-  session_map = SMap.empty;
-  resolved_map = SMap.empty;
-}
+module State = Client_registry_state
 
 (** Single process-wide actor state.  Protected by [state_mu]. *)
-let state : state ref = ref (make_state ())
+let state = ref State.empty
 let state_mu : Eio.Mutex.t = Eio.Mutex.create ()
 
-let with_state_rw f =
-  Eio.Mutex.use_rw ~protect:true state_mu (fun () -> f state)
+let apply_transition transition =
+  Eio.Mutex.use_rw ~protect:true state_mu (fun () ->
+    let next, value = transition !state in
+    state := next;
+    value)
+;;
 
-let with_state_ro f =
-  Eio.Mutex.use_ro state_mu (fun () -> f !state)
+let snapshot () =
+  Eio.Mutex.use_ro state_mu (fun () -> !state)
 
 (** {1 Initialization} *)
 
 (** Replace the registry and both session maps as one lifecycle operation. *)
 let clear_all () =
   Eio.Mutex.use_rw ~protect:true state_mu (fun () ->
-    state := make_state ()
+    state := State.empty
   )
 
 (** Reset registry for testing. *)
 let reset_for_testing () = clear_all ()
-
-(** {1 Internal helpers — must be called under [state_mu]} *)
-
-let get_registry_locked s = s.registry
 
 (** {1 Identity Resolution} *)
 
@@ -74,9 +48,11 @@ let get_registry_locked s = s.registry
     2. Extract identity from MCP params (_agent_name, _channel, etc.)
     3. Register new identity
 
-    The entire check-then-create sequence runs under [state_mu] so concurrent
-    callers with the same [mcp_session_id] are serialised — no more transient
-    orphan identities from the old lock-free path.
+    Existing sessions are touched in one atomic transition. A miss materializes
+    its candidate outside [state_mu], then commits through a second atomic
+    transition that rechecks ownership. Concurrent creators therefore converge
+    without running clock, randomness, nested locks, or logging under the state
+    mutex.
 
     @param mcp_session_id Optional MCP HTTP session ID
     @param params Tool call params (may contain _agent_name, etc.)
@@ -89,37 +65,41 @@ let get_or_create_identity ?mcp_session_id params =
        Return its typed identity without inserting an immortal registry row. *)
     Client_identity.from_mcp_params params
   | Some sid ->
-    with_state_rw (fun s ->
-      let reg = get_registry_locked !s in
-      match
-        Option.bind
-          (SMap.find_opt sid (!s).session_map)
-          (Client_identity.Registry.find_by_session reg)
-      with
-      | Some identity ->
-        Client_identity.Registry.touch reg identity.Client_identity.session_key ();
-        Option.value
-          (Client_identity.Registry.find_by_session reg identity.session_key)
-          ~default:identity
-      | None ->
-        let identity = Client_identity.from_mcp_params params in
-        let registered = Client_identity.Registry.register reg identity in
-        let s' =
-          { !s with
-            session_map =
-              SMap.add sid registered.Client_identity.session_key (!s).session_map
-          }
-        in
-        s := s';
-        Log.Session.info
-          "[AgentRegistry] New identity: %s (session=%s, mcp=%s)"
-          registered.agent_name
-          (String.sub
-             registered.session_key
-             0
-             (min 8 (String.length registered.session_key)))
-          sid;
-        registered)
+    let reused =
+      let now = Time_compat.now () in
+      apply_transition (fun state ->
+        match State.reuse_session ~now ~mcp_session_id:sid state with
+        | Some (next, identity) -> next, Some identity
+        | None -> state, None)
+    in
+    (match reused with
+     | Some identity -> identity
+     | None ->
+       (* Candidate materialization owns clock/random effects and therefore
+          stays outside [state_mu]. A second pure check at commit closes the
+          race with another creator for the same MCP session. *)
+       let candidate = Client_identity.from_mcp_params params in
+       let now = Time_compat.now () in
+       let outcome =
+         apply_transition (fun state ->
+           State.install_session
+             ~now
+             ~mcp_session_id:sid
+             ~candidate
+             state)
+       in
+       (match outcome with
+        | State.Reused identity -> identity
+        | State.Registered identity ->
+          Log.Session.info
+            "[AgentRegistry] New identity: %s (session=%s, mcp=%s)"
+            identity.agent_name
+            (String.sub
+               identity.session_key
+               0
+               (min 8 (String.length identity.session_key)))
+            sid;
+          identity))
 
 (** {1 Resolved Agent Name Cache}
 
@@ -127,36 +107,27 @@ let get_or_create_identity ?mcp_session_id params =
     ~180 lines of identity resolution on 2nd+ calls. *)
 
 let get_resolved_name sid =
-  with_state_ro (fun s -> SMap.find_opt sid s.resolved_map)
+  State.resolved_name (snapshot ()) sid
 
 let set_resolved_name sid name ~is_ephemeral =
-  with_state_rw (fun s ->
-    s := { !s with resolved_map = SMap.add sid (name, is_ephemeral) (!s).resolved_map }
-  )
+  apply_transition (fun state ->
+    ( State.cache_resolved_name
+        ~mcp_session_id:sid
+        ~name
+        ~is_ephemeral
+        state
+    , () ))
 
 (** {1 Statistics} *)
 
 (** Get total registered count *)
 let total_count () =
-  with_state_ro (fun s -> Client_identity.Registry.count s.registry)
+  State.count (snapshot ())
 
 (** {1 Cleanup} *)
 
 (** End one explicit MCP-session registration. The identity row is removed
     only when no other MCP session references the same session key. *)
 let unregister_mcp_session mcp_session_id =
-  with_state_rw (fun s ->
-    let reg = get_registry_locked !s in
-    match SMap.find_opt mcp_session_id (!s).session_map with
-    | None -> ()
-    | Some session_key ->
-      let session_map = SMap.remove mcp_session_id (!s).session_map in
-      let still_referenced =
-        SMap.exists (fun _ mapped -> String.equal mapped session_key) session_map
-      in
-      if not still_referenced then Client_identity.Registry.unregister reg session_key;
-      s :=
-        { !s with
-          session_map
-        ; resolved_map = SMap.remove mcp_session_id (!s).resolved_map
-        })
+  apply_transition (fun state ->
+    State.unregister_mcp_session ~mcp_session_id state, ())

--- a/lib/client_registry_eio.mli
+++ b/lib/client_registry_eio.mli
@@ -1,8 +1,8 @@
 (** Agent Registry Eio - Global agent identity tracking
 
-    Actor model: all mutable state (identity registry, session→key map,
-    resolved-name cache) is held in a single Mutex-protected record, removing
-    the TOCTOU race in the previous three-Atomic-store design.
+    Actor model: one immutable identity/session/cache snapshot is swapped
+    behind a single mutex. Identity materialization and logging stay outside
+    the critical section; pure transitions close creation races.
 
     @since 0.5.0
 *)

--- a/lib/client_registry_state.ml
+++ b/lib/client_registry_state.ml
@@ -1,0 +1,88 @@
+module String_map = Set_util.StringMap
+
+type t =
+  { identities : Client_identity.t String_map.t
+  ; session_map : string String_map.t
+  ; resolved_map : (string * bool) String_map.t
+  }
+
+type install_outcome =
+  | Registered of Client_identity.t
+  | Reused of Client_identity.t
+
+let empty =
+  { identities = String_map.empty
+  ; session_map = String_map.empty
+  ; resolved_map = String_map.empty
+  }
+;;
+
+let identity_for_mcp_session state mcp_session_id =
+  Option.bind
+    (String_map.find_opt mcp_session_id state.session_map)
+    (fun session_key -> String_map.find_opt session_key state.identities)
+;;
+
+let reuse_session ~now ~mcp_session_id state =
+  match identity_for_mcp_session state mcp_session_id with
+  | None -> None
+  | Some identity ->
+    let identity : Client_identity.t = { identity with last_seen = now } in
+    let identities =
+      String_map.add identity.Client_identity.session_key identity state.identities
+    in
+    Some ({ state with identities }, identity)
+;;
+
+let install_session ~now ~mcp_session_id ~candidate state =
+  match reuse_session ~now ~mcp_session_id state with
+  | Some (state, identity) -> state, Reused identity
+  | None ->
+    let identities =
+      String_map.add
+        candidate.Client_identity.session_key
+        candidate
+        state.identities
+    in
+    let session_map =
+      String_map.add
+        mcp_session_id
+        candidate.Client_identity.session_key
+        state.session_map
+    in
+    { state with identities; session_map }, Registered candidate
+;;
+
+let resolved_name state mcp_session_id =
+  String_map.find_opt mcp_session_id state.resolved_map
+;;
+
+let cache_resolved_name ~mcp_session_id ~name ~is_ephemeral state =
+  { state with
+    resolved_map =
+      String_map.add mcp_session_id (name, is_ephemeral) state.resolved_map
+  }
+;;
+
+let unregister_mcp_session ~mcp_session_id state =
+  match String_map.find_opt mcp_session_id state.session_map with
+  | None -> state
+  | Some session_key ->
+    let session_map = String_map.remove mcp_session_id state.session_map in
+    let still_referenced =
+      String_map.exists
+        (fun _ mapped_session_key -> String.equal mapped_session_key session_key)
+        session_map
+    in
+    let identities =
+      if still_referenced
+      then state.identities
+      else String_map.remove session_key state.identities
+    in
+    { identities
+    ; session_map
+    ; resolved_map = String_map.remove mcp_session_id state.resolved_map
+    }
+;;
+
+let count state = String_map.cardinal state.identities

--- a/lib/client_registry_state.ml
+++ b/lib/client_registry_state.ml
@@ -27,7 +27,8 @@ let reuse_session ~now ~mcp_session_id state =
   match identity_for_mcp_session state mcp_session_id with
   | None -> None
   | Some identity ->
-    let identity : Client_identity.t = { identity with last_seen = now } in
+    let last_seen = Float.max identity.last_seen now in
+    let identity : Client_identity.t = { identity with last_seen } in
     let identities =
       String_map.add identity.Client_identity.session_key identity state.identities
     in

--- a/lib/client_registry_state.mli
+++ b/lib/client_registry_state.mli
@@ -13,8 +13,9 @@ val empty : t
 
 val reuse_session :
   now:float -> mcp_session_id:string -> t -> (t * Client_identity.t) option
-(** Return and touch the identity already owned by [mcp_session_id]. A stale
-    session mapping whose identity is absent is treated as a miss. *)
+(** Return and touch the identity already owned by [mcp_session_id]. A delayed
+    caller cannot move [last_seen] behind a newer committed observation. A
+    stale session mapping whose identity is absent is treated as a miss. *)
 
 val install_session :
   now:float ->

--- a/lib/client_registry_state.mli
+++ b/lib/client_registry_state.mli
@@ -1,0 +1,41 @@
+(** Pure state transitions for MCP-session client identity ownership.
+
+    The outer [Client_registry_eio] shell supplies time and newly materialized
+    identities, then atomically swaps the returned immutable state. *)
+
+type t
+
+type install_outcome =
+  | Registered of Client_identity.t
+  | Reused of Client_identity.t
+
+val empty : t
+
+val reuse_session :
+  now:float -> mcp_session_id:string -> t -> (t * Client_identity.t) option
+(** Return and touch the identity already owned by [mcp_session_id]. A stale
+    session mapping whose identity is absent is treated as a miss. *)
+
+val install_session :
+  now:float ->
+  mcp_session_id:string ->
+  candidate:Client_identity.t ->
+  t ->
+  t * install_outcome
+(** Install [candidate] only if [mcp_session_id] is still unresolved. This
+    second check makes an outer resolve-materialize-commit sequence race-safe. *)
+
+val resolved_name : t -> string -> (string * bool) option
+
+val cache_resolved_name :
+  mcp_session_id:string ->
+  name:string ->
+  is_ephemeral:bool ->
+  t ->
+  t
+
+val unregister_mcp_session : mcp_session_id:string -> t -> t
+(** Remove one transport-session owner. Its identity is removed only after no
+    remaining MCP session refers to the same identity session key. *)
+
+val count : t -> int

--- a/lib/lockfree_atomic/lockfree_atomic.mli
+++ b/lib/lockfree_atomic/lockfree_atomic.mli
@@ -1,7 +1,7 @@
 (** Lock-free atomic update helpers built on [Atomic.compare_and_set].
 
-    Consolidates the CAS-loop pattern that has been duplicated across
-    lock-free registry refactors (agent_registry_eio, sse, tool_registry...).
+    Consolidates the CAS-loop pattern shared by current lock-free state owners
+    such as [Sse], [Subscriptions], and [Cache_eio].
 
     @since 0.11.x *)
 

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -9,6 +9,7 @@ packages/agent_core/lib/llm_provider/complete_stream_state.ml
 lib/server/server_runtime_param_request.ml
 lib/server/server_prompt_override_request.ml
 lib/mcp_server_eio_call_request.ml
+lib/client_registry_state.ml
 lib/schedule/schedule_domain.ml
 lib/turn_fsm/turn_fsm.ml
 lib/types/masc_domain.ml

--- a/test/test_client_identity.ml
+++ b/test/test_client_identity.ml
@@ -205,82 +205,6 @@ let test_to_display_string_empty_session_key () =
   check bool "empty session key display uses unknown prefix" true
     (str_contains display "(unknown)")
 
-(** Registry tests *)
-module RegistryTests = struct
-  (* Note: These tests require Eio runtime, run with test_integration *)
-  
-  let test_register_and_find () =
-    Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-    let reg = Client_identity.Registry.create () in
-    let identity = identity_for "test-agent" in
-    let _ = Client_identity.Registry.register reg identity in
-    
-    let found_by_session = Client_identity.Registry.find_by_session reg identity.session_key in
-    check bool "found by session" true (Option.is_some found_by_session);
-    
-    let found_by_name = Client_identity.Registry.find_by_name reg "test-agent" in
-    check bool "found by name" true (Option.is_some found_by_name)
-
-  let test_unregister () =
-    Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-    let reg = Client_identity.Registry.create () in
-    let identity = identity_for "test-agent" in
-    let registered = Client_identity.Registry.register reg identity in
-    
-    check int "count after register" 1 (Client_identity.Registry.count reg);
-    Client_identity.Registry.unregister reg registered.session_key;
-    check int "count after unregister" 0 (Client_identity.Registry.count reg)
-
-  let test_touch () =
-    Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-    let reg = Client_identity.Registry.create () in
-    (* Create identity with old timestamp *)
-    let old_time = Unix.gettimeofday () -. 10.0 in
-    let identity = Client_identity.({
-      (identity_for "test-agent") with
-      last_seen = old_time;
-      registered_at = old_time;
-    }) in
-    let _ = Client_identity.Registry.register reg identity in
-    
-    Client_identity.Registry.touch reg identity.session_key ();
-    
-    match Client_identity.Registry.find_by_session reg identity.session_key with
-    | Some updated ->
-        check bool "last_seen updated" true (updated.last_seen > old_time)
-    | None -> fail "identity not found after touch"
-
-  let test_list_all () =
-    Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-    let reg = Client_identity.Registry.create () in
-    let id1 = identity_for "active-agent" in
-    let id2 = Client_identity.({
-      (identity_for "stale-agent") with
-      last_seen = Unix.gettimeofday () -. 1000.0;
-      registered_at = Unix.gettimeofday () -. 1000.0;
-    }) in
-    
-    let _ = Client_identity.Registry.register reg id1 in
-    let _ = Client_identity.Registry.register reg id2 in
-    
-    let registered = Client_identity.Registry.list_all reg in
-    check int "all registered agents" 2 (List.length registered);
-    check bool "contains active agent" true
-      (List.exists
-         (fun (identity : Client_identity.t) ->
-            String.equal identity.agent_name "active-agent")
-         registered);
-    check bool "contains stale observation" true
-      (List.exists
-         (fun (identity : Client_identity.t) ->
-            String.equal identity.agent_name "stale-agent")
-         registered)
-end
-
 let () =
   run "Client_identity" [
     "basics", [
@@ -302,11 +226,5 @@ let () =
       test_case "same_agent" `Quick test_same_agent;
       test_case "to_display_string" `Quick test_to_display_string;
       test_case "to_display_string_empty_session_key" `Quick test_to_display_string_empty_session_key;
-    ];
-    "registry", [
-      test_case "register_and_find" `Quick RegistryTests.test_register_and_find;
-      test_case "unregister" `Quick RegistryTests.test_unregister;
-      test_case "touch" `Quick RegistryTests.test_touch;
-      test_case "list_all" `Quick RegistryTests.test_list_all;
     ];
   ]

--- a/test/test_client_registry_eio.ml
+++ b/test/test_client_registry_eio.ml
@@ -50,7 +50,14 @@ let test_pure_state_reuses_winner_after_race () =
      check string "race keeps installed identity" "first-key" identity.session_key;
      check (float 0.0) "race touches winner" 9.0 identity.last_seen
    | State.Registered _ -> fail "race replaced the installed identity");
-  check int "race leaves one identity" 1 (State.count state)
+  check int "race leaves one identity" 1 (State.count state);
+  let _, delayed_touch =
+    match State.reuse_session ~now:8.0 ~mcp_session_id:"shared-mcp" state with
+    | Some reused -> reused
+    | None -> fail "installed session disappeared before delayed touch"
+  in
+  check (float 0.0) "delayed touch cannot move last_seen backwards" 9.0
+    delayed_touch.last_seen
 ;;
 
 let test_pure_state_unregisters_last_owner () =

--- a/test/test_client_registry_eio.ml
+++ b/test/test_client_registry_eio.ml
@@ -3,7 +3,91 @@
 open Alcotest
 open Masc
 
-(* All tests must run within Eio context due to Eio.Mutex usage *)
+module State = Client_registry_state
+
+(* Shell tests run in Eio; the state-transition tests above the shell cases do
+   not need a runtime. *)
+
+let identity ~session_key ~agent_name ~last_seen : Client_identity.t =
+  { uuid = "00000000-0000-7000-8000-000000000000"
+  ; session_key
+  ; agent_name
+  ; agent_name_origin = `Supplied
+  ; channel = None
+  ; user_id = None
+  ; capabilities = []
+  ; registered_at = 1.0
+  ; last_seen
+  ; metadata = []
+  }
+;;
+
+let test_pure_state_reuses_winner_after_race () =
+  let first = identity ~session_key:"first-key" ~agent_name:"first" ~last_seen:1.0 in
+  let state, installed =
+    State.install_session
+      ~now:2.0
+      ~mcp_session_id:"shared-mcp"
+      ~candidate:first
+      State.empty
+  in
+  (match installed with
+   | State.Registered identity ->
+     check string "first candidate registered" "first-key" identity.session_key
+   | State.Reused _ -> fail "empty state unexpectedly reused an identity");
+  let competing =
+    identity ~session_key:"competing-key" ~agent_name:"competing" ~last_seen:3.0
+  in
+  let state, raced =
+    State.install_session
+      ~now:9.0
+      ~mcp_session_id:"shared-mcp"
+      ~candidate:competing
+      state
+  in
+  (match raced with
+   | State.Reused identity ->
+     check string "race keeps installed identity" "first-key" identity.session_key;
+     check (float 0.0) "race touches winner" 9.0 identity.last_seen
+   | State.Registered _ -> fail "race replaced the installed identity");
+  check int "race leaves one identity" 1 (State.count state)
+;;
+
+let test_pure_state_unregisters_last_owner () =
+  let shared =
+    identity ~session_key:"shared-key" ~agent_name:"shared" ~last_seen:1.0
+  in
+  let state, _ =
+    State.install_session
+      ~now:2.0
+      ~mcp_session_id:"owner-1"
+      ~candidate:shared
+      State.empty
+  in
+  let state, _ =
+    State.install_session
+      ~now:3.0
+      ~mcp_session_id:"owner-2"
+      ~candidate:shared
+      state
+  in
+  let state =
+    State.cache_resolved_name
+      ~mcp_session_id:"owner-2"
+      ~name:"shared"
+      ~is_ephemeral:false
+      state
+  in
+  let state = State.unregister_mcp_session ~mcp_session_id:"owner-2" state in
+  check int "shared identity remains" 1 (State.count state);
+  check
+    (option (pair string bool))
+    "closed owner cache removed"
+    None
+    (State.resolved_name state "owner-2");
+  let state = State.unregister_mcp_session ~mcp_session_id:"owner-1" state in
+  check int "last owner removes identity" 0 (State.count state)
+;;
 
 let test_init () =
   Eio_main.run @@ fun env ->
@@ -132,19 +216,9 @@ let test_concurrent_access () =
   ()
 
 (** Contract: N fibers racing to create an identity for the same
-    [mcp_session_id] must converge to a single [session_key].  This
-    is asserted even though under single-domain Eio with uncontended
-    Registry locks, [get_or_create_identity] currently executes
-    atomically and the race would not fire without the
-    double-checked locking fix.  The test defends the invariant
-    against future changes — a migration to multi-domain, a refactor
-    that introduces a yield between [Hashtbl.find_opt] and
-    [Hashtbl.replace], or Registry contention that forces
-    [reg.lock] to suspend — any of which would otherwise orphan the
-    first-seen identity because both fibers would observe [None] in
-    [session_identity_map], both [Registry.register] with a fresh
-    UUID [session_key], and only the last [Hashtbl.replace] would
-    win.  See lib/agent_registry_eio.ml [session_cache_mu] comment. *)
+    [mcp_session_id] converge to one [session_key]. Candidate materialization
+    happens outside the mutex, so [Client_registry_state.install_session] must
+    recheck the immutable snapshot at the atomic commit. *)
 let test_concurrent_same_mcp_session_id () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -178,6 +252,12 @@ let test_concurrent_same_mcp_session_id () =
 
 let () =
   run "Client_registry_eio" [
+    "pure state", [
+      test_case "race reuses winner" `Quick
+        test_pure_state_reuses_winner_after_race;
+      test_case "last owner removes identity" `Quick
+        test_pure_state_unregisters_last_owner;
+    ];
     "basics", [
       test_case "init" `Quick test_init;
       test_case


### PR DESCRIPTION
## Summary

- replace the nested mutable client identity registry with one immutable `Client_registry_state` snapshot
- materialize identity clock/random values and emit logs outside the registry mutex
- keep race closure as a pure second-check transition and delete the now-unused `Client_identity.Registry` API
- register the new state module with the typed pure-module ratchet

## Product impact

- User-visible change: none intended; MCP session identity continuity, touch timestamps, cache ownership, and last-owner cleanup are preserved

## Evidence

- `ocamlformat --check` passed for all touched OCaml source/test files
- `ocamlc -stop-after parsing` passed for all touched OCaml source/test files
- `git diff --check` passed
- deleted Registry API/reference check passed
- pure-core source check found no clock, random, Eio, mutex, atomic, log, filesystem, ref, or assignment effects
- local Dune build/tests intentionally not run per operator request; exact-head CI is the build authority

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

## GOAL LOOP ACT checklist

- [x] Observe — client registry held a second mutable registry and performed identity materialization plus logging under the outer state mutex
- [x] Orient — functional-core/effect-shell registry/cache sweep; immutable transition plus atomic swap
- [x] Decide — one bounded owner and its direct tests; no durable store or wire contract changes
- [x] Act — pure reuse/install/unregister/cache transitions replace nested locks and mutable maps
- [ ] Verify — parser/format/static checks passed; exact-head CI pending
- [x] Loop — remaining lock/effect and durable-authority owners stay in subsequent slices

## Review evidence

- Self-review: concurrent same-session winner, timestamp touch, shared owner retention, last-owner deletion, and cache cleanup are covered
- CI review pending

## Linked issue

- Relates #28221

## Variant addition checklist

- [x] **OCaml** — internal `install_outcome` added and exhaustively matched
- [x] **TypeScript** — N/A: no dashboard union changed
- [x] **TLA+ spec** — N/A: no modeled domain literal changed
- [x] **Event / JSON schema** — N/A: no wire or persisted schema changed
- [ ] **`make check-variants` passes** — not run locally per operator request; CI is the build authority