### PR TITLE
perf(dated-jsonl): project rows during the read, not after it

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -671,21 +671,24 @@ type stats = {
 
 let get_stats (config : config) =
   let store = get_audit_store config in
-  (* Read a large window to compute stats *)
-  let entries = Dated_jsonl.read_recent store 100_000 in
-  let count = List.length entries in
-  let oldest = ref None in
-  let newest = ref None in
-  List.iter (fun json ->
-    (match Safe_ops.json_float_opt "timestamp" json with
-     | Some ts ->
-       if !oldest = None then oldest := Some ts;
-       newest := Some ts
-     | None -> ())
-  ) entries;
+  (* Read a large window to compute stats. Project each row to its timestamp
+     during the read: this window is 100k rows and the three values below are
+     all that survives, so materialising the parsed trees costs gigabytes that
+     are discarded immediately. [Some] wraps every row so [total_entries] still
+     counts rows that carry no timestamp. *)
+  let timestamps =
+    Dated_jsonl.filter_map_recent store 100_000 ~f:(fun json ->
+      Some (Safe_ops.json_float_opt "timestamp" json))
+  in
   {
-    total_entries = count;
+    total_entries = List.length timestamps;
     file_size_bytes = 0; (* no longer a single file *)
-    oldest_timestamp = !oldest;
-    newest_timestamp = !newest;
+    (* Chronological order, so the first timestamp present is the oldest and
+       the last one present is the newest. *)
+    oldest_timestamp = List.find_map Fun.id timestamps;
+    newest_timestamp =
+      List.fold_left
+        (fun newest ts -> match ts with Some _ -> ts | None -> newest)
+        None
+        timestamps;
   }

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -830,7 +830,14 @@ let append_if_current_file_fits t ~max_current_file_bytes json =
 
 let set_append_guard guard = Atomic.set append_guard guard
 
-let read_recent ?(offset=0) t n =
+(* The only traversal for recent-row reads. [f] is applied per row so the
+   caller's projection is the only thing that accumulates; [read_recent] gets
+   its old behaviour back by projecting each row to itself.
+
+   [f] runs outside the parse [try] on purpose: the reader swallows
+   [Yojson.Json_error] to skip malformed rows, and a caller's decoder must not
+   inherit that swallow. *)
+let filter_map_recent ?(offset=0) t n ~f =
   if n <= 0 then []
   else begin
     let skip = ref offset in
@@ -850,21 +857,30 @@ let read_recent ?(offset=0) t n =
            let rev_lines = List.rev lines in
            List.iter (fun line ->
              if !count >= n then raise_notrace Done;
-             (try
-                let json = Yojson.Safe.from_string line in
-                if !skip > 0 then
-                  decr skip
-                else begin
-                  collected := json :: !collected;
-                  incr count
-                end
-              with Yojson.Json_error _ -> ())
+             let parsed =
+               try Some (Yojson.Safe.from_string line)
+               with Yojson.Json_error _ -> None
+             in
+             match parsed with
+             | None -> ()
+             | Some json ->
+               if !skip > 0 then
+                 decr skip
+               else begin
+                 (match f json with
+                  | Some value -> collected := value :: !collected
+                  | None -> ());
+                 incr count
+               end
            ) rev_lines
          ) days
        ) months
      with Done -> ());
     !collected
   end
+
+let read_recent ?offset t n =
+  filter_map_recent ?offset t n ~f:(fun json -> Some json)
 
 let read_recent_result ?(offset=0) t n =
   if offset < 0

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -99,10 +99,31 @@ val set_append_guard : ((unit -> unit) -> unit) -> unit
     runtimes can install resource accounting/backpressure without making this
     low-level storage library depend on those policy modules. *)
 
+val filter_map_recent :
+  ?offset:int -> t -> int -> f:(Yojson.Safe.t -> 'a option) -> 'a list
+(** [filter_map_recent ?offset t n ~f] is [List.filter_map f (read_recent
+    ?offset t n)] without ever holding the intermediate [Yojson.Safe.t list].
+    [f] is applied to each parsed row as it is read, so a row's tree is
+    unreachable before the next row is parsed; the result list is the only
+    thing that accumulates.
+
+    [n] and [offset] count parsed rows, not selected ones: [f] returning [None]
+    does not make the reader consume an extra row. Order, offset semantics, and
+    malformed-row skipping match {!read_recent} exactly.
+
+    Callers that decode rows into their own record type should prefer this over
+    [read_recent |> List.filter_map]: a [`Assoc] holds one cons cell, one tuple,
+    and one boxed value per field, so the tree is roughly 25x the source bytes
+    and a 100k-row window materialises gigabytes that the decoder immediately
+    discards. *)
+
 val read_recent : ?offset:int -> t -> int -> Yojson.Safe.t list
 (** [read_recent ?offset t n] returns the newest [n] entries in chronological
     order (oldest first), skipping the first [offset] newest entries.
-    Scans day-files from newest to oldest, stops early. *)
+    Scans day-files from newest to oldest, stops early.
+
+    Holds every row's parsed tree at once. Use {!filter_map_recent} when the
+    rows are being decoded into something smaller. *)
 
 val read_recent_result :
   ?offset:int -> t -> int -> (recent_entry list, read_error) result

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=662
+UNWIRED_BASELINE=660
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -136,6 +136,8 @@ normal_targets=(
   @test/runtest-test_keeper_secret_redaction
   @test/runtest-test_keeper_sandbox_docker_route
   @test/runtest-test_dashboard_dev_token_host_gate
+  @test/runtest-test_dated_jsonl
+  @test/runtest-test_audit_log
   @test/keeper_github_identity/runtest
 )
 

--- a/test/test_audit_log.ml
+++ b/test/test_audit_log.ml
@@ -91,6 +91,33 @@ let test_audit_events_filter_severity_before_paging () =
   check string "older error retained" "keeper-a" (row |> member "actor" |> to_string);
   check string "severity" "error" (row |> member "severity" |> to_string)
 
+(* ── get_stats ─────────────────────────────────────────────────────
+   [get_stats] projects each row to its timestamp during the read instead of
+   materialising the window. The reader hands rows over oldest-first, so the
+   first timestamp seen is the oldest and the last is the newest; a projection
+   that folded the other way would swap these two silently. *)
+
+let test_get_stats_reports_oldest_and_newest_in_read_order () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      List.iter
+        (fun ts ->
+          Audit_log.append_entry config
+            (entry ~timestamp:ts ~agent_id:"keeper-a"
+               ~action:Audit_log.AuthSuccess ~outcome:Audit_log.Success))
+        [ 100.0; 200.0; 300.0 ];
+      let stats = Audit_log.get_stats config in
+      check int "counts every row" 3 stats.Audit_log.total_entries;
+      check (option (float 0.001)) "oldest is the first row read" (Some 100.0)
+        stats.Audit_log.oldest_timestamp;
+      check (option (float 0.001)) "newest is the last row read" (Some 300.0)
+        stats.Audit_log.newest_timestamp)
+
 (* ── Codec round-trip tests ────────────────────────────────────────── *)
 
 let action_roundtrip label action expected_wire =
@@ -283,6 +310,8 @@ let () =
             test_non_public_details_deduplicate_canonical_keys;
           test_case "audit event severity filters before paging" `Quick
             test_audit_events_filter_severity_before_paging;
+          test_case "get_stats reports oldest and newest in read order" `Quick
+            test_get_stats_reports_oldest_and_newest_in_read_order;
         ] );
       ( "codec_roundtrip",
         [

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -100,6 +100,65 @@ let test_read_recent_skips_malformed_lines () =
   let values = Dated_jsonl.read_recent store 10 |> List.map json_i in
   check (list int) "read_recent skips malformed rows" [ 1; 2 ] values
 
+(* ── filter_map_recent ───────────────────────────────────
+   [read_recent] is now [filter_map_recent] with an identity projection, so
+   comparing the two proves nothing. Every expectation below is absolute. *)
+
+let test_filter_map_recent_is_chronological_across_day_files () =
+  let dir = tmpdir "dated_jsonl_filter_map_order" in
+  write_dated_file dir "2026-01" "31" [ {|{"i":1}|}; {|{"i":2}|} ];
+  write_dated_file dir "2026-02" "01" [ {|{"i":3}|}; {|{"i":4}|} ];
+  write_dated_file dir "2026-02" "02" [ {|{"i":5}|}; {|{"i":6}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let values = Dated_jsonl.filter_map_recent store 6 ~f:(fun j -> Some (json_i j)) in
+  check (list int) "oldest first across months" [ 1; 2; 3; 4; 5; 6 ] values
+
+let test_filter_map_recent_limit_counts_rows_read_not_rows_kept () =
+  let dir = tmpdir "dated_jsonl_filter_map_limit" in
+  write_dated_file dir "2026-01" "01"
+    [ {|{"i":1}|}; {|{"i":2}|}; {|{"i":3}|}; {|{"i":4}|}; {|{"i":5}|}; {|{"i":6}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  (* The newest 4 rows are 3..6; the evens among *those* are 4 and 6. A reader
+     that kept scanning until it had 4 selected rows would return [2;4;6]. *)
+  let values =
+    Dated_jsonl.filter_map_recent store 4 ~f:(fun j ->
+      let i = json_i j in
+      if i mod 2 = 0 then Some i else None)
+  in
+  check (list int) "n bounds rows read" [ 4; 6 ] values
+
+let test_filter_map_recent_offset_skips_newest_rows () =
+  let dir = tmpdir "dated_jsonl_filter_map_offset" in
+  write_dated_file dir "2026-01" "01"
+    [ {|{"i":1}|}; {|{"i":2}|}; {|{"i":3}|}; {|{"i":4}|}; {|{"i":5}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let values =
+    Dated_jsonl.filter_map_recent ~offset:2 store 2 ~f:(fun j -> Some (json_i j))
+  in
+  check (list int) "offset drops the two newest" [ 2; 3 ] values
+
+let test_filter_map_recent_skips_malformed_rows () =
+  let dir = tmpdir "dated_jsonl_filter_map_malformed" in
+  write_dated_file dir "2026-01" "01"
+    [ {|{"i":1}|}; "not-json"; {|{"i":2}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let values = Dated_jsonl.filter_map_recent store 10 ~f:(fun j -> Some (json_i j)) in
+  check (list int) "malformed row skipped" [ 1; 2 ] values
+
+let test_filter_map_recent_does_not_swallow_callback_failure () =
+  (* The reader swallows [Yojson.Json_error] to skip malformed rows. A decoder
+     that raises the same exception must still reach the caller, or a broken
+     decoder reads as an empty store. Guards the [try] scope in the reader. *)
+  let dir = tmpdir "dated_jsonl_filter_map_callback_raise" in
+  write_dated_file dir "2026-01" "01" [ {|{"i":1}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  check_raises "decoder failure reaches the caller"
+    (Yojson.Json_error "decoder rejected the row")
+    (fun () ->
+      ignore
+        (Dated_jsonl.filter_map_recent store 10 ~f:(fun _ ->
+           raise (Yojson.Json_error "decoder rejected the row"))))
+
 let test_read_recent_result_counts_malformed_physical_row () =
   let dir = tmpdir "dated_jsonl_recent_result_malformed" in
   write_dated_file
@@ -878,6 +937,19 @@ let () =
             test_load_tail_lines_keeps_first_data_after_blank_prefix;
           test_case "keeps first row when full file spans chunks" `Quick
             test_load_tail_lines_keeps_first_when_full_file_spans_chunks;
+        ] );
+      ( "filter_map_recent",
+        [
+          test_case "chronological across day files" `Quick
+            test_filter_map_recent_is_chronological_across_day_files;
+          test_case "n bounds rows read not rows kept" `Quick
+            test_filter_map_recent_limit_counts_rows_read_not_rows_kept;
+          test_case "offset skips newest rows" `Quick
+            test_filter_map_recent_offset_skips_newest_rows;
+          test_case "skips malformed rows" `Quick
+            test_filter_map_recent_skips_malformed_rows;
+          test_case "callback failure is not swallowed" `Quick
+            test_filter_map_recent_does_not_swallow_callback_failure;
         ] );
       ( "read_recent_lines",
         [


### PR DESCRIPTION
RFC-0372 §"Later, separable" — the read side materialises every row as a parsed tree even when the caller only wants a projection of it.

## Problem

`Dated_jsonl.read_recent` parses each row and accumulates the whole window before returning:

```ocaml
let json = Yojson.Safe.from_string line in
collected := json :: !collected
```

A `` `Assoc `` holds one cons cell, one tuple, one key string, and one boxed value per field, so a parsed row is far larger than its source bytes. Callers then convert immediately — `read_recent store n |> parse_entries`, `read_recent store 100_000 |> parse_event_records` — which means the strings, the trees, and the decoded records are all reachable at the same moment. The trees are pure intermediates.

`Audit_log.get_stats` is the extreme case: it reads a 100,000-row window and keeps three scalars (count, oldest timestamp, newest timestamp).

## Change

Add `Dated_jsonl.filter_map_recent`, which applies the caller's projection per row so a row's tree is unreachable before the next row is parsed:

```ocaml
val filter_map_recent :
  ?offset:int -> t -> int -> f:(Yojson.Safe.t -> 'a option) -> 'a list
```

`read_recent` is now this function with an identity projection — one traversal implementation, and its behaviour is unchanged by construction.

`f` runs **outside** the parse `try` on purpose. The reader swallows `Yojson.Json_error` to skip malformed rows; a decoder that raises the same exception must not inherit that swallow, or a broken decoder reads as an empty store. A test pins this.

`Audit_log.get_stats` migrates to the new function, projecting each row to `Some (timestamp option)` so `total_entries` still counts rows that carry no timestamp.

The other 31 `read_recent` call sites are untouched. This PR adds the abstraction and moves the site that materialises the largest window; the remaining decode-immediately sites (`telemetry_eio`, `audit_log.read_entries`) each have order-sensitive per-row side effects — rate-limited error logging, drop reporting — that need their own equivalence tests, so they are deliberately left for follow-ups rather than converted blind.

## Verification (local)

| check | result |
|---|---|
| `dune build --root . test/test_dated_jsonl.exe test/test_audit_log.exe` | `BUILD_EXIT=0` |
| `test_audit_log.exe` | **10 tests run, Test Successful** |
| `test_dated_jsonl.exe` | 49 tests run, 1 pre-existing failure (below) |
| `scripts/audit-ci-test-targets.sh` | OK — 199 CI targets all declared, 660 unwired at baseline |
| `dune build --root . @fmt` on changed files | clean (remaining `@fmt` diffs are dune files this PR does not touch) |

Six new cases, all passing:

- `filter_map_recent` — chronological across day files; `n` bounds rows *read* not rows *kept*; offset skips newest; malformed rows skipped; **callback failure is not swallowed**
- `audit_log` — `get_stats` reports oldest and newest in read order

Order expectations are absolute values, not a comparison against `read_recent`: since `read_recent` is now defined in terms of `filter_map_recent`, comparing the two would be a tautology.

### Pre-existing failure, confirmed by control

`read_range / strict entry iteration continues after malformed` fails on this machine because a `.DS_Store` appears inside the test's temp directory and the strict reader rejects it as an invalid layout entry. Running the **main-built** binary (`_build/default/test/test_dated_jsonl.exe`, built before these changes) reproduces the identical failure at 44 tests; this branch reports 49 — the difference is exactly the five new cases. macOS-only; CI runs Linux.

## Not claimed

No throughput or RSS number. RFC-0372 §5 makes `rss_peak_delta_mb` under doubled `--keepers` the Phase 2 gate and requires the idle p95 ≤ 50 ms baseline control; this host is at load average 85+ with an unrelated cache eviction running, so any measurement taken now must be discarded. The gate run is a follow-up, not a claim in this PR.

## CI wiring

`test_dated_jsonl` and `test_audit_log` compiled in CI but were not in the focused-execution allowlist, so neither ran. Both are added to `scripts/ci-run-focused-tests.sh` and `UNWIRED_BASELINE` is lowered 662 → 660 to hold the gain, as the audit script instructs.

RFC-WAIVED: touches `lib/dated_jsonl/`, `lib/audit_log.ml`, tests, and the CI test allowlist. None of the RFC-required subsystems (credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential, hooks, workflow docs). Direction is set by existing RFC-0372.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
