### PR TITLE
fix(test): assert the repeated-call abort names the tool under test

### DIFF
--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -248,7 +248,11 @@ let test_repeated_exact_dynamic_tool_call_aborts_the_turn () =
     check bool "second call continues" true (Option.is_none second.abort_turn);
     (match third.abort_turn with
      | Some (Repeated_tool_call { tool_name; repeated_count }) ->
-       check string "repeated tool" "masc_probe" tool_name;
+       (* The projected tool under test is [one_dynamic_tool]'s "effect".
+          #28335 shipped this assertion expecting the codex fixture's
+          "masc_probe", but the file did not compile until #28349/#28351,
+          so it never ran. *)
+       check string "repeated tool" "effect" tool_name;
        check int "repeat count" 3 repeated_count
      | None -> fail "reordered object did not produce a typed host stop");
     check (option string) "host stop is not a terminal error" None !terminal_error)


### PR DESCRIPTION
## 무엇

`test_repeated_exact_dynamic_tool_call_aborts_the_turn` 의 기대 리터럴 1건 수정 — `"masc_probe"` → `"effect"`.

## 왜

- 이 테스트의 대상 도구는 `one_dynamic_tool` 이 만드는 `"effect"` 인데, #28335 가 codex 픽스처의 `"masc_probe"` 를 기대하는 단언을 실었다.
- 파일이 #28318 이후 컴파일되지 않아 (#28349/#28351 이 복구) 이 단언은 한 번도 실행된 적이 없다.
- 컴파일 복구 후 suite 가 결정적으로 실패한다:

```
FAIL repeated tool
   Expected: `"masc_probe"'
   Received: `"effect"'
```

- 검출기 동작 자체는 올바르다 (`abort_turn` 이 문제 도구의 이름과 count=3 을 운반). 기대값만 틀렸다.

## 검증

- `dune build test/test_keeper_official_client_host.exe` green (main 44aa28e085 기준)
- `test_keeper_official_client_host.exe`: **18/18 green**
- 같은 컴파일 복구로 드러난 `test_runtime_codex_app_server` 의 no-deadline 결정적 실패 5건은 본 PR 과 무관 — #28360 에서 추적 (현행 main 에서 단독 실행으로 재확인함).

RFC-WAIVED: 테스트 기대 리터럴 1건 수정 — RFC 게이트 대상 subsystem 아님.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU1EnzuTuFCPZwbeqj9Ajr
