### PR TITLE
fix(ci): run the RFC-0374 probe suite in CI, not just compile it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1056,6 +1056,7 @@ jobs:
             @test/runtest-test_event_bus_subscription_contract \
             @test/runtest-test_fs_compat_home_guard \
             @test/runtest-test_guarded_dispatch_telemetry \
+            @test/runtest-test_keeper_capability_probe \
             @test/runtest-test_keeper_checkpoint_stale_guard \
             @test/runtest-test_keeper_contract_classifier_pure \
             @test/runtest-test_keeper_conditions_wire_parity \


### PR DESCRIPTION
main-red 복구. `Meta Guards` 실패를 되돌린다.

## 증상

```
[ci-test-targets] FAIL - 663 suites are declared but never run in CI (baseline 662)
1 more than the baseline.
```

#28432 (`ce9893d53d`) 가 머지되면서 main 의 `Meta Guards` 가 exit 2.

## 원인

#28432 는 `test_keeper_capability_probe` 를 `test/dune` 의 `(names)`/`(modules)` 에 등록했다. 그러면 **로컬에서는** 빌드되고 실행된다. CI 는 별도의 선언된 타깃 목록(`ci.yml`, `ci-run-focused-tests.sh`)을 돌리므로 거기 없으면 **compile-only** 다 — 컴파일은 되지만 실행되지 않고, 단언이 자기가 고정하는 코드보다 오래 살아남는다. `audit-ci-test-targets.sh` 가 정확히 이걸 세는 ratchet 이고 662 → 663 으로 올랐다.

#28432 의 PR 본문은 "실행까지 확인했다"고 적었다. 그건 로컬 실행이었고, CI 가 이 스위트를 돌릴지는 아무것도 확인하지 않았다.

## 수정

`.github/workflows/ci.yml` 의 타깃 목록에 `@test/runtest-test_keeper_capability_probe` 한 줄.

## 검증

```
$ bash scripts/audit-ci-test-targets.sh          # 수정 전 (origin/main)
[ci-test-targets] FAIL - 663 suites ... (baseline 662)

$ bash scripts/audit-ci-test-targets.sh          # 수정 후
[ci-test-targets] OK - 196 CI targets, all declared in Dune
[ci-test-targets] OK - 662 suites unwired, at baseline

$ dune build --root . @test/runtest-test_keeper_capability_probe
Test Successful in 0.002s. 8 tests run.
```

ratchet 통과만이 아니라 **alias 가 실제로 8 케이스를 실행하는지**까지 확인했다 — 목록에 이름만 올리고 안 도는 상태가 이 실패의 원인이었으므로.

Refs masc#28414, RFC-0374

🤖 Generated with [Claude Code](https://claude.com/claude-code)