### PR TITLE
docs(rfc): RFC-0374 keeper capability probe lane

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -235,6 +235,9 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0368 | 판단 없는 recovery는 keeper의 다음 claim이 스스로 해제한다 | Draft | - |
 | 0370 | Provider profile SSOT, quota-as-state, rotation eligibility for Internal-carr... | Draft | - |
 | 0371 | Effect 경계 회복 — 이펙트는 경계로, 코어는 순수 로직으로 | Draft | - |
+| 0372 | Request-scoped resource budget — bound what one read may consume | Draft | - |
+| 0373 | Keeper turn-lane admission | Draft | - |
+| 0374 | Keeper Capability Probe Lane | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |

--- a/docs/rfc/RFC-0373-keeper-turn-lane-admission.md
+++ b/docs/rfc/RFC-0373-keeper-turn-lane-admission.md
@@ -1,5 +1,5 @@
 ---
-rfc: 373
+rfc: "0373"
 title: Keeper turn-lane admission
 status: Draft
 created: 2026-08-12

--- a/docs/rfc/RFC-0374-keeper-capability-probe-lane.md
+++ b/docs/rfc/RFC-0374-keeper-capability-probe-lane.md
@@ -1,0 +1,227 @@
+---
+title: Keeper Capability Probe Lane
+rfc: "0374"
+status: Draft
+created: 2026-08-12
+implementation_prs: []
+---
+
+# RFC-0374: Keeper Capability Probe Lane
+
+| Field    | Value                                                              |
+|----------|--------------------------------------------------------------------|
+| Status   | Draft                                                              |
+| Scope    | `lib/keeper/keeper_capability_probe.{ml,mli}` (new), `lib/server/` route, `test/` |
+| Conflict | None expected — additive lane, no change to the turn driver         |
+| Issue    | masc#28414                                                          |
+
+## Problem
+
+There is no way to ask "can keeper K reach tool T on runtime R" without making
+the keeper actually do it in its own conversation. Every answer today costs a
+real turn, and a real turn is durable in three places:
+
+```
+keeper_chat/<k>.jsonl             re-injected into the next prompt
+traces/<trace>/trace-*.json       the Agent Core checkpoint
+config/keepers/<k>.memory-*.json  librarian output, survives both of the above
+```
+
+Measurement therefore mutates the thing being measured. On 2026-08-12 a
+47-runtime audit ran 361 turns through the chat surface and the third layer
+closed on it: the librarian read the accumulated probe traffic and committed a
+`lesson` fact at 20:27 —
+
+```
+RTPROBE 프로브 작업은 echo, read, board_post, board_list, add_task,
+keeper_tasks_list, goal_upsert, goal_list, board_comment, board_vote 등
+반복 실행으로 컨텍스트만 잠식하므로 무응답 처리하는 것이 적절하다.
+```
+
+— naming all ten probed tools and prescribing non-response. 25 subsequent
+turns across 6 runtimes came back `visible_reply` with `tools=[]`. The keeper
+was not wrong: repeated tool exercise does consume its context, and declining
+is a reasonable response to it.
+
+Two properties make this structural rather than incidental:
+
+1. **It regenerates.** The librarian retired an earlier instance of the same
+   fact on its own (rev 1657 added 18:06, rev 1659 removed 18:20) and wrote a
+   new one at 20:27 once probing continued. Clearing state does not help while
+   the method stays the same, and rewording the probe does not change the
+   pattern that produced the rule.
+2. **It destroys attribution, not just throughput.** The rule is soft — after
+   20:27 `ollama-cloud-deepseek-v4-flash-0731` still scored 4/4 and
+   `gpt-5.3-codex-spark` 2/3. So a zero result in that window is consistent
+   with both "the runtime cannot reach the tool" and "the keeper chose not
+   to", and nothing in the record separates them.
+
+A control turn confirms the rule is scoped, not over-general: an ordinary
+request with no probe marker and no tool-forcing ("보드에 최근 올라온 글이
+뭐가 있는지 좀 보여줘") called `masc_board_list` in 14.2 s. Production
+behaviour is intact. What is blocked is measurement.
+
+## Boundary
+
+The question "can K invoke T on R" decomposes into three parts with different
+determinism, and the current method conflates them:
+
+| Part                                          | Determinism   | Needs a model call   |
+|-----------------------------------------------|---------------|----------------------|
+| Is T in the tool surface projected for R       | deterministic | no                   |
+| Does the provider accept a request carrying T  | deterministic | round-trip only      |
+| Does the model choose T when asked             | stochastic    | yes                  |
+
+Only the third needs a turn, and it needs *a* conversation — not *the*
+keeper's conversation. That is the separation this RFC draws: a probe supplies
+its own minimal conversation and its own session identity, and writes to
+neither of the keeper's durable stores.
+
+The keeper's conversation is the SSOT for what the keeper has done. A
+capability probe is not something the keeper has done, so it does not belong
+there. This is a boundary correction, not a new subsystem.
+
+## Design
+
+### Seam
+
+The per-kind runners are already parameterized on exactly the two things that
+have to differ:
+
+```ocaml
+val run :
+  runtime_id:string ->
+  keeper_name:string ->        (* session store key + antigravity home leaf *)
+  base_path:string ->
+  tools:Agent_core.Tool.t list ->
+  initial_messages:Agent_core.Types.message list ->   (* caller supplies *)
+  ...
+```
+
+`initial_messages` means no runner reads the keeper transcript for itself, and
+`keeper_name` is what `Session_store.load ~base_path ~keeper_name`
+(`keeper_antigravity_runtime.ml:225`) and `~owner_leaf` (`:318`) key on. A
+probe passes a synthetic message list and a distinct identity; nothing else in
+the runners has to change.
+
+Persistence is already a separate concern — `Keeper_chat_store.append_*` and
+`Keeper_checkpoint_store.save_agent_core_*` are called by the turn
+orchestration, not by the runners. The probe lane simply does not call them.
+
+### Probe identity
+
+```ocaml
+(** Probe identity is a distinct keeper id, not a flag on the real one.
+    A boolean would leave one session store serving two purposes and put the
+    burden of "was this a probe" on every reader; a separate id makes the
+    isolation structural. *)
+type identity = private string
+
+val probe_identity : keeper_name:string -> identity
+```
+
+`probe_identity ~keeper_name:"sangsu"` yields a reserved id in a namespace that
+cannot collide with a configured keeper. The official-client session store and
+antigravity home for that id are separate directories, so a probe never
+start-or-resumes the keeper's real session.
+
+Reserved-namespace enforcement belongs at keeper registration: a configured
+keeper whose name falls in the probe namespace must be rejected at config
+admission, the same way other identity collisions are.
+
+### Result type
+
+Make the three outcomes that today all read as "0" distinguishable at the type
+level, so callers cannot collapse them:
+
+```ocaml
+type outcome =
+  | Tool_invoked      of { tool : string; elapsed_s : float }
+  | Replied_no_tool   of { reply_bytes : int; tools_seen : string list }
+  | Surface_absent    of { requested : string; advertised : string list }
+  | Provider_rejected of Agent_core.Error.t
+  | Transport_failed  of Agent_core.Error.t
+```
+
+`Surface_absent` is decidable before the model call — the probe compares the
+requested tool against the projected surface and returns without spending a
+turn. That alone answers the antigravity class of question (bridge advertises
+97 tools, CLI consumes none) at zero cost.
+
+No `Unknown -> permissive` arm. An unresolvable runtime id is an `Error`, per
+RFC-0206 §2.1 and the same rule `resolve_runtime_providers` already follows.
+
+### Interface
+
+```ocaml
+val probe_surface :
+  runtime_id:string ->
+  keeper_name:string ->
+  tool:string ->
+  (surface_result, error) result
+(** Deterministic. No provider call, no session, no turn. *)
+
+val probe_invocation :
+  runtime_id:string ->
+  keeper_name:string ->
+  base_path:string ->
+  tool:string ->
+  prompt:string ->
+  (outcome, error) result
+(** One provider round-trip against a synthetic conversation under a probe
+    identity. Writes nothing to keeper_chat, the checkpoint, or memory. *)
+```
+
+### What the probe must not do
+
+These are the invariants the tests exist to hold:
+
+- no `Keeper_chat_store.append_*` under a probe identity
+- no `Keeper_checkpoint_store.save_agent_core_*` under the real keeper's session
+- no write to `config/keepers/<real>.memory-*`
+- no mutation of the real keeper's official-client `session.json`
+
+## Verification
+
+| Check | Method |
+|-------|--------|
+| Probe leaves keeper_chat byte-identical | hash before/after a probe run |
+| Probe leaves the real checkpoint byte-identical | hash before/after |
+| Probe leaves memory revision unchanged | compare `revision` before/after |
+| `Surface_absent` needs no provider call | probe a nonexistent tool with the provider unreachable; must still answer |
+| Probe identity cannot be a configured keeper | config admission rejects a keeper named in the probe namespace |
+| Outcomes stay distinguishable | a quota-exhausted runtime yields `Provider_rejected`, never `Replied_no_tool` |
+
+The load-bearing test is the first three as a set: run N probes, assert all
+three stores are unchanged. That is the property the whole RFC exists to
+provide, and it is the one that regresses silently if a future caller reaches
+for the ordinary turn path.
+
+## Alternatives considered
+
+**Fact provenance instead (masc#28414 proposal 1).** Tag operator-injected
+turns so the librarian excludes them from summarization. Smaller change, and it
+addresses the librarian's actual blind spot. Rejected as the *primary* fix
+because it leaves the first two contamination layers intact — probe turns still
+land in the transcript and the checkpoint, still get re-injected, still grow the
+payload at ~900 KB/h under load. It remains worth doing, and is complementary
+rather than exclusive.
+
+**Rename the probe marker.** Cheapest, and wrong. The lesson enumerates tool
+names, so wording is unlikely to evade it; and the librarian re-promoted the
+rule twice under sustained load, so volume regenerates it regardless. Beyond
+effectiveness: a number obtained by circumventing the subject's stated policy
+is not evidence.
+
+**Delete the memory fact when it appears.** Treats a loop as a state. The
+journal shows the librarian already retires and re-adds this fact on its own;
+hand-editing a locked, journaled, revision-counted document owned by a
+concurrent writer adds a race for no durable benefit.
+
+## Out of scope
+
+- Changing what the librarian summarizes (proposal 1, separate RFC)
+- Any change to the turn driver's dispatch or the per-kind runners
+- Karma: the keeper has no read path to it at all
+  (`lib/tool_surface/` references 0, control `masc_board_vote` 3), so no probe
+  lane can measure it. That is a tool-surface gap, tracked separately.

--- a/docs/rfc/RFC-0374-keeper-capability-probe-lane.md
+++ b/docs/rfc/RFC-0374-keeper-capability-probe-lane.md
@@ -153,15 +153,33 @@ level, so callers cannot collapse them:
 type outcome =
   | Tool_invoked      of { tool : string; elapsed_s : float }
   | Replied_no_tool   of { reply_bytes : int; tools_seen : string list }
-  | Surface_absent    of { requested : string; advertised : string list }
+  | Not_projected     of { requested : string; projected : string list }
   | Provider_rejected of Agent_core.Error.t
   | Transport_failed  of Agent_core.Error.t
 ```
 
-`Surface_absent` is decidable before the model call — the probe compares the
-requested tool against the projected surface and returns without spending a
-turn. That alone answers the antigravity class of question (bridge advertises
-97 tools, CLI consumes none) at zero cost.
+`Not_projected` is decidable before the model call: MASC either puts the tool
+in the surface it hands the client, or it does not. When it does not, no turn
+is worth spending.
+
+**Its converse is not "reachable", and the naming has to keep that visible.**
+Projection is MASC's side of the wire; consumption is the client's. The two
+diverge, and that divergence is the largest single finding of the audit this
+RFC comes from — the antigravity bridge advertised 97 tools including all ten
+probed, `initialize` and `tools/list` both answered, and the models still
+reported no masc tool present. A probe that resolved capability from the
+projected surface alone would have called those runtimes healthy.
+
+So the lane keeps the two questions apart:
+
+| Question                        | Answered by      | Cost   |
+|---------------------------------|------------------|--------|
+| Does MASC project T?            | `probe_surface`  | none   |
+| Does the client consume what MASC projects? | `probe_invocation`, and only by observing a call | one turn |
+
+`Not_projected` is therefore a *sufficient* explanation for failure and never
+a sufficient basis for success. `probe_surface` returning "projected" means
+the turn is worth spending, nothing more.
 
 No `Unknown -> permissive` arm. An unresolvable runtime id is an `Error`, per
 RFC-0206 §2.1 and the same rule `resolve_runtime_providers` already follows.
@@ -203,7 +221,8 @@ These are the invariants the tests exist to hold:
 | Probe leaves keeper_chat byte-identical | hash before/after a probe run |
 | Probe leaves the real checkpoint byte-identical | hash before/after |
 | Probe leaves memory revision unchanged | compare `revision` before/after |
-| `Surface_absent` needs no provider call | probe a nonexistent tool with the provider unreachable; must still answer |
+| `Not_projected` needs no provider call | probe a nonexistent tool with the provider unreachable; must still answer |
+| "projected" is not reported as reachable | a runtime whose client ignores the surface (antigravity) yields `Replied_no_tool`, never a success from `probe_surface` alone |
 | Probe identity cannot be a configured keeper | config admission rejects a keeper named in the probe namespace |
 | Outcomes stay distinguishable | a quota-exhausted runtime yields `Provider_rejected`, never `Replied_no_tool` |
 

--- a/docs/rfc/RFC-0374-keeper-capability-probe-lane.md
+++ b/docs/rfc/RFC-0374-keeper-capability-probe-lane.md
@@ -104,9 +104,24 @@ val run :
 probe passes a synthetic message list and a distinct identity; nothing else in
 the runners has to change.
 
-Persistence is already a separate concern — `Keeper_chat_store.append_*` and
-`Keeper_checkpoint_store.save_agent_core_*` are called by the turn
-orchestration, not by the runners. The probe lane simply does not call them.
+Persistence is already a separate concern, and the runners do not participate
+in it. Measured on `origin/main`:
+
+```
+                                  Keeper_chat_store.  Keeper_checkpoint_store.
+keeper_antigravity_runtime.ml              0                    0
+keeper_claude_code_runtime.ml              0                    0
+keeper_codex_app_server_runtime.ml         0                    0
+```
+
+Control: both symbols do resolve elsewhere — `Keeper_checkpoint_store.save*`
+in `keeper_agent_run.ml`, `keeper_agent_run_finalize_response.ml`,
+`keeper_context_core.ml`; `Keeper_chat_store.` across the tool and delivery
+modules — so the zeros above are absence, not a mistyped pattern.
+
+Checkpoint persistence is owned by `Keeper_agent_run` and its finalizer. A
+probe that calls a runner directly and stops there writes nothing, without
+needing a flag anywhere in the persistence layer.
 
 ### Probe identity
 


### PR DESCRIPTION
## 목적

`sangsu × 47 런타임` 실측 중 측정이 측정 대상에 의해 차단된 사건(masc#28414)의 구조적 해법을 설계로 확정한다. 구현은 별도 PR.

## 왜 설계가 필요한가

키퍼 도구 가용성을 확인하려면 지금은 실제 턴을 써야 하고, 실제 턴은 세 곳에 durable하다.

```
keeper_chat/<k>.jsonl             매 턴 프롬프트에 재주입
traces/<trace>/trace-*.json       Agent Core 체크포인트
config/keepers/<k>.memory-*.json  librarian 출력 — 앞의 둘을 지워도 남음
```

측정이 대상을 바꾼다. 08-12 감사에서 361턴을 돌리자 librarian이 20:27에 프로브 10종을 **이름으로 열거하고 무응답을 처방하는** `lesson` fact를 커밋했고, 이후 25턴/6런타임이 런타임이 아니라 그 규칙을 측정했다.

두 성질이 이걸 일시적 사고가 아닌 구조로 만든다.

1. **재생성된다** — librarian은 같은 fact를 스스로 회수한 적이 있고(rev 1657 추가 18:06 → rev 1659 제거 18:20) 프로브가 계속되자 20:27에 다시 만들었다. 상태를 지워도, 문구를 바꿔도 방식이 같으면 돌아온다.
2. **처리량이 아니라 귀속을 잃는다** — 규칙은 하드 게이트가 아니다. 20:27 이후에도 `deepseek-v4-flash-0731` 4/4, `gpt-5.3-codex-spark` 2/3. 그래서 그 구간의 0점은 "런타임 결함"과 "규칙 준수" 중 어느 쪽인지 기록만으로 갈릴 수 없다.

대조군 1턴으로 사정거리는 확인했다. 마커·도구강제 없는 평범한 요청(`"보드에 최근 올라온 글이 뭐가 있는지 좀 보여줘"`)은 `masc_board_list`를 14.2s에 정상 호출한다. **프로덕션 동작은 손상되지 않았고 막힌 건 측정이다.**

## 설계 요지

측정 질문을 결정론 축으로 분해하면 모델 호출이 필요한 건 셋 중 하나뿐이다.

| 부분 | 결정론 | 모델 호출 |
|---|---|---|
| T가 R의 도구 표면에 있는가 | 결정론적 | 불필요 |
| provider가 T를 실은 요청을 받는가 | 결정론적 | 왕복만 |
| 모델이 T를 고르는가 | 확률적 | 필요 |

세 번째도 **키퍼의** 대화가 아니라 **어떤** 대화면 된다. 그게 이 RFC가 긋는 경계다.

seam은 이미 있다. per-kind 러너가 필요한 두 가지를 정확히 파라미터로 받는다.

- `initial_messages` — 러너가 키퍼 transcript를 직접 읽지 않는다
- `keeper_name` — `Session_store.load ~base_path ~keeper_name` (`keeper_antigravity_runtime.ml:225`)와 `~owner_leaf` (`:318`)의 키

persistence(`Keeper_chat_store.append_*`, `Keeper_checkpoint_store.save_agent_core_*`)는 러너가 아니라 턴 오케스트레이션이 호출한다. 프로브 레인은 그냥 안 부른다. **러너와 turn driver는 무변경.**

결과 타입은 지금 전부 "0"으로 읽히는 것들을 타입 레벨에서 분리한다 — `Tool_invoked` / `Replied_no_tool` / `Surface_absent` / `Provider_rejected` / `Transport_failed`. `Surface_absent`는 모델 호출 전에 결정되므로 antigravity 계열 질문(브리지는 97개 광고, CLI가 미소비)은 턴 0으로 답한다. `Unknown → permissive` arm 없음 (RFC-0206 §2.1).

## 함께 포함된 수정 — RFC-0373 frontmatter

`rfc: 373` (따옴표 없음)이 `rfc-generate-index.py`를 실패시킨다. generator는 테이블을 내기 전에 abort하므로:

- RFC-0373이 인덱스에서 **누락**돼 있었다
- 이후 어떤 RFC PR도 유효한 인덱스를 생성할 수 없다

이 PR이 인덱스를 생성하려면 필요한 최소 수정이라 함께 넣었다. 한 줄이고 이 PR 없이도 main-red다. 다른 RFC는 전부 `rfc: "0371"` 형태의 따옴표 문자열이다.

## 로컬 검증

```
scripts/rfc_enforcer.py --check --ignore-missing-section1   Checked 1, 1 passed
scripts/rfc-generate-index.py --check                       OK: up to date
scripts/pr_axis_check.py --check-rfc-collisions             No collisions
scripts/check-doc-code-refs.sh                              OK
scripts/check-doc-truth.sh                                  OK
```

RFC의 코드 참조(`keeper_antigravity_runtime.ml:225` / `:318`)와 karma 주장(`lib/tool_surface/` karma 0건, 대조군 `masc_board_vote` 3건)은 **origin/main 기준으로 재확인**했다. 이 세션에서 더러운 워킹트리 기준 인용으로 두 번 틀렸기 때문에 fresh worktree에서 다시 봤다.

## 미검증

- 구현 없음. probe identity의 예약 네임스페이스를 config admission에서 거부하는 지점은 설계에만 있고 코드로 확인하지 않았다.
- official-client 3종에서 프로브 identity로 세션이 실제로 분리되는지는 파라미터 경로로만 논증했고 실행으로 확인하지 않았다.
- Verification 표의 "세 스토어 불변" 테스트가 이 설계의 핵심인데 아직 없다.

RFC-WAIVED: 이 PR 자체가 RFC다.

Refs masc#28414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
