### PR TITLE
feat(gate): render Slack user ids as display names on inbound events

### DIFF
--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -27,6 +27,7 @@
   slack_gateway_state
   slack_socket_client
   slack_rest_client
+  slack_user_directory
   slack_observability
   gate_protocol
   gate_surface

--- a/lib/gate/slack_rest_client.ml
+++ b/lib/gate/slack_rest_client.ml
@@ -197,3 +197,73 @@ let auth_test ?clock ?(timeout_sec = default_http_timeout_sec) ~token () =
   match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_auth_test_response ~status ~body
+
+(* users.info — resolve one user's profile names for inbound identity
+   rendering (issue #28376). Slack Web API accepts form-encoded POST for this
+   method; ids come from Slack's own events ([A-Z0-9], no URL escaping
+   needed). A missing [users:read] scope surfaces as [Slack_api]. *)
+type user_info_ok = {
+  user_id : string;
+  name : string option;
+  real_name : string option;
+  display_name : string option;
+}
+
+let build_users_info_request ~token ~user_id =
+  let url = "https://slack.com/api/users.info" in
+  let headers =
+    ("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+    :: auth_headers ~token
+  in
+  (url, headers, "user=" ^ user_id)
+
+let parse_users_info_response ~status ~body =
+  if status < 200 || status >= 300 then Error (Http_status { code = status; body })
+  else
+    match parse_json_safe body with
+    | None -> Error (Other ("response not JSON: " ^ body))
+    | Some json ->
+      let ok =
+        match field_opt "ok" json with Some (`Bool b) -> b | _ -> false
+      in
+      if not ok then
+        let err =
+          match field_opt "error" json with
+          | Some (`String e) -> e
+          | _ -> "users.info failed"
+        in
+        Error (Slack_api { error = err })
+      else
+        (match field_opt "user" json with
+         | Some (`Assoc _ as user) ->
+           (match field_opt "id" user with
+            | Some (`String user_id) ->
+              (* Blank profile fields are represented as absent, not as empty
+                 labels a renderer would print verbatim. *)
+              let non_blank = function
+                | Some (`String s) when String.trim s <> "" -> Some s
+                | Some _ | None -> None
+              in
+              let profile =
+                match field_opt "profile" user with
+                | Some (`Assoc _ as profile) -> Some profile
+                | Some _ | None -> None
+              in
+              let profile_field key =
+                Option.bind profile (fun p -> non_blank (field_opt key p))
+              in
+              Ok
+                { user_id
+                ; name = non_blank (field_opt "name" user)
+                ; real_name = profile_field "real_name"
+                ; display_name = profile_field "display_name"
+                }
+            | Some _ | None -> Error (Other "ok=true but missing user.id"))
+         | Some _ | None -> Error (Other "ok=true but missing 'user'"))
+
+let users_info ?clock ?(timeout_sec = default_http_timeout_sec) ~token ~user_id
+    () =
+  let (url, headers, body) = build_users_info_request ~token ~user_id in
+  match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
+  | Error msg -> Error (Network msg)
+  | Ok (status, body) -> parse_users_info_response ~status ~body

--- a/lib/gate/slack_rest_client.mli
+++ b/lib/gate/slack_rest_client.mli
@@ -126,3 +126,32 @@ val parse_auth_test_response :
 (** Classifies an [auth.test] response. Non-2xx HTTP status is [Http_status];
     2xx Slack [ok=false] is [Slack_api]; [ok=true] without [user_id] is
     [Other]. *)
+
+(** One user's profile names from [users.info] (issue #28376). Blank fields
+    are [None], never empty labels. *)
+type user_info_ok = {
+  user_id : string;
+  name : string option;         (** Legacy handle. *)
+  real_name : string option;    (** [profile.real_name]. *)
+  display_name : string option; (** [profile.display_name]. *)
+}
+
+val users_info :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  token:string ->
+  user_id:string ->
+  unit ->
+  (user_info_ok, error) result
+(** [users.info] for one Slack user id. Bounded by [timeout_sec] (default
+    {!default_http_timeout_sec}) when [~clock] is supplied. A missing
+    [users:read] scope surfaces as [Slack_api]. *)
+
+val build_users_info_request :
+  token:string -> user_id:string -> string * (string * string) list * string
+(** Pure request builder for [users.info], exposed for unit tests. *)
+
+val parse_users_info_response :
+  status:int -> body:string -> (user_info_ok, error) result
+(** Classifies a [users.info] response. Non-2xx HTTP status is
+    [Http_status]; 2xx Slack [ok=false] is [Slack_api]. *)

--- a/lib/gate/slack_user_directory.ml
+++ b/lib/gate/slack_user_directory.ml
@@ -1,0 +1,153 @@
+(* Slack_user_directory — inbound identity rendering for Slack user ids
+   (issue #28376).
+
+   Maps [U…]/[W…] ids to display labels via an injected [users.info] fetch,
+   with a TTL cache so one lookup serves a conversation instead of one call
+   per message. Failures are cached too, on a shorter TTL: a permanently
+   failing id (e.g. the bot token lacks the [users:read] scope) would
+   otherwise refetch on every inbound message without changing the outcome,
+   while the shorter TTL still picks a scope fix up promptly. The raw id is
+   never replaced as an identity key anywhere — this module only renders.
+
+   The fetch and the clock are injected so cache behavior is deterministic
+   under test. Cache sections are short [Stdlib.Mutex] holds (cross-domain
+   safe, mirroring [Subsystem_health]); the fetch itself runs outside the
+   lock, so two concurrent misses may fetch twice — idempotent and rarer
+   than a lock held across HTTP. *)
+
+type entry =
+  | Label of string
+  | Fetch_failed
+
+type t =
+  { fetch :
+      user_id:string ->
+      (Slack_rest_client.user_info_ok, Slack_rest_client.error) result
+  ; now : unit -> float
+  ; success_ttl_sec : float
+  ; failure_ttl_sec : float
+  ; mu : Mutex.t
+  ; cache : (string, entry * float) Hashtbl.t
+  }
+
+let default_success_ttl_sec = 3600.0
+let default_failure_ttl_sec = 300.0
+
+let create ?(success_ttl_sec = default_success_ttl_sec)
+    ?(failure_ttl_sec = default_failure_ttl_sec) ~fetch ~now () =
+  { fetch
+  ; now
+  ; success_ttl_sec
+  ; failure_ttl_sec
+  ; mu = Mutex.create ()
+  ; cache = Hashtbl.create 32
+  }
+
+(* Slack's documented display precedence: the user-chosen display name, then
+   the profile real name, then the legacy handle. A profile with no usable
+   name resolves to [None] (rendered as the raw id by callers). *)
+let label_of_user_info (info : Slack_rest_client.user_info_ok) =
+  match info.display_name, info.real_name, info.name with
+  | Some label, _, _ | None, Some label, _ | None, None, Some label ->
+    Some label
+  | None, None, None -> None
+
+let live_entry t ~user_id =
+  Mutex.lock t.mu;
+  let found = Hashtbl.find_opt t.cache user_id in
+  Mutex.unlock t.mu;
+  match found with
+  | None -> None
+  | Some (entry, fetched_at) ->
+    let ttl =
+      match entry with
+      | Label _ -> t.success_ttl_sec
+      | Fetch_failed -> t.failure_ttl_sec
+    in
+    if t.now () -. fetched_at < ttl then Some entry else None
+
+let store_entry t ~user_id entry =
+  let stamped = (entry, t.now ()) in
+  Mutex.lock t.mu;
+  Hashtbl.replace t.cache user_id stamped;
+  Mutex.unlock t.mu
+
+let display_label t ~user_id =
+  match live_entry t ~user_id with
+  | Some (Label label) -> Some label
+  | Some Fetch_failed -> None
+  | None ->
+    let entry =
+      match t.fetch ~user_id with
+      | Ok info ->
+        (match label_of_user_info info with
+         | Some label -> Label label
+         | None -> Fetch_failed)
+      | Error error ->
+        Log.Server.warn
+          "slack users.info failed for %s (raw id will render until retry \
+           in %.0fs): %s"
+          user_id t.failure_ttl_sec
+          (Format.asprintf "%a" Slack_rest_client.pp_error error);
+        Fetch_failed
+    in
+    store_entry t ~user_id entry;
+    (match entry with Label label -> Some label | Fetch_failed -> None)
+
+(* Rewrite Slack mention escapes into plain [@label] text before a message
+   reaches keeper prompts and durable transcripts. Only the user-mention
+   escape is touched; channel ([<#…>]), special ([<!…>]) and link
+   ([<http…>]) escapes pass through unchanged. An unresolvable mention keeps
+   its exact wire form — lossless, never a guessed name.
+   Wire format:
+   https://api.slack.com/reference/surfaces/formatting#mentioning-users *)
+let rewrite_mentions t text =
+  let len = String.length text in
+  let buf = Buffer.create len in
+  let is_id_char c = (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') in
+  let rec loop i =
+    if i >= len then ()
+    else if
+      i + 2 < len
+      && text.[i] = '<'
+      && text.[i + 1] = '@'
+      && (text.[i + 2] = 'U' || text.[i + 2] = 'W')
+    then begin
+      let id_end = ref (i + 2) in
+      while !id_end < len && is_id_char text.[!id_end] do incr id_end done;
+      let id_end = !id_end in
+      let user_id = String.sub text (i + 2) (id_end - (i + 2)) in
+      if id_end < len && text.[id_end] = '>' && String.length user_id >= 2
+      then begin
+        (match display_label t ~user_id with
+         | Some label -> Buffer.add_string buf ("@" ^ label)
+         | None -> Buffer.add_string buf (String.sub text i (id_end + 1 - i)));
+        loop (id_end + 1)
+      end
+      else if id_end < len && text.[id_end] = '|' then begin
+        (* <@U…|label>: Slack already supplied the label; no fetch needed. *)
+        match String.index_from_opt text id_end '>' with
+        | Some close when close > id_end + 1
+                          && String.trim
+                               (String.sub text (id_end + 1)
+                                  (close - id_end - 1))
+                             <> "" ->
+          Buffer.add_string buf
+            ("@" ^ String.sub text (id_end + 1) (close - id_end - 1));
+          loop (close + 1)
+        | Some _ | None ->
+          Buffer.add_char buf text.[i];
+          loop (i + 1)
+      end
+      else begin
+        Buffer.add_char buf text.[i];
+        loop (i + 1)
+      end
+    end
+    else begin
+      Buffer.add_char buf text.[i];
+      loop (i + 1)
+    end
+  in
+  loop 0;
+  Buffer.contents buf

--- a/lib/gate/slack_user_directory.mli
+++ b/lib/gate/slack_user_directory.mli
@@ -1,0 +1,45 @@
+(** Slack_user_directory — inbound identity rendering for Slack user ids
+    (issue #28376).
+
+    Resolves [U…]/[W…] ids to display labels through an injected
+    [users.info] fetch with a TTL cache, and rewrites [<@U…>] mention
+    escapes into plain [@label] text. Rendering only: the raw id stays the
+    identity key everywhere; an unresolvable id keeps its exact wire form. *)
+
+type t
+
+val default_success_ttl_sec : float
+(** Seconds a resolved label serves from cache (3600). *)
+
+val default_failure_ttl_sec : float
+(** Seconds a failed lookup is not retried (300). Failure caching keeps a
+    permanently failing id (e.g. missing [users:read] scope) from refetching
+    on every inbound message, while still picking a fix up promptly. *)
+
+val create :
+  ?success_ttl_sec:float ->
+  ?failure_ttl_sec:float ->
+  fetch:
+    (user_id:string ->
+     (Slack_rest_client.user_info_ok, Slack_rest_client.error) result) ->
+  now:(unit -> float) ->
+  unit ->
+  t
+(** [fetch] and [now] are injected so cache behavior is deterministic under
+    test; production passes {!Slack_rest_client.users_info} and
+    [Unix.gettimeofday]. *)
+
+val display_label : t -> user_id:string -> string option
+(** The user's display label by Slack's documented precedence
+    ([profile.display_name], then [profile.real_name], then the legacy
+    handle). [None] when the lookup failed or no name is usable — callers
+    render the raw id. Serves from cache within the TTLs; fetches otherwise. *)
+
+val rewrite_mentions : t -> string -> string
+(** Rewrites [<@U…>] and [<@U…|label>] mention escapes to [@label]. Channel,
+    special and link escapes ([<#…>], [<!…>], [<http…>]) pass through
+    unchanged, as does any mention whose id cannot be resolved. *)
+
+val label_of_user_info : Slack_rest_client.user_info_ok -> string option
+(** Display precedence over one [users.info] record, exposed for unit
+    tests. *)

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -430,8 +430,39 @@ let accept_event ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id
       Slack_observability.Ignored;
     None
 
-let submit_event ?deliver ?team_id ingress ~dispatch_for_delivery ~clock
-    ~base_dir (ev : Gw.slack_event) =
+(* Inbound identity rendering (issue #28376): resolve the author's display
+   label and rewrite [<@U…>] mention escapes before the event reaches the
+   triggered/ambient lanes, so keeper prompts and durable transcripts carry
+   names instead of raw ids. Rendering only — [user_id] stays the identity
+   key everywhere (dedup, speaker_id, continuation channels). Runs after
+   [decode_event], so [mentions_bot] was already detected on the raw wire
+   text. Without a directory (no bot token) events pass through unchanged. *)
+let resolve_event_identity ?user_directory (ev : Gw.slack_event) =
+  match user_directory with
+  | None -> ev
+  | Some directory ->
+    (match ev with
+     | Gw.Message_create ({ user_id; user_name; text; _ } as message) ->
+       let user_name =
+         match user_name with
+         | Some _ as supplied -> supplied
+         | None -> Slack_user_directory.display_label directory ~user_id
+       in
+       Gw.Message_create
+         { message with
+           user_name
+         ; text = Slack_user_directory.rewrite_mentions directory text
+         }
+     | Gw.App_mention ({ text; _ } as mention) ->
+       Gw.App_mention
+         { mention with
+           text = Slack_user_directory.rewrite_mentions directory text
+         }
+     | Gw.Reaction_added _ | Gw.Ignored_event _ -> ev)
+
+let submit_event ?deliver ?team_id ?user_directory ingress ~dispatch_for_delivery
+    ~clock ~base_dir (ev : Gw.slack_event) =
+  let ev = resolve_event_identity ?user_directory ev in
   let submit ~channel_id ~event_id =
     match State.resolve_keeper_for_channel_result ~channel_id with
     | Error reason ->
@@ -628,7 +659,9 @@ let on_ambient ?resolved_keeper_name ?team_id ~base_dir (ev : Gw.slack_event) =
       Slack_observability.Reaction_added
   | Gw.Ignored_event _ -> ()
 
-let submit_ambient_event ?team_id ingress ~base_dir (ev : Gw.slack_event) =
+let submit_ambient_event ?team_id ?user_directory ingress ~base_dir
+    (ev : Gw.slack_event) =
+  let ev = resolve_event_identity ?user_directory ev in
   match ev with
   | Gw.Message_create { channel_id; ts; bot_id = None; _ } -> (
     match State.resolve_keeper_for_channel_result ~channel_id with
@@ -674,6 +707,7 @@ module For_testing = struct
   let submit_ambient_event = submit_ambient_event
   let record_external_attention = record_external_attention
   let mark_attention_resolved = mark_attention_resolved
+  let resolve_event_identity = resolve_event_identity
 end
 
 (* ---------------------------------------------------------------- *)
@@ -705,26 +739,39 @@ let start ~sw ~env ~state =
           without it, [app_mention] events still trigger (a mention by
           construction); only plain-message mention detection on the [message]
           event degrades. *)
-       let bot_user_id, team_id =
+       let bot_user_id, team_id, user_directory =
          match Env_config_slack.bot_token_opt () with
          | None ->
            Log.Server.warn
              "RFC-0317: SLACK_BOT_TOKEN unset; Slack plain-message mention \
               detection disabled (app_mention still triggers)";
-           None, None
-         | Some bot_token -> (
-           match Slack_rest_client.auth_test ~clock ~token:bot_token () with
-           | Ok { user_id; team_id } ->
-             State.record_ready ~bot_user_id:user_id;
-             Log.Server.info "RFC-0317: Slack auth.test ok (bot_user_id=%s)"
-               user_id;
-             Some user_id, team_id
-           | Error e ->
-             Log.Server.warn
-               "RFC-0317: Slack auth.test failed (%s); proceeding without \
-                bot_user_id"
-               (Format.asprintf "%a" Slack_rest_client.pp_error e);
-             None, None)
+           None, None, None
+         | Some bot_token ->
+           (* Inbound identity rendering (issue #28376) shares the bot token:
+              the directory resolves author ids to display labels through
+              users.info, bounded by the same gateway clock. *)
+           let user_directory =
+             Some
+               (Slack_user_directory.create
+                  ~fetch:(fun ~user_id ->
+                    Slack_rest_client.users_info ~clock ~token:bot_token
+                      ~user_id ())
+                  ~now:Unix.gettimeofday
+                    (* NDT-OK: cache-expiry clock only *)
+                  ())
+           in
+           (match Slack_rest_client.auth_test ~clock ~token:bot_token () with
+            | Ok { user_id; team_id } ->
+              State.record_ready ~bot_user_id:user_id;
+              Log.Server.info "RFC-0317: Slack auth.test ok (bot_user_id=%s)"
+                user_id;
+              Some user_id, team_id, user_directory
+            | Error e ->
+              Log.Server.warn
+                "RFC-0317: Slack auth.test failed (%s); proceeding without \
+                 bot_user_id"
+                (Format.asprintf "%a" Slack_rest_client.pp_error e);
+              None, None, user_directory)
        in
        State.set_trigger_policy policy;
        let ingress =
@@ -755,13 +802,14 @@ let start ~sw ~env ~state =
                  ingress
                  ~dispatch_for_delivery:(dispatch_for_config config)
                  ?team_id
+                 ?user_directory
                  ~clock
                  ~base_dir:config.base_path
                  ev)
              ~on_ambient:(fun ev ->
                let config = Mcp_server.workspace_config state in
-               submit_ambient_event ingress ?team_id ~base_dir:config.base_path
-                 ev)
+               submit_ambient_event ingress ?team_id ?user_directory
+                 ~base_dir:config.base_path ev)
              ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_slack_in_process_gateway.mli
+++ b/lib/server/server_slack_in_process_gateway.mli
@@ -63,6 +63,7 @@ module For_testing : sig
   val submit_event :
     ?deliver:(unit -> unit) ->
     ?team_id:string ->
+    ?user_directory:Slack_user_directory.t ->
     Connector_ingress_lane.t ->
     dispatch_for_delivery:
       (Gate_keeper_backend.connector_delivery -> Channel_gate.dispatch_fn) ->
@@ -73,10 +74,19 @@ module For_testing : sig
 
   val submit_ambient_event :
     ?team_id:string ->
+    ?user_directory:Slack_user_directory.t ->
     Connector_ingress_lane.t ->
     base_dir:string ->
     Slack_socket_client.slack_event ->
     unit
+
+  val resolve_event_identity :
+    ?user_directory:Slack_user_directory.t ->
+    Slack_socket_client.slack_event ->
+    Slack_socket_client.slack_event
+  (** Inbound identity rendering (issue #28376): author display label plus
+      [<@U…>] mention rewriting, applied by both submit lanes. Exposed so
+      tests can pin the mapping without a live socket. *)
 
   val record_external_attention :
     base_dir:string ->

--- a/test/dune
+++ b/test/dune
@@ -1634,6 +1634,8 @@
 
 (include stanzas/test_slack_rest_client.inc)
 
+(include stanzas/test_slack_user_directory.inc)
+
 (include stanzas/test_server_slack_gateway_attention.inc)
 
 (include stanzas/test_discord_wss_bridge.inc)

--- a/test/stanzas/test_slack_user_directory.inc
+++ b/test/stanzas/test_slack_user_directory.inc
@@ -1,0 +1,6 @@
+; Slack_user_directory cache + mention-rewrite tests (issue #28376).
+; Same minimal-deps stanza as test_slack_rest_client.
+(test
+ (name test_slack_user_directory)
+ (modules test_slack_user_directory)
+ (libraries alcotest yojson masc.gate))

--- a/test/test_server_slack_gateway_attention.ml
+++ b/test/test_server_slack_gateway_attention.ml
@@ -99,6 +99,49 @@ let test_sent_reply_retires_attention () =
     check int "pending after reply" 0
       (List.length (pending ~base_path ~keeper_name:"sangsu"))
 
+(* Inbound identity rendering (issue #28376): the lane-shared mapping
+   resolves the author label and rewrites mention escapes, and never touches
+   [user_id] or [ts] (identity keys). *)
+let test_resolve_event_identity_maps_names_and_mentions () =
+  let directory =
+    Slack_user_directory.create
+      ~fetch:(fun ~user_id ->
+        if String.equal user_id "U09L0RHPW7P" then
+          Ok
+            { Slack_rest_client.user_id
+            ; name = Some "vincent"
+            ; real_name = None
+            ; display_name = Some "Vincent"
+            }
+        else Error (Slack_rest_client.Slack_api { error = "user_not_found" }))
+      ~now:(fun () -> 0.0)
+      ()
+  in
+  let event =
+    Slack_gateway_state.Message_create
+      { channel_id = "C1"
+      ; thread_ts = None
+      ; user_id = "U09L0RHPW7P"
+      ; user_name = None
+      ; text = "<@U09L0RHPW7P> 확인"
+      ; ts = "1786524720.554309"
+      ; mentions_bot = true
+      ; bot_id = None
+      }
+  in
+  (match G.For_testing.resolve_event_identity ~user_directory:directory event with
+   | Slack_gateway_state.Message_create { user_id; user_name; text; ts; _ } ->
+     check string "identity key untouched" "U09L0RHPW7P" user_id;
+     check string "dedup key untouched" "1786524720.554309" ts;
+     check (option string) "author label resolved" (Some "Vincent") user_name;
+     check string "mention rewritten" "@Vincent 확인" text
+   | _ -> fail "message event mapped to another variant");
+  match G.For_testing.resolve_event_identity event with
+  | Slack_gateway_state.Message_create { user_name; text; _ } ->
+    check (option string) "no directory keeps the raw absence" None user_name;
+    check string "no directory keeps the wire text" "<@U09L0RHPW7P> 확인" text
+  | _ -> fail "message event mapped to another variant"
+
 let () =
   run "Server_slack_gateway_attention"
     [ "attention"
@@ -110,5 +153,7 @@ let () =
             test_duplicate_wire_delivery_keeps_one_pending
         ; test_case "sent reply retires attention" `Quick
             test_sent_reply_retires_attention
+        ; test_case "inbound identity mapping" `Quick
+            test_resolve_event_identity_maps_names_and_mentions
         ]
     ]

--- a/test/test_slack_rest_client.ml
+++ b/test/test_slack_rest_client.ml
@@ -176,6 +176,59 @@ let test_parse_auth_test_response_ok_missing_user_id_is_other () =
   | Error err ->
       failf "expected Other, got %s" (Format.asprintf "%a" R.pp_error err)
 
+let test_build_users_info_request_shape () =
+  let url, headers, body =
+    R.build_users_info_request ~token:"xoxb-secret" ~user_id:"U09L0RHPW7P"
+  in
+  check string "url" "https://slack.com/api/users.info" url;
+  check string "Authorization" "Bearer xoxb-secret"
+    (header_value headers "Authorization");
+  check string "Content-Type"
+    "application/x-www-form-urlencoded; charset=utf-8"
+    (header_value headers "Content-Type");
+  check string "body" "user=U09L0RHPW7P" body
+
+let test_parse_users_info_ok_extracts_names () =
+  let body =
+    {|{"ok":true,"user":{"id":"U1","name":"vincent",
+       "profile":{"display_name":"Vincent","real_name":"윤정식"}}}|}
+  in
+  match R.parse_users_info_response ~status:200 ~body with
+  | Ok { user_id; name; real_name; display_name } ->
+      check string "id" "U1" user_id;
+      check (option string) "name" (Some "vincent") name;
+      check (option string) "real_name" (Some "윤정식") real_name;
+      check (option string) "display_name" (Some "Vincent") display_name
+  | Error e -> failf "unexpected error: %a" R.pp_error e
+
+let test_parse_users_info_blank_names_are_absent () =
+  let body =
+    {|{"ok":true,"user":{"id":"U1","name":"  ",
+       "profile":{"display_name":"","real_name":"Real"}}}|}
+  in
+  match R.parse_users_info_response ~status:200 ~body with
+  | Ok { name; real_name; display_name; _ } ->
+      check (option string) "blank name absent" None name;
+      check (option string) "blank display_name absent" None display_name;
+      check (option string) "real_name kept" (Some "Real") real_name
+  | Error e -> failf "unexpected error: %a" R.pp_error e
+
+let test_parse_users_info_failures_are_typed () =
+  (match
+     R.parse_users_info_response ~status:200
+       ~body:{|{"ok":false,"error":"missing_scope"}|}
+   with
+  | Error (R.Slack_api { error }) -> check string "error" "missing_scope" error
+  | Ok _ | Error _ -> fail "ok=false must be Slack_api");
+  (match R.parse_users_info_response ~status:429 ~body:"rate limited" with
+  | Error (R.Http_status { code; _ }) -> check int "status" 429 code
+  | Ok _ | Error _ -> fail "non-2xx must be Http_status");
+  match
+    R.parse_users_info_response ~status:200 ~body:{|{"ok":true,"user":{}}|}
+  with
+  | Error (R.Other _) -> ()
+  | Ok _ | Error _ -> fail "missing user.id must be Other"
+
 let () =
   run "Slack_rest_client"
     [
@@ -219,5 +272,15 @@ let () =
             test_parse_auth_test_response_slack_error;
           test_case "ok missing user_id is Other" `Quick
             test_parse_auth_test_response_ok_missing_user_id_is_other;
+        ] );
+      ( "users_info",
+        [
+          test_case "request shape" `Quick test_build_users_info_request_shape;
+          test_case "ok extracts names" `Quick
+            test_parse_users_info_ok_extracts_names;
+          test_case "blank names are absent" `Quick
+            test_parse_users_info_blank_names_are_absent;
+          test_case "failures are typed" `Quick
+            test_parse_users_info_failures_are_typed;
         ] );
     ]

--- a/test/test_slack_user_directory.ml
+++ b/test/test_slack_user_directory.ml
@@ -1,0 +1,119 @@
+(* Slack_user_directory — cache, label precedence and mention rewriting
+   (issue #28376). Fetch and clock are injected, so every case is
+   deterministic: the fake fetch counts its calls and the fake clock is a
+   mutable ref. *)
+
+open Alcotest
+module D = Slack_user_directory
+module R = Slack_rest_client
+
+let info ?name ?real_name ?display_name user_id : R.user_info_ok =
+  { user_id; name; real_name; display_name }
+
+let directory ?success_ttl_sec ?failure_ttl_sec ~now_ref responses =
+  let calls = ref 0 in
+  let fetch ~user_id =
+    incr calls;
+    match List.assoc_opt user_id responses with
+    | Some result -> result
+    | None -> Error (R.Slack_api { error = "user_not_found" })
+  in
+  ( D.create ?success_ttl_sec ?failure_ttl_sec ~fetch
+      ~now:(fun () -> !now_ref)
+      ()
+  , calls )
+
+let test_label_precedence () =
+  check (option string) "display_name wins" (Some "Vincent")
+    (D.label_of_user_info
+       (info ~name:"vincent" ~real_name:"윤정식" ~display_name:"Vincent" "U1"));
+  check (option string) "real_name next" (Some "윤정식")
+    (D.label_of_user_info (info ~name:"vincent" ~real_name:"윤정식" "U1"));
+  check (option string) "legacy handle last" (Some "vincent")
+    (D.label_of_user_info (info ~name:"vincent" "U1"));
+  check (option string) "no usable name" None (D.label_of_user_info (info "U1"))
+
+let test_success_is_cached_within_ttl () =
+  let now_ref = ref 1000.0 in
+  let t, calls =
+    directory ~now_ref [ ("U1", Ok (info ~display_name:"Vincent" "U1")) ]
+  in
+  check (option string) "first lookup fetches" (Some "Vincent")
+    (D.display_label t ~user_id:"U1");
+  check (option string) "second lookup serves cache" (Some "Vincent")
+    (D.display_label t ~user_id:"U1");
+  check int "one fetch for two lookups" 1 !calls;
+  now_ref := 1000.0 +. D.default_success_ttl_sec +. 1.0;
+  check (option string) "expired entry refetches" (Some "Vincent")
+    (D.display_label t ~user_id:"U1");
+  check int "expiry caused the second fetch" 2 !calls
+
+let test_failure_is_cached_on_its_own_ttl () =
+  let now_ref = ref 1000.0 in
+  let t, calls =
+    directory ~now_ref [ ("U1", Error (R.Slack_api { error = "missing_scope" })) ]
+  in
+  check (option string) "failed lookup renders raw id" None
+    (D.display_label t ~user_id:"U1");
+  check (option string) "failure serves from cache" None
+    (D.display_label t ~user_id:"U1");
+  check int "no refetch inside the failure ttl" 1 !calls;
+  now_ref := 1000.0 +. D.default_failure_ttl_sec +. 1.0;
+  ignore (D.display_label t ~user_id:"U1");
+  check int "failure ttl expiry retries" 2 !calls
+
+let test_mention_rewrite () =
+  let now_ref = ref 0.0 in
+  let t, _ =
+    directory ~now_ref
+      [ ("U09L0RHPW7P", Ok (info ~display_name:"Vincent" "U09L0RHPW7P"))
+      ; ("U060QL6SV1V", Ok (info ~real_name:"KinoBot" "U060QL6SV1V"))
+      ]
+  in
+  check string "resolved mention becomes a name"
+    "@KinoBot 뭔데"
+    (D.rewrite_mentions t "<@U060QL6SV1V> 뭔데");
+  check string "multiple mentions in one message"
+    "@Vincent님, @KinoBot 확인 부탁"
+    (D.rewrite_mentions t "<@U09L0RHPW7P>님, <@U060QL6SV1V> 확인 부탁");
+  check string "labelled escape uses the supplied label without a fetch"
+    "@alice 안녕"
+    (D.rewrite_mentions t "<@U000UNKNOWN0|alice> 안녕");
+  check string "unresolvable mention keeps its exact wire form"
+    "<@U000UNKNOWN0> ping"
+    (D.rewrite_mentions t "<@U000UNKNOWN0> ping");
+  check string "channel, special and link escapes pass through"
+    "<#C123|general> <!here> <https://example.com|link>"
+    (D.rewrite_mentions t "<#C123|general> <!here> <https://example.com|link>");
+  check string "text without mentions is unchanged"
+    "plain @text < unrelated >"
+    (D.rewrite_mentions t "plain @text < unrelated >")
+
+let test_mention_rewrite_malformed_tokens_pass_through () =
+  let now_ref = ref 0.0 in
+  let t, calls = directory ~now_ref [] in
+  check string "unterminated mention stays verbatim" "<@U123"
+    (D.rewrite_mentions t "<@U123");
+  check string "empty label keeps the wire form" "<@U000UNKNOWN0|> hi"
+    (D.rewrite_mentions t "<@U000UNKNOWN0|> hi");
+  check string "short id stays verbatim" "<@U> hi"
+    (D.rewrite_mentions t "<@U> hi");
+  check int "malformed tokens never fetch" 0 !calls
+
+let () =
+  run "slack_user_directory"
+    [
+      ( "labels",
+        [ test_case "precedence" `Quick test_label_precedence ] );
+      ( "cache",
+        [
+          test_case "success ttl" `Quick test_success_is_cached_within_ttl;
+          test_case "failure ttl" `Quick test_failure_is_cached_on_its_own_ttl;
+        ] );
+      ( "mentions",
+        [
+          test_case "rewrite" `Quick test_mention_rewrite;
+          test_case "malformed tokens pass through" `Quick
+            test_mention_rewrite_malformed_tokens_pass_through;
+        ] );
+    ]


### PR DESCRIPTION
## 목표

keeper의 Slack 응답/프롬프트에 raw user ID(`@U09L0RHPW7P`)가 노출되는 문제(#28376)의 근본 수정. 원인은 양방향 미구현: lib 전체에 `users.info` 호출 0건 + 인바운드 `<@U…>` 멘션 escape가 모델까지 그대로 도달. 인바운드에서 이름을 해석하면 모델이 이름으로 지칭하게 되어 아웃바운드 노출도 사라진다 (아웃바운드 `@Uxxx` 정규식 재멘션화는 string 휴리스틱이라 채택하지 않음).

## 변경 파일

- `lib/gate/slack_rest_client.ml/.mli` — `users.info` 추가 (typed profile: `name`/`real_name`/`display_name`, blank는 `None`). pure builder/parser 분리 (기존 auth.test 패턴).
- `lib/gate/slack_user_directory.ml/.mli` (신규) — id→label TTL 캐시 + `<@U…>`/`<@U…|label>` 멘션 rewrite.
  - fetch/clock 주입 → 캐시 로직 결정론적 테스트.
  - 성공 1h / 실패 5m 캐시. 실패 캐싱은 `users:read` scope 부재 시 메시지당 재조회를 막되 scope 수정을 5분 내 반영하기 위함 (디렉터리 표준 negative cache — symptom 억제가 아니라 기능의 일부).
  - 해석 불가/malformed 토큰은 wire form 그대로 보존 (lossless, 추측 없음). channel/special/link escape는 무변경.
- `lib/server/server_slack_in_process_gateway.ml/.mli` — `resolve_event_identity`: triggered/ambient 두 lane 공용 지점에서 author label 해석 + 멘션 rewrite. `user_id`는 identity key로 불변 (dedup, speaker_id, continuation channel). `mentions_bot` 감지는 raw wire text에서 이미 수행된 뒤라 영향 없음. bot token 부재 시 디렉터리 없이 기존 동작 그대로.

## 로컬 검증

- `Slack_rest_client` 19 / `slack_user_directory` 5 / `Server_slack_gateway_attention` 5 — green
- `dune build @check` clean
- 캐시 케이스: TTL 내 단일 fetch, 만료 재조회, 실패 TTL 재시도, malformed 토큰 무-fetch 전부 단언

## 미검증

- 라이브 Slack 왕복 (머지 후 kidsnote keeper 채널에서 `<@U…>` 멘션 → `@Vincent` 렌더 확인 예정)
- `users:read` scope가 실제 bot token에 있는지 — 없으면 raw ID 유지 + warn 로그 (현행과 동일한 degrade)

Closes #28376

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU1EnzuTuFCPZwbeqj9Ajr
