### PR TITLE
fix(dashboard): stop dropping every conversation row over an additive stream_contract field

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -194,18 +194,42 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     ).toBeNull()
   })
 
-  it('rejects the removed delivery receipt wire field', () => {
+  // #27962 hard-cut the old delivery receipt off the wire and this test used
+  // to pin the removal. #28225 re-introduced `delivery_receipt` as a stream
+  // replay-coverage label on every persisted row; keeping the rejection pin
+  // made the boundary drop every direct-conversation row while only
+  // autonomous rows (no stream_contract) survived (#28407).
+  it('passes the #28225 delivery_receipt coverage label through', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          delivery_receipt: 'no_delivery_receipt',
+        },
+      }),
+    )
+    expect(out?.stream_contract?.delivery_receipt).toBe('no_delivery_receipt')
+  })
+
+  it('ignores unknown additive stream_contract fields instead of dropping the row', () => {
+    // The per-row safeParse drop means a rejected key here deletes the whole
+    // message from the transcript. An additive backend field must degrade to
+    // "ignored", never to "row dropped" (#28407).
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          some_future_field: 'introduced ahead of the dashboard',
+        },
+      }),
+    )
+    expect(out).not.toBeNull()
+    expect(out?.stream_contract?.source).toBe('backend_turn_trace')
     expect(
-      safeParseKeeperChatHistoryMessage(
-        validMessage({
-          stream_contract: {
-            source: 'backend_turn_trace',
-            status: 'backend_trace_join',
-            delivery_receipt: 'no_delivery_receipt',
-          },
-        }),
-      ),
-    ).toBeNull()
+      (out?.stream_contract as Record<string, unknown> | undefined)?.some_future_field,
+    ).toBeUndefined()
   })
 
   it('leaves turn_ref undefined on legacy rows without dropping the message', () => {

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -26,7 +26,6 @@ import {
   optional,
   record,
   safeParse,
-  strictObject,
   string,
   union,
   unknown,
@@ -226,7 +225,15 @@ export const KeeperChatBlockSchema = union([
 
 export type KeeperChatBlock = InferOutput<typeof KeeperChatBlockSchema>
 
-export const KeeperChatHistoryStreamContractSchema = strictObject({
+// `object`, not `strictObject`: this row-level schema feeds a tolerant
+// per-row drop, so an unknown key here does not reject one field — it
+// silently deletes the whole message from the transcript. #28225 adding
+// `delivery_receipt` to the backend emission wiped every direct-conversation
+// row while only autonomous rows (no stream_contract) survived (#28407).
+// Additive backend fields must degrade to "ignored", never to "row dropped";
+// the deploy-window rationale documented on `role`/`speaker_authority`
+// applies to this nested object the same way.
+export const KeeperChatHistoryStreamContractSchema = object({
   source: string(),
   status: string(),
   event_name: optional(string()),
@@ -240,6 +247,11 @@ export const KeeperChatHistoryStreamContractSchema = strictObject({
   lifecycle_events: optional(array(string())),
   lifecycleEvents: optional(array(string())),
   reason: optional(string()),
+  // keeper_chat_store.ml stream_delivery_receipt_field (#28225): names how the
+  // persisted row relates to live delivery (e.g. "no_delivery_receipt",
+  // "server_lifecycle_replay_only"). Open string for the same deploy-window
+  // reason as `source`/`status`.
+  delivery_receipt: optional(string()),
 })
 
 export type KeeperChatHistoryStreamContract = InferOutput<typeof KeeperChatHistoryStreamContractSchema>


### PR DESCRIPTION
## 문제 (#28407)

대시보드 keeper 대화 패널에서 직접 대화(대시보드/Slack)가 전부 사라지고 자율턴 그룹만 렌더된다. `/chat/history`는 313행을 정상 반환하지만 boundary 스키마가 대화 행 129개 전원을 조용히 드랍한다.

## 원인

- `KeeperChatHistoryStreamContractSchema`가 `strictObject`인데, 이 스키마의 실패는 필드 거부가 아니라 **행 전체 삭제**로 이어진다 (`safeParseKeeperChatHistoryMessage`의 행 단위 관용 드랍).
- #27962(08-10)가 구 delivery receipt를 와이어에서 hard-cut하고 테스트로 거부를 핀 → #28225(08-12)가 같은 이름 `delivery_receipt`를 replay-coverage 라벨로 재도입 → 이틀 간격의 계약 충돌이 22:24 재시작(신규 바이너리 활성화)과 함께 발현.
- 스키마 파일 자신의 주석("backend can introduce a new role ahead of the dashboard; a strict enum would silently drop valid messages during the deploy window")이 이 실패 클래스를 예언했으나 중첩 객체엔 적용되지 않았다.

## 수정

- `stream_contract` 검증을 `strictObject` → `object`: additive 백엔드 필드는 "무시"로 강등되고, 절대 "행 삭제"가 되지 않는다.
- `delivery_receipt`를 typed `optional(string())`로 수용 (서버 발신: `keeper_chat_store.ml` `stream_delivery_receipt_field`).
- 낡은 거부 핀 테스트를 pass-through 단언으로 교체 (#28225 재도입 반영).
- 클래스 회귀 테스트 추가: stream_contract 안의 임의 미지 additive 키가 행을 죽이지 않는다.

## 검증

- `src/api/schemas/keeper-chat-history.test.ts` 30/30 통과
- 인접 소비자 `keeper-message.test.ts` + `keeper-state.test.ts` 111/111 통과
- `tsc --noEmit` clean, `eslint src` clean
- **라이브 데이터 재현**: 실제 kidsnote `/chat/history` 응답 313행을 스키마에 통과 — 수정 전 184/313(대화 행 전멸), 수정 후 **313/313**

## 미검증

- 브라우저 라이브 확인(페이지 리로드 후 대화 렌더)은 vite dev 서버가 main working tree를 서빙하므로 머지 후 확인 필요

Closes #28407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU1EnzuTuFCPZwbeqj9Ajr
