### PR TITLE
fix(keeper): read the stall verdict's timestamps from one clock

### DIFF
--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -309,8 +309,13 @@ let rec await_attempt_stall ~clock ~threshold_sec ~attempt_started_at ~probe =
     | Some read -> read ()
     | None -> None
   in
+  (* [Time_compat.now], not [Eio.Time.now clock]: the value this is subtracted
+     from ([turn_observation.last_progress_at]) is stamped by
+     [Keeper_registry_setup.stamp_turn_progress] with [Time_compat.now], and a
+     difference between two clocks is only meaningful when both readings come
+     from the same one. [clock] is used for sleeping, not for dating. *)
   if attempt_stalled
-       ~now:(Eio.Time.now clock)
+       ~now:(Time_compat.now ())
        ~threshold_sec
        ~attempt_started_at
        ~sample
@@ -753,7 +758,10 @@ let run_try_provider
     let result =
       match ctx.provider_call_deadline_sec, Eio_context.get_clock_opt () with
       | Some threshold_sec, Some clock ->
-        let attempt_started_at = Eio.Time.now clock in
+        (* Same clock as [last_progress_at] (see [await_attempt_stall]): the
+           elapsed fallback and the progress comparison must not read two
+           different clocks. *)
+        let attempt_started_at = Time_compat.now () in
         (match
            Eio.Fiber.first
              (fun () -> `Attempt_finished (run_attempt_switch ()))


### PR DESCRIPTION
#28419 후속. 그 PR 의 self-review 에서 발견했으나 머지 타이밍에 밀려 main 에 도달하지 못한 수정 1건.

## 문제

`attempt_stalled` 가 비교하는 두 타임스탬프가 서로 다른 시계에서 나온다.

| 값 | 출처 |
|---|---|
| `last_progress_at` | `Keeper_registry_setup.stamp_turn_progress` → `Time_compat.now ()` |
| `now`, `attempt_started_at` (#28419 시점) | `Eio.Time.now clock` |

프로덕션에서 두 시계가 같은 Unix epoch 를 반환하는 것은 사실이지만, 정확성이 그 우연에 기대고 있다. 하네스가 mock clock 을 주입하거나 Eio clock 구현이 바뀌면 판정이 조용히 어긋난다 — stall 이 아닌 턴을 죽이거나(#28417 이 고친 바로 그 실패), wedge 를 놓친다.

`attempt_started_at` 도 같은 문제를 갖는다: elapsed 폴백은 `Eio.Time.now` 쌍으로 계산되고 progress 비교는 혼합 쌍으로 계산돼, 한 함수 안에서 두 분기가 서로 다른 시간 기준을 쓴다.

## 변경

두 읽기를 모두 `Time_compat.now ()` 로 통일한다. registry 가 stamp 하는 것과 같은 시계다. `clock` 은 폴링 간 `Eio.Time.sleep` 에만 남는다 — 재우는 역할과 날짜를 읽는 역할을 분리한다.

`Time_compat.now` 는 determinism gate 를 통과한다 (`keeper_heartbeat_loop_in_turn_pulse` 가 이미 같은 값을 이 시계로 읽는다). #28419 가 `Eio.Time.now` 를 쓴 이유는 `Unix.gettimeofday` 를 피하려던 것인데, 게이트를 우회하려다 더 나쁜 결합을 만든 셈이다.

## 검증 (로컬, 현재 main 위에서)

| 검사 | 결과 |
|---|---|
| `dune build --root . @check` | PASS (에러 0) |
| `dune exec --root . test/test_keeper_provider_call_deadline.exe` | **14 tests run, Test Successful** |

동작 변경이 아니라 시간 기준 통일이므로 #28419 의 테스트 14건이 그대로 통과해야 한다. 새 단위 테스트는 추가하지 않는다 — `attempt_stalled` 는 `now` 를 인자로 받는 순수 함수라 어느 시계로 읽었는지는 그 함수의 관찰 대상이 아니고, 호출부의 시계 선택을 단위 테스트로 고정하려면 clock 주입 하네스가 필요해 이 PR 범위를 넘는다.

RFC-WAIVED: `lib/keeper/keeper_turn_driver_try_provider.ml` 단일 파일 10줄. RFC 필수 subsystem(credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential, hooks, workflow 문서) 어디에도 해당하지 않음.
