### PR TITLE
fix(keeper): clamp codex reasoning effort into the catalog's accepted set

### DIFF
--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -58,6 +58,51 @@ let finish_raw_success ~keeper_name raw_trace_run (result : Runtime_agent.run_re
      | false, _ | _, None -> result)
 ;;
 
+(* Catalog-driven reasoning-effort clamp for the Codex app-server runtime.
+
+   [Runtime_inference.resolve_reasoning_effort] reads the operator-declared
+   per-model effort from runtime config; the official-client (codex_app_server)
+   runtime sits outside AGENT_CORE's request-validation layer, so a value the
+   selected model does not accept (e.g. [Max] on a model whose catalog row only
+   accepts up to [XHigh]) reaches the provider and fails the turn with a 400.
+
+   Snap the requested effort into the catalog's accepted set rather than fail
+   the turn: the requested effort when it is accepted, otherwise the nearest
+   accepted effort (highest below; lowest when every accepted effort is higher).
+   The catalog ([models.toml] [accepted_reasoning_efforts]) is the SSOT, so an
+   operator controls the effective effort by editing that row. *)
+let clamp_reasoning_effort_to_catalog
+    ~(model_id : string option)
+    ~(requested : Llm_provider.Reasoning_effort.t option)
+    : Llm_provider.Reasoning_effort.t option =
+  match requested, model_id with
+  | None, _ | _, None -> requested
+  | Some effort, Some model ->
+    (match Llm_provider.Capabilities.for_model_id_catalog model with
+     | None -> requested
+     | Some caps ->
+       (match caps.Llm_provider.Capabilities.accepted_reasoning_efforts with
+        | None -> requested
+        | Some accepted when List.mem effort accepted -> requested
+        | Some [] -> requested
+        | Some (first :: rest as accepted) ->
+          let below =
+            List.filter
+              (fun candidate ->
+                 Llm_provider.Reasoning_effort.compare candidate effort < 0)
+              accepted
+          in
+          let pick_max a b =
+            if Llm_provider.Reasoning_effort.compare a b >= 0 then a else b
+          in
+          let pick_min a b =
+            if Llm_provider.Reasoning_effort.compare a b <= 0 then a else b
+          in
+          match below with
+          | [] -> Some (List.fold_left pick_min first rest)
+          | b_first :: b_rest -> Some (List.fold_left pick_max b_first b_rest)))
+;;
+
 let project_messages messages =
   let rec loop developer history = function
     | [] -> Ok (List.rev developer, List.rev history)
@@ -424,6 +469,28 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~model_input_projection
         ~hooks:(Some hooks)
     in
+    (* Snap the operator-declared effort into the catalog's accepted set so a
+       per-model cap (e.g. [Max] unsupported on a model that tops out at
+       [XHigh]) does not fail the turn. The catalog is the SSOT; an operator
+       widens the accepted set by editing [models.toml]. The same value feeds
+       the raw_trace start record and the request so observation matches the
+       wire. *)
+    let effective_reasoning_effort =
+      clamp_reasoning_effort_to_catalog
+        ~model_id:config.model
+        ~requested:prepared.reasoning_effort
+    in
+    ( match prepared.reasoning_effort, effective_reasoning_effort with
+      | Some asked, Some effective
+        when Llm_provider.Reasoning_effort.compare asked effective <> 0 ->
+        Log.Keeper.info
+          ~keeper_name
+          "%s reasoning effort clamped to catalog: model=%s asked=%s effective=%s"
+          runtime_label
+          (Option.value config.model ~default:runtime_id)
+          (Llm_provider.Reasoning_effort.to_string asked)
+          (Llm_provider.Reasoning_effort.to_string effective)
+      | _ -> () );
     let* developer_messages, history = project_messages prepared.messages in
     let* prompt =
       match goal_blocks with
@@ -522,7 +589,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             ?reasoning_effort:
               (Option.map
                  Llm_provider.Reasoning_effort.to_string
-                 prepared.reasoning_effort)
+                 effective_reasoning_effort)
             ())
     in
     let* host_dynamic_tools =
@@ -657,7 +724,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
          ~clock
          ~cwd:Eio.Path.(Eio.Stdenv.fs env / base_path)
          ~dynamic_tools
-         ?reasoning_effort:prepared.reasoning_effort
+         ?reasoning_effort:effective_reasoning_effort
          ~thread_mode
          ~history
          ?on_stream_event
@@ -938,4 +1005,5 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 module For_testing = struct
   let codex_error_to_core_error = codex_error_to_core_error
+  let clamp_reasoning_effort_to_catalog = clamp_reasoning_effort_to_catalog
 end

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -33,4 +33,13 @@ module For_testing : sig
       [test_keeper_codex_error_carriage]. RFC-0370 §3.1. *)
   val codex_error_to_core_error :
     Runtime_codex_app_server.error -> Agent_core.Error.t
+
+  (** Snap a requested reasoning effort into the catalog's accepted set for
+      [model_id]: the requested effort when it is accepted, otherwise the
+      nearest accepted effort. Pure; pinned by
+      [test_keeper_codex_effort_clamp]. *)
+  val clamp_reasoning_effort_to_catalog :
+       model_id:string option
+    -> requested:Llm_provider.Reasoning_effort.t option
+    -> Llm_provider.Reasoning_effort.t option
 end

--- a/packages/agent_core/lib/llm_provider/reasoning_effort.ml
+++ b/packages/agent_core/lib/llm_provider/reasoning_effort.ml
@@ -11,6 +11,23 @@ type t =
 
 let all = [ None_; Minimal; Low; Medium; High; XHigh; Max ]
 
+(* Ordinal position on the canonical effort ladder. The variant declaration
+   order already encodes the ladder (None_ < Minimal < ... < Max); this
+   explicit map makes the order nameable and keeps [compare] total so a future
+   variant addition surfaces as a non-exhaustive match instead of a silent
+   misorder. *)
+let rank = function
+  | None_ -> 0
+  | Minimal -> 1
+  | Low -> 2
+  | Medium -> 3
+  | High -> 4
+  | XHigh -> 5
+  | Max -> 6
+;;
+
+let compare a b = Int.compare (rank a) (rank b)
+
 let to_string = function
   | None_ -> "none"
   | Minimal -> "minimal"

--- a/packages/agent_core/lib/llm_provider/reasoning_effort.mli
+++ b/packages/agent_core/lib/llm_provider/reasoning_effort.mli
@@ -15,6 +15,17 @@ type t =
   | Max
 
 val all : t list
+
+(** Ordinal position on the canonical effort ladder (None_ = 0 .. Max = 6).
+    Exposed so callers can order efforts for catalog-driven clamping without
+    re-deriving the ladder at every consumer. *)
+val rank : t -> int
+
+(** Total order following the effort ladder ([None_] < [Minimal] < ... < [Max]).
+    Used by catalog-driven clamping to pick the nearest accepted effort below a
+    requested one. *)
+val compare : t -> t -> int
+
 val to_string : t -> string
 val pp : Format.formatter -> t -> unit
 val show : t -> string

--- a/test/dune
+++ b/test/dune
@@ -111,6 +111,7 @@
   test_keeper_turn_driver_failover
   test_keeper_rotation_eligibility_census
   test_keeper_codex_error_carriage
+  test_keeper_codex_effort_clamp
   test_domain_pool
   test_sse
   test_graphql_api
@@ -405,6 +406,7 @@
   test_keeper_turn_driver_failover
   test_keeper_rotation_eligibility_census
   test_keeper_codex_error_carriage
+  test_keeper_codex_effort_clamp
   test_domain_pool
   test_sse
   test_graphql_api

--- a/test/test_keeper_codex_effort_clamp.ml
+++ b/test/test_keeper_codex_effort_clamp.ml
@@ -1,0 +1,75 @@
+(* Pins catalog-driven reasoning-effort clamping for the Codex app-server
+   runtime. The official-client runtime sits outside AGENT_CORE's request
+   validation, so an operator-declared effort the model rejects (e.g. [Max] on
+   a model whose catalog row tops out at [XHigh]) would reach the provider and
+   fail the turn with a 400. The keeper clamps the effort into the catalog's
+   accepted set before the request leaves the process. *)
+
+module Map = Masc.Keeper_codex_runtime.For_testing
+module Effort = Llm_provider.Reasoning_effort
+
+let label = function
+  | None -> "none"
+  | Some e -> Effort.to_string e
+
+let check_case ~label_prefix ~model_id ~requested ~expected () =
+  let got = Map.clamp_reasoning_effort_to_catalog ~model_id ~requested in
+  Alcotest.(check string)
+    (label_prefix ^ ": " ^ label requested ^ " -> " ^ label expected)
+    (label expected)
+    (label got)
+;;
+
+let test_clamp () =
+  let spark = "gpt-5.3-codex-spark-1p-codexswic-ev3" in
+  (* Regression: spark tops out at [XHigh]; [Max] must snap down to [XHigh]
+     rather than fail the turn. This also pins the spark catalog row: if the
+     row is removed the lookup returns [None] and [Max] passes through
+     unchanged, failing this assertion. *)
+  check_case
+    ~label_prefix:"spark"
+    ~model_id:(Some spark)
+    ~requested:(Some Effort.Max)
+    ~expected:(Some Effort.XHigh)
+    ();
+  check_case
+    ~label_prefix:"spark"
+    ~model_id:(Some spark)
+    ~requested:(Some Effort.XHigh)
+    ~expected:(Some Effort.XHigh)
+    ();
+  check_case
+    ~label_prefix:"spark"
+    ~model_id:(Some spark)
+    ~requested:(Some Effort.High)
+    ~expected:(Some Effort.High)
+    ();
+  check_case
+    ~label_prefix:"spark"
+    ~model_id:(Some spark)
+    ~requested:None
+    ~expected:None
+    ();
+  (* No model id: the keeper cannot look up a catalog row, so the requested
+     effort passes through unchanged. *)
+  check_case
+    ~label_prefix:"no-model"
+    ~model_id:None
+    ~requested:(Some Effort.Max)
+    ~expected:(Some Effort.Max)
+    ();
+  (* Catalog miss: an unrecognized model imposes no constraint. *)
+  check_case
+    ~label_prefix:"unknown"
+    ~model_id:(Some "masc-test-no-such-model")
+    ~requested:(Some Effort.Max)
+    ~expected:(Some Effort.Max)
+    ()
+;;
+
+let () =
+  Alcotest.run
+    "keeper_codex_effort_clamp"
+    [ ( "clamp"
+      , [ Alcotest.test_case "catalog clamps effort" `Quick test_clamp ] ) ]
+;;


### PR DESCRIPTION
## What

The official Codex app-server runtime (keeper path) sent an operator-declared `reasoning.effort` verbatim to the provider, so a model that rejects that value failed the turn with a 400:

```
Unsupported value: 'max' is not supported with the 'gpt-5.3-codex-spark-1p-codexswic-ev3' model.
Supported values are: 'low', 'medium', 'high', and 'xhigh'.   (param: reasoning.effort, status: 400)
```

## Why

The official-client runtimes sit outside AGENT_CORE's request validation — `runtime.ml` returns no capabilities for them (a load-bearing design, not a bug), so nothing clamped an operator-declared effort the model rejects before it left the process. agent_core backends have their own enforcement; the external `codex_app_server` lane did not.

## How

Before the request leaves the process, look up the model's `accepted_reasoning_efforts` via `Capabilities.for_model_id_catalog` and snap the requested effort to the nearest accepted value when it is not in the set:

- the highest accepted effort below the request (Max → XHigh on spark), or
- the lowest accepted, if every accepted effort ranks above the request.

The clamp is **policy, not a hard reject**. A keeper (autonomous) turn stops on a hard reject, so the catalog SSOT is honored with an observable clamp: the info log, `raw_trace`, and `run_turn` all carry the effective effort, not the requested one. This is distinct from the agent_core backends, where a reject is recoverable via lane rotation — a different question, so a different failure policy.

## Operator-settable surface

The catalog row IS the configuration interface: `accepted_reasoning_efforts` in `models.toml` is the single source of truth for per-model accepted efforts. The spark row already lists `["none","minimal","low","medium","high","xhigh"]` (no `max`), so no catalog change was needed — only the clamp that consults it. Adding or removing an accepted value for a model is a one-line catalog edit.

## Test

`test_keeper_codex_effort_clamp` pins six cases. The regression case fails if the spark catalog row is removed (the lookup returns `None` and `Max` passes through unchanged), so the test also pins the catalog row itself:

- spark + Max → XHigh
- spark + XHigh / High stay
- spark + None → None
- no model id → Max unchanged
- unknown model → Max unchanged

## Known CI dependency

`Build and Test` is expected to fail until #28379 lands. origin/main's `test_subsystem_health_state` does not compile: `Unbound module State`, because `lib/subsystem_health.mli` hides the `module State = Subsystem_health_state` alias that `lib/subsystem_health.ml:12` defines. Reproduced on a pristine detached `origin/main` checkout (4db3f162b5); unrelated to this PR. Will rebase onto main once #28379 merges.

## RFC

Not in an RFC-gated subsystem (credential / identity / repo / operator / sandbox / hooks / workflow). `keeper_codex_runtime` is the official-client turn runtime; `llm_provider` is the typed provider surface.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
