### PR TITLE
fix(dashboard): default timeout + concurrency bound for cached computes (RFC-0372 Phase 3/4)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -636,6 +636,11 @@ let run_cmd host port cli_base_path =
      Dashboard_cache.now() reads from Time_compat directly. *)
   Time_compat.set_clock (Eio.Stdenv.clock env);
 
+  (* RFC-0372 Phase 3: register the clock with Dashboard_cache so every
+     [get_or_compute] runs under a timeout. Without this the 37 call sites that
+     do not pass a clock compute without any ceiling. *)
+  Dashboard_cache.set_default_clock (Eio.Stdenv.clock env);
+
   (* Wire Runtime_events listener. After masc#18567 removed dead
      [Http_server_eio.start] (the only prior production caller), this
      would have been silently uninitialized. Idempotent-safe per

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -637,6 +637,49 @@ let get_or_compute_with_timeout key ~ttl ~clock ~timeout_sec compute =
         record_timeout_circuit key;
         timeout_error_json ~waiting key timeout_sec
 
+(* RFC-0372 Phase 3 — make the timeout the default rather than the opt-in.
+
+   [get_or_compute_with_timeout] has existed for a while, but it requires an
+   Eio clock at the call site, so most callers reach for the plain
+   [get_or_compute]: at the time of writing 9 call sites take the timeout and
+   37 do not. Those 37 compute without any ceiling, which is how one dashboard
+   read can hold a domain indefinitely. Converting them one by one is the
+   N-of-M patch CLAUDE.md rejects; the ceiling belongs in the default.
+
+   The clock is registered once at boot ([set_default_clock] from main_eio),
+   after which every [get_or_compute] runs under a timeout without changing a
+   single call site. Before registration — unit tests, non-Eio contexts — the
+   original unbounded path still runs, so nothing that never had a clock
+   suddenly needs one.
+
+   Individual call sites that need a tighter ceiling keep calling
+   [get_or_compute_with_timeout] explicitly; this only removes "no ceiling at
+   all" as a reachable state in production. *)
+let default_clock : float Eio.Time.clock_ty Eio.Resource.t option Atomic.t =
+  Atomic.make None
+
+let set_default_clock clock =
+  Atomic.set default_clock
+    (Some (clock :> float Eio.Time.clock_ty Eio.Resource.t))
+
+let clear_default_clock_for_tests () = Atomic.set default_clock None
+
+(* Deliberately generous: this is a backstop against unbounded compute, not a
+   latency target. The measured worst case for the widest dashboard read was
+   ~12s before RFC-0372 Phase 1/2; surfaces that want a tighter bound pass
+   their own [timeout_sec]. *)
+let default_compute_timeout_sec = 30.0
+
+let get_or_compute_unbounded = get_or_compute
+
+let get_or_compute key ~ttl compute =
+  match Atomic.get default_clock with
+  | Some clock ->
+    get_or_compute_with_timeout key ~ttl ~clock
+      ~timeout_sec:default_compute_timeout_sec compute
+  | None -> get_or_compute_unbounded key ~ttl compute
+;;
+
 let seed_stale_if_missing key ~stale_for value =
   let ts = now () in
   atomic_update table (fun map ->

--- a/lib/dashboard/dashboard_cache.mli
+++ b/lib/dashboard/dashboard_cache.mli
@@ -47,6 +47,19 @@ val get_or_compute_with_timeout :
     timeouts for the same key open a short fail-fast circuit; fresh or stale
     cache entries are still served normally. *)
 
+val set_default_clock : _ Eio.Time.clock -> unit
+(** Register the process clock so every {!get_or_compute} runs under
+    {!default_compute_timeout_sec}. Called once at boot. Until it is called,
+    [get_or_compute] keeps its original unbounded behaviour, which is what unit
+    tests and non-Eio contexts rely on. *)
+
+val clear_default_clock_for_tests : unit -> unit
+
+val default_compute_timeout_sec : float
+(** Backstop ceiling applied by {!get_or_compute} once the clock is
+    registered. A surface needing a tighter bound calls
+    {!get_or_compute_with_timeout} with its own value. *)
+
 val seed_stale_if_missing :
   string -> stale_for:float -> Yojson.Safe.t -> unit
 (** [seed_stale_if_missing key ~stale_for value] inserts [value] as an


### PR DESCRIPTION
RFC-0372 Phase 3 (timeout) + Phase 4 (concurrency bound) (RFC #28390, harness #28386, Phase 1 #28392 merged, Phase 2 #28395).

## The gap

`Dashboard_cache.get_or_compute_with_timeout` has existed for a while. But it takes an Eio clock at the call site, so most callers reach for the plain `get_or_compute`:

| variant | call sites |
|---|---|
| `get_or_compute_with_timeout` (bounded) | **9** |
| `get_or_compute` (no ceiling) | **37** |

Those 37 compute with no ceiling at all. That is how one dashboard read holds a domain indefinitely — the safe API existed, but the **default was the unsafe one**.

## Why not convert the 37

That is the N-of-M patch CLAUDE.md rejects: same transformation applied site by site, no shared abstraction, and the next new surface still arrives unprotected. The ceiling belongs in the default.

## The change

Register the clock once at boot; after that every `get_or_compute` runs under a timeout **without touching a single call site**.

```ocaml
Dashboard_cache.set_default_clock (Eio.Stdenv.clock env);
```

Before registration — unit tests, non-Eio contexts — the original unbounded path still runs, so nothing that never had a clock suddenly needs one. Sites wanting a tighter bound keep calling `get_or_compute_with_timeout` with their own value. This only removes **"no ceiling at all"** as a reachable production state.

Default is 30s: a backstop against unbounded compute, not a latency target. The widest dashboard read measured ~12s before Phase 1/2 brought it under a second.

## Tests

- `test_dashboard_cache`: 28 pass.
- `request_cost_gate` (Mode C): GREEN, no regression — 0.365s, probe p95 1.0ms, clean baseline (1.0ms).
- `test_dashboard_http_core`: same 3 pre-existing failures as main (`executor_pool 14`, `context-window shrink guard 2/3`).

## Second commit — Phase 4: bound concurrent computes

A timeout bounds how long one compute holds resources. It does not bound how many run together, so peak heap was (concurrent misses × per-request cost) with no ceiling on the first factor.

A semaphore now wraps the uncached compute path, acquired **inside** `Eio.Time.with_timeout` so waiting for a slot is itself bounded — a queued request fails as a timeout rather than hanging. The two only work as a pair: a semaphore alone lets the queue grow without limit, a timeout alone leaves concurrency unbounded. Cache hits and stale-while-revalidate reads never reach this path.

Default 4 slots (`MASC_DASHBOARD_COMPUTE_SLOTS` to override).

### Measured — and it is smaller than it looks

8 concurrent uncached reads (distinct `offset` values, so distinct cache keys; same-key requests are already collapsed by stampede protection):

| | base | peak | delta |
|---|---|---|---|
| no semaphore | 190 MB | 802 MB | **612 MB** |
| 4 slots | 187 MB | 758 MB | **571 MB** |

**7%** — well short of the 4/8 the slot count might suggest. OCaml's GC does not return major heap promptly, so limiting concurrent execution does not lower accumulated heap proportionally: the first batch's heap is still resident when the next starts.

So what the semaphore bounds is **concurrent execution, not heap size**. Its value at higher concurrency — where unbounded execution would otherwise scale linearly — is not measured here; 8 was the widest case tried.

## What remains open

**Cancellation propagation.** A client disconnect still does not abort the in-flight compute. A timeout bounds how long an abandoned request holds resources; it does not release them when the client leaves. `post_abort_heap_growth_mb` in Mode C is the axis that will show it, and it stays open.

RFC-WAIVED: implements RFC-0372 Phase 3 (timeout half), cited above (#28390). Touches no subsystem in the RFC discovery list.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
