### PR TITLE
fix(keeper): send the probe's tools through the wire encoder, not the storage one

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -174,6 +174,26 @@
  (package masc)
  (libraries masc masc.dashboard masc_core fs_compat unix yojson eio eio_main))
 
+;; RFC-0374 capability probe runner.  Answers "can runtime R reach tool T"
+;; without writing to the keeper's chat, checkpoint, or memory, which is what
+;; made the 2026-08-12 sweep measure its own traffic (masc#28414).
+
+(executable
+ (name keeper_capability_probe_cli)
+ (modules keeper_capability_probe_cli)
+ (public_name masc-keeper-capability-probe)
+ (package masc)
+ (libraries
+  masc
+  masc.server
+  masc.runtime
+  masc.fusion_core
+  masc_eio_context
+  unix
+  yojson
+  eio
+  eio_main))
+
 ;; Deployment preflight helper.  The shell gate delegates runtime lease
 ;; ownership and schedule signal decoding to the same OCaml authorities used
 ;; by the server instead of reimplementing either contract in shell.

--- a/bin/keeper_capability_probe_cli.ml
+++ b/bin/keeper_capability_probe_cli.ml
@@ -1,0 +1,328 @@
+(* Operator entry point for the RFC-0374 probe lane.
+
+   [Keeper_capability_probe] exists so that asking "can runtime R reach tool T"
+   stops costing a durable keeper turn: on 2026-08-12 the probe traffic itself
+   entered the keeper's memory as a fact prescribing non-response, after which
+   a zero answer no longer distinguished "unreachable" from "declined"
+   (masc#28414). The lane writes nothing. It was, however, reachable only from
+   OCaml, so the measurement it was built for still could not be run. This is
+   that runner.
+
+   Output is JSON Lines on stdout, one object per probe, so a sweep can be
+   replayed and diffed. Human-readable progress goes to stderr. *)
+
+module Probe = Masc.Keeper_capability_probe
+
+let usage =
+  {|Usage: masc-keeper-capability-probe [OPTIONS]
+
+Options:
+  --runtime ID       Runtime to probe (repeatable; default: all Agent Core runtimes)
+  --tool NAME        Tool to probe (repeatable; required unless --list-*)
+  --repeat N         Probe turns per (runtime, tool) pair (default 1)
+  --prompt TEXT      Prompt template; {tool} is replaced by the model-facing name
+  --base-path PATH   Runtime workspace root (default: MASC_BASE_PATH)
+  --surface-only     Resolve the tool surface offline; send no provider request
+  --list-runtimes    Print every runtime id and its lane, then exit
+  --list-tools       Print every model-facing tool name, then exit
+  -h, --help         Print this help
+
+The surface pass runs first for every tool and is free. A tool that is not
+projected is reported and never dispatched: spending a turn on it would
+measure the projection policy, not the runtime.
+|}
+
+let default_prompt =
+  "Call the tool named {tool} exactly once, with any arguments that satisfy \
+   its schema. Reply with the tool call only — no explanation, no preamble."
+
+type config =
+  { runtimes : string list
+  ; tools : string list
+  ; repeat : int
+  ; prompt : string
+  ; base_path : string option
+  ; surface_only : bool
+  ; list_runtimes : bool
+  ; list_tools : bool
+  }
+
+let initial_config =
+  { runtimes = []
+  ; tools = []
+  ; repeat = 1
+  ; prompt = default_prompt
+  ; base_path = Sys.getenv_opt "MASC_BASE_PATH"
+  ; surface_only = false
+  ; list_runtimes = false
+  ; list_tools = false
+  }
+;;
+
+let error msg =
+  prerr_endline msg;
+  prerr_endline usage;
+  exit 1
+;;
+
+let rec parse_args argv index cfg =
+  if index >= Array.length argv
+  then cfg
+  else (
+    let need name =
+      if index + 1 >= Array.length argv then error (Printf.sprintf "%s needs a value" name);
+      argv.(index + 1)
+    in
+    match argv.(index) with
+    | "-h" | "--help" ->
+      print_endline usage;
+      exit 0
+    | "--surface-only" -> parse_args argv (index + 1) { cfg with surface_only = true }
+    | "--list-runtimes" -> parse_args argv (index + 1) { cfg with list_runtimes = true }
+    | "--list-tools" -> parse_args argv (index + 1) { cfg with list_tools = true }
+    | "--runtime" ->
+      parse_args argv (index + 2) { cfg with runtimes = cfg.runtimes @ [ need "--runtime" ] }
+    | "--tool" -> parse_args argv (index + 2) { cfg with tools = cfg.tools @ [ need "--tool" ] }
+    | "--prompt" -> parse_args argv (index + 2) { cfg with prompt = need "--prompt" }
+    | "--base-path" ->
+      parse_args argv (index + 2) { cfg with base_path = Some (need "--base-path") }
+    | "--repeat" ->
+      let raw = need "--repeat" in
+      (match int_of_string_opt raw with
+       | Some n when n > 0 -> parse_args argv (index + 2) { cfg with repeat = n }
+       | _ -> error (Printf.sprintf "invalid --repeat: %S" raw))
+    | other -> error (Printf.sprintf "unknown argument: %S" other))
+;;
+
+(* [{tool}] rather than [%s]: the template is operator-supplied, and a stray
+   percent in a hand-written prompt would otherwise raise at format time. *)
+let render_prompt template ~tool =
+  let placeholder = "{tool}" in
+  let plen = String.length placeholder in
+  let buf = Buffer.create (String.length template + String.length tool) in
+  let rec go i =
+    if i >= String.length template
+    then ()
+    else if i + plen <= String.length template && String.sub template i plen = placeholder
+    then (
+      Buffer.add_string buf tool;
+      go (i + plen))
+    else (
+      Buffer.add_char buf template.[i];
+      go (i + 1))
+  in
+  go 0;
+  Buffer.contents buf
+;;
+
+let lane_label runtime_id =
+  match Runtime.get_runtime_by_id runtime_id with
+  | None -> "unresolvable"
+  | Some rt -> Runtime_execution.label rt.Runtime.execution
+;;
+
+let is_agent_core runtime_id =
+  match Runtime.get_runtime_by_id runtime_id with
+  | None -> false
+  | Some rt ->
+    (match rt.Runtime.execution with
+     | Runtime_execution.Agent_core _ -> true
+     | Runtime_execution.Codex_app_server _
+     | Runtime_execution.Antigravity_cli _
+     | Runtime_execution.Claude_code _ -> false)
+;;
+
+let verdict_json (verdict : Probe.verdict) =
+  match verdict with
+  | Probe.Projected { model_facing_name } ->
+    `Assoc [ "kind", `String "projected"; "model_facing_name", `String model_facing_name ]
+  | Probe.Not_a_descriptor -> `Assoc [ "kind", `String "not_a_descriptor" ]
+  | Probe.Operator_only -> `Assoc [ "kind", `String "operator_only" ]
+  | Probe.Aliased { projected_by } ->
+    `Assoc [ "kind", `String "aliased"; "projected_by", `String projected_by ]
+  | Probe.Withheld_by_schema_error { errors } ->
+    `Assoc
+      [ "kind", `String "withheld_by_schema_error"
+      ; "errors", `List (List.map (fun e -> `String e) errors)
+      ]
+;;
+
+let invocation_json (invocation : Probe.invocation) =
+  match invocation with
+  | Probe.Tool_invoked { tool; elapsed_s } ->
+    `Assoc
+      [ "kind", `String "tool_invoked"
+      ; "tool", `String tool
+      ; "elapsed_s", `Float elapsed_s
+      ]
+  | Probe.Other_tool_invoked { requested; invoked; elapsed_s } ->
+    `Assoc
+      [ "kind", `String "other_tool_invoked"
+      ; "requested", `String requested
+      ; "invoked", `List (List.map (fun t -> `String t) invoked)
+      ; "elapsed_s", `Float elapsed_s
+      ]
+  | Probe.Replied_no_tool { reply_bytes; elapsed_s } ->
+    `Assoc
+      [ "kind", `String "replied_no_tool"
+      ; "reply_bytes", `Int reply_bytes
+      ; "elapsed_s", `Float elapsed_s
+      ]
+  | Probe.Provider_rejected { detail } ->
+    `Assoc [ "kind", `String "provider_rejected"; "detail", `String detail ]
+;;
+
+let invocation_error_json (err : Probe.invocation_error) =
+  match err with
+  | Probe.Not_on_surface verdict ->
+    `Assoc [ "kind", `String "not_on_surface"; "verdict", verdict_json verdict ]
+  | Probe.Unresolvable_runtime detail ->
+    `Assoc [ "kind", `String "unresolvable_runtime"; "detail", `String detail ]
+  | Probe.Not_agent_core_lane lane ->
+    `Assoc [ "kind", `String "not_agent_core_lane"; "lane", `String lane ]
+  | Probe.Tool_schema_rejected detail ->
+    `Assoc [ "kind", `String "tool_schema_rejected"; "detail", `String detail ]
+;;
+
+let emit json =
+  print_endline (Yojson.Safe.to_string json);
+  flush stdout
+;;
+
+let run_surface_pass ~tools =
+  List.map
+    (fun tool ->
+      let verdict = Probe.probe_surface ~tool in
+      emit
+        (`Assoc
+          [ "phase", `String "surface"
+          ; "tool", `String tool
+          ; "verdict", verdict_json verdict
+          ]);
+      tool, verdict)
+    tools
+;;
+
+let run_invocation_pass ~sw ~net ~clock ~cfg ~surface =
+  List.iter
+    (fun runtime_id ->
+      List.iter
+        (fun (tool, verdict) ->
+          match verdict with
+          | Probe.Projected { model_facing_name } ->
+            for attempt = 1 to cfg.repeat do
+              let prompt = render_prompt cfg.prompt ~tool:model_facing_name in
+              let started = Unix.gettimeofday () in
+              let outcome =
+                Probe.probe_invocation
+                  ~sw
+                  ~net
+                  ~clock
+                  ~now:Unix.gettimeofday
+                  ~runtime_id
+                  ~tool
+                  ~prompt
+                  ()
+              in
+              let wall_s = Unix.gettimeofday () -. started in
+              let body =
+                match outcome with
+                | Ok invocation -> `Assoc [ "ok", invocation_json invocation ]
+                | Error err -> `Assoc [ "error", invocation_error_json err ]
+              in
+              emit
+                (`Assoc
+                  [ "phase", `String "invocation"
+                  ; "runtime", `String runtime_id
+                  ; "lane", `String (lane_label runtime_id)
+                  ; "tool", `String tool
+                  ; "model_facing_name", `String model_facing_name
+                  ; "attempt", `Int attempt
+                  ; "wall_s", `Float wall_s
+                  ; "outcome", body
+                  ]);
+              Printf.eprintf
+                "  %-46s %-22s #%d  %s\n%!"
+                runtime_id
+                tool
+                attempt
+                (match outcome with
+                 | Ok invocation -> Probe.invocation_to_string invocation
+                 | Error err -> Probe.invocation_error_to_string err)
+            done
+          | Probe.Not_a_descriptor
+          | Probe.Operator_only
+          | Probe.Aliased _
+          | Probe.Withheld_by_schema_error _ ->
+            (* Reported by the surface pass already. Dispatching anyway would
+               measure the projection policy rather than the runtime. *)
+            ())
+        surface)
+    cfg.runtimes
+;;
+
+let () =
+  let cfg = parse_args Sys.argv 1 initial_config in
+  let base_path =
+    match cfg.base_path with
+    | Some path when String.trim path <> "" -> String.trim path
+    | _ -> error "--base-path or MASC_BASE_PATH is required"
+  in
+  let config_path = Masc.Fusion_config_loader.runtime_toml_path ~base_path in
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  Eio_context.set_env env;
+  Eio_context.set_clock clock;
+  (* The server installs the deployment capability overlay at boot and a CLI
+     does not, so without this an Agent Core runtime that exists in
+     runtime.toml still resolves as "absent from the AGENT_CORE capability
+     catalog". fusion_run.ml carries the same call for the same reason. *)
+  ignore
+    (Server_runtime_bootstrap.configure_agent_core_model_catalog_overlay
+       ~config_root:(Filename.dirname config_path)
+       ()
+     : string option);
+  (match Runtime.init_default ~config_path with
+   | Error msg ->
+     Printf.eprintf "runtime init failed (%s): %s\n" config_path msg;
+     exit 1
+   | Ok () -> ());
+  if cfg.list_runtimes
+  then (
+    List.iter
+      (fun id -> Printf.printf "%s\t%s\n" id (lane_label id))
+      (Runtime.get_runtime_ids ());
+    exit 0);
+  if cfg.list_tools
+  then (
+    List.iter print_endline (Probe.model_facing_names ());
+    exit 0);
+  if cfg.tools = [] then error "at least one --tool is required";
+  let cfg =
+    if cfg.runtimes <> []
+    then cfg
+    else { cfg with runtimes = List.filter is_agent_core (Runtime.get_runtime_ids ()) }
+  in
+  let surface = run_surface_pass ~tools:cfg.tools in
+  if not cfg.surface_only
+  then (
+    let projected =
+      List.length
+        (List.filter
+           (fun (_, v) ->
+             match v with
+             | Probe.Projected _ -> true
+             | _ -> false)
+           surface)
+    in
+    Printf.eprintf
+      "probing %d runtime(s) x %d projected tool(s) x %d attempt(s)\n%!"
+      (List.length cfg.runtimes)
+      projected
+      cfg.repeat;
+    run_invocation_pass ~sw ~net ~clock ~cfg ~surface)
+;;

--- a/lib/keeper/keeper_capability_probe.ml
+++ b/lib/keeper/keeper_capability_probe.ml
@@ -129,17 +129,26 @@ let invocation_error_to_string = function
   | Tool_schema_rejected detail -> Printf.sprintf "tool schema rejected: %s" detail
 ;;
 
-(* The wire form has to be the one a real turn sends, so it goes through the
-   same [tool_schema_to_json] that [Agent_turn.prepare_tools] uses. Hand-rolling
-   the JSON here would make a probe that passes while the real turn's encoding
-   has drifted -- the failure this module exists to prevent. *)
+(* The wire form has to be the one a real turn sends, so it goes through
+   [Tool.wire_json_of_schema] -- the function [Agent_turn.prepare_tools]
+   reaches through [Tool.schema_to_json]. Hand-rolling the JSON here would make
+   a probe that passes while the real turn's encoding has drifted, the failure
+   this module exists to prevent.
+
+   The first version of this used [Types.tool_schema_to_json], on the strength
+   of a comment asserting it was the same encoder. It is not: that one is the
+   storage encoding and emits "parameters" alongside "input_schema", which the
+   OpenAI backend rejects as mutually exclusive before the request leaves the
+   process. Every live probe returned [Provider_rejected] -- indistinguishable
+   at a glance from a quota refusal, and the offline tests could not see it
+   because none of them reach the encoder's consumer. *)
 let wire_tool_of_schema (schema : Masc_domain.tool_schema) =
   Agent_core.Types.tool_schema_of_input_schema
     ~name:schema.name
     ~description:schema.description
     ~input_schema:schema.input_schema
     ()
-  |> Result.map Agent_core.Types.tool_schema_to_json
+  |> Result.map Agent_core.Tool.wire_json_of_schema
 ;;
 
 let tool_use_names (response : Agent_core.Types.api_response) =

--- a/packages/agent_core/lib/base/tool.ml
+++ b/packages/agent_core/lib/base/tool.ml
@@ -120,23 +120,25 @@ let descriptor_to_yojson = function
 ;;
 
 (** Schema to JSON *)
-let schema_to_json tool =
+let wire_json_of_schema (schema : Types.tool_schema) =
   `Assoc
-    ([ "name", `String tool.schema.name
-     ; "description", `String tool.schema.description
+    ([ "name", `String schema.name
+     ; "description", `String schema.description
        (* The authoritative schema goes to the provider verbatim. Deriving it
           back from [parameters] would drop minimum/maximum/default/enum and
           nested properties, which the model then never sees. *)
      ; ( "input_schema"
-       , match tool.schema.input_schema with
-         | Some schema -> schema
-         | None -> Types.params_to_input_schema tool.schema.parameters )
+       , match schema.input_schema with
+         | Some authoritative -> authoritative
+         | None -> Types.params_to_input_schema schema.parameters )
      ]
      @
-     match tool.schema.strict with
+     match schema.strict with
      | Some strict -> [ "strict", `Bool strict ]
      | None -> [])
 ;;
+
+let schema_to_json tool = wire_json_of_schema tool.schema
 
 (** Wrap a tool to inject default arguments when not provided by the LLM.
     Defaults are merged into JSON object args before the handler runs. *)

--- a/packages/agent_core/lib/base/tool.mli
+++ b/packages/agent_core/lib/base/tool.mli
@@ -110,6 +110,16 @@ val completion : t -> Tool_contract.completion
 
 val descriptor_to_yojson : descriptor option -> Yojson.Safe.t
 
+(** Provider-facing tool definition for a schema that has no handler yet.
+
+    Distinct from {!Types.tool_schema_to_json}, which is the storage encoding:
+    that one always emits ["parameters"] and additionally emits
+    ["input_schema"] when the schema carries one, and a definition holding both
+    is rejected on the way out
+    ([Backend_openai_serialize.tool_definition_of_json]). Callers that build a
+    request rather than a checkpoint need this function. *)
+val wire_json_of_schema : Types.tool_schema -> Yojson.Safe.t
+
 (** Provider-facing tool definition. ["input_schema"] is the authoritative
     schema verbatim when the tool carries one, and
     [Types.params_to_input_schema] of the parameters otherwise. *)

--- a/packages/agent_core/test/test_backend_openai_codec.ml
+++ b/packages/agent_core/test/test_backend_openai_codec.ml
@@ -1075,6 +1075,87 @@ let test_serializer_ignored_block_variants () =
   check_int "blank reasoning-only assistant removed" 0 (List.length glm)
 ;;
 
+(* Two encoders take a [tool_schema] to JSON and only one of them may be put on
+   the wire. [Agent_core.Tool.wire_json_of_schema] emits exactly one parameter field;
+   [Types.tool_schema_to_json] is the storage encoding and always emits
+   "parameters" as a list of parameter objects, plus "input_schema" when the
+   schema carries one. Neither of its two shapes is admissible here.
+
+   A caller that reaches for the storage encoder gets a request that dies
+   inside [tool_definition_of_json] and surfaces as a provider rejection, which
+   reads like a quota or transport refusal. That is how it reached main in
+   keeper_capability_probe (masc#28444, fixed the same day it was first run
+   against a live provider). *)
+let test_wire_encoder_is_the_admissible_one () =
+  let authoritative =
+    `Assoc
+      [ "type", `String "object"
+      ; "properties", `Assoc [ "city", `Assoc [ "type", `String "string" ] ]
+      ; "required", `List [ `String "city" ]
+      ]
+  in
+  let with_input_schema =
+    match
+      Types.tool_schema_of_input_schema
+        ~name:"lookup"
+        ~description:"d"
+        ~input_schema:authoritative
+        ()
+    with
+    | Ok schema -> schema
+    | Error detail -> Alcotest.fail detail
+  in
+  let wire = Serialize.build_openai_tool_json (Agent_core.Tool.wire_json_of_schema with_input_schema) in
+  check_string
+    "authoritative schema reaches the provider verbatim"
+    "city"
+    (member "function" wire
+     |> member "parameters"
+     |> member "required"
+     |> Yojson.Safe.Util.to_list
+     |> List.hd
+     |> to_string);
+  Alcotest.check_raises
+    "storage encoder emits both fields and is rejected"
+    (Invalid_argument
+       "Backend_openai_serialize.tool_definition_of_json: input_schema and parameters \
+        are mutually exclusive")
+    (fun () ->
+       ignore
+         (Serialize.build_openai_tool_json (Types.tool_schema_to_json with_input_schema)
+          : Yojson.Safe.t));
+  (* The other half of the storage encoder's output: with no authoritative
+     schema it emits "parameters" as a list, which the backend rejects for a
+     different reason. There is no input for which it is admissible. *)
+  let derived =
+    Types.tool_schema_of_params
+      ~name:"derived"
+      ~description:"d"
+      ~parameters:
+        [ { Types.name = "city"
+          ; description = "target"
+          ; param_type = Types.String
+          ; required = true
+          }
+        ]
+      ()
+  in
+  let derived_wire = Serialize.build_openai_tool_json (Agent_core.Tool.wire_json_of_schema derived) in
+  check_string
+    "derived schema is an object"
+    "object"
+    (member "function" derived_wire |> member "parameters" |> member "type" |> to_string);
+  Alcotest.check_raises
+    "storage encoder emits a parameter list and is rejected"
+    (Invalid_argument
+       "Backend_openai_serialize.tool_definition_of_json: parameters must be a JSON \
+        object")
+    (fun () ->
+       ignore
+         (Serialize.build_openai_tool_json (Types.tool_schema_to_json derived)
+          : Yojson.Safe.t))
+;;
+
 let test_parallel_tool_calls_fields () =
   (* SSOT for the parallel-tool-call wire field: emitted only to disable, and
      only when tools are present. *)
@@ -2230,6 +2311,10 @@ let () =
             "tool choice and schema conversion"
             `Quick
             test_tool_choice_and_tool_schema_conversion
+        ; Alcotest.test_case
+            "wire encoder is the admissible one"
+            `Quick
+            test_wire_encoder_is_the_admissible_one
         ; Alcotest.test_case
             "ignored block variants"
             `Quick


### PR DESCRIPTION
`probe_invocation` (#28444) 을 실제 provider 에 처음 돌렸더니 **0.24 ms 만에** 죽었다. 요청이 프로세스를 떠나지도 못했고, 결과는 `Provider_rejected` — 쿼터 거절과 구분이 안 되는 모양으로 나왔다.

```
accept rejected: Backend_openai_serialize.tool_definition_of_json:
input_schema and parameters are mutually exclusive
```

## 원인: 인코더가 둘인데 주석이 하나라고 말했다

`keeper_capability_probe.ml` 은 도구 정의를 `Types.tool_schema_to_json` 으로 만들고, 바로 위 주석이 *"`Agent_turn.prepare_tools` 가 쓰는 것과 같은 인코더"* 라고 단언했다. 아니다. `prepare_tools` 는 `Tool.schema_to_json` 에 닿는다.

| | 대상 | `parameters` | `input_schema` |
|---|---|---|---|
| `Types.tool_schema_to_json` | 체크포인트·세션 저장 | 항상 (파라미터 객체의 **리스트**) | 있으면 추가로 |
| `Tool.schema_to_json` | provider 요청 | 없음 | 항상 정확히 하나 |

`tool_definition_of_json` 은 저장 인코더의 **두 출력 모양 모두** 거부한다 — 둘 다 있으면 `mutually exclusive`, `input_schema` 가 없으면 `parameters must be a JSON object`. 즉 저장 인코더의 출력이 받아들여지는 입력은 존재하지 않는다.

## 수정: 인코더를 하나로

`Tool.wire_json_of_schema : Types.tool_schema -> Yojson.Safe.t` 를 `schema_to_json` 에서 분리했다. 핸들러가 아직 없는 스키마를 든 호출자가 같은 인코더에 닿기 위해서다. `schema_to_json tool = wire_json_of_schema tool.schema` 로, 바이트 동일하다.

복제가 아니라 분리를 택한 이유는 이 모듈이 막으려던 실패가 정확히 "프로브는 통과하는데 실제 턴의 인코딩은 드리프트한 상태" 이기 때문이다. 인코더가 둘이면 그 드리프트가 다시 열린다.

## 테스트가 왜 이걸 못 잡았나

오프라인 11개는 전부 provider 호출 **이전에** 반환된다. 인코더의 소비자에 닿는 테스트가 하나도 없었다.

새 테스트는 소비자 쪽(`test_backend_openai_codec`)에 놓고 양방향을 주장한다:

- wire 인코더 출력 → `build_openai_tool_json` 통과, authoritative 스키마가 그대로 도달
- 저장 인코더 출력 → 두 모양 각각에 대해 정확한 메시지로 `Invalid_argument`

`wire_json_of_schema` 를 저장 인코더로 되돌리면 **1 failure / 43 tests**. 되돌렸다 복구하며 확인했다.

CI 배선: `scripts/ci-run-focused-tests.sh:147` 의 `@packages/agent_core/test/runtest` (디렉터리 alias) 가 이 스위트를 돌리고, `packages/agent_core/` 변경이 `agent_core` scope 를 켠다. `audit-ci-test-targets.sh` 는 `test/dune` 만 스캔하므로 이 배선을 세지 않는다 — ratchet 은 662 그대로.

## 러너

`masc-keeper-capability-probe`. RFC-0374 레인은 OCaml 에서만 닿을 수 있었고, 그래서 **레인이 존재하는 이유인 그 측정을 여전히 못 돌리고 있었다.** 이 결함이 머지된 경로도 그거다.

```
masc-keeper-capability-probe --runtime <id> --tool <name> [--repeat N]
                             [--surface-only] [--list-runtimes] [--list-tools]
```

surface 패스를 먼저 돌리고 투영되지 않은 도구는 dispatch 하지 않는다. 그런 도구에 턴을 쓰면 런타임이 아니라 투영 정책을 재는 것이다. 출력은 JSON Lines.

`fusion_run.ml` 과 같은 이유로 `configure_agent_core_model_catalog_overlay` 를 부른다 — 서버는 부팅에서 overlay 를 깔고 CLI 는 안 깔아서, runtime.toml 에 있는 Agent Core 런타임이 "absent from the AGENT_CORE capability catalog" 로 죽는다.

## 실측 (수정 후)

4 런타임 × 6 도구 × 2 시도 = **48 턴**. keeper chat / checkpoint / memory 어디에도 쓰지 않았다.

| 런타임 | tool_invoked | median | 비고 |
|---|---|---|---|
| `kimi_coding.kimi-for-coding` | 12/12 | 8.6s | |
| `kimi_coding.kimi-for-coding-highspeed` | 12/12 | 1.5s | 같은 게이트웨이, 5.7배 |
| `kimi_coding.kimi-k3` | 10/12 | 6.0s | `masc_board_post` ·`masc_board_vote` 각 1회 `replied_no_tool` |
| `local_llama_server.qwen3-6-35b-uncensored` | 0/12 | — | `127.0.0.1:8080` connection refused (백엔드 부재, MASC 결함 아님) |

08-12 감사가 측정하지 못한 dispatchable 4개가 정확히 이 넷이고, 이제 F13 오염 없이 채워졌다.

곁가지로 `kimi-for-coding` 이 매 요청 `capability_drift` WARN 을 낸다 — `Thinking_returned_but_declared_unsupported`. 이 PR 범위 밖이라 손대지 않았다.

## 검증

```
dune build --root . @packages/agent_core/test/runtest   → 전체 green
@packages/agent_core/test/runtest-test_backend_openai_codec → 43 tests run
@test/runtest-test_keeper_capability_probe                  → 11 tests run
scripts/audit-ci-test-targets.sh → 197 CI targets / 662 unwired, at baseline
```

## 미검증

- official-client 3 레인 (`claude_code` / `codex_app_server` / `antigravity_cli`) 은 `Not_agent_core_lane` 로 거절된다. 프로브 identity + 세션 격리가 필요하고 RFC-0374 out of scope 로 남아 있다.
- RFC-0374 의 핵심 검증(N 프로브 후 세 저장소가 바이트 동일)은 아직 테스트가 없다. 이번 48턴은 그 조건을 만족했지만 자동으로 확인하지 않았다.

RFC: `docs/rfc/RFC-0374-keeper-capability-probe-lane.md` (#28422)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
