### PR TITLE
fix(fusion): deliver preset budgets, web tools and deadlines to the paths that ignored them

### DIFF
--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -55,6 +55,7 @@ let string_of_failure (f : Fusion_types.panel_failure) : string =
     "invalid_structured_response: " ^ detail
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid_max_output_tokens: %d" n
+  | Fusion_types.Invalid_timeout_s s -> Printf.sprintf "invalid_timeout_s: %g" s
 
 let string_of_decision (d : Fusion_types.judge_decision) : string =
   match d with

--- a/lib/fusion/fusion_agent_core.ml
+++ b/lib/fusion/fusion_agent_core.ml
@@ -77,6 +77,7 @@ let panel_failure_code (failure : Fusion_types.panel_failure) : string =
   | Fusion_types.Invalid_structured_response _ -> "invalid_structured_response"
   | Fusion_types.Empty_response _ -> "empty_response"
   | Fusion_types.Invalid_max_output_tokens _ -> "invalid_max_output_tokens"
+  | Fusion_types.Invalid_timeout_s _ -> "invalid_timeout_s"
 
 let panel_failure_detail ~runtime_id (failure : Fusion_types.panel_failure) : string =
   match failure with
@@ -87,6 +88,7 @@ let panel_failure_detail ~runtime_id (failure : Fusion_types.panel_failure) : st
   | Fusion_types.Empty_response detail -> detail
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid max_output_tokens %d" n
+  | Fusion_types.Invalid_timeout_s s -> Printf.sprintf "invalid timeout_s %g" s
 
 (* 이미 attribution된 실패를 재-attribution 없이 렌더한다. Provider_error의 detail은
    실패 시점(panel outcome_of_result / build_agent)에 provider_error_detail
@@ -103,6 +105,7 @@ let panel_failure_text (failure : Fusion_types.panel_failure) : string =
   | Fusion_types.Empty_response detail -> detail
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid max_output_tokens %d" n
+  | Fusion_types.Invalid_timeout_s s -> Printf.sprintf "invalid timeout_s %g" s
 
 (** [Keeper_tool_descriptor]에서 날것의 web tool descriptor를 찾아
     [Agent_core.Tool.t]로 변환한다. 패널/심판이 web_search/web_fetch를
@@ -141,6 +144,7 @@ let build_agent
     ~system_prompt
     ?(tools = [])
     ?max_tokens
+    ?timeout_s
     ?name
     ?provider_config_transform
     (model : string)
@@ -187,6 +191,23 @@ let build_agent
          | Some n when Fusion_policy.valid_max_output_tokens (Some n) ->
            Ok { base_config with max_tokens = Some n }
          | Some n -> Error (Fusion_types.Invalid_max_output_tokens n)
+       in
+       (* preset 데드라인은 [Runtime_agent.config.body_timeout_s]로 집행한다 —
+          AGENT_CORE가 이미 소유한 손잡이이며(Builder.with_body_timeout →
+          Complete.complete 비스트리밍 총 왕복 cap), provider의
+          [connect_timeout_s]와 달리 이름이 하는 일과 일치한다. provider config를
+          변형하지 않으므로 같은 런타임을 쓰는 다른 소비자(키퍼 턴 등)의 예산은
+          그대로다: override의 blast radius가 이 fusion 요청으로 한정된다.
+          [None]이면 base_config를 그대로 둬 런타임/provider 선언이 유일한 값으로
+          남는다. 유효성은 policy가 로드 시 이미 판정했지만, 직접 호출도 있으므로
+          여기서도 닫아 잘못된 데드라인이 조용히 무시되지 않게 한다. *)
+       let config =
+         match config, timeout_s with
+         | (Error _ as err), _ -> err
+         | Ok config, None -> Ok config
+         | Ok config, Some s when Fusion_policy.valid_timeout_s (Some s) ->
+           Ok { config with body_timeout_s = Some s }
+         | Ok _, Some s -> Error (Fusion_types.Invalid_timeout_s s)
        in
        match config with
        | Error _ as err -> err

--- a/lib/fusion/fusion_agent_core.mli
+++ b/lib/fusion/fusion_agent_core.mli
@@ -26,6 +26,13 @@ val build_agent
   -> system_prompt:string
   -> ?tools:Agent_core.Tool.t list
   -> ?max_tokens:int
+  -> ?timeout_s:float
+       (** Response deadline in seconds, enforced as the agent's
+           [body_timeout_s] (AGENT_CORE's total non-streaming round-trip cap).
+           Omitted leaves whatever the runtime/provider already declares — this
+           is a per-request override, not a second source of truth. A
+           non-positive or non-finite value fails with
+           [Invalid_timeout_s] rather than being dropped. *)
   -> ?name:string
   -> ?provider_config_transform:
        (Llm_provider.Provider_config.t

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -171,7 +171,7 @@ let apply_fusion_judge_output_contract provider_cfg =
    에러도 usage를 동반한다: 토큰을 태운 뒤 실패(빈 응답/파싱 실패)는 소비분을, 토큰
    소비 전 실패(빌드/실행/빈 결과/provider 에러)는 [zero_usage]를 싣는다. 호출자는
    실패 경로에서도 비용을 회계할 수 있다. *)
-let run_composed ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model
+let run_composed ~sw ~net ?max_tokens ?timeout_s ~judge_system_prompt ~judge_model
     ~web_tools ~prompt () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
@@ -179,7 +179,7 @@ let run_composed ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model
   let tools = if web_tools then Fusion_agent_core.web_tool_bundle () else [] in
   match
     Fusion_agent_core.build_agent ~sw ~net ~system_prompt:judge_system_prompt ~tools
-      ?max_tokens
+      ?max_tokens ?timeout_s
       ~provider_config_transform:apply_fusion_judge_output_contract
       judge_model
   with
@@ -216,29 +216,29 @@ let run_composed ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model
              ~prefix:"judge provider error: " e
          , Fusion_types.zero_usage ))
 
-let run ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~question
+let run ~sw ~net ?max_tokens ?timeout_s ~judge_system_prompt ~judge_model ~question
     ~panel ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
-    ~prompt:(compose_prompt ~question ~panel) ()
+  run_composed ~sw ~net ?max_tokens ?timeout_s ~judge_system_prompt ~judge_model
+    ~web_tools ~prompt:(compose_prompt ~question ~panel) ()
 
-let run_refine ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~question
-    ~panel ~prior ~web_tools () :
+let run_refine ~sw ~net ?max_tokens ?timeout_s ~judge_system_prompt ~judge_model
+    ~question ~panel ~prior ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
-    ~prompt:(compose_refine_prompt ~question ~panel ~prior) ()
+  run_composed ~sw ~net ?max_tokens ?timeout_s ~judge_system_prompt ~judge_model
+    ~web_tools ~prompt:(compose_refine_prompt ~question ~panel ~prior) ()
 
-let run_meta ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~question
-    ~panel ~priors ~web_tools () :
+let run_meta ~sw ~net ?max_tokens ?timeout_s ~judge_system_prompt ~judge_model
+    ~question ~panel ~priors ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
-    ~prompt:(compose_meta_prompt ~question ~panel ~priors) ()
+  run_composed ~sw ~net ?max_tokens ?timeout_s ~judge_system_prompt ~judge_model
+    ~web_tools ~prompt:(compose_meta_prompt ~question ~panel ~priors) ()
 
 module For_testing = struct
   let apply_output_contract = apply_fusion_judge_output_contract

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -43,8 +43,11 @@ val compose_prompt : question:string -> panel:Fusion_types.panel_outcome list ->
     {!Fusion_judge_parse.of_string}으로 파싱한다.
     [web_tools=true]면 심판 에이전트에 web_search/web_fetch를 주입한다.
     [max_tokens]는 출력 토큰 예산이다. 생략하면 Runtime_agent 기본값을 보존한다.
+    [timeout_s]는 응답 데드라인(초)이며 에이전트의 [body_timeout_s]로 집행된다.
+    생략하면 Provider transport가 선언한 값이 그대로 유일한 데드라인으로 남는다 —
+    preset은 그 위에 얹는 요청 단위 override지 두 번째 SSOT가 아니다.
     빌드/실행/빈응답/파싱 실패는 [Error (msg, usage)]. [Masc_agent_core_bridge.run_safe]는
-    예외/취소만 관측하며 Provider transport가 timeout을 소유한다. 성공 시 종합 + 소비
+    예외/취소만 관측한다. 성공 시 종합 + 소비
     토큰 [usage]를 반환하고(panel과 대칭, 비용 회계 RFC §10),
     실패 시에도 usage를 동반한다 — 응답을 받은 뒤 실패(빈 응답/파싱 실패)는 소비분을,
     토큰 소비 전 실패(빌드/실행/provider 에러)는 [Fusion_types.zero_usage]를 싣는다. 이로써
@@ -53,6 +56,7 @@ val run
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?max_tokens:int
+  -> ?timeout_s:float
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string
@@ -82,6 +86,7 @@ val run_refine
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?max_tokens:int
+  -> ?timeout_s:float
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string
@@ -121,6 +126,7 @@ val run_meta
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?max_tokens:int
+  -> ?timeout_s:float
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string

--- a/lib/fusion/fusion_official_client.ml
+++ b/lib/fusion/fusion_official_client.ml
@@ -75,11 +75,20 @@ let eio_context ~runtime_id =
    panelist runs the same client the keeper would, minus the parts a panelist
    has no business using. *)
 
-let resolved_timeout_s ~runtime_id ~default_timeout_s =
-  match Runtime_inference.resolve_turn_timeout_s ~runtime_id with
-  | None -> Some default_timeout_s
-  | Some seconds when seconds <= 0.0 -> None
-  | Some seconds -> Some seconds
+(* 데드라인 우선순위: preset 그룹의 [panel_timeout_s]([override_s]) > 런타임이 추론한
+   turn timeout > 어댑터 admission timeout. preset 이 가장 강한 이유는 그것이 이
+   요청에 대한 소비자의 명시 선언이기 때문이다 — 런타임 값은 모든 소비자가 공유하는
+   기본값이라, preset 이 그것을 이기지 못하면 "이 심의는 240s 까지 기다린다" 를
+   표현할 방법이 없다. [override_s] 는 [Fusion_policy.valid_timeout_s] 를 통과한
+   값만 들어온다(config 로드에서 판정). *)
+let resolved_timeout_s ~runtime_id ~override_s ~default_timeout_s =
+  match override_s with
+  | Some _ as declared -> declared
+  | None ->
+    (match Runtime_inference.resolve_turn_timeout_s ~runtime_id with
+     | None -> Some default_timeout_s
+     | Some seconds when seconds <= 0.0 -> None
+     | Some seconds -> Some seconds)
 ;;
 
 let bounded_claude_probe_config ~fallback_timeout_s
@@ -90,7 +99,7 @@ let bounded_claude_probe_config ~fallback_timeout_s
   | None -> { config with timeout_s = Some fallback_timeout_s }
 ;;
 
-let claude_config ~base_dir ~runtime_id ~system_prompt
+let claude_config ~base_dir ~runtime_id ~system_prompt ~override_s
   (execution : Runtime_execution.claude_code)
   : Runtime_claude_code.config
   =
@@ -99,11 +108,12 @@ let claude_config ~base_dir ~runtime_id ~system_prompt
   ; model = execution.model
   ; system_prompt
   ; admission_timeout_s = execution.timeout_s
-  ; timeout_s = resolved_timeout_s ~runtime_id ~default_timeout_s:execution.timeout_s
+  ; timeout_s =
+      resolved_timeout_s ~runtime_id ~override_s ~default_timeout_s:execution.timeout_s
   }
 ;;
 
-let codex_config ~runtime_id ~system_prompt
+let codex_config ~runtime_id ~system_prompt ~override_s
   (execution : Runtime_execution.codex_app_server)
   : Runtime_codex_app_server.config
   =
@@ -111,11 +121,12 @@ let codex_config ~runtime_id ~system_prompt
   ; model = execution.model
   ; developer_instructions = system_prompt
   ; admission_timeout_s = execution.timeout_s
-  ; timeout_s = resolved_timeout_s ~runtime_id ~default_timeout_s:execution.timeout_s
+  ; timeout_s =
+      resolved_timeout_s ~runtime_id ~override_s ~default_timeout_s:execution.timeout_s
   }
 ;;
 
-let antigravity_config ~base_dir ~runtime_id
+let antigravity_config ~base_dir ~runtime_id ~override_s
   (execution : Runtime_execution.antigravity_cli)
   : Runtime_antigravity.config
   =
@@ -132,11 +143,12 @@ let antigravity_config ~base_dir ~runtime_id
   ; sandbox = true
   ; disable_slash_commands = true
   ; admission_timeout_s = execution.timeout_s
-  ; timeout_s = resolved_timeout_s ~runtime_id ~default_timeout_s:execution.timeout_s
+  ; timeout_s =
+      resolved_timeout_s ~runtime_id ~override_s ~default_timeout_s:execution.timeout_s
   }
 ;;
 
-let run_panelist ~base_dir ~runtime_id ~system_prompt ~prompt =
+let run_panelist ~base_dir ~runtime_id ~system_prompt ?timeout_s ~prompt () =
   let ( let* ) = Result.bind in
   (* Both adapters take the system prompt as an option and treat [None] as
      "client default". An empty group prompt is not an instruction, so it
@@ -162,7 +174,9 @@ let run_panelist ~base_dir ~runtime_id ~system_prompt ~prompt =
          ~runtime_id
          "runtime is Agent_core-owned; it belongs on the Async_agent path")
   | Runtime_execution.Claude_code execution ->
-    let config = claude_config ~base_dir ~runtime_id ~system_prompt execution in
+    let config =
+      claude_config ~base_dir ~runtime_id ~system_prompt ~override_s:timeout_s execution
+    in
     let probe_config =
       bounded_claude_probe_config
         ~fallback_timeout_s:execution.timeout_s
@@ -194,14 +208,14 @@ let run_panelist ~base_dir ~runtime_id ~system_prompt ~prompt =
                ~runtime_id
                (Runtime_claude_code.error_to_string error))))
   | Runtime_execution.Codex_app_server execution ->
-    let config = codex_config ~runtime_id ~system_prompt execution in
+    let config = codex_config ~runtime_id ~system_prompt ~override_s:timeout_s execution in
     (match Runtime_codex_app_server.run_turn ~mgr ~clock ~cwd config ~prompt with
      | Ok (result : Runtime_codex_app_server.turn_result) -> Ok result.text
      | Error error ->
        Error
          (provider_error ~runtime_id (Runtime_codex_app_server.error_to_string error)))
   | Runtime_execution.Antigravity_cli execution ->
-    let config = antigravity_config ~base_dir ~runtime_id execution in
+    let config = antigravity_config ~base_dir ~runtime_id ~override_s:timeout_s execution in
     (* [home_dir] is left unset so the client uses the inherited HOME, which is
        where its OAuth token already lives. The keeper path overrides it for
        per-keeper isolation; a panelist has no durable state to isolate. *)

--- a/lib/fusion/fusion_official_client.mli
+++ b/lib/fusion/fusion_official_client.mli
@@ -24,10 +24,13 @@ module For_testing : sig
 
   val resolved_timeout_s
     :  runtime_id:string
+    -> override_s:float option
     -> default_timeout_s:float
     -> float option
   (** Resolve the same declared turn timeout used by each official-client
-      panel adapter. [turn-timeout-s = 0] produces [None]. *)
+      panel adapter. [override_s] (the preset group's declared deadline) wins
+      when present; otherwise the runtime's inferred turn timeout applies and
+      [turn-timeout-s = 0] produces [None]. *)
 
   val bounded_claude_probe_config
     :  fallback_timeout_s:float
@@ -41,9 +44,18 @@ val run_panelist
   :  base_dir:string
   -> runtime_id:string
   -> system_prompt:string
+  -> ?timeout_s:float
   -> prompt:string
+  -> unit
   -> (string, Fusion_types.panel_failure) result
 (** Execute [prompt] as a single turn on [runtime_id] and return the answer text.
+
+    [timeout_s] is the preset group's declared deadline. When present it wins
+    over the runtime-inferred turn timeout, because it is this request's
+    explicit statement while the runtime value is a default shared by every
+    consumer of that runtime. When absent the adapter resolves its own deadline
+    exactly as before. It does not move [admission_timeout_s], which bounds
+    waiting for admission rather than the answer.
 
     [base_dir] is the directory the official client is spawned in. There is no
     global accessor for the MASC base path, so callers thread it down from

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -37,6 +37,7 @@ let compute ~base_dir ~sw ~net ~policy ~topology ~request () : compute_outcome =
           let run_single_judge () =
             Fusion_judge.run ~sw ~net
               ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+              ?timeout_s:preset.Fusion_policy.judge_timeout_s
               ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
               ~judge_model:preset.Fusion_policy.judge
               ~question:req.Fusion_types.prompt ~panel ~web_tools:judge_web_tools ()
@@ -49,6 +50,7 @@ let compute ~base_dir ~sw ~net ~policy ~topology ~request () : compute_outcome =
             match
               Fusion_judge.run_refine ~sw ~net
                 ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+                ?timeout_s:preset.Fusion_policy.judge_timeout_s
                 ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                 ~judge_model:preset.Fusion_policy.judge
                 ~question:req.Fusion_types.prompt ~panel ~prior:s1
@@ -132,6 +134,7 @@ let compute ~base_dir ~sw ~net ~policy ~topology ~request () : compute_outcome =
                  (match
                     Fusion_judge.run_meta ~sw ~net
                       ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+                      ?timeout_s:preset.Fusion_policy.judge_timeout_s
                       ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                       ~judge_model:preset.Fusion_policy.judge
                       ~question:req.Fusion_types.prompt ~panel ~priors
@@ -213,6 +216,7 @@ let compute ~base_dir ~sw ~net ~policy ~topology ~request () : compute_outcome =
                   (match
                      Fusion_judge.run_meta ~sw ~net
                        ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+                       ?timeout_s:preset.Fusion_policy.judge_timeout_s
                        ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                        ~judge_model:preset.Fusion_policy.judge
                        ~question:req.Fusion_types.prompt ~panel ~priors
@@ -265,6 +269,7 @@ let compute ~base_dir ~sw ~net ~policy ~topology ~request () : compute_outcome =
                  (match
                     Fusion_judge.run_meta ~sw ~net
                       ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+                      ?timeout_s:preset.Fusion_policy.judge_timeout_s
                       ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                       ~judge_model:preset.Fusion_policy.judge
                       ~question:req.Fusion_types.prompt ~panel ~priors

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -5,7 +5,6 @@ type judge_run =
     , Fusion_types.judge_failure * Fusion_types.usage )
     result
   * float option
-  * bool
 
 type clock =
   { now_opt : unit -> float option
@@ -32,6 +31,26 @@ let elapsed_since_t0 clock =
   | _ -> None
 ;;
 
+(* 1차 심판의 출력 토큰 예산. per-judge [max_output_tokens]가 있으면 그것이,
+   없으면 preset의 [judge_max_output_tokens]가 적용된다 — meta/refine 심판이 쓰는
+   예산과 같은 값으로 폴백한다. 이전에는 둘 다 전달되지 않아 1차 심판만 런타임
+   기본값으로 돌았고, [judge_spec.jmax_output_tokens]는 파싱·검증·직렬화까지 되면서
+   실행 경로 소비자가 없는 미배선 필드였다. *)
+let first_judge_max_tokens ~(preset : Fusion_policy.preset) (j : Fusion_policy.judge_spec) =
+  match j.jmax_output_tokens with
+  | Some _ as budget -> budget
+  | None -> preset.judge_max_output_tokens
+;;
+
+(* 1차 심판의 web tool 주입 여부. [judge_web_tools]는 요청의 web_tools와 패널 그룹
+   설정에서 derive된 값([Fusion_policy.judge_web_tools_of])이고 [jweb_tools]는 이
+   1차 심판 고유 설정이다. 합집합이 옳은 이유: single/refine/meta 심판은 전부
+   [judge_web_tools]를 받으므로, 1차 심판만 그것을 무시하면 같은 요청 안에서
+   심판 축마다 도구 표면이 달라진다. 순수 — 테스트 가능. *)
+let first_judge_web_tools ~judge_web_tools (j : Fusion_policy.judge_spec) =
+  judge_web_tools || j.jweb_tools
+;;
+
 let run_first_judge
       ~sw
       ~net
@@ -40,30 +59,24 @@ let run_first_judge
       ~question
       ~clock
       ~judge_web_tools
-      ~already_timed_out
       (j : Fusion_policy.judge_spec)
   : judge_run
   =
   let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
-  let _ = preset, judge_web_tools, already_timed_out in
   let result =
     Fusion_judge.run
       ~sw
       ~net
+      ?max_tokens:(first_judge_max_tokens ~preset j)
       ~judge_system_prompt:j.jsystem_prompt
       ~judge_model:j.jmodel
       ~question
       ~panel
-      ~web_tools:j.jweb_tools
+      ~web_tools:(first_judge_web_tools ~judge_web_tools j)
       ()
   in
   let elapsed_s = elapsed_since_t0 clock in
-  let timed_out =
-    match result with
-    | Error (f, _) -> Fusion_types.judge_failure_is_timeout f
-    | Ok _ -> false
-  in
-  j, id, result, elapsed_s, timed_out
+  j, id, result, elapsed_s
 ;;
 
 let run_first_judges
@@ -86,14 +99,12 @@ let run_first_judges
       ~clock
       ~judge_web_tools
   in
-  Eio.Fiber.List.map
-    (run_first_judge ~already_timed_out:false)
-    judges
+  Eio.Fiber.List.map run_first_judge judges
 ;;
 
 let first_judge_nodes runs =
   List.map
-    (fun (_, id, result, elapsed_s, _timed_out) ->
+    (fun (_, id, result, elapsed_s) ->
        match result with
        | Ok (s, u) ->
          Fusion_types.Synthesized { Fusion_types.role = First id; synthesis = s; usage = u }
@@ -105,7 +116,7 @@ let first_judge_nodes runs =
 
 let successful_syntheses runs =
   List.filter_map
-    (fun (_, id, result, _, _) ->
+    (fun (_, id, result, _) ->
        match result with
        | Ok (s, u) -> Some (id, s, u)
        | Error _ -> None)
@@ -122,11 +133,11 @@ let successful_pair_syntheses pairs =
 ;;
 
 let firsts_usage runs =
-  Fusion_types.sum_all_usage (List.map (fun (_, id, result, _, _) -> id, result) runs)
+  Fusion_types.sum_all_usage (List.map (fun (_, id, result, _) -> id, result) runs)
 ;;
 
 let all_fail_error_of_runs ~fallback runs =
   Fusion_types.all_fail_error
     ~fallback
-    (List.map (fun (_, id, result, _, _) -> id, result) runs)
+    (List.map (fun (_, id, result, _) -> id, result) runs)
 ;;

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -51,6 +51,15 @@ let first_judge_web_tools ~judge_web_tools (j : Fusion_policy.judge_spec) =
   judge_web_tools || j.jweb_tools
 ;;
 
+(* 1차 심판의 응답 데드라인. [jmax_output_tokens]와 같은 우선순위 규칙이다:
+   자기 선언이 있으면 그것, 없으면 preset의 심판 데드라인. 1차 심판들은 서로 다른
+   모델일 수 있어(lens마다 다른 런타임) 속도 분포도 다르므로 per-judge 축이 있다. *)
+let first_judge_timeout_s ~(preset : Fusion_policy.preset) (j : Fusion_policy.judge_spec) =
+  match j.jtimeout_s with
+  | Some _ as deadline -> deadline
+  | None -> preset.judge_timeout_s
+;;
+
 let run_first_judge
       ~sw
       ~net
@@ -68,6 +77,7 @@ let run_first_judge
       ~sw
       ~net
       ?max_tokens:(first_judge_max_tokens ~preset j)
+      ?timeout_s:(first_judge_timeout_s ~preset j)
       ~judge_system_prompt:j.jsystem_prompt
       ~judge_model:j.jmodel
       ~question

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -41,6 +41,13 @@ val first_judge_web_tools
   -> Fusion_policy.judge_spec
   -> bool
 
+(** Response deadline for one first-pass judge: its own [jtimeout_s] when set,
+    otherwise the preset's [judge_timeout_s]. Pure. *)
+val first_judge_timeout_s
+  :  preset:Fusion_policy.preset
+  -> Fusion_policy.judge_spec
+  -> float option
+
 (** Run every first-pass judge concurrently over the same panel.
 
     [judge_web_tools] is the request/panel-derived setting

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -1,5 +1,10 @@
 (** Judge wave helpers for {!Fusion_orchestrator}. *)
 
+(** One first-pass judge run: its spec, derived identity, result, and elapsed
+    seconds since the wave clock started. Timeout classification is not carried
+    here — {!Fusion_types.judge_failure_is_timeout} derives it from the typed
+    failure wherever it is needed (the sink does exactly that), so a second
+    boolean copy would be a duplicate of the same fact. *)
 type judge_run =
   Fusion_policy.judge_spec
   * string
@@ -7,7 +12,6 @@ type judge_run =
     , Fusion_types.judge_failure * Fusion_types.usage )
     result
   * float option
-  * bool
 
 type clock
 
@@ -21,6 +25,31 @@ val make_runtime_clock : unit -> clock
 
 val elapsed_since_t0 : clock -> float option
 
+(** Output-token budget for one first-pass judge: its own [jmax_output_tokens]
+    when set, otherwise the preset's [judge_max_output_tokens] (the budget the
+    single/refine/meta judges already use). Pure. *)
+val first_judge_max_tokens
+  :  preset:Fusion_policy.preset
+  -> Fusion_policy.judge_spec
+  -> int option
+
+(** Whether one first-pass judge gets web tools: the union of the
+    request/panel-derived [judge_web_tools] and the judge's own [jweb_tools].
+    Pure. *)
+val first_judge_web_tools
+  :  judge_web_tools:bool
+  -> Fusion_policy.judge_spec
+  -> bool
+
+(** Run every first-pass judge concurrently over the same panel.
+
+    [judge_web_tools] is the request/panel-derived setting
+    ({!Fusion_policy.judge_web_tools_of}); each judge's own [jweb_tools] is
+    unioned with it, so a request that asks for web tools reaches the first
+    judges exactly as it reaches the single and meta judges.
+
+    Output budget per judge is the judge's own [jmax_output_tokens] when set,
+    otherwise the preset's [judge_max_output_tokens]. *)
 val run_first_judges
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -87,12 +87,13 @@ let run ~base_dir ~sw ~net ~groups ~prompt ()
                [Panels_unavailable], 섞이면 정족수로 완료되면서 그 자리는 조용히
                비었다. 여기서 갈라 별도 실행 경로로 보낸다. *)
             if Fusion_official_client.is_official_client ~runtime_id:model
-            then (oks, (panelist, model, g.system_prompt) :: officials, fails)
+            then (oks, (panelist, model, g.system_prompt, g.timeout_s) :: officials, fails)
             else (
               match
                 Fusion_agent_core.build_agent ~sw ~net ~system_prompt:g.system_prompt
                   ~tools
                   ?max_tokens:g.max_output_tokens
+                  ?timeout_s:g.timeout_s
                   ~name:panelist model
               with
               | Ok agent -> ((agent, panelist, model) :: oks, officials, fails)
@@ -135,18 +136,19 @@ let run ~base_dir ~sw ~net ~groups ~prompt ()
           Fusion_types.Failed { failed_model = panelist; reason })
         built
   in
-  (* official-client 패널리스트는 Agent_core fan-out 과 동시에 돈다. 각 어댑터가
-     자기 timeout 을 소유하므로 여기서 두 번째 데드라인을 걸지 않는다 —
-     [Async_agent.all] 쪽과 같은 규약이다.
+  (* official-client 패널리스트는 Agent_core fan-out 과 동시에 돈다. 데드라인은
+     그룹의 [timeout_s] 가 있으면 그것이, 없으면 어댑터가 소유한 turn timeout 이
+     쓰인다 — Agent_core 축이 [body_timeout_s] 를 override 하는 것과 같은 규약이며,
+     두 축 모두 preset 이 선언하지 않으면 런타임 설정이 유일한 값으로 남는다.
 
      usage 는 [zero_usage] 다. 공식 클라이언트는 토큰 회계를 돌려주지 않으므로,
      추정치를 지어내는 대신 "측정하지 않음" 을 0 으로 남긴다. *)
   let official_answered =
     Eio.Fiber.List.map
-      (fun (panelist, model, system_prompt) ->
+      (fun (panelist, model, system_prompt, timeout_s) ->
         match
           Fusion_official_client.run_panelist ~base_dir ~runtime_id:model ~system_prompt
-            ~prompt
+            ?timeout_s ~prompt ()
         with
         | Error reason -> Fusion_types.Failed { failed_model = panelist; reason }
         | Ok text ->

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -11,6 +11,9 @@ type config_error =
   | Missing_judge_model of string
   | Invalid_staged_judge_group_size of int
   | Invalid_max_output_tokens of string * int
+  | Invalid_timeout_s of string * float
+      (** (preset 이름, 데드라인): 유한 양수가 아닌 panel_timeout_s/judge_timeout_s/
+          1차 심판 timeout_s *)
   | Missing_default_preset of string
   | Judge_panel_prompt_missing of string  (** preset 이름; JOJ 1차 심판 prompt 누락 (RFC-0283) *)
   | Duplicate_judge of string * string  (** (preset 이름, 중복 judge 정체성) (RFC-0283) *)
@@ -26,6 +29,12 @@ let disabled : Fusion_policy.t =
   ; presets = []
   }
 
+(* 데드라인 키는 [~strict:false]로 읽는다. TOML에서 [120]과 [120.0]은 타입이
+   다르지만 운영자 의도는 같은 초 값이고, 정수를 쓴 preset이 Toml_type_error로
+   로드 전체를 깨뜨릴 이유가 없다. 값 자체의 유효성(유한 양수)은 여기서 판정하지
+   않고 [Fusion_policy.valid_timeout_s] 한 곳이 진다 — 검증 SSOT는 policy다. *)
+let find_timeout_s tbl path = Otoml.find_opt tbl (Otoml.get_float ~strict:false) path
+
 (* 패널 그룹 한 개 파싱. 그룹 sub-table(새 [[...panels]] 문법)에도, preset table
    자체(legacy flat 문법의 desugar)에도 동일하게 적용된다 — 두 문법이 같은 키
    이름(panel/label/panel_system_prompt/web_tools)을
@@ -40,6 +49,7 @@ let parse_group (tbl : Otoml.t) : Fusion_policy.panel_group =
   ; web_tools = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "web_tools" ]
   ; max_output_tokens =
       Otoml.find_opt tbl Otoml.get_integer [ "max_output_tokens_per_panel" ]
+  ; timeout_s = find_timeout_s tbl [ "panel_timeout_s" ]
   }
 
 (* JOJ 1차 심판 한 명 파싱 (RFC-0283). [[fusion.presets.NAME.judges]] sub-table의
@@ -53,6 +63,7 @@ let parse_judge_spec (tbl : Otoml.t) : Fusion_policy.judge_spec =
       Otoml.find_or ~default:"" tbl Otoml.get_string [ "system_prompt" ]
   ; jweb_tools = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "web_tools" ]
   ; jmax_output_tokens = Otoml.find_opt tbl Otoml.get_integer [ "max_output_tokens" ]
+  ; jtimeout_s = find_timeout_s tbl [ "timeout_s" ]
   }
 
 let parse_min_answered _name tbl =
@@ -75,6 +86,7 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
   let judge_max_output_tokens =
     Otoml.find_opt tbl Otoml.get_integer [ "judge_max_output_tokens" ]
   in
+  let judge_timeout_s = find_timeout_s tbl [ "judge_timeout_s" ] in
   let judges =
     match Otoml.find_opt tbl (Otoml.get_array Otoml.get_value) [ "judges" ] with
     | Some entries -> List.map parse_judge_spec entries
@@ -92,6 +104,7 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
       ; judge
       ; judge_system_prompt
       ; judge_max_output_tokens
+      ; judge_timeout_s
       ; judges
       ; min_answered
       ; fallback_judge_model
@@ -113,6 +126,7 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
            Duplicate_panelist (name, id)
          | Fusion_policy.Validated_preset.Bad_max_output_tokens v ->
            Invalid_max_output_tokens (name, v)
+         | Fusion_policy.Validated_preset.Bad_timeout_s v -> Invalid_timeout_s (name, v)
          | Fusion_policy.Validated_preset.Judge_panel_prompt_missing ->
            Judge_panel_prompt_missing name
          | Fusion_policy.Validated_preset.Duplicate_judge id ->

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -26,6 +26,9 @@ type config_error =
   | Invalid_staged_judge_group_size of int
       (** staged_judge_group_size < Fusion_policy.min_staged_judge_group_size *)
   | Invalid_max_output_tokens of string * int
+  | Invalid_timeout_s of string * float
+      (** (preset 이름, 데드라인): panel_timeout_s / judge_timeout_s / 1차 심판
+          timeout_s 가 유한 양수가 아님. *)
       (** (preset 이름, 값) — max_output_tokens override는 양수여야 함 *)
   | Missing_default_preset of string
       (** enabled인데 default_preset가 비었거나 presets에 없음. 빈 문자엏도 거부 —

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -16,6 +16,10 @@ let opt_string : string option -> Yojson.Safe.t = function
   | None -> `Null
   | Some s -> `String s
 
+let opt_float : float option -> Yojson.Safe.t = function
+  | None -> `Null
+  | Some s -> `Float s
+
 let panel_group_to_yojson (g : Fusion_policy.panel_group) : Yojson.Safe.t =
   `Assoc
     [ ( "models"
@@ -24,6 +28,7 @@ let panel_group_to_yojson (g : Fusion_policy.panel_group) : Yojson.Safe.t =
     ; ("system_prompt", `String g.Fusion_policy.system_prompt)
     ; ("web_tools", `Bool g.Fusion_policy.web_tools)
     ; ("max_output_tokens", opt_int g.Fusion_policy.max_output_tokens)
+    ; ("timeout_s", opt_float g.Fusion_policy.timeout_s)
     ]
 
 (* Judge fields are prefixed [j*] in the record; the JSON drops the prefix so the
@@ -35,6 +40,7 @@ let judge_spec_to_yojson (j : Fusion_policy.judge_spec) : Yojson.Safe.t =
     ; ("system_prompt", `String j.Fusion_policy.jsystem_prompt)
     ; ("web_tools", `Bool j.Fusion_policy.jweb_tools)
     ; ("max_output_tokens", opt_int j.Fusion_policy.jmax_output_tokens)
+    ; ("timeout_s", opt_float j.Fusion_policy.jtimeout_s)
     ]
 
 let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
@@ -44,6 +50,7 @@ let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
     ; ("judge", `String p.Fusion_policy.judge)
     ; ("judge_system_prompt", `String p.Fusion_policy.judge_system_prompt)
     ; ("judge_max_output_tokens", opt_int p.Fusion_policy.judge_max_output_tokens)
+    ; ("judge_timeout_s", opt_float p.Fusion_policy.judge_timeout_s)
     ; ("judges", `List (List.map judge_spec_to_yojson p.Fusion_policy.judges))
     ; ("min_answered", `Int p.Fusion_policy.min_answered)
     ; ("fallback_judge_model", opt_string p.Fusion_policy.fallback_judge_model)

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -14,6 +14,9 @@ type panel_group =
   ; system_prompt : string  (** 그룹 패널 모델 system prompt (config 필수) *)
   ; web_tools : bool  (** 그룹에 web_search/web_fetch 주입 여부 *)
   ; max_output_tokens : int option  (** 그룹 모델당 출력 토큰 예산 override *)
+  ; timeout_s : float option
+      (** 그룹 모델당 응답 데드라인(초). [None]이면 런타임/provider 설정이 그대로
+          적용된다 — preset은 그 위에 얹는 소비자 override지 두 번째 SSOT가 아니다. *)
   }
 [@@deriving show, eq]
 
@@ -26,6 +29,8 @@ type judge_spec =
   ; jsystem_prompt : string  (** 이 1차 심판의 lens (config 필수) *)
   ; jweb_tools : bool  (** web_search/web_fetch 주입 여부 *)
   ; jmax_output_tokens : int option  (** 출력 토큰 예산 override *)
+  ; jtimeout_s : float option
+      (** 이 1차 심판의 응답 데드라인(초). [None]이면 preset의 [judge_timeout_s]. *)
   }
 [@@deriving show, eq]
 
@@ -36,6 +41,9 @@ type preset =
       (** simple/refine/conditional 심판이자 JOJ의 meta-judge(reducer). (RFC-0283) *)
   ; judge_system_prompt : string
   ; judge_max_output_tokens : int option
+  ; judge_timeout_s : float option
+      (** 심판(single/refine/meta/stage-meta 및 [jtimeout_s] 없는 1차 심판)의 응답
+          데드라인(초). [None]이면 런타임/provider 설정. *)
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
@@ -54,6 +62,14 @@ let default_staged_judge_group_size = 3
 let valid_max_output_tokens = function
   | None -> true
   | Some n -> n > 0
+
+(* 데드라인은 양수여야 한다. 0/음수는 "즉시 만료" 또는 "무한"으로 해석이 갈리는
+   값이라 로드 단계에서 거부한다 — 해석을 코드가 임의로 고르면 운영자가 의도한
+   예산과 집행되는 예산이 갈라진다. NaN/infinity도 같은 이유로 거부한다
+   (Float.is_finite). "제한 없음"의 표현은 키 생략([None])이다. *)
+let valid_timeout_s = function
+  | None -> true
+  | Some s -> Float.is_finite s && s > 0.0
 
 (* 모든 그룹의 모델을 평탄화 — 그룹순 × 그룹내 모델순 보존 (패널 fan-out 순서와 동일). *)
 let preset_models (p : preset) =
@@ -141,6 +157,17 @@ let preset_judge_prompts_present (p : preset) =
     (fun (j : judge_spec) -> String.length (String.trim j.jsystem_prompt) > 0)
     p.judges
 
+(* preset 전체(패널 그룹 · 심판 · 1차 심판)의 데드라인 중 유효하지 않은 첫 값.
+   세 축을 한 술어로 모으는 이유는 검증 순서가 아니라 누락 방지다: 축이 늘어날 때
+   호출처가 아니라 이 함수만 고치면 되고, 어느 축을 빼먹었는지가 한 곳에서 보인다. *)
+let preset_invalid_timeout (p : preset) : float option =
+  List.concat
+    [ List.map (fun (g : panel_group) -> g.timeout_s) p.panels
+    ; [ p.judge_timeout_s ]
+    ; List.map (fun (j : judge_spec) -> j.jtimeout_s) p.judges
+    ]
+  |> List.find_map (fun v -> if valid_timeout_s v then None else v)
+
 type staged_judge_group_error =
   | Staged_group_size_below_min of int
   | Staged_too_few_judges of
@@ -220,6 +247,8 @@ module Validated_preset = struct
     | Duplicate_panelist of string  (** 두 패널이 같은 정체성(panelist_id) *)
     | Bad_max_output_tokens of int
         (** 그룹/심판 출력 토큰 예산 override가 양수가 아님 *)
+    | Bad_timeout_s of float
+        (** 그룹/심판 응답 데드라인이 유한 양수가 아님 *)
     | Judge_panel_prompt_missing  (** JOJ 1차 심판 system prompt 비어있음 (RFC-0283) *)
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성(judge_id) (RFC-0283) *)
     | Min_answered_below_min of int
@@ -262,12 +291,15 @@ module Validated_preset = struct
                 with
                 | Some (Some n) -> Error (Bad_max_output_tokens n)
                 | Some None | None ->
-                  let total = List.length (preset_models p) in
-                  if p.min_answered < min_answered_floor
-                  then Error (Min_answered_below_min p.min_answered)
-                  else if p.min_answered > total
-                  then Error (Min_answered_above_max p.min_answered)
-                  else Ok p)))
+                  (match preset_invalid_timeout p with
+                   | Some s -> Error (Bad_timeout_s s)
+                   | None ->
+                     let total = List.length (preset_models p) in
+                     if p.min_answered < min_answered_floor
+                     then Error (Min_answered_below_min p.min_answered)
+                     else if p.min_answered > total
+                     then Error (Min_answered_above_max p.min_answered)
+                     else Ok p))))
 
   let preset (t : t) : preset = t
 

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -19,6 +19,11 @@ type panel_group =
   ; web_tools : bool  (** 그룹에 web_search/web_fetch 주입 여부. *)
   ; max_output_tokens : int option
       (** 그룹 모델당 출력 토큰 예산 override. [None]이면 Runtime_agent 기본값. *)
+  ; timeout_s : float option
+      (** 그룹 모델당 응답 데드라인(초) — Agent_core 경로는 [body_timeout_s],
+          official-client 경로는 어댑터 turn timeout 으로 집행된다. [None]이면
+          런타임/provider 가 이미 선언한 값이 그대로 쓰인다: preset 은 그 위에
+          얹는 소비자 override 이며 별도 SSOT 가 아니다. *)
   }
 [@@deriving show, eq]
 
@@ -31,7 +36,9 @@ type judge_spec =
   ; jsystem_prompt : string  (** 이 1차 심판의 lens — config에서 필수(코드 default 없음). *)
   ; jweb_tools : bool  (** web_search/web_fetch 주입 여부. *)
   ; jmax_output_tokens : int option
-      (** 출력 토큰 예산 override. [None]이면 Runtime_agent 기본값. *)
+      (** 출력 토큰 예산 override. [None]이면 preset 의 [judge_max_output_tokens]. *)
+  ; jtimeout_s : float option
+      (** 이 1차 심판의 응답 데드라인(초). [None]이면 preset 의 [judge_timeout_s]. *)
   }
 [@@deriving show, eq]
 
@@ -48,6 +55,9 @@ type preset =
       (** 심판 모델 system prompt — config에서 필수(코드 default 없음). *)
   ; judge_max_output_tokens : int option
       (** 단일/refine/meta 심판 출력 토큰 예산 override. [None]이면 기본값. *)
+  ; judge_timeout_s : float option
+      (** 심판 응답 데드라인(초). single/refine/meta/stage-meta 와, 자기
+          [jtimeout_s] 가 없는 1차 심판에 적용된다. [None]이면 런타임/provider 설정. *)
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
@@ -78,6 +88,11 @@ val min_staged_judge_group_size : int
 
 (** Optional max-output-token overrides must be positive when present. *)
 val valid_max_output_tokens : int option -> bool
+
+(** Optional response deadlines must be finite and positive when present. Zero,
+    negative, NaN and infinity are rejected at load rather than given an
+    invented meaning; "no deadline" is expressed by omitting the key. *)
+val valid_timeout_s : float option -> bool
 
 (** 모든 그룹의 모델을 평탄화 (그룹순 × 그룹내 모델순 보존). *)
 val preset_models : preset -> string list
@@ -154,6 +169,8 @@ module Validated_preset : sig
     | Duplicate_panelist of string  (** 두 패널이 같은 정체성({!panelist_id}) *)
     | Bad_max_output_tokens of int
         (** 그룹/심판 max_output_tokens override가 양수가 아님 *)
+    | Bad_timeout_s of float
+        (** 그룹/심판/1차 심판 응답 데드라인이 유한 양수가 아님 *)
     | Judge_panel_prompt_missing  (** JOJ 1차 심판 system prompt 비어있음 (RFC-0283) *)
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성 (RFC-0283) *)
     | Min_answered_below_min of int

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -68,6 +68,7 @@ type panel_failure =
   | Invalid_structured_response of string
   | Empty_response of string
   | Invalid_max_output_tokens of int
+  | Invalid_timeout_s of float
 [@@deriving to_yojson, show, eq]
 
 let panel_failure_of_yojson = function
@@ -80,6 +81,12 @@ let panel_failure_of_yojson = function
   | `List [ `String "Empty_response"; `String detail ] -> Ok (Empty_response detail)
   | `List [ `String "Invalid_max_output_tokens"; `Int value ] ->
     Ok (Invalid_max_output_tokens value)
+  | `List [ `String "Invalid_timeout_s"; `Float value ] -> Ok (Invalid_timeout_s value)
+  (* durable 레코드가 정수로 직렬화된 데드라인을 담을 수 있다(Yojson은 3.0을 [`Int 3]
+     으로 쓰지 않지만, 손으로 쓴 레코드/이전 wire는 그럴 수 있다). 같은 값의 두 표현을
+     한쪽만 받아 replay를 깨뜨리지 않는다. *)
+  | `List [ `String "Invalid_timeout_s"; `Int value ] ->
+    Ok (Invalid_timeout_s (float_of_int value))
   | json ->
     Error
       (Printf.sprintf

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -76,6 +76,12 @@ type panel_failure =
           reasoning/thinking 본문은 노출하지 않는다. *)
   | Invalid_max_output_tokens of int
       (** Runtime defense-in-depth: output token override must be positive. *)
+  | Invalid_timeout_s of float
+      (** Runtime defense-in-depth: a response deadline must be finite and
+          positive. Config load already rejects these
+          ({!Fusion_policy.valid_timeout_s}), so reaching this means a direct
+          [build_agent] caller supplied one — fail loudly instead of dropping
+          the deadline. *)
 [@@deriving to_yojson, show, eq]
 
 val panel_failure_of_yojson : Yojson.Safe.t -> (panel_failure, string) result

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -19,6 +19,7 @@ let base_group : Fusion_policy.panel_group =
   ; system_prompt = "panel"
   ; web_tools = false
   ; max_output_tokens = None
+  ; timeout_s = None
   }
 
 (* RFC-0280: presets는 [Validated_preset.t]라 private — of_preset로만 생성. 테스트
@@ -42,6 +43,7 @@ let base_policy : Fusion_policy.t =
           ; judge = "a"
           ; judge_system_prompt = "judge"
           ; judge_max_output_tokens = None
+  ; judge_timeout_s = None
           ; judges = []
           ; min_answered = Fusion_policy.default_min_answered
           ; fallback_judge_model = None
@@ -731,6 +733,7 @@ let test_config_two_judges_not_staged_eligible () =
     ; jsystem_prompt = label ^ " lens"
     ; jweb_tools = false
     ; jmax_output_tokens = None
+    ; jtimeout_s = None
     }
   in
   let judges =
@@ -765,6 +768,135 @@ judge_max_output_tokens = -1
          (function Fusion_config.Invalid_max_output_tokens _ -> true | _ -> false)
          es)
   | Ok _ -> Alcotest.fail "expected Error Invalid_max_output_tokens"
+
+(* 데드라인 축(RFC-0252 §9). [panel_timeout_s]/[judge_timeout_s]/1차 심판
+   [timeout_s]는 오랫동안 운영 config에 존재하면서 파서에 소비자가 없었다 —
+   subscription CLI 패널이 실측 34.7s까지 걸려 240s를 선언해 뒀는데 그 값이 어디에도
+   도달하지 않았다. 파싱·검증·per-judge 폴백을 핀한다. *)
+let test_config_parses_timeouts () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p1"
+[fusion.presets.p1]
+panel = ["a", "b"]
+judge = "a"
+panel_system_prompt = "p"
+judge_system_prompt = "j"
+panel_timeout_s = 240.0
+judge_timeout_s = 180
+[[fusion.presets.p1.judges]]
+model = "a"
+label = "evidence"
+system_prompt = "lens"
+timeout_s = 90.5
+[[fusion.presets.p1.judges]]
+model = "b"
+label = "coverage"
+system_prompt = "lens"
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    Alcotest.failf "expected Ok, got %d error(s): %s" (List.length es)
+      (String.concat "; " (List.map Fusion_config.show_config_error es))
+  | Ok cfg ->
+    (match cfg.Fusion_policy.presets with
+     | [ vp ] ->
+       let p = Fusion_policy.Validated_preset.preset vp in
+       let group = List.hd p.Fusion_policy.panels in
+       Alcotest.(check (option (float 0.001)))
+         "panel_timeout_s reaches the group" (Some 240.0)
+         group.Fusion_policy.timeout_s;
+       (* 정수 리터럴도 초 값으로 읽힌다 — 운영자가 180과 180.0을 구분해 쓸 이유가 없다. *)
+       Alcotest.(check (option (float 0.001)))
+         "integer judge_timeout_s is accepted as seconds" (Some 180.0)
+         p.Fusion_policy.judge_timeout_s;
+       (match p.Fusion_policy.judges with
+        | [ evidence; coverage ] ->
+          Alcotest.(check (option (float 0.001)))
+            "per-judge timeout_s is parsed" (Some 90.5)
+            evidence.Fusion_policy.jtimeout_s;
+          Alcotest.(check (option (float 0.001)))
+            "a judge without its own deadline stays None (preset supplies it)" None
+            coverage.Fusion_policy.jtimeout_s
+        | js -> Alcotest.failf "expected 2 judges, got %d" (List.length js))
+     | ps -> Alcotest.failf "expected 1 preset, got %d" (List.length ps))
+
+let test_config_rejects_nonpositive_timeout () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p1"
+[fusion.presets.p1]
+panel = ["a", "b"]
+judge = "a"
+panel_system_prompt = "p"
+judge_system_prompt = "j"
+panel_timeout_s = 0
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    Alcotest.(check bool) "Invalid_timeout_s present" true
+      (List.exists
+         (function Fusion_config.Invalid_timeout_s _ -> true | _ -> false)
+         es)
+  | Ok _ -> Alcotest.fail "expected Error Invalid_timeout_s for a zero deadline"
+
+let test_config_rejects_negative_judge_timeout () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p1"
+[fusion.presets.p1]
+panel = ["a", "b"]
+judge = "a"
+panel_system_prompt = "p"
+judge_system_prompt = "j"
+judge_timeout_s = -30.0
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    Alcotest.(check bool) "Invalid_timeout_s present" true
+      (List.exists
+         (function Fusion_config.Invalid_timeout_s _ -> true | _ -> false)
+         es)
+  | Ok _ -> Alcotest.fail "expected Error Invalid_timeout_s for a negative deadline"
+
+(* 데드라인 미선언은 유효하다 — 그 경우 런타임/provider 선언이 유일한 값으로 남는다.
+   이 대조군이 없으면 위 두 거부 테스트는 "모든 preset을 거부해도" 통과한다. *)
+let test_config_absent_timeouts_are_valid () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p1"
+[fusion.presets.p1]
+panel = ["a", "b"]
+judge = "a"
+panel_system_prompt = "p"
+judge_system_prompt = "j"
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    Alcotest.failf "a preset without deadlines must load: %s"
+      (String.concat "; " (List.map Fusion_config.show_config_error es))
+  | Ok cfg ->
+    (match cfg.Fusion_policy.presets with
+     | [ vp ] ->
+       let p = Fusion_policy.Validated_preset.preset vp in
+       Alcotest.(check (option (float 0.001)))
+         "no preset judge deadline" None p.Fusion_policy.judge_timeout_s;
+       Alcotest.(check (option (float 0.001)))
+         "no panel group deadline" None
+         (List.hd p.Fusion_policy.panels).Fusion_policy.timeout_s
+     | ps -> Alcotest.failf "expected 1 preset, got %d" (List.length ps))
 
 (* enabled인데 default_preset 생략(="") → preset 생략 호출이 폭빽할 default가 없어
    항상 Preset_unknown ""로 deny. 빈 default_preset도 로드 거부. *)
@@ -837,6 +969,7 @@ let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthe
   ; judge
   ; judge_system_prompt = judge_prompt
   ; judge_max_output_tokens = None
+  ; judge_timeout_s = None
   ; judges
   ; min_answered
   ; fallback_judge_model
@@ -890,6 +1023,7 @@ let base_judge : Fusion_policy.judge_spec =
   ; jsystem_prompt = "lens"
   ; jweb_tools = false
   ; jmax_output_tokens = None
+    ; jtimeout_s = None
   }
 
 (* judges=[]면 (simple/refine/conditional preset) 기존과 동일하게 유효 = byte-identity. *)
@@ -1038,6 +1172,7 @@ let g_web4 : Fusion_policy.panel_group =
   ; system_prompt = "p"
   ; web_tools = true
   ; max_output_tokens = None
+  ; timeout_s = None
   }
 
 let test_judge_args_single_group_identity () =
@@ -1512,6 +1647,13 @@ let () =
             test_config_two_judges_not_staged_eligible
         ; Alcotest.test_case "invalid_max_output_tokens" `Quick
             test_config_invalid_max_output_tokens
+        ; Alcotest.test_case "timeouts_parse" `Quick test_config_parses_timeouts
+        ; Alcotest.test_case "zero_timeout_rejected" `Quick
+            test_config_rejects_nonpositive_timeout
+        ; Alcotest.test_case "negative_judge_timeout_rejected" `Quick
+            test_config_rejects_negative_judge_timeout
+        ; Alcotest.test_case "absent_timeouts_valid" `Quick
+            test_config_absent_timeouts_are_valid
         ; Alcotest.test_case "empty_default_preset" `Quick test_config_empty_default_preset
         ; Alcotest.test_case "disabled_with_preset" `Quick test_config_disabled_with_preset
         ; Alcotest.test_case "judges_parse" `Quick test_config_judges_parse

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -267,7 +267,7 @@ let test_sum_all_usage_empty_is_zero () =
    조용히 갈라졌다: [judge_max_output_tokens]는 1차 심판에만 미적용,
    [web_tools=true] 요청은 1차 심판에만 미주입. 결정을 순수 함수로 분리해 핀한다. *)
 
-let judge_spec ?(label = "") ?(web_tools = false) ?max_output_tokens model
+let judge_spec ?(label = "") ?(web_tools = false) ?max_output_tokens ?timeout_s model
   : Fusion_policy.judge_spec
   =
   { jmodel = model
@@ -275,9 +275,10 @@ let judge_spec ?(label = "") ?(web_tools = false) ?max_output_tokens model
   ; jsystem_prompt = "lens"
   ; jweb_tools = web_tools
   ; jmax_output_tokens = max_output_tokens
+  ; jtimeout_s = timeout_s
   }
 
-let preset_with ?judge_max_output_tokens judges : Fusion_policy.preset =
+let preset_with ?judge_max_output_tokens ?judge_timeout_s judges : Fusion_policy.preset =
   { name = "quorum"
   ; panels =
       [ { Fusion_policy.models = [ "p.one" ]
@@ -285,11 +286,13 @@ let preset_with ?judge_max_output_tokens judges : Fusion_policy.preset =
         ; system_prompt = "panelist"
         ; web_tools = false
         ; max_output_tokens = None
+        ; timeout_s = None
         }
       ]
   ; judge = "p.meta"
   ; judge_system_prompt = "meta"
   ; judge_max_output_tokens
+  ; judge_timeout_s
   ; judges
   ; min_answered = 1
   ; fallback_judge_model = None
@@ -315,6 +318,28 @@ let test_first_judge_budget_absent_stays_none () =
   let preset = preset_with [ j ] in
   check int_opt_t "no budget anywhere stays None (runtime default)" None
     (Fusion_orchestrator_judge_wave.first_judge_max_tokens ~preset j)
+
+let float_opt_t = testable (Fmt.option Fmt.float) (Option.equal Float.equal)
+
+let test_first_judge_deadline_prefers_own () =
+  let j = judge_spec ~timeout_s:90.0 "p.a" in
+  let preset = preset_with ~judge_timeout_s:180.0 [ j ] in
+  check float_opt_t "per-judge deadline wins over the preset judge deadline"
+    (Some 90.0)
+    (Fusion_orchestrator_judge_wave.first_judge_timeout_s ~preset j)
+
+let test_first_judge_deadline_falls_back_to_preset () =
+  let j = judge_spec "p.a" in
+  let preset = preset_with ~judge_timeout_s:180.0 [ j ] in
+  check float_opt_t "unset per-judge deadline falls back to the preset judge deadline"
+    (Some 180.0)
+    (Fusion_orchestrator_judge_wave.first_judge_timeout_s ~preset j)
+
+let test_first_judge_deadline_absent_stays_none () =
+  let j = judge_spec "p.a" in
+  let preset = preset_with [ j ] in
+  check float_opt_t "no deadline anywhere stays None (runtime/provider owns it)" None
+    (Fusion_orchestrator_judge_wave.first_judge_timeout_s ~preset j)
 
 let test_first_judge_web_tools_from_request () =
   let j = judge_spec ~web_tools:false "p.a" in
@@ -382,6 +407,14 @@ let () =
             test_first_judge_budget_falls_back_to_preset
         ; test_case "absent everywhere stays None" `Quick
             test_first_judge_budget_absent_stays_none
+        ] )
+    ; ( "first_judge_deadline"
+      , [ test_case "per-judge deadline wins" `Quick
+            test_first_judge_deadline_prefers_own
+        ; test_case "falls back to the preset judge deadline" `Quick
+            test_first_judge_deadline_falls_back_to_preset
+        ; test_case "absent everywhere stays None" `Quick
+            test_first_judge_deadline_absent_stays_none
         ] )
     ; ( "first_judge_web_tools"
       , [ test_case "request-derived setting reaches the judge" `Quick

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -262,6 +262,75 @@ let test_sum_all_usage_empty_is_zero () =
   check usage_t "no results -> zero usage" Fusion_types.zero_usage
     (Fusion_types.sum_all_usage [])
 
+(* 1차 심판(JOJ)의 예산·도구 표면 결정. 두 값 모두 이전에는 [run_first_judge]가
+   통째로 버려서, 같은 요청 안에서 single/refine/meta 심판과 1차 심판의 설정이
+   조용히 갈라졌다: [judge_max_output_tokens]는 1차 심판에만 미적용,
+   [web_tools=true] 요청은 1차 심판에만 미주입. 결정을 순수 함수로 분리해 핀한다. *)
+
+let judge_spec ?(label = "") ?(web_tools = false) ?max_output_tokens model
+  : Fusion_policy.judge_spec
+  =
+  { jmodel = model
+  ; jlabel = label
+  ; jsystem_prompt = "lens"
+  ; jweb_tools = web_tools
+  ; jmax_output_tokens = max_output_tokens
+  }
+
+let preset_with ?judge_max_output_tokens judges : Fusion_policy.preset =
+  { name = "quorum"
+  ; panels =
+      [ { Fusion_policy.models = [ "p.one" ]
+        ; label = ""
+        ; system_prompt = "panelist"
+        ; web_tools = false
+        ; max_output_tokens = None
+        }
+      ]
+  ; judge = "p.meta"
+  ; judge_system_prompt = "meta"
+  ; judge_max_output_tokens
+  ; judges
+  ; min_answered = 1
+  ; fallback_judge_model = None
+  }
+
+let int_opt_t = testable (Fmt.option Fmt.int) (Option.equal Int.equal)
+
+let test_first_judge_budget_prefers_own () =
+  let j = judge_spec ~max_output_tokens:512 "p.a" in
+  let preset = preset_with ~judge_max_output_tokens:2048 [ j ] in
+  check int_opt_t "per-judge budget wins over the preset judge budget" (Some 512)
+    (Fusion_orchestrator_judge_wave.first_judge_max_tokens ~preset j)
+
+let test_first_judge_budget_falls_back_to_preset () =
+  let j = judge_spec "p.a" in
+  let preset = preset_with ~judge_max_output_tokens:2048 [ j ] in
+  check int_opt_t "unset per-judge budget falls back to the preset judge budget"
+    (Some 2048)
+    (Fusion_orchestrator_judge_wave.first_judge_max_tokens ~preset j)
+
+let test_first_judge_budget_absent_stays_none () =
+  let j = judge_spec "p.a" in
+  let preset = preset_with [ j ] in
+  check int_opt_t "no budget anywhere stays None (runtime default)" None
+    (Fusion_orchestrator_judge_wave.first_judge_max_tokens ~preset j)
+
+let test_first_judge_web_tools_from_request () =
+  let j = judge_spec ~web_tools:false "p.a" in
+  check bool "request/panel-derived web tools reach a judge that did not ask" true
+    (Fusion_orchestrator_judge_wave.first_judge_web_tools ~judge_web_tools:true j)
+
+let test_first_judge_web_tools_from_own_spec () =
+  let j = judge_spec ~web_tools:true "p.a" in
+  check bool "a judge's own web_tools survives a request that did not ask" true
+    (Fusion_orchestrator_judge_wave.first_judge_web_tools ~judge_web_tools:false j)
+
+let test_first_judge_web_tools_absent_stays_off () =
+  let j = judge_spec ~web_tools:false "p.a" in
+  check bool "neither side asks -> no web tools" false
+    (Fusion_orchestrator_judge_wave.first_judge_web_tools ~judge_web_tools:false j)
+
 let () =
   run "fusion_judge_usage"
     [ ( "output_contract"
@@ -305,5 +374,21 @@ let () =
       , [ test_case "folds Ok and Error usage alike" `Quick
             test_sum_all_usage_folds_ok_and_error
         ; test_case "empty is zero" `Quick test_sum_all_usage_empty_is_zero
+        ] )
+    ; ( "first_judge_budget"
+      , [ test_case "per-judge budget wins" `Quick
+            test_first_judge_budget_prefers_own
+        ; test_case "falls back to the preset judge budget" `Quick
+            test_first_judge_budget_falls_back_to_preset
+        ; test_case "absent everywhere stays None" `Quick
+            test_first_judge_budget_absent_stays_none
+        ] )
+    ; ( "first_judge_web_tools"
+      , [ test_case "request-derived setting reaches the judge" `Quick
+            test_first_judge_web_tools_from_request
+        ; test_case "own spec survives a request that did not ask" `Quick
+            test_first_judge_web_tools_from_own_spec
+        ; test_case "neither side asks -> off" `Quick
+            test_first_judge_web_tools_absent_stays_off
         ] )
     ]

--- a/test/test_fusion_official_client_panel.ml
+++ b/test/test_fusion_official_client_panel.ml
@@ -119,6 +119,7 @@ let test_official_client_panel_honors_no_deadline () =
       (Option.is_none
          (Masc.Fusion_official_client.For_testing.resolved_timeout_s
             ~runtime_id:official_client_runtime
+            ~override_s:None
             ~default_timeout_s:300.0)))
 ;;
 
@@ -142,6 +143,7 @@ let panel_group models : Fusion_policy.panel_group =
   ; system_prompt = "Answer in one word."
   ; web_tools = false
   ; max_output_tokens = None
+        ; timeout_s = None
   }
 ;;
 

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -198,6 +198,7 @@ let fusion_tool_policy () : Fusion_policy.t =
     ; system_prompt = "panel system prompt"
     ; web_tools = false
     ; max_output_tokens = None
+    ; timeout_s = None
     }
   in
   let preset : Fusion_policy.preset =
@@ -206,6 +207,7 @@ let fusion_tool_policy () : Fusion_policy.t =
     ; judge = "judge.model"
     ; judge_system_prompt = "judge system prompt"
     ; judge_max_output_tokens = None
+    ; judge_timeout_s = None
     ; judges = []
     ; min_answered = Fusion_policy.default_min_answered
     ; fallback_judge_model = None


### PR DESCRIPTION
## 무엇이 문제였나

Fusion 흐름 전체를 점검하다 세 가지가 나왔다. 셋 다 "설정이 존재하는데 실행에 도달하지 않는" 같은 형태다.

### 1. 1차 심판(JoJ)이 preset 예산과 요청 web_tools를 못 받는다

```ocaml
let _ = preset, judge_web_tools, already_timed_out in
```

`run_first_judge`가 셋을 통째로 버렸다. 결과:

- `judge_max_output_tokens`는 single/refine/meta/stage-meta 심판에 전부 전달되는데 **1차 심판만** 런타임 기본값으로 돌았다.
- `judge_spec.jmax_output_tokens`는 파싱·범위검증·JSON 직렬화까지 되면서 **실행 경로 소비자가 0**이었다.
- `masc_fusion web_tools=true topology=judge_of_judges`는 패널과 meta 심판에 web tool을 주입하면서 **1차 심판에만 조용히 주입하지 않았다**.

### 2. preset 타임아웃이 어디에도 도달하지 않는다

운영 config가 `panel_timeout_s` / `judge_timeout_s`를 오래 담고 있었지만 파서에 소비자가 없었다. `subscription_trio`는 이유까지 적어뒀다 — 구독 CLI 턴 실측 중앙값 10-13s인데 `gemini-3.6-flash-high`만 34.7s라 240s를 선언 — 그런데 실제로 패널을 바운드한 건 provider `connect_timeout_s`와 official-client의 런타임 추론 turn timeout이었다.

소비자 0 확인(대조군 포함):

| 키 | 소비자 |
|---|---|
| `panel_timeout_s` | **0** |
| `judge_timeout_s` | **0** |
| `max_tool_calls_per_panel` | **0** |
| `[fusion.gate] per_hour_budget` | **0** |
| *(대조군)* `max_output_tokens_per_panel` | fusion_config.ml:42 |
| *(대조군)* `min_answered` | fusion_config.ml:59 |

### 3. 죽은 파라미터

`already_timed_out`은 항상 `false`로 넘어가 무시됐고, `judge_run` 튜플의 `timed_out`은 이 모듈 밖에 소비자가 없다(sink는 `judge_failure_is_timeout`으로 typed failure에서 직접 파생한다).

## 무엇을 했나

**타임아웃을 typed preset 축으로 만들고 집행한다.**

```
panel_timeout_s          -> panel_group.timeout_s
judge_timeout_s          -> preset.judge_timeout_s
[[...judges]].timeout_s  -> judge_spec.jtimeout_s
```

- Agent_core 패널·심판: 에이전트의 `body_timeout_s`로 집행. AGENT_CORE가 이미 소유한 손잡이이고(`Builder.with_body_timeout` → `Complete.complete` 비스트리밍 총 왕복 cap), provider `connect_timeout_s`와 달리 이름이 하는 일과 일치한다.
- official-client 패널: 어댑터 turn timeout으로, 런타임 추론보다 우선.
- `admission_timeout_s`는 건드리지 않는다 — 그건 답이 아니라 승인 대기를 바운드한다.

**두 번째 SSOT가 아니다.** 데드라인 미선언이면 런타임/provider가 선언한 값이 그대로 유일한 값으로 남는다. provider config가 아니라 agent config를 override하므로 blast radius가 이 fusion 요청으로 한정된다 — 같은 런타임을 쓰는 키퍼 턴의 예산은 그대로다.

유효성은 `Fusion_policy.valid_timeout_s` 한 곳이 진다. 0·음수·NaN·infinity는 로드에서 거부한다(해석을 코드가 임의로 고르면 운영자 의도와 집행값이 갈라진다). "제한 없음"의 표현은 키 생략이다. TOML 정수도 초로 받는다 — `180`과 `180.0`은 같은 의도다.

**1차 심판 결정을 순수 함수로 분리했다**: `first_judge_max_tokens` / `first_judge_web_tools` / `first_judge_timeout_s`. per-judge 선언이 있으면 그것, 없으면 preset 값. web tool은 요청 파생값과 judge 자기 설정의 합집합.

## 검증

- 전체 `dune build`
- `test/fusion_core` 83/83 (신규 4)
- `test_fusion_judge_usage` 24/24 (신규 6)
- **뮤테이션 확인**: `find_timeout_s`를 `None` 반환으로 바꾸면 파싱/거부 테스트 3개가 빨개지고, 부재-대조군(`absent_timeouts_valid`)은 초록으로 남는다.
- 운영자의 live `runtime.toml`을 실제 `Fusion_config.of_toml`에 통과시켜 5개 preset 로드 확인(일회성 실행기, 커밋하지 않음).

## 안 한 것

`run_first_judge`가 이 헬퍼들을 실제로 호출하는지는 테스트가 증명하지 못한다. 호출부를 `~web_tools:j.jweb_tools`로 되돌려도 새 테스트는 초록이다. 실제 호출 검증에는 provider stub이 필요한데 fusion 하네스에 없다.

RFC-WAIVED: 변경이 `pr-rfc-check.sh` 대상 subsystem(credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential, hooks, workflow 문서)에 닿지 않는다. fusion preset 축 확장이며 기존 RFC-0252 §9 / RFC-0283의 설정 계약을 넓히는 방향이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
