### PR TITLE
fix(keeper): drop reasoning-only tool-cycle interstitials

### DIFF
--- a/lib/keeper/keeper_checkpoint_purge.ml
+++ b/lib/keeper/keeper_checkpoint_purge.ml
@@ -256,26 +256,30 @@ let purge_messages ~config messages =
                cycle is grouped here, never in [Ordinary_message], so before
                this branch existed R2 could not reach it at all — the single
                largest reason unsigned reasoning survived a full purge.
-               A cycle message is never dropped even if stripping empties it:
-               that would break the ToolUse/ToolResult pairing the cycle is
-               indivisible for, and [Keeper_compaction_unit.validate] would
-               reject the output. In practice the opening message always keeps
-               its ToolUse block, so the empty case is defensive only. *)
+               The opening ToolUse and matching ToolResult anchors always
+               survive. An interstitial assistant message containing only
+               unsigned reasoning has no anchor, so it can be removed without
+               breaking the indivisible ToolUse/ToolResult pair. *)
             let cycle_messages =
               if config.strip_thinking
               then
-                List.map
+                List.filter_map
                   (fun message ->
                      if not (is_assistant message)
-                     then message
+                     then Some message
                      else (
                        let stripped, count = strip_reasoning_blocks message in
                        match stripped.Agent_core.Types.content with
-                       | [] -> message
+                       | [] when count > 0 ->
+                         reasoning_blocks_stripped
+                         := !reasoning_blocks_stripped + count;
+                         incr reasoning_messages_dropped;
+                         None
+                       | [] -> Some stripped
                        | _ :: _ ->
                          reasoning_blocks_stripped
                          := !reasoning_blocks_stripped + count;
-                         stripped))
+                         Some stripped))
                   cycle_messages
               else cycle_messages
             in

--- a/test/test_keeper_checkpoint_purge.ml
+++ b/test/test_keeper_checkpoint_purge.ml
@@ -175,18 +175,25 @@ let test_signed_reasoning_inside_tool_cycle_is_kept () =
       "signed thinking must replay byte-exact, got %s"
       (Types.show_message other)
 
-(* A cycle message is never dropped, even when stripping would empty it:
-   dropping it would orphan the paired ToolResult and fail structural
-   validation. *)
-let test_thinking_only_cycle_message_is_not_dropped () =
+(* An assistant progress frame can sit inside an already-open tool cycle
+   without carrying either anchor. Once its unsigned reasoning is stripped,
+   dropping that empty interstitial frame leaves the ToolUse/ToolResult pair
+   intact. *)
+let test_thinking_only_interstitial_cycle_message_is_dropped () =
   let messages =
-    [ block_message Types.Assistant [ unsigned_thinking "only-thinking"; tool_use "a" ]
+    [ block_message Types.Assistant [ tool_use "a" ]
+    ; block_message Types.Assistant [ unsigned_thinking "only-thinking" ]
     ; { (block_message Types.Tool [ tool_result "a" ]) with tool_call_id = Some "a" }
     ; text_message Types.User "after"
     ]
   in
-  let purged, _report = run messages in
-  Alcotest.(check int) "pairing intact" 3 (List.length purged)
+  let purged, report = run messages in
+  Alcotest.(check int) "unsigned reasoning stripped" 1 report.reasoning_blocks_stripped;
+  Alcotest.(check int) "empty interstitial dropped" 1 report.reasoning_messages_dropped;
+  Alcotest.(check int) "pairing intact" 3 (List.length purged);
+  match Masc.Keeper_compaction_unit.validate purged with
+  | Ok () -> ()
+  | Error _ -> Alcotest.fail "dropping the interstitial broke tool pairing"
 
 let test_tool_result_clear_preserves_pairing () =
   let messages = cycle "a" @ [ text_message Types.User "after" ] in
@@ -404,9 +411,9 @@ let () =
             `Quick
             test_signed_reasoning_inside_tool_cycle_is_kept
         ; Alcotest.test_case
-            "a thinking-only cycle message is not dropped"
+            "a thinking-only interstitial cycle message is dropped"
             `Quick
-            test_thinking_only_cycle_message_is_not_dropped
+            test_thinking_only_interstitial_cycle_message_is_dropped
         ; Alcotest.test_case
             "tool result clear preserves pairing"
             `Quick


### PR DESCRIPTION
## Why

PR #28346 restored the original message whenever reasoning stripping emptied an assistant frame inside a closed tool cycle. An interstitial assistant frame can contain only unsigned reasoning and no ToolUse/ToolResult anchor, so this fallback retained exactly the content R2 is meant to remove. The existing test named the case but actually included a ToolUse and never reached the empty-content branch.

## Change

- drop only assistant cycle frames emptied by removing one or more unsigned reasoning blocks
- retain the opening ToolUse and matching ToolResult anchors
- replace the mislabeled fixture with a real interstitial reasoning-only frame and validate the resulting tool cycle

## Checks

- git diff --check
- ocamlformat --check on both changed files
- Local Dune build intentionally not run per operator request; exact-head CI is the build authority.

## Review

Addresses #28346 review thread.