### PR TITLE
fix(fusion): deliver a cancelled run as cancelled, not as a failure

### DIFF
--- a/lib/fusion/fusion_delivery_projector.ml
+++ b/lib/fusion/fusion_delivery_projector.ml
@@ -5,7 +5,6 @@ type projection_error =
   | Non_durable_settlement
   | Ambiguous_settlement
   | Nonterminal_status of Keeper_msg_async.request_status
-  | Evidence_unavailable
   | Evidence_invalid of string
   | Projection_failed of string
   | Obligation_removal_failed of Fusion_delivery_obligation.error
@@ -22,31 +21,10 @@ let projection_error_to_string = function
     "Fusion settlement disagrees with canonical request truth"
   | Nonterminal_status status ->
     "Fusion request is not terminal: " ^ Keeper_msg_async.status_to_string status
-  | Evidence_unavailable ->
-    "Fusion computation completed successfully without deliberation evidence"
   | Evidence_invalid detail -> "invalid Fusion deliberation evidence: " ^ detail
   | Projection_failed detail -> "Fusion terminal projection failed: " ^ detail
 ;;
 
-(** Sink failure codes are derived from the typed error — never the other way
-    around. Only errors that are actually delivered through
-    [Fusion_sink.emit_failure] have a code; anything else is a programmer
-    error, so it fails fast instead of silently inventing a string. *)
-let projection_error_failure_code = function
-  | Evidence_unavailable -> "evidence_unavailable"
-  | ( Invalid_request_id _
-    | Obligation_unavailable _
-    | Identity_mismatch _
-    | Non_durable_settlement
-    | Ambiguous_settlement
-    | Nonterminal_status _
-    | Evidence_invalid _
-    | Projection_failed _
-    | Obligation_removal_failed _ ) as error ->
-    invalid_arg
-      ("projection error is not delivered as a sink failure: "
-       ^ projection_error_to_string error)
-;;
 
 let ( let* ) = Result.bind
 
@@ -83,16 +61,18 @@ let ensure_registry_entry ~registry obligation =
     Fusion_sink.broadcast_run_status ~registry ~run_id
 ;;
 
-let failure_of_status = function
+(* lifecycle 상태를 typed 실패로 옮긴다. 문자열 code 로 접지 않는 이유는 wake 가
+   보낼 terminal 이 사유에 달려 있기 때문이다 — 취소는 [Fusion_cancelled] 로 가야
+   키퍼가 "심의가 실패했다" 와 "심의가 중단됐다" 를 구분한다. *)
+let failure_of_status : Keeper_msg_async.request_status -> Fusion_sink.delivery_failure option
+  = function
   | Keeper_msg_async.Done { ok = false; body; _ } ->
-    Some ("computation_failed", body)
-  | Keeper_msg_async.Lost { reason } -> Some ("lost", reason)
+    Some (Fusion_sink.Computation_failed body)
+  | Keeper_msg_async.Lost { reason } -> Some (Fusion_sink.Lost reason)
   | Keeper_msg_async.Cancelled { reason; cancelled_by } ->
-    Some ("cancelled", Printf.sprintf "%s (cancelled_by=%s)" reason cancelled_by)
+    Some (Fusion_sink.Cancelled { reason; cancelled_by })
   | Keeper_msg_async.Persistence_failed { attempted_status; reason } ->
-    Some
-      ( "persistence_failed"
-      , Printf.sprintf "%s (attempted_status=%s)" reason attempted_status )
+    Some (Fusion_sink.Persistence_failed { attempted_status; reason })
   | Keeper_msg_async.Done { ok = true; _ }
   | Keeper_msg_async.Queued
   | Keeper_msg_async.Running
@@ -138,18 +118,16 @@ let project_entry ~registry ~base_path (entry : Keeper_msg_async.entry) =
          Remediate by delivering a typed failure through the same fail-closed
          sink and then clearing the obligation (a failed failure-projection
          still retains it). *)
-      let error = Evidence_unavailable in
       Fusion_sink.emit_failure ~registry ~base_dir:base_path
         ~keeper:payload.keeper_name ~run_id:entry.request_id ~channel:payload.channel
-        ~failure_code:(projection_error_failure_code error)
-        ~detail:(projection_error_to_string error)
+        ~failure:Fusion_sink.Evidence_unavailable
       |> Result.map_error (fun detail -> Projection_failed detail)
     | status ->
       (match failure_of_status status with
-       | Some (failure_code, detail) ->
+       | Some failure ->
          Fusion_sink.emit_failure ~registry ~base_dir:base_path
            ~keeper:payload.keeper_name ~run_id:entry.request_id
-           ~channel:payload.channel ~failure_code ~detail
+           ~channel:payload.channel ~failure
          |> Result.map_error (fun detail -> Projection_failed detail)
        | None -> Error (Nonterminal_status status))
   in

--- a/lib/fusion/fusion_delivery_projector.mli
+++ b/lib/fusion/fusion_delivery_projector.mli
@@ -8,17 +8,12 @@ type projection_error =
   | Non_durable_settlement
   | Ambiguous_settlement
   | Nonterminal_status of Keeper_msg_async.request_status
-  | Evidence_unavailable
   | Evidence_invalid of string
   | Projection_failed of string
   | Obligation_removal_failed of Fusion_delivery_obligation.error
 
 val projection_error_to_string : projection_error -> string
 
-val projection_error_failure_code : projection_error -> string
-(** Sink failure code derived from the typed error. Only errors delivered
-    through [Fusion_sink.emit_failure] have a code (currently
-    [Evidence_unavailable]); any other error raises [Invalid_argument]. *)
 
 val on_worker_settled :
   ?registry:Fusion_run_registry.t -> base_path:string -> Keeper_msg_async.worker_settlement -> unit

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -255,6 +255,53 @@ let judge_node_meta (o : Fusion_types.judge_outcome) : Yojson.Safe.t =
          ; ("timed_out", `Bool timed_out)
          ])
 
+(* 종결 실패의 사유. [Keeper_msg_async] 의 lifecycle 상태에서 파생되며, 여기까지
+   typed 로 오는 이유는 wake 가 보낼 terminal 이 사유에 달려 있기 때문이다: 취소는
+   실패가 아니라 취소로 도착해야 키퍼가 재시도 여부를 판단할 수 있다.
+
+   이전에는 이 자리가 [(string code, string detail)] 튜플이었고 wake 는 [~ok:bool]
+   을 받았다. 그래서 [Keeper_event_queue.Fusion_cancelled] 는 typed 로 존재하고
+   렌더러·코덱·테스트까지 갖췄는데 **생산자가 하나도 없었다** — 취소된 run 은 전부
+   [Fusion_failed] 로 도착했다. 사유를 문자열로 접은 뒤 불리언으로 한 번 더 접은
+   결과다. code 문자열은 registry wire 로 남지만(대시보드가 읽는다) 그것은 이
+   합에서 파생되지, 분기를 고르는 입력이 아니다. *)
+type delivery_failure =
+  | Computation_failed of string
+  | Lost of string
+  | Cancelled of
+      { reason : string
+      ; cancelled_by : string
+      }
+  | Persistence_failed of
+      { attempted_status : string
+      ; reason : string
+      }
+  | Evidence_unavailable
+
+let delivery_failure_code = function
+  | Computation_failed _ -> "computation_failed"
+  | Lost _ -> "lost"
+  | Cancelled _ -> "cancelled"
+  | Persistence_failed _ -> "persistence_failed"
+  | Evidence_unavailable -> "evidence_unavailable"
+
+let delivery_failure_detail = function
+  | Computation_failed detail | Lost detail -> detail
+  | Cancelled { reason; cancelled_by } ->
+    Printf.sprintf "%s (cancelled_by=%s)" reason cancelled_by
+  | Persistence_failed { attempted_status; reason } ->
+    Printf.sprintf "%s (attempted_status=%s)" reason attempted_status
+  | Evidence_unavailable ->
+    "Fusion computation completed successfully without deliberation evidence"
+
+(* 취소만 [Fusion_cancelled] 로 간다. 나머지는 심의가 실패한 것이고, 취소는
+   심의가 중단된 것이다 — 키퍼에게 다른 사실이다. *)
+let terminal_of_delivery_failure failure ~content =
+  match failure with
+  | Cancelled _ -> Keeper_event_queue.Fusion_cancelled
+  | Computation_failed _ | Lost _ | Persistence_failed _ | Evidence_unavailable ->
+    Keeper_event_queue.Fusion_failed content
+
 (* RFC-0266: 심의 완료 시 호출 키퍼를 typed [Fusion_completed] stimulus로 깨운다.
    board post + chat append(영속)와 별개로, 잠든(Running) 키퍼를 즉시 깨워
    resolved_answer가 다음 턴의 actionable 입력으로 도착하게 하는 hint+payload 경로다.
@@ -296,13 +343,8 @@ let broadcast_run_status ~registry ~run_id =
    stimulus on its next admitted turn (mirrors HITL's post-commit signal).
    Eio structural cancellation (Cancelled) is always re-raised. *)
 let wake_keeper_on_fusion_completion
-      ~base_dir ~keeper ~run_id ~channel ~ok ~resolved_answer ~board_post_id :
+      ~base_dir ~keeper ~run_id ~channel ~terminal ~board_post_id :
     (unit, string) result =
-  let terminal =
-    if ok
-    then Keeper_event_queue.Fusion_succeeded resolved_answer
-    else Keeper_event_queue.Fusion_failed resolved_answer
-  in
   let fusion_completion =
     Keeper_event_queue.{ run_id; terminal; board_post_id; channel }
   in
@@ -327,7 +369,12 @@ let wake_keeper_on_fusion_completion
       "fusion completion wake durable-commit failed run_id=%s: %s" run_id reason;
     Error reason
   | Ok () ->
-    Log.Keeper.info "fusion completion wake: keeper=%s run_id=%s ok=%b" keeper run_id ok;
+    Log.Keeper.info "fusion completion wake: keeper=%s run_id=%s terminal=%s" keeper
+      run_id
+      (match terminal with
+       | Keeper_event_queue.Fusion_succeeded _ -> "succeeded"
+       | Keeper_event_queue.Fusion_failed _ -> "failed"
+       | Keeper_event_queue.Fusion_cancelled -> "cancelled");
     (try
        match
          Keeper_registry.wakeup_running
@@ -542,8 +589,10 @@ let emit ~registry ~base_dir ~keeper ~run_id ~channel ~question ~panel ~judge ~j
            Fusion_run_registry.mark_completed registry ~run_id
              ~outcome:Fusion_run_registry.Succeeded;
            broadcast_run_status ~registry ~run_id;
-           wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~channel ~ok:true
-             ~resolved_answer:j.Fusion_types.resolved_answer ~board_post_id
+           wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~channel
+             ~terminal:
+               (Keeper_event_queue.Fusion_succeeded j.Fusion_types.resolved_answer)
+             ~board_post_id
          | Error e ->
            Fusion_run_registry.mark_completed registry ~run_id
              ~outcome:
@@ -552,9 +601,11 @@ let emit ~registry ~base_dir ~keeper ~run_id ~channel ~question ~panel ~judge ~j
                   ; code = Fusion_types.judge_failure_tag e
                   });
            broadcast_run_status ~registry ~run_id;
-           wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~channel ~ok:false
-             ~resolved_answer:
-               (Printf.sprintf "fusion run failed — %s" (render_failure e))
+           (* 심판이 실패한 것이지 run 이 취소된 것이 아니므로 [Fusion_failed] 다. *)
+           wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~channel
+             ~terminal:
+               (Keeper_event_queue.Fusion_failed
+                  (Printf.sprintf "fusion run failed — %s" (render_failure e)))
              ~board_post_id
        in
        (* Chat/Board are independently idempotent, but the producer obligation
@@ -572,9 +623,13 @@ let emit ~registry ~base_dir ~keeper ~run_id ~channel ~question ~panel ~judge ~j
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn -> Error (Printexc.to_string exn)
 
-let emit_failure ~registry ~base_dir ~keeper ~run_id ~channel ~failure_code ~detail =
+let emit_failure ~registry ~base_dir ~keeper ~run_id ~channel ~failure =
   let ( let* ) = Result.bind in
   let* delivery_key = delivery_key_of_run_id run_id in
+  let failure_code = delivery_failure_code failure in
+  let detail = delivery_failure_detail failure in
+  (* 취소도 chat 본문은 같은 한 줄로 남긴다 — 사람이 읽는 줄은 사유를 이미 담고
+     있고, 분기가 필요한 쪽은 키퍼가 받는 typed terminal 이다. *)
   let content =
     Printf.sprintf "Fusion run `%s` failed (%s): %s" run_id failure_code detail
   in
@@ -593,5 +648,6 @@ let emit_failure ~registry ~base_dir ~keeper ~run_id ~channel ~failure_code ~det
   Fusion_run_registry.mark_completed registry ~run_id
     ~outcome:(Fusion_run_registry.Failed { reason = detail; code = failure_code });
   broadcast_run_status ~registry ~run_id;
-  wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~channel ~ok:false
-    ~resolved_answer:content ~board_post_id:""
+  wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~channel
+    ~terminal:(terminal_of_delivery_failure failure ~content)
+    ~board_post_id:""

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -89,21 +89,45 @@ val wake_keeper_on_fusion_completion :
   -> keeper:string
   -> run_id:string
   -> channel:Keeper_continuation_channel.t
-  -> ok:bool
-  -> resolved_answer:string
+  -> terminal:Keeper_event_queue.fusion_terminal
   -> board_post_id:string
   -> (unit, string) result
+(** [terminal] 은 키퍼가 받는 typed 종결이다. 이전 시그니처는 [~ok:bool] 이라
+    성공/실패 둘로만 접혔고, 그래서 [Keeper_event_queue.Fusion_cancelled] 는 코덱과
+    렌더러를 갖추고도 생산자가 없었다. *)
+
+(** 종결 실패의 사유. wake 가 보낼 terminal 이 여기에 달려 있으므로 문자열 code 가
+    아니라 닫힌 합으로 전달한다: 취소는 실패가 아니라 취소로 도착해야 키퍼가 재시도
+    여부를 판단할 수 있다. registry wire 의 [code] 문자열은 이 합에서 파생된다. *)
+type delivery_failure =
+  | Computation_failed of string
+  | Lost of string
+  | Cancelled of
+      { reason : string
+      ; cancelled_by : string
+      }
+  | Persistence_failed of
+      { attempted_status : string
+      ; reason : string
+      }
+  | Evidence_unavailable
+
+(** registry/대시보드가 읽는 안정 wire 라벨. *)
+val delivery_failure_code : delivery_failure -> string
+
+(** 사람이 읽는 한 줄. 사유별 부가 정보(cancelled_by, attempted_status)를 포함한다. *)
+val delivery_failure_detail : delivery_failure -> string
 
 (** Idempotently project a terminal Fusion lifecycle failure to the Keeper chat
-    lane and its exact continuation channel. *)
+    lane and its exact continuation channel. [Cancelled] 는 키퍼에게
+    [Fusion_cancelled] 로, 나머지는 [Fusion_failed] 로 도착한다. *)
 val emit_failure :
      registry:Fusion_run_registry.t
   -> base_dir:string
   -> keeper:string
   -> run_id:string
   -> channel:Keeper_continuation_channel.t
-  -> failure_code:string
-  -> detail:string
+  -> failure:delivery_failure
   -> (unit, string) result
 
 (** RFC-0266 §7 Phase 4: broadcast a [fusion_run_status] SSE event carrying the

--- a/test/test_fusion_delivery_obligation.ml
+++ b/test/test_fusion_delivery_obligation.ml
@@ -368,21 +368,18 @@ let test_startup_recovery_remediates_missing_evidence () =
 ;;
 
 let test_evidence_unavailable_typed_failure_code () =
-  (* The sink failure code is derived from the typed variant — the live path
-     must never bypass it with a raw string. *)
+  (* The registry wire code is derived from the typed failure, never chosen by
+     a caller passing a raw string. The failure now lives in the sink because
+     that is where the terminal it maps to is decided. *)
   check string "failure code derives from typed variant" "evidence_unavailable"
-    (Fusion_delivery_projector.projection_error_failure_code
-       Fusion_delivery_projector.Evidence_unavailable);
+    (Fusion_sink.delivery_failure_code Fusion_sink.Evidence_unavailable);
   check string "detail derives from typed variant"
     "Fusion computation completed successfully without deliberation evidence"
-    (Fusion_delivery_projector.projection_error_to_string
-       Fusion_delivery_projector.Evidence_unavailable);
-  match
-    Fusion_delivery_projector.projection_error_failure_code
-      (Fusion_delivery_projector.Projection_failed "boom")
-  with
-  | _ -> fail "non-sink projection error must not have a failure code"
-  | exception Invalid_argument _ -> ()
+    (Fusion_sink.delivery_failure_detail Fusion_sink.Evidence_unavailable);
+  check string "cancellation keeps its provenance in the detail"
+    "operator stop (cancelled_by=vincent)"
+    (Fusion_sink.delivery_failure_detail
+       (Fusion_sink.Cancelled { reason = "operator stop"; cancelled_by = "vincent" }))
 ;;
 
 let () =

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -598,14 +598,80 @@ let test_emit_success_projects_board_chat_and_registry () =
     | None -> fail "fusion run should remain visible")
 ;;
 
+(* 취소가 실제로 [Fusion_cancelled] 로 키퍼에게 도달하는지 — 이 파일의 기존
+   cancellation 테스트는 stimulus 를 손으로 만들어 코덱과 렌더러만 확인했고, 그래서
+   "아무도 그 terminal 을 생산하지 않는다" 를 통과시켰다. 실제로 오랫동안 생산자가
+   0 이었고 취소된 run 은 전부 [Fusion_failed] 로 도착했다. 이 테스트는 sink 의 실제
+   실패 투영 경로를 태워 durable 큐에 들어간 terminal 을 읽는다. *)
+let test_cancelled_delivery_reaches_the_keeper_as_cancelled () =
+  with_isolated_base_path "fusion-cancel" (fun base_dir registry ->
+    let keeper = Printf.sprintf "fusion-cancel-%d" (Random.bits ()) in
+    let run_id = Printf.sprintf "fus-cancel-%d" (Random.bits ()) in
+    Fusion_run_registry.register_running registry ~run_id ~keeper ~preset:"trio"
+      ~topology:Fusion_types.Simple ~started_at:1.0;
+    let result =
+      Fusion_sink.emit_failure ~registry ~base_dir ~keeper ~run_id
+        ~channel:discord_channel
+        ~failure:
+          (Fusion_sink.Cancelled { reason = "operator stop"; cancelled_by = "vincent" })
+    in
+    check bool "cancellation projects" true (Result.is_ok result);
+    (match
+       Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper
+       |> Keeper_event_queue.dequeue
+     with
+     | Some ({ payload = Keeper_event_queue.Fusion_completed fc; _ }, _) ->
+       (match fc.terminal with
+        | Keeper_event_queue.Fusion_cancelled -> ()
+        | Keeper_event_queue.Fusion_failed _ ->
+          fail "a cancelled run must not arrive as a judge failure"
+        | Keeper_event_queue.Fusion_succeeded _ -> fail "cancellation arrived as success")
+     | Some _ -> fail "unexpected durable stimulus kind"
+     | None -> fail "cancellation must be durably queued");
+    (* registry wire 는 계속 문자열 code 를 싣는다(대시보드가 읽는다) — 다만 그 값이
+       typed 실패에서 파생된다. *)
+    match Fusion_run_registry.get registry ~run_id with
+    | Some { status = Fusion_run_registry.Completed (Fusion_run_registry.Failed { code; _ }); _ }
+      -> check string "registry code derives from the typed failure" "cancelled" code
+    | _ -> fail "registry must record the run as failed with its code")
+;;
+
+(* 대조군: 심판 실패는 여전히 [Fusion_failed] 로 간다. 이게 없으면 위 테스트는
+   "모든 실패를 cancelled 로 보내도" 통과한다. *)
+let test_judge_failure_still_reaches_the_keeper_as_failed () =
+  with_isolated_base_path "fusion-failed" (fun base_dir registry ->
+    let keeper = Printf.sprintf "fusion-failed-%d" (Random.bits ()) in
+    let run_id = Printf.sprintf "fus-failed-%d" (Random.bits ()) in
+    Fusion_run_registry.register_running registry ~run_id ~keeper ~preset:"trio"
+      ~topology:Fusion_types.Simple ~started_at:1.0;
+    let result =
+      Fusion_sink.emit_failure ~registry ~base_dir ~keeper ~run_id
+        ~channel:discord_channel ~failure:(Fusion_sink.Computation_failed "boom")
+    in
+    check bool "failure projects" true (Result.is_ok result);
+    match
+      Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper
+      |> Keeper_event_queue.dequeue
+    with
+    | Some ({ payload = Keeper_event_queue.Fusion_completed fc; _ }, _) ->
+      (match fc.terminal with
+       | Keeper_event_queue.Fusion_failed _ -> ()
+       | Keeper_event_queue.Fusion_cancelled ->
+         fail "a computation failure must not arrive as a cancellation"
+       | Keeper_event_queue.Fusion_succeeded _ -> fail "failure arrived as success")
+    | Some _ -> fail "unexpected durable stimulus kind"
+    | None -> fail "failure must be durably queued")
+;;
+
 let test_wake_durable_commit_carries_channel () =
   with_isolated_base_path "fusion-wake-durable" (fun base_dir _registry ->
     let keeper = Printf.sprintf "fusion-wake-%d" (Random.bits ()) in
     let run_id = Printf.sprintf "fus-wake-%d" (Random.bits ()) in
     let result =
       Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id
-        ~channel:discord_channel ~ok:true
-        ~resolved_answer:"WAKE-DURABLE-ANSWER" ~board_post_id:"post-wake-1"
+        ~channel:discord_channel
+        ~terminal:(Keeper_event_queue.Fusion_succeeded "WAKE-DURABLE-ANSWER")
+        ~board_post_id:"post-wake-1"
     in
     check bool "wake commits durably" true (Result.is_ok result);
     (match
@@ -624,7 +690,7 @@ let test_wake_durable_commit_carries_channel () =
      | None -> fail "completion stimulus must be durably persisted with its channel");
     let replay =
       Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id
-        ~channel:discord_channel ~ok:true ~resolved_answer:"WAKE-DURABLE-ANSWER"
+        ~channel:discord_channel ~terminal:(Keeper_event_queue.Fusion_succeeded "WAKE-DURABLE-ANSWER")
         ~board_post_id:"post-wake-1"
     in
     check bool "exact-recipient replay accepts the committed recipient" true
@@ -672,8 +738,7 @@ let test_wake_fail_closed_rejects_conflicting_delivery () =
      | Error e -> fail (Printf.sprintf "seeding the conflicting durable row should commit: %s" e));
     let result =
       Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id
-        ~channel:discord_channel ~ok:true
-        ~resolved_answer:"REAL-ANSWER" ~board_post_id
+        ~channel:discord_channel ~terminal:(Keeper_event_queue.Fusion_succeeded "REAL-ANSWER") ~board_post_id
     in
     check bool "conflicting durable commit fails the wake" true (Result.is_error result))
 ;;
@@ -699,15 +764,13 @@ let test_wake_isolates_keeper_run_identity () =
     in
     (match
        Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper:keeper_a
-         ~run_id ~channel:discord_channel ~ok:true
-         ~resolved_answer:"ANSWER-A" ~board_post_id:"post-iso-a"
+         ~run_id ~channel:discord_channel ~terminal:(Keeper_event_queue.Fusion_succeeded "ANSWER-A") ~board_post_id:"post-iso-a"
      with
      | Ok () -> ()
      | Error e -> fail (Printf.sprintf "keeper-a wake must commit: %s" e));
     (match
        Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper:keeper_b
-         ~run_id ~channel:channel_b ~ok:true
-         ~resolved_answer:"ANSWER-B" ~board_post_id:"post-iso-b"
+         ~run_id ~channel:channel_b ~terminal:(Keeper_event_queue.Fusion_succeeded "ANSWER-B") ~board_post_id:"post-iso-b"
      with
      | Ok () -> ()
      | Error e -> fail (Printf.sprintf "keeper-b wake must commit: %s" e));
@@ -766,8 +829,7 @@ let test_completion_wake_commits_durably_across_lane_replacement () =
          in
          let result =
            Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id
-             ~channel:discord_channel ~ok:true
-             ~resolved_answer:"REPLACED-LANE-ANSWER" ~board_post_id:"post-replaced"
+             ~channel:discord_channel ~terminal:(Keeper_event_queue.Fusion_succeeded "REPLACED-LANE-ANSWER") ~board_post_id:"post-replaced"
          in
          check bool "completion commits despite replaced live lane" true
            (Result.is_ok result);
@@ -802,19 +864,19 @@ let test_wake_board_recovery_keeps_canonical_identity () =
     let run_id = Printf.sprintf "fus-board-recovery-%d" (Random.bits ()) in
     let first =
       Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id
-        ~channel:discord_channel ~ok:true ~resolved_answer:"RECOVERED-ANSWER"
+        ~channel:discord_channel ~terminal:(Keeper_event_queue.Fusion_succeeded "RECOVERED-ANSWER")
         ~board_post_id:"post-canonical"
     in
     check bool "completion commits with Board evidence" true (Result.is_ok first);
     let replay =
       Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id
-        ~channel:discord_channel ~ok:true ~resolved_answer:"RECOVERED-ANSWER"
+        ~channel:discord_channel ~terminal:(Keeper_event_queue.Fusion_succeeded "RECOVERED-ANSWER")
         ~board_post_id:"post-canonical"
     in
     check bool "canonical replay is idempotent" true (Result.is_ok replay);
     let conflicting =
       Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id
-        ~channel:discord_channel ~ok:true ~resolved_answer:"RECOVERED-ANSWER"
+        ~channel:discord_channel ~terminal:(Keeper_event_queue.Fusion_succeeded "RECOVERED-ANSWER")
         ~board_post_id:"post-divergent"
     in
     check bool "divergent Board identity fails closed" true
@@ -1048,6 +1110,14 @@ let () =
             "scheduled wake is actionable (non-empty, carries message)"
             `Quick
             test_scheduled_wake_is_actionable
+        ; test_case
+            "cancelled delivery reaches the keeper as cancelled"
+            `Quick
+            test_cancelled_delivery_reaches_the_keeper_as_cancelled
+        ; test_case
+            "judge failure still reaches the keeper as failed"
+            `Quick
+            test_judge_failure_still_reaches_the_keeper_as_failed
         ] )
     ]
 ;;


### PR DESCRIPTION
## 발견

`Keeper_event_queue.Fusion_cancelled` 는 코덱, 렌더러("structurally cancelled"), reaction-ledger 라벨, world-observation arm, 그리고 전용 테스트까지 갖추고 있었다. **생산자만 없었다.** 취소된 fusion run 은 전부 `Fusion_failed` 로 키퍼에게 도착했다.

원인은 나가는 길의 두 번의 붕괴다:

1. `Fusion_delivery_projector.failure_of_status` 가 typed lifecycle 상태를 `(string code, string detail)` 튜플로 접었다.
2. `Fusion_sink.wake_keeper_on_fusion_completion` 이 `~ok:bool` 을 받았다.

wake 를 만들 시점에는 "운영자가 취소했다" 와 "심판이 실패했다" 가 같은 값이었다. 그 차이를 실어 나를 수 있는 variant 는 두 붕괴 뒤에 도달 불가로 앉아 있었다.

기존 테스트가 이걸 못 잡은 이유는 **stimulus 를 스스로 만들어** 코덱과 렌더러를 확인하기 때문이다. `Fusion_cancelled` 가 오면 올바르게 처리된다는 것은 증명하지만, 무엇이 그걸 만드는지는 묻지 않는다.

## 변경

두 붕괴를 typed 로 관통시킨다.

- `Fusion_sink.delivery_failure` — 닫힌 합(`Computation_failed` / `Lost` / `Cancelled` / `Persistence_failed` / `Evidence_unavailable`). registry wire 의 code 문자열은 대시보드가 읽으므로 남지만, 이제 **variant 에서 파생**되지 호출자가 고르지 않는다.
- `wake_keeper_on_fusion_completion` 이 `~ok` 대신 `~terminal` 을 받는다. 취소는 `Fusion_cancelled`, 나머지는 `Fusion_failed` — 취소된 run 은 *중단된* 것이고 실패한 run 은 *시도된* 것이라, 재시도 여부를 판단하는 키퍼에게 다른 사실이다.

배선이 죽인 것도 함께 제거한다: `projection_error` 의 `Evidence_unavailable`(이제 sink 가 그 실패를 소유한다)과 `projection_error_failure_code`(남은 호출자가 테스트뿐이었다).

## 검증

새 테스트는 실제 투영 경로를 태우고 durable 큐에서 terminal 을 읽는다. 대조군으로 "computation failure 는 여전히 `Fusion_failed` 로 도착한다" 를 함께 둔다 — 이게 없으면 첫 테스트는 **모든 실패를 취소로 relabel 해도** 통과한다.

**뮤테이션 확인**: `Cancelled` 를 `Fusion_failed` 로 되돌리면 취소 테스트가 빨개지고 대조군은 초록으로 남는다.

fusion_core 83/83, fusion_wake 16/16(신규 2), delivery_obligation 6/6, judge_usage·status green, ocamlformat clean.

## 무관한 main 상태

`test/test_keeper_vision_tool.ml` 은 현재 main 에서 컴파일되지 않는다(clean main worktree 에서 재현). 이 변경과 무관하다.

RFC-WAIVED: `pr-rfc-check.sh` 대상 subsystem 에 닿지 않는다. RFC-0266 이 정의한 typed 종결을 실제로 생산하게 만드는 변경이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
