### PR TITLE
docs(agent_core): stop naming two per-request deadlines as fields of this record

### DIFF
--- a/packages/agent_core/lib/llm_provider/provider_config.mli
+++ b/packages/agent_core/lib/llm_provider/provider_config.mli
@@ -178,9 +178,14 @@ type t =
   ; connect_timeout_s : float option
     (** Explicit connect + initial-response-headers wall-clock timeout.
       [None] applies no agent-core-owned deadline. [Some s] forces [s] seconds for
-      the connect/headers phase only — it is independent of
-      the body deadline ([body_timeout_s]) and the inter-chunk stream-idle
-      deadline ([stream_idle_timeout_s]).
+      the connect/headers phase only — it is independent of the body deadline and
+      the inter-chunk stream-idle deadline.
+
+      Those two are {b not fields of this record}: they are per-request arguments
+      of {!Complete.complete} ([?body_timeout_s] / [?stream_idle_timeout_s]),
+      because a deadline for one call is a property of that call rather than of
+      the endpoint. Naming them in brackets here read as sibling fields and sent
+      readers looking for them in this type.
 
       The consumer declares any deadline; AGENT_CORE never selects one from provider
       kind, URL, model, or process environment.


### PR DESCRIPTION
## 문제

`connect_timeout_s` 의 문서가 자신을 이렇게 대비시킨다:

> it is independent of the body deadline (`[body_timeout_s]`) and the inter-chunk stream-idle deadline (`[stream_idle_timeout_s]`)

둘 다 실재하지만 **`Provider_config.t` 의 필드가 아니다** — `Complete.complete` 의 per-request 인자다. 레코드 필드 docstring 안에서 대괄호로 적힌 이름은 형제 필드처럼 읽히므로, 독자는 이 타입에서 찾다가 못 찾고 "데드라인을 설정할 수 없다" 고 결론짓는다.

가정이 아니다. 이번 주 fusion preset 데드라인을 배선하면서 이 주석을 읽고 레코드에서 `body_timeout_s` 를 찾았고, 없어서 provider 축(`connect_timeout_s`)으로 우회할 뻔했다. 실제 손잡이(`Runtime_agent.config.body_timeout_s` → `Complete.complete` 소비)는 파이프라인을 grep 해서야 찾았다.

## 변경

어디에 살고 왜 거기 있는지 명시한다 — 한 호출의 데드라인은 endpoint 가 아니라 그 호출의 성질이다.

문서만 변경이며 동작 변화는 없다. `dune build packages/agent_core` 통과, ocamlformat clean.

이 파일의 나머지 대괄호 참조 4개(`json_object`, `reasoning_effort_to_string`, `supports_structured_output`, `supports_tool_choice`)는 전수 확인 결과 다른 모듈에 실재하므로 건드리지 않았다.

RFC-WAIVED: 문서 한 문단 수정이며 `pr-rfc-check.sh` 대상 subsystem 에 닿지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
