### PR TITLE
Fix dashboard chat auth bootstrap and duplicate failure cards

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -338,15 +338,20 @@ describe('Keeper Event Queue API', () => {
 })
 
 describe('streamKeeperMessage', () => {
+  const devTokenResponse = () => new Response(
+    JSON.stringify({ token: 'test-dev-token', actor: 'dashboard', role: 'admin' }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+
   it('posts direct reply mode to the keeper chat stream endpoint', async () => {
     window.history.replaceState({}, '', '/?agent=dashboard-eager-manta%E3%85%8A')
 
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response('data: {"type":"RUN_FINISHED"}\n\n', {
+    const fetchMock = vi.fn((url: string) => url === '/api/v1/dashboard/dev-token'
+      ? Promise.resolve(devTokenResponse())
+      : Promise.resolve(new Response('data: {"type":"RUN_FINISHED"}\n\n', {
         status: 200,
         headers: { 'Content-Type': 'text/event-stream' },
-      }),
-    )
+      })))
     vi.stubGlobal('fetch', fetchMock)
 
     const events: string[] = []
@@ -357,8 +362,8 @@ describe('streamKeeperMessage', () => {
       },
     })
 
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const [, init] = fetchMock.mock.calls[1] as unknown as [string, RequestInit]
     const headers = init.headers as Record<string, string>
     expect(JSON.parse(String(init.body))).toEqual({
       request_id: 'kmsg-stream-direct',
@@ -366,18 +371,18 @@ describe('streamKeeperMessage', () => {
       message: 'ping',
     })
     const actorHeader = headers['X-MASC-Agent'] ?? headers['x-masc-agent']
-    expect(actorHeader).toBe('dashboard-eager-manta')
+    expect(actorHeader).toBe('dashboard')
     expect(actorHeader).not.toContain('%')
     expect(events).toEqual(['RUN_FINISHED'])
   })
 
   it('forwards copilot context fields to the stream endpoint', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response('data: {"type":"RUN_FINISHED"}\n\n', {
+    const fetchMock = vi.fn((url: string) => url === '/api/v1/dashboard/dev-token'
+      ? Promise.resolve(devTokenResponse())
+      : Promise.resolve(new Response('data: {"type":"RUN_FINISHED"}\n\n', {
         status: 200,
         headers: { 'Content-Type': 'text/event-stream' },
-      }),
-    )
+      })))
     vi.stubGlobal('fetch', fetchMock)
 
     const events: string[] = []
@@ -397,8 +402,8 @@ describe('streamKeeperMessage', () => {
       },
     })
 
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const [, init] = fetchMock.mock.calls[1] as unknown as [string, RequestInit]
     expect(JSON.parse(String(init.body))).toEqual({
       request_id: 'kmsg-stream-copilot',
       name: 'sangsu',
@@ -417,12 +422,12 @@ describe('streamKeeperMessage', () => {
   })
 
   it('forwards semantic user blocks separately from attachment payloads', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response('data: {"type":"RUN_FINISHED"}\n\n', {
+    const fetchMock = vi.fn((url: string) => url === '/api/v1/dashboard/dev-token'
+      ? Promise.resolve(devTokenResponse())
+      : Promise.resolve(new Response('data: {"type":"RUN_FINISHED"}\n\n', {
         status: 200,
         headers: { 'Content-Type': 'text/event-stream' },
-      }),
-    )
+      })))
     vi.stubGlobal('fetch', fetchMock)
 
     await streamKeeperMessage('sangsu', 'describe this', {
@@ -449,7 +454,7 @@ describe('streamKeeperMessage', () => {
       ],
     })
 
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const [, init] = fetchMock.mock.calls[1] as unknown as [string, RequestInit]
     expect(JSON.parse(String(init.body))).toMatchObject({
       name: 'sangsu',
       message: 'describe this',
@@ -502,7 +507,7 @@ describe('streamKeeperMessage', () => {
       }
       if (url === '/api/v1/dashboard/dev-token') {
         return Promise.resolve(new Response(
-          JSON.stringify({ token: 'fresh-token', actor: 'dashboard', role: 'worker' }),
+          JSON.stringify({ token: 'fresh-token', actor: 'dashboard', role: 'admin' }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         ))
       }

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -11,7 +11,10 @@ import {
   fetchJsonWithTimeout,
   DEFAULT_GET_TIMEOUT_MS,
 } from './core'
-import { refreshDevTokenAfterAuthError } from './dev-token'
+import {
+  ensureDevToken,
+  refreshDevTokenAfterAuthError,
+} from './dev-token'
 import type { KeeperChatStreamEvent } from '../lib/keeper-chat-stream-contract'
 import type {
   KeeperCompositeSnapshot,
@@ -287,6 +290,14 @@ export async function streamKeeperMessage(
     surfaceContext,
   }: StreamKeeperMessageOptions,
 ): Promise<KeeperStreamOutcome> {
+  // Direct keeper chat is a mutation path just like MCP tools.  Bootstrap the
+  // loopback dashboard credential before constructing the request so a freshly
+  // loaded dashboard never emits a misleading 401 "Token required" toast.
+  // Existing credentials are left to the typed 401 recovery below; only a
+  // missing credential needs the preflight bootstrap. This avoids an extra
+  // network round-trip for every message while still preventing the common
+  // freshly-loaded-dashboard failure.
+  if (!jsonHeaders().Authorization) await ensureDevToken()
   const operationId = requestId?.trim() || `kmsg-${crypto.randomUUID()}`
   const body: Record<string, unknown> = {
     request_id: operationId,

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -1166,9 +1166,13 @@ export async function sendKeeperThreadMessage(
         reason: errorMessage,
       }),
     })
+    // The assistant placeholder is the single transcript owner of a stream
+    // failure. Keep the optimistic user message as a delivered input row;
+    // marking both rows as errors produced two identical red error cards for
+    // one failed HTTP request.
     finalizeAssistantEntry(keeperName, localId, {
-      delivery: 'error' as KeeperConversationDelivery,
-      error: errorMessage,
+      delivery: 'delivered',
+      error: null,
       streamContract: keeperStreamContract('client_stream_failure', 'contract_gap', {
         requestId: requestId ?? undefined,
         reason: errorMessage,


### PR DESCRIPTION
## What changed
- Bootstrap the loopback dashboard dev token before direct Keeper chat streaming when no bearer is present.
- Keep existing-token requests on the typed 401 recovery path without an extra request.
- Render stream failures on the assistant placeholder only, avoiding duplicate error cards on the optimistic user row.
- Update API coverage for the bootstrap request.

## Why
A freshly loaded Dashboard could submit `/api/v1/keepers/chat/stream` before its session token was installed, producing `Unauthorized: Token required`. A failed stream was also marked as an error on both transcript rows.

## Validation
- `vitest run src/api/keeper.test.ts` (37 passed)
- `vitest run src/keeper-actions.test.ts` (42 passed)
- `tsc --noEmit`
