### PR TITLE
fix(test): assert the tool name the repeat-guard fixture actually creates

### DIFF
--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -248,7 +248,9 @@ let test_repeated_exact_dynamic_tool_call_aborts_the_turn () =
     check bool "second call continues" true (Option.is_none second.abort_turn);
     (match third.abort_turn with
      | Some (Repeated_tool_call { tool_name; repeated_count }) ->
-       check string "repeated tool" "masc_probe" tool_name;
+       (* [one_dynamic_tool] names its fixture "effect"; "masc_probe" belongs
+          to the hand-built stop below, which never goes through the host. *)
+       check string "repeated tool" "effect" tool_name;
        check int "repeat count" 3 repeated_count
      | None -> fail "reordered object did not produce a typed host stop");
     check (option string) "host stop is not a terminal error" None !terminal_error)


### PR DESCRIPTION
`test_repeated_exact_dynamic_tool_call_aborts_the_turn` 은 한 번도 통과한 적이 없습니다.

```
[FAIL]  reasoning effort  7  repeated exact dynamic tool call aborts the turn
ASSERT repeated tool
   Expected: `"masc_probe"'
   Received: `"effect"'
```

`:251` 은 중단된 툴 이름이 `"masc_probe"` 라고 단언하는데, 이 테스트가 쓰는 fixture 헬퍼는 `"effect"` 를 만듭니다:

```ocaml
let one_dynamic_tool ~active handler =
  let tool = Agent_core.Tool.create ~name:"effect" ...
```

`"masc_probe"` 는 같은 파일 `:293`/`:303` 의 손으로 만든 stop 값입니다. 그쪽은 host 를 거치지 않으므로 자기 완결적이고 통과합니다. `:251` 만 남의 상수를 봅니다.

## 왜 여태 안 보였나

이 테스트는 `#28318` 이 도입했고, 그 이후 `test_keeper_official_client_host.ml` 이 계속 **컴파일되지 않았습니다** (`Llm_provider.Types.tool_error` 미적용 fixture 2건, `#28338`·`#28355` 로 순차 해소). 컴파일 실패가 단언 실패를 가렸습니다.

이 스위트는 `scripts/ci-run-focused-tests.sh` 에 배선돼 있으므로, 파일이 컴파일되기 시작하면 이 단언이 CI 를 빨갛게 만듭니다.

## 수정

기대값을 fixture 가 실제로 만드는 이름으로 맞춥니다.

```ocaml
(* [one_dynamic_tool] names its fixture "effect"; "masc_probe" belongs
   to the hand-built stop below, which never goes through the host. *)
check string "repeated tool" "effect" tool_name;
```

대안은 헬퍼 쪽을 `"masc_probe"` 로 개명해 파일 어휘를 통일하는 것이었습니다. 헬퍼는 다른 테스트도 쓰고 어떤 단언도 `"effect"` 를 보지 않으므로 그쪽도 안전하지만, 단언 하나를 맞추려고 공유 헬퍼를 바꾸는 것은 방향이 반대라고 판단했습니다. 다르게 보시면 바꾸겠습니다.

## 검증

```
dune build --root . @test/runtest-test_keeper_official_client_host
  → Test Successful in 0.072s. 18 tests run.   (exit 0)
```

수정 전 같은 명령은 `1 failure! 18 tests run` 이었습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
