### PR TITLE
[masc-mcp] Fix subsystem health test module reference

### DIFF
--- a/test/test_subsystem_health_state.ml
+++ b/test/test_subsystem_health_state.ml
@@ -1,4 +1,4 @@
-module State = Subsystem_health_state
+open Subsystem_health
 
 let apply event state = State.apply state event
 


### PR DESCRIPTION
## Problem

Build error in `test/test_subsystem_health_state.ml`:

```
Error: The module State is an alias for module Subsystem_health_state, which is missing
```

The test tried to define:
``ocaml
module State = Subsystem_health_state
```

But `Subsystem_health_state` is not exposed as a standalone module.

## Solution

Changed to:
``ocaml
open Subsystem_health
```

This uses the `State` module alias already defined inside `Subsystem_health`:
``ocaml
(* in lib/subsystem_health.ml *)
module State = Subsystem_health_state
```

## Changes
- `test/test_subsystem_health_state.ml`: Use `open Subsystem_health` instead of defining missing module alias

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>