### PR TITLE
fix(dashboard): give the cache timeout envelope one producer and one reader

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -179,14 +179,61 @@ let should_restore_stale_after_failure exn =
   | Eio.Cancel.Cancelled _ -> true
   | _ -> false
 
-let timeout_json ~key ~timeout_sec ~timeout_kind =
+(* The one shape a timed-out compute takes on the wire.
+
+   Every timeout path in this module goes through [timeout_error_json], and the
+   only sanctioned reader is [is_timeout_envelope] beside it. Both read
+   [timeout_error_code], so changing the wire value cannot leave a reader
+   behind — a recognizer that lives in another module and matches the string
+   itself drifts silently the moment a producer changes.
+
+   The envelope still travels in-band, as a value indistinguishable from a
+   computed payload until a reader checks; #28400 tracks moving it out of band
+   and giving it its own HTTP status. *)
+let timeout_error_code = "computation_timeout"
+
+type timeout_envelope = {
+  key : string;
+  timeout_sec : float;
+  timeout_kind : string;
+  waiting : bool;
+}
+
+let timeout_envelope_message { key; timeout_sec; timeout_kind; waiting } =
+  match timeout_kind with
+  | "circuit_open" ->
+    Printf.sprintf "Dashboard %s is failing fast after repeated cache timeouts" key
+  | _ when waiting ->
+    Printf.sprintf
+      "Dashboard %s timed out after %.0fs waiting for an in-flight computation"
+      key timeout_sec
+  | _ -> Printf.sprintf "Dashboard %s timed out after %.0fs" key timeout_sec
+
+let timeout_envelope_json envelope =
   `Assoc
     [
-      ("error", `String "computation_timeout");
-      ("timeout_sec", `Float timeout_sec);
-      ("key", `String key);
-      ("timeout_kind", `String timeout_kind);
+      ("error", `String timeout_error_code);
+      ("message", `String (timeout_envelope_message envelope));
+      ("generated_at", `String (Masc_domain.now_iso ()));
+      ("timeout_kind", `String envelope.timeout_kind);
+      ("timeout_sec", `Float envelope.timeout_sec);
+      ("key", `String envelope.key);
     ]
+
+let is_timeout_envelope = function
+  | `Assoc fields ->
+    (match List.assoc_opt "error" fields with
+     | Some (`String code) -> String.equal code timeout_error_code
+     | _ -> false)
+  | _ -> false
+
+let timeout_error_json ?timeout_kind ?(waiting = false) key timeout_sec =
+  let timeout_kind =
+    match timeout_kind with
+    | Some timeout_kind -> timeout_kind
+    | None -> if waiting then "waiter" else "owner"
+  in
+  timeout_envelope_json { key; timeout_sec; timeout_kind; waiting }
 
 (** Maximum seconds a waiter will poll for a [Computing] slot before evicting
     it and recomputing.
@@ -498,8 +545,8 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
                       ((), SMap.add key (Ready cooldown) map)
                   | None ->
                       let err_json =
-                        timeout_json ~key ~timeout_sec:(max_wait_sec ())
-                          ~timeout_kind:"compute"
+                        timeout_error_json ~timeout_kind:"compute" key
+                          (max_wait_sec ())
                       in
                       fallback_val := Some err_json;
                       let cooldown = { value = err_json; expires_at = ts +. 5.0; stale_until = ts +. 5.0 } in
@@ -508,7 +555,8 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
            );
            (match !fallback_val with
             | Some v -> v
-            | None -> `Assoc [("error", `String "Compute timeout")]))
+            | None ->
+                timeout_error_json ~timeout_kind:"compute" key (max_wait_sec ())))
     | `Retry_stuck (elapsed, _ceiling) ->
       (* Pair the watchdog with an SLO-actionable signal: if this counter
          climbs sustainedly, [release_on_cancel] is not firing and the
@@ -574,34 +622,6 @@ let peek key =
   | Some (Ready entry) when entry.stale_until > ts -> Some entry.value
   | Some (Computing { stale = Some stale_value; _ }) -> Some stale_value
   | _ -> None
-
-let timeout_error_json ?timeout_kind ?(waiting = false) key timeout_sec =
-  let timeout_kind =
-    match timeout_kind with
-    | Some timeout_kind -> timeout_kind
-    | None -> if waiting then "waiter" else "owner"
-  in
-  let message =
-    match timeout_kind with
-    | "circuit_open" ->
-      Printf.sprintf
-        "Dashboard %s is failing fast after repeated cache timeouts" key
-    | _ when waiting ->
-      Printf.sprintf
-        "Dashboard %s timed out after %.0fs waiting for an in-flight computation"
-        key timeout_sec
-    | _ ->
-      Printf.sprintf "Dashboard %s timed out after %.0fs" key timeout_sec
-  in
-  `Assoc
-    [
-      ("error", `String "computation_timeout");
-      ("message", `String message);
-      ("generated_at", `String (Masc_domain.now_iso ()));
-      ("timeout_kind", `String timeout_kind);
-      ("timeout_sec", `Float timeout_sec);
-      ("key", `String key);
-    ]
 
 (* RFC-0372 Phase 5 — a bounded compute is still not a yielding compute.
 

--- a/lib/dashboard/dashboard_cache.mli
+++ b/lib/dashboard/dashboard_cache.mli
@@ -37,6 +37,19 @@ exception Compute_timeout of string * bool
     Callers of [get_or_compute_with_timeout] do not need to handle this —
     it is caught and converted to a timeout-error JSON response. *)
 
+val timeout_error_code : string
+(** The [error] value carried by every timeout envelope this module emits. *)
+
+val is_timeout_envelope : Yojson.Safe.t -> bool
+(** [is_timeout_envelope json] is [true] when [json] is a timeout envelope
+    produced by this module rather than a computed payload.
+
+    Readers must call this instead of matching the [error] string themselves:
+    the recognizer shares {!timeout_error_code} with the producer, so the wire
+    value cannot change under a reader. The envelope still travels in-band as
+    data, which is why every reader needs this check at all; #28400 tracks
+    moving it out of band and giving it its own HTTP status. *)
+
 val get_or_compute_with_timeout :
   string -> ttl:float -> clock:_ Eio.Time.clock -> timeout_sec:float ->
   (unit -> Yojson.Safe.t) -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -305,14 +305,6 @@ let remember_dashboard_shell_last_good ~light json =
   else Atomic.set last_good_shell json
 ;;
 
-let is_dashboard_cache_timeout_json = function
-  | `Assoc fields ->
-    (match List.assoc_opt "error" fields with
-     | Some (`String ("Compute timeout" | "computation_timeout")) -> true
-     | _ -> false)
-  | _ -> false
-;;
-
 module Shell_projection_trace = Server_dashboard_shell_projection_trace
 
 type shell_projection_trace_status =
@@ -742,7 +734,7 @@ let dashboard_shell_http_json
         | None -> cache_load ()
         | Some t -> Server_timing.measure t Cache_lookup cache_load
       in
-      if is_dashboard_cache_timeout_json computed
+      if Dashboard_cache.is_timeout_envelope computed
       then timeout_fallback_payload (dashboard_shell_timeout_for ~light)
       else (
         remember_dashboard_shell_last_good ~light computed;

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -160,6 +160,3 @@ val dashboard_shell_payload_json :
   ?timing:Server_timing.t ->
   ?light:bool ->
   Workspace.config -> Yojson.Safe.t
-
-val is_dashboard_cache_timeout_json :
-  Yojson.Safe.t -> bool

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -47,7 +47,7 @@ let warm_shell_cache (state : Mcp_server.server_state) =
        in
        (try
           let light_result = cache_shell_payload ~light:true in
-          if is_dashboard_cache_timeout_json light_result
+          if Dashboard_cache.is_timeout_envelope light_result
           then
             Log.Dashboard.warn
               "light shell cache pre-warm timed out during compute (%.0fs)"
@@ -65,7 +65,7 @@ let warm_shell_cache (state : Mcp_server.server_state) =
             (Printexc.to_string exn));
        try
          let result = cache_shell_payload ~light:false in
-         if is_dashboard_cache_timeout_json result
+         if Dashboard_cache.is_timeout_envelope result
          then
            Log.Dashboard.warn
              "shell cache pre-warm timed out during compute (%.0fs)"

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -85,7 +85,7 @@ let schedule_namespace_truth_shell_refresh ~sw ~clock config =
                      Env_config_runtime.Dashboard.shell_timeout_sec;
                    `Assoc []
                in
-               if result <> `Assoc [] && not (is_dashboard_cache_timeout_json result)
+               if result <> `Assoc [] && not (Dashboard_cache.is_timeout_envelope result)
                then (
                  Atomic.set last_good_shell result;
                  Atomic.set shell_warmed true;

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -424,14 +424,7 @@ let test_stale_preserved_on_timeout ~clock ~sw () =
     Dashboard_cache.get_or_compute "stale_timeout" ~ttl:0.1 (fun () ->
       `String "fresh_recompute")
   in
-  let is_timeout_error =
-    match after with
-    | `Assoc pairs ->
-      (match List.assoc_opt "error" pairs with
-       | Some (`String "computation_timeout") -> true
-       | _ -> false)
-    | _ -> false
-  in
+  let is_timeout_error = Dashboard_cache.is_timeout_envelope after in
   Alcotest.(check bool) "no timeout error cached" false is_timeout_error
 
 (* -- 10. Expired stale falls back to last-good on timeout ------------------- *)
@@ -456,14 +449,7 @@ let test_expired_stale_restored_on_timeout ~clock () =
     Dashboard_cache.get_or_compute "expired_stale_timeout" ~ttl:0.05 (fun () ->
       `String "fresh_after_restore")
   in
-  let is_timeout_error =
-    match after with
-    | `Assoc pairs ->
-      (match List.assoc_opt "error" pairs with
-       | Some (`String "computation_timeout") -> true
-       | _ -> false)
-    | _ -> false
-  in
+  let is_timeout_error = Dashboard_cache.is_timeout_envelope after in
   Alcotest.(check bool) "expired stale restore avoids timeout poison" false
     is_timeout_error
 
@@ -481,14 +467,7 @@ let test_timeout_no_stale_returns_error ~clock () =
         `String "never_reached")
   in
   (* Should get timeout error JSON *)
-  let is_timeout_error =
-    match result with
-    | `Assoc pairs ->
-      (match List.assoc_opt "error" pairs with
-       | Some (`String "computation_timeout") -> true
-       | _ -> false)
-    | _ -> false
-  in
+  let is_timeout_error = Dashboard_cache.is_timeout_envelope result in
   Alcotest.(check bool) "timeout error returned" true is_timeout_error;
   (* Next call should recompute, not return cached error *)
   let v2 =
@@ -741,6 +720,51 @@ let test_compute_leaves_caller_domain ~clock ~sw ~dm () =
         true
         (d <> caller_domain))
 
+(* -- The timeout envelope has one producer and one recognizer -------------- *)
+
+(** Every timeout path returns the same envelope and the recognizer that sits
+    beside the producer accepts all of them, so no reader has to match the
+    [error] string itself.
+
+    The literal pins the value clients route on
+    ([dashboard/src/api/core.ts:725] branches on
+    [errorCode = "computation_timeout"]), so changing
+    {!Dashboard_cache.timeout_error_code} fails here rather than at a client
+    that quietly stops recognizing timeouts.
+
+    The control is a computed payload that carries its own [error] field: it
+    must stay unrecognized, or the check would swallow real data. *)
+let test_timeout_envelope_recognizer ~clock () =
+  Alcotest.(check string) "wire value clients route on" "computation_timeout"
+    Dashboard_cache.timeout_error_code;
+  Dashboard_cache.invalidate_all ();
+  let slow () =
+    Eio.Time.sleep clock 1.0;
+    `String "never_reached"
+  in
+  let timed_out () =
+    Dashboard_cache.get_or_compute_with_timeout "envelope_paths" ~ttl:1.0
+      ~clock ~timeout_sec:0.05 slow
+  in
+  let owner = timed_out () in
+  Alcotest.(check string) "owner kind" "owner" (timeout_kind owner);
+  Alcotest.(check bool) "owner envelope recognized" true
+    (Dashboard_cache.is_timeout_envelope owner);
+  for _ = 1 to 2 do
+    ignore (timed_out () : Yojson.Safe.t)
+  done;
+  let circuit = timed_out () in
+  Alcotest.(check string) "circuit kind" "circuit_open" (timeout_kind circuit);
+  Alcotest.(check bool) "circuit envelope recognized" true
+    (Dashboard_cache.is_timeout_envelope circuit);
+  Dashboard_cache.invalidate_all ();
+  let computed =
+    Dashboard_cache.get_or_compute "envelope_control" ~ttl:1.0 (fun () ->
+      `Assoc [ ("error", `String "not_a_timeout"); ("rows", `List []) ])
+  in
+  Alcotest.(check bool) "computed payload is not an envelope" false
+    (Dashboard_cache.is_timeout_envelope computed)
+
 (* -- Harness ---------------------------------------------------------------- *)
 
 let () =
@@ -818,5 +842,7 @@ let () =
             (test_repeated_no_stale_timeout_opens_circuit ~clock);
           test_case "waiter timeout returns error, not cached" `Quick
             (test_waiter_timeout_returns_error_not_cached ~clock);
+          test_case "timeout envelope producer and recognizer agree" `Quick
+            (test_timeout_envelope_recognizer ~clock);
         ] );
     ]


### PR DESCRIPTION
## 무엇이 문제였나

`dashboard_cache` 가 타임아웃 봉투를 **세 곳에서 서로 다른 모양으로** 만들었고, 그걸 읽는 코드는 **다른 모듈에 하나** 있었습니다.

| 생산자 | 모양 | `error` 값 |
|---|---|---|
| `timeout_json` | 4 필드 | `computation_timeout` |
| `timeout_error_json` | 6 필드 | `computation_timeout` |
| no-stale 폴백 (인라인 리터럴) | 1 필드 | `Compute timeout` |

리더는 `server_dashboard_http_core.is_dashboard_cache_timeout_json` 하나였고, 두 `error` 문자열을 손으로 매치했습니다:

```ocaml
| Some (`String ("Compute timeout" | "computation_timeout")) -> true
```

리더가 다른 모듈에 있으면 생산자가 바뀔 때 컴파일러가 잡아주지 못합니다. 그래서 이 분류기의 arm 개수는 계약이 아니라 **드리프트 개수**를 세고 있었고, 1 필드 모양은 `key` 도 `timeout_sec` 도 없어 정보 손실까지 있었습니다.

## 무엇을 바꿨나

- 타임아웃 경로 3곳 전부 `timeout_error_json` 하나를 지나갑니다. 폴백도 이제 `key` / `timeout_sec` / `timeout_kind` 를 싣습니다.
- `is_timeout_envelope` 를 생산자 옆에 두고 `.mli` 로 export 했습니다. 둘 다 `timeout_error_code` 를 읽습니다.
- 서버 검출 3곳(`server_dashboard_http_core.ml:745`, `execution_surfaces.ml:50,68`, `namespace_truth.ml:88`)과 `server_dashboard_http_core.mli` 의 export 를 recognizer 호출로 교체하고 분류기를 삭제했습니다.
- 테스트가 들고 있던 손수 만든 매처 3벌도 recognizer 로 교체했습니다. 테스트가 자기 매처를 가지고 있으면 생산자가 바뀌어도 초록으로 남습니다.

동작 변화는 폴백 봉투가 `key` / `timeout_sec` / `timeout_kind` / `message` / `generated_at` 를 추가로 싣는 것뿐입니다. 클라이언트는 `dashboard/src/api/core.ts:725` 에서 `errorCode` 만 분기하므로 additive 입니다.

## 검증

`dune build @check --root .` → exit 0 (전체 타입체크)
`./_build/default/test/test_dashboard_cache.exe` → `Test Successful in 2.019s. 30 tests run.`

새 테스트 `timeout envelope producer and recognizer agree` 가 회귀를 실제로 잡는지 mutation 으로 확인했습니다:

| mutation | 결과 |
|---|---|
| M1 — `is_timeout_envelope` 가 `timeout_error_code` 대신 리터럴을 비교 (리더 드리프트 재현) | exit 2, 4 FAIL |
| M2 — `timeout_error_code` 를 `"cache_timeout"` 으로 변경 (wire 값 변경) | exit 2, 3 FAIL |
| 대조군 — 원복 | exit 0, 30 tests |

테스트에는 컨트롤을 하나 넣었습니다: 자기 `error` 필드를 가진 계산 payload 는 봉투로 인식되면 안 됩니다. 인식하면 실데이터를 삼킵니다.

## 범위 밖

봉투는 여전히 in-band 로 HTTP 200 에 실려 나갑니다. 검출하지 않는 라우트는 그대로 200 + 봉투를 내려보냅니다. 상태 코드 축은 #28400 에 남아 있고, 이 PR 은 그걸 고치지 않습니다.

그 축을 여기서 같이 하지 않은 이유: 단일 초크 포인트가 `Http_server_eio.Response.json_value` (lib/server 직접 사용 280곳 + CORS 래퍼 122곳) 인데, 거기서 봉투를 판정하려면 하위 라이브러리가 `masc.dashboard` 를 알아야 합니다. 의존성 역방향이라 callback 역전이 필요하고, 그건 이 PR 과 다른 설계 결정입니다.

Refs #28400

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
