### PR TITLE
fix(dashboard): flip the remaining dev-meta fixtures to the admin contract

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -789,7 +789,7 @@ describe('dashboard websocket route subscriptions', () => {
   it('reconnects with a fresh token after hello auth rejection', async () => {
     vi.useFakeTimers()
     installWebSocketMocks()
-    setStoredToken('stale-token', { source: 'dev', actor: 'dashboard', role: 'worker' })
+    setStoredToken('stale-token', { source: 'dev', actor: 'dashboard', role: 'admin' })
 
     await connectDashboardWS({ tab: 'overview', params: {} })
     const socket = mockSockets[0]!
@@ -806,7 +806,7 @@ describe('dashboard websocket route subscriptions', () => {
     await flushPromises()
     expect(mockSockets).toHaveLength(1)
 
-    setStoredToken('fresh-token', { source: 'dev', actor: 'dashboard', role: 'worker' })
+    setStoredToken('fresh-token', { source: 'dev', actor: 'dashboard', role: 'admin' })
     await flushPromises()
     await flushPromises()
 

--- a/dashboard/src/demo/keeper-chat-queued-stream-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-queued-stream-fixture.ts
@@ -251,7 +251,7 @@ async function fixtureFetch(input: RequestInfo | URL, init?: RequestInit): Promi
   const path = requestPath(input)
   const method = requestMethod(input, init)
   if (path === '/api/v1/dashboard/dev-token' && method === 'GET') {
-    return json({ token: 'fixture-token', actor: 'dashboard', role: 'worker' })
+    return json({ token: 'fixture-token', actor: 'dashboard', role: 'admin' })
   }
   if (path === `/api/v1/keepers/${KEEPER}/chat/history` && method === 'GET') return json([])
   if (path === `/api/v1/keepers/${KEEPER}/waiting-inventory` && method === 'GET') {


### PR DESCRIPTION
#28354 후속 — api/ 밖에 남은 StoredTokenMeta 'worker' 리터럴 3개(ws 테스트 2, queued-stream demo 픽스처 1)를 admin 계약으로 전환. main `tsc --noEmit` 적색 해소. 검증: vitest dashboard-ws 51/51, tsc 0, eslint 0. 의도적으로 남긴 것: dev-token.test.ts의 거부 케이스 'worker', effective_role/worker_run 계열(다른 어휘).

🤖 Generated with [Claude Code](https://claude.com/claude-code)