### PR TITLE
fix(grpc): project durable keeper pauses

### DIFF
--- a/lib/server/masc_grpc_service.ml
+++ b/lib/server/masc_grpc_service.ml
@@ -189,7 +189,7 @@ type task_directive_decision =
       }
 
 type heartbeat_workspace_view =
-  { workspace_paused : bool
+  { keeper_paused : bool
   ; active_agent_count : int
   ; pending_task_count : int
   ; task_directive : task_directive_decision
@@ -223,9 +223,9 @@ let decide_task_directive tasks =
   first_todo tasks
 ;;
 
-(** Pure projection from one authoritative Workspace snapshot. *)
-let heartbeat_workspace_view ~workspace_paused ~active_agents ~tasks =
-  { workspace_paused
+(** Pure projection from authoritative Workspace and Keeper snapshots. *)
+let heartbeat_workspace_view ~keeper_paused ~active_agents ~tasks =
+  { keeper_paused
   ; active_agent_count = List.length active_agents
   ; pending_task_count =
       List.fold_left
@@ -234,6 +234,20 @@ let heartbeat_workspace_view ~workspace_paused ~active_agents ~tasks =
         tasks
   ; task_directive = decide_task_directive tasks
   }
+;;
+
+let keeper_paused_for_heartbeat ~base_path ~agent_name =
+  match
+    Keeper_registry_lookup.find_all_by_agent_name_in_base_path ~base_path agent_name
+  with
+  | [] -> false
+  | [ entry ] -> entry.meta.paused
+  | entries ->
+    Log.Transport.warn
+      "gRPC heartbeat: ambiguous keeper agent binding for %s (%d entries)"
+      agent_name
+      (List.length entries);
+    false
 ;;
 
 let directives_of_view ~agent_name view =
@@ -249,7 +263,7 @@ let directives_of_view ~agent_name view =
         error;
       []
   in
-  if view.workspace_paused
+  if view.keeper_paused
   then Keeper_directive.Pause :: task_directives
   else task_directives
 ;;
@@ -300,7 +314,10 @@ let handle_heartbeat
               let tasks = Workspace.get_tasks_safe workspace_config in
               let view =
                 heartbeat_workspace_view
-                  ~workspace_paused:(Workspace.is_paused workspace_config)
+                  ~keeper_paused:
+                    (keeper_paused_for_heartbeat
+                       ~base_path:workspace_config.base_path
+                       ~agent_name:ping.agent_name)
                   ~active_agents
                   ~tasks
               in

--- a/lib/server/masc_grpc_service.ml
+++ b/lib/server/masc_grpc_service.ml
@@ -236,6 +236,27 @@ let heartbeat_workspace_view ~keeper_paused ~active_agents ~tasks =
   }
 ;;
 
+(** Durable Keeper pause for one heartbeat ping, read from the live registry
+    only.
+
+    Scope: this answers "does a Keeper lane in this base_path currently hold a
+    durable pause", so a Keeper that exists only in persisted metadata is
+    [false] — it owns no lane to park. [Keeper_identity_binding.resolve] is the
+    authority for name resolution and does consult persisted metadata, but its
+    fallback lists every persisted Keeper and reads each meta file; the
+    heartbeat runs every 30s per connected agent and most pings come from
+    agents that are not Keepers at all, so that scan does not belong here.
+
+    The multi-entry branch is unreachable defence, not a policy choice.
+    [Keeper_identity.keeper_agent_name] makes agent_name a bijection of the
+    Keeper name ("keeper-<name>-agent"); the parse boundary rejects metadata
+    that breaks it, and [Keeper_registry.all] re-validates every entry on read
+    and drops the ones that fail, so two entries sharing one agent_name cannot
+    reach this scan. It still resolves to no directive rather than picking a
+    lane: a Pause the client accepts commits
+    [Keeper_latched_reason.Operator_paused], which only the receipt-first
+    [Resume_owner] transaction can clear, so a misaddressed pause is durable
+    while a skipped one is retried on the next ping. *)
 let keeper_paused_for_heartbeat ~base_path ~agent_name =
   match
     Keeper_registry_lookup.find_all_by_agent_name_in_base_path ~base_path agent_name
@@ -244,9 +265,11 @@ let keeper_paused_for_heartbeat ~base_path ~agent_name =
   | [ entry ] -> entry.meta.paused
   | entries ->
     Log.Transport.warn
-      "gRPC heartbeat: ambiguous keeper agent binding for %s (%d entries)"
+      "gRPC heartbeat: ambiguous keeper agent binding for %s (%s); emitting no pause"
       agent_name
-      (List.length entries);
+      (String.concat
+         ", "
+         (List.map (fun (entry : Keeper_registry.registry_entry) -> entry.name) entries));
     false
 ;;
 

--- a/test/test_grpc_workspace.ml
+++ b/test/test_grpc_workspace.ml
@@ -8,6 +8,20 @@
 
 module T = Masc_grpc_types
 module Keeper_directive = Masc.Keeper_directive
+module Keeper_registry = Masc.Keeper_registry
+
+let keeper_meta ~name ~agent_name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name
+        ; "agent_name", `String agent_name
+        ; "trace_id", `String ("trace-" ^ name)
+        ])
+  with
+  | Ok meta -> meta
+  | Error error -> Alcotest.failf "invalid keeper meta fixture: %s" error
+;;
 
 let task_id value =
   match Keeper_id.Task_id.of_string value with
@@ -684,14 +698,84 @@ let test_heartbeat_projects_workspace_view () =
     | _ -> Alcotest.fail "Heartbeat bidi handler missing")
 ;;
 
-let test_heartbeat_projects_workspace_pause_directive () =
+let test_heartbeat_projects_keeper_pause_not_workspace_pause () =
   Eio_main.run
   @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  with_temp_dir "masc-grpc-heartbeat-workspace-pause" (fun dir ->
+  Keeper_registry.For_testing.clear ();
+  with_temp_dir "masc-grpc-heartbeat-keeper-pause" (fun dir ->
+    Fun.protect
+      ~finally:Keeper_registry.For_testing.clear
+      (fun () ->
     let workspace_config = Workspace_utils.default_config dir in
-    ignore (Masc.Workspace.init workspace_config ~agent_name:(Some "alpha"));
+    let agent_name = "keeper-alpha-agent" in
+    let keeper_name = "alpha" in
+    ignore (Masc.Workspace.init workspace_config ~agent_name:(Some agent_name));
+    let meta = keeper_meta ~name:keeper_name ~agent_name in
+    ignore
+      (Keeper_registry.For_testing.register
+         ~base_path:workspace_config.base_path
+         keeper_name
+         meta);
     Masc.Workspace.pause workspace_config ~by:"operator" ~reason:"maintenance";
+    let service =
+      Masc_grpc_service.create_service
+        ~workspace_config
+        ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
+        ~lsp_dispatcher:(fun ~language_id:_ ~jsonrpc_request_json:_ ~workspace_root:_ ->
+          Error "test stub")
+    in
+    match Grpc_eio.Service.get_method service "Heartbeat" with
+    | Some { handler = `Bidi handler; _ } ->
+      Eio.Switch.run
+      @@ fun sw ->
+      let request_stream = Grpc_eio.Stream.create 16 in
+      let response_stream = handler ~sw request_stream in
+      let send_heartbeat session_id =
+        Grpc_eio.Stream.add
+          request_stream
+          (T.HeartbeatPing.to_bytes
+             { agent_name
+             ; session_id
+             ; timestamp_ms = 1700000000000L
+             ; current_task_id = ""
+             });
+        Eio.Time.with_timeout_exn (Eio.Stdenv.clock env) 1.0 (fun () ->
+          Grpc_eio.Stream.take response_stream)
+        |> T.HeartbeatAck.of_bytes
+      in
+      let workspace_paused_ack = send_heartbeat "sess-workspace-pause" in
+      Alcotest.(check (list string))
+        "workspace pause does not become a durable keeper pause"
+        []
+        (List.map T.HeartbeatAck.directive_to_wire workspace_paused_ack.directives);
+      ignore (Masc.Workspace.resume workspace_config ~by:"operator");
+      ignore
+        (Keeper_registry.For_testing.register
+           ~base_path:workspace_config.base_path
+           keeper_name
+           { meta with paused = true });
+      let keeper_paused_ack = send_heartbeat "sess-keeper-pause" in
+      Alcotest.(check (list string))
+        "durable keeper pause reaches its control stream"
+        [ "pause" ]
+        (List.map T.HeartbeatAck.directive_to_wire keeper_paused_ack.directives);
+      Grpc_eio.Stream.close request_stream
+    | _ -> Alcotest.fail "Heartbeat bidi handler missing"))
+;;
+
+let test_heartbeat_does_not_materialize_uninitialized_workspace () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Keeper_registry.For_testing.clear ();
+  with_temp_dir "masc-grpc-heartbeat-uninitialized" (fun dir ->
+    Fun.protect
+      ~finally:Keeper_registry.For_testing.clear
+      (fun () ->
+    let workspace_config = Workspace_utils.default_config dir in
+    let state_path = Workspace_utils.state_path workspace_config in
+    Alcotest.(check bool) "state absent before heartbeat" false (Sys.file_exists state_path);
     let service =
       Masc_grpc_service.create_service
         ~workspace_config
@@ -708,8 +792,8 @@ let test_heartbeat_projects_workspace_pause_directive () =
       Grpc_eio.Stream.add
         request_stream
         (T.HeartbeatPing.to_bytes
-           { agent_name = "alpha"
-           ; session_id = "sess-workspace-pause"
+           { agent_name = "uninitialized-grpc-agent"
+           ; session_id = "sess-uninitialized"
            ; timestamp_ms = 1700000000000L
            ; current_task_id = ""
            });
@@ -719,11 +803,15 @@ let test_heartbeat_projects_workspace_pause_directive () =
         |> T.HeartbeatAck.of_bytes
       in
       Alcotest.(check (list string))
-        "workspace pause reaches keeper control stream"
-        [ "pause" ]
+        "uninitialized heartbeat has no directives"
+        []
         (List.map T.HeartbeatAck.directive_to_wire ack.directives);
+      Alcotest.(check bool)
+        "heartbeat leaves state absent"
+        false
+        (Sys.file_exists state_path);
       Grpc_eio.Stream.close request_stream
-    | _ -> Alcotest.fail "Heartbeat bidi handler missing")
+    | _ -> Alcotest.fail "Heartbeat bidi handler missing"))
 ;;
 
 (* ====== Test suite ====== *)
@@ -795,9 +883,13 @@ let () =
             `Quick
             test_heartbeat_projects_workspace_view
         ; Alcotest.test_case
-            "heartbeat projects workspace pause directive"
+            "heartbeat projects keeper pause only"
             `Quick
-            test_heartbeat_projects_workspace_pause_directive
+            test_heartbeat_projects_keeper_pause_not_workspace_pause
+        ; Alcotest.test_case
+            "heartbeat leaves uninitialized workspace absent"
+            `Quick
+            test_heartbeat_does_not_materialize_uninitialized_workspace
         ] )
     ; ( "server_config"
       , [ Alcotest.test_case "default_port" `Quick test_grpc_default_port


### PR DESCRIPTION
## Why

PR #28348 projected the workspace-wide automation pause into Keeper_directive.Pause. The client persists that directive as an operator pause, while Workspace.resume only clears workspace state, so a normal namespace pause/resume could leave Keeper lanes durably stuck. The same read also materialized state.json for an uninitialized workspace.

## Change

- derive heartbeat Pause only from the exact Keeper registry entry whose agent_name matches the ping in the same base_path
- treat duplicate agent bindings as ambiguous and emit no directive
- remove Workspace.is_paused from the heartbeat path; workspace pause remains scoped to workspace automation
- keep raw resume absent: durable Keeper resume remains owned by the receipt-first Resume_owner transaction

## Regression coverage

- workspace pause does not emit a durable Keeper Pause
- a durably paused Keeper still receives Pause on its control stream
- a heartbeat against an uninitialized workspace leaves state.json absent

## Checks

- git diff --check
- ocamlformat --check on both changed files
- ocamlc stop-after-parsing on both changed files
- local Dune build/tests intentionally not run per operator request; exact-head GitHub CI is the build authority

Addresses both unresolved review threads on #28348.