### PR TITLE
test(harness): add Mode C request-cost gate for single-request boundedness

### DIFF
--- a/scripts/harness/perf/README.md
+++ b/scripts/harness/perf/README.md
@@ -278,3 +278,82 @@ constrained by RFC-0059 (keepers are pinned to the main domain; only *serving* m
 go through an RFC, validated by the Mode B keeper-load gate (whose sustained-load refinements have
 landed and now reproduce the keeper-burst RED — the gate Phase 3 must flip GREEN).
 launchd `ProcessType=Interactive` is a worthwhile but partial deployment-side mitigation.
+
+## Mode C: request-cost gate (`request_cost_gate.sh`)
+
+Modes A and B stress *contention*: many requests, or many keepers, competing for the one main
+Eio domain. They answer where work runs and who it queues behind. Mode C holds concurrency at
+**one** and asks a different question — how much does a single request cost?
+
+The distinction matters because the two failures need different fixes. Contention is solved by
+isolation (a dedicated pool or serving domain, RFC-0204). Cost is not: a read that materialises
+the whole store still kills whichever lane it lands on, and its heap is process-global, so every
+keeper shares the GC pressure. Isolation cannot make a large request small.
+
+### What it measures
+
+One heavy request, four axes:
+
+| axis | what it catches |
+|---|---|
+| `probe_p95_ms` | trivial-endpoint p95 while one heavy request is in flight |
+| `rss_peak_delta_mb` | heap growth attributable to that single request |
+| `cancel_recovery_s` | seconds until the probe recovers after the client aborts (3 consecutive healthy probes, so one lucky sample cannot pass it) |
+| `post_abort_heap_growth_mb` | heap growth *after* the client is gone — the unambiguous signal that cancellation did not propagate |
+
+`post_abort_heap_growth_mb` is the axis to trust. Latency is noisy; a heap that keeps climbing
+with no client left to receive the result is not.
+
+### Baseline control
+
+The run refuses to produce a verdict when the idle probe is already slow
+(`MAX_BASELINE_P95_MS`, default 50ms) and exits **1 (ERROR)** rather than 2 (RED). A busy host
+makes every downstream number look like a defect; RFC-0204's first diagnosis was reversed for
+exactly this reason. ERROR means "measurement invalid", not "code is fine".
+
+### Seeding
+
+An empty store cannot reproduce the defect — with little data the full scan is fast. The gate
+seeds a synthetic store (`seed_telemetry_store.py`) of a known shape: `--keepers` per-keeper
+fan-out stores plus the four fixed-path sources, `--entries` rows each, spread over dated
+partitions in the layout the reader expects.
+
+`--keepers` is a parameter because the reader's scan cap is per-store, not per-request. Running
+the gate at two keeper counts shows whether one request's cost tracks store count; if it does,
+the request has no budget of its own.
+
+### Run
+
+```bash
+# Boot mode (self-contained, deterministic). Reuses an existing build.
+MASC_HARNESS_SERVER_EXE=_build/default/bin/main_eio.exe \
+  scripts/harness/perf/request_cost_gate.sh --keepers 8 --entries 20000
+
+# Attach mode against a running server; --server-pid is required for the RSS axes.
+scripts/harness/perf/request_cost_gate.sh \
+  --base-url http://127.0.0.1:8935 --server-pid "$(lsof -ti :8935 -sTCP:LISTEN | head -1)"
+```
+
+Artifacts land in `logs/perf-request-cost/<run-id>/`: `summary.json`, per-probe `probes.csv`,
+and `rss.csv`.
+
+### Measured results (origin/main `7e57a3af79`, M3 Max 16-core, 2026-08-12)
+
+Seed: 8 keepers x 20,000 entries/store = 12 stores, 240,000 entries, 125MB on disk.
+One request to `/api/v1/dashboard/telemetry?n=0`:
+
+| axis | measured | threshold | verdict |
+|---|---|---|---|
+| `probe_p95_ms` | 1128.0 (max 4424.0) | 250 | FAIL |
+| `rss_peak_delta_mb` | 1005.5 | 512 | FAIL |
+| `cancel_recovery_s` | 20.4 | 5 | FAIL |
+| `post_abort_heap_growth_mb` | 315.6 | 64 | FAIL |
+
+A 125MB store yields 1GB of heap from one request — roughly 8x amplification — and the server
+keeps computing for 20 seconds after the client is gone. RED here is the proof the gate catches
+the defect; a gate that passes on current main would be too weak.
+
+Scaling was measured at 4 vs 8 keepers, but only the heap axis is comparable: the 4-keeper run
+had a baseline p95 of 22.1ms against 3.2ms for the 8-keeper run, so its latency numbers carry
+host contention. Heap grew 682.8MB -> 1005.5MB as keepers doubled. The baseline control added
+after that run rejects such a run outright.

--- a/scripts/harness/perf/request_cost_gate.sh
+++ b/scripts/harness/perf/request_cost_gate.sh
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+# request_cost_gate.sh — Mode C: gate the resource cost of a SINGLE dashboard read.
+#
+# Relationship to Modes A and B
+#   Mode A (scheduler_starvation_gate.sh) drives serving concurrency plus host hogs; Mode B
+#   (keeper_load_gate.sh) drives real keeper turns. Both stress CONTENTION and answer "where does
+#   work run, and who is it queued behind".
+#   Mode C holds concurrency at ONE and asks how much a single request costs. A read whose entry
+#   count scales with the store cannot be fixed by moving it to another domain or pool: the lane
+#   it lands on dies instead, and the heap it allocates is process-global, so every keeper shares
+#   the GC pressure. Isolation and boundedness are separate axes; this gate covers boundedness.
+#
+# What it measures (three axes, one request)
+#   1. probe_p95_ms        trivial-endpoint p95 while ONE heavy request is in flight
+#   2. rss_peak_delta_mb   peak RSS growth attributable to that one request
+#   3. cancel_recovery_s   seconds for the probe to return to baseline after the client aborts
+#                          (a server that does not propagate cancellation keeps computing)
+#
+# Gate semantics (falsifiable)
+#   GREEN requires all three under threshold. On current main this is expected to FAIL — that
+#   failure is the proof the gate catches the defect. A gate that passes on unfixed main is too
+#   weak and must be tightened.
+#
+# Scaling check
+#   --keepers is a seed parameter because the reader's scan cap is per-store, not per-request.
+#   Running the gate at two keeper counts shows whether one request's cost tracks store count;
+#   if it does, the request has no budget of its own.
+#
+# Exit codes
+#   0  GREEN  — single-request cost bounded
+#   2  RED    — cost unbounded (expected on current unfixed main)
+#   1  ERROR  — harness failure (server did not boot, missing tools, bad args)
+#
+# Reference: docs/rfc/RFC-0204-dashboard-serving-isolation.md (isolation axis; this gate is the
+# boundedness sibling). Changes no production code; measurement infrastructure only.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/harness/lib/server_bootstrap.sh"
+
+# ---- configuration (env-overridable) ----------------------------------------
+PROBE_ENDPOINT="${PROBE_ENDPOINT:-/health}"      # trivial, lock-free
+COST_ENDPOINT="${COST_ENDPOINT:-/api/v1/dashboard/telemetry?n=0}"
+BASELINE_PROBES="${BASELINE_PROBES:-15}"
+PROBE_INTERVAL_SEC="${PROBE_INTERVAL_SEC:-0.25}"
+PROBE_MAX_SEC="${PROBE_MAX_SEC:-20}"             # per-probe ceiling; a timeout counts as this
+COST_MAX_SEC="${COST_MAX_SEC:-120}"              # ceiling for the heavy request itself
+CANCEL_AFTER_SEC="${CANCEL_AFTER_SEC:-3}"        # abort the heavy client after this long
+CANCEL_WATCH_SEC="${CANCEL_WATCH_SEC:-60}"       # how long to wait for post-abort recovery
+SAMPLE_INTERVAL_SEC="${SAMPLE_INTERVAL_SEC:-0.5}"
+
+# Gate thresholds.
+THRESHOLD_MS="${THRESHOLD_MS:-250}"              # probe p95 under one heavy request
+MAX_RSS_DELTA_MB="${MAX_RSS_DELTA_MB:-512}"      # heap growth one request may cause
+MAX_CANCEL_RECOVERY_SEC="${MAX_CANCEL_RECOVERY_SEC:-5}"
+MAX_POST_ABORT_GROWTH_MB="${MAX_POST_ABORT_GROWTH_MB:-64}"  # heap growth after the client left
+
+# Control that must pass before any verdict is trusted. If the trivial endpoint is already slow
+# with no load on it, the host is contended and every downstream number is that contention, not
+# the request under test. Such a run exits ERROR (1), never RED (2): a RED from a busy host is a
+# false positive, and RFC-0204's first diagnosis was reversed for exactly this reason.
+MAX_BASELINE_P95_MS="${MAX_BASELINE_P95_MS:-50}"
+
+# Seed shape (boot mode only).
+SEED_KEEPERS="${SEED_KEEPERS:-8}"
+SEED_ENTRIES="${SEED_ENTRIES:-20000}"
+SEED_DAYS="${SEED_DAYS:-4}"
+
+# Attach mode: probe an already-running server instead of booting one. RSS is then read from
+# the listening PID. Booting is the default and is self-contained + deterministic.
+BASE_URL="${MASC_HARNESS_BASE_URL:-}"
+ATTACH_PID="${MASC_HARNESS_SERVER_PID:-}"
+KEEP_SERVER="${KEEP_SERVER:-0}"
+
+RUN_ID="${RUN_ID:-request-cost-$(date +%Y%m%d_%H%M%S)-$$}"
+RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/perf-request-cost/$RUN_ID}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+  --cost-endpoint PATH   heavy endpoint under test (default: $COST_ENDPOINT)
+  --probe-endpoint PATH  trivial endpoint to probe (default: $PROBE_ENDPOINT)
+  --keepers N            seeded per-keeper stores (default: $SEED_KEEPERS)
+  --entries N            seeded entries per store (default: $SEED_ENTRIES)
+  --threshold-ms N       max probe p95 under load before RED (default: $THRESHOLD_MS)
+  --max-rss-mb N         max RSS growth from one request before RED (default: $MAX_RSS_DELTA_MB)
+  --max-cancel-sec N     max post-abort recovery before RED (default: $MAX_CANCEL_RECOVERY_SEC)
+  --max-post-abort-mb N  max heap growth after client abort before RED (default: $MAX_POST_ABORT_GROWTH_MB)
+  --max-baseline-ms N    control: abort the run as ERROR if idle p95 exceeds this
+                         (default: $MAX_BASELINE_P95_MS)
+  --base-url URL         attach to a running server instead of booting
+  --server-pid PID       PID for RSS sampling in attach mode (default: autodetect by port)
+  --keep-server          do not stop the booted server on exit
+  -h|--help              this help
+Environment overrides mirror the flags.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cost-endpoint) COST_ENDPOINT="$2"; shift 2 ;;
+    --probe-endpoint) PROBE_ENDPOINT="$2"; shift 2 ;;
+    --keepers) SEED_KEEPERS="$2"; shift 2 ;;
+    --entries) SEED_ENTRIES="$2"; shift 2 ;;
+    --threshold-ms) THRESHOLD_MS="$2"; shift 2 ;;
+    --max-rss-mb) MAX_RSS_DELTA_MB="$2"; shift 2 ;;
+    --max-cancel-sec) MAX_CANCEL_RECOVERY_SEC="$2"; shift 2 ;;
+    --max-post-abort-mb) MAX_POST_ABORT_GROWTH_MB="$2"; shift 2 ;;
+    --max-baseline-ms) MAX_BASELINE_P95_MS="$2"; shift 2 ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --server-pid) ATTACH_PID="$2"; shift 2 ;;
+    --keep-server) KEEP_SERVER=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+for tool in curl jq awk python3 ps; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "ERROR: missing required tool: $tool" >&2; exit 1; }
+done
+
+mkdir -p "$RUN_DIR"
+PROBE_CSV="$RUN_DIR/probes.csv"
+RSS_CSV="$RUN_DIR/rss.csv"
+SUMMARY_FILE="$RUN_DIR/summary.json"
+SERVER_LOG="$RUN_DIR/server.log"
+SEED_INFO="$RUN_DIR/seed.json"
+echo "phase,elapsed_s,ms" > "$PROBE_CSV"
+echo "phase,elapsed_s,rss_kb" > "$RSS_CSV"
+
+SERVER_PID=""
+BASE_PATH=""
+SAMPLER_PID=""
+COST_PID=""
+
+cleanup() {
+  [[ -n "$SAMPLER_PID" ]] && kill "$SAMPLER_PID" 2>/dev/null || true
+  [[ -n "$COST_PID" ]] && kill "$COST_PID" 2>/dev/null || true
+  if [[ -n "$SERVER_PID" && "$KEEP_SERVER" != "1" ]]; then
+    harness_stop_server "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+# ---- helpers ----------------------------------------------------------------
+
+now_s() { python3 -c 'import time; print(time.time())'; }
+
+elapsed_since() { python3 -c "import sys; print(round(float(sys.argv[2])-float(sys.argv[1]),3))" "$1" "$(now_s)"; }
+
+rss_kb_of() {
+  local kb
+  kb="$(ps -o rss= -p "$1" 2>/dev/null | tr -d ' ')"
+  printf '%s\n' "${kb:-0}"
+}
+
+kb_to_mb() { python3 -c "import sys; print(round(float(sys.argv[1])/1024,1))" "$1"; }
+
+# One probe; prints milliseconds. A timeout is recorded as the ceiling rather than dropped,
+# so a hung server raises the statistic instead of silently shrinking the sample.
+probe_ms() {
+  local t
+  t="$(curl -s -o /dev/null -w '%{time_total}' --max-time "$PROBE_MAX_SEC" \
+        "${BASE_URL}${PROBE_ENDPOINT}" 2>/dev/null || echo "$PROBE_MAX_SEC")"
+  python3 -c "import sys; print(round(float(sys.argv[1])*1000,1))" "$t"
+}
+
+# Percentile in python rather than awk: `asort` is a gawk extension and macOS ships BSD awk,
+# where it fails at runtime. Empty input yields 0 so the caller never sees a blank field.
+percentile() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, col, pct = sys.argv[1], int(sys.argv[2]), float(sys.argv[3])
+values: list[float] = []
+with open(path, encoding="utf-8") as handle:
+    next(handle, None)
+    for line in handle:
+        parts = line.rstrip("\n").split(",")
+        if len(parts) >= col:
+            try:
+                values.append(float(parts[col - 1]))
+            except ValueError:
+                pass
+if not values:
+    print(0)
+    raise SystemExit(0)
+values.sort()
+index = max(1, min(int(pct / 100 * len(values)), len(values)))
+print(values[index - 1])
+PY
+}
+
+filter_phase() {
+  local phase="$1" src="$2" dst="$3"
+  head -1 "$src" > "$dst"
+  awk -F, -v ph="$phase" 'NR>1 && $1==ph' "$src" >> "$dst"
+}
+
+# The sampler runs concurrently with the measurement, so it must stay cheap: `ps` only, no
+# python per tick. Raw KB is recorded and converted once at verdict time.
+start_rss_sampler() {
+  local phase="$1" pid="$2"
+  local started
+  started="$(date +%s)"
+  (
+    while true; do
+      printf '%s,%s,%s\n' "$phase" "$(( $(date +%s) - started ))" \
+        "$(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ' || echo 0)" >> "$RSS_CSV"
+      sleep "$SAMPLE_INTERVAL_SEC"
+    done
+  ) &
+  SAMPLER_PID=$!
+}
+
+stop_rss_sampler() {
+  [[ -n "$SAMPLER_PID" ]] && kill "$SAMPLER_PID" 2>/dev/null || true
+  wait "$SAMPLER_PID" 2>/dev/null || true
+  SAMPLER_PID=""
+}
+
+# ---- server: boot or attach --------------------------------------------------
+
+if [[ -n "$BASE_URL" ]]; then
+  BASE_URL="${BASE_URL%/}"
+  echo "harness: attach mode -> $BASE_URL (no seeding; store shape is whatever the server has)"
+  if [[ -z "$ATTACH_PID" ]]; then
+    local_port="${BASE_URL##*:}"
+    ATTACH_PID="$(lsof -ti ":${local_port}" -sTCP:LISTEN 2>/dev/null | head -1 || true)"
+  fi
+  if [[ -z "$ATTACH_PID" ]]; then
+    echo "ERROR: attach mode needs --server-pid (RSS axis cannot be measured without it)" >&2
+    exit 1
+  fi
+  SERVER_RSS_PID="$ATTACH_PID"
+  SEED_KEEPERS=0
+  SEED_ENTRIES=0
+  printf '{"mode":"attach"}\n' > "$SEED_INFO"
+else
+  SERVER_EXE="$(harness_find_server_exe "$REPO_ROOT" "${MASC_HARNESS_SERVER_EXE:-}")" || {
+    echo "ERROR: server exe not found; build first (or set MASC_HARNESS_SERVER_EXE)" >&2
+    exit 1
+  }
+  PORT="$(harness_pick_free_port)"
+  BASE_PATH="$(harness_mktemp_dir "request-cost-base")"
+  echo "harness: seeding store (keepers=$SEED_KEEPERS entries/store=$SEED_ENTRIES days=$SEED_DAYS)"
+  python3 "$SCRIPT_DIR/seed_telemetry_store.py" \
+    --root "$BASE_PATH/.masc" \
+    --keepers "$SEED_KEEPERS" \
+    --entries-per-store "$SEED_ENTRIES" \
+    --days "$SEED_DAYS" > "$SEED_INFO"
+  cat "$SEED_INFO"
+
+  echo "harness: booting server on port $PORT (base-path $BASE_PATH)"
+  SERVER_PID="$(harness_start_server "$SERVER_EXE" "$PORT" "$BASE_PATH" "$SERVER_LOG")"
+  if ! harness_wait_for_health "$PORT" 60; then
+    echo "ERROR: server failed health check within 60s" >&2
+    harness_print_log_tail "$SERVER_LOG" || true
+    exit 1
+  fi
+  BASE_URL="http://127.0.0.1:${PORT}"
+  SERVER_RSS_PID="$SERVER_PID"
+fi
+
+# ---- phase 1: baseline -------------------------------------------------------
+
+echo "harness: phase 1 — baseline ($BASELINE_PROBES probes, no load)"
+T0="$(now_s)"
+for _ in $(seq 1 "$BASELINE_PROBES"); do
+  printf 'baseline,%s,%s\n' "$(elapsed_since "$T0")" "$(probe_ms)" >> "$PROBE_CSV"
+done
+RSS_BASELINE_KB="$(rss_kb_of "$SERVER_RSS_PID")"
+RSS_BASELINE="$(kb_to_mb "$RSS_BASELINE_KB")"
+printf 'baseline,%s,%s\n' "$(elapsed_since "$T0")" "$RSS_BASELINE_KB" >> "$RSS_CSV"
+
+filter_phase baseline "$PROBE_CSV" "$RUN_DIR/_baseline.csv"
+BASE_P50="$(percentile "$RUN_DIR/_baseline.csv" 3 50)"
+BASE_P95="$(percentile "$RUN_DIR/_baseline.csv" 3 95)"
+echo "         baseline p50=${BASE_P50}ms p95=${BASE_P95}ms rss=${RSS_BASELINE}MB"
+
+if python3 -c "import sys; sys.exit(0 if float(sys.argv[1])>float(sys.argv[2]) else 1)" \
+     "$BASE_P95" "$MAX_BASELINE_P95_MS"; then
+  echo "ERROR: baseline p95=${BASE_P95}ms exceeds the control ceiling ${MAX_BASELINE_P95_MS}ms." >&2
+  echo "       The host is contended; this run cannot attribute cost to the request under test." >&2
+  echo "       Quiet the host (stop builds/dev servers) and re-run, or raise MAX_BASELINE_P95_MS" >&2
+  echo "       deliberately if you accept a noisier measurement." >&2
+  jq -n --arg run_id "$RUN_ID" --argjson baseline_p95_ms "$BASE_P95" \
+        --argjson ceiling "$MAX_BASELINE_P95_MS" \
+    '{run_id:$run_id, verdict:"ERROR", reason:"baseline control failed",
+      baseline_p95_ms:$baseline_p95_ms, control_ceiling_ms:$ceiling}' > "$SUMMARY_FILE"
+  exit 1
+fi
+
+# ---- phase 2: one heavy request in flight ------------------------------------
+
+echo "harness: phase 2 — ONE heavy request ($COST_ENDPOINT)"
+T0="$(now_s)"
+start_rss_sampler loaded "$SERVER_RSS_PID"
+
+COST_START="$(now_s)"
+curl -s -o /dev/null -H 'Accept-Encoding: zstd' --max-time "$COST_MAX_SEC" \
+  "${BASE_URL}${COST_ENDPOINT}" >/dev/null 2>&1 &
+COST_PID=$!
+
+while kill -0 "$COST_PID" 2>/dev/null; do
+  printf 'loaded,%s,%s\n' "$(elapsed_since "$T0")" "$(probe_ms)" >> "$PROBE_CSV"
+  sleep "$PROBE_INTERVAL_SEC"
+done
+wait "$COST_PID" 2>/dev/null || true
+COST_DURATION="$(elapsed_since "$COST_START")"
+COST_PID=""
+stop_rss_sampler
+
+filter_phase loaded "$PROBE_CSV" "$RUN_DIR/_loaded.csv"
+LOAD_P95="$(percentile "$RUN_DIR/_loaded.csv" 3 95)"
+LOAD_MAX="$(percentile "$RUN_DIR/_loaded.csv" 3 100)"
+filter_phase loaded "$RSS_CSV" "$RUN_DIR/_loaded_rss.csv"
+RSS_PEAK_KB="$(percentile "$RUN_DIR/_loaded_rss.csv" 3 100)"
+RSS_PEAK="$(kb_to_mb "$RSS_PEAK_KB")"
+RSS_DELTA="$(python3 -c "import sys; print(round(float(sys.argv[1])-float(sys.argv[2]),1))" "$RSS_PEAK" "$RSS_BASELINE")"
+echo "         heavy request took ${COST_DURATION}s; probe p95=${LOAD_P95}ms max=${LOAD_MAX}ms"
+echo "         rss ${RSS_BASELINE}MB -> peak ${RSS_PEAK}MB (delta ${RSS_DELTA}MB)"
+
+# ---- phase 3: cancellation propagation ---------------------------------------
+# Fire the same request, abort the client mid-flight, then measure how long the probe stays
+# degraded. A server that propagates cancellation recovers immediately; one that does not keeps
+# computing for the full request duration with no client left to receive the result.
+
+echo "harness: phase 3 — abort client after ${CANCEL_AFTER_SEC}s, watch recovery"
+RECOVERY_CEILING="$(python3 -c "import sys; print(max(float(sys.argv[1])*3, float(sys.argv[2])))" "$BASE_P95" "$THRESHOLD_MS")"
+T0="$(now_s)"
+curl -s -o /dev/null -H 'Accept-Encoding: zstd' --max-time "$COST_MAX_SEC" \
+  "${BASE_URL}${COST_ENDPOINT}" >/dev/null 2>&1 &
+COST_PID=$!
+sleep "$CANCEL_AFTER_SEC"
+kill "$COST_PID" 2>/dev/null || true
+wait "$COST_PID" 2>/dev/null || true
+COST_PID=""
+ABORT_AT="$(now_s)"
+RSS_AT_ABORT_KB="$(rss_kb_of "$SERVER_RSS_PID")"
+RSS_POST_ABORT_MAX_KB="$RSS_AT_ABORT_KB"
+
+# Two signals, because latency alone is ambiguous. A single fast probe can land in a gap while
+# the server is still computing, so recovery requires CONSECUTIVE_HEALTHY probes in a row.
+# The unambiguous signal is heap: if RSS keeps climbing after the client is gone, the server is
+# still building a result nobody will receive — cancellation did not propagate.
+CONSECUTIVE_HEALTHY=3
+healthy_run=0
+CANCEL_RECOVERY="$CANCEL_WATCH_SEC"
+while true; do
+  waited="$(elapsed_since "$ABORT_AT")"
+  ms="$(probe_ms)"
+  printf 'cancel,%s,%s\n' "$(elapsed_since "$T0")" "$ms" >> "$PROBE_CSV"
+
+  rss_now_kb="$(rss_kb_of "$SERVER_RSS_PID")"
+  printf 'cancel,%s,%s\n' "$(elapsed_since "$T0")" "$rss_now_kb" >> "$RSS_CSV"
+  if (( rss_now_kb > RSS_POST_ABORT_MAX_KB )); then
+    RSS_POST_ABORT_MAX_KB="$rss_now_kb"
+  fi
+
+  if python3 -c "import sys; sys.exit(0 if float(sys.argv[1])<=float(sys.argv[2]) else 1)" "$ms" "$RECOVERY_CEILING"; then
+    healthy_run=$(( healthy_run + 1 ))
+  else
+    healthy_run=0
+  fi
+
+  if (( healthy_run >= CONSECUTIVE_HEALTHY )); then
+    CANCEL_RECOVERY="$waited"
+    break
+  fi
+  if python3 -c "import sys; sys.exit(0 if float(sys.argv[1])>=float(sys.argv[2]) else 1)" "$waited" "$CANCEL_WATCH_SEC"; then
+    CANCEL_RECOVERY="$CANCEL_WATCH_SEC"
+    break
+  fi
+  sleep "$PROBE_INTERVAL_SEC"
+done
+
+RSS_AT_ABORT="$(kb_to_mb "$RSS_AT_ABORT_KB")"
+POST_ABORT_GROWTH="$(python3 -c "import sys; print(round((float(sys.argv[1])-float(sys.argv[2]))/1024,1))" \
+  "$RSS_POST_ABORT_MAX_KB" "$RSS_AT_ABORT_KB")"
+echo "         recovery after abort: ${CANCEL_RECOVERY}s (needs ${CONSECUTIVE_HEALTHY} consecutive probes <= ${RECOVERY_CEILING}ms)"
+echo "         heap after abort: ${RSS_AT_ABORT}MB -> +${POST_ABORT_GROWTH}MB (growth with no client = no cancellation)"
+
+# ---- verdict -----------------------------------------------------------------
+
+fail_reasons=()
+gt() { python3 -c "import sys; sys.exit(0 if float(sys.argv[1])>float(sys.argv[2]) else 1)" "$1" "$2"; }
+
+if gt "$LOAD_P95" "$THRESHOLD_MS"; then
+  fail_reasons+=("probe_p95_ms=${LOAD_P95} > ${THRESHOLD_MS}")
+fi
+if gt "$RSS_DELTA" "$MAX_RSS_DELTA_MB"; then
+  fail_reasons+=("rss_peak_delta_mb=${RSS_DELTA} > ${MAX_RSS_DELTA_MB}")
+fi
+if gt "$CANCEL_RECOVERY" "$MAX_CANCEL_RECOVERY_SEC"; then
+  fail_reasons+=("cancel_recovery_s=${CANCEL_RECOVERY} > ${MAX_CANCEL_RECOVERY_SEC}")
+fi
+if gt "$POST_ABORT_GROWTH" "$MAX_POST_ABORT_GROWTH_MB"; then
+  fail_reasons+=("post_abort_heap_growth_mb=${POST_ABORT_GROWTH} > ${MAX_POST_ABORT_GROWTH_MB} (cancellation not propagated)")
+fi
+
+verdict="GREEN"
+exit_code=0
+if [[ ${#fail_reasons[@]} -gt 0 ]]; then
+  verdict="RED"
+  exit_code=2
+fi
+
+jq -n \
+  --arg run_id "$RUN_ID" \
+  --arg verdict "$verdict" \
+  --arg cost_endpoint "$COST_ENDPOINT" \
+  --arg probe_endpoint "$PROBE_ENDPOINT" \
+  --argjson seed "$(cat "$SEED_INFO")" \
+  --argjson baseline_p50_ms "$BASE_P50" \
+  --argjson baseline_p95_ms "$BASE_P95" \
+  --argjson probe_p95_ms "$LOAD_P95" \
+  --argjson probe_max_ms "$LOAD_MAX" \
+  --argjson cost_duration_s "$COST_DURATION" \
+  --argjson rss_baseline_mb "$RSS_BASELINE" \
+  --argjson rss_peak_mb "$RSS_PEAK" \
+  --argjson rss_peak_delta_mb "$RSS_DELTA" \
+  --argjson cancel_recovery_s "$CANCEL_RECOVERY" \
+  --argjson post_abort_heap_growth_mb "$POST_ABORT_GROWTH" \
+  --argjson threshold_ms "$THRESHOLD_MS" \
+  --argjson max_rss_delta_mb "$MAX_RSS_DELTA_MB" \
+  --argjson max_cancel_recovery_s "$MAX_CANCEL_RECOVERY_SEC" \
+  --argjson max_post_abort_heap_growth_mb "$MAX_POST_ABORT_GROWTH_MB" \
+  --argjson reasons "$(printf '%s\n' "${fail_reasons[@]+"${fail_reasons[@]}"}" | jq -R . | jq -s 'map(select(. != ""))')" \
+  '{run_id:$run_id, verdict:$verdict, cost_endpoint:$cost_endpoint, probe_endpoint:$probe_endpoint,
+    seed:$seed,
+    measured:{baseline_p50_ms:$baseline_p50_ms, baseline_p95_ms:$baseline_p95_ms,
+              probe_p95_ms:$probe_p95_ms, probe_max_ms:$probe_max_ms,
+              cost_duration_s:$cost_duration_s,
+              rss_baseline_mb:$rss_baseline_mb, rss_peak_mb:$rss_peak_mb,
+              rss_peak_delta_mb:$rss_peak_delta_mb,
+              cancel_recovery_s:$cancel_recovery_s,
+              post_abort_heap_growth_mb:$post_abort_heap_growth_mb},
+    thresholds:{probe_p95_ms:$threshold_ms, rss_peak_delta_mb:$max_rss_delta_mb,
+                cancel_recovery_s:$max_cancel_recovery_s,
+                post_abort_heap_growth_mb:$max_post_abort_heap_growth_mb},
+    failures:$reasons}' > "$SUMMARY_FILE"
+
+echo ""
+echo "verdict: $verdict"
+for reason in "${fail_reasons[@]+"${fail_reasons[@]}"}"; do
+  echo "  FAIL: $reason"
+done
+echo "artifacts: $RUN_DIR"
+exit "$exit_code"

--- a/scripts/harness/perf/seed_telemetry_store.py
+++ b/scripts/harness/perf/seed_telemetry_store.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Seed a synthetic MASC telemetry store for the request-cost harness.
+
+The request-cost defect (a single unbounded dashboard read materialising the
+whole store in the heap) is invisible on an empty store: with little data the
+full scan is fast. Reproducing it deterministically therefore needs a store of
+a known shape, which is what this script writes.
+
+Layout mirrors the production reader contract:
+
+    <root>/keepers/<name>/metrics/YYYY-MM/DD.jsonl   per-keeper fan-out source
+    <root>/telemetry/YYYY-MM/DD.jsonl                Agent_event
+    <root>/tool_calls/YYYY-MM/DD.jsonl               Tool_call_io
+    <root>/tool_usage/YYYY-MM/DD.jsonl               Tool_usage
+    <root>/agent-core-events/YYYY-MM/DD.jsonl        Agent_core_event
+
+Entries carry the field names the reader extracts (`ts`, `ts_unix`, `name`,
+`session_id`, `operation_id`) so timestamp extraction and scope filtering do
+the same work they do in production, plus filler to reach a realistic line
+size.
+
+The keeper count is a parameter because the per-request cost is expected to
+scale with it: the scan cap in the reader is per-store, not per-request, so
+doubling `--keepers` doubles the entries one request can materialise. A run at
+two keeper counts measures that directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Fixed-path sources the unified reader scans in addition to the per-keeper
+# fan-out. Names match `telemetry_unified_source_meta.fixed_store_dir`.
+FIXED_SOURCES: tuple[str, ...] = (
+    "telemetry",
+    "tool_calls",
+    "tool_usage",
+    "agent-core-events",
+)
+
+# Padding target per JSONL line. Production keeper.metrics.v1 rows run several
+# hundred bytes; a too-small row would understate parse and heap cost.
+TARGET_LINE_BYTES = 520
+
+# Deterministic epoch for generated timestamps. Fixed (not `now`) so two runs
+# of the harness produce byte-identical stores and results stay comparable.
+BASE_EPOCH = datetime(2026, 8, 1, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True, slots=True)
+class SeedPlan:
+    root: Path
+    keepers: int
+    entries_per_store: int
+    days: int
+
+
+def _entry(index: int, source: str, keeper: str, ts: datetime) -> str:
+    """One JSONL row shaped like the rows the reader parses."""
+    record: dict[str, object] = {
+        "schema": f"masc.harness.{source}.v1",
+        "record_kind": "turn",
+        "ts": ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "ts_unix": ts.timestamp(),
+        "name": keeper,
+        "agent_name": f"keeper-{keeper}-agent",
+        "session_id": f"harness-session-{index % 32}",
+        "operation_id": f"harness-op-{index}",
+        "trace_id": f"harness-trace-{index // 128}",
+        "channel": "scheduled_autonomous",
+        "generation": 1,
+        "index": index,
+    }
+    # Pad to a realistic line width so parse cost per entry is representative.
+    encoded = json.dumps(record, separators=(",", ":"))
+    deficit = TARGET_LINE_BYTES - len(encoded) - len('"filler":"",')
+    if deficit > 0:
+        record["filler"] = "x" * deficit
+        encoded = json.dumps(record, separators=(",", ":"))
+    return encoded
+
+
+def _write_store(store_dir: Path, source: str, keeper: str, plan: SeedPlan) -> int:
+    """Write one dated store; returns the number of entries written."""
+    per_day = max(1, plan.entries_per_store // plan.days)
+    written = 0
+    for day_offset in range(plan.days):
+        day = BASE_EPOCH + timedelta(days=day_offset)
+        day_dir = store_dir / day.strftime("%Y-%m")
+        day_dir.mkdir(parents=True, exist_ok=True)
+        target = day_dir / f"{day.strftime('%d')}.jsonl"
+        remaining = plan.entries_per_store - written
+        count = min(per_day, remaining) if day_offset < plan.days - 1 else remaining
+        if count <= 0:
+            break
+        with target.open("w", encoding="utf-8") as handle:
+            for i in range(count):
+                ts = day + timedelta(seconds=i % 86_400)
+                handle.write(_entry(written + i, source, keeper, ts))
+                handle.write("\n")
+        written += count
+    return written
+
+
+def seed(plan: SeedPlan) -> dict[str, object]:
+    stores = 0
+    entries = 0
+
+    for k in range(plan.keepers):
+        keeper = f"harness-keeper-{k:02d}"
+        store = plan.root / "keepers" / keeper / "metrics"
+        entries += _write_store(store, "keeper_metric", keeper, plan)
+        stores += 1
+
+    for source in FIXED_SOURCES:
+        store = plan.root / source
+        entries += _write_store(store, source, "harness-fixed", plan)
+        stores += 1
+
+    total_bytes = sum(p.stat().st_size for p in plan.root.rglob("*.jsonl"))
+    return {
+        "root": str(plan.root),
+        "keepers": plan.keepers,
+        "stores": stores,
+        "entries": entries,
+        "bytes": total_bytes,
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, type=Path,
+                        help="masc root to seed (created if absent)")
+    parser.add_argument("--keepers", type=int, default=8,
+                        help="per-keeper fan-out stores to create (default: 8)")
+    parser.add_argument("--entries-per-store", type=int, default=20_000,
+                        help="entries written per store (default: 20000)")
+    parser.add_argument("--days", type=int, default=4,
+                        help="dated partitions to spread entries across (default: 4)")
+    args = parser.parse_args(argv)
+
+    if args.keepers < 1 or args.entries_per_store < 1 or args.days < 1:
+        print("ERROR: --keepers, --entries-per-store and --days must be >= 1",
+              file=sys.stderr)
+        return 1
+
+    plan = SeedPlan(
+        root=args.root,
+        keepers=args.keepers,
+        entries_per_store=args.entries_per_store,
+        days=args.days,
+    )
+    plan.root.mkdir(parents=True, exist_ok=True)
+    print(json.dumps(seed(plan)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

Adds `scripts/harness/perf/request_cost_gate.sh` (Mode C) and its seed generator. Measurement infrastructure only — **no production code changes**.

## Why this is a separate mode

Mode A (`scheduler_starvation_gate.sh`) drives serving concurrency plus host hogs. Mode B (`keeper_load_gate.sh`) drives real keeper turns. Both stress **contention** and answer "where does work run, and who is it queued behind".

Neither holds concurrency at one. So neither can see a request whose cost scales with the **store** rather than with load — and that failure is not fixable by isolation. Moving such a read to a dedicated pool or serving domain (RFC-0204) means the lane it lands on dies instead, and its heap is process-global, so every keeper shares the GC pressure regardless of which domain allocated it.

Isolation and boundedness are separate axes. RFC-0204 covers the first; this gate covers the second.

## What it measures

One request, four axes:

| axis | catches |
|---|---|
| `probe_p95_ms` | trivial-endpoint p95 while one heavy request is in flight |
| `rss_peak_delta_mb` | heap growth attributable to that one request |
| `cancel_recovery_s` | recovery after client abort (3 consecutive healthy probes, so one lucky sample cannot pass it) |
| `post_abort_heap_growth_mb` | heap growth **after the client is gone** |

`post_abort_heap_growth_mb` is the axis to trust. Latency carries host noise; a heap still climbing with no client left to receive the result does not.

## Baseline control

The run exits **1 (ERROR)**, not 2 (RED), when the idle probe is already slow (`MAX_BASELINE_P95_MS`, default 50ms). A contended host makes every downstream number look like a defect. RFC-0204's first diagnosis was reversed for exactly this reason, so the gate refuses to produce a verdict it cannot attribute. ERROR means "measurement invalid", not "code is fine".

This was added after a real 4-vs-8-keeper comparison in this PR's own development produced a 22.1ms baseline and unusable latency numbers.

## Seeding

An empty store cannot reproduce the defect — with little data the full scan is fast. `seed_telemetry_store.py` writes a store of known shape into the layout the reader expects (`keepers/<name>/metrics/YYYY-MM/DD.jsonl` plus the four fixed-path sources).

`--keepers` is a parameter on purpose: the reader's scan cap is per-store, not per-request, so running at two keeper counts shows whether one request's cost tracks store count.

## Measured (origin/main `7e57a3af79`, M3 Max 16-core, 2026-08-12)

Seed: 8 keepers × 20,000 entries = 12 stores, 240,000 entries, 125MB on disk.
One `GET /api/v1/dashboard/telemetry?n=0`:

| axis | measured | threshold | verdict |
|---|---|---|---|
| `probe_p95_ms` | 1128.0 (max 4424.0) | 250 | FAIL |
| `rss_peak_delta_mb` | 1005.5 | 512 | FAIL |
| `cancel_recovery_s` | 20.4 | 5 | FAIL |
| `post_abort_heap_growth_mb` | 315.6 | 64 | FAIL |

A 125MB store yields 1GB of heap from one request (~8× amplification), and the server keeps computing for 20 seconds after the client is gone.

RED on current main is the point: a gate that passed here would be too weak to be worth running.

## Verification

Gate behaviour confirmed in all three states, not just the failing one:

- **RED (exit 2)** — 8 keepers × 20k entries, thresholds exceeded on all four axes
- **GREEN (exit 0)** — 1 keeper × 200 entries, all axes clear
- **ERROR (exit 1)** — baseline control tripped with `--max-baseline-ms 0.01`

`bash -n` and `shellcheck -S warning` clean on both scripts.

## Scope

- `scripts/harness/perf/request_cost_gate.sh` (new)
- `scripts/harness/perf/seed_telemetry_store.py` (new)
- `scripts/harness/perf/README.md` (Mode C section)

No production code, no library, no config. This PR claims no fix and closes no defect; it makes one measurable so a later fix has something to prove itself against.

RFC-WAIVED: measurement-only harness; touches no subsystem in the RFC discovery list (no credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, or workflow docs). Related design context is RFC-0204, cited above.

WORKAROUND-WAIVED: adds no production code path, so it cannot suppress a symptom. The four thresholds are gate criteria in test infrastructure, not runtime caps/cooldowns; nothing here changes server behaviour.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
