### PR TITLE
feat(keeper): RFC-0374 probe_invocation for the Agent Core lane

### DIFF
--- a/lib/keeper/keeper_capability_probe.ml
+++ b/lib/keeper/keeper_capability_probe.ml
@@ -77,3 +77,195 @@ let model_facing_names () =
   Keeper_tool_descriptor.model_visible_schemas ()
   |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
 ;;
+
+(* ------------------------------------------------------------------ *)
+(* Invocation (Agent Core lane)                                        *)
+(* ------------------------------------------------------------------ *)
+
+type invocation =
+  | Tool_invoked of
+      { tool : string
+      ; elapsed_s : float
+      }
+  | Other_tool_invoked of
+      { requested : string
+      ; invoked : string list
+      ; elapsed_s : float
+      }
+  | Replied_no_tool of
+      { reply_bytes : int
+      ; elapsed_s : float
+      }
+  | Provider_rejected of { detail : string }
+
+let invocation_to_string = function
+  | Tool_invoked { tool; elapsed_s } ->
+    Printf.sprintf "invoked %s in %.1fs" tool elapsed_s
+  | Other_tool_invoked { requested; invoked; elapsed_s } ->
+    Printf.sprintf
+      "called %s instead of %s in %.1fs"
+      (String.concat ", " invoked)
+      requested
+      elapsed_s
+  | Replied_no_tool { reply_bytes; elapsed_s } ->
+    Printf.sprintf "replied %d B without calling a tool in %.1fs" reply_bytes elapsed_s
+  | Provider_rejected { detail } -> Printf.sprintf "provider rejected: %s" detail
+;;
+
+type invocation_error =
+  | Not_on_surface of verdict
+  | Unresolvable_runtime of string
+  | Not_agent_core_lane of string
+  | Tool_schema_rejected of string
+
+let invocation_error_to_string = function
+  | Not_on_surface v -> verdict_to_string v
+  | Unresolvable_runtime detail -> detail
+  | Not_agent_core_lane label ->
+    Printf.sprintf
+      "%s is an official-client lane; its session is keyed by keeper name and \
+       this probe does not isolate one"
+      label
+  | Tool_schema_rejected detail -> Printf.sprintf "tool schema rejected: %s" detail
+;;
+
+(* The wire form has to be the one a real turn sends, so it goes through the
+   same [tool_schema_to_json] that [Agent_turn.prepare_tools] uses. Hand-rolling
+   the JSON here would make a probe that passes while the real turn's encoding
+   has drifted -- the failure this module exists to prevent. *)
+let wire_tool_of_schema (schema : Masc_domain.tool_schema) =
+  Agent_core.Types.tool_schema_of_input_schema
+    ~name:schema.name
+    ~description:schema.description
+    ~input_schema:schema.input_schema
+    ()
+  |> Result.map Agent_core.Types.tool_schema_to_json
+;;
+
+let tool_use_names (response : Agent_core.Types.api_response) =
+  List.filter_map
+    (function
+      | Agent_core.Types.ToolUse { name; _ } -> Some name
+      | Agent_core.Types.Text _
+      | Agent_core.Types.Thinking _
+      | Agent_core.Types.RedactedThinking _
+      | Agent_core.Types.ReasoningDetails _
+      | Agent_core.Types.ToolResult _
+      | Agent_core.Types.Image _
+      | Agent_core.Types.Document _
+      | Agent_core.Types.Audio _ -> None)
+    response.content
+;;
+
+let reply_bytes (response : Agent_core.Types.api_response) =
+  List.fold_left
+    (fun acc block ->
+      match block with
+      | Agent_core.Types.Text t -> acc + String.length t
+      | Agent_core.Types.Thinking _
+      | Agent_core.Types.RedactedThinking _
+      | Agent_core.Types.ReasoningDetails _
+      | Agent_core.Types.ToolUse _
+      | Agent_core.Types.ToolResult _
+      | Agent_core.Types.Image _
+      | Agent_core.Types.Document _
+      | Agent_core.Types.Audio _ -> acc)
+    0
+    response.content
+;;
+
+let probe_invocation ~sw ~net ?clock ~now ~runtime_id ~tool ~prompt () =
+  match probe_surface ~tool with
+  | (Not_a_descriptor | Operator_only | Aliased _ | Withheld_by_schema_error _) as v ->
+    Error (Not_on_surface v)
+  | Projected { model_facing_name } ->
+    (* The lane has to be checked before the provider config is used. Every
+       runtime resolves a provider config, including the official-client ones,
+       so resolving one is not evidence that this path is the path that runtime
+       actually takes. Probing claude_code over HTTP would answer a question
+       nobody asked. *)
+    (match Runtime.get_runtime_by_id runtime_id with
+     | None ->
+       Error (Unresolvable_runtime (Printf.sprintf "%s is not a configured runtime" runtime_id))
+     | Some rt ->
+       (match rt.Runtime.execution with
+        | Runtime_execution.Codex_app_server _
+        | Runtime_execution.Antigravity_cli _
+        | Runtime_execution.Claude_code _ ->
+          Error (Not_agent_core_lane (Runtime_execution.label rt.Runtime.execution))
+        | Runtime_execution.Agent_core _ ->
+    (match Runtime_agent_core_runner.resolve_runtime_providers ~runtime_id () with
+     | Error detail -> Error (Unresolvable_runtime detail)
+     | Ok [] ->
+       Error (Unresolvable_runtime (Printf.sprintf "%s resolved no provider" runtime_id))
+     | Ok (config :: _) ->
+       let schemas =
+         Keeper_tool_descriptor.model_visible_schemas ()
+         |> List.filter (fun (s : Masc_domain.tool_schema) ->
+           String.equal s.name model_facing_name)
+       in
+       (match schemas with
+        | [] ->
+          (* probe_surface said Projected, so model_visible_schemas must carry
+             the name. Reaching here means the two have drifted apart. *)
+          Error
+            (Tool_schema_rejected
+               (Printf.sprintf
+                  "%s is projected but absent from model_visible_schemas"
+                  model_facing_name))
+        | schema :: _ ->
+          (match wire_tool_of_schema schema with
+           | Error detail -> Error (Tool_schema_rejected detail)
+           | Ok tool_json ->
+             let messages =
+               [ { Agent_core.Types.role = Agent_core.Types.User
+                 ; content = [ Agent_core.Types.Text prompt ]
+                 ; name = None
+                 ; tool_call_id = None
+                 ; metadata = []
+                 }
+               ]
+             in
+             let started = now () in
+             (match
+                Keeper_provider_subcall.complete
+                  ~sw
+                  ~net
+                  ?clock
+                  ~config
+                  ~messages
+                  ~tools:[ tool_json ]
+                  ()
+              with
+              | Error err ->
+                (* Every arm is spelled out. A wildcard here would fold a new
+                   transport failure into the same string as a quota rejection,
+                   and telling those apart is the reason this lane exists. *)
+                let detail =
+                  match err with
+                  | Llm_provider.Http_client.HttpError { code; body; _ } ->
+                    Printf.sprintf "HTTP %d: %s" code (String.trim body)
+                  | Llm_provider.Http_client.NetworkError { message; _ } ->
+                    Printf.sprintf "network: %s" message
+                  | Llm_provider.Http_client.TimeoutError { message; _ } ->
+                    Printf.sprintf "timeout: %s" message
+                  | Llm_provider.Http_client.AcceptRejected { reason } ->
+                    Printf.sprintf "accept rejected: %s" reason
+                  | Llm_provider.Http_client.ProviderTerminal { message; _ } ->
+                    Printf.sprintf "provider terminal: %s" message
+                  | Llm_provider.Http_client.ProviderFailure { message; _ } ->
+                    Printf.sprintf "provider failure: %s" message
+                in
+                Ok (Provider_rejected { detail })
+              | Ok response ->
+                let elapsed_s = now () -. started in
+                (match tool_use_names response with
+                 | [] ->
+                   Ok (Replied_no_tool { reply_bytes = reply_bytes response; elapsed_s })
+                 | names when List.exists (String.equal model_facing_name) names ->
+                   Ok (Tool_invoked { tool = model_facing_name; elapsed_s })
+                 | invoked ->
+                   Ok
+                     (Other_tool_invoked
+                        { requested = model_facing_name; invoked; elapsed_s }))))))))
+;;

--- a/lib/keeper/keeper_capability_probe.mli
+++ b/lib/keeper/keeper_capability_probe.mli
@@ -63,3 +63,72 @@ val probe_surface : tool:string -> verdict
     Used to report what {e was} available when a probe asks for a name that is
     not, so the caller does not have to guess at a typo. *)
 val model_facing_names : unit -> string list
+
+(** {1 Invocation}
+
+    [probe_surface] answers whether MASC offers the tool. It cannot answer
+    whether the model picks it up, and the two diverge — see the header. This
+    is the other half, for the Agent Core (HTTP) lane. *)
+
+(** What one probe turn observed.
+
+    [Replied_no_tool] and [Provider_rejected] are kept apart because the audit
+    that motivated this module could not tell them apart: a turn that never
+    reached the provider and a turn the model answered in prose both showed up
+    as a zero. *)
+type invocation =
+  | Tool_invoked of
+      { tool : string
+      ; elapsed_s : float
+      }
+      (** The response carried a [ToolUse] block for the requested tool. *)
+  | Other_tool_invoked of
+      { requested : string
+      ; invoked : string list
+      ; elapsed_s : float
+      }
+      (** Tools were called, but not the one asked for. Distinct from silence:
+          the surface reached the model and the model used it. *)
+  | Replied_no_tool of
+      { reply_bytes : int
+      ; elapsed_s : float
+      }
+      (** The provider answered and the model called nothing. *)
+  | Provider_rejected of { detail : string }
+      (** The request never produced a response — quota, auth, transport. *)
+
+val invocation_to_string : invocation -> string
+
+(** Why a probe could not be attempted at all. *)
+type invocation_error =
+  | Not_on_surface of verdict
+      (** [probe_surface] already answers this one; no turn is worth spending. *)
+  | Unresolvable_runtime of string
+  | Not_agent_core_lane of string
+      (** The official-client lanes own a durable session keyed by keeper name,
+          so probing them needs the session isolation this function does not
+          implement. Reported rather than approximated. *)
+  | Tool_schema_rejected of string
+
+val invocation_error_to_string : invocation_error -> string
+
+(** Send one synthetic turn to [runtime_id] and report whether [tool] was
+    called.
+
+    Writes nothing. There is no keeper name, no session, and no checkpoint in
+    this path: the Agent Core lane is stateless per request, so isolation here
+    is the absence of a session rather than a separate one.
+
+    The turn goes through {!Keeper_provider_subcall.complete}, the same
+    boundary the vision tool uses, so it inherits the resolved provider
+    deadline instead of installing its own. *)
+val probe_invocation
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> now:(unit -> float)
+  -> runtime_id:string
+  -> tool:string
+  -> prompt:string
+  -> unit
+  -> (invocation, invocation_error) result

--- a/lib/keeper/keeper_provider_subcall.ml
+++ b/lib/keeper/keeper_provider_subcall.ml
@@ -4,12 +4,13 @@ type complete_fn =
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   config:Llm_provider.Provider_config.t ->
   messages:Agent_core.Types.message list ->
+  ?tools:Yojson.Safe.t list ->
   unit ->
   (Agent_core.Types.api_response, Llm_provider.Http_client.http_error) result
 
-let complete ?override ~sw ~net ?clock ~config ~messages () =
+let complete ?override ~sw ~net ?clock ~config ~messages ?tools () =
   match override with
-  | Some complete -> complete ~sw ~net ?clock ~config ~messages ()
+  | Some complete -> complete ~sw ~net ?clock ~config ~messages ?tools ()
   | None ->
     Llm_provider.Complete.complete
       ~sw
@@ -18,5 +19,6 @@ let complete ?override ~sw ~net ?clock ~config ~messages () =
       ?body_timeout_s:(Keeper_runtime_resolved.body_timeout_override_sec ())
       ~config
       ~messages
+      ?tools
       ()
 ;;

--- a/lib/keeper/keeper_provider_subcall.mli
+++ b/lib/keeper/keeper_provider_subcall.mli
@@ -11,6 +11,7 @@ type complete_fn =
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   config:Llm_provider.Provider_config.t ->
   messages:Agent_core.Types.message list ->
+  ?tools:Yojson.Safe.t list ->
   unit ->
   (Agent_core.Types.api_response, Llm_provider.Http_client.http_error) result
 
@@ -21,8 +22,15 @@ val complete
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> config:Llm_provider.Provider_config.t
   -> messages:Agent_core.Types.message list
+  -> ?tools:Yojson.Safe.t list
   -> unit
   -> (Agent_core.Types.api_response, Llm_provider.Http_client.http_error) result
-(** Production calls apply only
+(** [tools] is forwarded to the provider unchanged. It exists so a caller
+    that needs to observe whether the model {e chooses} a tool can do so
+    through this boundary instead of reaching past it into
+    {!Llm_provider.Complete}: the boundary owns the resolved deadline, and a
+    caller that bypassed it to gain a parameter would silently lose that.
+
+    Production calls apply only
     {!Keeper_runtime_resolved.body_timeout_override_sec} at the AGENT_CORE Provider
     boundary. No feature-local wall-clock timeout is installed. *)

--- a/test/test_keeper_capability_probe.ml
+++ b/test/test_keeper_capability_probe.ml
@@ -125,6 +125,119 @@ let test_no_descriptor_is_withheld_by_a_schema_error () =
   check (list string) "no descriptor has schema errors" [] withheld
 ;;
 
+
+(* probe_invocation, offline. Every case below returns before any provider
+   call, which is the point: the errors that can be decided without spending a
+   turn must be decided without spending one. *)
+
+let dummy_now () = 0.0
+
+let invocation_error =
+  testable (Fmt.of_to_string Probe.invocation_error_to_string) ( = )
+
+let probe_offline ~runtime_id ~tool =
+  (* sw/net are never forced on these paths. Eio.Switch.run gives a real
+     switch; the net resource is only reached after the lane and surface
+     checks pass, and no case here passes both. *)
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Probe.probe_invocation
+        ~sw
+        ~net:(Eio.Stdenv.net env)
+        ~now:dummy_now
+        ~runtime_id
+        ~tool
+        ~prompt:"probe"
+        ()))
+;;
+
+let test_operator_only_costs_no_turn () =
+  match probe_offline ~runtime_id:"ollama_cloud.deepseek-v4-flash" ~tool:"masc_status" with
+  | Error (Probe.Not_on_surface Probe.Operator_only) -> ()
+  | Ok inv -> failf "expected a surface refusal, got: %s" (Probe.invocation_to_string inv)
+  | Error e -> failf "expected Not_on_surface Operator_only, got: %s" (Probe.invocation_error_to_string e)
+;;
+
+let test_unknown_runtime_is_named () =
+  match probe_offline ~runtime_id:"not.a.runtime" ~tool:"masc_board_list" with
+  | Error (Probe.Unresolvable_runtime _) -> ()
+  | Ok inv -> failf "expected an unresolvable runtime, got: %s" (Probe.invocation_to_string inv)
+  | Error e -> failf "expected Unresolvable_runtime, got: %s" (Probe.invocation_error_to_string e)
+;;
+
+(* The lane guard needs a producer, not just a constructor: without it an
+   official-client runtime would be probed over HTTP and the answer would
+   describe a path that runtime never takes.
+
+   The default unit-test environment pins MASC_BASE_PATH="" and resolves no
+   official-client runtime at all, so iterating the ambient fleet asserts
+   nothing -- an earlier draft of this test did exactly that and a mutation
+   removing the whole guard still passed. The fixture below loads a runtime
+   whose execution is an official-client lane, which is what makes the guard
+   reachable. *)
+let official_client_runtime_toml ~cli_path ~oauth_source =
+  Printf.sprintf
+    {|[providers.antigravity]
+protocol = "antigravity-cli"
+command = %S
+is-non-interactive = true
+timeout-s = 30.0
+
+[providers.antigravity.credentials]
+type = "file"
+path = %S
+
+[models.gemini]
+api-name = "gemini-fixture"
+max-context = 128000
+
+[antigravity.gemini]
+
+[runtime]
+default = "antigravity.gemini"
+|}
+    cli_path
+    oauth_source
+;;
+
+let write_file path contents =
+  let oc = open_out path in
+  output_string oc contents;
+  close_out oc
+;;
+
+let test_lane_guard_refuses_an_official_client_runtime () =
+  let base = Filename.temp_file "probe-lane" ".d" in
+  Sys.remove base;
+  Unix.mkdir base 0o700;
+  let cli_path = Filename.concat base "fake-cli" in
+  write_file cli_path "#!/bin/sh\nexit 0\n";
+  Unix.chmod cli_path 0o700;
+  let oauth_source = Filename.concat base "oauth-token" in
+  write_file oauth_source "operator-oauth-fixture";
+  Unix.chmod oauth_source 0o600;
+  let runtime_path = Filename.concat base "runtime.toml" in
+  write_file runtime_path (official_client_runtime_toml ~cli_path ~oauth_source);
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+      (match Runtime.init_default ~config_path:runtime_path with
+       | Ok () -> ()
+       | Error e -> failf "fixture config rejected: %s" e);
+      (* Control: the fixture must actually produce an official-client lane,
+         or this test is back to asserting nothing. *)
+      (match Runtime.get_runtime_by_id "antigravity.gemini" with
+       | Some { execution = Runtime_execution.Antigravity_cli _; _ } -> ()
+       | Some rt ->
+         failf "fixture resolved the wrong lane: %s" (Runtime_execution.label rt.Runtime.execution)
+       | None -> fail "fixture runtime did not resolve");
+      match probe_offline ~runtime_id:"antigravity.gemini" ~tool:"masc_board_list" with
+      | Error (Probe.Not_agent_core_lane _) -> ()
+      | Ok inv -> failf "an official-client runtime was probed over HTTP: %s" (Probe.invocation_to_string inv)
+      | Error e -> failf "expected Not_agent_core_lane, got: %s" (Probe.invocation_error_to_string e))
+;;
+
 let () =
   run
     "keeper_capability_probe"
@@ -139,6 +252,11 @@ let () =
     ; ( "agreement with the surface"
       , [ test_case "round-trips every published name" `Quick test_agrees_with_the_surface_it_reports_on
         ; test_case "no schema-withheld descriptor" `Quick test_no_descriptor_is_withheld_by_a_schema_error
+        ] )
+    ; ( "probe_invocation (offline)"
+      , [ test_case "operator-only costs no turn" `Quick test_operator_only_costs_no_turn
+        ; test_case "unknown runtime is named" `Quick test_unknown_runtime_is_named
+        ; test_case "lane guard refuses an official-client runtime" `Quick test_lane_guard_refuses_an_official_client_runtime
         ] )
     ]
 ;;


### PR DESCRIPTION
RFC-0374 (#28422) 의 나머지 절반. `probe_surface` (#28432) 는 MASC 가 도구를 **투영하는지**를 답한다. 모델이 그걸 **집는지**는 못 답하고, antigravity 가 정확히 그 둘이 갈라지는 자리다. 이 PR 은 실제 호출을 관측하는 쪽을 Agent Core (HTTP) 레인에 대해 낸다.

## 왜 이 레인부터인가

08-12 감사가 측정하지 못한 dispatchable 런타임 4개가 전부 이 레인이다 — `kimi_coding` 3 + `local_llama_server` 1. 그리고 이 레인은 세션 디렉터리가 없어서 격리가 **별도 세션이 아니라 세션의 부재**로 성립한다.

## 경계를 우회하지 않고 넓혔다

`probe_invocation` 은 도구 스펙을 실어 보내야 하는데, `Keeper_provider_subcall.complete` 는 `~tools` 를 노출하지 않았다 (하위 `Llm_provider.Complete.complete` 는 받는다).

그 모듈은 스스로를 *"Single MASC boundary for non-streaming Keeper provider sub-calls"* 로 문서화하고 있고 resolved deadline 을 소유한다. 파라미터 하나 얻자고 경계를 우회하면 그 deadline 을 조용히 잃는다. 그래서 **경계를 optional `?tools` 로 한 칸 넓혔다.** 기존 호출자(`keeper_vision_tool`)는 문자 그대로 무변경이다.

## 레인 판별은 provider config 로 하면 안 된다

official-client 런타임도 provider config 를 resolve 한다. 그래서 config 가 나온다는 건 이 경로가 그 런타임이 실제로 타는 경로라는 증거가 아니다. `Runtime.get_runtime_by_id` 로 `execution` 을 보고 official-client 3종은 typed `Not_agent_core_lane` 으로 거부한다 — 근사하지 않는다.

## 테스트를 두 번 강제로 진짜로 만들었다

**1. 레인 가드 테스트가 처음엔 아무것도 검증하지 않았다.** ambient fleet 을 순회했는데 `MASC_BASE_PATH=""` 환경에서 official-client 런타임이 0개라 빈 리스트를 돌았다. **가드를 통째로 지운 변이가 11/11 통과했다.** 지금은 official-client 레인을 가진 `runtime.toml` 픽스처를 로드하고, 같은 변이가 실패한다:

```
mutant exit 1
[FAIL] lane guard refuses an official-client runtime
FAIL expected Not_agent_core_lane, got: runtime "antigravity.gemini" is owned by antigravity-cli, not the Agent Core
```

(부수 확인: 가드가 없어도 하위 계층이 거부한다. 이중 방어이고, 제 가드의 역할은 그 거부를 호출자가 구조적으로 읽을 수 있는 typed error 로 승격시키는 것이다.)

**2. content_block / http_error 매치에 wildcard 를 쓰지 않았다.** 전 variant 나열이 `Audio` 누락을 컴파일 타임에 잡았다. `_ ->` 였으면 조용히 통과하고 새 블록 타입은 영원히 안 보였을 것이다. http_error 도 같은 이유 — wildcard 는 새 transport 실패를 쿼터 거부와 같은 문자열로 접는다.

## 검증

```
dune build --root . lib/                                    FINAL_EXIT=0
./_build/default/test/test_keeper_capability_probe.exe      11 tests run, 0 failures
dune build --root . @test/runtest-test_keeper_capability_probe   11 tests run
bash scripts/audit-ci-test-targets.sh   OK - 196 CI targets / 662 unwired, at baseline
dune build --root . @fmt                내 파일 diff 없음
```

CI 배선(`@test/runtest-`)은 #28435 에서 이미 들어갔고 이 PR 이 케이스를 늘려도 alias 가 11개를 다 돈다는 걸 확인했다 — 로컬 실행만 보고 "확인했다"고 썼다가 main 을 깬 게 #28432 다.

## 미검증

- **실제 provider 왕복은 한 번도 안 돌렸다.** 테스트는 전부 provider 호출 이전에 반환되는 오프라인 경로다. 살아있는 런타임에 대고 도는 경로는 이 PR 에서 실행되지 않았다.
- `Tool_invoked` / `Other_tool_invoked` / `Replied_no_tool` 분기는 응답 파싱 로직만 있고 실제 응답으로 밟아보지 못했다.
- official-client 3종의 프로브(세션 격리 포함)는 범위 밖. RFC 의 probe identity 절이 그쪽이다.
- RFC 의 핵심 검증 "프로브 N회 후 세 스토어 바이트 동일"은 아직 없다. 지금은 쓰기 경로 자체가 없어 자명하게 참이라 테스트로서 의미가 없고, official-client 레인이 들어올 때 붙어야 한다.

RFC-WAIVED: RFC-0374 (#28422) 가 설계 문서다.

Refs masc#28414

🤖 Generated with [Claude Code](https://claude.com/claude-code)