### PR TITLE
feat(keeper): thread Slack surface posts into the continuation thread

### DIFF
--- a/lib/keeper/keeper_surface_post.ml
+++ b/lib/keeper/keeper_surface_post.ml
@@ -3,7 +3,11 @@ type rich_block = Yojson.Safe.t
 type post_target =
   | To_dashboard
   | To_discord of { channel_id : string }
-  | To_slack of { channel_id : string; blocks : rich_block list option }
+  | To_slack of
+      { channel_id : string
+      ; thread_ts : string option
+      ; blocks : rich_block list option
+      }
 
 let dashboard_label = "dashboard"
 let discord_label = "discord"
@@ -13,7 +17,10 @@ let resolve_target ~surface ~channel_id ?continuation_channel
     ?(bound_discord_channels = [])
     ?(bound_slack_channels = []) () : (post_target, string) result =
   let surface = String.trim surface in
-  let continuation_channel_id, continuation_parent_channel_id =
+  let ( continuation_channel_id
+      , continuation_parent_channel_id
+      , continuation_slack_thread_ts )
+    =
     match continuation_channel with
     | Some
         (Keeper_continuation_channel.Discord
@@ -23,17 +30,28 @@ let resolve_target ~surface ~channel_id ?continuation_channel
       , (match thread_id, parent_channel_id with
          | Some thread_id, Some parent_channel_id
            when String.equal thread_id channel_id -> Some parent_channel_id
-         | _ -> None) )
-    | Some (Keeper_continuation_channel.Slack { channel_id; _ })
+         | _ -> None)
+      , None )
+    | Some (Keeper_continuation_channel.Slack { channel_id; thread_ts; _ })
       when String.equal surface slack_label ->
-      Some channel_id, None
+      Some channel_id, None, thread_ts
     | Some
         ( Keeper_continuation_channel.Dashboard _
         | Keeper_continuation_channel.Discord _
         | Keeper_continuation_channel.Slack _
         | Keeper_continuation_channel.Unrouted _ )
     | None ->
-      None, None
+      None, None, None
+  in
+  (* A Slack [thread_ts] names a conversation inside one channel, so it only
+     travels with a post that lands on the continuation's own channel; an
+     explicit different channel gets a root post (a foreign thread_ts would be
+     rejected by Slack). *)
+  let slack_thread_ts_for ~channel_id =
+    match continuation_channel_id with
+    | Some continuation_id when String.equal channel_id continuation_id ->
+      continuation_slack_thread_ts
+    | Some _ | None -> None
   in
   let channel_id =
     match channel_id with
@@ -81,7 +99,13 @@ let resolve_target ~surface ~channel_id ?continuation_channel
         Error
           "this keeper has no Slack channel binding; bind a channel first \
            (posting to an unbound surface is an error, not a no-op)"
-    | None, [ only ] -> Ok (To_slack { channel_id = only; blocks = None })
+    | None, [ only ] ->
+        Ok
+          (To_slack
+             { channel_id = only
+             ; thread_ts = slack_thread_ts_for ~channel_id:only
+             ; blocks = None
+             })
     | None, _ :: _ :: _ ->
         Error
           (Printf.sprintf
@@ -91,7 +115,12 @@ let resolve_target ~surface ~channel_id ?continuation_channel
     | Some requested, bound ->
         let requested = String.trim requested in
         if List.exists (String.equal requested) bound then
-          Ok (To_slack { channel_id = requested; blocks = None })
+          Ok
+            (To_slack
+               { channel_id = requested
+               ; thread_ts = slack_thread_ts_for ~channel_id:requested
+               ; blocks = None
+               })
         else
           Error
             (Printf.sprintf
@@ -123,15 +152,15 @@ let matches_continuation_route target channel =
        continuation now carries [reply_to_message_id = Some _], so requiring
        [= None] here quarantined all of them (PR #28225 review). *)
     String.equal posted channel_id
-  | ( To_slack { channel_id = posted; _ }
-    , Keeper_continuation_channel.Slack
-        { channel_id; thread_ts = None; _ } ) ->
-    (* Slack differs from Discord: [thread_ts] is a destination distinct from the
-       channel root and the surface-post tool does not thread its post, so a
-       same-channel post only proves delivery for an unthreaded continuation.
-       Threaded Slack continuations settle through the recovery publisher, which
-       does thread via [?reply_to_message_id]. *)
+  | ( To_slack { channel_id = posted; thread_ts = posted_thread_ts; _ }
+    , Keeper_continuation_channel.Slack { channel_id; thread_ts; _ } ) ->
+    (* Slack differs from Discord: [thread_ts] is a destination distinct from
+       the channel root, so delivery is proven only when the post carried the
+       continuation's exact thread coordinate — both unthreaded, or both the
+       same thread. A root post never proves delivery for a threaded
+       continuation (that still settles through the recovery publisher). *)
     String.equal posted channel_id
+    && Option.equal String.equal posted_thread_ts thread_ts
   | ( To_dashboard
     , Keeper_continuation_channel.Dashboard _ ) ->
     (* Dashboard posts are currently keeper-global ([session_id=None]), so

--- a/lib/keeper/keeper_surface_post.mli
+++ b/lib/keeper/keeper_surface_post.mli
@@ -16,9 +16,16 @@ type post_target =
       (** Persist an assistant line + broadcast [keeper_chat_appended];
           the dashboard is always present. *)
   | To_discord of { channel_id : string }
-  | To_slack of { channel_id : string; blocks : rich_block list option }
-      (** Post to a bound Slack channel. [blocks] may carry Slack Block Kit
-          rich blocks to render alongside the plain-text fallback. *)
+  | To_slack of
+      { channel_id : string
+      ; thread_ts : string option
+      ; blocks : rich_block list option
+      }
+      (** Post to a bound Slack channel. [thread_ts] carries the continuation
+          thread coordinate when the post lands on the continuation's own
+          channel, so a threaded question is answered in its thread instead of
+          the channel root. [blocks] may carry Slack Block Kit rich blocks to
+          render alongside the plain-text fallback. *)
 
 val dashboard_label : string
 val discord_label : string
@@ -42,7 +49,9 @@ val resolve_target :
       keeps its thread channel as the target while authorizing it through
       the bound parent channel; an error names the bound channels when
       ambiguous, unbound, or foreign.
-    - ["slack"] → same semantics against [bound_slack_channels].
+    - ["slack"] → same semantics against [bound_slack_channels]. A typed
+      Slack continuation also supplies its [thread_ts], which travels with
+      the target only when the post lands on the continuation's own channel.
       A continuation for another connector never supplies an id.
     - any other label → error: P4 ships discord + dashboard + slack
       (generic gate connectors have no send surface yet). *)
@@ -54,9 +63,10 @@ val set_blocks : post_target -> rich_block list option -> post_target
 val matches_continuation_route :
   post_target -> Keeper_continuation_channel.t -> bool
 (** True only when the completed post proves the same concrete delivery route.
-    Keeper-global dashboard posts, Discord replies, and Slack thread replies
-    are not treated as exact matches when the post transport did not carry
-    those coordinates. *)
+    Keeper-global dashboard posts never match. A Slack post matches only when
+    it carried the continuation's exact thread coordinate ([thread_ts]
+    equality, including both-[None]); a root post does not prove delivery for
+    a threaded continuation. *)
 
 val ok_json : surface:string -> ?message_id:string -> unit -> string
 val error_json : string -> string

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -907,7 +907,13 @@ let handle_person_note_set ~config ~meta ~args =
    gateway and Owner connector delivery — rather than a direct env lookup here. *)
 let slack_token_opt = Env_config_slack.bot_token_opt
 
-let connector_post_gate_input ~connector ~channel_id ~content ?blocks () =
+let connector_post_gate_input ~connector ~channel_id ~content ?thread_ts ?blocks
+    () =
+  let thread_ts_fields =
+    match thread_ts with
+    | None -> []
+    | Some thread_ts -> [ "thread_ts", `String thread_ts ]
+  in
   let block_fields =
     match blocks with
     | None -> []
@@ -918,6 +924,7 @@ let connector_post_gate_input ~connector ~channel_id ~content ?blocks () =
      ; "channel_id", `String channel_id
      ; "content", `String content
      ]
+     @ thread_ts_fields
      @ block_fields)
 ;;
 
@@ -932,6 +939,7 @@ type connector_post_replay =
   | Replay_slack_post of
       { input : Yojson.Safe.t
       ; channel_id : string
+      ; thread_ts : string option
       ; content : string
       ; blocks : Yojson.Safe.t list
       }
@@ -953,6 +961,27 @@ let connector_post_replay_of_gate_input input =
         (Printf.sprintf "approved connector_post %s must be a string" key)
     | [] ->
       Error (Printf.sprintf "approved connector_post is missing %s" key)
+    | _ ->
+      Error (Printf.sprintf "approved connector_post repeats %s" key)
+  in
+  (* Absent means the field was never part of the durable request (older
+     approvals predate [thread_ts]); present means it must be a usable value.
+     Absence is never widened into a default coordinate. *)
+  let optional_string key fields =
+    match
+      List.filter_map
+        (fun (name, value) ->
+           if String.equal name key then Some value else None)
+        fields
+    with
+    | [] -> Ok None
+    | [ `String value ] when not (String.equal (String.trim value) "") ->
+      Ok (Some value)
+    | [ `String _ ] ->
+      Error (Printf.sprintf "approved connector_post %s is blank" key)
+    | [ _ ] ->
+      Error
+        (Printf.sprintf "approved connector_post %s must be a string" key)
     | _ ->
       Error (Printf.sprintf "approved connector_post repeats %s" key)
   in
@@ -988,9 +1017,11 @@ let connector_post_replay_of_gate_input input =
     then (
       let* () =
         reject_unknown
-          ~allowed:[ "connector"; "channel_id"; "content"; "blocks" ]
+          ~allowed:
+            [ "connector"; "channel_id"; "thread_ts"; "content"; "blocks" ]
           fields
       in
+      let* thread_ts = optional_string "thread_ts" fields in
       match
         List.filter_map
           (fun (name, value) ->
@@ -998,7 +1029,7 @@ let connector_post_replay_of_gate_input input =
           fields
       with
       | [ `List blocks ] ->
-        Ok (Replay_slack_post { input; channel_id; content; blocks })
+        Ok (Replay_slack_post { input; channel_id; thread_ts; content; blocks })
       | [ _ ] ->
         Error "approved connector_post blocks must be an array"
       | [] ->
@@ -1102,7 +1133,7 @@ let replay_connector_post_with_outcome
             ~content
             ();
           succeed Keeper_surface_post.discord_label ~message_id ()))
-  | Replay_slack_post { input; channel_id; content; blocks } ->
+  | Replay_slack_post { input; channel_id; thread_ts; content; blocks } ->
     with_connector_post_gate_execution
       ~config
       ~meta
@@ -1120,6 +1151,7 @@ let replay_connector_post_with_outcome
      | Some token ->
        (match
           Keeper_chat_slack.send_message_with_blocks
+            ?thread_ts
             ~token
             ~channel:channel_id
             ~content
@@ -1137,8 +1169,7 @@ let replay_connector_post_with_outcome
                ~keeper_name:meta.name
                ~content
                ~surface:
-                 (Surface_ref.Slack
-                    { team_id = None; channel_id; thread_ts = None })
+                 (Surface_ref.Slack { team_id = None; channel_id; thread_ts })
                ()
            with
            | Error detail ->
@@ -1281,7 +1312,9 @@ let handle_surface_post_with_outcome
         ?gate_grant
         (Replay_discord_post { input; channel_id; content = safe_content })
       |> Keeper_tool_execution.with_surface_post_receipt target
-    | Ok (Keeper_surface_post.To_slack { channel_id; blocks = _ } as target) ->
+    | Ok
+        (Keeper_surface_post.To_slack { channel_id; thread_ts; blocks = _ } as
+         target) ->
       let slack_blocks =
         Keeper_chat_slack.content_blocks_of_text safe_content
       in
@@ -1290,6 +1323,7 @@ let handle_surface_post_with_outcome
           ~connector:surface
           ~channel_id
           ~content:safe_content
+          ?thread_ts
           ~blocks:slack_blocks
           ()
       in
@@ -1302,6 +1336,7 @@ let handle_surface_post_with_outcome
         (Replay_slack_post
            { input
            ; channel_id
+           ; thread_ts
            ; content = safe_content
            ; blocks = slack_blocks
            })

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -35,6 +35,7 @@ type connector_post_replay =
   | Replay_slack_post of
       { input : Yojson.Safe.t
       ; channel_id : string
+      ; thread_ts : string option
       ; content : string
       ; blocks : Yojson.Safe.t list
       }

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -731,17 +731,50 @@ let test_large_connector_post_preserves_exact_durable_request () =
       (Replay_slack_post
          { input = decoded_input
          ; channel_id
+         ; thread_ts
          ; content = decoded_content
          ; blocks = decoded_blocks
          }) ->
     Alcotest.check json "exact durable request retained" input decoded_input;
     Alcotest.check Alcotest.string "channel retained" "C-exact" channel_id;
+    Alcotest.check
+      (Alcotest.option Alcotest.string)
+      "absent thread_ts stays absent"
+      None
+      thread_ts;
     Alcotest.check Alcotest.string "large content retained" content decoded_content;
     Alcotest.check
       (Alcotest.list json)
       "large blocks retained"
       blocks
       decoded_blocks
+  | Ok (Replay_discord_post _) ->
+    Alcotest.fail "Slack request decoded as Discord"
+  | Error detail -> Alcotest.fail detail
+;;
+
+let test_slack_connector_post_retains_thread_ts () =
+  let open Masc.Keeper_tool_in_process_runtime in
+  let input =
+    `Assoc
+      [ "connector", `String "slack"
+      ; "channel_id", `String "C-exact"
+      ; "thread_ts", `String "1700000000.000100"
+      ; "content", `String "threaded reply"
+      ; "blocks", `List []
+      ]
+  in
+  match
+    Masc.Keeper_tool_in_process_runtime.connector_post_replay_of_gate_input
+      input
+  with
+  | Ok (Replay_slack_post { thread_ts; channel_id; _ }) ->
+    Alcotest.check Alcotest.string "channel retained" "C-exact" channel_id;
+    Alcotest.check
+      (Alcotest.option Alcotest.string)
+      "thread coordinate retained"
+      (Some "1700000000.000100")
+      thread_ts
   | Ok (Replay_discord_post _) ->
     Alcotest.fail "Slack request decoded as Discord"
   | Error detail -> Alcotest.fail detail
@@ -768,6 +801,20 @@ let test_connector_post_rejects_heuristic_or_truncated_input () =
         ; "channel_id", `String "D-exact"
         ; "content", `String "exact"
         ; "truncated", `Bool true
+        ]
+    ; `Assoc
+        [ "connector", `String "slack"
+        ; "channel_id", `String "C-exact"
+        ; "thread_ts", `String "   "
+        ; "content", `String "blank thread coordinate"
+        ; "blocks", `List []
+        ]
+    ; `Assoc
+        [ "connector", `String "slack"
+        ; "channel_id", `String "C-exact"
+        ; "thread_ts", `Int 1700000000
+        ; "content", `String "non-string thread coordinate"
+        ; "blocks", `List []
         ]
     ]
 ;;
@@ -861,6 +908,10 @@ let () =
             "connector decoder rejects heuristic input"
             `Quick
             test_connector_post_rejects_heuristic_or_truncated_input
+        ; Alcotest.test_case
+            "slack connector request retains thread_ts"
+            `Quick
+            test_slack_connector_post_retains_thread_ts
         ; Alcotest.test_case
             "memory write replay keeps exact input"
             `Quick

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -15,11 +15,14 @@ let target_pp fmt = function
   | SP.To_dashboard -> Format.fprintf fmt "To_dashboard"
   | SP.To_discord { channel_id } ->
       Format.fprintf fmt "To_discord{%s}" channel_id
-  | SP.To_slack { channel_id; blocks } ->
+  | SP.To_slack { channel_id; thread_ts; blocks } ->
       let blocks_label =
         match blocks with None -> "no-blocks" | Some [] -> "empty" | Some _ -> "blocks"
       in
-      Format.fprintf fmt "To_slack{%s,%s}" channel_id blocks_label
+      let thread_label =
+        match thread_ts with None -> "root" | Some ts -> "thread:" ^ ts
+      in
+      Format.fprintf fmt "To_slack{%s,%s,%s}" channel_id thread_label blocks_label
 
 let target : SP.post_target testable = testable target_pp ( = )
 
@@ -164,7 +167,7 @@ let test_slack_unbound_is_error () =
 
 let test_slack_single_binding_resolves_implicitly () =
   check (result target string) "single slack binding"
-    (Ok (SP.To_slack { channel_id = "C123456"; blocks = None }))
+    (Ok (SP.To_slack { channel_id = "C123456"; thread_ts = None; blocks = None }))
     (resolve ~surface:"slack" ~channel_id:None
        ~bound_discord_channels:[] ~bound_slack_channels:[ "C123456" ] ())
 
@@ -178,7 +181,7 @@ let test_slack_multiple_bindings_require_channel_id () =
         (Astring.String.is_infix ~affix:"AAA, BBB" message)
   | Ok _ -> fail "ambiguous slack binding must not resolve");
   check (result target string) "explicit channel_id picks one"
-    (Ok (SP.To_slack { channel_id = "BBB"; blocks = None }))
+    (Ok (SP.To_slack { channel_id = "BBB"; thread_ts = None; blocks = None }))
     (resolve ~surface:"slack" ~channel_id:(Some "BBB")
        ~bound_discord_channels:[] ~bound_slack_channels:[ "AAA"; "BBB" ] ())
 
@@ -194,9 +197,23 @@ let test_slack_continuation_selects_exact_bound_channel () =
     | Ok channel -> channel
     | Error message -> fail message
   in
-  check (result target string) "typed Slack continuation channel"
-    (Ok (SP.To_slack { channel_id = "BBB"; blocks = None }))
+  check (result target string) "typed Slack continuation channel keeps its thread"
+    (Ok
+       (SP.To_slack
+          { channel_id = "BBB"; thread_ts = Some "thread"; blocks = None }))
     (resolve ~surface:"slack" ~channel_id:None ~continuation_channel
+       ~bound_discord_channels:[] ~bound_slack_channels:[ "AAA"; "BBB" ] ());
+  check (result target string)
+    "explicit continuation channel also keeps its thread"
+    (Ok
+       (SP.To_slack
+          { channel_id = "BBB"; thread_ts = Some "thread"; blocks = None }))
+    (resolve ~surface:"slack" ~channel_id:(Some "BBB") ~continuation_channel
+       ~bound_discord_channels:[] ~bound_slack_channels:[ "AAA"; "BBB" ] ());
+  check (result target string)
+    "explicit different channel posts to its root, not a foreign thread"
+    (Ok (SP.To_slack { channel_id = "AAA"; thread_ts = None; blocks = None }))
+    (resolve ~surface:"slack" ~channel_id:(Some "AAA") ~continuation_channel
        ~bound_discord_channels:[] ~bound_slack_channels:[ "AAA"; "BBB" ] ())
 
 let test_slack_foreign_channel_id_is_error () =
@@ -224,10 +241,14 @@ let test_unsupported_surface_is_error () =
 let test_set_blocks_attaches_to_slack () =
   let block = `Assoc [ ("type", `String "section") ] in
   let resolved =
-    SP.set_blocks (SP.To_slack { channel_id = "C1"; blocks = None }) (Some [ block ])
+    SP.set_blocks
+      (SP.To_slack { channel_id = "C1"; thread_ts = None; blocks = None })
+      (Some [ block ])
   in
   check (result target string) "blocks attached"
-    (Ok (SP.To_slack { channel_id = "C1"; blocks = Some [ block ] }))
+    (Ok
+       (SP.To_slack
+          { channel_id = "C1"; thread_ts = None; blocks = Some [ block ] }))
     (Ok resolved)
 
 let test_set_blocks_ignores_other_targets () =
@@ -282,15 +303,40 @@ let test_terminal_receipt_requires_exact_supported_route () =
   in
   check bool "Slack post to the channel delivers an unthreaded continuation" true
     (SP.matches_continuation_route
-       (SP.To_slack { channel_id = "C1"; blocks = None })
+       (SP.To_slack { channel_id = "C1"; thread_ts = None; blocks = None })
        (slack "C1"));
-  (* Slack thread_ts is a destination distinct from the channel root and the
-     tool does not thread its post, so a channel post does not prove delivery of
-     a threaded Slack continuation; recovery settles it. *)
+  (* Slack thread_ts is a destination distinct from the channel root, so a
+     root post does not prove delivery of a threaded Slack continuation;
+     recovery settles it. *)
   check bool "Slack channel post does not satisfy a threaded continuation" false
     (SP.matches_continuation_route
-       (SP.To_slack { channel_id = "C1"; blocks = None })
+       (SP.To_slack { channel_id = "C1"; thread_ts = None; blocks = None })
        (slack ~thread_ts:"1700000000.000100" "C1"));
+  check bool "Slack thread post delivers the same threaded continuation" true
+    (SP.matches_continuation_route
+       (SP.To_slack
+          { channel_id = "C1"
+          ; thread_ts = Some "1700000000.000100"
+          ; blocks = None
+          })
+       (slack ~thread_ts:"1700000000.000100" "C1"));
+  check bool "Slack thread post does not satisfy a different thread" false
+    (SP.matches_continuation_route
+       (SP.To_slack
+          { channel_id = "C1"
+          ; thread_ts = Some "1700000000.000100"
+          ; blocks = None
+          })
+       (slack ~thread_ts:"1700000000.000200" "C1"));
+  check bool "Slack thread post does not satisfy an unthreaded continuation"
+    false
+    (SP.matches_continuation_route
+       (SP.To_slack
+          { channel_id = "C1"
+          ; thread_ts = Some "1700000000.000100"
+          ; blocks = None
+          })
+       (slack "C1"));
   check bool "keeper-global dashboard post has no exact thread receipt" false
     (SP.matches_continuation_route
        SP.To_dashboard


### PR DESCRIPTION
## 목표

Slack 스레드에서 keeper를 멘션하면 ack는 스레드에, 본답변은 채널 루트에 갈라져 게시되는 문제(#28375)의 근본 수정. `To_slack` 타깃이 thread 좌표를 타입으로 들지 않아 발생 — thread_ts를 resolve → gate input → replay → 전송 → 영속까지 관통시킨다.

## 변경 파일

- `lib/keeper/keeper_surface_post.ml/.mli` — `To_slack`에 `thread_ts : string option` 추가. continuation의 thread_ts는 **post가 continuation 자신의 채널에 갈 때만** 동행 (다른 채널의 thread_ts는 Slack이 거부). `matches_continuation_route`는 thread_ts 등식으로 threaded delivery를 증명 — threaded continuation이 terminal surface post로 해소될 때 더 이상 quarantine되지 않음 (`keeper_unified_turn.ml:1164` 소비처).
- `lib/keeper/keeper_tool_in_process_runtime.ml/.mli` — durable `connector_post` gate input에 `thread_ts` 필드 추가. replay 디코더는 부재를 허용(구 approval 데이터, 레거시 P0)하고 blank/비문자열은 거부. `Replay_slack_post`가 thread_ts를 실어 `send_message_with_blocks ?thread_ts`로 전송, `Surface_ref.Slack`에 실제 좌표 영속.
- `test/test_keeper_surface_post.ml` — thread 보존/탈락(명시적 타 채널)/route 증명 3값(같은 스레드 true, 다른 스레드 false, 루트 vs 스레드 false) 케이스 추가.
- `test/test_keeper_gate_replay.ml` — thread_ts 보존, 부재=None, blank/비문자열 거부 케이스 추가.

## 로컬 검증

- `dune build lib/masc.cma` green
- suite 실행: `test_keeper_surface_post` 19 green / `test_keeper_gate_replay` 25 green / `test_keeper_turn_outcome` 27 green
- `dune build @check`의 유일한 실패는 main 유래 `test_subsystem_health_state.ml` 파손(#28378, 수정 PR #28379) — 본 PR 무관

## 미검증

- 라이브 Slack 왕복(스레드 멘션 → 스레드 응답)은 머지 후 kidsnote keeper로 확인 예정
- Discord 경로는 무변경 (thread id = channel id 라 해당 없음)

Closes #28375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU1EnzuTuFCPZwbeqj9Ajr
