### PR TITLE
fix(keeper): give the autonomous wake prompt a settings-panel projector

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -168,6 +168,15 @@ module KeeperAutonomous = struct
     else Ok trimmed
   ;;
 
+  (** The wording used when neither the fleet nor a keeper configures one.
+
+      This is the single definition; [Keeper_unified_prompt.autonomous_wake_marker]
+      is an alias of it. Keeping the literal here rather than in the prompt
+      module lets the operator settings projection report the same effective
+      value the prompt builder would use, without the projection reaching up a
+      layer to ask. *)
+  let default_wake_prompt = "Continue."
+
   (** Fleet-wide wake prompt, or [None] when unset. Read as a function: the
       value is steerable through the boot override store, and a keeper process
       outlives module-load time. *)
@@ -182,6 +191,11 @@ module KeeperAutonomous = struct
            (Env_config_core.Config_error
               (Printf.sprintf "MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT: %s" reason)))
   ;;
+
+  (** Fleet value else the literal default. This is what a keeper that states
+      no override of its own is woken with, and what the operator settings
+      projection reports. *)
+  let wake_prompt () = Option.value (wake_prompt_opt ()) ~default:default_wake_prompt
 end
 
 (** {1 Keeper Runtime Configuration} *)

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -59,11 +59,20 @@ module KeeperAutonomous : sig
       [autonomous_wake_prompt], so the two authoring surfaces cannot accept
       different values. *)
 
+  val default_wake_prompt : string
+  (** Wording used when neither fleet nor keeper configures one. Single
+      definition; {!Keeper_unified_prompt.autonomous_wake_marker} aliases it. *)
+
   val wake_prompt_opt : unit -> string option
   (** Fleet wake prompt, [None] when unset. Raises
       {!Env_config_core.Config_error} on a set-but-invalid value rather than
       falling back, so a typo surfaces at read time instead of silently
       restoring the default. *)
+
+  val wake_prompt : unit -> string
+  (** Fleet value else {!default_wake_prompt} -- what a keeper with no override
+      of its own is woken with, and what the operator settings projection
+      reports. *)
 end
 
 (** {1 Keeper runtime} *)

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -31,7 +31,7 @@ type turn_prompt_parts = {
    [effective_autonomous_wake_prompt]. Nothing classifies a turn by matching
    this string -- autonomy is a typed property of the turn -- and nothing may
    start, because the operator can change it. *)
-let autonomous_wake_marker = "Continue."
+let autonomous_wake_marker = Env_config_keeper.KeeperAutonomous.default_wake_prompt
 
 (* keeper profile, else fleet setting, else the literal above.
 
@@ -46,11 +46,7 @@ let effective_autonomous_wake_prompt
       ()
   =
   (* DET-OK: total resolution over two known sources, then a literal. *)
-  let fleet_or_literal () =
-    Option.value
-      (Env_config_keeper.KeeperAutonomous.wake_prompt_opt ())
-      ~default:autonomous_wake_marker
-  in
+  let fleet_or_literal () = Env_config_keeper.KeeperAutonomous.wake_prompt () in
   match profile_defaults with
   | Some d ->
     (match d.autonomous_wake_prompt with

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -563,6 +563,13 @@ let effective_setting_value (row : Keeper_runtime_setting_registry.setting) =
          display_float (Env_config_keeper.KeeperGeneratedMedia.retention_seconds ())
        | "MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC" ->
          display_float Env_config_keeper.KeeperGrpc.reconnect_backoff_sec
+       | "MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT" ->
+         (* Reports the same string the prompt builder would use for a keeper
+            with no override of its own, so the settings panel and the turn
+            agree. A keeper that sets [autonomous_wake_prompt] is not visible
+            here -- this row is the fleet value, and per-keeper overrides live
+            with the keeper. *)
+         Env_config_keeper.KeeperAutonomous.wake_prompt ()
        | "MASC_SEARXNG_URL" ->
          let url =
            match Env_config_core.raw_value_opt row.env_name with

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -559,6 +559,48 @@ let test_settings_projection_uses_typed_effective_values () =
     (deadline |> member "effective_value" |> to_string)
 ;;
 
+(* #28413. Adding a registry row gets a setting listed, but the effective-value
+   projector is a separate match on env_name whose fallthrough raises
+   "no typed effective-value projector for ...". A row without one still appears
+   in the operator panel -- with a null value and an error string -- which reads
+   as a broken setting rather than a missing projector. This asserts the row is
+   both present and readable, and that the panel reports the same string the
+   prompt builder resolves. *)
+let test_wake_prompt_is_readable_in_the_settings_projection () =
+  let open Yojson.Safe.Util in
+  let rows =
+    Keeper_runtime_config.settings_projection_to_yojson
+      (parse_or_fail "[autonomous]\nwake_prompt = \"what changed since your last turn?\"\n")
+    |> to_list
+  in
+  match
+    List.find_opt
+      (fun row ->
+         String.equal
+           (row |> member "env" |> to_string)
+           "MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT")
+      rows
+  with
+  | None -> fail "the wake prompt is absent from the operator settings projection"
+  | Some row ->
+    check string "the panel exposes the TOML key operators edit"
+      "autonomous.wake_prompt"
+      (row |> member "key" |> to_string);
+    check bool "the projection carries no error" true
+      (row |> member "effective_error" = `Null);
+    check string "the configured value is echoed back"
+      "what changed since your last turn?"
+      (row |> member "configured_value" |> to_string);
+    check string "the effective value is the one the prompt builder resolves"
+      (Keeper_unified_prompt.effective_autonomous_wake_prompt ())
+      (row |> member "effective_value" |> to_string);
+    check bool "the consumer is named" true
+      (row
+       |> member "consumers"
+       |> to_list
+       |> List.exists (fun c -> to_string c = "Keeper_unified_prompt"))
+;;
+
 (* PR #28225 review (comment 3761300276): the raw-config preview computed
    can_save from the keeper schema alone, but the raw-save path also runs the
    runtime parser (Runtime.save_config_text). A config that parses and passes
@@ -651,5 +693,7 @@ let () =
         ; test_case "whitespace stream idle env fails loud" `Quick test_resolved_stream_idle_timeout_whitespace_env_fails_loud
         ; test_case "preview precondition matches save (#28225)" `Quick
             test_preview_precondition_matches_save
+        ; test_case "wake prompt is readable in the settings panel (#28413)" `Quick
+            test_wake_prompt_is_readable_in_the_settings_projection
         ] )
     ]


### PR DESCRIPTION
#28456 후속. 그 PR 본문에서 "registry 투영으로 대시보드 노출이 자동으로 따라온다"고 썼는데, **절반만 맞았다.**

## 무엇이 깨져 있나

registry 행을 추가하면 setting 이 목록에 뜬다. 하지만 **effective value 투영기는 별도의 match** 이고, 그 fallthrough 는 이렇다:

```ocaml
| unsupported ->
  raise (Env_config_core.Config_error
    ("no typed effective-value projector for " ^ unsupported))
```

`MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT` 는 이 match 에 없다. 그래서 운영자 설정 패널에 행은 뜨는데:

```
effective_value : null
effective_error : "no typed effective-value projector for MASC_KEEPER_AUTONOMOUS_WAKE_PROMPT"
```

로 보인다. 투영기가 없다는 신호가 아니라 **설정이 고장 났다는 신호로 읽힌다.** 값을 편집해도 반영 여부를 패널에서 확인할 수 없다.

## 변경

투영기를 추가하고, 그 값이 프롬프트 빌더가 실제로 쓰는 값과 같도록 만든다.

리터럴 기본값의 소유자를 옮겼다: `Env_config_keeper.KeeperAutonomous.default_wake_prompt` 가 단일 정의이고 `Keeper_unified_prompt.autonomous_wake_marker` 는 그 alias 다. 투영기는 `lib/keeper_runtime` 에 있어 `lib/keeper` 를 올려다볼 수 없는데, 리터럴을 `lib/config` 에 두면 양쪽이 같은 정의를 본다. 두 번째 사본을 만들었다면 드리프트가 조용히 생겼을 자리다.

`wake_prompt ()` = 함대 값 else 리터럴. 프롬프트 해소와 패널 투영이 같은 함수를 부른다.

## 검증

```
test_runtime_toml_overrides           35 tests   OK
test_keeper_autonomous_turn_source    14 tests   OK
```

새 케이스 `wake prompt is readable in the settings panel (#28413)`:

- 행이 **존재**하는지 (없으면 fail)
- `key` 가 운영자가 편집하는 `autonomous.wake_prompt` 인지
- `effective_error` 가 null 인지
- `configured_value` 가 TOML 에 넣은 값을 그대로 돌려주는지
- `effective_value` 가 `Keeper_unified_prompt.effective_autonomous_wake_prompt ()` 와 **같은 문자열**인지 — 패널과 실제 턴이 어긋날 수 없게
- `consumers` 에 `Keeper_unified_prompt` 가 있는지

**변이 검증**: 투영기 case 만 삭제하면 이 테스트가 실패한다 (exit 1). 삭제해도 컴파일은 통과한다 — fallthrough 가 있어서 컴파일러는 누락을 못 잡는다. 그게 이 결함이 처음에 통과한 이유이고, 이 테스트가 필요한 이유다.

## 왜 이걸 놓쳤나

registry 에 넣으면 나머지가 따라온다고 **확인 없이 단정**했다. 실제로는 배선이 둘이고 하나만 자동이다. 사용자가 "대시보드에서 볼 수 있는 거냐"고 물어서 확인했고, 물어보지 않았으면 값이 에러로 뜨는 설정이 그대로 남았을 것이다.

RFC-WAIVED: credential/identity/operator/sandbox/hooks/workflow 어느 subsystem 도 건드리지 않는다. keeper 설정 투영과 그 테스트만 바뀐다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
