### PR TITLE
feat(keeper): RFC-0374 probe_surface — capability probing without a turn

### DIFF
--- a/lib/keeper/keeper_capability_probe.ml
+++ b/lib/keeper/keeper_capability_probe.ml
@@ -1,0 +1,79 @@
+(* RFC-0374 — the deterministic half of the capability probe lane.
+
+   Deliberately has no dependency on the turn driver, the runners, the chat
+   store, or the checkpoint store. That absence is the point of the module:
+   it is what lets a caller ask about the tool surface without the question
+   becoming part of the keeper's history.
+
+   Every "does this reach the model" decision is delegated to
+   [Keeper_tool_descriptor.keeper_model_names], which is the projection the
+   real surface is built from. Re-deriving it here from
+   [keeper_model_projection] alone looked equivalent and was not: that field
+   is only consulted after [model_schema_errors] clears, so a descriptor with
+   a broken schema is withheld from the model while its projection variant
+   still says [Preferred_public_name]. A probe that read the variant directly
+   would have reported such a tool as reachable. *)
+
+type verdict =
+  | Projected of { model_facing_name : string }
+  | Not_a_descriptor
+  | Operator_only
+  | Aliased of { projected_by : string }
+  | Withheld_by_schema_error of { errors : string list }
+
+let verdict_to_string = function
+  | Projected { model_facing_name } ->
+    Printf.sprintf "projected as %s" model_facing_name
+  | Not_a_descriptor -> "no descriptor declares this name"
+  | Operator_only -> "operator-only, withheld from the keeper model"
+  | Aliased { projected_by } ->
+    Printf.sprintf "transport alias; projected by %s" projected_by
+  | Withheld_by_schema_error { errors } ->
+    Printf.sprintf
+      "declared model-facing but withheld: %s"
+      (String.concat "; " errors)
+;;
+
+(* Operator-authored probe lists name tools inconsistently -- a public name in
+   one row, the internal name in the next -- so resolution accepts either.
+   This is name resolution, not a fallback: both strings are declared by the
+   same descriptor, so neither is a guess. *)
+let declares name (d : Keeper_tool_descriptor.t) =
+  String.equal d.public_name name || String.equal d.internal_name name
+;;
+
+let probe_surface ~tool =
+  match List.find_opt (declares tool) (Keeper_tool_descriptor.all_descriptors ()) with
+  | None -> Not_a_descriptor
+  | Some descriptor ->
+    (match Keeper_tool_descriptor.keeper_model_names descriptor with
+     | model_facing_name :: _ -> Projected { model_facing_name }
+     | [] ->
+       (* The SSOT withholds it. Which of the two reasons applies is not
+          recoverable from the empty list, so ask the same two predicates the
+          SSOT asked, in the same order it asked them. *)
+       (match
+          ( Keeper_tool_descriptor.model_schema_errors descriptor
+          , descriptor.keeper_model_projection )
+        with
+        | (_ :: _ as errors), _ -> Withheld_by_schema_error { errors }
+        | [], Operator_only -> Operator_only
+        | [], Transport_alias { projected_by } -> Aliased { projected_by }
+        | [], (Preferred_public_name | Internal_name) ->
+          (* keeper_model_names returns a name for these once the schema
+             clears, so reaching here means the SSOT changed shape and this
+             module has drifted from it. Say so rather than inventing a
+             verdict. *)
+          Withheld_by_schema_error
+            { errors =
+                [ "descriptor projects a model-facing name but the surface \
+                   withheld it; Keeper_capability_probe has drifted from \
+                   Keeper_tool_descriptor.keeper_model_names"
+                ]
+            }))
+;;
+
+let model_facing_names () =
+  Keeper_tool_descriptor.model_visible_schemas ()
+  |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
+;;

--- a/lib/keeper/keeper_capability_probe.mli
+++ b/lib/keeper/keeper_capability_probe.mli
@@ -1,0 +1,65 @@
+(** Capability probing that does not write into the keeper's conversation
+    (RFC-0374).
+
+    Asking "can keeper K reach tool T" used to cost a real turn, and a real
+    turn is durable in the chat transcript, the checkpoint, and — through the
+    librarian — the keeper's memory. Measurement therefore changed the thing
+    it measured: on 2026-08-12 the librarian read accumulated probe traffic
+    and committed a fact prescribing non-response to the probed tools, after
+    which a zero result no longer distinguished "the runtime cannot reach the
+    tool" from "the keeper declined" (masc#28414).
+
+    This module answers the part of that question that needs no model at all.
+    Whether MASC projects a tool into the surface it hands a client is decided
+    by the descriptor table, so it is decidable offline, for free, and without
+    touching any durable store.
+
+    {1 What a positive answer does not mean}
+
+    Projection is MASC's side of the wire; consumption is the client's. The
+    two diverge — the antigravity bridge advertised 97 tools including every
+    probed one, [initialize] and [tools/list] both answered, and the models
+    still reported no masc tool present. So [Projected] means a turn is worth
+    spending, and nothing more. Only observing an actual call establishes
+    reachability, which is [probe_invocation]'s job (not yet implemented).
+
+    @since 0.21.3 *)
+
+(** Why a tool is or is not in the keeper-facing surface.
+
+    The three negative cases are kept apart because they have different
+    fixes: a name that does not exist is a caller error, an operator tool is
+    working as designed, and an alias means the capability is present under
+    a different name. Collapsing them into [false] is what made
+    [masc_tasks] and [masc_status] look like the same failure during the
+    2026-08-12 audit when they are not. *)
+type verdict =
+  | Projected of { model_facing_name : string }
+      (** Reaches the model under this name. *)
+  | Not_a_descriptor
+      (** No descriptor declares this name, under any projection. *)
+  | Operator_only
+      (** Declared, but deliberately withheld from the autonomous model. *)
+  | Aliased of { projected_by : string }
+      (** Declared, but the capability reaches the model under another
+          descriptor's name. Probing the requested name measures the alias
+          policy rather than the runtime. *)
+  | Withheld_by_schema_error of { errors : string list }
+      (** Declared model-facing, but the surface drops it because its schema
+          does not validate. Distinct from [Operator_only]: nobody chose this,
+          and it is a defect in the descriptor rather than a policy. *)
+
+val verdict_to_string : verdict -> string
+
+(** Resolve [tool] against the keeper-facing tool surface.
+
+    Pure: reads the descriptor table and nothing else. No provider call, no
+    session, no filesystem write. Accepts either a public or an internal
+    descriptor name, because both appear in operator-authored probe lists. *)
+val probe_surface : tool:string -> verdict
+
+(** Every name that reaches the keeper model, in descriptor order.
+
+    Used to report what {e was} available when a probe asks for a name that is
+    not, so the caller does not have to guess at a typo. *)
+val model_facing_names : unit -> string list

--- a/test/dune
+++ b/test/dune
@@ -237,6 +237,7 @@
   test_runtime_provider_auth_headers
   test_dashboard_runtime_probe_nonblocking
   test_keeper_tool_policy_masc_surface
+  test_keeper_capability_probe
   test_tool_resolution_runtime_projection
   test_keeper_id
   test_keeper_repo_mapping
@@ -532,6 +533,7 @@
   test_runtime_provider_auth_headers
   test_dashboard_runtime_probe_nonblocking
   test_keeper_tool_policy_masc_surface
+  test_keeper_capability_probe
   test_tool_resolution_runtime_projection
   test_keeper_id
   test_keeper_repo_mapping

--- a/test/test_keeper_capability_probe.ml
+++ b/test/test_keeper_capability_probe.ml
@@ -1,0 +1,144 @@
+(* RFC-0374 probe_surface.
+
+   The cases below are the ones the 2026-08-12 audit actually hit. Each spent a
+   real keeper turn to learn something the descriptor table already knew, so
+   each is also a statement about what the probe lane is for. *)
+
+open Alcotest
+
+module Probe = Masc.Keeper_capability_probe
+module Descriptor = Masc.Keeper_tool_descriptor
+
+let verdict = testable (Fmt.of_to_string Probe.verdict_to_string) ( = )
+
+(* A tool the audit used as its Board probe and saw called on healthy
+   runtimes. Asserted against a literal, not against another call into the
+   projection -- computing the expectation with the function under test would
+   make this an identity. *)
+let test_board_list_is_projected () =
+  check
+    verdict
+    "masc_board_list reaches the model"
+    (Probe.Projected { model_facing_name = "masc_board_list" })
+    (Probe.probe_surface ~tool:"masc_board_list")
+;;
+
+(* masc_status was in the first probe set and scored 0 everywhere. The audit
+   read that as a runtime failure for several turns before finding the tool is
+   operator-only (#26924) -- it was never on the keeper surface to begin with.
+   probe_surface answers this without a turn. *)
+let test_operator_only_is_not_a_runtime_failure () =
+  check
+    verdict
+    "masc_status is withheld from the keeper model"
+    Probe.Operator_only
+    (Probe.probe_surface ~tool:"masc_status")
+;;
+
+(* Same shape, different cause: masc_tasks is the transport name and the
+   capability reaches the model as keeper_tasks_list. Probing masc_tasks
+   measures the alias policy, so the two must not collapse into one verdict. *)
+let test_transport_alias_names_its_projection () =
+  match Probe.probe_surface ~tool:"masc_tasks" with
+  | Probe.Aliased { projected_by } ->
+    check string "masc_tasks is projected by keeper_tasks_list" "keeper_tasks_list" projected_by
+  | other ->
+    failf "expected an alias verdict for masc_tasks, got: %s" (Probe.verdict_to_string other)
+;;
+
+let test_alias_target_is_itself_projected () =
+  check
+    verdict
+    "the alias target reaches the model under its own name"
+    (Probe.Projected { model_facing_name = "keeper_tasks_list" })
+    (Probe.probe_surface ~tool:"keeper_tasks_list")
+;;
+
+let test_unknown_name_is_not_a_silent_negative () =
+  check
+    verdict
+    "an undeclared name is reported as undeclared"
+    Probe.Not_a_descriptor
+    (Probe.probe_surface ~tool:"masc_definitely_not_a_tool")
+;;
+
+(* Karma was one of the seven categories the audit was asked to measure and the
+   only one it could not: the keeper has no read path to it. That is a surface
+   gap, and the probe should say so instead of leaving the caller to infer it
+   from a runtime that never calls anything. *)
+let test_karma_has_no_keeper_read_path () =
+  List.iter
+    (fun tool ->
+      check
+        verdict
+        (tool ^ " is not on the keeper surface")
+        Probe.Not_a_descriptor
+        (Probe.probe_surface ~tool))
+    [ "masc_karma"; "masc_karma_list"; "keeper_karma" ]
+;;
+
+(* The load-bearing agreement: probe_surface must not have its own opinion
+   about what reaches the model. Every name the real surface publishes has to
+   come back Projected under that same name, and nothing else may. *)
+let test_agrees_with_the_surface_it_reports_on () =
+  let published = Probe.model_facing_names () in
+  check bool "the surface is non-empty" true (published <> []);
+  List.iter
+    (fun name ->
+      check
+        verdict
+        (name ^ " round-trips through probe_surface")
+        (Probe.Projected { model_facing_name = name })
+        (Probe.probe_surface ~tool:name))
+    published;
+  let projected_but_unpublished =
+    Descriptor.all_descriptors ()
+    |> List.filter_map (fun (d : Descriptor.t) ->
+      match Probe.probe_surface ~tool:d.public_name with
+      | Probe.Projected { model_facing_name } when not (List.mem model_facing_name published)
+        -> Some model_facing_name
+      | Probe.Projected _
+      | Probe.Not_a_descriptor
+      | Probe.Operator_only
+      | Probe.Aliased _
+      | Probe.Withheld_by_schema_error _ -> None)
+  in
+  check
+    (list string)
+    "probe_surface projects nothing the surface does not publish"
+    []
+    projected_but_unpublished
+;;
+
+(* A descriptor withheld for a broken schema is a defect, not a policy, and the
+   audit's outcome vocabulary had nowhere to put it. Assert the surface is
+   currently clean so the day one appears it shows up here rather than as an
+   unexplained zero on some runtime. *)
+let test_no_descriptor_is_withheld_by_a_schema_error () =
+  let withheld =
+    Descriptor.all_descriptors ()
+    |> List.filter_map (fun (d : Descriptor.t) ->
+      match Descriptor.model_schema_errors d with
+      | [] -> None
+      | errors -> Some (Printf.sprintf "%s: %s" d.public_name (String.concat "; " errors)))
+  in
+  check (list string) "no descriptor has schema errors" [] withheld
+;;
+
+let () =
+  run
+    "keeper_capability_probe"
+    [ ( "probe_surface"
+      , [ test_case "board_list is projected" `Quick test_board_list_is_projected
+        ; test_case "operator-only is distinguished" `Quick test_operator_only_is_not_a_runtime_failure
+        ; test_case "transport alias names its projection" `Quick test_transport_alias_names_its_projection
+        ; test_case "alias target is projected" `Quick test_alias_target_is_itself_projected
+        ; test_case "unknown name is explicit" `Quick test_unknown_name_is_not_a_silent_negative
+        ; test_case "karma has no read path" `Quick test_karma_has_no_keeper_read_path
+        ] )
+    ; ( "agreement with the surface"
+      , [ test_case "round-trips every published name" `Quick test_agrees_with_the_surface_it_reports_on
+        ; test_case "no schema-withheld descriptor" `Quick test_no_descriptor_is_withheld_by_a_schema_error
+        ] )
+    ]
+;;


### PR DESCRIPTION
RFC-0374 (#28422, 머지됨) 의 결정론 절반을 구현한다.

## 무엇을 푸는가

"키퍼 K 가 런타임 R 에서 도구 T 를 부를 수 있나"를 확인하려면 지금은 실제 턴을 써야 하고, 실제 턴은 세 곳에 durable 하다 — chat transcript, 체크포인트, 그리고 librarian 을 거쳐 키퍼 memory. 08-12 에 그 루프가 닫혔다: librarian 이 누적된 프로브 트래픽을 읽고 프로브 10종에 무응답을 처방하는 fact 를 커밋했고, 이후 0점은 "런타임이 못 부른다"와 "키퍼가 안 부른다"를 구별하지 못하게 됐다 (masc#28414).

이 PR 은 **모델이 필요 없는 절반**을 낸다. MASC 가 도구를 키퍼 표면에 투영하는지는 descriptor 테이블이 결정하므로 오프라인에서 답할 수 있고, 아무 스토어에도 쓰지 않는다.

## 실측에서 죽어 있던 프로브 2개가 여기서 설명된다

감사에서 `masc_status` 와 `masc_tasks` 는 전 런타임 0점이었고, 몇 턴 동안 런타임 결함으로 읽혔다. 실제로는:

- `masc_status` → `Operator_only`. 애초에 키퍼 표면에 없다 (#26924)
- `masc_tasks` → `Transport_alias`. 능력은 `keeper_tasks_list` 로 도달한다

`verdict` 타입이 이 둘을 `Not_a_descriptor` 와 분리한다. 셋을 `false` 로 뭉치면 고치는 방법이 서로 다른 것들이 같아 보인다.

## SSOT — 첫 초안이 틀렸던 지점

"모델에 도달하는가" 판단을 전부 `Keeper_tool_descriptor.keeper_model_names` 에 위임한다.

이 모듈의 첫 초안은 `keeper_model_projection` variant 를 직접 읽었다. 동등해 보였지만 아니다 — 그 필드는 `model_schema_errors` 가 통과한 **뒤에만** 참조되므로, 스키마가 깨진 descriptor 는 variant 가 `Preferred_public_name` 인 채로 표면에서 제외된다. 직접 읽는 프로브는 그런 도구를 "도달 가능"이라고 보고했을 것이다.

`Withheld_by_schema_error` 를 별도 verdict 로 둔 것도 같은 이유다. 정책이 아니라 결함이고, 감사의 결과 어휘에는 이걸 담을 자리가 없었다.

## 검증

```
dune build --root . lib/                          FINAL_EXIT=0
dune build --root . test/test_keeper_capability_probe.exe   FINAL_EXIT=0
./_build/default/test/test_keeper_capability_probe.exe      8 tests run, 0 failures
```

**변이 테스트** — SSOT 위임을 첫 초안의 손수 구현으로 되돌리면:

```
MUTANT exit 1
[FAIL] operator-only is distinguished       (masc_status 가 Projected 로 나옴)
[FAIL] transport alias names its projection
[FAIL] round-trips every published name
3 failures! in 0.009s. 8 tests run.
```

통과하는 테스트가 아니라 **틀렸을 때 빨개지는 테스트**임을 확인했다.

**배선 확인** — `test/dune` 은 `(names)` 와 `(modules)` 두 필드에 등록이 필요하다. 하나만 넣으면 빌드가 실패하므로 조용히 안 도는 상태로 태어나지는 않지만, 실행까지 확인했다 (위 8 tests run). 새 모듈이 실제로 컴파일 대상인지도 의도적 타입 에러로 대조군을 잡았다.

기대값은 전부 리터럴이다. 검사 대상 함수를 기대값 쪽에도 쓰면 항등식이 되므로 `Projected { model_facing_name = "masc_board_list" }` 처럼 문자열을 직접 박았다.

## 범위 밖

`probe_invocation`(프로브 identity 하에 provider 왕복 1회)은 이 PR 에 없다. RFC 의 핵심 검증인 "프로브 N회 후 세 스토어 전부 바이트 동일"도 그 PR 에 붙는다 — 지금은 쓰기 경로 자체가 없어서 그 테스트가 자명하게 통과한다.

## 미검증

- 런타임의 `tools_support=false` 는 아직 반영하지 않는다. `probe_surface` 는 런타임 무관하게 MASC 투영만 답한다. RFC 의 `probe_surface ~runtime_id` 시그니처보다 좁다.
- `Withheld_by_schema_error` 는 현재 표면에 해당 사례가 0건이라 실데이터로 밟아보지 못했다. 테스트는 0건 유지를 단언한다.

## 이 결과가 성공을 뜻하지 않는 이유

`Projected` 는 "턴을 쓸 가치가 있다"이지 "도달 가능"이 아니다. antigravity 브리지는 97 도구를 광고하고 `initialize`·`tools/list` 둘 다 응답했는데 모델은 하나도 못 봤다. 투영은 MASC 쪽, 소비는 클라이언트 쪽이고 둘은 갈라진다. `.mli` 에 이 비대칭을 명시했다.

RFC-WAIVED: RFC-0374 (#28422) 가 이 구현의 설계 문서다.

Refs masc#28414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
