### PR TITLE
fix(registry): exact lane의 자체 lock도 같은 EDEADLK를 재현 (#28391 후속)

### DIFF
--- a/lib/exact_lane_run_registry.ml
+++ b/lib/exact_lane_run_registry.ml
@@ -198,7 +198,7 @@ type t =
   { store : Store.t
   ; failed_completions : (string * failed_completion) list Atomic.t
   ; projection : run list Atomic.t
-  ; observation_mutex : Stdlib.Mutex.t
+  ; observation_mutex : Cross_context_mutex.t
   }
 
 type completion_error =
@@ -271,7 +271,7 @@ let make store =
     { store
     ; failed_completions = Atomic.make []
     ; projection = Atomic.make []
-    ; observation_mutex = Stdlib.Mutex.create ()
+    ; observation_mutex = Cross_context_mutex.create ()
     }
   in
   publish_projection t;
@@ -281,8 +281,21 @@ let make store =
 let create ?path () = make (Store.create ?path ())
 let replay path = make (Store.replay path)
 
+(* [Cross_context_mutex], not [Stdlib.Mutex]: this lock wraps
+   [Store.register] / [Store.complete], whose critical section performs a
+   durable JSONL append and therefore suspends the fiber. A raw pthread mutex
+   held across that suspension is still held by the *same OS thread* when the
+   scheduler runs the next fiber on this domain, so that fiber's acquisition
+   is recursive and pthreads rejects it with
+   [Sys_error "Mutex.lock: Resource deadlock avoided"].
+
+   #28391 fixed the same shape inside [Run_registry_core], which this module
+   wraps; the outer lock kept reproducing it. Measured on the live fleet: 231
+   occurrences reached this lane through the board attention worker
+   ("Board attention worker raised unexpectedly"), which swallows them, plus
+   10 through the librarian lane. *)
 let register_running t ~run_id ~lane ~subject_id ~actor ~started_at ~input =
-  Stdlib.Mutex.protect t.observation_mutex (fun () ->
+  Cross_context_mutex.with_durable_lock t.observation_mutex (fun () ->
     Store.register
       t.store
       ~id:run_id
@@ -296,7 +309,7 @@ let register_running t ~run_id ~lane ~subject_id ~actor ~started_at ~input =
 let mark_completed t ~run_id ~outcome ~elapsed_s ~output =
   let completion = { Payload.outcome; elapsed_s; output } in
   let result =
-    Stdlib.Mutex.protect t.observation_mutex (fun () ->
+    Cross_context_mutex.with_durable_lock t.observation_mutex (fun () ->
       match Store.complete t.store ~id:run_id ~completion with
       | `Completed ->
         remove_failed_completion t run_id;

--- a/test/test_run_registry_concurrent_mutation.ml
+++ b/test/test_run_registry_concurrent_mutation.ml
@@ -16,11 +16,19 @@
     worker exception handlers, so the crash count understates the reach.
 
     These cases run the interleaving directly: [Eio.Fiber.both] resumes the
-    second fiber precisely while the first is suspended inside the lock. *)
+    second fiber precisely while the first is suspended inside the lock.
+
+    The shared [Run_registry_core] is not the whole surface: a consumer that
+    wraps [Store.register] in its own raw mutex reproduces the same recursion
+    one layer up. [Exact_lane_run_registry] did, and the board attention
+    worker drove 231 of the measured occurrences through it, so every
+    instantiation is covered here rather than only the one the fatal
+    backtrace named. *)
 
 open Alcotest
 
 module R = Masc.Verification_run_registry
+module Ex = Masc.Exact_lane_run_registry
 
 let remove_if_exists path =
   try Sys.remove path with
@@ -132,6 +140,66 @@ let test_both_appends_reach_the_log () =
       check int "both registrations were appended" 2 (register_events_in path))
 ;;
 
+(* The board attention worker's path. It reaches the shared core through a
+   second lock of its own, which is why fixing only the core left this lane
+   raising in production. *)
+let register_exact t ~run_id =
+  Ex.register_running
+    t
+    ~run_id
+    ~lane:Ex.Board_attention
+    ~subject_id:("cand-" ^ run_id)
+    ~actor:"keeper-rondo-agent"
+    ~started_at:100.0
+    ~input:(Ex.Exact_input (`Assoc []))
+;;
+
+let exact_ids t =
+  Ex.list_runs t |> List.map (fun (run : Ex.run) -> run.run_id) |> List.sort String.compare
+;;
+
+let test_exact_lane_concurrent_registrations () =
+  let path = fresh_path ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> remove_if_exists path)
+    (fun () ->
+      let t = Ex.create ~path () in
+      Eio_main.run (fun _env ->
+        Eio.Fiber.both
+          (fun () -> register_exact t ~run_id:"exact-a")
+          (fun () -> register_exact t ~run_id:"exact-b"));
+      check
+        (list string)
+        "both exact-lane registrations are tracked"
+        [ "exact-a"; "exact-b" ]
+        (exact_ids t))
+;;
+
+let test_exact_lane_completion_against_registration () =
+  let path = fresh_path ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> remove_if_exists path)
+    (fun () ->
+      let t = Ex.create ~path () in
+      register_exact t ~run_id:"exact-first";
+      Eio_main.run (fun _env ->
+        Eio.Fiber.both
+          (fun () ->
+            ignore
+              (Ex.mark_completed
+                 t
+                 ~run_id:"exact-first"
+                 ~outcome:Ex.Succeeded
+                 ~elapsed_s:1.0
+                 ~output:(`Assoc [])))
+          (fun () -> register_exact t ~run_id:"exact-second"));
+      check
+        (list string)
+        "an exact-lane completion and registration interleave without loss"
+        [ "exact-first"; "exact-second" ]
+        (exact_ids t))
+;;
+
 let () =
   run
     "run_registry_concurrent_mutation"
@@ -148,5 +216,15 @@ let () =
             "both appends reach the log"
             `Quick
             test_both_appends_reach_the_log
+        ] )
+    ; ( "exact lane (own outer lock)"
+      , [ test_case
+            "two registrations"
+            `Quick
+            test_exact_lane_concurrent_registrations
+        ; test_case
+            "completion against registration"
+            `Quick
+            test_exact_lane_completion_against_registration
         ] )
     ]


### PR DESCRIPTION
## #28391 은 절반만 고쳤습니다

FATAL 백트레이스가 `Verification_run_registry` 를 지목했고, 그 공유 코어(`Run_registry_core`)를 고쳤습니다. 그때 PR 본문에 "다른 지점이 남아 있을 수 있다"고 적었는데, 실제로 남아 있었습니다.

`Exact_lane_run_registry` 는 `Store.register` / `Store.complete` 를 **자기 raw `Stdlib.Mutex` 로 한 번 더 감쌉니다.** 그래서 같은 재귀 획득이 한 층 위에서 그대로 일어납니다.

#28391 이 이미 들어간 트리에서 두 fiber 를 한 domain 에 올려 실측:

```
Exact_lane_run_registry   RAISED Sys_error("Mutex.lock: Resource deadlock avoided")
Verification_run_registry ok (2 rows)
```

## 이 레인이 실측 발생의 대부분입니다

로그의 EDEADLK 242건을 잡은 지점별로 분류하면:

| 잡은 곳 | 건수 |
|---|---|
| `Board attention worker raised unexpectedly` | 231 |
| `memory os librarian failed lane=librarian_exact` | 10 |
| FATAL unhandled (`Completion_authority_agent`) | 1 |

board attention worker 는 `Keeper_board_attention_exact_flow` 를 거쳐 **exact lane 레지스트리에 등록**합니다. 즉 #28391 은 1건짜리 FATAL 만 막았고, 231건은 계속 나고 있었습니다. worker 의 핸들러가 삼켜서 WARN 으로만 보였을 뿐입니다.

## 수정

코어와 동일한 변환입니다. critical section 이 durable JSONL append 에서 suspend 하므로, 대기 fiber 는 자기 스레드가 이미 쥔 pthread mutex 를 다시 잡는 대신 Eio gate 에서 yield 해야 합니다.

잠금 순서는 그대로 단방향입니다(observation → mutation). `Store` 가 이 wrapper 를 역호출하는 경로는 없습니다.

## 나머지 raw mutex 표면도 훑었습니다

같은 모양을 기계적으로 추려 27개 후보를 얻고 전부 읽었습니다. 나머지 25개는 잠금을 쥔 채 suspend 하지 않습니다.

| 후보 | 판정 |
|---|---|
| `keeper_transition_audit`, `keeper_tool_call_log` 의 `append_queue` | in-memory `Stdlib.Queue`. **이름이 매치된 것이지 동작이 아님** |
| `shared_audit/store.ml` | append lock 이 이미 `Cross_context_mutex`. 레지스트리 mutex 는 테이블 조회만 |
| `backend.ml` | 결정을 잠금 밖으로 빼서 promise 를 밖에서 await. 주석에 의도 명시 |
| `keeper_board_attention_partition` (5곳) | critical section 전체가 `run_in_systhread` 안. **재현 프로브로 확인 — 재현 안 됨** |
| `exec_tap.ml` | `Unix.write` 는 스레드를 블록할 뿐 스케줄러에 yield 하지 않음 |
| `sse.ml`, `safe_ops.ml`, `keeper_approval/audit.ml` | 버퍼/카운터/Hashtbl 조회 |

partition store 는 모양이 가장 비슷해서 논증 대신 프로브를 짜서 확인했습니다 (`ensure_roots` 두 fiber → 정상 완료).

## 검증

```
dune build --root . @check                                              # exit 0
dune build --root . @test/runtest-test_run_registry_concurrent_mutation # 5 tests, 0 failed
dune build --root . @test/runtest-test_exact_lane_run_registry \
  @test/runtest-test_verification_run_registry \
  @test/runtest-test_fusion_run_registry_persist                        # 9 + 12 + 9 통과
```

**이 트리에서 outer lock 만 되돌리면** 새 케이스 2건이 프로덕션과 같은 예외로 실패하고, 코어 케이스 3건은 그대로 통과합니다:

```
  [OK]    same-domain fibers            0  two registrations.
  [OK]    same-domain fibers            1  completion against registration.
  [OK]    same-domain fibers            2  both appends reach the log.
> [FAIL]  exact lane (own outer lock)   0  two registrations.
  [FAIL]  exact lane (own outer lock)   1  completion against registration.
[exception] Sys_error("Mutex.lock: Resource deadlock avoided")
```

**#28391 이 완료된 것처럼 보였던 이유가 정확히 이 그림입니다** — 코어 케이스만 있으면 초록입니다. 이제 스위트가 `Run_registry_core` 의 3개 인스턴스(verification / exact lane / fusion) 를 모두 덮습니다. CI 배선은 #28391 에서 이미 해둔 guard 스텝을 그대로 씁니다.
