### PR TITLE
fix(telemetry): merge stores under one bounded allowance (RFC-0372 Phase 2)

### DIFF
--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -399,8 +399,23 @@ let unbounded_window_scan_cap = 50_000
 
    [read_limit] is abstract in the mli so "unbounded" cannot be constructed.
    Phase 1 of RFC-0372 caps what a caller may ask for; Phase 2 makes the
-   allowance span stores instead of applying to each. *)
-let max_read_entries = 10_000
+   allowance span stores instead of applying to each.
+
+   The ceiling is measured, not chosen. Phase 1 picked 10_000 provisionally;
+   request_cost_gate (Mode C, 8 keepers x 20k entries) then measured peak RSS
+   against it on this same reader:
+
+     n =  2_000 ->  80.2 MB, 0.49 s
+     n =  5_000 -> 129.4 MB, 1.03 s
+     n = 10_000 -> 185.1 MB, 2.29 s
+
+   That is roughly 13 KB of heap per entry (a ~25x expansion over the 521-byte
+   JSON rows) on top of a ~54 MB fixed cost. 10_000 buys a 5 MB response for
+   185 MB of heap; 2_000 keeps the response near 1 MB and the heap near 80 MB,
+   and it matches [default_windowed_telemetry_limit] so the widest default
+   request is also the widest possible one. Callers needing more paginate via
+   [offset]. *)
+let max_read_entries = 2_000
 
 let default_read_entries = 100
 
@@ -432,6 +447,36 @@ let bounded_entries_for_window store ~n ?since_ts ?until_ts () =
   in
   List.filter (within_requested_window ?since_ts ?until_ts) entries
 
+(* RFC-0372 Phase 2 — merge per-store slices while holding only the newest
+   [target] entries.
+
+   [List.concat_map] materialises every store's slice before anything is
+   trimmed, so the working set scales with store count: at 8 keepers the
+   per-keeper sources alone hold 8x what the caller asked for, and each added
+   keeper adds another multiple. Folding with a trim after each store keeps the
+   working set at O(target + one store's slice).
+
+   The merged result is unchanged. Each store is already newest-first, so an
+   entry beyond a store's own newest [target] is older than that store's newest
+   [target] and cannot reach the merged head. Trimming per store therefore
+   discards only entries that the final [take_first target] would have dropped
+   anyway.
+
+   [target <= 0] keeps the old concat behaviour; callers inside this module
+   always pass a positive limit since Phase 1, but the guard keeps the helper
+   total. *)
+let merge_newest_bounded ~target ~read items =
+  if target <= 0 then List.concat_map read items
+  else
+    List.fold_left
+      (fun acc item ->
+         match read item with
+         | [] -> acc
+         | slice -> sort_newest_first (slice @ acc) |> take_first target)
+      []
+      items
+;;
+
 let read_fixed_source dir source ~n ?since_ts ?until_ts () : Yojson.Safe.t list =
   match classify_store_dir source ~site:"read_fixed_source_dir" dir with
   | Store_missing | Store_invalid -> []
@@ -454,9 +499,8 @@ let read_keeper_metrics ~masc_root ?keeper_name ?since_ts ?until_ts ~n () :
     | None -> dirs
     | Some name -> List.filter (fun (k, _) -> String.equal k name) dirs
   in
-  List.concat_map (fun (_name, dir) ->
-    read_fixed_source dir Keeper_metric ~n ?since_ts ?until_ts ()
-  ) dirs
+  merge_newest_bounded ~target:n dirs ~read:(fun (_name, dir) ->
+    read_fixed_source dir Keeper_metric ~n ?since_ts ?until_ts ())
 
 let read_keeper_metrics_fast_top ~masc_root ~n () : Yojson.Safe.t list =
   let target = n + 1 in
@@ -506,8 +550,8 @@ let read_execution_receipts ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
     | None -> dirs
     | Some name -> List.filter (fun (k, _) -> String.equal k name) dirs
   in
-  List.concat_map
-    (fun (_name, dir) ->
+  merge_newest_bounded ~target:n dirs
+    ~read:(fun (_name, dir) ->
       try
         let store = Dated_jsonl.create ~base_dir:dir () in
         dated_jsonl_entries store ~n ?since_ts ?until_ts ()
@@ -520,7 +564,6 @@ let read_execution_receipts ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
         Log.Telemetry.warn
           "read_execution_receipts: store open failed for %s" dir;
         [])
-    dirs
 
 let read_trajectory_file path ~max_lines ?since_ts ?until_ts () =
   if
@@ -594,8 +637,8 @@ let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
      from being unbounded (the freeze cause). *)
   let max_lines = if n <= 0 then unbounded_window_scan_cap else n in
   let entries =
-    List.concat_map
-      (fun (_name, dir) ->
+    merge_newest_bounded ~target:max_lines dirs
+      ~read:(fun (_name, dir) ->
         protect_source_read Trajectory_tool_call
           ~site:"read_trajectory_tool_calls_readdir" ~default:[] (fun () ->
           Sys.readdir dir
@@ -607,7 +650,6 @@ let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
                read_trajectory_file
                  (Filename.concat dir name)
                  ~max_lines ?since_ts ?until_ts ())))
-      dirs
   in
   let entries = sort_newest_first entries in
   let entries = if n <= 0 then entries else take_first n entries in
@@ -659,9 +701,27 @@ let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
     if has_filter then max (n + offset) ((n + offset) * 2)
     else n + offset + 1
   in
+  (* Applied per source, before merging, so the bounded merge below keeps the
+     newest [per_source] entries that SURVIVE filtering. Filtering after the
+     merge (as this did previously) would let a trimmed merge drop entries the
+     filter would have kept, so the predicate has to travel with the read. *)
+  let keep json =
+    let keeper_ok =
+      match keeper_name with
+      | None -> true
+      | Some name ->
+        (match json with
+         | `Assoc fields ->
+           (match List.assoc_opt "source" fields with
+            | Some (`String "keeper_metric") -> true (* already filtered by dir *)
+            | _ -> matches_keeper name json)
+         | _ -> true)
+    in
+    keeper_ok && matches_scope ?session_id ?operation_id ?worker_run_id json
+  in
   let all_entries =
-    List.concat_map (fun source ->
-      match source with
+    merge_newest_bounded ~target:per_source sources ~read:(fun source ->
+      (match source with
       | Keeper_metric ->
         if Option.is_none keeper_name && not has_filter then
           read_keeper_metrics_fast_top ~masc_root ~n ()
@@ -682,27 +742,12 @@ let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
         match fixed_store_dir ~masc_root ~base_path source with
         | Some dir ->
           read_fixed_source dir source ~n:per_source ?since_ts ?until_ts ()
-        | None -> []
-    ) sources
+        | None -> [])
+      |> List.filter keep)
   in
   (* Filter by keeper_name for non-keeper-metric sources *)
-  let filtered = match keeper_name with
-    | None -> all_entries
-    | Some name ->
-      List.filter (fun json ->
-        match json with
-        | `Assoc fields ->
-          (match List.assoc_opt "source" fields with
-           | Some (`String "keeper_metric") -> true  (* already filtered *)
-           | _ -> matches_keeper name json)
-        | _ -> true
-      ) all_entries
-  in
-  let filtered =
-    List.filter
-      (fun json -> matches_scope ?session_id ?operation_id ?worker_run_id json)
-      filtered
-  in
+  (* [keep] already ran per source inside the merge above. *)
+  let filtered = all_entries in
   let filtered =
     if List.mem Agent_event sources && List.mem Tool_call_io sources then
       suppress_shadow_keeper_tool_events filtered


### PR DESCRIPTION
RFC-0372 Phase 2 (RFC #28390, harness #28386, Phase 1 #28392 merged).

## The defect

Three per-keeper readers plus the source fan-in used `List.concat_map`, which materialises every store's slice **before anything is trimmed**. The working set scaled with store count: at 8 keepers the per-keeper sources alone held 8× what the caller asked for.

## The change

`merge_newest_bounded` folds instead, trimming after each store — working set `O(target + one store's slice)`.

**The merged result is unchanged.** Each store is already newest-first, so an entry beyond a store's own newest `target` is older than that store's newest `target` and cannot reach the merged head. Trimming per store discards only what the final trim would have dropped anyway. This is an equivalence, not an approximation.

**The scope predicate moves with the read.** Filtering after a trimmed merge would let the merge drop entries the filter would have kept, so keeper/session/operation/worker matching now runs per source *before* merging. `suppress_shadow_keeper_tool_events` still runs on the merged set because it is cross-entry.

## The ceiling is now measured, not chosen

Phase 1 picked `max_read_entries = 10_000` provisionally. RFC-0372 §7 left "what is the right ceiling?" open, explicitly to be answered by measurement. Mode C on this reader (8 keepers × 20k entries):

| n | peak RSS delta | duration |
|---|---|---|
| 2,000 | 80.2 MB | 0.49 s |
| 5,000 | 129.4 MB | 1.03 s |
| 10,000 | 185.1 MB | 2.29 s |

≈ **13 KB of heap per entry** (~25× the 521-byte JSON row) over a ~54 MB fixed cost.

10,000 buys a 5 MB response for 185 MB of heap. 2,000 keeps the response near 1 MB, matches `default_windowed_telemetry_limit` (so the widest default request is also the widest possible one), and leaves `offset` for callers needing more.

## Measured end to end

Mode C, 8 keepers × 20k entries, `GET /api/v1/dashboard/telemetry?n=10000`:

| axis | before (Phase 1) | after |
|---|---|---|
| `rss_peak_delta_mb` | 205.2 | **56.1** |
| request duration | 2.21 s | 1.63 s |

### What this does not yet achieve

RFC-0372 §5 sets the Phase 2 criterion as **doubling `--keepers` leaves `rss_peak_delta_mb` flat.** It is improved but not flat:

| | 4 keepers | 8 keepers | growth |
|---|---|---|---|
| before | 682.8 MB | 1005.5 MB | +47% |
| after | 45.3 MB | 56.1 MB | **+24%** |

The residual tracks per-store read and parse cost, which a bounded merge cannot remove. Making cost genuinely independent of store count needs early termination per store — the cutoff strategy `read_keeper_metrics_fast_top` already uses, generalised to the other readers. That is follow-up work, not this PR, and the criterion stays open until it lands.

## A note on how this was measured

The first version of this change moved `rss_peak_delta_mb` from 205.2 to 209.5 — **no effect**. The reason was that the harness seed only creates keeper-metrics and the four fixed sources, and with no filter the keeper path takes `read_keeper_metrics_fast_top`, not the reader I had changed. The cost was coming from the source-level `concat_map` I had not touched.

Had the number moved for unrelated reasons I would have reported a fix that did nothing. Extending the seed to cover execution-receipts and trajectories is worth doing separately.

## Tests

- 42 telemetry cases pass (filter reordering is behaviour-visible, so this matters).
- `test_dashboard_http_core`: same 3 failures as main (`executor_pool 14`, `context-window shrink guard 2/3`), pre-existing.

RFC-WAIVED: implements RFC-0372 Phase 2, cited above (#28390). Touches no subsystem in the RFC discovery list.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
