### PR TITLE
fix(test): bind State to Masc.Subsystem_health_state directly (지문 12호 최종층)

### DIFF
--- a/test/test_subsystem_health_state.ml
+++ b/test/test_subsystem_health_state.ml
@@ -1,4 +1,4 @@
-open Masc.Subsystem_health
+module State = Masc.Subsystem_health_state
 
 let apply event state = State.apply state event
 


### PR DESCRIPTION
지문 12호의 네 번째이자 마지막 층이에요. 제 #28373 은 `open Masc.Subsystem_health` 로 open 자체는 해석되게 했지만, `module State = Subsystem_health_state` alias 가 **subsystem_health.ml 구현 전용**이고 .mli 에 export 되지 않아 `Unbound module State`(:3) 가 남았어요 — 머지 전 이 테스트를 컴파일한 run 이 또 없었으니, 제 수리도 한 층만 벗긴 가짜였던 셈이에용. 정직하게 기록해요.

## 수정 (이번엔 층이 안 남아요)

`open Masc.Subsystem_health` → `module State = Masc.Subsystem_health_state`

- `Subsystem_health_state` 는 lib/ 의 독립 모듈이라 wrapped 이름 `Masc.Subsystem_health_state` 로 **직접** 접근 가능해요 — 인터페이스 중개가 필요 없어요.
- `.mli` 가 `val apply : t -> event -> t` (:17) 등 이 테스트의 사용 전부를 export 해요 — 실측.
- #28367 의 원래 줄에서 필요했던 건 처음부터 `Masc.` 접두 하나였어요. 네 번의 시도가 각각 한 겹씩 벗긴 사슬: unqualified alias(#28367) → 다른 unqualified(#28369) → open 은 되나 alias 비공개(#28373) → 직접 모듈 참조(이 PR).

대안이던 ".mli 에 State export 추가"는 테스트 편의를 위한 표면 확장 + dead-export ratchet 후보라 기각했어요.

피해자 3건(#28363, #28365, #28370)은 이 머지 후 재차 merge-in 하면 풀려요.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
