### PR TITLE
fix(fusion): pass the clock that makes preset deadlines enforceable (P0)

### DIFF
--- a/lib/fusion/fusion_agent_core.ml
+++ b/lib/fusion/fusion_agent_core.ml
@@ -138,6 +138,20 @@ let web_tool_bundle () : Agent_core.Tool.t list =
   |> List.concat
   |> List.filter_map agent_core_tool_of_descriptor
 
+(* AGENT_CORE 는 데드라인을 요청받으면 그것을 강제할 clock 도 함께 요구한다:
+   [body_timeout_s] 만 주고 clock 을 빼면 요청이 dispatch 전에
+   "body_timeout_s was supplied without the clock required to enforce it" 로
+   거부된다(http_client.ml). 즉 preset 데드라인을 켜는 순간 clock 전달은 선택이
+   아니라 같은 계약의 반쪽이다 — 이 함수가 그 반쪽을 한 곳에서 공급한다.
+
+   clock 이 없으면 [None] 을 돌려주고 호출자는 데드라인 없이 진행한다. Eio 런타임
+   위에서 도는 정상 경로에는 항상 clock 이 있고, 없다면 그건 데드라인을 못 지키는
+   상황이지 패널을 전멸시킬 이유는 아니다(그 경우 provider 기본 데드라인이 남는다). *)
+let deadline_clock () =
+  match Masc_eio_env.get_opt () with
+  | Some { Masc_eio_env.clock; _ } -> Some clock
+  | None -> None
+
 let build_agent
     ~sw
     ~net

--- a/lib/fusion/fusion_agent_core.mli
+++ b/lib/fusion/fusion_agent_core.mli
@@ -20,6 +20,12 @@
     설정이 필요한 호출자가 resolved provider config를 agent build 전에 보강하는
     hook이다.
     미존재 runtime·빌드 실패는 [panel_failure]로. *)
+(** The Eio clock AGENT_CORE needs to enforce a requested deadline. Supplying
+    [body_timeout_s] without it makes the provider reject the request before
+    dispatch, so every fusion call site that sets a deadline must pass this
+    clock into [Async_agent.all]. [None] when no Eio env is published. *)
+val deadline_clock : unit -> float Eio.Time.clock_ty Eio.Resource.t option
+
 val build_agent
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -192,7 +192,10 @@ let run_composed ~sw ~net ?max_tokens ?timeout_s ~judge_system_prompt ~judge_mod
   | Ok agent ->
     (match
        Masc_agent_core_bridge.run_safe ~caller:Masc_agent_core_bridge.Fusion_judge (fun () ->
-         Ok (Agent_core.Async_agent.all ~sw [ (agent, prompt) ]))
+         Ok
+           (Agent_core.Async_agent.all ~sw
+              ?clock:(Fusion_agent_core.deadline_clock ())
+              [ (agent, prompt) ]))
      with
      | Error e ->
        Error

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -120,6 +120,7 @@ let run ~base_dir ~sw ~net ~groups ~prompt ()
       Masc_agent_core_bridge.run_safe ~caller:Masc_agent_core_bridge.Fusion_panel (fun () ->
         Ok
           (Agent_core.Async_agent.all ~sw
+             ?clock:(Fusion_agent_core.deadline_clock ())
              (List.map (fun (agent, _panelist, _model) -> (agent, prompt)) built)))
     with
     | Ok run_results ->


### PR DESCRIPTION
## P0 — 지금 fusion 은 첫 호출에서 전멸한다

#28409 가 preset 데드라인을 에이전트의 `body_timeout_s` 로 집행하게 만들었는데, AGENT_CORE 는 **데드라인과 그것을 강제할 clock 을 한 계약의 두 반쪽**으로 다룬다. clock 없이 `body_timeout_s` 만 주면 요청이 dispatch 전에 거부된다:

```
Complete.complete: body_timeout_s was supplied without the clock required to enforce it
                                                      (http_client.ml:291-298)
```

fusion 은 `Async_agent.all` 을 `?clock` 없이 부른다. 따라서 `panel_timeout_s` / `judge_timeout_s` 를 선언한 preset 의 **모든 패널과 심판이 dispatch 에서 실패**한다. 운영 config 는 5개 preset 전부에 240s/180s 를 선언하고 있으므로, 다음 `masc_fusion` 호출은 `0 of N panels answered` 로 돌아온다 — 예산을 실효화하려던 변경이 기능 전체를 죽인 것이다.

아직 안 터진 이유는 하나뿐이다: **그 머지 이후 fusion run 이 0건**이었다(마지막 run 08-11 13:17, 머지 08-12 14:22).

## 실측

quorum preset, `topology=judge_of_judges`, 같은 프롬프트:

| | 결과 |
|---|---|
| 수정 전 | panel **0/4**, 4개 전부 `body_timeout_s was supplied without the clock…`, judge nodes 0, `panels_unavailable` |
| 수정 후 | panel **4/4**, judge nodes 3 (`first:evidence` → `first:coverage` → `meta`), **29.7s**, resolved answer 정상 |

council preset, `topology=staged_judge_of_judges` (수정 후): panel 4/4, judge nodes **9** (first 6 → stage_meta 2 → final_meta 1), **97.8s**, LLM 호출 13회.

이 두 topology 가 실제로 실행된 것은 이번이 처음이다.

## 설계

accessor 를 `build_agent` 옆에 둔 이유는 계약의 나머지 반쪽이 거기서 설정되기 때문이다 — 두 반쪽이 다시 갈라질 수 없다. Eio env 가 없으면 `None` 을 돌려주고 데드라인 없이 진행한다: **강제 불가능한 예산은 provider 기본값으로 물러설 이유이지 패널을 잃을 이유가 아니다.**

## 검증

전체 `dune build`; `test/fusion_core` 83/83, `test_fusion_judge_usage` 24/24; ocamlformat clean.

**테스트로 못 잡는 부분**: 현재 fusion 하네스는 live provider 없이 dispatch 단계의 거부를 관측할 수 없다. 이것이 정확히 이 회귀가 main 까지 간 이유다 — 단위 테스트는 *결정*을 핀하지 *dispatch* 를 핀하지 않는다.

RFC-WAIVED: 회귀 수정이며 `pr-rfc-check.sh` 대상 subsystem 에 닿지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
