### PR TITLE
fix(test): qualify the wrapped Subsystem_health open (main Build and Test 복구)

### DIFF
--- a/test/test_subsystem_health_state.ml
+++ b/test/test_subsystem_health_state.ml
@@ -1,4 +1,4 @@
-open Subsystem_health
+open Masc.Subsystem_health
 
 let apply event state = State.apply state event
 


### PR DESCRIPTION
main 의 Build and Test 가 `test_subsystem_health_state.ml:1` 의 `Unbound module Subsystem_health` 로 실패 중이에요 — 현재 모든 open PR 이 이 지문을 물려받고 있어요 (12호).

## 왜 세 번째 시도인가

- #28367 원본: `module State = Subsystem_health_state` — masc 라이브러리 **밖**에서 library-internal 이름을 참조 → unbound.
- #28369 "수리": `open Subsystem_health` — **같은 실수 반복** (다른 unbound 이름으로 교체). 머지 전 이 테스트를 컴파일한 run 이 없었어요 (#28327 merge-train 클래스).
- masc 라이브러리는 wrapped 라 밖에서는 `Masc.<Module>` 로 접근해요 — 형제 테스트 실측: `test_keeper_checkpoint_purge.ml:6` 의 `module Purge = Masc.Keeper_checkpoint_purge`.

## 수정

`open Subsystem_health` → `open Masc.Subsystem_health` 한 줄. `State` alias(subsystem_health.ml:12)가 스코프에 들어와 이 파일의 단언 16곳이 전부 그걸 써요.

지문 피해자들(#28363, #28365, #28370)은 이 머지 후 rebase 로 해소돼요.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
