### PR TITLE
fix(auth): keep bind retries idempotent

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -563,14 +563,17 @@ type resolved_config_state =
 
 let resolved_config = Atomic.make Unconfigured
 
-let configure config =
+let rec configure config =
   let current = Atomic.get resolved_config in
   match current with
-  | Configured _ -> Error Already_configured
+  | Configured installed ->
+    if Server_auth_config.equal installed config
+    then Ok ()
+    else Error Already_configured
   | Unconfigured ->
     if Atomic.compare_and_set resolved_config current (Configured config)
     then Ok ()
-    else Error Already_configured
+    else configure config
 ;;
 
 let configure_error_to_string = function

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -181,8 +181,10 @@ type configure_error = Already_configured
 
 val configure : Server_auth_config.t -> (unit, configure_error) result
 (** Install the boot-resolved authorization policy before request handlers are
-    constructed. The policy is single-assignment for the process lifetime;
-    request handlers cannot turn it into a runtime control channel. *)
+    constructed. Reinstalling the identical policy is an idempotent no-op so a
+    transient socket-bind retry can repeat bootstrap; a different policy is
+    rejected for the process lifetime. Request handlers cannot turn it into a
+    runtime control channel. *)
 
 val configure_error_to_string : configure_error -> string
 

--- a/lib/server/server_auth_config.ml
+++ b/lib/server/server_auth_config.ml
@@ -41,6 +41,7 @@ let parse_boolean ~name = function
   | None -> Ok false
   | Some raw ->
     (match String.trim raw |> String.lowercase_ascii with
+     | "" -> Ok false
      | "1" | "true" | "yes" | "on" -> Ok true
      | "0" | "false" | "no" | "off" -> Ok false
      | _ -> Error (Malformed_boolean { name; raw }))
@@ -84,6 +85,14 @@ let fail_closed =
 
 let allow_anonymous_mutations config = config.anonymous_mutations_allowed
 let loopback_dev_mutation_origins config = config.allowlisted_dev_origins
+
+let equal left right =
+  Bool.equal left.anonymous_mutations_allowed right.anonymous_mutations_allowed
+  && List.equal
+       Server_request_authority.serialized_origin_equal
+       left.allowlisted_dev_origins
+       right.allowlisted_dev_origins
+;;
 
 let resolve_error_to_string = function
   | Malformed_boolean { name; raw } ->

--- a/lib/server/server_auth_config.mli
+++ b/lib/server/server_auth_config.mli
@@ -25,8 +25,8 @@ val read_env : unit -> raw
 (** Read the two HTTP authorization environment inputs once. *)
 
 val resolve : raw -> (t, resolve_error) result
-(** Parse the complete policy. Missing values use the current defaults;
-    present malformed values are errors rather than implicit defaults. *)
+(** Parse the complete policy. Missing and blank boolean values use the current
+    defaults; other present malformed values are errors. *)
 
 val fail_closed : t
 (** Policy used before the composition root installs configuration: anonymous
@@ -34,4 +34,5 @@ val fail_closed : t
 
 val allow_anonymous_mutations : t -> bool
 val loopback_dev_mutation_origins : t -> Server_request_authority.serialized_origin list
+val equal : t -> t -> bool
 val resolve_error_to_string : resolve_error -> string

--- a/test/test_server_request_authority.ml
+++ b/test/test_server_request_authority.ml
@@ -118,6 +118,32 @@ let test_auth_config_resolves_typed_policy () =
     (List.length (Server_auth_config.loopback_dev_mutation_origins config))
 ;;
 
+let test_auth_config_blank_anonymous_mutations_defaults_false () =
+  List.iter
+    (fun raw ->
+       let config =
+         resolve_auth_config
+           { allow_anonymous_mutations = Some raw
+           ; loopback_dev_mutation_origins = None
+           }
+       in
+       check
+         bool
+         (Printf.sprintf "blank %S is false" raw)
+         false
+         (Server_auth_config.allow_anonymous_mutations config))
+    [ ""; " \t " ]
+;;
+
+let test_auth_config_identical_reinstall_is_idempotent () =
+  match Server_auth.configure default_auth_config with
+  | Ok () -> ()
+  | Error error ->
+    failf
+      "identical policy reinstall failed: %s"
+      (Server_auth.configure_error_to_string error)
+;;
+
 let test_http1_closed_classification () =
   check_classification
     `Missing
@@ -709,6 +735,14 @@ let () =
             "policy is typed"
             `Quick
             test_auth_config_resolves_typed_policy
+        ; test_case
+            "blank anonymous mutations default false"
+            `Quick
+            test_auth_config_blank_anonymous_mutations_defaults_false
+        ; test_case
+            "identical policy reinstall is idempotent"
+            `Quick
+            test_auth_config_identical_reinstall_is_idempotent
         ; test_case
             "policy is resolved before admission"
             `Quick


### PR DESCRIPTION
## Why

PR #28345 installs the boot-resolved HTTP auth policy before socket bind. A transient EADDRINUSE retry re-enters bootstrap with the same policy, but strict one-shot configure rejected that second attempt before it could bind again. The same config parser also treated a blank anonymous-mutation env as malformed even though the established env contract treats blank as the default false value.

## Change

- accept an identical resolved auth policy as an idempotent no-op
- continue rejecting any different policy for the process lifetime
- retry the compare-and-set path so concurrent identical installs converge
- resolve blank and whitespace-only MASC_ALLOW_ANONYMOUS_MUTATIONS as false

## Regression coverage

- identical policy reinstall succeeds, modeling the port-bind retry
- a different policy remains rejected by the existing single-assignment test
- empty and whitespace-only anonymous-mutation values resolve false

## Checks

- git diff --check
- ocamlformat --check on all five changed OCaml files
- ocamlc stop-after-parsing on all five changed OCaml files
- local Dune build/tests intentionally not run per operator request; exact-head GitHub CI is the build authority

Addresses both unresolved review threads on #28345.