### PR TITLE
fix(dashboard): drop the two dead cache exports that tripped the ratchet

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -662,8 +662,6 @@ let set_default_clock clock =
   Atomic.set default_clock
     (Some (clock :> float Eio.Time.clock_ty Eio.Resource.t))
 
-let clear_default_clock_for_tests () = Atomic.set default_clock None
-
 (* Deliberately generous: this is a backstop against unbounded compute, not a
    latency target. The measured worst case for the widest dashboard read was
    ~12s before RFC-0372 Phase 1/2; surfaces that want a tighter bound pass

--- a/lib/dashboard/dashboard_cache.mli
+++ b/lib/dashboard/dashboard_cache.mli
@@ -48,17 +48,11 @@ val get_or_compute_with_timeout :
     cache entries are still served normally. *)
 
 val set_default_clock : _ Eio.Time.clock -> unit
-(** Register the process clock so every {!get_or_compute} runs under
-    {!default_compute_timeout_sec}. Called once at boot. Until it is called,
+(** Register the process clock so every {!get_or_compute} runs under the
+    default backstop timeout. Called once at boot. Until it is called,
     [get_or_compute] keeps its original unbounded behaviour, which is what unit
-    tests and non-Eio contexts rely on. *)
-
-val clear_default_clock_for_tests : unit -> unit
-
-val default_compute_timeout_sec : float
-(** Backstop ceiling applied by {!get_or_compute} once the clock is
-    registered. A surface needing a tighter bound calls
-    {!get_or_compute_with_timeout} with its own value. *)
+    tests and non-Eio contexts rely on. A surface needing a tighter bound
+    calls {!get_or_compute_with_timeout} with its own value. *)
 
 val seed_stale_if_missing :
   string -> stale_for:float -> Yojson.Safe.t -> unit


### PR DESCRIPTION
## main red 수리 — Meta Guards / dead-surface ratchet

main `b94e3fc9` 의 ci.yml run 31603949142 에서 Meta Guards 가 red 예요:

```
[dead-surface] FAIL - 550 dead exports, over the 548 baseline by 2.
```

+2 의 출처는 #28399 가 추가한 `dashboard_cache` 의 export 2개예요 (repo 전체 rg 로 실측):

| export | 호출자 | 처분 |
|---|---|---|
| `clear_default_clock_for_tests` | **0곳** (테스트 포함 어디에도 없음) | 전체 삭제 |
| `default_compute_timeout_sec` | dashboard_cache.ml 내부 1곳뿐 | .mli 노출만 제거, 내부 `let` 유지 |
| `set_default_clock` | bin/main_eio.ml:641 | 유지 (live) |

`clear_default_clock_for_tests` 는 #28399 리뷰(P2)와 #28400 에서 지적한 CLAUDE.md 체크리스트 6번(`reset_for_test` backdoor) 시그니처 그대로예요 — 쓰는 테스트가 함께 상륙하지 않았으니 숙청이 맞아요. default-timeout 경로를 검증하는 테스트가 나중에 들어올 때, 그 테스트와 함께 clear 헬퍼를 재도입하면 돼요 (#28400 에 기록됨).

## 검증

- clean worktree 에서 `python3 scripts/audit-dead-surface.py --exports --ratchet` → **`OK - 548 dead exports, at baseline`** (수리 전 동일 환경 550).
- 참고: repo 루트에서 돌리면 `_build` 오염으로 13 이 나와요 — CI 와 같은 결과는 clean tree 에서만 재현돼요.
- 이 파손은 merge-after 클래스(ratchet 이 main 에서만 실행)라 #28399 의 PR 체크에서는 보이지 않았어요. PR 체크의 red 는 전부 merge-concurrency cancellation 이었고요.

RFC-WAIVED: main-red 최소 수리 (dead export 2건 제거), RFC 대상 subsystem 미접촉.

연계: #28399 (원인), #28400 (P1 envelope/P2 테스트 gap 후속), #28320 (오전의 동일 ratchet 사건 — 549 지문), #28281/#28327 (merge-after 검사 구조 논의).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
