### PR TITLE
fix(dashboard): shell 이 200 본문으로 거부한 자격증명도 자가복구하도록

### DIFF
--- a/dashboard/src/store-shell-auth.test.ts
+++ b/dashboard/src/store-shell-auth.test.ts
@@ -11,6 +11,10 @@ const toastMocks = vi.hoisted(() => ({
   showToast: vi.fn(),
 }))
 
+const devTokenMocks = vi.hoisted(() => ({
+  refreshDevTokenAfterAuthError: vi.fn(async () => true),
+}))
+
 vi.mock('./api', () => apiMocks)
 vi.mock('./api/dashboard-hot', () => ({
   fetchDashboardShell: apiMocks.fetchDashboardShell,
@@ -22,6 +26,10 @@ vi.mock('./sse', () => ({
 }))
 vi.mock('./components/common/toast', () => ({
   showToast: toastMocks.showToast,
+}))
+vi.mock('./api/dev-token', async importOriginal => ({
+  ...(await importOriginal<typeof import('./api/dev-token')>()),
+  refreshDevTokenAfterAuthError: devTokenMocks.refreshDevTokenAfterAuthError,
 }))
 
 afterEach(async () => {
@@ -142,5 +150,81 @@ describe('refreshShell auth failure handling', () => {
 
     expect(store.shellAuthSummary.value).toBe(verifiedAuth)
     expect(sessionActor.currentCanonicalDashboardActor()).toBe('dashboard')
+  })
+})
+
+/* The server keeps the loopback read contract available to an unauthenticated
+   caller, so a rejected credential comes back as HTTP 200 with
+   `token_valid: false` and a typed `auth_error_code` in the body. The MCP
+   client only recovers from the auth envelope of a *failed* call, so before
+   this wiring a tab whose traffic was the shell poll re-sent the same
+   rejected token indefinitely — measured every 6 minutes across two server
+   restarts on 2026-08-12. */
+describe('rejected shell credential recovery', () => {
+  const rejected = {
+    enabled: true,
+    require_token: true,
+    token_present: true,
+    token_valid: false,
+    token_agent: null,
+    requested_agent: null,
+    effective_agent: null,
+    effective_role: null,
+    auth_error_code: 'invalid_token',
+    auth_error_detail: '[AuthError] Invalid token: Token mismatch',
+    can_keeper_msg: false,
+    keeper_msg_error: '[AuthError] Invalid token: Token mismatch',
+  } as const
+
+  function shellBody(auth: Record<string, unknown>) {
+    return {
+      generated_at: '2026-08-12T14:02:00Z',
+      status: { project: 'me' },
+      counts: { agents: 0, tasks: 0, keepers: 0, total_runtimes: 0 },
+      auth,
+    } as never
+  }
+
+  it('asks for a fresh dev token and forwards the typed rejection code', async () => {
+    const store = await import('./store')
+    store.hydrateShellSnapshot(shellBody(rejected), { light: true })
+    expect(devTokenMocks.refreshDevTokenAfterAuthError).toHaveBeenCalledWith('invalid_token')
+  })
+
+  it('reaches the same recovery through a shell refresh response', async () => {
+    apiMocks.fetchDashboardShell.mockResolvedValueOnce(shellBody(rejected))
+    const store = await import('./store')
+    await store.refreshShell({ force: true })
+    expect(devTokenMocks.refreshDevTokenAfterAuthError).toHaveBeenCalledWith('invalid_token')
+  })
+
+  it('leaves an accepted credential alone', async () => {
+    const store = await import('./store')
+    store.hydrateShellSnapshot(
+      shellBody({ ...rejected, token_valid: true, auth_error_code: null, auth_error_detail: null }),
+      { light: true },
+    )
+    expect(devTokenMocks.refreshDevTokenAfterAuthError).not.toHaveBeenCalled()
+  })
+
+  /* No stored credential is the pre-bootstrap state, not a rejection —
+     `ensureDevToken` mints the first token there. Refreshing on it would
+     race the bootstrap that is already in flight. */
+  it('does not treat a missing credential as a rejection', async () => {
+    const store = await import('./store')
+    store.hydrateShellSnapshot(
+      shellBody({ ...rejected, token_present: false, auth_error_code: 'missing_token' }),
+      { light: true },
+    )
+    expect(devTokenMocks.refreshDevTokenAfterAuthError).not.toHaveBeenCalled()
+  })
+
+  /* `preserveAuth` callers are explicitly not reporting on the credential —
+     they carry a stale auth slice forward, so acting on it would refresh from
+     data the caller already disclaimed. */
+  it('stays out of preserveAuth hydration', async () => {
+    const store = await import('./store')
+    store.hydrateShellSnapshot(shellBody(rejected), { light: true, preserveAuth: true })
+    expect(devTokenMocks.refreshDevTokenAfterAuthError).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -44,6 +44,7 @@ import { setArrayByKeyIfChanged } from './signal-utils'
 import { FetchScheduler } from './lib/fetch-scheduler'
 import { isRecord, asString, asNumber } from './components/common/normalize'
 import { setCanonicalDashboardActor } from './lib/dashboard-session-actor'
+import { refreshDevTokenAfterAuthError } from './api/dev-token'
 import { timeBoardRequest } from './board-metrics'
 import { namespaceTruth, namespaceTruthError, namespaceTruthInitializing } from './namespace-truth-signals'
 import { normalizeNamespaceTruth } from './namespace-truth-normalizers'
@@ -779,6 +780,30 @@ function normalizeShellAuthSummary(raw: unknown): DashboardShellAuthSummary | nu
   }
 }
 
+/* The shell reports a rejected credential inside the body of a 200 response
+   — `token_valid: false` plus the typed `auth_error_code` — because the
+   loopback read contract stays available to an unauthenticated caller. The
+   MCP client recovers from a rejected token by inspecting the auth error
+   envelope of a *failed* call (`api/mcp.ts`), so a tab whose traffic is the
+   shell/bootstrap poll never reaches that path and re-sends the same
+   rejected token for the life of the tab.
+
+   Measured on the live fleet 2026-08-12: one browser session re-sent a
+   single rejected token (`sha256[0:8] = 75598b82`) every 6 minutes across
+   two server restarts, and the server answered each one with
+   `[silent:dashboard_actor_fallback] outcome=error err_kind=token_mismatch`
+   — 7 in the 33 minutes sampled, with no terminating condition.
+
+   `refreshDevTokenAfterAuthError` owns the whole policy: it ignores codes
+   that a new token cannot fix, refuses to touch a manually pasted token,
+   deduplicates concurrent attempts, and reports failure when the refetched
+   token is identical, so a token that is rejected for some other reason
+   cannot drive a refresh loop. */
+function recoverFromRejectedShellAuth(auth: DashboardShellAuthSummary | null): void {
+  if (auth === null || auth.token_valid || !auth.token_present) return
+  void refreshDevTokenAfterAuthError(auth.auth_error_code)
+}
+
 export function hydrateShellSnapshot(
   data: DashboardShellResponse,
   opts?: { light?: boolean; preserveAuth?: boolean },
@@ -787,6 +812,7 @@ export function hydrateShellSnapshot(
   const preserveAuth = opts?.preserveAuth === true
   const normalizedAuth = normalizeShellAuthSummary(data.auth)
   if (!preserveAuth) {
+    recoverFromRejectedShellAuth(normalizedAuth)
     setCanonicalDashboardActor(
       normalizedAuth?.token_valid
         ? normalizedAuth.effective_agent ?? normalizedAuth.token_agent ?? null


### PR DESCRIPTION
RFC-0340 §Typed self-healing 은 이미 이 동작을 계약으로 못박고 있습니다.

> Loopback sessions may replace a managed dev-token and retry once only when the
> server returns `auth_error_code` equal to `invalid_token`, `token_expired`, or
> `actor_mismatch`. **REST**, Keeper streaming, MCP initialization, and MCP tool
> results use that same typed set.
>
> — `docs/rfc/RFC-0340-loopback-dashboard-worker-credential.md` §Typed self-healing

새 동작을 추가하는 PR 이 아니라, 계약에 REST 가 적혀 있는데 **배선이 MCP 쪽에만 되어 있던 것**을 잇는 PR 입니다.

## 증상

루프백 read 계약은 인증되지 않은 caller 에게도 열려 있어야 하므로, 거부된 대시보드 토큰은 401 이 아니라 **HTTP 200 본문**으로 돌아옵니다.

```
$ curl -s -H "Authorization: Bearer <stale>" /api/v1/dashboard/bootstrap
200
{"auth":{"token_present":true,"token_valid":false,
         "auth_error_code":"invalid_token",
         "auth_error_detail":"[AuthError] Invalid token: Token mismatch"}}
```

`api/mcp.ts` 의 복구는 **실패한 호출**의 auth 봉투를 읽어서 걸립니다. shell/bootstrap 폴링만 도는 탭은 그 경로에 도달하지 못하므로, 거부된 토큰을 탭 수명 내내 그대로 다시 보냅니다.

## 실측 (2026-08-12, 라이브 서버)

브라우저 세션 하나가 같은 거부 토큰(`sha256[0:8] = 75598b82`)을 **6분마다** 재전송했고, 서버는 매번 아래를 남겼습니다.

```
[silent:dashboard_actor_fallback] outcome=error token_hash_prefix=75598b82
  err_kind=token_mismatch actor_hint=dashboard
  err=[AuthError] Invalid token: Token mismatch — request actor hint ignored.
```

- 표본 33분 동안 7건, 종료 조건 없음
- **서버 재시작 2회를 넘어 생존** (부팅 31초 뒤부터 재개)
- 디스크의 dashboard 토큰 3종 중 이 해시와 일치하는 파일 없음 → 브라우저 보관 자격증명

로그 이름의 `[silent:...]` 접두가 이미 이 상태를 silent failure 로 자백하고 있습니다.

## 변경

`hydrateShellSnapshot` 이 shell 과 bootstrap 양쪽의 단일 통로이므로 여기 한 곳에만 배선했습니다.

```ocaml
(* dashboard/src/store.ts *)
if (!preserveAuth) {
  recoverFromRejectedShellAuth(normalizedAuth)
  setCanonicalDashboardActor(...)
}
```

정책은 새로 만들지 않고 기존 `refreshDevTokenAfterAuthError` 가 전부 소유합니다 — 새 토큰으로 고칠 수 없는 코드는 무시하고, 수동 붙여넣기 토큰은 건드리지 않으며, 동시 시도를 합치고, 재발급된 토큰이 동일하면 실패로 보고해서 refresh 루프를 막습니다. 이 PR 은 판정을 옮기지 않고 **호출 지점만** 추가합니다.

경계 3개를 명시적으로 제외했습니다.

| 제외 | 근거 |
|---|---|
| `token_present: false` | 자격증명 부재는 거부가 아니라 bootstrap 이전 상태. `ensureDevToken` 이 최초 발급을 담당하며, 여기서 refresh 하면 진행 중인 bootstrap 과 경합 |
| `preserveAuth` hydration | 호출자가 자격증명을 보고하지 않겠다고 선언한 경로. stale auth slice 를 그대로 넘기므로 그 값으로 판단하면 안 됨 |
| `token_valid: true` | 수락된 자격증명 |

## 검증

```
npx tsc --noEmit                      exit 0
src/store-shell-auth.test.ts          8 passed (기존 3 + 신규 5)
전체 대시보드 스위트                    8871 passed / 6 failed (2 files)
```

변이 검사 — `recoverFromRejectedShellAuth(normalizedAuth)` 한 줄만 제거:

```
× asks for a fresh dev token and forwards the typed rejection code
× reaches the same recovery through a shell refresh response
  (나머지 6건은 통과 — 경계 케이스는 배선과 무관하게 유지)
Tests  2 failed | 6 passed (8)
```

### 실패 6건은 이 PR 과 무관합니다

같은 커밋(`b94e3fc95c`)에서 **이 변경 없이** 전체 스위트를 돌린 베이스라인이 동일한 2파일 6건입니다.

| 파일 | 실패 | 베이스라인 |
|---|---|---|
| `src/components/copilot-dock.test.ts` | 2 | 동일하게 2건 실패 |
| `src/api/mcp.test.ts` | 4 | 동일하게 4건 실패 |

main 이 이미 red 인 상태입니다 (별건).

## 남긴 것

복구 성공 후 shell 을 즉시 재요청하지 않습니다. hydrate → recover → refreshShell → hydrate 재진입이 생기고, 다음 폴링이 어차피 새 토큰을 실어 보냅니다. 화면 갱신이 한 주기 늦는 것은 감수했습니다.

RFC-0340 §Typed self-healing (기존 계약 이행)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
