### PR TITLE
fix(dashboard): 로스터 정렬·턴 타임라인 접힘·인증 복구가 스스로 리셋되지 않도록

### DIFF
--- a/dashboard/src/api/dev-token.test.ts
+++ b/dashboard/src/api/dev-token.test.ts
@@ -197,7 +197,10 @@ describe('ensureDevToken', () => {
 
     await expect(refreshDevTokenAfterAuthError('invalid_token')).resolves.toBe(true)
     expect(token).toBe('fresh-token')
-    expect(clearStoredToken).toHaveBeenCalledTimes(1)
+    // Recovery replaces the token in place. Clearing first would be a second
+    // token-revision change, and each one re-dials the dashboard websocket.
+    expect(clearStoredToken).not.toHaveBeenCalled()
+    expect(setStoredToken).toHaveBeenCalledTimes(1)
     expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
 
     await expect(refreshDevTokenAfterAuthError('insufficient_role')).resolves.toBe(false)
@@ -229,7 +232,7 @@ describe('ensureDevToken', () => {
 
     const first = refreshDevTokenAfterAuthError('invalid_token')
     const second = refreshDevTokenAfterAuthError('token_expired')
-    expect(clearStoredToken).toHaveBeenCalledTimes(1)
+    expect(clearStoredToken).not.toHaveBeenCalled()
     expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
 
     resolveFetch(jsonResponse({
@@ -240,5 +243,39 @@ describe('ensureDevToken', () => {
 
     await expect(Promise.all([first, second])).resolves.toEqual([true, true])
     expect(token).toBe('fresh-token')
+  })
+
+  // A rejection the token cannot fix (server-side identity or policy) hands
+  // back the same credential. Calling that "recovered" makes the caller retry
+  // the identical request and refresh again on the identical failure, and
+  // every pass re-dials the websocket.
+  it('does not report recovery when the endpoint returns the same token', async () => {
+    let token: string | null = 'current-token'
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'admin' } | null = {
+      source: 'dev',
+      actor: 'dashboard',
+      role: 'admin',
+    }
+    getStoredToken.mockImplementation(() => token)
+    getStoredTokenMeta.mockImplementation(() => meta)
+    clearStoredToken.mockImplementation(() => {
+      token = null
+      meta = null
+    })
+    setStoredToken.mockImplementation((nextToken, nextMeta) => {
+      token = nextToken
+      meta = nextMeta
+    })
+    fetchWithTimeout.mockResolvedValueOnce(jsonResponse({
+      token: 'current-token',
+      actor: 'dashboard',
+      role: 'admin',
+    }))
+
+    await expect(refreshDevTokenAfterAuthError('invalid_token')).resolves.toBe(false)
+    expect(token).toBe('current-token')
+    // Unchanged credential, so nothing may announce a token change.
+    expect(setStoredToken).not.toHaveBeenCalled()
+    expect(clearStoredToken).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/api/dev-token.ts
+++ b/dashboard/src/api/dev-token.ts
@@ -167,10 +167,27 @@ export async function refreshDevTokenAfterAuthError(code: unknown): Promise<bool
   if (!getStoredToken()) return false
 
   const refresh = (async () => {
-    clearStoredToken()
+    // Re-fetch in place instead of clearing first. `clearStoredToken()` +
+    // `setStoredToken()` are two token-revision changes, and every change
+    // tears down and re-dials the dashboard websocket
+    // (`subscribeStoredTokenChanges` -> `reconnectAfterAuthTokenChange`), so
+    // one recovery produced two reconnects and two "서버 연결 복구됨"
+    // toasts. It also left a window where in-flight requests carried no
+    // Authorization header at all. `shouldRefreshDevToken()` already returns
+    // true for a stored `dev` token, so dropping the clear does not stop the
+    // re-fetch — and `ensureDevToken` only writes when the token differs.
+    const rejectedToken = getStoredToken()
     resetDevTokenBootstrap()
     await ensureDevToken()
-    return getStoredTokenMeta()?.source === 'dev' && getStoredToken() !== null
+    const refreshedToken = getStoredToken()
+    // Recovery means the caller now holds a *different* credential. Getting
+    // the same token back proves the token was not the reason the request
+    // was rejected; reporting success there makes the caller retry the
+    // identical request, fail identically, and refresh again — a loop that
+    // reconnects the websocket on every pass and never terminates.
+    return getStoredTokenMeta()?.source === 'dev'
+      && refreshedToken !== null
+      && refreshedToken !== rejectedToken
   })()
   devTokenRefreshPromise = refresh
   try {

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -12,6 +12,7 @@ import {
   ChatComposer,
   ChatTranscript,
   THINKING_TRACE_PREVIEW_CHARS,
+  _resetTraceCardOpenChoicesForTests,
   type ChatComposerSendPayload,
 } from './primitives'
 import { _resetChatStoreForTests, readKeeperDraft } from '../../keeper-chat-store'
@@ -115,6 +116,13 @@ function entry(
     ...rest,
   }
 }
+
+// Turn-timeline collapse choices are module state by design: they outlive
+// the transcript unmount that switching keepers causes. Clear them between
+// cases so no test inherits another's toggle.
+beforeEach(() => {
+  _resetTraceCardOpenChoicesForTests()
+})
 
 describe('ChatTranscript', () => {
   let container: HTMLDivElement
@@ -2823,6 +2831,89 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(settledTrace?.getAttribute('data-chat-turn-complete')).toBe('true')
     expect(container.querySelector('[data-chat-trace-step="think"]')?.textContent).toContain(thinking)
     expect(container.querySelector('[data-chat-trace-step="chat"]')?.textContent).toContain('완료된 응답')
+  })
+
+  // Switching keepers unmounts the whole transcript. The operator's collapse
+  // choice is addressed by turn id, not by component instance, so it has to
+  // survive that unmount — otherwise every timeline the operator folded away
+  // springs back open on return.
+  it('keeps a collapsed turn timeline collapsed across a transcript remount', async () => {
+    const settled = entry({
+      id: 'turn-collapse',
+      text: '완료된 응답',
+      role: 'assistant',
+      source: 'direct_assistant',
+      streamState: null,
+      delivery: 'history',
+      traceSteps: [{ kind: 'think', text: 'considered the options' }],
+    })
+    const renderTurn = (): void => {
+      render(
+        html`<${ChatTranscript}
+          entries=${[settled]}
+          emptyText="empty"
+          groupToolCalls=${true}
+          variant="messenger"
+        />`,
+        container,
+      )
+    }
+    const toggleEl = (): HTMLButtonElement | null =>
+      container.querySelector('.chat-block-trace-hd') as HTMLButtonElement | null
+
+    renderTurn()
+    expect(toggleEl()?.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.click(toggleEl() as HTMLButtonElement)
+    await waitFor(() => {
+      expect(toggleEl()?.getAttribute('aria-expanded')).toBe('false')
+    })
+
+    // The keeper switch: transcript unmounted, then mounted again.
+    render(null, container)
+    renderTurn()
+
+    expect(toggleEl()?.getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelector('[data-chat-trace-step="think"]')).toBeNull()
+  })
+
+  it('re-opens a turn timeline the operator expanded after a remount', async () => {
+    const live = (streaming: boolean): KeeperConversationEntry =>
+      entry({
+        id: 'turn-expand',
+        text: streaming ? '응답 작성 중' : '완료된 응답',
+        role: 'assistant',
+        source: 'direct_assistant',
+        streamState: streaming ? 'streaming' : null,
+        delivery: streaming ? 'streaming' : 'history',
+        traceSteps: [{ kind: 'think', text: 'considered the options' }],
+      })
+    const renderTurn = (streaming: boolean): void => {
+      render(
+        html`<${ChatTranscript}
+          entries=${[live(streaming)]}
+          emptyText="empty"
+          groupToolCalls=${true}
+          variant="messenger"
+        />`,
+        container,
+      )
+    }
+    const toggleEl = (): HTMLButtonElement | null =>
+      container.querySelector('.chat-block-trace-hd') as HTMLButtonElement | null
+
+    renderTurn(true)
+    expect(toggleEl()?.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(toggleEl() as HTMLButtonElement)
+    await waitFor(() => {
+      expect(toggleEl()?.getAttribute('aria-expanded')).toBe('true')
+    })
+
+    render(null, container)
+    renderTurn(true)
+
+    expect(toggleEl()?.getAttribute('aria-expanded')).toBe('true')
   })
 
   it('renders board post ids in assistant prose as board detail links', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3429,6 +3429,37 @@ function ChatResponseTraceStep({
   `
 }
 
+/** Addressable identity for one turn's timeline block. The assistant row owns
+ *  a turn bundle; a tool-only group is addressed by its first tool row. Both
+ *  ids come from the conversation store, so they survive the transcript
+ *  unmount that a keeper switch causes. */
+function traceCardIdentity(
+  assistant: KeeperConversationEntry | null,
+  tools: readonly KeeperConversationEntry[],
+): string | null {
+  if (assistant) return `turn:${assistant.id}`
+  const first = tools[0]
+  return first ? `tools:${first.id}` : null
+}
+
+/** Turn timelines the operator explicitly opened or collapsed. Only explicit
+ *  toggles are recorded, so the map is bounded by operator actions rather
+ *  than by transcript size. */
+const traceCardOpenChoices = new Map<string, boolean>()
+
+function traceCardOpenOverride(cardKey: string): boolean | undefined {
+  return traceCardOpenChoices.get(cardKey)
+}
+
+function setTraceCardOpenOverride(cardKey: string, open: boolean): void {
+  traceCardOpenChoices.set(cardKey, open)
+}
+
+/** Test-only: drop recorded collapse choices between cases. */
+export function _resetTraceCardOpenChoicesForTests(): void {
+  traceCardOpenChoices.clear()
+}
+
 function ToolTraceCard({
   tools,
   traceSteps = [],
@@ -3448,14 +3479,22 @@ function ToolTraceCard({
 }) {
   const liveTurn = assistant !== null && !turnComplete
   const structuralSummary = assistant?.source === 'autonomous_turn'
-  const userToggledRef = useRef(false)
-  const [open, setOpen] = useState(() => !liveTurn)
-  useEffect(() => {
-    if (!liveTurn && !userToggledRef.current) setOpen(true)
-  }, [liveTurn])
+  // Collapse state is derived, not stored-and-resynced: the operator's
+  // explicit choice for this turn if there is one, otherwise "open once the
+  // turn is no longer live". The choice lives outside the component because
+  // switching keepers unmounts the whole transcript — with the state held in
+  // `useState` + a `useRef` "did the user toggle" flag, both reset on remount
+  // and every collapsed timeline sprang back open.
+  const cardKey = traceCardIdentity(assistant, tools)
+  const [localOpen, setLocalOpen] = useState<boolean | null>(null)
+  const open =
+    (cardKey !== null ? traceCardOpenOverride(cardKey) : localOpen) ?? !liveTurn
   const toggleOpen = () => {
-    userToggledRef.current = true
-    setOpen((o) => !o)
+    const next = !open
+    if (cardKey !== null) setTraceCardOpenOverride(cardKey, next)
+    // Also drives the re-render; carries the state outright for a card with
+    // no addressable turn identity.
+    setLocalOpen(next)
   }
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
   const coverageStateForEntry = (entry: KeeperConversationEntry): ToolOutputCoverageState =>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -240,7 +240,55 @@ describe('KeeperWorkspaceRoster', () => {
     })
   })
 
-  it('sorts observed zero context ahead of unknown context', () => {
+  // The grouped view orders by the key the row prints. Context ratio is not
+  // on the row and moves every turn, so ordering by it reshuffled the list
+  // under the operator; recency is visible and is the same key the keepers
+  // page uses to pick its default selection.
+  it('orders a status group by the recency each row displays', () => {
+    keepers.value = [
+      mk({
+        name: 'a-stale-but-full',
+        status: 'running',
+        lifecycle_phase: 'Running',
+        context_ratio: 0.9,
+        last_activity_at: '2026-08-12T09:00:00Z',
+      }),
+      mk({
+        name: 'z-fresh-but-empty',
+        status: 'running',
+        lifecycle_phase: 'Running',
+        context_ratio: 0,
+        last_activity_at: '2026-08-12T09:30:00Z',
+      }),
+    ]
+    render(html`<${KeeperWorkspaceRoster} activeName="a-stale-but-full" />`, host)
+
+    const rows = Array.from(host.querySelectorAll('.kw-kp-row'))
+    expect(rows.map(row => row.textContent)).toEqual([
+      expect.stringContaining('z-fresh-but-empty'),
+      expect.stringContaining('a-stale-but-full'),
+    ])
+  })
+
+  // Same-recency rows must not depend on arrival order in the store: the
+  // reported symptom was a list that reshuffled between snapshots.
+  it('breaks a recency tie by name so the grouped order is stable', () => {
+    const rowsFor = (order: readonly string[]) => {
+      keepers.value = order.map(name =>
+        mk({ name, status: 'running', lifecycle_phase: 'Running' }),
+      )
+      render(null, host)
+      render(html`<${KeeperWorkspaceRoster} activeName=${order[0]} />`, host)
+      return Array.from(host.querySelectorAll('.kw-kp-row')).map(row => row.textContent)
+    }
+
+    const forward = rowsFor(['alpha', 'bravo', 'charlie'])
+    const reversed = rowsFor(['charlie', 'bravo', 'alpha'])
+    expect(forward).toEqual(reversed)
+  })
+
+  it('sorts observed zero context ahead of unknown context under the 주의 sort', () => {
+    rosterSortPref.value = 'att'
     keepers.value = [
       mk({ name: 'a-unknown', status: 'running', lifecycle_phase: 'Running' }),
       mk({ name: 'z-observed-zero', status: 'running', lifecycle_phase: 'Running', context_ratio: 0 }),

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -24,7 +24,7 @@ import { persistentSignal } from '../../lib/persistent-signal'
 import { keeperActivityDisplay, keeperDisplayRuntime } from '../../lib/keeper-runtime-display'
 import type { KeeperActivityDisplay } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
-import { sortByRecency } from '../../lib/keeper-recency'
+import { compareByRecency, sortByRecency } from '../../lib/keeper-recency'
 import type { Keeper } from '../../types'
 import { KEEPER_ACTION_LABELS, runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
 import { VirtualList } from '../common/virtual-list'
@@ -158,11 +158,19 @@ function keeperStatusRank(keeper: Keeper, bucketOf: BucketOf): number {
   return 3
 }
 
-function compareFleetRows(bucketOf: BucketOf): (a: Keeper, b: Keeper) => number {
+/** Bucket order first, then the same recency order the rows display.
+ *
+ *  The grouped view previously ordered within a bucket by context ratio
+ *  descending. That key is invisible on the row — the row shows a relative
+ *  activity time — and it moves on every turn as the window fills, so the
+ *  list reordered under the operator with no readable rule and a click could
+ *  land on whichever keeper had just taken that slot. Recency is the key the
+ *  row already prints, and it is the same SSOT the keepers page uses to pick
+ *  its default selection, so top-of-list and auto-selection agree. */
+function compareFleetRows(bucketOf: BucketOf, nowMs: number): (a: Keeper, b: Keeper) => number {
   return (a, b) =>
     keeperStatusRank(a, bucketOf) - keeperStatusRank(b, bucketOf)
-    || compareContextRatioDescending(a, b)
-    || a.name.localeCompare(b.name)
+    || compareByRecency(a, b, nowMs)
 }
 
 export function rosterFleetSummary(
@@ -615,7 +623,7 @@ export function KeeperWorkspaceRoster({
     for (const group of GROUP_ORDER) {
       const rows = visible
         .filter(k => bucketOf(k) === group.bucket)
-        .sort(compareFleetRows(bucketOf))
+        .sort(compareFleetRows(bucketOf, nowMs))
       if (rows.length === 0) continue
       items.push({ type: 'header', bucket: group.bucket, label: group.label, count: rows.length })
       for (const keeper of rows) items.push({ type: 'row', keeper })


### PR DESCRIPTION
## 증상 3건

1. **키퍼 목록 정렬 기준을 알 수 없고 계속 바뀜.** 키퍼를 클릭하면 다른 키퍼가 선택되는 일이 생김.
2. **턴 타임라인을 접어놔도 키퍼를 바꿨다 돌아오면 다시 펼쳐져 있음.**
3. **`서버 연결 복구됨` 토스트가 연달아 뜸.**

세 개 다 "있는 값을 읽는 대신 상태를 다시 만들어내는" 같은 모양입니다.

## 1. 로스터 정렬 (`상태순`, 기본값)

그룹 안에서의 순서가 **context ratio 내림차순**이었습니다 (`compareFleetRows`).

- 그 값은 행에 표시되지 않습니다. 행이 보여주는 것은 상대 활동 시각(`3분`, `방금`)입니다.
- 그 값은 턴마다 움직입니다. 컨텍스트가 차면 순서가 바뀝니다.

그래서 목록이 커서 아래에서 재정렬되고, 클릭이 방금 그 자리로 올라온 다른 키퍼에 떨어집니다.

행이 이미 인쇄하고 있는 **recency** 로 정렬하도록 바꿨습니다. 이 키는 keepers 페이지가 기본 선택 키퍼를 고를 때 쓰는 것과 같은 SSOT (`lib/keeper-recency.ts`) 라서, 목록 맨 위와 자동 선택이 어긋나지 않습니다. 동점은 이름으로 깨서 스냅샷 간 순서가 고정됩니다.

context ratio 정렬은 `주의` 정렬 모드에 그대로 남아 있고, 기존 계약 테스트는 그 모드로 옮겨 유지했습니다.

## 2. 턴 타임라인 접힘 상태

`useState` + `useRef`(사용자가 토글했는가) 조합이었습니다. 키퍼를 바꾸면 대화 트랜스크립트 전체가 unmount 되므로 둘 다 초기화되고, `useEffect` 가 다시 펼칩니다.

접힘 선택을 **턴 id 로 주소화**해서 컴포넌트 밖에 두고, 렌더 시점에 파생하도록 바꿨습니다 (`open = 명시적 선택 ?? !liveTurn`). effect 로 prop 변화를 감지해 초기화하지 않습니다.

기록되는 것은 조작자가 실제로 토글한 턴뿐이라 맵 크기는 트랜스크립트 길이가 아니라 사람의 조작 횟수로 제한됩니다.

## 3. 재접속 토스트

`refreshDevTokenAfterAuthError` 가 `clearStoredToken()` 후 `setStoredToken()` 을 했습니다. 토큰 revision 변화 1건마다 대시보드 웹소켓이 끊고 다시 붙습니다 (`subscribeStoredTokenChanges` → `reconnectAfterAuthTokenChange`). 복구 1회 = 재접속 2회 = 토스트 2개. 그 사이에는 Authorization 헤더 없이 나가는 요청 구간도 있었습니다.

또한 엔드포인트가 **같은 토큰**을 돌려줘도 복구 성공으로 보고했습니다. 토큰이 거부 사유가 아닌 경우 (예: 서버측 identity 문제 → #28383) 호출자는 동일 요청을 재시도하고 동일하게 실패하고 다시 refresh 합니다. 매번 웹소켓을 다시 붙이면서 끝나지 않습니다.

- 지우지 않고 제자리 교체 (revision 변화 1회)
- 자격증명이 **실제로 바뀐** 경우에만 복구 성공으로 보고

RFC-0340 §Typed self-healing 의 "replace a managed dev-token and retry once" 에서, replace 가 일어나지 않았으면 retry 도 없어야 한다는 쪽으로 좁힌 것입니다.

## 검증

```
npx tsc -b                                        # exit 0
npx vitest run src/api/dev-token.test.ts \
  src/components/chat/primitives.test.ts \
  src/components/keeper-workspace/keeper-workspace-roster.test.ts
# Test Files 3 passed | Tests 188 passed
```

새 테스트가 수정 전 코드에서 실제로 실패하는지 mutation 으로 확인했습니다.

| 되돌린 것 | 결과 |
|---|---|
| 그룹 정렬을 context ratio 로 | `× orders a status group by the recency each row displays` |
| 접힘 상태를 인스턴스 로컬로 | `× keeps a collapsed turn timeline collapsed across a transcript remount`, `× re-opens a turn timeline the operator expanded after a remount` |

`src/api/mcp.test.ts` 의 4건은 이 브랜치와 무관하게 origin/main 에서도 실패합니다 (stash 후 동일 4건 확인). 이 PR 에서 건드리지 않았습니다.

## 범위 밖

`#monitoring?section=agents` 와 `#keepers` 의 상태 표시 불일치는 별건입니다. 두 화면이 서로 다른 축을 씁니다:

- monitoring: `keeperBand(projection)` — `projection.signals.some(s => s.contributesToAttention)`
- keepers: `keeperBucket` = `deriveKeeperOperationalState(...).kind` — `runtime_blocker_class` / `fiber_dead` 만

attention signal 은 있는데 runtime blocker 는 없는 키퍼는 한쪽에서 `주의`, 다른 쪽에서 `실행 중` 으로 보입니다. 어느 축을 정본으로 삼을지는 제품 결정이라 이 PR 에 넣지 않았습니다.
