### PR TITLE
feat(keeper): make the autonomous wake prompt configurable per fleet and keeper

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -136,6 +136,54 @@ module KeeperPollIntervals = struct
   ;;
 end
 
+(** {1 Autonomous turn configuration} *)
+
+module KeeperAutonomous = struct
+  (** Upper bound on the wake prompt, in bytes.
+
+      This value is not a system prompt: it is appended to the durable
+      checkpoint as the user turn of every autonomous cycle, so its cost is
+      paid again on each subsequent turn that replays the history. A long
+      operator string therefore consumes prompt budget permanently rather
+      than once, which is why the bound is enforced where the value is read
+      instead of being left to the operator's judgement. *)
+  let max_wake_prompt_bytes = 2048
+
+  (** Shared contract for both authoring surfaces -- this env var and the
+      per-keeper [autonomous_wake_prompt] in keeper TOML. [Error] carries an
+      operator-facing reason; blank is rejected rather than folded into the
+      default, so "unset" and "set to nothing" stay distinguishable. *)
+  let validate_wake_prompt raw =
+    let trimmed = String.trim raw in
+    if String.equal trimmed ""
+    then Error "autonomous wake prompt must not be blank"
+    else if String.length trimmed > max_wake_prompt_bytes
+    then
+      Error
+        (Printf.sprintf
+           "autonomous wake prompt is %d bytes, over the %d-byte bound (it is \
+            appended to the durable checkpoint on every autonomous turn)"
+           (String.length trimmed)
+           max_wake_prompt_bytes)
+    else Ok trimmed
+  ;;
+
+  (** Fleet-wide wake prompt, or [None] when unset. Read as a function: the
+      value is steerable through the boot override store, and a keeper process
+      outlives module-load time. *)
+  let wake_prompt_opt () =
+    match Env_config_core.raw_value_opt "MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT" with
+    | None -> None
+    | Some raw ->
+      (match validate_wake_prompt raw with
+       | Ok value -> Some value
+       | Error reason ->
+         raise
+           (Env_config_core.Config_error
+              (Printf.sprintf "MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT: %s" reason)))
+  ;;
+end
+
 (** {1 Keeper Runtime Configuration} *)
 
 module KeeperRuntime = struct

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -45,6 +45,27 @@ module KeeperPollIntervals : sig
   val crash_persistence_drain_sec : float
 end
 
+(** {1 Autonomous turns} *)
+
+module KeeperAutonomous : sig
+  val max_wake_prompt_bytes : int
+  (** Byte bound on a wake prompt. The value is appended to the durable
+      checkpoint every autonomous turn, so its cost recurs for the life of the
+      conversation rather than being paid once. *)
+
+  val validate_wake_prompt : string -> (string, string) result
+  (** Trims, then rejects blank and over-bound values with an operator-facing
+      reason. Shared by [MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT] and the per-keeper
+      [autonomous_wake_prompt], so the two authoring surfaces cannot accept
+      different values. *)
+
+  val wake_prompt_opt : unit -> string option
+  (** Fleet wake prompt, [None] when unset. Raises
+      {!Env_config_core.Config_error} on a set-but-invalid value rather than
+      falling back, so a typo surfaces at read time instead of silently
+      restoring the default. *)
+end
+
 (** {1 Keeper runtime} *)
 
 module KeeperRuntime : sig

--- a/lib/config/keeper_runtime_setting_registry.ml
+++ b/lib/config/keeper_runtime_setting_registry.ml
@@ -146,6 +146,15 @@ let all =
       ~category:"lifecycle"
       "Global kill-switch for autonomous keeper activation"
   ; setting
+      ~env_name:"MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT"
+      ~exposure:(Toml_and_env "autonomous.wake_prompt")
+      ~value_kind:String
+      ~default:"Continue."
+      ~reload_class:Next_turn
+      ~consumers:[ "Keeper_unified_prompt" ]
+      ~category:"lifecycle"
+      "User message an autonomous turn is woken with, before any keeper override"
+  ; setting
       ~range:(float_range ~min:0.0 ())
       ~lifecycle:
         (retired

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -10,6 +10,11 @@ type keeper_profile_defaults = {
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
+  (* User message this keeper's autonomous turns are woken with, overriding the
+     fleet [autonomous.wake_prompt]. Distinct from [instructions]: that frames
+     the system prompt once, this is the conversation input the keeper receives
+     every cycle and which the durable checkpoint keeps. [None] inherits. *)
+  autonomous_wake_prompt : string option;
   active_goal_ids : string list option;
   max_context_override : int option;
   (* Telemetry Feedback — inject behavioral stats into keeper context *)
@@ -38,6 +43,7 @@ let empty_keeper_profile_defaults =
     sandbox_image = None;
     network_mode = None;
     multimodal_policy = None;
+    autonomous_wake_prompt = None;
     active_goal_ids = None;
     max_context_override = None;
     telemetry_feedback_enabled = None;

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -12,6 +12,7 @@ type keeper_profile_defaults = {
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
+  autonomous_wake_prompt : string option;
   active_goal_ids : string list option;
   max_context_override : int option;
   telemetry_feedback_enabled : bool option;

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -63,6 +63,7 @@ type keeper_profile_defaults =
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
+  autonomous_wake_prompt : string option;
   active_goal_ids : string list option;
   max_context_override : int option;
   telemetry_feedback_enabled : bool option;

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -63,6 +63,7 @@ type keeper_profile_defaults =
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
+  autonomous_wake_prompt : string option;
   active_goal_ids : string list option;
   max_context_override : int option;
   telemetry_feedback_enabled : bool option;

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -63,6 +63,7 @@ type keeper_profile_defaults =
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
+  autonomous_wake_prompt : string option;
   active_goal_ids : string list option;
   max_context_override : int option;
   telemetry_feedback_enabled : bool option;

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -7,6 +7,7 @@ include Keeper_types_profile_agent_core_env
 let keeper_toml_field_names =
   [ "name"
   ; "instructions"
+  ; "autonomous_wake_prompt"
   ; "autoboot_enabled"
   ; "mention_targets"
   ; "proactive_enabled"
@@ -58,7 +59,7 @@ let toml_value_kind = function
 
 let validate_known_keeper_field_types doc =
   let string_fields =
-    [ "name"; "instructions"; "sandbox_profile"
+    [ "name"; "instructions"; "autonomous_wake_prompt"; "sandbox_profile"
     ; "sandbox_image"; "network_mode"; "multimodal_policy" ]
   in
   let bool_fields =
@@ -184,9 +185,25 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
       Keeper_config.validate_max_context_override_value value
       |> Result.map Option.some
   in
+  (* Same contract the fleet env var is held to, so an operator cannot author a
+     blank or unbounded wake prompt on one surface and a valid one on the other. *)
+  let autonomous_wake_prompt_result =
+    match str "autonomous_wake_prompt" with
+    | None -> Ok None
+    | Some value ->
+      Env_config_keeper.KeeperAutonomous.validate_wake_prompt value
+      |> Result.map Option.some
+      |> Result.map_error (fun reason -> "keeper.autonomous_wake_prompt: " ^ reason)
+  in
+  let max_context_override_result =
+    Result.bind max_context_override_result (fun max_context_override ->
+      Result.map
+        (fun autonomous_wake_prompt -> max_context_override, autonomous_wake_prompt)
+        autonomous_wake_prompt_result)
+  in
   Result.bind result (fun () ->
     Result.map
-      (fun max_context_override ->
+      (fun (max_context_override, autonomous_wake_prompt) ->
       {
         id = None;
         manifest_path = None;
@@ -204,6 +221,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
           Option.bind (str "network_mode") network_mode_of_string;
         multimodal_policy =
           Option.bind (str "multimodal_policy") multimodal_policy_of_string;
+        autonomous_wake_prompt;
         active_goal_ids =
           if has "active_goal_ids" then
             Some (normalize_name_list (strs "active_goal_ids"))
@@ -241,6 +259,8 @@ let merge_keeper_profile_defaults
     id = prefer overlay.id base.id;
     manifest_path = prefer overlay.manifest_path base.manifest_path;
     instructions = prefer overlay.instructions base.instructions;
+    autonomous_wake_prompt =
+      prefer overlay.autonomous_wake_prompt base.autonomous_wake_prompt;
     autoboot_enabled = prefer overlay.autoboot_enabled base.autoboot_enabled;
     mention_targets =
       merge_string_list ~base:base.mention_targets overlay.mention_targets;

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -63,6 +63,7 @@ type keeper_profile_defaults =
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
+  autonomous_wake_prompt : string option;
   active_goal_ids : string list option;
   max_context_override : int option;
   telemetry_feedback_enabled : bool option;

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -25,8 +25,39 @@ type turn_prompt_parts = {
 
 (* Ordinary user input for an autonomous continuation. The durable checkpoint
    carries this cue and the assistant/tool suffix in normal conversation order;
-   the fresh observation frame alone rides [world_state] and stays ephemeral. *)
+   the fresh observation frame alone rides [world_state] and stays ephemeral.
+
+   This is the last resort, not the only value: see
+   [effective_autonomous_wake_prompt]. Nothing classifies a turn by matching
+   this string -- autonomy is a typed property of the turn -- and nothing may
+   start, because the operator can change it. *)
 let autonomous_wake_marker = "Continue."
+
+(* keeper profile, else fleet setting, else the literal above.
+
+   The two configured sources are deliberately different in kind. The fleet
+   value answers "how is a keeper woken here", the keeper value answers "what
+   is this keeper always being asked", and a keeper that states neither should
+   read the same as it did before this was configurable. Both are validated at
+   their own parse boundary, so an invalid value never reaches this point --
+   resolution stays total and cannot fail mid-prompt. *)
+let effective_autonomous_wake_prompt
+      ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
+      ()
+  =
+  (* DET-OK: total resolution over two known sources, then a literal. *)
+  let fleet_or_literal () =
+    Option.value
+      (Env_config_keeper.KeeperAutonomous.wake_prompt_opt ())
+      ~default:autonomous_wake_marker
+  in
+  match profile_defaults with
+  | Some d ->
+    (match d.autonomous_wake_prompt with
+     | Some prompt -> prompt
+     | None -> fleet_or_literal ())
+  | None -> fleet_or_literal ()
+;;
 
 let format_pending_messages
       (messages : Keeper_world_observation_message_scope.pending_message list)
@@ -1228,7 +1259,7 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
      retrieve them; call a tool when you need to look something up or act.\n\n"
     ^ Keeper_context_layers.assemble ~content_of
   in
-  let user_message = autonomous_wake_marker in
+  let user_message = effective_autonomous_wake_prompt ?profile_defaults () in
   { system_prompt; world_state; user_message }
 ;;
 

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -25,17 +25,34 @@ type turn_prompt_parts = {
           to the persisted message history. *)
   user_message : string;
       (** Current user-turn input. Operator utterances are durable. For an
-          autonomous continuation this is {!autonomous_wake_marker}, which is
-          also durable: each cycle is an ordinary next user turn followed by
-          its assistant/tool suffix. HITL resolutions are appended by the turn
-          driver. *)
+          autonomous continuation this is
+          {!effective_autonomous_wake_prompt}, which is also durable: each
+          cycle is an ordinary next user turn followed by its assistant/tool
+          suffix. HITL resolutions are appended by the turn driver. *)
 }
 
 val autonomous_wake_marker : string
-(** Durable input for an autonomous continuation. It is appended to the same
-    checkpoint as the following assistant/tool suffix. The fresh observation
-    frame lives separately in {!turn_prompt_parts.world_state} and is never
-    persisted. *)
+(** Last-resort input for an autonomous continuation, used when neither the
+    keeper nor the fleet configures one. It is appended to the same checkpoint
+    as the following assistant/tool suffix. The fresh observation frame lives
+    separately in {!turn_prompt_parts.world_state} and is never persisted.
+
+    Do not compare a turn's [user_message] against this to decide whether the
+    turn was autonomous: operators can change the value, and that classifier
+    would then be wrong for exactly the deployments that configured it. *)
+
+val effective_autonomous_wake_prompt :
+  ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
+  unit ->
+  string
+(** Resolves the wake prompt: the keeper's [autonomous_wake_prompt], else the
+    fleet [autonomous.wake_prompt] / [MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT], else
+    {!autonomous_wake_marker}. Total -- both configured sources are validated
+    where they are parsed, so this cannot fail while a prompt is being built.
+
+    Changing either source affects turns taken after the change. Earlier turns
+    keep the wording they were woken with, because the checkpoint is history
+    rather than a view. *)
 
 val format_current_task : Masc_domain.task -> string
 

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -412,6 +412,77 @@ let test_absent_session_identity_is_rejected () =
   | Error _ -> ()
 ;;
 
+(* #28413. The wake prompt is the user turn every autonomous cycle is woken
+   with, and it is kept by the durable checkpoint, so it is worth configuring
+   per keeper -- and worth bounding, since its cost recurs on every later turn
+   that replays the history. *)
+
+let wake_prompt_profile prompt =
+  { Keeper_types_profile.empty_keeper_profile_defaults with
+    autonomous_wake_prompt = prompt
+  }
+;;
+
+let test_wake_prompt_validation_rejects_blank_and_unbounded () =
+  let validate = Env_config_keeper.KeeperAutonomous.validate_wake_prompt in
+  Alcotest.(check bool)
+    "blank is rejected rather than folded into the default"
+    true
+    (Result.is_error (validate "   "));
+  Alcotest.(check bool) "empty is rejected" true (Result.is_error (validate ""));
+  let bound = Env_config_keeper.KeeperAutonomous.max_wake_prompt_bytes in
+  Alcotest.(check bool)
+    "a value at the bound is admitted"
+    true
+    (Result.is_ok (validate (String.make bound 'x')));
+  Alcotest.(check bool)
+    "one byte over the bound is rejected"
+    true
+    (Result.is_error (validate (String.make (bound + 1) 'x')));
+  match validate "  ask a better question  " with
+  | Error reason -> Alcotest.failf "a valid prompt was rejected: %s" reason
+  | Ok value ->
+    Alcotest.(check string) "surrounding whitespace is trimmed"
+      "ask a better question" value
+;;
+
+(* Ordering matters: the literal case must run before this process sets the
+   fleet variable, because OCaml's Unix has no unsetenv to undo it. *)
+let test_wake_prompt_resolution_order () =
+  let resolve ?profile_defaults () =
+    Keeper_unified_prompt.effective_autonomous_wake_prompt ?profile_defaults ()
+  in
+  Alcotest.(check string)
+    "no keeper and no fleet value resolves to the literal"
+    Keeper_unified_prompt.autonomous_wake_marker
+    (resolve ());
+  Alcotest.(check string)
+    "a keeper value is used even with no fleet value"
+    "keeper asks"
+    (resolve ~profile_defaults:(wake_prompt_profile (Some "keeper asks")) ());
+  Unix.putenv "MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT" "fleet asks";
+  Alcotest.(check string)
+    "a keeper without its own value inherits the fleet value"
+    "fleet asks"
+    (resolve ~profile_defaults:(wake_prompt_profile None) ());
+  Alcotest.(check string)
+    "no profile at all still inherits the fleet value"
+    "fleet asks"
+    (resolve ());
+  Alcotest.(check string)
+    "a keeper value overrides the fleet value"
+    "keeper asks"
+    (resolve ~profile_defaults:(wake_prompt_profile (Some "keeper asks")) ());
+  (* A set-but-invalid fleet value must surface, not silently restore the
+     default -- otherwise a typo reads as "configuration had no effect". *)
+  Unix.putenv "MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT" "   ";
+  Alcotest.check_raises
+    "a blank fleet value raises instead of falling back"
+    (Env_config_core.Config_error
+       "MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT: autonomous wake prompt must not be blank")
+    (fun () -> ignore (resolve ()))
+;;
+
 let () =
   Alcotest.run "keeper_autonomous_turn_source"
     [ ( "load_recent"
@@ -441,5 +512,11 @@ let () =
             test_session_identity_mismatch_is_rejected
         ; Alcotest.test_case "rejects an absent session identity" `Quick
             test_absent_session_identity_is_rejected
+        ] )
+    ; ( "wake_prompt"
+      , [ Alcotest.test_case "rejects blank and over-bound values" `Quick
+            test_wake_prompt_validation_rejects_blank_and_unbounded
+        ; Alcotest.test_case "keeper then fleet then literal (#28413)" `Quick
+            test_wake_prompt_resolution_order
         ] )
     ]


### PR DESCRIPTION
Closes #28413.

## 지금까지

자율 턴의 user message 는 리터럴 한 줄이었다.

```ocaml
(* keeper_unified_prompt.ml:29 *)
let autonomous_wake_marker = "Continue."
...
let user_message = autonomous_wake_marker in
```

이 문자열은 시스템 프롬프트가 아니라 **durable checkpoint 에 대화의 user 턴으로 남는다**. 관측 프레임(`world_state`)은 ephemeral 이라 히스토리에 안 남으므로, 히스토리만 놓고 보면 키퍼는 매 사이클 **내용 없는 재촉 한 줄**을 받는다. 키퍼마다 다른 상시 질문을 줄 수 있으면 자율 턴의 성격이 달라진다.

## 변경

해소 순서는 **키퍼 → 함대 → 리터럴**이다.

| 층 | 표면 |
|---|---|
| 키퍼 | keeper TOML `autonomous_wake_prompt` |
| 함대 | `autonomous.wake_prompt` / `MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT` |
| 최후 | `autonomous_wake_marker = "Continue."` (그대로 유지) |

`build_prompt_internal` 이 이미 `?profile_defaults` 를 받고 있어서 새 파라미터 배선은 없다. 값을 고르는 지점은 한 곳이다.

함대 설정은 `Keeper_runtime_setting_registry` 에 typed 항목으로 추가했으므로 TOML→env 매핑과 대시보드 노출(`/api/v1/runtime/config/raw` 의 `keeper_settings`)은 registry 투영으로 자동으로 따라온다.

## 지킨 것

**빈 값은 거부한다.** `Some ""` 를 조용히 기본값으로 압축하지 않는다 — 그러면 "설정 안 함"과 "빈 값으로 설정함"이 구분되지 않고, 오타가 "설정이 안 먹었다"로 읽힌다. 함대 값이 blank 면 읽는 시점에 `Config_error` 를 던지고, 키퍼 값이 blank 면 typed parse error 다.

**바이트 상한을 강제한다** (`max_wake_prompt_bytes = 2048`). 이 값은 매 자율 턴마다 durable 히스토리에 append 되므로, 비용이 한 번이 아니라 **이후 모든 턴에 반복해서** 든다. 운영자 판단에 맡기지 않고 읽는 자리에서 막는다.

**두 표면이 같은 계약을 쓴다.** `Env_config_keeper.KeeperAutonomous.validate_wake_prompt` 하나를 env 리더와 keeper TOML 파서가 공유한다. 한쪽에서 통과하고 다른 쪽에서 거부되는 값이 존재할 수 없다.

**해소는 total 이다.** 두 설정 소스 모두 각자의 parse 경계에서 검증되므로, 프롬프트를 만드는 도중에 실패할 수 없다.

**이 문자열로 턴을 분류하지 않는다.** 지금도 그런 코드는 없고(`rg -F '"Continue."'` → 정의 + 테스트뿐), 설정 가능해지는 순간 문자열 매칭 분류기는 그 값을 바꾼 배포에서 정확히 틀린다. `.mli` 에 그 금지를 명시했다.

**과거 턴은 건드리지 않는다.** 값을 바꾸면 이후 턴만 새 문구를 쓴다. checkpoint 는 뷰가 아니라 히스토리다.

## 검증

```
test_keeper_autonomous_turn_source          14 tests   OK
test_runtime_toml_overrides                 34 tests   OK
test_keeper_unified_verification_surface    34 tests   OK
test_keeper_replay_checkpoint               16 tests   OK
```

새 케이스 2 개:

- `rejects blank and over-bound values` — blank/empty 거부, 상한 정확히 경계(bound OK / bound+1 reject), 앞뒤 공백 trim
- `keeper then fleet then literal (#28413)` — 3 단 우선순위 전수, 그리고 blank 함대 값이 폴백 대신 raise 하는지

**변이 검증**: 해소에서 키퍼 override 분기만 제거하면 (`ignore profile_defaults; fleet_or_literal ()`) `FAIL a keeper value is used even with no fleet value` 로 실패한다 (exit 1). 테스트가 실제로 이 동작을 잡는다.

기존 테스트 3 곳은 리터럴이 아니라 심볼(`autonomous_wake_marker`)을 참조하던 그대로 두었고, 전부 green 이다.

RFC-WAIVED: credential/identity/operator/sandbox/hooks/workflow 어느 subsystem 도 건드리지 않는다. keeper 프롬프트 조립과 그 설정 표면만 바뀐다.

WORKAROUND-WAIVED: STRING_CLASSIFIER 시그니처는 본문이 문자열 분류기를 **금지**한다고 쓴 문장("이 문자열로 턴을 분류하지 않는다", "문자열 매칭 분류기는 ... 틀린다")에 걸린 오탐이다. 이 PR 은 분류기를 추가하지 않는다 — 추가할 수 없게 `.mli` 에 명시적으로 못박고, 자율 여부는 기존대로 typed 필드가 판정한다. 진단 근거: 게이트가 시그니처를 본문 텍스트로 매칭하므로 안티패턴을 서술하는 PR 과 저지르는 PR 을 구분하지 못한다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
