### PR TITLE
perf(telemetry): probe stores for a timestamp without keeping their rows

### DIFF
--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -119,11 +119,25 @@ let latest_ts_of_entries (entries : Yojson.Safe.t list) : float option =
       if ts > 0.0 then max_ts_opt acc ts else acc)
     None entries
 
+(* How many newest rows a freshness probe scans. Rows are append-ordered by
+   time, but a row can carry no usable timestamp, so the probe takes the max
+   over a small window rather than trusting the newest row alone. *)
+let latest_ts_probe_rows = 64
+
+(* Projects each scanned row to its timestamp instead of returning the parsed
+   rows: this runs once per store, and the summary path runs it once per
+   keeper, so retaining [latest_ts_probe_rows] trees per store made the
+   resident set scale with keeper count — the axis RFC-0372 §5 gates Phase 2
+   on. Same value as [latest_ts_of_entries] over the same window. *)
 let latest_store_ts source dir label : float option =
   if not (Sys.file_exists dir) then None
   else
     match Dated_jsonl.create ~base_dir:dir () with
-    | store -> latest_ts_of_entries (Dated_jsonl.read_recent store 64)
+    | store ->
+      Dated_jsonl.filter_map_recent store latest_ts_probe_rows ~f:(fun json ->
+        let ts = extract_ts json in
+        if ts > 0.0 then Some ts else None)
+      |> List.fold_left max_ts_opt None
     | exception (Eio.Cancel.Cancelled _ as e) -> raise e
     | exception exn ->
       observe_source_read_failure_exn source ~site:"latest_store_ts" exn;
@@ -490,6 +504,33 @@ let read_fixed_source dir source ~n ?since_ts ?until_ts () : Yojson.Safe.t list 
       observe_source_read_failure_exn source ~site:"read_fixed_source" exn;
       []
 
+(* The probe stage of [read_keeper_metrics_fast_top] needs one number per
+   keeper directory: the newest timestamp that directory can offer. Reading its
+   rows and keeping them made the resident set scale with keeper count — up to
+   64 parsed rows per directory, held for every directory at once, at the
+   ~13 KB per entry this module measured above. That is the axis RFC-0372 §5
+   makes the Phase 2 gate: adding a keeper must not raise the ceiling.
+
+   Projecting to the timestamp during the read costs one float per row instead
+   of one tree. Store classification and failure handling mirror
+   {!read_fixed_source} exactly, including that only [Dated_jsonl.create] is
+   guarded — a read that raises still propagates. Entries are not tagged
+   because nothing downstream sees them. *)
+let probe_latest_ts dir source ~n : float option =
+  match classify_store_dir source ~site:"probe_latest_ts_dir" dir with
+  | Store_missing | Store_invalid -> None
+  | Store_directory ->
+    match Dated_jsonl.create ~base_dir:dir () with
+    | store ->
+      Dated_jsonl.filter_map_recent store n ~f:(fun json ->
+        let ts = extract_ts json in
+        if ts > 0.0 then Some ts else None)
+      |> List.fold_left max_ts_opt None
+    | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+    | exception exn ->
+      observe_source_read_failure_exn source ~site:"probe_latest_ts" exn;
+      None
+
 (* ── Read keeper metrics (per-keeper directories) ───── *)
 
 let read_keeper_metrics ~masc_root ?keeper_name ?since_ts ?until_ts ~n () :
@@ -504,21 +545,20 @@ let read_keeper_metrics ~masc_root ?keeper_name ?since_ts ?until_ts ~n () :
 
 let read_keeper_metrics_fast_top ~masc_root ~n () : Yojson.Safe.t list =
   let target = n + 1 in
-  let probe_limit = min 64 target in
+  let probe_limit = min latest_ts_probe_rows target in
   let dirs = discover_keeper_metric_dirs masc_root in
   let probes =
     List.filter_map
       (fun (name, dir) ->
-        let entries = read_fixed_source dir Keeper_metric ~n:probe_limit () in
-        match latest_ts_of_entries entries with
+        match probe_latest_ts dir Keeper_metric ~n:probe_limit with
         | None -> None
-        | Some latest_ts -> Some (name, dir, latest_ts, entries))
+        | Some latest_ts -> Some (name, dir, latest_ts))
       dirs
-    |> List.sort (fun (_, _, a, _) (_, _, b, _) -> Float.compare b a)
+    |> List.sort (fun (_, _, a) (_, _, b) -> Float.compare b a)
   in
   let rec loop acc = function
     | [] -> acc
-    | (_name, dir, latest_ts, probe_entries) :: rest ->
+    | (_name, dir, latest_ts) :: rest ->
       let acc = sort_newest_first acc |> take_first target in
       let cutoff =
         if List.length acc < target then None
@@ -527,10 +567,11 @@ let read_keeper_metrics_fast_top ~masc_root ~n () : Yojson.Safe.t list =
       (match cutoff with
        | Some ts when latest_ts < ts -> acc
        | _ ->
-         let entries =
-           if target <= probe_limit then probe_entries
-           else read_fixed_source dir Keeper_metric ~n:target ()
-         in
+         (* Re-read rather than reusing probe rows. Holding them to save this
+            read for small [target] is what made the probe cost scale with
+            keeper count; the cutoff above already skips most directories, so
+            the reads this adds are the ones that contribute to the result. *)
+         let entries = read_fixed_source dir Keeper_metric ~n:target () in
          loop (sort_newest_first (entries @ acc) |> take_first target) rest)
   in
   loop [] probes

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=660
+UNWIRED_BASELINE=659
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -137,6 +137,7 @@ normal_targets=(
   @test/runtest-test_keeper_secret_redaction
   @test/runtest-test_keeper_sandbox_docker_route
   @test/runtest-test_dashboard_dev_token_host_gate
+  @test/runtest-test_telemetry_unified_keeper_fan_in
   @test/runtest-test_dated_jsonl
   @test/runtest-test_audit_log
   @test/keeper_github_identity/runtest

--- a/test/dune
+++ b/test/dune
@@ -1698,6 +1698,8 @@
 
 (include stanzas/test_dated_jsonl.inc)
 
+(include stanzas/test_telemetry_unified_keeper_fan_in.inc)
+
 (include stanzas/test_dated_jsonl_mutex_registry_10372.inc)
 
 (include stanzas/test_dated_jsonl_count_cache.inc)

--- a/test/stanzas/test_telemetry_unified_keeper_fan_in.inc
+++ b/test/stanzas/test_telemetry_unified_keeper_fan_in.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_telemetry_unified_keeper_fan_in)
+ (modules test_telemetry_unified_keeper_fan_in)
+ (libraries alcotest masc_test_deps))

--- a/test/test_telemetry_unified_keeper_fan_in.ml
+++ b/test/test_telemetry_unified_keeper_fan_in.ml
@@ -1,0 +1,142 @@
+(** Characterisation of the unfiltered keeper-metric fan-in.
+
+    With no [keeper_name] and no correlation filter, [read_unified] routes
+    [Keeper_metric] through an internal fast path that probes every keeper
+    directory for its newest timestamp, sorts the directories by it, and then
+    reads entries only while a directory can still beat the running cutoff.
+
+    That path has no test. These pin what it returns — newest-first, across
+    keeper directories, honouring the limit — so the probe stage can be changed
+    without guessing at its contract. The probe currently retains every
+    directory's probe rows, which is a cost proportional to keeper count and
+    the axis RFC-0372 §5 makes the Phase 2 gate; nothing below depends on that
+    retention. *)
+
+open Alcotest
+
+let counter = ref 0
+
+let temp_root () =
+  incr counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "telemetry_fan_in_%d_%d" !counter (Unix.getpid ()))
+  in
+  Fs_compat.mkdir_p dir;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+(* One keeper's metrics store, seeded with the given timestamps in the order
+   given. The reader treats a day-file as append-ordered. *)
+let seed_keeper masc_root ~name ~timestamps =
+  let metrics_dir =
+    Filename.concat
+      (Filename.concat (Filename.concat masc_root Common.keepers_runtime_dirname) name)
+      "metrics"
+  in
+  let month_dir = Filename.concat metrics_dir "2026-01" in
+  Fs_compat.mkdir_p month_dir;
+  let buf = Buffer.create 512 in
+  List.iter
+    (fun ts ->
+      Buffer.add_string buf
+        (Printf.sprintf {|{"timestamp":%.1f,"keeper":"%s","kind":"metric"}|} ts name);
+      Buffer.add_char buf '\n')
+    timestamps;
+  Fs_compat.append_file (Filename.concat month_dir "01.jsonl") (Buffer.contents buf)
+
+let timestamps_of entries =
+  List.map
+    (fun json -> Yojson.Safe.Util.(json |> member "timestamp" |> to_float))
+    entries
+
+let read_top root ~n =
+  Telemetry_unified.read_unified ~base_path:root ~masc_root:root
+    ~sources:[ Telemetry_unified.Keeper_metric ]
+    ~limit:(Telemetry_unified.read_limit_of_int n)
+    ()
+
+let with_root f =
+  let root = temp_root () in
+  Fun.protect ~finally:(fun () -> cleanup_dir root) (fun () -> f root)
+
+let test_returns_newest_first_across_keepers () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_root (fun root ->
+    seed_keeper root ~name:"alpha" ~timestamps:[ 100.0; 400.0 ];
+    seed_keeper root ~name:"bravo" ~timestamps:[ 200.0; 500.0 ];
+    seed_keeper root ~name:"charlie" ~timestamps:[ 300.0 ];
+    check (list (float 0.001)) "newest first across all keeper stores"
+      [ 500.0; 400.0; 300.0; 200.0; 100.0 ]
+      (timestamps_of (read_top root ~n:10)))
+
+let test_limit_takes_the_newest_slice () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_root (fun root ->
+    seed_keeper root ~name:"alpha" ~timestamps:[ 100.0; 400.0 ];
+    seed_keeper root ~name:"bravo" ~timestamps:[ 200.0; 500.0 ];
+    seed_keeper root ~name:"charlie" ~timestamps:[ 300.0 ];
+    check (list (float 0.001)) "limit keeps the newest two"
+      [ 500.0; 400.0 ]
+      (timestamps_of (read_top root ~n:2)))
+
+(* A keeper whose newest entry is older than the running cutoff must not
+   contribute, but must also not truncate the result: the early exit is an
+   optimisation, not a filter. *)
+let test_a_stale_keeper_does_not_shorten_the_result () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_root (fun root ->
+    seed_keeper root ~name:"fresh" ~timestamps:[ 900.0; 950.0; 990.0 ];
+    seed_keeper root ~name:"stale" ~timestamps:[ 1.0; 2.0 ];
+    check (list (float 0.001)) "cutoff skips the stale store only"
+      [ 990.0; 950.0; 900.0 ]
+      (timestamps_of (read_top root ~n:3)))
+
+let test_a_keeper_without_metrics_is_skipped () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_root (fun root ->
+    seed_keeper root ~name:"alpha" ~timestamps:[ 100.0 ];
+    (* A keeper directory with no metrics subdirectory at all. *)
+    Fs_compat.mkdir_p
+      (Filename.concat
+         (Filename.concat root Common.keepers_runtime_dirname)
+         "no-metrics");
+    check (list (float 0.001)) "directory without a metrics store is ignored"
+      [ 100.0 ]
+      (timestamps_of (read_top root ~n:10)))
+
+let test_empty_root_reads_nothing () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_root (fun root ->
+    check (list (float 0.001)) "no keepers, no entries" []
+      (timestamps_of (read_top root ~n:10)))
+
+let () =
+  run "telemetry_unified_keeper_fan_in"
+    [ ( "unfiltered_fast_path",
+        [ test_case "newest first across keepers" `Quick
+            test_returns_newest_first_across_keepers;
+          test_case "limit takes the newest slice" `Quick
+            test_limit_takes_the_newest_slice;
+          test_case "a stale keeper does not shorten the result" `Quick
+            test_a_stale_keeper_does_not_shorten_the_result;
+          test_case "a keeper without metrics is skipped" `Quick
+            test_a_keeper_without_metrics_is_skipped;
+          test_case "empty root reads nothing" `Quick test_empty_root_reads_nothing
+        ] )
+    ]


### PR DESCRIPTION
RFC-0372 Phase 2's gate is `rss_peak_delta_mb` staying flat as `--keepers` doubles — "cost is independent of store count". Two probe stages violate it, and both do so for the same reason: they parse rows to extract a single timestamp and then keep the rows.

## The two sites

**`read_keeper_metrics_fast_top`** — the path an unfiltered dashboard telemetry request takes. It probes every keeper directory for its newest timestamp, sorts directories by it, then reads entries only while a directory can still beat the running cutoff. The loop is already O(target): the cutoff stops it early. The probe in front of it is not:

```ocaml
let entries = read_fixed_source dir Keeper_metric ~n:probe_limit () in
match latest_ts_of_entries entries with
| Some latest_ts -> Some (name, dir, latest_ts, entries)   (* every directory's rows, at once *)
```

`probe_limit` is up to 64 rows, held for every keeper directory simultaneously. At the ~13 KB per entry this module measured for itself (`telemetry_unified.ml:411`), that is ~26 MB at 32 keepers and ~53 MB at 64 — exactly the doubling the gate forbids.

**`latest_store_ts`** — same shape, `latest_ts_of_entries (read_recent store 64)`, and the summary path calls it once per keeper.

## Change

Project to the timestamp during the read instead of materialising rows: one float per row rather than one parsed tree. Value is identical — `filter_map_recent` returns rows in the same order, and the fold is the same `max_ts_opt` fold `latest_ts_of_entries` runs.

The retained `entries` are dropped from the probe tuple, so it becomes a 3-tuple and the compiler checks every use. That removes the reuse of probe rows when `target <= probe_limit`; those directories are now re-read. The cutoff already skips directories that cannot contribute, so the reads this adds are the ones that reach the result, and each is tail-bounded. Memory is traded for I/O deliberately: the gate is on memory, and the probe read was already capped at 64 rows.

`64` appeared twice and is now `latest_ts_probe_rows`, which also names why the probe scans a window instead of trusting the newest row — a row can carry no usable timestamp.

## Verification (local)

The fast path had **no test**. It is internal (not in the mli), so rather than exposing it, `test/test_telemetry_unified_keeper_fan_in.ml` characterises it through `read_unified` with no keeper filter, which is the routing condition.

Order matters here:

| step | result |
|---|---|
| characterisation test on **unmodified** main | **5 tests run, Test Successful** |
| same test after both fixes | **5 tests run, Test Successful** |

Written and passing before the change, so it records existing behaviour rather than describing the new one. Cases: newest-first across keeper directories; limit takes the newest slice; **a stale keeper does not shorten the result** (the cutoff is an optimisation, not a filter — the failure mode of a bad cutoff change is a silently shorter response, not an error); a keeper directory without a metrics store is skipped; an empty root reads nothing.

| check | result |
|---|---|
| `dune build --root . test/test_telemetry_unified_keeper_fan_in.exe` | `BUILD_EXIT=0` |
| `scripts/audit-ci-test-targets.sh` | OK — 201 CI targets all declared, 659 unwired at baseline |
| `dune build --root . @fmt` | no diff on any file this PR touches |

Wired into `scripts/ci-run-focused-tests.sh` and `UNWIRED_BASELINE` lowered 660 → 659, since a suite that only compiles in CI proves nothing.

## Not claimed

The RFC-0372 §5 gate itself has not been run. It requires the idle p95 ≤ 50 ms baseline control and this host has been between load average 95 and 282 throughout. What is claimed is narrower and does not need the harness: the removed term was proportional to keeper count, which is readable from the code — `probes` held one slice per directory — and the constant it multiplies is the one this module already measured.

RFC-WAIVED: `lib/telemetry_unified/telemetry_unified.ml`, one new test, its dune stanza, and the CI test allowlist. None of the RFC-required subsystems. Direction is set by existing RFC-0372.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
