### PR TITLE
fix(dashboard): monitoring과 keepers가 하나의 주의 축을 읽도록

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -22,6 +22,7 @@ import { keepers } from '../../store'
 import { keeperMobilePane } from '../keeper-detail-state'
 import { runKeeperAction } from '../keeper-action-panel'
 import { KeeperWorkspaceRoster, rosterFilterPref, rosterFleetSummary, rosterSortPref } from './keeper-workspace-roster'
+import { keeperBucket } from './keeper-workspace-shared'
 import type { Keeper } from '../../types'
 
 function mk(partial: Partial<Keeper>): Keeper {
@@ -170,6 +171,25 @@ describe('KeeperWorkspaceRoster', () => {
     expect(attention?.getAttribute('title')).toContain('메시지 수가 아니라')
   })
 
+  // The reported split: monitoring showed 주의 for a keeper the keepers roster
+  // showed as plain 실행 중, because the roster answered from the execution
+  // row's blocked/needs_attention fields while monitoring read the runtime
+  // signals. Both now read the same attention axis, so a runtime-only signal
+  // (here: context past the warn threshold) is visible on this surface too.
+  it('marks a keeper 주의 from a runtime signal, not only from blocked tasks', () => {
+    keepers.value = [
+      mk({ name: 'hot', status: 'running', lifecycle_phase: 'Running', context_ratio: 0.99 }),
+    ]
+
+    render(html`<${KeeperWorkspaceRoster} activeName="hot" />`, host)
+
+    expect((host.querySelector('.kp-att') as HTMLElement | null)?.textContent).toBe('▲ 1')
+    const attentionChip = Array.from(host.querySelectorAll('.kw-rfilter')).find(chip =>
+      chip.textContent?.includes('주의'),
+    )
+    expect(attentionChip?.textContent).toBe('주의1')
+  })
+
   it('renders invalid configured keepers as a blocking row with one repair action', () => {
     keepers.value = [
       mk({
@@ -215,17 +235,25 @@ describe('KeeperWorkspaceRoster', () => {
   // unit test below.
 
   it('computes fleet summary from live keeper fields without local-only fleet actions', () => {
-    const result = rosterFleetSummary([
-      mk({ name: 'run', status: 'running', lifecycle_phase: 'Running', context_ratio: 0.8 }),
-      mk({ name: 'pause', status: 'running', paused: true, lifecycle_phase: 'Paused', needs_attention: true }),
-      mk({ name: 'off', status: 'stopped', lifecycle_phase: 'Stopped' }),
-      mk({
-        name: 'gate',
-        status: 'running',
-        lifecycle_phase: 'Running',
-        current_gate: { kind: 'approval_required', tool: 'shell' },
-      }),
-    ])
+    // The summary counts; deriving the attention axis is the accessor's job
+    // (the roster builds it from the fleet composite). A stub keeps this case
+    // about the counting.
+    const attentionOf = (keeper: Keeper) => (keeper.name === 'pause' ? 1 : 0)
+    const result = rosterFleetSummary(
+      [
+        mk({ name: 'run', status: 'running', lifecycle_phase: 'Running', context_ratio: 0.8 }),
+        mk({ name: 'pause', status: 'running', paused: true, lifecycle_phase: 'Paused', needs_attention: true }),
+        mk({ name: 'off', status: 'stopped', lifecycle_phase: 'Stopped' }),
+        mk({
+          name: 'gate',
+          status: 'running',
+          lifecycle_phase: 'Running',
+          current_gate: { kind: 'approval_required', tool: 'shell' },
+        }),
+      ],
+      keeper => keeperBucket(keeper),
+      attentionOf,
+    )
 
     expect(result).toEqual({
       total: 4,

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -25,6 +25,11 @@ import { keeperActivityDisplay, keeperDisplayRuntime } from '../../lib/keeper-ru
 import type { KeeperActivityDisplay } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import { compareByRecency, sortByRecency } from '../../lib/keeper-recency'
+import {
+  deriveKeeperRuntimeProjection,
+  keeperAttentionSignals,
+} from '../../lib/keeper-runtime-projection'
+import type { KeeperCompositeSnapshot } from '../../api/schemas/keeper-composite'
 import type { Keeper } from '../../types'
 import { KEEPER_ACTION_LABELS, runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
 import { VirtualList } from '../common/virtual-list'
@@ -113,12 +118,19 @@ const WINDOW_AT = 60
 // per-row context/tool rows, now moved to the runtime panel.
 const ROSTER_ROW_ESTIMATED_HEIGHT = 69
 
-/** Blocked tasks + explicit attention flag → the roster attention badge. */
-function attentionCount(keeper: Keeper): number {
-  return keeper.blocked_task_count ?? (keeper.needs_attention === true ? 1 : 0)
-}
-function needsAttention(keeper: Keeper): boolean {
-  return keeper.needs_attention === true || attentionCount(keeper) > 0
+/** How many attention signals this keeper is raising.
+ *
+ *  Threaded as an accessor for the same reason `bucketOf` is: the count comes
+ *  from the fleet composite, and a call site that cannot reach the composite
+ *  must not silently answer a different question. It used to read two flat
+ *  record fields (`needs_attention`, `blocked_task_count`) while the
+ *  monitoring roster read the runtime projection's attention signals, so one
+ *  keeper could be 주의 there and 실행 중 here. Both now read
+ *  `keeperAttentionSignals`. */
+type AttentionOf = (keeper: Keeper) => number
+
+function attentionSignalCount(keeper: Keeper, composite: KeeperCompositeSnapshot | null): number {
+  return keeperAttentionSignals(deriveKeeperRuntimeProjection({ keeper, composite })).length
 }
 
 function keeperContextRatio(keeper: Keeper): number | null {
@@ -175,7 +187,8 @@ function compareFleetRows(bucketOf: BucketOf, nowMs: number): (a: Keeper, b: Kee
 
 export function rosterFleetSummary(
   rows: readonly Keeper[],
-  bucketOf: BucketOf = keeperBucket,
+  bucketOf: BucketOf,
+  attentionOf: AttentionOf,
 ): RosterFleetSummary {
   const summary: RosterFleetSummary = {
     total: rows.length,
@@ -195,7 +208,7 @@ export function rosterFleetSummary(
     if (bucket === 'stuck') summary.stuck += 1
     if (bucket === 'paused') summary.paused += 1
     if (bucket === 'offline') summary.offline += 1
-    if (needsAttention(keeper)) summary.attention += 1
+    if (attentionOf(keeper) > 0) summary.attention += 1
     if (keeper.current_gate?.kind === 'approval_required') summary.approvalGate += 1
     const contextRatio = keeperContextRatio(keeper)
     if (contextRatio === null) {
@@ -212,16 +225,21 @@ export function rosterFleetSummary(
  *  above the rest, ordered by blocked-task count (min 1 when only the flag is
  *  set, so a flagged-but-unblocked keeper still outranks a calm one). Mirrors
  *  the v2 roster's numeric `k.att` sort key. */
-function attentionScore(keeper: Keeper): number {
-  return needsAttention(keeper) ? Math.max(1, attentionCount(keeper)) : 0
+function attentionScore(keeper: Keeper, attentionOf: AttentionOf): number {
+  return attentionOf(keeper)
 }
 
 /** Comparator for the 'name'/'att' flat sort modes. 'status' keeps the bucket
  *  grouping and 'recent' uses sortByRecency (decorate-sort-undecorate); neither
  *  reaches here. Name ties break alphabetically so the order is stable. */
-function compareKeepers(a: Keeper, b: Keeper, sort: 'name' | 'att'): number {
+function compareKeepers(
+  a: Keeper,
+  b: Keeper,
+  sort: 'name' | 'att',
+  attentionOf: AttentionOf,
+): number {
   if (sort === 'name') return a.name.localeCompare(b.name)
-  return attentionScore(b) - attentionScore(a)
+  return attentionScore(b, attentionOf) - attentionScore(a, attentionOf)
     || compareContextRatioDescending(a, b)
     || a.name.localeCompare(b.name)
 }
@@ -260,19 +278,20 @@ function matchesQuery(keeper: Keeper, q: string): boolean {
 
 function RosterRow({
   keeper,
+  attentionCount: att,
   active,
   onSelect,
   onMenu,
   style,
 }: {
   keeper: Keeper
+  attentionCount: number
   active: boolean
   onSelect: (name: string) => void
   onMenu: (keeper: Keeper, event: MouseEvent) => void
   style?: string
 }) {
   const tone = keeperFleetTone(keeper)
-  const att = attentionCount(keeper)
   const scope = keeperScope(keeper)
   const basepath = keeperBasepath(keeper)
   // Design roster identity sub-line = basepath; fall back to the scope proxy
@@ -534,15 +553,19 @@ export function KeeperWorkspaceRoster({
   const fleetSnapshot = fleetCompositeSnapshot.value
   const compositeByKeeperKey = useMemo(() => buildCompositeByKeeperKey(fleetSnapshot), [fleetSnapshot])
   const bucketOf: BucketOf = k => keeperBucket(k, compositeSnapshotForKeeper(k, compositeByKeeperKey))
+  // Same composite the buckets use, so grouping and the attention badge cannot
+  // disagree about the same keeper within one render pass.
+  const attentionOf: AttentionOf = k =>
+    attentionSignalCount(k, compositeSnapshotForKeeper(k, compositeByKeeperKey))
   const counts = {
     all: all.length,
     run: all.filter(k => bucketOf(k) === 'running').length,
-    att: all.filter(needsAttention).length,
+    att: all.filter(k => attentionOf(k) > 0).length,
   }
 
   const visible = all.filter(k => {
     if (filter === 'run' && bucketOf(k) !== 'running') return false
-    if (filter === 'att' && !needsAttention(k)) return false
+    if (filter === 'att' && attentionOf(k) === 0) return false
     return matchesQuery(k, query)
   })
 
@@ -552,7 +575,7 @@ export function KeeperWorkspaceRoster({
   const sortRows = (rows: Keeper[]): Keeper[] => {
     if (sort === 'status') return rows
     if (sort === 'recent') return sortByRecency(rows, nowMs)
-    return [...rows].sort((a, b) => compareKeepers(a, b, sort))
+    return [...rows].sort((a, b) => compareKeepers(a, b, sort, attentionOf))
   }
 
   const select = (name: string) => {
@@ -659,7 +682,7 @@ export function KeeperWorkspaceRoster({
     if (item.type === 'header') {
       return renderHeader(item)
     }
-    return html`<${RosterRow} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} />`
+    return html`<${RosterRow} keeper=${item.keeper} attentionCount=${attentionOf(item.keeper)} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} />`
   }
 
   function getKey(item: RosterItem): string {
@@ -735,7 +758,7 @@ export function KeeperWorkspaceRoster({
           : html`<div class="kw-roster-list roster-list">
               ${items.map(item => item.type === 'header'
                 ? renderHeader(item)
-                : html`<${RosterRow} key=${item.keeper.name} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} style=${rowStyle} />`)}
+                : html`<${RosterRow} key=${item.keeper.name} keeper=${item.keeper} attentionCount=${attentionOf(item.keeper)} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} style=${rowStyle} />`)}
             </div>`}
         `}
       ${menu

--- a/dashboard/src/lib/keeper-runtime-projection.test.ts
+++ b/dashboard/src/lib/keeper-runtime-projection.test.ts
@@ -184,6 +184,7 @@ describe('deriveKeeperRuntimeProjection', () => {
       'ksm_phase',
       'heartbeat',
       'context_ratio',
+      'blocked_tasks',
       'fiber_alive',
       'stop_requested',
       'runtime_trace',
@@ -233,5 +234,39 @@ describe('deriveKeeperRuntimeProjection', () => {
 
     expect(projection.headline).toBe('턴 진행 중')
     expect(projection.tone).toBe('ok')
+  })
+})
+
+
+// One attention axis: whatever a fleet surface uses to say 주의 has to come
+// from this list. The keepers roster used to answer from the execution row's
+// blocked/needs_attention fields while monitoring answered from these signals,
+// so the same keeper read 주의 on one surface and 실행 중 on the other.
+describe('attention axis', () => {
+  const attentionKinds = (k: Keeper) =>
+    deriveKeeperRuntimeProjection({ keeper: k, composite: null, nowMs: NOW_MS })
+      .signals.filter(signal => signal.contributesToAttention)
+      .map(signal => signal.kind)
+
+  it('raises an attention signal for blocked work carried on the execution row', () => {
+    expect(attentionKinds(keeper({ blocked_task_count: 3 }))).toContain('blocked_tasks')
+  })
+
+  it('raises an attention signal for an explicit attention flag', () => {
+    expect(attentionKinds(keeper({ needs_attention: true }))).toContain('blocked_tasks')
+  })
+
+  it('stays clear when there is no blocked work and no flag', () => {
+    expect(attentionKinds(keeper({ blocked_task_count: 0 }))).not.toContain('blocked_tasks')
+  })
+
+  it('carries the blocked count in the signal detail so a surface can show it', () => {
+    const signal = deriveKeeperRuntimeProjection({
+      keeper: keeper({ blocked_task_count: 3 }),
+      composite: null,
+      nowMs: NOW_MS,
+    }).signals.find(s => s.kind === 'blocked_tasks')
+    expect(signal?.detail).toBe('blocked_task_count 3')
+    expect(signal?.hint).toContain('3건')
   })
 })

--- a/dashboard/src/lib/keeper-runtime-projection.ts
+++ b/dashboard/src/lib/keeper-runtime-projection.ts
@@ -23,6 +23,7 @@ export type KeeperRuntimeProjectionSignalKind =
   | 'runtime_trace'
   | 'runtime_warning'
   | 'fsm_raw_lanes'
+  | 'blocked_tasks'
 
 export type KeeperRuntimeProjectionSignalState =
   | 'ok'
@@ -115,6 +116,24 @@ interface DeriveKeeperRuntimeProjectionInput {
   readonly nowMs?: number
 }
 
+/** The attention axis of a keeper runtime projection.
+ *
+ *  Every fleet surface must answer "does this keeper need me" from this one
+ *  list. The keepers roster used to answer it from two flat record fields
+ *  (`needs_attention`, `blocked_task_count`) while the monitoring roster read
+ *  these signals, so the same keeper showed 주의 on one surface and 실행 중 on
+ *  the other — a stale heartbeat, a context breach or a dead fiber was
+ *  visible in monitoring and invisible in the roster. */
+export function keeperAttentionSignals(
+  projection: KeeperRuntimeProjection,
+): KeeperRuntimeProjectionSignal[] {
+  return projection.signals.filter(signal => signal.contributesToAttention)
+}
+
+export function keeperNeedsAttention(projection: KeeperRuntimeProjection): boolean {
+  return projection.signals.some(signal => signal.contributesToAttention)
+}
+
 export const KEEPER_RUNTIME_CONTEXT_ATTENTION_RATIO = 0.95
 
 export function compactToken(value: string | null | undefined, fallback = 'unknown'): string {
@@ -184,6 +203,7 @@ export function deriveKeeperRuntimeProjection({
     runtimeWarnings,
     fsmLanes,
     runtimeReason,
+    backlog: deriveBacklogAttention(keeper),
   })
   const attentionSignals = signals.filter(signal => signal.contributesToAttention)
   const headline =
@@ -270,6 +290,25 @@ function deriveHeartbeatProjection(keeper: Keeper, nowMs: number): KeeperHeartbe
     ageMs,
     thresholdMs,
   }
+}
+
+/** Blocked work the keeper is carrying, read from the execution row.
+ *
+ *  This is the fact the keepers roster used to answer 주의 with on its own,
+ *  while the monitoring roster answered from the runtime signals. Carrying it
+ *  as a signal makes it part of the one attention axis both surfaces read,
+ *  instead of a second definition living on one surface. */
+export interface KeeperBacklogAttention {
+  readonly blockedTasks: number
+  readonly flagged: boolean
+}
+
+function deriveBacklogAttention(keeper: Keeper): KeeperBacklogAttention {
+  const blockedTasks =
+    typeof keeper.blocked_task_count === 'number' && Number.isFinite(keeper.blocked_task_count)
+      ? Math.max(0, keeper.blocked_task_count)
+      : 0
+  return { blockedTasks, flagged: keeper.needs_attention === true }
 }
 
 function deriveContextProjection(keeper: Keeper): KeeperContextProjection {
@@ -370,6 +409,7 @@ function fsmLaneSummary(lanes: readonly KeeperRuntimeProjectionFsmLane[]): strin
 
 function buildProjectionSignals({
   opState,
+  backlog,
   heartbeat,
   context,
   fiberAlive,
@@ -388,6 +428,7 @@ function buildProjectionSignals({
   readonly runtimeWarnings: readonly string[]
   readonly fsmLanes: readonly KeeperRuntimeProjectionFsmLane[]
   readonly runtimeReason: string
+  readonly backlog: KeeperBacklogAttention
 }): KeeperRuntimeProjectionSignal[] {
   const blockerAttention = opState.kind === 'stuck' || opState.attention !== 'clean'
   const ksmAttention = fsmLanes.some(lane => lane.axis === 'KSM' && lane.contributesToAttention)
@@ -435,6 +476,29 @@ function buildProjectionSignals({
       state: context.breach ? 'attention' : context.ratio === null ? 'unknown' : 'ok',
       contributesToAttention: context.breach,
       hint: context.breach ? `컨텍스트 사용량이 ${contextValue}입니다.` : null,
+    },
+    {
+      kind: 'blocked_tasks',
+      label: 'blocked work',
+      value:
+        backlog.blockedTasks > 0
+          ? `${backlog.blockedTasks} blocked`
+          : backlog.flagged
+            ? 'flagged'
+            : 'clear',
+      detail:
+        backlog.blockedTasks > 0
+          ? `blocked_task_count ${backlog.blockedTasks}`
+          : 'blocked_task_count 0',
+      tone: backlog.blockedTasks > 0 || backlog.flagged ? 'warn' : 'neutral',
+      state: backlog.blockedTasks > 0 || backlog.flagged ? 'attention' : 'ok',
+      contributesToAttention: backlog.blockedTasks > 0 || backlog.flagged,
+      hint:
+        backlog.blockedTasks > 0
+          ? `차단된 작업이 ${backlog.blockedTasks}건 있습니다.`
+          : backlog.flagged
+            ? '주의 플래그가 설정되어 있습니다.'
+            : null,
     },
     {
       kind: 'fiber_alive',

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -3,6 +3,7 @@ import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import { parseAgentStatus } from './agent-status'
 import { UNKNOWN_STATUS_LABEL } from './format-string'
 import {
+  keeperNeedsAttention,
   deriveKeeperRuntimeProjection,
   type KeeperRuntimeProjection,
 } from './keeper-runtime-projection'
@@ -268,7 +269,7 @@ function keeperBand(projection: KeeperRuntimeProjection): RuntimeBand {
   if (projection.opState.kind === 'offline') return 'offline'
   if (projection.opState.phase === 'Draining') return 'paused'
   if (isTransientPhase(projection.opState.phase)) return 'transient'
-  if (projection.signals.some(signal => signal.contributesToAttention)) {
+  if (keeperNeedsAttention(projection)) {
     return 'attention'
   }
   return 'active'


### PR DESCRIPTION
## 증상

`#monitoring?section=agents` 와 `#keepers` 가 같은 키퍼를 서로 다른 상태로 표시했습니다. 한쪽은 `주의`, 다른 쪽은 그냥 `실행 중`.

## 원인

두 화면이 "이 키퍼가 나를 필요로 하는가"를 **서로 다른 입력**으로 답하고 있었습니다.

| 화면 | 판정 근거 |
|---|---|
| monitoring | `keeperBand` → `projection.signals.some(s => s.contributesToAttention)` |
| keepers | `needsAttention` → `keeper.needs_attention \|\| keeper.blocked_task_count > 0` |

서로 상대가 못 보는 것을 봅니다.

- monitoring 만 보는 것: stale heartbeat, context 임계 초과, fiber 생존 미증명, stop 요청, runtime warning
- keepers 만 보는 것: execution row 의 blocked work

그래서 컨텍스트가 임계를 넘은 키퍼는 monitoring 에서 `주의`, 로스터에서는 `실행 중` 으로 보였습니다.

## 수정

두 화면이 같은 축(`keeperAttentionSignals`)을 읽습니다. 그리고 **어느 쪽도 신호를 잃지 않게** blocked work 를 그 축에 `blocked_tasks` 신호로 편입했습니다.

- monitoring: blocked work 를 새로 봅니다
- keepers: runtime 신호들을 새로 봅니다

로스터는 attention 개수를 `bucketOf` 와 같은 방식으로 accessor 로 흘립니다. 둘 다 fleet composite 에서 파생되는 값이고, composite 에 닿지 못하는 호출부가 조용히 다른 질문에 답하면 안 되기 때문입니다. `rosterFleetSummary` 는 두 accessor 를 필수 인자로 받습니다 — 기본값에 기대고 있던 호출부 1곳을 컴파일러가 잡아냈습니다.

배지 숫자는 자기 라벨의 의미를 지킵니다: `주의 신호 N건` 이므로 신호 개수를 세고, blocked 작업 건수는 그 신호의 detail/hint 로 들어갑니다.

## 검증

```
npx tsc -b                                              # exit 0
npx vitest run src/lib src/components/keeper-workspace src/components/agent-roster.test.ts
# Test Files 64 passed | Tests 1095 passed
```

새 테스트가 수정 전 동작에서 실제로 실패하는지 mutation 으로 확인했습니다.

| 되돌린 것 | 실패한 케이스 |
|---|---|
| `blocked_tasks` 신호의 `contributesToAttention` 를 false 로 | `raises an attention signal for blocked work…`, `…for an explicit attention flag`, `labels attention as an attention signal…`, `sorts by attention…` (4건) |
| 로스터 attention 을 flat 필드로 되돌림 | `marks a keeper 주의 from a runtime signal, not only from blocked tasks` |

두 번째가 보고된 증상 그대로입니다: `context_ratio: 0.99` 키퍼가 monitoring 에서는 주의였는데 로스터에서는 배지가 없었습니다.

## 범위 밖

`keeperBucket(keeper, composite = null)` 의 기본값은 남겨뒀습니다. 현재 이 기본값을 쓰는 두 호출부(`keeper-workspace-rail.ts:toMemoryKeeper`, `agent-detail-memory.ts`)는 running 과 stuck 을 같은 글리프로 접기 때문에 표시가 갈리지 않습니다. 같은 계열의 위험이라 언젠가 required 로 바꾸는 편이 낫지만, 이 PR 에서 건드릴 이유는 없었습니다.

또한 두 화면의 **어휘**는 여전히 다릅니다 — monitoring 은 5밴드(active/attention/paused/offline/transient), keepers 는 4버킷 + 교차 배지. 이 PR 은 "같은 사실을 양쪽이 본다"까지만 맞췄고, 표시 형태 통일은 별개 결정입니다.
