### PR TITLE
fix(verification): keep readable requests when one stored file cannot be read

### DIFF
--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -153,11 +153,27 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
 
 (* ── Snapshot assembly ──────────────────────────────── *)
 
-(** Load the raw verification request list from the supplied MASC base_path. *)
-let load_requests ~base_path () : V.verification_request list =
+(** Load the request scan from the supplied MASC base_path.
+
+    [failwith] is kept for the directory-level error, where the scan produced
+    no knowledge at all and a projection would be inventing one. A file the
+    schema cannot read is not that case: it arrives in [unreadable] and is
+    reported alongside the requests that did read. Before this, one such file
+    raised here and the whole endpoint answered 500, which named a single path
+    while hiding how many records the reader had actually rejected. *)
+let load_scan ~base_path () : V.request_scan =
   match V.list_requests base_path with
-  | Ok requests -> requests
+  | Ok scan -> scan
   | Error detail -> failwith detail
+
+(* Operator-facing shape for the files the reader could not parse. Emitted on
+   every projection that reads the store, so an unreadable record is visible
+   without having to correlate a counter against a log line. *)
+let unreadable_fields (scan : V.request_scan) =
+  [ ("unreadable_total", `Int (List.length scan.V.unreadable))
+  ; ( "unreadable"
+    , `List (List.map V.unreadable_to_yojson scan.V.unreadable) )
+  ]
 
 (** Filter by task_id when the caller requested a specific task. Empty
     string is treated as "no filter" to match the HTTP contract. *)
@@ -182,8 +198,8 @@ let fd_pressure_fields () = Keeper_fd_pressure.projection_fields ()
 (* Compute the request-listing projection from an already-loaded list.
    Factored out so [proof_compose] can share the disk scan between
    summary and request listing. *)
-let requests_json_of_requests ?task_id ~limit all : Yojson.Safe.t =
-  let filtered = filter_by_task_id all task_id in
+let requests_json_of_requests ?task_id ~limit (scan : V.request_scan) : Yojson.Safe.t =
+  let filtered = filter_by_task_id scan.V.readable task_id in
   let sorted = sort_desc filtered in
   let trimmed = take limit sorted in
   `Assoc
@@ -191,32 +207,35 @@ let requests_json_of_requests ?task_id ~limit all : Yojson.Safe.t =
      ; ("total", `Int (List.length filtered))
      ; ("requests", `List (List.map request_to_json trimmed))
      ]
+     @ unreadable_fields scan
      @ fd_pressure_fields ())
 
 let requests_json ~base_path ?task_id ?limit () : Yojson.Safe.t =
   let limit = clamp_limit limit in
-  let all = load_requests ~base_path () in
-  requests_json_of_requests ?task_id ~limit all
+  let scan = load_scan ~base_path () in
+  requests_json_of_requests ?task_id ~limit scan
 
 let summary_json ~base_path () : Yojson.Safe.t =
-  let all = load_requests ~base_path () in
+  let scan = load_scan ~base_path () in
   `Assoc
     ([ ("updated_at", `String (Masc_domain.now_iso ()))
-     ; ("total", `Int (List.length all))
+     ; ("total", `Int (List.length scan.V.readable))
      ]
+     @ unreadable_fields scan
      @ fd_pressure_fields ())
 
 (* Single-load companion for handlers that emit both projections side by side.
    One request-store scan feeds both projections. *)
 let proof_compose ~base_path ?limit () : Yojson.Safe.t * Yojson.Safe.t =
   let limit = clamp_limit limit in
-  let all = load_requests ~base_path () in
+  let scan = load_scan ~base_path () in
   let summary =
     `Assoc
       ([ ("updated_at", `String (Masc_domain.now_iso ()))
-       ; ("total", `Int (List.length all))
+       ; ("total", `Int (List.length scan.V.readable))
        ]
+       @ unreadable_fields scan
        @ fd_pressure_fields ())
   in
-  let requests = requests_json_of_requests ~limit all in
+  let requests = requests_json_of_requests ~limit scan in
   summary, requests

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -24,6 +24,18 @@ let criterion_of_yojson = function
   | `String _ -> Error "criterion must be a non-empty string"
   | _ -> Error "criterion must be a string"
 
+(** A stored file the current schema cannot read.
+
+    Kept as a value rather than collapsed into a failure. A request that cannot
+    be parsed says nothing about the requests beside it, so it must not decide
+    their fate: [list_requests] returns these alongside the ones it did read,
+    and the caller reports both. Nothing here is shaped to accept a superseded
+    schema — an unreadable file stays unreadable, it just stops being fatal. *)
+type unreadable_request = {
+  unreadable_path: string;
+  unreadable_detail: string;
+}
+
 (** Verification request *)
 type verification_request = {
   id: string;
@@ -32,6 +44,17 @@ type verification_request = {
   criteria: criterion list;
   worker: string;           (** Agent who produced the output *)
   created_at: float;
+}
+
+(** What one pass over the request directory found.
+
+    Both fields are reported. Returning only [readable] would drop the rest
+    silently; returning an error for the whole scan lets one file decide for
+    every other. The directory being unenumerable is still an error, because
+    then neither list is known. *)
+type request_scan = {
+  readable: verification_request list;
+  unreadable: unreadable_request list;
 }
 
 (** Serialization *)
@@ -176,6 +199,12 @@ let load_request base_path req_id =
   else
     Error (Printf.sprintf "Verification %s not found" req_id)
 
+let unreadable_to_yojson { unreadable_path; unreadable_detail } =
+  `Assoc
+    [ ("path", `String unreadable_path);
+      ("detail", `String unreadable_detail);
+    ]
+
 let list_requests_uncached base_path =
   let surface = "verification" in
   let observe_drop ~reason =
@@ -197,21 +226,26 @@ let list_requests_uncached base_path =
     Error (Printf.sprintf "verification request directory unreadable: %s" detail)
   | Ok files ->
     let files = List.filter (fun f -> Filename.check_suffix f ".json") files in
-    let rec load acc = function
-      | [] -> Ok (List.rev acc)
+    let rec load readable unreadable = function
+      | [] -> Ok { readable = List.rev readable; unreadable = List.rev unreadable }
       | file :: rest ->
         let id = Filename.chop_suffix file ".json" in
         (match load_request base_path id with
-         | Ok request -> load (request :: acc) rest
+         | Ok request -> load (request :: readable) unreadable rest
          | Error detail ->
            let path = Filename.concat dir file in
            report_drop
              ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
              ~path
              ~detail;
-           Error (Printf.sprintf "verification request unreadable at %s: %s" path detail))
+           load
+             readable
+             ({ unreadable_path = path; unreadable_detail = detail } :: unreadable)
+             rest)
     in
-    load [] files
+    load [] [] files
+
+let empty_scan = { readable = []; unreadable = [] }
 
 (* Public entry: read the current directory and every current-schema request.
    Content identity is not inferred from filesystem timestamps. *)
@@ -219,7 +253,7 @@ let list_requests base_path =
   let dir = verifications_dir base_path in
   match verification_directory dir with
   | Error detail -> Error detail
-  | Ok Missing_directory -> Ok []
+  | Ok Missing_directory -> Ok empty_scan
   | Ok Present_directory -> list_requests_uncached base_path
 
 (** High-level API *)

--- a/lib/verification.mli
+++ b/lib/verification.mli
@@ -13,6 +13,16 @@ val equal_criterion : criterion -> criterion -> bool
 val criterion_to_yojson : criterion -> Yojson.Safe.t
 val criterion_of_yojson : Yojson.Safe.t -> (criterion, string) result
 
+(** A stored file the current schema cannot read, carried as a value so one
+    such file does not decide the fate of the requests beside it. Nothing here
+    accepts a superseded schema — an unreadable file stays unreadable. *)
+type unreadable_request = {
+  unreadable_path: string;
+  unreadable_detail: string;
+}
+
+val unreadable_to_yojson : unreadable_request -> Yojson.Safe.t
+
 type verification_request = {
   id: string;
   task_id: string;
@@ -20,6 +30,14 @@ type verification_request = {
   criteria: criterion list;
   worker: string;
   created_at: float;
+}
+
+(** What one pass over the request directory found. Callers report both fields:
+    [readable] alone is a silent drop, and failing the scan over one entry in
+    [unreadable] loses every readable request with it. *)
+type request_scan = {
+  readable: verification_request list;
+  unreadable: unreadable_request list;
 }
 
 (** {1 Serialization} *)
@@ -38,9 +56,16 @@ val save_request : string -> verification_request -> (string, string) result
 val delete_request : string -> string -> (unit, string) result
 
 val load_request : string -> string -> (verification_request, string) result
-val list_requests : string -> (verification_request list, string) result
-(** Missing storage is an empty list. An unreadable directory or malformed
-    request is an [Error]; the caller never receives a partial list. *)
+val list_requests : string -> (request_scan, string) result
+(** Missing storage is an empty scan. A file the schema cannot read lands in
+    [unreadable] with its path and the parse detail, and every file that did
+    read lands in [readable] — one bad file no longer costs the rest. [Error]
+    is reserved for the directory itself being unenumerable, where neither
+    list is known.
+
+    Each unreadable entry still increments the [persistence_read_drops] counter
+    at read time, so the metric keeps meaning "this many records did not make
+    it into the projection". *)
 
 (** {1 High-level API} *)
 

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=662
+UNWIRED_BASELINE=661
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -56,6 +56,7 @@ normal_targets=(
   @test/runtest-test_keeper_gate_replay
   @test/runtest-test_workspace
   @test/runtest-test_verification
+  @test/runtest-test_dashboard_verification
   @test/runtest-test_tool_schema_constraint_enforcement
   @test/runtest-test_keeper_artifact_read_request
   @test/runtest-test_tool_input_validation

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -552,6 +552,60 @@ let string_field name j =
   | `String value -> value
   | _ -> Alcotest.fail (Printf.sprintf "%s not string" name)
 
+(* A stored file the schema cannot read must not take the projection with it.
+
+   This is the shape that reached production: a producer removed on 2026-08-07
+   left 171 records whose [criteria] entries are objects rather than strings,
+   and the projection raised on the first of them, so /api/v1/dashboard/proof
+   answered 500 for five days while 122 readable records sat beside them. The
+   fixture writes that exact shape rather than truncated JSON, so the case
+   fails if the projection ever goes back to reading the store all-or-nothing. *)
+let superseded_criteria_record =
+  {|{"id":"vrf-superseded","task_id":"t-superseded","output":null,|}
+  ^ {|"criteria":[{"type":"custom","description":"Task scope satisfied"}],|}
+  ^ {|"worker":"w","created_at":1.0}|}
+
+let test_projection_survives_an_unreadable_record () =
+  with_temp_base_path (fun base_path ->
+    let readable =
+      create_pending_request ~base_path ~task_id:"t-readable" ~worker:"w"
+        ~criteria:[ "criterion" ] ~evidence:[]
+    in
+    let dir = Filename.concat base_path ".masc/verifications" in
+    Fs_compat.save_file
+      (Filename.concat dir "vrf-superseded.json")
+      superseded_criteria_record;
+
+    let requests = D.requests_json ~base_path () in
+    Alcotest.(check int)
+      "the readable request is still projected"
+      1
+      (int_field "total" requests);
+    Alcotest.(check int)
+      "the unreadable record is counted, not swallowed"
+      1
+      (int_field "unreadable_total" requests);
+    (match member "unreadable" requests with
+     | `List [ entry ] ->
+       Alcotest.(check bool)
+         "the unreadable entry names its file"
+         true
+         (Astring.String.is_infix ~affix:"vrf-superseded.json"
+            (string_field "path" entry));
+       Alcotest.(check bool)
+         "the unreadable entry carries why it could not be read"
+         false
+         (String.equal (String.trim (string_field "detail" entry)) "")
+     | _ -> Alcotest.fail "unreadable is not a one-element list");
+
+    (* The summary projection reads the same store and must agree. *)
+    let summary = D.summary_json ~base_path () in
+    Alcotest.(check int) "summary counts the readable request"
+      1 (int_field "total" summary);
+    Alcotest.(check int) "summary counts the unreadable record"
+      1 (int_field "unreadable_total" summary);
+    ignore readable)
+
 let test_requests_and_summary_remain_available_after_fd_observation () =
   with_temp_base_path (fun base_path ->
     let _ =
@@ -620,6 +674,8 @@ let () =
         test_requests_json_snapshot_projection_edges;
       Alcotest.test_case "fd pressure remains observation-only" `Quick
         test_requests_and_summary_remain_available_after_fd_observation;
+      Alcotest.test_case "survives an unreadable record" `Quick
+        test_projection_survives_an_unreadable_record;
     ];
     "summary_json", [
       Alcotest.test_case "immutable submission count" `Quick

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -50,10 +50,20 @@ let with_eio_temp_dir_and_clock f =
     ~finally:Fs_compat.clear_fs
     (fun () -> with_temp_dir (f ~clock:(Eio.Stdenv.clock env)))
 
-let list_requests_exn base_path =
+let scan_exn base_path =
   match V.list_requests base_path with
-  | Ok requests -> requests
+  | Ok scan -> scan
   | Error detail -> Alcotest.fail detail
+;;
+
+(* Most cases here care only about the requests that read. Asserting the scan
+   found nothing unreadable keeps them honest: without it a case could pass
+   while quietly rejecting the record it meant to be reading. *)
+let list_requests_exn base_path =
+  let scan = scan_exn base_path in
+  Alcotest.(check int)
+    "no unreadable requests" 0 (List.length scan.V.unreadable);
+  scan.V.readable
 ;;
 
 let ensure_keeper_meta config name =
@@ -1335,7 +1345,14 @@ let test_request_path_uses_current_store () =
       (Filename.concat (active_verifications_dir base_path) (req_id ^ ".json"))
       (VS.request_path base_path req_id))
 
-let test_list_requests_rejects_bad_entry_with_metric () =
+(* A file the schema cannot read is reported, not silently skipped, and it does
+   not take the readable requests down with it.
+
+   The earlier contract failed the whole scan here. That kept the failure loud
+   but made it total: 171 records written by a producer removed on 2026-08-07
+   were enough to answer /api/v1/dashboard/proof with 500 for five days, naming
+   one path while saying nothing about the other 170 or the 122 that read fine. *)
+let test_list_requests_isolates_bad_entry_with_metric () =
   with_temp_dir (fun base_path ->
     let _ = V.create_request ~base_path ~task_id:"t1"
         ~output:`Null ~criteria:[] ~worker:"a" () in
@@ -1345,15 +1362,54 @@ let test_list_requests_rejects_bad_entry_with_metric () =
       persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
     in
     (match V.list_requests base_path with
-     | Ok _ -> Alcotest.fail "malformed request yielded a partial list"
-     | Error detail ->
-       Alcotest.(check bool)
-         "malformed path is named"
-         true
-         (Astring.String.is_infix ~affix:"broken.json" detail));
+     | Error detail -> Alcotest.fail detail
+     | Ok scan ->
+       Alcotest.(check int)
+         "the readable request survives its broken neighbour"
+         1
+         (List.length scan.V.readable);
+       Alcotest.(check int)
+         "the broken file is reported, not dropped"
+         1
+         (List.length scan.V.unreadable);
+       (match scan.V.unreadable with
+        | [ entry ] ->
+          Alcotest.(check bool)
+            "malformed path is named"
+            true
+            (Astring.String.is_infix ~affix:"broken.json" entry.V.unreadable_path);
+          Alcotest.(check bool)
+            "the parse detail is carried, not discarded"
+            false
+            (String.equal (String.trim entry.V.unreadable_detail) "")
+        | entries ->
+          Alcotest.failf "expected exactly one unreadable entry, got %d"
+            (List.length entries)));
     Alcotest.(check (float 0.1)) "broken file increments metric" 1.0
       (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
        -. before))
+
+(* The scan reports every unreadable file, not just the one it stopped at. The
+   old contract could only ever name one, which is what made a 171-record
+   problem look like a 1-record problem. *)
+let test_list_requests_reports_every_unreadable_entry () =
+  with_temp_dir (fun base_path ->
+    let _ = V.create_request ~base_path ~task_id:"t1"
+        ~output:`Null ~criteria:[] ~worker:"a" () in
+    let dir = active_verifications_dir base_path in
+    Fs_compat.save_file (Filename.concat dir "broken-a.json") "{not-json";
+    Fs_compat.save_file (Filename.concat dir "broken-b.json") "{also-not-json";
+    (* Well-formed JSON that the request schema still rejects — the shape that
+       actually accumulated on disk, as opposed to a truncated write. *)
+    Fs_compat.save_file (Filename.concat dir "broken-c.json")
+      {|{"id":"x","task_id":"t","output":null,"criteria":[{"type":"custom","description":"d"}],"worker":"w","created_at":1.0}|};
+    match V.list_requests base_path with
+    | Error detail -> Alcotest.fail detail
+    | Ok scan ->
+      Alcotest.(check int)
+        "readable request still returned" 1 (List.length scan.V.readable);
+      Alcotest.(check int)
+        "all three unreadable files reported" 3 (List.length scan.V.unreadable))
 
 let test_list_requests_rereads_current_request_content () =
   with_temp_dir (fun base_path ->
@@ -1375,9 +1431,22 @@ let test_list_requests_rereads_current_request_content () =
       1
       (List.length (list_requests_exn base_path));
     Fs_compat.save_file (VS.request_path base_path request.id) "{not-json";
+    (* The point of the case is that the second scan reads the file again
+       instead of reusing the first result. It used to observe that through the
+       scan failing; now the same re-read shows as the record moving out of
+       [readable] and into [unreadable], which says where it went as well as
+       that it moved. *)
     match V.list_requests base_path with
-    | Ok _ -> Alcotest.fail "changed malformed request reused an earlier list"
-    | Error _ -> ())
+    | Error detail -> Alcotest.fail detail
+    | Ok scan ->
+      Alcotest.(check int)
+        "changed malformed request reused an earlier list"
+        0
+        (List.length scan.V.readable);
+      Alcotest.(check int)
+        "the rewritten file is accounted for"
+        1
+        (List.length scan.V.unreadable))
 
 let create_evidence_request ~base_path ~request_id ~artifact_path =
   let profile_path =
@@ -2253,8 +2322,10 @@ let () =
         test_verifications_dir_resolves_active_store;
       Alcotest.test_case "request path uses current store" `Quick
         test_request_path_uses_current_store;
-      Alcotest.test_case "list requests rejects bad entry with metric" `Quick
-        test_list_requests_rejects_bad_entry_with_metric;
+      Alcotest.test_case "list requests isolates bad entry with metric" `Quick
+        test_list_requests_isolates_bad_entry_with_metric;
+      Alcotest.test_case "list requests reports every unreadable entry" `Quick
+        test_list_requests_reports_every_unreadable_entry;
       Alcotest.test_case "list requests rereads current content" `Quick
         test_list_requests_rereads_current_request_content;
       Alcotest.test_case "submitted evidence authority-scoped and contained" `Quick


### PR DESCRIPTION
Fixes #28452.

## The broken surface

`GET /api/v1/dashboard/proof` has answered 500 since 2026-08-07. It is
documented (`docs/DASHBOARD-INTEGRATION.md:189`) and its registration is pinned
by `test/test_dashboard_http_core.ml:1439`.

```
500 Internal Server Error: Failure("verification request unreadable at
.../vrf-e4610d9ae13dbebba7ff83d1f3ec6b85.json: criteria[0]: criterion must be a string")
```

One file is named. 293 are involved:

| `criteria` element shape | records | last written |
|---|---|---|
| `dict` — rejected | 171 | 2026-08-07 08:39 UTC |
| `empty-list` — accepted | 118 | 2026-08-12 14:11 UTC |
| `str` — accepted | 4 | 2026-08-12 15:24 UTC |

The shapes separate cleanly in time — 5.3 days of accepted writes follow the
last rejected one with none interleaved — and `workspace_task_classify.ml:83-89`
documents that producer being removed on purpose. So there is no live
writer/reader disagreement to reconcile. There is a store holding records the
current code no longer produces, and a reader that let any one of them decide
for the other 292.

## What was actually wrong

`list_requests_uncached` reported a *drop* and then aborted:

```ocaml
report_drop ~reason:...entry_load_error ...;
Error (Printf.sprintf "verification request unreadable at %s: %s" path detail)
```

`persistence_read_drops` incremented once, which reads as "one record did not
make it into the projection". None did. The counter answered a question it was
not measuring, and that is why a five-day outage on a documented endpoint went
unnoticed.

The abort came from #27949, and its goal is right: never serve a partial list
silently — the same class as #28410. The enforcement is what is wrong. "Do not
drop silently" was implemented as "discard everything", so a store with one bad
record reports strictly *less* than a store with none: the operator went from
122 records plus a named problem to a stack trace.

## Change

The scan reports both outcomes instead of choosing between silence and total
failure:

```ocaml
type unreadable_request = { unreadable_path : string; unreadable_detail : string }

type request_scan = {
  readable   : verification_request list;
  unreadable : unreadable_request list;
}
```

`list_requests : string -> (request_scan, string) result`. `Error` is now
reserved for the directory being unenumerable, where neither list is known.
Each unreadable entry still increments `persistence_read_drops` at read time,
so that metric goes back to meaning what its name says.

`requests_json`, `summary_json`, and `proof_compose` emit `unreadable_total`
and `unreadable[]` (path + parse detail per file). An operator now sees 122
readable and 171 unreadable with filenames, rather than a 500 quoting one path.

No parser is added for the object shape. That would be migration code for a
producer already removed, and it would leave the next malformed record —
truncated write, disk corruption, a future schema change — failing identically.
The isolation holds regardless of *why* a file cannot be read.

## Tests

`test_verification` 46/46, `test_dashboard_verification` 12/12.

- `list requests isolates bad entry with metric` — replaces the case that
  pinned the abort; the readable request survives, the broken file is named and
  carries its parse detail, and the counter still increments.
- `list requests reports every unreadable entry` — the old contract could only
  ever name one file, which is what made a 171-record problem look like a
  1-record problem. Fixture includes well-formed JSON the request schema still
  rejects, i.e. the shape actually on disk, not just truncated writes.
- `survives an unreadable record` (dashboard) — endpoint-level: the projection
  returns instead of raising, and reports both counts.
- `list requests rereads current request content` kept its intent. It observed
  "the scan is not memoized" through the scan failing; it now observes the
  record moving from `readable` to `unreadable`, which says where it went as
  well as that it moved.
- `list_requests_exn` asserts the scan found nothing unreadable, so an existing
  case cannot pass while quietly rejecting the record it means to read.

Mutation check — reverting `load` to abort on the first unreadable entry:

```
test_verification            4 [FAIL]
test_dashboard_verification  1 [FAIL]  survives an unreadable record
```

Restored: both suites green (forced rerun, 12 tests run, not a cache hit).

## CI wiring

`test_dashboard_verification` was declared in `test/dune` but absent from
`scripts/ci-run-focused-tests.sh`, so the regression test would have compiled
and never run. Added; CI targets 197 -> 198, unwired baseline 662 -> 661, which
`audit-ci-test-targets.sh` asks for by name when the count falls.

```
[ci-test-targets] OK - 198 CI targets, all declared in Dune
[ci-test-targets] OK - 661 suites unwired, at baseline
```

## Not in scope

- The 171 stored records stay on disk. They are now reported per file rather
  than fatal; deciding whether to prune them is a separate operational call.
- `dune build @fmt` diffs are 13 pre-existing `dune` files, none touched here.

RFC-WAIVED: verification store reader and a dashboard read projection; no
credential, identity, operator control-plane, sandbox, hook, or workflow
surface is touched.
