### PR TITLE
fix(dashboard): report a keeper's latest claim, from one shared window

### DIFF
--- a/lib/server/server_dashboard_http_composite.mli
+++ b/lib/server/server_dashboard_http_composite.mli
@@ -16,7 +16,18 @@ val composite_claim_scope_absent :
        (string *
         [> `Bool of bool | `List of 'a list | `Null | `String of string ])
        list ]
+val claim_rows_per_keeper : int
+val claim_window_rows : int
+
+type claim_window = Server_dashboard_http_composite_claims.claim_window
+
+val read_claim_window : unit -> claim_window
+
+val latest_task_claim_row :
+  claim_window -> keeper_name:string -> Yojson.Safe.t option
+
 val composite_claim_scope_json :
+  claim_window:claim_window ->
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val find_override_field_source :
   string -> Yojson.Safe.t -> Yojson.Safe.t option
@@ -25,6 +36,7 @@ val composite_config_drift_json :
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val composite_execution_receipt_json :
   config:Workspace.config ->
+  claim_window:claim_window ->
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val lower_string_opt : string option -> string option
 val string_opt_is_any : string option -> string list -> bool
@@ -85,6 +97,7 @@ val composite_recommended_actions_json :
   attention:composite_runtime_attention -> [> `List of Yojson.Safe.t list ]
 val enrich_composite_snapshot_json :
   config:Workspace.config ->
+  claim_window:claim_window ->
   Keeper_registry.registry_entry -> Yojson.Safe.t -> Yojson.Safe.t
 val dashboard_keeper_composite_json :
   config:Workspace.config ->

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -65,14 +65,80 @@ let composite_claim_scope_absent =
     ]
 ;;
 
-let composite_claim_scope_json ~keeper_name =
-  let entries = Keeper_tool_call_log.read_recent ~keeper_name ~n:100 () in
-  match
-    entries
-    |> List.find_opt (fun json ->
-      String.equal (Option.value ~default:"" (json_string "tool" json))
-        "keeper_task_claim")
-  with
+(* Rows one keeper's claim lookup considers, and the fleet-wide window that
+   covers it. [read_recent ~keeper_name ~n] over-scans by
+   [read_over_scan_factor] before its keeper filter, so a shared read of
+   [claim_window_rows] covers exactly what a per-keeper [read_recent ~n:100]
+   would have read. *)
+let claim_rows_per_keeper = 100
+
+let claim_window_rows =
+  claim_rows_per_keeper * Keeper_tool_call_log.read_over_scan_factor
+;;
+
+(* One fleet-wide tail of tool-call rows, read once and shared by every keeper
+   in the same composite envelope.
+
+   [composite_claim_scope_json] used to read its own window per keeper. Every
+   such read pulls [claim_window_rows] rows from the single shared tool-call
+   store, so the fleet envelope — which calls this once per keeper — read and
+   parsed the same rows once per keeper: identical bytes, identical parse
+   trees, N times, to answer N questions one read answers for all of them. On
+   the store this was measured against, rows average 6.8 KB.
+
+   Constructed only by [read_claim_window] so a caller cannot pass a list that
+   was filtered, reordered, or read with a different window. *)
+type claim_window = Claim_window of Yojson.Safe.t list
+
+let read_claim_window () =
+  Claim_window (Keeper_tool_call_log.read_recent_rows ~n:claim_window_rows ())
+;;
+
+let row_is_task_claim json =
+  (* The tool name is a string on the wire; [Keeper_tooling.Name] is the typed
+     vocabulary that owns it, so the comparison goes through the variant rather
+     than a literal. A renamed or removed constructor then fails to compile
+     instead of silently matching nothing. *)
+  match Option.bind (json_string "tool" json) Keeper_tooling.Name.of_string with
+  | Some Keeper_tooling.Name.Task_claim -> true
+  | Some
+      ( Keeper_tooling.Name.Broadcast
+      | Keeper_tooling.Name.Task_create
+      | Keeper_tooling.Name.Task_done
+      | Keeper_tooling.Name.Tasks_audit
+      | Keeper_tooling.Name.Tasks_list )
+  | None -> false
+;;
+
+(* The latest claim, not the first one a scan meets.
+
+   [Keeper_tool_call_log.read_recent] and [read_recent_rows] both return rows
+   oldest-first (dated_jsonl.mli: "the newest [n] entries in chronological
+   order (oldest first)"), so the [List.find_opt] this replaces returned the
+   *oldest* claim in the window. It went unnoticed because
+   [filter_rows_for_keeper] rings a busy keeper down to its last
+   [claim_rows_per_keeper] rows, which usually trims the older claim away and
+   leaves the newer one to be found by accident; a quiet keeper keeps both and
+   reports the superseded task. Measured live: keeper [analyst] (46 rows in
+   window, nothing trimmed) reported task-305 while it had claimed task-306.
+   See #28437.
+
+   Ordering is row order, which is what the store documents and what the
+   previous code relied on. The row's own [ts] is deliberately not consulted:
+   that would make append order and timestamp order two competing authorities
+   for "latest". *)
+let latest_task_claim_row (Claim_window rows) ~keeper_name =
+  Keeper_tool_call_log.filter_rows_for_keeper
+    ~keeper_name
+    ~n:claim_rows_per_keeper
+    rows
+  |> List.fold_left
+       (fun latest json -> if row_is_task_claim json then Some json else latest)
+       None
+;;
+
+let composite_claim_scope_json ~claim_window ~keeper_name =
+  match latest_task_claim_row claim_window ~keeper_name with
   | None -> composite_claim_scope_absent
   | Some call ->
     let output =
@@ -170,8 +236,8 @@ let composite_config_drift_json ~config ~keeper_name =
       ]
 ;;
 
-let composite_execution_receipt_json ~(config : Workspace.config) ~keeper_name =
-  let claim_scope = composite_claim_scope_json ~keeper_name in
+let composite_execution_receipt_json ~(config : Workspace.config) ~claim_window ~keeper_name =
+  let claim_scope = composite_claim_scope_json ~claim_window ~keeper_name in
   let config_drift = composite_config_drift_json ~config ~keeper_name in
   match Keeper_execution_receipt.latest_json config keeper_name with
   | None ->

--- a/lib/server/server_dashboard_http_composite_claims.mli
+++ b/lib/server/server_dashboard_http_composite_claims.mli
@@ -16,7 +16,29 @@ val composite_claim_scope_absent :
        (string *
         [> `Bool of bool | `List of 'a list | `Null | `String of string ])
        list ]
+val claim_rows_per_keeper : int
+(** Rows of one keeper's tool-call history a claim lookup considers. *)
+
+val claim_window_rows : int
+(** Fleet-wide rows {!read_claim_window} reads:
+    [claim_rows_per_keeper * Keeper_tool_call_log.read_over_scan_factor], which
+    is the coverage a per-keeper [read_recent ~n:claim_rows_per_keeper] had. *)
+
+type claim_window
+(** One fleet-wide tail of tool-call rows, read once and shared by every keeper
+    in the same composite envelope instead of re-read per keeper. Abstract so a
+    caller cannot substitute a list read with a different window. *)
+
+val read_claim_window : unit -> claim_window
+(** Read the shared window. One store read per envelope, not one per keeper. *)
+
+val latest_task_claim_row :
+  claim_window -> keeper_name:string -> Yojson.Safe.t option
+(** The keeper's most recent [Keeper_tooling.Name.Task_claim] row within the
+    window, by row order, or [None] if it did not claim inside it. *)
+
 val composite_claim_scope_json :
+  claim_window:claim_window ->
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val find_override_field_source :
   string -> Yojson.Safe.t -> Yojson.Safe.t option
@@ -25,6 +47,7 @@ val composite_config_drift_json :
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val composite_execution_receipt_json :
   config:Workspace.config ->
+  claim_window:claim_window ->
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val lower_string_opt : string option -> string option
 val string_opt_is_any : string option -> string list -> bool

--- a/lib/server/server_dashboard_http_composite_enrich.ml
+++ b/lib/server/server_dashboard_http_composite_enrich.ml
@@ -3,6 +3,7 @@ include Server_dashboard_http_composite_recommendations
 
 let enrich_composite_snapshot_json
       ~(config : Workspace.config)
+      ~claim_window
       (entry : Keeper_registry.registry_entry)
       json
   =
@@ -20,7 +21,9 @@ let enrich_composite_snapshot_json
               || String.equal name "recommended_actions"))
         fields
     in
-    let execution = composite_execution_receipt_json ~config ~keeper_name in
+    let execution =
+      composite_execution_receipt_json ~config ~claim_window ~keeper_name
+    in
     let attention = composite_runtime_attention ~snapshot:json ~execution in
     let recommended_actions =
       composite_recommended_actions_json ~keeper_name ~snapshot:json ~execution ~attention
@@ -43,14 +46,28 @@ let enrich_composite_snapshot_json
   | other -> other
 ;;
 
-let dashboard_keeper_composite_json
+(* The projection itself. Both routes below run exactly this; they differ only
+   in who owns the tool-call window it reads from. *)
+let composite_snapshot_json
       ~(config : Workspace.config)
+      ~claim_window
       (entry : Keeper_registry.registry_entry)
   : Yojson.Safe.t
   =
   Keeper_composite_observer.observe entry
   |> Keeper_composite_observer.snapshot_to_json
-  |> enrich_composite_snapshot_json ~config entry
+  |> enrich_composite_snapshot_json ~config ~claim_window entry
+;;
+
+let dashboard_keeper_composite_json
+      ~(config : Workspace.config)
+      (entry : Keeper_registry.registry_entry)
+  : Yojson.Safe.t
+  =
+  (* Single-keeper route: one window read, the same one the per-keeper
+     [read_recent] performed before. Cost here is unchanged; the saving is in
+     the fleet envelope below, which shares one window across every keeper. *)
+  composite_snapshot_json ~config ~claim_window:(read_claim_window ()) entry
 ;;
 
 let dashboard_fleet_composite_json ~(config : Workspace.config) () : Yojson.Safe.t =
@@ -74,7 +91,14 @@ let dashboard_fleet_composite_json ~(config : Workspace.config) () : Yojson.Safe
     (fun () ->
       Domain_pool_ref.submit_io_or_inline (fun () ->
         let entries = Keeper_registry.all ~base_path:config.base_path () in
-        let snapshots = List.map (dashboard_keeper_composite_json ~config) entries in
+        (* One tool-call window for the whole envelope. Every keeper's claim
+           lookup used to read this same fleet-wide tail for itself, so the
+           store was read and parsed once per keeper to produce N answers that
+           one read produces. *)
+        let claim_window = read_claim_window () in
+        let snapshots =
+          List.map (composite_snapshot_json ~config ~claim_window) entries
+        in
         `Assoc
           (* generated_at is a unix-second number (not ISO8601 string) to match the
              sibling timestamps in this same envelope (snapshots[].started_at /

--- a/lib/server/server_dashboard_http_composite_enrich.mli
+++ b/lib/server/server_dashboard_http_composite_enrich.mli
@@ -16,7 +16,18 @@ val composite_claim_scope_absent :
        (string *
         [> `Bool of bool | `List of 'a list | `Null | `String of string ])
        list ]
+val claim_rows_per_keeper : int
+val claim_window_rows : int
+
+type claim_window = Server_dashboard_http_composite_claims.claim_window
+
+val read_claim_window : unit -> claim_window
+
+val latest_task_claim_row :
+  claim_window -> keeper_name:string -> Yojson.Safe.t option
+
 val composite_claim_scope_json :
+  claim_window:claim_window ->
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val find_override_field_source :
   string -> Yojson.Safe.t -> Yojson.Safe.t option
@@ -25,6 +36,7 @@ val composite_config_drift_json :
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val composite_execution_receipt_json :
   config:Workspace.config ->
+  claim_window:claim_window ->
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val lower_string_opt : string option -> string option
 val string_opt_is_any : string option -> string list -> bool
@@ -85,6 +97,7 @@ val composite_recommended_actions_json :
   attention:composite_runtime_attention -> [> `List of Yojson.Safe.t list ]
 val enrich_composite_snapshot_json :
   config:Workspace.config ->
+  claim_window:claim_window ->
   Keeper_registry.registry_entry -> Yojson.Safe.t -> Yojson.Safe.t
 val dashboard_keeper_composite_json :
   config:Workspace.config ->

--- a/lib/server/server_dashboard_http_composite_recommendations.mli
+++ b/lib/server/server_dashboard_http_composite_recommendations.mli
@@ -16,7 +16,18 @@ val composite_claim_scope_absent :
        (string *
         [> `Bool of bool | `List of 'a list | `Null | `String of string ])
        list ]
+val claim_rows_per_keeper : int
+val claim_window_rows : int
+
+type claim_window = Server_dashboard_http_composite_claims.claim_window
+
+val read_claim_window : unit -> claim_window
+
+val latest_task_claim_row :
+  claim_window -> keeper_name:string -> Yojson.Safe.t option
+
 val composite_claim_scope_json :
+  claim_window:claim_window ->
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val find_override_field_source :
   string -> Yojson.Safe.t -> Yojson.Safe.t option
@@ -25,6 +36,7 @@ val composite_config_drift_json :
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val composite_execution_receipt_json :
   config:Workspace.config ->
+  claim_window:claim_window ->
   keeper_name:string -> [> `Assoc of (string * Yojson.Safe.t) list ]
 val lower_string_opt : string option -> string option
 val string_opt_is_any : string option -> string list -> bool

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -41,6 +41,7 @@ normal_targets=(
   @test/runtest-test_keeper_autoboot_single_owner
   @test/runtest-test_keeper_meta_current_schema
   @test/runtest-dashboard-http-behavior-contracts
+  @test/runtest-test_dashboard_composite_claim_window
   @test/runtest-test_model_inference_metrics
   @test/runtest-test_channel_gate_content_length_knob
   @test/runtest-test_keeper_decision_audit_dated_store

--- a/test/dune
+++ b/test/dune
@@ -945,6 +945,7 @@
   test_dashboard_briefing_sections
   test_dashboard_cache
   test_dashboard_http_core
+  test_dashboard_composite_claim_window
   test_eval_feed
   test_dashboard_verification
   test_tool_quality_classify
@@ -1085,6 +1086,7 @@
   test_dashboard_briefing_sections
   test_dashboard_cache
   test_dashboard_http_core
+  test_dashboard_composite_claim_window
   test_eval_feed
   test_dashboard_verification
   test_tool_quality_classify

--- a/test/test_dashboard_composite_claim_window.ml
+++ b/test/test_dashboard_composite_claim_window.ml
@@ -1,0 +1,212 @@
+(** The shared tool-call window behind a keeper's [claim_scope] (#28437).
+
+    Two properties are under test, and they are the same change:
+
+    - the claim reported is the keeper's {b latest} one, not the first row a
+      scan happens to meet in an oldest-first window;
+    - one window read serves every keeper in a fleet envelope, rather than
+      each keeper re-reading the same shared store.
+
+    The store is real: rows go in through [Keeper_tool_call_log.log_call] and
+    come back through [read_claim_window], so the test exercises
+    [Dated_jsonl]'s ordering rather than a hand-built list that would keep
+    passing if that ordering changed. *)
+
+open Masc
+
+let counter = ref 0
+
+let with_tmp_log f =
+  incr counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "test-composite-claim-window-%d-%d"
+         (Unix.getpid ())
+         !counter)
+  in
+  Fs_compat.mkdir_p dir;
+  Keeper_tool_call_log.reset_for_testing ();
+  Keeper_tool_call_log.init ~base_path:dir ();
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_tool_call_log.reset_for_testing ();
+      Fs_compat.remove_tree dir)
+    (fun () -> f ())
+;;
+
+let eio_test name fn =
+  Alcotest.test_case name `Quick (fun () ->
+    Eio_main.run
+    @@ fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    with_tmp_log fn)
+;;
+
+(* The payload shape [composite_claim_scope_json] decodes: the tool call's
+   output text is itself a JSON document carrying the claimed task. *)
+let claim_output ~task_id ~goal_id =
+  `Assoc
+    [ "result", `String (Printf.sprintf "claimed %s" task_id)
+    ; "claim_scope", `Assoc [ "mode", `String "all_tasks"; "scoped", `Bool false ]
+    ; "claimed_task", `Assoc [ "task_id", `String task_id; "goal_id", `String goal_id ]
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let log_claim ~keeper ~task_id ~goal_id =
+  Keeper_tool_call_log.log_call
+    ~keeper_name:keeper
+    ~tool_name:(Keeper_tooling.Name.to_string Keeper_tooling.Name.Task_claim)
+    ~input:(`Assoc [])
+    ~output_text:(claim_output ~task_id ~goal_id)
+    ~success:true
+    ~duration_ms:1.0
+    ()
+;;
+
+let log_noise ~keeper ~n =
+  for index = 1 to n do
+    Keeper_tool_call_log.log_call
+      ~keeper_name:keeper
+      ~tool_name:(Keeper_tooling.Name.to_string Keeper_tooling.Name.Tasks_list)
+      ~input:(`Assoc [])
+      ~output_text:(Printf.sprintf {|{"row":%d}|} index)
+      ~success:true
+      ~duration_ms:1.0
+      ()
+  done
+;;
+
+let claimed_task_id ~claim_window ~keeper =
+  match
+    Server_dashboard_http_composite_claims.composite_claim_scope_json
+      ~claim_window
+      ~keeper_name:keeper
+  with
+  | `Assoc fields ->
+    (match List.assoc_opt "claimed_task_id" fields with
+     | Some (`String id) -> Some id
+     | Some `Null | Some _ | None -> None)
+  | _ -> None
+;;
+
+let claim_present ~claim_window ~keeper =
+  match
+    Server_dashboard_http_composite_claims.composite_claim_scope_json
+      ~claim_window
+      ~keeper_name:keeper
+  with
+  | `Assoc fields ->
+    (match List.assoc_opt "present" fields with
+     | Some (`Bool present) -> present
+     | _ -> false)
+  | _ -> false
+;;
+
+(* The defect this file exists for.
+
+   Rows come back oldest-first, so taking the first matching row reported
+   task-a — the claim the keeper had already superseded. Measured live before
+   the fix: keeper [analyst] reported task-305 while it had claimed task-306. *)
+let test_reports_the_latest_claim () =
+  log_claim ~keeper:"analyst" ~task_id:"task-a" ~goal_id:"goal-a";
+  log_claim ~keeper:"analyst" ~task_id:"task-b" ~goal_id:"goal-b";
+  let claim_window = Server_dashboard_http_composite_claims.read_claim_window () in
+  Alcotest.(check (option string))
+    "the superseding claim is the one reported"
+    (Some "task-b")
+    (claimed_task_id ~claim_window ~keeper:"analyst")
+;;
+
+(* Why the defect stayed invisible on a busy keeper.
+
+   [filter_rows_for_keeper] keeps only that keeper's last
+   [claim_rows_per_keeper] rows, so enough traffic between two claims trims the
+   older one away and the first-match scan lands on the newer one by accident.
+   Correctness was inversely proportional to keeper traffic; watching a chatty
+   keeper, the bug never appeared. This case must keep passing either way — it
+   documents the mechanism, it does not detect it. *)
+let test_ring_trim_hides_the_older_claim () =
+  let rows_per_keeper =
+    Server_dashboard_http_composite_claims.claim_rows_per_keeper
+  in
+  log_claim ~keeper:"rondo" ~task_id:"task-old" ~goal_id:"goal-old";
+  log_noise ~keeper:"rondo" ~n:rows_per_keeper;
+  log_claim ~keeper:"rondo" ~task_id:"task-new" ~goal_id:"goal-new";
+  let claim_window = Server_dashboard_http_composite_claims.read_claim_window () in
+  Alcotest.(check (option string))
+    "a trimmed older claim cannot be reported"
+    (Some "task-new")
+    (claimed_task_id ~claim_window ~keeper:"rondo")
+;;
+
+(* The N+1 property: the window is fleet-wide, so one read answers for every
+   keeper. If it were keeper-specific, at most one of these could be right. *)
+let test_one_window_serves_every_keeper () =
+  log_claim ~keeper:"alice" ~task_id:"task-1" ~goal_id:"goal-1";
+  log_claim ~keeper:"bob" ~task_id:"task-2" ~goal_id:"goal-2";
+  log_claim ~keeper:"carol" ~task_id:"task-3" ~goal_id:"goal-3";
+  log_claim ~keeper:"alice" ~task_id:"task-4" ~goal_id:"goal-4";
+  let claim_window = Server_dashboard_http_composite_claims.read_claim_window () in
+  Alcotest.(check (option string))
+    "alice reads her own latest"
+    (Some "task-4")
+    (claimed_task_id ~claim_window ~keeper:"alice");
+  Alcotest.(check (option string))
+    "bob reads his own"
+    (Some "task-2")
+    (claimed_task_id ~claim_window ~keeper:"bob");
+  Alcotest.(check (option string))
+    "carol reads her own"
+    (Some "task-3")
+    (claimed_task_id ~claim_window ~keeper:"carol")
+;;
+
+let test_absent_without_a_claim () =
+  log_noise ~keeper:"quiet" ~n:3;
+  log_claim ~keeper:"other" ~task_id:"task-x" ~goal_id:"goal-x";
+  let claim_window = Server_dashboard_http_composite_claims.read_claim_window () in
+  Alcotest.(check bool)
+    "a keeper that never claimed reports absent"
+    false
+    (claim_present ~claim_window ~keeper:"quiet");
+  Alcotest.(check bool)
+    "a keeper absent from the log entirely reports absent"
+    false
+    (claim_present ~claim_window ~keeper:"never-seen")
+;;
+
+(* The shared read must cover what the per-keeper read covered, or the batch
+   would silently narrow the window it replaced. *)
+let test_window_reproduces_per_keeper_coverage () =
+  Alcotest.(check int)
+    "window is the per-keeper read's over-scanned coverage"
+    (Server_dashboard_http_composite_claims.claim_rows_per_keeper
+     * Keeper_tool_call_log.read_over_scan_factor)
+    Server_dashboard_http_composite_claims.claim_window_rows
+;;
+
+let () =
+  Alcotest.run
+    "composite claim window"
+    [ ( "latest claim (#28437)"
+      , [ eio_test "reports the latest claim, not the first row scanned"
+            test_reports_the_latest_claim
+        ; eio_test
+            "ring trim hides the older claim on a busy keeper"
+            test_ring_trim_hides_the_older_claim
+        ] )
+    ; ( "shared window"
+      , [ eio_test
+            "one window serves every keeper"
+            test_one_window_serves_every_keeper
+        ; eio_test "absent without a claim" test_absent_without_a_claim
+        ; Alcotest.test_case
+            "reproduces the per-keeper read's coverage"
+            `Quick
+            test_window_reproduces_per_keeper_coverage
+        ] )
+    ]
+;;


### PR DESCRIPTION
Fixes #28437.

## The wrong answer

`/api/v1/keepers/<name>/composite` reported a keeper's `claim_scope` as a task
it had already superseded, with `present: true` and `status: "claimed"` — full
confidence, wrong task. Measured live against `main` before this change:

| keeper | reported | actually claimed |
|---|---|---|
| `analyst` | `task-305` | **`task-306`** |
| `rondo` | `task-301` | `task-301` |

`analyst` also carried `claimed_goal_id` from the superseded claim; the real one
has no goal.

Three pieces compose into it:

1. `Dated_jsonl.read_recent` returns rows **oldest-first**. Documented, not a
   bug — `dated_jsonl.mli:103`, "the newest [n] entries in chronological order
   (oldest first)".
2. `composite_claim_scope_json` took `List.find_opt`, which on an oldest-first
   list is the **oldest** claim in the window.
3. `filter_rows_for_keeper` rings a keeper down to its last 100 rows, so a
   chatty keeper's older claim is usually trimmed away and the first-match scan
   lands on the newer one **by accident**.

Step 3 is why nobody saw it: correctness was inversely proportional to keeper
traffic. Measured on the live store, matching both HTTP responses exactly:

```
analyst   rows_in_window=46    trimmed=0     claims_kept=2  -> task-305, latest is task-306   STALE
rondo     rows_in_window=215   trimmed=115   claims_kept=1  -> task-301, latest is task-301   ok
```

`claim_scope` also feeds `composite_recommended_actions_json` and
`composite_runtime_attention`, so a superseded claim could drive an operator
recommendation about finished work.

## The N+1 behind it

Each keeper's claim lookup called `read_recent ~keeper_name ~n:100`, which
over-scans `100 * read_over_scan_factor` = 500 rows from the **single shared**
tool-call store before filtering. The fleet envelope calls that once per
keeper — so N keepers read and parsed the identical 500-row tail N times to
answer N questions one read answers for all of them.

Now one `read_claim_window ()` per envelope. At the live fleet size of 8
keepers, 4,000 row parses become 500.

What that costs, measured on the real 503 MB store (2,270 KiB per window,
4.5 KiB per row; a model of the two strategies, not the OCaml reader, so treat
it as a size rather than a benchmark):

| | row parses | bytes | modelled |
|---|---|---|---|
| before | 4,000 | 17.7 MiB | ~721 ms |
| after | 500 | 2.2 MiB | ~90 ms |

For a consistency check rather than a claim: the live uncached fleet composite
measures 962 ms, so ~75% of it is accounted for by the reads this removes,
leaving ~240 ms for receipts, meta, secrets, and JSON assembly. Cached hits
were already 1.4–7 ms and are untouched.

## Design

The window is a type, not a list, constructible only by `read_claim_window`:

```ocaml
type claim_window = Claim_window of Yojson.Safe.t list
```

so a caller cannot hand the lookup a list that was filtered, reordered, or read
with a different window. `claim_window_rows` is derived as
`claim_rows_per_keeper * Keeper_tool_call_log.read_over_scan_factor` rather than
written as 500 — `read_over_scan_factor` was already named for exactly this
("callers sharing one fleet read size their window with this to reproduce a
per-keeper `read_recent`'s coverage"), and a test pins the equality.

The shared read is composed from the log module's own exported pieces —
`read_recent_rows` then `filter_rows_for_keeper` — which is precisely what
`read_recent ~keeper_name` does internally. Coverage equivalence is by
construction, not by reimplementation.

The tool name goes through `Keeper_tooling.Name.Task_claim` instead of the
string literal it used, so a renamed constructor fails to compile rather than
silently matching nothing.

Ordering is row order. The row's own `ts` is deliberately not consulted: that
would leave append order and timestamp order as two competing authorities for
"latest".

## Tests

New `test/test_dashboard_composite_claim_window.ml`, 5 cases, all green. Rows go
in through `Keeper_tool_call_log.log_call` and come back through
`read_claim_window`, so `Dated_jsonl`'s ordering is under test rather than a
hand-built list that would keep passing if that ordering changed.

Reverting `latest_task_claim_row` to the old `List.find_opt` and re-running:

```
[FAIL]  reports the latest claim, not the first row scanned
        Expected: `Some "task-b"'   Received: `Some "task-a"'
[FAIL]  one window serves every keeper
[OK]    ring trim hides the older claim on a busy keeper
[OK]    absent without a claim
[OK]    reproduces the per-keeper read's coverage
```

Two cases detect the defect; the ring-trim case is a labelled control that
documents why it hid and is expected to pass either way — it does.

Also green: `test_keeper_tool_call_log` (36), `test_dashboard_http_core`
behavior contracts (12).

## Not in scope

- The window is still a fixed 500 fleet rows, so a keeper whose last claim
  predates it reports `absent`. That is unchanged behaviour, deliberately: this
  change fixes which row is picked, not how far back the search reaches.
  `Dated_jsonl.find_latest_entry_result` (newest-first, early stop) is the right
  primitive for removing the bound, but it is unbounded and needs its own
  design pass for keepers that never claimed.
- `server_dashboard_http_keeper_api.ml:2563` documents this route as "No
  mutation, no I/O" while the enrich path does four disk reads per keeper. The
  comment is wrong; the remaining three reads are separate work.

RFC-WAIVED: dashboard read projection and a JSONL read path; no credential,
identity, operator control-plane, sandbox, hook, or workflow surface is touched.
