### PR TITLE
docs(auth): dev-token 라우트가 자기 bearer 를 Worker 라고 부르지 않도록 (#28354 스윕 종결)

### DIFF
--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -75,7 +75,7 @@ let token_error_to_string = function
     Printf.sprintf "revoke dashboard credential %S: %s" agent_name detail
   | Credential_rotation_failed error ->
     Printf.sprintf
-      "persist dashboard Worker credential: %s"
+      "persist dashboard credential: %s"
       (Masc_domain.masc_error_to_string error)
   | Token_file_write_failed { path; detail } ->
     Printf.sprintf "persist dashboard dev-token %s: %s" path detail

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -929,11 +929,12 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/workspace" (fun request reqd ->
        with_public_read handle_dashboard_workspace request reqd)
-  (* Dev-only Worker bearer for the dashboard UI. Served exclusively when the
-     server binds to loopback and strict-auth env overrides are disabled, so
-     that a LAN deployment never hands out a credential over the wire. The
-     token is canonicalized to the [dashboard] actor and persisted at
-     [.masc/auth/dashboard.token]. *)
+  (* Dev-only bearer for the dashboard UI, minted at the role named by
+     [Server_routes_http_dashboard_dev_token.dashboard_dev_role]. Served
+     exclusively when the server binds to loopback and strict-auth env
+     overrides are disabled, so that a LAN deployment never hands out a
+     credential over the wire. The token is canonicalized to the [dashboard]
+     actor and persisted at [.masc/auth/dashboard.token]. *)
   |> Http.Router.get "/api/v1/dashboard/dev-token" (fun request reqd ->
        if (not (http_auth_bind_is_loopback ()))
           || http_auth_strict_enabled () then


### PR DESCRIPTION
#28354 가 남긴 마지막 잔여물입니다. 이번 세션에서 같은 마이그레이션이 네 번 물었는데, 매번 **실패로 발견**했지 찾아서 발견한 게 아니라 이번엔 전수로 훑었습니다.

| 발견 경로 | 대상 | PR |
|---|---|---|
| 대시보드 테스트 6건 실패 | TS 픽스처 14곳 | #28423 |
| CI `Build and Test` 성공 0/40 | OCaml dev-token 계약 | #28423 |
| e2e 를 실제로 실행 | CanAdmin 단언 2건 + RFC-0340 5곳 | #28436 |
| **전수 스윕** | 남은 문자열 2건 | 본 PR |

## 변경

둘 다 "이 자격증명이 무엇을 할 수 있는가"를 판단하는 사람이 읽는 자리입니다.

**`server_routes_http_routes_dashboard.ml`** — Admin bearer 를 발급하는 라우트에 이렇게 적혀 있었습니다.

```ocaml
(* Dev-only Worker bearer for the dashboard UI. ... *)
```

읽는 사람에게 루프백 자격증명이 저권한이라는 **반대 모델**을 심습니다. 인증 표면에서 그 모델은 파일의 나머지를 얼마나 조심해서 읽을지를 결정합니다. 역할을 되풀이하지 않고 `dashboard_dev_role` 을 가리키도록 바꿨습니다.

**`server_routes_http_dashboard_dev_token.ml`** — `Credential_rotation_failed` 가 Admin 으로 발급된 자격증명의 회전 실패를 보는 운영자에게 이렇게 말하고 있었습니다.

```
persist dashboard Worker credential: <error>
```

이 에러는 "어떤 role 이 실패했는가"가 아니라 "영속화가 실패했다"는 사실이라 role 을 뺐습니다.

## 왜 이것들이 살아남았나

둘 다 load-bearing 이 아닙니다. 컴파일러도 테스트도 문자열을 검증하지 않으니 계약이 바뀌어도 조용히 남습니다. 그래서 실패로는 절대 발견되지 않고, 스윕으로만 잡힙니다.

## 오탐으로 확인한 것

- `Domain_pool worker` 계열 (`board_dispatch`, `dashboard_cache`, `dashboard_http_keeper` 등) — 다른 개념
- `dashboard/src/api/dev-token.test.ts:166` — `role: 'worker'` 는 **거부 케이스**의 입력. 의도된 것
- `dashboard/src/store-shell-auth.test.ts:87` — `effective_agent: 'codex'` 인 codex 자격증명이라 worker 가 맞음
- `dashboardAuthAccess(summary, 'worker')` — 최소 요구 수준이지 "이 토큰이 worker 다"라는 단언이 아님

## 검증

```
dune build --root . @check                 exit 0
ocamlformat --check (변경 파일 2개)          exit 0
```

`dune build @fmt` 는 실패하지만 대상이 전부 `dune` 파일이고 제 `.ml` 두 개는 포함되지 않습니다 — main 의 선행 상태입니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
