### PR TITLE
refactor(dashboard): trim explanatory captions that crowd the keeper surfaces

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -978,18 +978,14 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     keeperFilter === 'agent-only' || keeperStateHints.length === 0
       ? null
       : `키퍼 ${keeperStateHints.join(' · ')}`
-  const fallbackStateTitle =
-    executionError.value
-      ? '상태 불러오기 실패'
-      : executionLoaded.value
-        ? '일부만 불러옴'
-        : '불러오는 중'
+  // The banner renders only for error / not-yet-loaded states
+  // (shouldShowExecutionFallbackState): a loaded-but-partial roster speaks
+  // through its own rows and health counts.
+  const fallbackStateTitle = executionError.value ? '상태 불러오기 실패' : '불러오는 중'
   const fallbackStateMessage =
     executionError.value
       ? `${scopeLabel}. 상태 정보를 아직 불러오지 못했습니다.`
-      : executionLoaded.value
-        ? `${scopeLabel}. 일부만 불러왔습니다.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''}`
-        : `${scopeLabel}.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''} 상태 정보가 올라오면 목록이 채워집니다.`
+      : `${scopeLabel}.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''} 상태 정보가 올라오면 목록이 채워집니다.`
 
   const rosterRows = useMemo(() => filtered.map((agent: Agent) => {
     const keeperRuntime = findKeeperRuntimeForAgent(agent, keeperRuntimeLookup)

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -966,7 +966,6 @@ describe('KeeperConfigPanel', () => {
 
     // identity tab (default): edit-scope callout + source provenance.
     expect(container.textContent).toContain('편집 가능 범위')
-    expect(container.textContent).toContain('runtime.toml')
     expect(container.textContent).toContain('[runtime.assignments]')
     expect(container.textContent).toContain('/tmp/config/keepers/default.toml')
     expect(container.textContent).toContain('/tmp/.masc/keepers/keeper-sangsu/live.json')

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1861,7 +1861,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
   // ── Tab content (the live fields, regrouped under the 8 prototype tabs) ──
   // identity ◈ — source provenance
   const identityTab = html`
-    <${KcfSec} title="편집 가능 범위" desc="여기서 저장되는 값은 keeper 프롬프트, live override 계층, runtime.toml의 [runtime.assignments]입니다.">
+    <${KcfSec} title="편집 가능 범위" desc="keeper 프롬프트 · live override · [runtime.assignments]">
       <${KcfFacts} rows=${[
         ['기본 소스', c.sources.default_source_kind],
         ['라이브 오버라이드', c.sources.has_live_override ? 'ON' : 'OFF'],
@@ -1889,7 +1889,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     ${promptSection}
     <${KcfSec}
       title="조립 추적"
-      desc="이 keeper의 시스템 프롬프트가 어느 레이어에서 조립됐는지 — 공유 베이스 위에 매니페스트/live override가 쌓이고, override_fields에 오른 필드가 매니페스트를 덮어씁니다.">
+      desc="베이스 → 매니페스트 → live override 순으로 조립. override_fields가 우선합니다.">
       <${KcfAssemblyTrace} config=${c} />
     </${KcfSec}>
   `
@@ -1917,13 +1917,13 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
 
     ${selectedRuntimeCatalogRows.length > 0
       ? html`
-        <${KcfSec} title="Runtime catalog spec" desc="선택 runtime 의 /api/v1/providers Provider × Model projection입니다. 요청 파라미터와 effective capability는 여기서 읽기 전용으로 확인합니다.">
+        <${KcfSec} title="Runtime catalog spec" desc="Provider × Model 스펙 (읽기 전용)">
           <${KcfFacts} rows=${selectedRuntimeCatalogRows} />
         </${KcfSec}>
       `
       : null}
 
-    <${KcfSec} title="실행" desc="런타임 후보는 읽기 전용입니다. fallback 은 마지막 runtime 을 제외한 항목에 순서대로 적용됩니다.">
+    <${KcfSec} title="실행" desc="읽기 전용 · fallback은 위에서부터 순서대로">
       <${KcfFacts} rows=${[
         ['활성 런타임', c.execution.active_model ? 'runtime' : null],
       ]} />

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -527,7 +527,6 @@ function KeeperQueueControlPanel({
       <div class="flex items-center justify-between gap-2">
         <div>
           <div class="text-sm font-semibold text-[var(--color-fg-primary)]">Keeper 작업 제어</div>
-          <div class="text-2xs text-[var(--color-fg-muted)]">durable operation과 Event Queue를 각각의 SSOT에서 제어합니다.</div>
         </div>
         <${GhostButton} onClick=${onClose}>닫기<//>
       </div>
@@ -571,7 +570,7 @@ function KeeperQueueControlPanel({
 
       <div class="grid gap-2">
         <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">
-          Queued chat operations ${operations.length}
+          채팅 대기열 ${operations.length}
         </div>
         ${operations.map((operation, index) => {
           const busy = pendingAction === operation.operationId
@@ -628,7 +627,7 @@ function KeeperQueueControlPanel({
           `
         })}
         ${operations.length === 0
-          ? html`<div class="text-2xs text-[var(--color-fg-muted)]">Queued operation이 없습니다.</div>`
+          ? html`<div class="text-2xs text-[var(--color-fg-muted)]">—</div>`
           : null}
       </div>
 
@@ -721,7 +720,7 @@ function KeeperQueueControlPanel({
           `
         })}
         ${eventRows.length === 0
-          ? html`<div class="text-2xs text-[var(--color-fg-muted)]">대기 중인 자율 이벤트가 없습니다.</div>`
+          ? html`<div class="text-2xs text-[var(--color-fg-muted)]">—</div>`
           : null}
       </div>
     </section>

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -141,7 +141,7 @@ describe('KeeperLaneStrip', () => {
     `)
     const text = el.textContent ?? ''
     expect(text).toContain('작업 대기열')
-    expect(text).toContain('외부 완료 대기 중')
+    expect(text).toContain('외부 응답 대기')
     expect(text).toContain('owner_fifo')
     expect(text).toContain('keeper_turn')
     expect(text).toContain('keeper finish in flight turn')
@@ -206,8 +206,10 @@ describe('KeeperLaneStrip', () => {
       '2026-08-08T06:39:09Z',
       '2026-08-06T03:59:42Z',
     ])
-    expect(el.textContent ?? '').toContain('최신 관측 → 오래된 관측')
-    expect(el.textContent ?? '').toContain('처리 우선순위를 뜻하지 않습니다')
+    expect(el.textContent ?? '').toContain('최신 → 오래된')
+    // The lane legend stays a compact time-order marker; the old prose
+    // disclaimer ("처리 우선순위를 뜻하지 않습니다") was removed for layout room.
+    expect(el.textContent ?? '').not.toContain('처리 우선순위')
     expect(el.textContent ?? '').toContain('실행 예정')
     expect(el.textContent ?? '').toContain('7시간 후')
     expect(el.textContent ?? '').not.toContain('실행 예정 · 지금')
@@ -295,7 +297,10 @@ describe('KeeperLaneStrip', () => {
     expect(el.querySelector('[data-testid="keeper-lane-truncation"]')).toBeNull()
   })
 
-  it('shows push delivery beside the snapshot time when WS is ready', () => {
+  it('renders no transport/freshness caption row', () => {
+    // The strip used to append "서버 기준 <시각> · WS 즉시 반영" under every
+    // queue. That caption described the transport, not the queue, and was
+    // removed for layout room — the data itself is the freshness signal.
     const el = mount(html`
       <${KeeperLaneStrip}
         keeper=${keeperFixture()}
@@ -303,27 +308,12 @@ describe('KeeperLaneStrip', () => {
         ready=${true}
         loading=${false}
         error=${null}
-        pushReady=${true}
       />
     `)
     const text = el.textContent ?? ''
-    expect(text).toContain('서버 기준')
-    expect(text).toContain('WS 즉시 반영')
-    expect(text).not.toContain('초마다')
-  })
-
-  it('omits the push label while WS is unavailable', () => {
-    const el = mount(html`
-      <${KeeperLaneStrip}
-        keeper=${keeperFixture()}
-        inventory=${inventoryFixture()}
-        ready=${true}
-        loading=${false}
-        error=${null}
-      />
-    `)
-    expect(el.textContent ?? '').not.toContain('WS 즉시 반영')
-    expect(el.textContent ?? '').not.toContain('재조회')
+    expect(text).not.toContain('서버 기준')
+    expect(text).not.toContain('WS 즉시 반영')
+    expect(text).not.toContain('기다리는 작업이 없습니다')
   })
 
   it('renders an explicit gap when the keeper is absent from the inventory', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -33,17 +33,16 @@ import {
 import { formatDateTimeKo, formatTimeUntil, relativeTime } from '../../lib/format-time'
 import { CountBadge } from '../v2/primitives-v2'
 import { JsonViewerCard } from '../common/json-viewer'
-import { dashboardWsReady } from '../../dashboard-ws-state'
 import {
   keeperWaitingInventoryState,
   subscribeKeeperWaitingInventory,
 } from '../../keeper-waiting-inventory-store'
 
 const LANE_STATE_LABELS: Record<string, string> = {
-  idle: '대기열 비어 있음',
-  busy: '현재 작업 처리 중',
-  waiting: '처리 대기 중',
-  deferred: '외부 완료 대기 중',
+  idle: '비어 있음',
+  busy: '처리 중',
+  waiting: '대기 중',
+  deferred: '외부 응답 대기',
 }
 
 const LANE_SOURCE_LABELS: Record<string, string> = {
@@ -225,7 +224,6 @@ export function KeeperLaneStrip({
   ready,
   loading,
   error,
-  pushReady = false,
 }: {
   keeper: Keeper
   inventory: DashboardKeeperWaitingInventory | null | undefined
@@ -234,8 +232,6 @@ export function KeeperLaneStrip({
   ready: boolean
   loading: boolean
   error: string | null
-  /** Whether the authenticated dashboard WS handshake completed. */
-  pushReady?: boolean
 }): VNode {
   const entry = inventoryEntry(inventory, keeper)
   const rows = waitingRowsNewestFirst(entry?.waiting_on ?? [])
@@ -263,8 +259,7 @@ export function KeeperLaneStrip({
                     <div class="grid gap-1">
                       <div class="flex flex-wrap items-center gap-2 text-3xs text-[var(--color-fg-muted)]">
                         <span class="font-semibold uppercase tracking-wide text-[var(--color-fg-secondary)]">HEAD</span>
-                        <span>시간축 · 최신 관측 → 오래된 관측</span>
-                        <span>source별 독립 대기열이며 처리 우선순위를 뜻하지 않습니다.</span>
+                        <span>최신 → 오래된</span>
                       </div>
                     <div class="max-h-[30rem] overflow-y-auto pr-1" data-testid="keeper-lane-graph" aria-label="대기 시작 시각순 작업 흐름">
                       ${rows.map((row, index) => html`
@@ -278,9 +273,6 @@ export function KeeperLaneStrip({
                     </div>
                     </div>
                   `
-                : null}
-              ${rows.length === 0
-                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${entry.state === 'busy' ? '새 작업은 현재 턴 뒤에 처리됩니다.' : '지금 기다리는 작업이 없습니다.'}</div>`
                 : null}
               ${countTruncated
                 ? html`<div class="text-2xs text-[var(--color-fg-muted)]" data-testid="keeper-lane-truncation">
@@ -297,9 +289,6 @@ export function KeeperLaneStrip({
                       >${item.label} <span class="font-mono text-[var(--color-fg-primary)]">${item.count}</span></span>
                     `)}
                   </div>`
-                : null}
-              ${inventory?.generated_at
-                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">서버 기준 ${formatDateTimeKo(inventory.generated_at)}${pushReady ? ' · WS 즉시 반영' : ''}</div>`
                 : null}
             </div>
           `
@@ -329,7 +318,6 @@ export function KeeperLaneSection({ keeper }: { keeper: Keeper }): VNode {
       ready=${current.ready}
       loading=${current.loading}
       error=${current.error}
-      pushReady=${dashboardWsReady.value}
     />
   `
 }

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -593,4 +593,17 @@ describe('shouldShowExecutionFallbackState', () => {
       expectedCount: 5,
     })).toBe(false)
   })
+
+  it('hides the fallback state after load even when counts are partial', () => {
+    // A loaded-but-partial roster is described by the roster rows and health
+    // counts themselves; the permanent "일부만 불러왔습니다" diagnostic banner
+    // was removed for layout room.
+    expect(shouldShowExecutionFallbackState({
+      executionLoaded: true,
+      executionLoading: false,
+      executionError: null,
+      loadedCount: 3,
+      expectedCount: 5,
+    })).toBe(false)
+  })
 })

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -509,13 +509,15 @@ interface ExecutionFallbackStateOptions {
 
 export function shouldShowExecutionFallbackState({
   executionLoaded,
-  executionLoading,
   executionError,
-  loadedCount,
   expectedCount,
 }: ExecutionFallbackStateOptions): boolean {
   if (expectedCount <= 0) return false
   if (executionError) return true
-  if (loadedCount >= expectedCount && executionLoaded) return false
-  return executionLoading || !executionLoaded || loadedCount < expectedCount
+  // Once execution state has loaded, the roster rows and health counts are
+  // the surface of truth — a loaded-but-partial diff banner ("일부만
+  // 불러왔습니다 / 키퍼 미기동 N개") repeated what the counts already show
+  // and sat permanently on screen whenever any configured keeper was not
+  // running. Only error and not-yet-loaded states warrant the banner.
+  return !executionLoaded
 }


### PR DESCRIPTION
## 배경

운영자 피드백: 대시보드 곳곳의 설명 문구가 레이아웃을 잡아먹으면서 데이터가 이미 보여주는 것을 반복한다. 문구 제거/축약으로 즉시 해소 가능한 항목만 이 PR에서 처리하고, 재설계가 필요한 항목(effort 설정 UI, 메모리 dev/일반 분리, 작업 제어 큐 시각화, Registry 표면 완성)은 별도 이슈로 분리했다.

## 변경

| 표면 | 전 | 후 |
|---|---|---|
| 작업 대기열 (lane strip) | "지금 기다리는 작업이 없습니다." / "서버 기준 2026-08-12 오후 11:49 · WS 즉시 반영" | 제거 (상태 칩이 이미 전달) |
| lane 상태 칩 | "대기열 비어 있음" 등 | "비어 있음" · "처리 중" · "대기 중" · "외부 응답 대기" |
| HEAD 범례 | "시간축 · 최신 관측 → 오래된 관측" + "source별 독립 대기열이며 처리 우선순위를 뜻하지 않습니다." | "최신 → 오래된" |
| Keeper 작업 제어 모달 | 부제 "durable operation과 Event Queue를 각각의 SSOT에서 제어합니다." / "Queued chat operations" / 빈 상태 문장 2종 | 부제 제거 / "채팅 대기열" / "—" |
| fleet roster | 상시 노출되던 "일부만 불러왔습니다. 키퍼 미기동 N개" 진단 배너 | 로드 완료 후 미표시 (오류·로딩 배너는 유지) |
| 설정 패널 desc 4종 | 조립 추적 등 2~3문장 설명 | 각 1줄 |

## 검증

- `keeper-lane-strip.test.ts` + `runtime-counts.test.ts` 56/56 (제거 사실을 핀하는 단언 추가: transport 캡션 부재, 우선순위 문구 부재, loaded-partial 배너 억제)
- `keeper-shared` / `agent-roster` / `keeper-config-panel` 테스트 210/210
- `tsc --noEmit` clean · `eslint src` clean

## 관련

- 재설계 분리 이슈: effort 설정 UI, 메모리 뷰 정보 분리, 작업 제어 큐 시각화, Registry 표면 — PR 본문 아래 코멘트로 링크 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU1EnzuTuFCPZwbeqj9Ajr
