### PR TITLE
feat(http): fall back to gzip when the client cannot speak zstd

### DIFF
--- a/lib/compression/compression_gzip.ml
+++ b/lib/compression/compression_gzip.ml
@@ -1,0 +1,50 @@
+(* Gzip codec — the fallback half of HTTP content negotiation.
+
+   See [compression_gzip.mli] for why this exists alongside the zstd codec. *)
+
+type compress_result =
+  | Unchanged of string
+  | Compressed of string
+
+(* Deterministic header: no mtime, no filename, no comment. A response body is
+   not a file, and stamping wall-clock into it would make identical payloads
+   produce different bytes — which would defeat any future ETag derived from
+   the encoded form. *)
+let no_mtime () = 0l
+
+let compress ?(level = 4) data =
+  let length = String.length data in
+  if length < Compression_codec.min_size then Unchanged data
+  else begin
+    let input = De.bigstring_create De.io_buffer_size in
+    let output = De.bigstring_create De.io_buffer_size in
+    let window = De.Lz77.make_window ~bits:15 in
+    let queue = De.Queue.create 0x1000 in
+    let encoded = Buffer.create (length / 4) in
+    let consumed = ref 0 in
+    let refill buffer =
+      let take = min (Bigstringaf.length buffer) (length - !consumed) in
+      Bigstringaf.blit_from_string data ~src_off:!consumed buffer ~dst_off:0
+        ~len:take;
+      consumed := !consumed + take;
+      take
+    in
+    let flush buffer written =
+      Buffer.add_string encoded (Bigstringaf.substring buffer ~off:0 ~len:written)
+    in
+    match
+      Gz.Higher.compress ~level ~w:window ~q:queue ~refill ~flush ()
+        (Gz.Higher.configuration Gz.Unix no_mtime)
+        input output
+    with
+    | () ->
+      let payload = Buffer.contents encoded in
+      (* Same rule as the zstd codec: never hand back a larger body just
+         because an encoding was available. *)
+      if String.length payload >= length then Unchanged data
+      else Compressed payload
+    | exception exn ->
+      Log.Misc.warn "gzip compression failed, sending identity: %s"
+        (Printexc.to_string exn);
+      Unchanged data
+  end

--- a/lib/compression/compression_gzip.mli
+++ b/lib/compression/compression_gzip.mli
@@ -1,0 +1,29 @@
+(** Gzip codec — the fallback half of HTTP content negotiation.
+
+    {!Compression_codec} owns zstd. Until this module existed the encoding
+    vocabulary had exactly one member, so "client does not speak zstd" and
+    "send it uncompressed" were the same branch: a dashboard telemetry response
+    measured 7,540 bytes to a zstd client and 1,095,519 bytes to every other
+    one, a factor of 145. zstd is sent only by Chrome 123+ and Firefox 126+ in
+    secure contexts; Safari, curl, and every programmatic client fall through.
+
+    This module is deliberately separate from {!Compression_codec} rather than a
+    third constructor in its [encoding] type: that type is also what
+    {!Compression_codec.decompress} dispatches on for stored payloads, and a
+    stored zstd blob has nothing to do with what an HTTP client will accept.
+    Negotiation is a transport concern and lives in [http_response_payload]. *)
+
+type compress_result =
+  | Unchanged of string
+      (** Payload below {!Compression_codec.min_size}, or encoding did not
+          shrink it, or the encoder raised. Callers send the original body with
+          no [Content-Encoding]. *)
+  | Compressed of string  (** gzip-encoded payload. *)
+
+val compress : ?level:int -> string -> compress_result
+(** [compress ?level data] gzip-encodes [data] (default level 4).
+
+    The gzip header carries no mtime, filename, or comment, so identical input
+    always yields identical bytes. Encoder failures are logged and surfaced as
+    [Unchanged] rather than raised: a response that cannot be compressed is
+    still a response. *)

--- a/lib/compression/dune
+++ b/lib/compression/dune
@@ -4,8 +4,8 @@
  (name masc_compression)
  (public_name masc.masc_compression)
  (wrapped false)
- (modules compression_codec)
+ (modules compression_codec compression_gzip)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4) + unused-value ratchet (warning 32)
  (flags
   (:standard -w +4 -w +33 -w +37))
- (libraries masc_log zstd))
+ (libraries masc_log zstd decompress.de decompress.gz bigstringaf))

--- a/lib/http_response_payload.ml
+++ b/lib/http_response_payload.ml
@@ -130,17 +130,45 @@ let accepts_encoding_header ~token = function
 let accepts_zstd_header header =
   accepts_encoding_header ~token:"zstd" header
 
+let accepts_gzip_header header =
+  accepts_encoding_header ~token:"gzip" header
+
+(* What the client will accept, in server preference order.
+
+   Closed on purpose: before this type existed the negotiation was
+   [if not (accepts_zstd ...) then send identity], so a single unsupported
+   token collapsed into "no compression at all". One dashboard telemetry
+   response measured 7,540 bytes to a zstd client and 1,095,519 bytes to
+   everyone else — 145x — because zstd is offered only by Chrome 123+ and
+   Firefox 126+ in secure contexts, while Safari, curl, and programmatic
+   clients speak gzip. Making the vocabulary a variant means adding an encoding
+   forces every branch here to place it, rather than leaving a fallthrough that
+   silently means identity. *)
+type negotiated_encoding =
+  | Prefer_zstd
+  | Prefer_gzip
+  | Identity_only
+
+let negotiate_encoding accept_encoding =
+  if accepts_zstd_header accept_encoding then Prefer_zstd
+  else if accepts_gzip_header accept_encoding then Prefer_gzip
+  else Identity_only
+
 let compress_body ?(level = 3) ?(compress = true) ~accept_encoding body =
-  if not compress then
-    body, []
-  else if not (accepts_zstd_header accept_encoding) then
-    body, [ vary_accept_encoding ]
+  if not compress then body, []
   else
-    match Compression_codec.compress ~level body with
-    | Compression_codec.Unchanged payload -> payload, [ vary_accept_encoding ]
-    | Compression_codec.Compressed { payload; encoding } ->
+    match negotiate_encoding accept_encoding with
+    | Identity_only -> body, [ vary_accept_encoding ]
+    | Prefer_zstd -> (
+      match Compression_codec.compress ~level body with
+      | Compression_codec.Unchanged payload -> payload, [ vary_accept_encoding ]
+      | Compression_codec.Compressed { payload; encoding } ->
         ( payload
-        , [
-            ("content-encoding", Compression_codec.content_encoding encoding);
-            vary_accept_encoding;
-          ] )
+        , [ ("content-encoding", Compression_codec.content_encoding encoding)
+          ; vary_accept_encoding
+          ] ))
+    | Prefer_gzip -> (
+      match Compression_gzip.compress body with
+      | Compression_gzip.Unchanged payload -> payload, [ vary_accept_encoding ]
+      | Compression_gzip.Compressed payload ->
+        (payload, [ ("content-encoding", "gzip"); vary_accept_encoding ]))

--- a/test/dune
+++ b/test/dune
@@ -1216,7 +1216,10 @@
   masc_test_deps
   masc_test_runtime
   masc.embedded_config
-  bigstringaf)
+  bigstringaf
+  ; test_compression decodes its own gzip output with the library's reader
+  decompress.de
+  decompress.gz)
  (deps ../bin/main_eio.exe))
 
 (test

--- a/test/test_compression.ml
+++ b/test/test_compression.ml
@@ -13,6 +13,7 @@
 
 module BackendCompression = Backend.Compression
 module Compression_codec = Compression_codec
+module Http_response_payload = Masc.Http_response_payload
 
 let test_backend_compress_skip_small () =
   let small = "tiny" in  (* <32 bytes, below min_dict_size *)
@@ -147,6 +148,103 @@ let ratio_tests = [
   "repeated data passthrough", `Quick, test_passthrough_repeated;
 ]
 
+(* ===== Gzip codec and content negotiation ===== *)
+
+(* Decode with the library's own reader rather than re-using anything from the
+   encoder path, so a round-trip proves the bytes are real gzip and not merely
+   self-consistent. *)
+let gunzip payload =
+  let input = De.bigstring_create De.io_buffer_size in
+  let output = De.bigstring_create De.io_buffer_size in
+  let decoded = Buffer.create (String.length payload * 4) in
+  let consumed = ref 0 in
+  let refill buffer =
+    let take = min (Bigstringaf.length buffer) (String.length payload - !consumed) in
+    Bigstringaf.blit_from_string payload ~src_off:!consumed buffer ~dst_off:0 ~len:take;
+    consumed := !consumed + take;
+    take
+  in
+  let flush buffer written =
+    Buffer.add_string decoded (Bigstringaf.substring buffer ~off:0 ~len:written)
+  in
+  match Gz.Higher.uncompress ~refill ~flush input output with
+  | Ok _ -> Ok (Buffer.contents decoded)
+  | Error (`Msg message) -> Error message
+
+let sample_json =
+  "[" ^ String.concat ","
+    (List.init 400 (fun i ->
+       Printf.sprintf {|{"i":%d,"keeper":"sangsu","ts":1786500000.0}|} i))
+  ^ "]"
+
+let test_gzip_round_trips () =
+  match Compression_gzip.compress sample_json with
+  | Compression_gzip.Unchanged _ ->
+    Alcotest.fail "a 400-row JSON array should compress"
+  | Compression_gzip.Compressed payload ->
+    Alcotest.(check bool) "gzip is smaller than the source" true
+      (String.length payload < String.length sample_json);
+    (match gunzip payload with
+     | Error message -> Alcotest.failf "gunzip rejected the payload: %s" message
+     | Ok decoded ->
+       Alcotest.(check string) "round trip is byte-identical" sample_json decoded)
+
+let test_gzip_is_deterministic () =
+  let once = Compression_gzip.compress sample_json in
+  let twice = Compression_gzip.compress sample_json in
+  match once, twice with
+  | Compression_gzip.Compressed a, Compression_gzip.Compressed b ->
+    Alcotest.(check string) "same input yields the same bytes" a b
+  | _ -> Alcotest.fail "expected both attempts to compress"
+
+let test_gzip_skips_small_payloads () =
+  let small = String.make (Compression_codec.min_size - 1) 'x' in
+  match Compression_gzip.compress small with
+  | Compression_gzip.Unchanged payload ->
+    Alcotest.(check string) "small payload passes through" small payload
+  | Compression_gzip.Compressed _ ->
+    Alcotest.fail "payload below min_size must not be encoded"
+
+(* The behaviour this change exists for: what a client actually receives.
+
+   Before, anything that did not offer zstd fell through to identity, so the
+   gzip and "nothing offered" rows below were the same 145x-larger body. *)
+let negotiated_encoding accept_encoding =
+  let _, headers =
+    Http_response_payload.compress_body ~accept_encoding sample_json
+  in
+  match List.assoc_opt "content-encoding" headers with
+  | Some encoding -> encoding
+  | None -> "identity"
+
+let test_negotiation_table () =
+  let check_case accept expected =
+    Alcotest.(check string)
+      (Printf.sprintf "Accept-Encoding: %s" (Option.value accept ~default:"<none>"))
+      expected (negotiated_encoding accept)
+  in
+  check_case (Some "zstd") "zstd";
+  check_case (Some "gzip, deflate") "gzip";
+  check_case (Some "gzip, deflate, br") "gzip";
+  check_case (Some "gzip;q=0.5, zstd;q=0.9") "zstd";
+  check_case (Some "gzip;q=0, deflate") "identity";
+  check_case (Some "identity") "identity";
+  check_case (Some "*") "zstd";
+  check_case None "identity"
+
+let test_negotiation_always_varies () =
+  let _, headers = Http_response_payload.compress_body ~accept_encoding:None sample_json in
+  Alcotest.(check bool) "identity responses still advertise Vary" true
+    (List.mem_assoc "vary" headers)
+
+let gzip_tests = [
+  "round trips through a real gunzip", `Quick, test_gzip_round_trips;
+  "is deterministic", `Quick, test_gzip_is_deterministic;
+  "skips payloads below min_size", `Quick, test_gzip_skips_small_payloads;
+  "negotiation table", `Quick, test_negotiation_table;
+  "identity still varies", `Quick, test_negotiation_always_varies;
+]
+
 (* ===== Test Entry Point ===== *)
 
 let () =
@@ -155,4 +253,5 @@ let () =
     "Thresholds", threshold_tests;
     "Codec", codec_tests;
     "Compression Ratios", ratio_tests;
+    "Gzip", gzip_tests;
   ]


### PR DESCRIPTION
## What

`compress_body` had exactly one encoding in its vocabulary, so **"client does
not offer zstd" and "send it uncompressed" were the same branch**:

```ocaml
else if not (accepts_zstd_header accept_encoding) then
  body, [ vary_accept_encoding ]      (* identity *)
```

zstd is offered only by Chrome 123+ and Firefox 126+, and only in secure
contexts. Safari, `curl`, Python `requests`, Go, and Node `fetch` all fall
through.

## Measured

One dashboard telemetry response, 32 keepers / 720k entries, same warm cache
entry for every row:

| Accept-Encoding | before | after |
|---|---|---|
| `zstd` | 7,540 B | 7,544 B |
| `gzip, deflate` | **1,095,519 B** | **26,079 B** |
| `gzip, deflate, br` | 1,095,519 B | 26,079 B |
| `identity` | 1,095,519 B | 1,095,519 B |
| *(absent)* | 1,095,519 B | 1,095,519 B |

145x before, 42x after. `identity` deliberately still returns the full body —
the client asked for it.

Verified end to end, not just by unit test: the response carries
`content-encoding: gzip`, `content-length: 26079`, and a body beginning
`1f 8b 08` — and `curl --compressed` negotiates and decodes it.

## Design

Negotiation now goes through a closed variant instead of a boolean:

```ocaml
type negotiated_encoding = Prefer_zstd | Prefer_gzip | Identity_only
```

Adding an encoding forces every branch to place it, rather than leaving a
fallthrough that silently means identity — which is exactly how the 145x gap
arose. `q=0`, `*`, and absent headers all resolve through the existing
`accepts_encoding_header`, which already parsed q-values.

`Compression_gzip` is a separate module rather than a third constructor of
`Compression_codec.encoding`, because that type is also what
`Compression_codec.decompress` dispatches on for **stored** payloads, and a
stored zstd blob has nothing to do with what an HTTP client will accept.
Negotiation is a transport concern and stays in `http_response_payload`.

The gzip header carries no mtime, filename, or comment, so identical input
always yields identical bytes — which keeps the door open for an ETag derived
from the encoded form.

## Tests

`test_compression.ml`, group `Gzip` (5 cases, suite 20/20 green):

- **round trip decoded with the library's own `Gz.Higher.uncompress`**, not
  anything from the encoder path, so it proves real gzip rather than
  self-consistency
- determinism: same input twice yields identical bytes
- payloads below `Compression_codec.min_size` pass through unencoded
- negotiation table: `zstd`, `gzip, deflate`, `gzip, deflate, br`,
  `gzip;q=0.5, zstd;q=0.9`, `gzip;q=0, deflate`, `identity`, `*`, absent
- identity responses still advertise `Vary`

## One unexplained observation

An early run of the measurement script returned `200` with a 58-byte body for
the compressed rows. It did not reproduce across subsequent runs of the same
script against the same binary and store, and I could not attribute it. Most
likely the binary was mid-copy, but I am not claiming that. Recording it rather
than dropping it.

## Dependency

Adds `decompress.de` / `decompress.gz` (pure OCaml, already in the switch) to
`masc_compression`, and to the test stanza so the test can decode independently.

RFC-WAIVED: HTTP content negotiation and a response codec; no credential,
identity, operator control-plane, sandbox, hook, or workflow path is touched.
