### PR TITLE
refactor(runtime): isolate lane preference state

### DIFF
--- a/lib/runtime/runtime_lane_preference.ml
+++ b/lib/runtime/runtime_lane_preference.ml
@@ -2,18 +2,14 @@
 
     See the [.mli] for the contract.  Implementation notes:
 
-    - State is a small [Hashtbl] guarded by [Stdlib.Mutex], matching the
-      {!Dashboard_agent_core_bridge} convention in this library (record/read may be
-      called from outside Eio fibers, so [Eio.Mutex] is not required).
-    - Expiry is lazy: [prefer_order] compares the entry age against
-      {!ttl_s} at call time and drops stale entries on read. *)
+    - One immutable state value is swapped under [Stdlib.Mutex] (record/read
+      may be called outside Eio fibers, so [Eio.Mutex] is not required).
+    - The shell observes clock and TTL once before locking. The pure state
+      transition resolves absence versus expiry and prunes stale entries. *)
 
-type entry =
-  { candidate : string
-  ; noted_at : float
-  }
+module State = Runtime_lane_preference_state
 
-let entries : (string, entry) Hashtbl.t = Hashtbl.create 8
+let state = ref State.empty
 let mu = Stdlib.Mutex.create ()
 
 let ttl_s = Env_config_runtime.Lane.preference_ttl_s
@@ -22,39 +18,29 @@ let ttl_s = Env_config_runtime.Lane.preference_ttl_s
    deterministic replay logic branches on these timestamps. *)
 let now () = Unix.gettimeofday ()
 
+let apply_transition transition =
+  Stdlib.Mutex.protect mu (fun () ->
+    let next, output = transition !state in
+    state := next;
+    output)
+;;
+
+let observe ~lane_id =
+  let observed_at = now () in
+  let ttl = ttl_s () in
+  apply_transition (State.observe ~now:observed_at ~ttl_s:ttl ~lane_id)
+;;
+
 let prefer_order ~lane_id candidates =
-  let preferred =
-    Stdlib.Mutex.protect mu (fun () ->
-      match Hashtbl.find_opt entries lane_id with
-      | None -> None
-      | Some entry ->
-        if Float.compare (now () -. entry.noted_at) (ttl_s ()) < 0
-        then Some entry.candidate
-        else begin
-          Hashtbl.remove entries lane_id;
-          None
-        end)
-  in
-  match preferred with
-  | Some candidate when List.exists (String.equal candidate) candidates ->
-    candidate :: List.filter (fun id -> not (String.equal id candidate)) candidates
-  | _ -> candidates
+  State.reorder (observe ~lane_id) candidates
 
 let note_success ~lane_id ~candidate =
-  Stdlib.Mutex.protect mu (fun () ->
-    Hashtbl.replace entries lane_id { candidate; noted_at = now () })
+  let noted_at = now () in
+  apply_transition (fun state ->
+    State.remember ~lane_id ~candidate ~noted_at state, ())
 
 let preferred_of_lane ~lane_id =
-  Stdlib.Mutex.protect mu (fun () ->
-    match Hashtbl.find_opt entries lane_id with
-    | None -> None
-    | Some entry ->
-      if Float.compare (now () -. entry.noted_at) (ttl_s ()) < 0
-      then Some (entry.candidate, entry.noted_at)
-      else begin
-        Hashtbl.remove entries lane_id;
-        None
-      end)
+  State.preferred (observe ~lane_id)
 
 let reset_for_testing () =
-  Stdlib.Mutex.protect mu (fun () -> Hashtbl.reset entries)
+  Stdlib.Mutex.protect mu (fun () -> state := State.empty)

--- a/lib/runtime/runtime_lane_preference.mli
+++ b/lib/runtime/runtime_lane_preference.mli
@@ -5,10 +5,12 @@
     every turn before the lane fails over.  This module remembers the last
     successful candidate per lane so later turns start from it instead.
 
-    The table is keyed by lane id and shared across keepers on purpose:
+    The immutable registry is keyed by lane id and shared across keepers on purpose:
     provider rate limits are account-scoped, so one keeper's failover
     discovery benefits every keeper routed through the same lane.  Entries
-    expire lazily on read against {!ttl_s}; there is no background sweeper. *)
+    expire lazily on read against {!ttl_s}; there is no background sweeper.
+    Clock and TTL are observed once outside the registry mutex, then supplied
+    to a pure transition. *)
 
 val prefer_order : lane_id:string -> string list -> string list
 (** Reorder [candidates] so the remembered last-good candidate for [lane_id]

--- a/lib/runtime/runtime_lane_preference_state.ml
+++ b/lib/runtime/runtime_lane_preference_state.ml
@@ -1,0 +1,44 @@
+module By_lane = Map.Make (String)
+
+type preference =
+  { candidate : string
+  ; noted_at : float
+  }
+
+type observation =
+  | No_preference
+  | Expired_preference
+  | Active_preference of preference
+
+type t = preference By_lane.t
+
+let empty = By_lane.empty
+
+let remember ~lane_id ~candidate ~noted_at state =
+  match By_lane.find_opt lane_id state with
+  | Some current when Float.compare current.noted_at noted_at > 0 -> state
+  | Some _ | None -> By_lane.add lane_id { candidate; noted_at } state
+;;
+
+let observe ~now ~ttl_s ~lane_id state =
+  match By_lane.find_opt lane_id state with
+  | None -> state, No_preference
+  | Some preference ->
+    if Float.compare ttl_s 0.0 > 0
+       && Float.compare (now -. preference.noted_at) ttl_s < 0
+    then state, Active_preference preference
+    else By_lane.remove lane_id state, Expired_preference
+;;
+
+let reorder observation candidates =
+  match observation with
+  | Active_preference { candidate; _ }
+    when List.exists (String.equal candidate) candidates ->
+    candidate :: List.filter (fun id -> not (String.equal id candidate)) candidates
+  | No_preference | Expired_preference | Active_preference _ -> candidates
+;;
+
+let preferred = function
+  | Active_preference { candidate; noted_at } -> Some (candidate, noted_at)
+  | No_preference | Expired_preference -> None
+;;

--- a/lib/runtime/runtime_lane_preference_state.mli
+++ b/lib/runtime/runtime_lane_preference_state.mli
@@ -1,0 +1,37 @@
+(** Pure immutable state for sticky runtime-lane preferences. *)
+
+type t
+
+type preference =
+  { candidate : string
+  ; noted_at : float
+  }
+
+type observation =
+  | No_preference
+  | Expired_preference
+  | Active_preference of preference
+(** The result of resolving one lane at one supplied instant. Expiry is kept
+    distinct from absence so the transition and its pruning are testable. *)
+
+val empty : t
+
+val remember :
+  lane_id:string -> candidate:string -> noted_at:float -> t -> t
+(** Remember the latest success by event time. A delayed commit carrying an
+    older [noted_at] cannot overwrite a newer success for the same lane. *)
+
+val observe :
+  now:float -> ttl_s:float -> lane_id:string -> t -> t * observation
+(** Resolve and, when necessary, prune the preference for [lane_id]. Time and
+    TTL policy are values supplied by the outer runtime shell. A non-positive
+    [ttl_s] always expires the entry, including when [noted_at] is newer than
+    [now] because the two effects raced before commit. *)
+
+val reorder : observation -> string list -> string list
+(** Move an active preferred candidate to the head while retaining the
+    declared relative order of all other candidates. *)
+
+val preferred : observation -> (string * float) option
+(** Project the public diagnostics view. Both absence and an expiry observed
+    by this call intentionally become [None] at that boundary. *)

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -13,3 +13,4 @@ lib/schedule/schedule_domain.ml
 lib/turn_fsm/turn_fsm.ml
 lib/types/masc_domain.ml
 lib/workspace/workspace_task_lifecycle.ml
+lib/runtime/runtime_lane_preference_state.ml

--- a/test/test_runtime_lane_preference.ml
+++ b/test/test_runtime_lane_preference.ml
@@ -5,6 +5,64 @@
     injecting a clock. *)
 
 let candidates = [ "alpha"; "beta"; "gamma" ]
+module State = Runtime_lane_preference_state
+
+let test_state_active_preference_reorders () =
+  let state =
+    State.remember ~lane_id:"lane-1" ~candidate:"beta" ~noted_at:10.0 State.empty
+  in
+  let _, observation = State.observe ~now:12.0 ~ttl_s:5.0 ~lane_id:"lane-1" state in
+  Alcotest.(check (list string))
+    "active candidate leads"
+    [ "beta"; "alpha"; "gamma" ]
+    (State.reorder observation candidates);
+  Alcotest.(check (option (pair string (float 0.001))))
+    "active diagnostics retain timestamp"
+    (Some ("beta", 10.0))
+    (State.preferred observation)
+;;
+
+let test_state_expiry_is_explicit_and_pruned () =
+  let state =
+    State.remember ~lane_id:"lane-1" ~candidate:"beta" ~noted_at:10.0 State.empty
+  in
+  let pruned, first = State.observe ~now:15.0 ~ttl_s:5.0 ~lane_id:"lane-1" state in
+  (match first with
+   | State.Expired_preference -> ()
+   | State.No_preference | State.Active_preference _ ->
+     Alcotest.fail "expiry was not represented explicitly");
+  let _, second =
+    State.observe ~now:15.0 ~ttl_s:5.0 ~lane_id:"lane-1" pruned
+  in
+  match second with
+  | State.No_preference -> ()
+  | State.Expired_preference | State.Active_preference _ ->
+    Alcotest.fail "expired preference was not pruned"
+;;
+
+let test_state_zero_ttl_disables_stickiness () =
+  let state =
+    State.remember ~lane_id:"lane-1" ~candidate:"beta" ~noted_at:11.0 State.empty
+  in
+  let _, observation = State.observe ~now:10.0 ~ttl_s:0.0 ~lane_id:"lane-1" state in
+  match observation with
+  | State.Expired_preference -> ()
+  | State.No_preference | State.Active_preference _ ->
+    Alcotest.fail "zero TTL retained an active preference"
+;;
+
+let test_state_delayed_older_success_cannot_replace_latest () =
+  let state =
+    State.empty
+    |> State.remember ~lane_id:"lane-1" ~candidate:"beta" ~noted_at:11.0
+    |> State.remember ~lane_id:"lane-1" ~candidate:"alpha" ~noted_at:10.0
+  in
+  let _, observation = State.observe ~now:12.0 ~ttl_s:5.0 ~lane_id:"lane-1" state in
+  Alcotest.(check (option (pair string (float 0.001))))
+    "newer success remains authoritative"
+    (Some ("beta", 11.0))
+    (State.preferred observation)
+;;
 
 let test_identity_without_state () =
   Runtime_lane_preference.reset_for_testing ();
@@ -97,8 +155,25 @@ let test_preferred_of_lane_expires () =
 
 let () =
   Alcotest.run "runtime_lane_preference"
-    [
-      ( "prefer_order"
+    [ ( "state"
+      , [ Alcotest.test_case
+            "active preference reorders"
+            `Quick
+            test_state_active_preference_reorders
+        ; Alcotest.test_case
+            "expiry is explicit and pruned"
+            `Quick
+            test_state_expiry_is_explicit_and_pruned
+        ; Alcotest.test_case
+            "zero TTL disables stickiness"
+            `Quick
+            test_state_zero_ttl_disables_stickiness
+        ; Alcotest.test_case
+            "delayed older success cannot replace latest"
+            `Quick
+            test_state_delayed_older_success_cannot_replace_latest
+        ] )
+    ; ( "prefer_order"
       , [ Alcotest.test_case "identity without state" `Quick
             test_identity_without_state
         ; Alcotest.test_case "remembered candidate first" `Quick


### PR DESCRIPTION
## Summary

- replace the mutable lane preference table with pure immutable transitions
- distinguish absent, expired, and active observations before projecting optional diagnostics
- observe wall clock and TTL once outside the registry mutex
- prevent an older delayed success from overwriting a newer event and keep TTL zero authoritative under races
- register the transition module with the OCaml pure-module audit

## Verification

- ocamlformat --check on changed OCaml files
- ocamlc -stop-after parsing on changed OCaml files
- git diff --check
- static effect scan of the registered pure module
- deterministic state tests for active ordering, expiry pruning, TTL zero, and reordered commits
- local Dune build and tests intentionally not run per user direction; GitHub CI is the build authority