### PR TITLE
refactor(health): isolate subsystem lifecycle state

### DIFF
--- a/lib/subsystem_health.ml
+++ b/lib/subsystem_health.ml
@@ -1,40 +1,40 @@
 (** Subsystem health registry.
     Tracks which forked subsystems are alive or have crashed.
-    Module-level Hashtbl: available from process start, no init timing dependency.
+    Module-level immutable state: available from process start, no init timing dependency.
     Called by fork_subsystem in server_runtime_bootstrap, queried by /health.
 
     [register] runs when a subsystem fiber is forked, [mark_dead] when a
     supervisor fiber observes the crash, and [to_yojson] from the HTTP
-    /health handler — three different fibers.  Without a mutex the
-    Hashtbl writes race and [to_yojson]'s fold can observe a half-written
-    state.  [Stdlib.Mutex] because the registry is read from the /health
-    handler which may run on a different domain than the fork callers. *)
+    /health handler — three different fibers. [Stdlib.Mutex] protects only
+    the state swap/snapshot because the registry may cross domains; clock
+    observation and JSON rendering stay outside the critical section. *)
 
-let registry : (string, bool * float option) Hashtbl.t = Hashtbl.create 8
+module State = Subsystem_health_state
+
+let state = ref State.empty
 let registry_mu = Stdlib.Mutex.create ()
 
-let with_lock f = Stdlib.Mutex.protect registry_mu f
+let apply event =
+  Stdlib.Mutex.protect registry_mu (fun () ->
+    state := State.apply !state event)
+;;
 
-let register name =
-  with_lock (fun () ->
-    Hashtbl.replace registry name (true, None))
+let register name = apply (State.Registered { name })
 
 let mark_dead name =
-  with_lock (fun () ->
-    Hashtbl.replace registry name (false, Some (Time_compat.now ())))
+  let crashed_at = Time_compat.now () in
+  apply (State.Crashed { name; crashed_at })
+;;
 
 let to_yojson () : Yojson.Safe.t =
-  let entries =
-    with_lock (fun () ->
-      Hashtbl.fold (fun name (alive, crash_time) acc ->
-        let status = if alive then "alive" else "dead" in
-        let fields = [
-          ("status", `String status);
-        ] @ (match crash_time with
-          | Some t -> [("crashed_at", `Float t)]
-          | None -> [])
-        in
-        (name, `Assoc fields) :: acc
-      ) registry [])
+  let snapshot = Stdlib.Mutex.protect registry_mu (fun () -> !state) in
+  let entry_to_json (name, health) =
+    let fields =
+      match health with
+      | State.Alive -> [ "status", `String "alive" ]
+      | State.Dead { crashed_at } ->
+        [ "status", `String "dead"; "crashed_at", `Float crashed_at ]
+    in
+    name, `Assoc fields
   in
-  `Assoc (List.sort (fun (a, _) (b, _) -> String.compare a b) entries)
+  `Assoc (List.map entry_to_json (State.entries snapshot))

--- a/lib/subsystem_health.mli
+++ b/lib/subsystem_health.mli
@@ -1,14 +1,14 @@
 (** Subsystem_health — process-wide registry of forked subsystems
     and their alive/dead state.
 
-    Module-level [Hashtbl] guarded by [Stdlib.Mutex] (cross-domain:
-    /health handler may run on a different domain than the fork
-    callers, ruling out [Eio.Mutex]). Available from process start
-    with no init timing dependency.
+    One immutable state value is guarded by [Stdlib.Mutex] (cross-domain:
+    /health handler may run on a different domain than the fork callers,
+    ruling out [Eio.Mutex]). Available from process start with no init timing
+    dependency. Clock observation and JSON rendering happen outside the
+    critical section.
 
-    Internal helpers (the [registry] table, [registry_mu] mutex,
-    and [with_lock] critical-section wrapper) are hidden — callers
-    consume only the three lifecycle entry points below. *)
+    Internal helpers (the state holder and [registry_mu] mutex) are hidden —
+    callers consume only the three lifecycle entry points below. *)
 
 val register : string -> unit
 (** Mark [name] as alive in the registry. Called from

--- a/lib/subsystem_health_state.ml
+++ b/lib/subsystem_health_state.ml
@@ -1,0 +1,23 @@
+module By_name = Map.Make (String)
+
+type health =
+  | Alive
+  | Dead of { crashed_at : float }
+
+type event =
+  | Registered of { name : string }
+  | Crashed of
+      { name : string
+      ; crashed_at : float
+      }
+
+type t = health By_name.t
+
+let empty = By_name.empty
+
+let apply state = function
+  | Registered { name } -> By_name.add name Alive state
+  | Crashed { name; crashed_at } -> By_name.add name (Dead { crashed_at }) state
+;;
+
+let entries state = By_name.bindings state

--- a/lib/subsystem_health_state.mli
+++ b/lib/subsystem_health_state.mli
@@ -1,0 +1,19 @@
+(** Pure immutable lifecycle state for forked subsystems. *)
+
+type health =
+  | Alive
+  | Dead of { crashed_at : float }
+
+type event =
+  | Registered of { name : string }
+  | Crashed of
+      { name : string
+      ; crashed_at : float
+      }
+
+type t
+
+val empty : t
+val apply : t -> event -> t
+val entries : t -> (string * health) list
+(** Alphabetically ordered immutable view of the registry. *)

--- a/scripts/ocaml-pure-modules.txt
+++ b/scripts/ocaml-pure-modules.txt
@@ -1,6 +1,7 @@
 # Modules whose implementations are pure decision cores. Registry growth is
 # the one-way ratchet: a registered module may not call canonical env, clock,
 # random, filesystem, Eio, mutation, or logging APIs.
+lib/subsystem_health_state.ml
 lib/keeper/keeper_runtime_trust_snapshot_core.ml
 lib/keeper_runtime/keeper_event_queue_state.ml
 lib/config/env_config_snapshot_core.ml

--- a/test/dune
+++ b/test/dune
@@ -634,6 +634,11 @@
  (libraries alcotest masc_test_deps masc.keeper_checkpoint_ref))
 
 (test
+ (name test_subsystem_health_state)
+ (modules test_subsystem_health_state)
+ (libraries alcotest masc_test_deps))
+
+(test
  (name test_keeper_checkpoint_purge)
  (modules test_keeper_checkpoint_purge)
  (libraries alcotest masc_test_deps))

--- a/test/test_subsystem_health_state.ml
+++ b/test/test_subsystem_health_state.ml
@@ -1,0 +1,97 @@
+module State = Subsystem_health_state
+
+let apply event state = State.apply state event
+
+let require_entry name entries =
+  match List.assoc_opt name entries with
+  | Some health -> health
+  | None -> Alcotest.failf "missing subsystem %s" name
+;;
+
+let test_state_transitions_are_typed_and_sorted () =
+  let state =
+    State.empty
+    |> apply (State.Registered { name = "zeta" })
+    |> apply (State.Registered { name = "alpha" })
+    |> apply (State.Crashed { name = "zeta"; crashed_at = 42.5 })
+  in
+  let entries = State.entries state in
+  Alcotest.(check (list string))
+    "names are canonical map order"
+    [ "alpha"; "zeta" ]
+    (List.map fst entries);
+  (match require_entry "alpha" entries with
+   | State.Alive -> ()
+   | State.Dead _ -> Alcotest.fail "registered subsystem is not alive");
+  match require_entry "zeta" entries with
+  | State.Dead { crashed_at } ->
+    Alcotest.(check (float 0.001)) "crash timestamp retained" 42.5 crashed_at
+  | State.Alive -> Alcotest.fail "crashed subsystem is still alive"
+;;
+
+let test_reregister_clears_crash_state () =
+  let state =
+    State.empty
+    |> apply (State.Crashed { name = "worker"; crashed_at = 10.0 })
+    |> apply (State.Registered { name = "worker" })
+  in
+  match require_entry "worker" (State.entries state) with
+  | State.Alive -> ()
+  | State.Dead _ -> Alcotest.fail "re-registration retained stale crash state"
+;;
+
+let test_wire_projection_keeps_current_shape () =
+  let string_field name json =
+    match Yojson.Safe.Util.member name json with
+    | `String value -> Some value
+    | _ -> None
+  in
+  Subsystem_health.register "wire-alive";
+  Subsystem_health.mark_dead "wire-dead";
+  match Subsystem_health.to_yojson () with
+  | `Assoc fields ->
+    Alcotest.(check bool)
+      "keys are sorted"
+      true
+      (List.map fst fields = [ "wire-alive"; "wire-dead" ]);
+    Alcotest.(check (option string))
+      "alive status"
+      (Some "alive")
+      (Option.bind (List.assoc_opt "wire-alive" fields) (string_field "status"));
+    (match List.assoc_opt "wire-dead" fields with
+     | Some (`Assoc dead_fields) ->
+       Alcotest.(check (option string))
+         "dead status"
+         (Some "dead")
+         (Option.bind
+            (List.assoc_opt "status" dead_fields)
+            (function
+              | `String value -> Some value
+              | _ -> None));
+       Alcotest.(check bool)
+         "dead timestamp present"
+         true
+         (List.mem_assoc "crashed_at" dead_fields)
+     | Some _ | None -> Alcotest.fail "dead subsystem JSON object missing")
+  | _ -> Alcotest.fail "subsystem health projection is not an object"
+;;
+
+let () =
+  Alcotest.run
+    "subsystem_health_state"
+    [ ( "state"
+      , [ Alcotest.test_case
+            "typed transitions and ordering"
+            `Quick
+            test_state_transitions_are_typed_and_sorted
+        ; Alcotest.test_case
+            "re-register clears crash"
+            `Quick
+            test_reregister_clears_crash_state
+        ; Alcotest.test_case
+            "wire projection"
+            `Quick
+            test_wire_projection_keeps_current_shape
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- replace the mutable subsystem health table with typed immutable lifecycle state
- capture crash time before entering the cross-domain mutex
- snapshot under the mutex and render the health JSON after releasing it
- preserve sorted subsystem keys and the existing alive/dead wire shape
- register the lifecycle state module with the OCaml pure-module audit

## Verification

- ocamlformat --check on changed OCaml files
- ocamlc -stop-after parsing on changed OCaml files
- git diff --check
- static effect scan of the registered pure module
- pure transition tests plus current health JSON characterization
- local Dune build and tests intentionally not run per user direction; GitHub CI is the build authority