### PR TITLE
fix(test): CanAdmin 게이트를 Worker 로 찌르도록 — #28423 의 미검증 항목 해소

### DIFF
--- a/docs/rfc/RFC-0340-dashboard-token-only-auth.md
+++ b/docs/rfc/RFC-0340-dashboard-token-only-auth.md
@@ -1,11 +1,11 @@
 ---
 rfc: "0340"
-title: "Loopback dashboard Worker credential"
+title: "Loopback dashboard token-only auth"
 status: Active
 updated: 2026-08-03
 ---
 
-# RFC-0340: Loopback dashboard Worker credential
+# RFC-0340: Loopback dashboard token-only auth
 
 - Status: Active
 - Date: 2026-07-10
@@ -30,20 +30,21 @@ The admitted request authority must also be an exact loopback host before any
 token or credential I/O occurs. Host suffix and substring matching are not
 part of the contract.
 
-The credential grants `Worker` permissions. It cannot satisfy `CanAdmin`,
-`CanInit`, or `CanReset`. Dashboard operations that require those permissions
-need an explicit operator credential. Known MCP tools continue to use their
-typed tool permission; the dev-token does not create a path-based exception.
+The credential's role is `RFC-dashboard-dev-token-configured-role`'s decision,
+not this RFC's; that RFC issues it as `Admin`. Known MCP tools continue to use
+their typed tool permission, and the dev-token does not create a path-based
+exception — the endpoint's own gate is the exact loopback `Host`, which this
+RFC specifies above.
 
 ## Durable rotation
 
 Only a valid credential whose actor is exactly `dashboard` and whose role is
-exactly `Worker` is reusable. Every other stored candidate enters one serialized
+exactly the configured issuance role is reusable. Every other stored candidate enters one serialized
 rotation:
 
 1. Persist the new raw token at `.masc/auth/dashboard.token.pending`.
 2. Revoke the current `dashboard` credential.
-3. Persist the new `Worker` credential for the journalled raw token.
+3. Persist the new credential for the journalled raw token.
 4. Atomically publish the raw token at `.masc/auth/dashboard.token` with private
    file permissions.
 5. Remove the pending journal.
@@ -85,13 +86,14 @@ MCP calls carrying an explicit actor are never replayed by this recovery path.
 
 - Invalid request authority performs zero dev-token file I/O.
 - The response has the exact actor and role contract.
-- An existing `Admin` dashboard credential is revoked; its bearer becomes
-  invalid and the replacement bearer resolves to `Worker`.
+- A dashboard credential whose role differs from the configured issuance role
+  is revoked, and its bearer becomes invalid.
 - Corrupt journals and injected read/write failures fail closed with stable
   error codes.
-- The Worker bearer receives `403` from
-  `POST /api/v1/dashboard/gate/mode` (`CanAdmin`) and can use an allowed
-  `CanVote` route.
+- `POST /api/v1/dashboard/gate/mode` (`CanAdmin`) answers `403` to a bearer
+  below that permission. `test_sse_storm_e2e` pins this with a minted `Worker`,
+  not with the dashboard bearer, whose role this RFC does not decide.
 - Typed REST and MCP auth failures retry once; prose-only failures do not retry.
-- `rg "~role:Masc_domain.Admin" lib/server/server_routes_http_dashboard_dev_token.ml`
-  returns no matches.
+- The issuance role is read from one constant
+  (`Server_routes_http_dashboard_dev_token.dashboard_dev_role`), never inlined
+  per call site.

--- a/test/stanzas/test_sse_storm_e2e.inc
+++ b/test/stanzas/test_sse_storm_e2e.inc
@@ -1,7 +1,7 @@
 (test
  (name test_sse_storm_e2e)
  (modules test_sse_storm_e2e)
- (libraries masc alcotest masc_test_runtime yojson unix)
+ (libraries masc masc.auth masc.masc_types alcotest masc_test_runtime yojson unix)
  (deps ../bin/main_eio.exe)
  (enabled_if (= %{env:MASC_E2E_TESTS=false} "true"))
  (action

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -670,23 +670,47 @@ let test_ag_ui_frames_are_wire_encoded () =
               event_id))
     first_masc_events
 
-let test_dashboard_dev_token_cannot_call_admin_route () =
-  with_server @@ fun ~port ~auth_token ~base_path:_ ->
-  let result =
-    run_curl
-      ~headers:
-        [ ("Accept", "application/json")
-        ; ("Authorization", "Bearer " ^ auth_token)
-        ; ("Content-Type", "application/json")
-        ]
-      ~method_:"POST"
-      ~body:"{}"
-      ~max_time:2.0
-      ~port
-      ~path:"/api/v1/dashboard/gate/mode"
-      ()
-  in
-  check_status "dashboard Worker token denied CanAdmin route" 403 result
+(* A credential the server accepts as a genuine non-admin caller. The loopback
+   dashboard dev-token used to serve that role here, but #28354 issues it as
+   [Masc_domain.Admin], so probing a CanAdmin gate with it stopped proving the
+   gate exists. Mint the negative probe explicitly instead of borrowing a
+   credential whose role is someone else's decision. *)
+let create_worker_token base_path ~agent_name =
+  match Auth.create_token base_path ~agent_name ~role:Masc_domain.Worker with
+  | Ok (raw_token, _) -> raw_token
+  | Error error ->
+    fail ("create_token failed: " ^ Masc_domain.masc_error_to_string error)
+
+let gate_mode_post ~port ~token =
+  run_curl
+    ~headers:
+      [ ("Accept", "application/json")
+      ; ("Authorization", "Bearer " ^ token)
+      ; ("Content-Type", "application/json")
+      ]
+    ~method_:"POST"
+    ~body:"{}"
+    ~max_time:2.0
+    ~port
+    ~path:"/api/v1/dashboard/gate/mode"
+    ()
+
+let test_gate_mode_route_is_admin_gated () =
+  with_server @@ fun ~port ~auth_token ~base_path ->
+  let worker_token = create_worker_token base_path ~agent_name:"sse-storm-worker" in
+  check_status
+    "Worker token denied CanAdmin route"
+    403
+    (gate_mode_post ~port ~token:worker_token);
+  (* The dashboard dev-token is Admin since #28354, so it clears authorization
+     and the empty body is what the route rejects. Asserting "not 403" rather
+     than a specific success code keeps this pinned to the authorization
+     decision, which is the subject, and leaves the request schema free to
+     change. *)
+  match (gate_mode_post ~port ~token:auth_token).status with
+  | Some 403 -> fail "dashboard dev-token was denied a CanAdmin route (#28354 issues it as Admin)"
+  | Some _ -> ()
+  | None -> fail "dashboard dev-token gate/mode request produced no HTTP status"
 
 let check_operation_error label expected_code result =
   match Yojson.Safe.from_string result.body with
@@ -774,9 +798,15 @@ let test_official_client_recovery_uses_real_admin_route () =
   let session_path =
     "/api/v1/runtime/sessions/official-client?keeper_name=" ^ keeper_name
   in
+  (* Probe with a minted Worker rather than the dashboard dev-token: #28354
+     issues that token as Admin, so it now reads this route successfully and
+     would turn the assertion into a claim about nothing. *)
+  let worker_token =
+    create_worker_token base_path ~agent_name:"sse-storm-recovery-worker"
+  in
   let worker =
     run_curl
-      ~headers:[ "Authorization", "Bearer " ^ auth_token ]
+      ~headers:[ "Authorization", "Bearer " ^ worker_token ]
       ~max_time:2.0
       ~port
       ~path:session_path
@@ -921,9 +951,9 @@ let () =
     [
       ( "auth"
       , [ test_case
-            "dev-token cannot call admin route"
+            "gate/mode is admin gated"
             `Slow
-            test_dashboard_dev_token_cannot_call_admin_route
+            test_gate_mode_route_is_admin_gated
         ; test_case
             "dev-token can use Keeper operation routes"
             `Slow


### PR DESCRIPTION
#28423 에서 `test_sse_storm_e2e` 는 **컴파일까지만 확인하고 실행은 CI 에 맡긴다**고 명시했습니다. 실제로 돌려보니 통과하지 않았습니다. 그 미검증 항목을 닫는 PR 입니다.

## 실행이 드러낸 것

```
[FAIL] auth 0  "dashboard Worker token denied CanAdmin route"   403 기대 → 400
[FAIL] auth 2  "Worker cannot read official-client recovery"     403 기대 → 200
2 failures! in 22.243s. 7 tests run.
```

둘 다 #28354 의 같은 마이그레이션에서 남은 것입니다. 루프백 대시보드 dev-token 이 **Worker 라서 거부된다**는 전제로 CanAdmin 게이트를 찌르고 있었는데, #28354 가 그 토큰을 Admin 으로 발급합니다.

- `400` — 인가는 통과했고, 게이트를 지난 뒤 빈 본문 `{}` 이 검증에서 떨어진 것
- `200` — Admin 이 실제로 읽어낸 것

## 기대값을 뒤집지 않은 이유

`403 → 200` 으로 고치는 게 제일 짧지만, 그러면 **테스트의 주제가 사라집니다.** `auth 2` 의 이름이 "official-client recovery uses real CanAdmin route" 인데, 대시보드 토큰이 Admin 이면 그 단언은 라우트가 admin-gated 라는 걸 더 이상 증명하지 않습니다. 불변식을 지우는 대신 **음성 프로브만 교체**했습니다.

```ocaml
let create_worker_token base_path ~agent_name =
  match Auth.create_token base_path ~agent_name ~role:Masc_domain.Worker with
```

`base_path` 는 이미 `with_server` 가 테스트 본문에 넘기고 있었고(`~base_path:_` 로 버려지던 값), 각 테스트가 자기 Worker 를 만듭니다. 남의 결정에 달린 역할을 빌려 쓰지 않습니다.

`auth 0` 에는 대시보드 토큰이 **거부되지 않는다**는 단언을 따로 넣었습니다 — 그게 #28354 의 실제 계약입니다. 성공 코드가 아니라 "403 아님" 으로 고정해서, 판정 대상은 인가 결정에 두고 요청 스키마는 자유롭게 뒀습니다.

## 변이 검사

프로브의 역할만 `Worker → Admin` 으로 바꾸면:

```
[FAIL] auth 0  gate/mode is admin gated.
[FAIL] auth 2  official-client recovery uses real CanAdmin route
  (나머지 5건은 통과)
2 failures! in 41.810s. 7 tests run.
```

단언이 라우트가 아니라 **자격증명에 의존**한다는 것 — 즉 게이트를 실제로 검증한다는 것이 확인됩니다.

## RFC-0340 정리

이 문서는 폐기된 Worker 모델을 5곳에서 서술하고 있었고, 그중 하나는 반증 가능한 형태였습니다.

```
- `rg "~role:Masc_domain.Admin" lib/server/server_routes_http_dashboard_dev_token.ml`
  returns no matches.
```

실제로는 1건 반환합니다 (`dashboard_dev_role = Masc_domain.Admin`). 인증 문서가 측정으로 반증되는 서술을 들고 있는 건 해롭습니다.

역할 결정은 이제 `RFC-dashboard-dev-token-configured-role` 소관이므로, RFC-0340 은 그걸 되풀이하지 않고 자기가 소유한 것만 남깁니다 — 루프백 `Host` 게이트, durable rotation, typed self-healing. 제목의 "Worker credential" 도 파일명이 이미 가리키던 실제 주제로 맞췄습니다.

## 검증

```
MASC_E2E_TESTS=true test_sse_storm_e2e     7/7 통과, exit 0  (42.09s)
dune build --root . test/test_sse_storm_e2e.exe   exit 0
```

CI 와 같은 env(`MASC_E2E_TESTS=true`, `MASC_MAIN_EIO_EXE`)로 실행했습니다. 병렬 세션이 dune 락을 쥐고 있어 alias 대신 실행 파일을 직접 돌렸고, stanza 가 주입하는 env 를 그대로 재현했습니다.

`test/stanzas/test_sse_storm_e2e.inc` 에 `masc.auth` + `masc.masc_types` 를 추가했습니다 (`Auth.create_token` / `Masc_domain.Worker` 참조용).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
