### PR TITLE
perf(dashboard): run cached computes off the HTTP domain (RFC-0372 Phase 5)

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -603,10 +603,48 @@ let timeout_error_json ?timeout_kind ?(waiting = false) key timeout_sec =
       ("key", `String key);
     ]
 
+(* RFC-0372 Phase 5 — a bounded compute is still not a yielding compute.
+
+   Phases 1-4 bounded what one dashboard read returns, how many stores it
+   merges, and how long it may run. None of that changes *where* it runs.
+   Every HTTP connection is a fiber forked onto one domain
+   ([server_bootstrap_http.ml]), and Eio fibers switch only at await points.
+   [List.sort] and Yojson decoding contain none, so the domain stops for the
+   whole pure-compute stretch between two file reads: sibling fibers, including
+   [/health], do not run.
+
+   Measured against the live server on 2026-08-12, one telemetry read on an
+   otherwise idle process: [/health] median 10-12ms -> 458ms, peak 5137ms,
+   back to 14ms the instant the read returned. The control pushed 700x more
+   bytes through the same client from a different server and left [/health] at
+   17ms median / 48ms peak, so the stall is the server's, not the harness's.
+   The per-probe timeline degrades across the entire window rather than in
+   periodic spikes, which is the signature of non-yielding compute rather than
+   GC pauses.
+
+   [submit_or_inline] moves the work to a worker domain and turns the caller's
+   wait into an await point, so sibling fibers run. It is also the only
+   sanctioned offload here: [Eio_guard.run_in_systhread] leaves the work with
+   no Eio effect handler, which poisons the shared [dir_mu] and takes keeper
+   persistence down process-wide (see the note in
+   [server_routes_http_routes_provider_runs.ml], which already offloads its own
+   dashboard compute this way). Pool workers run inside [Eio.Switch.run], so
+   [Eio.Mutex.use_rw ~protect] resolves normally.
+
+   Safe to offload here because [compute] runs without holding the cache lock
+   (see the header note); the pool is the only thing the caller waits on.
+
+   Weight stays at the default 1.0. This compute is CPU-bound and occupying a
+   whole worker is the intent; RFC-0204 rejects *reclassifying* existing I/O
+   submissions to 1.0, which is a different change. Pool size then bounds how
+   many computes run at once, so no separate concurrency gate is added. *)
+let offloaded compute () = Executor_pool_ref.submit_or_inline compute
+
 let get_or_compute_with_timeout key ~ttl ~clock ~timeout_sec compute =
   if Option.is_none (peek key) && timeout_circuit_is_open key then
     timeout_error_json ~timeout_kind:"circuit_open" key timeout_sec
   else
+    let compute = offloaded compute in
     try
       let value =
         if Eio_guard.is_ready () then

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -700,6 +700,47 @@ let test_runtime_git_probe_argv_disables_optional_locks () =
     [ "git"; "-C"; "/tmp/demo"; "--no-optional-locks"; "rev-parse"; "--short"; "HEAD" ]
     (Runtime.git_rev_parse_short_probe_argv "/tmp/demo")
 
+(* RFC-0372 Phase 5 — the compute must leave the caller's domain.
+
+   HTTP connections are fibers on one domain, and a pure compute never yields,
+   so a dashboard read run inline stops every sibling fiber for its duration.
+   The fix routes it through the executor pool; this test asserts the routing
+   actually happened by observing which domain [compute] ran on.
+
+   The no-pool leg is the control, and it must observe the caller's own domain.
+   Without it, "compute ran on some domain" passes whether or not the offload
+   took effect — the assertion would hold on the unfixed code too. *)
+let test_compute_leaves_caller_domain ~clock ~sw ~dm () =
+  let caller_domain = (Domain.self () :> int) in
+  let observed = ref None in
+  let compute () =
+    observed := Some (Domain.self () :> int);
+    `String "value"
+  in
+  let run_on key =
+    observed := None;
+    ignore
+      (Dashboard_cache.get_or_compute_with_timeout key ~ttl:60.0 ~clock
+         ~timeout_sec:30.0 compute);
+    !observed
+  in
+  Executor_pool_ref.For_testing.with_pool_option None (fun () ->
+    Alcotest.(check (option int))
+      "control: with no pool installed the compute stays on the caller domain"
+      (Some caller_domain)
+      (run_on "rfc0372-phase5-control"));
+  let pool = Eio.Executor_pool.create ~sw ~domain_count:1 dm in
+  Executor_pool_ref.For_testing.with_pool pool (fun () ->
+    match run_on "rfc0372-phase5-offloaded" with
+    | None -> Alcotest.fail "compute did not run"
+    | Some d ->
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "compute must run off the caller domain (caller=%d, compute=%d)"
+           caller_domain d)
+        true
+        (d <> caller_domain))
+
 (* -- Harness ---------------------------------------------------------------- *)
 
 let () =
@@ -715,6 +756,12 @@ let () =
         [
           test_case "nested get_or_compute" `Quick test_nested_no_deadlock;
           test_case "triple nesting" `Quick test_triple_nesting;
+        ] );
+      ( "offload",
+        [
+          test_case "compute leaves the caller domain" `Quick
+            (test_compute_leaves_caller_domain ~clock ~sw
+               ~dm:(Eio.Stdenv.domain_mgr env));
         ] );
       ( "correctness",
         [


### PR DESCRIPTION
## What

Route every cached dashboard compute through `Executor_pool_ref.submit_or_inline`
so it runs on a worker domain instead of the HTTP domain.

## Why

RFC-0372 Phases 1-4 bounded *what* a dashboard read returns, how many stores it
merges, and how long it may run. None of that changed *where* it runs.

Every HTTP connection is a fiber forked onto one domain
(`server_bootstrap_http.ml:156`), and Eio fibers switch only at await points.
`List.sort` and Yojson decoding contain none, so the domain stops for the whole
pure-compute stretch between two file reads. A bounded read is not a yielding
read.

This is the sibling of the starvation `scheduler_starvation_gate.sh` (Mode A)
already measures, but not the same defect. Mode A injects host CPU hogs and the
process sits at 12-27% CPU *waiting* to be scheduled; its proposed remedies are
QoS and core reservation. Here the domain is genuinely busy computing, so
neither remedy applies.

## Measurement

Isolated server, seeded store (32 keepers, 36 stores, 720k entries, 386MB),
stimulus `GET /api/v1/dashboard/telemetry?n=2000&since_ms=0&worker_run_id=no-such-run`,
observable `/health` latency from a concurrent probe loop. 3 runs each.

| | before | after |
|---|---|---|
| `/health` median during the read | 171.8 / 245.2 / 263.0 ms | **19.6 / 23.5 / 19.5 ms** |
| `/health` p95 during | 477 / 500 / 398 ms | **28.5 / 38.4 / 45.1 ms** |
| amplification vs idle (median) | 11.5x / 11.5x / 10.0x | **1.1x / 1.3x / 1.1x** |
| probes completed inside the window | 12 / 12 / 13 | **129 / 136 / 131** |
| the heavy read itself | 1.90 / 2.87 / 3.01 s | 2.57 / 3.49 / 2.98 s |

The heavy read is not faster and the samples overlap too much to call it a
regression, but cross-domain submission overhead makes slower the expected
direction. What changes is that the rest of the server keeps running: trivial
requests completed inside the window go up about 10x.

Two controls were run before attributing the stall to the server:

- Pushing 700x more bytes through the same client from a *different* server left
  `/health` at 17ms median / 48ms peak, so the degradation is not the harness's.
- The per-probe timeline degrades across the entire window rather than in
  periodic spikes, which is the signature of non-yielding compute rather than GC
  pauses. Probes get through only in the gaps where the read blocks on file I/O.

## Test

`test_dashboard_cache.ml` — "compute leaves the caller domain" observes
`Domain.self ()` inside `compute`.

Falsifiability checked: with the production change stashed, the test fails with
`compute must run off the caller domain (caller=0, compute=0)` while its control
assertion still passes. The control is the no-pool leg, which must observe the
caller's own domain; without it the assertion would hold on unfixed code too.

Full suite: 29 tests, green.

## Notes

- `submit_or_inline` is the only sanctioned offload here.
  `Eio_guard.run_in_systhread` leaves the work with no Eio effect handler, which
  poisons the shared `dir_mu` and takes keeper persistence down process-wide —
  see the existing note in `server_routes_http_routes_provider_runs.ml`, which
  already offloads its own dashboard compute this way. This change generalises
  that one call site to the cache all 46 sites share.
- Weight stays at the default 1.0. This compute is CPU-bound and occupying a
  worker is the intent. RFC-0204 rejects *reclassifying* existing I/O
  submissions to 1.0, which is a different change.
- Offloading is safe here because `compute` runs without holding the cache lock
  (`dashboard_cache.ml` header note).
- No separate concurrency gate is added: pool size now bounds how many computes
  run at once. A `MASC_DASHBOARD_COMPUTE_SLOTS` semaphore was prototyped for
  Phase 4 and measured only ~7% heap reduction while duplicating that bound, so
  it is dropped rather than landed. It never reached main.

RFC-WAIVED: no credential, identity, repo_manager, operator control-plane,
keeper sandbox, hooks or workflow-doc path is touched; this is a scheduling
change inside the dashboard read path, covered by RFC-0372.
