### PR TITLE
refactor(agent-core): isolate provider admission state

### DIFF
--- a/packages/agent_core/lib/llm_provider/dune
+++ b/packages/agent_core/lib/llm_provider/dune
@@ -17,6 +17,7 @@
   exact_output_measurement_transport
   prepared_completion_request
   http_client_phase_observer
+  provider_admission_state
   provider_registry_state
   exact_output_catalog_binding
   exact_output_resolver

--- a/packages/agent_core/lib/llm_provider/provider_admission.ml
+++ b/packages/agent_core/lib/llm_provider/provider_admission.ml
@@ -1,78 +1,60 @@
 (** Per-endpoint admission of concurrent provider requests. See the .mli for
     the contract. *)
 
-type key =
-  { kind : string
-  ; base_url : string
-  ; secret : Secret.identity option
-  }
+module State = Provider_admission_state
 
-module Key = struct
-  type t = key
-
-  let equal a b =
-    String.equal a.kind b.kind
-    && String.equal a.base_url b.base_url
-    && Option.equal Secret.equal_identity a.secret b.secret
-  ;;
-
-  let hash { kind; base_url; secret } =
-    let secret_hash =
-      match secret with
-      | None -> 0
-      | Some identity -> Secret.hash_identity identity
-    in
-    Hashtbl.hash (kind, base_url, secret_hash)
-  ;;
-end
-
-module Table = Hashtbl.Make (Key)
-
-type entry =
-  { scheduler : Slot_scheduler.t
-  ; declared_max : int
-  ; mutable conflict_warned : bool
-  }
-
-(* Stdlib.Mutex rather than Eio.Mutex: the critical section is a table
-   lookup/insert that never blocks or switches fibers, and the table is
-   shared by every domain that dispatches completions. All waiting happens
-   inside Slot_scheduler, whose Eio primitives are domain-safe. *)
-let table : entry Table.t = Table.create 8
-let table_mutex = Stdlib.Mutex.create ()
+(* Stdlib.Mutex rather than Eio.Mutex: the critical section only swaps an
+   immutable registry state and never blocks or switches fibers. Scheduler
+   creation, diagnostics, snapshots, and permit waiting remain outside it. *)
+let state : Slot_scheduler.t State.t ref = ref State.empty
+let state_mutex = Stdlib.Mutex.create ()
 
 let key_of_config (config : Provider_config.t) =
-  { kind = Provider_config.string_of_provider_kind config.kind
-  ; base_url = config.base_url
-  ; secret = Secret.identity config.api_key
-  }
+  State.key
+    ~kind:(Provider_config.string_of_provider_kind config.kind)
+    ~base_url:config.base_url
+    ~secret:(Secret.identity config.api_key)
+;;
+
+let apply_transition transition =
+  Stdlib.Mutex.protect state_mutex (fun () ->
+    let next, output = transition !state in
+    state := next;
+    output)
+;;
+
+let resolve_existing ~key ~max =
+  Stdlib.Mutex.protect state_mutex (fun () ->
+    match State.resolve_existing key ~declared_max:max !state with
+    | None -> None
+    | Some (next, resolution) ->
+      state := next;
+      Some resolution)
+;;
+
+let warn_conflict = function
+  | None -> ()
+  | Some (conflict : State.conflict) ->
+    Diag.warn
+      "provider_admission"
+      "conflicting max_concurrent_requests for %s %s: scheduler holds %d, a config \
+       declares %d; the first declaration stays authoritative"
+      conflict.kind
+      (Complete_common.sanitize_url_for_log conflict.base_url)
+      conflict.authoritative_max
+      conflict.declared_max
 ;;
 
 let entry_for ~key ~max =
-  Stdlib.Mutex.protect table_mutex (fun () ->
-    match Table.find_opt table key with
-    | Some entry ->
-      if entry.declared_max <> max && not entry.conflict_warned
-      then (
-        entry.conflict_warned <- true;
-        Diag.warn
-          "provider_admission"
-          "conflicting max_concurrent_requests for %s %s: scheduler holds %d, a config \
-           declares %d; the first declaration stays authoritative"
-          key.kind
-          (Complete_common.sanitize_url_for_log key.base_url)
-          entry.declared_max
-          max);
-      entry
+  let resolution =
+    match resolve_existing ~key ~max with
+    | Some resolution -> resolution
     | None ->
-      let entry =
-        { scheduler = Slot_scheduler.create ~max_slots:max
-        ; declared_max = max
-        ; conflict_warned = false
-        }
-      in
-      Table.add table key entry;
-      entry)
+      let candidate = Slot_scheduler.create ~max_slots:max in
+      apply_transition (State.install key ~declared_max:max ~candidate)
+  in
+  warn_conflict resolution.conflict;
+  resolution.scheduler
 ;;
 
 let with_admission ~(config : Provider_config.t) f =
@@ -82,13 +64,12 @@ let with_admission ~(config : Provider_config.t) f =
     (* max >= 1 is enforced by Complete_common.validate_all before any
        dispatch reaches this point; Slot_scheduler.create re-checks and
        raises on a bypassing caller rather than admitting silently. *)
-    let entry = entry_for ~key:(key_of_config config) ~max in
-    Slot_scheduler.with_permit entry.scheduler f
+    let scheduler = entry_for ~key:(key_of_config config) ~max in
+    Slot_scheduler.with_permit scheduler f
 ;;
 
 let snapshot_for ~(config : Provider_config.t) =
   let key = key_of_config config in
-  Stdlib.Mutex.protect table_mutex (fun () ->
-    Table.find_opt table key
-    |> Option.map (fun entry -> Slot_scheduler.snapshot entry.scheduler))
+  let snapshot = Stdlib.Mutex.protect state_mutex (fun () -> !state) in
+  State.find_scheduler key snapshot |> Option.map Slot_scheduler.snapshot
 ;;

--- a/packages/agent_core/lib/llm_provider/provider_admission.mli
+++ b/packages/agent_core/lib/llm_provider/provider_admission.mli
@@ -21,6 +21,10 @@
     reordered across the FIFO, or dropped. Retry policy remains the
     consumer's responsibility.
 
+    Registry decisions are pure immutable transitions. Scheduler creation,
+    diagnostics, snapshots, and permit waiting are performed after leaving
+    the registry's short process-wide critical section.
+
     @since 0.216.0 *)
 
 (** [with_admission ~config f] runs [f] under the endpoint's concurrency

--- a/packages/agent_core/lib/llm_provider/provider_admission_state.ml
+++ b/packages/agent_core/lib/llm_provider/provider_admission_state.ml
@@ -1,0 +1,115 @@
+type key =
+  { kind : string
+  ; base_url : string
+  ; secret : Secret.identity option
+  }
+
+let key ~kind ~base_url ~secret = { kind; base_url; secret }
+
+let key_equal left right =
+  String.equal left.kind right.kind
+  && String.equal left.base_url right.base_url
+  && Option.equal Secret.equal_identity left.secret right.secret
+;;
+
+type conflict =
+  { kind : string
+  ; base_url : string
+  ; authoritative_max : int
+  ; declared_max : int
+  }
+
+type 'scheduler resolution =
+  { scheduler : 'scheduler
+  ; conflict : conflict option
+  }
+
+type 'scheduler entry =
+  { key : key
+  ; scheduler : 'scheduler
+  ; declared_max : int
+  ; conflict_reported : bool
+  }
+
+type 'scheduler t = 'scheduler entry list
+
+let empty = []
+
+let conflict_for entry ~declared_max =
+  if entry.declared_max = declared_max || entry.conflict_reported
+  then None, entry
+  else
+    ( Some
+        { kind = entry.key.kind
+        ; base_url = entry.key.base_url
+        ; authoritative_max = entry.declared_max
+        ; declared_max
+        }
+    , { entry with conflict_reported = true } )
+;;
+
+let resolve_existing key ~declared_max state =
+  let rec loop before = function
+    | [] -> None
+    | entry :: after when key_equal key entry.key ->
+      let conflict, entry = conflict_for entry ~declared_max in
+      let state = List.rev_append before (entry :: after) in
+      Some (state, { scheduler = entry.scheduler; conflict })
+    | entry :: after -> loop (entry :: before) after
+  in
+  loop [] state
+;;
+
+let install key ~declared_max ~candidate state =
+  match resolve_existing key ~declared_max state with
+  | Some resolution -> resolution
+  | None ->
+    let entry =
+      { key
+      ; scheduler = candidate
+      ; declared_max
+      ; conflict_reported = false
+      }
+    in
+    entry :: state, { scheduler = candidate; conflict = None }
+;;
+
+let find_scheduler key state =
+  List.find_map
+    (fun entry -> if key_equal key entry.key then Some entry.scheduler else None)
+    state
+;;
+
+let test_key = key ~kind:"test" ~base_url:"https://provider.test" ~secret:None
+
+let%test "first declaration installs its scheduler" =
+  let state, resolution =
+    install test_key ~declared_max:1 ~candidate:"first" empty
+  in
+  String.equal resolution.scheduler "first"
+  && Option.is_none resolution.conflict
+  && Option.equal String.equal (find_scheduler test_key state) (Some "first")
+;;
+
+let%test "a conflicting declaration reports once and keeps the first scheduler" =
+  let state, _ = install test_key ~declared_max:1 ~candidate:"first" empty in
+  match resolve_existing test_key ~declared_max:5 state with
+  | None -> false
+  | Some (state, resolution) ->
+    String.equal resolution.scheduler "first"
+    && (match resolution.conflict with
+        | Some conflict ->
+          conflict.authoritative_max = 1 && conflict.declared_max = 5
+        | None -> false)
+    && (match resolve_existing test_key ~declared_max:5 state with
+        | Some (_, resolution) -> Option.is_none resolution.conflict
+        | None -> false)
+;;
+
+let%test "a raced installer reuses the winner" =
+  let state, _ = install test_key ~declared_max:2 ~candidate:"winner" empty in
+  let _, resolution =
+    install test_key ~declared_max:2 ~candidate:"loser" state
+  in
+  String.equal resolution.scheduler "winner"
+;;

--- a/packages/agent_core/lib/llm_provider/provider_admission_state.mli
+++ b/packages/agent_core/lib/llm_provider/provider_admission_state.mli
@@ -1,0 +1,41 @@
+(** Pure immutable registry transitions for per-provider admission schedulers. *)
+
+type key
+
+val key :
+  kind:string -> base_url:string -> secret:Secret.identity option -> key
+
+type conflict =
+  { kind : string
+  ; base_url : string
+  ; authoritative_max : int
+  ; declared_max : int
+  }
+
+type 'scheduler resolution =
+  { scheduler : 'scheduler
+  ; conflict : conflict option
+  }
+
+type 'scheduler t
+
+val empty : 'scheduler t
+
+val resolve_existing :
+  key ->
+  declared_max:int ->
+  'scheduler t ->
+  ('scheduler t * 'scheduler resolution) option
+(** Resolve an existing scheduler and claim the one-shot conflict report when
+    [declared_max] differs from its authoritative declaration. *)
+
+val install :
+  key ->
+  declared_max:int ->
+  candidate:'scheduler ->
+  'scheduler t ->
+  'scheduler t * 'scheduler resolution
+(** Install [candidate] only when the key is still absent. A concurrent winner
+    is reused and conflict reporting follows {!resolve_existing}. *)
+
+val find_scheduler : key -> 'scheduler t -> 'scheduler option

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -5,6 +5,7 @@ lib/keeper/keeper_runtime_trust_snapshot_core.ml
 lib/keeper_runtime/keeper_event_queue_state.ml
 lib/config/env_config_snapshot_core.ml
 packages/agent_core/lib/llm_provider/provider_registry_state.ml
+packages/agent_core/lib/llm_provider/provider_admission_state.ml
 packages/agent_core/lib/llm_provider/complete_stream_state.ml
 lib/server/server_runtime_param_request.ml
 lib/server/server_prompt_override_request.ml


### PR DESCRIPTION
## Summary

- represent the process-wide provider admission registry as pure immutable transitions
- keep scheduler creation, diagnostics, snapshots, and permit waiting outside the registry mutex
- preserve first-declaration authority, one-shot conflict reporting, secret-aware identity, and race-safe installation
- register the transition module with the OCaml pure-module audit

## Verification

- ocamlformat --check on all changed OCaml interfaces and implementations
- ocamlc -stop-after parsing on all changed OCaml interfaces and implementations
- git diff --check
- static effect scan of the registered pure module
- local Dune build and tests intentionally not run per user direction; GitHub CI is the build authority