### PR TITLE
feat(keeper): carry the surface-post delivery target to the dashboard card

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -252,6 +252,107 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('.chat-bubble')).toBeNull()
   })
 
+  it('names the dashboard as the delivery target instead of claiming a connector', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'dashboard-post-done',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'analyst',
+            text: '',
+            rawText: '',
+            details: {
+              turnOutcome: 'external_effect_completed',
+              externalEffectTarget: { kind: 'dashboard' },
+            },
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const status = container.querySelector(
+      '[data-chat-control-status="external_effect_completed"]',
+    )
+    expect(status).not.toBeNull()
+    expect(status?.getAttribute('data-chat-effect-target')).toBe('dashboard')
+    expect(status?.textContent).toContain('대시보드에 게시 완료')
+    expect(status?.textContent).not.toContain('Slack/Discord')
+  })
+
+  it('names the Slack thread destination on a threaded delivery target', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'slack-thread-post-done',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'kidsnote',
+            text: '',
+            rawText: '',
+            details: {
+              turnOutcome: 'external_effect_completed',
+              externalEffectTarget: {
+                kind: 'slack',
+                channelId: 'C09TK9L4DV4',
+                threadTs: '1786524720.554309',
+              },
+            },
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const status = container.querySelector(
+      '[data-chat-control-status="external_effect_completed"]',
+    )
+    expect(status).not.toBeNull()
+    expect(status?.getAttribute('data-chat-effect-target')).toBe('slack')
+    expect(status?.textContent).toContain('Slack으로 답변 완료')
+    expect(status?.textContent).toContain('C09TK9L4DV4')
+    expect(status?.textContent).toContain('스레드로 전송')
+  })
+
+  it('names the Discord channel destination on a discord delivery target', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'discord-post-done',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '',
+            rawText: '',
+            details: {
+              turnOutcome: 'external_effect_completed',
+              externalEffectTarget: { kind: 'discord', channelId: 'D-123' },
+            },
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const status = container.querySelector(
+      '[data-chat-control-status="external_effect_completed"]',
+    )
+    expect(status).not.toBeNull()
+    expect(status?.getAttribute('data-chat-effect-target')).toBe('discord')
+    expect(status?.textContent).toContain('Discord로 답변 완료')
+    expect(status?.textContent).toContain('D-123')
+  })
+
   it('renders a typed continuation checkpoint as durable status, not assistant prose', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2470,12 +2470,46 @@ function ChatControlStatusCard({
   }
 
   if (status === 'external_effect_completed') {
+    // The delivery target names where the terminal surface post actually
+    // landed; legacy events without it keep the generic connector copy.
+    const target = entry.details?.externalEffectTarget ?? null
+    const copy = (() => {
+      if (target?.kind === 'dashboard') {
+        return {
+          title: '대시보드에 게시 완료',
+          body: 'Keeper의 답변이 이 대시보드 채팅에 게시되었습니다.',
+          hint: '위 대화에서 확인할 수 있습니다.',
+        }
+      }
+      if (target?.kind === 'slack') {
+        return {
+          title: 'Slack으로 답변 완료',
+          body: target.threadTs
+            ? `Keeper의 답변이 Slack 채널 ${target.channelId}의 스레드로 전송되었습니다.`
+            : `Keeper의 답변이 Slack 채널 ${target.channelId}로 전송되었습니다.`,
+          hint: '답변 내용은 해당 채널에서 확인할 수 있습니다.',
+        }
+      }
+      if (target?.kind === 'discord') {
+        return {
+          title: 'Discord로 답변 완료',
+          body: `Keeper의 답변이 Discord 채널 ${target.channelId}로 전송되었습니다.`,
+          hint: '답변 내용은 해당 채널에서 확인할 수 있습니다.',
+        }
+      }
+      return {
+        title: '커넥터로 답변 완료',
+        body: 'Keeper의 답변이 외부 커넥터(Slack/Discord)로 전송되었습니다.',
+        hint: '답변 내용은 해당 채널에서 확인할 수 있습니다.',
+      }
+    })()
     return html`
       <article
         class="w-full rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-subtle)] px-4 py-3.5"
         role="status"
         aria-live="polite"
         data-chat-control-status="external_effect_completed"
+        data-chat-effect-target=${target?.kind ?? undefined}
         data-chat-entry-id=${entry.id}
         data-chat-turn-ref=${entry.turnRef ?? undefined}
       >
@@ -2488,16 +2522,16 @@ function ChatControlStatusCard({
           </div>
           <div class="min-w-0 flex-1">
             <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-              <strong class="text-sm font-semibold text-[var(--color-fg-primary)]">커넥터로 답변 완료</strong>
+              <strong class="text-sm font-semibold text-[var(--color-fg-primary)]">${copy.title}</strong>
               ${timestamp
                 ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]">${timestamp}</span>`
                 : null}
             </div>
             <p class="mt-1 text-sm leading-paragraph text-[var(--color-fg-secondary)]">
-              Keeper의 답변이 외부 커넥터(Slack/Discord)로 전송되었습니다.
+              ${copy.body}
             </p>
             <p class="mt-0.5 text-xs leading-paragraph text-[var(--color-fg-muted)]">
-              답변 내용은 해당 채널에서 확인할 수 있습니다.
+              ${copy.hint}
             </p>
           </div>
         </div>

--- a/dashboard/src/keeper-message.test.ts
+++ b/dashboard/src/keeper-message.test.ts
@@ -3,6 +3,7 @@ import {
   formatKeeperVisibleReply,
   keeperTurnOutcomeSuppressesReply,
   normalizeKeeperConversationDetails,
+  normalizeKeeperExternalEffectTarget,
   normalizeKeeperToolResponse,
 } from './keeper-message'
 
@@ -348,5 +349,58 @@ describe('normalizeKeeperToolResponse', () => {
     })
     const result = normalizeKeeperToolResponse(raw)
     expect(result.text).toBe('A\n\nB')
+  })
+})
+
+// ================================================================
+// normalizeKeeperExternalEffectTarget
+// ================================================================
+
+describe('normalizeKeeperExternalEffectTarget', () => {
+  it('decodes the three delivery target kinds', () => {
+    expect(normalizeKeeperExternalEffectTarget({ kind: 'dashboard' }))
+      .toEqual({ kind: 'dashboard' })
+    expect(
+      normalizeKeeperExternalEffectTarget({ kind: 'discord', channel_id: 'D1' }),
+    ).toEqual({ kind: 'discord', channelId: 'D1' })
+    expect(
+      normalizeKeeperExternalEffectTarget({
+        kind: 'slack',
+        channel_id: 'C1',
+        thread_ts: '1700000000.000100',
+      }),
+    ).toEqual({ kind: 'slack', channelId: 'C1', threadTs: '1700000000.000100' })
+    expect(
+      normalizeKeeperExternalEffectTarget({ kind: 'slack', channel_id: 'C1' }),
+    ).toEqual({ kind: 'slack', channelId: 'C1', threadTs: null })
+  })
+
+  it('decodes malformed or legacy input to null instead of guessing', () => {
+    expect(normalizeKeeperExternalEffectTarget(undefined)).toBeNull()
+    expect(normalizeKeeperExternalEffectTarget(null)).toBeNull()
+    expect(normalizeKeeperExternalEffectTarget('slack')).toBeNull()
+    expect(normalizeKeeperExternalEffectTarget({ kind: 'telegram' })).toBeNull()
+    expect(normalizeKeeperExternalEffectTarget({ kind: 'slack' })).toBeNull()
+    expect(
+      normalizeKeeperExternalEffectTarget({ kind: 'discord', channel_id: ' ' }),
+    ).toBeNull()
+  })
+
+  it('is surfaced by normalizeKeeperConversationDetails from the reply payload', () => {
+    const details = normalizeKeeperConversationDetails({
+      reply: '',
+      turn_outcome: 'external_effect_completed',
+      turn_ref: 'trace-1#2',
+      external_effect_target: { kind: 'dashboard' },
+    })
+    expect(details?.turnOutcome).toBe('external_effect_completed')
+    expect(details?.externalEffectTarget).toEqual({ kind: 'dashboard' })
+
+    const legacy = normalizeKeeperConversationDetails({
+      reply: '',
+      turn_outcome: 'external_effect_completed',
+      turn_ref: 'trace-1#2',
+    })
+    expect(legacy?.externalEffectTarget).toBeNull()
   })
 })

--- a/dashboard/src/keeper-message.ts
+++ b/dashboard/src/keeper-message.ts
@@ -1,5 +1,9 @@
 import { asNumber, asString, isRecord } from './components/common/normalize'
-import type { KeeperConversationDetails, KeeperTurnOutcome } from './types'
+import type {
+  KeeperConversationDetails,
+  KeeperExternalEffectTarget,
+  KeeperTurnOutcome,
+} from './types'
 
 function stripSkillRouteLines(text: string): string {
   return text
@@ -34,6 +38,26 @@ function normalizeKeeperTurnOutcome(value: unknown): KeeperTurnOutcome | null {
     default:
       return null
   }
+}
+
+// Closed decode of the reply payload's `external_effect_target` /
+// KEEPER_EXTERNAL_EFFECT_COMPLETED value. Missing field (legacy payload) or
+// any malformed shape decodes to null; the card then keeps its generic copy
+// instead of guessing a destination.
+export function normalizeKeeperExternalEffectTarget(
+  value: unknown,
+): KeeperExternalEffectTarget | null {
+  if (!isRecord(value)) return null
+  const kind = asString(value.kind, '').trim()
+  if (kind === 'dashboard') return { kind: 'dashboard' }
+  const channelId = asString(value.channel_id, '').trim()
+  if (!channelId) return null
+  if (kind === 'discord') return { kind: 'discord', channelId }
+  if (kind === 'slack') {
+    const threadTs = asString(value.thread_ts, '').trim()
+    return { kind: 'slack', channelId, threadTs: threadTs || null }
+  }
+  return null
 }
 
 function normalizeKeeperUsage(raw: unknown): NonNullable<KeeperConversationDetails['usage']> | null {
@@ -88,6 +112,9 @@ export function normalizeKeeperConversationDetails(raw: unknown): KeeperConversa
     usage,
     replyText: reply || null,
     turnOutcome: normalizeKeeperTurnOutcome(payload.turn_outcome),
+    externalEffectTarget: normalizeKeeperExternalEffectTarget(
+      payload.external_effect_target,
+    ),
     rawPayload: payload,
   }
 }

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -2,6 +2,7 @@ import {
   formatKeeperVisibleReply,
   keeperTurnOutcomeSuppressesReply,
   normalizeKeeperConversationDetails,
+  normalizeKeeperExternalEffectTarget,
 } from './keeper-message'
 import { parseTextToChatBlocks } from './lib/chat-blocks'
 import type { KeeperChatStreamEvent } from './api'
@@ -886,15 +887,20 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_EXTERNAL_EFFECT_COMPLETED') {
-        // The reply went out through an external connector (Slack/Discord), so
+        // The reply was already delivered by a terminal surface post, so
         // there is no assistant text — finalize as a terminal control status
-        // instead of leaving the entry streaming.
+        // instead of leaving the entry streaming. The event value names the
+        // real delivery target (null on legacy events).
+        const externalEffectTarget = normalizeKeeperExternalEffectTarget(
+          isRecord(event.value) ? event.value.target : null,
+        )
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
         updateThreadEntry(keeperName, assistantEntryId, entry => ({
           ...entry,
           details: {
             ...(entry.details ?? {}),
             turnOutcome: 'external_effect_completed',
+            externalEffectTarget,
           },
           text: '',
           delivery: 'delivered',

--- a/dashboard/src/lib/keeper-chat-stream-contract.ts
+++ b/dashboard/src/lib/keeper-chat-stream-contract.ts
@@ -134,7 +134,19 @@ type KeeperChatCustomEvent =
       name: 'KEEPER_CONTINUATION_CHECKPOINT'
       value: { message?: string; request_id?: string }
     }
-  | { type: 'CUSTOM'; name: 'KEEPER_EXTERNAL_EFFECT_COMPLETED'; value: null }
+  | {
+      type: 'CUSTOM'
+      name: 'KEEPER_EXTERNAL_EFFECT_COMPLETED'
+      // null is the legacy wire value; a typed target names the real
+      // destination of the completed surface post (#28374).
+      value: {
+        target?: {
+          kind?: 'dashboard' | 'discord' | 'slack'
+          channel_id?: string
+          thread_ts?: string
+        }
+      } | null
+    }
   | {
       type: 'CUSTOM'
       name: 'KEEPER_REPLY_DETAILS'

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -281,6 +281,45 @@ describe('SSEMessageSchema', () => {
     expect(r.success).toBe(true)
   })
 
+  it('accepts external-effect completion with and without a delivery target', () => {
+    const event = (value: unknown) => ({
+      type: 'keeper_chat_operation_event',
+      name: 'sangsu',
+      operation_id: 'kmsg-operation-1',
+      ag_ui_event: {
+        type: 'CUSTOM',
+        threadId: 'keeper-consumer:sangsu',
+        name: 'KEEPER_EXTERNAL_EFFECT_COMPLETED',
+        value,
+        timestamp: 1_712_000_000,
+      },
+    })
+    expect(SSEMessageSchema.safeParse(event(null)).success).toBe(true)
+    expect(
+      SSEMessageSchema.safeParse(event({ target: { kind: 'dashboard' } })).success,
+    ).toBe(true)
+    expect(
+      SSEMessageSchema.safeParse(
+        event({
+          target: {
+            kind: 'slack',
+            channel_id: 'C09TK9L4DV4',
+            thread_ts: '1786524720.554309',
+          },
+        }),
+      ).success,
+    ).toBe(true)
+    expect(
+      SSEMessageSchema.safeParse(event({ target: { kind: 'telegram' } })).success,
+    ).toBe(false)
+    expect(
+      SSEMessageSchema.safeParse(event({ target: { kind: 'slack' } })).success,
+    ).toBe(false)
+    expect(
+      SSEMessageSchema.safeParse(event({ widened: true })).success,
+    ).toBe(false)
+  })
+
   it('rejects an untyped Keeper custom event name', () => {
     const r = SSEMessageSchema.safeParse({
       type: 'keeper_chat_operation_event',

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -326,11 +326,34 @@ function validateKeeperCustomPayload(name: string, payload: unknown): SafeParseR
     'KEEPER_CONNECTED',
     'KEEPER_STREAM_MESSAGE_STOP',
     'KEEPER_STREAM_PING',
-    'KEEPER_EXTERNAL_EFFECT_COMPLETED',
   ].includes(name)) {
     return payload === null
       ? ok(true)
       : fail('ag_ui_event.value', `Expected null ${name} payload`)
+  }
+
+  if (name === 'KEEPER_EXTERNAL_EFFECT_COMPLETED') {
+    // null is the legacy wire value; a typed payload carries the delivery
+    // target of the completed surface post (#28374).
+    if (payload === null) return ok(true)
+    const object = exactCustomObject(payload, name, ['target'])
+    if (!object.success) return object
+    const target = object.data.target
+    if (!isRecord(target)) {
+      return fail('ag_ui_event.value.target', `Expected ${name} target object`)
+    }
+    const targetObject = exactCustomObject(target, name, [
+      'kind',
+      'channel_id',
+      'thread_ts',
+    ])
+    if (!targetObject.success) return targetObject
+    const kind = target.kind
+    if (kind === 'dashboard') return ok(true)
+    if (kind !== 'discord' && kind !== 'slack') {
+      return fail('ag_ui_event.value.target.kind', `Unknown ${name} target kind`)
+    }
+    return requiredString(targetObject.data, 'channel_id')
   }
 
   const allowedFields: Record<string, readonly string[]> = {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -673,6 +673,15 @@ export type KeeperTurnOutcome =
   | 'external_effect_pending'
   | 'no_visible_reply'
 
+// Where an `external_effect_completed` turn actually delivered its reply
+// (`external_effect_target` on the reply payload / the
+// KEEPER_EXTERNAL_EFFECT_COMPLETED event value). Absent on legacy payloads
+// that predate the field — the card then falls back to generic copy.
+export type KeeperExternalEffectTarget =
+  | { kind: 'dashboard' }
+  | { kind: 'discord'; channelId: string }
+  | { kind: 'slack'; channelId: string; threadTs: string | null }
+
 export interface KeeperConversationDetails {
   traceId?: string | null
   turnRef?: string | null
@@ -685,6 +694,7 @@ export interface KeeperConversationDetails {
   usage?: KeeperConversationUsage | null
   replyText?: string | null
   turnOutcome?: KeeperTurnOutcome | null
+  externalEffectTarget?: KeeperExternalEffectTarget | null
   rawPayload?: unknown
 }
 

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -373,7 +373,7 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
         in
         on_send_result final_result;
         send_text_rich_embeds ?clock ~token ~channel_id acc_text
-    | External_effect_completed ->
+    | External_effect_completed _ ->
         external_effect_completed := true;
         continue ()
     | Event_error { message } ->

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -44,7 +44,8 @@ type keeper_chat_event =
   | Text_message_start of { message_id : string; role : role }
   | Text_delta of string
   | Text_message_end
-  | External_effect_completed
+  | External_effect_completed of
+      { target : Keeper_surface_post.delivery_target option }
   | Run_finished of { run_id : string }
   | Event_error of { message : string }
   | Reply_details of reply_details

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -54,10 +54,12 @@ type keeper_chat_event =
   | Text_message_start of { message_id : string; role : role }
   | Text_delta of string
   | Text_message_end
-  | External_effect_completed
+  | External_effect_completed of
+      { target : Keeper_surface_post.delivery_target option }
       (** A terminal tool already delivered the reply outside this adapter.
           Connector adapters settle the receipt without emitting another
-          text message. *)
+          text message. [target] names where the post actually landed;
+          [None] only for legacy reply payloads that predate the field. *)
   | Run_finished of { run_id : string }
   | Event_error of { message : string }
   | Reply_details of reply_details

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -575,7 +575,7 @@ let adapter_loop_with_transport
         end;
         clear_activity ();
         ()
-    | External_effect_completed ->
+    | External_effect_completed _ ->
         external_effect_completed := true;
         (match streaming_transport, message_id with
          | Some (_, _, _, delete), Some message_id ->

--- a/lib/keeper/keeper_surface_post.ml
+++ b/lib/keeper/keeper_surface_post.ml
@@ -13,6 +13,62 @@ let dashboard_label = "dashboard"
 let discord_label = "discord"
 let slack_label = "slack"
 
+type delivery_target =
+  | Delivered_to_dashboard
+  | Delivered_to_discord of { channel_id : string }
+  | Delivered_to_slack of { channel_id : string; thread_ts : string option }
+
+let delivery_target_of_post_target = function
+  | To_dashboard -> Delivered_to_dashboard
+  | To_discord { channel_id } -> Delivered_to_discord { channel_id }
+  | To_slack { channel_id; thread_ts; blocks = _ } ->
+    Delivered_to_slack { channel_id; thread_ts }
+
+let delivery_target_to_yojson = function
+  | Delivered_to_dashboard -> `Assoc [ "kind", `String dashboard_label ]
+  | Delivered_to_discord { channel_id } ->
+    `Assoc [ "kind", `String discord_label; "channel_id", `String channel_id ]
+  | Delivered_to_slack { channel_id; thread_ts } ->
+    `Assoc
+      ([ "kind", `String slack_label; "channel_id", `String channel_id ]
+       @ match thread_ts with
+         | None -> []
+         | Some thread_ts -> [ "thread_ts", `String thread_ts ])
+
+let delivery_target_of_yojson json =
+  let field key fields =
+    match List.assoc_opt key fields with
+    | Some (`String value) when String.trim value <> "" -> Ok value
+    | Some _ ->
+      Error
+        (Printf.sprintf "delivery target %s must be a non-empty string" key)
+    | None -> Error (Printf.sprintf "delivery target is missing %s" key)
+  in
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "kind" fields with
+     | Some (`String kind) when String.equal kind dashboard_label ->
+       Ok Delivered_to_dashboard
+     | Some (`String kind) when String.equal kind discord_label ->
+       Result.map
+         (fun channel_id -> Delivered_to_discord { channel_id })
+         (field "channel_id" fields)
+     | Some (`String kind) when String.equal kind slack_label ->
+       Result.bind (field "channel_id" fields) (fun channel_id ->
+           match List.assoc_opt "thread_ts" fields with
+           | None -> Ok (Delivered_to_slack { channel_id; thread_ts = None })
+           | Some (`String thread_ts) when String.trim thread_ts <> "" ->
+             Ok (Delivered_to_slack { channel_id; thread_ts = Some thread_ts })
+           | Some _ ->
+             Error "delivery target thread_ts must be a non-empty string")
+     | Some (`String kind) ->
+       Error (Printf.sprintf "unknown delivery target kind %S" kind)
+     | Some _ -> Error "delivery target kind must be a string"
+     | None -> Error "delivery target is missing kind")
+  | _ -> Error "delivery target must be a JSON object"
+
+let delivery_target_wire_key = "external_effect_target"
+
 let resolve_target ~surface ~channel_id ?continuation_channel
     ?(bound_discord_channels = [])
     ?(bound_slack_channels = []) () : (post_target, string) result =

--- a/lib/keeper/keeper_surface_post.mli
+++ b/lib/keeper/keeper_surface_post.mli
@@ -31,6 +31,32 @@ val dashboard_label : string
 val discord_label : string
 val slack_label : string
 
+type delivery_target =
+  | Delivered_to_dashboard
+  | Delivered_to_discord of { channel_id : string }
+  | Delivered_to_slack of { channel_id : string; thread_ts : string option }
+(** Where a completed surface post actually landed — the destination
+    coordinates of a [post_target] without its payload ([blocks]). Carried on
+    the turn's reply payload and the [External_effect_completed] chat event so
+    the dashboard can name the real destination instead of assuming an
+    external connector (issue #28374). *)
+
+val delivery_target_of_post_target : post_target -> delivery_target
+
+val delivery_target_to_yojson : delivery_target -> Yojson.Safe.t
+(** [{"kind":"dashboard"}], [{"kind":"discord","channel_id":_}] or
+    [{"kind":"slack","channel_id":_,"thread_ts"?:_}]. [thread_ts] is omitted,
+    never [null], when absent. *)
+
+val delivery_target_of_yojson : Yojson.Safe.t -> (delivery_target, string) result
+(** Closed decode of {!delivery_target_to_yojson}. Unknown kinds, missing or
+    blank coordinates are errors, never defaults. *)
+
+val delivery_target_wire_key : string
+(** ["external_effect_target"] — the reply-payload field carrying the
+    delivery target. Shared by the producer ({!Keeper_turn}) and the stream
+    decoder so the wire name cannot drift. *)
+
 val resolve_target :
   surface:string ->
   channel_id:string option ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -776,7 +776,17 @@ let run_keeper_invocation_turn_admitted_inner
                                   detail)
                          | None -> None)
                 in
-                `Assoc [
+                let external_effect_target_field =
+                  match result.terminal_effect_receipt with
+                  | Some (Keeper_tool_execution.Surface_post_completed target) ->
+                    [ ( Keeper_surface_post.delivery_target_wire_key
+                      , Keeper_surface_post.delivery_target_to_yojson
+                          (Keeper_surface_post.delivery_target_of_post_target
+                             target) )
+                    ]
+                  | None -> []
+                in
+                `Assoc ([
                   ("reply", `String result.response_text);
                   ( Keeper_turn_outcome.wire_key,
                     `String
@@ -800,7 +810,7 @@ let run_keeper_invocation_turn_admitted_inner
                      chat row via append_turn ?turn_ref. *)
                   ( Keeper_turn_outcome.turn_ref_wire_key,
                     Ids.Turn_ref.to_yojson turn_ref );
-                ]
+                ] @ external_effect_target_field)
               in
               tool_result_ok_data reply_json
 

--- a/lib/server/server_keeper_chat_agui_projection.ml
+++ b/lib/server/server_keeper_chat_agui_projection.ml
@@ -102,8 +102,18 @@ let project ~timestamp ~redact_text ~redact_json state event =
           (Ag_ui.make_event ~timestamp ~thread_id:state.thread_id
              ~run_id:state.run_id ~message_id:state.message_id
              Ag_ui.Text_message_end) )
-  | External_effect_completed ->
-      state, Some (custom ~timestamp ~redact_json state External_effect_completed `Null)
+  | External_effect_completed { target } ->
+      (* [`Null] is the legacy wire value; a typed target upgrades it to an
+         object naming the real destination so the dashboard stops assuming
+         an external connector (#28374). *)
+      let value =
+        match target with
+        | None -> `Null
+        | Some target ->
+          `Assoc
+            [ "target", Keeper_surface_post.delivery_target_to_yojson target ]
+      in
+      state, Some (custom ~timestamp ~redact_json state External_effect_completed value)
   | Agent_core_stream_connected ->
       state, Some (custom ~timestamp ~redact_json state Connected `Null)
   | Agent_core_stream_message_start { provider_message_id; model; usage } ->

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -710,11 +710,13 @@ type canonical_reply_payload_error =
   | Invalid_payload_field_type of string
   | Unknown_turn_outcome
   | Invalid_turn_ref
+  | Invalid_external_effect_target of string
 
 type canonical_reply_payload =
   { payload_json : Yojson.Safe.t
   ; turn_outcome : Keeper_turn_outcome.t
   ; turn_ref : Ids.Turn_ref.t
+  ; external_effect_target : Keeper_surface_post.delivery_target option
   ; visible_reply : string
   ; poll_body : string
   }
@@ -733,6 +735,10 @@ let canonical_reply_payload_error_to_string = function
   | Unknown_turn_outcome ->
     "keeper reply payload contains an unknown turn_outcome"
   | Invalid_turn_ref -> "keeper reply payload contains an invalid turn_ref"
+  | Invalid_external_effect_target detail ->
+    Printf.sprintf
+      "keeper reply payload carries an invalid external_effect_target: %s"
+      detail
 ;;
 
 let required_unique_string_field field fields =
@@ -778,6 +784,26 @@ let canonical_reply_payload_of_body ~redact_text body =
     | Some turn_ref -> Ok turn_ref
     | None -> Error Invalid_turn_ref
   in
+  let* external_effect_target =
+    (* Absent on legacy payloads that predate the field; present means the
+       producer serialized a typed delivery target and it must decode. *)
+    match
+      List.filter_map
+        (fun (key, value) ->
+           if String.equal key Keeper_surface_post.delivery_target_wire_key
+           then Some value
+           else None)
+        fields
+    with
+    | [] -> Ok None
+    | [ value ] ->
+      (match Keeper_surface_post.delivery_target_of_yojson value with
+       | Ok target -> Ok (Some target)
+       | Error detail -> Error (Invalid_external_effect_target detail))
+    | _ ->
+      Error
+        (Duplicate_payload_field Keeper_surface_post.delivery_target_wire_key)
+  in
   let visible_reply =
     strip_keeper_visible_reply reply_raw |> redact_text |> String.trim
   in
@@ -788,6 +814,7 @@ let canonical_reply_payload_of_body ~redact_text body =
     { payload_json
     ; turn_outcome
     ; turn_ref
+    ; external_effect_target
     ; visible_reply
     ; poll_body = Yojson.Safe.to_string payload_json
     }
@@ -1345,7 +1372,8 @@ let process_single_turn ~user_row_origin ~submission
                | Duplicate_payload_field _
                | Invalid_payload_field_type _
                | Unknown_turn_outcome
-               | Invalid_turn_ref -> detail
+               | Invalid_turn_ref
+               | Invalid_external_effect_target _ -> detail
              in
              Log.Keeper.error
                "keeper_stream: canonical terminal projection rejected keeper=%s error=%s"
@@ -1802,7 +1830,9 @@ let process_single_turn ~user_row_origin ~submission
             Keeper_turn_outcome.equal turn_outcome
               Keeper_turn_outcome.External_effect_completed
           then
-            Keeper_chat_events.publish events External_effect_completed;
+            Keeper_chat_events.publish events
+              (External_effect_completed
+                 { target = canonical_reply.external_effect_target });
           if
             Keeper_turn_outcome.equal turn_outcome
               Keeper_turn_outcome.External_effect_pending

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -218,11 +218,13 @@ type canonical_reply_payload_error =
   | Invalid_payload_field_type of string
   | Unknown_turn_outcome
   | Invalid_turn_ref
+  | Invalid_external_effect_target of string
 
 type canonical_reply_payload =
   { payload_json : Yojson.Safe.t
   ; turn_outcome : Keeper_turn_outcome.t
   ; turn_ref : Ids.Turn_ref.t
+  ; external_effect_target : Keeper_surface_post.delivery_target option
   ; visible_reply : string
   ; poll_body : string
   }

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -195,7 +195,7 @@ let test_completed_external_effect_settles_without_duplicate_send () =
   let sends = ref 0 in
   let outcomes =
     run_adapter
-      [ Masc.Keeper_chat_events.External_effect_completed
+      [ Masc.Keeper_chat_events.External_effect_completed { target = None }
       ; Masc.Keeper_chat_events.Run_finished { run_id = "run-effect" }
       ]
       ~post_message:(fun ~content:_ ->

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -345,7 +345,7 @@ let test_completed_external_effect_settles_without_duplicate_send () =
   let sends = ref 0 in
   let outcomes =
     run_adapter
-      [ Masc.Keeper_chat_events.External_effect_completed
+      [ Masc.Keeper_chat_events.External_effect_completed { target = None }
       ; Masc.Keeper_chat_events.Run_finished { run_id = "run-effect" }
       ]
       ~send_plain:(fun ~content:_ ->
@@ -371,7 +371,7 @@ let test_completed_external_effect_deletes_streamed_draft () =
         deleted := message_id :: !deleted;
         Ok ())
       [ Masc.Keeper_chat_events.Text_delta "partial "
-      ; Masc.Keeper_chat_events.External_effect_completed
+      ; Masc.Keeper_chat_events.External_effect_completed { target = None }
       ; Masc.Keeper_chat_events.Run_finished { run_id = "run-effect-draft" }
       ]
       ~send_plain:(fun ~content:_ -> fail "external effect needs no side message")

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -344,6 +344,63 @@ let test_terminal_receipt_requires_exact_supported_route () =
         | Ok channel -> channel
         | Error message -> fail message))
 
+(* ── delivery_target codec ──────────────────────────────────────── *)
+
+let delivery_target_pp fmt = function
+  | SP.Delivered_to_dashboard -> Format.fprintf fmt "dashboard"
+  | SP.Delivered_to_discord { channel_id } ->
+      Format.fprintf fmt "discord{%s}" channel_id
+  | SP.Delivered_to_slack { channel_id; thread_ts } ->
+      Format.fprintf fmt "slack{%s,%s}" channel_id
+        (Option.value thread_ts ~default:"root")
+
+let delivery_target : SP.delivery_target testable =
+  testable delivery_target_pp ( = )
+
+let test_delivery_target_json_round_trip () =
+  List.iter
+    (fun target ->
+      match SP.delivery_target_of_yojson (SP.delivery_target_to_yojson target) with
+      | Ok decoded -> check delivery_target "round trip" target decoded
+      | Error message -> fail message)
+    [ SP.Delivered_to_dashboard
+    ; SP.Delivered_to_discord { channel_id = "D1" }
+    ; SP.Delivered_to_slack { channel_id = "C1"; thread_ts = None }
+    ; SP.Delivered_to_slack
+        { channel_id = "C1"; thread_ts = Some "1700000000.000100" }
+    ]
+
+let test_delivery_target_decode_rejects_widened_input () =
+  List.iter
+    (fun json ->
+      match SP.delivery_target_of_yojson json with
+      | Error _ -> ()
+      | Ok _ -> fail "widened delivery target must not decode")
+    [ `Assoc [ ("kind", `String "telegram") ]
+    ; `Assoc [ ("kind", `String "slack") ]
+    ; `Assoc [ ("kind", `String "slack"); ("channel_id", `String " ") ]
+    ; `Assoc
+        [ ("kind", `String "slack")
+        ; ("channel_id", `String "C1")
+        ; ("thread_ts", `Int 1700000000)
+        ]
+    ; `Assoc [ ("channel_id", `String "C1") ]
+    ; `String "dashboard"
+    ]
+
+let test_delivery_target_of_post_target_drops_payload_only () =
+  check delivery_target "dashboard maps" SP.Delivered_to_dashboard
+    (SP.delivery_target_of_post_target SP.To_dashboard);
+  check delivery_target "slack keeps destination coordinates"
+    (SP.Delivered_to_slack
+       { channel_id = "C1"; thread_ts = Some "1700000000.000100" })
+    (SP.delivery_target_of_post_target
+       (SP.To_slack
+          { channel_id = "C1"
+          ; thread_ts = Some "1700000000.000100"
+          ; blocks = Some [ `Assoc [ ("type", `String "section") ] ]
+          }))
+
 (* ── append_assistant_message ───────────────────────────────────── *)
 
 let with_temp_base_dir f =
@@ -434,6 +491,15 @@ let () =
         [
           test_case "requires exact supported route" `Quick
             test_terminal_receipt_requires_exact_supported_route;
+        ] );
+      ( "delivery target",
+        [
+          test_case "json round trip" `Quick
+            test_delivery_target_json_round_trip;
+          test_case "decode rejects widened input" `Quick
+            test_delivery_target_decode_rejects_widened_input;
+          test_case "post target maps to destination coordinates" `Quick
+            test_delivery_target_of_post_target_drops_payload_only;
         ] );
       ( "assistant append",
         [

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -103,6 +103,59 @@ let test_external_effect_completed_has_no_direct_reply_error () =
        (Some payload_json)
        "")
 
+let test_canonical_payload_carries_delivery_target () =
+  let turn_ref = Ids.Turn_ref.make ~trace_id:"post-target" ~absolute_turn:3 in
+  let body_with target_json =
+    `Assoc
+      ([ "reply", `String ""
+       ; TO.wire_key, `String (TO.to_label TO.External_effect_completed)
+       ; TO.turn_ref_wire_key, Ids.Turn_ref.to_yojson turn_ref
+       ]
+       @ target_json)
+    |> Yojson.Safe.to_string
+  in
+  (match
+     Stream.For_testing.canonical_reply_payload_of_body ~redact_text:Fun.id
+       (body_with
+          [ ( Masc.Keeper_surface_post.delivery_target_wire_key
+            , `Assoc [ "kind", `String "dashboard" ] )
+          ])
+   with
+   | Ok canonical ->
+     (match canonical.external_effect_target with
+      | Some Masc.Keeper_surface_post.Delivered_to_dashboard -> ()
+      | Some _ | None ->
+        fail "dashboard delivery target was not decoded from the payload")
+   | Error error ->
+     fail
+       (Server_routes_http_keeper_stream.canonical_reply_payload_error_to_string
+          error));
+  (match
+     Stream.For_testing.canonical_reply_payload_of_body ~redact_text:Fun.id
+       (body_with [])
+   with
+   | Ok canonical ->
+     (match canonical.external_effect_target with
+      | None -> ()
+      | Some _ -> fail "legacy payload without the field must decode to None")
+   | Error error ->
+     fail
+       (Server_routes_http_keeper_stream.canonical_reply_payload_error_to_string
+          error));
+  match
+    Stream.For_testing.canonical_reply_payload_of_body ~redact_text:Fun.id
+      (body_with
+         [ ( Masc.Keeper_surface_post.delivery_target_wire_key
+           , `Assoc [ "kind", `String "telegram" ] )
+         ])
+  with
+  | Error (Stream.Invalid_external_effect_target _) -> ()
+  | Error error ->
+    fail
+      (Server_routes_http_keeper_stream.canonical_reply_payload_error_to_string
+         error)
+  | Ok _ -> fail "unknown delivery target kind must reject the payload"
+
 let test_external_effect_status_survives_server_projection () =
   let turn_outcome =
     TO.of_result_surface
@@ -668,6 +721,8 @@ let () =
             test_external_effect_completed_has_no_direct_reply_error;
           test_case "external effect status survives server projection" `Quick
             test_external_effect_status_survives_server_projection;
+          test_case "canonical payload carries the delivery target" `Quick
+            test_canonical_payload_carries_delivery_target;
           test_case "external effect status becomes persisted chat block" `Quick
             test_external_effect_status_becomes_persisted_chat_block;
           test_case "terminal effect defer kinds remain distinct" `Quick


### PR DESCRIPTION
## 목표

커넥터 미연결 keeper가 `keeper_surface_post(surface="dashboard")`로 대시보드에 게시해도 "커넥터로 답변 완료 — Slack/Discord로 전송되었습니다"가 뜨는 오표시(#28374)의 근본 수정. 원인은 타깃 정보가 3층에서 소실되는 것: 분류(대상 불문 External_effect_completed) → 투영(AGUI payload `Null`) → 렌더(문구 하드코딩). typed delivery target을 reply payload → chat event → SSE → 카드까지 관통시킨다.

## 변경 파일

**OCaml**
- `keeper_surface_post.ml/.mli` — `delivery_target` 타입(+ closed JSON codec, wire key `external_effect_target`). post_target에서 목적지 좌표만 추출 (blocks 제외).
- `keeper_turn.ml` — terminal surface post 완료 시 reply payload에 `external_effect_target` 직렬화.
- `server_routes_http_keeper_stream.ml/.mli` — canonical reply payload가 타깃을 디코드 (부재=legacy 허용, malformed=typed reject `Invalid_external_effect_target`).
- `keeper_chat_events.ml/.mli` — `External_effect_completed of { target : delivery_target option }`.
- `server_keeper_chat_agui_projection.ml` — custom payload로 타깃 발행 (`Null`은 legacy wire 값 유지).
- `keeper_chat_discord.ml` / `keeper_chat_slack.ml` — 커넥터 어댑터는 타깃 무시 (기존 동작 유지).

**Dashboard**
- `types/core.ts` — `KeeperExternalEffectTarget`.
- `keeper-message.ts` — closed 디코더 `normalizeKeeperExternalEffectTarget` (REST/history 경로).
- `keeper-stream.ts` — SSE 경로에서 타깃 저장.
- `schemas/sse.ts` + `lib/keeper-chat-stream-contract.ts` — 이벤트 payload 계약 (null | {target}).
- `components/chat/primitives.ts` — 타깃별 카드: 대시보드 게시/Slack 채널·스레드/Discord 채널. 타깃 없으면 기존 generic 문구 유지 (legacy).

## 로컬 검증

- OCaml: `test_keeper_surface_post` 22 / `test_keeper_turn_outcome` 28 / `test_keeper_chat_slack` 32 / `test_keeper_chat_discord` 19 — green
- Dashboard: primitives + keeper-message + sse + turn-outcome-parity + keeper-stream 273 tests green, `tsc --noEmit` clean
- `dune build @check` 유일 실패는 main 유래 #28378 (수정 PR #28379)

## 미검증

- 라이브 SSE 왕복 (머지 후 analyst keeper 대시보드 게시로 확인 예정)
- Discord 라이브 경로

Closes #28374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU1EnzuTuFCPZwbeqj9Ajr
