### PR TITLE
refactor(dated_jsonl): cut the tail in one pass instead of four copies

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -506,6 +506,57 @@ let open_regular_input_result path =
     at most once while walking backwards. The loop stops after the chunk that
     contains the [n]th physical non-empty line, so it overscans by at most one
     8 KB chunk. Chunks are concatenated exactly once. *)
+(* Segment [buffer] on ['\n'] exactly as [String.split_on_char] does — the final
+   segment is always emitted, empty or not — without allocating anything. *)
+let fold_newline_segments buffer f init =
+  let len = Bytes.length buffer in
+  let rec loop start index acc =
+    if index >= len then f acc start len
+    else if Bytes.get buffer index = '\n' then
+      loop (index + 1) (index + 1) (f acc start index)
+    else loop start (index + 1) acc
+  in
+  loop 0 0 init
+
+let rec segment_has_content buffer index stop =
+  index < stop
+  && (not (trim_whitespace (Bytes.get buffer index))
+      || segment_has_content buffer (index + 1) stop)
+
+(* Cut the last [max_lines] non-empty segments out of [buffer].
+
+   The previous shape was [Bytes.to_string |> String.split_on_char |>
+   List.filter |> List.length |> List.filteri]. That copies the whole tail into
+   a string, then allocates a string for every segment including the ones about
+   to be dropped, then builds three lists over them. One dashboard read tails 36
+   stores at up to 2000 lines of ~520B each, so those copies are tens of MB of
+   short-lived allocation per request.
+
+   That matters beyond this reader: profiling one wide read showed the CPU
+   dominated by [caml_stw_empty_minor_heap] and the surrounding barrier frames,
+   and OCaml 5 stops *every* domain for each minor collection. Allocation here
+   is paid by every fiber in the process, not just this one.
+
+   Two scans over the buffer allocate nothing; only surviving lines become
+   strings. *)
+let last_non_empty_lines buffer ~max_lines =
+  let count =
+    fold_newline_segments buffer
+      (fun total start stop ->
+         if segment_has_content buffer start stop then total + 1 else total)
+      0
+  in
+  let skip = max 0 (count - max_lines) in
+  let _, reversed =
+    fold_newline_segments buffer
+      (fun (seen, acc) start stop ->
+         if not (segment_has_content buffer start stop) then (seen, acc)
+         else if seen < skip then (seen + 1, acc)
+         else (seen + 1, Bytes.sub_string buffer start (stop - start) :: acc))
+      (0, [])
+  in
+  List.rev reversed
+
 let load_tail_lines_from_channel input ~max_lines =
   if max_lines <= 0
   then []
@@ -550,16 +601,7 @@ let load_tail_lines_from_channel input ~max_lines =
           0
           !chunks
       in
-      let lines =
-        combined
-        |> Bytes.to_string
-        |> String.split_on_char '\n'
-        |> List.filter line_is_non_empty
-      in
-      let line_count = List.length lines in
-      if line_count <= max_lines
-      then lines
-      else List.filteri (fun index _ -> index >= line_count - max_lines) lines
+      last_non_empty_lines combined ~max_lines
     end
 ;;
 

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -380,6 +380,64 @@ let test_load_tail_lines_drops_partial_chunk_prefix () =
   let lines = Dated_jsonl.load_tail_lines path ~max_lines:5 in
   check (list string) "drops partial chunk prefix" expected lines
 
+(* Differential test for the single-pass rewrite of the tail cutter.
+
+   [load_tail_lines] used to build its result as
+   [Bytes.to_string |> String.split_on_char |> List.filter |> List.filteri].
+   That reference is reproduced here and compared against the live
+   implementation over generated inputs, so the rewrite is held to producing the
+   same list rather than to a handful of hand-picked cases. The generator mixes
+   blank lines, whitespace-only lines, a missing trailing newline, and contents
+   that straddle the 8KB chunk boundary, because those are where the two shapes
+   could diverge.
+
+   Seeded so a failure reproduces. *)
+let reference_tail_lines content ~max_lines =
+  if max_lines <= 0 then []
+  else
+    let is_blank character =
+      match character with ' ' | '\012' | '\n' | '\r' | '\t' -> true | _ -> false
+    in
+    let lines =
+      content
+      |> String.split_on_char '\n'
+      |> List.filter (fun line ->
+           String.exists (fun character -> not (is_blank character)) line)
+    in
+    let count = List.length lines in
+    if count <= max_lines then lines
+    else List.filteri (fun index _ -> index >= count - max_lines) lines
+
+let test_load_tail_lines_matches_reference () =
+  let dir = tmpdir "dated_jsonl_tail_differential" in
+  let state = Random.State.make [| 0x7A11 |] in
+  for case = 0 to 199 do
+    let row_count = Random.State.int state 40 in
+    let rows =
+      List.init row_count (fun index ->
+        match Random.State.int state 6 with
+        | 0 -> ""
+        | 1 -> "   "
+        | 2 -> "\t \r"
+        | 3 ->
+          (* straddle the 8KB chunk boundary *)
+          Printf.sprintf {|{"i":%d,"pad":"%s"}|} index
+            (String.make (Random.State.int state 3000) 'x')
+        | _ -> Printf.sprintf {|{"i":%d}|} index)
+    in
+    let content =
+      String.concat "\n" rows
+      ^ if Random.State.bool state then "\n" else ""
+    in
+    let path = Filename.concat dir (Printf.sprintf "case%d.jsonl" case) in
+    Fs_compat.append_file path content;
+    let max_lines = 1 + Random.State.int state 12 in
+    check (list string)
+      (Printf.sprintf "case %d (rows=%d, max_lines=%d)" case row_count max_lines)
+      (reference_tail_lines content ~max_lines)
+      (Dated_jsonl.load_tail_lines path ~max_lines)
+  done
+
 let test_load_tail_lines_missing_file_is_empty () =
   let path = Filename.concat (tmpdir "dated_jsonl_missing_tail") "missing.jsonl" in
   check
@@ -808,6 +866,8 @@ let () =
           test_case "strict latest scan crosses chunks" `Quick
             test_find_latest_entry_result_scans_backwards_across_chunks;
           test_case "drops partial chunk prefix" `Quick test_load_tail_lines_drops_partial_chunk_prefix;
+          test_case "matches the pre-rewrite reference" `Quick
+            test_load_tail_lines_matches_reference;
           test_case "missing tail is empty" `Quick
             test_load_tail_lines_missing_file_is_empty;
           test_case "counts nonempty tail rows exactly" `Quick


### PR DESCRIPTION
## What

`load_tail_lines_from_channel` built its result as

```ocaml
Bytes.to_string |> String.split_on_char '\n' |> List.filter |> List.filteri
```

which copies the whole tail into a string, allocates a string for every segment
including the ones about to be dropped, and builds three lists over them. The
existing comment — "chunks are concatenated exactly once" — describes only the
concatenation; three more copies follow it.

Replaced with two allocation-free scans over the buffer that cut only the
surviving segments.

## Why

One dashboard read tails 36 stores at up to 2000 lines of ~520B, so this is tens
of MB of short-lived allocation per request. OCaml 5 stops **every** domain for
each minor collection, so allocation here is paid process-wide rather than
locally.

## Honest measurement

**No measurable end-to-end win**, and that is consistent with the profile.
Sampling one wide read attributed ~580 samples to GC stop-the-world frames
(`caml_stw_empty_minor_heap_no_major_slice`, `caml_mark_roots_stw`,
`caml_try_run_on_all_domains_with_spin_work` and the surrounding barriers) and
49 to this reader — so removing its allocation entirely could only ever move a
small share. The dominant allocator is the JSON parse trees built for lines that
are then filtered out, which is a separate and larger change.

3 runs each, same store (32 keepers / 720k entries) and stimulus:

| | before | after |
|---|---|---|
| CPU | 5.10s | 4.87s |
| RSS delta | 110MB | 96MB |
| wall | 2.73s | 2.70s |

CPU and wall are within run-to-run noise on this host and I am not claiming
them. RSS delta is suggestive but n=3.

## The durable part is the test

`test_load_tail_lines_matches_reference` reproduces the pre-rewrite algorithm
inside the test and compares it against the live implementation over 200 seeded
inputs mixing blank lines, whitespace-only lines, a missing trailing newline,
and contents straddling the 8KB chunk boundary.

The expected side is an independent reimplementation, not a call to the function
under test, so it is not an identity. Injecting an off-by-one into `skip` makes
it fail, so it discriminates.

Full suite: 44 tests. One unrelated pre-existing failure —
`read_range 4 / strict entry iteration` rejects a `.DS_Store` that macOS drops
into the test's temp directory (`expected YYYY-MM month directory`). It does not
touch the tail reader. Filed separately.

RFC-WAIVED: storage read path refactor with proven output equivalence; no
credential, identity, operator control-plane, sandbox, hook or workflow path is
touched.
