### PR TITLE
fix(test): vision-tool complete 스텁에 ?tools 라벨 추가 (main 빌드 복구)

### DIFF
--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -143,6 +143,7 @@ let complete_should_not_run
     ?clock:_
     ~config:_
     ~messages:_
+    ?tools:_
     () =
   failwith "vision provider complete should not run"
 
@@ -578,7 +579,7 @@ let test_provider_for_vision_uses_runtime_temperature () =
 let test_uncapped_vision_fallback_rejects_before_provider_call () =
   with_temp_runtime_toml uncapped_vision_fallback_runtime_toml (fun () ->
     let provider_calls = ref 0 in
-    let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+    let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ ?tools:_ () =
       incr provider_calls;
       Ok (ok_response "provider call must not happen")
     in
@@ -642,7 +643,7 @@ let test_invalid_structured_vision_response_is_runtime_failure () =
     with_temp_base (fun _ ->
       let meta = make_meta "vision-invalid-structured-response" in
       let handle = store_image meta "\x89PNG\r\n\x1a\nraw" in
-      let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+      let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ ?tools:_ () =
         Ok (text_response "not-json")
       in
       let raw =
@@ -667,7 +668,7 @@ let test_invalid_structured_vision_response_is_runtime_failure () =
 
 let test_run_vision_invalid_structured_response_is_typed () =
   with_temp_runtime_toml single_vision_runtime_toml (fun () ->
-    let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+    let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ ?tools:_ () =
       Ok (text_response "not-json")
     in
     let outcome =
@@ -714,7 +715,7 @@ let test_retryable_provider_error_tries_next_runtime () =
       in
       let calls = ref 0 in
       let models = ref [] in
-      let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ () =
+      let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ ?tools:_ () =
         incr calls;
         models := config.Llm_provider.Provider_config.model_id :: !models;
         if !calls = 1 then
@@ -756,7 +757,7 @@ let test_candidate_failover_is_not_cut_off_by_local_deadline () =
       let handle = store_image meta "\x89PNG\r\n\x1a\nraw" in
       let calls = ref 0 in
       let models = ref [] in
-      let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ () =
+      let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ ?tools:_ () =
         incr calls;
         models := config.Llm_provider.Provider_config.model_id :: !models;
         Error
@@ -788,7 +789,7 @@ let test_non_retryable_provider_error_stops_without_trying_next_runtime () =
       let handle = store_image meta "\x89PNG\r\n\x1a\nraw" in
       let calls = ref 0 in
       let models = ref [] in
-      let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ () =
+      let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ ?tools:_ () =
         incr calls;
         models := config.Llm_provider.Provider_config.model_id :: !models;
         Error
@@ -820,7 +821,7 @@ let test_accept_rejected_is_policy_rejection_without_failover () =
       let handle = store_image meta "\x89PNG\r\n\x1a\nraw" in
       let calls = ref 0 in
       let models = ref [] in
-      let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ () =
+      let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ ?tools:_ () =
         incr calls;
         models := config.Llm_provider.Provider_config.model_id :: !models;
         Error


### PR DESCRIPTION
`dune build` 가 main 에서 깨져 있습니다.

```
File "test/test_keeper_vision_tool.ml", line 326:
Error: The value complete_should_not_run has type
         ... ~messages:Llm_provider.Types.message list -> unit -> 'a
       but an expression was expected of type
         Vt.complete_fn =
           ... ~messages:... -> ?tools:Yojson.Safe.t list -> unit ->
           (api_response, http_error) result
       A label ?tools was expected
```

## 원인

`Vt.complete_fn` 이 `~messages` 와 `()` 사이에 `?tools:Yojson.Safe.t list` 를 얻었는데, `test_keeper_vision_tool` 의 스텁 8개가 여전히 `~messages` 에서 끝납니다.

OCaml 에서 optional 파라미터는 화살표 타입에 포함되므로, 스텁이 그 라벨을 받지 않으면 `complete_fn` 과 매치되지 않습니다. 그래서 `~complete:` 로 넘기는 지점이 전부 타입 에러입니다.

## 변경

스텁들은 인자를 전부 무시하고 실패하거나 정해진 응답을 돌려줍니다 — 라벨을 **받는 것 자체**가 이들이 만족해야 할 계약의 전부라 `?tools:_` 로 추가했습니다.

| | 스텁 |
|---|---|
| `complete_should_not_run` | 1 |
| 인라인 `let complete ... ~config:_ ...` | 3 |
| 인라인 `let complete ... ~config ...` | 4 |
| | **8** |

## 검증

```
dune build --root . @check                        exit 0
test_keeper_vision_tool.exe                       all assertions passed
ocamlformat --check test/test_keeper_vision_tool.ml   exit 0
```

`@check` 가 통과하므로 이 파일이 유일한 파손이었습니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
