### PR TITLE
perf(audit-log): decode audit rows during the read

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -261,18 +261,21 @@ let get_audit_store (config : config) : Dated_jsonl.t =
       audit_store_cache := StringMap.add base store !audit_store_cache;
       store)
 
-(** Parse JSON list into audit entries. Logs first 5 failures individually,
-    then a summary. Returns only successfully parsed entries. *)
+(** How many individual corrupt-entry failures {!collect_entries} reports
+    before it switches to a suppressed count in the summary. *)
 let max_logged_errors = 5
 
-let parse_entries (jsons : Yojson.Safe.t list) : audit_entry list =
-  (* Logging side effects (per-entry corrupt-entry ERROR, rate-limited
-     by [max_logged_errors]) are kept inside the fold body — they are
-     observably equivalent to the original [List.iter] order. *)
+(* Takes decode results rather than rows. [read_entries] decodes during the
+   read so the parsed trees are not all held at once, and the reader calls its
+   projection newest-first — so the rate-limited logging below must stay out of
+   the projection, or which five failures get reported would flip. Folding over
+   the returned (chronological) list keeps the reported set and the [#N]
+   numbering identical to reading the whole window first. *)
+let collect_entries (decoded : (audit_entry, string) result list) :
+    audit_entry list =
   let ok_rev, err_count =
     List.fold_left
-      (fun (ok, errc) json ->
-        match entry_of_json_r json with
+      (fun (ok, errc) -> function
         | Ok entry -> (entry :: ok, errc)
         | Error reason ->
             let errc = errc + 1 in
@@ -280,11 +283,11 @@ let parse_entries (jsons : Yojson.Safe.t list) : audit_entry list =
               Log.Misc.error "audit_log: corrupt entry (#%d): %s" errc reason;
             (ok, errc))
       ([], 0)
-      jsons
+      decoded
   in
   if err_count > 0 then
     Log.Misc.error "audit_log: %d/%d entries failed to parse (possible corruption)%s"
-      err_count (List.length jsons)
+      err_count (List.length decoded)
       (if err_count > max_logged_errors
        then Printf.sprintf " (%d more suppressed)" (err_count - max_logged_errors)
        else "");
@@ -294,7 +297,9 @@ let parse_entries (jsons : Yojson.Safe.t list) : audit_entry list =
     Structural parse failures go through [parse_entries] ERROR path. *)
 let read_entries ?(n = 10_000) (config : config) : audit_entry list =
   let store = get_audit_store config in
-  Dated_jsonl.read_recent store n |> parse_entries
+  Dated_jsonl.filter_map_recent store n ~f:(fun json ->
+    Some (entry_of_json_r json))
+  |> collect_entries
 
 (** Append a single entry to the audit log (thread-safe via Dated_jsonl). *)
 let append_entry (config : config) (entry : audit_entry) =

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -12,7 +12,7 @@
 
     Internal helpers ([preview], [outcome_to_json]
     decoders, the [audit_store_cache] and its mutex,
-    [get_audit_store], [parse_entries], [max_logged_errors],
+    [get_audit_store], [collect_entries], [max_logged_errors],
     [remove_assoc_keys]) are hidden — callers use the typed log
     helpers and the read / prune / stats accessors only.
 

--- a/test/test_audit_log.ml
+++ b/test/test_audit_log.ml
@@ -118,6 +118,47 @@ let test_get_stats_reports_oldest_and_newest_in_read_order () =
       check (option (float 0.001)) "newest is the last row read" (Some 300.0)
         stats.Audit_log.newest_timestamp)
 
+(* [read_entries] decodes rows during the read. The reader calls its
+   projection newest-first while returning the rows oldest-first, so the
+   caller-visible order is what needs pinning; the rate-limited corrupt-entry
+   logging stays out of the projection precisely so it cannot follow the scan
+   direction. *)
+let test_read_entries_is_chronological_and_drops_corrupt_rows () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      List.iter
+        (fun ts ->
+          Audit_log.append_entry config
+            (entry ~timestamp:ts ~agent_id:(Printf.sprintf "keeper-%.0f" ts)
+               ~action:Audit_log.AuthSuccess ~outcome:Audit_log.Success))
+        [ 100.0; 200.0; 300.0 ];
+      (* Well-formed JSON that is not a decodable audit entry: it survives the
+         reader's own malformed-row filter and must be dropped by the decode
+         path instead. *)
+      let audit_dir =
+        Filename.concat (Workspace_utils.masc_dir config) "audit"
+      in
+      let day_file =
+        match Sys.readdir audit_dir with
+        | [| month |] ->
+          let month_dir = Filename.concat audit_dir month in
+          Filename.concat month_dir (Sys.readdir month_dir).(0)
+        | _ -> fail "expected exactly one month directory"
+      in
+      Fs_compat.append_file day_file ({|{"not":"an audit entry"}|} ^ "\n");
+      let entries = Audit_log.read_entries ~n:10 config in
+      check (list (float 0.001)) "oldest first"
+        [ 100.0; 200.0; 300.0 ]
+        (List.map (fun (e : Audit_log.audit_entry) -> e.timestamp) entries);
+      check (list string) "agents follow the same order"
+        [ "keeper-100"; "keeper-200"; "keeper-300" ]
+        (List.map (fun (e : Audit_log.audit_entry) -> e.agent_id) entries))
+
 (* ── Codec round-trip tests ────────────────────────────────────────── *)
 
 let action_roundtrip label action expected_wire =
@@ -312,6 +353,8 @@ let () =
             test_audit_events_filter_severity_before_paging;
           test_case "get_stats reports oldest and newest in read order" `Quick
             test_get_stats_reports_oldest_and_newest_in_read_order;
+          test_case "read_entries is chronological and drops corrupt rows"
+            `Quick test_read_entries_is_chronological_and_drops_corrupt_rows;
         ] );
       ( "codec_roundtrip",
         [


### PR DESCRIPTION
Third of the `read_recent |> decode` migrations from #28455. This is the one that PR deferred because its decoder has order-sensitive side effects.

## Why it was deferred, and what makes it safe now

`parse_entries` logs the first five corrupt entries individually, numbered `#1`..`#5`, then a summary with the suppressed count. `filter_map_recent` calls its projection newest-first (#28458 documented this), so moving that logging into the projection would silently change *which* five failures get reported and what number each carries.

The fix is not to reorder anything: keep the side effects out of the projection.

- the projection is now `fun json -> Some (entry_of_json_r json)` — pure, so scan direction cannot leak into anything observable
- `parse_entries` becomes `collect_entries`, taking `(audit_entry, string) result list` instead of `Yojson.Safe.t list`, and runs the identical fold over the returned list, which is chronological

Reported set, `#N` numbering, the `%d/%d` totals, and the suppressed count are therefore unchanged, while the parsed trees are no longer all held at once. `parse_entries` was hidden in the mli, so the rename has no external callers; the mli's hidden-helpers list is updated.

## Verification (local)

| check | result |
|---|---|
| `dune build --root . test/test_audit_log.exe` | `BUILD_EXIT=0` |
| `test_audit_log.exe` | **11 tests run, Test Successful** |

New case `read_entries is chronological and drops corrupt rows`: appends three entries at timestamps 100/200/300, then appends a well-formed JSON object that is *not* a decodable audit entry — it passes the reader's own malformed-row filter, so it exercises the decode-drop path rather than the parse-skip path. Asserts oldest-first on both timestamps and agent ids.

`test_audit_log` runs in CI (added to the focused allowlist in #28455).

## Correction to earlier scoping

While reading the neighbouring code for this change I found that `telemetry_unified.ml:392-416` already carries the measurement RFC-0372 §7 asks for:

```
n =  2_000 ->  80.2 MB, 0.49 s
n =  5_000 -> 129.4 MB, 1.03 s
n = 10_000 -> 185.1 MB, 2.29 s
```

— "roughly 13 KB of heap per entry (a ~25x expansion over the 521-byte JSON rows) on top of a ~54 MB fixed cost", with `max_read_entries = 2_000` derived from it. `read_limit` is already abstract so an unbounded request cannot be constructed, and the per-store merge already trims after each store. Phase 2 is further along than the RFC text alone suggests. No new measurement harness is needed for the ceiling; what remains on that axis is whether the allowance spans stores rather than applying per store.

## Not claimed

No throughput or RSS number from this PR. The RFC-0372 §5 gate needs the idle p95 ≤ 50 ms control and this host is at load average 270+.

RFC-WAIVED: `lib/audit_log.ml`, `lib/audit_log.mli`, one test file. None of the RFC-required subsystems. Direction is set by existing RFC-0372.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
