### PR TITLE
fix(keeper): gate the provider-call deadline on progress, not elapsed

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1130,6 +1130,36 @@ let run_named
             ; body_timeout_s
             ; provider_call_deadline_sec =
                 Keeper_runtime_resolved.provider_call_deadline_sec ()
+            ; (* #28417: the deadline is measured against the keeper's live
+                 progress signal, and this closure is the only thing that
+                 reads it. Injected here rather than imported inside
+                 [Keeper_turn_driver_try_provider] so the stall decision over
+                 there stays pure and unit-testable.
+
+                 Contract: never raises. A failed registry read yields [None],
+                 which degrades the deadline to its pre-#28417 elapsed
+                 ceiling instead of cancelling the attempt being watched. *)
+              provider_progress_probe =
+                Some
+                  (fun () ->
+                    try
+                      match Keeper_registry.get ~base_path keeper_name with
+                      | Some { current_turn_observation = Some obs; _ } ->
+                        Some
+                          { Keeper_turn_driver_try_provider.last_progress_at =
+                              obs.last_progress_at
+                          ; active_tool_count = obs.active_tool_count
+                          }
+                      | Some _ | None -> None
+                    with
+                    | Eio.Cancel.Cancelled _ as e -> raise e
+                    | exn ->
+                      Log.Keeper.warn
+                        "progress probe read failed for %s: %s (deadline \
+                         falls back to elapsed)"
+                        keeper_name
+                        (Printexc.to_string exn);
+                      None)
             ; temperature
             ; accept
             ; hooks

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -10,6 +10,25 @@
 
 open Result.Syntax
 
+(** A reading of the keeper's live in-turn progress signal (#28417).
+
+    Mirrors the two fields of [Keeper_registry_types.turn_observation] the
+    stall decision needs. Kept as its own record so this module does not
+    depend on [Keeper_registry]: the caller supplies the reading, this module
+    decides. *)
+type provider_progress_sample =
+  { last_progress_at : float
+        (** Unix timestamp of the most recent in-turn progress signal
+            (registry transitions, Agent Core streaming events, completed
+            tool calls). *)
+  ; active_tool_count : int
+        (** Tools issued but not yet completed. A tool that runs for minutes
+            refreshes no progress signal while it runs, so a non-zero count
+            means "working", not "stalled" -- the exclusion
+            [Keeper_registry_types]' [active_tool_count] doc comment has
+            described since RFC-0197 without any code ever reading it. *)
+  }
+
 (** Explicit context record for the extracted [try_provider] function.
 
     Each field corresponds to a variable captured by the original closure.
@@ -44,14 +63,38 @@ type try_provider_ctx =
   ; model_input_projection : Agent_core.Agent.model_input_projection option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
-  ; (* #27349: total wall-clock ceiling for THIS provider call attempt,
-       independent of streaming progress -- distinct from
-       [stream_idle_timeout_s] (inter-line gap) and [body_timeout_s]
-       (non-streaming body read only). [None] (the operator has not set
-       [MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC]) means no MASC-side
-       enforcement; the call runs exactly as it did before this field
-       existed. See [run_try_provider]'s use of [Eio.Time.with_timeout_exn]. *)
+  ; (* #27349, axis changed by #28417: the ceiling for THIS provider call
+       attempt. Distinct from [stream_idle_timeout_s] (streaming inter-line
+       gap) and [body_timeout_s] (non-streaming body read only): both of
+       those are AGENT_CORE-internal and observe the transport only, which is
+       why they left the non-streaming and pre-first-token (Admission/Queue)
+       stalls of #27355 unprotected.
+
+       #27349 measured this against total elapsed wall-clock. Elapsed cannot
+       separate "a turn that stopped" from "a turn that is taking a while",
+       and on 2026-08-12 the same 900s value did both at once: it correctly
+       rotated 4 wedged sangsu attempts (65 minutes with zero trajectory
+       events) and killed a healthy rondo attempt 6 seconds after a
+       successful tool call (30+ tool calls inside the window, longest
+       progress gap 120s). #28417 moves the measurement onto the progress
+       signal, which is the distinction #27355's own observation side always
+       documented -- see the OTel help text emitted for
+       [InFlightElapsedSeconds]: "a supervising consumer judges staleness
+       against progress, not against this value alone."
+
+       [None] (the operator has not set
+       [MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC] or
+       [turn.provider_call_deadline_sec]) means no MASC-side enforcement. *)
     provider_call_deadline_sec : float option
+  ; (* #28417: reads the keeper's live turn progress signal. Injected as a
+       callback instead of calling [Keeper_registry] from here so the stall
+       decision stays a pure function of its inputs (unit-testable with no
+       registry on disk) and this module keeps its current dependency set.
+
+       [None] disables progress-awareness and the deadline degrades to the
+       pre-#28417 elapsed ceiling. That is the conservative direction: it can
+       fire early on a healthy turn, never late on a wedged one. *)
+    provider_progress_probe : (unit -> provider_progress_sample option) option
   ; temperature : float option
   ; accept : Agent_core.Types.api_response -> bool
   ; hooks : Agent_core.Hooks.hooks option
@@ -231,6 +274,49 @@ let observe_checkpoint_stage observed (_ : Agent_core.Agent.checkpoint_stage) =
 ;;
 
 let same_run_retry_allowed observed = not (Atomic.get observed)
+
+(* #28417: how often the stall watchdog samples the progress signal while a
+   provider attempt runs. Small enough that the reported stall time stays
+   close to the configured threshold, large enough that a fleet of keepers
+   does not poll the registry continuously. Detection therefore lands in
+   [threshold_sec, threshold_sec + progress_poll_interval_sec). *)
+let progress_poll_interval_sec = 15.0
+
+let attempt_stalled ~now ~threshold_sec ~attempt_started_at ~sample =
+  match sample with
+  | Some { last_progress_at; active_tool_count } ->
+    (* A tool call that runs for minutes refreshes no progress signal while
+       it runs, so tools in flight are work, not a stall. The 2026-08-12
+       rondo attempt spent 120s inside one [Execute] and was healthy. *)
+    active_tool_count = 0 && now -. last_progress_at > threshold_sec
+  | None ->
+    (* Probe absent, or the keeper has no live turn observation to read.
+       Falling back to elapsed time reproduces the pre-#28417 ceiling: losing
+       the progress signal must not silently disable enforcement and leave a
+       wedged attempt running unbounded. *)
+    now -. attempt_started_at > threshold_sec
+;;
+
+(* #28417: blocks until the attempt has gone [threshold_sec] without a
+   progress signal, then returns. [probe] is contracted not to raise (the
+   injection site converts a failed registry read into [None]), so a
+   transient read failure degrades this fiber to the elapsed fallback instead
+   of cancelling the attempt it is watching. *)
+let rec await_attempt_stall ~clock ~threshold_sec ~attempt_started_at ~probe =
+  Eio.Time.sleep clock progress_poll_interval_sec;
+  let sample =
+    match probe with
+    | Some read -> read ()
+    | None -> None
+  in
+  if attempt_stalled
+       ~now:(Eio.Time.now clock)
+       ~threshold_sec
+       ~attempt_started_at
+       ~sample
+  then ()
+  else await_attempt_stall ~clock ~threshold_sec ~attempt_started_at ~probe
+;;
 
 let rejected_body_bytes = function
   | Agent_core.Error.Api
@@ -650,33 +736,54 @@ let run_try_provider
         in
         run_fn ())
     in
-    (* #27349: [Eio.Time.with_timeout]'s own signature requires a
-       polymorphic-variant error row ([> `Timeout]), which
-       [run_attempt_switch]'s concrete [Agent_core.Error.t] result
-       cannot unify with, so [with_timeout_exn] (raises the [Timeout]
-       exception) is the primitive that fits here — the established
-       pattern in this repo for wrapping a concretely-typed result
-       (graphql_client.ml, server_ide_lsp_proxy.ml). Catches ONLY
-       [Eio.Time.Timeout]: [Eio.Cancel.Cancelled] is never caught here, so
-       an outer cancellation (switch shutdown, etc.) propagates unmodified.
-       AGENT_CORE's own internal [stream_idle_timeout_s]/[body_timeout_s] firing
-       is a typed RETURN VALUE inside [Runtime_agent.run]'s result, not a
-       raised exception, so it can never reach this handler and be
-       misclassified as this deadline firing. *)
+    (* #28417: the attempt races a stall watchdog through [Eio.Fiber.first],
+       which cancels whichever fiber loses. This replaces #27349's
+       [Eio.Time.with_timeout_exn] wrap because that primitive can only count
+       elapsed time, while the verdict now depends on the keeper's progress
+       signal — something only a polling fiber can observe.
+
+       Cancellation semantics are unchanged: the attempt's own
+       [Eio.Switch.run] still unwinds when it loses the race, and
+       [Eio.Cancel.Cancelled] raised by an OUTER cancellation (switch
+       shutdown, etc.) still propagates unmodified because neither branch
+       catches it. AGENT_CORE's internal
+       [stream_idle_timeout_s]/[body_timeout_s] firing remains a typed RETURN
+       VALUE inside [Runtime_agent.run]'s result rather than an exception, so
+       it still cannot be misclassified as this deadline firing. *)
     let result =
       match ctx.provider_call_deadline_sec, Eio_context.get_clock_opt () with
-      | Some deadline_sec, Some clock ->
-        (try Eio.Time.with_timeout_exn clock deadline_sec run_attempt_switch with
-         | Eio.Time.Timeout ->
+      | Some threshold_sec, Some clock ->
+        let attempt_started_at = Eio.Time.now clock in
+        (match
+           Eio.Fiber.first
+             (fun () -> `Attempt_finished (run_attempt_switch ()))
+             (fun () ->
+               await_attempt_stall
+                 ~clock
+                 ~threshold_sec
+                 ~attempt_started_at
+                 ~probe:ctx.provider_progress_probe;
+               `Attempt_stalled)
+         with
+         | `Attempt_finished attempt_result -> attempt_result
+         | `Attempt_stalled ->
            Error
              (Agent_core.Error.Api
                 (Llm_provider.Retry.Timeout
                    { message =
                        Printf.sprintf
-                         "provider call exceeded the configured wall-clock \
-                          deadline (%.0fs, runtime_id=%s)"
-                         deadline_sec
+                         "provider call made no progress for %.0fs \
+                          (runtime_id=%s)"
+                         threshold_sec
                          ctx.runtime_id
+                       (* [Wall_clock] is kept deliberately: the existing
+                          classifiers
+                          ([Runtime_attempt_fsm.should_try_next],
+                          [Keeper_provider_runtime_boundary.is_provider_timeout_error])
+                          already route this phase to declared-lane candidate
+                          rotation, and this is still a wall-clock-derived
+                          verdict. Introducing a new phase would change retry
+                          policy, which #28417 does not intend to touch. *)
                    ; phase = Some Llm_provider.Http_client.Wall_clock
                    })))
       | None, _ | _, None -> run_attempt_switch ()

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -1,5 +1,18 @@
 (** Extracted provider-attempt runner for keeper runtime turns. *)
 
+(** A reading of the keeper's live in-turn progress signal (#28417).
+
+    Mirrors the two [Keeper_registry_types.turn_observation] fields the stall
+    decision needs, so this module decides without depending on
+    [Keeper_registry]. *)
+type provider_progress_sample =
+  { last_progress_at : float
+        (** Unix timestamp of the most recent in-turn progress signal. *)
+  ; active_tool_count : int
+        (** Tools issued but not yet completed; non-zero means work in
+            flight, not a stall. *)
+  }
+
 type try_provider_ctx =
   { runtime_id : string
   ; error_runtime_id : string
@@ -18,6 +31,13 @@ type try_provider_ctx =
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; provider_call_deadline_sec : float option
+        (** Seconds a provider attempt may go WITHOUT a progress signal
+            before it is cancelled and rotated (#28417 changed this from a
+            total-elapsed ceiling). [None] disables MASC-side enforcement. *)
+  ; provider_progress_probe : (unit -> provider_progress_sample option) option
+        (** Reads the keeper's live progress signal. Must not raise; return
+            [None] when unavailable, which degrades the deadline to the
+            pre-#28417 elapsed ceiling. *)
   ; temperature : float option
   ; accept : Agent_core.Types.api_response -> bool
   ; hooks : Agent_core.Hooks.hooks option
@@ -66,6 +86,25 @@ val observe_checkpoint_stage :
   bool Atomic.t -> Agent_core.Agent.checkpoint_stage -> unit
 
 val same_run_retry_allowed : bool Atomic.t -> bool
+
+val attempt_stalled :
+  now:float
+  -> threshold_sec:float
+  -> attempt_started_at:float
+  -> sample:provider_progress_sample option
+  -> bool
+(** The stall verdict for a running provider attempt (#28417), pure in its
+    inputs so it is testable without Eio or a registry.
+
+    With a [sample], the attempt is stalled when no tool is in flight AND the
+    last progress signal is older than [threshold_sec]. A tool call that runs
+    for minutes refreshes no progress signal while it runs, so tools in
+    flight count as work.
+
+    With [sample = None] (probe absent, or no live turn observation), the
+    verdict falls back to elapsed time since [attempt_started_at] — the
+    pre-#28417 behaviour, so a lost progress signal cannot silently disable
+    enforcement. *)
 
 val default_context_overflow_shrink_capacity : capacity_bytes:int -> int
 (** The shared provider-oracle target for one ordinary shrink step. The

--- a/test/test_keeper_provider_call_deadline.ml
+++ b/test/test_keeper_provider_call_deadline.ml
@@ -16,7 +16,13 @@
       ([Keeper_provider_runtime_boundary.is_provider_timeout_error]) without
       any change to either classifier.
 
-    The Eio.Time.with_timeout_exn wrap itself has no unit fixture, matching
+    - {!Masc.Keeper_turn_driver_try_provider.attempt_stalled}: the stall
+      verdict itself (#28417). #27349 measured the deadline against total
+      elapsed time, which cannot separate "a turn that stopped" from "a turn
+      that is taking a while"; the fixtures below are the two 2026-08-12
+      production attempts that proved it, one of each kind.
+
+    The Eio fiber race that applies the verdict has no unit fixture, matching
     this file's existing coverage boundary (no test calls [run_try_provider]
     directly either -- see test_keeper_turn_driver_failover.ml for the
     candidate-rotation layer's equivalent boundary). *)
@@ -62,6 +68,88 @@ let test_a_steadily_progressing_turn_stays_near_zero () =
     (Pulse.in_flight_elapsed_ms ~now_ts ~started_at);
   check (float 0.001) "since-last-progress stays small" 1.0
     (Pulse.since_last_progress_ms ~now_ts ~last_progress_at)
+;;
+
+(* {1 attempt_stalled -- the verdict the deadline now applies (#28417)} *)
+
+module Try_provider = Masc.Keeper_turn_driver_try_provider
+
+let sample ~last_progress_at ~active_tool_count =
+  Some { Try_provider.last_progress_at; active_tool_count }
+;;
+
+let threshold_sec = 900.0
+let attempt_started_at = 1_000_000.0
+
+let test_a_progressing_attempt_is_not_stalled () =
+  (* rondo, 2026-08-12 13:59:44Z: the attempt was cancelled 6 seconds after a
+     successful masc_transition, with 30+ tool calls inside the window. Its
+     ELAPSED time had reached the threshold -- which is exactly why the
+     pre-#28417 axis killed it -- while its progress was 6 seconds old. *)
+  let now = attempt_started_at +. threshold_sec +. 1.0 in
+  check bool "progress 6s ago is not a stall, however long the attempt ran"
+    false
+    (Try_provider.attempt_stalled
+       ~now
+       ~threshold_sec
+       ~attempt_started_at
+       ~sample:(sample ~last_progress_at:(now -. 6.0) ~active_tool_count:0))
+;;
+
+let test_a_wedged_attempt_is_stalled () =
+  (* sangsu, 2026-08-12 10:04Z-11:10Z: zero trajectory events for 65 minutes.
+     This is the class #27355 introduced the deadline for and it must still
+     fire on the new axis. *)
+  let now = attempt_started_at +. 4_000.0 in
+  check bool "65 minutes without a progress signal is a stall" true
+    (Try_provider.attempt_stalled
+       ~now
+       ~threshold_sec
+       ~attempt_started_at
+       ~sample:(sample ~last_progress_at:(now -. 3_900.0) ~active_tool_count:0))
+;;
+
+let test_a_tool_in_flight_is_not_a_stall () =
+  (* One Execute ran 120s inside rondo's window without refreshing the
+     progress signal. A tool that has been issued but not completed is work,
+     not a stall -- the exclusion [active_tool_count] has documented since
+     RFC-0197 with no code reading it until now. *)
+  let now = attempt_started_at +. 500.0 in
+  check bool "a tool in flight suppresses the stall verdict" false
+    (Try_provider.attempt_stalled
+       ~now
+       ~threshold_sec:60.0
+       ~attempt_started_at
+       ~sample:(sample ~last_progress_at:(now -. 200.0) ~active_tool_count:1))
+;;
+
+let test_the_threshold_boundary_is_exclusive () =
+  let now = attempt_started_at +. threshold_sec in
+  check bool "exactly at the threshold is not yet a stall" false
+    (Try_provider.attempt_stalled
+       ~now
+       ~threshold_sec
+       ~attempt_started_at
+       ~sample:
+         (sample ~last_progress_at:(now -. threshold_sec) ~active_tool_count:0))
+;;
+
+let test_a_missing_sample_falls_back_to_elapsed () =
+  (* Losing the progress signal must not silently disable enforcement, so the
+     verdict degrades to the pre-#28417 elapsed ceiling rather than to
+     "never stalled". *)
+  check bool "no sample, elapsed past the threshold, is a stall" true
+    (Try_provider.attempt_stalled
+       ~now:(attempt_started_at +. threshold_sec +. 1.0)
+       ~threshold_sec
+       ~attempt_started_at
+       ~sample:None);
+  check bool "no sample, elapsed within the threshold, is not a stall" false
+    (Try_provider.attempt_stalled
+       ~now:(attempt_started_at +. 500.0)
+       ~threshold_sec
+       ~attempt_started_at
+       ~sample:None)
 ;;
 
 (* {1 the synthetic Wall_clock timeout joins existing paths} *)
@@ -129,6 +217,18 @@ let () =
             test_since_last_progress_ms_floors_at_zero
         ; test_case "a steadily progressing turn stays near zero" `Quick
             test_a_steadily_progressing_turn_stays_near_zero
+        ] )
+    ; ( "attempt_stalled"
+      , [ test_case "a progressing attempt is not stalled" `Quick
+            test_a_progressing_attempt_is_not_stalled
+        ; test_case "a wedged attempt is stalled" `Quick
+            test_a_wedged_attempt_is_stalled
+        ; test_case "a tool in flight is not a stall" `Quick
+            test_a_tool_in_flight_is_not_a_stall
+        ; test_case "the threshold boundary is exclusive" `Quick
+            test_the_threshold_boundary_is_exclusive
+        ; test_case "a missing sample falls back to elapsed" `Quick
+            test_a_missing_sample_falls_back_to_elapsed
         ] )
     ; ( "wall_clock_timeout_integration"
       , [ test_case "carries the Wall_clock phase" `Quick


### PR DESCRIPTION
Closes #28417.

## 목적

`provider_call_deadline_sec` 의 측정 축을 **총 elapsed** 에서 **마지막 progress 이후 경과** 로 바꾼다.

elapsed 는 "멈춘 턴"과 "오래 걸리는 턴"을 구분하지 못한다. 2026-08-12 하루 동안 같은 900 값이 두 가지를 동시에 했다:

| 발화(UTC) | keeper | 창 내부 활동 | 결과 |
|---|---|---|---|
| 10:20:36 · 10:35:39 · 10:53:26 · 11:10:07 | sangsu | trajectory 이벤트 **0건 / 65분** | wedge 회전 — 의도대로 동작 |
| 13:59:44 | rondo | 도구 호출 **30회+**, 최장 progress 간격 120s | **정상 턴 폐기** — 마지막 도구 성공 6초 후 |

rondo 손실: 900초 작업 폐기(`no_degraded_retry` — 재시도·캐스케이드 회전 없음) + 재시작 복구 7분 24초.

## 왜 이 축인가

이 구분은 #27355 의 **관측 side 가 이미 문서화**하고 있었다. 같은 이슈가 심은 OTel help 텍스트 (`keeper_heartbeat_loop_in_turn_pulse.ml`):

> `InFlightElapsedSeconds`: "a supervising consumer judges staleness against **progress, not against this value alone**."
> `SinceLastProgressSeconds`: "a long-running turn that keeps progressing stays near zero; a stalled provider call grows unbounded."

`test_keeper_provider_call_deadline.ml` 의 기존 테스트 `a steadily progressing turn stays near zero` 주석도 같은 설계 의도를 명시한다. 신호(`since_last_progress_ms`)는 #27355 이후 always-on 으로 계산되어 SSE + OTel 로 나가고 있었고, **집행부만 그것을 읽지 않았다**. 이 PR 은 새 개념을 도입하지 않고 그 배선을 잇는다.

## 변경

- `keeper_turn_driver_try_provider.ml`
  - `provider_progress_sample` 타입 (`last_progress_at`, `active_tool_count`) 추가
  - `attempt_stalled` — 순수 판정 함수. tool 이 in-flight 면 stall 아님
  - `await_attempt_stall` — 15초 주기 폴링 워치독
  - 집행: `Eio.Time.with_timeout_exn` → `Eio.Fiber.first` (attempt vs 워치독 경쟁)
- `keeper_turn_driver.ml` — probe 클로저 주입 (registry 읽기는 여기서만)
- `test_keeper_provider_call_deadline.ml` — 위 두 실측 사례를 픽스처로 한 5개 케이스

### 설정 변경 없음

`turn.provider_call_deadline_sec = 900` 을 그대로 두면 새 축에서 두 사례가 정확히 갈린다: rondo(progress 간격 최대 120s)는 통과, sangsu(65분 무progress)는 15분에 발화. 운영자 액션 0, TOML 편집 0.

키 이름이 새 의미와 어긋나는 것은 사실이나, registry 에 선언되지 않은 TOML 키는 부팅 FATAL 이라 rename 은 새 바이너리와 옛 TOML 이 만나는 창에서 masc 를 못 뜨게 한다. 이름 정리는 별도 이슈로 분리한다.

## 설계 결정

- **probe 는 callback 주입.** `Keeper_turn_driver_try_provider` 가 `Keeper_registry` 를 직접 참조하지 않는 현재 의존 경계를 유지하고, stall 판정을 registry 없이 단위 테스트할 수 있게 한다.
- **probe 실패 → elapsed 폴백.** progress 신호를 잃었을 때 "절대 stall 아님"으로 degrade 하면 wedge 가 무한 실행된다. 폴백은 #28417 이전 동작이므로 보수적 방향(일찍 발화할 수는 있어도 늦지 않음).
- **`active_tool_count = 0` 조건.** 수 분짜리 도구는 실행 중 progress 신호를 갱신하지 않는다. 이 제외는 `keeper_registry_types.mli` 가 RFC-0197 을 인용하며 문서화해왔으나, `Mid_turn_no_progress` 심볼도 RFC-0197 파일도 저장소에 존재하지 않는다 — 읽는 코드가 처음 생겼다.
- **`Wall_clock` phase 유지.** `Runtime_attempt_fsm.should_try_next` 와 `Keeper_provider_runtime_boundary.is_provider_timeout_error` 가 이 phase 를 candidate rotation 으로 라우팅한다. 새 phase 는 retry 정책을 바꾸므로 범위 밖.
- **`Eio.Time.now` 사용.** `Unix.gettimeofday` 는 `scripts/ci/check-determinism-contract.sh` 의 diff ratchet 이 새 사이트에서 차단한다.

## 취소 semantics (불변)

`Eio.Fiber.first` 는 지는 fiber 를 취소한다. attempt 의 `Eio.Switch.run` 은 그대로 unwind 하고, 바깥에서 온 `Eio.Cancel.Cancelled` 는 어느 분기도 잡지 않으므로 그대로 전파된다. AGENT_CORE 내부의 `stream_idle_timeout_s`/`body_timeout_s` 는 여전히 `Runtime_agent.run` 결과 안의 typed 반환값이라 이 판정과 섞이지 않는다.

## 검증 (로컬)

| 검사 | 결과 |
|---|---|
| `dune build --root . @check` | PASS (에러 0) |
| `dune exec --root . test/test_keeper_provider_call_deadline.exe` | **14 tests run, Test Successful** |
| `scripts/ci/check-determinism-contract.sh` | **DET/NDT gate: PASS** |

### 회귀 감지 대조군 (mutation)

테스트가 통과한다는 사실만으로는 그것이 이 변경을 지키는지 알 수 없어서, `attempt_stalled` 의 progress 분기를 구 동작(elapsed)으로 일시 치환해 확인했다:

```
[FAIL] attempt_stalled  0  a progressing attempt is not stalled
[FAIL] attempt_stalled  2  a tool in flight is not a stall
2 failures! in 0.002s. 14 tests run.
```

wedge / boundary / fallback 3건은 구·신 양쪽에서 동일하게 통과한다 — wedge 는 두 축 모두에서 잡혀야 하므로 의도대로다. 치환은 되돌렸고 diff 에 잔여 없음(확인함).

## 미검증

- 워치독 fiber 경쟁의 통합 테스트는 없다. 이 파일의 기존 커버리지 경계와 동일 (`run_try_provider` 를 직접 호출하는 테스트가 원래 없음).
- 폴링 주기 15초 → stall 감지는 `[threshold, threshold + 15s)` 구간에 떨어진다.
- sangsu 4건 중 첫 건만 창 내부 활동을 확인했다. 나머지 3건은 같은 65분 무이벤트 구간 안에 있다는 사실로 귀속했다.

RFC-WAIVED: 변경 범위가 `lib/keeper/keeper_turn_driver*` 로, RFC 필수 subsystem(credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential, hooks, workflow 문서) 어디에도 해당하지 않음.
