### PR TITLE
fix(test): Admin dev-token 전환 이후 남은 테스트 표류 6+1건 정리 (CI Build and Test 복구)

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -160,11 +160,11 @@ describe('MCP 2026-07-28 dashboard client', () => {
     getStoredTokenMeta.mockReturnValue({
       source: 'dev',
       actor: 'dashboard',
-      role: 'worker',
+      role: 'admin',
     })
     fetchWithTimeout
       .mockResolvedValueOnce(new Response(JSON.stringify({
-        token: 'test-stored-token', actor: 'dashboard', role: 'worker',
+        token: 'test-stored-token', actor: 'dashboard', role: 'admin',
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(okToolResponse())
     const { callMcpTool } = await import('./mcp')
@@ -408,7 +408,7 @@ describe('MCP 2026-07-28 dashboard client', () => {
     getStoredTokenMeta.mockReturnValue(null)
     fetchWithTimeout
       .mockResolvedValueOnce(new Response(JSON.stringify({
-        token: 'loopback-dev-token', actor: 'dashboard', role: 'worker',
+        token: 'loopback-dev-token', actor: 'dashboard', role: 'admin',
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(okToolResponse())
 
@@ -416,15 +416,38 @@ describe('MCP 2026-07-28 dashboard client', () => {
     await callMcpTool('masc_status', {})
 
     expect(setStoredToken).toHaveBeenCalledWith('loopback-dev-token', {
-      source: 'dev', actor: 'dashboard', role: 'worker',
+      source: 'dev', actor: 'dashboard', role: 'admin',
     })
     expect(fetchWithTimeout.mock.calls.map(call => call[0]))
       .toEqual(['/api/v1/dashboard/dev-token', '/mcp'])
   })
 
+  /* The loopback dev-token is Admin (#28354), and `ensureDevToken` refuses any
+     other role rather than storing a credential it cannot use. Until this case
+     existed the refusal branch had no test of its own — it was reached by
+     accident, because the fixtures above still served the pre-#28354 `worker`
+     role, which silently turned four tests that meant to exercise bootstrap,
+     identity binding, and token refresh into four assertions about a bootstrap
+     that never ran. Pin the refusal here so those tests can state their own
+     subject. */
+  it('refuses a dev-token payload that is not the Admin contract', async () => {
+    getStoredToken.mockReturnValue(null)
+    getStoredTokenMeta.mockReturnValue(null)
+    fetchWithTimeout
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        token: 'loopback-dev-token', actor: 'dashboard', role: 'worker',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(okToolResponse())
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    expect(setStoredToken).not.toHaveBeenCalled()
+  })
+
   it('binds identity to a bearer bootstrapped during the call', async () => {
     let token: string | null = null
-    let meta: { source: 'dev'; actor: 'dashboard'; role: 'worker' } | null = null
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'admin' } | null = null
     let revision = 0
     getStoredToken.mockImplementation(() => token)
     getStoredTokenMeta.mockImplementation(() => meta)
@@ -436,7 +459,7 @@ describe('MCP 2026-07-28 dashboard client', () => {
     })
     fetchWithTimeout
       .mockResolvedValueOnce(new Response(JSON.stringify({
-        token: 'loopback-dev-token', actor: 'dashboard', role: 'worker',
+        token: 'loopback-dev-token', actor: 'dashboard', role: 'admin',
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(okToolResponse())
 
@@ -495,8 +518,8 @@ describe('MCP 2026-07-28 dashboard client', () => {
 
   it('refreshes a managed token once on a typed MCP auth result', async () => {
     let token: string | null = 'stale-dev-token'
-    let meta: { source: 'dev'; actor: 'dashboard'; role: 'worker' } | null = {
-      source: 'dev', actor: 'dashboard', role: 'worker',
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'admin' } | null = {
+      source: 'dev', actor: 'dashboard', role: 'admin',
     }
     let revision = 0
     getStoredToken.mockImplementation(() => token)
@@ -514,7 +537,7 @@ describe('MCP 2026-07-28 dashboard client', () => {
     })
     fetchWithTimeout
       .mockResolvedValueOnce(new Response(JSON.stringify({
-        token: 'stale-dev-token', actor: 'dashboard', role: 'worker',
+        token: 'stale-dev-token', actor: 'dashboard', role: 'admin',
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(new Response(`data: ${JSON.stringify({
         result: {
@@ -524,7 +547,7 @@ describe('MCP 2026-07-28 dashboard client', () => {
         },
       })}\n`, { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({
-        token: 'fresh-dev-token', actor: 'dashboard', role: 'worker',
+        token: 'fresh-dev-token', actor: 'dashboard', role: 'admin',
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(okToolResponse())
 
@@ -545,8 +568,8 @@ describe('MCP 2026-07-28 dashboard client', () => {
 
   it('refreshes a managed token once on a typed HTTP 401', async () => {
     let token: string | null = 'stale-dev-token'
-    let meta: { source: 'dev'; actor: 'dashboard'; role: 'worker' } | null = {
-      source: 'dev', actor: 'dashboard', role: 'worker',
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'admin' } | null = {
+      source: 'dev', actor: 'dashboard', role: 'admin',
     }
     let revision = 0
     getStoredToken.mockImplementation(() => token)
@@ -574,7 +597,7 @@ describe('MCP 2026-07-28 dashboard client', () => {
     })
     fetchWithTimeout
       .mockResolvedValueOnce(new Response(JSON.stringify({
-        token: 'stale-dev-token', actor: 'dashboard', role: 'worker',
+        token: 'stale-dev-token', actor: 'dashboard', role: 'admin',
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(new Response(JSON.stringify({
         jsonrpc: '2.0',
@@ -586,7 +609,7 @@ describe('MCP 2026-07-28 dashboard client', () => {
         },
       }), { status: 401, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(new Response(JSON.stringify({
-        token: 'fresh-dev-token', actor: 'dashboard', role: 'worker',
+        token: 'fresh-dev-token', actor: 'dashboard', role: 'admin',
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(okToolResponse())
 

--- a/dashboard/src/components/copilot-dock.test.ts
+++ b/dashboard/src/components/copilot-dock.test.ts
@@ -306,15 +306,35 @@ describe('CopilotDock', () => {
     )
   }
 
+  const DEV_TOKEN_PATH = '/api/v1/dashboard/dev-token'
+
+  /* `streamKeeperMessage` bootstraps the loopback dashboard credential before
+     it builds the request (#28371), so the dock now issues a dev-token GET
+     ahead of the keeper POST. A bare `mockResolvedValue(sseResponse(...))`
+     breaks on both counts: the GET becomes call[0], and the single Response's
+     body stream is consumed by whichever call reads it first, leaving the POST
+     with nothing to parse. Route by URL and build a fresh Response per call. */
+  function dockFetchMock(events: unknown[]) {
+    return vi.fn(async (url: string, _init?: RequestInit) =>
+      String(url).includes(DEV_TOKEN_PATH)
+        ? new Response(
+            JSON.stringify({ token: 'dock-dev-token', actor: 'dashboard', role: 'admin' }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        : sseResponse(events))
+  }
+
+  function keeperStreamCalls(mock: ReturnType<typeof dockFetchMock>) {
+    return mock.mock.calls.filter(([url]) => !String(url).includes(DEV_TOKEN_PATH))
+  }
+
   it('sends a message and shows a streaming reply', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      sseResponse([
-        { type: 'TEXT_MESSAGE_START', role: 'Assistant', messageId: 'm1' },
-        { type: 'TEXT_MESSAGE_CONTENT', delta: '안녕하세요' },
-        { type: 'TEXT_MESSAGE_END' },
-        { type: 'RUN_FINISHED' },
-      ]),
-    )
+    const fetchMock = dockFetchMock([
+      { type: 'TEXT_MESSAGE_START', role: 'Assistant', messageId: 'm1' },
+      { type: 'TEXT_MESSAGE_CONTENT', delta: '안녕하세요' },
+      { type: 'TEXT_MESSAGE_END' },
+      { type: 'RUN_FINISHED' },
+    ])
     vi.stubGlobal('fetch', fetchMock)
 
     const dock = renderDock()
@@ -329,17 +349,21 @@ describe('CopilotDock', () => {
     sendBtn.click()
 
     await waitFor(() => expect(container.querySelectorAll('[data-dock-message="user"]').length).toBe(1))
-    await waitFor(() => expect(container.querySelectorAll('[data-dock-message="assistant"]').length).toBe(1), { timeout: 3000 })
 
-    const assistant = container.querySelector('[data-dock-message="assistant"]')
-    expect(assistant?.textContent).toContain('안녕하세요')
+    /* The streaming placeholder also carries `data-dock-message="assistant"`,
+       so waiting for the element alone resolves on "작성 중…" — the settled
+       reply only lands in the `.then` of `streamKeeperMessage`. Wait on the
+       text the test is actually about. */
+    await waitFor(
+      () => expect(container.querySelector('[data-dock-message="assistant"]')?.textContent)
+        .toContain('안녕하세요'),
+      { timeout: 3000 },
+    )
   })
 
   it('posts copilot channel and surface context to the keeper stream', async () => {
     window.history.replaceState({}, '', '/?agent=dashboard-eager-manta')
-    const fetchMock = vi.fn().mockResolvedValue(
-      sseResponse([{ type: 'RUN_FINISHED' }]),
-    )
+    const fetchMock = dockFetchMock([{ type: 'RUN_FINISHED' }])
     vi.stubGlobal('fetch', fetchMock)
 
     const dock = renderDock()
@@ -352,11 +376,17 @@ describe('CopilotDock', () => {
     const sendBtn = container.querySelector('[aria-label="메시지 전송"]') as HTMLButtonElement
     sendBtn.click()
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    await waitFor(() => expect(keeperStreamCalls(fetchMock)).toHaveLength(1))
+    const [, init] = keeperStreamCalls(fetchMock)[0] as [string, RequestInit]
     const body = JSON.parse(String(init.body))
     expect(body.channel).toBe('copilot')
-    expect(body.channel_workspace_id).toBe('dashboard-eager-manta')
+    /* The `?agent=` query is a hint, and a managed dev-token credential
+       outranks it (#28334). `currentDashboardActor` returns the stored dev
+       token's actor whenever one exists and only falls back to the URL name
+       otherwise, so once the dock bootstraps a credential (#28371) the hint
+       must not reach the wire. Keeping the query in the URL pins that
+       precedence rather than asserting a value the hint no longer decides. */
+    expect(body.channel_workspace_id).toBe('dashboard')
     expect(body.surface_context).toMatchObject({
       label: expect.any(String),
       route: '/overview',

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -216,9 +216,13 @@ let dashboard_dev_token ~port =
              , List.assoc_opt "actor" fields
              , List.assoc_opt "role" fields )
            with
+           (* [Server_routes_http_dashboard_dev_token.dashboard_dev_role] is
+              [Masc_domain.Admin] since #28354; this arm still required the
+              pre-#28354 [worker] and so failed every run against a server that
+              honours the current contract. *)
            | ( Some (`String token)
              , Some (`String "dashboard")
-             , Some (`String "worker") )
+             , Some (`String "admin") )
              when String.trim token <> "" ->
              token
            | _ ->


### PR DESCRIPTION
main 에서 대시보드 테스트 6건이 실패하고 있었습니다. 6건 모두 **병합된 변경이 대체한 옛 동작**을 서술하고 있고, 프로덕션 결함은 하나도 없습니다.

## 어떻게 찾았나

`Build and Test` 가 최근 PR CI 런 40건에서 성공 0회라 원인을 역추적했습니다. 실패 파일을 이 변경 없이 같은 커밋에서 돌린 베이스라인과 대조해 6건이 전부 선행 실패임을 먼저 확정한 뒤, 각 실패를 마지막으로 그 경로를 바꾼 커밋까지 따라갔습니다.

## `api/mcp.test.ts` — 4건

#28354 가 루프백 dev-token 을 Admin 으로 발급하도록 바꿨고, 클라이언트는 다른 role 을 거부합니다.

```ts
// dashboard/src/api/dev-token.ts:122
if (!token || payload.actor !== 'dashboard' || payload.role !== 'admin') { … return }
```

픽스처는 `role: 'worker'` 로 남아 있었습니다(14곳). 그래서 부트스트랩이 `invalid_response` 로 중단되고, **bootstrap / identity binding / token refresh 를 검증하려던 4개 테스트가 전부 "일어나지 않은 부트스트랩"에 대한 단언**이 되어 있었습니다.

`StoredTokenMeta` 는 이미 role 이 `'admin'` 단일 리터럴입니다.

```ts
// dashboard/src/api/core.ts:29
export type StoredTokenMeta =
  | { source: 'dev'; actor: 'dashboard'; role: 'admin' }
```

테스트의 `'worker'` 는 이 타입이 아니라 지역 구조 타입 주석이라 `tsc` 를 통과했을 뿐입니다. 픽스처를 계약에 맞추고, 그동안 **우연히** 덮이던 거부 분기는 자기 이름을 가진 케이스로 명시했습니다.

라이브 서버가 실제로 Admin 을 발급하는 것도 확인했습니다 — `/api/v1/dashboard/dev-token` → `{"actor":"dashboard","role":"admin"}`.

## `components/copilot-dock.test.ts` — 2건

#28371 이 `streamKeeperMessage` 안에서 자격증명을 부트스트랩합니다.

```ts
// dashboard/src/api/keeper.ts:300
if (!jsonHeaders().Authorization) await ensureDevToken()
```

그래서 dock 은 keeper POST 앞에 dev-token GET 을 먼저 보냅니다. 테스트는 `mockResolvedValue(sseResponse(...))` 로 **Response 객체 하나**를 모든 호출에 돌려주고 있었으므로 두 가지가 동시에 깨졌습니다 — GET 이 `calls[0]` 이 되어 `init.body` 가 `undefined` 였고, 단일 Response 의 body 스트림을 먼저 읽은 쪽이 소진해 POST 가 파싱할 게 없었습니다. URL 로 라우팅하고 호출마다 새 Response 를 만듭니다.

라우팅 후 드러난 후속 2건도 옛 동작이었습니다.

| 단언 | 실제 계약 |
|---|---|
| `waitFor` 로 assistant 요소를 기다린 뒤 텍스트 검사 | 스트리밍 placeholder 에도 `data-dock-message="assistant"` 가 붙습니다. 최종 메시지는 `streamKeeperMessage` 의 `.then` 에서만 들어오므로, 요소가 아니라 **텍스트**를 기다려야 합니다 |
| `channel_workspace_id` 가 `?agent=` 힌트값 | `currentDashboardActor()` 는 저장된 dev 토큰의 actor 를 우선하고 URL 이름은 fallback 입니다. 자격증명이 힌트를 이깁니다 (#28334) |

두 번째는 기대값만 바꾸지 않고 `?agent=` 를 URL 에 그대로 두었습니다. 이제 그 쿼리는 값을 공급하는 게 아니라 **힌트가 자격증명을 이기지 못한다는 우선순위를 고정**합니다.

## `test/test_sse_storm_e2e.ml` — CI 를 죽이던 같은 표류

`Build and Test` 가 최근 PR CI 런 40건에서 성공 0회인 이유가 이것입니다. 끝까지 돈 10건이 전부 `Run focused OCaml behavior suites` 에서 죽었고, 로그가 결정적입니다.

```
FAIL dashboard dev-token response violates token/actor/role contract:
     {…"actor":"dashboard","role":"admin"}
##[error]Process completed with exit code 1
```

계약을 지킨 응답을 "계약 위반"으로 판정합니다. 서버는 `dashboard_dev_role = Masc_domain.Admin` 인데 (`lib/server/server_routes_http_dashboard_dev_token.ml:19`) 이 arm 만 `` `String "worker" `` 를 요구하고 있었습니다.

즉 #28354 는 dev-token 을 Admin 으로 바꾸면서 **TS 테스트와 OCaml 스위트 양쪽**을 두고 갔고, 그 결과가 대시보드 6건 + CI 전면 red 였습니다.

## 검증

```
tsc --noEmit                       exit 0, error TS 0건
dune build --root . test/test_sse_storm_e2e.exe    exit 0
api/mcp.test.ts                    23 passed  (22 + 신규 거부 케이스 1)
components/copilot-dock.test.ts    20 passed
전체 대시보드 스위트                 650 files / 8879 tests / 실패 0
```

베이스라인(같은 커밋, 이 변경 없음)은 650 files 중 2 files / 6 tests 실패였습니다.

`test_sse_storm_e2e` 는 서버를 띄우는 e2e 라 로컬에서 실행하지 않고 컴파일까지만 확인했습니다. 실제 통과 여부는 CI 에서 확인해야 합니다 — **이 PR 에서 미검증으로 남는 유일한 항목입니다.**

## 이 PR 이 하지 않는 것

세 계약(Admin dev-token, stream 경로 부트스트랩, bearer 우선) 중 어느 것도 건드리지 않습니다. 전부 의도된 프로덕션 변경임을 각 PR 제목·서버 소스·라이브 응답으로 확인한 뒤 테스트만 그쪽에 맞췄습니다. **프로덕션 코드 변경 0줄입니다.**

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
