### PR TITLE
fix(mcp): ignore unrecognized notifications instead of answering HTTP 400

### DIFF
--- a/lib/runtime/runtime_official_client_mcp.ml
+++ b/lib/runtime/runtime_official_client_mcp.ml
@@ -314,10 +314,16 @@ let dispatch_message
           ~next:{ expected with phase = Ready }
       in
       Ok { response = None; tool_called = false }
-    | _, None ->
-      error
-        "MCP message"
-        (Printf.sprintf "MCP notification %S is not supported" message.method_name)
+    (* A notification carries no id, so there is nothing to answer and JSON-RPC
+       forbids answering it. Returning a transport error here ended the session
+       instead: agy sends [notifications/roots/list_changed] immediately after
+       [notifications/initialized], got HTTP 400, and dropped the connection 32ms
+       into every antigravity turn, taking all advertised tools with it before
+       the model's first message (masc#28431). MCP 2025-06-18, Base Protocol /
+       Notifications: "The receiver MUST NOT send a response." Unrecognized
+       notifications are ignored; unrecognized *requests* still answer -32601
+       below, because those do carry an id and do expect a reply. *)
+    | _, None -> Ok { response = None; tool_called = false }
     | _, Some request_id ->
       let id = Mcp_transport_protocol.request_id_to_yojson request_id in
       Ok

--- a/test/test_runtime_official_client_mcp_http.ml
+++ b/test/test_runtime_official_client_mcp_http.ml
@@ -449,6 +449,76 @@ let test_callback_failures_do_not_poison_protocol_state () =
   check int "callback failures are observable rejections" 2 snapshot.rejected_requests
 ;;
 
+(* An unrecognized notification used to answer HTTP 400, which agy read as a
+   dead connection: it sends [notifications/roots/list_changed] right after
+   [notifications/initialized] and dropped the session 32ms into every turn,
+   removing all advertised tools before the model spoke (masc#28431). The
+   session must survive it and keep serving tools. *)
+let test_unknown_notification_is_ignored_and_session_survives () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let tool_specs () = [ `Assoc [ "name", `String "masc_probe" ] ] in
+  (* This test never reaches tools/call; the callback exists to satisfy [start]. *)
+  let call_tool ~name:_ ~call_id:_ ~arguments:_ = None in
+  let bridge =
+    Runtime_official_client_mcp_http.start
+      ~sw
+      ~net:env#net
+      ~secure_random:env#secure_random
+      ~server_name:"masc"
+      ~tool_specs
+      ~call_tool
+      ()
+  in
+  let endpoint, authorization = config_fields bridge in
+  let protocol_version =
+    initialize_session ~sw ~net:env#net ~endpoint ~authorization
+  in
+  let roots_changed =
+    request
+      ~protocol_version
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      {|{"jsonrpc":"2.0","method":"notifications/roots/list_changed"}|}
+  in
+  check int "unknown notification is accepted" 202 roots_changed.status;
+  check string "notification draws no body" "" (String.trim roots_changed.body);
+  let listed =
+    request
+      ~protocol_version
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 4 "tools/list" (`Assoc []))
+  in
+  check int "session survives the notification" 200 listed.status;
+  let snapshot = Runtime_official_client_mcp_http.For_testing.snapshot bridge in
+  check bool "phase is still ready" true (snapshot.phase = Ready);
+  (* An unrecognized *request* carries an id and still owes a JSON-RPC error. *)
+  let unknown_request =
+    request
+      ~protocol_version
+      ~sw
+      ~net:env#net
+      ~endpoint
+      ~authorization
+      (json_request 5 "resources/list" (`Assoc []))
+  in
+  check int "unknown request still answers" 200 unknown_request.status;
+  check int
+    "unknown request answers method-not-found"
+    (-32601)
+    (Yojson.Safe.from_string unknown_request.body
+     |> member "error"
+     |> member "code"
+     |> Yojson.Safe.Util.to_int)
+;;
+
 let () =
   run
     "runtime_official_client_mcp_http"
@@ -463,6 +533,12 @@ let () =
             "callback failures remain typed and do not poison lifecycle"
             `Quick
             test_callback_failures_do_not_poison_protocol_state
+        ] )
+    ; ( "notifications"
+      , [ test_case
+            "unknown notification is ignored and the session survives"
+            `Quick
+            test_unknown_notification_is_ignored_and_session_survives
         ] )
     ]
 ;;


### PR DESCRIPTION
Closes #28431.

## 무슨 일이 벌어지고 있었나

antigravity 런타임 11종 전부가 MASC 도구를 한 번도 호출하지 못했다. 모델은 "무엇을 하겠다"는 표를 출력하고 턴을 끝냈다.

원인은 모델도, permission 설정도, `--mode plan` 도 아니었다. **MCP 세션이 부팅 32ms 만에 끊기고 있었다.**

agy 가 MASC 관리 HOME 아래에 남긴 자기 로그에 그대로 적혀 있다:

```
00:02:48.752  server.go:2284]      initialized server successfully in 288.19525ms
00:02:48.784  mcp_manager.go:1737] MCP server connection closed unexpectedly
                                   for masc: sending
                                   "notifications/roots/list_changed": Bad Request
```

같은 로그에서 `masc_*` 도구 이름 등장 횟수 **0**. 97개 도구가 모델의 첫 메시지 전에 사라진다.

## 원인

`lib/runtime/runtime_official_client_mcp.ml` 의 dispatch 는 `id = None`(= notification)을 만나면 `notifications/initialized` 하나만 처리하고 나머지를 `error` 로 떨어뜨렸다. HTTP 층은 그 `error` 를 `` `Bad_request `` (400) 로 내보낸다.

MCP 2025-06-18, Base Protocol / Notifications:

> Notifications are sent from the client to the server or vice versa, as a one-way message. **The receiver MUST NOT send a response.**

`notifications/roots/list_changed` 는 roots capability 를 선언한 클라이언트의 표준 통지다. 서버가 roots 를 쓰지 않으면 무시해야 한다. 400 을 받은 agy 가 연결을 끊는 것은 올바른 클라이언트 동작이다.

## 변경

미지의 notification 은 응답 없이 무시한다. 미지의 *request* 는 id 를 가지고 있고 응답을 기대하므로 `-32601` 을 그대로 돌려준다 — 이 분기는 건드리지 않았다.

```ocaml
- | _, None ->
-   error "MCP message"
-     (Printf.sprintf "MCP notification %S is not supported" message.method_name)
+ | _, None -> Ok { response = None; tool_called = false }
```

## 검증

`test/test_runtime_official_client_mcp_http.ml` 에 케이스 추가:

- `notifications/roots/list_changed` → **202**, 본문 없음
- 그 뒤 `tools/list` → **200**, phase 는 여전히 `Ready` (세션 생존)
- `resources/list`(미지의 *request*) → 여전히 `-32601` 응답 (회귀 방지)

```
Test Successful in 0.152s. 3 tests run.
```

**변이 검증**: 수정을 되돌리고 같은 테스트를 돌리면 `FAIL unknown notification is accepted` 로 실패한다 (exit 1). 테스트가 실제로 이 결함을 잡는다는 것을 확인했다.

## 측정 근거

전용 프로브 키퍼(`rtprobe`)로 도구 카테고리 10종을 런타임별로 실행한 스윕:

| provider | 통과 |
|---|---|
| `claude_code` | **21 / 21** |
| `kimi_coding` | **8 / 8** |
| `antigravity_subscription` | **0 / 33** |

같은 하네스·같은 키퍼·같은 프롬프트다. claude CLI 는 이 통지를 보내지 않아 같은 브리지에서 전승한다. **클라이언트 종류에 따라 전부-아니면-전무로 갈리는 결함**이라 단일 클라이언트 테스트로는 드러나지 않았다.

## 범위 밖 (후속)

이 수정은 도구를 다시 보이게 만든다. antigravity 가 실제로 도구를 부르는지는 별개 축이고, 최소 두 가지가 남아 있다 — `toolPermission` 이 `request-review`(headless 에 리뷰어 없음)로 고정이고, `--mode` 가 `plan` 고정이며 `Accept_edits` variant 는 생성 코드가 0곳이다. 이 PR 머지 후 같은 스윕을 재실행해 다음 층을 특정한다.

RFC-WAIVED: credential/identity/operator/sandbox/hooks/workflow 중 어느 subsystem 도 건드리지 않는다. 변경은 `lib/runtime/` MCP 전송 계층 1줄과 그 테스트뿐이며, 근거는 RFC 가 아니라 MCP 2025-06-18 spec 의 MUST NOT 조항이다.

WORKAROUND-WAIVED: 증상 억제가 아니라 spec 위반 분기 제거다. 카운터·문자열 분류기·cap/cooldown·N-of-M 패치 어느 것도 추가하지 않으며, 코드가 순감(4줄 → 1줄)한다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
