### PR TITLE
docs(rfc): RFC-0373 keeper turn-lane admission — 자율턴이 chat 레인에 굶는 구조

### DIFF
--- a/docs/rfc/RFC-0373-keeper-turn-lane-admission.md
+++ b/docs/rfc/RFC-0373-keeper-turn-lane-admission.md
@@ -1,0 +1,173 @@
+---
+rfc: 373
+title: Keeper turn-lane admission
+status: Draft
+created: 2026-08-12
+---
+
+# RFC-0373: Keeper turn-lane admission
+
+## Problem
+
+A Keeper's autonomous work stops for as long as a chat operation runs, and
+nothing in the system bounds that wait or records that it was owed a turn.
+
+Observed on the live fleet, 2026-08-12, rondo:
+
+```
+13:40:42  keepalive turn scheduled: channel=scheduled_autonomous
+                                    reasons=scheduled_autonomous_turn,task_backlog
+13:44:37  yielded autonomous Owner child to a queued operation after 4538 turn(s),
+          checkpoint saved — will resume next cycle
+13:45:38  Keeper Owner deferred autonomous work: reason=turn_busy
+                                    holder_lane=chat_operation
+                                    holder_started_at=1786542277.7464499
+13:50:47  … same holder
+13:55:50  … same holder
+13:59:44  [fsm:transition] streaming -> failed:provider_error
+```
+
+One chat operation held the turn slot from 13:44:37 to 13:59:44 and ended in a
+provider error. The autonomous lane's own log line promises "will resume next
+cycle"; three consecutive cycles could not keep that promise.
+
+## Current structure
+
+`Keeper_owner` holds exactly one turn slot:
+
+```ocaml
+(* lib/keeper/keeper_owner.ml *)
+type turn_lane =
+  | Autonomous
+  | Chat_operation
+  | Maintenance
+
+type turn_in_flight =
+  { lane : turn_lane
+  ; started_at : float
+  }
+```
+
+The two lanes acquire it by opposite mechanisms.
+
+| | `Chat_operation` | `Autonomous` / `Maintenance` |
+|---|---|---|
+| mechanism | push | pull |
+| who acts | the owner itself, in `start_child_if_needed` | an external caller polling `run_autonomous_if_idle` |
+| when | after 7 distinct owner state transitions | once per keepalive cycle (~5 min observed) |
+| on contention | n/a — it only runs when the slot is free | returns `Busy`, caller abandons the cycle |
+| exported in `.mli` | **no entry point exists** | `run_autonomous_if_idle`, `run_maintenance_if_idle` |
+
+`start_child_if_needed` is re-entered from `Apply_meta`, `Submit_operation`,
+`Wake_operation_drain`, `Rollback_shutdown`, `Restore_shutdown`,
+`Child_finished`, and owner start. The decisive one is `Child_finished`: the
+moment *any* turn ends, the owner synchronously offers the freed slot to a
+queued chat operation. The autonomous lane is not on that path — it discovers
+the slot freed only on its next poll.
+
+On loss, `Defer_autonomous_work` records a skip reason and logs. There is no
+queue, no retry, no aging, and no preemption:
+
+```ocaml
+(* lib/keeper/keeper_heartbeat_loop.ml *)
+| Defer_autonomous_work block ->
+   Keeper_registry.record_skip_reasons … ~reasons:[ "keeper_owner_" ^ … ];
+   Log.Keeper.info … "Keeper Owner deferred autonomous work: %s; this keepalive
+     cycle records no turn status, crash, or work-health refresh"
+```
+
+`turn_admission_open` gates only on `paused`. There is no structure in which
+the autonomous lane can express "give me the slot when it frees".
+
+So the slot is a try-lock that one of its three users re-arms continuously and
+the others sample every five minutes. That asymmetry, not the exclusion itself,
+is what produces starvation.
+
+## What is not established
+
+The exclusivity has no stated rationale. `keeper_owner.mli` documents the
+mailbox contract and the behaviour of `run_autonomous_if_idle`, but
+`turn_lane` carries no doc comment and no cross-lane ordering or fairness
+guarantee is written anywhere. The plausible invariant — one agent-core
+conversation per Keeper, so two concurrent turns would interleave one
+transcript — is inference from the code, not a documented contract.
+
+**Any admission policy has to start by writing that invariant down.** Choosing
+a policy before knowing what the exclusion protects would be guessing.
+
+## Measurements
+
+Whole-day log, 2026-08-12, 7 keepers (`~/me/.masc/logs/system_log_2026-08-12.jsonl`):
+
+| | |
+|---|---|
+| autonomous deferrals | 50 |
+| holder lane was `chat_operation` | **50 / 50** |
+| holder lane was `maintenance` | 0 |
+| distinct blocking operations | 37 |
+| …that blocked more than one cycle | 8 |
+| longest single hold (lower bound) | **16.3 min**, costing 5 consecutive cycles |
+
+Per keeper, autonomous cycles scheduled vs. lost:
+
+| keeper | scheduled | deferred | loss |
+|---|---:|---:|---:|
+| sangsu | 136 | 31 | **18.6%** |
+| rondo | 120 | 8 | 6.2% |
+| analyst | 112 | 4 | 3.4% |
+| kidsnote | 131 | 3 | 2.2% |
+| code-reviewer | 104 | 2 | 1.9% |
+| taskmaster | 119 | 1 | 0.8% |
+| lane-smith | 123 | 1 | 0.8% |
+
+Fleet-wide loss is 5.6%, but it concentrates on the keeper carrying the most
+chat traffic: sangsu loses close to a fifth of its autonomous cycles. The
+distribution is the argument — the more a Keeper is talked to, the less
+autonomous work it does, which inverts the intent of both lanes.
+
+## Rejected direction
+
+Bounding the chat lane's hold with a cap, a timeout, or a cooldown, or
+demoting the repeated deferral log. Each suppresses the symptom while leaving
+admission unfair, and `CLAUDE.md` §워크어라운드 거부 기준 names
+cap/cooldown/dedup/repair as a rejection signature. The 16.3-minute hold is
+not a bug in the chat operation; it is a turn that legitimately took that
+long. The defect is that a legitimate long turn silently costs another lane
+its scheduled work with no record beyond a skip reason.
+
+## Directions to evaluate
+
+Listed with what each would cost, not ranked — the choice depends on the
+invariant established above.
+
+1. **Symmetric admission.** Let the autonomous lane register intent instead of
+   polling, and have `Child_finished` consult a single admission decision
+   rather than offering the slot to chat unconditionally. Keeps one turn at a
+   time; makes the order explicit and testable. Cost: the owner gains an
+   admission queue and the ordering policy becomes a contract that has to be
+   specified in the `.mli`.
+
+2. **Typed deferral debt.** Keep the try-lock, but make a lost cycle a value
+   the next admission reads, so N consecutive losses change the decision.
+   Smaller change; risks becoming aging-by-another-name if the debt only
+   feeds a threshold.
+
+3. **Separate the lanes.** Only viable if the one-conversation invariant turns
+   out not to require exclusion, which is exactly what is undocumented today.
+
+## Verification
+
+Whichever direction is taken, the acceptance bar is a test that fails against
+the current tree:
+
+- Two lanes contend on one owner; assert the autonomous lane runs within a
+  bounded number of admissions rather than "eventually".
+- A chat operation longer than one keepalive cycle does not cost the
+  autonomous lane more than the specified number of cycles.
+- The `.mli` states the cross-lane ordering, and a test pins it.
+
+## References
+
+- `lib/keeper/keeper_owner.ml` — `turn_in_flight`, `start_child_if_needed`, `Run_if_idle`
+- `lib/keeper/keeper_heartbeat_loop.ml` — `Defer_autonomous_work`
+- `lib/keeper/keeper_unified_turn_success.ml` — the "will resume next cycle" yield


### PR DESCRIPTION
문서만 추가합니다. 코드 변경 없음.

대시보드 이슈 조사(#28411 과 같은 세션) 중 발견한 것으로, "대화가 끝나면 자율턴이 안 쌓인다"는 보고의 실제 사슬입니다.

## 왜 패치가 아니라 RFC 인가

증상은 명확하지만 처방을 고를 근거가 아직 없습니다. `keeper_owner.mli` 는 mailbox 계약과 `run_autonomous_if_idle` 의 동작을 문서화하지만, **`turn_lane` 에는 doc comment 가 없고 레인 간 순서·공정성 계약이 어디에도 적혀 있지 않습니다.** 배타성이 무엇을 지키는지 모르는 상태에서 admission 정책을 고르는 건 추측입니다. 그래서 이 RFC 는 문제와 구조와 실측만 확정하고, 방향 3개는 각각의 비용과 함께 나열만 합니다.

cap / timeout / cooldown 으로 chat 레인 보유 시간을 자르는 방향은 명시적으로 거부했습니다 — `CLAUDE.md` §워크어라운드 거부 기준의 cap-cooldown 시그니처이고, 16.3분 보유는 chat operation 의 버그가 아니라 실제로 그만큼 걸린 정상 턴입니다. 결함은 긴 턴이 아니라, 정상적인 긴 턴이 다른 레인의 예정된 작업을 조용히 없애는데 스킵 사유 외에 아무 기록도 남지 않는다는 점입니다.

## 구조 (핵심)

턴 슬롯은 하나인데 획득 방식이 반대입니다.

| | `Chat_operation` | `Autonomous` |
|---|---|---|
| 방식 | push | pull |
| 주체 | owner 자신 (`start_child_if_needed`) | 외부 폴러 (`run_autonomous_if_idle`) |
| 시점 | owner 상태 전이 7개 지점마다 | keepalive 사이클 1회 (~5분) |
| 경합 시 | 해당 없음 | `Busy` 반환 후 사이클 포기 |
| `.mli` 진입점 | **없음** | 있음 |

결정적인 건 `Child_finished` 입니다 — 어떤 턴이든 끝나는 순간 owner 가 큐에 있는 chat operation 에게 동기적으로 빈 슬롯을 넘깁니다. 자율 레인은 그 경로에 없고, 다음 폴링에서야 슬롯이 빈 걸 압니다. 배타성 자체가 아니라 이 **비대칭**이 굶김을 만듭니다.

## 실측 (2026-08-12, 7 keeper, 하루치)

| | |
|---|---|
| 자율 deferral | 50 |
| holder 가 `chat_operation` | **50 / 50** |
| holder 가 `maintenance` | 0 |
| 서로 다른 차단 operation | 37 |
| 그중 2사이클 이상 차단 | 8 |
| 최장 단일 보유(하한) | **16.3분**, 연속 5사이클 손실 |

| keeper | scheduled | deferred | loss |
|---|---:|---:|---:|
| sangsu | 136 | 31 | **18.6%** |
| rondo | 120 | 8 | 6.2% |
| analyst | 112 | 4 | 3.4% |
| kidsnote | 131 | 3 | 2.2% |
| code-reviewer | 104 | 2 | 1.9% |
| taskmaster | 119 | 1 | 0.8% |
| lane-smith | 123 | 1 | 0.8% |

전체 손실은 5.6% 지만 분포가 논거입니다. 채팅을 많이 받는 keeper 일수록 자율 작업을 덜 합니다 — 두 레인의 의도가 서로를 상쇄합니다.

## 검증 기준 (구현 시)

어느 방향을 택하든 현재 트리에서 실패하는 테스트가 수용 조건입니다.

- 두 레인이 한 owner 에서 경합할 때, 자율 레인이 "언젠가"가 아니라 **정해진 admission 횟수 안에** 실행된다
- keepalive 사이클보다 긴 chat operation 이 자율 레인에서 명시된 사이클 수 이상을 뺏지 않는다
- `.mli` 가 레인 간 순서를 명시하고 테스트가 그것을 고정한다

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
