### PR TITLE
fix(test): alias the hidden State module in subsystem health test

### DIFF
--- a/test/test_subsystem_health_state.ml
+++ b/test/test_subsystem_health_state.ml
@@ -1,4 +1,5 @@
-open Masc.Subsystem_health
+module Subsystem_health = Masc.Subsystem_health
+module State = Masc.Subsystem_health_state
 
 let apply event state = State.apply state event
 


### PR DESCRIPTION
## 목표

main red 복구: `test_subsystem_health_state.ml`이 `subsystem_health.mli`가 export하지 않는 `State`를 참조해 `dune build @check`가 모든 PR에서 실패 (#28378).

## 변경 파일

- `test/test_subsystem_health_state.ml` — `open Masc.Subsystem_health` 1줄을 public 모듈 alias 2줄로 교체 (`Subsystem_health`, `State`)

## 로컬 검증

- `dune build @test/runtest-test_subsystem_health_state` — 컴파일 + **suite 실행** 3 tests green (#28369/#28373이 실행 없이 머지되어 재발한 전례 반영)

## 미검증

- 없음 (테스트 전용 변경, 라이브러리 코드 무변경)

Closes #28378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU1EnzuTuFCPZwbeqj9Ajr
