### PR TITLE
feat(keeper): 턴 슬롯이 실제로 비었을 때 자율 레인에 알리도록 (RFC-0373 2단계)

### DIFF
--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -198,6 +198,7 @@ type t =
   ; child_cancel : (unit -> unit) option Atomic.t
   ; stopping_waiters : ((unit, error) result Eio.Promise.u) list ref
   ; shutdown_idle_waiters : ((unit, error) result Eio.Promise.u) list ref
+  ; on_turn_slot_released : (unit -> unit) option
   }
 
 let error_to_string = function
@@ -220,6 +221,30 @@ let projection t = Atomic.get t.projection
 let operation_projection t = Atomic.get t.operation_projection
 let turn_in_flight t = Atomic.get t.turn_in_flight
 let shutdown_operation_id t = Atomic.get t.shutdown_operation_id
+
+(* The freed slot is offered to a queued chat operation first (the caller runs
+   [start_child_if_needed] immediately before this). Notifying only when it is
+   still unclaimed makes the signal mean "a turn can start now" rather than "a
+   turn ended": a listener woken by the latter would find the slot taken and
+   defer again, which is the cycle this notification exists to end.
+
+   The callback runs on the Owner fiber, so an exception from it would take
+   down the actor that every producer depends on. Contain it; a lost wake
+   degrades to the listener's own cadence, which is the behaviour before this
+   notification existed. *)
+let notify_turn_slot_released t =
+  match t.on_turn_slot_released with
+  | None -> ()
+  | Some notify ->
+    if Option.is_none (Atomic.get t.turn_in_flight)
+    then (
+      try notify () with
+      | exn ->
+        Log.Keeper.routine
+          ~keeper_name:t.keeper_name
+          "turn slot release listener raised: %s"
+          (Printexc.to_string exn))
+;;
 
 let turn_lane_to_string = function
   | Autonomous -> "autonomous"
@@ -423,6 +448,7 @@ let start
       ~operation_store_path
       ~now
       ~operation_runner
+      ~on_turn_slot_released
       ~keeper_name
       ~initial_meta
   =
@@ -471,6 +497,7 @@ let start
     ; child_cancel = Atomic.make None
     ; stopping_waiters = ref []
     ; shutdown_idle_waiters = ref []
+    ; on_turn_slot_released
     }
   in
   Eio.Switch.on_release sw (fun () ->
@@ -872,6 +899,7 @@ let start
             (fun waiter -> Eio.Promise.resolve waiter result)
             shutdown_idle_waiters;
           start_child_if_needed state shutdown_operation_id;
+          notify_turn_slot_released t;
           loop state shutdown_operation_id
         | Command (Begin_stopping, resolve) ->
           let transition = Keeper_owner_reducer.begin_stopping state in

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -136,9 +136,27 @@ val start
   -> operation_store_path:string
   -> now:(unit -> float)
   -> operation_runner:operation_runner option
+  -> on_turn_slot_released:(unit -> unit) option
   -> keeper_name:string
   -> initial_meta:Keeper_meta_contract.keeper_meta option
   -> (t, error) result
+(** [on_turn_slot_released] fires when a turn ends and the slot is still
+    unclaimed after the queued chat operation, if any, has been offered it. The
+    signal therefore means "a turn can start now", not "a turn ended".
+
+    It exists because the two lanes learn about a free slot by opposite means.
+    A chat producer notifies the Owner through {!wake_operation_drain} — "the
+    Owner never polls", as the {!operation_runner} contract says — while the
+    autonomous lane has no such channel and rediscovers the slot only on its
+    next keepalive cadence. RFC-0373 measured what that costs: over 2026-08-12
+    all 50 autonomous deferrals named a chat holder, one held the slot 16.3
+    minutes across 5 consecutive cycles, and the keeper carrying the most chat
+    traffic lost 18.6% of its autonomous cycles.
+
+    The callback runs on the Owner fiber. It must not block, and an exception
+    it raises is contained rather than propagated — a lost wake degrades to the
+    listener's own cadence. This does not change admission order: the chat lane
+    still receives the freed slot first. *)
 
 val projection : t -> Keeper_owner_reducer.projection
 (** Lock-free immutable snapshot. *)

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -28,6 +28,7 @@ type pool =
   ; owner_handles : Keeper_owner.t list Atomic.t
   ; stopping : bool Atomic.t
   ; operation_runner : Keeper_owner.operation_runner option
+  ; on_turn_slot_released : (keeper_name:string -> unit) option
   }
 
 let pools : (string, pool) Hashtbl.t = Hashtbl.create 4
@@ -166,6 +167,8 @@ let start_owner pool ~keeper_name ~initial_meta =
       (* NDT-OK: wall time is injected once at the Owner persistence boundary. *)
       ~now:Unix.gettimeofday
       ~operation_runner:pool.operation_runner
+      ~on_turn_slot_released:
+        (Option.map (fun notify () -> notify ~keeper_name) pool.on_turn_slot_released)
       ~keeper_name
       ~initial_meta
 ;;
@@ -241,7 +244,7 @@ let ensure_empty_in_pool pool keeper_name =
               Ok owner)))
 ;;
 
-let install_from_store ~sw ~operation_runner config =
+let install_from_store ~sw ~operation_runner ~on_turn_slot_released config =
   let base_path = pool_key config.Workspace.base_path in
   match load_all config with
   | Error _ as error -> error
@@ -255,6 +258,7 @@ let install_from_store ~sw ~operation_runner config =
       ; owner_handles = Atomic.make []
       ; stopping = Atomic.make false
       ; operation_runner
+      ; on_turn_slot_released
       }
     in
     let installed =

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -27,6 +27,7 @@ exception Install_failed of install_error
 val install_from_store
   :  sw:Eio.Switch.t
   -> operation_runner:Keeper_owner.operation_runner option
+  -> on_turn_slot_released:(keeper_name:string -> unit) option
   -> Workspace.config
   -> (int, install_error) result
 (** Load each valid persisted Keeper independently and start exactly one owner

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -367,6 +367,7 @@ type wakeup_intent =
   | Compaction_signal
   | Attention_result
   | Runtime_parameter_change
+  | Turn_slot_released
 
 let wakeup_intent_to_wire = function
   | Reactive_signal -> "reactive_signal"
@@ -378,6 +379,7 @@ let wakeup_intent_to_wire = function
   | Compaction_signal -> "compaction_signal"
   | Attention_result -> "attention_result"
   | Runtime_parameter_change -> "runtime_parameter_change"
+  | Turn_slot_released -> "turn_slot_released"
 ;;
 
 type wakeup_outcome =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -442,6 +442,7 @@ type wakeup_intent =
   | Compaction_signal
   | Attention_result
   | Runtime_parameter_change
+  | Turn_slot_released
 
 type wakeup_outcome =
   | Signaled

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -907,6 +907,20 @@ let initialize_owner_state_blocking
         ~sw
         ~operation_runner:
           (Some (Server_routes_http_keeper_stream.operation_runner ~state ~clock))
+        (* The chat lane is told when its dependency is ready
+           ([wake_operation_drain]); the autonomous lane had no equivalent and
+           rediscovered a freed slot only on its next keepalive cadence, which
+           RFC-0373 measured as up to five consecutive lost cycles. The Owner
+           fires this only when the freed slot is still unclaimed, so the wake
+           means a turn can start now. *)
+        ~on_turn_slot_released:
+          (Some
+             (fun ~keeper_name ->
+               ignore
+                 (Keeper_registry.wakeup_running
+                    ~intent:Keeper_registry.Turn_slot_released
+                    ~base_path:(Mcp_server.workspace_config state).base_path
+                    keeper_name)))
         (Mcp_server.workspace_config state)
     with
     | Ok count -> count

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -77,6 +77,7 @@ let with_ws name fn =
          Masc.Keeper_owner_registry.install_from_store
            ~sw
            ~operation_runner:None
+           ~on_turn_slot_released:None
            config
        with
        | Ok 1 -> ()

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -555,6 +555,7 @@ let test_event_operator_uses_exact_source_refs_across_unrelated_enqueues () =
           Masc.Keeper_owner_registry.install_from_store
             ~sw
             ~operation_runner:None
+           ~on_turn_slot_released:None
             config
         with
         | Ok _ -> ()
@@ -3099,7 +3100,7 @@ let prepare_config_sync_keeper ~sw config name =
   (match Masc.Keeper_meta_store.replace_snapshot config meta with
    | Ok () -> ()
    | Error error -> fail ("write meta: " ^ error));
-  match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+  match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
   | Ok _ -> ()
   | Error error ->
     fail (Masc.Keeper_owner_registry.install_error_to_string error)

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -42,7 +42,7 @@ let with_workspace f =
   Eio.Switch.on_release sw (fun () -> Masc_test_deps.cleanup_test_workspace dir);
   let config = Workspace_core.default_config dir in
   ignore (Workspace_core.init config ~agent_name:(Some "test"));
-  (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+  (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
    | Ok _ -> ()
    | Error error ->
      fail

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -65,7 +65,7 @@ let write_file path content =
 ;;
 
 let install_owner_inventory_exn ~sw config =
-  match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+  match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
   | Ok _ -> ()
   | Error error -> fail (Keeper_owner_registry.install_error_to_string error)
 ;;

--- a/test/test_keeper_compaction_outcome_counters.ml
+++ b/test/test_keeper_compaction_outcome_counters.ml
@@ -24,7 +24,7 @@ let with_workspace f =
        Eio.Switch.run @@ fun sw ->
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+       (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
         | Ok 0 -> ()
         | Ok count -> failf "unexpected initial owner count: %d" count
         | Error error ->

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -20,7 +20,7 @@ let with_owner_inventory config f =
   Eio_main.run @@ fun env ->
   if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
-  (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+  (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
    | Ok _ -> ()
    | Error error ->
      Alcotest.fail (Masc.Keeper_owner_registry.install_error_to_string error));
@@ -1126,6 +1126,7 @@ let test_status_surfaces_chat_operation_runtime () =
          Masc.Keeper_owner_registry.install_from_store
            ~sw
            ~operation_runner:None
+           ~on_turn_slot_released:None
            config
        with
        | Ok 1 -> ()

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -158,7 +158,7 @@ let test_grpc_pause_directive_records_reason () =
        let meta = make_meta keeper_name in
        Keeper_meta_store.replace_snapshot config meta
        |> Result.get_ok;
-       Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config
+       Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config
        |> Result.get_ok
        |> ignore;
        Keeper_registry.For_testing.clear ();

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -100,6 +100,7 @@ let start_owner_with_executor_ready
       (Option.map
          (fun execute -> Owner.{ ready = operation_ready; execute })
          operation_executor)
+    ~on_turn_slot_released:None
     ~keeper_name
     ~initial_meta
 ;;
@@ -809,6 +810,82 @@ let test_stopping_cancels_and_joins_autonomous_child () =
 
    The test states the blocked lane, not just the fact of blocking, because the
    holder's identity is what a fairness change would alter (RFC-0373). *)
+(* The release signal states availability, not completion. A listener woken by
+   "a turn ended" would find the slot already taken whenever a chat operation
+   was queued behind it, defer, and wait out its own cadence again — the exact
+   loop the notification exists to end. So the Owner fires it only after the
+   queued chat operation, if any, has been offered the slot and declined to
+   exist. Both directions are asserted here; only the negative one can tell the
+   two meanings apart. *)
+let test_turn_slot_release_signals_availability () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let released = ref 0 in
+  let path = Filename.temp_file "keeper-owner-slot-release-" ".sqlite3" in
+  Unix.unlink path;
+  Eio.Switch.on_release sw (fun () ->
+    if Sys.file_exists path then Unix.unlink path);
+  let chat_started, resolve_chat_started = Eio.Promise.create () in
+  let release_chat, resolve_release_chat = Eio.Promise.create () in
+  let execute ~sw:_ ~keeper_name:_ ~claim =
+    (match claim () with
+     | Error error -> fail (Owner.error_to_string error)
+     | Ok None -> fail "chat runner did not find its FIFO head"
+     | Ok (Some _) -> ());
+    Eio.Promise.resolve resolve_chat_started ();
+    Eio.Promise.await release_chat;
+    Owner.Operation_succeeded { outcome_ref = "turn:slot-release" }
+  in
+  let owner =
+    owner_ok
+      (Owner.start
+         ~sw
+         ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
+         ~operation_store_path:path
+         ~now:(fun () -> 42.0)
+         ~operation_runner:
+           (Some Owner.{ ready = (fun ~keeper_name:_ -> true); execute })
+         ~on_turn_slot_released:(Some (fun () -> incr released))
+         ~keeper_name:"slot-release"
+         ~initial_meta:(Some (make_meta "slot-release")))
+  in
+  let autonomous_started, resolve_autonomous_started = Eio.Promise.create () in
+  let release_autonomous, resolve_release_autonomous = Eio.Promise.create () in
+  let autonomous_result = Eio.Stream.create 1 in
+  Eio.Fiber.fork ~sw (fun () ->
+    Eio.Stream.add
+      autonomous_result
+      (Owner.run_autonomous_if_idle owner (fun () ->
+         Eio.Promise.resolve resolve_autonomous_started ();
+         Eio.Promise.await release_autonomous)));
+  Eio.Promise.await autonomous_started;
+  (* Queue the chat operation while the slot is held, so releasing it produces
+     the contested handoff: [Child_finished] frees the slot and offers it to the
+     queued operation in the same step. *)
+  ignore
+    (owner_ok
+       (Owner.submit_operation
+          owner
+          ~operation_id:(operation_id "kmsg-slot-release")
+          ~source:operation_source
+          ~input:(operation_input "queued behind autonomous")));
+  check int "a held slot signals nothing" 0 !released;
+  Eio.Promise.resolve resolve_release_autonomous ();
+  ignore (Eio.Stream.take autonomous_result);
+  Eio.Promise.await chat_started;
+  (* The chat operation took the slot in that handoff, so no turn can start and
+     no availability is owed. A signal here would mean "a turn ended", and its
+     listener would wake only to be told the slot is busy. *)
+  check
+    int
+    "a handoff claimed by chat owes no availability signal"
+    0
+    !released;
+  Eio.Promise.resolve resolve_release_chat ();
+  ignore (await_terminal owner (operation_id "kmsg-slot-release") 1_000);
+  check int "the slot left unclaimed signals once" 1 !released
+;;
+
 let test_chat_lane_holder_blocks_autonomous_admission () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
@@ -1252,6 +1329,7 @@ let test_startup_interrupts_running_without_requeue () =
               ~operation_store_path:path
               ~now:(fun () -> 20.0)
               ~operation_runner:None
+           ~on_turn_slot_released:None
               ~keeper_name:"interrupted-restart"
               ~initial_meta:(Some (make_meta "interrupted-restart")))
        in
@@ -1322,6 +1400,7 @@ let test_startup_queued_waits_for_runner_readiness () =
               ~now:(fun () -> 20.0)
               ~operation_runner:
                 (Some Owner.{ ready = (fun ~keeper_name:_ -> !ready); execute })
+              ~on_turn_slot_released:None
               ~keeper_name:"ready-after-registration"
               ~initial_meta:(Some (make_meta "ready-after-registration")))
        in
@@ -1768,7 +1847,7 @@ let test_root_inventory_loads_and_extends_exactly_once () =
        (match Keeper_meta_store.replace_snapshot config first with
         | Ok () -> ()
         | Error detail -> fail ("failed to seed owner meta: " ^ detail));
-       (match Owner_registry.install_from_store ~sw ~operation_runner:None config with
+       (match Owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
         | Ok count -> check int "strict startup owner count" 1 count
         | Error error -> fail (Owner_registry.install_error_to_string error));
        let loaded =
@@ -1836,7 +1915,7 @@ let test_agent_delegate_submits_owner_operation_without_waiting () =
        ignore (Workspace.init config ~agent_name:(Some "owner-tool-test"));
        let meta = make_meta "agent-operation-target" in
        Keeper_meta_store.replace_snapshot config meta |> Result.get_ok;
-       Owner_registry.install_from_store ~sw ~operation_runner:None config
+       Owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config
        |> Result.get_ok
        |> ignore;
        let ctx : _ Keeper_tool_surface.context =
@@ -1993,7 +2072,7 @@ let test_connector_submit_uses_owner_operation_idempotency () =
        (match Keeper_meta_store.replace_snapshot config meta with
         | Ok () -> ()
         | Error detail -> fail detail);
-       (match Owner_registry.install_from_store ~sw ~operation_runner:None config with
+       (match Owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
         | Ok 1 -> ()
         | Ok count -> failf "unexpected owner count %d" count
         | Error error -> fail (Owner_registry.install_error_to_string error));
@@ -2094,7 +2173,7 @@ let test_root_inventory_isolates_invalid_owner_snapshots () =
        Yojson.Safe.to_file
          (Filename.concat keepers_dir "inventory-path-name.json")
          (Keeper_meta_json.meta_to_json (make_meta "inventory-payload-name"));
-       (match Owner_registry.install_from_store ~sw ~operation_runner:None config with
+       (match Owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
         | Ok count -> check int "only valid owner starts" 1 count
         | Error error -> fail (Owner_registry.install_error_to_string error));
        (match Owner_registry.get ~base_path ~keeper_name:valid.name with
@@ -2147,7 +2226,7 @@ let test_registry_reads_owner_atomic_projection () =
        ignore (Workspace.init config ~agent_name:(Some "owner-projection-test"));
        let initial = make_meta "atomic-projection" in
        Keeper_meta_store.replace_snapshot config initial |> Result.get_ok;
-       Owner_registry.install_from_store ~sw ~operation_runner:None config
+       Owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config
        |> Result.get_ok
        |> ignore;
        let stale_entry =
@@ -2190,7 +2269,7 @@ let test_lifecycle_reservation_remains_owner_admission_authority () =
        (match Keeper_meta_store.replace_snapshot config meta with
         | Ok () -> ()
         | Error detail -> fail ("failed to seed reserved owner meta: " ^ detail));
-       (match Owner_registry.install_from_store ~sw ~operation_runner:None config with
+       (match Owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
         | Ok count -> check int "reserved owner count" 1 count
         | Error error -> fail (Owner_registry.install_error_to_string error));
        let token =
@@ -2242,7 +2321,7 @@ let test_create_waits_for_lifecycle_admission_before_installing_owner () =
        Eio.Switch.run @@ fun sw ->
        let config = Workspace.default_config base_path in
        ignore (Workspace.init config ~agent_name:(Some "owner-create-reservation-test"));
-       (match Owner_registry.install_from_store ~sw ~operation_runner:None config with
+       (match Owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
         | Ok count -> check int "empty owner inventory" 0 count
         | Error error -> fail (Owner_registry.install_error_to_string error));
        let meta = make_meta "create-reserved" in
@@ -2353,6 +2432,10 @@ let () =
             "chat lane holder blocks autonomous admission"
             `Quick
             test_chat_lane_holder_blocks_autonomous_admission
+        ; test_case
+            "turn slot release signals availability"
+            `Quick
+            test_turn_slot_release_signals_availability
         ; test_case
             "operation lifecycle is durable and projected"
             `Quick

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -63,7 +63,7 @@ let with_seeded_owner ?(registered = true) ?latched_reason ~paused ~generation f
          |> require_ok "read persisted Keeper metadata"
          |> require_some "persisted Keeper metadata"
        in
-       (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+       (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
         | Ok count -> Alcotest.(check int) "installed owner count" 1 count
         | Error error ->
           Alcotest.fail

--- a/test/test_keeper_paused_work_operator.ml
+++ b/test/test_keeper_paused_work_operator.ml
@@ -120,6 +120,7 @@ let with_source_terminal_lane f =
           Keeper_owner_registry.install_from_store
             ~sw:(current_switch ())
             ~operation_runner:None
+           ~on_turn_slot_released:None
             config
         with
         | Ok count -> Alcotest.(check int) "installed owner count" 1 count

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -103,6 +103,7 @@ let with_source_terminal_lane f =
           Keeper_owner_registry.install_from_store
             ~sw:(current_switch ())
             ~operation_runner:None
+           ~on_turn_slot_released:None
             config
         with
         | Ok count -> Alcotest.(check int) "installed owner count" 1 count

--- a/test/test_keeper_paused_work_transfer_transaction.ml
+++ b/test/test_keeper_paused_work_transfer_transaction.ml
@@ -132,7 +132,7 @@ let with_transfer_lane f =
            ~paused:false
        in
        let _, sw = current_test_context () in
-       (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+       (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
         | Ok count -> Alcotest.(check int) "installed owner count" 2 count
         | Error error ->
           Alcotest.fail (Keeper_owner_registry.install_error_to_string error));

--- a/test/test_keeper_shutdown_reconciliation_settlement.ml
+++ b/test/test_keeper_shutdown_reconciliation_settlement.ml
@@ -49,7 +49,7 @@ let with_workspace f =
             let config = Workspace.default_config base in
             let (_init_msg : string) = Workspace.init config ~agent_name:None in
             Eio.Switch.run @@ fun sw ->
-            (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+            (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
              | Ok 0 -> ()
              | Ok count -> failf "unexpected initial owner count: %d" count
              | Error error ->

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -950,6 +950,7 @@ let test_supervise_keepalive_wakes_ready_operation_drain () =
           Masc.Keeper_owner_registry.install_from_store
             ~sw
             ~operation_runner:(Some operation_runner)
+            ~on_turn_slot_released:None
             config
         with
         | Ok 1 -> ()

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -70,7 +70,7 @@ let with_owner_inventory config f =
   Eio_main.run @@ fun env ->
   if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
-  (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+  (match Masc.Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
    | Ok _ -> ()
    | Error error ->
      failwith (Masc.Keeper_owner_registry.install_error_to_string error));

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -51,7 +51,7 @@ let with_workspace f =
   Eio.Switch.on_release sw (fun () -> rm_rf dir);
   let config = Workspace_core.default_config dir in
   ignore (Workspace_core.init config ~agent_name:(Some "test"));
-  (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+  (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
    | Ok 0 -> ()
    | Ok count -> failf "expected empty owner inventory, got %d owners" count
    | Error error ->

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -294,7 +294,7 @@ let test_snapshot_keeps_context_unobserved_and_usage_separate () =
       init_runtime_default_for_snapshot base_dir;
       ignore (Workspace.init config ~agent_name:(Some "owner"));
       ignore (Workspace.bind_session config ~agent_name:"owner" ~capabilities:[] ());
-      (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+      (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
        | Ok _ -> ()
        | Error error ->
          Alcotest.fail (Keeper_owner_registry.install_error_to_string error));

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -99,7 +99,7 @@ let with_workspace f =
   Board_dispatch.init_jsonl ();
   let config = Workspace.default_config dir in
   ignore (Workspace.init config ~agent_name:(Some "test"));
-  (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None config with
+  (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
    | Ok _ -> ()
    | Error error -> fail (Keeper_owner_registry.install_error_to_string error));
   Executor_pool_ref.For_testing.with_pool

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1238,6 +1238,7 @@ let with_owner_inventory config f =
      Keeper_owner_registry.install_from_store
        ~sw
        ~operation_runner:None
+           ~on_turn_slot_released:None
        config
    with
    | Ok _ -> ()
@@ -1552,6 +1553,7 @@ let test_health_json_observes_owner_turn () =
              Keeper_owner_registry.install_from_store
                ~sw
                ~operation_runner:None
+           ~on_turn_slot_released:None
                config
            with
            | Ok _ -> ()
@@ -2928,6 +2930,7 @@ let test_health_json_keeps_in_flight_running_keeper_executable () =
              Keeper_owner_registry.install_from_store
                ~sw
                ~operation_runner:None
+           ~on_turn_slot_released:None
                config
            with
            | Ok _ -> ()


### PR DESCRIPTION
RFC-0373 (#28416) 이 굶김을 실측했고, #28441 이 슬롯이 지키는 불변식을 기록했습니다. 이 PR 은 남은 **비대칭 하나**를 닫습니다.

## 문제

두 레인이 "슬롯이 비었다"를 알게 되는 방식이 반대입니다.

| | 채팅 | 자율 |
|---|---|---|
| 알림 | `wake_operation_drain` | **없음** |
| 계약 문구 | *"the Owner never polls"* (`operation_runner`) | 폴링만 가능 |
| 빈 슬롯 인지 시점 | 즉시 | 다음 keepalive 주기 (~5분) |

같은 저장소가 "Owner 는 폴링하지 않는다"를 원칙으로 적어놓고 한쪽 레인에만 적용한 상태입니다.

그리고 **턴 종료로 키퍼를 깨우는 곳이 저장소에 하나도 없습니다.** `wakeup_running` 호출자는 전부 자극 생산자입니다 — discord, slack, fusion, completion authority, operator execute.

## 실측 (2026-08-12, 7 keeper)

| | |
|---|---|
| 자율 deferral | 50 |
| 그중 holder 가 chat | **50 / 50** |
| 최장 단일 보유 | **16.3분**, 연속 5사이클 손실 |
| sangsu 손실률 | **18.6%** (최저 keeper 는 0.8%) |

## 변경

keepalive 루프엔 이미 wake 기구가 있습니다 — `interruptible_sleep ~wakeup` 이 `Woken` 과 `Timeout` 을 구분합니다. 빠진 건 **울려줄 사람**뿐이었습니다.

```ocaml
val start
  :  ...
  -> on_turn_slot_released:(unit -> unit) option
```

### 신호의 의미가 핵심입니다

Owner 는 **큐에 있던 채팅 오퍼레이션이 빈 슬롯을 제안받은 뒤에도 여전히 비어 있을 때만** 울립니다. 즉 신호는 *"턴이 끝났다"* 가 아니라 ***"지금 턴을 시작할 수 있다"*** 입니다.

전자였다면 리스너는 깨어나서 슬롯이 이미 채팅에 넘어간 걸 발견하고 다시 defer 합니다 — 이 알림이 끝내려던 바로 그 루프입니다.

**admission 순서는 바뀌지 않습니다.** 채팅이 여전히 빈 슬롯을 먼저 받습니다. 이 PR 은 알림 격차만 닫고, 순서 문제는 RFC-0373 에 열어둡니다.

## 타입 선택 두 가지

- **`wakeup_intent` 에 `Turn_slot_released` 추가** — 기존 자극 intent 를 빌려 쓰면 intent 가 기록되는 곳에서 구분이 사라집니다. 변형 추가는 정의 2곳 + `to_string` 1곳으로 끝납니다.
- **필수 라벨 인자** (`operation_runner` 와 동일 관습) — optional 로 두면 warning 16 이 뜨고, 무엇보다 **30개 호출부가 기본값을 물려받는 대신 의도를 명시**하게 됩니다. 컴파일러가 전수를 강제했습니다.

## 콜백 안전성

Owner 파이버에서 실행되므로 예외가 나가면 모든 생산자가 의존하는 actor 가 죽습니다. 봉쇄하고 routine 로그만 남깁니다 — wake 하나를 잃으면 리스너 자신의 주기로 degrade 되며, 그건 이 알림이 없던 시절의 동작입니다.

## 검증

```
dune build --root . @check      exit 0
test_keeper_owner               38/38, exit 0
ocamlformat --check (6 파일)     clean
```

### 변이 검사

`Option.is_none (Atomic.get t.turn_in_flight)` 가드를 제거해 매 턴 종료마다 울리게 하면:

```
FAIL a handoff claimed by chat owes no availability signal
   Expected: `0'   Received: `1'
```

두 의미를 가르는 단언에서 정확히 실패합니다.

첫 시도 테스트는 이 변이를 **통과시켰습니다** — 채팅을 제출한 시점에 슬롯이 이미 비어 있어 `Submit_operation` 경로로 잡혔고, 문제의 `Child_finished` 핸드오프가 일어나지 않았기 때문입니다. 자율턴이 슬롯을 쥔 상태에서 채팅을 큐에 넣도록 다시 써서 실제 경합 핸드오프를 만들었습니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
