### PR TITLE
docs(dated-jsonl): state the projection call order, and migrate telemetry reads

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -108,8 +108,17 @@ val filter_map_recent :
     thing that accumulates.
 
     [n] and [offset] count parsed rows, not selected ones: [f] returning [None]
-    does not make the reader consume an extra row. Order, offset semantics, and
-    malformed-row skipping match {!read_recent} exactly.
+    does not make the reader consume an extra row. The returned list, the
+    offset semantics, and malformed-row skipping match {!read_recent} exactly.
+
+    {b [f] is called newest-first.} The scan walks months, day-files, and rows
+    in descending order and prepends, which is what makes the {e result}
+    chronological. So for a pure [f] this is exactly [List.filter_map f
+    (read_recent ?offset t n)], but for an [f] whose side effects depend on
+    call order — rate-limited error logging, "report the first N drops",
+    anything that stops after a quota — it is not: those effects see the
+    newest rows first. Convert such a call site with a test that pins the
+    effect, not by substitution.
 
     Callers that decode rows into their own record type should prefer this over
     [read_recent |> List.filter_map]: a [`Assoc] holds one cons cell, one tuple,

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -174,17 +174,19 @@ let report_telemetry_drop ~reason ~path ~detail =
     ~on_drop:(fun () -> observe_telemetry_drop ~reason)
     ~surface:telemetry_eio_surface ~reason ~path ~detail
 
+(* Per-row decode. Reporting a drop only logs and bumps a counter, with no
+   quota or early stop, so this is safe to run under a newest-first scan. *)
+let parse_event_record (json : Yojson.Safe.t) : event_record option =
+  match event_record_of_yojson json with
+  | Ok record -> Some record
+  | Error msg ->
+      report_telemetry_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+        ~path:"<in-memory>" ~detail:msg;
+      None
+
 let parse_event_records (jsons : Yojson.Safe.t list) : event_record list =
-  List.filter_map
-    (fun json ->
-      match event_record_of_yojson json with
-      | Ok record -> Some record
-      | Error msg ->
-          report_telemetry_drop
-            ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-            ~path:"<in-memory>" ~detail:msg;
-          None)
-    jsons
+  List.filter_map parse_event_record jsons
 
 let event_to_json event =
   let record = {
@@ -202,13 +204,13 @@ let track ?fs:_ config event : unit =
 (** Read all current date-split events. *)
 let read_all_events ?fs:_ config : event_record list =
   let store = get_telemetry_store config in
-  Dated_jsonl.read_recent store 100_000 |> parse_event_records
+  Dated_jsonl.filter_map_recent store 100_000 ~f:parse_event_record
 
 let read_recent_events ?fs:_ config ~limit : event_record list =
   if limit <= 0 then []
   else
     let store = get_telemetry_store config in
-    Dated_jsonl.read_recent store limit |> parse_event_records
+    Dated_jsonl.filter_map_recent store limit ~f:parse_event_record
 
 (* ── Tool usage summary cache ──────────────────────────────────────
    The dashboard refreshes Tool Monitor / Fleet Health / Tool Quality

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -145,6 +145,27 @@ let test_filter_map_recent_skips_malformed_rows () =
   let values = Dated_jsonl.filter_map_recent store 10 ~f:(fun j -> Some (json_i j)) in
   check (list int) "malformed row skipped" [ 1; 2 ] values
 
+let test_filter_map_recent_calls_the_projection_newest_first () =
+  (* The result is chronological, but the scan runs newest-first and prepends.
+     A projection whose side effects depend on call order is therefore *not*
+     interchangeable with [read_recent |> List.filter_map f]. Pinned because
+     the remaining migration targets (rate-limited decode-error logging, drop
+     reporting) are exactly that kind of projection. *)
+  let dir = tmpdir "dated_jsonl_filter_map_visit_order" in
+  write_dated_file dir "2026-01" "01" [ {|{"i":1}|}; {|{"i":2}|} ];
+  write_dated_file dir "2026-01" "02" [ {|{"i":3}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let visited = ref [] in
+  let values =
+    Dated_jsonl.filter_map_recent store 3 ~f:(fun j ->
+      let i = json_i j in
+      visited := i :: !visited;
+      Some i)
+  in
+  check (list int) "result is chronological" [ 1; 2; 3 ] values;
+  check (list int) "projection saw rows newest first" [ 3; 2; 1 ]
+    (List.rev !visited)
+
 let test_filter_map_recent_does_not_swallow_callback_failure () =
   (* The reader swallows [Yojson.Json_error] to skip malformed rows. A decoder
      that raises the same exception must still reach the caller, or a broken
@@ -948,6 +969,8 @@ let () =
             test_filter_map_recent_offset_skips_newest_rows;
           test_case "skips malformed rows" `Quick
             test_filter_map_recent_skips_malformed_rows;
+          test_case "projection is called newest first" `Quick
+            test_filter_map_recent_calls_the_projection_newest_first;
           test_case "callback failure is not swallowed" `Quick
             test_filter_map_recent_does_not_swallow_callback_failure;
         ] );

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -592,6 +592,30 @@ let test_legacy_single_file_is_ignored () =
     0
     (List.length (Telemetry_eio.read_all_events config))
 
+(* [read_all_events] decodes rows during the read now instead of materialising
+   the window first. The decoder runs under a newest-first scan while the
+   result stays chronological, so order is the thing worth pinning. *)
+let test_read_all_events_is_chronological_across_day_files () =
+  with_temp_dir (fun base_dir ->
+    Eio_main.run @@ fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let config = Workspace.default_config base_dir in
+    let dir = telemetry_dir base_dir in
+    let row ts agent_id =
+      Printf.sprintf
+        {|{"timestamp":%.1f,"event":["Agent_session_bound",{"agent_id":"%s","capabilities":[]}]}|}
+        ts agent_id
+    in
+    write_dated_file dir "2026-01" "31" [ row 100.0 "a"; row 200.0 "b" ];
+    write_dated_file dir "2026-02" "01" [ "not-json"; row 300.0 "c" ];
+    let timestamps =
+      Telemetry_eio.read_all_events config
+      |> List.map (fun (record : Telemetry_eio.event_record) -> record.timestamp)
+    in
+    check (list (float 0.001))
+      "oldest first across months, malformed row dropped"
+      [ 100.0; 200.0; 300.0 ] timestamps)
+
 let test_track_applies_default_retention_days () =
   with_env "MASC_TELEMETRY_RETENTION_DAYS" "" (fun () ->
     with_env "MASC_TELEMETRY_MAX_BYTES" "0" (fun () ->
@@ -705,6 +729,8 @@ let () =
         test_summarize_tool_usage_reads_date_split_store_without_fs;
       test_case "legacy single telemetry file is ignored" `Quick
         test_legacy_single_file_is_ignored;
+      test_case "read_all_events is chronological across day files" `Quick
+        test_read_all_events_is_chronological_across_day_files;
       test_case "track applies default retention days" `Quick
         test_track_applies_default_retention_days;
       test_case "track applies telemetry max bytes" `Quick


### PR DESCRIPTION
Follow-up to #28455. Two things: the contract that PR shipped was half-true, and the next decode-immediately call site is safe to move.

## The contract was half-true

`filter_map_recent`'s doc says order matches `read_recent` exactly. That holds for the **returned list**. It does not hold for **when `f` is called**.

`list_subdirs` sorts with `String.compare b a`, so months and day-files are walked newest-first, rows within a day are reversed, and results are prepended — which is precisely what makes the *result* chronological. The projection therefore sees the newest row first.

For a pure `f` this is exactly `List.filter_map f (read_recent ?offset t n)`. For an `f` whose side effects depend on call order — rate-limited error logging, "report the first N drops", anything with a quota — it is not: those effects see the rows in the opposite order.

#28455's own body said the remaining sites were deferred because they have order-sensitive per-row effects. That reasoning never made it into the interface, so the next person to migrate one reads "order matches exactly" and substitutes. This closes that gap:

- the mli now states the call order and says to convert such sites with a test that pins the effect, not by substitution
- a test asserts the result is `[1; 2; 3]` *and* the projection saw `[3; 2; 1]`, so the two orders cannot silently converge or drift

## telemetry_eio migrates

`report_telemetry_drop` reaches `Safe_ops.report_persistence_read_drop`, which logs a warning and bumps a counter. No quota, no early stop, no dependence on which row came first — so the decoder is order-independent and the newest-first scan is safe for it.

`parse_event_record` is extracted as the per-row function; `parse_event_records` keeps its signature and is defined in terms of it (tests use it directly). `read_all_events` (a 100,000-row window) and `read_recent_events` now project during the read.

Existing coverage of these two functions checks counts and retention only, so a test pins chronological order across day files with a malformed row in between.

## Verification

Run after the PR was opened; the body said "not run by me" until this edit.

| check | result |
|---|---|
| `dune build --root . test/test_dated_jsonl.exe test/test_telemetry_eio_coverage.exe` | `BUILD_EXIT=0` |
| `test_telemetry_eio_coverage.exe` | **39 tests run, Test Successful** |
| `test_dated_jsonl.exe` | 50 tests run, 1 pre-existing failure (below) |
| `dune build --root . @fmt` | no diff on any file this PR touches |

All new cases pass: `filter_map_recent` 0-5 (including **projection is called newest first**) and `store_reads / read_all_events is chronological`.

`read_range / strict entry iteration continues after malformed` fails here because a `.DS_Store` lands in the test's temp directory and the strict reader rejects it as an invalid layout entry. Established as pre-existing in #28455 by running the main-built binary, which reproduces it identically. macOS-only; CI runs Linux.

Static reading that motivated the change, unchanged by the run: the traversal direction comes from `list_subdirs` (`String.compare b a`, descending) and the `list_day_files` doc comment; `report_persistence_read_drop` was read end-to-end to confirm it has no quota or early exit.

No throughput or RSS claim. RFC-0372 §5's Phase 2 gate (`rss_peak_delta_mb` flat under doubled `--keepers`, idle p95 ≤ 50 ms control) still has not been run.

RFC-WAIVED: `lib/dated_jsonl/dated_jsonl.mli`, `lib/telemetry_eio.ml`, and two test files. None of the RFC-required subsystems. Direction is set by existing RFC-0372.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
