### PR TITLE
fix(auth): bearer 자격증명이 caller identity 를 결정하도록

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1011,6 +1011,7 @@ jobs:
             @test/runtest-test_auth_oauth \
             @test/runtest-test_server_oauth_protocol \
             @test/runtest-test_server_auth_dashboard_actor_resolution \
+            @test/runtest-test_caller_identity_credential_binding \
             @test/runtest-test_error_body_wire_shape \
             @test/runtest-test_mcp_error_code \
             @test/runtest-test_tool_registry_consistency \

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -203,6 +203,39 @@ let resolve_auth_fallback_agent_name
   | None -> minted
   | Some _ -> minted
 
+(** May the workspace display alias rewrite this caller name?
+
+    [Workspace.resolve_agent_name] answers "which agent record should this
+    name display as" by scanning [agents_dir] for the first file whose name
+    starts with [agent_name ^ "-"]. That is a display-layer lookup over a
+    directory listing, and it happily maps one identity onto an unrelated
+    record that merely shares the prefix — with no [dashboard.json] record
+    present, ["dashboard"] resolves to ["dashboard-admin-deft-cobra"].
+
+    The resolved name is then the subject of [Auth.authorize_tool_v2], which
+    verifies the presented token against *that subject's* credential. So a
+    caller holding the dashboard's own valid credential was authorized as a
+    different agent and rejected with [InvalidToken "Token mismatch"] — the
+    token was never the problem, and no token refresh could fix it.
+
+    The bearer credential is the authority on who the caller is. The display
+    alias may only rewrite a name the presented credential does not already
+    own. *)
+let alias_may_rewrite_identity ~credential_owner ~agent_name =
+  match credential_owner with
+  | Some owner -> not (String.equal owner agent_name)
+  | None -> true
+
+(** The authorization subject for this call: [agent_name], put through the
+    display alias only where {!alias_may_rewrite_identity} allows it.
+    [resolve_alias] is the workspace lookup, injected so the ordering between
+    the guard and the lookup is testable without a live workspace. *)
+let resolve_identity_alias ~credential_owner ~resolve_alias agent_name =
+  if alias_may_rewrite_identity ~credential_owner ~agent_name then
+    resolve_alias agent_name
+  else
+    agent_name
+
 let resolve_explicit_bound_alias ~config ~workspace_initialized ~log_mcp_exn
     ~has_explicit_agent_name agent_name =
   if has_explicit_agent_name && not (Nickname.is_generated_nickname agent_name)
@@ -249,17 +282,23 @@ let resolve ~(config : Workspace_utils_backend_setup.config) ~tool_name ~argumen
     | Some raw -> Auth.verify_internal_keeper_token config.base_path ~token:raw
     | None -> false
   in
-  let owner_keeper_identity =
+  (* The agent that owns the presented bearer credential. Resolved once and
+     used for both the keeper-owner projection and the alias guard below, so
+     one request performs one credential lookup instead of two. *)
+  let credential_owner =
     match token with
     | None -> None
     | Some raw -> (
         match Auth.resolve_agent_from_token config.base_path ~token:raw with
-        | Ok owner_name -> resolve_owner_keeper_identity config owner_name
+        | Ok owner_name -> Some owner_name
         | Error msg ->
             Log.Auth.routine
-              "owner_keeper_identity: token resolve failed: %s"
+              "caller identity: bearer token resolve failed: %s"
               (Masc_domain.masc_error_to_string msg);
             None)
+  in
+  let owner_keeper_identity =
+    Option.bind credential_owner (resolve_owner_keeper_identity config)
   in
   let mode_gate_error =
     if
@@ -283,8 +322,12 @@ let resolve ~(config : Workspace_utils_backend_setup.config) ~tool_name ~argumen
      decision. The record field [agent_name] stays a [string]. *)
   let agent_name = minted_name_to_string resolved_minted in
   let agent_name =
-    resolve_explicit_bound_alias ~config ~workspace_initialized ~log_mcp_exn
-      ~has_explicit_agent_name agent_name
+    resolve_identity_alias
+      ~credential_owner
+      ~resolve_alias:
+        (resolve_explicit_bound_alias ~config ~workspace_initialized
+           ~log_mcp_exn ~has_explicit_agent_name)
+      agent_name
   in
   {
     agent_name;

--- a/lib/mcp_server_eio_caller_identity.mli
+++ b/lib/mcp_server_eio_caller_identity.mli
@@ -24,6 +24,26 @@ val minted_name_is_transient : minted_name -> bool
     This is origin-based, not shape-based: [Stable -> false],
     [Ephemeral -> true], [Resolved_external _ -> false]. *)
 
+val alias_may_rewrite_identity :
+  credential_owner:string option -> agent_name:string -> bool
+(** Whether the workspace display alias ([Workspace.resolve_agent_name], a
+    prefix scan over [agents_dir]) may replace this caller name.
+
+    The resolved name becomes the subject of [Auth.authorize_tool_v2], which
+    checks the presented token against that subject's credential. A prefix
+    match onto an unrelated record therefore turns a valid credential into
+    [InvalidToken "Token mismatch"]. Answers [false] exactly when the
+    presented credential already owns [agent_name]. *)
+
+val resolve_identity_alias :
+  credential_owner:string option ->
+  resolve_alias:(string -> string) ->
+  string ->
+  string
+(** The authorization subject: the caller name put through [resolve_alias]
+    (the workspace display lookup) only where
+    {!alias_may_rewrite_identity} allows it. *)
+
 type t = {
   agent_name : string;
   agent_name_is_ephemeral : bool;

--- a/test/dune
+++ b/test/dune
@@ -1025,6 +1025,7 @@
   test_mcp_session_task_lifecycle
   test_client_registry_eio
   test_minted_name_gate
+  test_caller_identity_credential_binding
   test_identity_e2e
   test_identity_edge_cases
   test_verification
@@ -1164,6 +1165,7 @@
   test_mcp_session_task_lifecycle
   test_client_registry_eio
   test_minted_name_gate
+  test_caller_identity_credential_binding
   test_identity_e2e
   test_identity_edge_cases
   test_verification

--- a/test/test_caller_identity_credential_binding.ml
+++ b/test/test_caller_identity_credential_binding.ml
@@ -1,0 +1,139 @@
+(** Regression guard: a bearer credential decides the caller identity, and
+    the workspace display alias must not overrule it.
+
+    Observed on the live fleet (2026-08-12): every dashboard MCP tool call
+    failed with [AuthError] Invalid token: Token mismatch while presenting the
+    dashboard's own freshly minted credential. 860 failures in 3.5 hours, all
+    with agent_name="dashboard".
+
+    Chain, measured against the live workspace:
+
+      .masc/agents/dashboard.json                    absent
+      .masc/agents/dashboard-admin-deft-cobra.json   present
+      Workspace.resolve_agent_name "dashboard"    -> "dashboard-admin-deft-cobra"
+      Auth.verify_token ~agent_name:"dashboard"                  -> Ok
+      Auth.verify_token ~agent_name:"dashboard-admin-deft-cobra" -> Error
+                                        (InvalidToken "Token mismatch")
+
+    The alias is a display-layer prefix scan over a directory listing; it was
+    feeding the authorization subject. No token rotation could clear this,
+    because the presented token was never the failing input. *)
+
+open Alcotest
+
+module Caller = Masc.Mcp_server_eio_caller_identity
+
+let may_rewrite ~credential_owner ~agent_name =
+  Caller.alias_may_rewrite_identity ~credential_owner ~agent_name
+
+(* The exact live shape: the request names the credential it holds. *)
+let test_credential_owned_name_is_not_rewritable () =
+  check
+    bool
+    "an alias cannot rewrite the name owned by the presented credential"
+    false
+    (may_rewrite ~credential_owner:(Some "dashboard") ~agent_name:"dashboard")
+
+(* Keeper transport aliases keep working: the caller names "rondo" while the
+   credential belongs to "keeper-rondo-agent", so the alias is still the only
+   thing that can connect the two. *)
+let test_unowned_name_stays_rewritable () =
+  check
+    bool
+    "an alias may still rewrite a name the credential does not own"
+    true
+    (may_rewrite
+       ~credential_owner:(Some "keeper-rondo-agent")
+       ~agent_name:"rondo")
+
+let test_unauthenticated_request_stays_rewritable () =
+  check
+    bool
+    "without a resolvable credential the alias keeps its previous authority"
+    true
+    (may_rewrite ~credential_owner:None ~agent_name:"dashboard")
+
+(* Prefix-sharing is what the workspace scan matches on, and it is exactly
+   what must not reach the authorization subject when the name is owned. *)
+let test_prefix_sharing_owner_is_not_rewritable () =
+  List.iter
+    (fun name ->
+      check
+        bool
+        (Printf.sprintf "%S is credential-bound, so no alias rewrite" name)
+        false
+        (may_rewrite ~credential_owner:(Some name) ~agent_name:name))
+    [ "dashboard"; "dashboard-admin"; "keeper-rondo-agent"; "analyst" ]
+
+(* The live workspace lookup, as a stub: no [dashboard.json] record exists,
+   so the prefix scan returns the first record sharing the "dashboard-"
+   prefix. Injecting it pins the ordering between the guard and the lookup,
+   which is the part that decides what reaches [Auth.authorize_tool_v2]. *)
+let live_alias_scan = function
+  | "dashboard" | "dashboard-admin" -> "dashboard-admin-deft-cobra"
+  | "rondo" -> "keeper-rondo-agent"
+  | name -> name
+
+let subject_for ~credential_owner agent_name =
+  Caller.resolve_identity_alias
+    ~credential_owner
+    ~resolve_alias:live_alias_scan
+    agent_name
+
+let test_authorization_subject_is_the_presented_credential () =
+  check
+    string
+    "the dashboard's own credential authorizes as the dashboard"
+    "dashboard"
+    (subject_for ~credential_owner:(Some "dashboard") "dashboard")
+
+let test_authorization_subject_keeps_transport_alias () =
+  check
+    string
+    "a keeper transport alias still resolves to its bound record"
+    "keeper-rondo-agent"
+    (subject_for ~credential_owner:(Some "keeper-rondo-agent") "rondo")
+
+let test_authorization_subject_without_credential () =
+  check
+    string
+    "an unauthenticated caller keeps the previous alias behaviour"
+    "dashboard-admin-deft-cobra"
+    (subject_for ~credential_owner:None "dashboard")
+
+let () =
+  run
+    "caller_identity_credential_binding"
+    [ ( "authorization subject"
+      , [ test_case
+            "presented credential is the subject"
+            `Quick
+            test_authorization_subject_is_the_presented_credential
+        ; test_case
+            "transport alias still resolves"
+            `Quick
+            test_authorization_subject_keeps_transport_alias
+        ; test_case
+            "no credential keeps alias behaviour"
+            `Quick
+            test_authorization_subject_without_credential
+        ] )
+    ; ( "alias vs credential"
+      , [ test_case
+            "credential-owned name is not rewritable"
+            `Quick
+            test_credential_owned_name_is_not_rewritable
+        ; test_case
+            "unowned name stays rewritable"
+            `Quick
+            test_unowned_name_stays_rewritable
+        ; test_case
+            "unauthenticated request stays rewritable"
+            `Quick
+            test_unauthenticated_request_stays_rewritable
+        ; test_case
+            "prefix-sharing owners are not rewritable"
+            `Quick
+            test_prefix_sharing_owner_is_not_rewritable
+        ] )
+    ]


### PR DESCRIPTION
## 증상

대시보드 채팅 화면에서 `[AuthError] Invalid token: Token mismatch` 가 계속 뜨고, 토큰을 새로 받아도 사라지지 않았습니다.

실측 (live fleet, 2026-08-12):

| 항목 | 값 |
|---|---|
| `Token mismatch` 실패 건수 | 860건 (06:14Z ~ 09:49Z) |
| 그 중 `masc_keeper_status` | 848건 |
| agent_name | 전부 `dashboard` |
| 다른 자격증명 (`keeper-*-agent`) | 전부 정상 |

`.masc/auth/dashboard.token` 의 **현재 유효한** 토큰으로 직접 호출해도 동일하게 실패했습니다. 즉 토큰은 실패 원인이 아니었습니다.

```
POST /mcp  Authorization: Bearer <current dashboard.token>
  -> HTTP 200, isError=true, structuredContent.auth_error_code="invalid_token"
     "[AuthError] Invalid token: Token mismatch"
```

## 원인

`Workspace.resolve_agent_name` 은 "이 이름을 어느 agent record 로 표시할 것인가" 라는 **표시 계층 질문**에 답합니다. 구현은 `agents_dir` 에서 `<name>-` 로 시작하는 첫 파일을 찾는 prefix 스캔입니다 (`lib/workspace/workspace_identity.ml:33`).

그 결과가 `Auth.authorize_tool_v2` 의 **인증 주체**로 그대로 흘러갑니다 (`lib/mcp_server_eio_execute.ml:175`).

라이브 워크스페이스 실측 (`lib/auth` + `Workspace` 직접 호출 probe):

```
.masc/agents/dashboard.json                    없음
.masc/agents/dashboard-admin-deft-cobra.json   있음 (status=active, session_bound_at 존재)

Workspace.resolve_agent_name "dashboard"    -> "dashboard-admin-deft-cobra"
Auth.verify_token ~agent_name:"dashboard"                  -> Ok
Auth.verify_token ~agent_name:"dashboard-admin-deft-cobra" -> Error (InvalidToken "Token mismatch")
```

`dashboard-admin-deft-cobra` 토큰으로 호출하면 정상 통과하는 것도 같은 사슬로 설명됩니다 (exact match 라 alias 가 자기 자신을 가리킴).

토큰이 원인이 아니므로 대시보드의 typed self-healing (RFC-0340 §Typed self-healing) 은 같은 자격증명을 다시 받아 무한히 재시도했습니다. 이것이 재접속 토스트와 콘솔 폭주의 원인입니다.

## 수정

RFC-0340 §Request identity: *"A bearer-bound request must resolve to a credential identity."*

제시된 bearer 자격증명이 이미 소유한 이름은 display alias 가 덮어쓸 수 없게 했습니다.

- `alias_may_rewrite_identity ~credential_owner ~agent_name`
- `resolve_identity_alias` — 가드와 workspace 조회의 순서를 고정 (테스트 가능한 seam)
- credential owner 를 요청당 1회만 조회하고 keeper-owner projection 과 공유 (기존 2회 조회 → 1회)

동작 변화가 없는 경로:
- keeper transport alias (caller `rondo`, credential `keeper-rondo-agent`) — 소유하지 않은 이름이므로 alias 그대로 적용
- 인증되지 않은 요청 — 이전과 동일

## 검증

```
dune build --root . @check                                            # exit 0
dune build --root . @test/runtest-test_caller_identity_credential_binding  # 7 tests, 0 failed
```

가드가 실제로 동작하는지 mutation 으로 확인했습니다. `resolve_identity_alias` 에서 가드를 제거하면:

```
  Expected: `"dashboard"'
  Received: `"dashboard-admin-deft-cobra"'
  1 failure! 7 tests run.
```

새 스위트는 CI 의 auth 스텝(`@test/runtest-test_auth` 와 같은 스텝)에 배선했습니다. 배선하지 않으면 컴파일만 되고 실행되지 않습니다.

## 남은 것 (이 PR 범위 밖)

`Workspace.resolve_agent_name` 의 prefix 스캔은 `Sys.readdir` 순서에 의존합니다. `<name>-` 접두 파일이 2개 이상이면 어느 것이 선택될지 정해져 있지 않습니다. 표시 계층에서는 관측된 피해가 없어 이 PR 에서 건드리지 않았고, 인증 경로와의 연결만 끊었습니다.

RFC-0340 (docs/rfc/RFC-0340-dashboard-token-only-auth.md) §Request identity 를 근거로 합니다.
