### PR TITLE
fix(registry): run-registry mutation lock을 Eio-aware mutex로 (FATAL EDEADLK)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1052,6 +1052,7 @@ jobs:
             @test/runtest-test_clean_only_bug_mirrors \
             @test/runtest-test_contract_harness_auth_script \
             @test/runtest-test_eio_guard_yield_meter \
+            @test/runtest-test_run_registry_concurrent_mutation \
             @test/runtest-test_event_bus_subscription_contract \
             @test/runtest-test_fs_compat_home_guard \
             @test/runtest-test_guarded_dispatch_telemetry \

--- a/lib/run_registry_core/dune
+++ b/lib/run_registry_core/dune
@@ -4,4 +4,4 @@
  (name run_registry_core)
  (public_name masc.run_registry_core)
  (wrapped false)
- (libraries eio fs_compat masc_log threads unix yojson))
+ (libraries eio fs_compat masc_core masc_log threads unix yojson))

--- a/lib/run_registry_core/run_registry_core.ml
+++ b/lib/run_registry_core/run_registry_core.ml
@@ -108,7 +108,7 @@ module Make (Payload : Payload) = struct
   type t =
     { entries : entry list Atomic.t
     ; path : string option
-    ; mutation_mutex : Stdlib.Mutex.t
+    ; mutation_mutex : Cross_context_mutex.t
     }
 
   type event =
@@ -154,7 +154,7 @@ module Make (Payload : Payload) = struct
   let create ?path () =
     { entries = Atomic.make []
     ; path
-    ; mutation_mutex = Stdlib.Mutex.create ()
+    ; mutation_mutex = Cross_context_mutex.create ()
     }
 
   let event_to_yojson = function
@@ -299,14 +299,26 @@ module Make (Payload : Payload) = struct
        this registry-local lock, a completion on another domain can observe the
        new row after the CAS and append [Complete] before this [Register]
        reaches the path-level append lock. Replay then skips the completion as
-       unknown and drops the trailing register as stale Running. *)
-    Stdlib.Mutex.protect t.mutation_mutex (fun () ->
+       unknown and drops the trailing register as stale Running.
+
+       [Cross_context_mutex], not [Stdlib.Mutex]: the critical section performs
+       a durable JSONL append, which suspends the fiber. A raw pthread mutex
+       held across that suspension is still held by the *same OS thread* when
+       the scheduler runs another fiber on this domain, so the second fiber's
+       lock attempt is a recursive acquisition and raises
+       [Sys_error "Mutex.lock: Resource deadlock avoided"]. Measured on the
+       live fleet: 218 occurrences on 2026-08-11 and 37 on 2026-08-10, most
+       swallowed by worker handlers and one fatal in
+       [Completion_authority_agent.process_task_once], which took the server
+       down. The Eio gate makes a waiting fiber yield instead; the durable
+       variant keeps cancellation out of the committed transaction. *)
+    Cross_context_mutex.with_durable_lock t.mutation_mutex (fun () ->
       append_event_exn t (Register { id; started_at; registration });
       replace_entry_locked t entry)
   ;;
 
   let complete t ~id ~completion =
-    Stdlib.Mutex.protect t.mutation_mutex (fun () ->
+    Cross_context_mutex.with_durable_lock t.mutation_mutex (fun () ->
       let current = Atomic.get t.entries in
       if not (List.exists (fun entry -> String.equal entry.id id) current)
       then (
@@ -487,7 +499,7 @@ module Make (Payload : Payload) = struct
     then compact_replay_log path entries;
     { entries = Atomic.make entries
     ; path = Some path
-    ; mutation_mutex = Stdlib.Mutex.create ()
+    ; mutation_mutex = Cross_context_mutex.create ()
     }
   ;;
 end

--- a/test/dune
+++ b/test/dune
@@ -2498,6 +2498,8 @@
 (include stanzas/test_dashboard_continuity_briefs.inc)
 
 (include stanzas/test_verification_run_registry.inc)
+
+(include stanzas/test_run_registry_concurrent_mutation.inc)
 (include stanzas/test_exact_lane_run_registry.inc)
 
 ; The tool-call quality benchmark reads its case set and evidence fixture from

--- a/test/stanzas/test_run_registry_concurrent_mutation.inc
+++ b/test/stanzas/test_run_registry_concurrent_mutation.inc
@@ -1,0 +1,9 @@
+; Two fibers on one domain mutating a persisted run registry. The critical
+; section suspends on a durable append, so a raw pthread mutex held across it
+; is a recursive acquisition on the same OS thread -- the EDEADLK that took
+; the server down on 2026-08-12.
+
+(test
+ (name test_run_registry_concurrent_mutation)
+ (modules test_run_registry_concurrent_mutation)
+ (libraries masc_test_deps eio eio_main yojson))

--- a/test/test_run_registry_concurrent_mutation.ml
+++ b/test/test_run_registry_concurrent_mutation.ml
@@ -1,0 +1,152 @@
+(** Two fibers mutating one persisted run registry on the same domain.
+
+    The registry serializes "append the JSONL event, then publish the row" so a
+    completion cannot overtake its own registration in the replay log. That
+    critical section performs a durable append, which suspends the fiber.
+
+    A raw [Stdlib.Mutex] held across that suspension is still held by the same
+    OS thread when the scheduler runs the next fiber on this domain, so the
+    second fiber's acquisition is recursive and pthreads rejects it:
+    [Sys_error "Mutex.lock: Resource deadlock avoided"].
+
+    Measured on the live fleet before the fix: 218 occurrences on 2026-08-11,
+    37 on 2026-08-10, and one fatal in
+    [Completion_authority_agent.process_task_once] that took the server down
+    at 2026-08-12 20:55:29 KST. Most other occurrences were swallowed by
+    worker exception handlers, so the crash count understates the reach.
+
+    These cases run the interleaving directly: [Eio.Fiber.both] resumes the
+    second fiber precisely while the first is suspended inside the lock. *)
+
+open Alcotest
+
+module R = Masc.Verification_run_registry
+
+let remove_if_exists path =
+  try Sys.remove path with
+  | Sys_error _ -> ()
+;;
+
+let fresh_path suffix =
+  let path = Filename.temp_file "run-registry-concurrent-" suffix in
+  remove_if_exists path;
+  path
+;;
+
+let register t ~verification_id ~started_at =
+  R.register_running
+    t
+    ~verification_id
+    ~task_id:"task-concurrent"
+    ~producer:"keeper-rondo-agent"
+    ~authority_kind:"system_llm_agent"
+    ~authority_actor:("system-llm-agent-" ^ verification_id)
+    ~started_at
+;;
+
+let ids_of t =
+  R.list_runs t
+  |> List.map (fun (run : R.run) -> run.verification_id)
+  |> List.sort String.compare
+;;
+
+let test_concurrent_registrations_both_land () =
+  let path = fresh_path ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> remove_if_exists path)
+    (fun () ->
+      let t = R.create ~path () in
+      Eio_main.run (fun _env ->
+        Eio.Fiber.both
+          (fun () -> register t ~verification_id:"vrf-a" ~started_at:100.0)
+          (fun () -> register t ~verification_id:"vrf-b" ~started_at:101.0));
+      check
+        (list string)
+        "both concurrent registrations are tracked"
+        [ "vrf-a"; "vrf-b" ]
+        (ids_of t))
+;;
+
+let test_concurrent_register_and_complete_both_land () =
+  let path = fresh_path ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> remove_if_exists path)
+    (fun () ->
+      let t = R.create ~path () in
+      register t ~verification_id:"vrf-first" ~started_at:100.0;
+      Eio_main.run (fun _env ->
+        Eio.Fiber.both
+          (fun () ->
+            R.mark_completed
+              t
+              ~verification_id:"vrf-first"
+              ~outcome:R.Approved
+              ~tools:[]
+              ~elapsed_s:1.0
+              ())
+          (fun () -> register t ~verification_id:"vrf-second" ~started_at:102.0));
+      check
+        (list string)
+        "a completion and a registration interleave without losing either"
+        [ "vrf-first"; "vrf-second" ]
+        (ids_of t))
+;;
+
+(* The append-only log is the durability contract: a row that only reached
+   memory is lost on restart. Replay itself drops never-completed Running rows
+   by design ("review fibers do not survive server restart"), so the fact to
+   assert is that both appends reached the file. *)
+let register_events_in path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () ->
+      let rec count acc =
+        match input_line ic with
+        | exception End_of_file -> acc
+        | line ->
+          let is_register =
+            match Yojson.Safe.from_string line with
+            | `Assoc fields ->
+              (match List.assoc_opt "event" fields with
+               | Some (`String "register") -> true
+               | _ -> false)
+            | _ -> false
+            | exception _ -> false
+          in
+          count (if is_register then acc + 1 else acc)
+      in
+      count 0)
+;;
+
+let test_both_appends_reach_the_log () =
+  let path = fresh_path ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> remove_if_exists path)
+    (fun () ->
+      let t = R.create ~path () in
+      Eio_main.run (fun _env ->
+        Eio.Fiber.both
+          (fun () -> register t ~verification_id:"vrf-x" ~started_at:100.0)
+          (fun () -> register t ~verification_id:"vrf-y" ~started_at:101.0));
+      check int "both registrations were appended" 2 (register_events_in path))
+;;
+
+let () =
+  run
+    "run_registry_concurrent_mutation"
+    [ ( "same-domain fibers"
+      , [ test_case
+            "two registrations"
+            `Quick
+            test_concurrent_registrations_both_land
+        ; test_case
+            "completion against registration"
+            `Quick
+            test_concurrent_register_and_complete_both_land
+        ; test_case
+            "both appends reach the log"
+            `Quick
+            test_both_appends_reach_the_log
+        ] )
+    ]


### PR DESCRIPTION
## 증상

서버가 FATAL로 죽었습니다 (2026-08-12 20:55:29 KST).

```
[FATAL] Unhandled exception: Sys_error("Mutex.lock: Resource deadlock avoided")
Raised by primitive operation at Stdlib__Mutex.protect (mutex.ml:27)
Called from Masc__Verification_run_registry.register_running
             (lib/verification_run_registry.ml:293-297)
Called from Masc__Completion_authority_agent.process_task_once
             (lib/completion_authority_agent.ml:462-469)
```

일회성이 아닙니다. 같은 예외를 로그에서 센 값:

| 날짜 | 건수 |
|---|---|
| 2026-08-10 | 37 |
| 2026-08-11 | 218 |
| 2026-08-12 | 25 |

대부분은 워커의 예외 핸들러가 삼켜서 WARN 한 줄로 남았습니다 (`Board attention worker raised unexpectedly keeper=... : Sys_error("Mutex.lock: Resource deadlock avoided")`, `memory os librarian failed lane=librarian_exact: ...`). 그래서 FATAL 1건은 실제 도달 범위를 과소평가한 수치입니다.

## 원인

`Run_registry_core.register` / `complete` 가 **durable JSONL append 를 raw `Stdlib.Mutex` 안에서** 수행합니다.

```ocaml
Stdlib.Mutex.protect t.mutation_mutex (fun () ->
  append_event_exn t (Register ...);   (* Eio 파일 I/O — fiber 가 suspend *)
  replace_entry_locked t entry)
```

append 에서 fiber 가 suspend 하면, pthread mutex 는 **같은 OS 스레드**가 계속 쥔 상태입니다. 스케줄러가 같은 domain 의 다음 fiber 를 실행하고 그 fiber 가 같은 mutex 를 잠그면 재귀 획득이 되고, pthread 가 EDEADLK 를 돌려줍니다 → `Sys_error`.

같은 저장소의 `auth_credential_base.ml` 이 자기 캐시 mutex 에 달아둔 주석이 이 조건을 정확히 명시하고 있습니다 — *"Stdlib.Mutex is cooperative under Eio **because the critical section is short (hashtable lookup or replace) and never blocks on I/O**"*. 이 레지스트리의 critical section 은 I/O 를 합니다.

## 수정

`Cross_context_mutex` (lib/core) 로 교체했습니다. 이미 이 용도로 존재하는 primitive 입니다:

- Eio 컨텍스트: `Eio.Mutex` gate → 대기 fiber 가 domain 을 막지 않고 yield
- 그 아래 Stdlib mutex 는 `try_lock` + yield 로 협조적으로 획득 → system thread / Domain 간 직렬화는 그대로
- 비-Eio 호출자: 기존과 동일하게 `Stdlib.Mutex.protect`
- `with_durable_lock`: 커밋된 영속화 트랜잭션 도중에는 취소가 끼어들지 않음 — append-then-publish 순서 보장이 요구하는 것

기존 잠금이 지키던 계약(메모리 발행과 JSONL append 가 하나의 순서 있는 mutation)은 그대로입니다. 재귀 호출 경로는 없습니다: `notify_changed` 는 잠금 밖에서 호출되고, 읽기 경로는 `Atomic.get` 이라 잠금을 타지 않습니다.

## 검증

```
dune build --root . @check                                          # exit 0
dune build --root . @test/runtest-test_run_registry_concurrent_mutation   # 3 tests, 0 failed
dune build --root . @test/runtest-test_verification_run_registry \
  @test/runtest-test_exact_lane_run_registry \
  @test/runtest-test_fusion_run_registry_persist                    # 8 + 12 + 9 tests 통과
```

새 테스트는 `Eio.Fiber.both` 로 문제의 인터리빙을 그대로 재현합니다. **수정 전 트리에서 실행하면 프로덕션과 같은 예외로 3건 전부 실패합니다:**

```
[FAIL]  same-domain fibers  0  two registrations.
[FAIL]  same-domain fibers  1  completion against registration.
[FAIL]  same-domain fibers  2  both appends reach the log.
[exception] Sys_error("Mutex.lock: Resource deadlock avoided")
3 failures! in 0.004s. 3 tests run.
```

CI guard 스텝(`@test/runtest-test_eio_guard_yield_meter` 옆)에 배선했습니다. 배선 안 하면 컴파일만 되고 실행되지 않습니다.

## 범위 밖

`Stdlib.Mutex` 를 쥔 채 I/O 를 하는 다른 지점이 남아 있을 수 있습니다. 이 PR 은 FATAL 백트레이스가 지목한 레지스트리만 고쳤습니다. 전수 조사는 별도로 하는 편이 낫다고 봅니다.
