### PR TITLE
perf(dashboard): give the last two uncovered store scans their cache layer

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -311,6 +311,40 @@ let dashboard_proof_compute ~config ~limit () : Yojson.Safe.t =
     ]
 ;;
 
+(* Both the HTTP/1 router and the H2 gateway serve this projection, and the H2
+   registration carries a comment requiring the two to stay identical. Caching
+   at each call site would have been two copies of the policy and the first
+   chance for them to drift, so the cache lives with the projection and both
+   routes call this.
+
+   The route was offloaded but uncached, so a polling dashboard re-ran the
+   schedule scan every time: measured 272 ms cold and 204 ms warm for a 96 KB
+   response, the second pass no cheaper than the first. Its siblings
+   (briefing/sections, tool-quality) already pair the offload with the cache;
+   this one only ever had half the pair.
+
+   [live_cache_ttl_s] is the 30 s tier documented for "frequently-changing data
+   such as active keeper state" — schedule state belongs there rather than in
+   the 120 s projection tier. The response takes no query parameters, so
+   base_path is the whole key. *)
+let dashboard_scheduled_automation_http_json ~(config : Workspace.config) :
+  Yojson.Safe.t
+  =
+  let cache_key =
+    Server_dashboard_http_core_cache.dashboard_query_cache_key
+      config
+      "scheduled_automation"
+      []
+  in
+  Dashboard_cache.get_or_compute
+    cache_key
+    ~ttl:Server_dashboard_http_core_cache.live_cache_ttl_s
+    (fun () ->
+      Domain_pool_ref.submit_io_or_inline (fun () ->
+        Server_dashboard_schedule_projection.scheduled_automation_dashboard_json
+          config))
+;;
+
 let dashboard_proof_http_json ~config request : Yojson.Safe.t =
   let limit = int_query_param request "limit" ~default:25 |> clamp ~min_v:1 ~max_v:100 in
   let key =

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -79,6 +79,13 @@ val dashboard_gate_http_json :
 val dashboard_gate_tool_events_http_json :
   Httpun.Request.t -> base_path:string -> Yojson.Safe.t
 
+val dashboard_scheduled_automation_http_json :
+  config:Workspace.config -> Yojson.Safe.t
+(** Schedule projection for [GET /api/v1/dashboard/scheduled-automation],
+    cached and offloaded. Both the HTTP/1 router and the H2 gateway call this
+    rather than the projection directly, so the two transports cannot serve
+    different data or drift on cache policy. *)
+
 val dashboard_proof_http_json :
   config:Workspace.config -> Httpun.Request.t -> Yojson.Safe.t
 

--- a/lib/server/server_dashboard_http_agent_api.ml
+++ b/lib/server/server_dashboard_http_agent_api.ml
@@ -64,6 +64,54 @@ let positive_int_param ~name ~default = function
      | Some _ | None -> Error (name ^ " must be a positive integer"))
 ;;
 
+(* Per-agent tool-call rollup for [GET /api/v1/agent-activity].
+
+   The route carried neither of the two protections the dashboard applies to a
+   store scan, so [summarize_agent_activity] ran on the HTTP domain on every
+   request and nothing was reused between them: measured 105 ms cold and 75 ms
+   warm to produce 2.2 KB.
+
+   [hours] is part of the cache key because it selects the window the scan
+   covers — two windows are two answers, not one answer served twice. [since]
+   is derived inside the compute rather than keyed on: it moves with wall-clock,
+   so keying on it would make every request a miss. A cached window is therefore
+   anchored up to one TTL in the past, which is what the 30 s tier means for a
+   rollup whose default window is 24 h.
+
+   Named rather than inlined in the route so the cache policy has one home and
+   a test can reach it without an HTTP round trip. *)
+let agent_activity_http_json ~(config : Workspace.config) ~hours : Yojson.Safe.t =
+  let cache_key =
+    Server_dashboard_http_core_cache.dashboard_query_cache_key
+      config
+      "agent_activity"
+      [ ("hours", Some (string_of_float hours)) ]
+  in
+  Dashboard_cache.get_or_compute
+    cache_key
+    ~ttl:Server_dashboard_http_core_cache.live_cache_ttl_s
+    (fun () ->
+      Domain_pool_ref.submit_io_or_inline (fun () ->
+        let since = Time_compat.now () -. (hours *. Masc_time_constants.hour) in
+        let activities = Telemetry_eio.summarize_agent_activity config ~since in
+        `Assoc
+          [ ("hours", `Float hours);
+            ("agents",
+             `List
+               (List.map
+                  (fun (a : Telemetry_eio.agent_activity) ->
+                     `Assoc
+                       [ ("agent_id", `String a.agent_id);
+                         ("tool_calls", `Int a.tool_calls);
+                         ("success_count", `Int a.success_count);
+                         ("failure_count", `Int a.failure_count);
+                         ("first_seen", `Float a.first_seen);
+                         ("last_seen", `Float a.last_seen);
+                       ])
+                  activities));
+          ]))
+;;
+
 let add_agent_api_routes router =
   router
   (* Agent activity -- per-agent tool call stats from telemetry *)
@@ -79,22 +127,11 @@ let add_agent_api_routes router =
              (`Assoc [ "error", `String detail ])
              reqd
          | Ok hours ->
-         let since = Time_compat.now () -. (hours *. Masc_time_constants.hour) in
-         let activities =
-           Telemetry_eio.summarize_agent_activity (Mcp_server.workspace_config state) ~since
+         let json =
+           agent_activity_http_json
+             ~config:(Mcp_server.workspace_config state)
+             ~hours
          in
-         let json = `Assoc [
-           ("hours", `Float hours);
-           ("agents", `List (List.map (fun (a : Telemetry_eio.agent_activity) ->
-             `Assoc [
-               ("agent_id", `String a.agent_id);
-               ("tool_calls", `Int a.tool_calls);
-               ("success_count", `Int a.success_count);
-               ("failure_count", `Int a.failure_count);
-               ("first_seen", `Float a.first_seen);
-               ("last_seen", `Float a.last_seen);
-             ]) activities));
-         ] in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
 

--- a/lib/server/server_dashboard_http_agent_api.mli
+++ b/lib/server/server_dashboard_http_agent_api.mli
@@ -27,5 +27,11 @@ val positive_int_param
 (** Read an absent value as [default], otherwise require positive decimal
     digits. *)
 
+val agent_activity_http_json :
+  config:Masc.Workspace.config -> hours:float -> Yojson.Safe.t
+(** Per-agent tool-call rollup for [GET /api/v1/agent-activity], cached per
+    [(base_path, hours)] and computed off the HTTP domain. Exposed so the cache
+    policy can be exercised without an HTTP round trip. *)
+
 val add_agent_api_routes :
   Http_server_eio.Router.t -> Http_server_eio.Router.t

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -855,10 +855,8 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
       | `GET, "/api/v1/dashboard/scheduled-automation" ->
           with_h2_public_read h2_reqd (fun state ->
             let json =
-              Domain_pool_ref.submit_io_or_inline (fun () ->
-                Server_dashboard_schedule_projection
-                .scheduled_automation_dashboard_json
-                  (Mcp_server.workspace_config state))
+              dashboard_scheduled_automation_http_json
+                ~config:(Mcp_server.workspace_config state)
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1715,9 +1715,8 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/scheduled-automation" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json =
-           Domain_pool_ref.submit_io_or_inline (fun () ->
-             Server_dashboard_schedule_projection.scheduled_automation_dashboard_json
-               (Mcp_server.workspace_config state))
+           Server_dashboard_http.dashboard_scheduled_automation_http_json
+             ~config:(Mcp_server.workspace_config state)
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1413,6 +1413,71 @@ let test_dashboard_shell_timeout_fallback_reports_timing_context () =
       check int "timing top is empty without an active trace" 0
         (diagnostics |> member "projection_timing_top" |> to_list |> List.length))
 
+(* Both routes below scan a store. Seeding a sentinel under the key the
+   projection is supposed to consult, then asserting the projection returns it,
+   pins that the cache is actually in the path: without it the call recomputes
+   and answers with real data instead of the sentinel.
+
+   Measured before this: scheduled-automation 272 ms cold / 204 ms warm for
+   96 KB, agent-activity 105 ms cold / 75 ms warm for 2.2 KB. Neither second
+   pass was cheaper than its first, which is what an absent cache looks like
+   from outside. *)
+let cache_sentinel key = `Assoc [ ("sentinel", `String key) ]
+
+let seed_cache key =
+  ignore (Dashboard_cache.get_or_compute key ~ttl:60.0 (fun () -> cache_sentinel key))
+
+let test_scheduled_automation_reads_its_cache_key () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  Fun.protect
+    ~finally:Dashboard_cache.invalidate_all
+    (fun () ->
+      Dashboard_cache.invalidate_all ();
+      let cache_key =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key
+          config
+          "scheduled_automation"
+          []
+      in
+      seed_cache cache_key;
+      check
+        (of_pp Yojson.Safe.pp)
+        "scheduled-automation is served from its cache key"
+        (cache_sentinel cache_key)
+        (Server_dashboard_http.dashboard_scheduled_automation_http_json ~config))
+
+(* The window selects which rows the scan covers, so two windows must not share
+   an entry. Seeding only the 24 h key and asking for 1 h has to miss. *)
+let test_agent_activity_keys_on_its_window () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  Fun.protect
+    ~finally:Dashboard_cache.invalidate_all
+    (fun () ->
+      Dashboard_cache.invalidate_all ();
+      let key_for hours =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key
+          config
+          "agent_activity"
+          [ ("hours", Some (string_of_float hours)) ]
+      in
+      let default_key = key_for 24.0 in
+      seed_cache default_key;
+      check
+        (of_pp Yojson.Safe.pp)
+        "the default window is served from its cache key"
+        (cache_sentinel default_key)
+        (Server_dashboard_http_agent_api.agent_activity_http_json
+           ~config ~hours:24.0);
+      let other =
+        Server_dashboard_http_agent_api.agent_activity_http_json
+          ~config ~hours:1.0
+      in
+      check bool "a different window does not reuse the 24h entry" false
+        (Yojson.Safe.equal other (cache_sentinel default_key));
+      let open Yojson.Safe.Util in
+      check (float 0.001) "the computed window is the one asked for" 1.0
+        (other |> member "hours" |> to_float))
+
 let test_dashboard_proof_http_json_surfaces_submission_index () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   let module V = Lib.Verification in
@@ -3546,6 +3611,10 @@ let () =
             test_catchup_judge_prompt_failure_is_server_error;
           test_case "proof payload exposes submission index" `Quick
             test_dashboard_proof_http_json_surfaces_submission_index;
+          test_case "scheduled-automation reads its cache key" `Quick
+            test_scheduled_automation_reads_its_cache_key;
+          test_case "agent-activity keys on its window" `Quick
+            test_agent_activity_keys_on_its_window;
           test_case "execution trust uses narrow Keeper projection" `Quick
             test_execution_trust_uses_narrow_keeper_projection;
           test_case "execution trust cannot call full Keeper projection" `Quick


### PR DESCRIPTION
## Where the remaining cost is

Every `GET /api/v1` route on the running server, timed twice back to back. A
second pass that collapses means a cache is in front; a second pass that holds
means each request pays the full compute.

| route | pass 1 | pass 2 | bytes | layers present |
|---|---|---|---|---|
| `dashboard/repository-observation-snapshot` | 722.9ms | **681.4ms** | 2.9KB | neither |
| `dashboard/tool-quality` | 483.0ms | 19.2ms | 22KB | cache + offload |
| `dashboard/telemetry` | 383.5ms | 14.9ms | 139KB | cache + offload |
| `dashboard/harness-health` | 339.5ms | 14.4ms | 7.5KB | cache + offload |
| `dashboard/scheduled-automation` | 272.0ms | **204.0ms** | 96KB | offload only |
| `agent-activity` | 104.5ms | **75.3ms** | 2.2KB | neither |

The cached routes are the expensive ones and they are fine — a first visitor
pays, nobody else does. The three in bold pay on every request.

## Structural picture

Of 112 registered GET routes, 24 carry `Dashboard_cache`, 21 carry
`Domain_pool_ref`, and 87 carry neither. That 87 reads alarming and is not:
cross-referenced against the sweep, the uncovered routes measure 15–21 ms
against a ~12 ms HTTP round-trip floor on this host. They compute almost
nothing, which is why nobody gave them a layer. Exactly two uncovered routes
are expensive, and this PR is those two.

## Change

**`scheduled-automation`** — offloaded but never cached, so a polling dashboard
re-ran the schedule projection every time for a 96 KB response.

It is registered twice: once on the HTTP/1 router, once on the H2 gateway,
where the registration carries a comment requiring the two to stay identical
("a client that reaches the server over H2 must not see a different
projection"). Adding a cache at each call site would have been two copies of
one policy and the first chance for them to drift, so both routes now call
`Server_dashboard_http.dashboard_scheduled_automation_http_json`, the way
`dashboard_proof_http_json` is already shared between the same two transports.

**`agent-activity`** — carried neither layer, so `summarize_agent_activity`
ran on the HTTP domain on every request.

Extracted to `agent_activity_http_json ~config ~hours` for the same
single-home reason, plus so a test can reach it without an HTTP round trip.
`hours` is part of the cache key because the window selects which rows the
scan covers — two windows are two answers, not one answer served twice.
`since` is derived inside the compute rather than keyed on: it moves with
wall-clock, so keying on it would make every request a miss. A cached window
is therefore anchored up to one TTL in the past, which is what a 30 s tier
means for a rollup whose default window is 24 h.

Both use `live_cache_ttl_s`, the documented 30 s tier for "frequently-changing
data such as active keeper state and agent status" — no new constant.

## Tests

Two cases in `test_dashboard_http_core.ml`, both in the `dashboard behavior
contracts` suite that CI runs via `@test/runtest-dashboard-http-behavior-contracts`
(verified running: indices 7 and 8, `[OK]`).

Each seeds a sentinel under the key the projection is supposed to consult and
asserts the projection returns it. A projection that stops consulting the cache
recomputes and answers with real data, so the assertion fails rather than
passing on a technicality.

`agent-activity` additionally asserts that a second window neither reuses the
first window's entry nor loses the window it was asked for.

Mutation — dropping the `scheduled-automation` cache and keeping the offload:

```
[FAIL]  dashboard behavior contracts  7  scheduled-automation reads its cache key
```

Restored: suite green under `--force`, so not a cache hit.

## Not in scope

- `dashboard/repository-observation-snapshot` costs 681 ms on every request:
  10 git subprocesses across 5 repositories, no cache. It is left alone
  deliberately — `rg` across the repo finds exactly one reference to it, its
  own route registration. No client, no test, no doc. Optimizing an endpoint
  with no consumers is the wrong move and so is caching it into permanence;
  whether it should exist is a separate call. Filed as an observation rather
  than fixed here.
- A comment on that route claims the `Eio.Fiber.List.map` fan-out makes the
  snapshot cost the slowest repository. Timed individually the repositories sum
  to 745 ms and the slowest is 252 ms, and the endpoint measures 681–723 ms.
  Sampling the process table during a request does show concurrent git children
  (peak 2–3 of 10), so the fan-out is real and the commentary is optimistic
  rather than wrong — 10 concurrent git processes contend. Not chased further.

RFC-WAIVED: dashboard read projections and their cache policy; no credential,
identity, operator control-plane, sandbox, hook, or workflow surface is
touched.
